### PR TITLE
fix(mobile): keep dense profile charts scrollable

### DIFF
--- a/packages/mobile/src/components/you/YouCharts.tsx
+++ b/packages/mobile/src/components/you/YouCharts.tsx
@@ -32,20 +32,8 @@ const AXIS_LABEL_SIZE = 11;
 const STACK_BAR_RADIUS = 3;
 const MIN_ZOOM_SCALE = 1;
 const MAX_ZOOM_SCALE = 2.75;
-// gifted-charts does NOT lay its chart out inside the `width` prop we hand it.
-// BarAndLineChartsWrapper positions the plot ScrollView absolutely at
-// `marginLeft: yAxisLabelWidth + yAxisThickness` with `width: props.width`, and
-// renderHorizSections draws the rules/x-axis row as a `yAxisLabelWidth` spacer
-// followed by a `props.width + endSpacing` band. So the span the chart really
-// occupies is `yAxisLabelWidth + width + endSpacing` — all three have to come
-// out of the measured frame or the last bar and its label bleed past the
-// rounded card edge (#3778, #3050). We pin `endSpacing={0}` (it otherwise
-// defaults to `spacing`, and to 20 on the grouped chart, which passes spacing
-// per-datum), subtract the y-axis gutter below, and keep a small inset as slack.
+// gifted-charts renders its y-axis gutter outside `width`, so budget both against the measured frame.
 const CHART_WIDTH_INSET = 8;
-// Gutter reserved for the y-axis scale labels when `showYAxisScale` is set.
-// Passed straight to BarChart's `yAxisLabelWidth` so the number we budget for
-// and the number gifted-charts offsets the plot by can never drift apart.
 const Y_AXIS_LABEL_WIDTH = 32;
 // Floor for grouped flash|redpoint bars so a dense V0-V17 axis keeps each bar
 // above the iOS 44pt / Android 48dp touch target instead of shrinking to 4px.
