### PR TITLE
fix: stop double-counting party-session self-removes

### DIFF
--- a/packages/backend/src/__tests__/queue-sync-fixes.test.ts
+++ b/packages/backend/src/__tests__/queue-sync-fixes.test.ts
@@ -644,6 +644,44 @@ describe('order-sensitive dual-hash (stateHashOrdered)', () => {
       }),
     );
   });
+
+  // Issue #3382 — QueueItemRemoved must carry the removing connection's id so
+  // subscribers can drop echoes of their own removes instead of tagging them
+  // `removedBy: 'peer'` (a double count, since the local remove already
+  // tracked itself as 'self').
+  it('publishes the removing connection id on QueueItemRemoved', async () => {
+    const sessionId = uuidv4();
+    await registerAndJoinSession('client-1', sessionId, '/kilter/1/2/3/40', 'User1');
+
+    const climb = createTestClimb();
+    await queueMutations.addQueueItem({}, { item: climb }, ctxFor(sessionId));
+    publishSpy.mockClear();
+
+    await queueMutations.removeQueueItem({}, { uuid: climb.uuid }, ctxFor(sessionId));
+    const removedCall = publishSpy.mock.calls.find(
+      (call: unknown[]) => (call[1] as { __typename: string }).__typename === 'QueueItemRemoved',
+    );
+    expect(removedCall).toBeDefined();
+    expect((removedCall![1] as { clientId: string | null }).clientId).toBe('client-1');
+  });
+
+  // An anonymous publisher must send null, NOT '': peers compare defensively,
+  // and two empty-string clients would echo-suppress each other's removes.
+  it('coerces a missing connection id to null on QueueItemRemoved', async () => {
+    const sessionId = uuidv4();
+    await registerAndJoinSession('client-1', sessionId, '/kilter/1/2/3/40', 'User1');
+
+    const climb = createTestClimb();
+    await queueMutations.addQueueItem({}, { item: climb }, ctxFor(sessionId));
+    publishSpy.mockClear();
+
+    await queueMutations.removeQueueItem({}, { uuid: climb.uuid }, { ...ctxFor(sessionId), connectionId: '' });
+    const removedCall = publishSpy.mock.calls.find(
+      (call: unknown[]) => (call[1] as { __typename: string }).__typename === 'QueueItemRemoved',
+    );
+    expect(removedCall).toBeDefined();
+    expect((removedCall![1] as { clientId: string | null }).clientId).toBeNull();
+  });
 });
 
 // Issue #2387 — the setQueue "redundant resync" warning must be order-aware.

