### PR TITLE
ci: cover deploy/app-subdomain config and enforce the no-CSP rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
       sharedSchema: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.sharedSchema }}
       i18nCatalogs: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.i18nCatalogs }}
       rootCi: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.rootCi }}
+      # Files that decide what ships to app.boardsesh.com (Cloudflare Pages
+      # config + the export/build/deploy pipeline that produces it). None of
+      # these match any other filter above, so without this a PR touching only
+      # deploy/app-subdomain/_headers ran zero jobs and ci-status passed on
+      # `skipped`. Gates the `deploy-config` job (see below).
+      deployConfig: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.deployConfig }}
       # PR-only guard signal: did this PR edit the OTA-owned changelog data file?
       # Defaults false off PRs (the OTA bot legitimately rewrites it on push).
       changelogData: ${{ github.event_name == 'pull_request' && steps.filter.outputs.changelogData || 'false' }}
@@ -48,6 +54,10 @@ jobs:
       # shared-schema) that wouldn't trigger anyJs but still need setup so
       # test-backend / mobile-bundle / codegen-drift can run.
       runAny: ${{ github.event_name != 'pull_request' || steps.filter.outputs.anyJs == 'true' || steps.filter.outputs.web == 'true' || steps.filter.outputs.i18nCatalogs == 'true' || steps.filter.outputs.sharedSchema == 'true' || steps.filter.outputs.sharedDeps == 'true' || steps.filter.outputs.backend == 'true' || steps.filter.outputs.mobile == 'true' || steps.filter.outputs.ocr == 'true' || steps.filter.outputs.rootCi == 'true' }}
+      # NOTE: deployConfig is deliberately NOT part of runAny — the deploy-config
+      # job below needs [changes] only (no bun-install/build:db setup pass), so a
+      # deploy/app-subdomain-only PR doesn't pay for a `setup` run nothing else
+      # would consume.
     steps:
       - uses: actions/checkout@v6
       - id: filter
@@ -99,6 +109,15 @@ jobs:
               - 'packages/shared/graphql/**'
             i18nCatalogs:
               - 'packages/shared/i18n/locales/**'
+            # Everything that decides what ships to app.boardsesh.com: the
+            # Cloudflare Pages config copied into the export at deploy time,
+            # the export/build scripts that produce it, and the workflow that
+            # deploys it. See deploy/app-subdomain/README.md.
+            deployConfig:
+              - 'deploy/app-subdomain/**'
+              - 'scripts/build-expo-web-export.sh'
+              - 'Dockerfile.web'
+              - '.github/workflows/production-deploy.yml'
             rootCi:
               - '.github/workflows/ci.yml'
               - 'vite.config.ts'
@@ -374,6 +393,30 @@ jobs:
         run: vp run check:i18n
       - name: Check orphaned i18n keys
         run: vp run check:i18n:orphans
+
+  deploy-config:
+    needs: [changes]
+    # Deliberately not `--changed`-filtered: the tests read `_headers`/`_redirects`
+    # via fs at run time (not a static import), so Vitest's `--changed` module-graph
+    # analysis would never mark them as related to a diff that only touches those
+    # files. On a PR, a full un-filtered run of this one small project is what makes
+    # a CSP or SPA-fallback regression fail CI. (Pushes to main run the project a
+    # second time inside test-default, which reads its project list off the root
+    # vite.config.ts — harmless, and no substitute for this job on PRs.)
+    if: needs.changes.outputs.deployConfig == 'true' || needs.changes.outputs.rootCi == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: 'lts'
+          cache: true
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Validate deploy/app-subdomain config (_headers, _redirects, no-CSP rule)
+        run: vp test run --project deploy-app-subdomain
 
   test-default:
     needs: [changes, setup]
@@ -822,6 +865,7 @@ jobs:
       - commit-lint
       - release-notes
       - changelog-owned
+      - deploy-config
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -103,7 +103,11 @@ jobs:
           # Web deploys broadly: any change that isn't purely docs or mobile.
           WEB_CHANGED=false
           # app.boardsesh.com (standalone Expo web export) — deploys on the mobile
-          # app, its shared deps, the export script, or the CF Pages host config.
+          # app, its shared deps, the export script, or the two CF Pages host
+          # config files. Those two are named individually rather than globbed as
+          # `deploy/app-subdomain/*`: `case` wildcards span `/`, so the glob also
+          # caught the directory's README and its CI tests, and editing a comment
+          # in a test kicked off a production deploy.
           APP_CHANGED=false
           for file in $CHANGED_FILES; do
             case "$file" in
