### PR TITLE
fix(mobile): preserve offline auth sessions

### DIFF
--- a/docs/mobile-auth-flow.md
+++ b/docs/mobile-auth-flow.md
@@ -106,13 +106,20 @@ Tokens are stored in `expo-secure-store` under three keys:
 
 ### Proactive refresh
 
-`isTokenExpiringSoon()` returns `true` when the JWT is within 24 hours of expiry. `ensureFreshToken()` is called before every authenticated request and triggers a refresh if needed.
+`isTokenExpiringSoon()` returns `true` when the JWT is within 24 hours of expiry or when its stored expiry metadata is missing. `ensureFreshToken()` is called before every authenticated request and triggers a refresh if needed. Keeping the missing-expiry case refreshable lets older or partially migrated credentials repair their metadata as soon as the backend is reachable.
+
+On app startup and foreground revalidation, a successfully read JWT establishes the local session before the expiry and refresh checks run. If the expiry read, refresh request, or post-refresh keychain read is temporarily unavailable, native keeps that JWT authenticated in a degraded state. This preserves downloaded boards and other account-scoped offline data even when the JWT is already past its server expiry; it does not bypass backend authorization, so online requests still fail until refresh succeeds. The provider retries a degraded session when the app becomes active or connectivity transitions from offline to online. Reconnect checks are coalesced and stop after a clean authentication result.
 
 ### 401 retry with deduplication
 
 If a request returns `401`, `authenticatedFetch()` triggers a token refresh and retries the request once with the new JWT. Concurrent refresh attempts are deduplicated via a shared `refreshPromise` -- only one network call is made regardless of how many requests hit `401` simultaneously.
 
-If the refresh itself fails, all tokens are cleared and the user is signed out.
+Refresh outcomes are deliberately split:
+
+- A `401` or `403` rejection (or a confirmed missing refresh credential) means the session cannot be renewed. The provider transitions to anonymous and runs the normal account-isolation cleanup.
+- A transport error, timeout, rate limit, backend failure, or transient keychain read error is `unavailable`, not rejected. Existing credentials remain stored and the established local session stays rendered while native waits to retry.
+
+Every native auth resolution carries the credential generation it started with. The resolver checks that generation after each asynchronous step, and `AuthProvider` checks it again immediately before applying state, so a delayed offline/refresh result cannot revive an account after sign-out or overwrite a newer login.
 
 ## Endpoint reference
 

--- a/packages/mobile/src/lib/__tests__/auth-interceptor.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth-interceptor.test.ts
@@ -152,6 +152,24 @@ describe('ensureFreshToken', () => {
       warnSpy.mockRestore();
     }
   });
