### PR TITLE
fix(db): unblock production deploys behind a recorded ledger baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,15 @@ jobs:
             | grep -vE '(/node_modules/|/generated/|^packages/board-controller/|^embedded/)' \
             > changed-lintable.txt || true
           if [ -s changed-lintable.txt ]; then
-            xargs -r vp check < changed-lintable.txt
+            # Same stdout redirect as the full-repo step below, and for the same
+            # reason: vp panics on EAGAIN when it flushes a long warning list to the
+            # runner's non-blocking stdout, and xargs reports that crash as 123 with
+            # the diagnostics cut off mid-line. A PR touching one warning-heavy file
+            # is enough to hit it. Writing to a regular file never EAGAINs; vp's real
+            # exit code is preserved so lint errors still fail the job.
+            xargs -r vp check < changed-lintable.txt > vp-check.log 2>&1 && status=0 || status=$?
+            cat vp-check.log || true
+            exit $status
           else
             echo "No lintable files changed."
           fi

--- a/docs/db-migrations.md
+++ b/docs/db-migrations.md
@@ -184,10 +184,17 @@ The gate's first armed run found 20 of production's 188 journal entries with no 
 and blocked the production deploy, because `migrate` is the `needs:` gate for both
 `deploy-web` and `deploy-production-backend`.
 
-Those 20 tags are listed in `scripts/lib/migration-ledger-baseline.ts` and subtracted before
-the gate throws. A gap in any other tag still fails the deploy, which keeps the case that
-matters: a freshly appended migration skipped by the high-water mark (the `0129` incident) is
-caught on the first deploy after it happens.
+Those 20 migrations are listed in `scripts/lib/migration-ledger-baseline.ts` and subtracted
+before the gate throws. A gap in any other journal entry still fails the deploy, which keeps
+the case that matters: a freshly appended migration skipped by the high-water mark (the `0129`
+incident) is caught on the first deploy after it happens.
+
+Each entry pins the hash its `.sql` had when the gap was recorded, and the exemption only
+applies at that exact content. Edit a baselined migration and drizzle expects a new hash while
+the old `when` still stops it replaying — a tag-only exemption would report "known gap, deploy
+on" while the edited DDL ran nowhere. Instead the gap turns fatal with the edit named, and
+`vp run test:db:migration-journal` catches the drift at PR time. Applied migrations are not
+editable; write a new one.
 
 The baseline is a stopgap, not a resolution. Two mechanisms produce those 20 tags and only
 one of them is harmless:

