### PR TITLE
fix(sync): resync user data when the deletions retention window is blown

### DIFF
--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -600,7 +600,24 @@ ORDER BY deleted_at ASC, id ASC
 LIMIT $limit;
 ```
 
-Periodic cleanup: `DELETE FROM sync_deletions WHERE deleted_at < NOW() - INTERVAL '90 days'`.
+Periodic cleanup: `DELETE FROM sync_deletions WHERE deleted_at < NOW() - INTERVAL '90 days'` (the daily
+`pruneSyncDeletions` job).
+
+Because that prune is a hard delete and the query above is a strict `>` keyset, a device that has been
+away longer than the window can never be served the tombstones removed in the meantime. The client
+guards it with a wall-clock **deletions-coverage marker** (`sync_meta['deletions-coverage']`, written
+only when a deletions pull reaches its tail — never the checkpoint's own age, which stands still on a
+device whose user simply deleted nothing). Once the marker is older than `90 - 10 = 80` days, `pullSync`
+probes the network first and then rebuilds the local **user** tables from scratch: it deletes the rows of
+every `USER_DATA_TABLES` entry plus their checkpoints and `checkpoint:deletions`, and the same cycle
+re-pulls them from the epoch.
+
+Downloaded board catalogs are deliberately left alone — no production path emits a board tombstone (the
+only DELETEs of `board_climbs` / `board_climb_stats` run inside the transaction that sets
+`boardsesh.suppress_sync_tombstones`), so clearing them would recover nothing and cost a full
+re-download. `pending_mutations` is never touched either: unsynced local writes are not recoverable from
+the server. Both numbers live in one place, `packages/shared/offline-sync/src/sync/retention.ts`, which
+the backend prune job imports. See `sync/deletions-coverage.ts` for the invariant.
 
 ## Backend changes needed
 

--- a/packages/backend/src/services/__tests__/sync-deletions-prune.test.ts
+++ b/packages/backend/src/services/__tests__/sync-deletions-prune.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { syncDeletions } from '@boardsesh/db/schema';
+import { SYNC_DELETIONS_RETENTION_DAYS as SHARED_RETENTION_DAYS } from '@boardsesh/offline-sync';
 import { pruneSyncDeletions, SYNC_DELETIONS_RETENTION_DAYS } from '../sync-deletions-prune';
 import type { Database } from '../../db/client';
 
@@ -30,6 +31,16 @@ describe('pruneSyncDeletions', () => {
     expect(boundDates).toHaveLength(1);
     expect(boundDates[0].getTime()).toBeGreaterThanOrEqual(beforeMs);
     expect(boundDates[0].getTime()).toBeLessThanOrEqual(afterMs);
+  });
+
+  it('prunes on the SAME window the client staleness guard compares against', async () => {
+    // The client forces a from-scratch user-data resync once its deletions
+    // coverage marker is older than this value minus a margin (issue #3474). If
+    // the two ever forked — a local `= 90` re-introduced here and then edited —
+    // the server would prune tombstones inside a window the client still
+    // believes it is covered for, silently reopening the gap on device.
+    expect(SYNC_DELETIONS_RETENTION_DAYS).toBe(SHARED_RETENTION_DAYS);
+    expect(SYNC_DELETIONS_RETENTION_DAYS).toBe(90);
   });
 
   it('returns 0 when the driver reports no count', async () => {

--- a/packages/backend/src/services/sync-deletions-prune.ts
+++ b/packages/backend/src/services/sync-deletions-prune.ts
@@ -1,5 +1,6 @@
 import { lt } from 'drizzle-orm';
 import { syncDeletions } from '@boardsesh/db/schema';
+import { SYNC_DELETIONS_RETENTION_DAYS } from '@boardsesh/offline-sync';
 import { db, type Database } from '../db/client';
 
 /**
@@ -7,13 +8,18 @@ import { db, type Database } from '../db/client';
  * `sync_deletions` (packages/db/src/schema/app/sync-deletions.ts): tombstones
  * older than this are pruned by the daily job in server.ts.
  *
- * A client whose deletions checkpoint is older than this window can miss
- * pruned tombstones (stale local rows until the affected records are next
- * upserted). Detecting that gap and forcing a from-scratch resync is a
- * client-side follow-up; the unbounded-growth risk of never pruning is the
- * worse trade.
+ * The value is OWNED by @boardsesh/offline-sync (sync/retention.ts) and
+ * re-exported here under its long-standing name. The client's staleness guard
+ * compares its deletions-coverage marker against the same number minus a
+ * margin, and forces a from-scratch user-data resync when the window is blown
+ * (issue #3474) — if the two sides ever forked, the gap this job opens would go
+ * undetected on device again. Keep the single definition.
+ *
+ * Careful when LOWERING it: a client only picks up the new value with its next
+ * OTA bundle, so shortening the server window strands older clients comparing
+ * against the old one.
  */
-export const SYNC_DELETIONS_RETENTION_DAYS = 90;
+export { SYNC_DELETIONS_RETENTION_DAYS };
 
 export async function pruneSyncDeletions(database: Database = db): Promise<number> {
   const cutoff = new Date(Date.now() - SYNC_DELETIONS_RETENTION_DAYS * 24 * 60 * 60 * 1000);

--- a/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
+++ b/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
@@ -219,6 +219,7 @@ describe('snapshot-bootstrap bindings', () => {
     const options = startSyncSchedulerCore.mock.calls[0][6] as SchedulerOptions;
     expect(options.onSnapshotBootstrapError).toBeTypeOf('function');
     expect(options.onScopeDownloadComplete).toBeTypeOf('function');
+    expect(options.onCoverageReset).toBeTypeOf('function');
   });
 
   it('triggerSync passes snapshotSource through and wires the telemetry handlers', () => {
@@ -234,6 +235,7 @@ describe('snapshot-bootstrap bindings', () => {
     expect(options.snapshotSource).toBe(fakeSnapshotSource);
     expect(options.onSnapshotBootstrapError).toBeTypeOf('function');
     expect(options.onScopeDownloadComplete).toBeTypeOf('function');
+    expect(options.onCoverageReset).toBeTypeOf('function');
   });
 
   it('reports a bootstrap failure to Sentry with the snapshot-bootstrap tags', () => {
@@ -272,6 +274,28 @@ describe('snapshot-bootstrap bindings', () => {
       method: 'snapshot',
       durationMs: 1234,
     });
+  });
+
+  it('captures a PostHog event — not a Sentry error — when the coverage guard forces a resync', () => {
+    // A forced deletions-coverage reset is expected behaviour whose FREQUENCY is
+    // the signal (issue #3474), so it belongs with the operational events, not
+    // with the handled-error anomalies alongside it in the adapter.
+    startSyncScheduler(
+      db,
+      queryClient,
+      graphqlFetch,
+      () => [],
+      async () => {},
+    );
+    const options = startSyncSchedulerCore.mock.calls[0][6] as SchedulerOptions;
+    options.onCoverageReset?.({ markerAgeDays: 100, rowsCleared: 42, pendingMutations: 3 });
+
+    expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineSyncCoverageResetForced, {
+      markerAgeDays: 100,
+      rowsCleared: 42,
+      pendingMutations: 3,
+    });
+    expect(reportHandledError).not.toHaveBeenCalled();
   });
 
   it('pullSync binds the snapshot-bootstrap telemetry defaults but lets caller options win', async () => {

--- a/packages/mobile/src/offline/offline-sync-adapter.ts
+++ b/packages/mobile/src/offline/offline-sync-adapter.ts
@@ -27,6 +27,7 @@ import {
   type DrainQueue,
   type GraphQLFetch,
   type OfflineDatabase,
+  type CoverageResetReporter,
   type ScopeDownloadCompleteReporter,
   type SchedulerTriggers,
   type SchemaDriftReporter,
@@ -66,6 +67,16 @@ const reportSnapshotBootstrapError: SnapshotBootstrapErrorReporter = ({ scopeKey
 // path actually got used, and how long it took).
 const reportScopeDownloadComplete: ScopeDownloadCompleteReporter = ({ scopeKey, method, durationMs }) => {
   track(SHARED_EVENTS.OfflineBoardDownloadCompleted, { scopeKey, method, durationMs });
+};
+
+// The deletions-coverage guard rebuilt this device's local user data because it
+// had been away longer than the tombstone retention window (issue #3474).
+// track(), not reportHandledError(): nothing failed — the guard did its job —
+// and the only question anyone will ask is how often it fires. If this shows up
+// far more than the "device away for 80+ days" model predicts, the threshold or
+// the marker plumbing is wrong, not the user's phone.
+const reportCoverageReset: CoverageResetReporter = ({ markerAgeDays, rowsCleared, pendingMutations }) => {
+  track(SHARED_EVENTS.OfflineSyncCoverageResetForced, { markerAgeDays, rowsCleared, pendingMutations });
 };
 
 // A failed cycle is routine for offline users (the reconnect trigger retries),
@@ -137,6 +148,7 @@ export function startSyncScheduler(
     snapshotSource: options?.snapshotSource,
     onSnapshotBootstrapError: reportSnapshotBootstrapError,
     onScopeDownloadComplete: reportScopeDownloadComplete,
+    onCoverageReset: reportCoverageReset,
   });
 }
 
@@ -155,6 +167,7 @@ export function triggerSync(
     snapshotSource: options?.snapshotSource,
     onSnapshotBootstrapError: reportSnapshotBootstrapError,
     onScopeDownloadComplete: reportScopeDownloadComplete,
+    onCoverageReset: reportCoverageReset,
   });
 }
 
@@ -168,6 +181,7 @@ export function pullSync(
     onSchemaDrift: reportSchemaDrift,
     onSnapshotBootstrapError: reportSnapshotBootstrapError,
     onScopeDownloadComplete: reportScopeDownloadComplete,
+    onCoverageReset: reportCoverageReset,
     ...options,
   });
 }

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -269,6 +269,13 @@ export const SHARED_EVENTS = {
   // method: 'snapshot' | 'paged', durationMs }. Mobile-only today (the engine
   // is shared, so a future web offline consumer would fire this too).
   OfflineBoardDownloadCompleted: 'Offline Board Download Completed',
+  // Offline sync — the device went longer than the tombstone retention window
+  // without completing a deletions pull, so its local USER data was rebuilt
+  // from scratch (issue #3474). Expected behaviour rather than an error: the
+  // rate across the fleet is the signal. Props: { markerAgeDays, rowsCleared,
+  // pendingMutations }. Downloaded board catalogs are deliberately untouched,
+  // so this never implies a surprise re-download.
+  OfflineSyncCoverageResetForced: 'Offline Sync Coverage Reset Forced',
 } as const;
 
 export type SharedEventKey = keyof typeof SHARED_EVENTS;

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -60,7 +60,21 @@ export type {
   SchemaDriftReporter,
   ScopeDownloadCompleteInfo,
   ScopeDownloadCompleteReporter,
+  CoverageResetInfo,
+  CoverageResetReporter,
 } from './sync/pull-client';
+
+// --- Tombstone retention (issue #3474) --------------------------------------
+// The backend prune job imports SYNC_DELETIONS_RETENTION_DAYS from here so the
+// server's window and the client's staleness threshold can never fork.
+// evaluateDeletionsCoverage / resetUserDataForLostCoverage stay package-internal
+// on purpose (same reasoning as rewindDeletionsCheckpoint below): pull-client is
+// their only caller, and no app should be able to trigger a local wipe directly.
+export {
+  SYNC_DELETIONS_RETENTION_DAYS,
+  DELETIONS_COVERAGE_MARGIN_DAYS,
+  DELETIONS_COVERAGE_MAX_AGE_MS,
+} from './sync/retention';
 export {
   bootstrapScopeFromSnapshot,
   getBootstrapAttempts,

--- a/packages/shared/offline-sync/src/sync/__tests__/checkpoints.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/checkpoints.test.ts
@@ -10,6 +10,7 @@ import {
   deleteUserCheckpoints,
 } from '../checkpoints';
 import type { SyncCheckpoint } from '../checkpoints';
+import { getDeletionsCoverageAt, setDeletionsCoverageAt } from '../deletions-coverage';
 import { BOARD_DATA_TABLES } from '../table-config';
 import { runMigrations } from '../../db/migrations';
 import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
@@ -155,5 +156,18 @@ describe('deleteUserCheckpoints', () => {
       expect(await getCheckpoint(db, `checkpoint:${tableName}:kilter:1:5`)).not.toBeNull();
     }
     expect(await getCheckpoint(db, 'checkpoint:playlists')).toBeNull();
+  });
+
+  it('clears the deletions-coverage marker so it cannot leak into the next account', async () => {
+    // Sign-out rewinds the deletions cursor to the epoch, so the departing
+    // account's coverage marker describes nothing. Left behind and stale, it
+    // trips the #3474 guard on the NEXT account's first pull: a wasted probe and
+    // a reset of tables sign-out already emptied, reported as a coverage reset
+    // with rowsCleared: 0.
+    await setDeletionsCoverageAt(db, Date.now() - 100 * 24 * 60 * 60 * 1000);
+
+    await deleteUserCheckpoints(db);
+
+    expect(await getDeletionsCoverageAt(db)).toBeNull();
   });
 });

--- a/packages/shared/offline-sync/src/sync/__tests__/deletions-coverage.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/deletions-coverage.test.ts
@@ -86,9 +86,18 @@ describe('resetUserDataForLostCoverage', () => {
     // The rows are unreachable-but-present stale data: the tombstones that would
     // have removed them were pruned server-side, and the delta resolver never
     // re-emits a deleted row, so nothing short of deleting them locally works.
+    // Counted from the DB rather than hardcoded: `rowsCleared` feeds the
+    // telemetry payload, so it has to be the real row total, not the table count
+    // it happens to equal while every table holds exactly one seeded row.
+    let seededRows = 0;
+    for (const tableName of USER_DATA_TABLES) {
+      seededRows += await countRows(db, tableName);
+    }
+    expect(seededRows).toBeGreaterThan(0);
+
     const { rowsCleared } = await resetUserDataForLostCoverage(db, NOW);
 
-    expect(rowsCleared).toBe(USER_DATA_TABLES.length);
+    expect(rowsCleared).toBe(seededRows);
     for (const tableName of USER_DATA_TABLES) {
       expect(await countRows(db, tableName)).toBe(0);
       expect(await readMeta(db, `checkpoint:${tableName}`)).toBeNull();

--- a/packages/shared/offline-sync/src/sync/__tests__/deletions-coverage.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/deletions-coverage.test.ts
@@ -1,0 +1,208 @@
+// Deletions-coverage guard (issue #3474) — the staleness oracle and the reset
+// it authorises, against the REAL on-device DDL via node:sqlite.
+//
+// The failure this guards is rare (a device away from sync for 80+ days). The
+// REGRESSION it could cause — an unintended mass wipe of everyone's ticks,
+// playlists and favourites — is not. Most of the assertions below therefore pin
+// what must NOT happen.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  DELETIONS_COVERAGE_KEY,
+  evaluateDeletionsCoverage,
+  getDeletionsCoverageAt,
+  resetUserDataForLostCoverage,
+  setDeletionsCoverageAt,
+} from '../deletions-coverage';
+import { DELETIONS_COVERAGE_MARGIN_DAYS, SYNC_DELETIONS_RETENTION_DAYS } from '../retention';
+import { USER_DATA_TABLES, BOARD_DATA_TABLES } from '../table-config';
+import { runMigrations } from '../../db/migrations';
+import { ensureMutationQueueTable } from '../../mutation-queue/schema';
+import { enqueue, type PendingMutation } from '../../mutation-queue/queue';
+import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.parse('2026-07-01T12:00:00.000Z');
+
+describe('evaluateDeletionsCoverage', () => {
+  it('reads an absent marker as unknown, never as stale', () => {
+    // Rollout safety: the key is new, so every existing install hits this branch
+    // once. If absence ever meant "stale", the OTA that ships this feature would
+    // wipe the whole fleet's user data on its first sync.
+    expect(evaluateDeletionsCoverage(null, NOW)).toBe('unknown');
+  });
+
+  it('is fresh just inside the window and stale just outside it', () => {
+    const thresholdDays = SYNC_DELETIONS_RETENTION_DAYS - DELETIONS_COVERAGE_MARGIN_DAYS;
+    expect(thresholdDays).toBe(80);
+    expect(evaluateDeletionsCoverage(NOW - (thresholdDays - 1) * DAY_MS, NOW)).toBe('fresh');
+    expect(evaluateDeletionsCoverage(NOW - thresholdDays * DAY_MS, NOW)).toBe('fresh');
+    expect(evaluateDeletionsCoverage(NOW - (thresholdDays + 1) * DAY_MS, NOW)).toBe('stale');
+  });
+
+  it('reports a future-dated marker so the caller can re-stamp it', () => {
+    // A clock corrected backwards leaves a marker ahead of `now`. Without this
+    // branch `now - marker` stays negative forever and the marker can never go
+    // stale again — the guard would be permanently disarmed on that device.
+    expect(evaluateDeletionsCoverage(NOW + 10 * DAY_MS, NOW)).toBe('future');
+  });
+});
+
+describe('deletions-coverage marker round-trip', () => {
+  let db: TestSqliteDb;
+
+  beforeEach(async () => {
+    db = createTestDatabase();
+    await runMigrations(db);
+  });
+
+  it('stores and reads back the epoch-ms marker', async () => {
+    expect(await getDeletionsCoverageAt(db)).toBeNull();
+    await setDeletionsCoverageAt(db, NOW);
+    expect(await getDeletionsCoverageAt(db)).toBe(NOW);
+  });
+
+  it('reads a garbled marker as absent rather than infinitely old', async () => {
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      DELETIONS_COVERAGE_KEY,
+      'not-a-number',
+    ]);
+    expect(await getDeletionsCoverageAt(db)).toBeNull();
+  });
+});
+
+describe('resetUserDataForLostCoverage', () => {
+  let db: TestSqliteDb;
+
+  beforeEach(async () => {
+    db = createTestDatabase();
+    await runMigrations(db);
+    await ensureMutationQueueTable(db);
+    await seedEverything(db);
+  });
+
+  it('clears every user-data table and its checkpoint, plus the deletions cursor', async () => {
+    // The rows are unreachable-but-present stale data: the tombstones that would
+    // have removed them were pruned server-side, and the delta resolver never
+    // re-emits a deleted row, so nothing short of deleting them locally works.
+    const { rowsCleared } = await resetUserDataForLostCoverage(db, NOW);
+
+    expect(rowsCleared).toBe(USER_DATA_TABLES.length);
+    for (const tableName of USER_DATA_TABLES) {
+      expect(await countRows(db, tableName)).toBe(0);
+      expect(await readMeta(db, `checkpoint:${tableName}`)).toBeNull();
+    }
+    expect(await readMeta(db, 'checkpoint:deletions')).toBeNull();
+  });
+
+  it('leaves the downloaded board catalog and its markers completely alone', async () => {
+    // No production path emits a board tombstone (clear-aurora-board.ts sets
+    // `boardsesh.suppress_sync_tombstones` around the only DELETEs, and
+    // board_climb_grades has no delete trigger at all), so a lost deletions
+    // window costs the catalog nothing. Clearing it would re-download tens to
+    // hundreds of MB unprompted, possibly on cellular.
+    await resetUserDataForLostCoverage(db, NOW);
+
+    for (const tableName of BOARD_DATA_TABLES) {
+      expect(await countRows(db, tableName)).toBe(1);
+      expect(await readMeta(db, `checkpoint:${tableName}:kilter:1:5`)).not.toBeNull();
+    }
+    expect(await readMeta(db, 'scope-complete:kilter:1:5')).not.toBeNull();
+    expect(await readMeta(db, 'bootstrap-done:kilter:1:5')).not.toBeNull();
+    expect(await readMeta(db, 'bootstrap-attempts:kilter:1:5')).not.toBeNull();
+  });
+
+  it('preserves pending_mutations byte-for-byte', async () => {
+    // Unsynced local writes exist ONLY on the device. Draining first is not a
+    // substitute for never touching them: the drainer legitimately leaves rows
+    // behind (attempt budget, dead letters, offline).
+    const before = await readMutations(db);
+    expect(before).toHaveLength(2);
+
+    await resetUserDataForLostCoverage(db, NOW);
+
+    expect(await readMutations(db)).toEqual(before);
+  });
+
+  it('does not disturb the on-device schema version', async () => {
+    // A wipe that reset this would make the migration runner re-run every
+    // migration on the next launch.
+    const before = await readSchemaVersion(db);
+    expect(before).toBeGreaterThan(0);
+    await resetUserDataForLostCoverage(db, NOW);
+    expect(await readSchemaVersion(db)).toBe(before);
+  });
+
+  it('stamps the coverage marker inside the same transaction as the deletes', async () => {
+    // Otherwise a device whose rebuild pull then fails re-detects staleness and
+    // wipes again on every trigger. After a full wipe the invariant is trivially
+    // true — no surviving local user row predates this moment — so the stamp is
+    // honest, not optimistic.
+    await resetUserDataForLostCoverage(db, NOW);
+    expect(await getDeletionsCoverageAt(db)).toBe(NOW);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** One row in every synced table, every marker family, and two queued mutations. */
+async function seedEverything(db: TestSqliteDb): Promise<void> {
+  await db.runAsync("INSERT INTO boardsesh_ticks (uuid, status) VALUES ('tick-1', 'send')", []);
+  await db.runAsync("INSERT INTO playlists (uuid, name) VALUES ('playlist-1', 'Projects')", []);
+  await db.runAsync("INSERT INTO playlist_climbs (playlist_uuid, climb_uuid) VALUES ('playlist-1', 'climb-1')", []);
+  await db.runAsync("INSERT INTO user_favorites (board_name, climb_uuid, angle) VALUES ('kilter', 'climb-1', 40)", []);
+  await db.runAsync("INSERT INTO user_follows (following_id) VALUES ('user-2')", []);
+  await db.runAsync("INSERT INTO setter_follows (setter_username) VALUES ('setter-1')", []);
+  await db.runAsync("INSERT INTO playlist_follows (playlist_uuid) VALUES ('playlist-9')", []);
+
+  await db.runAsync("INSERT INTO board_climbs (uuid, board_type, layout_id) VALUES ('climb-1', 'kilter', 1)", []);
+  await db.runAsync(
+    "INSERT INTO board_climb_stats (board_type, climb_uuid, angle) VALUES ('kilter', 'climb-1', 40)",
+    [],
+  );
+  await db.runAsync(
+    "INSERT INTO board_climb_grades (board_type, climb_uuid, angle) VALUES ('kilter', 'climb-1', 40)",
+    [],
+  );
+
+  const cursor = JSON.stringify({ updatedAt: '2026-01-01T00:00:00Z', syncSeq: '7' });
+  for (const tableName of USER_DATA_TABLES) {
+    await putMeta(db, `checkpoint:${tableName}`, cursor);
+  }
+  for (const tableName of BOARD_DATA_TABLES) {
+    await putMeta(db, `checkpoint:${tableName}:kilter:1:5`, cursor);
+  }
+  await putMeta(db, 'checkpoint:deletions', cursor);
+  await putMeta(db, 'scope-complete:kilter:1:5', '1');
+  await putMeta(db, 'bootstrap-done:kilter:1:5', '1');
+  await putMeta(db, 'bootstrap-attempts:kilter:1:5', '2');
+
+  await enqueue(db, 'boardsesh_ticks', 'create', { uuid: 'offline-tick-1' }, 'idem-1');
+  await enqueue(db, 'user_favorites', 'create', { climb_uuid: 'climb-9' }, 'idem-2');
+}
+
+async function putMeta(db: TestSqliteDb, key: string, value: string): Promise<void> {
+  await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [key, value]);
+}
+
+async function readMeta(db: TestSqliteDb, key: string): Promise<string | null> {
+  const row = await db.getFirstAsync<{ value: string }>('SELECT value FROM sync_meta WHERE key = ?', [key]);
+  return row?.value ?? null;
+}
+
+async function countRows(db: TestSqliteDb, tableName: string): Promise<number> {
+  const row = await db.getFirstAsync<{ n: number }>(`SELECT COUNT(*) AS n FROM ${tableName}`, []);
+  return row?.n ?? 0;
+}
+
+async function readSchemaVersion(db: TestSqliteDb): Promise<number> {
+  const row = await db.getFirstAsync<{ version: number }>('SELECT version FROM schema_version WHERE id = 1', []);
+  return row?.version ?? 0;
+}
+
+async function readMutations(db: TestSqliteDb): Promise<PendingMutation[]> {
+  return db.getAllAsync<PendingMutation>('SELECT * FROM pending_mutations ORDER BY id ASC', []);
+}

--- a/packages/shared/offline-sync/src/sync/__tests__/deletions-coverage.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/deletions-coverage.test.ts
@@ -125,6 +125,22 @@ describe('resetUserDataForLostCoverage', () => {
     expect(await readMeta(db, 'checkpoint:deletions')).toBeNull();
   });
 
+  it('runs cleanly on already-empty tables and reports rowsCleared: 0', async () => {
+    // Reachable whenever a stale marker meets tables that hold nothing — a user
+    // who deleted everything server-side, or a sign-out teardown that raced the
+    // guard. It must be a no-op that still stamps the marker, not a throw and
+    // not a half-applied reset.
+    await resetUserDataForLostCoverage(db, NOW);
+
+    const { rowsCleared } = await resetUserDataForLostCoverage(db, NOW + 1000);
+
+    expect(rowsCleared).toBe(0);
+    expect(await readMeta(db, DELETIONS_COVERAGE_KEY)).toBe(String(NOW + 1000));
+    for (const tableName of USER_DATA_TABLES) {
+      expect(await countRows(db, tableName)).toBe(0);
+    }
+  });
+
   it('leaves the downloaded board catalog and its markers completely alone', async () => {
     // No production path emits a board tombstone (clear-aurora-board.ts sets
     // `boardsesh.suppress_sync_tombstones` around the only DELETEs, and

--- a/packages/shared/offline-sync/src/sync/__tests__/deletions-coverage.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/deletions-coverage.test.ts
@@ -15,7 +15,11 @@ import {
   resetUserDataForLostCoverage,
   setDeletionsCoverageAt,
 } from '../deletions-coverage';
-import { DELETIONS_COVERAGE_MARGIN_DAYS, SYNC_DELETIONS_RETENTION_DAYS } from '../retention';
+import {
+  DELETIONS_COVERAGE_EPOCH_FLOOR_MS,
+  DELETIONS_COVERAGE_MARGIN_DAYS,
+  SYNC_DELETIONS_RETENTION_DAYS,
+} from '../retention';
 import { USER_DATA_TABLES, BOARD_DATA_TABLES } from '../table-config';
 import { runMigrations } from '../../db/migrations';
 import { ensureMutationQueueTable } from '../../mutation-queue/schema';
@@ -47,6 +51,16 @@ describe('evaluateDeletionsCoverage', () => {
     // stale again — the guard would be permanently disarmed on that device.
     expect(evaluateDeletionsCoverage(NOW + 10 * DAY_MS, NOW)).toBe('future');
   });
+
+  it('treats an implausibly old marker as unknown, so a broken clock re-seeds instead of wiping', () => {
+    // The bad-clock loop this closes: a phone cold-boots with a dead RTC (1970 /
+    // 2001) before NTP lands, reads the real marker as 'future', re-stamps it
+    // with its bogus now — and once the clock corrects, that stamp is decades
+    // old and would authorise a wipe on a device that syncs every day.
+    expect(evaluateDeletionsCoverage(0, NOW)).toBe('unknown');
+    expect(evaluateDeletionsCoverage(Date.parse('2001-01-01T00:00:00Z'), NOW)).toBe('unknown');
+    expect(evaluateDeletionsCoverage(DELETIONS_COVERAGE_EPOCH_FLOOR_MS, NOW)).toBe('stale');
+  });
 });
 
 describe('deletions-coverage marker round-trip', () => {
@@ -64,11 +78,17 @@ describe('deletions-coverage marker round-trip', () => {
   });
 
   it('reads a garbled marker as absent rather than infinitely old', async () => {
-    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
-      DELETIONS_COVERAGE_KEY,
-      'not-a-number',
-    ]);
-    expect(await getDeletionsCoverageAt(db)).toBeNull();
+    // 'not-a-number' is the easy case. The ISO string is the dangerous one:
+    // Number.parseInt tolerates trailing garbage and would return 2026 — epoch-ms
+    // 1970, i.e. "decades stale" — so a future refactor that starts writing ISO
+    // timestamps here would silently arm a fleet-wide wipe.
+    for (const garbledValue of ['not-a-number', '2026-07-01T00:00:00Z', '', '  ', '17e14', '-1']) {
+      await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+        DELETIONS_COVERAGE_KEY,
+        garbledValue,
+      ]);
+      expect(await getDeletionsCoverageAt(db)).toBeNull();
+    }
   });
 });
 

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client.integration.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client.integration.test.ts
@@ -896,6 +896,13 @@ describe('sync layer — real-DDL integration', () => {
       expect(deletionsVariables[0]).toMatchObject({ limit: 1 });
       expect(deletionsVariables.length).toBeGreaterThanOrEqual(2);
 
+      // The wipe busts the user-data caches itself. It cannot lean on the
+      // rebuild to do it: the playlists pull returned zero documents (the user
+      // had emptied that table server-side), so syncTable's `totalProcessed > 0`
+      // gate never fires and a mounted screen would keep serving the pre-wipe
+      // react-query cache — #3474's symptom surviving the fix.
+      expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['playlists'] });
+
       // Marker advanced, and the operational event carried the honest numbers.
       expect(await readCoverage()).toBeGreaterThan(Date.now() - 60_000);
       expect(onCoverageReset).toHaveBeenCalledTimes(1);

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client.integration.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client.integration.test.ts
@@ -28,6 +28,7 @@ const onSchemaDrift = vi.fn();
 
 import { pullSync } from '../pull-client';
 import { enqueue } from '../../mutation-queue/queue';
+import { setBackgrounded } from '../../mutation-queue/drainer';
 import { processMutation, type GraphQLFetch } from '../../mutation-queue/handlers';
 import { runMigrations } from '../../db/migrations';
 import { ensureMutationQueueTable } from '../../mutation-queue/schema';
@@ -800,6 +801,221 @@ describe('sync layer — real-DDL integration', () => {
       expect(missingRequired).toEqual([]);
       expect(presentRequired).toEqual([...REQUIRED_SAVE_TICK_INPUT_FIELDS]);
       expect(capturedInput?.climbedAt).toBe('2024-05-30T10:00:00.000Z');
+    });
+  });
+  // -------------------------------------------------------------------------
+  // Deletions-coverage guard (issue #3474)
+  // -------------------------------------------------------------------------
+
+  describe('deletions-coverage guard forces a user-data resync when the retention window is blown', () => {
+    const DAY_MS = 24 * 60 * 60 * 1000;
+
+    /**
+     * A fetch that serves an empty `syncDeletions`, one tick document for
+     * `syncTicks`, and an empty page for every other sync query. Records the
+     * variables of every syncDeletions call so a test can tell the one-row
+     * reachability PROBE (limit 1) apart from the real deletions pull.
+     */
+    function makeCoverageFetch(tickDocuments: Record<string, unknown>[]) {
+      const deletionsVariables: Record<string, unknown>[] = [];
+      const fetch = vi.fn(async <T>(query: string, variables?: Record<string, unknown>): Promise<T> => {
+        if (query.includes('syncDeletions')) {
+          deletionsVariables.push(variables ?? {});
+          return { syncDeletions: { deletions: [], cursor: DEFAULT_CURSOR, hasMore: false } } as T;
+        }
+        if (query.includes('syncTicks')) {
+          return { syncTicks: { documents: tickDocuments, cursor: DEFAULT_CURSOR, hasMore: false } } as T;
+        }
+        return { [extractQueryName(query)]: { documents: [], cursor: DEFAULT_CURSOR, hasMore: false } } as T;
+      }) as unknown as GraphQLFetch;
+      return { fetch, deletionsVariables };
+    }
+
+    /** Rows and markers a long-absent device carries: stale user data + an intact catalog. */
+    async function seedStaleDevice(): Promise<void> {
+      await db.runAsync("INSERT INTO boardsesh_ticks (uuid, status) VALUES ('stale-tick', 'send')", []);
+      await db.runAsync("INSERT INTO playlists (uuid, name) VALUES ('stale-playlist', 'Old')", []);
+      await db.runAsync("INSERT INTO board_climbs (uuid, board_type, layout_id) VALUES ('climb-1', 'kilter', 1)", []);
+      await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+        'checkpoint:deletions',
+        JSON.stringify({ updatedAt: '2026-01-01T00:00:00Z', syncSeq: '7' }),
+      ]);
+      await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+        'checkpoint:board_climbs:kilter:1:5',
+        JSON.stringify({ updatedAt: '2026-01-01T00:00:00Z', syncSeq: '9' }),
+      ]);
+      await enqueue(db, 'boardsesh_ticks', 'create', { uuid: 'queued-tick' }, 'idem-coverage-1');
+    }
+
+    async function setCoverage(atMs: number): Promise<void> {
+      await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+        'deletions-coverage',
+        String(atMs),
+      ]);
+    }
+
+    async function readCoverage(): Promise<number | null> {
+      const row = await db.getFirstAsync<{ value: string }>('SELECT value FROM sync_meta WHERE key = ?', [
+        'deletions-coverage',
+      ]);
+      return row ? Number(row.value) : null;
+    }
+
+    async function countRows(tableName: string): Promise<number> {
+      const row = await db.getFirstAsync<{ n: number }>(`SELECT COUNT(*) AS n FROM ${tableName}`, []);
+      return row?.n ?? 0;
+    }
+
+    it('rebuilds user data from the server, keeps the catalog and the outbox (the #3474 regression test)', async () => {
+      // 100 days without a completed deletions pull: every tombstone in the
+      // window (cursor, now-90d] was hard-deleted server-side before this device
+      // asked for it, so `stale-tick` / `stale-playlist` could sit here forever —
+      // a delta pull never re-emits a row the server deleted.
+      await seedStaleDevice();
+      await setCoverage(Date.now() - 100 * DAY_MS);
+      const onCoverageReset = vi.fn();
+      const { fetch, deletionsVariables } = makeCoverageFetch([
+        { uuid: 'fresh-tick', status: 'send', updated_at: '2026-07-01T00:00:00Z' },
+      ]);
+
+      await pullSync(db, queryClient, fetch, { onCoverageReset });
+
+      // Stale local rows are gone; the freshly pulled one landed.
+      expect(await countRows('playlists')).toBe(0);
+      expect(await db.getFirstAsync('SELECT uuid FROM boardsesh_ticks WHERE uuid = ?', ['stale-tick'])).toBeNull();
+      expect(await db.getFirstAsync('SELECT uuid FROM boardsesh_ticks WHERE uuid = ?', ['fresh-tick'])).not.toBeNull();
+
+      // The downloaded catalog and its cursor are untouched — no surprise re-download.
+      expect(await countRows('board_climbs')).toBe(1);
+      expect(await readCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5')).not.toBeNull();
+
+      // The outbox survives: an unsynced write exists nowhere else.
+      expect(await countRows('pending_mutations')).toBe(1);
+
+      // A one-row probe ran BEFORE the wipe, then the real deletions pull.
+      expect(deletionsVariables[0]).toMatchObject({ limit: 1 });
+      expect(deletionsVariables.length).toBeGreaterThanOrEqual(2);
+
+      // Marker advanced, and the operational event carried the honest numbers.
+      expect(await readCoverage()).toBeGreaterThan(Date.now() - 60_000);
+      expect(onCoverageReset).toHaveBeenCalledTimes(1);
+      expect(onCoverageReset.mock.calls[0][0]).toMatchObject({
+        markerAgeDays: 100,
+        rowsCleared: 2,
+        pendingMutations: 1,
+      });
+    });
+
+    it('wipes NOTHING when the device is offline — the probe fails first', async () => {
+      // pullSync runs on every foreground, offline ones included. Wiping and
+      // only then discovering there is no connection would leave the user with
+      // an empty app until connectivity returns.
+      await seedStaleDevice();
+      const staleAt = Date.now() - 100 * DAY_MS;
+      await setCoverage(staleAt);
+      const onCoverageReset = vi.fn();
+      const offlineFetch = vi.fn(async () => {
+        throw new Error('Network request failed');
+      }) as unknown as GraphQLFetch;
+
+      await expect(pullSync(db, queryClient, offlineFetch, { onCoverageReset })).rejects.toThrow(
+        'Network request failed',
+      );
+
+      expect(await countRows('boardsesh_ticks')).toBe(1);
+      expect(await countRows('playlists')).toBe(1);
+      expect(await countRows('pending_mutations')).toBe(1);
+      expect(await readCheckpoint(db, 'checkpoint:deletions')).not.toBeNull();
+      expect(await readCoverage()).toBe(staleAt);
+      expect(onCoverageReset).not.toHaveBeenCalled();
+    });
+
+    it('does not wipe again on the next cycle (no probe, no second reset)', async () => {
+      // The reset stamps the marker in its own transaction, so a flaky network
+      // can never turn this into a wipe loop.
+      await seedStaleDevice();
+      await setCoverage(Date.now() - 100 * DAY_MS);
+      await pullSync(db, queryClient, makeCoverageFetch([{ uuid: 'fresh-tick', status: 'send' }]).fetch);
+
+      const onCoverageReset = vi.fn();
+      const second = makeCoverageFetch([{ uuid: 'fresh-tick', status: 'send' }]);
+      await pullSync(db, queryClient, second.fetch, { onCoverageReset });
+
+      expect(onCoverageReset).not.toHaveBeenCalled();
+      expect(second.deletionsVariables.every((variables) => variables.limit !== 1)).toBe(true);
+      expect(await db.getFirstAsync('SELECT uuid FROM boardsesh_ticks WHERE uuid = ?', ['fresh-tick'])).not.toBeNull();
+    });
+
+    it('seeds the marker and resets nothing on the first launch after the update (bootstrap OTA)', async () => {
+      // Every existing install lacks the key on that first launch. Absence must
+      // never mean "reset" — that would wipe the entire fleet's user data on the
+      // OTA that ships this guard.
+      await seedStaleDevice();
+      const onCoverageReset = vi.fn();
+
+      await pullSync(db, queryClient, makeCoverageFetch([]).fetch, { onCoverageReset });
+
+      expect(onCoverageReset).not.toHaveBeenCalled();
+      expect(await countRows('boardsesh_ticks')).toBe(1);
+      expect(await countRows('playlists')).toBe(1);
+      expect(await readCoverage()).toBeGreaterThan(Date.now() - 60_000);
+    });
+
+    it('ignores the deletions CHECKPOINT age — only the coverage marker decides', async () => {
+      // The checkpoint holds the server-side deleted_at of the last tombstone
+      // consumed and only advances on a non-empty page, so a user who has
+      // deleted nothing for 200 days carries a 200-day-old cursor on a perfectly
+      // current device. Wiring the oracle to it would wipe most of the fleet.
+      await seedStaleDevice();
+      await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+        'checkpoint:deletions',
+        JSON.stringify({ updatedAt: new Date(Date.now() - 200 * DAY_MS).toISOString(), syncSeq: '7' }),
+      ]);
+      await setCoverage(Date.now() - DAY_MS);
+      const onCoverageReset = vi.fn();
+
+      await pullSync(db, queryClient, makeCoverageFetch([]).fetch, { onCoverageReset });
+
+      expect(onCoverageReset).not.toHaveBeenCalled();
+      expect(await countRows('boardsesh_ticks')).toBe(1);
+      expect(await countRows('playlists')).toBe(1);
+    });
+
+    it('re-stamps a future-dated marker (clock corrected backwards) without resetting', async () => {
+      await seedStaleDevice();
+      await setCoverage(Date.now() + 10 * DAY_MS);
+      const onCoverageReset = vi.fn();
+
+      await pullSync(db, queryClient, makeCoverageFetch([]).fetch, { onCoverageReset });
+
+      expect(onCoverageReset).not.toHaveBeenCalled();
+      expect(await countRows('boardsesh_ticks')).toBe(1);
+      // Left in the future, the marker could never go stale again — the guard
+      // would be permanently disarmed on that device.
+      expect(await readCoverage()).toBeLessThan(Date.now() + 60_000);
+    });
+
+    it('does not advance the marker when the deletions pull is aborted mid-stream', async () => {
+      // A pull backgrounded on its first page consumed an unknown prefix of the
+      // stream. Claiming a fresh retention window off it would hide a real gap
+      // for another 80 days — this is what processDeletions' reachedTail buys.
+      const freshAt = Date.now() - DAY_MS;
+      await setCoverage(freshAt);
+      const abortingFetch = vi.fn(async <T>(query: string): Promise<T> => {
+        if (query.includes('syncDeletions')) {
+          setBackgrounded(true);
+          return { syncDeletions: { deletions: [], cursor: DEFAULT_CURSOR, hasMore: false } } as T;
+        }
+        return { [extractQueryName(query)]: { documents: [], cursor: DEFAULT_CURSOR, hasMore: false } } as T;
+      }) as unknown as GraphQLFetch;
+
+      try {
+        await pullSync(db, queryClient, abortingFetch);
+      } finally {
+        setBackgrounded(false);
+      }
+
+      expect(await readCoverage()).toBe(freshAt);
     });
   });
 });

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client.integration.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client.integration.test.ts
@@ -33,6 +33,7 @@ import { processMutation, type GraphQLFetch } from '../../mutation-queue/handler
 import { runMigrations } from '../../db/migrations';
 import { ensureMutationQueueTable } from '../../mutation-queue/schema';
 import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
+import { getDeletionsCoverageAt } from '../deletions-coverage';
 import { TABLE_CONFIGS } from '../table-config';
 
 // The non-null fields of the backend's `input SaveTickInput`
@@ -857,12 +858,10 @@ describe('sync layer — real-DDL integration', () => {
       ]);
     }
 
-    async function readCoverage(): Promise<number | null> {
-      const row = await db.getFirstAsync<{ value: string }>('SELECT value FROM sync_meta WHERE key = ?', [
-        'deletions-coverage',
-      ]);
-      return row ? Number(row.value) : null;
-    }
+    // The production reader, not a hand-rolled Number() — a local parse would
+    // accept values the app rejects (Number('17e14') is finite) and quietly
+    // certify behaviour the shipped code does not have.
+    const readCoverage = (): Promise<number | null> => getDeletionsCoverageAt(db);
 
     async function countRows(tableName: string): Promise<number> {
       const row = await db.getFirstAsync<{ n: number }>(`SELECT COUNT(*) AS n FROM ${tableName}`, []);

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client.integration.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client.integration.test.ts
@@ -28,7 +28,7 @@ const onSchemaDrift = vi.fn();
 
 import { pullSync } from '../pull-client';
 import { enqueue } from '../../mutation-queue/queue';
-import { setBackgrounded } from '../../mutation-queue/drainer';
+import { setBackgrounded, beginLocalPurge, __resetDrainerStateForTests } from '../../mutation-queue/drainer';
 import { processMutation, type GraphQLFetch } from '../../mutation-queue/handlers';
 import { runMigrations } from '../../db/migrations';
 import { ensureMutationQueueTable } from '../../mutation-queue/schema';
@@ -119,6 +119,9 @@ describe('sync layer — real-DDL integration', () => {
     await runMigrations(db);
     await ensureMutationQueueTable(db);
     queryClient = createMockQueryClient();
+    // The drainer flags and the wipe epoch are module-level, so a test that
+    // backgrounds or purges must not leak into the next one.
+    __resetDrainerStateForTests();
   });
 
   // -------------------------------------------------------------------------
@@ -932,6 +935,31 @@ describe('sync layer — real-DDL integration', () => {
       expect(await countRows('boardsesh_ticks')).toBe(1);
       expect(await countRows('playlists')).toBe(1);
       expect(await countRows('pending_mutations')).toBe(1);
+      expect(await readCheckpoint(db, 'checkpoint:deletions')).not.toBeNull();
+      expect(await readCoverage()).toBe(staleAt);
+      expect(onCoverageReset).not.toHaveBeenCalled();
+    });
+
+    it('wipes NOTHING when a local purge lands while the probe is on the wire', async () => {
+      // removeBoardScopeData (Storage → Remove board) calls beginLocalPurge(),
+      // which bumps the wipe epoch to abort the whole cycle. The probe is a real
+      // network round-trip, so that purge can land mid-flight — and a wipe
+      // dispatched after it would clear user data with no rebuild behind it,
+      // because every phase below bails at its first cycleAborted().
+      await seedStaleDevice();
+      const staleAt = Date.now() - 100 * DAY_MS;
+      await setCoverage(staleAt);
+      const onCoverageReset = vi.fn();
+      const { fetch } = makeCoverageFetch([{ uuid: 'fresh-tick', status: 'send' }]);
+      const purgingFetch = (async (query: string, variables?: Record<string, unknown>) => {
+        if (variables?.limit === 1) beginLocalPurge();
+        return fetch(query, variables);
+      }) as unknown as GraphQLFetch;
+
+      await pullSync(db, queryClient, purgingFetch, { onCoverageReset });
+
+      expect(await countRows('boardsesh_ticks')).toBe(1);
+      expect(await countRows('playlists')).toBe(1);
       expect(await readCheckpoint(db, 'checkpoint:deletions')).not.toBeNull();
       expect(await readCoverage()).toBe(staleAt);
       expect(onCoverageReset).not.toHaveBeenCalled();

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client.integration.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client.integration.test.ts
@@ -996,6 +996,27 @@ describe('sync layer — real-DDL integration', () => {
       expect(await readCoverage()).toBeGreaterThan(Date.now() - 60_000);
     });
 
+    it('claims no coverage when that first post-update pull never reaches the tail', async () => {
+      // The marker is only honest if it means "this device consumed the whole
+      // tombstone stream at time T". Stamping it up front on an absent marker
+      // would hand a device that has been away 89 days a fresh 80-day window it
+      // never earned — its next pull could then read 'fresh' with the tombstones
+      // already pruned, which is #3474 all over again.
+      await seedStaleDevice();
+      const onCoverageReset = vi.fn();
+      const failingFetch = vi.fn(async () => {
+        throw new Error('Network request failed');
+      }) as unknown as GraphQLFetch;
+
+      await expect(pullSync(db, queryClient, failingFetch, { onCoverageReset })).rejects.toThrow(
+        'Network request failed',
+      );
+
+      expect(await readCoverage()).toBeNull();
+      expect(onCoverageReset).not.toHaveBeenCalled();
+      expect(await countRows('boardsesh_ticks')).toBe(1);
+    });
+
     it('ignores the deletions CHECKPOINT age — only the coverage marker decides', async () => {
       // The checkpoint holds the server-side deleted_at of the last tombstone
       // consumed and only advances on a non-empty page, so a user who has

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
@@ -297,8 +297,38 @@ describe('pullSync', () => {
 
     await pullSync(db, queryClient, graphqlFetch);
 
-    const insertCalls = sqlCalls.filter((call) => call.sql.includes('INSERT OR REPLACE'));
+    // sync_meta writes are excluded: an empty cycle still stamps the
+    // deletions-coverage marker (pinned by the test below). This assertion is
+    // about DATA rows.
+    const insertCalls = sqlCalls.filter(
+      (call) => call.sql.includes('INSERT OR REPLACE') && !call.sql.includes('sync_meta'),
+    );
     expect(insertCalls).toHaveLength(0);
+  });
+
+  it('seeds the deletions-coverage marker and wipes nothing when the marker is absent', async () => {
+    // The mock db's getFirstAsync returns null, so the coverage marker reads as
+    // ABSENT — exactly the state of every existing install on the first launch
+    // after the OTA that introduces it. Absent must mean "seed it", never
+    // "assume the worst and reset": the alternative detonates a fleet-wide
+    // user-data wipe on rollout day. This pins that default for the whole suite.
+    setupGraphqlFetchForAllTables();
+
+    await pullSync(db, queryClient, graphqlFetch);
+
+    const coverageWrites = sqlCalls.filter(
+      (call) => call.sql.includes('INSERT OR REPLACE INTO sync_meta') && call.params?.[0] === 'deletions-coverage',
+    );
+    expect(coverageWrites.length).toBeGreaterThanOrEqual(1);
+    expect(Number(coverageWrites[0].params[1])).toBeGreaterThan(0);
+
+    // No user-table wipe, and the deletions cursor was not dropped.
+    const wipeDeletes = sqlCalls.filter((call) => call.sql === 'DELETE FROM boardsesh_ticks');
+    expect(wipeDeletes).toHaveLength(0);
+    const cursorDeletes = sqlCalls.filter(
+      (call) => call.sql.includes('DELETE FROM sync_meta') && call.params?.includes('checkpoint:deletions'),
+    );
+    expect(cursorDeletes).toHaveLength(0);
   });
 
   it('syncs per-board tables with boardType + layout/size scope variables', async () => {

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
@@ -297,11 +297,14 @@ describe('pullSync', () => {
 
     await pullSync(db, queryClient, graphqlFetch);
 
-    // sync_meta writes are excluded: an empty cycle still stamps the
-    // deletions-coverage marker (pinned by the test below). This assertion is
-    // about DATA rows.
+    // Only the deletions-coverage marker is excused: an empty cycle legitimately
+    // stamps it (pinned by the test below). Checkpoints go through the same
+    // `INSERT OR REPLACE INTO sync_meta`, so excluding sync_meta wholesale would
+    // stop this from catching "an empty cycle advanced a cursor".
     const insertCalls = sqlCalls.filter(
-      (call) => call.sql.includes('INSERT OR REPLACE') && !call.sql.includes('sync_meta'),
+      (call) =>
+        call.sql.includes('INSERT OR REPLACE') &&
+        !(call.sql.includes('sync_meta') && call.params?.[0] === 'deletions-coverage'),
     );
     expect(insertCalls).toHaveLength(0);
   });

--- a/packages/shared/offline-sync/src/sync/checkpoints.ts
+++ b/packages/shared/offline-sync/src/sync/checkpoints.ts
@@ -1,4 +1,5 @@
 import type { SqlExecutor } from '../database';
+import { DELETIONS_COVERAGE_KEY } from './retention';
 import { BOARD_DATA_TABLES } from './table-config';
 
 export type SyncCheckpoint = {
@@ -154,6 +155,15 @@ export async function deleteAllCheckpoints(db: SqlExecutor): Promise<void> {
  * update. board_climb_grades previously fell through this exact gap (its rows are
  * board reference data and are never cleared, but its checkpoint wasn't on the
  * hardcoded NOT-LIKE list, so it was wiped on every sign-out).
+ *
+ * The deletions-coverage marker goes too, even though it is not a `checkpoint:`
+ * key. It describes how much of the tombstone stream THIS account consumed, and
+ * sign-out rewinds the deletions cursor to the epoch, so it describes nothing
+ * afterwards. Left behind, a departing user's stale marker would trip the
+ * coverage guard on the NEXT account's first pull: a wasted network probe and a
+ * reset of tables sign-out already emptied, reported as a
+ * `OfflineSyncCoverageResetForced` with `rowsCleared: 0`. The new account
+ * re-stamps it when its own first deletions pull reaches the tail.
  */
 export async function deleteUserCheckpoints(db: SqlExecutor): Promise<void> {
   const preserveBoardTableClauses = BOARD_DATA_TABLES.map(() => 'AND key NOT LIKE ?').join('\n       ');
@@ -164,4 +174,5 @@ export async function deleteUserCheckpoints(db: SqlExecutor): Promise<void> {
        ${preserveBoardTableClauses}`,
     preserveBoardTableParams,
   );