+
+  it('maps a transient refresh-token keychain read failure to unavailable with its original cause', async () => {
+    const keychainError = new Error('refresh token keychain locked');
+    mockGetRefreshToken.mockRejectedValueOnce(keychainError);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      await expect(deduplicatedRefresh()).resolves.toEqual({
+        status: 'unavailable',
+        generation: 7,
+        error: keychainError,
+      });
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith('[Auth] Token refresh error:', keychainError.message);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 });
 
 describe('recoverAuthRejection', () => {

--- a/packages/mobile/src/lib/__tests__/auth-session.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth-session.test.ts
@@ -1,19 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const authState = {
-  generation: 1,
-  current: true,
-  token: 'old-jwt' as string | null,
-  expiring: true,
-};
+const authState = { generation: 1, current: true };
 const getAuthTokenMock = vi.fn();
 const isTokenExpiringSoonMock = vi.fn();
 const deduplicatedRefreshMock = vi.fn();
+const reportHandledErrorMock = vi.hoisted(() => vi.fn());
 
 type RefreshResult =
   | { status: 'refreshed'; generation: number }
   | { status: 'rejected'; generation: number }
-  | { status: 'unavailable'; generation: number }
+  | { status: 'unavailable'; generation: number; error: unknown }
   | { status: 'superseded' };
 
 vi.mock('../auth-store', () => ({
@@ -23,8 +19,9 @@ vi.mock('../auth-store', () => ({
   isTokenExpiringSoon: () => isTokenExpiringSoonMock(),
 }));
 
-vi.mock('../auth-interceptor', () => ({
-  deduplicatedRefresh: () => deduplicatedRefreshMock(),
+vi.mock('../auth-interceptor', () => ({ deduplicatedRefresh: () => deduplicatedRefreshMock() }));
+vi.mock('../error-reporting', () => ({
+  reportHandledError: (...args: unknown[]) => reportHandledErrorMock(...args),
 }));
 
 import { resolveAuthSession } from '../auth-session';
@@ -32,36 +29,147 @@ import { resolveAuthSession } from '../auth-session';
 beforeEach(() => {
   authState.generation = 1;
   authState.current = true;
-  authState.token = 'old-jwt';
   getAuthTokenMock.mockReset();
-  getAuthTokenMock.mockImplementation(async () => authState.token);
+  getAuthTokenMock.mockResolvedValue('old-jwt');
   isTokenExpiringSoonMock.mockReset();
   isTokenExpiringSoonMock.mockResolvedValue(true);
   deduplicatedRefreshMock.mockReset();
   deduplicatedRefreshMock.mockResolvedValue({ status: 'refreshed', generation: 1 } satisfies RefreshResult);
+  reportHandledErrorMock.mockReset();
+});
+
+describe('resolveAuthSession local credential provenance', () => {
+  it('returns anonymous only when the initial token read confirms there is no JWT', async () => {
+    getAuthTokenMock.mockResolvedValue(null);
+
+    await expect(resolveAuthSession()).resolves.toEqual({ status: 'anonymous', generation: 1 });
+    expect(isTokenExpiringSoonMock).not.toHaveBeenCalled();
+    expect(deduplicatedRefreshMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps an initial token-read failure unavailable instead of inventing an authenticated session', async () => {
+    const keychainError = new Error('keychain locked');
+    getAuthTokenMock.mockRejectedValue(keychainError);
+
+    await expect(resolveAuthSession()).resolves.toEqual({
+      status: 'unavailable',
+      stage: 'token-read',
+      error: keychainError,
+      generation: 1,
+    });
+  });
+
+  it('returns a clean authenticated session when the stored JWT is not expiring', async () => {
+    isTokenExpiringSoonMock.mockResolvedValue(false);
+
+    await expect(resolveAuthSession()).resolves.toEqual({
+      status: 'authenticated',
+      token: 'old-jwt',
+      generation: 1,
+    });
+    expect(deduplicatedRefreshMock).not.toHaveBeenCalled();
+  });
+
+  it('preserves the established session when the expiry metadata read fails', async () => {
+    const expiryReadError = new Error('expiry key unavailable');
+    isTokenExpiringSoonMock.mockRejectedValue(expiryReadError);
+
+    await expect(resolveAuthSession()).resolves.toEqual({
+      status: 'authenticated',
+      token: 'old-jwt',
+      generation: 1,
+      degraded: { stage: 'expiry-read', error: expiryReadError },
+    });
+  });
 });
 
 describe('resolveAuthSession refresh status mapping', () => {
-  it('maps a server-rejected refresh at expiry to anonymous', async () => {
-    deduplicatedRefreshMock.mockResolvedValue({ status: 'rejected', generation: 1 } satisfies RefreshResult);
+  it('still attempts refresh when expiry metadata says the token is expiring or has no stored expiry', async () => {
+    isTokenExpiringSoonMock.mockResolvedValue(true);
+    getAuthTokenMock.mockResolvedValueOnce('old-jwt').mockResolvedValueOnce('fresh-jwt');
 
-    await expect(resolveAuthSession()).resolves.toEqual({ status: 'anonymous' });
+    await expect(resolveAuthSession()).resolves.toEqual({
+      status: 'authenticated',
+      token: 'fresh-jwt',
+      generation: 1,
+    });
+    expect(deduplicatedRefreshMock).toHaveBeenCalledOnce();
   });
 
-  it('maps a transient network failure at expiry to unavailable, never anonymous', async () => {
-    deduplicatedRefreshMock.mockResolvedValue({ status: 'unavailable', generation: 1 } satisfies RefreshResult);
+  it('maps an explicitly rejected refresh to anonymous', async () => {
+    deduplicatedRefreshMock.mockResolvedValue({ status: 'rejected', generation: 1 } satisfies RefreshResult);
+
+    await expect(resolveAuthSession()).resolves.toEqual({ status: 'anonymous', generation: 1 });
+  });
+
+  it('keeps the original JWT authenticated when refresh is unavailable', async () => {
+    const networkError = new Error('Network request failed');
+    deduplicatedRefreshMock.mockResolvedValue({
+      status: 'unavailable',
+      generation: 1,
+      error: networkError,
+    } satisfies RefreshResult);
+
+    await expect(resolveAuthSession()).resolves.toEqual({
+      status: 'authenticated',
+      token: 'old-jwt',
+      generation: 1,
+      degraded: { stage: 'refresh-unavailable', error: networkError },
+    });
+    expect(getAuthTokenMock).toHaveBeenCalledOnce();
+    expect(reportHandledErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('defensively preserves and reports the original cause when the refresh promise rejects', async () => {
+    const refreshError = new Error('refresh implementation rejected');
+    deduplicatedRefreshMock.mockRejectedValue(refreshError);
+
+    await expect(resolveAuthSession()).resolves.toEqual({
+      status: 'authenticated',
+      token: 'old-jwt',
+      generation: 1,
+      degraded: { stage: 'refresh-unavailable', error: refreshError },
+    });
+    expect(reportHandledErrorMock).toHaveBeenCalledWith(refreshError, {
+      tags: { source: 'auth-session', auth_stage: 'refresh-unavailable' },
+    });
+  });
+
+  it('returns the refreshed token when refresh succeeds', async () => {
+    getAuthTokenMock.mockResolvedValueOnce('old-jwt').mockResolvedValueOnce('fresh-jwt');
+
+    await expect(resolveAuthSession()).resolves.toEqual({
+      status: 'authenticated',
+      token: 'fresh-jwt',
+      generation: 1,
+    });
+  });
+
+  it('preserves the original JWT when the refreshed-token read throws', async () => {
+    const rereadError = new Error('keychain relocked');
+    getAuthTokenMock.mockResolvedValueOnce('old-jwt').mockRejectedValueOnce(rereadError);
+
+    await expect(resolveAuthSession()).resolves.toEqual({
+      status: 'authenticated',
+      token: 'old-jwt',
+      generation: 1,
+      degraded: { stage: 'refreshed-token-read', error: rereadError },
+    });
+  });
+
+  it('preserves the original JWT when a successful refresh is followed by an unexpected null read', async () => {
+    getAuthTokenMock.mockResolvedValueOnce('old-jwt').mockResolvedValueOnce(null);
 
     const result = await resolveAuthSession();
 
-    expect(result.status).toBe('unavailable');
-    expect(result.status).not.toBe('anonymous');
-  });
-
-  it('returns the refreshed token when the expiring credential refreshes', async () => {
-    deduplicatedRefreshMock.mockResolvedValue({ status: 'refreshed', generation: 1 } satisfies RefreshResult);
-    getAuthTokenMock.mockResolvedValue('fresh-jwt');
-
-    await expect(resolveAuthSession()).resolves.toEqual({ status: 'authenticated', token: 'fresh-jwt' });
+    expect(result).toMatchObject({
+      status: 'authenticated',
+      token: 'old-jwt',
+      generation: 1,
+      degraded: { stage: 'refreshed-token-read' },
+    });
+    if (result.status !== 'authenticated') throw new Error('Expected an authenticated result');
+    expect(result.degraded?.error).toBeInstanceOf(Error);
   });
 });
 
@@ -75,15 +183,14 @@ describe('resolveAuthSession generation isolation', () => {
     );
 
     const oldSessionCheck = resolveAuthSession();
-    await vi.waitFor(() => expect(deduplicatedRefreshMock).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(deduplicatedRefreshMock).toHaveBeenCalledOnce());
     authState.current = false;
-    authState.token = 'new-user-jwt';
-    releaseRefresh({ status: 'refreshed', generation: 1 });
+    releaseRefresh({ status: 'unavailable', generation: 1, error: new Error('offline') });
 
     await expect(oldSessionCheck).resolves.toEqual({ status: 'superseded' });
   });
 
-  it('returns superseded when generation changes during the expiry read', async () => {
+  it('returns superseded when generation changes during a successful expiry read', async () => {
     let releaseExpiryRead!: (expiring: boolean) => void;
     isTokenExpiringSoonMock.mockReturnValueOnce(
       new Promise<boolean>((resolve) => {
@@ -92,14 +199,63 @@ describe('resolveAuthSession generation isolation', () => {
     );
 
     const oldSessionCheck = resolveAuthSession();
-    await vi.waitFor(() => expect(isTokenExpiringSoonMock).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(isTokenExpiringSoonMock).toHaveBeenCalledOnce());
     authState.current = false;
     releaseExpiryRead(false);
 
     await expect(oldSessionCheck).resolves.toEqual({ status: 'superseded' });
   });
 
-  it('returns superseded instead of unavailable when an old token read rejects after an account switch', async () => {
+  it('returns superseded when generation changes before a failing expiry read settles', async () => {
+    let rejectExpiryRead!: (error: Error) => void;
+    isTokenExpiringSoonMock.mockReturnValueOnce(
+      new Promise<boolean>((_resolve, reject) => {
+        rejectExpiryRead = reject;
+      }),
+    );
+
+    const oldSessionCheck = resolveAuthSession();
+    await vi.waitFor(() => expect(isTokenExpiringSoonMock).toHaveBeenCalledOnce());
+    authState.current = false;
+    rejectExpiryRead(new Error('old expiry read failed'));
+
+    await expect(oldSessionCheck).resolves.toEqual({ status: 'superseded' });
+  });
+
+  it('returns superseded without telemetry when generation changes before a rejected refresh settles', async () => {
+    let rejectRefresh!: (error: Error) => void;
+    deduplicatedRefreshMock.mockReturnValueOnce(
+      new Promise<RefreshResult>((_resolve, reject) => {
+        rejectRefresh = reject;
+      }),
+    );
+
+    const oldSessionCheck = resolveAuthSession();
+    await vi.waitFor(() => expect(deduplicatedRefreshMock).toHaveBeenCalledOnce());
+    authState.current = false;
+    rejectRefresh(new Error('old refresh failed'));
+
+    await expect(oldSessionCheck).resolves.toEqual({ status: 'superseded' });
+    expect(reportHandledErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('returns superseded when generation changes before the refreshed-token read rejects', async () => {
+    let rejectRefreshedTokenRead!: (error: Error) => void;
+    getAuthTokenMock.mockResolvedValueOnce('old-jwt').mockReturnValueOnce(
+      new Promise<string>((_resolve, reject) => {
+        rejectRefreshedTokenRead = reject;
+      }),
+    );
+
+    const oldSessionCheck = resolveAuthSession();
+    await vi.waitFor(() => expect(getAuthTokenMock).toHaveBeenCalledTimes(2));
+    authState.current = false;
+    rejectRefreshedTokenRead(new Error('old keychain read failed'));
+
+    await expect(oldSessionCheck).resolves.toEqual({ status: 'superseded' });
+  });
+
+  it('returns superseded instead of unavailable when an old initial token read rejects after an account switch', async () => {
     let rejectTokenRead!: (error: Error) => void;
     getAuthTokenMock.mockReturnValueOnce(
       new Promise<string>((_resolve, reject) => {

--- a/packages/mobile/src/lib/auth-interceptor.ts
+++ b/packages/mobile/src/lib/auth-interceptor.ts
@@ -14,7 +14,7 @@ import type { AuthRejectionResult } from './auth-rejection-result';
 type AuthRefreshResult =
   | { status: 'refreshed'; generation: number }
   | { status: 'rejected'; generation: number }
-  | { status: 'unavailable'; generation: number }
+  | { status: 'unavailable'; generation: number; error: unknown }
   | { status: 'superseded' };
 
 let refresh: { generation: number; promise: Promise<AuthRefreshResult> } | null = null;
@@ -35,11 +35,15 @@ function rejectedRefreshResult(generation: number): AuthRefreshResult {
 }
 
 async function refreshTokens(credentialGeneration: number): Promise<AuthRefreshResult> {
-  const currentRefreshToken = await getRefreshToken();
-  if (!isAuthCredentialGenerationCurrent(credentialGeneration)) return { status: 'superseded' };
-  if (!currentRefreshToken) return rejectedRefreshResult(credentialGeneration);
-
   try {
+    // Keep the SecureStore read inside the guarded failure boundary. A locked or
+    // temporarily unavailable keychain is no more authoritative than a failed
+    // fetch and must resolve as unavailable rather than reject the shared refresh
+    // promise (which could otherwise make callers treat the session as absent).
+    const currentRefreshToken = await getRefreshToken();
+    if (!isAuthCredentialGenerationCurrent(credentialGeneration)) return { status: 'superseded' };
+    if (!currentRefreshToken) return rejectedRefreshResult(credentialGeneration);
+
     const response = await fetch(`${BACKEND_URL}/auth/native/refresh`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -51,18 +55,28 @@ async function refreshTokens(credentialGeneration: number): Promise<AuthRefreshR
 
     if (!response.ok) {
       console.warn(`[Auth] Token refresh failed: HTTP ${response.status}`);
+      const refreshError = new Error(`Token refresh failed: HTTP ${response.status}`);
       // A 401/403 is an expired/revoked refresh token — routine, the user just
       // signs in again. A 5xx means our refresh endpoint is broken for everyone,
       // which we do want to see.
       if (response.status >= 500) {
-        reportError(new Error(`Token refresh failed: HTTP ${response.status}`), {
+        reportError(refreshError, {
+          tags: { source: 'auth-refresh' },
+          extra: { status: response.status },
+        });
+      } else if (response.status !== 401 && response.status !== 403) {
+        // Other unavailable responses (for example 429) are handled degradation,
+        // not logout. Report their original status once here; AuthProvider must
+        // not emit a second generic "refresh unavailable" exception.
+        reportHandledError(refreshError, {
+          ...(response.status === 429 ? { level: 'warning' as const } : {}),
           tags: { source: 'auth-refresh' },
           extra: { status: response.status },
         });
       }
       return response.status === 401 || response.status === 403
         ? { status: 'rejected', generation: credentialGeneration }
-        : { status: 'unavailable', generation: credentialGeneration };
+        : { status: 'unavailable', generation: credentialGeneration, error: refreshError };
     }
 
     const data = (await response.json()) as { jwt: string; refreshToken: string; expiresAt: string };
@@ -73,7 +87,7 @@ async function refreshTokens(credentialGeneration: number): Promise<AuthRefreshR
     console.warn('[Auth] Token refresh error:', error instanceof Error ? error.message : 'unknown');
     // Offline/aborted refreshes downgrade to a warning; a real throw reports.
     reportHandledError(error, { tags: { source: 'auth-refresh' } });
-    return { status: 'unavailable', generation: credentialGeneration };
+    return { status: 'unavailable', generation: credentialGeneration, error };
   }
 }
 

--- a/packages/mobile/src/lib/auth-interceptor.ts
+++ b/packages/mobile/src/lib/auth-interceptor.ts
@@ -65,7 +65,7 @@ async function refreshTokens(credentialGeneration: number): Promise<AuthRefreshR
           extra: { status: response.status },
         });
       } else if (response.status !== 401 && response.status !== 403) {
-        // Other unavailable responses (for example 429) are handled degradation,
+        // Other unavailable responses (for example 429) are handled as degradation,
         // not logout. Report their original status once here; AuthProvider must
         // not emit a second generic "refresh unavailable" exception.
         reportHandledError(refreshError, {

--- a/packages/mobile/src/lib/auth-session.ts
+++ b/packages/mobile/src/lib/auth-session.ts
@@ -1,4 +1,5 @@
 import { deduplicatedRefresh } from './auth-interceptor';
+import { reportHandledError } from './error-reporting';
 import {
   captureAuthCredentialGeneration,
   getAuthToken,
@@ -7,54 +8,111 @@ import {
 } from './auth-store';
 import type { UserStorageOwner } from './user-storage-owner';
 
+export type AuthSessionDegradation = {
+  stage: 'expiry-read' | 'refresh-unavailable' | 'refreshed-token-read';
+  error: unknown;
+};
+
 export type AuthSessionResult =
-  | { status: 'authenticated'; token: string; userId?: string; authSessionId?: string }
-  | { status: 'anonymous' }
+  | {
+      status: 'authenticated';
+      token: string;
+      generation: number;
+      degraded?: AuthSessionDegradation;
+      userId?: string;
+      authSessionId?: string;
+    }
+  | { status: 'anonymous'; generation: number }
   | { status: 'superseded' }
   | {
       status: 'unavailable';
+      stage: 'token-read';
       error: unknown;
+      generation: number;
       confirmedIdentity?: UserStorageOwner;
       identityInvalidated?: boolean;
     };
 
+function authenticatedSession(token: string, generation: number, degraded?: AuthSessionDegradation): AuthSessionResult {
+  if (!isAuthCredentialGenerationCurrent(generation)) return { status: 'superseded' };
+  return {
+    status: 'authenticated',
+    token,
+    generation,
+    ...(degraded ? { degraded } : {}),
+  };
+}
+
 /** Resolve the native mobile JWT session, refreshing it when necessary. */
 export async function resolveAuthSession(): Promise<AuthSessionResult> {
   const credentialGeneration = captureAuthCredentialGeneration();
+  let currentToken: string | null;
+
   try {
-    const currentToken = await getAuthToken();
-    if (!isAuthCredentialGenerationCurrent(credentialGeneration)) return { status: 'superseded' };
-    if (!currentToken) return { status: 'anonymous' };
-
-    const tokenExpiringSoon = await isTokenExpiringSoon();
-    if (!isAuthCredentialGenerationCurrent(credentialGeneration)) return { status: 'superseded' };
-    if (tokenExpiringSoon) {
-      // Refresh via the status-returning path (not the boolean `ensureFreshToken`,
-      // which collapses rejected and unavailable into the same `false`). A
-      // server-rejected refresh token is a real logout; a transient network
-      // failure must NOT sign the user out.
-      const refreshResult = await deduplicatedRefresh();
-      if (!isAuthCredentialGenerationCurrent(credentialGeneration) || refreshResult.status === 'superseded') {
-        return { status: 'superseded' };
-      }
-      if (refreshResult.status === 'rejected') return { status: 'anonymous' };
-      if (refreshResult.status === 'unavailable') {
-        // Preserve the session and let the caller retry, instead of a false logout.
-        return { status: 'unavailable', error: new Error('Token refresh unavailable') };
-      }
-
-      const refreshedToken = await getAuthToken();
-      if (!isAuthCredentialGenerationCurrent(credentialGeneration)) return { status: 'superseded' };
-      if (!refreshedToken) return { status: 'anonymous' };
-      return { status: 'authenticated', token: refreshedToken };
-    }
-
-    return isAuthCredentialGenerationCurrent(credentialGeneration)
-      ? { status: 'authenticated', token: currentToken }
-      : { status: 'superseded' };
+    currentToken = await getAuthToken();
   } catch (error) {
     return isAuthCredentialGenerationCurrent(credentialGeneration)
-      ? { status: 'unavailable', error }
+      ? { status: 'unavailable', stage: 'token-read', error, generation: credentialGeneration }
       : { status: 'superseded' };
   }
+
+  if (!isAuthCredentialGenerationCurrent(credentialGeneration)) return { status: 'superseded' };
+  if (!currentToken) return { status: 'anonymous', generation: credentialGeneration };
+
+  let tokenExpiringSoon: boolean;
+  try {
+    tokenExpiringSoon = await isTokenExpiringSoon();
+  } catch (error) {
+    return authenticatedSession(currentToken, credentialGeneration, { stage: 'expiry-read', error });
+  }
+
+  if (!isAuthCredentialGenerationCurrent(credentialGeneration)) return { status: 'superseded' };
+  if (!tokenExpiringSoon) return authenticatedSession(currentToken, credentialGeneration);
+
+  let refreshResult: Awaited<ReturnType<typeof deduplicatedRefresh>>;
+  try {
+    // Refresh via the status-returning path (not the boolean `ensureFreshToken`,
+    // which collapses rejected and unavailable into the same `false`). A
+    // server-rejected refresh token is a real logout; a transient network or
+    // keychain failure preserves the already-established local session.
+    refreshResult = await deduplicatedRefresh();
+  } catch (error) {
+    if (!isAuthCredentialGenerationCurrent(credentialGeneration)) return { status: 'superseded' };
+    // The concrete interceptor catches and reports all expected refresh failures.
+    // Keep this defensive boundary for an unexpected rejected implementation or
+    // test double, and report its original cause exactly once.
+    reportHandledError(error, {
+      tags: { source: 'auth-session', auth_stage: 'refresh-unavailable' },
+    });
+    return authenticatedSession(currentToken, credentialGeneration, { stage: 'refresh-unavailable', error });
+  }
+
+  if (!isAuthCredentialGenerationCurrent(credentialGeneration) || refreshResult.status === 'superseded') {
+    return { status: 'superseded' };
+  }
+  if (refreshResult.status === 'rejected') return { status: 'anonymous', generation: credentialGeneration };
+  if (refreshResult.status === 'unavailable') {
+    // `refreshTokens` owns telemetry for this original cause. Carry it to the
+    // caller for provenance, but do not report a second generic exception there.
+    return authenticatedSession(currentToken, credentialGeneration, {
+      stage: 'refresh-unavailable',
+      error: refreshResult.error,
+    });
+  }
+
+  let refreshedToken: string | null;
+  try {
+    refreshedToken = await getAuthToken();
+  } catch (error) {
+    return authenticatedSession(currentToken, credentialGeneration, { stage: 'refreshed-token-read', error });
+  }
+
+  if (!isAuthCredentialGenerationCurrent(credentialGeneration)) return { status: 'superseded' };
+  if (!refreshedToken) {
+    return authenticatedSession(currentToken, credentialGeneration, {
+      stage: 'refreshed-token-read',
+      error: new Error('Refreshed auth token was unavailable from secure storage'),
+    });
+  }
+  return authenticatedSession(refreshedToken, credentialGeneration);
 }

--- a/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, render, screen, waitFor, act } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { onlineManager, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const redirectMock = vi.hoisted(() => vi.fn());
 const platformState = vi.hoisted(() => ({ OS: 'ios' }));
@@ -122,6 +122,8 @@ beforeEach(() => {
   consumeWebOAuthReturnProviderMock.mockReset();
   consumeWebOAuthReturnProviderMock.mockReturnValue(null);
   trackMock.mockReset();
+  reportHandledErrorMock.mockReset();
+  onlineManager.setOnline(true);
   captureAuthCredentialGenerationMock.mockReset();
   captureAuthCredentialGenerationMock.mockReturnValue(1);
   authSignInWithCredentialsMock.mockReset();
@@ -153,8 +155,10 @@ vi.mock('../../lib/auth-store', () => ({
 // checkAuth reports keychain read failures; record the calls so the
 // rejection test can assert the failure was surfaced (and is a no-op otherwise).
 const reportErrorMock = vi.fn();
+const reportHandledErrorMock = vi.fn();
 vi.mock('../../lib/error-reporting', () => ({
   reportError: (...args: unknown[]) => reportErrorMock(...args),
+  reportHandledError: (...args: unknown[]) => reportHandledErrorMock(...args),
 }));
 
 vi.mock('../../lib/analytics', () => ({
@@ -275,7 +279,7 @@ const ensureFreshTokenMock = vi.fn().mockResolvedValue(true);
 type MockRefreshResult =
   | { status: 'refreshed'; generation: number }
   | { status: 'rejected'; generation: number }
-  | { status: 'unavailable'; generation: number }
+  | { status: 'unavailable'; generation: number; error: unknown }
   | { status: 'superseded' };
 // resolveAuthSession refreshes an expiring token through the status-returning
 // deduplicatedRefresh (not the boolean ensureFreshToken), so the refresh-fail
@@ -1293,6 +1297,214 @@ describe('AuthProvider.checkAuth signed-out cleanup', () => {
   });
 });
 
+describe('AuthProvider native degraded sessions', () => {
+  const refreshUnavailableError = new Error('Network request failed');
+
+  beforeEach(() => {
+    getAuthTokenMock.mockReset();
+    getAuthTokenMock.mockResolvedValue('old-jwt');
+    isTokenExpiringSoonMock.mockReset();
+    isTokenExpiringSoonMock.mockResolvedValue(true);
+    deduplicatedRefreshMock.mockReset();
+    deduplicatedRefreshMock.mockResolvedValue({
+      status: 'unavailable',
+      generation: 1,
+      error: refreshUnavailableError,
+    });
+    clearStoredSessionIdMock.mockReset();
+    clearStoredSessionIdMock.mockResolvedValue(undefined);
+    clearStoredActiveBoardMock.mockReset();
+    clearStoredActiveBoardMock.mockResolvedValue(undefined);
+    resetHttpClientMock.mockReset();
+    disposeWsClientMock.mockReset();
+    redirectMock.mockReset();
+    reportErrorMock.mockReset();
+    reportHandledErrorMock.mockReset();
+  });
+
+  const createWrapper = (queryClient: QueryClient) =>
+    function NativeAuthWrapper({ children }: { children: ReactNode }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          <AuthProvider>{children}</AuthProvider>
+        </QueryClientProvider>
+      );
+    };
+
+  it('keeps an expiring-token cold start authenticated when refresh is offline', async () => {
+    onlineManager.setOnline(false);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper(queryClient) });
+
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+
+    expect(deduplicatedRefreshMock).toHaveBeenCalledOnce();
+    expect(getAuthTokenMock).toHaveBeenCalledOnce();
+    expect(redirectMock).not.toHaveBeenCalledWith('/auth/login');
+    expect(redirectMock).not.toHaveBeenCalledWith('/auth/session-unavailable');
+    expect(clearStoredSessionIdMock).not.toHaveBeenCalled();
+    expect(clearStoredActiveBoardMock).not.toHaveBeenCalled();
+    // The interceptor owns refresh-unavailable reporting with the original
+    // transport error; the provider must not emit duplicate generic noise.
+    expect(reportErrorMock).not.toHaveBeenCalled();
+    expect(reportHandledErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps screenshot-mode follow-up token-read failures on the native login path', async () => {
+    vi.stubEnv('EXPO_PUBLIC_SCREENSHOT_MODE', '1');
+    const keychainError = new Error('screenshot keychain relocked');
+    getAuthTokenMock.mockResolvedValueOnce(null).mockRejectedValueOnce(keychainError);
+    authSignInWithCredentialsMock.mockResolvedValue({ success: true });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>{null}</AuthProvider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(redirectMock).toHaveBeenCalledWith('/auth/login'));
+    expect(redirectMock).not.toHaveBeenCalledWith('/auth/session-unavailable');
+    expect(reportHandledErrorMock).toHaveBeenCalledWith(keychainError, {
+      tags: { source: 'auth-session', auth_stage: 'token-read' },
+    });
+    expect(reportErrorMock).not.toHaveBeenCalled();
+    expect(clearStoredSessionIdMock).not.toHaveBeenCalled();
+    expect(clearStoredActiveBoardMock).not.toHaveBeenCalled();
+  });
+
+  it('preserves the authenticated foreground tree and caches during an unavailable refresh', async () => {
+    isTokenExpiringSoonMock.mockResolvedValue(false);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(['userPlaylists'], [{ id: 'offline-playlist' }]);
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper(queryClient) });
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+
+    isTokenExpiringSoonMock.mockResolvedValue(true);
+    redirectMock.mockReset();
+    await act(async () => {
+      await result.current.refreshAuthState();
+    });
+
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(redirectMock).not.toHaveBeenCalled();
+    expect(queryClient.getQueryData(['userPlaylists'])).toEqual([{ id: 'offline-playlist' }]);
+    expect(clearStoredSessionIdMock).not.toHaveBeenCalled();
+    expect(clearStoredActiveBoardMock).not.toHaveBeenCalled();
+    expect(resetHttpClientMock).not.toHaveBeenCalled();
+    expect(disposeWsClientMock).not.toHaveBeenCalled();
+  });
+
+  it('revalidates once on reconnect only while the native session is degraded', async () => {
+    onlineManager.setOnline(false);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper(queryClient) });
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+    expect(deduplicatedRefreshMock).toHaveBeenCalledOnce();
+
+    deduplicatedRefreshMock.mockResolvedValue({ status: 'refreshed', generation: 1 });
+    await act(async () => {
+      onlineManager.setOnline(true);
+      await vi.waitFor(() => expect(deduplicatedRefreshMock).toHaveBeenCalledTimes(2));
+    });
+
+    // A clean result removes the reconnect subscription. Later network changes
+    // must not create an auth refresh storm for an ordinary authenticated session.
+    await act(async () => {
+      onlineManager.setOnline(false);
+      onlineManager.setOnline(true);
+      await Promise.resolve();
+    });
+    expect(deduplicatedRefreshMock).toHaveBeenCalledTimes(2);
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  it('coalesces connectivity flaps and unsubscribes after unmount', async () => {
+    onlineManager.setOnline(false);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result, unmount } = renderHook(() => useAuth(), { wrapper: createWrapper(queryClient) });
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+
+    let releaseReconnect!: (result: MockRefreshResult) => void;
+    deduplicatedRefreshMock.mockReturnValueOnce(
+      new Promise<MockRefreshResult>((resolve) => {
+        releaseReconnect = resolve;
+      }),
+    );
+    act(() => onlineManager.setOnline(true));
+    await vi.waitFor(() => expect(deduplicatedRefreshMock).toHaveBeenCalledTimes(2));
+
+    act(() => {
+      onlineManager.setOnline(false);
+      onlineManager.setOnline(true);
+    });
+    expect(deduplicatedRefreshMock).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      releaseReconnect({ status: 'unavailable', generation: 1, error: refreshUnavailableError });
+      await Promise.resolve();
+    });
+    unmount();
+    act(() => {
+      onlineManager.setOnline(false);
+      onlineManager.setOnline(true);
+    });
+    expect(deduplicatedRefreshMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('lets a rejected reconnect refresh run the normal signed-out cleanup', async () => {
+    onlineManager.setOnline(false);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    renderHook(() => useAuth(), { wrapper: createWrapper(queryClient) });
+    await waitFor(() => expect(deduplicatedRefreshMock).toHaveBeenCalledOnce());
+
+    deduplicatedRefreshMock.mockResolvedValue({ status: 'rejected', generation: 1 });
+    act(() => onlineManager.setOnline(true));
+
+    await waitFor(() => expect(clearStoredSessionIdMock).toHaveBeenCalledOnce());
+    expect(clearStoredActiveBoardMock).toHaveBeenCalledOnce();
+    expect(resetHttpClientMock).toHaveBeenCalledOnce();
+    expect(disposeWsClientMock).toHaveBeenCalledOnce();
+    expect(redirectMock).toHaveBeenCalledWith('/auth/login');
+  });
+
+  it('reports expiry-read degradation once through handled telemetry', async () => {
+    const expiryReadError = new Error('expiry keychain read failed');
+    isTokenExpiringSoonMock.mockRejectedValue(expiryReadError);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper(queryClient) });
+
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+    expect(reportHandledErrorMock).toHaveBeenCalledWith(expiryReadError, {
+      tags: { source: 'auth-session', auth_stage: 'expiry-read' },
+    });
+    expect(reportErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('drops a resolved native session when its generation is stale at the provider boundary', async () => {
+    isTokenExpiringSoonMock.mockResolvedValue(false);
+    isAuthCredentialGenerationCurrentMock
+      .mockReturnValueOnce(true) // after the initial JWT read
+      .mockReturnValueOnce(true) // after the expiry read
+      .mockReturnValueOnce(true) // immediately before resolveAuthSession returns
+      .mockReturnValueOnce(false) // provider application boundary
+      .mockReturnValue(true);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>{null}</AuthProvider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(redirectMock).toHaveBeenCalledWith('/auth/login'));
+    expect(clearStoredSessionIdMock).not.toHaveBeenCalled();
+    expect(clearStoredActiveBoardMock).not.toHaveBeenCalled();
+    expect(resetHttpClientMock).not.toHaveBeenCalled();
+    expect(disposeWsClientMock).not.toHaveBeenCalled();
+  });
+});
+
 describe('AuthProvider.checkAuth keychain read failure', () => {
   beforeEach(() => {
     getAuthTokenMock.mockReset();
@@ -1311,7 +1523,8 @@ describe('AuthProvider.checkAuth keychain read failure', () => {
   // failure and releases the native loading gate using the established
   // signed-out behavior.
   it('still resolves the loading gate (onReady fires) when the token read rejects', async () => {
-    getAuthTokenMock.mockRejectedValue(new Error('keychain locked'));
+    const keychainError = new Error('keychain locked');
+    getAuthTokenMock.mockRejectedValue(keychainError);
     const onReady = vi.fn();
 
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -1326,7 +1539,10 @@ describe('AuthProvider.checkAuth keychain read failure', () => {
     // The whole point: the splash gate must release even though the read threw.
     await waitFor(() => expect(onReady).toHaveBeenCalled());
     // The failure is surfaced rather than swallowed silently.
-    expect(reportErrorMock).toHaveBeenCalledTimes(1);
+    expect(reportHandledErrorMock).toHaveBeenCalledWith(keychainError, {
+      tags: { source: 'auth-session', auth_stage: 'token-read' },
+    });
+    expect(reportErrorMock).not.toHaveBeenCalled();
     expect(redirectMock).toHaveBeenCalledWith('/auth/login');
     expect(redirectMock).not.toHaveBeenCalledWith('/auth/session-unavailable');
   });

--- a/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
@@ -7,6 +7,9 @@ import { onlineManager, QueryClient, QueryClientProvider } from '@tanstack/react
 const redirectMock = vi.hoisted(() => vi.fn());
 const platformState = vi.hoisted(() => ({ OS: 'ios' }));
 const routerState = vi.hoisted(() => ({ segments: [] as string[] }));
+const appStateState = vi.hoisted(() => ({
+  listener: null as ((nextAppState: string) => void) | null,
+}));
 const authTokenEventsState = vi.hoisted(() => ({
   listener: null as
     | ((token: string | null, source: 'local' | 'remote' | 'remote-signout' | 'session' | 'hint') => void)
@@ -43,7 +46,14 @@ vi.mock('expo-router', () => ({
 vi.mock('react-native', () => ({
   Platform: platformState,
   AppState: {
-    addEventListener: vi.fn(() => ({ remove: vi.fn() })),
+    addEventListener: vi.fn((_event: string, listener: (nextAppState: string) => void) => {
+      appStateState.listener = listener;
+      return {
+        remove: vi.fn(() => {
+          if (appStateState.listener === listener) appStateState.listener = null;
+        }),
+      };
+    }),
   },
 }));
 
@@ -102,6 +112,7 @@ vi.mock('../../lib/auth-session', async (importOriginal) => {
 beforeEach(() => {
   platformState.OS = 'ios';
   routerState.segments = [];
+  appStateState.listener = null;
   redirectMock.mockReset();
   isAuthCredentialGenerationCurrentMock.mockReset();
   isAuthCredentialGenerationCurrentMock.mockReturnValue(true);
@@ -1417,6 +1428,32 @@ describe('AuthProvider native degraded sessions', () => {
     });
     expect(deduplicatedRefreshMock).toHaveBeenCalledTimes(2);
     expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  it('revalidates and upgrades a degraded native session when the app becomes active', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper(queryClient) });
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+    expect(deduplicatedRefreshMock).toHaveBeenCalledOnce();
+    expect(appStateState.listener).not.toBeNull();
+
+    deduplicatedRefreshMock.mockResolvedValue({ status: 'refreshed', generation: 1 });
+    await act(async () => {
+      appStateState.listener?.('active');
+      await vi.waitFor(() => expect(getAuthTokenMock).toHaveBeenCalledTimes(3));
+    });
+
+    expect(deduplicatedRefreshMock).toHaveBeenCalledTimes(2);
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(clearStoredSessionIdMock).not.toHaveBeenCalled();
+    expect(clearStoredActiveBoardMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      onlineManager.setOnline(false);
+      onlineManager.setOnline(true);
+      await Promise.resolve();
+    });
+    expect(deduplicatedRefreshMock).toHaveBeenCalledTimes(2);
   });
 
   it('coalesces connectivity flaps and unsubscribes after unmount', async () => {

--- a/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
@@ -1489,6 +1489,38 @@ describe('AuthProvider native degraded sessions', () => {
     expect(deduplicatedRefreshMock).toHaveBeenCalledTimes(2);
   });
 
+  it('retries after consecutive reconnect failures and stops once the session is clean', async () => {
+    onlineManager.setOnline(false);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper(queryClient) });
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+    expect(deduplicatedRefreshMock).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      onlineManager.setOnline(true);
+      await vi.waitFor(() => expect(getAuthTokenMock).toHaveBeenCalledTimes(2));
+      await Promise.resolve();
+    });
+    expect(deduplicatedRefreshMock).toHaveBeenCalledTimes(2);
+    expect(result.current.isAuthenticated).toBe(true);
+
+    deduplicatedRefreshMock.mockResolvedValue({ status: 'refreshed', generation: 1 });
+    await act(async () => {
+      onlineManager.setOnline(false);
+      onlineManager.setOnline(true);
+      await vi.waitFor(() => expect(getAuthTokenMock).toHaveBeenCalledTimes(4));
+    });
+    expect(deduplicatedRefreshMock).toHaveBeenCalledTimes(3);
+    expect(result.current.isAuthenticated).toBe(true);
+
+    await act(async () => {
+      onlineManager.setOnline(false);
+      onlineManager.setOnline(true);
+      await Promise.resolve();
+    });
+    expect(deduplicatedRefreshMock).toHaveBeenCalledTimes(3);
+  });
+
   it('lets a rejected reconnect refresh run the normal signed-out cleanup', async () => {
     onlineManager.setOnline(false);
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -585,10 +585,10 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
         if (reconnectAuthCheckRef.current === reconnectCheck) reconnectAuthCheckRef.current = null;
       });
       reconnectAuthCheckRef.current = reconnectCheck;
-      // checkAuth owns expected failure handling. Keep this defensive catch so a
-      // future regression cannot turn a connectivity event into an unhandled
-      // promise rejection.
-      reconnectCheck.catch(reportError);
+      // checkAuth owns telemetry as well as expected failure handling. Keep a
+      // no-op rejection handler only as an unhandled-rejection guard; reporting
+      // here would duplicate the original error if that ownership ever regressed.
+      reconnectCheck.catch(() => {});
     });
   }, [checkAuth, isNativeSessionDegraded]);
 

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -1,10 +1,10 @@
 import { createContext, useContext, useEffect, useMemo, useRef, useState, useCallback, type ReactNode } from 'react';
 import { AppState, Platform } from 'react-native';
 import { useSegments, Redirect } from 'expo-router';
-import { useQueryClient } from '@tanstack/react-query';
+import { onlineManager, useQueryClient } from '@tanstack/react-query';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { AppLoadingSplash } from '../components/AppLoadingSplash';
-import { resolveAuthSession } from '../lib/auth-session';
+import { resolveAuthSession, type AuthSessionResult } from '../lib/auth-session';
 import { captureAuthCredentialGeneration, isAuthCredentialGenerationCurrent } from '../lib/auth-store';
 import { subscribeAuthTokenChanges } from '../lib/auth-token-events';
 import { bumpAuthTransportRevision } from '../lib/auth-transport-revision';
@@ -22,7 +22,7 @@ import {
 } from '../lib/auth';
 import { SCREENSHOT_USER_EMAIL, SCREENSHOT_USER_PASSWORD } from '../lib/screenshot-mode';
 import { reset as resetAnalytics, track } from '../lib/analytics';
-import { reportError } from '../lib/error-reporting';
+import { reportError, reportHandledError } from '../lib/error-reporting';
 import { setOnForcedSignOut } from '../lib/auth-interceptor';
 import { getHttpClient, resetHttpClient } from '../lib/graphql/client';
 import { disposeWsClient } from '../lib/graphql/ws-client';
@@ -97,6 +97,7 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [isSessionUnavailable, setIsSessionUnavailable] = useState(false);
+  const [isNativeSessionDegraded, setIsNativeSessionDegraded] = useState(false);
   const segments = useSegments();
   const queryClient = useQueryClient();
   const authStateRef = useRef({ isAuthenticated: false, isLoading: true });
@@ -108,6 +109,13 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
   const pendingAuthTransportRestartRef = useRef(false);
   const remoteInvalidationVersionRef = useRef(0);
   const remoteRevalidationRef = useRef<Promise<void> | null>(null);
+  const nativeSessionDegradedRef = useRef(false);
+  const reconnectAuthCheckRef = useRef<Promise<void> | null>(null);
+
+  const updateNativeSessionDegraded = useCallback((degraded: boolean) => {
+    nativeSessionDegradedRef.current = degraded;
+    setIsNativeSessionDegraded(degraded);
+  }, []);
 
   const beginAuthTransition = useCallback((): number => {
     authTransitionEpochRef.current += 1;
@@ -255,6 +263,7 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
   const handleSignedOutTransition = useCallback(
     async (transitionEpoch: number, forceFullCleanup = false): Promise<boolean> => {
       if (!isAuthTransitionCurrent(transitionEpoch)) return false;
+      updateNativeSessionDegraded(false);
       const previousStorageOwner = Platform.OS === 'web' ? authenticatedStorageOwnerRef.current : undefined;
       if (Platform.OS === 'web' && !forceFullCleanup && anonymousSessionIsolatedRef.current) {
         authStateRef.current = { ...authStateRef.current, isAuthenticated: false };
@@ -297,7 +306,13 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
       }
       return completed;
     },
-    [clearPersistedUserStores, isAuthTransitionCurrent, resetAnalyticsForSignedOutTransition, runSignedOutCleanup],
+    [
+      clearPersistedUserStores,
+      isAuthTransitionCurrent,
+      resetAnalyticsForSignedOutTransition,
+      runSignedOutCleanup,
+      updateNativeSessionDegraded,
+    ],
   );
 
   const handleAuthenticatedTransition = useCallback(
@@ -349,6 +364,35 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
     [isAuthTransitionCurrent, runSignedOutCleanup],
   );
 
+  const handleResolvedAuthenticatedTransition = useCallback(
+    async (
+      transitionEpoch: number,
+      authSession: Extract<AuthSessionResult, { status: 'authenticated' }>,
+    ): Promise<boolean> => {
+      // resolveAuthSession checks its captured generation after every await, but
+      // another login or logout can still win in the microtask between resolution
+      // and this provider continuation. Recheck at the state-application boundary
+      // so an old session can never revive or annotate a newer credential owner.
+      if (Platform.OS !== 'web' && !isAuthCredentialGenerationCurrent(authSession.generation)) return false;
+
+      if (Platform.OS !== 'web') {
+        const degradation = authSession.degraded;
+        // Refresh failures are reported with their original cause by the
+        // interceptor. The remaining storage-read degradations originate in the
+        // session resolver, so report those here through the handled-error policy.
+        if (degradation && degradation.stage !== 'refresh-unavailable') {
+          reportHandledError(degradation.error, {
+            tags: { source: 'auth-session', auth_stage: degradation.stage },
+          });
+        }
+        updateNativeSessionDegraded(degradation !== undefined);
+      }
+
+      return handleAuthenticatedTransition(transitionEpoch, authSession);
+    },
+    [handleAuthenticatedTransition, updateNativeSessionDegraded],
+  );
+
   const checkAuthForTransition = useCallback(
     async (transitionEpoch: number) => {
       try {
@@ -359,18 +403,27 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
           // must not redirect or clean up that newer session.
           return;
         }
+        if (Platform.OS !== 'web' && !isAuthCredentialGenerationCurrent(authSession.generation)) {
+          // The credential owner changed after resolveAuthSession settled but
+          // before this continuation could apply its result.
+          return;
+        }
         if (authSession.status === 'unavailable') {
           // A browser network outage is not a confirmed logout: preserve an
           // already-rendered web session, or show the retry route on cold start.
           // Native keychain failures retain their established policy below.
-          reportError(authSession.error);
           if (Platform.OS !== 'web') {
             // Preserve native behavior for transient keychain failures: release
             // the current UI without running confirmed-sign-out cleanup, then
             // retry the keychain when the app becomes active again.
+            reportHandledError(authSession.error, {
+              tags: { source: 'auth-session', auth_stage: authSession.stage },
+            });
+            updateNativeSessionDegraded(false);
             setIsAuthenticated(false);
             setIsSessionUnavailable(false);
           } else {
+            reportError(authSession.error);
             const previousStorageOwner = authenticatedStorageOwnerRef.current;
             const confirmedIdentityChanged =
               authSession.identityInvalidated === true ||
@@ -398,6 +451,7 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
         }
 
         if (authSession.status === 'anonymous') {
+          updateNativeSessionDegraded(false);
           pendingAuthTransportRestartRef.current = false;
           setIsSessionUnavailable(false);
           // Screenshot build: sign in programmatically here, before the loading gate
@@ -423,11 +477,27 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
                   const screenshotSession = await resolveAuthSession();
                   if (!isAuthTransitionCurrent(transitionEpoch)) return;
                   if (screenshotSession.status === 'authenticated') {
+                    if (Platform.OS !== 'web' && !isAuthCredentialGenerationCurrent(screenshotSession.generation)) {
+                      return;
+                    }
                     console.info('[screenshot] auto sign-in succeeded; rendering straight into home');
-                    await handleAuthenticatedTransition(transitionEpoch, screenshotSession);
+                    await handleResolvedAuthenticatedTransition(transitionEpoch, screenshotSession);
                   } else if (screenshotSession.status === 'unavailable') {
-                    reportError(screenshotSession.error);
-                    setIsSessionUnavailable(true);
+                    if (Platform.OS === 'web') {
+                      reportError(screenshotSession.error);
+                      setIsSessionUnavailable(true);
+                    } else if (isAuthCredentialGenerationCurrent(screenshotSession.generation)) {
+                      // Match the ordinary native token-read policy even in the
+                      // screenshot harness: a keychain failure is not a confirmed
+                      // logout and must not run cleanup or use the web-only retry
+                      // route.
+                      reportHandledError(screenshotSession.error, {
+                        tags: { source: 'auth-session', auth_stage: screenshotSession.stage },
+                      });
+                      updateNativeSessionDegraded(false);
+                      setIsAuthenticated(false);
+                      setIsSessionUnavailable(false);
+                    }
                   }
                   return;
                 }
@@ -453,7 +523,7 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
           await handleSignedOutTransition(transitionEpoch);
           return;
         }
-        await handleAuthenticatedTransition(transitionEpoch, authSession);
+        await handleResolvedAuthenticatedTransition(transitionEpoch, authSession);
       } catch (authCheckError) {
         if (!isAuthTransitionCurrent(transitionEpoch)) return;
         // resolveAuthSession normally converts transport/storage errors into the
@@ -462,6 +532,7 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
         // persisted session.
         reportError(authCheckError);
         if (Platform.OS !== 'web') {
+          updateNativeSessionDegraded(false);
           setIsAuthenticated(false);
           setIsSessionUnavailable(false);
         } else if (!authStateRef.current.isAuthenticated) {
@@ -472,7 +543,13 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
         if (isAuthTransitionCurrent(transitionEpoch)) setIsLoading(false);
       }
     },
-    [handleAuthenticatedTransition, handleSignedOutTransition, isAuthTransitionCurrent, runSignedOutCleanup],
+    [
+      handleResolvedAuthenticatedTransition,
+      handleSignedOutTransition,
+      isAuthTransitionCurrent,
+      runSignedOutCleanup,
+      updateNativeSessionDegraded,
+    ],
   );
 
   const checkAuth = useCallback((): Promise<void> => {
@@ -494,6 +571,26 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
     });
     return () => subscription.remove();
   }, [checkAuth]);
+
+  useEffect(() => {
+    if (Platform.OS === 'web' || !isNativeSessionDegraded) return;
+
+    let wasOnline = onlineManager.isOnline();
+    return onlineManager.subscribe((isOnline) => {
+      const reconnected = !wasOnline && isOnline;
+      wasOnline = isOnline;
+      if (!reconnected || !nativeSessionDegradedRef.current || reconnectAuthCheckRef.current) return;
+
+      const reconnectCheck = checkAuth().finally(() => {
+        if (reconnectAuthCheckRef.current === reconnectCheck) reconnectAuthCheckRef.current = null;
+      });
+      reconnectAuthCheckRef.current = reconnectCheck;
+      // checkAuth owns expected failure handling. Keep this defensive catch so a
+      // future regression cannot turn a connectivity event into an unhandled
+      // promise rejection.
+      reconnectCheck.catch(reportError);
+    });
+  }, [checkAuth, isNativeSessionDegraded]);
 
   // Both native OAuth flows run their provider sheet, exchange the identity
   // token for our JWT pair, and — on success — re-run checkAuth so the provider
@@ -575,6 +672,7 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
     async (method: 'manual' | 'account_deleted' = 'manual') => {
       const credentialGeneration = captureAuthCredentialGeneration();
       const transitionEpoch = beginAuthTransition();
+      updateNativeSessionDegraded(false);
       track(SHARED_EVENTS.Logout, { method });
       await drainLocalMutationQueueBestEffort();
 
@@ -638,6 +736,7 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
       enqueueAuthTransition,
       handleSignedOutTransition,
       isAuthTransitionCurrent,
+      updateNativeSessionDegraded,
     ],
   );
 


### PR DESCRIPTION
## Summary

- Preserve the native authenticated tree and account-scoped offline data when an existing JWT can be read but expiry metadata, refresh transport, or the refreshed-token keychain read is temporarily unavailable.
- Retry degraded sessions once connectivity returns while coalescing reconnect checks, and fence every result by credential generation so stale work cannot revive a signed-out account.
- Keep explicit refresh rejection as a real sign-out and preserve the existing Expo web behavior and telemetry ownership.

Closes #4001

## Release Notes

Keep climbing from your downloaded boards when you open Boardsesh without a connection.

## Test plan

- `vp test run --project mobile packages/mobile/src/lib/__tests__/auth-session.test.ts packages/mobile/src/lib/__tests__/auth-interceptor.test.ts packages/mobile/src/providers/__tests__/auth-provider.test.tsx --reporter=agent` (92 tests)
- `vp check docs/mobile-auth-flow.md packages/mobile/src/lib/auth-session.ts packages/mobile/src/lib/auth-interceptor.ts packages/mobile/src/lib/__tests__/auth-session.test.ts packages/mobile/src/lib/__tests__/auth-interceptor.test.ts packages/mobile/src/providers/auth-provider.tsx packages/mobile/src/providers/__tests__/auth-provider.test.tsx`
- `vp run typecheck:mobile`
- `vp run test:mobile -- --reporter=agent` (572 files, 4,882 tests; completed before the final review-only regression tests were added)
- `vp run check:mobile-bundle` (iOS and Android bundles)
- Prepared `.boardsesh/qa-notes.md` and confirmed Metro surfaced it at the issue worktree QA URL before publication.
