### PR TITLE
fix(sync): stop downscaling pushed Kilter tick quality to the Aurora 1-3 scale

### DIFF
--- a/packages/kilter-sync/src/api/kilter-rest.ts
+++ b/packages/kilter-sync/src/api/kilter-rest.ts
@@ -32,7 +32,11 @@ export type LogPushItem = {
    */
   topped: boolean;
   attemptCount: number;
-  /** Aurora scale (1-3), NOT the Boardsesh 1-5 scale — see convertQualityToAurora. */
+  /**
+   * Raw Boardsesh/Kilter Grips scale (1-5). Grips is natively 1-5
+   * (catalog-sync.ts, user-sync.ts), not Aurora 1-3. Confirm the scale
+   * against captured /api/logs traffic when wiring up the POST.
+   */
   quality?: number;
   difficulty?: number;
   isMirror: boolean;

--- a/packages/kilter-sync/src/sync/push-back.test.ts
+++ b/packages/kilter-sync/src/sync/push-back.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import type { boardseshTicks } from '@boardsesh/db/schema';
+
+import { buildLogPushItem } from './push-back';
+
+/**
+ * pushPendingTicks (push-back.ts) builds a LogPushItem per pending tick
+ * before handing off to Kilter's /api/logs/bulk. Kilter Grips ticks are
+ * natively on a 1-5 quality scale (see catalog-sync.ts, quality-scale.ts,
+ * user-sync.ts) — NOT Aurora's 1-3 scale. This guards against
+ * convertQualityToAurora (an Aurora-scale-only helper) being reapplied
+ * here, which would silently downscale every pushed tick's quality.
+ *
+ * The full push-back flow is gated behind KILTER_SYNC_PUSH_ENABLED and
+ * bails via pushNotWired() before any HTTP call today, so this exercises
+ * the item-construction logic directly rather than end-to-end.
+ */
+describe('buildLogPushItem', () => {
+  function makeTick(overrides: Partial<typeof boardseshTicks.$inferSelect> = {}): typeof boardseshTicks.$inferSelect {
+    return {
+      id: BigInt(1),
+      uuid: 'tick-uuid-1',
+      userId: 'user-1',
+      boardType: 'kilter',
+      climbUuid: 'climb-uuid-1',
+      angle: 40,
+      isMirror: false,
+      origin: 'native',
+      status: 'send',
+      attemptCount: 2,
+      quality: 4,
+      difficulty: null,
+      isBenchmark: false,
+      comment: '',
+      climbedAt: '2026-07-01T00:00:00.000Z',
+      createdAt: '2026-07-01T00:00:00.000Z',
+      updatedAt: '2026-07-01T00:00:00.000Z',
+      sessionId: null,
+      boardId: null,
+      auroraType: null,
+      auroraId: null,
+      auroraSyncedAt: null,
+      auroraSyncError: null,
+      kilterType: null,
+      kilterId: null,
+      kilterSyncedAt: null,
+      kilterSyncError: null,
+      kilterDetachedAt: null,
+      ...overrides,
+    };
+  }
+
+  it('passes tick.quality through unconverted (raw 1-5 Grips scale)', () => {
+    const tick = makeTick({ quality: 5 });
+    const item = buildLogPushItem(tick, new Map());
+    expect(item.quality).toBe(5);
+  });
+
+  it.each([1, 2, 3, 4, 5])('does not rescale quality=%d toward Aurora 1-3', (quality) => {
+    const tick = makeTick({ quality });
+    const item = buildLogPushItem(tick, new Map());
+    expect(item.quality).toBe(quality);
+  });
+
+  it('maps a null quality (attempts) to undefined, not 0', () => {
+    const tick = makeTick({ quality: null, status: 'attempt' });
+    const item = buildLogPushItem(tick, new Map());
+    expect(item.quality).toBeUndefined();
+  });
+
+  it('resolves climbUuid through the Kilter push-uuid alias map', () => {
+    const tick = makeTick({ climbUuid: 'canonical-uuid' });
+    const item = buildLogPushItem(tick, new Map([['canonical-uuid', 'kilter-alias-uuid']]));
+    expect(item.climbUuid).toBe('kilter-alias-uuid');
+  });
+});

--- a/packages/kilter-sync/src/sync/push-back.ts
+++ b/packages/kilter-sync/src/sync/push-back.ts
@@ -10,8 +10,6 @@ import {
   boardClimbAliases,
 } from '@boardsesh/db/schema';
 
-import { convertQualityToAurora } from '@boardsesh/shared-schema';
-
 import { KILTER_BOARD_TYPE } from '../api/types';
 import type {
   LogPushItem,
@@ -110,6 +108,33 @@ function resolveKilterPushUuid(map: Map<string, string>, canonicalUuid: string):
 }
 
 /**
+ * Builds the outgoing LogPushItem for a single pending tick. Exported (in
+ * addition to being used inline by pushPendingTicks) so tests can exercise
+ * the field mapping — most notably that `quality` passes through raw,
+ * unconverted — without standing up the full DB-backed pushPendingTicks
+ * flow, which bails out via pushNotWired() before any HTTP call today.
+ */
+export function buildLogPushItem(
+  tick: typeof boardseshTicks.$inferSelect,
+  pushUuidMap: Map<string, string>,
+): LogPushItem {
+  return {
+    clientReference: tick.uuid,
+    climbUuid: resolveKilterPushUuid(pushUuidMap, tick.climbUuid),
+    angle: tick.angle,
+    topped: tick.status === 'flash' || tick.status === 'send',
+    attemptCount: tick.attemptCount,
+    // Kilter Grips ticks are natively 1-5 (matching catalog-sync.ts/user-sync.ts),
+    // not Aurora's 1-3 — send tick.quality through unconverted.
+    quality: tick.quality ?? undefined,
+    difficulty: tick.difficulty ?? undefined,
+    isMirror: tick.isMirror ?? false,
+    comment: tick.comment ?? undefined,
+    climbedAt: tick.climbedAt,
+  };
+}
+
+/**
  * Placeholder thrown if the env gate is flipped on without a real REST
  * implementation behind these calls. The gate in pushKilterUserData
  * prevents these from running in normal operation; this exists so a
@@ -153,19 +178,7 @@ async function pushPendingTicks(db: DrizzleDb, userId: string, _accessToken: str
   // result (logs vs attempts) in JS — no need to recompute the CASE in SQL.
   const ticksByUuid = new Map(pending.map((tick) => [tick.uuid, tick]));
 
-  const items: LogPushItem[] = pending.map((tick) => ({
-    clientReference: tick.uuid,
-    climbUuid: resolveKilterPushUuid(pushUuidMap, tick.climbUuid),
-    angle: tick.angle,
-    topped: tick.status === 'flash' || tick.status === 'send',
-    attemptCount: tick.attemptCount,
-    // boardsesh_ticks.quality is 1-5; Kilter expects Aurora's 1-3.
-    quality: convertQualityToAurora(tick.quality) ?? undefined,
-    difficulty: tick.difficulty ?? undefined,
-    isMirror: tick.isMirror ?? false,
-    comment: tick.comment ?? undefined,
-    climbedAt: tick.climbedAt,
-  }));
+  const items: LogPushItem[] = pending.map((tick) => buildLogPushItem(tick, pushUuidMap));
 
   // Reaching here means the env gate is on but the wire implementation
   // hasn't been added yet — bail loudly so the daemon error log points

--- a/packages/shared-schema/src/utils.ts
+++ b/packages/shared-schema/src/utils.ts
@@ -82,6 +82,10 @@ export function normalizeQualityTo5(quality: number | null | undefined): number 
  * middle interpolates linearly (2->2, 3->2, 4->3), so convertQuality
  * round-trips (1->1->1, 2->3->2, 3->5->3). 0/null ("unrated") stays null;
  * out-of-range input is clamped to 1-5 defensively.
+ *
+ * Has no production callers today; kept for the Aurora/Tension push path.
+ * Do NOT use it for the Kilter Grips push (`packages/kilter-sync`) — Grips
+ * ticks are natively 1-5, so converting there silently downscales them.
  */
 export function convertQualityToAurora(quality: number | null | undefined): number | null {
   if (quality == null) return null;


### PR DESCRIPTION
## What & why

The Kilter Grips push-back path was downscaling every tick's quality rating on its way out. A 5-star tick left Boardsesh as a 3, a 4-star as a 3, a 3-star as a 2.

## Verified root cause

`pushPendingTicks` in `packages/kilter-sync/src/sync/push-back.ts` ran `convertQualityToAurora(tick.quality)` before putting the rating in the `/api/logs/bulk` payload. That helper is an Aurora-scale converter (1-5 -> 1-3) and Kilter Grips is not on the Aurora scale:

- `catalog-sync.ts` stores Grips `qualityAverage` verbatim (no conversion).
- `user-sync.ts` sanitizes incoming per-user Grips ratings against a raw 1-5 range, and the column carries a `1..5` DB CHECK (migration 0153, `boardsesh_ticks_quality_range`).

So the inbound Grips path treats the scale as 1-5 while the outbound path converted it to 1-3. The conversion was the bug.

Live impact today is zero: the push path is gated behind `KILTER_SYNC_PUSH_ENABLED` and bails through `pushNotWired()` before any HTTP call. This fixes it before the wire-up lands, when it would have started silently rewriting real ratings.

## Fix

- Send `tick.quality` through unconverted (`tick.quality ?? undefined`). No clamping is lost — the 0153 CHECK already constrains the column to NULL or 1..5, so 0 / out-of-range can't reach here.
- Extract the per-tick mapping into an exported `buildLogPushItem` so the field mapping is testable without standing up the DB-backed flow. Every other field is byte-identical to the previous inline `items.map(...)`.
- Correct the `LogPushItem.quality` doc comment (it claimed Aurora 1-3), keeping the file's existing "confirm against captured traffic when wiring the POST" caveat.
- Note on `convertQualityToAurora` that it now has no production callers and must not be used for the Grips push.

## Tests + fail-on-revert

New `packages/kilter-sync/src/sync/push-back.test.ts` (8 tests): raw pass-through for quality 1-5, null quality -> `undefined` (not 0), and climbUuid resolution through the Kilter push-uuid alias map.

Revert check: restoring the `convertQualityToAurora` call turns the suite red — 4 failed / 4 passed, headline `expected 3 to be 5`. Quality 3, 4 and 5 all fail; 1 and 2 are fixpoints of the conversion, so they stay green, which is the expected shape.

## QA Notes

No user-facing behaviour to exercise — the push path is unreachable in production (env gate + `pushNotWired()` throw). Validation is code-level:

- `vp test run --project kilter-sync --reporter=agent` — 16 files / 215 tests pass.
- `vp run typecheck:shared` and `tsc --noEmit` in `packages/kilter-sync` — clean.
- `vp lint` / `vp fmt --check` on the changed files — clean.

Reviewer check: confirm that outbound Grips quality should be raw 1-5, not Aurora 1-3. The in-repo evidence for that is the inbound Grips sync (`catalog-sync.ts`, `user-sync.ts`) plus the 1..5 DB CHECK; the definitive confirmation is captured `/api/logs` traffic, which the doc comment now asks the future wire-up author to check.

## Release Notes

none

Fixes #3527