@@ -119,7 +123,7 @@ jobs:
                 ;;
             esac
             case "$file" in
-              packages/mobile/*|packages/shared/*|packages/shared-schema/*|scripts/build-expo-web-export.sh|deploy/app-subdomain/*)
+              packages/mobile/*|packages/shared/*|packages/shared-schema/*|scripts/build-expo-web-export.sh|deploy/app-subdomain/_headers|deploy/app-subdomain/_redirects)
                 APP_CHANGED=true
                 ;;
             esac

--- a/deploy/app-subdomain/README.md
+++ b/deploy/app-subdomain/README.md
@@ -1,8 +1,10 @@
 # `deploy/app-subdomain/` — Cloudflare Pages config for app.boardsesh.com
 
-These two files (`_redirects`, `_headers`) are copied into the standalone Expo
-web export at deploy time and shipped to the `boardsesh-app` Cloudflare Pages
-project. They are **not** part of the export itself — the export recipe
+`_redirects` and `_headers` are copied into the standalone Expo web export at
+deploy time and shipped to the `boardsesh-app` Cloudflare Pages project. They
+are the only deployed files here; the rest of the directory is this README plus
+the CI tests that guard them (`__tests__/`, `vite.config.ts`). They are **not**
+part of the export itself — the export recipe
 (`scripts/build-expo-web-export.sh --subdomain`) emits a `baseUrl /` static SPA;
 this directory adds the host-level SPA fallback and caching rules Pages needs.
 
@@ -43,6 +45,21 @@ else falls through to the shell.
 allowances) breaks board rendering outright. This is the same constraint the
 `/app` surface documents — see the "WASM glue needs `Function()`" note in
 `docs/expo-web.md`.
+
+`__tests__/headers.test.ts` enforces it. A policy that restricts script sources
+fails CI unless it grants both `'unsafe-eval'` and `'wasm-unsafe-eval'`, and
+that covers `default-src` too, since `script-src` falls back to it. If the
+renderer ever stops needing `new Function(...)`, relax the test in the same PR
+that relaxes this rule.
+
+## Editing these files
+
+Run `vp test run --project deploy-app-subdomain`. The suite parses both config
+files and asserts what Cloudflare would send for concrete paths: the CSP rule
+above, the `noindex` tag, forever-caching on content-hashed assets only, and the
+`200` SPA rewrite for deep links. The `deploy-config` job in
+`.github/workflows/ci.yml` runs it on every PR touching this directory, the
+export script, `Dockerfile.web`, or the deploy workflow.
 
 ## Why `EXPO_PUBLIC_WEB_URL` is www, not app
 

--- a/deploy/app-subdomain/__tests__/cloudflare-config.ts
+++ b/deploy/app-subdomain/__tests__/cloudflare-config.ts
@@ -1,0 +1,125 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Parsers for the two Cloudflare Pages config files in this directory. Shared by
+// headers.test.ts and redirects.test.ts. Not a `*.test.ts` file, so the project's
+// `include` glob doesn't collect it as a suite.
+
+export type HeaderBlock = {
+  /** The path pattern the block applies to, e.g. `/*`, `/_expo/*`. */
+  path: string;
+  /**
+   * Header name -> every value written for it. Cloudflare permits repeating a
+   * header name within a block (two `Content-Security-Policy` lines are both
+   * sent, and browsers enforce their intersection), so this keeps all of them —
+   * a last-one-wins map would let a restrictive first policy slip past.
+   */
+  headers: Map<string, string[]>;
+};
+
+export type RedirectRule = {
+  from: string;
+  to: string;
+  /** Cloudflare Pages defaults to 302 when a rule omits the status. */
+  status: number;
+};
+
+function readConfigFile(name: string): string {
+  return readFileSync(resolve(import.meta.dirname, '..', name), 'utf8');
+}
+
+/** Strip blank lines and `#` comments, which both files use the same way. */
+function significantLines(source: string): string[] {
+  return source
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim() !== '' && !line.trim().startsWith('#'));
+}
+
+/**
+ * Parse Cloudflare Pages `_headers` syntax: a path line followed by indented
+ * `Name: value` lines. https://developers.cloudflare.com/pages/configuration/headers/
+ */
+export function parseHeadersFile(source: string): HeaderBlock[] {
+  const blocks: HeaderBlock[] = [];
+  let current: HeaderBlock | null = null;
+
+  for (const line of significantLines(source)) {
+    const trimmed = line.trim();
+    const isIndented = line.startsWith(' ') || line.startsWith('\t');
+    if (!isIndented) {
+      current = { path: trimmed, headers: new Map() };
+      blocks.push(current);
+      continue;
+    }
+
+    if (!current) {
+      throw new Error(`_headers: indented header line before any path: "${line}"`);
+    }
+    const separatorIndex = trimmed.indexOf(':');
+    if (separatorIndex === -1) {
+      throw new Error(`_headers: malformed header line (no ":"): "${line}"`);
+    }
+    const name = trimmed.slice(0, separatorIndex).trim();
+    const value = trimmed.slice(separatorIndex + 1).trim();
+    const existing = current.headers.get(name);
+    if (existing) {
+      existing.push(value);
+    } else {
+      current.headers.set(name, [value]);
+    }
+  }
+
+  return blocks;
+}
+
+/**
+ * Parse Cloudflare Pages `_redirects` syntax: `<from> <to> [status]`, one rule
+ * per line, applied in file order.
+ * https://developers.cloudflare.com/pages/configuration/redirects/
+ */
+export function parseRedirectsFile(source: string): RedirectRule[] {
+  return significantLines(source).map((line) => {
+    const [from, to, status] = line.trim().split(/\s+/);
+    if (!from || !to) {
+      throw new Error(`_redirects: malformed rule (needs "<from> <to> [status]"): "${line}"`);
+    }
+    return { from, to, status: status === undefined ? 302 : Number(status) };
+  });
+}
+
+/**
+ * Does a Cloudflare path pattern match a concrete request path? `*` is a
+ * wildcard that spans `/` (so `/*` really does cover `/index.html` and
+ * `/wasm/renderer.wasm`) — which is exactly the case a pattern-name string
+ * comparison would miss. `:placeholder` segments aren't used by either file
+ * here, so they aren't handled.
+ */
+export function pathMatchesPattern(pattern: string, requestPath: string): boolean {
+  const escaped = pattern.replaceAll(/[.+?^${}()|[\]\\]/g, String.raw`\$&`);
+  return new RegExp(`^${escaped.replaceAll('*', '.*')}$`).test(requestPath);
+}
+
+export const headerBlocks = parseHeadersFile(readConfigFile('_headers'));
+export const redirectRules = parseRedirectsFile(readConfigFile('_redirects'));
+
+/**
+ * Every value Cloudflare would send for `headerName` on `requestPath`, collected
+ * from all blocks whose pattern matches (Pages applies every matching rule, not
+ * just the first). Header lookup is case-insensitive.
+ */
+export function effectiveHeaderValues(requestPath: string, headerName: string): string[] {
+  const values: string[] = [];
+  for (const block of headerBlocks) {
+    if (!pathMatchesPattern(block.path, requestPath)) continue;
+    for (const [name, blockValues] of block.headers) {
+      if (name.toLowerCase() === headerName.toLowerCase()) values.push(...blockValues);
+    }
+  }
+  return values;
+}
+
+/** The rule Cloudflare would apply to `requestPath` — first match wins. */
+export function firstMatchingRedirect(requestPath: string): RedirectRule | undefined {
+  return redirectRules.find((rule) => pathMatchesPattern(rule.from, requestPath));
+}

