### PR TITLE
fix(mobile): tell the climber when a queue change is throttled

### DIFF
--- a/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
@@ -77,7 +77,10 @@ vi.mock('react-native', () => ({
   AppState: { addEventListener: vi.fn(() => ({ remove: vi.fn() })) },
 }));
 vi.mock('expo-crypto', () => ({ randomUUID: () => 'test-correlation-id' }));
-vi.mock('@boardsesh/graphql-client', () => ({ execute: graph.execute }));
+vi.mock('@boardsesh/graphql-client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/graphql-client')>()),
+  execute: graph.execute,
+}));
 vi.mock('@boardsesh/queue-react', () => ({ useQueueMutations: () => queueMutations }));
 vi.mock('@boardsesh/play-view', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@boardsesh/play-view')>()),

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -2618,8 +2618,45 @@ describe('QueueProvider mutation-failure resync', () => {
     });
 
     await waitFor(() => {
-      expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.rateLimited', 'error');
+      expect(toast.showToast.mock.calls.map(([message]) => message)).toEqual([
+        'mobile.queue.rateLimited',
+        'mobile.queue.outOfSyncRefreshed',
+      ]);
     });
+    expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.actionFailed', 'error');
+  });
+
+  it('keeps a non-throttled clear failure silent about pacing', async () => {
+    const snapshots: Snapshot[] = [];
+    const serverItem = makeQueueItem('server-kept', 'climb-kept');
+    routeHttpRequest(queueStateResponse([serverItem]));
+    queueMutations.removeQueueItem.mockRejectedValueOnce(new Error('network'));
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    const prepared = snapshots.at(-1);
+    if (!prepared) throw new Error('queue snapshot was not captured');
+    act(() => {
+      prepared.addToQueue(makeQueueItem('clear-one', 'climb-clear-one'));
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['clear-one']);
+    });
+
+    const snapshot = snapshots.at(-1);
+    if (!snapshot) throw new Error('queue snapshot was not captured');
+    act(() => {
+      snapshot.clearQueue();
+    });
+
+    await waitFor(() => {
+      expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.outOfSyncRefreshed', 'error');
+    });
+    expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.rateLimited', 'error');
     expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.actionFailed', 'error');
   });
 

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -239,6 +239,7 @@ type Snapshot = {
   playlistSuggestionSource: PlaylistSuggestionSource | null;
   addToQueue: ReturnType<typeof useQueue>['addToQueue'];
   removeFromQueue: ReturnType<typeof useQueue>['removeFromQueue'];
+  clearQueue: ReturnType<typeof useQueue>['clearQueue'];
   reorderQueue: ReturnType<typeof useQueue>['reorderQueue'];
   setQueue: ReturnType<typeof useQueue>['setQueue'];
   setCurrentClimb: ReturnType<typeof useQueue>['setCurrentClimb'];
@@ -336,6 +337,7 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
       playlistSuggestionSource,
       addToQueue: queue.addToQueue,
       removeFromQueue: queue.removeFromQueue,
+      clearQueue: queue.clearQueue,
       reorderQueue: queue.reorderQueue,
       setQueue: queue.setQueue,
       setCurrentClimb: queue.setCurrentClimb,
@@ -357,6 +359,7 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
     playlistSuggestionSource,
     queue.addToQueue,
     queue.removeFromQueue,
+    queue.clearQueue,
     queue.reorderQueue,
     queue.setQueue,
     queue.setCurrentClimb,
@@ -2478,6 +2481,176 @@ describe('QueueProvider mutation-failure resync', () => {
     // retry loop fired. No "refreshed" toast since nothing was applied.
     expect(queueStateCalls).toBe(1);
     expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.outOfSyncRefreshed', 'error');
+  });
+
+  // #3929: a throttled queue-CONTENT mutation used to be completely silent
+  // about pacing — the climber only ever saw the delayed "Queue was out of
+  // sync" notice, which reads as a bug rather than "ease off". These four cover
+  // add / remove / setQueue / clearQueue. The pacing hint lands first and the
+  // refresh notice still follows, exactly like the setCurrentClimb path above.
+  it('surfaces the pacing hint when a throttled add fails in a session', async () => {
+    const snapshots: Snapshot[] = [];
+    const serverItem = makeQueueItem('server-item', 'climb-server');
+    let queueStateCalls = 0;
+    routeHttpRequest(queueStateResponse([serverItem]), { onQueueStateCall: () => (queueStateCalls += 1) });
+    queueMutations.addQueueItem.mockRejectedValueOnce(makeRateLimitedError());
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    const snapshot = snapshots.at(-1);
+    if (!snapshot) throw new Error('queue snapshot was not captured');
+    act(() => {
+      snapshot.addToQueue(makeQueueItem('local-add', 'climb-local'));
+    });
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['server-item']);
+    });
+    // The divergence is real, so reconciliation still runs on top of the toast.
+    expect(queueStateCalls).toBe(1);
+    expect(toast.showToast.mock.calls.map(([message]) => message)).toEqual([
+      'mobile.queue.rateLimited',
+      'mobile.queue.outOfSyncRefreshed',
+    ]);
+  });
+
+  it('surfaces the pacing hint when a throttled remove fails in a session', async () => {
+    const snapshots: Snapshot[] = [];
+    const serverItem = makeQueueItem('server-kept', 'climb-kept');
+    let queueStateCalls = 0;
+    routeHttpRequest(queueStateResponse([serverItem]), { onQueueStateCall: () => (queueStateCalls += 1) });
+    queueMutations.removeQueueItem.mockRejectedValueOnce(makeRateLimitedError());
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    const prepared = snapshots.at(-1);
+    if (!prepared) throw new Error('queue snapshot was not captured');
+    act(() => {
+      prepared.addToQueue(makeQueueItem('to-remove', 'climb-remove'));
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toContain('to-remove');
+    });
+
+    const snapshot = snapshots.at(-1);
+    if (!snapshot) throw new Error('queue snapshot was not captured');
+    act(() => {
+      snapshot.removeFromQueue('to-remove');
+    });
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['server-kept']);
+    });
+    expect(queueStateCalls).toBe(1);
+    expect(toast.showToast.mock.calls.map(([message]) => message)).toEqual([
+      'mobile.queue.rateLimited',
+      'mobile.queue.outOfSyncRefreshed',
+    ]);
+  });
+
+  it('surfaces the pacing hint when a throttled setQueue fails in a session', async () => {
+    const snapshots: Snapshot[] = [];
+    const serverItem = makeQueueItem('server-item', 'climb-server');
+    let queueStateCalls = 0;
+    routeHttpRequest(queueStateResponse([serverItem]), { onQueueStateCall: () => (queueStateCalls += 1) });
+    queueMutations.setQueue.mockRejectedValueOnce(makeRateLimitedError());
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    const snapshot = snapshots.at(-1);
+    if (!snapshot) throw new Error('queue snapshot was not captured');
+    act(() => {
+      snapshot.setQueue([makeQueueItem('replaced-one', 'climb-replaced-one')]);
+    });
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['server-item']);
+    });
+    expect(queueStateCalls).toBe(1);
+    expect(toast.showToast.mock.calls.map(([message]) => message)).toEqual([
+      'mobile.queue.rateLimited',
+      'mobile.queue.outOfSyncRefreshed',
+    ]);
+  });
+
+  it('prefers the throttled rejection when clearing a queue partly fails', async () => {
+    const snapshots: Snapshot[] = [];
+    const serverItem = makeQueueItem('server-kept', 'climb-kept');
+    routeHttpRequest(queueStateResponse([serverItem]));
+    // The limiter typically rejects the TAIL of a clear's per-item removes, so
+    // the plain failure comes first: an implementation that classifies
+    // rejectedRemovals[0] would miss the pacing hint entirely.
+    queueMutations.removeQueueItem.mockRejectedValueOnce(new Error('network'));
+    queueMutations.removeQueueItem.mockRejectedValueOnce(makeRateLimitedError());
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    const prepared = snapshots.at(-1);
+    if (!prepared) throw new Error('queue snapshot was not captured');
+    act(() => {
+      prepared.addToQueue(makeQueueItem('clear-one', 'climb-clear-one'));
+      prepared.addToQueue(makeQueueItem('clear-two', 'climb-clear-two'));
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['clear-one', 'clear-two']);
+    });
+
+    const snapshot = snapshots.at(-1);
+    if (!snapshot) throw new Error('queue snapshot was not captured');
+    act(() => {
+      snapshot.clearQueue();
+    });
+
+    await waitFor(() => {
+      expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.rateLimited', 'error');
+    });
+    expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.actionFailed', 'error');
+  });
+
+  it('keeps a non-throttled add failure silent about pacing', async () => {
+    const snapshots: Snapshot[] = [];
+    const serverItem = makeQueueItem('server-item', 'climb-server');
+    let queueStateCalls = 0;
+    routeHttpRequest(queueStateResponse([serverItem]), { onQueueStateCall: () => (queueStateCalls += 1) });
+    queueMutations.addQueueItem.mockRejectedValueOnce(new Error('add failed'));
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    const snapshot = snapshots.at(-1);
+    if (!snapshot) throw new Error('queue snapshot was not captured');
+    act(() => {
+      snapshot.addToQueue(makeQueueItem('local-add', 'climb-local'));
+    });
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['server-item']);
+    });
+    expect(queueStateCalls).toBe(1);
+    // Guard test: a best-effort add that fails offline/transiently must stay
+    // quiet apart from the refresh notice. Reaching for
+    // showQueueMutationErrorToast here would fire "Action failed" on every
+    // dropped connection — the #2763 complaint all over again.
+    expect(toast.showToast.mock.calls.map(([message]) => message)).toEqual(['mobile.queue.outOfSyncRefreshed']);
   });
 });
 

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -692,6 +692,34 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     if (refreshed) showToast(t('mobile.queue.outOfSyncRefreshed'), 'error');
   }, [showToast, t]);
 