+  await db.runAsync('DELETE FROM sync_meta WHERE key = ?', [DELETIONS_COVERAGE_KEY]);
 }

--- a/packages/shared/offline-sync/src/sync/deletions-coverage.ts
+++ b/packages/shared/offline-sync/src/sync/deletions-coverage.ts
@@ -137,6 +137,10 @@ export async function resetUserDataForLostCoverage(
     await applyBusyTimeout(txn);
 
     for (const tableName of USER_DATA_TABLES) {
+      // Interpolated, because SQLite parameters bind values, not identifiers.
+      // Safe only while USER_DATA_TABLES stays compile-time literal (it is
+      // derived from TABLE_CONFIGS' keys) — same contract as removeBoardScopeData.
+      // Never let a computed or user-derived name into that array.
       const result = await txn.runAsync(`DELETE FROM ${tableName}`, []);
       rowsCleared += result.changes;
     }

--- a/packages/shared/offline-sync/src/sync/deletions-coverage.ts
+++ b/packages/shared/offline-sync/src/sync/deletions-coverage.ts
@@ -1,0 +1,151 @@
+// Deletions coverage — the client half of the tombstone-retention contract
+// (issue #3474). See retention.ts for the server half.
+//
+// THE INVARIANT. A client that pulled the deletions stream to its TAIL at
+// wall-clock time T has consumed every tombstone that existed at T. Anything the
+// server prunes after T was therefore already applied locally. The device can
+// only miss data if `now - T` exceeds the retention window — at which point
+// tombstones it never saw have been hard-deleted server-side and no cursor can
+// reach them again.
+//
+// WHY NOT THE CHECKPOINT'S OWN AGE. `checkpoint:deletions` holds the server-side
+// `deleted_at` of the last tombstone consumed, and pull-client only advances it
+// on a NON-EMPTY page. A user who has not deleted anything for three months
+// carries a three-month-old cursor on a perfectly current device — and in
+// production the board tables emit no tombstones at all (every production DELETE
+// of board_climbs / board_climb_stats runs inside the transaction that sets
+// `boardsesh.suppress_sync_tombstones`, see packages/db/src/queries/boards/clear-aurora-board.ts),
+// so the ONLY tombstones a given user ever sees are their own. A cursor-age test
+// would wipe most of the fleet. This marker is a client wall clock, written only
+// when the deletions pull actually reached the tail; never compare a
+// server-sourced timestamp against Date.now() here.
+
+import type { OfflineDatabase, SqlExecutor } from '../database';
+import { applyBusyTimeout } from '../db/pragmas';
+import { DELETIONS_CHECKPOINT_KEY, getCheckpointKey } from './checkpoints';
+import { DELETIONS_COVERAGE_MAX_AGE_MS } from './retention';
+import { USER_DATA_TABLES } from './table-config';
+
+/**
+ * sync_meta key holding the epoch-ms of the last completed deletions pull.
+ *
+ * Deliberately NOT under the `checkpoint:` prefix, for the same reason
+ * SCOPE_COMPLETE_PREFIX isn't: it describes client wall-clock coverage, not a
+ * server cursor. Sign-out's deleteUserCheckpoints resets the deletions cursor to
+ * the epoch, which RE-ESTABLISHES full coverage rather than losing it, so the
+ * marker must survive that wipe. scope-teardown's clearScopeSyncMeta uses an
+ * exact key list, so it is unaffected too.
+ */
+export const DELETIONS_COVERAGE_KEY = 'deletions-coverage';
+
+export type DeletionsCoverageVerdict =
+  /** No marker yet (fresh install, or the OTA that introduced this). Seed it, reset nothing. */
+  | 'unknown'
+  /** Marker is dated after `now` — a clock corrected backwards. Re-stamp it, reset nothing. */
+  | 'future'
+  /** Within the window: every tombstone since the marker is still queryable. */
+  | 'fresh'
+  /** Older than the window: tombstones may already be pruned. Forced resync. */
+  | 'stale';
+
+export async function getDeletionsCoverageAt(db: SqlExecutor): Promise<number | null> {
+  const row = await db.getFirstAsync<{ value: string }>('SELECT value FROM sync_meta WHERE key = ?', [
+    DELETIONS_COVERAGE_KEY,
+  ]);
+  if (!row) return null;
+  const parsed = Number.parseInt(row.value, 10);
+  // A corrupt value reads as absent: seeding a fresh marker is the safe
+  // direction (it costs one retention window of exposure), whereas treating it
+  // as infinitely old would wipe user data off a garbled row.
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export async function setDeletionsCoverageAt(db: SqlExecutor, atMs: number): Promise<void> {
+  await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+    DELETIONS_COVERAGE_KEY,
+    String(atMs),
+  ]);
+}
+
+/**
+ * Classify a coverage marker against the retention window. `coverageAt` is the
+ * stored marker (null when absent); `nowMs` is the caller's clock, passed in so
+ * tests don't have to fake time.
+ */
+export function evaluateDeletionsCoverage(coverageAt: number | null, nowMs: number): DeletionsCoverageVerdict {
+  if (coverageAt === null) return 'unknown';
+  if (coverageAt > nowMs) return 'future';
+  return nowMs - coverageAt > DELETIONS_COVERAGE_MAX_AGE_MS ? 'stale' : 'fresh';
+}
+
+/**
+ * Drop every local USER-DATA row and the cursors that describe them, so the
+ * cycle that follows re-pulls them from the epoch.
+ *
+ * WHAT IS DELETED: the rows of every USER_DATA_TABLES entry (ticks, playlists,
+ * playlist climbs, favourites, the three follow tables), each of their
+ * `checkpoint:<table>` keys, and the single `checkpoint:deletions` key. Rewinding
+ * a checkpoint alone would not do: the delta resolver never re-emits a row the
+ * server deleted, so a row that lost its tombstone can only be removed by
+ * deleting it locally.
+ *
+ * WHAT IS DELIBERATELY NOT TOUCHED, and why:
+ *  - `board_climbs` / `board_climb_stats` / `board_climb_grades` rows, their
+ *    `checkpoint:board_*` keys, `scope-complete:*` and the bootstrap markers.
+ *    No production path emits a board tombstone — the only DELETEs of those
+ *    tables run inside clear-aurora-board.ts's transaction, which sets
+ *    `boardsesh.suppress_sync_tombstones`, and board_climb_grades has no delete
+ *    trigger at all — so a lost deletions window costs the catalog nothing.
+ *    Clearing it would re-download tens to hundreds of MB, unprompted, possibly
+ *    on cellular. A catalog rebuild stays where the user asks for it
+ *    (removeBoardScopeData, behind the Storage settings flow).
+ *  - `pending_mutations`. Unsynced local writes are not recoverable from the
+ *    server; drainMutationQueue legitimately leaves rows behind (attempt budget,
+ *    dead letters, offline), so "drain first, then wipe" is not a substitute for
+ *    simply never touching the table.
+ *  - `schema_version` and every other sync_meta key. Deletes are by exact key,
+ *    never by pattern, so a future marker can't be swallowed by accident.
+ *
+ * KNOWN TRANSIENT: use-local-ticks JOINs pending_mutations onto boardsesh_ticks,
+ * so an optimistic tick whose mutation has not drained yet disappears from the
+ * logbook between this wipe and the drain that re-lands it from the server. The
+ * write itself is safe — it is still in the outbox.
+ *
+ * One exclusive transaction, busy timeout first (same shape as
+ * removeBoardScopeData): rows-gone-but-cursors-alive would be unrecoverable,
+ * because the strict `>` delta would never revisit the deleted rows.
+ */
+export async function resetUserDataForLostCoverage(
+  db: OfflineDatabase,
+  nowMs: number,
+): Promise<{ rowsCleared: number }> {
+  let rowsCleared = 0;
+
+  await db.withExclusiveTransactionAsync(async (txn) => {
+    // These deletes can take a moment on a large logbook; don't lose the BEGIN
+    // EXCLUSIVE to a straggling write on the main connection.
+    await applyBusyTimeout(txn);
+
+    for (const tableName of USER_DATA_TABLES) {
+      const result = await txn.runAsync(`DELETE FROM ${tableName}`, []);
+      rowsCleared += result.changes;
+    }
+
+    for (const tableName of USER_DATA_TABLES) {
+      await deleteMetaKey(txn, getCheckpointKey(tableName));
+    }
+    await deleteMetaKey(txn, DELETIONS_CHECKPOINT_KEY);
+
+    // Stamped LAST, inside the same transaction as the deletes it justifies.
+    // After a full wipe the invariant holds trivially — no local user row
+    // predates this moment — so the marker is honest, and a device whose
+    // rebuild pull then fails does not wipe itself again on every trigger.
+    await setDeletionsCoverageAt(txn, nowMs);
+  });
+
+  return { rowsCleared };
+}
+
+async function deleteMetaKey(txn: SqlExecutor, key: string): Promise<void> {
+  await txn.runAsync('DELETE FROM sync_meta WHERE key = ?', [key]);
+}

