### PR TITLE
test(backend): cover the WebSocket client-IP socket fallback end to end

### DIFF
--- a/packages/backend/src/__tests__/websocket-client-ip-context.test.ts
+++ b/packages/backend/src/__tests__/websocket-client-ip-context.test.ts
@@ -128,6 +128,16 @@ describe('WebSocket connection context client IP', () => {
     expect(context.clientIp).toBe('172.68.1.1');
   });
 
+  it('falls back to the upgrade socket address when no proxy headers are present', async () => {
+    const context = await connectAndReadContext({});
+
+    // The test server listens on 127.0.0.1, so a direct connection carrying no
+    // Cloudflare or forwarded headers must still resolve a keyable identity
+    // rather than undefined — undefined drops the caller back into the
+    // connectionId bucket this fix exists to retire.
+    expect(context.clientIp).toBe('127.0.0.1');
+  });
+
   it('gives two reconnects from one IP the same rate-limit identity', async () => {
     const headers = { 'cf-connecting-ip': '203.0.113.7' };
     const first = await connectAndReadContext(headers);

--- a/packages/backend/src/__tests__/websocket-client-ip.test.ts
+++ b/packages/backend/src/__tests__/websocket-client-ip.test.ts
@@ -138,6 +138,13 @@ describe('normalizeClientIp', () => {
   it('keys the hex form of an IPv4-mapped address as IPv6 instead of dropping it', () => {
     // `::ffff:c000:0201` is a valid IPv6 literal whose tail (`c000:0201`) is not
     // an IP, so the `::ffff:` unwrap must not fire here.
+    //
+    // Accepted consequence: every hex-form IPv4-mapped literal starts with the
+    // same four zero hextets, so they all collapse into the single
+    // `0:0:0:0::/64` bucket. Node renders IPv4-mapped socket addresses in dotted
+    // form and Cloudflare sends dotted `cf-connecting-ip`, so this shape only
+    // reaches us from a hand-forged header — sharing one bucket is the safe
+    // direction (stricter, not looser) for that traffic.
     expect(normalizeClientIp('::ffff:c000:0201')).toBe('0:0:0:0::/64');
   });
 });


### PR DESCRIPTION
## What / why

Follow-up to #4039 (the per-IP anonymous WebSocket rate-limit fix for #2863), which is already on main. Review of that work flagged two gaps in its test coverage; this PR closes both. No production code changes.

**Gap 1 — the socket-address fallback was never exercised end to end.** `websocket-client-ip-context.test.ts` covered the `cf-connecting-ip` and `x-forwarded-for` paths through the real `onConnect`, but not the case where an upgrade carries no proxy headers at all. `resolveWebSocketClientIp` was unit-tested for that branch in isolation, so nothing would have caught the plumbing regressing: if the socket fallback stopped reaching the context, `clientIp` goes `undefined` and the caller drops back into the per-connection `connectionId` bucket that #2863 exists to retire — silently, with every header-carrying test still green.

**Gap 2 — an accepted trade-off was undocumented.** Every hex-form IPv4-mapped literal (`::ffff:c000:0201`) starts with four zero hextets, so they all collapse into one `0:0:0:0::/64` bucket. The existing test asserted the value but its comment only explained why the `::ffff:` unwrap must not fire, not that the result pools those addresses together.

## Fix

- New case in `packages/backend/src/__tests__/websocket-client-ip-context.test.ts`: connect with an empty header bag and assert the context carries `127.0.0.1` (the test HTTP server's listen address).
- Comment on the hex-form case in `packages/backend/src/__tests__/websocket-client-ip.test.ts` recording why the shared bucket is acceptable: Node renders IPv4-mapped socket addresses in dotted form and Cloudflare sends dotted `cf-connecting-ip`, so this shape only arrives from a hand-forged header, and pooling it is the strict direction rather than the loose one.

## Tests

`vp test run --project backend src/__tests__/websocket-client-ip.test.ts src/__tests__/websocket-client-ip-context.test.ts` — 28 passed.

**How the new case fails on revert:** delete `clientIp` from the `createContext({...})` call in `packages/backend/src/websocket/setup.ts` and it goes red with `expected undefined to be '127.0.0.1'`, same as the three cases already in that file. It drives the genuine `setupWebSocketServer` upgrade path, not a hand-called `createContext`.

## QA Notes

Test-only. No runtime behaviour changes, no schema, no UI. Nothing to exercise manually.

## Release Notes

none

Refs #2863
