### PR TITLE
fix(mobile): finish atomic overlay cache hardening

### DIFF
--- a/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/AndroidAtomicFileCommitter.kt
+++ b/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/AndroidAtomicFileCommitter.kt
@@ -1,0 +1,31 @@
+package com.boardsesh.boardrenderer
+
+import android.system.ErrnoException
+import android.system.Os
+import java.io.File
+import java.io.IOException
+
+/** Android's API-21+ atomic same-filesystem publisher for completed overlay PNGs. */
+object AndroidAtomicFileCommitter : AtomicFileCommitter {
+    override fun commit(source: File, destination: File) {
+        try {
+            // AtomicFileWrite always creates source in destination.parentFile,
+            // so this is one same-filesystem rename that safely replaces an
+            // existing regular destination even under concurrent publication.
+            Os.rename(source.absolutePath, destination.absolutePath)
+        } catch (failure: ErrnoException) {
+            // CacheDirRecovery deliberately retries IOException only. Preserve
+            // errno as the cause while presenting the filesystem contract it
+            // expects at the module boundary.
+            throw IOException(
+                "Failed to publish ${source.absolutePath} at ${destination.absolutePath}",
+                failure,
+            )
+        } catch (failure: SecurityException) {
+            throw IOException(
+                "Permission denied publishing ${source.absolutePath} at ${destination.absolutePath}",
+                failure,
+            )
+        }
+    }
+}

--- a/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/AtomicFileWrite.kt
+++ b/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/AtomicFileWrite.kt
@@ -1,7 +1,19 @@
 package com.boardsesh.boardrenderer
 
 import java.io.File
+import java.io.FileOutputStream
 import java.io.IOException