--- a/packages/shared/offline-sync/src/sync/deletions-coverage.ts
+++ b/packages/shared/offline-sync/src/sync/deletions-coverage.ts
@@ -23,7 +23,7 @@
 import type { OfflineDatabase, SqlExecutor } from '../database';
 import { applyBusyTimeout } from '../db/pragmas';
 import { DELETIONS_CHECKPOINT_KEY, getCheckpointKey } from './checkpoints';
-import { DELETIONS_COVERAGE_MAX_AGE_MS } from './retention';
+import { DELETIONS_COVERAGE_EPOCH_FLOOR_MS, DELETIONS_COVERAGE_MAX_AGE_MS } from './retention';
 import { USER_DATA_TABLES } from './table-config';
 
 /**
@@ -39,7 +39,10 @@ import { USER_DATA_TABLES } from './table-config';
 export const DELETIONS_COVERAGE_KEY = 'deletions-coverage';
 
 export type DeletionsCoverageVerdict =
-  /** No marker yet (fresh install, or the OTA that introduced this). Seed it, reset nothing. */
+  /**
+   * No usable marker: absent (fresh install, or the OTA that introduced this),
+   * or a value below the plausibility floor. Seed it, reset nothing.
+   */
   | 'unknown'
   /** Marker is dated after `now` — a clock corrected backwards. Re-stamp it, reset nothing. */
   | 'future'
