### PR TITLE
fix(sync): reject sub-one Kilter Grips quality averages

### DIFF
--- a/packages/kilter-sync/src/sync/quality-scale.test.ts
+++ b/packages/kilter-sync/src/sync/quality-scale.test.ts
@@ -20,7 +20,7 @@ describe('correctGripsQualityAverage', () => {
     expect(correctGripsQualityAverage(4.0)).toBe(4.0);
   });
 
-  it('treats non-ratings as null (≤ 0 unrated, > 5 garbage, non-finite)', () => {
+  it('treats non-ratings as null (< 1 unrated/fractional, > 5 garbage, non-finite)', () => {
     expect(correctGripsQualityAverage(null)).toBeNull();
     expect(correctGripsQualityAverage(undefined)).toBeNull();
     expect(correctGripsQualityAverage(0)).toBeNull();
@@ -28,5 +28,11 @@ describe('correctGripsQualityAverage', () => {
     expect(correctGripsQualityAverage(5.0001)).toBeNull();
     expect(correctGripsQualityAverage(10)).toBeNull();
     expect(correctGripsQualityAverage(Number.NaN)).toBeNull();
+    // A 1-5 star scale has no valid value below 1 — a sub-one fraction (e.g. a
+    // pre-cutover blend gone wrong) is as much garbage as 0 or a negative.
+    expect(correctGripsQualityAverage(0.2)).toBeNull();
+    expect(correctGripsQualityAverage(0.99)).toBeNull();
+    // 1.0 is the lowest valid rating and must survive unchanged.
+    expect(correctGripsQualityAverage(1.0)).toBe(1.0);
   });
 });

--- a/packages/kilter-sync/src/sync/quality-scale.ts
+++ b/packages/kilter-sync/src/sync/quality-scale.ts
@@ -23,13 +23,14 @@
  * Store a Kilter Grips `qualityAverage` verbatim (it is already 1-5), guarding
  * only against non-ratings.
  *
- * - `null`/`undefined`/non-finite/`≤ 0`/`> 5` → `null` (unrated is never a 0
- *   rating; above 5 is garbage).
+ * - `null`/`undefined`/non-finite/`< 1`/`> 5` → `null` (a 1-5 star scale has no
+ *   valid value below 1 — anything in `(0, 1)` is as much garbage as `≤ 0`;
+ *   above 5 is garbage too).
  * - otherwise → `raw`, unchanged.
  */
 export function correctGripsQualityAverage(raw: number | null | undefined): number | null {
   if (raw == null) return null;
   const quality = Number(raw);
-  if (!Number.isFinite(quality) || quality <= 0 || quality > 5) return null;
+  if (!Number.isFinite(quality) || quality < 1 || quality > 5) return null;
   return quality;
 }


### PR DESCRIPTION
## Summary

- Tightens `correctGripsQualityAverage`'s lower bound from `quality <= 0` to `quality < 1`, so a sub-one fractional Kilter Grips `qualityAverage` (e.g. `0.2`, `0.99`) is now stored as `null` instead of being written verbatim as an impossible fraction-of-a-star rating.
- Code-only. No migration, no data backfill — see **Deferred** below.

### Why

A Kilter Grips star rating is a 1-5 scale; there is no valid rating below 1. The existing guard in `correctGripsQualityAverage` only rejected `quality <= 0`, so any value in the open interval `(0, 1)` — e.g. `0.2` or `0.25` — passed through untouched and got written to `board_climb_stats.quality_average` (and `upstream_quality_average`, which is seeded from the same value in the catalog-sync fold). Kilter's own upstream aggregate apparently blends in unrated/0 entries for some climb+angle pairs, producing exactly these sub-1 averages.

### Verified root cause

`packages/kilter-sync/src/sync/quality-scale.ts:33` (pre-fix):

```ts
if (!Number.isFinite(quality) || quality <= 0 || quality > 5) return null;
```

`quality <= 0` rejects `0` and negatives but admits anything in `(0, 1)`. That guarded value is consumed verbatim (no rescaling — see the file's module doc) by `packages/kilter-sync/src/sync/catalog-sync.ts:251` (`correctGripsQualityAverage(stat.qualityAverage)`), which feeds both `quality_average` and, via `upstreamQualityAverage: accum.qualityAverage` at `catalog-sync.ts:640`, `upstream_quality_average`.

### The fix

`packages/kilter-sync/src/sync/quality-scale.ts`:

```ts
if (!Number.isFinite(quality) || quality < 1 || quality > 5) return null;
```

Doc comment updated to describe the `< 1` bound and why (a 1-5 star scale has no valid value below 1).

## Tests

`packages/kilter-sync/src/sync/quality-scale.test.ts`, `'treats non-ratings as null'`:

- `correctGripsQualityAverage(0.2)` → `null`
- `correctGripsQualityAverage(0.99)` → `null`
- `correctGripsQualityAverage(1.0)` → `1.0` exactly (boundary must still pass through)

**Verified each fails on revert:** reverting the guard back to `quality <= 0` locally reproduces the bug — `correctGripsQualityAverage(0.2)` returns `0.2` instead of `null`, failing the new assertions (`1.0` and non-fractional cases still pass, since those never depended on the bound). Confirms the test actually exercises the fixed line rather than being vacuously true.

## Deferred: prod data cleanup

This PR only stops **new** sub-1 values from being written. It does **not** touch existing data.

Per issue #3522, prod currently has **~619 `board_climb_stats` rows** (board_type `kilter`) with `0 < quality_average < 1` (and the same upstream-sourced value likely also sitting in `upstream_quality_average` for those rows, since both columns are seeded from the same Grips aggregate). Cleanup of those existing rows (e.g. `UPDATE ... SET quality_average = NULL WHERE quality_average > 0 AND quality_average < 1`) requires a migration and is **deferred pending explicit maintainer sign-off** — no such migration is included in this PR.

## QA Notes

Code-only fix in a backend sync package; no UI surface to click through.

- Confirm `vp run typecheck:kilter` and the scoped test file (`packages/kilter-sync/src/sync/quality-scale.test.ts`) are green (see Test plan).
- Manual sanity check (optional, no DB write): in a REPL, `correctGripsQualityAverage(0.2)` → `null`, `correctGripsQualityAverage(1.0)` → `1.0`, `correctGripsQualityAverage(3.0)` → `3.0` (unchanged, regression guard against the old rescale bug still holds).
- No prod data changes ship with this PR — nothing to visually QA on existing climbs; new syncs simply stop persisting sub-1 fractional ratings going forward.

## Release Notes

Fixed a data glitch where some Kilter climbs could show an impossible fraction-of-a-star rating.

## Test plan

- [x] `vp run typecheck:kilter` — green
- [x] `vp test run --reporter=agent packages/kilter-sync/src/sync/quality-scale.test.ts` — 1 file, 3 tests passed
- [x] `vp check` (repo-wide) — no lint/format issues in the two changed files (pre-existing unrelated warnings/errors in `packages/db/scripts` are untouched by this diff)
- [x] Reverted the bound locally and confirmed the new assertions fail, then restored the fix and confirmed green again

Refs #3522 (kept open: the ~619-row prod cleanup below still needs maintainer sign-off; this PR only stops new garbage)

