### PR TITLE
fix(mobile): keep You-page bar charts inside their card width

### DIFF
--- a/packages/mobile/src/components/you/YouCharts.tsx
+++ b/packages/mobile/src/components/you/YouCharts.tsx
@@ -32,6 +32,21 @@ const AXIS_LABEL_SIZE = 11;
 const STACK_BAR_RADIUS = 3;
 const MIN_ZOOM_SCALE = 1;
 const MAX_ZOOM_SCALE = 2.75;
+// gifted-charts does NOT lay its chart out inside the `width` prop we hand it.
+// BarAndLineChartsWrapper positions the plot ScrollView absolutely at
+// `marginLeft: yAxisLabelWidth + yAxisThickness` with `width: props.width`, and
+// renderHorizSections draws the rules/x-axis row as a `yAxisLabelWidth` spacer
+// followed by a `props.width + endSpacing` band. So the span the chart really
+// occupies is `yAxisLabelWidth + width + endSpacing` — all three have to come
+// out of the measured frame or the last bar and its label bleed past the
+// rounded card edge (#3778, #3050). We pin `endSpacing={0}` (it otherwise
+// defaults to `spacing`, and to 20 on the grouped chart, which passes spacing
+// per-datum), subtract the y-axis gutter below, and keep a small inset as slack.
+const CHART_WIDTH_INSET = 8;
+// Gutter reserved for the y-axis scale labels when `showYAxisScale` is set.
+// Passed straight to BarChart's `yAxisLabelWidth` so the number we budget for
+// and the number gifted-charts offsets the plot by can never drift apart.
+const Y_AXIS_LABEL_WIDTH = 32;
 // Floor for grouped flash|redpoint bars so a dense V0-V17 axis keeps each bar
 // above the iOS 44pt / Android 48dp touch target instead of shrinking to 4px.
 const MIN_GROUPED_BAR = 6;
