### PR TITLE
fix(db): count Aurora's own duplicate ascents once (#3535)

### DIFF
--- a/packages/backend/src/__tests__/aurora-twin-dedup.test.ts
+++ b/packages/backend/src/__tests__/aurora-twin-dedup.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { beforeAll, afterEach, describe, expect, it } from 'vite-plus/test';
-import { sql } from 'drizzle-orm';
+import { sql, type SQL } from 'drizzle-orm';
 import { applyAuroraAscents } from '@boardsesh/aurora-sync/apply-user-logbook';
 import { db } from '../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
@@ -172,6 +172,21 @@ describe('#3535 Aurora-side duplicate ascents', () => {
     expect(counts).toEqual([{ boardType: BOARD, count: 1 }]);
   });
 
+  it('collapses the authenticated `ticks` query too', async () => {
+    await insertTick({ auroraId: 'aur-2' });
+    await insertTick({ auroraId: 'aur-1' });
+
+    // The mobile/web client read, keyed on the connection's own user.
+    const authenticatedContext = { userId: USER_ID, isAuthenticated: true } as unknown as Parameters<
+      typeof tickQueries.ticks
+    >[2];
+    const rows = (await tickQueries.ticks(null, { input: { boardType: BOARD } }, authenticatedContext)) as Array<{
+      auroraId: string | null;
+    }>;
+
+    expect(rows.map((row) => row.auroraId)).toEqual(['aur-1']);
+  });
+
   it('picks the same survivor whatever order the payload arrived in', async () => {
     await insertTick({ auroraId: 'aur-1' });
     await insertTick({ auroraId: 'aur-2' });
@@ -275,10 +290,10 @@ describe('#3535 Aurora-side duplicate ascents', () => {
    * them. `updateTick` writes in place and knows nothing about the group, so
    * the predicate has to absorb this itself.
    */
-  const localEdits: Array<[string, string]> = [
-    ['rated', `quality = 5`],
-    ['commented on', `comment = 'new beta'`],
-    ['re-graded', `difficulty = 24`],
+  const localEdits: Array<[string, SQL]> = [
+    ['rated', sql`quality = 5`],
+    ['commented on', sql`comment = 'new beta'`],
+    ['re-graded', sql`difficulty = 24`],
   ];
 
   for (const [action, assignment] of localEdits) {
@@ -290,9 +305,7 @@ describe('#3535 Aurora-side duplicate ascents', () => {
 
       // What updateTick does: writes the column and bumps updated_at past
       // aurora_synced_at.
-      await db.execute(
-        sql.raw(`UPDATE boardsesh_ticks SET ${assignment}, updated_at = now() WHERE aurora_id = 'aur-1'`),
-      );
+      await db.execute(sql`UPDATE boardsesh_ticks SET ${assignment}, updated_at = now() WHERE aurora_id = ${'aur-1'}`);
 
       expect(await visibleAuroraIds()).toEqual(['aur-1']);
       expect(await feedTotalCount()).toBe(1);

--- a/packages/backend/src/__tests__/aurora-twin-dedup.test.ts
+++ b/packages/backend/src/__tests__/aurora-twin-dedup.test.ts
@@ -1,0 +1,261 @@
+import { beforeAll, afterEach, describe, expect, it } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import { applyAuroraAscents } from '@boardsesh/aurora-sync/apply-user-logbook';
+import { db } from '../db/client';
+import * as dbSchema from '@boardsesh/db/schema';
+import { tickQueries } from '../graphql/resolvers/ticks/queries';
+import { setupWorkerDatabase } from './worker-db';
+
+/**
+ * #3535 — Aurora itself stores some ascents two-to-four times, each copy with
+ * its own real upstream uuid, so the aurora_id-keyed pull imports every copy as
+ * its own tick and the climber's logbook shows one send 2-4×.
+ *
+ * These run against the real worker Postgres because the fix IS a SQL
+ * predicate: a stub that re-states the condition in JS would assert its own
+ * copy of the rule and stay green through any change to the shipped SQL.
+ *
+ * Revert `notAuroraTwinDuplicate` out of the resolvers and the collapse,
+ * survivor-stability, tombstone-promotion and second-cycle read assertions all
+ * fail; loosen the rule to day granularity or drop a payload column from it and
+ * the "keeps genuinely different sends" cases fail.
+ */
+
+const USER_ID = 'twin3535-user';
+const BOARD = 'tension';
+const CLIMB_UUID = 'twin3535-climb-uuid';
+const CLIMB_NAME = 'Twin Test Climb';
+const ANGLE = 40;
+// Millisecond-precision instant: the twins share it exactly.
+const CLIMBED_AT = '2026-05-01T18:22:37.000Z';
+
+type TickOverrides = Partial<typeof dbSchema.boardseshTicks.$inferInsert>;
+
+/** Stable ordering for assertions; a native tick's NULL aurora_id sorts last. */
+function byAuroraId(left: string | null, right: string | null): number {
+  if (left === right) return 0;
+  if (left === null) return 1;
+  if (right === null) return -1;
+  return left < right ? -1 : 1;
+}
+
+let tickSeq = 0;
+
+async function insertTick(overrides: TickOverrides = {}): Promise<void> {
+  tickSeq += 1;
+  await db.insert(dbSchema.boardseshTicks).values({
+    uuid: `twin3535-tick-${tickSeq}`,
+    userId: USER_ID,
+    boardType: BOARD,
+    climbUuid: CLIMB_UUID,
+    angle: ANGLE,
+    isMirror: false,
+    origin: 'aurora_pull',
+    status: 'send',
+    attemptCount: 2,
+    quality: 3,
+    difficulty: 21,
+    isBenchmark: false,
+    comment: 'crimpy',
+    climbedAt: CLIMBED_AT,
+    auroraType: 'ascents',
+    auroraSyncedAt: CLIMBED_AT,
+    ...overrides,
+  });
+}
+
+/** aurora_ids the public per-user tick list (the You page's source) shows. */
+async function visibleAuroraIds(): Promise<Array<string | null>> {
+  const rows = (await tickQueries.userTicks(null, { userId: USER_ID, boardType: BOARD })) as Array<{
+    auroraId: string | null;
+  }>;
+  return rows.map((row) => row.auroraId).sort(byAuroraId);
+}
+
+/** Rows actually stored, regardless of what the read paths show. */
+async function storedAuroraIds(): Promise<string[]> {
+  const rows = await db
+    .select({ auroraId: dbSchema.boardseshTicks.auroraId })
+    .from(dbSchema.boardseshTicks)
+    .where(sql`user_id = ${USER_ID}`);
+  return rows.map((row) => row.auroraId ?? '').sort(byAuroraId);
+}
+
+async function feedTotalCount(): Promise<number> {
+  const feed = await tickQueries.userAscentsFeed(null, { userId: USER_ID, input: { boardType: BOARD } });
+  return feed.totalCount;
+}
+
+beforeAll(async () => {
+  await setupWorkerDatabase();
+  await db.execute(sql`
+    INSERT INTO users (id, email, name, created_at, updated_at)
+    VALUES (${USER_ID}, ${USER_ID + '@test.com'}, 'Twin Tester', now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `);
+  await db.execute(sql`
+    INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, frames, frames_count, is_draft, is_listed, edge_left, edge_right, edge_bottom, edge_top, created_at)
+    VALUES (${CLIMB_UUID}, ${BOARD}, 1, 'test-setter', ${CLIMB_NAME}, 'p1r1', 1, false, true, 0, 100, 0, 150, '2024-01-01')
+    ON CONFLICT (uuid) DO NOTHING
+  `);
+});
+
+afterEach(async () => {
+  await db.execute(sql`DELETE FROM boardsesh_ticks WHERE user_id = ${USER_ID}`);
+});
+
+describe('#3535 Aurora-side duplicate ascents', () => {
+  it('shows one tick per twin group and keeps the lowest aurora_id', async () => {
+    await insertTick({ auroraId: 'aur-3' });
+    await insertTick({ auroraId: 'aur-1' });
+    await insertTick({ auroraId: 'aur-2' });
+
+    expect(await storedAuroraIds()).toEqual(['aur-1', 'aur-2', 'aur-3']);
+    expect(await visibleAuroraIds()).toEqual(['aur-1']);
+    expect(await feedTotalCount()).toBe(1);
+
+    const counts = await tickQueries.userTickCountsByBoard(null, { userId: USER_ID });
+    expect(counts).toEqual([{ boardType: BOARD, count: 1 }]);
+  });
+
+  it('picks the same survivor whatever order the payload arrived in', async () => {
+    await insertTick({ auroraId: 'aur-1' });
+    await insertTick({ auroraId: 'aur-2' });
+    await insertTick({ auroraId: 'aur-3' });
+
+    // created_at is not the tiebreak: here the smallest aurora_id is also the
+    // OLDEST row, in the previous test it was the newest, and both give aur-1.
+    expect(await visibleAuroraIds()).toEqual(['aur-1']);
+  });
+
+  it('collapses the grouped (per-day) feed to one entry too', async () => {
+    await insertTick({ auroraId: 'aur-1' });
+    await insertTick({ auroraId: 'aur-2' });
+
+    const grouped = (await tickQueries.userGroupedAscentsFeed(null, {
+      userId: USER_ID,
+      input: { boardType: BOARD },
+    })) as { groups: Array<{ items: unknown[]; sendCount: number }>; totalCount: number };
+
+    expect(grouped.totalCount).toBe(1);
+    expect(grouped.groups).toHaveLength(1);
+    expect(grouped.groups[0].items).toHaveLength(1);
+    // The per-group tally is built from the same fetch, so it counts once too.
+    expect(grouped.groups[0].sendCount).toBe(1);
+  });
+
+  const differingPayloads: Array<[string, TickOverrides]> = [
+    ['comment', { comment: 'different beta' }],
+    ['quality', { quality: 5 }],
+    ['difficulty', { difficulty: 22 }],
+    ['is_mirror', { isMirror: true }],
+    ['attempt_count', { attemptCount: 7 }],
+    ['status', { status: 'flash' }],
+    ['is_benchmark', { isBenchmark: true }],
+  ];
+
+  for (const [field, overrides] of differingPayloads) {
+    it(`keeps both sends when they differ in ${field}`, async () => {
+      await insertTick({ auroraId: 'aur-1' });
+      await insertTick({ auroraId: 'aur-2', ...overrides });
+
+      expect(await visibleAuroraIds()).toEqual(['aur-1', 'aur-2']);
+      expect(await feedTotalCount()).toBe(2);
+    });
+  }
+
+  it('keeps two sends logged one millisecond apart (no tolerance window)', async () => {
+    await insertTick({ auroraId: 'aur-1', climbedAt: '2026-05-01T18:22:37.000Z' });
+    await insertTick({ auroraId: 'aur-2', climbedAt: '2026-05-01T18:22:37.001Z' });
+
+    expect(await visibleAuroraIds()).toEqual(['aur-1', 'aur-2']);
+  });
+
+  it('keeps two sends of the same climb on the same day', async () => {
+    await insertTick({ auroraId: 'aur-1', climbedAt: '2026-05-01T09:00:00.000Z' });
+    await insertTick({ auroraId: 'aur-2', climbedAt: '2026-05-01T19:30:00.000Z' });
+
+    expect(await visibleAuroraIds()).toEqual(['aur-1', 'aur-2']);
+  });
+
+  it('never hides a native tick, and is never hidden by one', async () => {
+    await insertTick({ auroraId: null, origin: 'native', auroraType: null, auroraSyncedAt: null });
+    await insertTick({ auroraId: 'aur-2' });
+
+    // byAuroraId puts the native row's NULL aurora_id last.
+    expect(await visibleAuroraIds()).toEqual(['aur-2', null]);
+  });
+
+  it('never treats a json-import surrogate id as a real Aurora twin', async () => {
+    await insertTick({ auroraId: 'json-import-aaa', origin: 'json_import' });
+    await insertTick({ auroraId: 'zzz-real-aurora-id' });
+
+    expect(await visibleAuroraIds()).toEqual(['json-import-aaa', 'zzz-real-aurora-id']);
+  });
+
+  it('never hides a second real Kilter link', async () => {
+    await insertTick({ auroraId: 'aur-1', kilterId: 'kil-1' });
+    await insertTick({ auroraId: 'aur-2', kilterId: 'kil-2' });
+
+    expect(await visibleAuroraIds()).toEqual(['aur-1', 'aur-2']);
+  });
+
+  it('promotes the next id when Aurora tombstones the survivor', async () => {
+    await insertTick({ auroraId: 'aur-1' });
+    await insertTick({ auroraId: 'aur-2' });
+    await insertTick({ auroraId: 'aur-3' });
+    expect(await visibleAuroraIds()).toEqual(['aur-1']);
+
+    // The tombstone path deletes the pull-owned row for that aurora_id.
+    await db.execute(sql`DELETE FROM boardsesh_ticks WHERE aurora_id = 'aur-1'`);
+
+    expect(await visibleAuroraIds()).toEqual(['aur-2']);
+    expect(await feedTotalCount()).toBe(1);
+  });
+
+  it('applies the same duplicate payload twice with no second-cycle churn', async () => {
+    const auroraIds = ['aur-b', 'aur-a', 'aur-c'];
+    const payload = auroraIds.map((auroraId) => ({
+      uuid: auroraId,
+      climb_uuid: CLIMB_UUID,
+      angle: ANGLE,
+      is_mirror: false,
+      attempt_id: 2,
+      bid_count: 2,
+      quality: null,
+      difficulty: 21,
+      is_benchmark: false,
+      comment: 'crimpy',
+      climbed_at: '2026-05-01 18:22:37',
+      created_at: '2026-05-01 18:25:00',
+      is_listed: true,
+    }));
+
+    const applyDb = db as unknown as Parameters<typeof applyAuroraAscents>[0];
+
+    await applyAuroraAscents(applyDb, BOARD, USER_ID, payload);
+    const afterFirst = await db
+      .select({ uuid: dbSchema.boardseshTicks.uuid, auroraId: dbSchema.boardseshTicks.auroraId })
+      .from(dbSchema.boardseshTicks)
+      .where(sql`user_id = ${USER_ID}`);
+
+    // Every real aurora_id is stored — the fix hides a twin, it never drops one.
+    expect(afterFirst.map((row) => row.auroraId).sort(byAuroraId)).toEqual(['aur-a', 'aur-b', 'aur-c']);
+    expect(await visibleAuroraIds()).toEqual(['aur-a']);
+
+    // Second cycle: identical payload, as an incremental re-pull would deliver.
+    await applyAuroraAscents(applyDb, BOARD, USER_ID, payload);
+    const afterSecond = await db
+      .select({ uuid: dbSchema.boardseshTicks.uuid, auroraId: dbSchema.boardseshTicks.auroraId })
+      .from(dbSchema.boardseshTicks)
+      .where(sql`user_id = ${USER_ID}`);
+
+    // No re-insert, no resurrection, same row identities: the second cycle is a
+    // no-op. A delete-the-loser fix would fail here — the deleted row's real
+    // aurora_id is a miss on every later pull and comes straight back.
+    expect(afterSecond.map((row) => row.auroraId).sort(byAuroraId)).toEqual(['aur-a', 'aur-b', 'aur-c']);
+    expect(new Set(afterSecond.map((row) => row.uuid))).toEqual(new Set(afterFirst.map((row) => row.uuid)));
+    expect(await visibleAuroraIds()).toEqual(['aur-a']);
+    expect(await feedTotalCount()).toBe(1);
+  });
+});

--- a/packages/backend/src/__tests__/aurora-twin-dedup.test.ts
+++ b/packages/backend/src/__tests__/aurora-twin-dedup.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { beforeAll, afterEach, describe, expect, it } from 'vite-plus/test';
 import { sql } from 'drizzle-orm';
 import { applyAuroraAscents } from '@boardsesh/aurora-sync/apply-user-logbook';
@@ -59,6 +61,11 @@ async function insertTick(overrides: TickOverrides = {}): Promise<void> {
     comment: 'crimpy',
     climbedAt: CLIMBED_AT,
     auroraType: 'ascents',
+    // The pull writes updated_at and aurora_synced_at from one `now()`, so a
+    // freshly pulled row is never "locally edited". Leaving updated_at on its
+    // defaultNow() would make every seeded row look edited and silently switch
+    // off the payload comparison these tests exercise.
+    updatedAt: CLIMBED_AT,
     auroraSyncedAt: CLIMBED_AT,
     ...overrides,
   });
@@ -102,6 +109,53 @@ beforeAll(async () => {
 
 afterEach(async () => {
   await db.execute(sql`DELETE FROM boardsesh_ticks WHERE user_id = ${USER_ID}`);
+});
+
+/**
+ * The predicate is a SQL restatement of `payloadDiffersFromStored`'s column
+ * list, and nothing in the type system pins the two together. Add a
+ * user-visible column to the pull's comparison — the natural place to add one —
+ * and the predicate would keep collapsing rows that now differ in it, hiding a
+ * real ascent with no other test going red. This is the guard for that.
+ */
+describe('#3535 payload column list stays in step with the pull', () => {
+  const repoRoot = fileURLToPath(new URL('../../../../', import.meta.url));
+
+  function sourceOf(relativePath: string): string {
+    return readFileSync(repoRoot + relativePath, 'utf8');
+  }
+
+  function bodyBetween(source: string, startMarker: string, endMarker: string): string {
+    const start = source.indexOf(startMarker);
+    expect(start, `missing marker ${startMarker}`).toBeGreaterThan(-1);
+    const end = source.indexOf(endMarker, start);
+    expect(end, `missing marker ${endMarker}`).toBeGreaterThan(start);
+    return source.slice(start, end);
+  }
+
+  it('compares every column payloadDiffersFromStored compares', () => {
+    const pullBody = bodyBetween(
+      sourceOf('packages/aurora-sync/src/sync/apply-user-logbook.ts'),
+      'function payloadDiffersFromStored',
+      '\n}',
+    );
+    const predicateBody = bodyBetween(
+      sourceOf('packages/db/src/queries/ticks/aurora-twin-dedup.ts'),
+      'export function notAuroraTwinDuplicate',
+      '\n}',
+    );
+
+    const pullColumns = new Set(Array.from(pullBody.matchAll(/\bstored\.(\w+)/g), (match) => match[1]));
+    const predicateColumns = new Set(
+      Array.from(predicateBody.matchAll(/\b(?:ticks|twin)\.(\w+)/g), (match) => match[1]),
+    );
+
+    // Sanity-check the extraction itself before trusting the comparison.
+    expect(pullColumns.size).toBeGreaterThanOrEqual(10);
+
+    const missing = [...pullColumns].filter((column) => !predicateColumns.has(column)).sort();
+    expect(missing, 'columns the pull compares but the twin predicate ignores').toEqual([]);
+  });
 });
 
 describe('#3535 Aurora-side duplicate ascents', () => {
@@ -211,6 +265,101 @@ describe('#3535 Aurora-side duplicate ascents', () => {
 
     expect(await visibleAuroraIds()).toEqual(['aur-2']);
     expect(await feedTotalCount()).toBe(1);
+  });
+
+  /**
+   * Editing the one visible tick drifts its payload away from the twins it is
+   * hiding. `isLocallyEdited` then makes every later pull skip that row, so
+   * payload parity is never restored and a strict payload rule would resurrect
+   * the duplicates permanently — making it look like rating a send created
+   * them. `updateTick` writes in place and knows nothing about the group, so
+   * the predicate has to absorb this itself.
+   */
+  const localEdits: Array<[string, string]> = [
+    ['rated', `quality = 5`],
+    ['commented on', `comment = 'new beta'`],
+    ['re-graded', `difficulty = 24`],
+  ];
+
+  for (const [action, assignment] of localEdits) {
+    it(`stays collapsed after the visible tick is ${action}`, async () => {
+      await insertTick({ auroraId: 'aur-1' });
+      await insertTick({ auroraId: 'aur-2' });
+      await insertTick({ auroraId: 'aur-3' });
+      expect(await visibleAuroraIds()).toEqual(['aur-1']);
+
+      // What updateTick does: writes the column and bumps updated_at past
+      // aurora_synced_at.
+      await db.execute(
+        sql.raw(`UPDATE boardsesh_ticks SET ${assignment}, updated_at = now() WHERE aurora_id = 'aur-1'`),
+      );
+
+      expect(await visibleAuroraIds()).toEqual(['aur-1']);
+      expect(await feedTotalCount()).toBe(1);
+    });
+  }
+
+  it('surfaces a hidden twin that itself diverges, rather than swallowing the change', async () => {
+    await insertTick({ auroraId: 'aur-1' });
+    await insertTick({ auroraId: 'aur-2' });
+    expect(await visibleAuroraIds()).toEqual(['aur-1']);
+
+    // Only the SURVIVOR's local edits relax the payload rule. A hidden row that
+    // diverges is a deliberate difference and must not be silently absorbed.
+    await db.execute(
+      sql`UPDATE boardsesh_ticks SET comment = 'other beta', updated_at = now() WHERE aurora_id = 'aur-2'`,
+    );
+
+    expect(await visibleAuroraIds()).toEqual(['aur-1', 'aur-2']);
+  });
+
+  it('keeps a logged attempt beside a send at the same instant, even once the attempt is edited', async () => {
+    // Aurora's bids land in the same table as its ascents. `status` and
+    // `aurora_type` sit outside the locally-edited relaxation precisely so an
+    // edit on the smaller-id row can never let a send absorb a real attempt.
+    await insertTick({ auroraId: 'aur-1', status: 'attempt', auroraType: 'bids', difficulty: null });
+    await insertTick({ auroraId: 'aur-2' });
+    expect(await visibleAuroraIds()).toEqual(['aur-1', 'aur-2']);
+
+    await db.execute(sql`UPDATE boardsesh_ticks SET quality = 5, updated_at = now() WHERE aurora_id = 'aur-1'`);
+
+    expect(await visibleAuroraIds()).toEqual(['aur-1', 'aur-2']);
+    expect(await feedTotalCount()).toBe(2);
+  });
+
+  it('keeps a bids row beside an ascents row that matches it in every other column', async () => {
+    await insertTick({ auroraId: 'aur-1', auroraType: 'bids' });
+    await insertTick({ auroraId: 'aur-2', auroraType: 'ascents' });
+
+    expect(await visibleAuroraIds()).toEqual(['aur-1', 'aur-2']);
+  });
+
+  it('resurfaces the twins when the survivor is moved off the natural key (recorded behaviour)', async () => {
+    await insertTick({ auroraId: 'aur-1' });
+    await insertTick({ auroraId: 'aur-2' });
+    expect(await visibleAuroraIds()).toEqual(['aur-1']);
+
+    // `updateTick` also accepts `angle` and `climbedAt`. Either moves the
+    // survivor out of the group entirely, so the rows it was hiding come back —
+    // the relaxation only covers payload columns. Recorded, not fixed; see the
+    // known-limitations section of the PR.
+    await db.execute(sql`UPDATE boardsesh_ticks SET angle = ${ANGLE + 5}, updated_at = now() WHERE aurora_id = 'aur-1'`);
+
+    expect(await visibleAuroraIds()).toEqual(['aur-1', 'aur-2']);
+  });
+
+  it('reveals the next twin when the visible tick is deleted (recorded behaviour)', async () => {
+    await insertTick({ auroraId: 'aur-1' });
+    await insertTick({ auroraId: 'aur-2' });
+    expect(await visibleAuroraIds()).toEqual(['aur-1']);
+
+    // deleteTick removes one row. The group is unaware of it, so the next id is
+    // promoted and the entry stays on screen. Known limitation, recorded here
+    // so a future reader does not mistake it for a predicate bug; the honest
+    // fix is a group-aware delete, tracked separately.
+    await db.execute(sql`DELETE FROM boardsesh_ticks WHERE aurora_id = 'aur-1'`);
+
+    expect(await visibleAuroraIds()).toEqual(['aur-2']);
   });
 
   it('applies the same duplicate payload twice with no second-cycle churn', async () => {

--- a/packages/backend/src/__tests__/aurora-twin-dedup.test.ts
+++ b/packages/backend/src/__tests__/aurora-twin-dedup.test.ts
@@ -341,9 +341,10 @@ describe('#3535 Aurora-side duplicate ascents', () => {
 
     // `updateTick` also accepts `angle` and `climbedAt`. Either moves the
     // survivor out of the group entirely, so the rows it was hiding come back —
-    // the relaxation only covers payload columns. Recorded, not fixed; see the
-    // known-limitations section of the PR.
-    await db.execute(sql`UPDATE boardsesh_ticks SET angle = ${ANGLE + 5}, updated_at = now() WHERE aurora_id = 'aur-1'`);
+    // the relaxation only covers payload columns. Recorded, not fixed — #4060.
+    await db.execute(
+      sql`UPDATE boardsesh_ticks SET angle = ${ANGLE + 5}, updated_at = now() WHERE aurora_id = 'aur-1'`,
+    );
 
     expect(await visibleAuroraIds()).toEqual(['aur-1', 'aur-2']);
   });
@@ -356,7 +357,7 @@ describe('#3535 Aurora-side duplicate ascents', () => {
     // deleteTick removes one row. The group is unaware of it, so the next id is
     // promoted and the entry stays on screen. Known limitation, recorded here
     // so a future reader does not mistake it for a predicate bug; the honest
-    // fix is a group-aware delete, tracked separately.
+    // fix is a group-aware delete, tracked in #4059.
     await db.execute(sql`DELETE FROM boardsesh_ticks WHERE aurora_id = 'aur-1'`);
 
     expect(await visibleAuroraIds()).toEqual(['aur-2']);

--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -8,7 +8,7 @@ import {
 } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
-import { toConfidenceTier } from '@boardsesh/db/queries';
+import { toConfidenceTier, notAuroraTwinDuplicate } from '@boardsesh/db/queries';
 import { requireAuthenticated, applyRateLimit, validateInput, isNoMatchClimb } from '../shared/helpers';
 import {
   consensusDifficultyNameExpr,
@@ -92,6 +92,11 @@ function buildAscentTickConditions(validated: AscentFeedFilterInput, userId: str
 
   const conditions = [
     eq(dbSchema.boardseshTicks.userId, userId),
+    // Aurora's own duplicate ascents count once (#3535). Sits in the SHARED
+    // conditions so the page query, the count query and the grouped feed's
+    // per-group tick fetch all collapse the same twins — a feed that showed a
+    // send once but counted it four times would be its own bug.
+    notAuroraTwinDuplicate(dbSchema.boardseshTicks),
     ...(validated.boardType ? [eq(dbSchema.boardseshTicks.boardType, validated.boardType)] : []),
     ...(validated.boardTypes && validated.boardTypes.length > 0 && !validated.boardType
       ? [inArray(dbSchema.boardseshTicks.boardType, validated.boardTypes)]
@@ -221,6 +226,8 @@ export const tickQueries = {
     const conditions = [
       eq(dbSchema.boardseshTicks.userId, userId),
       eq(dbSchema.boardseshTicks.boardType, input.boardType),
+      // Aurora's own duplicate ascents show up once (#3535).
+      notAuroraTwinDuplicate(dbSchema.boardseshTicks),
     ];
 
     if (input.climbUuids && input.climbUuids.length > 0) {
@@ -341,7 +348,14 @@ export const tickQueries = {
   userTicks: async (_: unknown, { userId, boardType }: { userId: string; boardType: string }): Promise<unknown[]> => {
     validateInput(BoardNameSchema, boardType, 'boardType');
 
-    const conditions = [eq(dbSchema.boardseshTicks.userId, userId), eq(dbSchema.boardseshTicks.boardType, boardType)];
+    const conditions = [
+      eq(dbSchema.boardseshTicks.userId, userId),
+      eq(dbSchema.boardseshTicks.boardType, boardType),
+      // Aurora's own duplicate ascents count once (#3535). This resolver feeds
+      // the You page's send totals and grade charts via deriveProfileViewModel,
+      // so a twin left in here inflates every one of those numbers.
+      notAuroraTwinDuplicate(dbSchema.boardseshTicks),
+    ];
 
     // Fetch ticks with layoutId from unified board_climbs table. We surface
     // `difficulty` as the raw user override (preserving the field's pre-fix
@@ -443,7 +457,9 @@ export const tickQueries = {
     const rows = await db
       .select({ boardType: dbSchema.boardseshTicks.boardType, tickCount: count() })
       .from(dbSchema.boardseshTicks)
-      .where(eq(dbSchema.boardseshTicks.userId, userId))
+      // Aurora's own duplicate ascents count once (#3535), so the inferred
+      // default board matches what the logbook actually shows.
+      .where(and(eq(dbSchema.boardseshTicks.userId, userId), notAuroraTwinDuplicate(dbSchema.boardseshTicks)))
       .groupBy(dbSchema.boardseshTicks.boardType);
 
     return rows.map((row) => ({ boardType: row.boardType, count: Number(row.tickCount) }));

--- a/packages/db/src/queries/index.ts
+++ b/packages/db/src/queries/index.ts
@@ -14,4 +14,5 @@ export * from './gyms/index';
 export * from './recommendations/index';
 export * from './grade-model/index';
 export * from './sessions/index';
+export * from './ticks/index';
 export * from './util/rows';

--- a/packages/db/src/queries/ticks/aurora-twin-dedup.ts
+++ b/packages/db/src/queries/ticks/aurora-twin-dedup.ts
@@ -1,0 +1,127 @@
+import { and, eq, isNotNull, not, notExists, or, sql, type Column, type SQL } from 'drizzle-orm';
+import { QueryBuilder, alias } from 'drizzle-orm/pg-core';
+import { boardseshTicks } from '../../schema';
+
+/**
+ * Read-time collapse of Aurora's own duplicate ascents (#3535).
+ *
+ * Aurora sometimes stores ONE ascent two-to-four times, each copy carrying its
+ * own real upstream uuid. The live pull is keyed on `aurora_id`, so every copy
+ * is a legitimate miss and lands as its own `boardsesh_ticks` row: the climber
+ * sees the same send 2-4× in their logbook and their totals count it 2-4×.
+ * Prod measured 11 groups / 25 rows fleet-wide (tension 7/16, kilter 4/9).
+ *
+ * Why this is a READ-side rule and not a write-side one:
+ *
+ *  - Every copy carries a real, still-live `aurora_id`. Deleting a copy cannot
+ *    preserve that id (`boardsesh_ticks_aurora_id_unique` allows one row per
+ *    id), so the next incremental pull sees an `aurora_id` miss and re-inserts
+ *    it — forever. The 0165/0166 dedup migrations only avoid that because they
+ *    MOVE the surrogate id onto the survivor first, which is impossible when
+ *    both sides already hold a real one.
+ *  - Suppressing at read time writes nothing, so the pull stays exactly as
+ *    idempotent as it is today, and no row that Aurora still lists can be lost.
+ *  - It heals every affected climber the moment it ships — no re-sync needed,
+ *    and no backfill touching live rows for a 25-row problem.
+ *
+ * The rule, deliberately narrow:
+ *
+ *  - Both rows must be REAL Aurora-pull rows: `origin = 'aurora_pull'` with a
+ *    non-NULL `aurora_id` that is not one of the JSON importer's synthetic
+ *    `json-import-%` surrogates. A native / imported / Kilter-pulled row is
+ *    never hidden by this rule.
+ *  - Same natural key at the EXACT instant: user, board, climb, angle and a
+ *    literally equal `climbed_at`. No tolerance window — Aurora stores at least
+ *    second precision and two genuine sends of the same climb at the same angle
+ *    in the same second are physically impossible, while two in the same day
+ *    are routine (lapping, projecting, warming up). The cross-source claim's
+ *    `NATURAL_KEY_TOLERANCE_SECONDS` / offset inference exist to reconcile a
+ *    timezone-shifted foreign original and must NOT be reused here: both rows
+ *    came from one source through one normaliser, so there is no offset.
+ *  - Identical payload on every column `payloadDiffersFromStored`
+ *    (packages/aurora-sync/src/sync/apply-user-logbook.ts) compares — mirror,
+ *    status, attempt count, quality, difficulty, benchmark, comment. Aurora
+ *    stored the same ascent verbatim, so requiring this costs nothing on the
+ *    real rows and rules out collapsing a genuine re-log that differs only in,
+ *    say, its comment.
+ *  - Never when BOTH rows carry a real `kilter_id`: that would hide a second
+ *    real Kilter ascent link, the same guard 0166 spells as
+ *    `tw.kilter_id IS NULL OR o.kilter_id IS NULL`.
+ *
+ * The survivor is the row with the lexicographically SMALLEST `aurora_id`.
+ * `created_at` is not usable as a tiebreak: co-arriving duplicates are written
+ * by one chunked INSERT and share a single `now()`, so the winner would fall
+ * out of payload order, and a full re-pull rewrites `created_at` wholesale.
+ * `aurora_id` is a stable upstream property, distinct by unique index, and
+ * identical on every device and every re-sync.
+ *
+ * Tombstones come out right for free: if Aurora deletes the survivor, the pull
+ * deletes that row, the next-smallest `aurora_id` in the group stops matching a
+ * smaller sibling, and the climber still sees exactly one tick.
+ */
+
+type TicksTable = typeof boardseshTicks;
+
+/** Surrogate ids minted by the JSON importer — not real upstream Aurora ids. */
+const SYNTHETIC_AURORA_ID_PATTERN = 'json-import-%';
+
+/**
+ * True for a row that is genuinely owned by the Aurora live pull. Takes the two
+ * columns structurally so it accepts both the base table and the self-join
+ * alias (drizzle bakes the table name into a column's type).
+ */
+function isRealAuroraPullRow(ticks: { origin: Column; auroraId: Column }): SQL {
+  return and(
+    eq(ticks.origin, 'aurora_pull'),
+    isNotNull(ticks.auroraId),
+    sql`${ticks.auroraId} NOT LIKE ${SYNTHETIC_AURORA_ID_PATTERN}`,
+  )!;
+}
+
+/**
+ * WHERE condition that keeps exactly one row per Aurora-side duplicate group.
+ *
+ * Composes as a plain condition, so a list query and its count query pick it up
+ * from the same shared conditions array and can never disagree about how many
+ * ascents there are. Index-backed: the correlated lookup probes
+ * `boardsesh_ticks_user_climb_lookup_idx` (user_id, board_type, angle,
+ * climb_uuid) with equality on all four columns.
+ *
+ * @param ticks the ticks table (or an alias of it) the query selects from.
+ */
+export function notAuroraTwinDuplicate(ticks: TicksTable = boardseshTicks): SQL {
+  const twin = alias(boardseshTicks, 'aurora_twin');
+
+  const smallerTwinExists = new QueryBuilder()
+    .select({ one: sql`1` })
+    .from(twin)
+    .where(
+      and(
+        isRealAuroraPullRow(twin),
+        eq(twin.userId, ticks.userId),
+        eq(twin.boardType, ticks.boardType),
+        eq(twin.climbUuid, ticks.climbUuid),
+        eq(twin.angle, ticks.angle),
+        // Exact instant. `climbed_at` is `timestamp without time zone` on both
+        // sides, written by the same normaliser — a plain `=` is the whole rule.
+        eq(twin.climbedAt, ticks.climbedAt),
+        // Verbatim payload — same column set as payloadDiffersFromStored.
+        sql`COALESCE(${twin.isMirror}, false) = COALESCE(${ticks.isMirror}, false)`,
+        eq(twin.status, ticks.status),
+        eq(twin.attemptCount, ticks.attemptCount),
+        sql`${twin.quality} IS NOT DISTINCT FROM ${ticks.quality}`,
+        sql`${twin.difficulty} IS NOT DISTINCT FROM ${ticks.difficulty}`,
+        sql`COALESCE(${twin.isBenchmark}, false) = COALESCE(${ticks.isBenchmark}, false)`,
+        sql`COALESCE(${twin.comment}, '') = COALESCE(${ticks.comment}, '')`,
+        // Survivor = smallest aurora_id. Strict `<` also makes the row-vs-itself
+        // comparison false, so a group of one always survives.
+        sql`${twin.auroraId} < ${ticks.auroraId}`,
+        // Two distinct real Kilter links are two real upstream ascents; hiding
+        // one would lose a link. Mirrors migration 0166's twin guard.
+        sql`(${twin.kilterId} IS NULL OR ${ticks.kilterId} IS NULL)`,
+      ),
+    );
+
+  // Non-Aurora-pull rows short-circuit before the correlated lookup runs.
+  return or(not(isRealAuroraPullRow(ticks)), notExists(smallerTwinExists))!;
+}

--- a/packages/db/src/queries/ticks/aurora-twin-dedup.ts
+++ b/packages/db/src/queries/ticks/aurora-twin-dedup.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNotNull, not, notExists, or, sql, type Column, type SQL } from 'drizzle-orm';
+import { and, eq, isNotNull, notExists, or, sql, type Column, type SQL } from 'drizzle-orm';
 import { QueryBuilder, alias } from 'drizzle-orm/pg-core';
 import { boardseshTicks } from '../../schema';
 
@@ -43,7 +43,15 @@ import { boardseshTicks } from '../../schema';
  *    status, attempt count, quality, difficulty, benchmark, comment. Aurora
  *    stored the same ascent verbatim, so requiring this costs nothing on the
  *    real rows and rules out collapsing a genuine re-log that differs only in,
- *    say, its comment.
+ *    say, its comment. The one exception, a deliberate widening: once the
+ *    survivor carries a local edit (`updated_at > aurora_synced_at`, the pull's
+ *    own `isLocallyEdited` test), equality on the user-editable columns is
+ *    dropped. Rating or commenting on the visible tick would otherwise un-hide
+ *    its twins, and the pull skips locally-edited rows, so nothing would ever
+ *    restore parity. `status` and `aurora_type` stay OUTSIDE that exception: an
+ *    attempt and a send, or a `bids` row and an `ascents` row, are two
+ *    different upstream facts, and an edited send must never swallow a real
+ *    logged attempt.
  *  - Never when BOTH rows carry a real `kilter_id`: that would hide a second
  *    real Kilter ascent link, the same guard 0166 spells as
  *    `tw.kilter_id IS NULL OR o.kilter_id IS NULL`.
@@ -64,6 +72,15 @@ type TicksTable = typeof boardseshTicks;
 
 /** Surrogate ids minted by the JSON importer — not real upstream Aurora ids. */
 const SYNTHETIC_AURORA_ID_PATTERN = 'json-import-%';
+
+/**
+ * SQL twin of `isLocallyEdited` (apply-user-logbook.ts): the row carries an edit
+ * made here that is newer than its last successful Aurora sync. A NULL
+ * `aurora_synced_at` means the pull is authoritative, so it is not a local edit.
+ */
+function isLocallyEdited(ticks: { updatedAt: Column; auroraSyncedAt: Column }): SQL {
+  return sql`(${ticks.auroraSyncedAt} IS NOT NULL AND ${ticks.updatedAt} > ${ticks.auroraSyncedAt})`;
+}
 
 /**
  * True for a row that is genuinely owned by the Aurora live pull. Takes the two
@@ -97,6 +114,14 @@ export function notAuroraTwinDuplicate(ticks: TicksTable = boardseshTicks): SQL 
     .from(twin)
     .where(
       and(
+        // The outer row must itself be a real Aurora-pull row. Testing it here
+        // rather than as an `or(not(...), notExists(...))` wrapper keeps the
+        // whole condition a plain NOT EXISTS, which Postgres plans as a hash
+        // anti-join; the wrapper form forces a per-row SubPlan and costs ~50×
+        // on the unbounded count/list reads (You page, logbook). Same truth
+        // table: for a non-Aurora-pull outer row the subquery is empty, so
+        // NOT EXISTS is true and the row is kept.
+        isRealAuroraPullRow(ticks),
         isRealAuroraPullRow(twin),
         eq(twin.userId, ticks.userId),
         eq(twin.boardType, ticks.boardType),
@@ -105,14 +130,35 @@ export function notAuroraTwinDuplicate(ticks: TicksTable = boardseshTicks): SQL 
         // Exact instant. `climbed_at` is `timestamp without time zone` on both
         // sides, written by the same normaliser — a plain `=` is the whole rule.
         eq(twin.climbedAt, ticks.climbedAt),
-        // Verbatim payload — same column set as payloadDiffersFromStored.
-        sql`COALESCE(${twin.isMirror}, false) = COALESCE(${ticks.isMirror}, false)`,
+        // Invariants no local edit may bridge. An attempt and a send, or an
+        // `ascents` row and a `bids` row, are two different upstream facts even
+        // at one instant, so they sit OUTSIDE the relaxation below: an edited
+        // send must never be able to swallow a real logged attempt.
         eq(twin.status, ticks.status),
-        eq(twin.attemptCount, ticks.attemptCount),
-        sql`${twin.quality} IS NOT DISTINCT FROM ${ticks.quality}`,
-        sql`${twin.difficulty} IS NOT DISTINCT FROM ${ticks.difficulty}`,
-        sql`COALESCE(${twin.isBenchmark}, false) = COALESCE(${ticks.isBenchmark}, false)`,
-        sql`COALESCE(${twin.comment}, '') = COALESCE(${ticks.comment}, '')`,
+        sql`${twin.auroraType} IS NOT DISTINCT FROM ${ticks.auroraType}`,
+        // Verbatim payload — same column set as payloadDiffersFromStored —
+        // UNLESS the survivor has since been edited here. Rating or commenting
+        // on the one visible tick is the most ordinary thing a climber does with
+        // a logbook entry, and it drifts the survivor's payload away from its
+        // twins; `isLocallyEdited` then makes the pull skip that row forever, so
+        // a strict payload rule would resurrect the duplicates permanently and
+        // make it look like the edit created them. Relaxing it is safe because
+        // the natural key above is the load-bearing guard: two genuine sends of
+        // one climb at one angle at the same instant are physically impossible.
+        // Only the SURVIVOR's edits relax the rule. If the hidden row is the one
+        // that changed, that is a deliberate divergence and it should surface
+        // rather than be swallowed.
+        or(
+          isLocallyEdited(twin),
+          and(
+            sql`COALESCE(${twin.isMirror}, false) = COALESCE(${ticks.isMirror}, false)`,
+            eq(twin.attemptCount, ticks.attemptCount),
+            sql`${twin.quality} IS NOT DISTINCT FROM ${ticks.quality}`,
+            sql`${twin.difficulty} IS NOT DISTINCT FROM ${ticks.difficulty}`,
+            sql`COALESCE(${twin.isBenchmark}, false) = COALESCE(${ticks.isBenchmark}, false)`,
+            sql`COALESCE(${twin.comment}, '') = COALESCE(${ticks.comment}, '')`,
+          ),
+        ),
         // Survivor = smallest aurora_id. Strict `<` also makes the row-vs-itself
         // comparison false, so a group of one always survives.
         sql`${twin.auroraId} < ${ticks.auroraId}`,
@@ -122,6 +168,5 @@ export function notAuroraTwinDuplicate(ticks: TicksTable = boardseshTicks): SQL 
       ),
     );
 
-  // Non-Aurora-pull rows short-circuit before the correlated lookup runs.
-  return or(not(isRealAuroraPullRow(ticks)), notExists(smallerTwinExists))!;
+  return notExists(smallerTwinExists);
 }

--- a/packages/db/src/queries/ticks/aurora-twin-dedup.ts
+++ b/packages/db/src/queries/ticks/aurora-twin-dedup.ts
@@ -152,7 +152,7 @@ export function notAuroraTwinDuplicate(ticks: TicksTable = boardseshTicks): SQL 
           isLocallyEdited(twin),
           and(
             sql`COALESCE(${twin.isMirror}, false) = COALESCE(${ticks.isMirror}, false)`,
-            eq(twin.attemptCount, ticks.attemptCount),
+            sql`${twin.attemptCount} IS NOT DISTINCT FROM ${ticks.attemptCount}`,
             sql`${twin.quality} IS NOT DISTINCT FROM ${ticks.quality}`,
             sql`${twin.difficulty} IS NOT DISTINCT FROM ${ticks.difficulty}`,
             sql`COALESCE(${twin.isBenchmark}, false) = COALESCE(${ticks.isBenchmark}, false)`,

--- a/packages/db/src/queries/ticks/index.ts
+++ b/packages/db/src/queries/ticks/index.ts
@@ -1,0 +1,1 @@
+export * from './aurora-twin-dedup';

--- a/packages/web/app/lib/data/get-logbook.ts
+++ b/packages/web/app/lib/data/get-logbook.ts
@@ -2,6 +2,7 @@ import { dbz } from '@/app/lib/db/db';
 import type { ClimbUuid } from '../types';
 import type { LogbookEntry, AuroraBoardName } from '../api-wrappers/aurora/types';
 import { boardseshTicks, boardClimbAliases } from '@/app/lib/db/schema';
+import { notAuroraTwinDuplicate } from '@boardsesh/db/queries';
 import { eq, and, inArray, desc, sql } from 'drizzle-orm';
 
 /**
@@ -15,7 +16,12 @@ export async function getLogbook(
   userId: string,
   climbUuids?: ClimbUuid[],
 ): Promise<LogbookEntry[]> {
-  const baseConditions = [eq(boardseshTicks.boardType, board), eq(boardseshTicks.userId, userId)];
+  const baseConditions = [
+    eq(boardseshTicks.boardType, board),
+    eq(boardseshTicks.userId, userId),
+    // Aurora's own duplicate ascents appear once (#3535).
+    notAuroraTwinDuplicate(boardseshTicks),
+  ];
 
   if (climbUuids && climbUuids.length > 0) {
     baseConditions.push(inArray(boardseshTicks.climbUuid, climbUuids));


### PR DESCRIPTION
## What & why

Aurora itself stores some ascents more than once — the same climb, the same angle, the same instant, each copy carrying its own real upstream uuid. Our live pull is keyed on `aurora_id`, so every copy is a legitimate miss and lands as its own `boardsesh_ticks` row. The climber then sees one send 2-4× in their logbook, and their totals count it 2-4×.

Measured in prod: **11 groups / 25 rows fleet-wide** (tension 7 groups / 16 rows, kilter 4 / 9).

## Design decision: read-time collapse, no writes, no migration

Two designs were on the table. This PR ships **(b) read-time dedup**.

**(a) write-path marker** — a nullable `aurora_duplicate_of` column set at insert time and honoured by the read paths.
**(b) read-time dedup** — one composable WHERE condition that keeps a single row per duplicate group.

Why (b):

- **Verified first that nothing already dedups.** `userAscentsFeed` (list + count), `userGroupedAscentsFeed`, `userTicks`, `ticks`, `userTickCountsByBoard` and the web `getLogbook` all count every row. The issue's premise holds.
- **(a)'s read-path work is a strict superset of (b)'s.** Both need the same one-condition edit in the same read paths. (a) then _adds_ a migration, a schema-sql mirror, write-path marker computation, and writes against live prod rows — for a 25-row problem.
- **(b) heals everyone the moment it deploys.** A marker only lands when that climber next syncs; someone whose credentials expired keeps their duplicates forever.
- **(b) cannot lose a send.** Nothing is written or deleted; the rule is reversible by a deploy, and the rows stay exactly as they are.
- **Deleting a copy is structurally impossible here** (the verdict's fatal finding, confirmed). `boardsesh_ticks_aurora_id_unique` allows one row per `aurora_id`, so a delete cannot preserve the loser's real id. The next incremental pull sees an `aurora_id` miss and re-inserts it — forever. Migrations 0165/0166 only stay stable because they MOVE the surrogate id onto the survivor first, which requires the original side to hold no real id. In aurora-vs-aurora, both sides do.

Cost of (b): one anti-join against `boardsesh_ticks_user_climb_lookup_idx` (user_id, board_type, angle, climb_uuid), equality on all four columns. The predicate is a **plain `NOT EXISTS`** with the outer row's own `origin = 'aurora_pull'` test folded _inside_ the subquery, and that shape is load-bearing: written as `or(not(isRealAuroraPullRow(ticks)), notExists(...))` the planner cannot use an anti-join and falls back to a per-row SubPlan — measured 3.6 ms → 192 ms on `count(*)` for a 20k-tick user in an 80k-row table, i.e. the You page and the logbook. Folded in, the same count runs in 28 ms. Identical truth table (for a non-Aurora-pull outer row the subquery is empty, so `NOT EXISTS` is true), verified row-by-row over 80k rows: zero disagreements between the two forms.

## The rule

Deliberately narrow. Two rows collapse only when **all** of this holds:

- Both are real Aurora-pull rows: `origin = 'aurora_pull'`, `aurora_id` non-NULL and not a `json-import-%` surrogate.
- Same user, board, climb, angle, and a **literally equal `climbed_at`** — exact instant, no tolerance window. Aurora carries at least second precision; two genuine sends of the same climb at the same angle in the same second are physically impossible, two in the same _day_ are routine. The cross-source claim's `NATURAL_KEY_TOLERANCE_SECONDS` / offset inference exist to reconcile a timezone-shifted _foreign_ original and are deliberately not reused: both rows come from one source through one normaliser.
- Matching `status` and `aurora_type`. Aurora's bids land in the same table as its ascents, so this is the guard that stops a send absorbing a real logged attempt at the same instant. These two sit **outside** the relaxation below.
- Verbatim payload on every column `payloadDiffersFromStored` compares — is_mirror, status, attempt_count, quality, difficulty, is_benchmark, comment — **with one deliberate widening**: once the survivor carries a local edit (`updated_at > aurora_synced_at`, the pull's own `isLocallyEdited` test), equality on the user-editable columns is dropped. Rating or commenting on the one visible tick drifts its payload away from the twins it hides, and `isLocallyEdited` then makes every later pull skip that row, so a strict rule would resurrect the duplicates permanently and make it look like the rating created them. Only the **survivor's** edits relax it; a hidden row that diverges surfaces rather than being swallowed.
- Not when **both** rows carry a real `kilter_id` — that would hide a second real Kilter link (migration 0166's `tw.kilter_id IS NULL OR o.kilter_id IS NULL` guard).

**Survivor = lexicographically smallest `aurora_id`.** Not `created_at`: co-arriving duplicates are written by one chunked INSERT and share a single `now()`, so the winner would fall out of payload order, and a full re-pull rewrites `created_at` wholesale. `aurora_id` is a stable upstream property, distinct by unique index, identical on every device and every re-sync.

Tombstones fall out right for free: if Aurora deletes the survivor, the pull deletes that row and the next-smallest id in the group becomes visible — still exactly one tick.

## Changes

- `packages/db/src/queries/ticks/aurora-twin-dedup.ts` (new) — `notAuroraTwinDuplicate()`, the shared condition, with the whole rationale in the header.
- `packages/backend/src/graphql/resolvers/ticks/queries.ts` — added to `buildAscentTickConditions` (which covers the flat feed's page + count queries **and** the grouped feed's group page, group count and per-group tick fetch), `ticks`, `userTicks` and `userTickCountsByBoard`.
- `packages/web/app/lib/data/get-logbook.ts` — added to the logbook query.

No schema change, no migration, no backfill, no write-path change.

## What this does not fix

- **Deleting a duplicated tick reveals the next copy** — #4059. `deleteTick` removes one row by uuid and knows nothing about the group, so the entry stays on screen and the delete reads as a no-op; clearing it takes one delete per copy. Recorded by a test rather than left to be discovered.
- **Editing the survivor's angle or date resurfaces its copies** — #4060. `UpdateTickInput` accepts `angle` / `climbedAt`, either of which moves the survivor out of the natural key. Also recorded by a test.
- **`syncTicks`** (the offline SQLite mirror) keeps mirroring the table faithfully — filtering it would break the `(updated_at, id)` cursor, since a row that later becomes the survivor never gets a new `updated_at` to be re-delivered on. Nothing user-visible breaks today (only `useLocalPendingTicks` reads that table), but a future local-first logbook read would reintroduce the bug there.
- **`board_climb_stats.quality_average` / `difficulty_average` / `fa_at`** are AVG/MIN over tick rows and still see every duplicate. `boardsesh_ascensionist_count` (COUNT DISTINCT user) and `userProfileStats` (count distinct climb) are unaffected.

Session surfaces are unaffected: pull-inserted rows carry no `session_id`.

## Tests

`packages/backend/src/__tests__/aurora-twin-dedup.test.ts` — 27 cases against the real worker Postgres, because the fix _is_ a SQL predicate and a JS stub would assert its own copy of the rule.

- The authenticated `ticks` query collapses too, not just `userTicks`.
- Twin group of 3 → one visible tick, lowest `aurora_id`, `userAscentsFeed.totalCount` 1, `userTickCountsByBoard` 1, and all 3 rows still stored.
- Same survivor with the insert order reversed (survivor is oldest in one case, newest in the other).
- Grouped feed: one group, one item, `sendCount` 1.
- Keeps both sends when they differ in comment / quality / difficulty / is_mirror / attempt_count / status / is_benchmark (7 cases).
- Keeps two sends 1 ms apart, and two sends 10 h apart on the same day.
- Never hides a native tick, a `json-import-%` surrogate, or a second real `kilter_id`.
- Keeps a logged attempt beside a send at the same instant, even once the attempt carries a local edit; keeps a `bids` row beside an `ascents` row that matches in every other column.
- Stays collapsed after the visible tick is rated / commented on / re-graded (3 cases), and surfaces a hidden twin that itself diverges.
- Survivor tombstoned away → next id promoted, still exactly one tick.
- A source-scanning parity test that extracts the pull's `payloadDiffersFromStored` column list and fails if the predicate ignores one of them — the guard against those two drifting apart.
- Two recorded-behaviour cases pinning the #4059 delete and #4060 re-key limitations above.
- **Two-cycle idempotence**: `applyAuroraAscents` with the same 3-twin payload twice — same three real `aurora_id`s stored, same row uuids, one visible tick after each cycle.

### Fail-on-revert (mutation-verified)

- Predicate forced to `TRUE` (i.e. the fix reverted) → **11 of 27 fail**: collapse + lowest-`aurora_id` survivor, survivor stability under reversed insert order, grouped-feed collapse, tombstone promotion, all three locally-edited cases, the diverging-hidden-twin case, the recorded delete behaviour, and two-cycle idempotence.
- `status` / `aurora_type` guards deleted → **4 fail**, including the attempt-vs-send case and the parity test.
- Match loosened to day granularity → **2 fail**: "1 ms apart" and "same day". This is the rejected design failing loudly.

## QA Notes

Needs a climber whose Aurora logbook contains one of the 11 duplicate groups (query in the issue finds them).

- Open that climber's logbook (web `/you` logbook and the mobile You page): the affected climb appears **once** at that timestamp, not 2-4×.
- Their send total / per-board tick count drops by exactly the duplicate rows for that group.
- Grouped (per-day) logbook view: one entry, `sendCount` reflecting one send.
- Everyone else's logbook and totals are unchanged — sanity-check a climber with same-day repeats of one climb (lapping / projecting): every lap still shows.
- Nothing is deleted: `SELECT count(*) FROM boardsesh_ticks WHERE user_id = '<user>'` is the same before and after deploy.
- Run a sync for that user afterwards; the count stays the same and the logbook still shows one.
- Rate or comment on an Aurora-pulled tick — its copies must stay hidden.
- Watch p95 on `userAscentsFeed` / `userTicks` after deploy; the predicate adds one index-backed anti-join.

## Release Notes

Aurora sometimes filed the same ascent two to four times. Your logbook and your send totals now count it once — every real send is still there, nothing was deleted, and a repeat lap on the same climb still shows up as its own send.

Fixes #3535
