### PR TITLE
fix(mobile): stop clipping the counts above Flash vs Redpoint bars

### DIFF
--- a/packages/mobile/src/components/you/YouCharts.tsx
+++ b/packages/mobile/src/components/you/YouCharts.tsx
@@ -1,5 +1,12 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import { Pressable, View, StyleSheet, type GestureResponderEvent, type LayoutChangeEvent } from 'react-native';
+import {
+  PixelRatio,
+  Pressable,
+  View,
+  StyleSheet,
+  type GestureResponderEvent,
+  type LayoutChangeEvent,
+} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { BarChart, LineChart } from 'react-native-gifted-charts';
 import type { RawGroupedBar, RawVPointsTimeline } from '@boardsesh/profile-stats';
@@ -18,6 +25,7 @@ import {
   getStackedBarsMaxValue,
   type ChartTooltipModel,
 } from './chart-model';
+import { computeBarTopLabelLayout, longestBarValue } from './bar-top-label';
 
 const MAX_X_LABELS = 12;
 const AXIS_LABEL_SIZE = 11;
@@ -31,6 +39,9 @@ const MIN_GROUPED_BAR = 6;
 // already carry their own 0.85 alpha, so a deeper dim keeps unselected pairs
 // readable on the dark violet card while the focused pair still pops.
 const CHART_LOWLIGHT_OPACITY = 0.5;
+// Mirrors `Text`'s maxFontSizeMultiplier: the count can grow by half again
+// under accessibility text sizes, and its box has to grow with it.
+const MAX_LABEL_FONT_SCALE = 1.5;
 
 export type ChartLegendItem = { color: string; label: string };
 
