### PR TITLE
fix(mobile): serialize remix handoff across native sheets

### DIFF
--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -234,10 +234,13 @@ modal, and only then pushes create:
 claim action → dismiss source sheet → settle → dismiss /play → closing transitionEnd → push create
 ```
 
-`dismissAndWait()` can return `aborted` when its owner unmounts; that aborts the rest of the
-handoff. This prevents a stale async action from opening create after its source disappeared.
-Repeated taps join neither a second dismiss nor a second push because the action guard is set
-before the first asynchronous boundary.
+`dismissAndWait()` can return `aborted` when its source-sheet owner unmounts; that aborts the
+rest of the handoff. The `/play` route has one deliberate exception: after its own callback has
+called `router.dismiss()`, route teardown is the expected close path, so its bounded native-stack
+ceiling remains alive when `transitionEnd` cannot arrive from the unmounted screen. A stale player
+callback invoked _after_ the player already disappeared still returns `aborted` without calling
+`router.dismiss()` again. Repeated taps join neither a second dismiss nor a second push because
+the action guard is set before the first asynchronous boundary.
 
 `handleSwitchBoardFromDrawer` in `drawer-host-provider.tsx` does the same
 `router.dismiss()` → `router.push('/boards')` when the play drawer's board-mismatch overlay
@@ -252,10 +255,11 @@ Two things that are easy to get wrong:
 
 - **Let the route own its close waiter.** The actual `/play` route subscribes to its native
   stack's `transitionEnd` before calling `router.dismiss()`, ignores events where `closing` is
-  false, and cleans up/returns `aborted` if the route unmounts first. On web there is no native
-  transition to await, so dismissal completes immediately. Thread this callback down through
-  the in-tree opener; a hook mounted in a sibling root provider cannot safely subscribe to the
-  `/play` navigator.
+  false, and uses its bounded ceiling if that dismissal unmounts the route before the native event
+  can reach JS. If the route was already gone before the callback starts, it returns `aborted`
+  instead of popping the now-visible route underneath. On web there is no native transition to
+  await, so dismissal completes immediately. Thread this callback down through the in-tree opener;
+  a hook mounted in a sibling root provider cannot safely subscribe to the `/play` navigator.
 - **Omit the player callback when there is no player route.** The same menu opens from the
   climbs list and BoardSheet, and on an **iPad regular-width layout the player is an inline
   detail pane**. Those entry points must not call `router.dismiss()` or they can pop an unrelated

--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -114,6 +114,13 @@ and on iOS it's the ceiling for the rare case the native event never arrives (a 
 mid-animation). A `__DEV__` warning fires only when the ceiling beats a native signal that was
 expected (an iOS dismiss of a still-registered sheet).
 
+Call `managed.dismissAndWait()` when the next step must not begin until that settle point. It
+uses the coordinator's existing native-dismiss-or-ceiling lifecycle rather than starting a
+second timer, and it also waits when `present()` is still in flight. Concurrent callers for the
+same sheet share the outcome. The promise resolves with `{ status: 'dismissed' }` after a normal
+settle (or the platform ceiling), and `{ status: 'aborted' }` if the sheet unregisters during the
+handoff. Stop the follow-up action on `aborted`; the owning surface has gone away.
+
 The same patch also guards the **Android** re-snap path: `snapToIndex` on an already-open
 multi-detent sheet fires `expand()` / `partialExpand()` fire-and-forget on the native
 `ModalBottomSheetView`. A store binary whose native `@expo/ui` predates one of those
@@ -218,12 +225,19 @@ player pushes create into a navigator that is already covered: create stacks **u
 still-live player (two drawers visible at once), and `CreateDrawer`'s root-window
 `BottomSheet` strands a scrim over the search list once you navigate away.
 
-**The fix: dismiss the modal route first, then push.**
+**The fix: finish each live surface in order, then push.** An edit/remix action claims a
+one-action guard synchronously, before closing its custom overlay. It then awaits the source
+managed sheet (Board or Queue), awaits the player route's close transition when the player is a
+modal, and only then pushes create:
 
-```ts
-if (isPlayerRoute(segments)) router.dismiss();
-router.push({ pathname: '/(tabs)/climbs/create', params });
+```text
+claim action → dismiss source sheet → settle → dismiss /play → closing transitionEnd → push create
 ```
+
+`dismissAndWait()` can return `aborted` when its owner unmounts; that aborts the rest of the
+handoff. This prevents a stale async action from opening create after its source disappeared.
+Repeated taps join neither a second dismiss nor a second push because the action guard is set
+before the first asynchronous boundary.
 
 `handleSwitchBoardFromDrawer` in `drawer-host-provider.tsx` does the same
 `router.dismiss()` → `router.push('/boards')` when the play drawer's board-mismatch overlay
@@ -236,15 +250,16 @@ it.
 
 Two things that are easy to get wrong:
 
