### PR TITLE
fix(ci): give app.boardsesh.com telemetry and a deploy freeze

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -543,9 +543,16 @@ jobs:
   # detect-changes. No inline Playwright smoke gate — a per-deploy expo-web boot
   # is too heavy here (this file has no such gate for web/backend either); the
   # expo-web-smoke suite stays the dispatch-only gate in e2e-tests.yml.
+  # Manual deploy freeze for app.boardsesh.com, the Cloudflare Pages analogue of
+  # check-rollback. deploy-web and deploy-production-backend both honour a pinned
+  # Vercel Instant Rollback; Pages has no equivalent signal here, so without this
+  # a dashboard rollback of the subdomain is silently clobbered by the next merge
+  # touching packages/mobile, packages/shared, packages/shared-schema, the export
+  # script, or deploy/app-subdomain. Set the repo variable APP_WEB_DEPLOY_HOLD to
+  # any non-empty value to hold the subdomain where it is; clear it to resume.
   deploy-app-web:
     needs: [detect-changes]
-    if: needs.detect-changes.outputs.app_changed == 'true'
+    if: needs.detect-changes.outputs.app_changed == 'true' && vars.APP_WEB_DEPLOY_HOLD == ''
     runs-on: ubuntu-latest
     environment: Production
     steps:
@@ -724,6 +731,34 @@ jobs:
   #         echo "Waiting for staging backend to be healthy..."
   #         sleep 5
   #         docker ps --filter "name=staging-backend" --format "table {{.Names}}\t{{.Status}}"
+
+  # Pings Discord when an app.boardsesh.com deploy was skipped by the freeze.
+  # Without this the hold is invisible: a skipped job just shows grey in the run
+  # summary, so a forgotten APP_WEB_DEPLOY_HOLD would quietly strand the
+  # subdomain on an old bundle. No-ops if DISCORD_DEPLOY_WEBHOOK is unset.
+  notify-app-web-held:
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.app_changed == 'true' && vars.APP_WEB_DEPLOY_HOLD != ''
+    runs-on: ubuntu-latest
+    environment: Production
+    steps:
+      - name: Notify Discord (app.boardsesh.com deploy held)
+        env:
+          DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          if [ -z "$DISCORD_DEPLOY_WEBHOOK" ]; then
+            echo "DISCORD_DEPLOY_WEBHOOK not set — skipping notification"
+            exit 0
+          fi
+          # URL wrapped in <…> so Discord suppresses the inline preview embed.
+          CONTENT=$(printf '🧊 **app.boardsesh.com deploy held** on `%s`\nAPP_WEB_DEPLOY_HOLD is set, so this commit did NOT ship to the browser app. The subdomain stays on its current deployment.\nClear the `APP_WEB_DEPLOY_HOLD` repo variable and re-run to resume.\n<%s>' \
+            "${COMMIT_SHA:0:7}" "$RUN_URL")
+          # allowed_mentions.parse=[] blocks @everyone/@here/role/user pings.
+          jq -n --arg content "$CONTENT" '{content: $content, allowed_mentions: {parse: []}}' \
+            | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
+              echo "::warning::Failed to post Discord notification (see status above)"
 
   # Pings Discord when a deploy ran during an active rollback: the release was
   # built and staged but NOT promoted, so production is still on the pinned

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -35,6 +35,31 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: boardsesh-daemon
 