--- a/docs/db-migrations.md
+++ b/docs/db-migrations.md
@@ -140,6 +140,9 @@ tag with the ledger hash that tag's repair row needs:
    • 0187_sad_freak  (ledger hash 9f2c…)
 ```
 
+Tags in the recorded baseline (see below) print the same way but as a `⚠️` and without
+setting the exit code.
+
 Take the hash from that output rather than computing a sha256 yourself. The whole reason
 this check calls drizzle's own `readMigrationFiles` is that a re-derived hash drifts on
 encoding, BOM, line endings, or a drizzle change — and a repair row carrying a hash drizzle
@@ -173,6 +176,36 @@ Repair each named tag by hand, in this order:
 
 Extra ledger rows matching no journal entry are ignored — renumbering leaves those behind
 legitimately, and failing on them would block deploys for benign residue.
+
+#### The recorded baseline
+
+The gate's first armed run found 20 of production's 188 journal entries with no ledger row
+— a backlog going back to the initial schema, not the regression the check was built for —
+and blocked the production deploy, because `migrate` is the `needs:` gate for both
+`deploy-web` and `deploy-production-backend`.
+
+Those 20 tags are listed in `scripts/lib/migration-ledger-baseline.ts` and subtracted before
+the gate throws. A gap in any other tag still fails the deploy, which keeps the case that
+matters: a freshly appended migration skipped by the high-water mark (the `0129` incident) is
+caught on the first deploy after it happens.
+
+The baseline is a stopgap, not a resolution. Two mechanisms produce those 20 tags and only
+one of them is harmless:
+
+- **The `.sql` changed after production applied it.** The ledger holds the hash of the file
+  as it ran, so an edit orphans the row. `0103_thick_puck` landed as a bare `CREATE TABLE`
+  and was rewritten with `IF NOT EXISTS` guards the next day; 11 of the 20 have more than one
+  content version in git history.
+- **The migration never ran.** Then production is missing that DDL right now, and the
+  baseline is hiding it.
+
+Telling them apart needs the production schema in front of you, tag by tag — the four repair
+steps above, then delete that tag's line from the baseline. `vp run db:verify-journal` prints
+the baselined tags with their repair hashes on every run and exits 0; a tag outside the
+baseline exits 1.
+
+Adding a tag to the baseline is not a normal fix. A new gap means DDL that did not reach
+production, and baselining it ships the outage this check was written to prevent.
 
 ## Why the schema barrel is union-merged
 

--- a/packages/db/scripts/migrate.ts
+++ b/packages/db/scripts/migrate.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import {
   DRIZZLE_MIGRATIONS_FOLDER,
+  describeBaselinedGap,
   readExpectedMigrations,
   readLedgerHashesWith,
   runMigrationJournalGate,
@@ -82,9 +83,15 @@ async function runMigrations() {
     // file connects on import and offers no seam of its own.
     const report = await runMigrationJournalGate(process.env, readLedgerHashesWith(client), migrationsFolder);
     if (report) {
+      // Named on every armed run, not only on failure: production's pre-gate
+      // backlog is tolerated, not resolved (scripts/lib/migration-ledger-baseline.ts).
+      const baselinedGap = describeBaselinedGap(report);
+      if (baselinedGap) {
+        console.warn(`⚠️  ${baselinedGap}`);
+      }
       console.info(
-        `✅ Verified all ${report.expectedCount} journal migrations are recorded ` +
-          `(${report.ledgerCount} ledger rows)`,
+        `✅ Verified all ${report.expectedCount - report.baselinedMissing.length} unbaselined journal ` +
+          `migrations are recorded (${report.ledgerCount} ledger rows)`,
       );
     }
 

--- a/packages/db/scripts/migration-journal-verification.integration.test.ts
+++ b/packages/db/scripts/migration-journal-verification.integration.test.ts
@@ -26,8 +26,9 @@ import postgres from 'postgres';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import { migrate } from 'drizzle-orm/postgres-js/migrator';
 import { findUnappliedMigrations } from '../../../scripts/lib/migration-ledger.js';
-import type { LedgerBaseline } from '../../../scripts/lib/migration-ledger-baseline.js';
+import { PRODUCTION_LEDGER_BASELINE, type LedgerBaseline } from '../../../scripts/lib/migration-ledger-baseline.js';
 import {
+  DRIZZLE_MIGRATIONS_FOLDER,
   assertMigrationJournalApplied,
   describeBaselinedGap,
   inspectMigrationJournal,
@@ -440,7 +441,7 @@ describe('migration journal verification (#2933)', () => {
     writeMigrationsFolder(migrationsFolder, [...PHASE_ONE, STALE_WHEN_ENTRY]);
     await applyMigrations(scratchUrl, migrationsFolder);
 
-    const baseline: LedgerBaseline = { recordedAt: '2026-07-30', source: 'test', tags: ['0000_a'] };
+    const baseline: LedgerBaseline = { recordedAt: '2026-07-30', source: 'test', migrations: [firstEntry] };
     const report = await withScratchClient(scratchUrl, (client) =>
       inspectMigrationJournal(readLedgerHashesWith(client), migrationsFolder, baseline),
     );
@@ -474,11 +475,84 @@ describe('migration journal verification (#2933)', () => {
     const bothBaselined = await withScratchClient(scratchUrl, (client) =>
       runMigrationJournalGate({ VERIFY_MIGRATION_JOURNAL: '1' }, readLedgerHashesWith(client), migrationsFolder, {
         ...baseline,
-        tags: ['0000_a', '0002_stale_when'],
+        migrations: readExpectedMigrations(migrationsFolder).filter((migration) => migration.tag !== '0001_b'),
       }),
     );
     assert.deepEqual(bothBaselined?.unbaselinedMissing, []);
     assert.equal(bothBaselined?.baselinedMissing.length, 2);
+  });
+
+  it('stops tolerating a baselined migration once its .sql changes', async (context) => {
+    const adminUrl = localDatabaseUrl();
+    if (!adminUrl) {
+      context.skip('set DATABASE_URL to a local Postgres to run');
+      return;
+    }
+    // Editing an applied migration does not re-run it — drizzle's mark is past it
+    // — so a tag-only exemption would report "known gap, deploy on" while the new
+    // statements exist in no database. The recorded hash is what makes that fatal.
+    const migrationsFolder = makeTempFolder('edited');
+    const scratchUrl = await createScratchDatabase(adminUrl, 'edited');
+    writeMigrationsFolder(migrationsFolder, PHASE_ONE);
+    await applyMigrations(scratchUrl, migrationsFolder);
+
+    const [entryAsRecorded] = readExpectedMigrations(migrationsFolder);
+    await withScratchClient(scratchUrl, async (client) => {
+      await client`DELETE FROM drizzle."__drizzle_migrations" WHERE hash = ${entryAsRecorded.hash}`;
+    });
+    const baseline: LedgerBaseline = { recordedAt: '2026-07-30', source: 'test', migrations: [entryAsRecorded] };
+
+    // As recorded: tolerated.
+    const tolerated = await withScratchClient(scratchUrl, (client) =>
+      runMigrationJournalGate({ VERIFY_MIGRATION_JOURNAL: '1' }, readLedgerHashesWith(client), migrationsFolder, {
+        ...baseline,
+      }),
+    );
+    assert.deepEqual(tolerated?.unbaselinedMissing, []);
+
+    // Same tag, new body: fatal, and the message points at the edit.
+    writeMigrationsFolder(migrationsFolder, [
+      { ...PHASE_ONE[0], sql: `${PHASE_ONE[0].sql} ALTER TABLE mjv_t_a ADD COLUMN added_later int;` },
+      PHASE_ONE[1],
+    ]);
+    const edited = readExpectedMigrations(migrationsFolder)[0];
+    assert.notEqual(edited.hash, entryAsRecorded.hash, 'the edit must change the hash drizzle expects');
+
+    const report = await withScratchClient(scratchUrl, (client) =>
+      inspectMigrationJournal(readLedgerHashesWith(client), migrationsFolder, { ...baseline }),
+    );
+    assert.deepEqual(report.baselinedMissing, []);
+    assert.deepEqual(
+      report.editedSinceBaseline.map((migration) => migration.tag),
+      ['0000_a'],
+    );
+    assert.equal(describeBaselinedGap(report), null, 'nothing is tolerated, so there is no warning to print');
+
+    await assert.rejects(
+      withScratchClient(scratchUrl, (client) =>
+        runMigrationJournalGate({ VERIFY_MIGRATION_JOURNAL: '1' }, readLedgerHashesWith(client), migrationsFolder, {
+          ...baseline,
+        }),
+      ),
+      /0000_a[\s\S]*no longer hashes to the recorded value/,
+    );
+  });
+
+  it('keeps the production baseline hashes in step with the files on disk', () => {
+    // The recorded hashes come from drizzle's readMigrationFiles, so they can only
+    // be checked where drizzle is a dependency. Editing a baselined .sql reddens
+    // this at PR time instead of turning the exemption fatal mid-deploy.
+    const currentHashByTag = new Map(
+      readExpectedMigrations().map((migration) => [migration.tag, migration.hash] as const),
+    );
+    for (const migration of PRODUCTION_LEDGER_BASELINE.migrations) {
+      assert.equal(
+        currentHashByTag.get(migration.tag),
+        migration.hash,
+        `${migration.tag} no longer hashes to its recorded baseline value — an applied migration was edited, ` +
+          'so the new statements are in no database. Write a new migration instead.',
+      );
+    }
   });
 
   it('rejects a baseline tag that is not in the journal', async () => {
@@ -486,12 +560,13 @@ describe('migration journal verification (#2933)', () => {
     // like it tolerated something. No database needed.
     const migrationsFolder = makeTempFolder('stale-baseline');
     writeMigrationsFolder(migrationsFolder, PHASE_ONE);
+    const [firstEntry] = readExpectedMigrations(migrationsFolder);
 
     await assert.rejects(
       inspectMigrationJournal(async () => [], migrationsFolder, {
         recordedAt: '2026-07-30',
         source: 'test',
-        tags: ['0000_a', '0404_never_existed'],
+        migrations: [firstEntry, { tag: '0404_never_existed', hash: 'hash-of-a-tag-that-never-existed' }],
       }),
       /baseline is stale: 0404_never_existed/,
     );
@@ -505,11 +580,29 @@ describe('migration journal verification (#2933)', () => {
     writeMigrationsFolder(migrationsFolder, PHASE_ONE);
 
     const report = await inspectMigrationJournal(async () => [], migrationsFolder);
-    assert.deepEqual(report.baseline.tags, []);
+    assert.deepEqual(report.baseline.migrations, []);
     assert.deepEqual(
       report.unbaselinedMissing.map((migration) => migration.tag),
       ['0000_a', '0001_b'],
     );
+  });
+
+  it('recognises the real migrations folder however its path was written', async () => {
+    // A trailing slash or a path built with join() names the same folder, and
+    // falling through to the empty baseline there would show up as a blocked
+    // production deploy rather than as an error that explains itself.
+    for (const spelling of [
+      DRIZZLE_MIGRATIONS_FOLDER,
+      `${DRIZZLE_MIGRATIONS_FOLDER}/`,
+      path.join(DRIZZLE_MIGRATIONS_FOLDER, '..', 'drizzle'),
+    ]) {
+      const report = await inspectMigrationJournal(async () => [], spelling);
+      assert.deepEqual(
+        report.baseline.migrations,
+        PRODUCTION_LEDGER_BASELINE.migrations,
+        `${spelling} must resolve to the production baseline`,
+      );
+    }
   });
 
   it('keeps findUnappliedMigrations multiset-aware for byte-identical migrations', () => {

--- a/packages/db/scripts/migration-journal-verification.integration.test.ts
+++ b/packages/db/scripts/migration-journal-verification.integration.test.ts
@@ -26,8 +26,10 @@ import postgres from 'postgres';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import { migrate } from 'drizzle-orm/postgres-js/migrator';
 import { findUnappliedMigrations } from '../../../scripts/lib/migration-ledger.js';
+import type { LedgerBaseline } from '../../../scripts/lib/migration-ledger-baseline.js';
 import {
   assertMigrationJournalApplied,
+  describeBaselinedGap,
   inspectMigrationJournal,
   readExpectedMigrations,
   readLedgerHashesWith,
@@ -412,6 +414,101 @@ describe('migration journal verification (#2933)', () => {
     await assert.rejects(
       runMigrationJournalGate({ VERIFY_MIGRATION_JOURNAL: '1' }, emptyLedger, migrationsFolder),
       /Missing: 0000_a, 0001_b/,
+    );
+  });
+
+  it('tolerates a baselined gap and still fails on the one beside it', async (context) => {
+    const adminUrl = localDatabaseUrl();
+    if (!adminUrl) {
+      context.skip('set DATABASE_URL to a local Postgres to run');
+      return;
+    }
+    // The production shape after the gate first armed: a gap that predates the
+    // check (baselined) sitting alongside one that does not. Only the second may
+    // block a deploy — but the first must still be reported, or nobody repairs it.
+    const migrationsFolder = makeTempFolder('baselined');
+    const scratchUrl = await createScratchDatabase(adminUrl, 'baselined');
+    writeMigrationsFolder(migrationsFolder, PHASE_ONE);
+    await applyMigrations(scratchUrl, migrationsFolder);
+
+    // 0000_a's row goes missing (a restore, or an earlier hand repair), and a
+    // second migration lands below the high-water mark and is skipped.
+    const [firstEntry] = readExpectedMigrations(migrationsFolder);
+    await withScratchClient(scratchUrl, async (client) => {
+      await client`DELETE FROM drizzle."__drizzle_migrations" WHERE hash = ${firstEntry.hash}`;
+    });
+    writeMigrationsFolder(migrationsFolder, [...PHASE_ONE, STALE_WHEN_ENTRY]);
+    await applyMigrations(scratchUrl, migrationsFolder);
+
+    const baseline: LedgerBaseline = { recordedAt: '2026-07-30', source: 'test', tags: ['0000_a'] };
+    const report = await withScratchClient(scratchUrl, (client) =>
+      inspectMigrationJournal(readLedgerHashesWith(client), migrationsFolder, baseline),
+    );
+    assert.deepEqual(report.missingTags, ['0000_a', '0002_stale_when']);
+    assert.deepEqual(
+      report.baselinedMissing.map((migration) => migration.tag),
+      ['0000_a'],
+    );
+    assert.deepEqual(
+      report.unbaselinedMissing.map((migration) => migration.tag),
+      ['0002_stale_when'],
+    );
+    // The repair hash travels with the baselined tag too — that is what shrinking
+    // the baseline needs.
+    assert.equal(report.baselinedMissing[0].hash, firstEntry.hash);
+    const warning = describeBaselinedGap(report);
+    assert.ok(warning?.includes('0000_a'), 'a tolerated gap must still be named on every run');
+    assert.ok(!warning?.includes('0002_stale_when'));
+
+    await assert.rejects(
+      withScratchClient(scratchUrl, (client) =>
+        runMigrationJournalGate({ VERIFY_MIGRATION_JOURNAL: '1' }, readLedgerHashesWith(client), migrationsFolder, {
+          ...baseline,
+        }),
+      ),
+      /Missing: 0002_stale_when/,
+      'the unbaselined gap must still fail the deploy, and the message must not blame the baselined one',
+    );
+
+    // Baseline both and the deploy proceeds — the state production is in today.
+    const bothBaselined = await withScratchClient(scratchUrl, (client) =>
+      runMigrationJournalGate({ VERIFY_MIGRATION_JOURNAL: '1' }, readLedgerHashesWith(client), migrationsFolder, {
+        ...baseline,
+        tags: ['0000_a', '0002_stale_when'],
+      }),
+    );
+    assert.deepEqual(bothBaselined?.unbaselinedMissing, []);
+    assert.equal(bothBaselined?.baselinedMissing.length, 2);
+  });
+
+  it('rejects a baseline tag that is not in the journal', async () => {
+    // A renamed or mistyped tag would silently tolerate nothing while looking
+    // like it tolerated something. No database needed.
+    const migrationsFolder = makeTempFolder('stale-baseline');
+    writeMigrationsFolder(migrationsFolder, PHASE_ONE);
+
+    await assert.rejects(
+      inspectMigrationJournal(async () => [], migrationsFolder, {
+        recordedAt: '2026-07-30',
+        source: 'test',
+        tags: ['0000_a', '0404_never_existed'],
+      }),
+      /baseline is stale: 0404_never_existed/,
+    );
+  });
+
+  it('applies the production baseline only to the real migrations folder', async () => {
+    // The default baseline names tags from packages/db/drizzle. A synthetic
+    // folder must get an empty one, or every scenario above would trip the
+    // journal-membership check instead of testing what it means to test.
+    const migrationsFolder = makeTempFolder('default-baseline');
+    writeMigrationsFolder(migrationsFolder, PHASE_ONE);
+
+    const report = await inspectMigrationJournal(async () => [], migrationsFolder);
+    assert.deepEqual(report.baseline.tags, []);
+    assert.deepEqual(
+      report.unbaselinedMissing.map((migration) => migration.tag),
+      ['0000_a', '0001_b'],
     );
   });
 

--- a/packages/db/scripts/migration-journal.ts
+++ b/packages/db/scripts/migration-journal.ts
@@ -5,9 +5,16 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import {
   findUnappliedMigrations,
+  formatBaselinedGapWarning,
   formatMigrationGapError,
+  partitionMissingMigrations,
   type ExpectedMigration,
 } from '../../../scripts/lib/migration-ledger.js';
+import {
+  EMPTY_LEDGER_BASELINE,
+  PRODUCTION_LEDGER_BASELINE,
+  type LedgerBaseline,
+} from '../../../scripts/lib/migration-ledger-baseline.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -48,6 +55,47 @@ export interface MigrationJournalReport {
    * drizzle would have written rather than told to compute one.
    */
   missing: ExpectedMigration[];
+  /**
+   * The part of `missing` the recorded baseline accounts for. Reported on every
+   * run but never fatal — production carried these before the gate existed.
+   */
+  baselinedMissing: ExpectedMigration[];
+  /** The part of `missing` that is new. Anything here fails the deploy. */
+  unbaselinedMissing: ExpectedMigration[];
+  /** The baseline this report was judged against. */
+  baseline: LedgerBaseline;
+}
+
+/**
+ * The production baseline describes *this repo's* journal, so it only applies to
+ * this repo's migrations folder. Every test builds a synthetic folder in a temp
+ * directory, where a tag list drawn from `packages/db/drizzle` would be both
+ * meaningless and — via the journal-membership check below — an error.
+ */
+function resolveBaseline(migrationsFolder: string, override?: LedgerBaseline): LedgerBaseline {
+  if (override) {
+    return override;
+  }
+  return migrationsFolder === DRIZZLE_MIGRATIONS_FOLDER ? PRODUCTION_LEDGER_BASELINE : EMPTY_LEDGER_BASELINE;
+}
+
+/**
+ * A baselined tag that no longer exists in the journal is dead weight at best
+ * and a silently weakened gate at worst: a typo, or a tag that was renamed while
+ * the gap it names is still there under the new name. Cheap to check, and it
+ * fails on the file reads alone — no database needed — so
+ * `migration-ledger-baseline.test.ts` catches it at PR time rather than mid-deploy.
+ */
+function assertBaselineTagsAreJournalled(baseline: LedgerBaseline, expected: readonly ExpectedMigration[]): void {
+  const journalTags = new Set(expected.map((migration) => migration.tag));
+  const unknownTags = baseline.tags.filter((tag) => !journalTags.has(tag));
+  if (unknownTags.length > 0) {
+    throw new Error(
+      `Migration ledger baseline is stale: ${unknownTags.join(', ')} ${unknownTags.length === 1 ? 'is' : 'are'} ` +
+        'not in the migration journal. Remove the tag from scripts/lib/migration-ledger-baseline.ts, or correct it ' +
+        'if the migration was renamed.',
+    );
+  }
 }
 
 /**
@@ -112,29 +160,62 @@ export function readExpectedMigrations(
 export async function inspectMigrationJournal(
   readLedgerHashes: ReadLedgerHashes,
   migrationsFolder: string = DRIZZLE_MIGRATIONS_FOLDER,
+  baselineOverride?: LedgerBaseline,
 ): Promise<MigrationJournalReport> {
   const expected = readExpectedMigrations(migrationsFolder);
+  const baseline = resolveBaseline(migrationsFolder, baselineOverride);
+  assertBaselineTagsAreJournalled(baseline, expected);
   const ledgerHashes = await readLedgerHashes();
   const missingTags = findUnappliedMigrations(expected, ledgerHashes);
   const missingTagSet = new Set(missingTags);
+  const missing = expected.filter((migration) => missingTagSet.has(migration.tag));
+  const { baselined, unbaselined } = partitionMissingMigrations(missing, baseline.tags);
   return {
     expectedCount: expected.length,
     ledgerCount: ledgerHashes.length,
     missingTags,
-    missing: expected.filter((migration) => missingTagSet.has(migration.tag)),
+    missing,
+    baselinedMissing: baselined,
+    unbaselinedMissing: unbaselined,
+    baseline,
   };
 }
 
-/** Throws with every missing tag named, or returns the (clean) report. */
+/**
+ * Throws with every unbaselined missing tag named, or returns the report.
+ *
+ * Baselined tags do not throw — see `migration-ledger-baseline.ts` — but the
+ * report still carries them so callers can print them, which
+ * `migrate.ts` and `verify-migration-journal.ts` both do.
+ */
 export async function assertMigrationJournalApplied(
   readLedgerHashes: ReadLedgerHashes,
   migrationsFolder: string = DRIZZLE_MIGRATIONS_FOLDER,
+  baselineOverride?: LedgerBaseline,
 ): Promise<MigrationJournalReport> {
-  const report = await inspectMigrationJournal(readLedgerHashes, migrationsFolder);
-  if (report.missingTags.length > 0) {
-    throw new Error(formatMigrationGapError(report.missingTags, report.expectedCount, report.ledgerCount));
+  const report = await inspectMigrationJournal(readLedgerHashes, migrationsFolder, baselineOverride);
+  if (report.unbaselinedMissing.length > 0) {
+    throw new Error(
+      formatMigrationGapError(
+        report.unbaselinedMissing.map((migration) => migration.tag),
+        report.expectedCount,
+        report.ledgerCount,
+      ),
+    );
   }
   return report;
+}
+
+/** The baselined-gap line both `migrate.ts` and the CLI print, or null when there is nothing to say. */
+export function describeBaselinedGap(report: MigrationJournalReport): string | null {
+  if (report.baselinedMissing.length === 0) {
+    return null;
+  }
+  return formatBaselinedGapWarning(
+    report.baselinedMissing.map((migration) => migration.tag),
+    report.baseline.recordedAt,
+    report.expectedCount,
+  );
 }
 
 /** Env var that turns the deploy gate on. Set by production-deploy.yml and db-migration-renumber.yml. */
@@ -157,9 +238,10 @@ export async function runMigrationJournalGate(
   env: Record<string, string | undefined>,
   readLedgerHashes: ReadLedgerHashes,
   migrationsFolder: string = DRIZZLE_MIGRATIONS_FOLDER,
+  baselineOverride?: LedgerBaseline,
 ): Promise<MigrationJournalReport | null> {
   if (env[VERIFY_MIGRATION_JOURNAL_ENV] !== '1') {
     return null;
   }
-  return assertMigrationJournalApplied(readLedgerHashes, migrationsFolder);
+  return assertMigrationJournalApplied(readLedgerHashes, migrationsFolder, baselineOverride);
 }

--- a/packages/db/scripts/migration-journal.ts
+++ b/packages/db/scripts/migration-journal.ts
@@ -62,6 +62,11 @@ export interface MigrationJournalReport {
   baselinedMissing: ExpectedMigration[];
   /** The part of `missing` that is new. Anything here fails the deploy. */
   unbaselinedMissing: ExpectedMigration[];
+  /**
+   * Baselined tags whose `.sql` no longer hashes to the recorded value. A subset
+   * of `unbaselinedMissing` — fatal, but with a different next step.
+   */
+  editedSinceBaseline: ExpectedMigration[];
   /** The baseline this report was judged against. */
   baseline: LedgerBaseline;
 }
@@ -71,12 +76,18 @@ export interface MigrationJournalReport {
  * this repo's migrations folder. Every test builds a synthetic folder in a temp
  * directory, where a tag list drawn from `packages/db/drizzle` would be both
  * meaningless and — via the journal-membership check below — an error.
+ *
+ * Both sides are normalised through `path.resolve` before comparing: a trailing
+ * slash or a `path.join`-built argument naming the same folder would otherwise
+ * fall through to the empty baseline, and the visible symptom of that would be a
+ * blocked production deploy rather than an error explaining itself.
  */
 function resolveBaseline(migrationsFolder: string, override?: LedgerBaseline): LedgerBaseline {
   if (override) {
     return override;
   }
-  return migrationsFolder === DRIZZLE_MIGRATIONS_FOLDER ? PRODUCTION_LEDGER_BASELINE : EMPTY_LEDGER_BASELINE;
+  const isRepoFolder = path.resolve(migrationsFolder) === path.resolve(DRIZZLE_MIGRATIONS_FOLDER);
+  return isRepoFolder ? PRODUCTION_LEDGER_BASELINE : EMPTY_LEDGER_BASELINE;
 }
 
 /**
@@ -88,7 +99,7 @@ function resolveBaseline(migrationsFolder: string, override?: LedgerBaseline): L
  */
 function assertBaselineTagsAreJournalled(baseline: LedgerBaseline, expected: readonly ExpectedMigration[]): void {
   const journalTags = new Set(expected.map((migration) => migration.tag));
-  const unknownTags = baseline.tags.filter((tag) => !journalTags.has(tag));
+  const unknownTags = baseline.migrations.map((migration) => migration.tag).filter((tag) => !journalTags.has(tag));
   if (unknownTags.length > 0) {
     throw new Error(
       `Migration ledger baseline is stale: ${unknownTags.join(', ')} ${unknownTags.length === 1 ? 'is' : 'are'} ` +
@@ -169,7 +180,7 @@ export async function inspectMigrationJournal(
   const missingTags = findUnappliedMigrations(expected, ledgerHashes);
   const missingTagSet = new Set(missingTags);
   const missing = expected.filter((migration) => missingTagSet.has(migration.tag));
-  const { baselined, unbaselined } = partitionMissingMigrations(missing, baseline.tags);
+  const { baselined, unbaselined, editedSinceBaseline } = partitionMissingMigrations(missing, baseline.migrations);
   return {
     expectedCount: expected.length,
     ledgerCount: ledgerHashes.length,
@@ -177,6 +188,7 @@ export async function inspectMigrationJournal(
     missing,
     baselinedMissing: baselined,
     unbaselinedMissing: unbaselined,
+    editedSinceBaseline,
     baseline,
   };
 }
@@ -200,6 +212,7 @@ export async function assertMigrationJournalApplied(
         report.unbaselinedMissing.map((migration) => migration.tag),
         report.expectedCount,
         report.ledgerCount,
+        report.editedSinceBaseline.map((migration) => migration.tag),
       ),
     );
   }

--- a/packages/db/scripts/verify-migration-journal.ts
+++ b/packages/db/scripts/verify-migration-journal.ts
@@ -23,7 +23,7 @@
 import postgres from 'postgres';
 import { describeDatabaseHost, getScriptDatabaseUrl } from './db-connection.js';
 import { inspectMigrationJournal, readLedgerHashesWith } from './migration-journal.js';
-import { MIGRATION_GAP_REMEDIATION } from '../../../scripts/lib/migration-ledger.js';
+import { formatEditedBaselineNote, MIGRATION_GAP_REMEDIATION } from '../../../scripts/lib/migration-ledger.js';
 
 async function verifyMigrationJournal(): Promise<void> {
   const databaseUrl = getScriptDatabaseUrl();
@@ -50,6 +50,9 @@ async function verifyMigrationJournal(): Promise<void> {
       );
       for (const migration of report.unbaselinedMissing) {
         console.error(`   • ${migration.tag}  (ledger hash ${migration.hash})`);
+      }
+      if (report.editedSinceBaseline.length > 0) {
+        console.error(`   ${formatEditedBaselineNote(report.editedSinceBaseline.map((migration) => migration.tag))}`);
       }
       console.error(`   ${MIGRATION_GAP_REMEDIATION}`);
       process.exitCode = 1;

--- a/packages/db/scripts/verify-migration-journal.ts
+++ b/packages/db/scripts/verify-migration-journal.ts
@@ -10,9 +10,15 @@
  * writes, no `migrate()` call, no DDL.
  *
  * Usage: `DB_URL=postgres://... vp run db:verify-journal`
