### PR TITLE
fix(mobile): correct native tab chrome metrics

### DIFF
--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -186,6 +186,12 @@ Is it a secondary surface OVER the current screen, or its own full surface?
    paints its own opaque `View` under its `GlassSurface` so the live tabs screen doesn't show
    through. See `isTabsChromeRoute` in `src/lib/route-segments.ts`.
 
+   A **pushed route** under `NativeTabs` is different: the native tab bar remains, but route
+   classification deliberately unmounts the BottomAccessory / queue chrome on screens such as
+   session detail. Its bottom layout must therefore trust the raw UIKit safe-area inset for the
+   chrome that is actually present; it must not carry the accessory reserve forward from the tab
+   root or add the tab-bar height a second time.
+
 3. **Board gestures and modal/sheet pan don't mix.** A full-screen board you pan/pinch (the
    `holds` and `zone` filters) is a **pushed** route, not a modal — a modal/sheet's own pan
    gesture competes with the board's.

--- a/packages/mobile/app/(tabs)/home/_layout.tsx
+++ b/packages/mobile/app/(tabs)/home/_layout.tsx
@@ -10,8 +10,9 @@ export default function HomeLayout() {
         {/* The Home feed owns its top via floating chrome (the avatar island + scope
           title), like the other tabs — so the stack header is hidden here. */}
         <Stack.Screen name="index" options={{ headerShown: false }} />
-        {/* Session detail keeps the native tab bar + bottom accessory by living in
-          this stack. It sets its own header title from the loaded session. */}
+        {/* Session detail keeps the native tab bar by living in this stack, while
+          pushed-route accessory/queue chrome unmounts. It sets its own header
+          title from the loaded session. */}
         <Stack.Screen name="session/[sessionId]" options={{ headerShown: true }} />
       </Stack>
     </BoardArtVisibilityProvider>

--- a/packages/mobile/app/(tabs)/home/session/[sessionId].tsx
+++ b/packages/mobile/app/(tabs)/home/session/[sessionId].tsx
@@ -1,4 +1,4 @@
-// Session detail pushed inside the Home tab stack, so the native tab bar + Liquid
-// Glass bottom accessory stay on screen (matching the playlist detail view). Shares
+// Session detail is pushed inside the Home tab stack, so the native tab bar stays
+// on screen while the Liquid Glass BottomAccessory/queue chrome unmounts. Shares
 // the same screen component as the Profile tab's session route.
 export { default } from '../../../../src/components/session/SessionDetailScreen';

--- a/packages/mobile/app/(tabs)/profile/_layout.tsx
+++ b/packages/mobile/app/(tabs)/profile/_layout.tsx
@@ -15,8 +15,9 @@ export default function ProfileLayout() {
           title collapsing into a glass capsule), like the Discover/Climbs tabs —
           so the stack header is hidden here. */}
         <Stack.Screen name="index" options={{ headerShown: false, title: t('mobile.nav.profile') }} />
-        {/* Session detail keeps the native tab bar + bottom accessory by living in
-          this stack. It sets its own header title from the loaded session. */}
+        {/* Session detail keeps the native tab bar by living in this stack, while
+          pushed-route accessory/queue chrome unmounts. It sets its own header
+          title from the loaded session. */}
         <Stack.Screen name="session/[sessionId]" options={{ headerShown: true }} />
         <Stack.Screen name="more" options={{ title: t('mobile.more.title') }} />
         <Stack.Screen name="accessibility" options={{ title: t('mobile.more.accessibility.title') }} />

--- a/packages/mobile/app/(tabs)/profile/session/[sessionId].tsx
+++ b/packages/mobile/app/(tabs)/profile/session/[sessionId].tsx
@@ -1,5 +1,5 @@
-// Session detail pushed inside the Profile tab stack (reached from the Sessions
-// sub-tab), so the native tab bar + Liquid Glass bottom accessory stay on screen
-// (matching the playlist detail view). Shares the same screen component as the Home
-// tab's session route.
+// Session detail is pushed inside the Profile tab stack (reached from the Sessions
+// sub-tab), so the native tab bar stays on screen while the Liquid Glass
+// BottomAccessory/queue chrome unmounts. Shares the same screen component as the
+// Home tab's session route.
 export { default } from '../../../../src/components/session/SessionDetailScreen';

--- a/packages/mobile/src/components/Toast.tsx
+++ b/packages/mobile/src/components/Toast.tsx
@@ -19,6 +19,7 @@ import type { UiVariant } from '../theme/resolve-ui-variant';
 import { isTabsRoute } from '../lib/route-segments';
 import { useTheme } from '../providers/theme-provider';
 import { createVariantComponent, selectByVariant } from '../theme/variants';
+import { useNativeTabBar } from '../hooks/use-bottom-accessory';
 
 export type ToastVariant = 'success' | 'error' | 'info' | 'warning';
 