--- a/deploy/app-subdomain/__tests__/headers.test.ts
+++ b/deploy/app-subdomain/__tests__/headers.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { effectiveHeaderValues, headerBlocks } from './cloudflare-config';
+
+// Guards the Cloudflare Pages `_headers` config shipped to app.boardsesh.com
+// (see ../README.md). This is the only check standing between a well-meant
+// "add a CSP" PR and a dark board renderer in production.
+
+/** Split a CSP into directive name -> source tokens. */
+function parseCspDirectives(csp: string): Map<string, string[]> {
+  const directives = new Map<string, string[]>();
+  for (const directive of csp.split(';')) {
+    const [name, ...sources] = directive.trim().split(/\s+/);
+    if (name) directives.set(name.toLowerCase(), sources);
+  }
+  return directives;
+}
+
+describe('deploy/app-subdomain/_headers', () => {
+  it('parses at least one block (sanity check the fixture path is right)', () => {
+    expect(headerBlocks.length).toBeGreaterThan(0);
+  });
+
+  // The hard rule from README.md: the board-renderer WASM glue instantiates via
+  // `new Function(...)`, so any CSP that restricts script sources without both
+  // eval allowances breaks the renderer outright. `script-src` falls back to
+  // `default-src`, so a `default-src`-only policy kills it just as dead — both
+  // spellings have to be caught. Tokens are compared exactly, because
+  // `'wasm-unsafe-eval'` contains `unsafe-eval` as a substring but does not
+  // permit `new Function(...)`.
+  it('never restricts script sources without unsafe-eval AND wasm-unsafe-eval', () => {
+    for (const block of headerBlocks) {
+      for (const [name, values] of block.headers) {
+        if (name.toLowerCase() !== 'content-security-policy') continue;
+        for (const csp of values) {
+          const directives = parseCspDirectives(csp);
+          const scriptSources = directives.get('script-src') ?? directives.get('default-src');
+          if (!scriptSources) continue;
+
+          const context = `${block.path} sets a CSP ("${csp}") restricting script sources`;
+          expect(
+            scriptSources,
+            `${context} without 'unsafe-eval' — breaks the board-renderer WASM glue (new Function(...)). See README.md.`,
+          ).toContain("'unsafe-eval'");
+          expect(
+            scriptSources,
+            `${context} without 'wasm-unsafe-eval' — breaks the board-renderer WASM glue. See README.md.`,
+          ).toContain("'wasm-unsafe-eval'");
+        }
+      }
+    }
+  });
+
+  it('applies X-Robots-Tag: noindex to every path', () => {
+    const robotsTags = effectiveHeaderValues('/index.html', 'X-Robots-Tag');
+    expect(robotsTags.join(', ')).toContain('noindex');
+  });
+
+  // Asserted against concrete request paths rather than block names, so the
+  // check follows what Cloudflare would actually send. `/*` spans `/`, so a
+  // cache rule parked there reaches every path below.
+  it('caches content-hashed assets forever', () => {
+    for (const hashedAssetPath of ['/_expo/static/js/web/entry-abc123.js', '/assets/logo-abc123.png']) {
+      const cacheControl = effectiveHeaderValues(hashedAssetPath, 'Cache-Control').join(', ');
+      expect(cacheControl, `"${hashedAssetPath}" must be cached forever`).toContain('immutable');
+      expect(cacheControl).toContain('max-age=31536000');
+    }
+  });
+
+  it('never caches index.html or wasm/* as immutable (fixed filenames, must revalidate)', () => {
+    for (const fixedNamePath of ['/index.html', '/wasm/board_renderer_bg.wasm']) {
+      const cacheControl = effectiveHeaderValues(fixedNamePath, 'Cache-Control').join(', ');
+      expect(
+        cacheControl,
+        `"${fixedNamePath}" has a fixed filename — an immutable Cache-Control would mask a deploy (stale index.html) or pin an old renderer (stale wasm). See README.md.`,
+      ).not.toContain('immutable');
+    }
+  });
+});

