### PR TITLE
fix(mobile): show ascent status in play drawer

### DIFF
--- a/packages/mobile/src/components/AscentStatusGlyph.tsx
+++ b/packages/mobile/src/components/AscentStatusGlyph.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { View, type StyleProp, type ViewStyle } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { AscentStatusValue } from '../lib/ascent-status-utils';
@@ -32,14 +32,14 @@ export const AscentStatusMark = React.memo(function AscentStatusMark({ status, s
   const { t } = useTranslation('climbs');
   const theme = useTheme();
 
-  const ascentStatusLabel = useMemo(() => {
-    if (!status) return undefined;
-    return {
-      flash: t('mobile.climbRow.ascentStatus.flash'),
-      send: t('mobile.climbRow.ascentStatus.send'),
-      attempt: t('mobile.climbRow.ascentStatus.attempt'),
-    }[status];
-  }, [status, t]);
+  const ascentStatusLabel =
+    status === 'flash'
+      ? t('mobile.climbRow.ascentStatus.flash')
+      : status === 'send'
+        ? t('mobile.climbRow.ascentStatus.send')
+        : status === 'attempt'
+          ? t('mobile.climbRow.ascentStatus.attempt')
+          : undefined;
 
   if (!status) return null;
   return (

--- a/packages/mobile/src/components/AscentStatusGlyph.tsx
+++ b/packages/mobile/src/components/AscentStatusGlyph.tsx
@@ -1,0 +1,64 @@
+import React, { useMemo } from 'react';
+import { View, type StyleProp, type ViewStyle } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import type { AscentStatusValue } from '../lib/ascent-status-utils';
+import { useAscentStatus } from '../hooks/use-ascent-status';
+import { useTheme } from '../providers/theme-provider';
+import { Icon } from './Icon';
+import type { IconName } from './icon-map';
+
+// Status is carried by glyph shape in a single neutral grey — not colour — so it
+// cannot be confused with the colour-coded grade beside it and remains readable
+// for colour-blind climbers. ⚡ flashed, ✓ sent, ✗ attempted.
+const ASCENT_STATUS_ICON: Record<AscentStatusValue, IconName> = {
+  flash: 'flash',
+  send: 'tick.outline',
+  attempt: 'ascent.attempt',
+};
+
+type AscentStatusGlyphProps = {
+  climbUuid: string;
+  angle: number;
+  style?: StyleProp<ViewStyle>;
+};
+
+type AscentStatusMarkProps = {
+  status: AscentStatusValue | null;
+  style?: StyleProp<ViewStyle>;
+};
+
+/** Pure visual/semantic marker for callers that already own a status index. */
+export const AscentStatusMark = React.memo(function AscentStatusMark({ status, style }: AscentStatusMarkProps) {
+  const { t } = useTranslation('climbs');
+  const theme = useTheme();
+
+  const ascentStatusLabel = useMemo(() => {
+    if (!status) return undefined;
+    return {
+      flash: t('mobile.climbRow.ascentStatus.flash'),
+      send: t('mobile.climbRow.ascentStatus.send'),
+      attempt: t('mobile.climbRow.ascentStatus.attempt'),
+    }[status];
+  }, [status, t]);
+
+  if (!status) return null;
+  return (
+    <View style={style} accessibilityRole="image" accessibilityLabel={ascentStatusLabel}>
+      <Icon name={ASCENT_STATUS_ICON[status]} size={16} color={theme.systemColors.secondaryLabel} />
+    </View>
+  );
+});
+
+/**
+ * The compact, accessible prior-ascent marker shared by climb rows and the play
+ * drawer. It alone subscribes to the pre-indexed logbook, leaving its parent
+ * free of logbook updates and avoiding an O(logbook) scan during rendering.
+ */
+export const AscentStatusGlyph = React.memo(function AscentStatusGlyph({
+  climbUuid,
+  angle,
+  style,
+}: AscentStatusGlyphProps) {
+  const ascentStatus = useAscentStatus(climbUuid, angle);
+  return <AscentStatusMark status={ascentStatus} style={style} />;
+});

--- a/packages/mobile/src/components/ClimbListItemContent.tsx
+++ b/packages/mobile/src/components/ClimbListItemContent.tsx
@@ -6,24 +6,12 @@ import { Text } from './Text';
 import { ClimbListThumbnail, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT } from './ClimbListThumbnail';
 import { formatSends, formatQuality } from '../lib/format-climb-stats';
 import { useDisplayGrade } from '../hooks/use-display-grade';
-import { useAscentStatus } from '../hooks/use-ascent-status';
 import { useTheme } from '../providers/theme-provider';
-import { Icon } from './Icon';
 import { ClimbAttributeIcons } from './ClimbAttributeIcons';
 import { ClimbPlaylistChips } from './ClimbPlaylistChips';
 import { isClimbResolved } from '../lib/queue-climb-resolution';
-import type { IconName } from './icon-map';
-import type { AscentStatusValue } from '../lib/ascent-status-utils';
-
-// Scan-line status marker. Status is carried by glyph SHAPE in a single neutral
-// grey — not a colour — so it can't be mistaken for the colour-coded grade right
-// beside it, and so it stays readable for colour-blind users. ⚡ flashed,
-// ✓ sent, ✗ attempted.
-const ASCENT_STATUS_ICON: Record<AscentStatusValue, IconName> = {
-  flash: 'flash',
-  send: 'tick.outline',
-  attempt: 'ascent.attempt',
-};
+import { AscentStatusGlyph } from './AscentStatusGlyph';
+import { Icon } from './Icon';
 
 /**
  * Minimal structural climb shape this visual needs. Kept permissive so BOTH the
@@ -109,44 +97,6 @@ type ClimbListItemContentProps = {
    */
   showPlaylistChips?: boolean;
 };
-
-/**
- * Isolated, memoized ascent-status glyph. It is the ONLY part of the climb row
- * that subscribes to the logbook (via `useAscentStatus` → `BoardProvider`), so a
- * tick write / logbook merge re-renders just this 16px icon — not the whole row
- * (thumbnail, name, grade). Props are primitives, so `React.memo` skips it on
- * unrelated parent re-renders. Restores the memo boundary the climbs-search
- * redesign removed when it inlined `useAscentStatus` into `ClimbListItemContent`.
- */
-const AscentStatusGlyph = React.memo(function AscentStatusGlyph({
-  climbUuid,
-  angle,
-}: {
-  climbUuid: string;
-  angle: number;
-}) {
-  const { t } = useTranslation('climbs');
-  const theme = useTheme();
-  const ascentStatus = useAscentStatus(climbUuid, angle);
-
-  // Spoken by VoiceOver/TalkBack — the only non-visual signal now colour is gone.
-  // Literal keys (not a dynamic `t(...)`) so the i18n orphan checker sees them.
-  const ascentStatusLabel = useMemo(() => {
-    if (!ascentStatus) return undefined;
-    return {
-      flash: t('mobile.climbRow.ascentStatus.flash'),
-      send: t('mobile.climbRow.ascentStatus.send'),
-      attempt: t('mobile.climbRow.ascentStatus.attempt'),
-    }[ascentStatus];
-  }, [ascentStatus, t]);
-
-  if (!ascentStatus) return null;
-  return (
-    <View accessibilityRole="image" accessibilityLabel={ascentStatusLabel}>
-      <Icon name={ASCENT_STATUS_ICON[ascentStatus]} size={16} color={theme.systemColors.secondaryLabel} />
-    </View>
-  );
-});
 
 /**
  * The shared visual of a climb list item: portrait thumbnail (with ascent

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -34,9 +34,8 @@ import { DeferredBoard } from './DeferredBoard';
 import { BoardRenderUnavailable } from './BoardRenderUnavailable';
 import { PlaybackControls } from './PlaybackControls';
 import { useMobilePlayback } from './use-mobile-playback';
-import { PlayDrawerHeader } from './PlayDrawerHeader';
 import { copyClimbName } from './copy-climb-name';
-import { SwipeableHeader } from './SwipeableHeader';
+import { PlayDrawerSwipeableHeader } from './PlayDrawerSwipeableHeader';
 import { PlayDrawerPreviewBanner } from './PlayDrawerPreviewBanner';
 import { PlayDrawerOnWallBanner } from './PlayDrawerOnWallBanner';
 import { PlayDrawerActionBar } from './PlayDrawerActionBar';
@@ -70,7 +69,7 @@ import { hapticSuccess } from '../../lib/haptics';
 import { usePlayDrawerWakeLock } from './use-play-drawer-wake-lock';
 import { resolveFavoriteRollback } from './favorite-rollback';
 import { buildPlayDrawerBoardLayout } from './lightbulb-control';
-import { getViewOnlyPreviewNavigationTarget } from './play-drawer-navigation';
+import { getViewOnlyPreviewNavigationTarget, swipeDirectionForOffset } from './play-drawer-navigation';
 import { useLightbulbControl } from '../ble/use-lightbulb-control';
 import { track } from '../../lib/analytics';
 import { iosSystemColors } from '../../theme/ios-colors';
@@ -295,9 +294,9 @@ export function PlayDrawer({
 
   const [swipeDirection, setSwipeDirection] = useState<'next' | 'prev'>('next');
   useAnimatedReaction(
-    () => (swipeTranslateX.value < 0 ? 'next' : 'prev'),
+    () => swipeDirectionForOffset(swipeTranslateX.value),
     (direction, previous) => {
-      if (direction !== previous) runOnJS(setSwipeDirection)(direction);
+      if (direction !== null && direction !== previous) runOnJS(setSwipeDirection)(direction);
     },
   );
   // Freeze the header peek's climb for the fling+commit window, mirroring the
@@ -888,42 +887,20 @@ export function PlayDrawer({
 
                   {/* Title + grade swipe with the board: same translateX, same
                       tilt/fling; the next climb's header slides in edge-adjacent. */}
-                  <SwipeableHeader
+                  <PlayDrawerSwipeableHeader
+                    boardName={boardName as BoardName}
+                    angle={angle}
                     swipeTranslateX={swipeTranslateX}
                     viewportWidth={windowWidth}
-                    current={
-                      <PlayDrawerHeader
-                        name={displayedClimb.name}
-                        difficulty={displayedGrade?.label ?? displayedClimb.difficulty}
-                        rawDifficulty={displayedClimb.difficulty}
-                        gradeColor={displayedGrade?.color}
-                        qualityAverage={displayedClimb.quality_average}
-                        ascensionistCount={displayedClimb.ascensionist_count}
-                        setterUsername={displayedClimb.setter_username}
-                        benchmarkDifficulty={displayedClimb.benchmark_difficulty}
-                        characteristics={displayedClimb.characteristics}
-                        // The accessory-bar wall climb is physically lit right now, so its
-                        // read-only "on the wall" status rides in the header's leading slot
-                        // (left of the name, opposite the grade) rather than as a banner.
-                        leading={isPreview && drawerPreviewIsWallClimb ? <PlayDrawerOnWallBanner /> : undefined}
-                        onLongPressName={handleCopyName}
-                      />
-                    }
-                    peek={
-                      headerPeekClimb ? (
-                        <PlayDrawerHeader
-                          name={headerPeekClimb.name}
-                          difficulty={peekGrade?.label ?? headerPeekClimb.difficulty}
-                          rawDifficulty={headerPeekClimb.difficulty}
-                          gradeColor={peekGrade?.color}
-                          qualityAverage={headerPeekClimb.quality_average}
-                          ascensionistCount={headerPeekClimb.ascensionist_count}
-                          setterUsername={headerPeekClimb.setter_username}
-                          benchmarkDifficulty={headerPeekClimb.benchmark_difficulty}
-                          characteristics={headerPeekClimb.characteristics}
-                        />
-                      ) : null
-                    }
+                    currentClimb={displayedClimb}
+                    currentGrade={displayedGrade}
+                    // The accessory-bar wall climb is physically lit right now, so its
+                    // read-only "on the wall" status rides in the header's leading slot
+                    // (left of the name, opposite the grade) rather than as a banner.
+                    currentLeading={isPreview && drawerPreviewIsWallClimb ? <PlayDrawerOnWallBanner /> : undefined}
+                    onLongPressCurrentName={handleCopyName}
+                    peekClimb={headerPeekClimb}
+                    peekGrade={peekGrade}
                   />
 
                   {isPreview && !drawerPreviewIsWallClimb ? (

--- a/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
@@ -7,9 +7,17 @@ import { Text } from '../Text';
 import { MarqueeText } from '../MarqueeText';
 import { DrawerHeader } from '../DrawerHeader';
 import { ClimbAttributeIcons } from '../ClimbAttributeIcons';
+import { AscentStatusGlyph, AscentStatusMark } from '../AscentStatusGlyph';
+import type { AscentStatusValue } from '../../lib/ascent-status-utils';
 import { iosSystemColors } from '../../theme/ios-colors';
+import { spacing } from '../../theme/tokens';
 
 type PlayDrawerHeaderProps = {
+  /** The climb and angle used for the compact prior-ascent marker beside its name. */
+  climbUuid: string;
+  angle: number;
+  /** Set by foreign-board drawers that own a small board-specific status index. */
+  ascentStatus?: AscentStatusValue | null;
   name: string;
   /** Display label (already formatted to V or Font per user preference). */
   difficulty: string;
@@ -37,6 +45,9 @@ type PlayDrawerHeaderProps = {
 };
 
 export const PlayDrawerHeader = memo(function PlayDrawerHeader({
+  climbUuid,
+  angle,
+  ascentStatus,
   name,
   difficulty,
   rawDifficulty,
@@ -84,6 +95,11 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
               </MarqueeText>
             </Pressable>
             <ClimbAttributeIcons benchmarkDifficulty={benchmarkDifficulty} characteristics={characteristics} />
+            {ascentStatus === undefined ? (
+              <AscentStatusGlyph climbUuid={climbUuid} angle={angle} style={styles.ascentStatus} />
+            ) : (
+              <AscentStatusMark status={ascentStatus} style={styles.ascentStatus} />
+            )}
           </View>
           <Text variant="caption1" style={styles.subtitleText} numberOfLines={1}>
             {subtitleParts.join(' · ')}
@@ -131,5 +147,8 @@ const styles = StyleSheet.create({
     color: iosSystemColors.systemGray,
     marginTop: 2,
     textAlign: 'center',
+  },
+  ascentStatus: {
+    marginLeft: spacing[1],
   },
 });

--- a/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
@@ -12,12 +12,7 @@ import type { AscentStatusValue } from '../../lib/ascent-status-utils';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing } from '../../theme/tokens';
 
-type PlayDrawerHeaderProps = {
-  /** The climb and angle used for the compact prior-ascent marker beside its name. */
-  climbUuid: string;
-  angle: number;
-  /** Set by foreign-board drawers that own a small board-specific status index. */
-  ascentStatus?: AscentStatusValue | null;
+type PlayDrawerHeaderBaseProps = {
   name: string;
   /** Display label (already formatted to V or Font per user preference). */
   difficulty: string;
@@ -44,22 +39,36 @@ type PlayDrawerHeaderProps = {
   onLongPressName?: () => void;
 };
 
-export const PlayDrawerHeader = memo(function PlayDrawerHeader({
-  climbUuid,
-  angle,
-  ascentStatus,
-  name,
-  difficulty,
-  rawDifficulty,
-  gradeColor,
-  qualityAverage,
-  ascensionistCount,
-  setterUsername,
-  benchmarkDifficulty,
-  characteristics,
-  leading,
-  onLongPressName,
-}: PlayDrawerHeaderProps) {
+type PlayDrawerHeaderProps = PlayDrawerHeaderBaseProps &
+  (
+    | {
+        /** The climb and angle used by the root-board live status lookup. */
+        climbUuid: string;
+        angle: number;
+        ascentStatus?: undefined;
+      }
+    | {
+        /** A status resolved by a foreign-board drawer's board-specific index. */
+        ascentStatus: AscentStatusValue | null;
+        climbUuid?: never;
+        angle?: never;
+      }
+  );
+
+export const PlayDrawerHeader = memo(function PlayDrawerHeader(props: PlayDrawerHeaderProps) {
+  const {
+    name,
+    difficulty,
+    rawDifficulty,
+    gradeColor,
+    qualityAverage,
+    ascensionistCount,
+    setterUsername,
+    benchmarkDifficulty,
+    characteristics,
+    leading,
+    onLongPressName,
+  } = props;
   const { t } = useTranslation('climbs');
   const resolvedGradeColor = useMemo(
     () => gradeColor ?? getGradeColor(rawDifficulty ?? difficulty) ?? DEFAULT_GRADE_COLOR,
@@ -95,10 +104,12 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
               </MarqueeText>
             </Pressable>
             <ClimbAttributeIcons benchmarkDifficulty={benchmarkDifficulty} characteristics={characteristics} />
-            {ascentStatus === undefined ? (
-              <AscentStatusGlyph climbUuid={climbUuid} angle={angle} style={styles.ascentStatus} />
+            {/* Undefined selects the root BoardProvider's live lookup; foreign-board
+                callers always provide a resolved status, including explicit null. */}
+            {props.ascentStatus === undefined ? (
+              <AscentStatusGlyph climbUuid={props.climbUuid} angle={props.angle} style={styles.ascentStatus} />
             ) : (
-              <AscentStatusMark status={ascentStatus} style={styles.ascentStatus} />
+              <AscentStatusMark status={props.ascentStatus} style={styles.ascentStatus} />
             )}
           </View>
           <Text variant="caption1" style={styles.subtitleText} numberOfLines={1}>

--- a/packages/mobile/src/components/play-drawer/PlayDrawerSwipeableHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerSwipeableHeader.tsx
@@ -99,6 +99,9 @@ function RootBoardHeader(props: PlayDrawerSwipeableHeaderProps) {
     () => peekOnlyUuids(props.currentClimb.uuid, peekClimbUuid),
     [props.currentClimb.uuid, peekClimbUuid],
   );
+  // Both hooks subscribe to the same board-keyed accumulated React Query
+  // entry, so this merge refreshes BoardProvider's index without touching its
+  // replaceable getLogbook request slot.
   useLogbook(props.boardName, requestedPeekUuids);
   return <HeaderContents {...props} />;
 }
@@ -163,5 +166,8 @@ export const PlayDrawerSwipeableHeader = memo(function PlayDrawerSwipeableHeader
   props: PlayDrawerSwipeableHeaderProps,
 ) {
   const rootBoard = useOptionalBoardActions();
+  // With no root provider, the adapter-backed standalone query is still valid
+  // and supplies explicit statuses; PlayDrawerHeader does not read a missing
+  // BoardProvider logbook context on this branch.
   return rootBoard?.boardName === props.boardName ? <RootBoardHeader {...props} /> : <ForeignBoardHeader {...props} />;
 });

--- a/packages/mobile/src/components/play-drawer/PlayDrawerSwipeableHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerSwipeableHeader.tsx
@@ -1,0 +1,172 @@
+import { memo, useEffect, useMemo, type ReactNode } from 'react';
+import type { SharedValue } from 'react-native-reanimated';
+import type { BoardName, Climb } from '@boardsesh/shared-schema';
+import { useLogbook, useOptionalBoardActions, type LogbookEntry } from '@boardsesh/board-react';
+import type { DisplayGrade } from '../../lib/boardsesh-grade-display';
+import { normalizeAscentStatus, pickHighestAscentStatus, type AscentStatusValue } from '../../lib/ascent-status-utils';
+import { PlayDrawerHeader } from './PlayDrawerHeader';
+import { SwipeableHeader } from './SwipeableHeader';
+
+type PlayDrawerSwipeableHeaderProps = {
+  boardName: BoardName;
+  angle: number;
+  swipeTranslateX: SharedValue<number>;
+  viewportWidth: number;
+  currentClimb: Climb;
+  currentGrade: DisplayGrade | null;
+  currentLeading?: ReactNode;
+  onLongPressCurrentName: () => void;
+  peekClimb: Climb | null;
+  peekGrade: DisplayGrade | null;
+};
+
+type HeaderContentsProps = PlayDrawerSwipeableHeaderProps & {
+  currentAscentStatus?: AscentStatusValue | null;
+  peekAscentStatus?: AscentStatusValue | null;
+};
+
+function HeaderContents({
+  angle,
+  swipeTranslateX,
+  viewportWidth,
+  currentClimb,
+  currentGrade,
+  currentLeading,
+  onLongPressCurrentName,
+  peekClimb,
+  peekGrade,
+  currentAscentStatus,
+  peekAscentStatus,
+}: HeaderContentsProps) {
+  return (
+    <SwipeableHeader
+      swipeTranslateX={swipeTranslateX}
+      viewportWidth={viewportWidth}
+      current={
+        <PlayDrawerHeader
+          climbUuid={currentClimb.uuid}
+          angle={angle}
+          ascentStatus={currentAscentStatus}
+          name={currentClimb.name}
+          difficulty={currentGrade?.label ?? currentClimb.difficulty}
+          rawDifficulty={currentClimb.difficulty}
+          gradeColor={currentGrade?.color}
+          qualityAverage={currentClimb.quality_average}
+          ascensionistCount={currentClimb.ascensionist_count}
+          setterUsername={currentClimb.setter_username}
+          benchmarkDifficulty={currentClimb.benchmark_difficulty}
+          characteristics={currentClimb.characteristics}
+          leading={currentLeading}
+          onLongPressName={onLongPressCurrentName}
+        />
+      }
+      peek={
+        peekClimb ? (
+          <PlayDrawerHeader
+            climbUuid={peekClimb.uuid}
+            angle={angle}
+            ascentStatus={peekAscentStatus}
+            name={peekClimb.name}
+            difficulty={peekGrade?.label ?? peekClimb.difficulty}
+            rawDifficulty={peekClimb.difficulty}
+            gradeColor={peekGrade?.color}
+            qualityAverage={peekClimb.quality_average}
+            ascensionistCount={peekClimb.ascensionist_count}
+            setterUsername={peekClimb.setter_username}
+            benchmarkDifficulty={peekClimb.benchmark_difficulty}
+            characteristics={peekClimb.characteristics}
+          />
+        ) : null
+      }
+    />
+  );
+}
+
+function peekOnlyUuids(currentClimbUuid: string, peekClimbUuid: string | null): string[] {
+  return peekClimbUuid && peekClimbUuid !== currentClimbUuid ? [peekClimbUuid] : [];
+}
+
+/**
+ * Normal path: the drawer board matches the app-root BoardProvider. Its indexed
+ * logbook remains the glyph source. This hook requests only the incoming peek;
+ * DeferredSections already owns the displayed/current climb request.
+ */
+function RootBoardHeader({
+  getLogbook,
+  ...props
+}: PlayDrawerSwipeableHeaderProps & { getLogbook: (climbUuids: string[]) => Promise<void> }) {
+  const peekClimbUuid = props.peekClimb?.uuid ?? null;
+  const requestedPeekUuids = useMemo(
+    () => peekOnlyUuids(props.currentClimb.uuid, peekClimbUuid),
+    [props.currentClimb.uuid, peekClimbUuid],
+  );
+  useEffect(() => {
+    if (requestedPeekUuids.length > 0) void getLogbook(requestedPeekUuids);
+  }, [getLogbook, requestedPeekUuids]);
+  return <HeaderContents {...props} />;
+}
+
+function buildForeignStatusIndex(
+  logbook: readonly LogbookEntry[],
+  currentClimbUuid: string,
+  peekClimbUuid: string | null,
+  angle: number,
+): Map<string, AscentStatusValue> {
+  const targetClimbUuids = new Set(peekClimbUuid ? [currentClimbUuid, peekClimbUuid] : [currentClimbUuid]);
+  const statusIndex = new Map<string, AscentStatusValue>();
+  for (const entry of logbook) {
+    if (entry.angle !== angle || !targetClimbUuids.has(entry.climb_uuid)) continue;
+    const nextStatus = normalizeAscentStatus({
+      status: entry.status,
+      isAscent: entry.is_ascent,
+      tries: entry.tries,
+    });
+    const existingStatus = statusIndex.get(entry.climb_uuid);
+    statusIndex.set(
+      entry.climb_uuid,
+      existingStatus ? (pickHighestAscentStatus([existingStatus, nextStatus]) ?? nextStatus) : nextStatus,
+    );
+  }
+  return statusIndex;
+}
+
+/**
+ * Foreign/profile override path: subscribe read-only to that board's accumulated
+ * logbook cache and build a tiny current+peek index once per cache/angle change.
+ * It requests only the peek; DeferredSections' current request merges into the
+ * same board-keyed accumulated cache, avoiding overlapping network work.
+ */
+function ForeignBoardHeader(props: PlayDrawerSwipeableHeaderProps) {
+  const peekClimbUuid = props.peekClimb?.uuid ?? null;
+  const requestedPeekUuids = useMemo(
+    () => peekOnlyUuids(props.currentClimb.uuid, peekClimbUuid),
+    [props.currentClimb.uuid, peekClimbUuid],
+  );
+  const { logbook } = useLogbook(props.boardName, requestedPeekUuids);
+  const statusIndex = useMemo(
+    () => buildForeignStatusIndex(logbook, props.currentClimb.uuid, peekClimbUuid, props.angle),
+    [logbook, props.currentClimb.uuid, peekClimbUuid, props.angle],
+  );
+  return (
+    <HeaderContents
+      {...props}
+      currentAscentStatus={statusIndex.get(props.currentClimb.uuid) ?? null}
+      peekAscentStatus={peekClimbUuid ? (statusIndex.get(peekClimbUuid) ?? null) : null}
+    />
+  );
+}
+
+/**
+ * Swipeable play-drawer title strip. Normal active-board opens reuse the root
+ * provider/index; foreign-board previews take the lightweight read-only path.
+ */
+export const PlayDrawerSwipeableHeader = memo(function PlayDrawerSwipeableHeader(
+  props: PlayDrawerSwipeableHeaderProps,
+) {
+  const rootBoard = useOptionalBoardActions();
+  return rootBoard?.boardName === props.boardName ? (
+    <RootBoardHeader {...props} getLogbook={rootBoard.getLogbook} />
+  ) : (
+    <ForeignBoardHeader {...props} />
+  );
+});

--- a/packages/mobile/src/components/play-drawer/PlayDrawerSwipeableHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerSwipeableHeader.tsx
@@ -93,7 +93,7 @@ function peekOnlyUuids(currentClimbUuid: string, peekClimbUuid: string | null): 
  * BoardProvider.getLogbook because that request slot is also used by the queue
  * toolbar and visible-climbs list.
  */
-function RootBoardHeader(props: PlayDrawerSwipeableHeaderProps) {
+const RootBoardHeader = memo(function RootBoardHeader(props: PlayDrawerSwipeableHeaderProps) {
   const peekClimbUuid = props.peekClimb?.uuid ?? null;
   const requestedPeekUuids = useMemo(
     () => peekOnlyUuids(props.currentClimb.uuid, peekClimbUuid),
@@ -104,7 +104,7 @@ function RootBoardHeader(props: PlayDrawerSwipeableHeaderProps) {
   // replaceable getLogbook request slot.
   useLogbook(props.boardName, requestedPeekUuids);
   return <HeaderContents {...props} />;
-}
+});
 
 function buildForeignStatusIndex(
   logbook: readonly LogbookEntry[],
@@ -138,7 +138,7 @@ function buildForeignStatusIndex(
  * It requests only the peek; DeferredSections' current request merges into the
  * same board-keyed accumulated cache, avoiding overlapping network work.
  */
-function ForeignBoardHeader(props: PlayDrawerSwipeableHeaderProps) {
+const ForeignBoardHeader = memo(function ForeignBoardHeader(props: PlayDrawerSwipeableHeaderProps) {
   const peekClimbUuid = props.peekClimb?.uuid ?? null;
   const requestedPeekUuids = useMemo(
     () => peekOnlyUuids(props.currentClimb.uuid, peekClimbUuid),
@@ -156,7 +156,7 @@ function ForeignBoardHeader(props: PlayDrawerSwipeableHeaderProps) {
       peekAscentStatus={peekClimbUuid ? (statusIndex.get(peekClimbUuid) ?? null) : null}
     />
   );
-}
+});
 
 /**
  * Swipeable play-drawer title strip. Normal active-board opens reuse the root

--- a/packages/mobile/src/components/play-drawer/PlayDrawerSwipeableHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerSwipeableHeader.tsx
@@ -116,6 +116,8 @@ function buildForeignStatusIndex(
   const statusIndex = new Map<string, AscentStatusValue>();
   for (const entry of logbook) {
     if (entry.angle !== angle || !targetClimbUuids.has(entry.climb_uuid)) continue;
+    // Match useAscentStatus's browse semantics: without an explicit mirror
+    // filter, history from both orientations contributes to the best status.
     const nextStatus = normalizeAscentStatus({
       status: entry.status,
       isAscent: entry.is_ascent,

--- a/packages/mobile/src/components/play-drawer/PlayDrawerSwipeableHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerSwipeableHeader.tsx
@@ -44,9 +44,9 @@ function HeaderContents({
       viewportWidth={viewportWidth}
       current={
         <PlayDrawerHeader
-          climbUuid={currentClimb.uuid}
-          angle={angle}
-          ascentStatus={currentAscentStatus}
+          {...(currentAscentStatus === undefined
+            ? { climbUuid: currentClimb.uuid, angle }
+            : { ascentStatus: currentAscentStatus })}
           name={currentClimb.name}
           difficulty={currentGrade?.label ?? currentClimb.difficulty}
           rawDifficulty={currentClimb.difficulty}
@@ -63,9 +63,9 @@ function HeaderContents({
       peek={
         peekClimb ? (
           <PlayDrawerHeader
-            climbUuid={peekClimb.uuid}
-            angle={angle}
-            ascentStatus={peekAscentStatus}
+            {...(peekAscentStatus === undefined
+              ? { climbUuid: peekClimb.uuid, angle }
+              : { ascentStatus: peekAscentStatus })}
             name={peekClimb.name}
             difficulty={peekGrade?.label ?? peekClimb.difficulty}
             rawDifficulty={peekClimb.difficulty}

--- a/packages/mobile/src/components/play-drawer/PlayDrawerSwipeableHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerSwipeableHeader.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, type ReactNode } from 'react';
+import { memo, useMemo, type ReactNode } from 'react';
 import type { SharedValue } from 'react-native-reanimated';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
 import { useLogbook, useOptionalBoardActions, type LogbookEntry } from '@boardsesh/board-react';
@@ -88,21 +88,18 @@ function peekOnlyUuids(currentClimbUuid: string, peekClimbUuid: string | null): 
 
 /**
  * Normal path: the drawer board matches the app-root BoardProvider. Its indexed
- * logbook remains the glyph source. This hook requests only the incoming peek;
- * DeferredSections already owns the displayed/current climb request.
+ * logbook remains the glyph source. A separate read-only query requests only the
+ * incoming peek and merges it into the same accumulated cache; it must not call
+ * BoardProvider.getLogbook because that request slot is also used by the queue
+ * toolbar and visible-climbs list.
  */
-function RootBoardHeader({
-  getLogbook,
-  ...props
-}: PlayDrawerSwipeableHeaderProps & { getLogbook: (climbUuids: string[]) => Promise<void> }) {
+function RootBoardHeader(props: PlayDrawerSwipeableHeaderProps) {
   const peekClimbUuid = props.peekClimb?.uuid ?? null;
   const requestedPeekUuids = useMemo(
     () => peekOnlyUuids(props.currentClimb.uuid, peekClimbUuid),
     [props.currentClimb.uuid, peekClimbUuid],
   );
-  useEffect(() => {
-    if (requestedPeekUuids.length > 0) void getLogbook(requestedPeekUuids);
-  }, [getLogbook, requestedPeekUuids]);
+  useLogbook(props.boardName, requestedPeekUuids);
   return <HeaderContents {...props} />;
 }
 
@@ -166,9 +163,5 @@ export const PlayDrawerSwipeableHeader = memo(function PlayDrawerSwipeableHeader
   props: PlayDrawerSwipeableHeaderProps,
 ) {
   const rootBoard = useOptionalBoardActions();
-  return rootBoard?.boardName === props.boardName ? (
-    <RootBoardHeader {...props} getLogbook={rootBoard.getLogbook} />
-  ) : (
-    <ForeignBoardHeader {...props} />
-  );
+  return rootBoard?.boardName === props.boardName ? <RootBoardHeader {...props} /> : <ForeignBoardHeader {...props} />;
 });

--- a/packages/mobile/src/components/play-drawer/SwipeableHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/SwipeableHeader.tsx
@@ -47,7 +47,12 @@ export const SwipeableHeader = memo(function SwipeableHeader({
 
   return (
     <View style={styles.container}>
-      <Animated.View style={[styles.peekLayer, peekStyle]} pointerEvents="none">
+      <Animated.View
+        style={[styles.peekLayer, peekStyle]}
+        pointerEvents="none"
+        accessibilityElementsHidden
+        importantForAccessibility="no-hide-descendants"
+      >
         {peek}
       </Animated.View>
       <Animated.View style={[styles.currentLayer, currentStyle]}>{current}</Animated.View>

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-ascent-status.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-ascent-status.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+const statusByClimbAngle = vi.hoisted(() => new Map<string, 'flash' | 'send' | 'attempt'>());
+const climbAngleKey = (climbUuid: string, angle: number) => `${climbUuid}:${angle}`;
+
+vi.mock('react-native', () => ({
+  View: ({
+    children,
+    accessibilityLabel,
+    accessibilityRole,
+  }: {
+    children?: ReactNode;
+    accessibilityLabel?: string;
+    accessibilityRole?: string;
+  }) => createElement('div', { 'aria-label': accessibilityLabel, role: accessibilityRole }, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+  Pressable: ({ children }: { children?: ReactNode }) => createElement('button', null, children),
+}));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@boardsesh/board-constants/grade-colors', () => ({
+  getGradeColor: () => '#abcdef',
+  DEFAULT_GRADE_COLOR: '#000000',
+}));
+vi.mock('../../../lib/format-climb-stats', () => ({
+  formatSends: (count: number) => `${count} sends`,
+  formatQuality: (value: string) => value,
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../MarqueeText', () => ({
+  MarqueeText: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../DrawerHeader', () => ({
+  DrawerHeader: ({ center }: { center?: ReactNode }) => createElement('div', null, center),
+}));
+vi.mock('../../ClimbAttributeIcons', () => ({ ClimbAttributeIcons: () => null }));
+vi.mock('../../../hooks/use-ascent-status', () => ({
+  useAscentStatus: (climbUuid: string, angle: number) =>
+    statusByClimbAngle.get(climbAngleKey(climbUuid, angle)) ?? null,
+}));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { secondaryLabel: '#8E8E93' } }),
+}));
+vi.mock('../../Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }),
+}));
+
+import { PlayDrawerHeader } from '../PlayDrawerHeader';
+
+const baseProps = {
+  climbUuid: 'climb-1',
+  angle: 40,
+  name: 'Hueco Madness',
+  difficulty: 'V6',
+  qualityAverage: '0',
+  ascensionistCount: 0,
+  setterUsername: '',
+};
+
+describe('PlayDrawerHeader ascent status', () => {
+  beforeEach(() => statusByClimbAngle.clear());
+
+  it.each([
+    ['flash', 'flash', 'mobile.climbRow.ascentStatus.flash'],
+    ['send', 'tick.outline', 'mobile.climbRow.ascentStatus.send'],
+    ['attempt', 'ascent.attempt', 'mobile.climbRow.ascentStatus.attempt'],
+  ] as const)('shows the canonical %s glyph and label', (status, icon, label) => {
+    statusByClimbAngle.set(climbAngleKey('climb-1', 40), status);
+    const { container, getByLabelText } = render(createElement(PlayDrawerHeader, baseProps));
+
+    expect(getByLabelText(label)).toBeTruthy();
+    expect(container.querySelector('[data-icon]')?.getAttribute('data-icon')).toBe(icon);
+  });
+
+  it('omits the marker when the current angle has no prior history', () => {
+    statusByClimbAngle.set(climbAngleKey('climb-1', 30), 'flash');
+    const { container } = render(createElement(PlayDrawerHeader, baseProps));
+
+    expect(container.querySelector('[data-icon]')).toBeNull();
+  });
+
+  it('updates for the current angle and displayed climb while the drawer swipes', () => {
+    statusByClimbAngle.set(climbAngleKey('climb-1', 40), 'flash');
+    statusByClimbAngle.set(climbAngleKey('climb-1', 30), 'attempt');
+    statusByClimbAngle.set(climbAngleKey('climb-2', 30), 'send');
+    const { container, rerender } = render(createElement(PlayDrawerHeader, baseProps));
+    expect(container.querySelector('[data-icon]')?.getAttribute('data-icon')).toBe('flash');
+
+    rerender(createElement(PlayDrawerHeader, { ...baseProps, angle: 30 }));
+    expect(container.querySelector('[data-icon]')?.getAttribute('data-icon')).toBe('ascent.attempt');
+
+    rerender(createElement(PlayDrawerHeader, { ...baseProps, climbUuid: 'climb-2', angle: 30 }));
+    expect(container.querySelector('[data-icon]')?.getAttribute('data-icon')).toBe('tick.outline');
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-ascent-status.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-ascent-status.test.tsx
@@ -85,7 +85,7 @@ describe('PlayDrawerHeader ascent status', () => {
     expect(container.querySelector('[data-icon]')).toBeNull();
   });
 
-  it('updates for the current angle and displayed climb while the drawer swipes', () => {
+  it('updates when the current angle or displayed climb prop changes', () => {
     statusByClimbAngle.set(climbAngleKey('climb-1', 40), 'flash');
     statusByClimbAngle.set(climbAngleKey('climb-1', 30), 'attempt');
     statusByClimbAngle.set(climbAngleKey('climb-2', 30), 'send');

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-header-copy-name.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-header-copy-name.test.tsx
@@ -50,7 +50,7 @@ vi.mock('../../DrawerHeader', () => ({
   DrawerHeader: ({ center }: { center?: ReactNode }) => createElement('div', null, center),
 }));
 vi.mock('../../ClimbAttributeIcons', () => ({ ClimbAttributeIcons: () => createElement('i', null) }));
-vi.mock('../../AscentStatusGlyph', () => ({ AscentStatusGlyph: () => null }));
+vi.mock('../../AscentStatusGlyph', () => ({ AscentStatusGlyph: () => null, AscentStatusMark: () => null }));
 
 import { PlayDrawerHeader } from '../PlayDrawerHeader';
 

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-header-copy-name.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-header-copy-name.test.tsx
@@ -50,10 +50,13 @@ vi.mock('../../DrawerHeader', () => ({
   DrawerHeader: ({ center }: { center?: ReactNode }) => createElement('div', null, center),
 }));
 vi.mock('../../ClimbAttributeIcons', () => ({ ClimbAttributeIcons: () => createElement('i', null) }));
+vi.mock('../../AscentStatusGlyph', () => ({ AscentStatusGlyph: () => null }));
 
 import { PlayDrawerHeader } from '../PlayDrawerHeader';
 
 const baseProps = {
+  climbUuid: 'climb-1',
+  angle: 40,
   name: 'Hueco Madness',
   difficulty: 'V6',
   qualityAverage: '0',

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-navigation.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-navigation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
-import { getViewOnlyPreviewNavigationTarget } from '../play-drawer-navigation';
+import { getViewOnlyPreviewNavigationTarget, swipeDirectionForOffset } from '../play-drawer-navigation';
 
 function makeItem(id: string): ClimbQueueItem {
   return {
@@ -79,5 +79,23 @@ describe('getViewOnlyPreviewNavigationTarget', () => {
         targetItem: makeItem('previous'),
       }),
     ).toEqual({ viewOnly: false });
+  });
+});
+
+describe('swipeDirectionForOffset', () => {
+  it('keeps the initial next peek at rest and after a next-swipe reset', () => {
+    let retainedDirection: 'next' | 'prev' = 'next';
+    for (const offset of [0, -80, 0]) {
+      const directionUpdate = swipeDirectionForOffset(offset);
+      if (directionUpdate !== null) retainedDirection = directionUpdate;
+    }
+
+    expect(retainedDirection).toBe('next');
+    expect(swipeDirectionForOffset(0)).toBeNull();
+  });
+
+  it('reports prev only for a positive, non-zero swipe', () => {
+    expect(swipeDirectionForOffset(25)).toBe('prev');
+    expect(swipeDirectionForOffset(-25)).toBe('next');
   });
 });

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-swipeable-header-logbook.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-swipeable-header-logbook.test.tsx
@@ -180,8 +180,22 @@ describe('PlayDrawerSwipeableHeader logbook I/O', () => {
     expect(iconWithin(container, 'peek-header')).toBe('flash');
   });
 
-  it('reads a foreign board accumulated cache while requesting only its peek', () => {
-    logbookState.rootBoardName = 'kilter';
+  it('does not request the current climb again when the mounted peek is the same climb', () => {
+    logbookState.rootIndex = indexEntries([entry('current', 'send')]);
+
+    const { container } = render(createElement(PlayDrawerSwipeableHeader, { ...baseProps, peekClimb: currentClimb }));
+
+    expect(logbookState.useLogbook).toHaveBeenCalledWith('tension', []);
+    expect(logbookState.rootGetLogbook).not.toHaveBeenCalled();
+    expect(iconWithin(container, 'current-header')).toBe('tick.outline');
+    expect(iconWithin(container, 'peek-header')).toBe('tick.outline');
+  });
+
+  it.each([
+    ['a different root board', 'kilter'],
+    ['no root provider', null],
+  ])('reads the accumulated cache with %s while requesting only its peek', (_label, rootBoardName) => {
+    logbookState.rootBoardName = rootBoardName;
     logbookState.rootIndex = indexEntries([entry('current', 'attempt')]);
     // Models the board-keyed accumulated cache after DeferredSections fetched
     // current and this header's non-overlapping query fetched peek.

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-swipeable-header-logbook.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-swipeable-header-logbook.test.tsx
@@ -1,0 +1,213 @@
+// @vitest-environment jsdom
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, within } from '@testing-library/react';
+import type { Climb } from '@boardsesh/shared-schema';
+
+type TestEntry = {
+  climb_uuid: string;
+  angle: number;
+  is_mirror: boolean;
+  status: 'flash' | 'send' | 'attempt';
+  is_ascent: boolean;
+  tries: number;
+};
+
+const logbookState = vi.hoisted(() => ({
+  rootBoardName: 'tension' as string | null,
+  rootIndex: new Map<string, TestEntry[]>(),
+  accumulatedByBoard: new Map<string, TestEntry[]>(),
+  useLogbook: vi.fn(),
+  rootFetchedUuids: new Set<string>(),
+  rootGetLogbook: vi.fn(),
+  rootNetworkFetch: vi.fn(),
+}));
+
+vi.mock('@boardsesh/board-react', () => ({
+  logbookClimbAngleKey: (climbUuid: string, angle: number) => `${climbUuid}:${angle}`,
+  useOptionalBoardActions: () =>
+    logbookState.rootBoardName
+      ? { boardName: logbookState.rootBoardName, getLogbook: logbookState.rootGetLogbook }
+      : null,
+  useOptionalBoardLogbook: () => ({ logbookByClimbAngle: logbookState.rootIndex }),
+  useLogbook: (boardName: string, climbUuids: string[]) => {
+    logbookState.useLogbook(boardName, climbUuids);
+    return { logbook: logbookState.accumulatedByBoard.get(boardName) ?? [] };
+  },
+}));
+
+vi.mock('react-native', () => ({
+  View: ({
+    children,
+    accessibilityLabel,
+    accessibilityRole,
+  }: {
+    children?: ReactNode;
+    accessibilityLabel?: string;
+    accessibilityRole?: string;
+  }) => createElement('div', { 'aria-label': accessibilityLabel, role: accessibilityRole }, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+  Pressable: ({ children }: { children?: ReactNode }) => createElement('button', null, children),
+}));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@boardsesh/board-constants/grade-colors', () => ({
+  getGradeColor: () => '#abcdef',
+  DEFAULT_GRADE_COLOR: '#000000',
+}));
+vi.mock('../../../lib/format-climb-stats', () => ({ formatSends: () => '', formatQuality: (value: string) => value }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { secondaryLabel: '#8E8E93' } }),
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../MarqueeText', () => ({
+  MarqueeText: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../DrawerHeader', () => ({
+  DrawerHeader: ({ center }: { center?: ReactNode }) => createElement('div', null, center),
+}));
+vi.mock('../../ClimbAttributeIcons', () => ({ ClimbAttributeIcons: () => null }));
+vi.mock('../../Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }),
+}));
+vi.mock('../SwipeableHeader', () => ({
+  SwipeableHeader: ({ current, peek }: { current: ReactNode; peek: ReactNode }) =>
+    createElement(
+      'div',
+      null,
+      createElement('div', { 'data-testid': 'current-header' }, current),
+      createElement('div', { 'data-testid': 'peek-header' }, peek),
+    ),
+}));
+
+import { PlayDrawerSwipeableHeader } from '../PlayDrawerSwipeableHeader';
+
+function climb(uuid: string): Climb {
+  return {
+    uuid,
+    name: uuid,
+    frames: 'p1r12',
+    difficulty: 'V4',
+    quality_average: '0',
+    ascensionist_count: 0,
+    setter_username: '',
+    benchmark_difficulty: null,
+  } as unknown as Climb;
+}
+
+function entry(climbUuid: string, status: TestEntry['status'], angle = 40, isMirror = false): TestEntry {
+  return {
+    climb_uuid: climbUuid,
+    angle,
+    is_mirror: isMirror,
+    status,
+    is_ascent: status !== 'attempt',
+    tries: status === 'flash' ? 1 : 2,
+  };
+}
+
+function indexEntries(entries: TestEntry[]): Map<string, TestEntry[]> {
+  const index = new Map<string, TestEntry[]>();
+  for (const tick of entries) {
+    const key = `${tick.climb_uuid}:${tick.angle}`;
+    const bucket = index.get(key);
+    if (bucket) bucket.push(tick);
+    else index.set(key, [tick]);
+  }
+  return index;
+}
+
+const currentClimb = climb('current');
+const peekClimb = climb('peek');
+const thirdClimb = climb('third');
+const baseProps = {
+  boardName: 'tension' as const,
+  angle: 40,
+  swipeTranslateX: { value: 0 } as never,
+  viewportWidth: 390,
+  currentClimb,
+  currentGrade: null,
+  onLongPressCurrentName: vi.fn(),
+  peekClimb,
+  peekGrade: null,
+};
+
+function iconWithin(container: HTMLElement, testId: string): string | null {
+  return within(container).getByTestId(testId).querySelector('[data-icon]')?.getAttribute('data-icon') ?? null;
+}
+
+describe('PlayDrawerSwipeableHeader logbook I/O', () => {
+  beforeEach(() => {
+    logbookState.rootBoardName = 'tension';
+    logbookState.rootIndex = new Map();
+    logbookState.accumulatedByBoard.clear();
+    logbookState.useLogbook.mockClear();
+    logbookState.rootFetchedUuids.clear();
+    logbookState.rootGetLogbook.mockReset();
+    logbookState.rootNetworkFetch.mockClear();
+    logbookState.rootGetLogbook.mockImplementation(async (climbUuids: string[]) => {
+      const missingClimbUuids = climbUuids.filter((climbUuid) => !logbookState.rootFetchedUuids.has(climbUuid));
+      if (missingClimbUuids.length > 0) logbookState.rootNetworkFetch(missingClimbUuids);
+    });
+  });
+
+  it('reuses the matching root index and its fetched tracking for each incoming peek', async () => {
+    logbookState.rootIndex = indexEntries([
+      entry('current', 'send'),
+      // Browse semantics intentionally combine orientations: the mirror flash
+      // wins even when the drawer art is currently unmirrored.
+      entry('current', 'flash', 40, true),
+      entry('current', 'attempt', 30),
+      entry('peek', 'send'),
+      entry('third', 'flash'),
+    ]);
+    // The root fetched this in an earlier visible-climbs batch. Calling its
+    // stable getLogbook seam must reuse that tracker instead of issuing a new
+    // independent query for the same peek.
+    logbookState.rootFetchedUuids.add('peek');
+    const { container, rerender } = render(createElement(PlayDrawerSwipeableHeader, baseProps));
+
+    await vi.waitFor(() => expect(logbookState.rootGetLogbook).toHaveBeenCalledWith(['peek']));
+    expect(logbookState.rootNetworkFetch).not.toHaveBeenCalled();
+    expect(logbookState.useLogbook).not.toHaveBeenCalled();
+    expect(iconWithin(container, 'current-header')).toBe('flash');
+    expect(iconWithin(container, 'peek-header')).toBe('tick.outline');
+
+    rerender(createElement(PlayDrawerSwipeableHeader, { ...baseProps, angle: 30 }));
+    expect(iconWithin(container, 'current-header')).toBe('ascent.attempt');
+
+    rerender(
+      createElement(PlayDrawerSwipeableHeader, {
+        ...baseProps,
+        currentClimb: peekClimb,
+        peekClimb: thirdClimb,
+      }),
+    );
+    await vi.waitFor(() => expect(logbookState.rootGetLogbook).toHaveBeenLastCalledWith(['third']));
+    expect(logbookState.rootGetLogbook.mock.calls.some(([climbUuids]) => climbUuids.includes('current'))).toBe(false);
+    expect(iconWithin(container, 'peek-header')).toBe('flash');
+  });
+
+  it('reads a foreign board accumulated cache while requesting only its peek', () => {
+    logbookState.rootBoardName = 'kilter';
+    logbookState.rootIndex = indexEntries([entry('current', 'attempt')]);
+    // Models the board-keyed accumulated cache after DeferredSections fetched
+    // current and this header's non-overlapping query fetched peek.
+    logbookState.accumulatedByBoard.set('tension', [
+      entry('current', 'send'),
+      entry('current', 'flash', 40, true),
+      entry('current', 'attempt', 30),
+      entry('peek', 'send'),
+    ]);
+
+    const { container } = render(createElement(PlayDrawerSwipeableHeader, baseProps));
+
+    expect(logbookState.useLogbook).toHaveBeenCalledWith('tension', ['peek']);
+    expect(logbookState.useLogbook.mock.calls.some(([, climbUuids]) => climbUuids.includes('current'))).toBe(false);
+    expect(iconWithin(container, 'current-header')).toBe('flash');
+    expect(iconWithin(container, 'peek-header')).toBe('tick.outline');
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-swipeable-header-logbook.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-swipeable-header-logbook.test.tsx
@@ -161,6 +161,7 @@ describe('PlayDrawerSwipeableHeader logbook I/O', () => {
       // wins even when the drawer art is currently unmirrored.
       entry('current', 'flash', 40, true),
       entry('current', 'attempt', 30),
+      entry('peek', 'attempt'),
       entry('peek', 'send'),
       entry('third', 'flash'),
     ]);

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-swipeable-header-logbook.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-swipeable-header-logbook.test.tsx
@@ -18,9 +18,7 @@ const logbookState = vi.hoisted(() => ({
   rootIndex: new Map<string, TestEntry[]>(),
   accumulatedByBoard: new Map<string, TestEntry[]>(),
   useLogbook: vi.fn(),
-  rootFetchedUuids: new Set<string>(),
   rootGetLogbook: vi.fn(),
-  rootNetworkFetch: vi.fn(),
 }));
 
 vi.mock('@boardsesh/board-react', () => ({
@@ -145,16 +143,10 @@ describe('PlayDrawerSwipeableHeader logbook I/O', () => {
     logbookState.rootIndex = new Map();
     logbookState.accumulatedByBoard.clear();
     logbookState.useLogbook.mockClear();
-    logbookState.rootFetchedUuids.clear();
     logbookState.rootGetLogbook.mockReset();
-    logbookState.rootNetworkFetch.mockClear();
-    logbookState.rootGetLogbook.mockImplementation(async (climbUuids: string[]) => {
-      const missingClimbUuids = climbUuids.filter((climbUuid) => !logbookState.rootFetchedUuids.has(climbUuid));
-      if (missingClimbUuids.length > 0) logbookState.rootNetworkFetch(missingClimbUuids);
-    });
   });
 
-  it('reuses the matching root index and its fetched tracking for each incoming peek', async () => {
+  it('uses the matching root index without replacing another provider request', () => {
     logbookState.rootIndex = indexEntries([
       entry('current', 'send'),
       // Browse semantics intentionally combine orientations: the mirror flash
@@ -165,15 +157,10 @@ describe('PlayDrawerSwipeableHeader logbook I/O', () => {
       entry('peek', 'send'),
       entry('third', 'flash'),
     ]);
-    // The root fetched this in an earlier visible-climbs batch. Calling its
-    // stable getLogbook seam must reuse that tracker instead of issuing a new
-    // independent query for the same peek.
-    logbookState.rootFetchedUuids.add('peek');
     const { container, rerender } = render(createElement(PlayDrawerSwipeableHeader, baseProps));
 
-    await vi.waitFor(() => expect(logbookState.rootGetLogbook).toHaveBeenCalledWith(['peek']));
-    expect(logbookState.rootNetworkFetch).not.toHaveBeenCalled();
-    expect(logbookState.useLogbook).not.toHaveBeenCalled();
+    expect(logbookState.useLogbook).toHaveBeenCalledWith('tension', ['peek']);
+    expect(logbookState.rootGetLogbook).not.toHaveBeenCalled();
     expect(iconWithin(container, 'current-header')).toBe('flash');
     expect(iconWithin(container, 'peek-header')).toBe('tick.outline');
 
@@ -187,8 +174,9 @@ describe('PlayDrawerSwipeableHeader logbook I/O', () => {
         peekClimb: thirdClimb,
       }),
     );
-    await vi.waitFor(() => expect(logbookState.rootGetLogbook).toHaveBeenLastCalledWith(['third']));
-    expect(logbookState.rootGetLogbook.mock.calls.some(([climbUuids]) => climbUuids.includes('current'))).toBe(false);
+    expect(logbookState.useLogbook).toHaveBeenLastCalledWith('tension', ['third']);
+    expect(logbookState.useLogbook.mock.calls.some(([, climbUuids]) => climbUuids.includes('current'))).toBe(false);
+    expect(logbookState.rootGetLogbook).not.toHaveBeenCalled();
     expect(iconWithin(container, 'peek-header')).toBe('flash');
   });
 

--- a/packages/mobile/src/components/play-drawer/__tests__/swipeable-header-accessibility.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/swipeable-header-accessibility.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { createElement, type ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+}));
+vi.mock('react-native-reanimated', () => ({
+  default: {
+    View: ({
+      children,
+      accessibilityElementsHidden,
+      importantForAccessibility,
+    }: {
+      children?: ReactNode;
+      accessibilityElementsHidden?: boolean;
+      importantForAccessibility?: string;
+    }) =>
+      createElement(
+        'div',
+        {
+          'data-accessibility-hidden': String(accessibilityElementsHidden ?? false),
+          'data-important-for-accessibility': importantForAccessibility,
+        },
+        children,
+      ),
+  },
+  useAnimatedStyle: (factory: () => unknown) => factory(),
+}));
+
+import { SwipeableHeader } from '../SwipeableHeader';
+
+describe('SwipeableHeader accessibility', () => {
+  it('hides the mounted offscreen peek subtree from assistive technology', () => {
+    const { getByText } = render(
+      createElement(SwipeableHeader, {
+        swipeTranslateX: { value: 0 } as never,
+        viewportWidth: 390,
+        current: createElement('span', null, 'Current header'),
+        peek: createElement('span', null, 'Peek header'),
+      }),
+    );
+
+    const peekLayer = getByText('Peek header').parentElement;
+    expect(peekLayer?.getAttribute('data-accessibility-hidden')).toBe('true');
+    expect(peekLayer?.getAttribute('data-important-for-accessibility')).toBe('no-hide-descendants');
+    expect(getByText('Current header').parentElement?.getAttribute('data-accessibility-hidden')).toBe('false');
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/swipeable-header-accessibility.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/swipeable-header-accessibility.test.tsx
@@ -21,7 +21,8 @@ vi.mock('react-native-reanimated', () => ({
       createElement(
         'div',
         {
-          'data-accessibility-hidden': String(accessibilityElementsHidden ?? false),
+          'data-accessibility-hidden':
+            accessibilityElementsHidden === undefined ? undefined : String(accessibilityElementsHidden),
           'data-important-for-accessibility': importantForAccessibility,
         },
         children,
@@ -46,6 +47,6 @@ describe('SwipeableHeader accessibility', () => {
     const peekLayer = getByText('Peek header').parentElement;
     expect(peekLayer?.getAttribute('data-accessibility-hidden')).toBe('true');
     expect(peekLayer?.getAttribute('data-important-for-accessibility')).toBe('no-hide-descendants');
-    expect(getByText('Current header').parentElement?.getAttribute('data-accessibility-hidden')).toBe('false');
+    expect(getByText('Current header').parentElement?.hasAttribute('data-accessibility-hidden')).toBe(false);
   });
 });

--- a/packages/mobile/src/components/play-drawer/play-drawer-navigation.ts
+++ b/packages/mobile/src/components/play-drawer/play-drawer-navigation.ts
@@ -1,5 +1,18 @@
 import type { ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
 
+export type DrawerSwipeDirection = 'next' | 'prev';
+
+/**
+ * Returns a direction only while the swipe has a real horizontal sign. At rest
+ * and after the post-commit reset, callers retain the last non-zero direction
+ * instead of spuriously treating zero as "prev" and flipping the header peek.
+ */
+export function swipeDirectionForOffset(offset: number): DrawerSwipeDirection | null {
+  'worklet';
+  if (offset === 0) return null;
+  return offset < 0 ? 'next' : 'prev';
+}
+
 export type ViewOnlyPreviewNavigationTarget =
   | { viewOnly: false }
   | { viewOnly: true; targetItem: ClimbQueueItem | null };

--- a/packages/mobile/src/hooks/__tests__/use-ascent-status.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-ascent-status.test.tsx
@@ -69,6 +69,32 @@ describe('useAscentStatus', () => {
     expect(renderHook(() => useAscentStatus('a', 40)).result.current).toBe('flashed');
   });
 
+  it.each(['flash', 'send', 'attempt'] as const)('returns a %s entry at the current angle', (status) => {
+    ctrl.board = boardFrom([entry({ status })]);
+    expect(renderHook(() => useAscentStatus('a', 40)).result.current).toBe(status);
+  });
+
+  it('uses the O(1) climb-angle bucket again when the displayed climb or angle changes', () => {
+    ctrl.board = boardFrom([
+      entry({ climb_uuid: 'a', angle: 40, status: 'flash' }),
+      entry({ climb_uuid: 'a', angle: 30, status: 'attempt' }),
+      entry({ climb_uuid: 'b', angle: 30, status: 'send' }),
+    ]);
+    const { result, rerender } = renderHook(
+      ({ climbUuid, angle }: { climbUuid: string; angle: number }) => useAscentStatus(climbUuid, angle),
+      {
+        initialProps: { climbUuid: 'a', angle: 40 },
+      },
+    );
+    expect(result.current).toBe('flash');
+
+    rerender({ climbUuid: 'a', angle: 30 });
+    expect(result.current).toBe('attempt');
+
+    rerender({ climbUuid: 'b', angle: 30 });
+    expect(result.current).toBe('send');
+  });
+
   it('filters by mirror when isMirror is provided', () => {
     ctrl.board = boardFrom([
       entry({ is_mirror: true, status: 'mirror-send' }),


### PR DESCRIPTION
## Summary

- Show flash, send, and attempt status directly on the current and peeked climbs in the play drawer.
- Fetch only the incoming peek through an independent query that merges into the shared logbook cache without replacing another provider consumer's request.
- Keep hidden swipe content out of the accessibility tree and avoid zero-offset request churn.

Closes #3757

## Release Notes

See whether you flashed, sent, or tried a climb right in the play drawer.

## Test plan

- `vp check` on all changed files
- Original focused mobile tests: 24 passed; request-isolation regression: 2 passed
- `vp run typecheck:mobile`
- `vp run test:mobile`: 4,878 tests passed before the request-isolation follow-up
- `vp run check:mobile-bundle`: iOS and Android bundles passed before the request-isolation follow-up
- Independent code review: pass
- [ ] Fresh full CI/OTA cycle for commit `3811a6381`
