### PR TITLE
fix(mobile): disavow location on Android BLUETOOTH_SCAN

### DIFF
--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -461,10 +461,23 @@ export default ({ config, projectRoot }: ConfigContext): ExpoConfig & { newArchE
         'FOREGROUND_SERVICE_CONNECTED_DEVICE',
         'POST_NOTIFICATIONS',
       ],
-      // Do NOT add `neverForLocation` to BLUETOOTH_SCAN here: react-native-ble-plx
-      // caps ACCESS_FINE_LOCATION at maxSdkVersion=30 when it's set, which would
-      // break expo-location (board/session discovery) and expo-maps (Google Maps)
-      // on Android 12+. We keep fine location uncapped on purpose.
+      // BLUETOOTH_SCAN needs `android:usesPermissionFlags="neverForLocation"` on
+      // Android 12+ or the OS silently drops every scan result for a caller
+      // without location permission. It is set in
+      // ./plugins/with-android-bluetooth-feature, NOT here (this list can only
+      // carry bare permission names) and NOT via react-native-ble-plx's
+      // `neverForLocation: true` prop. Verified by running `expo prebuild
+      // --platform android` both ways: the prop caps ACCESS_COARSE/FINE_LOCATION
+      // at maxSdkVersion=30 — which would break expo-location (board/session
+      // discovery) and expo-maps (Google Maps) on Android 12+ — and leaves
+      // BLUETOOTH_SCAN untouched, because Expo's base permissions mod declares
+      // it first and ble-plx's addScanPermissionToManifest early-returns on an
+      // existing element. Our own mod gets the flag without the cap:
+      //   <uses-permission-sdk-23 android:name="android.permission.ACCESS_FINE_LOCATION"/>   <!-- uncapped -->
+      //   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>          <!-- uncapped -->
+      //   <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+      //       android:usesPermissionFlags="neverForLocation" tools:targetApi="31"/>
+      // Keep fine location uncapped on purpose.
       blockedPermissions: ['android.permission.BLUETOOTH_ADVERTISE'],
       // expo-maps on Android renders Google Maps, which needs an API key. iOS
       // uses Apple Maps and needs none. Supplied via env so iOS works out of the

--- a/packages/mobile/plugins/with-android-bluetooth-feature.js
+++ b/packages/mobile/plugins/with-android-bluetooth-feature.js
@@ -1,4 +1,11 @@
-const { createRunOncePlugin, withAndroidManifest } = require('expo/config-plugins');
+const { AndroidConfig, createRunOncePlugin, withAndroidManifest } = require('expo/config-plugins');
+
+// Owns both of the app's Android Bluetooth manifest bits:
+//   1. the `<uses-feature android:name="android.hardware.bluetooth_le">` declaration, and
+//   2. the `neverForLocation` disavowal on `<uses-permission BLUETOOTH_SCAN>`.
+// Neither is expressible through `app.config.ts`'s `android.permissions` list,
+// and neither belongs to a dependency's plugin (see the BLUETOOTH_SCAN note
+// below for why react-native-ble-plx's `neverForLocation` prop is not usable).
 
 // Declares BLE as a *recommended* (not required) hardware feature. Play uses
 // <uses-feature> for store filtering and device-catalogue ranking. We use
