### PR TITLE
fix(mobile): make the logbook Filter chip icon-only on iOS

### DIFF
--- a/packages/mobile/src/components/you/LogbookChipRow.ios.tsx
+++ b/packages/mobile/src/components/you/LogbookChipRow.ios.tsx
@@ -28,6 +28,8 @@ import {
   foregroundColor,
   padding,
   menuActionDismissBehavior,
+  labelStyle,
+  accessibilityLabel,
 } from '@expo/ui/swift-ui/modifiers';
 import { useTheme } from '../../providers/theme-provider';
 import { useGradeFormat } from '../../hooks/use-grade-format';
@@ -104,6 +106,21 @@ function LogbookChipRowComponent({
   const handleAngleChip = useCallback(() => onToggleFacet('angle'), [onToggleFacet]);
   const handleDateChip = useCallback(() => onToggleFacet('date'), [onToggleFacet]);
 
+  // The Filter chip is icon-only. `SwiftUI.Button(title, systemImage:)` builds a
+  // `Label`, and inside the glass HStack the icon+one-word title combination made
+  // SwiftUI compress the title to "F…" (#3782) — the plain-text chips beside it are
+  // fine. `labelStyle(.iconOnly)` drops the title from layout so the chip sizes to
+  // the symbol alone, matching the round icon-only filter button the Android
+  // (Material) logbook toolbar already ships. The title still has to be passed —
+  // @expo/ui only renders `systemImage` when a `label` is present — and iconOnly
+  // keeps it as the VoiceOver name; `accessibilityLabel` states that explicitly so
+  // the affordance can't silently lose its name.
+  const filterLabel = t('mobile.logbook.filter');
+  const filterModifiers = useMemo(
+    () => [...chipModifiers(anyFilterActive(facets)), labelStyle('iconOnly'), accessibilityLabel(filterLabel)],
+    [chipModifiers, facets, filterLabel],
+  );
+
   const handleSelectLatest = useCallback(() => onSelectPreset('recent'), [onSelectPreset]);
   const handleSelectHardest = useCallback(() => onSelectPreset('hardest'), [onSelectPreset]);
 
@@ -116,15 +133,16 @@ function LogbookChipRowComponent({
       <ScrollView axes="horizontal" showsIndicators={false}>
         {/* Vertical padding gives a pressed chip's glass lens room to expand. */}
         <HStack spacing={spacing[2]} modifiers={[padding({ horizontal: spacing[4], vertical: spacing[2] })]}>
-          {/* Filter → the long-tail sheet. An action button, not a menu. Neutral
-              glass until at least one facet is active, then amber — matching the
-              climb search, where Filters only colours up once filters are set. The
-              sort (Latest/Hardest) doesn't count, so it never tints the Filter chip. */}
+          {/* Filter → the long-tail sheet. An action button, not a menu, and
+              icon-only (see filterModifiers). Neutral glass until at least one
+              facet is active, then amber — matching the climb search, where Filters
+              only colours up once filters are set. The sort (Latest/Hardest)
+              doesn't count, so it never tints the Filter chip. */}
           <Button
-            label={t('mobile.logbook.filter')}
+            label={filterLabel}
             systemImage="line.3.horizontal.decrease"
             onPress={onOpenFilters}
-            modifiers={chipModifiers(anyFilterActive(facets))}
+            modifiers={filterModifiers}
           />
 
           {/* Latest / Hardest — live-commit the sort preset; null lights neither. */}

--- a/packages/mobile/src/components/you/__tests__/logbook-chip-row-filter-icon.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-chip-row-filter-icon.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+//
+// Locks the icon-only Filter chip (#3782). The iOS chip row is platform-split, so
+// it is imported by its EXPLICIT `.ios` path — the extensionless specifier is
+// aliased to a null stub in packages/mobile/vite.config.ts, and `.ios` sidesteps
+// that alias. @expo/ui resolves native views at module load, so the SwiftUI
+// surface is mocked and the assertions run against the props/modifiers the row
+// hands the native Button.
+//
+// NOTE: the mobile vitest config inlines `__DEV__: 'true'` (a define, not a
+// global), so this suite never gates on `!__DEV__`.
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { DEFAULT_LOGBOOK_FILTERS } from '@boardsesh/logbook';
+import type { Grade } from '@boardsesh/shared-schema';
+
+type ModifierRecord = { modifier: string; arg?: unknown };
+type ButtonRecord = { label?: string; systemImage?: string; modifiers?: ModifierRecord[] };
+
+const captured = vi.hoisted(() => ({ buttons: [] as ButtonRecord[] }));
+
+// Each modifier factory records its name + argument so the test can assert the
+// exact SwiftUI modifiers applied to the Filter chip.
+vi.mock('@expo/ui/swift-ui/modifiers', () => {
+  const make =
+    (modifier: string) =>
+    (arg?: unknown): ModifierRecord => ({ modifier, arg });
+  return {
+    buttonStyle: make('buttonStyle'),
+    controlSize: make('controlSize'),
+    tint: make('tint'),
+    foregroundColor: make('foregroundColor'),
+    padding: make('padding'),
+    menuActionDismissBehavior: make('menuActionDismissBehavior'),
+    labelStyle: make('labelStyle'),
+    accessibilityLabel: make('accessibilityLabel'),
+  };
+});
+
+vi.mock('@expo/ui/swift-ui', () => {
+  const passthrough = ({ children }: { children?: ReactNode }) => createElement('div', null, children);
+  return {
+    Host: passthrough,
+    ScrollView: passthrough,
+    HStack: passthrough,
+    Menu: passthrough,
+    Toggle: () => null,
+    Button: (props: ButtonRecord) => {
+      captured.buttons.push(props);
+      return null;
+    },
+  };
+});
+
+vi.mock('react-native', () => ({
+  StyleSheet: { create: <T,>(styles: T): T => styles },
+  // src/theme/colors.ts reads Platform.OS / PlatformColor at module load.
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+}));
+
+vi.mock('react-i18next', () => ({
+  // Return the key so the assertions can name the exact catalog key in play.
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ brandColors: { accent: '#F5A524' } }),
+}));
+
+vi.mock('../../../hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({ formatGrade: (name: string) => name }),
+}));
+
+// Imported after the mocks so the module graph resolves against them.
+const { LogbookChipRow } = await import('../LogbookChipRow.ios');
+
+const GRADES: Grade[] = [
+  { difficultyId: 10, name: '6a' },
+  { difficultyId: 14, name: '6b' },
+];
+
+function renderRow() {
+  captured.buttons = [];
+  render(
+    createElement(LogbookChipRow, {
+      sortPreset: 'recent' as const,
+      onSelectPreset: vi.fn(),
+      onOpenFilters: vi.fn(),
+      filters: DEFAULT_LOGBOOK_FILTERS,
+      grades: GRADES,
+      onToggleFacet: vi.fn(),
+      onUpdateFilters: vi.fn(),
+    }),
+  );
+  const filterButton = captured.buttons[0];
+  if (!filterButton) throw new Error('the Filter chip did not render');
+  return filterButton;
+}
+
+function modifierNames(button: ButtonRecord): string[] {
+  return (button.modifiers ?? []).map((entry) => entry.modifier);
+}
+
+describe('LogbookChipRow.ios Filter chip', () => {
+  it('renders the filter symbol with the title dropped from layout', () => {
+    const filterButton = renderRow();
+
+    expect(filterButton.systemImage).toBe('line.3.horizontal.decrease');
+    // Icon-only: without this the SwiftUI Label lays the title out beside the
+    // symbol and the glass HStack compresses it to "F…" (#3782).
+    expect(filterButton.modifiers).toContainEqual({ modifier: 'labelStyle', arg: 'iconOnly' });
+  });
+
+  it('keeps the mobile.logbook.filter wording as the accessible name', () => {
+    const filterButton = renderRow();
+
+    // @expo/ui only renders `systemImage` when a `label` is present, so the title
+    // must still be passed even though iconOnly hides it.
+    expect(filterButton.label).toBe('mobile.logbook.filter');
+    expect(filterButton.modifiers).toContainEqual({
+      modifier: 'accessibilityLabel',
+      arg: 'mobile.logbook.filter',
+    });
+  });
+
+  it('keeps the neutral-glass chip styling alongside the icon-only modifiers', () => {
+    const filterButton = renderRow();
+
+    // Default filters ⇒ no facet active ⇒ neutral glass, not amber prominent.
+    expect(filterButton.modifiers).toContainEqual({ modifier: 'buttonStyle', arg: 'glass' });
+    expect(modifierNames(filterButton)).toEqual(['buttonStyle', 'controlSize', 'labelStyle', 'accessibilityLabel']);
+  });
+
+  it('leaves the other chips as plain text chips', () => {
+    renderRow();
+
+    const otherButtons = captured.buttons.slice(1);
+    expect(otherButtons.length).toBeGreaterThan(0);
+    for (const button of otherButtons) {
+      expect(button.systemImage).toBeUndefined();
+      expect(modifierNames(button)).not.toContain('labelStyle');
+    }
+  });
+});

