### PR TITLE
fix(mobile): release board art under the player, guard remix-only render throws

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/create.tsx
+++ b/packages/mobile/app/(tabs)/climbs/create.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
+import { SUPPORTED_BOARDS } from '@boardsesh/board-config';
 import type { BoardName } from '@boardsesh/shared-schema';
 import { CreateClimbScreen } from '../../../src/components/create-climb/CreateClimbScreen';
 import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
@@ -20,6 +21,21 @@ type CreateClimbParams = {
 };
 
 /**
+ * Narrow an untrusted board name to a supported one, or `undefined`.
+ *
+ * `useLocalSearchParams` is untrusted input on this route: the app's
+ * universal-link entry is a wildcard, so `…/climbs/create?boardName=<anything>`
+ * can open it cold from outside the app. The value used to be cast straight to
+ * `BoardName` and indexed into `STATE_TO_PRIMARY_CODE`, which throws during
+ * render on the remix/edit path (#3804). Treating an unsupported value as absent
+ * makes it fall back to the active board, exactly like a missing param.
+ */
+function supportedBoardName(candidate: string | undefined): BoardName | undefined {
+  if (candidate == null) return undefined;
+  return (SUPPORTED_BOARDS as readonly string[]).includes(candidate) ? (candidate as BoardName) : undefined;
+}
+
+/**
  * Create-climb route. Board config comes from route params (passed by the FAB,
  * fork/edit entry points); falls back to the user's active board when the
  * params are absent so the screen can be opened bare.
@@ -29,7 +45,7 @@ export default function CreateClimbRoute() {
   const { data: activeBoard } = useActiveBoard();
 
   const board = useMemo(() => {
-    const boardName = (params.boardName ?? activeBoard?.boardType) as BoardName | undefined;
+    const boardName = supportedBoardName(params.boardName) ?? supportedBoardName(activeBoard?.boardType);
     const layoutId = params.layoutId ? Number(params.layoutId) : activeBoard?.layoutId;
     const sizeId = params.sizeId ? Number(params.sizeId) : activeBoard?.sizeId;
     const setIds = params.setIds ?? activeBoard?.setIds;

--- a/packages/mobile/src/components/create-climb/__tests__/brush-roles.test.ts
+++ b/packages/mobile/src/components/create-climb/__tests__/brush-roles.test.ts
@@ -1,9 +1,17 @@
 import { describe, expect, it } from 'vitest';
+import type { BoardName } from '@boardsesh/shared-schema';
 import { brushRoleColor, getPaintRoles } from '../brush-roles';
 
 describe('getPaintRoles', () => {
   it('excludes FOOT for MoonBoard saved-climb roles', () => {
     expect(getPaintRoles('moonboard')).toEqual(['STARTING', 'HAND', 'FINISH']);
+  });
+
+  // Callers read this during render, so an unknown board must degrade rather than
+  // throw where nothing can catch it (#3804).
+  it('returns no paint roles for a board missing from the role table', () => {
+    expect(() => getPaintRoles('not-a-board' as BoardName)).not.toThrow();
+    expect(getPaintRoles('not-a-board' as BoardName)).toEqual([]);
   });
 
   it('returns all four paint roles for Kilter', () => {

--- a/packages/mobile/src/components/create-climb/brush-roles.ts
+++ b/packages/mobile/src/components/create-climb/brush-roles.ts
@@ -11,9 +11,12 @@ export type BrushRole = Extract<HoldState, 'STARTING' | 'HAND' | 'FINISH' | 'FOO
 
 export const PAINT_ROLES: ReadonlyArray<Exclude<BrushRole, 'OFF'>> = ['STARTING', 'HAND', 'FINISH', 'FOOT'];
 
+// Optional-chained for the same reason as `brushRoleColor` below: callers read this
+// during render (CreateDrawerActionBar, HoldRoleSheet), so an unknown `boardName`
+// would throw where nothing can catch it. An unknown board paints no roles.
 export function getPaintRoles(boardName: BoardName): ReadonlyArray<Exclude<BrushRole, 'OFF'>> {
   const supportedRoles = STATE_TO_PRIMARY_CODE[boardName];
-  return PAINT_ROLES.filter((role) => supportedRoles[role] !== undefined);
+  return PAINT_ROLES.filter((role) => supportedRoles?.[role] !== undefined);
 }
 
 /**

--- a/packages/mobile/src/providers/__tests__/board-art-visibility-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/board-art-visibility-provider.test.tsx
@@ -61,4 +61,41 @@ describe('BoardArtVisibilityProvider', () => {
     const { container } = renderWithin('climbs');
     expect(readVisible(container)).toBe('true');
   });
+
+  // The player paints its own opaque backing over the whole tab shell, so the tab's
+  // list thumbnails are occluded but still mounted — pinning their decoded bitmaps
+  // through the app's peak board-art moment (the player's own full-res board is live,
+  // and remixing from it opens the create board too). #3804.
+  it('hides tab board art on iPhone while the player is up', () => {
+    deviceLayout.isPad = false;
+    segments.value = ['play'];
+    const { container } = renderWithin('climbs');
+    expect(readVisible(container)).toBe('false');
+  });
+
+  // Over-blanking guards. Both of these are root/pushed surfaces that float over a
+  // still-VISIBLE list, so blanking under them would be a user-facing regression —
+  // which is why occlusion is an allowlist of opaque-backed routes rather than
+  // "no tab is active".
+  it('stays visible on iPhone under the user drawer', () => {
+    deviceLayout.isPad = false;
+    segments.value = ['user-drawer'];
+    const { container } = renderWithin('climbs');
+    expect(readVisible(container)).toBe('true');
+  });
+
+  it('stays visible on iPhone under the create drawer', () => {
+    deviceLayout.isPad = false;
+    segments.value = ['(tabs)', 'climbs', 'create'];
+    const { container } = renderWithin('climbs');
+    expect(readVisible(container)).toBe('true');
+  });
+
+  it('still blanks an inactive iPad tab under the user drawer', () => {
+    // iPad behaviour is unchanged: a root modal leaves no tab active, so every tab
+    // blanks via the iPad branch regardless of the new player check.
+    segments.value = ['user-drawer'];
+    const { container } = renderWithin('climbs');
+    expect(readVisible(container)).toBe('false');
+  });
 });

--- a/packages/mobile/src/providers/board-art-visibility-provider.tsx
+++ b/packages/mobile/src/providers/board-art-visibility-provider.tsx
@@ -2,7 +2,7 @@ import { type ReactNode } from 'react';
 import { useSegments } from 'expo-router';
 import { BoardArtVisibilityContext } from '../components/board-art-visibility-context';
 import { useDeviceLayout } from '../hooks/use-device-layout';
-import { tabsActiveSegment } from '../lib/route-segments';
+import { isPlayerRoute, tabsActiveSegment } from '../lib/route-segments';
 
 // The top-level tab names ((tabs)/<name>). Typing the `tab` prop as this union
 // (not a bare string) makes a typo in a layout's `tab="…"` a compile error rather
@@ -10,26 +10,45 @@ import { tabsActiveSegment } from '../lib/route-segments';
 export type BoardArtTab = 'climbs' | 'discover' | 'home' | 'profile' | 'record' | 'wall';
 
 /**
- * Wraps one iPad tab's stack so its board art blanks while another tab is the
- * focused destination. The iPad shell keeps every tab mounted
- * (`detachInactiveScreens={false}`), so without this an inactive tab's
- * `LayeredClimbImage` views retain their decoded bitmaps off-screen for the life
- * of the session — `Image.clearMemoryCache()` reclaims only unreferenced cache
- * copies, not bitmaps a mounted view still holds (#3803).
+ * Wraps one tab's stack so its board art blanks while that art is not on screen.
+ * Two independent hidden cases, because they have different cost/benefit:
  *
- * iPhone is opted out by construction (`isPad` is launch-fixed false → always
- * visible): its tabs already freeze/detach on blur, and re-decoding board art on
- * every tab return would flash the thumbnails for no memory win.
+ * 1. **The player is up — every device.** `/play` is a `transparentModal` that
+ *    paints its OWN opaque backing (app/_layout.tsx), so the whole tab shell
+ *    behind it is fully occluded while still mounted — pinning every list
+ *    thumbnail's decoded bitmap for as long as the player is open. Blanking here
+ *    is invisible by construction (nothing behind the player is on screen) and
+ *    it is the app's peak board-art moment: the player's own full-res board is
+ *    live on top, and remixing from it opens the create board as well (#3804).
+ *    The player itself renders OUTSIDE every provider (it is a root route, not
+ *    under `(tabs)`), so its board keeps painting — as do the root-mounted queue
+ *    accessory and the iPad sidebar/detail pane.
+ *
+ * 2. **An inactive tab — iPad only.** The iPad shell keeps every tab mounted
+ *    (`detachInactiveScreens={false}`), so without this an inactive tab's
+ *    `LayeredClimbImage` views retain their decoded bitmaps off-screen for the
+ *    life of the session — `Image.clearMemoryCache()` reclaims only unreferenced
+ *    cache copies, not bitmaps a mounted view still holds (#3803). iPhone is
+ *    opted out of THIS case only: its tabs already freeze/detach on blur, and
+ *    re-decoding on every tab return would flash the thumbnails for no memory
+ *    win. Case 1 is a much rarer transition for a much larger working set, so it
+ *    applies on iPhone too.
+ *
+ * Anything hidden re-decodes from the disk cache in tens of ms when shown again.
  */
 export function BoardArtVisibilityProvider({ tab, children }: { tab: BoardArtTab; children: ReactNode }) {
   const { isPad } = useDeviceLayout();
   const segments = useSegments();
-  // Non-iPad: always visible. On iPad: visible only while THIS tab is the focused
-  // top-level destination (segment 1). A pushed sub-route of the tab keeps it active
-  // (`tabsActiveSegment` still returns the tab name); a root modal or the player
-  // (segment 0 is not `(tabs)`) returns null, so every tab blanks — correct, the
-  // shell behind it is occluded. The value is a primitive boolean, so the provider
+  // Case 1. Deliberately keyed on the player route specifically, NOT on
+  // `tabsActiveSegment(segments) === null` — that would also fire for the
+  // `user-drawer` root modal and for a tab's own `create` drawer, both of which
+  // float over a still-VISIBLE list. Blanking under those would be a user-facing
+  // regression, so occlusion stays an explicit allowlist of opaque-backed surfaces.
+  const occludedByPlayer = isPlayerRoute(segments);
+  // Case 2: visible only while THIS tab is the focused top-level destination
+  // (segment 1). A pushed sub-route of the tab keeps it active (`tabsActiveSegment`
+  // still returns the tab name). The value is a primitive boolean, so the provider
   // needs no memo (react/jsx-no-constructed-context-values).
-  const visible = !isPad || tabsActiveSegment(segments) === tab;
+  const visible = !occludedByPlayer && (!isPad || tabsActiveSegment(segments) === tab);
   return <BoardArtVisibilityContext.Provider value={visible}>{children}</BoardArtVisibilityContext.Provider>;
 }