@@ -8,6 +15,8 @@ const { createRunOncePlugin, withAndroidManifest } = require('expo/config-plugin
 // the Play pre-launch report. The boolean lives in an attribute so the marker
 // is the feature name itself — re-running prebuild finds it and no-ops.
 const FEATURE_NAME = 'android.hardware.bluetooth_le';
+
+const SCAN_PERMISSION_NAME = 'android.permission.BLUETOOTH_SCAN';
 
 /**
  * Adds `<uses-feature android:name="android.hardware.bluetooth_le"
@@ -38,13 +47,67 @@ function addBluetoothLeFeature(androidManifest) {
   return androidManifest;
 }
 
+/**
+ * Marks `BLUETOOTH_SCAN` with `android:usesPermissionFlags="neverForLocation"`.
+ *
+ * Without it, Android 12+ (API 31) treats every BLE scan as potentially
+ * location-deriving: AOSP's `Utils.hasDisavowedLocationForScan()` reads this
+ * exact flag off the calling package's `BLUETOOTH_SCAN` declaration, and when
+ * it is absent each delivered `ScanResult` is gated on the caller holding
+ * ACCESS_FINE/COARSE_LOCATION. Results are dropped in the *delivery* loop, not
+ * rejected at `startScan()` — so the app sees a scan that starts cleanly,
+ * reports no error, and finds nothing. Boardsesh's runtime request asks only
+ * for BLUETOOTH_SCAN/BLUETOOTH_CONNECT on API 31+, so anyone who declined the
+ * separate "boards near you" location prompt got a permanently empty picker.
+ *
+ * Why this mod and not react-native-ble-plx's `neverForLocation: true` prop:
+ * verified by running `expo prebuild --platform android` both ways. The prop
+ * caps ACCESS_COARSE/FINE_LOCATION at `maxSdkVersion=30` (which would break
+ * expo-location's nearby-boards and expo-maps on Android 12+) and leaves
+ * BLUETOOTH_SCAN *completely untouched*, because Expo's base `android.permissions`
+ * mod declares BLUETOOTH_SCAN first and ble-plx's `addScanPermissionToManifest`
+ * early-returns on an existing element. All of the cost, none of the benefit.
+ *
+ * Find-or-create rather than find-only: if a future mod-ordering change stops
+ * Expo's base mod from declaring BLUETOOTH_SCAN before this one, the fix
+ * degrades to "still correct" instead of silently reverting. Location
+ * permissions are never touched here — they stay uncapped on purpose.
+ *
+ * @param {{ manifest: { $?: Record<string, string>, 'uses-permission'?: Array<{ $: Record<string, string> }> } }} androidManifest
+ * @returns {typeof androidManifest}
+ */
+function addNeverForLocationScanFlag(androidManifest) {
+  // `tools:targetApi` needs the tools namespace on <manifest>. It happens to be
+  // present today (the BLUETOOTH_ADVERTISE `tools:node="remove"` block puts it
+  // there), but emitting a tools: attribute without it fails the Android build,
+  // so don't depend on an unrelated block staying put.
+  const withTools = AndroidConfig.Manifest.ensureToolsAvailable(androidManifest);
+  const manifest = withTools.manifest;
+  const usesPermission = manifest['uses-permission'] ?? [];
+
+  let scanPermission = usesPermission.find((permission) => permission?.$?.['android:name'] === SCAN_PERMISSION_NAME);
+  if (!scanPermission) {
+    scanPermission = { $: { 'android:name': SCAN_PERMISSION_NAME } };
+    usesPermission.push(scanPermission);
+    manifest['uses-permission'] = usesPermission;
+  }
+
+  scanPermission.$['android:usesPermissionFlags'] = 'neverForLocation';
+  scanPermission.$['tools:targetApi'] = '31';
+
+  return withTools;
+}
+
 function withAndroidBluetoothFeature(config) {
   return withAndroidManifest(config, (modConfig) => {
     modConfig.modResults = addBluetoothLeFeature(modConfig.modResults);
+    modConfig.modResults = addNeverForLocationScanFlag(modConfig.modResults);
     return modConfig;
   });
 }
 
-module.exports = createRunOncePlugin(withAndroidBluetoothFeature, 'with-android-bluetooth-feature', '1.0.0');
+module.exports = createRunOncePlugin(withAndroidBluetoothFeature, 'with-android-bluetooth-feature', '1.1.0');
 module.exports.addBluetoothLeFeature = addBluetoothLeFeature;
+module.exports.addNeverForLocationScanFlag = addNeverForLocationScanFlag;
 module.exports.FEATURE_NAME = FEATURE_NAME;
+module.exports.SCAN_PERMISSION_NAME = SCAN_PERMISSION_NAME;

--- a/packages/mobile/src/lib/__tests__/android-bluetooth-feature-plugin.test.ts
+++ b/packages/mobile/src/lib/__tests__/android-bluetooth-feature-plugin.test.ts
@@ -17,7 +17,24 @@ type AndroidManifestShape = {
   };
 };
 
