### PR TITLE
fix(mobile): enable OAuth on web

### DIFF
--- a/docs/expo-web-deployment.md
+++ b/docs/expo-web-deployment.md
@@ -80,12 +80,29 @@ reaching production.
 ### Cross-origin backend
 
 Because the app runs on `app.boardsesh.com` and the backend on
-`ws.boardsesh.com` (`EXPO_PUBLIC_BACKEND_URL`), the browser session exchange
-(`POST /auth/native/exchange`), GraphQL, and token refresh are all cross-origin.
+`ws.boardsesh.com` (`EXPO_PUBLIC_BACKEND_URL`), GraphQL and authenticated API
+requests are cross-origin.
 The backend CORS allow-list (`packages/backend/src/handlers/cors.ts`) includes
 `https://app.boardsesh.com` (configurable via `APP_ORIGIN`, prod default) plus
 its numbered preview form `https://{N}.app.boardsesh.com`. No auth token is ever
 persisted in the browser's AsyncStorage.
+
+### Browser authentication
+
+Expo web shares the NextAuth session cookie issued by `www.boardsesh.com`; it
+does not use the native transfer-token or refresh-token flow. Credentials calls
+the narrowly CORS-enabled NextAuth endpoints on www, then
+`packages/mobile/src/lib/auth-store.web.ts` reads the HttpOnly session through
+`/api/auth/session` and keeps the backend JWE from `/api/internal/ws-auth` in
+memory only.
+
+Google and Apple buttons use the same browser NextAuth providers as the classic
+web app. They navigate to `/auth/native-start` on www, which performs the
+CSRF-backed provider POST, and pass the initiating Expo export as the callback:
+`/app` for the same-origin build or `/` for `app.boardsesh.com`. The NextAuth
+redirect allow-list accepts only the configured app origin and numbered app
+previews, and the shared `.boardsesh.com` session cookie is available when the
+Expo export reloads.
 
 ### Infra follow-ups (not provisioned here)
 

--- a/docs/mobile-auth-flow.md
+++ b/docs/mobile-auth-flow.md
@@ -2,7 +2,12 @@
 
 ## Overview
 
