### PR TITLE
fix(mobile): recreate the board-renderer overlay cache dir when the OS reclaims it

### DIFF
--- a/.github/workflows/android-pr-rn.yml
+++ b/.github/workflows/android-pr-rn.yml
@@ -100,16 +100,16 @@ jobs:
       - name: Run local-module unit tests (Robolectric/JUnit)
         working-directory: packages/mobile/android
         # Robolectric/JUnit tests for local Expo modules that ship them:
-        # live-activity (session-presence lifecycle + foreground-service retry)
-        # and memory-trim (Glide trim-level policy). The gradle project path for
-        # an Expo local module is autolinking-derived, so discover it rather
-        # than hardcode.
+        # live-activity (session-presence lifecycle + foreground-service retry),
+        # memory-trim (Glide trim-level policy) and board-renderer (overlay
+        # cache-dir recovery). The gradle project path for an Expo local module
+        # is autolinking-derived, so discover it rather than hardcode.
         run: |
           set -euo pipefail
           # One entry per local module that ships Kotlin unit tests. Adding a
           # module here is the only change needed — each name is discovered
           # and must resolve to exactly one Gradle project.
-          TESTED_MODULES=(live-activity memory-trim)
+          TESTED_MODULES=(live-activity memory-trim board-renderer)
           ALL_PROJECTS=$(./gradlew --no-daemon -q projects)
           for MODULE in "${TESTED_MODULES[@]}"; do
             mapfile -t PROJECTS < <(printf '%s\n' "$ALL_PROJECTS" | sed -n "s/.*Project '\(:[^']*${MODULE}[^']*\)'.*/\1/p")

--- a/packages/mobile/modules/board-renderer/android/build.gradle
+++ b/packages/mobile/modules/board-renderer/android/build.gradle
@@ -42,4 +42,20 @@ android {
       path 'src/main/cpp/CMakeLists.txt'
     }
   }
+
+  testOptions {
+    // CacheDirRecovery logs through android.util.Log on the (tested) retry
+    // path, and the JVM stub android.jar throws on every un-mocked call. The
+    // recovery logic itself is plain java.io.File work, so returning defaults
+    // for the Android stubs is enough — no Robolectric needed.
+    unitTests.returnDefaultValues = true
+  }
+}
+
+dependencies {
+  // JVM unit tests for the cache-dir recovery helper (re-create a reclaimed
+  // overlay cache dir, retry the PNG write once). Run via
+  // :…:testDebugUnitTest from .github/workflows/android-pr-rn.yml; the repo's
+  // `vp` flow has no Kotlin test runner.
+  testImplementation 'junit:junit:4.13.2'
 }

--- a/packages/mobile/modules/board-renderer/android/build.gradle
+++ b/packages/mobile/modules/board-renderer/android/build.gradle
@@ -42,14 +42,6 @@ android {
       path 'src/main/cpp/CMakeLists.txt'
     }
   }