+import java.io.OutputStream
+
+/**
+ * Publishes [source] at [destination] with one atomic same-filesystem rename.
+ * Android supplies [AndroidAtomicFileCommitter]; tests inject a JVM implementation
+ * so the write/close/cleanup contract stays testable without Robolectric.
+ */
+fun interface AtomicFileCommitter {
+    @Throws(IOException::class)
+    fun commit(source: File, destination: File)
+}
 
 /**
  * Writes a file by writing to a temp file next to the destination first, then
@@ -11,9 +23,9 @@ import java.io.IOException
  * There is no window where a reader can observe a partially-written file at
  * [destination]'s path.
  *
- * `File.renameTo` is an atomic `rename(2)` when the source and destination are
- * on the same filesystem, which they are here — the temp file is created in
- * [destination]'s own parent directory.
+ * The injected [AtomicFileCommitter] performs the publication. Production uses
+ * `android.system.Os.rename`, and the unique temp file is created in
+ * [destination]'s own parent directory so the rename stays on one filesystem.
  *
  * Fixes #3748: `BoardRendererModule.renderOverlay` used to write the overlay
  * PNG directly to its final cache path via `FileOutputStream`, and only
@@ -23,31 +35,76 @@ import java.io.IOException
  * PNG on disk, and the cache's `exists()`-only fast path then served it as a
  * permanent "successful" render forever.
  *
- * Pure `java.io` on purpose — no Android framework calls — so
+ * This helper remains pure `java.io` — no Android framework calls — so
  * [AtomicFileWriteTest] needs neither Robolectric nor a real Bitmap, matching
  * [CacheDirRecovery]'s approach for its sibling helper.
  */
 object AtomicFileWrite {
     /**
-     * Temp-file suffix used for the in-flight write. Shared with
-     * [CachePruner], which sweeps any file ending in this suffix as an
-     * orphaned artifact of a crash between [write] and the rename.
+     * A short hidden prefix plus `.tmp` suffix keeps in-flight files private to
+     * this cache contract and distinguishable from unrelated temp files. The
+     * final `.png` name is deliberately absent: cache readers must never mistake
+     * an in-flight write for a renderable overlay.
      */
+    const val TEMP_PREFIX: String = ".bsov-"
     const val TEMP_SUFFIX: String = ".tmp"
 
-    fun writeAtomically(destination: File, write: (tempFile: File) -> Unit) {
-        val tempFile = File(destination.parentFile, "${destination.name}$TEMP_SUFFIX")
+    fun isManagedTempFile(file: File): Boolean =
+        file.name.startsWith(TEMP_PREFIX) && file.name.endsWith(TEMP_SUFFIX)
+
+    /**
+     * Creates a fresh same-directory temp file, lets [write] encode into a stream
+     * owned by this helper, closes it, then atomically publishes it. Every failure
+     * in that pipeline emerges as [IOException], which is the contract consumed
+     * by [CacheDirRecovery]. An existing destination is untouched unless commit
+     * succeeds.
+     */
+    fun writeAtomically(
+        destination: File,
+        committer: AtomicFileCommitter,
+        outputStreamFactory: (File) -> OutputStream = { tempFile -> FileOutputStream(tempFile) },
+        write: (OutputStream) -> Boolean,
+    ) {
+        val parentDirectory = destination.parentFile
+            ?: throw IOException("Atomic destination has no parent: ${destination.absolutePath}")
+        val tempFile = try {
+            File.createTempFile(TEMP_PREFIX, TEMP_SUFFIX, parentDirectory)
+        } catch (failure: IOException) {
+            throw failure
+        } catch (failure: Exception) {
+            throw IOException(
+                "Failed to create an overlay temp file in ${parentDirectory.absolutePath}",
+                failure,
+            )
+        }
+
         try {
-            write(tempFile)
-            if (!tempFile.renameTo(destination)) {
-                throw IOException(
-                    "Failed to move ${tempFile.absolutePath} into place at ${destination.absolutePath}"
-                )
+            outputStreamFactory(tempFile).use { outputStream ->
+                if (!write(outputStream)) {
+                    throw IOException("PNG compression failed for ${destination.absolutePath}")
+                }
             }
+            committer.commit(tempFile, destination)
+        } catch (failure: IOException) {
+            // Preserve the exact filesystem failure (and its suppressed close
+            // failure, if any) so recovery and diagnostics see the real cause.
+            throw failure
+        } catch (failure: Exception) {
+            // SecurityException and any encoder/publisher exception still need
+            // to enter CacheDirRecovery's IOException-only retry contract.
+            throw IOException(
+                "Failed to write overlay atomically at ${destination.absolutePath}",
+                failure,
+            )
         } finally {
-            // No-op if the rename already moved it away; cleans up any partial
-            // temp file left by a throw above (from `write` or the rename check).
-            tempFile.delete()
+            // No-op after a successful rename. Cleanup must never replace the
+            // original write/close/commit exception; an undeletable orphan is
+            // picked up by CachePruner on the next module start.
+            try {
+                tempFile.delete()
+            } catch (_: SecurityException) {
+                // Best effort only; preserve the pipeline's primary result.
+            }
         }
     }
 }

--- a/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/AtomicFileWrite.kt
+++ b/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/AtomicFileWrite.kt
@@ -69,9 +69,10 @@ object AtomicFileWrite {
             ?: throw IOException("Atomic destination has no parent: ${destination.absolutePath}")
         val tempFile = try {
             File.createTempFile(TEMP_PREFIX, TEMP_SUFFIX, parentDirectory)
-        } catch (failure: IOException) {
-            throw failure
         } catch (failure: Exception) {
+            // Keep a raw temp-creation I/O failure intact for recovery instead
+            // of wrapping it with the broader non-I/O normalization below.
+            if (failure is IOException) throw failure
             throw IOException(
                 "Failed to create an overlay temp file in ${parentDirectory.absolutePath}",
                 failure,
@@ -85,11 +86,10 @@ object AtomicFileWrite {
                 }
             }
             committer.commit(tempFile, destination)
-        } catch (failure: IOException) {
-            // Preserve the exact filesystem failure (and its suppressed close
-            // failure, if any) so recovery and diagnostics see the real cause.
-            throw failure
         } catch (failure: Exception) {
+            // Preserve an existing filesystem failure (and any suppressed close
+            // failure) rather than wrapping it inside another IOException.
+            if (failure is IOException) throw failure
             // SecurityException and any encoder/publisher exception still need
             // to enter CacheDirRecovery's IOException-only retry contract.
             throw IOException(
@@ -100,11 +100,7 @@ object AtomicFileWrite {
             // No-op after a successful rename. Cleanup must never replace the
             // original write/close/commit exception; an undeletable orphan is
             // picked up by CachePruner on the next module start.
-            try {
-                tempFile.delete()
-            } catch (_: SecurityException) {
-                // Best effort only; preserve the pipeline's primary result.
-            }
+            tempFile.delete()
         }
     }
 }

--- a/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/BoardRendererModule.kt
+++ b/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/BoardRendererModule.kt
@@ -4,7 +4,6 @@ import android.graphics.Bitmap
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import java.io.File
-import java.io.FileOutputStream
 import java.nio.ByteBuffer
 
 class BoardRendererModule : Module() {
@@ -87,21 +86,16 @@ class BoardRendererModule : Module() {
                     )
                 },
             ) {
-                // Write to a temp file and rename into place so a thrown exception
-                // mid-compress (IO interruption, storage-full, process kill) can
-                // never leave a partial PNG at outputFile's path — it either lands
-                // whole or not at all (see AtomicFileWrite, #3748). The temp name is
-                // deterministic ("$cacheKey.png.tmp"), which is safe because Expo
-                // serialises every call into this module on a single modulesQueue
-                // (see #4041's PR body) — there's no concurrent renderOverlay call
-                // for the same cacheKey to collide with.
-                AtomicFileWrite.writeAtomically(outputFile) { tempFile ->
-                    FileOutputStream(tempFile).use { outputStream ->
-                        val written = overlayBitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
-                        if (!written) {
-                            throw Exception("PNG compression failed")
-                        }
-                    }
+                // Fresh same-directory temp creation, compression, stream close,
+                // and the atomic Os.rename publication all live inside this retry
+                // boundary. A reclaimed cache directory therefore retries the
+                // entire pipeline with a new unique temp file, while concurrent
+                // renders never share an in-flight path (AtomicFileWrite, #3748).
+                AtomicFileWrite.writeAtomically(
+                    destination = outputFile,
+                    committer = AndroidAtomicFileCommitter,
+                ) { outputStream ->
+                    overlayBitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
                 }
             }
         } finally {

--- a/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/BoardRendererModule.kt
+++ b/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/BoardRendererModule.kt
@@ -90,7 +90,7 @@ class BoardRendererModule : Module() {
                 // and the atomic Os.rename publication all live inside this retry
                 // boundary. A reclaimed cache directory therefore retries the
                 // entire pipeline with a new unique temp file, while concurrent
-                // renders never share an in-flight path (AtomicFileWrite, #3748).
+                // renders never share an in-flight path (see AtomicFileWrite).
                 AtomicFileWrite.writeAtomically(
                     destination = outputFile,
                     committer = AndroidAtomicFileCommitter,

--- a/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/CachePruner.kt
+++ b/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/CachePruner.kt
@@ -5,10 +5,10 @@ import java.io.File
 /**
  * Pure file-system bookkeeping for the overlay PNG cache directory:
  *
- * 1. Sweep any orphaned [AtomicFileWrite] temp file — a process kill between
- *    the compress and the rename (see #3748) leaves one of these behind. It's
- *    never a valid cache entry, so it's removed unconditionally rather than
- *    waiting for the size cap to evict it by LRU.
+ * 1. Sweep orphaned [AtomicFileWrite] temp files — a process kill between the
+ *    compress and rename (see #3748) leaves one behind. Only files carrying
+ *    that helper's private prefix *and* suffix are swept; unrelated `.tmp`
+ *    files are not ours to delete.
  * 2. Evict cache entries oldest-first by mtime until the directory is back
  *    under [pruneCacheIfNeeded]'s `maxBytes`.
  *
@@ -27,9 +27,7 @@ object CachePruner {
     fun pruneCacheIfNeeded(cacheDir: File, maxBytes: Long): Result {
         val files = cacheDir.listFiles()?.toList() ?: return Result(0, 0, 0)
 
-        val (staleTempFiles, cacheEntries) = files.partition {
-            it.name.endsWith(AtomicFileWrite.TEMP_SUFFIX)
-        }
+        val (staleTempFiles, cacheEntries) = files.partition(AtomicFileWrite::isManagedTempFile)
         var orphanedRemoved = 0
         for (tempFile in staleTempFiles) {
             if (tempFile.delete()) orphanedRemoved++

--- a/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/CachePruner.kt
+++ b/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/CachePruner.kt
@@ -6,11 +6,12 @@ import java.io.File
  * Pure file-system bookkeeping for the overlay PNG cache directory:
  *
  * 1. Sweep orphaned [AtomicFileWrite] temp files — a process kill between the
- *    compress and rename (see #3748) leaves one behind. Only files carrying
- *    that helper's private prefix *and* suffix are swept; unrelated `.tmp`
- *    files are not ours to delete.
- * 2. Evict cache entries oldest-first by mtime until the directory is back
- *    under [pruneCacheIfNeeded]'s `maxBytes`.
+ *    compress and rename leaves one behind. Only files carrying that helper's
+ *    private prefix *and* suffix are swept; unrelated `.tmp` files are not ours
+ *    to delete.
+ * 2. Count and evict final `.png` overlay entries oldest-first by mtime until
+ *    those managed entries are back under [pruneCacheIfNeeded]'s `maxBytes`.
+ *    Every other file is excluded from both size accounting and eviction.
  *
  * Pure `java.io` on purpose — no Android framework calls (in particular, no
  * `android.util.Log`) — so [CachePrunerTest] can run as a plain JUnit test.
@@ -18,6 +19,8 @@ import java.io.File
  * counts in the returned [Result].
  */
 object CachePruner {
+    private const val CACHE_ENTRY_SUFFIX = ".png"
+
     data class Result(
         val orphanedTempFilesRemoved: Int,
         val cacheEntriesEvicted: Int,
@@ -27,7 +30,10 @@ object CachePruner {
     fun pruneCacheIfNeeded(cacheDir: File, maxBytes: Long): Result {
         val files = cacheDir.listFiles()?.toList() ?: return Result(0, 0, 0)
 
-        val (staleTempFiles, cacheEntries) = files.partition(AtomicFileWrite::isManagedTempFile)
+        val staleTempFiles = files.filter(AtomicFileWrite::isManagedTempFile)
+        val cacheEntries = files.filter { file ->
+            file.isFile && file.name.endsWith(CACHE_ENTRY_SUFFIX)
+        }
         var orphanedRemoved = 0
         for (tempFile in staleTempFiles) {
             if (tempFile.delete()) orphanedRemoved++

--- a/packages/mobile/modules/board-renderer/android/src/test/java/com/boardsesh/boardrenderer/AtomicFileWriteTest.kt
+++ b/packages/mobile/modules/board-renderer/android/src/test/java/com/boardsesh/boardrenderer/AtomicFileWriteTest.kt
@@ -135,6 +135,8 @@ class AtomicFileWriteTest {
     @Test
     fun `a close IOException is preserved and commit is never attempted`() {
         val destination = File(cacheDir, "climb.png")
+        val previousRender = byteArrayOf(9, 9, 9)
+        destination.writeBytes(previousRender)
         val closeFailure = IOException("simulated close failure")
         var commitCalled = false
         val neverCommit = AtomicFileCommitter { _, _ -> commitCalled = true }
@@ -162,7 +164,7 @@ class AtomicFileWriteTest {
 
         assertSame(closeFailure, thrown)
         assertFalse(commitCalled)
-        assertFalse(destination.exists())
+        assertArrayEquals(previousRender, destination.readBytes())
         assertTrue(managedTempFiles().isEmpty())
     }
 
@@ -354,8 +356,8 @@ class AtomicFileWriteTest {
         firstThread.join(5_000)
         secondThread.join(5_000)
 
-        assertFalse("first publisher completed", firstThread.isAlive)
-        assertFalse("second publisher completed", secondThread.isAlive)
+        assertFalse("first publisher thread timed out", firstThread.isAlive)
+        assertFalse("second publisher thread timed out", secondThread.isAlive)
         assertTrue("both atomic renames succeeded: $failures", failures.isEmpty())
         val publishedBytes = destination.readBytes()
         assertTrue(

--- a/packages/mobile/modules/board-renderer/android/src/test/java/com/boardsesh/boardrenderer/AtomicFileWriteTest.kt
+++ b/packages/mobile/modules/board-renderer/android/src/test/java/com/boardsesh/boardrenderer/AtomicFileWriteTest.kt
@@ -1,26 +1,41 @@
 package com.boardsesh.boardrenderer
 
 import java.io.File
+import java.io.FileNotFoundException
+import java.io.FileOutputStream
 import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import org.junit.After
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
 /**
- * Covers [AtomicFileWrite] in isolation — the temp-file-then-rename machinery
- * that fixes #3748 (a mid-compress crash used to leave a truncated PNG at the
- * final cache path, and the cache's `exists()`-only fast path then served it
- * forever). The actual PNG `compress()` call needs a real `Bitmap` (JNI) and
- * isn't exercised here; this covers the write-atomically wrapper with a plain
- * byte-array stand-in, mirroring [CacheDirRecoveryTest]'s approach for the
- * sibling helper.
+ * Plain-JVM coverage for the fresh-temp -> write -> close -> commit pipeline
+ * used by BoardRendererModule. Android's production committer is injected at
+ * the call site; these tests use the JVM's same-directory atomic move so no
+ * Android framework method is executed under the unmocked android.jar stubs.
  */
 class AtomicFileWriteTest {
     private lateinit var cacheDir: File
+
+    private val jvmAtomicCommitter = AtomicFileCommitter { source, destination ->
+        Files.move(
+            source.toPath(),
+            destination.toPath(),
+            StandardCopyOption.ATOMIC_MOVE,
+            StandardCopyOption.REPLACE_EXISTING,
+        )
+    }
 
     @Before
     fun createCacheDir() {
@@ -35,95 +50,318 @@ class AtomicFileWriteTest {
         cacheDir.deleteRecursively()
     }
 
-    private fun tempFileFor(destination: File) =
-        File(destination.parentFile, "${destination.name}${AtomicFileWrite.TEMP_SUFFIX}")
+    private fun managedTempFiles(): List<File> =
+        cacheDir.listFiles()?.filter(AtomicFileWrite::isManagedTempFile) ?: emptyList()
 
-    @Test
-    fun `lands the destination file only after a successful write`() {
-        val destination = File(cacheDir, "climb.png")
-
-        AtomicFileWrite.writeAtomically(destination) { tempFile ->
-            tempFile.writeBytes(byteArrayOf(1, 2, 3))
+    private fun writeBytes(
+        destination: File,
+        bytes: ByteArray,
+        committer: AtomicFileCommitter = jvmAtomicCommitter,
+        observedTempFiles: MutableList<File>? = null,
+    ) {
+        AtomicFileWrite.writeAtomically(
+            destination = destination,
+            committer = committer,
+            outputStreamFactory = { tempFile ->
+                observedTempFiles?.add(tempFile)
+                FileOutputStream(tempFile)
+            },
+        ) { outputStream ->
+            outputStream.write(bytes)
+            true
         }
-
-        assertTrue("destination exists after a clean write", destination.exists())
-        assertArrayEquals(byteArrayOf(1, 2, 3), destination.readBytes())
-        assertFalse("temp file is gone once renamed away", tempFileFor(destination).exists())
     }
 
-    /**
-     * The regression this fix closes: a crash mid-write must never leave a
-     * partial file at the destination path for the cache's `exists()`-only
-     * fast path to pick up.
-     */
     @Test
-    fun `a throw during write leaves no file at the destination`() {
+    fun `uses a fresh unique private temp in the destination directory`() {
         val destination = File(cacheDir, "climb.png")
+        val observedTempFiles = mutableListOf<File>()
 
-        val failure = try {
-            AtomicFileWrite.writeAtomically(destination) { tempFile ->
-                tempFile.writeBytes(byteArrayOf(1, 2, 3))
-                throw IOException("simulated mid-compress crash")
-            }
-            null
-        } catch (thrown: IOException) {
-            thrown
+        writeBytes(destination, byteArrayOf(1, 2, 3), observedTempFiles = observedTempFiles)
+        writeBytes(destination, byteArrayOf(4, 5, 6), observedTempFiles = observedTempFiles)
+
+        assertEquals(2, observedTempFiles.size)
+        for (tempFile in observedTempFiles) {
+            assertEquals(cacheDir.canonicalFile, tempFile.parentFile.canonicalFile)
+            assertTrue(tempFile.name.startsWith(AtomicFileWrite.TEMP_PREFIX))
+            assertTrue(tempFile.name.endsWith(AtomicFileWrite.TEMP_SUFFIX))
+            assertFalse("an in-flight file must not look like a PNG", tempFile.name.contains(".png"))
         }
-
-        assertEquals("simulated mid-compress crash", failure?.message)
-        assertFalse("no partial file at the destination", destination.exists())
-        assertFalse("temp file cleaned up on the failure path", tempFileFor(destination).exists())
+        assertNotEquals("each attempt gets a collision-proof path", observedTempFiles[0].name, observedTempFiles[1].name)
+        assertArrayEquals(byteArrayOf(4, 5, 6), destination.readBytes())
+        assertTrue("successful commits leave no private temp", managedTempFiles().isEmpty())
     }
 
-    /**
-     * A throwing write must not clobber whatever was already at the
-     * destination — e.g. a still-valid cache entry from a previous render.
-     */
     @Test
-    fun `a throw during write leaves a pre-existing destination untouched`() {
+    fun `a writer IOException is preserved and leaves the destination untouched`() {
         val destination = File(cacheDir, "climb.png")
         destination.writeBytes(byteArrayOf(9, 9, 9))
+        val writerFailure = IOException("simulated mid-compress write failure")
 
-        try {
-            AtomicFileWrite.writeAtomically(destination) { tempFile ->
-                tempFile.writeBytes(byteArrayOf(1, 2, 3))
-                throw IOException("simulated mid-compress crash")
+        val thrown = try {
+            AtomicFileWrite.writeAtomically(destination, jvmAtomicCommitter) { outputStream ->
+                outputStream.write(byteArrayOf(1, 2, 3))
+                throw writerFailure
             }
-        } catch (expected: IOException) {
-            // expected
+            null
+        } catch (failure: IOException) {
+            failure
         }
 
-        assertArrayEquals(
-            "pre-existing destination survives a failed re-render untouched",
-            byteArrayOf(9, 9, 9),
-            destination.readBytes(),
-        )
+        assertSame("the original IOException reaches CacheDirRecovery", writerFailure, thrown)
+        assertArrayEquals(byteArrayOf(9, 9, 9), destination.readBytes())
+        assertTrue("partial temp is cleaned up", managedTempFiles().isEmpty())
     }
 
     @Test
-    fun `a failed rename propagates and still cleans up the temp file`() {
-        // A directory sitting where the destination should be: renameTo can
-        // never win.
+    fun `a false compressor result emerges as IOException`() {
         val destination = File(cacheDir, "climb.png")
-        destination.mkdirs()
 
-        val failure = try {
-            AtomicFileWrite.writeAtomically(destination) { tempFile ->
-                tempFile.writeBytes(byteArrayOf(1, 2, 3))
+        val thrown = try {
+            AtomicFileWrite.writeAtomically(destination, jvmAtomicCommitter) { outputStream ->
+                outputStream.write(byteArrayOf(1, 2, 3))
+                false
             }
             null
-        } catch (thrown: IOException) {
-            thrown
+        } catch (failure: IOException) {
+            failure
         }
 
+        assertTrue(thrown?.message?.contains("PNG compression failed") == true)
+        assertFalse(destination.exists())
+        assertTrue(managedTempFiles().isEmpty())
+    }
+
+    @Test
+    fun `a close IOException is preserved and commit is never attempted`() {
+        val destination = File(cacheDir, "climb.png")
+        val closeFailure = IOException("simulated close failure")
+        var commitCalled = false
+        val neverCommit = AtomicFileCommitter { _, _ -> commitCalled = true }
+
+        val thrown = try {
+            AtomicFileWrite.writeAtomically(
+                destination = destination,
+                committer = neverCommit,
+                outputStreamFactory = { tempFile ->
+                    object : FileOutputStream(tempFile) {
+                        override fun close() {
+                            super.close()
+                            throw closeFailure
+                        }
+                    }
+                },
+            ) { outputStream ->
+                outputStream.write(byteArrayOf(1, 2, 3))
+                true
+            }
+            null
+        } catch (failure: IOException) {
+            failure
+        }
+
+        assertSame(closeFailure, thrown)
+        assertFalse(commitCalled)
+        assertFalse(destination.exists())
+        assertTrue(managedTempFiles().isEmpty())
+    }
+
+    @Test
+    fun `an output stream open IOException is preserved`() {
+        val destination = File(cacheDir, "climb.png")
+        val openFailure = FileNotFoundException("simulated output stream open failure")
+
+        val thrown = try {
+            AtomicFileWrite.writeAtomically(
+                destination = destination,
+                committer = jvmAtomicCommitter,
+                outputStreamFactory = { throw openFailure },
+            ) { true }
+            null
+        } catch (failure: IOException) {
+            failure
+        }
+
+        assertSame(openFailure, thrown)
+        assertFalse(destination.exists())
+        assertTrue(managedTempFiles().isEmpty())
+    }
+
+    @Test
+    fun `a writer failure remains primary when close also fails`() {
+        val destination = File(cacheDir, "climb.png")
+        val writerFailure = IOException("simulated writer failure")
+        val closeFailure = IOException("simulated close failure")
+
+        val thrown = try {
+            AtomicFileWrite.writeAtomically(
+                destination = destination,
+                committer = jvmAtomicCommitter,
+                outputStreamFactory = { tempFile ->
+                    object : FileOutputStream(tempFile) {
+                        override fun close() {
+                            super.close()
+                            throw closeFailure
+                        }
+                    }
+                },
+            ) {
+                throw writerFailure
+            }
+            null
+        } catch (failure: IOException) {
+            failure
+        }
+
+        assertSame("writer failure remains the primary exception", writerFailure, thrown)
+        assertTrue("close failure is retained for diagnostics", thrown?.suppressed?.contains(closeFailure) == true)
+        assertFalse(destination.exists())
+        assertTrue(managedTempFiles().isEmpty())
+    }
+
+    @Test
+    fun `a commit IOException is preserved and leaves an existing destination untouched`() {
+        val destination = File(cacheDir, "climb.png")
+        destination.writeBytes(byteArrayOf(9, 9, 9))
+        val commitFailure = IOException("simulated rename failure")
+
+        val thrown = try {
+            writeBytes(
+                destination,
+                byteArrayOf(1, 2, 3),
+                committer = AtomicFileCommitter { _, _ -> throw commitFailure },
+            )
+            null
+        } catch (failure: IOException) {
+            failure
+        }
+
+        assertSame(commitFailure, thrown)
+        assertArrayEquals(byteArrayOf(9, 9, 9), destination.readBytes())
+        assertTrue(managedTempFiles().isEmpty())
+    }
+
+    @Test
+    fun `a non-IO writer failure is normalized with its cause preserved`() {
+        val destination = File(cacheDir, "climb.png")
+        val encoderFailure = IllegalStateException("encoder rejected bitmap")
+
+        val thrown = try {
+            AtomicFileWrite.writeAtomically(destination, jvmAtomicCommitter) {
+                throw encoderFailure
+            }
+            null
+        } catch (failure: IOException) {
+            failure
+        }
+
+        assertSame(encoderFailure, thrown?.cause)
+        assertFalse(destination.exists())
+        assertTrue(managedTempFiles().isEmpty())
+    }
+
+    @Test
+    fun `a missing parent directory emerges as IOException`() {
+        val destination = File(cacheDir, "climb.png")
+        assertTrue(cacheDir.deleteRecursively())
+
+        val thrown = try {
+            writeBytes(destination, byteArrayOf(1, 2, 3))
+            null
+        } catch (failure: IOException) {
+            failure
+        }
+
+        assertTrue("temp creation failure is recoverable", thrown is IOException)
+        assertFalse(destination.exists())
+    }
+
+    @Test
+    fun `directory disappearance retries the complete pipeline with a fresh temp`() {
+        val destination = File(cacheDir, "climb.png")
+        val observedTempFiles = mutableListOf<File>()
+        var commitAttempts = 0
+        var writeAttempts = 0
+        var recoveredFrom: IOException? = null
+        val disappearingDirectoryCommitter = AtomicFileCommitter { source, finalDestination ->
+            commitAttempts++
+            if (commitAttempts == 1) {
+                assertTrue(source.delete())
+                assertTrue(cacheDir.delete())
+                throw FileNotFoundException("cache directory disappeared before publish")
+            }
+            jvmAtomicCommitter.commit(source, finalDestination)
+        }
+
+        CacheDirRecovery.retryOnceAfterRecreating(
+            cacheDir,
+            onRecovered = { failure -> recoveredFrom = failure },
+        ) {
+            AtomicFileWrite.writeAtomically(
+                destination = destination,
+                committer = disappearingDirectoryCommitter,
+                outputStreamFactory = { tempFile ->
+                    observedTempFiles.add(tempFile)
+                    FileOutputStream(tempFile)
+                },
+            ) { outputStream ->
+                writeAttempts++
+                outputStream.write(byteArrayOf(1, 2, 3))
+                true
+            }
+        }
+
+        assertEquals(2, writeAttempts)
+        assertEquals(2, commitAttempts)
+        assertTrue(recoveredFrom is FileNotFoundException)
+        assertEquals(2, observedTempFiles.size)
+        assertNotEquals(observedTempFiles[0].name, observedTempFiles[1].name)
+        assertArrayEquals(byteArrayOf(1, 2, 3), destination.readBytes())
+        assertTrue(managedTempFiles().isEmpty())
+    }
+
+    @Test
+    fun `concurrent publications never collide or expose mixed contents`() {
+        val destination = File(cacheDir, "climb.png")
+        val firstPayload = ByteArray(32 * 1024) { 0x11.toByte() }
+        val secondPayload = ByteArray(32 * 1024) { 0x22.toByte() }
+        val writersReady = CountDownLatch(2)
+        val allowCommit = CountDownLatch(1)
+        val failures = Collections.synchronizedList(mutableListOf<Throwable>())
+
+        fun publicationThread(payload: ByteArray): Thread = Thread {
+            try {
+                AtomicFileWrite.writeAtomically(destination, jvmAtomicCommitter) { outputStream ->
+                    outputStream.write(payload)
+                    writersReady.countDown()
+                    if (!allowCommit.await(5, TimeUnit.SECONDS)) {
+                        throw IOException("timed out waiting to publish concurrently")
+                    }
+                    true
+                }
+            } catch (failure: Throwable) {
+                failures.add(failure)
+            }
+        }
+
+        val firstThread = publicationThread(firstPayload)
+        val secondThread = publicationThread(secondPayload)
+        firstThread.start()
+        secondThread.start()
+        assertTrue("both unique temps were fully written", writersReady.await(5, TimeUnit.SECONDS))
+        assertEquals("two in-flight paths coexist", 2, managedTempFiles().size)
+        allowCommit.countDown()
+        firstThread.join(5_000)
+        secondThread.join(5_000)
+
+        assertFalse("first publisher completed", firstThread.isAlive)
+        assertFalse("second publisher completed", secondThread.isAlive)
+        assertTrue("both atomic renames succeeded: $failures", failures.isEmpty())
+        val publishedBytes = destination.readBytes()
         assertTrue(
-            "rename failure surfaces as an IOException",
-            failure?.message?.contains("Failed to move") == true,
+            "the winner is one complete payload, never an interleaving",
+            publishedBytes.contentEquals(firstPayload) || publishedBytes.contentEquals(secondPayload),
         )
-        assertFalse(
-            "temp file cleaned up even though the rename failed",
-            tempFileFor(destination).exists(),
-        )
-        assertTrue("destination directory itself is untouched", destination.isDirectory)
+        assertTrue(managedTempFiles().isEmpty())
     }
 }

--- a/packages/mobile/modules/board-renderer/android/src/test/java/com/boardsesh/boardrenderer/CachePrunerTest.kt
+++ b/packages/mobile/modules/board-renderer/android/src/test/java/com/boardsesh/boardrenderer/CachePrunerTest.kt
@@ -10,9 +10,10 @@ import org.junit.Test
 
 /**
  * Covers [CachePruner] in isolation: the orphaned-temp-file sweep (a process
- * kill between [AtomicFileWrite]'s compress and rename leaves a
- * "$cacheKey.png.tmp" behind — #3748) and the size-based LRU eviction it runs
- * alongside.
+ * kill between [AtomicFileWrite]'s compress and rename leaves a private
+ * ".bsov-*.tmp" behind — #3748) and the size-based LRU eviction it runs
+ * alongside. The private prefix is part of the safety contract: this helper
+ * must never sweep an unrelated component's `.tmp` file.
  */
 class CachePrunerTest {
     private lateinit var cacheDir: File
@@ -32,7 +33,7 @@ class CachePrunerTest {
 
     @Test
     fun `sweeps an orphaned temp file regardless of the size cap`() {
-        val orphan = File(cacheDir, "abc123.png${AtomicFileWrite.TEMP_SUFFIX}")
+        val orphan = File(cacheDir, "${AtomicFileWrite.TEMP_PREFIX}abc123${AtomicFileWrite.TEMP_SUFFIX}")
         orphan.writeBytes(byteArrayOf(1))
         val validEntry = File(cacheDir, "def456.png")
         validEntry.writeBytes(byteArrayOf(1, 2, 3))
@@ -46,6 +47,26 @@ class CachePrunerTest {
     }
 
     @Test
+    fun `sweeps only private-prefix temp files`() {
+        val managedOrphan = File(
+            cacheDir,
+            "${AtomicFileWrite.TEMP_PREFIX}managed${AtomicFileWrite.TEMP_SUFFIX}",
+        )
+        managedOrphan.writeBytes(byteArrayOf(1))
+        val unrelatedTemp = File(cacheDir, "download${AtomicFileWrite.TEMP_SUFFIX}")
+        unrelatedTemp.writeBytes(byteArrayOf(2))
+        val prefixOnly = File(cacheDir, "${AtomicFileWrite.TEMP_PREFIX}not-a-temp.png")
+        prefixOnly.writeBytes(byteArrayOf(3))
+
+        val result = CachePruner.pruneCacheIfNeeded(cacheDir, maxBytes = 1_000_000)
+
+        assertEquals(1, result.orphanedTempFilesRemoved)
+        assertFalse(managedOrphan.exists())
+        assertTrue("unowned .tmp file survives", unrelatedTemp.exists())
+        assertTrue("prefix without the private suffix survives", prefixOnly.exists())
+    }
+
+    @Test
     fun `does nothing when the cache is empty`() {
         val result = CachePruner.pruneCacheIfNeeded(cacheDir, maxBytes = 1_000_000)
 
@@ -56,7 +77,7 @@ class CachePrunerTest {
 
     @Test
     fun `evicts oldest-first once the cap is exceeded, on top of the temp sweep`() {
-        val orphan = File(cacheDir, "orphan.png${AtomicFileWrite.TEMP_SUFFIX}")
+        val orphan = File(cacheDir, "${AtomicFileWrite.TEMP_PREFIX}orphan${AtomicFileWrite.TEMP_SUFFIX}")
         orphan.writeBytes(ByteArray(10))
 
         val oldest = File(cacheDir, "oldest.png")
@@ -82,7 +103,7 @@ class CachePrunerTest {
         // Even a huge orphaned temp file must not push a well-under-cap real
         // entry into eviction — it's swept unconditionally, before the cap
         // check ever runs against the remaining entries.
-        val orphan = File(cacheDir, "huge.png${AtomicFileWrite.TEMP_SUFFIX}")
+        val orphan = File(cacheDir, "${AtomicFileWrite.TEMP_PREFIX}huge${AtomicFileWrite.TEMP_SUFFIX}")
         orphan.writeBytes(ByteArray(1_000))
         val validEntry = File(cacheDir, "small.png")
         validEntry.writeBytes(ByteArray(5))

--- a/packages/mobile/modules/board-renderer/android/src/test/java/com/boardsesh/boardrenderer/CachePrunerTest.kt
+++ b/packages/mobile/modules/board-renderer/android/src/test/java/com/boardsesh/boardrenderer/CachePrunerTest.kt
@@ -11,9 +11,9 @@ import org.junit.Test
 /**
  * Covers [CachePruner] in isolation: the orphaned-temp-file sweep (a process
  * kill between [AtomicFileWrite]'s compress and rename leaves a private
- * ".bsov-*.tmp" behind — #3748) and the size-based LRU eviction it runs
- * alongside. The private prefix is part of the safety contract: this helper
- * must never sweep an unrelated component's `.tmp` file.
+ * ".bsov-*.tmp" behind) and the size-based LRU eviction it runs alongside. The
+ * private prefix and final `.png` suffix are part of the safety contract: this
+ * helper must never sweep, count, or evict an unrelated component's file.
  */
 class CachePrunerTest {
     private lateinit var cacheDir: File
@@ -95,6 +95,35 @@ class CachePrunerTest {
         assertFalse("orphan swept", orphan.exists())
         assertFalse("oldest entry evicted by LRU", oldest.exists())
         assertTrue("newest entry survives", newest.exists())
+        assertEquals(10L, result.finalTotalBytes)
+    }
+
+    @Test
+    fun `over-cap eviction preserves unrelated files and temp files`() {
+        val unrelatedTemp = File(cacheDir, "download.tmp")
+        unrelatedTemp.writeBytes(ByteArray(1_000))
+        unrelatedTemp.setLastModified(1_000)
+
+        val unrelatedMetadata = File(cacheDir, "metadata.json")
+        unrelatedMetadata.writeBytes(ByteArray(1_000))
+        unrelatedMetadata.setLastModified(2_000)
+
+        val oldestManagedEntry = File(cacheDir, "oldest.png")
+        oldestManagedEntry.writeBytes(ByteArray(10))
+        oldestManagedEntry.setLastModified(3_000)
+
+        val newestManagedEntry = File(cacheDir, "newest.png")
+        newestManagedEntry.writeBytes(ByteArray(10))
+        newestManagedEntry.setLastModified(4_000)
+
+        val result = CachePruner.pruneCacheIfNeeded(cacheDir, maxBytes = 15)
+
+        assertEquals(0, result.orphanedTempFilesRemoved)
+        assertEquals(1, result.cacheEntriesEvicted)
+        assertTrue("unrelated .tmp file survives", unrelatedTemp.exists())
+        assertTrue("unrelated metadata survives", unrelatedMetadata.exists())
+        assertFalse("oldest managed PNG is evicted", oldestManagedEntry.exists())
+        assertTrue("newest managed PNG survives", newestManagedEntry.exists())
         assertEquals(10L, result.finalTotalBytes)
     }
 

--- a/packages/mobile/modules/board-renderer/src/overlay-cache-store.web.ts
+++ b/packages/mobile/modules/board-renderer/src/overlay-cache-store.web.ts
@@ -157,7 +157,7 @@ let hydratePromise: Promise<void> | null = null;
  * synchronous warm-up can surface prior-session renders. Idempotent — the first
  * call kicks off the async hydration and later calls await the same promise.
  *
- * `currentVersionPrefix` (e.g. `v3_`) makes eviction deterministic and
+ * `currentVersionPrefix` (e.g. `v5_`) makes eviction deterministic and
  * store-owned rather than dependent on the hook's warm-up: any key whose
  * cacheKey doesn't carry the current renderer version is deleted here, so
  * stale-version PNGs never burn a hydrate slot and are always reclaimed —

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render.test.ts
@@ -109,12 +109,10 @@ describe('buildCacheKey', () => {
     expect(small).not.toBe(full);
   });
 
-  it('uses RENDERER_VERSION v4 to invalidate stale overlay PNGs', () => {
-    // v4 (issue #2202) switches hold colors to each role's calibrated
-    // displayColor and boosts Grasshopper's default stroke width. The
-    // version prefix guarantees pre-fix v3 cache files (rendered with the
-    // raw, too-dark LED colors) cannot be reused.
-    expect(buildCacheKey('kilter', 1, 10, '24', 'p1r42')).toMatch(/^v4_/);
+  it('uses RENDERER_VERSION v5 to invalidate non-atomic v4 overlay PNGs', () => {
+    // v5 (issue #3748) ensures a newly built native client never trusts a v4
+    // file that may have been truncated by the old direct-to-destination write.
+    expect(buildCacheKey('kilter', 1, 10, '24', 'p1r42')).toMatch(/^v5_/);
   });
 
   it('uses a distinct style token so filled (list) and stroke (play view) never collide', () => {
@@ -433,33 +431,32 @@ describe('renderedOverlays warm-up from disk cache', () => {
 
   it('exposes the populated map so a fresh hook init can hit it synchronously', () => {
     expect(_renderedOverlaysForTests).toBeInstanceOf(Map);
-    _renderedOverlaysForTests.set('v4_kilter_1_10_24_deadbeef', 'file:///prior/session.png');
-    expect(_renderedOverlaysForTests.get('v4_kilter_1_10_24_deadbeef')).toBe('file:///prior/session.png');
-    _renderedOverlaysForTests.delete('v4_kilter_1_10_24_deadbeef');
+    _renderedOverlaysForTests.set('v5_kilter_1_10_24_deadbeef', 'file:///prior/session.png');
+    expect(_renderedOverlaysForTests.get('v5_kilter_1_10_24_deadbeef')).toBe('file:///prior/session.png');
+    _renderedOverlaysForTests.delete('v5_kilter_1_10_24_deadbeef');
   });
 
   it('only loads PNGs whose name starts with the current RENDERER_VERSION prefix', () => {
-    // Mix of v1/v2/v3 leftovers from previous app sessions and current v4
-    // entries. The warm-up should only surface v4 keys; older keys would
-    // never match any cacheKey lookup (all current keys are v4_*) so
-    // loading them just bloats memory. v3 leftovers matter for issue #2202:
-    // they were rendered with the raw, too-dark LED colors and must not be
-    // reused post-fix.
+    // Mix older leftovers (including v4 files written before #3748) with
+    // current v5 entries. The warm-up must surface only v5 keys; all older
+    // files are invalid under the current atomic-publication cache contract.
     const v1Entry = makeMockEntry('v1_kilter_1_10_24_aaaaaaaa.png');
     const v2Entry = makeMockEntry('v2_kilter_1_10_24_bbbbbbbb.png');
     const v3Entry = makeMockEntry('v3_kilter_1_10_24_eeeeeeee.png');
-    const v4EntryA = makeMockEntry('v4_kilter_1_10_24_cccccccc.png');
-    const v4EntryB = makeMockEntry('v4_tension_2_8_15_dddddddd.png');
-    directoryListSpy.mockReturnValue([v1Entry, v2Entry, v3Entry, v4EntryA, v4EntryB]);
+    const v4Entry = makeMockEntry('v4_kilter_1_10_24_ffffffff.png');
+    const v5EntryA = makeMockEntry('v5_kilter_1_10_24_cccccccc.png');
+    const v5EntryB = makeMockEntry('v5_tension_2_8_15_dddddddd.png');
+    directoryListSpy.mockReturnValue([v1Entry, v2Entry, v3Entry, v4Entry, v5EntryA, v5EntryB]);
 
     _runWarmupForTests();
 
-    expect(_renderedOverlaysForTests.has('v4_kilter_1_10_24_cccccccc')).toBe(true);
-    expect(_renderedOverlaysForTests.has('v4_tension_2_8_15_dddddddd')).toBe(true);
+    expect(_renderedOverlaysForTests.has('v5_kilter_1_10_24_cccccccc')).toBe(true);
+    expect(_renderedOverlaysForTests.has('v5_tension_2_8_15_dddddddd')).toBe(true);
     expect(_renderedOverlaysForTests.has('v1_kilter_1_10_24_aaaaaaaa')).toBe(false);
     expect(_renderedOverlaysForTests.has('v2_kilter_1_10_24_bbbbbbbb')).toBe(false);
     expect(_renderedOverlaysForTests.has('v3_kilter_1_10_24_eeeeeeee')).toBe(false);
-    // Only the two v4 entries should be present — no stragglers from
+    expect(_renderedOverlaysForTests.has('v4_kilter_1_10_24_ffffffff')).toBe(false);
+    // Only the two v5 entries should be present — no stragglers from
     // future-version PNGs slipping in either.
     expect(_renderedOverlaysForTests.size).toBe(2);
   });
@@ -467,16 +464,18 @@ describe('renderedOverlays warm-up from disk cache', () => {
   it('opportunistically deletes stale-version PNG files to reclaim disk', () => {
     const v1Entry = makeMockEntry('v1_kilter_1_10_24_aaaaaaaa.png');
     const v2Entry = makeMockEntry('v2_kilter_1_10_24_bbbbbbbb.png');
-    const v4Entry = makeMockEntry('v4_kilter_1_10_24_cccccccc.png');
-    directoryListSpy.mockReturnValue([v1Entry, v2Entry, v4Entry]);
+    const v4Entry = makeMockEntry('v4_kilter_1_10_24_stale.png');
+    const v5Entry = makeMockEntry('v5_kilter_1_10_24_cccccccc.png');
+    directoryListSpy.mockReturnValue([v1Entry, v2Entry, v4Entry, v5Entry]);
 
     _runWarmupForTests();
 
     expect(v1Entry.delete).toHaveBeenCalledTimes(1);
     expect(v2Entry.delete).toHaveBeenCalledTimes(1);
+    expect(v4Entry.delete).toHaveBeenCalledTimes(1);
     // Current-version files must never be deleted — they're the cache hits
     // the warm-up exists to surface.
-    expect(v4Entry.delete).not.toHaveBeenCalled();
+    expect(v5Entry.delete).not.toHaveBeenCalled();
   });
 
   it('keeps loading remaining entries when a delete throws', () => {
@@ -486,10 +485,10 @@ describe('renderedOverlays warm-up from disk cache', () => {
     v1Entry.delete.mockImplementation(() => {
       throw new Error('EACCES');
     });
-    const v4Entry = makeMockEntry('v4_kilter_1_10_24_bbbbbbbb.png');
-    directoryListSpy.mockReturnValue([v1Entry, v4Entry]);
+    const v5Entry = makeMockEntry('v5_kilter_1_10_24_bbbbbbbb.png');
+    directoryListSpy.mockReturnValue([v1Entry, v5Entry]);
 
     expect(() => _runWarmupForTests()).not.toThrow();
-    expect(_renderedOverlaysForTests.has('v4_kilter_1_10_24_bbbbbbbb')).toBe(true);
+    expect(_renderedOverlaysForTests.has('v5_kilter_1_10_24_bbbbbbbb')).toBe(true);
   });
 });

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render.test.ts
@@ -110,7 +110,7 @@ describe('buildCacheKey', () => {
   });
 
   it('uses RENDERER_VERSION v5 to invalidate non-atomic v4 overlay PNGs', () => {
-    // v5 (issue #3748) ensures a newly built native client never trusts a v4
+    // v5 ensures a newly built native client never trusts a v4
     // file that may have been truncated by the old direct-to-destination write.
     expect(buildCacheKey('kilter', 1, 10, '24', 'p1r42')).toMatch(/^v5_/);
   });
@@ -437,7 +437,7 @@ describe('renderedOverlays warm-up from disk cache', () => {
   });
 
   it('only loads PNGs whose name starts with the current RENDERER_VERSION prefix', () => {
-    // Mix older leftovers (including v4 files written before #3748) with
+    // Mix older leftovers (including v4 files written before atomic publication) with
     // current v5 entries. The warm-up must surface only v5 keys; all older
     // files are invalid under the current atomic-publication cache contract.
     const v1Entry = makeMockEntry('v1_kilter_1_10_24_aaaaaaaa.png');

--- a/packages/mobile/src/hooks/renderer-version.ts
+++ b/packages/mobile/src/hooks/renderer-version.ts
@@ -8,7 +8,7 @@
  * binaries during rollout. v4 (issue #2202) switches hold colors to each role's
  * calibrated displayColor and boosts Grasshopper's default stroke width — both
  * change the rendered pixels for a config that otherwise hashes the same, so
- * stale v3 PNGs must not be reused. v5 (issue #3748) invalidates any v4 native
+ * stale v3 PNGs must not be reused. v5 invalidates any v4 native
  * PNG that may have been truncated before publication became atomic. This
  * version is shared by native and Expo web, so the web Cache API intentionally
  * performs the same one-time v4 flush. The accompanying native-module changes

--- a/packages/mobile/src/hooks/renderer-version.ts
+++ b/packages/mobile/src/hooks/renderer-version.ts
@@ -8,14 +8,19 @@
  * binaries during rollout. v4 (issue #2202) switches hold colors to each role's
  * calibrated displayColor and boosts Grasshopper's default stroke width — both
  * change the rendered pixels for a config that otherwise hashes the same, so
- * stale v3 PNGs must not be reused.
+ * stale v3 PNGs must not be reused. v5 (issue #3748) invalidates any v4 native
+ * PNG that may have been truncated before publication became atomic. This
+ * version is shared by native and Expo web, so the web Cache API intentionally
+ * performs the same one-time v4 flush. The accompanying native-module changes
+ * move Expo's fingerprint, keeping the v5 JS contract isolated to binaries that
+ * contain the atomic writer.
  *
  * Lives in its own module so both the hook (use-native-climb-render.ts) and the
  * web overlay warm-up (overlay-cache-warmup.web.ts) can read it without a
  * circular import — the hook imports the warm-up, so the warm-up must not import
  * back from the hook.
  */
-export const RENDERER_VERSION = 4;
+export const RENDERER_VERSION = 5;
 
 /** Cache-key prefix stamped on every overlay produced by the current renderer. */
 export const currentOverlayVersionPrefix = (): string => `v${RENDERER_VERSION}_`;

--- a/packages/mobile/src/lib/__tests__/overlay-cache.web.test.ts
+++ b/packages/mobile/src/lib/__tests__/overlay-cache.web.test.ts
@@ -15,6 +15,7 @@ import {
   MARKER_RENDERER_UNAVAILABLE_MESSAGE,
   _webRendererForTests,
 } from '../../../modules/board-renderer/src/index.web';
+import { currentOverlayVersionPrefix } from '../../hooks/renderer-version';
 
 // --- Fakes for the browser storage/encoding APIs jsdom does not implement ---
 
@@ -157,24 +158,27 @@ describe('overlay-cache-store hydration + snapshot (warmup contract)', () => {
     expect(snapshotOverlayEntries()).toHaveLength(limit);
   });
 
-  it('evicts stale-version keys during hydration when given the current prefix', async () => {
+  it('flushes shared web v4 entries when the native and web renderer contract moves to v5', async () => {
     const { store } = installCaches();
     await writeOverlayToCache('v2_s_wfull_kilter_1_2_25_old', new Blob() as Blob);
-    await writeOverlayToCache('v3_s_wfull_kilter_1_2_25_keep', new Blob() as Blob);
+    await writeOverlayToCache('v4_s_wfull_kilter_1_2_25_pre_atomic', new Blob() as Blob);
+    await writeOverlayToCache('v5_s_wfull_kilter_1_2_25_keep', new Blob() as Blob);
     await writeOverlayToCache('v1_f_w400_kilter_1_2_25_ancient', new Blob() as Blob);
     _overlayCacheStoreForTests.renderedObjectUrls.clear();
 
-    await hydrateOverlayCache('v3_');
+    expect(currentOverlayVersionPrefix()).toBe('v5_');
+    await hydrateOverlayCache(currentOverlayVersionPrefix());
 
     // Stale-version PNGs are deleted from the Cache API, not hydrated — so they
     // never burn a hydrate slot and are always reclaimed regardless of the
     // warm-up race.
     expect(store.has(_overlayCacheStoreForTests.overlayKeyUrl('v2_s_wfull_kilter_1_2_25_old'))).toBe(false);
+    expect(store.has(_overlayCacheStoreForTests.overlayKeyUrl('v4_s_wfull_kilter_1_2_25_pre_atomic'))).toBe(false);
     expect(store.has(_overlayCacheStoreForTests.overlayKeyUrl('v1_f_w400_kilter_1_2_25_ancient'))).toBe(false);
-    expect(store.has(_overlayCacheStoreForTests.overlayKeyUrl('v3_s_wfull_kilter_1_2_25_keep'))).toBe(true);
+    expect(store.has(_overlayCacheStoreForTests.overlayKeyUrl('v5_s_wfull_kilter_1_2_25_keep'))).toBe(true);
     const entries = snapshotOverlayEntries();
     expect(entries).toHaveLength(1);
-    expect(entries[0].name).toBe('v3_s_wfull_kilter_1_2_25_keep.png');
+    expect(entries[0].name).toBe('v5_s_wfull_kilter_1_2_25_keep.png');
   });
 
   it('releaseAllObjectUrls revokes every retained URL', async () => {


### PR DESCRIPTION
> [!IMPORTANT]
> **Native follow-up:** #4073 merged before its final correctness fixes landed. This draft contains only the remaining changes against current `main` and completes the fix for #3748. It changes Android native source and must ride an Android native release rather than an OTA-only rollout.

## Summary

#4073 established atomic overlay writes on both platforms, including Foundation `.atomic` on iOS. This follow-up carries the reviewed hardening that did not make that merge:

- Android creates a fresh, hidden, same-directory `.bsov-*.tmp` for every attempt, then publishes the closed PNG with API-21+ `android.system.Os.rename`.
- The atomic publisher is injected so the pipeline stays plain-JVM testable. `ErrnoException`, output creation/write/close failures, compression failure, and commit failure all surface as `IOException` while preserving their causes.
- The complete temp-create → compress → close → rename pipeline sits inside `CacheDirRecovery`, so directory reclamation retries from a new temp path.
- Startup cleanup sweeps only private `.bsov-*.tmp` artifacts. Size accounting and LRU eviction consider only final `.png` overlays, so unrelated files and unrelated `.tmp` files survive even when the PNG cache exceeds its cap.
- Renderer cache version v5 forces old potentially partial v4 overlays to regenerate. Native disk warm-up rejects v4 files, and the shared Expo web Cache API intentionally performs the same one-time v4 flush.
- Concurrent publication is safe: writers use distinct temp paths and the final file is always one complete winner.

No Swift change remains in this diff because the iOS `.atomic` write already shipped in #4073.

## Native delivery and fingerprints

The final OTA compatibility check on commit `74339261b` confirms:

| Platform | Result | Fingerprint |
| --- | --- | --- |
| iOS | OTA-compatible | `f2fb048a9827` (matches `main`; already released) |
| Android | Native change | PR `04a822f5aa0a` · `main` `48d2971669bd` |

Only Android changes fingerprint, as expected: this diff adds Kotlin under `packages/mobile/modules/board-renderer/android`. The v5 JavaScript contract therefore cannot reach incompatible older Android binaries and must ride a native Android release. iOS retains the Foundation atomic-write change already merged by #4073.

## QA

QA notes cover first render, cached reopen, concurrent thumbnail activity, app restart/cache warm-up, cache-directory reclamation, and the intentional Expo web v4 regeneration. Metro surfaced the notes at `.boardsesh/qa-notes.md`.

Validation completed before push:

- `vp run typecheck:mobile`
- `vp run test:mobile`: 572 files / 4,864 tests
- `vp run check:mobile-bundle`: iOS and Android bundles
- isolated JVM suite compiled against the installed Android SDK: 21 tests
- focused post-review `CachePrunerTest`: 6 tests, including over-cap preservation of unrelated files
- focused post-review `AtomicFileWriteTest`: 11 tests, including prior-render preservation on close failure
- scoped `vp check`: no formatting, lint, or type warnings in changed TypeScript files

Physical-device process-kill/storage-pressure QA and the macOS simulator check remain manual gates.

## Release Notes

Board hold overlays recover cleanly after an interrupted render instead of staying blank or corrupted.
