### PR TITLE
fix(db): keep stats-less climbs past the stats-having boundary

### DIFF
--- a/packages/backend/src/__tests__/climb-queries.test.ts
+++ b/packages/backend/src/__tests__/climb-queries.test.ts
@@ -749,4 +749,110 @@ describe('Climb Query Functions', () => {
       });
     });
   });
+
+  // Issue #1971. The stats-driven search INNER JOINs board_climb_stats, so climbs
+  // with no stats row at the searched angle are invisible to it. It used to fall
+  // back to the unified LEFT JOIN search only on page 0, so a narrow filter went
+  // silent past its last stats-having climb — while countClimbs kept counting the
+  // stats-less ones, leaving the header count higher than the list and firing
+  // "no more climbs" early. This walks a seeded 5-climb result set to exhaustion
+  // against real Postgres, so it can't be satisfied by re-deriving the routing rule.
+  describe('stats-having boundary pagination (#1971)', () => {
+    const PREFIX = 'STATS-BOUNDARY-TEST-';
+    const id = (suffix: string) => PREFIX + suffix;
+    // Dedicated setter so `settername` narrows the search to exactly these climbs.
+    const BOUNDARY_SETTER = 'stats-boundary-setter';
+
+    const boundaryParams: ParsedBoardRouteParameters = {
+      board_name: 'kilter',
+      layout_id: 1,
+      size_id: 7,
+      set_ids: [1],
+      angle: 40,
+    };
+
+    // The order the unified list must come back in under ascents DESC:
+    // stats-having by ascensionist_count DESC NULLS LAST, then stats-less by uuid DESC.
+    const STATS_HAVING = [id('a-ascents-100'), id('b-ascents-50'), id('c-ascents-null')];
+    const STATS_LESS = [id('e-no-stats'), id('d-no-stats')];
+    const ALL_SEEDED = [...STATS_HAVING, ...STATS_LESS];
+
+    const boundarySearch = (page: number): ClimbSearchParams => ({
+      page,
+      pageSize: 2,
+      sortBy: 'ascents',
+      sortOrder: 'desc',
+      settername: [BOUNDARY_SETTER],
+    });
+
+    beforeAll(async () => {
+      await db.execute(sql`
+        INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, frames, frames_count, is_draft, is_listed, edge_left, edge_right, edge_bottom, edge_top, created_at, required_set_ids, compatible_size_ids)
+        VALUES
+          (${id('a-ascents-100')}, 'kilter', 1, ${BOUNDARY_SETTER}, 'Boundary A', 'p600r12', 1, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[1], ARRAY[7]),
+          (${id('b-ascents-50')}, 'kilter', 1, ${BOUNDARY_SETTER}, 'Boundary B', 'p601r12', 1, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[1], ARRAY[7]),
+          (${id('c-ascents-null')}, 'kilter', 1, ${BOUNDARY_SETTER}, 'Boundary C', 'p602r12', 1, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[1], ARRAY[7]),
+          (${id('d-no-stats')}, 'kilter', 1, ${BOUNDARY_SETTER}, 'Boundary D', 'p603r12', 1, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[1], ARRAY[7]),
+          (${id('e-no-stats')}, 'kilter', 1, ${BOUNDARY_SETTER}, 'Boundary E', 'p604r12', 1, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[1], ARRAY[7])
+        ON CONFLICT DO NOTHING
+      `);
+
+      // Only A, B and C have a stats row at angle 40. C's ascensionist_count is NULL
+      // so it sits in the NULLS-LAST tail — the exact spot where the fallback's
+      // ordering could otherwise interleave it with the stats-less climbs.
+      await db.execute(sql`
+        INSERT INTO board_climb_stats (board_type, climb_uuid, angle, display_difficulty, ascensionist_count, difficulty_average, quality_average)
+        VALUES
+          ('kilter', ${id('a-ascents-100')}, 40, 20.0, 100, 20.0, 4.0),
+          ('kilter', ${id('b-ascents-50')}, 40, 20.0, 50, 20.0, 3.0),
+          ('kilter', ${id('c-ascents-null')}, 40, 20.0, NULL, 20.0, NULL)
+        ON CONFLICT DO NOTHING
+      `);
+    });
+
+    afterAll(async () => {
+      await db.execute(sql`DELETE FROM board_climb_stats WHERE climb_uuid LIKE ${PREFIX + '%'}`);
+      await db.execute(sql`DELETE FROM board_climbs WHERE uuid LIKE ${PREFIX + '%'}`);
+    });
+
+    it('pages past the last stats-having climb instead of stopping there', async () => {
+      const collected: string[] = [];
+      let pagesWalked = 0;
+      let hasMore = true;
+      // Bounded so a hasMore that never clears fails loudly instead of hanging.
+      while (hasMore && pagesWalked < 10) {
+        const result = await searchClimbs(boundaryParams, boundarySearch(pagesWalked));
+        collected.push(...result.climbs.map((climb) => climb.uuid));
+        hasMore = result.hasMore;
+        pagesWalked += 1;
+      }
+
+      expect(pagesWalked).toBeLessThan(10);
+      // No climb served twice across the stats-having → stats-less boundary.
+      expect(new Set(collected).size).toBe(collected.length);
+      // Every seeded climb reachable by paging — the regression the issue reports.
+      expect([...collected].sort()).toEqual([...ALL_SEEDED].sort());
+
+      // The header badge and the visible list must finally agree.
+      const totalCount = await countClimbs(boundaryParams, boundarySearch(0));
+      expect(collected.length).toBe(totalCount);
+
+      // Stats-having climbs first, in ascents-DESC order with the NULL count last,
+      // then the stats-less climbs by uuid DESC.
+      expect(collected.slice(0, STATS_HAVING.length)).toEqual(STATS_HAVING);
+      expect(collected.slice(STATS_HAVING.length)).toEqual(STATS_LESS);
+    });
+
+    it('keeps stats filters on the stats-driven path (stats-less climbs stay excluded)', async () => {
+      // minAscents is a stats predicate, so countClimbs excludes stats-less climbs
+      // too — routing this through the fallback would only double the query count
+      // without surfacing anything new.
+      const statsFiltered: ClimbSearchParams = { ...boundarySearch(0), pageSize: 100, minAscents: 1 };
+      const result = await searchClimbs(boundaryParams, statsFiltered);
+      const uuids = result.climbs.map((climb) => climb.uuid).filter((uuid) => uuid.startsWith(PREFIX));
+
+      expect(uuids).toEqual([id('a-ascents-100'), id('b-ascents-50')]);
+      expect(await countClimbs(boundaryParams, statsFiltered)).toBe(2);
+    });
+  });
 });

