### PR TITLE
fix(mobile): hide the angle picker star row when there's no rating

### DIFF
--- a/packages/mobile/src/components/play-drawer/AngleSelectorSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/AngleSelectorSheet.tsx
@@ -118,17 +118,19 @@ export const AngleSelectorSheet = memo(function AngleSelectorSheet({
           </Text>
         ) : null}
 
-        <View style={styles.stars} accessibilityLabel={`★ ${quality.toFixed(1)}`}>
-          {[1, 2, 3, 4, 5].map((n) => (
-            <Text
-              key={n}
-              variant="body"
-              style={[styles.star, { color: quality >= n ? iosSystemColors.starGold : systemColors.secondaryLabel }]}
-            >
-              {quality >= n ? '★' : '☆'}
-            </Text>
-          ))}
-        </View>
+        {quality > 0 ? (
+          <View style={styles.stars} accessibilityLabel={`★ ${quality.toFixed(1)}`}>
+            {[1, 2, 3, 4, 5].map((n) => (
+              <Text
+                key={n}
+                variant="body"
+                style={[styles.star, { color: quality >= n ? iosSystemColors.starGold : systemColors.secondaryLabel }]}
+              >
+                {quality >= n ? '★' : '☆'}
+              </Text>
+            ))}
+          </View>
+        ) : null}
 
         {stats && stats.sends > 0 ? (
           <Text variant="caption1" style={[styles.ascents, { color: systemColors.secondaryLabel }]}>

--- a/packages/mobile/src/components/play-drawer/__tests__/angle-selector-sheet-stats-gate.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/angle-selector-sheet-stats-gate.test.tsx
@@ -80,7 +80,13 @@ vi.mock('../../../hooks/use-grade-format', () => ({
   useGradeFormat: () => ({ gradeFormat: 'v_grade' }),
 }));
 
-vi.mock('../community-utils', () => ({ buildAngleStatsMap: () => new Map() }));
+const angleStats = vi.hoisted(() => ({
+  map: new Map<number, { quality: number; sends: number; gradeName?: string; color?: string }>(),
+}));
+
+vi.mock('../community-utils', () => ({
+  buildAngleStatsMap: () => angleStats.map,
+}));
 
 vi.mock('../AngleBoardDiagram', () => ({ AngleBoardDiagram: () => null }));
 
@@ -105,6 +111,7 @@ const noop = () => {};
 
 beforeEach(() => {
   stats.calls = [];
+  angleStats.map = new Map();
 });
 
 afterEach(() => {
@@ -146,5 +153,67 @@ describe('AngleSelectorSheet — stats-history fetch gating', () => {
     );
 
     expect(stats.calls.some((call) => call.climbUuid === 'climb-1')).toBe(true);
+  });
+});
+
+// Regression for #3784: the angle preview's star row rendered unconditionally,
+// so any angle without community rating data (or a stats row with quality 0)
+// showed five hollow stars next to the real min-rating filter in
+// ClimbFilterSheet, reading as a second, broken-looking rating control. The
+// star row must only render once there is a meaningful (> 0) quality value.
+describe('AngleSelectorSheet — star row quality gating', () => {
+  it('hides the star row when there is no stats entry for the selected angle', () => {
+    const { container } = render(
+      createElement(AngleSelectorSheet, {
+        visible: true,
+        onClose: noop,
+        boardName: 'kilter',
+        layoutId: 1,
+        climbUuid: 'climb-1',
+        currentAngle: 40,
+        onAngleChange: noop,
+      }),
+    );
+
+    expect(container.textContent).not.toContain('★');
+    expect(container.textContent).not.toContain('☆');
+  });
+
+  it('hides the star row when stats exist but quality is 0', () => {
+    angleStats.map.set(40, { quality: 0, sends: 12 });
+
+    const { container } = render(
+      createElement(AngleSelectorSheet, {
+        visible: true,
+        onClose: noop,
+        boardName: 'kilter',
+        layoutId: 1,
+        climbUuid: 'climb-1',
+        currentAngle: 40,
+        onAngleChange: noop,
+      }),
+    );
+
+    expect(container.textContent).not.toContain('★');
+    expect(container.textContent).not.toContain('☆');
+  });
+
+  it('shows the star row once the selected angle has a meaningful quality', () => {
+    angleStats.map.set(40, { quality: 3.5, sends: 12 });
+
+    const { container } = render(
+      createElement(AngleSelectorSheet, {
+        visible: true,
+        onClose: noop,
+        boardName: 'kilter',
+        layoutId: 1,
+        climbUuid: 'climb-1',
+        currentAngle: 40,
+        onAngleChange: noop,
+      }),
+    );
+
+    expect(container.textContent).toContain('★');
+    expect(container.textContent).toContain('☆');
   });
 });


### PR DESCRIPTION
## Summary

The angle selector sheet on mobile rendered a fixed 5-star row for every angle, even when the angle had no community rating at all. For an unrated angle that meant a row of five hollow stars sitting right under the angle heading — which reads like a min-rating filter control you can tap, except it does nothing. The real min-rating filter lives in the climb filter sheet, so the duplicate-looking row was pure noise (the screenshot in #3784 is exactly this all-hollow case).

**Root cause (verified):** in `packages/mobile/src/components/play-drawer/AngleSelectorSheet.tsx`, `quality` is derived as `stats?.quality ?? 0`, but the star `<View>` was rendered unconditionally — unlike its siblings in the same block (`gradeName` and the ascents line, which are both already gated). So a missing stats entry, or a stats entry with `quality === 0`, still painted `☆☆☆☆☆`.

**Fix:** gate the star row on `quality > 0`, mirroring the sibling guards. `quality > 0` subsumes the "no stats" case because the `?? 0` collapse already happens one line up. This matches the app's existing precedent — `CommunitySection.tsx` hides its own star row on the same `> 0` threshold — and after this change `AngleSelectorSheet.tsx` is the only remaining raw-star row in `packages/mobile/src`, now consistent with it.

**Scope note for the reporter:** the sheet still shows the (informational, non-interactive) star row for angles that *do* have a community rating; it only disappears when there is no rating to show. If you meant "drop the stars from this sheet entirely", say so on the PR and we'll open a follow-up — this change deliberately keeps the rating as information while killing the misleading empty control.

## Test plan

- Extended `packages/mobile/src/components/play-drawer/__tests__/angle-selector-sheet-stats-gate.test.tsx` with two headline cases: no stats entry at all, and a stats entry with `quality: 0`. Both assert no `☆` glyph is rendered. Existing stats-gating tests kept and still pass (5/5).
- **Fail-on-revert verified:** reverting only the component hunk (`git apply -R`) and re-running that file gives `2 failed | 3 passed` — precisely the two new tests, with a real assertion message (`expected "…40°☆☆☆☆☆…" not to contain "☆"`), proving the pre-fix component really did render five hollow stars and the negative assertions are not vacuous. Patch re-applied; tree byte-identical.
- `vp test run --reporter=agent --project mobile packages/mobile/src/components/play-drawer/__tests__` → 36 files / 290 tests passed (no adjacent regressions).
- `vp check` on the changed files → clean. `vp run typecheck:mobile` → clean.
- No layout/detent risk: the sheet uses a fixed `androidSafeSnapPoints(['90%'])` with a top-aligned flow layout, so removing a row shrinks content inside a fixed detent (no #3330/#3776 class of bug). The `accessibilityLabel` lived on the star View itself, so it disappears with the row it described — no orphaned a11y label.
- Pure JS, mobile-only, OTA-safe. No migrations, no new i18n keys, no native files touched.

## QA Notes

Mobile, play drawer → angle selector sheet:

1. Open a climb on a board/angle combination that has **no** community rating for some angles. Those angles should show the heading and (when present) grade/ascents, with **no** star row — no row of hollow stars.
2. Pick an angle that **does** have a rating. The star row still shows the filled/hollow split for that rating, as information only.
3. Confirm the actual min-rating control is still where it belongs, in the climb filter sheet, and still filters.
4. Sheet height/scroll: with the star rows gone, the list should just be shorter — no clipped footer, no detent jump, on both iOS and Android.

## Release Notes

- Angles with no community rating no longer show an empty row of stars in the angle picker — the rating only appears when there's an actual rating behind it.

Fixes #3784