+  // Failure handler for the four queue-CONTENT mutations (add/remove/clear/
+  // setQueue). Two things happen, deliberately independent:
+  //
+  //  1. If the backend throttled us, say so straight away. Without this the
+  //     climber gets no pacing hint at all — the only feedback was the delayed
+  //     "Queue was out of sync" toast, which reads as a bug rather than "ease
+  //     off" (#3929).
+  //  2. Reconcile regardless. Content divergence is permanent (see the comment
+  //     above), so the resync must run even when we already toasted.
+  //
+  // That means a throttled content mutation shows TWO toasts: the pacing hint
+  // now, and `outOfSyncRefreshed` a round-trip later once reconciliation
+  // actually replaced the queue. That is by design and matches the existing
+  // setCurrentClimb contract asserted in queue-provider-session-updates.test.tsx
+  // ("Two toasts, deliberately"). Don't collapse them — suppressing the refresh
+  // toast hides a queue that genuinely swapped under the climber.
+  //
+  // Deliberately NOT showQueueMutationErrorToast: that helper also fires
+  // `actionFailed` + reportHandledError on every non-throttle error, and these
+  // syncs are best-effort (offline/transient failures must stay silent, #2763).
+  const reconcileFailedContentMutation = useCallback(
+    (error: unknown) => {
+      if (sessionIdRef.current && isRateLimitedError(error)) showToast(t('mobile.queue.rateLimited'), 'error');
+      void resyncQueueAfterMutationFailure();
+    },
+    [resyncQueueAfterMutationFailure, showToast, t],
+  );
+
   const confirmClimbOnWall = useCallback((climbUuid: string) => mutations.confirmClimbOnWall(climbUuid), [mutations]);
   const setSessionBoardSerial = useCallback((serial: string) => mutations.setSessionBoardSerial(serial), [mutations]);
   // Broadcast that THIS phone's BLE link to the wall dropped. The shared mutation