-The mobile auth flow lets React Native (Expo) clients authenticate with the Boardsesh backend. React Native cannot share the NextAuth session cookie used by the web app because there is no embedded WebView hosting the Next.js origin. Instead, the mobile app completes OAuth in a system browser, receives a short-lived transfer token from the web callback, and exchanges it for a long-lived JWT + refresh token pair via the backend.
+The native mobile auth flow lets React Native (Expo) clients authenticate with the Boardsesh backend. Native iOS and Android cannot share the NextAuth session cookie used by the web app because there is no embedded WebView hosting the Next.js origin. Instead, the native app completes OAuth with the provider SDK (or its system-browser fallback), then receives Boardsesh access and refresh tokens.
+
+The Expo browser target is different: it shares the `.boardsesh.com` NextAuth
+cookie with `www.boardsesh.com`, keeps its backend JWE in memory, and returns
+from Google/Apple OAuth directly to the `/app` or `app.boardsesh.com` export.
+See [`expo-web-deployment.md`](./expo-web-deployment.md#browser-authentication).
 
 ## Token exchange flow
 

--- a/packages/mobile/app/auth/login.tsx
+++ b/packages/mobile/app/auth/login.tsx
@@ -2,12 +2,9 @@ import { useState } from 'react';
 import { KeyboardAvoidingView, Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
-import * as AppleAuthentication from 'expo-apple-authentication';
-import { GoogleSigninButton } from '@react-native-google-signin/google-signin';
 import { useTranslation } from 'react-i18next';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { classifyNativeAuthFailureReason } from '../../src/lib/native-auth-analytics';
-import { isGoogleSignInConfigured } from '../../src/lib/auth';
 import { EMAIL_REGEX } from '../../src/lib/auth-validation';
 import { useAuth } from '../../src/providers/auth-provider';
 import { useTheme } from '../../src/providers/theme-provider';
@@ -19,6 +16,7 @@ import { track } from '../../src/lib/analytics';
 import { reportError } from '../../src/lib/error-reporting';
 import { hapticLight } from '../../src/lib/haptics';
 import { openDiscordInvite } from '../../src/lib/discord';
+import { OAuthProviderButtons, useOAuthProviders } from '../../src/components/auth/OAuthProviderButtons';
 
 export default function LoginScreen() {
   const { signInWithCredentials } = useAuth();
@@ -97,15 +95,8 @@ export default function LoginScreen() {
   const showAndroidFreezeNotice =
     Platform.OS === 'android' && typeof Platform.Version === 'number' && Platform.Version >= 35;
 
-  const isDark = theme.colorScheme === 'dark';
-
-  // Sign in with Apple is iOS-only; Google only when the build shipped its
-  // native config (an Apple-only / misconfigured build hides it rather than
-  // showing a button that fails on tap). Hide the whole social section if
-  // neither is available so the divider doesn't dangle.
-  const showAppleSignIn = Platform.OS === 'ios';
-  const showGoogleSignIn = isGoogleSignInConfigured();
-  const showSocialSignIn = showAppleSignIn || showGoogleSignIn;
+  const oauthProviders = useOAuthProviders();
+  const showSocialSignIn = oauthProviders.loading || oauthProviders.apple || oauthProviders.google;
 
   return (
     <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
@@ -224,41 +215,15 @@ export default function LoginScreen() {
               <View style={[styles.dividerLine, { backgroundColor: theme.systemColors.separator }]} />
             </View>
 
-            <View style={styles.buttons}>
-              {showAppleSignIn && (
-                // Apple's official native button — App Review requires it when other
-                // third-party logins are offered. Self-labeled/localized; colour and
-                // corner radius come from the dedicated props (not `style`).
-                <AppleAuthentication.AppleAuthenticationButton
-                  buttonType={AppleAuthentication.AppleAuthenticationButtonType.SIGN_IN}
-                  buttonStyle={
-                    isDark
-                      ? AppleAuthentication.AppleAuthenticationButtonStyle.WHITE
-                      : AppleAuthentication.AppleAuthenticationButtonStyle.BLACK
-                  }
-                  cornerRadius={12}
-                  style={styles.appleButton}
-                  onPress={() => {
-                    hapticLight();
-                    void handleOAuthSignIn('apple');
-                  }}
-                />
-              )}
-              {/* Google's official brand-compliant button — only when the build
-                  shipped the Google native config (otherwise it would fail on tap). */}
-              {showGoogleSignIn && (
-                <GoogleSigninButton
-                  size={GoogleSigninButton.Size.Wide}
-                  color={isDark ? GoogleSigninButton.Color.Dark : GoogleSigninButton.Color.Light}
-                  disabled={oauthInProgress}
-                  style={styles.googleButton}
-                  onPress={() => {
-                    hapticLight();
-                    void handleOAuthSignIn('google');
-                  }}
-                />
-              )}
-            </View>
+            <OAuthProviderButtons
+              disabled={oauthInProgress}
+              isRegistration={false}
+              providers={oauthProviders}
+              onSignIn={(provider) => {
+                hapticLight();
+                void handleOAuthSignIn(provider);
+              }}
+            />
           </>
         )}
 
@@ -350,10 +315,6 @@ const styles = StyleSheet.create({
     fontSize: 13,
     opacity: 0.6,
   },
-  buttons: { gap: 12 },
-  // Apple's native button needs explicit height + width or it renders nothing.
-  appleButton: { width: '100%', height: 50 },
-  googleButton: { width: '100%', height: 50 },
   forgotPasswordHit: {
     alignSelf: 'center',
     marginTop: 4,

--- a/packages/mobile/app/auth/login.tsx
+++ b/packages/mobile/app/auth/login.tsx
@@ -96,7 +96,8 @@ export default function LoginScreen() {
     Platform.OS === 'android' && typeof Platform.Version === 'number' && Platform.Version >= 35;
 
   const oauthProviders = useOAuthProviders();
-  const showSocialSignIn = oauthProviders.loading || oauthProviders.apple || oauthProviders.google;
+  const showSocialSignIn =
+    oauthProviders.loading || oauthProviders.error || oauthProviders.apple || oauthProviders.google;
 
   return (
     <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>

--- a/packages/mobile/app/auth/register.tsx
+++ b/packages/mobile/app/auth/register.tsx
@@ -1,12 +1,9 @@
 import { useState } from 'react';
 import { KeyboardAvoidingView, Platform, Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { Stack, useRouter } from 'expo-router';
-import * as AppleAuthentication from 'expo-apple-authentication';
-import { GoogleSigninButton } from '@react-native-google-signin/google-signin';
 import { useTranslation } from 'react-i18next';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { classifyNativeAuthFailureReason } from '../../src/lib/native-auth-analytics';
-import { isGoogleSignInConfigured } from '../../src/lib/auth';
 import { validateRegisterFields, isValid, type RegisterFieldErrors } from '../../src/lib/auth-validation';
 import { useAuth } from '../../src/providers/auth-provider';
 import { useTheme } from '../../src/providers/theme-provider';
@@ -18,6 +15,7 @@ import { track, setPersonProperties } from '../../src/lib/analytics';
 import { webApiUrl } from '../../src/lib/env';
 import { reportError } from '../../src/lib/error-reporting';
 import { hapticLight } from '../../src/lib/haptics';
+import { OAuthProviderButtons, useOAuthProviders } from '../../src/components/auth/OAuthProviderButtons';
 
 type FieldKey = 'name' | 'email' | 'password' | 'confirmPassword';
 
@@ -205,10 +203,8 @@ export default function RegisterScreen() {
     }
   }
 
-  const isDark = theme.colorScheme === 'dark';
-  const showAppleSignIn = Platform.OS === 'ios';
-  const showGoogleSignIn = isGoogleSignInConfigured();
-  const showSocialSignIn = showAppleSignIn || showGoogleSignIn;
+  const oauthProviders = useOAuthProviders();
+  const showSocialSignIn = oauthProviders.loading || oauthProviders.apple || oauthProviders.google;
 
   return (
     <>
@@ -265,37 +261,15 @@ export default function RegisterScreen() {
 
               {showSocialSignIn && (
                 <>
-                  <View style={styles.socialButtons}>
-                    {showAppleSignIn && (
-                      // SIGN_UP variant on the registration screen, per Apple HIG.
-                      <AppleAuthentication.AppleAuthenticationButton
-                        buttonType={AppleAuthentication.AppleAuthenticationButtonType.SIGN_UP}
-                        buttonStyle={
-                          isDark
-                            ? AppleAuthentication.AppleAuthenticationButtonStyle.WHITE
-                            : AppleAuthentication.AppleAuthenticationButtonStyle.BLACK
-                        }
-                        cornerRadius={12}
-                        style={styles.appleButton}
-                        onPress={() => {
-                          hapticLight();
-                          void handleOAuthSignIn('apple');
-                        }}
-                      />
-                    )}
-                    {showGoogleSignIn && (
-                      <GoogleSigninButton
-                        size={GoogleSigninButton.Size.Wide}
-                        color={isDark ? GoogleSigninButton.Color.Dark : GoogleSigninButton.Color.Light}
-                        disabled={oauthInProgress}
-                        style={styles.googleButton}
-                        onPress={() => {
-                          hapticLight();
-                          void handleOAuthSignIn('google');
-                        }}
-                      />
-                    )}
-                  </View>
+                  <OAuthProviderButtons
+                    disabled={oauthInProgress}
+                    isRegistration
+                    providers={oauthProviders}
+                    onSignIn={(provider) => {
+                      hapticLight();
+                      void handleOAuthSignIn(provider);
+                    }}
+                  />
 
                   <View style={styles.dividerRow}>
                     <View style={[styles.dividerLine, { backgroundColor: theme.systemColors.separator }]} />
@@ -423,10 +397,6 @@ export default function RegisterScreen() {
 const styles = StyleSheet.create({
   container: { flexGrow: 1, justifyContent: 'flex-start', padding: 24 },
   intro: { marginBottom: 24 },
-  socialButtons: { gap: 12 },
-  // Apple's native button needs explicit height + width or it renders nothing.
-  appleButton: { width: '100%', height: 50 },
-  googleButton: { width: '100%', height: 50 },
   dividerRow: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/packages/mobile/app/auth/register.tsx
+++ b/packages/mobile/app/auth/register.tsx
@@ -204,7 +204,8 @@ export default function RegisterScreen() {
   }
 
   const oauthProviders = useOAuthProviders();
-  const showSocialSignIn = oauthProviders.loading || oauthProviders.apple || oauthProviders.google;
+  const showSocialSignIn =
+    oauthProviders.loading || oauthProviders.error || oauthProviders.apple || oauthProviders.google;
 
   return (
     <>

--- a/packages/mobile/src/components/auth/OAuthProviderButtons.tsx
+++ b/packages/mobile/src/components/auth/OAuthProviderButtons.tsx
@@ -12,6 +12,8 @@ export function useOAuthProviders(): OAuthProviderAvailability {
     apple: Platform.OS === 'ios',
     google: isGoogleSignInConfigured(),
     loading: false,
+    error: false,
+    retry: () => undefined,
   };
 }
 

--- a/packages/mobile/src/components/auth/OAuthProviderButtons.tsx
+++ b/packages/mobile/src/components/auth/OAuthProviderButtons.tsx
@@ -39,7 +39,9 @@ export function OAuthProviderButtons({ disabled, isRegistration, onSignIn, provi
           }
           cornerRadius={12}
           style={[styles.providerButton, disabled ? styles.disabled : undefined]}
-          onPress={() => onSignIn('apple')}
+          onPress={() => {
+            if (!disabled) onSignIn('apple');
+          }}
         />
       ) : null}
       {providers.google ? (

--- a/packages/mobile/src/components/auth/OAuthProviderButtons.tsx
+++ b/packages/mobile/src/components/auth/OAuthProviderButtons.tsx
@@ -1,0 +1,63 @@
+import * as AppleAuthentication from 'expo-apple-authentication';
+import { GoogleSigninButton } from '@react-native-google-signin/google-signin';
+import { Platform, StyleSheet, View } from 'react-native';
+import { isGoogleSignInConfigured } from '../../lib/auth';
+import { useTheme } from '../../providers/theme-provider';
+import type { OAuthProviderAvailability, OAuthProviderButtonsProps } from './OAuthProviderButtons.types';
+
+export type { OAuthProvider } from './OAuthProviderButtons.types';
+
+export function useOAuthProviders(): OAuthProviderAvailability {
+  return {
+    apple: Platform.OS === 'ios',
+    google: isGoogleSignInConfigured(),
+    loading: false,
+  };
+}
+
+/**
+ * Native provider controls remain the SDK-owned buttons required by Apple and
+ * Google. The web implementation lives in OAuthProviderButtons.web.tsx.
+ */
+export function OAuthProviderButtons({ disabled, isRegistration, onSignIn, providers }: OAuthProviderButtonsProps) {
+  const theme = useTheme();
+  const isDark = theme.colorScheme === 'dark';
+
+  return (
+    <View style={styles.buttons}>
+      {providers.apple ? (
+        <AppleAuthentication.AppleAuthenticationButton
+          buttonType={
+            isRegistration
+              ? AppleAuthentication.AppleAuthenticationButtonType.SIGN_UP
+              : AppleAuthentication.AppleAuthenticationButtonType.SIGN_IN
+          }
+          buttonStyle={
+            isDark
+              ? AppleAuthentication.AppleAuthenticationButtonStyle.WHITE
+              : AppleAuthentication.AppleAuthenticationButtonStyle.BLACK
+          }
+          cornerRadius={12}
+          style={[styles.providerButton, disabled ? styles.disabled : undefined]}
+          onPress={() => onSignIn('apple')}
+        />
+      ) : null}
+      {providers.google ? (
+        <GoogleSigninButton
+          size={GoogleSigninButton.Size.Wide}
+          color={isDark ? GoogleSigninButton.Color.Dark : GoogleSigninButton.Color.Light}
+          disabled={disabled}
+          style={styles.providerButton}
+          onPress={() => onSignIn('google')}
+        />
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  buttons: { gap: 12 },
+  // Native SDK buttons need explicit dimensions or they render nothing.
+  providerButton: { width: '100%', height: 50 },
+  disabled: { opacity: 0.5 },
+});

--- a/packages/mobile/src/components/auth/OAuthProviderButtons.types.ts
+++ b/packages/mobile/src/components/auth/OAuthProviderButtons.types.ts
@@ -4,6 +4,8 @@ export type OAuthProviderAvailability = {
   apple: boolean;
   google: boolean;
   loading: boolean;
+  error: boolean;
+  retry: () => void;
 };
 
 export type OAuthProviderButtonsProps = {

--- a/packages/mobile/src/components/auth/OAuthProviderButtons.types.ts
+++ b/packages/mobile/src/components/auth/OAuthProviderButtons.types.ts
@@ -1,0 +1,14 @@
+export type OAuthProvider = 'apple' | 'google';
+
+export type OAuthProviderAvailability = {
+  apple: boolean;
+  google: boolean;
+  loading: boolean;
+};
+
+export type OAuthProviderButtonsProps = {
+  disabled: boolean;
+  isRegistration: boolean;
+  onSignIn: (provider: OAuthProvider) => void;
+  providers: OAuthProviderAvailability;
+};

--- a/packages/mobile/src/components/auth/OAuthProviderButtons.web.tsx
+++ b/packages/mobile/src/components/auth/OAuthProviderButtons.web.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import Svg, { Path } from 'react-native-svg';
+import { useTranslation } from 'react-i18next';
+import { webApiUrl } from '../../lib/env';
+import { useTheme } from '../../providers/theme-provider';
+import type { OAuthProviderAvailability, OAuthProviderButtonsProps } from './OAuthProviderButtons.types';
+
+export type { OAuthProvider } from './OAuthProviderButtons.types';
+
+type ProvidersConfigResponse = {
+  apple?: unknown;
+  google?: unknown;
+};
+
+const UNAVAILABLE_PROVIDERS: OAuthProviderAvailability = {
+  apple: false,
+  google: false,
+  loading: false,
+};
+
+function parseProvidersConfig(response: ProvidersConfigResponse): OAuthProviderAvailability {
+  return {
+    apple: response.apple === true,
+    google: response.google === true,
+    loading: false,
+  };
+}
+
+export function useOAuthProviders(): OAuthProviderAvailability {
+  const [providers, setProviders] = useState<OAuthProviderAvailability>({
+    ...UNAVAILABLE_PROVIDERS,
+    loading: true,
+  });
+
+  useEffect(() => {
+    const abortController = new AbortController();
+
+    void fetch(webApiUrl('/api/auth/providers-config'), {
+      credentials: 'include',
+      cache: 'no-store',
+      headers: { Accept: 'application/json' },
+      signal: abortController.signal,
+    })
+      .then(async (response) => {
+        if (!response.ok) throw new Error(`Provider discovery failed with ${response.status}`);
+        return (await response.json()) as ProvidersConfigResponse;
+      })
+      .then((response) => setProviders(parseProvidersConfig(response)))
+      .catch((error: unknown) => {
+        if (error instanceof Error && error.name === 'AbortError') return;
+        setProviders(UNAVAILABLE_PROVIDERS);
+      });
+
+    return () => abortController.abort();
+  }, []);
+
+  return providers;
+}
+
+function GoogleIcon() {
+  return (
+    <Svg viewBox="0 0 24 24" width={20} height={20} accessibilityElementsHidden>
+      <Path
+        fill="#4285F4"
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+      />
+      <Path
+        fill="#34A853"
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+      />
+      <Path
+        fill="#FBBC05"
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+      />
+      <Path
+        fill="#EA4335"
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+      />
+    </Svg>
+  );
+}
+
+function AppleIcon({ color }: { color: string }) {
+  return (
+    <Svg viewBox="0 0 24 24" width={20} height={20} accessibilityElementsHidden>
+      <Path
+        fill={color}
+        d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"
+      />
+    </Svg>
+  );
+}
+
+export function OAuthProviderButtons({ disabled, onSignIn, providers }: OAuthProviderButtonsProps) {
+  const { t } = useTranslation('auth');
+  const theme = useTheme();
+  const appleBackground = theme.colorScheme === 'dark' ? '#FFFFFF' : '#000000';
+  const appleForeground = theme.colorScheme === 'dark' ? '#000000' : '#FFFFFF';
+
+  if (providers.loading) {
+    return (
+      <View style={styles.loadingButtons} accessibilityLabel={t('nativeStart.orContinueWith')}>
+        <View style={[styles.loadingButton, { backgroundColor: theme.systemColors.fill }]} />
+        <View style={[styles.loadingButton, { backgroundColor: theme.systemColors.fill }]} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.buttons}>
+      {providers.google ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={t('login.providers.google')}
+          disabled={disabled}
+          onPress={() => onSignIn('google')}
+          style={({ pressed }) => [
+            styles.providerButton,
+            styles.googleButton,
+            disabled ? styles.disabled : undefined,
+            pressed ? styles.pressed : undefined,
+          ]}
+        >
+          <GoogleIcon />
+          <Text style={styles.googleLabel}>{t('login.providers.google')}</Text>
+        </Pressable>
+      ) : null}
+      {providers.apple ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={t('login.providers.apple')}
+          disabled={disabled}
+          onPress={() => onSignIn('apple')}
+          style={({ pressed }) => [
+            styles.providerButton,
+            { backgroundColor: appleBackground, borderColor: appleBackground },
+            disabled ? styles.disabled : undefined,
+            pressed ? styles.pressed : undefined,
+          ]}
+        >
+          <AppleIcon color={appleForeground} />
+          <Text style={[styles.appleLabel, { color: appleForeground }]}>{t('login.providers.apple')}</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  buttons: { gap: 12 },
+  loadingButtons: { gap: 12, minHeight: 112 },
+  providerButton: {
+    width: '100%',
+    height: 50,
+    borderRadius: 4,
+    borderWidth: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+  },
+  googleButton: {
+    backgroundColor: '#FFFFFF',
+    borderColor: '#747775',
+  },
+  googleLabel: {
+    color: '#1F1F1F',
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  appleLabel: {
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  loadingButton: {
+    width: '100%',
+    height: 50,
+    borderRadius: 4,
+    opacity: 0.45,
+  },
+  disabled: { opacity: 0.5 },
+  pressed: { opacity: 0.8 },
+});

--- a/packages/mobile/src/components/auth/OAuthProviderButtons.web.tsx
+++ b/packages/mobile/src/components/auth/OAuthProviderButtons.web.tsx
@@ -17,6 +17,8 @@ const UNAVAILABLE_PROVIDERS: OAuthProviderAvailability = {
   apple: false,
   google: false,
   loading: false,
+  error: false,
+  retry: () => undefined,
 };
 
 function parseProvidersConfig(response: ProvidersConfigResponse): OAuthProviderAvailability {
@@ -24,17 +26,25 @@ function parseProvidersConfig(response: ProvidersConfigResponse): OAuthProviderA
     apple: response.apple === true,
     google: response.google === true,
     loading: false,
+    error: false,
+    retry: () => undefined,
   };
 }
 
 export function useOAuthProviders(): OAuthProviderAvailability {
+  const [requestVersion, setRequestVersion] = useState(0);
   const [providers, setProviders] = useState<OAuthProviderAvailability>({
     ...UNAVAILABLE_PROVIDERS,
     loading: true,
+    retry: () => setRequestVersion((version) => version + 1),
   });
 
   useEffect(() => {
     const abortController = new AbortController();
+    let disposed = false;
+    const timeoutId = setTimeout(() => abortController.abort(), 8_000);
+    const retry = () => setRequestVersion((version) => version + 1);
+    setProviders({ ...UNAVAILABLE_PROVIDERS, loading: true, retry });
 
     void fetch(webApiUrl('/api/auth/providers-config'), {
       credentials: 'include',
@@ -46,14 +56,22 @@ export function useOAuthProviders(): OAuthProviderAvailability {
         if (!response.ok) throw new Error(`Provider discovery failed with ${response.status}`);
         return (await response.json()) as ProvidersConfigResponse;
       })
-      .then((response) => setProviders(parseProvidersConfig(response)))
-      .catch((error: unknown) => {
-        if (error instanceof Error && error.name === 'AbortError') return;
-        setProviders(UNAVAILABLE_PROVIDERS);
+      .then((response) => {
+        clearTimeout(timeoutId);
+        setProviders({ ...parseProvidersConfig(response), retry });
+      })
+      .catch(() => {
+        clearTimeout(timeoutId);
+        if (disposed) return;
+        setProviders({ ...UNAVAILABLE_PROVIDERS, error: true, retry });
       });
 
-    return () => abortController.abort();
-  }, []);
+    return () => {
+      disposed = true;
+      clearTimeout(timeoutId);
+      abortController.abort();
+    };
+  }, [requestVersion]);
 
   return providers;
 }
@@ -103,6 +121,26 @@ export function OAuthProviderButtons({ disabled, onSignIn, providers }: OAuthPro
       <View style={styles.loadingButtons} accessibilityLabel={t('nativeStart.orContinueWith')}>
         <View style={[styles.loadingButton, { backgroundColor: theme.systemColors.fill }]} />
         <View style={[styles.loadingButton, { backgroundColor: theme.systemColors.fill }]} />
+      </View>
+    );
+  }
+
+  if (providers.error) {
+    return (
+      <View style={styles.discoveryError} accessibilityRole="alert">
+        <Text style={[styles.discoveryErrorText, { color: theme.systemColors.secondaryLabel }]}>
+          {t('nativeStart.providerDiscoveryError')}
+        </Text>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={t('nativeStart.retryProviders')}
+          disabled={disabled}
+          onPress={providers.retry}
+        >
+          <Text style={[styles.retryLabel, { color: theme.systemColors.accent }]}>
+            {t('nativeStart.retryProviders')}
+          </Text>
+        </Pressable>
       </View>
     );
   }
@@ -179,6 +217,9 @@ const styles = StyleSheet.create({
     borderRadius: 4,
     opacity: 0.45,
   },
+  discoveryError: { alignItems: 'center', gap: 8 },
+  discoveryErrorText: { fontSize: 14, textAlign: 'center' },
+  retryLabel: { fontSize: 15, fontWeight: '600' },
   disabled: { opacity: 0.5 },
   pressed: { opacity: 0.8 },
 });

--- a/packages/mobile/src/components/auth/OAuthProviderButtons.web.tsx
+++ b/packages/mobile/src/components/auth/OAuthProviderButtons.web.tsx
@@ -115,6 +115,9 @@ export function OAuthProviderButtons({ disabled, onSignIn, providers }: OAuthPro
   const theme = useTheme();
   const appleBackground = theme.colorScheme === 'dark' ? '#FFFFFF' : '#000000';
   const appleForeground = theme.colorScheme === 'dark' ? '#000000' : '#FFFFFF';
+  const googleBackground = theme.colorScheme === 'dark' ? '#131314' : '#FFFFFF';
+  const googleBorder = theme.colorScheme === 'dark' ? '#8E918F' : '#747775';
+  const googleForeground = theme.colorScheme === 'dark' ? '#E3E3E3' : '#1F1F1F';
 
   if (providers.loading) {
     return (
@@ -155,13 +158,13 @@ export function OAuthProviderButtons({ disabled, onSignIn, providers }: OAuthPro
           onPress={() => onSignIn('google')}
           style={({ pressed }) => [
             styles.providerButton,
-            styles.googleButton,
+            { backgroundColor: googleBackground, borderColor: googleBorder },
             disabled ? styles.disabled : undefined,
             pressed ? styles.pressed : undefined,
           ]}
         >
           <GoogleIcon />
-          <Text style={styles.googleLabel}>{t('login.providers.google')}</Text>
+          <Text style={[styles.googleLabel, { color: googleForeground }]}>{t('login.providers.google')}</Text>
         </Pressable>
       ) : null}
       {providers.apple ? (
@@ -198,12 +201,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     gap: 12,
   },
-  googleButton: {
-    backgroundColor: '#FFFFFF',
-    borderColor: '#747775',
-  },
   googleLabel: {
-    color: '#1F1F1F',
     fontSize: 15,
     fontWeight: '600',
   },

--- a/packages/mobile/src/components/auth/OAuthProviderButtons.web.tsx
+++ b/packages/mobile/src/components/auth/OAuthProviderButtons.web.tsx
@@ -58,6 +58,7 @@ export function useOAuthProviders(): OAuthProviderAvailability {
       })
       .then((response) => {
         clearTimeout(timeoutId);
+        if (disposed) return;
         setProviders({ ...parseProvidersConfig(response), retry });
       })
       .catch(() => {

--- a/packages/mobile/src/components/auth/__tests__/OAuthProviderButtons.web.test.tsx
+++ b/packages/mobile/src/components/auth/__tests__/OAuthProviderButtons.web.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-native', () => ({
+  Pressable: ({
+    accessibilityLabel,
+    children,
+    disabled,
+    onPress,
+  }: {
+    accessibilityLabel?: string;
+    children: ReactNode;
+    disabled?: boolean;
+    onPress?: () => void;
+  }) => createElement('button', { 'aria-label': accessibilityLabel, disabled, onClick: onPress }, children),
+  StyleSheet: { create: <Styles,>(styles: Styles) => styles },
+  Text: ({ children }: { children: ReactNode }) => createElement('span', null, children),
+  View: ({ accessibilityLabel, children }: { accessibilityLabel?: string; children: ReactNode }) =>
+    createElement('div', { 'aria-label': accessibilityLabel }, children),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      ({
+        'login.providers.google': 'Continue with Google',
+        'login.providers.apple': 'Continue with Apple',
+        'nativeStart.orContinueWith': 'or continue with',
+      })[key] ?? key,
+  }),
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    colorScheme: 'light',
+    systemColors: { fill: '#cccccc' },
+  }),
+}));
+
+vi.mock('react-native-svg', () => ({
+  default: ({ children }: { children: ReactNode }) => createElement('svg', null, children),
+  Path: (props: Record<string, unknown>) => createElement('path', props),
+}));
+
+import { OAuthProviderButtons, useOAuthProviders } from '../OAuthProviderButtons.web';
+
+function ProviderHarness({ onSignIn = vi.fn() }: { onSignIn?: (provider: 'apple' | 'google') => void }) {
+  const providers = useOAuthProviders();
+  return <OAuthProviderButtons disabled={false} isRegistration={false} providers={providers} onSignIn={onSignIn} />;
+}
+
+describe('OAuthProviderButtons on web', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('reserves button space while provider discovery is loading', () => {
+    vi.mocked(fetch).mockReturnValue(new Promise(() => {}));
+
+    const { container } = render(<ProviderHarness />);
+
+    expect(container.querySelectorAll('[aria-label="or continue with"]')).toHaveLength(1);
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('fetches configured providers with credentials and renders only Apple and Google', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ google: true, apple: false, facebook: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    render(<ProviderHarness />);
+    await act(async () => {});
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://www.boardsesh.com/api/auth/providers-config',
+      expect.objectContaining({ credentials: 'include', cache: 'no-store' }),
+    );
+    expect(screen.getByRole('button', { name: 'Continue with Google' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Continue with Apple' })).toBeNull();
+    expect(screen.queryByText('Continue with Facebook')).toBeNull();
+  });
+
+  it('starts the selected provider and hides the controls when discovery fails', async () => {
+    const onSignIn = vi.fn();
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ google: true, apple: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const { unmount } = render(<ProviderHarness onSignIn={onSignIn} />);
+    await act(async () => {});
+    fireEvent.click(screen.getByRole('button', { name: 'Continue with Apple' }));
+    expect(onSignIn).toHaveBeenCalledWith('apple');
+    unmount();
+
+    vi.mocked(fetch).mockRejectedValueOnce(new Error('offline'));
+    render(<ProviderHarness />);
+    await act(async () => {});
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('disables provider controls while a sign-in is in progress', () => {
+    const onSignIn = vi.fn();
+    render(
+      <OAuthProviderButtons
+        disabled
+        isRegistration
+        providers={{ apple: true, google: true, loading: false }}
+        onSignIn={onSignIn}
+      />,
+    );
+
+    const googleButton = screen.getByRole('button', { name: 'Continue with Google' });
+    const appleButton = screen.getByRole('button', { name: 'Continue with Apple' });
+    expect((googleButton as HTMLButtonElement).disabled).toBe(true);
+    expect((appleButton as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(googleButton);
+    expect(onSignIn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/components/auth/__tests__/OAuthProviderButtons.web.test.tsx
+++ b/packages/mobile/src/components/auth/__tests__/OAuthProviderButtons.web.test.tsx
@@ -60,6 +60,7 @@ describe('OAuthProviderButtons on web', () => {
 
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -138,6 +139,21 @@ describe('OAuthProviderButtons on web', () => {
     await act(async () => {});
     expect(fetch).toHaveBeenCalledTimes(2);
     expect(screen.getByRole('button', { name: 'Continue with Google' })).toBeTruthy();
+  });
+
+  it('offers a retry when provider discovery times out', async () => {
+    vi.useFakeTimers();
+    vi.mocked(fetch).mockImplementation(
+      (_input, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+        }),
+    );
+
+    render(<ProviderHarness />);
+    await act(() => vi.advanceTimersByTimeAsync(8_000));
+
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeTruthy();
   });
 
   it('disables provider controls while a sign-in is in progress', () => {

--- a/packages/mobile/src/components/auth/__tests__/OAuthProviderButtons.web.test.tsx
+++ b/packages/mobile/src/components/auth/__tests__/OAuthProviderButtons.web.test.tsx
@@ -90,9 +90,9 @@ describe('OAuthProviderButtons on web', () => {
     expect(screen.queryByText('Continue with Facebook')).toBeNull();
   });
 
-  it('starts the selected provider and hides the controls when discovery fails', async () => {
+  it('starts the selected provider', async () => {
     const onSignIn = vi.fn();
-    vi.mocked(fetch).mockResolvedValueOnce(
+    vi.mocked(fetch).mockResolvedValue(
       new Response(JSON.stringify({ google: true, apple: true }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -104,8 +104,10 @@ describe('OAuthProviderButtons on web', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Continue with Apple' }));
     expect(onSignIn).toHaveBeenCalledWith('apple');
     unmount();
+  });
 
-    vi.mocked(fetch).mockRejectedValueOnce(new Error('offline'));
+  it('hides the controls when discovery fails', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('offline'));
     render(<ProviderHarness />);
     await act(async () => {});
     expect(screen.queryByRole('button')).toBeNull();

--- a/packages/mobile/src/components/auth/__tests__/OAuthProviderButtons.web.test.tsx
+++ b/packages/mobile/src/components/auth/__tests__/OAuthProviderButtons.web.test.tsx
@@ -90,6 +90,21 @@ describe('OAuthProviderButtons on web', () => {
     expect(screen.queryByText('Continue with Facebook')).toBeNull();
   });
 
+  it('renders Apple when it is the only configured provider', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ google: false, apple: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    render(<ProviderHarness />);
+    await act(async () => {});
+
+    expect(screen.getByRole('button', { name: 'Continue with Apple' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Continue with Google' })).toBeNull();
+  });
+
   it('starts the selected provider', async () => {
     const onSignIn = vi.fn();
     vi.mocked(fetch).mockResolvedValue(

--- a/packages/mobile/src/components/auth/__tests__/OAuthProviderButtons.web.test.tsx
+++ b/packages/mobile/src/components/auth/__tests__/OAuthProviderButtons.web.test.tsx
@@ -28,6 +28,8 @@ vi.mock('react-i18next', () => ({
         'login.providers.google': 'Continue with Google',
         'login.providers.apple': 'Continue with Apple',
         'nativeStart.orContinueWith': 'or continue with',
+        'nativeStart.providerDiscoveryError': "We couldn't load the social sign-in options.",
+        'nativeStart.retryProviders': 'Try again',
       })[key] ?? key,
   }),
 }));
@@ -35,7 +37,7 @@ vi.mock('react-i18next', () => ({
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
     colorScheme: 'light',
-    systemColors: { fill: '#cccccc' },
+    systemColors: { accent: '#0066cc', fill: '#cccccc', secondaryLabel: '#666666' },
   }),
 }));
 
@@ -121,11 +123,21 @@ describe('OAuthProviderButtons on web', () => {
     unmount();
   });
 
-  it('hides the controls when discovery fails', async () => {
+  it('offers a retry when discovery fails', async () => {
     vi.mocked(fetch).mockRejectedValue(new Error('offline'));
     render(<ProviderHarness />);
     await act(async () => {});
-    expect(screen.queryByRole('button')).toBeNull();
+    const retryButton = screen.getByRole('button', { name: 'Try again' });
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ google: true, apple: false }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    fireEvent.click(retryButton);
+    await act(async () => {});
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(screen.getByRole('button', { name: 'Continue with Google' })).toBeTruthy();
   });
 
   it('disables provider controls while a sign-in is in progress', () => {
@@ -134,7 +146,7 @@ describe('OAuthProviderButtons on web', () => {
       <OAuthProviderButtons
         disabled
         isRegistration
-        providers={{ apple: true, google: true, loading: false }}
+        providers={{ apple: true, google: true, loading: false, error: false, retry: vi.fn() }}
         onSignIn={onSignIn}
       />,
     );

--- a/packages/mobile/src/hooks/__tests__/use-native-oauth-sign-in.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-oauth-sign-in.test.tsx
@@ -25,6 +25,11 @@ vi.mock('../../lib/analytics', () => ({ track: (...args: unknown[]) => trackMock
 const reportErrorMock = vi.fn();
 vi.mock('../../lib/error-reporting', () => ({ reportError: (...args: unknown[]) => reportErrorMock(...args) }));
 
+const setOAuthPendingMock = vi.fn();
+vi.mock('../../lib/oauth-pending-store', () => ({
+  setOAuthPending: (...args: unknown[]) => setOAuthPendingMock(...args),
+}));
+
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 
 // The hook reads Platform.OS to gate the browser web fallback (Google + Apple)
@@ -70,6 +75,8 @@ describe('useNativeOAuthSignIn — Google web fallback (iOS)', () => {
     signInWithGoogleMock.mockReset();
     signInWithGoogleWebMock.mockReset();
     signInWithAppleWebMock.mockReset();
+    setOAuthPendingMock.mockReset();
+    setOAuthPendingMock.mockResolvedValue(undefined);
   });
 
   it('falls back to the web flow when native Google throws ("Unable to open Safari") and signs in', async () => {
@@ -176,6 +183,51 @@ describe('useNativeOAuthSignIn — Google web fallback (iOS)', () => {
     });
     // A browser that never opened is a failure, not the user backing out.
     expect(events).not.toContainEqual(expect.objectContaining({ event: 'Login Cancelled', flow: 'web_fallback' }));
+  });
+});
+
+describe('useNativeOAuthSignIn — Expo web redirect', () => {
+  beforeEach(() => {
+    platform.OS = 'web';
+    trackMock.mockReset();
+    reportErrorMock.mockReset();
+    signInWithAppleMock.mockReset();
+    signInWithGoogleMock.mockReset();
+    signInWithGoogleWebMock.mockReset();
+    signInWithAppleWebMock.mockReset();
+    setOAuthPendingMock.mockReset();
+    setOAuthPendingMock.mockResolvedValue(undefined);
+  });
+
+  it('persists the attempt and treats a full-page Google redirect as neither success nor failure', async () => {
+    signInWithGoogleMock.mockResolvedValue({ success: false, redirecting: true });
+
+    await runSignIn('google');
+
+    expect(setOAuthPendingMock).toHaveBeenCalledWith({
+      provider: 'google',
+      attemptedAt: expect.any(Number),
+      isRegistration: false,
+    });
+    expect(signInWithGoogleMock).toHaveBeenCalledTimes(1);
+    expect(signInWithGoogleWebMock).not.toHaveBeenCalled();
+    expect(trackMock).toHaveBeenCalledWith('Login Attempted', {
+      auth_method: 'google',
+      flow: 'web',
+    });
+    expect(trackMock).not.toHaveBeenCalledWith('Login Succeeded', expect.anything());
+    expect(trackMock).not.toHaveBeenCalledWith('Login Failed', expect.anything());
+    expect(reportErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('continues to OAuth when the analytics marker cannot be persisted', async () => {
+    setOAuthPendingMock.mockRejectedValue(new Error('IndexedDB unavailable'));
+    signInWithAppleMock.mockResolvedValue({ success: false, redirecting: true });
+
+    await runSignIn('apple');
+
+    expect(signInWithAppleMock).toHaveBeenCalledTimes(1);
+    expect(reportErrorMock).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/mobile/src/hooks/__tests__/use-native-oauth-sign-in.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-oauth-sign-in.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 
 // Mock the auth provider so the hook gets controllable sign-in functions without
 // pulling in the provider's native dependency chain. The `type OAuthSignInResult`
@@ -26,8 +26,14 @@ const reportErrorMock = vi.fn();
 vi.mock('../../lib/error-reporting', () => ({ reportError: (...args: unknown[]) => reportErrorMock(...args) }));
 
 const setOAuthPendingMock = vi.fn();
+const consumeFreshOAuthPendingMock = vi.fn();
 vi.mock('../../lib/oauth-pending-store', () => ({
   setOAuthPending: (...args: unknown[]) => setOAuthPendingMock(...args),
+  consumeFreshOAuthPending: (...args: unknown[]) => consumeFreshOAuthPendingMock(...args),
+}));
+const consumeWebOAuthReturnMock = vi.fn();
+vi.mock('../../lib/oauth-return', () => ({
+  consumeWebOAuthReturn: (...args: unknown[]) => consumeWebOAuthReturnMock(...args),
 }));
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
@@ -77,6 +83,9 @@ describe('useNativeOAuthSignIn — Google web fallback (iOS)', () => {
     signInWithAppleWebMock.mockReset();
     setOAuthPendingMock.mockReset();
     setOAuthPendingMock.mockResolvedValue(undefined);
+    consumeWebOAuthReturnMock.mockReset();
+    consumeWebOAuthReturnMock.mockReturnValue(null);
+    consumeFreshOAuthPendingMock.mockReset();
   });
 
   it('falls back to the web flow when native Google throws ("Unable to open Safari") and signs in', async () => {
@@ -205,11 +214,12 @@ describe('useNativeOAuthSignIn — Expo web redirect', () => {
     await runSignIn('google');
 
     expect(setOAuthPendingMock).toHaveBeenCalledWith({
+      attemptId: expect.any(String),
       provider: 'google',
       attemptedAt: expect.any(Number),
       isRegistration: false,
     });
-    expect(signInWithGoogleMock).toHaveBeenCalledTimes(1);
+    expect(signInWithGoogleMock).toHaveBeenCalledWith(expect.any(String), false);
     expect(signInWithGoogleWebMock).not.toHaveBeenCalled();
     expect(trackMock).toHaveBeenCalledWith('Login Attempted', {
       auth_method: 'google',
@@ -228,6 +238,32 @@ describe('useNativeOAuthSignIn — Expo web redirect', () => {
 
     expect(signInWithAppleMock).toHaveBeenCalledTimes(1);
     expect(reportErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a provider error only for its matching browser attempt', async () => {
+    consumeWebOAuthReturnMock.mockReturnValue({
+      provider: 'apple',
+      attemptId: 'attempt-apple-1',
+      error: 'AccessDenied',
+    });
+    consumeFreshOAuthPendingMock.mockResolvedValue({
+      attemptId: 'attempt-apple-1',
+      provider: 'apple',
+      attemptedAt: Date.now(),
+      isRegistration: false,
+    });
+    const setError = vi.fn();
+
+    renderHook(() => useNativeOAuthSignIn({ setError }));
+
+    await waitFor(() => expect(setError).toHaveBeenCalledWith('nativeStart.oauthError'));
+    expect(consumeFreshOAuthPendingMock).toHaveBeenCalledWith('attempt-apple-1');
+    expect(trackMock).toHaveBeenCalledWith('Login Failed', {
+      auth_method: 'apple',
+      flow: 'web',
+      failure_reason: 'oauth',
+      failure_detail: 'AccessDenied',
+    });
   });
 });
 

--- a/packages/mobile/src/hooks/__tests__/use-native-oauth-sign-in.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-oauth-sign-in.test.tsx
@@ -33,7 +33,7 @@ vi.mock('../../lib/oauth-pending-store', () => ({
 }));
 const consumeWebOAuthReturnMock = vi.fn();
 vi.mock('../../lib/oauth-return', () => ({
-  consumeWebOAuthReturn: (...args: unknown[]) => consumeWebOAuthReturnMock(...args),
+  consumeWebOAuthErrorReturn: (...args: unknown[]) => consumeWebOAuthReturnMock(...args),
 }));
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));

--- a/packages/mobile/src/hooks/use-native-oauth-sign-in.ts
+++ b/packages/mobile/src/hooks/use-native-oauth-sign-in.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Platform } from 'react-native';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { useAuth } from '../providers/auth-provider';
@@ -9,7 +9,9 @@ import {
   isRecoverableAndroidGoogleSignInError,
   nativeSignInErrorCode,
 } from '../lib/native-auth-analytics';
-import { setOAuthPending } from '../lib/oauth-pending-store';
+import { consumeFreshOAuthPending, setOAuthPending } from '../lib/oauth-pending-store';
+import { consumeWebOAuthReturn } from '../lib/oauth-return';
+import { createWebOAuthAttemptId } from '../lib/oauth-return-marker';
 import type { OAuthSignInResult } from '../lib/auth';
 import { useTranslation } from 'react-i18next';
 
@@ -34,11 +36,31 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
   const { signInWithApple, signInWithGoogle, signInWithGoogleWeb, signInWithAppleWeb } = useAuth();
   const { t } = useTranslation('auth');
   const [inProgress, setInProgress] = useState(false);
+  const inProgressRef = useRef(false);
+
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const returnedOAuth = consumeWebOAuthReturn();
+    if (!returnedOAuth?.error) return;
+
+    void consumeFreshOAuthPending(returnedOAuth.attemptId).then((marker) => {
+      if (!marker || marker.provider !== returnedOAuth.provider) return;
+      track(SHARED_EVENTS.LoginFailed, {
+        auth_method: marker.provider,
+        flow: 'web',
+        failure_reason: 'oauth',
+        failure_detail: returnedOAuth.error,
+        ...(marker.isRegistration ? { is_registration: true } : {}),
+      });
+      setError(t('nativeStart.oauthError'));
+    });
+  }, [setError, t]);
 
   const signIn = useCallback(
     async (provider: Provider) => {
       // A rapid double-tap would open two concurrent native sheets.
-      if (inProgress) return;
+      if (inProgressRef.current) return;
+      inProgressRef.current = true;
       setInProgress(true);
       setError(null);
       const registrationProps = isRegistration ? { is_registration: true } : {};
@@ -141,17 +163,21 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
       };
 
       try {
+        const attemptId = Platform.OS === 'web' ? createWebOAuthAttemptId() : undefined;
         if (Platform.OS === 'web') {
           // The browser unloads for NextAuth, so persist the attempt before
           // navigation. AuthProvider consumes it only after the returned cookie
           // is confirmed; a storage failure must not prevent sign-in.
           try {
-            await setOAuthPending({ provider, attemptedAt: Date.now(), isRegistration });
+            await setOAuthPending({ attemptId: attemptId!, provider, attemptedAt: Date.now(), isRegistration });
           } catch {
             // Analytics continuity is best-effort; authentication is not.
           }
         }
-        const result = provider === 'apple' ? await signInWithApple() : await signInWithGoogle();
+        const result =
+          provider === 'apple'
+            ? await signInWithApple(attemptId, isRegistration)
+            : await signInWithGoogle(attemptId, isRegistration);
         if ('redirecting' in result) {
           return;
         }
@@ -242,19 +268,11 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
         });
         setError(t('nativeStart.oauthError'));
       } finally {
+        inProgressRef.current = false;
         setInProgress(false);
       }
     },
-    [
-      inProgress,
-      isRegistration,
-      setError,
-      signInWithApple,
-      signInWithGoogle,
-      signInWithGoogleWeb,
-      signInWithAppleWeb,
-      t,
-    ],
+    [isRegistration, setError, signInWithApple, signInWithGoogle, signInWithGoogleWeb, signInWithAppleWeb, t],
   );
 
   return { signIn, inProgress };

--- a/packages/mobile/src/hooks/use-native-oauth-sign-in.ts
+++ b/packages/mobile/src/hooks/use-native-oauth-sign-in.ts
@@ -165,7 +165,7 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
           // distinct event keeps it out of the LoginFailed count.
           track(SHARED_EVENTS.LoginCancelled, {
             auth_method: provider,
-            flow: 'native',
+            flow: primaryFlow,
             duration_ms: Date.now() - attemptStartedAt,
             ...registrationProps,
           });

--- a/packages/mobile/src/hooks/use-native-oauth-sign-in.ts
+++ b/packages/mobile/src/hooks/use-native-oauth-sign-in.ts
@@ -10,7 +10,7 @@ import {
   nativeSignInErrorCode,
 } from '../lib/native-auth-analytics';
 import { consumeFreshOAuthPending, setOAuthPending } from '../lib/oauth-pending-store';
-import { consumeWebOAuthReturn } from '../lib/oauth-return';
+import { consumeWebOAuthErrorReturn } from '../lib/oauth-return';
 import { createWebOAuthAttemptId } from '../lib/oauth-return-marker';
 import type { OAuthSignInResult } from '../lib/auth';
 import { useTranslation } from 'react-i18next';
@@ -40,7 +40,7 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
 
   useEffect(() => {
     if (Platform.OS !== 'web') return;
-    const returnedOAuth = consumeWebOAuthReturn();
+    const returnedOAuth = consumeWebOAuthErrorReturn();
     if (!returnedOAuth?.error) return;
 
     void consumeFreshOAuthPending(returnedOAuth.attemptId).then((marker) => {

--- a/packages/mobile/src/hooks/use-native-oauth-sign-in.ts
+++ b/packages/mobile/src/hooks/use-native-oauth-sign-in.ts
@@ -9,6 +9,7 @@ import {
   isRecoverableAndroidGoogleSignInError,
   nativeSignInErrorCode,
 } from '../lib/native-auth-analytics';
+import { setOAuthPending } from '../lib/oauth-pending-store';
 import type { OAuthSignInResult } from '../lib/auth';
 import { useTranslation } from 'react-i18next';
 
@@ -41,7 +42,8 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
       setInProgress(true);
       setError(null);
       const registrationProps = isRegistration ? { is_registration: true } : {};
-      track(SHARED_EVENTS.LoginAttempted, { auth_method: provider, flow: 'native', ...registrationProps });
+      const primaryFlow = Platform.OS === 'web' ? 'web' : 'native';
+      track(SHARED_EVENTS.LoginAttempted, { auth_method: provider, flow: primaryFlow, ...registrationProps });
       // duration_ms separates a human dismissing the system sheet (seconds) from
       // the flow dying programmatically (sub-second).
       const attemptStartedAt = Date.now();
@@ -105,6 +107,9 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
           // AuthProvider flips isAuthenticated and the redirect handles navigation.
           return;
         }
+        if ('redirecting' in fallback) {
+          return;
+        }
         if ('cancelled' in fallback) {
           // The user dismissed the browser — intent, not a failure. A distinct
           // event keeps it out of the LoginFailed count.
@@ -136,9 +141,22 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
       };
 
       try {
+        if (Platform.OS === 'web') {
+          // The browser unloads for NextAuth, so persist the attempt before
+          // navigation. AuthProvider consumes it only after the returned cookie
+          // is confirmed; a storage failure must not prevent sign-in.
+          try {
+            await setOAuthPending({ provider, attemptedAt: Date.now(), isRegistration });
+          } catch {
+            // Analytics continuity is best-effort; authentication is not.
+          }
+        }
         const result = provider === 'apple' ? await signInWithApple() : await signInWithGoogle();
+        if ('redirecting' in result) {
+          return;
+        }
         if (result.success) {
-          track(SHARED_EVENTS.LoginSucceeded, { auth_method: provider, flow: 'native', ...registrationProps });
+          track(SHARED_EVENTS.LoginSucceeded, { auth_method: provider, flow: primaryFlow, ...registrationProps });
           // AuthProvider flips isAuthenticated and the redirect handles navigation.
           return;
         }
@@ -160,7 +178,7 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
         const oauthFailureReason = classifyNativeAuthFailureReason(result, 'oauth');
         track(SHARED_EVENTS.LoginFailed, {
           auth_method: provider,
-          flow: 'native',
+          flow: primaryFlow,
           failure_reason: oauthFailureReason,
           failure_detail: result.error,
           recoverable: Platform.OS === 'ios',
@@ -178,9 +196,9 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
         // Surface to error tracking too: an OAuth 401 / no_id_token is a config
         // bug (client-id audience mismatch, unconfigured backend) rather than a
         // user typo. Network blips downgrade to a warning.
-        reportError(new Error(`Native ${provider} sign-in failed: ${result.error}`), {
+        reportError(new Error(`${primaryFlow} ${provider} sign-in failed: ${result.error}`), {
           level: result.error === 'network' ? 'warning' : 'error',
-          tags: { source: 'native-auth', provider, flow: 'native', failure_reason: oauthFailureReason },
+          tags: { source: 'native-auth', provider, flow: primaryFlow, failure_reason: oauthFailureReason },
           extra: { status: result.status, server_error: result.error },
         });
         setError(result.error === 'network' ? t('nativeStart.networkError') : t('nativeStart.oauthError'));
@@ -202,7 +220,7 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
           (Platform.OS === 'android' && provider === 'google' && isRecoverableAndroidGoogleSignInError(oauthError));
         track(SHARED_EVENTS.LoginFailed, {
           auth_method: provider,
-          flow: 'native',
+          flow: primaryFlow,
           failure_reason: 'exception',
           failure_detail: nativeErrorCode ?? (oauthError instanceof Error ? oauthError.message : undefined),
           recoverable: willFallBack,
@@ -217,7 +235,7 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
           tags: {
             source: 'native-auth',
             provider,
-            flow: 'native',
+            flow: primaryFlow,
             mechanism: 'exception',
             native_error_code: nativeErrorCode,
           },

--- a/packages/mobile/src/lib/__tests__/auth.web.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth.web.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { captureAuthCredentialGeneration, clearTokens, getAuthToken, synchronizeWebSession } from '../auth-store.web';
 import {
+  buildWebOAuthStartUrl,
   registerWithCredentials,
   requestPasswordReset,
   resetPassword,
@@ -47,6 +48,26 @@ beforeEach(async () => {
 
 afterEach(() => {
   vi.unstubAllEnvs();
+});
+
+describe('Expo web OAuth', () => {
+  it('starts Google on www and returns to the same-origin /app export', () => {
+    const url = new URL(buildWebOAuthStartUrl('google', 'https://www.boardsesh.com'));
+
+    expect(url.origin).toBe(WEB);
+    expect(url.pathname).toBe('/auth/native-start');
+    expect(url.searchParams.get('provider')).toBe('google');
+    expect(url.searchParams.get('callbackUrl')).toBe('https://www.boardsesh.com/app');
+  });
+
+  it('starts Apple on www and returns to the standalone app root', () => {
+    const url = new URL(buildWebOAuthStartUrl('apple', 'https://app.boardsesh.com', ''));
+
+    expect(url.origin).toBe(WEB);
+    expect(url.pathname).toBe('/auth/native-start');
+    expect(url.searchParams.get('provider')).toBe('apple');
+    expect(url.searchParams.get('callbackUrl')).toBe('https://app.boardsesh.com/');
+  });
 });
 
 describe('Expo web credentials auth', () => {

--- a/packages/mobile/src/lib/__tests__/auth.web.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth.web.test.ts
@@ -60,7 +60,7 @@ describe('Expo web OAuth', () => {
     expect(url.origin).toBe(WEB);
     expect(url.pathname).toBe('/auth/native-start');
     expect(url.searchParams.get('provider')).toBe('google');
-    expect(url.searchParams.get('callbackUrl')).toBe('https://www.boardsesh.com/app');
+    expect(url.searchParams.get('callbackUrl')).toBe('https://www.boardsesh.com/app?boardseshOAuthProvider=google');
   });
 
   it('starts Apple on www and returns to the standalone app root', () => {
@@ -69,7 +69,7 @@ describe('Expo web OAuth', () => {
     expect(url.origin).toBe(WEB);
     expect(url.pathname).toBe('/auth/native-start');
     expect(url.searchParams.get('provider')).toBe('apple');
-    expect(url.searchParams.get('callbackUrl')).toBe('https://app.boardsesh.com/');
+    expect(url.searchParams.get('callbackUrl')).toBe('https://app.boardsesh.com/?boardseshOAuthProvider=apple');
   });
 
   it('reports browser navigation failures without throwing', async () => {

--- a/packages/mobile/src/lib/__tests__/auth.web.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth.web.test.ts
@@ -55,21 +55,25 @@ afterEach(() => {
 
 describe('Expo web OAuth', () => {
   it('starts Google on www and returns to the same-origin /app export', () => {
-    const url = new URL(buildWebOAuthStartUrl('google', 'https://www.boardsesh.com'));
+    const url = new URL(buildWebOAuthStartUrl('google', 'https://www.boardsesh.com', 'attempt-google-1'));
 
     expect(url.origin).toBe(WEB);
     expect(url.pathname).toBe('/auth/native-start');
     expect(url.searchParams.get('provider')).toBe('google');
-    expect(url.searchParams.get('callbackUrl')).toBe('https://www.boardsesh.com/app?boardseshOAuthProvider=google');
+    expect(url.searchParams.get('callbackUrl')).toBe(
+      'https://www.boardsesh.com/app/auth/login?boardseshOAuthProvider=google&boardseshOAuthAttempt=attempt-google-1',
+    );
   });
 
   it('starts Apple on www and returns to the standalone app root', () => {
-    const url = new URL(buildWebOAuthStartUrl('apple', 'https://app.boardsesh.com', ''));
+    const url = new URL(buildWebOAuthStartUrl('apple', 'https://app.boardsesh.com', 'attempt-apple-1', true, ''));
 
     expect(url.origin).toBe(WEB);
     expect(url.pathname).toBe('/auth/native-start');
     expect(url.searchParams.get('provider')).toBe('apple');
-    expect(url.searchParams.get('callbackUrl')).toBe('https://app.boardsesh.com/?boardseshOAuthProvider=apple');
+    expect(url.searchParams.get('callbackUrl')).toBe(
+      'https://app.boardsesh.com/auth/register?boardseshOAuthProvider=apple&boardseshOAuthAttempt=attempt-apple-1',
+    );
   });
 
   it('reports browser navigation failures without throwing', async () => {
@@ -82,7 +86,7 @@ describe('Expo web OAuth', () => {
       },
     });
 
-    await expect(signInWithGoogle()).resolves.toEqual({
+    await expect(signInWithGoogle('attempt-google-1')).resolves.toEqual({
       success: false,
       status: null,
       error: 'browser_unavailable',

--- a/packages/mobile/src/lib/__tests__/auth.web.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth.web.test.ts
@@ -7,6 +7,7 @@ import {
   resetPassword,
   signInWithCredentials,
   signInWithGoogle,
+  signInWithGoogleWeb,
   signOut,
   signOutForGeneration,
 } from '../auth.web';
@@ -91,6 +92,22 @@ describe('Expo web OAuth', () => {
       status: null,
       error: 'browser_unavailable',
     });
+  });
+
+  it('generates an attempt ID when the browser fallback starts without one', async () => {
+    const assign = vi.fn();
+    vi.stubGlobal('window', {
+      location: {
+        origin: 'https://app.boardsesh.com',
+        assign,
+      },
+    });
+
+    await expect(signInWithGoogleWeb()).resolves.toEqual({ success: false, redirecting: true });
+
+    const startUrl = new URL(assign.mock.calls[0]![0] as string);
+    const callbackUrl = new URL(startUrl.searchParams.get('callbackUrl')!);
+    expect(callbackUrl.searchParams.get('boardseshOAuthAttempt')).toMatch(/^[A-Za-z0-9_-]{8,128}$/);
   });
 });
 

--- a/packages/mobile/src/lib/__tests__/auth.web.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth.web.test.ts
@@ -6,6 +6,7 @@ import {
   requestPasswordReset,
   resetPassword,
   signInWithCredentials,
+  signInWithGoogle,
   signOut,
   signOutForGeneration,
 } from '../auth.web';
@@ -37,6 +38,7 @@ function requestBody(callIndex: number): string {
 }
 
 beforeEach(async () => {
+  vi.stubGlobal('fetch', fetchMock);
   fetchMock.mockReset();
   // Simulate the www-mounted export (experiments.baseUrl '/app'): Expo CLI
   // inlines this into the bundle as EXPO_BASE_URL, and appCallbackUrl derives
@@ -48,6 +50,7 @@ beforeEach(async () => {
 
 afterEach(() => {
   vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
 });
 
 describe('Expo web OAuth', () => {
@@ -67,6 +70,23 @@ describe('Expo web OAuth', () => {
     expect(url.pathname).toBe('/auth/native-start');
     expect(url.searchParams.get('provider')).toBe('apple');
     expect(url.searchParams.get('callbackUrl')).toBe('https://app.boardsesh.com/');
+  });
+
+  it('reports browser navigation failures without throwing', async () => {
+    vi.stubGlobal('window', {
+      location: {
+        origin: 'https://app.boardsesh.com',
+        assign: vi.fn(() => {
+          throw new Error('navigation blocked');
+        }),
+      },
+    });
+
+    await expect(signInWithGoogle()).resolves.toEqual({
+      success: false,
+      status: null,
+      error: 'browser_unavailable',
+    });
   });
 });
 

--- a/packages/mobile/src/lib/__tests__/oauth-pending-store.test.ts
+++ b/packages/mobile/src/lib/__tests__/oauth-pending-store.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@react-native-async-storage/async-storage', () => {
   let storage: Record<string, string> = {};
+  let failNextRemove = false;
   return {
     default: {
       getItem: vi.fn(async (key: string) => storage[key] ?? null),
@@ -9,6 +10,10 @@ vi.mock('@react-native-async-storage/async-storage', () => {
         storage[key] = value;
       }),
       removeItem: vi.fn(async (key: string) => {
+        if (failNextRemove) {
+          failNextRemove = false;
+          throw new Error('storage unavailable');
+        }
         delete storage[key];
       }),
       getAllKeys: vi.fn(async () => Object.keys(storage)),
@@ -17,6 +22,10 @@ vi.mock('@react-native-async-storage/async-storage', () => {
       }),
       __reset: () => {
         storage = {};
+        failNextRemove = false;
+      },
+      __failNextRemove: () => {
+        failNextRemove = true;
       },
     },
   };
@@ -57,5 +66,19 @@ describe('oauth-pending-store', () => {
     });
 
     await expect(consumeFreshOAuthPending()).resolves.toBeNull();
+  });
+
+  it('returns a fresh marker when one-time cleanup fails', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    const asyncStorage = (await import('@react-native-async-storage/async-storage')).default as unknown as {
+      __failNextRemove: () => void;
+    };
+    asyncStorage.__failNextRemove();
+    const { consumeFreshOAuthPending, setOAuthPending } = await import('../oauth-pending-store');
+    const marker = { provider: 'apple' as const, attemptedAt: 999_000, isRegistration: false };
+
+    await setOAuthPending(marker);
+
+    await expect(consumeFreshOAuthPending()).resolves.toEqual(marker);
   });
 });

--- a/packages/mobile/src/lib/__tests__/oauth-pending-store.test.ts
+++ b/packages/mobile/src/lib/__tests__/oauth-pending-store.test.ts
@@ -67,7 +67,7 @@ describe('oauth-pending-store', () => {
     await setOAuthPending({
       attemptId: 'attempt-apple-1',
       provider: 'apple',
-      attemptedAt: 1_000_000 - 5 * 60 * 1000 - 1,
+      attemptedAt: 1_000_000 - 10 * 60 * 1000 - 1,
       isRegistration: true,
     });
 

--- a/packages/mobile/src/lib/__tests__/oauth-pending-store.test.ts
+++ b/packages/mobile/src/lib/__tests__/oauth-pending-store.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@react-native-async-storage/async-storage', () => {
+  let storage: Record<string, string> = {};
+  return {
+    default: {
+      getItem: vi.fn(async (key: string) => storage[key] ?? null),
+      setItem: vi.fn(async (key: string, value: string) => {
+        storage[key] = value;
+      }),
+      removeItem: vi.fn(async (key: string) => {
+        delete storage[key];
+      }),
+      getAllKeys: vi.fn(async () => Object.keys(storage)),
+      removeMany: vi.fn(async (keys: string[]) => {
+        keys.forEach((key) => delete storage[key]);
+      }),
+      __reset: () => {
+        storage = {};
+      },
+    },
+  };
+});
+
+describe('oauth-pending-store', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.useRealTimers();
+    const asyncStorage = (await import('@react-native-async-storage/async-storage')).default as unknown as {
+      __reset: () => void;
+    };
+    asyncStorage.__reset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('consumes a fresh marker once', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    const { consumeFreshOAuthPending, setOAuthPending } = await import('../oauth-pending-store');
+    const marker = { provider: 'google' as const, attemptedAt: 999_000, isRegistration: false };
+
+    await setOAuthPending(marker);
+
+    await expect(consumeFreshOAuthPending()).resolves.toEqual(marker);
+    await expect(consumeFreshOAuthPending()).resolves.toBeNull();
+  });
+
+  it('discards an expired marker', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    const { consumeFreshOAuthPending, setOAuthPending } = await import('../oauth-pending-store');
+    await setOAuthPending({
+      provider: 'apple',
+      attemptedAt: 1_000_000 - 5 * 60 * 1000 - 1,
+      isRegistration: true,
+    });
+
+    await expect(consumeFreshOAuthPending()).resolves.toBeNull();
+  });
+});

--- a/packages/mobile/src/lib/__tests__/oauth-pending-store.test.ts
+++ b/packages/mobile/src/lib/__tests__/oauth-pending-store.test.ts
@@ -48,24 +48,30 @@ describe('oauth-pending-store', () => {
   it('consumes a fresh marker once', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
     const { consumeFreshOAuthPending, setOAuthPending } = await import('../oauth-pending-store');
-    const marker = { provider: 'google' as const, attemptedAt: 999_000, isRegistration: false };
+    const marker = {
+      attemptId: 'attempt-google-1',
+      provider: 'google' as const,
+      attemptedAt: 999_000,
+      isRegistration: false,
+    };
 
     await setOAuthPending(marker);
 
-    await expect(consumeFreshOAuthPending()).resolves.toEqual(marker);
-    await expect(consumeFreshOAuthPending()).resolves.toBeNull();
+    await expect(consumeFreshOAuthPending(marker.attemptId)).resolves.toEqual(marker);
+    await expect(consumeFreshOAuthPending(marker.attemptId)).resolves.toBeNull();
   });
 
   it('discards an expired marker', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
     const { consumeFreshOAuthPending, setOAuthPending } = await import('../oauth-pending-store');
     await setOAuthPending({
+      attemptId: 'attempt-apple-1',
       provider: 'apple',
       attemptedAt: 1_000_000 - 5 * 60 * 1000 - 1,
       isRegistration: true,
     });
 
-    await expect(consumeFreshOAuthPending()).resolves.toBeNull();
+    await expect(consumeFreshOAuthPending('attempt-apple-1')).resolves.toBeNull();
   });
 
   it('returns a fresh marker when one-time cleanup fails', async () => {
@@ -75,10 +81,37 @@ describe('oauth-pending-store', () => {
     };
     asyncStorage.__failNextRemove();
     const { consumeFreshOAuthPending, setOAuthPending } = await import('../oauth-pending-store');
-    const marker = { provider: 'apple' as const, attemptedAt: 999_000, isRegistration: false };
+    const marker = {
+      attemptId: 'attempt-apple-2',
+      provider: 'apple' as const,
+      attemptedAt: 999_000,
+      isRegistration: false,
+    };
 
     await setOAuthPending(marker);
 
-    await expect(consumeFreshOAuthPending()).resolves.toEqual(marker);
+    await expect(consumeFreshOAuthPending(marker.attemptId)).resolves.toEqual(marker);
+  });
+
+  it('keeps concurrent attempts isolated', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    const { consumeFreshOAuthPending, setOAuthPending } = await import('../oauth-pending-store');
+    const google = {
+      attemptId: 'attempt-google-2',
+      provider: 'google' as const,
+      attemptedAt: 999_000,
+      isRegistration: false,
+    };
+    const apple = {
+      attemptId: 'attempt-apple-3',
+      provider: 'apple' as const,
+      attemptedAt: 999_500,
+      isRegistration: true,
+    };
+    await setOAuthPending(google);
+    await setOAuthPending(apple);
+
+    await expect(consumeFreshOAuthPending(apple.attemptId)).resolves.toEqual(apple);
+    await expect(consumeFreshOAuthPending(google.attemptId)).resolves.toEqual(google);
   });
 });

--- a/packages/mobile/src/lib/__tests__/oauth-return.web.test.ts
+++ b/packages/mobile/src/lib/__tests__/oauth-return.web.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import { consumeWebOAuthReturnProvider } from '../oauth-return.web';
+
+afterEach(() => {
+  window.history.replaceState({}, '', '/');
+});
+
+describe('consumeWebOAuthReturnProvider', () => {
+  it('returns a valid provider and removes only the one-time marker', () => {
+    window.history.replaceState({}, '', '/app?boardseshOAuthProvider=google&keep=1');
+
+    expect(consumeWebOAuthReturnProvider()).toBe('google');
+    expect(window.location.pathname).toBe('/app');
+    expect(window.location.search).toBe('?keep=1');
+    expect(consumeWebOAuthReturnProvider()).toBeNull();
+  });
+
+  it('removes an invalid provider marker without attributing a login', () => {
+    window.history.replaceState({}, '', '/?boardseshOAuthProvider=facebook');
+
+    expect(consumeWebOAuthReturnProvider()).toBeNull();
+    expect(window.location.search).toBe('');
+  });
+});

--- a/packages/mobile/src/lib/__tests__/oauth-return.web.test.ts
+++ b/packages/mobile/src/lib/__tests__/oauth-return.web.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it } from 'vitest';
-import { consumeWebOAuthReturn } from '../oauth-return.web';
+import { consumeWebOAuthErrorReturn, consumeWebOAuthReturn } from '../oauth-return.web';
 
 afterEach(() => {
   window.history.replaceState({}, '', '/');
@@ -44,5 +44,21 @@ describe('consumeWebOAuthReturn', () => {
       error: 'OAuthCallback',
     });
     expect(window.location.search).toBe('');
+  });
+
+  it('leaves a successful return for AuthProvider to consume', () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/auth/login?boardseshOAuthProvider=google&boardseshOAuthAttempt=attempt-google-2',
+    );
+
+    expect(consumeWebOAuthErrorReturn()).toBeNull();
+    expect(window.location.search).toContain('boardseshOAuthAttempt=attempt-google-2');
+    expect(consumeWebOAuthReturn()).toEqual({
+      provider: 'google',
+      attemptId: 'attempt-google-2',
+      error: null,
+    });
   });
 });

--- a/packages/mobile/src/lib/__tests__/oauth-return.web.test.ts
+++ b/packages/mobile/src/lib/__tests__/oauth-return.web.test.ts
@@ -1,25 +1,48 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it } from 'vitest';
-import { consumeWebOAuthReturnProvider } from '../oauth-return.web';
+import { consumeWebOAuthReturn } from '../oauth-return.web';
 
 afterEach(() => {
   window.history.replaceState({}, '', '/');
 });
 
-describe('consumeWebOAuthReturnProvider', () => {
+describe('consumeWebOAuthReturn', () => {
   it('returns a valid provider and removes only the one-time marker', () => {
-    window.history.replaceState({}, '', '/app?boardseshOAuthProvider=google&keep=1');
+    window.history.replaceState(
+      {},
+      '',
+      '/app/auth/login?boardseshOAuthProvider=google&boardseshOAuthAttempt=attempt-google-1&keep=1',
+    );
 
-    expect(consumeWebOAuthReturnProvider()).toBe('google');
-    expect(window.location.pathname).toBe('/app');
+    expect(consumeWebOAuthReturn()).toEqual({
+      provider: 'google',
+      attemptId: 'attempt-google-1',
+      error: null,
+    });
+    expect(window.location.pathname).toBe('/app/auth/login');
     expect(window.location.search).toBe('?keep=1');
-    expect(consumeWebOAuthReturnProvider()).toBeNull();
+    expect(consumeWebOAuthReturn()).toBeNull();
   });
 
   it('removes an invalid provider marker without attributing a login', () => {
     window.history.replaceState({}, '', '/?boardseshOAuthProvider=facebook');
 
-    expect(consumeWebOAuthReturnProvider()).toBeNull();
+    expect(consumeWebOAuthReturn()).toBeNull();
+    expect(window.location.search).toBe('');
+  });
+
+  it('returns a provider failure to the initiating attempt', () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/auth/register?boardseshOAuthProvider=apple&boardseshOAuthAttempt=attempt-apple-1&boardseshOAuthError=OAuthCallback',
+    );
+
+    expect(consumeWebOAuthReturn()).toEqual({
+      provider: 'apple',
+      attemptId: 'attempt-apple-1',
+      error: 'OAuthCallback',
+    });
     expect(window.location.search).toBe('');
   });
 });

--- a/packages/mobile/src/lib/auth.ts
+++ b/packages/mobile/src/lib/auth.ts
@@ -45,7 +45,11 @@ type NativeAuthFailure = { success: false; status: number | null; error: string 
 // A native OAuth attempt resolves to one of: success, an explicit user
 // cancellation (no error shown), or a real failure carrying the server's
 // status/error (mapped to a translated message by the caller).
-export type OAuthSignInResult = { success: true } | { success: false; cancelled: true } | NativeAuthFailure;
+export type OAuthSignInResult =
+  | { success: true }
+  | { success: false; cancelled: true }
+  | { success: false; redirecting: true }
+  | NativeAuthFailure;
 
 /**
  * POST a verified provider identity token to the backend, which verifies it

--- a/packages/mobile/src/lib/auth.web.ts
+++ b/packages/mobile/src/lib/auth.web.ts
@@ -12,13 +12,17 @@ import {
   type WebAuthIdentity,
 } from './auth-store.web';
 import { withAuthCookieLock } from './auth-cookie-lock.web';
-import { webApiUrl } from './env';
+import { WEB_BASE_URL, webApiUrl } from './env';
 
 export type AuthProvider = 'google' | 'apple';
 
 type AuthFailure = { success: false; status: number | null; error: string };
 
-export type OAuthSignInResult = { success: true } | { success: false; cancelled: true } | AuthFailure;
+export type OAuthSignInResult =
+  | { success: true }
+  | { success: false; cancelled: true }
+  | { success: false; redirecting: true }
+  | AuthFailure;
 export type CredentialsSignInResult = { success: true } | AuthFailure;
 export type RegistrationResult =
   | { success: true; authenticated?: true }
@@ -491,22 +495,52 @@ export function isGoogleSignInConfigured(): boolean {
   return false;
 }
 
-function unavailableOAuth(): Promise<OAuthSignInResult> {
-  return Promise.resolve({ success: false, status: null, error: 'oauth_unavailable' });
+/**
+ * Build the NextAuth start URL for the Expo browser app. OAuth itself always
+ * runs on WEB_BASE_URL (www in production), while the callback returns to the
+ * actual export that initiated it: `/app` for the same-origin build and `/` for
+ * app.boardsesh.com.
+ */
+export function buildWebOAuthStartUrl(
+  provider: AuthProvider,
+  appOrigin: string,
+  exportBasePath = process.env.EXPO_BASE_URL || '/',
+): string {
+  const callbackUrl = new URL(exportBasePath || '/', appOrigin).toString();
+  const startUrl = new URL('/auth/native-start', WEB_BASE_URL);
+  startUrl.searchParams.set('provider', provider);
+  startUrl.searchParams.set('callbackUrl', callbackUrl);
+  return startUrl.toString();
+}
+
+function startWebOAuth(provider: AuthProvider): Promise<OAuthSignInResult> {
+  if (typeof window === 'undefined') {
+    return Promise.resolve({ success: false, status: null, error: 'browser_unavailable' });
+  }
+
+  try {
+    window.location.assign(buildWebOAuthStartUrl(provider, window.location.origin));
+    // The document is about to unload. This distinct result prevents the
+    // in-process native flow from reporting success or checking the old cookie
+    // before the provider round-trip returns.
+    return Promise.resolve({ success: false, redirecting: true });
+  } catch {
+    return Promise.resolve({ success: false, status: null, error: 'browser_unavailable' });
+  }
 }
 
 export function signInWithApple(): Promise<OAuthSignInResult> {
-  return unavailableOAuth();
+  return startWebOAuth('apple');
 }
 
 export function signInWithGoogle(): Promise<OAuthSignInResult> {
-  return unavailableOAuth();
+  return startWebOAuth('google');
 }
 
 export function signInWithGoogleWeb(): Promise<OAuthSignInResult> {
-  return unavailableOAuth();
+  return startWebOAuth('google');
 }
 
 export function signInWithAppleWeb(): Promise<OAuthSignInResult> {
-  return unavailableOAuth();
+  return startWebOAuth('apple');
 }

--- a/packages/mobile/src/lib/auth.web.ts
+++ b/packages/mobile/src/lib/auth.web.ts
@@ -13,7 +13,11 @@ import {
 } from './auth-store.web';
 import { withAuthCookieLock } from './auth-cookie-lock.web';
 import { WEB_BASE_URL, webApiUrl } from './env';
-import { WEB_OAUTH_RETURN_ATTEMPT_PARAM, WEB_OAUTH_RETURN_PROVIDER_PARAM } from './oauth-return-marker';
+import {
+  createWebOAuthAttemptId,
+  WEB_OAUTH_RETURN_ATTEMPT_PARAM,
+  WEB_OAUTH_RETURN_PROVIDER_PARAM,
+} from './oauth-return-marker';
 
 export type AuthProvider = 'google' | 'apple';
 
@@ -525,8 +529,8 @@ function startWebOAuth(provider: AuthProvider, attemptId?: string, isRegistratio
   }
 
   try {
-    if (!attemptId) throw new Error('Missing browser OAuth attempt ID');
-    window.location.assign(buildWebOAuthStartUrl(provider, window.location.origin, attemptId, isRegistration));
+    const resolvedAttemptId = attemptId ?? createWebOAuthAttemptId();
+    window.location.assign(buildWebOAuthStartUrl(provider, window.location.origin, resolvedAttemptId, isRegistration));
     // The document is about to unload. This distinct result prevents the
     // in-process native flow from reporting success or checking the old cookie
     // before the provider round-trip returns.

--- a/packages/mobile/src/lib/auth.web.ts
+++ b/packages/mobile/src/lib/auth.web.ts
@@ -13,6 +13,7 @@ import {
 } from './auth-store.web';
 import { withAuthCookieLock } from './auth-cookie-lock.web';
 import { WEB_BASE_URL, webApiUrl } from './env';
+import { WEB_OAUTH_RETURN_PROVIDER_PARAM } from './oauth-return-marker';
 
 export type AuthProvider = 'google' | 'apple';
 
@@ -506,10 +507,11 @@ export function buildWebOAuthStartUrl(
   appOrigin: string,
   exportBasePath = process.env.EXPO_BASE_URL || '/',
 ): string {
-  const callbackUrl = new URL(exportBasePath || '/', appOrigin).toString();
+  const callbackUrl = new URL(exportBasePath || '/', appOrigin);
+  callbackUrl.searchParams.set(WEB_OAUTH_RETURN_PROVIDER_PARAM, provider);
   const startUrl = new URL('/auth/native-start', WEB_BASE_URL);
   startUrl.searchParams.set('provider', provider);
-  startUrl.searchParams.set('callbackUrl', callbackUrl);
+  startUrl.searchParams.set('callbackUrl', callbackUrl.toString());
   return startUrl.toString();
 }
 

--- a/packages/mobile/src/lib/auth.web.ts
+++ b/packages/mobile/src/lib/auth.web.ts
@@ -13,7 +13,7 @@ import {
 } from './auth-store.web';
 import { withAuthCookieLock } from './auth-cookie-lock.web';
 import { WEB_BASE_URL, webApiUrl } from './env';
-import { WEB_OAUTH_RETURN_PROVIDER_PARAM } from './oauth-return-marker';
+import { WEB_OAUTH_RETURN_ATTEMPT_PARAM, WEB_OAUTH_RETURN_PROVIDER_PARAM } from './oauth-return-marker';
 
 export type AuthProvider = 'google' | 'apple';
 
@@ -499,29 +499,34 @@ export function isGoogleSignInConfigured(): boolean {
 /**
  * Build the NextAuth start URL for the Expo browser app. OAuth itself always
  * runs on WEB_BASE_URL (www in production), while the callback returns to the
- * actual export that initiated it: `/app` for the same-origin build and `/` for
- * app.boardsesh.com.
+ * exact auth route that initiated it: `/app/auth/...` for the same-origin build
+ * and `/auth/...` for app.boardsesh.com.
  */
 export function buildWebOAuthStartUrl(
   provider: AuthProvider,
   appOrigin: string,
+  attemptId: string,
+  isRegistration = false,
   exportBasePath = process.env.EXPO_BASE_URL || '/',
 ): string {
-  const callbackUrl = new URL(exportBasePath || '/', appOrigin);
+  const normalizedBasePath = exportBasePath === '/' ? '' : exportBasePath.replace(/\/$/, '');
+  const callbackUrl = new URL(`${normalizedBasePath}/auth/${isRegistration ? 'register' : 'login'}`, appOrigin);
   callbackUrl.searchParams.set(WEB_OAUTH_RETURN_PROVIDER_PARAM, provider);
+  callbackUrl.searchParams.set(WEB_OAUTH_RETURN_ATTEMPT_PARAM, attemptId);
   const startUrl = new URL('/auth/native-start', WEB_BASE_URL);
   startUrl.searchParams.set('provider', provider);
   startUrl.searchParams.set('callbackUrl', callbackUrl.toString());
   return startUrl.toString();
 }
 
-function startWebOAuth(provider: AuthProvider): Promise<OAuthSignInResult> {
+function startWebOAuth(provider: AuthProvider, attemptId?: string, isRegistration = false): Promise<OAuthSignInResult> {
   if (typeof window === 'undefined') {
     return Promise.resolve({ success: false, status: null, error: 'browser_unavailable' });
   }
 
   try {
-    window.location.assign(buildWebOAuthStartUrl(provider, window.location.origin));
+    if (!attemptId) throw new Error('Missing browser OAuth attempt ID');
+    window.location.assign(buildWebOAuthStartUrl(provider, window.location.origin, attemptId, isRegistration));
     // The document is about to unload. This distinct result prevents the
     // in-process native flow from reporting success or checking the old cookie
     // before the provider round-trip returns.
@@ -531,12 +536,12 @@ function startWebOAuth(provider: AuthProvider): Promise<OAuthSignInResult> {
   }
 }
 
-export function signInWithApple(): Promise<OAuthSignInResult> {
-  return startWebOAuth('apple');
+export function signInWithApple(webAttemptId?: string, isRegistration = false): Promise<OAuthSignInResult> {
+  return startWebOAuth('apple', webAttemptId, isRegistration);
 }
 
-export function signInWithGoogle(): Promise<OAuthSignInResult> {
-  return startWebOAuth('google');
+export function signInWithGoogle(webAttemptId?: string, isRegistration = false): Promise<OAuthSignInResult> {
+  return startWebOAuth('google', webAttemptId, isRegistration);
 }
 
 export function signInWithGoogleWeb(): Promise<OAuthSignInResult> {

--- a/packages/mobile/src/lib/oauth-pending-store.ts
+++ b/packages/mobile/src/lib/oauth-pending-store.ts
@@ -1,0 +1,51 @@
+import { getPreference, removePreference, setPreference } from './preference-store';
+import type { AuthProvider } from './auth';
+
+const OAUTH_PENDING_KEY = 'auth:oauth-pending';
+const OAUTH_PENDING_MAX_AGE_MS = 5 * 60 * 1000;
+
+export type OAuthPendingMarker = {
+  provider: AuthProvider;
+  attemptedAt: number;
+  isRegistration: boolean;
+};
+
+function isOAuthPendingMarker(candidate: unknown): candidate is OAuthPendingMarker {
+  if (typeof candidate !== 'object' || candidate === null || Array.isArray(candidate)) return false;
+  const marker = candidate as Record<string, unknown>;
+  return (
+    (marker.provider === 'google' || marker.provider === 'apple') &&
+    typeof marker.attemptedAt === 'number' &&
+    Number.isFinite(marker.attemptedAt) &&
+    typeof marker.isRegistration === 'boolean'
+  );
+}
+
+export function setOAuthPending(marker: OAuthPendingMarker): Promise<void> {
+  return setPreference(OAUTH_PENDING_KEY, marker);
+}
+
+/**
+ * Consume a browser-OAuth attempt after the returned NextAuth cookie has been
+ * confirmed. Storage failures are analytics-only and must never block login.
+ */
+export async function consumeFreshOAuthPending(): Promise<OAuthPendingMarker | null> {
+  let stored: unknown;
+  try {
+    stored = await getPreference<unknown>(OAUTH_PENDING_KEY);
+  } catch {
+    return null;
+  }
+  if (stored === null) return null;
+
+  try {
+    await removePreference(OAUTH_PENDING_KEY);
+  } catch {
+    // A failed cleanup may duplicate telemetry on a later reload, but must not
+    // turn a completed OAuth login into an auth failure.
+  }
+
+  if (!isOAuthPendingMarker(stored)) return null;
+  const age = Date.now() - stored.attemptedAt;
+  return age >= 0 && age <= OAUTH_PENDING_MAX_AGE_MS ? stored : null;
+}

--- a/packages/mobile/src/lib/oauth-pending-store.ts
+++ b/packages/mobile/src/lib/oauth-pending-store.ts
@@ -3,7 +3,7 @@ import type { AuthProvider } from './auth';
 import { WEB_OAUTH_ATTEMPT_ID_PATTERN } from './oauth-return-marker';
 
 const OAUTH_PENDING_KEY_PREFIX = 'auth:oauth-pending:';
-const OAUTH_PENDING_MAX_AGE_MS = 5 * 60 * 1000;
+const OAUTH_PENDING_MAX_AGE_MS = 10 * 60 * 1000;
 
 export type OAuthPendingMarker = {
   attemptId: string;

--- a/packages/mobile/src/lib/oauth-pending-store.ts
+++ b/packages/mobile/src/lib/oauth-pending-store.ts
@@ -1,10 +1,12 @@
 import { getPreference, removePreference, setPreference } from './preference-store';
 import type { AuthProvider } from './auth';
 
-const OAUTH_PENDING_KEY = 'auth:oauth-pending';
+const OAUTH_PENDING_KEY_PREFIX = 'auth:oauth-pending:';
 const OAUTH_PENDING_MAX_AGE_MS = 5 * 60 * 1000;
+const OAUTH_ATTEMPT_ID_PATTERN = /^[A-Za-z0-9_-]{8,128}$/;
 
 export type OAuthPendingMarker = {
+  attemptId: string;
   provider: AuthProvider;
   attemptedAt: number;
   isRegistration: boolean;
@@ -14,6 +16,8 @@ function isOAuthPendingMarker(candidate: unknown): candidate is OAuthPendingMark
   if (typeof candidate !== 'object' || candidate === null || Array.isArray(candidate)) return false;
   const marker = candidate as Record<string, unknown>;
   return (
+    typeof marker.attemptId === 'string' &&
+    OAUTH_ATTEMPT_ID_PATTERN.test(marker.attemptId) &&
     (marker.provider === 'google' || marker.provider === 'apple') &&
     typeof marker.attemptedAt === 'number' &&
     Number.isFinite(marker.attemptedAt) &&
@@ -22,30 +26,32 @@ function isOAuthPendingMarker(candidate: unknown): candidate is OAuthPendingMark
 }
 
 export function setOAuthPending(marker: OAuthPendingMarker): Promise<void> {
-  return setPreference(OAUTH_PENDING_KEY, marker);
+  return setPreference(`${OAUTH_PENDING_KEY_PREFIX}${marker.attemptId}`, marker);
 }
 
 /**
  * Consume a browser-OAuth attempt after the returned NextAuth cookie has been
  * confirmed. Storage failures are analytics-only and must never block login.
  */
-export async function consumeFreshOAuthPending(): Promise<OAuthPendingMarker | null> {
+export async function consumeFreshOAuthPending(attemptId: string): Promise<OAuthPendingMarker | null> {
+  if (!OAUTH_ATTEMPT_ID_PATTERN.test(attemptId)) return null;
+  const storageKey = `${OAUTH_PENDING_KEY_PREFIX}${attemptId}`;
   let stored: unknown;
   try {
-    stored = await getPreference<unknown>(OAUTH_PENDING_KEY);
+    stored = await getPreference<unknown>(storageKey);
   } catch {
     return null;
   }
   if (stored === null) return null;
 
   try {
-    await removePreference(OAUTH_PENDING_KEY);
+    await removePreference(storageKey);
   } catch {
     // A failed cleanup may duplicate telemetry on a later reload, but must not
     // turn a completed OAuth login into an auth failure.
   }
 
-  if (!isOAuthPendingMarker(stored)) return null;
+  if (!isOAuthPendingMarker(stored) || stored.attemptId !== attemptId) return null;
   const age = Date.now() - stored.attemptedAt;
   return age >= 0 && age <= OAUTH_PENDING_MAX_AGE_MS ? stored : null;
 }

--- a/packages/mobile/src/lib/oauth-pending-store.ts
+++ b/packages/mobile/src/lib/oauth-pending-store.ts
@@ -1,9 +1,9 @@
 import { getPreference, removePreference, setPreference } from './preference-store';
 import type { AuthProvider } from './auth';
+import { WEB_OAUTH_ATTEMPT_ID_PATTERN } from './oauth-return-marker';
 
 const OAUTH_PENDING_KEY_PREFIX = 'auth:oauth-pending:';
 const OAUTH_PENDING_MAX_AGE_MS = 5 * 60 * 1000;
-const OAUTH_ATTEMPT_ID_PATTERN = /^[A-Za-z0-9_-]{8,128}$/;
 
 export type OAuthPendingMarker = {
   attemptId: string;
@@ -17,7 +17,7 @@ function isOAuthPendingMarker(candidate: unknown): candidate is OAuthPendingMark
   const marker = candidate as Record<string, unknown>;
   return (
     typeof marker.attemptId === 'string' &&
-    OAUTH_ATTEMPT_ID_PATTERN.test(marker.attemptId) &&
+    WEB_OAUTH_ATTEMPT_ID_PATTERN.test(marker.attemptId) &&
     (marker.provider === 'google' || marker.provider === 'apple') &&
     typeof marker.attemptedAt === 'number' &&
     Number.isFinite(marker.attemptedAt) &&
@@ -34,7 +34,7 @@ export function setOAuthPending(marker: OAuthPendingMarker): Promise<void> {
  * confirmed. Storage failures are analytics-only and must never block login.
  */
 export async function consumeFreshOAuthPending(attemptId: string): Promise<OAuthPendingMarker | null> {
-  if (!OAUTH_ATTEMPT_ID_PATTERN.test(attemptId)) return null;
+  if (!WEB_OAUTH_ATTEMPT_ID_PATTERN.test(attemptId)) return null;
   const storageKey = `${OAUTH_PENDING_KEY_PREFIX}${attemptId}`;
   let stored: unknown;
   try {

--- a/packages/mobile/src/lib/oauth-return-marker.ts
+++ b/packages/mobile/src/lib/oauth-return-marker.ts
@@ -1,0 +1,1 @@
+export const WEB_OAUTH_RETURN_PROVIDER_PARAM = 'boardseshOAuthProvider';

--- a/packages/mobile/src/lib/oauth-return-marker.ts
+++ b/packages/mobile/src/lib/oauth-return-marker.ts
@@ -1,1 +1,9 @@
 export const WEB_OAUTH_RETURN_PROVIDER_PARAM = 'boardseshOAuthProvider';
+export const WEB_OAUTH_RETURN_ATTEMPT_PARAM = 'boardseshOAuthAttempt';
+export const WEB_OAUTH_RETURN_ERROR_PARAM = 'boardseshOAuthError';
+
+export function createWebOAuthAttemptId(): string {
+  if (typeof globalThis.crypto?.randomUUID === 'function') return globalThis.crypto.randomUUID();
+
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}-${Math.random().toString(36).slice(2)}`;
+}

--- a/packages/mobile/src/lib/oauth-return-marker.ts
+++ b/packages/mobile/src/lib/oauth-return-marker.ts
@@ -1,9 +1,14 @@
 export const WEB_OAUTH_RETURN_PROVIDER_PARAM = 'boardseshOAuthProvider';
 export const WEB_OAUTH_RETURN_ATTEMPT_PARAM = 'boardseshOAuthAttempt';
 export const WEB_OAUTH_RETURN_ERROR_PARAM = 'boardseshOAuthError';
+export const WEB_OAUTH_ATTEMPT_ID_PATTERN = /^[A-Za-z0-9_-]{8,128}$/;
 
 export function createWebOAuthAttemptId(): string {
   if (typeof globalThis.crypto?.randomUUID === 'function') return globalThis.crypto.randomUUID();
 
-  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}-${Math.random().toString(36).slice(2)}`;
+  if (typeof globalThis.crypto?.getRandomValues !== 'function') {
+    throw new Error('Secure random number generation is unavailable');
+  }
+  const randomBytes = globalThis.crypto.getRandomValues(new Uint8Array(16));
+  return Array.from(randomBytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
 }

--- a/packages/mobile/src/lib/oauth-return.ts
+++ b/packages/mobile/src/lib/oauth-return.ts
@@ -9,3 +9,7 @@ export type WebOAuthReturn = {
 export function consumeWebOAuthReturn(): WebOAuthReturn | null {
   return null;
 }
+
+export function consumeWebOAuthErrorReturn(): WebOAuthReturn | null {
+  return null;
+}

--- a/packages/mobile/src/lib/oauth-return.ts
+++ b/packages/mobile/src/lib/oauth-return.ts
@@ -1,0 +1,5 @@
+import type { AuthProvider } from './auth';
+
+export function consumeWebOAuthReturnProvider(): AuthProvider | null {
+  return null;
+}

--- a/packages/mobile/src/lib/oauth-return.ts
+++ b/packages/mobile/src/lib/oauth-return.ts
@@ -1,5 +1,11 @@
 import type { AuthProvider } from './auth';
 
-export function consumeWebOAuthReturnProvider(): AuthProvider | null {
+export type WebOAuthReturn = {
+  provider: AuthProvider;
+  attemptId: string;
+  error: string | null;
+};
+
+export function consumeWebOAuthReturn(): WebOAuthReturn | null {
   return null;
 }

--- a/packages/mobile/src/lib/oauth-return.web.ts
+++ b/packages/mobile/src/lib/oauth-return.web.ts
@@ -1,20 +1,33 @@
 import type { AuthProvider } from './auth';
-import { WEB_OAUTH_RETURN_PROVIDER_PARAM } from './oauth-return-marker';
+import type { WebOAuthReturn } from './oauth-return';
+import {
+  WEB_OAUTH_RETURN_ATTEMPT_PARAM,
+  WEB_OAUTH_RETURN_ERROR_PARAM,
+  WEB_OAUTH_RETURN_PROVIDER_PARAM,
+} from './oauth-return-marker';
 
-export function consumeWebOAuthReturnProvider(): AuthProvider | null {
+const OAUTH_ATTEMPT_ID_PATTERN = /^[A-Za-z0-9_-]{8,128}$/;
+
+export function consumeWebOAuthReturn(): WebOAuthReturn | null {
   if (typeof window === 'undefined') return null;
 
   const currentUrl = new URL(window.location.href);
-  const candidate = currentUrl.searchParams.get(WEB_OAUTH_RETURN_PROVIDER_PARAM);
-  const provider: AuthProvider | null = candidate === 'apple' || candidate === 'google' ? candidate : null;
-  if (candidate === null) return null;
+  const providerCandidate = currentUrl.searchParams.get(WEB_OAUTH_RETURN_PROVIDER_PARAM);
+  const attemptId = currentUrl.searchParams.get(WEB_OAUTH_RETURN_ATTEMPT_PARAM);
+  const error = currentUrl.searchParams.get(WEB_OAUTH_RETURN_ERROR_PARAM);
+  const provider: AuthProvider | null =
+    providerCandidate === 'apple' || providerCandidate === 'google' ? providerCandidate : null;
+  if (providerCandidate === null && attemptId === null && error === null) return null;
 
   currentUrl.searchParams.delete(WEB_OAUTH_RETURN_PROVIDER_PARAM);
+  currentUrl.searchParams.delete(WEB_OAUTH_RETURN_ATTEMPT_PARAM);
+  currentUrl.searchParams.delete(WEB_OAUTH_RETURN_ERROR_PARAM);
   try {
     window.history.replaceState(window.history.state, '', currentUrl.toString());
   } catch {
     // URL cleanup is cosmetic. The provider marker has still been consumed by
     // this app lifecycle and the durable attempt marker remains one-time.
   }
-  return provider;
+  if (!provider || !attemptId || !OAUTH_ATTEMPT_ID_PATTERN.test(attemptId)) return null;
+  return { provider, attemptId, error };
 }

--- a/packages/mobile/src/lib/oauth-return.web.ts
+++ b/packages/mobile/src/lib/oauth-return.web.ts
@@ -1,0 +1,20 @@
+import type { AuthProvider } from './auth';
+import { WEB_OAUTH_RETURN_PROVIDER_PARAM } from './oauth-return-marker';
+
+export function consumeWebOAuthReturnProvider(): AuthProvider | null {
+  if (typeof window === 'undefined') return null;
+
+  const currentUrl = new URL(window.location.href);
+  const candidate = currentUrl.searchParams.get(WEB_OAUTH_RETURN_PROVIDER_PARAM);
+  const provider: AuthProvider | null = candidate === 'apple' || candidate === 'google' ? candidate : null;
+  if (candidate === null) return null;
+
+  currentUrl.searchParams.delete(WEB_OAUTH_RETURN_PROVIDER_PARAM);
+  try {
+    window.history.replaceState(window.history.state, '', currentUrl.toString());
+  } catch {
+    // URL cleanup is cosmetic. The provider marker has still been consumed by
+    // this app lifecycle and the durable attempt marker remains one-time.
+  }
+  return provider;
+}

--- a/packages/mobile/src/lib/oauth-return.web.ts
+++ b/packages/mobile/src/lib/oauth-return.web.ts
@@ -31,3 +31,10 @@ export function consumeWebOAuthReturn(): WebOAuthReturn | null {
   if (!provider || !attemptId || !OAUTH_ATTEMPT_ID_PATTERN.test(attemptId)) return null;
   return { provider, attemptId, error };
 }
+
+export function consumeWebOAuthErrorReturn(): WebOAuthReturn | null {
+  if (typeof window === 'undefined') return null;
+  const currentUrl = new URL(window.location.href);
+  if (!currentUrl.searchParams.has(WEB_OAUTH_RETURN_ERROR_PARAM)) return null;
+  return consumeWebOAuthReturn();
+}

--- a/packages/mobile/src/lib/oauth-return.web.ts
+++ b/packages/mobile/src/lib/oauth-return.web.ts
@@ -4,9 +4,8 @@ import {
   WEB_OAUTH_RETURN_ATTEMPT_PARAM,
   WEB_OAUTH_RETURN_ERROR_PARAM,
   WEB_OAUTH_RETURN_PROVIDER_PARAM,
+  WEB_OAUTH_ATTEMPT_ID_PATTERN,
 } from './oauth-return-marker';
-
-const OAUTH_ATTEMPT_ID_PATTERN = /^[A-Za-z0-9_-]{8,128}$/;
 
 export function consumeWebOAuthReturn(): WebOAuthReturn | null {
   if (typeof window === 'undefined') return null;
@@ -28,7 +27,7 @@ export function consumeWebOAuthReturn(): WebOAuthReturn | null {
     // URL cleanup is cosmetic. The provider marker has still been consumed by
     // this app lifecycle and the durable attempt marker remains one-time.
   }
-  if (!provider || !attemptId || !OAUTH_ATTEMPT_ID_PATTERN.test(attemptId)) return null;
+  if (!provider || !attemptId || !WEB_OAUTH_ATTEMPT_ID_PATTERN.test(attemptId)) return null;
   return { provider, attemptId, error };
 }
 

--- a/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
@@ -24,6 +24,8 @@ const userStorageOwnerState = vi.hoisted(() => ({
   set: vi.fn(),
 }));
 const bumpAuthTransportRevisionMock = vi.hoisted(() => vi.fn());
+const consumeFreshOAuthPendingMock = vi.hoisted(() => vi.fn());
+const trackMock = vi.hoisted(() => vi.fn());
 
 // expo-router and react-native both reach for the native runtime; stub the
 // thin surface AuthProvider consumes. `useSegments` returning `[]` keeps the
@@ -114,6 +116,9 @@ beforeEach(() => {
     userStorageOwnerState.current = owner as { userId: string; authSessionId: string } | null;
   });
   bumpAuthTransportRevisionMock.mockReset();
+  consumeFreshOAuthPendingMock.mockReset();
+  consumeFreshOAuthPendingMock.mockResolvedValue(null);
+  trackMock.mockReset();
   captureAuthCredentialGenerationMock.mockReset();
   captureAuthCredentialGenerationMock.mockReturnValue(1);
   authSignInWithCredentialsMock.mockReset();
@@ -147,6 +152,15 @@ vi.mock('../../lib/auth-store', () => ({
 const reportErrorMock = vi.fn();
 vi.mock('../../lib/error-reporting', () => ({
   reportError: (...args: unknown[]) => reportErrorMock(...args),
+}));
+
+vi.mock('../../lib/analytics', () => ({
+  reset: vi.fn(),
+  track: (...args: unknown[]) => trackMock(...args),
+}));
+
+vi.mock('../../lib/oauth-pending-store', () => ({
+  consumeFreshOAuthPending: (...args: unknown[]) => consumeFreshOAuthPendingMock(...args),
 }));
 
 const authSignOutMock = vi.fn();
@@ -619,6 +633,47 @@ describe('AuthProvider.register', () => {
     });
 
     expect(getAuthTokenMock).toHaveBeenCalledTimes(authReadsBeforeRegistration);
+  });
+});
+
+describe('AuthProvider Expo-web OAuth completion', () => {
+  beforeEach(() => {
+    platformState.OS = 'web';
+    getAuthTokenMock.mockReset();
+    getAuthTokenMock.mockResolvedValue('backend-jwe');
+    isTokenExpiringSoonMock.mockReset();
+    isTokenExpiringSoonMock.mockResolvedValue(false);
+  });
+
+  it('consumes a pending attempt after the returned web session is authenticated', async () => {
+    consumeFreshOAuthPendingMock.mockResolvedValue({
+      provider: 'apple',
+      attemptedAt: Date.now(),
+      isRegistration: true,
+    });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>{children}</AuthProvider>
+      </QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+    await waitFor(() =>
+      expect(trackMock).toHaveBeenCalledWith('Login Succeeded', {
+        auth_method: 'apple',
+        flow: 'web',
+        is_registration: true,
+      }),
+    );
+    expect(consumeFreshOAuthPendingMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.refreshAuthState();
+    });
+    expect(consumeFreshOAuthPendingMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
@@ -25,6 +25,7 @@ const userStorageOwnerState = vi.hoisted(() => ({
 }));
 const bumpAuthTransportRevisionMock = vi.hoisted(() => vi.fn());
 const consumeFreshOAuthPendingMock = vi.hoisted(() => vi.fn());
+const consumeWebOAuthReturnProviderMock = vi.hoisted(() => vi.fn());
 const trackMock = vi.hoisted(() => vi.fn());
 
 // expo-router and react-native both reach for the native runtime; stub the
@@ -118,6 +119,8 @@ beforeEach(() => {
   bumpAuthTransportRevisionMock.mockReset();
   consumeFreshOAuthPendingMock.mockReset();
   consumeFreshOAuthPendingMock.mockResolvedValue(null);
+  consumeWebOAuthReturnProviderMock.mockReset();
+  consumeWebOAuthReturnProviderMock.mockReturnValue(null);
   trackMock.mockReset();
   captureAuthCredentialGenerationMock.mockReset();
   captureAuthCredentialGenerationMock.mockReturnValue(1);
@@ -161,6 +164,10 @@ vi.mock('../../lib/analytics', () => ({
 
 vi.mock('../../lib/oauth-pending-store', () => ({
   consumeFreshOAuthPending: (...args: unknown[]) => consumeFreshOAuthPendingMock(...args),
+}));
+
+vi.mock('../../lib/oauth-return', () => ({
+  consumeWebOAuthReturnProvider: (...args: unknown[]) => consumeWebOAuthReturnProviderMock(...args),
 }));
 
 const authSignOutMock = vi.fn();
@@ -646,6 +653,7 @@ describe('AuthProvider Expo-web OAuth completion', () => {
   });
 
   it('consumes a pending attempt after the returned web session is authenticated', async () => {
+    consumeWebOAuthReturnProviderMock.mockReturnValue('apple');
     consumeFreshOAuthPendingMock.mockResolvedValue({
       provider: 'apple',
       attemptedAt: Date.now(),
@@ -674,6 +682,25 @@ describe('AuthProvider Expo-web OAuth completion', () => {
       await result.current.refreshAuthState();
     });
     expect(consumeFreshOAuthPendingMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not attribute a login when the OAuth return has no pending attempt', async () => {
+    consumeWebOAuthReturnProviderMock.mockReturnValue('google');
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>{children}</AuthProvider>
+      </QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+    await waitFor(() => expect(consumeFreshOAuthPendingMock).toHaveBeenCalledTimes(1));
+    expect(trackMock).not.toHaveBeenCalledWith(
+      'Login Succeeded',
+      expect.objectContaining({ auth_method: 'google', flow: 'web' }),
+    );
   });
 });
 

--- a/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
@@ -167,7 +167,7 @@ vi.mock('../../lib/oauth-pending-store', () => ({
 }));
 
 vi.mock('../../lib/oauth-return', () => ({
-  consumeWebOAuthReturnProvider: (...args: unknown[]) => consumeWebOAuthReturnProviderMock(...args),
+  consumeWebOAuthReturn: (...args: unknown[]) => consumeWebOAuthReturnProviderMock(...args),
 }));
 
 const authSignOutMock = vi.fn();
@@ -653,8 +653,13 @@ describe('AuthProvider Expo-web OAuth completion', () => {
   });
 
   it('consumes a pending attempt after the returned web session is authenticated', async () => {
-    consumeWebOAuthReturnProviderMock.mockReturnValue('apple');
+    consumeWebOAuthReturnProviderMock.mockReturnValue({
+      provider: 'apple',
+      attemptId: 'attempt-apple-1',
+      error: null,
+    });
     consumeFreshOAuthPendingMock.mockResolvedValue({
+      attemptId: 'attempt-apple-1',
       provider: 'apple',
       attemptedAt: Date.now(),
       isRegistration: true,
@@ -685,7 +690,11 @@ describe('AuthProvider Expo-web OAuth completion', () => {
   });
 
   it('does not attribute a login when the OAuth return has no pending attempt', async () => {
-    consumeWebOAuthReturnProviderMock.mockReturnValue('google');
+    consumeWebOAuthReturnProviderMock.mockReturnValue({
+      provider: 'google',
+      attemptId: 'attempt-google-1',
+      error: null,
+    });
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const wrapper = ({ children }: { children: ReactNode }) => (
       <QueryClientProvider client={queryClient}>

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -38,6 +38,7 @@ import { setSetting } from '../settings';
 import { getPendingCount, setSigningOut } from '@boardsesh/offline-sync';
 import { drainMutationQueue } from '../offline/offline-sync-adapter';
 import { stopTokenManagement } from '../notifications';
+import { consumeFreshOAuthPending } from '../lib/oauth-pending-store';
 
 type AuthState = {
   isAuthenticated: boolean;
@@ -296,6 +297,7 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
 
   const handleAuthenticatedTransition = useCallback(
     async (transitionEpoch: number, authSession: { userId?: string; authSessionId?: string }): Promise<boolean> => {
+      const wasAuthenticated = authStateRef.current.isAuthenticated;
       let authenticatedIdentityChanged = false;
       if (Platform.OS === 'web') {
         const nextUserId = authSession.userId;
@@ -325,6 +327,16 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
       if (Platform.OS === 'web' && (pendingAuthTransportRestartRef.current || authenticatedIdentityChanged)) {
         pendingAuthTransportRestartRef.current = false;
         bumpAuthTransportRevision();
+      }
+      if (Platform.OS === 'web' && !wasAuthenticated) {
+        void consumeFreshOAuthPending().then((marker) => {
+          if (!marker) return;
+          track(SHARED_EVENTS.LoginSucceeded, {
+            auth_method: marker.provider,
+            flow: 'web',
+            ...(marker.isRegistration ? { is_registration: true } : {}),
+          });
+        });
       }
       return true;
     },

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -39,6 +39,7 @@ import { getPendingCount, setSigningOut } from '@boardsesh/offline-sync';
 import { drainMutationQueue } from '../offline/offline-sync-adapter';
 import { stopTokenManagement } from '../notifications';
 import { consumeFreshOAuthPending } from '../lib/oauth-pending-store';
+import { consumeWebOAuthReturnProvider } from '../lib/oauth-return';
 
 type AuthState = {
   isAuthenticated: boolean;
@@ -328,9 +329,10 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
         pendingAuthTransportRestartRef.current = false;
         bumpAuthTransportRevision();
       }
-      if (Platform.OS === 'web' && !wasAuthenticated) {
+      const returnedOAuthProvider = Platform.OS === 'web' && !wasAuthenticated ? consumeWebOAuthReturnProvider() : null;
+      if (returnedOAuthProvider) {
         void consumeFreshOAuthPending().then((marker) => {
-          if (!marker) return;
+          if (!marker || marker.provider !== returnedOAuthProvider) return;
           track(SHARED_EVENTS.LoginSucceeded, {
             auth_method: marker.provider,
             flow: 'web',

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -39,13 +39,13 @@ import { getPendingCount, setSigningOut } from '@boardsesh/offline-sync';
 import { drainMutationQueue } from '../offline/offline-sync-adapter';
 import { stopTokenManagement } from '../notifications';
 import { consumeFreshOAuthPending } from '../lib/oauth-pending-store';
-import { consumeWebOAuthReturnProvider } from '../lib/oauth-return';
+import { consumeWebOAuthReturn } from '../lib/oauth-return';
 
 type AuthState = {
   isAuthenticated: boolean;
   isLoading: boolean;
-  signInWithApple: () => Promise<OAuthSignInResult>;
-  signInWithGoogle: () => Promise<OAuthSignInResult>;
+  signInWithApple: (webAttemptId?: string, isRegistration?: boolean) => Promise<OAuthSignInResult>;
+  signInWithGoogle: (webAttemptId?: string, isRegistration?: boolean) => Promise<OAuthSignInResult>;
   // Browser-OAuth fallback for when native Google sign-in can't present (iOS 26.5.1).
   signInWithGoogleWeb: () => Promise<OAuthSignInResult>;
   // Browser-OAuth fallback for when native Sign in with Apple throws (code 1000).
@@ -329,10 +329,10 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
         pendingAuthTransportRestartRef.current = false;
         bumpAuthTransportRevision();
       }
-      const returnedOAuthProvider = Platform.OS === 'web' && !wasAuthenticated ? consumeWebOAuthReturnProvider() : null;
-      if (returnedOAuthProvider) {
-        void consumeFreshOAuthPending().then((marker) => {
-          if (!marker || marker.provider !== returnedOAuthProvider) return;
+      const returnedOAuth = Platform.OS === 'web' && !wasAuthenticated ? consumeWebOAuthReturn() : null;
+      if (returnedOAuth && returnedOAuth.error === null) {
+        void consumeFreshOAuthPending(returnedOAuth.attemptId).then((marker) => {
+          if (!marker || marker.provider !== returnedOAuth.provider) return;
           track(SHARED_EVENTS.LoginSucceeded, {
             auth_method: marker.provider,
             flow: 'web',

--- a/packages/shared/i18n/locales/en-US/auth.json
+++ b/packages/shared/i18n/locales/en-US/auth.json
@@ -125,7 +125,9 @@
     "signIn": "Sign in",
     "orContinueWith": "or continue with",
     "networkError": "Could not reach Boardsesh. Check your connection and try again.",
-    "oauthError": "Sign in didn't complete. Give it another go."
+    "oauthError": "Sign in didn't complete. Give it another go.",
+    "providerDiscoveryError": "We couldn't load the social sign-in options.",
+    "retryProviders": "Try again"
   },
   "forgotPassword": {
     "heading": "Reset Password",

--- a/packages/shared/i18n/locales/es/auth.json
+++ b/packages/shared/i18n/locales/es/auth.json
@@ -127,7 +127,7 @@
     "networkError": "No se pudo conectar con Boardsesh. Comprueba tu conexión e inténtalo de nuevo.",
     "oauthError": "No se pudo completar el inicio de sesión. Inténtalo de nuevo.",
     "providerDiscoveryError": "No pudimos cargar las opciones de inicio de sesión social.",
-    "retryProviders": "Intentar de nuevo"
+    "retryProviders": "Inténtalo de nuevo"
   },
   "forgotPassword": {
     "heading": "Restablecer contraseña",

--- a/packages/shared/i18n/locales/es/auth.json
+++ b/packages/shared/i18n/locales/es/auth.json
@@ -125,7 +125,9 @@
     "signIn": "Iniciar sesión",
     "orContinueWith": "o continúa con",
     "networkError": "No se pudo conectar con Boardsesh. Comprueba tu conexión e inténtalo de nuevo.",
-    "oauthError": "No se pudo completar el inicio de sesión. Inténtalo de nuevo."
+    "oauthError": "No se pudo completar el inicio de sesión. Inténtalo de nuevo.",
+    "providerDiscoveryError": "No pudimos cargar las opciones de inicio de sesión social.",
+    "retryProviders": "Intentar de nuevo"
   },
   "forgotPassword": {
     "heading": "Restablecer contraseña",

--- a/packages/shared/i18n/locales/fr/auth.json
+++ b/packages/shared/i18n/locales/fr/auth.json
@@ -125,7 +125,9 @@
     "signIn": "Se connecter",
     "orContinueWith": "ou continuez avec",
     "networkError": "Impossible de joindre Boardsesh. Vérifiez votre connexion et réessayez.",
-    "oauthError": "La connexion n'a pas abouti. Réessayez."
+    "oauthError": "La connexion n'a pas abouti. Réessayez.",
+    "providerDiscoveryError": "Impossible de charger les options de connexion sociale.",
+    "retryProviders": "Réessayer"
   },
   "forgotPassword": {
     "heading": "Réinitialiser le mot de passe",

--- a/packages/web/app/__tests__/middleware.test.ts
+++ b/packages/web/app/__tests__/middleware.test.ts
@@ -783,10 +783,24 @@ describe('middleware cross-subdomain auth CORS', () => {
     expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull();
   });
 
-  it('does not add CORS to an auth path outside the allow-list, even from the app origin', () => {
-    // /api/auth/providers-config isn't one of the endpoints the app calls
-    // cross-origin, so it must not grow an ambient-credential CORS surface.
+  it('allows provider discovery from the standalone app origin', () => {
     const response = middleware(makeCorsRequest('/api/auth/providers-config', { origin: APP_ORIGIN }));
+
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe(APP_ORIGIN);
+    expect(response.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+  });
+
+  it('allows provider discovery from a numbered preview origin', () => {
+    const preview = 'https://14.app.boardsesh.com';
+    const response = middleware(makeCorsRequest('/api/auth/providers-config', { origin: preview }));
+
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe(preview);
+  });
+
+  it('rejects provider discovery from a look-alike app origin', () => {
+    const response = middleware(
+      makeCorsRequest('/api/auth/providers-config', { origin: 'https://app.boardsesh.com.evil.com' }),
+    );
 
     expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull();
   });

--- a/packages/web/app/api/auth/[...nextauth]/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/[...nextauth]/__tests__/route.test.ts
@@ -49,6 +49,7 @@ describe('POST /api/auth/[...nextauth]', () => {
     vi.stubEnv('VERCEL_ENV', 'production');
     vi.stubEnv('NEXTAUTH_URL', 'https://www.boardsesh.com');
     vi.stubEnv('AUTH_COOKIE_DOMAIN', '');
+    vi.stubEnv('NEXTAUTH_SECRET', 'test-nextauth-secret');
     nextAuthHandlerMock.mockResolvedValue(new Response(null, { status: 200 }));
   });
 
@@ -226,5 +227,114 @@ describe('POST /api/auth/[...nextauth]', () => {
 
     const setCookies = response.headers.getSetCookie();
     expect(setCookies).toEqual(['next-auth.session-token=fresh-jwt; Path=/; HttpOnly; SameSite=Lax']);
+  });
+
+  it('binds an Expo Google return to OAuth state and returns callback errors to the app', async () => {
+    const returnUrl =
+      'https://app.boardsesh.com/auth/login?boardseshOAuthProvider=google&boardseshOAuthAttempt=attempt-google-1';
+    nextAuthHandlerMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { Location: 'https://accounts.google.com/o/oauth2/v2/auth?state=google-state-1' },
+      }),
+    );
+    const signInRequest = request('/api/auth/signin/google', {
+      csrfToken: 'csrf-token',
+      callbackUrl: returnUrl,
+    });
+
+    const signInResponse = await POST(signInRequest, context);
+    const returnCookie = signInResponse.headers
+      .getSetCookie()
+      .find((setCookie) => setCookie.startsWith('boardsesh.oauth-return.'));
+    expect(returnCookie).toContain('HttpOnly');
+    expect(returnCookie).toContain('SameSite=None');
+    expect(returnCookie).toContain('Secure');
+
+    nextAuthHandlerMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { Location: 'https://www.boardsesh.com/auth/error?error=AccessDenied' },
+      }),
+    );
+    const callbackRequest = new NextRequest(
+      'https://www.boardsesh.com/api/auth/callback/google?state=google-state-1&code=provider-code',
+      {
+        headers: { Cookie: returnCookie!.split(';', 1)[0]! },
+      },
+    );
+
+    const callbackResponse = await GET(callbackRequest, context);
+    const destination = new URL(callbackResponse.headers.get('Location')!);
+    expect(destination.origin + destination.pathname).toBe('https://app.boardsesh.com/auth/login');
+    expect(destination.searchParams.get('boardseshOAuthProvider')).toBe('google');
+    expect(destination.searchParams.get('boardseshOAuthAttempt')).toBe('attempt-google-1');
+    expect(destination.searchParams.get('boardseshOAuthError')).toBe('AccessDenied');
+    expect(callbackResponse.headers.getSetCookie()).toContainEqual(
+      expect.stringMatching(/^boardsesh\.oauth-return\..*=; .*Max-Age=0/),
+    );
+  });
+
+  it('returns an Apple form-post callback to the exact Expo registration attempt', async () => {
+    const returnUrl =
+      'https://www.boardsesh.com/app/auth/register?boardseshOAuthProvider=apple&boardseshOAuthAttempt=attempt-apple-1';
+    nextAuthHandlerMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { Location: 'https://appleid.apple.com/auth/authorize?state=apple-state-1' },
+      }),
+    );
+    const signInResponse = await POST(
+      request('/api/auth/signin/apple', { csrfToken: 'csrf-token', callbackUrl: returnUrl }),
+      context,
+    );
+    const returnCookie = signInResponse.headers
+      .getSetCookie()
+      .find((setCookie) => setCookie.startsWith('boardsesh.oauth-return.'));
+
+    nextAuthHandlerMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: {
+          Location: 'https://www.boardsesh.com/app',
+          'Set-Cookie': '__Secure-next-auth.session-token=fresh; Path=/; Secure; HttpOnly',
+        },
+      }),
+    );
+    const callbackRequest = new NextRequest('https://www.boardsesh.com/api/auth/callback/apple', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Cookie: returnCookie!.split(';', 1)[0]!,
+      },
+      body: new URLSearchParams({ state: 'apple-state-1', code: 'provider-code' }),
+    });
+
+    const callbackResponse = await POST(callbackRequest, context);
+    expect(callbackResponse.headers.get('Location')).toBe(returnUrl);
+    expect(callbackResponse.headers.getSetCookie()).toContainEqual(
+      expect.stringContaining('__Secure-next-auth.session-token=fresh'),
+    );
+  });
+
+  it('does not bind an untrusted or malformed Expo callback URL', async () => {
+    nextAuthHandlerMock.mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { Location: 'https://accounts.google.com/o/oauth2/v2/auth?state=google-state-1' },
+      }),
+    );
+    const lookalikeRequest = request('/api/auth/signin/google', {
+      csrfToken: 'csrf-token',
+      callbackUrl:
+        'https://app.boardsesh.com.evil.example/auth/login?boardseshOAuthProvider=google&boardseshOAuthAttempt=attempt-google-1',
+    });
+
+    const response = await POST(lookalikeRequest, context);
+
+    expect(response.headers.getSetCookie().some((setCookie) => setCookie.startsWith('boardsesh.oauth-return.'))).toBe(
+      false,
+    );
+    expect(nextAuthHandlerMock).toHaveBeenCalledWith(lookalikeRequest, context);
   });
 });

--- a/packages/web/app/api/auth/[...nextauth]/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/[...nextauth]/__tests__/route.test.ts
@@ -275,6 +275,70 @@ describe('POST /api/auth/[...nextauth]', () => {
     );
   });
 
+  it('returns a successful Google callback to the exact Expo login attempt', async () => {
+    const returnUrl =
+      'https://app.boardsesh.com/auth/login?boardseshOAuthProvider=google&boardseshOAuthAttempt=attempt-google-2';
+    nextAuthHandlerMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { Location: 'https://accounts.google.com/o/oauth2/v2/auth?state=google-state-2' },
+      }),
+    );
+    const signInResponse = await POST(
+      request('/api/auth/signin/google', { csrfToken: 'csrf-token', callbackUrl: returnUrl }),
+      context,
+    );
+    const returnCookie = signInResponse.headers
+      .getSetCookie()
+      .find((setCookie) => setCookie.startsWith('boardsesh.oauth-return.'));
+
+    nextAuthHandlerMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { Location: 'https://www.boardsesh.com/app' },
+      }),
+    );
+    const callbackRequest = new NextRequest(
+      'https://www.boardsesh.com/api/auth/callback/google?state=google-state-2&code=provider-code',
+      { headers: { Cookie: returnCookie!.split(';', 1)[0]! } },
+    );
+
+    const callbackResponse = await GET(callbackRequest, context);
+
+    expect(callbackResponse.status).toBe(302);
+    expect(callbackResponse.headers.get('Location')).toBe(returnUrl);
+  });
+
+  it('turns a non-redirect callback failure into a return to the Expo app', async () => {
+    const returnUrl =
+      'https://app.boardsesh.com/auth/login?boardseshOAuthProvider=google&boardseshOAuthAttempt=attempt-google-3';
+    nextAuthHandlerMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { Location: 'https://accounts.google.com/o/oauth2/v2/auth?state=google-state-3' },
+      }),
+    );
+    const signInResponse = await POST(
+      request('/api/auth/signin/google', { csrfToken: 'csrf-token', callbackUrl: returnUrl }),
+      context,
+    );
+    const returnCookie = signInResponse.headers
+      .getSetCookie()
+      .find((setCookie) => setCookie.startsWith('boardsesh.oauth-return.'));
+    nextAuthHandlerMock.mockResolvedValueOnce(new Response('upstream failed', { status: 500 }));
+    const callbackRequest = new NextRequest(
+      'https://www.boardsesh.com/api/auth/callback/google?state=google-state-3&code=provider-code',
+      { headers: { Cookie: returnCookie!.split(';', 1)[0]! } },
+    );
+
+    const callbackResponse = await GET(callbackRequest, context);
+
+    expect(callbackResponse.status).toBe(302);
+    const destination = new URL(callbackResponse.headers.get('Location')!);
+    expect(destination.origin + destination.pathname).toBe('https://app.boardsesh.com/auth/login');
+    expect(destination.searchParams.get('boardseshOAuthError')).toBe('OAuthCallback');
+  });
+
   it('returns an Apple form-post callback to the exact Expo registration attempt', async () => {
     const returnUrl =
       'https://www.boardsesh.com/app/auth/register?boardseshOAuthProvider=apple&boardseshOAuthAttempt=attempt-apple-1';
@@ -336,5 +400,24 @@ describe('POST /api/auth/[...nextauth]', () => {
       false,
     );
     expect(nextAuthHandlerMock).toHaveBeenCalledWith(lookalikeRequest, context);
+  });
+
+  it('fails explicitly when Expo return binding has no signing secret', async () => {
+    vi.stubEnv('NEXTAUTH_SECRET', '');
+    nextAuthHandlerMock.mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { Location: 'https://accounts.google.com/o/oauth2/v2/auth?state=google-state-4' },
+      }),
+    );
+    const signInRequest = request('/api/auth/signin/google', {
+      csrfToken: 'csrf-token',
+      callbackUrl:
+        'https://app.boardsesh.com/auth/login?boardseshOAuthProvider=google&boardseshOAuthAttempt=attempt-google-4',
+    });
+
+    await expect(POST(signInRequest, context)).rejects.toThrow(
+      'NEXTAUTH_SECRET is required to bind Expo web OAuth returns',
+    );
   });
 });

--- a/packages/web/app/api/auth/[...nextauth]/route.ts
+++ b/packages/web/app/api/auth/[...nextauth]/route.ts
@@ -28,9 +28,12 @@ type ExpectedSignOutIdentity = {
 };
 
 const handler = NextAuth(authOptions) as NextAuthHandler;
+const OAUTH_SIGNIN_PATH_PATTERN = /\/api\/auth\/signin\/(apple|google)\/?$/;
+const OAUTH_CALLBACK_PATH_PATTERN = /\/api\/auth\/callback\/(apple|google)\/?$/;
 
 function oauthProviderForPath(pathname: string, action: 'signin' | 'callback'): ExpoWebOAuthProvider | null {
-  const match = pathname.match(new RegExp(`/api/auth/${action}/(apple|google)/?$`));
+  const pattern = action === 'signin' ? OAUTH_SIGNIN_PATH_PATTERN : OAUTH_CALLBACK_PATH_PATTERN;
+  const match = pathname.match(pattern);
   return match?.[1] === 'apple' || match?.[1] === 'google' ? match[1] : null;
 }
 

--- a/packages/web/app/api/auth/[...nextauth]/route.ts
+++ b/packages/web/app/api/auth/[...nextauth]/route.ts
@@ -8,6 +8,13 @@ import {
   responseSetsSessionCookie,
   sessionCookieName,
 } from '@/app/lib/auth/secure-cookies';
+import {
+  bindExpoReturnToState,
+  readExpoReturnForState,
+  redirectExpoOAuthResponse,
+  validatedExpoReturnUrl,
+  type ExpoWebOAuthProvider,
+} from '@/app/lib/auth/expo-web-oauth-return';
 
 type NextAuthRouteContext = {
   params: Promise<{ nextauth: string[] }>;
@@ -21,6 +28,69 @@ type ExpectedSignOutIdentity = {
 };
 
 const handler = NextAuth(authOptions) as NextAuthHandler;
+
+function oauthProviderForPath(pathname: string, action: 'signin' | 'callback'): ExpoWebOAuthProvider | null {
+  const match = pathname.match(new RegExp(`/api/auth/${action}/(apple|google)/?$`));
+  return match?.[1] === 'apple' || match?.[1] === 'google' ? match[1] : null;
+}
+
+async function readOAuthForm(request: NextRequest): Promise<FormData | null> {
+  try {
+    return await request.clone().formData();
+  } catch {
+    return null;
+  }
+}
+
+function stateFromAuthorizationRedirect(response: Response): string | null {
+  const location = response.headers.get('Location');
+  if (!location) return null;
+  try {
+    return new URL(location, 'https://provider.invalid').searchParams.get('state');
+  } catch {
+    return null;
+  }
+}
+
+function responseContainsOAuthError(response: Response): boolean {
+  const location = response.headers.get('Location');
+  if (!location) return false;
+  try {
+    return new URL(location, 'https://auth.invalid').searchParams.has('error');
+  } catch {
+    return false;
+  }
+}
+
+async function handleExpoOAuthPost(
+  request: NextRequest,
+  context: NextAuthRouteContext,
+  pathname: string,
+): Promise<Response | null> {
+  const signInProvider = oauthProviderForPath(pathname, 'signin');
+  if (signInProvider) {
+    const form = await readOAuthForm(request);
+    const returnUrl = validatedExpoReturnUrl(form?.get('callbackUrl') ?? null, signInProvider, request.nextUrl.origin);
+    if (!returnUrl) return null;
+
+    const response = clearLegacyCookieIfSessionWritten(await handler(request, context));
+    const state = stateFromAuthorizationRedirect(response);
+    if (state) return bindExpoReturnToState(response, request, state, signInProvider, returnUrl);
+    return responseContainsOAuthError(response)
+      ? redirectExpoOAuthResponse(response, request, null, returnUrl)
+      : response;
+  }
+
+  const callbackProvider = oauthProviderForPath(pathname, 'callback');
+  if (!callbackProvider) return null;
+  const form = await readOAuthForm(request);
+  const state = form?.get('state');
+  if (typeof state !== 'string' || !state) return null;
+  const descriptor = readExpoReturnForState(request, state, callbackProvider);
+  if (!descriptor) return null;
+  const response = clearLegacyCookieIfSessionWritten(await handler(request, context));
+  return redirectExpoOAuthResponse(response, request, state, descriptor.returnUrl);
+}
 
 async function readExpectedSignOutIdentity(
   request: NextRequest,
@@ -75,6 +145,8 @@ export async function POST(request: NextRequest, context: NextAuthRouteContext):
   const pathname = request.nextUrl.pathname.endsWith('/')
     ? request.nextUrl.pathname.slice(0, -1)
     : request.nextUrl.pathname;
+  const expoOAuthResponse = await handleExpoOAuthPost(request, context, pathname);
+  if (expoOAuthResponse) return expoOAuthResponse;
   if (!pathname.endsWith('/api/auth/signout')) {
     return clearLegacyCookieIfSessionWritten(await handler(request, context));
   }
@@ -110,5 +182,14 @@ export async function POST(request: NextRequest, context: NextAuthRouteContext):
 }
 
 export async function GET(request: NextRequest, context: NextAuthRouteContext): Promise<Response> {
+  const callbackProvider = oauthProviderForPath(request.nextUrl.pathname, 'callback');
+  const state = request.nextUrl.searchParams.get('state');
+  if (callbackProvider && state) {
+    const descriptor = readExpoReturnForState(request, state, callbackProvider);
+    if (descriptor) {
+      const response = clearLegacyCookieIfSessionWritten(await handler(request, context));
+      return redirectExpoOAuthResponse(response, request, state, descriptor.returnUrl);
+    }
+  }
   return clearLegacyCookieIfSessionWritten(await handler(request, context));
 }

--- a/packages/web/app/lib/auth/auth-options.ts
+++ b/packages/web/app/lib/auth/auth-options.ts
@@ -41,7 +41,7 @@ if (process.env.APPLE_ID && process.env.APPLE_SECRET) {
     AppleProvider({
       clientId: process.env.APPLE_ID,
       clientSecret: process.env.APPLE_SECRET,
-      checks: ['pkce'],
+      checks: ['pkce', 'state'],
       allowDangerousEmailAccountLinking: true,
     }),
   );

--- a/packages/web/app/lib/auth/cross-subdomain-cors.ts
+++ b/packages/web/app/lib/auth/cross-subdomain-cors.ts
@@ -14,6 +14,9 @@ import { isAllowedAppOrigin } from '@/app/lib/auth/app-origin-allowlist';
 // set tight so no other route grows an ambient-credential CORS surface.
 const CORS_AUTH_PATHS = new Set([
   '/api/auth/session',
+  // The Expo-web login/register screens discover which configured providers
+  // should be offered before starting a browser OAuth redirect.
+  '/api/auth/providers-config',
   '/api/auth/csrf',
   '/api/auth/callback/credentials',
   '/api/auth/signout',

--- a/packages/web/app/lib/auth/expo-web-oauth-return.ts
+++ b/packages/web/app/lib/auth/expo-web-oauth-return.ts
@@ -41,9 +41,9 @@ function returnCookieName(state: string): string {
   return `${COOKIE_PREFIX}${stateHash}`;
 }
 
-function encodeDescriptor(descriptor: ReturnDescriptor): string | null {
+function encodeDescriptor(descriptor: ReturnDescriptor): string {
   const secret = signingSecret();
-  if (!secret) return null;
+  if (!secret) throw new Error('NEXTAUTH_SECRET is required to bind Expo web OAuth returns');
   const payload = Buffer.from(JSON.stringify(descriptor)).toString('base64url');
   return `${payload}.${signature(payload, secret).toString('base64url')}`;
 }
@@ -134,7 +134,6 @@ export function bindExpoReturnToState(
   returnUrl: string,
 ): Response {
   const encoded = encodeDescriptor({ provider, returnUrl, createdAt: Date.now() });
-  if (!encoded) return response;
   response.headers.append(
     'Set-Cookie',
     `${returnCookieName(state)}=${encoded}; ${cookieAttributes(request, Math.floor(RETURN_MAX_AGE_MS / 1000))}`,
@@ -156,7 +155,7 @@ export function readExpoReturnForState(
 
 function responseErrorCode(response: Response): string | null {
   const location = response.headers.get('Location');
-  if (!location) return null;
+  if (!location) return response.status >= 300 && response.status < 400 ? null : 'OAuthCallback';
   try {
     const candidate = new URL(location, 'https://auth.invalid');
     const error = candidate.searchParams.get('error');
@@ -175,9 +174,17 @@ export function redirectExpoOAuthResponse(
   const destination = new URL(returnUrl);
   const errorCode = responseErrorCode(response);
   if (errorCode) destination.searchParams.set(RETURN_ERROR_PARAM, errorCode);
-  response.headers.set('Location', destination.toString());
+  const headers = new Headers(response.headers);
+  headers.set('Location', destination.toString());
   if (state) {
-    response.headers.append('Set-Cookie', `${returnCookieName(state)}=; ${cookieAttributes(request, 0)}`);
+    headers.append('Set-Cookie', `${returnCookieName(state)}=; ${cookieAttributes(request, 0)}`);
   }
-  return response;
+  if (response.status >= 300 && response.status < 400) {
+    response.headers.set('Location', destination.toString());
+    if (state) {
+      response.headers.append('Set-Cookie', `${returnCookieName(state)}=; ${cookieAttributes(request, 0)}`);
+    }
+    return response;
+  }
+  return new Response(null, { status: 302, headers });
 }

--- a/packages/web/app/lib/auth/expo-web-oauth-return.ts
+++ b/packages/web/app/lib/auth/expo-web-oauth-return.ts
@@ -1,0 +1,183 @@
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+import type { NextRequest } from 'next/server';
+import { isAllowedAppOrigin } from './app-origin-allowlist';
+
+const RETURN_PROVIDER_PARAM = 'boardseshOAuthProvider';
+const RETURN_ATTEMPT_PARAM = 'boardseshOAuthAttempt';
+const RETURN_ERROR_PARAM = 'boardseshOAuthError';
+const ATTEMPT_ID_PATTERN = /^[A-Za-z0-9_-]{8,128}$/;
+const RETURN_MAX_AGE_MS = 10 * 60 * 1000;
+const COOKIE_PREFIX = 'boardsesh.oauth-return.';
+const KNOWN_ERROR_CODES = new Set([
+  'AccessDenied',
+  'Callback',
+  'Configuration',
+  'OAuthAccountNotLinked',
+  'OAuthCallback',
+  'OAuthCreateAccount',
+  'OAuthSignin',
+  'SessionRequired',
+  'Signin',
+]);
+
+export type ExpoWebOAuthProvider = 'apple' | 'google';
+
+type ReturnDescriptor = {
+  provider: ExpoWebOAuthProvider;
+  returnUrl: string;
+  createdAt: number;
+};
+
+function signingSecret(): string | null {
+  return process.env.NEXTAUTH_SECRET?.trim() || null;
+}
+
+function signature(payload: string, secret: string): Buffer {
+  return createHmac('sha256', secret).update(payload).digest();
+}
+
+function returnCookieName(state: string): string {
+  const stateHash = createHash('sha256').update(state).digest('hex').slice(0, 32);
+  return `${COOKIE_PREFIX}${stateHash}`;
+}
+
+function encodeDescriptor(descriptor: ReturnDescriptor): string | null {
+  const secret = signingSecret();
+  if (!secret) return null;
+  const payload = Buffer.from(JSON.stringify(descriptor)).toString('base64url');
+  return `${payload}.${signature(payload, secret).toString('base64url')}`;
+}
+
+function decodeDescriptor(encoded: string): ReturnDescriptor | null {
+  const secret = signingSecret();
+  if (!secret) return null;
+  const separatorIndex = encoded.lastIndexOf('.');
+  if (separatorIndex <= 0) return null;
+  const payload = encoded.slice(0, separatorIndex);
+  const suppliedSignature = Buffer.from(encoded.slice(separatorIndex + 1), 'base64url');
+  const expectedSignature = signature(payload, secret);
+  if (suppliedSignature.length !== expectedSignature.length || !timingSafeEqual(suppliedSignature, expectedSignature)) {
+    return null;
+  }
+
+  try {
+    const candidate = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as unknown;
+    if (typeof candidate !== 'object' || candidate === null || Array.isArray(candidate)) return null;
+    const descriptor = candidate as Record<string, unknown>;
+    if (
+      (descriptor.provider !== 'apple' && descriptor.provider !== 'google') ||
+      typeof descriptor.returnUrl !== 'string' ||
+      typeof descriptor.createdAt !== 'number' ||
+      !Number.isFinite(descriptor.createdAt)
+    ) {
+      return null;
+    }
+    const age = Date.now() - descriptor.createdAt;
+    if (age < 0 || age > RETURN_MAX_AGE_MS) return null;
+    return descriptor as ReturnDescriptor;
+  } catch {
+    return null;
+  }
+}
+
+export function validatedExpoReturnUrl(
+  candidate: FormDataEntryValue | string | null,
+  provider: ExpoWebOAuthProvider,
+  authOrigin: string,
+): string | null {
+  if (typeof candidate !== 'string') return null;
+  let returnUrl: URL;
+  try {
+    returnUrl = new URL(candidate);
+  } catch {
+    return null;
+  }
+
+  const isSameOriginExport = returnUrl.origin === authOrigin;
+  if (!isSameOriginExport && !isAllowedAppOrigin(returnUrl.origin)) return null;
+  if (
+    (isSameOriginExport && !/^\/app\/auth\/(?:login|register)$/.test(returnUrl.pathname)) ||
+    (!isSameOriginExport && !/^\/auth\/(?:login|register)$/.test(returnUrl.pathname))
+  ) {
+    return null;
+  }
+  if (returnUrl.username || returnUrl.password || returnUrl.hash) return null;
+  if (returnUrl.searchParams.get(RETURN_PROVIDER_PARAM) !== provider) return null;
+  const attemptId = returnUrl.searchParams.get(RETURN_ATTEMPT_PARAM);
+  if (!attemptId || !ATTEMPT_ID_PATTERN.test(attemptId)) return null;
+  if (returnUrl.searchParams.has(RETURN_ERROR_PARAM)) return null;
+  const allowedParams = new Set([RETURN_PROVIDER_PARAM, RETURN_ATTEMPT_PARAM]);
+  for (const key of returnUrl.searchParams.keys()) {
+    if (!allowedParams.has(key)) return null;
+  }
+  return returnUrl.toString();
+}
+
+function cookieAttributes(request: NextRequest, maxAge: number): string {
+  const secure = request.nextUrl.protocol === 'https:';
+  return [
+    'Path=/',
+    'HttpOnly',
+    secure ? 'SameSite=None' : 'SameSite=Lax',
+    secure ? 'Secure' : null,
+    `Max-Age=${maxAge}`,
+  ]
+    .filter(Boolean)
+    .join('; ');
+}
+
+export function bindExpoReturnToState(
+  response: Response,
+  request: NextRequest,
+  state: string,
+  provider: ExpoWebOAuthProvider,
+  returnUrl: string,
+): Response {
+  const encoded = encodeDescriptor({ provider, returnUrl, createdAt: Date.now() });
+  if (!encoded) return response;
+  response.headers.append(
+    'Set-Cookie',
+    `${returnCookieName(state)}=${encoded}; ${cookieAttributes(request, Math.floor(RETURN_MAX_AGE_MS / 1000))}`,
+  );
+  return response;
+}
+
+export function readExpoReturnForState(
+  request: NextRequest,
+  state: string,
+  provider: ExpoWebOAuthProvider,
+): ReturnDescriptor | null {
+  const encoded = request.cookies.get(returnCookieName(state))?.value;
+  if (!encoded) return null;
+  const descriptor = decodeDescriptor(encoded);
+  if (!descriptor || descriptor.provider !== provider) return null;
+  return validatedExpoReturnUrl(descriptor.returnUrl, provider, request.nextUrl.origin) ? descriptor : null;
+}
+
+function responseErrorCode(response: Response): string | null {
+  const location = response.headers.get('Location');
+  if (!location) return null;
+  try {
+    const candidate = new URL(location, 'https://auth.invalid');
+    const error = candidate.searchParams.get('error');
+    return error && KNOWN_ERROR_CODES.has(error) ? error : error ? 'OAuthCallback' : null;
+  } catch {
+    return null;
+  }
+}
+
+export function redirectExpoOAuthResponse(
+  response: Response,
+  request: NextRequest,
+  state: string | null,
+  returnUrl: string,
+): Response {
+  const destination = new URL(returnUrl);
+  const errorCode = responseErrorCode(response);
+  if (errorCode) destination.searchParams.set(RETURN_ERROR_PARAM, errorCode);
+  response.headers.set('Location', destination.toString());
+  if (state) {
+    response.headers.append('Set-Cookie', `${returnCookieName(state)}=; ${cookieAttributes(request, 0)}`);
+  }
+  return response;
+}

--- a/packages/web/app/lib/auth/expo-web-oauth-return.ts
+++ b/packages/web/app/lib/auth/expo-web-oauth-return.ts
@@ -174,17 +174,17 @@ export function redirectExpoOAuthResponse(
   const destination = new URL(returnUrl);
   const errorCode = responseErrorCode(response);
   if (errorCode) destination.searchParams.set(RETURN_ERROR_PARAM, errorCode);
-  const headers = new Headers(response.headers);
-  headers.set('Location', destination.toString());
-  if (state) {
-    headers.append('Set-Cookie', `${returnCookieName(state)}=; ${cookieAttributes(request, 0)}`);
-  }
   if (response.status >= 300 && response.status < 400) {
     response.headers.set('Location', destination.toString());
     if (state) {
       response.headers.append('Set-Cookie', `${returnCookieName(state)}=; ${cookieAttributes(request, 0)}`);
     }
     return response;
+  }
+  const headers = new Headers(response.headers);
+  headers.set('Location', destination.toString());
+  if (state) {
+    headers.append('Set-Cookie', `${returnCookieName(state)}=; ${cookieAttributes(request, 0)}`);
   }
   return new Response(null, { status: 302, headers });
 }

--- a/packages/web/app/lib/auth/expo-web-oauth-return.ts
+++ b/packages/web/app/lib/auth/expo-web-oauth-return.ts
@@ -174,17 +174,11 @@ export function redirectExpoOAuthResponse(
   const destination = new URL(returnUrl);
   const errorCode = responseErrorCode(response);
   if (errorCode) destination.searchParams.set(RETURN_ERROR_PARAM, errorCode);
-  if (response.status >= 300 && response.status < 400) {
-    response.headers.set('Location', destination.toString());
-    if (state) {
-      response.headers.append('Set-Cookie', `${returnCookieName(state)}=; ${cookieAttributes(request, 0)}`);
-    }
-    return response;
-  }
   const headers = new Headers(response.headers);
   headers.set('Location', destination.toString());
   if (state) {
     headers.append('Set-Cookie', `${returnCookieName(state)}=; ${cookieAttributes(request, 0)}`);
   }
-  return new Response(null, { status: 302, headers });
+  const status = response.status >= 300 && response.status < 400 ? response.status : 302;
+  return new Response(null, { status, headers });
 }


### PR DESCRIPTION
## Summary

- route Apple and Google sign-in from the Expo browser app through the existing NextAuth OAuth start endpoint
- bind each validated Expo return target to the provider's OAuth `state`, so success, cancellation, callback errors, and non-redirect server failures return to the exact login or registration screen that started the attempt
- isolate pending attempts by ID to keep cross-tab analytics attribution correct, preserve successful return markers until the authenticated transition owns them, and guard rapid double-submits synchronously
- show only configured providers with accessible web controls while preserving the native SDK buttons
- bound provider discovery to eight seconds and offer an explicit retry after transient failures
- allow credentialed provider discovery only from trusted Expo app and preview origins; Apple now verifies both PKCE and state

The root cause was that the Expo web auth implementation explicitly returned `oauth_unavailable`, while the login and registration screens only rendered native provider controls. The follow-up hardening also prevents NextAuth's classic `/auth/error` page from trapping Expo users after a provider cancellation or callback failure.

## Release Notes

Sign in with Apple or Google from Boardsesh in your browser, with failed or cancelled attempts returning you to the app so you can try again.

## Test plan

- `vp run typecheck:mobile`
- `vp run test:mobile` (551 files, 4612 tests)
- focused mobile OAuth/auth-provider/component tests (87 tests in the final review pass)
- focused NextAuth route tests, including Google success/errors, Apple form-post callbacks, non-redirect failures, cookie preservation/cleanup, missing signing secret, and untrusted callback rejection (17 tests)
- `vp run check:mobile-bundle`
- `vp run check:mobile-web-bundle`
- `vp run check:i18n`
- touched-file `vp check` and `git diff --check`
- earlier iOS simulator native build, install, and launch succeeded

Repository-wide `vp run typecheck:web` remains red locally on the unrelated baseline missing `@boardsesh/kiosk` package export; the full CI typecheck passes. The latest simulator rerun was blocked by a stale shared Xcode-cache lock whose recorded process no longer exists; native iOS/Android bundles and the Expo web export pass.