--- a/packages/backend/src/graphql/resolvers/queue/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/queue/mutations.ts
@@ -150,6 +150,10 @@ export const queueMutations = {
       stateHash,
       stateHashOrdered,
       uuid,
+      // Same coercion as setCurrentClimb/publishPlaybackState: an empty-string connectionId must
+      // become null, because peers compare defensively and two anonymous clients would otherwise
+      // echo-suppress each other's removes.
+      clientId: ctx.connectionId || null,
     });
 
     logMutationMetrics('removeQueueItem', performance.now() - startTime, sessionId);

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -1278,6 +1278,7 @@ export const QUEUE_UPDATES_SUBSCRIPTION = `
         stateHash
         stateHashOrdered
         uuid
+        clientId
       }
       ... on QueueReordered {
         sequence

--- a/packages/mobile/src/providers/__tests__/queue-provider-sync-gate.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-sync-gate.test.tsx
@@ -205,6 +205,7 @@ type Snapshot = {
   state: ReturnType<typeof useQueue>['state'];
   sessionId: string | null;
   subscribeToQueueEvents: ReturnType<typeof useQueue>['subscribeToQueueEvents'];
+  removeFromQueue: ReturnType<typeof useQueue>['removeFromQueue'];
 };
 
 const user = (overrides: Partial<SessionUser> = {}): SessionUser => ({
@@ -360,8 +361,9 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
       state: queue.state,
       sessionId: queue.sessionId,
       subscribeToQueueEvents: queue.subscribeToQueueEvents,
+      removeFromQueue: queue.removeFromQueue,
     });
-  }, [queue.state, queue.sessionId, queue.subscribeToQueueEvents, onSnapshot]);
+  }, [queue.state, queue.sessionId, queue.subscribeToQueueEvents, queue.removeFromQueue, onSnapshot]);
   return null;
 }
 
@@ -942,6 +944,62 @@ describe('QueueItemRemoved self-echo attribution (issue #3382)', () => {
     expect(analytics.track).toHaveBeenCalledWith(
       'Climb Removed from Queue',
       expect.objectContaining({ removedBy: 'peer' }),
+    );
+  });
+
+  // The suppressed echo used to be the only mobile remove carrying
+  // `partyMode`, so the surviving self-track has to compute it or a PostHog
+  // breakdown on partyMode loses every mobile self-remove.
+  const seedAndRemoveLocally = async () => {
+    const snapshots: Snapshot[] = [];
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(ws.getQueueUpdatesSink()).not.toBeNull();
+    });
+    const queueUpdatesSink = ws.getQueueUpdatesSink();
+    if (!queueUpdatesSink) throw new Error('queue updates sink was not captured');
+
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireFullSync(1, 'hash-1') } });
+    });
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireQueueItemAdded(2, 'hash-2', wireItem('q1', 'c1')) } });
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['q1']);
+    });
+
+    analytics.track.mockClear();
+    act(() => {
+      snapshots.at(-1)?.removeFromQueue('q1');
+    });
+    await waitFor(() => {
+      expect(removeTrackCalls()).toHaveLength(1);
+    });
+  };
+
+  it('tracks a local remove with partyMode: true when the crew has more than one climber', async () => {
+    const joined = createJoinSessionResponse();
+    graph.execute.mockResolvedValue({
+      joinSession: {
+        ...joined.joinSession,
+        users: [...joined.joinSession.users, user({ id: 'participant-peer', username: 'Sam', userId: 'db-peer' })],
+      },
+    });
+
+    await seedAndRemoveLocally();
+    expect(analytics.track).toHaveBeenCalledWith(
+      'Climb Removed from Queue',
+      expect.objectContaining({ removedBy: 'self', partyMode: true }),
+    );
+  });
+
+  it('tracks a solo remove with partyMode: false', async () => {
+    await seedAndRemoveLocally();
+    expect(analytics.track).toHaveBeenCalledWith(
+      'Climb Removed from Queue',
+      expect.objectContaining({ removedBy: 'self', partyMode: false }),
     );
   });
 });

--- a/packages/mobile/src/providers/__tests__/queue-provider-sync-gate.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-sync-gate.test.tsx
@@ -284,6 +284,19 @@ function wireQueueItemAdded(sequence: number, stateHash: string, item: ReturnTyp
   };
 }
 
+// Wire-shaped QueueItemRemoved matching QUEUE_UPDATES_SUBSCRIPTION's `... on
+// QueueItemRemoved` fragment. `clientId` is the removing connection's id
+// (#3382); it is nullable on the wire, so a pre-#3382 server sends null.
+function wireQueueItemRemoved(sequence: number, stateHash: string, uuid: string, clientId: string | null) {
+  return {
+    __typename: 'QueueItemRemoved',
+    sequence,
+    stateHash,
+    uuid,
+    clientId,
+  };
+}
+
 // Wire-shaped PlaybackStateChanged matching QUEUE_UPDATES_SUBSCRIPTION's `...
 // on PlaybackStateChanged` fragment (issue #3358) — no top-level `stateHash`,
 // since this event doesn't mutate queue state.
@@ -846,5 +859,89 @@ describe('QueueProvider queue sync gate', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// Issue #3382 — a remove echoed back to the client that issued it must NOT be
+// tracked again. The local remove already fired `Climb Removed from Queue`
+// with `removedBy: 'self'` at the mutation site (queue-provider.tsx), so the
+// echo handler firing a second, peer-attributed copy double counted every
+// party-session self-remove. joinSession returns clientId 'client-self' in
+// this harness, which is exactly what the backend stamps onto the event.
+describe('QueueItemRemoved self-echo attribution (issue #3382)', () => {
+  const seedAndRemove = async (clientId: string | null) => {
+    const snapshots: Snapshot[] = [];
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(ws.getQueueUpdatesSink()).not.toBeNull();
+    });
+    const queueUpdatesSink = ws.getQueueUpdatesSink();
+    if (!queueUpdatesSink) throw new Error('queue updates sink was not captured');
+
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireFullSync(1, 'hash-1') } });
+    });
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireQueueItemAdded(2, 'hash-2', wireItem('q1', 'c1')) } });
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['q1']);
+    });
+
+    analytics.track.mockClear();
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireQueueItemRemoved(3, 'hash-3', 'q1', clientId) } });
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue).toEqual([]);
+    });
+    return snapshots;
+  };
+
+  const removeTrackCalls = () =>
+    analytics.track.mock.calls.filter(([eventName]) => eventName === 'Climb Removed from Queue');
+
+  beforeEach(() => {
+    ws.reset();
+    ws.client.on.mockClear();
+    ws.client.subscribe.mockClear();
+    activeBoard.getStoredActiveBoard.mockReset();
+    activeBoard.getStoredActiveBoard.mockResolvedValue(activeBoard.stored);
+    toast.showToast.mockClear();
+    analytics.track.mockClear();
+    for (const mutation of Object.values(queueMutations) as Array<ReturnType<typeof vi.fn>>) {
+      mutation.mockReset();
+      mutation.mockResolvedValue(undefined);
+    }
+    sessionStore.getStoredSessionId.mockReset();
+    sessionStore.getStoredSessionId.mockResolvedValue('session-1');
+    graph.execute.mockReset();
+    graph.execute.mockResolvedValue(createJoinSessionResponse());
+    http.request.mockReset();
+    routeHttpRequest(queueStateResponse([]));
+  });
+
+  it('does not track a remove echoed back from this client', async () => {
+    await seedAndRemove('client-self');
+    expect(removeTrackCalls()).toHaveLength(0);
+  });
+
+  it("still tracks a peer's remove as removedBy: 'peer'", async () => {
+    await seedAndRemove('client-peer');
+    expect(removeTrackCalls()).toHaveLength(1);
+    expect(analytics.track).toHaveBeenCalledWith(
+      'Climb Removed from Queue',
+      expect.objectContaining({ removedBy: 'peer', partyMode: true }),
+    );
+  });
+
+  it("falls back to 'peer' when a pre-#3382 server sends no clientId", async () => {
+    await seedAndRemove(null);
+    expect(removeTrackCalls()).toHaveLength(1);
+    expect(analytics.track).toHaveBeenCalledWith(
+      'Climb Removed from Queue',
+      expect.objectContaining({ removedBy: 'peer' }),
+    );
   });
 });

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -14,7 +14,7 @@ import type {
   PlaylistSuggestionSource,
   SetCurrentClimbOptions,
 } from '@boardsesh/queue';