@@ -757,12 +785,12 @@ export function QueueProvider({ children }: { children: ReactNode }) {
         if (__DEV__) console.warn('[queue] addQueueItem sync failed', error);
         // In a party session the add never reached peers — reconcile against the
         // server so this client doesn't silently diverge. Solo is a true no-op.
-        void resyncQueueAfterMutationFailure();
+        reconcileFailedContentMutation(error);
       });
       // Surface the "Climb added to queue · Open" snackbar for every add path.
       showQueueAddedSnackbar();
     },
-    [mutations, resyncQueueAfterMutationFailure, showQueueAddedSnackbar],
+    [mutations, reconcileFailedContentMutation, showQueueAddedSnackbar],
   );
 
   const removeFromQueue = useCallback(
@@ -783,10 +811,10 @@ export function QueueProvider({ children }: { children: ReactNode }) {
         if (__DEV__) console.warn('[queue] removeQueueItem sync failed', error);
         // The remove never reached peers in a party session — reconcile so the
         // dropped item doesn't linger on peers (or come back here). Solo no-ops.
-        void resyncQueueAfterMutationFailure();
+        reconcileFailedContentMutation(error);
       });
     },
-    [mutations, resyncQueueAfterMutationFailure],
+    [mutations, reconcileFailedContentMutation],
   );
 
   const reorderQueue = useCallback(
@@ -829,11 +857,17 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     // coalesces the burst) and tell the user we refreshed. Solo: the local
     // clear is authoritative, so resync no-ops and no toast fires.
     void Promise.allSettled(itemsToRemove.map((item) => mutations.removeQueueItem(item.uuid))).then((results) => {
-      if (results.some((result) => result.status === 'rejected')) {
-        void resyncQueueAfterMutationFailure();
-      }
+      const rejectedRemovals = results.filter(
+        (result): result is PromiseRejectedResult => result.status === 'rejected',
+      );
+      if (rejectedRemovals.length === 0) return;
+      // A clear fires N per-item removes and the limiter typically rejects only
+      // the tail, so prefer a throttled reason over the first one — otherwise an
+      // unrelated early failure would swallow the pacing hint.
+      const throttledRemoval = rejectedRemovals.find((rejected) => isRateLimitedError(rejected.reason));
+      reconcileFailedContentMutation((throttledRemoval ?? rejectedRemovals[0]).reason);
     });
-  }, [mutations, resyncQueueAfterMutationFailure]);
+  }, [mutations, reconcileFailedContentMutation]);
 
   // Replace the whole queue in one shot: optimistic local UPDATE_QUEUE (the
   // source of truth for the user's queue) + SET_QUEUE sync that no-ops in solo
