### PR TITLE
fix(sync): let a resolved status beat the English-prose network heuristic

### DIFF
--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
@@ -222,6 +222,15 @@ describe('isTransportNetworkError', () => {
     expect(isTransportNetworkError(new Error('The secure connection failed.'))).toBe(true);
   });
 
+  it('still matches the English-prose fallback even when a status resolves — the union contract is unconditional (#4027)', () => {
+    // isTransportNetworkError itself carries NO status-aware precedence — that
+    // logic lives only in isNetworkError. This pins the unchanged contract that
+    // error-reporting.ts's Sentry severity tagging depends on: a resolved status
+    // must NOT suppress this predicate, only isNetworkError's retry decision.
+    const error = Object.assign(new Error('The connection has timed out unexpectedly.'), { status: 400 });
+    expect(isTransportNetworkError(error)).toBe(true);
+  });
+
   it('does NOT match a programmer bug that merely mentions fetch/network/timed out', () => {
     // Narrow markers keep real bugs at error level rather than silently retrying them.
     expect(isTransportNetworkError(new TypeError("Cannot read property 'fetch' of undefined"))).toBe(false);

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
@@ -253,3 +253,46 @@ describe('isNetworkError', () => {
     expect(isNetworkError(new TypeError('Network request failed'))).toBe(true);
   });
 });
+
+describe('isNetworkError / isRetryable — resolved status beats the English-prose heuristic (#4027)', () => {
+  // A server that replies with a real HTTP/GraphQL status has, by definition,
+  // received the request — that's a server verdict, not a transport failure, no
+  // matter what its message happens to say. Without this, a status whose message
+  // matches IOS_NSURL_ENGLISH_DESCRIPTIONS would classify as `isNetworkError` and
+  // head-of-line-block the ENTIRE drain cycle (drainer.ts's `networkStop`) waiting
+  // for a reconnect that will never come, instead of dead-lettering/retrying that
+  // one mutation via the status-based rules.
+
+  it('400 + an NSURL-prose-matching message: status wins, NOT a network error, dead-letters', () => {
+    const error = Object.assign(new Error('The connection has timed out unexpectedly.'), { status: 400 });
+    expect(isNetworkError(error)).toBe(false);
+    expect(isRetryable(error)).toBe(false);
+  });
+
+  it('503 + an NSURL-prose-matching message: status wins, NOT a network error, but still retries (via status)', () => {
+    const error = Object.assign(new Error('The connection has timed out unexpectedly.'), { status: 503 });
+    expect(isNetworkError(error)).toBe(false);
+    expect(isRetryable(error)).toBe(true);
+  });
+
+  it('no status + an NSURL-prose-matching message: unchanged, still a network error and retryable', () => {
+    const error = new Error('The connection has timed out unexpectedly.');
+    expect(isNetworkError(error)).toBe(true);
+    expect(isRetryable(error)).toBe(true);
+  });
+
+  it('no status + a locale-independent code: unchanged, still a network error and retryable', () => {
+    const error = { code: 'ECONNREFUSED' };
+    expect(isNetworkError(error)).toBe(true);
+    expect(isRetryable(error)).toBe(true);
+  });
+
+  it('a resolved status + a locale-independent code: locale-independent signal keeps precedence, still a network error', () => {
+    // Pins the precedence contract: only the English-prose fallback defers to a
+    // resolved status. Locale-independent signals (errno codes, stable markers)
+    // are trustworthy regardless of what status also resolves.
+    const error = Object.assign(new Error('boom'), { status: 400, code: 'ECONNREFUSED' });
+    expect(isNetworkError(error)).toBe(true);
+    expect(isRetryable(error)).toBe(true);
+  });
+});

