### PR TITLE
fix(mobile): respect server statuses in network telemetry

### DIFF
--- a/packages/mobile/src/lib/__tests__/error-reporting.test.ts
+++ b/packages/mobile/src/lib/__tests__/error-reporting.test.ts
@@ -206,6 +206,15 @@ describe('reportHandledError', () => {
     });
   });
 
+  it('reports an HTTP error at error level', () => {
+    const serverError = Object.assign(new Error('Internal Server Error'), { response: { status: 500 } });
+    reportHandledError(serverError, { tags: { source: 'react-query', kind: 'mutation' } });
+    expect(mockedCaptureToSentry).toHaveBeenCalledWith(serverError, {
+      level: 'error',
+      tags: { source: 'react-query', kind: 'mutation' },
+    });
+  });
+
   it('reports an HTTP error even when its message resembles NSURL prose', () => {
     const serverError = Object.assign(new Error('The connection has timed out unexpectedly.'), {
       response: { status: 400 },

--- a/packages/mobile/src/lib/__tests__/error-reporting.test.ts
+++ b/packages/mobile/src/lib/__tests__/error-reporting.test.ts
@@ -206,8 +206,23 @@ describe('reportHandledError', () => {
     });
   });
 
-  it('reports a real server error (response with an HTTP status) at error level', () => {
-    const serverError = Object.assign(new Error('Internal Server Error'), { response: { status: 500 } });
+  it('reports an HTTP error even when its message resembles NSURL prose', () => {
+    const serverError = Object.assign(new Error('The connection has timed out unexpectedly.'), {
+      response: { status: 400 },
+    });
+    reportHandledError(serverError, { tags: { source: 'react-query', kind: 'mutation' } });
+    expect(mockedCaptureToSentry).toHaveBeenCalledWith(serverError, {
+      level: 'error',
+      tags: { source: 'react-query', kind: 'mutation' },
+    });
+  });
+
+  it('reports a nested GraphQL status even when its message resembles NSURL prose', () => {
+    const serverError = Object.assign(new Error('The connection has timed out unexpectedly.'), {
+      response: {
+        errors: [{ message: 'invalid input', extensions: { code: 400 } }],
+      },
+    });
     reportHandledError(serverError, { tags: { source: 'react-query', kind: 'mutation' } });
     expect(mockedCaptureToSentry).toHaveBeenCalledWith(serverError, {
       level: 'error',

--- a/packages/mobile/src/lib/error-reporting.ts
+++ b/packages/mobile/src/lib/error-reporting.ts
@@ -1,5 +1,5 @@
 import { isBleWriteTimeoutError } from '@boardsesh/ble-protocol/connection-error';
-import { isTransportNetworkError } from '@boardsesh/offline-sync/error-classification';
+import { getErrorStatus, isNetworkError as isSharedNetworkError } from '@boardsesh/offline-sync/error-classification';
 import { captureToSentry, type ErrorReportContext } from './sentry';
 import {
   isExpectedAuthError,
@@ -44,20 +44,19 @@ function isCancellation(error: unknown): boolean {
  *   - every other transport rejection — RN's `TypeError: Network request failed`,
  *     the WinterCG `Error: "fetch failed: <cause>"` wrapper (graphql-ws HTTP),
  *     Android `UnknownHostException`, and bare iOS NSURLError descriptions — is
- *     classified by the shared, locale-independent `isTransportNetworkError`
- *     (message markers, error codes, `.cause` recursion). Sharing that matcher
- *     with the offline drainer's dead-letter classifier keeps the two in agreement
- *     on what counts as "offline" (#3610).
+ *     classified by the shared status-aware network predicate. A resolved
+ *     HTTP/GraphQL status beats the best-effort English prose fallback, keeping
+ *     telemetry in step with the offline drainer.
  */
 function isNetworkError(error: unknown): boolean {
   if (typeof error !== 'object' || error === null) return false;
   const name = (error as { name?: unknown }).name;
   if (name === 'GraphQLEmptyResponseError') return true;
-  const response = (error as { response?: { status?: unknown } }).response;
-  // A ClientError with a `response` but no numeric `status` is a transport
-  // failure; one with a status is a real server error (4xx/5xx) we want to see.
-  if (response !== undefined && typeof (response as { status?: unknown }).status !== 'number') return true;
-  return isTransportNetworkError(error);
+  const response = (error as { response?: unknown }).response;
+  // Preserve statusless ClientError as a transport signal while allowing a
+  // status nested in response.errors[].extensions to win over message prose.
+  if (response !== undefined && getErrorStatus(error) === null) return true;
+  return isSharedNetworkError(error);
 }
 
 // Board-account credential codes the app already surfaces as UX — the integrations

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
@@ -222,11 +222,9 @@ describe('isTransportNetworkError', () => {
     expect(isTransportNetworkError(new Error('The secure connection failed.'))).toBe(true);
   });
 
-  it('still matches the English-prose fallback even when a status resolves — the union contract is unconditional (#4027)', () => {
-    // isTransportNetworkError itself carries NO status-aware precedence — that
-    // logic lives only in isNetworkError. This pins the unchanged contract that
-    // error-reporting.ts's Sentry severity tagging depends on: a resolved status
-    // must NOT suppress this predicate, only isNetworkError's retry decision.
+  it('keeps the low-level transport predicate status-blind', () => {
+    // Status precedence belongs to isNetworkError; callers may still ask for
+    // transport evidence directly without changing this predicate's contract.
     const error = Object.assign(new Error('The connection has timed out unexpectedly.'), { status: 400 });
     expect(isTransportNetworkError(error)).toBe(true);
   });
@@ -263,7 +261,7 @@ describe('isNetworkError', () => {
   });
 });
 
-describe('isNetworkError / isRetryable — resolved status beats the English-prose heuristic (#4027)', () => {
+describe('isNetworkError / isRetryable — resolved status beats the English-prose heuristic', () => {
   // A server that replies with a real HTTP/GraphQL status has, by definition,
   // received the request — that's a server verdict, not a transport failure, no
   // matter what its message happens to say. Without this, a status whose message
@@ -282,6 +280,16 @@ describe('isNetworkError / isRetryable — resolved status beats the English-pro
     const error = Object.assign(new Error('The connection has timed out unexpectedly.'), { status: 503 });
     expect(isNetworkError(error)).toBe(false);
     expect(isRetryable(error)).toBe(true);
+  });
+
+  it('nested GraphQL 400 plus NSURL prose: status wins and the mutation dead-letters', () => {
+    const error = Object.assign(new Error('The connection has timed out unexpectedly.'), {
+      response: {
+        errors: [{ message: 'invalid input', extensions: { code: 400 } }],
+      },
+    });
+    expect(isNetworkError(error)).toBe(false);
+    expect(isRetryable(error)).toBe(false);
   });
 
   it('no status + an NSURL-prose-matching message: unchanged, still a network error and retryable', () => {

--- a/packages/shared/offline-sync/src/mutation-queue/error-classification.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/error-classification.ts
@@ -138,23 +138,15 @@ function isEnglishProseTransportSignal(error: unknown, depth = 0): boolean {
 }
 
 /**
- * Pure, locale-independent predicate: is this a transport/reachability failure
- * (offline, DNS, reset, TLS, timeout) that never reached the server? Matches on
- * error name/code and stable message markers rather than localized prose, and
- * recurses into `.cause` because WinterCG/undici wrap the underlying error there.
+ * Raw transport/reachability predicate covering both stable identifiers and the
+ * best-effort English NSURL prose fallback. It recurses into `.cause` because
+ * WinterCG/undici wrap the underlying error there.
  *
- * Shared by the offline drainer's dead-letter classifier (`isNetworkError` below)
- * and mobile's `reportHandledError` noise policy (imported via the
- * `@boardsesh/offline-sync/error-classification` subpath) so both agree on what
- * "offline" means. Deliberately excludes AbortError — its cancel-vs-retry meaning
- * differs per call site, so each site handles it.
- *
- * NOTE: this is the union of BOTH halves above with no precedence between them —
- * exactly the pre-#4027 behavior, preserved here unchanged because mobile's
- * `reportHandledError` severity tagging (error-reporting.ts) consumes this
- * function directly and doesn't need (or want) status-aware precedence for a
- * "warning vs error" Sentry tag. `isNetworkError` below is where the two halves
- * get different treatment.
+ * This preserves the raw union for callers that already know no server response
+ * exists. Status-sensitive callers must use `isNetworkError` below so a resolved
+ * HTTP/GraphQL status can take precedence over English prose without weakening
+ * stable transport signals. It deliberately excludes AbortError, whose
+ * cancel-vs-retry meaning differs by call site.
  */
 export function isTransportNetworkError(error: unknown, depth = 0): boolean {
   return isLocaleIndependentTransportSignal(error, depth) || isEnglishProseTransportSignal(error, depth);


### PR DESCRIPTION
## Summary

- complete the mobile half of the status-precedence fix merged in #4067
- classify resolved HTTP and GraphQL statuses as server errors even when their message resembles connection prose
- preserve warning-level handling for empty and statusless GraphQL client responses

Completes the remaining work for #4027.

## Validation

- `vp test run packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts packages/mobile/src/lib/__tests__/error-reporting.test.ts --reporter=agent` (76 tests)
- `vp run typecheck:mobile`
- `vp check --fix` on the changed files

## Release Notes

- [x] No release note needed (internal / technical change)