-- **Gate the dismiss.** The same menu opens from the climbs list and the board sheet, where
-  there is no modal to close — and on an **iPad regular-width layout the player renders in the
-  detail pane, not the `/play` route** at all. An ungated `router.dismiss()` pops the wrong
-  screen. Gate on `isPlayerRoute(segments)` (`src/lib/route-segments.ts`).
-- **Read the segments from a ref, not a dep.** `useSegments()` hands back a fresh array on
-  every navigation, so listing it in a `useCallback` dep array churns the callback identity and
-  rebuilds any memoised list built on top of it (here, `useClimbActions`' action list). Mirror
-  it with the repo's latest-ref idiom (`segmentsRef.current = segments`) and read it inside the
-  handler.
+- **Let the route own its close waiter.** The actual `/play` route subscribes to its native
+  stack's `transitionEnd` before calling `router.dismiss()`, ignores events where `closing` is
+  false, and cleans up/returns `aborted` if the route unmounts first. On web there is no native
+  transition to await, so dismissal completes immediately. Thread this callback down through
+  the in-tree opener; a hook mounted in a sibling root provider cannot safely subscribe to the
+  `/play` navigator.
+- **Omit the player callback when there is no player route.** The same menu opens from the
+  climbs list and BoardSheet, and on an **iPad regular-width layout the player is an inline
+  detail pane**. Those entry points must not call `router.dismiss()` or they can pop an unrelated
+  route. The callback's presence is the gate; do not infer it from root-level segments.
 
 The rule of thumb: **before pushing a route, ask which navigator it lands in.** Same navigator
 is fine. A navigator _below_ the modal you're standing in needs the dismiss first.

--- a/packages/mobile/app/gyms/edit.tsx
+++ b/packages/mobile/app/gyms/edit.tsx
@@ -2,11 +2,11 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import type { BottomSheetModal } from '@expo/ui/community/bottom-sheet';
 import type { Gym, UpdateGymInput } from '@boardsesh/shared-schema';
 import { useGym, useUpdateGym } from '../../src/lib/graphql/hooks';
 import { useToast } from '../../src/providers/toast-provider';
 import { useTheme } from '../../src/providers/theme-provider';
+import type { ManagedSheetHandle } from '../../src/providers/sheet-presentation-provider';
 import { useStackScreenOptions } from '../../src/hooks/use-stack-screen-options';
 import { hapticSelection } from '../../src/lib/haptics';
 import { GymForm, type GymFormSeed, type GymFormSubmitValues } from '../../src/components/gym-directory/GymForm';
@@ -105,7 +105,7 @@ function EditGymForm({ gym }: { gym: Gym }) {
   const { systemColors } = useTheme();
   const { showToast } = useToast();
   const updateGym = useUpdateGym();
-  const claimSheetRef = useRef<BottomSheetModal>(null);
+  const claimSheetRef = useRef<ManagedSheetHandle>(null);
 
   const seed = useMemo<GymFormSeed>(
     () => ({

--- a/packages/mobile/app/gyms/index.tsx
+++ b/packages/mobile/app/gyms/index.tsx
@@ -3,7 +3,6 @@ import { Linking, Pressable, StyleSheet, TextInput, View } from 'react-native';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import type { BottomSheetModal } from '@expo/ui/community/bottom-sheet';
 import type { BoardName, Gym, UserBoard } from '@boardsesh/shared-schema';
 import { useNearbyBoards, useNearbyGyms } from '../../src/lib/graphql/hooks';
 import { useSetActiveBoard } from '../../src/lib/graphql/use-active-board';
@@ -12,6 +11,7 @@ import { useDeviceLocation, type Coords } from '../../src/lib/use-device-locatio
 import { useGeocodePlace } from '../../src/lib/use-place-search';
 import { useToast } from '../../src/providers/toast-provider';
 import { useTheme } from '../../src/providers/theme-provider';
+import type { ManagedSheetHandle } from '../../src/providers/sheet-presentation-provider';
 import { hapticSelection } from '../../src/lib/haptics';
 import { resolveBoardReturnTo } from '../../src/lib/boards/board-return-to';
 import { Text } from '../../src/components/Text';
@@ -88,7 +88,7 @@ export default function GymDiscovery() {
   // "Claim this gym" action; the ClaimGymSheet is mounted per-target so its form
   // starts clean each open, and cleared when the sheet fully dismisses.
   const [claimTargetGym, setClaimTargetGym] = useState<Gym | null>(null);
-  const claimSheetRef = useRef<BottomSheetModal>(null);
+  const claimSheetRef = useRef<ManagedSheetHandle>(null);
 
   // `inputText` is the raw field; `appliedFilter` is the applied filter sent to the
   // backend (name + the board-type chips' selected `boardTypes`).

--- a/packages/mobile/app/play.tsx
+++ b/packages/mobile/app/play.tsx
@@ -7,10 +7,18 @@ import { QueueSheet, type QueueSheetHandle } from '../src/components/play-drawer
 import { DevicePickerSheetHost } from '../src/components/ble/DevicePickerSheetHost';
 import { useQueueSheetHandlers } from '../src/components/play-drawer/use-queue-sheet-handlers';
 import type { QueueItemRowBoard } from '../src/components/QueueItemRow';
-import { useDrawerHost, usePlayDrawerRoute } from '../src/providers/drawer-host-provider';
+import {
+  useDrawerHost,
+  usePlayDrawerRoute,
+  type BoardConfig,
+  type OpenClimbActionsOptions,
+} from '../src/providers/drawer-host-provider';
 import { useQueueActions, useQueueSessionControls } from '../src/providers/queue-provider';
 import { useTheme } from '../src/providers/theme-provider';
 import { playDrawerMaterialTint } from '../src/theme/colors';
+import { usePlayerDismissAndWait } from '../src/components/create-climb/use-player-dismiss-and-wait';
+import type { Climb } from '@boardsesh/shared-schema';
+import type { DismissAndWaitResult } from '../src/providers/sheet-presentation-provider';
 
 /**
  * Full-screen "now playing" player route (`presentation: 'fullScreenModal'`,
@@ -54,6 +62,20 @@ export default function PlayScreen() {
   const queueSheetRef = useRef<QueueSheetHandle>(null);
   const presentQueue = useCallback(() => queueSheetRef.current?.present(), []);
   const requestCloseQueue = useCallback(() => queueSheetRef.current?.dismiss(), []);
+  const dismissQueueAndWait = useCallback((): Promise<DismissAndWaitResult> => {
+    const handle = queueSheetRef.current;
+    return handle ? handle.dismissAndWait() : Promise.resolve({ status: 'aborted' });
+  }, []);
+  const dismissPlayerAndWait = usePlayerDismissAndWait();
+  // Any actions menu opened from this route receives the route-owned transition
+  // waiter. That includes the root FullWindowOverlay and the route's QueueSheet;
+  // neither can safely discover the native-stack navigation object itself.
+  const openPlayerClimbActions = useCallback(
+    (climb: Climb, boardConfigOverride?: BoardConfig, options?: OpenClimbActionsOptions) => {
+      openClimbActions(climb, boardConfigOverride, { ...options, dismissPlayerAndWait });
+    },
+    [openClimbActions, dismissPlayerAndWait],
+  );
 
   // Paint the glass first, mount the heavy player content one frame later so the
   // native present starts immediately (see the file comment). rAF fires before
@@ -87,11 +109,12 @@ export default function PlayScreen() {
   const { handleClimbPress, handleOpenActions, handleSuggestionPress, handleTickHistory } = useQueueSheetHandlers({
     setCurrentClimb,
     openPlayDrawer,
-    openClimbActions,
+    openClimbActions: openPlayerClimbActions,
     openLogAscent,
     storedBoardConfig,
     sessionId,
     requestCloseQueueSheet: requestCloseQueue,
+    dismissQueueSheetAndWait: dismissQueueAndWait,
   });
 
   return (
@@ -121,7 +144,8 @@ export default function PlayScreen() {
             boardMismatch={boardMismatch}
             mismatchBoardLabel={mismatchBoardLabel}
             onSwitchBoard={onSwitchBoard}
-            onOpenClimbActions={openClimbActions}
+            onOpenClimbActions={openPlayerClimbActions}
+            dismissPlayerAndWait={dismissPlayerAndWait}
             openTarget={playTarget}
           />
           {queueBoard ? (

--- a/packages/mobile/app/play.tsx
+++ b/packages/mobile/app/play.tsx
@@ -18,7 +18,7 @@ import { useTheme } from '../src/providers/theme-provider';
 import { playDrawerMaterialTint } from '../src/theme/colors';
 import { usePlayerDismissAndWait } from '../src/components/create-climb/use-player-dismiss-and-wait';
 import type { Climb } from '@boardsesh/shared-schema';
-import type { DismissAndWaitResult } from '../src/providers/sheet-presentation-provider';
+import { dismissManagedSheetAndWait, type DismissAndWaitResult } from '../src/providers/sheet-presentation-provider';
 
 /**
  * Full-screen "now playing" player route (`presentation: 'fullScreenModal'`,
@@ -63,8 +63,7 @@ export default function PlayScreen() {
   const presentQueue = useCallback(() => queueSheetRef.current?.present(), []);
   const requestCloseQueue = useCallback(() => queueSheetRef.current?.dismiss(), []);
   const dismissQueueAndWait = useCallback((): Promise<DismissAndWaitResult> => {
-    const handle = queueSheetRef.current;
-    return handle ? handle.dismissAndWait() : Promise.resolve({ status: 'aborted' });
+    return dismissManagedSheetAndWait(queueSheetRef.current);
   }, []);
   const dismissPlayerAndWait = usePlayerDismissAndWait();
   // Any actions menu opened from this route receives the route-owned transition

--- a/packages/mobile/src/components/ClimbActionsSheet.tsx
+++ b/packages/mobile/src/components/ClimbActionsSheet.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, type RefObject } from 'react';
 import { View, StyleSheet } from 'react-native';
+import type { BottomSheetMethods } from '@expo/ui/community/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import * as Clipboard from 'expo-clipboard';
 import * as WebBrowser from 'expo-web-browser';
@@ -8,7 +9,7 @@ import { buildReadableClimbViewPath } from '@boardsesh/play-view/readable-url-ut
 import { computeCanUpdate, type SavedClimbSnapshot } from '@boardsesh/create-climb-react';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { ModalSheet } from './ModalSheet';
-import { useCreateClimbNavigation } from './create-climb/use-create-climb-navigation';
+import { useCreateClimbNavigation, type DismissSurfaceAndWait } from './create-climb/use-create-climb-navigation';
 import { ClimbPreviewCard } from './ClimbPreviewCard';
 import { ListRow } from './ListRow';
 import { Icon } from './Icon';
@@ -17,6 +18,7 @@ import { useTheme } from '../providers/theme-provider';
 import { spacing } from '../theme/tokens';
 import { WEB_BASE_URL } from '../lib/env';
 import { track } from '../lib/analytics';
+import type { DismissAndWaitResult, ManagedSheetHandle } from '../providers/sheet-presentation-provider';
 
 type ClimbActionsSheetProps = {
   visible: boolean;
@@ -38,6 +40,8 @@ type ClimbActionsSheetProps = {
   onEditEntry?: () => void;
   /** When provided, shows an "Add beta video" row that opens the share-your-beta sheet. */
   onAddBetaVideo?: () => void;
+  /** Supplied only by the `/play` route; omitted by the persistent iPad pane. */
+  dismissPlayerAndWait?: DismissSurfaceAndWait;
   onClose: () => void;
 };
 
@@ -63,10 +67,28 @@ function ClimbActionsSheet({
   onTick,
   onEditEntry,
   onAddBetaVideo,
+  dismissPlayerAndWait,
   onClose,
 }: ClimbActionsSheetProps) {
   const { t } = useTranslation('climbs');
-  const { openRemix, openEdit } = useCreateClimbNavigation();
+  // ModalSheet's public ref stays source-compatible with BottomSheetMethods, while
+  // the coordinator-backed runtime handle also carries dismissAndWait.
+  const managedSheetRef = useRef<ManagedSheetHandle>(null);
+  const modalSheetRef = managedSheetRef as RefObject<BottomSheetMethods | null>;
+  const dismissActionsSheetAndWait = useCallback((): Promise<DismissAndWaitResult> => {
+    const handle = managedSheetRef.current;
+    return handle ? handle.dismissAndWait() : Promise.resolve({ status: 'aborted' });
+  }, []);
+  const { openRemix, openEdit, resetActionGuard } = useCreateClimbNavigation({
+    dismissSourceSheet: dismissActionsSheetAndWait,
+    dismissPlayerAndWait,
+  });
+  // PlayDrawer keeps this sheet mounted after first use. Re-arm only when a NEW
+  // presentation opens; do not reset on close while the old sheet is still
+  // hit-testable during its dismiss animation.
+  useEffect(() => {
+    if (visible) resetActionGuard();
+  }, [visible, resetActionGuard]);
   const { showToast } = useToast();
   const theme = useTheme();
 
@@ -138,20 +160,16 @@ function ClimbActionsSheet({
     }
   }, [climb, boardName, layoutId, sizeId, setIds, angle, onClose, showToast, t]);
 
-  // Close this sub-sheet, then navigate. `openRemix`/`openEdit` decide for themselves
-  // whether a player route needs dismissing first (it does from `/play`; it doesn't from
-  // an iPad detail pane, or anywhere else this sheet might later be reused), so create
-  // opens as the sole top surface instead of stacking underneath.
+  // The navigation hook claims the action before closing this sub-sheet, then awaits
+  // the injected player transition when (and only when) this is the real `/play` route.
   const handleFork = useCallback(() => {
     if (!climb) return;
-    onClose();
-    openRemix(climb, { boardName, layoutId, sizeId, setIds, angle });
+    openRemix(climb, { boardName, layoutId, sizeId, setIds, angle }, onClose);
   }, [climb, boardName, layoutId, sizeId, setIds, angle, openRemix, onClose]);
 
   const handleEdit = useCallback(() => {
     if (!climb) return;
-    onClose();
-    openEdit(climb, { boardName, layoutId, sizeId, setIds, angle });
+    openEdit(climb, { boardName, layoutId, sizeId, setIds, angle }, onClose);
   }, [climb, boardName, layoutId, sizeId, setIds, angle, openEdit, onClose]);
 
   // Edit is owner-only, and only while the climb is still a draft OR within
@@ -182,7 +200,13 @@ function ClimbActionsSheet({
   } = theme.actionColors;
 
   return (
-    <ModalSheet visible={visible && !!climb} snapPoints={snapPoints} onClose={onClose} enablePanDownToClose>
+    <ModalSheet
+      ref={modalSheetRef}
+      visible={visible && !!climb}
+      snapPoints={snapPoints}
+      onClose={onClose}
+      enablePanDownToClose
+    >
       {climb && (
         <ClimbPreviewCard
           climb={climb}

--- a/packages/mobile/src/components/ClimbActionsSheet.tsx
+++ b/packages/mobile/src/components/ClimbActionsSheet.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, type RefObject } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { View, StyleSheet } from 'react-native';
-import type { BottomSheetMethods } from '@expo/ui/community/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import * as Clipboard from 'expo-clipboard';
 import * as WebBrowser from 'expo-web-browser';
@@ -71,10 +70,7 @@ function ClimbActionsSheet({
   onClose,
 }: ClimbActionsSheetProps) {
   const { t } = useTranslation('climbs');
-  // ModalSheet's public ref stays source-compatible with BottomSheetMethods, while
-  // the coordinator-backed runtime handle also carries dismissAndWait.
   const managedSheetRef = useRef<ManagedSheetHandle>(null);
-  const modalSheetRef = managedSheetRef as RefObject<BottomSheetMethods | null>;
   const dismissActionsSheetAndWait = useCallback((): Promise<DismissAndWaitResult> => {
     const handle = managedSheetRef.current;
     return handle ? handle.dismissAndWait() : Promise.resolve({ status: 'aborted' });
@@ -201,7 +197,7 @@ function ClimbActionsSheet({
 
   return (
     <ModalSheet
-      ref={modalSheetRef}
+      ref={managedSheetRef}
       visible={visible && !!climb}
       snapPoints={snapPoints}
       onClose={onClose}

--- a/packages/mobile/src/components/ClimbActionsSheet.tsx
+++ b/packages/mobile/src/components/ClimbActionsSheet.tsx
@@ -17,7 +17,7 @@ import { useTheme } from '../providers/theme-provider';
 import { spacing } from '../theme/tokens';
 import { WEB_BASE_URL } from '../lib/env';
 import { track } from '../lib/analytics';
-import type { DismissAndWaitResult, ManagedSheetHandle } from '../providers/sheet-presentation-provider';
+import { dismissManagedSheetAndWait, type ManagedSheetHandle } from '../providers/sheet-presentation-provider';
 
 type ClimbActionsSheetProps = {
   visible: boolean;
@@ -71,10 +71,7 @@ function ClimbActionsSheet({
 }: ClimbActionsSheetProps) {
   const { t } = useTranslation('climbs');
   const managedSheetRef = useRef<ManagedSheetHandle>(null);
-  const dismissActionsSheetAndWait = useCallback((): Promise<DismissAndWaitResult> => {
-    const handle = managedSheetRef.current;
-    return handle ? handle.dismissAndWait() : Promise.resolve({ status: 'aborted' });
-  }, []);
+  const dismissActionsSheetAndWait = useCallback(() => dismissManagedSheetAndWait(managedSheetRef.current), []);
   const { openRemix, openEdit, resetActionGuard } = useCreateClimbNavigation({
     dismissSourceSheet: dismissActionsSheetAndWait,
     dismissPlayerAndWait,

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -26,7 +26,11 @@ import { androidSafeSnapPoints } from './sheet-snap-points';
 import { useSheetBodyContentStyle } from './sheet-content-inset';
 import { useSheetColumnStyle } from './use-sheet-column-style';
 import { useSheetDetentProbe } from './sheet-detent-probe';
-import { useManagedSheet, type PresenterGroup } from '../providers/sheet-presentation-provider';
+import {
+  useManagedSheet,
+  type ManagedSheetHandle,
+  type PresenterGroup,
+} from '../providers/sheet-presentation-provider';
 
 type ModalSheetProps = {
   children: ReactNode;
@@ -52,7 +56,7 @@ type ModalSheetProps = {
   footer?: ReactNode;
 };
 
-export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(function ModalSheet(
+export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(function ModalSheet(
   {
     children,
     visible,
@@ -85,7 +89,7 @@ export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(functi
     onClose,
     onFullyDismissed,
   });
-  useImperativeHandle(ref, () => managed.handle as BottomSheetMethods, [managed.handle]);
+  useImperativeHandle(ref, () => managed.handle, [managed.handle]);
 
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;

--- a/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { createElement, forwardRef, useImperativeHandle, type ReactNode } from 'react';
 import type { Climb } from '@boardsesh/shared-schema';
+import type { DismissAndWaitResult } from '../../providers/sheet-presentation-provider';
 
 // The sheet is mounted always-on inside the Play Drawer and toggled via the
 // controlled `visible` prop (the ModalSheet coordinator drives present/dismiss).
@@ -10,7 +11,7 @@ import type { Climb } from '@boardsesh/shared-schema';
 const sheet = vi.hoisted(() => ({
   visible: undefined as boolean | undefined,
   exposeHandle: true,
-  dismissAndWait: vi.fn(async () => ({ status: 'dismissed' as const })),
+  dismissAndWait: vi.fn<() => Promise<DismissAndWaitResult>>(async () => ({ status: 'dismissed' })),
 }));
 const preview = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }));
 const ctrl = vi.hoisted(() => ({
@@ -354,5 +355,17 @@ describe('ClimbActionsSheet create-climb navigation (Remix / Edit)', () => {
 
     expect(sheet.dismissAndWait).not.toHaveBeenCalled();
     await waitFor(() => expect(nav.push).toHaveBeenCalledTimes(1));
+  });
+
+  it('stops the handoff when the source sheet disappears during dismissal', async () => {
+    sheet.dismissAndWait.mockResolvedValueOnce({ status: 'aborted' });
+    const dismissPlayerAndWait = vi.fn(async () => ({ status: 'dismissed' as const }));
+    render(<ClimbActionsSheet visible={true} {...baseProps} dismissPlayerAndWait={dismissPlayerAndWait} />);
+
+    fireEvent.click(screen.getByText('mobile.climbActions.fork'));
+
+    await waitFor(() => expect(sheet.dismissAndWait).toHaveBeenCalledTimes(1));
+    expect(dismissPlayerAndWait).not.toHaveBeenCalled();
+    expect(nav.push).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
@@ -1,22 +1,22 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { createElement, type ReactNode } from 'react';
+import { createElement, forwardRef, useImperativeHandle, type ReactNode } from 'react';
 import type { Climb } from '@boardsesh/shared-schema';
 
 // The sheet is mounted always-on inside the Play Drawer and toggled via the
 // controlled `visible` prop (the ModalSheet coordinator drives present/dismiss).
 // The mock captures the latest `visible` it was handed.
-const sheet = vi.hoisted(() => ({ visible: undefined as boolean | undefined }));
+const sheet = vi.hoisted(() => ({
+  visible: undefined as boolean | undefined,
+  dismissAndWait: vi.fn(async () => ({ status: 'dismissed' as const })),
+}));
 const preview = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }));
-// `segments` drives the real `useCreateClimbNavigation` (deliberately NOT mocked, so the
-// Remix/Edit rows are covered end-to-end through the hook that owns the player dismiss).
 const ctrl = vi.hoisted(() => ({
   variant: 'liquidGlass' as 'liquidGlass' | 'material',
   canUpdate: false,
-  segments: ['play'] as readonly string[],
 }));
-const nav = vi.hoisted(() => ({ push: vi.fn(), dismiss: vi.fn() }));
+const nav = vi.hoisted(() => ({ push: vi.fn() }));
 const clipboard = vi.hoisted(() => ({ setStringAsync: vi.fn() }));
 const urlBuilder = vi.hoisted(() => ({ buildReadableClimbViewPath: vi.fn(() => '/readable/view/x') }));
 
@@ -28,10 +28,14 @@ vi.mock('react-native', () => ({
 vi.mock('@expo/ui/community/bottom-sheet', () => ({ BottomSheetModal: function BottomSheetModal() {} }));
 
 vi.mock('../ModalSheet', () => ({
-  ModalSheet: ({ children, visible }: { children?: ReactNode; visible?: boolean }) => {
+  ModalSheet: forwardRef(function MockModalSheet(
+    { children, visible }: { children?: ReactNode; visible?: boolean },
+    ref,
+  ) {
     sheet.visible = visible;
+    useImperativeHandle(ref, () => ({ dismissAndWait: sheet.dismissAndWait }));
     return createElement('div', { 'data-modal-sheet': 'true', 'data-visible': String(visible) }, children);
-  },
+  }),
 }));
 
 vi.mock('../ClimbPreviewCard', () => ({
@@ -51,8 +55,7 @@ vi.mock('../Icon', () => ({
 }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('expo-router', () => ({
-  useRouter: () => ({ push: nav.push, dismiss: nav.dismiss }),
-  useSegments: () => ctrl.segments,
+  useRouter: () => ({ push: nav.push }),
 }));
 vi.mock('expo-clipboard', () => ({ setStringAsync: clipboard.setStringAsync }));
 vi.mock('expo-web-browser', () => ({ openBrowserAsync: vi.fn() }));
@@ -110,15 +113,13 @@ const baseProps = {
 
 beforeEach(() => {
   sheet.visible = undefined;
+  sheet.dismissAndWait.mockClear();
   clipboard.setStringAsync.mockClear();
   urlBuilder.buildReadableClimbViewPath.mockClear();
   preview.props = null;
   ctrl.variant = 'liquidGlass';
   ctrl.canUpdate = false;
-  // This sheet only ever renders inside the play drawer, so /play is the realistic default.
-  ctrl.segments = ['play'];
   nav.push.mockClear();
-  nav.dismiss.mockClear();
 });
 
 describe('ClimbActionsSheet controlled visible (always-mounted toggle)', () => {
@@ -273,14 +274,20 @@ describe('ClimbActionsSheet create-climb navigation (Remix / Edit)', () => {
   // Both /play and /(tabs)/climbs/create are transparentModals, but in different
   // navigators — create lives under the player, so it must not be pushed while the
   // player is still up.
-  it('closes the sheet, dismisses the player, then pushes create with the fork params', () => {
+  it('claims the action, closes the sheet, then awaits the injected player dismissal before pushing', async () => {
     const onClose = vi.fn();
-    render(<ClimbActionsSheet visible={true} {...baseProps} onClose={onClose} />);
+    const dismissPlayerAndWait = vi.fn(async () => ({ status: 'dismissed' as const }));
+    render(
+      <ClimbActionsSheet visible={true} {...baseProps} onClose={onClose} dismissPlayerAndWait={dismissPlayerAndWait} />,
+    );
 
     fireEvent.click(screen.getByText('mobile.climbActions.fork'));
 
     expect(onClose).toHaveBeenCalledTimes(1);
-    expect(nav.dismiss).toHaveBeenCalledTimes(1);
+    expect(sheet.dismissAndWait).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(dismissPlayerAndWait).toHaveBeenCalledTimes(1));
+    expect(onClose.mock.invocationCallOrder[0]).toBeLessThan(dismissPlayerAndWait.mock.invocationCallOrder[0]);
+    await waitFor(() => expect(nav.push).toHaveBeenCalledTimes(1));
     expect(nav.push).toHaveBeenCalledWith({
       pathname: '/(tabs)/climbs/create',
       params: {
@@ -296,13 +303,22 @@ describe('ClimbActionsSheet create-climb navigation (Remix / Edit)', () => {
     });
   });
 
-  it('pushes create in edit mode from the owner-only Edit row', () => {
+  it('pushes create in edit mode from the owner-only Edit row', async () => {
     ctrl.canUpdate = true;
-    render(<ClimbActionsSheet visible={true} {...baseProps} climb={ownerClimb} currentUserId="user-1" />);
+    const dismissPlayerAndWait = vi.fn(async () => ({ status: 'dismissed' as const }));
+    render(
+      <ClimbActionsSheet
+        visible={true}
+        {...baseProps}
+        climb={ownerClimb}
+        currentUserId="user-1"
+        dismissPlayerAndWait={dismissPlayerAndWait}
+      />,
+    );
 
     fireEvent.click(screen.getByText('mobile.climbActions.edit'));
 
-    expect(nav.dismiss).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(nav.push).toHaveBeenCalledTimes(1));
     expect(nav.push).toHaveBeenCalledWith({
       pathname: '/(tabs)/climbs/create',
       params: {
@@ -319,13 +335,11 @@ describe('ClimbActionsSheet create-climb navigation (Remix / Edit)', () => {
   // On an iPad regular-width layout the player renders in the detail PANE, not the
   // /play route — there is no modal to dismiss, and popping one would take the wrong
   // screen with it.
-  it('does not dismiss when the player is a pane rather than the /play route', () => {
-    ctrl.segments = ['(tabs)', 'climbs'];
+  it('does not dismiss a player route when the player is an inline pane', async () => {
     render(<ClimbActionsSheet visible={true} {...baseProps} />);
 
     fireEvent.click(screen.getByText('mobile.climbActions.fork'));
 
-    expect(nav.dismiss).not.toHaveBeenCalled();
-    expect(nav.push).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(nav.push).toHaveBeenCalledTimes(1));
   });
 });

--- a/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
@@ -9,6 +9,7 @@ import type { Climb } from '@boardsesh/shared-schema';
 // The mock captures the latest `visible` it was handed.
 const sheet = vi.hoisted(() => ({
   visible: undefined as boolean | undefined,
+  exposeHandle: true,
   dismissAndWait: vi.fn(async () => ({ status: 'dismissed' as const })),
 }));
 const preview = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }));
@@ -22,6 +23,7 @@ const urlBuilder = vi.hoisted(() => ({ buildReadableClimbViewPath: vi.fn(() => '
 
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Platform: { OS: 'ios' },
   StyleSheet: { create: (styles: unknown) => styles },
 }));
 
@@ -33,7 +35,7 @@ vi.mock('../ModalSheet', () => ({
     ref,
   ) {
     sheet.visible = visible;
-    useImperativeHandle(ref, () => ({ dismissAndWait: sheet.dismissAndWait }));
+    useImperativeHandle(ref, () => (sheet.exposeHandle ? { dismissAndWait: sheet.dismissAndWait } : (null as never)));
     return createElement('div', { 'data-modal-sheet': 'true', 'data-visible': String(visible) }, children);
   }),
 }));
@@ -113,6 +115,7 @@ const baseProps = {
 
 beforeEach(() => {
   sheet.visible = undefined;
+  sheet.exposeHandle = true;
   sheet.dismissAndWait.mockClear();
   clipboard.setStringAsync.mockClear();
   urlBuilder.buildReadableClimbViewPath.mockClear();
@@ -340,6 +343,16 @@ describe('ClimbActionsSheet create-climb navigation (Remix / Edit)', () => {
 
     fireEvent.click(screen.getByText('mobile.climbActions.fork'));
 
+    await waitFor(() => expect(nav.push).toHaveBeenCalledTimes(1));
+  });
+
+  it('continues when the source sheet handle is already absent', async () => {
+    sheet.exposeHandle = false;
+    render(<ClimbActionsSheet visible={true} {...baseProps} />);
+
+    fireEvent.click(screen.getByText('mobile.climbActions.fork'));
+
+    expect(sheet.dismissAndWait).not.toHaveBeenCalled();
     await waitFor(() => expect(nav.push).toHaveBeenCalledTimes(1));
   });
 });

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -29,7 +29,7 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { Platform, StyleSheet } from 'react-native';
 import { BottomSheetModal } from '@expo/ui/community/bottom-sheet';
-import { useManagedSheet } from '../../providers/sheet-presentation-provider';
+import { useManagedSheet, type DismissAndWaitResult } from '../../providers/sheet-presentation-provider';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { useBoardPresenceCurrent, useBoardPresenceFeed } from '@boardsesh/board-presence-react';
 import { useTheme } from '../../providers/theme-provider';
@@ -49,6 +49,8 @@ export type { BoardSheetClimbAction } from './NowOnTheWallPanel';
 export type BoardSheetHandle = {
   present: () => void;
   dismiss: () => void;
+  /** Dismiss and resolve only after the native animation settles. */
+  dismissAndWait: () => Promise<DismissAndWaitResult>;
 };
 
 type BoardSheetProps = {
@@ -171,6 +173,10 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       dismiss: () => {
         invalidatePanelActions();
         managed.handle.dismiss();
+      },
+      dismissAndWait: () => {
+        invalidatePanelActions();
+        return managed.handle.dismissAndWait();
       },
     }),
     [managed.handle, invalidatePanelActions],

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -50,6 +50,7 @@ const managedSheet = vi.hoisted(() => ({
   // then fires `lastOnFullyDismissed` itself to settle the dismiss late.
   deferSettle: false,
   lastOnFullyDismissed: null as (() => void) | null,
+  dismissAndWait: vi.fn(async () => ({ status: 'dismissed' as const })),
 }));
 const climbRows = vi.hoisted(() => ({ props: [] as Record<string, unknown>[] }));
 const thumbnails = vi.hoisted(() => ({ props: [] as Record<string, unknown>[] }));
@@ -179,6 +180,7 @@ vi.mock('../../../providers/sheet-presentation-provider', () => ({
             opts.onFullyDismissed?.();
           }
         },
+        dismissAndWait: managedSheet.dismissAndWait,
       },
     };
   },
@@ -395,6 +397,7 @@ describe('BoardSheet', () => {
     sheetModal.onChange = null;
     managedSheet.deferSettle = false;
     managedSheet.lastOnFullyDismissed = null;
+    managedSheet.dismissAndWait.mockClear();
     climbRows.props = [];
     thumbnails.props = [];
     safeArea.bottom = 0;
@@ -418,6 +421,23 @@ describe('BoardSheet', () => {
 
     ref.current?.dismiss();
     expect(sheetModal.dismiss).toHaveBeenCalled();
+  });
+
+  it('forwards dismissAndWait through the imperative ref', async () => {
+    const ref = createRef<BoardSheetHandle>();
+    render(
+      createElement(BoardSheet, {
+        ref,
+        boardLabel: 'Garage Wall',
+        onClose: noop,
+        boardConfig,
+        onSwitchBoard: noop,
+      }),
+    );
+
+    if (!ref.current) throw new Error('board sheet handle did not mount');
+    await expect(ref.current.dismissAndWait()).resolves.toEqual({ status: 'dismissed' });
+    expect(managedSheet.dismissAndWait).toHaveBeenCalledTimes(1);
   });
 
   it('renders no presence content while dismissed — zero list/hero/chrome work', () => {

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -39,6 +39,7 @@ import { spacing, borderRadius, overlays } from '../../theme/tokens';
 import { withAlpha, type MaterialSurfaceContainers } from '../../theme/colors';
 import { useEffectiveSurfaceMode } from '../../hooks/use-effective-surface-mode';
 import { useClimbActions, type ClimbActionId, type ClimbActionItem } from './use-climb-actions';
+import type { DismissSurfaceAndWait } from '../create-climb/use-create-climb-navigation';
 import { fitBoardArt, computeReactionBoardMaxSize } from './board-art-fit';
 
 // Log a tick / Add to playlist / Share get pulled out of the scrollable list into a
@@ -63,6 +64,10 @@ type ClimbReactionMenuProps = {
    *  forces UIKit to dismiss `/play` and the tick sheet closes immediately.
    *  Receives the climb/board snapshot the menu was opened for. */
   onTick?: (climb: Climb, boardConfig: BoardConfig) => void;
+  /** Native sheet underneath this custom overlay, if any. */
+  dismissSourceSheet?: DismissSurfaceAndWait;
+  /** Supplied only when this menu was opened from the `/play` route. */
+  dismissPlayerAndWait?: DismissSurfaceAndWait;
   /** Read once at the app root (resolved) and passed in, so the mount-time enter
    *  animation uses the real value rather than useReduceMotion's conservative default. */
   reduceMotion: boolean;
@@ -143,6 +148,8 @@ export function ClimbReactionMenu({
   onEditEntry,
   onAddBetaVideo,
   onTick,
+  dismissSourceSheet,
+  dismissPlayerAndWait,
   reduceMotion,
   onClose,
 }: ClimbReactionMenuProps) {
@@ -236,6 +243,8 @@ export function ClimbReactionMenu({
     onSelectPlaylist: openPlaylist,
     onAddBetaVideo,
     onTick,
+    dismissSourceSheet,
+    dismissPlayerAndWait,
   });
 
   // Split the actions into the fixed top button row (tick / playlist / share, in that

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -233,6 +233,9 @@ export function ClimbReactionMenu({
     dismiss();
   }, [view, backToMenu, dismiss]);
 
+  // DrawerHost conditionally mounts this overlay only while an action target is
+  // present, so every open gets a fresh create-navigation double-tap guard. The
+  // guard intentionally stays claimed throughout this instance's exit animation.
   const actions = useClimbActions({
     climb,
     boardConfig,

--- a/packages/mobile/src/components/climb-actions/__tests__/use-climb-actions.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/use-climb-actions.test.tsx
@@ -1,12 +1,12 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import type { Climb } from '@boardsesh/shared-schema';
 import type { ClimbActionId } from '../use-climb-actions';
 
-// `segments` drives the real `useCreateClimbNavigation` (deliberately NOT mocked here,
-// so fork/edit get end-to-end coverage through the hook that owns the player dismiss).
-const ctrl = vi.hoisted(() => ({ canUpdate: false, segments: ['(tabs)', 'climbs'] as readonly string[] }));
+// Keep the real useCreateClimbNavigation in this test so fork/edit exercise the
+// one-action and injected-dismiss handoff end to end.
+const ctrl = vi.hoisted(() => ({ canUpdate: false }));
 const openers = vi.hoisted(() => ({
   openPlayDrawer: vi.fn(),
   openAddToPlaylist: vi.fn(),
@@ -15,14 +15,12 @@ const openers = vi.hoisted(() => ({
   addToQueue: vi.fn(),
   toggleFavoriteMutate: vi.fn(),
   push: vi.fn(),
-  dismiss: vi.fn(),
   shareClimb: vi.fn(async () => {}),
 }));
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('expo-router', () => ({
-  useRouter: () => ({ push: openers.push, dismiss: openers.dismiss }),
-  useSegments: () => ctrl.segments,
+  useRouter: () => ({ push: openers.push }),
 }));
 vi.mock('expo-crypto', () => ({ randomUUID: () => 'queue-uuid' }));
 vi.mock('expo-web-browser', () => ({ openBrowserAsync: vi.fn(async () => {}) }));
@@ -92,7 +90,6 @@ function ids(args: ActionArgs): ClimbActionId[] {
 
 beforeEach(() => {
   ctrl.canUpdate = false;
-  ctrl.segments = ['(tabs)', 'climbs'];
   Object.values(openers).forEach((fn) => fn.mockClear?.());
 });
 
@@ -292,24 +289,33 @@ describe('useClimbActions create-climb navigation (fork / edit)', () => {
     });
   });
 
-  // The player is a transparentModal in the ROOT stack; create is a transparentModal in
-  // the CLIMBS-TAB stack underneath it. Pushing without dismissing stacks create under
-  // the live player (two drawers + a stranded scrim).
-  it('dismisses the player route first when the menu was opened from /play', () => {
-    ctrl.segments = ['play'];
-    const { result } = renderActions({ climb, boardConfig: kilterBoard, isAuthenticated: false });
+  it('awaits the injected player close before pushing create', async () => {
+    let finishPlayerDismiss: (result: { status: 'dismissed' }) => void = () => {};
+    const dismissPlayerAndWait = vi.fn(
+      () =>
+        new Promise<{ status: 'dismissed' }>((resolve) => {
+          finishPlayerDismiss = resolve;
+        }),
+    );
+    const { result } = renderActions({
+      climb,
+      boardConfig: kilterBoard,
+      isAuthenticated: false,
+      dismissPlayerAndWait,
+    });
     result.current.find((action) => action.id === 'fork')?.run();
 
-    expect(openers.dismiss).toHaveBeenCalledTimes(1);
+    expect(dismissPlayerAndWait).toHaveBeenCalledTimes(1);
+    expect(openers.push).not.toHaveBeenCalled();
+
+    await act(async () => finishPlayerDismiss({ status: 'dismissed' }));
     expect(openers.push).toHaveBeenCalledTimes(1);
   });
 
-  it('does not dismiss anything when remixing from the climbs list', () => {
-    ctrl.segments = ['(tabs)', 'climbs'];
+  it('pushes directly when no source or player dismiss callback is present', () => {
     const { result } = renderActions({ climb, boardConfig: kilterBoard, isAuthenticated: false });
     result.current.find((action) => action.id === 'fork')?.run();
 
-    expect(openers.dismiss).not.toHaveBeenCalled();
     expect(openers.push).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mobile/src/components/climb-actions/use-climb-actions.ts
+++ b/packages/mobile/src/components/climb-actions/use-climb-actions.ts
@@ -19,7 +19,7 @@ import type { Climb } from '@boardsesh/shared-schema';
 import { computeCanUpdate, type SavedClimbSnapshot } from '@boardsesh/create-climb-react';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import type { IconName } from '../icon-map';
-import { useCreateClimbNavigation } from '../create-climb/use-create-climb-navigation';
+import { useCreateClimbNavigation, type DismissSurfaceAndWait } from '../create-climb/use-create-climb-navigation';
 import { useDrawerHost, boardConfigsMatch, type BoardConfig } from '../../providers/drawer-host-provider';
 import { useQueueActions } from '../../providers/queue-provider';
 import { useToggleFavorite, useFavoriteStatus } from '../../lib/graphql/hooks';
@@ -97,6 +97,10 @@ type UseClimbActionsArgs = {
    * ticking opens the root sheet (correct off `/play`, where nothing conflicts).
    */
   onTick?: (climb: Climb, boardConfig: BoardConfig) => void;
+  /** Native BoardSheet / QueueSheet underneath the custom overlay, if any. */
+  dismissSourceSheet?: DismissSurfaceAndWait;
+  /** `/play`-owned native-stack close waiter; absent for every inline surface. */
+  dismissPlayerAndWait?: DismissSurfaceAndWait;
 };
 
 // Mirrors web's constructClimbInfoUrl: Kilter no longer has a public app URL.
@@ -116,9 +120,11 @@ export function useClimbActions({
   onSelectPlaylist,
   onAddBetaVideo,
   onTick,
+  dismissSourceSheet,
+  dismissPlayerAndWait,
 }: UseClimbActionsArgs): ClimbActionItem[] {
   const { t } = useTranslation('climbs');
-  const { openRemix, openEdit } = useCreateClimbNavigation();
+  const { openRemix, openEdit } = useCreateClimbNavigation({ dismissSourceSheet, dismissPlayerAndWait });
   const { actionColors } = useTheme();
   const { addToQueue } = useQueueActions();
   const { mutate: toggleFavoriteMutate } = useToggleFavorite();
@@ -298,11 +304,10 @@ export function useClimbActions({
         title: t('mobile.climbActions.edit'),
         icon: 'edit',
         color: accentColor,
-        // Dismiss the overlay, then navigate. `openEdit` closes the player route
-        // first when we're inside it, so create doesn't stack under `/play`.
+        // `openEdit` claims the action before dismissing this overlay, then owns
+        // the source-sheet → player-route → create ordering.
         run: () => {
-          after();
-          openEdit(climb, boardConfig);
+          openEdit(climb, boardConfig, after);
         },
       });
     }
@@ -312,10 +317,9 @@ export function useClimbActions({
       title: t('mobile.climbActions.fork'),
       icon: 'branch',
       color: accentColor,
-      // Same as edit: `openRemix` closes the player route first when we're inside it.
+      // Same serialized handoff as Edit.
       run: () => {
-        after();
-        openRemix(climb, boardConfig);
+        openRemix(climb, boardConfig, after);
       },
     });
 
@@ -366,6 +370,8 @@ export function useClimbActions({
     onSelectPlaylist,
     onAddBetaVideo,
     onTick,
+    dismissSourceSheet,
+    dismissPlayerAndWait,
     after,
     t,
     actionColors,

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-navigation.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-navigation.test.tsx
@@ -91,6 +91,18 @@ describe('useCreateClimbNavigation serialized handoff', () => {
 
     expect(router.push).toHaveBeenCalledTimes(1);
   });
+
+  it('accepts a fresh action after its owning menu unmounts and mounts again', () => {
+    const firstMenu = renderHook(() => useCreateClimbNavigation());
+    firstMenu.result.current.openRemix(climb, board);
+    expect(router.push).toHaveBeenCalledTimes(1);
+    firstMenu.unmount();
+
+    const reopenedMenu = renderHook(() => useCreateClimbNavigation());
+    reopenedMenu.result.current.openRemix(climb, board);
+
+    expect(router.push).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('useCreateClimbNavigation params', () => {

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-navigation.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-navigation.test.tsx
@@ -1,17 +1,14 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Climb } from '@boardsesh/shared-schema';
+import type { DismissAndWaitResult } from '../../../providers/sheet-presentation-provider';
 
-const ctrl = vi.hoisted(() => ({ segments: ['(tabs)', 'climbs'] as readonly string[] }));
-const router = vi.hoisted(() => ({ push: vi.fn(), dismiss: vi.fn() }));
+const router = vi.hoisted(() => ({ push: vi.fn() }));
 
-vi.mock('expo-router', () => ({
-  useRouter: () => router,
-  useSegments: () => ctrl.segments,
-}));
+vi.mock('expo-router', () => ({ useRouter: () => router }));
 
-import { useCreateClimbNavigation } from '../use-create-climb-navigation';
+import { useCreateClimbNavigation, type DismissSurfaceAndWait } from '../use-create-climb-navigation';
 
 const climb = {
   uuid: 'climb-1',
@@ -22,45 +19,76 @@ const climb = {
 
 const board = { boardName: 'kilter', layoutId: 8, sizeId: 17, setIds: '26,27', angle: 40 };
 
+function deferredDismiss() {
+  let resolvePromise: (result: DismissAndWaitResult) => void = () => {};
+  const promise = new Promise<DismissAndWaitResult>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return { promise, resolve: resolvePromise };
+}
+
 beforeEach(() => {
-  ctrl.segments = ['(tabs)', 'climbs'];
   router.push.mockClear();
-  router.dismiss.mockClear();
 });
 
-describe('useCreateClimbNavigation player dismiss', () => {
-  // /play is a transparentModal in the ROOT stack; /(tabs)/climbs/create is a
-  // transparentModal in the CLIMBS-TAB stack, which is mounted BENEATH it. Pushing
-  // create without dismissing the player stacks it under the live player.
-  it('dismisses the player before pushing create when /play is focused', () => {
-    ctrl.segments = ['play'];
-    const { result } = renderHook(() => useCreateClimbNavigation());
+describe('useCreateClimbNavigation serialized handoff', () => {
+  it('claims one action before overlay dismissal, then waits source → player → push', async () => {
+    const sourceDeferred = deferredDismiss();
+    const playerDeferred = deferredDismiss();
+    const dismissSourceSheet = vi.fn(() => sourceDeferred.promise);
+    const dismissPlayerAndWait = vi.fn(() => playerDeferred.promise);
+    const dismissOverlay = vi.fn();
+    const { result } = renderHook(() => useCreateClimbNavigation({ dismissSourceSheet, dismissPlayerAndWait }));
 
-    result.current.openRemix(climb, board);
+    result.current.openRemix(climb, board, dismissOverlay);
+    result.current.openRemix(climb, board, dismissOverlay); // overlay is still hit-testable
 
-    expect(router.dismiss).toHaveBeenCalledTimes(1);
+    expect(dismissOverlay).toHaveBeenCalledTimes(1);
+    expect(dismissSourceSheet).toHaveBeenCalledTimes(1);
+    expect(dismissOverlay.mock.invocationCallOrder[0]).toBeLessThan(dismissSourceSheet.mock.invocationCallOrder[0]);
+    expect(dismissPlayerAndWait).not.toHaveBeenCalled();
+    expect(router.push).not.toHaveBeenCalled();
+
+    await act(async () => sourceDeferred.resolve({ status: 'dismissed' }));
+    expect(dismissPlayerAndWait).toHaveBeenCalledTimes(1);
+    expect(router.push).not.toHaveBeenCalled();
+
+    await act(async () => playerDeferred.resolve({ status: 'dismissed' }));
     expect(router.push).toHaveBeenCalledTimes(1);
-    expect(router.dismiss.mock.invocationCallOrder[0]).toBeLessThan(router.push.mock.invocationCallOrder[0]);
   });
 
-  it('pushes without dismissing from the climbs list', () => {
-    const { result } = renderHook(() => useCreateClimbNavigation());
-
-    result.current.openRemix(climb, board);
-
-    expect(router.dismiss).not.toHaveBeenCalled();
-    expect(router.push).toHaveBeenCalledTimes(1);
-  });
-
-  // The iPad regular-width layout hosts the player in the detail pane, so the focused
-  // route is still a tabs route and there is no modal to pop.
-  it('pushes without dismissing from a pushed climbs sub-route (iPad pane player)', () => {
-    ctrl.segments = ['(tabs)', 'climbs', '[climbUuid]'];
-    const { result } = renderHook(() => useCreateClimbNavigation());
+  it('stops when source-sheet teardown aborts the wait', async () => {
+    const dismissPlayerAndWait = vi.fn(async () => ({ status: 'dismissed' as const }));
+    const { result } = renderHook(() =>
+      useCreateClimbNavigation({
+        dismissSourceSheet: async () => ({ status: 'aborted' }),
+        dismissPlayerAndWait,
+      }),
+    );
 
     result.current.openEdit(climb, board);
+    await act(async () => {});
 
-    expect(router.dismiss).not.toHaveBeenCalled();
+    expect(dismissPlayerAndWait).not.toHaveBeenCalled();
+    expect(router.push).not.toHaveBeenCalled();
+  });
+
+  it('stops when the player route unmount aborts its transition wait', async () => {
+    const { result } = renderHook(() =>
+      useCreateClimbNavigation({ dismissPlayerAndWait: async () => ({ status: 'aborted' }) }),
+    );
+
+    result.current.openRemix(climb, board);
+    await act(async () => {});
+
+    expect(router.push).not.toHaveBeenCalled();
+  });
+
+  it('pushes immediately when no native source or player callback was injected (including iPad panes)', () => {
+    const { result } = renderHook(() => useCreateClimbNavigation());
+
+    result.current.openRemix(climb, board);
+
     expect(router.push).toHaveBeenCalledTimes(1);
   });
 });
@@ -114,28 +142,23 @@ describe('useCreateClimbNavigation params', () => {
 });
 
 describe('useCreateClimbNavigation callback stability', () => {
-  // `useSegments()` returns a fresh array on every navigation. If it were a dep rather
-  // than a ref read, these callbacks would change identity on each one and rebuild
-  // `useClimbActions`' memoised action list.
-  it('keeps openRemix / openEdit stable across a segments change', () => {
-    const { result, rerender } = renderHook(() => useCreateClimbNavigation());
-    const first = { openRemix: result.current.openRemix, openEdit: result.current.openEdit };
+  it('keeps openRemix / openEdit stable while reading the latest injected waiter', async () => {
+    const firstWaiter = vi.fn(async () => ({ status: 'dismissed' as const }));
+    const secondWaiter = vi.fn(async () => ({ status: 'dismissed' as const }));
+    const { result, rerender } = renderHook(
+      ({ dismissSourceSheet }: { dismissSourceSheet?: DismissSurfaceAndWait }) =>
+        useCreateClimbNavigation({ dismissSourceSheet }),
+      { initialProps: { dismissSourceSheet: firstWaiter } },
+    );
+    const firstCallbacks = { openRemix: result.current.openRemix, openEdit: result.current.openEdit };
 
-    ctrl.segments = ['play'];
-    rerender();
+    rerender({ dismissSourceSheet: secondWaiter });
+    result.current.openRemix(climb, board);
+    await act(async () => {});
 
-    expect(result.current.openRemix).toBe(first.openRemix);
-    expect(result.current.openEdit).toBe(first.openEdit);
-  });
-
-  it('still reads the CURRENT segments through the stable callback', () => {
-    const { result, rerender } = renderHook(() => useCreateClimbNavigation());
-    const openRemix = result.current.openRemix;
-
-    ctrl.segments = ['play'];
-    rerender();
-    openRemix(climb, board);
-
-    expect(router.dismiss).toHaveBeenCalledTimes(1);
+    expect(result.current.openRemix).toBe(firstCallbacks.openRemix);
+    expect(result.current.openEdit).toBe(firstCallbacks.openEdit);
+    expect(firstWaiter).not.toHaveBeenCalled();
+    expect(secondWaiter).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-navigation.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-navigation.test.tsx
@@ -5,8 +5,10 @@ import type { Climb } from '@boardsesh/shared-schema';
 import type { DismissAndWaitResult } from '../../../providers/sheet-presentation-provider';
 
 const router = vi.hoisted(() => ({ push: vi.fn() }));
+const sentry = vi.hoisted(() => ({ capture: vi.fn() }));
 
 vi.mock('expo-router', () => ({ useRouter: () => router }));
+vi.mock('../../../lib/sentry', () => ({ captureToSentry: sentry.capture }));
 
 import { useCreateClimbNavigation, type DismissSurfaceAndWait } from '../use-create-climb-navigation';
 
@@ -28,7 +30,8 @@ function deferredDismiss() {
 }
 
 beforeEach(() => {
-  router.push.mockClear();
+  router.push.mockReset();
+  sentry.capture.mockClear();
 });
 
 describe('useCreateClimbNavigation serialized handoff', () => {
@@ -101,6 +104,29 @@ describe('useCreateClimbNavigation serialized handoff', () => {
     const reopenedMenu = renderHook(() => useCreateClimbNavigation());
     reopenedMenu.result.current.openRemix(climb, board);
 
+    expect(router.push).toHaveBeenCalledTimes(2);
+  });
+
+  it('captures a failed route push while preserving the one-action claim until re-open', async () => {
+    const navigationError = new Error('route transition failed');
+    router.push.mockImplementationOnce(() => {
+      throw navigationError;
+    });
+    const { result } = renderHook(() => useCreateClimbNavigation());
+
+    result.current.openRemix(climb, board);
+    await act(async () => {});
+
+    expect(sentry.capture).toHaveBeenCalledWith(navigationError, {
+      level: 'error',
+      tags: { source: 'create-climb-handoff' },
+    });
+
+    result.current.openRemix(climb, board);
+    expect(router.push).toHaveBeenCalledTimes(1);
+
+    result.current.resetActionGuard();
+    result.current.openRemix(climb, board);
     expect(router.push).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/mobile/src/components/create-climb/__tests__/use-player-dismiss-and-wait.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-player-dismiss-and-wait.test.tsx
@@ -1,11 +1,15 @@
 // @vitest-environment jsdom
-import { act, renderHook } from '@testing-library/react';
+import { act, fireEvent, render, renderHook, screen } from '@testing-library/react';
+import { useCallback, useEffect, useState } from 'react';
+import type { Climb } from '@boardsesh/shared-schema';
+import type { BoardConfig } from '../../../providers/drawer-host-provider';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCreateClimbNavigation, type DismissSurfaceAndWait } from '../use-create-climb-navigation';
 
 type Transition = { data?: { closing?: boolean } };
 
 const platform = vi.hoisted(() => ({ OS: 'ios' }));
-const router = vi.hoisted(() => ({ dismiss: vi.fn() }));
+const router = vi.hoisted(() => ({ dismiss: vi.fn(), push: vi.fn() }));
 const navigation = vi.hoisted(() => ({
   listener: null as ((transition: Transition) => void) | null,
   unsubscribe: vi.fn(),
@@ -25,12 +29,14 @@ vi.mock('expo-router', () => ({
   useRouter: () => router,
   useNavigation: () => navigationSource.current ?? navigation,
 }));
+vi.mock('../../../lib/sentry', () => ({ captureToSentry: vi.fn() }));
 
 import { usePlayerDismissAndWait } from '../use-player-dismiss-and-wait';
 
 beforeEach(() => {
   platform.OS = 'ios';
-  router.dismiss.mockClear();
+  router.dismiss.mockReset();
+  router.push.mockReset();
   navigation.listener = null;
   navigation.unsubscribe.mockClear();
   navigation.addListener.mockClear();
@@ -62,13 +68,31 @@ describe('usePlayerDismissAndWait', () => {
     expect(navigation.unsubscribe).toHaveBeenCalledTimes(1);
   });
 
-  it('cleans up and resolves aborted when the player route unmounts first', async () => {
+  it('returns aborted from a stale player callback without dismissing the route underneath', async () => {
     const { result, unmount } = renderHook(() => usePlayerDismissAndWait());
-    const resultPromise = result.current();
+    const dismissStalePlayer = result.current;
 
     unmount();
 
-    await expect(resultPromise).resolves.toEqual({ status: 'aborted' });
+    await expect(dismissStalePlayer()).resolves.toEqual({ status: 'aborted' });
+    expect(router.dismiss).not.toHaveBeenCalled();
+    expect(navigation.addListener).not.toHaveBeenCalled();
+  });
+
+  it('waits through synchronous player unmount after its own dismiss request', async () => {
+    vi.useFakeTimers();
+    const { result, unmount } = renderHook(() => usePlayerDismissAndWait());
+    router.dismiss.mockImplementationOnce(unmount);
+
+    const resultPromise = result.current();
+    const settled = vi.fn();
+    void resultPromise.then(settled);
+
+    await act(async () => vi.advanceTimersByTimeAsync(549));
+    expect(settled).not.toHaveBeenCalled();
+
+    await act(async () => vi.advanceTimersByTimeAsync(1));
+    await expect(resultPromise).resolves.toEqual({ status: 'dismissed' });
     expect(navigation.unsubscribe).toHaveBeenCalledTimes(1);
   });
 
@@ -118,5 +142,76 @@ describe('usePlayerDismissAndWait', () => {
     act(() => replacementListener?.({ data: { closing: true } }));
     await expect(resultPromise).resolves.toEqual({ status: 'dismissed' });
     expect(replacementUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+});
+
+const handoffClimb = {
+  uuid: 'climb-1',
+  name: 'Sloper Traverse',
+  frames: 'p1129r15p1130r12',
+  description: 'Start matched on the jug',
+} as unknown as Climb;
+const handoffBoard = {
+  boardName: 'kilter',
+  layoutId: 8,
+  sizeId: 17,
+  setIds: '26,27',
+  angle: 40,
+} as unknown as BoardConfig;
+
+function PlayerDismissBridge({ onReady }: { onReady: (waiter: DismissSurfaceAndWait) => void }) {
+  const dismissPlayerAndWait = usePlayerDismissAndWait();
+  useEffect(() => onReady(dismissPlayerAndWait), [dismissPlayerAndWait, onReady]);
+  return null;
+}
+
+function PlayerCreateHandoffHarness({ onPlayerUnmountReady }: { onPlayerUnmountReady: (unmount: () => void) => void }) {
+  const [isPlayerMounted, setIsPlayerMounted] = useState(true);
+  const [dismissPlayerAndWait, setDismissPlayerAndWait] = useState<DismissSurfaceAndWait>();
+  const { openRemix } = useCreateClimbNavigation({ dismissPlayerAndWait });
+  const acceptPlayerWaiter = useCallback((waiter: DismissSurfaceAndWait) => {
+    setDismissPlayerAndWait(() => waiter);
+  }, []);
+  const dismissPlayerRoute = useCallback(() => {
+    setIsPlayerMounted(false);
+  }, []);
+
+  useEffect(() => onPlayerUnmountReady(dismissPlayerRoute), [dismissPlayerRoute, onPlayerUnmountReady]);
+
+  return (
+    <>
+      <button type="button" onClick={() => openRemix(handoffClimb, handoffBoard)}>
+        Open create
+      </button>
+      {isPlayerMounted ? <PlayerDismissBridge onReady={acceptPlayerWaiter} /> : null}
+    </>
+  );
+}
+
+describe('player-to-create handoff', () => {
+  it('pushes create after the player unmounts before its native transition event', async () => {
+    vi.useFakeTimers();
+    let unmountPlayerRoute = () => {};
+    render(<PlayerCreateHandoffHarness onPlayerUnmountReady={(unmount) => (unmountPlayerRoute = unmount)} />);
+    router.dismiss.mockImplementationOnce(unmountPlayerRoute);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open create' }));
+
+    await act(async () => vi.advanceTimersByTimeAsync(550));
+
+    expect(router.dismiss).toHaveBeenCalledTimes(1);
+    expect(router.push).toHaveBeenCalledWith({
+      pathname: '/(tabs)/climbs/create',
+      params: {
+        forkFrames: 'p1129r15p1130r12',
+        forkName: 'Sloper Traverse',
+        forkDescription: 'Start matched on the jug',
+        boardName: 'kilter',
+        layoutId: '8',
+        sizeId: '17',
+        setIds: '26,27',
+        angle: '40',
+      },
+    });
   });
 });

--- a/packages/mobile/src/components/create-climb/__tests__/use-player-dismiss-and-wait.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-player-dismiss-and-wait.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { act, renderHook } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 type Transition = { data?: { closing?: boolean } };
 
@@ -37,6 +37,10 @@ beforeEach(() => {
   navigationSource.current = null;
 });
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe('usePlayerDismissAndWait', () => {
   it('subscribes before dismiss and resolves only the closing transitionEnd', async () => {
     const { result } = renderHook(() => usePlayerDismissAndWait());
@@ -65,6 +69,20 @@ describe('usePlayerDismissAndWait', () => {
     unmount();
 
     await expect(resultPromise).resolves.toEqual({ status: 'aborted' });
+    expect(navigation.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('settles through a bounded ceiling when transitionEnd never arrives', async () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => usePlayerDismissAndWait());
+    const resultPromise = result.current();
+
+    await act(async () => vi.advanceTimersByTimeAsync(1_000));
+
+    await expect(resultPromise).resolves.toEqual({ status: 'dismissed' });
+    expect(navigation.unsubscribe).toHaveBeenCalledTimes(1);
+
+    act(() => navigation.listener?.({ data: { closing: true } }));
     expect(navigation.unsubscribe).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/mobile/src/components/create-climb/__tests__/use-player-dismiss-and-wait.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-player-dismiss-and-wait.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Transition = { data?: { closing?: boolean } };
+
+const platform = vi.hoisted(() => ({ OS: 'ios' }));
+const router = vi.hoisted(() => ({ dismiss: vi.fn() }));
+const navigation = vi.hoisted(() => ({
+  listener: null as ((transition: Transition) => void) | null,
+  unsubscribe: vi.fn(),
+  addListener: vi.fn((_event: string, listener: (transition: Transition) => void) => {
+    navigation.listener = listener;
+    return navigation.unsubscribe;
+  }),
+}));
+
+vi.mock('react-native', () => ({ Platform: platform }));
+vi.mock('expo-router', () => ({
+  useRouter: () => router,
+  useNavigation: () => navigation,
+}));
+
+import { usePlayerDismissAndWait } from '../use-player-dismiss-and-wait';
+
+beforeEach(() => {
+  platform.OS = 'ios';
+  router.dismiss.mockClear();
+  navigation.listener = null;
+  navigation.unsubscribe.mockClear();
+  navigation.addListener.mockClear();
+});
+
+describe('usePlayerDismissAndWait', () => {
+  it('subscribes before dismiss and resolves only the closing transitionEnd', async () => {
+    const { result } = renderHook(() => usePlayerDismissAndWait());
+    const settled = vi.fn();
+
+    const resultPromise = result.current();
+    void resultPromise.then(settled);
+
+    expect(navigation.addListener).toHaveBeenCalledWith('transitionEnd', expect.any(Function));
+    expect(navigation.addListener.mock.invocationCallOrder[0]).toBeLessThan(router.dismiss.mock.invocationCallOrder[0]);
+
+    act(() => navigation.listener?.({ data: { closing: false } }));
+    await Promise.resolve();
+    expect(settled).not.toHaveBeenCalled();
+    expect(navigation.unsubscribe).not.toHaveBeenCalled();
+
+    act(() => navigation.listener?.({ data: { closing: true } }));
+    await expect(resultPromise).resolves.toEqual({ status: 'dismissed' });
+    expect(navigation.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up and resolves aborted when the player route unmounts first', async () => {
+    const { result, unmount } = renderHook(() => usePlayerDismissAndWait());
+    const resultPromise = result.current();
+
+    unmount();
+
+    await expect(resultPromise).resolves.toEqual({ status: 'aborted' });
+    expect(navigation.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not wait for a native event on web', async () => {
+    platform.OS = 'web';
+    const { result } = renderHook(() => usePlayerDismissAndWait());
+
+    await expect(result.current()).resolves.toEqual({ status: 'dismissed' });
+
+    expect(router.dismiss).toHaveBeenCalledTimes(1);
+    expect(navigation.addListener).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/components/create-climb/__tests__/use-player-dismiss-and-wait.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-player-dismiss-and-wait.test.tsx
@@ -14,11 +14,16 @@ const navigation = vi.hoisted(() => ({
     return navigation.unsubscribe;
   }),
 }));
+const navigationSource = vi.hoisted(() => ({
+  current: null as null | {
+    addListener: (event: string, listener: (transition: Transition) => void) => () => void;
+  },
+}));
 
 vi.mock('react-native', () => ({ Platform: platform }));
 vi.mock('expo-router', () => ({
   useRouter: () => router,
-  useNavigation: () => navigation,
+  useNavigation: () => navigationSource.current ?? navigation,
 }));
 
 import { usePlayerDismissAndWait } from '../use-player-dismiss-and-wait';
@@ -29,6 +34,7 @@ beforeEach(() => {
   navigation.listener = null;
   navigation.unsubscribe.mockClear();
   navigation.addListener.mockClear();
+  navigationSource.current = null;
 });
 
 describe('usePlayerDismissAndWait', () => {
@@ -70,5 +76,29 @@ describe('usePlayerDismissAndWait', () => {
 
     expect(router.dismiss).toHaveBeenCalledTimes(1);
     expect(navigation.addListener).not.toHaveBeenCalled();
+  });
+
+  it('keeps the callback stable while subscribing through the latest route navigation object', async () => {
+    let replacementListener: ((transition: Transition) => void) | null = null;
+    const replacementUnsubscribe = vi.fn();
+    const replacementNavigation = {
+      addListener: vi.fn((_event: string, listener: (transition: Transition) => void) => {
+        replacementListener = listener;
+        return replacementUnsubscribe;
+      }),
+    };
+    const { result, rerender } = renderHook(() => usePlayerDismissAndWait());
+    const initialCallback = result.current;
+
+    navigationSource.current = replacementNavigation;
+    rerender();
+
+    expect(result.current).toBe(initialCallback);
+    const resultPromise = result.current();
+    expect(replacementNavigation.addListener).toHaveBeenCalledWith('transitionEnd', expect.any(Function));
+
+    act(() => replacementListener?.({ data: { closing: true } }));
+    await expect(resultPromise).resolves.toEqual({ status: 'dismissed' });
+    expect(replacementUnsubscribe).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mobile/src/components/create-climb/use-create-climb-navigation.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-navigation.ts
@@ -1,8 +1,17 @@
 import { useCallback, useRef } from 'react';
-import { useRouter, useSegments } from 'expo-router';
+import { useRouter } from 'expo-router';
 import type { Climb } from '@boardsesh/shared-schema';
-import { isPlayerRoute } from '../../lib/route-segments';
 import type { BoardConfig } from '../../providers/drawer-host-provider';
+import type { DismissAndWaitResult } from '../../providers/sheet-presentation-provider';
+
+export type DismissSurfaceAndWait = () => Promise<DismissAndWaitResult>;
+
+type UseCreateClimbNavigationOptions = {
+  /** A native BoardSheet / QueueSheet underneath the actions overlay. */
+  dismissSourceSheet?: DismissSurfaceAndWait;
+  /** Supplied only by the real `/play` route. iPad panes deliberately omit it. */
+  dismissPlayerAndWait?: DismissSurfaceAndWait;
+};
 
 /** expo-router params are strings; the create route reads them via `useLocalSearchParams`. */
 function boardParams(board: BoardConfig): Record<string, string> {
@@ -18,64 +27,81 @@ function boardParams(board: BoardConfig): Record<string, string> {
 /**
  * Navigation to the create-climb route (`/(tabs)/climbs/create`) for remix / edit.
  *
- * Remix and Edit can fire from INSIDE the player (`/play`, a `transparentModal` in the
- * ROOT stack). The create route is another `transparentModal`, but it lives in the
- * CLIMBS-TAB stack — a different navigator, mounted BENEATH the root modal. Pushing it
- * while the player is up therefore stacks create under the still-live player: two
- * drawers, and create's bottom sheet strands over the search list once you navigate
- * away. So dismiss the player first, mirroring `handleSwitchBoardFromDrawer`
- * (drawer-host-provider) — the same `router.dismiss()` → `router.push()` shape.
- *
- * The reaction menu that hosts Remix/Edit also opens from the climbs list and the board
- * sheet, and on an iPad regular-width layout the player renders in the detail PANE
- * rather than the `/play` route. Neither has a modal to close, so gate the dismiss on
- * `isPlayerRoute` — otherwise we'd pop the wrong screen.
- *
- * The back-to-back `dismiss()` + `push()` is not a race: both enqueue onto expo-router's
- * single `routingQueue` (`POP` then the navigate), so they drain in order. And `dismiss()`
- * only enqueues — unlike `goBack()` it does not `assertIsReady()` — so an over-eager gate
- * would pop a screen, never throw.
+ * A single accepted action owns the whole handoff: dismiss the custom actions overlay,
+ * await any source native sheet, await the `/play` native-stack closing transition, then
+ * push create. CreateDrawer intentionally remains outside the sheet coordinator, so the
+ * two preceding surfaces must be physically gone before its first render presents it.
  */
-export function useCreateClimbNavigation() {
+export function useCreateClimbNavigation({
+  dismissSourceSheet,
+  dismissPlayerAndWait,
+}: UseCreateClimbNavigationOptions = {}) {
   const router = useRouter();
-  const segments = useSegments();
-  // `useSegments()` hands back a fresh array on every navigation. Reading it from a ref
-  // inside the callback — rather than listing it as a dep — keeps `navigateToCreate` /
-  // `openRemix` / `openEdit` referentially stable, so `useClimbActions`' memoised action
-  // list doesn't rebuild on every navigation. Only ever read from an event handler, well
-  // after render, so the ref is never stale at the point of use.
-  const segmentsRef = useRef(segments);
-  segmentsRef.current = segments;
+  const dismissSourceSheetRef = useRef(dismissSourceSheet);
+  dismissSourceSheetRef.current = dismissSourceSheet;
+  const dismissPlayerAndWaitRef = useRef(dismissPlayerAndWait);
+  dismissPlayerAndWaitRef.current = dismissPlayerAndWait;
+  // The actions overlay remains hit-testable during its short exit animation. Claim the
+  // action synchronously, before asking it to animate out, so a double tap cannot enqueue
+  // two native dismissals or two create routes.
+  const actionInFlightRef = useRef(false);
+  const resetActionGuard = useCallback(() => {
+    actionInFlightRef.current = false;
+  }, []);
 
   const navigateToCreate = useCallback(
-    (params: Record<string, string>) => {
-      if (isPlayerRoute(segmentsRef.current)) router.dismiss();
-      router.push({ pathname: '/(tabs)/climbs/create', params });
+    (params: Record<string, string>, onActionAccepted?: () => void) => {
+      if (actionInFlightRef.current) return;
+      actionInFlightRef.current = true;
+      onActionAccepted?.();
+
+      const completeHandoff = async () => {
+        const dismissSource = dismissSourceSheetRef.current;
+        if (dismissSource) {
+          const sourceResult = await dismissSource();
+          if (sourceResult.status === 'aborted') return;
+        }
+
+        const dismissPlayer = dismissPlayerAndWaitRef.current;
+        if (dismissPlayer) {
+          const playerResult = await dismissPlayer();
+          if (playerResult.status === 'aborted') return;
+        }
+
+        router.push({ pathname: '/(tabs)/climbs/create', params });
+      };
+      void completeHandoff();
     },
     [router],
   );
 
   const openRemix = useCallback(
-    (climb: Climb, board: BoardConfig) =>
-      navigateToCreate({
-        forkFrames: climb.frames,
-        forkName: climb.name,
-        forkDescription: climb.description ?? '',
-        ...boardParams(board),
-      }),
+    (climb: Climb, board: BoardConfig, onActionAccepted?: () => void) =>
+      navigateToCreate(
+        {
+          forkFrames: climb.frames,
+          forkName: climb.name,
+          forkDescription: climb.description ?? '',
+          ...boardParams(board),
+        },
+        onActionAccepted,
+      ),
     [navigateToCreate],
   );
 
   const openEdit = useCallback(
-    (climb: Climb, board: BoardConfig) =>
-      navigateToCreate({
-        editClimbUuid: climb.uuid,
-        ...boardParams(board),
-      }),
+    (climb: Climb, board: BoardConfig, onActionAccepted?: () => void) =>
+      navigateToCreate(
+        {
+          editClimbUuid: climb.uuid,
+          ...boardParams(board),
+        },
+        onActionAccepted,
+      ),
     [navigateToCreate],
   );
 
-  // Only the two semantic wrappers are exposed. `navigateToCreate` stays internal so a
-  // caller can't hand-roll params and skip the dismiss reasoning that lives here.
-  return { openRemix, openEdit };
+  // Only the semantic wrappers are exposed. A caller cannot hand-roll params or bypass
+  // the one-action / source-sheet / player-transition ordering above.
+  return { openRemix, openEdit, resetActionGuard };
 }

--- a/packages/mobile/src/components/create-climb/use-create-climb-navigation.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-navigation.ts
@@ -3,6 +3,7 @@ import { useRouter } from 'expo-router';
 import type { Climb } from '@boardsesh/shared-schema';
 import type { BoardConfig } from '../../providers/drawer-host-provider';
 import type { DismissAndWaitResult } from '../../providers/sheet-presentation-provider';
+import { captureToSentry } from '../../lib/sentry';
 
 export type DismissSurfaceAndWait = () => Promise<DismissAndWaitResult>;
 
@@ -70,7 +71,15 @@ export function useCreateClimbNavigation({
 
         router.push({ pathname: '/(tabs)/climbs/create', params });
       };
-      void completeHandoff();
+      void completeHandoff().catch((error: unknown) => {
+        // The owning overlay is already closing, so keep this presentation's
+        // one-action claim intact. A re-open resets the guard (or remounts this
+        // hook), while the failed route transition still reaches diagnostics.
+        captureToSentry(error, {
+          level: 'error',
+          tags: { source: 'create-climb-handoff' },
+        });
+      });
     },
     [router],
   );

--- a/packages/mobile/src/components/create-climb/use-player-dismiss-and-wait.ts
+++ b/packages/mobile/src/components/create-climb/use-player-dismiss-and-wait.ts
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { Platform } from 'react-native';
+import { useNavigation, useRouter } from 'expo-router';
+import type { DismissAndWaitResult } from '../../providers/sheet-presentation-provider';
+
+type NativeStackTransitionEndEvent = {
+  data?: {
+    closing?: boolean;
+  };
+};
+
+type NativeStackTransitionNavigation = {
+  addListener: (event: 'transitionEnd', listener: (transition: NativeStackTransitionEndEvent) => void) => () => void;
+};
+
+const DISMISSED_RESULT: DismissAndWaitResult = { status: 'dismissed' };
+const ABORTED_RESULT: DismissAndWaitResult = { status: 'aborted' };
+
+/**
+ * `/play`-owned dismissal callback for the create-climb handoff.
+ *
+ * The hook must be mounted inside the actual player route so `useNavigation()`
+ * resolves the native-stack screen navigation object. It subscribes before the
+ * dismiss request and waits specifically for the closing transition to end.
+ * Expo web does not emit that native event, so it dismisses and resolves in the
+ * same turn. Route teardown aborts any outstanding waiter and removes its listener.
+ */
+export function usePlayerDismissAndWait(): () => Promise<DismissAndWaitResult> {
+  const router = useRouter();
+  const navigation = useNavigation() as unknown as NativeStackTransitionNavigation;
+  const pendingAbortsRef = useRef(new Set<() => void>());
+
+  useEffect(
+    () => () => {
+      for (const abort of pendingAbortsRef.current) abort();
+    },
+    [],
+  );
+
+  return useCallback(() => {
+    if (Platform.OS === 'web') {
+      try {
+        router.dismiss();
+        return Promise.resolve(DISMISSED_RESULT);
+      } catch {
+        return Promise.resolve(ABORTED_RESULT);
+      }
+    }
+
+    return new Promise<DismissAndWaitResult>((resolve) => {
+      let finished = false;
+      let unsubscribe = () => {};
+      let finish = (_result: DismissAndWaitResult) => {};
+      const abort = () => finish(ABORTED_RESULT);
+
+      finish = (result: DismissAndWaitResult) => {
+        if (finished) return;
+        finished = true;
+        pendingAbortsRef.current.delete(abort);
+        unsubscribe();
+        resolve(result);
+      };
+      pendingAbortsRef.current.add(abort);
+
+      try {
+        // Register first: a fast native transition must not finish in the gap
+        // between router.dismiss() and listener attachment.
+        unsubscribe = navigation.addListener('transitionEnd', (transition) => {
+          if (transition.data?.closing !== true) return;
+          finish(DISMISSED_RESULT);
+        });
+        router.dismiss();
+      } catch {
+        finish(ABORTED_RESULT);
+      }
+    });
+  }, [navigation, router]);
+}

--- a/packages/mobile/src/components/create-climb/use-player-dismiss-and-wait.ts
+++ b/packages/mobile/src/components/create-climb/use-player-dismiss-and-wait.ts
@@ -28,6 +28,8 @@ const ABORTED_RESULT: DismissAndWaitResult = { status: 'aborted' };
 export function usePlayerDismissAndWait(): () => Promise<DismissAndWaitResult> {
   const router = useRouter();
   const navigation = useNavigation() as unknown as NativeStackTransitionNavigation;
+  const navigationRef = useRef(navigation);
+  navigationRef.current = navigation;
   const pendingAbortsRef = useRef(new Set<() => void>());
 
   useEffect(
@@ -65,7 +67,7 @@ export function usePlayerDismissAndWait(): () => Promise<DismissAndWaitResult> {
       try {
         // Register first: a fast native transition must not finish in the gap
         // between router.dismiss() and listener attachment.
-        unsubscribe = navigation.addListener('transitionEnd', (transition) => {
+        unsubscribe = navigationRef.current.addListener('transitionEnd', (transition) => {
           if (transition.data?.closing !== true) return;
           finish(DISMISSED_RESULT);
         });
@@ -74,5 +76,5 @@ export function usePlayerDismissAndWait(): () => Promise<DismissAndWaitResult> {
         finish(ABORTED_RESULT);
       }
     });
-  }, [navigation, router]);
+  }, [router]);
 }

--- a/packages/mobile/src/components/create-climb/use-player-dismiss-and-wait.ts
+++ b/packages/mobile/src/components/create-climb/use-player-dismiss-and-wait.ts
@@ -15,6 +15,10 @@ type NativeStackTransitionNavigation = {
 
 const DISMISSED_RESULT: DismissAndWaitResult = { status: 'dismissed' };
 const ABORTED_RESULT: DismissAndWaitResult = { status: 'aborted' };
+// Native-stack modal closes normally finish well inside this window. The timer
+// is only a fail-safe for a missing transitionEnd event, so keep it comfortably
+// beyond the usual animation rather than risking an overlapping presentation.
+const PLAYER_DISMISS_CEILING_MS = 800;
 
 /**
  * `/play`-owned dismissal callback for the create-climb handoff.
@@ -23,7 +27,8 @@ const ABORTED_RESULT: DismissAndWaitResult = { status: 'aborted' };
  * resolves the native-stack screen navigation object. It subscribes before the
  * dismiss request and waits specifically for the closing transition to end.
  * Expo web does not emit that native event, so it dismisses and resolves in the
- * same turn. Route teardown aborts any outstanding waiter and removes its listener.
+ * same turn. A bounded ceiling handles a lost native event; route teardown
+ * aborts any outstanding waiter and removes its listener.
  */
 export function usePlayerDismissAndWait(): () => Promise<DismissAndWaitResult> {
   const router = useRouter();
@@ -52,6 +57,7 @@ export function usePlayerDismissAndWait(): () => Promise<DismissAndWaitResult> {
     return new Promise<DismissAndWaitResult>((resolve) => {
       let finished = false;
       let unsubscribe = () => {};
+      let ceilingTimer: ReturnType<typeof setTimeout> | null = null;
       let finish = (_result: DismissAndWaitResult) => {};
       const abort = () => finish(ABORTED_RESULT);
 
@@ -59,6 +65,7 @@ export function usePlayerDismissAndWait(): () => Promise<DismissAndWaitResult> {
         if (finished) return;
         finished = true;
         pendingAbortsRef.current.delete(abort);
+        if (ceilingTimer !== null) clearTimeout(ceilingTimer);
         unsubscribe();
         resolve(result);
       };
@@ -71,6 +78,7 @@ export function usePlayerDismissAndWait(): () => Promise<DismissAndWaitResult> {
           if (transition.data?.closing !== true) return;
           finish(DISMISSED_RESULT);
         });
+        ceilingTimer = setTimeout(() => finish(DISMISSED_RESULT), PLAYER_DISMISS_CEILING_MS);
         router.dismiss();
       } catch {
         finish(ABORTED_RESULT);

--- a/packages/mobile/src/components/create-climb/use-player-dismiss-and-wait.ts
+++ b/packages/mobile/src/components/create-climb/use-player-dismiss-and-wait.ts
@@ -15,10 +15,10 @@ type NativeStackTransitionNavigation = {
 
 const DISMISSED_RESULT: DismissAndWaitResult = { status: 'dismissed' };
 const ABORTED_RESULT: DismissAndWaitResult = { status: 'aborted' };
-// Native-stack modal closes normally finish well inside this window. The timer
-// is only a fail-safe for a missing transitionEnd event, so keep it comfortably
-// beyond the usual animation rather than risking an overlapping presentation.
-const PLAYER_DISMISS_CEILING_MS = 800;
+// Match the native-sheet coordinator's conservative ceilings. A player route can
+// unmount before react-native-screens delivers transitionEnd, so this is also the
+// sole settle signal for that expected teardown path.
+const PLAYER_DISMISS_CEILING_MS = Platform.OS === 'ios' ? 550 : 350;
 
 /**
  * `/play`-owned dismissal callback for the create-climb handoff.
@@ -27,24 +27,33 @@ const PLAYER_DISMISS_CEILING_MS = 800;
  * resolves the native-stack screen navigation object. It subscribes before the
  * dismiss request and waits specifically for the closing transition to end.
  * Expo web does not emit that native event, so it dismisses and resolves in the
- * same turn. A bounded ceiling handles a lost native event; route teardown
- * aborts any outstanding waiter and removes its listener.
+ * same turn. A bounded ceiling handles a lost native event. Route teardown
+ * before this helper starts a dismiss aborts the waiter; teardown caused by this
+ * helper's own dismiss keeps the ceiling alive, because the native event emitter
+ * can disappear before react-native-screens emits transitionEnd.
  */
 export function usePlayerDismissAndWait(): () => Promise<DismissAndWaitResult> {
   const router = useRouter();
   const navigation = useNavigation() as unknown as NativeStackTransitionNavigation;
   const navigationRef = useRef(navigation);
   navigationRef.current = navigation;
-  const pendingAbortsRef = useRef(new Set<() => void>());
+  const isPlayerMountedRef = useRef(true);
+  const pendingRouteUnmountsRef = useRef(new Set<() => void>());
 
-  useEffect(
-    () => () => {
-      for (const abort of pendingAbortsRef.current) abort();
-    },
-    [],
-  );
+  useEffect(() => {
+    isPlayerMountedRef.current = true;
+    return () => {
+      isPlayerMountedRef.current = false;
+      for (const handleRouteUnmount of pendingRouteUnmountsRef.current) handleRouteUnmount();
+    };
+  }, []);
 
   return useCallback(() => {
+    // The callback is threaded through a root-mounted actions menu. If the
+    // player disappeared while an earlier source-sheet wait was settling, do not
+    // let its stale callback pop whatever route is now visible underneath.
+    if (!isPlayerMountedRef.current) return Promise.resolve(ABORTED_RESULT);
+
     if (Platform.OS === 'web') {
       try {
         router.dismiss();
@@ -56,20 +65,40 @@ export function usePlayerDismissAndWait(): () => Promise<DismissAndWaitResult> {
 
     return new Promise<DismissAndWaitResult>((resolve) => {
       let finished = false;
+      let dismissRequested = false;
       let unsubscribe = () => {};
       let ceilingTimer: ReturnType<typeof setTimeout> | null = null;
-      let finish = (_result: DismissAndWaitResult) => {};
-      const abort = () => finish(ABORTED_RESULT);
+      let handleRouteUnmount = () => {};
 
-      finish = (result: DismissAndWaitResult) => {
+      const unsubscribeOnce = () => {
+        const currentUnsubscribe = unsubscribe;
+        unsubscribe = () => {};
+        currentUnsubscribe();
+      };
+
+      const finish = (result: DismissAndWaitResult) => {
         if (finished) return;
         finished = true;
-        pendingAbortsRef.current.delete(abort);
+        pendingRouteUnmountsRef.current.delete(handleRouteUnmount);
         if (ceilingTimer !== null) clearTimeout(ceilingTimer);
-        unsubscribe();
+        unsubscribeOnce();
         resolve(result);
       };
-      pendingAbortsRef.current.add(abort);
+
+      handleRouteUnmount = () => {
+        if (!dismissRequested) {
+          finish(ABORTED_RESULT);
+          return;
+        }
+
+        // This is the normal result of router.dismiss(): React tears down the
+        // player before its native close animation has necessarily reported a
+        // transitionEnd. The listener is now attached to a dead screen, but the
+        // timer is closure-owned and must remain to keep the next route from
+        // presenting over the outgoing player animation.
+        unsubscribeOnce();
+      };
+      pendingRouteUnmountsRef.current.add(handleRouteUnmount);
 
       try {
         // Register first: a fast native transition must not finish in the gap
@@ -78,7 +107,16 @@ export function usePlayerDismissAndWait(): () => Promise<DismissAndWaitResult> {
           if (transition.data?.closing !== true) return;
           finish(DISMISSED_RESULT);
         });
+        // An unusual synchronous teardown while registering must not continue
+        // into router.dismiss() after it has already aborted this waiter.
+        if (finished) {
+          unsubscribeOnce();
+          return;
+        }
         ceilingTimer = setTimeout(() => finish(DISMISSED_RESULT), PLAYER_DISMISS_CEILING_MS);
+        // Set this before calling router.dismiss(): React can synchronously
+        // unmount /play from inside that call, before it returns to this frame.
+        dismissRequested = true;
         router.dismiss();
       } catch {
         finish(ABORTED_RESULT);

--- a/packages/mobile/src/components/gym-directory/ClaimGymSheet.tsx
+++ b/packages/mobile/src/components/gym-directory/ClaimGymSheet.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState, type RefObject } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { BottomSheetModal, BottomSheetTextInput } from '@expo/ui/community/bottom-sheet';
+import { BottomSheetTextInput } from '@expo/ui/community/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import type { Gym } from '@boardsesh/shared-schema';
 import { extractDomain, isClaimableDomain, GYM_CLAIM_MESSAGE_MAX_LENGTH } from '@boardsesh/gym-claim';
@@ -13,11 +13,12 @@ import { useTheme } from '../../providers/theme-provider';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useRequestGymClaim } from '../../lib/graphql/hooks';
 import { extractGraphqlMessage } from '../../lib/graphql/extract-error-message';
+import type { ManagedSheetHandle } from '../../providers/sheet-presentation-provider';
 
 type ClaimMode = 'domain' | 'admin';
 
 type ClaimGymSheetProps = {
-  sheetRef: RefObject<BottomSheetModal | null>;
+  sheetRef: RefObject<ManagedSheetHandle | null>;
   gym: Gym;
   /** Fired after the sheet fully dismisses. A host that mounts this per-target
    *  (the wall finder) clears its target here so the same gym can re-open later. */

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -152,6 +152,8 @@ type PlayDrawerProps = {
    *  its own in-tree beta opener via `options.onAddBetaVideo` so the beta sheet
    *  stacks above the `/play` modal (#3505). */
   onOpenClimbActions?: (climb: Climb, boardConfigOverride?: BoardConfig, options?: OpenClimbActionsOptions) => void;
+  /** Supplied only by the `/play` route. The persistent iPad pane omits it. */
+  dismissPlayerAndWait?: OpenClimbActionsOptions['dismissPlayerAndWait'];
   /** The climb to show; applied on mount and whenever `nonce` changes. */
   openTarget: PlayDrawerOpenTarget | null;
   /** Rendering context. `'route'` (default) is the full-screen `/play` modal — a
@@ -188,6 +190,7 @@ export function PlayDrawer({
   mismatchBoardLabel,
   onSwitchBoard,
   onOpenClimbActions,
+  dismissPlayerAndWait,
   openTarget,
   presentation = 'route',
   paneTopInset = true,
@@ -1079,6 +1082,7 @@ export function PlayDrawer({
           }}
           onToggleFavorite={handleToggleFavorite}
           onAddBetaVideo={isAuthenticated ? handleOpenAddBetaVideo : undefined}
+          dismissPlayerAndWait={dismissPlayerAndWait}
           onClose={handleCloseSubDrawer}
         />
       )}

--- a/packages/mobile/src/components/play-drawer/QueueSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueSheet.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { View, Pressable, Platform, StyleSheet } from 'react-native';
 import { BottomSheetModal } from '@expo/ui/community/bottom-sheet';
-import { useManagedSheet } from '../../providers/sheet-presentation-provider';
+import { useManagedSheet, type DismissAndWaitResult } from '../../providers/sheet-presentation-provider';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import type { Climb, ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
@@ -39,6 +39,8 @@ type QueueSheetProps = {
 export type QueueSheetHandle = {
   present: () => void;
   dismiss: () => void;
+  /** Dismiss and resolve only after the native animation settles. */
+  dismissAndWait: () => Promise<DismissAndWaitResult>;
 };
 
 export const QueueSheet = forwardRef<QueueSheetHandle, QueueSheetProps>(function QueueSheet(
@@ -127,6 +129,7 @@ export const QueueSheet = forwardRef<QueueSheetHandle, QueueSheetProps>(function
       dismiss: () => {
         managed.handle.dismiss();
       },
+      dismissAndWait: () => managed.handle.dismissAndWait(),
     }),
     [managed.handle],
   );

--- a/packages/mobile/src/components/play-drawer/__tests__/queue-sheet-freeze.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/queue-sheet-freeze.test.tsx
@@ -20,6 +20,7 @@ const queueData = vi.hoisted(() => ({
 const managedSheet = vi.hoisted(() => ({
   present: vi.fn(),
   dismiss: vi.fn(),
+  dismissAndWait: vi.fn(async () => ({ status: 'dismissed' as const })),
   onChange: vi.fn(),
   onFullyDismissed: vi.fn(),
 }));
@@ -45,7 +46,11 @@ vi.mock('@expo/ui/community/bottom-sheet', () => ({
 
 vi.mock('../../../providers/sheet-presentation-provider', () => ({
   useManagedSheet: () => ({
-    handle: { present: managedSheet.present, dismiss: managedSheet.dismiss },
+    handle: {
+      present: managedSheet.present,
+      dismiss: managedSheet.dismiss,
+      dismissAndWait: managedSheet.dismissAndWait,
+    },
     onChange: managedSheet.onChange,
     onFullyDismissed: managedSheet.onFullyDismissed,
   }),
@@ -147,6 +152,7 @@ describe('QueueSheet freeze contract', () => {
     queueData.current = makeData(['a', 'b']);
     managedSheet.present.mockClear();
     managedSheet.dismiss.mockClear();
+    managedSheet.dismissAndWait.mockClear();
     queueList.renders = 0;
     queueList.lastQueue = null;
   });
@@ -190,5 +196,14 @@ describe('QueueSheet freeze contract', () => {
     expect(managedSheet.present).toHaveBeenCalledTimes(1);
     expect(container.querySelector('[data-testid="queue-list"]')?.getAttribute('data-uuids')).toBe('a,b,c');
     expect(queueList.lastQueue).toBe(queueData.current?.queue);
+  });
+
+  it('forwards dismissAndWait through the imperative handle', async () => {
+    const handleRef = createRef<QueueSheetHandle>();
+    renderSheet(handleRef);
+
+    if (!handleRef.current) throw new Error('queue sheet handle did not mount');
+    await expect(handleRef.current.dismissAndWait()).resolves.toEqual({ status: 'dismissed' });
+    expect(managedSheet.dismissAndWait).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mobile/src/components/play-drawer/use-queue-sheet-handlers.ts
+++ b/packages/mobile/src/components/play-drawer/use-queue-sheet-handlers.ts
@@ -7,12 +7,18 @@ import type {
   SetCurrentClimbOptions,
 } from '@boardsesh/queue';
 import { climbToQueueItem } from '../../lib/climb-to-queue-item';
-import type { BoardConfig, LogAscentInput, OpenPlayDrawerOptions } from '../../providers/drawer-host-provider';
+import type {
+  BoardConfig,
+  LogAscentInput,
+  OpenClimbActionsOptions,
+  OpenPlayDrawerOptions,
+} from '../../providers/drawer-host-provider';
+import type { DismissAndWaitResult } from '../../providers/sheet-presentation-provider';
 
 type QueueSheetHandlerDeps = {
   setCurrentClimb: (item: ClimbQueueItem, options?: SetCurrentClimbOptions) => void;
   openPlayDrawer: (climb: Climb, options?: OpenPlayDrawerOptions) => void;
-  openClimbActions: (climb: Climb, boardConfigOverride?: BoardConfig) => void;
+  openClimbActions: (climb: Climb, boardConfigOverride?: BoardConfig, options?: OpenClimbActionsOptions) => void;
   openLogAscent: (input: LogAscentInput) => void;
   /** The user's STORED active board (never a drawer override) — the queue renders
    *  against it, and a tick-history log is filed against it. */
@@ -21,6 +27,8 @@ type QueueSheetHandlerDeps = {
   /** Dismiss the QueueSheet this set of handlers drives (the host's instance or
    *  the play-route's instance). */
   requestCloseQueueSheet: () => void;
+  /** Await the exact QueueSheet instance this handler set drives. */
+  dismissQueueSheetAndWait: () => Promise<DismissAndWaitResult>;
 };
 
 type QueueSheetHandlers = {
@@ -46,6 +54,7 @@ export function useQueueSheetHandlers({
   storedBoardConfig,
   sessionId,
   requestCloseQueueSheet,
+  dismissQueueSheetAndWait,
 }: QueueSheetHandlerDeps): QueueSheetHandlers {
   // Tap a queue item → make it current (for the whole session, always-live) and
   // show it in the play drawer.
@@ -63,9 +72,9 @@ export function useQueueSheetHandlers({
   // correct.
   const handleOpenActions = useCallback(
     (item: ClimbQueueItem) => {
-      openClimbActions(item.climb);
+      openClimbActions(item.climb, undefined, { dismissSourceSheet: dismissQueueSheetAndWait });
     },
-    [openClimbActions],
+    [openClimbActions, dismissQueueSheetAndWait],
   );
 
   // Tap a suggestion → activate it with a suggestion source built from the

--- a/packages/mobile/src/components/user-drawer/FeedbackSheet.tsx
+++ b/packages/mobile/src/components/user-drawer/FeedbackSheet.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, type RefObject } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { BottomSheetModal, BottomSheetTextInput } from '@expo/ui/community/bottom-sheet';
+import { BottomSheetTextInput } from '@expo/ui/community/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import { ModalSheet } from '../ModalSheet';
 import { Text } from '../Text';
@@ -16,6 +16,7 @@ import { spacing, borderRadius } from '../../theme/tokens';
 import { useSubmitMobileAppFeedback } from '../../lib/feedback/use-submit-app-feedback';
 import { runBleAdvertisementRecon } from '../../lib/ble/advertisement-recon';
 import { openDiscordInvite } from '../../lib/discord';
+import type { ManagedSheetHandle } from '../../providers/sheet-presentation-provider';
 
 export type FeedbackSheetMode = 'rating' | 'bug';
 
@@ -24,7 +25,7 @@ const COMMENT_MAX_LENGTH = 2000;
 const STAR_RATING_VALUES = [1, 2, 3, 4, 5] as const;
 
 type FeedbackSheetProps = {
-  sheetRef: RefObject<BottomSheetModal | null>;
+  sheetRef: RefObject<ManagedSheetHandle | null>;
   mode: FeedbackSheetMode;
   /**
    * Show a "Join Discord" link below the submit button. Used on the login screen,

--- a/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
+++ b/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
@@ -1,11 +1,11 @@
 import { createContext, useCallback, useContext, useMemo, useRef, useState, type ReactNode } from 'react';
 import { router, useSegments } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import type { BottomSheetModal } from '@expo/ui/community/bottom-sheet';
 import { openDiscordInvite } from '../../lib/discord';
 import { reportError } from '../../lib/error-reporting';
 import { showSignOutFailure } from '../../lib/sign-out-failure-alert';
 import { useAuth } from '../../providers/auth-provider';
+import type { ManagedSheetHandle } from '../../providers/sheet-presentation-provider';
 import { FeedbackSheet, type FeedbackSheetMode } from './FeedbackSheet';
 
 type BoardReturnTo = '/(tabs)/discover' | '/(tabs)/climbs';
@@ -50,7 +50,7 @@ export function UserDrawerProvider({ children }: { children: ReactNode }) {
   const { signOut } = useAuth();
   const { t } = useTranslation('common');
   const segments = useSegments();
-  const feedbackSheetRef = useRef<BottomSheetModal>(null);
+  const feedbackSheetRef = useRef<ManagedSheetHandle>(null);
   const [feedbackMode, setFeedbackMode] = useState<FeedbackSheetMode>('rating');
 
   // Mirror the latest focused-route segments into a ref so the callbacks below

--- a/packages/mobile/src/components/user-drawer/__tests__/FeedbackSheet.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/FeedbackSheet.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent } from '@testing-library/react';
 import { createElement, createRef, type ReactNode } from 'react';
-import type { BottomSheetModal } from '@expo/ui/community/bottom-sheet';
+import type { ManagedSheetHandle } from '../../../providers/sheet-presentation-provider';
 
 type ViewMockProps = { children?: ReactNode };
 vi.mock('react-native', () => ({
@@ -124,20 +124,20 @@ describe('FeedbackSheet bug report contact consent', () => {
     root.querySelector('[data-switch="feedbackForm.contactConsentLabel"]') as HTMLButtonElement | null;
 
   it('defaults contact consent to on (opt-out) for an authenticated bug report', () => {
-    const sheetRef = createRef<BottomSheetModal>();
+    const sheetRef = createRef<ManagedSheetHandle>();
     const { container } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
     expect(switchRow(container)?.getAttribute('data-value')).toBe('true');
   });
 
   it('does not render the consent switch when unauthenticated', () => {
     auth.isAuthenticated = false;
-    const sheetRef = createRef<BottomSheetModal>();
+    const sheetRef = createRef<ManagedSheetHandle>();
     const { container } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
     expect(switchRow(container)).toBeNull();
   });
 
   it('submits contactConsent true by default without the user touching the switch', async () => {
-    const sheetRef = createRef<BottomSheetModal>();
+    const sheetRef = createRef<ManagedSheetHandle>();
     const { container, getByPlaceholderText } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
     fireEvent.change(getByPlaceholderText('feedbackForm.bugPlaceholder'), {
       target: { value: 'the board disconnects on start' },
@@ -148,7 +148,7 @@ describe('FeedbackSheet bug report contact consent', () => {
   });
 
   it('respects an explicit opt-out when the reporter flips the switch off', async () => {
-    const sheetRef = createRef<BottomSheetModal>();
+    const sheetRef = createRef<ManagedSheetHandle>();
     const { container, getByPlaceholderText } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
     fireEvent.click(switchRow(container)!);
     expect(switchRow(container)?.getAttribute('data-value')).toBe('false');
@@ -162,7 +162,7 @@ describe('FeedbackSheet bug report contact consent', () => {
   });
 
   it('resets the switch back to on after a successful submit, even from an opt-out', async () => {
-    const sheetRef = createRef<BottomSheetModal>();
+    const sheetRef = createRef<ManagedSheetHandle>();
     const { container, getByPlaceholderText } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
     fireEvent.click(switchRow(container)!);
     expect(switchRow(container)?.getAttribute('data-value')).toBe('false');
@@ -176,7 +176,7 @@ describe('FeedbackSheet bug report contact consent', () => {
   });
 
   it('resets the switch back to on when the sheet mode changes away and back', () => {
-    const sheetRef = createRef<BottomSheetModal>();
+    const sheetRef = createRef<ManagedSheetHandle>();
     const { container, rerender } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
     fireEvent.click(switchRow(container)!);
     expect(switchRow(container)?.getAttribute('data-value')).toBe('false');

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -30,10 +30,12 @@ const queueSheet = vi.hoisted(() => ({
     };
     onClose: () => void;
     onClimbPress: (item: ClimbQueueItem) => void;
+    onOpenActions: (item: ClimbQueueItem) => void;
     onSuggestionPress: (climb: ClimbQueueItem['climb'], source: PlaylistSuggestionSource) => void;
   },
   present: vi.fn(),
   dismiss: vi.fn(),
+  dismissAndWait: vi.fn(async () => ({ status: 'dismissed' as const })),
 }));
 
 const climbActions = vi.hoisted(() => ({
@@ -52,6 +54,7 @@ const boardSheet = vi.hoisted(() => ({
   props: null as null | Record<string, unknown>,
   present: vi.fn(),
   dismiss: vi.fn(),
+  dismissAndWait: vi.fn(async () => ({ status: 'dismissed' as const })),
 }));
 
 const activeBoard = vi.hoisted(() => {
@@ -146,6 +149,7 @@ vi.mock('../../components/play-drawer/QueueSheet', async () => {
           };
           onClose: () => void;
           onClimbPress: (item: ClimbQueueItem) => void;
+          onOpenActions: (item: ClimbQueueItem) => void;
           onSuggestionPress: (climb: ClimbQueueItem['climb'], source: PlaylistSuggestionSource) => void;
         },
         ref,
@@ -154,6 +158,7 @@ vi.mock('../../components/play-drawer/QueueSheet', async () => {
         React.useImperativeHandle(ref, () => ({
           present: queueSheet.present,
           dismiss: queueSheet.dismiss,
+          dismissAndWait: queueSheet.dismissAndWait,
         }));
         return React.createElement('div', { 'data-queue-sheet': 'true' });
       },
@@ -191,7 +196,11 @@ vi.mock('../../components/board-presence/BoardSheet', async () => {
   return {
     BoardSheet: React.forwardRef((props: Record<string, unknown>, ref) => {
       boardSheet.props = props;
-      React.useImperativeHandle(ref, () => ({ present: boardSheet.present, dismiss: boardSheet.dismiss }));
+      React.useImperativeHandle(ref, () => ({
+        present: boardSheet.present,
+        dismiss: boardSheet.dismiss,
+        dismissAndWait: boardSheet.dismissAndWait,
+      }));
       return React.createElement('div', { 'data-board-sheet': 'true' });
     }),
   };
@@ -451,11 +460,13 @@ describe('DrawerHostProvider queue sheet (always-live, no driver gate)', () => {
     queueSheet.props = null;
     queueSheet.present.mockClear();
     queueSheet.dismiss.mockClear();
+    queueSheet.dismissAndWait.mockClear();
     climbActions.props = null;
     playlistSheet.props = null;
     boardSheet.props = null;
     boardSheet.present.mockClear();
     boardSheet.dismiss.mockClear();
+    boardSheet.dismissAndWait.mockClear();
   });
 
   it('broadcasts queued climb selection for every session member', async () => {
@@ -530,6 +541,21 @@ describe('DrawerHostProvider queue sheet (always-live, no driver gate)', () => {
     });
     expect(routes.at(-1)?.playTarget?.options).toEqual({ committedExternally: true });
   });
+
+  it('threads the exact queue-sheet settle callback into climb actions', async () => {
+    const hosts: Array<HostValue> = [];
+    renderHost((host) => hosts.push(host));
+    await waitFor(() => expect(queueSheet.props).not.toBeNull());
+
+    const item = makeQueueItem('queue-actions', 'climb-actions');
+    act(() => queueSheet.props?.onOpenActions(item));
+    await waitFor(() => expect(climbActions.props).not.toBeNull());
+
+    const dismissSourceSheet = climbActions.props?.dismissSourceSheet as (() => Promise<unknown>) | undefined;
+    if (!dismissSourceSheet) throw new Error('queue dismiss callback was not forwarded');
+    await expect(dismissSourceSheet()).resolves.toEqual({ status: 'dismissed' });
+    expect(queueSheet.dismissAndWait).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('DrawerHostProvider board sheet climb actions', () => {
@@ -543,6 +569,7 @@ describe('DrawerHostProvider board sheet climb actions', () => {
     boardSheet.props = null;
     boardSheet.present.mockClear();
     boardSheet.dismiss.mockClear();
+    boardSheet.dismissAndWait.mockClear();
   });
 
   it('sets current and opens the drawer when any session member taps a board-sheet climb', async () => {
@@ -628,6 +655,10 @@ describe('DrawerHostProvider board sheet climb actions', () => {
       climb,
       boardConfig: { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2', angle: 30 },
     });
+    const dismissSourceSheet = climbActions.props?.dismissSourceSheet as (() => Promise<unknown>) | undefined;
+    if (!dismissSourceSheet) throw new Error('board dismiss callback was not forwarded');
+    await expect(dismissSourceSheet()).resolves.toEqual({ status: 'dismissed' });
+    expect(boardSheet.dismissAndWait).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -638,11 +669,13 @@ describe('DrawerHostProvider queue sheet open / re-open', () => {
     queueSheet.props = null;
     queueSheet.present.mockClear();
     queueSheet.dismiss.mockClear();
+    queueSheet.dismissAndWait.mockClear();
     climbActions.props = null;
     playlistSheet.props = null;
     boardSheet.props = null;
     boardSheet.present.mockClear();
     boardSheet.dismiss.mockClear();
+    boardSheet.dismissAndWait.mockClear();
   });
 
   it('stays mounted and presents via the imperative handle on open', async () => {
@@ -1007,6 +1040,21 @@ describe('DrawerHostProvider iPad pane open (regular width)', () => {
     // drawer's job (via openTarget.options), so the host never calls
     // setCurrentClimb on a pane open.
     layoutCfg.widthClass = 'regular';
+    climbActions.props = null;
+    boardSheet.dismissAndWait.mockClear();
+  });
+
+  it('opens wall-column actions without attaching the modal BoardSheet dismiss', async () => {
+    const hosts: Array<HostValue> = [];
+    renderHost((host) => hosts.push(host));
+    await waitFor(() => expect(hosts.at(-1)?.boardPanelProps).not.toBeNull());
+
+    const climb = makeQueueItem('queue-pane-actions', 'climb-pane-actions').climb as unknown as Climb;
+    act(() => hosts.at(-1)?.boardPanelProps?.onOpenActions(makeBoardSheetAction(climb)));
+    await waitFor(() => expect(climbActions.props).not.toBeNull());
+
+    expect(climbActions.props?.dismissSourceSheet).toBeUndefined();
+    expect(boardSheet.dismissAndWait).not.toHaveBeenCalled();
   });
 
   it('drives the pane open target without navigating to /play', async () => {

--- a/packages/mobile/src/providers/__tests__/sheet-presentation-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/sheet-presentation-provider.test.tsx
@@ -133,6 +133,20 @@ describe('SheetPresentationProvider coordinator', () => {
     expect(settled).toHaveBeenCalledTimes(1);
   });
 
+  it('aborts a present-in-flight dismiss waiter when a fresh open supersedes it', async () => {
+    const a = makeSheet();
+    coordinator.register({ id: 'a', group: 'root', ...a });
+    coordinator.setDesiredOpen('a', true);
+
+    const resultPromise = coordinator.dismissAndWait('a');
+    coordinator.setDesiredOpen('a', true);
+
+    await expect(resultPromise).resolves.toEqual({ status: 'aborted' });
+    vi.advanceTimersByTime(SETTLE_MS);
+    expect(a.dismiss).not.toHaveBeenCalled();
+    expect(coordinator.isPresented('a')).toBe(true);
+  });
+
   it('dismissAndWait uses the existing platform ceiling and resolves duplicate waiters together', async () => {
     const a = makeSheet();
     coordinator.register({ id: 'a', group: 'root', ...a });

--- a/packages/mobile/src/providers/__tests__/sheet-presentation-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/sheet-presentation-provider.test.tsx
@@ -108,6 +108,62 @@ describe('SheetPresentationProvider coordinator', () => {
     expect(a.onFullyDismissed).toHaveBeenCalledTimes(1);
   });
 
+  it('dismissAndWait follows a present-in-flight through its later dismiss settle', async () => {
+    const a = makeSheet();
+    coordinator.register({ id: 'a', group: 'root', ...a });
+    coordinator.setDesiredOpen('a', true);
+
+    const settled = vi.fn();
+    const resultPromise = coordinator.dismissAndWait('a');
+    void resultPromise.then(settled);
+    expect(a.dismiss).not.toHaveBeenCalled(); // presenting cannot be interrupted
+
+    vi.advanceTimersByTime(SETTLE_MS); // present settles, then dismiss starts
+    expect(a.dismiss).toHaveBeenCalledTimes(1);
+    await Promise.resolve();
+    expect(settled).not.toHaveBeenCalled();
+
+    coordinator.notifyFullyDismissed('a');
+    await expect(resultPromise).resolves.toEqual({ status: 'dismissed' });
+    expect(settled).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismissAndWait uses the existing platform ceiling and resolves duplicate waiters together', async () => {
+    const a = makeSheet();
+    coordinator.register({ id: 'a', group: 'root', ...a });
+    coordinator.setDesiredOpen('a', true);
+    vi.advanceTimersByTime(SETTLE_MS);
+
+    const first = coordinator.dismissAndWait('a');
+    const second = coordinator.dismissAndWait('a');
+    expect(a.dismiss).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(SETTLE_MS);
+    await expect(Promise.all([first, second])).resolves.toEqual([{ status: 'dismissed' }, { status: 'dismissed' }]);
+  });
+
+  it('dismissAndWait resolves aborted when the registered Host tears down before settle', async () => {
+    const a = makeSheet();
+    const unregister = coordinator.register({ id: 'a', group: 'root', ...a });
+    coordinator.setDesiredOpen('a', true);
+    vi.advanceTimersByTime(SETTLE_MS);
+
+    const resultPromise = coordinator.dismissAndWait('a');
+    expect(a.dismiss).toHaveBeenCalledTimes(1);
+    unregister();
+
+    await expect(resultPromise).resolves.toEqual({ status: 'aborted' });
+    expect(coordinator.isBusy('root')).toBe(true); // teardown still keeps the group guarded
+  });
+
+  it('dismissAndWait resolves immediately when the sheet is already absent', async () => {
+    const a = makeSheet();
+    coordinator.register({ id: 'a', group: 'root', ...a });
+
+    await expect(coordinator.dismissAndWait('a')).resolves.toEqual({ status: 'dismissed' });
+    expect(a.dismiss).not.toHaveBeenCalled();
+  });
+
   it('warns (dev) when an iOS coordinator-driven dismiss settles via the ceiling timer', () => {
     vi.stubGlobal('__DEV__', true);
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -358,6 +414,18 @@ describe('useManagedSheet bridge', () => {
       managed?.handle.dismiss();
     });
     expect(sheetApi.dismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards dismissAndWait through the managed handle', async () => {
+    render(createElement(SheetPresentationProvider, null, createElement(ManagedHarness, { open: true })));
+    vi.advanceTimersByTime(SETTLE_MS);
+
+    if (!managed) throw new Error('managed sheet did not mount');
+    const resultPromise = managed.handle.dismissAndWait();
+    expect(sheetApi.dismiss).toHaveBeenCalledTimes(1);
+    act(() => managed?.onFullyDismissed());
+
+    await expect(resultPromise).resolves.toEqual({ status: 'dismissed' });
   });
 
   it('a user pan-down (onChange(-1)) fires onClose', () => {

--- a/packages/mobile/src/providers/__tests__/sheet-presentation-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/sheet-presentation-provider.test.tsx
@@ -9,6 +9,7 @@ vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }));
 
 import {
   SheetPresentationProvider,
+  dismissManagedSheetAndWait,
   useSheetPresentation,
   useManagedSheet,
   type SheetCoordinator,
@@ -38,6 +39,10 @@ afterEach(() => {
 });
 
 describe('SheetPresentationProvider coordinator', () => {
+  it('treats a missing managed-sheet handle as already dismissed', async () => {
+    await expect(dismissManagedSheetAndWait(null)).resolves.toEqual({ status: 'dismissed' });
+  });
+
   it('presents an opened sheet and reports it presented after the settle window', () => {
     const a = makeSheet();
     coordinator.register({ id: 'a', group: 'root', ...a });

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -44,7 +44,7 @@ import { SIDEBAR_WIDTH } from '../theme/layout';
 import { useQueueSnackbar } from './queue-snackbar-provider';
 import { useBoardPresenceControls, type ResolveBoardUuidArgs } from './board-presence-provider';
 import { useOptionalBluetoothContext } from './bluetooth-provider';
-import type { DismissAndWaitResult } from './sheet-presentation-provider';
+import { dismissManagedSheetAndWait, type DismissAndWaitResult } from './sheet-presentation-provider';
 
 export type BoardConfig = {
   boardName: string;
@@ -583,8 +583,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     queueSheetRef.current?.dismiss();
   }, []);
   const dismissQueueSheetAndWait = useCallback((): Promise<DismissAndWaitResult> => {
-    const handle = queueSheetRef.current;
-    return handle ? handle.dismissAndWait() : Promise.resolve({ status: 'aborted' });
+    return dismissManagedSheetAndWait(queueSheetRef.current);
   }, []);
 
   // Board sheet: present imperatively via the ref, exactly like the queue sheet
@@ -599,8 +598,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   }, []);
   const requestCloseBoardSheet = useCallback(() => boardSheetRef.current?.dismiss(), []);
   const dismissBoardSheetAndWait = useCallback((): Promise<DismissAndWaitResult> => {
-    const handle = boardSheetRef.current;
-    return handle ? handle.dismissAndWait() : Promise.resolve({ status: 'aborted' });
+    return dismissManagedSheetAndWait(boardSheetRef.current);
   }, []);
   // Snackbar "Open": dismiss the snackbar, then open the queue sheet.
   const handleSnackbarOpen = useCallback(() => {

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -44,6 +44,7 @@ import { SIDEBAR_WIDTH } from '../theme/layout';
 import { useQueueSnackbar } from './queue-snackbar-provider';
 import { useBoardPresenceControls, type ResolveBoardUuidArgs } from './board-presence-provider';
 import { useOptionalBluetoothContext } from './bluetooth-provider';
+import type { DismissAndWaitResult } from './sheet-presentation-provider';
 
 export type BoardConfig = {
   boardName: string;
@@ -69,6 +70,12 @@ export type OpenClimbActionsOptions = {
    *  with it (the "tick sheet closes immediately" bug). Same fix shape as
    *  `onAddBetaVideo` (#3505). Receives the climb/board snapshot the menu opened for. */
   onTick?: (climb: Climb, boardConfig: BoardConfig) => void;
+  /** Awaitable close for a native BoardSheet / QueueSheet underneath the custom
+   * actions overlay. Omitted when the source is an inline iPad pane. */
+  dismissSourceSheet?: () => Promise<DismissAndWaitResult>;
+  /** `/play`-owned native-stack close waiter. Threaded from the route because a
+   * root overlay cannot safely subscribe to the player's transition events. */
+  dismissPlayerAndWait?: () => Promise<DismissAndWaitResult>;
 };
 
 export type LogAscentInput = {
@@ -335,6 +342,8 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     onEditEntry?: () => void;
     onAddBetaVideo?: (climb: Climb, boardConfig: BoardConfig) => void;
     onTick?: (climb: Climb, boardConfig: BoardConfig) => void;
+    dismissSourceSheet?: () => Promise<DismissAndWaitResult>;
+    dismissPlayerAndWait?: () => Promise<DismissAndWaitResult>;
   } | null>(null);
   const { addToQueue, setSessionBoardPath, setCurrentClimb } = useQueueActions();
   const { sessionId } = useQueueSessionControls();
@@ -524,6 +533,8 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
         onEditEntry: options?.onEditEntry,
         onAddBetaVideo: options?.onAddBetaVideo,
         onTick: options?.onTick,
+        dismissSourceSheet: options?.dismissSourceSheet,
+        dismissPlayerAndWait: options?.dismissPlayerAndWait,
       });
     },
     [],
@@ -571,6 +582,10 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   const requestCloseQueueSheet = useCallback(() => {
     queueSheetRef.current?.dismiss();
   }, []);
+  const dismissQueueSheetAndWait = useCallback((): Promise<DismissAndWaitResult> => {
+    const handle = queueSheetRef.current;
+    return handle ? handle.dismissAndWait() : Promise.resolve({ status: 'aborted' });
+  }, []);
 
   // Board sheet: present imperatively via the ref, exactly like the queue sheet
   // and Play Drawer. gorhom's present() from a `visible`-prop effect is a silent
@@ -583,6 +598,10 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     boardSheetRef.current?.present();
   }, []);
   const requestCloseBoardSheet = useCallback(() => boardSheetRef.current?.dismiss(), []);
+  const dismissBoardSheetAndWait = useCallback((): Promise<DismissAndWaitResult> => {
+    const handle = boardSheetRef.current;
+    return handle ? handle.dismissAndWait() : Promise.resolve({ status: 'aborted' });
+  }, []);
   // Snackbar "Open": dismiss the snackbar, then open the queue sheet.
   const handleSnackbarOpen = useCallback(() => {
     dismissSnackbar();
@@ -617,6 +636,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     storedBoardConfig: storedActiveBoardConfig,
     sessionId,
     requestCloseQueueSheet,
+    dismissQueueSheetAndWait,
   });
 
   // Switch-board control inside the board sheet: dismiss the sheet, then open
@@ -695,7 +715,17 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     [openAddToPlaylist],
   );
 
-  const handleBoardSheetOpenActions = useCallback(
+  const handleBoardSheetModalOpenActions = useCallback(
+    (action: BoardSheetClimbAction) => {
+      openClimbActions(action.climb, action.boardConfig, { dismissSourceSheet: dismissBoardSheetAndWait });
+    },
+    [openClimbActions, dismissBoardSheetAndWait],
+  );
+
+  // The regular-width iPad wall surface is a persistent inline pane, not the
+  // BoardSheet modal. Never hand it a modal dismiss callback: doing so could close
+  // an unrelated hidden/reopening sheet or abort a valid create navigation.
+  const handleBoardPanelOpenActions = useCallback(
     (action: BoardSheetClimbAction) => {
       openClimbActions(action.climb, action.boardConfig);
     },
@@ -764,7 +794,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
             onClimbPress: handleBoardSheetClimbPress,
             onAddToQueue: handleBoardSheetAddToQueue,
             onOpenPlaylist: handleBoardSheetOpenPlaylist,
-            onOpenActions: handleBoardSheetOpenActions,
+            onOpenActions: handleBoardPanelOpenActions,
           }
         : null,
     [
@@ -774,7 +804,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
       handleBoardSheetClimbPress,
       handleBoardSheetAddToQueue,
       handleBoardSheetOpenPlaylist,
-      handleBoardSheetOpenActions,
+      handleBoardPanelOpenActions,
     ],
   );
 
@@ -900,7 +930,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
           onClimbPress={handleBoardSheetClimbPress}
           onAddToQueue={handleBoardSheetAddToQueue}
           onOpenPlaylist={handleBoardSheetOpenPlaylist}
-          onOpenActions={handleBoardSheetOpenActions}
+          onOpenActions={handleBoardSheetModalOpenActions}
         />
         {/* Rendered after the queue/board sheets so its iOS FullWindowOverlay mounts as a
           later sibling and floats above them when a row inside those sheets is
@@ -915,6 +945,8 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
             onEditEntry={climbActions.onEditEntry}
             onAddBetaVideo={climbActions.onAddBetaVideo}
             onTick={climbActions.onTick}
+            dismissSourceSheet={climbActions.dismissSourceSheet}
+            dismissPlayerAndWait={climbActions.dismissPlayerAndWait}
             reduceMotion={reduceMotion}
             onClose={closeClimbActions}
           />

--- a/packages/mobile/src/providers/sheet-presentation-provider.tsx
+++ b/packages/mobile/src/providers/sheet-presentation-provider.tsx
@@ -49,6 +49,14 @@ import type { BottomSheetMethods } from '@expo/ui/community/bottom-sheet';
 
 export type PresenterGroup = 'root' | (string & {});
 
+/** Result of an awaitable surface dismissal. `aborted` means the registered
+ * host disappeared before its native dismiss settled; callers must stop the
+ * handoff instead of presenting a replacement over an indeterminate teardown. */
+export type DismissAndWaitResult = { status: 'dismissed' } | { status: 'aborted' };
+
+const DISMISSED_RESULT: DismissAndWaitResult = { status: 'dismissed' };
+const ABORTED_RESULT: DismissAndWaitResult = { status: 'aborted' };
+
 /** How long after JS asks a native sheet to dismiss we treat it as still
  * animating (the ceiling before we let the next transition run). iOS modal sheet
  * present/dismiss is ~0.4-0.5s; Android material is quicker. This is the primary
@@ -98,6 +106,10 @@ export type SheetCoordinator = {
   /** Declarative entry point: the desired open/closed state for a sheet. The
    * scheduler reconciles it against what's physically presented. */
   setDesiredOpen: (id: string, open: boolean) => void;
+  /** Close this sheet and resolve only after the coordinator's existing native
+   * settle signal / platform ceiling. Duplicate callers share the same settle;
+   * unregistering the host resolves every pending caller as `aborted`. */
+  dismissAndWait: (id: string) => Promise<DismissAndWaitResult>;
   /** The native sheet finished its dismiss animation (patched `@expo/ui`
    * `onDismiss`). Early-resolves the settle so the next transition can start. */
   notifyFullyDismissed: (id: string) => void;
@@ -123,6 +135,7 @@ export function SheetPresentationProvider({ children }: { children: ReactNode })
   const registrations = useRef(new Map<string, Registration>());
   const desired = useRef(new Map<string, { open: boolean; seq: number }>());
   const groups = useRef(new Map<PresenterGroup, GroupState>());
+  const dismissWaiters = useRef(new Map<string, Set<(result: DismissAndWaitResult) => void>>());
   const seqCounter = useRef(0);
 
   const coordinator = useMemo<SheetCoordinator>(() => {
@@ -157,6 +170,13 @@ export function SheetPresentationProvider({ children }: { children: ReactNode })
       return bestId;
     }
 
+    function settleDismissWaiters(id: string, result: DismissAndWaitResult): void {
+      const waiters = dismissWaiters.current.get(id);
+      if (!waiters) return;
+      dismissWaiters.current.delete(id);
+      for (const resolve of waiters) resolve(result);
+    }
+
     function onSettle(group: PresenterGroup, viaCeiling: boolean): void {
       const state = groupState(group);
       const inFlight = state.inFlight;
@@ -167,6 +187,10 @@ export function SheetPresentationProvider({ children }: { children: ReactNode })
         state.presentedId = inFlight.id;
       } else {
         state.presentedId = null;
+        // Resolve before the consumer's onFullyDismissed callback: that callback
+        // may unmount/unregister the Host, which is an abort only while a native
+        // dismissal is still outstanding, not after it has settled.
+        settleDismissWaiters(inFlight.id, DISMISSED_RESULT);
         registrations.current.get(inFlight.id)?.onFullyDismissed?.();
         if (__DEV__ && viaCeiling && inFlight.expectNative) {
           console.warn(
@@ -241,6 +265,10 @@ export function SheetPresentationProvider({ children }: { children: ReactNode })
         groupState(reg.group);
         return () => {
           const state = groupState(reg.group);
+          // A caller waiting to navigate must not continue after this Host is
+          // torn down. Resolve (never reject) so fire-and-forget action paths do
+          // not create unhandled promise rejections.
+          settleDismissWaiters(reg.id, ABORTED_RESULT);
           // Was this sheet presented or mid-transition when it unmounted? If so its
           // native teardown is still animating out, even though no coordinator
           // dismiss was issued (e.g. a present-on-mount sheet the parent unmounts
@@ -275,6 +303,39 @@ export function SheetPresentationProvider({ children }: { children: ReactNode })
         desired.current.set(id, { open, seq });
         const group = groupOf(id);
         if (group) pump(group);
+      },
+
+      dismissAndWait(id) {
+        const registration = registrations.current.get(id);
+        // No registration and no transition owned by this id means there is no
+        // native surface left to wait for.
+        if (!registration) return Promise.resolve(DISMISSED_RESULT);
+
+        const state = groupState(registration.group);
+        const involved = state.presentedId === id || state.inFlight?.id === id;
+        const previous = desired.current.get(id);
+        desired.current.set(id, { open: false, seq: previous?.seq ?? 0 });
+
+        if (!involved) {
+          // It may have been desired while another group member was transitioning,
+          // but it never reached the native presenter. Cancel that queued desire
+          // and finish immediately.
+          pump(registration.group);
+          return Promise.resolve(DISMISSED_RESULT);
+        }
+
+        return new Promise<DismissAndWaitResult>((resolve) => {
+          let waiters = dismissWaiters.current.get(id);
+          if (!waiters) {
+            waiters = new Set();
+            dismissWaiters.current.set(id, waiters);
+          }
+          waiters.add(resolve);
+          // Presented → dismiss now. Present-in-flight → the desired-close is
+          // observed when that transition settles, then the normal pump starts a
+          // dismiss. An already-running dismiss simply keeps this waiter attached.
+          pump(registration.group);
+        });
       },
 
       notifyFullyDismissed(id) {
@@ -326,7 +387,9 @@ export function SheetPresentationProvider({ children }: { children: ReactNode })
 export type ManagedSheetHandle = Pick<
   BottomSheetMethods,
   'present' | 'dismiss' | 'close' | 'forceClose' | 'snapToIndex' | 'snapToPosition' | 'expand' | 'collapse'
->;
+> & {
+  dismissAndWait: () => Promise<DismissAndWaitResult>;
+};
 
 type UseManagedSheetOptions = {
   /** Controlled open state. Pass a boolean to drive the sheet declaratively;
@@ -440,6 +503,7 @@ export function useManagedSheet({
     () => ({
       present: () => coordinator.setDesiredOpen(id, true),
       dismiss: () => coordinator.setDesiredOpen(id, false),
+      dismissAndWait: () => coordinator.dismissAndWait(id),
       close: () => coordinator.setDesiredOpen(id, false),
       forceClose: () => coordinator.setDesiredOpen(id, false),
       snapToIndex: (index: number) => {

--- a/packages/mobile/src/providers/sheet-presentation-provider.tsx
+++ b/packages/mobile/src/providers/sheet-presentation-provider.tsx
@@ -301,6 +301,10 @@ export function SheetPresentationProvider({ children }: { children: ReactNode })
         const prev = desired.current.get(id);
         const seq = open ? (seqCounter.current += 1) : (prev?.seq ?? 0);
         desired.current.set(id, { open, seq });
+        // A fresh open supersedes an in-flight caller-owned dismissal. Resolve
+        // those waiters as aborted so the caller does not navigate away while
+        // the source surface is being deliberately re-presented.
+        if (open) settleDismissWaiters(id, ABORTED_RESULT);
         const group = groupOf(id);
         if (group) pump(group);
       },

--- a/packages/mobile/src/providers/sheet-presentation-provider.tsx
+++ b/packages/mobile/src/providers/sheet-presentation-provider.tsx
@@ -391,6 +391,15 @@ export type ManagedSheetHandle = Pick<
   dismissAndWait: () => Promise<DismissAndWaitResult>;
 };
 
+/** Await a mounted managed sheet, or succeed immediately when no native
+ * surface exists. `aborted` is reserved for a registered host disappearing
+ * while its dismissal is already in flight. */
+export function dismissManagedSheetAndWait(
+  handle: Pick<ManagedSheetHandle, 'dismissAndWait'> | null | undefined,
+): Promise<DismissAndWaitResult> {
+  return handle ? handle.dismissAndWait() : Promise.resolve(DISMISSED_RESULT);
+}
+
 type UseManagedSheetOptions = {
   /** Controlled open state. Pass a boolean to drive the sheet declaratively;
    * leave `undefined` for purely imperative consumers (drive via the returned


### PR DESCRIPTION
## Summary

- add a coordinator-owned `dismissAndWait` contract for native sheets, including sheets that are still presenting, duplicate waiters, teardown aborts, and a bounded fallback
- let the `/play` route wait for its own closing `transitionEnd` event before the create drawer is pushed
- serialize Remix/Edit as source sheet → player → create, while preserving the iPad inline-pane path

The remix path could previously close its visible menu and push create without waiting for the native Board/Queue sheet or the player route to finish dismissing. That allowed CreateDrawer to present underneath a still-live native sheet, leaving a stranded scrim or an apparently dead action.

Fixes #4076

## Validation

- independent adversarial review: no findings
- focused mobile tests: 8 files, 136 tests passed
- `vp run typecheck:mobile`
- `git diff --check origin/main...HEAD`

## Device QA

- iPhone: exercise BoardSheet and QueueSheet → player → Remix/Edit with slow animations and repeated taps
- Android: confirm the bounded fallback never leaves a stuck sheet
- iPad regular width: confirm inline panes do not dismiss an unrelated route

## Release Notes

Remixing or editing a climb now waits for the current board, queue, and player screens to finish closing before the editor opens, preventing stranded sheets and taps that appear to do nothing.
