### PR TITLE
fix(sync): null impossible upstream fa_at values before they land in board_climb_stats

### DIFF
--- a/.github/workflows/dev-db-docker.yml
+++ b/.github/workflows/dev-db-docker.yml
@@ -9,6 +9,9 @@ on:
       - 'packages/db/src/schema/**'
       - 'packages/db/drizzle/**'
       - 'packages/db/package.json'
+      # Copied into the dev-db image's node_modules (fa_at guard used by
+      # import-aurora-board-unified) — rebuild when it changes.
+      - 'packages/sync-runtime/**'
       - '.github/workflows/dev-db-docker.yml'
   workflow_dispatch:
 

--- a/bun.lock
+++ b/bun.lock
@@ -150,6 +150,7 @@
         "@boardsesh/board-constants": "*",
         "@boardsesh/kiosk": "*",
         "@boardsesh/shared-schema": "*",
+        "@boardsesh/sync-runtime": "*",
         "drizzle-orm": "^0.45.1",
         "postgres": "^3.4.8",
         "uuid": "^13.0.0",

--- a/packages/aurora-sync/src/sync/shared-sync.test.ts
+++ b/packages/aurora-sync/src/sync/shared-sync.test.ts
@@ -57,6 +57,7 @@ vi.mock('drizzle-orm/postgres-js', async () => {
   };
 });
 
+import type { SQL } from 'drizzle-orm';
 import { PgDialect } from 'drizzle-orm/pg-core';
 import {
   climbListingConflictSet,
@@ -85,6 +86,15 @@ import {
  */
 const shimInsertedRows: Array<Record<string, unknown>> = [];
 
+/**
+ * Every `set` object handed to an `.onConflictDoUpdate(...)` call on the
+ * shim, in call order. Lets a test assert on the conflict clause the query
+ * builder actually RECORDED for a write — rebuilding the same clause by
+ * calling the production helper again would be a tautology that stays green
+ * even if the write path stops using the helper.
+ */
+const shimConflictSets: Array<Record<string, unknown>> = [];
+
 function createDbShim() {
   const fluent: Record<string, unknown> = {};
   const proxy: ProxyHandler<typeof fluent> = {
@@ -105,6 +115,12 @@ function createDbShim() {
           // the database without needing a real one.
           if (prop === 'values' && Array.isArray(args[0])) {
             shimInsertedRows.push(...(args[0] as Array<Record<string, unknown>>));
+          }
+          // Record conflict clauses so a test can assert on the SET a write
+          // actually shipped, not on a helper re-invoked inside the test.
+          if (prop === 'onConflictDoUpdate' && args[0] != null && typeof args[0] === 'object') {
+            const { set } = args[0] as { set?: Record<string, unknown> };
+            if (set != null) shimConflictSets.push(set);
           }
           return shim;
         },
@@ -226,6 +242,81 @@ describe('board_climb_holds writes', () => {
       { boardType: 'decoy', climbUuid: 'CLIMB-2', frameNumber: 1, holdId: 100, holdState: 'STARTING' },
       { boardType: 'decoy', climbUuid: 'CLIMB-2', frameNumber: 1, holdId: 300, holdState: 'HAND' },
     ]);
+  });
+});
+
+describe('board_climb_stats fa_username / fa_at sanitization (issue #3536)', () => {
+  beforeEach(() => {
+    mockSharedSync.mockReset();
+    mockPopulateDenormalizedColumns.mockReset();
+    mockPopulateDenormalizedColumns.mockResolvedValue(undefined);
+    shimInsertedRows.length = 0;
+  });
+
+  function climbStat(over: Partial<ReturnType<typeof baseClimbStat>>) {
+    return { ...baseClimbStat(), ...over };
+  }
+
+  function baseClimbStat() {
+    return {
+      climb_uuid: 'CLIMB-STATS',
+      angle: 40,
+      display_difficulty: 20,
+      benchmark_difficulty: 20,
+      ascensionist_count: 5,
+      difficulty_average: 20.1,
+      quality_average: 3,
+      fa_username: 'somebody',
+      fa_at: '2024-03-15T12:34:56.000Z',
+    };
+  }
+
+  it('nulls fa_username/fa_at for a future fa_at (2033 garbage) via the real syncSharedData write path', async () => {
+    mockSharedSync.mockResolvedValueOnce(
+      complete({
+        climb_stats: [climbStat({ climb_uuid: 'CLIMB-FUTURE', fa_at: '2033-01-01T00:00:00.000Z' })],
+      } as Partial<SyncData>),
+    );
+
+    await syncSharedData(fakePostgresClient(), 'decoy', 'token');
+
+    const statsRows = shimInsertedRows.filter(
+      (row) => 'upstreamQualityAverage' in row && row.climbUuid === 'CLIMB-FUTURE',
+    );
+    expect(statsRows).toHaveLength(1);
+    expect(statsRows[0]).toMatchObject({ faUsername: null, faAt: null });
+  });
+
+  it('nulls fa_username/fa_at for a pre-2016 fa_at via the real syncSharedData write path', async () => {
+    mockSharedSync.mockResolvedValueOnce(
+      complete({
+        climb_stats: [climbStat({ climb_uuid: 'CLIMB-PAST', fa_at: '2006-01-01T00:00:00.000Z' })],
+      } as Partial<SyncData>),
+    );
+
+    await syncSharedData(fakePostgresClient(), 'decoy', 'token');
+
+    const statsRows = shimInsertedRows.filter(
+      (row) => 'upstreamQualityAverage' in row && row.climbUuid === 'CLIMB-PAST',
+    );
+    expect(statsRows).toHaveLength(1);
+    expect(statsRows[0]).toMatchObject({ faUsername: null, faAt: null });
+  });
+
+  it('preserves a valid fa_at and fa_username verbatim via the real syncSharedData write path', async () => {
+    mockSharedSync.mockResolvedValueOnce(
+      complete({
+        climb_stats: [climbStat({ climb_uuid: 'CLIMB-VALID' })],
+      } as Partial<SyncData>),
+    );
+
+    await syncSharedData(fakePostgresClient(), 'decoy', 'token');
+
+    const statsRows = shimInsertedRows.filter(
+      (row) => 'upstreamQualityAverage' in row && row.climbUuid === 'CLIMB-VALID',
+    );
+    expect(statsRows).toHaveLength(1);
+    expect(statsRows[0]).toMatchObject({ faUsername: 'somebody', faAt: '2024-03-15T12:34:56.000Z' });
   });
 });
 