-type BluetoothFeaturePlugin = {
+/** The single argument @expo/config-plugins hands a manifest mod. */
+type ManifestModConfig = {
+  modResults: AndroidManifestShape;
+  modRequest: Record<string, unknown>;
+  modRawConfig: Record<string, unknown>;
+};
+
+type ExpoConfigWithMods = {
+  name: string;
+  slug: string;
+  mods?: {
+    android?: {
+      manifest?: (modConfig: ManifestModConfig) => Promise<ManifestModConfig>;
+    };
+  };
+};
+
+type BluetoothFeaturePlugin = ((config: ExpoConfigWithMods) => ExpoConfigWithMods) & {
   addBluetoothLeFeature(androidManifest: AndroidManifestShape): AndroidManifestShape;
   addNeverForLocationScanFlag(androidManifest: AndroidManifestShape): AndroidManifestShape;
   FEATURE_NAME: string;
@@ -153,6 +170,67 @@ describe('addNeverForLocationScanFlag', () => {
     const result = plugin.addNeverForLocationScanFlag(manifestWithBaseScanPermission());
 
     expect(result.manifest.$?.['xmlns:tools']).toBe('http://schemas.android.com/tools');
+  });
+});
+
+/**
+ * Registers the exported (run-once-wrapped) plugin on a bare config and runs the
+ * android manifest mod @expo/config-plugins would run at prebuild time.
+ *
+ * This is the only assertion path that covers the plugin's *wiring*. Everything
+ * else in this file calls the two exported transforms directly, so deleting
+ * `modConfig.modResults = addNeverForLocationScanFlag(...)` from
+ * `withAndroidBluetoothFeature` would leave those green while the flag silently
+ * stopped reaching the generated manifest — and no CI job runs `expo prebuild`
+ * to catch it downstream.
+ */
+async function runPluginManifestMod(androidManifest: AndroidManifestShape): Promise<AndroidManifestShape> {
+  const config = plugin({ name: 'Boardsesh', slug: 'boardsesh' });
+  const manifestMod = config.mods?.android?.manifest;
+  if (!manifestMod) {
+    throw new Error('the plugin did not register an android.manifest mod');
+  }
+
+  const result = await manifestMod({ modResults: androidManifest, modRequest: {}, modRawConfig: {} });
+  return result.modResults;
+}
+
+describe('withAndroidBluetoothFeature (the plugin as prebuild runs it)', () => {
+  it('applies both manifest mods', async () => {
+    const modResults = await runPluginManifestMod(manifestWithBaseScanPermission());
+
+    const bleFeature = (modResults.manifest['uses-feature'] ?? []).find(
+      (feature) => feature.$['android:name'] === plugin.FEATURE_NAME,
+    );
+    expect(bleFeature?.$['android:required']).toBe('false');
+
+    const scanPermission = scanPermissionOf(modResults);
+    expect(scanPermission?.$['android:usesPermissionFlags']).toBe('neverForLocation');
+    expect(scanPermission?.$['tools:targetApi']).toBe('31');
+    expect(modResults.manifest.$?.['xmlns:tools']).toBe('http://schemas.android.com/tools');
+  });
+
+  it('leaves location permissions uncapped end to end', async () => {
+    const modResults = await runPluginManifestMod({
+      manifest: {
+        $: { 'xmlns:android': 'http://schemas.android.com/apk/res/android' },
+        'uses-permission': [
+          { $: { 'android:name': plugin.SCAN_PERMISSION_NAME } },
+          { $: { 'android:name': 'android.permission.ACCESS_FINE_LOCATION' } },
+        ],
+        'uses-permission-sdk-23': [{ $: { 'android:name': 'android.permission.ACCESS_FINE_LOCATION' } }],
+      },
+    });
+
+    const locationEntries = [
+      ...(modResults.manifest['uses-permission'] ?? []),
+      ...(modResults.manifest['uses-permission-sdk-23'] ?? []),
+    ].filter((permission) => permission.$['android:name'].includes('_LOCATION'));
+
+    expect(locationEntries).toHaveLength(2);
+    for (const entry of locationEntries) {
+      expect(entry.$['android:maxSdkVersion']).toBeUndefined();
+    }
   });
 });
 