+  # --- Expo web export (deploy-app-web) -------------------------------------
+  # These are read only by the `expo export` in deploy-app-web, but they live at
+  # workflow level on purpose: scripts/mobile-ci-env-parity.test.ts extracts
+  # workflow-level `env:` (2-space indent) and would not see a job-level block.
+  # They are all public client values — `EXPO_PUBLIC_*` is inlined into the JS
+  # bundle at build time, so none of this is a secret.
+  #
+  # EXPO_PUBLIC_WEB_URL is the AUTH origin and is deliberately www.boardsesh.com,
+  # NOT app.boardsesh.com: the SPA does credentialed cross-origin auth against
+  # www. See docs/expo-web-deployment.md.
+  EXPO_PUBLIC_BACKEND_URL: https://ws.boardsesh.com
+  EXPO_PUBLIC_WS_URL: wss://ws.boardsesh.com/graphql
+  EXPO_PUBLIC_WEB_URL: https://www.boardsesh.com
+  # Same DSN and project as every other mobile workflow, so app.boardsesh.com
+  # reports alongside the native fleet. Until this landed the subdomain shipped
+  # with no client telemetry at all: both SDKs gate on these vars being present
+  # at BUILD time (sentry.ts `isSentryEnabled`, posthog-client.ts
+  # `isAnalyticsEnabled`), and deploy-app-web set neither.
+  EXPO_PUBLIC_SENTRY_DSN: https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400
+  EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+  # Separates browser-app events from the native fleet in both SDKs. `environment`
+  # is init-only, so this build-time var is the only place it can be set
+  # (src/lib/app-environment.ts `resolveAppEnvironment`).
+  EXPO_PUBLIC_SENTRY_ENVIRONMENT: production-web
+
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
@@ -532,26 +557,31 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build standalone Expo web export (production env baked in)
-        # EXPO_PUBLIC_WEB_URL is the AUTH origin and is deliberately
-        # www.boardsesh.com, NOT app.boardsesh.com: the SPA does credentialed
-        # cross-origin auth against www. See docs/expo-web-deployment.md.
+        # The EXPO_PUBLIC_* values come from the workflow-level `env:` block
+        # (see the header) so mobile-ci-env-parity can read them; the export
+        # inherits them, no per-step re-declaration needed.
         #
         # BOARDSESH_EXPORT_EXPECT_URLS is inert until sibling PR #3797 lands the
         # `--clear` + env-assertion support; once it does, it becomes the
         # in-export stale-env detector. The independent grep step below covers us
         # regardless of merge order.
         run: |
-          EXPO_PUBLIC_BACKEND_URL=https://ws.boardsesh.com \
-          EXPO_PUBLIC_WS_URL=wss://ws.boardsesh.com/graphql \
-          EXPO_PUBLIC_WEB_URL=https://www.boardsesh.com \
           BOARDSESH_EXPORT_EXPECT_URLS="https://ws.boardsesh.com https://www.boardsesh.com" \
           bash scripts/build-expo-web-export.sh --subdomain "$RUNNER_TEMP/app-standalone"
 
-      - name: Verify production origins are baked into the bundles
+      - name: Verify production origins and telemetry keys are baked into the bundles
         # Belt-and-braces stale-env guard, independent of #3797's
         # BOARDSESH_EXPORT_EXPECT_URLS. `expo export` reuses Metro's transform
         # cache even when EXPO_PUBLIC_* change, so an old env can silently ship;
-        # grep the emitted JS bundles for both prod origins and fail otherwise.
+        # grep the emitted JS bundles for each expected value and fail otherwise.
+        #
+        # The telemetry keys are checked here for the same reason the origins
+        # are: EXPO_PUBLIC_* are inlined at build time, so "the workflow set it"
+        # and "the bundle contains it" are different claims. This step asserts
+        # the second. It does NOT prove either SDK initialises under
+        # react-native-web — that needs the preview check in the PR body.
+        env:
+          POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
         run: |
           set -euo pipefail
           js_glob="$RUNNER_TEMP/app-standalone/_expo/static/js/web"
@@ -562,6 +592,30 @@ jobs:
             fi
             echo "ok: found '$origin' in the emitted bundles"
           done
