### PR TITLE
fix(sync): skip contentless kilter catalog stat rows

### DIFF
--- a/packages/kilter-sync/src/sync/catalog-stats.test.ts
+++ b/packages/kilter-sync/src/sync/catalog-stats.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 
-import { foldCatalogStat, foldCatalogStatOnce, shouldRelistFoldedCanonical } from './catalog-sync';
+import {
+  foldCatalogStat,
+  foldCatalogStatOnce,
+  shouldRelistFoldedCanonical,
+  shouldSkipEmptyCatalogStat,
+} from './catalog-sync';
 import type { KilterCatalogStat } from '../api/kilter-rest';
 import type { StatAccum } from './catalog-sync';
 
@@ -326,6 +331,42 @@ describe('foldCatalogStat — kilter catalog stat accumulation', () => {
     });
     expect(merged.faUsername).toBe('mergefa');
     expect(merged.faAt).toBe('2023-01-01T00:00:00.000Z');
+  });
+});
+
+describe('shouldSkipEmptyCatalogStat — phantom (climb, angle) stat row guard (issue #3522)', () => {
+  function accum(over: Partial<StatAccum> = {}): StatAccum {
+    return {
+      canonicalUuid: CANON,
+      angle: 40,
+      kilterCount: 0,
+      displayDifficulty: null,
+      difficultyAverage: null,
+      qualityAverage: null,
+      faUsername: null,
+      faAt: null,
+      hasOwnRowStats: false,
+      ...over,
+    };
+  }
+
+  it('skips a fully empty stat: zero ascents and nothing to display', () => {
+    // e.g. Grips reporting {ascentCount: 0, difficulty: 0, quality: 0} for an
+    // angle nobody has climbed — the guards already null the display fields,
+    // but without this check it would still INSERT an all-null phantom row.
+    expect(shouldSkipEmptyCatalogStat(accum())).toBe(true);
+  });
+
+  it('keeps a zero-ascent stat that carries a real grade (freshly set, unclimbed angle)', () => {
+    expect(shouldSkipEmptyCatalogStat(accum({ kilterCount: 0, displayDifficulty: 20 }))).toBe(false);
+    expect(shouldSkipEmptyCatalogStat(accum({ kilterCount: 0, difficultyAverage: 20.4 }))).toBe(false);
+    expect(shouldSkipEmptyCatalogStat(accum({ kilterCount: 0, qualityAverage: 4.2 }))).toBe(false);
+    expect(shouldSkipEmptyCatalogStat(accum({ kilterCount: 0, faUsername: 'setter' }))).toBe(false);
+    expect(shouldSkipEmptyCatalogStat(accum({ kilterCount: 0, faAt: '2024-01-01T00:00:00.000Z' }))).toBe(false);
+  });
+
+  it('keeps a stat with real ascents but no grade/quality data yet', () => {
+    expect(shouldSkipEmptyCatalogStat(accum({ kilterCount: 12 }))).toBe(false);
   });
 });
 

--- a/packages/kilter-sync/src/sync/catalog-sync.ts
+++ b/packages/kilter-sync/src/sync/catalog-sync.ts
@@ -291,6 +291,30 @@ function guardDifficulty(difficulty: number | null | undefined): number | null {
   return difficulty != null && difficulty > 1 ? difficulty : null;
 }
 
+/**
+ * Whether a per-(canonical, angle) accumulator carries no real information at
+ * all: zero ascents and nothing (grade, quality, first-ascent) to display.
+ * Grips reports a stat row for every angle a layout supports, including ones
+ * nobody has actually climbed — those rows are already guarded to NULL
+ * displayDifficulty/qualityAverage (see guardDifficulty / correctGripsQualityAverage),
+ * but without this check they'd still produce an all-null board_climb_stats
+ * INSERT: a phantom row for a (climb, angle) pair nobody has climbed (issue
+ * #3522). A row with a real grade but 0 ascents (freshly set, unclimbed) or
+ * real ascents but no grade yet is NOT empty and must still be written — only
+ * skip the case where every field is genuinely absent. Pure + exported for
+ * unit testing.
+ */
+export function shouldSkipEmptyCatalogStat(accum: StatAccum): boolean {
+  return (
+    accum.kilterCount === 0 &&
+    accum.displayDifficulty == null &&
+    accum.difficultyAverage == null &&
+    accum.qualityAverage == null &&
+    accum.faUsername == null &&
+    accum.faAt == null
+  );
+}
+
 export function foldCatalogStatOnce(
   accumByKey: Map<string, StatAccum>,
   seenSourceStats: Set<string>,
@@ -687,27 +711,29 @@ async function syncBoardLayoutGroup(
     }
   }
 