@@ -856,10 +890,10 @@ export function QueueProvider({ children }: { children: ReactNode }) {
         currentClimbQueueItem && isClimbResolved(currentClimbQueueItem.climb) ? currentClimbQueueItem : undefined;
       mutations.setQueue(syncableQueue, syncableCurrent).catch((error) => {
         if (__DEV__) console.warn('[queue] setQueue sync failed', error);
-        void resyncQueueAfterMutationFailure();
+        reconcileFailedContentMutation(error);
       });
     },
-    [mutations, resyncQueueAfterMutationFailure],
+    [mutations, reconcileFailedContentMutation],
   );
 
   // Stable live read of the queue + current climb (see QueueContextValue). Reads

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -692,26 +692,12 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     if (refreshed) showToast(t('mobile.queue.outOfSyncRefreshed'), 'error');
   }, [showToast, t]);
 
-  // Failure handler for the four queue-CONTENT mutations (add/remove/clear/
-  // setQueue). Two things happen, deliberately independent:
-  //
-  //  1. If the backend throttled us, say so straight away. Without this the
-  //     climber gets no pacing hint at all — the only feedback was the delayed
-  //     "Queue was out of sync" toast, which reads as a bug rather than "ease
-  //     off" (#3929).
-  //  2. Reconcile regardless. Content divergence is permanent (see the comment
-  //     above), so the resync must run even when we already toasted.
-  //
-  // That means a throttled content mutation shows TWO toasts: the pacing hint
-  // now, and `outOfSyncRefreshed` a round-trip later once reconciliation
-  // actually replaced the queue. That is by design and matches the existing
-  // setCurrentClimb contract asserted in queue-provider-session-updates.test.tsx
-  // ("Two toasts, deliberately"). Don't collapse them — suppressing the refresh
-  // toast hides a queue that genuinely swapped under the climber.
-  //
-  // Deliberately NOT showQueueMutationErrorToast: that helper also fires
-  // `actionFailed` + reportHandledError on every non-throttle error, and these
-  // syncs are best-effort (offline/transient failures must stay silent, #2763).
+  // Failure handler for the four queue-CONTENT mutations (add/remove/clear/setQueue).
+  // A throttled one shows TWO toasts by design (#3929): the pacing hint now, and
+  // `outOfSyncRefreshed` a round-trip later once reconciliation replaced the queue —
+  // same contract as setCurrentClimb ("Two toasts, deliberately" in the tests).
+  // Not showQueueMutationErrorToast: that also fires `actionFailed` on every
+  // non-throttle error, and these syncs must stay silent when offline (#2763).
   const reconcileFailedContentMutation = useCallback(
     (error: unknown) => {
       if (sessionIdRef.current && isRateLimitedError(error)) showToast(t('mobile.queue.rateLimited'), 'error');


### PR DESCRIPTION
## What / why

Fixes #3929.

Adding, removing, clearing or replacing a queue item goes through a GraphQL mutation. When the server rate-limits that mutation, the mobile queue provider silently swallowed the error: every one of those four call sites routed its `.catch` straight into `resyncQueueAfterMutationFailure()`. The climber tapped "add to queue", nothing appeared, and the only visible feedback was an `outOfSyncRefreshed` toast — which says the queue was refreshed, not that the change was refused. Worse, the resync itself is another request into the same limiter, so a throttled tap immediately spent more budget.

`setCurrentClimb` already handled this correctly (`mobile.queue.rateLimited`); the four content mutations did not.

## Verified root cause

`packages/mobile/src/providers/queue-provider.tsx` — `addToQueue`, `removeFromQueue`, `clearQueue` and `setQueue` each caught a failed mutation and called `void resyncQueueAfterMutationFailure()` unconditionally, with no inspection of the error. `isRateLimitedError` from `@boardsesh/graphql-client` was never consulted on any of the four paths, so a 429 was indistinguishable from a dropped connection.

## The fix

New `reconcileFailedContentMutation(error)` helper (queue-provider.tsx). It checks `isRateLimitedError(error)` and, when true, shows the existing `mobile.queue.rateLimited` toast before still handing off to the resync (the toast is additive, not a substitute — the queue state still reconciles). All four content-mutation call sites now go through it.

`clearQueue` fans out per-item removals, so it narrows the settled results with a `PromiseRejectedResult` type predicate, early-returns when nothing failed, and prefers the throttled rejection over an arbitrary first failure — otherwise one unrelated error would mask the real "you're going too fast" signal.

No new i18n keys: `mobile.queue.rateLimited` already exists in `en-US`, `es` and `fr`.

## Tests

`packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx` (+173 lines, 5 tests):

- three pacing tests (add / remove / setQueue) assert the recorded toast sequence contains `mobile.queue.rateLimited`. **On revert of only `queue-provider.tsx` these fail with `- "mobile.queue.rateLimited" / + "mobile.queue.outOfSyncRefreshed"`.**
- `prefers the throttled rejection when clearing a queue partly fails` — **fails on revert** (missing pacing toast). Also mutation-proved: replacing `(throttledRemoval ?? rejectedRemovals[0]).reason` with `rejectedRemovals[0].reason` kills exactly this test.
- an over-toasting guard (regression cover for #2763) that stays green on revert but is *not* inert: swapping the helper body for a plain `showQueueMutationErrorToast(...)` kills it.

Also fixed `queue-provider-leave-session.test.tsx`: its `@boardsesh/graphql-client` mock was a bare object literal with no `isRateLimitedError` export, so the new helper threw inside the `addToQueue` catch and aborted the resync. It now spreads `importOriginal()` like every other queue-provider test file.

Validation: `vp run test:mobile` → 562 files / 4761 tests passed. `vp run typecheck:mobile` clean. `vp check` → 0 errors.

## QA Notes

- **Device gate (please exercise):** the toast overlay is a root-level JS view that renders *behind* `@expo/ui` sheets and modal routes (documented in `toast-provider.tsx`). `clearQueue` is invoked from `QueueSheet.tsx` and `addToQueue` from `PlayDrawer.tsx` / `drawer-host-provider.tsx` — all sheet-hosted. Please trip the limiter from inside the play drawer and from QueueSheet and report whether the pacing toast is actually visible. The same exposure already exists today for `setCurrentClimb`'s `rateLimited` toast, so this PR does not make it worse, but it does widen the surface. The non-sheet paths (climbs list row, climbs tab) are unaffected by that caveat.
- Rapid-tap a queue add until the server throttles: expect the "slow down" toast plus a queue that still reconciles to the server state (no lost items, no duplicate rows).
- Solo (no session) must stay silent — the `sessionIdRef.current` guard is unchanged.
- Reorder is untouched: it already routed through `showQueueMutationErrorToast` and rolls back.
- **Known, accepted:** `addQueueItem` is not coalesced, so N rapid throttled adds produce N `showToast` calls (each with a haptic) while only 2 toasts render. Bounded in practice by `execute`'s two rate-limit retries honouring the server's `retryAfterSeconds`. Toast-message dedupe belongs in the toast provider — worth a follow-up issue, not a change here.

## Release Notes

Tap the queue too fast and the app now tells you so. Adding, removing, clearing or replacing climbs used to fail silently when the server asked you to slow down — the queue just quietly snapped back. Now you get the same "give it a second" nudge you already get when switching the current climb, and your queue still lands on whatever the server actually has.