-
-  testOptions {
-    // CacheDirRecovery logs through android.util.Log on the (tested) retry
-    // path, and the JVM stub android.jar throws on every un-mocked call. The
-    // recovery logic itself is plain java.io.File work, so returning defaults
-    // for the Android stubs is enough — no Robolectric needed.
-    unitTests.returnDefaultValues = true
-  }
 }
 
 dependencies {

--- a/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/BoardRendererModule.kt
+++ b/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/BoardRendererModule.kt
@@ -75,11 +75,16 @@ class BoardRendererModule : Module() {
             overlayBitmap.setPremultiplied(true)
             overlayBitmap.copyPixelsFromBuffer(ByteBuffer.wrap(rgbaData))
 
-            FileOutputStream(outputFile).use { outputStream ->
-                val written = overlayBitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
-                if (!written) {
-                    outputFile.delete()
-                    throw Exception("PNG compression failed")
+            // Android can reclaim context.cacheDir mid-session, which deletes
+            // the directory out from under us and makes every later write fail
+            // with FileNotFoundException. Re-create it and try once more.
+            CacheDirRecovery.retryOnceAfterRecreating(cacheDir) {
+                FileOutputStream(outputFile).use { outputStream ->
+                    val written = overlayBitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
+                    if (!written) {
+                        outputFile.delete()
+                        throw Exception("PNG compression failed")
+                    }
                 }
             }
         } finally {

--- a/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/BoardRendererModule.kt
+++ b/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/BoardRendererModule.kt
@@ -78,7 +78,16 @@ class BoardRendererModule : Module() {
             // Android can reclaim context.cacheDir mid-session, which deletes
             // the directory out from under us and makes every later write fail
             // with FileNotFoundException. Re-create it and try once more.
-            CacheDirRecovery.retryOnceAfterRecreating(cacheDir) {
+            CacheDirRecovery.retryOnceAfterRecreating(
+                cacheDir,
+                onRecovered = { writeFailure ->
+                    android.util.Log.w(
+                        "BoardRenderer",
+                        "Cache dir ${cacheDir.absolutePath} was gone; re-created it and retrying the write",
+                        writeFailure
+                    )
+                },
+            ) {
                 FileOutputStream(outputFile).use { outputStream ->
                     val written = overlayBitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
                     if (!written) {

--- a/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/BoardRendererModule.kt
+++ b/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/BoardRendererModule.kt
@@ -81,9 +81,12 @@ class BoardRendererModule : Module() {
             CacheDirRecovery.retryOnceAfterRecreating(
                 cacheDir,
                 onRecovered = { writeFailure ->
+                    // Not claiming the directory *had* vanished: any IOException
+                    // lands here, so an out-of-space failure with the directory
+                    // in place the whole time gets one retry and this line too.
                     android.util.Log.w(
                         "BoardRenderer",
-                        "Cache dir ${cacheDir.absolutePath} was gone; re-created it and retrying the write",
+                        "Overlay write failed; cache dir ${cacheDir.absolutePath} is in place, retrying once",
                         writeFailure
                     )
                 },

--- a/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/CacheDirRecovery.kt
+++ b/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/CacheDirRecovery.kt
@@ -12,27 +12,39 @@ import java.io.IOException
  * hold overlays silently stop drawing until the app is restarted.
  *
  * This re-creates the directory and retries the write exactly once.
+ *
+ * Pure `java.io` on purpose — no Android framework calls — so the JVM unit tests
+ * in `CacheDirRecoveryTest` need neither Robolectric nor a module-wide
+ * `unitTests.returnDefaultValues` escape hatch (which would silently no-op any
+ * Android API a future test touches). The diagnostic log lives at the call site
+ * in [BoardRendererModule], through the `onRecovered` callback.
  */
 object CacheDirRecovery {
     /**
-     * Runs [action]. If it fails with an [IOException] *and* [cacheDir] is
-     * missing, re-creates the directory and runs [action] one more time.
+     * Runs [action]. If it fails with an [IOException] and [cacheDir] is a
+     * directory again afterwards, invokes [onRecovered] and runs [action] one
+     * more time.
      *
-     * `mkdirs()` returns false when the directory already exists, so an
-     * IO failure with the directory still in place (out of disk space, a
-     * read-only volume) propagates immediately instead of being retried —
-     * the retry is bounded to a single extra attempt either way.
+     * The gate is "is the directory there now", not "did *this* call create
+     * it": `mkdirs()` returns false both when the directory is already back
+     * (something else restored it between the failure and here) and when it
+     * can't be created at all, and only the second case should give up. A path
+     * we genuinely can't turn into a directory — read-only volume, a regular
+     * file sitting on the path — rethrows the original failure. That matches
+     * the iOS twin's rule, and the retry is bounded to a single extra attempt
+     * either way, so a persistently broken filesystem still fails fast.
      */
-    fun <T> retryOnceAfterRecreating(cacheDir: File, action: () -> T): T {
+    fun <T> retryOnceAfterRecreating(
+        cacheDir: File,
+        onRecovered: (IOException) -> Unit = {},
+        action: () -> T,
+    ): T {
         return try {
             action()
         } catch (writeFailure: IOException) {
-            if (!cacheDir.mkdirs()) throw writeFailure
-            android.util.Log.w(
-                "BoardRenderer",
-                "Cache dir ${cacheDir.absolutePath} had vanished; re-created it and retrying the write",
-                writeFailure
-            )
+            cacheDir.mkdirs()
+            if (!cacheDir.isDirectory) throw writeFailure
+            onRecovered(writeFailure)
             action()
         }
     }

--- a/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/CacheDirRecovery.kt
+++ b/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/CacheDirRecovery.kt
@@ -1,0 +1,39 @@
+package com.boardsesh.boardrenderer
+
+import java.io.File
+import java.io.IOException
+
+/**
+ * The overlay PNG cache lives under `context.cacheDir`, which Android is free to
+ * reclaim at any time under storage pressure — including while our process is
+ * alive. The directory is created once when [BoardRendererModule.cacheDir] is
+ * first touched, so once the OS deletes it every later write fails with
+ * `FileNotFoundException` (ENOENT on the parent) and the render promise rejects:
+ * hold overlays silently stop drawing until the app is restarted.
+ *
+ * This re-creates the directory and retries the write exactly once.
+ */
+object CacheDirRecovery {
+    /**
+     * Runs [action]. If it fails with an [IOException] *and* [cacheDir] is
+     * missing, re-creates the directory and runs [action] one more time.
+     *
+     * `mkdirs()` returns false when the directory already exists, so an
+     * IO failure with the directory still in place (out of disk space, a
+     * read-only volume) propagates immediately instead of being retried —
+     * the retry is bounded to a single extra attempt either way.
+     */
+    fun <T> retryOnceAfterRecreating(cacheDir: File, action: () -> T): T {
+        return try {
+            action()
+        } catch (writeFailure: IOException) {
+            if (!cacheDir.mkdirs()) throw writeFailure
+            android.util.Log.w(
+                "BoardRenderer",
+                "Cache dir ${cacheDir.absolutePath} had vanished; re-created it and retrying the write",
+                writeFailure
+            )
+            action()
+        }
+    }
+}

--- a/packages/mobile/modules/board-renderer/android/src/test/java/com/boardsesh/boardrenderer/CacheDirRecoveryTest.kt
+++ b/packages/mobile/modules/board-renderer/android/src/test/java/com/boardsesh/boardrenderer/CacheDirRecoveryTest.kt
@@ -1,0 +1,103 @@
+package com.boardsesh.boardrenderer
+
+import java.io.File
+import java.io.FileNotFoundException
+import java.io.FileOutputStream
+import java.io.IOException
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class CacheDirRecoveryTest {
+    private lateinit var cacheDir: File
+
+    @Before
+    fun createCacheDir() {
+        cacheDir = File.createTempFile("board-thumbnails", "").let { placeholder ->
+            placeholder.delete()
+            placeholder.also { it.mkdirs() }
+        }
+    }
+
+    @After
+    fun removeCacheDir() {
+        cacheDir.deleteRecursively()
+    }
+
+    /**
+     * The real failure: the OS reclaimed the cache dir mid-session, so the
+     * first write fails with FileNotFoundException. Reverting the guard makes
+     * that first failure propagate and the PNG never lands.
+     */
+    @Test
+    fun `recreates a reclaimed cache dir and lands the write on the retry`() {
+        val outputFile = File(cacheDir, "climb.png")
+        assertTrue("precondition: dir was reclaimed", cacheDir.deleteRecursively())
+
+        var attempts = 0
+        val writtenPath = CacheDirRecovery.retryOnceAfterRecreating(cacheDir) {
+            attempts++
+            FileOutputStream(outputFile).use { it.write(byteArrayOf(1, 2, 3)) }
+            outputFile.absolutePath
+        }
+
+        assertEquals("write is retried exactly once", 2, attempts)
+        assertTrue("cache dir was re-created", cacheDir.isDirectory)
+        assertEquals(outputFile.absolutePath, writtenPath)
+        assertTrue("PNG landed on disk", outputFile.exists())
+        assertEquals(3, outputFile.length())
+    }
+
+    @Test
+    fun `does not retry when the cache dir is still present`() {
+        var attempts = 0
+
+        val failure = try {
+            CacheDirRecovery.retryOnceAfterRecreating(cacheDir) {
+                attempts++
+                throw IOException("No space left on device")
+            }
+            null
+        } catch (thrown: IOException) {
+            thrown
+        }
+
+        assertEquals("a healthy dir means the failure is not transient", 1, attempts)
+        assertEquals("No space left on device", failure?.message)
+    }
+
+    @Test
+    fun `a second failure propagates instead of looping`() {
+        var attempts = 0
+        assertTrue(cacheDir.deleteRecursively())
+
+        val failure = try {
+            CacheDirRecovery.retryOnceAfterRecreating(cacheDir) {
+                attempts++
+                throw FileNotFoundException("still gone")
+            }
+            null
+        } catch (thrown: FileNotFoundException) {
+            thrown
+        }
+
+        assertEquals("retry is bounded to one extra attempt", 2, attempts)
+        assertEquals("still gone", failure?.message)
+    }
+
+    @Test
+    fun `passes the value through untouched on the happy path`() {
+        var attempts = 0
+        val result = CacheDirRecovery.retryOnceAfterRecreating(cacheDir) {
+            attempts++
+            "file://${cacheDir.absolutePath}/climb.png"
+        }
+
+        assertEquals(1, attempts)
+        assertEquals("file://${cacheDir.absolutePath}/climb.png", result)
+        assertFalse(File(cacheDir, "climb.png").exists())
+    }
+}

--- a/packages/mobile/modules/board-renderer/android/src/test/java/com/boardsesh/boardrenderer/CacheDirRecoveryTest.kt
+++ b/packages/mobile/modules/board-renderer/android/src/test/java/com/boardsesh/boardrenderer/CacheDirRecoveryTest.kt
@@ -7,10 +7,20 @@ import java.io.IOException
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+/**
+ * Covers [CacheDirRecovery] in isolation. The guard's single call site —
+ * `CacheDirRecovery.retryOnceAfterRecreating(cacheDir) { … }` wrapping the
+ * `FileOutputStream` write in `BoardRendererModule.renderOverlay` — is *not*
+ * covered here: exercising it needs a real `Bitmap` (JNI) plus a `Module`
+ * appContext, i.e. a Robolectric harness, which is disproportionate for this
+ * fix. Keep the wrapper at that one write site; deleting it re-opens #3182
+ * without failing anything below.
+ */
 class CacheDirRecoveryTest {
     private lateinit var cacheDir: File
 
@@ -38,7 +48,11 @@ class CacheDirRecoveryTest {
         assertTrue("precondition: dir was reclaimed", cacheDir.deleteRecursively())
 
         var attempts = 0
-        val writtenPath = CacheDirRecovery.retryOnceAfterRecreating(cacheDir) {
+        var recoveredFrom: IOException? = null
+        val writtenPath = CacheDirRecovery.retryOnceAfterRecreating(
+            cacheDir,
+            onRecovered = { writeFailure -> recoveredFrom = writeFailure },
+        ) {
             attempts++
             FileOutputStream(outputFile).use { it.write(byteArrayOf(1, 2, 3)) }
             outputFile.absolutePath
@@ -49,24 +63,63 @@ class CacheDirRecoveryTest {
         assertEquals(outputFile.absolutePath, writtenPath)
         assertTrue("PNG landed on disk", outputFile.exists())
         assertEquals(3, outputFile.length())
+        assertTrue(
+            "the call site gets the original failure to log",
+            recoveredFrom is FileNotFoundException,
+        )
+    }
+
+    /**
+     * The gate is "is the dir there now", not "did we create it": if anything
+     * else restores the directory between the failed write and the catch block,
+     * `mkdirs()` returns false and a did-we-create-it gate would drop the
+     * overlay even though the retry would now succeed.
+     */
+    @Test
+    fun `retries when something else restored the cache dir first`() {
+        val outputFile = File(cacheDir, "climb.png")
+        assertTrue(cacheDir.deleteRecursively())
+
+        var attempts = 0
+        CacheDirRecovery.retryOnceAfterRecreating(cacheDir) {
+            attempts++
+            if (attempts == 1) {
+                // Another actor puts the directory back as our write fails.
+                cacheDir.mkdirs()
+                throw FileNotFoundException("$outputFile (No such file or directory)")
+            }
+            FileOutputStream(outputFile).use { it.write(byteArrayOf(1, 2, 3)) }
+        }
+
+        assertEquals(2, attempts)
+        assertTrue("PNG landed on the retry", outputFile.exists())
     }
 
     @Test
-    fun `does not retry when the cache dir is still present`() {
-        var attempts = 0
+    fun `propagates without retrying when the path cannot be a directory`() {
+        assertTrue(cacheDir.deleteRecursively())
+        // A regular file where the cache dir should be: mkdirs() can never win.
+        FileOutputStream(cacheDir).use { it.write(byteArrayOf(0)) }
 
+        var attempts = 0
+        var recovered = false
         val failure = try {
-            CacheDirRecovery.retryOnceAfterRecreating(cacheDir) {
+            CacheDirRecovery.retryOnceAfterRecreating(
+                cacheDir,
+                onRecovered = { recovered = true },
+            ) {
                 attempts++
-                throw IOException("No space left on device")
+                throw IOException("Not a directory")
             }
             null
         } catch (thrown: IOException) {
             thrown
         }
 
-        assertEquals("a healthy dir means the failure is not transient", 1, attempts)
-        assertEquals("No space left on device", failure?.message)
+        assertEquals("an unusable cache path is not transient", 1, attempts)
+        assertFalse("nothing to log when there was no recovery", recovered)
+        assertEquals("Not a directory", failure?.message)
+        assertTrue(cacheDir.delete())
     }
 
     @Test
@@ -91,7 +144,11 @@ class CacheDirRecoveryTest {
     @Test
     fun `passes the value through untouched on the happy path`() {
         var attempts = 0
-        val result = CacheDirRecovery.retryOnceAfterRecreating(cacheDir) {
+        var recoveredFrom: IOException? = null
+        val result = CacheDirRecovery.retryOnceAfterRecreating(
+            cacheDir,
+            onRecovered = { writeFailure -> recoveredFrom = writeFailure },
+        ) {
             attempts++
             "file://${cacheDir.absolutePath}/climb.png"
         }
@@ -99,5 +156,6 @@ class CacheDirRecoveryTest {
         assertEquals(1, attempts)
         assertEquals("file://${cacheDir.absolutePath}/climb.png", result)
         assertFalse(File(cacheDir, "climb.png").exists())
+        assertNull("no recovery on the hot path", recoveredFrom)
     }
 }

--- a/packages/mobile/modules/board-renderer/ios/BoardRendererModule.swift
+++ b/packages/mobile/modules/board-renderer/ios/BoardRendererModule.swift
@@ -25,6 +25,25 @@ public class BoardRendererModule: Module {
     pruneCacheIfNeeded(maxBytes: BoardRendererModule.cacheCapBytes)
   }()
 
+  /// `Library/Caches` is reclaimable: iOS can delete our cache directory at any
+  /// point under storage pressure, including while the app is running. The
+  /// directory is only created once, when `cacheDir` is first touched, so once
+  /// it's gone every later write throws and hold overlays silently stop drawing
+  /// until the app relaunches. Re-create it and retry the write exactly once.
+  ///
+  /// A failure with the directory still in place (out of disk space, a
+  /// protected volume) propagates immediately rather than being retried.
+  private func retryOnceAfterRecreatingCacheDir<T>(_ action: () throws -> T) throws -> T {
+    do {
+      return try action()
+    } catch {
+      guard !FileManager.default.fileExists(atPath: cacheDir.path) else { throw error }
+      NSLog("[BoardRenderer] Cache dir at \(cacheDir.path) had vanished; re-creating and retrying")
+      try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+      return try action()
+    }
+  }
+
   private func pruneCacheIfNeeded(maxBytes: Int) {
     // Sort by modificationDate (not contentAccessDate) because that's what
     // we can reliably bump on a cache hit via setAttributes(.modificationDate:).
@@ -139,7 +158,9 @@ public class BoardRendererModule: Module {
         userInfo: [NSLocalizedDescriptionKey: "PNG encoding failed"])
     }
 
-    try pngData.write(to: outputUrl)
+    try retryOnceAfterRecreatingCacheDir {
+      try pngData.write(to: outputUrl)
+    }
     return outputUrl.absoluteString
   }
 

--- a/packages/mobile/modules/board-renderer/ios/BoardRendererModule.swift
+++ b/packages/mobile/modules/board-renderer/ios/BoardRendererModule.swift
@@ -48,7 +48,10 @@ public class BoardRendererModule: Module {
       guard FileManager.default.fileExists(atPath: cacheDir.path, isDirectory: &isDirectory),
         isDirectory.boolValue
       else { throw error }
-      NSLog("[BoardRenderer] Cache dir at \(cacheDir.path) was gone; re-created it and retrying the write")
+      // Deliberately not claiming the directory *had* vanished: `catch` here
+      // covers every thrown error, so a permissions or out-of-space failure
+      // reaches this line too, with the directory in place the whole time.
+      NSLog("[BoardRenderer] Overlay write failed (\(error)); cache dir at \(cacheDir.path) is in place, retrying once")
       return try action()
     }
   }

--- a/packages/mobile/modules/board-renderer/ios/BoardRendererModule.swift
+++ b/packages/mobile/modules/board-renderer/ios/BoardRendererModule.swift
@@ -31,15 +31,24 @@ public class BoardRendererModule: Module {
   /// it's gone every later write throws and hold overlays silently stop drawing
   /// until the app relaunches. Re-create it and retry the write exactly once.
   ///
-  /// A failure with the directory still in place (out of disk space, a
-  /// protected volume) propagates immediately rather than being retried.
+  /// The gate is "is the directory there now" — same rule as the Android twin
+  /// in `CacheDirRecovery`. A path we can't turn into a directory (protected or
+  /// read-only volume) rethrows the original error, and the retry is bounded to
+  /// a single extra attempt, so a persistently broken filesystem still fails
+  /// fast instead of looping.
   private func retryOnceAfterRecreatingCacheDir<T>(_ action: () throws -> T) throws -> T {
     do {
       return try action()
     } catch {
-      guard !FileManager.default.fileExists(atPath: cacheDir.path) else { throw error }
-      NSLog("[BoardRenderer] Cache dir at \(cacheDir.path) had vanished; re-creating and retrying")
-      try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+      // `withIntermediateDirectories: true` is a no-op when the directory is
+      // already back, so this covers both "we restored it" and "something else
+      // restored it first".
+      try? FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+      var isDirectory: ObjCBool = false
+      guard FileManager.default.fileExists(atPath: cacheDir.path, isDirectory: &isDirectory),
+        isDirectory.boolValue
+      else { throw error }
+      NSLog("[BoardRenderer] Cache dir at \(cacheDir.path) was gone; re-created it and retrying the write")
       return try action()
     }
   }


### PR DESCRIPTION
## What & why

The native board renderer writes each climb's hold overlay to a PNG cache dir —
`<context.cacheDir>/board-thumbnails` on Android, `Library/Caches/board-thumbnails`
on iOS. Both platforms treat that directory as reclaimable storage and can delete
it at any time, including while our process is alive.

Both renderers created the directory exactly once per process (Kotlin
`private val cacheDir: File by lazy { … also { it.mkdirs() } }`, Swift
`private lazy var cacheDir` with a one-shot `createDirectory`) and never
re-checked it before a write. Once the OS reclaimed it, every later write threw
(`FileNotFoundException` / ENOENT on Android, a Cocoa write error on iOS), the
render promise rejected, and hold overlays silently stopped drawing — board
backgrounds still rendered, so there was no crash and no visible error, just
climbs with no holds marked. It self-healed only on the next app launch, when the
lazy initialiser ran again.

**Severity, honestly:** this is the P3 hardening the issue asks for, not a
demonstrated production outage. The evidence on #3182 is one Samsung dev/tester
device, 1 user across 8 sessions in an 18-minute window on 2026-06-23, running a
local Metro dev bundle. The code defect is real and cheap to close; the user
impact is unquantified.

## Verified root cause

Read against `origin/main` (fc06d498f):

- `BoardRendererModule.kt` — `cacheDir` created once at lines 11-15; the write at
  line 78 (`FileOutputStream(outputFile).use { … }`) had no guard.
- `BoardRendererModule.swift` — `cacheDir` created once at lines 11-20; the write
  at line 142 (`try pngData.write(to: outputUrl)`) had no guard.

## The fix

A single bounded recover-and-retry around the write on each platform:

- **Android** — new `CacheDirRecovery.retryOnceAfterRecreating(cacheDir) { … }`.
  On an `IOException` it calls `cacheDir.mkdirs()` and retries once if the path
  is a directory afterwards.
- **iOS** — `retryOnceAfterRecreatingCacheDir { … }` mirrors it exactly:
  `createDirectory(withIntermediateDirectories: true)`, then retry if the path
  is a directory, otherwise rethrow the original error.

Both are no-ops on the hot path (directory present ⇒ nothing extra runs), and the
retry is bounded to exactly one extra attempt, so a persistently broken
filesystem still fails fast rather than looping.

The gate is deliberately "is the directory there now", not "did _this_ call
create it". `mkdirs()` returns false both when the directory is already back and
when it can't be created at all, so a did-we-create-it gate drops the recovery
whenever anything else restores the directory between the failed write and the
catch block — and would leave the two platforms implementing different rules.
Today the module's calls serialise on Expo's single `modulesQueue`, so that race
isn't reachable from JS; it's a trap armed for whoever adds a second caller. A
path we genuinely can't turn into a directory (read-only volume, a regular file
in the way) still rethrows on the first attempt.

## Tests & fail-on-revert

`CacheDirRecoveryTest.kt` (plain JUnit, no Robolectric — matches
`MemoryTrimPolicyTest`) drives the helper against a real temp directory:

- delete the dir, then run an action that fails with `FileNotFoundException`
  while the dir is gone and writes a file once it's back — asserts the dir was
  re-created, the file landed, the action ran exactly twice, and the call site
  got the original failure to log;
- dir deleted but restored by _someone else_ while the first write fails —
  asserts the retry still happens and the PNG lands (the race above);
- a regular file sitting on the cache path — asserts one attempt only, original
  failure propagates, no recovery callback;
- dir gone + action that always throws — asserts exactly two attempts, second
  failure propagates;
- happy path passes the value through with one attempt and never fires the
  callback.

Fail-on-revert, run rather than reasoned about (kotlinc 2.1.20 + JUnit 4.13.2
against the files in this branch):

- replace the helper body with a bare `return action()` (the pre-fix
  behaviour) → `Tests run: 5, Failures: 3` — the reclaimed-dir test fails with
  the exact production symptom, `FileNotFoundException: …/climb.png (No such
file or directory)`;
- use the narrower `if (!cacheDir.mkdirs()) throw writeFailure` gate → the
  restored-by-someone-else test fails;
- restore → `OK (5 tests)`.

**What the tests don't pin:** they exercise the helper, not its wiring. Deleting
the `CacheDirRecovery.retryOnceAfterRecreating(cacheDir) { … }` wrapper from
`BoardRendererModule.renderOverlay` re-opens the bug and still compiles green,
because covering that call site needs a real `Bitmap` (JNI) and a `Module`
appContext — a Robolectric harness that isn't worth it for a P3. That's called
out in the test file's KDoc so the next person doesn't unwrap it.

The helper is deliberately pure `java.io` (the diagnostic `Log.w` moved to the
call site), so the module needs no `unitTests.returnDefaultValues` — which would
have silently no-op'd any Android API a future test in this module touched.

`board-renderer` is added to `TESTED_MODULES` in
`.github/workflows/android-pr-rn.yml`, which is an explicit allowlist — without
that line the test would compile but never run.

**iOS has no automated test here.** Wiring this module into
`scripts/prepare-rn-ios-tests.mjs` would also require linking
`BoardRendererNative.xcframework` into the `BoardseshTests` target, which no
existing entry does — disproportionate scaffolding for a P3 hardening fix. The
iOS half is review-verified plus manual QA below. If a maintainer wants iOS
parity coverage, that's a follow-up.

## Shipping

**Not OTA-able.** This is Kotlin + Swift in a native module, so it can't ride
EAS Update — it lands with the next native store release on both platforms.

Not a Bluetooth change (PNG cache write path only), so the mandatory Fable BLE
review doesn't apply, but it is native code with no OTA safety net.

## QA Notes

Needs a fresh native build (dev-client or store build); an OTA won't carry it.

**Android**

1. Debug build on device/emulator, open a board view so climbs render.
2. With the app still foregrounded:
   `adb shell run-as com.boardsesh.app.dev rm -rf cache/board-thumbnails`
3. Navigate to a climb not yet rendered this session.
4. Expect holds to still draw, with logcat showing
   `BoardRenderer: Overlay write failed; cache dir … is in place, retrying once`.
   Before the fix: background only, no holds.

**iOS**

1. Simulator build, open a board view.
2. Delete `Library/Caches/board-thumbnails` from the app container
   (`xcrun simctl get_app_container booted <bundle id> data`) while running.
3. Navigate to an unrendered climb.
4. Expect holds to still draw and
   `[BoardRenderer] Overlay write failed (…); cache dir … is in place, retrying once` in the
   console.

**Edge cases**

- Normal renders (dir present) unchanged — no extra directory work on the hot
  path, no scroll perf change in the climb list.
- A real write failure with the dir present costs at most one extra attempt and
  then propagates — no retry loop, no swallowed error.
- The 200 MB cache prune still evicts oldest-first afterwards.

## Release Notes

Fixed a rare glitch where hold markers could go missing on a climb if your phone
was low on storage — the app now rebuilds its overlay cache and redraws them.

Fixes #3182
