### PR TITLE
test(sync): cover the push-uuid alias-map miss in buildLogPushItem

### DIFF
--- a/packages/kilter-sync/src/sync/push-back.test.ts
+++ b/packages/kilter-sync/src/sync/push-back.test.ts
@@ -73,4 +73,10 @@ describe('buildLogPushItem', () => {
     const item = buildLogPushItem(tick, new Map([['canonical-uuid', 'kilter-alias-uuid']]));
     expect(item.climbUuid).toBe('kilter-alias-uuid');
   });
+
+  it('falls back to the canonical climbUuid when the alias map has no entry', () => {
+    const tick = makeTick({ climbUuid: 'canonical-uuid' });
+    const item = buildLogPushItem(tick, new Map([['some-other-uuid', 'kilter-alias-uuid']]));
+    expect(item.climbUuid).toBe('canonical-uuid');
+  });
 });


### PR DESCRIPTION
## What & why

Review follow-up to #4030 (fixed #3527), which merged before this commit landed on the branch.

The claude-review bot flagged one gap in `push-back.test.ts`: `buildLogPushItem` was covered for the case where the Kilter push-uuid alias map has an entry for the tick's climb, but not for the miss case, where `resolveKilterPushUuid` must fall back to the canonical UUID.

## Fix

Adds that one test. No production code changes.

## Tests + fail-on-revert

`packages/kilter-sync/src/sync/push-back.test.ts` now has 9 tests. Deleting the `?? canonicalUuid` fallback in `resolveKilterPushUuid` turns the new case red (undefined vs `'canonical-uuid'`); without this test that deletion stays green.

## QA Notes

Test-only. `vp test run --project kilter-sync --reporter=agent packages/kilter-sync/src/sync/push-back.test.ts` → 9/9 pass; `vp lint` / `vp fmt --check` on the file are clean.

## Release Notes

- [x] No release note needed (internal / technical change)