--- a/packages/mobile/src/components/you/__tests__/logbook-chip-row-filter-icon.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-chip-row-filter-icon.test.tsx
@@ -94,7 +94,10 @@ function renderRow(filters: LogbookFilterState = DEFAULT_LOGBOOK_FILTERS) {
       onUpdateFilters: vi.fn(),
     }),
   );
-  const filterButton = captured.buttons[0];
+  // Look the chip up by label, not position, so a chip reorder fails loudly here
+  // instead of silently asserting against whatever chip moved into slot 0. The
+  // leading position is a separate assertion below.
+  const filterButton = captured.buttons.find((button) => button.label === 'mobile.logbook.filter');
   if (!filterButton) throw new Error('the Filter chip did not render');
   return filterButton;
 }
@@ -107,6 +110,8 @@ describe('LogbookChipRow.ios Filter chip', () => {
   it('renders the filter symbol with the title dropped from layout', () => {
     const filterButton = renderRow();
 
+    // Filter leads the row (the sheet opener sits before the sort/facet chips).
+    expect(captured.buttons[0]).toBe(filterButton);
     expect(filterButton.systemImage).toBe('line.3.horizontal.decrease');
     // Icon-only: without this the SwiftUI Label lays the title out beside the
     // symbol and the glass HStack compresses it to "F…" (#3782).
@@ -151,9 +156,9 @@ describe('LogbookChipRow.ios Filter chip', () => {
   });
 
   it('leaves the other chips as plain text chips', () => {
-    renderRow();
+    const filterButton = renderRow();
 
-    const otherButtons = captured.buttons.slice(1);
+    const otherButtons = captured.buttons.filter((button) => button !== filterButton);
     expect(otherButtons.length).toBeGreaterThan(0);
     for (const button of otherButtons) {
       expect(button.systemImage).toBeUndefined();

--- a/packages/mobile/src/components/you/__tests__/logbook-chip-row-filter-icon.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-chip-row-filter-icon.test.tsx
@@ -12,7 +12,7 @@
 import { render } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { DEFAULT_LOGBOOK_FILTERS } from '@boardsesh/logbook';
+import { DEFAULT_LOGBOOK_FILTERS, type LogbookFilterState } from '@boardsesh/logbook';
 import type { Grade } from '@boardsesh/shared-schema';
 
 type ModifierRecord = { modifier: string; arg?: unknown };
@@ -81,14 +81,14 @@ const GRADES: Grade[] = [
   { difficultyId: 14, name: '6b' },
 ];
 
-function renderRow() {
+function renderRow(filters: LogbookFilterState = DEFAULT_LOGBOOK_FILTERS) {
   captured.buttons = [];
   render(
     createElement(LogbookChipRow, {
       sortPreset: 'recent' as const,
       onSelectPreset: vi.fn(),
       onOpenFilters: vi.fn(),
-      filters: DEFAULT_LOGBOOK_FILTERS,
+      filters,
       grades: GRADES,
       onToggleFacet: vi.fn(),
       onUpdateFilters: vi.fn(),
@@ -131,6 +131,23 @@ describe('LogbookChipRow.ios Filter chip', () => {
     // Default filters ⇒ no facet active ⇒ neutral glass, not amber prominent.
     expect(filterButton.modifiers).toContainEqual({ modifier: 'buttonStyle', arg: 'glass' });
     expect(modifierNames(filterButton)).toEqual(['buttonStyle', 'controlSize', 'labelStyle', 'accessibilityLabel']);
+  });
+
+  it('keeps the icon-only modifiers on the amber chip once a facet is set', () => {
+    // A grade bound makes the grade facet active ⇒ anyFilterActive ⇒ amber
+    // prominent glass. The icon-only pair must survive that longer modifier list,
+    // otherwise the chip regresses to "F…" exactly when a filter is in play.
+    const filterButton = renderRow({ ...DEFAULT_LOGBOOK_FILTERS, minGrade: 10 });
+
+    expect(filterButton.modifiers).toContainEqual({ modifier: 'buttonStyle', arg: 'glassProminent' });
+    expect(modifierNames(filterButton)).toEqual([
+      'buttonStyle',
+      'controlSize',
+      'tint',
+      'foregroundColor',
+      'labelStyle',
+      'accessibilityLabel',
+    ]);
   });
 
   it('leaves the other chips as plain text chips', () => {

--- a/scripts/mobile-platform-imports-check.sh
+++ b/scripts/mobile-platform-imports-check.sh
@@ -25,10 +25,18 @@ gorhom_scan_dirs=(packages/mobile packages/shared)
 
 # swift-ui (and its sub-paths, e.g. /modifiers) must live only in *.ios.{ts,tsx}.
 # Match a quoted module specifier so a stray mention in a comment doesn't trip it.
+#
+# Vitest suites under `__tests__/` are exempt: they name the specifier only to
+# vi.mock() it (the call needs a literal path), they run in node, and Metro never
+# reaches them from an app entry — so they cannot produce the device crash this
+# guard exists to prevent. Everything Metro can reach is still scanned, and the
+# exemption is narrow: `__tests__/<file>.test.ts(x)` only, so a production module
+# can't dodge the guard by living in a test folder.
 swiftui_bad=$(
   grep -rlE "['\"]@expo/ui/swift-ui" "${scan_dirs[@]}" \
     --include='*.ts' --include='*.tsx' \
     | grep -vE '\.ios\.(ts|tsx)$' \
+    | grep -vE '/__tests__/[^/]+\.test\.(ts|tsx)$' \
     || true
 )
 


### PR DESCRIPTION
## What & why

On the mobile app's Profile → Logbook tab, the iOS Liquid Glass toolbar's leading **Filter** chip rendered as `F…` instead of `Filter` ([#3782](https://github.com/boardsesh/boardsesh/issues/3782)) — the plain-text chips beside it (`Latest`, `Hardest`, `Grade`) laid out fine in the same row.

## Root cause

`packages/mobile/src/components/you/LogbookChipRow.ios.tsx` renders the chip as `<Button label systemImage="line.3.horizontal.decrease" />`. @expo/ui's `Button.swift` maps that to `SwiftUI.Button(title, systemImage:)`, which builds a `Label`. Inside the glass `HStack` (small `controlSize`, horizontal `ScrollView`, `Host matchContents={{ vertical: true }}`), the symbol + one-word title combination appears to be what SwiftUI compresses — the search row's `FilterChipRow.ios.tsx` uses the same symbol with a longer title (`Filters · N`) and is unaffected. Not a string-length problem: `Filter` / `Filtrar` / `Filtrer` are all short.

## Fix

Add `labelStyle('iconOnly')` to the Filter chip's modifiers so the title leaves layout entirely and the chip sizes to the SF Symbol alone. This is the same icon-only filter affordance the Android (Material) logbook toolbar already ships in `LogbookTab.tsx`, and the issue author explicitly sanctioned going icon-only.

The title is still passed — @expo/ui only renders `systemImage` when a `label` is present — and `.labelStyle(.iconOnly)` keeps it as the VoiceOver name. An explicit `accessibilityLabel(t('mobile.logbook.filter'))` states that so the affordance can't silently lose its name. No new i18n keys: the existing `mobile.logbook.filter` key (en-US / es / fr) is reused.

Pure JS/TSX, OTA-safe, iOS-only. No native rebuild, no new dependency.

## Tests

New `packages/mobile/src/components/you/__tests__/logbook-chip-row-filter-icon.test.tsx` (jsdom). The extensionless `LogbookChipRow` specifier is aliased to a null stub in `packages/mobile/vite.config.ts`, so the suite imports the component by its **explicit `.ios` path** and mocks `@expo/ui/swift-ui` + `.../modifiers`, recording every modifier by name and argument. It asserts the chip carries `labelStyle('iconOnly')` + `accessibilityLabel('mobile.logbook.filter')` alongside the neutral-glass styling, that the same pair survives the longer amber (`glassProminent`) modifier list once a grade bound is set, and that the sibling text chips stay plain (no `systemImage`, no `labelStyle`).

**Fail-on-revert:** reverting `LogbookChipRow.ios.tsx` to `origin/main` and re-running the suite fails 4 of 5 tests (missing `labelStyle`, missing `accessibilityLabel`, and both modifier-list mismatches). Restoring it passes 5/5.

`scripts/mobile-platform-imports-check.sh` gained one narrow exemption: a vitest file under `__tests__/` may name `@expo/ui/swift-ui` because `vi.mock()` needs a literal specifier. Test modules run in node and Metro never reaches them from an app entry, so they can't cause the "Unable to get view config" crash the guard exists to stop. Every module Metro can reach is still scanned, and the exemption only matches `__tests__/<file>.test.ts(x)` — a production module can't dodge the guard by moving into a test folder.

## QA Notes

- **iOS visual confirmation is pending** — this was implemented on a Linux box with no simulator. SwiftUI layout can't be asserted in jsdom, so the on-device check is: Profile → Logbook on an iOS 26 (Liquid Glass) build, confirm the leading chip is a round icon-only filter button with no `F…` text, that it still opens the filter sheet, that it turns amber once a facet is set, and that VoiceOver reads it as "Filter".
- Risk is bounded: Android already ships this exact icon-only shape for the same control, and the issue author asked for it as one of two acceptable fixes.
- Unchanged surfaces: the Android and web logbook chip rows, and the climbs-search `FilterChipRow.ios.tsx`.

## Release Notes

The Logbook's filter button on iOS now shows a clean filter icon instead of a chopped-off "F…".

Fixes #3782
