### PR TITLE
fix(backend): MoonBoard playlist activation left the queue empty

### DIFF
--- a/packages/backend/src/__tests__/hydrate-climbs.test.ts
+++ b/packages/backend/src/__tests__/hydrate-climbs.test.ts
@@ -292,6 +292,38 @@ describe('hydrateClimbsByRefs', () => {
 
       expect(result[0].angle).toBe(40);
     });
+
+    // `wallAngle` is the angle of the wall the user is standing at, not a
+    // display hint: the queue, the board-presence broadcast and the logged
+    // ascent all read it back. So it survives the stats fallback that
+    // `angleOverrides` follows.
+    it('reports wallAngle verbatim even when the stats join fell back to another angle', async () => {
+      mockDb.select.mockReturnValueOnce(makeChain([{ ...baseRow, statsAngle: 50 }]));
+
+      const result = await hydrateClimbsByRefs([{ climbUuid: 'c1', boardType: 'kilter' }], { wallAngle: 40 });
+
+      expect(result[0].angle).toBe(40);
+    });
+
+    it('reports wallAngle when the climb has no stats row at all', async () => {
+      mockDb.select.mockReturnValueOnce(makeChain([{ ...baseRow, statsAngle: null }]));
+
+      const result = await hydrateClimbsByRefs([{ climbUuid: 'c1', boardType: 'kilter' }], { wallAngle: 25 });
+
+      expect(result[0].angle).toBe(25);
+    });
+
+    it('lets wallAngle win over a conflicting per-ref override', async () => {
+      mockDb.select.mockReturnValueOnce(makeChain([{ ...baseRow, statsAngle: 50 }]));
+
+      const overrides = new Map<string, number | null>([['kilter:c1', 30]]);
+      const result = await hydrateClimbsByRefs([{ climbUuid: 'c1', boardType: 'kilter' }], {
+        wallAngle: 40,
+        angleOverrides: overrides,
+      });
+
+      expect(result[0].angle).toBe(40);
+    });
   });
 
   describe('flattened Boardsesh grade fields', () => {

--- a/packages/backend/src/__tests__/playlist-climbs-moonboard-size-filter.test.ts
+++ b/packages/backend/src/__tests__/playlist-climbs-moonboard-size-filter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vite-plus/test';
+import { describe, it, expect, beforeAll, afterAll } from 'vite-plus/test';
 import { sql } from 'drizzle-orm';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { db } from '../db/client';
@@ -84,6 +84,13 @@ describe('playlistClimbs / setterClimbsFull — size filter skips non-size-scope
     `);
   });
 
+  // Hand the worker DB back clean: `playlists` isn't in setup.ts's reset list
+  // and the explicit ids above don't advance the sequence, so leaving rows
+  // behind would collide with the next file that inserts without an id.
+  afterAll(async () => {
+    await db.execute(sql`TRUNCATE TABLE playlist_climbs, playlist_ownership, playlists RESTART IDENTITY CASCADE`);
+  });
+
   it('returns every MoonBoard playlist climb in specific-board mode even when a sizeId is passed', async () => {
     const result = await playlistQueries.playlistClimbs(
       null,
@@ -96,7 +103,7 @@ describe('playlistClimbs / setterClimbsFull — size filter skips non-size-scope
     expect(result.hasMore).toBe(false);
   });
 
-  it('still size-filters Aurora boards, and falls back to the most-ascents angle when the requested angle has no stats', async () => {
+  it('still size-filters Aurora boards, and keeps the requested angle while the grade falls back', async () => {
     const result = await playlistQueries.playlistClimbs(
       null,
       { input: { playlistId: KILTER_PLAYLIST_UUID, boardName: 'kilter', layoutId: 1, sizeId: 10, angle: 40 } },
@@ -105,9 +112,13 @@ describe('playlistClimbs / setterClimbsFull — size filter skips non-size-scope
 
     expect(result.climbs.map((climb) => climb.uuid)).toEqual(['kilter-sized-climb']);
     // No 40° stats row → the EXISTS guard drops the override and the join
-    // falls back to the most-ascents angle (50°) instead of blanking the grade.
-    expect(result.climbs[0].angle).toBe(50);
+    // falls back to the most-ascents angle (50°) instead of blanking the grade…
     expect(result.climbs[0].difficulty).toBeTruthy();
+    // …but the reported angle stays the wall the user asked for. These climbs
+    // are queued straight from playlist activation, and the tick badge, the
+    // board-presence report and the logged ascent all read `climb.angle` as
+    // the angle of the wall in front of the user.
+    expect(result.climbs[0].angle).toBe(40);
   });
 
   it('setterClimbsFull returns MoonBoard climbs in specific-board mode even when a sizeId is passed', async () => {

--- a/packages/backend/src/__tests__/playlist-climbs-moonboard-size-filter.test.ts
+++ b/packages/backend/src/__tests__/playlist-climbs-moonboard-size-filter.test.ts
@@ -50,7 +50,10 @@ async function seedStats(boardType: string, uuid: string, angle: number, display
 
 describe('playlistClimbs / setterClimbsFull — size filter skips non-size-scoped boards (real DB)', () => {
   beforeAll(async () => {
-    // Playlist tables aren't in the global per-file reset list, so own the cleanup.
+    // Playlist tables aren't in the global per-file reset list, so own the
+    // cleanup. Truncating is safe here: every vitest worker runs against its own
+    // throwaway database (worker-db.ts, keyed on VITEST_POOL_ID) and files
+    // inside a worker run one at a time, so no other file is mid-seed.
     await db.execute(sql`TRUNCATE TABLE playlist_climbs, playlist_ownership, playlists RESTART IDENTITY CASCADE`);
 
     // MoonBoard climbs: compatible_size_ids stays NULL, as in production —

--- a/packages/backend/src/__tests__/playlist-climbs-moonboard-size-filter.test.ts
+++ b/packages/backend/src/__tests__/playlist-climbs-moonboard-size-filter.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeAll } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { playlistQueries } from '../graphql/resolvers/playlists/queries';
+import { setterFollowQueries } from '../graphql/resolvers/social/setter-follows';
+
+// Seeds use raw `sql` rather than `db.insert(...)` because the integration test
+// DB is built from a minimal hand-maintained DDL (schema-sql.ts), not the full
+// Drizzle schema — the query builder emits every default-bearing column (e.g.
+// quality_normalized) which that DDL omits, so a builder insert fails. Naming
+// only the columns the test DDL declares is the genuine raw-SQL exception.
+
+// Integration test (real DB) for the MoonBoard playlist-activation bug: the
+// specific-board playlistClimbs query filtered on compatible_size_ids, which
+// MoonBoard climbs never have populated (single fixed size), so `1 = ANY(NULL)`
+// dropped every row and activating a playlist climb left the queue with only
+// the tapped climb. The size filter must skip non-size-scoped boards while
+// still applying to Aurora boards. setterClimbsFull had the identical filter.
+
+const MOON_PLAYLIST_UUID = 'pl-moon-size-filter';
+const KILTER_PLAYLIST_UUID = 'pl-kilter-size-filter';
+
+function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext {
+  return {
+    connectionId: 'conn-1',
+    isAuthenticated: false,
+    userId: null,
+    sessionId: null,
+    boardPath: null,
+    controllerId: null,
+    controllerApiKey: null,
+    ...overrides,
+  } as ConnectionContext;
+}
+
+async function seedClimb(boardType: string, uuid: string, name: string, setter: string, sizeIdsSql: string) {
+  await db.execute(sql`
+    INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, description, frames, is_listed, compatible_size_ids)
+    VALUES (${uuid}, ${boardType}, 1, ${setter}, ${name}, '', 'p1r1', true, ${sql.raw(sizeIdsSql)})
+  `);
+}
+
+async function seedStats(boardType: string, uuid: string, angle: number, displayDifficulty: number, ascents: number) {
+  await db.execute(sql`
+    INSERT INTO board_climb_stats (board_type, climb_uuid, angle, display_difficulty, difficulty_average, quality_average, ascensionist_count, benchmark_difficulty)
+    VALUES (${boardType}, ${uuid}, ${angle}, ${displayDifficulty}, ${displayDifficulty}, 3.0, ${ascents}, 0)
+  `);
+}
+
+describe('playlistClimbs / setterClimbsFull — size filter skips non-size-scoped boards (real DB)', () => {
+  beforeAll(async () => {
+    // Playlist tables aren't in the global per-file reset list, so own the cleanup.
+    await db.execute(sql`TRUNCATE TABLE playlist_climbs, playlist_ownership, playlists RESTART IDENTITY CASCADE`);
+
+    // MoonBoard climbs: compatible_size_ids stays NULL, as in production —
+    // populate-denormalized-columns skips the size-edges step for moonboard.
+    await seedClimb('moonboard', 'moon-climb-1', 'Moon one', 'moon-setter', 'NULL');
+    await seedStats('moonboard', 'moon-climb-1', 40, 20, 50);
+    await seedClimb('moonboard', 'moon-climb-2', 'Moon two', 'moon-setter', 'NULL');
+    await seedStats('moonboard', 'moon-climb-2', 40, 22, 30);
+
+    // Kilter climbs: one compatible with size 10, one only with size 99 — the
+    // size filter must still apply to size-scoped boards. The size-10 climb has
+    // stats ONLY at 50°, so a 40° request also exercises the most-ascents
+    // fallback the specific-board path gained by moving onto hydrateClimbsByRefs.
+    await seedClimb('kilter', 'kilter-sized-climb', 'Fits size 10', 'kilter-setter', 'ARRAY[10]::integer[]');
+    await seedStats('kilter', 'kilter-sized-climb', 50, 18, 100);
+    await seedClimb('kilter', 'kilter-other-size-climb', 'Fits size 99 only', 'kilter-setter', 'ARRAY[99]::integer[]');
+    await seedStats('kilter', 'kilter-other-size-climb', 40, 19, 80);
+
+    await db.execute(sql`
+      INSERT INTO playlists (id, uuid, board_type, layout_id, name, is_public)
+      VALUES (1, ${MOON_PLAYLIST_UUID}, 'moonboard', 1, 'Moon circuit', true),
+             (2, ${KILTER_PLAYLIST_UUID}, 'kilter', 1, 'Kilter circuit', true)
+    `);
+    await db.execute(sql`
+      INSERT INTO playlist_climbs (playlist_id, climb_uuid, angle, position)
+      VALUES (1, 'moon-climb-1', 40, 0), (1, 'moon-climb-2', 40, 1),
+             (2, 'kilter-sized-climb', 40, 0), (2, 'kilter-other-size-climb', 40, 1)
+    `);
+  });
+
+  it('returns every MoonBoard playlist climb in specific-board mode even when a sizeId is passed', async () => {
+    const result = await playlistQueries.playlistClimbs(
+      null,
+      { input: { playlistId: MOON_PLAYLIST_UUID, boardName: 'moonboard', layoutId: 1, sizeId: 1, angle: 40 } },
+      makeCtx(),
+    );
+
+    expect(result.climbs.map((climb) => climb.uuid)).toEqual(['moon-climb-1', 'moon-climb-2']);
+    expect(result.climbs[0].difficulty).toBeTruthy();
+    expect(result.hasMore).toBe(false);
+  });
+
+  it('still size-filters Aurora boards, and falls back to the most-ascents angle when the requested angle has no stats', async () => {
+    const result = await playlistQueries.playlistClimbs(
+      null,
+      { input: { playlistId: KILTER_PLAYLIST_UUID, boardName: 'kilter', layoutId: 1, sizeId: 10, angle: 40 } },
+      makeCtx(),
+    );
+
+    expect(result.climbs.map((climb) => climb.uuid)).toEqual(['kilter-sized-climb']);
+    // No 40° stats row → the EXISTS guard drops the override and the join
+    // falls back to the most-ascents angle (50°) instead of blanking the grade.
+    expect(result.climbs[0].angle).toBe(50);
+    expect(result.climbs[0].difficulty).toBeTruthy();
+  });
+
+  it('setterClimbsFull returns MoonBoard climbs in specific-board mode even when a sizeId is passed', async () => {
+    const result = await setterFollowQueries.setterClimbsFull(
+      null,
+      { input: { username: 'moon-setter', boardType: 'moonboard', layoutId: 1, sizeId: 1, angle: 40 } },
+      makeCtx(),
+    );
+
+    expect(result.totalCount).toBe(2);
+    expect(result.climbs.map((climb) => climb.uuid).sort()).toEqual(['moon-climb-1', 'moon-climb-2']);
+  });
+
+  it('setterClimbsFull still size-filters Aurora boards', async () => {
+    const result = await setterFollowQueries.setterClimbsFull(
+      null,
+      { input: { username: 'kilter-setter', boardType: 'kilter', layoutId: 1, sizeId: 10, angle: 40 } },
+      makeCtx(),
+    );
+
+    expect(result.climbs.map((climb) => climb.uuid)).toEqual(['kilter-sized-climb']);
+    expect(result.totalCount).toBe(1);
+  });
+});

--- a/packages/backend/src/__tests__/playlist-queries.test.ts
+++ b/packages/backend/src/__tests__/playlist-queries.test.ts
@@ -341,20 +341,23 @@ describe('playlistClimbs resolver', () => {
     const countChain = createMockChain([{ count: 1 }]);
     mockDb.select.mockReturnValueOnce(countChain);
 
-    // 3. Climbs query (specific-board mode)
+    // 3. Refs query (specific-board mode)
+    const refsChain = createMockChain([{ climbUuid: 'climb-1', playlistAngle: 40 }]);
+    mockDb.select.mockReturnValueOnce(refsChain);
+
+    // 4. Hydrate query
     const climbsChain = createMockChain([
       {
         climbUuid: 'climb-1',
-        playlistAngle: 40,
-        position: 0,
-        uuid: 'climb-1',
         layoutId: 1,
+        boardType: 'kilter',
         setter_username: 'setter1',
         name: 'Kilter Climb',
         description: '',
         frames: '',
+        statsAngle: 40,
         ascensionist_count: 10,
-        difficulty: 'V5',
+        difficulty_id: 5,
         quality_average: 3.5,
         difficulty_error: 0.2,
         benchmark_difficulty: null,

--- a/packages/backend/src/__tests__/resolver-frames-fields.test.ts
+++ b/packages/backend/src/__tests__/resolver-frames-fields.test.ts
@@ -178,7 +178,9 @@ describe('playlistClimbs (specific-board) surfaces framesCount/framesPace', () =
 
     // count query
     mockDb.select.mockReturnValueOnce(makeChain([{ count: 1 }]));
-    // climb data (fetchSpecificBoardClimbs)
+    // ref page (fetchSpecificBoardClimbs)
+    mockDb.select.mockReturnValueOnce(makeChain([{ climbUuid: 'climb-abc', playlistAngle: 40 }]));
+    // climb data (hydrateClimbsByRefs)
     mockDb.select.mockReturnValueOnce(makeChain([rawClimbRow()]));
 
     const result = await playlistClimbs(
@@ -195,11 +197,13 @@ describe('playlistClimbs (specific-board) surfaces framesCount/framesPace', () =
     const { playlistClimbs } = await import('../graphql/resolvers/playlists/queries/playlist-climbs');
 
     mockDb.select.mockReturnValueOnce(makeChain([{ count: 1 }]));
+    mockDb.select.mockReturnValueOnce(makeChain([{ climbUuid: 'climb-abc', playlistAngle: 40 }]));
     mockDb.select.mockReturnValueOnce(makeChain([rawClimbRow()]));
 
     await playlistClimbs(null, { input: { playlistId: '1', boardName: 'kilter', angle: 40 } }, makeCtx());
 
-    const dataSelectArg = mockDb.select.mock.calls[1]?.[0] as Record<string, unknown> | undefined;
+    // Third call is the hydrator's data select; first arg is the projection object
+    const dataSelectArg = mockDb.select.mock.calls[2]?.[0] as Record<string, unknown> | undefined;
     const keys = dataSelectArg ? Object.keys(dataSelectArg) : [];
     expect(keys).toContain('frames_count');
     expect(keys).toContain('frames_pace');

--- a/packages/backend/src/__tests__/smart-playlists.test.ts
+++ b/packages/backend/src/__tests__/smart-playlists.test.ts
@@ -127,6 +127,30 @@ const USER_ROW = {
   avatarUrl: 'https://img/marco-avatar.jpg',
 };
 
+/** A full page of recommendation refs, as `selectRecommendationClimbRefs` returns them. */
+function makeRecommendationRefs(count: number) {
+  return Array.from({ length: count }, (_, index) => ({ climbUuid: `rec-${index}`, boardType: 'kilter' }));
+}
+
+/** The hydrator row `hydrateClimbsByRefs` selects for one of those refs. */
+function hydratedRowFor(ref: { climbUuid: string; boardType: string }) {
+  return {
+    climbUuid: ref.climbUuid,
+    layoutId: 8,
+    boardType: ref.boardType,
+    setter_username: 'u',
+    name: `climb ${ref.climbUuid}`,
+    description: '',
+    frames: '',
+    statsAngle: 45,
+    ascensionist_count: 5,
+    difficulty_id: 20,
+    quality_average: 5,
+    difficulty_error: 0,
+    benchmark_difficulty: null,
+  };
+}
+
 describe('smartPlaylist resolver', () => {
   beforeEach(() => {
     // resetAllMocks (not clearAllMocks) so the `mockReturnValueOnce` queues
@@ -460,11 +484,13 @@ describe('smartPlaylist resolver', () => {
 
   it('RECOMMENDED_* keeps hasMore true below the offset clamp when more climbs remain', async () => {
     const ctx = makeCtx();
+    const refs = makeRecommendationRefs(20);
     resolveTargetMock.mockResolvedValueOnce({ boardType: 'kilter', layoutId: 8, sizeId: 25, angle: 45, setIds: null });
-    selectRefsMock.mockResolvedValueOnce([]);
+    selectRefsMock.mockResolvedValueOnce(refs);
     countRefsMock.mockResolvedValueOnce(1000);
-    // fetchUserMeta; hydrate short-circuits on an empty refs page.
+    // fetchUserMeta, then the hydrator's data select.
     mockDb.select.mockReturnValueOnce(makeChain([USER_ROW]).chain);
+    mockDb.select.mockReturnValueOnce(makeChain(refs.map(hydratedRowFor)).chain);
 
     const result = await playlistQueries.smartPlaylist(
       null,
@@ -472,15 +498,18 @@ describe('smartPlaylist resolver', () => {
       ctx,
     );
 
+    expect(result.climbs).toHaveLength(20);
     expect(result.hasMore).toBe(true);
   });
 
   it('RECOMMENDED_* terminates paging at the offset clamp even when totalCount says more remain', async () => {
     const ctx = makeCtx();
+    const refs = makeRecommendationRefs(20);
     resolveTargetMock.mockResolvedValueOnce({ boardType: 'kilter', layoutId: 8, sizeId: 25, angle: 45, setIds: null });
-    selectRefsMock.mockResolvedValueOnce([]);
+    selectRefsMock.mockResolvedValueOnce(refs);
     countRefsMock.mockResolvedValueOnce(1000);
     mockDb.select.mockReturnValueOnce(makeChain([USER_ROW]).chain);
+    mockDb.select.mockReturnValueOnce(makeChain(refs.map(hydratedRowFor)).chain);
 
     // MAX_RECOMMENDATION_OFFSET (500) / pageSize (20) clamps at page 25 — any
     // request past it re-serves that same page, so hasMore must go false there
@@ -491,6 +520,7 @@ describe('smartPlaylist resolver', () => {
       ctx,
     );
 
+    expect(result.climbs).toHaveLength(20);
     expect(result.hasMore).toBe(false);
     expect(selectRefsMock).toHaveBeenCalledWith('RECOMMENDED_CROWD_FAVORITES', expect.anything(), 'user-123', 25, 20);
   });

--- a/packages/backend/src/__tests__/smart-playlists.test.ts
+++ b/packages/backend/src/__tests__/smart-playlists.test.ts
@@ -457,6 +457,43 @@ describe('smartPlaylist resolver', () => {
     expect(result.climbs[0]).toMatchObject({ uuid: 'c1', angle: 45 });
     expect(selectRefsMock).toHaveBeenCalledTimes(1);
   });
+
+  it('RECOMMENDED_* keeps hasMore true below the offset clamp when more climbs remain', async () => {
+    const ctx = makeCtx();
+    resolveTargetMock.mockResolvedValueOnce({ boardType: 'kilter', layoutId: 8, sizeId: 25, angle: 45, setIds: null });
+    selectRefsMock.mockResolvedValueOnce([]);
+    countRefsMock.mockResolvedValueOnce(1000);
+    // fetchUserMeta; hydrate short-circuits on an empty refs page.
+    mockDb.select.mockReturnValueOnce(makeChain([USER_ROW]).chain);
+
+    const result = await playlistQueries.smartPlaylist(
+      null,
+      { input: { type: 'RECOMMENDED_CROWD_FAVORITES', userId: 'user-123', page: 5, pageSize: 20 } },
+      ctx,
+    );
+
+    expect(result.hasMore).toBe(true);
+  });
+
+  it('RECOMMENDED_* terminates paging at the offset clamp even when totalCount says more remain', async () => {
+    const ctx = makeCtx();
+    resolveTargetMock.mockResolvedValueOnce({ boardType: 'kilter', layoutId: 8, sizeId: 25, angle: 45, setIds: null });
+    selectRefsMock.mockResolvedValueOnce([]);
+    countRefsMock.mockResolvedValueOnce(1000);
+    mockDb.select.mockReturnValueOnce(makeChain([USER_ROW]).chain);
+
+    // MAX_RECOMMENDATION_OFFSET (500) / pageSize (20) clamps at page 25 — any
+    // request past it re-serves that same page, so hasMore must go false there
+    // or infinite scroll refetches the identical page forever.
+    const result = await playlistQueries.smartPlaylist(
+      null,
+      { input: { type: 'RECOMMENDED_CROWD_FAVORITES', userId: 'user-123', page: 30, pageSize: 20 } },
+      ctx,
+    );
+
+    expect(result.hasMore).toBe(false);
+    expect(selectRefsMock).toHaveBeenCalledWith('RECOMMENDED_CROWD_FAVORITES', expect.anything(), 'user-123', 25, 20);
+  });
 });
 
 describe('mySmartPlaylistCounts resolver', () => {

--- a/packages/backend/src/graphql/resolvers/playlists/helpers/hydrate-climbs.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/helpers/hydrate-climbs.ts
@@ -16,6 +16,17 @@ export type HydrateClimbsOptions = {
    * `null` values are treated as "no override" (same as omitting the entry).
    */
   angleOverrides?: Map<string, number | null>;
+  /**
+   * Single angle applied to every ref — the wall the user is actually on. Stats
+   * still fall back to the most-ascended angle when the climb has nothing at
+   * this angle (so the grade never blanks), but the returned `angle` stays the
+   * requested one, because downstream consumers (queue tick badges, board
+   * presence, logged ascents) read it as the live wall angle.
+   *
+   * Takes precedence over `angleOverrides`, which stays the right choice when
+   * each ref genuinely carries its own angle.
+   */
+  wallAngle?: number;
 };
 
 /**
@@ -37,13 +48,28 @@ export async function hydrateClimbsByRefs(refs: ClimbRef[], options?: HydrateCli
   // the board's angle; playlists store a per-climb angle), join board_climb_stats
   // at THAT angle so difficulty/quality/ascents/benchmark all match — not just
   // the returned `angle` field. Falls back to the most-ascended angle.
-  const overrideEntries = [...(options?.angleOverrides ?? new Map<string, number | null>())].filter(
-    (entry): entry is [string, number] => typeof entry[1] === 'number',
-  );
+  const wallAngle = typeof options?.wallAngle === 'number' ? options.wallAngle : null;
+  const overrideEntries =
+    wallAngle != null
+      ? []
+      : [...(options?.angleOverrides ?? new Map<string, number | null>())].filter(
+          (entry): entry is [string, number] => typeof entry[1] === 'number',
+        );
   // The override only wins when the climb actually has a stats row at that
   // angle — the EXISTS guard makes a missing row yield NULL so the COALESCE
   // falls through to the most-ascended angle rather than blanking the grade
   // (a climb with no ascents at the user's selected angle still shows one).
+  // One wall angle for every ref needs no VALUES list — just the same guard
+  // around a constant.
+  const wallAngleExpr =
+    wallAngle == null
+      ? null
+      : sql`(SELECT ${wallAngle}::int WHERE EXISTS (
+            SELECT 1 FROM board_climb_stats s_ov
+            WHERE s_ov.board_type = ${tables.climbs.boardType}
+              AND s_ov.climb_uuid = ${tables.climbs.uuid}
+              AND s_ov.angle = ${wallAngle}::int
+          ))`;
   const overrideAngleExpr = overrideEntries.length
     ? sql`(SELECT ov.angle FROM (VALUES ${sql.join(
         overrideEntries.map(([key, angle]) => {
@@ -61,7 +87,7 @@ export async function hydrateClimbsByRefs(refs: ClimbRef[], options?: HydrateCli
               AND s_ov.climb_uuid = ${tables.climbs.uuid}
               AND s_ov.angle = ov.angle
           ))`
-    : sql`NULL::int`;
+    : (wallAngleExpr ?? sql`NULL::int`);
 
   const rows = await db
     .select({
@@ -140,7 +166,11 @@ export async function hydrateClimbsByRefs(refs: ClimbRef[], options?: HydrateCli
     // `angle` always matches the difficulty/quality/ascents shown — the
     // override can fall back to most-ascents (via the EXISTS guard above) when
     // the climb has no stats at the requested angle.
-    const angle = row.statsAngle ?? override ?? DEFAULT_ANGLE;
+    // A caller-supplied wall angle is the live board angle and is returned
+    // verbatim, even when the stats join fell back to the most-ascended angle
+    // for the displayed grade. Otherwise prefer the angle the stats row was
+    // actually joined at, so `angle` matches the difficulty shown.
+    const angle = wallAngle ?? row.statsAngle ?? override ?? DEFAULT_ANGLE;
     const boardName = (row.boardType || ref.boardType) as BoardName;
     climbs.push({
       uuid: row.climbUuid,

--- a/packages/backend/src/graphql/resolvers/playlists/queries/playlist-climbs.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/playlist-climbs.ts
@@ -3,7 +3,6 @@ import { type ConnectionContext, type Climb, type BoardName, SUPPORTED_BOARDS } 
 import { isSizeScopedBoard, parseSetIds } from '@boardsesh/board-config';
 import { db } from '../../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
-import { getClimbStars, getGradeLabel, toConfidenceTier } from '@boardsesh/db/queries';
 import { validateInput } from '../../shared/helpers';
 import { GetPlaylistClimbsInputSchema } from '../../../../validation/schemas';
 import { UNIFIED_TABLES, isValidBoardName } from '../../../../db/queries/util/table-select';
@@ -32,6 +31,12 @@ function paginateResults<T>(results: T[], pageSize: number) {
 
 /**
  * Specific-board mode: fetch climbs filtered by board type, layout, and size edges.
+ *
+ * Same two-step shape as the all-boards path: read the page of refs from
+ * playlistClimbs (with the board/layout/size filters on the join), then hand
+ * them to the shared hydrator, which joins stats/grades at the requested angle
+ * and falls back to the most-ascended angle when the climb has no stats there
+ * — so the selected angle never blanks a grade.
  */
 async function fetchSpecificBoardClimbs(
   playlistId: bigint,
@@ -94,78 +99,31 @@ async function fetchSpecificBoardClimbs(
     );
   }
 
-  const inputAngle = input.angle ?? 40;
-
-  const results = await db
+  const refRows = await db
     .select({
       climbUuid: dbSchema.playlistClimbs.climbUuid,
       playlistAngle: dbSchema.playlistClimbs.angle,
-      position: dbSchema.playlistClimbs.position,
-      uuid: tables.climbs.uuid,
-      layoutId: tables.climbs.layoutId,
-      setter_username: tables.climbs.setterUsername,
-      name: tables.climbs.name,
-      description: tables.climbs.description,
-      frames: tables.climbs.frames,
-      frames_count: tables.climbs.framesCount,
-      frames_pace: tables.climbs.framesPace,
-      ascensionist_count: tables.climbStats.ascensionistCount,
-      difficulty_id: sql<number | null>`ROUND(${tables.climbStats.displayDifficulty}::numeric, 0)`,
-      quality_average: sql<number>`ROUND(${tables.climbStats.qualityAverage}::numeric, 2)`,
-      difficulty_error: sql<number>`ROUND(${tables.climbStats.difficultyAverage}::numeric - ${tables.climbStats.displayDifficulty}::numeric, 2)`,
-      benchmark_difficulty: tables.climbStats.benchmarkDifficulty,
-      boardsesh_difficulty: sql<
-        number | null
-      >`COALESCE(${dbSchema.boardClimbGrades.universalGrade}, ${dbSchema.boardClimbGrades.localGrade})`,
-      boardsesh_confidence: dbSchema.boardClimbGrades.confidence,
     })
     .from(dbSchema.playlistClimbs)
     .innerJoin(tables.climbs, and(...climbJoinConditions))
-    .leftJoin(
-      tables.climbStats,
-      and(
-        eq(tables.climbStats.climbUuid, dbSchema.playlistClimbs.climbUuid),
-        eq(tables.climbStats.boardType, boardName),
-        eq(tables.climbStats.angle, inputAngle),
-      ),
-    )
-    // Boardsesh grade at the same angle the stats row was joined at (inputAngle).
-    .leftJoin(
-      dbSchema.boardClimbGrades,
-      and(
-        eq(dbSchema.boardClimbGrades.climbUuid, dbSchema.playlistClimbs.climbUuid),
-        eq(dbSchema.boardClimbGrades.boardType, boardName),
-        eq(dbSchema.boardClimbGrades.angle, inputAngle),
-      ),
-    )
     .where(eq(dbSchema.playlistClimbs.playlistId, playlistId))
     .orderBy(asc(dbSchema.playlistClimbs.position), asc(dbSchema.playlistClimbs.addedAt))
     .limit(pageSize + 1)
     .offset(page * pageSize);
 
-  const { items, hasMore } = paginateResults(results, pageSize);
+  const { items, hasMore } = paginateResults(refRows, pageSize);
 
-  const climbs: Climb[] = items.map((result) => ({
-    uuid: result.uuid || result.climbUuid,
-    layoutId: result.layoutId,
-    setter_username: result.setter_username || '',
-    name: result.name || '',
-    description: result.description || '',
-    frames: result.frames || '',
-    framesCount: result.frames_count ?? null,
-    framesPace: result.frames_pace ?? null,
-    angle: inputAngle,
-    ascensionist_count: Number(result.ascensionist_count || 0),
-    difficulty: getGradeLabel(result.difficulty_id),
-    quality_average: result.quality_average?.toString() || '0',
-    stars: getClimbStars(result.quality_average),
-    difficulty_error: result.difficulty_error?.toString() || '0',
-    benchmark_difficulty:
-      result.benchmark_difficulty && result.benchmark_difficulty > 0 ? result.benchmark_difficulty.toString() : null,
-    boardType: boardName,
-    boardseshDifficulty: result.boardsesh_difficulty == null ? null : Number(result.boardsesh_difficulty),
-    boardseshConfidence: toConfidenceTier(result.boardsesh_confidence),
-  }));
+  // The caller's angle (the wall the user is on) wins; a climb's added-at
+  // angle is the secondary signal, mirroring the all-boards path.
+  const angleOverrides = new Map<string, number | null>();
+  for (const row of items) {
+    angleOverrides.set(`${boardName}:${row.climbUuid}`, input.angle ?? row.playlistAngle ?? null);
+  }
+
+  const climbs = await hydrateClimbsByRefs(
+    items.map((row) => ({ climbUuid: row.climbUuid, boardType: boardName })),
+    { angleOverrides },
+  );
 
   return { climbs, hasMore };
 }

--- a/packages/backend/src/graphql/resolvers/playlists/queries/playlist-climbs.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/playlist-climbs.ts
@@ -7,7 +7,7 @@ import { validateInput } from '../../shared/helpers';
 import { GetPlaylistClimbsInputSchema } from '../../../../validation/schemas';
 import { UNIFIED_TABLES, isValidBoardName } from '../../../../db/queries/util/table-select';
 import { verifyPlaylistAccess } from '../helpers/enrichment';
-import { hydrateClimbsByRefs } from '../helpers/hydrate-climbs';
+import { hydrateClimbsByRefs, type HydrateClimbsOptions } from '../helpers/hydrate-climbs';
 
 export type PlaylistClimbsInput = {
   playlistId: string;
@@ -36,7 +36,10 @@ function paginateResults<T>(results: T[], pageSize: number) {
  * playlistClimbs (with the board/layout/size filters on the join), then hand
  * them to the shared hydrator, which joins stats/grades at the requested angle
  * and falls back to the most-ascended angle when the climb has no stats there
- * — so the selected angle never blanks a grade.
+ * — so the selected angle never blanks a grade. The returned `angle` still
+ * reports the requested wall angle: these climbs go straight into the queue on
+ * playlist activation, and the tick badge, the board-presence report and the
+ * logged ascent all read `climb.angle` as the wall in front of the user.
  */
 async function fetchSpecificBoardClimbs(
   playlistId: bigint,
@@ -113,16 +116,23 @@ async function fetchSpecificBoardClimbs(
 
   const { items, hasMore } = paginateResults(refRows, pageSize);
 
-  // The caller's angle (the wall the user is on) wins; a climb's added-at
-  // angle is the secondary signal, mirroring the all-boards path.
-  const angleOverrides = new Map<string, number | null>();
-  for (const row of items) {
-    angleOverrides.set(`${boardName}:${row.climbUuid}`, input.angle ?? row.playlistAngle ?? null);
+  // The caller's angle is the wall the user is standing at, so it applies to
+  // every row and is reported back verbatim. Without one, fall back per row to
+  // the climb's added-at angle, mirroring the all-boards path.
+  let hydrateOptions: HydrateClimbsOptions;
+  if (input.angle != null) {
+    hydrateOptions = { wallAngle: input.angle };
+  } else {
+    const angleOverrides = new Map<string, number | null>();
+    for (const row of items) {
+      angleOverrides.set(`${boardName}:${row.climbUuid}`, row.playlistAngle ?? null);
+    }
+    hydrateOptions = { angleOverrides };
   }
 
   const climbs = await hydrateClimbsByRefs(
     items.map((row) => ({ climbUuid: row.climbUuid, boardType: boardName })),
-    { angleOverrides },
+    hydrateOptions,
   );
 
   return { climbs, hasMore };

--- a/packages/backend/src/graphql/resolvers/playlists/queries/smart-playlists.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/smart-playlists.ts
@@ -295,7 +295,8 @@ export const smartPlaylist = async (
     if (!target) {
       return { meta: emptyMeta, climbs: [], totalCount: 0, hasMore: false };
     }
-    const recPage = Math.min(page, Math.floor(MAX_RECOMMENDATION_OFFSET / pageSize));
+    const maxRecPage = Math.floor(MAX_RECOMMENDATION_OFFSET / pageSize);
+    const recPage = Math.min(page, maxRecPage);
     const owner = await fetchUserMeta(input.userId);
     const [pageRefs, totalCount] = await Promise.all([
       selectRecommendationClimbRefs(input.type, target, input.userId, recPage, pageSize),
@@ -316,7 +317,10 @@ export const smartPlaylist = async (
       },
       climbs,
       totalCount,
-      hasMore: (recPage + 1) * pageSize < totalCount,
+      // Paging stops at the offset clamp: past maxRecPage every request would
+      // re-serve the same clamped page, so hasMore must go false there even
+      // when totalCount says otherwise (infinite-scroll loop otherwise).
+      hasMore: recPage < maxRecPage && (recPage + 1) * pageSize < totalCount,
     };
   }
 

--- a/packages/backend/src/graphql/resolvers/social/setter-follows.ts
+++ b/packages/backend/src/graphql/resolvers/social/setter-follows.ts
@@ -1,4 +1,5 @@
 import { eq, and, count, sql, ilike, inArray } from 'drizzle-orm';
+import { isSizeScopedBoard } from '@boardsesh/board-config';
 import { type ConnectionContext, type Climb, type BoardName, SUPPORTED_BOARDS } from '@boardsesh/shared-schema';
 import { executeRows } from '@boardsesh/db/client';
 import { db } from '../../../db/client';
@@ -238,8 +239,10 @@ export const setterFollowQueries = {
         filterConditions.push(eq(tables.climbs.layoutId, layoutId));
       }
 
-      // Filter by compatible size if sizeId is provided
-      if (sizeId != null) {
+      // Filter by compatible size if sizeId is provided. MoonBoard climbs never
+      // have compatible_size_ids populated (single fixed size), so a size filter
+      // would drop every row: `1 = ANY(NULL)` is NULL.
+      if (sizeId != null && isSizeScopedBoard(boardName)) {
         filterConditions.push(sql`${sizeId} = ANY(${tables.climbs.compatibleSizeIds})`);
       }
 

--- a/packages/web/app/components/climb-actions/actions/playlist-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/playlist-action.tsx
@@ -41,9 +41,6 @@ export function PlaylistAction({
   onComplete,
   onOpenPlaylistSelector,
 }: ClimbActionProps): ClimbActionResult {
-  // Playlists not supported for moonboard yet
-  const isMoonboard = boardDetails.board_name === 'moonboard';
-
   const { t } = useTranslation('climbs');
   const { openAuthModal } = useAuthModal();
   const [popoverOpen, setPopoverOpen] = useState(false);
@@ -445,7 +442,7 @@ export function PlaylistAction({
     expandedContent,
     menuItem,
     key: 'playlist',
-    available: !isMoonboard,
+    available: true,
   };
 }
 

--- a/packages/web/app/components/library/__tests__/playlist-edit-drawer.test.tsx
+++ b/packages/web/app/components/library/__tests__/playlist-edit-drawer.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import PlaylistEditDrawer from '../playlist-edit-drawer';
+import type { Playlist } from '@boardsesh/graphql/operations/playlists';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+const mockShowMessage = vi.fn();
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: mockShowMessage }),
+}));
+
+const mockUseWsAuthToken = vi.fn();
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => mockUseWsAuthToken(),
+}));
+
+const mockExecuteGraphQL = vi.fn();
+vi.mock('@/app/lib/graphql/client', () => ({
+  executeGraphQL: (...args: unknown[]) => mockExecuteGraphQL(...args),
+}));
+
+vi.mock('@/app/components/swipeable-drawer/swipeable-drawer', () => ({
+  default: (props: { open: boolean; extra?: React.ReactNode; children?: React.ReactNode }) => {
+    if (!props.open) return null;
+    return (
+      <div data-testid="drawer">
+        {props.children}
+        <div data-testid="drawer-extra">{props.extra}</div>
+      </div>
+    );
+  },
+}));
+
+function createPlaylist(overrides?: Partial<Playlist>): Playlist {
+  return {
+    id: '1',
+    uuid: 'pl-uuid-1',
+    boardType: 'kilter',
+    layoutId: 1,
+    name: 'Crimp circuit',
+    description: 'Ten hard ones',
+    isPublic: false,
+    color: '#ff0000',
+    icon: '🔥',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as Playlist;
+}
+
+const getDescriptionField = () =>
+  screen.getByPlaceholderText(tFromCatalog('playlists', 'edit.fields.descriptionPlaceholder')) as HTMLTextAreaElement;
+const getSave = () =>
+  within(screen.getByTestId('drawer-extra')).getByRole('button', {
+    name: tFromCatalog('playlists', 'edit.actions.save'),
+  });
+const getRemoveIcon = () => screen.getByRole('button', { name: tFromCatalog('playlists', 'edit.fields.removeIcon') });
+
+describe('PlaylistEditDrawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseWsAuthToken.mockReturnValue({ token: 'test-token', isAuthenticated: true, isLoading: false });
+  });
+
+  function renderDrawer(playlist: Playlist) {
+    const onClose = vi.fn();
+    const onSuccess = vi.fn();
+    render(<PlaylistEditDrawer open playlist={playlist} onClose={onClose} onSuccess={onSuccess} />);
+    return { onClose, onSuccess };
+  }
+
+  // The server contract is '' = clear the field, undefined = leave it unchanged.
+  // The drawer used to map an emptied field to undefined, so "Remove" on the
+  // icon and a cleared description silently did nothing on save.
+  it("sends '' for an emptied description and a removed icon so the server clears them", async () => {
+    const playlist = createPlaylist();
+    mockExecuteGraphQL.mockResolvedValueOnce({ updatePlaylist: playlist });
+    const { onSuccess, onClose } = renderDrawer(playlist);
+
+    await waitFor(() => expect(getDescriptionField().value).toBe('Ten hard ones'));
+
+    fireEvent.change(getDescriptionField(), { target: { value: '' } });
+    fireEvent.click(getRemoveIcon());
+    fireEvent.click(getSave());
+
+    await waitFor(() => expect(mockExecuteGraphQL).toHaveBeenCalledTimes(1));
+
+    const [, variables, token] = mockExecuteGraphQL.mock.calls[0];
+    expect(variables).toEqual({
+      input: {
+        playlistId: 'pl-uuid-1',
+        name: 'Crimp circuit',
+        description: '',
+        color: '#ff0000',
+        icon: '',
+        isPublic: false,
+      },
+    });
+    expect(token).toBe('test-token');
+    expect(onSuccess).toHaveBeenCalledWith(playlist);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves untouched fields at their seeded values', async () => {
+    const playlist = createPlaylist();
+    mockExecuteGraphQL.mockResolvedValueOnce({ updatePlaylist: playlist });
+    renderDrawer(playlist);
+
+    await waitFor(() => expect(getDescriptionField().value).toBe('Ten hard ones'));
+    fireEvent.click(getSave());
+
+    await waitFor(() => expect(mockExecuteGraphQL).toHaveBeenCalledTimes(1));
+
+    const [, variables] = mockExecuteGraphQL.mock.calls[0];
+    expect(variables).toEqual({
+      input: {
+        playlistId: 'pl-uuid-1',
+        name: 'Crimp circuit',
+        description: 'Ten hard ones',
+        color: '#ff0000',
+        icon: '🔥',
+        isPublic: false,
+      },
+    });
+  });
+
+  it("sends '' for a playlist that never had a colour or icon", async () => {
+    const playlist = createPlaylist({ color: undefined, icon: undefined, description: undefined });
+    mockExecuteGraphQL.mockResolvedValueOnce({ updatePlaylist: playlist });
+    renderDrawer(playlist);
+
+    await waitFor(() => expect(getDescriptionField().value).toBe(''));
+    fireEvent.click(getSave());
+
+    await waitFor(() => expect(mockExecuteGraphQL).toHaveBeenCalledTimes(1));
+
+    const [, variables] = mockExecuteGraphQL.mock.calls[0];
+    expect(variables).toEqual({
+      input: {
+        playlistId: 'pl-uuid-1',
+        name: 'Crimp circuit',
+        description: '',
+        color: '',
+        icon: '',
+        isPublic: false,
+      },
+    });
+  });
+
+  it('shows an error and keeps the drawer open when the mutation fails', async () => {
+    const playlist = createPlaylist();
+    mockExecuteGraphQL.mockRejectedValueOnce(new Error('boom'));
+    const { onSuccess, onClose } = renderDrawer(playlist);
+
+    fireEvent.click(getSave());
+
+    await waitFor(() =>
+      expect(mockShowMessage).toHaveBeenCalledWith(tFromCatalog('playlists', 'edit.messages.updateFailed'), 'error'),
+    );
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/components/library/playlist-edit-drawer.tsx
+++ b/packages/web/app/components/library/playlist-edit-drawer.tsx
@@ -111,19 +111,24 @@ export default function PlaylistEditDrawer({ open, playlist, onClose, onSuccess 
 
       // Extract and validate hex color
       let colorHex: string | undefined;
-      if (formValues.color && isValidHexColor(formValues.color)) {
+      if (!formValues.color) {
+        colorHex = '';
+      } else if (isValidHexColor(formValues.color)) {
         colorHex = formValues.color;
       }
 
+      // The server treats '' as "clear this field" and undefined as "leave
+      // unchanged" — the form is seeded from the playlist, so send the values
+      // as-is and an emptied description/icon/colour actually clears.
       const response = await executeGraphQL<UpdatePlaylistMutationResponse, UpdatePlaylistMutationVariables>(
         UPDATE_PLAYLIST,
         {
           input: {
             playlistId: playlist.uuid,
             name: formValues.name,
-            description: formValues.description || undefined,
+            description: formValues.description,
             color: colorHex,
-            icon: formValues.icon || undefined,
+            icon: formValues.icon,
             isPublic: formValues.isPublic,
           },
         },

--- a/packages/web/app/components/library/playlist-edit-drawer.tsx
+++ b/packages/web/app/components/library/playlist-edit-drawer.tsx
@@ -48,9 +48,11 @@ const EmojiPicker = dynamic(
   },
 );
 
-// Validate hex color format
+// Matches the server's PlaylistColorSchema (`^(#[0-9A-Fa-f]{6})?$`) exactly.
+// A shorthand `#abc` would pass a looser check here and then fail validation
+// server-side, sinking the whole updatePlaylist mutation, not just the colour.
 const isValidHexColor = (color: string): boolean => {
-  return /^#([0-9A-Fa-f]{3}){1,2}$/.test(color);
+  return /^#[0-9A-Fa-f]{6}$/.test(color);
 };
 
 type PlaylistEditDrawerProps = {

--- a/packages/web/app/hooks/__tests__/use-climb-actions-data.test.tsx
+++ b/packages/web/app/hooks/__tests__/use-climb-actions-data.test.tsx
@@ -265,6 +265,35 @@ describe('useClimbActionsData', () => {
     });
   });
 
+  // Playlists are Boardsesh-native, not an Aurora feature, so MoonBoard climbs
+  // get the same membership read as Kilter/Tension. It used to be gated off,
+  // which left the "already in this playlist" checkmarks permanently blank.
+  it('reads playlist membership for MoonBoard climbs', async () => {
+    mockRequest.mockResolvedValueOnce({ favorites: [] });
+    mockRequest.mockResolvedValueOnce({
+      allUserPlaylists: {
+        playlists: [{ uuid: 'pl-moon', name: 'Moon circuit', climbCount: 4 }],
+        totalCount: 1,
+        hasMore: false,
+      },
+    });
+    mockRequest.mockResolvedValueOnce({
+      playlistsForClimbs: [{ climbUuid: 'climb-1', playlistUuids: ['pl-moon'] }],
+    });
+
+    const wrapper = createQueryWrapper();
+    const { result } = renderHook(() => useClimbActionsData({ ...defaultOptions, boardName: 'moonboard' }), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.playlistsProviderProps.playlistMemberships.get('climb-1')?.has('pl-moon')).toBe(true);
+    });
+    expect(mockRequest).toHaveBeenCalledWith('GET_PLAYLISTS_FOR_CLIMBS', {
+      input: { boardType: 'moonboard', layoutId: 1, climbUuids: ['climb-1', 'climb-2'] },
+    });
+  });
+
   it('addToPlaylist sends mutation and updates accumulated cache', async () => {
     mockRequest.mockResolvedValueOnce({ favorites: [] });
     mockRequest.mockResolvedValueOnce({

--- a/packages/web/app/hooks/use-climb-actions-data.tsx
+++ b/packages/web/app/hooks/use-climb-actions-data.tsx
@@ -209,8 +209,7 @@ export function useClimbActionsData({ boardName, layoutId, angle, climbUuids }: 
     {
       accumulatedKey: memAccKey,
       fetchKeyPrefix: memFetchKeyPrefix,
-      // MoonBoard doesn't support playlists (no playlist API in Aurora for MoonBoard)
-      enabled: isAuthenticated && !isAuthLoading && !!boardName && layoutId > 0 && boardName !== 'moonboard',
+      enabled: isAuthenticated && !isAuthLoading && !!boardName && layoutId > 0,
       fetchChunk: memFetchChunk,
       merge: mergeMapFn,
       initialValue: EMPTY_MAP,


### PR DESCRIPTION
## Summary

Setting a climb active from a playlist is supposed to fill the queue with the following playlist items. On Aurora boards it does; on MoonBoard the queue ended up holding only the tapped climb.

Root cause: the board-scoped `playlistClimbs` query filters on `compatible_size_ids`, which MoonBoard climbs never have populated (single fixed size, and `populate-denormalized-columns` deliberately skips the size-edges step for moonboard). `sizeId = ANY(NULL)` evaluates to NULL, so the inner join dropped every row and the activation refresh returned zero climbs. The fix guards the size filter with the existing `isSizeScopedBoard` predicate (already used by the sync resolvers and offline search). `setterClimbsFull` had the identical unguarded filter — a setter's MoonBoard climbs came back empty too — and gets the same guard.

The activation path is the one this bug lands on: `playlist-detail-content.tsx` → `fetchPlaylistSuggestionClimbs` → `playlistClimbs` in specific-board mode with the board's `sizeId`, feeding `usePlaylistClimbActivation`'s refreshed suggestion source.

While in the playlist code, this also fixes the worst findings from a review of the feature:

- **Specific-board playlist climbs now hydrate through `hydrateClimbsByRefs`** (same two-step shape as all-boards mode), gaining the most-ascents angle fallback: a selected angle with no stats row no longer blanks the grade/stars. MoonBoard (25°/40° only) was hit hardest by the old hard `leftJoin` at the requested angle.
- **Removed the leftover MoonBoard gating on web playlist actions.** Playlists are Boardsesh-native (the old comment claiming an Aurora API dependency was wrong), but the membership read was disabled for moonboard while add/remove/create were reachable — so checkmarks never showed and removal was impossible. Membership reads and the playlist action are now enabled for MoonBoard.
- **Playlist edit drawer can actually clear description/icon/colour.** The server contract is `''` = clear, `undefined` = leave unchanged; the drawer mapped empty fields to `undefined`, so "Remove icon" silently did nothing on save.
- **Smart-playlist recommendation paging terminates at the offset clamp.** `hasMore` was computed from the uncapped total while the offset clamped at page 25, so infinite scroll refetched the same page forever once a pool exceeded 520 climbs.

Remaining medium/low findings from the review are being filed as separate issues.

## Release Notes

- MoonBoard playlists now queue up properly — set a climb active and the rest of the playlist lines up behind it
- Add MoonBoard climbs to playlists from the queue and play views, with checkmarks that actually show what's already in
- Removing a playlist's icon or description now sticks when you save
- Playlist climbs keep their grade even at angles nobody's logged yet

## Test plan

- Backend integration test (`playlist-climbs-moonboard-size-filter.test.ts`, real DB): a moonboard playlist in specific-board mode with a `sizeId` returns its climbs; a kilter playlist still size-filters; the most-ascents angle fallback kicks in when the requested angle has no stats; same pair of cases for `setterClimbsFull`. Deleting the `isSizeScopedBoard` guard fails 2 of the 4.
- Web test (`playlist-edit-drawer.test.tsx`): an emptied description and a removed icon go out as `''`, untouched fields keep their seeded values, and a colourless playlist still clears. Reverting the drawer fix fails 3 of the 4.
- Web test (`use-climb-actions-data.test.tsx`): a moonboard board name still issues `GET_PLAYLISTS_FOR_CLIMBS` and fills `playlistMemberships` — putting the old `boardName !== 'moonboard'` gate back fails it.
- Unit tests in `smart-playlists.test.ts`: `hasMore` stays true below the recommendation offset clamp, goes false at it. Both drive a full page of refs plus the matching hydrator rows (an empty page against `totalCount=1000` isn't a state production can reach).
- `vp check`, `vp run typecheck:backend`, `vp run typecheck:web`, `vp test run --project backend playlist`/`smart-playlists`, `vp test run --project web playlist-edit-drawer` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzNSyNEB2RVMdaYwrKLY1Q