--- a/packages/mobile/src/lib/__tests__/android-bluetooth-feature-plugin.test.ts
+++ b/packages/mobile/src/lib/__tests__/android-bluetooth-feature-plugin.test.ts
@@ -10,14 +10,18 @@ type UsesFeature = {
 
 type AndroidManifestShape = {
   manifest: {
+    $?: Record<string, string>;
     'uses-feature'?: UsesFeature[];
     'uses-permission'?: UsesFeature[];
+    'uses-permission-sdk-23'?: UsesFeature[];
   };
 };
 
 type BluetoothFeaturePlugin = {
   addBluetoothLeFeature(androidManifest: AndroidManifestShape): AndroidManifestShape;
+  addNeverForLocationScanFlag(androidManifest: AndroidManifestShape): AndroidManifestShape;
   FEATURE_NAME: string;
+  SCAN_PERMISSION_NAME: string;
 };
 
 const plugin = require('../../../plugins/with-android-bluetooth-feature.js') as BluetoothFeaturePlugin;
@@ -57,5 +61,97 @@ describe('with-android-bluetooth-feature', () => {
       (feature) => feature.$['android:name'] === plugin.FEATURE_NAME,
     );
     expect(bleEntries).toHaveLength(1);
+  });
+});
+
+/** What Expo's base `android.permissions` mod leaves behind before our mod runs. */
+function manifestWithBaseScanPermission(): AndroidManifestShape {
+  return {
+    manifest: {
+      $: { 'xmlns:android': 'http://schemas.android.com/apk/res/android' },
+      'uses-permission': [{ $: { 'android:name': plugin.SCAN_PERMISSION_NAME } }],
+    },
+  };
+}
+
+function scanPermissionOf(result: AndroidManifestShape): UsesFeature | undefined {
+  return (result.manifest['uses-permission'] ?? []).find(
+    (permission) => permission.$['android:name'] === plugin.SCAN_PERMISSION_NAME,
+  );
+}
+
+describe('addNeverForLocationScanFlag', () => {
+  it('flags an existing BLUETOOTH_SCAN as neverForLocation', () => {
+    // The bug this whole change exists for: without the flag, Android 12+ drops
+    // every scan result for a caller that has no location permission — no error,
+    // no callback, just an empty board picker.
+    const result = plugin.addNeverForLocationScanFlag(manifestWithBaseScanPermission());
+    const scanPermission = scanPermissionOf(result);
+
+    expect(scanPermission?.$['android:usesPermissionFlags']).toBe('neverForLocation');
+    expect(scanPermission?.$['tools:targetApi']).toBe('31');
+  });
+
+  it('does not cap or otherwise modify location permissions', () => {
+    // The highest-consequence wrong fix is "simplify" this to ble-plx's
+    // `neverForLocation: true` prop, which caps ACCESS_COARSE/FINE_LOCATION at
+    // maxSdkVersion=30 and silently breaks nearby-boards + Google Maps on
+    // Android 12+. Nothing here may touch a location declaration.
+    const manifest: AndroidManifestShape = {
+      manifest: {
+        $: { 'xmlns:android': 'http://schemas.android.com/apk/res/android' },
+        'uses-permission': [
+          { $: { 'android:name': plugin.SCAN_PERMISSION_NAME } },
+          { $: { 'android:name': 'android.permission.ACCESS_FINE_LOCATION' } },
+          { $: { 'android:name': 'android.permission.ACCESS_COARSE_LOCATION' } },
+        ],
+        'uses-permission-sdk-23': [{ $: { 'android:name': 'android.permission.ACCESS_FINE_LOCATION' } }],
+      },
+    };
+
+    const result = plugin.addNeverForLocationScanFlag(manifest);
+    const locationEntries = [
+      ...(result.manifest['uses-permission'] ?? []),
+      ...(result.manifest['uses-permission-sdk-23'] ?? []),
+    ].filter((permission) => permission.$['android:name'].includes('_LOCATION'));
+
+    expect(locationEntries).toHaveLength(3);
+    for (const entry of locationEntries) {
+      expect(entry.$['android:maxSdkVersion']).toBeUndefined();
+      expect(entry.$['android:usesPermissionFlags']).toBeUndefined();
+    }
+  });
+
+  it('adds a flagged BLUETOOTH_SCAN when none is declared', () => {
+    // Find-or-create: a mod-ordering or `android.permissions` change that stops
+    // Expo's base mod from declaring BLUETOOTH_SCAN first would otherwise turn
+    // this whole fix into a silent no-op.
+    const result = plugin.addNeverForLocationScanFlag({
+      manifest: { $: { 'xmlns:android': 'http://schemas.android.com/apk/res/android' } },
+    });
+    const scanPermission = scanPermissionOf(result);
+
+    expect(scanPermission?.$['android:usesPermissionFlags']).toBe('neverForLocation');
+    expect(result.manifest['uses-permission']).toHaveLength(1);
+  });
+
+  it('is idempotent — a second pass leaves one flagged entry', () => {
+    const once = plugin.addNeverForLocationScanFlag(manifestWithBaseScanPermission());
+    const twice = plugin.addNeverForLocationScanFlag(once);
+
+    const scanEntries = (twice.manifest['uses-permission'] ?? []).filter(
+      (permission) => permission.$['android:name'] === plugin.SCAN_PERMISSION_NAME,
+    );
+    expect(scanEntries).toHaveLength(1);
+    expect(scanEntries[0]?.$['android:usesPermissionFlags']).toBe('neverForLocation');
+  });
+
+  it('ensures the tools namespace so tools:targetApi is legal', () => {
+    // Emitting a tools: attribute into a manifest with no tools namespace fails
+    // the Android build. It happens to be present today only because of the
+    // unrelated BLUETOOTH_ADVERTISE `tools:node="remove"` block.
+    const result = plugin.addNeverForLocationScanFlag(manifestWithBaseScanPermission());
+
+    expect(result.manifest.$?.['xmlns:tools']).toBe('http://schemas.android.com/tools');
   });
 });