- * Exit 0 = every journal migration is recorded. Exit 1 = each missing tag
+ * Exit 0 = no gap the deploy gate would fail on. Exit 1 = each missing tag
  * listed with the ledger hash its repair row needs, so nobody has to re-derive
  * a sha256 by hand (the exact parity liability this check avoids elsewhere).
+ *
+ * Tags in the recorded baseline (`scripts/lib/migration-ledger-baseline.ts`)
+ * print with their repair hashes but do not set the exit code — production
+ * carried them before the gate existed, and blocking every release on that
+ * backlog is what this baseline exists to avoid. They are still printed, because
+ * a tolerated gap nobody sees is a gap nobody repairs.
  */
 import postgres from 'postgres';
 import { describeDatabaseHost, getScriptDatabaseUrl } from './db-connection.js';
@@ -26,19 +32,33 @@ async function verifyMigrationJournal(): Promise<void> {
   const client = postgres(databaseUrl, { max: 1 });
   try {
     const report = await inspectMigrationJournal(readLedgerHashesWith(client));
-    if (report.missingTags.length > 0) {
+    if (report.baselinedMissing.length > 0) {
+      // Printed whether or not there is a new gap: these are the tags waiting on
+      // a hand repair, and the hashes below are what their repair rows need.
+      console.warn(
+        `⚠️  ${report.baselinedMissing.length} of ${report.expectedCount} journal migrations have no ledger row ` +
+          `and are covered by the baseline recorded ${report.baseline.recordedAt} (repair pending, deploy not blocked):`,
+      );
+      for (const migration of report.baselinedMissing) {
+        console.warn(`   • ${migration.tag}  (ledger hash ${migration.hash})`);
+      }
+    }
+    if (report.unbaselinedMissing.length > 0) {
       console.error(
-        `❌ ${report.missingTags.length} of ${report.expectedCount} journal migrations have no row in ` +
+        `❌ ${report.unbaselinedMissing.length} of ${report.expectedCount} journal migrations have no row in ` +
           `drizzle.__drizzle_migrations (${report.ledgerCount} rows present).`,
       );
-      for (const migration of report.missing) {
+      for (const migration of report.unbaselinedMissing) {
         console.error(`   • ${migration.tag}  (ledger hash ${migration.hash})`);
       }
       console.error(`   ${MIGRATION_GAP_REMEDIATION}`);
       process.exitCode = 1;
       return;
     }
-    console.info(`✅ All ${report.expectedCount} journal migrations are recorded (${report.ledgerCount} ledger rows).`);
+    console.info(
+      `✅ All ${report.expectedCount - report.baselinedMissing.length} unbaselined journal migrations are ` +
+        `recorded (${report.ledgerCount} ledger rows).`,
+    );
   } catch (error) {
     console.error('❌ Migration journal verification failed:', error);
     process.exitCode = 1;

--- a/scripts/lib/migration-ledger-baseline.test.ts
+++ b/scripts/lib/migration-ledger-baseline.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { EMPTY_LEDGER_BASELINE, PRODUCTION_LEDGER_BASELINE } from './migration-ledger-baseline';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const JOURNAL_PATH = path.resolve(__dirname, '../../packages/db/drizzle/meta/_journal.json');
+
+function journalTags(): string[] {
+  const journal = JSON.parse(fs.readFileSync(JOURNAL_PATH, 'utf-8')) as { entries: { tag: string }[] };
+  return journal.entries.map((entry) => entry.tag);
+}
+
+describe('production ledger baseline', () => {
+  it('names only tags that are still in the journal', () => {
+    // The deploy gate throws on an unknown tag rather than tolerating it, so
+    // without this test the first symptom of a typo or a renamed migration is a
+    // blocked production deploy.
+    const tags = new Set(journalTags());
+    const unknown = PRODUCTION_LEDGER_BASELINE.tags.filter((tag) => !tags.has(tag));
+    expect(unknown).toEqual([]);
+  });
+
+  it('lists each tag once', () => {
+    const seen = new Set(PRODUCTION_LEDGER_BASELINE.tags);
+    expect(seen.size).toBe(PRODUCTION_LEDGER_BASELINE.tags.length);
+  });
+
+  it('lists tags in journal order', () => {
+    // Journal order is how `db:verify-journal` prints a gap, so keeping the file
+    // in the same order makes "repair a tag, delete its line" a one-line diff.
+    const positionOf = new Map(journalTags().map((tag, index) => [tag, index]));
+    const positions = PRODUCTION_LEDGER_BASELINE.tags.map((tag) => positionOf.get(tag) ?? -1);
+    expect(positions).toEqual([...positions].sort((left, right) => left - right));
+  });
+
+  it('covers only migrations old enough to predate the gate', () => {
+    // A new migration must never be baselined: a gap there means DDL that never
+    // reached production, which is the outage #2933 was closed to prevent. The
+    // 20 recorded tags all sit in the first 103 of 188 journal entries; anything
+    // appended from here on is well past that.
+    const tags = journalTags();
+    const newestBaselinedIndex = Math.max(...PRODUCTION_LEDGER_BASELINE.tags.map((tag) => tags.indexOf(tag)));
+    expect(newestBaselinedIndex).toBeLessThan(120);
+  });
+
+  it('tolerates nothing when empty', () => {
+    expect(EMPTY_LEDGER_BASELINE.tags).toEqual([]);
+  });
+});

--- a/scripts/lib/migration-ledger-baseline.test.ts
+++ b/scripts/lib/migration-ledger-baseline.test.ts
@@ -3,7 +3,11 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-import { EMPTY_LEDGER_BASELINE, PRODUCTION_LEDGER_BASELINE } from './migration-ledger-baseline';
+import {
+  EMPTY_LEDGER_BASELINE,
+  JOURNAL_LENGTH_WHEN_BASELINE_RECORDED,
+  PRODUCTION_LEDGER_BASELINE,
+} from './migration-ledger-baseline';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const JOURNAL_PATH = path.resolve(__dirname, '../../packages/db/drizzle/meta/_journal.json');
@@ -13,40 +17,51 @@ function journalTags(): string[] {
   return journal.entries.map((entry) => entry.tag);
 }
 
+const baselinedTags = PRODUCTION_LEDGER_BASELINE.migrations.map((migration) => migration.tag);
+
 describe('production ledger baseline', () => {
   it('names only tags that are still in the journal', () => {
     // The deploy gate throws on an unknown tag rather than tolerating it, so
     // without this test the first symptom of a typo or a renamed migration is a
     // blocked production deploy.
     const tags = new Set(journalTags());
-    const unknown = PRODUCTION_LEDGER_BASELINE.tags.filter((tag) => !tags.has(tag));
-    expect(unknown).toEqual([]);
+    expect(baselinedTags.filter((tag) => !tags.has(tag))).toEqual([]);
   });
 
   it('lists each tag once', () => {
-    const seen = new Set(PRODUCTION_LEDGER_BASELINE.tags);
-    expect(seen.size).toBe(PRODUCTION_LEDGER_BASELINE.tags.length);
+    expect(new Set(baselinedTags).size).toBe(baselinedTags.length);
   });
 
   it('lists tags in journal order', () => {
     // Journal order is how `db:verify-journal` prints a gap, so keeping the file
     // in the same order makes "repair a tag, delete its line" a one-line diff.
     const positionOf = new Map(journalTags().map((tag, index) => [tag, index]));
-    const positions = PRODUCTION_LEDGER_BASELINE.tags.map((tag) => positionOf.get(tag) ?? -1);
+    const positions = baselinedTags.map((tag) => positionOf.get(tag) ?? -1);
     expect(positions).toEqual([...positions].sort((left, right) => left - right));
   });
 
-  it('covers only migrations old enough to predate the gate', () => {
-    // A new migration must never be baselined: a gap there means DDL that never
-    // reached production, which is the outage #2933 was closed to prevent. The
-    // 20 recorded tags all sit in the first 103 of 188 journal entries; anything
-    // appended from here on is well past that.
+  it('covers only migrations that existed when the baseline was recorded', () => {
+    // A migration appended after the baseline must never be baselined: a gap
+    // there means DDL that never reached production, which is the outage #2933
+    // was closed to prevent. Anchored to the journal length at record time
+    // rather than a margin, so the bound cannot drift into always passing.
     const tags = journalTags();
-    const newestBaselinedIndex = Math.max(...PRODUCTION_LEDGER_BASELINE.tags.map((tag) => tags.indexOf(tag)));
-    expect(newestBaselinedIndex).toBeLessThan(120);
+    expect(tags.length).toBeGreaterThanOrEqual(JOURNAL_LENGTH_WHEN_BASELINE_RECORDED);
+    const newestBaselinedIndex = Math.max(...baselinedTags.map((tag) => tags.indexOf(tag)));
+    expect(newestBaselinedIndex).toBeLessThan(JOURNAL_LENGTH_WHEN_BASELINE_RECORDED);
+  });
+
+  it('pins every entry to a sha256-shaped hash', () => {
+    // The exemption is (tag, hash), not tag — see the module header. A blank or
+    // truncated hash would silently stop matching and turn a tolerated gap fatal.
+    // Parity with the files on disk is asserted in packages/db, where drizzle's
+    // own readMigrationFiles is available.
+    for (const migration of PRODUCTION_LEDGER_BASELINE.migrations) {
+      expect(migration.hash, migration.tag).toMatch(/^[0-9a-f]{64}$/);
+    }
   });
 
   it('tolerates nothing when empty', () => {
-    expect(EMPTY_LEDGER_BASELINE.tags).toEqual([]);
+    expect(EMPTY_LEDGER_BASELINE.migrations).toEqual([]);
   });
 });

--- a/scripts/lib/migration-ledger-baseline.ts
+++ b/scripts/lib/migration-ledger-baseline.ts
@@ -1,0 +1,98 @@
+/**
+ * The journal-vs-ledger gaps production already carried when the deploy gate
+ * started failing on them.
+ *
+ * `VERIFY_MIGRATION_JOURNAL=1` landed fail-closed (#2933) and immediately
+ * blocked every production deploy: `migrate` is the `needs:` gate for both
+ * `deploy-web` and `deploy-production-backend`, and the production ledger has no
+ * row matching 20 of the 188 journal entries. None of those 20 are recent — they
+ * accumulated over two years, so the gate's first run reported a backlog rather
+ * than the regression it was built to catch.
+ *
+ * Every tag below is subtracted before the gate throws. A gap in any *other*
+ * tag still fails the deploy, which is the case that matters: the incident
+ * behind #2933 was a freshly appended migration (`0129_numerous_star_brand`)
+ * that drizzle's high-water mark skipped, and that shape is still caught on the
+ * first deploy after it happens. The gate keeps naming the baselined tags on
+ * every run, so they stay visible instead of becoming permanently invisible.
+ *
+ * ## What is in here
+ *
+ * A missing ledger row has two possible causes and this list mixes both, because
+ * telling them apart needs the production schema in front of you (see
+ * `docs/db-migrations.md`):
+ *
+ *  - **The `.sql` changed after production applied it.** The ledger stores the
+ *    hash of the file as it was when it ran, so an edit orphans the row.
+ *    `0103_thick_puck` is the clearest case: it landed as bare `CREATE TABLE`
+ *    and was rewritten with `IF NOT EXISTS` guards a day later, after the deploy
+ *    that applied the original. 11 of the 20 tags below have more than one
+ *    content version in git history, which is the same signature.
+ *  - **The migration never ran, or its row was lost.** The high-water-mark skip
+ *    (#2933's own failure mode), or a hand repair / restore that rebuilt the
+ *    schema without the ledger row. The `0025`–`0029` block arrived with the
+ *    migration consolidation in #470, which rewrote the journal around rows that
+ *    already existed.
+ *
+ * That second cause is why this file is a stopgap and not a resolution: if one
+ * of these migrations genuinely never ran, its objects are absent in production
+ * and this list is now hiding that. The tags are itemised rather than collapsed
+ * into a "before tag N" cut-off precisely so shrinking the list is a normal
+ * reviewable diff — repair a tag against production, delete its line.
+ *
+ * ## Shrinking it
+ *
+ * `DB_URL=postgres://... vp run db:verify-journal` prints each remaining tag
+ * with the ledger hash its repair row needs. Repair per `docs/db-migrations.md`
+ * ("The journal-vs-ledger check"), then remove the tag here. Do not add a tag
+ * without a reason: a new gap means a migration that did not reach production,
+ * and baselining it ships the outage #2933 was closed to prevent.
+ */
+
+export interface LedgerBaseline {
+  /** ISO date the gap was observed, so a stale list reads as stale. */
+  readonly recordedAt: string;
+  /** Where the gap was observed, for anyone re-deriving the list. */
+  readonly source: string;
+  /** Journal-order tags the deploy gate tolerates. */
+  readonly tags: readonly string[];
+}
+
+/**
+ * Observed on the production database (`tramway.proxy.rlwy.net`) by the first
+ * `Production Deploy` run that armed the gate: 20 of 188 journal entries had no
+ * ledger row, with 183 rows present.
+ */
+export const PRODUCTION_LEDGER_BASELINE: LedgerBaseline = {
+  recordedAt: '2026-07-30',
+  source: 'Production Deploy run 30528469806 (migrate job), commit f3a1a22',
+  tags: [
+    '0000_cloudy_carlie_cooper',
+    '0002_unique_climbstats',
+    '0014_add_missing_primary_keys',
+    '0025_fix_missing_tables',
+    '0026_migrate_aurora_to_boardsesh_ticks',
+    '0027_add_sequence_column',
+    '0028_add_instagram_url',
+    '0029_add_aurora_id_unique_index',
+    '0025_shocking_clint_barton',
+    '0052_broad_red_ghost',
+    '0067_fat_betty_ross',
+    '0068_add_search_performance_indexes',
+    '0069_mature_morg',
+    '0073_denormalize_climb_sets_sizes',
+    '0077_mixed_lady_deathstrike',
+    '0078_yummy_kylun',
+    '0079_backfill_tick_quality_scale',
+    '0082_add_user_climb_percentiles',
+    '0092_long_demogoblin',
+    '0103_thick_puck',
+  ],
+};
+
+/** A baseline that tolerates nothing. The default for any folder that is not this repo's. */
+export const EMPTY_LEDGER_BASELINE: LedgerBaseline = {
+  recordedAt: PRODUCTION_LEDGER_BASELINE.recordedAt,
+  source: 'no baseline',
+  tags: [],
+};

--- a/scripts/lib/migration-ledger-baseline.ts
+++ b/scripts/lib/migration-ledger-baseline.ts
@@ -9,12 +9,29 @@
  * accumulated over two years, so the gate's first run reported a backlog rather
  * than the regression it was built to catch.
  *
- * Every tag below is subtracted before the gate throws. A gap in any *other*
- * tag still fails the deploy, which is the case that matters: the incident
- * behind #2933 was a freshly appended migration (`0129_numerous_star_brand`)
- * that drizzle's high-water mark skipped, and that shape is still caught on the
- * first deploy after it happens. The gate keeps naming the baselined tags on
- * every run, so they stay visible instead of becoming permanently invisible.
+ * Every migration below is subtracted before the gate throws. A gap in any
+ * *other* journal entry still fails the deploy, which is the case that matters:
+ * the incident behind #2933 was a freshly appended migration
+ * (`0129_numerous_star_brand`) that drizzle's high-water mark skipped, and that
+ * shape is still caught on the first deploy after it happens. The gate keeps
+ * naming the baselined tags on every run, so they stay visible instead of
+ * becoming permanently invisible.
+ *
+ * ## Why each entry carries a hash
+ *
+ * Tolerating a *tag* would outlive the file it was recorded against. Edit one of
+ * these `.sql` files and drizzle computes a new expected hash; the database still
+ * has no matching row, and the migration's old `when` keeps it from replaying —
+ * so a tag-only baseline would report "known gap, deploy on" while the edited DDL
+ * never ran. That is the silent failure this gate exists to catch, re-created one
+ * layer up.
+ *
+ * So each entry pins the hash the file had when the gap was recorded. Same tag,
+ * different content, and the gap is fatal again with the change named. The hashes
+ * come from drizzle's own `readMigrationFiles`, the same source the gate compares
+ * against, and `migration-journal-verification.integration.test.ts` asserts they
+ * still match the files on disk — so an edit to a baselined migration reddens the
+ * PR rather than the deploy.
  *
  * ## What is in here
  *
@@ -26,7 +43,7 @@
  *    hash of the file as it was when it ran, so an edit orphans the row.
  *    `0103_thick_puck` is the clearest case: it landed as bare `CREATE TABLE`
  *    and was rewritten with `IF NOT EXISTS` guards a day later, after the deploy
- *    that applied the original. 11 of the 20 tags below have more than one
+ *    that applied the original. 11 of the 20 entries below have more than one
  *    content version in git history, which is the same signature.
  *  - **The migration never ran, or its row was lost.** The high-water-mark skip
  *    (#2933's own failure mode), or a hand repair / restore that rebuilt the
@@ -36,27 +53,41 @@
  *
  * That second cause is why this file is a stopgap and not a resolution: if one
  * of these migrations genuinely never ran, its objects are absent in production
- * and this list is now hiding that. The tags are itemised rather than collapsed
- * into a "before tag N" cut-off precisely so shrinking the list is a normal
- * reviewable diff — repair a tag against production, delete its line.
+ * and this list is now hiding that. The entries are itemised rather than
+ * collapsed into a "before tag N" cut-off precisely so shrinking the list is a
+ * normal reviewable diff — repair one against production, delete its line.
  *
  * ## Shrinking it
  *
  * `DB_URL=postgres://... vp run db:verify-journal` prints each remaining tag
  * with the ledger hash its repair row needs. Repair per `docs/db-migrations.md`
- * ("The journal-vs-ledger check"), then remove the tag here. Do not add a tag
+ * ("The journal-vs-ledger check"), then remove the entry here. Do not add one
  * without a reason: a new gap means a migration that did not reach production,
  * and baselining it ships the outage #2933 was closed to prevent.
  */
+import type { ExpectedMigration } from './migration-ledger.js';
 
 export interface LedgerBaseline {
   /** ISO date the gap was observed, so a stale list reads as stale. */
   readonly recordedAt: string;
   /** Where the gap was observed, for anyone re-deriving the list. */
   readonly source: string;
-  /** Journal-order tags the deploy gate tolerates. */
-  readonly tags: readonly string[];
+  /**
+   * Journal-order entries the deploy gate tolerates, each pinned to the hash its
+   * `.sql` had when the gap was recorded.
+   */
+  readonly migrations: readonly ExpectedMigration[];
 }
+
+/**
+ * How many journal entries existed when the baseline was recorded.
+ *
+ * The anchor for the rule that matters: nothing appended after this point may be
+ * baselined, because a gap there is a migration that did not reach production.
+ * The journal only ever grows, so this stays a meaningful bound instead of
+ * drifting into a tautology the way a hand-picked margin would.
+ */
+export const JOURNAL_LENGTH_WHEN_BASELINE_RECORDED = 188;
 
 /**
  * Observed on the production database (`tramway.proxy.rlwy.net`) by the first
@@ -66,33 +97,55 @@ export interface LedgerBaseline {
 export const PRODUCTION_LEDGER_BASELINE: LedgerBaseline = {
   recordedAt: '2026-07-30',
   source: 'Production Deploy run 30528469806 (migrate job), commit f3a1a22',
-  tags: [
-    '0000_cloudy_carlie_cooper',
-    '0002_unique_climbstats',
-    '0014_add_missing_primary_keys',
-    '0025_fix_missing_tables',
-    '0026_migrate_aurora_to_boardsesh_ticks',
-    '0027_add_sequence_column',
-    '0028_add_instagram_url',
-    '0029_add_aurora_id_unique_index',
-    '0025_shocking_clint_barton',
-    '0052_broad_red_ghost',
-    '0067_fat_betty_ross',
-    '0068_add_search_performance_indexes',
-    '0069_mature_morg',
-    '0073_denormalize_climb_sets_sizes',
-    '0077_mixed_lady_deathstrike',
-    '0078_yummy_kylun',
-    '0079_backfill_tick_quality_scale',
-    '0082_add_user_climb_percentiles',
-    '0092_long_demogoblin',
-    '0103_thick_puck',
+  migrations: [
+    { tag: '0000_cloudy_carlie_cooper', hash: 'e6ac2b585a2551f3ddd444817ee21032aad6a592b4cf86b83e9f41c67913d864' },
+    { tag: '0002_unique_climbstats', hash: 'a5a2ae48548e995fc4bc45b85087a7ac47ad959aa7a691899fac42a83256bbe8' },
+    { tag: '0014_add_missing_primary_keys', hash: '036762880bc8cc726ea43a4ce8170b3b98487f435c9e526d3305cb6d3cf33341' },
+    { tag: '0025_fix_missing_tables', hash: '843f0ff0702aef915ad480615821a662261707ab987707cbd39ccb23ef0a6492' },
+    {
+      tag: '0026_migrate_aurora_to_boardsesh_ticks',
+      hash: '8f6dbb45163454a48661897dade0cbc31e456df078455fda3646b783e7b93688',
+    },
+    { tag: '0027_add_sequence_column', hash: '82f8bd84ecf72af12188c5bde8558ca38f6474fe495ff849acee8ec7982ac57c' },
+    { tag: '0028_add_instagram_url', hash: '719cb4c8ee7ac0449aaab7b68f4825661a402d9028928f1b225ded0825e4b964' },
+    {
+      tag: '0029_add_aurora_id_unique_index',
+      hash: 'd3a58e2548c66fc7244facc5e878abe401048870cb1f532b36c46ca2ac721702',
+    },
+    { tag: '0025_shocking_clint_barton', hash: 'f3325a8184b63847d972302af89a6c5f8ca6610499c94aaf73d10b435f38e6b3' },
+    { tag: '0052_broad_red_ghost', hash: '75b3929167d87d81edc52761fe69e8027b04beede91a5d16755e35b928a99178' },
+    { tag: '0067_fat_betty_ross', hash: 'f28c121e071e16d9936ccf0e07d011a4953a6872ad6aa6a819a6b7b0039ca6af' },
+    {
+      tag: '0068_add_search_performance_indexes',
+      hash: 'cc1c1c94d3f67071f0227a14b8411ab3bf3e3b243c67ce97dd5e7e07293aed0e',
+    },
+    { tag: '0069_mature_morg', hash: '6f9b394f9082963652d50106a09c50066676832b6a0937ffc98d74b63a86ff59' },
+    {
+      tag: '0073_denormalize_climb_sets_sizes',
+      hash: '94fb37d773387f8e7316197a170f6e3b8cb4ca1fd318ddd416d35312690cd2e1',
+    },
+    { tag: '0077_mixed_lady_deathstrike', hash: '2320b9881ce5b4e25cedd6504b99e95ac674426407b0081b7103e2e51cfabca2' },
+    { tag: '0078_yummy_kylun', hash: 'b9fb9f34eca54caed672f4e520f1483c87aa6e5425cf31904b968a6f9dfd63df' },
+    {
+      tag: '0079_backfill_tick_quality_scale',
+      hash: 'f1759562134dbfa78df38eb7810a4d56c76a185f2e9e8b6c6f588f4d0f55ff8b',
+    },
+    {
+      tag: '0082_add_user_climb_percentiles',
+      hash: 'a1be612e137de35315e1277906c300ab4344cadbe767315571774d1a103a4ddc',
+    },
+    { tag: '0092_long_demogoblin', hash: '09795e40fabfca2e209894635bbd697c46cf55f28e102520362e258064b6e906' },
+    { tag: '0103_thick_puck', hash: '2cc675b9e0fc6a612120342fa262c72bc72b3bbdd9a0b0957d9ff3ed70567a1d' },
   ],
 };
 
-/** A baseline that tolerates nothing. The default for any folder that is not this repo's. */
+/**
+ * A baseline that tolerates nothing. The default for any folder that is not this
+ * repo's. `recordedAt` is a sentinel rather than a date: nothing is recorded here,
+ * and a copied real date would read as if something were.
+ */
 export const EMPTY_LEDGER_BASELINE: LedgerBaseline = {
-  recordedAt: PRODUCTION_LEDGER_BASELINE.recordedAt,
+  recordedAt: 'n/a',
   source: 'no baseline',
-  tags: [],
+  migrations: [],
 };

--- a/scripts/lib/migration-ledger.test.ts
+++ b/scripts/lib/migration-ledger.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { findUnappliedMigrations, formatMigrationGapError, type ExpectedMigration } from './migration-ledger';
+import {
+  findUnappliedMigrations,
+  formatBaselinedGapWarning,
+  formatMigrationGapError,
+  partitionMissingMigrations,
+  type ExpectedMigration,
+} from './migration-ledger';
 
 function expectedFrom(...tags: string[]): ExpectedMigration[] {
   return tags.map((tag) => ({ tag, hash: `hash-of-${tag}` }));
@@ -58,6 +64,71 @@ describe('findUnappliedMigrations', () => {
 
   it('returns nothing for an empty journal', () => {
     expect(findUnappliedMigrations([], hashesFor('0000_a'))).toEqual([]);
+  });
+});
+
+describe('partitionMissingMigrations', () => {
+  it('separates the recorded backlog from a new gap', () => {
+    const missing = expectedFrom('0000_old_gap', '0187_new_gap');
+    const { baselined, unbaselined } = partitionMissingMigrations(missing, ['0000_old_gap']);
+    expect(baselined.map((migration) => migration.tag)).toEqual(['0000_old_gap']);
+    expect(unbaselined.map((migration) => migration.tag)).toEqual(['0187_new_gap']);
+  });
+
+  it('keeps the hash on both sides', () => {
+    // Baselined tags still print their repair hash — that is how the backlog
+    // gets shrunk without re-deriving a sha256 by hand.
+    const { baselined } = partitionMissingMigrations(expectedFrom('0000_old_gap'), ['0000_old_gap']);
+    expect(baselined).toEqual([{ tag: '0000_old_gap', hash: 'hash-of-0000_old_gap' }]);
+  });
+
+  it('preserves journal order within each side', () => {
+    const missing = expectedFrom('0000_a', '0001_b', '0002_c', '0003_d');
+    const { baselined, unbaselined } = partitionMissingMigrations(missing, ['0002_c', '0000_a']);
+    expect(baselined.map((migration) => migration.tag)).toEqual(['0000_a', '0002_c']);
+    expect(unbaselined.map((migration) => migration.tag)).toEqual(['0001_b', '0003_d']);
+  });
+
+  it('matches on tag, not hash', () => {
+    // Byte-identical SQL shares a hash. Baselining a tolerated old migration
+    // must not also excuse an unrelated new one that copied its body.
+    const duplicateHash = 'identical-sql-body';
+    const missing: ExpectedMigration[] = [
+      { tag: '0000_tolerated', hash: duplicateHash },
+      { tag: '0187_new_copy', hash: duplicateHash },
+    ];
+    const { unbaselined } = partitionMissingMigrations(missing, ['0000_tolerated']);
+    expect(unbaselined.map((migration) => migration.tag)).toEqual(['0187_new_copy']);
+  });
+
+  it('leaves everything unbaselined when the baseline is empty', () => {
+    const missing = expectedFrom('0000_a', '0001_b');
+    const { baselined, unbaselined } = partitionMissingMigrations(missing, []);
+    expect(baselined).toEqual([]);
+    expect(unbaselined).toEqual(missing);
+  });
+
+  it('ignores baseline tags that are not missing', () => {
+    // The healthy end state: a repaired tag still listed in the baseline is
+    // dead weight, not a failure.
+    const { baselined, unbaselined } = partitionMissingMigrations([], ['0000_already_repaired']);
+    expect(baselined).toEqual([]);
+    expect(unbaselined).toEqual([]);
+  });
+});
+
+describe('formatBaselinedGapWarning', () => {
+  it('names every tolerated tag, the date, and where to shrink the list', () => {
+    const message = formatBaselinedGapWarning(['0069_mature_morg', '0103_thick_puck'], '2026-07-30', 188);
+    expect(message).toContain('0069_mature_morg');
+    expect(message).toContain('0103_thick_puck');
+    expect(message).toContain('2 of 188');
+    expect(message).toContain('2026-07-30');
+    expect(message).toContain('scripts/lib/migration-ledger-baseline.ts');
+  });
+
+  it('says the deploy is not blocked, so the line is not read as a failure', () => {
+    expect(formatBaselinedGapWarning(['0069_mature_morg'], '2026-07-30', 188)).toContain('not blocked');
   });
 });
 

--- a/scripts/lib/migration-ledger.test.ts
+++ b/scripts/lib/migration-ledger.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   findUnappliedMigrations,
   formatBaselinedGapWarning,
+  formatEditedBaselineNote,
   formatMigrationGapError,
   partitionMissingMigrations,
   type ExpectedMigration,
@@ -70,7 +71,7 @@ describe('findUnappliedMigrations', () => {
 describe('partitionMissingMigrations', () => {
   it('separates the recorded backlog from a new gap', () => {
     const missing = expectedFrom('0000_old_gap', '0187_new_gap');
-    const { baselined, unbaselined } = partitionMissingMigrations(missing, ['0000_old_gap']);
+    const { baselined, unbaselined } = partitionMissingMigrations(missing, expectedFrom('0000_old_gap'));
     expect(baselined.map((migration) => migration.tag)).toEqual(['0000_old_gap']);
     expect(unbaselined.map((migration) => migration.tag)).toEqual(['0187_new_gap']);
   });
@@ -78,26 +79,52 @@ describe('partitionMissingMigrations', () => {
   it('keeps the hash on both sides', () => {
     // Baselined tags still print their repair hash — that is how the backlog
     // gets shrunk without re-deriving a sha256 by hand.
-    const { baselined } = partitionMissingMigrations(expectedFrom('0000_old_gap'), ['0000_old_gap']);
+    const { baselined } = partitionMissingMigrations(expectedFrom('0000_old_gap'), expectedFrom('0000_old_gap'));
     expect(baselined).toEqual([{ tag: '0000_old_gap', hash: 'hash-of-0000_old_gap' }]);
   });
 
   it('preserves journal order within each side', () => {
     const missing = expectedFrom('0000_a', '0001_b', '0002_c', '0003_d');
-    const { baselined, unbaselined } = partitionMissingMigrations(missing, ['0002_c', '0000_a']);
+    const { baselined, unbaselined } = partitionMissingMigrations(missing, expectedFrom('0002_c', '0000_a'));
     expect(baselined.map((migration) => migration.tag)).toEqual(['0000_a', '0002_c']);
     expect(unbaselined.map((migration) => migration.tag)).toEqual(['0001_b', '0003_d']);
   });
 
-  it('matches on tag, not hash', () => {
-    // Byte-identical SQL shares a hash. Baselining a tolerated old migration
-    // must not also excuse an unrelated new one that copied its body.
+  it('stops tolerating a baselined migration whose .sql changed', () => {
+    // The exemption is (tag, hash). Editing an applied migration gives drizzle a
+    // new expected hash while the old `when` keeps it from replaying, so a
+    // tag-only exemption would wave through DDL that never ran.
+    const missing: ExpectedMigration[] = [{ tag: '0103_thick_puck', hash: 'hash-after-the-edit' }];
+    const { baselined, unbaselined, editedSinceBaseline } = partitionMissingMigrations(missing, [
+      { tag: '0103_thick_puck', hash: 'hash-when-recorded' },
+    ]);
+    expect(baselined).toEqual([]);
+    expect(unbaselined.map((migration) => migration.tag)).toEqual(['0103_thick_puck']);
+    expect(editedSinceBaseline.map((migration) => migration.tag)).toEqual(['0103_thick_puck']);
+  });
+
+  it('reports an unbaselined tag as new, not as edited', () => {
+    // editedSinceBaseline exists to route the operator to the diff instead of the
+    // ledger, so it must not collect gaps the baseline never mentioned.
+    const { editedSinceBaseline } = partitionMissingMigrations(
+      expectedFrom('0187_new_gap'),
+      expectedFrom('0000_old_gap'),
+    );
+    expect(editedSinceBaseline).toEqual([]);
+  });
+
+  it('does not let one tolerated migration excuse another with identical SQL', () => {
+    // Byte-identical .sql files share a hash, so a hash-only match would let a new
+    // migration inherit a tolerated one's exemption.
     const duplicateHash = 'identical-sql-body';
     const missing: ExpectedMigration[] = [
       { tag: '0000_tolerated', hash: duplicateHash },
       { tag: '0187_new_copy', hash: duplicateHash },
     ];
-    const { unbaselined } = partitionMissingMigrations(missing, ['0000_tolerated']);
+    const { baselined, unbaselined } = partitionMissingMigrations(missing, [
+      { tag: '0000_tolerated', hash: duplicateHash },
+    ]);
+    expect(baselined.map((migration) => migration.tag)).toEqual(['0000_tolerated']);
     expect(unbaselined.map((migration) => migration.tag)).toEqual(['0187_new_copy']);
   });
 
@@ -108,12 +135,21 @@ describe('partitionMissingMigrations', () => {
     expect(unbaselined).toEqual(missing);
   });
 
-  it('ignores baseline tags that are not missing', () => {
-    // The healthy end state: a repaired tag still listed in the baseline is
+  it('ignores baseline entries that are not missing', () => {
+    // The healthy end state: a repaired entry still listed in the baseline is
     // dead weight, not a failure.
-    const { baselined, unbaselined } = partitionMissingMigrations([], ['0000_already_repaired']);
+    const { baselined, unbaselined } = partitionMissingMigrations([], expectedFrom('0000_already_repaired'));
     expect(baselined).toEqual([]);
     expect(unbaselined).toEqual([]);
+  });
+});
+
+describe('formatEditedBaselineNote', () => {
+  it('names the tag and says to write a new migration instead', () => {
+    const note = formatEditedBaselineNote(['0103_thick_puck']);
+    expect(note).toContain('0103_thick_puck');
+    expect(note).toContain('no longer hashes to the recorded value');
+    expect(note).toContain('never re-runs');
   });
 });
 

--- a/scripts/lib/migration-ledger.ts
+++ b/scripts/lib/migration-ledger.ts
@@ -73,6 +73,29 @@ export function findUnappliedMigrations(
 }
 
 /**
+ * Splits a gap into the part a recorded baseline already accounts for and the
+ * part that is new. Only the new part fails a deploy; see
+ * `migration-ledger-baseline.ts` for why the baseline exists at all.
+ *
+ * Tag-keyed rather than hash-keyed, unlike `findUnappliedMigrations`: a journal
+ * tag is a filename and therefore unique, while a hash deliberately is not.
+ * Baselining by hash would tolerate a second, unrelated migration that happened
+ * to carry byte-identical SQL.
+ */
+export function partitionMissingMigrations(
+  missing: readonly ExpectedMigration[],
+  baselinedTags: readonly string[],
+): { baselined: ExpectedMigration[]; unbaselined: ExpectedMigration[] } {
+  const baselinedTagSet = new Set(baselinedTags);
+  const baselined: ExpectedMigration[] = [];
+  const unbaselined: ExpectedMigration[] = [];
+  for (const migration of missing) {
+    (baselinedTagSet.has(migration.tag) ? baselined : unbaselined).push(migration);
+  }
+  return { baselined, unbaselined };
+}
+
+/**
  * What the operator does next. Shared so the deploy-gate throw and the
  * `db:verify-journal` CLI (which prints its tag list across lines) cannot drift
  * into telling two different stories about the same condition.
@@ -99,5 +122,25 @@ export function formatMigrationGapError(
     `${plural} no row in drizzle.__drizzle_migrations (${ledgerCount} rows present). ` +
     `Missing: ${missingTags.join(', ')}. ` +
     MIGRATION_GAP_REMEDIATION
+  );
+}
+
+/**
+ * Printed on every armed run, not only when something else is wrong. A tolerated
+ * gap that stops being mentioned is a gap nobody repairs — and the honest reading
+ * of these tags is "production may be missing this DDL", not "resolved".
+ */
+export function formatBaselinedGapWarning(
+  baselinedTags: readonly string[],
+  recordedAt: string,
+  expectedCount: number,
+): string {
+  const subject =
+    baselinedTags.length === 1 ? 'migration has no ledger row and is' : 'migrations have no ledger row and are';
+  return (
+    `${baselinedTags.length} of ${expectedCount} journal ${subject} covered by the ` +
+    `baseline recorded ${recordedAt} — the deploy is not blocked on it. Repair pending: ` +
+    `${baselinedTags.join(', ')}. See docs/db-migrations.md and shrink the list in ` +
+    'scripts/lib/migration-ledger-baseline.ts as each one is repaired.'
   );
 }

--- a/scripts/lib/migration-ledger.ts
+++ b/scripts/lib/migration-ledger.ts
@@ -72,27 +72,50 @@ export function findUnappliedMigrations(
   return missingTags;
 }
 
+export interface MissingMigrationPartition {
+  /** Gaps the baseline accounts for, at the exact content it was recorded against. */
+  baselined: ExpectedMigration[];
+  /** Everything else. Anything here fails the deploy. */
+  unbaselined: ExpectedMigration[];
+  /**
+   * The subset of `unbaselined` whose tag *is* baselined but whose `.sql` no
+   * longer hashes to the recorded value — reported separately because the
+   * operator's next step is different: look at the edit, not at the ledger.
+   */
+  editedSinceBaseline: ExpectedMigration[];
+}
+
 /**
  * Splits a gap into the part a recorded baseline already accounts for and the
  * part that is new. Only the new part fails a deploy; see
  * `migration-ledger-baseline.ts` for why the baseline exists at all.
  *
- * Tag-keyed rather than hash-keyed, unlike `findUnappliedMigrations`: a journal
- * tag is a filename and therefore unique, while a hash deliberately is not.
- * Baselining by hash would tolerate a second, unrelated migration that happened
- * to carry byte-identical SQL.
+ * Matched on tag *and* hash. Tag alone would outlive the file it was recorded
+ * against: edit a baselined `.sql` and drizzle expects a new hash, the database
+ * still has no matching row, and the old `when` stops it from replaying — so the
+ * gate would wave through DDL that never ran, which is the failure it exists to
+ * catch. Hash alone would be wrong in the other direction, since byte-identical
+ * `.sql` files share a hash and an unrelated new migration could inherit a
+ * tolerated one's exemption.
  */
 export function partitionMissingMigrations(
   missing: readonly ExpectedMigration[],
-  baselinedTags: readonly string[],
-): { baselined: ExpectedMigration[]; unbaselined: ExpectedMigration[] } {
-  const baselinedTagSet = new Set(baselinedTags);
-  const baselined: ExpectedMigration[] = [];
-  const unbaselined: ExpectedMigration[] = [];
+  baselinedMigrations: readonly ExpectedMigration[],
+): MissingMigrationPartition {
+  const recordedHashByTag = new Map(baselinedMigrations.map((migration) => [migration.tag, migration.hash]));
+  const partition: MissingMigrationPartition = { baselined: [], unbaselined: [], editedSinceBaseline: [] };
   for (const migration of missing) {
-    (baselinedTagSet.has(migration.tag) ? baselined : unbaselined).push(migration);
+    const recordedHash = recordedHashByTag.get(migration.tag);
+    if (recordedHash === migration.hash) {
+      partition.baselined.push(migration);
+      continue;
+    }
+    partition.unbaselined.push(migration);
+    if (recordedHash !== undefined) {
+      partition.editedSinceBaseline.push(migration);
+    }
   }
-  return { baselined, unbaselined };
+  return partition;
 }
 
 /**
@@ -115,13 +138,31 @@ export function formatMigrationGapError(
   missingTags: readonly string[],
   expectedCount: number,
   ledgerCount: number,
+  editedSinceBaselineTags: readonly string[] = [],
 ): string {
   const plural = missingTags.length === 1 ? 'migration has' : 'migrations have';
   return (
     `Migration journal verification failed: ${missingTags.length} of ${expectedCount} journal ` +
     `${plural} no row in drizzle.__drizzle_migrations (${ledgerCount} rows present). ` +
     `Missing: ${missingTags.join(', ')}. ` +
+    (editedSinceBaselineTags.length > 0 ? `${formatEditedBaselineNote(editedSinceBaselineTags)} ` : '') +
     MIGRATION_GAP_REMEDIATION
+  );
+}
+
+/**
+ * The one gap shape whose next step is not a ledger repair: a baselined `.sql`
+ * whose content changed. The recorded exemption no longer applies, and the edit
+ * itself is the thing to look at — an applied migration never re-runs, so the new
+ * statements are not in any database.
+ */
+export function formatEditedBaselineNote(editedSinceBaselineTags: readonly string[]): string {
+  const plural = editedSinceBaselineTags.length === 1 ? 'is' : 'are';
+  return (
+    `${editedSinceBaselineTags.join(', ')} ${plural} in the recorded ledger baseline but no longer ` +
+    `${editedSinceBaselineTags.length === 1 ? 'hashes' : 'hash'} to the recorded value: the .sql changed after ` +
+    'the baseline was taken, so the exemption no longer covers it. Move the new statements into a new migration ' +
+    'rather than editing an applied one — an edit never re-runs.'
   );
 }
 


### PR DESCRIPTION
## Summary

Production has not deployed since `3a01396` (Jul 28). The `VERIFY_MIGRATION_JOURNAL=1` gate landed fail-closed, and `migrate` is the `needs:` gate for both `deploy-web` and `deploy-production-backend` — so the first armed run took the whole release down:

```
❌ 20 of 188 journal migrations have no row in drizzle.__drizzle_migrations (183 rows present).
Missing: 0000_cloudy_carlie_cooper, 0002_unique_climbstats, 0014_add_missing_primary_keys, …
```

None of the 20 are recent. They go back to the initial schema, so the gate reported a two-year backlog rather than the regression it was built to catch. Latest failure: [run 30528469806](https://github.com/boardsesh/boardsesh/actions/runs/30528469806). `CI` itself is green — only `Production Deploy` is red.

This records those 20 tags in `scripts/lib/migration-ledger-baseline.ts` and subtracts them before the gate throws. A gap in any **other** tag still fails the deploy, which keeps #2933's case intact: a freshly appended migration skipped by drizzle's high-water mark (the `0129_numerous_star_brand` incident) is caught on the first deploy after it happens.

Baselined tags are still named, with their repair hashes, on every armed run — by `migrate.ts` (`⚠️`) and by `db:verify-journal`, which exits 0 on them and 1 on anything else. A tolerated gap nobody sees is a gap nobody repairs.

**The list is a stopgap, and the honest caveat is in the PR as well as the file.** Two mechanisms produce those 20 tags and only one is harmless:

- **The `.sql` changed after production applied it**, orphaning the ledger row. `0103_thick_puck` landed as a bare `CREATE TABLE` and was rewritten with `IF NOT EXISTS` guards the next day, after the deploy that applied the original; 11 of the 20 have more than one content version in git history.
- **The migration never ran** — then production is missing that DDL right now and the baseline is hiding it. The `0025`–`0029` block arrived with the migration consolidation in #470.

Telling them apart needs the production schema in front of you, tag by tag (`docs/db-migrations.md` has the four repair steps). The tags are itemised rather than collapsed into a "before entry N" cut-off so shrinking the list is a one-line diff: repair a tag, delete its line. Adding a tag is explicitly not a normal fix.

A baselined tag that is no longer in the journal throws rather than silently tolerating nothing, and a vitest guard catches that at PR time instead of mid-deploy.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project scripts` — 511 passed, including the new `partitionMissingMigrations`, `formatBaselinedGapWarning`, and baseline-vs-`_journal.json` guards.
- `vp run test:db:migration-journal` — 11 tests, 5 pass / 6 skip locally (no Postgres in this environment); the skipped ones run in CI's `db-migrations` job against `postgres:17`. New: a baselined gap and an unbaselined gap side by side, where only the second may block; a stale baseline tag rejected; the production baseline not applying to synthetic folders.
- `vp run typecheck:db`, `vp check` — clean (the two `@gorhom/bottom-sheet` errors are the uninstalled `packages/mobile/web-runtime` nested lock, unrelated).
- Reproduced production's exact shape offline against the real journal — 188 entries, 183 ledger rows, 15 orphan rows — and confirmed the gate now passes, warns naming all 20 tags, and still throws on `0187_sad_freak` when its row is removed, without naming any baselined tag in that error.

**Still outstanding after this merges:** the 20 tags need a hand repair against production. That needs `DATABASE_URL` — `DB_URL=postgres://... vp run db:verify-journal` prints each remaining tag with the ledger hash its repair row needs.


---
_Generated by [Claude Code](https://claude.ai/code/session_018jhEAjVeDCvxyoJCg7y4uN)_