### PR TITLE
fix(backend): clear kiosk queue previews when a board goes private or is deleted

### DIFF
--- a/packages/backend/src/__tests__/board-queue-preview.test.ts
+++ b/packages/backend/src/__tests__/board-queue-preview.test.ts
@@ -20,6 +20,7 @@ import {
   buildBoardQueuePreview,
   getBoardQueuePreviewSnapshot,
   publishBoardQueuePreviewForSession,
+  publishBoardQueuePreviewTombstoneForBoard,
   publishBoardQueuePreviewTombstoneForSession,
   registerBoardQueuePreviewHook,
   toBoardQueuePreviewItem,
@@ -31,6 +32,7 @@ import {
 import { boardPresenceMutations } from '../graphql/resolvers/board-presence/mutations';
 import { SYSTEM_BOARD_OWNER_ID } from '../graphql/resolvers/board-presence/shared';
 import { roomManager } from '../services/room-manager';
+import { socialBoardMutations } from '../graphql/resolvers/social/boards';
 
 const TEST_USER_ID = 'board-queue-preview-test-user';
 const TEST_BOARD_PATH = 'queue-preview-test/1/10/1,2/40';
@@ -87,18 +89,23 @@ function makeQueueEvent(item: ClimbQueueItem): QueueEvent {
 }
 
 let boardSlugCounter = 0;
-async function makeBoard({
+/**
+ * Insert a board and return both keys: the numeric id the preview channel is
+ * keyed by, and the (real, schema-valid) uuid the social board mutations take.
+ */
+async function makeBoardRow({
   isPublic,
   ownerId = TEST_USER_ID,
 }: {
   isPublic: boolean;
   ownerId?: string;
-}): Promise<number> {
+}): Promise<{ id: number; uuid: string }> {
   const slug = `qp-board-${Date.now().toString(36)}-${boardSlugCounter++}`;
+  const boardUuid = uuidv4();
   const [row] = await db
     .insert(dbSchema.userBoards)
     .values({
-      uuid: `uuid-${slug}`,
+      uuid: boardUuid,
       slug,
       ownerId,
       boardType: 'kilter',
@@ -110,7 +117,12 @@ async function makeBoard({
       isPublic,
     })
     .returning({ id: dbSchema.userBoards.id });
-  return Number(row.id);
+  return { id: Number(row.id), uuid: boardUuid };
+}
+
+async function makeBoard(options: { isPublic: boolean; ownerId?: string }): Promise<number> {
+  const { id } = await makeBoardRow(options);
+  return id;
 }
 
 async function makeSession({
@@ -189,13 +201,13 @@ async function cleanup(): Promise<void> {
 }
 
 /** A public board with a public, active, queue-seeded session bound to it. */
-async function makePreviewableSession(): Promise<{ boardId: number; sessionId: string }> {
-  const boardId = await makeBoard({ isPublic: true });
+async function makePreviewableSession(): Promise<{ boardId: number; boardUuid: string; sessionId: string }> {
+  const { id: boardId, uuid: boardUuid } = await makeBoardRow({ isPublic: true });
   const sessionId = await makeSession({ boardId, isPublic: true });
   const queue = [makeQueueItem(1), makeQueueItem(2)];
   await seedQueueState(sessionId, queue, queue[0]);
   await bindSessionToBoard(sessionId, boardId);
-  return { boardId, sessionId };
+  return { boardId, boardUuid, sessionId };
 }
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -812,6 +824,118 @@ describe('board-queue-preview tombstone', () => {
       // nothing to clear — and even an empty publish would leak "a session
       // just ended here" timing on the private board's channel.
       await roomManager.endSession(sessionId);
+      expect(received).toHaveLength(0);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it('the board-level tombstone publishes an empty snapshot for a board with a bound session', async () => {
+    const { boardId } = await makePreviewableSession();
+    const received: BoardQueuePreview[] = [];
+    const unsubscribe = await pubsub.subscribeBoardQueuePreview(String(boardId), (preview) => received.push(preview));
+
+    try {
+      await publishBoardQueuePreviewTombstoneForBoard(boardId);
+
+      expect(received).toHaveLength(1);
+      expect(received[0]).toMatchObject({ boardId, ...EMPTY_PREVIEW_SHAPE });
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it('the board-level tombstone publishes nothing when no session is bound to the board', async () => {
+    const boardId = await makeBoard({ isPublic: true });
+    const received: BoardQueuePreview[] = [];
+    const unsubscribe = await pubsub.subscribeBoardQueuePreview(String(boardId), (preview) => received.push(preview));
+
+    try {
+      // Nothing ever previewed here, so there is nothing to clear.
+      await publishBoardQueuePreviewTombstoneForBoard(boardId);
+      expect(received).toHaveLength(0);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it('flipping the BOARD to private via updateBoard tombstones the kiosk', async () => {
+    const { boardId, boardUuid } = await makePreviewableSession();
+    const received: BoardQueuePreview[] = [];
+    const unsubscribe = await pubsub.subscribeBoardQueuePreview(String(boardId), (preview) => received.push(preview));
+
+    try {
+      await socialBoardMutations.updateBoard(null, { input: { boardUuid, isPublic: false } }, authCtx());
+
+      expect(received).toHaveLength(1);
+      expect(received[0]).toMatchObject({ boardId, ...EMPTY_PREVIEW_SHAPE });
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it('an updateBoard that does not touch isPublic never tombstones', async () => {
+    const { boardId, boardUuid } = await makePreviewableSession();
+    const received: BoardQueuePreview[] = [];
+    const unsubscribe = await pubsub.subscribeBoardQueuePreview(String(boardId), (preview) => received.push(preview));
+
+    try {
+      await socialBoardMutations.updateBoard(null, { input: { boardUuid, name: 'Renamed Wall' } }, authCtx());
+      expect(received).toHaveLength(0);
+
+      // Nor does re-asserting the board is public.
+      await socialBoardMutations.updateBoard(null, { input: { boardUuid, isPublic: true } }, authCtx());
+      expect(received).toHaveLength(0);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it('does not tombstone when a board that was already private is updated', async () => {
+    const { id: boardId, uuid: boardUuid } = await makeBoardRow({ isPublic: false });
+    const sessionId = await makeSession({ boardId, isPublic: true });
+    await seedQueueState(sessionId, [makeQueueItem(1)], null);
+    await bindSessionToBoard(sessionId, boardId);
+
+    const received: BoardQueuePreview[] = [];
+    const unsubscribe = await pubsub.subscribeBoardQueuePreview(String(boardId), (preview) => received.push(preview));
+
+    try {
+      // The channel never carried a snapshot — an empty publish here would
+      // leak "something just changed" on a private board's channel.
+      await socialBoardMutations.updateBoard(null, { input: { boardUuid, isPublic: false } }, authCtx());
+      expect(received).toHaveLength(0);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it('soft-deleting a public board tombstones the kiosk', async () => {
+    const { boardId, boardUuid } = await makePreviewableSession();
+    const received: BoardQueuePreview[] = [];
+    const unsubscribe = await pubsub.subscribeBoardQueuePreview(String(boardId), (preview) => received.push(preview));
+
+    try {
+      await socialBoardMutations.deleteBoard(null, { boardUuid }, authCtx());
+
+      expect(received).toHaveLength(1);
+      expect(received[0]).toMatchObject({ boardId, ...EMPTY_PREVIEW_SHAPE });
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it('soft-deleting a private board publishes nothing', async () => {
+    const { id: boardId, uuid: boardUuid } = await makeBoardRow({ isPublic: false });
+    const sessionId = await makeSession({ boardId, isPublic: true });
+    await seedQueueState(sessionId, [makeQueueItem(1)], null);
+    await bindSessionToBoard(sessionId, boardId);
+
+    const received: BoardQueuePreview[] = [];
+    const unsubscribe = await pubsub.subscribeBoardQueuePreview(String(boardId), (preview) => received.push(preview));
+
+    try {
+      await socialBoardMutations.deleteBoard(null, { boardUuid }, authCtx());
       expect(received).toHaveLength(0);
     } finally {
       unsubscribe();

--- a/packages/backend/src/__tests__/board-queue-preview.test.ts
+++ b/packages/backend/src/__tests__/board-queue-preview.test.ts
@@ -845,14 +845,82 @@ describe('board-queue-preview tombstone', () => {
     }
   });
 
-  it('the board-level tombstone publishes nothing when no session is bound to the board', async () => {
+  it('the board-level tombstone publishes even with no session binding (kiosks seeded from the DB fallback)', async () => {
+    // The `board:{id}:session` binding is only a side effect of a climb
+    // report, TTLs out after 12h and is process-local without Redis — but a
+    // kiosk's snapshot can come from resolvePublicPreviewSessionForBoard's
+    // durable fallback. Gating the tombstone on the binding would strand
+    // exactly those kiosks on a stale queue.
     const boardId = await makeBoard({ isPublic: true });
     const received: BoardQueuePreview[] = [];
     const unsubscribe = await pubsub.subscribeBoardQueuePreview(String(boardId), (preview) => received.push(preview));
 
     try {
-      // Nothing ever previewed here, so there is nothing to clear.
       await publishBoardQueuePreviewTombstoneForBoard(boardId);
+      expect(received).toHaveLength(1);
+      expect(received[0]).toMatchObject({ boardId, ...EMPTY_PREVIEW_SHAPE });
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it('flipping private clears a kiosk whose snapshot came from the DB fallback (no binding)', async () => {
+    const { id: boardId, uuid: boardUuid } = await makeBoardRow({ isPublic: true });
+    const sessionId = await makeSession({ boardId, isPublic: true });
+    await seedQueueState(sessionId, [makeQueueItem(1)], null);
+    // Deliberately no bindSessionToBoard — the seed still finds this session
+    // through the durable fallback, so the kiosk is showing a queue the flip
+    // has to clear.
+    expect(await getBoardQueuePreviewSnapshot(boardId)).not.toBeNull();
+
+    const received: BoardQueuePreview[] = [];
+    const unsubscribe = await pubsub.subscribeBoardQueuePreview(String(boardId), (preview) => received.push(preview));
+
+    try {
+      await socialBoardMutations.updateBoard(null, { input: { boardUuid, isPublic: false } }, authCtx());
+
+      expect(received).toHaveLength(1);
+      expect(received[0]).toMatchObject({ boardId, ...EMPTY_PREVIEW_SHAPE });
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it('does not tombstone when a SYSTEM-owned board flips isPublic (still anon-readable)', async () => {
+    await seedSystemBoardOwner();
+    const { id: boardId, uuid: boardUuid } = await makeBoardRow({ isPublic: true, ownerId: SYSTEM_BOARD_OWNER_ID });
+    const sessionId = await makeSession({ boardId, isPublic: true });
+    await seedQueueState(sessionId, [makeQueueItem(1)], null);
+    await bindSessionToBoard(sessionId, boardId);
+
+    const received: BoardQueuePreview[] = [];
+    const unsubscribe = await pubsub.subscribeBoardQueuePreview(String(boardId), (preview) => received.push(preview));
+
+    try {
+      // System boards stay anon-readable whatever isPublic says, so the
+      // producer keeps publishing — blanking their kiosks would be a bug.
+      await socialBoardMutations.updateBoard(
+        null,
+        { input: { boardUuid, isPublic: false } },
+        authCtx({ userId: SYSTEM_BOARD_OWNER_ID }),
+      );
+      expect(received).toHaveLength(0);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it('does not tombstone when a soft-deleted board is restored and flipped private in one update', async () => {
+    const { boardId, boardUuid } = await makePreviewableSession();
+    await db.update(dbSchema.userBoards).set({ deletedAt: new Date() }).where(eq(dbSchema.userBoards.id, boardId));
+
+    const received: BoardQueuePreview[] = [];
+    const unsubscribe = await pubsub.subscribeBoardQueuePreview(String(boardId), (preview) => received.push(preview));
+
+    try {
+      // The board was already out of the anon-readable set, so this update is
+      // not an anon-readable → not-anon-readable transition.
+      await socialBoardMutations.updateBoard(null, { input: { boardUuid, isPublic: false } }, authCtx());
       expect(received).toHaveLength(0);
     } finally {
       unsubscribe();

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -25,6 +25,7 @@ import { findExactNameMatchesWithin, decideAutoGymAttachment, AUTO_GYM_MATCH_RAD
 import { isGenericGymName } from '@boardsesh/db/queries';
 import { getUserCommunityRoles, hasAdminOrLeader, rolesGrantAdminOrLeader } from './roles';
 import { SYSTEM_BOARD_OWNER_ID, requireAnonReadableBoard } from '../board-presence/shared';
+import { publishBoardQueuePreviewTombstoneForBoard } from '../../../services/board-queue-preview';
 import { logger } from '../../../utils/logger';
 import { redisClientManager } from '../../../redis/client';
 import { isUniqueViolation } from '../../../utils/postgres-errors';
@@ -1943,6 +1944,33 @@ export const socialBoardMutations = {
       throw error;
     }
 
+    // A public→private flip takes the board out of the anon-readable set, so
+    // the board-queue-preview producer goes quiet — public kiosks would keep
+    // rendering the last snapshot forever. Clear them with a tombstone.
+    // The "was previously anon-readable" gate lives HERE, on the pre-update
+    // row we already hold: a board that was never anon-readable must not get a
+    // publish on its channel at all (that alone would leak "something changed
+    // here" to anyone who guessed the board id). System-owned boards stay
+    // anon-readable regardless of isPublic, so a flip there is not a
+    // transition and must not blank their kiosks.
+    if (
+      board.isPublic &&
+      validatedInput.isPublic === false &&
+      !board.deletedAt &&
+      board.ownerId !== SYSTEM_BOARD_OWNER_ID
+    ) {
+      try {
+        await publishBoardQueuePreviewTombstoneForBoard(board.id);
+      } catch (error) {
+        // A pubsub hiccup must never fail the edit itself — the kiosk clears
+        // on its next reconnect/seed instead.
+        logger.warn('Failed to publish board queue preview tombstone on private flip', {
+          boardId: board.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
     // Update PostGIS location column
     if (validatedInput.latitude !== undefined || validatedInput.longitude !== undefined) {
       const lat = validatedInput.latitude ?? updated.latitude;
@@ -1970,7 +1998,11 @@ export const socialBoardMutations = {
     const userId = ctx.userId!;
 
     const [board] = await db
-      .select({ id: dbSchema.userBoards.id, ownerId: dbSchema.userBoards.ownerId })
+      .select({
+        id: dbSchema.userBoards.id,
+        ownerId: dbSchema.userBoards.ownerId,
+        isPublic: dbSchema.userBoards.isPublic,
+      })
       .from(dbSchema.userBoards)
       .where(and(eq(dbSchema.userBoards.uuid, boardUuid), isNull(dbSchema.userBoards.deletedAt)))
       .limit(1);
@@ -1989,6 +2021,22 @@ export const socialBoardMutations = {
       .update(dbSchema.userBoards)
       .set({ deletedAt: new Date(), syncFrozenAt: new Date() })
       .where(eq(dbSchema.userBoards.id, board.id));
+
+    // Same reasoning as the public→private flip in updateBoard: a soft-deleted
+    // board drops out of the anon-readable set, so the preview producer goes
+    // quiet and kiosks would keep the last snapshot. Gate on the pre-delete
+    // row's anon-readability (a private board's channel never carried a
+    // snapshot, and publishing on it would leak the deletion's timing).
+    if (board.isPublic || board.ownerId === SYSTEM_BOARD_OWNER_ID) {
+      try {
+        await publishBoardQueuePreviewTombstoneForBoard(board.id);
+      } catch (error) {
+        logger.warn('Failed to publish board queue preview tombstone on board delete', {
+          boardId: board.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
 
     return true;
   },

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -2027,7 +2027,11 @@ export const socialBoardMutations = {
     // quiet and kiosks would keep the last snapshot. Gate on the pre-delete
     // row's anon-readability (a private board's channel never carried a
     // snapshot, and publishing on it would leak the deletion's timing).
-    if (board.isPublic || board.ownerId === SYSTEM_BOARD_OWNER_ID) {
+    // `isPublic` alone is the whole gate: the other half of
+    // `isBoardAnonReadable` — system-owned boards — is unreachable here,
+    // because the ownership check above only lets the authenticated owner
+    // through and nobody can authenticate as the synthetic system owner.
+    if (board.isPublic) {
       try {
         await publishBoardQueuePreviewTombstoneForBoard(board.id);
       } catch (error) {

--- a/packages/backend/src/services/board-queue-preview-tombstone.ts
+++ b/packages/backend/src/services/board-queue-preview-tombstone.ts
@@ -108,9 +108,16 @@ export async function publishBoardQueuePreviewTombstoneForSession(sessionId: str
  * board-visibility flip is not a queue event, and once the flip commits the
  * producer simply goes quiet.
  *
- * Only publishes when the board still has a bound session (the only case where
- * a snapshot was ever produced, so the only case where anything needs
- * clearing).
+ * Publishes UNCONDITIONALLY once the caller's transition gate holds. It
+ * deliberately does not require a live `board:{id}:session` binding first:
+ * that binding is only a side effect of a climb report, TTLs out after 12h,
+ * and is process-local when Redis is off — while the snapshot a kiosk is
+ * actually rendering can equally come from
+ * `resolvePublicPreviewSessionForBoard`'s durable fallback (newest active
+ * public `board_sessions` row for the board). Gating on the binding would
+ * leave exactly those kiosks — no send in 12h, Redis flushed, or a Redis-less
+ * restart — stuck on the stale queue forever, which is the bug this exists to
+ * fix. An empty publish on a channel nobody watches costs one PUBLISH.
  *
  * Deliberately does NOT re-check `isBoardAnonReadable` or
  * `isPublicActiveSession` the way `...ForSession` does: by the time a caller
@@ -125,8 +132,5 @@ export async function publishBoardQueuePreviewTombstoneForSession(sessionId: str
  * `...ForSession`'s gate 1 exists to prevent.
  */
 export async function publishBoardQueuePreviewTombstoneForBoard(boardId: number): Promise<void> {
-  const boundSessionId = await pubsub.getBoardSession(String(boardId));
-  if (!boundSessionId) return;
-
   pubsub.publishBoardQueuePreview(String(boardId), buildEmptyBoardQueuePreview(boardId));
 }

--- a/packages/backend/src/services/board-queue-preview-tombstone.ts
+++ b/packages/backend/src/services/board-queue-preview-tombstone.ts
@@ -67,6 +67,9 @@ export function buildEmptyBoardQueuePreview(boardId: number): BoardQueuePreview 
  * explicit `endSession` mutation, and the inactivity sweep). There is
  * currently no mutation that flips `board_sessions.is_public` after creation
  * — if one is ever added, it MUST call this too when flipping to private.
+ * The board-level equivalent (`user_boards.is_public` flipped private, or the
+ * board soft-deleted) goes through `publishBoardQueuePreviewTombstoneForBoard`
+ * below, which `updateBoard`/`deleteBoard` call.
  *
  * Guards, in order:
  * - Only while the board's REVERSE binding still points at THIS session. When
@@ -95,4 +98,35 @@ export async function publishBoardQueuePreviewTombstoneForSession(sessionId: str
   if (await isPublicActiveSession(sessionId)) return;
 
   pubsub.publishBoardQueuePreview(boardId, buildEmptyBoardQueuePreview(Number(boardId)));
+}
+
+/**
+ * Publish an EMPTY preview (tombstone) for a board that just STOPPED being
+ * anonymously readable — `user_boards.is_public` flipped true→false, or the
+ * board was soft-deleted. Without this, kiosks keep rendering the last
+ * snapshot forever: the live producer re-gates every queue event, but a
+ * board-visibility flip is not a queue event, and once the flip commits the
+ * producer simply goes quiet.
+ *
+ * Only publishes when the board still has a bound session (the only case where
+ * a snapshot was ever produced, so the only case where anything needs
+ * clearing).
+ *
+ * Deliberately does NOT re-check `isBoardAnonReadable` or
+ * `isPublicActiveSession` the way `...ForSession` does: by the time a caller
+ * gets here the board is already private/deleted, so both gates would return
+ * false and suppress the exact publish this function exists to make.
+ *
+ * **The caller owns the privacy gate.** Call this ONLY on a genuine
+ * anon-readable → not-anon-readable transition, using the pre-update row it
+ * already has in hand (no extra query needed). Publishing on a board that was
+ * never anon-readable would leak "something just changed here" on a private
+ * board's channel to anyone who guessed its id — the same leak
+ * `...ForSession`'s gate 1 exists to prevent.
+ */
+export async function publishBoardQueuePreviewTombstoneForBoard(boardId: number): Promise<void> {
+  const boundSessionId = await pubsub.getBoardSession(String(boardId));
+  if (!boundSessionId) return;
+
+  pubsub.publishBoardQueuePreview(String(boardId), buildEmptyBoardQueuePreview(boardId));
 }

--- a/packages/backend/src/services/board-queue-preview.ts
+++ b/packages/backend/src/services/board-queue-preview.ts
@@ -15,6 +15,7 @@ import { logger } from '../utils/logger';
 export {
   buildEmptyBoardQueuePreview,
   isPublicActiveSession,
+  publishBoardQueuePreviewTombstoneForBoard,
   publishBoardQueuePreviewTombstoneForSession,
 } from './board-queue-preview-tombstone';
 


### PR DESCRIPTION
## What / why

A gym kiosk showing a board's "Up next" queue kept displaying the last snapshot forever after the board was flipped to private or deleted. The board-queue-preview producer only republishes on queue events, so once a board leaves the anon-readable set it simply goes quiet — nothing ever tells the kiosk to clear.

## Verified root cause

- `updateBoard` (`packages/backend/src/graphql/resolvers/social/boards.ts`) writes `updateValues.isPublic` and commits, but never touches pubsub — `rg pubsub` in that file had zero hits.
- `deleteBoard` in the same file has the identical gap on soft-delete.
- Naively reusing the session-level helper would not have fixed it: `publishBoardQueuePreviewTombstoneForSession` gates on `isBoardAnonReadable(boardId)`, which re-reads `user_boards.is_public` live. Once the flip commits that gate is false and the call silently no-ops.
- The tombstone module's own doc comment flagged this as an open gap (`board_sessions.is_public`); the issue is one level up, at `user_boards.is_public`, and is distinct from #3628's session-level tombstone.

## Fix

- New `publishBoardQueuePreviewTombstoneForBoard(boardId)` in `packages/backend/src/services/board-queue-preview-tombstone.ts`: publishes an empty snapshot for the board. It deliberately skips the anon-readable / session-active gates, since by the time a caller reaches it the board is already private or deleted and both gates would suppress the very publish it exists to make. Re-exported from `board-queue-preview.ts` (single import point).
- It also does **not** require a live `board:{id}:session` binding. Paired QA caught that an earlier revision did: that binding is only written as a side effect of a climb report, carries a 12h TTL, and is process-local memory when Redis is off — while the snapshot a kiosk renders can equally come from `resolvePublicPreviewSessionForBoard`'s durable fallback (newest active public `board_sessions` row). Gating on the binding stranded exactly those kiosks — no send in 12h, Redis flushed, or a Redis-less restart — on the stale queue, the issue's own symptom. An empty publish on a channel nobody watches costs one PUBLISH.
- The privacy gate lives at the **call sites**, which already hold the pre-update row — no extra query, and no publish on a channel that was never anon-readable (that alone would leak "something changed here" to anyone who guessed a private board's id):
  - `updateBoard`: fires only on a genuine true→false flip of a live, non-system-owned board (`board.isPublic && input.isPublic === false && !board.deletedAt && ownerId !== SYSTEM_BOARD_OWNER_ID`). System-owned boards stay anon-readable regardless of `isPublic`, so a flip there is not a transition and must not blank their kiosks.
  - `deleteBoard`: fires when the pre-delete row was anon-readable, which here is just `board.isPublic` — the other half of `isBoardAnonReadable` (system-owned boards) is unreachable, because the ownership check above it only lets the authenticated owner through and nobody can authenticate as the synthetic system owner.
- Both are wrapped in try/catch + `logger.warn`, so a pubsub hiccup never fails the edit or the delete.

## Tests

Extends the existing `board-queue-preview tombstone` describe in `packages/backend/src/__tests__/board-queue-preview.test.ts` (7 new cases), reusing its `makePreviewableSession` / `bindSessionToBoard` / `subscribeBoardQueuePreview` harness:

- board-level tombstone publishes one empty snapshot for the board, including with no session binding at all (the DB-fallback kiosk case).
- `updateBoard(isPublic: false)` on a public board whose kiosk was seeded through the durable fallback with **no** binding → one empty snapshot (asserts the seed was non-null first).
- `updateBoard(isPublic: false)` on a previewable public board → subscriber receives exactly one empty snapshot.
- `updateBoard` that renames only, and one that re-asserts `isPublic: true` → zero publishes.
- `updateBoard(isPublic: false)` on an already-private board → zero publishes (the privacy invariant).
- `deleteBoard` on a public board with a bound session → one empty snapshot; on a private board → zero.
- system-owned board flipping `isPublic: false` → zero publishes (it stays anon-readable, so its kiosks must not blank).
- soft-deleted board restored *and* flipped private in one update → zero publishes (not an anon-readable transition).

**Fail-on-revert:** with `boards.ts` reverted to `main` and the tests kept, the two end-to-end cases fail (`expected [] to have a length of 1 but got +0`); the rest of the file stays green. Reinstating the binding early-return in the helper fails the two DB-fallback cases and nothing else. These call the real resolvers and assert on a real subscriber, so they cannot pass without the wiring.

`makeBoard` now inserts a real UUID (the social board mutations validate `boardUuid` as a UUID) and is split into `makeBoardRow` returning `{ id, uuid }`.

Validation: `vp run typecheck:backend` clean; `vp test run --project backend packages/backend/src/__tests__/board-queue-preview.test.ts` → 42/42 pass; `vp check` formatting clean (its 2 lint errors are pre-existing and in other packages, untouched here).

Test-infra note: this file needs an isolated postgres to run reliably right now — the shared `:5433` worker DBs deadlock in the `beforeEach` TRUNCATE when other backend suites run concurrently. That is environmental, not this branch.

## QA Notes

Backend-only, no schema or migration change.

1. Make a board public and take a session on it so a kiosk shows the queue.
2. Flip the board to private in board settings — the kiosk preview must clear immediately instead of holding the last climb.
3. Repeat with delete — same immediate clear.
4. Sanity: editing a private board's name or visibility must not push anything to its preview channel.
5. Fallback path worth exercising: leave the board idle long enough that no recent climb was reported (or restart the backend), then flip it private — the kiosk must still clear.

## Release Notes

Kiosk displays now clear a board's queue preview the moment you flip that board to private or delete it, instead of leaving the last climb on screen.

Fixes #3649
