### PR TITLE
fix(mobile): preserve OAuth registration fallback context

### DIFF
--- a/packages/mobile/src/hooks/__tests__/use-native-oauth-sign-in.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-oauth-sign-in.test.tsx
@@ -64,8 +64,8 @@ function trackedEvents(): TrackedEvent[] {
   }));
 }
 
-async function runSignIn(provider: 'google' | 'apple', setError = vi.fn()) {
-  const { result } = renderHook(() => useNativeOAuthSignIn({ setError }));
+async function runSignIn(provider: 'google' | 'apple', setError = vi.fn(), isRegistration = false) {
+  const { result } = renderHook(() => useNativeOAuthSignIn({ isRegistration, setError }));
   await act(async () => {
     await result.current.signIn(provider);
   });
@@ -131,6 +131,15 @@ describe('useNativeOAuthSignIn — Google web fallback (iOS)', () => {
       reason: 'invalid_oauth_token',
       recoverable: true,
     });
+  });
+
+  it('preserves registration attribution when the native flow falls back to the browser', async () => {
+    signInWithGoogleMock.mockRejectedValue(Object.assign(new Error('Unable to open Safari'), { code: -1 }));
+    signInWithGoogleWebMock.mockResolvedValue({ success: true });
+
+    await runSignIn('google', vi.fn(), true);
+
+    expect(signInWithGoogleWebMock).toHaveBeenCalledWith(true);
   });
 
   it('does NOT fall back when the user cancels native Google, and logs a cancel (not a failure)', async () => {
@@ -324,6 +333,15 @@ describe('useNativeOAuthSignIn — Apple web fallback (iOS)', () => {
       recoverable: undefined,
       mechanism: 'browser_deeplink',
     });
+  });
+
+  it('preserves registration attribution when the native flow falls back to the browser', async () => {
+    signInWithAppleMock.mockRejectedValue(Object.assign(new Error('unknown'), { code: 1000 }));
+    signInWithAppleWebMock.mockResolvedValue({ success: true });
+
+    await runSignIn('apple', vi.fn(), true);
+
+    expect(signInWithAppleWebMock).toHaveBeenCalledWith(true);
   });
 
   it('does NOT fall back when the user cancels native Apple, and logs a cancel (not a failure)', async () => {

--- a/packages/mobile/src/hooks/use-native-oauth-sign-in.ts
+++ b/packages/mobile/src/hooks/use-native-oauth-sign-in.ts
@@ -87,7 +87,7 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
       // Keyed by provider so the map is exhaustive: extending Provider without a
       // web fn here is a type error, rather than silently routing the new provider
       // to the Google flow.
-      const webFallbackFor: Record<Provider, () => Promise<OAuthSignInResult>> = {
+      const webFallbackFor: Record<Provider, (registration: boolean) => Promise<OAuthSignInResult>> = {
         apple: signInWithAppleWeb,
         google: signInWithGoogleWeb,
       };
@@ -101,7 +101,7 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
         });
         let fallback: OAuthSignInResult;
         try {
-          fallback = await webFallbackFor[provider]();
+          fallback = await webFallbackFor[provider](isRegistration);
         } catch (fallbackError) {
           track(SHARED_EVENTS.LoginFailed, {
             auth_method: provider,

--- a/packages/mobile/src/lib/auth.ts
+++ b/packages/mobile/src/lib/auth.ts
@@ -317,15 +317,20 @@ async function signInWithProviderWeb(provider: AuthProvider): Promise<OAuthSignI
 
 // Browser Google fallback — for when native GoogleSignin can't present its OAuth
 // browser (iOS 26.5.1 fails with GIDSignIn "Unable to open Safari" before any
-// network call).
-export function signInWithGoogleWeb(): Promise<OAuthSignInResult> {
+// network call). Native OAuth returns directly to the app through a transfer
+// token, so /auth/native-start has no separate login/register destination.
+// Registration attribution remains with useNativeOAuthSignIn; the argument is
+// intentionally unused here to keep the native and web platform APIs aligned.
+export function signInWithGoogleWeb(_isRegistration = false): Promise<OAuthSignInResult> {
   return signInWithProviderWeb('google');
 }
 
 // Browser Apple fallback — for when native Sign in with Apple throws a non-cancel
 // error (ASAuthorizationError.unknown / code 1000: device not signed into iCloud,
 // 2FA disabled, transient Apple ID issues), which otherwise dead-ends the user.
-export function signInWithAppleWeb(): Promise<OAuthSignInResult> {
+// As above, registration attribution is recorded by the hook rather than routed
+// through the native browser handoff.
+export function signInWithAppleWeb(_isRegistration = false): Promise<OAuthSignInResult> {
   return signInWithProviderWeb('apple');
 }
 

--- a/packages/mobile/src/lib/auth.web.ts
+++ b/packages/mobile/src/lib/auth.web.ts
@@ -548,10 +548,10 @@ export function signInWithGoogle(webAttemptId?: string, isRegistration = false):
   return startWebOAuth('google', webAttemptId, isRegistration);
 }
 
-export function signInWithGoogleWeb(): Promise<OAuthSignInResult> {
-  return startWebOAuth('google');
+export function signInWithGoogleWeb(isRegistration = false): Promise<OAuthSignInResult> {
+  return startWebOAuth('google', undefined, isRegistration);
 }
 
-export function signInWithAppleWeb(): Promise<OAuthSignInResult> {
-  return startWebOAuth('apple');
+export function signInWithAppleWeb(isRegistration = false): Promise<OAuthSignInResult> {
+  return startWebOAuth('apple', undefined, isRegistration);
 }

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -47,9 +47,9 @@ type AuthState = {
   signInWithApple: (webAttemptId?: string, isRegistration?: boolean) => Promise<OAuthSignInResult>;
   signInWithGoogle: (webAttemptId?: string, isRegistration?: boolean) => Promise<OAuthSignInResult>;
   // Browser-OAuth fallback for when native Google sign-in can't present (iOS 26.5.1).
-  signInWithGoogleWeb: () => Promise<OAuthSignInResult>;
+  signInWithGoogleWeb: (isRegistration?: boolean) => Promise<OAuthSignInResult>;
   // Browser-OAuth fallback for when native Sign in with Apple throws (code 1000).
-  signInWithAppleWeb: () => Promise<OAuthSignInResult>;
+  signInWithAppleWeb: (isRegistration?: boolean) => Promise<OAuthSignInResult>;
   signInWithCredentials: (email: string, password: string) => Promise<CredentialsSignInResult>;
   register: (email: string, password: string, name?: string) => Promise<RegistrationResult>;
   signOut: (method?: 'manual' | 'account_deleted') => Promise<void>;
@@ -513,24 +513,30 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
   // Browser-based Google fallback (native SDK can't present the OAuth browser on
   // iOS 26.5.1). Same success contract as the native flow: re-run checkAuth so the
   // provider flips to the authenticated UI.
-  const signInWithGoogleWeb = useCallback(async (): Promise<OAuthSignInResult> => {
-    const result = await authSignInWithGoogleWeb();
-    if (result.success) {
-      await checkAuth();
-    }
-    return result;
-  }, [checkAuth]);
+  const signInWithGoogleWeb = useCallback(
+    async (isRegistration = false): Promise<OAuthSignInResult> => {
+      const result = await authSignInWithGoogleWeb(isRegistration);
+      if (result.success) {
+        await checkAuth();
+      }
+      return result;
+    },
+    [checkAuth],
+  );
 
   // Browser-based Apple fallback (native Sign in with Apple threw a non-cancel
   // error). Same success contract as the native flow: re-run checkAuth so the
   // provider flips to the authenticated UI.
-  const signInWithAppleWeb = useCallback(async (): Promise<OAuthSignInResult> => {
-    const result = await authSignInWithAppleWeb();
-    if (result.success) {
-      await checkAuth();
-    }
-    return result;
-  }, [checkAuth]);
+  const signInWithAppleWeb = useCallback(
+    async (isRegistration = false): Promise<OAuthSignInResult> => {
+      const result = await authSignInWithAppleWeb(isRegistration);
+      if (result.success) {
+        await checkAuth();
+      }
+      return result;
+    },
+    [checkAuth],
+  );
 
   const signInWithCredentials = useCallback(
     async (email: string, password: string): Promise<CredentialsSignInResult> => {

--- a/packages/web/app/api/auth/providers-config/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/providers-config/__tests__/route.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { GET } from '../route';
+
+describe('GET /api/auth/providers-config', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('reports every provider when all required credentials are present', async () => {
+    vi.stubEnv('GOOGLE_CLIENT_ID', 'google-id');
+    vi.stubEnv('GOOGLE_CLIENT_SECRET', 'google-secret');
+    vi.stubEnv('APPLE_ID', 'apple-id');
+    vi.stubEnv('APPLE_SECRET', 'apple-secret');
+    vi.stubEnv('FACEBOOK_CLIENT_ID', 'facebook-id');
+    vi.stubEnv('FACEBOOK_CLIENT_SECRET', 'facebook-secret');
+
+    const response = await GET();
+
+    await expect(response.json()).resolves.toEqual({
+      google: true,
+      apple: true,
+      facebook: true,
+    });
+  });
+
+  it('reports no providers when credentials are absent', async () => {
+    vi.stubEnv('GOOGLE_CLIENT_ID', undefined);
+    vi.stubEnv('GOOGLE_CLIENT_SECRET', undefined);
+    vi.stubEnv('APPLE_ID', undefined);
+    vi.stubEnv('APPLE_SECRET', undefined);
+    vi.stubEnv('FACEBOOK_CLIENT_ID', undefined);
+    vi.stubEnv('FACEBOOK_CLIENT_SECRET', undefined);
+
+    const response = await GET();
+
+    await expect(response.json()).resolves.toEqual({
+      google: false,
+      apple: false,
+      facebook: false,
+    });
+  });
+
+  it('reports only providers with both required credentials', async () => {
+    vi.stubEnv('GOOGLE_CLIENT_ID', 'google-id');
+    vi.stubEnv('GOOGLE_CLIENT_SECRET', 'google-secret');
+    vi.stubEnv('APPLE_ID', 'apple-id');
+    vi.stubEnv('APPLE_SECRET', '');
+    vi.stubEnv('FACEBOOK_CLIENT_ID', 'facebook-id');
+    vi.stubEnv('FACEBOOK_CLIENT_SECRET', 'facebook-secret');
+
+    const response = await GET();
+
+    await expect(response.json()).resolves.toEqual({
+      google: true,
+      apple: false,
+      facebook: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- preserve registration attribution when Apple or Google native sign-in falls back to browser OAuth
- forward the registration flag through the auth hook, provider, and platform helpers
- add direct coverage for the OAuth provider-availability endpoint

## Test Plan
- vp test run --project mobile packages/mobile/src/lib/__tests__/auth.web.test.ts packages/mobile/src/hooks/__tests__/use-native-oauth-sign-in.test.tsx --reporter=agent
- vp test run --project web packages/web/app/api/auth/providers-config/__tests__/route.test.ts --reporter=agent
- vp run typecheck:mobile
- vp check on changed files

## Release Notes
Sign up with Apple or Google now stays in the sign-up flow when your device switches to browser sign-in.