### PR TITLE
fix(sync): narrow the bare "secure connection" NSURL match

### DIFF
--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
@@ -218,7 +218,8 @@ describe('isTransportNetworkError', () => {
 
   it('matches the best-effort English NSURLError descriptions (un-wrapped iOS case)', () => {
     expect(isTransportNetworkError(new Error('The internet connection appears to be offline.'))).toBe(true);
-    expect(isTransportNetworkError(new Error('A TLS error caused the secure connection to fail.'))).toBe(true);
+    expect(isTransportNetworkError(new Error('A secure connection to the server cannot be made.'))).toBe(true);
+    expect(isTransportNetworkError(new Error('The secure connection failed.'))).toBe(true);
   });
 
   it('does NOT match a programmer bug that merely mentions fetch/network/timed out', () => {
@@ -226,6 +227,12 @@ describe('isTransportNetworkError', () => {
     expect(isTransportNetworkError(new TypeError("Cannot read property 'fetch' of undefined"))).toBe(false);
     expect(isTransportNetworkError(new Error('BLE write timed out waiting for the board to accept data'))).toBe(false);
     expect(isTransportNetworkError(new Error('network graph render failed'))).toBe(false);
+  });
+
+  it('does NOT match an app-level business message that merely contains "secure connection"', () => {
+    // Regression guard: the regex was previously a bare `secure connection` alternative,
+    // which would have swallowed any unrelated message containing that substring.
+    expect(isTransportNetworkError(new Error('This operation requires a secure connection'))).toBe(false);
   });
 
   it('does not classify a non-object or a real server error', () => {

--- a/packages/shared/offline-sync/src/mutation-queue/error-classification.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/error-classification.ts
@@ -87,7 +87,7 @@ const TRANSPORT_NETWORK_CODES = new Set([
 // specific (never a bare "connection"/"network"/"timed out") so a real bug is
 // never misclassified as offline.
 const IOS_NSURL_ENGLISH_DESCRIPTIONS =
-  /the request timed out|network connection was lost|connection appears to be offline|could not connect to the server|secure connection|the connection has timed out|not connected to the internet/i;
+  /the request timed out|network connection was lost|connection appears to be offline|could not connect to the server|secure connection to the server cannot be made|secure connection failed|the connection has timed out|not connected to the internet/i;
 
 const MAX_CAUSE_DEPTH = 3;
 


### PR DESCRIPTION
## Summary

The English-prose fallback that classifies un-wrapped iOS `NSURLError` descriptions as transport failures carried a bare `secure connection` alternative:

```
/... |could not connect to the server|secure connection|the connection has timed out| ... /i
```

Any message merely *containing* that phrase — "This operation requires a secure connection" is the obvious shape — would be classified as a transport/network error, and `isRetryable` returns `true` unconditionally for network errors. A hard failure would then retry forever at the head of the mutation outbox, blocking every queued mutation behind it, and with no telemetry: network failures are downgraded to `warning` in the reporter.

### Verified root cause

`IOS_NSURL_ENGLISH_DESCRIPTIONS` at `packages/shared/offline-sync/src/mutation-queue/error-classification.ts:90`. Every other alternative in that regex is a full Apple sentence fragment ("the request timed out", "network connection was lost", "connection appears to be offline"); `secure connection` was the one bare noun phrase, and the comment directly above the constant already states the intended rule — "specific (never a bare `connection`/`network`/`timed out`) so a real bug is never misclassified as offline". The bare alternative violated the rule the file sets for itself.

Latent, not live: the backend emits no message containing the phrase today, and the locale-independent code/marker/`.cause` checks are the primary signal. This is the sharp edge, not an outage.

### Fix

Replace the bare alternative with the two phrasings #3869 prescribes: `secure connection to the server cannot be made` and `secure connection failed`. The first is a genuine substring of Apple's `NSURLErrorSecureConnectionFailed` (-1200) `localizedDescription` — "An SSL error has occurred and a secure connection to the server cannot be made." The second is the belt-and-braces alternative named in the issue.

The change is strictly narrowing, so it can only ever produce **fewer** matches. If a real iOS TLS description someday matches neither literal, it falls through to `isRetryable` → status `null` → dead-letter, which surfaces the failure to the user. That fails safe in exactly the direction the issue asks for: better to surface an error than to silently head-of-line-block the outbox.

Issue bullet 3 (let a resolved HTTP/GraphQL status beat the English-prose heuristic) is deliberately out of scope — it reorders `isRetryable`, which runs `isNetworkError` before `getErrorStatus`, and touches mobile's `reportHandledError`. Tracked in #4027.

## Tests

`packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts`:

- The positive case now asserts the two real Apple phrasings classify as transport, replacing a fabricated string ("A TLS error caused the secure connection to fail.") that only passed because the bare substring swallowed it.
- New negative case: `This operation requires a secure connection` must **not** classify as transport.

**Fail-on-revert:** restoring the bare `secure connection` alternative on line 90 and re-running the file gives 1 failed / 42 passed — the failure is exactly the new negative guard (`expected true to be false`, line 235). The two positive assertions stay green under the old regex, as they must: a bare substring is strictly broader. So the negative test is the sole discriminating guard, and it discriminates.

Scoped validation on the restored tree:

- `vp test run --reporter=agent packages/shared/offline-sync` — 19 files / 269 tests pass.
- `vp test run --project mobile --reporter=agent packages/mobile/src/lib/__tests__/error-reporting.test.ts packages/mobile/src/lib/__tests__/global-error-capture.test.ts` — 2 files / 32 tests pass. These are the only downstream consumers (`error-reporting.ts:60` imports `isTransportNetworkError`; `drainer.ts:5` imports `isRetryable`/`isNetworkError`).
- Repo-wide grep for "secure connection": only the regex itself and the three test lines in this diff.

## QA Notes

No UI surface — this is classification logic behind the offline mutation outbox. Nothing to click through.

If you want to exercise it on device: put the phone in airplane mode mid-sync, confirm queued ticks still retry and drain when connectivity returns (the un-touched NSURL codes and `.cause` markers carry that path). The narrowed branch only fires for un-wrapped iOS TLS descriptions, which needs a genuinely broken TLS endpoint to reproduce.

## Release Notes

none

Fixes #3869