--- a/packages/shared/offline-sync/src/mutation-queue/error-classification.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/error-classification.ts
@@ -92,6 +92,52 @@ const IOS_NSURL_ENGLISH_DESCRIPTIONS =
 const MAX_CAUSE_DEPTH = 3;
 
 /**
+ * Locale-independent half of the transport check: errno-style codes and the
+ * always-English fetch/polyfill wrapper strings / Java exception class names
+ * (never localized prose — see TRANSPORT_NETWORK_MARKERS above). Recurses into
+ * `.cause` because WinterCG/undici wrap the underlying error there. Split out
+ * from the English-prose heuristic below (rather than merged into one boolean)
+ * so `isNetworkError` can give this signal unconditional precedence over a
+ * resolved HTTP/GraphQL status while the prose fallback defers to one (#4027).
+ */
+function isLocaleIndependentTransportSignal(error: unknown, depth = 0): boolean {
+  if (error === null || typeof error !== 'object') return false;
+
+  const code = (error as { code?: unknown }).code;
+  if (typeof code === 'string' && TRANSPORT_NETWORK_CODES.has(code)) return true;
+
+  const message = (error as { message?: unknown }).message;
+  if (typeof message === 'string' && TRANSPORT_NETWORK_MARKERS.test(message)) return true;
+
+  if (depth < MAX_CAUSE_DEPTH) {
+    const cause = (error as { cause?: unknown }).cause;
+    if (cause !== undefined && cause !== error && isLocaleIndependentTransportSignal(cause, depth + 1)) return true;
+  }
+
+  return false;
+}
+
+/**
+ * English-prose half of the transport check: the best-effort, un-wrapped iOS
+ * NSURLError descriptions (see IOS_NSURL_ENGLISH_DESCRIPTIONS above). Recurses
+ * into `.cause` the same way the locale-independent half does. Kept separate so
+ * callers can require a resolved status to be absent before trusting it.
+ */
+function isEnglishProseTransportSignal(error: unknown, depth = 0): boolean {
+  if (error === null || typeof error !== 'object') return false;
+
+  const message = (error as { message?: unknown }).message;
+  if (typeof message === 'string' && IOS_NSURL_ENGLISH_DESCRIPTIONS.test(message)) return true;
+
+  if (depth < MAX_CAUSE_DEPTH) {
+    const cause = (error as { cause?: unknown }).cause;
+    if (cause !== undefined && cause !== error && isEnglishProseTransportSignal(cause, depth + 1)) return true;
+  }
+
+  return false;
+}
+
+/**
  * Pure, locale-independent predicate: is this a transport/reachability failure
  * (offline, DNS, reset, TLS, timeout) that never reached the server? Matches on
  * error name/code and stable message markers rather than localized prose, and
@@ -102,27 +148,16 @@ const MAX_CAUSE_DEPTH = 3;
  * `@boardsesh/offline-sync/error-classification` subpath) so both agree on what
  * "offline" means. Deliberately excludes AbortError — its cancel-vs-retry meaning
  * differs per call site, so each site handles it.
+ *
+ * NOTE: this is the union of BOTH halves above with no precedence between them —
+ * exactly the pre-#4027 behavior, preserved here unchanged because mobile's
+ * `reportHandledError` severity tagging (error-reporting.ts) consumes this
+ * function directly and doesn't need (or want) status-aware precedence for a
+ * "warning vs error" Sentry tag. `isNetworkError` below is where the two halves
+ * get different treatment.
  */
 export function isTransportNetworkError(error: unknown, depth = 0): boolean {
-  if (error === null || typeof error !== 'object') return false;
-
-  const code = (error as { code?: unknown }).code;
-  if (typeof code === 'string' && TRANSPORT_NETWORK_CODES.has(code)) return true;
-
-  const message = (error as { message?: unknown }).message;
-  if (
-    typeof message === 'string' &&
-    (TRANSPORT_NETWORK_MARKERS.test(message) || IOS_NSURL_ENGLISH_DESCRIPTIONS.test(message))
-  ) {
-    return true;
-  }
-
-  if (depth < MAX_CAUSE_DEPTH) {
-    const cause = (error as { cause?: unknown }).cause;
-    if (cause !== undefined && cause !== error && isTransportNetworkError(cause, depth + 1)) return true;
-  }
-
-  return false;
+  return isLocaleIndependentTransportSignal(error, depth) || isEnglishProseTransportSignal(error, depth);
 }
 
 /**
@@ -131,10 +166,23 @@ export function isTransportNetworkError(error: unknown, depth = 0): boolean {
  * a plain Error carrying the WinterCG "fetch failed: <cause>" wrapper, or a bare
  * NSURLError description. Distinct from a server that replied with an error status
  * — the drainer treats these two very differently (a network error must never
- * advance retry_count toward the dead-letter).
+ * advance retry_count toward the dead-letter; instead it halts the whole drain
+ * cycle to wait for reconnectivity — see drainer.ts's `networkStop`).
+ *
+ * The drainer calls this directly (drainer.ts) AND `isRetryable` below calls it
+ * first — so the precedence decided here applies to both call sites. Locale-
+ * independent signals (errno codes, stable markers, `.cause` chain) and a
+ * cancelled request always count as network regardless of any status that also
+ * resolves — those are trustworthy identifiers of a transport failure. The
+ * English-prose NSURL fallback is a best-effort LAST RESORT for un-wrapped iOS
+ * descriptions: when a real HTTP/GraphQL status ALSO resolves, the server verdict
+ * wins. Without this, a 400 (or any status) whose message happens to match the
+ * English prose would head-of-line-block the ENTIRE drain cycle waiting for a
+ * reconnect that, since the request demonstrably reached the server, will never
+ * come (#4027).
  */
 export function isNetworkError(error: unknown): boolean {
-  if (isTransportNetworkError(error)) return true;
+  if (isLocaleIndependentTransportSignal(error)) return true;
   // A cancelled request (app backgrounded mid-drain, AbortController timeout)
   // surfaces as an error NAMED AbortError — not a TypeError, and not reliably a
   // DOMException instance across RN runtimes, so match by name. The request
@@ -143,12 +191,23 @@ export function isNetworkError(error: unknown): boolean {
   if (error instanceof Error && error.name === 'AbortError') {
     return true;
   }
-  return false;
+  // A resolved HTTP/GraphQL status is a server verdict: the request reached the
+  // server, so this is not a transport/reachability failure no matter what the
+  // message says. Only fall through to the English-prose heuristic when no
+  // status resolves at all.
+  if (getErrorStatus(error) !== null) {
+    return false;
+  }
+  return isEnglishProseTransportSignal(error);
 }
 
 export function isRetryable(error: unknown): boolean {
   // Network failures always retry — the request never reached the server, so
-  // replaying it is safe.
+  // replaying it is safe. `isNetworkError` itself now defers to a resolved status
+  // for the English-prose-only case (#4027), so this check is already
+  // status-aware even though it textually runs before the `getErrorStatus` call
+  // below — see isNetworkError's doc comment for why the precedence lives there
+  // rather than being duplicated here.
   if (isNetworkError(error)) {
     return true;
   }


### PR DESCRIPTION
## Summary

`isNetworkError` in `packages/shared/offline-sync/src/mutation-queue/error-classification.ts` never consulted `getErrorStatus`. If a server ever replies with a real HTTP/GraphQL status whose error message happens to match the best-effort, English-only `IOS_NSURL_ENGLISH_DESCRIPTIONS` fallback (meant to rescue un-wrapped iOS `NSURLError` descriptions), it was classified as a network/transport failure instead of a server verdict.

### Why this is worse than it sounds

`packages/shared/offline-sync/src/mutation-queue/drainer.ts:225` calls the exported `isNetworkError` **directly**, before it ever reaches `isRetryable`. When `isNetworkError` returns `true`, the drainer sets `networkStop = true`, which — per the comment at drainer.ts:260 (`// Connectivity is gone — end the cycle`) — **halts the entire drain cycle**, not just the one mutation. Every other pending mutation in the outbox stays blocked behind it until a reconnect trigger fires. For a message that merely resembles NSURL prose but was actually attached to a real 400/503, that reconnect never comes, because the device is online and the request already reached the server.

Fixing the ordering only inside `isRetryable` (the literal wording of #4027) would not have fixed this: `isRetryable`'s own internal `isNetworkError(error)` check runs *after* the drainer's own direct call to the same pure function on the same input, so by the time `isRetryable` is reached it's already unreachable dead code for this exact case. The fix has to live in `isNetworkError` itself, which both call sites funnel through.

## The fix

Split the transport check in `error-classification.ts` into two internal halves:

- `isLocaleIndependentTransportSignal` — errno codes (`ECONNREFUSED`, etc.) and the always-English fetch/polyfill wrapper strings / Java exception class names. Trustworthy identifiers of a transport failure regardless of what status also resolves.
- `isEnglishProseTransportSignal` — the best-effort, un-wrapped iOS `NSURLError` description fallback. Last resort only.

`isNetworkError` now checks the locale-independent signal and `AbortError`-by-name unconditionally (unchanged precedence), then **only** falls back to the English-prose heuristic when `getErrorStatus` resolves to `null`. A resolved status is a server verdict and wins outright.

`isTransportNetworkError`'s external contract is **unchanged** — it's still the union of both halves with no precedence between them (`isLocaleIndependentTransportSignal(error) || isEnglishProseTransportSignal(error)`). This matters because `packages/mobile/src/lib/error-reporting.ts` imports `isTransportNetworkError` directly for Sentry severity tagging (`reportHandledError`'s "warning vs error" noise policy) and doesn't need or want status-aware precedence there — it's classifying "is this worth waking someone up for", not "should this retry". No code change was needed in `error-reporting.ts`; its existing test suite was run unmodified to confirm no regression.

`isRetryable`'s own code is unchanged — it already calls `isNetworkError` first, then `getErrorStatus`. Fixing precedence inside `isNetworkError` makes that composition correct by construction at both call sites (the drainer's direct call and `isRetryable`'s internal one), rather than duplicating the status-gate in two places where it could drift.

## Behavioral delta worth flagging

One class of input now takes a different path through the drainer, on purpose:

**A 5xx status whose message also matches the English-prose fallback.** Before: classified as `isNetworkError` → `networkStop` → the mutation (and every mutation behind it) stays `pending` forever, retry_count never advances, waiting for a reconnect that already happened (the server responded). After: the resolved status wins, `isNetworkError` returns `false`, and it falls through to `isRetryable`'s status rules → `500 >= 500` → retryable via `recordFailure` → advances `retry_count` and eventually dead-letters after `max_retries`, while the rest of the batch keeps draining. This is strictly more correct (the request demonstrably reached the server), but it is an observable change in *which* mechanism handles it.

Verified today (same as the #3869 finding this issue was carved out of): the backend emits no message matching `IOS_NSURL_ENGLISH_DESCRIPTIONS`, so this is a latent sharp edge, not a live outage — consistent with the P3 priority.

## Tests

`packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts` — new `describe` block, `isNetworkError / isRetryable — resolved status beats the English-prose heuristic (#4027)`:

- `400` + NSURL-prose-matching message → not a network error, `isRetryable` false (dead-letters).
- `503` + NSURL-prose-matching message → not a network error, but `isRetryable` true (retries via the status path).
- no status + NSURL-prose-matching message → unchanged, still a network error and retryable.
- no status + locale-independent code (`ECONNREFUSED`) → unchanged, still a network error and retryable.
- resolved status (400) **+** a locale-independent code → still a network error regardless of status — pins the precedence contract that only the English-prose fallback defers to a resolved status.

`drainer.test.ts` mocks the entire `error-classification` module (both `isRetryable` and `isNetworkError`), so it needed no changes — it only verifies drainer control-flow given a mocked classifier.

Validation run:

- `vp test run --project offline-sync --reporter=agent` — 20 files / 297 tests pass.
- `vp run typecheck:offline-sync` — clean.
- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` (`vp run` form, not the `--project`-before-`run` footgun) — passing, including `error-reporting.test.ts` and `global-error-capture.test.ts`, the only two downstream consumers of `isTransportNetworkError`.

## QA Notes

No UI surface — this is classification logic behind the offline mutation outbox. Nothing to click through. On-device reproduction would need a genuinely broken TLS endpoint or a crafted server response matching the NSURL phrasing, neither of which exists in the current backend.

## Release Notes

Offline ticks logged while your connection is spotty no longer get stuck waiting behind one bad request — a real server error now clears out of the queue (or retries on its own terms) instead of stalling every other queued tick behind it.

Closes #4027
