### PR TITLE
test(db): make the serial-uniqueness regression test run on a fresh DB and assert the right index

### DIFF
--- a/packages/db/scripts/user-boards-serial-uniqueness.integration.test.ts
+++ b/packages/db/scripts/user-boards-serial-uniqueness.integration.test.ts
@@ -12,7 +12,17 @@ import { sql, type SQLWrapper } from 'drizzle-orm';
 import { createScriptDb } from './db-connection.js';
 import { executeRows } from '../src/client/index.js';
 
+// Mirrors packages/location-sync/src/ids.ts and the ensureSystemUser() upsert in
+// packages/location-sync/src/upsert.ts. Kept as literals so @boardsesh/db doesn't
+// take a dependency on location-sync; seeding the identical row here means a later
+// real sync's ON CONFLICT DO NOTHING is a genuine no-op instead of leaving a
+// permanently wrong email/name behind on a dev database.
 const SYSTEM_USER_ID = '00000000-0000-0000-0000-000000000000';
+const SYSTEM_USER_EMAIL = 'system@boardsesh.com';
+const SYSTEM_USER_NAME = 'Boardsesh';
+
+const SERIAL_UNIQUENESS_INDEX = 'user_boards_unique_owner_serial';
+const UNIQUE_VIOLATION_CODE = '23505';
 
 type ExecuteDb = {
   execute(query: SQLWrapper | string): PromiseLike<unknown>;
@@ -20,23 +30,44 @@ type ExecuteDb = {
 
 type CountRow = { count: number | string };
 
-// drizzle-orm >= 0.44 wraps driver failures in a DrizzleQueryError whose
-// `message` is a generic "Failed query: ..." string — the underlying
-// PostgresError (with the real "duplicate key"/constraint text) lives on
-// `.cause`. Walk the cause chain (bounded, in case of cycles) so the
-// assertion below actually inspects the Postgres error text instead of the
-// wrapper's own message. Mirrors packages/backend/src/utils/postgres-errors.ts.
-function messageChainMatches(error: unknown, pattern: RegExp): boolean {
-  let current: unknown = error;
+type ErrorRecord = Record<string, unknown>;
+
+function asErrorRecord(error: unknown): ErrorRecord | null {
+  return typeof error === 'object' && error !== null ? (error as ErrorRecord) : null;
+}
+
+// drizzle-orm >= 0.44 wraps driver failures in a DrizzleQueryError whose own
+// fields are a generic "Failed query: ..." message — the underlying PostgresError
+// (with `code` and `constraint_name`) lives on `.cause`. Walk the cause chain
+// (bounded, in case of cycles) so the assertion below inspects the real Postgres
+// fields. Mirrors packages/backend/src/utils/postgres-errors.ts.
+function* errorChain(error: unknown): Generator<ErrorRecord> {
+  let currentRecord = asErrorRecord(error);
   let depth = 0;
-  while (current && depth < 5) {
-    if (current instanceof Error && pattern.test(current.message)) {
-      return true;
-    }
-    current = current instanceof Error ? current.cause : undefined;
+  while (currentRecord && depth < 5) {
+    yield currentRecord;
+    currentRecord = asErrorRecord(currentRecord.cause);
     depth += 1;
   }
-  return false;
+}
+
+// Assert on the structured Postgres fields rather than error message text. A
+// message match on "duplicate key" is satisfied by any unique violation on the
+// table — including user_boards_unique_owner_config and the uuid primary key —
+// so it would go green without proving anything about the serial index.
+function violatesConstraint(error: unknown, constraintName: string): boolean {
+  let sawUniqueViolation = false;
+  let sawConstraint = false;
+  for (const errorRecord of errorChain(error)) {
+    if (errorRecord.code === UNIQUE_VIOLATION_CODE) {
+      sawUniqueViolation = true;
+    }
+    const constraint = errorRecord.constraint ?? errorRecord.constraint_name;
+    if (constraint === constraintName) {
+      sawConstraint = true;
+    }
+  }
+  return sawUniqueViolation && sawConstraint;
 }
 
 function localDatabaseUrl(): string | null {
@@ -64,7 +95,7 @@ async function skipReason(commandDb: ExecuteDb): Promise<string | null> {
           to_regclass('public.user_boards')::text AS "boardsTable",
           EXISTS (
             SELECT 1 FROM pg_indexes
-            WHERE indexname = 'user_boards_unique_owner_serial'
+            WHERE indexname = ${SERIAL_UNIQUENESS_INDEX}
               AND indexdef LIKE '%00000000-0000-0000-0000-000000000000%'
           ) AS "systemExcluded"
       `,
@@ -81,22 +112,27 @@ async function skipReason(commandDb: ExecuteDb): Promise<string | null> {
   return null;
 }
 
-async function ensureUser(commandDb: ExecuteDb, id: string, email: string): Promise<void> {
+async function ensureUser(commandDb: ExecuteDb, id: string, email: string, name = 'Serial Test'): Promise<void> {
   await commandDb.execute(sql`
     INSERT INTO users (id, email, name)
-    VALUES (${id}, ${email}, ${'Serial Test'})
+    VALUES (${id}, ${email}, ${name})
     ON CONFLICT (id) DO NOTHING
   `);
 }
 
+// `layoutId` varies so two boards owned by the same non-system user can differ in
+// board config. Without that, a second insert would also collide with
+// user_boards_unique_owner_config (owner_id, board_type, layout_id, size_id,
+// set_ids) and Postgres would report that constraint instead — the rejection
+// would prove nothing about the serial index under test.
 async function insertBoard(
   commandDb: ExecuteDb,
-  values: { uuid: string; slug: string; ownerId: string; serial: string },
+  values: { uuid: string; slug: string; ownerId: string; serial: string; layoutId: number },
 ): Promise<void> {
   await commandDb.execute(sql`
     INSERT INTO user_boards (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, serial_number, is_owned)
     VALUES (
-      ${values.uuid}, ${values.slug}, ${values.ownerId}, 'kilter', 1, 10, '20',
+      ${values.uuid}, ${values.slug}, ${values.ownerId}, 'kilter', ${values.layoutId}, 10, '20',
       ${'Serial Test Board'}, ${values.serial}, false
     )
   `);
@@ -133,9 +169,10 @@ describe('user_boards serial uniqueness — system catalog exemption', () => {
       await ensureUser(db, otherOwnerId, 'serial-uniqueness-test@example.com');
       // The SYSTEM catalog user isn't seeded by any migration (production relies
       // on location-sync's own idempotent upsert) — seed it here so this test is
-      // self-contained on a fresh DB. ON CONFLICT DO NOTHING keeps it safe on a
-      // DB where the row already exists from a prior sync or test run.
-      await ensureUser(db, SYSTEM_USER_ID, 'system@boardsesh.internal');
+      // self-contained on a fresh DB, using location-sync's exact identity so the
+      // row this test leaves behind is the row a real sync would have written.
+      // ON CONFLICT DO NOTHING keeps it safe when the row already exists.
+      await ensureUser(db, SYSTEM_USER_ID, SYSTEM_USER_EMAIL, SYSTEM_USER_NAME);
 
       // Two SYSTEM-owned boards with the same serial must both persist.
       await insertBoard(db, {
@@ -143,12 +180,14 @@ describe('user_boards serial uniqueness — system catalog exemption', () => {
         slug: 'serialuniq-sys-1',
         ownerId: SYSTEM_USER_ID,
         serial: sharedSerial,
+        layoutId: 1,
       });
       await insertBoard(db, {
         uuid: uuids.system2,
         slug: 'serialuniq-sys-2',
         ownerId: SYSTEM_USER_ID,
         serial: sharedSerial,
+        layoutId: 1,
       });
 
       const [systemCount] = await executeRows<CountRow>(
@@ -163,6 +202,7 @@ describe('user_boards serial uniqueness — system catalog exemption', () => {
         slug: 'serialuniq-other-1',
         ownerId: otherOwnerId,
         serial: sharedSerial,
+        layoutId: 1,
       });
       // ...but a second one for the same owner must violate the unique index.
       await assert.rejects(
@@ -172,8 +212,11 @@ describe('user_boards serial uniqueness — system catalog exemption', () => {
             slug: 'serialuniq-other-2',
             ownerId: otherOwnerId,
             serial: sharedSerial,
+            // A different layout so user_boards_unique_owner_config cannot fire
+            // and only the serial index can reject this row.
+            layoutId: 2,
           }),
-        (error: unknown) => messageChainMatches(error, /user_boards_unique_owner_serial|duplicate key/i),
+        (error: unknown) => violatesConstraint(error, SERIAL_UNIQUENESS_INDEX),
         'a non-system owner must not bind the same serial twice',
       );
 

--- a/packages/db/scripts/user-boards-serial-uniqueness.integration.test.ts
+++ b/packages/db/scripts/user-boards-serial-uniqueness.integration.test.ts
@@ -55,19 +55,17 @@ function* errorChain(error: unknown): Generator<ErrorRecord> {
 // message match on "duplicate key" is satisfied by any unique violation on the
 // table — including user_boards_unique_owner_config and the uuid primary key —
 // so it would go green without proving anything about the serial index.
+// Both fields must come from the SAME chain node: a code read off one wrapper and
+// a constraint name off another would let two unrelated failures satisfy the
+// assertion together.
 function violatesConstraint(error: unknown, constraintName: string): boolean {
-  let sawUniqueViolation = false;
-  let sawConstraint = false;
   for (const errorRecord of errorChain(error)) {
-    if (errorRecord.code === UNIQUE_VIOLATION_CODE) {
-      sawUniqueViolation = true;
-    }
     const constraint = errorRecord.constraint ?? errorRecord.constraint_name;
-    if (constraint === constraintName) {
-      sawConstraint = true;
+    if (errorRecord.code === UNIQUE_VIOLATION_CODE && constraint === constraintName) {
+      return true;
     }
   }
-  return sawUniqueViolation && sawConstraint;
+  return false;
 }
 
 function localDatabaseUrl(): string | null {

--- a/packages/db/scripts/user-boards-serial-uniqueness.integration.test.ts
+++ b/packages/db/scripts/user-boards-serial-uniqueness.integration.test.ts
@@ -20,6 +20,25 @@ type ExecuteDb = {
 
 type CountRow = { count: number | string };
 
+// drizzle-orm >= 0.44 wraps driver failures in a DrizzleQueryError whose
+// `message` is a generic "Failed query: ..." string — the underlying
+// PostgresError (with the real "duplicate key"/constraint text) lives on
+// `.cause`. Walk the cause chain (bounded, in case of cycles) so the
+// assertion below actually inspects the Postgres error text instead of the
+// wrapper's own message. Mirrors packages/backend/src/utils/postgres-errors.ts.
+function messageChainMatches(error: unknown, pattern: RegExp): boolean {
+  let current: unknown = error;
+  let depth = 0;
+  while (current && depth < 5) {
+    if (current instanceof Error && pattern.test(current.message)) {
+      return true;
+    }
+    current = current instanceof Error ? current.cause : undefined;
+    depth += 1;
+  }
+  return false;
+}
+
 function localDatabaseUrl(): string | null {
   const databaseUrl = process.env.DATABASE_URL;
   if (!databaseUrl) {
@@ -112,6 +131,11 @@ describe('user_boards serial uniqueness — system catalog exemption', () => {
       await db.execute(sql`DELETE FROM user_boards WHERE serial_number = ${sharedSerial}`);
 
       await ensureUser(db, otherOwnerId, 'serial-uniqueness-test@example.com');
+      // The SYSTEM catalog user isn't seeded by any migration (production relies
+      // on location-sync's own idempotent upsert) — seed it here so this test is
+      // self-contained on a fresh DB. ON CONFLICT DO NOTHING keeps it safe on a
+      // DB where the row already exists from a prior sync or test run.
+      await ensureUser(db, SYSTEM_USER_ID, 'system@boardsesh.internal');
 
       // Two SYSTEM-owned boards with the same serial must both persist.
       await insertBoard(db, {
@@ -149,7 +173,7 @@ describe('user_boards serial uniqueness — system catalog exemption', () => {
             ownerId: otherOwnerId,
             serial: sharedSerial,
           }),
-        /user_boards_unique_owner_serial|duplicate key/i,
+        (error: unknown) => messageChainMatches(error, /user_boards_unique_owner_serial|duplicate key/i),
         'a non-system owner must not bind the same serial twice',
       );
 


### PR DESCRIPTION
## What & why

`packages/db/scripts/user-boards-serial-uniqueness.integration.test.ts` — the regression coverage for migration 0131's system-catalog serial exemption — could not run on a fresh dev database. Its first insert binds a board to the SYSTEM catalog owner (`00000000-0000-0000-0000-000000000000`), but nothing in the schema or the baked `ghcr.io/boardsesh/boardsesh-dev-db` image creates that `users` row, so the test died on a foreign-key violation instead of exercising the exemption.

While fixing that, a second and worse problem turned up: even on a database where the test *did* run, its final assertion was passing for the wrong reason.

Fixes #3876

## Verified root cause

**1. Missing SYSTEM user (the reported bug).** No migration inserts the SYSTEM row — production relies on `ensureSystemUser()` in `packages/location-sync/src/upsert.ts`, which runs as part of a location sync. A developer who has never run a location sync has no such row. Reproduced on an isolated container from the exact dev-db image (`docker run -d ghcr.io/boardsesh/boardsesh-dev-db:latest`): 0 rows for that id, and the test fails with

```
insert or update on table "user_boards" violates foreign key constraint "user_boards_owner_id_fkey"
```

**2. The rejection assertion never touched the index under test.** The test's two non-system boards shared *every* config column, so the second insert collided with `user_boards_unique_owner_config (owner_id, board_type, layout_id, size_id, set_ids)` — not with `user_boards_unique_owner_serial`. Probed the live error object to confirm:

```
--- depth 0 DrizzleQueryError  keys: query, params, cause
--- depth 1 PostgresError      code: 23505, constraint_name: user_boards_unique_owner_config
```

The old matcher was a message regex, `/user_boards_unique_owner_serial|duplicate key/i`, and the `duplicate key` alternation happily accepted the config-index violation. The test asserted nothing about serial uniqueness.

**3. Drizzle wraps the driver error.** drizzle-orm ≥ 0.44 raises a `DrizzleQueryError` whose own message is a generic `Failed query: ...`; the real `code`/`constraint_name` live on `.cause`. Any matcher reading the top-level error alone fails regardless of what the database did.

## The fix

One file, tests only. No production code, no schema, no migration.

- Seed the SYSTEM catalog user before the system-owned inserts, using location-sync's own identity — `system@boardsesh.com` / `Boardsesh` — via `ON CONFLICT (id) DO NOTHING`. Matching the canonical values matters: `ensureSystemUser()` is also `ON CONFLICT DO NOTHING`, so a test-seeded row with a made-up email would never be repaired by a later real sync and would sit on that dev database forever as the displayed owner of every system gym and board.
- Give the second non-system board a different `layout_id`, so `user_boards_unique_owner_config` cannot fire and only the serial index can reject the row.
- Assert on structured Postgres fields — `code === '23505'` **and** `constraint_name === 'user_boards_unique_owner_serial'` — walking the cause chain the way `packages/backend/src/utils/postgres-errors.ts` already does, following any non-null object link (not just `instanceof Error`) with the same depth-5 bound.

## Tests

The test itself is the change. Everything below ran against an isolated throwaway container off the same baked image (`docker run -d --name fin3876-freshdb -p 55433:5432 ghcr.io/boardsesh/boardsesh-dev-db:latest`), verified to hold 0 SYSTEM rows and to have `user_boards_unique_owner_serial` present. The shared dev DB cannot reproduce #3876 at all — it already has the SYSTEM row — so a fresh container is the only honest oracle. No `docker compose down -v`; shared infra untouched; container removed afterwards.

Command: `DATABASE_URL=postgresql://postgres:password@localhost:55433/main tsx --test scripts/user-boards-serial-uniqueness.integration.test.ts` from `packages/db`.

| Scenario | Result |
| --- | --- |
| Branch HEAD, fresh DB, SYSTEM row absent | `# pass 1 # fail 0` |
| Same again immediately (idempotency) | `# pass 1 # fail 0` |
| **Revert:** `git checkout origin/main -- <file>`, SYSTEM row deleted | `# fail 1` — FK violation on the first `INSERT INTO user_boards`, exactly the issue |
| **Mutation:** drop only the `ensureUser(db, SYSTEM_USER_ID, …)` line | `# fail 1` — the seed hunk is load-bearing |
| **Mutation:** give `other2` the same `layoutId` as `other1` | `# fail 1` — the config index fires, the constraint-name assertion correctly rejects it |

That third mutation is the one that matters: under the old message regex the same scenario went *green*. Restored file re-verified green after each mutation.

Also: `vp run typecheck:db` clean (`tsc --noEmit`, 0 errors). `vp lint` on the file reports 2 `no-floating-promises` warnings, 0 errors — identical to what `origin/main`'s version of the file reports, so nothing new was introduced.

## QA Notes

- These `packages/db` integration tests are **not** wired into PR CI (only `scripts/migration-journal-verification.integration.test.ts` runs there), so green checks on this PR prove nothing about the test itself. To verify by hand, use a throwaway container rather than the shared dev DB — the shared one already contains the SYSTEM row and cannot reproduce the bug:
  ```
  docker run -d --name qa3876 -p 55433:5432 ghcr.io/boardsesh/boardsesh-dev-db:latest
  cd packages/db && DATABASE_URL=postgresql://postgres:password@localhost:55433/main \
    ../../node_modules/.bun/tsx*/node_modules/.bin/tsx --test scripts/user-boards-serial-uniqueness.integration.test.ts
  docker rm -f qa3876
  ```
- The test deliberately leaves the SYSTEM `users` row behind (it cleans up its boards and the throwaway owner, not the catalog user). Deleting it would break any location-sync data already on that database. Because the seeded values now match `ensureSystemUser()` exactly, a later real sync is a genuine no-op.
- Housekeeping on the shared dev box: its SYSTEM row is currently `system@boardsesh.com | Serial Test`, left by an earlier iteration of this work. `UPDATE users SET name='Boardsesh' WHERE id='00000000-0000-0000-0000-000000000000';` cleans it up. Cosmetic — nothing in the repo looks the system user up by name or email.
- Sibling `packages/db/scripts/dedupe-gym-locations.integration.test.ts` seeds its own SYSTEM row with `ON CONFLICT DO NOTHING`; whichever runs first wins, neither errors.

## Release Notes

none

- [x] No release note needed (internal / technical change)