@@ -592,6 +683,48 @@ describe('climb conflict policies (SQL)', () => {
     expect(evalUpstreamCoalesce(upSql, null, 100)).toBe(100);
     // A row that never carried a count on either side seeds at 0.
     expect(evalUpstreamCoalesce(upSql, null, null)).toBe(0);
+  });
+
+  it('fa_username / fa_at: the RECORDED stats conflict SET ships bare excluded.* (#3536)', async () => {
+    // Renders the conflict clause captured from the query builder during a
+    // real syncSharedData climb_stats write — NOT the production helper
+    // re-invoked here, which would stay green even if upsertClimbStats
+    // stopped using it. sanitizeFirstAscent runs once, at INSERT-value
+    // construction, so the shipped ON CONFLICT clause must stay a plain
+    // excluded.* with no GREATEST/COALESCE range check drifting out of sync
+    // with the JS-side guard.
+    mockSharedSync.mockReset();
+    mockPopulateDenormalizedColumns.mockReset();
+    mockPopulateDenormalizedColumns.mockResolvedValue(undefined);
+    shimConflictSets.length = 0;
+    mockSharedSync.mockResolvedValueOnce(
+      complete({
+        climb_stats: [
+          {
+            climb_uuid: 'CLIMB-CONFLICT-SET',
+            angle: 40,
+            display_difficulty: 20,
+            benchmark_difficulty: 20,
+            ascensionist_count: 5,
+            difficulty_average: 20.1,
+            quality_average: 3,
+            fa_username: 'somebody',
+            fa_at: '2024-03-15T12:34:56.000Z',
+          },
+        ],
+      } as Partial<SyncData>),
+    );
+
+    await syncSharedData(fakePostgresClient(), 'decoy', 'token');
+
+    // board_climb_stats is the only writer whose conflict set carries fa_at.
+    const statsConflictSets = shimConflictSets.filter(
+      (conflictSet) => 'faAt' in conflictSet && 'faUsername' in conflictSet,
+    );
+    expect(statsConflictSets).toHaveLength(1);
+    const recordedSet = statsConflictSets[0] as { faUsername: SQL; faAt: SQL };
+    expect(render(recordedSet.faUsername)).toBe('excluded.fa_username');
+    expect(render(recordedSet.faAt)).toBe('excluded.fa_at');
   });
 });
 

--- a/packages/aurora-sync/src/sync/shared-sync.ts
+++ b/packages/aurora-sync/src/sync/shared-sync.ts
@@ -32,6 +32,7 @@ import {
   snapshotClimbStatsHistoryIfDue,
 } from '@boardsesh/db/queries';
 import { setterFollows, notifications, userBoardMappings, userFollows } from '@boardsesh/db/schema';
+import { sanitizeFirstAscent } from '@boardsesh/sync-runtime';
 
 // Common ancestor of `PostgresJsDatabase` and the `PgTransaction` Drizzle
 // hands you inside `db.transaction(async (tx) => …)`. Both expose the same
