### PR TITLE
fix(db): fail the deploy on any unapplied migration, named

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,9 @@ jobs:
               - 'packages/db/scripts/migration-journal.ts'
               - 'packages/db/scripts/verify-migration-journal.ts'
               - 'packages/db/scripts/migration-journal-verification.integration.test.ts'
+              # Defines the test:migration-journal script this job's new step
+              # invokes, so editing it has to run the job that depends on it.
+              - 'packages/db/package.json'
 
   setup:
     needs: [changes]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,13 @@ jobs:
               - 'packages/db/src/schema/**'
               - 'scripts/check-db-migrations.ts'
               - 'scripts/lib/drizzle-migrations.ts'
+              # The journal<->ledger verification that gates the production
+              # deploy (#2933) and its real-database test.
+              - 'scripts/lib/migration-ledger.ts'
+              - 'packages/db/scripts/migrate.ts'
+              - 'packages/db/scripts/migration-journal.ts'
+              - 'packages/db/scripts/verify-migration-journal.ts'
+              - 'packages/db/scripts/migration-journal-verification.integration.test.ts'
 
   setup:
     needs: [changes]
@@ -257,7 +264,24 @@ jobs:
     # board-constants and the sync packages).
     if: needs.changes.outputs.dbMigrations == 'true' || needs.changes.outputs.rootCi == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
+    # A stock Postgres is enough: the journal<->ledger test builds its own
+    # throwaway migrations folder and database, so it needs no board data and
+    # never pulls the (large) boardsesh-dev-db image.
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - uses: actions/checkout@v6
         with:
@@ -274,6 +298,14 @@ jobs:
         run: |
           git fetch --no-tags --depth=1 origin main
           vp run check:db-migrations -- --base origin/main
+      # Guards the failure mode check:db-migrations cannot see: a migration
+      # whose `when` lands below drizzle's created_at high-water mark is skipped
+      # forever and silently (#2933). Drives drizzle's real migrate() against a
+      # scratch database.
+      - name: Verify the migration journal check against a real database
+        env:
+          MIGRATION_JOURNAL_DB_URL: postgres://postgres:postgres@localhost:5432/postgres
+        run: vp run test:db:migration-journal
 
   codegen-drift:
     needs: [changes, setup]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
               # The journal<->ledger verification that gates the production
               # deploy (#2933) and its real-database test.
               - 'scripts/lib/migration-ledger.ts'
+              - 'scripts/lib/migration-ledger.test.ts'
               - 'packages/db/scripts/migrate.ts'
               - 'packages/db/scripts/migration-journal.ts'
               - 'packages/db/scripts/verify-migration-journal.ts'

--- a/docs/db-migrations.md
+++ b/docs/db-migrations.md
@@ -147,12 +147,27 @@ would not have written re-opens the same gap under a different name.
 
 **When it fires.** It does not self-heal, on purpose: several migrations here are data
 backfills whose idempotence hinges on `_bs_migration_guards` semantic keys, so re-running a
-mixed DDL/DML set unattended is worse than a blocked deploy. Repair each named tag by hand:
+mixed DDL/DML set unattended is worse than a blocked deploy.
 
-1. Read `packages/db/drizzle/<tag>.sql` and confirm it is safe against the current schema.
-2. Apply it inside a transaction.
-3. In the same transaction, insert the ledger row with the journal's `when` as `created_at`
-   and the hash `db:verify-journal` printed for that tag:
+A missing row is not proof the migration never ran. Two states produce the same report and
+need different repairs:
+
+- **The migration never ran** — usually drizzle's high-water-mark skip, the `0129` case
+  above. The objects are absent.
+- **The schema is there, the ledger row is not** — a snapshot or restore, a row lost in an
+  earlier hand repair, a renumber. `boardsesh-dev-db` is in exactly this state for
+  `0187_sad_freak` today (#3978): the tables and types exist, the row does not. The `.sql`
+  files are not idempotent, so applying one here just fails on `… already exists`.
+
+Repair each named tag by hand, in this order:
+
+1. Check whether that migration's objects already exist (`\d <table>`, `\dT <type>`). If they
+   all do, go straight to step 3 and insert only the ledger row.
+2. Otherwise read `packages/db/drizzle/<tag>.sql`, confirm it is safe against the current
+   schema, and apply it inside a transaction. Partial state — some objects present, some not
+   — means trimming the statement list by hand; there is no safe shortcut.
+3. Insert the ledger row (in the same transaction as step 2, when there was one) with the
+   journal's `when` as `created_at` and the hash `db:verify-journal` printed for that tag:
    `INSERT INTO drizzle."__drizzle_migrations" (hash, created_at) VALUES ('<ledger hash>', <when>);`
 4. Re-run `vp run db:verify-journal` to confirm the repair.
 

--- a/docs/db-migrations.md
+++ b/docs/db-migrations.md
@@ -132,7 +132,18 @@ DB_URL=postgres://... vp run db:verify-journal
 
 That is one `SELECT hash FROM drizzle.__drizzle_migrations` plus local file reads — safe to
 point at production, and worth doing before merging anything that touches the migration
-folder, since `migrate` gates both production deploy jobs.
+folder, since `migrate` gates both production deploy jobs. On a gap it prints each missing
+tag with the ledger hash that tag's repair row needs:
+
+```
+❌ 1 of 188 journal migrations have no row in drizzle.__drizzle_migrations (189 rows present).
+   • 0187_sad_freak  (ledger hash 9f2c…)
+```
+
+Take the hash from that output rather than computing a sha256 yourself. The whole reason
+this check calls drizzle's own `readMigrationFiles` is that a re-derived hash drifts on
+encoding, BOM, line endings, or a drizzle change — and a repair row carrying a hash drizzle
+would not have written re-opens the same gap under a different name.
 
 **When it fires.** It does not self-heal, on purpose: several migrations here are data
 backfills whose idempotence hinges on `_bs_migration_guards` semantic keys, so re-running a
@@ -141,9 +152,9 @@ mixed DDL/DML set unattended is worse than a blocked deploy. Repair each named t
 1. Read `packages/db/drizzle/<tag>.sql` and confirm it is safe against the current schema.
 2. Apply it inside a transaction.
 3. In the same transaction, insert the ledger row with the journal's `when` as `created_at`
-   and the same hash drizzle would have written:
-   `INSERT INTO drizzle."__drizzle_migrations" (hash, created_at) VALUES (<sha256 of the .sql body>, <when>);`
-   `vp run db:verify-journal` confirms the repair.
+   and the hash `db:verify-journal` printed for that tag:
+   `INSERT INTO drizzle."__drizzle_migrations" (hash, created_at) VALUES ('<ledger hash>', <when>);`
+4. Re-run `vp run db:verify-journal` to confirm the repair.
 
 Extra ledger rows matching no journal entry are ignored — renumbering leaves those behind
 legitimately, and failing on them would block deploys for benign residue.

--- a/docs/db-migrations.md
+++ b/docs/db-migrations.md
@@ -105,6 +105,49 @@ It deliberately ignores six duplicate numbers that main has carried since 2024
 (`0025`, `0048`–`0052`). Both sides are journalled and applied in production; they order
 correctly by `when` and cannot be fixed now.
 
+### The journal-vs-ledger check (`VERIFY_MIGRATION_JOURNAL=1`)
+
+`check:db-migrations` reads files. It cannot see whether a database actually ran them, and
+one failure mode only shows up there.
+
+Drizzle's applier is a single high-water mark, not a reconciliation. `PgDialect.migrate()`
+reads `max(created_at)` from `drizzle.__drizzle_migrations` **once, before the loop**, and
+applies only journal entries whose `when` is strictly greater. A migration appended with a
+`when` at or below that mark is skipped on that deploy — and on every deploy after it,
+because the mark only ever moves up. Production hit this with `0129_numerous_star_brand`:
+`location_sync_gym_sources` was never created, and the first Kilter location sync days
+later died on `relation "location_sync_gym_sources" does not exist`.
+
+With `VERIFY_MIGRATION_JOURNAL=1`, `packages/db/scripts/migrate.ts` now checks **every**
+journal entry against the ledger, keyed on the migration hash, and throws with the missing
+tags named. `production-deploy.yml` and `db-migration-renumber.yml` both set it. It stays
+opt-in for now because the `boardsesh-dev-db` image is missing `0187_sad_freak`'s ledger
+row, so a default-on check would redden every developer's `vp run db:migrate`.
+
+Run it read-only against any database, without applying anything:
+
+```
+DB_URL=postgres://... vp run db:verify-journal
+```
+
+That is one `SELECT hash FROM drizzle.__drizzle_migrations` plus local file reads — safe to
+point at production, and worth doing before merging anything that touches the migration
+folder, since `migrate` gates both production deploy jobs.
+
+**When it fires.** It does not self-heal, on purpose: several migrations here are data
+backfills whose idempotence hinges on `_bs_migration_guards` semantic keys, so re-running a
+mixed DDL/DML set unattended is worse than a blocked deploy. Repair each named tag by hand:
+
+1. Read `packages/db/drizzle/<tag>.sql` and confirm it is safe against the current schema.
+2. Apply it inside a transaction.
+3. In the same transaction, insert the ledger row with the journal's `when` as `created_at`
+   and the same hash drizzle would have written:
+   `INSERT INTO drizzle."__drizzle_migrations" (hash, created_at) VALUES (<sha256 of the .sql body>, <when>);`
+   `vp run db:verify-journal` confirms the repair.
+
+Extra ledger rows matching no journal entry are ignored — renumbering leaves those behind
+legitimately, and failing on them would block deploys for benign residue.
+
 ## Why the schema barrel is union-merged
 
 `.gitattributes` marks `packages/db/src/schema/**/index.ts` as `merge=union`. The file is

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -72,6 +72,8 @@
     "db:migrate": "bun scripts/migrate.ts",
     "test": "tsx --test scripts/**/*.test.ts src/**/*.test.ts",
     "test:explain": "tsx --test src/queries/climbs/__tests__/search-climbs-explain.integration.test.ts",
+    "test:migration-journal": "tsx --test scripts/migration-journal-verification.integration.test.ts",
+    "db:verify-journal": "tsx scripts/verify-migration-journal.ts",
     "db:studio": "drizzle-kit studio",
     "db:import-moonboard": "tsx scripts/import-moonboard-problems.ts",
     "db:import-moonboard-2024": "tsx scripts/import-moonboard-2024.ts",

--- a/packages/db/scripts/migrate.ts
+++ b/packages/db/scripts/migrate.ts
@@ -3,24 +3,15 @@ import { migrate } from 'drizzle-orm/postgres-js/migrator';
 import postgres from 'postgres';
 import { config } from 'dotenv';
 import path from 'path';
-import fs from 'fs';
 import { fileURLToPath } from 'url';
+import {
+  DRIZZLE_MIGRATIONS_FOLDER,
+  assertMigrationJournalApplied,
+  readExpectedMigrations,
+  readLedgerHashesWith,
+} from './migration-journal.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-type MigrationJournalEntry = {
-  tag: string;
-  when: number;
-};
-
-type MigrationJournal = {
-  entries: MigrationJournalEntry[];
-};
-
-type LatestAppliedMigrationRow = {
-  latestCreatedAt: number | string | bigint | null;
-  appliedMigrationCount: number | string | bigint | null;
-};
 
 // Load environment files (same as drizzle.config.ts)
 config({ path: path.resolve(__dirname, '../../../.boardsesh/dev-db.env') });
