### PR TITLE
fix(mobile): write the overlay PNG atomically so a mid-write crash can't leave a corrupt cache hit

### DIFF
--- a/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/AtomicFileWrite.kt
+++ b/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/AtomicFileWrite.kt
@@ -1,0 +1,53 @@
+package com.boardsesh.boardrenderer
+
+import java.io.File
+import java.io.IOException
+
+/**
+ * Writes a file by writing to a temp file next to the destination first, then
+ * renaming it into place. A thrown exception from [write] — or a failed rename
+ * — deletes the temp file and leaves [destination] completely untouched: either
+ * its prior contents (if any) survive unchanged, or nothing was ever created.
+ * There is no window where a reader can observe a partially-written file at
+ * [destination]'s path.
+ *
+ * `File.renameTo` is an atomic `rename(2)` when the source and destination are
+ * on the same filesystem, which they are here — the temp file is created in
+ * [destination]'s own parent directory.
+ *
+ * Fixes #3748: `BoardRendererModule.renderOverlay` used to write the overlay
+ * PNG directly to its final cache path via `FileOutputStream`, and only
+ * cleaned up when `compress()` returned `false` — not when it (or the
+ * underlying stream write) *threw*, e.g. an IO interruption, a storage-full
+ * condition, or the process getting killed mid-write. That left a truncated
+ * PNG on disk, and the cache's `exists()`-only fast path then served it as a
+ * permanent "successful" render forever.
+ *
+ * Pure `java.io` on purpose — no Android framework calls — so
+ * [AtomicFileWriteTest] needs neither Robolectric nor a real Bitmap, matching
+ * [CacheDirRecovery]'s approach for its sibling helper.
+ */
+object AtomicFileWrite {
+    /**
+     * Temp-file suffix used for the in-flight write. Shared with
+     * [CachePruner], which sweeps any file ending in this suffix as an
+     * orphaned artifact of a crash between [write] and the rename.
+     */
+    const val TEMP_SUFFIX: String = ".tmp"
+
+    fun writeAtomically(destination: File, write: (tempFile: File) -> Unit) {
+        val tempFile = File(destination.parentFile, "${destination.name}$TEMP_SUFFIX")
+        try {
+            write(tempFile)
+            if (!tempFile.renameTo(destination)) {
+                throw IOException(
+                    "Failed to move ${tempFile.absolutePath} into place at ${destination.absolutePath}"
+                )
+            }
+        } finally {
+            // No-op if the rename already moved it away; cleans up any partial
+            // temp file left by a throw above (from `write` or the rename check).
+            tempFile.delete()
+        }
+    }
+}

