### PR TITLE
fix(mobile): fail the BLE connect when its first write kills the link (#3875)

### DIFF
--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -1787,6 +1787,11 @@ describe('useBoardBluetooth connect() initial frame write (#3875)', () => {
     expect(Alert.alert).toHaveBeenCalledWith('ble.connectionFailedTitle', 'bluetooth.connectFailed');
     const failure = mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Failed');
     expect(failure?.[1]).toMatchObject({ failureReason: 'dropped_after_connect' });
+    // clearConnectionAfterDrop disposes the adapter on BOTH of its callers, not
+    // just the write-failure one — the adapter self-cleans after firing its own
+    // event, but the explicit disconnect is what stops a half-alive native link
+    // and the onDeviceDisconnected subscription leaking.
+    expect(fakeAdapter.disconnect).toHaveBeenCalled();
   });
 
   it('still connects when the initial climb is incompatible with the board (#3875)', async () => {
@@ -1928,6 +1933,76 @@ describe('useBoardBluetooth connect() initial frame write (#3875)', () => {
     await act(async () => {
       await result.current.connect();
     });
+    expect(result.current.connectInitialSendRef.current).toBeNull();
+  });
+
+  it('fails the connect when the board config switches during the initial write (#3875)', async () => {
+    // The guard for commit 1 (connectedConfigKeyRef assigned when the link opens
+    // rather than after the initial send). That move is what makes this path
+    // reachable at all: the config-switch effect early-returns while the ref is
+    // null, so before it, a board switch landing inside the awaited write left
+    // the stale connection up. Now the effect tears it down and the identity
+    // bail below stops connect() lighting the lightbulb over a dead adapter.
+    //
+    // The alert asserted here is deliberately the generic "move closer" copy,
+    // which does NOT describe what happened — the climber navigated away, the
+    // link did not drop. That wart is accepted (see the comment beside the bail);
+    // this assertion pins it so a future distinct bail reason updates the test on
+    // purpose instead of silently changing what the climber is told.
+    let releaseWrite: (() => void) | undefined;
+    let writeReached: (() => void) | undefined;
+    const writeGate = new Promise<void>((resolve) => {
+      releaseWrite = resolve;
+    });
+    const writeStarted = new Promise<void>((resolve) => {
+      writeReached = resolve;
+    });
+    const fakeAdapter = makeFakeAdapter({
+      write: vi.fn(async () => {
+        writeReached?.();
+        await writeGate;
+      }),
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockAuroraSendable();
+
+    const { result, rerender } = renderHook((props) => useBoardBluetooth(props), {
+      initialProps: { boardName: 'kilter', layoutId: 1, sizeId: 1 },
+    });
+
+    // Park connect() on the initial write. Only then is adapterRef (and, thanks
+    // to commit 1, connectedConfigKeyRef) set, which is what stops the
+    // config-switch effect early-returning and makes this test non-vacuous.
+    let pending: Promise<boolean> | undefined;
+    await act(async () => {
+      pending = result.current.connect('p100r12');
+      await writeStarted;
+    });
+
+    // The switch needs its own act: effects queued by rerender only flush when
+    // the act scope exits, so doing this inside the block above would release the
+    // write before the teardown had run.
+    await act(async () => {
+      rerender({ boardName: 'kilter', layoutId: 2, sizeId: 1 });
+    });
+    expect(fakeAdapter.disconnect).toHaveBeenCalled();
+
+    let connected: boolean | undefined;
+    await act(async () => {
+      releaseWrite?.();
+      connected = await pending;
+    });
+
+    expect(connected).toBe(false);
+    expect(result.current.isConnected).toBe(false);
+    expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Success')).toBeUndefined();
+    expect(Alert.alert).toHaveBeenCalledWith('ble.connectionFailedTitle', 'bluetooth.connectFailed');
+    const failure = mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Failed');
+    expect(failure?.[1]).toMatchObject({ failureReason: 'dropped_after_connect' });
+    // The switched-away connection must not leave a seed behind for the new
+    // board's AutoSender to inherit.
     expect(result.current.connectInitialSendRef.current).toBeNull();
   });
 });

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -1848,6 +1848,73 @@ describe('useBoardBluetooth connect() initial frame write (#3875)', () => {
     const sendFailure = mockTrack.mock.calls.find(([name]) => name === 'Climb Sent to Board Failure');
     expect(sendFailure?.[1]).toMatchObject({ sendSource: 'connect' });
   });
+
+  it('leaves the AutoSender dedup unseeded when the initial write failed (#3875)', async () => {
+    // The seed tells the AutoSender "these frames are already on the wall".
+    // Seeding it after a write that never landed made the AutoSender skip the
+    // write (connected board, dark wall) and fire onWallConfirmed anyway, so the
+    // party feed reported a climb as lit on a dark wall. The link is alive here,
+    // so the connect itself must still succeed.
+    const fakeAdapter = makeFakeAdapter({
+      write: vi.fn().mockRejectedValue(new Error('GATT write failed')),
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockAuroraSendable();
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      await result.current.connect('p100r12');
+    });
+
+    expect(result.current.isConnected).toBe(true);
+    expect(result.current.connectInitialSendRef.current).toBeNull();
+  });
+
+  it('seeds the AutoSender dedup when the initial write landed (#3875)', async () => {
+    // The mutation guard for the test above: clearing the seed unconditionally
+    // would pass it while reintroducing the doubled connect haptic and the
+    // redundant full-frame re-write the seed exists to prevent.
+    const fakeAdapter = makeFakeAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockAuroraSendable();
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      await result.current.connect('p100r12');
+    });
+
+    expect(result.current.connectInitialSendRef.current).toEqual({
+      frames: 'p100r12',
+      mirrored: false,
+      colorSignature: expect.any(String),
+    });
+  });
+
+  it('clears a stale dedup seed when connecting without initial frames (#3875)', async () => {
+    const fakeAdapter = makeFakeAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockAuroraSendable();
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      await result.current.connect('p100r12');
+    });
+    expect(result.current.connectInitialSendRef.current).not.toBeNull();
+
+    await act(async () => {
+      await result.current.connect();
+    });
+    expect(result.current.connectInitialSendRef.current).toBeNull();
+  });
 });
 
 describe('convertToMirroredFramesString', () => {

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -1781,6 +1781,12 @@ describe('useBoardBluetooth connect() initial frame write (#3875)', () => {
     expect(connected).toBe(false);
     expect(result.current.isConnected).toBe(false);
     expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Success')).toBeUndefined();
+    // Asserted here too, not just in the test above: this is the arm the boolean
+    // return value cannot reach, so it needs its own proof that the climber is
+    // told and the failure is recorded.
+    expect(Alert.alert).toHaveBeenCalledWith('ble.connectionFailedTitle', 'bluetooth.connectFailed');
+    const failure = mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Failed');
+    expect(failure?.[1]).toMatchObject({ failureReason: 'dropped_after_connect' });
   });
 
   it('still connects when the initial climb is incompatible with the board (#3875)', async () => {

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -1689,6 +1689,15 @@ describe('useBoardBluetooth remembered-board persistence (#3609)', () => {
 // connect() writes initialFrames before declaring success. That write can take
 // the link with it. These tests pin the boundary: a lost link fails the connect,
 // while a write the board merely refused does not.
+//
+// Which side of that boundary a test lands on is decided by the rejection
+// message, via isDisconnectionError (@boardsesh/ble-protocol/connection-error):
+// 'Not connected' matches its "definite drop" pattern and tears the connection
+// down; 'GATT write failed' does not and leaves the link alive. Deliberately not
+// re-derived in the test bodies — asserting against a locally rebuilt predicate
+// is the tautology this repo has already shipped once. If a change to
+// isDisconnectionError ever collapsed those two messages to the same verdict,
+// the pair below would start agreeing and this comment is the breadcrumb.
 describe('useBoardBluetooth connect() initial frame write (#3875)', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -1686,6 +1686,170 @@ describe('useBoardBluetooth remembered-board persistence (#3609)', () => {
   });
 });
 
+// connect() writes initialFrames before declaring success. That write can take
+// the link with it. These tests pin the boundary: a lost link fails the connect,
+// while a write the board merely refused does not.
+describe('useBoardBluetooth connect() initial frame write (#3875)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetReactNativePermissionHarness();
+    mockBleManager.state.mockResolvedValue('PoweredOn');
+  });
+
+  function mockAuroraSendable() {
+    mockGetLedPlacements.mockReturnValue({ 100: 7, 999: 8 });
+    mockGetAuroraBluetoothPacket.mockReturnValue({
+      packet: new Uint8Array([0x01]),
+      skippedPositionCount: 0,
+      skippedRoleCount: 0,
+      totalPlacements: 1,
+    });
+  }
+
+  it('fails the connect when the initial write kills the link (#3875)', async () => {
+    // The write rejects with a disconnection signature, so sendFramesToBoard tears
+    // the connection down. connect() used to sail past that and light the
+    // lightbulb over a null adapter: every later send then early-returned with
+    // skipReason 'no_adapter' and the wall stayed dark until the climber toggled
+    // the connection off and back on.
+    const fakeAdapter = makeFakeAdapter({
+      write: vi.fn().mockRejectedValue(new Error('Not connected')),
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockAuroraSendable();
+    const onConnectSuccess = vi.fn();
+
+    const { result } = renderHook(() =>
+      useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1, onConnectSuccess }),
+    );
+
+    let connected: boolean | undefined;
+    await act(async () => {
+      connected = await result.current.connect('p100r12');
+    });
+
+    expect(connected).toBe(false);
+    expect(result.current.isConnected).toBe(false);
+    expect(onConnectSuccess).not.toHaveBeenCalled();
+    expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Success')).toBeUndefined();
+    const failure = mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Failed');
+    expect(failure?.[1]).toMatchObject({ boardName: 'kilter', failureReason: 'dropped_after_connect' });
+    expect(Alert.alert).toHaveBeenCalledWith('ble.connectionFailedTitle', 'bluetooth.connectFailed');
+    expect(fakeAdapter.disconnect).toHaveBeenCalled();
+  });
+
+  it('fails the connect when a drop event lands during the initial write (#3875)', async () => {
+    // The write itself RESOLVES — the adapter's own disconnect event fires while
+    // it is in flight. sendFramesToBoard therefore returns true, so the return
+    // value cannot see this at all; only the adapter identity can. If this test
+    // is the only failing one, someone replaced the identity check with a check
+    // on sendFramesToBoard's boolean.
+    let dropLink: (() => void) | undefined;
+    const fakeAdapter = {
+      ...makeFakeAdapter(),
+      onDisconnect: vi.fn((handler: (info?: { source: string }) => void) => {
+        dropLink = () => handler({ source: 'adapter-event' });
+        return () => {};
+      }),
+      write: vi.fn(async () => {
+        dropLink?.();
+      }),
+    };
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockAuroraSendable();
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    let connected: boolean | undefined;
+    await act(async () => {
+      connected = await result.current.connect('p100r12');
+    });
+
+    expect(connected).toBe(false);
+    expect(result.current.isConnected).toBe(false);
+    expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Success')).toBeUndefined();
+  });
+
+  it('still connects when the initial climb is incompatible with the board (#3875)', async () => {
+    // Every placement skipped → sendFramesToBoard returns false, but the GATT
+    // link is untouched. Failing the connect here (the fix the issue asked for)
+    // would strand a live adapter behind a dark lightbulb and raise a bogus
+    // "couldn't connect" on a board that is connected.
+    const fakeAdapter = makeFakeAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockGetLedPlacements.mockReturnValue({ 100: 7 });
+    mockGetAuroraBluetoothPacket.mockReturnValue({
+      packet: new Uint8Array([]),
+      skippedPositionCount: 3,
+      skippedRoleCount: 1,
+      totalPlacements: 4,
+    });
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    let connected: boolean | undefined;
+    await act(async () => {
+      connected = await result.current.connect('p100r12');
+    });
+
+    expect(connected).toBe(true);
+    expect(result.current.isConnected).toBe(true);
+    expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Success')).toBeDefined();
+  });
+
+  it('still connects when the initial write fails on a live link (#3875)', async () => {
+    // The far more common flavour: an ordinary write rejection (write_failed /
+    // write_timeout / characteristic_unavailable) that isDisconnectionError does
+    // not match. The link is alive, so the connect stands.
+    const fakeAdapter = makeFakeAdapter({
+      write: vi.fn().mockRejectedValue(new Error('GATT write failed')),
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockAuroraSendable();
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    let connected: boolean | undefined;
+    await act(async () => {
+      connected = await result.current.connect('p100r12');
+    });
+
+    expect(connected).toBe(true);
+    expect(result.current.isConnected).toBe(true);
+    expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Success')).toBeDefined();
+  });
+
+  it('attributes the initial write to sendSource "connect" (#3875)', async () => {
+    // Makes the connect-time send separable in PostHog. Before this, telling a
+    // connect-time failure from a mid-session one meant joining on a
+    // sub-10ms gap against Bluetooth Connection Success.
+    const fakeAdapter = makeFakeAdapter({
+      write: vi.fn().mockRejectedValue(new Error('GATT write failed')),
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockAuroraSendable();
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      await result.current.connect('p100r12');
+    });
+
+    const sendFailure = mockTrack.mock.calls.find(([name]) => name === 'Climb Sent to Board Failure');
+    expect(sendFailure?.[1]).toMatchObject({ sendSource: 'connect' });
+  });
+});
+
 describe('convertToMirroredFramesString', () => {
   it('correctly maps hold IDs to mirrored IDs', () => {
     const holdsData: HoldPlacement[] = [makePlacement(100, 200), makePlacement(101, 201)];

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -1007,6 +1007,17 @@ export function useBoardBluetooth({
         // with skipReason 'no_adapter', and onConnectSuccess claiming a board hold
         // in board presence that we cannot write to (#3875).
         //
+        // A third, non-drop route reaches this bail: the config-switch effect
+        // below. Its deps (boardName/layoutId/sizeId) are route-derived provider
+        // state, so navigating to a different board while the awaited write is in
+        // flight re-runs it, and — since connectedConfigKeyRef is now assigned when
+        // the link opens rather than after this send — it tears the now-stale
+        // connection down. Bailing is right (the adapter really is gone), but the
+        // alert then reads "move closer" for what was a deliberate switch. Accepted:
+        // the copy is mildly wrong on a path where the user has already navigated
+        // away, and the alternative is streaming the new config's LED map to the old
+        // wall. Revisit with a distinct reason if it shows up in support.
+        //
         // The signal is adapter IDENTITY, not initialSendResult. Do not "simplify"
         // this to `if (initialSendResult === false)`:
         //   - false does NOT mean the link died. It is also returned for

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -253,8 +253,10 @@ export const convertToMirroredFramesString = (frames: string, holdsData: HoldPla
  */
 export type BleSendContext = {
   /** Where the send came from: the queue auto-sender, an undo, a deliberate
-   *  clear (passed by clearBoard), or a wall-kiosk relight. */
-  sendSource: 'auto' | 'undo' | 'clear' | 'wall-relight';
+   *  clear (passed by clearBoard), a wall-kiosk relight, or connect()'s own
+   *  initial frame write (`connect` — the one send that can take the link with
+   *  it, so it needs to be separable in analytics). */
+  sendSource: 'auto' | 'undo' | 'clear' | 'wall-relight' | 'connect';
   targetQueueItemUuid?: string;
   climbUuid?: string;
   /** The climb's own board metadata, when known — lets a board/climb mismatch be seen. */
@@ -982,15 +984,58 @@ export function useBoardBluetooth({
           }
         }
 
-        // Send initial frames if provided; seed the AutoSender's dedup with
-        // what was written so it doesn't immediately repeat the identical
-        // frame (and its success haptic) when it mounts on isConnected.
+        // Send initial frames if provided. `sendSource: 'connect'` makes the
+        // resulting Climb Sent to Board Success/Failure/Skipped attributable to
+        // this connect-time write instead of having to be inferred from a
+        // millisecond gap against Bluetooth Connection Success.
         if (initialFrames) {
-          await sendFramesToBoard(initialFrames, mirrored);
-          connectInitialSendRef.current = { frames: initialFrames, mirrored: !!mirrored, colorSignature };
-        } else {
-          connectInitialSendRef.current = null;
+          await sendFramesToBoard(initialFrames, mirrored, undefined, { sendSource: 'connect' });
         }
+
+        // The initial write can kill the link it just rode in on: out of range
+        // during the handshake, the box powered off, or a second phone stealing a
+        // last-connection-wins board. Both teardown routes (sendFramesToBoard's
+        // isDisconnectionError branch, and the adapter's own onDisconnect
+        // subscription registered above) run clearConnectionAfterDrop, which nulls
+        // adapterRef. Without this check connect() went on to setIsConnected(true)
+        // over a null adapter: a lit lightbulb, every later send early-returning
+        // with skipReason 'no_adapter', and onConnectSuccess claiming a board hold
+        // in board presence that we cannot write to (#3875).
+        //
+        // The signal is adapter IDENTITY, not sendFramesToBoard's return value. Do
+        // not "simplify" this to `if (sendFramesToBoard(...) === false)`:
+        //   - false does NOT mean the link died. It is also returned for
+        //     incompatible_climb, missing_mirror_data, missing_led_placements and
+        //     every ordinary write rejection (write_failed, write_timeout,
+        //     characteristic_unavailable). Failing the connect on those would
+        //     strand a live adapter behind a dark bulb — the mirror-image bug.
+        //   - false is NOT returned when the adapter's onDisconnect fires during
+        //     the write: write() resolves, the send reports success, and the
+        //     teardown has already happened. The boolean misses that case entirely.
+        if (adapterRef.current !== adapter) {
+          // clearConnectionAfterDrop already flipped isConnected to false, aborted
+          // this write generation, disposed the adapter and cleared the Sentry BLE
+          // tags — including onConnectionChange?.(false) without a preceding true,
+          // which no consumer reads today but a future one must tolerate.
+          connectInitialSendRef.current = null;
+          Alert.alert(t('ble.connectionFailedTitle'), tCommon('bluetooth.connectFailed'));
+          track(SHARED_EVENTS.BluetoothConnectionFailed, {
+            boardName,
+            layoutId,
+            sizeId,
+            // Sits alongside the classifyBleFailure categories used by the catch
+            // block below; this one is only reachable from the initial write.
+            failureReason: 'dropped_after_connect',
+          });
+          return false;
+        }
+
+        // Seed the AutoSender's dedup with what was written so it doesn't
+        // immediately repeat the identical frame (and its success haptic) when it
+        // mounts on isConnected.
+        connectInitialSendRef.current = initialFrames
+          ? { frames: initialFrames, mirrored: !!mirrored, colorSignature }
+          : null;
 
         lastDisconnectInfoRef.current = null;
         setIsConnected(true);

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -988,8 +988,9 @@ export function useBoardBluetooth({
         // resulting Climb Sent to Board Success/Failure/Skipped attributable to
         // this connect-time write instead of having to be inferred from a
         // millisecond gap against Bluetooth Connection Success.
+        let initialSendResult: boolean | undefined;
         if (initialFrames) {
-          await sendFramesToBoard(initialFrames, mirrored, undefined, { sendSource: 'connect' });
+          initialSendResult = await sendFramesToBoard(initialFrames, mirrored, undefined, { sendSource: 'connect' });
         }
 
         // The initial write can kill the link it just rode in on: out of range
@@ -1002,8 +1003,8 @@ export function useBoardBluetooth({
         // with skipReason 'no_adapter', and onConnectSuccess claiming a board hold
         // in board presence that we cannot write to (#3875).
         //
-        // The signal is adapter IDENTITY, not sendFramesToBoard's return value. Do
-        // not "simplify" this to `if (sendFramesToBoard(...) === false)`:
+        // The signal is adapter IDENTITY, not initialSendResult. Do not "simplify"
+        // this to `if (initialSendResult === false)`:
         //   - false does NOT mean the link died. It is also returned for
         //     incompatible_climb, missing_mirror_data, missing_led_placements and
         //     every ordinary write rejection (write_failed, write_timeout,
@@ -1032,10 +1033,18 @@ export function useBoardBluetooth({
 
         // Seed the AutoSender's dedup with what was written so it doesn't
         // immediately repeat the identical frame (and its success haptic) when it
-        // mounts on isConnected.
-        connectInitialSendRef.current = initialFrames
-          ? { frames: initialFrames, mirrored: !!mirrored, colorSignature }
-          : null;
+        // mounts on isConnected — but ONLY when the write actually landed. Seeding
+        // after a failed write told the AutoSender the wall already showed this
+        // climb, so it (a) skipped the write and left a connected board dark until
+        // the climber navigated away and back, and (b) hit the byte-identical
+        // branch that fires onWallConfirmed, reporting a lit climb to the party /
+        // presence feed over a dark wall. Assigned on every exit path (including
+        // the bail above), so a later native-connection adoption — which never
+        // assigns this ref — can't inherit a stale seed either.
+        connectInitialSendRef.current =
+          initialFrames && initialSendResult === true
+            ? { frames: initialFrames, mirrored: !!mirrored, colorSignature }
+            : null;
 
         lastDisconnectInfoRef.current = null;
         setIsConnected(true);

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -282,6 +282,10 @@ type UseBoardBluetoothOptions = {
   holdsData?: HoldPlacement[];
   ledColorOverrides?: LedColorOverrides;
   analyticsBoardId?: number | null;
+  /** Fired on every connection-state edge. A consumer must tolerate a `false`
+   *  with no preceding `true`: when connect()'s initial write kills the link,
+   *  the drop teardown fires `false` and connect() then bails before it would
+   *  ever have fired `true` (#3875). */
   onConnectionChange?: (connected: boolean) => void;
   onConnectSuccess?: (serial: string | null) => void;
   /** Reads whether this connection was made via the mismatch "Connect anyway"

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -914,6 +914,14 @@ export function useBoardBluetooth({
 
         unsubDisconnectRef.current = adapter.onDisconnect(handleDisconnection);
         adapterRef.current = adapter;
+        // Assigned here, beside adapterRef, rather than after the initial send:
+        // the physical link exists from this line on, and the config-switch effect
+        // early-returns while this ref is null. Leaving it null across the awaited
+        // initial write meant a board/layout/size change landing in that window
+        // couldn't tear the (now-wrong) connection down. Both drop paths
+        // (clearConnectionAfterDrop, teardownConnection) already clear it.
+        connectedConfigKeyRef.current =
+          layoutId !== undefined && sizeId !== undefined ? boardConfigKey(boardName, layoutId, sizeId) : null;
 
         // Push board configuration into the native BoardBleManager so the
         // Dynamic Island widget intent path (next/prev tapped while the app
@@ -984,8 +992,6 @@ export function useBoardBluetooth({
           connectInitialSendRef.current = null;
         }
 
-        connectedConfigKeyRef.current =
-          layoutId !== undefined && sizeId !== undefined ? boardConfigKey(boardName, layoutId, sizeId) : null;
         lastDisconnectInfoRef.current = null;
         setIsConnected(true);
         onConnectionChange?.(true);

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -1045,6 +1045,13 @@ export function useBoardBluetooth({
         // presence feed over a dark wall. Assigned on every exit path (including
         // the bail above), so a later native-connection adoption — which never
         // assigns this ref — can't inherit a stale seed either.
+        //
+        // Accepted cost: an incompatible initialFrames no longer suppresses the
+        // AutoSender's own attempt, so the climber can see ble.errorIncompatible
+        // twice. That is deliberate — suppressing the second alert also suppresses
+        // the truthful "nothing is on the wall" state and puts a phantom
+        // onWallConfirmed on the party feed. One extra alert beats telling the
+        // crew a climb is lit when the wall is dark.
         connectInitialSendRef.current =
           initialFrames && initialSendResult === true
             ? { frames: initialFrames, mirrored: !!mirrored, colorSignature }


### PR DESCRIPTION
## Summary

Closes #3875.

**Premise correction, up front.** The issue's symptom is real and reproduces exactly. Its _suggested fix_ is wrong in both directions, and the six lines it points at contain a second, more frequent defect the issue doesn't describe.

### 1. "Check `sendFramesToBoard`'s return value; on `false` fail the connect" would make things worse

- **False negative.** `false` does not mean the link died. It is also returned for `incompatible_climb` (an Aurora climb whose every placement is skipped, or a MoonBoard with zero holds), `missing_mirror_data`, `missing_led_placements`, and _every_ ordinary write rejection — `write_failed`, `write_timeout`, `characteristic_unavailable`. On all of those the GATT link is alive and `adapterRef.current` is intact. Failing the connect there leaves a live adapter behind a dark lightbulb and raises a "couldn't connect" alert on a board that is connected — the mirror image of the reported bug. `write_failed` and `write_timeout` alone hit 58 and 38 mobile users in 60 days.
- **False positive.** The boolean does not catch the drop at all when the adapter's own `onDisconnect` fires _during_ the initial write. `write()` resolves, `sendFramesToBoard` returns `true`, `handleDisconnection` has already nulled `adapterRef` — and `connect()` declares success.

The sound signal is **adapter identity** (`adapterRef.current !== adapter`), not the boolean. Six of the new tests exist to keep a future refactor from making that swap: three go red if the identity check is removed, five go red if it is replaced with `initialSendResult === false`. Both mutations were run, not assumed — see the mutation table below for the per-test breakdown.

### 2. Second defect, same six lines, and the one with production occurrences

`connectInitialSendRef.current` was seeded with `initialFrames` unconditionally — _including when the write failed_. The AutoSender (`bluetooth-provider.tsx:383-397`) consumes that seed and sets both `lastSentSignatureRef` and `lastPhysicalFramesRef`, so it then:

- never writes the current climb — connected board, dark wall, only fixable by navigating away and back; and
- takes the byte-identical branch at `:413-423`, which fires `onWallConfirmed` — so the party / presence feed reports a climb as lit on a wall that is dark.

Gating the seed on the send actually returning `true` fixes both. This is what the boolean _is_ good for; connect success is not.

### 3. Frequency — why this stays P3

Built an oracle from a mobile `Climb Sent to Board Failure` immediately followed by a `Bluetooth Connection Success` for the same person (only `connect()`'s initial send can produce that ordering). Over 180 days, mobile only:

- the **titled dead-link symptom: 0 occurrences**;
- the **seed defect: 2 occurrences, 2 users** — `write_failed`/MoonBoard/2.0.0 at a 0 ms gap and `incompatible_climb`/Kilter/2.2.2 at 2 ms.

(The 47 pairs in a 5-second window are ordinary mid-session failures followed by a genuine user reconnect — scan + GATT takes >2s, so they are not this path.) The issue's own `Climb Sent to Board Skipped` telemetry, added 2026-07-24, has fired zero times project-wide, so it is not yet a usable oracle. P3 is correct; this is a robustness fix, not an incident response.

## What changed

Three functional commits, each reviewable and revertable on its own (plus three comment/test-only follow-ups from review and paired QA):

1. **`connectedConfigKeyRef` moves up** to sit beside `adapterRef.current = adapter`. The physical link exists from that line, but the ref was only assigned after the initial send, and the config-switch effect early-returns while it is null — so a board/layout/size change landing during the awaited write could not tear the now-wrong connection down. This makes the adapter-identity check below authoritative for that case too. Drop this commit and the fix still handles everything else.

   **This commit opens a new path into the bail, and it is reachable.** An earlier draft of this body called it "practically unreachable — the effect's deps can't change inside that window"; that was wrong, and paired QA was right to push back. The effect's deps are `boardName`/`layoutId`/`sizeId`, which are route-derived provider state, so tapping through to a different board while the initial write is in flight _does_ re-run it. The window is short (it opens once the GATT handshake resolves and closes one LED write later) but it is ordinary navigation, not a race you have to engineer. When it happens the teardown is correct — the alternative is streaming the new config's LED map to the old wall — but the climber sees "Couldn't connect. Move closer to the board and try again" and we log `dropped_after_connect` for what was a deliberate switch. Accepted under ruling 2, and now documented in the code beside the bail so the next reader doesn't have to re-derive it. Listed as a device-QA gate below.

2. **The identity bail.** On `adapterRef.current !== adapter`: clear the seed, alert, track `Bluetooth Connection Failed` with `failureReason: 'dropped_after_connect'`, return `false`. No `setIsConnected(false)` needed — `clearConnectionAfterDrop` already did it, disposed the adapter, aborted the write generation and cleared the Sentry BLE tags. Also tags the initial send `sendSource: 'connect'` so a connect-time send failure is separable in PostHog instead of needing a sub-10ms gap join.
3. **The seed gate.**

## Decisions a reviewer will ask about

- **No new i18n keys.** The bail reuses `tCommon('bluetooth.connectFailed')` — "Couldn't connect. Move closer to the board and try again." A link that dies inside its first write is almost always range/RF, so the advice fits, and it means no es/fr additions and no glossary review.
- **`connect()`'s return value now changes.** It returns `false` where it used to return `true`. Every caller was re-checked in the code, not from the plan: `use-lightbulb-control.ts:96`, `WallScrubber.tsx:168`, `WallEmptyState.tsx:28`, `use-create-climb-screen.ts:452`, `live-activity-bridge.tsx:165`, `bluetooth-provider.tsx:959`. All six `void` the promise and never inspect it — no caller regression, no double alert.
- **`onConnectionChange?.(false)` can now fire without a preceding `true`** (from `clearConnectionAfterDrop` on the bail path). The option has no consumers anywhere in `packages/mobile` today; the comment says a future one must tolerate it.
- **An incompatible initial climb can now raise `ble.errorIncompatible` twice** — it no longer seeds the dedup, so the AutoSender attempts the write once more. Deliberate: suppressing the second alert also suppresses the truthful "nothing is on the wall" state and produces the phantom `onWallConfirmed` above. One extra alert beats telling the crew a climb is lit when the wall is dark. One of the two real production occurrences is exactly this shape.
- **`failureReason: 'dropped_after_connect'` is a new free-form value** alongside the `classifyBleFailure` categories. Any saved PostHog insight enumerating that property needs it added. `packages/shared/analytics/src/events.ts` is deliberately untouched — it is doc-only there and sits inside PR #3980's hunk region.
- **JS-only ⇒ OTA-safe.** No native surface, no fingerprint change, no new binary.

## Collision note

PR #3980 also touches `use-board-bluetooth.ts` (a permission-denial analytics hunk at ~:863) and `use-board-bluetooth.test.ts` (an insertion at ~:194). This PR's hunks are at ~:987-1050 and a new `describe` at the end of the test file, so they should not overlap. Whoever lands second rebases.

## Test plan

Nine tests in a new `useBoardBluetooth connect() initial frame write (#3875)` describe. All assertions are on hook-observable output only — `connect()`'s return, `isConnected`, `mockTrack` call names/props, the exposed `connectInitialSendRef`, an `onConnectSuccess` spy. None re-derives `isDisconnectionError` or the identity comparison in the test body.

1. dead link on the first write → `connect()` false, not connected, no success event, `dropped_after_connect` failure, adapter disposed
2. drop event _during_ the write (write resolves) → `connect()` false, alert raised, `dropped_after_connect` tracked, adapter disposed — the arm the boolean cannot reach
3. incompatible climb → still connects (guards against the issue's over-fix)
4. transient write failure on a live link → still connects (same guard, common flavour)
5. `sendSource: 'connect'` on the send analytics
6. failed initial write → dedup unseeded, still connected
7. successful initial write → dedup seeded
8. connect with no frames clears a stale seed
9. board config switches _during_ the initial write → `connect()` false, no seed left behind for the new board

**Mutation checks actually run, with results.** Re-derived against the final HEAD after paired QA caught the first pass being both stale and wrong — the numbers below were produced by applying each mutation to the real file, running `use-board-bluetooth.test.ts`, and reverting. Baseline is 87 passed.

| mutation                                                                    | red tests         | observed            |
| --------------------------------------------------------------------------- | ----------------- | ------------------- |
| identity bail removed                                                       | 1, 2, 9           | 3 failed, 84 passed |
| identity bail → `initialSendResult === false` (the issue's literal fix)     | 2, 3, 4, 6, 9     | 5 failed, 82 passed |
| seed gate → seed whenever a send was attempted                              | 6                 | 1 failed, 86 passed |
| seed always cleared                                                         | 7, 8              | 2 failed, 85 passed |
| `connectedConfigKeyRef` assigned after the send (the pre-commit-1 shape)     | 9                 | 1 failed, 86 passed |

Restored and green after each (87 passed).

The last row is the one that matters for commit 1: moving that assignment back to where it used to live fails test 9 **and nothing else** — every pre-existing config-switch teardown test still passes — so test 9 isolates exactly what commit 1 changed rather than just re-testing the effect.

The earlier version of this table claimed 3 failures for the second mutation. It is 4: test 6 also goes red, because that mutation bails the connect on the ordinary live-link write failure test 6 sets up, so its `isConnected` assertion fails. The correction strengthens the row rather than weakening it — test 6 turns out to be a second, independent guard against the issue's suggested fix. The old totals (81/80/85/84) were also taken before the two review commits changed the test count, so none of them summed to the real suite size.

Validation (all foreground, all green): `vp run typecheck:mobile`, `vp run test:mobile` (557 files / 4689 tests), `vp check` (0 errors), `vp run check:mobile-bundle`.

Two review follow-up commits after the first green run: the `onConnectionChange(false)` contract moved onto the option type, a breadcrumb naming `isDisconnectionError` as what decides which side of the boundary each fixture lands on, the alert + failure-event assertions added to test 2, and the double-alert trade-off moved out of this body and into the code beside the seed gate that causes it. The review bot's claim that `failureReason` is a typed union in `packages/shared/analytics/src/events.ts` is wrong — event props are `Record<string, AnalyticsPropertyValue | undefined>`; rebutted in a PR comment with the file/line evidence.

Two more follow-up commits after paired QA and the latest review pass. The first is comment-only: the config-switch route into the bail is now named in the code (it was missing from the list of causes), and the two body inaccuracies QA found — the understated mutation table and the "practically unreachable" framing — are corrected above. Both were reporting defects rather than code defects; no behaviour changed.

The second is test-only, closing the one coverage gap paired QA and the review bot independently flagged: commit 1 was the only functional commit without a test of its own (test 9), and the drop-during-write arm now asserts adapter disposal too, since `clearConnectionAfterDrop` disconnects on both of its callers and only the write-failure arm was checking it.

## Device QA / maintainer gates

This machine is Linux — no macOS, no iOS simulator, no BLE hardware — so the physical triggers can't be produced here. None of these block CI, but they are the honest gaps:

- [ ] **Dead-link-on-first-write on real hardware.** Needs a board plus walking out of range during the connect handshake, powering the box off mid-connect, or a second phone stealing a last-connection-wins board in the ~200ms window around the first write. Verify: the bulb stays dark, the `bluetooth.connectFailed` copy reads sensibly for this cause, and a second lightbulb tap recovers cleanly.
- [ ] **Success-path regression on all three board families** (Kilter, Tension, MoonBoard): connect-and-light from the play drawer and from the create-climb BLE toggle must still light on the first tap with exactly **one** success haptic. That is the dedup seed doing its job — test 7 guards it in CI, but the haptic is only observable on device.
- [ ] **iOS pass if a device is available.** The adapter `onDisconnect` timing (test 2) is CoreBluetooth-supervision-timeout dependent and can't be reproduced on Android or in vitest.
- [ ] **Maintainer call on the double `ble.errorIncompatible` alert** (see Decisions above) — the one behaviour change a climber could notice.
- [ ] **Board switch during the initial write** (see commit 1 above): tap the lightbulb on one board, then navigate to a different board/layout/size before the first write settles. Expect the old link to be torn down (correct) plus a "move closer" alert that doesn't match the cause. Confirm it's rare enough in real use to leave as-is; if not, the fix is a distinct bail reason rather than a change to the teardown.

JS-only, so a `pr-<number>` OTA preview channel is enough for the on-device pass; no new binary needed.

## Release Notes

- Your board no longer shows as connected when the connection actually died on the first send — you get told to move closer and try again instead of tapping into a dark wall.
- If the first send after connecting doesn't land, the next climb you pick actually gets written to the wall, and your crew no longer sees it as lit when it isn't.