@@ -53,26 +54,32 @@ const VARIANT_CONFIG: Record<ToastVariant, { icon: IconName; colorKey: 'success'
 export const Toast = createVariantComponent('Toast', { liquidGlass: ToastGlass, material: ToastMaterial });
 
 /**
- * Reserve the worst-case queue toolbar height on tab screens so a toast never
- * covers the current-climb controls; off tab screens it sits just above the safe
- * area. Shared by both variants — ToastProvider sits above QueueProvider, so this
- * must stay independent from queue context.
+ * On JS-tab screens, reserve the worst-case queue toolbar height so a toast never
+ * covers current-climb controls. NativeTabs folds its own bar/accessory into the
+ * safe-area inset, and off-tab screens use the ordinary safe-area gap. Shared by
+ * both variants — ToastProvider sits above QueueProvider, so this must stay
+ * independent from queue context.
  */
 function useToastBottomOffset(uiVariant: UiVariant) {
   const insets = useSafeAreaInsets();
   const segments = useSegments();
+  // Use the same canonical predicate that selects NativeTabs in the tab layout.
+  // The UI variant alone is insufficient: Liquid Glass falls back to the JS bar
+  // on older iOS versions, Android, and tablets.
+  const usesNativeTabBar = useNativeTabBar();
   const toolbarReserve = selectByVariant(uiVariant, {
     material: MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT,
     liquidGlass: TOOLBAR_RESERVE,
   });
-  // The Material variant's JS nav bar is the taller M3 80dp bar; Liquid Glass uses
-  // the 49pt iOS tab bar. This is an independent recomputation (it sits above
-  // QueueProvider, so it can't use computeBottomChromeMetrics) — keep the tab-bar
-  // term variant-aware to match, or the Material snackbar tucks under the nav bar.
+  // ToastProvider sits above QueueProvider, so it cannot read current-climb state
+  // from computeBottomChromeMetrics and conservatively reserves the JS queue bar.
+  // NativeTabs is different: UIKit has already folded both its tab bar and any
+  // BottomAccessory into `insets.bottom`, so adding either reserve here recreates
+  // #3973. Material and the Liquid Glass JS fallback still need both explicit
+  // terms because their tab/queue bars are outside the UIKit safe-area inset.
   const tabBarHeight = selectByVariant(uiVariant, { material: MATERIAL_TAB_BAR_HEIGHT, liquidGlass: TAB_BAR_HEIGHT });
-  return isTabsRoute(segments)
-    ? insets.bottom + tabBarHeight + toolbarReserve + spacing[2]
-    : insets.bottom + spacing[3];
+  if (!isTabsRoute(segments)) return insets.bottom + spacing[3];
+  return usesNativeTabBar ? insets.bottom + spacing[2] : insets.bottom + tabBarHeight + toolbarReserve + spacing[2];
 }
 
 function ToastMaterial({ toast, onDismiss }: ToastProps) {

--- a/packages/mobile/src/components/Toast.tsx
+++ b/packages/mobile/src/components/Toast.tsx
@@ -16,10 +16,10 @@ import {
   TOOLBAR_RESERVE,
 } from '../theme/layout';
 import type { UiVariant } from '../theme/resolve-ui-variant';
-import { isTabsRoute } from '../lib/route-segments';
+import { isTabsRoute, isTopLevelTabRoute } from '../lib/route-segments';
 import { useTheme } from '../providers/theme-provider';
 import { createVariantComponent, selectByVariant } from '../theme/variants';
-import { useNativeTabBar } from '../hooks/use-bottom-accessory';
+import { isBottomAccessoryAvailable, useNativeTabBar } from '../hooks/use-bottom-accessory';
 
 export type ToastVariant = 'success' | 'error' | 'info' | 'warning';
 
@@ -67,19 +67,28 @@ function useToastBottomOffset(uiVariant: UiVariant) {
   // The UI variant alone is insufficient: Liquid Glass falls back to the JS bar
   // on older iOS versions, Android, and tablets.
   const usesNativeTabBar = useNativeTabBar();
+  const nativeBottomAccessoryAvailable = isBottomAccessoryAvailable();
   const toolbarReserve = selectByVariant(uiVariant, {
     material: MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT,
     liquidGlass: TOOLBAR_RESERVE,
   });
   // ToastProvider sits above QueueProvider, so it cannot read current-climb state
   // from computeBottomChromeMetrics and conservatively reserves the JS queue bar.
-  // NativeTabs is different: UIKit has already folded both its tab bar and any
-  // BottomAccessory into `insets.bottom`, so adding either reserve here recreates
-  // #3973. Material and the Liquid Glass JS fallback still need both explicit
-  // terms because their tab/queue bars are outside the UIKit safe-area inset.
+  // NativeTabs with BottomAccessory is different: UIKit has already folded both
+  // pieces of chrome into `insets.bottom`, so adding either reserve here recreates
+  // #3973. If a native tab bar is available but its BottomAccessory export is not,
+  // the JS PersistentQueueBar takes over on top-level tab routes; preserve that
+  // toolbar reserve without adding the native tab bar a second time. Pushed tab
+  // routes never render PersistentQueueBar, so they keep only the raw native inset.
+  // Material and the Liquid Glass JS fallback still need both explicit terms
+  // because their tab/queue bars are outside the UIKit safe-area inset.
   const tabBarHeight = selectByVariant(uiVariant, { material: MATERIAL_TAB_BAR_HEIGHT, liquidGlass: TAB_BAR_HEIGHT });
   if (!isTabsRoute(segments)) return insets.bottom + spacing[3];
-  return usesNativeTabBar ? insets.bottom + spacing[2] : insets.bottom + tabBarHeight + toolbarReserve + spacing[2];
+  if (usesNativeTabBar) {
+    const jsQueueReserve = !nativeBottomAccessoryAvailable && isTopLevelTabRoute(segments) ? toolbarReserve : 0;
+    return insets.bottom + jsQueueReserve + spacing[2];
+  }
+  return insets.bottom + tabBarHeight + toolbarReserve + spacing[2];
 }
 
 function ToastMaterial({ toast, onDismiss }: ToastProps) {

--- a/packages/mobile/src/components/__tests__/toast.test.tsx
+++ b/packages/mobile/src/components/__tests__/toast.test.tsx
@@ -7,7 +7,9 @@ import { createElement, type ReactNode } from 'react';
 const ctrl = vi.hoisted(() => ({
   variant: 'material' as 'material' | 'liquidGlass',
   nativeTabBar: false,
+  nativeBottomAccessoryAvailable: true,
   insetsBottom: 34,
+  segments: ['(tabs)', 'climbs'] as readonly string[],
 }));
 
 type ViewMockProps = { children?: ReactNode; accessibilityRole?: string };
@@ -64,11 +66,14 @@ vi.mock('react-native-paper', () => ({
     ),
 }));
 
-vi.mock('expo-router', () => ({ useSegments: () => ['(tabs)', 'climbs'] }));
+vi.mock('expo-router', () => ({ useSegments: () => ctrl.segments }));
 vi.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 47, bottom: ctrl.insetsBottom, left: 0, right: 0 }),
 }));
-vi.mock('../../hooks/use-bottom-accessory', () => ({ useNativeTabBar: () => ctrl.nativeTabBar }));
+vi.mock('../../hooks/use-bottom-accessory', () => ({
+  isBottomAccessoryAvailable: () => ctrl.nativeBottomAccessoryAvailable,
+  useNativeTabBar: () => ctrl.nativeTabBar,
+}));
 
 vi.mock('../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', { 'data-text': 'true' }, children),
@@ -88,9 +93,9 @@ vi.mock('../../theme/layout', () => ({
   MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT: 48,
   MATERIAL_TAB_BAR_HEIGHT: 80,
   TAB_BAR_HEIGHT: 49,
-  TOOLBAR_RESERVE: 56,
+  // Production semantics: glassSize.hero(56) + TOOLBAR_GAP_ABOVE_TABBAR(10).
+  TOOLBAR_RESERVE: 66,
 }));
