### PR TITLE
fix(mobile): walk MoonBoard playlists in the play drawer, and surface failed playlist adds

### DIFF
--- a/packages/backend/src/__tests__/playlist-climbs-board-scope.test.ts
+++ b/packages/backend/src/__tests__/playlist-climbs-board-scope.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeAll } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { playlistQueries } from '../graphql/resolvers/playlists/queries';
+
+// Seeds use raw `sql` rather than `db.insert(...)` because the integration test
+// DB is built from a minimal hand-maintained DDL (schema-sql.ts), not the full
+// Drizzle schema — the query builder emits every default-bearing column which
+// that DDL omits, so a builder insert fails. Naming only the columns the test
+// DDL declares is the genuine raw-SQL exception.
+
+// Integration test (real DB) for #3891: specific-board mode size-filters the
+// climb join on `compatible_size_ids`. MoonBoard has one fixed product size, so
+// its climbs carry NULL there — and the old `sizeId = ANY(NULL)` predicate is
+// NULL, never true, so every MoonBoard row was dropped. A MoonBoard playlist
+// therefore returned zero climbs to the play drawer's queue-replacement fetch
+// while the (all-boards-mode) detail list looked fine, and swiping in the drawer
+// had a one-item queue to walk.
+//
+// The pair "MoonBoard climbs come back" + "a size-incompatible Kilter climb is
+// still excluded" is load-bearing: either alone is satisfied by deleting the
+// predicate outright.
+
+const MOONBOARD_PLAYLIST_UUID = 'pl-board-scope-moon';
+const KILTER_PLAYLIST_UUID = 'pl-board-scope-kilter';
+const MOONBOARD_SIZE_ID = 1;
+const KILTER_SIZE_ID = 25;
+
+function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext {
+  return {
+    connectionId: 'conn-1',
+    isAuthenticated: false,
+    userId: null,
+    sessionId: null,
+    boardPath: null,
+    controllerId: null,
+    controllerApiKey: null,
+    ...overrides,
+  } as ConnectionContext;
+}
+
+async function seedClimb(
+  boardType: string,
+  uuid: string,
+  name: string,
+  layoutId: number,
+  compatibleSizeIds: number[] | null,
+) {
+  // Bind the array as a Postgres array literal cast to int[] — a JS array bound
+  // directly is expanded into a `(a, b, c)` record by the driver.
+  const sizeIdsLiteral = compatibleSizeIds === null ? null : `{${compatibleSizeIds.join(',')}}`;
+  await db.execute(sql`
+    INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, description, frames, is_listed, compatible_size_ids)
+    VALUES (${uuid}, ${boardType}, ${layoutId}, 'setter', ${name}, '', 'p1r1', true, ${sizeIdsLiteral}::int[])
+  `);
+}
+
+async function seedStats(boardType: string, uuid: string, angle: number) {
+  await db.execute(sql`
+    INSERT INTO board_climb_stats (board_type, climb_uuid, angle, display_difficulty, difficulty_average, quality_average, ascensionist_count, benchmark_difficulty)
+    VALUES (${boardType}, ${uuid}, ${angle}, 18, 18, 3.0, 10, 0)
+  `);
+}
+
+describe('playlistClimbs — board-scoped size filtering (real DB)', () => {
+  beforeAll(async () => {
+    // Playlist tables aren't in the global per-file reset list, so own the cleanup.
+    await db.execute(sql`TRUNCATE TABLE playlist_climbs, playlist_ownership, playlists RESTART IDENTITY CASCADE`);
+
+    // MoonBoard: one fixed size, so the ingest leaves compatible_size_ids NULL.
+    await seedClimb('moonboard', 'moon-1', 'Moon One', 7, null);
+    await seedClimb('moonboard', 'moon-2', 'Moon Two', 7, null);
+    await seedStats('moonboard', 'moon-1', 40);
+    await seedStats('moonboard', 'moon-2', 40);
+
+    // Kilter: real size variants. `kilter-fits` is climbable on the queried size
+    // (among others), `kilter-other` is not.
+    await seedClimb('kilter', 'kilter-fits', 'Fits This Size', 1, [7, KILTER_SIZE_ID, 28]);
+    await seedClimb('kilter', 'kilter-other', 'Different Size Only', 1, [99]);
+    await seedStats('kilter', 'kilter-fits', 40);
+    await seedStats('kilter', 'kilter-other', 40);
+
+    // Explicit ids keep the playlist_climbs FK references trivial; the TRUNCATE
+    // ... RESTART IDENTITY above frees ids 1 and 2.
+    await db.execute(sql`
+      INSERT INTO playlists (id, uuid, board_type, layout_id, name, is_public)
+      VALUES (1, ${MOONBOARD_PLAYLIST_UUID}, 'moonboard', 7, 'Minimoon circuit', true),
+             (2, ${KILTER_PLAYLIST_UUID}, 'kilter', 1, 'Kilter sizes', true)
+    `);
+    await db.execute(sql`
+      INSERT INTO playlist_climbs (playlist_id, climb_uuid, angle, position)
+      VALUES (1, 'moon-1', 40, 0), (1, 'moon-2', 40, 1),
+             (2, 'kilter-fits', 40, 0), (2, 'kilter-other', 40, 1)
+    `);
+  });
+
+  it('returns a MoonBoard playlist’s climbs in board-scoped mode, in position order', async () => {
+    const result = await playlistQueries.playlistClimbs(
+      null,
+      {
+        input: {
+          playlistId: MOONBOARD_PLAYLIST_UUID,
+          boardName: 'moonboard',
+          layoutId: 7,
+          sizeId: MOONBOARD_SIZE_ID,
+          angle: 40,
+        },
+      },
+      makeCtx(),
+    );
+
+    // Before the fix this was `[]` while totalCount said 2 — the play drawer then
+    // built a one-item queue and prev/next had nowhere to go.
+    expect(result.climbs.map((climb) => climb.uuid)).toEqual(['moon-1', 'moon-2']);
+    expect(result.totalCount).toBe(2);
+  });
+
+  it('still excludes a Kilter climb that does not fit the requested size', async () => {
+    const result = await playlistQueries.playlistClimbs(
+      null,
+      {
+        input: {
+          playlistId: KILTER_PLAYLIST_UUID,
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: KILTER_SIZE_ID,
+          angle: 40,
+        },
+      },
+      makeCtx(),
+    );
+
+    // The size filter must still bite on size-scoped boards: `kilter-other` is
+    // only climbable on size 99. Deleting the predicate (rather than gating it on
+    // board type) would make the MoonBoard case above pass and break this one.
+    expect(result.climbs.map((climb) => climb.uuid)).toEqual(['kilter-fits']);
+  });
+
+  it('keeps a size-compatible Kilter climb whose array holds several sizes', async () => {
+    // Pins the array-containment direction of the `= ANY(...)` → `@> ARRAY[...]`
+    // rewrite: the requested size is one element of a multi-element array, not the
+    // whole array.
+    const result = await playlistQueries.playlistClimbs(
+      null,
+      { input: { playlistId: KILTER_PLAYLIST_UUID, boardName: 'kilter', layoutId: 1, sizeId: 7, angle: 40 } },
+      makeCtx(),
+    );
+
+    expect(result.climbs.map((climb) => climb.uuid)).toEqual(['kilter-fits']);
+  });
+
+  it('agrees with all-boards mode about which MoonBoard climbs are in the playlist', async () => {
+    // The user-visible invariant behind the bug report: the detail list
+    // (all-boards mode) and the play drawer's queue fetch (board-scoped mode)
+    // must contain the same climbs, however each is implemented.
+    const boardScoped = await playlistQueries.playlistClimbs(
+      null,
+      {
+        input: {
+          playlistId: MOONBOARD_PLAYLIST_UUID,
+          boardName: 'moonboard',
+          layoutId: 7,
+          sizeId: MOONBOARD_SIZE_ID,
+          angle: 40,
+        },
+      },
+      makeCtx(),
+    );
+    const allBoards = await playlistQueries.playlistClimbs(
+      null,
+      { input: { playlistId: MOONBOARD_PLAYLIST_UUID, activeBoardName: 'moonboard', activeAngle: 40 } },
+      makeCtx(),
+    );
+
+    expect(new Set(boardScoped.climbs.map((climb) => climb.uuid))).toEqual(
+      new Set(allBoards.climbs.map((climb) => climb.uuid)),
+    );
+  });
+});

--- a/packages/backend/src/__tests__/playlist-climbs-board-scope.test.ts
+++ b/packages/backend/src/__tests__/playlist-climbs-board-scope.test.ts
@@ -21,11 +21,22 @@ import { playlistQueries } from '../graphql/resolvers/playlists/queries';
 // The pair "MoonBoard climbs come back" + "a size-incompatible Kilter climb is
 // still excluded" is load-bearing: either alone is satisfied by deleting the
 // predicate outright.
+//
+// Once MoonBoard rows reach this join they also have to be scoped to the hold sets
+// the wall actually has, which is what `required_set_ids` encodes for MoonBoard's
+// optional wooden / screw-on add-ons — so the set-filtering cases below run against
+// the real query too, not a predicate rebuilt in the test.
 
 const MOONBOARD_PLAYLIST_UUID = 'pl-board-scope-moon';
 const KILTER_PLAYLIST_UUID = 'pl-board-scope-kilter';
+const MOONBOARD_SETS_PLAYLIST_UUID = 'pl-board-scope-moon-sets';
 const MOONBOARD_SIZE_ID = 1;
 const KILTER_SIZE_ID = 25;
