### PR TITLE
fix(mobile): carry queue-item attribution across the mobile wire

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -136,6 +136,12 @@ Two non-obvious narrowing points bit us in #3927: `climbToQueueItem` hand-picked
 
 The contract is enforced by `packages/backend/src/__tests__/queue-climb-field-contract.test.ts`, which reads every list from its live source and compares by set equality against the GraphQL `ClimbInput` type. `userAscents` / `userAttempts` are the only deliberate exception — they are per-user tick counts and must never be broadcast, at the cost of behaving exactly like the bug the test guards against.
 
+### Queue item field contract
+
+The **item** wrapping that climb flaps for the same reason (#3995). `ClimbQueueItemInput` carries `addedBy`, `addedByUser`, `tickedBy` and `suggested` alongside `uuid`/`climb`, and each crosses its own write list (`toQueueItemInput` in `@boardsesh/queue-react`), the backend's Zod item schema, and each client's read selection (`QUEUE_ITEM_FIELDS` in `@boardsesh/graphql`, `SUBSCRIPTION_QUEUE_ITEM_FIELDS` on mobile, plus mobile's `toClimbQueueItem` rebuild). Item drift is louder than climb drift because attribution is rendered: the queue row's trailing avatar blinks in and out depending on who wrote last. Before #3995 mobile neither sent nor selected the four, so a phone in the session stripped attribution from climbs the crew had queued on web. The same contract test guards the item lists, by set equality against `ClimbQueueItemInput`.
+
+The note above about the adapter populating `addedBy`/`addedByUser` from `usePartyProfile` describes **web**. Mobile stamps its own identity in `attributeNewItem` (`queue-provider.tsx`), which deliberately skips an item that already carries attribution and anything already sitting in this device's queue — a blanket wire-level fallback would let a phone claim authorship of a peer's item on its next full-queue write.
+
 ## Technology Stack
 
 | Component          | Technology                        | Purpose                                                       |

--- a/packages/backend/src/__tests__/operations-schema-validation.test.ts
+++ b/packages/backend/src/__tests__/operations-schema-validation.test.ts
@@ -58,6 +58,22 @@ function readMobileSubscriptionClimbFields(): string {
   return extractTemplateConst(readMobileOperationsSource(), 'SUBSCRIPTION_CLIMB_FIELDS');
 }
 
+/**
+ * Mobile's operation strings interpolate `${SUBSCRIPTION_QUEUE_ITEM_FIELDS}` (which
+ * itself interpolates `${SUBSCRIPTION_CLIMB_FIELDS}`) at build time via JS template
+ * literals. The regex extraction above reads raw source text, so it captures those
+ * placeholders literally — substitute them, outer one first, to reproduce what the
+ * real template literal evaluates to before parsing as GraphQL. One helper so a new
+ * nested selection const cannot be taught to one call site and forgotten at another.
+ */
+function resolveMobileTemplatePlaceholders(rawSource: string, mobileOperationsSource: string): string {
+  const queueItemFields = extractTemplateConst(mobileOperationsSource, 'SUBSCRIPTION_QUEUE_ITEM_FIELDS');
+  const climbFields = extractTemplateConst(mobileOperationsSource, 'SUBSCRIPTION_CLIMB_FIELDS');
+  return rawSource
+    .replaceAll('${SUBSCRIPTION_QUEUE_ITEM_FIELDS}', queueItemFields)
+    .replaceAll('${SUBSCRIPTION_CLIMB_FIELDS}', climbFields);
+}
+
 // Collect the field names selected inside every `climb { ... }` selection set of
 // a GraphQL operation document. Both the shared queue-session subscription and a
 // wrapped copy of the mobile fragment feed through this, so parity is compared
@@ -158,16 +174,11 @@ describe('shared-schema operations validate against the executable schema', () =
  */
 describe('mobile plain-string subscription documents validate against the executable schema', () => {
   const mobileOperationsSource = readMobileOperationsSource();
-  const subscriptionClimbFields = extractTemplateConst(mobileOperationsSource, 'SUBSCRIPTION_CLIMB_FIELDS');
-
-  // QUEUE_UPDATES_SUBSCRIPTION interpolates `${SUBSCRIPTION_CLIMB_FIELDS}` at build
-  // time via a JS template literal. The regex extraction below reads raw source text,
-  // so it captures that placeholder literally — substitute the extracted field list
-  // in its place to reproduce what the real template literal evaluates to before
-  // parsing as GraphQL.
   function readMobilePlainOperation(constName: string): string {
-    const rawSource = extractTemplateConst(mobileOperationsSource, constName);
-    return rawSource.replaceAll('${SUBSCRIPTION_CLIMB_FIELDS}', subscriptionClimbFields);
+    return resolveMobileTemplatePlaceholders(
+      extractTemplateConst(mobileOperationsSource, constName),
+      mobileOperationsSource,
+    );
   }
 
   const mobilePlainOperationNames = [
@@ -291,14 +302,9 @@ describe('mobile QUEUE_UPDATES_SUBSCRIPTION selects the same PlaybackStateChange
   }
 
   const mobileOperationsSource = readMobileOperationsSource();
-  const subscriptionClimbFields = extractTemplateConst(mobileOperationsSource, 'SUBSCRIPTION_CLIMB_FIELDS');
-  // Same placeholder-substitution technique as the "mobile plain-string
-  // subscription documents" describe block above — QUEUE_UPDATES_SUBSCRIPTION
-  // interpolates `${SUBSCRIPTION_CLIMB_FIELDS}` at build time, so replicate
-  // that before parsing raw extracted source text as GraphQL.
-  const mobileQueueUpdates = extractTemplateConst(mobileOperationsSource, 'QUEUE_UPDATES_SUBSCRIPTION').replaceAll(
-    '${SUBSCRIPTION_CLIMB_FIELDS}',
-    subscriptionClimbFields,
+  const mobileQueueUpdates = resolveMobileTemplatePlaceholders(
+    extractTemplateConst(mobileOperationsSource, 'QUEUE_UPDATES_SUBSCRIPTION'),
+    mobileOperationsSource,
   );
 
   const sharedPlaybackFields = inlineFragmentFieldNames(queueSessionOperations.QUEUE_UPDATES, 'PlaybackStateChanged');

--- a/packages/backend/src/__tests__/queue-climb-field-contract.test.ts
+++ b/packages/backend/src/__tests__/queue-climb-field-contract.test.ts
@@ -51,21 +51,57 @@ function climbSelectionFieldNames(operationSource: string): Set<string> {
 }
 
 /**
- * Mobile hand-maintains its selection set as a plain template string, so read it
- * out of the source text rather than importing the mobile package (which would
- * drag React Native deps into this backend test). Same technique as
+ * The GraphQL fields a queue ITEM hangs off in these operations: the FullSync
+ * queue list, the FullSync current pointer, and the per-variant `item` (aliased
+ * `addedItem` / `currentItem` to dodge the union nullability conflict).
+ */
+const QUEUE_ITEM_PARENT_FIELDS = new Set(['queue', 'currentClimbQueueItem', 'item']);
+
+/** Top-level field names selected on each queue ITEM of an operation. */
+function queueItemSelectionFieldNames(operationSource: string): Set<string> {
+  const fields = new Set<string>();
+  visit(parse(operationSource), {
+    Field(node) {
+      if (!QUEUE_ITEM_PARENT_FIELDS.has(node.name.value) || !node.selectionSet) return;
+      for (const selection of node.selectionSet.selections) {
+        if (selection.kind === 'Field') fields.add(selection.alias?.value ?? selection.name.value);
+      }
+    },
+  });
+  return fields;
+}
+
+/**
+ * Mobile hand-maintains its selection sets as plain template strings, so read
+ * them out of the source text rather than importing the mobile package (which
+ * would drag React Native deps into this backend test). Same technique as
  * `operations-schema-validation.test.ts`.
  */
-function mobileSubscriptionClimbFields(): Set<string> {
+function mobileSelectionTemplate(constName: string): string {
   const source = readFileSync(
     new URL('../../../../packages/mobile/src/lib/graphql/operations.ts', import.meta.url),
     'utf-8',
   );
-  const match = source.match(/SUBSCRIPTION_CLIMB_FIELDS\s*=\s*`([\s\S]*?)`/);
+  const match = source.match(new RegExp(`${constName}\\s*=\\s*\`([\\s\\S]*?)\``));
   if (!match?.[1]) {
-    throw new Error('Could not extract SUBSCRIPTION_CLIMB_FIELDS from mobile operations.ts');
+    throw new Error(`Could not extract ${constName} from mobile operations.ts`);
   }
-  return climbSelectionFieldNames(`{ climb { ${match[1]} } }`);
+  return match[1];
+}
+
+function mobileSubscriptionClimbFields(): Set<string> {
+  return climbSelectionFieldNames(`{ climb { ${mobileSelectionTemplate('SUBSCRIPTION_CLIMB_FIELDS')} } }`);
+}
+
+function mobileSubscriptionQueueItemFields(): Set<string> {
+  // The template interpolates the climb selection; stub the interpolation so the
+  // string parses. What the climb sub-selection contains is the climb-level
+  // guard's job, not this one's.
+  const template = mobileSelectionTemplate('SUBSCRIPTION_QUEUE_ITEM_FIELDS').replace(
+    '${SUBSCRIPTION_CLIMB_FIELDS}',
+    'uuid',
+  );
+  return queueItemSelectionFieldNames(`{ item { ${template} } }`);
 }
 
 const climbInputFields = inputTypeFieldNames('ClimbInput');
@@ -201,6 +237,54 @@ describe('queue climb field parity: the two READ paths', () => {
         readButNeverWritten,
         'This selection set reads fields that no client writes, so they can only ever be null. ' +
           'Either add them to ClimbInput or drop them from the selection set.',
+      ).toEqual([]);
+    });
+  }
+});
+
+/**
+ * The same guard one level up (#3995).
+ *
+ * A queue item carries more than its climb: `addedBy` / `addedByUser` are who
+ * put it on the wall, `tickedBy` is who has sent it this session, `suggested`
+ * marks a playlist suggestion. Mobile shipped a `{ uuid, climb }` write mapper
+ * AND a `{ uuid, climb }` selection set, so climbs queued from a phone reached
+ * peers anonymous and a phone's next full-queue write wiped the crew's avatars
+ * off web-queued climbs. Both platforms now write all four, which makes the READ
+ * side flap-critical — hence this parity check, the read-side counterpart to the
+ * `satisfies Record<keyof ClimbQueueItemInput, true>` guard on the write mapper.
+ */
+describe('queue item field parity: the two READ paths', () => {
+  const queueItemInputFields = inputTypeFieldNames('ClimbQueueItemInput');
+
+  it('found the ClimbQueueItemInput type in the schema', () => {
+    expect(queueItemInputFields.size).toBeGreaterThan(0);
+  });
+
+  for (const [name, fields] of [
+    [
+      'shared QUEUE_ITEM_FIELDS (packages/shared/graphql/src/operations/queue-session.ts)',
+      queueItemSelectionFieldNames(QUEUE_UPDATES),
+    ],
+    [
+      'mobile SUBSCRIPTION_QUEUE_ITEM_FIELDS (packages/mobile/src/lib/graphql/operations.ts)',
+      mobileSubscriptionQueueItemFields(),
+    ],
+  ] as const) {
+    it(`${name} selects exactly what ClimbQueueItemInput declares`, () => {
+      const notRead = [...queueItemInputFields].filter((field) => !fields.has(field));
+      const readButNeverWritten = [...fields].filter((field) => !queueItemInputFields.has(field));
+
+      expect(
+        notRead,
+        'This selection set is missing item-level fields that clients WRITE, so they will FLAP: ' +
+          'this peer rebuilds the item without them and its next full-queue write pushes the gap ' +
+          'back to everyone — the crew\'s "added by" avatars blink out. Add them here.',
+      ).toEqual([]);
+      expect(
+        readButNeverWritten,
+        'This selection set reads item-level fields no client writes, so they can only ever be null. ' +
+          'Either add them to ClimbQueueItemInput or drop them from the selection set.',
       ).toEqual([]);
     });
   }

--- a/packages/backend/src/__tests__/queue-climb-field-contract.test.ts
+++ b/packages/backend/src/__tests__/queue-climb-field-contract.test.ts
@@ -253,12 +253,38 @@ describe('queue climb field parity: the two READ paths', () => {
  * off web-queued climbs. Both platforms now write all four, which makes the READ
  * side flap-critical — hence this parity check, the read-side counterpart to the
  * `satisfies Record<keyof ClimbQueueItemInput, true>` guard on the write mapper.
+ *
+ * `NATIVE_IOS_QUEUE_UPDATES` (same shared operations file) is a third, deliberately
+ * slim contract and is NOT guarded here. It feeds the Swift Live Activity / widget,
+ * which only needs to know which climb is current, so it selects a subset on purpose
+ * to keep the native payload small. It cannot cause the flap above: the widget's
+ * `sendSetCurrentClimb` omits `shouldAddToQueue`, so the backend never appends a queue
+ * row for it and the shared reducer never rewrites an existing entry — only the
+ * current-climb pointer loses attribution, not the rows the avatars render from.
  */
-describe('queue item field parity: the two READ paths', () => {
+describe('queue item field parity: the shared and mobile READ paths', () => {
   const queueItemInputFields = inputTypeFieldNames('ClimbQueueItemInput');
 
   it('found the ClimbQueueItemInput type in the schema', () => {
     expect(queueItemInputFields.size).toBeGreaterThan(0);
+  });
+
+  it('mobile interpolates the shared item selection at every item-selection site', () => {
+    const mobileOperationsSource = readFileSync(
+      new URL('../../../../packages/mobile/src/lib/graphql/operations.ts', import.meta.url),
+      'utf-8',
+    );
+    const itemSelectionSites = mobileOperationsSource.match(/\b(?:queue|currentClimbQueueItem|item)\s*\{/g) ?? [];
+    const sharedSelectionInterpolations = mobileOperationsSource.match(/\$\{SUBSCRIPTION_QUEUE_ITEM_FIELDS\}/g) ?? [];
+
+    expect(itemSelectionSites.length).toBeGreaterThan(0);
+    expect(
+      sharedSelectionInterpolations.length,
+      'A queue-item selection set in mobile operations.ts is written out longhand instead of ' +
+        'interpolating SUBSCRIPTION_QUEUE_ITEM_FIELDS. The parity check below unions field names ' +
+        'across every item selection in a document, so one complete site would mask the incomplete ' +
+        'sibling — and the missing fields would FLAP.',
+    ).toBe(itemSelectionSites.length);
   });
 
   for (const [name, fields] of [

--- a/packages/mobile/src/lib/__tests__/climb-to-queue-item.test.ts
+++ b/packages/mobile/src/lib/__tests__/climb-to-queue-item.test.ts
@@ -5,7 +5,7 @@ vi.mock('expo-crypto', () => ({
   randomUUID: () => 'generated-uuid',
 }));
 
-import { climbToQueueItem, toClimbInput } from '../climb-to-queue-item';
+import { climbToQueueItem, toClimbInput, toQueueItemWireInput } from '../climb-to-queue-item';
 
 // A climb queued from search / detail must keep its multi-frame playback
 // metadata so playback uses the setter's pace rather than DEFAULT_PACE_MS.
@@ -95,5 +95,41 @@ describe('climbToQueueItem ownership / draft state (#3927)', () => {
     const sent = new Set(Object.keys(toClimbInput(climb)));
 
     expect(kept).toEqual(sent);
+  });
+});
+
+// The same contract, one level up (#3995). This client used to send a bare
+// `{ uuid, climb }` for every queue mutation, so a climb queued from a phone
+// reached the crew with no author, and the phone's next full-queue write wiped
+// the "added by" avatars off the climbs they queued from web.
+describe('toQueueItemWireInput (#3995)', () => {
+  it('carries queue-item attribution, not just the climb', () => {
+    const input = toQueueItemWireInput({
+      uuid: 'queue-slot-1',
+      climb: makeClimb(),
+      addedBy: 'client-1',
+      addedByUser: { id: 'party-uuid-1', username: 'Marco', avatarUrl: 'https://example.test/a.png' },
+      tickedBy: ['db-user-1'],
+      suggested: true,
+    });
+
+    expect(input.addedBy).toBe('client-1');
+    expect(input.addedByUser).toEqual({
+      id: 'party-uuid-1',
+      username: 'Marco',
+      avatarUrl: 'https://example.test/a.png',
+    });
+    expect(input.tickedBy).toEqual(['db-user-1']);
+    expect(input.suggested).toBe(true);
+  });
+
+  // The climb half must still go out in full: the item-level fix must not have
+  // narrowed what `toClimbInput` sends. Read live off both functions, same
+  // technique as the climb-level guard above.
+  it('still sends the full toClimbInput climb field set', () => {
+    const climb = makeClimb();
+    const sentOnTheWire = new Set(Object.keys(toQueueItemWireInput({ uuid: 'queue-slot-1', climb }).climb));
+
+    expect(sentOnTheWire).toEqual(new Set(Object.keys(toClimbInput(climb))));
   });
 });

--- a/packages/mobile/src/lib/__tests__/queue-conversion.test.ts
+++ b/packages/mobile/src/lib/__tests__/queue-conversion.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { parse, visit } from 'graphql';
 import { toClimbQueueItem, type SubscriptionQueueItem } from '../queue-conversion';
-import { SUBSCRIPTION_CLIMB_FIELDS } from '../graphql/operations';
+import { SUBSCRIPTION_CLIMB_FIELDS, SUBSCRIPTION_QUEUE_ITEM_FIELDS } from '../graphql/operations';
 
 // Parse the selection set with graphql's own parser rather than splitting on
 // whitespace: an alias (`uuid: id`), an argument, or a directive would make a
@@ -13,6 +13,20 @@ function selectedClimbFieldNames(): Set<string> {
   visit(parse(`{ climb { ${SUBSCRIPTION_CLIMB_FIELDS} } }`), {
     Field(node) {
       if (node.name.value !== 'climb' || !node.selectionSet) return;
+      for (const selection of node.selectionSet.selections) {
+        if (selection.kind === 'Field') fields.add(selection.alias?.value ?? selection.name.value);
+      }
+    },
+  });
+  return fields;
+}
+
+// Same collector, one level up: the top-level fields selected on each queue item.
+function selectedQueueItemFieldNames(): Set<string> {
+  const fields = new Set<string>();
+  visit(parse(`{ item { ${SUBSCRIPTION_QUEUE_ITEM_FIELDS} } }`), {
+    Field(node) {
+      if (node.name.value !== 'item' || !node.selectionSet) return;
       for (const selection of node.selectionSet.selections) {
         if (selection.kind === 'Field') fields.add(selection.alias?.value ?? selection.name.value);
       }
@@ -121,5 +135,51 @@ describe('toClimbQueueItem (SEED-2 fields)', () => {
     const rebuilt = new Set(Object.keys(toClimbQueueItem(makeSubscriptionItem()).climb));
 
     expect(rebuilt).toEqual(selectedClimbFieldNames());
+  });
+});
+
+// The item level of the same contract (#3995). This client now WRITES
+// addedBy / addedByUser / tickedBy / suggested, so dropping them on the way IN
+// would make them flap: we would rebuild every peer item without an author, and
+// our next full-queue write would push that gap back to the whole crew.
+describe('toClimbQueueItem item-level attribution (#3995)', () => {
+  it("keeps a web peer's attribution through the rebuild", () => {
+    const result = toClimbQueueItem({
+      ...makeSubscriptionItem(),
+      addedBy: 'client-web-1',
+      addedByUser: { id: 'web-peer', username: 'Ana', avatarUrl: 'https://example.test/a.png' },
+      tickedBy: ['db-user-1'],
+      suggested: true,
+    });
+
+    expect(result.addedBy).toBe('client-web-1');
+    expect(result.addedByUser).toEqual({ id: 'web-peer', username: 'Ana', avatarUrl: 'https://example.test/a.png' });
+    expect(result.tickedBy).toEqual(['db-user-1']);
+    expect(result.suggested).toBe(true);
+  });
+
+  // The reducer's ClimbQueueItem types the last three as optional-not-nullable,
+  // so a server null must narrow to undefined rather than be carried through.
+  it('narrows server nulls to undefined for the optional-only fields', () => {
+    const result = toClimbQueueItem({
+      ...makeSubscriptionItem(),
+      addedByUser: null,
+      tickedBy: null,
+      suggested: null,
+    });
+
+    expect(result.addedByUser).toBeUndefined();
+    expect(result.tickedBy).toBeUndefined();
+    expect(result.suggested).toBeUndefined();
+  });
+
+  // Set EQUALITY, derived from the live selection set: an item-level field the
+  // subscription selects but this rebuild drops is lost on every FullSync, and a
+  // field rebuilt here that the subscription does not select can only ever be
+  // undefined. Adding a seventh field to one side alone turns this red.
+  it('rebuilds exactly the field set SUBSCRIPTION_QUEUE_ITEM_FIELDS selects', () => {
+    const rebuilt = new Set(Object.keys(toClimbQueueItem(makeSubscriptionItem())));
+
+    expect(rebuilt).toEqual(selectedQueueItemFieldNames());
   });
 });

--- a/packages/mobile/src/lib/climb-to-queue-item.ts
+++ b/packages/mobile/src/lib/climb-to-queue-item.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from 'expo-crypto';
-import type { Climb, ClimbInput } from '@boardsesh/shared-schema';
+import type { Climb, ClimbInput, ClimbQueueItemInput } from '@boardsesh/shared-schema';
 import type { ClimbQueueItem } from '@boardsesh/queue';
+// Subpath import, not the barrel: nine queue-provider suites whole-module-mock
+// `@boardsesh/queue-react`, and this module sits in all of their graphs.
+import { toClimbQueueItemInput } from '@boardsesh/queue-react/queue-item-input';
 
 // `isClimbResolved` lives in ./queue-climb-resolution (no expo-crypto import) so
 // the shared visual can pull the predicate without this module's native deps.
@@ -54,6 +57,22 @@ export function toClimbInput(climb: Climb): ClimbInput {
 }
 
 /**
+ * Map a local queue item to the GraphQL `ClimbQueueItemInput` — the ONE item->wire
+ * seam for every mobile write path (add / setCurrent / setQueue / replace).
+ *
+ * The item level carries more than the climb: `addedBy` / `addedByUser` are who
+ * queued it (the avatar peers render on the queue row), `tickedBy` is who has
+ * sent it this session, and `suggested` marks a playlist suggestion. This client
+ * used to send only `{ uuid, climb }`, so every climb queued from a phone landed
+ * on peers anonymous — and worse, a phone's next full-queue write stripped the
+ * attribution off the climbs the crew had queued from web (#3995). The field list
+ * lives in the shared mapper so the two platforms cannot drift again.
+ */
+export function toQueueItemWireInput(item: ClimbQueueItem): ClimbQueueItemInput {
+  return toClimbQueueItemInput(item, toClimbInput);
+}
+
+/**
  * Build a ClimbQueueItem from a Climb returned by SEARCH_CLIMBS / climb-detail
  * queries. The mutation input is GraphQL's `ClimbInput`, which is a strict
  * subset of `Climb` — passing the whole response (e.g. with `created_at`)
@@ -68,6 +87,10 @@ export function toClimbInput(climb: Climb): ClimbInput {
  * gap back to everyone. `climb-to-queue-item.test.ts` asserts the two key sets
  * are equal, and `queue-climb-field-contract.test.ts` ties both to the schema.
  * See #3927.
+ *
+ * The same contract now applies one level up, at the queue item itself: what
+ * `toQueueItemWireInput` sends, `SUBSCRIPTION_QUEUE_ITEM_FIELDS` must select and
+ * `toClimbQueueItem` must rebuild. See #3995.
  */
 export function climbToQueueItem(climb: Climb, options?: { suggested?: boolean; uuid?: string }): ClimbQueueItem {
   return {

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -1245,6 +1245,25 @@ export const SUBSCRIPTION_CLIMB_FIELDS = `
   boardseshConfidence
 `;
 
+// The item-level fields that cross the wire alongside the climb. This client now
+// WRITES all four (`toQueueItemWireInput` in lib/climb-to-queue-item.ts), so
+// omitting them here would make them FLAP: we would rebuild every peer item
+// without attribution and our next full-queue write would push the gap back to
+// the whole crew — the exact bug #3995 was filed for, one level up from #3927.
+//
+// Exported so `lib/__tests__/queue-conversion.test.ts` can assert the rebuild
+// covers exactly this set, and read straight out of this source by
+// packages/backend/src/__tests__/queue-climb-field-contract.test.ts, which ties
+// it to the GraphQL `ClimbQueueItemInput`.
+export const SUBSCRIPTION_QUEUE_ITEM_FIELDS = `
+  uuid
+  climb { ${SUBSCRIPTION_CLIMB_FIELDS} }
+  addedBy
+  addedByUser { id username avatarUrl }
+  tickedBy
+  suggested
+`;
+
 // QueueItemAdded.item is ClimbQueueItem! and CurrentClimbChanged.item is
 // ClimbQueueItem — GraphQL rejects overlapping field selections with
 // differing nullability across union members ('Fields "item" conflict ...
@@ -1262,15 +1281,15 @@ export const QUEUE_UPDATES_SUBSCRIPTION = `
           sequence
           stateHash
           stateHashOrdered
-          queue { uuid climb { ${SUBSCRIPTION_CLIMB_FIELDS} } }
-          currentClimbQueueItem { uuid climb { ${SUBSCRIPTION_CLIMB_FIELDS} } }
+          queue { ${SUBSCRIPTION_QUEUE_ITEM_FIELDS} }
+          currentClimbQueueItem { ${SUBSCRIPTION_QUEUE_ITEM_FIELDS} }
         }
       }
       ... on QueueItemAdded {
         sequence
         stateHash
         stateHashOrdered
-        addedItem: item { uuid climb { ${SUBSCRIPTION_CLIMB_FIELDS} } }
+        addedItem: item { ${SUBSCRIPTION_QUEUE_ITEM_FIELDS} }
         position
       }
       ... on QueueItemRemoved {
@@ -1291,7 +1310,7 @@ export const QUEUE_UPDATES_SUBSCRIPTION = `
         sequence
         stateHash
         stateHashOrdered
-        currentItem: item { uuid climb { ${SUBSCRIPTION_CLIMB_FIELDS} } }
+        currentItem: item { ${SUBSCRIPTION_QUEUE_ITEM_FIELDS} }
         clientId
         correlationId
       }
@@ -1328,8 +1347,8 @@ export const GET_SESSION_QUEUE_STATE = gql`
         sequence
         stateHash
         stateHashOrdered
-        queue { uuid climb { ${SUBSCRIPTION_CLIMB_FIELDS} } }
-        currentClimbQueueItem { uuid climb { ${SUBSCRIPTION_CLIMB_FIELDS} } }
+        queue { ${SUBSCRIPTION_QUEUE_ITEM_FIELDS} }
+        currentClimbQueueItem { ${SUBSCRIPTION_QUEUE_ITEM_FIELDS} }
       }
     }
   }

--- a/packages/mobile/src/lib/queue-conversion.ts
+++ b/packages/mobile/src/lib/queue-conversion.ts
@@ -55,9 +55,28 @@ export type SubscriptionClimb = {
   boardseshConfidence?: string | null;
 };
 
+export type SubscriptionQueueItemUser = {
+  id: string;
+  username: string;
+  avatarUrl?: string | null;
+};
+
+/**
+ * Keep these fields in sync with `SUBSCRIPTION_QUEUE_ITEM_FIELDS` in
+ * `src/lib/graphql/operations.ts` and with `toQueueItemWireInput` in
+ * `src/lib/climb-to-queue-item.ts`. The item level is in the drift contract too
+ * (#3995): this client WRITES `addedBy` / `addedByUser` / `tickedBy` /
+ * `suggested`, so a field it fails to rebuild here is a field its next
+ * full-queue write strips off every peer's queue — the crew's "added by" avatars
+ * blink out the moment a phone touches the queue.
+ */
 export type SubscriptionQueueItem = {
   uuid: string;
   climb: SubscriptionClimb;
+  addedBy?: string | null;
+  addedByUser?: SubscriptionQueueItemUser | null;
+  tickedBy?: (string | null)[] | null;
+  suggested?: boolean | null;
 };
 
 /**
@@ -69,6 +88,13 @@ export type SubscriptionQueueItem = {
 export function toClimbQueueItem(subscriptionItem: SubscriptionQueueItem): ClimbQueueItem {
   return {
     uuid: subscriptionItem.uuid,
+    // Who queued it, who has ticked it, whether it's a playlist suggestion. The
+    // reducer's ClimbQueueItem types the last three as optional-not-nullable, so
+    // a server null narrows to undefined rather than being carried as null.
+    addedBy: subscriptionItem.addedBy,
+    addedByUser: subscriptionItem.addedByUser ?? undefined,
+    tickedBy: subscriptionItem.tickedBy ?? undefined,
+    suggested: subscriptionItem.suggested ?? undefined,
     climb: {
       uuid: subscriptionItem.climb.uuid,
       boardType: subscriptionItem.climb.boardType ?? undefined,

--- a/packages/mobile/src/providers/__tests__/queue-provider-attribution.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-attribution.test.tsx
@@ -1,0 +1,415 @@
+// @vitest-environment jsdom
+//
+// Queue-item attribution (#3995). Mobile used to send a bare `{ uuid, climb }`
+// for every queue mutation, so a climb queued from a phone reached the crew with
+// no name and no avatar — and the phone's next full-queue write stripped the
+// attribution off the climbs they had queued from web.
+//
+// Two halves are under test here, and they pull in opposite directions:
+//   1. a climb THIS device introduces must carry this climber's identity;
+//   2. an item that came from a PEER must be forwarded untouched — an over-eager
+//      identity fallback would re-author the whole crew's queue on the next
+//      whole-queue write.
+//
+// The WS/HTTP/store harness follows queue-provider-sync-gate.test.tsx (it is the
+// one that captures the `queueUpdates` sink, needed to deliver a peer item the
+// way production does). Unlike the sibling suites, `@boardsesh/queue-react` is
+// mocked with `importOriginal` so the REAL wire mapper stays in place — a
+// wholesale mock would stub out the very code these tests exist to check.
+import { act, render, waitFor } from '@testing-library/react';
+import { createElement, useEffect } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ClimbQueueItem } from '@boardsesh/queue';
+import type { ClimbQueueItemInput, SessionStatus, SessionUser, UserBoard } from '@boardsesh/shared-schema';
+
+const ws = vi.hoisted(() => {
+  type WsEventName = 'connected' | 'closed';
+  type QueueUpdatesSink = { next: (payload: { data?: { queueUpdates?: unknown } }) => void };
+  let queueUpdatesSink: QueueUpdatesSink | null = null;
+  const listeners: Record<WsEventName, Set<() => void>> = { connected: new Set(), closed: new Set() };
+  return {
+    getQueueUpdatesSink: () => queueUpdatesSink,
+    client: {
+      on: vi.fn((eventName: WsEventName, listener: () => void) => {
+        listeners[eventName].add(listener);
+        return () => {
+          listeners[eventName].delete(listener);
+        };
+      }),
+      subscribe: vi.fn((request: { query: string }, sink: { next: (payload: unknown) => void }) => {
+        if (request.query.includes('queueUpdates')) queueUpdatesSink = sink as QueueUpdatesSink;
+        return vi.fn();
+      }),
+    },
+    reset: () => {
+      queueUpdatesSink = null;
+      listeners.connected.clear();
+      listeners.closed.clear();
+    },
+  };
+});
+
+const graph = vi.hoisted(() => ({ execute: vi.fn() }));
+const http = vi.hoisted(() => ({ request: vi.fn() }));
+const toast = vi.hoisted(() => ({ showToast: vi.fn() }));
+const errorReporter = vi.hoisted(() => ({ reportError: vi.fn(), reportHandledError: vi.fn() }));
+
+const activeBoard = vi.hoisted(() => ({
+  stored: {
+    uuid: 'board-1',
+    slug: 'board-1',
+    ownerId: 'owner-1',
+    boardType: 'kilter',
+    layoutId: 1,
+    sizeId: 10,
+    setIds: '1,2',
+    name: 'Test board',
+    isPublic: true,
+    isUnlisted: false,
+    hideLocation: false,
+    isOwned: true,
+    angle: 40,
+    isAngleAdjustable: true,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    totalAscents: 0,
+    uniqueClimbers: 0,
+    followerCount: 0,
+    commentCount: 0,
+    isFollowedByMe: false,
+  } satisfies UserBoard,
+  getStoredActiveBoard: vi.fn(),
+  setActiveBoard: vi.fn(async () => {}),
+}));
+
+const queueMutations = vi.hoisted(() => ({
+  addQueueItem: vi.fn(async (_item: ClimbQueueItem) => {}),
+  removeQueueItem: vi.fn(async () => {}),
+  reorderQueueItem: vi.fn(async () => {}),
+  setCurrentClimb: vi.fn(async (_item: ClimbQueueItem, _shouldAddToQueue: boolean, _correlationId?: string) => {}),
+  mirrorCurrentClimb: vi.fn(async () => {}),
+  publishPlaybackState: vi.fn(async () => {}),
+  setQueue: vi.fn(async (_queue: ClimbQueueItem[], _currentClimbQueueItem?: ClimbQueueItem) => {}),
+  replaceQueueItem: vi.fn(async () => {}),
+  confirmClimbOnWall: vi.fn(async () => {}),
+  reportWallDisconnect: vi.fn(async () => {}),
+  setSessionBoardSerial: vi.fn(async () => {}),
+  setSessionBoardPath: vi.fn(async () => {}),
+}));
+
+// The deps mobile hands the shared hook, so the REAL item->wire mapper can be
+// called directly at the end of the chain.
+type CapturedMutationDeps = { toQueueItemInput: (item: ClimbQueueItem) => ClimbQueueItemInput };
+const capturedMutationDeps = vi.hoisted(() => ({ current: null as CapturedMutationDeps | null }));
+
+const sessionStore = vi.hoisted(() => ({
+  getStoredSessionId: vi.fn(async () => 'session-1' as string | null),
+  setStoredSessionId: vi.fn(async () => {}),
+  clearStoredSessionId: vi.fn(async () => {}),
+  getStoredCreatedSessionId: vi.fn(async () => null as string | null),
+  setStoredCreatedSessionId: vi.fn(async () => {}),
+  clearStoredCreatedSessionId: vi.fn(async () => {}),
+}));
+
+const queueSnapshotStore = vi.hoisted(() => ({
+  getStoredQueueSnapshot: vi.fn(async () => null),
+  setStoredQueueSnapshot: vi.fn(async () => {}),
+  clearStoredQueueSnapshot: vi.fn(async () => {}),
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios', select: (options: Record<string, unknown>) => options.ios ?? options.default },
+  AppState: { addEventListener: vi.fn(() => ({ remove: vi.fn() })) },
+}));
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'test-correlation-id' }));
+vi.mock('@boardsesh/graphql-client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/graphql-client')>()),
+  execute: graph.execute,
+}));
+// importOriginal, NOT a wholesale replacement: the real mapper must survive.
+vi.mock('@boardsesh/queue-react', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/queue-react')>()),
+  useQueueMutations: (deps: CapturedMutationDeps) => {
+    capturedMutationDeps.current = deps;
+    return queueMutations;
+  },
+}));
+vi.mock('@boardsesh/play-view', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/play-view')>()),
+  emitWallConfirm: vi.fn(),
+}));
+vi.mock('../../lib/graphql/ws-client', () => ({ getWsClient: () => ws.client }));
+vi.mock('../../lib/session-store', () => sessionStore);
+vi.mock('../../lib/queue-snapshot-store', () => queueSnapshotStore);
+vi.mock('../../lib/active-board-store', () => ({ getStoredActiveBoard: activeBoard.getStoredActiveBoard }));
+vi.mock('../../lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: activeBoard.stored }),
+  useSetActiveBoard: () => activeBoard.setActiveBoard,
+}));
+vi.mock('../../lib/graphql/client', () => ({ getHttpClient: () => ({ request: http.request }) }));
+vi.mock('../../lib/analytics', () => ({ track: vi.fn() }));
+vi.mock('../toast-provider', () => ({ useToast: () => ({ showToast: toast.showToast }) }));
+vi.mock('../queue-snackbar-provider', () => ({ useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }) }));
+// A signed-in climber with a resolved party profile — the only state in which
+// this device stamps identity at all.
+vi.mock('../party-profile-provider', () => ({
+  usePartyProfile: () => ({
+    profile: { id: 'party-uuid-1' },
+    username: 'Marco',
+    avatarUrl: 'https://example.test/marco.png',
+  }),
+}));
+vi.mock('../../lib/error-reporting', () => ({
+  reportError: errorReporter.reportError,
+  reportHandledError: errorReporter.reportHandledError,
+}));
+
+import { QueueProvider, useQueue } from '../queue-provider';
+
+const SELF_ATTRIBUTION = {
+  id: 'party-uuid-1',
+  username: 'Marco',
+  avatarUrl: 'https://example.test/marco.png',
+};
+const PEER_ATTRIBUTION = { id: 'web-peer', username: 'Ana', avatarUrl: 'https://example.test/ana.png' };
+
+type Snapshot = {
+  state: ReturnType<typeof useQueue>['state'];
+  sessionId: string | null;
+  addToQueue: ReturnType<typeof useQueue>['addToQueue'];
+  setQueue: ReturnType<typeof useQueue>['setQueue'];
+  setCurrentClimb: ReturnType<typeof useQueue>['setCurrentClimb'];
+};
+
+function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
+  const queue = useQueue();
+  useEffect(() => {
+    onSnapshot({
+      state: queue.state,
+      sessionId: queue.sessionId,
+      addToQueue: queue.addToQueue,
+      setQueue: queue.setQueue,
+      setCurrentClimb: queue.setCurrentClimb,
+    });
+  }, [queue.state, queue.sessionId, queue.addToQueue, queue.setQueue, queue.setCurrentClimb, onSnapshot]);
+  return null;
+}
+
+function renderProvider(onSnapshot: (snapshot: Snapshot) => void) {
+  return render(createElement(QueueProvider, null, createElement(Probe, { onSnapshot })));
+}
+
+const user = (overrides: Partial<SessionUser> = {}): SessionUser => ({
+  id: 'participant-1',
+  username: 'Alex',
+  isLeader: false,
+  avatarUrl: undefined,
+  userId: 'db-user-1',
+  connectionState: 'CONNECTED',
+  ...overrides,
+});
+
+function createJoinSessionResponse() {
+  return {
+    joinSession: {
+      participantId: 'participant-self',
+      clientId: 'client-self',
+      isLeader: false,
+      lastConnectedBoardSerial: null,
+      boardPath: '/kilter/1/10/1,2/40/list',
+      users: [user({ id: 'participant-self', username: 'Marco', userId: 'db-self' })],
+    },
+  };
+}
+
+const statusResponse = (status: SessionStatus | null = 'active') => ({ sessionStatus: status });
+
+function makeQueueItem(uuid: string, climbUuid = uuid): ClimbQueueItem {
+  return {
+    uuid,
+    climb: {
+      uuid: climbUuid,
+      name: `Climb ${climbUuid}`,
+      frames: 'p1r12',
+      setter_username: 'setter',
+      angle: 40,
+      ascensionist_count: 0,
+      difficulty: 'V3',
+      quality_average: '3.0',
+      stars: 3,
+      difficulty_error: '0.3',
+      benchmark_difficulty: null,
+    },
+  };
+}
+
+// Wire-shaped item as SUBSCRIPTION_QUEUE_ITEM_FIELDS now selects it: climb plus
+// the four item-level fields.
+type WirePeerItem = {
+  uuid: string;
+  climb: ClimbQueueItem['climb'];
+  addedBy: string | null;
+  addedByUser: { id: string; username: string; avatarUrl: string } | null;
+  tickedBy: string[] | null;
+  suggested: boolean | null;
+};
+
+function wirePeerItem(uuid: string): WirePeerItem {
+  const { climb } = makeQueueItem(uuid);
+  return {
+    uuid,
+    climb,
+    addedBy: 'client-web-1',
+    addedByUser: PEER_ATTRIBUTION,
+    tickedBy: null,
+    suggested: null,
+  };
+}
+
+function wireFullSync(sequence: number, stateHash: string, queue: WirePeerItem[]) {
+  return {
+    __typename: 'FullSync',
+    sequence,
+    state: { sequence, stateHash, queue, currentClimbQueueItem: null },
+  };
+}
+
+/** Render, join, and push a FullSync carrying the given peer items. */
+async function renderWithPeerQueue(snapshots: Snapshot[], peerItems: WirePeerItem[]) {
+  renderProvider((snapshot) => snapshots.push(snapshot));
+  await waitFor(() => {
+    expect(ws.getQueueUpdatesSink()).not.toBeNull();
+    expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+  });
+  const queueUpdatesSink = ws.getQueueUpdatesSink();
+  if (!queueUpdatesSink) throw new Error('queue updates sink was not captured');
+  act(() => {
+    queueUpdatesSink.next({ data: { queueUpdates: wireFullSync(1, 'hash-1', peerItems) } });
+  });
+  await waitFor(() => {
+    expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(peerItems.map((item) => item.uuid));
+  });
+}
+
+describe('QueueProvider queue-item attribution (#3995)', () => {
+  beforeEach(() => {
+    ws.reset();
+    ws.client.on.mockClear();
+    ws.client.subscribe.mockClear();
+    capturedMutationDeps.current = null;
+    activeBoard.getStoredActiveBoard.mockReset();
+    activeBoard.getStoredActiveBoard.mockResolvedValue(activeBoard.stored);
+    toast.showToast.mockClear();
+    errorReporter.reportError.mockClear();
+    errorReporter.reportHandledError.mockClear();
+    for (const mutation of Object.values(queueMutations) as Array<ReturnType<typeof vi.fn>>) {
+      mutation.mockReset();
+      mutation.mockResolvedValue(undefined);
+    }
+    sessionStore.getStoredSessionId.mockReset();
+    sessionStore.getStoredSessionId.mockResolvedValue('session-1');
+    graph.execute.mockReset();
+    graph.execute.mockResolvedValue(createJoinSessionResponse());
+    http.request.mockReset();
+    http.request.mockImplementation(async (operation: string) => {
+      if (operation.includes('SessionStatus')) return statusResponse();
+      return { endSession: { sessionId: 'session-1' } };
+    });
+  });
+
+  it('stamps the local climber onto a climb queued from this phone', async () => {
+    const snapshots: Snapshot[] = [];
+    await renderWithPeerQueue(snapshots, []);
+
+    act(() => {
+      snapshots.at(-1)?.addToQueue(makeQueueItem('mine-1'));
+    });
+
+    await waitFor(() => expect(queueMutations.addQueueItem).toHaveBeenCalledTimes(1));
+    const broadcastItem = queueMutations.addQueueItem.mock.calls[0]?.[0];
+    expect(broadcastItem?.addedByUser).toEqual(SELF_ATTRIBUTION);
+    expect(broadcastItem?.addedBy).toBe('client-self');
+    // Local state and broadcast must agree — a phone that shows no author on its
+    // own row while peers see one is the same bug from the other side.
+    expect(snapshots.at(-1)?.state.queue.find((item) => item.uuid === 'mine-1')?.addedByUser).toEqual(SELF_ATTRIBUTION);
+  });
+
+  it('does not claim a climb a peer added, on a whole-queue write', async () => {
+    const snapshots: Snapshot[] = [];
+    // The peer item arrives the way production delivers it: over the queueUpdates
+    // subscription, rebuilt by toClimbQueueItem.
+    await renderWithPeerQueue(snapshots, [wirePeerItem('peer-1')]);
+    expect(snapshots.at(-1)?.state.queue[0]?.addedByUser).toEqual(PEER_ATTRIBUTION);
+
+    // Now this phone rewrites the whole queue (playlist activation, generated
+    // session, reorder) — the vector that used to anonymise the crew's climbs.
+    const peerItem = snapshots.at(-1)?.state.queue[0];
+    if (!peerItem) throw new Error('peer item was not applied to local state');
+    act(() => {
+      snapshots.at(-1)?.setQueue([peerItem, makeQueueItem('mine-1')]);
+    });
+
+    await waitFor(() => expect(queueMutations.setQueue).toHaveBeenCalledTimes(1));
+    const [broadcastQueue] = queueMutations.setQueue.mock.calls[0] ?? [];
+    expect(broadcastQueue?.[0]?.addedByUser).toEqual(PEER_ATTRIBUTION);
+    expect(broadcastQueue?.[0]?.addedBy).toBe('client-web-1');
+    // The climb this phone contributed in the same write does get stamped.
+    expect(broadcastQueue?.[1]?.addedByUser).toEqual(SELF_ATTRIBUTION);
+  });
+
+  it('forwards an already-attributed item handed straight to setQueue', async () => {
+    const snapshots: Snapshot[] = [];
+    await renderWithPeerQueue(snapshots, []);
+
+    const peerItem: ClimbQueueItem = {
+      ...makeQueueItem('peer-2'),
+      addedBy: 'client-web-1',
+      addedByUser: PEER_ATTRIBUTION,
+    };
+    act(() => {
+      snapshots.at(-1)?.setQueue([peerItem]);
+    });
+
+    await waitFor(() => expect(queueMutations.setQueue).toHaveBeenCalledTimes(1));
+    const [broadcastQueue] = queueMutations.setQueue.mock.calls[0] ?? [];
+    expect(broadcastQueue?.[0]?.addedByUser).toEqual(PEER_ATTRIBUTION);
+  });
+
+  it("does not re-author an unattributed item already in this device's queue", async () => {
+    const snapshots: Snapshot[] = [];
+    // A peer running an older client sends an item with no attribution at all.
+    const unattributed = { ...wirePeerItem('peer-3'), addedBy: null, addedByUser: null };
+    await renderWithPeerQueue(snapshots, [unattributed]);
+
+    const queuedItem = snapshots.at(-1)?.state.queue[0];
+    if (!queuedItem) throw new Error('peer item was not applied to local state');
+    act(() => {
+      snapshots.at(-1)?.setCurrentClimb(queuedItem);
+    });
+
+    await waitFor(() => expect(queueMutations.setCurrentClimb).toHaveBeenCalledTimes(1));
+    const broadcastItem = queueMutations.setCurrentClimb.mock.calls[0]?.[0];
+    expect(broadcastItem?.addedByUser).toBeUndefined();
+    expect(broadcastItem?.addedBy).toBeFalsy();
+  });
+
+  it('serialises the stamped fields through the wire mapper mobile injects', async () => {
+    const snapshots: Snapshot[] = [];
+    await renderWithPeerQueue(snapshots, []);
+
+    act(() => {
+      snapshots.at(-1)?.addToQueue({ ...makeQueueItem('mine-2'), suggested: true });
+    });
+    await waitFor(() => expect(queueMutations.addQueueItem).toHaveBeenCalledTimes(1));
+
+    const stampedItem = queueMutations.addQueueItem.mock.calls[0]?.[0];
+    const toQueueItemInput = capturedMutationDeps.current?.toQueueItemInput;
+    if (!stampedItem || !toQueueItemInput) throw new Error('mutation deps were not captured');
+
+    const wireInput = toQueueItemInput(stampedItem);
+    expect(wireInput.addedByUser).toEqual(SELF_ATTRIBUTION);
+    expect(wireInput.addedBy).toBe('client-self');
+    expect(wireInput.suggested).toBe(true);
+    expect(wireInput.climb.name).toBe('Climb mine-2');
+  });
+});

--- a/packages/mobile/src/providers/__tests__/queue-provider.test.ts
+++ b/packages/mobile/src/providers/__tests__/queue-provider.test.ts
@@ -83,14 +83,10 @@ describe('toClimbQueueItem', () => {
     expect(result.climb.benchmark_difficulty).toBeNull();
   });
 
-  it('produces a valid ClimbQueueItem shape without extra properties', () => {
-    const subscriptionItem = makeSubscriptionItem('qi-3', 'climb-123', 'Slab King');
-
-    const result = toClimbQueueItem(subscriptionItem);
-
-    // Should have exactly uuid and climb at the top level
-    expect(Object.keys(result)).toEqual(['uuid', 'climb']);
-  });
+  // The top-level field set of a rebuilt item is asserted in
+  // packages/mobile/src/lib/__tests__/queue-conversion.test.ts, which derives the
+  // expectation by parsing SUBSCRIPTION_QUEUE_ITEM_FIELDS. A hardcoded key list
+  // here would just be a second transcription that drifts on the next field.
 });
 
 // ── INITIAL_QUEUE_DATA ──────────────────────────────────────────────────

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -255,6 +255,12 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   //
   // Requires BOTH a profile id and a non-empty username: an anonymous phone must
   // not push a blank-named avatar onto every peer's queue row.
+  //
+  // Assigned during render, so there is a window between a session join landing
+  // a new `clientId` and the next render where a stamp would carry
+  // `addedBy: null` with `addedByUser` populated. Peers render the avatar off
+  // `addedByUser`, so the row still shows the right person; only the legacy
+  // clientId field is absent. Same trade the other during-render refs here make.
   const selfAttributionRef = useRef<QueueItemAttribution | null>(null);
   selfAttributionRef.current =
     partyProfile?.id && partyUsername
@@ -468,7 +474,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     // tickedBy / suggested) that used to be dropped here, which anonymised every
     // climb queued from a phone and stripped the crew's avatars on the next
     // full-queue write (#3995). See toQueueItemWireInput.
-    toQueueItemInput: (item) => toQueueItemWireInput(item),
+    toQueueItemInput: toQueueItemWireInput,
     // Where a deferred queue-add (a superseded or drained-then-throttled
     // activation) should land, so peers see the order this device shows. Read
     // live off `stateRef` — assigned during render — because the send can fire

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -16,6 +16,7 @@ import type {
 } from '@boardsesh/queue';
 import { createJoinSessionTracker, type QueueSyncGate } from '@boardsesh/queue-runtime';
 import { useQueueMutations, type PublishPlaybackStateInput } from '@boardsesh/queue-react';
+import type { QueueItemAttribution } from '@boardsesh/queue-react/queue-item-input';
 import type { SubscriptionQueueEvent, SessionUser } from '@boardsesh/shared-schema';
 import { execute, isRateLimitedError } from '@boardsesh/graphql-client';
 import { buildBoardPath } from '@boardsesh/board-config';
@@ -32,7 +33,7 @@ import { getStoredActiveBoard } from '../lib/active-board-store';
 import { useActiveBoard, useSetActiveBoard } from '../lib/graphql/use-active-board';
 import { findPreviousQueueItem, findNextQueueItemWithSuggestions } from '@boardsesh/play-view';
 import { toClimbQueueItem } from '../lib/queue-conversion';
-import { climbToQueueItem, toClimbInput, isClimbResolved } from '../lib/climb-to-queue-item';
+import { climbToQueueItem, toQueueItemWireInput, isClimbResolved } from '../lib/climb-to-queue-item';
 import { track } from '../lib/analytics';
 import { reportHandledError } from '../lib/error-reporting';
 import { useAuthTransportRevision } from '../lib/auth-transport-revision';
@@ -236,7 +237,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // ref because the joinTracker is memoized once (empty deps) and its execute
   // closure must read the latest value — mirrors web's usernameRef/avatarUrlRef
   // in persistent-session/hooks/session-connection-ports.ts.
-  const { username: partyUsername, avatarUrl: partyAvatarUrl } = usePartyProfile();
+  const { profile: partyProfile, username: partyUsername, avatarUrl: partyAvatarUrl } = usePartyProfile();
   const identityRef = useRef<{ username: string | undefined; avatarUrl: string | undefined }>({
     username: partyUsername,
     avatarUrl: partyAvatarUrl,
@@ -246,6 +247,40 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // re-announce effect (below) only fires when it changes afterwards — e.g. the
   // profile resolved after a cold-launch eager join, or the user edited it.
   const announcedIdentityRef = useRef<{ username: string | undefined; avatarUrl: string | undefined } | null>(null);
+
+  // The attribution this device stamps onto a queue item IT introduces, or null
+  // while signed out / before the party profile resolves. Assigned during render
+  // (same pattern as identityRef) so the queue callbacks — memoized on
+  // `mutations`, not on identity — always read the latest.
+  //
+  // Requires BOTH a profile id and a non-empty username: an anonymous phone must
+  // not push a blank-named avatar onto every peer's queue row.
+  const selfAttributionRef = useRef<QueueItemAttribution | null>(null);
+  selfAttributionRef.current =
+    partyProfile?.id && partyUsername
+      ? {
+          addedBy: sessionRuntimeStateRef.current.clientId || null,
+          addedByUser: { id: partyProfile.id, username: partyUsername, avatarUrl: partyAvatarUrl ?? null },
+        }
+      : null;
+
+  /**
+   * Stamp this device's identity onto an item it is INTRODUCING to the queue.
+   *
+   * Deliberately not done in `toQueueItemInput`: a wire-level fallback would
+   * claim authorship of any unattributed item on the next full-queue write —
+   * including a peer's item that arrived before their profile resolved. So skip
+   * an item that already carries attribution, and skip anything already sitting
+   * in this device's queue (that item is not ours to claim; whatever it carries
+   * came from the crew).
+   */
+  const attributeNewItem = useCallback((item: ClimbQueueItem): ClimbQueueItem => {
+    const self = selfAttributionRef.current;
+    if (!self) return item;
+    if (item.addedBy || item.addedByUser) return item;
+    if (stateRef.current.queue.some((queueItem) => queueItem.uuid === item.uuid)) return item;
+    return { ...item, ...self };
+  }, []);
 
   // The active board is read synchronously from the React Query cache
   // (staleTime: Infinity, hydrated from AsyncStorage) so analytics call sites
@@ -422,8 +457,11 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     getSessionId: () => sessionIdRef.current,
     // Strip the climb to ClimbInput fields — sending the raw search climb (with
     // created_at) makes the server reject the mutation and silently breaks queue
-    // sync to peers. See toClimbInput.
-    toQueueItemInput: (item) => ({ uuid: item.uuid, climb: toClimbInput(item.climb) }),
+    // sync to peers — and carry the item-level fields (addedBy / addedByUser /
+    // tickedBy / suggested) that used to be dropped here, which anonymised every
+    // climb queued from a phone and stripped the crew's avatars on the next
+    // full-queue write (#3995). See toQueueItemWireInput.
+    toQueueItemInput: (item) => toQueueItemWireInput(item),
     // Where a deferred queue-add (a superseded or drained-then-throttled
     // activation) should land, so peers see the order this device shows. Read
     // live off `stateRef` — assigned during render — because the send can fire
@@ -746,7 +784,10 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   }, [state.needsResync]);
 
   const addToQueue = useCallback(
-    (item: ClimbQueueItem) => {
+    (rawItem: ClimbQueueItem) => {
+      // Whoever tapped "add" owns this climb — stamp identity before the dispatch
+      // so the local queue and the broadcast carry the same object (#3995).
+      const item = attributeNewItem(rawItem);
       // Optimistic local dispatch is the source of truth for the user's queue.
       // The server echoes this item via the WS subscription, but
       // DELTA_ADD_QUEUE_ITEM dedupes by uuid so the echo is a no-op. The shared
@@ -776,7 +817,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       // Surface the "Climb added to queue · Open" snackbar for every add path.
       showQueueAddedSnackbar();
     },
-    [mutations, reconcileFailedContentMutation, showQueueAddedSnackbar],
+    [attributeNewItem, mutations, reconcileFailedContentMutation, showQueueAddedSnackbar],
   );
 
   const removeFromQueue = useCallback(
@@ -865,21 +906,34 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       // A whole-queue replace sets its own current; it supersedes any deferred
       // current re-broadcast (#3868).
       pendingUnsyncedCurrentRef.current = null;
-      dispatch({ type: 'UPDATE_QUEUE', payload: { queue, currentClimbQueueItem: currentClimbQueueItem ?? null } });
+      // Stamp BEFORE the dispatch, and feed the same array to both the local
+      // reducer and the broadcast — otherwise this device's own queue would show
+      // no author while peers saw one (#3995). The membership check reads
+      // `stateRef.current.queue`, which is still the pre-dispatch queue here, so
+      // a climb the crew already had keeps whoever queued it.
+      const attributedQueue = queue.map((item) => attributeNewItem(item));
+      const attributedCurrent = currentClimbQueueItem
+        ? (attributedQueue.find((item) => item.uuid === currentClimbQueueItem.uuid) ??
+          attributeNewItem(currentClimbQueueItem))
+        : currentClimbQueueItem;
+      dispatch({
+        type: 'UPDATE_QUEUE',
+        payload: { queue: attributedQueue, currentClimbQueueItem: attributedCurrent ?? null },
+      });
       // Keep the full queue locally, but never broadcast a placeholder/thin item
       // to peers (#2527): drop unresolved items from the wire payload (they can't
       // form a valid ClimbInput and peers can't render them). useQueueResolveClimbs
       // hydrates any resolvable item in place; a later mutation re-syncs the real
       // one. An unresolved current climb is likewise not sent as current.
-      const syncableQueue = queue.filter((item) => isClimbResolved(item.climb));
+      const syncableQueue = attributedQueue.filter((item) => isClimbResolved(item.climb));
       const syncableCurrent =
-        currentClimbQueueItem && isClimbResolved(currentClimbQueueItem.climb) ? currentClimbQueueItem : undefined;
+        attributedCurrent && isClimbResolved(attributedCurrent.climb) ? attributedCurrent : undefined;
       mutations.setQueue(syncableQueue, syncableCurrent).catch((error) => {
         if (__DEV__) console.warn('[queue] setQueue sync failed', error);
         reconcileFailedContentMutation(error);
       });
     },
-    [mutations, reconcileFailedContentMutation],
+    [attributeNewItem, mutations, reconcileFailedContentMutation],
   );
 
   // Stable live read of the queue + current climb (see QueueContextValue). Reads
@@ -964,11 +1018,17 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // instead of re-applied.
   const dispatchSetCurrent = useCallback(
     (
-      item: ClimbQueueItem,
+      rawItem: ClimbQueueItem,
       shouldAddToQueue: boolean,
       playlistSuggestionSource?: PlaylistSuggestionSource | null,
       insertAfterCurrent?: boolean,
     ) => {
+      // Activating a climb that isn't in the queue yet (shouldAddToQueue, or the
+      // playlist peek minted in nextClimb) introduces it — stamp it before the
+      // dispatch so state and broadcast agree. Navigating onto an item already in
+      // the queue is a no-op here: attributeNewItem sees the uuid and leaves it
+      // alone, so stepping through the crew's queue never re-authors it (#3995).
+      const item = attributeNewItem(rawItem);
       const correlationId = coordinator.generateCorrelationId();
       dispatch({
         type: 'DELTA_UPDATE_CURRENT_CLIMB',
@@ -1032,7 +1092,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
         showQueueMutationErrorToast(error, t, showToast);
       });
     },
-    [coordinator, mutations, recoverThrottledQueueAdd, resyncQueueAfterMutationFailure, showToast, t],
+    [attributeNewItem, coordinator, mutations, recoverThrottledQueueAdd, resyncQueueAfterMutationFailure, showToast, t],
   );
 
   // Re-broadcast the current climb once a deferred thin item hydrates (#3868).

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -273,12 +273,19 @@ export function QueueProvider({ children }: { children: ReactNode }) {
    * an item that already carries attribution, and skip anything already sitting
    * in this device's queue (that item is not ours to claim; whatever it carries
    * came from the crew).
+   *
+   * `existingUuids` lets a whole-queue write hoist that membership lookup once
+   * rather than rescanning the current queue per item — playlist activation can
+   * hand us the entire board list. Omit it and the scan is used.
    */
-  const attributeNewItem = useCallback((item: ClimbQueueItem): ClimbQueueItem => {
+  const attributeNewItem = useCallback((item: ClimbQueueItem, existingUuids?: Set<string>): ClimbQueueItem => {
     const self = selfAttributionRef.current;
     if (!self) return item;
     if (item.addedBy || item.addedByUser) return item;
-    if (stateRef.current.queue.some((queueItem) => queueItem.uuid === item.uuid)) return item;
+    const alreadyQueued = existingUuids
+      ? existingUuids.has(item.uuid)
+      : stateRef.current.queue.some((queueItem) => queueItem.uuid === item.uuid);
+    if (alreadyQueued) return item;
     return { ...item, ...self };
   }, []);
 
@@ -911,10 +918,11 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       // no author while peers saw one (#3995). The membership check reads
       // `stateRef.current.queue`, which is still the pre-dispatch queue here, so
       // a climb the crew already had keeps whoever queued it.
-      const attributedQueue = queue.map((item) => attributeNewItem(item));
+      const existingUuids = new Set(stateRef.current.queue.map((queueItem) => queueItem.uuid));
+      const attributedQueue = queue.map((item) => attributeNewItem(item, existingUuids));
       const attributedCurrent = currentClimbQueueItem
         ? (attributedQueue.find((item) => item.uuid === currentClimbQueueItem.uuid) ??
-          attributeNewItem(currentClimbQueueItem))
+          attributeNewItem(currentClimbQueueItem, existingUuids))
         : currentClimbQueueItem;
       dispatch({
         type: 'UPDATE_QUEUE',

--- a/packages/shared/queue-react/package.json
+++ b/packages/shared/queue-react/package.json
@@ -14,6 +14,11 @@
       "types": "./src/create-queue-mutations.ts",
       "import": "./src/create-queue-mutations.ts",
       "default": "./src/create-queue-mutations.ts"
+    },
+    "./queue-item-input": {
+      "types": "./src/queue-item-input.ts",
+      "import": "./src/queue-item-input.ts",
+      "default": "./src/queue-item-input.ts"
     }
   },
   "scripts": {

--- a/packages/shared/queue-react/src/__tests__/queue-item-input.test.ts
+++ b/packages/shared/queue-react/src/__tests__/queue-item-input.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import type { ClimbInput } from '@boardsesh/shared-schema';
+import { toClimbQueueItemInput, WIRE_ITEM_FIELDS, type WireBoundQueueItem } from '../queue-item-input';
+
+// The item level of the queue wire contract (#3995). Mobile used to send only
+// `{ uuid, climb }` here, so every climb queued from a phone reached peers with
+// no author — and a phone's next full-queue write stripped the attribution off
+// the climbs the crew queued from web. These assertions run the REAL mapper; the
+// climb half is stubbed to an identity so nothing here re-implements what it
+// checks.
+
+type StubClimb = { uuid: string };
+const identityClimbInput = (climb: StubClimb): ClimbInput => climb as unknown as ClimbInput;
+
+function makeItem(overrides: Partial<WireBoundQueueItem<StubClimb>> = {}): WireBoundQueueItem<StubClimb> {
+  return {
+    uuid: 'queue-slot-1',
+    climb: { uuid: 'climb-1' },
+    addedBy: 'client-1',
+    addedByUser: { id: 'u1', username: 'Marco', avatarUrl: 'https://example.test/a.png' },
+    tickedBy: ['u1'],
+    suggested: true,
+    ...overrides,
+  };
+}
+
+describe('toClimbQueueItemInput', () => {
+  it('carries the item-level fields onto the wire', () => {
+    const input = toClimbQueueItemInput(makeItem(), identityClimbInput);
+
+    expect(input.addedBy).toBe('client-1');
+    expect(input.addedByUser).toEqual({ id: 'u1', username: 'Marco', avatarUrl: 'https://example.test/a.png' });
+    expect(input.tickedBy).toEqual(['u1']);
+    expect(input.suggested).toBe(true);
+  });
+
+  it('maps the climb through the platform mapper it was given', () => {
+    const input = toClimbQueueItemInput(makeItem(), identityClimbInput);
+
+    expect(input.uuid).toBe('queue-slot-1');
+    expect(input.climb).toEqual({ uuid: 'climb-1' });
+  });
+
+  // The wire type is `[String!]` — a null entry would be rejected outright.
+  it('drops null entries from tickedBy', () => {
+    const input = toClimbQueueItemInput(makeItem({ tickedBy: ['u1', null] }), identityClimbInput);
+
+    expect(input.tickedBy).toEqual(['u1']);
+  });
+
+  // Pins the web-parity decision: web has always sent `undefined` here, and a
+  // `?? null` coercion would write a null over whatever the server holds.
+  it('leaves an absent addedBy absent rather than coercing it to null', () => {
+    const input = toClimbQueueItemInput(makeItem({ addedBy: undefined }), identityClimbInput);
+
+    expect(input.addedBy).toBeUndefined();
+    expect(input.addedBy).not.toBeNull();
+  });
+
+  it('omits addedByUser entirely when the item has no author', () => {
+    const input = toClimbQueueItemInput(makeItem({ addedByUser: undefined }), identityClimbInput);
+
+    expect(input.addedByUser).toBeUndefined();
+  });
+
+  // Drift guard, read live off the mapper's own output and the `satisfies
+  // Record<keyof ClimbQueueItemInput, true>` guard. A dropped field fails here;
+  // a field ADDED to the GraphQL input without teaching the mapper fails
+  // typecheck on WIRE_ITEM_FIELDS. Neither side can be hand-edited into
+  // agreement with a stale list.
+  it('emits exactly the ClimbQueueItemInput field set', () => {
+    const emitted = new Set(Object.keys(toClimbQueueItemInput(makeItem(), identityClimbInput)));
+
+    expect(emitted).toEqual(new Set(Object.keys(WIRE_ITEM_FIELDS)));
+  });
+});

--- a/packages/shared/queue-react/src/create-queue-mutations.ts
+++ b/packages/shared/queue-react/src/create-queue-mutations.ts
@@ -62,7 +62,16 @@ export type QueueMutationsDeps<TItem> = {
   getClient: () => Client | null;
   /** Live active-session-id getter (web: session?.id; mobile: sessionIdRef.current). */
   getSessionId: () => string | null;
-  /** Platform mapper: item -> wire input (web: toClimbQueueItemInput; mobile: thin {uuid,climb}). */
+  /**
+   * Platform mapper: item -> wire input. BOTH platforms delegate to
+   * `toClimbQueueItemInput` from `@boardsesh/queue-react/queue-item-input`,
+   * supplying only their own climb mapper — this is the single item->wire seam
+   * for every write path here (addQueueItem / setCurrentClimb / setQueue /
+   * replaceQueueItem; `mirrorCurrentClimb` carries no item at all). Dropping an
+   * item-level field here does not just blank it: it FLAPS for the whole crew,
+   * because this client rebuilds peer items without it and its next full-queue
+   * write pushes the gap back to everyone. See #3927 / #3995.
+   */
   toQueueItemInput: (item: TItem) => ClimbQueueItemInput;
   /**
    * Live index of `uuid` in THIS client's local queue, or -1 when it is not

--- a/packages/shared/queue-react/src/index.ts
+++ b/packages/shared/queue-react/src/index.ts
@@ -9,3 +9,9 @@
 export { useQueueMutations } from './use-queue-mutations';
 export { createQueueMutations } from './create-queue-mutations';
 export type { QueueMutationsActions, QueueMutationsDeps, PublishPlaybackStateInput } from './create-queue-mutations';
+// Re-exported for discoverability only. Consumers import the dedicated
+// `@boardsesh/queue-react/queue-item-input` subpath instead: nine mobile provider
+// suites whole-module-mock this barrel, and a barrel import of the mapper would
+// resolve to `undefined` inside every one of them.
+export { toClimbQueueItemInput, WIRE_ITEM_FIELDS } from './queue-item-input';
+export type { QueueItemAttribution, WireBoundQueueItem } from './queue-item-input';

--- a/packages/shared/queue-react/src/queue-item-input.ts
+++ b/packages/shared/queue-react/src/queue-item-input.ts
@@ -1,0 +1,93 @@
+// The item-level wire contract, shared by web and mobile.
+//
+// A queue item is more than its climb: `addedBy` / `addedByUser` are who put it
+// on the wall, `tickedBy` is who has sent it this session, and `suggested` marks
+// a playlist suggestion. Dropping any of them on the way out does NOT merely
+// leave the field blank for peers — it FLAPS. The client that omits it rebuilds
+// every peer item without it, and its next full-queue write pushes the gap back
+// to the whole crew, so the originator loses it too on the following FullSync.
+// That is exactly the failure #3927 fixed at the climb level and #3995 fixed at
+// the item level (mobile shipped a `{ uuid, climb }` mapper and anonymised every
+// climb queued from a phone).
+//
+// Pure TS, no React — it lives in @boardsesh/queue-react because that package
+// already owns the mutation wire contract and already depends on shared-schema
+// (@boardsesh/queue deliberately has zero dependencies and cannot name
+// `ClimbQueueItemInput`). Imported through the `./queue-item-input` subpath so
+// the nine mobile provider suites that whole-module-mock `@boardsesh/queue-react`
+// still get the real mapper.
+import type { ClimbInput, ClimbQueueItemInput } from '@boardsesh/shared-schema';
+import type { QueueItemUser } from '@boardsesh/queue';
+
+/**
+ * The identity a client stamps onto an item IT introduces. `addedBy` is the
+ * connection clientId (legacy attribution); `addedByUser` is the party profile
+ * the queue row renders an avatar from.
+ */
+export type QueueItemAttribution = {
+  addedBy: string | null;
+  addedByUser?: QueueItemUser;
+};
+
+/**
+ * The item shape both platforms' local queue items structurally satisfy. Generic
+ * over the climb so each platform keeps its own local Climb type and supplies its
+ * own `toClimbInput`.
+ */
+export type WireBoundQueueItem<TClimb> = {
+  uuid: string;
+  climb: TClimb;
+  addedBy?: string | null;
+  addedByUser?: QueueItemUser;
+  tickedBy?: (string | null)[] | null;
+  suggested?: boolean | null;
+};
+
+/**
+ * Compile-time exhaustiveness guard: `satisfies Record<keyof ClimbQueueItemInput,
+ * true>` turns typecheck RED the moment a seventh field lands on the GraphQL
+ * input without this mapper learning to send it. Tests compare the mapper's own
+ * `Object.keys` against this set, so neither side can be hand-edited into
+ * agreement with a stale field list.
+ */
+export const WIRE_ITEM_FIELDS = {
+  uuid: true,
+  climb: true,
+  addedBy: true,
+  addedByUser: true,
+  tickedBy: true,
+  suggested: true,
+} satisfies Record<keyof ClimbQueueItemInput, true>;
+
+/**
+ * Map a local queue item to the GraphQL `ClimbQueueItemInput`.
+ *
+ * Deliberately a pure passthrough: no identity fallback lives here. Stamping
+ * "me" onto an unattributed item at the WIRE would claim authorship of every
+ * peer item on the next full-queue write — including one a peer added before
+ * their profile resolved. Attribution belongs at item CONSTRUCTION, where the
+ * client knows the item is its own.
+ */
+export function toClimbQueueItemInput<TClimb>(
+  item: WireBoundQueueItem<TClimb>,
+  toClimbInput: (climb: TClimb) => ClimbInput,
+): ClimbQueueItemInput {
+  return {
+    uuid: item.uuid,
+    climb: toClimbInput(item.climb),
+    // Left undefined (not coerced to null) when absent, matching what web has
+    // always written — a null would overwrite a peer's value on the server.
+    addedBy: item.addedBy,
+    addedByUser: item.addedByUser
+      ? {
+          id: item.addedByUser.id,
+          username: item.addedByUser.username,
+          avatarUrl: item.addedByUser.avatarUrl,
+        }
+      : undefined,
+    // The wire type is `[String!]` — drop local nulls rather than send a value
+    // the server would reject.
+    tickedBy: item.tickedBy?.filter((id): id is string => id !== null),
+    suggested: item.suggested,
+  };
+}

--- a/packages/web/app/components/persistent-session/__tests__/to-climb-queue-item-input.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/to-climb-queue-item-input.test.ts
@@ -81,4 +81,41 @@ describe('toClimbQueueItemInput', () => {
     const sent = new Set(Object.keys(toClimbQueueItemInput(makeItem()).climb));
     expect(sent).toEqual(climbInputFieldNames());
   });
+
+  // The one non-passthrough coercion in web's climb mapper. Mobile sends
+  // `description` raw, so the shared extraction had to keep web's own `|| ''`
+  // rather than repoint web at mobile's mapper (#3995).
+  it('sends an empty-string description rather than null when the climb has none', () => {
+    const input = toClimbQueueItemInput(makeItem({ description: undefined }));
+    expect(input.climb.description).toBe('');
+  });
+});
+
+// The item level now delegates to `@boardsesh/queue-react/queue-item-input`,
+// shared with mobile so the two platforms cannot drift apart again (#3995).
+// These pin the delegation to zero behaviour change: a refactor that forgot a
+// field, or coerced an absent `addedBy` to null, goes red here.
+describe('toClimbQueueItemInput item-level attribution', () => {
+  it('keeps the item-level attribution after the shared-mapper delegation', () => {
+    const input = toClimbQueueItemInput({
+      ...makeItem(),
+      addedBy: 'client-1',
+      addedByUser: { id: 'u1', username: 'Marco', avatarUrl: 'https://example.test/a.png' },
+      tickedBy: ['u1', null],
+      suggested: true,
+    });
+
+    expect(input.addedBy).toBe('client-1');
+    expect(input.addedByUser).toEqual({ id: 'u1', username: 'Marco', avatarUrl: 'https://example.test/a.png' });
+    // The wire input is `[String!]` — local nulls are dropped, not sent.
+    expect(input.tickedBy).toEqual(['u1']);
+    expect(input.suggested).toBe(true);
+  });
+
+  it('leaves an absent addedBy undefined rather than writing a null over a peer value', () => {
+    const input = toClimbQueueItemInput({ ...makeItem(), addedBy: undefined, addedByUser: undefined });
+
+    expect(input.addedBy).toBeUndefined();
+    expect(input.addedByUser).toBeUndefined();
+  });
 });

--- a/packages/web/app/components/persistent-session/types.ts
+++ b/packages/web/app/components/persistent-session/types.ts
@@ -7,7 +7,9 @@ import type {
   SessionSummary,
   QueueState,
   ClimbQueueItemInput,
+  ClimbInput,
 } from '@boardsesh/shared-schema';
+import { toClimbQueueItemInput as toSharedClimbQueueItemInput } from '@boardsesh/queue-react/queue-item-input';
 import type { QueueAction, QueueSearchParams, PlaylistSuggestionSource } from '@boardsesh/queue';
 import type { ClimbQueueItem as LocalClimbQueueItem } from '../queue-control/types';
 import type { BoardDetails, ParsedBoardRouteParameters } from '@/app/lib/types';
@@ -253,67 +255,64 @@ export type PendingInitialQueue = {
   sessionName?: string;
 };
 
-// Convert local ClimbQueueItem to GraphQL input format
-// Explicit return type so the compiler catches any drift between the web's
-// local item shape and the shared wire input (rather than a cast at the call
-// site silently absorbing it).
-export function toClimbQueueItemInput(item: LocalClimbQueueItem): ClimbQueueItemInput {
+// Map web's local climb to the GraphQL `ClimbInput`. Web-specific on purpose:
+// it sends `description: item.climb.description || ''` where mobile sends the
+// raw value, so this must NOT be collapsed onto mobile's `toClimbInput`.
+function toClimbInput(climb: LocalClimbQueueItem['climb']): ClimbInput {
   return {
-    uuid: item.uuid,
-    climb: {
-      uuid: item.climb.uuid,
-      setter_username: item.climb.setter_username,
-      // userId is the stable identity for ownership gates (Edit button,
-      // 24h post-publish window). Null/undefined for Aurora-synced climbs.
-      userId: item.climb.userId ?? null,
-      name: item.climb.name,
-      description: item.climb.description || '',
-      frames: item.climb.frames,
-      angle: item.climb.angle,
-      ascensionist_count: item.climb.ascensionist_count,
-      difficulty: item.climb.difficulty,
-      quality_average: item.climb.quality_average,
-      stars: item.climb.stars,
-      difficulty_error: item.climb.difficulty_error,
-      mirrored: item.climb.mirrored,
-      benchmark_difficulty: item.climb.benchmark_difficulty,
-      // Both selection sets already SELECT these two, so leaving them off the
-      // input meant every web-originated write cleared the no-match / method
-      // tags that peers were rendering.
-      is_no_match: item.climb.is_no_match ?? null,
-      characteristics: item.climb.characteristics ?? null,
-      // Round-trip draft/publish state so peers can decide locally whether
-      // to surface the Edit affordance without re-querying the DB.
-      is_draft: item.climb.is_draft ?? null,
-      published_at: item.climb.published_at ?? null,
-      userAscents: item.climb.userAscents,
-      userAttempts: item.climb.userAttempts,
-      // Multi-frame metadata so a peer who receives this climb via queue
-      // broadcast plays back at the climb's native pace instead of falling
-      // through to the DEFAULT_PACE_MS (750 ms) heuristic.
-      framesCount: item.climb.framesCount ?? null,
-      framesPace: item.climb.framesPace ?? null,
-      // Board identity so a peer on a different wall can classify this climb
-      // as a spill instead of dark-firing their board (issue #3193).
-      boardType: item.climb.boardType,
-      layoutId: item.climb.layoutId ?? null,
-      // Round-trip the Boardsesh grade so party peers render it without a refetch.
-      boardseshDifficulty: item.climb.boardseshDifficulty ?? null,
-      boardseshConfidence: item.climb.boardseshConfidence ?? null,
-    },
-    addedBy: item.addedBy,
-    addedByUser: item.addedByUser
-      ? {
-          id: item.addedByUser.id,
-          username: item.addedByUser.username,
-          avatarUrl: item.addedByUser.avatarUrl,
-        }
-      : undefined,
-    // The wire input is `[String!]` — drop any local nulls rather than send
-    // an invalid value the server would reject.
-    tickedBy: item.tickedBy?.filter((id): id is string => id !== null),
-    suggested: item.suggested,
+    uuid: climb.uuid,
+    setter_username: climb.setter_username,
+    // userId is the stable identity for ownership gates (Edit button,
+    // 24h post-publish window). Null/undefined for Aurora-synced climbs.
+    userId: climb.userId ?? null,
+    name: climb.name,
+    description: climb.description || '',
+    frames: climb.frames,
+    angle: climb.angle,
+    ascensionist_count: climb.ascensionist_count,
+    difficulty: climb.difficulty,
+    quality_average: climb.quality_average,
+    stars: climb.stars,
+    difficulty_error: climb.difficulty_error,
+    mirrored: climb.mirrored,
+    benchmark_difficulty: climb.benchmark_difficulty,
+    // Both selection sets already SELECT these two, so leaving them off the
+    // input meant every web-originated write cleared the no-match / method
+    // tags that peers were rendering.
+    is_no_match: climb.is_no_match ?? null,
+    characteristics: climb.characteristics ?? null,
+    // Round-trip draft/publish state so peers can decide locally whether
+    // to surface the Edit affordance without re-querying the DB.
+    is_draft: climb.is_draft ?? null,
+    published_at: climb.published_at ?? null,
+    userAscents: climb.userAscents,
+    userAttempts: climb.userAttempts,
+    // Multi-frame metadata so a peer who receives this climb via queue
+    // broadcast plays back at the climb's native pace instead of falling
+    // through to the DEFAULT_PACE_MS (750 ms) heuristic.
+    framesCount: climb.framesCount ?? null,
+    framesPace: climb.framesPace ?? null,
+    // Board identity so a peer on a different wall can classify this climb
+    // as a spill instead of dark-firing their board (issue #3193).
+    boardType: climb.boardType,
+    layoutId: climb.layoutId ?? null,
+    // Round-trip the Boardsesh grade so party peers render it without a refetch.
+    boardseshDifficulty: climb.boardseshDifficulty ?? null,
+    boardseshConfidence: climb.boardseshConfidence ?? null,
   };
+}
+
+// Convert local ClimbQueueItem to GraphQL input format.
+//
+// The ITEM-level field list (addedBy / addedByUser / tickedBy / suggested) lives
+// in `@boardsesh/queue-react/queue-item-input` so web and mobile cannot drift
+// apart again — mobile shipped a `{ uuid, climb }` copy of this function and
+// anonymised every climb queued from a phone (#3995). Only the climb mapper is
+// per-platform. Explicit return type so the compiler catches any drift between
+// the web's local item shape and the shared wire input (rather than a cast at
+// the call site silently absorbing it).
+export function toClimbQueueItemInput(item: LocalClimbQueueItem): ClimbQueueItemInput {
+  return toSharedClimbQueueItemInput(item, toClimbInput);
 }
 
 // Shared refs type used across hooks


### PR DESCRIPTION
## What / why

A climb queued from the phone reached everyone else in the session anonymous — no name, no avatar in the queue row's trailing slot. Worse, once a phone was in the session it _stripped_ the attribution off climbs the crew had queued from web, so the avatars blinked in and out depending on who touched the queue last.

## Verified root cause

Two halves, both on mobile.

**Write side.** `packages/mobile/src/providers/queue-provider.tsx` bound the shared mutation core's one item→wire seam to a thin literal:

```ts
toQueueItemInput: (item) => ({ uuid: item.uuid, climb: toClimbInput(item.climb) }),
```

That seam serves every mobile write path in `packages/shared/queue-react/src/create-queue-mutations.ts` (add / setCurrent / setQueue / replace — `mirrorCurrentClimb` takes only a boolean and carries no item). So `addedBy`, `addedByUser`, `tickedBy` and `suggested` never left the phone, even though the GraphQL `ClimbQueueItemInput` declares all four, the backend's Zod shape accepts them, and the backend stores whatever arrives verbatim (it never synthesises attribution). Web has always sent all four and renders the avatar from `item.addedByUser`. Mobile also never populated them locally — `climbToQueueItem` set only `uuid` / `suggested` / `climb`.

**Read side.** Mobile maintains its _own_ subscription and resync selection sets, and they selected `{ uuid climb { … } }` too — no `addedBy` / `addedByUser` / `tickedBy` / `suggested`. So the phone rebuilt every peer item without attribution, and its next full-queue write pushed that gap back to the whole crew. This is exactly the flap `docs/websocket-implementation.md` and the #3927 contract test warn about, one level up from the climb.

## Fix

**Shared, so the two platforms cannot drift again** — `packages/shared/queue-react/src/queue-item-input.ts` owns the item-level field list for both clients. Pure TS, no React; it lives in `queue-react` because that package already owns the mutation wire contract and already depends on shared-schema (`@boardsesh/queue` deliberately has zero dependencies and cannot name `ClimbQueueItemInput`). It's a pure passthrough with a `satisfies Record<keyof ClimbQueueItemInput, true>` guard, exported on a dedicated `./queue-item-input` subpath — load-bearing, because nine mobile provider suites whole-module-mock `@boardsesh/queue-react` and `climb-to-queue-item.ts` sits in all nine module graphs.

**Write side.** Mobile's `toQueueItemWireInput` delegates to it; the provider binds `toQueueItemInput` to that. Identity is stamped at item _construction_, not at the wire, in the three funnels that introduce an item (`addToQueue`, `dispatchSetCurrent`, `setQueue`). `attributeNewItem` skips an item that already carries attribution and skips anything already in `stateRef.current.queue` — a wire-level `??` fallback would have claimed authorship of every unattributed peer item on the next whole-queue write. `setQueue` stamps the array _before_ the local dispatch and feeds the same array to both the reducer and the broadcast, so state and wire agree. Stamping needs both a party-profile id and a non-empty username, so an anonymous phone never pushes a blank-named avatar at peers.

**Read side.** `SUBSCRIPTION_QUEUE_ITEM_FIELDS` in `packages/mobile/src/lib/graphql/operations.ts` selects all four, applied at all six item-selection sites (FullSync queue + current, `QueueItemAdded.addedItem`, `CurrentClimbChanged.currentItem`, and both inside `GET_SESSION_QUEUE_STATE`). `toClimbQueueItem` rebuilds them, narrowing server nulls to `undefined` for the three fields the reducer types optional-not-nullable.

**Web** keeps byte-identical output: the inline climb literal is extracted to a local `toClimbInput` — keeping web's own `description: item.climb.description || ''` verbatim, which mobile's mapper does _not_ do — and `toClimbQueueItemInput` becomes a one-line delegation.

Out of scope on purpose: `packages/mobile/src/providers/bluetooth-provider.tsx:689` still builds a thin `{ uuid, climb }` input for the board-presence `reportBoardClimb` mutation. Different mutation, different consumer (wall presence, kiosk-redacted) — don't read the remaining literal as a missed spot. Mobile still doesn't _render_ an "added by" avatar in its own queue list; that's read-side UI on a different surface and a separate PR. The Swift Live Activity / widget path is also left alone: `packages/mobile/modules/live-activity/ios/SessionWebSocketManager.swift:363` builds its own attribution-less input and `NATIVE_IOS_QUEUE_UPDATES` deliberately reads a slim subset. Harmless — that call omits `shouldAddToQueue`, so the backend never appends a queue row for it and the reducer never rewrites an existing one; only the current-climb _pointer_ is unattributed, not the queue rows the avatars render from. The new backend describe says so in a comment.

## Tests

Every new test runs the real mapper / real provider — none rebuilds the predicate it checks.

- **`packages/shared/queue-react/src/__tests__/queue-item-input.test.ts`** (new) — the four fields survive; null entries drop from `tickedBy` (`[String!]`); an absent `addedBy` stays `undefined` rather than coercing to `null`; output keys equal `WIRE_ITEM_FIELDS`. _Reverting the mapper to `{uuid, climb}` fails all four; adding a seventh GraphQL field without teaching the mapper fails typecheck on the `satisfies` guard._
- **`packages/mobile/src/lib/__tests__/climb-to-queue-item.test.ts`** — `toQueueItemWireInput` carries all four AND still emits the full `toClimbInput` climb key set. _The pre-fix shape emits two keys and fails immediately._
- **`packages/mobile/src/lib/__tests__/queue-conversion.test.ts`** — a web peer's attribution survives the rebuild; nulls narrow to `undefined`; the rebuilt key set equals what `SUBSCRIPTION_QUEUE_ITEM_FIELDS` selects (parsed with graphql's own parser, not string-split). _Deleting the four rebuild lines fails._
- **`packages/mobile/src/providers/__tests__/queue-provider-attribution.test.tsx`** (new) — end-to-end through the real provider, with `@boardsesh/queue-react` mocked via `importOriginal` so the real mapper survives. Stamps this climber on a phone-queued climb (local state _and_ broadcast); does **not** re-author a peer item delivered over the queueUpdates subscription when the phone rewrites the whole queue; forwards an already-attributed item handed straight to `setQueue`; does not re-author an unattributed item already in this device's queue; the captured wire mapper serialises the stamped fields. _Mutation-tested both ways: disabling the stamping reds 3 of 5; removing the two misattribution guards reds a different 3 of 5; dropping the four fields from `toClimbQueueItem` reds the peer case._
- **`packages/backend/src/__tests__/queue-climb-field-contract.test.ts`** — new item-level parity describe: both read paths (shared `QUEUE_ITEM_FIELDS`, mobile `SUBSCRIPTION_QUEUE_ITEM_FIELDS` read live out of source) must select exactly what `ClimbQueueItemInput` declares. Plus an interpolation-count assertion, because the parity check unions field names across every item selection in a document, so one complete site would mask a longhand sibling. _Deleting `suggested` from the mobile template reds the parity check; writing one of the six selection sites out longhand reds the interpolation check while parity stays green — which is exactly the blind spot it closes._
- **`packages/backend/src/__tests__/operations-schema-validation.test.ts`** — taught to resolve the nested `${SUBSCRIPTION_QUEUE_ITEM_FIELDS}` placeholder (factored into one helper so a future nested const can't be taught to one call site and forgotten at another). This is what proves mobile's new selection set parses and validates against the executable schema.
- **`packages/web/app/components/persistent-session/__tests__/to-climb-queue-item-input.test.ts`** — pins the delegation to zero behaviour change: all four item fields, `tickedBy` nulls filtered, absent `addedBy` stays `undefined`, and `description: ''` for a null-description climb. _A refactor that repointed web at mobile's `toClimbInput` reds the description case._
- **`packages/mobile/src/providers/__tests__/queue-provider.test.ts`** — dropped `produces a valid ClimbQueueItem shape without extra properties`. It hand-transcribed the top-level key list as `['uuid', 'climb']`, which the four rebuilt attribution fields now break. It's superseded by the live-derived assertion in `queue-conversion.test.ts` that parses `SUBSCRIPTION_QUEUE_ITEM_FIELDS` instead of restating it, so the guard survives the next field added.

## Validation

- `vp check` — 0 errors, 288 warnings (all pre-existing; none in touched files)
- `vp run typecheck` — clean across every scope
- `vp run check:mobile-bundle` — OK (Metro resolves the new subpath export)
- `vp test run --project queue-react` — 43 passed
- `vp run test:mobile` — the whole mobile package, 563 files / 4765 tests passed (a `queue-provider-*` glob misses `queue-provider.test.ts`, so the full run is the honest gate here)
- backend: `queue-climb-field-contract` 10 passed, `operations-schema-validation` 223 passed
- web: `to-climb-queue-item-input` 9 passed

## QA Notes

1. **Misattribution.** Two devices, one session. Web peer queues climb A. On the phone, trigger a whole-queue write (activate a playlist, generate a session, drag-reorder). Climb A must still show the _web_ user's avatar on web afterwards, not the phone user's. Then the reverse: a climb the phone added shows the phone user.
2. **The flap.** Add climbs from both clients, then force a reconnect/FullSync on web. Attribution must be stable across the round trip — no avatars blinking depending on who wrote last.
3. **Signed-out phone.** Stamping requires both a party-profile id and a non-empty username. Verify no crash and no empty-initial avatar on web when the phone is anonymous.
4. **Solo mode.** No session: `addedBy` resolves from `sessionRuntimeStateRef.current.clientId`, which is `''` before a join (stored as `null`). Confirm queueing solo still works, the local snapshot round-trips, and starting a session afterwards seeds the queue with attribution intact.
5. **`suggested` pruning.** Mobile now both sends _and_ receives `suggested`, so `pruneSuggestedQueueItemsAfterCurrent` can fire on peer-originated suggestion items during a local playlist activation. On web start a playlist-suggestion flow, then have the phone activate a playlist climb; confirm the web queue doesn't silently swallow items it should keep.
6. **Mobile queue list** still shows no "added by" avatar of its own — that's unchanged and out of scope.

OTA-safe: JS/TS only, no native deps, no schema change, no migration.

## Release Notes

Climbs you queue from the phone now show your name and avatar to everyone in the session instead of landing anonymous — and a phone in the session no longer wipes the "added by" avatars off the climbs your crew queued from the web.

Fixes #3995