@@ -386,7 +401,9 @@ export const StackedBarChart = memo(function StackedBarChart({
           zoomable={interactive && zoomable}
         >
           {(width, zoomScale, scrollEnabled) => {
-            const fitted = fitBars(width, stackData.length, minBarWidth);
+            const axisGutter = showYAxisScale ? Y_AXIS_LABEL_WIDTH : 0;
+            const chartWidth = width - CHART_WIDTH_INSET - axisGutter;
+            const fitted = fitBars(chartWidth, stackData.length, minBarWidth);
             const barWidth = Math.max(minBarWidth, Math.round(fitted.barWidth * zoomScale));
             const spacing = Math.max(2, Math.round(fitted.spacing * zoomScale));
             // gifted sizes each x-axis label box to ~one bar by default, so a wide
@@ -401,14 +418,15 @@ export const StackedBarChart = memo(function StackedBarChart({
             return (
               <BarChart
                 stackData={sizedData}
-                width={width - 8}
+                width={chartWidth}
                 height={height - 28}
                 barWidth={barWidth}
                 spacing={spacing}
                 initialSpacing={8}
+                endSpacing={0}
                 hideRules={!showYAxisScale}
                 hideYAxisText={!showYAxisScale}
-                yAxisLabelWidth={showYAxisScale ? 32 : 0}
+                yAxisLabelWidth={axisGutter}
                 maxValue={yAxisMaxValue}
                 yAxisThickness={0}
                 xAxisThickness={StyleSheet.hairlineWidth}
@@ -504,11 +522,14 @@ export const GroupedBarChart = memo(function GroupedBarChart({
           zoomable={interactive && zoomable}
         >
           {(width, zoomScale, scrollEnabled) => {
+            const chartWidth = width - CHART_WIDTH_INSET;
             const list = bars ?? [];
             const initial = 8;
             const baseBarWidth = Math.max(
               MIN_GROUPED_BAR,
-              Math.floor((width - initial * 2 - groupGap * list.length - innerGap * list.length) / (list.length * 2)),
+              Math.floor(
+                (chartWidth - initial * 2 - groupGap * list.length - innerGap * list.length) / (list.length * 2),
+              ),
             );
             const barWidth = Math.max(MIN_GROUPED_BAR, Math.round(baseBarWidth * zoomScale));
             const zoomedGroupGap = Math.max(groupGap, Math.round(groupGap * zoomScale));
@@ -552,14 +573,20 @@ export const GroupedBarChart = memo(function GroupedBarChart({
             return (
               <BarChart
                 data={data}
-                width={width - 8}
+                width={chartWidth}
                 height={height - 28 - labelLayout.headroom}
                 barWidth={barWidth}
                 initialSpacing={initial}
+                endSpacing={0}
                 barBorderRadius={STACK_BAR_RADIUS}
                 topLabelContainerStyle={{ width: labelLayout.width, left: labelLayout.left }}
                 hideRules
                 hideYAxisText
+                // `hideYAxisText` alone still reserves gifted-charts'
+                // `yAxisEmptyLabelWidth` (10px) to the left of the plot, which
+                // lands outside `width`. Pin it to 0 so `chartWidth` is the
+                // whole occupied span (#3778, #3050).
+                yAxisLabelWidth={0}
                 maxValue={yAxisMaxValue}
                 yAxisThickness={0}
                 xAxisThickness={StyleSheet.hairlineWidth}
@@ -769,6 +796,12 @@ const styles = StyleSheet.create({
     position: 'relative',
     alignItems: 'center',
     justifyContent: 'center',
+    // Second layer behind the width budgeting above: if a future gifted-charts
+    // version reserves gutter we didn't account for, it gets clipped at the
+    // frame instead of bleeding past the rounded card edge (#3778, #3050). The
+    // reset-zoom button sits inside the frame and the tooltip overlay is a
+    // sibling on `chartShell`, so neither is affected.
+    overflow: 'hidden',
   },
   emptyState: {
     alignItems: 'center',

--- a/packages/mobile/src/components/you/__tests__/you-charts-width-budget.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/you-charts-width-budget.test.tsx
@@ -1,0 +1,250 @@
+// @vitest-environment jsdom
+//
+// Regression coverage for #3778 / #3050: the You-page Activity and Grade
+// Distribution bar charts (and the Flash vs Redpoint grouped chart, same file
+// / same bug) bled past the rounded card edge.
+//
+// gifted-charts does not draw inside the `width` prop it is given. It offsets
+// the plot area by `yAxisLabelWidth` to the LEFT of that width and extends the
+// rules/x-axis row by `endSpacing` to the RIGHT of it, so the span it really
+// occupies is `yAxisLabelWidth + width + endSpacing`. Both You-page charts
+// handed it the full measured frame width (minus a token 8px) while also asking
+// for a y-axis gutter, so the chart occupied ~22-32px more than the card had.
+//
+// This repo has no visual regression harness for RN charts, so these tests pin
+// the prop contract instead: the FULL occupied span must fit inside the
+// measured frame, and the fitted bar/spacing content must fit inside the width
+// prop. The library-default fallbacks below mirror gifted-charts-core 0.1.81
+// (`AxesAndRulesDefaults.yAxisEmptyLabelWidth = 10`, `yAxisLabelWidth = 35`,
+// `endSpacing = spacing`, `BarDefaults.spacing = 20`) so a chart that simply
+// omits a prop is still measured at its true rendered size.
+import { createElement, useEffect, type ReactNode } from 'react';
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RawGroupedBar } from '@boardsesh/profile-stats';
+import type { ColoredBar } from '../profile-chart-colors';
+
+const FRAME_WIDTH = 320;
+
+// Minimal RN surface — mirrors you-charts-tap-tooltip.test.tsx's mock so
+// ChartFrame's width-gated render path reaches the chart under test.
+// PixelRatio is needed because GroupedBarChart reads PixelRatio.getFontScale()
+// for its top-label rotation layout (#3779).
+vi.mock('react-native', () => ({
+  View: ({ children, onLayout }: { children?: ReactNode; onLayout?: (event: unknown) => void }) => {
+    useEffect(() => {
+      onLayout?.({ nativeEvent: { layout: { width: FRAME_WIDTH, height: 160, x: 0, y: 0 } } });
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- fire once on mount, matching a real layout pass
+    }, []);
+    return createElement('div', null, children);
+  },
+  Pressable: ({ children }: { children?: ReactNode }) => createElement('button', { type: 'button' }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+  PixelRatio: { getFontScale: () => 1 },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+type BarChartCall = {
+  width?: number;
+  barWidth?: number;
+  spacing?: number;
+  initialSpacing?: number;
+  endSpacing?: number;
+  yAxisLabelWidth?: number;
+  hideYAxisText?: boolean;
+  stackData?: { stacks?: { value: number }[] }[];
+  data?: { spacing?: number }[];
+};
+
+const barChartCalls: BarChartCall[] = [];
+
+vi.mock('react-native-gifted-charts', () => ({
+  BarChart: (props: BarChartCall) => {
+    barChartCalls.push(props);
+    return createElement('div', { 'data-testid': 'gifted-bar-chart' });
+  },
+  LineChart: () => createElement('div', { 'data-testid': 'gifted-line-chart' }),
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({
+  Icon: () => createElement('span', { 'data-testid': 'icon' }),
+}));
+vi.mock('../../ActivityIndicator', () => ({
+  ActivityIndicator: () => createElement('span', { 'data-testid': 'activity-indicator' }),
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    variant: 'material' as const,
+    colorScheme: 'light' as const,
+    systemColors: {
+      secondaryLabel: '#666666',
+      tertiaryLabel: '#999999',
+      elevatedSurface: '#ffffff',
+      separator: '#dddddd',
+      label: '#111111',
+    },
+    chartColors: {
+      secondaryLabel: '#666666',
+      tertiaryLabel: '#999999',
+      elevatedSurface: '#ffffff',
+      separator: '#dddddd',
+      label: '#111111',
+    },
+  }),
+}));
+
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 0: 0, 1: 4, 2: 8, 3: 12, 4: 16 },
+  borderRadius: { full: 999, xl: 16 },
+  opacity: { peek: 0.5 },
+  materialElevationByLevel: { level2: {} },
+}));
+
+vi.mock('../../../lib/haptics', () => ({
+  hapticSelection: vi.fn(),
+}));
+
+vi.mock('../profile-chart-colors', () => ({
+  gradeChartColor: (key: string) => `grade-${key}`,
+  layoutChartColor: (key: string) => `layout-${key}`,
+  flashRedpointColor: (key: string) => `status-${key}`,
+}));
+
+import { StackedBarChart, GroupedBarChart } from '../YouCharts';
+
+// gifted-charts-core defaults, applied when we omit the prop. Transcribed from
+// `AxesAndRulesDefaults` / `BarDefaults` in dist/utils/constants.js at the
+// version pinned in bun.lock (0.1.81) — bun's isolated install puts
+// gifted-charts-core outside packages/mobile's resolution path, so they can't be
+// imported. COUPLING: bumping react-native-gifted-charts can move these, and a
+// bump that grows a default would make the charts overflow again while these
+// tests stayed green. Re-read dist/utils/constants.js on any such bump.
+const GIFTED_DEFAULT_SPACING = 20;
+const GIFTED_Y_AXIS_LABEL_WIDTH = 35;
+const GIFTED_Y_AXIS_EMPTY_LABEL_WIDTH = 10;
+
+beforeEach(() => {
+  barChartCalls.length = 0;
+});
+
+/**
+ * Horizontal span BarChart actually occupies in its parent: the y-axis gutter it
+ * offsets the plot by, plus the `width` it draws into, plus the `endSpacing`
+ * the rules/x-axis row extends by. This is the number that must fit the card.
+ */
+function occupiedSpan(call: BarChartCall): number {
+  const barLevelSpacing = call.spacing ?? GIFTED_DEFAULT_SPACING;
+  const endSpacing = call.endSpacing ?? barLevelSpacing;
+  const yAxisGutter =
+    call.yAxisLabelWidth ?? (call.hideYAxisText ? GIFTED_Y_AXIS_EMPTY_LABEL_WIDTH : GIFTED_Y_AXIS_LABEL_WIDTH);
+  return yAxisGutter + (call.width ?? 0) + endSpacing;
+}
+
+/** Total pixel span the fitted stack-bar data actually occupies. */
+function stackedContentSpan(call: BarChartCall): number {
+  const count = call.stackData?.length ?? 0;
+  const barWidth = call.barWidth ?? 0;
+  const spacing = call.spacing ?? 0;
+  const initial = call.initialSpacing ?? 0;
+  return initial * 2 + count * barWidth + Math.max(0, count - 1) * spacing;
+}
+
+/**
+ * Same, for the flattened grouped data: `spacing` is carried per-datum there
+ * rather than as a single BarChart-level prop.
+ */
+function groupedContentSpan(call: BarChartCall): number {
+  const data = call.data ?? [];
+  const barWidth = call.barWidth ?? 0;
+  const initial = call.initialSpacing ?? 0;
+  const gaps = data.reduce((total, datum) => total + (datum.spacing ?? 0), 0);
+  return initial + data.length * barWidth + gaps;
+}
+
+describe('StackedBarChart width budget (#3778, #3050)', () => {
+  const bars: ColoredBar[] = Array.from({ length: 10 }, (_, index) => ({
+    key: `V${index}`,
+    label: `V${index}`,
+    segments: [{ key: 'kilter-1', label: 'Kilter Original', value: index + 1 }],
+  }));
+
+  it('keeps the whole chart — y-axis gutter included — inside the measured frame', () => {
+    // `showYAxisScale` is what ProgressTab passes for Activity and Grade
+    // Distribution, the two charts reported in #3778 / #3050. It buys a 32px
+    // y-axis gutter that gifted-charts renders OUTSIDE the `width` prop, so it
+    // has to be budgeted out of the frame. Pre-fix this was 32 + 312 + 8 = 352
+    // against a 320px frame.
+    render(<StackedBarChart bars={bars} colorBy="layout" showYAxisScale />);
+
+    expect(barChartCalls).toHaveLength(1);
+    const call = barChartCalls[0]!;
+    expect(call.width).toBeGreaterThan(0);
+    expect(occupiedSpan(call)).toBeLessThanOrEqual(FRAME_WIDTH);
+  });
+
+  it('sizes bars to fit inside the width actually given to BarChart', () => {
+    render(<StackedBarChart bars={bars} colorBy="layout" showYAxisScale />);
+
+    const call = barChartCalls[0]!;
+    // The fitted content must also not exceed the canvas BarChart was told to
+    // draw into, or the last bar is clipped by the plot ScrollView at zoom 1.
+    expect(stackedContentSpan(call)).toBeLessThanOrEqual(call.width!);
+  });
+
+  it('stays inside the frame without the y-axis scale too', () => {
+    render(<StackedBarChart bars={bars} colorBy="layout" />);
+
+    const call = barChartCalls[0]!;
+    expect(call.yAxisLabelWidth).toBe(0);
+    expect(occupiedSpan(call)).toBeLessThanOrEqual(FRAME_WIDTH);
+    expect(stackedContentSpan(call)).toBeLessThanOrEqual(call.width!);
+  });
+});
+
+describe('GroupedBarChart width budget (#3778, #3050)', () => {
+  const groupedBars: RawGroupedBar[] = Array.from({ length: 8 }, (_, index) => ({
+    key: `V${index}`,
+    label: `V${index}`,
+    values: [
+      { key: 'flash', label: 'Flash', value: index },
+      { key: 'redpoint', label: 'Redpoint', value: index + 1 },
+    ],
+  }));
+
+  it('keeps the whole chart — y-axis gutter included — inside the measured frame', () => {
+    render(<GroupedBarChart bars={groupedBars} />);
+
+    expect(barChartCalls).toHaveLength(1);
+    const call = barChartCalls[0]!;
+    expect(call.width).toBeGreaterThan(0);
+    // `hideYAxisText` on its own still reserves gifted-charts'
+    // `yAxisEmptyLabelWidth` (10px) outside `width`, and an unset `endSpacing`
+    // falls back to the 20px default `spacing` because this chart carries
+    // spacing per-datum. Pre-fix that was 10 + 312 + 20 = 342 against a 320px
+    // frame.
+    expect(occupiedSpan(call)).toBeLessThanOrEqual(FRAME_WIDTH);
+  });
+
+  it('pins the y-axis gutter so the library default cannot creep back', () => {
+    render(<GroupedBarChart bars={groupedBars} />);
+
+    const call = barChartCalls[0]!;
+    expect(call.yAxisLabelWidth).toBe(0);
+    expect(call.endSpacing).toBe(0);
+  });
+
+  it('sizes grouped bars to fit inside the width actually given to BarChart', () => {
+    render(<GroupedBarChart bars={groupedBars} />);
+
+    const call = barChartCalls[0]!;
+    expect(call.data?.length).toBe(groupedBars.length * 2);
+    expect(groupedContentSpan(call)).toBeLessThanOrEqual(call.width!);
+  });
+});


### PR DESCRIPTION
## Summary

The You → Progress tab's Activity and Grade Distribution bar charts (and the
Flash vs Redpoint grouped chart, same file, same bug) could render past the
rounded card edge — grid lines, the last bar, and its label bleeding straight
to the screen edge with no clipping. Two bug reports hit the same root cause:

- **#3778** — internal report with a screenshot showing the grid rules and
  rightmost bar crossing the card border on both the Activity and Grade
  Distribution charts.
- **#3050** — a TestFlight tester on iPhone 15 (nb-NO locale): "Charts goes
  beyond the rectangle… if stuff doesnt fit maybe should be able to swipe to
  see." Same component, same geometry bug — not locale-specific, it's pure
  arithmetic, not label-width driven.

### Root cause

`react-native-gifted-charts` (`^1.4.77` / `gifted-charts-core@0.1.81`) does not
draw inside the `width` prop it's handed:

- `BarAndLineChartsWrapper` positions the plot `ScrollView` absolutely at
  `marginLeft: yAxisLabelWidth + yAxisThickness`, `width: props.width`.
- `renderHorizSections` draws the rules/x-axis row as a `yAxisLabelWidth`
  spacer followed by a `props.width + endSpacing` band.

So the real occupied span is `yAxisLabelWidth + width + endSpacing`. Both
`StackedBarChart` (Activity, Grade Distribution) and `GroupedBarChart`
(Flash vs Redpoint) in `packages/mobile/src/components/you/YouCharts.tsx`
handed `BarChart` the measured frame width minus a flat 8px, while also
asking for a y-axis gutter that gifted-charts renders *outside* that width,
and never pinned `endSpacing` (which defaults to `spacing`, 20px on the
grouped chart). Net overflow: ~32px on the stacked charts, ~22px on the
grouped one, against nothing clipping it (`styles.frame` had no `overflow`).

### Fix

- Compute one `chartWidth` budget — measured frame minus a fixed inset minus
  the y-axis gutter — that both the bar-fitting math and the `BarChart`
  `width` prop use, so they can't drift apart.
- Pin `endSpacing={0}` and `yAxisLabelWidth` explicitly on both charts so a
  future library default can't silently reopen the gap.
- Add `overflow: 'hidden'` on the chart frame as a second clipping layer.
- `TotalAreaChart` (the V-Points line, a *different* bug — #3780, cardinal-
  spline overshoot) is untouched. That's owned separately; this PR is scoped
  to sizing/overflow only.

This ports the sizing fix from draft #4029 (now conflicting with `main`),
rescoped to sizing-only — the `curved={false}` V-Points change and its test
file are excluded — and extended to also close #3050, which #4029 never
referenced.

On the tester's "maybe should be able to swipe to see" suggestion: the fix
here is to make the chart fit, matching #3778's resolution, rather than add
permanent horizontal scroll. `ChartFrame` already supports pinch-zoom-to-scroll
for genuinely dense data (many weeks / many grades), which covers that case
without a UX change.

Closes #3778
Closes #3050

## Release Notes

- [ ] No release note needed (internal / technical change)

Your Activity, Grade Distribution, and Flash vs Redpoint charts on the You
page now stay inside their cards instead of spilling past the edge.

## Test plan

- New regression test `you-charts-width-budget.test.tsx`: fits fake
  `StackedBarChart`/`GroupedBarChart` data and asserts the full occupied span
  (`yAxisLabelWidth + width + endSpacing`) never exceeds the measured card
  frame, and the fitted bar/spacing content never exceeds the `width` prop
  `BarChart` is actually given (6 assertions).
- Verified fail-on-revert: stashed the fix and reran against `main`'s
  `YouCharts.tsx` — 5 of 6 assertions go red, including both headline
  occupied-span checks (`352 > 320` stacked, `342 > 320` grouped).
- `vp check` — 0 errors (296 pre-existing warnings elsewhere, none touching
  changed files).
- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — 4856/4857 passed; one unrelated pre-existing test
  (`app/__tests__/acknowledgements.test.tsx`, a GitHub-profile-chip test) hit
  a 5s timeout under this box's load, confirmed flaky by rerunning it alone
  (passed in 3.56s).
- `vp run check:mobile-bundle` — OK.

### Visual QA

I attempted the automated Android-emulator screenshot path
(`vp run mobile:android-doctor` → `vp run mobile:android-shots`) for
before/after captures of the Activity and Grade Distribution cards in light
and dark. The SDK bootstrap succeeded (KVM present, AVD ready), but the
emulator boot itself segfaulted under `xvfb-run` twice in a row, both times
at the identical point (right after "Emulator is performing a full startup"),
most likely from resource contention with several other agents concurrently
running heavy builds/tests/emulators on this same sandbox (shared `/dev/kvm`,
competing display servers). Concluding the path is infeasible in this
sandbox right now rather than retrying further — **the emulator path is
infeasible in this environment.**

This is a layout/visual fix with no automated before/after image attached.
@marcodejongh — requesting visual sign-off on this one (You → Progress tab,
Activity + Grade Distribution + Flash vs Redpoint, light and dark, on a
narrow device if convenient) before merge. Per repo policy, visual PRs are
never auto-merged regardless of CI/screenshot status.