--- a/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/BoardRendererModule.kt
+++ b/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/BoardRendererModule.kt
@@ -17,33 +17,23 @@ class BoardRendererModule : Module() {
     @Volatile
     private var pruned = false
 
-    private fun pruneCacheIfNeeded(maxBytes: Long) {
-        val files = cacheDir.listFiles() ?: return
-        var totalBytes = files.sumOf { it.length() }
-        if (totalBytes <= maxBytes) return
-
-        // Android's File.lastModified() is our LRU proxy — atime is not
-        // reliably available on the filesystems Android caches live on.
-        val sorted = files.sortedBy { it.lastModified() }
-        var removed = 0
-        for (file in sorted) {
-            if (totalBytes <= maxBytes) break
-            val size = file.length()
-            if (file.delete()) {
-                totalBytes -= size
-                removed++
-            }
-        }
-        if (removed > 0) {
-            android.util.Log.i("BoardRenderer", "Pruned $removed cached PNGs; new total $totalBytes bytes")
-        }
-    }
-
     private fun renderOverlay(configJson: String, cacheKey: String): String {
         if (!pruned) {
             synchronized(this@BoardRendererModule) {
                 if (!pruned) {
-                    pruneCacheIfNeeded(CACHE_CAP_BYTES)
+                    val result = CachePruner.pruneCacheIfNeeded(cacheDir, CACHE_CAP_BYTES)
+                    if (result.orphanedTempFilesRemoved > 0) {
+                        android.util.Log.i(
+                            "BoardRenderer",
+                            "Swept ${result.orphanedTempFilesRemoved} orphaned temp file(s) from a prior crash",
+                        )
+                    }
+                    if (result.cacheEntriesEvicted > 0) {
+                        android.util.Log.i(
+                            "BoardRenderer",
+                            "Pruned ${result.cacheEntriesEvicted} cached PNGs; new total ${result.finalTotalBytes} bytes",
+                        )
+                    }
                     pruned = true
                 }
             }
@@ -51,9 +41,15 @@ class BoardRendererModule : Module() {
         val outputFile = File(cacheDir, "$cacheKey.png")
 
         if (outputFile.exists()) {
-            // Touch mtime so LRU treats hot files as recently used.
-            outputFile.setLastModified(System.currentTimeMillis())
-            return "file://${outputFile.absolutePath}"
+            if (outputFile.length() > 0) {
+                // Touch mtime so LRU treats hot files as recently used.
+                outputFile.setLastModified(System.currentTimeMillis())
+                return "file://${outputFile.absolutePath}"
+            }
+            // A zero-byte leftover — a partial write from before this fix shipped
+            // (new writes can no longer land partially; see AtomicFileWrite) — is
+            // never a valid cache hit. Delete it and fall through to render.
+            outputFile.delete()
         }
 
         val renderResult = BoardRendererBridge.render(configJson)
@@ -91,11 +87,20 @@ class BoardRendererModule : Module() {
                     )
                 },
             ) {
-                FileOutputStream(outputFile).use { outputStream ->
-                    val written = overlayBitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
-                    if (!written) {
-                        outputFile.delete()
-                        throw Exception("PNG compression failed")
+                // Write to a temp file and rename into place so a thrown exception
+                // mid-compress (IO interruption, storage-full, process kill) can
+                // never leave a partial PNG at outputFile's path — it either lands
+                // whole or not at all (see AtomicFileWrite, #3748). The temp name is
+                // deterministic ("$cacheKey.png.tmp"), which is safe because Expo
+                // serialises every call into this module on a single modulesQueue
+                // (see #4041's PR body) — there's no concurrent renderOverlay call
+                // for the same cacheKey to collide with.
+                AtomicFileWrite.writeAtomically(outputFile) { tempFile ->
+                    FileOutputStream(tempFile).use { outputStream ->
+                        val written = overlayBitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
+                        if (!written) {
+                            throw Exception("PNG compression failed")
+                        }
                     }
                 }
             }

--- a/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/CachePruner.kt
+++ b/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/CachePruner.kt
@@ -1,0 +1,57 @@
+package com.boardsesh.boardrenderer
+
+import java.io.File
+
+/**
+ * Pure file-system bookkeeping for the overlay PNG cache directory:
+ *
+ * 1. Sweep any orphaned [AtomicFileWrite] temp file — a process kill between
+ *    the compress and the rename (see #3748) leaves one of these behind. It's
+ *    never a valid cache entry, so it's removed unconditionally rather than
+ *    waiting for the size cap to evict it by LRU.
+ * 2. Evict cache entries oldest-first by mtime until the directory is back
+ *    under [pruneCacheIfNeeded]'s `maxBytes`.
+ *
+ * Pure `java.io` on purpose — no Android framework calls (in particular, no
+ * `android.util.Log`) — so [CachePrunerTest] can run as a plain JUnit test.
+ * `BoardRendererModule` does the Android logging at the call site using the
+ * counts in the returned [Result].
+ */
+object CachePruner {
+    data class Result(
+        val orphanedTempFilesRemoved: Int,
+        val cacheEntriesEvicted: Int,
+        val finalTotalBytes: Long,
+    )
+
+    fun pruneCacheIfNeeded(cacheDir: File, maxBytes: Long): Result {
+        val files = cacheDir.listFiles()?.toList() ?: return Result(0, 0, 0)
+
+        val (staleTempFiles, cacheEntries) = files.partition {
+            it.name.endsWith(AtomicFileWrite.TEMP_SUFFIX)
+        }
+        var orphanedRemoved = 0
+        for (tempFile in staleTempFiles) {
+            if (tempFile.delete()) orphanedRemoved++
+        }
+
+        var totalBytes = cacheEntries.sumOf { it.length() }
+        if (totalBytes <= maxBytes) {
+            return Result(orphanedRemoved, 0, totalBytes)
+        }
+
+        // Android's File.lastModified() is our LRU proxy — atime is not
+        // reliably available on the filesystems Android caches live on.
+        val sorted = cacheEntries.sortedBy { it.lastModified() }
+        var evicted = 0
+        for (file in sorted) {
+            if (totalBytes <= maxBytes) break
+            val size = file.length()
+            if (file.delete()) {
+                totalBytes -= size
+                evicted++
+            }
+        }
+        return Result(orphanedRemoved, evicted, totalBytes)
+    }
+}

--- a/packages/mobile/modules/board-renderer/android/src/test/java/com/boardsesh/boardrenderer/AtomicFileWriteTest.kt
+++ b/packages/mobile/modules/board-renderer/android/src/test/java/com/boardsesh/boardrenderer/AtomicFileWriteTest.kt
@@ -1,0 +1,129 @@
+package com.boardsesh.boardrenderer
+
+import java.io.File
+import java.io.IOException
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Covers [AtomicFileWrite] in isolation — the temp-file-then-rename machinery
+ * that fixes #3748 (a mid-compress crash used to leave a truncated PNG at the
+ * final cache path, and the cache's `exists()`-only fast path then served it
+ * forever). The actual PNG `compress()` call needs a real `Bitmap` (JNI) and
+ * isn't exercised here; this covers the write-atomically wrapper with a plain
+ * byte-array stand-in, mirroring [CacheDirRecoveryTest]'s approach for the
+ * sibling helper.
+ */
+class AtomicFileWriteTest {
+    private lateinit var cacheDir: File
+
+    @Before
+    fun createCacheDir() {
+        cacheDir = File.createTempFile("board-thumbnails", "").let { placeholder ->
+            placeholder.delete()
+            placeholder.also { it.mkdirs() }
+        }
+    }
+
+    @After
+    fun removeCacheDir() {
+        cacheDir.deleteRecursively()
+    }
+
+    private fun tempFileFor(destination: File) =
+        File(destination.parentFile, "${destination.name}${AtomicFileWrite.TEMP_SUFFIX}")
+
+    @Test
+    fun `lands the destination file only after a successful write`() {
+        val destination = File(cacheDir, "climb.png")
+
+        AtomicFileWrite.writeAtomically(destination) { tempFile ->
+            tempFile.writeBytes(byteArrayOf(1, 2, 3))
+        }
+
+        assertTrue("destination exists after a clean write", destination.exists())
+        assertArrayEquals(byteArrayOf(1, 2, 3), destination.readBytes())
+        assertFalse("temp file is gone once renamed away", tempFileFor(destination).exists())
+    }
+
+    /**
+     * The regression this fix closes: a crash mid-write must never leave a
+     * partial file at the destination path for the cache's `exists()`-only
+     * fast path to pick up.
+     */
+    @Test
+    fun `a throw during write leaves no file at the destination`() {
+        val destination = File(cacheDir, "climb.png")
+
+        val failure = try {
+            AtomicFileWrite.writeAtomically(destination) { tempFile ->
+                tempFile.writeBytes(byteArrayOf(1, 2, 3))
+                throw IOException("simulated mid-compress crash")
+            }
+            null
+        } catch (thrown: IOException) {
+            thrown
+        }
+
+        assertEquals("simulated mid-compress crash", failure?.message)
+        assertFalse("no partial file at the destination", destination.exists())
+        assertFalse("temp file cleaned up on the failure path", tempFileFor(destination).exists())
+    }
+
+    /**
+     * A throwing write must not clobber whatever was already at the
+     * destination — e.g. a still-valid cache entry from a previous render.
+     */
+    @Test
+    fun `a throw during write leaves a pre-existing destination untouched`() {
+        val destination = File(cacheDir, "climb.png")
+        destination.writeBytes(byteArrayOf(9, 9, 9))
+
+        try {
+            AtomicFileWrite.writeAtomically(destination) { tempFile ->
+                tempFile.writeBytes(byteArrayOf(1, 2, 3))
+                throw IOException("simulated mid-compress crash")
+            }
+        } catch (expected: IOException) {
+            // expected
+        }
+
+        assertArrayEquals(
+            "pre-existing destination survives a failed re-render untouched",
+            byteArrayOf(9, 9, 9),
+            destination.readBytes(),
+        )
+    }
+
+    @Test
+    fun `a failed rename propagates and still cleans up the temp file`() {
+        // A directory sitting where the destination should be: renameTo can
+        // never win.
+        val destination = File(cacheDir, "climb.png")
+        destination.mkdirs()
+
+        val failure = try {
+            AtomicFileWrite.writeAtomically(destination) { tempFile ->
+                tempFile.writeBytes(byteArrayOf(1, 2, 3))
+            }
+            null
+        } catch (thrown: IOException) {
+            thrown
+        }
+
+        assertTrue(
+            "rename failure surfaces as an IOException",
+            failure?.message?.contains("Failed to move") == true,
+        )
+        assertFalse(
+            "temp file cleaned up even though the rename failed",
+            tempFileFor(destination).exists(),
+        )
+        assertTrue("destination directory itself is untouched", destination.isDirectory)
+    }
+}

--- a/packages/mobile/modules/board-renderer/android/src/test/java/com/boardsesh/boardrenderer/CachePrunerTest.kt
+++ b/packages/mobile/modules/board-renderer/android/src/test/java/com/boardsesh/boardrenderer/CachePrunerTest.kt
@@ -1,0 +1,97 @@
+package com.boardsesh.boardrenderer
+
+import java.io.File
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Covers [CachePruner] in isolation: the orphaned-temp-file sweep (a process
+ * kill between [AtomicFileWrite]'s compress and rename leaves a
+ * "$cacheKey.png.tmp" behind — #3748) and the size-based LRU eviction it runs
+ * alongside.
+ */
+class CachePrunerTest {
+    private lateinit var cacheDir: File
+
+    @Before
+    fun createCacheDir() {
+        cacheDir = File.createTempFile("board-thumbnails", "").let { placeholder ->
+            placeholder.delete()
+            placeholder.also { it.mkdirs() }
+        }
+    }
+
+    @After
+    fun removeCacheDir() {
+        cacheDir.deleteRecursively()
+    }
+
+    @Test
+    fun `sweeps an orphaned temp file regardless of the size cap`() {
+        val orphan = File(cacheDir, "abc123.png${AtomicFileWrite.TEMP_SUFFIX}")
+        orphan.writeBytes(byteArrayOf(1))
+        val validEntry = File(cacheDir, "def456.png")
+        validEntry.writeBytes(byteArrayOf(1, 2, 3))
+
+        val result = CachePruner.pruneCacheIfNeeded(cacheDir, maxBytes = 1_000_000)
+
+        assertEquals(1, result.orphanedTempFilesRemoved)
+        assertEquals(0, result.cacheEntriesEvicted)
+        assertFalse("orphaned temp file is gone", orphan.exists())
+        assertTrue("valid cache entry survives (well under cap)", validEntry.exists())
+    }
+
+    @Test
+    fun `does nothing when the cache is empty`() {
+        val result = CachePruner.pruneCacheIfNeeded(cacheDir, maxBytes = 1_000_000)
+
+        assertEquals(0, result.orphanedTempFilesRemoved)
+        assertEquals(0, result.cacheEntriesEvicted)
+        assertEquals(0L, result.finalTotalBytes)
+    }
+
+    @Test
+    fun `evicts oldest-first once the cap is exceeded, on top of the temp sweep`() {
+        val orphan = File(cacheDir, "orphan.png${AtomicFileWrite.TEMP_SUFFIX}")
+        orphan.writeBytes(ByteArray(10))
+
+        val oldest = File(cacheDir, "oldest.png")
+        oldest.writeBytes(ByteArray(10))
+        oldest.setLastModified(1_000)
+
+        val newest = File(cacheDir, "newest.png")
+        newest.writeBytes(ByteArray(10))
+        newest.setLastModified(2_000)
+
+        val result = CachePruner.pruneCacheIfNeeded(cacheDir, maxBytes = 15)
+
+        assertEquals(1, result.orphanedTempFilesRemoved)
+        assertEquals(1, result.cacheEntriesEvicted)
+        assertFalse("orphan swept", orphan.exists())
+        assertFalse("oldest entry evicted by LRU", oldest.exists())
+        assertTrue("newest entry survives", newest.exists())
+        assertEquals(10L, result.finalTotalBytes)
+    }
+
+    @Test
+    fun `a temp file never counts toward the size cap for real cache entries`() {
+        // Even a huge orphaned temp file must not push a well-under-cap real
+        // entry into eviction — it's swept unconditionally, before the cap
+        // check ever runs against the remaining entries.
+        val orphan = File(cacheDir, "huge.png${AtomicFileWrite.TEMP_SUFFIX}")
+        orphan.writeBytes(ByteArray(1_000))
+        val validEntry = File(cacheDir, "small.png")
+        validEntry.writeBytes(ByteArray(5))
+
+        val result = CachePruner.pruneCacheIfNeeded(cacheDir, maxBytes = 10)
+
+        assertEquals(1, result.orphanedTempFilesRemoved)
+        assertEquals(0, result.cacheEntriesEvicted)
+        assertTrue("real entry untouched", validEntry.exists())
+        assertEquals(5L, result.finalTotalBytes)
+    }
+}

--- a/packages/mobile/modules/board-renderer/ios/BoardRendererModule.swift
+++ b/packages/mobile/modules/board-renderer/ios/BoardRendererModule.swift
@@ -101,12 +101,21 @@ public class BoardRendererModule: Module {
     _ = self.pruneOnce
     let outputUrl = self.cacheDir.appendingPathComponent("\(cacheKey).png")
 
-    if FileManager.default.fileExists(atPath: outputUrl.path) {
+    if let attributes = try? FileManager.default.attributesOfItem(atPath: outputUrl.path),
+      let existingSize = attributes[.size] as? Int,
+      existingSize > 0
+    {
       // Touch mtime so LRU treats hot files as recently used.
       try? FileManager.default.setAttributes(
         [.modificationDate: Date()], ofItemAtPath: outputUrl.path
       )
       return outputUrl.absoluteString
+    } else if FileManager.default.fileExists(atPath: outputUrl.path) {
+      // A zero-byte leftover — a partial write from before this fix shipped
+      // (writes are now atomic; see the `.atomic` option below, and the
+      // Android twin AtomicFileWrite.kt, #3748) — is never a valid cache hit.
+      // Delete it and fall through to render.
+      try? FileManager.default.removeItem(atPath: outputUrl.path)
     }
 
     let jsonData = Array(configJson.utf8)
@@ -171,7 +180,11 @@ public class BoardRendererModule: Module {
     }
 
     try retryOnceAfterRecreatingCacheDir {
-      try pngData.write(to: outputUrl)
+      // .atomic writes to a temp file in cacheDir and renames it into place,
+      // so a crash mid-write can never leave a partial PNG at outputUrl's path
+      // — it either lands whole or not at all (see AtomicFileWrite.kt for the
+      // Android twin, #3748).
+      try pngData.write(to: outputUrl, options: .atomic)
     }
     return outputUrl.absoluteString
   }


### PR DESCRIPTION
> [!IMPORTANT]
> **[native-train]** — this PR touches native Kotlin (`modules/board-renderer/android/`) and Swift (`modules/board-renderer/ios/`) and moves the Expo native fingerprint. Per repo policy, `main` must stay OTA-compatible with store binaries, so this PR **stays a draft** and rides the next native release train — do not mark it ready for review or merge it on its own schedule.

## Summary

Closes #3748.

`BoardRendererModule.renderOverlay` writes each climb's hold-overlay PNG to a cache file keyed by `cacheKey`, and treats any future call for that key as a cache hit purely on `File.exists()` / `FileManager.fileExists(atPath:)`. If the write was interrupted partway through — an IO error, a storage-full condition, the process getting killed mid-compress — a truncated PNG was left at the final path with nothing to clean it up, and it was then served as a "successful" render forever. Unlike the vanished-cache-dir bug fixed in #3182/#4041, no JS-side existence check can catch this: the file *does* exist, it's just wrong.

### The fix

- **Android** — new `AtomicFileWrite.writeAtomically(destination) { tempFile -> … }` (pure `java.io`, no Android framework calls): writes into `"$cacheKey.png.tmp"` next to the destination, then `renameTo()`s it into place only after a fully successful `compress()`. Any throw — from the compress call or a failed rename — deletes the temp file in a `finally` and leaves the destination completely untouched, so a partial write is now structurally impossible instead of relying on cleanup-after-the-fact. Composes inside the existing `CacheDirRecovery.retryOnceAfterRecreating` wrapper from #4041 (that guards the *directory* vanishing; this guards the *write* itself).
- **Read-side sanity check (both platforms)** — the fast path now also requires the cached file's length to be `> 0`, not just `exists()`. This is what lets a file already corrupted by the bug *before* this fix ships self-heal on its next request — new writes can no longer land partially, but old corrupt ones are still sitting on devices until they're overwritten.
- **`CachePruner`** — extracted the existing size-cap LRU eviction out of `BoardRendererModule` into its own pure-`java.io` object, alongside a new unconditional sweep of orphaned `*.tmp` files. A process kill between the temp write and the rename leaves one of these behind; it's never a valid cache entry, so it's swept regardless of whether the cache is over its size cap.
- **iOS** — one-line fix: `pngData.write(to: outputUrl, options: .atomic)`. Foundation's `.atomic` option already does the temp-file-then-rename dance Android needed hand-rolled, so no custom logic was needed there.

### Assumptions worth flagging

- The Android temp filename is deterministic (`"$cacheKey.png.tmp"`), not a random `File.createTempFile` name. That's only safe because Expo serialises every call into this module on a single `modulesQueue` (documented in #4041's PR body) — there's no concurrent `renderOverlay` call for the same `cacheKey` to collide with today. Worth revisiting if that ever changes.
- iOS's `.atomic` write is a Foundation-internal implementation; if it ever leaves its own OS-managed stray temp file behind on a kill, that's outside our control and not something this PR chases further.

## Release Notes

- [ ] No release note needed (internal / technical change)

Board hold overlays can no longer get stuck showing a corrupted image after a rare mid-save crash — a broken render clears itself out instead of sticking around forever.

## Test plan

**Green `vp` checks below do not cover this fix.** This is pure native Kotlin/Swift; nothing in `vp check` / `vp run typecheck:mobile` / `vp run test:mobile` / `vp run check:mobile-bundle` compiles or exercises either platform's code. The real coverage is native CI:

- **Android**: new `AtomicFileWriteTest.kt` (happy path; a throw during write leaves nothing at the destination; a throw during write leaves a *pre-existing* destination completely untouched — the actual regression this closes; a failed rename still cleans up the temp file) and `CachePrunerTest.kt` (the orphaned-temp sweep, on its own and layered with the existing size-cap LRU eviction). Both are plain JUnit — no Robolectric, no real `Bitmap`/JNI — matching `CacheDirRecoveryTest`'s existing pattern for the sibling helper (#4041). These run in CI via `.github/workflows/android-pr-rn.yml`'s `board-renderer:testDebugUnitTest` job (the module is already listed in `TESTED_MODULES`).
- **iOS**: no new test added. The fix is a single documented Apple API flag (`.atomic`) with no hand-rolled logic to isolate, and there's no existing board-renderer coverage under `ios-tests/` to extend — a new XCTest target felt disproportionate for a P3 fix. Validated by `ios-rn-ci.yml`'s existing build-for-testing step (compiles the module) plus manual code review; a real mid-write-crash repro isn't practically automatable here.
- No JS/TS touched — the native return contract (`file://…` URI string) is unchanged, so nothing on the RN side needed updating.
- Not run locally: this environment has no Android SDK / Xcode toolchain to execute `testDebugUnitTest` or build the iOS target directly, so this relies on CI for both platforms.