@@ -403,9 +391,12 @@ export const StackedBarChart = memo(function StackedBarChart({
           {(width, zoomScale, scrollEnabled) => {
             const axisGutter = showYAxisScale ? Y_AXIS_LABEL_WIDTH : 0;
             const chartWidth = width - CHART_WIDTH_INSET - axisGutter;
+            const initialSpacing = 8;
             const fitted = fitBars(chartWidth, stackData.length, minBarWidth);
             const barWidth = Math.max(minBarWidth, Math.round(fitted.barWidth * zoomScale));
             const spacing = Math.max(2, Math.round(fitted.spacing * zoomScale));
+            const contentWidth =
+              initialSpacing + stackData.length * barWidth + Math.max(0, stackData.length - 1) * spacing;
             // gifted sizes each x-axis label box to ~one bar by default, so a wide
             // week label ("W23 '24") on a 5px bar clips to "...". Give every KEPT
             // label the full downsample-step width so it renders in full; blanked
@@ -422,7 +413,7 @@ export const StackedBarChart = memo(function StackedBarChart({
                 height={height - 28}
                 barWidth={barWidth}
                 spacing={spacing}
-                initialSpacing={8}
+                initialSpacing={initialSpacing}
                 endSpacing={0}
                 hideRules={!showYAxisScale}
                 hideYAxisText={!showYAxisScale}
@@ -441,7 +432,7 @@ export const StackedBarChart = memo(function StackedBarChart({
                 lowlightOpacity={opacity.peek}
                 onBackgroundPress={interactive ? () => setSelectedIndex(null) : undefined}
                 isAnimated={false}
-                disableScroll={!scrollEnabled}
+                disableScroll={!(scrollEnabled || contentWidth > chartWidth)}
                 disablePress={!interactive}
               />
             );
@@ -534,6 +525,11 @@ export const GroupedBarChart = memo(function GroupedBarChart({
             const barWidth = Math.max(MIN_GROUPED_BAR, Math.round(baseBarWidth * zoomScale));
             const zoomedGroupGap = Math.max(groupGap, Math.round(groupGap * zoomScale));
             const zoomedInnerGap = Math.max(innerGap, Math.round(innerGap * zoomScale));
+            const contentWidth =
+              initial +
+              list.length * 2 * barWidth +
+              list.length * zoomedInnerGap +
+              Math.max(0, list.length - 1) * zoomedGroupGap;
             // A count may spill into the gap beside its bar; past that it turns
             // vertical rather than getting clipped (#3779).
             const labelLayout = computeBarTopLabelLayout(
@@ -582,10 +578,6 @@ export const GroupedBarChart = memo(function GroupedBarChart({
                 topLabelContainerStyle={{ width: labelLayout.width, left: labelLayout.left }}
                 hideRules
                 hideYAxisText
-                // `hideYAxisText` alone still reserves gifted-charts'
-                // `yAxisEmptyLabelWidth` (10px) to the left of the plot, which
-                // lands outside `width`. Pin it to 0 so `chartWidth` is the
-                // whole occupied span (#3778, #3050).
                 yAxisLabelWidth={0}
                 maxValue={yAxisMaxValue}
                 yAxisThickness={0}
@@ -598,7 +590,7 @@ export const GroupedBarChart = memo(function GroupedBarChart({
                 lowlightOpacity={CHART_LOWLIGHT_OPACITY}
                 onBackgroundPress={interactive ? () => setSelectedIndex(null) : undefined}
                 isAnimated={false}
-                disableScroll={!scrollEnabled}
+                disableScroll={!(scrollEnabled || contentWidth > chartWidth)}
                 disablePress={!interactive}
               />
             );
@@ -796,12 +788,6 @@ const styles = StyleSheet.create({
     position: 'relative',
     alignItems: 'center',
     justifyContent: 'center',
-    // Second layer behind the width budgeting above: if a future gifted-charts
-    // version reserves gutter we didn't account for, it gets clipped at the
-    // frame instead of bleeding past the rounded card edge (#3778, #3050). The
-    // reset-zoom button sits inside the frame and the tooltip overlay is a
-    // sibling on `chartShell`, so neither is affected.
-    overflow: 'hidden',
   },
   emptyState: {
     alignItems: 'center',

--- a/packages/mobile/src/components/you/YouCharts.tsx
+++ b/packages/mobile/src/components/you/YouCharts.tsx
@@ -32,9 +32,11 @@ const AXIS_LABEL_SIZE = 11;
 const STACK_BAR_RADIUS = 3;
 const MIN_ZOOM_SCALE = 1;
 const MAX_ZOOM_SCALE = 2.75;
-// gifted-charts renders its y-axis gutter outside `width`, so budget both against the measured frame.
+// gifted-charts offsets the gutter outside `width`, so keep both inside the measured frame with 8px slack.
 const CHART_WIDTH_INSET = 8;
+// Use this for both the width budget and BarChart prop so the visible gutter cannot drift.
 const Y_AXIS_LABEL_WIDTH = 32;
+const CHART_INITIAL_SPACING = 8;
 // Floor for grouped flash|redpoint bars so a dense V0-V17 axis keeps each bar
 // above the iOS 44pt / Android 48dp touch target instead of shrinking to 4px.
 const MIN_GROUPED_BAR = 6;
@@ -60,8 +62,7 @@ function downsampleLabel(index: number, total: number, label: string, max: numbe
 function fitBars(width: number, count: number, minBar = 3): { barWidth: number; spacing: number } {
   if (count <= 0 || width <= 0) return { barWidth: minBar, spacing: 2 };
   const spacing = count > 26 ? 2 : count > 12 ? 4 : 8;
-  const initial = 8;
-  const available = width - initial * 2 - spacing * (count - 1);
+  const available = width - CHART_INITIAL_SPACING - spacing * (count - 1);
   const barWidth = Math.max(minBar, Math.floor(available / count));
   return { barWidth, spacing };
 }
@@ -391,7 +392,7 @@ export const StackedBarChart = memo(function StackedBarChart({
           {(width, zoomScale, scrollEnabled) => {
             const axisGutter = showYAxisScale ? Y_AXIS_LABEL_WIDTH : 0;
             const chartWidth = width - CHART_WIDTH_INSET - axisGutter;
-            const initialSpacing = 8;
+            const initialSpacing = CHART_INITIAL_SPACING;
             const fitted = fitBars(chartWidth, stackData.length, minBarWidth);
             const barWidth = Math.max(minBarWidth, Math.round(fitted.barWidth * zoomScale));
             const spacing = Math.max(2, Math.round(fitted.spacing * zoomScale));

--- a/packages/mobile/src/components/you/__tests__/you-charts-width-budget.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/you-charts-width-budget.test.tsx
@@ -186,9 +186,8 @@ describe('StackedBarChart width budget (#3778, #3050)', () => {
     render(<StackedBarChart bars={bars} colorBy="layout" showYAxisScale />);
 
     const call = barChartCalls[0]!;
-    // The fitted content must also not exceed the canvas BarChart was told to
-    // draw into, or the last bar is clipped by the plot ScrollView at zoom 1.
-    expect(stackedContentSpan(call)).toBeLessThanOrEqual(call.width!);
+    expect(call.initialSpacing).toBe(8);
+    expect(stackedContentSpan(call)).toBe(call.width);
   });
 
   it('stays inside the frame without the y-axis scale too', () => {
@@ -295,7 +294,6 @@ describe('GroupedBarChart width budget (#3778, #3050)', () => {
     render(<GroupedBarChart bars={largeCountBars} />);
     const accessibilityScaleCall = barChartCalls[0]!;
 
-    expect(getFontScaleMock).toHaveBeenCalledTimes(2);
     expect(accessibilityScaleCall.width).toBe(normalScaleCall.width);
     expect(accessibilityScaleCall.topLabelContainerStyle?.width).toBeGreaterThan(
       normalScaleCall.topLabelContainerStyle?.width ?? 0,

--- a/packages/mobile/src/components/you/__tests__/you-charts-width-budget.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/you-charts-width-budget.test.tsx
@@ -12,12 +12,8 @@
 // for a y-axis gutter, so the chart occupied ~22-32px more than the card had.
 //
 // This repo has no visual regression harness for RN charts, so these tests pin
-// the prop contract instead: the FULL occupied span must fit inside the
-// measured frame, and the fitted bar/spacing content must fit inside the width
-// prop. The library-default fallbacks below mirror gifted-charts-core 0.1.81
-// (`AxesAndRulesDefaults.yAxisEmptyLabelWidth = 10`, `yAxisLabelWidth = 35`,
-// `endSpacing = spacing`, `BarDefaults.spacing = 20`) so a chart that simply
-// omits a prop is still measured at its true rendered size.
+// every layout prop explicitly: the FULL occupied span must fit inside the
+// measured frame, and the fitted bar/spacing content must fit inside `width`.
 import { createElement, useEffect, type ReactNode } from 'react';
 import { render } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -25,6 +21,7 @@ import type { RawGroupedBar } from '@boardsesh/profile-stats';
 import type { ColoredBar } from '../profile-chart-colors';
 
 const FRAME_WIDTH = 320;
+const getFontScaleMock = vi.hoisted(() => vi.fn(() => 1));
 
 // Minimal RN surface — mirrors you-charts-tap-tooltip.test.tsx's mock so
 // ChartFrame's width-gated render path reaches the chart under test.
@@ -40,7 +37,7 @@ vi.mock('react-native', () => ({
   },
   Pressable: ({ children }: { children?: ReactNode }) => createElement('button', { type: 'button' }, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
-  PixelRatio: { getFontScale: () => 1 },
+  PixelRatio: { getFontScale: getFontScaleMock },
 }));
 
 vi.mock('react-i18next', () => ({
@@ -49,12 +46,15 @@ vi.mock('react-i18next', () => ({
 
 type BarChartCall = {
   width?: number;
+  height?: number;
   barWidth?: number;
   spacing?: number;
   initialSpacing?: number;
   endSpacing?: number;
   yAxisLabelWidth?: number;
   hideYAxisText?: boolean;
+  disableScroll?: boolean;
+  topLabelContainerStyle?: { width?: number; left?: number };
   stackData?: { stacks?: { value: number }[] }[];
   data?: { spacing?: number }[];
 };
@@ -119,19 +119,10 @@ vi.mock('../profile-chart-colors', () => ({
 
 import { StackedBarChart, GroupedBarChart } from '../YouCharts';
 
-// gifted-charts-core defaults, applied when we omit the prop. Transcribed from
-// `AxesAndRulesDefaults` / `BarDefaults` in dist/utils/constants.js at the
-// version pinned in bun.lock (0.1.81) — bun's isolated install puts
-// gifted-charts-core outside packages/mobile's resolution path, so they can't be
-// imported. COUPLING: bumping react-native-gifted-charts can move these, and a
-// bump that grows a default would make the charts overflow again while these
-// tests stayed green. Re-read dist/utils/constants.js on any such bump.
-const GIFTED_DEFAULT_SPACING = 20;
-const GIFTED_Y_AXIS_LABEL_WIDTH = 35;
-const GIFTED_Y_AXIS_EMPTY_LABEL_WIDTH = 10;
-
 beforeEach(() => {
   barChartCalls.length = 0;
+  getFontScaleMock.mockReset();
+  getFontScaleMock.mockReturnValue(1);
 });
 
 /**
@@ -140,11 +131,10 @@ beforeEach(() => {
  * the rules/x-axis row extends by. This is the number that must fit the card.
  */
 function occupiedSpan(call: BarChartCall): number {
-  const barLevelSpacing = call.spacing ?? GIFTED_DEFAULT_SPACING;
-  const endSpacing = call.endSpacing ?? barLevelSpacing;
-  const yAxisGutter =
-    call.yAxisLabelWidth ?? (call.hideYAxisText ? GIFTED_Y_AXIS_EMPTY_LABEL_WIDTH : GIFTED_Y_AXIS_LABEL_WIDTH);
-  return yAxisGutter + (call.width ?? 0) + endSpacing;
+  if (call.yAxisLabelWidth === undefined || call.width === undefined || call.endSpacing === undefined) {
+    return Number.POSITIVE_INFINITY;
+  }
+  return call.yAxisLabelWidth + call.width + call.endSpacing;
 }
 
 /** Total pixel span the fitted stack-bar data actually occupies. */
@@ -153,7 +143,7 @@ function stackedContentSpan(call: BarChartCall): number {
   const barWidth = call.barWidth ?? 0;
   const spacing = call.spacing ?? 0;
   const initial = call.initialSpacing ?? 0;
-  return initial * 2 + count * barWidth + Math.max(0, count - 1) * spacing;
+  return initial + count * barWidth + Math.max(0, count - 1) * spacing;
 }
 
 /**
@@ -164,7 +154,7 @@ function groupedContentSpan(call: BarChartCall): number {
   const data = call.data ?? [];
   const barWidth = call.barWidth ?? 0;
   const initial = call.initialSpacing ?? 0;
-  const gaps = data.reduce((total, datum) => total + (datum.spacing ?? 0), 0);
+  const gaps = data.slice(0, -1).reduce((total, datum) => total + (datum.spacing ?? 0), 0);
   return initial + data.length * barWidth + gaps;
 }
 
@@ -185,7 +175,10 @@ describe('StackedBarChart width budget (#3778, #3050)', () => {
 
     expect(barChartCalls).toHaveLength(1);
     const call = barChartCalls[0]!;
-    expect(call.width).toBeGreaterThan(0);
+    expect(call.width).toBe(FRAME_WIDTH - 8 - 32);
+    expect(call.yAxisLabelWidth).toBe(32);
+    expect(call.endSpacing).toBe(0);
+    expect(call.disableScroll).toBe(true);
     expect(occupiedSpan(call)).toBeLessThanOrEqual(FRAME_WIDTH);
   });
 
@@ -202,9 +195,26 @@ describe('StackedBarChart width budget (#3778, #3050)', () => {
     render(<StackedBarChart bars={bars} colorBy="layout" />);
 
     const call = barChartCalls[0]!;
+    expect(call.width).toBe(FRAME_WIDTH - 8);
     expect(call.yAxisLabelWidth).toBe(0);
+    expect(call.endSpacing).toBe(0);
     expect(occupiedSpan(call)).toBeLessThanOrEqual(FRAME_WIDTH);
     expect(stackedContentSpan(call)).toBeLessThanOrEqual(call.width!);
+  });
+
+  it('enables base-scale scrolling when 52 weeks cannot fit above the minimum bar width', () => {
+    const weeklyBars: ColoredBar[] = Array.from({ length: 52 }, (_, index) => ({
+      key: `week-${index}`,
+      label: `W${index + 1}`,
+      segments: [{ key: 'kilter-1', label: 'Kilter Original', value: index + 1 }],
+    }));
+
+    render(<StackedBarChart bars={weeklyBars} colorBy="layout" showYAxisScale />);
+
+    const call = barChartCalls[0]!;
+    expect(stackedContentSpan(call)).toBeGreaterThan(call.width!);
+    expect(call.disableScroll).toBe(false);
+    expect(occupiedSpan(call)).toBeLessThanOrEqual(FRAME_WIDTH);
   });
 });
 
@@ -223,7 +233,7 @@ describe('GroupedBarChart width budget (#3778, #3050)', () => {
 
     expect(barChartCalls).toHaveLength(1);
     const call = barChartCalls[0]!;
-    expect(call.width).toBeGreaterThan(0);
+    expect(call.width).toBe(FRAME_WIDTH - 8);
     // `hideYAxisText` on its own still reserves gifted-charts'
     // `yAxisEmptyLabelWidth` (10px) outside `width`, and an unset `endSpacing`
     // falls back to the 20px default `spacing` because this chart carries
@@ -238,6 +248,7 @@ describe('GroupedBarChart width budget (#3778, #3050)', () => {
     const call = barChartCalls[0]!;
     expect(call.yAxisLabelWidth).toBe(0);
     expect(call.endSpacing).toBe(0);
+    expect(call.disableScroll).toBe(true);
   });
 
   it('sizes grouped bars to fit inside the width actually given to BarChart', () => {
@@ -246,5 +257,49 @@ describe('GroupedBarChart width budget (#3778, #3050)', () => {
     const call = barChartCalls[0]!;
     expect(call.data?.length).toBe(groupedBars.length * 2);
     expect(groupedContentSpan(call)).toBeLessThanOrEqual(call.width!);
+  });
+
+  it('enables base-scale scrolling when dense grade groups exceed the plot width', () => {
+    const denseGroupedBars: RawGroupedBar[] = Array.from({ length: 18 }, (_, index) => ({
+      key: `V${index}`,
+      label: `V${index}`,
+      values: [
+        { key: 'flash', label: 'Flash', value: index + 1 },
+        { key: 'redpoint', label: 'Redpoint', value: index + 2 },
+      ],
+    }));
+
+    render(<GroupedBarChart bars={denseGroupedBars} />);
+
+    const call = barChartCalls[0]!;
+    expect(groupedContentSpan(call)).toBeGreaterThan(call.width!);
+    expect(call.disableScroll).toBe(false);
+    expect(occupiedSpan(call)).toBeLessThanOrEqual(FRAME_WIDTH);
+  });
+
+  it('preserves PixelRatio-driven top-label headroom from #3779', () => {
+    const largeCountBars = groupedBars.map((bar, index) => ({
+      ...bar,
+      values: bar.values.map((value, valueIndex) => ({
+        ...value,
+        value: valueIndex === 0 ? 128 - index : 44 - index,
+      })),
+    }));
+
+    const normalRender = render(<GroupedBarChart bars={largeCountBars} />);
+    const normalScaleCall = barChartCalls[0]!;
+    normalRender.unmount();
+
+    barChartCalls.length = 0;
+    getFontScaleMock.mockReturnValue(2);
+    render(<GroupedBarChart bars={largeCountBars} />);
+    const accessibilityScaleCall = barChartCalls[0]!;
+
+    expect(getFontScaleMock).toHaveBeenCalledTimes(2);
+    expect(accessibilityScaleCall.width).toBe(normalScaleCall.width);
+    expect(accessibilityScaleCall.topLabelContainerStyle?.width).toBeGreaterThan(
+      normalScaleCall.topLabelContainerStyle?.width ?? 0,
+    );
+    expect(accessibilityScaleCall.height).toBeLessThan(normalScaleCall.height ?? Number.POSITIVE_INFINITY);
   });
 });


### PR DESCRIPTION
## What & why

PR #4074 fixed the outer width budget for the You → Progress bar charts, but it merged with a dense-data P1 still unresolved. At the base scale, `StackedBarChart` keeps a 4px minimum bar and `GroupedBarChart` keeps a 6px minimum bar plus its inner and group gaps. A 52-week Activity chart or an 18-grade Flash vs Redpoint chart can therefore have content wider than the fitted plot while `disableScroll` remains true. The card itself fits, but the final weeks or grades are unreachable inside the chart.

This corrective follow-up keeps the plot viewport at the width budget established by #4074 and enables gifted-charts' internal horizontal scroll exactly when its rendered content exceeds that viewport:

- Stacked: `initialSpacing + count × barWidth + max(0, count - 1) × spacing`
- Grouped: `initialSpacing + groupCount × 2 × barWidth + groupCount × innerGap + max(0, groupCount - 1) × groupGap`

Scrolling is enabled when that value is greater than `chartWidth`, or when pinch zoom already requires scrolling. Ordinary charts that fit remain non-scrollable. The y-axis gutter stays explicitly budgeted, `endSpacing` stays at zero, and the outer chart width never grows past the card.

The blanket frame `overflow: hidden` from #4074 is removed. It could clip the rotated count labels and top-label headroom added in #3779; width budgeting and the chart's own scroll viewport provide the boundary instead.

## Regression coverage

- A 52-week stacked Activity chart proves every week remains reachable at the minimum 4px bar width.
- An 18-grade grouped chart proves every Flash/Redpoint pair remains reachable at the minimum 6px bar width.
- Ordinary stacked and grouped charts remain non-scrollable at base scale.
- The tests pin the explicit width, y-axis gutter, and end-spacing props without copying gifted-charts' defaults.
- PixelRatio-driven count-label sizing and #3779's top-label headroom remain covered.

## Validation

- Independent review of exact commit `356165647`: approved with no blocking or non-blocking findings.
- Reviewer suite: 30 You-chart files / 218 tests passed.
- Focused regression suite: 3 files / 19 tests passed.
- Full mobile suite: 574 files / 4,879 tests passed.
- `vp run typecheck:mobile`: passed.
- `vp run check:mobile-bundle`: iOS and Android passed.
- Scoped `vp check --fix` on both changed files: no warnings or errors.
- QA notes: `.boardsesh/qa-notes.md`, surfaced by `vp run dev:mobile`.
- QA Metro URL: `http://vibetunnel-2.tailedd9d5.ts.net:8081`.

## Release Notes

Your full Activity and Grade Distribution history stays reachable on narrow screens, even when every week or grade has data.

Fixes #3778
Fixes #3050