@@ -134,6 +135,24 @@ export function climbStatsUpstreamConflictSet() {
   return {
     upstreamAscensionistCount: sql`COALESCE(excluded.upstream_ascensionist_count, ${climbStatsSchema.upstreamAscensionistCount}, 0)`,
     ascensionistCount: sql`COALESCE(excluded.upstream_ascensionist_count, ${climbStatsSchema.upstreamAscensionistCount}, 0) + COALESCE(${climbStatsSchema.boardseshAscensionistCount}, 0)`,
+  };
+}
+
+/**
+ * Conflict policy for board_climb_stats.fa_username / fa_at on the Aurora
+ * shared sync. Deliberately a bare `excluded.*` — the incoming value is
+ * already sanitized once at INSERT-value construction time (sanitizeFirstAscent,
+ * applied in upsertClimbStats' values.map), so `excluded.*` in this same
+ * statement reflects that sanitized value; no SQL-side range check is needed
+ * or wanted here (see @boardsesh/sync-runtime's sanitizeFirstAscent docs for
+ * why duplicating the range logic in SQL would risk drifting out of sync).
+ * Not exported: the test renders the conflict set RECORDED from the query
+ * builder, not this helper, so it can't drift from what actually ships.
+ */
+function firstAscentConflictSet() {
+  return {
+    faUsername: sql`excluded.fa_username`,
+    faAt: sql`excluded.fa_at`,
   };
 }
 
@@ -510,8 +529,10 @@ async function upsertClimbStats(db: DrizzleDb, board: AuroraBoardName, data: Cli
         // We just normalised quality_average to 1-5, so the row is on the
         // canonical scale — the one-time 1-3→1-5 backfill must skip it.
         qualityNormalized: true,
-        faUsername: item.fa_username,
-        faAt: item.fa_at,
+        // Guard against impossible upstream fa_at values (future/pre-2016
+        // dates) before they reach the INSERT/ON CONFLICT — see
+        // sanitizeFirstAscent for why nulling (not clamping) is correct here.
+        ...sanitizeFirstAscent({ faUsername: item.fa_username, faAt: item.fa_at }),
       };
     });
 
@@ -564,8 +585,9 @@ async function upsertClimbStats(db: DrizzleDb, board: AuroraBoardName, data: Cli
           upstreamQualityAverage: sql`excluded.upstream_quality_average`,
           qualityAverage: blendedQualityAverage,
           qualityNormalized: sql`true`,
-          faUsername: sql`excluded.fa_username`,
-          faAt: sql`excluded.fa_at`,
+          // See firstAscentConflictSet: sanitized once at INSERT-value
+          // construction time, so excluded.* here is already safe.
+          ...firstAscentConflictSet(),
           // Record that an upstream (manufacturer) sync last touched this row.
           upstreamSyncedAt: sql`excluded.upstream_synced_at`,
         },

--- a/packages/db/docker/Dockerfile.dev-db
+++ b/packages/db/docker/Dockerfile.dev-db
@@ -84,13 +84,19 @@ COPY packages/db/tsconfig.json /app/tsconfig.json
 # sharp dep would otherwise break the standalone install. MoonBoard
 # required_set_ids are populated by the backfill, run from the full monorepo
 # against the live DB, not in this image.
+#
+# @boardsesh/sync-runtime (dependency-free; the fa_at range guard used by
+# import-aurora-board-unified, issue #3536) IS loaded at runtime, so like
+# shared-schema it is stripped from package.json and copied straight into
+# node_modules below.
 RUN cd /app && \
-    sed -i -e '/"@boardsesh\/shared-schema"/d' -e '/"@boardsesh\/board-config"/d' -e '/"@boardsesh\/board-constants"/d' -e '/"@boardsesh\/kiosk"/d' -e '/"sharp"/d' package.json && \
+    sed -i -e '/"@boardsesh\/shared-schema"/d' -e '/"@boardsesh\/board-config"/d' -e '/"@boardsesh\/board-constants"/d' -e '/"@boardsesh\/kiosk"/d' -e '/"@boardsesh\/sync-runtime"/d' -e '/"sharp"/d' package.json && \
     curl -fsSL https://bun.sh/install | bash && \
     ln -s /root/.bun/bin/bun /usr/local/bin/bun && \
     ln -s /root/.bun/bin/bunx /usr/local/bin/bunx && \
     bun install --ignore-scripts
 COPY packages/shared-schema/ /app/node_modules/@boardsesh/shared-schema/
+COPY packages/sync-runtime/ /app/node_modules/@boardsesh/sync-runtime/
 
 # Single RUN: download → extract → fix → start PG → import → migrate → stop PG → clean
 RUN set -e && \

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -95,6 +95,7 @@
     "@boardsesh/board-constants": "*",
     "@boardsesh/kiosk": "*",
     "@boardsesh/shared-schema": "*",
