### PR TITLE
docs: fix canonical-consolidation direction (config-tuple, not /b)

### DIFF
--- a/docs/web-reposition.md
+++ b/docs/web-reposition.md
@@ -32,6 +32,33 @@ Loose ends to clean when the routes go (not runtime callers, but they'd go stale
 `app/lib/api-docs/openapi-routes.ts` (documents `proxy/login`, `proxy/saveAscent`),
 `docs/branch-deploys.md` migration table, and the routes' own `__tests__`.
 
+### Shipped hardware pins `www` URL shapes (two different ones)
+
+Two shipped artefacts point at `www.boardsesh.com`, and they pin **different**
+things. Neither is fixable by us for the copies already in the field.
+
+- **The legacy page-route shape.** `packages/web/board-controller/main.py:627`
+  builds
+  `https://www.boardsesh.com/{board_name}/{board_layout}/{board_size}/{board_set}/{board_angle}/list?controllerUrl=…`
+  and 302s to it on line 629, using named slugs (defaults:
+  `kilter`/`original`/`12x12`/`screw_bolt`/`40`). This is a FastAPI app users run
+  on their own host from this repo, so the source is editable, but we can't push
+  the update — installed copies keep sending traffic at the old shape. The legacy
+  config-tuple `/list` route has to keep resolving.
+- **The `www` host plus `/api/internal/board-render`.**
+  `embedded/projects/board-controller/src/config/board_config.h:41` (same define
+  at `embedded/projects/moonboard-dev-server/src/config/board_config.h:17`) sets
+  `DEFAULT_RENDER_BASE_URL "https://www.boardsesh.com"`. The firmware never
+  requests a page: `buildBoardRenderThumbnailUrl`
+  (`embedded/libs/thumbnail-client/src/thumbnail_client.cpp:298-324`) appends
+  `/api/internal/board-render` plus a
+  `board_name`/`layout_id`/`size_id`/`set_ids`/`frames` query string. So this
+  pins that API route, not the route tree — A6 must not delete it. The default is
+  overridable at build time (`#ifndef`) and at runtime through the device's own
+  config endpoint (`embedded/libs/esp-web-server/src/esp_web_server.cpp:708-714`
+  persists `render_base_url`), so it is recoverable, but only by hand, one device
+  at a time.
+
 ### `/app` redirect destinations (for the route redirects in A6)
 
 | Web route removed  | `/app` destination                                          | Status                                                                                                                                         |
@@ -78,8 +105,20 @@ plus `useOptionalPlaylistActivation`. Refactor `multiboard-climb-list.tsx` and
   through the teardown.
 - `app/__tests__/climb-canonical-parity.test.ts` — documents that the legacy and
   `/b` view trees self-canonicalize into different URLs today (split PageRank).
-  **Flip at A1:** once the `url-utils` helpers emit `/b`, change the legacy
-  assertion to `.startsWith('/b/')` and assert parity.
+  **Flip at A1:** the consolidation target is the config-tuple tree (route
+  segments `/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/…`, served in
+  its named-slug form — `/kilter/original/12x12/screw_bolt/40/…`), not `/b`.
+  `/b/{slug}` resolves through `boardBySlug`
+  (`packages/backend/src/graphql/resolvers/social/boards.ts:786-800`), which
+  reads `user_boards` scoped only by `slug` and `deletedAt` — a board a specific
+  user owns, not a climb config. Most climbs have no `/b` URL at all, and popular
+  configs have many (one per owning user), so `/b` can't be the canonical for a
+  climb config. The `url-utils` helpers already emit the config-tuple form, so A1
+  has no work there; what changes is the `/b` pages' inline canonical literal,
+  which reaches `createPageMetadata` without touching `url-utils` —
+  `b/[board_slug]/[angle]/view/[climb_uuid]/page.tsx:54` and
+  `b/[board_slug]/[angle]/list/page.tsx:37`. Point those at the legacy tree's
+  canonical, then flip the `/b`-tree assertion to match and assert parity.
 - `b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/view-seo-fragment.test.tsx`
   — the climb-view page SSR-emits `ClimbViewSeoFragment` (the crawlable payload).
   Guards A2's drawer→static swap from dropping it.

--- a/packages/web/app/__tests__/climb-canonical-parity.test.ts
+++ b/packages/web/app/__tests__/climb-canonical-parity.test.ts
@@ -10,11 +10,26 @@ import { describe, expect, it, vi } from 'vite-plus/test';
  * `/b/…` canonical straight through. Two self-canonicalizing trees for one climb
  * permanently splits PageRank.
  *
- * A1 (canonical consolidation) repoints the `url-utils` helpers to emit the `/b`
- * form. WHEN A1 LANDS: flip the legacy assertion to `.startsWith('/b/')` (and
- * assert parity with the slug canonical), then delete the `false`/legacy-tree
- * markers. Until then this test documents the split and guards against it
- * silently widening.
+ * A1 (canonical consolidation) points both trees at the config-tuple tree
+ * (route segments `/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/…`,
+ * served in its named-slug form — `/kilter/original/12x12/screw_bolt/40/…`),
+ * not at `/b`. `/b/{slug}` resolves through `boardBySlug`
+ * (`packages/backend/src/graphql/resolvers/social/boards.ts:786-800`), which
+ * reads `user_boards` scoped only by `slug` and `deletedAt` — a board a specific
+ * user owns, not a climb config. Most climbs have no `/b` URL at all, because no
+ * `user_boards` row exists for their layout/size/set/angle combination; popular
+ * configs have many `/b` URLs, one per user who owns a board with that config.
+ * The config-tuple tree is the only one that names a climb config uniquely, so
+ * it is the consolidation target.
+ *
+ * The `url-utils` helpers already emit that form, so A1 has no work there. What
+ * changes is the `/b` pages' inline canonical literal, which reaches
+ * `createPageMetadata` without passing through `url-utils`:
+ * `app/b/[board_slug]/[angle]/view/[climb_uuid]/page.tsx:54` and its list
+ * sibling `app/b/[board_slug]/[angle]/list/page.tsx:37`. WHEN A1 LANDS: point
+ * that literal at the legacy tree's canonical for the same climb, then flip the
+ * `/b` test below to assert parity and drop its split markers. Until then this
+ * test documents the split and guards against it silently widening.
  */
 
 vi.mock('server-only', () => ({}));
@@ -106,15 +121,18 @@ function canonicalPath(canonical: string | URL | { url: string | URL } | null | 
   return new URL(url.toString(), 'https://www.boardsesh.com').pathname;
 }
 
-describe('climb-view canonical parity (RED until A1 consolidates onto /b)', () => {
-  it('the /b slug view already self-canonicalizes into the /b tree', async () => {
+describe('climb-view canonical parity (documents the split; the /b half flips at A1)', () => {
+  it('the /b slug view self-canonicalizes into the /b tree today (flips at A1)', async () => {
     const metadata = await slugPage.generateMetadata({
       params: Promise.resolve({ board_slug: 'kilter-original-12x12', angle: '40', climb_uuid: CLIMB_UUID }),
     });
+    // A1 repoints this page's inline canonical literal at the legacy tree, so
+    // this flips to `.toBe(false)` plus an equality assertion against the legacy
+    // page's canonical for the same climb.
     expect(canonicalPath(metadata.alternates?.canonical).startsWith('/b/')).toBe(true);
   });
 
-  it('documents the split: the legacy view canonicalizes into the legacy tree, NOT /b (flip at A1)', async () => {
+  it('documents the split: the legacy view already canonicalizes onto the config-tuple tree A1 keeps', async () => {
     const metadata = await legacyPage.generateMetadata({
       params: Promise.resolve({
         board_name: 'kilter',
@@ -126,8 +144,9 @@ describe('climb-view canonical parity (RED until A1 consolidates onto /b)', () =
       }),
     });
     const path = canonicalPath(metadata.alternates?.canonical);
-    // A1 flips these two lines to `expect(path.startsWith('/b/')).toBe(true)` and
-    // asserts equality with the slug canonical for the same climb.
+    // No flip needed here at A1 — this tree is already the consolidation target.
+    // The prefix check is deliberately shape-agnostic: it holds for the
+    // named-slug canonical this page emits today and for the numeric fallback.
     expect(path.startsWith('/b/')).toBe(false);
     expect(path.startsWith('/kilter/')).toBe(true);
     // The uuid survives into the canonical either way (embedded in the name slug).


### PR DESCRIPTION
## Summary

Two places told future contributors to do the wrong thing: the header comment on
`packages/web/app/__tests__/climb-canonical-parity.test.ts` and the matching A1
bullet in `docs/web-reposition.md`. Both said A1 repoints the `url-utils` helpers
to emit the `/b` form. That is backwards on both halves.

- **Wrong target.** `/b/{slug}` resolves through `boardBySlug`
  (`packages/backend/src/graphql/resolvers/social/boards.ts:786-800`), which
  reads `user_boards` scoped only by `slug` and `deletedAt` — a board one user
  owns, not a climb config. Most climbs have no `/b` URL at all, because no
  `user_boards` row exists for their layout/size/set/angle combination, and
  popular configs have many `/b` URLs, one per owning user. The config-tuple tree
  is the only one that names a climb config uniquely, so it is the consolidation
  target. Both files now say so, and spell out that the tree is served in its
  named-slug form (`/kilter/original/12x12/screw_bolt/40/…`) rather than the
  numeric fallback.
- **Wrong subject.** `url-utils` already emits that form
  (`constructClimbViewUrlWithSlugs`, reached via `tryConstructSlugViewUrl`), so
  A1 has no work there. What A1 edits is the `/b` pages' inline canonical
  literal, which reaches `createPageMetadata` without going through `url-utils`:
  `app/b/[board_slug]/[angle]/view/[climb_uuid]/page.tsx:54` and
  `app/b/[board_slug]/[angle]/list/page.tsx:37`.

The stray comments inside the test body (describe title, the two inline "flip at
A1" notes) echoed the same wrong direction and are corrected to match. No
assertions changed.

`docs/web-reposition.md` also gains a section on the two shipped hardware
artefacts that point at `www`. They pin different things, worth keeping straight
before A6 deletes anything:

- `packages/web/board-controller/main.py:627` builds
  `https://www.boardsesh.com/{board}/{layout}/{size}/{set}/{angle}/list?controllerUrl=…`
  and 302s to it on line 629 (defaults `kilter`/`original`/`12x12`/`screw_bolt`/`40`).
  Users run this FastAPI app on their own host, so we can edit the source but
  can't push the update to installed copies. The legacy `/list` route has to keep
  resolving.
- `embedded/projects/board-controller/src/config/board_config.h:41` (same define
  at `embedded/projects/moonboard-dev-server/src/config/board_config.h:17`) sets
  `DEFAULT_RENDER_BASE_URL "https://www.boardsesh.com"`. The firmware requests
  `/api/internal/board-render` with a query string
  (`embedded/libs/thumbnail-client/src/thumbnail_client.cpp:298-324`), not a page,
  so it pins that API route and the host. It is overridable per device at build
  time (`#ifndef`) and at runtime via the device config endpoint
  (`embedded/libs/esp-web-server/src/esp_web_server.cpp:708-714`), one device at a
  time.

No behaviour change. Comments and docs only; the test asserts exactly what it did
before and still passes.

## Testing

- `vp check` — 0 errors (297 warnings, all pre-existing `no-floating-promises`
  noise in `packages/db` test files, untouched here)
- `vp run typecheck` — pass
- `vp test run --reporter=agent --project web` — 473 files, 5849 tests, 0 failed

## Release Notes

none
