### PR TITLE
fix(backend): make addClimbToPlaylist idempotent under concurrent adds

### DIFF
--- a/packages/backend/src/__tests__/add-climb-to-playlist-race.test.ts
+++ b/packages/backend/src/__tests__/add-climb-to-playlist-race.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { playlistMutations } from '../graphql/resolvers/playlists/mutations';
+
+// Integration test (real DB) for #3993: addClimbToPlaylist did a plain
+// pre-check SELECT for an existing (playlistId, climbUuid) row, and only
+// opened a transaction afterward to assign a position and insert. Two
+// concurrent calls for the same not-yet-present climb both see an empty
+// pre-check, both reach the INSERT, and the loser hits the
+// `unique_playlist_climb` unique index as a raw 23505 unique-violation
+// instead of the intended idempotent no-op. Seeds use raw `sql` because the
+// test DB is a minimal DDL (schema-sql.ts), so a builder insert
+// over-specifies columns — same pattern as playlist-reorder-integration.test.ts.
+
+const PLAYLIST_UUID = 'pl-race-3993';
+const OWNER_ID = 'user-123'; // seeded by setup.ts
+
+function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext {
+  return {
+    connectionId: 'conn-1',
+    isAuthenticated: true,
+    userId: OWNER_ID,
+    sessionId: null,
+    boardPath: null,
+    controllerId: null,
+    controllerApiKey: null,
+    ...overrides,
+  } as ConnectionContext;
+}
+
+async function playlistClimbRows(climbUuid: string): Promise<{ id: string; position: number }[]> {
+  const result = await db.execute(sql`
+    SELECT id, position FROM playlist_climbs
+    WHERE playlist_id = 1 AND climb_uuid = ${climbUuid}
+  `);
+  return Array.from(result as Iterable<{ id: string; position: number }>);
+}
+
+describe('addClimbToPlaylist — real DB (#3993)', () => {
+  // Playlist tables aren't in setup.ts's per-file reset list, so own the reset.
+  // RESTART IDENTITY frees id=1 for a stable, trivially-referenced playlist.
+  beforeEach(async () => {
+    await db.execute(sql`TRUNCATE TABLE playlist_climbs, playlist_ownership, playlists RESTART IDENTITY CASCADE`);
+    await db.execute(sql`
+      INSERT INTO playlists (id, uuid, board_type, layout_id, name, is_public)
+      VALUES (1, ${PLAYLIST_UUID}, 'kilter', 1, 'Race', true)
+    `);
+    await db.execute(sql`
+      INSERT INTO playlist_ownership (playlist_id, user_id)
+      VALUES (1, ${OWNER_ID})
+    `);
+  });
+
+  afterAll(async () => {
+    await db.execute(sql`TRUNCATE TABLE playlist_climbs, playlist_ownership, playlists RESTART IDENTITY CASCADE`);
+  });
+
+  it('resolves both concurrent adds of the same climb without throwing, inserting exactly one row', async () => {
+    // Fires two genuinely concurrent DB round-trips (Promise.all, not
+    // sequential awaits). On the pre-fix check-then-insert code, one of the
+    // two branches throws a raw 23505 unique-violation instead of
+    // resolving — reverting the fix reproduces that throw here.
+    const [resultA, resultB] = await Promise.all([
+      playlistMutations.addClimbToPlaylist(
+        null,
+        { input: { playlistId: PLAYLIST_UUID, climbUuid: 'climb-racer', angle: 40 } },
+        makeCtx(),
+      ),
+      playlistMutations.addClimbToPlaylist(
+        null,
+        { input: { playlistId: PLAYLIST_UUID, climbUuid: 'climb-racer', angle: 40 } },
+        makeCtx(),
+      ),
+    ]);
+
+    const rows = await playlistClimbRows('climb-racer');
+    expect(rows).toHaveLength(1);
+
+    // Both results describe the same underlying row.
+    expect(resultA).toMatchObject({ climbUuid: 'climb-racer', position: rows[0].position });
+    expect(resultB).toMatchObject({ climbUuid: 'climb-racer', position: rows[0].position });
+    expect((resultA as { id: string }).id).toBe((resultB as { id: string }).id);
+  });
+
+  it('inserts both rows without error when two different climbs are added concurrently', async () => {
+    // `position` has no unique constraint (playlist_climbs_position_idx is a
+    // plain index, not unique) — two racers can legitimately compute the same
+    // maxPosition under READ COMMITTED and both land on it. Every read path
+    // (playlist-climbs.ts, playlist-reorder-integration.test.ts's own
+    // orderedClimbs helper) already orders by `(position ASC, added_at ASC)`,
+    // so a duplicate position resolves deterministically via addedAt and
+    // never breaks display order. This test guards that neither insert
+    // throws and both rows persist — not position uniqueness, which the
+    // schema doesn't provide and the codebase doesn't require.
+    const [resultA, resultB] = await Promise.all([
+      playlistMutations.addClimbToPlaylist(
+        null,
+        { input: { playlistId: PLAYLIST_UUID, climbUuid: 'climb-one', angle: 40 } },
+        makeCtx(),
+      ),
+      playlistMutations.addClimbToPlaylist(
+        null,
+        { input: { playlistId: PLAYLIST_UUID, climbUuid: 'climb-two', angle: 40 } },
+        makeCtx(),
+      ),
+    ]);
+
+    const rows = await db.execute(sql`
+      SELECT climb_uuid, position FROM playlist_climbs
+      WHERE playlist_id = 1
+      ORDER BY position ASC, added_at ASC
+    `);
+    const materializedRows = Array.from(rows as Iterable<{ climb_uuid: string; position: number }>);
+
+    expect(materializedRows).toHaveLength(2);
+    expect(materializedRows.map((row) => row.climb_uuid).sort()).toEqual(['climb-one', 'climb-two']);
+    expect([resultA, resultB].map((result) => (result as { climbUuid: string }).climbUuid).sort()).toEqual([
+      'climb-one',
+      'climb-two',
+    ]);
+  });
+
+  it('returns the pre-existing row unchanged when the climb is already present (no duplicate insert, no position bump)', async () => {
+    await db.execute(sql`
+      INSERT INTO playlist_climbs (playlist_id, climb_uuid, angle, position)
+      VALUES (1, 'climb-existing', 40, 7)
+    `);
+    const [seededRow] = await playlistClimbRows('climb-existing');
+
+    const result = (await playlistMutations.addClimbToPlaylist(
+      null,
+      { input: { playlistId: PLAYLIST_UUID, climbUuid: 'climb-existing', angle: 40 } },
+      makeCtx(),
+    )) as { id: string; position: number };
+
+    expect(result.id).toBe(seededRow.id);
+    expect(result.position).toBe(7);
+
+    const rows = await playlistClimbRows('climb-existing');
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/packages/backend/src/graphql/resolvers/playlists/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/mutations.ts
@@ -290,33 +290,18 @@ export const playlistMutations = {
 
     const playlistId = ownership[0].id;
 
-    // Check if climb already exists in playlist
-    const existing = await db
-      .select()
-      .from(dbSchema.playlistClimbs)
-      .where(
-        and(
-          eq(dbSchema.playlistClimbs.playlistId, playlistId),
-          eq(dbSchema.playlistClimbs.climbUuid, validatedInput.climbUuid),
-        ),
-      )
-      .limit(1);
-
-    if (existing.length > 0) {
-      // Already in playlist - return existing
-      return {
-        id: existing[0].id.toString(),
-        playlistId: validatedInput.playlistId,
-        climbUuid: existing[0].climbUuid,
-        angle: existing[0].angle,
-        position: existing[0].position,
-        addedAt: existing[0].addedAt.toISOString(),
-      };
-    }
-
-    // Use transaction to prevent race condition in position assignment
-    const playlistClimb = await db.transaction(async (tx) => {
-      // Get max position within transaction
+    // Insert-or-noop + position assignment share one transaction: a plain
+    // pre-check SELECT followed by a separate INSERT leaves a window where
+    // two concurrent calls for the same (playlistId, climbUuid) both see no
+    // existing row and both reach the INSERT, so the second hits the
+    // unique_playlist_climb index as a raw 23505 instead of the intended
+    // idempotent no-op. onConflictDoNothing lets Postgres's index arbitrate;
+    // when our insert loses the race we re-select the winner's row inside
+    // the same transaction (read-your-writes) and return it in the same
+    // "already in playlist" shape the old pre-check used.
+    // `wasAlreadyPresent` isn't surfaced in the response: the "added" vs
+    // "already present" shape stays identical, as it was before this fix.
+    const { playlistClimb } = await db.transaction(async (tx) => {
       const maxPosition = await tx
         .select({ max: sql<number>`coalesce(max(${dbSchema.playlistClimbs.position}), -1)` })
         .from(dbSchema.playlistClimbs)
@@ -325,8 +310,7 @@ export const playlistMutations = {
 
       const nextPosition = (maxPosition[0]?.max ?? -1) + 1;
 
-      // Add climb to playlist
-      const [newClimb] = await tx
+      const [insertedClimb] = await tx
         .insert(dbSchema.playlistClimbs)
         .values({
           playlistId,
@@ -335,16 +319,41 @@ export const playlistMutations = {
           position: nextPosition,
           addedAt: new Date(),
         })
+        .onConflictDoNothing({
+          target: [dbSchema.playlistClimbs.playlistId, dbSchema.playlistClimbs.climbUuid],
+        })
         .returning();
 
-      // Update playlist updatedAt and lastAccessedAt
-      const now = new Date();
-      await tx
-        .update(dbSchema.playlists)
-        .set({ updatedAt: now, lastAccessedAt: now })
-        .where(eq(dbSchema.playlists.id, playlistId));
+      if (insertedClimb) {
+        const now = new Date();
+        await tx
+          .update(dbSchema.playlists)
+          .set({ updatedAt: now, lastAccessedAt: now })
+          .where(eq(dbSchema.playlists.id, playlistId));
 
-      return newClimb;
+        return { playlistClimb: insertedClimb, wasAlreadyPresent: false };
+      }
+
+      // Conflict hit: a concurrent insert won the race. Re-select the
+      // winner's row within this transaction for read-your-writes.
+      const [existingClimb] = await tx
+        .select()
+        .from(dbSchema.playlistClimbs)
+        .where(
+          and(
+            eq(dbSchema.playlistClimbs.playlistId, playlistId),
+            eq(dbSchema.playlistClimbs.climbUuid, validatedInput.climbUuid),
+          ),
+        )
+        .limit(1);
+
+      if (!existingClimb) {
+        // Should be unreachable: onConflictDoNothing only skips when a
+        // conflicting row exists. Fail loudly rather than return undefined.
+        throw new Error('Failed to add climb to playlist: conflicting row not found after insert skip');
+      }
+
+      return { playlistClimb: existingClimb, wasAlreadyPresent: true };
     });
 
     return {

--- a/packages/backend/src/graphql/resolvers/playlists/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/mutations.ts
@@ -306,62 +306,71 @@ export const playlistMutations = {
     // conflicting row is gone by then, so a second insert attempt succeeds.
     // Two attempts is enough for that hand-off; a third would only mean the
     // caller is racing itself in a loop, which is worth failing loudly on.
+    // The isolation level is pinned rather than inherited: the retry only
+    // works because a re-select sees other transactions' committed deletes,
+    // which a stricter level (or a changed server default) would hide. Both
+    // attempts share one transaction so the position assignment and the
+    // insert stay atomic; the second attempt only runs in the rare
+    // vanished-row window.
     const maxInsertAttempts = 2;
-    const playlistClimb = await db.transaction(async (tx) => {
-      for (let attempt = 0; attempt < maxInsertAttempts; attempt += 1) {
-        const maxPosition = await tx
-          .select({ max: sql<number>`coalesce(max(${dbSchema.playlistClimbs.position}), -1)` })
-          .from(dbSchema.playlistClimbs)
-          .where(eq(dbSchema.playlistClimbs.playlistId, playlistId))
-          .limit(1);
+    const playlistClimb = await db.transaction(
+      async (tx) => {
+        for (let attempt = 0; attempt < maxInsertAttempts; attempt += 1) {
+          const maxPosition = await tx
+            .select({ max: sql<number>`coalesce(max(${dbSchema.playlistClimbs.position}), -1)` })
+            .from(dbSchema.playlistClimbs)
+            .where(eq(dbSchema.playlistClimbs.playlistId, playlistId))
+            .limit(1);
 
-        const nextPosition = (maxPosition[0]?.max ?? -1) + 1;
+          const nextPosition = (maxPosition[0]?.max ?? -1) + 1;
 
-        const [insertedClimb] = await tx
-          .insert(dbSchema.playlistClimbs)
-          .values({
-            playlistId,
-            climbUuid: validatedInput.climbUuid,
-            angle: validatedInput.angle,
-            position: nextPosition,
-            addedAt: new Date(),
-          })
-          .onConflictDoNothing({
-            target: [dbSchema.playlistClimbs.playlistId, dbSchema.playlistClimbs.climbUuid],
-          })
-          .returning();
+          const [insertedClimb] = await tx
+            .insert(dbSchema.playlistClimbs)
+            .values({
+              playlistId,
+              climbUuid: validatedInput.climbUuid,
+              angle: validatedInput.angle,
+              position: nextPosition,
+              addedAt: new Date(),
+            })
+            .onConflictDoNothing({
+              target: [dbSchema.playlistClimbs.playlistId, dbSchema.playlistClimbs.climbUuid],
+            })
+            .returning();
 
-        if (insertedClimb) {
-          const now = new Date();
-          await tx
-            .update(dbSchema.playlists)
-            .set({ updatedAt: now, lastAccessedAt: now })
-            .where(eq(dbSchema.playlists.id, playlistId));
+          if (insertedClimb) {
+            const now = new Date();
+            await tx
+              .update(dbSchema.playlists)
+              .set({ updatedAt: now, lastAccessedAt: now })
+              .where(eq(dbSchema.playlists.id, playlistId));
 
-          return insertedClimb;
+            return insertedClimb;
+          }
+
+          // Conflict hit: a concurrent insert won the race. Re-select the
+          // winner's row and hand it back unchanged (no updatedAt bump), which
+          // is what the old pre-check branch did for an already-present climb.
+          const [existingClimb] = await tx
+            .select()
+            .from(dbSchema.playlistClimbs)
+            .where(
+              and(
+                eq(dbSchema.playlistClimbs.playlistId, playlistId),
+                eq(dbSchema.playlistClimbs.climbUuid, validatedInput.climbUuid),
+              ),
+            )
+            .limit(1);
+
+          if (existingClimb) {
+            return existingClimb;
+          }
         }
 
-        // Conflict hit: a concurrent insert won the race. Re-select the
-        // winner's row and hand it back unchanged (no updatedAt bump), which
-        // is what the old pre-check branch did for an already-present climb.
-        const [existingClimb] = await tx
-          .select()
-          .from(dbSchema.playlistClimbs)
-          .where(
-            and(
-              eq(dbSchema.playlistClimbs.playlistId, playlistId),
-              eq(dbSchema.playlistClimbs.climbUuid, validatedInput.climbUuid),
-            ),
-          )
-          .limit(1);
-
-        if (existingClimb) {
-          return existingClimb;
-        }
-      }
-
-      throw new Error('Failed to add climb to playlist: conflicting row kept vanishing between insert and re-select');
-    });
+        throw new Error('Failed to add climb to playlist: conflicting row kept vanishing between insert and re-select');
+      },
+      { isolationLevel: 'read committed' },
+    );
 
     return {
       id: playlistClimb.id.toString(),

--- a/packages/backend/src/graphql/resolvers/playlists/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/mutations.ts
@@ -296,64 +296,71 @@ export const playlistMutations = {
     // existing row and both reach the INSERT, so the second hits the
     // unique_playlist_climb index as a raw 23505 instead of the intended
     // idempotent no-op. onConflictDoNothing lets Postgres's index arbitrate;
-    // when our insert loses the race we re-select the winner's row inside
-    // the same transaction (read-your-writes) and return it in the same
-    // "already in playlist" shape the old pre-check used.
-    // `wasAlreadyPresent` isn't surfaced in the response: the "added" vs
-    // "already present" shape stays identical, as it was before this fix.
-    const { playlistClimb } = await db.transaction(async (tx) => {
-      const maxPosition = await tx
-        .select({ max: sql<number>`coalesce(max(${dbSchema.playlistClimbs.position}), -1)` })
-        .from(dbSchema.playlistClimbs)
-        .where(eq(dbSchema.playlistClimbs.playlistId, playlistId))
-        .limit(1);
+    // when our insert loses the race we re-select the winner's row and return
+    // it in the same "already in playlist" shape the old pre-check used.
+    //
+    // The re-select can legitimately come back empty: under READ COMMITTED
+    // every statement takes a fresh snapshot, so the row we conflicted with
+    // can be removed (a concurrent removeClimbFromPlaylist committing, or the
+    // racing inserter rolling back) between our INSERT and our SELECT. The
+    // conflicting row is gone by then, so a second insert attempt succeeds.
+    // Two attempts is enough for that hand-off; a third would only mean the
+    // caller is racing itself in a loop, which is worth failing loudly on.
+    const maxInsertAttempts = 2;
+    const playlistClimb = await db.transaction(async (tx) => {
+      for (let attempt = 0; attempt < maxInsertAttempts; attempt += 1) {
+        const maxPosition = await tx
+          .select({ max: sql<number>`coalesce(max(${dbSchema.playlistClimbs.position}), -1)` })
+          .from(dbSchema.playlistClimbs)
+          .where(eq(dbSchema.playlistClimbs.playlistId, playlistId))
+          .limit(1);
 
-      const nextPosition = (maxPosition[0]?.max ?? -1) + 1;
+        const nextPosition = (maxPosition[0]?.max ?? -1) + 1;
 
-      const [insertedClimb] = await tx
-        .insert(dbSchema.playlistClimbs)
-        .values({
-          playlistId,
-          climbUuid: validatedInput.climbUuid,
-          angle: validatedInput.angle,
-          position: nextPosition,
-          addedAt: new Date(),
-        })
-        .onConflictDoNothing({
-          target: [dbSchema.playlistClimbs.playlistId, dbSchema.playlistClimbs.climbUuid],
-        })
-        .returning();
+        const [insertedClimb] = await tx
+          .insert(dbSchema.playlistClimbs)
+          .values({
+            playlistId,
+            climbUuid: validatedInput.climbUuid,
+            angle: validatedInput.angle,
+            position: nextPosition,
+            addedAt: new Date(),
+          })
+          .onConflictDoNothing({
+            target: [dbSchema.playlistClimbs.playlistId, dbSchema.playlistClimbs.climbUuid],
+          })
+          .returning();
 
-      if (insertedClimb) {
-        const now = new Date();
-        await tx
-          .update(dbSchema.playlists)
-          .set({ updatedAt: now, lastAccessedAt: now })
-          .where(eq(dbSchema.playlists.id, playlistId));
+        if (insertedClimb) {
+          const now = new Date();
+          await tx
+            .update(dbSchema.playlists)
+            .set({ updatedAt: now, lastAccessedAt: now })
+            .where(eq(dbSchema.playlists.id, playlistId));
 
-        return { playlistClimb: insertedClimb, wasAlreadyPresent: false };
+          return insertedClimb;
+        }
+
+        // Conflict hit: a concurrent insert won the race. Re-select the
+        // winner's row and hand it back unchanged (no updatedAt bump), which
+        // is what the old pre-check branch did for an already-present climb.
+        const [existingClimb] = await tx
+          .select()
+          .from(dbSchema.playlistClimbs)
+          .where(
+            and(
+              eq(dbSchema.playlistClimbs.playlistId, playlistId),
+              eq(dbSchema.playlistClimbs.climbUuid, validatedInput.climbUuid),
+            ),
+          )
+          .limit(1);
+
+        if (existingClimb) {
+          return existingClimb;
+        }
       }
 
-      // Conflict hit: a concurrent insert won the race. Re-select the
-      // winner's row within this transaction for read-your-writes.
-      const [existingClimb] = await tx
-        .select()
-        .from(dbSchema.playlistClimbs)
-        .where(
-          and(
-            eq(dbSchema.playlistClimbs.playlistId, playlistId),
-            eq(dbSchema.playlistClimbs.climbUuid, validatedInput.climbUuid),
-          ),
-        )
-        .limit(1);
-
-      if (!existingClimb) {
-        // Should be unreachable: onConflictDoNothing only skips when a
-        // conflicting row exists. Fail loudly rather than return undefined.
-        throw new Error('Failed to add climb to playlist: conflicting row not found after insert skip');
-      }
-
-      return { playlistClimb: existingClimb, wasAlreadyPresent: true };
+      throw new Error('Failed to add climb to playlist: conflicting row kept vanishing between insert and re-select');
     });
 
     return {


### PR DESCRIPTION
## What & why

Adding the same climb to a playlist twice at the same time could blow up with a raw Postgres unique-violation instead of quietly doing nothing. The mobile offline outbox replays queued adds, and a double-tap or a replay landing next to a live add is enough to hit it.

Fixes #3993

## Verified root cause

`addClimbToPlaylist` was check-then-insert:

1. a plain, non-transactional `SELECT` for an existing `(playlist_id, climb_uuid)` row — return early if found;
2. a *separate* transaction that computed `max(position)` and inserted.

Two concurrent calls for the same not-yet-present climb both see an empty pre-check, both reach the `INSERT`, and the loser hits the `unique_playlist_climb` unique index as a raw `23505` (`duplicate key value violates unique constraint "unique_playlist_climb"`) surfaced as a GraphQL error — instead of the idempotent no-op the pre-check was there to provide.

Proven, not assumed: reverting only the resolver hunk and re-running the new test file throws exactly that `PostgresError` / code `23505`, `detail: Key (playlist_id, climb_uuid)=(1, climb-racer) already exists`, out of the `Promise.all` racer.

## The fix

`packages/backend/src/graphql/resolvers/playlists/mutations.ts` — all changes are inside `addClimbToPlaylist`; `removeClimbFromPlaylist` and `createPlaylist` are untouched.

- Delete the pre-check `SELECT`. Position assignment and insert-or-noop now share one transaction.
- The insert uses `.onConflictDoNothing({ target: [playlistId, climbUuid] })`, so Postgres's own unique index arbitrates the race rather than our snapshot.
- If our insert loses, re-select the winner's row and return it in the *same* response shape the old "already in playlist" branch returned (byte-identical fields, and still the stored row's `angle`, not the caller's). `playlists.updatedAt` / `lastAccessedAt` are only bumped when a row was actually inserted — same as before.
- The re-select can legitimately miss: under READ COMMITTED each statement takes a fresh snapshot, so the conflicting row can be deleted (concurrent `removeClimbFromPlaylist`) or rolled back between our `INSERT` and our `SELECT`. Insert + re-select therefore run in a bounded **2-attempt** loop — the conflicting row is gone by the retry, so the second insert succeeds. Only a caller racing itself in a loop reaches the throw. The transaction pins `isolationLevel: 'read committed'` rather than inheriting it, since that retry is exactly what a stricter level would break.

`onConflictDoNothing`'s target matches the real index in all three places it is defined: `packages/db/src/schema/app/playlists.ts:92` (`uniqueIndex('unique_playlist_climb').on(playlistId, climbUuid)`), the shipped migration `packages/db/drizzle/0025_fix_missing_tables.sql:287`, and the backend test DDL `packages/backend/src/__tests__/schema-sql.ts:630`. Same columns, same order, non-partial. **No migration in this PR** — the index already shipped in 0025.

## Tests

New real-DB integration test: `packages/backend/src/__tests__/add-climb-to-playlist-race.test.ts` (3 tests, all green).

1. **Two concurrent adds of the same climb** (`Promise.all`, not sequential awaits) both resolve, exactly one row lands, and both results describe the same row id/position. **Load-bearing**: revert the resolver hunk and this test fails with the real `23505` above, thrown from inside the racer. This is also the proof the two calls genuinely reach the DB concurrently — the pool is not serialising them.
2. **Two concurrent adds of *different* climbs** both insert and neither throws. Regression guard (passes on `main` too). It deliberately does *not* assert position uniqueness: `playlist_climbs_position_idx` is a plain `index()`, not `uniqueIndex()` (`packages/db/src/schema/app/playlists.ts:96`), and every read path orders by `(position ASC, added_at ASC)`, so a shared position resolves deterministically.
3. **Already-present climb** returns the pre-existing row unchanged — same id, same position, no duplicate insert, no position bump. Regression guard that also exercises the new `onConflictDoNothing`-miss → re-select branch.

The delete-during-race retry path is not unit-testable without a statement-level scheduler; it is covered by reasoning and by test 3 exercising the re-select branch itself.

Validation run: `vp run typecheck:backend` (pass), `vp check` on both changed files (pass, 0 warnings), the new test file 3/3, and an adjacent `--project backend playlist` sweep (79 passed; the one red was the known concurrent worker-DB provisioning flake in setup.ts, failing before any test code imports the resolver, and passing on re-run).

## QA Notes

Backend-only, no UI change and no schema change to exercise by hand.

- Add a climb to a playlist that isn't in it: it lands once, at the end, and the playlist's "updated" timestamp bumps.
- Add the same climb again: you get the existing row back, unchanged position, no duplicate, and the playlist timestamp does **not** bump (matches previous behaviour).
- Rapid double-tap "add to playlist" from mobile, or let the offline outbox drain a queued add while another device adds the same climb: no error toast, one row.
- Worth eyeballing: response shape of `addClimbToPlaylist` is unchanged (`id`, `playlistId`, `climbUuid`, `angle`, `position`, `addedAt`); GraphQL contract `addClimbToPlaylist(input: AddClimbToPlaylistInput!): PlaylistClimb!` untouched.
- Deliberately not done: keeping a cheap non-transactional pre-check `SELECT` as a fast path for the already-present case. It would save ~4 round-trips on repeat adds but leaves two divergent code paths for one mutation; the transaction is now the single authority. Easy to add later if playlist adds ever show up in latency traces.
- Known adjacent exposure, out of scope: `packages/web/app/lib/data-sync/aurora/user-sync.ts:347` inserts into `playlist_climbs` with delete-then-loop-insert and no `onConflictDoNothing`, so the Aurora sync path keeps its own differently-shaped exposure to the same index. Filed as #4023.

## Release Notes

Adding a climb to a playlist no longer errors out when the same climb gets added twice at once — a double-tap, or your phone syncing a queued add while another device adds the same climb, now quietly ends up with one entry instead of a failure.
