### PR TITLE
chore(mobile): instrument iOS sheet detent height to settle the #3776 measurement branch

### DIFF
--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -49,6 +49,7 @@ import { useTheme } from '../providers/theme-provider';
 import { useManagedSheet } from '../providers/sheet-presentation-provider';
 import { androidSafeSnapPoints } from './sheet-snap-points';
 import { useSheetColumnStyle } from './use-sheet-column-style';
+import { useSheetDetentProbe } from './sheet-detent-probe';
 import { useGrades, useSearchClimbsCount } from '../lib/graphql/hooks';
 import type { BoardName, HoldsFilter } from '@boardsesh/shared-schema';
 import { getTallWideScope } from '@boardsesh/board-constants';
@@ -264,6 +265,9 @@ export function ClimbFilterSheet({
   // (#3330). The shared hook pins the column to this single detent's height;
   // Android bounds the column natively, so it keeps flex:1.
   const sheetColumnStyle = useSheetColumnStyle(detentSnapPoints);
+  // Dev-only observers for #3922 — they feed a log line, never layout. This is
+  // the sheet #3776 was reported against, so it is the one to capture on an SE 3.
+  const { probeProps, sentinelProps, onColumnLayout } = useSheetDetentProbe(sheetColumnStyle, 'ClimbFilterSheet');
   // Tall/Wide apply on any board whose active size has a shorter/narrower sibling
   // in its family (getTallWideScope — the shared source of truth the chip row and
   // server filter use), not just Kilter. Each toggle renders only where it applies,
@@ -721,11 +725,17 @@ export function ClimbFilterSheet({
       onFullyDismissed={managed.onFullyDismissed}
       handleIndicatorStyle={[styles.indicator, { backgroundColor: systemColors.separator }]}
     >
+      {/* #3922 instrumentation, dev builds only. The sentinel is in-flow but
+          zero-height and the probe is absolutely positioned, so neither adds
+          anything to the wrapper's content size — the one-in-flow-child rule
+          below still holds. */}
+      {sentinelProps ? <View {...sentinelProps} /> : null}
+      {probeProps ? <View {...probeProps} /> : null}
       {/* One column child bounded to the detent height (JS-computed on iOS, see
           sheetColumnStyle) — the scroll body then actually scrolls and the
           footer pins. Handed multiple direct children, the native sheet sizes
           to content and the flex:1 ScrollView collapses (no scrolling). */}
-      <View style={sheetColumnStyle}>
+      <View style={sheetColumnStyle} onLayout={onColumnLayout}>
         <View style={styles.header}>
           <Text variant="title3">{t('mobile.filter.title')}</Text>
           <Pressable onPress={handleReset} hitSlop={8} accessibilityRole="button" disabled={!anyActive}>

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -25,6 +25,7 @@ import { useTheme } from '../providers/theme-provider';
 import { androidSafeSnapPoints } from './sheet-snap-points';
 import { useSheetBodyContentStyle } from './sheet-content-inset';
 import { useSheetColumnStyle } from './use-sheet-column-style';
+import { useSheetDetentProbe } from './sheet-detent-probe';
 import { useManagedSheet, type PresenterGroup } from '../providers/sheet-presentation-provider';
 
 type ModalSheetProps = {
@@ -92,6 +93,8 @@ export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(functi
   // Track the resting detent so the iOS column bound follows drags between detents.
   const [activeIndex, setActiveIndex] = useState(0);
   const columnStyle = useSheetColumnStyle(snapPoints, { enableDynamicSizing, activeIndex });
+  // Dev-only observers for #3922 — they feed a log line, never layout.
+  const { probeProps, sentinelProps, onColumnLayout } = useSheetDetentProbe(columnStyle, 'ModalSheet');
 
   const handleChange = useCallback(
     (index: number) => {
@@ -123,9 +126,13 @@ export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(functi
   // not pad content for it. With a footer the body scrolls above the footer, which
   // already carries `insets.bottom`.
   const bodyContentContainerStyle = useSheetBodyContentStyle(Boolean(footer), contentContainerStyle, insets.bottom);
+  // #3922: measure whichever view actually carries columnStyle — the body when
+  // there is no footer, the KeyboardAvoidingView below when there is.
+  const bodyLayout = footer ? undefined : onColumnLayout;
   const body = scrollable ? (
     <BottomSheetScrollView
       style={bodyStyle}
+      onLayout={bodyLayout}
       contentContainerStyle={bodyContentContainerStyle}
       showsVerticalScrollIndicator={false}
       keyboardShouldPersistTaps="handled"
@@ -134,9 +141,13 @@ export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(functi
       {children}
     </BottomSheetScrollView>
   ) : enableDynamicSizing && !footer && Platform.OS === 'web' ? (
+    // Web + dynamic sizing only, where the column is never bounded and the
+    // #3922 probe stays idle — so there is nothing to measure here.
     <BottomSheetView style={[bodyStyle, bodyContentContainerStyle]}>{children}</BottomSheetView>
   ) : (
-    <View style={[bodyStyle, bodyContentContainerStyle]}>{children}</View>
+    <View style={[bodyStyle, bodyContentContainerStyle]} onLayout={bodyLayout}>
+      {children}
+    </View>
   );
 
   const footerBar = footer ? (
@@ -166,13 +177,19 @@ export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(functi
       onFullyDismissed={managed.onFullyDismissed}
       style={styles.sheet}
     >
+      {/* #3922 instrumentation, dev builds only. The sentinel is in-flow but
+          zero-height and the probe is absolutely positioned, so neither adds
+          anything to the wrapper's content size in either of @expo/ui's layout
+          branches — the "single flex child" rule below still holds. */}
+      {sentinelProps ? <View {...sentinelProps} /> : null}
+      {probeProps ? <View {...probeProps} /> : null}
       {footer ? (
         // The single flex child of the native sheet: bound to the detent height on
         // iOS (see useSheetColumnStyle) so the pinned footer can't fall off-screen
         // (#3330); flex:1 on Android / fitToContents. `padding` on both platforms:
         // the Android Compose dialog window does not resize for the keyboard, so
         // without it the keyboard covers the footer's input (emulator-verified).
-        <KeyboardAvoidingView style={columnStyle} behavior="padding">
+        <KeyboardAvoidingView style={columnStyle} behavior="padding" onLayout={onColumnLayout}>
           {body}
           {footerBar}
         </KeyboardAvoidingView>

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -21,6 +21,7 @@ import { useTheme } from '../providers/theme-provider';
 import { androidSafeSnapPoints } from './sheet-snap-points';
 import { useSheetBodyContentStyle } from './sheet-content-inset';
 import { useSheetColumnStyle } from './use-sheet-column-style';
+import { useSheetDetentProbe } from './sheet-detent-probe';
 import { useManagedSheet, type PresenterGroup } from '../providers/sheet-presentation-provider';
 
 type SheetProps = {
@@ -92,6 +93,8 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
   // Track the resting detent so the iOS column bound follows drags between detents.
   const [activeIndex, setActiveIndex] = useState(0);
   const columnStyle = useSheetColumnStyle(snapPoints, { enableDynamicSizing, activeIndex });
+  // Dev-only observers for #3922 — they feed a log line, never layout.
+  const { probeProps, sentinelProps, onColumnLayout } = useSheetDetentProbe(columnStyle, 'Sheet');
 
   const handleChange = useCallback(
     (index: number) => {
@@ -123,9 +126,13 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
   // not pad content for it. With a footer the body scrolls above the footer, which
   // already carries `insets.bottom`.
   const bodyContentContainerStyle = useSheetBodyContentStyle(Boolean(footer), contentContainerStyle, insets.bottom);
+  // #3922: measure whichever view actually carries columnStyle — the body when
+  // there is no footer, the KeyboardAvoidingView below when there is.
+  const bodyLayout = footer ? undefined : onColumnLayout;
   const body = scrollable ? (
     <BottomSheetScrollView
       style={bodyStyle}
+      onLayout={bodyLayout}
       contentContainerStyle={bodyContentContainerStyle}
       showsVerticalScrollIndicator={false}
       keyboardShouldPersistTaps="handled"
@@ -134,9 +141,13 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
       {children}
     </BottomSheetScrollView>
   ) : enableDynamicSizing && !footer && Platform.OS === 'web' ? (
+    // Web + dynamic sizing only, where the column is never bounded and the
+    // #3922 probe stays idle — so there is nothing to measure here.
     <BottomSheetView style={[bodyStyle, bodyContentContainerStyle]}>{children}</BottomSheetView>
   ) : (
-    <View style={[bodyStyle, bodyContentContainerStyle]}>{children}</View>
+    <View style={[bodyStyle, bodyContentContainerStyle]} onLayout={bodyLayout}>
+      {children}
+    </View>
   );
 
   const footerBar = footer ? (
@@ -166,13 +177,19 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
       handleIndicatorStyle={sheetChrome.handleStyle}
       style={styles.sheet}
     >
+      {/* #3922 instrumentation, dev builds only. The sentinel is in-flow but
+          zero-height and the probe is absolutely positioned, so neither adds
+          anything to the wrapper's content size in either of @expo/ui's layout
+          branches — the "single flex child" rule below still holds. */}
+      {sentinelProps ? <View {...sentinelProps} /> : null}
+      {probeProps ? <View {...probeProps} /> : null}
       {footer ? (
         // The single flex child of the native sheet: bound to the detent height on
         // iOS (see useSheetColumnStyle) so the pinned footer can't fall off-screen
         // (#3330); flex:1 on Android / fitToContents. `padding` on both platforms:
         // the Android Compose dialog window does not resize for the keyboard, so
         // without it the keyboard covers the footer's input (emulator-verified).
-        <KeyboardAvoidingView style={columnStyle} behavior="padding">
+        <KeyboardAvoidingView style={columnStyle} behavior="padding" onLayout={onColumnLayout}>
           {body}
           {footerBar}
         </KeyboardAvoidingView>

--- a/packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx
@@ -143,7 +143,12 @@ vi.mock('react-native', () => ({
       placeholder,
       'aria-label': accessibilityLabel,
     }),
-  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+  StyleSheet: {
+    create: (styles: Record<string, unknown>) => styles,
+    hairlineWidth: 1,
+    // Consumed by the #3922 detent probe (sheet-detent-probe.ts).
+    absoluteFill: { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 },
+  },
 }));
 
 vi.mock('react-native-gesture-handler', () => ({

--- a/packages/mobile/src/components/__tests__/sheet-detent-probe.test.tsx
+++ b/packages/mobile/src/components/__tests__/sheet-detent-probe.test.tsx
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { LayoutChangeEvent, ViewStyle } from 'react-native';
+
+const platformMock = vi.hoisted(() => ({ OS: 'ios' as 'ios' | 'android', Version: '26.1' as string }));
+const absoluteFill = vi.hoisted(() => ({ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }));
+
+vi.mock('react-native', () => ({
+  Platform: platformMock,
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, absoluteFill },
+  useWindowDimensions: () => ({ width: 375, height: 667 }),
+}));
+
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 20, bottom: 0, left: 0, right: 0 }),
+}));
+
+import { useSheetDetentProbe } from '../sheet-detent-probe';
+import { useSheetColumnStyle } from '../use-sheet-column-style';
+
+// A layout event carrying only the fields the probe reads.
+function layout({ height = 0, y = 0 }: { height?: number; y?: number }): LayoutChangeEvent {
+  return { nativeEvent: { layout: { x: 0, y, width: 375, height } } } as LayoutChangeEvent;
+}
+
+const FIXED_COLUMN: ViewStyle = { height: 541 };
+const FLEX_COLUMN: ViewStyle = { flex: 1 };
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  platformMock.OS = 'ios';
+  platformMock.Version = '26.1';
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+});
+
+describe('useSheetDetentProbe — wiring', () => {
+  it('hands back an absolute-fill probe and a zero-height sentinel for a fixed-height column', () => {
+    const { result } = renderHook(() => useSheetDetentProbe(FIXED_COLUMN, 'Sheet'));
+    // The probe must not be able to swallow a tap on the sheet's content.
+    expect(result.current.probeProps?.pointerEvents).toBe('none');
+    expect(result.current.probeProps?.style).toBe(absoluteFill);
+    // Zero height keeps the sentinel out of the wrapper's content size, so it
+    // cannot move the layout it exists to measure.
+    expect(result.current.sentinelProps?.style).toEqual({ height: 0 });
+    expect(result.current.onColumnLayout).toBeTypeOf('function');
+  });
+
+  it('stays idle for a flex column (Android / dynamic sizing / non-% detents)', () => {
+    const { result } = renderHook(() => useSheetDetentProbe(FLEX_COLUMN, 'Sheet'));
+    expect(result.current.probeProps).toBeNull();
+    expect(result.current.sentinelProps).toBeNull();
+    expect(result.current.onColumnLayout).toBeUndefined();
+  });
+
+  it('keeps callback identity stable so the probe views never remount', () => {
+    const { result, rerender } = renderHook(() => useSheetDetentProbe(FIXED_COLUMN, 'Sheet'));
+    const first = result.current;
+    rerender();
+    expect(result.current.probeProps).toBe(first.probeProps);
+    expect(result.current.sentinelProps).toBe(first.sentinelProps);
+    expect(result.current.onColumnLayout).toBe(first.onColumnLayout);
+  });
+});
+
+describe('useSheetDetentProbe — logging', () => {
+  it('logs once, only after all three measurements have arrived', () => {
+    const { result } = renderHook(() => useSheetDetentProbe(FIXED_COLUMN, 'ClimbFilterSheet'));
+    const { probeProps, sentinelProps, onColumnLayout } = result.current;
+
+    probeProps?.onLayout(layout({ height: 548 }));
+    expect(logSpy).not.toHaveBeenCalled();
+    sentinelProps?.onLayout(layout({ y: 16 }));
+    expect(logSpy).not.toHaveBeenCalled();
+
+    onColumnLayout?.(layout({ height: 390 }));
+    expect(logSpy).toHaveBeenCalledTimes(1);
+
+    const [tag, payload] = logSpy.mock.calls[0] as [string, Record<string, unknown>];
+    expect(tag).toContain('#3922');
+    expect(payload).toMatchObject({
+      sheet: 'ClimbFilterSheet',
+      window: { width: 375, height: 667 },
+      insets: { top: 20, bottom: 0 },
+      formulaHeight: 541,
+      probeHeight: 548,
+      columnHeight: 390,
+      sentinelY: 16,
+    });
+  });
+
+  it('reports the in-flow height as probe minus the measured padding, not probe alone', () => {
+    // The distinction that killed the first fix attempt: an absolutely
+    // positioned child resolves against its containing block's PADDING box, so
+    // the probe reads one paddingTop LONG. Verified against yoga-layout@3.2.1
+    // on @expo/ui's wrapper subtree: setViewSize 548 + paddingTop 16 gives
+    // probe=548 while the in-flow column receives 532.
+    const { result } = renderHook(() => useSheetDetentProbe(FIXED_COLUMN, 'Sheet'));
+    result.current.probeProps?.onLayout(layout({ height: 548 }));
+    result.current.sentinelProps?.onLayout(layout({ y: 16 }));
+    result.current.onColumnLayout?.(layout({ height: 541 }));
+
+    const [, payload] = logSpy.mock.calls[0] as [string, Record<string, unknown>];
+    expect(payload.availableInFlowHeight).toBe(532);
+    expect(payload.availableInFlowHeight).not.toBe(payload.probeHeight);
+  });
+
+  it('does not log again once an epoch has been reported', () => {
+    const { result } = renderHook(() => useSheetDetentProbe(FIXED_COLUMN, 'Sheet'));
+    const { probeProps, sentinelProps, onColumnLayout } = result.current;
+    probeProps?.onLayout(layout({ height: 548 }));
+    sentinelProps?.onLayout(layout({ y: 16 }));
+    onColumnLayout?.(layout({ height: 541 }));
+    expect(logSpy).toHaveBeenCalledTimes(1);
+
+    // A settle animation or keyboard resize re-fires layout on the same detent.
+    probeProps?.onLayout(layout({ height: 548 }));
+    onColumnLayout?.(layout({ height: 541 }));
+    expect(logSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts a fresh epoch when the detent height changes, without mixing readings', () => {
+    const { result, rerender } = renderHook(({ style }) => useSheetDetentProbe(style, 'Sheet'), {
+      initialProps: { style: FIXED_COLUMN },
+    });
+    result.current.probeProps?.onLayout(layout({ height: 548 }));
+    result.current.sentinelProps?.onLayout(layout({ y: 16 }));
+    result.current.onColumnLayout?.(layout({ height: 541 }));
+    expect(logSpy).toHaveBeenCalledTimes(1);
+
+    // Drag to a taller detent: the formula height changes, so the previous
+    // epoch's probe/sentinel readings must not be reused.
+    rerender({ style: { height: 300 } as ViewStyle });
+    result.current.onColumnLayout?.(layout({ height: 300 }));
+    expect(logSpy).toHaveBeenCalledTimes(1);
+
+    result.current.probeProps?.onLayout(layout({ height: 307 }));
+    result.current.sentinelProps?.onLayout(layout({ y: 16 }));
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    const [, payload] = logSpy.mock.calls[1] as [string, Record<string, unknown>];
+    expect(payload).toMatchObject({ formulaHeight: 300, probeHeight: 307, columnHeight: 300 });
+  });
+});
+
+describe('detent instrumentation gate', () => {
+  // @expo/ui's BottomSheet.ios.tsx picks its layout branch with this expression;
+  // Sheet.tsx passes `undefined` snap points whenever dynamic sizing is on.
+  function expoFitToContents(enableDynamicSizing: boolean, snapPoints: string[] | undefined): boolean {
+    const forwarded = enableDynamicSizing ? undefined : snapPoints;
+    return enableDynamicSizing && (!forwarded || forwarded.length === 0);
+  }
+
+  it('never bounds the column while @expo/ui is measuring content height', () => {
+    // The hook gates on enableDynamicSizing alone while @expo/ui uses a compound
+    // condition. They agree today only because of how Sheet.tsx forwards snap
+    // points — pin it, so a change to either side fails here instead of on a device.
+    for (const enableDynamicSizing of [true, false]) {
+      for (const snapPoints of [undefined, [], ['90%'], ['48%', '80%']]) {
+        const { result } = renderHook(() => useSheetColumnStyle(snapPoints, { enableDynamicSizing }));
+        const bounded = typeof (result.current as ViewStyle).height === 'number';
+        if (bounded) {
+          expect(expoFitToContents(enableDynamicSizing, snapPoints)).toBe(false);
+        }
+      }
+    }
+  });
+
+  it('instruments exactly the sheets the column bound applies to', () => {
+    const bounded = renderHook(() => useSheetColumnStyle(['90%'], { enableDynamicSizing: false }));
+    const unbounded = renderHook(() => useSheetColumnStyle(['90%'], { enableDynamicSizing: true }));
+
+    const withBound = renderHook(() => useSheetDetentProbe(bounded.result.current, 'Sheet'));
+    const withoutBound = renderHook(() => useSheetDetentProbe(unbounded.result.current, 'Sheet'));
+
+    expect(withBound.result.current.probeProps).not.toBeNull();
+    expect(withoutBound.result.current.probeProps).toBeNull();
+  });
+});

--- a/packages/mobile/src/components/__tests__/sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/sheet.test.tsx
@@ -80,6 +80,8 @@ vi.mock('react-native', () => ({
   StyleSheet: {
     create: (styles: Record<string, unknown>) => styles,
     hairlineWidth: 1,
+    // Consumed by the #3922 detent probe (sheet-detent-probe.ts).
+    absoluteFill: { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 },
     // Faithful flatten (arrays merge left-to-right, falsy entries skipped) — the
     // footerless body composes its bottom inset through withSheetBottomInset.
     flatten: function flatten(style: unknown): Record<string, unknown> | undefined {

--- a/packages/mobile/src/components/sheet-detent-probe.ts
+++ b/packages/mobile/src/components/sheet-detent-probe.ts
@@ -1,0 +1,173 @@
+import { useCallback, useMemo, useRef } from 'react';
+import { StyleSheet, useWindowDimensions, type LayoutChangeEvent, type StyleProp, type ViewStyle } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+/**
+ * Development-only instrumentation for the iOS sheet detent height (#3922).
+ *
+ * `useSheetColumnStyle` computes the column height from `useWindowDimensions()`
+ * plus tuned constants. Four merged revisions of that formula (#3352, #3371,
+ * #3433, #3444) and one rejected one (#3611) never closed the ~142pt dead gap
+ * reported on an iPhone SE 3 in #3776, and the two competing models of how
+ * SwiftUI resolves `.fraction(f)` disagree by 30–50pt. #3922's acceptance
+ * criteria ask for device numbers before any further change lands.
+ *
+ * This hook collects those numbers. It is an OBSERVER: nothing it measures
+ * feeds back into layout, so the rendered tree is byte-identical to main.
+ *
+ * ## What gets measured, and why it takes three probes
+ *
+ * `@expo/ui`'s iOS sheet does not hand our children straight to the native
+ * host. `BottomSheet.ios.tsx` wraps them in
+ * `<View style={{ flexGrow: 1, height: 0, paddingTop: 16 }}>` inside
+ * `RNHostView`, whose Yoga node is sized by SwiftUI through
+ * `ReportSizeToYogaNodeModifier` → `shadowNodeProxy.setViewSize()`
+ * (`RNHostView.swift`). `SheetScrollContextReset` renders no host view, so our
+ * children are direct Yoga children of that wrapper.
+ *
+ * - **probe** — `StyleSheet.absoluteFill`. An absolutely positioned child with
+ *   all four insets set resolves against its containing block's PADDING box,
+ *   not its content box (Yoga `AbsoluteLayout.cpp`; CSS-correct). Verified
+ *   against the repo's own `yoga-layout@3.2.1` on the wrapper subtree above:
+ *   with `setViewSize` = 548 and `paddingTop` = 16, the probe reports **548**
+ *   while the in-flow column receives **532**. So the probe alone reads one
+ *   `paddingTop` LONG — driving a column height from it would push a pinned
+ *   footer past the detent, which is #3330 (a clipped Apply/Save) rather than
+ *   #3776 (a cosmetic dead gap).
+ * - **sentinel** — an in-flow, zero-height first child. Its `layout.y` is the
+ *   wrapper's real `paddingTop`, which `BottomSheet.ios.tsx` makes conditional
+ *   (`handleComponent !== null ? 16 : 0`). Measuring it beats assuming 16.
+ *   A zero-height child adds nothing to the wrapper's content size.
+ * - **column** — the view actually carrying `useSheetColumnStyle`'s height.
+ *   Comparing it against the formula answers whether the computed height is
+ *   honoured at all, which is what separates the two branches in #3922.
+ *
+ * The available in-flow height is therefore `probeHeight − sentinelY`, and the
+ * point of this instrumentation is to learn that number on a real device before
+ * anything acts on it.
+ *
+ * ## Reading the log
+ *
+ * On an iPhone SE 3 / iOS 26 (window 667, the device from #3330 and #3776):
+ * - `probeHeight − sentinelY ≈ 548` — the native size report is right and the
+ *   formula is only ~7pt off, so the column height is NOT the lever for
+ *   #3776's 142pt gap; the gap lives elsewhere in the tree.
+ * - `probeHeight − sentinelY ≈ 391` — the SwiftUI → Yoga size report is itself
+ *   short of the real detent, which matches the ~390pt column measured on
+ *   #3776. No JS formula could ever have been right, and the fix belongs
+ *   upstream in `RNHostView` / Expo rather than here.
+ *
+ * A `columnHeight` that does not match `formulaHeight` means the computed
+ * height is not reaching the view, which would make both branches moot.
+ */
+
+/** One measurement epoch. Keyed on the formula height, which already moves with
+ * the active detent and the window size, so no extra reset plumbing is needed. */
+type ProbeEpoch = {
+  key: number | null;
+  probeHeight: number | null;
+  columnHeight: number | null;
+  sentinelY: number | null;
+  logged: boolean;
+};
+
+export type SheetDetentProbeProps = {
+  style: StyleProp<ViewStyle>;
+  pointerEvents: 'none';
+  onLayout: (event: LayoutChangeEvent) => void;
+};
+
+export type SheetDetentProbe = {
+  /** Absolute-fill observer. Out of flow, so it contributes nothing to the
+   * wrapper's content size in either of Expo's two layout branches. */
+  probeProps: SheetDetentProbeProps | null;
+  /** Zero-height in-flow first child. `layout.y` is the wrapper's paddingTop. */
+  sentinelProps: SheetDetentProbeProps | null;
+  /** Attach to the view carrying `useSheetColumnStyle`'s style. */
+  onColumnLayout: ((event: LayoutChangeEvent) => void) | undefined;
+};
+
+const IDLE: SheetDetentProbe = { probeProps: null, sentinelProps: null, onColumnLayout: undefined };
+
+const probeStyles = StyleSheet.create({ sentinel: { height: 0 } });
+
+/**
+ * @param columnStyle the style returned by `useSheetColumnStyle`. Instrumentation
+ *   runs only when that style carries a numeric height — i.e. exactly the iOS
+ *   fixed-detent sheets #3922 is about. Android, web, `enableDynamicSizing` and
+ *   non-`%` detents all yield `flex: 1` and are left completely untouched.
+ * @param label identifies the sheet in the log line.
+ */
+export function useSheetDetentProbe(columnStyle: ViewStyle, label: string): SheetDetentProbe {
+  const window = useWindowDimensions();
+  const insets = useSafeAreaInsets();
+  const formulaHeight = typeof columnStyle.height === 'number' ? columnStyle.height : null;
+
+  const epoch = useRef<ProbeEpoch>({
+    key: null,
+    probeHeight: null,
+    columnHeight: null,
+    sentinelY: null,
+    logged: false,
+  });
+
+  // Kept in a ref so the layout callbacks stay referentially stable: the probe
+  // views must never remount, and a re-render must not re-arm the log.
+  const context = useRef({ window, insets, formulaHeight, label });
+  context.current = { window, insets, formulaHeight, label };
+
+  const record = useCallback((field: 'probeHeight' | 'columnHeight' | 'sentinelY', measured: number) => {
+    const { formulaHeight: key, window: dimensions, insets: safeArea, label: sheetLabel } = context.current;
+    if (key == null) return;
+    const current = epoch.current;
+    if (current.key !== key) {
+      // New detent or new window size — drop the previous epoch's readings
+      // rather than mixing them into one log line.
+      epoch.current = { key, probeHeight: null, columnHeight: null, sentinelY: null, logged: false };
+    }
+    const next = epoch.current;
+    next[field] = measured;
+    if (next.logged || next.probeHeight == null || next.columnHeight == null || next.sentinelY == null) {
+      return;
+    }
+    next.logged = true;
+    console.log('[sheet-detent #3922]', {
+      sheet: sheetLabel,
+      window: { width: dimensions.width, height: dimensions.height },
+      insets: { top: safeArea.top, bottom: safeArea.bottom },
+      formulaHeight: key,
+      probeHeight: next.probeHeight,
+      columnHeight: next.columnHeight,
+      sentinelY: next.sentinelY,
+      // The number every prior formula was trying to guess.
+      availableInFlowHeight: next.probeHeight - next.sentinelY,
+    });
+  }, []);
+
+  const onProbeLayout = useCallback(
+    (event: LayoutChangeEvent) => record('probeHeight', event.nativeEvent.layout.height),
+    [record],
+  );
+  const onSentinelLayout = useCallback(
+    (event: LayoutChangeEvent) => record('sentinelY', event.nativeEvent.layout.y),
+    [record],
+  );
+  const onColumnLayout = useCallback(
+    (event: LayoutChangeEvent) => record('columnHeight', event.nativeEvent.layout.height),
+    [record],
+  );
+
+  const probeProps = useMemo<SheetDetentProbeProps>(
+    () => ({ style: StyleSheet.absoluteFill, pointerEvents: 'none', onLayout: onProbeLayout }),
+    [onProbeLayout],
+  );
+  const sentinelProps = useMemo<SheetDetentProbeProps>(
+    () => ({ style: probeStyles.sentinel, pointerEvents: 'none', onLayout: onSentinelLayout }),
+    [onSentinelLayout],
+  );
+
+  // `__DEV__` is a compile-time constant under Metro, so the whole thing drops
+  // out of release bundles and production sheets render exactly as they do now.
+  if (!__DEV__ || formulaHeight == null) return IDLE;
+  return { probeProps, sentinelProps, onColumnLayout };
+}


### PR DESCRIPTION
## What this is

Measurement, not a fix. It adds dev-only instrumentation to the iOS sheet detent
height so #3776's open question can be answered with real numbers instead of a
fifth formula.

**Zero behaviour change.** Nothing measured feeds back into layout, and the whole
thing is behind `__DEV__`, so release bundles are byte-identical. That means this
PR does **not** need iOS visual sign-off to merge — there is nothing visual to
sign off. The numbers it produces are what the follow-up will need sign-off for.

## Why measurement, and not another formula

`useSheetColumnStyle` guesses the detent height from `useWindowDimensions()` plus
tuned constants. That formula has been revised four times (#3352, #3371, #3433,
#3444) and once more in a PR that was rejected (#3611), and none of it closed the
~142pt dead gap on an iPhone SE 3 in #3776. #3922 says the reason is that the two
competing models of how SwiftUI resolves `.fraction(f)` disagree by 30–50pt and
neither explains the gap, and asks for device numbers before anything else lands.

I first planned to make the probe drive the column height. That plan went to
adversarial review and was rejected on empirical grounds — the reviewer ran the
repo's own `yoga-layout@3.2.1` against `@expo/ui`'s wrapper subtree and refuted
it. I reproduced every number before pivoting. The three findings that killed it,
because they also shape what this PR measures:

1. **An absolute-fill probe reads one `paddingTop` LONG.** An absolutely
   positioned child with all four insets set resolves against its containing
   block's *padding* box, not its content box (Yoga `AbsoluteLayout.cpp`;
   CSS-correct). With `setViewSize` = 548 and the wrapper's `paddingTop` = 16,
   the probe reports **548** while the in-flow column receives **532**. Driving a
   height off the raw probe would push a pinned footer past the detent — a
   clipped Apply/Save (#3330), strictly worse than the cosmetic dead gap it was
   meant to fix.
2. **The pre-`setViewSize` frame reports 16, not 0.** Before SwiftUI's size lands,
   the wrapper floors at its own padding. A `height > 0` guard accepts that, so a
   naive implementation can render a sheet as a 16pt sliver — and per
   `onGeometryChange` ordering that is the normal path on present, not an edge case.
3. **Even implemented perfectly it could not fix #3776.** On the SE 3 the formula
   gives 541 and a perfect probe-minus-padding gives 532: a **9pt move, in the
   wrong direction, against a 142pt reported gap.** Column height is not the lever.

So the honest next step is the one the issue's acceptance criteria literally ask
for: measure first.

## What it measures

Three observers on every iOS sheet with a fixed `%` detent:

| Observer | What it is | What it tells us |
| --- | --- | --- |
| **probe** | `StyleSheet.absoluteFill`, `pointerEvents="none"` | the wrapper's padding box |
| **sentinel** | in-flow, zero-height first child | `layout.y` is the wrapper's *real* `paddingTop` — `@expo/ui` makes it conditional (`handleComponent !== null ? 16 : 0`), so measure it rather than assume 16 |
| **column** | `onLayout` on the view carrying `columnStyle` | whether the computed height reaches the view at all |

The number that matters is `probeHeight − sentinelY`. One `console.log` per sheet
presentation, carrying window dims, insets, `formulaHeight`, `probeHeight`,
`columnHeight`, `sentinelY`, and that difference.

Neither observer can move the layout it measures: the probe is out of flow and
the sentinel is zero-height, so neither adds anything to the wrapper's content
size in either of `@expo/ui`'s two layout branches (confirmed on the Yoga harness
for the bounded, unbounded, and `fitToContents` cases).

## The decision tree this resolves

Capture on an **iPhone SE 3 / iOS 26** — the device behind both #3330 and #3776 —
with the climb filter sheet:

- **`availableInFlowHeight ≈ 548`** → the native size report is right and the
  formula is only ~7pt off. The column height is *not* the lever; #3776's 142pt
  gap comes from somewhere else in the tree, and the next step is finding what
  actually consumes that space. Fixable in JS, but not in this hook.
- **`availableInFlowHeight ≈ 391`** → the SwiftUI → Yoga size report is itself
  short of the real detent. This matches the ~390pt column measured on #3776, and
  it means no JS formula could ever have been right. The fix is upstream in
  `RNHostView.swift` / `@expo/ui`, and the work re-scopes to an upstream issue
  plus a local workaround.
- **`columnHeight ≠ formulaHeight`** → the computed height is not reaching the
  view at all, which would make both branches above moot and is its own bug.

## How to capture (@marcodejongh)

Needs a **dev client** against Metro — `__DEV__` must be true, so a TestFlight or
store build prints nothing.

1. `vp run dev:mobile`, launch the dev client on the SE 3
2. Climbs tab → filter button
3. Copy the `[sheet-detent #3922]` line from the Metro console into #3922

Full device matrix, the extra sheets worth a pass, and a "should be identical to
main" regression list are in `.boardsesh/qa-notes.md` on this branch.

**If a dev-client run is inconvenient**, say so and I'll add a settings-toggle
readout that surfaces the same numbers on screen in a TestFlight build. I did not
build that speculatively, since it would add production surface to a
measurement-only change.

## Tests

- New suite for probe/sentinel wiring, the one-shot log, epoch reset on a detent
  change, and callback identity stability (the probe views must never remount).
- A test asserting the reported height is `probe − sentinel`, not `probe` —
  pinning the padding-box distinction that killed the first design.
- Pins the gate invariant the reviewer flagged: the hook gates on
  `enableDynamicSizing` alone while `@expo/ui` uses a compound condition. They
  agree today only because of how `Sheet.tsx` forwards snap points, which was
  undocumented. Now a change to either side fails a test instead of a device.
- Adds `StyleSheet.absoluteFill` to the two sheet test mocks that lacked it. The
  reviewer's point that these mocks assert the formula against itself is fair and
  is part of how four revisions shipped green; this PR does not claim to fix that.
- The existing formula suite is untouched.

I did not pin Yoga's padding-box behaviour in a unit test: `yoga-layout` is an
undeclared transitive dependency here (not hoisted, not in `packages/mobile`), so
importing it from a test would add a resolution landmine to a measurement PR. The
verified numbers are recorded in the hook's doc comment instead.

`vp run typecheck:mobile`, `vp run test:mobile` (572 files / 4860 tests),
`vp check` (0 errors) and `vp run check:mobile-bundle` all pass.

## Release Notes

- [x] No release note needed (internal / technical change)

Dev-only instrumentation behind `__DEV__` — nothing reaches users, so there is
nothing for the "What's New" screen to show.

---

Related to #3922 — deliberately not closing it. The issue is resolved only once
the device numbers pick a branch.

Credit: the adversarial review that rejected my original controller design caught
all three defects above before they could reach a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJjt7hx3cv13F1s9iJPaH9