@@ -68,47 +59,30 @@ async function runMigrations() {
       },
     });
 
-    const migrationsFolder = path.resolve(__dirname, '../drizzle');
-    const journalPath = path.join(migrationsFolder, 'meta', '_journal.json');
-    const journal = JSON.parse(fs.readFileSync(journalPath, 'utf-8')) as MigrationJournal;
-    const latestJournalEntry = journal.entries.reduce<MigrationJournalEntry | null>(
-      (latestEntry, entry) => (!latestEntry || entry.when > latestEntry.when ? entry : latestEntry),
-      null,
-    );
-    if (!latestJournalEntry) {
+    const migrationsFolder = DRIZZLE_MIGRATIONS_FOLDER;
+    const expectedMigrations = readExpectedMigrations(migrationsFolder);
+    if (expectedMigrations.length === 0) {
       throw new Error('Migration journal is empty');
     }
-    console.info(`📋 Found ${journal.entries.length} migrations in journal`);
+    console.info(`📋 Found ${expectedMigrations.length} migrations in journal`);
 
     await migrate(db, { migrationsFolder });
 
+    // Per-entry, hash-keyed verification (#2933). The old check asserted
+    // `max(created_at) >= the newest journal entry's when`, which is exactly the
+    // one condition a below-the-high-water-mark gap cannot violate, and the
+    // count mismatch that *would* have caught it was a console.warn. See
+    // scripts/lib/migration-ledger.ts for the mechanism.
+    //
+    // Still behind the env gate: the boardsesh-dev-db image is missing
+    // 0187_sad_freak's ledger row, so a default-on check would redden every
+    // developer's `vp run db:migrate` today. Both places that matter
+    // (production-deploy.yml, db-migration-renumber.yml) already set it.
     if (process.env.VERIFY_MIGRATION_JOURNAL === '1') {
-      const appliedMigrationRows = await client<LatestAppliedMigrationRow[]>`
-      SELECT
-        MAX(created_at)::bigint AS "latestCreatedAt",
-        COUNT(*)::int AS "appliedMigrationCount"
-      FROM drizzle."__drizzle_migrations"
-    `;
-      const latestAppliedCreatedAt = Number(appliedMigrationRows[0]?.latestCreatedAt ?? 0);
-      const appliedMigrationCount = Number(appliedMigrationRows[0]?.appliedMigrationCount ?? 0);
-
-      if (latestAppliedCreatedAt < latestJournalEntry.when) {
-        throw new Error(
-          `Latest migration verification failed: database latest created_at is ${latestAppliedCreatedAt}, ` +
-            `but bundled latest migration ${latestJournalEntry.tag} has created_at ${latestJournalEntry.when}.`,
-        );
-      }
-
-      if (appliedMigrationCount !== journal.entries.length) {
-        console.warn(
-          `⚠️ Migration table has ${appliedMigrationCount} rows for ${journal.entries.length} journal entries; ` +
-            `continuing because latest migration ${latestJournalEntry.tag} is applied.`,
-        );
-      }
-
+      const report = await assertMigrationJournalApplied(readLedgerHashesWith(client), migrationsFolder);
       console.info(
-        `✅ Verified latest migration ${latestJournalEntry.tag} is applied ` +
-          `(created_at ${latestAppliedCreatedAt}; ${appliedMigrationCount}/${journal.entries.length} rows recorded)`,
+        `✅ Verified all ${report.expectedCount} journal migrations are recorded ` +
+          `(${report.ledgerCount} ledger rows)`,
       );
     }
 

--- a/packages/db/scripts/migrate.ts
+++ b/packages/db/scripts/migrate.ts
@@ -6,9 +6,9 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import {
   DRIZZLE_MIGRATIONS_FOLDER,
-  assertMigrationJournalApplied,
   readExpectedMigrations,
   readLedgerHashesWith,
+  runMigrationJournalGate,
 } from './migration-journal.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -77,9 +77,11 @@ async function runMigrations() {
     // Still behind the env gate: the boardsesh-dev-db image is missing
     // 0187_sad_freak's ledger row, so a default-on check would redden every
     // developer's `vp run db:migrate` today. Both places that matter
-    // (production-deploy.yml, db-migration-renumber.yml) already set it.
-    if (process.env.VERIFY_MIGRATION_JOURNAL === '1') {
-      const report = await assertMigrationJournalApplied(readLedgerHashesWith(client), migrationsFolder);
+    // (production-deploy.yml, db-migration-renumber.yml) already set it. The
+    // gate itself is `runMigrationJournalGate` so it has test coverage; this
+    // file connects on import and offers no seam of its own.
+    const report = await runMigrationJournalGate(process.env, readLedgerHashesWith(client), migrationsFolder);
+    if (report) {
       console.info(
         `✅ Verified all ${report.expectedCount} journal migrations are recorded ` +
           `(${report.ledgerCount} ledger rows)`,

--- a/packages/db/scripts/migration-journal-verification.integration.test.ts
+++ b/packages/db/scripts/migration-journal-verification.integration.test.ts
@@ -269,6 +269,14 @@ describe('migration journal verification (#2933)', () => {
       inspectMigrationJournal(readLedgerHashesWith(client), migrationsFolder),
     );
     assert.deepEqual(afterRerun.missingTags, ['0000_a'], 'a re-run is expected not to restore the deleted row');
+
+    // The repair needs the hash, not just the tag: re-deriving a sha256 by hand
+    // is the parity liability this whole check exists to avoid.
+    assert.deepEqual(
+      afterDeletion.missing.map((migration) => migration.tag),
+      ['0000_a'],
+    );
+    assert.equal(afterDeletion.missing[0].hash, firstEntryHash);
   });
 
   it('ignores ledger rows that belong to no journal entry', async (context) => {
@@ -296,6 +304,36 @@ describe('migration journal verification (#2933)', () => {
     );
     assert.deepEqual(report.missingTags, []);
     assert.equal(report.ledgerCount, 3);
+  });
+
+  it('refuses to pair tags with hashes when drizzle stops returning journal order', () => {
+    // No database needed. The ordering guard cannot be tripped from outside —
+    // drizzle reads the same journal we do, so folderMillis always matches —
+    // hence the injected reader. This pins the behaviour a future drizzle that
+    // reorders or filters readMigrationFiles would hit: throw, never silently
+    // attach the wrong tag to a hash.
+    const migrationsFolder = makeTempFolder('ordering');
+    writeMigrationsFolder(migrationsFolder, PHASE_ONE);
+
+    const inOrder = readExpectedMigrations(migrationsFolder);
+    assert.deepEqual(
+      inOrder.map((migration) => migration.tag),
+      ['0000_a', '0001_b'],
+    );
+
+    assert.throws(
+      () =>
+        readExpectedMigrations(migrationsFolder, () => [
+          { folderMillis: 3000, hash: 'hash-of-0001_b' },
+          { folderMillis: 1000, hash: 'hash-of-0000_a' },
+        ]),
+      /no longer returns journal order/,
+    );
+
+    assert.throws(
+      () => readExpectedMigrations(migrationsFolder, () => [{ folderMillis: 1000, hash: 'hash-of-0000_a' }]),
+      /drizzle read 1 migration files for 2 journal entries/,
+    );
   });
 
   it('keeps findUnappliedMigrations multiset-aware for byte-identical migrations', () => {

--- a/packages/db/scripts/migration-journal-verification.integration.test.ts
+++ b/packages/db/scripts/migration-journal-verification.integration.test.ts
@@ -26,7 +26,13 @@ import postgres from 'postgres';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import { migrate } from 'drizzle-orm/postgres-js/migrator';
 import { findUnappliedMigrations } from '../../../scripts/lib/migration-ledger.js';
-import { inspectMigrationJournal, readExpectedMigrations, readLedgerHashesWith } from './migration-journal.js';
+import {
+  assertMigrationJournalApplied,
+  inspectMigrationJournal,
+  readExpectedMigrations,
+  readLedgerHashesWith,
+  runMigrationJournalGate,
+} from './migration-journal.js';
 
 type ScratchJournalEntry = { idx: number; version: string; when: number; tag: string; breakpoints: boolean };
 
@@ -188,6 +194,20 @@ describe('migration journal verification (#2933)', () => {
     assert.deepEqual(report.missingTags, [], 'a fully applied database must not trip the deploy gate');
     assert.equal(report.expectedCount, 2);
     assert.equal(report.ledgerCount, 2);
+
+    // The gate must also be incapable of failing closed on a healthy database:
+    // `migrate` is the `needs:` gate for both production deploy jobs, so a
+    // false positive here stops every release.
+    await assert.doesNotReject(
+      withScratchClient(scratchUrl, (client) =>
+        assertMigrationJournalApplied(readLedgerHashesWith(client), migrationsFolder),
+      ),
+    );
+    await assert.doesNotReject(
+      withScratchClient(scratchUrl, (client) =>
+        runMigrationJournalGate({ VERIFY_MIGRATION_JOURNAL: '1' }, readLedgerHashesWith(client), migrationsFolder),
+      ),
+    );
   });
 
   it('catches the migration drizzle skips below its created_at high-water mark', async (context) => {
@@ -235,6 +255,41 @@ describe('migration journal verification (#2933)', () => {
     assert.equal(ledgerCount, 2);
 
     assert.deepEqual(missingTags, ['0002_stale_when'], 'the per-entry check must name the skipped migration');
+
+    // Detecting the gap is not the fix — failing on it is. These two pin the
+    // fail-closed behaviour #2933 asks for, so the check cannot be quietly
+    // downgraded back to "report it and deploy anyway".
+    await assert.rejects(
+      withScratchClient(scratchUrl, (client) =>
+        assertMigrationJournalApplied(readLedgerHashesWith(client), migrationsFolder),
+      ),
+      /Migration journal verification failed:[\s\S]*0002_stale_when/,
+    );
+    await assert.rejects(
+      withScratchClient(scratchUrl, (client) =>
+        runMigrationJournalGate({ VERIFY_MIGRATION_JOURNAL: '1' }, readLedgerHashesWith(client), migrationsFolder),
+      ),
+      /0002_stale_when/,
+      'migrate.ts runs the check through runMigrationJournalGate — it must throw, not report',
+    );
+
+    // Gate off: the same broken database passes untouched. That is what keeps
+    // `vp run db:migrate` usable against the dev-db image (#3978) — and it must
+    // not read the ledger at all, so a future default-on flip is a visible change.
+    let ledgerReads = 0;
+    const gateOff = await withScratchClient(scratchUrl, (client) => {
+      const readHashes = readLedgerHashesWith(client);
+      return runMigrationJournalGate(
+        {},
+        () => {
+          ledgerReads += 1;
+          return readHashes();
+        },
+        migrationsFolder,
+      );
+    });
+    assert.equal(gateOff, null, 'an unset VERIFY_MIGRATION_JOURNAL must skip the check');
+    assert.equal(ledgerReads, 0, 'the gate must not query the ledger when it is off');
 
     // And it never self-heals: a third deploy does not create the table either.
     await applyMigrations(scratchUrl, migrationsFolder);
@@ -333,6 +388,30 @@ describe('migration journal verification (#2933)', () => {
     assert.throws(
       () => readExpectedMigrations(migrationsFolder, () => [{ folderMillis: 1000, hash: 'hash-of-0000_a' }]),
       /drizzle read 1 migration files for 2 journal entries/,
+    );
+  });
+
+  it('only arms the deploy gate on an exact VERIFY_MIGRATION_JOURNAL=1', async () => {
+    // No database needed: the ledger reader is a stub, so this pins the env
+    // contract on its own. `production-deploy.yml` and `db-migration-renumber.yml`
+    // both pass the literal '1'; anything else must leave the check off rather
+    // than half-on.
+    const migrationsFolder = makeTempFolder('gate');
+    writeMigrationsFolder(migrationsFolder, PHASE_ONE);
+    const emptyLedger = async () => [];
+
+    for (const value of [undefined, '', '0', 'true', 'yes']) {
+      const report = await runMigrationJournalGate(
+        value === undefined ? {} : { VERIFY_MIGRATION_JOURNAL: value },
+        emptyLedger,
+        migrationsFolder,
+      );
+      assert.equal(report, null, `VERIFY_MIGRATION_JOURNAL=${String(value)} must not arm the gate`);
+    }
+
+    await assert.rejects(
+      runMigrationJournalGate({ VERIFY_MIGRATION_JOURNAL: '1' }, emptyLedger, migrationsFolder),
+      /Missing: 0000_a, 0001_b/,
     );
   });
 

--- a/packages/db/scripts/migration-journal-verification.integration.test.ts
+++ b/packages/db/scripts/migration-journal-verification.integration.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Real-database regression coverage for #2933.
+ *
+ * Drizzle's applier is a single high-water mark: `PgDialect.migrate()` snapshots
+ * `max(created_at)` from `drizzle.__drizzle_migrations` once, before the loop,
+ * and applies only journal entries whose `when` is strictly greater. A migration
+ * appended with a `when` at or below that mark is skipped on that deploy and on
+ * every deploy after it. Production hit exactly this with
+ * `0129_numerous_star_brand`, and `migrate.ts`'s old latest-only assertion stayed
+ * green through it.
+ *
+ * These tests drive drizzle's real `migrate()` against a throwaway database, so
+ * the skip behaviour is observed rather than assumed, and the hash parity is
+ * asserted against the rows drizzle itself INSERTed (not against a re-derived
+ * sha256, which would be a tautology).
+ *
+ * Skips unless DATABASE_URL points at a local Postgres. It never touches the
+ * shared dev database: every scenario creates and drops its own database.
+ */
+import { after, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { migrate } from 'drizzle-orm/postgres-js/migrator';
+import { findUnappliedMigrations } from '../../../scripts/lib/migration-ledger.js';
+import { inspectMigrationJournal, readExpectedMigrations, readLedgerHashesWith } from './migration-journal.js';
+
+type ScratchJournalEntry = { idx: number; version: string; when: number; tag: string; breakpoints: boolean };
+
+const LOCAL_HOSTNAMES = ['localhost', '127.0.0.1', 'postgres'];
+
+function localDatabaseUrl(): string | null {
+  const databaseUrl = process.env.MIGRATION_JOURNAL_DB_URL ?? process.env.DATABASE_URL;
+  let resolved: string | null = null;
+  if (databaseUrl) {
+    try {
+      const hostname = new URL(databaseUrl).hostname.toLowerCase();
+      resolved = LOCAL_HOSTNAMES.includes(hostname) ? databaseUrl : null;
+    } catch {
+      resolved = null;
+    }
+  }
+  // Skipping is the right local default, but a silent skip in CI is a false
+  // green — the job exists precisely to run these against a real database.
+  if (!resolved && process.env.CI) {
+    throw new Error(
+      'CI is set but no local Postgres URL is available: set MIGRATION_JOURNAL_DB_URL (or DATABASE_URL) ' +
+        `to a host in ${LOCAL_HOSTNAMES.join(', ')}.`,
+    );
+  }
+  return resolved;
+}
+
+/** Writes a v7 drizzle migrations folder with exactly `entries` in it. */
+function writeMigrationsFolder(folder: string, entries: readonly { tag: string; when: number; sql: string }[]): void {
+  fs.mkdirSync(path.join(folder, 'meta'), { recursive: true });
+  const journalEntries: ScratchJournalEntry[] = entries.map((entry, idx) => ({
+    idx,
+    version: '7',
+    when: entry.when,
+    tag: entry.tag,
+    breakpoints: true,
+  }));
+  fs.writeFileSync(
+    path.join(folder, 'meta', '_journal.json'),
+    JSON.stringify({ version: '7', dialect: 'postgresql', entries: journalEntries }, null, 2),
+  );
+  for (const entry of entries) {
+    fs.writeFileSync(path.join(folder, `${entry.tag}.sql`), entry.sql);
+  }
+}
+
+const createdDatabases: { adminUrl: string; databaseName: string }[] = [];
+
+/** Creates a throwaway database next to `adminUrl` and returns a URL for it. */
+async function createScratchDatabase(adminUrl: string, label: string): Promise<string> {
+  const databaseName = `bs_mjv_${label}_${process.pid}_${Math.floor(Math.random() * 1e6)}`;
+  const admin = postgres(adminUrl, { max: 1 });
+  try {
+    await admin.unsafe(`DROP DATABASE IF EXISTS "${databaseName}"`);
+    await admin.unsafe(`CREATE DATABASE "${databaseName}"`);
+  } finally {
+    await admin.end().catch(() => {});
+  }
+  createdDatabases.push({ adminUrl, databaseName });
+  const scratchUrl = new URL(adminUrl);
+  scratchUrl.pathname = `/${databaseName}`;
+  return scratchUrl.toString();
+}
+
+after(async () => {
+  for (const { adminUrl, databaseName } of createdDatabases) {
+    const admin = postgres(adminUrl, { max: 1 });
+    try {
+      await admin.unsafe(`DROP DATABASE IF EXISTS "${databaseName}" WITH (FORCE)`);
+    } catch {
+      // Best effort: a leaked scratch database is noise, not a test failure.
+    } finally {
+      await admin.end().catch(() => {});
+    }
+  }
+});
+
+async function applyMigrations(scratchUrl: string, migrationsFolder: string): Promise<void> {
+  const client = postgres(scratchUrl, { max: 1 });
+  try {
+    await migrate(drizzle(client), { migrationsFolder });
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+async function withScratchClient<T>(scratchUrl: string, run: (client: postgres.Sql) => Promise<T>): Promise<T> {
+  const client = postgres(scratchUrl, { max: 1 });
+  try {
+    return await run(client);
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+async function tableExists(scratchUrl: string, tableName: string): Promise<boolean> {
+  return withScratchClient(scratchUrl, async (client) => {
+    const rows = await client<
+      { present: string | null }[]
+    >`SELECT to_regclass(${`public.${tableName}`})::text AS present`;
+    return rows[0]?.present != null;
+  });
+}
+
+function makeTempFolder(label: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `bs-mjv-${label}-`));
+}
+
+const PHASE_ONE = [
+  { tag: '0000_a', when: 1000, sql: 'CREATE TABLE mjv_t_a (id int);' },
+  { tag: '0001_b', when: 3000, sql: 'CREATE TABLE mjv_t_b (id int);' },
+];
+// The bug in one line: appended later, but `when` sits below 0001_b's 3000.
+const STALE_WHEN_ENTRY = { tag: '0002_stale_when', when: 2000, sql: 'CREATE TABLE mjv_t_stale (id int);' };
+
+describe('migration journal verification (#2933)', () => {
+  it('matches the hashes drizzle itself writes to the ledger', async (context) => {
+    const adminUrl = localDatabaseUrl();
+    if (!adminUrl) {
+      context.skip('set DATABASE_URL to a local Postgres to run');
+      return;
+    }
+    // Non-tautological on purpose: this compares readExpectedMigrations' hashes
+    // against the rows drizzle's own migrate() INSERTed, so a future drizzle
+    // version changing how the ledger hash is computed turns this red instead of
+    // turning the production deploy gate into a false positive.
+    const migrationsFolder = makeTempFolder('parity');
+    writeMigrationsFolder(migrationsFolder, [...PHASE_ONE, STALE_WHEN_ENTRY]);
+    const scratchUrl = await createScratchDatabase(adminUrl, 'parity');
+
+    await applyMigrations(scratchUrl, migrationsFolder);
+
+    const expected = readExpectedMigrations(migrationsFolder);
+    const ledgerHashes = await withScratchClient(scratchUrl, (client) => readLedgerHashesWith(client)());
+    assert.equal(expected.length, 3);
+    for (const migration of expected) {
+      assert.ok(
+        ledgerHashes.includes(migration.hash),
+        `drizzle recorded no ledger row matching ${migration.tag}'s hash`,
+      );
+    }
+  });
+
+  it('reports a healthy database as complete', async (context) => {
+    const adminUrl = localDatabaseUrl();
+    if (!adminUrl) {
+      context.skip('set DATABASE_URL to a local Postgres to run');
+      return;
+    }
+    const migrationsFolder = makeTempFolder('healthy');
+    writeMigrationsFolder(migrationsFolder, PHASE_ONE);
+    const scratchUrl = await createScratchDatabase(adminUrl, 'healthy');
+
+    await applyMigrations(scratchUrl, migrationsFolder);
+
+    const report = await withScratchClient(scratchUrl, (client) =>
+      inspectMigrationJournal(readLedgerHashesWith(client), migrationsFolder),
+    );
+    assert.deepEqual(report.missingTags, [], 'a fully applied database must not trip the deploy gate');
+    assert.equal(report.expectedCount, 2);
+    assert.equal(report.ledgerCount, 2);
+  });
+
+  it('catches the migration drizzle skips below its created_at high-water mark', async (context) => {
+    const adminUrl = localDatabaseUrl();
+    if (!adminUrl) {
+      context.skip('set DATABASE_URL to a local Postgres to run');
+      return;
+    }
+    const migrationsFolder = makeTempFolder('gap');
+    const scratchUrl = await createScratchDatabase(adminUrl, 'gap');
+
+    // Deploy 1: journal ends at when=3000.
+    writeMigrationsFolder(migrationsFolder, PHASE_ONE);
+    await applyMigrations(scratchUrl, migrationsFolder);
+
+    // Deploy 2: a third migration lands with when=2000, below the mark.
+    writeMigrationsFolder(migrationsFolder, [...PHASE_ONE, STALE_WHEN_ENTRY]);
+    await applyMigrations(scratchUrl, migrationsFolder);
+
+    assert.equal(await tableExists(scratchUrl, 'mjv_t_a'), true);
+    assert.equal(await tableExists(scratchUrl, 'mjv_t_b'), true);
+    assert.equal(
+      await tableExists(scratchUrl, 'mjv_t_stale'),
+      false,
+      'drizzle is expected to skip the below-high-water-mark migration',
+    );
+
+    const { latestCreatedAt, ledgerCount, missingTags } = await withScratchClient(scratchUrl, async (client) => {
+      const rows = await client<{ latestCreatedAt: string | null; ledgerCount: number }[]>`
+        SELECT MAX(created_at)::bigint AS "latestCreatedAt", COUNT(*)::int AS "ledgerCount"
+        FROM drizzle."__drizzle_migrations"
+      `;
+      const report = await inspectMigrationJournal(readLedgerHashesWith(client), migrationsFolder);
+      return {
+        latestCreatedAt: Number(rows[0]?.latestCreatedAt ?? 0),
+        ledgerCount: Number(rows[0]?.ledgerCount ?? 0),
+        missingTags: report.missingTags,
+      };
+    });
+
+    // main's old assertion: max(created_at) >= the newest journal `when`. It
+    // passes here, which is the whole reason the gap shipped to production.
+    const newestJournalWhen = Math.max(...[...PHASE_ONE, STALE_WHEN_ENTRY].map((entry) => entry.when));
+    assert.equal(latestCreatedAt >= newestJournalWhen, true, 'the old latest-only check is expected to pass');
+    assert.equal(ledgerCount, 2);
+
+    assert.deepEqual(missingTags, ['0002_stale_when'], 'the per-entry check must name the skipped migration');
+
+    // And it never self-heals: a third deploy does not create the table either.
+    await applyMigrations(scratchUrl, migrationsFolder);
+    assert.equal(await tableExists(scratchUrl, 'mjv_t_stale'), false, 'a later deploy is expected not to self-heal');
+  });
+
+  it('catches a ledger row deleted out from under a fully applied database', async (context) => {
+    const adminUrl = localDatabaseUrl();
+    if (!adminUrl) {
+      context.skip('set DATABASE_URL to a local Postgres to run');
+      return;
+    }
+    const migrationsFolder = makeTempFolder('deleted');
+    writeMigrationsFolder(migrationsFolder, PHASE_ONE);
+    const scratchUrl = await createScratchDatabase(adminUrl, 'deleted');
+    await applyMigrations(scratchUrl, migrationsFolder);
+
+    const expected = readExpectedMigrations(migrationsFolder);
+    const firstEntryHash = expected[0].hash;
+    await withScratchClient(scratchUrl, async (client) => {
+      await client`DELETE FROM drizzle."__drizzle_migrations" WHERE hash = ${firstEntryHash}`;
+    });
+
+    const afterDeletion = await withScratchClient(scratchUrl, (client) =>
+      inspectMigrationJournal(readLedgerHashesWith(client), migrationsFolder),
+    );
+    assert.deepEqual(afterDeletion.missingTags, ['0000_a']);
+
+    // migrate() does not restore it — the high-water mark is still at 3000.
+    await applyMigrations(scratchUrl, migrationsFolder);
+    const afterRerun = await withScratchClient(scratchUrl, (client) =>
+      inspectMigrationJournal(readLedgerHashesWith(client), migrationsFolder),
+    );
+    assert.deepEqual(afterRerun.missingTags, ['0000_a'], 'a re-run is expected not to restore the deleted row');
+  });
+
+  it('ignores ledger rows that belong to no journal entry', async (context) => {
+    const adminUrl = localDatabaseUrl();
+    if (!adminUrl) {
+      context.skip('set DATABASE_URL to a local Postgres to run');
+      return;
+    }
+    // Renumbering leaves orphan rows behind (two on the shared dev database).
+    // Failing on those would block deploys for benign residue.
+    const migrationsFolder = makeTempFolder('orphan');
+    writeMigrationsFolder(migrationsFolder, PHASE_ONE);
+    const scratchUrl = await createScratchDatabase(adminUrl, 'orphan');
+    await applyMigrations(scratchUrl, migrationsFolder);
+
+    await withScratchClient(scratchUrl, async (client) => {
+      await client`
+        INSERT INTO drizzle."__drizzle_migrations" (hash, created_at)
+        VALUES (${'hash-of-a-renumbered-away-migration'}, ${500})
+      `;
+    });
+
+    const report = await withScratchClient(scratchUrl, (client) =>
+      inspectMigrationJournal(readLedgerHashesWith(client), migrationsFolder),
+    );
+    assert.deepEqual(report.missingTags, []);
+    assert.equal(report.ledgerCount, 3);
+  });
+
+  it('keeps findUnappliedMigrations multiset-aware for byte-identical migrations', () => {
+    // No database needed; pins the property the real folder could regain via a
+    // renumber that copies a .sql file without deleting the original.
+    const duplicate = 'identical-sql-body';
+    assert.deepEqual(
+      findUnappliedMigrations(
+        [
+          { tag: '0000_original', hash: duplicate },
+          { tag: '0001_copy', hash: duplicate },
+        ],
+        [duplicate],
+      ),
+      ['0001_copy'],
+    );
+  });
+});

--- a/packages/db/scripts/migration-journal.ts
+++ b/packages/db/scripts/migration-journal.ts
@@ -66,12 +66,19 @@ export interface MigrationJournalReport {
  * journal entry, and each file's `folderMillis` equal to that entry's `when`. A
  * drizzle version that reordered or filtered `readMigrationFiles` would throw
  * here instead of quietly attaching the wrong tag to a hash.
+ *
+ * Both invariants are unreachable against drizzle 0.45.x: `readMigrationFiles`
+ * iterates `journal.entries` in order, pushes exactly one entry per journal
+ * entry (or throws `No file ... found`), and copies `folderMillis` straight from
+ * `journalEntry.when` — the same journal this function parses. They are a
+ * tripwire for a future drizzle bump, not a live guard, which is why the
+ * `readFiles` seam exists at all: without it there is nothing to test.
  */
 export function readExpectedMigrations(
   migrationsFolder: string = DRIZZLE_MIGRATIONS_FOLDER,
-  // Seam for the ordering guard's own test: the two invariants below compare
-  // drizzle's output against the journal, and since drizzle reads that same
-  // journal there is no way to misalign them from the outside.
+  // Seam for the ordering guard's own test (see above). No production caller
+  // passes this — drizzle reads the same journal we do, so the invariants
+  // cannot be misaligned from the outside.
   readFiles: (config: {
     migrationsFolder: string;
   }) => readonly { folderMillis: number; hash: string }[] = readMigrationFiles,
@@ -128,4 +135,31 @@ export async function assertMigrationJournalApplied(
     throw new Error(formatMigrationGapError(report.missingTags, report.expectedCount, report.ledgerCount));
   }
   return report;
+}
+
+/** Env var that turns the deploy gate on. Set by production-deploy.yml and db-migration-renumber.yml. */
+export const VERIFY_MIGRATION_JOURNAL_ENV = 'VERIFY_MIGRATION_JOURNAL';
+
+/**
+ * The deploy gate exactly as `migrate.ts` runs it: verify when
+ * `VERIFY_MIGRATION_JOURNAL=1`, otherwise do nothing and touch no database.
+ *
+ * This lives here rather than inline in `migrate.ts` so the fail-closed
+ * behaviour — the whole point of #2933 — is reachable from a test. `migrate.ts`
+ * is a top-level script that connects on import and has no seam, so an inline
+ * gate would be uncovered: swapping the throwing check for the reporting one
+ * would restore the pre-fix "detect the gap, log it, deploy anyway" semantics
+ * with the suite still green.
+ *
+ * Returns the report when the gate ran, `null` when it was off.
+ */
+export async function runMigrationJournalGate(
+  env: Record<string, string | undefined>,
+  readLedgerHashes: ReadLedgerHashes,
+  migrationsFolder: string = DRIZZLE_MIGRATIONS_FOLDER,
+): Promise<MigrationJournalReport | null> {
+  if (env[VERIFY_MIGRATION_JOURNAL_ENV] !== '1') {
+    return null;
+  }
+  return assertMigrationJournalApplied(readLedgerHashes, migrationsFolder);
 }

--- a/packages/db/scripts/migration-journal.ts
+++ b/packages/db/scripts/migration-journal.ts
@@ -41,6 +41,13 @@ export interface MigrationJournalReport {
   ledgerCount: number;
   /** Journal-order tags with no ledger row. Empty means the database is complete. */
   missingTags: string[];
+  /**
+   * The same gap with each tag's hash attached. The repair inserts a ledger row
+   * carrying that hash, and re-deriving the sha256 by hand is exactly the parity
+   * liability this module exists to avoid — so the operator is handed the hash
+   * drizzle would have written rather than told to compute one.
+   */
+  missing: ExpectedMigration[];
 }
 
 /**
@@ -60,10 +67,18 @@ export interface MigrationJournalReport {
  * drizzle version that reordered or filtered `readMigrationFiles` would throw
  * here instead of quietly attaching the wrong tag to a hash.
  */
-export function readExpectedMigrations(migrationsFolder: string = DRIZZLE_MIGRATIONS_FOLDER): ExpectedMigration[] {
+export function readExpectedMigrations(
+  migrationsFolder: string = DRIZZLE_MIGRATIONS_FOLDER,
+  // Seam for the ordering guard's own test: the two invariants below compare
+  // drizzle's output against the journal, and since drizzle reads that same
+  // journal there is no way to misalign them from the outside.
+  readFiles: (config: {
+    migrationsFolder: string;
+  }) => readonly { folderMillis: number; hash: string }[] = readMigrationFiles,
+): ExpectedMigration[] {
   const journalPath = path.join(migrationsFolder, 'meta', '_journal.json');
   const journal = JSON.parse(fs.readFileSync(journalPath, 'utf-8')) as MigrationJournal;
-  const migrationFiles = readMigrationFiles({ migrationsFolder });
+  const migrationFiles = readFiles({ migrationsFolder });
   if (migrationFiles.length !== journal.entries.length) {
     throw new Error(
       `Migration journal verification failed: drizzle read ${migrationFiles.length} migration files ` +
@@ -93,10 +108,13 @@ export async function inspectMigrationJournal(
 ): Promise<MigrationJournalReport> {
   const expected = readExpectedMigrations(migrationsFolder);
   const ledgerHashes = await readLedgerHashes();
+  const missingTags = findUnappliedMigrations(expected, ledgerHashes);
+  const missingTagSet = new Set(missingTags);
   return {
     expectedCount: expected.length,
     ledgerCount: ledgerHashes.length,
-    missingTags: findUnappliedMigrations(expected, ledgerHashes),
+    missingTags,
+    missing: expected.filter((migration) => missingTagSet.has(migration.tag)),
   };
 }
 

--- a/packages/db/scripts/migration-journal.ts
+++ b/packages/db/scripts/migration-journal.ts
@@ -1,0 +1,99 @@
+import { readMigrationFiles } from 'drizzle-orm/migrator';
+import type { Sql } from 'postgres';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  findUnappliedMigrations,
+  formatMigrationGapError,
+  type ExpectedMigration,
+} from '../../../scripts/lib/migration-ledger.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** The drizzle folder `migrate.ts` applies and `verify-migration-journal.ts` checks. */
+export const DRIZZLE_MIGRATIONS_FOLDER = path.resolve(__dirname, '../drizzle');
+
+type MigrationJournalEntry = { tag: string; when: number };
+type MigrationJournal = { entries: MigrationJournalEntry[] };
+
+/**
+ * Injected read of `drizzle."__drizzle_migrations"`. A function rather than a
+ * client so the integration test can point the same check at a throwaway
+ * database, and so nothing here owns a connection.
+ */
+export type ReadLedgerHashes = () => Promise<readonly string[]>;
+
+/**
+ * The one query this check runs against a real database. A single SELECT on
+ * drizzle's own bookkeeping table — no writes, nothing schema-dependent — which
+ * is what makes `verify-migration-journal.ts` safe to point at production.
+ */
+export function readLedgerHashesWith(client: Sql): ReadLedgerHashes {
+  return async () => {
+    const rows = await client<{ hash: string }[]>`SELECT hash FROM drizzle."__drizzle_migrations"`;
+    return rows.map((row) => row.hash);
+  };
+}
+
+export interface MigrationJournalReport {
+  expectedCount: number;
+  ledgerCount: number;
+  /** Journal-order tags with no ledger row. Empty means the database is complete. */
+  missingTags: string[];
+}
+
+/**
+ * Journal entries paired with the hash drizzle records for each one.
+ *
+ * The hashes come from drizzle's own exported `readMigrationFiles` rather than a
+ * re-derived sha256: any re-derivation is a permanent parity liability (file
+ * encoding, BOM, line endings, or a future drizzle change all silently turn this
+ * deploy gate into a false positive). `readMigrationFiles` walks
+ * `journal.entries` in order and returns one entry per journal entry, so zipping
+ * it back against the journal by index is exact — same file, same parse.
+ */
+export function readExpectedMigrations(migrationsFolder: string = DRIZZLE_MIGRATIONS_FOLDER): ExpectedMigration[] {
+  const journalPath = path.join(migrationsFolder, 'meta', '_journal.json');
+  const journal = JSON.parse(fs.readFileSync(journalPath, 'utf-8')) as MigrationJournal;
+  const migrationFiles = readMigrationFiles({ migrationsFolder });
+  if (migrationFiles.length !== journal.entries.length) {
+    throw new Error(
+      `Migration journal verification failed: drizzle read ${migrationFiles.length} migration files ` +
+        `for ${journal.entries.length} journal entries in ${migrationsFolder}.`,
+    );
+  }
+  return migrationFiles.map((migrationFile, index) => ({
+    tag: journal.entries[index].tag,
+    hash: migrationFile.hash,
+  }));
+}
+
+/**
+ * Read-only: one `SELECT hash FROM drizzle."__drizzle_migrations"` plus local
+ * file reads. Safe to point at production.
+ */
+export async function inspectMigrationJournal(
+  readLedgerHashes: ReadLedgerHashes,
+  migrationsFolder: string = DRIZZLE_MIGRATIONS_FOLDER,
+): Promise<MigrationJournalReport> {
+  const expected = readExpectedMigrations(migrationsFolder);
+  const ledgerHashes = await readLedgerHashes();
+  return {
+    expectedCount: expected.length,
+    ledgerCount: ledgerHashes.length,
+    missingTags: findUnappliedMigrations(expected, ledgerHashes),
+  };
+}
+
+/** Throws with every missing tag named, or returns the (clean) report. */
+export async function assertMigrationJournalApplied(
+  readLedgerHashes: ReadLedgerHashes,
+  migrationsFolder: string = DRIZZLE_MIGRATIONS_FOLDER,
+): Promise<MigrationJournalReport> {
+  const report = await inspectMigrationJournal(readLedgerHashes, migrationsFolder);
+  if (report.missingTags.length > 0) {
+    throw new Error(formatMigrationGapError(report.missingTags, report.expectedCount, report.ledgerCount));
+  }
+  return report;
+}

--- a/packages/db/scripts/migration-journal.ts
+++ b/packages/db/scripts/migration-journal.ts
@@ -52,6 +52,13 @@ export interface MigrationJournalReport {
  * deploy gate into a false positive). `readMigrationFiles` walks
  * `journal.entries` in order and returns one entry per journal entry, so zipping
  * it back against the journal by index is exact — same file, same parse.
+ *
+ * `MigrationMeta` carries no `tag`, so the index zip is the only join available,
+ * and it rests on drizzle's iteration order. Rather than trust that silently,
+ * both invariants that would break the pairing are checked below: one file per
+ * journal entry, and each file's `folderMillis` equal to that entry's `when`. A
+ * drizzle version that reordered or filtered `readMigrationFiles` would throw
+ * here instead of quietly attaching the wrong tag to a hash.
  */
 export function readExpectedMigrations(migrationsFolder: string = DRIZZLE_MIGRATIONS_FOLDER): ExpectedMigration[] {
   const journalPath = path.join(migrationsFolder, 'meta', '_journal.json');
@@ -63,10 +70,17 @@ export function readExpectedMigrations(migrationsFolder: string = DRIZZLE_MIGRAT
         `for ${journal.entries.length} journal entries in ${migrationsFolder}.`,
     );
   }
-  return migrationFiles.map((migrationFile, index) => ({
-    tag: journal.entries[index].tag,
-    hash: migrationFile.hash,
-  }));
+  return migrationFiles.map((migrationFile, index) => {
+    const journalEntry = journal.entries[index];
+    if (migrationFile.folderMillis !== journalEntry.when) {
+      throw new Error(
+        `Migration journal verification failed: drizzle's migration file at position ${index} has ` +
+          `folderMillis ${migrationFile.folderMillis}, but journal entry ${journalEntry.tag} has ` +
+          `when ${journalEntry.when}. readMigrationFiles no longer returns journal order.`,
+      );
+    }
+    return { tag: journalEntry.tag, hash: migrationFile.hash };
+  });
 }
 
 /**

--- a/packages/db/scripts/verify-migration-journal.ts
+++ b/packages/db/scripts/verify-migration-journal.ts
@@ -15,6 +15,7 @@
 import postgres from 'postgres';
 import { describeDatabaseHost, getScriptDatabaseUrl } from './db-connection.js';
 import { inspectMigrationJournal, readLedgerHashesWith } from './migration-journal.js';
+import { MIGRATION_GAP_REMEDIATION } from '../../../scripts/lib/migration-ledger.js';
 
 async function verifyMigrationJournal(): Promise<void> {
   const databaseUrl = getScriptDatabaseUrl();
@@ -31,10 +32,7 @@ async function verifyMigrationJournal(): Promise<void> {
       for (const tag of report.missingTags) {
         console.error(`   • ${tag}`);
       }
-      console.error(
-        "   These were skipped by drizzle's created_at high-water mark and will never re-apply on their own. " +
-          'See docs/db-migrations.md for the repair.',
-      );
+      console.error(`   ${MIGRATION_GAP_REMEDIATION}`);
       process.exitCode = 1;
       return;
     }

--- a/packages/db/scripts/verify-migration-journal.ts
+++ b/packages/db/scripts/verify-migration-journal.ts
@@ -1,0 +1,50 @@
+/**
+ * Read-only pre-flight for the migration journal check that `migrate.ts` runs
+ * under `VERIFY_MIGRATION_JOURNAL=1`.
+ *
+ * Why it exists separately: `migrate` is the gate job for both `deploy-web` and
+ * `deploy-backend` in `production-deploy.yml`, so a gap in the target database's
+ * ledger blocks the whole production deploy. This script answers "would that
+ * gate fire?" without applying anything — one
+ * `SELECT hash FROM drizzle."__drizzle_migrations"` plus local file reads. No
+ * writes, no `migrate()` call, no DDL.
+ *
+ * Usage: `DB_URL=postgres://... vp run db:verify-journal`
+ * Exit 0 = every journal migration is recorded. Exit 1 = missing tags listed.
+ */
+import postgres from 'postgres';
+import { describeDatabaseHost, getScriptDatabaseUrl } from './db-connection.js';
+import { inspectMigrationJournal, readLedgerHashesWith } from './migration-journal.js';
+
+async function verifyMigrationJournal(): Promise<void> {
+  const databaseUrl = getScriptDatabaseUrl();
+  console.info(`🔎 Verifying migration journal against: ${describeDatabaseHost(databaseUrl)} (read-only)`);
+
+  const client = postgres(databaseUrl, { max: 1 });
+  try {
+    const report = await inspectMigrationJournal(readLedgerHashesWith(client));
+    if (report.missingTags.length > 0) {
+      console.error(
+        `❌ ${report.missingTags.length} of ${report.expectedCount} journal migrations have no row in ` +
+          `drizzle.__drizzle_migrations (${report.ledgerCount} rows present).`,
+      );
+      for (const tag of report.missingTags) {
+        console.error(`   • ${tag}`);
+      }
+      console.error(
+        "   These were skipped by drizzle's created_at high-water mark and will never re-apply on their own. " +
+          'See docs/db-migrations.md for the repair.',
+      );
+      process.exitCode = 1;
+      return;
+    }
+    console.info(`✅ All ${report.expectedCount} journal migrations are recorded (${report.ledgerCount} ledger rows).`);
+  } catch (error) {
+    console.error('❌ Migration journal verification failed:', error);
+    process.exitCode = 1;
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+void verifyMigrationJournal();

--- a/packages/db/scripts/verify-migration-journal.ts
+++ b/packages/db/scripts/verify-migration-journal.ts
@@ -10,7 +10,9 @@
  * writes, no `migrate()` call, no DDL.
  *
  * Usage: `DB_URL=postgres://... vp run db:verify-journal`
- * Exit 0 = every journal migration is recorded. Exit 1 = missing tags listed.
+ * Exit 0 = every journal migration is recorded. Exit 1 = each missing tag
+ * listed with the ledger hash its repair row needs, so nobody has to re-derive
+ * a sha256 by hand (the exact parity liability this check avoids elsewhere).
  */
 import postgres from 'postgres';
 import { describeDatabaseHost, getScriptDatabaseUrl } from './db-connection.js';
@@ -29,8 +31,8 @@ async function verifyMigrationJournal(): Promise<void> {
         `❌ ${report.missingTags.length} of ${report.expectedCount} journal migrations have no row in ` +
           `drizzle.__drizzle_migrations (${report.ledgerCount} rows present).`,
       );
-      for (const tag of report.missingTags) {
-        console.error(`   • ${tag}`);
+      for (const migration of report.missing) {
+        console.error(`   • ${migration.tag}  (ledger hash ${migration.hash})`);
       }
       console.error(`   ${MIGRATION_GAP_REMEDIATION}`);
       process.exitCode = 1;

--- a/scripts/lib/migration-ledger.test.ts
+++ b/scripts/lib/migration-ledger.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { findUnappliedMigrations, formatMigrationGapError, type ExpectedMigration } from './migration-ledger';
+
+function expectedFrom(...tags: string[]): ExpectedMigration[] {
+  return tags.map((tag) => ({ tag, hash: `hash-of-${tag}` }));
+}
+
+function hashesFor(...tags: string[]): string[] {
+  return tags.map((tag) => `hash-of-${tag}`);
+}
+
+describe('findUnappliedMigrations', () => {
+  it('returns nothing when every journal hash has a ledger row', () => {
+    // The false-positive case: a check that fails closed on a healthy database
+    // blocks every production deploy, which is worse than the bug it catches.
+    const expected = expectedFrom('0000_a', '0001_b', '0002_c');
+    expect(findUnappliedMigrations(expected, hashesFor('0000_a', '0001_b', '0002_c'))).toEqual([]);
+  });
+
+  it('names the migration whose ledger row is missing from the middle', () => {
+    // #2933 itself: 0129_numerous_star_brand applied cleanly in the journal but
+    // its `when` sat below the ledger high-water mark, so drizzle skipped it and
+    // the latest-only assertion in migrate.ts stayed green.
+    const expected = expectedFrom('0000_a', '0001_b', '0002_c');
+    expect(findUnappliedMigrations(expected, hashesFor('0000_a', '0002_c'))).toEqual(['0001_b']);
+  });
+
+  it('reports missing tags in journal order', () => {
+    const expected = expectedFrom('0000_a', '0001_b', '0002_c', '0003_d');
+    expect(findUnappliedMigrations(expected, hashesFor('0002_c'))).toEqual(['0000_a', '0001_b', '0003_d']);
+  });
+
+  it('ignores ledger rows whose hash matches no journal entry', () => {
+    // Renumbering legitimately leaves orphan rows behind — the local dev DB has
+    // two. Failing on them would block deploys for benign residue.
+    const expected = expectedFrom('0000_a', '0001_b');
+    const ledger = [...hashesFor('0000_a', '0001_b'), 'hash-of-a-renumbered-away-migration'];
+    expect(findUnappliedMigrations(expected, ledger)).toEqual([]);
+  });
+
+  it('requires one ledger row per entry when two migrations share a hash', () => {
+    // Byte-identical .sql files hash identically. A Set-based implementation
+    // would call the second one applied off the first one's row.
+    const duplicateHash = 'identical-sql-body';
+    const expected: ExpectedMigration[] = [
+      { tag: '0000_original', hash: duplicateHash },
+      { tag: '0001_copy', hash: duplicateHash },
+    ];
+    expect(findUnappliedMigrations(expected, [duplicateHash])).toEqual(['0001_copy']);
+    expect(findUnappliedMigrations(expected, [duplicateHash, duplicateHash])).toEqual([]);
+  });
+
+  it('returns every tag against an empty ledger', () => {
+    const expected = expectedFrom('0000_a', '0001_b');
+    expect(findUnappliedMigrations(expected, [])).toEqual(['0000_a', '0001_b']);
+  });
+
+  it('returns nothing for an empty journal', () => {
+    expect(findUnappliedMigrations([], hashesFor('0000_a'))).toEqual([]);
+  });
+});
+
+describe('formatMigrationGapError', () => {
+  it('names every missing tag and both counts', () => {
+    const message = formatMigrationGapError(['0129_numerous_star_brand', '0130_lucky_star'], 131, 125);
+    expect(message).toContain('0129_numerous_star_brand');
+    expect(message).toContain('0130_lucky_star');
+    expect(message).toContain('2 of 131');
+    expect(message).toContain('125 rows present');
+  });
+
+  it('reads correctly for a single missing migration', () => {
+    const message = formatMigrationGapError(['0129_numerous_star_brand'], 131, 130);
+    expect(message).toContain('1 of 131 journal migration has no row');
+  });
+});

--- a/scripts/lib/migration-ledger.ts
+++ b/scripts/lib/migration-ledger.ts
@@ -78,9 +78,10 @@ export function findUnappliedMigrations(
  * into telling two different stories about the same condition.
  */
 export const MIGRATION_GAP_REMEDIATION =
-  "These were skipped by drizzle's created_at high-water mark and will never re-apply on their own — " +
-  'apply each .sql by hand inside a transaction and insert its ledger row with the journal\'s "when" as created_at. ' +
-  'See docs/db-migrations.md.';
+  "These will never re-apply on their own (most often drizzle's created_at high-water mark skipped them, " +
+  "but a database can also carry the schema without the ledger row) — check first whether each migration's " +
+  'objects already exist: if they do, insert only the ledger row; if they do not, apply the .sql by hand inside ' +
+  'a transaction and insert the row in the same transaction. See docs/db-migrations.md.';
 
 /**
  * Operator-facing message. Names every missing tag — an error that fires but

--- a/scripts/lib/migration-ledger.ts
+++ b/scripts/lib/migration-ledger.ts
@@ -73,6 +73,16 @@ export function findUnappliedMigrations(
 }
 
 /**
+ * What the operator does next. Shared so the deploy-gate throw and the
+ * `db:verify-journal` CLI (which prints its tag list across lines) cannot drift
+ * into telling two different stories about the same condition.
+ */
+export const MIGRATION_GAP_REMEDIATION =
+  "These were skipped by drizzle's created_at high-water mark and will never re-apply on their own — " +
+  'apply each .sql by hand inside a transaction and insert its ledger row with the journal\'s "when" as created_at. ' +
+  'See docs/db-migrations.md.';
+
+/**
  * Operator-facing message. Names every missing tag — an error that fires but
  * won't say which migration is missing leaves the operator no better off than
  * the runtime crash this check replaces.
@@ -87,8 +97,6 @@ export function formatMigrationGapError(
     `Migration journal verification failed: ${missingTags.length} of ${expectedCount} journal ` +
     `${plural} no row in drizzle.__drizzle_migrations (${ledgerCount} rows present). ` +
     `Missing: ${missingTags.join(', ')}. ` +
-    `These were skipped by drizzle's created_at high-water mark and will never re-apply on their own — ` +
-    `apply each .sql by hand inside a transaction and insert its ledger row with the journal's "when" as created_at. ` +
-    `See docs/db-migrations.md.`
+    MIGRATION_GAP_REMEDIATION
   );
 }

--- a/scripts/lib/migration-ledger.ts
+++ b/scripts/lib/migration-ledger.ts
@@ -1,0 +1,94 @@
+/**
+ * Pure comparison between the migration journal and drizzle's applied-migration
+ * ledger (`drizzle.__drizzle_migrations`).
+ *
+ * Why this exists: drizzle's applier is a single high-water mark, not a
+ * reconciliation. `PgDialect.migrate()` reads `max(created_at)` from the ledger
+ * once, before the loop, and applies only journal entries whose `when` is
+ * strictly greater. A migration whose `when` lands at or below that mark is
+ * skipped on that deploy — and on every deploy after it, because the mark only
+ * ever moves up. Nothing in drizzle ever asks "which specific migrations are
+ * missing?", so the gap is invisible until a query hits the absent object at
+ * runtime (production hit exactly this: `relation "location_sync_gym_sources"
+ * does not exist`, days after the deploy that skipped `0129_numerous_star_brand`).
+ *
+ * `packages/db/scripts/migrate.ts` used to verify the wrong thing — it asserted
+ * `max(created_at) >= the newest journal entry's when`, which is precisely the
+ * one condition a below-the-mark gap cannot violate. This module asks the
+ * per-entry question instead.
+ *
+ * Two properties of the real data shape the API:
+ *
+ *  - **The key is `hash`, not `created_at`.** The `boardsesh-dev-db` image
+ *    bulk-loads its ledger with synthetic timestamps (34 distinct `created_at`
+ *    values are duplicated, one of them 13 times), so 180 of 188 journal entries
+ *    have no `created_at`-matching row there. Hashes survive the bulk load:
+ *    187 of 188 match. Matching on `created_at` would false-positive on
+ *    essentially every local and CI database.
+ *  - **Missing-only, never extra.** Ledger rows whose hash matches no journal
+ *    entry are legitimate renumber residue (two exist on the local dev DB right
+ *    now). Failing on those would block deploys for a non-problem.
+ *
+ * Callers get the hashes from drizzle's own exported `readMigrationFiles`
+ * (`drizzle-orm/migrator`) rather than re-deriving sha256, so the hash can't
+ * drift from what the migrator actually inserts.
+ */
+
+/** One journal entry paired with the hash drizzle would record for its `.sql`. */
+export interface ExpectedMigration {
+  tag: string;
+  hash: string;
+}
+
+/**
+ * Journal-order list of tags that have no matching row in the ledger.
+ *
+ * Multiset-aware on purpose: two byte-identical `.sql` files share a hash, and
+ * this repo has carried duplicate-content migrations before (see the
+ * `0177_illegal_omega_red` note in `scripts/lib/drizzle-migrations.ts`). Two
+ * such entries need two ledger rows, not one — a `Set`-based implementation
+ * would silently call the second one applied.
+ *
+ * Extra ledger hashes with no journal entry are ignored; see the module header.
+ */
+export function findUnappliedMigrations(
+  expected: readonly ExpectedMigration[],
+  ledgerHashes: readonly string[],
+): string[] {
+  const remainingByHash = new Map<string, number>();
+  for (const hash of ledgerHashes) {
+    remainingByHash.set(hash, (remainingByHash.get(hash) ?? 0) + 1);
+  }
+
+  const missingTags: string[] = [];
+  for (const migration of expected) {
+    const remaining = remainingByHash.get(migration.hash) ?? 0;
+    if (remaining > 0) {
+      remainingByHash.set(migration.hash, remaining - 1);
+    } else {
+      missingTags.push(migration.tag);
+    }
+  }
+  return missingTags;
+}
+
+/**
+ * Operator-facing message. Names every missing tag — an error that fires but
+ * won't say which migration is missing leaves the operator no better off than
+ * the runtime crash this check replaces.
+ */
+export function formatMigrationGapError(
+  missingTags: readonly string[],
+  expectedCount: number,
+  ledgerCount: number,
+): string {
+  const plural = missingTags.length === 1 ? 'migration has' : 'migrations have';
+  return (
+    `Migration journal verification failed: ${missingTags.length} of ${expectedCount} journal ` +
+    `${plural} no row in drizzle.__drizzle_migrations (${ledgerCount} rows present). ` +
+    `Missing: ${missingTags.join(', ')}. ` +
+    `These were skipped by drizzle's created_at high-water mark and will never re-apply on their own — ` +
+    `apply each .sql by hand inside a transaction and insert its ledger row with the journal's "when" as created_at. ` +
+    `See docs/db-migrations.md.`
+  );
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -159,6 +159,16 @@ export default defineConfig({
         dependsOn: ['db:up'],
         cache: false,
       },
+      // Read-only pre-flight for the VERIFY_MIGRATION_JOURNAL=1 gate that
+      // production-deploy.yml runs (#2933): reports any journal migration with
+      // no row in drizzle.__drizzle_migrations. One SELECT, no writes, no
+      // migrate() call — safe to point at production before a deploy. No db:up
+      // dependency: it's normally run by hand against DB_URL, same pattern as
+      // db:dedupe-gyms.
+      'db:verify-journal': {
+        command: 'bun run --filter=@boardsesh/db db:verify-journal',
+        cache: false,
+      },
       'db:studio': {
         command: 'bun run --filter=@boardsesh/db db:studio',
         dependsOn: ['db:up'],
@@ -208,6 +218,15 @@ export default defineConfig({
       },
       'test:db': {
         command: 'bun run --filter=@boardsesh/db test',
+      },
+      // The one packages/db node:test file CI runs (from ci.yml's db-migrations
+      // job, against a stock postgres:17 service). It builds its own throwaway
+      // migrations folder and database, so it needs no board data and no db:up.
+      // Locally it skips unless DATABASE_URL/MIGRATION_JOURNAL_DB_URL points at
+      // a local Postgres.
+      'test:db:migration-journal': {
+        command: 'bun run --filter=@boardsesh/db test:migration-journal',
+        cache: false,
       },
       'locations:aurora': {
         command: 'bun run --filter=@boardsesh/aurora-sync sync:locations',


### PR DESCRIPTION
## Summary

Closes #2933.

`migrate.ts`'s journal verification asked the wrong question and answered it advisorily. It asserted `max(created_at) >= the newest journal entry's when` — which is exactly the one condition a below-the-high-water-mark gap cannot violate — and the count mismatch that *would* have caught prod's missing `0129_numerous_star_brand` was a `console.warn` followed by `✅ Verified…`.

This replaces it with a per-entry, hash-keyed check that fails the deploy and names the missing tags.

### What changed

- **`scripts/lib/migration-ledger.ts`** (new, pure, zero deps) — `findUnappliedMigrations()` diffs the journal against the ledger by hash and returns the missing tags in journal order; `formatMigrationGapError()` builds the operator-facing message. Sits next to `scripts/lib/drizzle-migrations.ts`, whose header docs already describe this exact "skipped forever, silently" failure mode, and its unit tests run in CI's existing `scripts` Vitest project with no new wiring.
- **`packages/db/scripts/migration-journal.ts`** (new) — reads the expected `{tag, hash}` pairs and runs the check. Shared by `migrate.ts`, the new pre-flight script, and the integration test so they can't drift apart.
- **`packages/db/scripts/migrate.ts`** — the `LatestAppliedMigrationRow` type, the `MAX/COUNT` query, the latest-only `throw`, the count-mismatch `console.warn`, and the `latestJournalEntry` reduce are gone. The per-entry check strictly subsumes all of it. The `VERIFY_MIGRATION_JOURNAL` block is no longer inline: it is `runMigrationJournalGate()` in `migration-journal.ts`, because a script that connects on import offers no seam and an inline gate could never be covered by a test (see the QA round below).
- **`packages/db/scripts/verify-migration-journal.ts`** + `vp run db:verify-journal` (new) — the same check, read-only, no `migrate()` call. One `SELECT hash FROM drizzle."__drizzle_migrations"` plus local file reads. This exists so the maintainer can point it at production **before** merging (see the merge gate below).
- **`.github/workflows/ci.yml`** — a `postgres:17` service on the `db-migrations` job plus a step running the real-database test, and the `dbMigrations` path filter extended to the new files.
- **`docs/db-migrations.md`** — a "The journal-vs-ledger check" subsection under The guard rails: the mechanism, what `VERIFY_MIGRATION_JOURNAL=1` now enforces, and the repair when it fires.

### Where the issue was right, and the three things it got wrong

The issue's diagnosis is correct and its proposed fix is the one that shipped. Three refinements found while building it:

1. **The hash comes from drizzle, not from us.** The issue says "compute `sha256(<tag>.sql file contents)` (same as drizzle's `readMigrationFiles`)". Re-deriving it is a permanent parity liability — file encoding, BOM, line endings, or a future drizzle change all silently turn this deploy gate into a false positive. The fix calls the exported `readMigrationFiles` from `drizzle-orm/migrator` instead, so divergence is structurally impossible rather than merely tested for.

2. **The `VERIFY_MIGRATION_JOURNAL=1` gate stays** (the issue floats dropping it). It is not safe today, and this is measured, not hypothetical: `vp run db:verify-journal` against the current `boardsesh-dev-db` image reports `1 of 188 journal migrations have no row in drizzle.__drizzle_migrations (189 rows present). Missing: 0187_sad_freak`. A default-on hard check would redden `vp run db:migrate` for every developer until the image is rebuilt, and would newly gate `db-migration-renumber.yml`'s second "re-applying is a no-op" run. The gate is already set in both places that matter (`production-deploy.yml:331`, `db-migration-renumber.yml:203`), so keeping it loses nothing. **Sequencing: land it gated, rebuild the dev-db image so it is self-consistent, flip the default in a follow-up.**

3. **The high-water mark does not advance during a run** — good news the issue's root-cause section implies otherwise. `PgDialect.migrate()` snapshots `lastDbMigration` with `order by created_at desc limit 1` **once, before** the loop and never updates it inside the transaction. So on a fresh, empty database `lastDbMigration` is undefined and *every* journal entry applies in journal order regardless of `when`. The 18 out-of-order `when` values currently on main (including `0129`) therefore do **not** break a from-zero bootstrap. The gap only ever opens incrementally, when a migration whose `when` is below an already-applied max is added later.

### Deliberately not doing

- **No auto-healing.** The check refuses to deploy; it does not re-apply the skipped SQL. Several migrations on main are data backfills whose idempotence hinges on `_bs_migration_guards` semantic keys, and re-running a mixed DDL/DML set unattended is a worse failure than a blocked deploy with an exact tag.
- **No ledger-orphan detection.** Rows whose hash matches no journal entry are ignored — two exist on the local dev DB as benign renumber residue. So the issue's "possibly related: hash/`created_at` drift" note is only half-addressed: a *replaced* row is caught, an *extra* row is not.
- **Not rewriting the 18 stale `when` values** in `_journal.json`. Harmless for from-zero bootstraps (see #3 above), and rewriting them would make every already-migrated database report a fresh gap — the exact false positive this is built to avoid.
- **Not fixing `scripts/dev-db-up.sh`'s identical high-water-mark applier**, and not wiring the whole `packages/db` node:test suite into CI (#3861). Both filed separately below.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

**Unit — `scripts/lib/migration-ledger.test.ts`** (9 tests, runs in CI's `scripts` project today):
healthy database returns `[]`; a hash missing from the middle returns exactly that tag; missing tags come back in journal order; orphan ledger rows are ignored; two entries sharing a hash need two ledger rows; empty ledger returns everything; the error message names every tag and both counts.

**Real database — `packages/db/scripts/migration-journal-verification.integration.test.ts`** (8 tests, node:test, self-skipping; refuses any host outside `localhost`/`127.0.0.1`/`postgres`, and throws rather than skipping when `CI` is set so a missing service URL can't produce a false green). Every scenario creates and drops its own database; the shared dev DB is never written to.

1. **Hash parity, non-tautologically** — runs drizzle's real `migrate()`, then asserts every hash from `readExpectedMigrations` appears in the rows *drizzle itself* INSERTed. A test that re-implements sha256 and compares it to our sha256 would be a pure tautology; this instead catches a future drizzle version changing how the ledger hash is computed, which is the one thing that would turn this guard into a deploy-blocking false positive.
2. **The gap, end to end** — two-phase apply with a third entry at `when=2000` below the `3000` mark: the table is not created, main's latest-only condition *passes*, the new check returns exactly `['0002_stale_when']`, and a third `migrate()` still does not create it.
3. **Deliberate ledger deletion** — the check names the tag; `migrate()` does not restore it.
4. **Healthy database** — `[]`, 2 expected, 2 ledger rows, and neither `assertMigrationJournalApplied` nor `runMigrationJournalGate` rejects. A gate that can fail closed on a healthy database stops every release, so the negative matters as much as the positive.
5. **Orphan ledger row** — ignored.
6. **Fail-closed, not just detected** — on the gap database above, `assertMigrationJournalApplied` and `runMigrationJournalGate` must both reject naming `0002_stale_when`, and with the gate off the same broken database passes without the ledger being read at all.
7. **Env contract** — only an exact `VERIFY_MIGRATION_JOURNAL=1` arms the gate; `''`, `'0'`, `'true'`, `'yes'` and unset all leave it off.

**Mutation check (run, not claimed).** Six independent breaks of the fix, red every time, each restored and re-verified green after:

| Mutation | Result |
| --- | --- |
| `findUnappliedMigrations` uses a `Set` instead of multiset counting | unit: 1 failed / 498 |
| `findUnappliedMigrations` reverted to main's latest-only semantics | unit: 4 failed / 498; integration: 2 of 6 failed |
| `readExpectedMigrations`' `folderMillis !== when` ordering guard deleted | integration: 1 of 7 failed |
| the gate reports the gap instead of throwing (the pre-fix semantics) | integration: 2 of 8 failed |
| `assertMigrationJournalApplied` warns instead of throwing | integration: 2 of 8 failed |
| the gate ignores `VERIFY_MIGRATION_JOURNAL` and always runs | integration: 2 of 8 failed |

The second, fourth and fifth are the #2933 regression itself in three different shapes — detect the gap, log it, deploy anyway. All three now go red.

**Validation** (all foreground, all `vp`):

- `vp check` — clean for this diff. The 2 pre-existing repo errors are `TS2307: Cannot find module '@gorhom/bottom-sheet'` in `packages/mobile/src/web-shims/bottom-sheet.tsx`, from the isolated `web-runtime` install not being present locally. Unrelated.
- `vp run typecheck` — green.
- `vp test run --project scripts --reporter=agent` — 498 passed / 37 files.
- `vp run test:db:migration-journal` against a throwaway `postgres:17` — 8 passed, 0 skipped. Also confirmed green in CI on the `postgres:17` service (`tests 7 / pass 7 / skipped 0`), so the new job step is really running.
- `vp run db:verify-journal` read-only against the local dev DB — correctly reports the `0187_sad_freak` gap described above (exit 1). This is the script doing its job on real data, not a failure of this PR.

## Review follow-ups applied

All three points from the automated review, judged on merit:

1. **Implicit ordering contract** (valid, and now enforced rather than commented). `MigrationMeta` carries no `tag`, so pairing hashes to tags is an index zip against `journal.entries`. `readExpectedMigrations` now checks each file's `folderMillis` against that entry's `when` in addition to the existing length check — a drizzle version that reordered or filtered `readMigrationFiles` throws instead of quietly attaching the wrong tag to a hash. Untrippable from outside by construction (both sides read the same journal field), so it takes an injected file reader to be testable at all — and it is unreachable against drizzle 0.45.x specifically, which is now written down where the seam is defined. It is a tripwire for a future drizzle bump, not a live guard.
2. **`migration-ledger.test.ts` missing from the path filter** (valid). Added.
3. **Duplicated error text** (valid). The remediation sentence is now a shared `MIGRATION_GAP_REMEDIATION` constant used by both the deploy-gate throw and the CLI, which keeps the CLI's multi-line tag list without letting the two stories drift.

Second round, both valid and both fixed:

4. **The runbook contradicted the PR's own rationale** — the best catch on this PR. `docs/db-migrations.md` told the operator to insert "the sha256 of the .sql body", which is precisely the re-derivation this check exists to avoid, and there was no supported way to get the right hash. `db:verify-journal` now prints it beside each missing tag, and the docs point at that output:

   ```
   ❌ 1 of 188 journal migrations have no row in drizzle.__drizzle_migrations (189 rows present).
      • 0187_sad_freak  (ledger hash 439223b04a903f46dd89b36d7f2b989c761086a6f84f354809abbcce3bd2cd0a)
   ```

5. **The ordering guard had no test.** It now does. `readExpectedMigrations` takes an injected file reader (defaulting to drizzle's `readMigrationFiles`), so a reordered or truncated result can be fed to it — a reorder throws `readMigrationFiles no longer returns journal order`, a short read throws on the count. **Mutation-checked**: deleting the `folderMillis !== when` comparison turns that case red (6/7 pass), restored after.

### Paired QA review — the one that mattered

A paired reviewer ran three mutations of their own and found the load-bearing gap: **the deploy gate had no test.** Every test here exercised the *detector* (`inspectMigrationJournal` / `findUnappliedMigrations`); the throw that turns a detected gap into a failed deploy — the literal subject of the PR title — was called by no test. Swapping `assertMigrationJournalApplied` for `inspectMigrationJournal` in `migrate.ts`, which restores exactly the pre-fix "report it and deploy anyway" behaviour #2933 complains about, left 498/498 unit and 7/7 integration green. Fixed:

- The gate moved out of `migrate.ts` into `runMigrationJournalGate()`, because `migrate.ts` connects on import and has no seam — an inline gate is uncoverable by construction. `migrate.ts` now just calls it.
- The gap test requires both the assert and the gate to **reject**; the healthy test requires both **not** to; the gate-off path must not query the ledger. Plus the env contract. Three mutations confirm all of it (table above).

Two smaller QA points, both fair, both fixed:

- **The remediation text stated one cause as fact** — "skipped by drizzle's created_at high-water mark" — and that is not the cause of the one real gap the tool reports today. `boardsesh-dev-db` has `0187_sad_freak`'s schema *without* its ledger row (#3978), and the `.sql` is not idempotent, so an operator following the old text literally hits `type "logbook_sync_skip_reason" already exists`. The message and the docs runbook now separate the two states and check for existing objects first.
- **`packages/db/package.json` was missing from the `dbMigrations` path filter**, even though it defines the `test:migration-journal` script the new CI step invokes. Added.

QA also re-derived the regression surface independently and cleared the one that looked dangerous: `db-migration-renumber.yml` runs this gate against the dev-db image, but 0187's `when` is *above* that image's max `created_at`, so `migrate()` already dies on the non-idempotent `CREATE TYPE` before the verification block is reached. That workflow is broken on main already; #3978 is its home, and this PR adds no new regression there.

## Merge gates

- [ ] **Maintainer: run `vp run db:verify-journal` read-only against production and confirm zero missing tags, BEFORE merging.** `migrate` is the `needs:` gate for both `deploy-web` and `deploy-backend` in `production-deploy.yml`, so any pre-existing ledger drift in prod — a hand-applied row with a wrong hash, a row lost during the 0129 remediation, a historical renumber that rewrote a `.sql` body after it was applied — turns the first post-merge deploy red and ships nothing. If it reports a gap, reconcile that gap first (`docs/db-migrations.md` has the repair). The script is read-only: one `SELECT` plus local file reads. **I did not and will not connect to production from the dev box**, so this risk is unresolved by design; local evidence is only mildly encouraging (the dev-db image preserves 187/188 hashes through a bulk ledger copy, but the dev image is not prod).
- [x] Confirm the `db-migrations` job actually fired on this PR's own diff — the path-filter edit is what makes the new test run. Verified: the job log shows the new step running against the `postgres:17` service with `pass 8 / fail 0 / skipped 0`.

No device QA: this is a CI/deploy-script change with no mobile, BLE, or UI surface.

## Follow-ups filed

- #3978 — `vp run db:up` currently fails against the `boardsesh-dev-db:latest` image (`relation "board_climb_ingest_skips" already exists` applying `0187_sad_freak` — the image has 0187's schema but not its ledger row). This is also what keeps the env gate in place.
- #3979 — `scripts/dev-db-up.sh`'s inlined applier (`entry.when <= lastAppliedAt`) has the identical high-water-mark gap. Local blast radius only, and it wants to be fixed alongside the dev-db image refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xu9FhyVPEPTuBSGBigiDgd


