### PR TITLE
docs(repo): require a Fable review on all Bluetooth changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Boardsesh is a monorepo. Next.js 16 web app + React Native (Expo) mobile app for
 - No AI-generated images. Real photos or diagrams only.
 - No buzzwords. Concrete numbers, plain language.
 - Default to action. Full autonomy except no data deletion without asking.
+- **Bluetooth changes require a Fable review.** Any change touching Bluetooth/BLE code — `packages/shared/ble-protocol/`, `packages/mobile/src/lib/ble/`, or the web Bluetooth LED control in `packages/web` — must be reviewed by Fable before merge.
 
 ## PR Lifecycle (mandatory)
 


### PR DESCRIPTION
## Summary

Adds a Project Rule to `CLAUDE.md`: any change touching Bluetooth/BLE code (`packages/shared/ble-protocol/`, `packages/mobile/src/lib/ble/`, or the web Bluetooth LED control in `packages/web`) must be reviewed by Fable before merge. BLE is the code area where a plausible-looking fix most easily ships a subtle regression (see the identity-vs-boolean discussion on #3998), so review of these changes is pinned to the strongest available reviewer.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

Docs-only change to `CLAUDE.md`; no code paths affected. Verified the file renders correctly and the new bullet sits under Project Rules.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZf2ipf3bu6vw7G623ZQHn)_