@@ -53,10 +56,15 @@ export async function getDeletionsCoverageAt(db: SqlExecutor): Promise<number | 
     DELETIONS_COVERAGE_KEY,
   ]);
   if (!row) return null;
+  // Digits-only, deliberately: Number.parseInt tolerates trailing garbage, so an
+  // ISO string written by some future refactor would parse to its leading year
+  // ('2026-07-01…' → 2026 ≈ epoch-ms 1970) and read as decades stale. A corrupt
+  // value must read as ABSENT — seeding a fresh marker costs one retention
+  // window of exposure, whereas treating it as infinitely old wipes user data
+  // off a garbled row. (evaluateDeletionsCoverage's floor catches the same class
+  // of value; this is the cheaper of the two belts.)
+  if (!/^\d+$/.test(row.value.trim())) return null;
   const parsed = Number.parseInt(row.value, 10);
-  // A corrupt value reads as absent: seeding a fresh marker is the safe
-  // direction (it costs one retention window of exposure), whereas treating it
-  // as infinitely old would wipe user data off a garbled row.
   return Number.isFinite(parsed) ? parsed : null;
 }
 
@@ -74,6 +82,12 @@ export async function setDeletionsCoverageAt(db: SqlExecutor, atMs: number): Pro
  */
 export function evaluateDeletionsCoverage(coverageAt: number | null, nowMs: number): DeletionsCoverageVerdict {
   if (coverageAt === null) return 'unknown';
+  // Below the floor is a broken clock, not an old device — see
+  // DELETIONS_COVERAGE_EPOCH_FLOOR_MS. A phone that boots to 1970 before NTP
+  // lands takes the 'future' branch and re-stamps the marker with its bogus
+  // "now"; without this, the correction back to real time would then read as
+  // decades stale and wipe a device that has been syncing daily.
+  if (coverageAt < DELETIONS_COVERAGE_EPOCH_FLOOR_MS) return 'unknown';
   if (coverageAt > nowMs) return 'future';
   return nowMs - coverageAt > DELETIONS_COVERAGE_MAX_AGE_MS ? 'stale' : 'fresh';
 }