-vi.mock('../../lib/route-segments', () => ({ isTabsRoute: () => true }));
 vi.mock('../../providers/theme-provider', () => ({
   useTheme: () => ({
     variant: ctrl.variant,
@@ -101,14 +106,21 @@ vi.mock('../../providers/theme-provider', () => ({
 }));
 
 import { Toast } from '../Toast';
+import { TAB_BAR_HEIGHT, TOOLBAR_RESERVE } from '../../theme/layout';
+import { spacing } from '../../theme/tokens';
 
 const toast = { id: 't1', message: 'Saved tick', variant: 'success' as const, duration: 3000 };
+// Representative iPhone native-tab inset without BottomAccessory. This is
+// realistic arithmetic, not a device-verified product contract.
+const NATIVE_TAB_ONLY_INSET = 34 + TAB_BAR_HEIGHT;
 
 describe('Toast', () => {
   beforeEach(() => {
     ctrl.variant = 'material';
     ctrl.nativeTabBar = false;
+    ctrl.nativeBottomAccessoryAvailable = true;
     ctrl.insetsBottom = 34;
+    ctrl.segments = ['(tabs)', 'climbs'];
   });
 
   it('renders a Paper Snackbar on the Material variant', () => {
@@ -178,8 +190,10 @@ describe('Toast', () => {
   it('preserves explicit tab and queue reserves on the Liquid Glass JS fallback', () => {
     ctrl.variant = 'liquidGlass';
     const { container } = render(<Toast toast={toast} onDismiss={() => {}} />);
-    // 34 safe area + 49 JS tab bar + 56 floating queue reserve + 8 gap.
-    expect(container.querySelector('[data-animated]')?.getAttribute('data-style')).toContain('"bottom":147');
+    const expectedBottom = 34 + TAB_BAR_HEIGHT + TOOLBAR_RESERVE + spacing[2];
+    expect(container.querySelector('[data-animated]')?.getAttribute('data-style')).toContain(
+      `"bottom":${expectedBottom}`,
+    );
   });
 
   it('does not add native tab or accessory chrome to the measured 139pt UIKit inset (#3973)', () => {
@@ -190,6 +204,33 @@ describe('Toast', () => {
     // 139 already includes the home indicator, native tab bar, and accessory;
     // Toast adds only its 8pt visual gap.
     expect(container.querySelector('[data-animated]')?.getAttribute('data-style')).toContain('"bottom":147');
+  });
+
+  it('clears the JS queue bar when NativeTabs cannot mount a BottomAccessory', () => {
+    ctrl.variant = 'liquidGlass';
+    ctrl.nativeTabBar = true;
+    ctrl.nativeBottomAccessoryAvailable = false;
+    ctrl.insetsBottom = NATIVE_TAB_ONLY_INSET;
+    const { container } = render(<Toast toast={toast} onDismiss={() => {}} />);
+    const expectedBottom = NATIVE_TAB_ONLY_INSET + TOOLBAR_RESERVE + spacing[2];
+    // NativeTabs owns the tab-only inset, while the unavailable BottomAccessory
+    // falls back to the JS queue tray. Do not add TAB_BAR_HEIGHT a second time.
+    expect(container.querySelector('[data-animated]')?.getAttribute('data-style')).toContain(
+      `"bottom":${expectedBottom}`,
+    );
+  });
+
+  it('does not reserve the JS queue bar on a pushed NativeTabs route', () => {
+    ctrl.variant = 'liquidGlass';
+    ctrl.nativeTabBar = true;
+    ctrl.nativeBottomAccessoryAvailable = false;
+    ctrl.insetsBottom = NATIVE_TAB_ONLY_INSET;
+    ctrl.segments = ['(tabs)', 'home', 'session', '[sessionId]'];
+    const { container } = render(<Toast toast={toast} onDismiss={() => {}} />);
+    const expectedBottom = NATIVE_TAB_ONLY_INSET + spacing[2];
+    expect(container.querySelector('[data-animated]')?.getAttribute('data-style')).toContain(
+      `"bottom":${expectedBottom}`,
+    );
   });
 
   it('auto-dismisses via timer on the Liquid Glass variant', () => {

--- a/packages/mobile/src/components/__tests__/toast.test.tsx
+++ b/packages/mobile/src/components/__tests__/toast.test.tsx
@@ -1,10 +1,14 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 
 // Controls the resolved UI variant the Toast branches on.
-const ctrl = vi.hoisted(() => ({ variant: 'material' as 'material' | 'liquidGlass' }));
+const ctrl = vi.hoisted(() => ({
+  variant: 'material' as 'material' | 'liquidGlass',
+  nativeTabBar: false,
+  insetsBottom: 34,
+}));
 
 type ViewMockProps = { children?: ReactNode; accessibilityRole?: string };
 vi.mock('react-native', () => ({
@@ -62,8 +66,9 @@ vi.mock('react-native-paper', () => ({
 
 vi.mock('expo-router', () => ({ useSegments: () => ['(tabs)', 'climbs'] }));
 vi.mock('react-native-safe-area-context', () => ({
-  useSafeAreaInsets: () => ({ top: 47, bottom: 34, left: 0, right: 0 }),
+  useSafeAreaInsets: () => ({ top: 47, bottom: ctrl.insetsBottom, left: 0, right: 0 }),
 }));
+vi.mock('../../hooks/use-bottom-accessory', () => ({ useNativeTabBar: () => ctrl.nativeTabBar }));
 
 vi.mock('../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', { 'data-text': 'true' }, children),
@@ -100,6 +105,12 @@ import { Toast } from '../Toast';
 const toast = { id: 't1', message: 'Saved tick', variant: 'success' as const, duration: 3000 };
 
 describe('Toast', () => {
+  beforeEach(() => {
+    ctrl.variant = 'material';
+    ctrl.nativeTabBar = false;
+    ctrl.insetsBottom = 34;
+  });
+
   it('renders a Paper Snackbar on the Material variant', () => {
     ctrl.variant = 'material';
     const { container } = render(<Toast toast={toast} onDismiss={() => {}} />);
@@ -164,9 +175,20 @@ describe('Toast', () => {
     expect(container.querySelector('[data-paper-snackbar]')).toBeNull();
   });
 
-  it('positions Liquid Glass toasts above the floating toolbar reserve', () => {
+  it('preserves explicit tab and queue reserves on the Liquid Glass JS fallback', () => {
     ctrl.variant = 'liquidGlass';
     const { container } = render(<Toast toast={toast} onDismiss={() => {}} />);
+    // 34 safe area + 49 JS tab bar + 56 floating queue reserve + 8 gap.
+    expect(container.querySelector('[data-animated]')?.getAttribute('data-style')).toContain('"bottom":147');
+  });
+
+  it('does not add native tab or accessory chrome to the measured 139pt UIKit inset (#3973)', () => {
+    ctrl.variant = 'liquidGlass';
+    ctrl.nativeTabBar = true;
+    ctrl.insetsBottom = 139;
+    const { container } = render(<Toast toast={toast} onDismiss={() => {}} />);
+    // 139 already includes the home indicator, native tab bar, and accessory;
+    // Toast adds only its 8pt visual gap.
     expect(container.querySelector('[data-animated]')?.getAttribute('data-style')).toContain('"bottom":147');
   });
 

--- a/packages/mobile/src/components/session/SessionDetailScreen.tsx
+++ b/packages/mobile/src/components/session/SessionDetailScreen.tsx
@@ -30,9 +30,9 @@ const keyExtractor = (tick: SessionDetailTick) => tick.uuid;
 /**
  * Session detail — hero + stats + ticks list. Mounted from a per-tab route
  * (`home/session/[sessionId]`, `profile/session/[sessionId]`) so it pushes inside
- * the tab stack and keeps the native tab bar + Liquid Glass bottom accessory on
- * screen (matching the playlist detail view), rather than a root push that slides
- * the tab bar away.
+ * the tab stack and keeps the tab bar on screen, rather than a root push that
+ * slides it away. Pushed routes are intentionally not accessory surfaces, so the
+ * Liquid Glass BottomAccessory unmounts here.
  */
 export default function SessionDetailScreen() {
   const { sessionId } = useLocalSearchParams<{ sessionId: string }>();
@@ -42,9 +42,9 @@ export default function SessionDetailScreen() {
   const router = useRouter();
   const { openPlayDrawer } = useDrawerHost();
   const bottomChrome = useBottomChromeMetrics();
-  // floatingControlBottom (not scrollBottomPadding) reserves the iOS-26 native
-  // accessory — the now-playing bar — so the last sends clear it instead of
-  // hiding behind it.
+  // Session detail is a pushed route without queue/accessory chrome. Use the
+  // floating-control metric so the final row clears whichever tab bar is actually
+  // rendered: UIKit's raw inset for NativeTabs, or the explicit JS bar height.
   const paddingBottom = bottomChrome.floatingControlBottom + spacing[6];
 
   const { data: session, isPending } = useSessionDetail(sessionId);

--- a/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
+++ b/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
@@ -15,7 +15,8 @@ const DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET = 139;
 // An intentionally non-device value used only to prove that the pure function
 // treats a native UIKit inset as opaque and does not add TAB_BAR_HEIGHT to it.
 // Keep it distinct from the 139pt device anchor so arithmetic fixtures cannot be
-// mistaken for a measured no-accessory or minimized-tab contract.
+// mistaken for a measured no-accessory or minimized-tab contract. The plausible
+// 83pt value (34pt home indicator + 49pt tab bar) is still inferred, not measured.
 const SYNTHETIC_NATIVE_SAFE_AREA_INSET = 100;
 
 describe('computeBottomChromeMetrics', () => {
@@ -274,6 +275,10 @@ describe('computeBottomChromeMetrics', () => {
         hasCurrentClimb: true,
         nativeAccessoryMounted: true,
       });
+      // Before #3973, preSessionFooterBottom was intentionally smaller than
+      // fixedFooterBottom because the latter double-counted native chrome. Once the
+      // UIKit inset is treated as opaque, equality is the invariant: both consumers
+      // clear the same already-composed native tab/accessory region.
       expect(metrics.preSessionFooterBottom).toBe(DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET);
       expect(metrics.fixedFooterBottom).toBe(DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET);
       // Native accessory mounted → no JS queue reserve, so the list also rides the raw inset.

--- a/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
+++ b/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
@@ -4,15 +4,18 @@ import {
   MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT,
   MATERIAL_TAB_BAR_HEIGHT,
   TAB_BAR_HEIGHT,
-  TOOLBAR_GAP_ABOVE_TABBAR,
   TOOLBAR_RESERVE,
   floatingContextBarBottom,
   glassSize,
 } from '../../theme/layout';
 
-// Assert the arbitration in terms of the layout constants (not magic numbers) so
-// this stays correct when the glass-size ladder is retuned.
-const NATIVE_ACCESSORY_RESERVE = glassSize.standard + TOOLBAR_GAP_ABOVE_TABBAR;
+// The only device-measured native inset in this suite. Do not turn inferred
+// no-accessory/minimized values into product contracts without iOS 26 hardware QA.
+const DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET = 139;
+// A plausible 34pt home-indicator + 49pt tab-bar arithmetic fixture. This is NOT
+// an on-device measurement; it is used only to prove that the pure function treats
+// a native UIKit inset as opaque and does not add TAB_BAR_HEIGHT to it.
+const SYNTHETIC_NATIVE_SAFE_AREA_INSET = 83;
 
 describe('computeBottomChromeMetrics', () => {
   it('reserves nothing extra outside the tabs group', () => {
@@ -38,7 +41,7 @@ describe('computeBottomChromeMetrics', () => {
     const metrics = computeBottomChromeMetrics({
       uiVariant: 'liquidGlass',
       usesNativeTabBar: true,
-      insetsBottom: 0,
+      insetsBottom: SYNTHETIC_NATIVE_SAFE_AREA_INSET,
       insideTabs: true,
       onAccessorySurface: true,
       hasCurrentClimb: true,
@@ -46,9 +49,9 @@ describe('computeBottomChromeMetrics', () => {
     });
     expect(metrics.jsQueueToolbarVisible).toBe(true);
     expect(metrics.jsQueueReserve).toBe(TOOLBAR_RESERVE);
-    expect(metrics.scrollBottomPadding).toBe(TAB_BAR_HEIGHT + TOOLBAR_RESERVE);
-    expect(metrics.floatingControlBottom).toBe(TAB_BAR_HEIGHT + TOOLBAR_RESERVE);
-    expect(metrics.fixedFooterBottom).toBe(TAB_BAR_HEIGHT + TOOLBAR_RESERVE);
+    expect(metrics.scrollBottomPadding).toBe(SYNTHETIC_NATIVE_SAFE_AREA_INSET + TOOLBAR_RESERVE);
+    expect(metrics.floatingControlBottom).toBe(SYNTHETIC_NATIVE_SAFE_AREA_INSET + TOOLBAR_RESERVE);
+    expect(metrics.fixedFooterBottom).toBe(SYNTHETIC_NATIVE_SAFE_AREA_INSET + TOOLBAR_RESERVE);
   });
 
   it('clears the JS Material tab bar for Liquid Glass on a non-capable device', () => {
@@ -91,11 +94,13 @@ describe('computeBottomChromeMetrics', () => {
     expect(metrics.fixedFooterBottom).toBe(MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT);
   });
 
-  it('does not pad scroll content for the UIKit-owned native accessory', () => {
+  it('anchors every native-tab offset to the UIKit safe-area inset, including the 139pt accessory anchor (#3973)', () => {
     const metrics = computeBottomChromeMetrics({
       uiVariant: 'liquidGlass',
       usesNativeTabBar: true,
-      insetsBottom: 0,
+      // iPhone 17 Pro / iOS 26 with the BottomAccessory: 34 home indicator +
+      // 49 native tab bar + 56 accessory. UIKit has already included all three.
+      insetsBottom: DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET,
       insideTabs: true,
       onAccessorySurface: true,
       hasCurrentClimb: true,
@@ -104,12 +109,12 @@ describe('computeBottomChromeMetrics', () => {
     expect(metrics.nativeAccessoryVisible).toBe(true);
     expect(metrics.jsQueueToolbarVisible).toBe(false);
     expect(metrics.jsQueueReserve).toBe(0);
-    // UIKit adds the accessory inset itself, so scroll padding is just the tab bar.
-    expect(metrics.scrollBottomPadding).toBe(TAB_BAR_HEIGHT);
-    // But floating controls must still clear the accessory.
-    expect(metrics.nativeAccessoryReserve).toBe(NATIVE_ACCESSORY_RESERVE);
-    expect(metrics.floatingControlBottom).toBe(TAB_BAR_HEIGHT + NATIVE_ACCESSORY_RESERVE);
-    expect(metrics.fixedFooterBottom).toBe(TAB_BAR_HEIGHT + NATIVE_ACCESSORY_RESERVE);
+    expect(metrics.tabBarHeight).toBe(TAB_BAR_HEIGHT);
+    expect(metrics.tabBarBottom).toBe(DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET);
+    expect(metrics.nativeAccessoryReserve).toBe(0);
+    expect(metrics.scrollBottomPadding).toBe(DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET);
+    expect(metrics.floatingControlBottom).toBe(DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET);
+    expect(metrics.fixedFooterBottom).toBe(DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET);
   });
 
   it('hides the bar but keeps tab-bar clearance on a pushed sub-route (Material)', () => {
@@ -137,7 +142,7 @@ describe('computeBottomChromeMetrics', () => {
     const metrics = computeBottomChromeMetrics({
       uiVariant: 'liquidGlass',
       usesNativeTabBar: true,
-      insetsBottom: 0,
+      insetsBottom: SYNTHETIC_NATIVE_SAFE_AREA_INSET,
       insideTabs: true,
       onAccessorySurface: false,
       hasCurrentClimb: true,
@@ -147,7 +152,7 @@ describe('computeBottomChromeMetrics', () => {
     expect(metrics.jsQueueToolbarVisible).toBe(false);
     expect(metrics.jsQueueReserve).toBe(0);
     expect(metrics.tabBarHeight).toBe(TAB_BAR_HEIGHT);
-    expect(metrics.scrollBottomPadding).toBe(TAB_BAR_HEIGHT);
+    expect(metrics.scrollBottomPadding).toBe(SYNTHETIC_NATIVE_SAFE_AREA_INSET);
   });
 
   it('reserves no queue chrome for fixed footers outside the tabs group', () => {
@@ -174,7 +179,7 @@ describe('computeBottomChromeMetrics', () => {
     const metrics = computeBottomChromeMetrics({
       uiVariant: 'liquidGlass',
       usesNativeTabBar: true,
-      insetsBottom: 34,
+      insetsBottom: SYNTHETIC_NATIVE_SAFE_AREA_INSET,
       insideTabs: true,
       onAccessorySurface: true,
       hasCurrentClimb: false,
@@ -182,9 +187,9 @@ describe('computeBottomChromeMetrics', () => {
     });
     expect(metrics.jsQueueToolbarVisible).toBe(false);
     expect(metrics.nativeAccessoryVisible).toBe(false); // mounted, but no climb to show
-    expect(metrics.scrollBottomPadding).toBe(34 + TAB_BAR_HEIGHT);
-    expect(metrics.floatingControlBottom).toBe(34 + TAB_BAR_HEIGHT);
-    expect(metrics.fixedFooterBottom).toBe(34 + TAB_BAR_HEIGHT);
+    expect(metrics.scrollBottomPadding).toBe(SYNTHETIC_NATIVE_SAFE_AREA_INSET);
+    expect(metrics.floatingControlBottom).toBe(SYNTHETIC_NATIVE_SAFE_AREA_INSET);
+    expect(metrics.fixedFooterBottom).toBe(SYNTHETIC_NATIVE_SAFE_AREA_INSET);
   });
 
   it('keeps scroll tab clearance but not fixed-footer tab clearance inside Material tabs', () => {
@@ -210,7 +215,7 @@ describe('computeBottomChromeMetrics', () => {
     const metrics = computeBottomChromeMetrics({
       uiVariant: 'liquidGlass',
       usesNativeTabBar: true,
-      insetsBottom: 0,
+      insetsBottom: DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET,
       insideTabs: true,
       onAccessorySurface: true,
       hasCurrentClimb: true,
@@ -227,7 +232,8 @@ describe('computeBottomChromeMetrics', () => {
           const metrics = computeBottomChromeMetrics({
             uiVariant: 'liquidGlass',
             usesNativeTabBar: true,
-            insetsBottom: 0,
+            // Geometry is irrelevant to this visibility-only total-function test.
+            insetsBottom: SYNTHETIC_NATIVE_SAFE_AREA_INSET,
             insideTabs: true,
             onAccessorySurface,
             hasCurrentClimb,
@@ -255,22 +261,22 @@ describe('computeBottomChromeMetrics', () => {
     });
 
     it('anchors Liquid Glass to the raw inset and never double-counts the tab bar', () => {
-      // iPhone 17 Pro / iOS 26: the glass tab bar already extends the inset, so the
-      // footer is the raw inset — NOT fixedFooterBottom, which would add the bar again.
+      // iPhone 17 Pro / iOS 26: the glass tab bar already extends the inset, so every
+      // bottom metric anchors to the raw value rather than adding chrome again.
       const metrics = computeBottomChromeMetrics({
         uiVariant: 'liquidGlass',
         usesNativeTabBar: true,
-        insetsBottom: 139,
+        insetsBottom: DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET,
         insideTabs: true,
         onAccessorySurface: true,
         hasCurrentClimb: true,
         nativeAccessoryMounted: true,
       });
-      expect(metrics.preSessionFooterBottom).toBe(139);
-      expect(metrics.preSessionFooterBottom).toBeLessThan(metrics.fixedFooterBottom);
+      expect(metrics.preSessionFooterBottom).toBe(DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET);
+      expect(metrics.fixedFooterBottom).toBe(DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET);
       // Native accessory mounted → no JS queue reserve, so the list also rides the raw inset.
       expect(metrics.jsQueueReserve).toBe(0);
-      expect(metrics.inSessionListBottom).toBe(139);
+      expect(metrics.inSessionListBottom).toBe(DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET);
     });
 
     it('adds the JS queue reserve to both Liquid Glass session bottoms when the accessory is unavailable', () => {
@@ -368,7 +374,9 @@ describe('computeBottomChromeMetrics', () => {
                       yield {
                         uiVariant,
                         usesNativeTabBar,
-                        insetsBottom: 34,
+                        // Synthetic for the total-function matrix: realistic device
+                        // states are pinned separately above.
+                        insetsBottom: SYNTHETIC_NATIVE_SAFE_AREA_INSET,
                         insideTabs,
                         onAccessorySurface,
                         hasCurrentClimb,
@@ -414,6 +422,33 @@ describe('computeBottomChromeMetrics', () => {
       }
       expect(drifted).toEqual([]);
     });
+
+    it('never adds native-tab chrome beyond the UIKit safe area', () => {
+      // Use the full input cross-product at one synthetic opaque inset and at the
+      // on-device 139pt anchor. On the NativeTabs path UIKit's safe area already
+      // covers the 49pt tab bar and,
+      // when present, the 56pt BottomAccessory. The only extra bottom reserve
+      // this function may add is a JS queue tray in a transitional/fallback
+      // state; it must never add native chrome again.
+      const doubleCounted = [];
+      for (const insetsBottom of [SYNTHETIC_NATIVE_SAFE_AREA_INSET, DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET]) {
+        for (const inputs of allInputs()) {
+          if (!inputs.usesNativeTabBar || !inputs.insideTabs || inputs.usesSidebar) continue;
+          const metrics = computeBottomChromeMetrics({ ...inputs, insetsBottom });
+          const expectedBottom = insetsBottom + metrics.jsQueueReserve;
+          if (
+            metrics.tabBarBottom !== insetsBottom ||
+            metrics.nativeAccessoryReserve !== 0 ||
+            metrics.scrollBottomPadding !== expectedBottom ||
+            metrics.floatingControlBottom !== expectedBottom ||
+            metrics.fixedFooterBottom !== expectedBottom
+          ) {
+            doubleCounted.push({ inputs: { ...inputs, insetsBottom }, metrics, expectedBottom });
+          }
+        }
+      }
+      expect(doubleCounted).toEqual([]);
+    });
   });
 
   describe('regular-width iPad sidebar (usesSidebar)', () => {
@@ -422,7 +457,7 @@ describe('computeBottomChromeMetrics', () => {
       // footer, so nothing floats at the bottom — every offset is the raw inset.
       const metrics = computeBottomChromeMetrics({
         uiVariant: 'liquidGlass',
-        usesNativeTabBar: true,
+        usesNativeTabBar: false,
         insetsBottom: 20,
         insideTabs: true,
         onAccessorySurface: true,
@@ -492,7 +527,7 @@ describe('computeBottomChromeMetrics', () => {
       const withFlag = computeBottomChromeMetrics({
         uiVariant: 'liquidGlass',
         usesNativeTabBar: true,
-        insetsBottom: 34,
+        insetsBottom: SYNTHETIC_NATIVE_SAFE_AREA_INSET,
         insideTabs: true,
         onAccessorySurface: true,
         hasCurrentClimb: false,
@@ -502,14 +537,14 @@ describe('computeBottomChromeMetrics', () => {
       const withoutFlag = computeBottomChromeMetrics({
         uiVariant: 'liquidGlass',
         usesNativeTabBar: true,
-        insetsBottom: 34,
+        insetsBottom: SYNTHETIC_NATIVE_SAFE_AREA_INSET,
         insideTabs: true,
         onAccessorySurface: true,
         hasCurrentClimb: false,
         nativeAccessoryMounted: false,
       });
       expect(withFlag).toEqual(withoutFlag);
-      expect(withoutFlag.scrollBottomPadding).toBe(34 + TAB_BAR_HEIGHT);
+      expect(withoutFlag.scrollBottomPadding).toBe(SYNTHETIC_NATIVE_SAFE_AREA_INSET);
     });
   });
 });

--- a/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
+++ b/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
@@ -12,11 +12,11 @@ import {
 // The only device-measured native inset in this suite. Do not turn inferred
 // no-accessory/minimized values into product contracts without iOS 26 hardware QA.
 const DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET = 139;
-// A plausible 34pt home-indicator + 49pt tab-bar arithmetic fixture. Although
-// that sum matches a typical no-accessory inset, this exact state has not been
-// measured in this suite. It is used only to prove that the pure function treats
-// a native UIKit inset as opaque and does not add TAB_BAR_HEIGHT to it.
-const SYNTHETIC_NATIVE_SAFE_AREA_INSET = 83;
+// An intentionally non-device value used only to prove that the pure function
+// treats a native UIKit inset as opaque and does not add TAB_BAR_HEIGHT to it.
+// Keep it distinct from the 139pt device anchor so arithmetic fixtures cannot be
+// mistaken for a measured no-accessory or minimized-tab contract.
+const SYNTHETIC_NATIVE_SAFE_AREA_INSET = 100;
 
 describe('computeBottomChromeMetrics', () => {
   it('reserves nothing extra outside the tabs group', () => {
@@ -116,6 +116,7 @@ describe('computeBottomChromeMetrics', () => {
     expect(metrics.scrollBottomPadding).toBe(DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET);
     expect(metrics.floatingControlBottom).toBe(DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET);
     expect(metrics.fixedFooterBottom).toBe(DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET);
+    expect(metrics.preSessionFooterBottom).toBe(DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET);
   });
 
   it('hides the bar but keeps tab-bar clearance on a pushed sub-route (Material)', () => {

--- a/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
+++ b/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
@@ -12,8 +12,9 @@ import {
 // The only device-measured native inset in this suite. Do not turn inferred
 // no-accessory/minimized values into product contracts without iOS 26 hardware QA.
 const DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET = 139;
-// A plausible 34pt home-indicator + 49pt tab-bar arithmetic fixture. This is NOT
-// an on-device measurement; it is used only to prove that the pure function treats
+// A plausible 34pt home-indicator + 49pt tab-bar arithmetic fixture. Although
+// that sum matches a typical no-accessory inset, this exact state has not been
+// measured in this suite. It is used only to prove that the pure function treats
 // a native UIKit inset as opaque and does not add TAB_BAR_HEIGHT to it.
 const SYNTHETIC_NATIVE_SAFE_AREA_INSET = 83;
 
@@ -494,6 +495,29 @@ describe('computeBottomChromeMetrics', () => {
       expect(metrics.scrollBottomPadding).toBe(0);
       expect(metrics.floatingControlBottom).toBe(0);
       expect(metrics.nativeAccessoryMounted).toBe(false);
+    });
+
+    it('ignores a native-tab signal when the iPad sidebar owns navigation', () => {
+      // The shell should not report both today, but keep this total-function
+      // combination pinned: the sidebar branch wins before phone tab/accessory
+      // arithmetic and therefore adds no native chrome.
+      const metrics = computeBottomChromeMetrics({
+        uiVariant: 'liquidGlass',
+        usesNativeTabBar: true,
+        insetsBottom: 20,
+        insideTabs: true,
+        onAccessorySurface: true,
+        hasCurrentClimb: true,
+        nativeAccessoryMounted: true,
+        usesSidebar: true,
+      });
+      expect(metrics.tabBarHeight).toBe(0);
+      expect(metrics.tabBarBottom).toBe(20);
+      expect(metrics.nativeAccessoryMounted).toBe(false);
+      expect(metrics.nativeAccessoryReserve).toBe(0);
+      expect(metrics.scrollBottomPadding).toBe(20);
+      expect(metrics.floatingControlBottom).toBe(20);
+      expect(metrics.fixedFooterBottom).toBe(20);
     });
 
     it('keeps the JS queue toolbar when the sidebar is visible but the detail pane is suppressed', () => {

--- a/packages/mobile/src/hooks/bottom-chrome-metrics.ts
+++ b/packages/mobile/src/hooks/bottom-chrome-metrics.ts
@@ -67,9 +67,18 @@ export type BottomChromeMetrics = {
   nativeAccessoryMounted: boolean;
   nativeAccessoryVisible: boolean;
   jsQueueToolbarVisible: boolean;
+  /** Physical height of the rendered bottom tab bar; zero outside tabs/sidebar mode. */
   tabBarHeight: number;
+  /**
+   * Bottom clearance through the tab bar. NativeTabs returns the raw UIKit inset
+   * because it already contains native chrome; JS tabs add their in-flow height.
+   */
   tabBarBottom: number;
   jsQueueReserve: number;
+  /**
+   * Accessory clearance not already present in the safe-area inset. This is zero
+   * on the real NativeTabs path because UIKit owns and insets BottomAccessory.
+   */
   nativeAccessoryReserve: number;
   /** Bottom padding for scroll views so the last row clears the tab bar + JS toolbar. */
   scrollBottomPadding: number;
@@ -77,8 +86,8 @@ export type BottomChromeMetrics = {
   floatingControlBottom: number;
   /**
    * Bottom padding for fixed footers. NativeTabs overlays content, so fixed
-   * footers clear the tab bar there. Material JS tabs are in flow, so fixed
-   * footers clear only active queue/accessory chrome.
+   * footers use the raw UIKit inset that already clears native chrome. Material
+   * JS tabs are in flow, so fixed footers clear only active queue chrome.
    */
   fixedFooterBottom: number;
   /**
@@ -99,10 +108,10 @@ export type BottomChromeMetrics = {
    * Verified on-device (iPhone 17 Pro / iOS 26): with the native tab bar + climb
    * accessory present, the safe-area bottom inset is 139 = home indicator (34) +
    * tab bar (49) + accessory (56) — the glass tab bar extends the UIKit safe area.
-   * `fixedFooterBottom` would add the tab bar + accessory a second time (246),
-   * stranding the control ~110px up the screen — hence the raw inset on glass.
-   * That evidence covers the *native tab bar* path only, where `jsQueueReserve`
-   * is 0 (the accessory owns the climb) so this stays exactly 139.
+   * Every native-tab metric starts at that raw inset, rather than adding either
+   * piece of UIKit-owned chrome again; only separately rendered JS queue chrome
+   * may add a reserve. That evidence covers the *native tab bar* path with the
+   * accessory, where `jsQueueReserve` is 0, so this stays exactly 139.
    *
    * On the JS-tab-bar fallback (iOS < 26, non-glass-capable iPhones, iPad in a
    * narrow split, Android forced to Liquid Glass) the floating
@@ -172,12 +181,16 @@ export function computeBottomChromeMetrics({
   const jsQueueToolbarVisible = onAccessorySurface && hasCurrentClimb && !effectiveNativeAccessoryMounted;
   // The native iOS tab bar is 49pt; the JS M3 `MaterialTabBar` is taller. Key this
   // on the *rendered* bar, not the variant — Liquid Glass on iOS < 26 / Android
-  // falls back to the JS bar. Floating overlays (FAB, snackbar) and scroll padding
-  // clear this height, so it has to track the real bar on screen.
+  // falls back to the JS bar. `tabBarHeight` describes the rendered bar, while
+  // `tabBarBottom` is the full clearance from the screen bottom: the opaque raw
+  // inset for NativeTabs, or raw inset + JS bar height for the fallback.
   const tabBarConstant = usesNativeTabBar ? TAB_BAR_HEIGHT : MATERIAL_TAB_BAR_HEIGHT;
   const tabBarHeight = insideTabs && !usesSidebar ? tabBarConstant : 0;
   // Only the native tab bar overlays content (UIKit draws it over the scroll view);
-  // the JS `MaterialTabBar` sits in flow.
+  // the JS `MaterialTabBar` sits in flow. NativeTabs extends UIKit's safe-area
+  // inset to include both the bar and its BottomAccessory, so neither is an
+  // additional bottom offset. On-device, that inset is 139pt with an accessory on
+  // an iPhone 17 Pro (34 home indicator + 49 tab bar + 56 accessory).
   const tabBarOverlaysContent = insideTabs && usesNativeTabBar;
   // The Material bar reserves its full height even though it's tucked ~2px into the
   // tab bar (MATERIAL_TABBAR_OVERLAP in persistent-queue-bar), so its visible height
@@ -186,8 +199,15 @@ export function computeBottomChromeMetrics({
   // this pure arbitration. Don't "fix" it by subtracting the overlap here.
   const jsQueueToolbarReserve = uiVariant === 'material' ? MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT : TOOLBAR_RESERVE;
   const jsQueueReserve = jsQueueToolbarVisible ? jsQueueToolbarReserve : 0;
-  const nativeAccessoryReserve = nativeAccessoryVisible ? glassSize.standard + TOOLBAR_GAP_ABOVE_TABBAR : 0;
-  const tabBarBottom = insetsBottom + tabBarHeight;
+  // A native accessory is UIKit-owned and already folded into `insetsBottom` on
+  // the real NativeTabs path. Keep this field as an *additional* reserve so every
+  // offset below can use one shared formula without double-counting it. The
+  // non-overlay branch only keeps this pure total function conservative if a
+  // future or synthetic caller supplies the otherwise-inconsistent combination
+  // "native accessory visible without NativeTabs".
+  const nativeAccessoryReserve =
+    nativeAccessoryVisible && !tabBarOverlaysContent ? glassSize.standard + TOOLBAR_GAP_ABOVE_TABBAR : 0;
+  const tabBarBottom = insetsBottom + (tabBarOverlaysContent ? 0 : tabBarHeight);
   const activeQueueChromeReserve = Math.max(jsQueueReserve, nativeAccessoryReserve);
   const contentInsetBottom = tabBarOverlaysContent || !insideTabs ? tabBarBottom : 0;
   const fixedFooterBottom = contentInsetBottom + activeQueueChromeReserve;
@@ -202,8 +222,8 @@ export function computeBottomChromeMetrics({
     tabBarBottom,
     jsQueueReserve,
     nativeAccessoryReserve,
-    scrollBottomPadding: insetsBottom + tabBarHeight + jsQueueReserve,
-    floatingControlBottom: insetsBottom + tabBarHeight + Math.max(jsQueueReserve, nativeAccessoryReserve),
+    scrollBottomPadding: tabBarBottom + jsQueueReserve,
+    floatingControlBottom: tabBarBottom + Math.max(jsQueueReserve, nativeAccessoryReserve),
     fixedFooterBottom,
     // selectByVariant (vs a raw ternary) keeps these exhaustive: a new UiVariant is
     // a compile error here, since this file is outside the components/ guard scope.

--- a/packages/mobile/src/lib/session-feed-navigation.ts
+++ b/packages/mobile/src/lib/session-feed-navigation.ts
@@ -4,8 +4,9 @@ import type { SessionFeedItem } from '@boardsesh/shared-schema';
 type Router = ReturnType<typeof useRouter>;
 
 // Session detail lives once per tab stack (Home, Profile) so the push stays inside
-// the tab and keeps the native tab bar + bottom accessory on screen. Each feed
-// passes the route for its own tab so the detail lands in that tab's back stack.
+// the tab and keeps the native tab bar on screen; pushed-route accessory/queue
+// chrome unmounts. Each feed passes the route for its own tab so the detail lands
+// in that tab's back stack.
 export type SessionDetailPathname = '/home/session/[sessionId]' | '/profile/session/[sessionId]';
 
 export function navigateToSessionFeedItem(

--- a/packages/mobile/src/providers/__tests__/toast-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/toast-provider.test.tsx
@@ -25,6 +25,7 @@ vi.mock('expo-router', () => ({
 }));
 
 vi.mock('../../hooks/use-bottom-accessory', () => ({
+  isBottomAccessoryAvailable: () => false,
   useNativeTabBar: () => false,
 }));
 

--- a/packages/mobile/src/providers/__tests__/toast-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/toast-provider.test.tsx
@@ -24,6 +24,10 @@ vi.mock('expo-router', () => ({
   useSegments: () => ['(tabs)', 'climbs'],
 }));
 
+vi.mock('../../hooks/use-bottom-accessory', () => ({
+  useNativeTabBar: () => false,
+}));
+
 vi.mock('../../components/Icon', () => ({
   Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }),
 }));


### PR DESCRIPTION
## Summary

- Treat the iOS 26 native tab-bar inset as opaque instead of adding tab and accessory heights a second time.
- Use the same native-tab predicate for scroll padding, floating/fixed controls, and Toast placement.
- Preserve existing Material, sidebar, and JavaScript Liquid Glass fallback geometry.
- Correct pushed-session route documentation to match the actual accessory mount gate.

Closes #3973

## Release Notes

Keep controls, lists, and messages tucked above the iOS tab bar without the extra gap.

## Test plan

- Focused bottom-chrome and Toast tests: 32 passed
- `vp check` on all 10 changed files
- `vp run typecheck:mobile`
- `vp run test:mobile` (clean rerun; isolated auth-provider retry also passed 38/38)
- `vp run check:mobile-bundle` (iOS and Android passed; existing expo-share-intent SDK warning only)
- Independent code review: pass
- [ ] iOS 26 device: record raw bottom inset and screenshot top-level route with active accessory (known measured reference: 139 pt)
- [ ] iOS 26 device: capture top-level route without an active climb
- [ ] iOS 26 device: verify pushed Session Detail last-row clearance
- [ ] iOS 26 device: verify minimized tab state after scrolling
- [ ] iOS 26 device: verify QueueAddedSnackbar and Toast clearance