--- a/deploy/app-subdomain/__tests__/redirects.test.ts
+++ b/deploy/app-subdomain/__tests__/redirects.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { firstMatchingRedirect, redirectRules } from './cloudflare-config';
+
+// Guards the SPA fallback in `_redirects` (see ../README.md). Expo Router serves
+// every route from one exported shell, so losing this rule — or downgrading its
+// `200` rewrite to a redirect — 404s or mangles every deep link on
+// app.boardsesh.com.
+
+describe('deploy/app-subdomain/_redirects', () => {
+  it('parses at least one rule (sanity check the fixture path is right)', () => {
+    expect(redirectRules.length).toBeGreaterThan(0);
+  });
+
+  it('serves the SPA shell for deep links', () => {
+    // `/auth/callback` carries the transfer token back from the www auth origin;
+    // a 301/302 here would drop its query string on some clients.
+    for (const deepLink of ['/climbs', '/auth/callback', '/nested/deep/route']) {
+      const rule = firstMatchingRedirect(deepLink);
+      expect(rule, `"${deepLink}" must fall through to the exported shell`).toBeDefined();
+      expect(rule?.to, `"${deepLink}" must resolve to the SPA shell`).toBe('/index.html');
+      expect(rule?.status, `"${deepLink}" must be a 200 rewrite, not a redirect — the URL has to stay put`).toBe(200);
+    }
+  });
+});