-import { createJoinSessionTracker, type QueueSyncGate } from '@boardsesh/queue-runtime';
+import { countDistinctSessionUsers, createJoinSessionTracker, type QueueSyncGate } from '@boardsesh/queue-runtime';
 import { useQueueMutations, type PublishPlaybackStateInput } from '@boardsesh/queue-react';
 import type { SubscriptionQueueEvent, SessionUser } from '@boardsesh/shared-schema';
 import { execute, isRateLimitedError } from '@boardsesh/graphql-client';
@@ -772,11 +772,16 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       // item locally; the server mutation only syncs it to an existing session
       // (and no-ops when there's none).
       dispatch({ type: 'DELTA_REMOVE_QUEUE_ITEM', payload: { uuid } });
+      // partyMode matches web's self-track (QueueContext.tsx): the crew roster
+      // holds more than one distinct human. Without it the suppressed self-echo
+      // would take `partyMode: true` with it and a PostHog breakdown on
+      // partyMode would lose every mobile self-remove.
       track(SHARED_EVENTS.ClimbRemovedFromQueue, {
         climbUuid: removedItem?.climb.uuid ?? null,
         queueItemUuid: uuid,
         boardName: activeBoardRef.current?.boardType,
         layoutId: activeBoardRef.current?.layoutId,
+        partyMode: countDistinctSessionUsers(sessionRuntimeStateRef.current?.users) > 1,
         removedBy: 'self',
       });
       mutations.removeQueueItem(uuid).catch((error) => {

--- a/packages/mobile/src/providers/queue/use-session-realtime.ts
+++ b/packages/mobile/src/providers/queue/use-session-realtime.ts
@@ -548,12 +548,33 @@ export function useSessionRealtime({
                 track(SHARED_EVENTS.ClimbAddedToQueue, {
                   boardName: activeBoardRef.current?.boardType,
                   layoutId: activeBoardRef.current?.layoutId,
+                  // QueueItemAdded carries no clientId on the wire yet, so a
+                  // self-add echo is still tracked here (double count) — #4042.
                   addedFromTab: 'peer_broadcast',
                   currentQueueLength: stateRef.current.queue.length + 1,
                   partyMode: true,
                 });
                 break;
-              case 'QueueItemRemoved':
+              case 'QueueItemRemoved': {
+                // The server echoes our own removes back to us. A locally
+                // initiated remove already tracked itself with
+                // removedBy: 'self' at the mutation site (queue-provider.tsx),
+                // so tracking the echo would double count — stay silent rather
+                // than emit a second, peer-attributed copy (#3382).
+                //
+                // Both truthiness guards are load-bearing: solo/unjoined state
+                // leaves clientId as '' (createEmptySessionRuntimeState) and a
+                // pre-#3382 server sends no clientId at all. Either way we fall
+                // back to today's 'peer' attribution.
+                const selfClientId = sessionRuntimeStateRef.current?.clientId;
+                if (
+                  event.__typename === 'QueueItemRemoved' &&
+                  event.clientId &&
+                  selfClientId &&
+                  event.clientId === selfClientId
+                ) {
+                  break;
+                }
                 track(SHARED_EVENTS.ClimbRemovedFromQueue, {
                   boardName: activeBoardRef.current?.boardType,
                   layoutId: activeBoardRef.current?.layoutId,
@@ -561,6 +582,7 @@ export function useSessionRealtime({
                   removedBy: 'peer',
                 });
                 break;
+              }
               case 'QueueReordered':
                 if (event.__typename === 'QueueReordered') {
                   track(SHARED_EVENTS.QueueReordered, {

--- a/packages/mobile/src/providers/queue/use-session-realtime.ts
+++ b/packages/mobile/src/providers/queue/use-session-realtime.ts
@@ -566,6 +566,11 @@ export function useSessionRealtime({
                 // leaves clientId as '' (createEmptySessionRuntimeState) and a
                 // pre-#3382 server sends no clientId at all. Either way we fall
                 // back to today's 'peer' attribution.
+                //
+                // The `__typename` re-check is load-bearing, not dead code:
+                // this switch discriminates on `result.eventType`, a separate
+                // variable, so `event` is still the full union here and TS
+                // rejects `event.clientId` without it.
                 const selfClientId = sessionRuntimeStateRef.current?.clientId;
                 if (
                   event.__typename === 'QueueItemRemoved' &&

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -6834,6 +6834,8 @@ type QueueItemRemoved {
   stateHashOrdered: String
   "UUID of the removed item"
   uuid: ID!
+  "Connection id of the client that removed the item; null when unknown (widget/controller paths, or a pre-#3382 server). Clients compare it against their own joinSession clientId to suppress self-echoes."
+  clientId: ID
 }
 
 """

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -5702,6 +5702,8 @@ export type QueueItemAdded = {
 /** Event when an item is removed from the queue. */
 export type QueueItemRemoved = {
   __typename?: 'QueueItemRemoved';
+  /** Connection id of the client that removed the item; null when unknown (widget/controller paths, or a pre-#3382 server). Clients compare it against their own joinSession clientId to suppress self-echoes. */
+  clientId?: Maybe<Scalars['ID']['output']>;
   /** Sequence number of this event */
   sequence: Scalars['Int']['output'];
   /** Order-insensitive queue state hash (v1) after this event is applied */
@@ -11698,6 +11700,7 @@ export type QueueItemRemovedResolvers<
   ContextType = ConnectionContext,
   ParentType extends ResolversParentTypes['QueueItemRemoved'] = ResolversParentTypes['QueueItemRemoved'],
 > = ResolversObject<{
+  clientId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   sequence?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   stateHash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   stateHashOrdered?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/packages/shared-schema/src/schema/events.ts
+++ b/packages/shared-schema/src/schema/events.ts
@@ -255,6 +255,8 @@ export const eventsTypeDefs = /* GraphQL */ `
     stateHashOrdered: String
     "UUID of the removed item"
     uuid: ID!
+    "Connection id of the client that removed the item; null when unknown (widget/controller paths, or a pre-#3382 server). Clients compare it against their own joinSession clientId to suppress self-echoes."
+    clientId: ID
   }
 
   """

--- a/packages/shared-schema/src/types/events.ts
+++ b/packages/shared-schema/src/types/events.ts
@@ -51,6 +51,8 @@ export type QueueEvent =
       stateHash: string;
       stateHashOrdered?: string | null;
       uuid: string;
+      /** Connection id of the removing client; optional so legacy/replayed payloads still typecheck. */
+      clientId?: string | null;
     }
   | {
       __typename: 'QueueReordered';
@@ -109,6 +111,8 @@ export type SubscriptionQueueEvent =
       stateHash: string;
       stateHashOrdered?: string | null;
       uuid: string;
+      /** Connection id of the removing client; optional so legacy/replayed payloads still typecheck. */
+      clientId?: string | null;
     }
   | {
       __typename: 'QueueReordered';

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -5699,6 +5699,8 @@ export type QueueItemAdded = {
 /** Event when an item is removed from the queue. */
 export type QueueItemRemoved = {
   __typename?: 'QueueItemRemoved';
+  /** Connection id of the client that removed the item; null when unknown (widget/controller paths, or a pre-#3382 server). Clients compare it against their own joinSession clientId to suppress self-echoes. */
+  clientId?: Maybe<Scalars['ID']['output']>;
   /** Sequence number of this event */
   sequence: Scalars['Int']['output'];
   /** Order-insensitive queue state hash (v1) after this event is applied */

--- a/packages/shared/graphql/src/operations/queue-session.ts
+++ b/packages/shared/graphql/src/operations/queue-session.ts
@@ -448,6 +448,10 @@ export const EVENTS_REPLAY = `
           }
           position
         }
+        # No clientId here on purpose: delta replay only runs from session-connection.ts's
+        # reconnect(), so every replayed event carries the PRE-reconnect connectionId while the
+        # client already holds the new one. The self-echo comparison could never match, so the
+        # field would be dead weight (see #3382).
         ... on QueueItemRemoved {
           sequence
           stateHash
@@ -526,6 +530,7 @@ export const QUEUE_UPDATES = `
         stateHash
         stateHashOrdered
         uuid
+        clientId
       }
       ... on QueueReordered {
         sequence

--- a/packages/shared/queue-runtime/src/subscription-adapter.ts
+++ b/packages/shared/queue-runtime/src/subscription-adapter.ts
@@ -59,6 +59,8 @@ export type SubscriptionWireEnvelope<TWireItem> =
       sequence?: number | null;
       stateHash?: string | null;
       stateHashOrdered?: string | null;
+      /** Connection id of the removing client; read by analytics to suppress self-echoes (#3382). */
+      clientId?: string | null;
     }
   | {
       __typename: 'QueueReordered';

--- a/packages/web/app/components/persistent-session/__tests__/use-peer-broadcast-analytics.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/use-peer-broadcast-analytics.test.ts
@@ -47,6 +47,7 @@ describe('usePeerBroadcastAnalytics', () => {
         isOnBoardRoute: true,
         boardLayoutName: 'Original',
         queueRef: { current: new Array(2) },
+        clientId: null,
       }),
     );
 
@@ -69,6 +70,7 @@ describe('usePeerBroadcastAnalytics', () => {
         isOnBoardRoute: true,
         boardLayoutName: 'Original',
         queueRef: { current: new Array(2) },
+        clientId: null,
       }),
     );
 
@@ -94,6 +96,7 @@ describe('usePeerBroadcastAnalytics', () => {
         isOnBoardRoute: false,
         boardLayoutName: null,
         queueRef: { current: new Array(0) },
+        clientId: null,
       }),
     );
 
@@ -111,6 +114,7 @@ describe('usePeerBroadcastAnalytics', () => {
         isOnBoardRoute: true,
         boardLayoutName: 'Original',
         queueRef: { current: new Array(0) },
+        clientId: null,
       }),
     );
 
@@ -130,6 +134,7 @@ describe('usePeerBroadcastAnalytics', () => {
         isOnBoardRoute: true,
         boardLayoutName: 'Original',
         queueRef: { current: new Array(0) },
+        clientId: null,
       }),
     );
 
@@ -150,6 +155,7 @@ describe('usePeerBroadcastAnalytics', () => {
           isOnBoardRoute: props.isOnBoardRoute,
           boardLayoutName: props.boardLayoutName,
           queueRef,
+          clientId: null,
         }),
       { initialProps: { isOnBoardRoute: true, boardLayoutName: 'Original' } },
     );
@@ -179,6 +185,7 @@ describe('usePeerBroadcastAnalytics', () => {
         isOnBoardRoute: true,
         boardLayoutName: 'Original',
         queueRef,
+        clientId: null,
       }),
     );
 
@@ -206,6 +213,7 @@ describe('usePeerBroadcastAnalytics', () => {
           isOnBoardRoute: props.isOnBoardRoute,
           boardLayoutName: 'Original',
           queueRef: { current: new Array(0) },
+          clientId: null,
         }),
       { initialProps: { isOnBoardRoute: false } },
     );
@@ -216,5 +224,78 @@ describe('usePeerBroadcastAnalytics', () => {
     rerender({ isOnBoardRoute: true });
     emit(addedEvent);
     expect(mockTrack).toHaveBeenCalledTimes(1);
+  });
+  // Issue #3382 — the server echoes our own remove back to us. The local
+  // remove already tracked `removedBy: 'self'` in graphql-queue/QueueContext.tsx
+  // (:693), so tracking the echo double counted every party-session
+  // self-remove. QueueItemRemoved now carries the removing connection id.
+  it('skips a QueueItemRemoved echoed back from this client', () => {
+    const { subscribeToQueueEvents, emit } = createSubscribeToQueueEvents();
+    renderHook(() =>
+      usePeerBroadcastAnalytics({
+        subscribeToQueueEvents,
+        isOnBoardRoute: true,
+        boardLayoutName: 'Original',
+        queueRef: { current: new Array(2) },
+        clientId: 'conn-self',
+      }),
+    );
+
+    emit({ ...removedEvent, clientId: 'conn-self' });
+
+    expect(mockTrack).not.toHaveBeenCalled();
+  });
+
+  it("still fires 'peer' for a QueueItemRemoved from another client", () => {
+    const { subscribeToQueueEvents, emit } = createSubscribeToQueueEvents();
+    renderHook(() =>
+      usePeerBroadcastAnalytics({
+        subscribeToQueueEvents,
+        isOnBoardRoute: true,
+        boardLayoutName: 'Original',
+        queueRef: { current: new Array(2) },
+        clientId: 'conn-self',
+      }),
+    );
+
+    emit({ ...removedEvent, clientId: 'conn-peer' });
+
+    expect(mockTrack).toHaveBeenCalledTimes(1);
+    expect(mockTrack).toHaveBeenCalledWith('Climb Removed from Queue', {
+      boardLayout: 'Original',
+      partyMode: true,
+      removedBy: 'peer',
+    });
+  });
+
+  // A pre-#3382 server sends no clientId; a solo/unjoined client has none of
+  // its own. Both fall back to the historical 'peer' attribution rather than
+  // silently dropping the event.
+  it("falls back to 'peer' when either side has no clientId", () => {
+    const { subscribeToQueueEvents, emit } = createSubscribeToQueueEvents();
+    const { rerender } = renderHook(
+      (props: { clientId: string | null }) =>
+        usePeerBroadcastAnalytics({
+          subscribeToQueueEvents,
+          isOnBoardRoute: true,
+          boardLayoutName: 'Original',
+          queueRef: { current: new Array(2) },
+          clientId: props.clientId,
+        }),
+      { initialProps: { clientId: 'conn-self' } as { clientId: string | null } },
+    );
+
+    // Legacy server: event carries no clientId.
+    emit({ ...removedEvent, clientId: null });
+    expect(mockTrack).toHaveBeenCalledTimes(1);
+
+    // Unjoined client: we have no clientId of our own.
+    rerender({ clientId: null });
+    emit({ ...removedEvent, clientId: 'conn-peer' });
+    expect(mockTrack).toHaveBeenCalledTimes(2);
+    expect(mockTrack).toHaveBeenLastCalledWith(
+      'Climb Removed from Queue',
+      expect.objectContaining({ removedBy: 'peer' }),
+    );
   });
 });

--- a/packages/web/app/components/persistent-session/hooks/use-peer-broadcast-analytics.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-peer-broadcast-analytics.ts
@@ -20,6 +20,13 @@ type UsePeerBroadcastAnalyticsParams = {
    * exactly this purpose (`queueRef`).
    */
   queueRef: RefObject<{ length: number }>;
+  /**
+   * This client's joinSession-returned connection id (`lifecycle.session.clientId`),
+   * or null when not in a session. Used to suppress self-echoes of our own
+   * removes. Read via a ref internally so a rejoin doesn't tear down the
+   * subscription effect.
+   */
+  clientId: string | null;
 };
 
 /**
@@ -39,21 +46,26 @@ type UsePeerBroadcastAnalyticsParams = {
  * firing off-board too, a parity regression.
  *
  * Fires on every `QueueItemAdded`/`QueueItemRemoved` event this client's
- * queue subscription receives — including echoes of this client's own
- * mutations. The wire protocol never suppresses self-echoes for add/remove
- * (only `CurrentClimbChanged` carries a clientId for that); this mirrors the
- * old hook's behavior exactly — it never filtered self vs peer either.
+ * queue subscription receives. `QueueItemRemoved` now carries the removing
+ * client's connection id (#3382), so echoes of our OWN removes are skipped —
+ * the local remove already tracked itself with `removedBy: 'self'` in
+ * `graphql-queue/QueueContext.tsx`, and tracking the echo double counted.
+ * `QueueItemAdded` still has no clientId on the wire, so self-adds remain
+ * double counted — tracked as a follow-up in #4042.
  */
 export function usePeerBroadcastAnalytics({
   subscribeToQueueEvents,
   isOnBoardRoute,
   boardLayoutName,
   queueRef,
+  clientId,
 }: UsePeerBroadcastAnalyticsParams) {
   const isOnBoardRouteRef = useRef(isOnBoardRoute);
   isOnBoardRouteRef.current = isOnBoardRoute;
   const boardLayoutNameRef = useRef(boardLayoutName);
   boardLayoutNameRef.current = boardLayoutName;
+  const clientIdRef = useRef(clientId);
+  clientIdRef.current = clientId;
 
   useEffect(() => {
     const unsubscribe = subscribeToQueueEvents((event: SubscriptionQueueEvent) => {
@@ -71,10 +83,12 @@ export function usePeerBroadcastAnalytics({
           partyMode: true,
         });
       } else if (event.__typename === 'QueueItemRemoved') {
-        // TODO(#3383): `removedBy: 'peer'` mislabels echoes of THIS client's
-        // own removes. `QueueItemRemoved` has no `clientId` (unlike
-        // `CurrentClimbChanged`), so self-echoes can't be filtered here — a
-        // proper fix needs the wire field. Left hardcoded until then.
+        // Echo of our own remove: `graphql-queue/QueueContext.tsx` already
+        // tracked it with `removedBy: 'self'`, so tracking again would double
+        // count. Both truthiness guards matter — a solo/unjoined client has no
+        // clientId, and a pre-#3382 server sends none, so either way we fall
+        // back to the historical 'peer' attribution.
+        if (event.clientId && clientIdRef.current && event.clientId === clientIdRef.current) return;
         track('Climb Removed from Queue', {
           boardLayout: boardLayoutNameRef.current,
           partyMode: true,

--- a/packages/web/app/components/persistent-session/persistent-session-context.tsx
+++ b/packages/web/app/components/persistent-session/persistent-session-context.tsx
@@ -216,6 +216,10 @@ export const PersistentSessionProvider: React.FC<{ children: React.ReactNode }> 
     isOnBoardRoute: isBoardRoutePath(pathname),
     boardLayoutName: lifecycle.activeSession?.boardDetails.layout_name ?? null,
     queueRef,
+    // Our joinSession-returned connection id — the same value the backend
+    // stamps onto QueueItemRemoved, so the hook can drop echoes of our own
+    // removes instead of mislabelling them as a peer's (#3382).
+    clientId: lifecycle.session?.clientId ?? null,
   });
 
   // Session-scoped "the wall is lit" indicator, owned here (root, always


### PR DESCRIPTION
## What & why

In a party session, removing a climb emitted **two** `Climb Removed from Queue` events — one correct, one attributed to a peer who did nothing.

The local remove already tracked itself at the mutation site with `removedBy: 'self'` (`packages/web/app/components/graphql-queue/QueueContext.tsx:693` on web, `packages/mobile/src/providers/queue-provider.tsx:775-781` on mobile). The server then echoed the same remove back to the originator, and the echo handler fired a second event — hardcoded `removedBy: 'peer'` on both platforms (`use-peer-broadcast-analytics.ts`, which carried a literal `TODO(#3383)`, and `use-session-realtime.ts`).

## Verified root cause

`type QueueItemRemoved` carried no publisher identity — only `sequence`/`stateHash`/`stateHashOrdered`/`uuid` (`packages/shared-schema/src/schema/events.ts`), and the single backend publisher (`removeQueueItem`) sent none. With nothing to compare against, both echo handlers had to guess, and both guessed "peer".

So this is a **double count**, not just a mislabel. Relabelling the echo to `'self'` (the obvious-looking fix) would have kept the duplicate and made it invisible.

**Identity semantics.** The `clientId` the backend stamps on wire events is `ctx.connectionId` — the same value `joinSession` hands back to the client (`sessions/mutations.ts`, "`result.clientId` is the connection ID"). Mobile stores it in `sessionRuntimeState.clientId`; web in `lifecycle.session.clientId`. Mobile's `coordinator.clientId` is a locally generated uuid the server never sees — comparing against **that** would never match and would have produced a green, inert PR. The standing precedent is the hook this telemetry was relocated from, which passed `context: { myClientId: persistentSession.clientId ?? undefined }`.

**Answer to #3382's "Open question (verify)" — pre-existing skew, not a #3372 regression.** `git show 08cc81eed^:packages/web/app/components/graphql-queue/hooks/use-queue-event-subscription.ts` shows the deleted board-route hook subscribed to the identical `persistentSession.subscribeToQueueEvents` stream and hardcoded `removedBy: 'peer'` in its own `case 'QueueItemRemoved':` arm. The W6 relocation to the root changed nothing about self-echo exposure.

## Fix

- Additive nullable `clientId: ID` on `type QueueItemRemoved` (+ both hand-written unions in `shared-schema/src/types/events.ts`, optional so legacy/replayed payloads still typecheck).
- `removeQueueItem` publishes `clientId: ctx.connectionId || null`. The `|| null` coercion matters: two anonymous clients with `''` would otherwise echo-suppress each other.
- `clientId` selected on `QUEUE_UPDATES` (shared) and `QUEUE_UPDATES_SUBSCRIPTION` (mobile); `SubscriptionWireEnvelope` widened.
- Both echo handlers skip the analytics track when `event.clientId` matches our own joinSession clientId. Both truthiness guards are load-bearing — a solo/unjoined client has `clientId: ''`, and a pre-#3382 server sends none; either way we fall back to today's `'peer'`.
- `TODO(#3383)` removed.

The reducer path is untouched (`liftEnvelopeToSyncEvent`'s `QueueItemRemoved` case unchanged), so queue state cannot diverge — this is telemetry-only.

**`EVENTS_REPLAY` and `NATIVE_IOS_QUEUE_UPDATES` deliberately do NOT select `clientId`.** Replay _does_ reach the web analytics path (`session-connection.ts:652` → ports → `use-event-processor.ts` `notifyQueueSubscribers`), but delta replay only runs inside `reconnect()`, so every replayed event carries the **pre-reconnect** connectionId while the client already holds the new one — the comparison could never match and the field would be dead weight. `NATIVE_IOS_QUEUE_UPDATES` is an exact-match drift guard against the Swift client and must not diverge.

## Tests + fail-on-revert

1. **Backend contract** (`queue-sync-fixes.test.ts`): the `QueueItemRemoved` payload handed to `pubsub.publishQueueEvent` carries `clientId === ctx.connectionId`, and an empty connectionId publishes `null` (not `''`). Reverting the publisher drops the field entirely and both assertions fail.
2. **Mobile** (`queue-provider-sync-gate.test.tsx`): feeds a real wire-shaped `QueueItemRemoved` through the recorded subscription sink after a FullSync + add. `clientId: 'client-self'` (the harness's joinSession value) fires **no** `Climb Removed from Queue`; `'client-peer'` and `null` both still fire `removedBy: 'peer'`. **Mutation-tested** — neutering the guard to `false &&` makes exactly the self case fail (1 failed / 10 passed).
3. **Web** (`use-peer-broadcast-analytics.test.ts`): same self/peer/null matrix against the hook. Existing `QueueItemAdded` assertions left untouched as an unchanged-path guard.

None of the tests rebuild the handler's predicate — each feeds a literal envelope shaped like the real subscription selection.

## Scope: adds are out

`QueueItemAdded` has the identical bug (`addedFromTab: 'peer_broadcast'` hardcoded on both echo handlers while the local add already tracked itself), so party-session self-adds are double counted the same way. Deliberately out of scope here to keep the diff surgical — filed as **#4042** and referenced in-code at both sites.

## Risks

- **Metric discontinuity.** `Climb Removed from Queue` volume will **drop** on deploy: party-session self-removes stop emitting a duplicate. That is the fix working, not a telemetry outage. Note the asymmetry — `Climb Added to Queue` stays ~2x inflated until #4042 lands, so removes go to 1x while adds stay ~2x and any add/remove ratio on a dashboard shifts.
- **Bigger drop than 2x → 1x on mobile bulk paths.** `clearQueue` (`packages/mobile/src/providers/queue-provider.tsx:822-836`) fires N `removeQueueItem` mutations but tracks only `Queue Cleared` — no per-item event. Before this change the originating client received N echoes, each tracked `removedBy: 'peer'`; now all N are suppressed, so a party-session clear goes from N events to 0. Same for the resurrected-queue-add undo (`queue-provider.tsx:933`). Volume for clears is already carried by `Queue Cleared.totalCount`.
- ~~**`partyMode` shape asymmetry on mobile.**~~ Fixed in this PR. The suppressed echo was the only mobile remove carrying `partyMode`, so the surviving self-track now computes it the same way web does (`countDistinctSessionUsers(roster) > 1`), keeping a PostHog breakdown on `partyMode = true` intact across the deploy. Covered by two tests (party roster → `true`, solo → `false`); dropping the line fails both.
- **Reconnect window.** `connectionId` changes on reconnect and the stored id only updates once the rejoin resolves. An echo landing inside that window can still be tagged `'peer'`. Analytics-only, rare, strictly better than today's unconditional mislabel.
- **Residual, web-only.** A self-remove whose echo was lost to a socket drop is redelivered by delta replay and still tags `removedBy: 'peer'`. `connectionId` cannot survive the reconnect that triggers replay; a connection-stable client id is out of scope.
- **Legacy publishers.** Widget/controller paths and pre-deploy servers yield `clientId: null`, falling through to today's `'peer'`. The change is strictly additive.

No migration, no i18n keys, no BLE/native code, no `any`.

## QA Notes

1. **Party session, two clients** (mobile + mobile, or mobile + RN-web), both joined to the same session on the same board.
2. Remove a climb on client A. Expected: the climb disappears on both clients (unchanged), analytics records **one** remove on A (`removedBy: 'self'`) — not the current two — and one on B (`removedBy: 'peer'`).
3. Repeat from B to confirm symmetry.
4. Solo (no session): remove a climb; one `removedBy: 'self'`, queue behaves as before.
5. Edge: force a reconnect (airplane-mode toggle) mid-session, then remove. Queue must stay correct; a stray `'peer'` tag on the reconnect boundary is known and acceptable.
6. Regression watch: adds, reorders, and current-climb changes are deliberately untouched.
7. **Blast-radius caveat for counting events on web:** the root hook is board-route-gated and the `'self'` counterpart only fires inside the board-route `GraphQLQueueProvider`, so the double count exists only on board routes. The off-board bridge fires _neither_ event (`queue-actions-core.ts:132-135`) — an off-board event count of zero is expected, not a failure.

## Release Notes

none

Fixes #3382
Fixes #3383

#3383 is a near-duplicate of #3382 filed from the same #3372 review — it is the issue the removed `TODO(#3383)` marker named, and the only one of the pair that mentions mobile. Both are closed by this change; if you'd rather keep #3382 as the canonical one, close #3383 as a duplicate instead.