+
+          # Sentry: match the DSN's ingest host, not the whole DSN, so the log
+          # never echoes the key portion.
+          if ! grep -rql "o4510644927660032.ingest.us.sentry.io" "$js_glob"/*.js; then
+            echo "::error::Sentry DSN not baked into the export — app.boardsesh.com would ship with no crash reporting." >&2
+            exit 1
+          fi
+          echo "ok: found the Sentry ingest host in the emitted bundles"
+
+          if [ -z "${POSTHOG_KEY:-}" ]; then
+            echo "::error::vars.NEXT_PUBLIC_POSTHOG_KEY is unset — the export would ship with analytics disabled." >&2
+            exit 1
+          fi
+          if ! grep -rql "$POSTHOG_KEY" "$js_glob"/*.js; then
+            echo "::error::PostHog key not baked into the export — app.boardsesh.com would ship with no analytics." >&2
+            exit 1
+          fi
+          echo "ok: found the PostHog key in the emitted bundles"
+
+          if ! grep -rql "production-web" "$js_glob"/*.js; then
+            echo "::error::EXPO_PUBLIC_SENTRY_ENVIRONMENT not baked in — app events would be indistinguishable from the native fleet." >&2
+            exit 1
+          fi
+          echo "ok: found the production-web environment tag in the emitted bundles"
 
       - name: Add Cloudflare Pages host config to the export
         # _redirects (SPA fallback) + _headers (noindex/caching/no-CSP) are host

--- a/docs/expo-web-deployment.md
+++ b/docs/expo-web-deployment.md
@@ -104,6 +104,60 @@ redirect allow-list accepts only the configured app origin and numbered app
 previews, and the shared `.boardsesh.com` session cookie is available when the
 Expo export reloads.
 
+### Telemetry (baked at build time)
+
+`deploy-app-web` builds the export with `EXPO_PUBLIC_SENTRY_DSN`,
+`EXPO_PUBLIC_POSTHOG_KEY` and `EXPO_PUBLIC_SENTRY_ENVIRONMENT=production-web`
+set in `production-deploy.yml`'s **workflow-level** `env:` block.
+
+These are not optional and they are not runtime config. `EXPO_PUBLIC_*` values
+are inlined into the JS bundle by `expo export`, and both SDKs decide whether
+they are enabled at module load from the baked value — `isSentryEnabled`
+(`packages/mobile/src/lib/sentry.ts`) and `isAnalyticsEnabled`
+(`packages/mobile/src/lib/posthog-client.ts`). Drop either key and the deploy
+still succeeds; it just publishes a production browser app with crash reporting
+or analytics silently off.
+
+Two constraints on where they live:
+
+- **Workflow level, not job level.** `scripts/mobile-ci-env-parity.test.ts`
+  extracts workflow-level `env:` at 2-space indent; a job-level block is
+  invisible to it, and the test guarding these three keys would pass over a
+  workflow that had quietly dropped them.
+- **`production-web`, not `production`.** `environment` is init-only in both
+  SDKs, so this build-time value is the only thing separating browser-app events
+  from the native fleet in Sentry and PostHog.
+
+The deploy greps the emitted bundles for both keys and the environment tag and
+fails if any is missing — `expo export` reuses Metro's transform cache across
+env changes, so "the workflow set it" and "the bundle contains it" are separate
+claims.
+
+Neither SDK has a `.web.ts` fork or a `WEB_SHIM_MODULES` entry, so the
+react-native builds run as-is under react-native-web. If either turns out not to
+initialise there, the fork target is `@sentry/browser` + `posthog-js-lite` — the
+pair the classic web app already uses.
+
+### Freezing the subdomain deploy
+
+`deploy-web` and `deploy-production-backend` honour `check-rollback`, which
+detects a pinned Vercel Instant Rollback and stages instead of promoting.
+Cloudflare Pages has no equivalent signal, so `deploy-app-web` gates on a repo
+variable instead:
+
+- Set **`APP_WEB_DEPLOY_HOLD`** to any non-empty value to hold
+  `app.boardsesh.com` at its current deployment. Without it, a Pages dashboard
+  rollback is clobbered by the next merge touching `packages/mobile`,
+  `packages/shared`, `packages/shared-schema`,
+  `scripts/build-expo-web-export.sh`, or `deploy/app-subdomain`.
+- Clear the variable to resume. Nothing queues while held — the next qualifying
+  merge deploys.
+- A held run posts to the Discord deploy channel, because a skipped job is only
+  grey in the run summary and a forgotten hold would otherwise strand the
+  browser app on an old bundle.
+- `notify-failure` fires on `failure`/`cancelled` only, so a held (skipped) job
+  raises no false alarm.
+
 ### Infra follow-ups (not provisioned here)
 
 These are DNS / hosting operations outside this repo's build:

--- a/scripts/mobile-ci-env-parity.test.ts
+++ b/scripts/mobile-ci-env-parity.test.ts
@@ -85,6 +85,43 @@ function workflowEnvValue(source: string, key: string): string | null {
   return match ? match[1] : null;
 }
 
+// The standalone Expo web export (app.boardsesh.com) is deliberately NOT in the
+// fingerprint-parity list above: it is a browser bundle and never enters the
+// native fingerprint graph, so locking its env to the native builds would be
+// meaningless. It has its own, narrower contract — the telemetry keys must be
+// present at BUILD time, because `EXPO_PUBLIC_*` is inlined into the JS bundle
+// and both SDKs latch their enablement off these vars at module load
+// (src/lib/sentry.ts `isSentryEnabled`, src/lib/posthog-client.ts
+// `isAnalyticsEnabled`). Omitting them does not fail the deploy — it ships a
+// production browser app with crash reporting and analytics silently off, which
+// is exactly what happened until these were added.
+describe('Expo web export telemetry (app.boardsesh.com)', () => {
+  const PRODUCTION_DEPLOY = 'production-deploy.yml';
+
+  it.each(['EXPO_PUBLIC_SENTRY_DSN', 'EXPO_PUBLIC_POSTHOG_KEY', 'EXPO_PUBLIC_SENTRY_ENVIRONMENT'])(
+    'declares %s at workflow level in production-deploy.yml',
+    (key) => {
+      // Workflow level (2-space indent) specifically: a job-level block is
+      // invisible to workflowEnvValue, and moving these into deploy-app-web
+      // would silently blind this test.
+      expect(workflowEnvValue(readWorkflow(PRODUCTION_DEPLOY), key)).not.toBeNull();
+    },
+  );
+
+  it('tags the browser app with its own Sentry/PostHog environment', () => {
+    // `environment` is init-only in both SDKs, so this build-time value is the
+    // only thing separating browser-app events from the native fleet.
+    expect(workflowEnvValue(readWorkflow(PRODUCTION_DEPLOY), 'EXPO_PUBLIC_SENTRY_ENVIRONMENT')).toBe('production-web');
+  });
+
+  it('reports to the same Sentry project as the native workflows', () => {
+    // One project for all three SDKs (see docs) — a divergent DSN here would
+    // split the browser app off into its own project without anyone noticing.
+    const dsn = workflowEnvValue(readWorkflow(PRODUCTION_DEPLOY), 'EXPO_PUBLIC_SENTRY_DSN');
+    expect(dsn).toBe(workflowEnvValue(readWorkflow(NATIVE_ANDROID), 'EXPO_PUBLIC_SENTRY_DSN'));
+  });
+});
+
 describe('mobile CI env parity (OTA fingerprint invariant)', () => {
   // The PR-time OTA-compat check + the per-PR preview publish resolve the same
   // fingerprint as the native builds + OTA publish, so they must share the same


### PR DESCRIPTION
First PRs of the Expo Web Program phases 4–6 (Next.js scope-down / SEO move / web-only tail). Both are safety rails on `deploy-app-web` — no product code, no deletes.

Combines W-01 and W-02 from the plan. They were scoped as two PRs, but both edit `production-deploy.yml` and W-02 is 30 lines, so a stacked split would buy a rebase burden and no reviewer benefit. Two clean commits instead.

## The browser app has been shipping with no telemetry

`deploy-app-web` set four `EXPO_PUBLIC_*` values inline in the build step, and neither `EXPO_PUBLIC_SENTRY_DSN` nor `EXPO_PUBLIC_POSTHOG_KEY` — while all six mobile workflows set both. Those vars are inlined into the JS bundle at build time, and both SDKs gate on them being present _then_:

- `packages/mobile/src/lib/sentry.ts` — `isSentryEnabled = !!sentryDsn && !__DEV__`
- `packages/mobile/src/lib/posthog-client.ts` — `isAnalyticsEnabled = !!apiKey && !__DEV__`

So every production deploy of `app.boardsesh.com` has gone out with crash reporting and analytics both off. That is also why the subdomain has never appeared in the Sentry or PostHog data next to the native fleet.

This moves the export's env to a **workflow-level** block and adds the two keys plus `EXPO_PUBLIC_SENTRY_ENVIRONMENT: production-web`, which separates browser-app events from the native fleet in both SDKs (`environment` is init-only, so the build-time var is the only place it can be set — `src/lib/app-environment.ts`).

Workflow level rather than job level is deliberate: `scripts/mobile-ci-env-parity.test.ts` extracts workflow-level `env:` at 2-space indent (`^ {2}KEY:`) and cannot see a job-level block. Everything in there is a public client value — `EXPO_PUBLIC_*` is inlined into the bundle, so none of it is a secret.

That test now guards these three keys, in its own `describe` rather than the fingerprint-parity list. The distinction matters: the web export is a browser bundle and never enters the native fingerprint graph, so locking its env to the native builds would be meaningless. Its contract is narrower — the keys must exist at build time, the environment must be `production-web`, and the DSN must match the native workflows so all three SDKs stay in one Sentry project. Verified by mutation: deleting `EXPO_PUBLIC_SENTRY_DSN` from the workflow turns two of the new assertions red.

The stale-env grep now also asserts both keys and the environment tag actually landed in the emitted bundles. "The workflow set it" and "the bundle contains it" are different claims, and `expo export` reuses Metro's transform cache across env changes. The Sentry assertion matches the DSN's ingest host rather than the whole DSN so the log never echoes the key portion.

## A deploy freeze for the subdomain

`deploy-web` and `deploy-production-backend` both honour `check-rollback`, which detects a pinned Vercel Instant Rollback and stages instead of promoting. Cloudflare Pages has no equivalent signal here, and `deploy-app-web` gated only on `detect-changes` — so a Pages dashboard rollback was silently clobbered by the next merge touching `packages/mobile`, `packages/shared`, `packages/shared-schema`, the export script, or `deploy/app-subdomain`.

Set the `APP_WEB_DEPLOY_HOLD` repo variable to hold the subdomain where it is; clear it to resume. A held run pings Discord, because a skipped job is just grey in the run summary and a forgotten hold would strand the browser app on an old bundle with nobody noticing.

## What a reviewer should check

- The two keys and `production-web` appear in the emitted bundles on the next deploy (the new grep step fails the job if not).
- **Still unverified, and the reason this is worth watching on the first deploy:** neither `@sentry/react-native` nor `posthog-react-native` is in `metro.config.js`'s `WEB_SHIM_MODULES`, and there are no `.web.ts` forks for either. Until now the missing keys meant neither SDK ever tried to initialise in the browser build, so whether they initialise cleanly under react-native-web is genuinely untested. If the first deploy shows an init error in the browser console, the fix is `.web.ts` forks over `@sentry/browser` + `posthog-js-lite` — the same pair the classic web app already uses. Nothing here can break the app shell, since both SDKs are already bundled today and only the gate flips.
- With `APP_WEB_DEPLOY_HOLD` set, a merge touching `packages/mobile/**` skips `deploy-app-web` and posts to Discord; with it unset, the job runs exactly as before.
- `notify-failure` fires on `failure` or `cancelled` only, and a held job is `skipped`, so the freeze raises no false alarm.

One thing to know for sequencing: `Dockerfile.web` sets `EXPO_PUBLIC_WEB_URL` from its own `BASE_URL` build arg, inside the container. The workflow-level env added here does not reach it, so today's Vercel `build-web` is unaffected. That interaction becomes live if #3795 moves production web onto `Dockerfile.web`, which is why the plan sequences the `/app` prod-static retirement before it.

## Release Notes

none