--- a/packages/shared/create-climb-react/src/__tests__/use-create-climb.test.ts
+++ b/packages/shared/create-climb-react/src/__tests__/use-create-climb.test.ts
@@ -319,6 +319,24 @@ describe('useCreateClimb', () => {
       });
       expect(result.current.generateFramesString()).toBe('p100r42');
     });
+
+    // A seeded map is the only way to reach the role-table read at all: with an
+    // empty map the filter callback never runs. That made an unknown board a
+    // remix/edit-ONLY crash, thrown from the useReducer lazy initialiser — i.e.
+    // during render, where nothing can catch it (#3804). 'decoy' is a real
+    // BoardName that this file's STATE_TO_PRIMARY_CODE mock deliberately omits.
+    it('seeds no holds for a board missing from the role table instead of throwing', () => {
+      const initialHoldsMap = {
+        100: { state: 'STARTING' as const, color: '#00FF00', displayColor: '#00FF00' },
+        200: { state: 'HAND' as const, color: '#00FFFF', displayColor: '#00FFFF' },
+      };
+
+      const { result } = renderHook(() => useCreateClimb('decoy', { initialHoldsMap }));
+
+      expect(result.current.litUpHoldsMap).toEqual({});
+      expect(result.current.totalHolds).toBe(0);
+      expect(result.current.isValid).toBe(false);
+    });
   });
 
   describe('loadHolds', () => {

--- a/packages/shared/create-climb-react/src/use-create-climb.ts
+++ b/packages/shared/create-climb-react/src/use-create-climb.ts
@@ -9,10 +9,18 @@ type UseCreateClimbOptions = {
 // Drop holds whose state the board doesn't support (e.g. a colour-only / MoonBoard
 // product without FOOT), so a fork or draft seeded from another board never carries
 // an unpaintable hold.
+//
+// `stateToCode` is optional-chained because this runs inside the `useReducer` lazy
+// initialiser — i.e. DURING RENDER, where a throw is unrecoverable. A seeded map is
+// the only way to reach the read at all: for a new climb the map is empty, so the
+// filter callback never runs. That made an unknown `boardName` a remix/edit-only
+// render crash (#3804). Degrading to "no supported holds" matches
+// `accumulateFramesToMaps` in @boardsesh/board-constants, which already reads this
+// same table with `?.`.
 function filterSupportedHoldsMap(boardName: BoardName, holdsMap: LitUpHoldsMap): LitUpHoldsMap {
   const stateToCode = STATE_TO_PRIMARY_CODE[boardName];
   return Object.fromEntries(
-    Object.entries(holdsMap).filter(([, hold]) => hold.state !== 'OFF' && stateToCode[hold.state] !== undefined),
+    Object.entries(holdsMap).filter(([, hold]) => hold.state !== 'OFF' && stateToCode?.[hold.state] !== undefined),
   ) as LitUpHoldsMap;
 }
 
@@ -146,12 +154,15 @@ export function useCreateClimb(boardName: BoardName, options?: UseCreateClimbOpt
             if (finishCount >= 2) return prev;
           }
 
-          const stateCode = STATE_TO_PRIMARY_CODE[boardName][nextState];
+          // Optional-chained for the same reason as `filterSupportedHoldsMap`: an
+          // unknown board must not throw. Both reads already return `prev` when the
+          // lookup misses, so this only widens "missing role" to "missing board".
+          const stateCode = STATE_TO_PRIMARY_CODE[boardName]?.[nextState];
           if (stateCode === undefined) {
             return prev;
           }
 
-          const holdInfo = HOLD_STATE_MAP[boardName][stateCode];
+          const holdInfo = HOLD_STATE_MAP[boardName]?.[stateCode];
           if (!holdInfo) {
             return prev;
           }
@@ -177,7 +188,7 @@ export function useCreateClimb(boardName: BoardName, options?: UseCreateClimbOpt
     return Object.entries(litUpHoldsMap)
       .filter(([, hold]) => hold.state !== 'OFF')
       .flatMap(([holdId, hold]) => {
-        const code = stateToCode[hold.state];
+        const code = stateToCode?.[hold.state];
         return code === undefined ? [] : [`p${holdId}r${code}`];
       })
       .join('');


### PR DESCRIPTION
## Summary

Two OTA-safe hardenings on the remix path, from the #3804 investigation. **Related to #3804 — not claimed as a proven fix, and deliberately not `Closes`.** The forensic write-up is posted as a comment on the issue; the short version is that the crashing build could never have received the mitigations that landed 07-24…07-26, so the honest verdict is "most plausible cause + close the gaps that remain on current `main`", not "fixed".

### Why the reported build matters

Build 6 is iOS marketing version **2.2.0** (anchor `release/ios-v2.2.0-08f1cf331ae6`). Its production-OTA window closed on **2026-07-08T07:09Z**, when `packages/mobile/modules/live-activity/ios/BoardBleManager.swift` — a native fingerprint input — changed on `main`. The tester crashed on **07-19** running JS frozen at ~07-07/07-08.

So build 6 **could never receive** any of:

| Fix | Landed |
| --- | --- |
| #3337 — dismiss the player before pushing create | 07-25 |
| #3867 — `BoardArtVisibility` blanking + iPad cache sweep | 07-25 |
| `2f899f4f1` — `Image.configureCache({ maxMemoryCost })`, capping SDWebImage's **unbounded** decoded-bitmap cache | 07-26 |

That build ran an unbounded iOS image memory cache, no board-art blanking, and — pre-#3337 — kept the player mounted underneath the create screen on remix.

### What this PR changes

**A. Board art under the player, on iPhone** (`board-art-visibility-provider.tsx`)

`/play` is a `transparentModal` that "paints its own opaque backing" (`app/_layout.tsx`), so the tab shell behind it is fully occluded while still mounted — pinning every list thumbnail's decoded bitmap. `LayeredClimbImage` puts one hidden-but-mounted surface at ~100 MB+. The provider only blanked *inactive tabs*, on iPad, and the `!isPad ||` short-circuit disabled the occlusion branch entirely on iPhone. Occlusion now applies on every device.

This is the app's peak board-art moment: the player's own full-res board is live on top, and remixing from it opens the create board too.

Kept as an **explicit allowlist of opaque-backed routes** rather than `tabsActiveSegment(...) === null` — the `user-drawer` root modal and the tab's own `create` drawer both float over a still-*visible* list, so blanking under those would be a user-facing regression. Both are covered by tests. iPad behaviour is unchanged (a root modal already leaves no tab active, so every tab blanks via the iPad branch).

**B. Remix-only render throws** (`use-create-climb.ts`, `brush-roles.ts`, `climbs/create.tsx`)

`STATE_TO_PRIMARY_CODE[boardName]` was indexed without `?.` inside the `useReducer` lazy initialiser — i.e. **during render**, where a throw is unrecoverable. A seeded holds map is the only way to reach that read: with an empty map the filter callback never runs, so this could **only** throw on remix/edit, which matches the issue title exactly. Same unguarded shape in `getPaintRoles` (read during render by `CreateDrawerActionBar` and `HoldRoleSheet`) and in `setHoldState` / `generateFramesString`.

All are now consistent with `brushRoleColor` and with `accumulateFramesToMaps` in `@boardsesh/board-constants`, which already read this table with `?.`. I guarded every read in the file rather than only the two on the render path, so the guard isn't half-applied.

The board name reaching that table came from an unvalidated `as BoardName` cast of a route param, and the app's universal-link entry is a **wildcard** — so `…/climbs/create?boardName=<anything>` can open the route cold from outside the app. It is now narrowed against `SUPPORTED_BOARDS`, with an unsupported value treated as *absent* so it falls back to the active board exactly like a missing param (rather than nulling out into a permanent spinner).

### Scope notes

- **Deferred, filed separately:** bounding the create board's own background decode. `InteractiveCreateBoard` passes no `renderWidth`/`backgroundVariant`, so the board photo decodes at native ~1080px with `allowDownscaling={false}` — 5–11 MB RGBA per layer. Cutting it trades pinch-zoom sharpness, which is a product call. → #4075
- **Also split out:** remix-path sheet hygiene (#4076) and the Live Activity background-cold-launch path (#4077).
- **Not touched:** anything in `packages/web`.

## Release Notes

- Remixing a climb is lighter on your phone: opening the player now lets the climbs behind it release their artwork instead of holding it all in memory, so a long browse-and-remix session is less likely to end with the app disappearing.
- A remix opened from a bad or shared link falls back to your own board instead of dying on a blank screen.

## Test plan

- `vp check` — exit 0, **0 errors**, 296 pre-existing warnings, none in the changed files.
- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — **571 files / 4856 tests passed**.
- `vp run check:mobile-bundle` — iOS + Android bundles OK.
- Affected suites: 9 files / 74 tests passed.

**All three fixes are mutation-tested** — each new test fails when its fix is reverted, verified by reverting all three at once:

- `hides tab board art on iPhone while the player is up` ✗ without A
- `returns no paint roles for a board missing from the role table` ✗ without the `brush-roles` guard
- `seeds no holds for a board missing from the role table instead of throwing` ✗ without the `use-create-climb` guard

Over-blanking guards (`stays visible on iPhone under the user drawer`, `stays visible on iPhone under the create drawer`, `still blanks an inactive iPad tab under the user drawer`) pass in both directions — they exist to stop a future "simplification" to `activeTab === null`.

## Device QA — required, and NOT done

This was built on Linux. **There is no iOS simulator on this box**, and the mechanism is iOS-only (`Image.configureCache` is `@platform ios`), so Android proves nothing here. Someone with a device needs to check:

- [ ] **iPhone, the one that can actually fail.** Open the player over a scrolled climbs list, then dismiss it. Watch for a thumbnail flash as the list re-decodes from the disk cache. Expected: covered by the slide-down animation. If it flashes, the fix is to defer the unblank by a frame.
- [ ] **iPhone, remix end-to-end.** Player → ⋯ → Remix. Create opens pre-filled, no stranded scrim, list intact on the way back.
- [ ] **iPhone, no over-blanking.** Open the user drawer and the create drawer — the list behind each must keep its thumbnails.
- [ ] **iPad regression.** Unchanged by construction, but confirm the sidebar cell and detail-pane player never blank.
- [ ] **Memory soak.** Browse a large list, open/close the player repeatedly, watch resident image memory plateau rather than climb.

## Prod verification checklist (read-only — for @marcodejongh)

No production database was touched by this work, and none of these need write access.

- [ ] **Sentry `BOARDSESH-8B`** (`watchdog_termination`) — event frequency on builds that carry the 07-24…26 mitigations vs. builds before them. This is the single read that confirms or kills the whole hypothesis, and #3867 was blocked on the same missing token.
- [ ] Sentry: any `EXC_BAD_ACCESS` in the expo-image / SDWebImage decode path since `expo-image@57.0.1` shipped.
- [ ] App Store Connect: any further crash feedback naming remix/create on a build ≥ the first one carrying #3337 + #3867 + the cache cap.
- [ ] If all three are clean across a full release cycle, #3804 can be closed as resolved-by-accumulation — closure criteria are spelled out in the issue comment.
