### PR TITLE
fix(web): authenticate private board slug lookups

### DIFF
--- a/packages/backend/src/__tests__/anon-entity-masking.test.ts
+++ b/packages/backend/src/__tests__/anon-entity-masking.test.ts
@@ -20,8 +20,9 @@ import { SYSTEM_BOARD_OWNER_ID } from '../graphql/resolvers/board-presence/share
  *    requireAnonReadableBoard and the board-presence family — a signed-in
  *    climber still resolves a gym's private board by uuid (BLE connect flow,
  *    boardsBySerialNumbers).
- *  - boardBySlug is NOT masked at all (the anonymous, shared-cached /b/{slug}
- *    web surface has no token path); pinned so the exclusion stays deliberate.
+ *  - boardBySlug uses the same anonymous-only mask. The server-rendered web
+ *    lookup forwards a signed-in user's token and keeps that response out of
+ *    the shared cache, so private direct links still work without leaking.
  *
  * Masking is expressed as `null` rather than a thrown NOT_FOUND because these
  * SDL fields are nullable — `null` already means "no such entity", so it is the
@@ -270,16 +271,38 @@ describe('board(boardUuid) anonymous masking', () => {
 });
 
 // ============================================================================
-// boardBySlug — deliberately NOT masked
+// boardBySlug — same anonymous-only mask as board(boardUuid)
 // ============================================================================
 
