### PR TITLE
fix(shared): recover and position a coalesced activation's queue-add

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -741,6 +741,32 @@ Note that duplicate sequence numbers remain legal on one specific path: `setClim
 | `mirrorCurrentClimb`       | `ClimbMirrored`                     | Flips the mirror flag on the current climb and the matching queue item.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `setQueue`                 | `FullSync`                          | Bulk replaces queue + current climb. Used for offline → online reconciliation and playlist activation updates that must atomically preserve queue history, keep manually queued future items, and drop stale future suggested items. Also carries mobile's session generate: `appendGeneratedSession` (`queue-provider.tsx`) sends the existing queue with the generated items appended and the **current climb unchanged**, so peers see the session queued behind whatever's active rather than a wholesale replace that jumps everyone to climb #1. It falls back to the first generated climb only when nothing is current, matching web's `start-sesh-drawer`. |
 
+### Deferred queue-adds from the setCurrentClimb coalescer
+
+Rapid activations are coalesced client-side (`packages/shared/queue-runtime/src/set-current-climb-coalescer.ts`): one `setCurrentClimb` in flight, the most recent pending args win. A dropped `setCurrentClimb` costs two things, not one. The pointer move self-heals — the next activation or any peer broadcast re-establishes it — but a `shouldAddToQueue: true` payload's brand-new queue slot does not: the reducer already inserted it locally and no later activation retroactively adds it, so the climb would sit in that climber's queue and nobody else's.
+
+So both ways a pending activation can lose its `setCurrentClimb` fire the content half on its own as a plain `ADD_QUEUE_ITEM`:
+
+1. **superseded while pending** — a newer activation replaced it;
+2. **drained and then rejected** — rate limit or socket blip (#3936).
+
+The deferred add is fire-and-forget (awaiting it inside the drain would hold `inFlight` through a multi-second back-off and manufacture more supersedes) and carries the item's **live local index**, read at send time rather than at enqueue time. That index counts the items ahead of it the server already has, so the insert reproduces the sending client's order; an overshoot — an earlier item that has not landed yet — is clamped to an append by the resolver.
+
+When the item is no longer in the local queue at send time, `packages/shared/queue-react/src/create-queue-mutations.ts` splits by cause:
+
+| Cause of local absence                                                    | Behaviour           |
+| ------------------------------------------------------------------------- | ------------------- |
+| per-item remove / swipe / mobile clear-queue (one `removeQueueItem` each) | skip                |
+| wholesale local replace — web's Clear, mobile's playlist replace-my-queue | skip                |
+| wholesale **server** sync (`FullSync` → `INITIAL_QUEUE_DATA`)             | send, no `position` |
+| a **peer** removed the item mid-back-off                                  | send, no `position` |
+
+The last row is a known gap, not an oversight: a peer's removal arrives as a server delta and is indistinguishable from a sync at that layer, so the add fires and can resurrect a climb the peer just deleted. Closing it needs a delta-origin signal the mutations factory does not have.
+
+The server-sync row is the one that matters most. The burst's head activation is itself an add, so the server answers it with `FullSync` (published with no `clientId`, so the origin cannot suppress its own echo), which `INITIAL_QUEUE_DATA` applies by **replacing** the local queue. A rate-limited drain rejects seconds later, by which time the pending item's optimistic slot is already gone. Skipping on mere absence would make the whole recovery inert in exactly the interleaving it exists for.
+
+The burst _head_ — the call whose `enqueue` promise actually rejects — is not covered by the coalescer at all. Mobile recovers it caller-side (`recoverThrottledQueueAdd`); web does not. Tracked in #4009 and #4006.
+
 ### Tick Mode and Queue Bar Freeze
 
 When a user opens the inline tick bar (to log a send/flash/attempt for the current climb), the queue control bar freezes navigation to prevent the active climb from changing mid-tick. This is implemented client-side in `queue-control-bar.tsx`:

--- a/packages/backend/src/__tests__/helpers/headless-queue-client.ts
+++ b/packages/backend/src/__tests__/helpers/headless-queue-client.ts
@@ -326,6 +326,10 @@ export class HeadlessParticipant {
       getClient: () => this.client,
       getSessionId: () => this.sessionId,
       toQueueItemInput,
+      // Wired to this participant's REAL reducer queue, not a stub: a `() => -1`
+      // would compile and silently switch every deferred queue-add off inside
+      // the harness that exists to exercise that seam end-to-end.
+      getQueuePosition: (uuid) => this.state.queue.findIndex((item) => item.uuid === uuid),
     });
   }
 

--- a/packages/mobile/src/providers/__tests__/queue-provider-local-queue.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-local-queue.test.tsx
@@ -67,6 +67,7 @@ const queueMutations = vi.hoisted(() => ({
 // REAL ensureReady seam (the no-lazy-create contract) is testable directly.
 type CapturedMutationDeps = {
   getSessionId: () => string | null;
+  getQueuePosition: (uuid: string) => number;
   ensureReady?: (capturedSessionId: string | null) => Promise<string | null>;
 };
 const capturedMutationDeps = vi.hoisted(() => ({ current: null as CapturedMutationDeps | null }));
@@ -345,6 +346,46 @@ describe('QueueProvider local solo queue', () => {
       ]);
       expect(snapshots.at(-1)?.state.currentClimbQueueItem?.uuid).toBe('item-x');
     });
+  });
+
+  // The wiring typecheck cannot see: wrong ref, wrong field, inverted return.
+  // A deferred queue-add (a superseded or throttled-away activation) positions
+  // itself with this, so a broken binding silently reverts #3936 to appending.
+  it('exposes the live local queue index to the shared mutations (getQueuePosition)', async () => {
+    const itemA = makeQueueItem('item-a');
+    const itemB = makeQueueItem('item-b');
+    const itemC = makeQueueItem('item-c');
+    queueSnapshotStore.getStoredQueueSnapshot.mockResolvedValue(storedSnapshot([itemA, itemB, itemC], itemA));
+
+    const snapshots: Snapshot[] = [];
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(capturedMutationDeps.current).not.toBeNull();
+      expect(snapshots.at(-1)?.state.queue.map((entry) => entry.uuid)).toEqual(['item-a', 'item-b', 'item-c']);
+    });
+    const deps = capturedMutationDeps.current;
+    if (!deps) throw new Error('mutation deps were not captured');
+
+    expect(deps.getQueuePosition('item-a')).toBe(0);
+    expect(deps.getQueuePosition('item-c')).toBe(2);
+    expect(deps.getQueuePosition('never-queued')).toBe(-1);
+
+    // Reads the LIVE reducer state, not a mount-time snapshot: activating a new
+    // climb slots it in after the current one, and the index follows.
+    act(() => {
+      snapshots.at(-1)?.setCurrentClimb(makeQueueItem('item-x'));
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((entry) => entry.uuid)).toEqual([
+        'item-a',
+        'item-x',
+        'item-b',
+        'item-c',
+      ]);
+    });
+    expect(deps.getQueuePosition('item-x')).toBe(1);
+    expect(deps.getQueuePosition('item-c')).toBe(3);
   });
 
   it('persists the solo queue after mutations (debounced)', async () => {

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -424,6 +424,11 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     // created_at) makes the server reject the mutation and silently breaks queue
     // sync to peers. See toClimbInput.
     toQueueItemInput: (item) => ({ uuid: item.uuid, climb: toClimbInput(item.climb) }),
+    // Where a deferred queue-add (a superseded or drained-then-throttled
+    // activation) should land, so peers see the order this device shows. Read
+    // live off `stateRef` — assigned during render — because the send can fire
+    // seconds after the activation. Same read `recoverThrottledQueueAdd` uses.
+    getQueuePosition: (uuid) => stateRef.current.queue.findIndex((queueItem) => queueItem.uuid === uuid),
     ensureReady: async (capturedSessionId) => {
       if (!capturedSessionId) return null;
       await ensureJoined(capturedSessionId);

--- a/packages/shared/queue-react/src/__tests__/create-queue-mutations.test.ts
+++ b/packages/shared/queue-react/src/__tests__/create-queue-mutations.test.ts
@@ -28,11 +28,18 @@ const toQueueItemInput = (it: TestItem) => ({ uuid: it.uuid, climb: it.climb }) 
 const client = {} as never; // execute is mocked, so the client value is opaque.
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
+// Stands in for the client's local reducer queue. `getQueuePosition` is wired to
+// a real findIndex over it, so an expected `position` comes from seeded data
+// rather than a stub's canned return. Tests mutate it to model reorders, removes
+// and wholesale server syncs mid-flight.
+let localQueue: TestItem[] = [];
+
 function make(overrides: Partial<QueueMutationsDeps<TestItem>> = {}) {
   return createQueueMutations<TestItem>({
     getClient: () => client,
     getSessionId: () => 'S',
     toQueueItemInput,
+    getQueuePosition: (uuid) => localQueue.findIndex((queueItem) => queueItem.uuid === uuid),
     ...overrides,
   });
 }
@@ -42,6 +49,7 @@ const queriesFor = (query: string) => executeMock.mock.calls.filter(([, op]) => 
 beforeEach(() => {
   executeMock.mockReset();
   executeMock.mockResolvedValue(undefined);
+  localQueue = [];
 });
 
 describe('web mode (no ensureReady)', () => {
@@ -297,6 +305,186 @@ describe('setCurrentClimb coalescer', () => {
 
     firstResolve?.();
     await Promise.all([pA, pB, pC]);
+  });
+
+  it('carries the item local position on the superseded queue-add (#3936)', async () => {
+    // The picker's own queue: the superseded item B sits at index 2, because the
+    // reducer inserted it right after the current climb.
+    localQueue = [item('X'), item('cur'), item('B')];
+    let firstResolve: (() => void) | undefined;
+    let setCurrentCalls = 0;
+    executeMock.mockImplementation((_c, op) => {
+      if (op.query !== SET_CURRENT_CLIMB) return Promise.resolve();
+      setCurrentCalls += 1;
+      if (setCurrentCalls === 1)
+        return new Promise<void>((resolve) => {
+          firstResolve = () => resolve();
+        });
+      return Promise.resolve();
+    });
+
+    const m = make();
+    const pA = m.setCurrentClimb(item('A'), true);
+    const pB = m.setCurrentClimb(item('B'), true);
+    const pC = m.setCurrentClimb(item('C'), true); // supersedes B -> ADD(B)
+    await flush();
+
+    // Exact variables: `position` is optional on this same object, so a partial
+    // match would stay green if it were dropped again — which IS the bug.
+    expect(queriesFor(ADD_QUEUE_ITEM)).toHaveLength(1);
+    expect(queriesFor(ADD_QUEUE_ITEM)[0][1].variables).toEqual({
+      item: { uuid: 'B', climb: { uuid: 'c-B' } },
+      position: 2,
+    });
+
+    firstResolve?.();
+    await Promise.all([pA, pB, pC]);
+  });
+
+  it('fires a positioned ADD_QUEUE_ITEM when the DRAINED activation is throttled away (#3936)', async () => {
+    localQueue = [item('X'), item('cur'), item('A'), item('B')];
+    let firstResolve: (() => void) | undefined;
+    let setCurrentCalls = 0;
+    executeMock.mockImplementation((_c, op) => {
+      if (op.query !== SET_CURRENT_CLIMB) return Promise.resolve();
+      setCurrentCalls += 1;
+      if (setCurrentCalls === 1)
+        return new Promise<void>((resolve) => {
+          firstResolve = () => resolve();
+        });
+      return Promise.reject(new Error('RATE_LIMITED'));
+    });
+    const onBestEffortError = vi.fn();
+
+    const m = make({ onBestEffortError });
+    const pA = m.setCurrentClimb(item('A'), true);
+    const pB = m.setCurrentClimb(item('B'), true); // pending; drains, then throttled
+    // pB parked as pending synchronously, so releasing the head drains it now.
+    firstResolve?.();
+    await Promise.all([pA, pB]);
+    await flush();
+
+    expect(queriesFor(ADD_QUEUE_ITEM)).toHaveLength(1);
+    expect(queriesFor(ADD_QUEUE_ITEM)[0][1].variables).toEqual({
+      item: { uuid: 'B', climb: { uuid: 'c-B' } },
+      position: 3,
+    });
+    // The pointer loss is still reported (dev-log only) — the recovery does not
+    // replace the report.
+    expect(onBestEffortError).toHaveBeenCalledWith('setCurrentClimb', expect.any(Error));
+  });
+
+  // The interleaving that makes a bare "-1 -> skip" guard swallow the whole
+  // fix: the burst's HEAD activation is itself an add, so the server answers it
+  // with a FullSync, which INITIAL_QUEUE_DATA applies by REPLACING the local
+  // queue — wiping the pending item's not-yet-sent optimistic slot seconds
+  // before the rate-limited drain rejects.
+  it('still sends the deferred add when a wholesale server sync wiped the local slot', async () => {
+    localQueue = [item('X'), item('cur'), item('A'), item('B')];
+    let firstResolve: (() => void) | undefined;
+    let setCurrentCalls = 0;
+    executeMock.mockImplementation((_c, op) => {
+      if (op.query !== SET_CURRENT_CLIMB) return Promise.resolve();
+      setCurrentCalls += 1;
+      if (setCurrentCalls === 1)
+        return new Promise<void>((resolve) => {
+          firstResolve = () => resolve();
+        });
+      // The drained send sits in rate-limit back-off. While it does, the
+      // FullSync triggered by A's own add lands: the server snapshot has no B.
+      return new Promise<void>((_resolve, reject) =>
+        setTimeout(() => {
+          localQueue = [item('X'), item('cur'), item('A')];
+          reject(new Error('RATE_LIMITED'));
+        }, 0),
+      );
+    });
+
+    const m = make({ onBestEffortError: () => {} });
+    const pA = m.setCurrentClimb(item('A'), true);
+    const pB = m.setCurrentClimb(item('B'), true);
+    // pB parked as pending synchronously, so releasing the head drains it now.
+    firstResolve?.();
+    await Promise.all([pA, pB]);
+    await flush();
+
+    // Dropping this add is the bug: the crew never gets the climb and the
+    // picker's pick vanishes. No position to honour, so the server appends.
+    expect(queriesFor(ADD_QUEUE_ITEM)).toHaveLength(1);
+    expect(queriesFor(ADD_QUEUE_ITEM)[0][1].variables).toEqual({ item: { uuid: 'B', climb: { uuid: 'c-B' } } });
+    expect(queriesFor(ADD_QUEUE_ITEM)[0][1].variables.position).toBeUndefined();
+  });
+
+  it('skips the deferred add when the climber REMOVED the item while it was backing off', async () => {
+    localQueue = [item('X'), item('cur'), item('A'), item('B')];
+    let firstResolve: (() => void) | undefined;
+    let setCurrentCalls = 0;
+    let removeDuringBackoff: (() => Promise<void>) | undefined;
+    executeMock.mockImplementation((_c, op) => {
+      if (op.query !== SET_CURRENT_CLIMB) return Promise.resolve();
+      setCurrentCalls += 1;
+      if (setCurrentCalls === 1)
+        return new Promise<void>((resolve) => {
+          firstResolve = () => resolve();
+        });
+      return new Promise<void>((_resolve, reject) =>
+        setTimeout(() => {
+          localQueue = localQueue.filter((queueItem) => queueItem.uuid !== 'B');
+          void removeDuringBackoff?.();
+          reject(new Error('RATE_LIMITED'));
+        }, 0),
+      );
+    });
+
+    const m = make({ onBestEffortError: () => {} });
+    removeDuringBackoff = () => m.removeQueueItem('B');
+    const pA = m.setCurrentClimb(item('A'), true);
+    const pB = m.setCurrentClimb(item('B'), true);
+    // pB parked as pending synchronously, so releasing the head drains it now.
+    firstResolve?.();
+    await Promise.all([pA, pB]);
+    await flush();
+
+    // The climber dropped it. Re-adding would put a climb nobody asked for back
+    // on the whole crew's queue.
+    expect(queriesFor(ADD_QUEUE_ITEM)).toHaveLength(0);
+    expect(queriesFor(REMOVE_QUEUE_ITEM)).toHaveLength(1);
+  });
+
+  it('reads the position at SEND time, not at enqueue time', async () => {
+    // B starts at index 0 and is reordered to index 2 while the throttled
+    // SET_CURRENT_CLIMB backs off. A captured-at-enqueue index would misplace it
+    // for the whole crew.
+    localQueue = [item('B'), item('X')];
+    let firstResolve: (() => void) | undefined;
+    let setCurrentCalls = 0;
+    executeMock.mockImplementation((_c, op) => {
+      if (op.query !== SET_CURRENT_CLIMB) return Promise.resolve();
+      setCurrentCalls += 1;
+      if (setCurrentCalls === 1)
+        return new Promise<void>((resolve) => {
+          firstResolve = () => resolve();
+        });
+      return new Promise<void>((_resolve, reject) =>
+        setTimeout(() => {
+          localQueue = [item('X'), item('cur'), item('B')];
+          reject(new Error('RATE_LIMITED'));
+        }, 0),
+      );
+    });
+
+    const m = make({ onBestEffortError: () => {} });
+    const pA = m.setCurrentClimb(item('A'), true);
+    const pB = m.setCurrentClimb(item('B'), true);
+    // pB parked as pending synchronously, so releasing the head drains it now.
+    firstResolve?.();
+    await Promise.all([pA, pB]);
+    await flush();
+
+    expect(queriesFor(ADD_QUEUE_ITEM)[0][1].variables).toEqual({
+      item: { uuid: 'B', climb: { uuid: 'c-B' } },
+      position: 2,
+    });
   });
 
   it('lazily creates a session from null on setCurrentClimb (mobile) and dispatches it', async () => {

--- a/packages/shared/queue-react/src/__tests__/create-queue-mutations.test.ts
+++ b/packages/shared/queue-react/src/__tests__/create-queue-mutations.test.ts
@@ -451,6 +451,118 @@ describe('setCurrentClimb coalescer', () => {
     expect(queriesFor(REMOVE_QUEUE_ITEM)).toHaveLength(1);
   });
 
+  // Web's Clear button (`setQueue([])`) and mobile's playlist "replace my
+  // queue" (`setQueue([item], item)`) are climber-initiated removals that never
+  // call removeQueueItem — so the ledger has to learn about them from setQueue.
+  it('skips the deferred add when the climber REPLACED the whole queue while it was backing off', async () => {
+    localQueue = [item('X'), item('cur'), item('A'), item('B')];
+    let firstResolve: (() => void) | undefined;
+    let setCurrentCalls = 0;
+    let clearDuringBackoff: (() => Promise<void>) | undefined;
+    executeMock.mockImplementation((_c, op) => {
+      if (op.query !== SET_CURRENT_CLIMB) return Promise.resolve();
+      setCurrentCalls += 1;
+      if (setCurrentCalls === 1)
+        return new Promise<void>((resolve) => {
+          firstResolve = () => resolve();
+        });
+      return new Promise<void>((_resolve, reject) =>
+        setTimeout(() => {
+          localQueue = [];
+          void clearDuringBackoff?.();
+          reject(new Error('RATE_LIMITED'));
+        }, 0),
+      );
+    });
+
+    const m = make({ onBestEffortError: () => {} });
+    clearDuringBackoff = () => m.setQueue([]);
+    const pA = m.setCurrentClimb(item('A'), true);
+    const pB = m.setCurrentClimb(item('B'), true);
+    // pB parked as pending synchronously, so releasing the head drains it now.
+    firstResolve?.();
+    await Promise.all([pA, pB]);
+    await flush();
+
+    expect(queriesFor(ADD_QUEUE_ITEM)).toHaveLength(0);
+    expect(queriesFor(SET_QUEUE)).toHaveLength(1);
+  });
+
+  // The ordering guard on the replace diff: only activations enqueued BEFORE
+  // the replace can have been discarded by it. A climb picked afterwards and
+  // then wiped by a server sync must still reach the crew.
+  it('still sends the deferred add when the wholesale replace happened BEFORE the activation', async () => {
+    const m = make({ onBestEffortError: () => {} });
+    localQueue = [];
+    await m.setQueue([]);
+
+    localQueue = [item('cur'), item('A'), item('B')];
+    let firstResolve: (() => void) | undefined;
+    let setCurrentCalls = 0;
+    executeMock.mockImplementation((_c, op) => {
+      if (op.query !== SET_CURRENT_CLIMB) return Promise.resolve();
+      setCurrentCalls += 1;
+      if (setCurrentCalls === 1)
+        return new Promise<void>((resolve) => {
+          firstResolve = () => resolve();
+        });
+      return new Promise<void>((_resolve, reject) =>
+        setTimeout(() => {
+          localQueue = [item('cur'), item('A')];
+          reject(new Error('RATE_LIMITED'));
+        }, 0),
+      );
+    });
+
+    const pA = m.setCurrentClimb(item('A'), true);
+    const pB = m.setCurrentClimb(item('B'), true);
+    firstResolve?.();
+    await Promise.all([pA, pB]);
+    await flush();
+
+    expect(queriesFor(ADD_QUEUE_ITEM)).toHaveLength(1);
+    expect(queriesFor(ADD_QUEUE_ITEM)[0][1].variables).toEqual({ item: { uuid: 'B', climb: { uuid: 'c-B' } } });
+  });
+
+  // mobile's clearQueue fires one removeQueueItem per queued item in a single
+  // burst. A ring buffer smaller than the queue evicts the earliest entries of
+  // its own clear, and that climb reappears on the crew's just-emptied queue.
+  it('suppresses the FIRST item of a whole-queue clear far bigger than a 50-entry ledger', async () => {
+    const bulk = Array.from({ length: 60 }, (_, index) => item(`q${index}`));
+    localQueue = [item('cur'), ...bulk];
+    let firstResolve: (() => void) | undefined;
+    let setCurrentCalls = 0;
+    let clearDuringBackoff: (() => Promise<unknown>) | undefined;
+    executeMock.mockImplementation((_c, op) => {
+      if (op.query !== SET_CURRENT_CLIMB) return Promise.resolve();
+      setCurrentCalls += 1;
+      if (setCurrentCalls === 1)
+        return new Promise<void>((resolve) => {
+          firstResolve = () => resolve();
+        });
+      return new Promise<void>((_resolve, reject) =>
+        setTimeout(() => {
+          localQueue = [];
+          void clearDuringBackoff?.();
+          reject(new Error('RATE_LIMITED'));
+        }, 0),
+      );
+    });
+
+    const m = make({ onBestEffortError: () => {} });
+    // Oldest-first, exactly like the mobile provider's clearQueue.
+    clearDuringBackoff = () => Promise.allSettled(bulk.map((queueItem) => m.removeQueueItem(queueItem.uuid)));
+    const pA = m.setCurrentClimb(item('A'), true);
+    // q0 is the first uuid the clear records — the one a 50-entry ring drops.
+    const pQ0 = m.setCurrentClimb(bulk[0], true);
+    firstResolve?.();
+    await Promise.all([pA, pQ0]);
+    await flush();
+
+    expect(queriesFor(REMOVE_QUEUE_ITEM)).toHaveLength(60);
+    expect(queriesFor(ADD_QUEUE_ITEM)).toHaveLength(0);
+  });
+
   it('reads the position at SEND time, not at enqueue time', async () => {
     // B starts at index 0 and is reordered to index 2 while the throttled
     // SET_CURRENT_CLIMB backs off. A captured-at-enqueue index would misplace it

--- a/packages/shared/queue-react/src/__tests__/use-queue-mutations.test.ts
+++ b/packages/shared/queue-react/src/__tests__/use-queue-mutations.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import type { ClimbQueueItemInput } from '@boardsesh/shared-schema';
+import { ADD_QUEUE_ITEM, SET_CURRENT_CLIMB } from '@boardsesh/graphql/operations/queue-session';
 
 const { executeMock } = vi.hoisted(() => ({ executeMock: vi.fn() }));
 vi.mock('@boardsesh/graphql-client', () => ({ execute: executeMock }));
@@ -25,9 +26,16 @@ beforeEach(() => {
   executeMock.mockResolvedValue(undefined);
 });
 
+const noQueue = () => -1;
+
 describe('useQueueMutations (React wrapper)', () => {
   it('keeps action identities stable across rerenders (factory built once)', () => {
-    const deps: QueueMutationsDeps<TestItem> = { getClient: () => client, getSessionId: () => 'S', toQueueItemInput };
+    const deps: QueueMutationsDeps<TestItem> = {
+      getClient: () => client,
+      getSessionId: () => 'S',
+      toQueueItemInput,
+      getQueuePosition: noQueue,
+    };
     const { result, rerender } = renderMutations(deps);
     const first = result.current;
     rerender({ ...deps });
@@ -40,6 +48,7 @@ describe('useQueueMutations (React wrapper)', () => {
       getClient: () => client,
       getSessionId: () => sessionId,
       toQueueItemInput,
+      getQueuePosition: noQueue,
     };
     const { result, rerender } = renderMutations(deps);
     const actions = result.current;
@@ -60,6 +69,7 @@ describe('useQueueMutations (React wrapper)', () => {
       getClient: () => client,
       getSessionId: () => null,
       toQueueItemInput,
+      getQueuePosition: noQueue,
     };
     const { result, rerender } = renderMutations(base);
     const webActions = result.current;
@@ -74,5 +84,46 @@ describe('useQueueMutations (React wrapper)', () => {
     // Mobile semantics now: the same disconnected action silently no-ops.
     await expect(result.current.removeQueueItem('x')).resolves.toBeUndefined();
     expect(executeMock).not.toHaveBeenCalled();
+  });
+
+  it('forwards getQueuePosition LIVE through the ref, not captured at mount', async () => {
+    // A deferred queue-add can fire long after mount, so a mount-time capture
+    // would position it against a stale queue (#3936). Observed through the
+    // only public surface that reads it: the coalescer's superseded queue-add.
+    let firstResolve: (() => void) | undefined;
+    let setCurrentCalls = 0;
+    executeMock.mockImplementation((_c: unknown, op: { query: string }) => {
+      if (op.query !== SET_CURRENT_CLIMB) return Promise.resolve();
+      setCurrentCalls += 1;
+      if (setCurrentCalls === 1)
+        return new Promise<void>((resolve) => {
+          firstResolve = () => resolve();
+        });
+      return Promise.resolve();
+    });
+
+    const mountDeps: QueueMutationsDeps<TestItem> = {
+      getClient: () => client,
+      getSessionId: () => 'S',
+      toQueueItemInput,
+      getQueuePosition: () => 1,
+    };
+    const { result, rerender } = renderMutations(mountDeps);
+    // A later render brings a different local queue; the factory identity is
+    // unchanged, so only ref-forwarding can pick this up.
+    rerender({ ...mountDeps, getQueuePosition: () => 5 });
+
+    const actions = result.current;
+    const pA = actions.setCurrentClimb({ uuid: 'A', climb: { uuid: 'c-A' } }, true);
+    const pB = actions.setCurrentClimb({ uuid: 'B', climb: { uuid: 'c-B' } }, true);
+    const pC = actions.setCurrentClimb({ uuid: 'C', climb: { uuid: 'c-C' } }, true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const adds = executeMock.mock.calls.filter(([, op]) => op.query === ADD_QUEUE_ITEM);
+    expect(adds).toHaveLength(1);
+    expect(adds[0][1].variables).toEqual({ item: { uuid: 'B', climb: { uuid: 'c-B' } }, position: 5 });
+
+    firstResolve?.();
+    await Promise.all([pA, pB, pC]);
   });
 });

--- a/packages/shared/queue-react/src/create-queue-mutations.ts
+++ b/packages/shared/queue-react/src/create-queue-mutations.ts
@@ -148,20 +148,52 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
 
   type Ready = { client: Client; sessionId: string };
 
-  // Bounded ledger of uuids the climber explicitly asked to drop. A deferred
-  // queue-add whose item has left the local queue is still sent (see
-  // sendDeferredQueueAdd for why), EXCEPT when it left because of a remove —
-  // resurrecting a climb the climber just dropped fights them. `removeQueueItem`
-  // is the single choke point for every explicit removal on both platforms
-  // (mobile: remove / clear-queue / the #3934 undo leg; web: queue-actions-core),
-  // so recording here needs no platform wiring. Bounded because a deferred add
-  // fires within seconds of the loss it is recovering; the cap follows the
-  // reducer's own `.slice(-50)` convention for correlation ids.
-  const REMOVED_UUID_MEMORY = 50;
-  const removedUuids: string[] = [];
+  // Ledger of uuids the climber explicitly asked to drop. A deferred queue-add
+  // whose item has left the local queue is still sent (see sendDeferredQueueAdd
+  // for why), EXCEPT when it left because the climber dropped it — resurrecting
+  // a climb they just removed fights them.
+  //
+  // Two mutations are the choke points for climber-initiated removal, and both
+  // record here, so no platform wiring is needed:
+  //   - `removeQueueItem` — per-item swipe/delete, mobile's clear-queue (which
+  //     fires one call per queued item) and the #3934 undo leg; web's queue
+  //     actions.
+  //   - `setQueue` — a WHOLESALE local replace. Web's Clear button
+  //     (`setQueue([])`) and mobile's playlist "replace my queue"
+  //     (`setQueue([item], item)`) never touch `removeQueueItem`, so the replace
+  //     diffs `addCandidateUuids` against the new queue (see the action below).
+  // NOT covered, deliberately, because this layer has no signal for it: a PEER
+  // removing the item mid-back-off arrives as a server delta, which is
+  // indistinguishable here from a wholesale sync, so it takes the append branch.
+  // Pre-existing on the superseded path, which appended unconditionally.
+  //
+  // Backed by an insertion-ordered Set rather than a small ring: mobile's
+  // `clearQueue` fires one `removeQueueItem` per queued item in a single burst,
+  // so a 50-entry ring evicted its own earliest entries on any queue longer than
+  // that and let one climb reappear on the queue the climber had just cleared.
+  // The cap only stops a pathological session growing without bound — it sits
+  // far above any realistic queue, and an entry costs ~40 bytes.
+  const REMOVED_UUID_MEMORY = 2000;
+  const removedUuids = new Set<string>();
   function rememberRemovedUuid(uuid: string): void {
-    removedUuids.push(uuid);
-    if (removedUuids.length > REMOVED_UUID_MEMORY) removedUuids.shift();
+    removedUuids.add(uuid);
+    if (removedUuids.size > REMOVED_UUID_MEMORY) {
+      const oldest = removedUuids.values().next();
+      if (!oldest.done) removedUuids.delete(oldest.value);
+    }
+  }
+
+  // uuids of recent activations that carried a queue-add — the only uuids a
+  // deferred add ever asks about, and so all a wholesale `setQueue` needs to
+  // diff against to work out what the climber just discarded (it never sees the
+  // previous queue). Order matters: an activation recorded AFTER a replace is
+  // not a candidate at replace time, so a climb picked after a Clear is never
+  // mistaken for one the Clear discarded.
+  const ADD_CANDIDATE_MEMORY = 32;
+  const addCandidateUuids: string[] = [];
+  function rememberAddCandidate(uuid: string): void {
+    addCandidateUuids.push(uuid);
+    if (addCandidateUuids.length > ADD_CANDIDATE_MEMORY) addCandidateUuids.shift();
   }
 
   // Every queue mutation goes through here so the shared `execute` retry loop
@@ -264,9 +296,10 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
         // The item is no longer in this client's local queue. Two very different
         // reasons, and only one of them means "don't send":
         //
-        // - The climber removed it. Honour that; a bare ADD would resurrect a
-        //   climb they just dropped onto the whole crew's queue.
-        if (removedUuids.includes(input.uuid)) return;
+        // - The climber dropped it, by a per-item remove or by replacing the
+        //   whole queue. Honour that; a bare ADD would resurrect a climb they
+        //   just discarded onto the whole crew's queue.
+        if (removedUuids.has(input.uuid)) return;
         // - A wholesale server sync replaced the queue. The activation that
         //   started this coalesced burst was itself an add, so the server
         //   answered it with a FullSync, which INITIAL_QUEUE_DATA applies by
@@ -319,6 +352,9 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
     },
 
     setCurrentClimb: async (item, shouldAddToQueue, correlationId) => {
+      // Only an activation that carries a queue-add can ever produce a deferred
+      // ADD, so only those uuids need tracking for the wholesale-replace diff.
+      if (item !== null && shouldAddToQueue) rememberAddCandidate(toQueueItemInput(item).uuid);
       // Web throws upfront when disconnected (no ensureReady); mobile enqueues
       // and lets the coalescer's sendArgs resolve / create the session.
       if (!ensureReady && (!getClient() || !getSessionId())) {
@@ -349,12 +385,29 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
     },
 
     setQueue: async (queue, currentClimbQueueItem) => {
+      const queueInputs = queue.map(toQueueItemInput);
+      // A wholesale replace is climber intent exactly like a per-item remove —
+      // web's Clear button and mobile's playlist "replace my queue" both land
+      // here and never touch `removeQueueItem`. Any recent activation missing
+      // from the new queue was just discarded, so its deferred add must not
+      // resurrect it. Recorded before the session guards: a replace that no-ops
+      // for want of a session is still the climber saying "drop these".
+      // (Mobile passes only the resolved items here, so an unresolved
+      // placeholder reads as discarded — harmless, since the ledger is
+      // consulted only once the item has also left the local queue, and an
+      // activation is always a resolved climb.)
+      if (addCandidateUuids.length > 0) {
+        const nextUuids = new Set(queueInputs.map((queueInput) => queueInput.uuid));
+        for (const candidate of addCandidateUuids) {
+          if (!nextUuids.has(candidate)) rememberRemovedUuid(candidate);
+        }
+      }
       const ready = await resolveCore({ allowCreate: false });
       if (!ready) return;
       await runMutation(ready.client, {
         query: SET_QUEUE,
         variables: {
-          queue: queue.map(toQueueItemInput),
+          queue: queueInputs,
           currentClimbQueueItem: currentClimbQueueItem ? toQueueItemInput(currentClimbQueueItem) : undefined,
         },
       });

--- a/packages/shared/queue-react/src/create-queue-mutations.ts
+++ b/packages/shared/queue-react/src/create-queue-mutations.ts
@@ -65,6 +65,17 @@ export type QueueMutationsDeps<TItem> = {
   /** Platform mapper: item -> wire input (web: toClimbQueueItemInput; mobile: thin {uuid,climb}). */
   toQueueItemInput: (item: TItem) => ClimbQueueItemInput;
   /**
+   * Live index of `uuid` in THIS client's local queue, or -1 when it is not
+   * queued here. Read at SEND time (never captured at enqueue time) for a
+   * deferred ADD_QUEUE_ITEM, so the insert reproduces the order the climber
+   * actually sees even when the send sat in rate-limit back-off for seconds.
+   *
+   * Required rather than optional: an absent implementation would silently fall
+   * back to appending, which is exactly the bug (#3936). Both bindings are
+   * compile-forced to supply it.
+   */
+  getQueuePosition: (uuid: string) => number;
+  /**
    * Optional session-resolution seam. When provided (mobile), it resolves and
    * joins the session before mutating, returning the resolved id (or null to
    * no-op — mobile returns null for a null `capturedSessionId`, keeping the
@@ -132,9 +143,26 @@ export type QueueMutationsActions<TItem> = {
 };
 
 export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): QueueMutationsActions<TItem> {
-  const { getClient, getSessionId, toQueueItemInput, ensureReady, onBestEffortError, onRateLimited } = deps;
+  const { getClient, getSessionId, toQueueItemInput, getQueuePosition, ensureReady, onBestEffortError, onRateLimited } =
+    deps;
 
   type Ready = { client: Client; sessionId: string };
+
+  // Bounded ledger of uuids the climber explicitly asked to drop. A deferred
+  // queue-add whose item has left the local queue is still sent (see
+  // sendDeferredQueueAdd for why), EXCEPT when it left because of a remove —
+  // resurrecting a climb the climber just dropped fights them. `removeQueueItem`
+  // is the single choke point for every explicit removal on both platforms
+  // (mobile: remove / clear-queue / the #3934 undo leg; web: queue-actions-core),
+  // so recording here needs no platform wiring. Bounded because a deferred add
+  // fires within seconds of the loss it is recovering; the cap follows the
+  // reducer's own `.slice(-50)` convention for correlation ids.
+  const REMOVED_UUID_MEMORY = 50;
+  const removedUuids: string[] = [];
+  function rememberRemovedUuid(uuid: string): void {
+    removedUuids.push(uuid);
+    if (removedUuids.length > REMOVED_UUID_MEMORY) removedUuids.shift();
+  }
 
   // Every queue mutation goes through here so the shared `execute` retry loop
   // (bounded back-off on RATE_LIMITED) and the `onRateLimited` notifier apply
@@ -180,7 +208,7 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
 
   // Serialize-and-supersede SET_CURRENT_CLIMB. `getContext` snapshots the
   // session id at enqueue; the captured value flows through sendArgs /
-  // sendSupersededQueueAdd so a session that flips mid-flight neither resurrects
+  // sendDeferredQueueAdd so a session that flips mid-flight neither resurrects
   // a stale climb nor fires a queue-add against the wrong session.
   const coalescer = createSetCurrentClimbCoalescer<string | null, TItem>({
     getContext: () => getSessionId(),
@@ -217,23 +245,51 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
         },
       });
     },
-    sendSupersededQueueAdd: async (item, capturedSessionId) => {
+    sendDeferredQueueAdd: async (item, capturedSessionId) => {
       const client = getClient();
       if (!client || !capturedSessionId || getSessionId() !== capturedSessionId) return;
       if (ensureReady) {
         // capturedSessionId is concrete, so this only joins — but honour a null
-        // return (session ended between supersede and drain) and bail rather
+        // return (session ended between the loss and this send) and bail rather
         // than fire an ADD against a dead session, mirroring the sendArgs path.
         const sessionId = await ensureReady(capturedSessionId);
         if (!sessionId) return;
       }
-      await runMutation(client, {
-        query: ADD_QUEUE_ITEM,
-        variables: { item: toQueueItemInput(item) },
-      });
+      const input = toQueueItemInput(item);
+      // Read the position AFTER the session guards (a dead-session bail costs
+      // nothing) and live rather than at enqueue time — a drained add can fire
+      // seconds later, after reorders.
+      const position = getQueuePosition(input.uuid);
+      if (position < 0) {
+        // The item is no longer in this client's local queue. Two very different
+        // reasons, and only one of them means "don't send":
+        //
+        // - The climber removed it. Honour that; a bare ADD would resurrect a
+        //   climb they just dropped onto the whole crew's queue.
+        if (removedUuids.includes(input.uuid)) return;
+        // - A wholesale server sync replaced the queue. The activation that
+        //   started this coalesced burst was itself an add, so the server
+        //   answered it with a FullSync, which INITIAL_QUEUE_DATA applies by
+        //   REPLACING the local queue — wiping the not-yet-sent optimistic slot
+        //   seconds before the rate-limited drain rejects. Dropping the add here
+        //   is precisely the bug (#3936): the crew never gets the climb and the
+        //   picker's pick vanishes. Send it without a position; the server
+        //   appends, which is no worse than the pre-fix behaviour and at least
+        //   the crew gets the climb.
+        await runMutation(client, { query: ADD_QUEUE_ITEM, variables: { item: input } });
+        return;
+      }
+      // The local index counts the items ahead of it that the server already
+      // has, so the insert reproduces this client's order. When an earlier item
+      // has not landed yet the index overshoots and the server clamps to an
+      // append (addQueueItem in the backend resolver) — degrading to the old
+      // behaviour rather than to a wrong position. Correct for both optimistic
+      // conventions (insert-after-current on activation, append on
+      // peek-promotion) without the coalescer knowing which one ran.
+      await runMutation(client, { query: ADD_QUEUE_ITEM, variables: { item: input, position } });
     },
     onDrainError: (error) => onBestEffortError?.('setCurrentClimb', error),
-    onSupersededQueueAddError: (error) => onBestEffortError?.('addQueueItem', error),
+    onDeferredQueueAddError: (error) => onBestEffortError?.('addQueueItem', error),
   });
 
   return {
@@ -247,6 +303,10 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
     },
 
     removeQueueItem: async (uuid) => {
+      // Recorded before the session guards: a remove that no-ops for want of a
+      // session is still the climber saying "drop this", and a deferred add
+      // must not resurrect it.
+      rememberRemovedUuid(uuid);
       const ready = await resolveCore({ allowCreate: false });
       if (!ready) return;
       await runMutation(ready.client, { query: REMOVE_QUEUE_ITEM, variables: { uuid } });

--- a/packages/shared/queue-react/src/use-queue-mutations.ts
+++ b/packages/shared/queue-react/src/use-queue-mutations.ts
@@ -31,6 +31,7 @@ export function useQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Queue
         getClient: () => depsRef.current.getClient(),
         getSessionId: () => depsRef.current.getSessionId(),
         toQueueItemInput: (item) => depsRef.current.toQueueItemInput(item),
+        getQueuePosition: (uuid) => depsRef.current.getQueuePosition(uuid),
         ensureReady: hasEnsureReady
           ? (capturedSessionId) => depsRef.current.ensureReady!(capturedSessionId)
           : undefined,

--- a/packages/shared/queue-runtime/src/__tests__/set-current-climb-coalescer.test.ts
+++ b/packages/shared/queue-runtime/src/__tests__/set-current-climb-coalescer.test.ts
@@ -89,15 +89,15 @@ describe('createSetCurrentClimbCoalescer', () => {
     expect(calls.map((c) => c.item?.uuid)).toEqual(['a', 'c']);
   });
 
-  it('fires sendSupersededQueueAdd for a superseded args carrying shouldAddToQueue', async () => {
+  it('fires sendDeferredQueueAdd for a superseded args carrying shouldAddToQueue', async () => {
     const first = deferred();
     const calls: SetCurrentClimbArgs[] = [];
     const sendArgs = vi.fn(async (args: SetCurrentClimbArgs) => {
       calls.push(args);
       if (calls.length === 1) await first.promise;
     });
-    const sendSupersededQueueAdd = vi.fn(async (_item: ClimbQueueItem) => {});
-    const coalescer = createSetCurrentClimbCoalescer({ sendArgs, sendSupersededQueueAdd });
+    const sendDeferredQueueAdd = vi.fn(async (_item: ClimbQueueItem) => {});
+    const coalescer = createSetCurrentClimbCoalescer({ sendArgs, sendDeferredQueueAdd });
 
     const firstEnqueue = coalescer.enqueue({ item: makeItem('a') });
     await Promise.resolve();
@@ -109,19 +109,19 @@ describe('createSetCurrentClimbCoalescer', () => {
     first.resolve();
     await firstEnqueue;
 
-    expect(sendSupersededQueueAdd).toHaveBeenCalledTimes(1);
-    expect(sendSupersededQueueAdd).toHaveBeenCalledWith(makeItem('b'), undefined);
+    expect(sendDeferredQueueAdd).toHaveBeenCalledTimes(1);
+    expect(sendDeferredQueueAdd).toHaveBeenCalledWith(makeItem('b'), undefined);
   });
 
-  it('omits sendSupersededQueueAdd when the superseded args had no shouldAddToQueue', async () => {
+  it('omits sendDeferredQueueAdd when the superseded args had no shouldAddToQueue', async () => {
     const first = deferred();
     let sendCount = 0;
     const sendArgs = vi.fn(async (_args: SetCurrentClimbArgs) => {
       sendCount += 1;
       if (sendCount === 1) await first.promise;
     });
-    const sendSupersededQueueAdd = vi.fn(async (_item: ClimbQueueItem) => {});
-    const coalescer = createSetCurrentClimbCoalescer({ sendArgs, sendSupersededQueueAdd });
+    const sendDeferredQueueAdd = vi.fn(async (_item: ClimbQueueItem) => {});
+    const coalescer = createSetCurrentClimbCoalescer({ sendArgs, sendDeferredQueueAdd });
 
     const firstEnqueue = coalescer.enqueue({ item: makeItem('a') });
     await Promise.resolve();
@@ -131,7 +131,7 @@ describe('createSetCurrentClimbCoalescer', () => {
     first.resolve();
     await firstEnqueue;
 
-    expect(sendSupersededQueueAdd).not.toHaveBeenCalled();
+    expect(sendDeferredQueueAdd).not.toHaveBeenCalled();
   });
 
   it('propagates errors from the first send but still drains pending', async () => {
@@ -223,20 +223,20 @@ describe('createSetCurrentClimbCoalescer', () => {
     ]);
   });
 
-  it('sendSupersededQueueAdd receives the captured context of the superseded args (not the current)', async () => {
+  it('sendDeferredQueueAdd receives the captured context of the superseded args (not the current)', async () => {
     const first = deferred();
     let currentSession = 'sess-A';
     const sendArgs = vi.fn(async (_args: SetCurrentClimbArgs, _ctx: string) => {
       if (sendArgs.mock.calls.length === 1) await first.promise;
     });
     const supersedeCalls: Array<{ uuid: string; ctx: string }> = [];
-    const sendSupersededQueueAdd = vi.fn(async (item: ClimbQueueItem, ctx: string) => {
+    const sendDeferredQueueAdd = vi.fn(async (item: ClimbQueueItem, ctx: string) => {
       supersedeCalls.push({ uuid: item.uuid, ctx });
     });
     const coalescer = createSetCurrentClimbCoalescer<string>({
       getContext: () => currentSession,
       sendArgs,
-      sendSupersededQueueAdd,
+      sendDeferredQueueAdd,
     });
 
     const firstEnqueue = coalescer.enqueue({ item: makeItem('a') });
@@ -265,5 +265,226 @@ describe('createSetCurrentClimbCoalescer', () => {
     await coalescer.enqueue({ item: makeItem('a') });
 
     expect(sendArgs).toHaveBeenCalledWith({ item: makeItem('a') }, undefined);
+  });
+});
+
+// The second way a pending activation loses its setCurrentClimb: it drains, and
+// the drained send rejects (rate limit, socket blip). On `main` that lost the
+// queue-add outright — the slot existed on the picker's device and nowhere else
+// (#3936).
+describe('createSetCurrentClimbCoalescer — drained-then-rejected recovery', () => {
+  // Drives one held first send, one drained send whose outcome the test picks.
+  function harness(drainOutcome: 'reject' | 'resolve', deferredAdd?: (item: ClimbQueueItem) => Promise<void>) {
+    const first = deferred();
+    let sendCount = 0;
+    const sendArgs = vi.fn(async (_args: SetCurrentClimbArgs) => {
+      sendCount += 1;
+      if (sendCount === 1) {
+        await first.promise;
+        return;
+      }
+      if (drainOutcome === 'reject') throw new Error('RATE_LIMITED');
+    });
+    const sendDeferredQueueAdd = vi.fn(deferredAdd ?? (async (_item: ClimbQueueItem) => {}));
+    const onDrainError = vi.fn();
+    const coalescer = createSetCurrentClimbCoalescer({ sendArgs, sendDeferredQueueAdd, onDrainError });
+    return { first, sendArgs, sendDeferredQueueAdd, onDrainError, coalescer };
+  }
+
+  it('fires the deferred queue-add when a drained pending call rejects', async () => {
+    const { first, sendDeferredQueueAdd, coalescer } = harness('reject');
+
+    const firstEnqueue = coalescer.enqueue({ item: makeItem('a') });
+    await Promise.resolve();
+    // 'b' is the tail of the burst: it drains and its SET_CURRENT_CLIMB is
+    // throttled away. Its queue slot has to reach the server anyway.
+    await coalescer.enqueue({ item: makeItem('b'), shouldAddToQueue: true });
+
+    first.resolve();
+    await firstEnqueue;
+
+    expect(sendDeferredQueueAdd).toHaveBeenCalledTimes(1);
+    expect(sendDeferredQueueAdd).toHaveBeenCalledWith(makeItem('b'), undefined);
+  });
+
+  it('does not fire the deferred add for a drained POINTER-ONLY call', async () => {
+    const { first, sendDeferredQueueAdd, coalescer } = harness('reject');
+
+    const firstEnqueue = coalescer.enqueue({ item: makeItem('a') });
+    await Promise.resolve();
+    // No shouldAddToQueue: a rapid queue swipe moves the pointer only. Adding
+    // anything here would inject a phantom slot on every throttled swipe.
+    await coalescer.enqueue({ item: makeItem('b') });
+
+    first.resolve();
+    await firstEnqueue;
+
+    expect(sendDeferredQueueAdd).not.toHaveBeenCalled();
+  });
+
+  it('does not fire the deferred add when the drained call succeeds', async () => {
+    const { first, sendDeferredQueueAdd, coalescer } = harness('resolve');
+
+    const firstEnqueue = coalescer.enqueue({ item: makeItem('a') });
+    await Promise.resolve();
+    await coalescer.enqueue({ item: makeItem('b'), shouldAddToQueue: true });
+
+    first.resolve();
+    await firstEnqueue;
+
+    // The setCurrentClimb landed and carried shouldAddToQueue with it — a
+    // second ADD here would duplicate every coalesced burst's tail.
+    expect(sendDeferredQueueAdd).not.toHaveBeenCalled();
+  });
+
+  it('still reports the drain failure to onDrainError', async () => {
+    const { first, onDrainError, coalescer } = harness('reject');
+
+    const firstEnqueue = coalescer.enqueue({ item: makeItem('a') });
+    await Promise.resolve();
+    await coalescer.enqueue({ item: makeItem('b'), shouldAddToQueue: true });
+
+    first.resolve();
+    await firstEnqueue;
+
+    expect(onDrainError).toHaveBeenCalledTimes(1);
+    expect(onDrainError.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+  });
+
+  it('does not await the deferred add (a backing-off ADD must not wedge the drain)', async () => {
+    // A rate-limited ADD can sit in the transport's back-off for seconds.
+    const { first, sendArgs, sendDeferredQueueAdd, coalescer } = harness(
+      'reject',
+      () => new Promise<void>(() => {}), // never settles
+    );
+
+    const firstEnqueue = coalescer.enqueue({ item: makeItem('a') });
+    await Promise.resolve();
+    await coalescer.enqueue({ item: makeItem('b'), shouldAddToQueue: true });
+
+    first.resolve();
+    await firstEnqueue; // resolves despite the never-settling ADD
+    expect(sendDeferredQueueAdd).toHaveBeenCalledTimes(1);
+
+    // inFlight was released, so a later activation is SENT, not parked pending.
+    // (The harness keeps rejecting, hence the rejects.toThrow — what matters is
+    // that sendArgs ran at all rather than the call sitting in `pending`.)
+    await expect(coalescer.enqueue({ item: makeItem('c') })).rejects.toThrow('RATE_LIMITED');
+    expect(sendArgs).toHaveBeenCalledTimes(3);
+  });
+
+  it('routes a SYNCHRONOUS throw from the deferred add to the error sink instead of wedging', async () => {
+    const first = deferred();
+    let sendCount = 0;
+    const sendArgs = vi.fn(async (_args: SetCurrentClimbArgs) => {
+      sendCount += 1;
+      if (sendCount === 1) {
+        await first.promise;
+        return;
+      }
+      if (sendCount === 2) throw new Error('RATE_LIMITED');
+    });
+    // Not `async`: the option type promises a Promise but nothing enforces it.
+    // Unguarded, this throw escapes the drain's enclosing `finally` and leaves
+    // inFlight stuck true forever.
+    const sendDeferredQueueAdd = vi.fn((_item: ClimbQueueItem): Promise<void> => {
+      throw new Error('sync boom');
+    });
+    const onDeferredQueueAddError = vi.fn();
+    const coalescer = createSetCurrentClimbCoalescer({ sendArgs, sendDeferredQueueAdd, onDeferredQueueAddError });
+
+    const firstEnqueue = coalescer.enqueue({ item: makeItem('a') });
+    await Promise.resolve();
+    await coalescer.enqueue({ item: makeItem('b'), shouldAddToQueue: true });
+
+    first.resolve();
+    await firstEnqueue;
+
+    expect(onDeferredQueueAddError).toHaveBeenCalledWith(expect.any(Error));
+    // Not wedged: a later activation is still sent.
+    await coalescer.enqueue({ item: makeItem('c') });
+    expect(sendArgs).toHaveBeenCalledTimes(3);
+  });
+
+  it('uses the DRAINED entry captured context, not the current one', async () => {
+    const first = deferred();
+    let currentSession = 'sess-A';
+    let sendCount = 0;
+    const sendArgs = vi.fn(async (_args: SetCurrentClimbArgs, _ctx: string) => {
+      sendCount += 1;
+      if (sendCount === 1) {
+        await first.promise;
+        return;
+      }
+      throw new Error('RATE_LIMITED');
+    });
+    const addCalls: Array<{ uuid: string; ctx: string }> = [];
+    const sendDeferredQueueAdd = vi.fn(async (item: ClimbQueueItem, ctx: string) => {
+      addCalls.push({ uuid: item.uuid, ctx });
+    });
+    const coalescer = createSetCurrentClimbCoalescer<string>({
+      getContext: () => currentSession,
+      sendArgs,
+      sendDeferredQueueAdd,
+      onDrainError: () => {},
+    });
+
+    const firstEnqueue = coalescer.enqueue({ item: makeItem('a') });
+    await Promise.resolve();
+    await coalescer.enqueue({ item: makeItem('b'), shouldAddToQueue: true });
+    // The session flips while 'b' is parked as pending.
+    currentSession = 'sess-B';
+
+    first.resolve();
+    await firstEnqueue;
+
+    expect(addCalls).toEqual([{ uuid: 'b', ctx: 'sess-A' }]);
+  });
+
+  // The disjointness that actually holds. It is NOT "one recovery per queue
+  // item": the head and a later pending entry can carry the same item (double-
+  // tapping one queue row does exactly that, since mobile's dispatchSetCurrent
+  // always sets shouldAddToQueue), and then both the caller-side recovery and
+  // the coalescer's deferred add fire for it. The server's add is idempotent by
+  // uuid, so the second one is a no-op.
+  it('never recovers the head-of-burst args itself — that rejection belongs to the caller', async () => {
+    const sendArgs = vi.fn(async (_args: SetCurrentClimbArgs) => {
+      throw new Error('RATE_LIMITED');
+    });
+    const sendDeferredQueueAdd = vi.fn(async (_item: ClimbQueueItem) => {});
+    const coalescer = createSetCurrentClimbCoalescer({ sendArgs, sendDeferredQueueAdd });
+
+    // No pending entry: a lone activation whose send rejects.
+    await expect(coalescer.enqueue({ item: makeItem('a'), shouldAddToQueue: true })).rejects.toThrow('RATE_LIMITED');
+
+    expect(sendDeferredQueueAdd).not.toHaveBeenCalled();
+  });
+
+  it('recovers a drained entry even when the head rejection also reaches the caller (same item)', async () => {
+    const first = deferred();
+    let sendCount = 0;
+    const sendArgs = vi.fn(async (_args: SetCurrentClimbArgs) => {
+      sendCount += 1;
+      if (sendCount === 1) {
+        await first.promise;
+        throw new Error('RATE_LIMITED head');
+      }
+      throw new Error('RATE_LIMITED drain');
+    });
+    const sendDeferredQueueAdd = vi.fn(async (_item: ClimbQueueItem) => {});
+    const coalescer = createSetCurrentClimbCoalescer({ sendArgs, sendDeferredQueueAdd, onDrainError: () => {} });
+
+    // Double-tapping one queue row: the same item is the burst head AND the
+    // pending entry.
+    const firstEnqueue = coalescer.enqueue({ item: makeItem('a'), shouldAddToQueue: true });
+    await Promise.resolve();
+    await coalescer.enqueue({ item: makeItem('a'), shouldAddToQueue: true });
+
+    first.resolve();
+    // The head's rejection still propagates, so a caller-side recovery can run.
+    await expect(firstEnqueue).rejects.toThrow('RATE_LIMITED head');
+    // And the drained copy is recovered here. Both paths firing for one item is
+    // acceptable: the server skips a duplicate uuid.
+    expect(sendDeferredQueueAdd).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/shared/queue-runtime/src/set-current-climb-coalescer.ts
+++ b/packages/shared/queue-runtime/src/set-current-climb-coalescer.ts
@@ -4,14 +4,22 @@
 // than the backend can process them. Stacking them up at the client is wasted
 // work — only the latest target climb matters. This factory implements
 // "serialize-and-supersede": at most one mutation in flight, the most recent
-// pending args win, and any superseded `shouldAddToQueue:true` payload still
-// gets its ADD_QUEUE_ITEM sent (so the queue mutation reaches the server even
-// when the setCurrentClimb is dropped).
+// pending args win.
+//
+// A dropped SET_CURRENT_CLIMB costs two things, not one. The pointer move
+// self-heals (the next activation or any peer broadcast re-establishes it), but
+// a `shouldAddToQueue:true` payload's brand-new queue slot does not — the
+// reducer already inserted it locally and no later activation retroactively
+// adds it, so the climb would sit in this climber's queue and nobody else's.
+// So both ways a pending activation can lose its setCurrentClimb fire the
+// content half on its own via `sendDeferredQueueAdd`:
+//   1. superseded while pending (a newer activation replaced it), and
+//   2. drained and then rejected (rate limit, socket blip) — #3936.
 //
 // Extracted from web's
 // `packages/web/app/components/persistent-session/hooks/use-queue-mutations.ts`
 // so mobile picks up the same semantics. Pure TS — no React, no GraphQL
-// client coupling. Callers wire `sendArgs` / `sendSupersededQueueAdd` to
+// client coupling. Callers wire `sendArgs` / `sendDeferredQueueAdd` to
 // their platform-specific transport.
 
 import type { ClimbQueueItem } from '@boardsesh/queue';
@@ -33,22 +41,24 @@ export type SetCurrentClimbCoalescerOptions<TContext = void, TItem = ClimbQueueI
    *  WS connection epoch — so a delayed drain dispatches against the same
    *  context the enqueue happened in, not whatever's current. */
   sendArgs: (args: SetCurrentClimbArgs<TItem>, context: TContext) => Promise<void>;
-  /** Fire-and-forget ADD_QUEUE_ITEM for a superseded request whose
-   *  shouldAddToQueue flag was true. Receives the context captured when
-   *  the now-superseded args were enqueued (not the current context) — so
-   *  a session that flipped between enqueue and supersede doesn't get a
-   *  stray queue-add. If omitted, superseded queue-adds are silently
-   *  dropped (matches the no-coalescing baseline mobile had before). */
-  sendSupersededQueueAdd?: (item: TItem, context: TContext) => Promise<void>;
+  /** Fire-and-forget ADD_QUEUE_ITEM for a pending request whose
+   *  shouldAddToQueue flag was true but whose SET_CURRENT_CLIMB never
+   *  landed — either because a newer activation superseded it, or because
+   *  it drained and then rejected. Receives the context captured when those
+   *  args were enqueued (not the current context) — so a session that
+   *  flipped in between doesn't get a stray queue-add. If omitted, deferred
+   *  queue-adds are silently dropped (matches the no-coalescing baseline
+   *  mobile had before). */
+  sendDeferredQueueAdd?: (item: TItem, context: TContext) => Promise<void>;
   /** Snapshot caller state at enqueue time. Whatever this returns is
    *  captured into the pending entry and threaded through to sendArgs /
-   *  sendSupersededQueueAdd. Defaults to `() => undefined`. */
+   *  sendDeferredQueueAdd. Defaults to `() => undefined`. */
   getContext?: () => TContext;
   /** Errors during the drain loop are swallowed — this is the sink. */
   onDrainError?: (error: unknown) => void;
-  /** Sink for errors when the fire-and-forget superseded ADD_QUEUE_ITEM
-   *  rejects. */
-  onSupersededQueueAddError?: (error: unknown) => void;
+  /** Sink for errors when the fire-and-forget deferred ADD_QUEUE_ITEM
+   *  rejects (or throws synchronously). */
+  onDeferredQueueAddError?: (error: unknown) => void;
 };
 
 export type SetCurrentClimbCoalescer<TItem = ClimbQueueItem> = {
@@ -73,11 +83,31 @@ export function createSetCurrentClimbCoalescer<TContext = void, TItem = ClimbQue
     ((err) => {
       console.error('Failed to send coalesced setCurrentClimb mutation:', err);
     });
-  const onSupersededQueueAddError =
-    options.onSupersededQueueAddError ??
+  const onDeferredQueueAddError =
+    options.onDeferredQueueAddError ??
     ((err) => {
-      console.error('Failed to add superseded queue item:', err);
+      console.error('Failed to add deferred queue item:', err);
     });
+
+  // Both loss paths (superseded-while-pending, drained-then-rejected) funnel
+  // here so they behave identically. Fire-and-forget by contract: a rate-limited
+  // ADD can sit in the transport's back-off for seconds, and awaiting it inside
+  // the drain loop would hold `inFlight` true, parking later activations as
+  // pending and manufacturing more supersedes.
+  function fireDeferredQueueAdd(lost: Pending): void {
+    const { item, shouldAddToQueue } = lost.args;
+    if (!shouldAddToQueue || item === null || options.sendDeferredQueueAdd === undefined) return;
+    try {
+      options.sendDeferredQueueAdd(item, lost.context).catch(onDeferredQueueAddError);
+    } catch (error) {
+      // The option type promises a Promise, but nothing stops a non-async
+      // implementation throwing synchronously. From the drain loop's `catch`
+      // that throw escapes the enclosing `finally`, so `inFlight` would stay
+      // true forever and every later activation would park as pending and never
+      // be sent. Route it to the same sink as a rejection.
+      onDeferredQueueAddError(error);
+    }
+  }
 
   return {
     async enqueue(args) {
@@ -90,16 +120,7 @@ export function createSetCurrentClimbCoalescer<TContext = void, TItem = ClimbQue
         // captured context — not the current one — so a session swap
         // between enqueue and supersede doesn't fire the queue-add against
         // the new session.
-        if (
-          state.pending !== null &&
-          state.pending.args.shouldAddToQueue &&
-          state.pending.args.item !== null &&
-          options.sendSupersededQueueAdd !== undefined
-        ) {
-          options
-            .sendSupersededQueueAdd(state.pending.args.item, state.pending.context)
-            .catch(onSupersededQueueAddError);
-        }
+        if (state.pending !== null) fireDeferredQueueAdd(state.pending);
         state.pending = { args, context };
         return;
       }
@@ -114,6 +135,12 @@ export function createSetCurrentClimbCoalescer<TContext = void, TItem = ClimbQue
           try {
             await options.sendArgs(next.args, next.context);
           } catch (error) {
+            // This drained activation's SET_CURRENT_CLIMB never landed, so its
+            // queue slot exists on this device and nowhere else. Recover the
+            // content half exactly like the superseded branch does (#3936).
+            // Before onDrainError, so a caller sink that throws can't swallow
+            // the recovery.
+            fireDeferredQueueAdd(next);
             onDrainError(error);
           }
         }

--- a/packages/web/app/components/persistent-session/hooks/use-queue-mutations.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-queue-mutations.ts
@@ -11,6 +11,10 @@ import { type Session, toClimbQueueItemInput } from '../types';
 type UseQueueMutationsArgs = {
   client: Client | null;
   session: Session | null;
+  /** The live local queue. Only read to position a deferred queue-add (a
+   *  superseded or drained-then-throttled activation) where the climber sees
+   *  it, so peers get the same order (#3936). */
+  queue: LocalClimbQueueItem[];
   /** Fired while a throttled mutation backs off to retry — see the caller's
    *  "catching up" snackbar wiring (#2655). */
   onRateLimited?: (event: RateLimitRetryEvent) => void;
@@ -23,14 +27,24 @@ type UseQueueMutationsArgs = {
 // the coalescer + cross-session-leak semantics.
 export type QueueMutationsActions = SharedQueueMutationsActions<LocalClimbQueueItem>;
 
-export function useQueueMutations({ client, session, onRateLimited }: UseQueueMutationsArgs): QueueMutationsActions {
+export function useQueueMutations({
+  client,
+  session,
+  queue,
+  onRateLimited,
+}: UseQueueMutationsArgs): QueueMutationsActions {
   // Refs keep the injected getters reading live values without recreating the
   // shared hook's callbacks on every render.
   const clientRef = useRef(client);
   const sessionRef = useRef(session);
+  const queueRef = useRef(queue);
   const onRateLimitedRef = useRef(onRateLimited);
   clientRef.current = client;
   sessionRef.current = session;
+  // Assigned during render (like its siblings) so a deferred queue-add resolving
+  // in the same tick as a queue event reads the post-event queue, not the
+  // previous render's.
+  queueRef.current = queue;
   onRateLimitedRef.current = onRateLimited;
 
   // No `ensureReady`: web sessions are already joined (see use-session-lifecycle),
@@ -40,6 +54,7 @@ export function useQueueMutations({ client, session, onRateLimited }: UseQueueMu
     getClient: () => clientRef.current,
     getSessionId: () => sessionRef.current?.id ?? null,
     toQueueItemInput: toClimbQueueItemInput,
+    getQueuePosition: (uuid) => queueRef.current.findIndex((queueItem) => queueItem.uuid === uuid),
     onBestEffortError: (action, error) => {
       console.error(`Failed to ${action}:`, error);
     },

--- a/packages/web/app/components/persistent-session/persistent-session-context.tsx
+++ b/packages/web/app/components/persistent-session/persistent-session-context.tsx
@@ -168,6 +168,10 @@ export const PersistentSessionProvider: React.FC<{ children: React.ReactNode }> 
   const mutations = useQueueMutations({
     client: lifecycle.client,
     session: lifecycle.session,
+    // Positions a deferred queue-add (superseded or drained-then-throttled
+    // activation) where this client shows it, so peers get the same order
+    // (#3936). Same reducer state `queueRef` above mirrors.
+    queue: eventProcessor.queue,
     onRateLimited,
   });
 


### PR DESCRIPTION
## Premise correction, up front

The issue's repro says "solo or party" and "the boulder you picked shows up at the bottom of everyone's queue".
Both are off, and one of them changes what to test:

1. **Party-only.** In solo there is no session, so `getContext()` returns null and the deferred queue-add bails on
   `!capturedSessionId` before sending anything (`create-queue-mutations.ts`). Mobile solo keeps the correct
   local order; web throws `Not connected to session` with no session. Neither bug is reachable without an
   active session.
2. **The picker does not see the bottom-of-queue order immediately.** Their own `QueueItemAdded` echo is
   uuid-idempotent (`insertQueueItemIdempotent`), so their local order is untouched. The _crew_ sees the wrong
   order right away; the picker sees it only once a FullSync or the ordered-hash drift watchdog rewrites their
   queue from the server — which the next activation's own add reliably triggers
   (`queue-navigation.ts` publishes `FullSync` whenever `addedToQueue`). Same user-visible damage, different
   mechanism.
3. **Web's exposure is much narrower than "two fast taps".** Web's ordinary activation does not use
   `shouldAddToQueue` at all — it sends an explicit `addQueueItem(item, currentIndex + 1)` then
   `setCurrentClimb(item, false, …)`. The only web caller that reaches the coalescer with a queue-add is
   promoting a playlist peek / suggested item. The mobile "two fast taps" claim holds.
4. **"Permanently and silently" overstates Bug 2.** Mobile runs the ordered-state-hash drift gate, so a
   local-only extra slot eventually triggers a resync that deletes it locally too. The durable harm is that the
   crew never gets the climb and the picker's pick disappears — not a permanent local ghost.
5. **The two platforms' optimistic inserts disagree**, which decides the fix's shape. Mobile activation inserts
   after current; mobile peek-promotion and web peek-promotion both _append_. There is no single "insert after
   current" rule to hard-code — the deferred add has to carry the position the item actually occupies in this
   client's queue.

Both defects reproduce. Verified with a throwaway vitest against the real `createQueueMutations` before writing
any fix: Bug 1 fires exactly one `ADD_QUEUE_ITEM` with `variables: { item }` and `position: undefined`; Bug 2
fires **zero** adds and surfaces only a dev-log `onBestEffortError('setCurrentClimb', …)`.

## Summary

Closes #3936. Both fixes land in the shared seam, so web and mobile get them together.

**Design call (the one the issue asked for): the issue's option 2** — recovery inside the coalescer, not a
widened `onDrainError`. Option 1 would have reused mobile's richer `recoverThrottledQueueAdd` but left web's
identical hole open forever and added a third recovery policy to a file that already has two. Approved by the
maintainer before implementation.

### `packages/shared/queue-runtime/src/set-current-climb-coalescer.ts`

- `sendSupersededQueueAdd` → `sendDeferredQueueAdd`, `onSupersededQueueAddError` → `onDeferredQueueAddError`.
  Single consumer, so the rename is compile-enforced (`grep` over the repo confirms: only the coalescer, its
  test, and `create-queue-mutations.ts`).
- One `fireDeferredQueueAdd(pending)` helper, called from **both** loss paths: superseded-while-pending
  (unchanged behaviour) and the drain loop's `catch` (new — Bug 2).
- The drain path fires the add **before** `onDrainError`, so a caller sink that throws cannot swallow the
  recovery, and **never awaits it**: a rate-limited ADD can sit in `execute`'s back-off for seconds, and
  awaiting it inside the drain would hold `inFlight` true, parking later activations as pending and
  manufacturing more supersedes.
- The helper body is `try`/`catch`-guarded. The option type promises a `Promise`, but a non-`async`
  implementation can throw synchronously — from inside the drain's `catch` that throw escapes the enclosing
  `finally` and wedges the coalescer with `inFlight` stuck true forever. Now it routes to
  `onDeferredQueueAddError` like a rejection.

### `packages/shared/queue-react/src/create-queue-mutations.ts`

- New **required** dep `getQueuePosition: (uuid) => number`. Required, not optional, so both bindings are
  compile-forced — an optional dep would silently fall back to appending, which _is_ the bug.
- The deferred add reads the position **after** the session guards and **live at send time**, then sends
  `{ item, position }`. The local index counts the items ahead of it that the server already has, so the insert
  reproduces this client's order; when an earlier item hasn't landed yet the index overshoots and the server
  clamps to an append — degrading to today's behaviour, not to a wrong position.

### Deviation from the plan (blocking review finding, and it matters)

The plan had `position === -1 → return` ("don't resurrect a climb they dropped"). **The adversarial review was
right that this makes the Bug-2 half of the fix inert in the dominant interleaving**, and I changed the design:

> the burst's head activation is itself an add → the server answers it with a `FullSync` → `FullSync` maps to
> `INITIAL_QUEUE_DATA` → the reducer **replaces** the queue wholesale (`queue: filteredQueue`) → the
> not-yet-sent pending slot is gone. The drained `SET_CURRENT_CLIMB` being recovered from is `RATE_LIMITED`,
> i.e. ≥ ~2s later, so by the time the deferred add reads the position the item has already been wiped and the
> guard would skip. Zero adds. Exactly the bug.

So absence is now split by cause:

- **the climber dropped it** → skip. Tracked by a ledger of dropped uuids. Queue-item uuids are per-slot and
  unique, so a re-added climb has a new uuid and is never falsely skipped.
- **a wholesale server sync replaced the queue** → send anyway, with no `position`. An append beats a drop:
  the crew getting the climb at the bottom is the pre-fix behaviour, dropping it is #3936.

This still satisfies maintainer ruling 3 (one shared helper, so the skip applies to the superseded path too),
it just makes the skip conditional on an actual drop instead of on mere absence.

#### What feeds the "climber dropped it" ledger (corrected after review)

The first cut of this PR claimed `removeQueueItem` was "the single choke point for every explicit removal on
both platforms". **That was wrong**, and the QA pass was right to block on it. Two climber-facing clears never
go near `removeQueueItem`:

- web's Clear button — `setQueue([])` (`play-view/queue-drawer.tsx`, `…/list/layout-client.tsx`)
- mobile's playlist "replace my queue" — `setQueue([item], item)` (`lib/playlists/use-playlist-activation.ts`)

Left as written, a climb activated just before either of those could have been resurrected onto the freshly
emptied queue by its own deferred add — new behaviour, since `main` sent nothing on that path at all. So
`setQueue` now records too: it diffs the new queue against the recent `shouldAddToQueue` activations and marks
anything the replace discarded. The diff is order-sensitive on purpose — an activation made _after_ a Clear was
never a candidate at Clear time, so a climb picked afterwards and then wiped by a server sync still reaches the
crew. Both directions are pinned by tests.

The full coverage statement, so the next reader does not have to re-derive it:

| Cause of local absence                                        | Behaviour          | Covered by                  |
| ------------------------------------------------------------- | ------------------ | --------------------------- |
| per-item remove / swipe / mobile clear-queue / #3934 undo leg | skip               | `removeQueueItem` ledger    |
| web Clear button, mobile playlist replace-my-queue            | skip               | `setQueue` diff             |
| wholesale server sync (`FullSync` → `INITIAL_QUEUE_DATA`)     | send, unpositioned | append branch               |
| **a PEER removed it mid-back-off**                            | send, unpositioned | **not covered** — see below |

A peer's removal arrives as a server delta and is indistinguishable from a sync at this layer, so it takes the
append branch and can resurrect a climb the peer just deleted. That is pre-existing on the superseded path
(`main` appended unconditionally there), it needs a signal this seam does not have, and it is called out rather
than papered over.

The ledger is also no longer a 50-entry ring. Mobile's `clearQueue` fires one `removeQueueItem` per queued
item in a single burst, so any queue longer than 50 evicted the earliest entries of its own clear and one climb
could reappear on the emptied queue. It is an insertion-ordered `Set` now, capped far above any realistic queue
purely so a pathological session cannot grow it without bound.

### Wiring

- mobile `queue-provider.tsx`: `stateRef.current.queue.findIndex(…)` — the same live read
  `recoverThrottledQueueAdd` already uses.
- web `persistent-session/hooks/use-queue-mutations.ts` + `persistent-session-context.tsx`: the reducer queue
  through a render-assigned ref, mirroring the sibling refs in that provider.
- `packages/backend/src/__tests__/helpers/headless-queue-client.ts`: third consumer the plan missed (second
  blocking review finding — it would have red-ed CI on the first push). Wired to the harness's **real** reducer
  queue, not a `() => -1` stub, which would compile and silently switch every deferred add off inside the
  integration harness that exists to exercise this seam.

No backend change, no schema change, no migration. JS-only → OTA-safe, no fingerprint change.

## Review findings, answered

| #            | Finding                                                                             | Resolution                                                                                                                                                                                                                                          |
| ------------ | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 1 (blocking) | `-1 → skip` makes the Bug-2 fix inert after a FullSync wipe                         | **Accepted, design changed.** Removal ledger + append-on-sync-wipe. Permanent test: `still sends the deferred add when a wholesale server sync wiped the local slot`.                                                                               |
| 2 (blocking) | Backend headless harness is a third consumer                                        | **Accepted.** Wired to real reducer state.                                                                                                                                                                                                          |
| 3            | "exactly one of {caller recovery, deferred add} fires" is false                     | **Accepted.** Two tests now: the head's rejection never fires its own deferred add, and the same-uuid double-rejection case where both _do_ fire (bounded — the resolver skips a duplicate uuid).                                                   |
| 4            | Web's burst-head rejection stays unfixed                                            | **True, and stated plainly.** Web has no caller-side recovery, so a web suggested-item promotion that _heads_ a throttled burst still loses its add. Web is fixed for the superseded and drained paths only. Filed as a follow-up (see below).      |
| 5            | Deferred ADD races the drained `setCurrentClimb`, so peer order is nondeterministic | **Accepted.** Device-QA items softened below, with the race spelled out.                                                                                                                                                                            |
| 6            | Assert full `variables` objects, and test 12 needs re-deriving                      | **Accepted.** Every position assertion is an exact `toEqual` on the whole variables object (`position` is optional on the same object, so `objectContaining` would stay green if it were dropped again). Test 12 re-derived against the new design. |
| 7 (nit)      | Sync throw from the helper wedges the coalescer                                     | **Accepted.** `try`/`catch` + its own test.                                                                                                                                                                                                         |
| 8 (nit)      | Stale prose; reuse an existing `CapturedMutationDeps` file                          | **Accepted.** Comment updated; the mobile test went into `queue-provider-local-queue.test.tsx`, which already captures the deps object.                                                                                                             |

Second QA pass, on the implementation:

| #              | Finding                                                                                                                            | Resolution                                                                                                                                                                                                                             |
| -------------- | ---------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| A (should-fix) | The "`removeQueueItem` is the single choke point" premise is false — web's Clear and mobile's playlist replace both use `setQueue` | **Accepted, and it was a real regression.** `setQueue` now records the discarded activations; the coverage table above replaces the wrong claim. Two new tests (the skip, and the ordering guard that keeps it from over-suppressing). |
| B (should-fix) | The 50-entry ring evicts the earliest entries of mobile's own >50-item clear                                                       | **Accepted.** Insertion-ordered `Set`, cap far above any realistic queue. New test drives a 60-item clear and asserts its **first** uuid is still suppressed.                                                                          |
| C (should-fix) | Release note overclaims "in the spot you put it" — the throttled path appends                                                      | **Accepted.** Copy rewritten to promise delivery always and position only when the app is not throttling.                                                                                                                              |
| D (nit)        | Device-QA gate 2's "A's pointer must not yank back" contradicts the FullSync analysis                                              | **Accepted.** `INITIAL_QUEUE_DATA` replaces `currentClimbQueueItem` too, so the pointer settling on the burst head is pre-existing on `main`. Gate reworded so it can't fail the PR.                                                   |
| E (nit)        | A peer removing the item mid-back-off takes the append branch                                                                      | **True, documented, not fixed.** In the coverage table above and at the guard. No signal for it at this layer.                                                                                                                         |
| F (nit)        | Mobile's `recoverThrottledQueueAdd` carries the same inert `position === -1` guard                                                 | **Filed as #4009** (mobile counterpart of #4006). Out of scope here — it is #3934's code path, not the coalescer's.                                                                                                                    |

## Test plan

`vp test run --reporter=agent packages/shared/queue-react packages/shared/queue-runtime` — 155 green
(baseline 139).
`vp run typecheck` (exit 0) · `vp test run --project mobile` 4681 green · `vp test run --project web` 5838
green · `vp test run --project backend` 2743 green (one flake on the first pass, green on a full re-run —
the known `VITEST_POOL_ID` sandbox flake, not this change) · `vp check` clean for every file this PR touches.

New tests, all **mutation-tested** (broken, confirmed red, restored):

| Mutation                                                         | Tests that go red               |
| ---------------------------------------------------------------- | ------------------------------- |
| delete `fireDeferredQueueAdd(next)` from the drain `catch`       | 8 (5 coalescer + 3 factory)     |
| drop `position` from the deferred ADD                            | 3                               |
| use the plan's original bare `-1 → skip`                         | 2, incl. the FullSync-wipe test |
| drop the explicit-remove skip                                    | 1                               |
| capture `getQueuePosition` at mount instead of through `depsRef` | 1                               |
| stub mobile's `getQueuePosition` to `() => -1`                   | 1                               |
| disable the `setQueue` discard diff (QA finding A)               | 1                               |
| shrink the ledger back to a 50-entry ring (QA finding B)         | 1                               |

The ordering-guard test (`still sends the deferred add when the wholesale replace happened BEFORE the
activation`) has no single-line mutation — it exists to block the cheaper design where `setQueue` stores its
resulting uuid set and the deferred add skips anything missing from it, which would re-break the FullSync case
for every climber who ever hit Clear.

The load-bearing one is `still sends the deferred add when a wholesale server sync wiped the local slot`: it
drives the real factory, replaces the local queue with a server snapshot lacking the item _while the throttled
send backs off_, and asserts an ADD still fires. That is the test the plan did not have, and it is the one that
makes the fix non-deletable.

## Device QA / maintainer gates

No native code, no BLE, no platform API — pure TS plus wiring, OTA-safe. This machine is Linux, and none of
these need macOS. **My read: desirable, not a merge gate.** Two phones on a `pr-<N>` OTA channel in one party
session (this also covers the gate #3934 left outstanding):

1. **Bug 1, no throttling needed.** On phone A activate a climb from search, then a second one fast enough that
   the first is still in flight. On phone B the first climb should land immediately after the current climb, not
   at the bottom.
2. **Bug 2.** Rapid-fire activations on A until "Too many changes too fast" appears. The **last** pick of the
   burst must now show up on B (it does not on `main`), exactly once. **Ignore where A's own pointer ends up** —
   `INITIAL_QUEUE_DATA` replaces `currentClimbQueueItem` as well as the queue, so the FullSync the burst head
   triggers can settle A back on an earlier climb. That happens on `main` too and this PR neither causes nor
   fixes it.
3. **Order caveat for 1 and 2 (review finding 5).** The deferred ADD and the drained `setCurrentClimb` are not
   ordered relative to each other, and the server anchors a `shouldAddToQueue` insert at the _server's_ current
   climb — which lags, because the superseded pointer never landed. So the tail of a heavily throttled burst can
   legitimately land one slot off, and a subsequent FullSync will publish that order. **A one-slot mismatch on a
   throttled burst is not a failure of this fix**; the climb reaching B at all is what changed. Judge item 1
   (unthrottled) strictly and item 2 loosely.
4. **Negative check.** Rapid _queue swipes_ (pointer-only, no `shouldAddToQueue`) must add nothing to either
   queue. Unit-tested, worth confirming in the wild.
5. **Web (deprecated surface, low priority).** In a party session, promote a playlist suggestion twice in quick
   succession and confirm the peer's order matches. That is web's only path into either bug.

Maintainer decisions already taken and reflected here: option 2 over option 1; `getQueuePosition` required;
one shared helper so the skip applies to both paths; close #3936 on this PR and file the web divergence
separately.

Two calls for the maintainer:

- **The deviation from ruling 3.** Absence with no matching drop now appends instead of skipping. Rationale and
  the FullSync evidence chain are above; the alternative is a fix that does nothing in the interleaving the
  issue describes.
- **The peer-removal case** (row 4 of the coverage table) stays on the append branch. If you want it skipped it
  needs a delta-origin signal this layer does not have, and it is a separate change.

## Follow-ups filed

- **Mobile's burst-head hole** (filed as #4009). `recoverThrottledQueueAdd` carries the same `position === -1`
  bail this PR had to design around, so #3934's caller-side recovery goes inert once a FullSync wipes the local
  slot — and then fires a `removeQueueItem` that undoes an add which did land. Mobile counterpart of #4006.
- **Web's burst-head hole** (filed as #4006). `queue-actions-core.ts`'s coalescer `.catch` logs and cleans up but never re-sends,
  and `enqueue` only rejects for the burst-_starting_ call — so a web suggested-item promotion that heads a
  throttled burst still loses its ADD, with neither recovery firing. Not fixed here; on the surface being
  replaced by the RN web deploy.
- **Web peek-promotion `insertAfterCurrent` divergence** (filed as #4007). `queue-actions-core.ts` omits `insertAfterCurrent`, so
  it appends locally while the server's `setCurrentClimb(shouldAddToQueue)` inserts after current — the two
  disagree with no throttling and no coalescing at all. Low priority, same deprecated surface.
- **Resync fallback for a doubly-failed deferred add.** Stays a dev-log, as the superseded path always has.

## Release Notes

- Pick climbs back to back in a party session and none of them go missing. A quick double-pick now lands right
  after the current climb for the whole crew instead of at the bottom, and a climb you picked while the app was
  throttling still reaches them rather than vanishing.
