### PR TITLE
fix(mobile): show downloaded boards in the picker with no signal

### DIFF
--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -769,6 +769,30 @@ async function saveTick(db: SQLiteDatabase, tickData: TickInput) {
 | Backend GraphQL API   | Mostly unchanged. New sync pull queries + sync_deletions + idempotent mutations + addFavorite/removeFavorite. |
 | Aurora sync daemon    | Unchanged. Picks up ticks without `aurora_id` and pushes to Aurora API.                                       |
 
+## Board identity offline (why snapshots, not scope keys)
+
+The board picker and My Boards get their list from `myBoards`, a network-only GraphQL
+query. Offline the client's `networkMode: 'offlineFirst'` makes it PAUSE rather than
+error, so both screens saw an empty list and told the user they had no boards (#3897).
+
+The enabled-boards setting can't stand in for that list. A scope key is
+`"boardType:layoutId:sizeId"` — it names a DOWNLOAD, not a board, and one download
+serves every board the user has on that layout+size ("Marco's garage" and "Gym wall"
+on the same Kilter Original 12x12 share one). It carries no `uuid`, `name`, `setIds`
+or `angle`, and `uuid` is server-issued: `setActiveBoard`, `BoardProvider`, the BLE
+wrapper and the board-presence subscription all key on it, so it can never be
+synthesised from board-config.
+
+So board identity is snapshotted at download time into one more MMKV settings key
+(`offlineBoardsV1`, see `packages/mobile/src/settings/offline-boards.ts`) as a flat
+list of `UserBoard`s deduped by `uuid` — never a scope-keyed map, which would hide one
+of two boards sharing a scope. Reads run through a runtime shape guard so a card
+written by an older build degrades (one fewer row) instead of crashing the picker, and
+the list is cleared at sign-out because it carries the previous account's board names.
+
+The picker offers a snapshot only when its scope is in `getDownloadedScopeKeys()` —
+the honest "will actually serve climbs" signal — plus the active board unconditionally.
+
 ## Account lifecycle
 
 On logout or account switch:
@@ -776,7 +800,8 @@ On logout or account switch:
 1. Cancel any in-progress sync pull or mutation queue drain.
 2. Delete user data tables from SQLite (`boardsesh_ticks`, `playlists`, `playlist_climbs`, `user_favorites`, `user_follows`, `setter_follows`, `playlist_follows`, `user_playlist_pins`, `pending_mutations`). Board reference data stays — no need to re-copy the 150-200MB pre-warmed database.
 3. Clear the TanStack Query cache.
-4. On new login, sync pull client fetches the new user's data (small, seconds).
+4. Reset `syncEnabledBoards` and the `offlineBoardsV1` snapshots (board names must not survive into the next account on a shared device).
+5. On new login, sync pull client fetches the new user's data (small, seconds).
 
 ## Performance targets
 

--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -793,6 +793,22 @@ the list is cleared at sign-out because it carries the previous account's board 
 The picker offers a snapshot only when its scope is in `getDownloadedScopeKeys()` —
 the honest "will actually serve climbs" signal — plus the active board unconditionally.
 
+Card lifecycle, since no single event covers it:
+
+- **Written** by `enableBoardsOffline` (the one download funnel) and refreshed from a
+  live `myBoards` by `useRememberDownloadedBoards`, which remembers boards whose scope
+  is in `syncEnabledBoards`. Deliberately not "or already downloaded": toggling
+  "Available offline" off leaves the rows and checkpoint on disk so re-enabling
+  resumes instantly, so a downloaded-keyed refresh would re-write the card the toggle
+  just dropped.
+- **Dropped per scope** (`forgetOfflineBoardScope`) when offline is turned off or the
+  data is removed — the download is per scope, so every board sharing it loses its card.
+- **Dropped per board** (`forgetOfflineBoard`) on delete and unfollow, and pruned
+  against a **complete** `myBoards` (`hasMore === false`) for the deleted-on-another-
+  device case. A card the backend no longer knows is worse than a stale row: activating
+  it writes a dead `uuid` into `active-board-store` and board presence. `myBoards` pages
+  at 20, which is why the prune refuses to run on a truncated page.
+
 ## Account lifecycle
 
 On logout or account switch:

--- a/packages/mobile/app/boards/__tests__/index-offline.test.tsx
+++ b/packages/mobile/app/boards/__tests__/index-offline.test.tsx
@@ -233,7 +233,7 @@ describe('board picker with no usable network list', () => {
     expect(screen.queryByText('Try again')).toBeNull();
   });
 
-  it('falls back to downloaded boards when the connection lies (online, every request fails)', () => {
+  it('falls back to downloaded boards when the connection lies (online, every request fails)', async () => {
     // Captive portal / gym wifi with a dead upstream: onlineManager reports online, so
     // retries never pause and the query really errors.
     state.isOffline = false;
@@ -243,8 +243,15 @@ describe('board picker with no usable network list', () => {
 
     render(createElement(BoardSelection));
 
-    expect(screen.getByRole('button', { name: 'Marco garage' })).toBeTruthy();
+    const row = screen.getByRole('button', { name: 'Marco garage' });
     expect(screen.queryByText('Something went wrong')).toBeNull();
+
+    fireEvent.click(row);
+    await waitFor(() => expect(setActiveBoardMock).toHaveBeenCalledTimes(1));
+    // The adopt guard must follow the rows, not `isOffline`: here `isOffline` is false
+    // but every request still fails, so a follow mutation can only produce the
+    // "Could not follow X" toast (plus a Sentry report) on a downloaded board.
+    expect(adoptFoundBoardMock).not.toHaveBeenCalled();
   });
 
   it('keeps a retry escape hatch when the connection lies and nothing is downloaded', () => {
@@ -255,6 +262,22 @@ describe('board picker with no usable network list', () => {
 
     expect(screen.getByText('Nothing downloaded yet')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Try again' })).toBeTruthy();
+  });
+
+  it('still adopts on tap when the network list is usable', async () => {
+    // The other direction of the same guard: online, selecting a board must still
+    // follow it and offer its download.
+    state.myBoards = {
+      data: { boards: [board({ uuid: 'net-1', name: 'Network board' })] },
+      isLoading: false,
+      isError: false,
+      isRefetching: false,
+    };
+
+    render(createElement(BoardSelection));
+    fireEvent.click(screen.getByRole('button', { name: 'Network board' }));
+
+    await waitFor(() => expect(adoptFoundBoardMock).toHaveBeenCalledTimes(1));
   });
 
   it('leaves the online screen untouched', () => {

--- a/packages/mobile/app/boards/__tests__/index-offline.test.tsx
+++ b/packages/mobile/app/boards/__tests__/index-offline.test.tsx
@@ -73,6 +73,8 @@ vi.mock('react-i18next', () => ({
         'mobile.errorTitle': 'Something went wrong',
         'mobile.errorRetry': 'Try again',
         'mobile.offline.pickerNotice': "No signal — here are the boards you've downloaded.",
+        'mobile.offline.pickerNoticeUnreachable':
+          "Can't reach your boards right now — here are the ones you've downloaded.",
         'mobile.offline.pickerEmptyTitle': 'Nothing downloaded yet',
         'mobile.offline.pickerEmptyBody': 'Boards you make available offline show up here.',
         'mobile.discovery.yourBoardsTitle': 'Your boards',
@@ -245,6 +247,9 @@ describe('board picker with no usable network list', () => {
 
     const row = screen.getByRole('button', { name: 'Marco garage' });
     expect(screen.queryByText('Something went wrong')).toBeNull();
+    // The device has bars here, so "No signal" would be a lie.
+    expect(screen.getByText("Can't reach your boards right now — here are the ones you've downloaded.")).toBeTruthy();
+    expect(screen.queryByText("No signal — here are the boards you've downloaded.")).toBeNull();
 
     fireEvent.click(row);
     await waitFor(() => expect(setActiveBoardMock).toHaveBeenCalledTimes(1));

--- a/packages/mobile/app/boards/__tests__/index-offline.test.tsx
+++ b/packages/mobile/app/boards/__tests__/index-offline.test.tsx
@@ -1,0 +1,297 @@
+// @vitest-environment jsdom
+//
+// Regression cover for #3897: with no signal the board picker used to render its
+// "No boards yet — create one" empty state. `myBoards` is a plain network query and
+// the client runs `networkMode: 'offlineFirst'`, so offline the retryer PAUSES
+// (status pending, fetchStatus paused, isError false) — the screen therefore saw an
+// empty list, not an error, and told the user they had no boards while offering a
+// CTA that also needs the network.
+//
+// The mocked hook shapes below are the real offline shapes: `useMyBoards` returns
+// `{ data: undefined, isLoading: false, isError: false }`.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+type Children = { children?: ReactNode };
+type ButtonProps = { title: string; onPress?: () => void };
+type CarouselItem = { key: string; title: string };
+
+const routerMock = vi.hoisted(() => ({ push: vi.fn(), dismissTo: vi.fn() }));
+const toastMock = vi.hoisted(() => ({ showToast: vi.fn() }));
+const setActiveBoardMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const adoptFoundBoardMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const rememberDownloadedBoardsMock = vi.hoisted(() => vi.fn());
+
+const state = vi.hoisted(() => ({
+  isOffline: false,
+  offlineCards: [] as unknown[],
+  downloadedScopeKeys: [] as string[],
+  activeBoard: undefined as unknown,
+  myBoards: {
+    data: undefined as { boards: unknown[] } | undefined,
+    isLoading: false,
+    isError: false,
+    isRefetching: false,
+  },
+  popular: { configs: [] as unknown[] },
+}));
+
+const board = (overrides: Partial<UserBoard> & { uuid: string; name: string }): UserBoard =>
+  ({
+    boardType: 'kilter',
+    layoutId: 8,
+    sizeId: 17,
+    setIds: '20,21',
+    angle: 40,
+    sizeName: '12 x 12',
+    isOwned: true,
+    isFollowedByMe: true,
+    ownerId: 'me',
+    ...overrides,
+  }) as unknown as UserBoard;
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  View: ({ children }: Children) => createElement('div', null, children),
+  ScrollView: ({ children }: Children) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('expo-router', () => ({
+  useRouter: () => routerMock,
+  useLocalSearchParams: () => ({}),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'mobile.emptyTitle': 'No boards yet',
+        'mobile.emptySubtitle': 'Search for a board to get started',
+        'mobile.errorTitle': 'Something went wrong',
+        'mobile.errorRetry': 'Try again',
+        'mobile.offline.pickerNotice': "No signal — here are the boards you've downloaded.",
+        'mobile.offline.pickerEmptyTitle': 'Nothing downloaded yet',
+        'mobile.offline.pickerEmptyBody': 'Boards you make available offline show up here.',
+        'mobile.discovery.yourBoardsTitle': 'Your boards',
+        'mobile.discovery.popularTitle': 'Popular',
+        'mobile.discovery.create': 'Create a board',
+        'mobile.discovery.findNearby': 'Find nearby',
+        'mobile.discovery.bluetooth': 'Bluetooth',
+        'mobile.discovery.findGym': 'Find a gym',
+        'mobile.boardSwitchError': 'Could not switch board',
+      };
+      return map[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock('expo-sqlite', () => ({ useSQLiteContext: () => ({}) }));
+
+// The screen's only useQuery is ['downloadedScopeKeys'].
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({ data: state.downloadedScopeKeys }),
+}));
+
+vi.mock('@boardsesh/offline-sync', () => ({
+  getDownloadedScopeKeys: vi.fn(async () => state.downloadedScopeKeys),
+  offlineBoardKeyForBoard: (input: { boardType: string; layoutId: number; sizeId: number }) =>
+    `${input.boardType}:${input.layoutId}:${input.sizeId}`,
+}));
+
+vi.mock('../../../src/lib/graphql/hooks', () => ({
+  useMyBoards: () => ({ ...state.myBoards, refetch: vi.fn() }),
+  usePopularBoardConfigs: () => ({ data: state.popular }),
+  useNearbyBoards: () => ({ data: undefined, isLoading: false }),
+}));
+
+vi.mock('../../../src/lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: state.activeBoard }),
+  useSetActiveBoard: () => setActiveBoardMock,
+}));
+
+vi.mock('../../../src/lib/board-discovery/use-adopt-found-board', () => ({
+  useAdoptFoundBoard: () => adoptFoundBoardMock,
+}));
+
+vi.mock('../../../src/lib/use-device-location', () => ({
+  useDeviceLocation: () => ({ status: 'idle', coords: undefined, request: vi.fn() }),
+}));
+
+vi.mock('../../../src/providers/auth-provider', () => ({
+  useAuth: () => ({ isAuthenticated: true, refreshAuthState: vi.fn() }),
+}));
+vi.mock('../../../src/providers/toast-provider', () => ({ useToast: () => toastMock }));
+vi.mock('../../../src/lib/haptics', () => ({ hapticSelection: vi.fn() }));
+vi.mock('../../../src/lib/onboarding/onboarding-storage', () => ({
+  setBoardRevealTipPending: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../../src/lib/analytics', () => ({ track: vi.fn() }));
+vi.mock('../../../src/hooks/use-bottom-chrome-metrics', () => ({
+  useBottomChromeMetrics: () => ({ scrollBottomPadding: 0 }),
+}));
+vi.mock('../../../src/hooks/use-is-offline', () => ({ useIsOffline: () => state.isOffline }));
+vi.mock('../../../src/settings', () => ({ useOfflineBoards: () => state.offlineCards }));
+vi.mock('../../../src/offline/use-remember-downloaded-boards', () => ({
+  useRememberDownloadedBoards: (boards: unknown) => rememberDownloadedBoardsMock(boards),
+}));
+
+vi.mock('../../../src/theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 5: 20, 8: 32 },
+}));
+vi.mock('../../../src/theme/ios-colors', () => ({
+  iosSystemColors: { systemGray: '#8e8e93', systemRed: '#f00' },
+}));
+
+vi.mock('../../../src/components/Text', () => ({
+  Text: ({ children }: Children) => createElement('span', null, children),
+}));
+vi.mock('../../../src/components/Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('i', { 'data-icon': name }),
+}));
+vi.mock('../../../src/components/Button', () => ({
+  Button: ({ title, onPress }: ButtonProps) => createElement('button', { onClick: onPress, type: 'button' }, title),
+}));
+vi.mock('../../../src/components/ActivityIndicator', () => ({
+  ActivityIndicator: () => createElement('div', { 'data-testid': 'spinner' }),
+}));
+vi.mock('../../../src/components/board-discovery/BoardCarousel', () => ({
+  BoardCarousel: ({ items, onSelect }: { items: CarouselItem[]; onSelect: (item: CarouselItem) => void }) =>
+    createElement(
+      'div',
+      { 'data-testid': 'carousel' },
+      items.map((item) =>
+        createElement('button', { key: item.key, type: 'button', onClick: () => onSelect(item) }, item.title),
+      ),
+    ),
+}));
+vi.mock('../../../src/components/board-discovery/BoardModeCard', () => ({
+  BoardModeCard: ({ label }: { label: string }) => createElement('div', { 'data-mode-card': label }, label),
+}));
+vi.mock('../../../src/components/board-discovery/BluetoothQuickstartSheet', () => ({
+  BluetoothQuickstartSheet: () => createElement('div', { 'data-testid': 'ble-sheet' }),
+}));
+
+const { default: BoardSelection } = await import('../index');
+
+const downloadedBoard = board({ uuid: 'board-a', name: 'Marco garage' });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setActiveBoardMock.mockResolvedValue(undefined);
+  state.isOffline = false;
+  state.offlineCards = [];
+  state.downloadedScopeKeys = [];
+  state.activeBoard = undefined;
+  state.myBoards = { data: undefined, isLoading: false, isError: false, isRefetching: false };
+  state.popular = { configs: [] };
+});
+
+describe('board picker with no usable network list', () => {
+  it('lists the downloaded board and switches to it on tap', async () => {
+    state.isOffline = true;
+    state.offlineCards = [downloadedBoard];
+    state.downloadedScopeKeys = ['kilter:8:17'];
+
+    render(createElement(BoardSelection));
+
+    // On today's code this row does not exist: the screen renders "No boards yet".
+    const row = screen.getByRole('button', { name: 'Marco garage' });
+    expect(screen.queryByText('No boards yet')).toBeNull();
+    expect(screen.getByText("No signal — here are the boards you've downloaded.")).toBeTruthy();
+
+    fireEvent.click(row);
+    await waitFor(() => expect(setActiveBoardMock).toHaveBeenCalledTimes(1));
+    expect(setActiveBoardMock.mock.calls[0]?.[0]).toMatchObject({ uuid: 'board-a' });
+    expect(toastMock.showToast).not.toHaveBeenCalled();
+  });
+
+  it('does not fire the follow/adopt mutation while offline', async () => {
+    state.isOffline = true;
+    state.offlineCards = [downloadedBoard];
+    state.downloadedScopeKeys = ['kilter:8:17'];
+
+    render(createElement(BoardSelection));
+    fireEvent.click(screen.getByRole('button', { name: 'Marco garage' }));
+
+    await waitFor(() => expect(setActiveBoardMock).toHaveBeenCalledTimes(1));
+    // Adoption is a follow mutation plus a download confirm — offline all it can do is
+    // raise a "Could not follow X" error toast on a board the user already has.
+    expect(adoptFoundBoardMock).not.toHaveBeenCalled();
+  });
+
+  it('shows the offline empty state, not "create a board", when nothing is downloaded', () => {
+    state.isOffline = true;
+
+    render(createElement(BoardSelection));
+
+    expect(screen.getByText('Nothing downloaded yet')).toBeTruthy();
+    expect(screen.queryByText('No boards yet')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Create a board' })).toBeNull();
+    expect(screen.queryByText('Try again')).toBeNull();
+  });
+
+  it('falls back to downloaded boards when the connection lies (online, every request fails)', () => {
+    // Captive portal / gym wifi with a dead upstream: onlineManager reports online, so
+    // retries never pause and the query really errors.
+    state.isOffline = false;
+    state.myBoards = { data: undefined, isLoading: false, isError: true, isRefetching: false };
+    state.offlineCards = [downloadedBoard];
+    state.downloadedScopeKeys = ['kilter:8:17'];
+
+    render(createElement(BoardSelection));
+
+    expect(screen.getByRole('button', { name: 'Marco garage' })).toBeTruthy();
+    expect(screen.queryByText('Something went wrong')).toBeNull();
+  });
+
+  it('keeps a retry escape hatch when the connection lies and nothing is downloaded', () => {
+    state.isOffline = false;
+    state.myBoards = { data: undefined, isLoading: false, isError: true, isRefetching: false };
+
+    render(createElement(BoardSelection));
+
+    expect(screen.getByText('Nothing downloaded yet')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeTruthy();
+  });
+
+  it('leaves the online screen untouched', () => {
+    state.myBoards = {
+      data: { boards: [board({ uuid: 'net-1', name: 'Network board' })] },
+      isLoading: false,
+      isError: false,
+      isRefetching: false,
+    };
+    state.popular = {
+      configs: [
+        {
+          boardType: 'kilter',
+          layoutId: 8,
+          sizeId: 17,
+          setIds: [20, 21],
+          setNames: ['Bolt ons'],
+          climbCount: 1,
+          totalAscents: 1,
+          boardCount: 1,
+          displayName: 'Kilter Original',
+          sizeName: '12 x 12',
+        },
+      ],
+    };
+    // Downloaded snapshots exist, but online they must not change anything.
+    state.offlineCards = [downloadedBoard];
+    state.downloadedScopeKeys = ['kilter:8:17'];
+
+    render(createElement(BoardSelection));
+
+    expect(screen.getByRole('button', { name: 'Network board' })).toBeTruthy();
+    expect(screen.getByText('Popular')).toBeTruthy();
+    expect(screen.queryByText("No signal — here are the boards you've downloaded.")).toBeNull();
+    // All four discovery mode cards, including the two that need a connection.
+    for (const label of ['Find nearby', 'Bluetooth', 'Find a gym', 'Create a board']) {
+      expect(document.querySelector(`[data-mode-card="${label}"]`)).toBeTruthy();
+    }
+  });
+});

--- a/packages/mobile/app/boards/__tests__/manage-offline.test.tsx
+++ b/packages/mobile/app/boards/__tests__/manage-offline.test.tsx
@@ -1,0 +1,289 @@
+// @vitest-environment jsdom
+//
+// #3897, second surface. My Boards has TWO offline failures and the profile is the
+// fatal one: `useProfile` is a plain network query, so with no signal `currentUserId`
+// is undefined and the guard `(isError && myBoards.length === 0) || !currentUserId`
+// fired the hard "Something went wrong / Try again" state — regardless of anything
+// done to the board list. Offline the screen now renders a flat list of the boards
+// this device downloaded (owned-vs-followed can't be classified without the profile
+// id, so the headers are dropped rather than guessed) with the network affordances
+// hidden.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+type Children = { children?: ReactNode };
+type ButtonProps = { title: string; onPress?: () => void };
+type ManageRowProps = { board: UserBoard; readOnly?: boolean; downloadState?: string };
+
+const routerMock = vi.hoisted(() => ({ push: vi.fn() }));
+const setOptionsMock = vi.hoisted(() => vi.fn());
+
+const state = vi.hoisted(() => ({
+  isOffline: false,
+  profileId: undefined as string | undefined,
+  isProfileLoading: false,
+  offlineCards: [] as unknown[],
+  enabledBoards: [] as string[],
+  downloadedScopeKeys: [] as string[],
+  activeBoard: undefined as unknown,
+  myBoards: {
+    data: undefined as { boards: unknown[] } | undefined,
+    isLoading: false,
+    isError: false,
+    isRefetching: false,
+  },
+}));
+
+const board = (overrides: Partial<UserBoard> & { uuid: string; name: string }): UserBoard =>
+  ({
+    boardType: 'kilter',
+    layoutId: 8,
+    sizeId: 17,
+    setIds: '20,21',
+    angle: 40,
+    isOwned: true,
+    ownerId: 'me',
+    ...overrides,
+  }) as unknown as UserBoard;
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  View: ({ children }: Children) => createElement('div', null, children),
+  Pressable: ({ children, onPress }: Children & { onPress?: () => void }) =>
+    createElement('button', { onClick: onPress, type: 'button' }, children),
+  RefreshControl: () => null,
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('@shopify/flash-list', () => ({
+  FlashList: ({
+    data,
+    renderItem,
+    ListHeaderComponent,
+    ListEmptyComponent,
+  }: {
+    data: { key: string }[];
+    renderItem: (input: { item: unknown }) => ReactNode;
+    ListHeaderComponent?: ReactNode;
+    ListEmptyComponent?: ReactNode;
+  }) =>
+    createElement(
+      'div',
+      { 'data-testid': 'list' },
+      ListHeaderComponent,
+      data.length === 0
+        ? ListEmptyComponent
+        : data.map((item) => createElement('div', { key: item.key }, renderItem({ item }))),
+    ),
+}));
+
+vi.mock('expo-router', () => ({
+  useRouter: () => routerMock,
+  useNavigation: () => ({ setOptions: setOptionsMock }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    i18n: { language: 'en-US' },
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'mobile.errorTitle': 'Something went wrong',
+        'mobile.errorRetry': 'Try again',
+        'mobile.emptyTitle': 'No boards yet',
+        'mobile.emptySubtitle': 'Search for a board to get started',
+        'mobile.discovery.create': 'Create a board',
+        'mobile.manage.ownedHeader': 'Your boards',
+        'mobile.manage.followingHeader': 'Following',
+        'mobile.manage.edit': 'Edit',
+        'mobile.offline.pickerNotice': "No signal — here are the boards you've downloaded.",
+      };
+      return map[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock('expo-sqlite', () => ({ useSQLiteContext: () => ({}) }));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({ data: state.downloadedScopeKeys, refetch: vi.fn() }),
+}));
+
+vi.mock('@boardsesh/offline-sync', () => ({
+  getDownloadedScopeKeys: vi.fn(async () => state.downloadedScopeKeys),
+  getCheckpoint: vi.fn(async () => null),
+  getCheckpointKey: (table: string, key: string) => `${table}:${key}`,
+  getBootstrapAttempts: vi.fn(async () => 0),
+  estimateScopeDownload: () => ({ kind: 'unknown' }),
+  offlineBoardKeyForBoard: (input: { boardType: string; layoutId: number; sizeId: number }) =>
+    `${input.boardType}:${input.layoutId}:${input.sizeId}`,
+}));
+
+vi.mock('../../../src/lib/graphql/hooks', () => ({
+  useMyBoards: () => ({ ...state.myBoards, refetch: vi.fn() }),
+  useProfile: () => ({
+    data: state.profileId ? { id: state.profileId } : undefined,
+    isLoading: state.isProfileLoading,
+    isError: false,
+    refetch: vi.fn(),
+  }),
+  useDeleteBoard: () => ({ isPending: false, variables: undefined, mutateAsync: vi.fn() }),
+  useUnfollowBoard: () => ({ isPending: false, variables: undefined, mutateAsync: vi.fn() }),
+}));
+
+vi.mock('../../../src/lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: state.activeBoard }),
+  useClearActiveBoard: () => vi.fn(),
+}));
+
+vi.mock('../../../src/providers/auth-provider', () => ({
+  useAuth: () => ({ isAuthenticated: true, refreshAuthState: vi.fn() }),
+}));
+vi.mock('../../../src/providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('../../../src/providers/dialog-provider', () => ({ useConfirm: () => vi.fn().mockResolvedValue(false) }));
+vi.mock('../../../src/providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: {
+      background: '#fff',
+      secondaryBackground: '#eee',
+      tertiaryBackground: '#ddd',
+      label: '#000',
+      secondaryLabel: '#666',
+      tertiaryLabel: '#999',
+      separator: '#ccc',
+    },
+    brandColors: { primary: '#6D28D9', onPrimary: '#fff' },
+  }),
+}));
+vi.mock('../../../src/providers/feature-flags-provider', () => ({ useOfflineDownloadsEnabled: () => true }));
+vi.mock('../../../src/hooks/use-bottom-chrome-metrics', () => ({
+  useBottomChromeMetrics: () => ({ scrollBottomPadding: 0 }),
+}));
+vi.mock('../../../src/hooks/use-is-offline', () => ({ useIsOffline: () => state.isOffline }));
+vi.mock('../../../src/sync', () => ({ useSyncStatus: () => ({ isSyncing: false, progress: null }) }));
+vi.mock('../../../src/offline/use-board-downloads', () => ({
+  useBoardDownloads: () => ({ enableBoardsOffline: vi.fn() }),
+}));
+vi.mock('../../../src/offline/use-remember-downloaded-boards', () => ({
+  useRememberDownloadedBoards: vi.fn(),
+}));
+vi.mock('../../../src/offline/use-snapshot-manifest', () => ({ useSnapshotManifest: () => null }));
+vi.mock('../../../src/lib/format-bytes', () => ({ formatBytes: (bytes: number) => `${bytes} B` }));
+vi.mock('../../../src/lib/haptics', () => ({ hapticSelection: vi.fn() }));
+vi.mock('../../../src/settings', () => ({
+  getSetting: () => state.enabledBoards,
+  useSetting: () => [state.enabledBoards, vi.fn()],
+  setOfflineBoardEnabled: vi.fn(),
+  forgetOfflineBoardScope: vi.fn(),
+  useOfflineBoards: () => state.offlineCards,
+  offlineBoardKeyForBoard: (input: { boardType: string; layoutId: number; sizeId: number }) =>
+    `${input.boardType}:${input.layoutId}:${input.sizeId}`,
+  offlineBoardScopeForBoard: (input: { boardType: string; layoutId: number; sizeId: number }) => ({
+    boardType: input.boardType,
+    layoutId: input.layoutId,
+    sizeId: input.sizeId,
+  }),
+}));
+
+vi.mock('../../../src/theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 5: 20, 8: 32, 16: 64 },
+}));
+vi.mock('../../../src/theme/ios-colors', () => ({
+  iosSystemColors: { systemGray: '#8e8e93', systemRed: '#f00' },
+}));
+
+vi.mock('../../../src/components/Text', () => ({
+  Text: ({ children }: Children) => createElement('span', null, children),
+}));
+vi.mock('../../../src/components/Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('i', { 'data-icon': name }),
+}));
+vi.mock('../../../src/components/Button', () => ({
+  Button: ({ title, onPress }: ButtonProps) => createElement('button', { onClick: onPress, type: 'button' }, title),
+}));
+vi.mock('../../../src/components/ActivityIndicator', () => ({
+  ActivityIndicator: () => createElement('div', { 'data-testid': 'spinner' }),
+}));
+vi.mock('../../../src/components/board-discovery/BoardManageRow', () => ({
+  BoardManageRow: ({ board: rowBoard, readOnly, downloadState }: ManageRowProps) =>
+    createElement(
+      'div',
+      { 'data-board': rowBoard.uuid, 'data-readonly': String(!!readOnly), 'data-download-state': downloadState ?? '' },
+      rowBoard.name,
+    ),
+}));
+
+const { default: ManageBoards } = await import('../manage');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.isOffline = false;
+  state.profileId = undefined;
+  state.isProfileLoading = false;
+  state.offlineCards = [];
+  state.enabledBoards = [];
+  state.downloadedScopeKeys = [];
+  state.activeBoard = undefined;
+  state.myBoards = { data: undefined, isLoading: false, isError: false, isRefetching: false };
+});
+
+describe('My Boards with no usable network list', () => {
+  it('renders the downloaded boards instead of the hard error state when the profile is missing', () => {
+    state.isOffline = true;
+    state.offlineCards = [board({ uuid: 'board-a', name: 'Marco garage' })];
+    state.downloadedScopeKeys = ['kilter:8:17'];
+
+    render(createElement(ManageBoards));
+
+    // On today's code `!currentUserId` short-circuits straight to the error state.
+    expect(screen.getByText('Marco garage')).toBeTruthy();
+    expect(screen.queryByText('Something went wrong')).toBeNull();
+    expect(screen.queryByText('Try again')).toBeNull();
+    expect(screen.getByText("No signal — here are the boards you've downloaded.")).toBeTruthy();
+  });
+
+  it('hides the network-only affordances: Create, Edit, and the per-row mutations', () => {
+    state.isOffline = true;
+    state.offlineCards = [board({ uuid: 'board-a', name: 'Marco garage' })];
+    state.enabledBoards = ['kilter:8:17'];
+    state.downloadedScopeKeys = ['kilter:8:17'];
+
+    render(createElement(ManageBoards));
+
+    expect(screen.queryByRole('button', { name: 'Create a board' })).toBeNull();
+    expect(document.querySelector('[data-board="board-a"]')?.getAttribute('data-readonly')).toBe('true');
+    // The header Edit button only reveals delete/unfollow, both server mutations.
+    expect(setOptionsMock.mock.calls.at(-1)?.[0]?.headerRight).toBeUndefined();
+    // The local offline toggle keeps working — its state comes off disk, not the wire.
+    expect(document.querySelector('[data-board="board-a"]')?.getAttribute('data-download-state')).toBe('downloaded');
+  });
+
+  it('leaves the owned/followed split and the Create button alone online', () => {
+    state.profileId = 'me';
+    state.myBoards = {
+      data: { boards: [board({ uuid: 'net-1', name: 'Network board' })] },
+      isLoading: false,
+      isError: false,
+      isRefetching: false,
+    };
+    state.offlineCards = [board({ uuid: 'board-a', name: 'Marco garage' })];
+    state.downloadedScopeKeys = ['kilter:8:17'];
+
+    render(createElement(ManageBoards));
+
+    expect(screen.getByText('Your boards')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Create a board' })).toBeTruthy();
+    expect(screen.getByText('Network board')).toBeTruthy();
+    expect(screen.queryByText('Marco garage')).toBeNull();
+    expect(document.querySelector('[data-board="net-1"]')?.getAttribute('data-readonly')).toBe('false');
+  });
+
+  it('still shows the retry state offline when nothing has been downloaded', () => {
+    state.isOffline = true;
+
+    render(createElement(ManageBoards));
+
+    expect(screen.getByText('Something went wrong')).toBeTruthy();
+  });
+});

--- a/packages/mobile/app/boards/__tests__/manage-offline.test.tsx
+++ b/packages/mobile/app/boards/__tests__/manage-offline.test.tsx
@@ -279,6 +279,31 @@ describe('My Boards with no usable network list', () => {
     expect(document.querySelector('[data-board="net-1"]')?.getAttribute('data-readonly')).toBe('false');
   });
 
+  it('degrades to the read-only list, not the error state, when the profile fails online', () => {
+    // Reviewer-flagged path: online, boards loaded, but the profile settled with no
+    // id (e.g. a 401 on that query alone). Today that shows the hard error state;
+    // owned-vs-followed is unclassifiable, so the read-only list is the honest render.
+    state.isOffline = false;
+    state.profileId = undefined;
+    state.isProfileLoading = false;
+    state.myBoards = {
+      data: { boards: [board({ uuid: 'net-1', name: 'Network board' })] },
+      isLoading: false,
+      isError: false,
+      isRefetching: false,
+    };
+    state.offlineCards = [board({ uuid: 'board-a', name: 'Marco garage' })];
+    state.enabledBoards = ['kilter:8:17'];
+    state.downloadedScopeKeys = ['kilter:8:17'];
+
+    render(createElement(ManageBoards));
+
+    expect(screen.queryByText('Something went wrong')).toBeNull();
+    expect(screen.getByText('Marco garage')).toBeTruthy();
+    expect(screen.queryByText('Your boards')).toBeNull();
+    expect(document.querySelector('[data-board="board-a"]')?.getAttribute('data-readonly')).toBe('true');
+  });
+
   it('still shows the retry state offline when nothing has been downloaded', () => {
     state.isOffline = true;
 

--- a/packages/mobile/app/boards/__tests__/manage-offline.test.tsx
+++ b/packages/mobile/app/boards/__tests__/manage-offline.test.tsx
@@ -9,16 +9,26 @@
 // id, so the headers are dropped rather than guessed) with the network affordances
 // hidden.
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import type { UserBoard } from '@boardsesh/shared-schema';
 
 type Children = { children?: ReactNode };
 type ButtonProps = { title: string; onPress?: () => void };
-type ManageRowProps = { board: UserBoard; readOnly?: boolean; downloadState?: string };
+type ManageRowProps = {
+  board: UserBoard;
+  readOnly?: boolean;
+  downloadState?: string;
+  onDelete: (board: UserBoard) => void;
+  onUnfollow: (board: UserBoard) => void;
+};
 
 const routerMock = vi.hoisted(() => ({ push: vi.fn() }));
 const setOptionsMock = vi.hoisted(() => vi.fn());
+const forgetOfflineBoardMock = vi.hoisted(() => vi.fn());
+const deleteBoardMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const unfollowBoardMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const confirmMock = vi.hoisted(() => vi.fn().mockResolvedValue(false));
 
 const state = vi.hoisted(() => ({
   isOffline: false,
@@ -128,8 +138,8 @@ vi.mock('../../../src/lib/graphql/hooks', () => ({
     isError: false,
     refetch: vi.fn(),
   }),
-  useDeleteBoard: () => ({ isPending: false, variables: undefined, mutateAsync: vi.fn() }),
-  useUnfollowBoard: () => ({ isPending: false, variables: undefined, mutateAsync: vi.fn() }),
+  useDeleteBoard: () => ({ isPending: false, variables: undefined, mutateAsync: deleteBoardMock }),
+  useUnfollowBoard: () => ({ isPending: false, variables: undefined, mutateAsync: unfollowBoardMock }),
 }));
 
 vi.mock('../../../src/lib/graphql/use-active-board', () => ({
@@ -141,7 +151,7 @@ vi.mock('../../../src/providers/auth-provider', () => ({
   useAuth: () => ({ isAuthenticated: true, refreshAuthState: vi.fn() }),
 }));
 vi.mock('../../../src/providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
-vi.mock('../../../src/providers/dialog-provider', () => ({ useConfirm: () => vi.fn().mockResolvedValue(false) }));
+vi.mock('../../../src/providers/dialog-provider', () => ({ useConfirm: () => confirmMock }));
 vi.mock('../../../src/providers/theme-provider', () => ({
   useTheme: () => ({
     systemColors: {
@@ -175,6 +185,7 @@ vi.mock('../../../src/settings', () => ({
   getSetting: () => state.enabledBoards,
   useSetting: () => [state.enabledBoards, vi.fn()],
   setOfflineBoardEnabled: vi.fn(),
+  forgetOfflineBoard: (uuid: string) => forgetOfflineBoardMock(uuid),
   forgetOfflineBoardScope: vi.fn(),
   useOfflineBoards: () => state.offlineCards,
   offlineBoardKeyForBoard: (input: { boardType: string; layoutId: number; sizeId: number }) =>
@@ -206,11 +217,13 @@ vi.mock('../../../src/components/ActivityIndicator', () => ({
   ActivityIndicator: () => createElement('div', { 'data-testid': 'spinner' }),
 }));
 vi.mock('../../../src/components/board-discovery/BoardManageRow', () => ({
-  BoardManageRow: ({ board: rowBoard, readOnly, downloadState }: ManageRowProps) =>
+  BoardManageRow: ({ board: rowBoard, readOnly, downloadState, onDelete, onUnfollow }: ManageRowProps) =>
     createElement(
       'div',
       { 'data-board': rowBoard.uuid, 'data-readonly': String(!!readOnly), 'data-download-state': downloadState ?? '' },
       rowBoard.name,
+      createElement('button', { type: 'button', onClick: () => onDelete(rowBoard) }, `delete ${rowBoard.uuid}`),
+      createElement('button', { type: 'button', onClick: () => onUnfollow(rowBoard) }, `unfollow ${rowBoard.uuid}`),
     ),
 }));
 
@@ -218,6 +231,9 @@ const { default: ManageBoards } = await import('../manage');
 
 beforeEach(() => {
   vi.clearAllMocks();
+  deleteBoardMock.mockResolvedValue(undefined);
+  unfollowBoardMock.mockResolvedValue(undefined);
+  confirmMock.mockResolvedValue(false);
   state.isOffline = false;
   state.profileId = undefined;
   state.isProfileLoading = false;
@@ -302,6 +318,58 @@ describe('My Boards with no usable network list', () => {
     expect(screen.getByText('Marco garage')).toBeTruthy();
     expect(screen.queryByText('Your boards')).toBeNull();
     expect(document.querySelector('[data-board="board-a"]')?.getAttribute('data-readonly')).toBe('true');
+  });
+
+  it('forgets a deleted board so its card cannot outlive it', async () => {
+    // A plain toggle-off leaves the download in place, so the scope stays "downloaded"
+    // and forgetOfflineBoardScope never fires here. Without the per-uuid forget the
+    // card lives forever and hands a uuid the backend has dropped to setActiveBoard.
+    confirmMock.mockResolvedValue(true);
+    state.profileId = 'me';
+    state.myBoards = {
+      data: { boards: [board({ uuid: 'net-1', name: 'Network board' })] },
+      isLoading: false,
+      isError: false,
+      isRefetching: false,
+    };
+
+    render(createElement(ManageBoards));
+    fireEvent.click(screen.getByText('delete net-1'));
+
+    await waitFor(() => expect(forgetOfflineBoardMock).toHaveBeenCalledWith('net-1'));
+  });
+
+  it('forgets an unfollowed board too', async () => {
+    state.profileId = 'me';
+    state.myBoards = {
+      data: { boards: [board({ uuid: 'net-1', name: 'Network board', isOwned: false, ownerId: 'someone' })] },
+      isLoading: false,
+      isError: false,
+      isRefetching: false,
+    };
+
+    render(createElement(ManageBoards));
+    fireEvent.click(screen.getByText('unfollow net-1'));
+
+    await waitFor(() => expect(forgetOfflineBoardMock).toHaveBeenCalledWith('net-1'));
+  });
+
+  it('keeps the card when the delete mutation fails', async () => {
+    confirmMock.mockResolvedValue(true);
+    deleteBoardMock.mockRejectedValue(new Error('offline'));
+    state.profileId = 'me';
+    state.myBoards = {
+      data: { boards: [board({ uuid: 'net-1', name: 'Network board' })] },
+      isLoading: false,
+      isError: false,
+      isRefetching: false,
+    };
+
+    render(createElement(ManageBoards));
+    fireEvent.click(screen.getByText('delete net-1'));
+
+    await waitFor(() => expect(deleteBoardMock).toHaveBeenCalled());
+    expect(forgetOfflineBoardMock).not.toHaveBeenCalled();
   });
 
   it('still shows the retry state offline when nothing has been downloaded', () => {

--- a/packages/mobile/app/boards/__tests__/manage-offline.test.tsx
+++ b/packages/mobile/app/boards/__tests__/manage-offline.test.tsx
@@ -108,6 +108,8 @@ vi.mock('react-i18next', () => ({
         'mobile.manage.followingHeader': 'Following',
         'mobile.manage.edit': 'Edit',
         'mobile.offline.pickerNotice': "No signal — here are the boards you've downloaded.",
+        'mobile.offline.pickerNoticeUnreachable':
+          "Can't reach your boards right now — here are the ones you've downloaded.",
       };
       return map[key] ?? key;
     },
@@ -317,6 +319,8 @@ describe('My Boards with no usable network list', () => {
     expect(screen.queryByText('Something went wrong')).toBeNull();
     expect(screen.getByText('Marco garage')).toBeTruthy();
     expect(screen.queryByText('Your boards')).toBeNull();
+    // Online with a dead profile request: the notice must not claim there is no signal.
+    expect(screen.getByText("Can't reach your boards right now — here are the ones you've downloaded.")).toBeTruthy();
     expect(document.querySelector('[data-board="board-a"]')?.getAttribute('data-readonly')).toBe('true');
   });
 

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -319,8 +319,10 @@ export default function BoardSelection() {
         contentContainerStyle={[styles.container, { paddingBottom: scrollBottomPadding }]}
         showsVerticalScrollIndicator={false}
       >
+        {/* "No signal" is only true on the offline branch. The lying-connection branch
+            has bars — it just can't reach us — so it gets its own line. */}
         <Text variant="subheadline" style={styles.offlineNotice}>
-          {t('mobile.offline.pickerNotice')}
+          {isOffline ? t('mobile.offline.pickerNotice') : t('mobile.offline.pickerNoticeUnreachable')}
         </Text>
         {offlineItems.length > 0 ? (
           <Section title={t('mobile.discovery.yourBoardsTitle')}>

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -35,6 +35,11 @@ import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { iosSystemColors } from '../../src/theme/ios-colors';
 import { spacing } from '../../src/theme/tokens';
 
+// Module-level so an absent board list keeps a stable identity: offline
+// `boardConnection` is always undefined, and a fresh `[]` per render would
+// recompute the offline rows on every commit.
+const EMPTY_BOARDS: UserBoard[] = [];
+
 export default function BoardSelection() {
   const { isAuthenticated, refreshAuthState } = useAuth();
   const bottomChrome = useBottomChromeMetrics();
@@ -61,7 +66,7 @@ export default function BoardSelection() {
     refetch,
     isRefetching,
   } = useMyBoards(undefined, { enabled: isAuthenticated });
-  const myBoards = boardConnection?.boards ?? [];
+  const myBoards = boardConnection?.boards ?? EMPTY_BOARDS;
   // Keep the offline snapshots in step with the live list (renames, and a backfill
   // for boards downloaded before this existed). No-ops while offline.
   useRememberDownloadedBoards(boardConnection?.boards);

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -67,9 +67,10 @@ export default function BoardSelection() {
     isRefetching,
   } = useMyBoards(undefined, { enabled: isAuthenticated });
   const myBoards = boardConnection?.boards ?? EMPTY_BOARDS;
-  // Keep the offline snapshots in step with the live list (renames, and a backfill
-  // for boards downloaded before this existed). No-ops while offline.
-  useRememberDownloadedBoards(boardConnection?.boards);
+  // Keep the offline snapshots in step with the live list: renames, a backfill for
+  // boards downloaded before this existed, and a prune of boards the server no longer
+  // lists. No-ops while offline.
+  useRememberDownloadedBoards(boardConnection);
 
   // Offline (or a connection that reports online while every request fails), the
   // network board list is unavailable: `myBoards` is a plain `getHttpClient` query,
@@ -148,15 +149,18 @@ export default function BoardSelection() {
         // errors are handled inside and intentionally don't reach the catch below
         // (which only guards the board-switch write above).
         //
-        // Skipped offline: adoption is a follow mutation plus a download confirm, so
-        // with no signal the only thing it can produce is a "Could not follow X" error
-        // toast on a board the user already has downloaded.
-        if (!isOffline) void adoptFoundBoard(board);
+        // Skipped whenever the rows came from the local snapshots: adoption is a follow
+        // mutation plus a download confirm, so with no usable connection the only thing
+        // it can produce is a "Could not follow X" error toast on a board the user
+        // already has downloaded. Gated on `isLocalOnly`, not `isOffline` — the
+        // lying-connection branch (captive portal, dead upstream) renders the same rows
+        // with `isOffline === false`, and its requests fail just as hard.
+        if (!isLocalOnly) void adoptFoundBoard(board);
       } catch {
         showToast(t('mobile.boardSwitchError'), 'error');
       }
     },
-    [setActiveBoard, adoptFoundBoard, router, boardReturnTo, showToast, t, fromOnboarding, isOffline],
+    [setActiveBoard, adoptFoundBoard, router, boardReturnTo, showToast, t, fromOnboarding, isLocalOnly],
   );
 
   const myBoardItems = useMemo(

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -2,8 +2,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { View, ScrollView, StyleSheet } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
+import { useSQLiteContext } from 'expo-sqlite';
+import { useQuery } from '@tanstack/react-query';
 import type BottomSheet from '@expo/ui/community/bottom-sheet';
 import type { UserBoard } from '@boardsesh/shared-schema';
+import { getDownloadedScopeKeys } from '@boardsesh/offline-sync';
 import { useMyBoards, usePopularBoardConfigs, useNearbyBoards } from '../../src/lib/graphql/hooks';
 import { useActiveBoard, useSetActiveBoard } from '../../src/lib/graphql/use-active-board';
 import { useAdoptFoundBoard } from '../../src/lib/board-discovery/use-adopt-found-board';
@@ -19,8 +22,12 @@ import { BoardCarousel } from '../../src/components/board-discovery/BoardCarouse
 import { BoardModeCard, type ModeCardState } from '../../src/components/board-discovery/BoardModeCard';
 import { BluetoothQuickstartSheet } from '../../src/components/board-discovery/BluetoothQuickstartSheet';
 import { userBoardToItem, popularConfigToItem } from '../../src/components/board-discovery/board-items';
+import { offlineBoardRows } from '../../src/components/board-discovery/offline-board-items';
 import type { DiscoveryBoardItem } from '../../src/components/board-discovery/BoardDiscoveryCard';
 import { useBottomChromeMetrics } from '../../src/hooks/use-bottom-chrome-metrics';
+import { useIsOffline } from '../../src/hooks/use-is-offline';
+import { useOfflineBoards } from '../../src/settings';
+import { useRememberDownloadedBoards } from '../../src/offline/use-remember-downloaded-boards';
 import { resolveBoardReturnTo } from '../../src/lib/boards/board-return-to';
 import { setBoardRevealTipPending } from '../../src/lib/onboarding/onboarding-storage';
 import { track } from '../../src/lib/analytics';
@@ -55,6 +62,42 @@ export default function BoardSelection() {
     isRefetching,
   } = useMyBoards(undefined, { enabled: isAuthenticated });
   const myBoards = boardConnection?.boards ?? [];
+  // Keep the offline snapshots in step with the live list (renames, and a backfill
+  // for boards downloaded before this existed). No-ops while offline.
+  useRememberDownloadedBoards(boardConnection?.boards);
+
+  // Offline (or a connection that reports online while every request fails), the
+  // network board list is unavailable: `myBoards` is a plain `getHttpClient` query,
+  // and with `networkMode: 'offlineFirst'` its retryer PAUSES rather than erroring —
+  // so the screen used to render the "No boards yet — create one" empty state, a
+  // false claim whose only CTA also needs the network. Fall back to the boards this
+  // device has actually downloaded.
+  const isOffline = useIsOffline();
+  const db = useSQLiteContext();
+  // Ungated by the offline-downloads flag: this reads rows already on disk, and a
+  // flag flipped off must not strand a device that has downloads.
+  const { data: downloadedScopeKeys } = useQuery({
+    queryKey: ['downloadedScopeKeys'],
+    queryFn: () => getDownloadedScopeKeys(db),
+  });
+  const offlineCards = useOfflineBoards();
+  // `isError && nothing cached` is the lying-connection case: captive portal or gym
+  // wifi with a dead upstream, where onlineManager says online, the request fails for
+  // real, and retries never pause. Same belt-and-braces reasoning as
+  // offlineAwareRequest's network-failure catch.
+  const isLocalOnly = isOffline || (isError && myBoards.length === 0);
+  const offlineRows = useMemo(
+    () =>
+      isLocalOnly
+        ? offlineBoardRows({
+            cards: offlineCards,
+            cachedMyBoards: myBoards,
+            activeBoard: activeBoard ?? null,
+            downloadedScopeKeys: downloadedScopeKeys ?? [],
+          })
+        : [],
+    [isLocalOnly, offlineCards, myBoards, activeBoard, downloadedScopeKeys],
+  );
 
   const { data: popular } = usePopularBoardConfigs({ limit: 12 });
 
@@ -99,12 +142,16 @@ export default function BoardSelection() {
         // board already in My Boards a no-op for follow. Fire-and-forget: its own
         // errors are handled inside and intentionally don't reach the catch below
         // (which only guards the board-switch write above).
-        void adoptFoundBoard(board);
+        //
+        // Skipped offline: adoption is a follow mutation plus a download confirm, so
+        // with no signal the only thing it can produce is a "Could not follow X" error
+        // toast on a board the user already has downloaded.
+        if (!isOffline) void adoptFoundBoard(board);
       } catch {
         showToast(t('mobile.boardSwitchError'), 'error');
       }
     },
-    [setActiveBoard, adoptFoundBoard, router, boardReturnTo, showToast, t, fromOnboarding],
+    [setActiveBoard, adoptFoundBoard, router, boardReturnTo, showToast, t, fromOnboarding, isOffline],
   );
 
   const myBoardItems = useMemo(
@@ -121,6 +168,13 @@ export default function BoardSelection() {
         .filter((item): item is DiscoveryBoardItem => item !== null),
     [nearby?.boards, activeBoard?.uuid],
   );
+  const offlineItems = useMemo(
+    () =>
+      offlineRows
+        .map((board) => userBoardToItem(board, activeBoard?.uuid))
+        .filter((item): item is DiscoveryBoardItem => item !== null),
+    [offlineRows, activeBoard?.uuid],
+  );
   const popularItems = useMemo(
     () => (popular?.configs ?? []).map(popularConfigToItem).filter((item): item is DiscoveryBoardItem => item !== null),
     [popular?.configs],
@@ -132,7 +186,11 @@ export default function BoardSelection() {
   const onSelectMyBoard = useCallback(
     (item: DiscoveryBoardItem) => {
       const board =
-        myBoards.find((b) => b.uuid === item.key) ?? (nearby?.boards ?? []).find((b) => b.uuid === item.key);
+        myBoards.find((b) => b.uuid === item.key) ??
+        (nearby?.boards ?? []).find((b) => b.uuid === item.key) ??
+        // Offline rows come from the persisted snapshots, which aren't in either
+        // network list — without this an offline tap is dead.
+        offlineRows.find((b) => b.uuid === item.key);
       if (board) {
         void activateBoard(board);
       } else {
@@ -142,7 +200,7 @@ export default function BoardSelection() {
         showToast(t('mobile.boardSwitchError'), 'error');
       }
     },
-    [myBoards, nearby?.boards, activateBoard, showToast, t],
+    [myBoards, nearby?.boards, offlineRows, activateBoard, showToast, t],
   );
   const nearbySection =
     nearbyItems.length > 0 ? (
@@ -217,7 +275,9 @@ export default function BoardSelection() {
             ? 'unavailable'
             : 'idle';
 
-  if (isMyBoardsLoading) {
+  // The offline branch must not be swallowed by the loading spinner: the very first
+  // offline render is still "fetching" before the retryer pauses.
+  if (isMyBoardsLoading && !isLocalOnly) {
     return (
       <View style={styles.centered}>
         <ActivityIndicator size="large" />
@@ -236,6 +296,48 @@ export default function BoardSelection() {
           {t('mobile.signInSubtitle')}
         </Text>
         <Button title={t('mobile.signInCta')} onPress={() => router.push('/auth/login')} style={styles.stateButton} />
+      </ScrollView>
+    );
+  }
+
+  // No usable network list: offer what this device downloaded instead of the mode
+  // cards, Popular, and a "create a board" CTA that all need a connection.
+  if (isLocalOnly) {
+    return (
+      <ScrollView
+        contentInsetAdjustmentBehavior="automatic"
+        style={styles.flex}
+        contentContainerStyle={[styles.container, { paddingBottom: scrollBottomPadding }]}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text variant="subheadline" style={styles.offlineNotice}>
+          {t('mobile.offline.pickerNotice')}
+        </Text>
+        {offlineItems.length > 0 ? (
+          <Section title={t('mobile.discovery.yourBoardsTitle')}>
+            <BoardCarousel items={offlineItems} onSelect={onSelectMyBoard} />
+          </Section>
+        ) : (
+          <View style={styles.emptyState}>
+            <Text variant="headline" style={styles.emptyTitle}>
+              {t('mobile.offline.pickerEmptyTitle')}
+            </Text>
+            <Text variant="subheadline" style={styles.emptySubtitle}>
+              {t('mobile.offline.pickerEmptyBody')}
+            </Text>
+            {/* Only the lying-connection case gets a retry — offline it would just
+                pause, and the user already knows they have no signal. */}
+            {isError ? (
+              <Button
+                title={t('mobile.errorRetry')}
+                variant="outlined"
+                loading={isRefetching}
+                onPress={() => void refetch()}
+                style={styles.emptyCta}
+              />
+            ) : null}
+          </View>
+        )}
       </ScrollView>
     );
   }
@@ -347,6 +449,10 @@ const styles = StyleSheet.create({
     gap: spacing[5],
   },
   onboardingHeader: {
+    paddingHorizontal: spacing[4],
+    opacity: 0.7,
+  },
+  offlineNotice: {
     paddingHorizontal: spacing[4],
     opacity: 0.7,
   },

--- a/packages/mobile/app/boards/manage.tsx
+++ b/packages/mobile/app/boards/manage.tsx
@@ -453,8 +453,10 @@ export default function ManageBoards() {
         ListHeaderComponent={
           showOfflineList ? (
             <View style={styles.listHeader}>
+              {/* Only the offline branch actually has no signal — the profile-failure
+                  and lying-connection branches have bars and a dead request. */}
               <Text variant="subheadline" style={styles.offlineNotice}>
-                {t('mobile.offline.pickerNotice')}
+                {isOffline ? t('mobile.offline.pickerNotice') : t('mobile.offline.pickerNoticeUnreachable')}
               </Text>
             </View>
           ) : items.length > 0 ? (

--- a/packages/mobile/app/boards/manage.tsx
+++ b/packages/mobile/app/boards/manage.tsx
@@ -30,6 +30,7 @@ import {
   getSetting,
   useSetting,
   setOfflineBoardEnabled,
+  forgetOfflineBoard,
   forgetOfflineBoardScope,
   useOfflineBoards,
   offlineBoardKeyForBoard,
@@ -239,9 +240,9 @@ export default function ManageBoards() {
   // Only take over the screen when there is actually something to show; otherwise the
   // existing loading/error states still tell the more honest story.
   const showOfflineList = shouldUseOfflineList && offlineItems.length > 0;
-  // Keep the snapshots fresh from the live list while online (renames, and a backfill
-  // for boards downloaded before this existed).
-  useRememberDownloadedBoards(boardConnection?.boards);
+  // Keep the snapshots fresh from the live list while online (renames, a backfill for
+  // boards downloaded before this existed, and a prune of boards the server dropped).
+  useRememberDownloadedBoards(boardConnection);
 
   const onCreate = useCallback(() => {
     router.push('/boards/create');
@@ -266,6 +267,10 @@ export default function ManageBoards() {
       if (!confirmed) return;
       try {
         await deleteBoard.mutateAsync(board.uuid);
+        // The offline picker's snapshot goes with it. The download itself stays (a
+        // sibling board can share the scope), but a card for a board the backend has
+        // dropped must never reach setActiveBoard.
+        forgetOfflineBoard(board.uuid);
         // The deleted board can't stay the active selection — drop it so the app
         // routes to the picker instead of a board that no longer exists.
         if (activeUuid === board.uuid) await clearActiveBoard();
@@ -280,6 +285,8 @@ export default function ManageBoards() {
     async (board: UserBoard) => {
       try {
         await unfollowBoard.mutateAsync(board.uuid);
+        // Same as delete: the board is no longer the user's, so its offline card goes.
+        forgetOfflineBoard(board.uuid);
         if (activeUuid === board.uuid) await clearActiveBoard();
       } catch {
         showToast(t('mobile.manage.unfollowError'), 'error');

--- a/packages/mobile/app/boards/manage.tsx
+++ b/packages/mobile/app/boards/manage.tsx
@@ -218,9 +218,9 @@ export default function ManageBoards() {
   const isOffline = useIsOffline();
   const offlineCards = useOfflineBoards();
   const profileUnavailable = !currentUserId && !isProfileLoading;
-  const useOfflineList = isOffline || profileUnavailable || (isError && myBoards.length === 0);
+  const shouldUseOfflineList = isOffline || profileUnavailable || (isError && myBoards.length === 0);
   const offlineItems = useMemo(() => {
-    if (!useOfflineList) return EMPTY_ITEMS;
+    if (!shouldUseOfflineList) return EMPTY_ITEMS;
     return offlineBoardRows({
       cards: offlineCards,
       cachedMyBoards: myBoards,
@@ -235,10 +235,10 @@ export default function ManageBoards() {
         isActive: board.uuid === activeUuid,
       }),
     );
-  }, [useOfflineList, offlineCards, myBoards, activeBoard, downloadedScopeKeys, activeUuid]);
+  }, [shouldUseOfflineList, offlineCards, myBoards, activeBoard, downloadedScopeKeys, activeUuid]);
   // Only take over the screen when there is actually something to show; otherwise the
   // existing loading/error states still tell the more honest story.
-  const showOfflineList = useOfflineList && offlineItems.length > 0;
+  const showOfflineList = shouldUseOfflineList && offlineItems.length > 0;
   // Keep the snapshots fresh from the live list while online (renames, and a backfill
   // for boards downloaded before this existed).
   useRememberDownloadedBoards(boardConnection?.boards);

--- a/packages/mobile/app/boards/manage.tsx
+++ b/packages/mobile/app/boards/manage.tsx
@@ -23,12 +23,15 @@ import {
   estimateScopeDownload,
 } from '@boardsesh/offline-sync';
 import { useBoardDownloads } from '../../src/offline/use-board-downloads';
+import { useRememberDownloadedBoards } from '../../src/offline/use-remember-downloaded-boards';
 import { useSnapshotManifest } from '../../src/offline/use-snapshot-manifest';
 import { formatBytes } from '../../src/lib/format-bytes';
 import {
   getSetting,
   useSetting,
   setOfflineBoardEnabled,
+  forgetOfflineBoardScope,
+  useOfflineBoards,
   offlineBoardKeyForBoard,
   offlineBoardScopeForBoard,
 } from '../../src/settings';
@@ -40,10 +43,13 @@ import { ActivityIndicator } from '../../src/components/ActivityIndicator';
 import { BoardManageRow } from '../../src/components/board-discovery/BoardManageRow';
 import { boardDownloadState, boardIsBootstrapping } from '../../src/components/board-discovery/board-offline-state';
 import { buildManageItems, type ManageItem } from '../../src/components/board-discovery/manage-items';
+import { offlineBoardRows } from '../../src/components/board-discovery/offline-board-items';
+import { useIsOffline } from '../../src/hooks/use-is-offline';
 import { iosSystemColors } from '../../src/theme/ios-colors';
 import { spacing } from '../../src/theme/tokens';
 
 const EMPTY_BOARDS: UserBoard[] = [];
+const EMPTY_ITEMS: ManageItem[] = [];
 
 const keyExtractor = (item: ManageItem) => item.key;
 const getItemType = (item: ManageItem) => item.type;
@@ -121,10 +127,12 @@ export default function ManageBoards() {
   // Per-scope "downloaded" signal: which scopes actually have a board_climbs
   // checkpoint. Refetched whenever a cycle finishes (isSyncing → false), so a
   // board flips to "Available offline" only once its own data has landed.
+  // Ungated by the flag: the offline fallback below needs it too, and a device that
+  // still holds downloads after a kill-switch rollback must not be stranded. One
+  // cheap indexed read, shared with the Storage screen's cache entry.
   const { data: downloadedScopeKeys, refetch: refetchDownloaded } = useQuery({
     queryKey: ['downloadedScopeKeys'],
     queryFn: () => getDownloadedScopeKeys(db),
-    enabled: offlineDownloadsEnabled,
   });
   const downloadedSet = useMemo(() => new Set(downloadedScopeKeys ?? []), [downloadedScopeKeys]);
   useEffect(() => {
@@ -140,6 +148,9 @@ export default function ManageBoards() {
         // Disabling just drops the setting entry; the cached rows + checkpoint stay
         // so re-enabling resumes instantly, so no confirm is needed.
         setOfflineBoardEnabled(scope, false);
+        // Drop the offline picker's snapshots for this scope too, so it stops
+        // offering a board the user just opted out of.
+        forgetOfflineBoardScope(scope);
         return;
       }
       // How big is this download? Only the snapshot path can answer honestly, and
@@ -197,6 +208,40 @@ export default function ManageBoards() {
       }),
     [myBoards, currentUserId, activeUuid, t],
   );
+
+  // Offline this screen has TWO independent failures, and the profile is the fatal
+  // one: `useProfile` is a plain network query, so with no signal `currentUserId` is
+  // undefined and the guard below shows a hard "Something went wrong" state no matter
+  // what the board list does. Fall back to a flat list of the boards this device
+  // downloaded — owned-vs-followed genuinely cannot be classified without the profile
+  // id, so the headers are dropped rather than guessed.
+  const isOffline = useIsOffline();
+  const offlineCards = useOfflineBoards();
+  const profileUnavailable = !currentUserId && !isProfileLoading;
+  const useOfflineList = isOffline || profileUnavailable || (isError && myBoards.length === 0);
+  const offlineItems = useMemo(() => {
+    if (!useOfflineList) return EMPTY_ITEMS;
+    return offlineBoardRows({
+      cards: offlineCards,
+      cachedMyBoards: myBoards,
+      activeBoard: activeBoard ?? null,
+      downloadedScopeKeys: downloadedScopeKeys ?? [],
+    }).map(
+      (board): ManageItem => ({
+        type: 'board',
+        key: board.uuid,
+        board,
+        isOwned: board.isOwned,
+        isActive: board.uuid === activeUuid,
+      }),
+    );
+  }, [useOfflineList, offlineCards, myBoards, activeBoard, downloadedScopeKeys, activeUuid]);
+  // Only take over the screen when there is actually something to show; otherwise the
+  // existing loading/error states still tell the more honest story.
+  const showOfflineList = useOfflineList && offlineItems.length > 0;
+  // Keep the snapshots fresh from the live list while online (renames, and a backfill
+  // for boards downloaded before this existed).
+  useRememberDownloadedBoards(boardConnection?.boards);
 
   const onCreate = useCallback(() => {
     router.push('/boards/create');
@@ -276,6 +321,9 @@ export default function ManageBoards() {
           board={item.board}
           isOwned={item.isOwned}
           isActive={item.isActive}
+          // Offline every row affordance except the offline toggle is a network
+          // mutation (edit, delete, unfollow), so the row goes read-only.
+          readOnly={showOfflineList}
           isEditing={isEditing}
           isMutating={isMutating}
           downloadState={downloadState}
@@ -294,6 +342,7 @@ export default function ManageBoards() {
       unfollowBoard.isPending,
       unfollowBoard.variables,
       isEditing,
+      showOfflineList,
       offlineDownloadsEnabled,
       enabledSet,
       isSyncing,
@@ -310,7 +359,7 @@ export default function ManageBoards() {
 
   // Edit / Done lives in the native header. Only offered when there are boards to
   // manage; collapse edit mode if the list empties out (last board removed).
-  const hasBoards = myBoards.length > 0;
+  const hasBoards = myBoards.length > 0 && !showOfflineList;
   useEffect(() => {
     if (!hasBoards && isEditing) setIsEditing(false);
   }, [hasBoards, isEditing]);
@@ -353,7 +402,7 @@ export default function ManageBoards() {
   // Wait for the profile too: owned-vs-followed is keyed on currentUserId, so
   // rendering before it resolves would file the user's own boards under
   // "Following" (myBoards can win the race on a cold open / deep link).
-  if ((isLoading && myBoards.length === 0) || (isProfileLoading && !currentUserId)) {
+  if (!showOfflineList && ((isLoading && myBoards.length === 0) || (isProfileLoading && !currentUserId))) {
     return (
       <View style={[styles.centered, { backgroundColor: systemColors.background }]}>
         <ActivityIndicator size="large" />
@@ -364,7 +413,7 @@ export default function ManageBoards() {
   // Boards failed with nothing cached, OR the profile settled without an id —
   // without currentUserId we can't classify owned vs followed, so never render
   // the list; offer a retry that refetches both.
-  if ((isError && myBoards.length === 0) || !currentUserId) {
+  if (!showOfflineList && ((isError && myBoards.length === 0) || !currentUserId)) {
     return (
       <View style={[styles.centered, { backgroundColor: systemColors.background }]}>
         <Icon name="error" size={40} color={iosSystemColors.systemRed} />
@@ -388,14 +437,20 @@ export default function ManageBoards() {
   return (
     <View style={[styles.flex, { backgroundColor: systemColors.background }]}>
       <FlashList
-        data={items}
+        data={showOfflineList ? offlineItems : items}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
         getItemType={getItemType}
         contentInsetAdjustmentBehavior="automatic"
         contentContainerStyle={{ paddingBottom }}
         ListHeaderComponent={
-          items.length > 0 ? (
+          showOfflineList ? (
+            <View style={styles.listHeader}>
+              <Text variant="subheadline" style={styles.offlineNotice}>
+                {t('mobile.offline.pickerNotice')}
+              </Text>
+            </View>
+          ) : items.length > 0 ? (
             <View style={styles.listHeader}>
               <Button title={t('mobile.discovery.create')} variant="outlined" onPress={onCreate} />
             </View>
@@ -429,6 +484,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing[4],
     paddingTop: spacing[4],
     paddingBottom: spacing[2],
+  },
+  offlineNotice: {
+    opacity: 0.7,
   },
   sectionHeader: {
     paddingHorizontal: spacing[4],

--- a/packages/mobile/src/components/board-discovery/BoardManageRow.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardManageRow.tsx
@@ -29,6 +29,12 @@ type BoardManageRowProps = {
    * destructive action never depends on the hard-to-hit swipe gesture.
    */
   isEditing?: boolean;
+  /**
+   * No network: hide every affordance that is a server mutation (tap-to-edit, the
+   * swipe delete/unfollow) and leave only the local offline toggle. The row still
+   * shows the board, its subtitle and its download status.
+   */
+  readOnly?: boolean;
   /** A mutation targeting this row is in flight — show a spinner and disable the swipe. */
   isMutating: boolean;
   /**
@@ -64,6 +70,7 @@ function BoardManageRowComponent({
   isOwned,
   isActive,
   isEditing = false,
+  readOnly = false,
   isMutating,
   downloadState,
   downloadCount,
@@ -203,7 +210,7 @@ function BoardManageRowComponent({
 
       {isMutating ? (
         <ActivityIndicator size="small" />
-      ) : !isEditing && isOwned ? (
+      ) : !isEditing && !readOnly && isOwned ? (
         <Icon name="chevron.right" size={14} color={iosSystemColors.systemGray4} />
       ) : null}
     </View>
@@ -211,8 +218,10 @@ function BoardManageRowComponent({
 
   return (
     <SwipeableRow
-      onPress={isOwned && !isEditing ? () => onEdit(board) : undefined}
-      pressAccessibilityLabel={isOwned && !isEditing ? t('mobile.manage.editAria', { name: board.name }) : undefined}
+      onPress={isOwned && !isEditing && !readOnly ? () => onEdit(board) : undefined}
+      pressAccessibilityLabel={
+        isOwned && !isEditing && !readOnly ? t('mobile.manage.editAria', { name: board.name }) : undefined
+      }
       onAction={isOwned ? () => onDelete(board) : () => onUnfollow(board)}
       actionLabel={
         isOwned
@@ -221,7 +230,7 @@ function BoardManageRowComponent({
       }
       actionIcon={isOwned ? 'delete' : 'minus.circle'}
       actionColor={isOwned ? iosSystemColors.systemRed : iosSystemColors.systemOrange}
-      enabled={!isMutating && !isEditing}
+      enabled={!isMutating && !isEditing && !readOnly}
       resetKey={board.uuid}
     >
       {content}

--- a/packages/mobile/src/components/board-discovery/__tests__/board-manage-row.test.tsx
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-manage-row.test.tsx
@@ -9,6 +9,7 @@ import type { UserBoard } from '@boardsesh/shared-schema';
 // must then render no toggle and no offline status caption — the pre-offline UI.
 
 const offlineToggleProps = vi.hoisted(() => ({ last: null as Record<string, unknown> | null }));
+const swipeableProps = vi.hoisted(() => ({ last: null as Record<string, unknown> | null }));
 
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
@@ -25,7 +26,13 @@ vi.mock('react-native', () => ({
 }));
 
 vi.mock('../../SwipeableRow', () => ({
-  SwipeableRow: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  SwipeableRow: (props: { children?: ReactNode }) => {
+    // Recorded, not just rendered: `onPress` (tap-to-edit) and `enabled` (the swipe
+    // delete/unfollow) are the affordances read-only mode has to take away, and both
+    // live on this wrapper rather than in the row's own markup.
+    swipeableProps.last = props as Record<string, unknown>;
+    return createElement('div', null, props.children);
+  },
 }));
 vi.mock('../../BoardImageNative', () => ({
   BoardImageNative: () => createElement('div', { 'data-testid': 'board-image' }),
@@ -66,7 +73,7 @@ vi.mock('../../../providers/theme-provider', () => ({
 vi.mock('../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
 }));
-vi.mock('../../Icon', () => ({ Icon: () => createElement('span', { 'data-icon': 'true' }) }));
+vi.mock('../../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }) }));
 vi.mock('../../ActivityIndicator', () => ({ ActivityIndicator: () => createElement('span') }));
 
 import { BoardManageRow } from '../BoardManageRow';
@@ -95,6 +102,7 @@ const rowProps = {
 afterEach(() => {
   cleanup();
   offlineToggleProps.last = null;
+  swipeableProps.last = null;
 });
 
 describe('BoardManageRow offline toggle gating', () => {
@@ -130,6 +138,36 @@ describe('BoardManageRow offline toggle gating', () => {
     const { queryByText } = render(<BoardManageRow {...rowProps} downloadState="downloading" downloadCount={42} />);
     expect(queryByText('mobile.offline.downloadingCount')).not.toBeNull();
     expect(queryByText('mobile.offline.bootstrapping')).toBeNull();
+  });
+});
+
+describe('BoardManageRow read-only mode', () => {
+  // #3897: with no usable connection every row affordance except the offline toggle is
+  // a server mutation, so the row must not offer them at all — a swipe-to-delete that
+  // can only fail is worse than no swipe.
+  it('offers tap-to-edit, the swipe action and the chevron by default', () => {
+    const { container } = render(<BoardManageRow {...rowProps} downloadState={undefined} />);
+    expect(swipeableProps.last?.onPress).toBeTypeOf('function');
+    expect(swipeableProps.last?.enabled).toBe(true);
+    expect(container.querySelector('[data-icon="chevron.right"]')).not.toBeNull();
+  });
+
+  it('takes all three away when read-only', () => {
+    const { container } = render(<BoardManageRow {...rowProps} readOnly downloadState={undefined} />);
+    expect(swipeableProps.last?.onPress).toBeUndefined();
+    expect(swipeableProps.last?.pressAccessibilityLabel).toBeUndefined();
+    expect(swipeableProps.last?.enabled).toBe(false);
+    expect(container.querySelector('[data-icon="chevron.right"]')).toBeNull();
+  });
+
+  it('keeps the offline toggle, which is a local write', () => {
+    const onToggleOffline = vi.fn();
+    const { getByTestId } = render(
+      <BoardManageRow {...rowProps} readOnly downloadState="downloaded" onToggleOffline={onToggleOffline} />,
+    );
+    expect(getByTestId('offline-toggle')).not.toBeNull();
+    (offlineToggleProps.last?.onPress as () => void)();
+    expect(onToggleOffline).toHaveBeenCalledWith(board);
   });
 });
 

--- a/packages/mobile/src/components/board-discovery/__tests__/offline-board-items.test.ts
+++ b/packages/mobile/src/components/board-discovery/__tests__/offline-board-items.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { offlineBoardRows } from '../offline-board-items';
+
+// Scope keys on the expectation side are hardcoded literals, NOT re-derived with
+// offlineBoardKeyForBoard: a test that rebuilds the production expression can only
+// ever agree with itself (see the SQL-stub-tests lesson in this repo).
+const board = (overrides: Partial<UserBoard> & { uuid: string; name: string }): UserBoard =>
+  ({
+    boardType: 'kilter',
+    layoutId: 8,
+    sizeId: 17,
+    setIds: '20,21',
+    angle: 40,
+    ...overrides,
+  }) as unknown as UserBoard;
+
+const kilterOriginal = 'kilter:8:17';
+
+describe('offlineBoardRows', () => {
+  it('offers BOTH boards that share one downloaded scope', () => {
+    // The regression the whole design turns on: one download serves every board on
+    // the same layout+size (storage-board-label.ts), so a scope-keyed map would drop
+    // one of these two silently.
+    const rows = offlineBoardRows({
+      cards: [board({ uuid: 'garage', name: "Marco's garage" }), board({ uuid: 'gym-wall', name: 'Gym wall' })],
+      cachedMyBoards: [],
+      activeBoard: null,
+      downloadedScopeKeys: [kilterOriginal],
+    });
+
+    // Both rows, each under its own name (name order: "Gym wall" then "Marco's garage").
+    expect(rows.map((row) => [row.uuid, row.name])).toEqual([
+      ['gym-wall', 'Gym wall'],
+      ['garage', "Marco's garage"],
+    ]);
+  });
+
+  it('excludes a card whose scope has no download', () => {
+    const rows = offlineBoardRows({
+      cards: [
+        board({ uuid: 'downloaded', name: 'Downloaded' }),
+        board({ uuid: 'not-downloaded', name: 'Not downloaded', layoutId: 1, sizeId: 5 }),
+      ],
+      cachedMyBoards: [],
+      activeBoard: null,
+      downloadedScopeKeys: [kilterOriginal],
+    });
+
+    expect(rows.map((row) => row.uuid)).toEqual(['downloaded']);
+  });
+
+  it('always offers the active board, downloaded or not, and sorts it first', () => {
+    const rows = offlineBoardRows({
+      cards: [board({ uuid: 'aaa-downloaded', name: 'Aaa downloaded' })],
+      cachedMyBoards: [],
+      activeBoard: board({ uuid: 'active', name: 'Zzz active', boardType: 'tension', layoutId: 12, sizeId: 3 }),
+      downloadedScopeKeys: [kilterOriginal],
+    });
+
+    expect(rows.map((row) => row.uuid)).toEqual(['active', 'aaa-downloaded']);
+  });
+
+  it('sorts the non-active rows by name', () => {
+    const rows = offlineBoardRows({
+      cards: [
+        board({ uuid: 'z', name: 'Zebra wall' }),
+        board({ uuid: 'a', name: 'Aardvark wall' }),
+        board({ uuid: 'm', name: 'Moose wall' }),
+      ],
+      cachedMyBoards: [],
+      activeBoard: null,
+      downloadedScopeKeys: [kilterOriginal],
+    });
+
+    expect(rows.map((row) => row.name)).toEqual(['Aardvark wall', 'Moose wall', 'Zebra wall']);
+  });
+
+  it('prefers the fresher copy of a board: active board beats cached beats card', () => {
+    const rows = offlineBoardRows({
+      cards: [board({ uuid: 'same', name: 'Stale snapshot name' })],
+      cachedMyBoards: [board({ uuid: 'same', name: 'Cached name' })],
+      activeBoard: board({ uuid: 'same', name: 'Freshest name' }),
+      downloadedScopeKeys: [kilterOriginal],
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.name).toBe('Freshest name');
+  });
+
+  it('prefers the cached copy over the snapshot when the board is not active', () => {
+    const rows = offlineBoardRows({
+      cards: [board({ uuid: 'renamed', name: 'Old name' })],
+      cachedMyBoards: [board({ uuid: 'renamed', name: 'New name' })],
+      activeBoard: null,
+      downloadedScopeKeys: [kilterOriginal],
+    });
+
+    expect(rows.map((row) => row.name)).toEqual(['New name']);
+  });
+
+  it('drops a malformed legacy card instead of rendering or crashing on it', () => {
+    const rows = offlineBoardRows({
+      // A card written by an older build: no uuid, and a layoutId that no longer
+      // parses. Reaching setActiveBoard/board-presence with either would be worse
+      // than one missing row.
+      cards: [
+        {
+          name: 'No uuid',
+          boardType: 'kilter',
+          layoutId: 8,
+          sizeId: 17,
+          setIds: '20',
+          angle: 40,
+        } as unknown as UserBoard,
+        board({ uuid: 'nan-layout', name: 'NaN layout', layoutId: Number.NaN }),
+        board({ uuid: 'good', name: 'Good' }),
+      ],
+      cachedMyBoards: [],
+      activeBoard: null,
+      downloadedScopeKeys: [kilterOriginal],
+    });
+
+    expect(rows.map((row) => row.uuid)).toEqual(['good']);
+  });
+
+  it('returns nothing when no scope is downloaded and there is no active board', () => {
+    const rows = offlineBoardRows({
+      cards: [board({ uuid: 'a', name: 'A' })],
+      cachedMyBoards: [board({ uuid: 'b', name: 'B' })],
+      activeBoard: null,
+      downloadedScopeKeys: [],
+    });
+
+    expect(rows).toEqual([]);
+  });
+});

--- a/packages/mobile/src/components/board-discovery/offline-board-items.ts
+++ b/packages/mobile/src/components/board-discovery/offline-board-items.ts
@@ -1,0 +1,59 @@
+// Which boards the picker may offer when the network list is unavailable.
+//
+// Pure and unit-tested, because every rule here is one the screen would otherwise
+// get wrong: three candidate sources with different freshness, a scope that can be
+// shared by two boards, and a filter that must not hide the board the user is
+// standing in front of.
+
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { offlineBoardKeyForBoard } from '@boardsesh/offline-sync';
+import { isOfflineBoardCard } from '../../lib/boards/offline-board-card';
+
+export type OfflineBoardRowsInput = {
+  /** Snapshots persisted at download time (`settings/offline-boards.ts`). */
+  cards: readonly UserBoard[];
+  /** A warm `['myBoards']` React Query entry, if this session already fetched one. */
+  cachedMyBoards: readonly UserBoard[];
+  /** The persisted active board — the one identity that always survives a cold start. */
+  activeBoard: UserBoard | null;
+  /** Scopes with a scope-complete marker, i.e. the ones that will actually serve climbs. */
+  downloadedScopeKeys: readonly string[];
+};
+
+/**
+ * The rows to render, freshest copy of each board wins.
+ *
+ * - Candidates are cards ∪ cached `myBoards` ∪ the active board, deduped by `uuid`,
+ *   with the fresher source overwriting the staler one (active > cached > card), so a
+ *   board renamed since its snapshot shows its current name.
+ * - Only scopes in `downloadedScopeKeys` are offered: activating a board whose
+ *   climbs aren't on disk lands the user on an empty list, which reads as a worse
+ *   bug than the picker one. `downloadedScopeKeys` — not `syncEnabledBoards` — is
+ *   the honest signal, the same one My Boards captions "Available offline".
+ * - The active board is always offered, downloaded or not, so the board you are
+ *   already on can never vanish from the list, and it sorts first.
+ */
+export function offlineBoardRows(input: OfflineBoardRowsInput): UserBoard[] {
+  const byUuid = new Map<string, UserBoard>();
+  // Staler sources first so the fresher ones overwrite them.
+  for (const board of input.cards) {
+    if (isOfflineBoardCard(board)) byUuid.set(board.uuid, board);
+  }
+  for (const board of input.cachedMyBoards) {
+    if (isOfflineBoardCard(board)) byUuid.set(board.uuid, board);
+  }
+  const activeUuid = input.activeBoard && isOfflineBoardCard(input.activeBoard) ? input.activeBoard.uuid : undefined;
+  if (input.activeBoard && activeUuid !== undefined) byUuid.set(activeUuid, input.activeBoard);
+
+  const downloaded = new Set(input.downloadedScopeKeys);
+  const rows = [...byUuid.values()].filter(
+    (board) => board.uuid === activeUuid || downloaded.has(offlineBoardKeyForBoard(board)),
+  );
+
+  rows.sort((left, right) => {
+    if (left.uuid === activeUuid) return -1;
+    if (right.uuid === activeUuid) return 1;
+    return left.name.localeCompare(right.name);
+  });
+  return rows;
+}

--- a/packages/mobile/src/components/board-discovery/offline-board-items.ts
+++ b/packages/mobile/src/components/board-discovery/offline-board-items.ts
@@ -53,7 +53,10 @@ export function offlineBoardRows(input: OfflineBoardRowsInput): UserBoard[] {
   rows.sort((left, right) => {
     if (left.uuid === activeUuid) return -1;
     if (right.uuid === activeUuid) return 1;
-    return left.name.localeCompare(right.name);
+    // Device locale on purpose — a Spanish user should get Spanish collation for their
+    // own board names. `sensitivity: 'base'` keeps "gym wall" and "Gym Wall" adjacent
+    // instead of splitting the list by capitalisation.
+    return left.name.localeCompare(right.name, undefined, { sensitivity: 'base' });
   });
   return rows;
 }

--- a/packages/mobile/src/lib/boards/offline-board-card.ts
+++ b/packages/mobile/src/lib/boards/offline-board-card.ts
@@ -1,0 +1,44 @@
+// Runtime shape guard for a persisted board snapshot ("offline board card").
+//
+// The offline picker replays `UserBoard`s that were written to MMKV at download
+// time, possibly by an older build. `active-board-store.ts` already documents the
+// hazard: JSON.parse succeeds on a stale shape, so the value is silently cast to a
+// type it no longer matches. Here the stakes are higher — a card with a NaN
+// `layoutId` or a missing `uuid` would reach `setActiveBoard` and board-presence.
+//
+// So every read goes through this guard and anything that fails is dropped
+// silently: a shape change must degrade the picker (one fewer row), never crash it.
+// Pure module — no MMKV, no React — so both the settings store and the row selector
+// can use it.
+
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+/**
+ * The fields the offline picker actually depends on: identity (`uuid`), the scope
+ * tuple used to match a download (`boardType`/`layoutId`/`sizeId`), and what the
+ * carousel and `setActiveBoard` consume (`setIds`, `name`, `angle`). Optional
+ * `UserBoard` fields are deliberately not checked — missing ones already read as
+ * `undefined` everywhere.
+ */
+export function isOfflineBoardCard(value: unknown): value is UserBoard {
+  if (typeof value !== 'object' || value === null) return false;
+  const card = value as Partial<UserBoard>;
+  return (
+    typeof card.uuid === 'string' &&
+    card.uuid.length > 0 &&
+    typeof card.boardType === 'string' &&
+    card.boardType.length > 0 &&
+    Number.isInteger(card.layoutId) &&
+    Number.isInteger(card.sizeId) &&
+    typeof card.setIds === 'string' &&
+    typeof card.name === 'string' &&
+    typeof card.angle === 'number' &&
+    Number.isFinite(card.angle)
+  );
+}
+
+/** Every usable card in a persisted value, dropping junk and non-array values. */
+export function readOfflineBoardCards(value: unknown): UserBoard[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(isOfflineBoardCard);
+}

--- a/packages/mobile/src/offline/__tests__/remove-offline-board.test.ts
+++ b/packages/mobile/src/offline/__tests__/remove-offline-board.test.ts
@@ -51,7 +51,9 @@ vi.mock('../../lib/error-reporting', () => ({
 import type { QueryClient } from '@tanstack/react-query';
 import { removeOfflineBoard, compactOfflineDatabase } from '../remove-offline-board';
 import { getSetting, setSetting, resetAllSettings } from '../../settings/hooks';
+import { getOfflineBoards, rememberOfflineBoards } from '../../settings/offline-boards';
 import type { OfflineBoardScope, OfflineDatabase } from '@boardsesh/offline-sync';
+import type { UserBoard } from '@boardsesh/shared-schema';
 
 const KILTER_12X14: OfflineBoardScope = { boardType: 'kilter', layoutId: 1, sizeId: 7 };
 const KILTER_8X12: OfflineBoardScope = { boardType: 'kilter', layoutId: 1, sizeId: 8 };
@@ -121,6 +123,19 @@ describe('removeOfflineBoard', () => {
 
     await expect(removeOfflineBoard({ db, queryClient, scope: KILTER_12X14 })).rejects.toThrow('disk went away');
     expect(getSetting('syncEnabledBoards')).toEqual([]);
+  });
+
+  // The offline picker replays snapshots taken at download time. Once the rows are
+  // gone, a surviving card offers a board with no climbs behind it.
+  it('forgets the offline picker snapshots for the scope it just deleted', async () => {
+    const card = (uuid: string, sizeId: number): UserBoard =>
+      ({ uuid, name: uuid, boardType: 'kilter', layoutId: 1, sizeId, setIds: '20', angle: 40 }) as unknown as UserBoard;
+    setSetting('syncEnabledBoards', ['kilter:1:7', 'kilter:1:8']);
+    rememberOfflineBoards([card('removed', 7), card('kept', 8)]);
+
+    await removeOfflineBoard({ db, queryClient, scope: KILTER_12X14 });
+
+    expect(getOfflineBoards().map((entry) => entry.uuid)).toEqual(['kept']);
   });
 
   it('invalidates the readers that could still hold deleted rows', async () => {

--- a/packages/mobile/src/offline/__tests__/use-remember-downloaded-boards.test.tsx
+++ b/packages/mobile/src/offline/__tests__/use-remember-downloaded-boards.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+const rememberOfflineBoardsMock = vi.hoisted(() => vi.fn());
+
+const state = vi.hoisted(() => ({
+  isOffline: false,
+  enabledBoards: [] as string[],
+  downloadedScopeKeys: undefined as string[] | undefined,
+}));
+
+vi.mock('expo-sqlite', () => ({ useSQLiteContext: () => ({}) }));
+vi.mock('@tanstack/react-query', () => ({ useQuery: () => ({ data: state.downloadedScopeKeys }) }));
+vi.mock('@boardsesh/offline-sync', () => ({ getDownloadedScopeKeys: vi.fn(async () => []) }));
+vi.mock('../../hooks/use-is-offline', () => ({ useIsOffline: () => state.isOffline }));
+vi.mock('../../settings', () => ({
+  rememberOfflineBoards: (boards: unknown) => rememberOfflineBoardsMock(boards),
+  useSetting: () => [state.enabledBoards, vi.fn()],
+  offlineBoardKeyForBoard: (input: { boardType: string; layoutId: number; sizeId: number }) =>
+    `${input.boardType}:${input.layoutId}:${input.sizeId}`,
+}));
+
+const { useRememberDownloadedBoards } = await import('../use-remember-downloaded-boards');
+
+const board = (overrides: Partial<UserBoard> & { uuid: string; name: string }): UserBoard =>
+  ({
+    boardType: 'kilter',
+    layoutId: 8,
+    sizeId: 17,
+    setIds: '20,21',
+    angle: 40,
+    ...overrides,
+  }) as unknown as UserBoard;
+
+const garage = board({ uuid: 'garage', name: 'Marco garage' });
+const tension = board({ uuid: 'tension', name: 'Tension wall', boardType: 'tension', layoutId: 12, sizeId: 3 });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.isOffline = false;
+  state.enabledBoards = [];
+  state.downloadedScopeKeys = undefined;
+});
+
+describe('useRememberDownloadedBoards', () => {
+  it('remembers only the boards whose scope is enabled or already downloaded', () => {
+    state.enabledBoards = ['kilter:8:17'];
+
+    renderHook(() => useRememberDownloadedBoards([garage, tension]));
+
+    expect(rememberOfflineBoardsMock).toHaveBeenCalledTimes(1);
+    expect((rememberOfflineBoardsMock.mock.calls[0]?.[0] as UserBoard[]).map((entry) => entry.uuid)).toEqual([
+      'garage',
+    ]);
+  });
+
+  it('backfills a board that was downloaded before snapshots existed', () => {
+    // Nothing in syncEnabledBoards for this scope, but the data is on disk — this is
+    // the pre-fix-build upgrade path.
+    state.downloadedScopeKeys = ['tension:12:3'];
+
+    renderHook(() => useRememberDownloadedBoards([garage, tension]));
+
+    expect((rememberOfflineBoardsMock.mock.calls[0]?.[0] as UserBoard[]).map((entry) => entry.uuid)).toEqual([
+      'tension',
+    ]);
+  });
+
+  it('does nothing while offline — the live list is stale or absent', () => {
+    state.isOffline = true;
+    state.enabledBoards = ['kilter:8:17'];
+
+    renderHook(() => useRememberDownloadedBoards([garage]));
+
+    expect(rememberOfflineBoardsMock).not.toHaveBeenCalled();
+  });
+
+  it('does nothing before the board list resolves', () => {
+    state.enabledBoards = ['kilter:8:17'];
+
+    renderHook(() => useRememberDownloadedBoards(undefined));
+
+    expect(rememberOfflineBoardsMock).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no scope is enabled or downloaded', () => {
+    renderHook(() => useRememberDownloadedBoards([garage, tension]));
+
+    expect(rememberOfflineBoardsMock).not.toHaveBeenCalled();
+  });
+
+  it('does not re-run on a re-render with the same inputs', () => {
+    state.enabledBoards = ['kilter:8:17'];
+    const boards = [garage];
+
+    const { rerender } = renderHook(() => useRememberDownloadedBoards(boards));
+    rerender();
+    rerender();
+
+    // The effect deps must stay stable, or every myBoards refetch would churn the
+    // settings store (and with it every useSetting consumer app-wide).
+    expect(rememberOfflineBoardsMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mobile/src/offline/__tests__/use-remember-downloaded-boards.test.tsx
+++ b/packages/mobile/src/offline/__tests__/use-remember-downloaded-boards.test.tsx
@@ -1,22 +1,20 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
-import type { UserBoard } from '@boardsesh/shared-schema';
+import type { UserBoard, UserBoardConnection } from '@boardsesh/shared-schema';
 
 const rememberOfflineBoardsMock = vi.hoisted(() => vi.fn());
+const pruneOfflineBoardsMock = vi.hoisted(() => vi.fn());
 
 const state = vi.hoisted(() => ({
   isOffline: false,
   enabledBoards: [] as string[],
-  downloadedScopeKeys: undefined as string[] | undefined,
 }));
 
-vi.mock('expo-sqlite', () => ({ useSQLiteContext: () => ({}) }));
-vi.mock('@tanstack/react-query', () => ({ useQuery: () => ({ data: state.downloadedScopeKeys }) }));
-vi.mock('@boardsesh/offline-sync', () => ({ getDownloadedScopeKeys: vi.fn(async () => []) }));
 vi.mock('../../hooks/use-is-offline', () => ({ useIsOffline: () => state.isOffline }));
 vi.mock('../../settings', () => ({
   rememberOfflineBoards: (boards: unknown) => rememberOfflineBoardsMock(boards),
+  pruneOfflineBoards: (uuids: unknown) => pruneOfflineBoardsMock(uuids),
   useSetting: () => [state.enabledBoards, vi.fn()],
   offlineBoardKeyForBoard: (input: { boardType: string; layoutId: number; sizeId: number }) =>
     `${input.boardType}:${input.layoutId}:${input.sizeId}`,
@@ -34,47 +32,85 @@ const board = (overrides: Partial<UserBoard> & { uuid: string; name: string }): 
     ...overrides,
   }) as unknown as UserBoard;
 
+const connection = (boards: UserBoard[], hasMore = false): UserBoardConnection => ({
+  boards,
+  totalCount: boards.length,
+  hasMore,
+});
+
 const garage = board({ uuid: 'garage', name: 'Marco garage' });
 const tension = board({ uuid: 'tension', name: 'Tension wall', boardType: 'tension', layoutId: 12, sizeId: 3 });
+
+const rememberedUuids = () => (rememberOfflineBoardsMock.mock.calls[0]?.[0] as UserBoard[]).map((entry) => entry.uuid);
 
 beforeEach(() => {
   vi.clearAllMocks();
   state.isOffline = false;
   state.enabledBoards = [];
-  state.downloadedScopeKeys = undefined;
 });
 
 describe('useRememberDownloadedBoards', () => {
-  it('remembers only the boards whose scope is enabled or already downloaded', () => {
+  it('remembers only the boards whose scope is enabled for offline', () => {
     state.enabledBoards = ['kilter:8:17'];
 
-    renderHook(() => useRememberDownloadedBoards([garage, tension]));
+    renderHook(() => useRememberDownloadedBoards(connection([garage, tension])));
 
     expect(rememberOfflineBoardsMock).toHaveBeenCalledTimes(1);
-    expect((rememberOfflineBoardsMock.mock.calls[0]?.[0] as UserBoard[]).map((entry) => entry.uuid)).toEqual([
-      'garage',
-    ]);
+    expect(rememberedUuids()).toEqual(['garage']);
   });
 
-  it('backfills a board that was downloaded before snapshots existed', () => {
-    // Nothing in syncEnabledBoards for this scope, but the data is on disk — this is
-    // the pre-fix-build upgrade path.
-    state.downloadedScopeKeys = ['tension:12:3'];
+  it('backfills a board downloaded before snapshots existed', () => {
+    // The pre-fix-build upgrade path: the download predates this feature, so there is
+    // no card — but enabling is the only way to download, so the scope is still listed.
+    state.enabledBoards = ['tension:12:3'];
 
-    renderHook(() => useRememberDownloadedBoards([garage, tension]));
+    renderHook(() => useRememberDownloadedBoards(connection([garage, tension])));
 
-    expect((rememberOfflineBoardsMock.mock.calls[0]?.[0] as UserBoard[]).map((entry) => entry.uuid)).toEqual([
-      'tension',
-    ]);
+    expect(rememberedUuids()).toEqual(['tension']);
+  });
+
+  it('does not re-remember a board whose offline toggle was just turned off', () => {
+    // Turning "Available offline" off drops the scope from syncEnabledBoards but
+    // deliberately leaves the rows and checkpoint on disk so re-enabling resumes
+    // instantly. Keying the refresh off "downloaded" instead of "enabled" would write
+    // the card straight back and undo the forget two lines earlier in manage.tsx.
+    state.enabledBoards = [];
+
+    renderHook(() => useRememberDownloadedBoards(connection([garage])));
+
+    // `rememberOfflineBoards` is add-only and ignores an empty list, so what matters is
+    // that the board is not in it.
+    expect(rememberedUuids()).toEqual([]);
+  });
+
+  it('prunes cards for boards the server no longer lists', () => {
+    state.enabledBoards = ['kilter:8:17'];
+
+    renderHook(() => useRememberDownloadedBoards(connection([garage])));
+
+    // Deleted / unfollowed on another device: nothing local fires, so the complete
+    // list is the only signal that the board is gone.
+    expect(pruneOfflineBoardsMock).toHaveBeenCalledWith(['garage']);
+  });
+
+  it('never prunes from a truncated page', () => {
+    // myBoards pages at 20; pruning on the first page would delete every card past it.
+    state.enabledBoards = ['kilter:8:17'];
+
+    renderHook(() => useRememberDownloadedBoards(connection([garage], true)));
+
+    expect(rememberOfflineBoardsMock).toHaveBeenCalledTimes(1);
+    expect(pruneOfflineBoardsMock).not.toHaveBeenCalled();
   });
 
   it('does nothing while offline — the live list is stale or absent', () => {
     state.isOffline = true;
     state.enabledBoards = ['kilter:8:17'];
 
-    renderHook(() => useRememberDownloadedBoards([garage]));
+    renderHook(() => useRememberDownloadedBoards(connection([garage])));
 
     expect(rememberOfflineBoardsMock).not.toHaveBeenCalled();
+    expect(pruneOfflineBoardsMock).not.toHaveBeenCalled();
   });
 
   it('does nothing before the board list resolves', () => {
@@ -83,24 +119,20 @@ describe('useRememberDownloadedBoards', () => {
     renderHook(() => useRememberDownloadedBoards(undefined));
 
     expect(rememberOfflineBoardsMock).not.toHaveBeenCalled();
-  });
-
-  it('does nothing when no scope is enabled or downloaded', () => {
-    renderHook(() => useRememberDownloadedBoards([garage, tension]));
-
-    expect(rememberOfflineBoardsMock).not.toHaveBeenCalled();
+    expect(pruneOfflineBoardsMock).not.toHaveBeenCalled();
   });
 
   it('does not re-run on a re-render with the same inputs', () => {
     state.enabledBoards = ['kilter:8:17'];
-    const boards = [garage];
+    const stable = connection([garage]);
 
-    const { rerender } = renderHook(() => useRememberDownloadedBoards(boards));
+    const { rerender } = renderHook(() => useRememberDownloadedBoards(stable));
     rerender();
     rerender();
 
     // The effect deps must stay stable, or every myBoards refetch would churn the
     // settings store (and with it every useSetting consumer app-wide).
     expect(rememberOfflineBoardsMock).toHaveBeenCalledTimes(1);
+    expect(pruneOfflineBoardsMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mobile/src/offline/remove-offline-board.ts
+++ b/packages/mobile/src/offline/remove-offline-board.ts
@@ -17,7 +17,7 @@ import {
   type OfflineDatabase,
   type ScopeTeardownResult,
 } from '@boardsesh/offline-sync';
-import { getSetting, setOfflineBoardEnabled } from '../settings';
+import { getSetting, setOfflineBoardEnabled, forgetOfflineBoardScope } from '../settings';
 import { reportHandledError } from '../lib/error-reporting';
 
 /** The query keys that read board reference rows, derived from the tables we delete from. */
@@ -77,6 +77,9 @@ export async function removeOfflineBoard(params: {
   const { db, queryClient, scope } = params;
 
   setOfflineBoardEnabled(scope, false);
+  // The offline picker's snapshots for this scope go with the data. Left behind,
+  // they'd offer a board whose climbs have just been deleted.
+  forgetOfflineBoardScope(scope);
   beginLocalPurge();
 
   const retainedScopes = getSetting('syncEnabledBoards')

--- a/packages/mobile/src/offline/use-board-downloads.ts
+++ b/packages/mobile/src/offline/use-board-downloads.ts
@@ -3,7 +3,7 @@ import { useSQLiteContext } from 'expo-sqlite';
 import { useQueryClient } from '@tanstack/react-query';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import type { GraphQLFetch } from '@boardsesh/offline-sync';
-import { getSetting, setOfflineBoardEnabled, offlineBoardScopeForBoard } from '../settings';
+import { getSetting, setOfflineBoardEnabled, offlineBoardScopeForBoard, rememberOfflineBoards } from '../settings';
 import { getHttpClient } from '../lib/graphql/client';
 import { setSyncProgress } from '../sync';
 import { triggerSync, drainMutationQueue } from './offline-sync-adapter';
@@ -41,6 +41,12 @@ export function useBoardDownloads() {
       for (const board of list) {
         setOfflineBoardEnabled(offlineBoardScopeForBoard(board), true);
       }
+      // Snapshot the board identities while we hold them. This is the single funnel
+      // for every offline enable (the My Boards toggle, adopt-found-board, the
+      // "download all" settings toggle), so the offline picker gets its rows without
+      // any caller having to remember to persist them. A scope key alone can't name
+      // a board — see settings/offline-boards.ts.
+      rememberOfflineBoards(list);
       triggerSync(db, queryClient, graphqlFetch, () => getSetting('syncEnabledBoards'), drainQueue, {
         onProgress: setSyncProgress,
         snapshotSource,

--- a/packages/mobile/src/offline/use-remember-downloaded-boards.ts
+++ b/packages/mobile/src/offline/use-remember-downloaded-boards.ts
@@ -1,50 +1,49 @@
 import { useEffect } from 'react';
-import { useSQLiteContext } from 'expo-sqlite';
-import { useQuery } from '@tanstack/react-query';
-import { getDownloadedScopeKeys } from '@boardsesh/offline-sync';
-import type { UserBoard } from '@boardsesh/shared-schema';
-import { rememberOfflineBoards, useSetting, offlineBoardKeyForBoard } from '../settings';
+import type { UserBoardConnection } from '@boardsesh/shared-schema';
+import { rememberOfflineBoards, pruneOfflineBoards, useSetting, offlineBoardKeyForBoard } from '../settings';
 import { useIsOffline } from '../hooks/use-is-offline';
 
 /**
- * Keep the offline picker's board snapshots fresh whenever `myBoards` resolves
- * online.
+ * Keep the offline picker's board snapshots in step with the live `myBoards` list.
  *
  * `useBoardDownloads` snapshots a board at the moment offline is enabled, which
- * covers every new download. This hook covers the two gaps that leaves:
+ * covers every new download. This hook covers the three gaps that leaves:
  *
  * - a board renamed or reconfigured on another device would otherwise show its old
  *   name offline forever;
  * - a board downloaded on a build that predates this feature has no snapshot at all,
- *   and is backfilled here the first time the app is online.
+ *   and is backfilled the next time this screen is open online;
+ * - a board deleted or unfollowed on ANOTHER device would keep its card forever —
+ *   nothing local ever fires for it — so a complete server list also prunes.
  *
- * Only boards whose scope is enabled or already downloaded are remembered — the
- * picker must not offer a board whose climbs aren't on disk, and there is no reason
- * to persist the rest of `myBoards`.
+ * Only boards whose scope is in `syncEnabledBoards` are remembered. Deliberately not
+ * "or already downloaded": a plain "Available offline" toggle-off leaves the rows and
+ * checkpoint on disk so re-enabling resumes instantly, so the scope stays downloaded
+ * and this hook would re-remember the board the toggle just forgot. Enabled is also
+ * sufficient for the pre-fix backfill — enabling is the only way to download.
  *
- * Not gated on the offline-downloads flag: this reads data already on disk and one
- * setting, and a flag flipped off must not strand a device that has downloads.
+ * Not gated on the offline-downloads flag: this reads one setting, and a flag flipped
+ * off must not strand a device that has downloads.
  */
-export function useRememberDownloadedBoards(boards: readonly UserBoard[] | undefined): void {
+export function useRememberDownloadedBoards(connection: UserBoardConnection | undefined): void {
   const isOffline = useIsOffline();
-  const db = useSQLiteContext();
   const [enabledBoards] = useSetting('syncEnabledBoards');
-  // Shares the ['downloadedScopeKeys'] cache entry My Boards and the Storage screen
-  // already populate, so this is at most one extra indexed read per session.
-  const { data: downloadedScopeKeys } = useQuery({
-    queryKey: ['downloadedScopeKeys'],
-    queryFn: () => getDownloadedScopeKeys(db),
-  });
+  const boards = connection?.boards;
+  // Absent connection → assume incomplete, so the prune below can never run on a
+  // list we have no reason to trust.
+  const hasMore = connection?.hasMore ?? true;
 
   useEffect(() => {
     // Offline, `boards` is either stale or absent — refreshing from it would either
     // no-op or overwrite good snapshots with older ones.
     if (isOffline || !boards) return;
-    const scopesToRemember = new Set([...enabledBoards, ...(downloadedScopeKeys ?? [])]);
-    if (scopesToRemember.size === 0) return;
-    const downloadedBoards = boards.filter((board) => scopesToRemember.has(offlineBoardKeyForBoard(board)));
+    const enabledScopes = new Set(enabledBoards);
+    const downloadedBoards = boards.filter((board) => enabledScopes.has(offlineBoardKeyForBoard(board)));
     // `rememberOfflineBoards` skips the write when nothing changed, which is what
     // keeps this effect from churning every `useSetting` consumer on each refetch.
     rememberOfflineBoards(downloadedBoards);
-  }, [isOffline, boards, enabledBoards, downloadedScopeKeys]);
+    // Only a COMPLETE list can say a board is gone. `myBoards` pages at 20, so a
+    // truncated first page would otherwise delete every card past it.
+    if (!hasMore) pruneOfflineBoards(boards.map((board) => board.uuid));
+  }, [isOffline, boards, hasMore, enabledBoards]);
 }

--- a/packages/mobile/src/offline/use-remember-downloaded-boards.ts
+++ b/packages/mobile/src/offline/use-remember-downloaded-boards.ts
@@ -1,0 +1,50 @@
+import { useEffect } from 'react';
+import { useSQLiteContext } from 'expo-sqlite';
+import { useQuery } from '@tanstack/react-query';
+import { getDownloadedScopeKeys } from '@boardsesh/offline-sync';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { rememberOfflineBoards, useSetting, offlineBoardKeyForBoard } from '../settings';
+import { useIsOffline } from '../hooks/use-is-offline';
+
+/**
+ * Keep the offline picker's board snapshots fresh whenever `myBoards` resolves
+ * online.
+ *
+ * `useBoardDownloads` snapshots a board at the moment offline is enabled, which
+ * covers every new download. This hook covers the two gaps that leaves:
+ *
+ * - a board renamed or reconfigured on another device would otherwise show its old
+ *   name offline forever;
+ * - a board downloaded on a build that predates this feature has no snapshot at all,
+ *   and is backfilled here the first time the app is online.
+ *
+ * Only boards whose scope is enabled or already downloaded are remembered — the
+ * picker must not offer a board whose climbs aren't on disk, and there is no reason
+ * to persist the rest of `myBoards`.
+ *
+ * Not gated on the offline-downloads flag: this reads data already on disk and one
+ * setting, and a flag flipped off must not strand a device that has downloads.
+ */
+export function useRememberDownloadedBoards(boards: readonly UserBoard[] | undefined): void {
+  const isOffline = useIsOffline();
+  const db = useSQLiteContext();
+  const [enabledBoards] = useSetting('syncEnabledBoards');
+  // Shares the ['downloadedScopeKeys'] cache entry My Boards and the Storage screen
+  // already populate, so this is at most one extra indexed read per session.
+  const { data: downloadedScopeKeys } = useQuery({
+    queryKey: ['downloadedScopeKeys'],
+    queryFn: () => getDownloadedScopeKeys(db),
+  });
+
+  useEffect(() => {
+    // Offline, `boards` is either stale or absent — refreshing from it would either
+    // no-op or overwrite good snapshots with older ones.
+    if (isOffline || !boards) return;
+    const scopesToRemember = new Set([...enabledBoards, ...(downloadedScopeKeys ?? [])]);
+    if (scopesToRemember.size === 0) return;
+    const downloadedBoards = boards.filter((board) => scopesToRemember.has(offlineBoardKeyForBoard(board)));
+    // `rememberOfflineBoards` skips the write when nothing changed, which is what
+    // keeps this effect from churning every `useSetting` consumer on each refetch.
+    rememberOfflineBoards(downloadedBoards);
+  }, [isOffline, boards, enabledBoards, downloadedScopeKeys]);
+}

--- a/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
@@ -260,8 +260,11 @@ vi.mock('../../notifications', () => ({
 // The provider clears the per-user offline-boards setting on sign-out. Stub the
 // settings barrel so the test's static graph never pulls react-native-mmkv (→ the
 // react-native Flow entry, which Rolldown's collection scan can't parse under RN 0.86).
+const setSettingMock = vi.hoisted(() => vi.fn());
+const clearOfflineBoardsMock = vi.hoisted(() => vi.fn());
 vi.mock('../../settings', () => ({
-  setSetting: vi.fn(),
+  setSetting: (...args: unknown[]) => setSettingMock(...args),
+  clearOfflineBoards: () => clearOfflineBoardsMock(),
 }));
 
 // The provider registers its forced-sign-out cleanup against this lib-layer hook
@@ -330,6 +333,8 @@ describe('AuthProvider.signOut', () => {
     disposeWsClientMock.mockReset();
     reportErrorMock.mockReset();
     redirectMock.mockReset();
+    setSettingMock.mockReset();
+    clearOfflineBoardsMock.mockReset();
     // Default: a signed-in session whose token is fresh, so checkAuth flips
     // isAuthenticated to true without taking the refresh branch.
     getAuthTokenMock.mockResolvedValue('jwt-token');
@@ -399,6 +404,11 @@ describe('AuthProvider.signOut', () => {
     expect(clearSessionCommentDraftMock).not.toHaveBeenCalled();
     expect(resetHttpClientMock).toHaveBeenCalledTimes(1);
     expect(disposeWsClientMock).toHaveBeenCalledTimes(1);
+    // Shared-device privacy: the per-user offline selection AND the board snapshots
+    // the offline picker replays (which carry board NAMES) must not survive into the
+    // next account. Asserted, not left to code review.
+    expect(setSettingMock).toHaveBeenCalledWith('syncEnabledBoards', []);
+    expect(clearOfflineBoardsMock).toHaveBeenCalledTimes(1);
     // Active board cache was wiped — both the targeted removeQueries and the
     // subsequent clear() do this; verifying the end state is enough.
     expect(queryClient.getQueryData(['activeBoard'])).toBeUndefined();

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -34,7 +34,7 @@ import { clearSessionCommentDraft } from '../lib/session-comment-draft-store';
 import { setCurrentUserStorageOwner, type UserStorageOwner } from '../lib/user-storage-owner';
 import { ACTIVE_BOARD_QUERY_KEY } from '../lib/graphql/use-active-board';
 import { clearUserData, getDatabaseHandle } from '../db';
-import { setSetting } from '../settings';
+import { setSetting, clearOfflineBoards } from '../settings';
 import { getPendingCount, setSigningOut } from '@boardsesh/offline-sync';
 import { drainMutationQueue } from '../offline/offline-sync-adapter';
 import { stopTokenManagement } from '../notifications';
@@ -224,6 +224,10 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
       // rows + checkpoints survive (clearUserData preserves them), so if the next user
       // enables the same board the download resumes instantly.
       setSetting('syncEnabledBoards', []);
+      // ...and the board snapshots the offline picker replays. These carry the
+      // previous account's board NAMES, so on a shared device a missed clear would
+      // show one user's walls in the next user's picker.
+      clearOfflineBoards();
       // Drop the in-memory active-board cache too. It's `staleTime: Infinity`, so
       // without this the next user to sign in on a shared device would inherit the
       // previous user's board until a manual switch.

--- a/packages/mobile/src/settings/__tests__/offline-boards.test.ts
+++ b/packages/mobile/src/settings/__tests__/offline-boards.test.ts
@@ -164,6 +164,26 @@ describe('offline board snapshots', () => {
     expect(getOfflineBoards()).toEqual([]);
   });
 
+  it('clears a corrupt stored value even though it reads as empty', () => {
+    // The early-out must read the raw bytes, not the shape-guarded view: a card that
+    // fails the guard still carries the previous account's board name on disk.
+    mockStorage.set('offlineBoardsV1', '[{"uuid":"a","name":"Someone else\'s wall"}]');
+    setSpy.mockClear();
+
+    clearOfflineBoards();
+
+    expect(setSpy).toHaveBeenCalled();
+    expect(mockStorage.get('offlineBoardsV1')).toBe('[]');
+  });
+
+  it('does not write when there is nothing to clear', () => {
+    clearOfflineBoards();
+    setSpy.mockClear();
+
+    clearOfflineBoards();
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
   it('reads a corrupt or non-array stored value as empty rather than throwing', () => {
     mockStorage.set('offlineBoardsV1', '{"not":"an array"}');
     expect(getOfflineBoards()).toEqual([]);

--- a/packages/mobile/src/settings/__tests__/offline-boards.test.ts
+++ b/packages/mobile/src/settings/__tests__/offline-boards.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+const mockStorage = new Map<string, string>();
+const setSpy = vi.fn();
+
+vi.mock('react-native-mmkv', () => {
+  const createMockInstance = () => ({
+    getString(key: string) {
+      return mockStorage.get(key);
+    },
+    set(key: string, value: string) {
+      setSpy(key, value);
+      mockStorage.set(key, value);
+    },
+    remove(key: string) {
+      mockStorage.delete(key);
+    },
+    clearAll() {
+      mockStorage.clear();
+    },
+  });
+  return { createMMKV: vi.fn(() => createMockInstance()) };
+});
+
+import {
+  getOfflineBoards,
+  rememberOfflineBoards,
+  forgetOfflineBoardScope,
+  clearOfflineBoards,
+} from '../offline-boards';
+import { resetAllSettings } from '../hooks';
+
+const board = (overrides: Partial<UserBoard> & { uuid: string; name: string }): UserBoard =>
+  ({
+    boardType: 'kilter',
+    layoutId: 8,
+    sizeId: 17,
+    setIds: '20,21',
+    angle: 40,
+    ...overrides,
+  }) as unknown as UserBoard;
+
+describe('offline board snapshots', () => {
+  beforeEach(() => {
+    mockStorage.clear();
+    resetAllSettings();
+    setSpy.mockClear();
+  });
+
+  it('starts empty', () => {
+    expect(getOfflineBoards()).toEqual([]);
+  });
+
+  it('upserts by uuid, most-recent-first, without duplicating a re-enabled board', () => {
+    rememberOfflineBoards([board({ uuid: 'a', name: 'Garage' })]);
+    rememberOfflineBoards([board({ uuid: 'b', name: 'Gym' })]);
+    rememberOfflineBoards([board({ uuid: 'a', name: 'Garage renamed' })]);
+
+    expect(getOfflineBoards().map((card) => [card.uuid, card.name])).toEqual([
+      ['a', 'Garage renamed'],
+      ['b', 'Gym'],
+    ]);
+  });
+
+  it('does not write when the remembered list is unchanged', () => {
+    const boards = [board({ uuid: 'a', name: 'Garage' }), board({ uuid: 'b', name: 'Gym' })];
+    rememberOfflineBoards(boards);
+    setSpy.mockClear();
+
+    // Every settings write calls emitChange(), which re-renders every useSetting
+    // consumer app-wide. The online refresh hook runs on each myBoards success, so a
+    // no-op refresh must not touch storage.
+    rememberOfflineBoards(boards);
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it('caps the remembered list at 20 boards, keeping the most recent', () => {
+    for (let index = 0; index < 25; index += 1) {
+      rememberOfflineBoards([board({ uuid: `b${index}`, name: `Board ${index}` })]);
+    }
+    const cards = getOfflineBoards();
+    expect(cards).toHaveLength(20);
+    expect(cards[0]?.uuid).toBe('b24');
+    expect(cards.at(-1)?.uuid).toBe('b5');
+  });
+
+  it('ignores boards that fail the shape guard', () => {
+    rememberOfflineBoards([
+      board({ uuid: 'ok', name: 'Fine' }),
+      { uuid: 'bad', name: 'No layout', boardType: 'kilter', setIds: '20', angle: 40 } as unknown as UserBoard,
+    ]);
+    expect(getOfflineBoards().map((card) => card.uuid)).toEqual(['ok']);
+  });
+
+  it('forgets BOTH boards that share the scope being turned off', () => {
+    // The download is per scope, so disabling one of two same-layout boards removes
+    // the data behind both — leaving the sibling would offer a board with no climbs.
+    rememberOfflineBoards([
+      board({ uuid: 'garage', name: 'Garage' }),
+      board({ uuid: 'gym', name: 'Gym' }),
+      board({ uuid: 'tension', name: 'Tension', boardType: 'tension', layoutId: 12, sizeId: 3 }),
+    ]);
+
+    forgetOfflineBoardScope({ boardType: 'kilter', layoutId: 8, sizeId: 17 });
+
+    expect(getOfflineBoards().map((card) => card.uuid)).toEqual(['tension']);
+  });
+
+  it('does not write when the scope being forgotten has no cards', () => {
+    rememberOfflineBoards([board({ uuid: 'garage', name: 'Garage' })]);
+    setSpy.mockClear();
+
+    forgetOfflineBoardScope({ boardType: 'tension', layoutId: 12, sizeId: 3 });
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it('clears every card', () => {
+    rememberOfflineBoards([board({ uuid: 'a', name: 'A' }), board({ uuid: 'b', name: 'B' })]);
+    clearOfflineBoards();
+    expect(getOfflineBoards()).toEqual([]);
+  });
+
+  it('reads a corrupt or non-array stored value as empty rather than throwing', () => {
+    mockStorage.set('offlineBoardsV1', '{"not":"an array"}');
+    expect(getOfflineBoards()).toEqual([]);
+
+    mockStorage.set('offlineBoardsV1', 'not json at all');
+    expect(getOfflineBoards()).toEqual([]);
+  });
+});

--- a/packages/mobile/src/settings/__tests__/offline-boards.test.ts
+++ b/packages/mobile/src/settings/__tests__/offline-boards.test.ts
@@ -26,7 +26,9 @@ vi.mock('react-native-mmkv', () => {
 import {
   getOfflineBoards,
   rememberOfflineBoards,
+  forgetOfflineBoard,
   forgetOfflineBoardScope,
+  pruneOfflineBoards,
   clearOfflineBoards,
 } from '../offline-boards';
 import { resetAllSettings } from '../hooks';
@@ -112,6 +114,47 @@ describe('offline board snapshots', () => {
     setSpy.mockClear();
 
     forgetOfflineBoardScope({ boardType: 'tension', layoutId: 12, sizeId: 3 });
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it('forgets one board by uuid, leaving its scope sibling alone', () => {
+    // Delete / unfollow is per board, not per scope: "Marco's garage" and "Gym wall"
+    // can share one Kilter Original 12x12 download, and unfollowing one must not take
+    // the other off the offline picker.
+    rememberOfflineBoards([board({ uuid: 'garage', name: 'Garage' }), board({ uuid: 'gym', name: 'Gym' })]);
+
+    forgetOfflineBoard('gym');
+
+    expect(getOfflineBoards().map((card) => card.uuid)).toEqual(['garage']);
+  });
+
+  it('does not write when the uuid being forgotten has no card', () => {
+    rememberOfflineBoards([board({ uuid: 'garage', name: 'Garage' })]);
+    setSpy.mockClear();
+
+    forgetOfflineBoard('never-stored');
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it('prunes cards absent from a complete server list', () => {
+    // The board was deleted or unfollowed on another device, so no local call ever
+    // fires for it — without this it would sit in the picker forever and hand a dead
+    // uuid to setActiveBoard.
+    rememberOfflineBoards([
+      board({ uuid: 'garage', name: 'Garage' }),
+      board({ uuid: 'gone', name: 'Unfollowed elsewhere' }),
+    ]);
+
+    pruneOfflineBoards(['garage', 'some-board-with-no-card']);
+
+    expect(getOfflineBoards().map((card) => card.uuid)).toEqual(['garage']);
+  });
+
+  it('does not write when every card is still on the server list', () => {
+    rememberOfflineBoards([board({ uuid: 'garage', name: 'Garage' })]);
+    setSpy.mockClear();
+
+    pruneOfflineBoards(['garage', 'gym']);
     expect(setSpy).not.toHaveBeenCalled();
   });
 

--- a/packages/mobile/src/settings/defaults.ts
+++ b/packages/mobile/src/settings/defaults.ts
@@ -3,6 +3,7 @@ import type { AppSettings } from './types';
 export const DEFAULT_SETTINGS: AppSettings = {
   defaultBoardUuid: null,
   syncEnabledBoards: [],
+  offlineBoardsV1: [],
   autoOfflineBoards: false,
   autoConnectBle: true,
   keepScreenAwake: true,

--- a/packages/mobile/src/settings/index.ts
+++ b/packages/mobile/src/settings/index.ts
@@ -14,6 +14,8 @@ export {
   getOfflineBoards,
   useOfflineBoards,
   rememberOfflineBoards,
+  forgetOfflineBoard,
   forgetOfflineBoardScope,
+  pruneOfflineBoards,
   clearOfflineBoards,
 } from './offline-boards';

--- a/packages/mobile/src/settings/index.ts
+++ b/packages/mobile/src/settings/index.ts
@@ -10,3 +10,10 @@ export {
   type OfflineBoardLike,
 } from '@boardsesh/offline-sync';
 export { isOfflineBoardEnabled, setOfflineBoardEnabled, useOfflineBoardEnabled } from './use-offline-board';
+export {
+  getOfflineBoards,
+  useOfflineBoards,
+  rememberOfflineBoards,
+  forgetOfflineBoardScope,
+  clearOfflineBoards,
+} from './offline-boards';

--- a/packages/mobile/src/settings/offline-boards.ts
+++ b/packages/mobile/src/settings/offline-boards.ts
@@ -60,6 +60,9 @@ export function useOfflineBoards(): UserBoard[] {
  */
 export function rememberOfflineBoards(boards: readonly UserBoard[]): void {
   const incoming = boards.filter(isOfflineBoardCard);
+  // Nothing usable to add: this is an ADD-only call, so it never empties the list.
+  // Forgetting is `forgetOfflineBoardScope` (per scope) or `clearOfflineBoards` (all),
+  // which keeps a refetch that momentarily returns nothing from wiping the picker.
   if (incoming.length === 0) return;
   const current = getOfflineBoards();
   const incomingUuids = new Set(incoming.map((board) => board.uuid));

--- a/packages/mobile/src/settings/offline-boards.ts
+++ b/packages/mobile/src/settings/offline-boards.ts
@@ -87,6 +87,33 @@ export function forgetOfflineBoardScope(scope: OfflineBoardScope): void {
   setSetting(SETTING_KEY, next);
 }
 
+/** Forget one board by `uuid`. Used when the server no longer has it (delete, unfollow). */
+export function forgetOfflineBoard(uuid: string): void {
+  const current = getOfflineBoards();
+  const next = current.filter((card) => card.uuid !== uuid);
+  if (next.length === current.length) return;
+  setSetting(SETTING_KEY, next);
+}
+
+/**
+ * Drop every card whose board is absent from `knownUuids`.
+ *
+ * Only ever called with a COMPLETE server board list (`myBoards` with `hasMore`
+ * false). Without this, a board deleted or unfollowed on another device keeps its
+ * card forever: nothing else clears it, because a plain toggle-off leaves the
+ * downloaded rows in place and `forgetOfflineBoardScope` is keyed on the scope, not
+ * the board. A dead card is worse than a stale row — activating it writes a `uuid`
+ * the backend no longer knows into `active-board-store`, which is exactly the
+ * board-presence poisoning this feature refuses to risk with synthetic uuids.
+ */
+export function pruneOfflineBoards(knownUuids: readonly string[]): void {
+  const known = new Set(knownUuids);
+  const current = getOfflineBoards();
+  const next = current.filter((card) => known.has(card.uuid));
+  if (next.length === current.length) return;
+  setSetting(SETTING_KEY, next);
+}
+
 /** Drop every card. Used at the sign-out boundary (see `auth-provider`). */
 export function clearOfflineBoards(): void {
   setSetting(SETTING_KEY, []);

--- a/packages/mobile/src/settings/offline-boards.ts
+++ b/packages/mobile/src/settings/offline-boards.ts
@@ -114,7 +114,15 @@ export function pruneOfflineBoards(knownUuids: readonly string[]): void {
   setSetting(SETTING_KEY, next);
 }
 
-/** Drop every card. Used at the sign-out boundary (see `auth-provider`). */
+/**
+ * Drop every card. Used at the sign-out boundary (see `auth-provider`).
+ *
+ * The early-out reads the RAW stored value, not `getOfflineBoards()`: a stored value
+ * that is corrupt or fails the shape guard reads as empty but is still bytes on disk,
+ * and sign-out has to clear those too.
+ */
 export function clearOfflineBoards(): void {
+  const stored = getSetting(SETTING_KEY);
+  if (Array.isArray(stored) && stored.length === 0) return;
   setSetting(SETTING_KEY, []);
 }

--- a/packages/mobile/src/settings/offline-boards.ts
+++ b/packages/mobile/src/settings/offline-boards.ts
@@ -1,0 +1,86 @@
+import { useMemo } from 'react';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { offlineBoardKey, offlineBoardKeyForBoard, type OfflineBoardScope } from '@boardsesh/offline-sync';
+import { getSetting, setSetting, useSetting } from './hooks';
+import { isOfflineBoardCard, readOfflineBoardCards } from '../lib/boards/offline-board-card';
+
+/**
+ * Remembered board identities for the offline picker.
+ *
+ * `syncEnabledBoards` records WHICH SCOPES are downloaded, and that is all it can
+ * record: a scope key is `"boardType:layoutId:sizeId"`, which is shared by every one
+ * of the user's boards on that layout+size ("Marco's garage" and "Gym wall" on the
+ * same Kilter Original 12x12 share ONE download — see `storage-board-label.ts`). It
+ * carries no `uuid`, `name`, `setIds` or `angle`, so it cannot name a board, and
+ * `uuid` in particular is server-issued: `setActiveBoard`, `BoardProvider`, the BLE
+ * wrapper and the board-presence subscription all key on it, so it can never be
+ * synthesised.
+ *
+ * So the board list is snapshotted at the moment offline is enabled — data the app
+ * already holds in hand — and kept as a flat list deduped by `uuid`, not a
+ * scope-keyed map (a map would silently hide one of two boards sharing a scope).
+ *
+ * Reads go through `isOfflineBoardCard`, so a card written by an older build with a
+ * shape `UserBoard` no longer matches is dropped rather than rendered wrong.
+ */
+
+const SETTING_KEY = 'offlineBoardsV1';
+
+/**
+ * Plenty of headroom: the realistic maximum is a handful of boards (a home wall,
+ * a couple of gyms). The cap only exists so a long-lived install can't grow the
+ * MMKV value without bound.
+ */
+const MAX_REMEMBERED_BOARDS = 20;
+
+export function getOfflineBoards(): UserBoard[] {
+  return readOfflineBoardCards(getSetting(SETTING_KEY));
+}
+
+/** Reactive read. Re-renders when boards are remembered or forgotten. */
+export function useOfflineBoards(): UserBoard[] {
+  const [stored] = useSetting(SETTING_KEY);
+  // `useSetting`'s snapshot is reference-stable between writes, so this memo only
+  // re-filters when the stored value actually changed.
+  return useMemo(() => readOfflineBoardCards(stored), [stored]);
+}
+
+/**
+ * Snapshot `boards` so the offline picker can name them. Upserts by `uuid`,
+ * most-recent-first.
+ *
+ * Skips the write when the result is byte-identical to what is already stored:
+ * every settings write calls `emitChange()`, which clears the whole per-key
+ * snapshot cache and re-renders every `useSetting` consumer app-wide. This runs on
+ * each successful `myBoards` fetch, so a no-op refresh must stay a no-op.
+ */
+export function rememberOfflineBoards(boards: readonly UserBoard[]): void {
+  const incoming = boards.filter(isOfflineBoardCard);
+  if (incoming.length === 0) return;
+  const current = getOfflineBoards();
+  const incomingUuids = new Set(incoming.map((board) => board.uuid));
+  const next = [...incoming, ...current.filter((card) => !incomingUuids.has(card.uuid))].slice(
+    0,
+    MAX_REMEMBERED_BOARDS,
+  );
+  if (JSON.stringify(next) === JSON.stringify(current)) return;
+  setSetting(SETTING_KEY, next);
+}
+
+/**
+ * Forget every card in `scope`. Plural by design: a download is per scope, so
+ * turning one off removes the data behind every board sharing it — leaving the
+ * sibling card would offer a board whose climbs are gone.
+ */
+export function forgetOfflineBoardScope(scope: OfflineBoardScope): void {
+  const key = offlineBoardKey(scope);
+  const current = getOfflineBoards();
+  const next = current.filter((card) => offlineBoardKeyForBoard(card) !== key);
+  if (next.length === current.length) return;
+  setSetting(SETTING_KEY, next);
+}
+
+/** Drop every card. Used at the sign-out boundary (see `auth-provider`). */
+export function clearOfflineBoards(): void {
+  setSetting(SETTING_KEY, []);
+}

--- a/packages/mobile/src/settings/offline-boards.ts
+++ b/packages/mobile/src/settings/offline-boards.ts
@@ -53,6 +53,10 @@ export function useOfflineBoards(): UserBoard[] {
  * every settings write calls `emitChange()`, which clears the whole per-key
  * snapshot cache and re-renders every `useSetting` consumer app-wide. This runs on
  * each successful `myBoards` fetch, so a no-op refresh must stay a no-op.
+ *
+ * The comparison is `JSON.stringify`, so it is key-order sensitive. That is the safe
+ * direction to be wrong in: reordered fields on the wire cost one redundant write
+ * (and the stored bytes really did change), never a missed update.
  */
 export function rememberOfflineBoards(boards: readonly UserBoard[]): void {
   const incoming = boards.filter(isOfflineBoardCard);

--- a/packages/mobile/src/settings/types.ts
+++ b/packages/mobile/src/settings/types.ts
@@ -1,6 +1,16 @@
+import type { UserBoard } from '@boardsesh/shared-schema';
+
 export type AppSettings = {
   defaultBoardUuid: string | null;
   syncEnabledBoards: string[];
+  /**
+   * Snapshots of the boards the user made available offline, so the picker can
+   * still name and switch between them with no signal (`myBoards` is network-only
+   * and a scope key can't identify a board — see `settings/offline-boards.ts`).
+   * Versioned key: bump the `V1` suffix if `UserBoard` gains a required field, so
+   * stale cards are ignored rather than misread.
+   */
+  offlineBoardsV1: UserBoard[];
   /** Keep every board the user follows/uses available offline by default. */
   autoOfflineBoards: boolean;
   autoConnectBle: boolean;

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -271,7 +271,10 @@
       "enableTitle": "Download {{name}}?",
       "enableMessage": "Downloads all this board's climbs so you can browse and log sends with no signal.",
       "enableMessageWithSize": "About {{size}}. Downloads all this board's climbs so you can browse and log sends with no signal.",
-      "enableConfirm": "Download"
+      "enableConfirm": "Download",
+      "pickerNotice": "No signal — here are the boards you've downloaded.",
+      "pickerEmptyTitle": "Nothing downloaded yet",
+      "pickerEmptyBody": "Boards you make available offline show up here. Grab one while you have signal."
     }
   },
   "boardEntity": {

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -273,6 +273,7 @@
       "enableMessageWithSize": "About {{size}}. Downloads all this board's climbs so you can browse and log sends with no signal.",
       "enableConfirm": "Download",
       "pickerNotice": "No signal — here are the boards you've downloaded.",
+      "pickerNoticeUnreachable": "Can't reach your boards right now — here are the ones you've downloaded.",
       "pickerEmptyTitle": "Nothing downloaded yet",
       "pickerEmptyBody": "Boards you make available offline show up here. Grab one while you have signal."
     }

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -271,7 +271,10 @@
       "enableTitle": "¿Descargar {{name}}?",
       "enableMessage": "Descarga todas las vías de este plafón para explorarlas y registrar tus ascensos sin conexión.",
       "enableMessageWithSize": "Unos {{size}}. Descarga todas las vías de este plafón para explorarlas y registrar tus ascensos sin conexión.",
-      "enableConfirm": "Descargar"
+      "enableConfirm": "Descargar",
+      "pickerNotice": "Sin conexión: estos son los plafones que has descargado.",
+      "pickerEmptyTitle": "Todavía no has descargado nada",
+      "pickerEmptyBody": "Los plafones que dejes disponibles sin conexión aparecen aquí. Descarga uno cuando tengas conexión."
     }
   },
   "boardEntity": {

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -273,6 +273,7 @@
       "enableMessageWithSize": "Unos {{size}}. Descarga todas las vías de este plafón para explorarlas y registrar tus ascensos sin conexión.",
       "enableConfirm": "Descargar",
       "pickerNotice": "Sin conexión: estos son los plafones que has descargado.",
+      "pickerNoticeUnreachable": "Ahora mismo no podemos cargar tus plafones: estos son los que has descargado.",
       "pickerEmptyTitle": "Todavía no has descargado nada",
       "pickerEmptyBody": "Los plafones que dejes disponibles sin conexión aparecen aquí. Descarga uno cuando tengas conexión."
     }

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -271,7 +271,10 @@
       "enableTitle": "Télécharger {{name}} ?",
       "enableMessage": "Télécharge toutes les voies de cette board pour les parcourir et enregistrer tes croix hors ligne.",
       "enableMessageWithSize": "Environ {{size}}. Télécharge toutes les voies de cette board pour les parcourir et enregistrer tes croix hors ligne.",
-      "enableConfirm": "Télécharger"
+      "enableConfirm": "Télécharger",
+      "pickerNotice": "Pas de réseau — voici les boards que tu as téléchargées.",
+      "pickerEmptyTitle": "Rien de téléchargé pour le moment",
+      "pickerEmptyBody": "Les boards que tu rends disponibles hors ligne apparaissent ici. Télécharge-en une quand tu as du réseau."
     }
   },
   "boardEntity": {

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -273,6 +273,7 @@
       "enableMessageWithSize": "Environ {{size}}. Télécharge toutes les voies de cette board pour les parcourir et enregistrer tes croix hors ligne.",
       "enableConfirm": "Télécharger",
       "pickerNotice": "Pas de réseau — voici les boards que tu as téléchargées.",
+      "pickerNoticeUnreachable": "Impossible de charger tes boards pour l'instant — voici celles que tu as téléchargées.",
       "pickerEmptyTitle": "Rien de téléchargé pour le moment",
       "pickerEmptyBody": "Les boards que tu rends disponibles hors ligne apparaissent ici. Télécharge-en une quand tu as du réseau."
     }


### PR DESCRIPTION
## Premise correction (read this first)

The issue and the recon get three things wrong, and one of them changes the shape of the fix.

**1. It is not a hang.** The recon says the picker "hangs on a network query". It does not. `createQueryClient()` sets `networkMode: 'offlineFirst'`, so offline the fetch runs, fails, and the retryer **pauses** — query-core's `canContinue()` requires `onlineManager.isOnline()` unless the mode is `'always'`. I proved the terminal state against the real `createQueryClient()` with a rejecting `queryFn` and `onlineManager.setOnline(false)`: after ~1s the query settles at `status: 'pending'`, `fetchStatus: 'paused'`, `data: undefined`, `isError: false`, `isLoading: false`. (That was a diagnostic, not a shipped test — it asserts React Query's semantics, not ours.)

So `app/boards/index.tsx` rendered its **"No boards yet — create one" empty state**: a false claim that the user has no boards, whose only CTA also needs the network. That is worse than a spinner, and it means we had to replace an *empty* state, not a *loading* state. The existing `isError` retry screen never appeared offline at all.

**2. `boards/manage.tsx` breaks for a different reason than stated.** The issue says it "leans on the same network board list". It does, but that is not what kills it. The guard is `if ((isError && myBoards.length === 0) || !currentUserId)`, and `useProfile` is a raw `getHttpClient().request` too — so offline `currentUserId` is `undefined` and the screen shows the hard "Something went wrong / Try again" state **regardless of anything done to the board list**. Fixing that screen meant handling the missing profile id, not just the boards.

**3. The "BoardSheet switcher footer" is not a third surface.** `BoardSheet` → `NowOnTheWallPanel.handleSwitchBoard` just calls `onSwitchBoard()`, which navigates to `/boards`. Two broken screens, not three.

And a correction to the design framing: the scope key does not merely *lack* angle/setIds/uuid/name — it **cannot identify a board at all**. `storage-board-label.ts` already documents that one scope key (`boardType:layoutId:sizeId`) is shared by several of the user's boards ("Marco's garage" and "Gym wall" on the same Kilter Original 12x12 share ONE download). Any design that maps scope key → one board is wrong by construction. That is why the store is a flat list deduped by `uuid`, not a map.

## Summary

Closes #3897.

**Persist, not reconstruct.** `uuid` is server-issued and unreconstructible — `setActiveBoard`, `BoardProvider boardUuid`, `bluetooth-provider-wrapper`, and `drawer-host-provider`'s board-presence subscription all key on it, so a synthetic one would subscribe presence to a nonexistent board and could mint a duplicate board on reconnect. `setIds`, `name` and `angle` are user data that `@boardsesh/board-config` cannot know. So board identity is snapshotted from data the app already holds in hand, at the moment offline is enabled, into **one more key in the existing MMKV settings store** (`offlineBoardsV1`, next to `syncEnabledBoards`). No new storage engine, no new lifecycle, no new dependency; MMKV is synchronous, so the offline picker paints its rows with no async flash.

What changed:

- **New settings key + store** (`src/settings/offline-boards.ts`): upsert by `uuid`, most-recent-first, capped at 20 (the realistic maximum is a handful — the cap only stops unbounded growth). Writes are skipped when the result is byte-identical, because every settings write calls `emitChange()` and re-renders every `useSetting` consumer app-wide.
- **Runtime shape guard** (`src/lib/boards/offline-board-card.ts`): every read drops cards that fail it, silently. A `UserBoard` shape change must cost one row, never crash the picker — the hazard `active-board-store.ts`'s header already warns about.
- **Pure row selector** (`src/components/board-discovery/offline-board-items.ts`): candidates = snapshots ∪ warm `myBoards` ∪ active board, deduped by `uuid` freshest-source-wins; only scopes in `getDownloadedScopeKeys()` are offered (the honest "will actually serve climbs" signal, same one My Boards captions "Available offline"), **plus** the active board unconditionally so the board you're standing in front of can't vanish.
- **Write points, all local, no new network call**: the single `enableBoardsOffline` funnel (so the manage toggle, adopt-found-board and "download all" are covered automatically), the toggle-off, removal, delete and unfollow paths, and an online refresh hook that keeps names fresh after an edit on another device, backfills boards downloaded by a pre-fix build, and prunes boards the server no longer lists.
- **Sign-out clears it** next to the existing `syncEnabledBoards` reset — the snapshots carry board **names**, so on a shared device a missed clear would show one account's walls in the next account's picker. Asserted in `auth-provider.test.tsx`, not left to code review.
- **`app/boards/index.tsx`**: offline renders the downloaded boards through the existing `userBoardToItem` + `BoardCarousel`, hides the network-only mode cards and Popular, and replaces both the "No boards yet" empty state and the error screen. `onSelectMyBoard` now resolves from the offline rows too (it previously looked up only `myBoards`/`nearby` — a dead tap). Activation skips `adoptFoundBoard` whenever the rows came from the local snapshots: it is a follow mutation plus a download confirm, so with no usable connection it can only produce a "Could not follow X" error toast on a board the user already has.
- **`app/boards/manage.tsx`**: offline renders a flat, un-headed list with `Edit`, `Create` and swipe unfollow/delete suppressed (all server mutations, via a new `readOnly` prop on `BoardManageRow`). The per-row offline toggle and status caption keep working — both are local. Owned-vs-followed is genuinely unclassifiable without the profile id, so the headers are dropped rather than guessed.
- **The "lying connection" fallback** (`isError` + nothing cached → offline rows) is in, per the ruling: gym wifi with a dead upstream or a captive portal reports online, so retries never pause and the query really errors. When that happens with nothing downloaded, the retry button stays — the escape hatch isn't lost.
- i18n keys in all three locales (Spanish uses **plafón** per the glossary); a section in `docs/offline-sync-plan.md` recording why identity is snapshotted.

Pure JS/TS — no native change, so this ships OTA on the existing fingerprint.

### Deviations from the approved plan

- The shape guard lives in its own pure module (`src/lib/boards/offline-board-card.ts`) rather than inside the settings store, so the selector can use it without importing MMKV. Three files where the plan said two.
- `manage.tsx`'s `['downloadedScopeKeys']` query is no longer gated on the offline-downloads flag. The offline fallback needs it, and a device still holding downloads after a kill-switch rollback must not be stranded — same reasoning `more.tsx` already applies to its ungated copy.
- The offline branch on `manage.tsx` also triggers when the profile settles without an id **online** (e.g. a profile 401 with boards loaded). Today that shows the hard error state; now it shows the downloaded boards read-only. Strictly better, but it is a behaviour change outside the offline path — flagging it explicitly.
- `BoardManageRow` gained a `readOnly` prop. Passing no-op handlers would have left the swipe and the chevron visibly present but dead.

## Review round 2 — three real defects, all fixed

The paired QA reviewer found three should-fix defects. All three were re-derived from the code and confirmed; all three are fixed in this PR, each with a test that fails without the fix.

**1. The adopt guard was on the wrong flag** (`app/boards/index.tsx`). The rows render under `isLocalOnly = isOffline || (isError && myBoards.length === 0)`, but the "don't follow over a dead link" guard read `if (!isOffline)`. On the lying-connection branch — the one ruling 3 asked for — `isOffline` is false, so tapping an offline row still fired `followBoard` and raised exactly the "Could not follow X" toast (plus a Sentry `reportError`) this PR claims to have removed, on a board the user already owns and has downloaded. Now gated on `isLocalOnly`. The lying-connection test asserts `adoptFoundBoard` stays unfired, and a new online case asserts it still *does* fire when the network list is usable, so the guard can't be over-applied either.

**2. The refresh hook undid the toggle-off it was meant to respect** (`src/offline/use-remember-downloaded-boards.ts`). It remembered every board whose scope was in `syncEnabledBoards` **∪ `downloadedScopeKeys`**. Turning "Available offline" off deliberately leaves the rows and checkpoint on disk (so re-enabling resumes instantly), so the scope stays *downloaded*; the effect re-ran the instant the toggle wrote and re-remembered the board `forgetOfflineBoardScope` had dropped two lines earlier in `manage.tsx`. The `downloadedScopeKeys` term was never needed for the stated pre-fix backfill either — enabling is the only way to download, so an old download is by definition still in `syncEnabledBoards`. The union is gone (and with it the hook's extra SQLite query), and the test that encoded the bug as correct behaviour has been rewritten.

**3. Nothing pruned a card for a board that no longer exists** (`src/settings/offline-boards.ts`, `app/boards/manage.tsx`). `rememberOfflineBoards` is add-only, `forgetOfflineBoardScope` is keyed on the scope, and delete/unfollow touched neither `syncEnabledBoards` nor the checkpoint — so an unfollowed board kept its card forever, and activating it would write a `uuid` the backend no longer knows into `active-board-store`, which is the board-presence poisoning this design refuses to risk with synthetic uuids. Two fixes: `forgetOfflineBoard(uuid)` on the delete and unfollow success paths (deterministic, and it leaves a scope sibling alone), and `pruneOfflineBoards()` in the refresh hook for the deleted-on-another-device case. The prune only runs on a **complete** list (`hasMore === false`) — `myBoards` pages at 20, and pruning off a truncated first page would delete every card past it.

Also from that review:

- `BoardManageRow.readOnly` now has real component tests. The manage-screen test only asserted the prop was passed through, and deleting all three `!readOnly` terms inside the component left the suite green. The new cases record the `SwipeableRow` props and assert `onPress`, `enabled` and the chevron are all gone read-only, present otherwise — and that the local offline toggle still works.
- Narrowing an inaccurate claim: the pre-fix backfill needs the user to open the board picker or My Boards **while online**, not merely to launch the app online — the hook is mounted on those two screens only. Corrected in the QA gates below.

## Review-bot follow-ups (round 2)

Both of `claude-review`'s remaining notes are fixed rather than deferred:

- **The "No signal" notice was lying on two branches.** `mobile.offline.pickerNotice` was shown for the offline, lying-connection AND profile-failure paths, but only the first has no signal. New key `mobile.offline.pickerNoticeUnreachable` ("Can't reach your boards right now — here are the ones you've downloaded.") in all three locales, picked on `!isOffline` in both screens, asserted in both screen tests.
- **`clearOfflineBoards` wrote unconditionally.** It now early-outs, but on the RAW stored value rather than `getOfflineBoards()` — a card that fails the shape guard reads as empty and is still the previous account's board name sitting on disk. Both directions are tested.

From the bot's earlier pass, two points that had been left open:

- `remove-offline-board.ts`'s `forgetOfflineBoardScope` call now has a test (remove one of two downloaded scopes, the other scope's card survives).
- `offline-board-items.ts` sorts with `{ sensitivity: 'base' }` so capitalisation doesn't split the list. The locale stays the device's on purpose — a Spanish user should get Spanish collation for their own board names.

## Release Notes

- Switch boards with no signal — the picker now lists the boards you've downloaded instead of claiming you have none.
- My Boards works offline too, so you can see what's downloaded from inside the gym dead zone.
- No more "Could not follow" error when you pick a downloaded board offline.

## Test plan

`vp run typecheck` (full monorepo), `vp check` (0 errors), `vp run test:mobile` → **562 files / 4730 tests passed** (baseline on `main` was 557/4680), `vp test run packages/shared/i18n` (60 catalog-parity tests), `vp run check:mobile-bundle` → OK.

New tests:

- `src/components/board-discovery/__tests__/offline-board-items.test.ts` — pure, literal fixtures with **hardcoded** scope-key strings on the expectation side, deliberately not re-derived with `offlineBoardKeyForBoard` (a test that rebuilds the production expression can only agree with itself — the shape that hid a real `ne`/`eq` inversion in this repo before). Covers: two boards sharing one scope both appear (the regression the whole design turns on), a non-downloaded scope is excluded, the active board is always offered and sorts first, freshest-source-wins, and a malformed legacy card is dropped rather than rendered or thrown on.
- `src/settings/__tests__/offline-boards.test.ts` — upsert by uuid, most-recent-first, the cap, **no write when nothing changed** (asserted on the mocked `storage.set`), forgetting a scope drops both of its cards, forgetting one uuid leaves its scope sibling alone, pruning against a complete server list, corrupt/non-array values read as `[]`.
- `app/boards/__tests__/index-offline.test.tsx` — mocked with the **real** offline shapes (`useMyBoards` → `{ data: undefined, isLoading: false, isError: false }`). Row renders and switches, no adopt/follow mutation offline **or on the lying connection**, adopt still fires online, offline empty state with no "create a board" CTA, the retry escape hatch, and an explicit "online is unchanged" case.
- `app/boards/__tests__/manage-offline.test.tsx` — offline with `useProfile` undefined renders the boards and not the error state, hides Create/Edit/row mutations while the offline toggle still reads `downloaded`, leaves the owned/followed split and Create alone online, and delete/unfollow forget the board's card (but not when the mutation fails).
- `src/offline/__tests__/use-remember-downloaded-boards.test.tsx` — the enabled-scope filter, the pre-fix-build backfill, **no re-remember after a toggle-off**, the prune on a complete list, **no prune on a truncated page**, the offline guard, the unresolved-list guard, and effect-dep stability across re-renders (the settings-churn risk).
- `src/components/board-discovery/__tests__/board-manage-row.test.tsx` — the `readOnly` prop actually removes tap-to-edit, the swipe action and the chevron, and keeps the local offline toggle.
- `auth-provider.test.tsx` — sign-out clears both `syncEnabledBoards` and the snapshots.

Added after the first review pass: an explicit case for the online profile-failure path on `manage.tsx` (`isOffline = false`, no user id, boards loaded → read-only list, not the error state).

### Mutation checks (run, not claimed)

Each guard was broken locally and the suite re-run:

| Mutation | Result |
| --- | --- |
| Delete the `downloadedScopeKeys` filter in the selector | 2 red (`excludes a card whose scope has no download`, `returns nothing when no scope is downloaded`) |
| Invert freshest-source-wins (cards written last) | 2 red (both freshness tests) |
| Drop the serialize-compare in `rememberOfflineBoards` | 1 red (`does not write when the remembered list is unchanged`) |
| Force `isLocalOnly = false` in `boards/index.tsx` | 5 of 6 red; the "online unchanged" case stayed green, as it should |
| Force `showOfflineList = false` in `boards/manage.tsx` | 2 red |
| Delete the `isOffline` guard in `useRememberDownloadedBoards` | 1 red (`does nothing while offline`) |

Round 2, same method:

| Mutation | Result |
| --- | --- |
| Put the adopt guard back on `isOffline` instead of `isLocalOnly` | 1 red (the lying-connection case) |
| Remember every board instead of only enabled scopes, and drop the `hasMore` prune gate | 5 of 8 red in the hook suite |
| Delete both `forgetOfflineBoard(board.uuid)` calls in `manage.tsx` | 2 red |
| Delete the three `!readOnly` terms in `BoardManageRow` | 1 red (all three affordances asserted in one case) |

All restored afterwards.

## Device-QA / maintainer gates

The decisive checks cannot run here (Linux: no macOS, no iOS simulator, no device with real radios — `vp run check:mobile-simulator` and `vp run mobile:screenshot` skip). The Android emulator can do airplane mode but not a captive portal.

Needed on device, per platform (iOS + Android), **on a build that includes this fix** — the upgrade-path gap means a user who downloaded on a pre-fix build has no snapshots until they next open the board picker or My Boards **while online** (the backfill hook is mounted on those two screens only, not app-wide), so the repro must download on the fixed build:

1. Enable offline for **two** boards, wait for both to reach "Available offline".
2. Force-quit, airplane mode, cold start. Climbs → board switcher → `/boards`. Expect both boards listed, the offline notice, no "No boards yet", no "Create a board" CTA, no error screen.
3. Switch to the **non-active** board: climbs populate from local SQLite, no "Could not follow" toast.
4. Switch back; the active-board marker follows correctly.
5. **Two boards sharing one layout+size** (the `storage-board-label.ts` case) — both rows appear with their own names.
6. `/boards/manage` offline: list renders, no error state, offline toggles still reflect real state, no Edit/Create.
7. **Lying connection**: join wifi with no upstream (or a captive portal) and repeat step 2 — this exercises the `isError` branch, not the `isOffline` one.
8. Sign out, sign in as a second account: the first account's board names must not appear.
9. Unfollow (or delete) one of the two downloaded boards while online, then repeat step 2 — the unfollowed board must be gone from the offline picker. Turning its "Available offline" toggle off should have the same effect.
10. **Warm-session narrowing, by design, worth a look:** go offline mid-session with a board in `myBoards` that is *not* downloaded. The picker now narrows to downloaded boards only, so that board disappears rather than being offered with no climbs behind it. Confirm that reads as correct on device.
11. **Known interaction, not a failure of this PR**: if the offline cold start shows the "Sign in" wall instead of the picker, that is `resolveAuthSession` returning `unavailable` and the native branch calling `setIsAuthenticated(false)` — filed as #4001. Note it and link there rather than reopening this.

## Follow-ups filed

- #4001 — offline cold start can sign the user out on native (`resolveAuthSession` `unavailable` → `setIsAuthenticated(false)`). A spurious sign-out offline is worse than the bug fixed here.
- #4002 — design: persist the React Query cache, or keep solving offline reads per-surface? Would subsume this fix plus `profile`/`myGyms`/playlists, but changes cold-start behaviour for every query — not something to smuggle into a P3.
- #4003 — restore the owned/followed split on offline My Boards by persisting the current user id.

## Deliberately not in scope

Making create / follow / unfollow / delete / board edit work offline (the picker hides them instead); Nearby / Popular / gym-finder discovery (inherently network); a `user_boards` SQLite table or any change to `syncEnabledBoards`' shape or the pull client; `offline-request.ts`; any `packages/web` change.