@@ -466,6 +477,12 @@ export const GroupedBarChart = memo(function GroupedBarChart({
     [bars, colorScheme],
   );
   const yAxisMaxValue = fitYAxisToData ? getGroupedBarsMaxValue(bars) : undefined;
+  // Size every count off the widest one so the whole row reads the same way.
+  const longestCount = useMemo(
+    () => longestBarValue((bars ?? []).flatMap((bar) => bar.values.map((value) => value.value))),
+    [bars],
+  );
+  const labelFontScale = Math.min(PixelRatio.getFontScale(), MAX_LABEL_FONT_SCALE);
   const handlePress = useCallback(
     (index: number) => {
       if (!interactive) return;
@@ -496,6 +513,14 @@ export const GroupedBarChart = memo(function GroupedBarChart({
             const barWidth = Math.max(MIN_GROUPED_BAR, Math.round(baseBarWidth * zoomScale));
             const zoomedGroupGap = Math.max(groupGap, Math.round(groupGap * zoomScale));
             const zoomedInnerGap = Math.max(innerGap, Math.round(innerGap * zoomScale));
+            // A count may spill into the gap beside its bar; past that it turns
+            // vertical rather than getting clipped (#3779).
+            const labelLayout = computeBarTopLabelLayout(
+              longestCount,
+              barWidth,
+              barWidth + zoomedInnerGap,
+              labelFontScale,
+            );
             const data = list.flatMap((bar, barIndex) =>
               bar.values.map((value, valueIndex) => ({
                 value: value.value,
@@ -507,7 +532,17 @@ export const GroupedBarChart = memo(function GroupedBarChart({
                 topLabelComponent:
                   value.value > 0
                     ? () => (
-                        <Text variant="caption2" color={chartColors.secondaryLabel} style={styles.barTopLabel}>
+                        <Text
+                          variant="caption2"
+                          color={chartColors.secondaryLabel}
+                          numberOfLines={1}
+                          style={[
+                            styles.barTopLabel,
+                            labelLayout.rotated
+                              ? { transform: [{ rotate: '-90deg' }], marginBottom: labelLayout.marginBottom }
+                              : null,
+                          ]}
+                        >
                           {value.value}
                         </Text>
                       )
@@ -518,11 +553,11 @@ export const GroupedBarChart = memo(function GroupedBarChart({
               <BarChart
                 data={data}
                 width={width - 8}
-                height={height - 28}
+                height={height - 28 - labelLayout.headroom}
                 barWidth={barWidth}
                 initialSpacing={initial}
                 barBorderRadius={STACK_BAR_RADIUS}
-                topLabelContainerStyle={{ width: barWidth }}
+                topLabelContainerStyle={{ width: labelLayout.width, left: labelLayout.left }}
                 hideRules
                 hideYAxisText
                 maxValue={yAxisMaxValue}

--- a/packages/mobile/src/components/you/__tests__/bar-top-label.test.ts
+++ b/packages/mobile/src/components/you/__tests__/bar-top-label.test.ts
@@ -1,0 +1,64 @@
+// Issue #3779: the counts above the You -> Progress "Flash vs Redpoint" bars
+// were clipped on a phone. Seven grade pairs across a 320pt card leave each bar
+// about 13px wide, and gifted-charts boxes the top label to exactly one bar
+// width, so "128" lost its digits. These pin the sizing decisions.
+import { describe, expect, it } from 'vitest';
+import { computeBarTopLabelLayout, estimateBarTopLabelWidth, longestBarValue } from '../bar-top-label';
+
+describe('longestBarValue', () => {
+  it('picks the value with the most digits, not the largest', () => {
+    expect(longestBarValue([9, 128, 82])).toBe(128);
+    expect(longestBarValue([])).toBe(0);
+  });
+});
+
+describe('estimateBarTopLabelWidth', () => {
+  it('grows with digit count and with the accessibility font scale', () => {
+    expect(estimateBarTopLabelWidth(7)).toBeLessThan(estimateBarTopLabelWidth(82));
+    expect(estimateBarTopLabelWidth(82)).toBeLessThan(estimateBarTopLabelWidth(128));
+    expect(estimateBarTopLabelWidth(128, 1.5)).toBeGreaterThan(estimateBarTopLabelWidth(128));
+  });
+});
+
+describe('computeBarTopLabelLayout', () => {
+  it('leaves a single digit alone: no wider box, no rotation', () => {
+    const layout = computeBarTopLabelLayout(7, 13, 16);
+    expect(layout.rotated).toBe(false);
+    expect(layout.width).toBe(13);
+    expect(layout.left).toBe(0);
+    expect(layout.headroom).toBe(0);
+  });
+
+  it('borrows the gap beside the bar when that is enough room', () => {
+    // "82" needs ~18px: more than a 16px bar, but the 22px column has it.
+    const layout = computeBarTopLabelLayout(82, 16, 22);
+    expect(layout.rotated).toBe(false);
+    expect(layout.width).toBeGreaterThan(16);
+    expect(layout.width).toBeLessThanOrEqual(22);
+    // Re-centred over its own bar, so the box overhangs both sides evenly.
+    expect(layout.left).toBe(Math.round((16 - layout.width) / 2));
+  });
+
+  it('stands a three-digit count vertical when the column is a phone-width 13px', () => {
+    const layout = computeBarTopLabelLayout(128, 13, 16);
+    expect(layout.rotated).toBe(true);
+    // The box has to be at least as wide as the text or the glyphs clip before
+    // the rotation ever happens.
+    expect(layout.width).toBeGreaterThanOrEqual(estimateBarTopLabelWidth(128));
+    expect(layout.left).toBeLessThan(0);
+    // Rotation pivots on the centre, so the label is lifted clear of the bar.
+    expect(layout.marginBottom).toBeGreaterThan(2);
+    expect(layout.headroom).toBeGreaterThan(0);
+  });
+
+  it('does not rotate the same count once the chart is zoomed and bars are wide', () => {
+    const layout = computeBarTopLabelLayout(128, 40, 46);
+    expect(layout.rotated).toBe(false);
+    expect(layout.headroom).toBe(0);
+  });
+
+  it('rotates at a bar width that was fine, once accessibility text scales up', () => {
+    expect(computeBarTopLabelLayout(128, 24, 30, 1).rotated).toBe(false);
+    expect(computeBarTopLabelLayout(128, 24, 30, 1.5).rotated).toBe(true);
+  });
+});

--- a/packages/mobile/src/components/you/__tests__/you-charts-bar-top-label.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/you-charts-bar-top-label.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+//
+// Issue #3779: on the You -> Progress "Flash vs Redpoint" card the count drawn
+// above each bar was clipped — the reporter's screenshot shows seven grade
+// pairs on a phone, where each bar lands around 13px wide, and gifted-charts
+// boxes a top label to exactly one bar width. These tests hold the wiring
+// between GroupedBarChart and computeBarTopLabelLayout: the label box has to
+// outgrow the bar, re-centre itself, and turn vertical when even the gap beside
+// the bar isn't enough.
+import { createElement, useEffect, type ReactElement, type ReactNode } from 'react';
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RawGroupedBar } from '@boardsesh/profile-stats';
+
+const CARD_WIDTH = 320;
+
+vi.mock('react-native', () => ({
+  View: ({ children, onLayout }: { children?: ReactNode; onLayout?: (event: unknown) => void }) => {
+    useEffect(() => {
+      onLayout?.({ nativeEvent: { layout: { width: CARD_WIDTH, height: 160, x: 0, y: 0 } } });
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- fire once on mount, matching a real layout pass
+    }, []);
+    return createElement('div', null, children);
+  },
+  Pressable: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
+    createElement('button', { type: 'button', onClick: onPress }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+  PixelRatio: { getFontScale: () => 1 },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+type BarItem = {
+  value: number;
+  topLabelComponent?: () => ReactElement;
+};
+type CapturedChartProps = {
+  data?: BarItem[];
+  barWidth?: number;
+  height?: number;
+  topLabelContainerStyle?: { width?: number; left?: number };
+};
+
+// The label box is a prop, not rendered output, so capture props rather than
+// JSON-serialising them (JSON silently drops the component callbacks).
+let chartProps: CapturedChartProps | null = null;
+
+vi.mock('react-native-gifted-charts', () => ({
+  BarChart: (props: CapturedChartProps) => {
+    chartProps = props;
+    return createElement('div', { 'data-testid': 'gifted-bar-chart' });
+  },
+  LineChart: () => createElement('div', { 'data-testid': 'gifted-line-chart' }),
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({
+  Icon: () => createElement('span', { 'data-testid': 'icon' }),
+}));
+vi.mock('../../ActivityIndicator', () => ({
+  ActivityIndicator: () => createElement('span', { 'data-testid': 'activity-indicator' }),
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    variant: 'material' as const,
+    colorScheme: 'light' as const,
+    systemColors: {
+      secondaryLabel: '#666666',
+      tertiaryLabel: '#999999',
+      elevatedSurface: '#ffffff',
+      separator: '#dddddd',
+      label: '#111111',
+    },
+    chartColors: {
+      secondaryLabel: '#666666',
+      tertiaryLabel: '#999999',
+      elevatedSurface: '#ffffff',
+      separator: '#dddddd',
+      label: '#111111',
+    },
+  }),
+}));
+
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 0: 0, 1: 4, 2: 8, 3: 12, 4: 16 },
+  borderRadius: { full: 999, xl: 16 },
+  opacity: { peek: 0.5 },
+  materialElevationByLevel: { level2: {} },
+}));
+
+vi.mock('../../../lib/haptics', () => ({ hapticSelection: vi.fn() }));
+
+vi.mock('../profile-chart-colors', () => ({
+  gradeChartColor: (key: string) => `grade-${key}`,
+  layoutChartColor: (key: string) => `layout-${key}`,
+  flashRedpointColor: (key: string) => `status-${key}`,
+}));
+
+import { GroupedBarChart } from '../YouCharts';
+
+/** The reporter's chart: V0-V6, counts up to 128, on a 320pt phone card. */
+const reportedBars: RawGroupedBar[] = [128, 82, 61, 44, 41, 36, 30].map((flash, index) => ({
+  key: `V${index}`,
+  label: `V${index}`,
+  values: [
+    { key: 'flash', label: 'Flash', value: flash },
+    { key: 'redpoint', label: 'Redpoint', value: Math.round(flash / 3) },
+  ],
+}));
+
+const singleDigitBars: RawGroupedBar[] = reportedBars.map((bar) => ({
+  ...bar,
+  values: bar.values.map((value) => ({ ...value, value: 4 })),
+}));
+
+function labelStyles(props: CapturedChartProps): Record<string, unknown>[] {
+  const element = props.data?.[0]?.topLabelComponent?.();
+  if (!element) return [];
+  const { style } = element.props as { style?: unknown };
+  return (Array.isArray(style) ? style : [style]).filter(
+    (entry): entry is Record<string, unknown> => typeof entry === 'object' && entry !== null,
+  );
+}
+
+describe('GroupedBarChart top-label sizing (#3779)', () => {
+  beforeEach(() => {
+    chartProps = null;
+  });
+
+  it('gives a three-digit count a box wider than its 13px bar, centred over it', () => {
+    render(<GroupedBarChart bars={reportedBars} />);
+    const props = chartProps;
+    expect(props).not.toBeNull();
+    if (!props) return;
+
+    // The bug: gifted-charts defaults this box to exactly `barWidth`.
+    expect(props.barWidth).toBeLessThan(20);
+    expect(props.topLabelContainerStyle?.width).toBeGreaterThan(props.barWidth ?? 0);
+    // Widening alone would push the label right; the offset re-centres it.
+    expect(props.topLabelContainerStyle?.left).toBeLessThan(0);
+  });
+
+  it('turns the count vertical and reserves height for it when bars are that narrow', () => {
+    render(<GroupedBarChart bars={reportedBars} />);
+    const props = chartProps;
+    expect(props).not.toBeNull();
+    if (!props) return;
+
+    const rotation = labelStyles(props).find((style) => 'transform' in style);
+    expect(rotation).toEqual({ transform: [{ rotate: '-90deg' }], marginBottom: expect.any(Number) });
+    // Plot height shrinks so the standing label still fits inside the card.
+    expect(props.height).toBeLessThan(150 - 28);
+  });
+
+  it('leaves single-digit counts horizontal and the plot at full height', () => {
+    render(<GroupedBarChart bars={singleDigitBars} />);
+    const props = chartProps;
+    expect(props).not.toBeNull();
+    if (!props) return;
+
+    expect(labelStyles(props).some((style) => 'transform' in style)).toBe(false);
+    expect(props.height).toBe(150 - 28);
+    expect(props.topLabelContainerStyle?.width).toBe(props.barWidth);
+  });
+});

--- a/packages/mobile/src/components/you/__tests__/you-charts-bar-top-label.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/you-charts-bar-top-label.test.tsx
@@ -13,11 +13,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { RawGroupedBar } from '@boardsesh/profile-stats';
 
 const CARD_WIDTH = 320;
+// GroupedBarChart's own default `height` prop, and the room it always reserves
+// under the plot for the grade axis. Only the card *width* comes from onLayout.
+const CHART_HEIGHT = 150;
+const X_AXIS_RESERVE = 28;
 
 vi.mock('react-native', () => ({
   View: ({ children, onLayout }: { children?: ReactNode; onLayout?: (event: unknown) => void }) => {
     useEffect(() => {
-      onLayout?.({ nativeEvent: { layout: { width: CARD_WIDTH, height: 160, x: 0, y: 0 } } });
+      onLayout?.({ nativeEvent: { layout: { width: CARD_WIDTH, height: CHART_HEIGHT, x: 0, y: 0 } } });
       // eslint-disable-next-line react-hooks/exhaustive-deps -- fire once on mount, matching a real layout pass
     }, []);
     return createElement('div', null, children);
@@ -154,7 +158,7 @@ describe('GroupedBarChart top-label sizing (#3779)', () => {
     const rotation = labelStyles(props).find((style) => 'transform' in style);
     expect(rotation).toEqual({ transform: [{ rotate: '-90deg' }], marginBottom: expect.any(Number) });
     // Plot height shrinks so the standing label still fits inside the card.
-    expect(props.height).toBeLessThan(150 - 28);
+    expect(props.height).toBeLessThan(CHART_HEIGHT - X_AXIS_RESERVE);
   });
 
   it('leaves single-digit counts horizontal and the plot at full height', () => {
@@ -164,7 +168,7 @@ describe('GroupedBarChart top-label sizing (#3779)', () => {
     if (!props) return;
 
     expect(labelStyles(props).some((style) => 'transform' in style)).toBe(false);
-    expect(props.height).toBe(150 - 28);
+    expect(props.height).toBe(CHART_HEIGHT - X_AXIS_RESERVE);
     expect(props.topLabelContainerStyle?.width).toBe(props.barWidth);
   });
 });

--- a/packages/mobile/src/components/you/__tests__/you-charts-tap-tooltip.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/you-charts-tap-tooltip.test.tsx
@@ -31,6 +31,7 @@ vi.mock('react-native', () => ({
   Pressable: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
     createElement('button', { type: 'button', onClick: onPress }, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+  PixelRatio: { getFontScale: () => 1 },
 }));
 
 vi.mock('react-i18next', () => ({

--- a/packages/mobile/src/components/you/bar-top-label.ts
+++ b/packages/mobile/src/components/you/bar-top-label.ts
@@ -1,0 +1,85 @@
+/**
+ * Layout maths for the count printed above each bar of the You -> Progress
+ * "Flash vs Redpoint" chart (#3779).
+ *
+ * gifted-charts boxes a bar's top label in a container that is exactly one bar
+ * wide, so on a phone — where seven or more grade pairs squeeze each bar down
+ * to roughly 13px — a three-digit count ("128") wraps or gets cut off. These
+ * helpers decide how much room the count really needs and, when the column is
+ * hopeless, stand the count on end so it reads vertically instead of being
+ * clipped.
+ */
+
+/** The count renders at the `caption2` ramp: 11px on both UI variants. */
+export const BAR_TOP_LABEL_FONT_SIZE = 11;
+/** Tallest `caption2` line height across the two variants (Material's 16). */
+export const BAR_TOP_LABEL_LINE_HEIGHT = 16;
+/** Semibold digits measure ~0.62em wide in both SF and Roboto. */
+const DIGIT_WIDTH_EM = 0.62;
+/** A hair of breathing room on each side so glyphs never touch the box edge. */
+const LABEL_SIDE_PADDING = 2;
+/** Matches `styles.barTopLabel`: the gap between the count and the bar top. */
+const BASE_LABEL_GAP = 2;
+
+/** Widest count label in the chart, so every bar gets the same treatment. */
+export function longestBarValue(values: readonly number[]): number {
+  return values.reduce((widest, value) => (String(value).length > String(widest).length ? value : widest), 0);
+}
+
+/** Rendered width of a count label, in px, at the given accessibility font scale. */
+export function estimateBarTopLabelWidth(value: number, fontScale = 1): number {
+  const digits = String(Math.round(value)).length;
+  return Math.ceil(digits * BAR_TOP_LABEL_FONT_SIZE * DIGIT_WIDTH_EM * fontScale) + LABEL_SIDE_PADDING * 2;
+}
+
+export type BarTopLabelLayout = {
+  /** Width of the absolutely-positioned label box gifted-charts renders. */
+  width: number;
+  /** Left offset that keeps a wider-than-bar box centred over its own bar. */
+  left: number;
+  /** True when the count is rotated to read bottom-to-top. */
+  rotated: boolean;
+  /** Bottom margin that lifts the label clear of the bar it belongs to. */
+  marginBottom: number;
+  /** Extra vertical room a rotated label needs above the tallest bar. */
+  headroom: number;
+};
+
+/**
+ * Decide how to draw the count above a bar.
+ *
+ * - Fits inside the bar: leave it alone (the pre-#3779 behaviour).
+ * - Fits if it borrows the gap to its neighbour: widen the box and re-centre it.
+ * - Still too wide: rotate it vertical, which costs height instead of width.
+ *
+ * `columnWidth` is the horizontal room a label may claim before it would collide
+ * with the next label — one bar plus the gap to the bar beside it.
+ */
+export function computeBarTopLabelLayout(
+  longestValue: number,
+  barWidth: number,
+  columnWidth: number,
+  fontScale = 1,
+): BarTopLabelLayout {
+  const textWidth = estimateBarTopLabelWidth(longestValue, fontScale);
+  if (textWidth <= columnWidth) {
+    const width = Math.max(barWidth, Math.min(columnWidth, textWidth));
+    return {
+      width,
+      left: Math.round((barWidth - width) / 2),
+      rotated: false,
+      marginBottom: BASE_LABEL_GAP,
+      headroom: 0,
+    };
+  }
+  const lineHeight = Math.ceil(BAR_TOP_LABEL_LINE_HEIGHT * fontScale);
+  return {
+    width: textWidth,
+    left: Math.round((barWidth - textWidth) / 2),
+    rotated: true,
+    // The rotation pivots on the label's centre, so half of it would swing down
+    // over the bar. Push the whole box up by that half before it turns.
+    marginBottom: Math.round((textWidth - lineHeight) / 2) + BASE_LABEL_GAP,
+    headroom: Math.max(0, textWidth - lineHeight),
+  };
+}


### PR DESCRIPTION
## What & why

On the You → Progress tab, the **Flash vs Redpoint** card prints the ascent count above each bar. On a phone those counts were cut off: the reporter's screenshot shows a row of clipped numbers over seven grade pairs.

## Verified root cause

`GroupedBarChart` (`packages/mobile/src/components/you/YouCharts.tsx`) hands gifted-charts `topLabelContainerStyle={{ width: barWidth }}`, so every count is boxed into exactly one bar's width. That width is tiny: with seven grades on a 320pt card, `barWidth` computes to **12px** (two bars per grade, a 16px gap between groups, a 3px gap inside one). An 11px `caption2` "128" needs about 25px, so the digits wrapped or were cut. The bar-width box landed in 7bf8f4f9b (2026-06-17), before the screenshot.

Note on scope: the first pass at this issue read the report as the _web_ profile chart and thinned its x-axis labels. That was wrong on both counts — the screenshot is the mobile card (per-bar count labels, round legend dots, HIG uppercase section title), and the clipped element is the count, not the grade axis. The web change has been dropped; this PR touches mobile only.

## Fix

New pure helper `packages/mobile/src/components/you/bar-top-label.ts` sizes the count box off the widest count in the chart, following the two options the reporter suggested:

1. **Fits the bar** → unchanged.
2. **Fits if it borrows the gap next to the bar** → widen the box and shift it left so it stays centred over its own bar.
3. **Still too wide** → stand the count on end (`rotate: -90deg`), lifted clear of the bar top, with the plot height reduced by the extra the standing label needs so the tallest one still fits inside the card.

Accessibility text sizes are accounted for: the estimate scales with `PixelRatio.getFontScale()`, capped at the 1.5 multiplier `Text` already enforces. Zoom in on the chart and wide bars go back to horizontal counts automatically.

## Tests + fail-on-revert

- `packages/mobile/src/components/you/__tests__/bar-top-label.test.ts` — 7 unit tests over the sizing decisions (single digit untouched, gap-borrowing, rotation at phone widths, no rotation when zoomed, rotation once text scales to 1.5×).
- `packages/mobile/src/components/you/__tests__/you-charts-bar-top-label.test.tsx` — renders `GroupedBarChart` with the reporter's own data (V0–V6, counts to 128, 320pt card) and captures the real props handed to gifted-charts instead of serialising them, so the label box and the rotation style are observable.

Revert check: removing the three fix hunks from `YouCharts.tsx` (the container style, the rotation style, the height reserve) turns **2 of the 3** render tests red. The third is the guard that single-digit counts stay horizontal, which is expected to hold either way.

## QA Notes

Device QA on a phone (not a tablet), You → Progress → Flash vs Redpoint:

- A climber with 3-digit counts at any grade: every count is fully readable, standing vertically above its bar, none clipped at the top of the card.
- A climber with only 1–2 digit counts: counts stay horizontal, exactly as before.
- Pinch-zoom the chart: as bars widen, counts flip back to horizontal and stay centred over their own bar.
- Bump the system text size to the largest setting: counts still readable, not overlapping their neighbour.
- Tap a grade pair: the tooltip still opens and clears on background tap (unchanged).
- Both light and dark, both UI variants.

Not covered here: the reporter's second question on the same screenshot, "where are the + grades?" — plus grades collapse into whole V-grades by design (`grade-mapping.ts` maps several Font grades onto one `v_grade` for chart aggregation). Switching the grade display format to Font or "both" shows the finer steps.

## Release Notes

The ascent counts above the Flash vs Redpoint bars on your Progress tab no longer get chopped off. When the bars are too narrow for a three-digit count, the number now stands on end so you can still read it.

Fixes #3779
