### PR TITLE
fix(shared): harden Both climb-type filter against dormant backend default

### DIFF
--- a/packages/backend/src/validation/schemas/climbs.ts
+++ b/packages/backend/src/validation/schemas/climbs.ts
@@ -197,9 +197,20 @@ export const ClimbSearchInputSchema = z.object({
   showOnlyCompleted: z.boolean().optional(),
   onlyDrafts: z.boolean().optional(),
   projectsOnly: z.boolean().optional(),
-  // Default to boulders-only so non-web GraphQL callers (mobile, scripts)
-  // get the same shape as the web UI when the field is omitted. Web sends
-  // explicit values from URL state, so its behaviour is unchanged.
+  // Intended to default to boulders-only so non-web GraphQL callers (mobile,
+  // scripts) get the same shape as the web UI when the field is omitted. This
+  // default is currently DEAD CODE: searchClimbs (see
+  // packages/backend/src/graphql/resolvers/climbs/queries.ts) calls
+  // validateInput(ClimbSearchInputSchema, input, 'input') only for its
+  // throw-on-invalid side effect and discards the parsed/defaulted return
+  // value, so every downstream consumer (mapSearchInputToParams) reads the
+  // raw, un-defaulted input — an omitted boulders/routes stays undefined, not
+  // true/false (see #2636). Do not "fix" this by wiring the parsed result
+  // into use without auditing every caller of @boardsesh/climb-filters'
+  // toClimbSearchInput first: its both-selected ("All") case now sends
+  // explicit boulders: true, routes: true (hardened by #2636) so it's safe,
+  // but its both-off case still relies on omission staying undefined, and
+  // reactivating this default would flip that to boulders-only.
   boulders: z.boolean().optional().default(true),
   routes: z.boolean().optional().default(false),
   zoneBox: z

--- a/packages/shared/climb-filters/src/__tests__/climb-type-filter.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/climb-type-filter.test.ts
@@ -35,10 +35,15 @@ describe('climb-type (boulders/routes) filter', () => {
     expect(input.boulders).toBeUndefined();
   });
 
-  it('omits both fields when both are selected (no frames_count constraint)', () => {
+  it('sends explicit boulders=true, routes=true when both are selected (no frames_count constraint)', () => {
+    // Regression guard for #2636: omission here is currently equivalent to
+    // explicit true/true (both parse to "no constraint" downstream), but
+    // omission relies on the backend's Zod default(true)/default(false) for
+    // these fields staying dead code (see filter-state.ts comment above the
+    // both-on branch). Sending explicit true/true removes that footgun.
     const input = inputFor({ boulders: true, routes: true });
-    expect(input.boulders).toBeUndefined();
-    expect(input.routes).toBeUndefined();
+    expect(input.boulders).toBe(true);
+    expect(input.routes).toBe(true);
   });
 
   it('omits both fields when neither is selected (widened to all climbs)', () => {

--- a/packages/shared/climb-filters/src/filter-state.ts
+++ b/packages/shared/climb-filters/src/filter-state.ts
@@ -51,9 +51,11 @@ export type ClimbFilterState = {
   onlyWithBetaVideos?: boolean;
   // Climb-type toggles. Default is boulders-only (routes hidden) — see
   // DEFAULT_CLIMB_FILTER_STATE. Both-on or both-off means "no preference" and
-  // omits the frames_count constraint. Maps to ClimbSearchInput.boulders/routes,
-  // whose SQL lives in @boardsesh/db create-climb-filters.ts (boulders →
-  // frames_count = 1 or NULL, routes → frames_count > 1).
+  // maps to no frames_count constraint (both-on sends explicit boulders:
+  // true, routes: true rather than omitting — see toClimbSearchInput for
+  // why). Maps to ClimbSearchInput.boulders/routes, whose SQL lives in
+  // @boardsesh/db create-climb-filters.ts (boulders → frames_count = 1 or
+  // NULL, routes → frames_count > 1).
   boulders?: boolean;
   routes?: boolean;
   status: StatusFilter;
@@ -191,13 +193,32 @@ export function toClimbSearchInput(
   if (state.showOnlyAttempted) input.showOnlyAttempted = true;
   if (state.showOnlyCompleted) input.showOnlyCompleted = true;
 
-  // Climb-type filter: apply only when exactly one of boulders/routes is
-  // selected. Both-on and both-off mean "no preference" → omit entirely (the
-  // backend treats a missing frames_count constraint as all climbs). Mirrors
-  // create-climb-filters.ts and web's never-both-off toggle behaviour.
+  // Climb-type filter. Both-on ("All") and both-off mean "no preference" for
+  // the frames_count constraint, but they must NOT be handled the same way:
+  //
+  // - Both-off is genuinely omitted (unreachable via any current UI — web's
+  //   never-both-off toggle and mobile's boulders/routes/both selector never
+  //   produce it — kept as-is, out of scope for this fix).
+  // - Both-on ("All") sends explicit boulders: true, routes: true rather than
+  //   omitting both fields. Omission and explicit true/true are proven
+  //   behaviourally identical today (both parse to no frames_count
+  //   constraint), but only because the backend resolver's Zod
+  //   default(true)/default(false) for these fields is dead code —
+  //   searchClimbs's validateInput() call at
+  //   packages/backend/src/graphql/resolvers/climbs/queries.ts discards its
+  //   parsed/defaulted return value, so the default never actually applies.
+  //   If that discard is ever "cleaned up" to use the parsed result, an
+  //   omitted both/both would silently start defaulting to
+  //   boulders=true/routes=false (boulders-only) — reintroducing the exact
+  //   regression reported in issue #2636. Sending explicit true/true removes
+  //   that footgun regardless of what the backend resolver does with its
+  //   validation return. See create-climb-filters.ts for the SQL this maps to.
   const bouldersOn = state.boulders ?? true;
   const routesOn = state.routes ?? false;
-  if (bouldersOn !== routesOn) {
+  if (bouldersOn && routesOn) {
+    input.boulders = true;
+    input.routes = true;
+  } else if (bouldersOn !== routesOn) {
     if (bouldersOn) input.boulders = true;
     if (routesOn) input.routes = true;
   }


### PR DESCRIPTION
## What this PR actually is

**The reported symptom does not reproduce on current `main`.** Selecting "Both" (All) climb types today already returns every climb — boulders and routes — because of a real, currently-dormant bug elsewhere in the stack that happens to cancel out the one this issue describes. This PR hardens the code so that cancellation stops being an accident.

### Why "Both" isn't broken today

- `toClimbSearchInput` (`packages/shared/climb-filters/src/filter-state.ts`) omits `boulders`/`routes` from the GraphQL input entirely when both are selected — the comment there says the backend treats the omission as "no constraint."
- The backend's `ClimbSearchInputSchema` (`packages/backend/src/validation/schemas/climbs.ts`) has `boulders: z.boolean().optional().default(true)` and `routes: z.boolean().optional().default(false)` — which, if applied, would turn an omitted "Both" into boulders-only. This is exactly the bug #2636 describes.
- But that default is **dead code**: `searchClimbs` (`packages/backend/src/graphql/resolvers/climbs/queries.ts:151`) calls `validateInput(ClimbSearchInputSchema, input, 'input')` only for its throw-on-invalid side effect and **discards the parsed/defaulted return value**. Every downstream consumer (`mapSearchInputToParams(input)`) reads the raw, un-defaulted GraphQL input, so an omitted `boulders`/`routes` stays `undefined`, not `true`/`false`. `createClimbFilters` then sees `wantsBoulders = wantsRoutes = false` and applies **no** `frames_count` constraint — all climbs, boulders and routes both.

Confirmed with a throwaway `node:test` repro calling `createClimbFilters` directly: omitted `{}` and explicit `{boulders:true, routes:true}` produce byte-identical SQL (no `frames_count` clause) on current `main`; only `{boulders:true, routes:false}` produces the boulders-only clause. Also confirmed web is unaffected — `SearchRequestParams.boulders`/`.routes` are non-optional there and every web call site sends explicit values, so web never hits the omission branch.

### Why this is worth fixing anyway

`git log -S` on the `validateInput` call in `queries.ts` shows it has **never**, since being introduced, captured a return value — the Zod default has been inert since the day it landed (the commit that added it, `9e2aaa27f`, touched `climbs.ts` and `create-climb-filters.ts` but never `queries.ts`). If anyone ever "cleans up" that discard to actually use the parsed/defaulted result — a change that looks like an innocent refactor, not a behavior change — an omitted "Both" would silently start defaulting to boulders-only, reintroducing the exact regression #2636 reports, invisibly (there was zero test coverage on `boulders`/`routes` at the `create-climb-filters`/`climb-queries` level before this PR).

## The fix

`toClimbSearchInput`'s both-selected ("All") branch now sends explicit `boulders: true, routes: true` instead of omitting both fields. Omission and explicit `true`/`true` are proven behaviorally identical today (both produce "no `frames_count` constraint" downstream) — this is a pure hardening change, zero observable behavior difference, that removes the backend footgun above regardless of what happens to `queries.ts` in the future.

The both-off (neither selected) case is left omitting, unchanged — it's unreachable via any current UI (web has a never-both-off guard; mobile's boulders/routes/both selector never produces it) and out of scope here.

Also updated the misleading comment on `ClimbSearchInputSchema.boulders`/`.routes` in `packages/backend/src/validation/schemas/climbs.ts` to say plainly that the default is dead code today, and why reactivating it needs care.

## Scope note — please read before merging

**This PR does not close the full scope of #2636.** #2636's issue body is actually a broad "revival tracker" (`Revive: [codex] Restore mobile climb filter stack (was #2539)`) for reviving a stale branch that intended to:

1. Restore mobile's climb-type control as a genuine 3-way **All / Boulders / Routes** selector, defaulting to **All**.
2. Reconnect live result counts and removable active-filter chips into mobile search.
3. Migrate `climbType` i18n keys from flat (`climbType`/`boulders`/`routes`/`both`) to nested (`climbType.label`/`.all`/`.boulders`/`.routes`) across en-US/es/fr.

None of those three is implemented _by this PR_. But — correcting an earlier version of this section, which claimed all three were still unbuilt — two of the three **already exist on `main` today**, built independently against the current component tree (`ClimbTopChrome`/`ClimbFilterFab`) rather than by reviving the stale #2539 branch:

| #2636 sub-item                                 | Status on `main`                                                                                                                                                                                                                              | Where                                                                                                                                      |
| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
| 1. 3-way climb-type selector                   | **Built.** Boulders / Routes / Both segmented control, derived from `getClimbTypeFilter` so the sheet and the chip row can't disagree.                                                                                                        | `packages/mobile/src/components/ClimbFilterSheet.tsx:411-431` (its own comment calls it "main's #2496 control")                            |
| 2. Live result counts + removable filter chips | **Built.** The Apply button reads `Show {count}` from a debounced live preview count; active filters render as chips with a close affordance (`mobile.search.removeFilterAria`), including a climb-type chip that clears back to the default. | `ClimbFilterSheet.tsx:632`; `packages/mobile/src/lib/filter-tokens.ts:179-185`; `packages/mobile/src/components/search/FilterTokenRow.tsx` |
| 3. Flat → nested `climbType` i18n keys         | **Not done.** Still flat in all three locales.                                                                                                                                                                                                | `packages/shared/i18n/locales/{en-US,es,fr}/climbs.json:645` — `mobile.filter.climbType` / `.boulders` / `.routes` / `.both`               |

So the genuine remaining gap is much smaller than "the mobile filter stack needs reviving". It is:

- the flat → nested `climbType` i18n key migration (row 3), and
- two wording/default deltas on the existing control: it's labelled **"Both"**, not "All", and the default is **boulders-only** (`DEFAULT_CLIMB_FILTERS.boulders = true, routes = false` in `filter-state.ts`), not All. That default is deliberate — it matches web — so flipping it is a product decision, not a bug.

**Suggested disposition for #2534:** narrow it to those two items rather than leaving it open as a branch-revival task. The branch it was tracking is now almost entirely superseded.

What this PR _does_ close is the one concrete, currently-real correctness note that #2636's own body called out explicitly under "Open correctness issue to address in the revival": _"The 'All climbs' default is silently overridden by backend Zod defaults... A fresh implementation must either send explicit `boulders:true, routes:true` for 'All' or drop/realign those backend defaults."_ That's exactly what this PR does, at the shared `@boardsesh/climb-filters` layer, so web and mobile's existing "Both" selector both inherit it.

I'm closing #2636 per explicit orchestrator direction for this batch: the correctness bullet it flagged is now genuinely fixed, its reported symptom doesn't reproduce, and — per the table above — most of the UI scope it described has already shipped under other issues.

## Follow-up filed

Filed **#3975** — audited every `validateInput(...)` call site in `packages/backend/src/graphql/resolvers/` (~150+) against every schema with a live `.default(...)`. The discard-the-return style is repo-wide but harmless everywhere else (the schemas being discarded have no defaults to lose); `ClimbSearchInputSchema` was the one live instance. Filed as a low-priority "worth a lint rule / review habit" note, not a live-bug backlog.

## Testing

- Replaced the tautological test (`omits both fields when both are selected`, which just re-asserted the code's own branch condition) with a real regression guard: `toClimbSearchInput` must emit explicit `boulders: true, routes: true` for the both-selected state.
- **Mutation check performed**: stashed the `filter-state.ts` fix, ran the new test against the unmodified logic — it failed (`expected undefined to be true`), confirming it's a real assertion and not a tautology. Restored the fix; full `climb-filters` suite (188 tests) is green.
- `vp run typecheck` — green.
- `vp check` — 0 errors (271 pre-existing warnings, none touching this PR's files).

## Release Notes

- [x] No release note needed (internal / technical change)

This is an internal hardening fix. Today's "All" climb-type filter behavior on web is unchanged; this closes a dormant footgun that could have silently regressed it in a future refactor.

## Maintainer gates

- No device QA needed — pure TypeScript logic, fully covered by unit tests, no BLE/native/rendering surface.
- Please confirm you're OK with closing #2636 given the scope note above. Two of the three UI items it describes already shipped under other issues; the real leftovers are the nested `climbType` i18n keys and the "Both" vs "All" label/default question, which I'd suggest narrowing #2534 to rather than reopening this.