--- a/packages/shared/offline-sync/src/sync/deletions-coverage.ts
+++ b/packages/shared/offline-sync/src/sync/deletions-coverage.ts
@@ -23,28 +23,24 @@
 import type { OfflineDatabase, SqlExecutor } from '../database';
 import { applyBusyTimeout } from '../db/pragmas';
 import { DELETIONS_CHECKPOINT_KEY, getCheckpointKey } from './checkpoints';
-import { DELETIONS_COVERAGE_EPOCH_FLOOR_MS, DELETIONS_COVERAGE_MAX_AGE_MS } from './retention';
+import { DELETIONS_COVERAGE_EPOCH_FLOOR_MS, DELETIONS_COVERAGE_KEY, DELETIONS_COVERAGE_MAX_AGE_MS } from './retention';
 import { USER_DATA_TABLES } from './table-config';
 
-/**
- * sync_meta key holding the epoch-ms of the last completed deletions pull.
- *
- * Deliberately NOT under the `checkpoint:` prefix, for the same reason
- * SCOPE_COMPLETE_PREFIX isn't: it describes client wall-clock coverage, not a
- * server cursor. Sign-out's deleteUserCheckpoints resets the deletions cursor to
- * the epoch, which RE-ESTABLISHES full coverage rather than losing it, so the
- * marker must survive that wipe. scope-teardown's clearScopeSyncMeta uses an
- * exact key list, so it is unaffected too.
- */
-export const DELETIONS_COVERAGE_KEY = 'deletions-coverage';
+// The key itself lives in retention.ts (dependency-free, so sign-out's
+// checkpoint teardown can clear it without importing this module).
+export { DELETIONS_COVERAGE_KEY } from './retention';
 
 export type DeletionsCoverageVerdict =
   /**
    * No usable marker: absent (fresh install, or the OTA that introduced this),
-   * or a value below the plausibility floor. Seed it, reset nothing.
+   * or a value below the plausibility floor. Reset nothing; the next completed
+   * deletions pull stamps it.
    */
   | 'unknown'
