### PR TITLE
fix(backend): playlistClimbs.totalCount respects board scope filters

### DIFF
--- a/packages/backend/src/__tests__/playlist-climbs-board-scope.test.ts
+++ b/packages/backend/src/__tests__/playlist-climbs-board-scope.test.ts
@@ -163,6 +163,11 @@ describe('playlistClimbs — board-scoped size and hold-set filtering (real DB)'
     // only climbable on size 99. Deleting the predicate (rather than gating it on
     // board type) would make the MoonBoard case above pass and break this one.
     expect(result.climbs.map((climb) => climb.uuid)).toEqual(['kilter-fits']);
+    // #4000: totalCount must respect the same size filter as `climbs`. The
+    // playlist has 2 rows in `playlist_climbs` (`kilter-fits` + `kilter-other`),
+    // but only 1 fits this size — before the fix totalCount reported 2, so a
+    // paginating client would expect a second page that could never arrive.
+    expect(result.totalCount).toBe(1);
   });
 
   it('keeps a size-compatible Kilter climb whose array holds several sizes', async () => {
@@ -200,6 +205,9 @@ describe('playlistClimbs — board-scoped size and hold-set filtering (real DB)'
     // "needs nothing installed", and a hand-curated playlist shouldn't lose a climb
     // over missing denormalised data.
     expect(result.climbs.map((climb) => climb.uuid)).toEqual(['moon-sets-base', 'moon-sets-null']);
+    // #4000: the playlist has 3 rows, but `moon-sets-wooden` fails the hold-set
+    // filter, so totalCount must be 2 to match `climbs`, not the raw row count.
+    expect(result.totalCount).toBe(2);
   });
 
   it('keeps every MoonBoard climb once the wooden holds are installed', async () => {
@@ -221,6 +229,7 @@ describe('playlistClimbs — board-scoped size and hold-set filtering (real DB)'
     );
 
     expect(result.climbs.map((climb) => climb.uuid)).toEqual(['moon-sets-base', 'moon-sets-wooden', 'moon-sets-null']);
+    expect(result.totalCount).toBe(3);
   });
 
   it('leaves the playlist whole when the caller sends no set ids', async () => {
@@ -241,6 +250,7 @@ describe('playlistClimbs — board-scoped size and hold-set filtering (real DB)'
     );
 
     expect(result.climbs.map((climb) => climb.uuid)).toEqual(['moon-sets-base', 'moon-sets-wooden', 'moon-sets-null']);
+    expect(result.totalCount).toBe(3);
   });
 
   it('keeps Kilter climbs whose required sets have not been backfilled', async () => {

--- a/packages/backend/src/__tests__/playlist-climbs-total-count.test.ts
+++ b/packages/backend/src/__tests__/playlist-climbs-total-count.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeAll } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { playlistQueries } from '../graphql/resolvers/playlists/queries';
+
+// Seeds use raw `sql` rather than `db.insert(...)` because the integration test
+// DB is built from a minimal hand-maintained DDL (schema-sql.ts), not the full
+// Drizzle schema — the query builder emits every default-bearing column that
+// DDL omits, so a builder insert fails. Naming only the columns the test DDL
+// declares is the genuine raw-SQL exception (see playlist-climbs-board-scope.test.ts).
+
+// Integration test (real DB) for #4000: `playlistClimbs.totalCount` must
+// respect the same filters `climbs` is joined against, in both specific-board
+// and all-boards mode. Before the fix, `totalCount` was a bare
+// `count(*) FROM playlist_climbs WHERE playlist_id = ...` with no join at all,
+// so it counted rows the `climbs` query would never return — a paginating
+// client would expect a page that could never arrive.
+
+const CROSS_BOARD_PLAYLIST_UUID = 'pl-total-count-cross-board';
+const LAYOUT_MISMATCH_PLAYLIST_UUID = 'pl-total-count-layout';
+const ORPHANED_REF_PLAYLIST_UUID = 'pl-total-count-orphaned';
+
+function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext {
+  return {
+    connectionId: 'conn-1',
+    isAuthenticated: false,
+    userId: null,
+    sessionId: null,
+    boardPath: null,
+    controllerId: null,
+    controllerApiKey: null,
+    ...overrides,
+  } as ConnectionContext;
+}
+
+async function seedClimb(boardType: string, uuid: string, name: string, layoutId: number) {
+  await db.execute(sql`
+    INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, description, frames, is_listed)
+    VALUES (${uuid}, ${boardType}, ${layoutId}, 'setter', ${name}, '', 'p1r1', true)
+  `);
+}
+
+async function seedStats(boardType: string, uuid: string, angle: number) {
+  await db.execute(sql`
+    INSERT INTO board_climb_stats (board_type, climb_uuid, angle, display_difficulty, difficulty_average, quality_average, ascensionist_count, benchmark_difficulty)
+    VALUES (${boardType}, ${uuid}, ${angle}, 18, 18, 3.0, 10, 0)
+  `);
+}
+
+describe('playlistClimbs — totalCount respects query filters (real DB, #4000)', () => {
+  beforeAll(async () => {
+    // Playlist tables aren't in the global per-file reset list, so own the cleanup.
+    await db.execute(sql`TRUNCATE TABLE playlist_climbs, playlist_ownership, playlists RESTART IDENTITY CASCADE`);
+
+    // --- Cross-board playlist: 2 kilter climbs, 1 tension climb ---
+    await seedClimb('kilter', 'cb-kilter-1', 'Kilter One', 1);
+    await seedClimb('kilter', 'cb-kilter-2', 'Kilter Two', 1);
+    await seedClimb('tension', 'cb-tension-1', 'Tension One', 1);
+    await seedStats('kilter', 'cb-kilter-1', 40);
+    await seedStats('kilter', 'cb-kilter-2', 40);
+    await seedStats('tension', 'cb-tension-1', 40);
+
+    // --- Layout-mismatch playlist: 2 climbs on layout 1, 1 climb on layout 2, all kilter ---
+    await seedClimb('kilter', 'lm-layout1-a', 'Layout1 A', 1);
+    await seedClimb('kilter', 'lm-layout1-b', 'Layout1 B', 1);
+    await seedClimb('kilter', 'lm-layout2', 'Layout2', 2);
+    await seedStats('kilter', 'lm-layout1-a', 40);
+    await seedStats('kilter', 'lm-layout1-b', 40);
+    await seedStats('kilter', 'lm-layout2', 40);
+
+    // --- Orphaned-ref playlist: 1 real climb, 1 playlist_climbs row whose
+    // climb_uuid has no matching board_climbs row at all (deleted/never-synced) ---
+    await seedClimb('kilter', 'or-real', 'Real Climb', 1);
+    await seedStats('kilter', 'or-real', 40);
+
+    await db.execute(sql`
+      INSERT INTO playlists (id, uuid, board_type, layout_id, name, is_public)
+      VALUES (1, ${CROSS_BOARD_PLAYLIST_UUID}, 'kilter', 1, 'Cross-board set', true),
+             (2, ${LAYOUT_MISMATCH_PLAYLIST_UUID}, 'kilter', 1, 'Layout mismatch set', true),
+             (3, ${ORPHANED_REF_PLAYLIST_UUID}, 'kilter', 1, 'Orphaned ref set', true)
+    `);
+    await db.execute(sql`
+      INSERT INTO playlist_climbs (playlist_id, climb_uuid, angle, position)
+      VALUES (1, 'cb-kilter-1', 40, 0), (1, 'cb-kilter-2', 40, 1), (1, 'cb-tension-1', 40, 2),
+             (2, 'lm-layout1-a', 40, 0), (2, 'lm-layout1-b', 40, 1), (2, 'lm-layout2', 40, 2),
+             (3, 'or-real', 40, 0), (3, 'missing-climb-uuid', 40, 1)
+    `);
+  });
+
+  it('specific-board mode: totalCount only counts climbs on the requested board, not the whole playlist', async () => {
+    const result = await playlistQueries.playlistClimbs(
+      null,
+      { input: { playlistId: CROSS_BOARD_PLAYLIST_UUID, boardName: 'kilter', layoutId: 1, angle: 40 } },
+      makeCtx(),
+    );
+
+    // playlist_climbs has 3 rows for this playlist, but only 2 are kilter.
+    expect(result.climbs.map((climb) => climb.uuid).sort()).toEqual(['cb-kilter-1', 'cb-kilter-2']);
+    expect(result.totalCount).toBe(2);
+  });
+
+  it('all-boards mode: totalCount counts every board, matching the unfiltered climbs list', async () => {
+    const result = await playlistQueries.playlistClimbs(
+      null,
+      { input: { playlistId: CROSS_BOARD_PLAYLIST_UUID, activeBoardName: 'kilter', activeAngle: 40 } },
+      makeCtx(),
+    );
+
+    expect(result.climbs).toHaveLength(3);
+    expect(result.totalCount).toBe(3);
+  });
+
+  it('specific-board mode: totalCount respects the layoutId filter', async () => {
+    const result = await playlistQueries.playlistClimbs(
+      null,
+      { input: { playlistId: LAYOUT_MISMATCH_PLAYLIST_UUID, boardName: 'kilter', layoutId: 1, angle: 40 } },
+      makeCtx(),
+    );
+
+    // 3 rows in playlist_climbs, but only 2 are on layout 1.
+    expect(result.climbs.map((climb) => climb.uuid).sort()).toEqual(['lm-layout1-a', 'lm-layout1-b']);
+    expect(result.totalCount).toBe(2);
+  });
+
+  it('all-boards mode: totalCount excludes a playlist_climbs row whose climb no longer exists', async () => {
+    const result = await playlistQueries.playlistClimbs(
+      null,
+      { input: { playlistId: ORPHANED_REF_PLAYLIST_UUID, activeBoardName: 'kilter', activeAngle: 40 } },
+      makeCtx(),
+    );
+
+    // playlist_climbs has 2 rows for this playlist; one points at a climb_uuid
+    // with no board_climbs row (never synced / deleted). It cannot be hydrated
+    // into `climbs`, so it must not inflate totalCount either.
+    expect(result.climbs.map((climb) => climb.uuid)).toEqual(['or-real']);
+    expect(result.totalCount).toBe(1);
+  });
+});

--- a/packages/backend/src/graphql/resolvers/playlists/queries/playlist-climbs.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/playlist-climbs.ts
@@ -30,31 +30,15 @@ function paginateResults<T>(results: T[], pageSize: number) {
 }
 
 /**
- * Specific-board mode: fetch climbs filtered by board type, layout, and size edges.
- *
- * Same two-step shape as the all-boards path: read the page of refs from
- * playlistClimbs (with the board/layout/size filters on the join), then hand
- * them to the shared hydrator, which joins stats/grades at the requested angle
- * and falls back to the most-ascended angle when the climb has no stats there
- * — so the selected angle never blanks a grade. The returned `angle` still
- * reports the requested wall angle: these climbs go straight into the queue on
- * playlist activation, and the tick badge, the board-presence report and the
- * logged ascent all read `climb.angle` as the wall in front of the user.
+ * Build the climb join conditions for specific-board mode (board type, layout,
+ * size, and hold-set scoping). Shared by the ref-rows query and the totalCount
+ * query so the count always reflects the same rows the page can return (#4000).
  */
-async function fetchSpecificBoardClimbs(
-  playlistId: bigint,
+function buildSpecificBoardClimbJoinConditions(
+  tables: typeof UNIFIED_TABLES,
+  boardName: BoardName,
   input: PlaylistClimbsInput,
-  page: number,
-  pageSize: number,
-): Promise<{ climbs: Climb[]; hasMore: boolean }> {
-  const boardName = input.boardName as BoardName;
-  if (!isValidBoardName(boardName)) {
-    throw new Error(`Invalid board name: ${String(boardName)}. Must be one of: ${SUPPORTED_BOARDS.join(', ')}`);
-  }
-
-  const tables = UNIFIED_TABLES;
-
-  // Build climb join conditions
+) {
   const climbJoinConditions = [
     eq(tables.climbs.uuid, dbSchema.playlistClimbs.climbUuid),
     eq(tables.climbs.boardType, boardName),
@@ -102,6 +86,48 @@ async function fetchSpecificBoardClimbs(
     );
   }
 
+  return climbJoinConditions;
+}
+
+/**
+ * Specific-board mode: fetch climbs filtered by board type, layout, and size edges.
+ *
+ * Same two-step shape as the all-boards path: read the page of refs from
+ * playlistClimbs (with the board/layout/size filters on the join), then hand
+ * them to the shared hydrator, which joins stats/grades at the requested angle
+ * and falls back to the most-ascended angle when the climb has no stats there
+ * — so the selected angle never blanks a grade. The returned `angle` still
+ * reports the requested wall angle: these climbs go straight into the queue on
+ * playlist activation, and the tick badge, the board-presence report and the
+ * logged ascent all read `climb.angle` as the wall in front of the user.
+ *
+ * `totalCount` is computed with the exact same join conditions as the ref-rows
+ * query (#4000) — before this fix it counted every `playlist_climbs` row for
+ * the playlist regardless of board/layout/size/set scope, so it could report a
+ * higher count than `climbs` could ever page through.
+ */
+async function fetchSpecificBoardClimbs(
+  playlistId: bigint,
+  input: PlaylistClimbsInput,
+  page: number,
+  pageSize: number,
+): Promise<{ climbs: Climb[]; totalCount: number; hasMore: boolean }> {
+  const boardName = input.boardName as BoardName;
+  if (!isValidBoardName(boardName)) {
+    throw new Error(`Invalid board name: ${String(boardName)}. Must be one of: ${SUPPORTED_BOARDS.join(', ')}`);
+  }
+
+  const tables = UNIFIED_TABLES;
+  const climbJoinConditions = buildSpecificBoardClimbJoinConditions(tables, boardName, input);
+
+  const [countResult] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(dbSchema.playlistClimbs)
+    .innerJoin(tables.climbs, and(...climbJoinConditions))
+    .where(eq(dbSchema.playlistClimbs.playlistId, playlistId));
+
+  const totalCount = countResult?.count ?? 0;
+
   const refRows = await db
     .select({
       climbUuid: dbSchema.playlistClimbs.climbUuid,
@@ -135,7 +161,7 @@ async function fetchSpecificBoardClimbs(
     hydrateOptions,
   );
 
-  return { climbs, hasMore };
+  return { climbs, totalCount, hasMore };
 }
 
 /**
@@ -145,14 +171,27 @@ async function fetchSpecificBoardClimbs(
  * override) from playlistClimbs in position order, then hand them to the
  * shared hydrator which owns the climbs/climbStats join. Lets schema changes
  * to climbStats live in exactly one file (`helpers/hydrate-climbs.ts`).
+ *
+ * `totalCount` is computed with the same inner join to `climbs` the ref-rows
+ * query uses (#4000), rather than a bare `playlist_climbs` row count. A stale
+ * playlist row whose `climb_uuid` no longer resolves is excluded from both
+ * results, so the count cannot exceed what paging through `climbs` can return.
  */
 async function fetchAllBoardsClimbs(
   playlistId: bigint,
   input: PlaylistClimbsInput,
   page: number,
   pageSize: number,
-): Promise<{ climbs: Climb[]; hasMore: boolean }> {
+): Promise<{ climbs: Climb[]; totalCount: number; hasMore: boolean }> {
   const tables = UNIFIED_TABLES;
+
+  const [countResult] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(dbSchema.playlistClimbs)
+    .innerJoin(tables.climbs, eq(tables.climbs.uuid, dbSchema.playlistClimbs.climbUuid))
+    .where(eq(dbSchema.playlistClimbs.playlistId, playlistId));
+
+  const totalCount = countResult?.count ?? 0;
 
   const refRows = await db
     .select({
@@ -185,12 +224,18 @@ async function fetchAllBoardsClimbs(
     { angleOverrides },
   );
 
-  return { climbs, hasMore };
+  return { climbs, totalCount, hasMore };
 }
 
 /**
  * Get climbs in a playlist with full climb data.
  * Supports specific-board mode (boardName provided) or all-boards mode (boardName omitted).
+ *
+ * `totalCount` is delegated to whichever branch runs, since each computes it
+ * with the same join conditions its own `climbs` query applies (#4000) — a
+ * playlist-wide count here would ignore the board/layout/size scoping the
+ * specific-board branch imposes and could report more than `climbs` could
+ * ever page through.
  */
 export const playlistClimbs = async (
   _: unknown,
@@ -205,19 +250,7 @@ export const playlistClimbs = async (
   // Verify access (throws if denied)
   const playlistId = await verifyPlaylistAccess(input.playlistId, ctx.userId ?? null);
 
-  // Get total count
-  const countResult = await db
-    .select({ count: sql<number>`count(*)::int` })
-    .from(dbSchema.playlistClimbs)
-    .where(eq(dbSchema.playlistClimbs.playlistId, playlistId));
-
-  const totalCount = countResult[0]?.count || 0;
-
-  if (input.boardName) {
-    const { climbs, hasMore } = await fetchSpecificBoardClimbs(playlistId, input, page, pageSize);
-    return { climbs, totalCount, hasMore };
-  } else {
-    const { climbs, hasMore } = await fetchAllBoardsClimbs(playlistId, input, page, pageSize);
-    return { climbs, totalCount, hasMore };
-  }
+  return input.boardName
+    ? fetchSpecificBoardClimbs(playlistId, input, page, pageSize)
+    : fetchAllBoardsClimbs(playlistId, input, page, pageSize);
 };

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -1972,7 +1972,7 @@ Result of fetching playlist climbs.
 type PlaylistClimbsResult {
   "List of climbs with full data"
   climbs: [Climb!]!
-  "Total count"
+  "Total number of climbs matching the supplied board, layout, size, and hold-set filters before pagination"
   totalCount: Int!
   "Whether more are available"
   hasMore: Boolean!

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -4311,7 +4311,7 @@ export type PlaylistClimbsResult = {
   climbs: Array<Climb>;
   /** Whether more are available */
   hasMore: Scalars['Boolean']['output'];
-  /** Total count */
+  /** Total number of climbs matching the supplied board, layout, size, and hold-set filters before pagination */
   totalCount: Scalars['Int']['output'];
 };
 

--- a/packages/shared-schema/src/schema/playlists.ts
+++ b/packages/shared-schema/src/schema/playlists.ts
@@ -263,7 +263,7 @@ export const playlistsTypeDefs = /* GraphQL */ `
   type PlaylistClimbsResult {
     "List of climbs with full data"
     climbs: [Climb!]!
-    "Total count"
+    "Total number of climbs matching the supplied board, layout, size, and hold-set filters before pagination"
     totalCount: Int!
     "Whether more are available"
     hasMore: Boolean!

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -4308,7 +4308,7 @@ export type PlaylistClimbsResult = {
   climbs: Array<Climb>;
   /** Whether more are available */
   hasMore: Scalars['Boolean']['output'];
-  /** Total count */
+  /** Total number of climbs matching the supplied board, layout, size, and hold-set filters before pagination */
   totalCount: Scalars['Int']['output'];
 };
 


### PR DESCRIPTION
## Summary

- `playlistClimbs.totalCount` counted every `playlist_climbs` row for the playlist with no join at all, while `climbs` applies board/layout/size/hold-set filters via an inner join to `board_climbs`. A mixed-board or size-incompatible playlist could report a `totalCount` higher than `climbs` could ever page through (the MoonBoard case in #3891 made this stark: `totalCount: 2`, `climbs: []`, before that bug was fixed in #3997).
- Fixed by computing `totalCount` in each mode (`fetchSpecificBoardClimbs` / `fetchAllBoardsClimbs`) with the exact same join conditions the `climbs` query already applies, instead of a bare row count in the shared dispatcher. All-boards mode also now excludes a `playlist_climbs` row whose `climb_uuid` no longer resolves to a listed climb (deleted/never-synced), the same defect class on the same join the ref-rows query already uses.
- Updated the `PlaylistClimbsResult.totalCount` schema description (shared by `playlistClimbs`, `userFavoriteClimbs`, `setterClimbsFull`, `userClimbs`) to state the filtered-count contract explicitly, and regenerated the GraphQL codegen output.

### Why filtered count, not "playlist size"

Checked #4000's premise directly: no production client reads `playlistClimbs.totalCount` today (mobile, web, and `@boardsesh/playlists-react` all read only `climbs`/`hasMore` off this query). So this was a latent trap, not a live bug — the actual work was picking the field's contract.

The tie-breaker: `PlaylistClimbsResult` is shared by three other resolvers that already read `totalCount` in production UI (`userFavoriteClimbs`, `setterClimbsFull`, `userClimbs`), and every one of them counts with the *same filter conditions* their own `climbs` query applies — `setterClimbsFull` and `userClimbs` in particular already do exactly the "count via the same `WHERE`/join as the page query" pattern this PR brings `playlistClimbs` in line with. Filtered count isn't just what a paginating client would assume — it's the field's actual, pre-existing meaning everywhere else it's used.

## Test plan

- [x] `vp check`
- [x] `vp run typecheck:backend`
- [x] `vp test run --project backend --reporter=agent`
- New test file `packages/backend/src/__tests__/playlist-climbs-total-count.test.ts`: specific-board mode only counts the requested board (not the whole playlist); all-boards mode matches the unfiltered climbs count; specific-board mode respects a `layoutId` mismatch; all-boards mode excludes a `playlist_climbs` row pointing at a climb that no longer exists.
- Turned two previously-unasserted fixtures in `playlist-climbs-board-scope.test.ts` (the Kilter size mismatch and the MoonBoard hold-set mismatch cases) into real `totalCount` regression assertions — before this fix they demonstrated the bug without checking for it.

## Release Notes

- [x] No release note needed (internal / technical change)
