### PR TITLE
fix(sync): keep real rating dates on Kilter climb ratings

### DIFF
--- a/docs/kilter-sync.md
+++ b/docs/kilter-sync.md
@@ -128,6 +128,8 @@ Kilter exposes ratings as a first-class resource at `POST /api/climb-rating/` �
 
 The conflict target on insert is the natural key `(board_type, climb_uuid, angle, user_id)`, not `kilter_id` — same reasoning as the ticks path. Kilter's per-rating payload doesn't carry `weight`, so kilter-origin rows leave that column NULL.
 
+Two timestamp invariants are easy to break by accident (issue #3524). **`created_at` comes from the upstream rating date** (`raw.created_at`, parsed by `parseKilterTimestamp`), not from the column default — without it every historical rating collapses onto the day our sync first saw it. It is deliberately absent from the `DO UPDATE` SET, so a Boardsesh-originated rating that a later sync adopts keeps its own original date rather than being re-stamped with Kilter's. **The `DO UPDATE` is change-guarded** by a row-wise `IS DISTINCT FROM` over `(rating, difficulty_grade_id, comment, kilter_id)`, comparing the existing row against the *effective* new value (`COALESCE(EXCLUDED.…, existing)` for the COALESCE'd columns, not bare `EXCLUDED`). PowerSync redelivers a full snapshot every cycle, so without the guard the update fires for every rating on every run and `updated_at` degrades into "when the sync last ran".
+
 ### Circuits → playlists
 
 Circuit rows upsert into `playlists` (`kilter_id` = `circuit_uuid`, `kilter_type = 'circuits'`). The climbs list is **full-replace per sync**: delete every `playlist_climbs` row for the playlist, re-insert from the snapshot, chunk inserts at 500 rows to stay under the 65535-parameter Postgres ceiling. Matches aurora-sync's circuit handling. Ownership is idempotent via `(playlist_id, user_id)` unique.

--- a/packages/backend/src/__tests__/kilter-climb-ratings-timestamps.test.ts
+++ b/packages/backend/src/__tests__/kilter-climb-ratings-timestamps.test.ts
@@ -1,0 +1,238 @@
+// Real-Postgres test for the kilter-sync climb-ratings upsert (issue #3524).
+//
+// Both behaviours under test are properties of the generated SQL, not of JS,
+// so a mocked-drizzle unit test could only re-assert a predicate we wrote
+// ourselves. These run the real `insert ... on conflict do update` against
+// Postgres and read the stored timestamps back:
+//
+//   1. created_at must come from the upstream rating date, not defaultNow().
+//   2. updated_at must only move when the rating actually changed — PowerSync
+//      redelivers a full snapshot every cycle, so an unguarded DO UPDATE
+//      rewrites updated_at on every sync for every row.
+import { describe, it, expect, beforeEach } from 'vite-plus/test';
+import { and, eq, sql } from 'drizzle-orm';
+import { boardClimbRatings } from '@boardsesh/db/schema';
+import { applyClimbRatings } from '@boardsesh/kilter-sync/sync';
+import type { PowerSyncOp } from '@boardsesh/kilter-sync/api';
+import { db } from '../db/client';
+
+// Seeded by the shared test setup.
+const USER_ID = 'user-123';
+const CLIMB_UUID = 'climb-rating-ts-1';
+const ANGLE = 40;
+// Deliberately carries a non-UTC offset: Kilter sends ISO strings with an
+// offset and the stored value must be the normalised UTC instant.
+const UPSTREAM_RATED_AT = '2024-03-05T18:30:00+02:00';
+const UPSTREAM_RATED_AT_UTC_MS = Date.parse(UPSTREAM_RATED_AT);
+
+type RatingPayload = {
+  rating: number | null;
+  difficulty_grade_id: number | null;
+  comment: string | null;
+  created_at: string;
+};
+
+function putOp({ rating, difficulty_grade_id, comment, created_at }: RatingPayload): PowerSyncOp {
+  return {
+    op: 'PUT',
+    object_id: 'kilter-rating-1',
+    object_type: 'climb_ratings',
+    data: {
+      id: 'kilter-rating-1',
+      climb_rating_uuid: 'kilter-rating-1',
+      user_uuid: 'kilter-user-1',
+      gym_uuid: null,
+      wall_uuid: null,
+      product_layout_uuid: null,
+      climb_uuid: CLIMB_UUID,
+      angle: ANGLE,
+      rating,
+      difficulty_grade_id,
+      comment,
+      created_at,
+    },
+  } as unknown as PowerSyncOp;
+}
+
+async function syncRating(payload: RatingPayload): Promise<void> {
+  await applyClimbRatings(db, USER_ID, [putOp(payload)], new Map<string, string>());
+}
+
+async function readRating() {
+  const [row] = await db
+    .select({
+      rating: boardClimbRatings.rating,
+      difficultyGradeId: boardClimbRatings.difficultyGradeId,
+      comment: boardClimbRatings.comment,
+      kilterId: boardClimbRatings.kilterId,
+      createdAt: boardClimbRatings.createdAt,
+      updatedAt: boardClimbRatings.updatedAt,
+    })
+    .from(boardClimbRatings)
+    .where(and(eq(boardClimbRatings.userId, USER_ID), eq(boardClimbRatings.climbUuid, CLIMB_UUID)))
+    .limit(1);
+  return row ?? null;
+}
+
+// Backdate updated_at so a rewrite is unmistakable: the column defaults to
+// now(), and a same-millisecond comparison could otherwise pass by accident.
+const BACKDATED_UPDATED_AT = new Date('2020-01-01T00:00:00Z');
+
+async function backdateUpdatedAt(): Promise<void> {
+  await db
+    .update(boardClimbRatings)
+    .set({ updatedAt: BACKDATED_UPDATED_AT })
+    .where(and(eq(boardClimbRatings.userId, USER_ID), eq(boardClimbRatings.climbUuid, CLIMB_UUID)));
+}
+
+describe('applyClimbRatings timestamps (real Postgres)', () => {
+  beforeEach(async () => {
+    await db.delete(boardClimbRatings).where(eq(boardClimbRatings.userId, USER_ID));
+  });
+
+  it('stamps created_at from the upstream rating date, not sync time', async () => {
+    await syncRating({ rating: 4, difficulty_grade_id: 17, comment: 'crimpy', created_at: UPSTREAM_RATED_AT });
+
+    const row = await readRating();
+    expect(row).not.toBeNull();
+    expect(row?.createdAt?.getTime()).toBe(UPSTREAM_RATED_AT_UTC_MS);
+  });
+
+  it('falls back to the column default when upstream sends an unparseable date', async () => {
+    const before = Date.now() - 1000;
+    await syncRating({ rating: 3, difficulty_grade_id: 17, comment: '', created_at: 'not-a-date' });
+
+    const row = await readRating();
+    // No Invalid Date written (which Postgres rejects and would abort the
+    // whole ratings batch) — the row exists with a now()-ish created_at.
+    expect(row).not.toBeNull();
+    expect(row?.createdAt?.getTime()).toBeGreaterThanOrEqual(before);
+  });
+
+  it('leaves updated_at alone when an unchanged rating is redelivered', async () => {
+    const payload: RatingPayload = {
+      rating: 4,
+      difficulty_grade_id: 17,
+      comment: 'crimpy',
+      created_at: UPSTREAM_RATED_AT,
+    };
+    await syncRating(payload);
+    await backdateUpdatedAt();
+
+    // Exactly what the next PowerSync cycle redelivers: same row, no change.
+    await syncRating(payload);
+
+    const row = await readRating();
+    expect(row?.updatedAt?.getTime()).toBe(BACKDATED_UPDATED_AT.getTime());
+    // The conflict path must never re-stamp created_at either.
+    expect(row?.createdAt?.getTime()).toBe(UPSTREAM_RATED_AT_UTC_MS);
+  });
+
+  it('treats a cleared upstream comment as a real change', async () => {
+    await syncRating({ rating: 4, difficulty_grade_id: 17, comment: 'crimpy', created_at: UPSTREAM_RATED_AT });
+    await backdateUpdatedAt();
+
+    // A null upstream comment is normalised to '' before the insert, so the
+    // SET's COALESCE(EXCLUDED.comment, …) never fires for kilter PUTs and the
+    // stored comment really is cleared. Pinning it here so the change guard
+    // can't be mistaken for the reason a cleared comment stops propagating:
+    // the write still lands and updated_at still moves.
+    await syncRating({ rating: 4, difficulty_grade_id: 17, comment: null, created_at: UPSTREAM_RATED_AT });
+
+    const row = await readRating();
+    expect(row?.comment).toBe('');
+    expect(row?.updatedAt?.getTime()).toBeGreaterThan(BACKDATED_UPDATED_AT.getTime());
+  });
+
+  it('bumps updated_at when the rating really changes', async () => {
+    await syncRating({ rating: 4, difficulty_grade_id: 17, comment: 'crimpy', created_at: UPSTREAM_RATED_AT });
+    await backdateUpdatedAt();
+
+    await syncRating({ rating: 2, difficulty_grade_id: 17, comment: 'crimpy', created_at: UPSTREAM_RATED_AT });
+
+    const row = await readRating();
+    expect(row?.rating).toBe(2);
+    expect(row?.updatedAt?.getTime()).toBeGreaterThan(BACKDATED_UPDATED_AT.getTime());
+    // A changed rating still must not rewrite the original rating date.
+    expect(row?.createdAt?.getTime()).toBe(UPSTREAM_RATED_AT_UTC_MS);
+  });
+
+  it('adopts kilter_id onto a Boardsesh-originated row and bumps updated_at once', async () => {
+    await db.insert(boardClimbRatings).values({
+      boardType: 'kilter',
+      climbUuid: CLIMB_UUID,
+      angle: ANGLE,
+      userId: USER_ID,
+      rating: 4,
+      difficultyGradeId: 17,
+      comment: 'crimpy',
+      createdAt: new Date('2023-01-01T00:00:00Z'),
+      updatedAt: BACKDATED_UPDATED_AT,
+    });
+    // Postgres stores the backdate; re-assert via a direct write so the row is
+    // definitely not now()-stamped by the insert defaults.
+    await backdateUpdatedAt();
+
+    await syncRating({ rating: 4, difficulty_grade_id: 17, comment: 'crimpy', created_at: UPSTREAM_RATED_AT });
+
+    const adopted = await readRating();
+    expect(adopted?.kilterId).toBe('kilter-rating-1');
+    // Adopting the surrogate IS a change, so updated_at moves...
+    expect(adopted?.updatedAt?.getTime()).toBeGreaterThan(BACKDATED_UPDATED_AT.getTime());
+    // ...but the Boardsesh-side created_at is preserved, not overwritten by
+    // the upstream date.
+    expect(adopted?.createdAt?.getTime()).toBe(Date.parse('2023-01-01T00:00:00Z'));
+
+    // A second identical cycle now has nothing left to adopt: no bump.
+    await backdateUpdatedAt();
+    await syncRating({ rating: 4, difficulty_grade_id: 17, comment: 'crimpy', created_at: UPSTREAM_RATED_AT });
+    const settled = await readRating();
+    expect(settled?.updatedAt?.getTime()).toBe(BACKDATED_UPDATED_AT.getTime());
+  });
+
+  it('still applies the change guard across a full batch of rows', async () => {
+    // Guards against a regression where the guard only worked for single-row
+    // inserts: the real sync flushes hundreds of ratings per statement.
+    const ops: PowerSyncOp[] = [0, 1, 2].map(
+      (index) =>
+        ({
+          op: 'PUT',
+          object_id: `kilter-rating-batch-${index}`,
+          object_type: 'climb_ratings',
+          data: {
+            id: `kilter-rating-batch-${index}`,
+            climb_rating_uuid: `kilter-rating-batch-${index}`,
+            user_uuid: 'kilter-user-1',
+            gym_uuid: null,
+            wall_uuid: null,
+            product_layout_uuid: null,
+            climb_uuid: `${CLIMB_UUID}-batch-${index}`,
+            angle: ANGLE,
+            rating: 3,
+            difficulty_grade_id: 17,
+            comment: 'batch',
+            created_at: UPSTREAM_RATED_AT,
+          },
+        }) as unknown as PowerSyncOp,
+    );
+
+    await applyClimbRatings(db, USER_ID, ops, new Map<string, string>());
+    await db
+      .update(boardClimbRatings)
+      .set({ updatedAt: BACKDATED_UPDATED_AT })
+      .where(eq(boardClimbRatings.userId, USER_ID));
+
+    await applyClimbRatings(db, USER_ID, ops, new Map<string, string>());
+
+    const rows = await db
+      .select({ updatedAt: boardClimbRatings.updatedAt, createdAt: boardClimbRatings.createdAt })
+      .from(boardClimbRatings)
+      .where(and(eq(boardClimbRatings.userId, USER_ID), sql`${boardClimbRatings.climbUuid} LIKE '%-batch-%'`));
+
+    expect(rows).toHaveLength(3);
+    for (const row of rows) {
+      expect(row.updatedAt?.getTime()).toBe(BACKDATED_UPDATED_AT.getTime());
+      expect(row.createdAt?.getTime()).toBe(UPSTREAM_RATED_AT_UTC_MS);
+    }
+  });
+});

--- a/packages/kilter-sync/src/sync/index.ts
+++ b/packages/kilter-sync/src/sync/index.ts
@@ -1,5 +1,10 @@
 export {
   syncKilterUserData,
+  // Exported for the real-Postgres test in packages/backend: the ratings
+  // conflict clause (created_at from upstream + the setWhere change guard)
+  // can only be verified against an actual database.
+  applyClimbRatings,
+  parseKilterTimestamp,
   type SyncKilterUserDataArgs,
   type SyncKilterUserDataResult,
   type ApplyCircuitsResult,

--- a/packages/kilter-sync/src/sync/index.ts
+++ b/packages/kilter-sync/src/sync/index.ts
@@ -4,7 +4,6 @@ export {
   // conflict clause (created_at from upstream + the setWhere change guard)
   // can only be verified against an actual database.
   applyClimbRatings,
-  parseKilterTimestamp,
   type SyncKilterUserDataArgs,
   type SyncKilterUserDataResult,
   type ApplyCircuitsResult,

--- a/packages/kilter-sync/src/sync/user-sync.test.ts
+++ b/packages/kilter-sync/src/sync/user-sync.test.ts
@@ -1052,7 +1052,34 @@ import {
  * connection, so query-shape assertions need no database.
  */
 const renderOnlyDb = drizzle({} as never);
-import { applyCircuits, applyClimbRatings, sanitizeKilterRating } from './user-sync';
+import { applyCircuits, applyClimbRatings, parseKilterTimestamp, sanitizeKilterRating } from './user-sync';
+
+describe('parseKilterTimestamp', () => {
+  it('keeps the instant of a Z-suffixed UTC string', () => {
+    expect(parseKilterTimestamp('2024-03-05T18:30:00.000Z')?.toISOString()).toBe('2024-03-05T18:30:00.000Z');
+  });
+
+  it('normalises an explicit offset to UTC', () => {
+    expect(parseKilterTimestamp('2024-03-05T18:30:00-02:00')?.toISOString()).toBe('2024-03-05T20:30:00.000Z');
+  });
+
+  it('reads a zone-less wall clock as UTC, not as the host process timezone', () => {
+    expect(parseKilterTimestamp('2024-03-05 18:30:00')?.toISOString()).toBe('2024-03-05T18:30:00.000Z');
+    expect(parseKilterTimestamp('2024-03-05T18:30:00')?.toISOString()).toBe('2024-03-05T18:30:00.000Z');
+  });
+
+  it('reads a date-only value as midnight UTC (the trailing -05 is a day, not an offset)', () => {
+    expect(parseKilterTimestamp('2024-03-05')?.toISOString()).toBe('2024-03-05T00:00:00.000Z');
+  });
+
+  it('returns undefined for missing, empty and unparseable values so the insert falls back to the default', () => {
+    expect(parseKilterTimestamp(null)).toBeUndefined();
+    expect(parseKilterTimestamp(undefined)).toBeUndefined();
+    expect(parseKilterTimestamp('')).toBeUndefined();
+    expect(parseKilterTimestamp('   ')).toBeUndefined();
+    expect(parseKilterTimestamp('not-a-date')).toBeUndefined();
+  });
+});
 
 describe('sanitizeKilterRating', () => {
   it('keeps valid 1-5 ratings', () => {
@@ -1213,6 +1240,9 @@ describe('applyClimbRatings — bulk upsert with COALESCE comment', () => {
       rating: 4,
       userId: 'user-1',
       boardType: 'kilter',
+      // The upstream rating date, not sync time. Dropping the createdAt
+      // mapping has to fail here too, not only in the real-Postgres test.
+      createdAt: new Date('2026-05-01T12:00:00.000Z'),
     });
     expect(insertValues[0][1]).toMatchObject({ kilterId: 'r-2', climbUuid: 'climb-B' });
     // No delete because there were no REMOVEs.

--- a/packages/kilter-sync/src/sync/user-sync.ts
+++ b/packages/kilter-sync/src/sync/user-sync.ts
@@ -1003,6 +1003,14 @@ function hasZoneInfo(value: string): boolean {
   return TIMESTAMP_UTC_SUFFIX.test(value) || TIMESTAMP_OFFSET_SUFFIX.test(value);
 }
 
+// Pin a zone-less value to UTC. A date-only value gets a full midnight time
+// component: `2024-03-05Z` is outside the ECMAScript date-time grammar, so
+// `Date.parse` would be free to reject it.
+function toUtcIsoString(value: string): string {
+  const withTimeSeparator = value.replace(/\s+/, 'T');
+  return withTimeSeparator.includes('T') ? `${withTimeSeparator}Z` : `${withTimeSeparator}T00:00:00Z`;
+}
+
 /**
  * Kilter timestamps observed on the wire are `Z`-suffixed UTC ISO strings.
  * A value that carries a `Z` or a `±HH:MM` offset is normalised to that
@@ -1018,7 +1026,7 @@ export function parseKilterTimestamp(value: string | null | undefined): Date | u
   if (!value) return undefined;
   const trimmed = value.trim();
   if (!trimmed) return undefined;
-  const normalized = hasZoneInfo(trimmed) ? trimmed : `${trimmed.replace(' ', 'T')}Z`;
+  const normalized = hasZoneInfo(trimmed) ? trimmed : toUtcIsoString(trimmed);
   const parsedMs = Date.parse(normalized);
   if (!Number.isFinite(parsedMs)) return undefined;
   return new Date(parsedMs);

--- a/packages/kilter-sync/src/sync/user-sync.ts
+++ b/packages/kilter-sync/src/sync/user-sync.ts
@@ -992,15 +992,34 @@ export function sanitizeKilterRating(rating: number | null | undefined): number 
   return value;
 }
 
+// A trailing `Z`, or a `±HH:MM` / `±HHMM` / `±HH` offset that follows a clock
+// time (the clock-time prefix is what keeps a date-only `2024-03-05` from
+// reading its `-05` as an offset). Anything else is a bare wall clock with no
+// zone information.
+const TIMESTAMP_UTC_SUFFIX = /Z$/i;
+const TIMESTAMP_OFFSET_SUFFIX = /\d{2}:\d{2}(?::\d{2})?(?:\.\d+)?\s*[+-]\d{2}(?::?\d{2})?$/;
+
+function hasZoneInfo(value: string): boolean {
+  return TIMESTAMP_UTC_SUFFIX.test(value) || TIMESTAMP_OFFSET_SUFFIX.test(value);
+}
+
 /**
- * Kilter timestamps are ISO strings carrying an offset. Return a Date in UTC,
- * or undefined when the value is missing/unparseable so the caller's insert
- * falls back to the column default instead of writing an Invalid Date.
- * Exported for unit testing.
+ * Kilter timestamps observed on the wire are `Z`-suffixed UTC ISO strings.
+ * A value that carries a `Z` or a `±HH:MM` offset is normalised to that
+ * instant. A bare wall clock with no zone (`"2024-03-05 18:30:00"`) is read as
+ * UTC rather than left to `Date.parse`, which would apply the *host process's*
+ * timezone and skew the stored date by the container's offset. Reading it as
+ * UTC matches `applyLogs`, which writes the upstream string straight into a
+ * `mode: 'string'` column where Postgres stores the wall clock verbatim.
+ * Returns undefined when the value is missing or unparseable, so the caller's
+ * insert falls back to the column default instead of writing an Invalid Date.
  */
 export function parseKilterTimestamp(value: string | null | undefined): Date | undefined {
   if (!value) return undefined;
-  const parsedMs = Date.parse(value);
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const normalized = hasZoneInfo(trimmed) ? trimmed : `${trimmed.replace(' ', 'T')}Z`;
+  const parsedMs = Date.parse(normalized);
   if (!Number.isFinite(parsedMs)) return undefined;
   return new Date(parsedMs);
 }

--- a/packages/kilter-sync/src/sync/user-sync.ts
+++ b/packages/kilter-sync/src/sync/user-sync.ts
@@ -992,6 +992,19 @@ export function sanitizeKilterRating(rating: number | null | undefined): number 
   return value;
 }
 
+/**
+ * Kilter timestamps are ISO strings carrying an offset. Return a Date in UTC,
+ * or undefined when the value is missing/unparseable so the caller's insert
+ * falls back to the column default instead of writing an Invalid Date.
+ * Exported for unit testing.
+ */
+export function parseKilterTimestamp(value: string | null | undefined): Date | undefined {
+  if (!value) return undefined;
+  const parsedMs = Date.parse(value);
+  if (!Number.isFinite(parsedMs)) return undefined;
+  return new Date(parsedMs);
+}
+
 export async function applyClimbRatings(
   tx: DrizzleDb,
   userId: string,
@@ -1060,6 +1073,16 @@ export async function applyClimbRatings(
       // itself. Leave null for kilter-origin rows.
       weight: null,
       kilterId: raw.climb_rating_uuid,
+      // When the user actually rated the climb upstream. Without this the
+      // insert falls through to the column's defaultNow(), so created_at
+      // recorded when OUR sync first saw the row — every historical rating
+      // collapsed onto the day the Kilter sync started. Kilter sends an ISO
+      // string with an offset; Date.parse normalises it to UTC, matching the
+      // ::timestamptz-on-both-sides treatment applyLogs gives created_at.
+      // Unparseable input falls back to the column default rather than
+      // writing an Invalid Date (which Postgres rejects and which would abort
+      // the whole ratings batch).
+      createdAt: parseKilterTimestamp(raw.created_at),
     });
   }
   const values = Array.from(valuesByConflictKey.values());
@@ -1090,6 +1113,23 @@ export async function applyClimbRatings(
         kilterId: sql`COALESCE(EXCLUDED.kilter_id, ${boardClimbRatings.kilterId})`,
         updatedAt: new Date(),
       },
+      // PowerSync redelivers a full snapshot every cycle, so without this
+      // guard the DO UPDATE fires for every rating on every sync and rewrites
+      // updated_at even when nothing about the rating changed — the column
+      // then tracks "when the sync last ran", not "when the user last touched
+      // this rating". Skip the UPDATE entirely when the row would not change.
+      //
+      // The right-hand side has to be the EFFECTIVE new value, not raw
+      // EXCLUDED: comment and kilter_id are written through COALESCE above, so
+      // comparing against bare EXCLUDED would call a no-op COALESCE fallback a
+      // "change" and bump updated_at anyway. Row-wise IS DISTINCT FROM handles
+      // the nullable columns (rating, difficulty_grade_id, kilter_id) without
+      // NULL-propagating to unknown. created_at is deliberately absent from
+      // both the SET and this predicate: an existing row keeps the first
+      // created_at it was stamped with.
+      setWhere: sql`(${boardClimbRatings.rating}, ${boardClimbRatings.difficultyGradeId}, ${boardClimbRatings.comment}, ${boardClimbRatings.kilterId})
+        IS DISTINCT FROM
+        (EXCLUDED.rating, EXCLUDED.difficulty_grade_id, COALESCE(EXCLUDED.comment, ${boardClimbRatings.comment}), COALESCE(EXCLUDED.kilter_id, ${boardClimbRatings.kilterId}))`,
     });
 }
 


### PR DESCRIPTION
## What / why

Every `board_climb_ratings` row written by the Kilter sync carried timestamps that described **our sync**, not the climber. `min(created_at)` in production sits at the day the Kilter sync started, so anything ordered or dated off this table ("rated 3 days ago", recency sorts) is wrong.

## Verified root cause

`packages/kilter-sync/src/sync/user-sync.ts`, `applyClimbRatings`:

1. **`created_at` was never mapped.** The per-PUT values object maps every `RawClimbRating` field except `raw.created_at`, so the insert fell through to the column default (`createdAt: timestamp('created_at').defaultNow().notNull()`, `packages/db/src/schema/boards/unified.ts`). Every historical rating collapsed onto first-sight day.
2. **`updated_at` was bumped unconditionally.** The `onConflictDoUpdate` SET clause contained `updatedAt: new Date()` with no change guard. PowerSync redelivers a full snapshot every cycle, so the DO UPDATE fired for every rating on every sync and rewrote `updated_at` even when nothing about the rating had changed. The column tracked "when the sync last ran".

## Fix

- Map `createdAt` from `raw.created_at` via a new `parseKilterTimestamp` helper. Every payload we've observed is a `Z`-suffixed UTC ISO string; a value carrying a `Z` or a `±HH:MM` offset is normalised to that instant, and a zone-less wall clock (`"2024-03-05 18:30:00"`) is read as **UTC** rather than handed to bare `Date.parse`, which applies the host process's timezone and would skew the stored date by the container's offset. Reading it as UTC matches `applyLogs`, which writes the upstream string straight into a `mode: 'string'` column where Postgres keeps the wall clock verbatim. An unparseable value returns `undefined` so the insert falls back to the column default rather than writing an Invalid Date, which Postgres rejects and which would abort the whole ratings batch for that user.
- Add a `setWhere` to the conflict clause: a row-wise `IS DISTINCT FROM` over `(rating, difficulty_grade_id, comment, kilter_id)`. The right-hand side is the **effective** new value, not bare `EXCLUDED` — `comment` and `kilter_id` are written through `COALESCE(EXCLUDED.…, existing)`, so comparing raw `EXCLUDED` would count a no-op COALESCE fallback as a change and bump `updated_at` anyway. Row-wise `IS DISTINCT FROM` also handles the nullable columns without NULL-propagating to unknown.
- `created_at` is deliberately absent from both the SET and the guard: an existing row keeps the first `created_at` it was stamped with, so a Boardsesh-originated rating adopted by a later sync is not re-dated to the Kilter timestamp.
- `applyClimbRatings` is now exported from `@boardsesh/kilter-sync/sync` so the real-DB test can drive it. `parseKilterTimestamp` stays module-local and is covered by unit tests in the package's own suite.
- `docs/kilter-sync.md` gains the two invariants a future change could silently break: `created_at` comes from upstream and is never re-stamped on conflict, and the DO UPDATE is change-guarded.

### No backfill for existing rows

Existing rows' original `created_at` is **unrecoverable**. The upstream date was never persisted anywhere on our side — it was read off the PowerSync payload and dropped, and the payload is not retained. The only surviving value is the sync-time default already in the column, and Kilter's PowerSync stream carries no history we could replay a date from without a full re-pull that would itself rewrite the same rows. So this PR changes go-forward behaviour only. Rows re-delivered by a future sync cycle will keep their (wrong) `created_at` by design, because re-stamping on conflict would break the Boardsesh-originated case above. If we later decide the wrong dates are worse than the churn, that is a deliberate one-shot migration, not something this upsert should do implicitly.

## Tests

New real-Postgres test: `packages/backend/src/__tests__/kilter-climb-ratings-timestamps.test.ts` (7 tests). The change guard is a property of the generated SQL, not of JS — a mocked-drizzle test could only re-assert a predicate we wrote ourselves, so this drives the actual `insert … on conflict do update` against Postgres and reads the stored timestamps back.

Plus, in the package's own DB-free suite (`packages/kilter-sync/src/sync/user-sync.test.ts`): the existing bulk-insert test now asserts `createdAt` on the values map, so dropping the mapping fails there too without a database; and `parseKilterTimestamp` gets direct coverage for the `Z`, explicit-offset, zone-less, date-only, and unparseable branches.

Coverage: upstream date is stored (with a non-UTC offset, proving UTC normalisation); unparseable date falls back to the default instead of aborting; an unchanged redelivery leaves `updated_at` and `created_at` untouched; a real rating change bumps `updated_at` but not `created_at`; `kilter_id` adoption onto a Boardsesh-originated row bumps once then settles; the guard holds across a multi-row batch (the real sync flushes hundreds per statement); and a cleared upstream comment is pinned as a real change.

**Fail-on-revert, both arms verified:**

- Removing the `createdAt` mapping → 4 failed (`expected 1785457710098 to be 1709656200000` — sync time instead of the rating date).
- Removing the `setWhere` → 3 failed (`expected 1785458436147 to be 1577836800000` — `updated_at` rewritten on an unchanged redelivery).

## QA Notes

Backend/sync-worker only, no UI surface. Nothing to click through.

To exercise on a dev DB: run a Kilter user sync twice with no upstream changes between cycles, then check `board_climb_ratings` — `created_at` should match the rating dates in the Kilter app (not today), and `updated_at` should be identical across both runs. Change one rating in the Kilter app, sync again, and only that row's `updated_at` should move.

## Release Notes

none — nothing currently reads `board_climb_ratings.created_at` (the only consumer of the table is the tick-quality join, which reads `rating`), so the corrected dates aren't visible on any surface yet. This fixes the data before a surface depends on it.

Fixes #3524
