### PR TITLE
fix(sync): flush each Kilter catalog layout in one transaction

### DIFF
--- a/packages/kilter-sync/src/sync/catalog-sync.transaction.integration.test.ts
+++ b/packages/kilter-sync/src/sync/catalog-sync.transaction.integration.test.ts
@@ -217,7 +217,11 @@ describeIntegration('Kilter catalog layout flush is atomic (issue #3538)', () =>
       // explicitly so a partially-committed pre-fix state is cleaned as well.
       const tagPrefix = `${tag}-%`;
       await db.execute(sql`DELETE FROM board_climb_holds WHERE climb_uuid LIKE ${tagPrefix}`);
-      await db.execute(sql`DELETE FROM board_climb_aliases WHERE alias_uuid LIKE ${tagPrefix}`);
+      // Match both columns: this fixture only writes self-aliases, but an alias
+      // pointing AT a tagged canonical from a tagged alias uuid must not leak.
+      await db.execute(
+        sql`DELETE FROM board_climb_aliases WHERE alias_uuid LIKE ${tagPrefix} OR canonical_uuid LIKE ${tagPrefix}`,
+      );
       await db.execute(sql`DELETE FROM board_climbs WHERE uuid LIKE ${tagPrefix}`);
       await closePool();
     }

--- a/packages/kilter-sync/src/sync/catalog-sync.transaction.integration.test.ts
+++ b/packages/kilter-sync/src/sync/catalog-sync.transaction.integration.test.ts
@@ -10,11 +10,18 @@
 // skips hold/fingerprint re-derivation forever (no self-heal).
 //
 // This test drives the real `flushKilterLayoutBatch` against a migrated
-// Postgres (the dev DB). It self-skips when DATABASE_URL is not a local
-// database, and runs entirely inside an outer transaction that always
-// rolls back, so it never leaves rows behind. Run locally with:
+// Postgres (the dev DB) on an AUTOCOMMIT connection — deliberately NOT wrapped
+// in an outer rollback transaction. That is load-bearing: the orphaned-row
+// symptom only exists when the flush's statements commit independently, so a
+// fixture transaction around the test would hide it (a mid-flush FK error
+// would poison the fixture transaction instead of leaving a stranded climb).
+// Every row it writes is tagged with a unique per-run uuid prefix and deleted
+// in a `finally`.
 //
-//   DATABASE_URL=postgres://…@localhost:5432/… VITEST_POOL_ID=solo-issue3538 \
+// It self-skips when DATABASE_URL is not a local database, so it does NOT run
+// in CI. Run it locally against the dev DB with:
+//
+//   DATABASE_URL=postgres://…@localhost:5432/… \
 //     vp test run --reporter=agent packages/kilter-sync/src/sync/catalog-sync.transaction.integration.test.ts
 
 import { describe, it, expect } from 'vitest';
@@ -28,33 +35,45 @@ function localDatabaseUrl(): string | null {
   if (!databaseUrl) {
     return null;
   }
-  const hostname = new URL(databaseUrl).hostname.toLowerCase();
+  let hostname: string;
+  try {
+    hostname = new URL(databaseUrl).hostname.toLowerCase();
+  } catch {
+    // A malformed DATABASE_URL should skip the file, not crash it at import.
+    return null;
+  }
   return ['localhost', '127.0.0.1', 'postgres'].includes(hostname) ? databaseUrl : null;
 }
 
 const describeIntegration = localDatabaseUrl() ? describe : describe.skip;
 
