### PR TITLE
fix(mobile): return isPad from useDeviceLayout

### DIFF
--- a/packages/mobile/src/hooks/__tests__/use-device-layout.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-device-layout.test.ts
@@ -37,8 +37,8 @@ describe('useDeviceLayout', () => {
     expect(result.current).toMatchObject({
       isPad: true,
       isTablet: true,
-      wallDeviceClass: expect.any(String) as unknown as string,
-      widthClass: expect.any(String) as unknown as string,
+      wallDeviceClass: expect.any(String),
+      widthClass: expect.any(String),
     });
   });
 

--- a/packages/mobile/src/hooks/__tests__/use-device-layout.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-device-layout.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+// `Platform.isPad` is launch-fixed, and the screen dimensions are read once via
+// `Dimensions.get('screen')`, so both are driven directly rather than through a
+// real react-native runtime.
+const platform = vi.hoisted(() => ({ OS: 'ios' as string, isPad: true as boolean }));
+const screen = vi.hoisted(() => ({ width: 1024, height: 1366 }));
+const windowWidth = vi.hoisted(() => ({ value: 1024 }));
+
+vi.mock('react-native', () => ({
+  Platform: platform,
+  Dimensions: { get: () => screen },
+  useWindowDimensions: () => ({ width: windowWidth.value, height: screen.height }),
+}));
+
+import { useDeviceLayout } from '../use-device-layout';
+
+describe('useDeviceLayout', () => {
+  beforeEach(() => {
+    platform.OS = 'ios';
+    platform.isPad = true;
+    screen.width = 1024;
+    screen.height = 1366;
+    windowWidth.value = 1024;
+  });
+
+  // Regression guard: `isPad` is computed inside the hook but has to be part of
+  // the RETURNED object too. It was dropped once while consumers still
+  // destructured it (use-image-cache-memory-management, board-art-visibility-
+  // provider), which reads `undefined` at runtime — a silent iPad-only bug that
+  // only `tsc` caught. Assert the whole public shape, not just one field.
+  it('returns isPad alongside isTablet and wallDeviceClass', () => {
+    const { result } = renderHook(() => useDeviceLayout());
+
+    expect(result.current).toMatchObject({
+      isPad: true,
+      isTablet: true,
+      wallDeviceClass: expect.any(String) as unknown as string,
+      widthClass: expect.any(String) as unknown as string,
+    });
+  });
+
+  it('reports isPad false on Android tablets', () => {
+    platform.OS = 'android';
+    platform.isPad = false;
+
+    const { result } = renderHook(() => useDeviceLayout());
+
+    // An Android tablet is still a tablet — only the iPad-specific flag flips.
+    expect(result.current.isPad).toBe(false);
+    expect(result.current.isTablet).toBe(true);
+  });
+
+  it('reports isPad false on a phone', () => {
+    platform.OS = 'ios';
+    platform.isPad = false;
+    screen.width = 390;
+    screen.height = 844;
+    windowWidth.value = 390;
+
+    const { result } = renderHook(() => useDeviceLayout());
+
+    expect(result.current.isPad).toBe(false);
+    expect(result.current.isTablet).toBe(false);
+  });
+
+  // The window width is live (Split View / Stage Manager / multi-window) while
+  // `isPad` is launch-fixed, so a narrow split must not flip it.
+  it('keeps isPad true when an iPad is resized into a narrow split', () => {
+    windowWidth.value = 400;
+
+    const { result } = renderHook(() => useDeviceLayout());
+
+    expect(result.current.isPad).toBe(true);
+    expect(result.current.widthClass).toBe('compact');
+  });
+});

--- a/packages/mobile/src/hooks/use-device-layout.ts
+++ b/packages/mobile/src/hooks/use-device-layout.ts
@@ -30,7 +30,11 @@ import {
  * — the PHYSICAL screen, not the app window (which shrinks under Split View /
  * multi-window / DeX) — and rotation-invariant via `max`/`min`, so memoized once.
  */
-export function useDeviceLayout(): DeviceLayout & { isTablet: boolean; wallDeviceClass: WallDeviceClass } {
+export function useDeviceLayout(): DeviceLayout & {
+  isPad: boolean;
+  isTablet: boolean;
+  wallDeviceClass: WallDeviceClass;
+} {
   const { width } = useWindowDimensions();
   // `Platform.isPad` is iOS-only (undefined on Android), so guard on the OS too.
   const isPad = Platform.OS === 'ios' && Platform.isPad === true;
@@ -50,7 +54,7 @@ export function useDeviceLayout(): DeviceLayout & { isTablet: boolean; wallDevic
   const isAndroidTablet = Platform.OS === 'android' && isTablet;
   const wallDeviceClass = resolveWallDeviceClass({ screenLongSide, isPad, isAndroidTablet });
   return useMemo(
-    () => ({ ...resolveDeviceLayout({ width, isTablet }), isTablet, wallDeviceClass }),
-    [width, isTablet, wallDeviceClass],
+    () => ({ ...resolveDeviceLayout({ width, isTablet }), isPad, isTablet, wallDeviceClass }),
+    [width, isPad, isTablet, wallDeviceClass],
   );
 }


### PR DESCRIPTION
## Summary

`typecheck:mobile` is currently **failing on `main`**:

```
use-image-cache-memory-management.ts(79,11): error TS2339: Property 'isPad' does not exist
board-art-visibility-provider.tsx(25,11):   error TS2339: Property 'isPad' does not exist
```

The android-tablet-shell merge (#3613) added `isTablet` / `wallDeviceClass` to `useDeviceLayout`'s return but dropped `isPad`, while both consumers still destructure it. `isPad` is still computed inside the hook — it just never makes it into the returned object.

**User-visible effect on iPad:** the decoded-bitmap memory cache is never cleared on tab change (`isPad` is `undefined`, so the flush is skipped), and the board-art visibility gate never engages.

Split out of #3971 (the Expo SDK 57 bump) on review feedback — this is JS-only with **no native fingerprint change**, so it can land on `main` and ride OTA immediately rather than waiting for a native release train.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile` — the two TS2339 errors are gone
- `vp test run --project mobile use-device-layout` — 4 passing

Adds `use-device-layout.test.ts`, which had no test file at all. It asserts the whole returned shape (`isPad` / `isTablet` / `wallDeviceClass` / `widthClass`) rather than one field, plus the launch-fixed semantics: `isPad` stays true when an iPad is resized into a narrow Split View, and is false on Android tablets and phones.

Verified it's a real guard, not a passing decoration — reverting the `isPad` return makes all 4 tests fail:

```
Test Files  1 failed (1)
     Tests  4 failed (4)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01214fRRANfX3jL91sspHLq6
