### PR TITLE
fix(mobile): treat a session ending as teardown, not a sync error

### DIFF
--- a/packages/mobile/src/providers/__tests__/queue-provider-join-session-ended.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-join-session-ended.test.tsx
@@ -1,0 +1,316 @@
+// @vitest-environment jsdom
+//
+// #3087: a party session that already ended server-side (leader ended it, or
+// it was reaped) while a peer is joining/rejoining used to be treated as a
+// generic sync failure — the JOIN_SESSION catch in `startJoinedSubscriptions`
+// unconditionally showed `mobile.queue.syncError` and reported a handled
+// error, even though `ensureJoined` rejecting with a `SESSION_ENDED`-coded
+// `GraphQLOperationError` is expected teardown, not a defect. Web already
+// special-cases this exact code (session-connection-ports.ts); this file
+// covers the analogous mobile guard: silently clear the stored session and
+// show the calm `mobile.toast.sessionEnded` toast instead, while a genuine
+// (non-coded) join failure still surfaces the noisy syncError path unchanged.
+// Reuses the WS/HTTP/store mock harness pattern from
+// queue-provider-backgrounded-join.test.tsx.
+import { render, waitFor } from '@testing-library/react';
+import { createElement, useEffect } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { GraphQLOperationError } from '@boardsesh/graphql-client';
+
+const ws = vi.hoisted(() => {
+  type WsEventName = 'connected' | 'closed';
+  const listeners: Record<WsEventName, Set<() => void>> = {
+    connected: new Set(),
+    closed: new Set(),
+  };
+  return {
+    emit: (eventName: WsEventName) => {
+      for (const listener of listeners[eventName]) listener();
+    },
+    client: {
+      on: vi.fn((eventName: WsEventName, listener: () => void) => {
+        listeners[eventName].add(listener);
+        return () => {
+          listeners[eventName].delete(listener);
+        };
+      }),
+      subscribe: vi.fn(() => vi.fn()),
+    },
+    reset: () => {
+      listeners.connected.clear();
+      listeners.closed.clear();
+    },
+  };
+});
+
+const graph = vi.hoisted(() => ({
+  execute: vi.fn(),
+}));
+
+const http = vi.hoisted(() => ({
+  request: vi.fn(),
+}));
+
+const analytics = vi.hoisted(() => ({
+  track: vi.fn(),
+}));
+
+const sessionStore = vi.hoisted(() => ({
+  getStoredSessionId: vi.fn(async () => 'session-1' as string | null),
+  setStoredSessionId: vi.fn(async () => {}),
+  clearStoredSessionId: vi.fn(async () => {}),
+  getStoredCreatedSessionId: vi.fn(async () => null as string | null),
+  setStoredCreatedSessionId: vi.fn(async () => {}),
+  clearStoredCreatedSessionId: vi.fn(async () => {}),
+}));
+
+const queueSnapshotStore = vi.hoisted(() => ({
+  getStoredQueueSnapshot: vi.fn(async () => null),
+  setStoredQueueSnapshot: vi.fn(async () => {}),
+  clearStoredQueueSnapshot: vi.fn(async () => {}),
+}));
+
+const activeBoard = vi.hoisted(() => ({
+  stored: {
+    uuid: 'board-1',
+    slug: 'board-1',
+    ownerId: 'owner-1',
+    boardType: 'kilter',
+    layoutId: 1,
+    sizeId: 10,
+    setIds: '1,2',
+    name: 'Test board',
+    isPublic: true,
+    isUnlisted: false,
+    hideLocation: false,
+    isOwned: true,
+    angle: 40,
+    isAngleAdjustable: true,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    totalAscents: 0,
+    uniqueClimbers: 0,
+    followerCount: 0,
+    commentCount: 0,
+    isFollowedByMe: false,
+  } satisfies UserBoard,
+  getStoredActiveBoard: vi.fn(),
+  setActiveBoard: vi.fn(async () => {}),
+}));
+
+const toast = vi.hoisted(() => ({
+  showToast: vi.fn(),
+}));
+
+const errorReporter = vi.hoisted(() => ({
+  reportError: vi.fn(),
+  reportHandledError: vi.fn(),
+}));
+
+const queueMutations = vi.hoisted(() => ({
+  addQueueItem: vi.fn(async () => {}),
+  removeQueueItem: vi.fn(async () => {}),
+  reorderQueueItem: vi.fn(async () => {}),
+  setCurrentClimb: vi.fn(async () => {}),
+  mirrorCurrentClimb: vi.fn(async () => {}),
+  publishPlaybackState: vi.fn(async () => {}),
+  setQueue: vi.fn(async () => {}),
+  replaceQueueItem: vi.fn(async () => {}),
+  confirmClimbOnWall: vi.fn(async () => {}),
+  reportWallDisconnect: vi.fn(async () => {}),
+  setSessionBoardSerial: vi.fn(async () => {}),
+  setSessionBoardPath: vi.fn(async () => {}),
+}));
+
+const appState = vi.hoisted(() => {
+  let currentState = 'active';
+  const changeHandlers = new Set<(state: string) => void>();
+  return {
+    getCurrentState: () => currentState,
+    setState: (next: string) => {
+      currentState = next;
+    },
+    emitChange: (next: string) => {
+      currentState = next;
+      for (const handler of changeHandlers) handler(next);
+    },
+    addEventListener: vi.fn((_event: string, handler: (state: string) => void) => {
+      changeHandlers.add(handler);
+      return { remove: vi.fn(() => changeHandlers.delete(handler)) };
+    }),
+    reset: () => {
+      currentState = 'active';
+      changeHandlers.clear();
+    },
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios', select: (options: Record<string, unknown>) => options.ios ?? options.default },
+  AppState: {
+    get currentState() {
+      return appState.getCurrentState();
+    },
+    addEventListener: appState.addEventListener,
+  },
+}));
+
+vi.mock('expo-crypto', () => ({
+  randomUUID: () => 'test-correlation-id',
+}));
+
+vi.mock('@boardsesh/graphql-client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/graphql-client')>()),
+  execute: graph.execute,
+}));
+
+vi.mock('@boardsesh/queue-react', () => ({
+  useQueueMutations: () => queueMutations,
+}));
+
+vi.mock('@boardsesh/play-view', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/play-view')>()),
+  emitWallConfirm: vi.fn(),
+}));
+
+vi.mock('../../lib/graphql/ws-client', () => ({
+  getWsClient: () => ws.client,
+}));
+
+vi.mock('../../lib/session-store', () => sessionStore);
+
+vi.mock('../../lib/queue-snapshot-store', () => queueSnapshotStore);
+
+vi.mock('../../lib/active-board-store', () => ({
+  getStoredActiveBoard: activeBoard.getStoredActiveBoard,
+}));
+
+vi.mock('../../lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: activeBoard.stored }),
+  useSetActiveBoard: () => activeBoard.setActiveBoard,
+}));
+
+vi.mock('../../lib/graphql/client', () => ({
+  getHttpClient: () => ({ request: http.request }),
+}));
+
+vi.mock('../../lib/analytics', () => analytics);
+
+vi.mock('../toast-provider', () => ({
+  useToast: () => ({ showToast: toast.showToast }),
+}));
+
+vi.mock('../queue-snackbar-provider', () => ({
+  useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }),
+}));
+
+vi.mock('../party-profile-provider', () => ({
+  usePartyProfile: () => ({ username: undefined, avatarUrl: undefined }),
+}));
+
+vi.mock('../../lib/error-reporting', () => ({
+  reportError: errorReporter.reportError,
+  reportHandledError: errorReporter.reportHandledError,
+}));
+
+import { QueueProvider, useQueue } from '../queue-provider';
+
+function Probe({ onSessionId }: { onSessionId: (sessionId: string | null) => void }) {
+  const { sessionId } = useQueue();
+  useEffect(() => {
+    onSessionId(sessionId);
+  }, [sessionId, onSessionId]);
+  return null;
+}
+
+function renderProvider() {
+  const sessionIds: Array<string | null> = [];
+  const result = render(
+    createElement(QueueProvider, null, createElement(Probe, { onSessionId: (id) => sessionIds.push(id) })),
+  );
+  return { result, sessionIds };
+}
+
+describe('QueueProvider JOIN_SESSION SESSION_ENDED guard (#3087)', () => {
+  beforeEach(() => {
+    ws.reset();
+    ws.client.on.mockClear();
+    ws.client.subscribe.mockClear();
+    activeBoard.stored = { ...activeBoard.stored };
+    activeBoard.getStoredActiveBoard.mockReset();
+    activeBoard.getStoredActiveBoard.mockResolvedValue(activeBoard.stored);
+    activeBoard.setActiveBoard.mockClear();
+    toast.showToast.mockClear();
+    analytics.track.mockClear();
+    errorReporter.reportError.mockClear();
+    errorReporter.reportHandledError.mockClear();
+    for (const mutation of Object.values(queueMutations) as Array<ReturnType<typeof vi.fn>>) {
+      mutation.mockReset();
+      mutation.mockResolvedValue(undefined);
+    }
+    sessionStore.getStoredSessionId.mockReset();
+    sessionStore.getStoredSessionId.mockResolvedValue('session-1');
+    sessionStore.setStoredSessionId.mockClear();
+    sessionStore.clearStoredSessionId.mockClear();
+    graph.execute.mockReset();
+    http.request.mockReset();
+    http.request.mockImplementation(async (operation: string) => {
+      if (operation.includes('SessionStatus')) return { sessionStatus: 'active' };
+      if (operation.includes('GetSessionQueueState')) return { session: { queueState: null } };
+      return { endSession: { sessionId: 'session-1' } };
+    });
+    appState.reset();
+    appState.addEventListener.mockClear();
+  });
+
+  it('silently clears the session and toasts sessionEnded when JOIN_SESSION rejects with SESSION_ENDED', async () => {
+    graph.execute.mockImplementation((_client: unknown, operation: { query: string }) => {
+      if (operation.query.includes('JoinSession')) {
+        return Promise.reject(
+          new GraphQLOperationError([{ message: 'This session has ended', extensions: { code: 'SESSION_ENDED' } }]),
+        );
+      }
+      return Promise.resolve({});
+    });
+
+    const { sessionIds } = renderProvider();
+
+    await waitFor(() => {
+      expect(toast.showToast).toHaveBeenCalledWith('mobile.toast.sessionEnded', 'success');
+    });
+
+    // The session is cleared locally — the probe's sessionId settles to null.
+    await waitFor(() => {
+      expect(sessionIds.at(-1)).toBeNull();
+    });
+
+    expect(sessionStore.clearStoredSessionId).toHaveBeenCalled();
+    expect(errorReporter.reportHandledError).not.toHaveBeenCalled();
+    // Only the sessionEnded toast fired — never the generic sync-error one.
+    expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.syncError', 'error');
+  });
+
+  it('still reports a genuine (non-coded) join failure as a sync error (regression guard)', async () => {
+    graph.execute.mockImplementation((_client: unknown, operation: { query: string }) => {
+      if (operation.query.includes('JoinSession')) {
+        return Promise.reject(new Error("GraphQL mutation 'JoinSession' timed out after 30000ms"));
+      }
+      return Promise.resolve({});
+    });
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(errorReporter.reportHandledError).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({ tags: { source: 'queue-sync', op: 'join' } }),
+      );
+    });
+    expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.syncError', 'error');
+    expect(toast.showToast).not.toHaveBeenCalledWith('mobile.toast.sessionEnded', 'success');
+  });
+});