-// A fake board_layout id — board_climbs has no FK to board_layouts, so any
-// integer works here without needing a real layout fixture.
-const FAKE_LAYOUT_ID = -3538;
+// A real kilter layout, because `populateDenormalizedColumns` resolves the hold
+// ids in `frames` through board_placements scoped to (board_type, layout_id).
+// With a fake layout id the joins match nothing and the denormalized-columns
+// step — half of the #3538 symptom — would be a silent no-op here.
+const KILTER_LAYOUT_ID = 1;
+const HOLD_IDS = [1073, 1074];
+const FRAMES = HOLD_IDS.map((holdId) => `p${holdId}r12`).join('');
 
 function fakeClimb(uuid: string, name: string): NewBoardClimb {
   return {
     uuid,
     boardType: 'kilter',
-    layoutId: FAKE_LAYOUT_ID,
+    layoutId: KILTER_LAYOUT_ID,
     setterId: null,
     setterUsername: 'issue-3538-tester',
     name,
     description: '',
     characteristics: null,
+    // Left NULL on purpose: populateDenormalizedColumns derives the edges from
+    // the frames hold ids, which is the precondition for required_set_ids.
     edgeLeft: null,
     edgeRight: null,
     edgeBottom: null,
     edgeTop: null,
     framesCount: 1,
     framesPace: 0,
-    frames: `p1000r12`,
+    frames: FRAMES,
     isDraft: false,
     isListed: true,
     createdAt: new Date().toISOString(),
@@ -63,7 +82,7 @@ function fakeClimb(uuid: string, name: string): NewBoardClimb {
 }
 
 describeIntegration('Kilter catalog layout flush is atomic (issue #3538)', () => {
-  it('lands climbs+holds+aliases together, and rolls back the whole batch on a mid-flush failure', async (testContext) => {
+  it('lands climbs+holds+aliases+denormalized columns together, and leaves no orphan on a mid-flush failure', async (testContext) => {
     const db = createDb();
 
     try {
@@ -80,87 +99,126 @@ describeIntegration('Kilter catalog layout flush is atomic (issue #3538)', () =>
       return;
     }
 
+    const [placements] = await executeRows<{ n: number | string }>(
+      db,
+      sql`SELECT count(*)::int AS n FROM board_placements
+          WHERE board_type = 'kilter' AND layout_id = ${KILTER_LAYOUT_ID} AND id = ANY(${sql`ARRAY[${sql.join(
+            HOLD_IDS.map((holdId) => sql`${holdId}`),
+            sql`, `,
+          )}]::int[]`})`,
+    );
+    if (Number(placements?.n ?? 0) !== HOLD_IDS.length) {
+      // No board catalog seeded — the denormalized-columns assertions below
+      // would be vacuous, so skip rather than assert nothing.
+      testContext.skip();
+      return;
+    }
+
     const tag = `3538-${Date.now()}`;
     const happyUuid = `${tag}-happy`;
     const abortUuid = `${tag}-abort`;
     const missingHoldClimbUuid = `${tag}-never-inserted`;
 
-    const rollback = new Error('rollback issue-3538 integration fixture');
+    const climbCount = async (uuid: string): Promise<number> => {
+      const [row] = await executeRows<{ n: number | string }>(
+        db,
+        sql`SELECT count(*)::int AS n FROM board_climbs WHERE uuid = ${uuid}`,
+      );
+      return Number(row?.n ?? 0);
+    };
+    const holdCount = async (uuid: string): Promise<number> => {
+      const [row] = await executeRows<{ n: number | string }>(
+        db,
+        sql`SELECT count(*)::int AS n FROM board_climb_holds WHERE climb_uuid = ${uuid}`,
+      );
+      return Number(row?.n ?? 0);
+    };
+    const aliasCount = async (uuid: string): Promise<number> => {
+      const [row] = await executeRows<{ n: number | string }>(
+        db,
+        sql`SELECT count(*)::int AS n FROM board_climb_aliases WHERE canonical_uuid = ${uuid}`,
+      );
+      return Number(row?.n ?? 0);
+    };
+
     try {
-      await db.transaction(async (transaction) => {
-        const tx = transaction as unknown as typeof db;
+      // --- Happy path: one new canonical, its holds, its self-alias, and the
+      // denormalized columns the last in-transaction step fills in. ---
+      await flushKilterLayoutBatch(
+        db,
+        [fakeClimb(happyUuid, 'Issue 3538 happy path')],
+        HOLD_IDS.map((holdId) => ({
+          boardType: 'kilter',
+          climbUuid: happyUuid,
+          holdId,
+          frameNumber: 1,
+          holdState: 'ON',
+        })),
+        [{ boardType: 'kilter', aliasUuid: happyUuid, canonicalUuid: happyUuid, source: 'kilter' }],
+      );
+      expect(await climbCount(happyUuid)).toBe(1);
+      expect(await holdCount(happyUuid)).toBe(HOLD_IDS.length);
+      expect(await aliasCount(happyUuid)).toBe(1);
 
-        const climbCount = async (uuid: string): Promise<number> => {
-          const [row] = await executeRows<{ n: number | string }>(
-            tx,
-            sql`SELECT count(*)::int AS n FROM board_climbs WHERE uuid = ${uuid}`,
-          );
-          return Number(row?.n ?? 0);
-        };
-        const holdCount = async (uuid: string): Promise<number> => {
-          const [row] = await executeRows<{ n: number | string }>(
-            tx,
-            sql`SELECT count(*)::int AS n FROM board_climb_holds WHERE climb_uuid = ${uuid}`,
-          );
-          return Number(row?.n ?? 0);
-        };
-        const aliasCount = async (uuid: string): Promise<number> => {
-          const [row] = await executeRows<{ n: number | string }>(
-            tx,
-            sql`SELECT count(*)::int AS n FROM board_climb_aliases WHERE canonical_uuid = ${uuid}`,
-          );
-          return Number(row?.n ?? 0);
-        };
+      // The other half of the #3538 symptom: a stranded climb also has NULL
+      // required_set_ids, so board filtering silently drops it. Assert the
+      // denormalized step really ran inside the same flush.
+      const [denorm] = await executeRows<{ requiredSetIds: number[] | null; edgeLeft: number | null }>(
+        db,
+        sql`SELECT required_set_ids AS "requiredSetIds", edge_left AS "edgeLeft"
+            FROM board_climbs WHERE uuid = ${happyUuid}`,
+      );
+      expect(denorm?.requiredSetIds).not.toBeNull();
+      expect(denorm?.requiredSetIds?.length).toBeGreaterThan(0);
+      expect(denorm?.edgeLeft).not.toBeNull();
 
-        // --- Happy path: one new canonical, one hold, one self-alias. ---
+      // --- Atomicity path: the holds insert references a climb uuid that was
+      // never inserted anywhere (not this batch, not previously), so
+      // board_climb_holds_climb_fk rejects it with a real FK violation —
+      // naturally simulating a mid-flush abort. ---
+      let sawExpectedFailure = false;
+      try {
         await flushKilterLayoutBatch(
-          tx,
-          [fakeClimb(happyUuid, 'Issue 3538 happy path')],
-          [{ boardType: 'kilter', climbUuid: happyUuid, holdId: 1000, frameNumber: 1, holdState: 'ON' }],
-          [{ boardType: 'kilter', aliasUuid: happyUuid, canonicalUuid: happyUuid, source: 'kilter' }],
+          db,
+          [fakeClimb(abortUuid, 'Issue 3538 abort path')],
+          [
+            {
+              boardType: 'kilter',
+              climbUuid: missingHoldClimbUuid,
+              holdId: HOLD_IDS[0],
+              frameNumber: 1,
+              holdState: 'ON',
+            },
+          ],
+          [{ boardType: 'kilter', aliasUuid: abortUuid, canonicalUuid: abortUuid, source: 'kilter' }],
         );
-        expect(await climbCount(happyUuid)).toBe(1);
-        expect(await holdCount(happyUuid)).toBe(1);
-        expect(await aliasCount(happyUuid)).toBe(1);
-
-        // --- Atomicity path: the holds insert references a climb uuid that
-        // was never inserted anywhere (not this batch, not previously) —
-        // board_climb_holds_climb_fk rejects it with a real FK violation,
-        // naturally simulating a mid-flush abort. Pre-fix (separate
-        // autocommit statements) the climb row below would have landed
-        // alone, exactly reproducing #3538. Post-fix, the whole batch must
-        // roll back together.
-        let sawExpectedFailure = false;
-        try {
-          await flushKilterLayoutBatch(
-            tx,
-            [fakeClimb(abortUuid, 'Issue 3538 abort path')],
-            [{ boardType: 'kilter', climbUuid: missingHoldClimbUuid, holdId: 1000, frameNumber: 1, holdState: 'ON' }],
-            [{ boardType: 'kilter', aliasUuid: abortUuid, canonicalUuid: abortUuid, source: 'kilter' }],
-          );
-        } catch {
-          sawExpectedFailure = true;
-        }
-        expect(sawExpectedFailure).toBe(true);
-
-        // Load-bearing assertion: the climb row for the aborted batch must
-        // NOT exist. If flushKilterLayoutBatch reverts to separate awaited
-        // statements, this fails (the climb row lands, orphaned).
-        expect(await climbCount(abortUuid)).toBe(0);
-        expect(await aliasCount(abortUuid)).toBe(0);
-
-        // The earlier, unrelated happy-path batch is untouched by the
-        // aborted one — confirms the rollback is scoped to its own batch,
-        // not the whole test transaction (that's the outer fixture's job).
-        expect(await climbCount(happyUuid)).toBe(1);
-
-        throw rollback;
-      });
-    } catch (error: unknown) {
-      if (error !== rollback) {
-        throw error;
+      } catch {
+        sawExpectedFailure = true;
       }
+      expect(sawExpectedFailure).toBe(true);
+
+      // Load-bearing assertion, and the exact #3538 mechanism: on this
+      // autocommit connection the climbs insert commits on its own unless the
+      // flush wraps the batch in a transaction. Revert `flushKilterLayoutBatch`
+      // to separate awaited statements and this reads 1 — a climb row with
+      // is_listed=true, a hold_fingerprint, zero holds and NULL
+      // required_set_ids, which no later cycle ever repairs.
+      expect(await climbCount(abortUuid)).toBe(0);
+      expect(await holdCount(abortUuid)).toBe(0);
+      expect(await aliasCount(abortUuid)).toBe(0);
+
+      // The earlier, already-committed happy-path batch is untouched by the
+      // aborted one — the rollback is scoped to its own batch.
+      expect(await climbCount(happyUuid)).toBe(1);
+      expect(await holdCount(happyUuid)).toBe(HOLD_IDS.length);
     } finally {
+      // Runs on assertion failure too, so a red test still leaves the dev DB
+      // clean. Holds/aliases would cascade from board_climbs, but delete them
+      // explicitly so a partially-committed pre-fix state is cleaned as well.
+      const tagPrefix = `${tag}-%`;
+      await db.execute(sql`DELETE FROM board_climb_holds WHERE climb_uuid LIKE ${tagPrefix}`);
+      await db.execute(sql`DELETE FROM board_climb_aliases WHERE alias_uuid LIKE ${tagPrefix}`);
+      await db.execute(sql`DELETE FROM board_climbs WHERE uuid LIKE ${tagPrefix}`);
       await closePool();
     }
   }, 20_000);

--- a/packages/kilter-sync/src/sync/catalog-sync.transaction.integration.test.ts
+++ b/packages/kilter-sync/src/sync/catalog-sync.transaction.integration.test.ts
@@ -1,0 +1,167 @@
+// Integration test for issue #3538: a per-Grips-layout catalog flush
+// (climbs + holds + aliases + denormalized columns) must be atomic.
+//
+// Before the fix, `syncBoardLayoutGroup` ran these four steps as separate
+// autocommit statement groups. A process kill (SIGKILL on deploy, OOM, crash)
+// between the climbs insert and any later step left a `board_climbs` row
+// committed (is_listed=true, hold_fingerprint set) with no
+// `board_climb_holds` rows and NULL required_set_ids/compatible_size_ids —
+// and the next cycle's UUID-identity short-circuit matches it by uuid and
+// skips hold/fingerprint re-derivation forever (no self-heal).
+//
+// This test drives the real `flushKilterLayoutBatch` against a migrated
+// Postgres (the dev DB). It self-skips when DATABASE_URL is not a local
+// database, and runs entirely inside an outer transaction that always
+// rolls back, so it never leaves rows behind. Run locally with:
+//
+//   DATABASE_URL=postgres://…@localhost:5432/… VITEST_POOL_ID=solo-issue3538 \
+//     vp test run --reporter=agent packages/kilter-sync/src/sync/catalog-sync.transaction.integration.test.ts
+
+import { describe, it, expect } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { createDb, closePool, executeRows } from '@boardsesh/db/client';
+import type { NewBoardClimb } from '@boardsesh/db/schema';
+import { flushKilterLayoutBatch } from './catalog-sync';
+
+function localDatabaseUrl(): string | null {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    return null;
+  }
+  const hostname = new URL(databaseUrl).hostname.toLowerCase();
+  return ['localhost', '127.0.0.1', 'postgres'].includes(hostname) ? databaseUrl : null;
+}
+
+const describeIntegration = localDatabaseUrl() ? describe : describe.skip;
+
+// A fake board_layout id — board_climbs has no FK to board_layouts, so any
+// integer works here without needing a real layout fixture.
+const FAKE_LAYOUT_ID = -3538;
+
+function fakeClimb(uuid: string, name: string): NewBoardClimb {
+  return {
+    uuid,
+    boardType: 'kilter',
+    layoutId: FAKE_LAYOUT_ID,
+    setterId: null,
+    setterUsername: 'issue-3538-tester',
+    name,
+    description: '',
+    characteristics: null,
+    edgeLeft: null,
+    edgeRight: null,
+    edgeBottom: null,
+    edgeTop: null,
+    framesCount: 1,
+    framesPace: 0,
+    frames: `p1000r12`,
+    isDraft: false,
+    isListed: true,
+    createdAt: new Date().toISOString(),
+    holdFingerprint: `fp-${uuid}`,
+  };
+}
+
+describeIntegration('Kilter catalog layout flush is atomic (issue #3538)', () => {
+  it('lands climbs+holds+aliases together, and rolls back the whole batch on a mid-flush failure', async (testContext) => {
+    const db = createDb();
+
+    try {
+      const [schema] = await executeRows<{ climbsTable: string | null }>(
+        db,
+        sql`SELECT to_regclass('public.board_climbs')::text AS "climbsTable"`,
+      );
+      if (!schema?.climbsTable) {
+        testContext.skip();
+        return;
+      }
+    } catch {
+      testContext.skip();
+      return;
+    }
+
+    const tag = `3538-${Date.now()}`;
+    const happyUuid = `${tag}-happy`;
+    const abortUuid = `${tag}-abort`;
+    const missingHoldClimbUuid = `${tag}-never-inserted`;
+
+    const rollback = new Error('rollback issue-3538 integration fixture');
+    try {
+      await db.transaction(async (transaction) => {
+        const tx = transaction as unknown as typeof db;
+
+        const climbCount = async (uuid: string): Promise<number> => {
+          const [row] = await executeRows<{ n: number | string }>(
+            tx,
+            sql`SELECT count(*)::int AS n FROM board_climbs WHERE uuid = ${uuid}`,
+          );
+          return Number(row?.n ?? 0);
+        };
+        const holdCount = async (uuid: string): Promise<number> => {
+          const [row] = await executeRows<{ n: number | string }>(
+            tx,
+            sql`SELECT count(*)::int AS n FROM board_climb_holds WHERE climb_uuid = ${uuid}`,
+          );
+          return Number(row?.n ?? 0);
+        };
+        const aliasCount = async (uuid: string): Promise<number> => {
+          const [row] = await executeRows<{ n: number | string }>(
+            tx,
+            sql`SELECT count(*)::int AS n FROM board_climb_aliases WHERE canonical_uuid = ${uuid}`,
+          );
+          return Number(row?.n ?? 0);
+        };
+
+        // --- Happy path: one new canonical, one hold, one self-alias. ---
+        await flushKilterLayoutBatch(
+          tx,
+          [fakeClimb(happyUuid, 'Issue 3538 happy path')],
+          [{ boardType: 'kilter', climbUuid: happyUuid, holdId: 1000, frameNumber: 1, holdState: 'ON' }],
+          [{ boardType: 'kilter', aliasUuid: happyUuid, canonicalUuid: happyUuid, source: 'kilter' }],
+        );
+        expect(await climbCount(happyUuid)).toBe(1);
+        expect(await holdCount(happyUuid)).toBe(1);
+        expect(await aliasCount(happyUuid)).toBe(1);
+
+        // --- Atomicity path: the holds insert references a climb uuid that
+        // was never inserted anywhere (not this batch, not previously) —
+        // board_climb_holds_climb_fk rejects it with a real FK violation,
+        // naturally simulating a mid-flush abort. Pre-fix (separate
+        // autocommit statements) the climb row below would have landed
+        // alone, exactly reproducing #3538. Post-fix, the whole batch must
+        // roll back together.
+        let sawExpectedFailure = false;
+        try {
+          await flushKilterLayoutBatch(
+            tx,
+            [fakeClimb(abortUuid, 'Issue 3538 abort path')],
+            [{ boardType: 'kilter', climbUuid: missingHoldClimbUuid, holdId: 1000, frameNumber: 1, holdState: 'ON' }],
+            [{ boardType: 'kilter', aliasUuid: abortUuid, canonicalUuid: abortUuid, source: 'kilter' }],
+          );
+        } catch {
+          sawExpectedFailure = true;
+        }
+        expect(sawExpectedFailure).toBe(true);
+
+        // Load-bearing assertion: the climb row for the aborted batch must
+        // NOT exist. If flushKilterLayoutBatch reverts to separate awaited
+        // statements, this fails (the climb row lands, orphaned).
+        expect(await climbCount(abortUuid)).toBe(0);
+        expect(await aliasCount(abortUuid)).toBe(0);
+
+        // The earlier, unrelated happy-path batch is untouched by the
+        // aborted one — confirms the rollback is scoped to its own batch,
+        // not the whole test transaction (that's the outer fixture's job).
+        expect(await climbCount(happyUuid)).toBe(1);
+
+        throw rollback;
+      });
+    } catch (error: unknown) {
+      if (error !== rollback) {
+        throw error;
+      }
+    } finally {
+      await closePool();
+    }
+  }, 20_000);
+});

--- a/packages/kilter-sync/src/sync/catalog-sync.ts
+++ b/packages/kilter-sync/src/sync/catalog-sync.ts
@@ -298,14 +298,11 @@ export function foldCatalogStatOnce(
   return true;
 }
 
-type NewHoldRow = {
-  boardType: string;
-  climbUuid: string;
-  holdId: number;
-  frameNumber: number;
-  holdState: string;
-};
-type NewAliasRow = { boardType: string; aliasUuid: string; canonicalUuid: string; source: string };
+// Derived from the schema (not hand-written) so a column added to or widened on
+// board_climb_holds / board_climb_aliases is a compile error at this API
+// boundary instead of silent drift — matching how NewBoardClimb is imported.
+type NewHoldRow = typeof boardClimbHolds.$inferInsert;
+type NewAliasRow = typeof boardClimbAliases.$inferInsert;
 
 /**
  * Flush one Grips layout's new-canonical batch (climbs + holds + aliases +
@@ -324,6 +321,17 @@ type NewAliasRow = { boardType: string; aliasUuid: string; canonicalUuid: string
  *
  * Mirrors the pattern already used by aurora-sync's shared-sync.ts (`db.transaction`
  * passing `tx` into every per-table upsert helper, no cast needed).
+ *
+ * Scope trade-off: the transaction spans a whole Grips layout, not a
+ * `processBatches` chunk (`BATCH` caps each statement, not the transaction). In
+ * steady state `newClimbInserts` is ~0 so this costs nothing. On a first bulk
+ * ingest or a large decoder-backlog recovery it can hold tens of thousands of
+ * `board_climbs` rows (and ~10x that in holds) plus the three
+ * `populateDenormalizedColumns` UPDATEs open in one transaction: a bigger
+ * snapshot, and a failure near the end retries the whole layout next cycle
+ * instead of keeping partial progress. That is the deliberate price of the
+ * all-or-nothing guarantee — a partially-flushed layout is unrecoverable
+ * (see the UUID short-circuit above), a retried one is not.
  */
 export async function flushKilterLayoutBatch(
   db: DrizzleDb,

--- a/packages/kilter-sync/src/sync/catalog-sync.ts
+++ b/packages/kilter-sync/src/sync/catalog-sync.ts
@@ -301,8 +301,8 @@ export function foldCatalogStatOnce(
 // Derived from the schema (not hand-written) so a column added to or widened on
 // board_climb_holds / board_climb_aliases is a compile error at this API
 // boundary instead of silent drift — matching how NewBoardClimb is imported.
-type NewHoldRow = typeof boardClimbHolds.$inferInsert;
-type NewAliasRow = typeof boardClimbAliases.$inferInsert;
+export type NewHoldRow = typeof boardClimbHolds.$inferInsert;
+export type NewAliasRow = typeof boardClimbAliases.$inferInsert;
 
 /**
  * Flush one Grips layout's new-canonical batch (climbs + holds + aliases +

--- a/packages/kilter-sync/src/sync/catalog-sync.ts
+++ b/packages/kilter-sync/src/sync/catalog-sync.ts
@@ -298,6 +298,98 @@ export function foldCatalogStatOnce(
   return true;
 }
 
+type NewHoldRow = {
+  boardType: string;
+  climbUuid: string;
+  holdId: number;
+  frameNumber: number;
+  holdState: string;
+};
+type NewAliasRow = { boardType: string; aliasUuid: string; canonicalUuid: string; source: string };
+
+/**
+ * Flush one Grips layout's new-canonical batch (climbs + holds + aliases +
+ * denormalized columns) as a single atomic unit.
+ *
+ * Prior to #3538 these four steps ran as separate autocommit statement
+ * groups. A process kill between the climbs insert and any later step left
+ * `board_climbs` rows committed (is_listed=true, hold_fingerprint set) with
+ * no `board_climb_holds` rows and NULL `required_set_ids`/`compatible_size_ids`.
+ * Worse, the next cycle's UUID-identity short-circuit in `syncBoardLayoutGroup`
+ * matches these stranded rows by uuid and skips all hold/fingerprint
+ * re-derivation forever — there is no self-heal path, so the gap is permanent
+ * per affected climb. Wrapping the whole flush in one `db.transaction` makes
+ * it all-or-nothing: either every row for this batch lands, or none does and
+ * the climb is re-attempted (and re-derived from scratch) on the next cycle.
+ *
+ * Mirrors the pattern already used by aurora-sync's shared-sync.ts (`db.transaction`
+ * passing `tx` into every per-table upsert helper, no cast needed).
+ */
+export async function flushKilterLayoutBatch(
+  db: DrizzleDb,
+  newClimbInserts: NewBoardClimb[],
+  newHoldRows: NewHoldRow[],
+  aliasRows: NewAliasRow[],
+): Promise<void> {
+  if (newClimbInserts.length === 0 && newHoldRows.length === 0 && aliasRows.length === 0) return;
+
+  await db.transaction(async (tx) => {
+    if (newClimbInserts.length > 0) {
+      await processBatches(newClimbInserts, async (chunk) => {
+        await tx
+          .insert(boardClimbs)
+          .values(chunk)
+          .onConflictDoUpdate({
+            target: [boardClimbs.uuid],
+            // Never overwrite a user-authored climb on a UUID collision — the
+            // catalog sync only owns Kilter-synced rows (user_id IS NULL).
+            setWhere: isNull(boardClimbs.userId),
+            set: {
+              holdFingerprint: sql`COALESCE(${boardClimbs.holdFingerprint}, excluded.hold_fingerprint)`,
+              frames: sql`COALESCE(${boardClimbs.frames}, excluded.frames)`,
+              // Track the latest derived no_match on a re-sync that reaches this
+              // branch (the dedup path normally skips existing UUIDs). Overwrite
+              // (not COALESCE) so a "No match" prefix removed upstream actually
+              // clears the token — matching aurora-sync's excluded.characteristics.
+              //
+              // ASSUMPTION: Kilter/Tension characteristics currently only carry
+              // `no_match`; method tags are MoonBoard-only. A blind overwrite is
+              // therefore safe — the incoming value is either ['no_match'] or null,
+              // and we want null to clear a stale token. If Kilter ever gains its
+              // own characteristic tokens (e.g. board-specific flags), switch this
+              // to a merge expression (e.g. array_cat + dedup) so that tokens not
+              // managed by this sync path aren't silently dropped.
+              characteristics: sql`excluded.characteristics`,
+            },
+          });
+      });
+    }
+    if (newHoldRows.length > 0) {
+      await processBatches(newHoldRows, async (chunk) => {
+        await tx.insert(boardClimbHolds).values(chunk).onConflictDoNothing();
+      });
+    }
+    if (aliasRows.length > 0) {
+      await processBatches(aliasRows, async (chunk) => {
+        await tx
+          .insert(boardClimbAliases)
+          .values(chunk)
+          .onConflictDoUpdate({
+            target: [boardClimbAliases.boardType, boardClimbAliases.aliasUuid],
+            set: { lastSeenAt: sql`now()`, source: sql`excluded.source` },
+          });
+      });
+    }
+    if (newClimbInserts.length > 0) {
+      await populateDenormalizedColumns(
+        tx,
+        KILTER,
+        newClimbInserts.map((climb) => climb.uuid),
+      );
+    }
+  });
+}
+
 /**
  * Sync every Grips layout that maps to one board_layouts.id. Existing climbs
  * for the layout are loaded once (uuid identity + fingerprint maps) so dedup is
@@ -518,61 +610,13 @@ async function syncBoardLayoutGroup(
 
     // Flush this Grips layout. Order matters: climbs before holds (FK) before
     // aliases (canonical FK). Stats are deferred to the group-level pass.
-    if (newClimbInserts.length > 0) {
-      await processBatches(newClimbInserts, async (chunk) => {
-        await db
-          .insert(boardClimbs)
-          .values(chunk)
-          .onConflictDoUpdate({
-            target: [boardClimbs.uuid],
-            // Never overwrite a user-authored climb on a UUID collision — the
-            // catalog sync only owns Kilter-synced rows (user_id IS NULL).
-            setWhere: isNull(boardClimbs.userId),
-            set: {
-              holdFingerprint: sql`COALESCE(${boardClimbs.holdFingerprint}, excluded.hold_fingerprint)`,
-              frames: sql`COALESCE(${boardClimbs.frames}, excluded.frames)`,
-              // Track the latest derived no_match on a re-sync that reaches this
-              // branch (the dedup path normally skips existing UUIDs). Overwrite
-              // (not COALESCE) so a "No match" prefix removed upstream actually
-              // clears the token — matching aurora-sync's excluded.characteristics.
-              //
-              // ASSUMPTION: Kilter/Tension characteristics currently only carry
-              // `no_match`; method tags are MoonBoard-only. A blind overwrite is
-              // therefore safe — the incoming value is either ['no_match'] or null,
-              // and we want null to clear a stale token. If Kilter ever gains its
-              // own characteristic tokens (e.g. board-specific flags), switch this
-              // to a merge expression (e.g. array_cat + dedup) so that tokens not
-              // managed by this sync path aren't silently dropped.
-              characteristics: sql`excluded.characteristics`,
-            },
-          });
-      });
-      result.canonicalsInserted += newClimbInserts.length;
-    }
-    if (newHoldRows.length > 0) {
-      await processBatches(newHoldRows, async (chunk) => {
-        await db.insert(boardClimbHolds).values(chunk).onConflictDoNothing();
-      });
-    }
-    if (aliasRows.length > 0) {
-      await processBatches(aliasRows, async (chunk) => {
-        await db
-          .insert(boardClimbAliases)
-          .values(chunk)
-          .onConflictDoUpdate({
-            target: [boardClimbAliases.boardType, boardClimbAliases.aliasUuid],
-            set: { lastSeenAt: sql`now()`, source: sql`excluded.source` },
-          });
-      });
-      result.aliasesUpserted += aliasRows.length;
-    }
-    if (newClimbInserts.length > 0) {
-      await populateDenormalizedColumns(
-        db,
-        KILTER,
-        newClimbInserts.map((climb) => climb.uuid),
-      );
-    }
+    // The whole flush runs in one transaction — a crash/kill between steps
+    // must never leave a canonical committed without its holds/aliases/denorm
+    // columns (see #3538: a stranded climb matches on UUID identity on every
+    // later run and never gets its holds re-derived).
+    await flushKilterLayoutBatch(db, newClimbInserts, newHoldRows, aliasRows);
+    result.canonicalsInserted += newClimbInserts.length;
+    result.aliasesUpserted += aliasRows.length;
     log(
       `[kilter-catalog] layout ${gripsLayoutUuid}: ${climbs.length} climbs, +${newClimbInserts.length} canonical, +${aliasRows.length} aliases`,
     );


### PR DESCRIPTION
## What & why

The Kilter catalog sync flushes each Grips layout in four steps — insert new canonical `board_climbs`, insert their `board_climb_holds`, upsert `board_climb_aliases`, then fill in the denormalized `required_set_ids` / `compatible_size_ids`. Those four ran as separate autocommit statement groups, so any interruption between them (SIGKILL on deploy, OOM, a network drop mid-flush) committed the climb row on its own.

That partial state is permanent, which is what makes it worth fixing rather than tolerating. The stranded row has `is_listed = true` and a `hold_fingerprint`, so on the next cycle `syncBoardLayoutGroup`'s UUID-identity short-circuit matches it by uuid and skips hold and fingerprint re-derivation entirely. There is no self-heal path: the climb stays in the catalog with zero holds and NULL `required_set_ids` forever — it renders with no holds lit and gets dropped by board/size filtering.

## Root cause (verified)

`flushKilterLayoutBatch` (extracted in this PR from the inline flush in `syncBoardLayoutGroup`) issued its four statement groups directly against `db`. Verified empirically, not just by reading: the new integration test drives the real flush against the dev DB on an autocommit connection and provokes a genuine FK violation in the holds step. With the fix reverted, the aborted batch's climb row is still present afterwards — `expect(await climbCount(abortUuid)).toBe(0)` reads `1`. That is the orphan from the issue, reproduced.

## Fix

`packages/kilter-sync/src/sync/catalog-sync.ts` — wrap the whole per-layout flush in one `db.transaction`, passing `tx` into every insert and into `populateDenormalizedColumns`. All-or-nothing: either every row for the batch lands, or none does and the layout is re-attempted (and re-derived from scratch) next cycle. Mirrors the pattern aurora-sync's `shared-sync.ts` already uses.

Deliberate trade-off, documented in the function's doc comment: the transaction spans a whole Grips layout, not a `processBatches` chunk (`BATCH = 1000` caps each *statement*, not the transaction). Steady state inserts ~0 new canonicals so this is free. A first bulk ingest or a large decoder-backlog recovery will hold tens of thousands of rows open in one transaction and, on a late failure, retry the whole layout. That is the price of the guarantee — a partially-flushed layout is unrecoverable, a retried one is not.

No schema change, so no migration.

## Tests

`packages/kilter-sync/src/sync/catalog-sync.transaction.integration.test.ts` — drives the real `flushKilterLayoutBatch` against a migrated Postgres.

- Happy path: climb + holds + self-alias land, **and** `required_set_ids` / `edge_left` are populated (it uses a real kilter `layout_id` so the `board_placements` joins in `populateDenormalizedColumns` actually resolve — with a fake layout id that step is a silent no-op and the denormalized half of the symptom goes uncovered).
- Atomicity path: the holds insert references a climb uuid that exists nowhere, so `board_climb_holds_climb_fk` rejects it — a real mid-flush abort, not a stubbed throw. Asserts the batch's climb, holds and alias are all absent afterwards, and that the earlier committed batch is untouched.

**Fail-on-revert story.** Replacing `await db.transaction(async (tx) => {` with `{ const tx = db;` (body byte-identical) makes the test fail with `expected 1 to be +0` at the `climbCount(abortUuid)` assertion. Restoring it passes again. The test deliberately does **not** run inside an outer rollback fixture — that was an earlier iteration of this test, and it hid the mechanism: the FK error poisoned the fixture transaction (`25P02`) before the load-bearing assertion could run, so it went red for the wrong reason and never observed an orphan. On autocommit it observes the literal stranded row. Every row it writes is tagged with a per-run uuid prefix and deleted in a `finally`, so a red run leaves the dev DB clean too (verified: zero `3538-%` rows in all three tables afterwards).

**This test skips in CI** — it self-skips unless `DATABASE_URL` points at localhost, matching the moonboard-sync precedent. Do not read the green CI check as covering the atomicity guarantee. Run locally with:

```
DATABASE_URL=postgresql://postgres:password@localhost:5432/main \
  vp test run --reporter=agent packages/kilter-sync/src/sync/catalog-sync.transaction.integration.test.ts
```

Also in this PR: `NewHoldRow` / `NewAliasRow` are now derived from the drizzle schema (`typeof boardClimbHolds.$inferInsert`) instead of hand-written structural types, since extracting the flush turned them into a real exported API boundary that could otherwise drift from the tables.

Scoped validation: `vp run typecheck:kilter` clean, `vp check` on both changed files clean, `vp test run --project kilter-sync` → 207 passed / 1 skipped, and the integration test above → 1 passed against the dev DB.

## QA Notes

Daemon-internal; nothing to click. If you want to exercise it, run the kilter catalog sync against a local DB and confirm every newly-inserted `board_climbs` row has matching `board_climb_holds` rows and a non-NULL `required_set_ids`:

```sql
SELECT c.uuid
FROM board_climbs c
LEFT JOIN board_climb_holds h ON h.climb_uuid = c.uuid
WHERE c.board_type = 'kilter' AND c.user_id IS NULL
  AND (h.climb_uuid IS NULL OR c.required_set_ids IS NULL);
```

Note this PR prevents *new* orphans; it does not backfill ones already stranded in production. Repairing existing rows is out of scope and left for a follow-up.

## Release Notes

none

Fixes #3538
