### PR TITLE
fix(mobile): clear climb name on filter-sheet Reset, surface it as a row

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -333,6 +333,9 @@ function ClimbListInner() {
   // actual TextInput/native field, leaving it visually stale.
   const handleSheetNameChange = useCallback(
     (text: string) => {
+      // ORDER MATTERS — see the comment above: mirror the raw text first, THEN
+      // let handleSearchChange's normalized write win by running second.
+      // Swapping these two lines silently regresses the top-bar mirror.
       applyVisibleSearchText(text);
       handleSearchChange(text);
     },

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -323,6 +323,32 @@ function ClimbListInner() {
     nativeSearchRef.current?.clearText();
   }, [setName]);
 
+  // Composed for the filter sheet's in-line name field (#3606): mirror the raw
+  // keystroke into the top bar/native search bar FIRST via applyVisibleSearchText
+  // (silent — doesn't re-enter this same handler), THEN run handleSearchChange's
+  // normal normalize+debounce+commit path, whose ref/state writes run second and
+  // so win. Without the mirror call first, the top bar's own resync effect (see
+  // the visibleSearchTextNeedsSync effect above) would see visibleSearchTextRef
+  // already in lockstep with the sheet's typing and skip re-seeding the top bar's
+  // actual TextInput/native field, leaving it visually stale.
+  const handleSheetNameChange = useCallback(
+    (text: string) => {
+      applyVisibleSearchText(text);
+      handleSearchChange(text);
+    },
+    [applyVisibleSearchText, handleSearchChange],
+  );
+
+  // The ONE clearing path for name, shared by the filter sheet's Reset button and
+  // its inline × (#3606) — mirrors handleNativeSearchCancel's clearing sequence
+  // but deliberately does NOT touch setShowFilters: Reset must not close the sheet.
+  const handleClearName = useCallback(() => {
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    visibleSearchTextRef.current = '';
+    setName('');
+    applyVisibleSearchText('');
+  }, [applyVisibleSearchText, setName]);
+
   const handleSearchFocus = useCallback(() => {
     setShowGrade(false);
     setIsSearchFocused(true);
@@ -1565,6 +1591,8 @@ function ClimbListInner() {
           searchName={name}
           lastUsedGradeId={lastUsedGrade}
           onApply={handleApplyFilters}
+          onNameChange={handleSheetNameChange}
+          onClearName={handleClearName}
         />
       ) : null}
     </View>

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -343,7 +343,10 @@ function ClimbListInner() {
   // its inline × (#3606) — mirrors handleNativeSearchCancel's clearing sequence
   // but deliberately does NOT touch setShowFilters: Reset must not close the sheet.
   const handleClearName = useCallback(() => {
-    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
     visibleSearchTextRef.current = '';
     setName('');
     applyVisibleSearchText('');

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -3,6 +3,7 @@ import {
   View,
   Pressable,
   StyleSheet,
+  TextInput,
   type ViewStyle,
   type NativeScrollEvent,
   type NativeSyntheticEvent,
@@ -56,6 +57,7 @@ import { parseSetIdsParam, prewarmCreateBoardHolds } from '../lib/create-board-h
 import { subscribeToHoldsFilterSelection } from '../lib/hold-filter-handoff';
 import { subscribeToZoneFilterSelection, type ZoneFilterSelection } from '../lib/zone-filter-handoff';
 import { subscribeToSetterFilterSelection } from '../lib/setter-filter-handoff';
+import { visibleSearchTextNeedsSync } from '../lib/search-name';
 import { useAuth } from '../providers/auth-provider';
 import { hapticSelection } from '../lib/haptics';
 import { springs } from '../theme/animations';
@@ -77,11 +79,19 @@ type ClimbFilterSheetProps = {
   boardConfig: BoardSearchConfig | null;
   currentFilters: ClimbFilters;
   currentBoardFilters: ClimbBoardFilterState;
-  /** Current committed name term, so the live "Show N" count matches Apply. */
+  /** Current committed name term, so the live "Show N" count matches Apply and
+   *  the in-sheet name field seeds correctly. */
   searchName?: string;
   /** Last-used grade id; centres the grade rail on a familiar grade when unset. */
   lastUsedGradeId?: number;
   onApply: (filters: ClimbFilters, boardFilters: ClimbBoardFilterState) => void;
+  /** Fired per keystroke as the in-sheet name field changes (mirrors into the
+   *  parent's live search — name is committed outside the Apply-gated draft
+   *  model, same as the top-bar search field). */
+  onNameChange?: (text: string) => void;
+  /** Fired by Reset and the field's inline × — the ONE clearing path for name,
+   *  shared so there is exactly one code path to reason about (#3606). */
+  onClearName?: () => void;
 };
 
 // The status enum is still driven from the sheet — "My drafts" (Your progress
@@ -155,8 +165,11 @@ export function ClimbFilterSheet({
   searchName,
   lastUsedGradeId,
   onApply,
+  onNameChange,
+  onClearName,
 }: ClimbFilterSheetProps) {
   const { t } = useTranslation('climbs');
+  const { t: tCommon } = useTranslation('common');
   const theme = useTheme();
   const { systemColors } = theme;
   const { isAuthenticated } = useAuth();
@@ -179,6 +192,25 @@ export function ClimbFilterSheet({
     statusForAuth(normalizeRetiredStatus(currentFilters), isAuthenticated),
   );
   const [localBoardFilters, setLocalBoardFilters] = useState<ClimbBoardFilterState>(currentBoardFilters);
+  // The name field's own draft — seeded from the committed `searchName` prop.
+  // Name lives outside the Apply-gated draft model (it's committed live via the
+  // parent's debounce, same as the top-bar search field), so this is a plain
+  // display draft, not part of localFilters/DEFAULT_FILTERS.
+  const [nameDraft, setNameDraft] = useState(searchName ?? '');
+  // Ref snapshot of the draft, read (not the reactive `nameDraft`) inside the
+  // resync effect below so the effect's own deps stay just [searchName] — same
+  // shape as the parent's top-bar sync effect, which reads visibleSearchTextRef.
+  const nameDraftRef = useRef(nameDraft);
+  nameDraftRef.current = nameDraft;
+
+  // Resync the field from an external `searchName` change (board switch, recent
+  // pill, cancel) — but ignore a trim-only difference, exactly like the parent's
+  // own top-bar sync effect (packages/mobile/app/(tabs)/climbs/index.tsx), so a
+  // mid-typing space isn't yanked out from under the cursor.
+  useEffect(() => {
+    if (!visibleSearchTextNeedsSync(nameDraftRef.current, searchName ?? '')) return;
+    setNameDraft(searchName ?? '');
+  }, [searchName]);
   // The sub-pickers (setters / holds / zone) are pushed routes, not stacked
   // sheets (native sheets can't stack above this one). While a sub-route is open
   // we suspend — dismiss the native sheet without unmounting, so the draft below
@@ -237,19 +269,28 @@ export function ClimbFilterSheet({
     : { hasShorter: false, hasNarrower: false };
 
   // Live "Show N" preview for the in-progress edits (matches what Apply yields).
-  // Debounced so rapid chip/toggle taps don't each fire a count request.
-  const [debouncedEdits, setDebouncedEdits] = useState({ filters: localFilters, boardFilters: localBoardFilters });
+  // Debounced so rapid chip/toggle taps — and now keystrokes in the name field —
+  // don't each fire a count request. `name` rides along so an in-sheet name edit
+  // is reflected in the preview the same way a chip/toggle edit is.
+  const [debouncedEdits, setDebouncedEdits] = useState({
+    filters: localFilters,
+    boardFilters: localBoardFilters,
+    name: nameDraft,
+  });
   useEffect(() => {
-    const handle = setTimeout(() => setDebouncedEdits({ filters: localFilters, boardFilters: localBoardFilters }), 250);
+    const handle = setTimeout(
+      () => setDebouncedEdits({ filters: localFilters, boardFilters: localBoardFilters, name: nameDraft }),
+      250,
+    );
     return () => clearTimeout(handle);
-  }, [localFilters, localBoardFilters]);
+  }, [localFilters, localBoardFilters, nameDraft]);
   const previewInput = useMemo(() => {
     if (!boardConfig) return null;
     return mergeBoardFilters(
-      toClimbSearchInput(debouncedEdits.filters, boardConfig, { page: 0, pageSize: 1 }, { name: searchName }),
+      toClimbSearchInput(debouncedEdits.filters, boardConfig, { page: 0, pageSize: 1 }, { name: debouncedEdits.name }),
       debouncedEdits.boardFilters,
     );
-  }, [boardConfig, debouncedEdits, searchName]);
+  }, [boardConfig, debouncedEdits]);
   const { data: previewCount } = useSearchClimbsCount(
     previewInput ?? { boardName: '', layoutId: 0, sizeId: 0, setIds: '', angle: 0 },
     !!previewInput,
@@ -337,6 +378,25 @@ export function ClimbFilterSheet({
     },
     [updateLocalFilters],
   );
+
+  // Per-keystroke: update the field's own display state immediately, and mirror
+  // the raw text out to the parent (which commits it live via its own debounce —
+  // name is not part of the Apply-gated draft, see the `nameDraft` comment above).
+  const handleNameTextChange = useCallback(
+    (text: string) => {
+      setNameDraft(text);
+      onNameChange?.(text);
+    },
+    [onNameChange],
+  );
+
+  // The ONE clearing path for name, shared by the inline × and Reset (#3606) —
+  // clears the field's own display state and asks the parent to clear the
+  // committed name + the top-bar/native-search-bar mirror.
+  const handleClearNameField = useCallback(() => {
+    setNameDraft('');
+    onClearName?.();
+  }, [onClearName]);
 
   const handleSortByChange = useCallback(
     (sortBy: SortOption) =>
@@ -461,8 +521,14 @@ export function ClimbFilterSheet({
     hapticSelection();
     updateLocalFilters(DEFAULT_FILTERS);
     updateLocalBoardFilters(DEFAULT_CLIMB_BOARD_FILTER_STATE);
+    // Clear the name field too (#3606) — via the same single clearing path the
+    // inline × uses, so Reset and × can never drift apart. setNameDraft gives
+    // instant visual feedback; onClearName clears the parent's committed name
+    // (and its top-bar/native-search-bar mirror) in the same tick.
+    setNameDraft('');
+    onClearName?.();
     hasLocalDraftEditsRef.current = false;
-  }, [updateLocalBoardFilters, updateLocalFilters]);
+  }, [updateLocalBoardFilters, updateLocalFilters, onClearName]);
 
   // The Holds row is always visible now (no Refine accordion to expand), so
   // prewarm the create-board hold geometry as soon as the sheet is visible with
@@ -668,12 +734,49 @@ export function ClimbFilterSheet({
           onScroll={handleScroll}
           scrollEventThrottle={32}
           onContentSizeChange={handleScrollContentSizeChange}
+          // This sheet never hosted a text input before the name field below —
+          // without this, a first tap on Apply/Reset/another row while the
+          // keyboard is up over the field can be swallowed (standard RN
+          // ScrollView gotcha; the tap dismisses the keyboard instead of firing).
+          keyboardShouldPersistTaps="handled"
         >
           {/* Flat, labeled sections — no accordions. The scroll body is one column
               child (styles.body) so the native sheet scrolls and the footer pins. */}
           <View style={styles.body}>
-            {/* 1 · DIFFICULTY — grade bound + grade accuracy. */}
+            {/* 1 · NAME — climb-name search term, first row so Reset has something
+                visible to reset (#3606). Committed live via onNameChange/onClearName,
+                same as the top-bar search field — NOT part of localFilters/Apply. */}
             <View style={styles.sectionFirst}>
+              <Text variant="headline" style={styles.sectionHeader}>
+                {t('mobile.filter.section.name')}
+              </Text>
+              <View style={[styles.nameInputRow, { backgroundColor: systemColors.tertiaryBackground }]}>
+                <TextInput
+                  value={nameDraft}
+                  onChangeText={handleNameTextChange}
+                  placeholder={t('search.placeholders.climbs')}
+                  placeholderTextColor={systemColors.tertiaryLabel}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  returnKeyType="search"
+                  accessibilityLabel={t('mobile.filter.section.name')}
+                  style={[styles.nameInput, { color: systemColors.label }]}
+                />
+                {nameDraft.length > 0 ? (
+                  <Pressable
+                    onPress={handleClearNameField}
+                    hitSlop={8}
+                    accessibilityRole="button"
+                    accessibilityLabel={tCommon('clear')}
+                  >
+                    <Icon name="close" size={14} color={systemColors.tertiaryLabel} />
+                  </Pressable>
+                ) : null}
+              </View>
+            </View>
+
+            {/* 2 · DIFFICULTY — grade bound + grade accuracy. */}
+            <View style={styles.section}>
               <Text variant="headline" style={styles.sectionHeader}>
                 {t('mobile.filter.section.difficulty')}
               </Text>
@@ -714,7 +817,7 @@ export function ClimbFilterSheet({
               />
             </View>
 
-            {/* 2 · YOUR PROGRESS — auth-only; the per-user tick-flag selector plus
+            {/* 3 · YOUR PROGRESS — auth-only; the per-user tick-flag selector plus
                 the "My drafts" toggle (old Status 'drafts', with its side-effects). */}
             {isAuthenticated ? (
               <View style={styles.section}>
@@ -739,7 +842,7 @@ export function ClimbFilterSheet({
               </View>
             ) : null}
 
-            {/* 3 · QUALITY — benchmarks, min rating, popularity (incl. Unrepeated). */}
+            {/* 4 · QUALITY — benchmarks, min rating, popularity (incl. Unrepeated). */}
             <View style={styles.section}>
               <Text variant="headline" style={styles.sectionHeader}>
                 {t('mobile.filter.section.quality')}
@@ -809,7 +912,7 @@ export function ClimbFilterSheet({
               </View>
             </View>
 
-            {/* 4 · THE CLIMB — type, shape, setters, holds, zones, beta. */}
+            {/* 5 · THE CLIMB — type, shape, setters, holds, zones, beta. */}
             <View style={styles.section}>
               <Text variant="headline" style={styles.sectionHeader}>
                 {t('mobile.filter.section.theClimb')}
@@ -948,7 +1051,7 @@ export function ClimbFilterSheet({
               />
             </View>
 
-            {/* 5 · SORT — sort key + direction (or reshuffle for random). */}
+            {/* 6 · SORT — sort key + direction (or reshuffle for random). */}
             <View style={styles.section}>
               <Text variant="headline" style={styles.sectionHeader}>
                 {t('mobile.filter.section.sort')}
@@ -1040,7 +1143,7 @@ const styles = StyleSheet.create({
   body: {
     paddingHorizontal: spacing[4],
   },
-  // Each top-level group. A generous top pad separates the five headers into
+  // Each top-level group. A generous top pad separates the six headers into
   // distinct inset-style groups; the first group sits tighter under the sheet header.
   section: {
     paddingTop: spacing[5],
@@ -1048,10 +1151,26 @@ const styles = StyleSheet.create({
   sectionFirst: {
     paddingTop: spacing[2],
   },
-  // The five group titles — more prominent than the muted footnote sub-labels so
-  // the flat sheet reads as five inset groups without accordions.
+  // The six group titles — more prominent than the muted footnote sub-labels so
+  // the flat sheet reads as six inset groups without accordions.
   sectionHeader: {
     marginBottom: spacing[3],
+  },
+  // The name field's row — same tertiaryBackground pill language as the
+  // tappable rows below (setters/holds/zone), so it reads as part of the family.
+  nameInputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[3],
+    borderRadius: 10,
+    minHeight: 44,
+  },
+  nameInput: {
+    flex: 1,
+    fontSize: 17,
+    paddingVertical: 0,
   },
   subsectionLabel: {
     opacity: 0.55,

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -697,7 +697,13 @@ export function ClimbFilterSheet({
     previewCount != null ? t('mobile.filter.showCount', { count: previewCount }) : t('mobile.filter.apply');
   // Reset stays a quiet secondary accent until there's actually something to
   // reset — so the header isn't a second always-on violet next to Apply.
-  const anyActive = hasActiveClimbFilters(localFilters) || hasActiveBoardFilters(localBoardFilters);
+  // The name counts as something to reset (#3606): it lives outside
+  // ClimbFilters, so neither hasActive* helper can see it, and a lone climb-name
+  // search — the issue's own repro — would otherwise leave Reset disabled with
+  // the one thing the user wants gone still on screen. Same `.length > 0` rule
+  // as the inline × below, so the two clear affordances appear together.
+  const anyActive =
+    hasActiveClimbFilters(localFilters) || hasActiveBoardFilters(localBoardFilters) || nameDraft.length > 0;
 
   return (
     <BottomSheetModal

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -87,11 +87,15 @@ type ClimbFilterSheetProps = {
   onApply: (filters: ClimbFilters, boardFilters: ClimbBoardFilterState) => void;
   /** Fired per keystroke as the in-sheet name field changes (mirrors into the
    *  parent's live search — name is committed outside the Apply-gated draft
-   *  model, same as the top-bar search field). */
-  onNameChange?: (text: string) => void;
+   *  model, same as the top-bar search field). Required: the sheet only owns the
+   *  field's display state, so an unwired caller would render a name field that
+   *  looks like it filters and doesn't. */
+  onNameChange: (text: string) => void;
   /** Fired by Reset and the field's inline × — the ONE clearing path for name,
-   *  shared so there is exactly one code path to reason about (#3606). */
-  onClearName?: () => void;
+   *  shared so there is exactly one code path to reason about (#3606). Required
+   *  for the same reason as `onNameChange`: without it, clearing would blank the
+   *  field while the committed search term quietly survived. */
+  onClearName: () => void;
 };
 
 // The status enum is still driven from the sheet — "My drafts" (Your progress
@@ -385,7 +389,7 @@ export function ClimbFilterSheet({
   const handleNameTextChange = useCallback(
     (text: string) => {
       setNameDraft(text);
-      onNameChange?.(text);
+      onNameChange(text);
     },
     [onNameChange],
   );
@@ -395,7 +399,7 @@ export function ClimbFilterSheet({
   // committed name + the top-bar/native-search-bar mirror.
   const handleClearNameField = useCallback(() => {
     setNameDraft('');
-    onClearName?.();
+    onClearName();
   }, [onClearName]);
 
   const handleSortByChange = useCallback(

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -521,14 +521,13 @@ export function ClimbFilterSheet({
     hapticSelection();
     updateLocalFilters(DEFAULT_FILTERS);
     updateLocalBoardFilters(DEFAULT_CLIMB_BOARD_FILTER_STATE);
-    // Clear the name field too (#3606) — via the same single clearing path the
-    // inline × uses, so Reset and × can never drift apart. setNameDraft gives
-    // instant visual feedback; onClearName clears the parent's committed name
-    // (and its top-bar/native-search-bar mirror) in the same tick.
-    setNameDraft('');
-    onClearName?.();
+    // Clear the name field too (#3606) — CALLS handleClearNameField rather than
+    // repeating its two lines, so Reset and the inline × are two callers of one
+    // function, not two copies that can silently drift apart if the clearing
+    // logic grows.
+    handleClearNameField();
     hasLocalDraftEditsRef.current = false;
-  }, [updateLocalBoardFilters, updateLocalFilters, onClearName]);
+  }, [updateLocalBoardFilters, updateLocalFilters, handleClearNameField]);
 
   // The Holds row is always visible now (no Refine accordion to expand), so
   // prewarm the create-board hold geometry as soon as the sheet is visible with

--- a/packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx
@@ -796,6 +796,31 @@ describe('ClimbFilterSheet name field (#3606)', () => {
     expect(onClearName).toHaveBeenCalledTimes(1);
   });
 
+  // The issue's literal repro: a lone climb-name search with every other control
+  // still at its default. `anyActive` used to be built only from
+  // hasActiveClimbFilters/hasActiveBoardFilters, neither of which can see the
+  // name — so Reset rendered disabled and the fix above it was unreachable.
+  // Note the activity mocks stay at their default `false` here on purpose.
+  it('enables Reset and clears the name when ONLY a climb name is set', () => {
+    const onClearName = vi.fn();
+    const { getByText } = renderFilterSheet({ searchName: 'crimpy', onClearName });
+
+    const resetButton = getByText('mobile.filter.reset').closest('button');
+    expect(resetButton?.disabled).toBe(false);
+
+    fireEvent.click(getByText('mobile.filter.reset'));
+    expect(onClearName).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves Reset disabled when nothing at all is set', () => {
+    const onClearName = vi.fn();
+    const { getByText } = renderFilterSheet({ onClearName });
+
+    expect(getByText('mobile.filter.reset').closest('button')?.disabled).toBe(true);
+    fireEvent.click(getByText('mobile.filter.reset'));
+    expect(onClearName).not.toHaveBeenCalled();
+  });
+
   it('mirrors a typed name to onNameChange and to the field itself', () => {
     const onNameChange = vi.fn();
     const { getByLabelText } = renderFilterSheet({ onNameChange });

--- a/packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx
@@ -374,6 +374,8 @@ function renderFilterSheet(overrides: Partial<Parameters<typeof ClimbFilterSheet
     currentBoardFilters,
     searchName: '',
     onApply: vi.fn(),
+    onNameChange: vi.fn(),
+    onClearName: vi.fn(),
     ...overrides,
   };
 

--- a/packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx
@@ -77,6 +77,14 @@ const createBoardHoldsMocks = vi.hoisted(() => ({
   prewarmCreateBoardHolds: vi.fn(),
 }));
 
+// A spy (not a bare stub) so a test can inspect the `name` it was called with —
+// needed to assert the "Show N" preview reflects an in-sheet name edit (#3606).
+// Typed explicitly: an inferred `() => {}` gives `.mock.calls` the `[][]` tuple
+// type and `lastCall?.[3]` fails to typecheck (TS2493).
+const searchInputMocks = vi.hoisted(() => ({
+  toClimbSearchInput: vi.fn((..._args: unknown[]) => ({})),
+}));
+
 const currentFilters: ClimbFilters = {
   sortBy: 'popular',
   sortOrder: 'desc',
@@ -100,6 +108,13 @@ const boardConfig = {
   angle: 40,
 };
 
+type TextInputProps = {
+  value?: string;
+  onChangeText?: (text: string) => void;
+  placeholder?: string;
+  accessibilityLabel?: string;
+};
+
 vi.mock('react-native', () => ({
   Platform: { OS: 'android' },
   useWindowDimensions: () => ({ width: 390, height: 844 }),
@@ -118,6 +133,16 @@ vi.mock('react-native', () => ({
       renderedChildren,
     );
   },
+  // The name field's input (#3606) — a plain controlled `<input>` standing in
+  // for RN's TextInput; `onChangeText` (not DOM's `onChange`-with-event) is the
+  // callback shape ClimbFilterSheet actually calls.
+  TextInput: ({ value, onChangeText, placeholder, accessibilityLabel }: TextInputProps) =>
+    createElement('input', {
+      value,
+      onChange: (event: { target: { value: string } }) => onChangeText?.(event.target.value),
+      placeholder,
+      'aria-label': accessibilityLabel,
+    }),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
 }));
 
@@ -213,7 +238,7 @@ vi.mock('@boardsesh/climb-filters', () => ({
   hasActiveBoardFilters: filterActivityMocks.hasActiveBoardFilters,
   applyStatusChange: (_filters: unknown, status: string) => ({ status }),
   normalizeRetiredStatus: (filters: unknown) => filters,
-  toClimbSearchInput: () => ({}),
+  toClimbSearchInput: searchInputMocks.toClimbSearchInput,
   newSortSeed: () => '424242',
   mergeBoardFilters: (input: unknown) => input,
   formatMinAscentsFilterCount: (count: number) => String(count),
@@ -366,6 +391,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   filterActivityMocks.hasActiveClimbFilters.mockImplementation(() => false);
   filterActivityMocks.hasActiveBoardFilters.mockImplementation(() => false);
+  searchInputMocks.toClimbSearchInput.mockImplementation(() => ({}));
   bottomSheetModalProps.latest = null;
   bottomSheetModalProps.mountCount = 0;
   bottomSheetScrollViewProps.latest = null;
@@ -688,10 +714,12 @@ describe('ClimbFilterSheet random sort', () => {
 });
 
 describe('ClimbFilterSheet flat sections', () => {
-  it('renders five labeled sections flat, without any accordion controls', () => {
+  it('renders six labeled sections flat, without any accordion controls', () => {
     const { getByText, queryByText } = renderFilterSheet();
 
-    // The five top-level group headers are all present and always visible.
+    // The six top-level group headers are all present and always visible — Name
+    // is now the first (#3606), ahead of Difficulty.
+    expect(getByText('mobile.filter.section.name')).not.toBeNull();
     expect(getByText('mobile.filter.section.difficulty')).not.toBeNull();
     expect(getByText('mobile.filter.progress.label')).not.toBeNull();
     expect(getByText('mobile.filter.section.quality')).not.toBeNull();
@@ -744,5 +772,92 @@ describe('ClimbFilterSheet flat sections', () => {
     const call = onApply.mock.calls.at(-1);
     expect((call?.[0] as ClimbFilters).status).toBe('any');
     expect((call?.[1] as { onlyBenchmarks?: boolean }).onlyBenchmarks).toBe(true);
+  });
+});
+
+// Regression coverage for #3606: Reset silently left the committed climb-name
+// term in place (no wire existed to clear it), and the maintainer separately
+// asked for the name to be a visible, editable first row in the sheet.
+describe('ClimbFilterSheet name field (#3606)', () => {
+  it('clears the name via onClearName on Reset, but NOT on Apply', () => {
+    // Reset is only enabled while the draft has active filters.
+    filterActivityMocks.hasActiveClimbFilters.mockImplementation(() => true);
+    const onClearName = vi.fn();
+    const onApply = vi.fn();
+    const { getByText } = renderFilterSheet({ searchName: 'crimpy', onClearName, onApply });
+
+    // Guards against the wiring landing on the wrong button — a plausible
+    // copy-paste inversion given Reset/Apply sit in the same header/footer.
+    fireEvent.click(getByText('mobile.filter.showCount12'));
+    expect(onClearName).not.toHaveBeenCalled();
+    expect(onApply).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(getByText('mobile.filter.reset'));
+    expect(onClearName).toHaveBeenCalledTimes(1);
+  });
+
+  it('mirrors a typed name to onNameChange and to the field itself', () => {
+    const onNameChange = vi.fn();
+    const { getByLabelText } = renderFilterSheet({ onNameChange });
+
+    const input = getByLabelText('mobile.filter.section.name') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'crimp' } });
+
+    expect(onNameChange).toHaveBeenCalledWith('crimp');
+    expect(input.value).toBe('crimp');
+  });
+
+  it('shows the inline clear button only once there is text, and routes it through the same path as Reset', () => {
+    const onClearName = vi.fn();
+    // Seeded non-empty so the clear button is visible immediately.
+    const { getByLabelText, queryByLabelText } = renderFilterSheet({ searchName: 'foot', onClearName });
+
+    const input = getByLabelText('mobile.filter.section.name') as HTMLInputElement;
+    expect(input.value).toBe('foot');
+
+    fireEvent.click(getByLabelText('clear'));
+
+    expect(input.value).toBe('');
+    expect(onClearName).toHaveBeenCalledTimes(1);
+    expect(queryByLabelText('clear')).toBeNull();
+  });
+
+  it('resyncs the name field from an external searchName change, but ignores a trim-only difference', () => {
+    const rendered = renderFilterSheet({ searchName: 'crimp' });
+    const input = rendered.getByLabelText('mobile.filter.section.name') as HTMLInputElement;
+    expect(input.value).toBe('crimp');
+
+    // A genuine external change (board switch / recent-pill apply / cancel)
+    // re-seeds the field.
+    rendered.rerender(<ClimbFilterSheet {...rendered.props} searchName="jugs" />);
+    expect(input.value).toBe('jugs');
+
+    // Simulate mid-typing a trailing space, then the parent commits the
+    // NORMALIZED (trimmed) value — the field's own trailing space must survive,
+    // not get yanked out from under the cursor.
+    fireEvent.change(input, { target: { value: 'sloper ' } });
+    rendered.rerender(<ClimbFilterSheet {...rendered.props} searchName="sloper" />);
+    expect(input.value).toBe('sloper ');
+  });
+
+  it('reflects an in-sheet name edit in the "Show N" preview after the debounce', () => {
+    vi.useFakeTimers();
+    try {
+      const { getByLabelText } = renderFilterSheet();
+      searchInputMocks.toClimbSearchInput.mockClear();
+
+      const input = getByLabelText('mobile.filter.section.name') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: 'crimp' } });
+
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+
+      const lastCall = searchInputMocks.toClimbSearchInput.mock.calls.at(-1);
+      // 4th positional arg is `{ name }` — see toClimbSearchInput(filters, boardConfig, pageParams, { name }).
+      expect(lastCall?.[3]).toEqual({ name: 'crimp' });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -656,6 +656,7 @@
       "apply": "Apply filters",
       "reset": "Reset",
       "section": {
+        "name": "Climb name",
         "difficulty": "Difficulty",
         "quality": "Quality",
         "theClimb": "The climb",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -656,6 +656,7 @@
       "apply": "Aplicar filtros",
       "reset": "Restablecer",
       "section": {
+        "name": "Nombre del bloque",
         "difficulty": "Dificultad",
         "quality": "Calidad",
         "theClimb": "El bloque",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -656,6 +656,7 @@
       "apply": "Appliquer les filtres",
       "reset": "Réinitialiser",
       "section": {
+        "name": "Nom du bloc",
         "difficulty": "Difficulté",
         "quality": "Qualité",
         "theClimb": "Le bloc",


### PR DESCRIPTION
## Premise check

Confirmed as reported, no correction needed. The climb-name search term lives
in a separate reducer slice (`ClimbSearchState.name`, committed live via a
300ms debounce) from the sheet's Apply-gated filter draft
(`ClimbFilters`/`DEFAULT_FILTERS`), which has no `name` field. Reset only ever
called the two draft setters that exist inside the sheet — there was no prop to
also clear the parent's committed name, and none was added when Reset was
built. Root cause is an incomplete prop contract, not an inverted condition or
a logic bug: there was no wire to cut, because it was never run.

## What changed

Two coupled changes, per the issue's own ask:

1. **Reset now clears the climb name.** `ClimbFilterSheet` gets a new
   `onClearName: () => void` prop; `handleReset` calls it alongside the two
   existing draft resets. The parent (`app/(tabs)/climbs/index.tsx`) wires a new
   `handleClearName` that clears the debounce timer, the committed `name`, and
   mirrors the clear into whichever search bar is showing (custom capsule or
   the iOS-26 native one) — reusing the exact `applyVisibleSearchText` +
   `setName('')` mechanism `handleApplyRecentFilter` and the per-board restore
   paths already use. `handleNativeSearchCancel` is untouched — Reset must not
   close the sheet, and cancel's `setShowFilters(false)` is a different intent.
2. **Climb name is now the sheet's first row**, above "1 · Difficulty" (now "2 ·
   Difficulty" — the six section-comment numbers shifted). It's a plain
   `TextInput` with an inline × that only shows once there's text. Typing
   mirrors live into the top bar / native search bar via a new composed
   `handleSheetNameChange` (`applyVisibleSearchText` first, then
   `handleSearchChange` — order matters, see the code comment: the debounced
   `handleSearchChange` write must run second so the normalized value wins).
   The × and Reset share **one** clearing path
   (`onClearName`/`handleClearNameField`) — there's exactly one code path to
   reason about for "clear the name". The "Show N" apply-button preview now
   folds the in-sheet name draft into its existing 250ms-debounced
   `filters`/`boardFilters` state, so an in-sheet name edit updates the count
   the same way a chip/toggle edit already does.
3. **Reset is now tappable when a climb name is the only thing set.** Caught by
   the paired QA review, and it's the issue's literal repro. The header Reset
   button's enabled state (`anyActive`) was built purely from
   `hasActiveClimbFilters`/`hasActiveBoardFilters`, and neither can see the
   name — that's the whole point of the root cause above, name lives outside
   `ClimbFilters`. So with a lone climb-name search and every other control at
   its default, Reset rendered greyed out and `handleReset` never fired, making
   change (1) unreachable in exactly the state the reporter described.
   `anyActive` now also folds in `nameDraft.length > 0`, the same rule that
   already gates the field's inline ×, so the two clear affordances light up
   together.
4. **`onNameChange` / `onClearName` are required props**, not optional. Review
   note, and a fair one: the sheet only owns the field's *display* state, so an
   unwired caller would render a name field that looks like it filters and
   doesn't, and a × that blanks the field while the committed term survives.
   There's one consumer and it passes both, so requiring them costs nothing and
   the compiler now enforces it.

New i18n key `mobile.filter.section.name` in `en-US`/`es`/`fr` ("Climb name" /
"Nombre del bloque" / "Nom du bloc" — following this same file's existing
`theClimb` → "El bloque"/"Le bloc" precedent). Everything else reuses existing
catalog entries (placeholder = `search.placeholders.climbs`, clear-button label
= `common:clear`). Also added `keyboardShouldPersistTaps="handled"` to the
sheet's scroll view — it never hosted a text input before, so a first tap on
Apply/Reset while the keyboard is up could otherwise get swallowed.

## Why one clearing path

The inline × and Reset both call the same `onClearName`/`handleClearNameField`
functions rather than each having their own "clear the name" logic. This means
a future bug in clearing can only exist in one place, and the tests below only
need to prove that path works once and that both buttons reach it.

## Testing

`packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx`, seven
new tests:

- Reset calls `onClearName` exactly once; Apply does **not** (guards against a
  copy-paste inversion between the two buttons, which share a header/footer).
- With **only** a climb name set — the activity mocks deliberately left at
  their default `false`, so nothing else counts as active — Reset renders
  enabled and clears the name. This is the one the QA review's blocking finding
  was about; the earlier Reset test forced `hasActiveClimbFilters` to `true`,
  which happened to also be what un-disabled the button, so it masked the gap.
- With nothing at all set, Reset stays disabled and `onClearName` never fires
  (the flip side, so the gate isn't just always-on).
- Typing in the name field mirrors to `onNameChange` and updates the field's
  own displayed value.
- The inline × only renders once there's text, and clearing through it goes
  through the same `onClearName` path as Reset.
- The field resyncs from an external `searchName` prop change (board switch /
  recent pill), but a trim-only difference (mid-typing trailing space) does
  **not** yank the field — exercised through the real DOM value the field
  renders, not by re-asserting the shared `visibleSearchTextNeedsSync` helper's
  own return value against itself.
- The "Show N" preview reflects an in-sheet name edit after the 250ms debounce.

**Mutation checks performed** (twice): removed the `onClearName()` call from
`handleReset`, confirmed exactly the Reset regression test went red and no
other test was affected, then restored it. Same again for the `anyActive` gate
— dropping the `nameDraft.length > 0` clause reds exactly the name-only Reset
test (28/29), restoring it is back to 29/29.

Full validation, all green:

- `vp run typecheck:mobile`
- `vp run test:mobile` — 557 files / 4687 tests (4680 baseline + 7 new)
- `vp check` — 0 errors (286 pre-existing warnings elsewhere in the repo,
  unrelated to this change)
- `vp run check:i18n` / `vp run check:i18n:orphans` — both OK
- `vp run check:mobile-bundle` — OK

## Device QA gates (not covered by this PR's automated validation)

- **iOS**: the two-way text mirroring (`applyVisibleSearchText` into
  `nativeSearchRef`/`searchHeaderRef`) and the iOS-26 native bottom-tab search
  bar variant (`useNativeAccessoryActive`) can't be exercised in jsdom/vitest
  (RN native components are mocked), and this box has no iOS simulator. Needs a
  real device/simulator pass: typing in the sheet should visibly update the top
  search bar / native search bar live, and Reset should visibly clear whichever
  is showing.
- **Keyboard/tap interaction**: `keyboardShouldPersistTaps="handled"` is
  included, but whether a tap on Apply/Reset while the keyboard is up actually
  registers is a native gesture behavior jsdom can't verify.
- **Android**: attempted an emulator pass on this box (Pixel AVD, dev-client +
  Metro against this branch). The emulator booted and the dev-client installed
  cleanly, but the app hadn't finished its first JS bundle launch inside this
  session's time budget, so the interactive part (open sheet, type a name, tap
  Reset, screenshot) wasn't completed. No crash/error was observed in the
  process I could inspect. Left as a gate for the next pass rather than
  claiming a verification that didn't finish. Worth walking the issue's exact
  repro on that pass: type only a climb name, touch nothing else, confirm Reset
  is coloured/tappable and clears both the sheet field and the top bar.

## Scope

Not touched, deliberately: `handleNativeSearchCancel` (different intent — see
above); Apply's handling of name (still commits live via debounce, independent
of Apply, same as today); how `name` persists to per-board last-search storage
(already board-scoped, untouched); a web equivalent (web's climb search is
URL-param-driven with no local-draft-plus-Apply sheet model and no existing
Reset/name coupling — no parity gap found there).

## Release Notes

The filter sheet's Reset button now actually resets everything — including any
climb name you'd typed in. And you can type or clear a climb name right there
in the sheet, front and center, so you don't have to hunt for the search bar
separately.

Closes #3606.