--- a/packages/backend/src/services/__tests__/search-cache.test.ts
+++ b/packages/backend/src/services/__tests__/search-cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
-import { SearchCacheService, DEFAULT_SEARCH_CACHE_TTL } from '../search-cache';
+import { SearchCacheService, DEFAULT_SEARCH_CACHE_TTL, CACHE_VERSION } from '../search-cache';
 import { redisClientManager } from '../../redis/client';
 import type { ClimbSearchParams, ParsedBoardRouteParameters } from '../../db/queries/climbs/index';
 import { logger } from '../../utils/logger';
@@ -77,7 +77,15 @@ describe('SearchCacheService', () => {
       const key = service.buildCacheKey(makeRouteParams(), {}, 'results');
 
       expect(key).toBeTruthy();
-      expect(key.startsWith('boardsesh:climb-search:v4:results:')).toBe(true);
+      expect(key.startsWith(`boardsesh:climb-search:${CACHE_VERSION}:results:`)).toBe(true);
+    });
+
+    it('pins the current cache version so a bump is a deliberate, reviewed edit', () => {
+      // The one place the version literal is written down in a test. Bumping
+      // CACHE_VERSION must land here too, which is the point: a content-changing
+      // search fix should not silently keep serving stale keys.
+      expect(CACHE_VERSION).toBe('v5');
+      expect(CACHE_VERSION).toMatch(/^v\d+$/);
     });
 
     it('matches expected key format', () => {
@@ -88,7 +96,7 @@ describe('SearchCacheService', () => {
       // boardsesh:climb-search:version:suffix:board:layout:size:sets:angle:hash
       expect(segments[0]).toBe('boardsesh');
       expect(segments[1]).toBe('climb-search');
-      expect(segments[2]).toBe('v4');
+      expect(segments[2]).toBe(CACHE_VERSION);
       expect(segments[3]).toBe('results');
       expect(segments[4]).toBe('kilter');
       expect(segments[5]).toBe('1');

--- a/packages/backend/src/services/search-cache.ts
+++ b/packages/backend/src/services/search-cache.ts
@@ -17,8 +17,11 @@ export const DEFAULT_SEARCH_CACHE_TTL = 86400;
  * of stats-less ones. Without the bump, already-cached truncated pages would keep
  * serving the bug for the full 24h TTL, and an old-ordering page 0 next to a
  * new-ordering page 1 would duplicate or skip rows at the boundary.
+ *
+ * Exported so search-cache.test.ts asserts the key layout against this constant
+ * instead of re-typing the version literal in every assertion.
  */
-const CACHE_VERSION = 'v5';
+export const CACHE_VERSION = 'v5';
 
 /**
  * Recursively sorts the keys of an object so that JSON.stringify produces

--- a/packages/backend/src/services/search-cache.ts
+++ b/packages/backend/src/services/search-cache.ts
@@ -12,8 +12,13 @@ export const DEFAULT_SEARCH_CACHE_TTL = 86400;
  * popular-sort counting NULL frames_count, name ILIKE escaping, zone fail-closed.
  * v4: stars field now maps quality_average (1-5) straight to 0-5 instead of the
  * old x5/x3 0-15 scale (was saturating at 15).
+ * v5: searches past the stats-having boundary now return stats-less climbs
+ * (issue #1971), and the stats-driven fallback orders stats-having climbs ahead
+ * of stats-less ones. Without the bump, already-cached truncated pages would keep
+ * serving the bug for the full 24h TTL, and an old-ordering page 0 next to a
+ * new-ordering page 1 would duplicate or skip rows at the boundary.
  */
-const CACHE_VERSION = 'v4';
+const CACHE_VERSION = 'v5';
 
 /**
  * Recursively sorts the keys of an object so that JSON.stringify produces

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -70,7 +70,7 @@
     "lint-fix": "vp lint --fix",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "bun scripts/migrate.ts",
-    "test": "tsx --test scripts/**/*.test.ts src/**/*.test.ts",
+    "test": "tsx --test 'scripts/**/*.test.ts' 'src/**/*.test.ts'",
     "test:explain": "tsx --test src/queries/climbs/__tests__/search-climbs-explain.integration.test.ts",
     "test:migration-journal": "tsx --test scripts/migration-journal-verification.integration.test.ts",
     "db:verify-journal": "tsx scripts/verify-migration-journal.ts",

--- a/packages/db/src/queries/climbs/__tests__/search-climbs-explain.integration.test.ts
+++ b/packages/db/src/queries/climbs/__tests__/search-climbs-explain.integration.test.ts
@@ -295,6 +295,9 @@ if (!EXPLAIN_DB_URL) {
       );
       assert.deepEqual(kinds, ['guard', 'select', 'guard', 'select']);
 
+      // Smoke test only, and deliberately weak: the harness setter matches zero rows,
+      // so the planner picks a trivial serial plan whatever the GUC says. The
+      // statement-ordering assertion above is what actually guards #1969 / #3856.
       const nodes = await explainNodes(selects[1].query, selects[1].params, GUARD);
       assert.equal(
         hasGatherNode(nodes),

--- a/packages/db/src/queries/climbs/__tests__/search-climbs-explain.integration.test.ts
+++ b/packages/db/src/queries/climbs/__tests__/search-climbs-explain.integration.test.ts
@@ -271,6 +271,39 @@ if (!EXPLAIN_DB_URL) {
       },
     );
 
+    void it('page>0 fallback (#1971) runs SET LOCAL before its SELECT and stays serial', async () => {
+      // A setter nobody has: statsDrivenSearch exhausts its stats-having set
+      // immediately, so page 1 takes the fallback and we get a SECOND select —
+      // the LEFT JOIN query the page-0 gate used to prevent past page 0. The only
+      // invariant that matters here is that it can't allocate parallel-sort DSM
+      // segments (the #1969 / #3856 failure mode). Plan shape beyond that is
+      // statistics-dependent and deliberately not asserted.
+      const statements = await runSearch({
+        page: 1,
+        pageSize: 20,
+        sortBy: 'ascents',
+        sortOrder: 'desc',
+        settername: ['boardsesh-explain-harness-no-such-setter'],
+      });
+      const selects = tableSelects(statements);
+      assert.equal(selects.length, 2, 'an exhausted stats-driven page past page 0 must fall back');
+      assert.ok(/board_climbs/.test(selects[1].query), 'the fallback query is the unified LEFT JOIN');
+
+      // Every SELECT must be immediately preceded by its own SET LOCAL guard.
+      const kinds = statements.map((statement) =>
+        /SET LOCAL max_parallel_workers_per_gather\s*=\s*0/i.test(statement.query) ? 'guard' : 'select',
+      );
+      assert.deepEqual(kinds, ['guard', 'select', 'guard', 'select']);
+
+      const nodes = await explainNodes(selects[1].query, selects[1].params, GUARD);
+      assert.equal(
+        hasGatherNode(nodes),
+        false,
+        'the fallback must not produce a parallel Gather under the SET LOCAL guard',
+      );
+      if (RUN_ANALYZE) await logTiming('#1971 page-1 fallback', selects[1]);
+    });
+
     void it('random sort is deterministic per seed, reshuffles across seeds, and paginates without overlap', async () => {
       const uuidsFor = async (sortSeed: string, page = 0) =>
         (await searchClimbs(db, PARAMS, { page, pageSize: 15, sortBy: 'random', sortSeed })).climbs.map((c) => c.uuid);

--- a/packages/db/src/queries/climbs/__tests__/search-climbs.test.ts
+++ b/packages/db/src/queries/climbs/__tests__/search-climbs.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { PgDialect } from 'drizzle-orm/pg-core';
-import type { SQL } from 'drizzle-orm';
+import { getTableName, is, Table, type SQL } from 'drizzle-orm';
 import { chooseSearchPath, getStatsDrivenSort, clampSearchPage, MAX_SEARCH_PAGE, searchClimbs } from '../search-climbs';
 import { mapSearchInputToParams, normalizeSearchSortBy, type BoardRouteParams } from '../types';
 import type { DbInstance } from '../../../client/postgres';
@@ -11,7 +11,6 @@ const baseInput = {
   isDraftsQuery: false,
   projectsOnly: false,
   routesOnly: false,
-  page: 0,
   hasStatsFilters: false,
 };
 
@@ -52,7 +51,7 @@ void describe('clampSearchPage', () => {
 });
 
 void describe('chooseSearchPath', () => {
-  void describe('the hot path: ascents DESC, page 0, no stats filters', () => {
+  void describe('the hot path: ascents DESC, no stats filters', () => {
     void it('uses stats-driven-with-fallback so projects appear at the bottom of narrow-filter pages', () => {
       assert.equal(chooseSearchPath(baseInput), 'stats-driven-with-fallback');
     });
@@ -64,23 +63,9 @@ void describe('chooseSearchPath', () => {
     });
   });
 
-  void describe('pages > 0', () => {
-    void it('uses stats-driven-only on page 1 — fallback would re-create DSM pressure', () => {
-      assert.equal(chooseSearchPath({ ...baseInput, page: 1 }), 'stats-driven-only');
-    });
-
-    void it('uses stats-driven-only on a deep page', () => {
-      assert.equal(chooseSearchPath({ ...baseInput, page: 47 }), 'stats-driven-only');
-    });
-  });
-
   void describe('stats filters active (e.g. minAscents >= 1)', () => {
-    void it('uses stats-driven-only on page 0 — stats-less climbs would be filtered out anyway', () => {
+    void it('uses stats-driven-only — stats-less climbs would be filtered out anyway', () => {
       assert.equal(chooseSearchPath({ ...baseInput, hasStatsFilters: true }), 'stats-driven-only');
-    });
-
-    void it('uses stats-driven-only on deeper pages with stats filters', () => {
-      assert.equal(chooseSearchPath({ ...baseInput, page: 5, hasStatsFilters: true }), 'stats-driven-only');
     });
   });
 
@@ -97,33 +82,25 @@ void describe('chooseSearchPath', () => {
       assert.equal(chooseSearchPath({ ...baseInput, statsDrivenSort: null }), 'standard-only');
     });
 
-    void it('uses stats-driven-with-fallback for quality DESC page 0', () => {
+    void it('uses stats-driven-with-fallback for quality DESC', () => {
       assert.equal(chooseSearchPath({ ...baseInput, statsDrivenSort: 'quality' }), 'stats-driven-with-fallback');
-    });
-
-    void it('uses stats-driven-only for quality DESC after page 0', () => {
-      assert.equal(chooseSearchPath({ ...baseInput, statsDrivenSort: 'quality', page: 1 }), 'stats-driven-only');
     });
   });
 
   void describe('precedence', () => {
     void it('projectsOnly trumps the hot path', () => {
-      assert.equal(
-        chooseSearchPath({ ...baseInput, projectsOnly: true, page: 0, hasStatsFilters: false }),
-        'standard-only',
-      );
+      assert.equal(chooseSearchPath({ ...baseInput, projectsOnly: true, hasStatsFilters: false }), 'standard-only');
     });
 
     void it('drafts trumps the hot path', () => {
-      assert.equal(chooseSearchPath({ ...baseInput, isDraftsQuery: true, page: 0 }), 'standard-only');
+      assert.equal(chooseSearchPath({ ...baseInput, isDraftsQuery: true }), 'standard-only');
     });
 
-    void it('non-ascents sort trumps page/filter conditions', () => {
+    void it('non-ascents sort trumps the filter conditions', () => {
       assert.equal(
         chooseSearchPath({
           ...baseInput,
           statsDrivenSort: null,
-          page: 0,
           hasStatsFilters: false,
         }),
         'standard-only',
@@ -167,6 +144,40 @@ void describe('normalizeSearchSortBy', () => {
   });
 });
 
+const dialect = new PgDialect();
+const GUARD_PATTERN = /SET LOCAL max_parallel_workers_per_gather\s*=\s*0/i;
+// The stats-presence ORDER BY key the stats-driven fallback prepends (issue #1971).
+const STATS_PRESENCE_KEY_PATTERN = /case when\s+"?board_climb_stats"?\."?climb_uuid"?\s+is null/i;
+
+/** Minimal row shape searchClimbs' row mapper reads; enough to identify a row by uuid. */
+function fakeRow(uuid: string): Record<string, unknown> {
+  return {
+    uuid,
+    setter_username: null,
+    userId: null,
+    name: uuid,
+    frames: null,
+    is_draft: false,
+    angle: 40,
+    ascensionist_count: null,
+    difficulty_id: null,
+    quality_average: null,
+    difficulty_error: null,
+    benchmark_difficulty: null,
+    description: null,
+    characteristics: null,
+    created_at: null,
+    published_at: null,
+    frames_count: 1,
+    frames_pace: null,
+    boardsesh_difficulty: null,
+    boardsesh_confidence: null,
+  };
+}
+
+/** What one SELECT the code under test issued looked like. */
+type RecordedQuery = { table: string | null; orderBy: string[] };
+
 // Fake SearchDb: a minimal stand-in for a top-level Drizzle instance. Every
 // select chain method returns the same builder object, and awaiting it (via a
 // real `.then`) records that the query ran — so a test can assert the query
@@ -174,15 +185,30 @@ void describe('normalizeSearchSortBy', () => {
 // mock in packages/web/app/lib/db/queries/climbs/__tests__/holds-heatmap.test.ts,
 // adapted to node:test (no module mocking needed — searchClimbs takes `db` as
 // a plain parameter).
-function createFakeSearchDb() {
+//
+// Each builder also records the table `from()` was called with and the RENDERED
+// ORDER BY fragments, so a test can assert on the SQL the code actually emitted
+// instead of re-deriving an expectation from the same helpers. `scriptedRows`
+// supplies the rows the Nth select resolves with (default: none).
+function createFakeSearchDb(scriptedRows: Record<string, unknown>[][] = []) {
   const callOrder: string[] = [];
   const executedStatements: SQL[] = [];
+  const queries: RecordedQuery[] = [];
 
   const makeSelectBuilder = () => {
+    const recorded: RecordedQuery = { table: null, orderBy: [] };
     const builder: Record<string, unknown> = {};
-    for (const method of ['from', 'innerJoin', 'leftJoin', 'where', 'orderBy', 'limit', 'offset']) {
+    for (const method of ['innerJoin', 'leftJoin', 'where', 'limit', 'offset']) {
       builder[method] = () => builder;
     }
+    builder.from = (source: unknown) => {
+      recorded.table = is(source, Table) ? getTableName(source) : null;
+      return builder;
+    };
+    builder.orderBy = (...fragments: SQL[]) => {
+      recorded.orderBy = fragments.map((fragment) => dialect.sqlToQuery(fragment).sql);
+      return builder;
+    };
     // A real, spec-compliant thenable so drizzle's internal `await` can't
     // swallow a rejection and so this reliably resolves like a genuine query.
     builder.then = (
@@ -190,7 +216,9 @@ function createFakeSearchDb() {
       onRejected?: ((reason: unknown) => unknown) | null,
     ) => {
       callOrder.push('select');
-      return Promise.resolve([]).then(onFulfilled, onRejected);
+      queries.push(recorded);
+      const rows = scriptedRows[queries.length - 1] ?? [];
+      return Promise.resolve(rows).then(onFulfilled, onRejected);
     };
     return builder;
   };
@@ -208,11 +236,35 @@ function createFakeSearchDb() {
     transaction: (callback: (transactionDb: typeof tx) => unknown) => callback(tx),
   };
 
-  return { fakeDb, callOrder, executedStatements };
+  return { fakeDb, callOrder, executedStatements, queries };
 }
 
-const dialect = new PgDialect();
-const GUARD_PATTERN = /SET LOCAL max_parallel_workers_per_gather\s*=\s*0/i;
+/**
+ * The #3856 regression net, expressed as an invariant rather than a fixed call
+ * list: every SELECT must be immediately preceded by its own SET LOCAL guard, and
+ * every executed statement must BE that guard. Deleting the guard from either
+ * statsDrivenSearch or standardSearch turns this red.
+ */
+function assertEverySelectIsGuarded(callOrder: string[], executedStatements: SQL[]): void {
+  assert.ok(callOrder.length > 0, 'expected at least one statement');
+  assert.equal(callOrder.length % 2, 0, `expected alternating execute/select pairs; saw: ${callOrder.join(', ')}`);
+  for (let index = 0; index < callOrder.length; index += 2) {
+    assert.equal(
+      callOrder[index],
+      'execute',
+      `statement ${index} must be the SET LOCAL guard: ${callOrder.join(', ')}`,
+    );
+    assert.equal(callOrder[index + 1], 'select', `statement ${index + 1} must be the SELECT: ${callOrder.join(', ')}`);
+  }
+  const rendered = executedStatements.map((statement) => dialect.sqlToQuery(statement).sql);
+  assert.equal(rendered.length, callOrder.length / 2, 'every SELECT must have its own executed guard statement');
+  for (const statement of rendered) {
+    assert.ok(
+      GUARD_PATTERN.test(statement),
+      `expected a SET LOCAL max_parallel_workers_per_gather = 0 guard; saw: ${statement}`,
+    );
+  }
+}
 
 const SEARCH_PARAMS: BoardRouteParams = {
   board_name: 'kilter',
@@ -222,14 +274,32 @@ const SEARCH_PARAMS: BoardRouteParams = {
   angle: 40,
 };
 
-void describe('statsDrivenSearch — DSM parallelism guard (#3856)', () => {
+void describe('search queries — DSM parallelism guard (#3856)', () => {
   void it('runs the stats-driven query inside a transaction that disables per-gather parallelism first', async () => {
+    const { fakeDb, callOrder, executedStatements, queries } = createFakeSearchDb();
+
+    // minAscents makes this 'stats-driven-only' (a stats predicate can't be met
+    // through the LEFT JOIN), isolating the assertion to statsDrivenSearch's own
+    // guard — the same shape as the production repro (Sentry BOARDSESH-AK: page 1,
+    // narrow grade band, pageSize 100).
+    await searchClimbs(fakeDb as unknown as DbInstance, SEARCH_PARAMS, {
+      page: 1,
+      pageSize: 100,
+      sortBy: 'ascents',
+      sortOrder: 'desc',
+      minAscents: 1,
+    });
+
+    assert.deepEqual(callOrder, ['execute', 'select'], 'stats filters must keep this on the stats-driven path only');
+    assert.equal(queries[0].table, 'board_climb_stats');
+    assertEverySelectIsGuarded(callOrder, executedStatements);
+  });
+
+  void it('guards both queries when the stats-driven path falls back to the standard search', async () => {
+    // No stats filters + an empty stats-driven page ⇒ the fallback runs too, so
+    // this covers standardSearch's guard (07dfe54b2) in the same walk.
     const { fakeDb, callOrder, executedStatements } = createFakeSearchDb();
 
-    // page:1 forces chooseSearchPath to 'stats-driven-only' (no standardSearch
-    // fallback), isolating this assertion to statsDrivenSearch's own guard —
-    // the same page shape as the production repro (Sentry BOARDSESH-AK: page 1,
-    // narrow grade band, pageSize 100).
     await searchClimbs(fakeDb as unknown as DbInstance, SEARCH_PARAMS, {
       page: 1,
       pageSize: 100,
@@ -237,12 +307,8 @@ void describe('statsDrivenSearch — DSM parallelism guard (#3856)', () => {
       sortOrder: 'desc',
     });
 
-    assert.deepEqual(callOrder, ['execute', 'select'], 'SET LOCAL must run before the stats-driven SELECT');
-    const renderedGuards = executedStatements.map((statement) => dialect.sqlToQuery(statement).sql);
-    assert.ok(
-      renderedGuards.some((statement) => GUARD_PATTERN.test(statement)),
-      `expected a SET LOCAL max_parallel_workers_per_gather = 0 guard; saw: ${renderedGuards.join(', ')}`,
-    );
+    assert.deepEqual(callOrder, ['execute', 'select', 'execute', 'select']);
+    assertEverySelectIsGuarded(callOrder, executedStatements);
   });
 
   void it('also guards the quality-sort stats-driven path', async () => {
@@ -253,13 +319,98 @@ void describe('statsDrivenSearch — DSM parallelism guard (#3856)', () => {
       pageSize: 20,
       sortBy: 'quality',
       sortOrder: 'desc',
+      minRating: 3,
     });
 
-    assert.deepEqual(callOrder, ['execute', 'select'], 'SET LOCAL must run before the stats-driven SELECT');
-    const renderedGuards = executedStatements.map((statement) => dialect.sqlToQuery(statement).sql);
+    assert.deepEqual(callOrder, ['execute', 'select']);
+    assertEverySelectIsGuarded(callOrder, executedStatements);
+  });
+});
+
+void describe('stats-driven fallback past the first page (#1971)', () => {
+  void it('falls back to the LEFT JOIN search on page 2 and returns the fallback query results', async () => {
+    // First select (stats-driven) returns fewer than pageSize+1 rows ⇒ partial page.
+    // Second select (fallback) returns pageSize+1 rows ⇒ trimmed page with hasMore.
+    const { fakeDb, queries } = createFakeSearchDb([
+      [fakeRow('stats-only-1')],
+      [fakeRow('unified-1'), fakeRow('unified-2'), fakeRow('unified-3')],
+    ]);
+
+    const result = await searchClimbs(fakeDb as unknown as DbInstance, SEARCH_PARAMS, {
+      page: 2,
+      pageSize: 2,
+      sortBy: 'ascents',
+      sortOrder: 'desc',
+    });
+
+    assert.equal(queries.length, 2, 'a partial stats-driven page past page 0 must still fall back');
+    assert.equal(queries[0].table, 'board_climb_stats', 'the first query is the stats-driven INNER JOIN');
+    assert.equal(queries[1].table, 'board_climbs', 'the fallback query is the unified LEFT JOIN');
+    assert.deepEqual(
+      result.climbs.map((climb) => climb.uuid),
+      ['unified-1', 'unified-2'],
+      'searchClimbs must return the fallback rows, not the truncated stats-driven ones',
+    );
+    assert.equal(result.hasMore, true, 'hasMore must come from the fallback query');
+  });
+
+  void it('keeps a full stats-driven page as-is (no fallback when the page is not exhausted)', async () => {
+    const { fakeDb, queries } = createFakeSearchDb([[fakeRow('stats-1'), fakeRow('stats-2'), fakeRow('stats-3')]]);
+
+    const result = await searchClimbs(fakeDb as unknown as DbInstance, SEARCH_PARAMS, {
+      page: 2,
+      pageSize: 2,
+      sortBy: 'ascents',
+      sortOrder: 'desc',
+    });
+
+    assert.equal(queries.length, 1, 'a full stats-driven page must not pay for a second query');
+    assert.deepEqual(
+      result.climbs.map((climb) => climb.uuid),
+      ['stats-1', 'stats-2'],
+    );
+    assert.equal(result.hasMore, true);
+  });
+
+  void it('orders stats-having climbs ahead of stats-less ones in the fallback query only', async () => {
+    const { fakeDb, queries } = createFakeSearchDb();
+
+    await searchClimbs(fakeDb as unknown as DbInstance, SEARCH_PARAMS, {
+      page: 2,
+      pageSize: 2,
+      sortBy: 'ascents',
+      sortOrder: 'desc',
+    });
+
+    assert.equal(queries.length, 2);
+    // The stats-driven query INNER JOINs, so every row has a stats row — no key.
     assert.ok(
-      renderedGuards.some((statement) => GUARD_PATTERN.test(statement)),
-      `expected a SET LOCAL max_parallel_workers_per_gather = 0 guard; saw: ${renderedGuards.join(', ')}`,
+      !queries[0].orderBy.some((fragment) => STATS_PRESENCE_KEY_PATTERN.test(fragment)),
+      `stats-driven query must not carry the stats-presence key; saw: ${queries[0].orderBy.join(' | ')}`,
+    );
+    assert.ok(
+      STATS_PRESENCE_KEY_PATTERN.test(queries[1].orderBy[0] ?? ''),
+      `fallback ORDER BY must LEAD with the stats-presence key; saw: ${queries[1].orderBy.join(' | ')}`,
+    );
+  });
+
+  void it('does not add the stats-presence key to a standard-only search', async () => {
+    const { fakeDb, queries } = createFakeSearchDb();
+
+    // 'creation' has no stats-driven index path ⇒ standard-only. Adding the key
+    // here would reorder creation/name/popular and break the random shuffle.
+    await searchClimbs(fakeDb as unknown as DbInstance, SEARCH_PARAMS, {
+      page: 2,
+      pageSize: 2,
+      sortBy: 'creation',
+      sortOrder: 'desc',
+    });
+
+    assert.equal(queries.length, 1);
+    assert.equal(queries[0].table, 'board_climbs');
+    assert.ok(
+      !queries[0].orderBy.some((fragment) => STATS_PRESENCE_KEY_PATTERN.test(fragment)),
+      `standard-only query must not carry the stats-presence key; saw: ${queries[0].orderBy.join(' | ')}`,
     );
   });
 });

--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -193,10 +193,15 @@ export const searchClimbs = async (
   // page-0 gate predates both guards (9acb8b913) and was protecting against a plan
   // shape that is now disabled by GUC — do not re-introduce it.
   //
-  // Cost: the fallback only fires once statsDriven is exhausted, so broad filters
-  // (hasMore=true) never reach it. Narrow filters pay one extra serial query on the
-  // boundary page and two queries per page past it, each bounded by
-  // OFFSET page*pageSize + LIMIT pageSize+1 with page clamped to MAX_SEARCH_PAGE.
+  // Cost: the fallback only fires once statsDriven is exhausted. Broad filters never
+  // reach it at shallow depth (hasMore stays true), but a deep enough page — one whose
+  // OFFSET lands past the stats-having count — reaches it on any filter, bounded by
+  // that filter's selectivity. The extra work is the countClimbs scan shape plus a
+  // top-N heapsort bounded by OFFSET + LIMIT, so per-page cost past the boundary is
+  // roughly constant and equal to today's page-0 fallback cost on the same filter.
+  // `page` is clamped to MAX_SEARCH_PAGE; `pageSize` is caller-supplied and is NOT
+  // clamped here (searchClimbs defaults it to 20), so the OFFSET bound is only as
+  // tight as whatever validates pageSize upstream.
   //
   // `orderStatsHavingFirst: true` makes the fallback's ordering a prefix-compatible
   // continuation of the stats-driven pages — see runStandardSearch.

--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -156,7 +156,7 @@ export const searchClimbs = async (
 
   const hasStatsFilters = filters.getClimbStatsConditions().length > 0;
   if (!statsDrivenSort) {
-    return standardSearch(db, params, searchParams, filters, sortBy, sortOrder, isDraftsQuery, page, pageSize);
+    return standardSearch(db, params, searchParams, filters, sortBy, sortOrder, isDraftsQuery, page, pageSize, false);
   }
 
   const path = chooseSearchPath({
@@ -165,12 +165,11 @@ export const searchClimbs = async (
     projectsOnly: !!searchParams.projectsOnly,
     // Routes-only (frames_count > 1, boulders off) — see chooseSearchPath.
     routesOnly: !!searchParams.routes && !searchParams.boulders,
-    page,
     hasStatsFilters,
   });
 
   if (path === 'standard-only') {
-    return standardSearch(db, params, searchParams, filters, sortBy, sortOrder, isDraftsQuery, page, pageSize);
+    return standardSearch(db, params, searchParams, filters, sortBy, sortOrder, isDraftsQuery, page, pageSize, false);
   }
 
   // Both 'stats-driven-only' and 'stats-driven-with-fallback' start with statsDriven.
@@ -179,30 +178,32 @@ export const searchClimbs = async (
     return statsResult;
   }
 
-  // statsDriven returned a partial page. Fall back to standardSearch only on page 0
-  // without stats filters, where stats-less climbs (projects) need to fill out
-  // narrow-filter results. The fallback's dataset is small enough that the planner
-  // picks a serial plan and doesn't allocate parallel-sort DSM segments.
+  // statsDriven returned a partial page: it has exhausted the climbs that HAVE a
+  // stats row at this angle. Re-run the same window through standardSearch's LEFT
+  // JOIN so stats-less climbs (projects) still show up — on ANY page, not just
+  // page 0 (issue #1971). The count badge comes from countClimbs, which counts the
+  // unified LEFT JOIN universe, so truncating here is what made the count disagree
+  // with the visible list and fired "no more climbs" early.
   //
-  // KNOWN TRADE-OFF: sparse first-page ascents/quality sorts can pay for two
-  // queries: the stats-driven index probe and then the LEFT JOIN fallback. That
-  // is intentional so stats-less climbs still appear at the bottom of the first
-  // page instead of disappearing from narrow result sets.
+  // Why running standardSearch past page 0 is safe now: the #1969 failure mode was
+  // a parallel plan whose per-worker DSM allocations exhausted /dev/shm. Both paths
+  // have since been wrapped in `SET LOCAL max_parallel_workers_per_gather = 0`
+  // (standardSearch in 07dfe54b2, statsDrivenSearch in a31f88baf / #3856), so
+  // neither can allocate a parallel-sort DSM segment regardless of page depth. The
+  // page-0 gate predates both guards (9acb8b913) and was protecting against a plan
+  // shape that is now disabled by GUC — do not re-introduce it.
   //
-  // KNOWN TRADE-OFF (search-climbs.ts:80-91 review feedback): when the page-0
-  // fallback returns hasMore=true but the user navigates to page 1, statsDriven on
-  // page 1 returns 0 and we don't fall back (page > 0). The user sees an empty
-  // next page. Accepted because:
-  //   - The narrow-filter case where this is visible is a small fraction of traffic.
-  //   - Running standardSearch on page > 0 with deep OFFSET re-creates the parallel
-  //     plan and /dev/shm pressure that PR #1969 fixes for the hot path.
-  //   - A properly correct fix needs server-side state across pages (count of
-  //     stats-having for the filter) which itself takes a parallel plan on broad
-  //     filters — verified ~862ms via EXPLAIN ANALYZE.
-  // Future work: track in production via cache-miss telemetry; consider keyset
-  // pagination or a popular_climbs materialized view as the next scale move.
+  // Cost: the fallback only fires once statsDriven is exhausted, so broad filters
+  // (hasMore=true) never reach it. Narrow filters pay one extra serial query on the
+  // boundary page and two queries per page past it, each bounded by
+  // OFFSET page*pageSize + LIMIT pageSize+1 with page clamped to MAX_SEARCH_PAGE.
+  //
+  // `orderStatsHavingFirst: true` makes the fallback's ordering a prefix-compatible
+  // continuation of the stats-driven pages — see runStandardSearch.
+  // Future work: keyset pagination or a popular_climbs materialized view so the
+  // stats-driven path can rank stats-less climbs natively.
   if (path === 'stats-driven-with-fallback') {
-    return standardSearch(db, params, searchParams, filters, sortBy, sortOrder, isDraftsQuery, page, pageSize);
+    return standardSearch(db, params, searchParams, filters, sortBy, sortOrder, isDraftsQuery, page, pageSize, true);
   }
   return statsResult;
 };
@@ -226,15 +227,15 @@ export type SearchPath = 'standard-only' | 'stats-driven-only' | 'stats-driven-w
  *   - drafts query          → standard-only (drafts have no stats rows)
  *   - projectsOnly          → standard-only (the user explicitly wants stats-less climbs)
  *   - routesOnly            → standard-only (routes are few + often unclimbed; the stats path drops them)
- *   - page === 0 && !hasStatsFilters → stats-driven-with-fallback
- *   - otherwise             → stats-driven-only
+ *   - hasStatsFilters       → stats-driven-only (a stats predicate can't be satisfied through the
+ *                             LEFT JOIN either, so a fallback would return nothing new)
+ *   - otherwise             → stats-driven-with-fallback (any page — see issue #1971)
  */
 export function chooseSearchPath(input: {
   statsDrivenSort: StatsDrivenSort | null;
   isDraftsQuery: boolean;
   projectsOnly: boolean;
   routesOnly: boolean;
-  page: number;
   hasStatsFilters: boolean;
 }): SearchPath {
   if (!input.statsDrivenSort) return 'standard-only';
@@ -246,8 +247,12 @@ export function chooseSearchPath(input: {
   // comes back empty while the count says e.g. 66. Force the LEFT JOIN path so
   // unclimbed routes surface; the tiny routes dataset makes the index plan moot.
   if (input.routesOnly) return 'standard-only';
-  if (input.page === 0 && !input.hasStatsFilters) return 'stats-driven-with-fallback';
-  return 'stats-driven-only';
+  // Stats filters (minAscents, grade range, quality, accuracy) exclude stats-less
+  // climbs from the LEFT JOIN path too, so a fallback would return nothing new and
+  // just double the query count. countClimbs applies the same conditions, so the
+  // count and the list already agree on this branch.
+  if (input.hasStatsFilters) return 'stats-driven-only';
+  return 'stats-driven-with-fallback';
 }
 
 /**
@@ -261,9 +266,10 @@ export function chooseSearchPath(input: {
  * mirroring the standardSearch / countClimbs / getHoldHeatmapData guards.
  *
  * The INNER JOIN excludes climbs without a stats row at this angle. The caller
- * (`searchClimbs`) compensates only on page 0 without stats filters, where
- * stats-less climbs (projects) need to fill out narrow-filter results. See the
- * comment in `searchClimbs` for the full reasoning.
+ * (`searchClimbs`) compensates on any page without stats filters, whenever this
+ * query returns a partial page — stats-less climbs (projects) need to fill out
+ * narrow-filter results at every depth, not just the first page (issue #1971).
+ * See the comment in `searchClimbs` for the full reasoning.
  *
  * All climb filters (including personal progress like hideCompleted) are in
  * the WHERE clause — not the JOIN ON — so they apply correctly to the result set.
@@ -385,6 +391,9 @@ async function runStatsDrivenSearch(
  * Standard search: FROM board_climbs LEFT JOIN board_climb_stats.
  * Used for non-default sorts (difficulty, name, creation, popular) and for
  * draft queries.
+ *
+ * @param orderStatsHavingFirst Pass `true` only from the stats-driven fallback so
+ * the result window lines up with statsDrivenSearch's pages. See runStandardSearch.
  */
 async function standardSearch(
   db: SearchDb,
@@ -396,6 +405,7 @@ async function standardSearch(
   isDraftsQuery: boolean,
   page: number,
   pageSize: number,
+  orderStatsHavingFirst: boolean,
 ): Promise<ClimbSearchResult> {
   const transaction = getTransaction(db);
   if (transaction) {
@@ -411,6 +421,7 @@ async function standardSearch(
         isDraftsQuery,
         page,
         pageSize,
+        orderStatsHavingFirst,
       );
     });
   }
@@ -424,7 +435,18 @@ async function standardSearch(
     await execute(sql`SET LOCAL max_parallel_workers_per_gather = 0`);
   }
 
-  return runStandardSearch(db, params, searchParams, filters, sortBy, sortOrder, isDraftsQuery, page, pageSize);
+  return runStandardSearch(
+    db,
+    params,
+    searchParams,
+    filters,
+    sortBy,
+    sortOrder,
+    isDraftsQuery,
+    page,
+    pageSize,
+    orderStatsHavingFirst,
+  );
 }
 
 async function runStandardSearch(
@@ -437,6 +459,7 @@ async function runStandardSearch(
   isDraftsQuery: boolean,
   page: number,
   pageSize: number,
+  orderStatsHavingFirst: boolean,
 ): Promise<ClimbSearchResult> {
   // For the popular sort, pre-aggregate total ascents across all angles via a joined subquery
   // instead of a correlated subquery that runs per candidate row.
@@ -540,6 +563,23 @@ async function runStandardSearch(
       ? sql`${sortColumn} ASC NULLS FIRST`
       : sql`${sortColumn} DESC NULLS LAST`;
 
+  // Stats-presence key, used ONLY by the stats-driven fallback (issue #1971). It
+  // pins every climb that has a board_climb_stats row at this angle ahead of every
+  // stats-less one, so the unified order becomes
+  //   [stats-having, in exactly statsDrivenSearch's order] ++ [stats-less by uuid DESC]
+  // and each fallback page is a prefix-compatible continuation of the stats-driven
+  // pages — nothing duplicated or skipped at the boundary. Rows with a non-NULL sort
+  // key are unaffected (they already sort ahead of every NULL); the key only
+  // disambiguates the NULL tail, where a stats row with a NULL ascensionist_count /
+  // quality_average would otherwise interleave with stats-less climbs by uuid DESC.
+  // Never set it for name/creation/popular/random sorts — it would reorder them (and
+  // break the md5 shuffle's page stability).
+  const orderByKeys = [
+    ...(orderStatsHavingFirst ? [sql`CASE WHEN ${boardClimbStats.climbUuid} IS NULL THEN 1 ELSE 0 END ASC`] : []),
+    orderByClause,
+    desc(boardClimbs.uuid),
+  ];
+
   // LEFT JOIN preserves climbs without stats (they get NULL stats columns).
   const coreQuery = db
     .select(selectFields)
@@ -562,7 +602,7 @@ async function runStandardSearch(
 
   const results: RawSelectResult[] = (await queryWithJoins
     .where(and(...whereConditions))
-    .orderBy(orderByClause, desc(boardClimbs.uuid))
+    .orderBy(...orderByKeys)
     .limit(pageSize + 1)
     .offset(page * pageSize)) as unknown as RawSelectResult[];
 

--- a/packages/web/app/lib/db/queries/climbs/search-climbs.ts
+++ b/packages/web/app/lib/db/queries/climbs/search-climbs.ts
@@ -85,7 +85,10 @@ function _getCachedFn(boardName: BoardName, revalidate: number): CachedClimbSear
     // v6: onlyBenchmarks now included in buildClimbSearchParamsJson (was previously
     // omitted entirely, so the SSR path never forwarded it — see issue #2320). The key
     // rotates naturally since the JSON payload gains a field, but bumping documents intent.
-    fn = unstable_cache(_executeClimbSearch, [`climb-search-v6:${boardName}`], {
+    // v7: searches past the stats-having boundary now return stats-less climbs (issue
+    // #1971), and the stats-driven fallback orders stats-having climbs ahead of
+    // stats-less ones — cached truncated pages must not keep serving the old result.
+    fn = unstable_cache(_executeClimbSearch, [`climb-search-v7:${boardName}`], {
       revalidate,
       tags: ['climb-search', getBoardClimbSearchTag(boardName)],
     });


### PR DESCRIPTION
## What & why

On a narrow filter, the climb list silently stopped at the stats-having boundary while the header badge kept reporting the true total. A search filtered down to, say, 35 matching climbs would show 21 and then say "no more climbs" — the 14 climbs with no `board_climb_stats` row at that angle (typically projects nobody has sent) just vanished.

## Verified root cause

`searchClimbs` routes ascents-DESC searches through the index-driven `statsDrivenSearch` path (PR #1969, to stop parallel-sort DSM segments saturating `/dev/shm`). When that path returns a partial page it falls back to the unified LEFT JOIN `standardSearch` — but the fallback was gated on `page === 0`. Past page 0 the partial page was returned as-is, so every stats-less climb after the boundary was unreachable, while `countClimbs` (which has always counted the full LEFT JOIN universe) kept reporting them.

The `page === 0` gate (9acb8b913) predates both parallelism guards. Both search paths are now wrapped in `SET LOCAL max_parallel_workers_per_gather = 0` (`standardSearch` in 07dfe54b2, `statsDrivenSearch` in a31f88baf / #3856), so neither can allocate a parallel-sort DSM segment at any page depth. The gate was protecting against a plan shape that is now disabled by GUC.

Schema context for the "stats-having" split: `ascensionistCount` is `packages/db/src/schema/boards/unified.ts:654` and `qualityAverage` is `:677`, both nullable columns on `board_climb_stats`, which is LEFT JOINed — so "stats-less" means no row at that board/layout/angle, not a zero.

## Fix

- `chooseSearchPath` now returns `'stats-driven-with-fallback'` on **every** page when there are no stats filters. `page` is gone from its input entirely; `hasStatsFilters` gets its own early return.
- The fallback passes `orderStatsHavingFirst: true`, which prepends `CASE WHEN board_climb_stats.climb_uuid IS NULL THEN 1 ELSE 0 END ASC` to the ORDER BY. That makes the fallback's ordering a prefix-compatible continuation of the stats-driven pages, so page 1 can't duplicate or skip a row that page 0 already showed. Both standard-only call sites pass `false`, so nothing else changes ordering.
- Bumped both search caches in lockstep — backend `CACHE_VERSION` `v4` → `v5`, web `climb-search-v6:` → `climb-search-v7:`. Without it, already-cached truncated pages would keep serving the bug for the full 24h TTL, and an old-ordering page 0 next to a new-ordering page 1 would tear at the boundary.
- Replaced the three stale comment blocks that still justified the page-0 gate.

Follow-up fix from adversarial QA, in the second commit:

- `CACHE_VERSION` is now exported and `search-cache.test.ts` asserts the key layout against the constant, with one explicit `toBe('v5')` pin so a bump stays a deliberate, reviewed edit. (The bump had broken two hardcoded `'v4'` literals in that test — a guaranteed CI red.)
- Quoted the globs in `packages/db`'s `test` script. Unquoted, bun's shell collapsed `src/**/*.test.ts` to a single level, so **none** of the 214 tests under `packages/db/src` ever ran under `vp run test:db` — including the ones added here.

## Tests

- `packages/db/.../__tests__/search-climbs.test.ts` — new `stats-driven fallback past the first page (#1971)` case plus a rewritten DSM-parallelism guard assertion (`assertEverySelectIsGuarded` now checks the alternating guard/select shape for every executed statement, covering `standardSearch`'s guard too). The ORDER BY assertion reads the recorded emitted SQL via `PgDialect.sqlToQuery` rather than re-deriving an expectation string. All `page` fixtures removed now that routing no longer takes a page.
  - **On revert** (re-add `&& page === 0` to the fallback branch): `3 failed / 28` — `search queries — DSM parallelism guard (#3856)` and `stats-driven fallback past the first page (#1971)` both go red. Restored: 28/28.
- `packages/backend/src/__tests__/climb-queries.test.ts` — real-Postgres walk over a seeded fixture (three stats-having, two stats-less, `pageSize` 2): page 0 `[a,b]`, page 1 `[c,e]`, page 2 `[d]`, five distinct uuids, zero duplicates.
  - **On revert**: page 1 returns the partial `[c]` and `d`/`e` never appear, so the collected-uuid assertion fails with 3 of 5.
- `packages/backend/src/services/__tests__/search-cache.test.ts` — the new version pin fails the moment `CACHE_VERSION` moves without a matching test edit.
- `search-climbs-explain.integration.test.ts` — new `#1971` case asserts the emitted statement order is `guard, select, guard, select`, i.e. the fallback query gets its own `SET LOCAL` before it runs. The `hasGatherNode === false` check in that case is labelled in-code as a smoke test: the harness setter matches zero rows, so the planner would pick a serial plan regardless. The statement-ordering assertion is the load-bearing one for #1969 / #3856.

**Test-coverage caveats, stated plainly:**

- The `packages/db` cases were validated with a direct `bunx tsx --test <file>` run (28/28 at HEAD, 3 red on revert). PR CI does not run `packages/db`'s unit tests at all — only `test:db:migration-journal`. The backend real-Postgres test is the only CI-covered gate on this fix.
- Quoting the `test` globs makes `vp run test:db` execute 228 tests instead of 134. That immediately surfaces **3 pre-existing failures** in `create-climb-filters.test.ts` (`createClimbFilters: zone modes` ×2, `createClimbFilters: MoonBoard hold search` ×1). They are equally red on `origin/main` — stale MoonBoard calibration expectations that drifted when the shared geometry changed, invisible until now because the glob was skipping the file. Not touched here; deciding whether the geometry or the assertions are wrong needs board-geometry context, so they are filed separately as #4049.

## QA Notes

- Pick a board/layout/angle plus a filter narrow enough that fewer than ~21 climbs have recorded ascents at that angle but some stats-less climbs still match (a setter with mostly-unsent problems works). Land without a `?page` param, scroll past the boundary: the list should now continue into the stats-less climbs and the final count should match the header badge.
- Check the boundary itself for tears — the last climb of page 0 and the first of page 1 should not repeat, and nothing should be skipped between them.
- Sorts other than ascents-DESC (name, creation date, popular, and the seeded random shuffle) are untouched — spot-check one to confirm ordering and pagination are unchanged.
- **Post-deploy:** confirm the cache-version bump actually rotated keys. A narrow search that previously returned a truncated page must return the full list on the *first* request after deploy, not only after the 24h TTL expires. If it still truncates, the `v5` / `v7` bump did not reach that layer.

## Release Notes

Narrow searches no longer cut off early. If a filter turned up 35 climbs but the list stopped at 21 and said "no more climbs", the missing ones were projects with no logged ascents — they're back in the list now, ranked after the climbs people have sent.

Fixes #1971