+    "@boardsesh/sync-runtime": "*",
     "drizzle-orm": "^0.45.1",
     "postgres": "^3.4.8",
     "uuid": "^13.0.0"

--- a/packages/db/scripts/import-aurora-board-unified.ts
+++ b/packages/db/scripts/import-aurora-board-unified.ts
@@ -33,6 +33,7 @@ import { boardseshTicks } from '../src/schema/app/ascents.js';
 import { recomputeClimbStatsBulk } from '../src/queries/climb-stats/recompute.js';
 import { clearAuroraBoardData, countBoardseshOwnedRows } from '../src/queries/boards/clear-aurora-board.js';
 import { normalizeQualityTo5 } from '@boardsesh/shared-schema';
+import { sanitizeFirstAscent } from '@boardsesh/sync-runtime';
 import { createScriptDb, getScriptDatabaseUrl } from './db-connection.js';
 import {
   dedupeSourceClimbHolds,
@@ -439,8 +440,14 @@ function createImportConfigs(): ImportConfig[] {
         // value, which equals the blend when a climb has no Boardsesh votes.
         upstreamQualityAverage: normalizeQualityTo5(toNullableNumber(row.quality_average)),
         qualityNormalized: true,
-        faUsername: toNullableText(row.fa_username),
-        faAt: toNullableText(row.fa_at),
+        // The Aurora SQLite dumps ship the same impossible fa_at garbage the
+        // live sync does (future / pre-2016 dates, issue #3536) — and this
+        // bulk importer is the most likely origin of the bad prod rows, so it
+        // gets the same guard as the sync writers.
+        ...sanitizeFirstAscent({
+          faUsername: toNullableText(row.fa_username),
+          faAt: toNullableText(row.fa_at),
+        }),
       }),
     },
     {
@@ -458,8 +465,11 @@ function createImportConfigs(): ImportConfig[] {
         ascensionistCount: toNullableNumber(row.ascensionist_count),
         difficultyAverage: toNullableNumber(row.difficulty_average),
         qualityAverage: toNullableNumber(row.quality_average),
-        faUsername: toNullableText(row.fa_username),
-        faAt: toNullableText(row.fa_at),
+        // Same fa_at range guard as climb_stats above (issue #3536).
+        ...sanitizeFirstAscent({
+          faUsername: toNullableText(row.fa_username),
+          faAt: toNullableText(row.fa_at),
+        }),
         createdAt: toNullableText(row.created_at),
       }),
     },

--- a/packages/kilter-sync/src/sync/catalog-stats.test.ts
+++ b/packages/kilter-sync/src/sync/catalog-stats.test.ts
@@ -269,6 +269,64 @@ describe('foldCatalogStat — kilter catalog stat accumulation', () => {
     foldCatalogStat(map, stat({ climbUuid: CANON, angle: 30, ascentCount: 3 }), CANON);
     expect(map.size).toBe(2);
   });
