### PR TITLE
fix(mobile): keep You-page charts inside their card and off the spline

### DIFF
--- a/packages/mobile/src/components/you/YouCharts.tsx
+++ b/packages/mobile/src/components/you/YouCharts.tsx
@@ -24,6 +24,13 @@ const AXIS_LABEL_SIZE = 11;
 const STACK_BAR_RADIUS = 3;
 const MIN_ZOOM_SCALE = 1;
 const MAX_ZOOM_SCALE = 2.75;
+// gifted-charts' BarChart renders its bars/spacing into whatever `width` prop
+// it's given, but that width is itself a few px narrower than the measured
+// frame (room for the chart's own right-edge padding). Bar-fitting math MUST
+// use the same narrowed budget the chart is actually given, or the fitted
+// bars (sized off the full frame width) run wider than the canvas they're
+// drawn into and the last bar/label spills past the card edge (#3778).
+const CHART_WIDTH_INSET = 8;
 // Floor for grouped flash|redpoint bars so a dense V0-V17 axis keeps each bar
 // above the iOS 44pt / Android 48dp touch target instead of shrinking to 4px.
 const MIN_GROUPED_BAR = 6;
@@ -375,7 +382,8 @@ export const StackedBarChart = memo(function StackedBarChart({
           zoomable={interactive && zoomable}
         >
           {(width, zoomScale, scrollEnabled) => {
-            const fitted = fitBars(width, stackData.length, minBarWidth);
+            const chartWidth = width - CHART_WIDTH_INSET;
+            const fitted = fitBars(chartWidth, stackData.length, minBarWidth);
             const barWidth = Math.max(minBarWidth, Math.round(fitted.barWidth * zoomScale));
             const spacing = Math.max(2, Math.round(fitted.spacing * zoomScale));
             // gifted sizes each x-axis label box to ~one bar by default, so a wide
@@ -390,7 +398,7 @@ export const StackedBarChart = memo(function StackedBarChart({
             return (
               <BarChart
                 stackData={sizedData}
-                width={width - 8}
+                width={chartWidth}
                 height={height - 28}
                 barWidth={barWidth}
                 spacing={spacing}
@@ -487,11 +495,14 @@ export const GroupedBarChart = memo(function GroupedBarChart({
           zoomable={interactive && zoomable}
         >
           {(width, zoomScale, scrollEnabled) => {
+            const chartWidth = width - CHART_WIDTH_INSET;
             const list = bars ?? [];
             const initial = 8;
             const baseBarWidth = Math.max(
               MIN_GROUPED_BAR,
-              Math.floor((width - initial * 2 - groupGap * list.length - innerGap * list.length) / (list.length * 2)),
+              Math.floor(
+                (chartWidth - initial * 2 - groupGap * list.length - innerGap * list.length) / (list.length * 2),
+              ),
             );
             const barWidth = Math.max(MIN_GROUPED_BAR, Math.round(baseBarWidth * zoomScale));
             const zoomedGroupGap = Math.max(groupGap, Math.round(groupGap * zoomScale));
@@ -517,7 +528,7 @@ export const GroupedBarChart = memo(function GroupedBarChart({
             return (
               <BarChart
                 data={data}
-                width={width - 8}
+                width={chartWidth}
                 height={height - 28}
                 barWidth={barWidth}
                 initialSpacing={initial}

--- a/packages/mobile/src/components/you/YouCharts.tsx
+++ b/packages/mobile/src/components/you/YouCharts.tsx
@@ -24,13 +24,21 @@ const AXIS_LABEL_SIZE = 11;
 const STACK_BAR_RADIUS = 3;
 const MIN_ZOOM_SCALE = 1;
 const MAX_ZOOM_SCALE = 2.75;
-// gifted-charts' BarChart renders its bars/spacing into whatever `width` prop
-// it's given, but that width is itself a few px narrower than the measured
-// frame (room for the chart's own right-edge padding). Bar-fitting math MUST
-// use the same narrowed budget the chart is actually given, or the fitted
-// bars (sized off the full frame width) run wider than the canvas they're
-// drawn into and the last bar/label spills past the card edge (#3778).
+// gifted-charts does NOT lay its chart out inside the `width` prop we hand it.
+// BarAndLineChartsWrapper positions the plot ScrollView absolutely at
+// `marginLeft: yAxisLabelWidth + yAxisThickness` with `width: props.width`, and
+// renderHorizSections draws the rules/x-axis row as a `yAxisLabelWidth` spacer
+// followed by a `props.width + endSpacing` band. So the span the chart really
+// occupies is `yAxisLabelWidth + width + endSpacing` — all three have to come
+// out of the measured frame or the last bar and its label bleed past the
+// rounded card edge (#3778). We pin `endSpacing={0}` (it otherwise defaults to
+// `spacing`, and to 20 on the grouped chart, which passes spacing per-datum),
+// subtract the y-axis gutter below, and keep a small inset as slack.
 const CHART_WIDTH_INSET = 8;
+// Gutter reserved for the y-axis scale labels when `showYAxisScale` is set.
+// Passed straight to BarChart's `yAxisLabelWidth` so the number we budget for
+// and the number gifted-charts offsets the plot by can never drift apart.
+const Y_AXIS_LABEL_WIDTH = 32;
 // Floor for grouped flash|redpoint bars so a dense V0-V17 axis keeps each bar
 // above the iOS 44pt / Android 48dp touch target instead of shrinking to 4px.
 const MIN_GROUPED_BAR = 6;
@@ -382,7 +390,8 @@ export const StackedBarChart = memo(function StackedBarChart({
           zoomable={interactive && zoomable}
         >
           {(width, zoomScale, scrollEnabled) => {
-            const chartWidth = width - CHART_WIDTH_INSET;
+            const axisGutter = showYAxisScale ? Y_AXIS_LABEL_WIDTH : 0;
+            const chartWidth = width - CHART_WIDTH_INSET - axisGutter;
             const fitted = fitBars(chartWidth, stackData.length, minBarWidth);
             const barWidth = Math.max(minBarWidth, Math.round(fitted.barWidth * zoomScale));
             const spacing = Math.max(2, Math.round(fitted.spacing * zoomScale));
@@ -403,9 +412,10 @@ export const StackedBarChart = memo(function StackedBarChart({
                 barWidth={barWidth}
                 spacing={spacing}
                 initialSpacing={8}
+                endSpacing={0}
                 hideRules={!showYAxisScale}
                 hideYAxisText={!showYAxisScale}
-                yAxisLabelWidth={showYAxisScale ? 32 : 0}
+                yAxisLabelWidth={axisGutter}
                 maxValue={yAxisMaxValue}
                 yAxisThickness={0}
                 xAxisThickness={StyleSheet.hairlineWidth}
@@ -532,10 +542,16 @@ export const GroupedBarChart = memo(function GroupedBarChart({
                 height={height - 28}
                 barWidth={barWidth}
                 initialSpacing={initial}
+                endSpacing={0}
                 barBorderRadius={STACK_BAR_RADIUS}
                 topLabelContainerStyle={{ width: barWidth }}
                 hideRules
                 hideYAxisText
+                // `hideYAxisText` alone still reserves gifted-charts'
+                // `yAxisEmptyLabelWidth` (10px) to the left of the plot, which
+                // lands outside `width`. Pin it to 0 so `chartWidth` is the
+                // whole occupied span (#3778).
+                yAxisLabelWidth={0}
                 maxValue={yAxisMaxValue}
                 yAxisThickness={0}
                 xAxisThickness={StyleSheet.hairlineWidth}
@@ -749,6 +765,12 @@ const styles = StyleSheet.create({
     position: 'relative',
     alignItems: 'center',
     justifyContent: 'center',
+    // Second layer behind the width budgeting above: if a future gifted-charts
+    // version reserves gutter we didn't account for, it gets clipped at the
+    // frame instead of bleeding past the rounded card edge (#3778). The
+    // reset-zoom button sits inside the frame and the tooltip overlay is a
+    // sibling on `chartShell`, so neither is affected.
+    overflow: 'hidden',
   },
   emptyState: {
     alignItems: 'center',

--- a/packages/mobile/src/components/you/YouCharts.tsx
+++ b/packages/mobile/src/components/you/YouCharts.tsx
@@ -692,8 +692,12 @@ export const TotalAreaChart = memo(function TotalAreaChart({
             endOpacity={colorScheme === 'dark' ? 0.1 : 0.04}
             gradientDirection="vertical"
             thickness={2}
-            curved
-            curvature={0.2}
+            // Cardinal-spline curving (gifted-charts' `curved`) can overshoot past a
+            // data point's y-value between two neighbours, making a flat or dipping
+            // week look like it rose. The weekly cadence is evenly spaced already,
+            // so a straight-segment line reads just as smoothly without the
+            // overshoot (#3780).
+            curved={false}
             maxValue={model.maxValue}
             noOfSections={model.sections}
             yAxisLabelTexts={model.yAxisLabelTexts}

--- a/packages/mobile/src/components/you/__tests__/you-charts-line-interpolation.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/you-charts-line-interpolation.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+//
+// Regression coverage for #3780: the V-Points area chart used gifted-charts'
+// cardinal-spline `curved` interpolation, which can overshoot past a data
+// point's y-value between two neighbours — making a flat or dipping week
+// look like it rose (or vice versa). This repo has no visual regression
+// harness, so this test pins the prop contract instead: the LineChart must
+// render straight segments (`curved={false}`) with no leftover `curvature`.
+import { createElement, useEffect, type ReactNode } from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { RawVPointsTimeline } from '@boardsesh/profile-stats';
+
+const FRAME_WIDTH = 320;
+
+vi.mock('react-native', () => ({
+  View: ({ children, onLayout }: { children?: ReactNode; onLayout?: (event: unknown) => void }) => {
+    useEffect(() => {
+      onLayout?.({ nativeEvent: { layout: { width: FRAME_WIDTH, height: 160, x: 0, y: 0 } } });
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- fire once on mount, matching a real layout pass
+    }, []);
+    return createElement('div', null, children);
+  },
+  Pressable: ({ children }: { children?: ReactNode }) => createElement('button', { type: 'button' }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+type LineChartCall = { curved?: boolean; curvature?: number; width?: number };
+
+const lineChartCalls: LineChartCall[] = [];
+
+vi.mock('react-native-gifted-charts', () => ({
+  BarChart: () => createElement('div', { 'data-testid': 'gifted-bar-chart' }),
+  LineChart: (props: LineChartCall) => {
+    lineChartCalls.push(props);
+    return createElement('div', { 'data-testid': 'gifted-line-chart' });
+  },
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({
+  Icon: () => createElement('span', { 'data-testid': 'icon' }),
+}));
+vi.mock('../../ActivityIndicator', () => ({
+  ActivityIndicator: () => createElement('span', { 'data-testid': 'activity-indicator' }),
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    variant: 'material' as const,
+    colorScheme: 'light' as const,
+    systemColors: {
+      secondaryLabel: '#666666',
+      tertiaryLabel: '#999999',
+      elevatedSurface: '#ffffff',
+      separator: '#dddddd',
+      label: '#111111',
+    },
+    chartColors: {
+      secondaryLabel: '#666666',
+      tertiaryLabel: '#999999',
+      elevatedSurface: '#ffffff',
+      separator: '#dddddd',
+      label: '#111111',
+    },
+  }),
+}));
+
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 0: 0, 1: 4, 2: 8, 3: 12, 4: 16 },
+  borderRadius: { full: 999, xl: 16 },
+  opacity: { peek: 0.5 },
+  materialElevationByLevel: { level2: {} },
+}));
+
+vi.mock('../../../lib/haptics', () => ({
+  hapticSelection: vi.fn(),
+}));
+
+vi.mock('../profile-chart-colors', () => ({
+  gradeChartColor: (key: string) => `grade-${key}`,
+  layoutChartColor: (key: string) => `layout-${key}`,
+  flashRedpointColor: (key: string) => `status-${key}`,
+}));
+
+import { TotalAreaChart } from '../YouCharts';
+
+describe('TotalAreaChart line interpolation (#3780)', () => {
+  const timeline: RawVPointsTimeline = {
+    weekLabels: ['W1', 'W2', 'W3', 'W4'],
+    series: [{ layoutKey: 'kilter-1', displayName: 'Kilter Original', data: [10, 12, 9, 20] }],
+    totalPoints: 20,
+  };
+
+  it('renders straight segments instead of an overshooting curve', () => {
+    lineChartCalls.length = 0;
+    render(<TotalAreaChart timeline={timeline} color="#7c3aed" />);
+
+    expect(lineChartCalls).toHaveLength(1);
+    const call = lineChartCalls[0]!;
+    expect(call.curved).toBe(false);
+    expect(call.curvature).toBeUndefined();
+  });
+});

--- a/packages/mobile/src/components/you/__tests__/you-charts-line-interpolation.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/you-charts-line-interpolation.test.tsx
@@ -8,7 +8,7 @@
 // render straight segments (`curved={false}`) with no leftover `curvature`.
 import { createElement, useEffect, type ReactNode } from 'react';
 import { render } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { RawVPointsTimeline } from '@boardsesh/profile-stats';
 
 const FRAME_WIDTH = 320;
@@ -91,6 +91,10 @@ vi.mock('../profile-chart-colors', () => ({
 
 import { TotalAreaChart } from '../YouCharts';
 
+beforeEach(() => {
+  lineChartCalls.length = 0;
+});
+
 describe('TotalAreaChart line interpolation (#3780)', () => {
   const timeline: RawVPointsTimeline = {
     weekLabels: ['W1', 'W2', 'W3', 'W4'],
@@ -99,7 +103,6 @@ describe('TotalAreaChart line interpolation (#3780)', () => {
   };
 
   it('renders straight segments instead of an overshooting curve', () => {
-    lineChartCalls.length = 0;
     render(<TotalAreaChart timeline={timeline} color="#7c3aed" />);
 
     expect(lineChartCalls).toHaveLength(1);

--- a/packages/mobile/src/components/you/__tests__/you-charts-width-budget.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/you-charts-width-budget.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+//
+// Regression coverage for #3778: You-page Activity/Grade Distribution bar
+// charts could overflow their card width. StackedBarChart and GroupedBarChart
+// fit bar/spacing sizes off the measured frame width, then handed
+// gifted-charts' BarChart a narrower `width` prop (room for its own
+// right-edge padding) — so the fitted content ran wider than the canvas it
+// was drawn into. This repo has no visual regression harness, so these tests
+// pin the underlying prop contract instead: the fitted bar/spacing budget
+// must never exceed the width actually given to BarChart.
+import { createElement, useEffect, type ReactNode } from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { RawGroupedBar } from '@boardsesh/profile-stats';
+import type { ColoredBar } from '../profile-chart-colors';
+
+const FRAME_WIDTH = 320;
+
+// Minimal RN surface — mirrors you-charts-tap-tooltip.test.tsx's mock so
+// ChartFrame's width-gated render path reaches the chart under test.
+vi.mock('react-native', () => ({
+  View: ({ children, onLayout }: { children?: ReactNode; onLayout?: (event: unknown) => void }) => {
+    useEffect(() => {
+      onLayout?.({ nativeEvent: { layout: { width: FRAME_WIDTH, height: 160, x: 0, y: 0 } } });
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- fire once on mount, matching a real layout pass
+    }, []);
+    return createElement('div', null, children);
+  },
+  Pressable: ({ children }: { children?: ReactNode }) => createElement('button', { type: 'button' }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+type BarChartCall = {
+  width?: number;
+  barWidth?: number;
+  spacing?: number;
+  initialSpacing?: number;
+  stackData?: { stacks?: { value: number }[] }[];
+  data?: unknown[];
+};
+
+const barChartCalls: BarChartCall[] = [];
+
+vi.mock('react-native-gifted-charts', () => ({
+  BarChart: (props: BarChartCall) => {
+    barChartCalls.push(props);
+    return createElement('div', { 'data-testid': 'gifted-bar-chart' });
+  },
+  LineChart: () => createElement('div', { 'data-testid': 'gifted-line-chart' }),
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({
+  Icon: () => createElement('span', { 'data-testid': 'icon' }),
+}));
+vi.mock('../../ActivityIndicator', () => ({
+  ActivityIndicator: () => createElement('span', { 'data-testid': 'activity-indicator' }),
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    variant: 'material' as const,
+    colorScheme: 'light' as const,
+    systemColors: {
+      secondaryLabel: '#666666',
+      tertiaryLabel: '#999999',
+      elevatedSurface: '#ffffff',
+      separator: '#dddddd',
+      label: '#111111',
+    },
+    chartColors: {
+      secondaryLabel: '#666666',
+      tertiaryLabel: '#999999',
+      elevatedSurface: '#ffffff',
+      separator: '#dddddd',
+      label: '#111111',
+    },
+  }),
+}));
+
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 0: 0, 1: 4, 2: 8, 3: 12, 4: 16 },
+  borderRadius: { full: 999, xl: 16 },
+  opacity: { peek: 0.5 },
+  materialElevationByLevel: { level2: {} },
+}));
+
+vi.mock('../../../lib/haptics', () => ({
+  hapticSelection: vi.fn(),
+}));
+
+vi.mock('../profile-chart-colors', () => ({
+  gradeChartColor: (key: string) => `grade-${key}`,
+  layoutChartColor: (key: string) => `layout-${key}`,
+  flashRedpointColor: (key: string) => `status-${key}`,
+}));
+
+import { StackedBarChart, GroupedBarChart } from '../YouCharts';
+
+/** Total pixel span the fitted stack-bar data actually occupies. */
+function stackedContentSpan(call: BarChartCall): number {
+  const count = call.stackData?.length ?? 0;
+  const barWidth = call.barWidth ?? 0;
+  const spacing = call.spacing ?? 0;
+  const initial = call.initialSpacing ?? 0;
+  return initial * 2 + count * barWidth + Math.max(0, count - 1) * spacing;
+}
+
+describe('StackedBarChart width budget (#3778)', () => {
+  const bars: ColoredBar[] = Array.from({ length: 10 }, (_, index) => ({
+    key: `V${index}`,
+    label: `V${index}`,
+    segments: [{ key: 'kilter-1', label: 'Kilter Original', value: index + 1 }],
+  }));
+
+  it('sizes bars to fit inside the width actually given to BarChart', () => {
+    barChartCalls.length = 0;
+    render(<StackedBarChart bars={bars} colorBy="layout" />);
+
+    expect(barChartCalls).toHaveLength(1);
+    const call = barChartCalls[0]!;
+    expect(call.width).toBeGreaterThan(0);
+    // The fitted content must not exceed the canvas BarChart was told to draw
+    // into — before the #3778 fix, bars were fit to the full frame width while
+    // BarChart was given `width - 8`, so this budget was routinely blown.
+    expect(stackedContentSpan(call)).toBeLessThanOrEqual(call.width!);
+  });
+});
+
+describe('GroupedBarChart width budget (#3778)', () => {
+  const groupedBars: RawGroupedBar[] = Array.from({ length: 8 }, (_, index) => ({
+    key: `V${index}`,
+    label: `V${index}`,
+    values: [
+      { key: 'flash', label: 'Flash', value: index },
+      { key: 'redpoint', label: 'Redpoint', value: index + 1 },
+    ],
+  }));
+
+  it('sizes grouped bars to fit inside the width actually given to BarChart', () => {
+    barChartCalls.length = 0;
+    render(<GroupedBarChart bars={groupedBars} />);
+
+    expect(barChartCalls).toHaveLength(1);
+    const call = barChartCalls[0]!;
+    expect(call.width).toBeGreaterThan(0);
+    const count = call.data?.length ?? 0;
+    // Grouped data flattens two bars per grade; spacing is per-item (carried on
+    // each datum) rather than a single BarChart-level prop, so just confirm the
+    // canvas width lines up with the frame's narrowed budget instead of the
+    // pre-fix mismatched (wider) fitting budget.
+    expect(count).toBeGreaterThan(0);
+    expect(call.width).toBe(FRAME_WIDTH - 8);
+  });
+});

--- a/packages/mobile/src/components/you/__tests__/you-charts-width-budget.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/you-charts-width-budget.test.tsx
@@ -19,7 +19,7 @@
 // omits a prop is still measured at its true rendered size.
 import { createElement, useEffect, type ReactNode } from 'react';
 import { render } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { RawGroupedBar } from '@boardsesh/profile-stats';
 import type { ColoredBar } from '../profile-chart-colors';
 
@@ -115,10 +115,20 @@ vi.mock('../profile-chart-colors', () => ({
 
 import { StackedBarChart, GroupedBarChart } from '../YouCharts';
 
-// gifted-charts-core 0.1.81 defaults, applied when we omit the prop.
+// gifted-charts-core defaults, applied when we omit the prop. Transcribed from
+// `AxesAndRulesDefaults` / `BarDefaults` in dist/utils/constants.js at the
+// version pinned in bun.lock (0.1.81) — bun's isolated install puts
+// gifted-charts-core outside packages/mobile's resolution path, so they can't be
+// imported. COUPLING: bumping react-native-gifted-charts can move these, and a
+// bump that grows a default would make the charts overflow again while these
+// tests stayed green. Re-read dist/utils/constants.js on any such bump.
 const GIFTED_DEFAULT_SPACING = 20;
 const GIFTED_Y_AXIS_LABEL_WIDTH = 35;
 const GIFTED_Y_AXIS_EMPTY_LABEL_WIDTH = 10;
+
+beforeEach(() => {
+  barChartCalls.length = 0;
+});
 
 /**
  * Horizontal span BarChart actually occupies in its parent: the y-axis gutter it
@@ -162,7 +172,6 @@ describe('StackedBarChart width budget (#3778)', () => {
   }));
 
   it('keeps the whole chart — y-axis gutter included — inside the measured frame', () => {
-    barChartCalls.length = 0;
     // `showYAxisScale` is what ProgressTab passes for Activity and Grade
     // Distribution, the two charts reported in #3778. It buys a 32px y-axis
     // gutter that gifted-charts renders OUTSIDE the `width` prop, so it has to
@@ -177,7 +186,6 @@ describe('StackedBarChart width budget (#3778)', () => {
   });
 
   it('sizes bars to fit inside the width actually given to BarChart', () => {
-    barChartCalls.length = 0;
     render(<StackedBarChart bars={bars} colorBy="layout" showYAxisScale />);
 
     const call = barChartCalls[0]!;
@@ -187,7 +195,6 @@ describe('StackedBarChart width budget (#3778)', () => {
   });
 
   it('stays inside the frame without the y-axis scale too', () => {
-    barChartCalls.length = 0;
     render(<StackedBarChart bars={bars} colorBy="layout" />);
 
     const call = barChartCalls[0]!;
@@ -208,7 +215,6 @@ describe('GroupedBarChart width budget (#3778)', () => {
   }));
 
   it('keeps the whole chart — y-axis gutter included — inside the measured frame', () => {
-    barChartCalls.length = 0;
     render(<GroupedBarChart bars={groupedBars} />);
 
     expect(barChartCalls).toHaveLength(1);
@@ -223,7 +229,6 @@ describe('GroupedBarChart width budget (#3778)', () => {
   });
 
   it('pins the y-axis gutter so the library default cannot creep back', () => {
-    barChartCalls.length = 0;
     render(<GroupedBarChart bars={groupedBars} />);
 
     const call = barChartCalls[0]!;
@@ -232,7 +237,6 @@ describe('GroupedBarChart width budget (#3778)', () => {
   });
 
   it('sizes grouped bars to fit inside the width actually given to BarChart', () => {
-    barChartCalls.length = 0;
     render(<GroupedBarChart bars={groupedBars} />);
 
     const call = barChartCalls[0]!;

--- a/packages/mobile/src/components/you/__tests__/you-charts-width-budget.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/you-charts-width-budget.test.tsx
@@ -1,13 +1,22 @@
 // @vitest-environment jsdom
 //
-// Regression coverage for #3778: You-page Activity/Grade Distribution bar
-// charts could overflow their card width. StackedBarChart and GroupedBarChart
-// fit bar/spacing sizes off the measured frame width, then handed
-// gifted-charts' BarChart a narrower `width` prop (room for its own
-// right-edge padding) — so the fitted content ran wider than the canvas it
-// was drawn into. This repo has no visual regression harness, so these tests
-// pin the underlying prop contract instead: the fitted bar/spacing budget
-// must never exceed the width actually given to BarChart.
+// Regression coverage for #3778: the You-page Activity and Grade Distribution
+// bar charts bled past the rounded card edge.
+//
+// gifted-charts does not draw inside the `width` prop it is given. It offsets
+// the plot area by `yAxisLabelWidth` to the LEFT of that width and extends the
+// rules/x-axis row by `endSpacing` to the RIGHT of it, so the span it really
+// occupies is `yAxisLabelWidth + width + endSpacing`. Both You-page charts
+// handed it the full measured frame width (minus a token 8px) while also asking
+// for a y-axis gutter, so the chart occupied ~26-32px more than the card had.
+//
+// This repo has no visual regression harness for RN charts, so these tests pin
+// the prop contract instead: the FULL occupied span must fit inside the
+// measured frame, and the fitted bar/spacing content must fit inside the width
+// prop. The library-default fallbacks below mirror gifted-charts-core 0.1.81
+// (`AxesAndRulesDefaults.yAxisEmptyLabelWidth = 10`, `yAxisLabelWidth = 35`,
+// `endSpacing = spacing`, `BarDefaults.spacing = 20`) so a chart that simply
+// omits a prop is still measured at its true rendered size.
 import { createElement, useEffect, type ReactNode } from 'react';
 import { render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
@@ -39,8 +48,11 @@ type BarChartCall = {
   barWidth?: number;
   spacing?: number;
   initialSpacing?: number;
+  endSpacing?: number;
+  yAxisLabelWidth?: number;
+  hideYAxisText?: boolean;
   stackData?: { stacks?: { value: number }[] }[];
-  data?: unknown[];
+  data?: { spacing?: number }[];
 };
 
 const barChartCalls: BarChartCall[] = [];
@@ -103,6 +115,24 @@ vi.mock('../profile-chart-colors', () => ({
 
 import { StackedBarChart, GroupedBarChart } from '../YouCharts';
 
+// gifted-charts-core 0.1.81 defaults, applied when we omit the prop.
+const GIFTED_DEFAULT_SPACING = 20;
+const GIFTED_Y_AXIS_LABEL_WIDTH = 35;
+const GIFTED_Y_AXIS_EMPTY_LABEL_WIDTH = 10;
+
+/**
+ * Horizontal span BarChart actually occupies in its parent: the y-axis gutter it
+ * offsets the plot by, plus the `width` it draws into, plus the `endSpacing`
+ * the rules/x-axis row extends by. This is the number that must fit the card.
+ */
+function occupiedSpan(call: BarChartCall): number {
+  const barLevelSpacing = call.spacing ?? GIFTED_DEFAULT_SPACING;
+  const endSpacing = call.endSpacing ?? barLevelSpacing;
+  const yAxisGutter =
+    call.yAxisLabelWidth ?? (call.hideYAxisText ? GIFTED_Y_AXIS_EMPTY_LABEL_WIDTH : GIFTED_Y_AXIS_LABEL_WIDTH);
+  return yAxisGutter + (call.width ?? 0) + endSpacing;
+}
+
 /** Total pixel span the fitted stack-bar data actually occupies. */
 function stackedContentSpan(call: BarChartCall): number {
   const count = call.stackData?.length ?? 0;
@@ -112,6 +142,18 @@ function stackedContentSpan(call: BarChartCall): number {
   return initial * 2 + count * barWidth + Math.max(0, count - 1) * spacing;
 }
 
+/**
+ * Same, for the flattened grouped data: `spacing` is carried per-datum there
+ * rather than as a single BarChart-level prop.
+ */
+function groupedContentSpan(call: BarChartCall): number {
+  const data = call.data ?? [];
+  const barWidth = call.barWidth ?? 0;
+  const initial = call.initialSpacing ?? 0;
+  const gaps = data.reduce((total, datum) => total + (datum.spacing ?? 0), 0);
+  return initial + data.length * barWidth + gaps;
+}
+
 describe('StackedBarChart width budget (#3778)', () => {
   const bars: ColoredBar[] = Array.from({ length: 10 }, (_, index) => ({
     key: `V${index}`,
@@ -119,16 +161,38 @@ describe('StackedBarChart width budget (#3778)', () => {
     segments: [{ key: 'kilter-1', label: 'Kilter Original', value: index + 1 }],
   }));
 
-  it('sizes bars to fit inside the width actually given to BarChart', () => {
+  it('keeps the whole chart — y-axis gutter included — inside the measured frame', () => {
     barChartCalls.length = 0;
-    render(<StackedBarChart bars={bars} colorBy="layout" />);
+    // `showYAxisScale` is what ProgressTab passes for Activity and Grade
+    // Distribution, the two charts reported in #3778. It buys a 32px y-axis
+    // gutter that gifted-charts renders OUTSIDE the `width` prop, so it has to
+    // be budgeted out of the frame. Pre-fix this was 32 + 312 + 8 = 352 against
+    // a 320px frame.
+    render(<StackedBarChart bars={bars} colorBy="layout" showYAxisScale />);
 
     expect(barChartCalls).toHaveLength(1);
     const call = barChartCalls[0]!;
     expect(call.width).toBeGreaterThan(0);
-    // The fitted content must not exceed the canvas BarChart was told to draw
-    // into — before the #3778 fix, bars were fit to the full frame width while
-    // BarChart was given `width - 8`, so this budget was routinely blown.
+    expect(occupiedSpan(call)).toBeLessThanOrEqual(FRAME_WIDTH);
+  });
+
+  it('sizes bars to fit inside the width actually given to BarChart', () => {
+    barChartCalls.length = 0;
+    render(<StackedBarChart bars={bars} colorBy="layout" showYAxisScale />);
+
+    const call = barChartCalls[0]!;
+    // The fitted content must also not exceed the canvas BarChart was told to
+    // draw into, or the last bar is clipped by the plot ScrollView at zoom 1.
+    expect(stackedContentSpan(call)).toBeLessThanOrEqual(call.width!);
+  });
+
+  it('stays inside the frame without the y-axis scale too', () => {
+    barChartCalls.length = 0;
+    render(<StackedBarChart bars={bars} colorBy="layout" />);
+
+    const call = barChartCalls[0]!;
+    expect(call.yAxisLabelWidth).toBe(0);
+    expect(occupiedSpan(call)).toBeLessThanOrEqual(FRAME_WIDTH);
     expect(stackedContentSpan(call)).toBeLessThanOrEqual(call.width!);
   });
 });
@@ -143,19 +207,36 @@ describe('GroupedBarChart width budget (#3778)', () => {
     ],
   }));
 
-  it('sizes grouped bars to fit inside the width actually given to BarChart', () => {
+  it('keeps the whole chart — y-axis gutter included — inside the measured frame', () => {
     barChartCalls.length = 0;
     render(<GroupedBarChart bars={groupedBars} />);
 
     expect(barChartCalls).toHaveLength(1);
     const call = barChartCalls[0]!;
     expect(call.width).toBeGreaterThan(0);
-    const count = call.data?.length ?? 0;
-    // Grouped data flattens two bars per grade; spacing is per-item (carried on
-    // each datum) rather than a single BarChart-level prop, so just confirm the
-    // canvas width lines up with the frame's narrowed budget instead of the
-    // pre-fix mismatched (wider) fitting budget.
-    expect(count).toBeGreaterThan(0);
-    expect(call.width).toBe(FRAME_WIDTH - 8);
+    // `hideYAxisText` on its own still reserves gifted-charts'
+    // `yAxisEmptyLabelWidth` (10px) outside `width`, and an unset `endSpacing`
+    // falls back to the 20px default `spacing` because this chart carries
+    // spacing per-datum. Pre-fix that was 10 + 312 + 20 = 342 against a 320px
+    // frame.
+    expect(occupiedSpan(call)).toBeLessThanOrEqual(FRAME_WIDTH);
+  });
+
+  it('pins the y-axis gutter so the library default cannot creep back', () => {
+    barChartCalls.length = 0;
+    render(<GroupedBarChart bars={groupedBars} />);
+
+    const call = barChartCalls[0]!;
+    expect(call.yAxisLabelWidth).toBe(0);
+    expect(call.endSpacing).toBe(0);
+  });
+
+  it('sizes grouped bars to fit inside the width actually given to BarChart', () => {
+    barChartCalls.length = 0;
+    render(<GroupedBarChart bars={groupedBars} />);
+
+    const call = barChartCalls[0]!;
+    expect(call.data?.length).toBe(groupedBars.length * 2);
+    expect(groupedContentSpan(call)).toBeLessThanOrEqual(call.width!);
   });
 });


### PR DESCRIPTION
## What & why

Two separate You-page chart bugs, both in `packages/mobile/src/components/you/YouCharts.tsx`.

**#3778 — Activity and Grade Distribution bars bleed past the card edge.**
`react-native-gifted-charts` does not lay its chart out inside the `width` prop it
is handed. `BarAndLineChartsWrapper` positions the plot `ScrollView` absolutely at
`marginLeft: yAxisLabelWidth + yAxisThickness` with `width: props.width`, and
`renderHorizSections` draws the rules/x-axis row as a `yAxisLabelWidth` spacer
followed by a `props.width + endSpacing` band. The span the chart really occupies
is `yAxisLabelWidth + width + endSpacing`.

Both You-page bar charts gave BarChart the measured frame width minus a token 8px
*and* asked for a y-axis gutter, so they occupied more than the card had:

| Chart | y-axis gutter | width | endSpacing | occupied |
| --- | --- | --- | --- | --- |
| `StackedBarChart` with `showYAxisScale` (ProgressTab Activity + Grade Distribution) | 32 | frame − 8 | 8 (defaults to `spacing`) | **frame + 32** |
| `GroupedBarChart` | 10 (`hideYAxisText` still reserves `yAxisEmptyLabelWidth`) | frame − 8 | 20 (defaults to `spacing`, unset here because spacing is per-datum) | **frame + 22** |

Nothing clipped it — neither `styles.frame` nor the `Card` set `overflow`, so the
overflow landed outside the rounded card exactly as screenshotted in the issue.

The four other `StackedBarChart` consumers (`SessionGradeChart`,
`SessionAnalyticsSection`, `record/summary.tsx`, `WorkoutTypeShelf`) don't pass
`showYAxisScale`, so their gutter was already 0 — which matches the issue naming
only Activity and Grade Distribution. `TotalAreaChart` already budgets correctly
(`width - 48` against a 35px default gutter), the internal proof that the gutter
is additive.

**#3780 — the V-Points line overshoots the data.** `TotalAreaChart` drew the
cumulative line with gifted-charts' `curved` / `curvature={0.2}` interpolation.
`gifted-charts-core`'s `bezierCommand`/`controlPoint` is an unclamped
Catmull-Rom spline, so it swings past a point's y-value between two neighbours —
a flat or dipping week reads as a rise. Weeks are evenly spaced already.

## Verified root cause

Read directly against the installed libraries (`react-native-gifted-charts`
1.4.77 / `gifted-charts-core` 0.1.81), not inferred:

- `react-native-gifted-charts/dist/Components/BarAndLineChartsWrapper/index.js` — plot ScrollView `position: 'absolute'`, `marginLeft: yAxisLabelWidth + yAxisThickness`, `width: props.width`.
- `.../renderHorizSections.js` — a `width: yAxisLabelWidth` spacer followed by a `width: (props.width ?? totalWidth) + endSpacing` rules/x-axis row.
- `gifted-charts-core/dist/BarChart/index.js:100` + `dist/utils/constants.js:86` — `hideYAxisText` falls back to `yAxisEmptyLabelWidth = 10`; `endSpacing` falls back to `spacing` (default 20).
- `gifted-charts-core/dist/utils/index.js:131-153` — `bezierCommand`/`controlPoint`, unclamped Catmull-Rom.

## Fix

- Subtract the y-axis gutter from the width budget *before* it reaches either `fitBars` or the `width` prop, so the fitting math and the canvas agree and the whole thing fits the frame.
- Pin `endSpacing={0}` on both charts.
- Pin `yAxisLabelWidth` explicitly on both (`axisGutter` on stacked, `0` on grouped) so the library defaults can't creep back in a version bump.
- `overflow: 'hidden'` on `styles.frame` as a second layer. The reset-zoom button lives inside the frame (`top: 8`/`right: 8`) and the tooltip overlay is a sibling on `chartShell`, so neither is affected.
- `curved={false}` on `TotalAreaChart`, with `curvature` dropped.

## Tests & fail-on-revert

There's no visual-diff harness for these RN charts, so both tests pin the prop
contract, mocking `react-native-gifted-charts` and asserting on the props BarChart
is actually handed.

`you-charts-width-budget.test.tsx` (6 assertions) measures the **full occupied
span** — `yAxisLabelWidth + width + endSpacing`, with gifted-charts-core 0.1.81
defaults filled in for omitted props — against the measured frame, plus the
internal bar/spacing span against the `width` prop.

`you-charts-line-interpolation.test.tsx` asserts `curved={false}` with no leftover
`curvature`.

Fail-on-revert, verified by restoring `YouCharts.tsx` to `origin/main` and
re-running: **6 of 7 tests go red**, including both headline occupied-span
assertions — `expected 352 to be less than or equal to 320` (stacked, 32 + 312 + 8)
and `expected 342 to be less than or equal to 320` (grouped, 10 + 312 + 20) — and
`expected true to be false` for `curved`. The file was then restored and confirmed
byte-identical.

The first pass at #3778 shipped a test whose grouped assertion (`width === frame - 8`)
was a tautology: it passed identically before and after the change. That's been
replaced with the occupied-span assertions above.

## QA Notes

Scoped validation, all from the worktree:

- `vp test run --reporter=agent --project mobile packages/mobile/src/components/you/__tests__/` — 27 files / 200 tests green.
- Adjacent `StackedBarChart`/`GroupedBarChart` consumers (`SessionAnalyticsSection`, `record/summary-error-state`, `workout-type-shelf`) — 3 files / 11 tests green.
- `vp run typecheck:mobile` — clean.
- `vp check packages/mobile/src/components/you/` — 0 errors (1 pre-existing warning in an untouched file, `logbook-tab-grouped.test.tsx:207`).

To exercise by hand: **You → Progress tab**.

- Activity and Grade Distribution charts: bars and the last x-axis label must sit inside the rounded card, with the y-axis scale still legible on the left. Check light and dark, and a narrow device (iPhone SE) where the budget is tightest.
- Pinch-zoom the same charts to ~2.75x and back. Bars should still be clipped by the plot ScrollView, never drawn over the card edge, and the reset-zoom button must remain visible and tappable in the frame's top-right (it sits inside the new `overflow: 'hidden'`).
- Flash vs Redpoint (grouped) chart: same edge check, plus the per-bar top value labels must not be clipped at the top of the frame.
- V-Points chart: on a week where the cumulative total is flat, the line must be flat between the two points rather than bulging above them.
- Sanity-check the unaffected charts still render normally: in-session grade chart, session analytics, record summary, pre-session workout-type shelf.

Not visually verified on a device or emulator in this pass — the change is
geometry-only and pinned by prop assertions, but a before/after capture of the
Progress tab is worth attaching before this leaves draft.

## Release Notes

The Activity and Grade Distribution charts on your You page no longer spill past
the edge of their card, so the last week or grade is readable again. The V-Points
line now tracks your actual weekly totals instead of curving above them and making
a flat week look like a jump.

Fixes #3778
Fixes #3780