--- a/packages/mobile/src/lib/__tests__/android-bluetooth-feature-plugin.test.ts
+++ b/packages/mobile/src/lib/__tests__/android-bluetooth-feature-plugin.test.ts
@@ -155,3 +155,30 @@ describe('addNeverForLocationScanFlag', () => {
     expect(result.manifest.$?.['xmlns:tools']).toBe('http://schemas.android.com/tools');
   });
 });
+
+describe('the two mods composed, as withAndroidBluetoothFeature runs them', () => {
+  it('keeps both results when chained through the same manifest object', () => {
+    // withAndroidBluetoothFeature assigns each mod's return value back onto
+    // modConfig.modResults, so the second mod's return has to still carry the
+    // first mod's mutations. AndroidConfig.Manifest.ensureToolsAvailable mutates
+    // in place today; if it ever started returning a fresh object, the
+    // uses-feature entry would silently vanish from the generated manifest.
+    const chained = plugin.addNeverForLocationScanFlag(plugin.addBluetoothLeFeature(manifestWithBaseScanPermission()));
+
+    const bleFeature = (chained.manifest['uses-feature'] ?? []).find(
+      (feature) => feature.$['android:name'] === plugin.FEATURE_NAME,
+    );
+    expect(bleFeature?.$['android:required']).toBe('false');
+    expect(scanPermissionOf(chained)?.$['android:usesPermissionFlags']).toBe('neverForLocation');
+    expect(chained.manifest.$?.['xmlns:tools']).toBe('http://schemas.android.com/tools');
+  });
+
+  it('is order-independent', () => {
+    const otherOrder = plugin.addBluetoothLeFeature(
+      plugin.addNeverForLocationScanFlag(manifestWithBaseScanPermission()),
+    );
+
+    expect(otherOrder.manifest['uses-feature']).toHaveLength(1);
+    expect(scanPermissionOf(otherOrder)?.$['android:usesPermissionFlags']).toBe('neverForLocation');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3889.

PR **B of 2** for #3889, and the actual fix. PR A (#3980) is the JS-only mitigation that reaches the installed fleet today; this one is a **native manifest change — it ships in a binary, not an OTA.** Current 2.3.0 store users (including the reporter) get nothing from it until the next Android store build.

### Root cause

On Android 12+ (API 31), `BLUETOOTH_SCAN` was declared in `packages/mobile/app.config.ts` without `android:usesPermissionFlags="neverForLocation"`. AOSP's `Utils.hasDisavowedLocationForScan()` reads that exact flag off the calling package's `BLUETOOTH_SCAN` declaration; when it is absent, every delivered `ScanResult` is gated on the caller holding `ACCESS_FINE_LOCATION` or `ACCESS_COARSE_LOCATION`, and results are dropped **in the delivery loop** — not rejected at `startScan()`.

Meanwhile `src/lib/ble/use-ble-permissions.ts` requests only `BLUETOOTH_SCAN` + `BLUETOOTH_CONNECT` on API 31+. That is correct — but only if the manifest disavows location. The two halves have been out of sync, so `startDeviceScan` succeeds, no error callback fires, the 15s timer expires, and the picker shows an empty list with troubleshooting copy blaming the board's power switch.

### The old code comment was wrong in a way that mattered

`app.config.ts` said we can't add `neverForLocation` because react-native-ble-plx caps `ACCESS_FINE_LOCATION` at `maxSdkVersion=30`. The cap is real — but the comment missed that ble-plx's prop **would not add the flag at all.** I ran `expo prebuild --platform android` both ways to confirm.

With `['react-native-ble-plx', { neverForLocation: true }]`:

```xml
<uses-permission-sdk-23 android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="30"/>
<uses-permission-sdk-23 android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30"/>
<uses-permission android:name="android.permission.BLUETOOTH_SCAN"/>   <!-- UNCHANGED -->
```

`BLUETOOTH_SCAN` is untouched: ble-plx's `addScanPermissionToManifest` early-returns when the element already exists, and Expo's base `android.permissions` mod (we list `'BLUETOOTH_SCAN'` in `app.config.ts`) declared it first. All of the cost, none of the benefit. The comment read as "we evaluated this and it doesn't work"; what actually doesn't work is only ble-plx's route. The comment is now rewritten to say that, with the verified snippet inline.

### Verified generated manifest

`CI=1 expo prebuild --platform android --no-install --clean` from `packages/mobile`, before and after this change (generated `android/` deleted afterwards, tree clean):

**Before**
```xml
<uses-permission-sdk-23 android:name="android.permission.ACCESS_COARSE_LOCATION"/>
<uses-permission-sdk-23 android:name="android.permission.ACCESS_FINE_LOCATION"/>
<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
<uses-permission android:name="android.permission.BLUETOOTH_SCAN"/>
```

**After**
```xml
<uses-permission-sdk-23 android:name="android.permission.ACCESS_COARSE_LOCATION"/>
<uses-permission-sdk-23 android:name="android.permission.ACCESS_FINE_LOCATION"/>
<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
<uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" tools:targetApi="31"/>
```

All four location declarations stay uncapped, so `expo-location` (nearby boards) and `expo-maps` (Google Maps) keep working on Android 12+ — the exact thing the old comment was protecting.

### What changed

- `plugins/with-android-bluetooth-feature.js` — new exported pure function `addNeverForLocationScanFlag`. Find-or-create on the `BLUETOOTH_SCAN` `uses-permission` (so a future mod-ordering change degrades to "still correct" rather than "silently reverted"), `AndroidConfig.Manifest.ensureToolsAvailable` before emitting `tools:targetApi`, and it never touches an `ACCESS_*_LOCATION` entry. Run-once version bumped to `1.1.0`; filename and plugin id kept (per the ruling), header rewritten to say it owns both Android Bluetooth manifest bits.
- `app.config.ts` — the corrected comment, with the prebuild-verified snippet so nobody has to re-derive it. `android.permissions` itself is unchanged.

### Not doing

- Not setting `neverForLocation: true` on the ble-plx plugin (proven above to be all cap, no flag).
- Not capping, removing, or touching `ACCESS_FINE_LOCATION` / `ACCESS_COARSE_LOCATION`.
- Not changing the runtime permission request on either API branch. The API-31+ branch is already right; the API<31 branch genuinely needs fine location and is unaffected by this PR (~5% of Android picker sessions).
- Not touching the Aurora scan filter or `HIGH_POWER_BOARD_SCAN_OPTIONS`. #3806/#3811 settled that.

### Deviation from the approved plan

The plan also called for a coupling comment in `src/lib/ble/use-ble-permissions.ts` (the API-31+ branch is only correct because the manifest disavows location). **That comment already landed in PR A** (#3980) as part of the mitigation work, so it isn't repeated here.

### Fixed after QA review

**The fix could be deleted with a fully green pipeline.** Every case in `android-bluetooth-feature-plugin.test.ts` called the two exported transforms directly; nothing invoked `withAndroidBluetoothFeature` or the exported run-once plugin. The reviewer deleted only the wiring line

```js
modConfig.modResults = addNeverForLocationScanFlag(modConfig.modResults);
```

leaving `addNeverForLocationScanFlag` fully intact, and all 10 tests still passed. Since no CI job runs `expo prebuild`, that one line was the only thing standing between "fix ships" and "fix silently absent", and nothing guarded it. The "composed" describe block reads like it does, but it hand-chains the two functions rather than running the mod.

There is now a `withAndroidBluetoothFeature (the plugin as prebuild runs it)` block that registers the exported plugin on a bare config and invokes `config.mods.android.manifest(...)`. Mutation-checked both ways: deleting **either** wiring line turns "applies both manifest mods" red, and it is the only test that goes red for the `neverForLocation` one.

### Don't over-read the metrics after this ships

PostHog, `BLE Picker Devices Resolved`, Android, last 120 days: the `devicesTotal = 0` rate by `$os_version` is 17.7% (A16), 16.5% (A15), 11.2% (A14), 16.0% (A13), 5.5% (A12). If the location gate blocked every Android 12+ scan, those would read ~100%. They read 5–18% because most users already granted location for "find nearby boards", and AOSP's gate accepts *coarse* location too. This is a real bug for the subset who declined, plus a privacy defect in its own right — but the empty-picker cluster will not collapse when it ships, and that is not a sign the fix failed. `androidLocationPermissionGranted` (added in PR A) is the oracle: watch whether `devicesTotal = 0` decouples from location grant state, counting **users**, not events.

## Release Notes

- Connecting to a board no longer needs Location permission on Android 12 and newer.

## Test plan

Everything run in the foreground with `vp`:

- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — 557 files, 4683 tests, all passing.
- `vp check` — 0 errors.
- `vp run check:mobile-bundle` — Android bundle OK.
- `CI=1 expo prebuild --platform android --no-install --clean`, twice (with and without the mod) — see the manifest diff above. Generated `android/` removed; `git status` clean.

New tests in `src/lib/__tests__/android-bluetooth-feature-plugin.test.ts`:

- flags an existing `BLUETOOTH_SCAN` as `neverForLocation` (+ `tools:targetApi="31"`)
- **does not cap or otherwise modify location permissions** — the one I most want, since the tempting wrong fix is ble-plx's prop
- adds a flagged `BLUETOOTH_SCAN` when none is declared (mod-ordering safety)
- is idempotent across two passes
- ensures the `tools` namespace
- the two mods **composed** the way `withAndroidBluetoothFeature` runs them (chained through one manifest object, and order-independent)
- **the exported plugin itself, driven the way prebuild drives it** — added after QA review, see below

**Mutation checks (actually run, not claimed):**

| Mutation | Result |
|---|---|
| Delete the `addNeverForLocationScanFlag` call + the flag assignment | 3 tests red |
| Cap the location entries at `maxSdkVersion=30` (what ble-plx's prop does) | 1 test red — "does not cap or otherwise modify location permissions" |
| Make `addNeverForLocationScanFlag` return a freshly-built object instead of mutating in place | 2 tests red, including the chained-composition test |
| Delete **only** the `addNeverForLocationScanFlag` wiring line from `withAndroidBluetoothFeature` | 1 test red — "applies both manifest mods". Before the review fix: **0 red** |
| Delete **only** the `addBluetoothLeFeature` wiring line | 1 test red — same case |

Both restored; the suite is green again.

**Not automatable here:** no CI job runs `expo prebuild`, so nothing in the suite asserts on a *real* generated manifest. Verified by hand and pasted above. Adding prebuild to CI is a much larger change and out of scope.

## Merge / CI expectations

- **This busts the iOS screenshot `.app` cache by design.** `mobile-screenshots-ios.yml` keys its cache on `plugins/**`, so this change forces the ~30 min native rebuild. Expected, not a failure.
- **Native fingerprint changes**, so no OTA delivery. Per `ota-fingerprint-parity-batch-bomb`, the next production OTA publish after this merges must resolve the same config the native build did — `mobile-ci-env-parity.test.ts` covers it, but a post-merge parity check is worth doing.

## Device QA gates (Android hardware, maintainer) — required before merge

This machine is Linux: no Android device, no emulator with a real board, no BLE hardware. All of the below need a maintainer on an Android 12+ phone running a **new native build**, not an OTA.

1. **The fix itself.** Fresh install, never grant Location, turn the system Location toggle **off**, open the board picker. Expected: boards appear and connect. Today: empty list.
2. **OEM scan-result denylist — check this first if any board family goes dark.** For a disavowed client, Android 12+ applies a location denylist to scan results (`config_bluetooth_location_denylist_mac` / `_advertising_data`) and drops matches. AOSP ships it effectively empty and it targets location-inferring payloads (iBeacon-class), so Aurora boards — custom service UUID, `"Kilter Board #12345"`-style names — should be nowhere near it. But OEMs can populate it and I can't test that on Linux. Verify **Kilter, Tension and MoonBoard** all still enumerate (MoonBoard scans unfiltered through the same path, so a denylist could bite one family and not another), and try a Samsung/Xiaomi build as well as a Pixel.
3. **No location prompt on the BLE path.** Nothing should ask for location while connecting a board; "Find nearby boards" must still prompt and work when tapped.
4. **Maps and nearby still work.** With location granted, open the gyms map and the nearby-boards carousel on Android 12+. This is the failure mode the old comment was guarding against; the prebuild diff says we're safe, but it's cheap to confirm.
5. **Android 11 unchanged.** If a ≤11 device is available: the location prompt should still appear and scanning should still work.
6. **Manifest spot-check.** `aapt dump permissions` (or Android Studio's merged-manifest view) on the release APK should show `BLUETOOTH_SCAN` with the `neverForLocation` flag and `ACCESS_FINE_LOCATION` with **no** `maxSdkVersion`.