+
+// Stand-ins for a MoonBoard's base grid plus its optional add-on sets. A wall
+// built without the wooden holds sends only `MOONBOARD_BASE_SET_ID`.
+const MOONBOARD_BASE_SET_ID = 20;
+const MOONBOARD_WOODEN_SET_ID = 21;
 
 function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext {
   return {
@@ -46,13 +57,15 @@ async function seedClimb(
   name: string,
   layoutId: number,
   compatibleSizeIds: number[] | null,
+  requiredSetIds: number[] | null = null,
 ) {
   // Bind the array as a Postgres array literal cast to int[] — a JS array bound
   // directly is expanded into a `(a, b, c)` record by the driver.
   const sizeIdsLiteral = compatibleSizeIds === null ? null : `{${compatibleSizeIds.join(',')}}`;
+  const setIdsLiteral = requiredSetIds === null ? null : `{${requiredSetIds.join(',')}}`;
   await db.execute(sql`
-    INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, description, frames, is_listed, compatible_size_ids)
-    VALUES (${uuid}, ${boardType}, ${layoutId}, 'setter', ${name}, '', 'p1r1', true, ${sizeIdsLiteral}::int[])
+    INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, description, frames, is_listed, compatible_size_ids, required_set_ids)
+    VALUES (${uuid}, ${boardType}, ${layoutId}, 'setter', ${name}, '', 'p1r1', true, ${sizeIdsLiteral}::int[], ${setIdsLiteral}::int[])
   `);
 }
 
@@ -63,7 +76,7 @@ async function seedStats(boardType: string, uuid: string, angle: number) {
   `);
 }
 
-describe('playlistClimbs — board-scoped size filtering (real DB)', () => {
+describe('playlistClimbs — board-scoped size and hold-set filtering (real DB)', () => {
   beforeAll(async () => {
     // Playlist tables aren't in the global per-file reset list, so own the cleanup.
     await db.execute(sql`TRUNCATE TABLE playlist_climbs, playlist_ownership, playlists RESTART IDENTITY CASCADE`);
@@ -81,17 +94,32 @@ describe('playlistClimbs — board-scoped size filtering (real DB)', () => {
     await seedStats('kilter', 'kilter-fits', 40);
     await seedStats('kilter', 'kilter-other', 40);
 
+    // MoonBoard hold sets: the base grid is always installed, the wooden add-on
+    // only on some walls. `moon-sets-null` stands for a row the required-set-ids
+    // backfill hasn't reached yet.
+    await seedClimb('moonboard', 'moon-sets-base', 'Base Holds Only', 7, null, [MOONBOARD_BASE_SET_ID]);
+    await seedClimb('moonboard', 'moon-sets-wooden', 'Needs Wooden Holds', 7, null, [
+      MOONBOARD_BASE_SET_ID,
+      MOONBOARD_WOODEN_SET_ID,
+    ]);
+    await seedClimb('moonboard', 'moon-sets-null', 'Not Backfilled Yet', 7, null, null);
+    await seedStats('moonboard', 'moon-sets-base', 40);
+    await seedStats('moonboard', 'moon-sets-wooden', 40);
+    await seedStats('moonboard', 'moon-sets-null', 40);
+
     // Explicit ids keep the playlist_climbs FK references trivial; the TRUNCATE
-    // ... RESTART IDENTITY above frees ids 1 and 2.
+    // ... RESTART IDENTITY above frees ids 1, 2 and 3.
     await db.execute(sql`
       INSERT INTO playlists (id, uuid, board_type, layout_id, name, is_public)
       VALUES (1, ${MOONBOARD_PLAYLIST_UUID}, 'moonboard', 7, 'Minimoon circuit', true),
-             (2, ${KILTER_PLAYLIST_UUID}, 'kilter', 1, 'Kilter sizes', true)
+             (2, ${KILTER_PLAYLIST_UUID}, 'kilter', 1, 'Kilter sizes', true),
+             (3, ${MOONBOARD_SETS_PLAYLIST_UUID}, 'moonboard', 7, 'Wooden hold session', true)
     `);
     await db.execute(sql`
       INSERT INTO playlist_climbs (playlist_id, climb_uuid, angle, position)
       VALUES (1, 'moon-1', 40, 0), (1, 'moon-2', 40, 1),
-             (2, 'kilter-fits', 40, 0), (2, 'kilter-other', 40, 1)
+             (2, 'kilter-fits', 40, 0), (2, 'kilter-other', 40, 1),
+             (3, 'moon-sets-base', 40, 0), (3, 'moon-sets-wooden', 40, 1), (3, 'moon-sets-null', 40, 2)
     `);
   });
 
@@ -144,6 +172,93 @@ describe('playlistClimbs — board-scoped size filtering (real DB)', () => {
     const result = await playlistQueries.playlistClimbs(
       null,
       { input: { playlistId: KILTER_PLAYLIST_UUID, boardName: 'kilter', layoutId: 1, sizeId: 7, angle: 40 } },
+      makeCtx(),
+    );
+
+    expect(result.climbs.map((climb) => climb.uuid)).toEqual(['kilter-fits']);
+  });
+
+  it('drops a MoonBoard climb needing a hold set the wall does not have', async () => {
+    // A MoonBoard without the wooden add-on sends only the base set. `moon-sets-wooden`
+    // needs both, so queueing it would light a problem with holes in it.
+    const result = await playlistQueries.playlistClimbs(
+      null,
+      {
+        input: {
+          playlistId: MOONBOARD_SETS_PLAYLIST_UUID,
+          boardName: 'moonboard',
+          layoutId: 7,
+          sizeId: MOONBOARD_SIZE_ID,
+          setIds: String(MOONBOARD_BASE_SET_ID),
+          angle: 40,
+        },
+      },
+      makeCtx(),
+    );
+
+    // `moon-sets-null` rides along: NULL required sets means "not backfilled", not
+    // "needs nothing installed", and a hand-curated playlist shouldn't lose a climb
+    // over missing denormalised data.
+    expect(result.climbs.map((climb) => climb.uuid)).toEqual(['moon-sets-base', 'moon-sets-null']);
+  });
+
+  it('keeps every MoonBoard climb once the wooden holds are installed', async () => {
+    // Same playlist, same climbs, wooden set selected — the pair with the test above
+    // is what stops the filter being satisfied by a predicate that always excludes.
+    const result = await playlistQueries.playlistClimbs(
+      null,
+      {
+        input: {
+          playlistId: MOONBOARD_SETS_PLAYLIST_UUID,
+          boardName: 'moonboard',
+          layoutId: 7,
+          sizeId: MOONBOARD_SIZE_ID,
+          setIds: `${MOONBOARD_BASE_SET_ID},${MOONBOARD_WOODEN_SET_ID}`,
+          angle: 40,
+        },
+      },
+      makeCtx(),
+    );
+
+    expect(result.climbs.map((climb) => climb.uuid)).toEqual(['moon-sets-base', 'moon-sets-wooden', 'moon-sets-null']);
+  });
+
+  it('leaves the playlist whole when the caller sends no set ids', async () => {
+    // Web's all-boards list and any caller that omits setIds must not start losing
+    // climbs — the filter only applies to a caller that told us what is installed.
+    const result = await playlistQueries.playlistClimbs(
+      null,
+      {
+        input: {
+          playlistId: MOONBOARD_SETS_PLAYLIST_UUID,
+          boardName: 'moonboard',
+          layoutId: 7,
+          sizeId: MOONBOARD_SIZE_ID,
+          angle: 40,
+        },
+      },
+      makeCtx(),
+    );
+
+    expect(result.climbs.map((climb) => climb.uuid)).toEqual(['moon-sets-base', 'moon-sets-wooden', 'moon-sets-null']);
+  });
+
+  it('keeps Kilter climbs whose required sets have not been backfilled', async () => {
+    // The deliberate divergence from climb search, which excludes NULL required sets
+    // on Aurora boards. Here a NULL means the denormalisation hasn't run, and the
+    // climber put this climb in the list themselves.
+    const result = await playlistQueries.playlistClimbs(
+      null,
+      {
+        input: {
+          playlistId: KILTER_PLAYLIST_UUID,
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: KILTER_SIZE_ID,
+          setIds: '1,20',
+          angle: 40,
+        },
+      },
       makeCtx(),
     );
 

--- a/packages/backend/src/graphql/resolvers/playlists/queries/playlist-climbs.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/playlist-climbs.ts
@@ -79,7 +79,11 @@ async function fetchSpecificBoardClimbs(
   // MoonBoard and drafts: `required_set_ids` is denormalised and backfilled
   // asynchronously, and a playlist is a list the climber curated by hand. Missing
   // provenance should not make one of their own climbs disappear — only a climb we
-  // positively know needs an uninstalled set is dropped.
+  // positively know needs an uninstalled set is dropped. The blast radius of the
+  // more permissive choice is small: in prod (2026-07-31) 1,223 of 408,035 Kilter
+  // climbs (0.30%) and 776 of 153,370 Tension climbs (0.51%) still have a NULL
+  // `required_set_ids`, so at most half a percent of Aurora playlist rows keep the
+  // pre-#3891 behaviour, versus every one of them disappearing on a backfill lag.
   const selectedSetIds = input.setIds == null ? [] : parseSetIds(input.setIds);
   if (selectedSetIds.length > 0) {
     climbJoinConditions.push(

--- a/packages/backend/src/graphql/resolvers/playlists/queries/playlist-climbs.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/playlist-climbs.ts
@@ -1,6 +1,6 @@
 import { eq, and, asc, sql } from 'drizzle-orm';
 import { type ConnectionContext, type Climb, type BoardName, SUPPORTED_BOARDS } from '@boardsesh/shared-schema';
-import { isSizeScopedBoard } from '@boardsesh/board-config';
+import { isSizeScopedBoard, parseSetIds } from '@boardsesh/board-config';
 import { db } from '../../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { getClimbStars, getGradeLabel, toConfidenceTier } from '@boardsesh/db/queries';
@@ -66,6 +66,28 @@ async function fetchSpecificBoardClimbs(
   // board_climbs_compatible_size_ids_idx GIN index applies, matching those callers.
   if (input.sizeId != null && isSizeScopedBoard(boardName)) {
     climbJoinConditions.push(sql`${tables.climbs.compatibleSizeIds} @> ARRAY[${input.sizeId}]::int[]`);
+  }
+
+  // Hold-set scoping, the same `required_set_ids <@ selected sets` containment the
+  // main climb search applies (`create-climb-filters.ts`). Dropping the broken size
+  // predicate for MoonBoard is what finally let MoonBoard rows through this join, and
+  // MoonBoard is exactly the board whose optional wooden / screw-on add-on sets are
+  // encoded in `required_set_ids` — without this, a wall built without those sets
+  // hands the play drawer climbs it cannot light in full.
+  //
+  // NULL is tolerated on every board here, where search only tolerates it for
+  // MoonBoard and drafts: `required_set_ids` is denormalised and backfilled
+  // asynchronously, and a playlist is a list the climber curated by hand. Missing
+  // provenance should not make one of their own climbs disappear — only a climb we
+  // positively know needs an uninstalled set is dropped.
+  const selectedSetIds = input.setIds == null ? [] : parseSetIds(input.setIds);
+  if (selectedSetIds.length > 0) {
+    climbJoinConditions.push(
+      sql`(${tables.climbs.requiredSetIds} IS NULL OR ${tables.climbs.requiredSetIds} <@ ARRAY[${sql.join(
+        selectedSetIds.map((setId) => sql`${setId}`),
+        sql`, `,
+      )}]::int[])`,
+    );
   }
 
   const inputAngle = input.angle ?? 40;

--- a/packages/backend/src/graphql/resolvers/playlists/queries/playlist-climbs.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/playlist-climbs.ts
@@ -1,5 +1,6 @@
 import { eq, and, asc, sql } from 'drizzle-orm';
 import { type ConnectionContext, type Climb, type BoardName, SUPPORTED_BOARDS } from '@boardsesh/shared-schema';
+import { isSizeScopedBoard } from '@boardsesh/board-config';
 import { db } from '../../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { getClimbStars, getGradeLabel, toConfidenceTier } from '@boardsesh/db/queries';
@@ -55,8 +56,16 @@ async function fetchSpecificBoardClimbs(
     climbJoinConditions.push(eq(tables.climbs.layoutId, input.layoutId));
   }
 
-  if (input.sizeId != null) {
-    climbJoinConditions.push(sql`${input.sizeId} = ANY(${tables.climbs.compatibleSizeIds})`);
+  // Size-scope the join only for boards that actually have size variants.
+  // MoonBoard has one fixed product size, so its climbs carry NULL
+  // `compatible_size_ids` — and `sizeId = ANY(NULL)` is NULL, never true, which
+  // silently dropped every MoonBoard row from this join (#3891). `isSizeScopedBoard`
+  // is the one guard for that; the sibling call sites are the main climb search
+  // (`create-climb-filters.ts`) and the sync pull (`sync/queries.ts`). Array
+  // containment (`@>`) rather than `= ANY` so the existing
+  // board_climbs_compatible_size_ids_idx GIN index applies, matching those callers.
+  if (input.sizeId != null && isSizeScopedBoard(boardName)) {
+    climbJoinConditions.push(sql`${tables.climbs.compatibleSizeIds} @> ARRAY[${input.sizeId}]::int[]`);
   }
 
   const inputAngle = input.angle ?? 40;

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -184,21 +184,37 @@ export function ClimbReactionMenu({
   // auto-dismiss after 3s, so hold the message and fire it on the way out — the
   // unmount cleanup covers both dismissal and the parent tearing us down. Ref'd
   // showToast so the cleanup effect never re-runs and flushes early (#3891).
+  //
+  // Holding only works while there is still a cleanup to come. Dismiss the whole
+  // overlay while the request is in flight and the cleanup has already run by the
+  // time the rejection lands — writing to the ref then would park the message in a
+  // dead component forever. `overlayGoneRef` records that we are past cleanup, and
+  // a message arriving after it goes straight to the toast, which by then is the
+  // top layer anyway.
   const { showToast } = useToast();
   const showToastRef = useRef(showToast);
   showToastRef.current = showToast;
   const pendingFailureRef = useRef<string | null>(null);
+  const overlayGoneRef = useRef(false);
   const holdFailureUntilDismissed = useCallback((message: string) => {
+    if (overlayGoneRef.current) {
+      showToastRef.current(message, 'error');
+      return;
+    }
     pendingFailureRef.current = message;
   }, []);
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    // Reset on mount as well as set on unmount: a mount/cleanup/mount cycle
+    // (StrictMode, Fast Refresh) would otherwise leave a live overlay classified as
+    // gone, toasting failures behind itself where nobody sees them.
+    overlayGoneRef.current = false;
+    return () => {
+      overlayGoneRef.current = true;
       const pendingFailure = pendingFailureRef.current;
       pendingFailureRef.current = null;
       if (pendingFailure) showToastRef.current(pendingFailure, 'error');
-    },
-    [],
-  );
+    };
+  }, []);
 
   // Hardware back (Android) / VoiceOver escape: pop the playlist view first,
   // dismiss the whole overlay only from the top-level menu.

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Keyboard,
   type LayoutChangeEvent,
@@ -32,6 +32,7 @@ import { getBoardRenderData } from '../../lib/board-details';
 import { formatSends, formatQuality } from '../../lib/format-climb-stats';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { useTheme } from '../../providers/theme-provider';
+import { useToast } from '../../providers/toast-provider';
 import type { BoardConfig } from '../../providers/drawer-host-provider';
 import { springs, timing } from '../../theme/animations';
 import { spacing, borderRadius, overlays } from '../../theme/tokens';
@@ -176,6 +177,28 @@ export function ClimbReactionMenu({
   const backToMenu = useCallback(() => setView('menu'), []);
   // Stable so useClimbActions' memo doesn't rebuild the action list every render.
   const openPlaylist = useCallback(() => setView('playlist'), []);
+
+  // A playlist add/remove that fails after the picker is gone but while THIS
+  // overlay is still up (back-to-menu unmounts the picker; the overlay stays).
+  // A toast fired now would render behind the FullWindowOverlay / Modal and
+  // auto-dismiss after 3s, so hold the message and fire it on the way out — the
+  // unmount cleanup covers both dismissal and the parent tearing us down. Ref'd
+  // showToast so the cleanup effect never re-runs and flushes early (#3891).
+  const { showToast } = useToast();
+  const showToastRef = useRef(showToast);
+  showToastRef.current = showToast;
+  const pendingFailureRef = useRef<string | null>(null);
+  const holdFailureUntilDismissed = useCallback((message: string) => {
+    pendingFailureRef.current = message;
+  }, []);
+  useEffect(
+    () => () => {
+      const pendingFailure = pendingFailureRef.current;
+      pendingFailureRef.current = null;
+      if (pendingFailure) showToastRef.current(pendingFailure, 'error');
+    },
+    [],
+  );
 
   // Hardware back (Android) / VoiceOver escape: pop the playlist view first,
   // dismiss the whole overlay only from the top-level menu.
@@ -482,6 +505,7 @@ export function ClimbReactionMenu({
                   TextInputComponent={TextInput}
                   onBack={backToMenu}
                   maxHeight={menuMaxHeight}
+                  onDetachedFailure={holdFailureUntilDismissed}
                 />
               ) : (
                 <View>

--- a/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
@@ -309,6 +309,23 @@ describe('ClimbReactionMenu view switching', () => {
     expect(showToast).not.toHaveBeenCalled();
   });
 
+  // The other order, and the one that used to lose the message: the climber
+  // dismisses the whole overlay while the add is still in flight. Cleanup has
+  // already run by the time the rejection lands, so there is no later flush to
+  // ride out on — the message has to toast the moment it arrives.
+  it('toasts immediately when the failure lands after the overlay is already gone', () => {
+    const { getByLabelText, unmount } = renderMenu();
+    act(() => fireEvent.click(getByLabelText('Add to Playlist')));
+    const reportDetachedFailure = captured.pickerOnDetachedFailure;
+    expect(reportDetachedFailure).toBeTypeOf('function');
+
+    unmount();
+    expect(showToast).not.toHaveBeenCalled();
+
+    act(() => reportDetachedFailure?.("Couldn't add to Minimoon circuit"));
+    expect(showToast).toHaveBeenCalledWith("Couldn't add to Minimoon circuit", 'error');
+  });
+
   it('hardware back dismisses from the menu but only pops the picker from the playlist view', () => {
     const { getByLabelText, onClose, container } = renderMenu();
 

--- a/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
@@ -9,12 +9,15 @@ import type { Climb } from '@boardsesh/shared-schema';
 const captured = vi.hoisted(() => ({
   actionArgs: null as Record<string, unknown> | null,
   pickerOnBack: undefined as undefined | (() => void),
+  pickerOnDetachedFailure: undefined as undefined | ((message: string) => void),
   modalOnRequestClose: undefined as undefined | (() => void),
   boardImageProps: null as Record<string, unknown> | null,
   ran: undefined as undefined | string,
   glassSurfaceProps: null as Record<string, unknown> | null,
   fadeColors: null as readonly string[] | null,
 }));
+
+const showToast = vi.hoisted(() => vi.fn());
 
 // Drives the rendering branches: which material sits under the overlay, which
 // scheme, and how tall the window is (a short window forces the action list to
@@ -116,11 +119,19 @@ vi.mock('../../BoardImageNative', () => ({
 }));
 vi.mock('../../ClimbAttributeIcons', () => ({ ClimbAttributeIcons: () => null }));
 vi.mock('../../playlist/InlinePlaylistPicker', () => ({
-  InlinePlaylistPicker: ({ onBack }: { onBack?: () => void }) => {
+  InlinePlaylistPicker: ({
+    onBack,
+    onDetachedFailure,
+  }: {
+    onBack?: () => void;
+    onDetachedFailure?: (message: string) => void;
+  }) => {
     captured.pickerOnBack = onBack;
+    captured.pickerOnDetachedFailure = onDetachedFailure;
     return createElement('div', { 'data-picker': 'true' }, 'picker');
   },
 }));
+vi.mock('../../../providers/toast-provider', () => ({ useToast: () => ({ showToast }) }));
 vi.mock('../../../lib/board-details', () => ({
   getBoardRenderData: () => ({ boardWidth: 120, boardHeight: 120 }),
 }));
@@ -191,7 +202,9 @@ describe('ClimbReactionMenu view switching', () => {
   beforeEach(() => {
     captured.actionArgs = null;
     captured.pickerOnBack = undefined;
+    captured.pickerOnDetachedFailure = undefined;
     captured.modalOnRequestClose = undefined;
+    showToast.mockReset();
     captured.boardImageProps = null;
     captured.ran = undefined;
     captured.glassSurfaceProps = null;
@@ -268,6 +281,32 @@ describe('ClimbReactionMenu view switching', () => {
     act(() => captured.pickerOnBack?.());
     expect(container.querySelector('[data-picker="true"]')).toBeNull();
     expect(getByLabelText('Add to Playlist')).not.toBeNull();
+  });
+
+  // #3891. Back-to-menu unmounts the picker while this overlay is still presented,
+  // so "the picker is gone" does NOT mean "a toast is visible" — a root toast
+  // renders behind the FullWindowOverlay / Modal and self-dismisses in 3s. The
+  // overlay takes the message and fires it on the way out instead.
+  it('holds a detached playlist failure until the overlay itself is gone, then toasts it', () => {
+    const { getByLabelText, unmount } = renderMenu();
+    act(() => fireEvent.click(getByLabelText('Add to Playlist')));
+    expect(captured.pickerOnDetachedFailure).toBeTypeOf('function');
+
+    // The add rejects after back-to-menu: picker unmounted, overlay still up.
+    act(() => captured.pickerOnBack?.());
+    act(() => captured.pickerOnDetachedFailure?.("Couldn't add to Minimoon circuit"));
+    expect(showToast).not.toHaveBeenCalled();
+
+    unmount();
+    expect(showToast).toHaveBeenCalledWith("Couldn't add to Minimoon circuit", 'error');
+  });
+
+  it('does not toast on dismissal when no playlist failure was handed over', () => {
+    const { getByLabelText, unmount } = renderMenu();
+    act(() => fireEvent.click(getByLabelText('Add to Playlist')));
+    act(() => captured.pickerOnBack?.());
+    unmount();
+    expect(showToast).not.toHaveBeenCalled();
   });
 
   it('hardware back dismisses from the menu but only pops the picker from the playlist view', () => {

--- a/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
+++ b/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
@@ -26,6 +26,8 @@ import { useClimbPlaylistMemberships } from '../../hooks/use-climb-playlist-memb
 import { getHttpClient } from '../../lib/graphql/client';
 import { usePlaylistsContext, type Playlist } from '../../providers/playlists-provider';
 import { useTheme } from '../../providers/theme-provider';
+import { useToast } from '../../providers/toast-provider';
+import { reportHandledError } from '../../lib/error-reporting';
 import { sortPlaylistsByName } from '../../lib/sort-filter-playlists';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { borderRadius, spacing } from '../../theme/tokens';
@@ -90,10 +92,13 @@ const playlistKey = (playlist: Playlist) => playlist.id;
  * by the reaction overlay (`ClimbReactionMenu`) and the add-to-playlist
  * `ModalSheet` (`AddToPlaylistSheet`).
  *
- * Feedback is inline, never a toast: a toast fired while a `FullWindowOverlay`
- * or native sheet is on screen renders behind it and is invisible. Success is
- * the optimistic checkmark itself; failures revert the optimistic state and
- * surface an inline error line.
+ * Feedback is inline *while the picker is on screen*: a toast fired while a
+ * `FullWindowOverlay` or native sheet is up renders behind it and is invisible.
+ * Success is the optimistic checkmark itself; failures revert the optimistic
+ * state and surface an inline error line. Once the host is gone (the climber
+ * dismissed the sheet/overlay while the request was still in flight — which on
+ * gym wifi is most of the window) the inline line has nowhere to render, so the
+ * failure goes out as a toast on whatever screen they dismissed to (#3891).
  */
 export function InlinePlaylistPicker({
   climb,
@@ -146,6 +151,31 @@ export function InlinePlaylistPicker({
 
   const [error, setError] = useState<string | null>(null);
 
+  // Whether this picker is still on screen. Read inside a settled request's catch
+  // block to pick the channel the climber can actually see — see `surfaceFailure`.
+  const mountedRef = useRef(true);
+
+  /**
+   * Report a membership failure through whichever channel is visible right now.
+   * Mounted: the inline error line (a root toast would render behind the sheet /
+   * FullWindowOverlay hosting us). Unmounted: a toast, which is now the only
+   * surface left — `setError` on a dead component is a silent no-op, and that is
+   * how a failed add used to reach nobody at all (#3891). Mutually exclusive, so
+   * there is never a double signal; the choice is made at the moment the
+   * rejection lands, not when the tap happened.
+   */
+  const { showToast } = useToast();
+  const surfaceFailure = useCallback(
+    (inlineMessage: string, toastMessage: string) => {
+      if (mountedRef.current) {
+        setError(inlineMessage);
+      } else {
+        showToast(toastMessage, 'error');
+      }
+    },
+    [showToast],
+  );
+
   const sortedPlaylists = useMemo(() => sortPlaylistsByName(playlists), [playlists]);
 
   // Write a membership set to the cache and mirror it into the shared chip store
@@ -193,7 +223,16 @@ export function InlinePlaylistPicker({
           writeMembership(
             willBeMember ? current.filter((uuid) => uuid !== playlist.uuid) : [...new Set([...current, playlist.uuid])],
           );
-          setError(t(willBeMember ? 'actions.playlist.toast.addFailed' : 'actions.playlist.toast.removeFailed'));
+          surfaceFailure(
+            t(willBeMember ? 'actions.playlist.toast.addFailed' : 'actions.playlist.toast.removeFailed'),
+            t(willBeMember ? 'actions.playlist.toast.addFailedNamed' : 'actions.playlist.toast.removeFailedNamed', {
+              playlist: playlist.name,
+            }),
+          );
+          // Unconditional, regardless of mount state: before this, a toggle that
+          // failed after the host was dismissed left no trace anywhere — not even
+          // in a release build's logs (the console.warn below is __DEV__-only).
+          reportHandledError(toggleError, { tags: { source: 'playlist', op: 'toggle-membership' } });
           if (__DEV__) {
             console.warn('[playlist] toggle membership failed', {
               playlistUuid: playlist.uuid,
@@ -207,7 +246,18 @@ export function InlinePlaylistPicker({
         togglingRef.current.delete(playlist.uuid);
       }
     },
-    [queryClient, membershipKey, members, writeMembership, addToPlaylist, removeFromPlaylist, climb.uuid, angle, t],
+    [
+      queryClient,
+      membershipKey,
+      members,
+      writeMembership,
+      addToPlaylist,
+      removeFromPlaylist,
+      climb.uuid,
+      angle,
+      surfaceFailure,
+      t,
+    ],
   );
 
   // === Inline create form ===
@@ -223,7 +273,13 @@ export function InlinePlaylistPicker({
   // continuation (add + UI updates) aborts instead of adding the climb after the
   // user backed out.
   const createRequestIdRef = useRef(0);
-  useEffect(() => () => void (createRequestIdRef.current += 1), []);
+  useEffect(
+    () => () => {
+      createRequestIdRef.current += 1;
+      mountedRef.current = false;
+    },
+    [],
+  );
 
   const resetCreate = useCallback(() => {
     setName('');
@@ -297,7 +353,14 @@ export function InlinePlaylistPicker({
       const current = queryClient.getQueryData<string[]>(membershipKey) ?? [...members];
       writeMembership([...new Set([...current, created.uuid])]);
     } catch (addError) {
-      if (isCurrent()) setError(t('actions.playlist.toast.addFailed'));
+      // Not gated on isCurrent(): the form is already closed by this point, so a
+      // stale token here means the picker went away — exactly the case that needs
+      // the toast rather than a no-op setError.
+      surfaceFailure(
+        t('actions.playlist.toast.addFailed'),
+        t('actions.playlist.toast.addFailedNamed', { playlist: created.name }),
+      );
+      reportHandledError(addError, { tags: { source: 'playlist', op: 'create-then-add' } });
       if (__DEV__) {
         console.warn('[playlist] created playlist but failed to add climb', {
           playlistUuid: created.uuid,
@@ -323,6 +386,7 @@ export function InlinePlaylistPicker({
     membershipKey,
     members,
     writeMembership,
+    surfaceFailure,
     t,
   ]);
 

--- a/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
+++ b/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
@@ -82,6 +82,19 @@ type InlinePlaylistPickerProps = {
    *  overlay (default), `BottomSheetFlatList` inside a `ModalSheet` so it scrolls
    *  with the sheet. Injected rather than `.map`-ing rows in a ScrollView. */
   ListComponent?: ComponentType<FlatListProps<Playlist>>;
+  /**
+   * Where a failure goes once it settles *after* this picker has unmounted.
+   * Defaults to a root toast, which is right when unmounting the picker IS the
+   * host going away — `AddToPlaylistSheet`'s data is only cleared on the sheet's
+   * `onFullyDismissed`, so by then the toast layer is on top.
+   *
+   * The reaction overlay outlives the picker: "back" pops to its action menu and
+   * unmounts us while the `FullWindowOverlay` (iOS) / transparent `Modal`
+   * (Android) is still presented, and a root toast renders BEHIND those (see
+   * toast-provider). Hosts in that shape must pass their own channel — one that
+   * holds the message until they are gone — or the failure is invisible again.
+   */
+  onDetachedFailure?: (message: string) => void;
 };
 
 const playlistKey = (playlist: Playlist) => playlist.id;
@@ -95,10 +108,12 @@ const playlistKey = (playlist: Playlist) => playlist.id;
  * Feedback is inline *while the picker is on screen*: a toast fired while a
  * `FullWindowOverlay` or native sheet is up renders behind it and is invisible.
  * Success is the optimistic checkmark itself; failures revert the optimistic
- * state and surface an inline error line. Once the host is gone (the climber
- * dismissed the sheet/overlay while the request was still in flight — which on
- * gym wifi is most of the window) the inline line has nowhere to render, so the
- * failure goes out as a toast on whatever screen they dismissed to (#3891).
+ * state and surface an inline error line. Once this picker is gone (the climber
+ * dismissed the sheet/overlay, or popped back to the reaction menu, while the
+ * request was still in flight — which on gym wifi is most of the window) the
+ * inline line has nowhere to render, so the failure is handed to
+ * `onDetachedFailure`, defaulting to a toast on whatever they dismissed to
+ * (#3891).
  */
 export function InlinePlaylistPicker({
   climb,
@@ -109,6 +124,7 @@ export function InlinePlaylistPicker({
   onBack,
   maxHeight,
   ListComponent = FlatList,
+  onDetachedFailure,
 }: InlinePlaylistPickerProps) {
   const { t } = useTranslation('climbs');
   const { t: tc } = useTranslation('common');
@@ -158,20 +174,34 @@ export function InlinePlaylistPicker({
   /**
    * Report a membership failure through whichever channel is visible right now.
    * Mounted: the inline error line (a root toast would render behind the sheet /
-   * FullWindowOverlay hosting us). Unmounted: a toast, which is now the only
-   * surface left — `setError` on a dead component is a silent no-op, and that is
-   * how a failed add used to reach nobody at all (#3891). Mutually exclusive, so
-   * there is never a double signal; the choice is made at the moment the
-   * rejection lands, not when the tap happened.
+   * FullWindowOverlay hosting us). Unmounted: hand it to the host's detached
+   * channel, defaulting to a toast — `setError` on a dead component is a silent
+   * no-op, and that is how a failed add used to reach nobody at all (#3891).
+   * Mutually exclusive, so there is never a double signal; the choice is made at
+   * the moment the rejection lands, not when the tap happened.
+   *
+   * The two messages differ on purpose: the inline line sits inside the picker
+   * the climber is looking at, so it stays generic, while the detached one has to
+   * say which playlist it is about.
    */
   const { showToast } = useToast();
+  // Read through a ref so a host that rebuilds the callback each render can't
+  // churn `surfaceFailure` (and through it `handleToggle`, and through that every
+  // memoized row).
+  const detachedFailureRef = useRef(onDetachedFailure);
+  detachedFailureRef.current = onDetachedFailure;
   const surfaceFailure = useCallback(
-    (inlineMessage: string, toastMessage: string) => {
+    (inlineMessage: string, detachedMessage: string) => {
       if (mountedRef.current) {
         setError(inlineMessage);
-      } else {
-        showToast(toastMessage, 'error');
+        return;
       }
+      const reportDetached = detachedFailureRef.current;
+      if (reportDetached) {
+        reportDetached(detachedMessage);
+        return;
+      }
+      showToast(detachedMessage, 'error');
     },
     [showToast],
   );
@@ -273,13 +303,16 @@ export function InlinePlaylistPicker({
   // continuation (add + UI updates) aborts instead of adding the climb after the
   // user backed out.
   const createRequestIdRef = useRef(0);
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    // Set on mount as well as cleared on unmount: a mount/cleanup/mount cycle
+    // (StrictMode, Fast Refresh) would otherwise leave a live picker classified
+    // as detached forever, sending every failure to an invisible toast.
+    mountedRef.current = true;
+    return () => {
       createRequestIdRef.current += 1;
       mountedRef.current = false;
-    },
-    [],
-  );
+    };
+  }, []);
 
   const resetCreate = useCallback(() => {
     setName('');
@@ -353,11 +386,15 @@ export function InlinePlaylistPicker({
       const current = queryClient.getQueryData<string[]>(membershipKey) ?? [...members];
       writeMembership([...new Set([...current, created.uuid])]);
     } catch (addError) {
-      // Not gated on isCurrent(): the form is already closed by this point, so a
-      // stale token here means the picker went away — exactly the case that needs
-      // the toast rather than a no-op setError.
+      // Not gated on isCurrent(). The token goes stale two ways here and both
+      // want the message shown: the picker went away (so `surfaceFailure` routes
+      // to the detached channel), or a SECOND inline create was submitted while
+      // this add was in flight (so the climber is looking at that form, and
+      // suppressing this would silently lose the first playlist's add). Because
+      // the second case can leave the create form open — where the list header's
+      // error line isn't rendered — both channels name the playlist.
       surfaceFailure(
-        t('actions.playlist.toast.addFailed'),
+        t('actions.playlist.toast.addFailedNamed', { playlist: created.name }),
         t('actions.playlist.toast.addFailedNamed', { playlist: created.name }),
       );
       reportHandledError(addError, { tags: { source: 'playlist', op: 'create-then-add' } });
@@ -525,9 +562,12 @@ export function InlinePlaylistPicker({
                 );
               })}
             </View>
-            {createError ? (
+            {/* The list header's error line isn't mounted while this form is open,
+                so a membership failure that lands here (an add from before the form
+                was opened) shows in the form's slot instead of nowhere. */}
+            {(createError ?? error) ? (
               <Text variant="footnote" color={iosSystemColors.systemRed} style={styles.errorText}>
-                {createError}
+                {createError ?? error}
               </Text>
             ) : null}
             <View style={styles.createActions}>

--- a/packages/mobile/src/components/playlist/__tests__/InlinePlaylistPicker.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/InlinePlaylistPicker.test.tsx
@@ -20,6 +20,8 @@ const queryClientMock = vi.hoisted(() => ({
   cancelQueries: vi.fn(async () => {}),
 }));
 const membershipStore = vi.hoisted(() => ({ setMembershipForClimb: vi.fn() }));
+const showToast = vi.hoisted(() => vi.fn());
+const reportHandledError = vi.hoisted(() => vi.fn());
 
 vi.mock('react-native', () => ({
   ActivityIndicator: () => createElement('div', { 'data-spinner': 'true' }),
@@ -64,9 +66,17 @@ vi.mock('react-native', () => ({
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
 }));
 
+// Interpolating values into the key keeps the named-toast copy assertable without
+// pulling in a real i18n instance.
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({
+    t: (key: string, values?: Record<string, unknown>) =>
+      values ? `${key}:${Object.entries(values).map(([name, value]) => `${name}=${String(value)}`)}` : key,
+  }),
 }));
+
+vi.mock('../../../providers/toast-provider', () => ({ useToast: () => ({ showToast }) }));
+vi.mock('../../../lib/error-reporting', () => ({ reportHandledError }));
 
 vi.mock('@tanstack/react-query', () => ({
   useQuery: () => ({ data: qstate.data, isLoading: qstate.loading }),
@@ -202,6 +212,8 @@ describe('InlinePlaylistPicker', () => {
     queryClientMock.setQueryData.mockReset();
     queryClientMock.cancelQueries.mockClear();
     membershipStore.setMembershipForClimb.mockReset();
+    showToast.mockReset();
+    reportHandledError.mockReset();
   });
 
   it('shows the sign-in blurb and no create button when signed out', () => {
@@ -271,6 +283,109 @@ describe('InlinePlaylistPicker', () => {
     // Optimistic write then revert to the previous set.
     expect(queryClientMock.setQueryData).toHaveBeenNthCalledWith(1, expect.anything(), ['p-1']);
     expect(queryClientMock.setQueryData).toHaveBeenNthCalledWith(2, expect.anything(), []);
+  });
+
+  // #3891: the climber taps a playlist, sees the optimistic checkmark, and
+  // dismisses the sheet/overlay before the request settles — which on gym wifi is
+  // most of the window. The catch block still runs (the rollback below proves it),
+  // but `setError` on an unmounted component is a silent no-op, so the failure used
+  // to reach nobody: no banner, no toast, no Sentry. These four cases pin the
+  // routing; 5 and 6 are only meaningful as a pair (each alone is satisfied by an
+  // always-toast or a never-toast implementation).
+  describe('failure feedback survives the host being dismissed', () => {
+    function setupDeferredAdd(members: string[] = []) {
+      playlistContext.playlists = [makePlaylist('p-1', 'Minimoon circuit')];
+      qstate.data = members;
+      const pending = deferred<void>();
+      const rejection = pending.promise.then(() => {
+        throw new Error('offline');
+      });
+      // Swallow the rejection here so an unhandled-rejection warning can't fail the
+      // run; the component has its own catch on the same promise.
+      rejection.catch(() => {});
+      return { pending, rejection };
+    }
+
+    it('toasts the failure, naming the playlist, when the picker unmounted before the add settled', async () => {
+      const { pending, rejection } = setupDeferredAdd();
+      playlistContext.addToPlaylist.mockReset().mockReturnValueOnce(rejection);
+      const { getByLabelText, unmount } = renderPicker();
+
+      fireEvent.click(getByLabelText('Minimoon circuit'));
+      await waitFor(() => expect(playlistContext.addToPlaylist).toHaveBeenCalled());
+      // Optimistic checkmark is already written — this is what the climber saw
+      // before dismissing.
+      expect(queryClientMock.setQueryData).toHaveBeenNthCalledWith(1, expect.anything(), ['p-1']);
+
+      unmount();
+      pending.resolve();
+
+      await waitFor(() => {
+        expect(showToast).toHaveBeenCalledWith(
+          'actions.playlist.toast.addFailedNamed:playlist=Minimoon circuit',
+          'error',
+        );
+      });
+      // The optimistic membership is still rolled back, so the checkmark is gone
+      // when the picker is reopened.
+      expect(membershipStore.setMembershipForClimb).toHaveBeenLastCalledWith('climb-1', []);
+    });
+
+    it('keeps the failure inline and does NOT toast while the picker is still mounted', async () => {
+      const { pending, rejection } = setupDeferredAdd();
+      playlistContext.addToPlaylist.mockReset().mockReturnValueOnce(rejection);
+      const { getByLabelText, getByText } = renderPicker();
+
+      fireEvent.click(getByLabelText('Minimoon circuit'));
+      await waitFor(() => expect(playlistContext.addToPlaylist).toHaveBeenCalled());
+      pending.resolve();
+
+      await waitFor(() => expect(getByText('actions.playlist.toast.addFailed')).not.toBeNull());
+      // A root toast would render behind the sheet / FullWindowOverlay hosting the
+      // picker, so this one must stay inline.
+      expect(showToast).not.toHaveBeenCalled();
+    });
+
+    it('toasts the remove failure (not the add copy) when the picker is gone', async () => {
+      const { pending, rejection } = setupDeferredAdd(['p-1']);
+      playlistContext.removeFromPlaylist.mockReset().mockReturnValueOnce(rejection);
+      const { getByLabelText, unmount } = renderPicker();
+
+      fireEvent.click(getByLabelText('Minimoon circuit'));
+      await waitFor(() => expect(playlistContext.removeFromPlaylist).toHaveBeenCalled());
+      unmount();
+      pending.resolve();
+
+      await waitFor(() => {
+        expect(showToast).toHaveBeenCalledWith(
+          'actions.playlist.toast.removeFailedNamed:playlist=Minimoon circuit',
+          'error',
+        );
+      });
+      // Membership is restored, so the checkmark comes back.
+      expect(membershipStore.setMembershipForClimb).toHaveBeenLastCalledWith('climb-1', ['p-1']);
+    });
+
+    it.each([
+      ['mounted', false],
+      ['unmounted', true],
+    ])('reports the toggle failure to Sentry while %s', async (_label, dismiss) => {
+      const { pending, rejection } = setupDeferredAdd();
+      playlistContext.addToPlaylist.mockReset().mockReturnValueOnce(rejection);
+      const { getByLabelText, unmount } = renderPicker();
+
+      fireEvent.click(getByLabelText('Minimoon circuit'));
+      await waitFor(() => expect(playlistContext.addToPlaylist).toHaveBeenCalled());
+      if (dismiss) unmount();
+      pending.resolve();
+
+      await waitFor(() => {
+        expect(reportHandledError).toHaveBeenCalledWith(expect.any(Error), {
+          tags: { source: 'playlist', op: 'toggle-membership' },
+        });
+      });
+      expect(reportHandledError).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('creates a playlist inline and adds the climb to it', async () => {

--- a/packages/mobile/src/components/playlist/__tests__/InlinePlaylistPicker.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/InlinePlaylistPicker.test.tsx
@@ -173,7 +173,7 @@ function NameInput(props: { value?: string; onChangeText?: (text: string) => voi
   });
 }
 
-function renderPicker(onBack?: () => void) {
+function renderPicker(onBack?: () => void, onDetachedFailure?: (message: string) => void) {
   return render(
     <InlinePlaylistPicker
       climb={climb}
@@ -182,6 +182,7 @@ function renderPicker(onBack?: () => void) {
       layoutId={1}
       TextInputComponent={NameInput as never}
       onBack={onBack}
+      onDetachedFailure={onDetachedFailure}
     />,
   );
 }
@@ -366,6 +367,32 @@ describe('InlinePlaylistPicker', () => {
       expect(membershipStore.setMembershipForClimb).toHaveBeenLastCalledWith('climb-1', ['p-1']);
     });
 
+    // Mount state alone is the WRONG signal for "is a toast visible". The reaction
+    // overlay's back button pops to its action menu, which unmounts the picker
+    // while the FullWindowOverlay / transparent Modal is still presented — and a
+    // root toast renders behind those, then self-dismisses in 3s. So the host gets
+    // to say where a detached failure goes; only hosts whose dismissal IS the
+    // picker's unmount (the ModalSheet) fall through to the toast.
+    it('hands the failure to the host channel instead of a toast when the host outlives the picker', async () => {
+      const { pending, rejection } = setupDeferredAdd();
+      playlistContext.addToPlaylist.mockReset().mockReturnValueOnce(rejection);
+      const onDetachedFailure = vi.fn();
+      const { getByLabelText, unmount } = renderPicker(undefined, onDetachedFailure);
+
+      fireEvent.click(getByLabelText('Minimoon circuit'));
+      await waitFor(() => expect(playlistContext.addToPlaylist).toHaveBeenCalled());
+      // Back-to-menu: the picker goes, the overlay stays.
+      unmount();
+      pending.resolve();
+
+      await waitFor(() => {
+        expect(onDetachedFailure).toHaveBeenCalledWith(
+          'actions.playlist.toast.addFailedNamed:playlist=Minimoon circuit',
+        );
+      });
+      expect(showToast).not.toHaveBeenCalled();
+    });
+
     it.each([
       ['mounted', false],
       ['unmounted', true],
@@ -419,7 +446,7 @@ describe('InlinePlaylistPicker', () => {
     fireEvent.click(getByLabelText('actions.playlist.create.submit'));
 
     await waitFor(() => {
-      expect(getByText('actions.playlist.toast.addFailed')).not.toBeNull();
+      expect(getByText('actions.playlist.toast.addFailedNamed:playlist=Projects')).not.toBeNull();
     });
     // Created exactly once (no duplicate), the add was attempted, and the form
     // closed — so a retry taps the existing row rather than re-creating.
@@ -458,6 +485,45 @@ describe('InlinePlaylistPicker', () => {
     expect(reportHandledError).toHaveBeenCalledWith(expect.any(Error), {
       tags: { source: 'playlist', op: 'create-then-add' },
     });
+  });
+
+  it('names the playlist when a create-then-add fails while a SECOND create form is open', async () => {
+    // The other way the create token goes stale, with the picker still mounted:
+    // submit a second inline create while the first playlist's add is in flight.
+    // The stale continuation must still speak (dropping it loses the first
+    // playlist's add silently), it must name which playlist it is about, and the
+    // message has to land in the form's error slot — the list header that
+    // normally carries it isn't mounted while the form is open.
+    const first = makePlaylist('p-first', 'Minimoon circuit');
+    const secondCreate = deferred<Playlist>();
+    playlistContext.createPlaylist.mockReset().mockResolvedValueOnce(first).mockReturnValueOnce(secondCreate.promise);
+    const pendingAdd = deferred<void>();
+    const rejection = pendingAdd.promise.then(() => {
+      throw new Error('offline');
+    });
+    rejection.catch(() => {});
+    playlistContext.addToPlaylist.mockReset().mockReturnValueOnce(rejection);
+    const { getByLabelText, getByText } = renderPicker();
+
+    fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
+    fireEvent.change(getByLabelText('name-input'), { target: { value: 'Minimoon circuit' } });
+    fireEvent.click(getByLabelText('actions.playlist.create.submit'));
+    await waitFor(() => expect(playlistContext.addToPlaylist).toHaveBeenCalledWith('p-first', 'climb-1', 40));
+
+    // Second create: bumps the token, so the first add's continuation is stale.
+    fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
+    fireEvent.change(getByLabelText('name-input'), { target: { value: 'Board projects' } });
+    fireEvent.click(getByLabelText('actions.playlist.create.submit'));
+    await waitFor(() => expect(playlistContext.createPlaylist).toHaveBeenCalledTimes(2));
+
+    pendingAdd.resolve();
+
+    await waitFor(() => {
+      expect(getByText('actions.playlist.toast.addFailedNamed:playlist=Minimoon circuit')).not.toBeNull();
+    });
+    // Still mounted, so nothing goes to the (invisible-behind-the-host) toast.
+    expect(showToast).not.toHaveBeenCalled();
+    secondCreate.resolve(makePlaylist('p-second', 'Board projects'));
   });
 
   it('shows a create failure inline and keeps the form open without adding', async () => {

--- a/packages/mobile/src/components/playlist/__tests__/InlinePlaylistPicker.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/InlinePlaylistPicker.test.tsx
@@ -428,6 +428,38 @@ describe('InlinePlaylistPicker', () => {
     expect(queryByLabelText('actions.playlist.create.submit')).toBeNull();
   });
 
+  it('toasts a failed create-then-add when the picker went away mid-request', async () => {
+    // The same hole as the toggle path, one flow over: the create succeeds, the
+    // picker unmounts, then the add rejects. This one used to be gated on
+    // isCurrent() — false after unmount — so it reported nothing at all. The form
+    // is already closed by the time the add runs, so a stale token here means the
+    // picker is gone, which is exactly when the toast is the only channel left.
+    const created = makePlaylist('p-new', 'Projects');
+    playlistContext.createPlaylist.mockResolvedValueOnce(created);
+    const pending = deferred<void>();
+    const rejection = pending.promise.then(() => {
+      throw new Error('offline');
+    });
+    rejection.catch(() => {});
+    playlistContext.addToPlaylist.mockReset().mockReturnValueOnce(rejection);
+    const { getByLabelText, unmount } = renderPicker();
+
+    fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
+    fireEvent.change(getByLabelText('name-input'), { target: { value: 'Projects' } });
+    fireEvent.click(getByLabelText('actions.playlist.create.submit'));
+    await waitFor(() => expect(playlistContext.addToPlaylist).toHaveBeenCalled());
+
+    unmount();
+    pending.resolve();
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith('actions.playlist.toast.addFailedNamed:playlist=Projects', 'error');
+    });
+    expect(reportHandledError).toHaveBeenCalledWith(expect.any(Error), {
+      tags: { source: 'playlist', op: 'create-then-add' },
+    });
+  });
+
   it('shows a create failure inline and keeps the form open without adding', async () => {
     playlistContext.createPlaylist.mockRejectedValueOnce(new Error('create failed'));
     const { getByLabelText, getByText } = renderPicker();

--- a/packages/mobile/src/lib/playlists/__tests__/playlist-climb-render-board.test.ts
+++ b/packages/mobile/src/lib/playlists/__tests__/playlist-climb-render-board.test.ts
@@ -134,3 +134,53 @@ describe('resolvePlaylistClimbRenderBoard', () => {
     expect(result).toBeNull();
   });
 });
+
+describe('MoonBoard hold-set fit', () => {
+  // MoonBoard 2024 (layout 3): cell 1 is Hold Set D (set 5), cell 2 is Wooden
+  // Holds (set 8). getMoonBoardDetails renders the full grid whichever sets are
+  // bolted on, so without the set check both climbs below would read as an exact
+  // fit on a base-only wall — and the row would open into a queue the set-scoped
+  // backend fetch had already emptied (#3891).
+  function moonBoard2024(setIds: number[]): PlaylistRenderBoard {
+    const config = getBoardConfigForPlaylist('moonboard', 3);
+    if (!config) throw new Error('Missing MoonBoard 2024 board config');
+    return {
+      boardName: config.boardName,
+      layoutId: config.layoutId,
+      sizeId: config.sizeId,
+      setIds: setIds.join(','),
+      angle: 40,
+    };
+  }
+
+  it('marks a wooden-set climb incompatible on a base-only wall', () => {
+    const baseOnlyWall = moonBoard2024([5, 6, 7]);
+    const climb = makeClimb({ boardType: 'moonboard', layoutId: 3, frames: 'p1r42p2r43' });
+
+    const result = resolvePlaylistClimbRenderBoard(climb, baseOnlyWall);
+
+    expect(result?.incompatible).toBe(true);
+    expect(result?.fit).toBe('incompatible');
+  });
+
+  it('renders the same climb on the active wall once the wooden set is installed', () => {
+    const woodenWall = moonBoard2024([5, 6, 7, 8]);
+    const climb = makeClimb({ boardType: 'moonboard', layoutId: 3, frames: 'p1r42p2r43' });
+
+    const result = resolvePlaylistClimbRenderBoard(climb, woodenWall);
+
+    expect(result?.incompatible).toBe(false);
+    expect(result?.fit).toBe('exact');
+    expect(result?.renderBoard).toEqual(woodenWall);
+  });
+
+  it('keeps a base-set climb on a base-only wall', () => {
+    const baseOnlyWall = moonBoard2024([5, 6, 7]);
+    const climb = makeClimb({ boardType: 'moonboard', layoutId: 3, frames: 'p1r42p9r43' });
+
+    const result = resolvePlaylistClimbRenderBoard(climb, baseOnlyWall);
+
+    expect(result?.incompatible).toBe(false);
+    expect(result?.fit).toBe('exact');
+  });
+});

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import type { Climb, ClimbQueueItem } from '@boardsesh/queue';
 import type { UsePlaylistClimbActivationOptions } from '@boardsesh/playlists-react';
-import { usePlaylistActivation } from '../use-playlist-activation';
+import { usePlaylistActivation, _resetEmptyBoardFetchReportsForTests } from '../use-playlist-activation';
 
 // The shared `usePlaylistClimbActivation` is exercised by @boardsesh/playlists-react's
 // own tests. Here we mock it to capture the options the mobile wrapper builds —
@@ -127,6 +127,9 @@ function captured(): UsePlaylistClimbActivationOptions {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // The canary's once-per-session Set is module state; clear it so a reused
+  // sourceId can't make a case pass by reporting nothing.
+  _resetEmptyBoardFetchReportsForTests();
   mocks.activeBoard = { boardType: 'kilter', layoutId: 1, sizeId: 2, setIds: '3', angle: 40 };
   mocks.activeClimbUuid = null;
   mocks.suggestionSource = null;

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -79,7 +79,7 @@ vi.mock('../../climb-to-queue-item', () => ({
   }),
 }));
 
-function makeClimb(uuid: string): Climb {
+function makeClimb(uuid: string, overrides: Partial<Climb> = {}): Climb {
   return {
     uuid,
     name: `Climb ${uuid}`,
@@ -92,6 +92,7 @@ function makeClimb(uuid: string): Climb {
     stars: 3,
     difficulty_error: '0',
     benchmark_difficulty: null,
+    ...overrides,
   };
 }
 
@@ -516,7 +517,7 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
       await waitFor(() => {
         expect(mocks.reportHandledError).toHaveBeenCalledWith(expect.any(Error), {
           tags: { source: 'playlist', op: 'replace-queue-empty' },
-          extra: { sourceId: 'playlist:empty-fetch-1', loadedCount: 3 },
+          extra: { sourceId: 'playlist:empty-fetch-1', renderableCount: 3, loadedCount: 3 },
         });
       });
       // Documents the degraded-but-not-crashed behaviour: the tapped climb is still
@@ -566,6 +567,54 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
 
       await waitFor(() => expect(fetchPage).toHaveBeenCalled());
       expect(mocks.reportHandledError).not.toHaveBeenCalled();
+    });
+
+    it('stays silent when the loaded climbs are all on a board this one cannot render', async () => {
+      // The detail list runs the resolver in ALL-BOARDS mode on purpose, so
+      // `allClimbs` carries climbs from other board types and layouts. A playlist
+      // declared on kilter layout 1 whose climbs were all added from a Tension
+      // board legitimately fetches nothing here — reporting it would drown the
+      // signal this canary exists to give.
+      const tapped = makeClimb('b');
+      const fetchPage = vi.fn().mockResolvedValue({ climbs: [], hasMore: false });
+      const { result } = renderActivation(fetchPage, {
+        replaceQueueOnActivate: true,
+        sourceId: 'playlist:empty-fetch-4',
+        allClimbs: [
+          makeClimb('a', { boardType: 'tension', layoutId: 9 }),
+          makeClimb('b', { boardType: 'tension', layoutId: 9 }),
+        ],
+      });
+
+      await act(async () => {
+        await result.current.activate(tapped);
+      });
+
+      await waitFor(() => expect(fetchPage).toHaveBeenCalled());
+      expect(mocks.reportHandledError).not.toHaveBeenCalled();
+    });
+
+    it('still reports when only some of the loaded climbs belong to the active board', async () => {
+      // The mixed case is the one that matters: one climbable row plus a pile of
+      // off-board ones still means the board-scoped fetch owed us that row.
+      const tapped = makeClimb('b');
+      const fetchPage = vi.fn().mockResolvedValue({ climbs: [], hasMore: false });
+      const { result } = renderActivation(fetchPage, {
+        replaceQueueOnActivate: true,
+        sourceId: 'playlist:empty-fetch-5',
+        allClimbs: [makeClimb('a', { boardType: 'tension', layoutId: 9 }), tapped],
+      });
+
+      await act(async () => {
+        await result.current.activate(tapped);
+      });
+
+      await waitFor(() => {
+        expect(mocks.reportHandledError).toHaveBeenCalledWith(expect.any(Error), {
+          tags: { source: 'playlist', op: 'replace-queue-empty' },
+          extra: { sourceId: 'playlist:empty-fetch-5', renderableCount: 1, loadedCount: 2 },
+        });
+      });
     });
 
     it('keeps the queue unchanged and shows a toast when the full playlist fetch fails', async () => {

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -617,6 +617,65 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
       });
     });
 
+    it('stays silent when a MoonBoard wall lacks the sets its playlist climbs need', async () => {
+      // MoonBoard's renderable holds are the whole grid whatever add-on sets are
+      // bolted on, so the canary's compatibility check has to look at hold sets
+      // too. A base-only 2024 wall opening a wooden-holds playlist legitimately
+      // fetches nothing (the backend's `required_set_ids <@ selected sets`
+      // containment drops every row) — reporting that would poison the signal.
+      mocks.activeBoard = {
+        boardType: 'moonboard',
+        layoutId: 3,
+        sizeId: 21,
+        setIds: '5,6,7',
+        angle: 40,
+      } as ActiveBoard;
+      const tapped = makeClimb('b', { boardType: 'moonboard', layoutId: 3, frames: 'p1r42p2r43' });
+      const fetchPage = vi.fn().mockResolvedValue({ climbs: [], hasMore: false });
+      const { result } = renderActivation(fetchPage, {
+        replaceQueueOnActivate: true,
+        sourceId: 'playlist:empty-fetch-6',
+        allClimbs: [makeClimb('a', { boardType: 'moonboard', layoutId: 3, frames: 'p2r42p17r43' }), tapped],
+      });
+
+      await act(async () => {
+        await result.current.activate(tapped);
+      });
+
+      await waitFor(() => expect(fetchPage).toHaveBeenCalled());
+      expect(mocks.reportHandledError).not.toHaveBeenCalled();
+    });
+
+    it('still reports for a MoonBoard wall that does have the sets its playlist climbs need', async () => {
+      // Same wall with the wooden sets installed: now the backend owed us those
+      // rows, so an empty fetch is a real defect and must page us.
+      mocks.activeBoard = {
+        boardType: 'moonboard',
+        layoutId: 3,
+        sizeId: 21,
+        setIds: '5,6,7,8,9,10',
+        angle: 40,
+      } as ActiveBoard;
+      const tapped = makeClimb('b', { boardType: 'moonboard', layoutId: 3, frames: 'p1r42p2r43' });
+      const fetchPage = vi.fn().mockResolvedValue({ climbs: [], hasMore: false });
+      const { result } = renderActivation(fetchPage, {
+        replaceQueueOnActivate: true,
+        sourceId: 'playlist:empty-fetch-7',
+        allClimbs: [tapped],
+      });
+
+      await act(async () => {
+        await result.current.activate(tapped);
+      });
+
+      await waitFor(() => {
+        expect(mocks.reportHandledError).toHaveBeenCalledWith(expect.any(Error), {
+          tags: { source: 'playlist', op: 'replace-queue-empty' },
+          extra: { sourceId: 'playlist:empty-fetch-7', renderableCount: 1, loadedCount: 1 },
+        });
+      });
+    });
+
     it('keeps the queue unchanged and shows a toast when the full playlist fetch fails', async () => {
       const fetchPage = vi.fn().mockRejectedValue(new Error('network'));
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => ({
   fetchSuggestion: vi.fn(),
   captured: undefined as UsePlaylistClimbActivationOptions | undefined,
   queueItemCounter: 0,
+  reportHandledError: vi.fn(),
 }));
 
 const VIEW_ONLY_BOARD = { boardName: 'tension', layoutId: 9, sizeId: 5, setIds: '1,2', angle: 35 };
@@ -67,6 +68,7 @@ vi.mock('react-i18next', () => ({
 vi.mock('../../graphql/use-active-board', () => ({
   useActiveBoard: () => ({ data: mocks.activeBoard }),
 }));
+vi.mock('../../error-reporting', () => ({ reportHandledError: mocks.reportHandledError }));
 // Unique uuid per call (mirrors the real randomUUID wrapper) — the "same item"
 // assertions below would be vacuous if every call minted the same uuid.
 vi.mock('../../climb-to-queue-item', () => ({
@@ -489,6 +491,78 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
 
       expect(result.current.queueReplaceSheet.visible).toBe(false);
       expect(mocks.setQueue).not.toHaveBeenCalled();
+    });
+
+    // #3891 canary. A board-scoped fetch that comes back empty for a playlist whose
+    // detail list already has climbs degrades into a plausible one-item queue —
+    // no error, no toast, just a circuit you can't swipe through. That is exactly
+    // how the MoonBoard size filter hid for months, so it now reports to Sentry.
+    it('reports (and does not silently one-item) an empty board-scoped fetch for a non-empty playlist', async () => {
+      const tapped = makeClimb('b');
+      const fetchPage = vi.fn().mockResolvedValue({ climbs: [], hasMore: false });
+      const { result } = renderActivation(fetchPage, {
+        replaceQueueOnActivate: true,
+        sourceId: 'playlist:empty-fetch-1',
+        allClimbs: [makeClimb('a'), tapped, makeClimb('c')],
+      });
+
+      await act(async () => {
+        await result.current.activate(tapped);
+      });
+
+      await waitFor(() => {
+        expect(mocks.reportHandledError).toHaveBeenCalledWith(expect.any(Error), {
+          tags: { source: 'playlist', op: 'replace-queue-empty' },
+          extra: { sourceId: 'playlist:empty-fetch-1', loadedCount: 3 },
+        });
+      });
+      // Documents the degraded-but-not-crashed behaviour: the tapped climb is still
+      // playable, it just has nowhere to swipe to. The canary is telemetry, not a fix.
+      const lastSetQueue = mocks.setQueue.mock.calls.at(-1);
+      expect(lastSetQueue?.[0].map((item: ClimbQueueItem) => item.climb.uuid)).toEqual(['b']);
+      expect(mocks.showToast).not.toHaveBeenCalled();
+    });
+
+    it('reports an empty board-scoped fetch at most once per playlist per session', async () => {
+      const tapped = makeClimb('b');
+      const fetchPage = vi.fn().mockResolvedValue({ climbs: [], hasMore: false });
+      const { result } = renderActivation(fetchPage, {
+        replaceQueueOnActivate: true,
+        sourceId: 'playlist:empty-fetch-2',
+        allClimbs: [makeClimb('a'), tapped],
+      });
+
+      await act(async () => {
+        await result.current.activate(tapped);
+      });
+      await waitFor(() => expect(mocks.reportHandledError).toHaveBeenCalledTimes(1));
+
+      // A climber poking at a broken playlist re-taps rows freely, and
+      // reportHandledError has no dedup of its own — one bad playlist must not
+      // become hundreds of identical Sentry events.
+      await act(async () => {
+        await result.current.activate(tapped);
+      });
+      await waitFor(() => expect(fetchPage).toHaveBeenCalledTimes(2));
+      expect(mocks.reportHandledError).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not report an empty board-scoped fetch for a playlist with no loaded climbs', async () => {
+      // Nothing loaded means nothing to disagree with — an empty playlist legitimately
+      // fetches nothing, and a false positive here would be permanent noise.
+      const fetchPage = vi.fn().mockResolvedValue({ climbs: [], hasMore: false });
+      const { result } = renderActivation(fetchPage, {
+        replaceQueueOnActivate: true,
+        sourceId: 'playlist:empty-fetch-3',
+        allClimbs: [],
+      });
+
+      await act(async () => {
+        await result.current.activate(makeClimb('b'));
+      });
+
+      await waitFor(() => expect(fetchPage).toHaveBeenCalled());
+      expect(mocks.reportHandledError).not.toHaveBeenCalled();
     });
 
     it('keeps the queue unchanged and shows a toast when the full playlist fetch fails', async () => {

--- a/packages/mobile/src/lib/playlists/playlist-climb-render-board.ts
+++ b/packages/mobile/src/lib/playlists/playlist-climb-render-board.ts
@@ -45,6 +45,11 @@ export function getPlaylistRenderBoardTarget(renderBoard: PlaylistRenderBoard): 
     board_name: boardName,
     layout_id: renderBoard.layoutId,
     holdsData: renderData?.holdsData,
+    // MoonBoard holdsData covers the full grid whichever add-on sets are bolted
+    // on, so hand over the wall's sets too. Without them a wooden-set climb reads
+    // as an exact fit on a base-only wall: the row renders undimmed, and the tap
+    // then falls through the set-scoped backend fetch into a one-item queue.
+    set_ids: setIds,
   };
 }
 

--- a/packages/mobile/src/lib/playlists/use-playlist-activation.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-activation.ts
@@ -25,6 +25,7 @@ import {
   PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE,
 } from '@boardsesh/playlists-react';
 import { createPlaylistSuggestionSource, getQueueBoardKey, type Climb, type ClimbQueueItem } from '@boardsesh/queue';
+import { canAddClimbToBoard } from '@boardsesh/board-config';
 import { useActiveClimbUuid, usePlaylistSuggestionSource, useQueueActions } from '../../providers/queue-provider';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
 import { useToast } from '../../providers/toast-provider';
@@ -32,6 +33,7 @@ import { useActiveBoard } from '../graphql/use-active-board';
 import { climbToQueueItem } from '../climb-to-queue-item';
 import { reportHandledError } from '../error-reporting';
 import { toSchemaClimb } from '../climb-types';
+import { getPlaylistRenderBoardTarget } from './playlist-climb-render-board';
 import type { PlaylistRenderBoard } from './use-playlist-render-board';
 
 // Playlists whose board-scoped fetch has already been reported as empty this app
@@ -47,6 +49,29 @@ const reportedEmptyBoardFetches = new Set<string>();
  */
 export function _resetEmptyBoardFetchReportsForTests(): void {
   reportedEmptyBoardFetches.clear();
+}
+
+/**
+ * How many of the loaded climbs the active board could actually render.
+ *
+ * The canary below compares the board-scoped fetch against THIS, not against the
+ * raw loaded count. The playlist detail list runs the resolver in all-boards mode
+ * on purpose, so `allClimbs` also carries climbs on other board types, other
+ * layouts, and climbs whose holds don't exist on the active size — a board-scoped
+ * fetch dropping every one of those is correct behaviour, not a defect, and
+ * reporting it would bury the signal the canary exists to give.
+ *
+ * `canAddClimbToBoard` is the same predicate the playlist rows use to decide
+ * whether to dim a climb as incompatible, so "the list showed it as climbable
+ * here" and "the board-scoped query should have returned it" stay in agreement.
+ */
+function countClimbsThisBoardCanRender(climbs: Climb[], board: PlaylistRenderBoard): number {
+  const target = getPlaylistRenderBoardTarget(board);
+  let count = 0;
+  for (const climb of climbs) {
+    if (canAddClimbToBoard(climb, target).ok) count += 1;
+  }
+  return count;
 }
 
 /** A single page of the suggestion-refresh fetch. */
@@ -181,12 +206,12 @@ export function usePlaylistActivation({
   const playlistSuggestionSourceRef = useRef(playlistSuggestionSource);
   playlistSuggestionSourceRef.current = playlistSuggestionSource;
 
-  // How many climbs the screen has loaded, mirrored into a ref so the empty-fetch
-  // canary below can read it without putting `allClimbs` in
+  // The climbs the screen has loaded, mirrored into a ref so the empty-fetch
+  // canary below can read them without putting `allClimbs` in
   // `replaceQueueWithPlaylist`'s deps — that array's identity changes on every
   // page-in and would churn the whole activation callback chain.
-  const loadedClimbCountRef = useRef(allClimbs.length);
-  loadedClimbCountRef.current = allClimbs.length;
+  const loadedClimbsRef = useRef(allClimbs);
+  loadedClimbsRef.current = allClimbs;
 
   // The queue item the returned callback built for this tap. queueApi.setCurrentClimb
   // dispatches that exact instance so the drawer's navigation anchor and the queue
@@ -333,17 +358,28 @@ export function usePlaylistActivation({
         const climbs = options.loadedClimbs ?? (await fetchAllClimbsForBoard({ signal: abortController.signal }));
         if (abortController.signal.aborted) return;
         // Canary. A board-scoped fetch that comes back empty for a playlist the
-        // detail list has already rendered climbs for degrades into a perfectly
-        // plausible one-item queue (buildPlaylistQueue appends the tapped climb),
-        // with no error anywhere — which is exactly how #3891's MoonBoard size
-        // filter stayed invisible for months. Sentry-only, once per playlist per
-        // session, so the next instance of that class pages us instead of a user.
-        if (climbs.length === 0 && loadedClimbCountRef.current > 0 && !reportedEmptyBoardFetches.has(sourceId)) {
-          reportedEmptyBoardFetches.add(sourceId);
-          reportHandledError(new Error('Playlist board-scoped fetch returned no climbs'), {
-            tags: { source: 'playlist', op: 'replace-queue-empty' },
-            extra: { sourceId, loadedCount: loadedClimbCountRef.current },
+        // detail list has already rendered climbable rows for degrades into a
+        // perfectly plausible one-item queue (buildPlaylistQueue appends the
+        // tapped climb), with no error anywhere — which is exactly how #3891's
+        // MoonBoard size filter stayed invisible for months. Sentry-only, once
+        // per playlist per session, so the next instance of that class pages us
+        // instead of a user. Gated on climbs this board CAN render, so a playlist
+        // full of off-board climbs (legitimately empty here) stays silent.
+        if (climbs.length === 0 && activeBoard && !reportedEmptyBoardFetches.has(sourceId)) {
+          const renderableCount = countClimbsThisBoardCanRender(loadedClimbsRef.current, {
+            boardName: activeBoard.boardType,
+            layoutId: activeBoard.layoutId,
+            sizeId: activeBoard.sizeId,
+            setIds: activeBoard.setIds,
+            angle: activeBoard.angle,
           });
+          if (renderableCount > 0) {
+            reportedEmptyBoardFetches.add(sourceId);
+            reportHandledError(new Error('Playlist board-scoped fetch returned no climbs'), {
+              tags: { source: 'playlist', op: 'replace-queue-empty' },
+              extra: { sourceId, renderableCount, loadedCount: loadedClimbsRef.current.length },
+            });
+          }
         }
         // Re-check live queue state after the async load: new future items may
         // have landed while the ordered list streamed in, and replacement still
@@ -380,7 +416,7 @@ export function usePlaylistActivation({
         setIsReplacingQueue(false);
       }
     },
-    [fetchAllClimbsForBoard, getQueueSnapshot, openPlayDrawer, setQueue, showToast, sourceId, t],
+    [activeBoard, fetchAllClimbsForBoard, getQueueSnapshot, openPlayDrawer, setQueue, showToast, sourceId, t],
   );
 
   const cancelQueueReplacement = useCallback(() => {

--- a/packages/mobile/src/lib/playlists/use-playlist-activation.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-activation.ts
@@ -34,6 +34,12 @@ import { reportHandledError } from '../error-reporting';
 import { toSchemaClimb } from '../climb-types';
 import type { PlaylistRenderBoard } from './use-playlist-render-board';
 
+// Playlists whose board-scoped fetch has already been reported as empty this app
+// session. `reportHandledError` has no dedup or rate limit of its own, and a
+// climber poking at a broken playlist re-taps rows freely, so without this one
+// bad playlist could ship hundreds of identical events.
+const reportedEmptyBoardFetches = new Set<string>();
+
 /** A single page of the suggestion-refresh fetch. */
 export type PlaylistActivationPage = {
   climbs: Climb[];
@@ -165,6 +171,13 @@ export function usePlaylistActivation({
   const playlistSuggestionSource = usePlaylistSuggestionSource();
   const playlistSuggestionSourceRef = useRef(playlistSuggestionSource);
   playlistSuggestionSourceRef.current = playlistSuggestionSource;
+
+  // How many climbs the screen has loaded, mirrored into a ref so the empty-fetch
+  // canary below can read it without putting `allClimbs` in
+  // `replaceQueueWithPlaylist`'s deps — that array's identity changes on every
+  // page-in and would churn the whole activation callback chain.
+  const loadedClimbCountRef = useRef(allClimbs.length);
+  loadedClimbCountRef.current = allClimbs.length;
 
   // The queue item the returned callback built for this tap. queueApi.setCurrentClimb
   // dispatches that exact instance so the drawer's navigation anchor and the queue
@@ -310,6 +323,19 @@ export function usePlaylistActivation({
       try {
         const climbs = options.loadedClimbs ?? (await fetchAllClimbsForBoard({ signal: abortController.signal }));
         if (abortController.signal.aborted) return;
+        // Canary. A board-scoped fetch that comes back empty for a playlist the
+        // detail list has already rendered climbs for degrades into a perfectly
+        // plausible one-item queue (buildPlaylistQueue appends the tapped climb),
+        // with no error anywhere — which is exactly how #3891's MoonBoard size
+        // filter stayed invisible for months. Sentry-only, once per playlist per
+        // session, so the next instance of that class pages us instead of a user.
+        if (climbs.length === 0 && loadedClimbCountRef.current > 0 && !reportedEmptyBoardFetches.has(sourceId)) {
+          reportedEmptyBoardFetches.add(sourceId);
+          reportHandledError(new Error('Playlist board-scoped fetch returned no climbs'), {
+            tags: { source: 'playlist', op: 'replace-queue-empty' },
+            extra: { sourceId, loadedCount: loadedClimbCountRef.current },
+          });
+        }
         // Re-check live queue state after the async load: new future items may
         // have landed while the ordered list streamed in, and replacement still
         // clears them — so warn instead of clearing silently. Skipped once the
@@ -345,7 +371,7 @@ export function usePlaylistActivation({
         setIsReplacingQueue(false);
       }
     },
-    [fetchAllClimbsForBoard, getQueueSnapshot, openPlayDrawer, setQueue, showToast, t],
+    [fetchAllClimbsForBoard, getQueueSnapshot, openPlayDrawer, setQueue, showToast, sourceId, t],
   );
 
   const cancelQueueReplacement = useCallback(() => {

--- a/packages/mobile/src/lib/playlists/use-playlist-activation.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-activation.ts
@@ -64,6 +64,10 @@ export function _resetEmptyBoardFetchReportsForTests(): void {
  * `canAddClimbToBoard` is the same predicate the playlist rows use to decide
  * whether to dim a climb as incompatible, so "the list showed it as climbable
  * here" and "the board-scoped query should have returned it" stay in agreement.
+ * Hold sets included: `getPlaylistRenderBoardTarget` hands the wall's `set_ids`
+ * to the predicate, which is what keeps it matching the backend's
+ * `required_set_ids <@ selected sets` containment on MoonBoard — whose render
+ * data covers the whole grid whichever add-on sets are actually bolted on.
  */
 function countClimbsThisBoardCanRender(climbs: Climb[], board: PlaylistRenderBoard): number {
   const target = getPlaylistRenderBoardTarget(board);

--- a/packages/mobile/src/lib/playlists/use-playlist-activation.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-activation.ts
@@ -40,6 +40,15 @@ import type { PlaylistRenderBoard } from './use-playlist-render-board';
 // bad playlist could ship hundreds of identical events.
 const reportedEmptyBoardFetches = new Set<string>();
 
+/**
+ * Clear the once-per-session canary bookkeeping. Test-only: the Set above is
+ * module state that outlives an individual test, so without this a case that
+ * reuses a sourceId would see zero reports and pass for the wrong reason.
+ */
+export function _resetEmptyBoardFetchReportsForTests(): void {
+  reportedEmptyBoardFetches.clear();
+}
+
 /** A single page of the suggestion-refresh fetch. */
 export type PlaylistActivationPage = {
   climbs: Climb[];

--- a/packages/shared/board-config/src/__tests__/board-compatibility.test.ts
+++ b/packages/shared/board-config/src/__tests__/board-compatibility.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
+  canAddClimbToBoard,
   classifyClimbBoardCompatibility,
   findNextCompatibleQueueItem,
   type ActiveBoardForCompatibility,
   type ClimbBoardIdentity,
 } from '../board-compatibility';
+import type { BoardCompatibilityTarget } from '../types';
 
 const KILTER_L1: ActiveBoardForCompatibility = { boardName: 'kilter', layoutId: 1 };
 const KILTER_HOMEWALL_L8: ActiveBoardForCompatibility = { boardName: 'kilter', layoutId: 8 };
@@ -126,5 +128,57 @@ describe('findNextCompatibleQueueItem', () => {
     const result = findNextCompatibleQueueItem(queue, 'gone', KILTER_L1);
     expect(result.item?.uuid).toBe('q1');
     expect(result.skippedCount).toBe(1);
+  });
+});
+
+describe('canAddClimbToBoard — MoonBoard hold-set containment', () => {
+  // MoonBoard 2024 (layout 3). getMoonBoardDetails emits the whole grid as
+  // holdsData whichever add-on sets are bolted on, so the hold-id check below
+  // passes for every same-layout climb — the set check is the only thing that
+  // can tell a wooden-set climb from a base-set one.
+  const FULL_GRID_HOLDS = Array.from({ length: 198 }, (_, index) => ({ id: index + 1 }));
+
+  function moonBoard2024(setIds?: number[]): BoardCompatibilityTarget {
+    return { board_name: 'moonboard', layout_id: 3, holdsData: FULL_GRID_HOLDS, set_ids: setIds };
+  }
+
+  // Cell 1 is Hold Set D (set 5); cells 2 and 17 are the wooden sets (8 and 10).
+  const BASE_SET_CLIMB = { boardType: 'moonboard', layoutId: 3, frames: 'p1r42p9r43' };
+  const WOODEN_SET_CLIMB = { boardType: 'moonboard', layoutId: 3, frames: 'p1r42p2r43p17r44' };
+
+  it('rejects a wooden-set climb on a wall built without the wooden sets', () => {
+    expect(canAddClimbToBoard(WOODEN_SET_CLIMB, moonBoard2024([5]))).toEqual({
+      ok: false,
+      reason: 'holds_out_of_range',
+    });
+  });
+
+  it('accepts the same climb once the wooden sets are installed', () => {
+    expect(canAddClimbToBoard(WOODEN_SET_CLIMB, moonBoard2024([5, 8, 10]))).toEqual({ ok: true });
+  });
+
+  it('accepts a base-set climb on a base-only wall', () => {
+    expect(canAddClimbToBoard(BASE_SET_CLIMB, moonBoard2024([5]))).toEqual({ ok: true });
+  });
+
+  it('skips the set check when the caller supplies no set_ids', () => {
+    // Opt-in: callers that never knew about hold sets keep their old answer
+    // rather than silently losing every wooden-set climb.
+    expect(canAddClimbToBoard(WOODEN_SET_CLIMB, moonBoard2024())).toEqual({ ok: true });
+  });
+
+  it('does not apply the MoonBoard cell-set map to Aurora boards', () => {
+    // Aurora hold placements are already per-set, so their uninstalled-set holds
+    // fail the hold-id check instead. Running the MoonBoard map over a Kilter
+    // frames string would reject on hold ids that mean something else entirely.
+    const kilterTarget: BoardCompatibilityTarget = {
+      board_name: 'kilter',
+      layout_id: 3,
+      holdsData: FULL_GRID_HOLDS,
+      set_ids: [5],
+    };
+    expect(canAddClimbToBoard({ boardType: 'kilter', layoutId: 3, frames: 'p1r42p2r43p17r44' }, kilterTarget)).toEqual({
+      ok: true,
+    });
   });
 });

--- a/packages/shared/board-config/src/board-compatibility.ts
+++ b/packages/shared/board-config/src/board-compatibility.ts
@@ -1,6 +1,7 @@
 import type { BoardName } from '@boardsesh/shared-schema';
 
 import { toBoardName } from './board-name';
+import { requiredSetIdsForMoonBoard } from './moonboard-cell-sets';
 import type { ClimbCompatibilityInput, BoardCompatibilityTarget } from './types';
 
 /**
@@ -57,6 +58,12 @@ function getValidHoldIds(target: BoardCompatibilityTarget): Set<number> | null {
  *     board. This naturally allows smaller boards to be added to larger
  *     queues (subset of holds) but rejects larger-board climbs that use
  *     holds missing on a smaller board.
+ *  4. On MoonBoard only, and only when the caller supplies `target.set_ids`:
+ *     the sets the climb's cells belong to must all be installed on the wall.
+ *     MoonBoard's `holdsData` is the whole grid whatever sets are bolted on, so
+ *     rule 3 can't catch a wooden-set climb on a base-only wall — the cell-to-set
+ *     map can. Aurora boards need no equivalent because their hold placements are
+ *     per-set, so an uninstalled set's holds already fail rule 3.
  */
 export function canAddClimbToBoard(
   climb: ClimbCompatibilityInput,
@@ -67,6 +74,15 @@ export function canAddClimbToBoard(
   }
   if (climb.layoutId != null && climb.layoutId !== target.layout_id) {
     return { ok: false, reason: 'layout' };
+  }
+  if (target.board_name === 'moonboard' && target.set_ids && target.set_ids.length > 0) {
+    const installedSetIds = new Set(target.set_ids);
+    const requiredSetIds = requiredSetIdsForMoonBoard(target.layout_id, climb.frames ?? '');
+    for (const setId of requiredSetIds) {
+      if (!installedSetIds.has(setId)) {
+        return { ok: false, reason: 'holds_out_of_range' };
+      }
+    }
   }
   const validIds = getValidHoldIds(target);
   if (!validIds) {

--- a/packages/shared/board-config/src/types.ts
+++ b/packages/shared/board-config/src/types.ts
@@ -13,4 +13,11 @@ export type BoardCompatibilityTarget = {
   board_name: BoardName;
   layout_id: number;
   holdsData?: { id: number }[] | null;
+  /**
+   * The hold sets bolted onto the wall. Only consulted for MoonBoard, whose
+   * `holdsData` is the full grid regardless of which add-on sets are installed
+   * (see `getMoonBoardDetails`), so hold-id containment alone can't tell a
+   * base-set climb from a wooden-set one. Omit it and the set check is skipped.
+   */
+  set_ids?: number[] | null;
 };

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -232,6 +232,8 @@
         "removed": "Removed from playlist",
         "addFailed": "Failed to add to playlist",
         "removeFailed": "Failed to remove from playlist",
+        "addFailedNamed": "Couldn't add to \"{{playlist}}\"",
+        "removeFailedNamed": "Couldn't remove from \"{{playlist}}\"",
         "createdNamed": "Created playlist \"{{name}}\"",
         "createFailed": "Failed to create playlist"
       },

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -232,6 +232,8 @@
         "removed": "Eliminado de la playlist",
         "addFailed": "No se pudo añadir a la playlist",
         "removeFailed": "No se pudo eliminar de la playlist",
+        "addFailedNamed": "No se pudo añadir a \"{{playlist}}\"",
+        "removeFailedNamed": "No se pudo eliminar de \"{{playlist}}\"",
         "createdNamed": "Playlist creada \"{{name}}\"",
         "createFailed": "No se pudo crear la playlist"
       },

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -232,6 +232,8 @@
         "removed": "Retiré de la playlist",
         "addFailed": "Impossible d'ajouter à la playlist",
         "removeFailed": "Impossible de retirer de la playlist",
+        "addFailedNamed": "Impossible d'ajouter à « {{playlist}} »",
+        "removeFailedNamed": "Impossible de retirer de « {{playlist}} »",
         "createdNamed": "Playlist « {{name}} » créée",
         "createFailed": "Impossible de créer la playlist"
       },


### PR DESCRIPTION
## Summary

Closes #3891. Follow-ups filed so this issue closes clean: #3996 (the Discover design items), #4000 (`playlistClimbs.totalCount` ignores its own board filters), #4008 (two more callers with the same MoonBoard `= ANY` bug, found in review).

### The issue body was partly wrong, and the correction is the point

The issue tracked two claims. Neither survived contact with the code as written:

1. **"Can't scroll a playlist's climb list" does not reproduce.** The list is virtualized and scrolls fine. The reporter refined this himself: *"i am on a playlist i select a climb, i light it up, but swiping right/left does not go to the next available climb on the playlist."* That is a different bug, it does reproduce, and it is **the headline of this PR**. It was very nearly scoped out.

2. **"Sometimes adds and sometimes doesn't" is not a data-loss bug.** `addClimbToPlaylist` is idempotent and angle-agnostic (pre-existence check on `(playlistId, climbUuid)` only), so the write always persists when the request lands. What is real is a *feedback* hole: when the request fails, the failure can reach nobody at all. Fixed here as a second, smaller defect.

The reporter's "sometimes adds and sometimes doesn't" was most likely defect 1 bleeding over — the climb **is** in the playlist, the drawer just behaves as if it isn't. I'm not claiming the feedback hole is definitely what he saw; it's a proven trust hole worth closing on its own.

---

### Defect 1 (headline): MoonBoard playlists produce a one-climb queue

`playlistClimbs`' specific-board mode size-scoped the climb join with:

```ts
sql`${input.sizeId} = ANY(${tables.climbs.compatibleSizeIds})`
```

MoonBoard has one fixed product size, so its climbs carry `NULL` in `compatible_size_ids` — and `x = ANY(NULL)` is `NULL`, never true. **Every** MoonBoard row was dropped from that join. Against the local dev catalog: all 142,566 MoonBoard climbs have NULL there, and `1 = ANY(compatible_size_ids)` matches exactly zero of them. A MoonBoard board's `sizeId` is always `1`, never null, so the filter always ran.

Why it surfaced as "swiping doesn't advance" rather than "the playlist is empty": the playlist detail **list** deliberately runs all-boards mode (off-board climbs still list, dimmed), so the list looked correct. The play drawer's queue comes from a *different* query — `replaceQueueWithPlaylist` → `fetchAllClimbsForBoard` → specific-board mode → `[]` → `buildPlaylistQueue` hits its "activated climb wasn't in the loaded list" branch and appends only the tapped climb. Queue of one. Previous/next have nowhere to go, and nothing errors, because as far as the code knows the playlist legitimately has no climbs on this board.

The fix is the guard the repo already has and this one resolver never got: `isSizeScopedBoard`, whose own doc comment calls itself "one source of truth for the `!== 'moonboard'` size-scoping guard shared by the sync resolvers, the offline local search, and the offline download-availability check." The main climb search (`create-climb-filters.ts`) and the sync pull (`sync/queries.ts`) were already gated; this one never was.

**Correction to an earlier version of this description**, which claimed this was "the last ungated caller". It isn't — review found two more live instances of the identical bug: `setter-follows.ts:243` (`setterClimbs`) and `setter-stats.ts:36` (`getSetterStats`). Both make every MoonBoard setter read as having published nothing. Out of scope here (different surface, own tests), filed as #4008.

Bundled with it: `= ANY(...)` → `@> ARRAY[...]::int[]`, matching those three call sites and picking up the existing `board_climbs_compatible_size_ids_idx` GIN index (migration 0073). The new tests pin both the include and the exclude direction, so the rewrite is not taken on faith.

**Deliberately board-type-gated, not NULL-tolerant.** `compatible_size_ids IS NULL OR ...` would also un-hide the two NULL Kilter *draft* rows that search deliberately excludes (see the "Draft climbs may have NULL compatible_size_ids" comments in `count-climbs.ts` and `search-climbs.ts`), and would give the codebase two different size-scoping semantics.

### Defect 2: a failed playlist add could reach nobody

`InlinePlaylistPicker.handleToggle`'s catch rolled the optimistic membership back correctly, then reported via `setError` — a `useState` on the picker — plus a `__DEV__`-gated `console.warn`. Neither host dismisses on toggle; **the climber does**, after seeing the optimistic checkmark, while the request is still in flight. On gym wifi that is most of the window. Once the sheet or reaction overlay is dismissed, `playlistData` is nulled and the picker unmounts, so `setError` is a silent no-op and the `console.warn` doesn't exist in a release build. No toast, no banner, no Sentry. The climber walks away believing a curated entry exists.

I proved the catch block *does* still run post-unmount (the cache rollback lands), so this isn't the navigate-then-mutate observer-dropping pattern — `addToPlaylist` is `mutateAsync` inside an awaited try/catch. The catch is the right place; it just had no channel that outlives the component.

So: report through whichever channel is visible at the moment the rejection lands. Mounted → inline banner (a root toast renders behind a native sheet / `FullWindowOverlay`, per the comment in `toast-provider.tsx`). Detached → the host's channel, defaulting to a toast. Mutually exclusive, so no double signal. The detached message names the playlist — "Couldn't add to Minimoon circuit" is actionable two screens away in a way that "Failed to add to playlist" isn't. `reportHandledError` now fires unconditionally, matching how every other playlist mutation reports.

**Review caught that the first cut of this was a no-op on one of the two hosts.** It used the picker's own mount state as a proxy for "the host is gone", which only holds in the `ModalSheet`: `AddToPlaylistSheet`'s data is nulled on `onFullyDismissed`, so unmount really does mean the sheet has finished leaving. The reaction overlay is the other shape entirely — `handleRequestClose` pops the playlist view back to the action menu rather than dismissing, so the *first* backdrop tap or Back press unmounts the picker while the `FullWindowOverlay` / transparent `Modal` is still up. The toast would have fired into the layer behind it and self-dismissed after 3s, unseen. Now the host owns that channel: the overlay holds the message and fires it from its own unmount, which covers both dismissal and the parent tearing it down.

Three smaller things from the same review:

- `mountedRef` is now set on mount as well as cleared on unmount. A mount/cleanup/mount cycle (StrictMode, Fast Refresh) would otherwise classify a live picker as detached forever.
- The membership error also renders in the create form's error slot. The list header that normally carries it isn't mounted while that form is open, so a failure landing there had nowhere to go.
- The create-then-add failure names the playlist on *both* channels. The create token goes stale two ways, not one: the picker went away, or a second inline create was submitted while the first add was in flight — in which case the climber is still looking at the picker, at a different playlist's form.

### Defect 3 (canary, not a fix): report an empty board-scoped fetch

Defect 1 hid for months precisely because a zero-row board-scoped fetch degrades into a *plausible* one-item queue. `replaceQueueWithPlaylist` now reports to Sentry when the board fetch comes back empty for a playlist the screen has already loaded **climbable** climbs for. Sentry-only, no user-facing change, and gated to **once per playlist per app session** — `reportHandledError` has no dedup or rate limit of its own (checked), and a climber poking at a broken circuit re-taps rows freely.

**Review was right about the false-positive surface, and I've reversed my first answer to it.** The original gate compared against the raw loaded count, but the detail list runs the resolver in all-boards mode on purpose, so `allClimbs` also carries climbs on other board types and layouts. The board-mismatch banner can't compensate — `boardLooselyMatches` compares boardType and layoutId only — so a Kilter-layout-1 playlist whose owner only ever added Tension climbs activates normally, fetches nothing (correctly), and shipped an event indistinguishable from a real recurrence. I'd argued that noise was acceptable; it isn't, because it poisons the one signal the canary exists to give. It now counts the loaded climbs `canAddClimbToBoard` says the active board can render — the same predicate the rows use to dim an incompatible climb — so "the list showed it as climbable" and "the query owed us that row" stay in agreement.

### Defect 4: the hold-set filter and the client disagreed on MoonBoard

Review of the set-scoping fix caught that it broke the invariant the canary's own docstring asserts. `canAddClimbToBoard` cannot see hold sets on MoonBoard: `getMoonBoardDetails` builds `holdsData` from the full grid (`numColumns * rowTop`) whichever add-on sets are actually bolted on, so every same-layout MoonBoard climb counted as renderable. Aurora boards were never affected — `getHolePlacements` is per-set, so out-of-set holds already fail the hold-id check with `holds_out_of_range`.

Two consequences on a MoonBoard built without its wooden / screw-on sets:

- **The canary false-positived.** Open a wooden-holds playlist and the board-scoped fetch correctly returns nothing (every row dropped by the new `<@` predicate), while `countClimbsThisBoardCanRender` still said "> 0" — firing `Playlist board-scoped fetch returned no climbs` on correct behaviour, poisoning the exact signal the canary was added to give.
- **A wooden-set row rendered undimmed.** `resolvePlaylistClimbRenderBoard` resolved it to `{ fit: 'exact', incompatible: false }`, so it looked fully climbable — and tapping it hit the new set filter, got a short list back, and `buildPlaylistQueue` fell through to appending just the tapped climb. #3891's own symptom, reachable again on partial-set walls.

Fixed at the root rather than in each caller: `BoardCompatibilityTarget` gained an optional `set_ids`, and on MoonBoard only, `canAddClimbToBoard` requires `requiredSetIdsForMoonBoard(layout_id, frames)` to be a subset of it — the same containment the backend applies. It's opt-in, so every existing caller that omits `set_ids` keeps its current answer. `getPlaylistRenderBoardTarget` now passes the wall's sets, which fixes both the canary and the row dimming from one place.

**On the NULL tolerance.** The resolver tolerates NULL `required_set_ids` on every board, where search only tolerates it for MoonBoard and drafts. Review was right that this rested on an unmeasured assumption, so here is the measurement: in prod on 2026-07-31, 1,223 of 408,035 Kilter climbs (0.30%) and 776 of 153,370 Tension climbs (0.51%) still have NULL. At most half a percent of Aurora playlist rows keep the pre-fix behaviour, versus every one of them disappearing on a backfill lag — and a playlist is a list the climber curated by hand, so the permissive side is the right one to err on.

## Release Notes

- MoonBoard playlists work on the wall again: light up a climb from a playlist and swiping left/right now walks the rest of the circuit instead of stranding you on one climb.
- If adding a climb to a playlist fails, you'll now hear about it — even if you've already swiped the sheet away — and the message names the playlist.

## Test plan

Everything below was run in the foreground and is green.

- `vp run typecheck` (whole repo)
- `vp test run --project backend --reporter=agent playlist` — 12 files, 98 tests
- `vp run test:mobile` — 557 files, 4695 tests
- `vp test run --reporter=agent catalog-completeness` — 60 tests (i18n parity across en-US / es / fr)
- `vp check` — 0 errors
- `vp run check:mobile-bundle` — OK

New tests:

- `packages/backend/src/__tests__/playlist-climbs-board-scope.test.ts` (real DB, 4 cases): MoonBoard playlist returns its climbs in board-scoped mode; a size-incompatible Kilter climb is still excluded; a size-*compatible* Kilter climb whose array holds several sizes survives the `@>` rewrite; board-scoped and all-boards mode agree about which MoonBoard climbs are in the playlist.
- `InlinePlaylistPicker.test.tsx` (7 cases): toasts the named failure when the picker unmounted before the add settled (and still rolls the membership back); keeps it inline and does **not** toast while mounted; **hands the failure to the host channel instead of a toast when the host outlives the picker**; the remove direction gets the remove copy, not the add copy; Sentry is told either way; the create-then-add failure after unmount; **the create-then-add failure while a second create form is open**.
- `ClimbReactionMenu.test.tsx` (2 cases): a detached playlist failure is held while the overlay is still presented and toasted once it's gone; nothing is toasted on dismissal when no failure was handed over.
- `use-playlist-activation.test.tsx` (7 cases): the canary fires with the right tags and the queue still degrades to one item; it fires at most once per playlist; it does not fire for a playlist with nothing loaded; **it stays silent when every loaded climb is on a board this one can't render**; **it still fires when only some of them are**; **it stays silent on a MoonBoard wall that lacks the sets its playlist climbs need**; **it still fires on a MoonBoard wall that does have them**.
- `board-compatibility.test.ts` (5 cases, shared): a wooden-set climb is rejected on a base-only MoonBoard 2024 wall and accepted once the wooden sets are installed; a base-set climb passes either way; the check is skipped when the caller supplies no `set_ids`; the MoonBoard cell-set map is never applied to Aurora boards.
- `playlist-climb-render-board.test.ts` (3 cases): a wooden-set climb dims as incompatible on a base-only wall, renders on the active wall once the set is installed, and a base-set climb is unaffected.

**Mutation checks — actually run, not asserted:**

| Mutation | Expected red | Result |
| --- | --- | --- |
| Restore `sizeId = ANY(...)` | MoonBoard cases | 2 failed (MoonBoard + cross-mode agreement) |
| Delete the size predicate entirely | Kilter exclusion cases | 2 failed (exclusion + multi-size include) |
| Always toast (drop the mounted branch *and* the inline write) | "does NOT toast while mounted" | 3 failed |
| Never toast (plain `setError`) | the two detached cases | 2 failed |
| Drop the canary's per-playlist dedup | "at most once per playlist" | 1 failed |
| Ignore `onDetachedFailure`, always toast | the host-channel case | 1 failed |
| Overlay toasts immediately instead of holding | "holds until the overlay is gone" | 1 failed |
| Drop the canary's renderability gate | the two board-scoping cases | 2 failed |
| Drop the `set_ids` wiring in `getPlaylistRenderBoardTarget` | the two MoonBoard set cases | 2 failed |
| Restore the `isCurrent()` gate on create-then-add | both create-then-add cases | 2 failed |
| Revert the create form's error slot to `createError` only | "second create form is open" | 1 failed |

Correction to an earlier version of this table: "always toast → 3 failed" only holds for the stronger mutation that *also* drops the inline write. A pure always-toast (keep `setError`, add `showToast`) reds one case, not three.

## Device QA gates (cannot be closed on this Linux box)

No macOS, no iOS simulator, no MoonBoard rows in the dev DB's `user_boards`. These need a maintainer or a device:

1. **iOS, required — the headline fix.** MoonBoard (ideally Mini MoonBoard, matching the reporter) as the active board → open a playlist with 3+ climbs → tap a climb → the drawer lights it → swipe left/right walks the playlist and the queue tray shows the whole circuit, not one entry. I can prove the resolver returns the climbs; I can't prove the drawer walks them.
2. **iOS, required — Defect 2's premise.** In Add-to-playlist (both the ellipsis `ModalSheet` **and** the long-press reaction overlay), cut the network mid-request: tap a playlist then dismiss immediately → an error toast naming the playlist must appear on the destination screen. Repeat *without* dismissing → inline banner, no toast. The "a root toast is invisible behind a native sheet" claim is a rendering-order fact about `@expo/ui` sheets and iOS `FullWindowOverlay` that only a device settles. The reaction overlay is a different host from the sheet and z-orders differently, and it now takes a *different* code path (the overlay holds the message and fires it on its own dismissal, rather than the picker toasting on unmount) — check both. In the overlay the expected sequence is: tap a playlist → tap the backdrop once (back to the action menu, nothing visible yet) → tap it again to close the overlay → the named error toast appears.
3. **Regression sweep on a real MoonBoard board.** The playlist detail list must still list the same climbs. This PR widens the swipe query, not the list query, but both live in the same resolver file.
4. **Prod data check (needs prod read access).** Whether `board_climbs` has any Mini MoonBoard 2025 (layout 7) rows at all — the dev catalog only has MoonBoard layouts 2/4/5/6. Immaterial to the fix (all MoonBoard layouts have NULL `compatible_size_ids` equally), but worth confirming the reporter's climbs exist under the layout his board resolves to, in case there's a separate layout-mapping bug behind his report.
5. **Android** is reachable locally via the emulator and is worth a pass on the toast half, but it isn't the reported platform and doesn't substitute for the iOS sheet checks.

## Things a reviewer should push back on if they disagree

- **Blast radius.** `fetchSpecificBoardClimbs` also serves web's playlist detail. The change strictly *widens* MoonBoard results and is a no-op for every size-scoped board. Web MoonBoard playlists will start showing climbs where they showed none — correct, but a visible behaviour change on a surface being deprecated.
- **MoonBoard climbs now enter the play queue via this path for the first time.** They already render in the detail list and light up on a single tap, so the renderer handles them, but a 30-climb MoonBoard queue built by `fetchAllClimbsForBoard`'s drain-until-`hasMore` loop is a code path no MoonBoard user has ever hit. I deliberately did **not** touch that drain loop despite it tripping the repo's own perf checklist — changing pagination in the same PR as the filter would make any regression unattributable.
- **A residual ~300ms race is left open on purpose.** If the rejection lands *during* the sheet's dismiss animation, `mountedRef` is still true, so the banner renders onto a view that is animating away and no toast fires. Closing it needs a pending-toggle handoff registry, which the orchestrator and I both judged over-engineering. Flagging so it can be overruled.
- **`playlistClimbs.totalCount` is still inconsistent** — it counts every row in the playlist and ignores the board filters, so before this fix it said 2 while `climbs` was `[]`. No production client reads it (verified across mobile, web, and playlists-react), so it's latent, not live, and changing a GraphQL field's semantics deserves its own decision. Worth a follow-up if anyone wants it.

## Deviations from the approved plan

- The plan's `surfaceFailure(messageKey)` took one key; it takes two resolved messages instead, because the ruling added a playlist-named toast while the inline banner keeps the generic copy. Same routing, no `t(variable)` calls.
- The plan reused `t('actions.playlist.toast.addFailed')` everywhere; per ruling 4 there are two new keys (`addFailedNamed` / `removeFailedNamed`) in en-US, es and fr. They use a `{{playlist}}` placeholder as the ruling specified, which reads slightly off next to the sibling `createdNamed`'s `{{name}}` — say the word and I'll align them.
- The canary reads `allClimbs` through a ref rather than adding it to `replaceQueueWithPlaylist`'s deps. That array's identity changes on every page-in and would churn the whole activation callback chain, which the repo's perf checklist calls out. The per-climb compatibility scan only runs when the board-scoped fetch came back empty, so it costs nothing on the normal path.
- The create-then-add catch is no longer gated on `isCurrent()`. Review pointed out my first rationale for this was incomplete: the token also goes stale when a *second* inline create is submitted mid-add, with the picker still mounted. Both cases want the message shown — suppressing the second would silently lose the first playlist's add — so it names the playlist on both channels and there's a test for each.


