### PR TITLE
fix(mobile): stop the V-Points line overshooting week-to-week data

### DIFF
--- a/packages/mobile/src/components/you/YouCharts.tsx
+++ b/packages/mobile/src/components/you/YouCharts.tsx
@@ -716,11 +716,7 @@ export const TotalAreaChart = memo(function TotalAreaChart({
             endOpacity={colorScheme === 'dark' ? 0.1 : 0.04}
             gradientDirection="vertical"
             thickness={2}
-            // Cardinal-spline curving (gifted-charts' `curved`) can overshoot past a
-            // data point's y-value between two neighbours, making a flat or dipping
-            // week look like it rose. The weekly cadence is evenly spaced already,
-            // so a straight-segment line reads just as smoothly without the
-            // overshoot (#3780).
+            // Straight segments avoid gifted-charts' cardinal-spline overshoot (#3780).
             curved={false}
             maxValue={model.maxValue}
             noOfSections={model.sections}

--- a/packages/mobile/src/components/you/YouCharts.tsx
+++ b/packages/mobile/src/components/you/YouCharts.tsx
@@ -716,8 +716,12 @@ export const TotalAreaChart = memo(function TotalAreaChart({
             endOpacity={colorScheme === 'dark' ? 0.1 : 0.04}
             gradientDirection="vertical"
             thickness={2}
-            curved
-            curvature={0.2}
+            // Cardinal-spline curving (gifted-charts' `curved`) can overshoot past a
+            // data point's y-value between two neighbours, making a flat or dipping
+            // week look like it rose. The weekly cadence is evenly spaced already,
+            // so a straight-segment line reads just as smoothly without the
+            // overshoot (#3780).
+            curved={false}
             maxValue={model.maxValue}
             noOfSections={model.sections}
             yAxisLabelTexts={model.yAxisLabelTexts}

--- a/packages/mobile/src/components/you/__tests__/you-charts-line-interpolation.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/you-charts-line-interpolation.test.tsx
@@ -8,7 +8,7 @@
 // render straight segments (`curved={false}`) with no leftover `curvature`.
 import { createElement, useEffect, type ReactNode } from 'react';
 import { render } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { RawVPointsTimeline } from '@boardsesh/profile-stats';
 
 const FRAME_WIDTH = 320;
@@ -31,12 +31,13 @@ vi.mock('react-i18next', () => ({
 
 type LineChartCall = { curved?: boolean; curvature?: number; width?: number };
 
-const lineChartCalls: LineChartCall[] = [];
+// Hoist the mock so vi.mock's hoisted factory can access it.
+const { lineChartMock } = vi.hoisted(() => ({ lineChartMock: vi.fn<(props: LineChartCall) => void>() }));
 
 vi.mock('react-native-gifted-charts', () => ({
   BarChart: () => createElement('div', { 'data-testid': 'gifted-bar-chart' }),
   LineChart: (props: LineChartCall) => {
-    lineChartCalls.push(props);
+    lineChartMock(props);
     return createElement('div', { 'data-testid': 'gifted-line-chart' });
   },
 }));
@@ -92,18 +93,22 @@ vi.mock('../profile-chart-colors', () => ({
 import { TotalAreaChart } from '../YouCharts';
 
 describe('TotalAreaChart line interpolation (#3780)', () => {
+  // V-points data is cumulative, so the fixture must be monotonically non-decreasing.
   const timeline: RawVPointsTimeline = {
     weekLabels: ['W1', 'W2', 'W3', 'W4'],
-    series: [{ layoutKey: 'kilter-1', displayName: 'Kilter Original', data: [10, 12, 9, 20] }],
-    totalPoints: 20,
+    series: [{ layoutKey: 'kilter-1', displayName: 'Kilter Original', data: [10, 22, 31, 51] }],
+    totalPoints: 51,
   };
 
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('renders straight segments instead of an overshooting curve', () => {
-    lineChartCalls.length = 0;
     render(<TotalAreaChart timeline={timeline} color="#7c3aed" />);
 
-    expect(lineChartCalls).toHaveLength(1);
-    const call = lineChartCalls[0]!;
+    expect(lineChartMock).toHaveBeenCalledTimes(1);
+    const call = lineChartMock.mock.calls[0]![0];
     expect(call.curved).toBe(false);
     expect(call.curvature).toBeUndefined();
   });

--- a/packages/mobile/src/components/you/__tests__/you-charts-line-interpolation.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/you-charts-line-interpolation.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+//
+// Regression coverage for #3780: the V-Points area chart used gifted-charts'
+// cardinal-spline `curved` interpolation, which can overshoot past a data
+// point's y-value between two neighbours — making a flat or dipping week
+// look like it rose (or vice versa). This repo has no visual regression
+// harness, so this test pins the prop contract instead: the LineChart must
+// render straight segments (`curved={false}`) with no leftover `curvature`.
+import { createElement, useEffect, type ReactNode } from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { RawVPointsTimeline } from '@boardsesh/profile-stats';
+
+const FRAME_WIDTH = 320;
+
+vi.mock('react-native', () => ({
+  View: ({ children, onLayout }: { children?: ReactNode; onLayout?: (event: unknown) => void }) => {
+    useEffect(() => {
+      onLayout?.({ nativeEvent: { layout: { width: FRAME_WIDTH, height: 160, x: 0, y: 0 } } });
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- fire once on mount, matching a real layout pass
+    }, []);
+    return createElement('div', null, children);
+  },
+  Pressable: ({ children }: { children?: ReactNode }) => createElement('button', { type: 'button' }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+type LineChartCall = { curved?: boolean; curvature?: number; width?: number };
+
+const lineChartCalls: LineChartCall[] = [];
+
+vi.mock('react-native-gifted-charts', () => ({
+  BarChart: () => createElement('div', { 'data-testid': 'gifted-bar-chart' }),
+  LineChart: (props: LineChartCall) => {
+    lineChartCalls.push(props);
+    return createElement('div', { 'data-testid': 'gifted-line-chart' });
+  },
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({
+  Icon: () => createElement('span', { 'data-testid': 'icon' }),
+}));
+vi.mock('../../ActivityIndicator', () => ({
+  ActivityIndicator: () => createElement('span', { 'data-testid': 'activity-indicator' }),
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    variant: 'material' as const,
+    colorScheme: 'light' as const,
+    systemColors: {
+      secondaryLabel: '#666666',
+      tertiaryLabel: '#999999',
+      elevatedSurface: '#ffffff',
+      separator: '#dddddd',
+      label: '#111111',
+    },
+    chartColors: {
+      secondaryLabel: '#666666',
+      tertiaryLabel: '#999999',
+      elevatedSurface: '#ffffff',
+      separator: '#dddddd',
+      label: '#111111',
+    },
+  }),
+}));
+
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 0: 0, 1: 4, 2: 8, 3: 12, 4: 16 },
+  borderRadius: { full: 999, xl: 16 },
+  opacity: { peek: 0.5 },
+  materialElevationByLevel: { level2: {} },
+}));
+
+vi.mock('../../../lib/haptics', () => ({
+  hapticSelection: vi.fn(),
+}));
+
+vi.mock('../profile-chart-colors', () => ({
+  gradeChartColor: (key: string) => `grade-${key}`,
+  layoutChartColor: (key: string) => `layout-${key}`,
+  flashRedpointColor: (key: string) => `status-${key}`,
+}));
+
+import { TotalAreaChart } from '../YouCharts';
+
+describe('TotalAreaChart line interpolation (#3780)', () => {
+  const timeline: RawVPointsTimeline = {
+    weekLabels: ['W1', 'W2', 'W3', 'W4'],
+    series: [{ layoutKey: 'kilter-1', displayName: 'Kilter Original', data: [10, 12, 9, 20] }],
+    totalPoints: 20,
+  };
+
+  it('renders straight segments instead of an overshooting curve', () => {
+    lineChartCalls.length = 0;
+    render(<TotalAreaChart timeline={timeline} color="#7c3aed" />);
+
+    expect(lineChartCalls).toHaveLength(1);
+    const call = lineChartCalls[0]!;
+    expect(call.curved).toBe(false);
+    expect(call.curvature).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- The V-Points chart on You → Progress (`TotalAreaChart` in `packages/mobile/src/components/you/YouCharts.tsx`) rendered its line with gifted-charts' cardinal-spline `curved`/`curvature={0.2}` interpolation. That algorithm can swing the curve past a real data point's y-value between two neighbouring weeks.
- The V-Points series is a **cumulative running total** (`buildVPointsTimeline` in `packages/shared/profile-stats/src/chart-builders.ts` — each week's value only ever adds to the previous one). A curve that dips below the lower of two neighbouring weeks is showing something that can never actually happen: your total points going down. That's the "better/worse than reality" effect reported in #3780.
- Fix: drop `curved`/`curvature`, render straight segments between the real weekly points instead (`curved={false}`). A straight segment between two points can never exceed either endpoint, so overshoot is impossible — and since the data is evenly spaced (one point per ISO week, per the issue), straight segments read cleanly without extra plumbing.

## Why not a true monotone spline?

The issue asks for monotone interpolation (derivative constrained at each point — i.e. Fritsch–Carlson). I looked into it and I'm recommending the straight-line fix instead, for now:

- `gifted-charts`/`gifted-charts-core@0.1.81` only exposes `CurveType.CUBIC` (this cardinal-spline bezier, the overshoot source) and `CurveType.QUADRATIC` (also overshoots — plain through-midpoint quadratic, no derivative clamping). There's no monotone option and no prop to hand the library a custom SVG path or per-segment bezier control points.
- The workaround I considered — computing a monotone Hermite spline ourselves and feeding gifted-charts a dense array of interpolated sub-points so the line still looks curved — has a real problem: I traced `activatePointers()` in the library (`react-native-gifted-charts/dist/LineChart/index.js`), and a data point with `hidePointer: true` (needed on every synthetic sub-point so its fake value doesn't drive the tooltip) causes the touch pointer to **silently stop updating entirely** on that touch, rather than snapping to the nearest real point. With N synthetic points per week, most of the chart would become a tooltip dead zone. That's a worse regression than the P3 cosmetic bug it would fix.
- Straight-line segments through the real weekly points sidestep this cleanly: zero risk to the existing pointer/tooltip/spacing/label logic (untouched), and mathematically zero chance of overshoot.

**Follow-up idea for later** if the smooth-curve look is wanted back: implement the Fritsch–Carlson monotone spline in `@boardsesh/profile-stats` as a pure, testable function, but pair it with a from-scratch pointer/tooltip layer (bypass gifted-charts' built-in pointer entirely) so dense synthetic points don't break touch. That's a bigger lift than this P3 warrants on its own.

## Visual verification

This is a visual change, so it should not be merged without a look — flagging @marcodejongh for sign-off.

I was not able to produce before/after screenshots in this sandbox: the Android SDK bootstrapped cleanly (`vp run mobile:android-doctor` — KVM, adb, emulator, and the `boardsesh-pixel` AVD all came up fine), but rendering the You/Progress tab needs real logged-in data from a seeded backend (screenshot mode is a presentation-stability switch, not a data mock — see `packages/mobile/src/lib/screenshot-mode.ts`). Both data paths were blocked here:
- The shared dev Postgres (Tailscale-tunneled, shared across this batch run) hit a migration collision (`relation "board_climb_ingest_skips" already exists`) from a concurrent sibling agent's `vp run dev`, so local seeded data wasn't available.
- The prod test-account auto-login path needs `SCREENSHOT_USER_PASSWORD`, which isn't available in this sandbox.

To eyeball it locally: You tab → Progress sub-tab → V-Points card, ideally on an account with some week-to-week point swings (a big week followed by a quieter one shows the difference best). Before this PR the line curves smoothly through/past each point; after, it's straight segments between the real weekly dots — flat weeks stay flat, no dips below the previous week.

## Test plan

- [x] `vp check` — 0 errors (296 pre-existing warnings, unrelated to this change)
- [x] `vp run typecheck:mobile` — clean
- [x] `vp run test:mobile` — 572 files / 4852 tests passed, including the new regression test (`you-charts-line-interpolation.test.tsx`) which asserts `curved={false}` and no leftover `curvature` prop on the V-Points `LineChart`
- [x] `vp run check:mobile-bundle` — OK
- [ ] Manual visual check on device/emulator — **needs @marcodejongh**, see above

## Scope

- Mobile-only (this chart doesn't render on web; gifted-charts isn't a web dependency).
- JS/TS only, no native changes — ships OTA.
- Sibling PR fixing the chart-card overflow (#3778/#3050) touches layout/sizing in the same file area; this PR only touches the `LineChart`'s curve prop and adds a new test file, so the diffs shouldn't collide. Will rebase if they do once that one merges.

## Release Notes

Your V-Points progress line now connects the dots straight instead of curving — no more phantom dips or bumps between weeks making a session look better or worse than it was.

Closes #3780