+
+  it('nulls fa_username/fa_at on the canonical-own-row branch for an impossible future date (issue #3536)', () => {
+    const accum = fold({
+      stat: stat({
+        climbUuid: CANON,
+        angle: 40,
+        ascentCount: 1,
+        faUsername: 'somebody',
+        faAt: '2033-01-01T00:00:00.000Z',
+      }),
+      canonical: CANON,
+    });
+    expect(accum.faUsername).toBeNull();
+    expect(accum.faAt).toBeNull();
+  });
+
+  it('nulls fa_username/fa_at on the merge-fill branch for a pre-2016 date (issue #3536)', () => {
+    const accum = fold({
+      stat: stat({
+        climbUuid: MERGED,
+        angle: 40,
+        ascentCount: 1,
+        faUsername: 'somebody',
+        faAt: '2006-01-01T00:00:00.000Z',
+      }),
+      canonical: CANON,
+    });
+    expect(accum.faUsername).toBeNull();
+    expect(accum.faAt).toBeNull();
+  });
+
+  it('preserves a valid fa_at verbatim on both branches (regression guard against over-nulling)', () => {
+    const own = fold({
+      stat: stat({
+        climbUuid: CANON,
+        angle: 40,
+        ascentCount: 1,
+        faUsername: 'goodfa',
+        faAt: '2024-03-15T12:34:56.000Z',
+      }),
+      canonical: CANON,
+    });
+    expect(own.faUsername).toBe('goodfa');
+    expect(own.faAt).toBe('2024-03-15T12:34:56.000Z');
+
+    const merged = fold({
+      stat: stat({
+        climbUuid: MERGED,
+        angle: 30,
+        ascentCount: 1,
+        faUsername: 'mergefa',
+        faAt: '2023-01-01T00:00:00.000Z',
+      }),
+      canonical: CANON,
+    });
+    expect(merged.faUsername).toBe('mergefa');
+    expect(merged.faAt).toBe('2023-01-01T00:00:00.000Z');
+  });
 });
 
 describe('shouldRelistFoldedCanonical — re-list fold decision', () => {

--- a/packages/kilter-sync/src/sync/catalog-sync.ts
+++ b/packages/kilter-sync/src/sync/catalog-sync.ts
@@ -23,6 +23,7 @@ import { KilterApiError } from '../api/errors';
 import { pullKilterReference, type KilterReferencePull } from './reference-pull';
 import { correctGripsQualityAverage } from './quality-scale';
 import { buildLayoutResolver } from './layout-resolver';
+import { sanitizeFirstAscent } from '@boardsesh/sync-runtime';
 import { decodeGripsClimbConcat } from './catalog-parse';
 import {
   buildSkipRow,
@@ -253,14 +254,21 @@ export function foldCatalogStat(
   // (valid grade ids are ~10-33), so treat anything ≤ 1 as "no grade" → null.
   const incomingDisplayDifficulty = guardDifficulty(stat.currentDifficultyId ?? stat.difficultyAverage);
   const incomingDifficultyAverage = guardDifficulty(stat.difficultyAverage);
+  // Guard against impossible upstream fa_at values (future/pre-2016 dates)
+  // before they reach either branch below — see sanitizeFirstAscent for why
+  // nulling (not clamping) is correct here.
+  const { faUsername: sanitizedFaUsername, faAt: sanitizedFaAt } = sanitizeFirstAscent({
+    faUsername: stat.faUsername,
+    faAt: stat.faAt,
+  });
   const isCanonicalOwnRow = stat.climbUuid.toLowerCase() === canonicalUuid.toLowerCase();
   if (isCanonicalOwnRow) {
     // The canonical's own Grips row is authoritative — overwrite.
     accum.displayDifficulty = incomingDisplayDifficulty;
     accum.difficultyAverage = incomingDifficultyAverage;
     accum.qualityAverage = incomingQuality;
-    accum.faUsername = stat.faUsername;
-    accum.faAt = stat.faAt;
+    accum.faUsername = sanitizedFaUsername;
+    accum.faAt = sanitizedFaAt;
     accum.hasOwnRowStats = true;
   } else if (!accum.hasOwnRowStats) {
     // Fingerprint-merged duplicate: fill only the fields the canonical hasn't
@@ -269,8 +277,8 @@ export function foldCatalogStat(
     if (accum.displayDifficulty == null) accum.displayDifficulty = incomingDisplayDifficulty;
     if (accum.difficultyAverage == null) accum.difficultyAverage = incomingDifficultyAverage;
     if (accum.qualityAverage == null) accum.qualityAverage = incomingQuality;
-    if (accum.faUsername == null) accum.faUsername = stat.faUsername;
-    if (accum.faAt == null) accum.faAt = stat.faAt;
+    if (accum.faUsername == null) accum.faUsername = sanitizedFaUsername;
+    if (accum.faAt == null) accum.faAt = sanitizedFaAt;
   }
 }
 
@@ -683,6 +691,11 @@ async function syncBoardLayoutGroup(
             qualityAverage: blendedQuality,
             // Grips quality is natively 1-5, so a written row is always normalized.
             qualityNormalized: sql`true`,
+            // fa_* COALESCE deliberately kept as-is (#3536): the
+            // sanitizeFirstAscent guard in foldCatalogStat only stops NEW
+            // garbage from landing (a nulled incoming value falls through to
+            // the stored one), so an already-poisoned stored fa_at survives
+            // here until the deferred prod cleanup heals it.
             faUsername: sql`COALESCE(excluded.fa_username, ${boardClimbStats.faUsername})`,
             faAt: sql`COALESCE(excluded.fa_at, ${boardClimbStats.faAt})`,
             upstreamSyncedAt: sql`excluded.upstream_synced_at`,

--- a/packages/kilter-sync/src/sync/stats-repair.ts
+++ b/packages/kilter-sync/src/sync/stats-repair.ts
@@ -185,9 +185,10 @@ function statValueFromAccum(accum: StatAccum): RepairStatValue {
     angle: accum.angle,
     displayDifficulty: accum.displayDifficulty,
     difficultyAverage: accum.difficultyAverage,
-    // qualityAverage (Grips' native 1-5, stored verbatim) and difficulty were
-    // range-guarded by foldCatalogStat when this repair accumulated the stat
-    // rows — the repair reads them straight from the accum.
+    // qualityAverage (Grips' native 1-5, stored verbatim), difficulty, and
+    // the fa_* fields (#3536 range guard) were all guarded by foldCatalogStat
+    // when this repair accumulated the stat rows — the repair reads them
+    // straight from the accum.
     qualityAverage: accum.qualityAverage,
     // Corrected manufacturer average also seeds the blend's upstream term.
     upstreamQualityAverage: accum.qualityAverage,
@@ -290,6 +291,11 @@ async function upsertRepairedStats(db: DrizzleDb, statValues: RepairStatValue[])
           upstreamQualityAverage: sql`COALESCE(excluded.upstream_quality_average, ${boardClimbStats.upstreamQualityAverage})`,
           qualityAverage: blendedQuality,
           qualityNormalized: sql`true`,
+          // fa_* COALESCE deliberately kept as-is (#3536): the
+          // sanitizeFirstAscent guard in foldCatalogStat (which built these
+          // values) only stops NEW garbage from landing, so an
+          // already-poisoned stored fa_at survives here until the deferred
+          // prod cleanup heals it.
           faUsername: sql`COALESCE(excluded.fa_username, ${boardClimbStats.faUsername})`,
           faAt: sql`COALESCE(excluded.fa_at, ${boardClimbStats.faAt})`,
           upstreamSyncedAt: sql`excluded.upstream_synced_at`,

--- a/packages/sync-runtime/src/index.ts
+++ b/packages/sync-runtime/src/index.ts
@@ -15,3 +15,5 @@ export {
 export type { UpstreamPlaylistWriteDecision } from './upstream-playlist-ownership';
 export { DaemonLease, DaemonLeaseLostError } from './lease';
 export type { DaemonLeaseIo, DaemonLeaseRuntime } from './lease';
+export { sanitizeFirstAscent, FIRST_ASCENT_EARLIEST_MS } from './sanitize-first-ascent';
+export type { FirstAscentFields } from './sanitize-first-ascent';

--- a/packages/sync-runtime/src/sanitize-first-ascent.test.ts
+++ b/packages/sync-runtime/src/sanitize-first-ascent.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeFirstAscent, FIRST_ASCENT_EARLIEST_MS } from './sanitize-first-ascent';
+
+const NOW = new Date('2026-07-31T00:00:00.000Z');
+
+describe('sanitizeFirstAscent', () => {
+  it('nulls both fields for a future date (e.g. upstream 2033 garbage)', () => {
+    expect(sanitizeFirstAscent({ faUsername: 'someone', faAt: '2033-01-01T00:00:00.000Z' }, NOW)).toEqual({
+      faUsername: null,
+      faAt: null,
+    });
+  });
+
+  it('nulls both fields for a pre-launch date (before any board existed)', () => {
+    expect(sanitizeFirstAscent({ faUsername: 'someone', faAt: '2006-01-01T00:00:00.000Z' }, NOW)).toEqual({
+      faUsername: null,
+      faAt: null,
+    });
+  });
+
+  it('passes through the exact earliest-allowed boundary', () => {
+    const fields = { faUsername: 'someone', faAt: new Date(FIRST_ASCENT_EARLIEST_MS).toISOString() };
+    expect(sanitizeFirstAscent(fields, NOW)).toEqual(fields);
+  });
+
+  it('nulls one millisecond before the earliest-allowed boundary', () => {
+    const oneMsBefore = new Date(FIRST_ASCENT_EARLIEST_MS - 1).toISOString();
+    expect(sanitizeFirstAscent({ faUsername: 'someone', faAt: oneMsBefore }, NOW)).toEqual({
+      faUsername: null,
+      faAt: null,
+    });
+  });
+
+  it('passes through the current moment (no clock skew)', () => {
+    const fields = { faUsername: 'someone', faAt: NOW.toISOString() };
+    expect(sanitizeFirstAscent(fields, NOW)).toEqual(fields);
+  });
+
+  it('nulls a date more than the one-day clock-skew grace window in the future', () => {
+    const twoDaysAhead = new Date(NOW.getTime() + 2 * 24 * 60 * 60 * 1000).toISOString();
+    expect(sanitizeFirstAscent({ faUsername: 'someone', faAt: twoDaysAhead }, NOW)).toEqual({
+      faUsername: null,
+      faAt: null,
+    });
+  });
+
+  it('nulls both fields for an unparseable date string', () => {
+    expect(sanitizeFirstAscent({ faUsername: 'someone', faAt: 'not-a-date' }, NOW)).toEqual({
+      faUsername: null,
+      faAt: null,
+    });
+  });
+
+  it('passes a null faAt through unchanged even with a present faUsername', () => {
+    // Documents that the FA/count-contradiction case (null faAt alongside a
+    // faUsername, or vice versa) is explicitly out of scope for this fix.
+    const fields = { faUsername: 'someone', faAt: null };
+    expect(sanitizeFirstAscent(fields, NOW)).toEqual(fields);
+  });
+
+  it('preserves a valid recent fa_at and fa_username verbatim, without reformatting', () => {
+    const fields = { faUsername: 'climber123', faAt: '2024-03-15T12:34:56.000Z' };
+    expect(sanitizeFirstAscent(fields, NOW)).toEqual(fields);
+    expect(sanitizeFirstAscent(fields, NOW).faAt).toBe('2024-03-15T12:34:56.000Z');
+  });
+});

--- a/packages/sync-runtime/src/sanitize-first-ascent.ts
+++ b/packages/sync-runtime/src/sanitize-first-ascent.ts
@@ -1,0 +1,68 @@
+/**
+ * Guard against impossible `fa_at` / `fa_username` values landing in
+ * `board_climb_stats` from upstream (Aurora / Kilter Grips) catalog syncs.
+ *
+ * Both syncs write these fields verbatim from the upstream payload (see the
+ * comment in aurora-sync's shared-sync.ts on why null must pass through
+ * unchanged — it is how Aurora signals a correction). But upstream data has
+ * shipped occasional garbage: dates decades in the future (e.g. 2033) or
+ * before the boards existed (pre-2016), which then render as a nonsensical
+ * "first ascent" on the climb page (issue #3536).
+ *
+ * This is deliberately a pure, dependency-free helper (mirrors
+ * upstream-playlist-ownership.ts in this package) so both writers can share
+ * one range check instead of duplicating the boundary logic. It only ever
+ * NULLS a bad value — never invents or clamps one, since a clamped date would
+ * be a fabricated fact worse than an honest blank.
+ *
+ * Deliberately out of scope: the FA/count-contradiction cases (a climb with a
+ * `fa_at` but zero recorded ascents, or ascents with no `fa_at`) are a
+ * different bug needing its own reasoning about which side is authoritative
+ * — not addressed here.
+ */
+
+/**
+ * Earliest plausible first-ascent instant (2016-01-01T00:00:00Z), as epoch
+ * milliseconds. A number (not a shared `Date`) on purpose: `Object.freeze`
+ * cannot stop `Date#setTime`-style mutation, so a shared Date would let any
+ * caller silently move the boundary for everyone.
+ *
+ * The bound is chosen for the Aurora-board catalogs these writers ingest —
+ * the earliest Aurora boards date to around 2016, so anything before that is
+ * upstream garbage *for these feeds*. MoonBoard climbs are older (the
+ * original MoonBoard dates to ~2005), but MoonBoard imports don't flow
+ * through these writers today; revisit this bound before routing a MoonBoard
+ * catalog through this guard.
+ */
+export const FIRST_ASCENT_EARLIEST_MS = Date.parse('2016-01-01T00:00:00.000Z');
+
+/** Tolerance for minor upstream/server clock skew so a genuinely-just-sent FA isn't nulled. */
+const FUTURE_GRACE_MS = 24 * 60 * 60 * 1000;
+
+export type FirstAscentFields = {
+  faUsername: string | null;
+  faAt: string | null;
+};
+
+/**
+ * Returns `fields` unchanged when `faAt` is null (a legitimate correction
+ * signal, or the count-contradiction case — explicitly out of scope here) or
+ * parses to a plausible date. Returns both fields nulled together when `faAt`
+ * is unparseable, before the board existed, or further in the future than a
+ * one-day clock-skew grace window allows.
+ */
+export function sanitizeFirstAscent(fields: FirstAscentFields, now: Date = new Date()): FirstAscentFields {
+  if (fields.faAt == null) {
+    return fields;
+  }
+
+  const parsed = new Date(fields.faAt);
+  const parsedMs = parsed.getTime();
+  const latestAllowedMs = now.getTime() + FUTURE_GRACE_MS;
+
+  if (Number.isNaN(parsedMs) || parsedMs < FIRST_ASCENT_EARLIEST_MS || parsedMs > latestAllowedMs) {
+    return { faUsername: null, faAt: null };
+  }
+
+  return fields;
+}


### PR DESCRIPTION
## Summary

Fixes #3536

Climb pages occasionally show a nonsense "first ascent" — a date decades in the future (e.g. 2033) or from before the board existed. Root cause (verified): the upstream Aurora / Kilter Grips catalogs ship these impossible `fa_at` timestamps (they come from unvalidated user-device clocks), and every one of our ingest paths copied `fa_username` / `fa_at` into `board_climb_stats` verbatim, with no range check. The bulk bootstrap importer (`import-aurora-board-unified.ts`, which seeds a board straight from the Aurora SQLite dump) is the most likely origin of the bad rows currently in prod.

This PR is **guard-only**: it stops new garbage from landing. It contains no migration and rewrites no existing data.

### What changed

New pure helper `sanitizeFirstAscent` in `@boardsesh/sync-runtime` (`packages/sync-runtime/src/sanitize-first-ascent.ts`): when `fa_at` is unparseable, earlier than 2016-01-01 (the bound is chosen for the Aurora-board catalogs these writers ingest; MoonBoard imports don't flow through them today), or more than a one-day clock-skew grace window in the future, it nulls `fa_username` and `fa_at` together. It never invents or clamps a date — a clamped date would be a fabricated fact worse than an honest blank. A null `fa_at` passes through untouched (that's Aurora's correction signal).

All four write paths for these columns now run through the guard:

1. **Aurora shared sync** — `packages/aurora-sync/src/sync/shared-sync.ts`, `upsertClimbStats` (sanitized at INSERT-value construction; the `ON CONFLICT` clause stays a bare `excluded.*` that reflects the sanitized value).
2. **Kilter Grips catalog sync** — `packages/kilter-sync/src/sync/catalog-sync.ts`, `foldCatalogStat` (both the canonical-own-row and merge-fill branches).
3. **Kilter Grips stats repair** — `packages/kilter-sync/src/sync/stats-repair.ts` accumulates through the same `foldCatalogStat`, so its values are guarded transitively.
4. **Bulk bootstrap importer** — `packages/db/scripts/import-aurora-board-unified.ts`, both the `climb_stats` and `climb_stats_history` row mappers. This required adding the (dependency-free) `@boardsesh/sync-runtime` workspace dep to `packages/db`, plus the matching strip-list + copy lines in `Dockerfile.dev-db` and a `packages/sync-runtime/**` rebuild trigger in `dev-db-docker.yml`.

The kilter-sync `COALESCE(excluded.fa_at, existing)` conflict clauses are deliberately **unchanged** (now documented inline): the guard only stops new garbage; a nulled incoming value falls through to the stored one, so an already-poisoned row survives until the deferred cleanup below heals it.

### Tests (and fail-on-revert)

- `packages/sync-runtime/src/sanitize-first-ascent.test.ts` — boundary-exact unit tests (earliest bound, ±1 ms, clock-skew grace, unparseable, null pass-through, verbatim preservation).
- `packages/aurora-sync/src/sync/shared-sync.test.ts` — drives the real `syncSharedData` write path through the db shim and asserts the rows that would hit the database; plus a conflict-clause test that renders the `ON CONFLICT ... SET` **recorded from the query builder** (not the helper re-invoked in the test), per the repo's SQL-stub rule.
- `packages/kilter-sync/src/sync/catalog-stats.test.ts` — garbage nulled on both fold branches; valid dates preserved verbatim (over-nulling regression guard).
- Fail-on-revert verified by mutation: deleting the `sanitizeFirstAscent` call in `upsertClimbStats` fails 2 tests; swapping the shipped conflict clause to a `COALESCE` variant fails the recorded-conflict-set test.

## Deferred: prod data cleanup (needs sign-off)

Prod currently holds a small number of already-poisoned rows (~2 by the issue's investigation). This PR intentionally does **not** touch them — no migration, no `UPDATE`. Healing them is a one-off data fix that modifies existing rows, so it is deferred pending explicit maintainer sign-off on the cleanup statement and its scope. Until then, those rows keep rendering as before on their climb pages; every sync/import from now on is guarded.

## QA Notes

No UI surface changed, so there is no dev-server flow to exercise; validation is test-driven:

- `vp check` — 0 errors.
- `vp run typecheck` — clean.
- `vp test run --reporter=agent` on the three touched test files — 59/59 pass.
- `packages/db` script tests (`aurora-board-import-helpers.test.ts`) — pass.
- Paired-QA findings applied on top of the original implementation: (1) the fourth write path (bulk importer) guarded; (2) `FIRST_ASCENT_EARLIEST` doc comment corrected (the 2016 bound is Aurora-catalog-specific, not "no Boardsesh board predates 2016" — MoonBoard is ~2005) and the exported boundary frozen as an epoch-ms number so no caller can mutate a shared `Date`; (3) the near-tautological `bare excluded.*` test rewritten to render the conflict set recorded from the query builder; (4) `COALESCE` conflict semantics kept and documented as intentional.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check` (format + lint, type-aware): 0 errors.
- `vp run typecheck`: exit 0.
- `vp test run --reporter=agent packages/sync-runtime/src/sanitize-first-ascent.test.ts packages/aurora-sync/src/sync/shared-sync.test.ts packages/kilter-sync/src/sync/catalog-stats.test.ts`: 59/59 pass.
- Mutation checks (guard removed / conflict clause drifted) fail the suite as designed.