--- a/deploy/app-subdomain/vite.config.ts
+++ b/deploy/app-subdomain/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite-plus';
+
+// Standalone Vitest project for deploy/app-subdomain — the Cloudflare Pages
+// config for app.boardsesh.com (see README.md). These aren't part of any
+// package, so they get their own project (same pattern as scripts/vite.config.ts)
+// registered in the root vite.config.ts's test.projects.
+export default defineConfig({
+  test: {
+    name: 'deploy-app-subdomain',
+    globals: true,
+    environment: 'node',
+    include: ['__tests__/**/*.test.ts'],
+  },
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -133,6 +133,7 @@ export default defineConfig({
       './packages/shared-schema/vite.config.ts',
       './packages/mobile/vite.config.ts',
       './scripts/vite.config.ts',
+      './deploy/app-subdomain/vite.config.ts',
     ],
   },
   staged: {


### PR DESCRIPTION
## What this fixes

Five paths decide what ships to app.boardsesh.com, and none of them matched any
path filter in `ci.yml`:

```
deploy/app-subdomain/_headers
deploy/app-subdomain/_redirects
scripts/build-expo-web-export.sh
Dockerfile.web
.github/workflows/production-deploy.yml
```

A PR touching only those ran zero jobs, and `ci-status` passed because it treats
`skipped` as fine. On top of that, the one hard rule in
`deploy/app-subdomain/README.md` (never add a CSP that restricts script sources,
because the board-renderer WASM glue instantiates via `new Function(...)`) had
nothing enforcing it.

## Changes

A `deployConfig` path filter covering those five paths, gating a new
`deploy-config` job that is listed in `ci-status`'s `needs`. The job needs only
`[changes]` — the tests read files off disk and import nothing from the
workspace, so it skips the `setup` pass. `deployConfig` is deliberately left out
of `runAny` for the same reason.

`deploy/app-subdomain/__tests__/` holds the guard itself, as a small Vitest
project (`deploy-app-subdomain`) registered in the root `vite.config.ts`, the
same way `scripts/` is. It is not `--changed`-filtered: the config files are
read via `fs` rather than imported, so Vitest's module graph would never connect
them to the diff.

`headers.test.ts` and `redirects.test.ts` parse the two config files and assert
what Cloudflare would actually send for concrete request paths:

- No policy restricting script sources without both `'unsafe-eval'` and
  `'wasm-unsafe-eval'`. Tokens are compared exactly, since `'wasm-unsafe-eval'`
  contains `unsafe-eval` as a substring but does not permit `new Function(...)`.
  `default-src` counts too, because `script-src` falls back to it.
- `X-Robots-Tag` carries `noindex`.
- `/_expo/*` and `/assets/*` are cached forever (they are content-hashed).
- `/index.html` and `/wasm/*` are not immutable-cached. This resolves the path
  against every block pattern, so an `immutable` rule parked on `/*` is caught —
  `*` spans `/` in Cloudflare patterns.
- Deep links resolve to `/index.html` with a `200` rewrite, not a redirect.

`production-deploy.yml` no longer treats `deploy/app-subdomain/*` as an app
change. Shell `case` wildcards span `/`, so that glob also matched the README and
the new tests, and editing a comment in a test would have kicked off a production
Cloudflare Pages deploy. The two config files are now named individually.

## Verifying the guard bites

Each row is a mutation applied to the real config file, with the suite run
against it and the file restored afterwards:

| Mutation | Result |
| --- | --- |
| `script-src 'self'` on `/*` | fails |
| `script-src 'self' 'wasm-unsafe-eval'` (no `unsafe-eval`) | fails |
| `default-src 'self'` with no `script-src` | fails |
| two CSP lines, restrictive one first | fails |
| `script-src` granting both allowances | passes |
| `immutable` added to `/*` | fails |
| `immutable` dropped from `/_expo/*` | fails |
| `X-Robots-Tag: index, follow` | fails |
| `X-Robots-Tag: noindex, nofollow` (stricter) | passes |
| SPA fallback changed to `301` | fails |
| SPA catch-all narrowed to `/api/*` | fails |
| unmodified files | passes |

This PR edits `production-deploy.yml`, which is inside the new filter, so the
`deploy-config` job runs on this PR.

## Notes

`scripts/ci-test-default-projects.ts` builds its project list by reading
`test.projects` out of the root `vite.config.ts`, so `deploy-app-subdomain` is
now picked up by `test-default` as well. That means it runs a second time on
pushes to main. It costs a few seconds and does not replace the dedicated job,
which is what covers PRs.

`deploy/` is not a Bun workspace package and every `typecheck:*` task is
filtered by package, so `vp run typecheck` does not cover these files. They are
type-checked by `vp check`'s type-aware lint, which the `lint` job runs. Same
situation as `scripts/`.

## Release Notes

none