-  const statValues = [...statsByCanonicalAngle.values()].map((accum) => ({
-    boardType: KILTER,
-    climbUuid: accum.canonicalUuid,
-    angle: accum.angle,
-    displayDifficulty: accum.displayDifficulty,
-    difficultyAverage: accum.difficultyAverage,
-    qualityAverage: accum.qualityAverage,
-    // The manufacturer average also seeds upstream_quality_average (the blend's
-    // upstream term). On a fresh INSERT quality_average == this value because no
-    // Boardsesh votes exist yet; on conflict quality_average is re-blended below.
-    upstreamQualityAverage: accum.qualityAverage,
-    // qualityAverage is Grips' own 1-5 value, stored verbatim in the fold above
-    // (correctGripsQualityAverage only drops non-ratings).
-    qualityNormalized: true,
-    faUsername: accum.faUsername,
-    faAt: accum.faAt,
-    upstreamAscensionistCount: accum.kilterCount,
-    ascensionistCount: accum.kilterCount,
-    // Record that a Kilter Grips catalog sync last touched this row.
-    upstreamSyncedAt: new Date().toISOString(),
-  }));
+  const statValues = [...statsByCanonicalAngle.values()]
+    .filter((accum) => !shouldSkipEmptyCatalogStat(accum))
+    .map((accum) => ({
+      boardType: KILTER,
+      climbUuid: accum.canonicalUuid,
+      angle: accum.angle,
+      displayDifficulty: accum.displayDifficulty,
+      difficultyAverage: accum.difficultyAverage,
+      qualityAverage: accum.qualityAverage,
+      // The manufacturer average also seeds upstream_quality_average (the blend's
+      // upstream term). On a fresh INSERT quality_average == this value because no
+      // Boardsesh votes exist yet; on conflict quality_average is re-blended below.
+      upstreamQualityAverage: accum.qualityAverage,
+      // qualityAverage is Grips' own 1-5 value, stored verbatim in the fold above
+      // (correctGripsQualityAverage only drops non-ratings).
+      qualityNormalized: true,
+      faUsername: accum.faUsername,
+      faAt: accum.faAt,
+      upstreamAscensionistCount: accum.kilterCount,
+      ascensionistCount: accum.kilterCount,
+      // Record that a Kilter Grips catalog sync last touched this row.
+      upstreamSyncedAt: new Date().toISOString(),
+    }));
   if (statValues.length > 0) {
     // The NEW upstream count this upsert resolves to: GREATEST of stored and
     // incoming, so a stale/partial sync can never lower a climb. Defined ONCE and


### PR DESCRIPTION
## Summary

The two headline defects in #3522 are **already fixed on `main`**, before this PR:

- The difficulty 0-guard (`guardDifficulty` in `catalog-sync.ts`) landed in `f3ebf0379`.
- The quality lower-bound guard (`correctGripsQualityAverage` rejecting `< 1`) landed in `6c691ecb4` (#4047).

Both are covered by existing tests in `catalog-stats.test.ts` / `quality-scale.test.ts`. Reviewers: this PR is **not** re-adding those guards — it closes the one gap that was still open.

**The remaining gap**: `syncBoardLayoutGroup`'s `statValues` construction unconditionally turned every accumulated per-(canonical, angle) stat into a `board_climb_stats` upsert row — including ones where Grips reported zero ascents and nothing to display (no grade, no quality, no first-ascent). Those guards null the bad *values*, but a fully-empty accumulator still produced an all-null INSERT: a phantom stats row for a (climb, angle) pair nobody has actually climbed.

## Fix

Added `shouldSkipEmptyCatalogStat(accum)` in `packages/kilter-sync/src/sync/catalog-sync.ts` — true only when ascents are 0 **and** every display field (grade, quality, first-ascent) is null. Filtered `statValues` with it before the upsert.

A row is kept (not skipped) when:
- it has a real grade but 0 ascents (freshly set, unclimbed angle), or
- it has real ascents but no grade/quality data yet.

Only genuinely contentless rows are dropped. No schema change, no change to the existing difficulty/quality guards.

## Existing prod data — read-only checklist for Marco

Guards only stop **new** poison; they don't retroactively fix already-written rows, because the upsert's `ON CONFLICT` uses `COALESCE(excluded.x, stored.x)` for `display_difficulty`/`difficulty_average`/`upstream_quality_average` — once the guard nulls an incoming bad value, `COALESCE(null, <already-bad stored value>)` just keeps the old value. A normal daemon re-sync will **not** self-heal these rows (unlike #3567). This is a decision for Marco — nothing below is run by this PR or by me.

**1. Verify (read-only, safe to run anytime):**

```sql
SELECT
  COUNT(*) FILTER (WHERE display_difficulty <= 1 OR difficulty_average <= 1) AS zero_or_placeholder_difficulty_rows,
  COUNT(*) FILTER (WHERE upstream_quality_average > 0 AND upstream_quality_average < 1) AS sub_one_upstream_quality_rows,
  COUNT(*) FILTER (
    WHERE COALESCE(upstream_ascensionist_count, 0) = 0
      AND COALESCE(boardsesh_ascensionist_count, 0) = 0
      AND display_difficulty IS NULL
      AND quality_average IS NULL
  ) AS phantom_empty_rows
FROM board_climb_stats
WHERE board_type = 'kilter';
```

**2. Option A — null the bad values, keep the rows (recommended default):**

```sql
-- Difficulty: same threshold as guardDifficulty (id 1 doesn't exist, 0 is the "no data" sentinel).
UPDATE board_climb_stats
SET display_difficulty = NULL, difficulty_average = NULL
WHERE board_type = 'kilter' AND (display_difficulty <= 1 OR difficulty_average <= 1);

-- Quality: null the impossible sub-1-star upstream average...
UPDATE board_climb_stats
SET upstream_quality_average = NULL
WHERE board_type = 'kilter' AND upstream_quality_average > 0 AND upstream_quality_average < 1;

-- ...then recompute the materialized quality_average blend using the EXACT
-- formula in packages/db/src/queries/climb-stats/quality-blend.ts
-- (blendedQualityAverageSql) — it is a stored column, not computed on read.
UPDATE board_climb_stats
SET quality_average = COALESCE(
  (
    (COALESCE(upstream_quality_average * upstream_ascensionist_count, 0) + COALESCE(boardsesh_quality_sum, 0))
    / NULLIF(
        COALESCE(CASE WHEN upstream_quality_average IS NOT NULL THEN upstream_ascensionist_count END, 0)
        + COALESCE(boardsesh_quality_count, 0),
        0
      )
  ),
  upstream_quality_average
)
WHERE board_type = 'kilter';
```

**3. Option B — Marco-only alternative, NOT run or endorsed here: delete the phantom rows outright.** Instead of just nulling fields, you may prefer to remove the pure-phantom `(climb, angle)` rows entirely (upstream ascents = 0, Boardsesh ascents = 0, no display fields at all — the `phantom_empty_rows` count from the verify query above):

```sql
-- DATA DELETION — Marco's call only, not proposed as the default path.
DELETE FROM board_climb_stats
WHERE board_type = 'kilter'
  AND COALESCE(upstream_ascensionist_count, 0) = 0
  AND COALESCE(boardsesh_ascensionist_count, 0) = 0
  AND display_difficulty IS NULL
  AND quality_average IS NULL;
```

Going forward, the guard in this PR stops new phantom rows of this shape from being created, so option A vs. B is purely about the historical backlog.

## Follow-up filed

The same class of bug (missing difficulty positivity guard, unconditional empty-row insert) also exists in `packages/aurora-sync/src/sync/shared-sync.ts` (`parseDifficultyFields`, `upsertClimbStats`) and the shared `packages/db/src/queries/climb-stats/recompute.ts` seed/AVG path. That's a different package with a different accumulator shape, so it's split out to #4068 rather than folded into this PR.

## Test plan

- `packages/kilter-sync/src/sync/catalog-stats.test.ts` — new `shouldSkipEmptyCatalogStat` describe block: fully-empty stat is skipped; zero-ascent-but-graded is kept; ascents-but-no-grade is kept.
- `vp check`
- `vp run typecheck`
- `vp test run --project kilter-sync --reporter=agent`

## Release Notes

Boardsesh no longer creates phantom stat rows for angles nobody's climbed on Kilter — the bogus grade-0 and impossible sub-one-star entries some climbs picked up from empty upstream data stop appearing.

Closes #3522