-describe('boardBySlug is deliberately not anon-masked', () => {
-  it('still enriches a PRIVATE board for an anonymous caller', async () => {
-    // Accepted residual exposure (#3648): /b/{slug} resolves through an
-    // anonymous, cross-user cached fetch with no token path, so masking here
-    // would 404 a private board's own owner on their own pages.
-    const board = await socialBoardQueries.boardBySlug(null, { slug: privateBoard.slug }, anonCtx());
+describe('boardBySlug anonymous masking', () => {
+  it('masks a PRIVATE board identically to a board that does not exist', async () => {
+    const missing = await socialBoardQueries.boardBySlug(null, { slug: uuidv4() }, anonCtx());
+    const privateResult = await socialBoardQueries.boardBySlug(null, { slug: privateBoard.slug }, anonCtx());
+
+    expect(privateResult).toEqual(missing);
+    expect(privateResult).toBeNull();
+  });
+
+  it.each([
+    ['PUBLIC', () => publicBoard, 'Public Wall'],
+    ['UNLISTED but public', () => unlistedBoard, 'Unlisted Wall'],
+    ['non-public SYSTEM-owned', () => systemPrivateBoard, 'Shared MoonBoard Config'],
+  ] as const)('keeps a %s board readable anonymously', async (_label, getBoard, expectedName) => {
+    const board = getBoard();
+    const result = await socialBoardQueries.boardBySlug(null, { slug: board.slug }, anonCtx());
+    expect(result?.name).toBe(expectedName);
+  });
+
+  it('returns a PRIVATE board to its owner', async () => {
+    const board = await socialBoardQueries.boardBySlug(null, { slug: privateBoard.slug }, authCtx(OWNER));
     expect(board?.name).toBe('Private Wall');
+    expect(board?.canEdit).toBe(true);
+  });
+
+  it('returns a PRIVATE board to an authenticated non-owner', async () => {
+    const board = await socialBoardQueries.boardBySlug(null, { slug: privateBoard.slug }, authCtx(STRANGER));
+    expect(board?.name).toBe('Private Wall');
+    expect(board?.boardId).toBeNull();
   });
 });
 

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -802,14 +802,9 @@ export const socialBoardQueries = {
   /**
    * Get a board by slug (for URL routing).
    *
-   * INTENTIONALLY NOT anon-masked, unlike `board(boardUuid)` above. This read
-   * backs the entire `/b/{slug}/**` web surface through
-   * `packages/web/app/lib/board-slug-utils.ts`, whose fetch is anonymous by
-   * construction — no token path at all, and a cross-user `revalidate: 300`
-   * shared cache that could never hold a per-viewer result. Masking here would
-   * 404 every private board's own OWNER on their own board pages. Accepted
-   * residual exposure (a private board's name is disclosable to a slug holder)
-   * until the end-of-life web climbing surface goes away. See #3648.
+   * This follows the same anonymous-only mask as `board(boardUuid)`: direct
+   * private-board links keep working for signed-in climbers, while anonymous
+   * requests cannot disclose a private board through the shared web cache.
    */
   boardBySlug: async (_: unknown, { slug }: { slug: string }, ctx: ConnectionContext) => {
     // Validate slug format: lowercase alphanumeric with hyphens, max 120 chars
@@ -824,7 +819,9 @@ export const socialBoardQueries = {
       .limit(1);
 
     if (!board) return null;
-    return enrichBoard(board, ctx.isAuthenticated ? ctx.userId : undefined);
+    const viewerId = ctx.isAuthenticated ? ctx.userId : undefined;
+    if (!viewerId && !isRowAnonReadable(board)) return null;
+    return enrichBoard(board, viewerId);
   },
 
   /**

--- a/packages/web/app/lib/__tests__/board-slug-utils.test.ts
+++ b/packages/web/app/lib/__tests__/board-slug-utils.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+const { fetchMock, getServerAuthTokenMock } = vi.hoisted(() => ({
+  fetchMock: vi.fn<typeof fetch>(),
+  getServerAuthTokenMock: vi.fn<() => Promise<string | undefined>>(),
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('react', () => ({
+  // React cache is request-scoped in Server Components. Keep the unit under
+  // test directly callable so separate invocations can model separate requests.
+  cache: <CachedFunction extends (...args: never[]) => unknown>(fn: CachedFunction): CachedFunction => fn,
+}));
+
+vi.mock('@/app/lib/auth/server-auth', () => ({
+  getServerAuthToken: getServerAuthTokenMock,
+}));
+
+vi.mock('@/app/lib/graphql/client', () => ({
+  getGraphQLHttpUrl: () => 'http://backend.test/graphql',
+}));
+
+vi.stubGlobal('fetch', fetchMock);
+
+import { resolveBoardBySlug, type ResolvedBoard } from '../board-slug-utils';
+
+const publicBoard: ResolvedBoard = {
+  uuid: '11111111-1111-4111-8111-111111111111',
+  slug: 'community-wall',
+  boardType: 'kilter',
+  layoutId: 1,
+  sizeId: 10,
+  setIds: '1,20',
+  name: 'Community Wall',
+  description: null,
+  locationName: null,
+  isPublic: true,
+  isOwned: true,
+  ownerId: 'owner-1',
+  angle: 40,
+  isAngleAdjustable: true,
+};
+
+const privateBoard: ResolvedBoard = {
+  ...publicBoard,
+  uuid: '22222222-2222-4222-8222-222222222222',
+  slug: 'home-project-wall',
+  name: 'Home Project Wall',
+  isPublic: false,
+};
+
+function graphQlResponse(board: ResolvedBoard | null): Response {
+  return new Response(JSON.stringify({ data: { boardBySlug: board } }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('resolveBoardBySlug', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    getServerAuthTokenMock.mockReset();
+    getServerAuthTokenMock.mockResolvedValue(undefined);
+  });
+
+  it('shares public anonymous lookups without sending an authorization header', async () => {
+    fetchMock.mockResolvedValueOnce(graphQlResponse(publicBoard));
+
+    await expect(resolveBoardBySlug(publicBoard.slug)).resolves.toEqual(publicBoard);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, requestInit] = fetchMock.mock.calls[0];
+    expect(new Headers(requestInit?.headers).get('Authorization')).toBeNull();
+    expect(requestInit).toMatchObject({
+      method: 'POST',
+      next: { revalidate: 300 },
+    });
+    expect(requestInit).not.toHaveProperty('cache');
+  });
+
+  it('keeps an anonymously masked private lookup as not found', async () => {
+    fetchMock.mockResolvedValueOnce(graphQlResponse(null));
+
+    await expect(resolveBoardBySlug(privateBoard.slug)).resolves.toBeNull();
+
+    const [, requestInit] = fetchMock.mock.calls[0];
+    expect(new Headers(requestInit?.headers).get('Authorization')).toBeNull();
+    expect(requestInit).toMatchObject({ next: { revalidate: 300 } });
+  });
+
+  it('forwards the session token for private boards and disables shared caching', async () => {
+    getServerAuthTokenMock.mockResolvedValueOnce('signed-session-token');
+    fetchMock.mockResolvedValueOnce(graphQlResponse(privateBoard));
+
+    await expect(resolveBoardBySlug(privateBoard.slug)).resolves.toEqual(privateBoard);
+
+    const [, requestInit] = fetchMock.mock.calls[0];
+    expect(new Headers(requestInit?.headers).get('Authorization')).toBe('Bearer signed-session-token');
+    expect(requestInit).toMatchObject({ cache: 'no-store' });
+    expect(requestInit).not.toHaveProperty('next');
+  });
+
+  it('does not let a private authenticated result cross into a later anonymous request', async () => {
+    getServerAuthTokenMock.mockResolvedValueOnce('signed-session-token').mockResolvedValueOnce(undefined);
+    fetchMock.mockResolvedValueOnce(graphQlResponse(privateBoard)).mockResolvedValueOnce(graphQlResponse(null));
+
+    await expect(resolveBoardBySlug(privateBoard.slug)).resolves.toEqual(privateBoard);
+    await expect(resolveBoardBySlug(privateBoard.slug)).resolves.toBeNull();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [, authenticatedRequest] = fetchMock.mock.calls[0];
+    const [, anonymousRequest] = fetchMock.mock.calls[1];
+    expect(authenticatedRequest).toMatchObject({ cache: 'no-store' });
+    expect(anonymousRequest).toMatchObject({ next: { revalidate: 300 } });
+    expect(new Headers(anonymousRequest?.headers).get('Authorization')).toBeNull();
+  });
+
+  it('does not let an anonymous miss cross into a later authenticated request', async () => {
+    getServerAuthTokenMock.mockResolvedValueOnce(undefined).mockResolvedValueOnce('signed-session-token');
+    fetchMock.mockResolvedValueOnce(graphQlResponse(null)).mockResolvedValueOnce(graphQlResponse(privateBoard));
+
+    await expect(resolveBoardBySlug(privateBoard.slug)).resolves.toBeNull();
+    await expect(resolveBoardBySlug(privateBoard.slug)).resolves.toEqual(privateBoard);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [, anonymousRequest] = fetchMock.mock.calls[0];
+    const [, authenticatedRequest] = fetchMock.mock.calls[1];
+    expect(anonymousRequest).toMatchObject({ next: { revalidate: 300 } });
+    expect(new Headers(anonymousRequest?.headers).get('Authorization')).toBeNull();
+    expect(authenticatedRequest).toMatchObject({ cache: 'no-store' });
+    expect(authenticatedRequest).not.toHaveProperty('next');
+    expect(new Headers(authenticatedRequest?.headers).get('Authorization')).toBe('Bearer signed-session-token');
+  });
+});

--- a/packages/web/app/lib/board-slug-utils.ts
+++ b/packages/web/app/lib/board-slug-utils.ts
@@ -1,5 +1,7 @@
+import 'server-only';
 import { cache } from 'react';
 import type { ParsedBoardRouteParameters, BoardName } from '@/app/lib/types';
+import { getServerAuthToken } from '@/app/lib/auth/server-auth';
 import { getGraphQLHttpUrl } from '@/app/lib/graphql/client';
 
 export type ResolvedBoard = {
@@ -47,11 +49,21 @@ export const resolveBoardBySlug = cache(async (slug: string): Promise<ResolvedBo
   `;
 
   try {
+    const authToken = await getServerAuthToken();
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (authToken) {
+      headers.Authorization = `Bearer ${authToken}`;
+    }
+
+    // Authenticated responses can contain private boards, so they must never
+    // enter the shared data cache. Anonymous responses remain safely reusable.
+    const cacheOptions = authToken ? { cache: 'no-store' as const } : { next: { revalidate: 300 } };
+
     const response = await fetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers,
       body: JSON.stringify({ query, variables: { slug } }),
-      next: { revalidate: 300 }, // Cache for 5 minutes
+      ...cacheOptions,
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary

- forward the signed-in server token when resolving board slugs
- keep authenticated private-board responses out of shared caches while retaining short anonymous public-board revalidation
- mask private boards from anonymous slug lookups without breaking signed-in owner or non-owner links
- cover both authenticated/anonymous request orders and the complete board visibility matrix

Follow-up to #3648 and #4086.

## Validation

- independent security re-review approved `c3805bc8243e0577465773bdc4eea9dde5b5151d`
- web regression tests: 5 passed
- backend board resolver tests: 24 passed
- backend typecheck passed
- scoped `vp check` and `git diff --check` passed

## Release Notes

Private board links now keep working when you are signed in without exposing the board to signed-out visitors.
