### PR TITLE
fix(mobile): clear the queue tray for the pre-session Start capsule

### DIFF
--- a/packages/mobile/src/components/queue-control/ActiveContextBar.tsx
+++ b/packages/mobile/src/components/queue-control/ActiveContextBar.tsx
@@ -22,6 +22,7 @@ import {
   TOOLBAR_FAB_SIZE,
   TOOLBAR_GAP_ABOVE_TABBAR,
   TABBAR_SEAM_OVERLAP,
+  floatingContextBarBottom,
   glassSize,
 } from '../../theme/layout';
 import { useReduceMotion } from '../../hooks/use-reduce-motion';
@@ -66,10 +67,11 @@ export function ActiveContextBar({
   // Docked (Material): sit on the tab bar's REAL measured top, tucked under its hairline
   // by one px. Before the first measurement, fall back to the constant-estimated top
   // (≤2px off for a single frame, then it snaps to the truth). Floating (glass) keeps
-  // its lift above the tab bar.
+  // its lift above the tab bar — shared with the #3967 tray-clearance tests via
+  // `floatingContextBarBottom`, so the tray can't move without moving that guard.
   const bottom = dockToTabBar
     ? (measuredTabBarHeight ?? bottomChrome.tabBarBottom) - TABBAR_SEAM_OVERLAP
-    : bottomChrome.tabBarBottom + gapAboveTabBar;
+    : floatingContextBarBottom(bottomChrome.tabBarBottom, gapAboveTabBar);
 
   // Outer shell: plain View so `pointerEvents="box-none"` is respected on Android.
   // Reanimated's `entering` animations ignore pointerEvents on the animated view

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -82,6 +82,8 @@ vi.mock('../../../theme/layout', () => ({
   TOOLBAR_GAP_ABOVE_TABBAR: 10,
   TABBAR_SEAM_OVERLAP: 1,
   SIDEBAR_WIDTH: 96,
+  // Mirrors the real implementation — ActiveContextBar's floating branch calls it.
+  floatingContextBarBottom: (tabBarBottom: number, gapAboveTabBar = 10) => tabBarBottom + gapAboveTabBar,
   glassSize: { hero: 64, inline: 44 },
 }));
 // The docked Material bar reads the tab bar's measured height to position itself.

--- a/packages/mobile/src/components/session-screen/SessionStartFab.tsx
+++ b/packages/mobile/src/components/session-screen/SessionStartFab.tsx
@@ -45,9 +45,18 @@ type SessionStartFabProps = {
  * not a full-width pinned bar. Liquid Glass renders a brand-tinted **glass**
  * capsule (the iOS 26 `.glassProminent` look: a `GlassSurface` tinted with the
  * brand hue, not a flat opaque fill); Material renders an M3 extended FAB. Both sit
- * over the host-supplied `bottomOffset` (variant-correct: the raw safe-area inset on
- * Liquid Glass — which already includes the tab bar + accessory — or the fixed-footer
- * reserve on Material) and report their height through `onHeightChange`.
+ * over the host-supplied `bottomOffset` and report their height through
+ * `onHeightChange`.
+ *
+ * `bottomOffset` is variant-correct, but on Liquid Glass it is NOT just the safe-area
+ * inset: it is the inset plus the JS queue-tray reserve. That reserve is 0 only on the
+ * native-tab-bar path, where the UIKit glass bar already extends the inset over the tab
+ * bar + accessory. On the JS-tab-bar fallback the floating `PersistentQueueBar` is an
+ * overlay outside the safe area, so the reserve has to be added explicitly or this
+ * capsule lands under the tray's log-ascent tick (#3967). Material uses the
+ * fixed-footer reserve. Don't re-derive any of that here — take the number the host
+ * passes; the whole arbitration lives in `computeBottomChromeMetrics`
+ * (`preSessionFooterBottom`).
  *
  * The End action no longer lives here — it docks in the top chrome (see
  * `RecordTopChrome` / `SessionScreenHeader`).

--- a/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
@@ -259,9 +259,11 @@ export function PreSessionView({ showChrome = false }: PreSessionViewProps) {
   const canStart = activeBoard != null && !isStarting && generatorPreviewReady;
   // The single source of the Start capsule's bottom offset: passed to SessionStartFab
   // AND used for the list reservation, so the FAB position and the last-row clearance
-  // can't drift. The Material-vs-glass arbitration — with the on-device iPhone 17 Pro
-  // evidence for why glass uses the raw inset — lives in computeBottomChromeMetrics
-  // (see `preSessionFooterBottom`).
+  // can't drift. The Material-vs-glass arbitration lives in computeBottomChromeMetrics
+  // (see `preSessionFooterBottom`): on glass it is the safe-area inset PLUS the JS
+  // queue-tray reserve. The on-device iPhone 17 Pro evidence for using the raw inset
+  // only covers the native-tab-bar path, where that reserve is 0; reading the inset
+  // alone puts the capsule back under the tray on the JS-tab-bar fallback (#3967).
   const footerBottom = bottomChrome.preSessionFooterBottom;
 
   // Inline status copy shown above an empty preview (loading / no results /

--- a/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
+++ b/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
@@ -303,6 +303,12 @@ describe('computeBottomChromeMetrics', () => {
     // window bottom (the same assumption `contentInsetBottom` encodes); a native
     // overlaying tab bar or the sidebar shell leaves the screen floor at the window
     // bottom.
+    //
+    // KEEP IN SYNC: this helper hand-copies `ActiveContextBar`'s floating-bottom
+    // formula. It has to (importing the component would drag react-native into this
+    // deliberately RN-free suite — see the file header), but that means changing the
+    // tray's position over there without changing it here leaves these tests green
+    // against a stale band. If you move the tray, move this too.
     const trayTopAboveScreenFloor = (
       metrics: ReturnType<typeof computeBottomChromeMetrics>,
       usesNativeTabBar: boolean,
@@ -344,6 +350,13 @@ describe('computeBottomChromeMetrics', () => {
   });
 
   describe('session-bottom invariants across the whole input matrix', () => {
+    // Deliberately exhaustive, including combinations no shell produces today
+    // (`usesNativeTabBar` with `insideTabs: false`, say). `computeBottomChromeMetrics`
+    // is a pure total function and the callers that feed it — `useNativeTabBar`, the
+    // sidebar shell — change shape more often than it does, so pinning the invariants
+    // over the full cross-product is what stops a future caller from routing a new
+    // combination into an unreserved branch. The realistic configurations are covered
+    // by the hand-written cases above; these add the ones nobody thought to enumerate.
     const allInputs = function* () {
       for (const uiVariant of ['liquidGlass', 'material'] as const) {
         for (const usesNativeTabBar of [true, false]) {

--- a/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
+++ b/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
@@ -6,6 +6,7 @@ import {
   TAB_BAR_HEIGHT,
   TOOLBAR_GAP_ABOVE_TABBAR,
   TOOLBAR_RESERVE,
+  floatingContextBarBottom,
   glassSize,
 } from '../../theme/layout';
 
@@ -292,30 +293,28 @@ describe('computeBottomChromeMetrics', () => {
   });
 
   describe('pre-session Start capsule clears the floating queue tray (#3967)', () => {
-    // The tray band is rebuilt here from `ActiveContextBar`'s OWN formula
-    // (packages/mobile/src/components/queue-control/ActiveContextBar.tsx: floating
-    // bottom = `bottomChrome.tabBarBottom + TOOLBAR_GAP_ABOVE_TABBAR`, content height
-    // `glassSize.hero`) rather than from `preSessionFooterBottom`, so this is not a
-    // tautology: the two sides come from independent code paths. The tray renders at
-    // app root in window coordinates while the Start capsule is inside the tab screen,
-    // so convert the tray to screen-local coordinates first. An in-flow JS
-    // `MaterialTabBar` means the screen's floor already sits `tabBarBottom` above the
-    // window bottom (the same assumption `contentInsetBottom` encodes); a native
+    // The tray band is rebuilt from `floatingContextBarBottom` — the SAME function
+    // `ActiveContextBar` positions itself with — rather than from
+    // `preSessionFooterBottom`, so this is not a tautology: the two sides come from
+    // independent code paths, and moving the tray moves this guard with it instead of
+    // leaving it green against a stale band. (The formula lives in theme/layout so this
+    // suite can use it without importing the component, which would pull react-native
+    // into an otherwise pure test file.) Tray height is `glassSize.hero`, its tallest
+    // island.
+    //
+    // The tray renders at app root in window coordinates while the Start capsule is
+    // inside the tab screen, so convert to screen-local coordinates first. An in-flow
+    // JS `MaterialTabBar` means the screen's floor already sits `tabBarBottom` above
+    // the window bottom (the same assumption `contentInsetBottom` encodes); a native
     // overlaying tab bar or the sidebar shell leaves the screen floor at the window
     // bottom.
-    //
-    // KEEP IN SYNC: this helper hand-copies `ActiveContextBar`'s floating-bottom
-    // formula. It has to (importing the component would drag react-native into this
-    // deliberately RN-free suite — see the file header), but that means changing the
-    // tray's position over there without changing it here leaves these tests green
-    // against a stale band. If you move the tray, move this too.
     const trayTopAboveScreenFloor = (
       metrics: ReturnType<typeof computeBottomChromeMetrics>,
       usesNativeTabBar: boolean,
     ) => {
       const jsTabBarInFlow = metrics.tabBarHeight > 0 && !usesNativeTabBar;
       const screenFloorAboveWindow = jsTabBarInFlow ? metrics.tabBarBottom : 0;
-      return metrics.tabBarBottom + TOOLBAR_GAP_ABOVE_TABBAR + glassSize.hero - screenFloorAboveWindow;
+      return floatingContextBarBottom(metrics.tabBarBottom) + glassSize.hero - screenFloorAboveWindow;
     };
 
     it('clears the tray on an iOS < 26 / non-glass-capable iPhone', () => {
@@ -387,22 +386,33 @@ describe('computeBottomChromeMetrics', () => {
       }
     };
 
+    // Both invariants collect every offending input rather than asserting inside the
+    // loop: a bare `expect` in a 256-iteration loop reports only "expected 34 to be
+    // 100" and leaves you bisecting by hand for which combination produced it.
     it('always reserves at least the JS queue tray when that tray is visible', () => {
+      const unreserved = [];
       for (const inputs of allInputs()) {
         const metrics = computeBottomChromeMetrics(inputs);
         if (!metrics.jsQueueToolbarVisible) continue;
-        expect(metrics.preSessionFooterBottom).toBeGreaterThanOrEqual(metrics.jsQueueReserve);
+        if (metrics.preSessionFooterBottom < metrics.jsQueueReserve) {
+          unreserved.push({ inputs, footer: metrics.preSessionFooterBottom, reserve: metrics.jsQueueReserve });
+        }
       }
+      expect(unreserved).toEqual([]);
     });
 
     it('keeps the pre-session footer and the in-session list on the same bottom chrome', () => {
       // Both session surfaces sit under the same tab bar + queue tray, so their
       // bottom offsets must not drift apart — one branch being edited without the
       // other is exactly what caused #3967.
+      const drifted = [];
       for (const inputs of allInputs()) {
         const metrics = computeBottomChromeMetrics(inputs);
-        expect(metrics.preSessionFooterBottom).toBe(metrics.inSessionListBottom);
+        if (metrics.preSessionFooterBottom !== metrics.inSessionListBottom) {
+          drifted.push({ inputs, footer: metrics.preSessionFooterBottom, list: metrics.inSessionListBottom });
+        }
       }
+      expect(drifted).toEqual([]);
     });
   });
 

--- a/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
+++ b/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
@@ -347,22 +347,24 @@ describe('computeBottomChromeMetrics', () => {
     const allInputs = function* () {
       for (const uiVariant of ['liquidGlass', 'material'] as const) {
         for (const usesNativeTabBar of [true, false]) {
-          for (const onAccessorySurface of [true, false]) {
-            for (const hasCurrentClimb of [true, false]) {
-              for (const nativeAccessoryMounted of [true, false]) {
-                for (const usesSidebar of [true, false]) {
-                  for (const detailPaneOwnsQueue of [true, false]) {
-                    yield {
-                      uiVariant,
-                      usesNativeTabBar,
-                      insetsBottom: 34,
-                      insideTabs: true,
-                      onAccessorySurface,
-                      hasCurrentClimb,
-                      nativeAccessoryMounted,
-                      usesSidebar,
-                      detailPaneOwnsQueue,
-                    };
+          for (const insideTabs of [true, false]) {
+            for (const onAccessorySurface of [true, false]) {
+              for (const hasCurrentClimb of [true, false]) {
+                for (const nativeAccessoryMounted of [true, false]) {
+                  for (const usesSidebar of [true, false]) {
+                    for (const detailPaneOwnsQueue of [true, false]) {
+                      yield {
+                        uiVariant,
+                        usesNativeTabBar,
+                        insetsBottom: 34,
+                        insideTabs,
+                        onAccessorySurface,
+                        hasCurrentClimb,
+                        nativeAccessoryMounted,
+                        usesSidebar,
+                        detailPaneOwnsQueue,
+                      };
+                    }
                   }
                 }
               }

--- a/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
+++ b/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
@@ -272,7 +272,11 @@ describe('computeBottomChromeMetrics', () => {
       expect(metrics.inSessionListBottom).toBe(139);
     });
 
-    it('adds only the JS queue reserve to the Liquid Glass in-session list when the accessory is unavailable', () => {
+    it('adds the JS queue reserve to both Liquid Glass session bottoms when the accessory is unavailable', () => {
+      // iOS < 26 / non-glass-capable iPhone: the JS `PersistentQueueBar` tray is an
+      // overlay outside the UIKit safe area, so BOTH the in-session list and the
+      // pre-session Start capsule have to reserve for it. Before #3967 the footer
+      // rode the raw inset and landed under the tray's log-ascent tick.
       const metrics = computeBottomChromeMetrics({
         uiVariant: 'liquidGlass',
         usesNativeTabBar: false,
@@ -283,7 +287,107 @@ describe('computeBottomChromeMetrics', () => {
         nativeAccessoryMounted: false,
       });
       expect(metrics.inSessionListBottom).toBe(34 + TOOLBAR_RESERVE);
-      expect(metrics.preSessionFooterBottom).toBe(34);
+      expect(metrics.preSessionFooterBottom).toBe(34 + TOOLBAR_RESERVE);
+    });
+  });
+
+  describe('pre-session Start capsule clears the floating queue tray (#3967)', () => {
+    // The tray band is rebuilt here from `ActiveContextBar`'s OWN formula
+    // (packages/mobile/src/components/queue-control/ActiveContextBar.tsx: floating
+    // bottom = `bottomChrome.tabBarBottom + TOOLBAR_GAP_ABOVE_TABBAR`, content height
+    // `glassSize.hero`) rather than from `preSessionFooterBottom`, so this is not a
+    // tautology: the two sides come from independent code paths. The tray renders at
+    // app root in window coordinates while the Start capsule is inside the tab screen,
+    // so convert the tray to screen-local coordinates first. An in-flow JS
+    // `MaterialTabBar` means the screen's floor already sits `tabBarBottom` above the
+    // window bottom (the same assumption `contentInsetBottom` encodes); a native
+    // overlaying tab bar or the sidebar shell leaves the screen floor at the window
+    // bottom.
+    const trayTopAboveScreenFloor = (
+      metrics: ReturnType<typeof computeBottomChromeMetrics>,
+      usesNativeTabBar: boolean,
+    ) => {
+      const jsTabBarInFlow = metrics.tabBarHeight > 0 && !usesNativeTabBar;
+      const screenFloorAboveWindow = jsTabBarInFlow ? metrics.tabBarBottom : 0;
+      return metrics.tabBarBottom + TOOLBAR_GAP_ABOVE_TABBAR + glassSize.hero - screenFloorAboveWindow;
+    };
+
+    it('clears the tray on an iOS < 26 / non-glass-capable iPhone', () => {
+      const metrics = computeBottomChromeMetrics({
+        uiVariant: 'liquidGlass',
+        usesNativeTabBar: false,
+        insetsBottom: 34,
+        insideTabs: true,
+        onAccessorySurface: true,
+        hasCurrentClimb: true,
+        nativeAccessoryMounted: false,
+      });
+      expect(metrics.jsQueueToolbarVisible).toBe(true);
+      expect(metrics.preSessionFooterBottom).toBeGreaterThanOrEqual(trayTopAboveScreenFloor(metrics, false));
+    });
+
+    it('clears the tray on an iPad in a narrow split (sidebar without the detail pane)', () => {
+      const metrics = computeBottomChromeMetrics({
+        uiVariant: 'liquidGlass',
+        usesNativeTabBar: false,
+        insetsBottom: 20,
+        insideTabs: true,
+        onAccessorySurface: true,
+        hasCurrentClimb: true,
+        nativeAccessoryMounted: true,
+        usesSidebar: true,
+        detailPaneOwnsQueue: false,
+      });
+      expect(metrics.jsQueueToolbarVisible).toBe(true);
+      expect(metrics.preSessionFooterBottom).toBeGreaterThanOrEqual(trayTopAboveScreenFloor(metrics, false));
+    });
+  });
+
+  describe('session-bottom invariants across the whole input matrix', () => {
+    const allInputs = function* () {
+      for (const uiVariant of ['liquidGlass', 'material'] as const) {
+        for (const usesNativeTabBar of [true, false]) {
+          for (const onAccessorySurface of [true, false]) {
+            for (const hasCurrentClimb of [true, false]) {
+              for (const nativeAccessoryMounted of [true, false]) {
+                for (const usesSidebar of [true, false]) {
+                  for (const detailPaneOwnsQueue of [true, false]) {
+                    yield {
+                      uiVariant,
+                      usesNativeTabBar,
+                      insetsBottom: 34,
+                      insideTabs: true,
+                      onAccessorySurface,
+                      hasCurrentClimb,
+                      nativeAccessoryMounted,
+                      usesSidebar,
+                      detailPaneOwnsQueue,
+                    };
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    it('always reserves at least the JS queue tray when that tray is visible', () => {
+      for (const inputs of allInputs()) {
+        const metrics = computeBottomChromeMetrics(inputs);
+        if (!metrics.jsQueueToolbarVisible) continue;
+        expect(metrics.preSessionFooterBottom).toBeGreaterThanOrEqual(metrics.jsQueueReserve);
+      }
+    });
+
+    it('keeps the pre-session footer and the in-session list on the same bottom chrome', () => {
+      // Both session surfaces sit under the same tab bar + queue tray, so their
+      // bottom offsets must not drift apart — one branch being edited without the
+      // other is exactly what caused #3967.
+      for (const inputs of allInputs()) {
+        const metrics = computeBottomChromeMetrics(inputs);
+        expect(metrics.preSessionFooterBottom).toBe(metrics.inSessionListBottom);
+      }
     });
   });
 
@@ -356,7 +460,7 @@ describe('computeBottomChromeMetrics', () => {
       expect(metrics.floatingControlBottom).toBe(20 + TOOLBAR_RESERVE);
       expect(metrics.fixedFooterBottom).toBe(TOOLBAR_RESERVE);
       expect(metrics.inSessionListBottom).toBe(20 + TOOLBAR_RESERVE);
-      expect(metrics.preSessionFooterBottom).toBe(20);
+      expect(metrics.preSessionFooterBottom).toBe(20 + TOOLBAR_RESERVE);
     });
 
     it('defaults usesSidebar to false so existing compact call sites are unchanged', () => {

--- a/packages/mobile/src/hooks/bottom-chrome-metrics.ts
+++ b/packages/mobile/src/hooks/bottom-chrome-metrics.ts
@@ -91,13 +91,25 @@ export type BottomChromeMetrics = {
   inSessionListBottom: number;
   /**
    * Bottom offset for the pre-session Start capsule / footer. Material uses the
-   * fixed-footer reserve; Liquid Glass anchors to the raw safe-area inset.
+   * fixed-footer reserve; Liquid Glass anchors to the raw safe-area inset plus
+   * the JS queue reserve — identical arithmetic to {@link inSessionListBottom},
+   * and it must stay in lockstep with it: both surfaces clear the same bottom
+   * chrome, and letting one branch drift is what caused #3967.
    *
    * Verified on-device (iPhone 17 Pro / iOS 26): with the native tab bar + climb
    * accessory present, the safe-area bottom inset is 139 = home indicator (34) +
    * tab bar (49) + accessory (56) — the glass tab bar extends the UIKit safe area.
    * `fixedFooterBottom` would add the tab bar + accessory a second time (246),
    * stranding the control ~110px up the screen — hence the raw inset on glass.
+   * That evidence covers the *native tab bar* path only, where `jsQueueReserve`
+   * is 0 (the accessory owns the climb) so this stays exactly 139.
+   *
+   * On the JS-tab-bar fallback (iOS < 26, non-glass-capable iPhones, iPad in a
+   * narrow split, Android forced to Liquid Glass) the floating
+   * `PersistentQueueBar` is a JS overlay that does NOT extend the UIKit safe
+   * area, so nothing reserves for it implicitly — the raw inset alone dropped
+   * the Start capsule under the tray's log-ascent tick (#3967). Hence the
+   * explicit `+ jsQueueReserve`.
    */
   preSessionFooterBottom: number;
 };
@@ -199,6 +211,12 @@ export function computeBottomChromeMetrics({
       material: fixedFooterBottom,
       liquidGlass: insetsBottom + jsQueueReserve,
     }),
-    preSessionFooterBottom: selectByVariant(uiVariant, { material: fixedFooterBottom, liquidGlass: insetsBottom }),
+    // Keep this branch identical to `inSessionListBottom`: the JS queue tray is an
+    // overlay outside the safe area, so the Start capsule only clears it when the
+    // reserve is added explicitly (#3967).
+    preSessionFooterBottom: selectByVariant(uiVariant, {
+      material: fixedFooterBottom,
+      liquidGlass: insetsBottom + jsQueueReserve,
+    }),
   };
 }

--- a/packages/mobile/src/theme/layout.ts
+++ b/packages/mobile/src/theme/layout.ts
@@ -81,6 +81,23 @@ export const TOOLBAR_GAP_ABOVE_TABBAR = 10;
  *  — the hero log-ascent tick (`glassSize.hero`) — so nothing hides under it. */
 export const TOOLBAR_RESERVE = glassSize.hero + TOOLBAR_GAP_ABOVE_TABBAR;
 
+/**
+ * Window-coordinate `bottom` of the floating (Liquid Glass) active-context bar —
+ * the tray that holds the climb capsule and the log-ascent tick.
+ *
+ * `ActiveContextBar` positions itself with this, and the #3967 regression tests
+ * rebuild the tray's band with it to prove the pre-session Start capsule clears
+ * the tray. It lives here rather than inside the component so those two can't
+ * disagree: the tests need the formula but must not import `ActiveContextBar`
+ * (that would pull react-native into an otherwise pure suite). Move the tray by
+ * editing this, and the guard moves with it.
+ *
+ * Docking (the Material variant) is deliberately NOT here — it keys off the tab
+ * bar's *measured* height, which only the component has.
+ */
+export const floatingContextBarBottom = (tabBarBottom: number, gapAboveTabBar = TOOLBAR_GAP_ABOVE_TABBAR) =>
+  tabBarBottom + gapAboveTabBar;
+
 /** Height of the Material active-context bar docked directly above the tab bar. */
 export const MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT = glassSize.standard;
 


### PR DESCRIPTION
Fixes #3967.

## What was wrong

`computeBottomChromeMetrics` (`packages/mobile/src/hooks/bottom-chrome-metrics.ts`) had two sibling outputs that had drifted apart:

```ts
inSessionListBottom:    selectByVariant(uiVariant, { material: fixedFooterBottom, liquidGlass: insetsBottom + jsQueueReserve }),
preSessionFooterBottom: selectByVariant(uiVariant, { material: fixedFooterBottom, liquidGlass: insetsBottom }),
```

The Liquid Glass branch of `preSessionFooterBottom` omitted `jsQueueReserve`. The docblock justifying the raw inset carries real on-device evidence (iPhone 17 Pro / iOS 26: bottom safe-area inset 139 = home indicator 34 + tab bar 49 + accessory 56, so `fixedFooterBottom` would double-count to 246). That evidence is correct — but it only describes the **native tab bar** path, which is exactly the path where `jsQueueReserve` is 0 because the UIKit `BottomAccessory` owns the climb. The conclusion got applied to the whole `liquidGlass` variant.

`resolveUiVariant` returns `liquidGlass` on every iPhone, including iOS < 26 (blur fallback). `useNativeTabBar()` additionally requires `glassCapable && !isTablet`. So on iOS < 26, on non-glass-capable iPhones, on iPad in a narrow split, and on Android with the variant forced to Liquid Glass, you get the glass variant **plus** the JS `MaterialTabBar` **plus** the JS `PersistentQueueBar` tray — and that tray is a JS overlay that does not extend the UIKit safe area. Nothing reserved for it, so the Start capsule sat underneath it.

Measured in screen-local coordinates (`[bottom, top]` from the screen's bottom edge):

| configuration | tray band | Start capsule | overlap |
| --- | --- | --- | --- |
| iOS < 26 / non-glass iPhone | `[10, 66]` | `[42, 94]` | 24pt of the capsule inside the tray |
| iPad narrow Split View | `[30, 86]` | `[28, 80]` | 50 of the capsule's 52pt covered |
| iOS 26 iPhone, native accessory | no JS tray | `[139, …]` | none |

The tray's trailing `heroSlot` is the log-ascent tick FAB (56 wide, right-aligned at a 16pt inset) and the Start capsule is `alignItems: 'flex-end'` — so the tick sat right over the capsule's tappable right half. That is the "stuck behind the tray, hard to click" in the report.

## What the issue body got wrong (or left ambiguous)

The report is accurate as far as it goes, but two things will trip up anyone reproducing it:

1. **"iOS 2.2.2" is the app version, not the OS version.** This bug does **not** reproduce on an iPhone running iOS 26 — that path mounts the native accessory inside the UIKit glass tab bar, `jsQueueReserve` is 0, and the footer offset is already correct (139, on-device verified). Try it on a current iPhone and you will conclude the report is bogus. The reporter is on iOS < 26, a non-glass-capable iPhone, or an iPad in a narrow split.
2. **"tray" is the floating `PersistentQueueBar`** (centred climb capsule + standalone log-ascent tick), not the tab bar and not the play drawer.

## The fix

One line: make the glass branch symmetric with `inSessionListBottom`.

```ts
preSessionFooterBottom: selectByVariant(uiVariant, {
  material: fixedFooterBottom,
  liquidGlass: insetsBottom + jsQueueReserve,
}),
```

Plus a rewritten docblock that keeps the iPhone 17 Pro evidence but scopes it to the native-tab-bar path, and says the two fields must stay in lockstep. The same stale "raw safe-area inset on Liquid Glass" wording lived on in two call sites the one-line fix didn't touch — `SessionStartFab`'s docblock and `PreSessionView`'s comment above `footerBottom` — so both are corrected too. That over-generalisation is what caused this bug once; leaving copies of it in the files a future consumer actually reads would just relocate it.

Resulting values:

- iOS < 26 / non-glass iPhone: 34 → 100. Capsule clears the tray by 42pt.
- iPad narrow split: 20 → 86. Clears the tray exactly.
- **iOS 26 native accessory: unchanged at 139** — `jsQueueReserve` is 0, so this is byte-identical to the on-device-verified value.
- No current climb, Material variant, iPad with the detail pane mounted: all unchanged.

The change is **monotone** — the footer can only move up, and only when the JS tray is actually mounted — so even if the coordinate model were off, it cannot introduce a new occlusion. Worst case is extra air under the capsule.

## Tests

`packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts`:

- Two existing assertions encoded the bug as correct (`preSessionFooterBottom` 34 on the iOS < 26 case, 20 on the iPad narrow split). Both updated to `+ TOOLBAR_RESERVE`.
- **New — tray-clearance geometry.** Rebuilds the tray's band from `ActiveContextBar`'s own formula (`tabBarBottom + TOOLBAR_GAP_ABOVE_TABBAR`, height `glassSize.hero`), converts it to screen-local coordinates, and asserts `preSessionFooterBottom >= trayTop`. Not a tautology: the expected side comes from the layout constants + `tabBarBottom`, the actual side from `preSessionFooterBottom` — two independent code paths.
  The tray's formula (`floatingContextBarBottom`) was pulled out of `ActiveContextBar` into `theme/layout` so the
  component and the guard share one definition — a comment saying "keep these in sync" is not a safety net, and
  the test can't import the component without dragging react-native into a pure suite. Checked: nudging the shared
  formula up by 200 reddens both geometry tests.
- **New — matrix invariant.** Over variant × native/JS tab bar × accessory surface × climb × accessory mount × sidebar × detail pane: whenever `jsQueueToolbarVisible`, `preSessionFooterBottom >= jsQueueReserve`.
- **New — symmetry pin.** Over the same matrix, `preSessionFooterBottom === inSessionListBottom`, so one branch can't be edited without the other again.

**Mutation check (run, not claimed):** deleting `+ jsQueueReserve` from the new line turns **6 tests red** — both updated literals, both geometry tests, the matrix invariant, and the symmetry pin. Restoring it returns the file to 29/29 green. The existing iOS 26 test (`preSessionFooterBottom === 139`, `toBeLessThan(fixedFooterBottom)`) stayed green throughout — that is the guard that the one configuration with device evidence is undisturbed.

## Validation

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 557 files, 4678 tests, all passing
- `vp check` — 0 errors (271 pre-existing warnings, none in the touched files)
- `vp run check:mobile-bundle` — OK

## Deliberately not in this PR

- **`floatingControlBottom` / `scrollBottomPadding` double-count the tab bar + accessory on the iOS 26 native-glass path** (246 instead of ~139 for snackbars and FABs). Real, but it errs safe — everything floats too high, never occluded — it is a different symptom from this report, and unlike this fix it moves controls **down**, so it needs an iOS 26 device. Filed as #3973 with the arithmetic worked out and cross-linked to #3776 (whose "~142pt dead gap" may be the same root cause).
- **The tighter `usesNativeTabBar`-conditional formula.** `insetsBottom` is vestigial on the in-flow-JS-tab-bar path, so the tightest correct value would clear the tray by ~8pt instead of 42. It threads more inputs into the branch and can move the capsule back **down** — the one direction that could re-create an occlusion, on hardware nobody here can test. Deferred pending device feedback.
- **Collapsing `preSessionFooterBottom` and `inSessionListBottom`** into one field now that they are numerically identical. The two names document genuinely different consumers (`InSessionView` list padding vs `PreSessionView` absolute footer offset); the symmetry test gives the same drift protection without churning 2 components and 4 test files.

## Device QA gates (maintainer)

Nothing here was rendered — Linux box, no macOS, no simulator, no iPad. The arithmetic is unit-proven; the pixels are not. On the Record tab's "Start a session" screen **with a current climb set** (so the tray is up):

1. **iPhone on iOS < 26 or any non-glass-capable iPhone — the primary gate.** The "Start" capsule must sit fully above the floating climb capsule + tick, and a tap on its right half (previously under the tick FAB) must start the session rather than open the log-ascent sheet. No such device? Force the same code path by setting the UI variant to Liquid Glass in settings on an Android phone.
2. **iPhone on iOS 26 — the no-change gate.** The Start capsule must be in exactly the same place as before. Any movement means `jsQueueReserve` leaked into a case it shouldn't, which would undo the on-device work recorded in the docblock.
3. **iPad in narrow Split View / Slide Over.** Worst case before the fix (50 of 52pt covered). Confirm it clears.
4. **Android on the default Material variant — control.** The Start FAB must not move at all.
5. **Judgement call:** on (1) the capsule now floats ~42pt above the tray rather than the ~8pt a tighter formula would give. If that reads as too much air, say so and the conditional variant is a small follow-up — but only with device confirmation, since it moves the capsule back down.

Ships OTA: pure JS, no native inputs touched, no fingerprint impact.

## Release Notes

Starting a session on older iPhones and on iPad in Split View: the "Start" button no longer hides under the floating climb bar, so you can actually tap it instead of hitting the log-ascent tick by mistake.