--- a/packages/mobile/src/providers/queue/use-session-realtime.ts
+++ b/packages/mobile/src/providers/queue/use-session-realtime.ts
@@ -17,7 +17,7 @@ import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { parseBoardPath, parseNamedBoardPath } from '@boardsesh/board-config';
 import type { SessionUser, SubscriptionQueueEvent, UserBoard } from '@boardsesh/shared-schema';
 import { emitWallConfirm } from '@boardsesh/play-view';
-import { isNotSessionMemberError } from '@boardsesh/graphql-client';
+import { GraphQLOperationError, isNotSessionMemberError } from '@boardsesh/graphql-client';
 import { getWsClient } from '../../lib/graphql/ws-client';
 import { AUTH_REFRESH_RETRY_CLOSE_CODE } from '../../lib/graphql/ws-close-codes';
 import {
@@ -421,6 +421,25 @@ export function useSessionRealtime({
           joinDeferredForBackground = true;
           joinRetryCount = 0;
           clearJoinRetryTimer();
+          return;
+        }
+        // The party session already ended server-side (leader ended it, or it
+        // was reaped) while we were joining/rejoining — expected teardown, not
+        // a sync failure. Mirrors web's SESSION_ENDED guard
+        // (session-connection-ports.ts) and this file's own NOT_SESSION_MEMBER
+        // subscription-error branch. Unlike that branch this toasts: a client
+        // whose join fails here never receives the live `SessionEnded`
+        // subscription event (which does toast), so this is often the only
+        // signal the user gets that the session is gone. Guarded on the still-
+        // active session so a late error from a superseded A→B switch can't
+        // clear the new session.
+        if (
+          joinError instanceof GraphQLOperationError &&
+          joinError.extensions?.code === 'SESSION_ENDED' &&
+          sessionIdRef.current === sessionId
+        ) {
+          void clearSessionRef.current();
+          showToastRef.current(tRef.current('mobile.toast.sessionEnded'), 'success');
           return;
         }
         logJoinFailure(joinError);

--- a/packages/mobile/src/providers/queue/use-session-realtime.ts
+++ b/packages/mobile/src/providers/queue/use-session-realtime.ts
@@ -430,14 +430,10 @@ export function useSessionRealtime({
         // subscription-error branch. Unlike that branch this toasts: a client
         // whose join fails here never receives the live `SessionEnded`
         // subscription event (which does toast), so this is often the only
-        // signal the user gets that the session is gone. Guarded on the still-
-        // active session so a late error from a superseded A→B switch can't
-        // clear the new session.
-        if (
-          joinError instanceof GraphQLOperationError &&
-          joinError.extensions?.code === 'SESSION_ENDED' &&
-          sessionIdRef.current === sessionId
-        ) {
+        // signal the user gets that the session is gone. A late error from a
+        // superseded A→B switch is already dropped by the guard at the top of
+        // this catch block, so it can't clear the new session.
+        if (joinError instanceof GraphQLOperationError && joinError.extensions?.code === 'SESSION_ENDED') {
           void clearSessionRef.current();
           showToastRef.current(tRef.current('mobile.toast.sessionEnded'), 'success');
           return;


### PR DESCRIPTION
## Summary

When the leader ended a party session while a peer was still live, the peer's mobile app flashed a red "Sync error" toast and shipped a handled `GraphQLOperationError` to error tracking — for what is ordinary session teardown. Web has handled this silently since #2696; mobile never got the guard.

**Verified root cause.** The backend intentionally rejects a JOIN against an ended session with `new GraphQLError('This session has ended', { extensions: { code: 'SESSION_ENDED' } })` (`packages/backend/src/services/room-manager/client-lifecycle.ts:112-118` — the only emitter of that code in the repo). On mobile the rejection surfaces from `ensureJoined` inside `useSessionRealtime`'s join catch, which had no code discrimination and fell straight through to `showToast('mobile.queue.syncError', 'error')` + `reportHandledError(..., { source: 'queue-sync', op: 'join' })`. The chain was checked end to end rather than assumed: `execute()` wraps server errors into a real `GraphQLOperationError` whose constructor prefers the *coded* error when picking `.extensions`, and `createJoinSessionTracker.ensureJoined` rethrows the original error unmodified, so both the `instanceof` and the `extensions.code` read hold at the catch site.

The issue body pointed at `queue-provider.tsx`; the join catch has since moved to `packages/mobile/src/providers/queue/use-session-realtime.ts`.

**Fix.** In that catch, a `SESSION_ENDED`-coded `GraphQLOperationError` now clears the local session and shows the existing `mobile.toast.sessionEnded` success toast instead of the error toast, and skips the error report. It toasts (where web stays silent) on purpose: a client whose join fails here never receives the live `SessionEnded` subscription event, so this is the only signal the user gets that the session is gone. The branch sits after the existing backgrounded-join branch, so a rejection that lands while the app is backgrounded still defers and re-joins on foreground, hitting the new branch there.

No new i18n key — `mobile.toast.sessionEnded` already exists in `en-US`/`es`/`fr` and is already used elsewhere in this file.

## Test plan

New `packages/mobile/src/providers/__tests__/queue-provider-join-session-ended.test.tsx`:

1. A `JoinSession` mutation rejecting with `SESSION_ENDED` → session cleared, `mobile.toast.sessionEnded` / `success`, no `reportHandledError`.
2. Regression guard: a join rejection with **no** `extensions.code` still produces `mobile.queue.syncError` / `error` and still reports — so the guard can't quietly swallow genuine sync failures.

**Fail-on-revert story (executed, not asserted).** Reverse-applied the source-only hunk with `git apply -R` and re-ran the file: 1 failed / 1 passed. Case 1 failed exactly at the pre-fix behaviour — `showToast` received `["mobile.queue.syncError","error"]` instead of `["mobile.toast.sessionEnded","success"]` — while case 2 stayed green, proving it is not a tautology on the fixed branch. Restored; tree clean.

Scoped validation: the new file 2/2; the whole `packages/mobile/src/providers/__tests__/` directory 40 files / 452 tests pass; `vp run typecheck:mobile` clean; `vp check` clean.

## QA Notes

Needs two devices/clients in one party session.

- **Headline path**: peer joins a session, leader ends it while the peer is live and mid queue/join activity. Peer should get the green "session ended" toast and drop back to solo — no red "Sync error", no Sentry/PostHog `GraphQLOperationError "This session has ended"`.
- **Backgrounded peer**: background the peer, end the session from the leader, foreground the peer. Same green toast on foreground, not the error toast.
- **No double toast**: the peer should see the ended toast exactly once, whether the news arrives via the `SessionEnded` subscription event or via the failed re-join.
- **Genuine sync failure still shouts**: kill the backend (or go offline) with a live session — the red "Sync error" toast and retry behaviour must be unchanged.
- **Leader self-end**: leader ending their own session still toasts and clears as before.
- **A→B switch**: leave session A for session B while A is being ended — B must stay connected.

## Release Notes

- When someone ends a session you're in, you now get a plain "session ended" note instead of a red sync error.

## Follow-up (not in this PR)

Queue *mutations* reach the same backend error through `useQueueMutations`' `ensureReady` seam when the join cache is cold after a socket reconnect, and still land in `showQueueMutationErrorToast` as `mobile.queue.actionFailed` + a handled report. Lower volume (needs a reconnect to be reachable) and a different call site; the clean fix is the shared `isSessionEndedError` helper next to `isRateLimitedError` in `packages/shared/graphql-client/src/errors.ts`, used from both places. Left out to keep this diff on the headline path.

Fixes #3087