-  /** Marker is dated after `now` — a clock corrected backwards. Re-stamp it, reset nothing. */
+  /**
+   * Marker is dated after `now` — a clock corrected backwards. Reset nothing;
+   * the completed-pass stamp overwrites it with a real `now`.
+   */
   | 'future'
   /** Within the window: every tombstone since the marker is still queryable. */
   | 'fresh'

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -746,7 +746,10 @@ async function enforceDeletionsCoverage(
   const verdict = evaluateDeletionsCoverage(coverageAt, Date.now());
 
   if (verdict === 'fresh') return;
-  if (verdict === 'unknown' || verdict === 'future') {
+  // `coverageAt === null` IS the 'unknown' verdict — spelling it that way here
+  // narrows coverageAt to a number for the rest of the function, so the
+  // markerAgeDays below needs no fallback for a case that cannot happen.
+  if (coverageAt === null || verdict === 'future') {
     await setDeletionsCoverageAt(db, Date.now());
     return;
   }
@@ -780,8 +783,7 @@ async function enforceDeletionsCoverage(
     queryClient.invalidateQueries({ queryKey: JSON.parse(serializedKey) as string[] });
   }
 
-  // coverageAt is non-null here: only a present marker can evaluate to 'stale'.
-  const markerAgeDays = Math.round((resetAt - (coverageAt ?? resetAt)) / 86_400_000);
+  const markerAgeDays = Math.round((resetAt - coverageAt) / 86_400_000);
   options?.onCoverageReset?.({ markerAgeDays, rowsCleared, pendingMutations });
 }
 

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -797,7 +797,9 @@ async function enforceDeletionsCoverage(
     queryClient.invalidateQueries({ queryKey: JSON.parse(serializedKey) as string[] });
   }
 
-  const markerAgeDays = Math.round((evaluatedAt - coverageAt) / 86_400_000);
+  // floor, not round: a 79.6-day marker must not be reported as 80 (the
+  // threshold value) when the decision was made on exact milliseconds.
+  const markerAgeDays = Math.floor((evaluatedAt - coverageAt) / 86_400_000);
   options?.onCoverageReset?.({ markerAgeDays, rowsCleared, pendingMutations });
 }
 

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -750,8 +750,12 @@ async function enforceDeletionsCoverage(
   // retained tombstone window.
   if (isSigningOut()) return;
 
+  // One clock reading for the whole decision. The probe below is a network
+  // round-trip, so re-reading Date.now() after it would report a marker age
+  // that isn't the one the verdict was made on.
+  const evaluatedAt = Date.now();
   const coverageAt = await getDeletionsCoverageAt(db);
-  const verdict = evaluateDeletionsCoverage(coverageAt, Date.now());
+  const verdict = evaluateDeletionsCoverage(coverageAt, evaluatedAt);
 
   // Only 'stale' does anything. Keeping the explicit `coverageAt === null`
   // disjunct means an absent marker can never structurally reach the wipe below,
@@ -773,8 +777,9 @@ async function enforceDeletionsCoverage(
   if (isSigningOut() || isBackgrounded() || getWipeEpoch() !== cycleEpoch) return;
 
   const pendingMutations = await getPendingCount(db);
-  const resetAt = Date.now();
-  const { rowsCleared } = await resetUserDataForLostCoverage(db, resetAt);
+  // The STAMP is read fresh — it claims coverage as of the wipe itself, which is
+  // after the probe. Only the reported age below uses the decision's clock.
+  const { rowsCleared } = await resetUserDataForLostCoverage(db, Date.now());
 
   // Bust every user-data cache the wipe just invalidated. The rebuild below
   // cannot be relied on to do it: syncTable only invalidates when it pulled at
@@ -792,7 +797,7 @@ async function enforceDeletionsCoverage(
     queryClient.invalidateQueries({ queryKey: JSON.parse(serializedKey) as string[] });
   }
 
-  const markerAgeDays = Math.round((resetAt - coverageAt) / 86_400_000);
+  const markerAgeDays = Math.round((evaluatedAt - coverageAt) / 86_400_000);
   options?.onCoverageReset?.({ markerAgeDays, rowsCleared, pendingMutations });
 }
 
@@ -835,6 +840,10 @@ export async function pullSync(
   // See deletions-coverage.ts for the invariant and for exactly what the reset
   // does (and does not) clear.
   await enforceDeletionsCoverage(db, queryClient, graphqlFetch, cycleEpoch, options);
+  // The phase can spend a probe and a multi-table wipe; the bootstrap phase below
+  // starts downloading before the deletions phase's own cycleAborted(), so check
+  // here rather than let a teardown that landed during it kick off a download.
+  if (cycleAborted()) return;
 
   const enabledBoards = options?.enabledBoards ?? [];
   const onProgress = options?.onProgress;

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -702,17 +702,24 @@ async function runBootstrapPhase(
  * deletions pull, so tombstones it never saw are already pruned server-side
  * (issue #3474).
  *
- * Three of the four verdicts do NOT reset:
- *  - `unknown` (no marker): seed it and move on. The key is new, so EVERY
- *    existing install lacks it on the first launch after the update, and there
- *    is no persisted last-sync wall clock to seed from (mobile's lastSyncedAt is
- *    an in-memory store that resets each launch). Treating absence as "stale"
- *    would detonate a fleet-wide reset on the OTA that introduces the marker. A
+ * Three of the four verdicts do NOTHING AT ALL — no reset, and no stamp either.
+ * The marker is written in exactly one place, after the deletions pull below
+ * reaches its tail, because that is the only moment coverage is actually
+ * established. Claiming it here would be a lie a failed or backgrounded first
+ * pull could never take back:
+ *  - `unknown` (no marker, or one below the plausibility floor): the key is new,
+ *    so EVERY existing install lacks it on the first launch after the update,
+ *    and there is no persisted last-sync wall clock to seed from (mobile's
+ *    lastSyncedAt is an in-memory store that resets each launch). Treating
+ *    absence as "stale" would detonate a fleet-wide reset on the rollout. A
  *    device that has ALREADY been away longer than the window therefore keeps
  *    its stale rows — status quo, not a regression, and the only design that
- *    cannot mass-wipe the fleet on rollout.
- *  - `future` (marker dated after now): a clock corrected backwards. Re-stamp so
- *    it can go stale normally again instead of being frozen fresh forever.
+ *    cannot mass-wipe the fleet on rollout. It stays `unknown` until a pull
+ *    actually completes, so a device that can never finish one never claims a
+ *    window it did not have.
+ *  - `future` (marker dated after now): a clock corrected backwards. The
+ *    completed-pass stamp overwrites it with a real `now`, which unfreezes it
+ *    without inventing coverage on a cycle that failed.
  *  - `fresh`: the common path — one sync_meta read and nothing else.
  *
  * A `stale` verdict PROBES the network before touching anything. pullSync runs
@@ -746,17 +753,12 @@ async function enforceDeletionsCoverage(
   const coverageAt = await getDeletionsCoverageAt(db);
   const verdict = evaluateDeletionsCoverage(coverageAt, Date.now());
 
-  if (verdict === 'fresh') return;
-  // Everything that is not 'stale' re-seeds and resets nothing: an absent
-  // marker, a clock still ahead of the stamp, or a value below the plausibility
-  // floor. Keeping the explicit `coverageAt === null` disjunct means an absent
-  // marker can never structurally reach the wipe below, whatever the classifier
-  // is later taught to return — and it narrows coverageAt to a number, so
-  // markerAgeDays needs no fallback for a case that cannot happen.
-  if (coverageAt === null || verdict !== 'stale') {
-    await setDeletionsCoverageAt(db, Date.now());
-    return;
-  }
+  // Only 'stale' does anything. Keeping the explicit `coverageAt === null`
+  // disjunct means an absent marker can never structurally reach the wipe below,
+  // whatever the classifier is later taught to return — and it narrows
+  // coverageAt to a number, so markerAgeDays needs no fallback for a case that
+  // cannot happen.
+  if (coverageAt === null || verdict !== 'stale') return;
 
   // Reachability + auth probe. Its payload is irrelevant; only "did it resolve"
   // matters, so it asks for a single row.

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -24,7 +24,14 @@ import {
 } from './snapshot-bootstrap';
 import { parseSnapshotManifest, type SnapshotManifest } from './snapshot-manifest';
 import { findSnapshotEntry, isSnapshotEntryUsable } from './snapshot-estimate';
+import {
+  evaluateDeletionsCoverage,
+  getDeletionsCoverageAt,
+  setDeletionsCoverageAt,
+  resetUserDataForLostCoverage,
+} from './deletions-coverage';
 import { applyBusyTimeout } from '../db/pragmas';
+import { getPendingCount } from '../mutation-queue/queue';
 import { isSigningOut, getWipeEpoch, isBackgrounded } from '../mutation-queue/drainer';
 import { parseOfflineBoardKey, type OfflineBoardScope } from '../offline-board-key';
 
@@ -76,6 +83,27 @@ export type ScopeDownloadCompleteInfo = {
 };
 export type ScopeDownloadCompleteReporter = (info: ScopeDownloadCompleteInfo) => void;
 
+/**
+ * Fired when the deletions-coverage guard forced a from-scratch user-data
+ * resync (issue #3474) — the device went longer than the tombstone retention
+ * window without completing a deletions pull, so tombstones it never saw may
+ * already be pruned server-side.
+ *
+ * This is an EXPECTED operational event, not an error: its rate across the
+ * fleet is the only thing anyone will ask about, which is why the mobile
+ * adapter routes it to `track()` rather than Sentry. `markerAgeDays` is the age
+ * of the coverage marker that tripped the guard, `rowsCleared` the number of
+ * local user-data rows dropped, and `pendingMutations` the outbox depth at that
+ * moment (which the reset leaves untouched — a non-zero value here is normal,
+ * not a loss).
+ */
+export type CoverageResetInfo = {
+  markerAgeDays: number;
+  rowsCleared: number;
+  pendingMutations: number;
+};
+export type CoverageResetReporter = (info: CoverageResetInfo) => void;
+
 export type SyncOptions = {
   /** Encoded board scope keys ("boardType:layoutId:sizeId") to download offline. */
   enabledBoards?: string[];
@@ -91,6 +119,8 @@ export type SyncOptions = {
   onSnapshotBootstrapError?: SnapshotBootstrapErrorReporter;
   /** Telemetry for comparing the snapshot vs paged download paths. See ScopeDownloadCompleteInfo. */
   onScopeDownloadComplete?: ScopeDownloadCompleteReporter;
+  /** Telemetry for a forced deletions-coverage resync. See CoverageResetInfo. */
+  onCoverageReset?: CoverageResetReporter;
 };
 
 /** A per-board download target: the parsed scope plus its encoded key. */
@@ -344,7 +374,7 @@ async function processDeletions(
   /** The epoch pullSync captured at CYCLE start — see `cycleAborted` there. */
   cycleEpoch: number,
   onProgress?: (documentsProcessed: number) => void,
-): Promise<void> {
+): Promise<{ reachedTail: boolean }> {
   const checkpointKey = DELETIONS_CHECKPOINT_KEY;
   const checkpoint = await getCheckpoint(db, checkpointKey);
 
@@ -361,14 +391,14 @@ async function processDeletions(
   while (hasMore) {
     // Sign-out is wiping local data: stop before this page writes the old
     // user's rows back (mirrors the drainer's guard).
-    if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) return;
+    if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) return { reachedTail: false };
     const response = await graphqlFetch<{ syncDeletions: SyncDeletionsResult }>(SYNC_DELETIONS_QUERY, {
       cursor,
       limit: PAGE_LIMIT,
     });
     const result = response.syncDeletions;
 
-    if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) return;
+    if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) return { reachedTail: false };
 
     // Empty page can't advance the cursor; break to avoid an infinite loop if
     // the backend returns deletions:[] with hasMore:true (I2).
@@ -440,6 +470,13 @@ async function processDeletions(
   for (const serializedKey of invalidatedKeys) {
     queryClient.invalidateQueries({ queryKey: JSON.parse(serializedKey) as string[] });
   }
+
+  // Both loop exits mean the server has nothing more past this cursor:
+  // hasMore === false, or an empty page (the tail). Only THIS outcome licenses
+  // stamping the coverage marker — the aborts above return false, because a
+  // pull that was backgrounded on its first page has consumed nothing and must
+  // not claim a full retention window of coverage (mirrors syncTable).
+  return { reachedTail: true };
 }
 
 // The manifest is fetched at most once per pullSync run and its outcome cached
@@ -659,6 +696,77 @@ async function runBootstrapPhase(
   return skipPagedPull;
 }
 
+/**
+ * Deletions-coverage guard: force a from-scratch user-data resync when this
+ * device went longer than the tombstone retention window without completing a
+ * deletions pull, so tombstones it never saw are already pruned server-side
+ * (issue #3474).
+ *
+ * Three of the four verdicts do NOT reset:
+ *  - `unknown` (no marker): seed it and move on. The key is new, so EVERY
+ *    existing install lacks it on the first launch after the update, and there
+ *    is no persisted last-sync wall clock to seed from (mobile's lastSyncedAt is
+ *    an in-memory store that resets each launch). Treating absence as "stale"
+ *    would detonate a fleet-wide reset on the OTA that introduces the marker. A
+ *    device that has ALREADY been away longer than the window therefore keeps
+ *    its stale rows — status quo, not a regression, and the only design that
+ *    cannot mass-wipe the fleet on rollout.
+ *  - `future` (marker dated after now): a clock corrected backwards. Re-stamp so
+ *    it can go stale normally again instead of being frozen fresh forever.
+ *  - `fresh`: the common path — one sync_meta read and nothing else.
+ *
+ * A `stale` verdict PROBES the network before touching anything. pullSync runs
+ * on every foreground, including offline ones; wiping first and only then
+ * discovering there is no connection would leave the user staring at an empty
+ * app until connectivity returns. The probe is a one-row syncDeletions request
+ * whose result is discarded — it proves reachability AND the credential, so an
+ * expired-token device can't wipe itself either. A throw propagates to the
+ * scheduler's catch, which retries on the next trigger with local data intact.
+ *
+ * `beginLocalPurge()` is deliberately NOT called: it bumps the wipe epoch, which
+ * would abort the very cycle that is supposed to rebuild. It isn't needed here —
+ * the scheduler single-flights pullSync, so no other pull page is on the wire,
+ * and the drainer writes only to pending_mutations, which this reset never
+ * touches.
+ */
+async function enforceDeletionsCoverage(
+  db: OfflineDatabase,
+  graphqlFetch: <T>(query: string, variables?: Record<string, unknown>) => Promise<T>,
+  options?: SyncOptions,
+): Promise<void> {
+  // Sign-out is (or is about to be) wiping local user data on its own terms;
+  // don't write sync_meta into a DB mid-teardown, and don't spend a probe on an
+  // account that is going away. Its deleteUserCheckpoints resets the deletions
+  // cursor to the epoch anyway, so the next signed-in pull re-reads the whole
+  // retained tombstone window.
+  if (isSigningOut()) return;
+
+  const coverageAt = await getDeletionsCoverageAt(db);
+  const verdict = evaluateDeletionsCoverage(coverageAt, Date.now());
+
+  if (verdict === 'fresh') return;
+  if (verdict === 'unknown' || verdict === 'future') {
+    await setDeletionsCoverageAt(db, Date.now());
+    return;
+  }
+
+  // Reachability + auth probe. Its payload is irrelevant; only "did it resolve"
+  // matters, so it asks for a single row.
+  await graphqlFetch<{ syncDeletions: SyncDeletionsResult }>(SYNC_DELETIONS_QUERY, { cursor: undefined, limit: 1 });
+
+  // Re-check the teardown flags after the network await — the probe may have
+  // been in flight across a sign-out or a backgrounding, and neither wants a
+  // multi-table DELETE dispatched at it.
+  if (isSigningOut() || isBackgrounded()) return;
+
+  const pendingMutations = await getPendingCount(db);
+  const resetAt = Date.now();
+  const { rowsCleared } = await resetUserDataForLostCoverage(db, resetAt);
+  // coverageAt is non-null here: only a present marker can evaluate to 'stale'.
+  const markerAgeDays = Math.round((resetAt - (coverageAt ?? resetAt)) / 86_400_000);
+  options?.onCoverageReset?.({ markerAgeDays, rowsCleared, pendingMutations });
+}
+
 export async function pullSync(
   db: OfflineDatabase,
   queryClient: QueryInvalidator,
@@ -669,6 +777,12 @@ export async function pullSync(
   // bootstrap phase below (which runs before the first cycleAborted() check)
   // when the app is already backgrounded.
   if (isBackgrounded()) return;
+
+  // Phase -1: deletions-coverage guard (issue #3474). Runs BEFORE the bootstrap
+  // phase and before cycleEpoch is captured, so the reset and the rebuild that
+  // follows belong to the same cycle. See deletions-coverage.ts for the
+  // invariant and for exactly what the reset does (and does not) clear.
+  await enforceDeletionsCoverage(db, graphqlFetch, options);
 
   const enabledBoards = options?.enabledBoards ?? [];
   const onProgress = options?.onProgress;
@@ -737,10 +851,14 @@ export async function pullSync(
   // never fetch it again.
   if (cycleAborted()) return;
   onProgress?.({ phase: 'deletions', currentTable: null, documentsProcessed: 0 });
-  await processDeletions(db, queryClient, graphqlFetch, cycleEpoch, (deletionsProcessed) => {
+  const deletionsResult = await processDeletions(db, queryClient, graphqlFetch, cycleEpoch, (deletionsProcessed) => {
     totalDocuments = deletionsProcessed;
     onProgress?.({ phase: 'deletions', currentTable: null, documentsProcessed: totalDocuments });
   });
+  // The coverage marker advances ONLY on a completed pass. An aborted one (sign-out,
+  // purge, backgrounding) consumed an unknown prefix of the stream, so claiming a
+  // fresh retention window off it would hide a real gap. See deletions-coverage.ts.
+  if (deletionsResult.reachedTail) await setDeletionsCoverageAt(db, Date.now());
 
   for (const tableName of USER_DATA_TABLES) {
     if (cycleAborted()) return;

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -731,6 +731,7 @@ async function runBootstrapPhase(
  */
 async function enforceDeletionsCoverage(
   db: OfflineDatabase,
+  queryClient: QueryInvalidator,
   graphqlFetch: <T>(query: string, variables?: Record<string, unknown>) => Promise<T>,
   options?: SyncOptions,
 ): Promise<void> {
@@ -762,6 +763,23 @@ async function enforceDeletionsCoverage(
   const pendingMutations = await getPendingCount(db);
   const resetAt = Date.now();
   const { rowsCleared } = await resetUserDataForLostCoverage(db, resetAt);
+
+  // Bust every user-data cache the wipe just invalidated. The rebuild below
+  // cannot be relied on to do it: syncTable only invalidates when it pulled at
+  // least one document and processDeletions only on arrivals, so a table the
+  // user had emptied server-side re-pulls nothing and a mounted screen would
+  // keep serving the pre-wipe react-query cache — the exact #3474 symptom
+  // surviving the fix. Deduped by serialized key, same shape as processDeletions.
+  const invalidatedKeys = new Set<string>();
+  for (const tableName of USER_DATA_TABLES) {
+    for (const key of TABLE_CONFIGS[tableName].invalidateKeys) {
+      invalidatedKeys.add(JSON.stringify(key));
+    }
+  }
+  for (const serializedKey of invalidatedKeys) {
+    queryClient.invalidateQueries({ queryKey: JSON.parse(serializedKey) as string[] });
+  }
+
   // coverageAt is non-null here: only a present marker can evaluate to 'stale'.
   const markerAgeDays = Math.round((resetAt - (coverageAt ?? resetAt)) / 86_400_000);
   options?.onCoverageReset?.({ markerAgeDays, rowsCleared, pendingMutations });
@@ -782,7 +800,7 @@ export async function pullSync(
   // phase and before cycleEpoch is captured, so the reset and the rebuild that
   // follows belong to the same cycle. See deletions-coverage.ts for the
   // invariant and for exactly what the reset does (and does not) clear.
-  await enforceDeletionsCoverage(db, graphqlFetch, options);
+  await enforceDeletionsCoverage(db, queryClient, graphqlFetch, options);
 
   const enabledBoards = options?.enabledBoards ?? [];
   const onProgress = options?.onProgress;

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -733,6 +733,7 @@ async function enforceDeletionsCoverage(
   db: OfflineDatabase,
   queryClient: QueryInvalidator,
   graphqlFetch: <T>(query: string, variables?: Record<string, unknown>) => Promise<T>,
+  cycleEpoch: number,
   options?: SyncOptions,
 ): Promise<void> {
   // Sign-out is (or is about to be) wiping local user data on its own terms;
@@ -746,10 +747,13 @@ async function enforceDeletionsCoverage(
   const verdict = evaluateDeletionsCoverage(coverageAt, Date.now());
 
   if (verdict === 'fresh') return;
-  // `coverageAt === null` IS the 'unknown' verdict — spelling it that way here
-  // narrows coverageAt to a number for the rest of the function, so the
-  // markerAgeDays below needs no fallback for a case that cannot happen.
-  if (coverageAt === null || verdict === 'future') {
+  // Everything that is not 'stale' re-seeds and resets nothing: an absent
+  // marker, a clock still ahead of the stamp, or a value below the plausibility
+  // floor. Keeping the explicit `coverageAt === null` disjunct means an absent
+  // marker can never structurally reach the wipe below, whatever the classifier
+  // is later taught to return — and it narrows coverageAt to a number, so
+  // markerAgeDays needs no fallback for a case that cannot happen.
+  if (coverageAt === null || verdict !== 'stale') {
     await setDeletionsCoverageAt(db, Date.now());
     return;
   }
@@ -760,8 +764,11 @@ async function enforceDeletionsCoverage(
 
   // Re-check the teardown flags after the network await — the probe may have
   // been in flight across a sign-out or a backgrounding, and neither wants a
-  // multi-table DELETE dispatched at it.
-  if (isSigningOut() || isBackgrounded()) return;
+  // multi-table DELETE dispatched at it. The epoch check catches the third
+  // teardown: a board removal (or any beginLocalPurge) that landed while the
+  // probe was on the wire is about to abort this cycle at its first
+  // cycleAborted(), so a wipe here would clear user data with no rebuild behind it.
+  if (isSigningOut() || isBackgrounded() || getWipeEpoch() !== cycleEpoch) return;
 
   const pendingMutations = await getPendingCount(db);
   const resetAt = Date.now();
@@ -798,16 +805,6 @@ export async function pullSync(
   // when the app is already backgrounded.
   if (isBackgrounded()) return;
 
-  // Phase -1: deletions-coverage guard (issue #3474). Runs BEFORE the bootstrap
-  // phase and before cycleEpoch is captured, so the reset and the rebuild that
-  // follows belong to the same cycle. See deletions-coverage.ts for the
-  // invariant and for exactly what the reset does (and does not) clear.
-  await enforceDeletionsCoverage(db, queryClient, graphqlFetch, options);
-
-  const enabledBoards = options?.enabledBoards ?? [];
-  const onProgress = options?.onProgress;
-  let totalDocuments = 0;
-
   // Captured ONCE for the whole cycle and threaded into every phase, so a wipe or a
   // local purge aborts the entire pull rather than just whichever table is mid-flight.
   //
@@ -821,10 +818,25 @@ export async function pullSync(
   //
   // Sign-out never hit this because `isSigningOut()` is a persistent flag that stays
   // true for every subsequent table; the epoch alone is not a substitute for it.
+  //
+  // Captured immediately after the entry guard and BEFORE the coverage phase's
+  // awaits: that phase can spend a network probe plus a multi-table wipe, and a
+  // purge landing inside that window must read as "not my epoch" rather than be
+  // adopted as this cycle's own baseline.
   const cycleEpoch = getWipeEpoch();
   // Unlike the other two checks, isBackgrounded() is live, not latched — a background
   // dip that clears before the next check runs won't abort a cycle it can no longer affect.
   const cycleAborted = (): boolean => isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded();
+
+  // Phase -1: deletions-coverage guard (issue #3474). Runs BEFORE the bootstrap
+  // phase, so the reset and the rebuild that follows belong to the same cycle.
+  // See deletions-coverage.ts for the invariant and for exactly what the reset
+  // does (and does not) clear.
+  await enforceDeletionsCoverage(db, queryClient, graphqlFetch, cycleEpoch, options);
+
+  const enabledBoards = options?.enabledBoards ?? [];
+  const onProgress = options?.onProgress;
+  let totalDocuments = 0;
 
   // Parse the enabled scope keys once; malformed keys are dropped (a stray value
   // can't crash the pull) so both the bootstrap phase and the paged board loop

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -745,9 +745,9 @@ async function enforceDeletionsCoverage(
 ): Promise<void> {
   // Sign-out is (or is about to be) wiping local user data on its own terms;
   // don't write sync_meta into a DB mid-teardown, and don't spend a probe on an
-  // account that is going away. Its deleteUserCheckpoints resets the deletions
-  // cursor to the epoch anyway, so the next signed-in pull re-reads the whole
-  // retained tombstone window.
+  // account that is going away. Its deleteUserCheckpoints drops the coverage
+  // marker and rewinds the deletions cursor to the epoch anyway, so the next
+  // signed-in pull re-reads the whole retained tombstone window and re-stamps.
   if (isSigningOut()) return;
 
   // One clock reading for the whole decision. The probe below is a network

--- a/packages/shared/offline-sync/src/sync/retention.ts
+++ b/packages/shared/offline-sync/src/sync/retention.ts
@@ -1,0 +1,43 @@
+// Tombstone retention — the ONE number the server prune job and the client
+// staleness guard must agree on (issue #3474).
+//
+// The backend hard-deletes `sync_deletions` rows older than
+// SYNC_DELETIONS_RETENTION_DAYS (packages/backend/src/services/sync-deletions-prune.ts,
+// run daily from server.ts). The sync resolver pages tombstones on a strict `>`
+// keyset, so a client whose deletions coverage predates the prune cutoff can
+// never be served the tombstones that were removed in between: rows deleted
+// server-side stay on that device forever (a hard-deleted record is never
+// re-upserted, so nothing else clears it).
+//
+// The client half of the contract lives in deletions-coverage.ts. This file is
+// imported by BOTH sides — the backend depends on @boardsesh/offline-sync
+// already (packages/backend/package.json), and this package depends on nothing
+// outside @boardsesh/shared-schema, so there is no cycle.
+
+/**
+ * How long a tombstone stays queryable before the daily prune job deletes it.
+ * Lowering this shortens the window a stale device has to catch up.
+ */
+export const SYNC_DELETIONS_RETENTION_DAYS = 90;
+
+/**
+ * Slack between "the client believes it is covered" and "the server has actually
+ * pruned". It absorbs prune-job lag (the job runs daily, not continuously), the
+ * duration of a long sync cycle, and modest device clock skew — a device would
+ * need to jump more than 10 days for the margin alone to flip the verdict.
+ */
+export const DELETIONS_COVERAGE_MARGIN_DAYS = 10;
+
+/**
+ * The client's staleness threshold: once its coverage marker is older than this,
+ * tombstones it never saw may already be pruned and the only recovery is a
+ * from-scratch user-data resync.
+ *
+ * NOTE: the client's copy of these numbers only refreshes with the OTA bundle.
+ * Lowering SYNC_DELETIONS_RETENTION_DAYS on the backend does NOT reach older
+ * clients — they keep comparing against the value they shipped with, and the
+ * window between the two values is unguarded until they update. Raise the margin
+ * (or ship the OTA first) before shortening the server window.
+ */
+export const DELETIONS_COVERAGE_MAX_AGE_MS =
+  (SYNC_DELETIONS_RETENTION_DAYS - DELETIONS_COVERAGE_MARGIN_DAYS) * 24 * 60 * 60 * 1000;

--- a/packages/shared/offline-sync/src/sync/retention.ts
+++ b/packages/shared/offline-sync/src/sync/retention.ts
@@ -41,3 +41,14 @@ export const DELETIONS_COVERAGE_MARGIN_DAYS = 10;
  */
 export const DELETIONS_COVERAGE_MAX_AGE_MS =
   (SYNC_DELETIONS_RETENTION_DAYS - DELETIONS_COVERAGE_MARGIN_DAYS) * 24 * 60 * 60 * 1000;
+
+/**
+ * Earliest epoch-ms a coverage marker can plausibly hold. Boardsesh shipped no
+ * offline sync before 2025, so a marker below this is never an old device — it
+ * is a garbage clock (a phone that cold-boots to 1970/2001 before NTP lands and
+ * re-stamps the marker with its bogus "now") or a garbled row. Both read as
+ * decades stale, and wiping user data off a device that has been syncing daily
+ * is the regression this guard exists to avoid, so the classifier treats them as
+ * "no marker" and re-seeds instead.
+ */
+export const DELETIONS_COVERAGE_EPOCH_FLOOR_MS = Date.parse('2025-01-01T00:00:00Z');

--- a/packages/shared/offline-sync/src/sync/retention.ts
+++ b/packages/shared/offline-sync/src/sync/retention.ts
@@ -15,6 +15,19 @@
 // outside @boardsesh/shared-schema, so there is no cycle.
 
 /**
+ * sync_meta key holding the epoch-ms of the last completed deletions pull.
+ *
+ * Lives here, in the dependency-free module, because both deletions-coverage.ts
+ * (which owns the semantics) and checkpoints.ts (which clears it on sign-out)
+ * need it, and deletions-coverage.ts already imports checkpoints.ts.
+ *
+ * Deliberately NOT under the `checkpoint:` prefix, for the same reason
+ * SCOPE_COMPLETE_PREFIX isn't: it describes client wall-clock coverage, not a
+ * server cursor.
+ */
+export const DELETIONS_COVERAGE_KEY = 'deletions-coverage';
+
+/**
  * How long a tombstone stays queryable before the daily prune job deletes it.
  * Lowering this shortens the window a stale device has to catch up.
  */

--- a/packages/shared/offline-sync/src/sync/sync-scheduler.ts
+++ b/packages/shared/offline-sync/src/sync/sync-scheduler.ts
@@ -4,6 +4,7 @@ import {
   type SyncProgress,
   type SchemaDriftReporter,
   type ScopeDownloadCompleteReporter,
+  type CoverageResetReporter,
 } from './pull-client';
 import type { SnapshotSource, SnapshotBootstrapErrorReporter } from './snapshot-bootstrap';
 
@@ -58,6 +59,8 @@ export type SchedulerOptions = {
   onSnapshotBootstrapError?: SnapshotBootstrapErrorReporter;
   /** Threaded through to pullSync's SyncOptions — see ScopeDownloadCompleteInfo. */
   onScopeDownloadComplete?: ScopeDownloadCompleteReporter;
+  /** Threaded through to pullSync's SyncOptions — see CoverageResetInfo. */
+  onCoverageReset?: CoverageResetReporter;
 };
 
 let isSyncing = false;
@@ -96,6 +99,7 @@ async function runSync(
       snapshotSource: options?.snapshotSource,
       onSnapshotBootstrapError: options?.onSnapshotBootstrapError,
       onScopeDownloadComplete: options?.onScopeDownloadComplete,
+      onCoverageReset: options?.onCoverageReset,
     });
   } catch (error) {
     options?.onCycleError?.(error);


### PR DESCRIPTION
## What & why

A device that goes months without syncing keeps ticks, playlists and favourites you deleted elsewhere — permanently.

The backend hard-deletes tombstones older than 90 days (`pruneSyncDeletions`, run daily from `server.ts`), and the `syncDeletions` resolver pages on a strict `>` keyset. So every tombstone whose `deleted_at` fell in `(client cursor, now − 90d]` was destroyed before that client ever asked for it, and the client can never be served it again. Those local rows survive until an unrelated upsert of the same primary key — which, for a row the server hard-deleted, never happens. The prune service's own doc comment flagged this client-side gap as unaddressed.

Fixes #3474.

## Verified root cause

- `packages/backend/src/services/sync-deletions-prune.ts` — 90-day cutoff, `DELETE FROM sync_deletions WHERE deleted_at < cutoff`.
- `packages/backend/src/graphql/resolvers/sync/queries.ts` — `(deleted_at, id) > (cursor)`, strict.
- `packages/shared/offline-sync/src/sync/pull-client.ts` — `processDeletions` read the checkpoint and paged straight from it, with no notion of how old that coverage was.

Two corrections to the obvious fix, both load-bearing:

**The staleness oracle cannot be the checkpoint's own age.** `checkpoint:deletions` stores the server-side `deleted_at` of the last consumed tombstone, and only advances on a non-empty page. A user who has deleted nothing for three months carries a three-month-old cursor on a perfectly current device. Worse, in production the board tables emit **no** tombstones at all — the only production DELETEs of `board_climbs` / `board_climb_stats` run inside `clearAuroraBoardData`'s transaction, which sets `boardsesh.suppress_sync_tombstones` (`packages/db/drizzle/0144_offline_sync_backend.sql:391-393` + `packages/db/src/queries/boards/clear-aurora-board.ts:154`), and `board_climb_grades` has no delete trigger. So the only tombstones any user sees are their own deletes. A cursor-age test would have reset most of the fleet.

**The reset must not touch the board catalog.** Same finding: no board tombstone is ever emitted in production, so a blown deletions window costs the offline catalog nothing. Clearing it would re-download tens to hundreds of MB, unprompted, possibly on cellular — the exact cost `remove-offline-board.ts` already treats as something to ask about.

## Fix

A wall-clock **deletions-coverage marker**. A client that reached the deletions tail at time T has consumed every tombstone that existed at T; anything pruned after T was already applied. It can only miss data if `now − T` exceeds retention.

- `packages/shared/offline-sync/src/sync/retention.ts` (new) — `SYNC_DELETIONS_RETENTION_DAYS = 90`, `DELETIONS_COVERAGE_MARGIN_DAYS = 10`, `DELETIONS_COVERAGE_MAX_AGE_MS` (80 days). The backend prune job now imports and re-exports the retention constant instead of defining its own, so the two sides can't fork.
- `packages/shared/offline-sync/src/sync/deletions-coverage.ts` (new) — `sync_meta['deletions-coverage']` (deliberately outside the `checkpoint:` prefix, so sign-out's checkpoint wipe leaves it alone), the four-way verdict, and `resetUserDataForLostCoverage`: one exclusive transaction that deletes the rows of every `USER_DATA_TABLES` entry, their checkpoints and `checkpoint:deletions`, then stamps the marker.
- `packages/shared/offline-sync/src/sync/pull-client.ts` — `processDeletions` now returns `{ reachedTail }` (mirroring `syncTable`), and the marker only advances on a completed pass. A new guard runs at the top of `pullSync`, before the bootstrap phase.
- Cache busting: the reset invalidates every `USER_DATA_TABLES` react-query key itself. It can't lean on the rebuild — `syncTable` only busts caches when it pulled at least one document and `processDeletions` only on arrivals, so a table the user emptied server-side re-pulls nothing and a mounted screen would keep serving the pre-wipe cache.
- Telemetry: `Offline Sync Coverage Reset Forced` via the injected `onCoverageReset` seam → `track()` in the mobile adapter. The shared package stays analytics-free.

Behaviour of the guard, branch by branch:

| marker                                          | action                                        |
| ----------------------------------------------- | --------------------------------------------- |
| absent, or implausibly old (broken clock)       | nothing — **no reset**, and no stamp either   |
| dated in the future (clock corrected backwards) | nothing — **no reset**                        |
| within 80 days                                  | nothing (one `sync_meta` read)                |
| older than 80 days                              | probe → reset user data → same cycle rebuilds |

The marker is written in exactly one place: after the deletions pull reaches its tail. That is the only moment coverage actually exists, so a first post-update pull that fails or gets backgrounded leaves the marker absent rather than handing a device that has been away 89 days a fresh 80-day window it never earned.

Five further guards came out of review, each closing a path where a _healthy_ device could reset itself (or claim coverage it never had):

- **Plausibility floor** (`DELETIONS_COVERAGE_EPOCH_FLOOR_MS`, 2025-01-01). A phone that cold-boots with a dead RTC (1970 / 2001) before NTP lands reads the real marker as `future` and re-stamps it with its bogus now; once the clock corrects, that stamp is decades old and authorises a wipe on a device that has been syncing daily. Anything below the floor classifies as `unknown`, so it resets nothing and is overwritten by the next completed pass.
- **Digits-only marker parse.** `Number.parseInt` tolerates trailing garbage, so an ISO string (`'2026-07-01T…'` → `2026`) would have parsed to ~1970 and read as stale — the opposite of what `getDeletionsCoverageAt`'s "a corrupt value reads as absent" contract promised.
- **No eager stamp on a non-stale verdict** (Codex P2). The guard used to seed the marker up front for `unknown` / `future`; a first pull that then failed left behind a coverage claim the device never established. Now only the completed-pass stamp writes it.
- **The marker is dropped on sign-out.** It sat outside the `checkpoint:` prefix and survived the sign-out teardown, but sign-out rewinds the deletions cursor to the epoch, so a departing account's stale marker only served to trip the guard on the NEXT account's first pull — a wasted probe and a reset of tables sign-out had already emptied, reported as `rowsCleared: 0`.
- **`cycleEpoch` is captured before the coverage phase**, and the post-probe re-check compares it. The probe is a real round-trip, so a `beginLocalPurge()` (Storage → Remove board) could land inside it and be adopted as this cycle's own epoch — the wipe would then run and every later phase would bail at its first `cycleAborted()`, leaving user data cleared with no rebuild behind it.

The `stale` branch **probes the network first** — a one-row `syncDeletions` request whose result is discarded. `pullSync` runs on every foreground including offline ones; wiping first and then failing the first fetch would leave the user with an empty app until connectivity returns. The probe also proves the credential, so an expired-token device can't wipe itself. `pending_mutations` is never touched.

## Tests + fail-on-revert

`packages/shared/offline-sync/src/sync/__tests__/deletions-coverage.test.ts` (new) and a new block in `pull-client.integration.test.ts` (real DDL via `node:sqlite`), plus one case in the mock-db `pull-client.test.ts` and the mobile adapter suite.

- **stale + online** — 100-day-old marker: stale tick and playlist gone, freshly-pulled tick present, `board_climbs` and `checkpoint:board_climbs:*` untouched, `pending_mutations` intact, marker advanced. _Revert phase −1 out of `pullSync` and this fails_ — verified: only this test broke.
- **stale + offline** — the fetch rejects: nothing is wiped, the old marker survives. _Remove the probe and both this and the case above fail_ — verified.
- **absent marker (bootstrap OTA)** — no reset, rows survive, and the marker is seeded by the completed pass itself. _Make absence mean "stale" and 20 tests across the suite fail_ — verified. This is the fleet-wipe guard.
- **no coverage claim without a completed pass** — absent marker + a failing fetch: the marker stays absent. _Re-add the eager stamp and this plus the aborted-pull test fail_ — verified.
- **sign-out** — a stale marker does not survive `deleteUserCheckpoints`, so it cannot leak into the next account.
- **empty tables** — a reset on already-cleared tables is a clean no-op that still stamps the marker (`rowsCleared: 0`).
- **wrong oracle** — `checkpoint:deletions` dated 200 days ago, coverage marker 1 day old: no reset. Fails if anyone rewires the oracle to the checkpoint.
- **aborted deletions pull** — backgrounded mid-stream: the marker does not advance. Fails if `processDeletions` goes back to returning `void`.
- **purge mid-probe** — `beginLocalPurge()` fires while the probe is on the wire: nothing wiped, marker unchanged, no reset event. _Drop the epoch comparison from the post-probe re-check and only this test fails_ — verified.
- **broken clock** — marker at epoch 0 and at 2001 read as `unknown`, not `stale`; the floor value itself is still `stale`. _Delete the floor check and this fails_ — verified.
- **garbled marker** — `'not-a-number'`, an ISO string, empty, whitespace, `'17e14'`, `'-1'` all read as absent. _Delete the digits-only test and the ISO case fails_ — verified.
- **future-dated marker**, boundary cases at 79 / 80 / 81 days.
- **reset scope** — `pending_mutations` byte-identical across the reset, `schema_version` untouched, every board table and marker family preserved.
- **backend** — the prune window and the client's shared constant must be the same value; re-introducing a local `= 90` and editing either side fails at the seam.

## Blast radius

Pure JS/TS, no native code and no DB migration (the marker is a row in the existing `sync_meta`). CI still reports a fingerprint change and applies `native-fingerprint`, same as every other JS-only change under `packages/shared` — so it rides the next store/TestFlight build rather than an OTA. Every offline mobile user's first sync after the update writes the marker and resets **nothing**.

## QA Notes

The failure being guarded is rare; the regression it could cause is not. Weight QA accordingly.

1. **Negative case (the important one).** On a device with boards downloaded, take the build and foreground the app. Expect: boards keep their "downloaded" chips, ticks/playlists/favourites all still there, a normal short sync cycle, no re-download, no `Offline Sync Coverage Reset Forced` event.
2. **Positive case, forced.** There's no user-facing trigger — hand-write `sync_meta['deletions-coverage']` to `Date.now() - 100 * 86400000` (dev script or SQLite write), then foreground. Expect: one small `syncDeletions` request, ticks/playlists/favourites clear and immediately re-populate from the server, downloaded boards stay downloaded (no catalog re-download), and one PostHog event with `markerAgeDays ≈ 100`.
3. **Offline safety.** Repeat (2) in airplane mode. Expect: nothing wiped — ticks, playlists and downloaded boards all still present — and a failed sync cycle in Settings. Re-enable the network and confirm the reset then runs on the next trigger.
4. **Outbox.** Repeat (2) in airplane mode, log a tick offline so it queues, then re-enable the network and foreground. Expect: the reset runs and the offline tick still reaches the server and reappears in the logbook. It may blink out between the wipe and the drain — that transient is expected; permanent loss is not.

## Release Notes

Pick the app back up after months away and it now rebuilds your ticks, playlists and favourites from the server, instead of quietly hanging on to ones you deleted while you were gone. Your downloaded boards stay put — no surprise re-download — and anything you logged offline still goes up.
