### PR TITLE
chore(mobile): record Live Activity intent exit diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ Boardsesh is a monorepo. Next.js 16 web app + React Native (Expo) mobile app for
 - No AI-generated images. Real photos or diagrams only.
 - No buzzwords. Concrete numbers, plain language.
 - Default to action. Full autonomy except no data deletion without asking.
+- **Bluetooth changes require a Fable review.** Any change touching Bluetooth/BLE code — `packages/shared/ble-protocol/`, `packages/mobile/src/lib/ble/`, `packages/mobile/modules/live-activity/ios/`, or the web Bluetooth LED control in `packages/web` — must be reviewed by Fable before merge.
 
 ## PR Lifecycle (mandatory)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Boardsesh is a monorepo. Next.js 16 web app + React Native (Expo) mobile app for
 - No AI-generated images. Real photos or diagrams only.
 - No buzzwords. Concrete numbers, plain language.
 - Default to action. Full autonomy except no data deletion without asking.
-- **Bluetooth changes require a Fable review.** Any change touching Bluetooth/BLE code — `packages/shared/ble-protocol/`, `packages/mobile/src/lib/ble/`, or the web Bluetooth LED control in `packages/web` — must be reviewed by Fable before merge.
+- **Bluetooth changes require a Fable review.** Any change touching Bluetooth/BLE code — `packages/shared/ble-protocol/`, `packages/mobile/src/lib/ble/`, `packages/mobile/modules/live-activity/ios/`, or the web Bluetooth LED control in `packages/web` — must be reviewed by Fable before merge.
 
 ## PR Lifecycle (mandatory)
 

--- a/docs/live-activity-push-testing.md
+++ b/docs/live-activity-push-testing.md
@@ -440,6 +440,11 @@ Connect your iPhone and open Xcode > Window > Devices and Simulators > your devi
 
 ### Interrupted intent diagnostics
 
+The first deployment of these diagnostics requires a new iOS binary: the
+durable store and App Intent recorder live in Swift and cannot be activated by
+an OTA bundle alone. Once that binary is installed, the React-side consumer and
+reporting changes can follow the normal fingerprint-compatible OTA path.
+
 The main app target keeps a best-effort marker for each `LiveActivityIntent`
 run (`NextClimbIntent`, `PreviousClimbIntent`, `TakeControlIntent`, and
 `ReconnectBoardIntent`). The widget-extension copies compile the recorder calls

--- a/docs/live-activity-push-testing.md
+++ b/docs/live-activity-push-testing.md
@@ -438,6 +438,53 @@ Connect your iPhone and open Xcode > Window > Devices and Simulators > your devi
 - `LiveActivityPlugin` — token registration with backend
 - `NativeWebSocketPlugin` — WebSocket connection state
 
+### Interrupted intent diagnostics
+
+The main app target keeps a best-effort marker for each `LiveActivityIntent`
+run (`NextClimbIntent`, `PreviousClimbIntent`, `TakeControlIntent`, and
+`ReconnectBoardIntent`). The widget-extension copies compile the recorder calls
+out with `#if !WIDGET_EXTENSION`; widget fallback execution never writes the
+main app's store.
+
+The marker is an app-local `UserDefaults` envelope, not App Group storage. It is
+schema-versioned, limited to the newest 16 records, and contains only generated
+run/process UUIDs, the fixed intent kind, app version/build, timestamps, a
+coarse last stage/result, and whether the React root committed. It never stores
+user, climb, queue, session, endpoint/server, auth-token, or Bluetooth
+peripheral values. A React effect mounted directly under the real app root marks
+the root commit; it is deliberately not a module-import side effect.
+
+On foreground, native code atomically consumes only incomplete records from a
+different process that are at least 30 seconds old. It discards records from a
+different build, an unknown schema, corrupt/future-dated records, and records
+older than 24 hours. A durable consumed-key ring prevents a run from being
+returned twice. JS reports each returned record as an informational Sentry
+message with the fixed fingerprint `live-activity-intent-interrupted`; it is not
+captured as an exception or crash. A normally returning intent always marks its
+record completed, including guard/early-return paths, so it is never reported.
+
+This instrumentation does not change the intent work budget. Widget HTTP still
+uses its existing 10-second request timeout, and navigation BLE still waits up
+to 3 seconds for readiness plus the existing 1.5-second write-drain window. It
+also does not cancel BLE work when the background task expires.
+
+#### MetricKit audit (no new integration)
+
+The mobile app currently pins `@sentry/react-native` 7.11.0, whose podspec pins
+Sentry Cocoa 8.58.0. That Cocoa SDK has a MetricKit integration, but
+`enableMetricKit` and `enableMetricKitRawPayload` both default to off, and our
+`src/lib/sentry.ts` initialization does not enable either option. Consequently,
+Boardsesh does not currently subscribe Sentry to MetricKit payloads. If enabled,
+that SDK version's supported conversion covers hang, CPU-exception, and
+disk-write diagnostics; its MetricKit manager disables crash diagnostics by
+default. No MetricKit option or reporting behavior is changed for #4077.
+
+Existing Sentry coverage remains separate: native crash handling is explicitly
+enabled, app-hang tracking uses the configured 2-second threshold, and Sentry
+Cocoa's watchdog-termination tracking retains its default-on setting. Those
+signals do not correlate an unlogged termination to a specific Live Activity
+intent run, which is why the small durable marker is needed.
+
 ### Inspect Push Token
 
 The push token is logged (first 8 characters) when obtained:

--- a/docs/live-activity-push-testing.md
+++ b/docs/live-activity-push-testing.md
@@ -467,11 +467,20 @@ returned twice. JS reports each returned record as an informational Sentry
 message with the fixed fingerprint `live-activity-intent-interrupted`; it is not
 captured as an exception or crash. A normally returning intent always marks its
 record completed, including guard/early-return paths, so it is never reported.
+Its normal completion class stays on that stored completed record; interrupted
+records have no completion class, and the native consume payload cannot include
+one.
 
 This instrumentation does not change the intent work budget. Widget HTTP still
 uses its existing 10-second request timeout, and navigation BLE still waits up
 to 3 seconds for readiness plus the existing 1.5-second write-drain window. It
 also does not cancel BLE work when the background task expires.
+
+For navigation intents, `bleFinishedSuccess` means the specific display
+request's native callback succeeded and the global write queue drained inside
+that 1.5-second window. Encoding, connection/enqueue, write, and drain-timeout
+failures record `bleFinishedFailure`; a write that finishes after the deadline
+continues normally but cannot change the already-settled diagnostic result.
 
 #### MetricKit audit (no new integration)
 

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -81,6 +81,7 @@ import { InstallReferrerTracker } from '../src/components/analytics/InstallRefer
 import { OnboardingGate } from '../src/components/onboarding/OnboardingGate';
 import { AccessoryOnboardingTip } from '../src/components/onboarding/AccessoryOnboardingTip';
 import { FreezeDebugOverlay } from '../src/components/FreezeDebugOverlay';
+import { LiveActivityIntentDiagnostics } from '../src/components/LiveActivityIntentDiagnostics';
 // Side-effect import: instantiates the Android-only MemoryTrim native module
 // (expo-modules-core creates modules lazily on first JS access), whose Kotlin
 // OnCreate registers the Glide trim-on-UI_HIDDEN callback. No-op on iOS.
@@ -447,6 +448,10 @@ function RootLayout() {
 
   return (
     <GestureHandlerRootView style={layoutStyles.root}>
+      {/* Effect runs only after this React root commits. It marks whether an
+          iOS LiveActivityIntent background launch mounted React, then consumes
+          eligible interrupted markers when the app is foregrounded. */}
+      <LiveActivityIntentDiagnostics />
       {/* PostHogProvider sits at the top so touch autocapture covers the whole
           app. It owns the single PostHog client; manual events go through the
           imperative wrapper in src/lib/analytics. No-ops (renders children

--- a/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
+++ b/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
@@ -201,6 +201,29 @@ final class BoardBleWriteFlowTests: XCTestCase {
         )
     }
 
+    private func queueItem(frames: String = "p1r42", mirrored: Bool = false) -> SharedQueueItem {
+        SharedQueueItem(
+            uuid: "queue-item",
+            climbUuid: "climb-item",
+            climbName: "Test climb",
+            difficulty: "6c+/V5",
+            angle: 40,
+            frames: frames,
+            setterUsername: "tester",
+            mirrored: mirrored
+        )
+    }
+
+    private func waitForWriteQueueDepth(_ expectedDepth: Int) async {
+        for _ in 0..<1_000 {
+            if manager.testHooks.sync({ manager.testHooks.writeQueueDepth }) == expectedDepth {
+                return
+            }
+            await Task.yield()
+        }
+        XCTFail("write queue did not reach depth \(expectedDepth)")
+    }
+
     /// Fire the most recently scheduled one-shot with `label`, on the BLE queue.
     private func fireLatestOneShot(label: String) {
         manager.testHooks.sync {
@@ -1154,5 +1177,226 @@ final class BoardBleWriteFlowTests: XCTestCase {
         XCTAssertNil(completionError)
         XCTAssertEqual(completionTelemetry?.writeType, "withResponse")
         XCTAssertEqual(completionTelemetry?.writeTypeSource, BoardBleWriteTypeSource.moonboardCharacteristic.rawValue)
+    }
+
+    func testIntentDisplaySucceedsOnlyAfterItsRequestAndGlobalQueueDrain() async {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(canSendDefault: true, maxWriteValueLength: 512)
+        let characteristic = makeCharacteristic(properties: .writeWithoutResponse)
+
+        hooks.sync {
+            hooks.setConfiguration(moonboardConfiguration())
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+        }
+
+        let resultTask = Task {
+            await hooks.displayCurrentItemAwaitingDrain(
+                items: [queueItem()],
+                currentIndex: 0,
+                drainTimeout: 1
+            )
+        }
+        await waitForWriteQueueDepth(1)
+
+        XCTAssertEqual(peripheral.writtenChunks.count, 1)
+        fireLatestOneShot(label: "chunkDelay")
+
+        let succeeded = await resultTask.value
+        XCTAssertTrue(succeeded)
+        XCTAssertEqual(hooks.sync { hooks.writeQueueDepth }, 0)
+        XCTAssertFalse(hooks.sync { hooks.isWriting })
+    }
+
+    func testIntentDisplayReportsEncodingAndEnqueueFailures() async {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(canSendDefault: true, maxWriteValueLength: 512)
+        let characteristic = makeCharacteristic(properties: .writeWithoutResponse)
+
+        hooks.sync {
+            hooks.setConfiguration(moonboardConfiguration())
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+        }
+        let encodingSucceeded = await hooks.displayCurrentItemAwaitingDrain(
+            items: [queueItem(frames: "garbage")],
+            currentIndex: 0,
+            drainTimeout: 1
+        )
+        XCTAssertFalse(encodingSucceeded)
+        XCTAssertTrue(peripheral.writtenChunks.isEmpty)
+
+        hooks.sync {
+            hooks.setConnection(peripheral: nil, characteristic: nil)
+        }
+        let enqueueSucceeded = await hooks.displayCurrentItemAwaitingDrain(
+            items: [queueItem()],
+            currentIndex: 0,
+            drainTimeout: 1
+        )
+        XCTAssertFalse(enqueueSucceeded)
+        XCTAssertTrue(peripheral.writtenChunks.isEmpty)
+    }
+
+    func testIntentDisplayReportsWriteFailureAfterQueueDrains() async {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(canSendDefault: true, maxWriteValueLength: 512)
+        let characteristic = makeCharacteristic(properties: .write)
+
+        hooks.sync {
+            hooks.setConfiguration(moonboardConfiguration())
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+        }
+
+        let resultTask = Task {
+            await hooks.displayCurrentItemAwaitingDrain(
+                items: [queueItem()],
+                currentIndex: 0,
+                drainTimeout: 1
+            )
+        }
+        await waitForWriteQueueDepth(1)
+        hooks.fireWriteAck(error: BoardBleError.writeCancelled)
+
+        let succeeded = await resultTask.value
+        XCTAssertFalse(succeeded)
+        XCTAssertEqual(hooks.sync { hooks.writeQueueDepth }, 0)
+        XCTAssertFalse(hooks.sync { hooks.isWriting })
+    }
+
+    func testIntentDisplayDrainTimeoutStaysFailureWhenWriteFinishesLater() async {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(canSendDefault: false, maxWriteValueLength: 512)
+        let characteristic = makeCharacteristic(properties: .writeWithoutResponse)
+
+        hooks.sync {
+            hooks.setConfiguration(moonboardConfiguration())
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+        }
+
+        let resultTask = Task {
+            await hooks.displayCurrentItemAwaitingDrain(
+                items: [queueItem()],
+                currentIndex: 0,
+                drainTimeout: 0
+            )
+        }
+        await waitForWriteQueueDepth(1)
+
+        let initialResult = await resultTask.value
+        XCTAssertFalse(initialResult)
+        XCTAssertEqual(hooks.sync { hooks.writeQueueDepth }, 1)
+
+        peripheral.canSendDefault = true
+        hooks.sync { scheduler.repeatingTimers[0].fire() }
+        fireLatestOneShot(label: "chunkDelay")
+
+        XCTAssertEqual(peripheral.writtenChunks.count, 1)
+        XCTAssertEqual(hooks.sync { hooks.writeQueueDepth }, 0)
+        XCTAssertFalse(hooks.sync { hooks.isWriting })
+        // Reading the already-completed task again proves the late per-request
+        // callback cannot turn the timed-out diagnostic result into success.
+        let resultAfterLateCompletion = await resultTask.value
+        XCTAssertFalse(resultAfterLateCompletion)
+    }
+
+    func testIntentDisplayNeedsGlobalDrainAfterSpecificRequestSucceeds() async {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(canSendDefault: true, maxWriteValueLength: 512)
+        let characteristic = makeCharacteristic(properties: .writeWithoutResponse)
+
+        hooks.sync {
+            hooks.setConfiguration(moonboardConfiguration())
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+        }
+
+        let resultTask = Task {
+            await hooks.displayCurrentItemAwaitingDrain(
+                items: [queueItem()],
+                currentIndex: 0,
+                drainTimeout: 1
+            )
+        }
+        await waitForWriteQueueDepth(1)
+
+        hooks.sync {
+            manager.write(data: Data([0x01])) { _, _ in }
+        }
+        XCTAssertEqual(hooks.sync { hooks.writeQueueDepth }, 2)
+
+        // Complete the intent's own request successfully, then park a second
+        // request so the existing global drain condition cannot signal.
+        peripheral.canSendDefault = false
+        fireLatestOneShot(label: "chunkDelay")
+        XCTAssertEqual(hooks.sync { hooks.writeQueueDepth }, 1)
+
+        let succeeded = await resultTask.value
+        XCTAssertFalse(succeeded)
+        XCTAssertEqual(peripheral.writtenChunks.count, 1)
+
+        // The unrelated queued request is not cancelled by the intent's drain
+        // deadline and can still finish normally afterwards.
+        peripheral.canSendDefault = true
+        hooks.sync { scheduler.repeatingTimers[0].fire() }
+        fireLatestOneShot(label: "chunkDelay")
+        XCTAssertEqual(peripheral.writtenChunks.count, 2)
+        XCTAssertEqual(hooks.sync { hooks.writeQueueDepth }, 0)
+    }
+
+    func testIntentDisplayPreservesIntentionalEmptyFrameClear() async {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(canSendDefault: true, maxWriteValueLength: 512)
+        let characteristic = makeCharacteristic(properties: .writeWithoutResponse)
+
+        hooks.sync {
+            hooks.setConfiguration(moonboardConfiguration())
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+        }
+
+        let resultTask = Task {
+            await hooks.displayCurrentItemAwaitingDrain(
+                items: [queueItem(frames: "")],
+                currentIndex: 0,
+                drainTimeout: 1
+            )
+        }
+        await waitForWriteQueueDepth(1)
+        fireLatestOneShot(label: "chunkDelay")
+
+        let succeeded = await resultTask.value
+        XCTAssertTrue(succeeded)
+        XCTAssertEqual(peripheral.writtenChunks.count, 1)
+        XCTAssertEqual(String(data: peripheral.writtenChunks[0].data, encoding: .utf8), "l##")
+    }
+}
+
+@available(iOS 17.0, *)
+final class WaiterPoolOutcomeTests: XCTestCase {
+    func testWaitReportsImmediateSignalAndTimeoutOutcomes() async {
+        let queue = DispatchQueue(label: "com.boardsesh.tests.waiter-pool")
+        let pool = WaiterPool(queue: queue)
+
+        let immediateResult = await pool.wait(timeout: 1) { true }
+        let timeoutResult = await pool.wait(timeout: 0) { false }
+        XCTAssertTrue(immediateResult)
+        XCTAssertFalse(timeoutResult)
+    }
+
+    func testWaitReportsExplicitSignal() async {
+        let queue = DispatchQueue(label: "com.boardsesh.tests.waiter-pool-signal")
+        let pool = WaiterPool(queue: queue)
+        let resultTask = Task {
+            await pool.wait(timeout: 1) { false }
+        }
+
+        var waiterWasRegistered = false
+        for _ in 0..<1_000 {
+            waiterWasRegistered = queue.sync { pool.hasPendingWaiters }
+            if waiterWasRegistered { break }
+            await Task.yield()
+        }
+        XCTAssertTrue(waiterWasRegistered)
+        queue.sync { pool.signalAll() }
+
+        let signaledResult = await resultTask.value
+        XCTAssertTrue(signaledResult)
     }
 }

--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -655,7 +655,7 @@ final class LiveActivityIntentDiagnosticStoreTests: XCTestCase {
         )
     }
 
-    func testRunLifecycleAndNormalEarlyCompletionAreDurableAndIdempotent() {
+    func testRunLifecycleAndNormalEarlyCompletionAreDurableAndIdempotent() throws {
         let store = makeStore()
         let run = store.begin(kind: .nextClimb)
 
@@ -669,9 +669,10 @@ final class LiveActivityIntentDiagnosticStoreTests: XCTestCase {
         run.mark(.bleStarted)
         run.complete(.success)
 
-        let completed = store.recordsSnapshot().single
-        XCTAssertEqual(completed?.lastStage, .completed)
-        XCTAssertEqual(completed?.completionClass, .navigationOutOfBounds)
+        let completed = try XCTUnwrap(store.recordsSnapshot().single)
+        XCTAssertEqual(completed.lastStage, .completed)
+        XCTAssertEqual(completed.completionClass, .navigationOutOfBounds)
+        XCTAssertNil(LiveActivityInterruptedIntentDiagnostic(record: completed))
     }
 
     func testSameProcessAndCompletedRecordsAreNeverConsumed() {
@@ -686,7 +687,7 @@ final class LiveActivityIntentDiagnosticStoreTests: XCTestCase {
         XCTAssertEqual(store.recordsSnapshot().count, 2)
     }
 
-    func testPreviousProcessRecordWaitsForGraceThenConsumesOnce() {
+    func testPreviousProcessRecordWaitsForGraceThenConsumesOnce() throws {
         let firstProcess = makeStore(processId: UUID())
         _ = firstProcess.begin(kind: .nextClimb)
 
@@ -697,7 +698,14 @@ final class LiveActivityIntentDiagnosticStoreTests: XCTestCase {
         clockNow = clockNow.addingTimeInterval(2)
         let consumed = foregroundProcess.consumeInterruptedRuns()
         XCTAssertEqual(consumed.count, 1)
-        XCTAssertEqual(consumed.single?.intentKind, .nextClimb)
+        let interrupted = try XCTUnwrap(consumed.single)
+        XCTAssertEqual(interrupted.intentKind, .nextClimb)
+        XCTAssertNotEqual(interrupted.lastStage, .completed)
+        XCTAssertNil(interrupted.completionClass)
+        let bridgeDiagnostic = try XCTUnwrap(LiveActivityInterruptedIntentDiagnostic(record: interrupted))
+        XCTAssertEqual(bridgeDiagnostic.lastStage, .entered)
+        XCTAssertEqual(bridgeDiagnostic.bridgePayload["lastStage"] as? String, "entered")
+        XCTAssertNil(bridgeDiagnostic.bridgePayload["completionClass"])
         XCTAssertTrue(foregroundProcess.consumeInterruptedRuns().isEmpty)
 
         // Recreating the consumer with the same durable store still cannot
@@ -763,6 +771,25 @@ final class LiveActivityIntentDiagnosticStoreTests: XCTestCase {
         XCTAssertEqual(Set(records.map(\.runId)).count, 4)
     }
 
+    func testInterruptedStageProjectionCoversEveryNonCompletedStage() {
+        let storedInterruptedStages = Set(
+            LiveActivityIntentDiagnosticStage.allCases
+                .filter { $0 != .completed }
+                .map(\.rawValue)
+        )
+        let bridgeStages = Set(LiveActivityInterruptedIntentDiagnosticStage.allCases.map(\.rawValue))
+
+        XCTAssertEqual(bridgeStages, storedInterruptedStages)
+        for storedStage in LiveActivityIntentDiagnosticStage.allCases {
+            let projected = LiveActivityInterruptedIntentDiagnosticStage(rawValue: storedStage.rawValue)
+            if storedStage == .completed {
+                XCTAssertNil(projected)
+            } else {
+                XCTAssertEqual(projected?.rawValue, storedStage.rawValue)
+            }
+        }
+    }
+
     func testPersistedAndBridgedFieldsAreBoundedAndIdentifierFree() throws {
         let store = makeStore(
             appVersion: "2.0.0<script>alert(1)</script>",
@@ -777,7 +804,8 @@ final class LiveActivityIntentDiagnosticStoreTests: XCTestCase {
         XCTAssertNotNil(UUID(uuidString: record.runId))
         XCTAssertNotNil(UUID(uuidString: record.processId))
 
-        let bridgeJson = try JSONSerialization.data(withJSONObject: record.bridgePayload)
+        let bridgeDiagnostic = try XCTUnwrap(LiveActivityInterruptedIntentDiagnostic(record: record))
+        let bridgeJson = try JSONSerialization.data(withJSONObject: bridgeDiagnostic.bridgePayload)
         let bridgeText = try XCTUnwrap(String(data: bridgeJson, encoding: .utf8)).lowercased()
         for forbiddenKey in ["userid", "climb", "session", "server", "endpoint", "peripheral", "authtoken"] {
             XCTAssertFalse(bridgeText.contains(forbiddenKey), "unexpected identifier field: \(forbiddenKey)")

--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -80,6 +80,40 @@ final class LiveActivityWidgetTests: XCTestCase {
         XCTAssertEqual(SharedWidgetTakeControlRuntime.action(for: wallControl), .alreadyAllowed)
     }
 
+    func testReconnectDiagnosticKeepsBleFailureWhenTakeControlAlsoFails() {
+        XCTAssertEqual(
+            ReconnectBoardIntent.diagnosticCompletionClass(
+                current: .bleFailure,
+                networkResult: .serverRejected
+            ),
+            .bleFailure
+        )
+        XCTAssertEqual(
+            ReconnectBoardIntent.diagnosticCompletionClass(
+                current: .bleFailure,
+                networkResult: .retryableFailure
+            ),
+            .bleFailure
+        )
+    }
+
+    func testReconnectDiagnosticRecordsNetworkFailureAfterSuccessfulBleReconnect() {
+        XCTAssertEqual(
+            ReconnectBoardIntent.diagnosticCompletionClass(
+                current: .success,
+                networkResult: .serverRejected
+            ),
+            .serverRejected
+        )
+        XCTAssertEqual(
+            ReconnectBoardIntent.diagnosticCompletionClass(
+                current: .success,
+                networkResult: .retryableFailure
+            ),
+            .retryableNetworkFailure
+        )
+    }
+
     func testMarkControlClaimedEnablesPartyNavigationButKeepsAuthorization() {
         SharedWidgetWallControlState.save(navigationAllowed: false, isPartySession: true, to: defaults)
 

--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -577,3 +577,182 @@ final class LiveActivityWidgetTests: XCTestCase {
         XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: .write, boardName: "moonboard"), .withResponse)
     }
 }
+
+@available(iOS 17.0, *)
+final class LiveActivityIntentDiagnosticStoreTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private var clockNow: Date!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "com.boardsesh.rn.intent-diagnostic-tests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+        clockNow = Date(timeIntervalSince1970: 2_000_000_000)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        clockNow = nil
+        super.tearDown()
+    }
+
+    private func makeStore(
+        processId: UUID = UUID(),
+        appVersion: String = "2.0.0",
+        buildNumber: String = "481",
+        maxRecords: Int = 16,
+        timeToLive: TimeInterval = 24 * 60 * 60,
+        incompleteGrace: TimeInterval = 30
+    ) -> LiveActivityIntentDiagnosticStore {
+        LiveActivityIntentDiagnosticStore(
+            defaults: defaults,
+            storageKey: "intent-diagnostic-tests",
+            processId: processId,
+            appVersion: appVersion,
+            buildNumber: buildNumber,
+            maxRecords: maxRecords,
+            timeToLive: timeToLive,
+            incompleteGrace: incompleteGrace,
+            now: { [unowned self] in self.clockNow }
+        )
+    }
+
+    func testRunLifecycleAndNormalEarlyCompletionAreDurableAndIdempotent() {
+        let store = makeStore()
+        let run = store.begin(kind: .nextClimb)
+
+        XCTAssertEqual(store.recordsSnapshot().single?.lastStage, .entered)
+        run.mark(.networkStarted)
+        XCTAssertEqual(store.recordsSnapshot().single?.lastStage, .networkStarted)
+
+        // Models an ordinary guard return (for example queue bounds). The
+        // production intent uses defer, so the same completion always runs.
+        run.complete(.navigationOutOfBounds)
+        run.mark(.bleStarted)
+        run.complete(.success)
+
+        let completed = store.recordsSnapshot().single
+        XCTAssertEqual(completed?.lastStage, .completed)
+        XCTAssertEqual(completed?.completionClass, .navigationOutOfBounds)
+    }
+
+    func testSameProcessAndCompletedRecordsAreNeverConsumed() {
+        let processId = UUID()
+        let store = makeStore(processId: processId)
+        _ = store.begin(kind: .previousClimb)
+        let completed = store.begin(kind: .takeControl)
+        completed.complete(.alreadyAllowed)
+        clockNow = clockNow.addingTimeInterval(60)
+
+        XCTAssertTrue(store.consumeInterruptedRuns().isEmpty)
+        XCTAssertEqual(store.recordsSnapshot().count, 2)
+    }
+
+    func testPreviousProcessRecordWaitsForGraceThenConsumesOnce() {
+        let firstProcess = makeStore(processId: UUID())
+        _ = firstProcess.begin(kind: .nextClimb)
+
+        clockNow = clockNow.addingTimeInterval(29)
+        let foregroundProcess = makeStore(processId: UUID())
+        XCTAssertTrue(foregroundProcess.consumeInterruptedRuns().isEmpty)
+
+        clockNow = clockNow.addingTimeInterval(2)
+        let consumed = foregroundProcess.consumeInterruptedRuns()
+        XCTAssertEqual(consumed.count, 1)
+        XCTAssertEqual(consumed.single?.intentKind, .nextClimb)
+        XCTAssertTrue(foregroundProcess.consumeInterruptedRuns().isEmpty)
+
+        // Recreating the consumer with the same durable store still cannot
+        // return the consumed run a second time.
+        let secondConsumer = makeStore(processId: UUID())
+        XCTAssertTrue(secondConsumer.consumeInterruptedRuns().isEmpty)
+    }
+
+    func testReactRootMarkerTouchesOnlyIncompleteRunsFromCurrentProcess() {
+        let oldProcess = makeStore(processId: UUID())
+        _ = oldProcess.begin(kind: .nextClimb)
+
+        let currentProcess = makeStore(processId: UUID())
+        _ = currentProcess.begin(kind: .reconnectBoard)
+        let completed = currentProcess.begin(kind: .takeControl)
+        completed.complete(.success)
+        currentProcess.markReactRootMounted()
+
+        let records = currentProcess.recordsSnapshot()
+        XCTAssertFalse(records.first(where: { $0.intentKind == .nextClimb })?.reactRootMounted ?? true)
+        XCTAssertTrue(records.first(where: { $0.intentKind == .reconnectBoard })?.reactRootMounted ?? false)
+        XCTAssertFalse(records.first(where: { $0.intentKind == .takeControl })?.reactRootMounted ?? true)
+    }
+
+    func testTimeToLiveAndBuildValidationDiscardInsteadOfReport() {
+        let oldBuild = makeStore(processId: UUID(), buildNumber: "480")
+        _ = oldBuild.begin(kind: .nextClimb)
+        clockNow = clockNow.addingTimeInterval(31)
+
+        let newBuild = makeStore(processId: UUID(), buildNumber: "481")
+        XCTAssertTrue(newBuild.consumeInterruptedRuns().isEmpty)
+        XCTAssertTrue(newBuild.recordsSnapshot().isEmpty)
+
+        let currentBuild = makeStore(processId: UUID(), timeToLive: 60)
+        _ = currentBuild.begin(kind: .previousClimb)
+        clockNow = clockNow.addingTimeInterval(61)
+        let laterProcess = makeStore(processId: UUID(), timeToLive: 60)
+        XCTAssertTrue(laterProcess.consumeInterruptedRuns().isEmpty)
+        XCTAssertTrue(laterProcess.recordsSnapshot().isEmpty)
+    }
+
+    func testCorruptAndWrongSchemaPayloadsFailClosed() {
+        defaults.set(Data("not-json".utf8), forKey: "intent-diagnostic-tests")
+        let store = makeStore()
+        XCTAssertTrue(store.consumeInterruptedRuns().isEmpty)
+        XCTAssertTrue(store.recordsSnapshot().isEmpty)
+
+        let wrongSchema = Data("{\"schemaVersion\":2,\"records\":[],\"consumed\":[]}".utf8)
+        defaults.set(wrongSchema, forKey: "intent-diagnostic-tests")
+        XCTAssertTrue(store.consumeInterruptedRuns().isEmpty)
+        XCTAssertTrue(store.recordsSnapshot().isEmpty)
+    }
+
+    func testRingBufferKeepsOnlyNewestBoundedRecords() {
+        let store = makeStore(maxRecords: 4)
+        for index in 0..<10 {
+            _ = store.begin(kind: index.isMultiple(of: 2) ? .nextClimb : .previousClimb)
+            clockNow = clockNow.addingTimeInterval(1)
+        }
+
+        let records = store.recordsSnapshot()
+        XCTAssertEqual(records.count, 4)
+        XCTAssertEqual(Set(records.map(\.runId)).count, 4)
+    }
+
+    func testPersistedAndBridgedFieldsAreBoundedAndIdentifierFree() throws {
+        let store = makeStore(
+            appVersion: "2.0.0<script>alert(1)</script>",
+            buildNumber: "481\nBearer secret"
+        )
+        _ = store.begin(kind: .reconnectBoard)
+        let record = try XCTUnwrap(store.recordsSnapshot().single)
+
+        XCTAssertEqual(record.appVersion, "2.0.0scriptalert1script")
+        XCTAssertEqual(record.buildNumber, "481Bearersecret")
+        XCTAssertLessThanOrEqual(record.appVersion.count, 64)
+        XCTAssertNotNil(UUID(uuidString: record.runId))
+        XCTAssertNotNil(UUID(uuidString: record.processId))
+
+        let bridgeJson = try JSONSerialization.data(withJSONObject: record.bridgePayload)
+        let bridgeText = try XCTUnwrap(String(data: bridgeJson, encoding: .utf8)).lowercased()
+        for forbiddenKey in ["userid", "climb", "session", "server", "endpoint", "peripheral", "authtoken"] {
+            XCTAssertFalse(bridgeText.contains(forbiddenKey), "unexpected identifier field: \(forbiddenKey)")
+        }
+    }
+}
+
+private extension Array {
+    var single: Element? {
+        count == 1 ? first : nil
+    }
+}

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -168,6 +168,29 @@ enum BoardBleError: LocalizedError {
     }
 }
 
+/// One-shot result for the specific display request issued by a Live Activity
+/// intent. Display callbacks settle on `bleQueue`; the awaiting task reads the
+/// result after the global drain waiter resumes. The lock makes that cross-task
+/// read explicit and prevents a defensive duplicate callback from changing the
+/// first result.
+private final class BoardBleDisplayWriteOutcome: @unchecked Sendable {
+    private let lock = NSLock()
+    private var settledResult: Bool?
+
+    func settle(succeeded: Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard settledResult == nil else { return }
+        settledResult = succeeded
+    }
+
+    var succeeded: Bool? {
+        lock.lock()
+        defer { lock.unlock() }
+        return settledResult
+    }
+}
+
 final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate {
     static let shared = BoardBleManager()
 
@@ -557,6 +580,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     /// no-op cleanly. The not-ready case is logged at `error` level so a
     /// "widget UI moved but wall didn't" report can be diagnosed from
     /// Console.app without recompiling under DEBUG.
+    /// Returns true only when this display request's callback succeeds AND the
+    /// global write queue drains before `drainTimeout`.
     func displayCurrentItemAwaitingReady(
         items: [SharedQueueItem],
         currentIndex: Int,
@@ -573,9 +598,39 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             ) }
             logger.error("displayCurrentItemAwaitingReady: not ready after \(readyTimeout, privacy: .public)s — centralState=\(state.centralState, privacy: .public) peripheral=\(state.hasPeripheral, privacy: .public) writeChar=\(state.hasWriteChar, privacy: .public); BLE write will no-op until the JS layer's BluetoothAutoSender re-fires")
         }
-        displayCurrentItem(items: items, currentIndex: currentIndex)
-        await waitForWriteDrain(timeout: drainTimeout)
-        return ready
+
+        return await displayCurrentItemAwaitingDrain(
+            items: items,
+            currentIndex: currentIndex,
+            drainTimeout: drainTimeout
+        )
+    }
+
+    private func displayCurrentItemAwaitingDrain(
+        items: [SharedQueueItem],
+        currentIndex: Int,
+        drainTimeout: TimeInterval
+    ) async -> Bool {
+        let displayOutcome = BoardBleDisplayWriteOutcome()
+        // Both blocks enter the same serial queue in call order: the display
+        // attempt settles or enqueues its specific request before the drain
+        // waiter evaluates the global queue predicate.
+        runOnBleQueue { [weak self] in
+            guard let self else {
+                displayOutcome.settle(succeeded: false)
+                return
+            }
+            self.displayCurrentItemOnBleQueue(items: items, currentIndex: currentIndex) { succeeded in
+                displayOutcome.settle(succeeded: succeeded)
+            }
+        }
+        let drainedBeforeTimeout = await waitForWriteDrain(timeout: drainTimeout)
+
+        // Success requires BOTH this display request's callback and the existing
+        // global drain condition. On timeout the write is deliberately left
+        // alone; a later callback may settle the one-shot outcome but cannot
+        // emit a second intent diagnostic because this await has already ended.
+        return drainedBeforeTimeout && displayOutcome.succeeded == true
     }
 
     private var isAvailableOnBleQueue: Bool {
@@ -866,17 +921,27 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         displayCurrentItemOnBleQueue(items: items, currentIndex: currentIndex)
     }
 
-    private func displayCurrentItemOnBleQueue(items: [SharedQueueItem], currentIndex: Int) {
+    private func displayCurrentItemOnBleQueue(
+        items: [SharedQueueItem],
+        currentIndex: Int,
+        completion: ((Bool) -> Void)? = nil
+    ) {
         guard currentIndex >= 0, currentIndex < items.count else {
-            clearBoardOnBleQueue()
+            clearBoardOnBleQueue(completion: completion)
             return
         }
-        displayItemOnBleQueue(items[currentIndex])
+        displayItemOnBleQueue(items[currentIndex], completion: completion)
     }
 
-    private func clearBoardOnBleQueue() {
-        guard let configuration else { return }
-        guard connectedPeripheral != nil, writeCharacteristic != nil else { return }
+    private func clearBoardOnBleQueue(completion: ((Bool) -> Void)? = nil) {
+        guard let configuration else {
+            completion?(false)
+            return
+        }
+        guard connectedPeripheral != nil, writeCharacteristic != nil else {
+            completion?(false)
+            return
+        }
 
         // `l##` (empty frame) is MoonBoard's clear-all: community firmware
         // (ArduinoMoonBoardLED) clears every LED on each incoming frame; unverified
@@ -896,17 +961,30 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             )
         }
 
-        guard !result.packet.isEmpty else { return }
+        guard !result.packet.isEmpty else {
+            completion?(false)
+            return
+        }
         writeOnBleQueue(data: result.packet) { [weak self] error, _ in
             if let error {
                 self?.logger.error("BLE clear failed: \(error.localizedDescription, privacy: .public)")
             }
+            completion?(error == nil)
         }
     }
 
-    private func displayItemOnBleQueue(_ item: SharedQueueItem) {
-        guard let configuration else { return }
-        guard connectedPeripheral != nil, writeCharacteristic != nil else { return }
+    private func displayItemOnBleQueue(
+        _ item: SharedQueueItem,
+        completion: ((Bool) -> Void)? = nil
+    ) {
+        guard let configuration else {
+            completion?(false)
+            return
+        }
+        guard connectedPeripheral != nil, writeCharacteristic != nil else {
+            completion?(false)
+            return
+        }
 
         // MoonBoard encodes straight from grid coordinates into the ASCII `l#…#`
         // frame format — it has no LED placement map and the Aurora binary
@@ -926,12 +1004,14 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                 // makeMoonboardPacket returns an empty packet for this all-skipped
                 // case so it never reaches the wall.
                 logger.warning("Skipping MoonBoard BLE write: no encodable holds for climb \(item.climbUuid, privacy: .public)")
+                completion?(false)
                 return
             }
             writeOnBleQueue(data: result.packet) { [weak self] error, _ in
                 if let error {
                     self?.logger.error("BLE write failed: \(error.localizedDescription, privacy: .public)")
                 }
+                completion?(error == nil)
             }
             return
         }
@@ -943,6 +1023,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         )
         guard !ledPlacements.isEmpty || item.frames.isEmpty else {
             logger.error("Missing LED placement data for \(configuration.boardName, privacy: .public) layout=\(configuration.layoutId, privacy: .public) size=\(configuration.sizeId, privacy: .public)")
+            completion?(false)
             return
         }
 
@@ -954,6 +1035,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                 layoutId: configuration.layoutId
             ) else {
                 logger.warning("Cannot mirror frames for climb \(item.climbUuid, privacy: .public)")
+                completion?(false)
                 return
             }
             framesToSend = mirroredFrames
@@ -971,6 +1053,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
         guard !result.packet.isEmpty || framesToSend.isEmpty else {
             logger.warning("Skipping BLE write because no placements resolved for climb \(item.climbUuid, privacy: .public)")
+            completion?(false)
             return
         }
 
@@ -978,6 +1061,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             if let error {
                 self?.logger.error("BLE write failed: \(error.localizedDescription, privacy: .public)")
             }
+            completion?(error == nil)
         }
     }
 
@@ -1556,12 +1640,12 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     }
 
     private func waitUntilReady(timeout: TimeInterval) async {
-        await readyWaiters.wait(timeout: timeout) { [weak self] in
+        _ = await readyWaiters.wait(timeout: timeout) { [weak self] in
             self?.isReadyForWrite ?? true
         }
     }
 
-    private func waitForWriteDrain(timeout: TimeInterval) async {
+    private func waitForWriteDrain(timeout: TimeInterval) async -> Bool {
         await drainWaiters.wait(timeout: timeout) { [weak self] in
             guard let self else { return true }
             return self.writeQueue.isEmpty && !self.isWriting
@@ -2288,6 +2372,21 @@ extension BoardBleManager {
         /// before the call returns — the suite's determinism relies on it.
         func sync<T>(_ body: () -> T) -> T {
             manager.runOnBleQueueSync(body)
+        }
+
+        /// Exercise the intent display request + global drain contract after
+        /// readiness has already been established, without creating a real
+        /// CBCentralManager in the Swift unit-test target.
+        func displayCurrentItemAwaitingDrain(
+            items: [SharedQueueItem],
+            currentIndex: Int,
+            drainTimeout: TimeInterval
+        ) async -> Bool {
+            await manager.displayCurrentItemAwaitingDrain(
+                items: items,
+                currentIndex: currentIndex,
+                drainTimeout: drainTimeout
+            )
         }
 
         /// Directly seed the connection the write path guards on. No CoreBluetooth

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -562,7 +562,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         currentIndex: Int,
         readyTimeout: TimeInterval,
         drainTimeout: TimeInterval = 1.5
-    ) async {
+    ) async -> Bool {
         await waitUntilReady(timeout: readyTimeout)
         let ready = runOnBleQueueSync { isReadyForWrite }
         if !ready {
@@ -575,6 +575,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         }
         displayCurrentItem(items: items, currentIndex: currentIndex)
         await waitForWriteDrain(timeout: drainTimeout)
+        return ready
     }
 
     private var isAvailableOnBleQueue: Bool {

--- a/packages/mobile/modules/live-activity/ios/ClimbNavigationIntent.swift
+++ b/packages/mobile/modules/live-activity/ios/ClimbNavigationIntent.swift
@@ -37,12 +37,24 @@ enum ClimbNavigationIntent {
     static let httpSuccessCorrelationId = "widget-navigate"
 
     static func perform(direction: ClimbNavigationDirection, label: String) async {
+        #if !WIDGET_EXTENSION
+        let diagnosticKind: LiveActivityIntentDiagnosticKind = direction == .next ? .nextClimb : .previousClimb
+        let diagnosticRun = LiveActivityIntentDiagnostics.begin(kind: diagnosticKind)
+        var completionClass = LiveActivityIntentCompletionClass.success
+        defer { diagnosticRun.complete(completionClass) }
+        #endif
+
         // One notice per intent firing — production TestFlight builds need
         // this signal to diagnose "widget UI moved but wall didn't" reports.
         // Volume is bounded by user taps so the log isn't noisy.
         logger.notice("\(label).perform() running bundle=\(Bundle.main.bundleIdentifier ?? "unknown", privacy: .public) process=\(ProcessInfo.processInfo.processName, privacy: .public) direction=\(direction.rawValue, privacy: .public)")
 
-        guard let defaults = SharedConstants.sharedDefaults else { return }
+        guard let defaults = SharedConstants.sharedDefaults else {
+            #if !WIDGET_EXTENSION
+            completionClass = .sharedDefaultsUnavailable
+            #endif
+            return
+        }
         // No navigationAllowed gate: the widget only shows Prev/Next when this
         // device holds the board (connectedByMe — see SessionFooter), so reaching
         // here means we may drive. Gating visibility rather than the intent fixes
@@ -53,17 +65,37 @@ enum ClimbNavigationIntent {
 
         let (items, currentIndex) = SharedQueueState.load(from: defaults)
         guard let newIndex = direction.newIndex(from: currentIndex, count: items.count) else {
+            #if !WIDGET_EXTENSION
+            completionClass = .navigationOutOfBounds
+            #endif
             return
         }
 
         let navigationResult: WidgetNavigationResult
         if wallControl.requiresServerAuthorization {
+            #if !WIDGET_EXTENSION
+            diagnosticRun.mark(.networkStarted)
+            #endif
             navigationResult = await WidgetNetworking.sendNavigation(action: direction.rawValue, currentIndex: newIndex)
+            #if !WIDGET_EXTENSION
+            switch navigationResult {
+            case .success:
+                diagnosticRun.mark(.networkFinishedSuccess)
+            case .serverRejected:
+                diagnosticRun.mark(.networkFinishedTerminal)
+            case .retryableFailure:
+                diagnosticRun.mark(.networkFinishedRetryable)
+                completionClass = .retryableNetworkFailure
+            }
+            #endif
         } else {
             navigationResult = .success
         }
 
         guard navigationResult != .serverRejected else {
+            #if !WIDGET_EXTENSION
+            completionClass = .serverRejected
+            #endif
             logger.notice("\(label).perform() rejected by server; skipping local widget, BLE, and JS fallback updates")
             return
         }
@@ -91,13 +123,17 @@ enum ClimbNavigationIntent {
             let content = ActivityContent(state: newState, staleDate: Date().addingTimeInterval(SharedConstants.liveActivityStaleInterval))
             await activity.update(content)
         }
+        #if !WIDGET_EXTENSION
+        diagnosticRun.mark(.activityKitUpdated)
+        #endif
 
         // Direct BLE writes happen only after the server accepts party-session
         // navigation, or for local-only sessions. Retryable HTTP failures use
         // the Darwin/WebSocket fallback, whose mutation path owns repainting.
         #if !WIDGET_EXTENSION
-        let bleWriteTask: Task<Void, Never>?
+        let bleWriteTask: Task<Bool, Never>?
         if navigationResult == .success {
+            diagnosticRun.mark(.bleStarted)
             bleWriteTask = Task {
                 await LiveActivityBleBridge.writeBoardForIntent(items: items, currentIndex: newIndex)
             }
@@ -136,11 +172,18 @@ enum ClimbNavigationIntent {
         // re-send is a fast no-op against the wall's last-frame buffer.
         #if !WIDGET_EXTENSION
         if let bleWriteTask {
-            await bleWriteTask.value
+            let writeWasReady = await bleWriteTask.value
+            diagnosticRun.mark(writeWasReady ? .bleFinishedSuccess : .bleFinishedFailure)
+            if !writeWasReady {
+                completionClass = .bleFailure
+            }
         }
         #endif
 
         postQueueNavigateDarwinNotification()
+        #if !WIDGET_EXTENSION
+        diagnosticRun.mark(.darwinPosted)
+        #endif
     }
 
     private static func postQueueNavigateDarwinNotification() {

--- a/packages/mobile/modules/live-activity/ios/ClimbNavigationIntent.swift
+++ b/packages/mobile/modules/live-activity/ios/ClimbNavigationIntent.swift
@@ -172,9 +172,9 @@ enum ClimbNavigationIntent {
         // re-send is a fast no-op against the wall's last-frame buffer.
         #if !WIDGET_EXTENSION
         if let bleWriteTask {
-            let writeWasReady = await bleWriteTask.value
-            diagnosticRun.mark(writeWasReady ? .bleFinishedSuccess : .bleFinishedFailure)
-            if !writeWasReady {
+            let writeSucceeded = await bleWriteTask.value
+            diagnosticRun.mark(writeSucceeded ? .bleFinishedSuccess : .bleFinishedFailure)
+            if !writeSucceeded {
                 completionClass = .bleFailure
             }
         }

--- a/packages/mobile/modules/live-activity/ios/LiveActivityBleBridge.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityBleBridge.swift
@@ -16,11 +16,15 @@ enum LiveActivityBleBridge {
     /// main actor for the duration, so main actor is only briefly held at
     /// function entry/exit.
     @MainActor
-    static func writeBoardForIntent(items: [SharedQueueItem], currentIndex: Int) async {
+    /// Returns whether CoreBluetooth was ready when the existing display call
+    /// was enqueued. This is diagnostic-only; the write/no-op behavior and both
+    /// timeout values are unchanged.
+    @discardableResult
+    static func writeBoardForIntent(items: [SharedQueueItem], currentIndex: Int) async -> Bool {
         let task = BleIntentBackgroundTask()
         task.begin(name: "ble-display-intent")
         defer { task.end() }
-        await BoardBleManager.shared.displayCurrentItemAwaitingReady(
+        return await BoardBleManager.shared.displayCurrentItemAwaitingReady(
             items: items,
             currentIndex: currentIndex,
             readyTimeout: 3.0

--- a/packages/mobile/modules/live-activity/ios/LiveActivityBleBridge.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityBleBridge.swift
@@ -16,9 +16,9 @@ enum LiveActivityBleBridge {
     /// main actor for the duration, so main actor is only briefly held at
     /// function entry/exit.
     @MainActor
-    /// Returns whether CoreBluetooth was ready when the existing display call
-    /// was enqueued. This is diagnostic-only; the write/no-op behavior and both
-    /// timeout values are unchanged.
+    /// Returns true only when this display request completed successfully and
+    /// the global write queue drained inside its existing timeout. This is
+    /// diagnostic-only; failed or late writes keep their existing behavior.
     @discardableResult
     static func writeBoardForIntent(items: [SharedQueueItem], currentIndex: Int) async -> Bool {
         let task = BleIntentBackgroundTask()

--- a/packages/mobile/modules/live-activity/ios/LiveActivityIntentDiagnostics.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityIntentDiagnostics.swift
@@ -1,0 +1,410 @@
+#if !WIDGET_EXTENSION || BOARDSESH_TESTS
+
+import Foundation
+
+/// Fixed, non-identifying intent kinds. Keep this exhaustive with every
+/// `LiveActivityIntent` compiled into the main app and widget targets.
+enum LiveActivityIntentDiagnosticKind: String, Codable, CaseIterable {
+    case nextClimb
+    case previousClimb
+    case takeControl
+    case reconnectBoard
+}
+
+/// Coarse progress only. These values deliberately carry no queue, climb,
+/// session, endpoint, user, or peripheral details.
+enum LiveActivityIntentDiagnosticStage: String, Codable, CaseIterable {
+    case entered
+    case networkStarted
+    case networkFinishedSuccess
+    case networkFinishedRetryable
+    case networkFinishedTerminal
+    case activityKitUpdated
+    case bleStarted
+    case bleFinishedSuccess
+    case bleFinishedFailure
+    case darwinPosted
+    case completed
+}
+
+/// Sanitized normal-exit classes. An interrupted run has no completion class.
+enum LiveActivityIntentCompletionClass: String, Codable, CaseIterable {
+    case success
+    case sharedDefaultsUnavailable
+    case navigationOutOfBounds
+    case serverRejected
+    case retryableNetworkFailure
+    case localNavigationEnabled
+    case alreadyAllowed
+    case bleFailure
+}
+
+struct LiveActivityIntentDiagnosticRecord: Codable, Equatable {
+    static let currentSchemaVersion = 1
+
+    let schemaVersion: Int
+    let runId: String
+    let processId: String
+    let intentKind: LiveActivityIntentDiagnosticKind
+    let appVersion: String
+    let buildNumber: String
+    let startedAt: Date
+    var updatedAt: Date
+    var lastStage: LiveActivityIntentDiagnosticStage
+    var completionClass: LiveActivityIntentCompletionClass?
+    var reactRootMounted: Bool
+
+    var storageKey: String {
+        "\(processId):\(runId)"
+    }
+
+    var bridgePayload: [String: Any] {
+        var payload: [String: Any] = [
+            "schemaVersion": schemaVersion,
+            "runId": runId,
+            "processId": processId,
+            "intentKind": intentKind.rawValue,
+            "appVersion": appVersion,
+            "buildNumber": buildNumber,
+            "startedAtMs": Int64(startedAt.timeIntervalSince1970 * 1_000),
+            "updatedAtMs": Int64(updatedAt.timeIntervalSince1970 * 1_000),
+            "lastStage": lastStage.rawValue,
+            "reactRootMounted": reactRootMounted,
+        ]
+        if let completionClass {
+            payload["completionClass"] = completionClass.rawValue
+        }
+        return payload
+    }
+}
+
+private struct ConsumedIntentDiagnostic: Codable {
+    let storageKey: String
+    let consumedAt: Date
+}
+
+private struct IntentDiagnosticEnvelope: Codable {
+    static let currentSchemaVersion = 1
+
+    let schemaVersion: Int
+    var records: [LiveActivityIntentDiagnosticRecord]
+    var consumed: [ConsumedIntentDiagnostic]
+
+    static var empty: IntentDiagnosticEnvelope {
+        IntentDiagnosticEnvelope(
+            schemaVersion: currentSchemaVersion,
+            records: [],
+            consumed: []
+        )
+    }
+}
+
+/// App-local, bounded storage for Live Activity intent markers.
+///
+/// The main app is the only production target that compiles this file. The
+/// `BOARDSESH_TESTS` exception above lets the generated XCTest target exercise
+/// the exact production store while still compiling shared intent sources with
+/// `WIDGET_EXTENSION`. The real widget target never defines that test flag.
+///
+/// One encoded envelope is replaced under a process lock on each transition.
+/// `UserDefaults.set(Data, forKey:)` is a best-effort atomic replacement at the
+/// app-local persistence boundary; failures must never affect intent behavior.
+final class LiveActivityIntentDiagnosticStore {
+    static let defaultStorageKey = "bs_live_activity_intent_diagnostics_v1"
+    static let defaultMaxRecords = 16
+    static let defaultTimeToLive: TimeInterval = 24 * 60 * 60
+    static let defaultIncompleteGrace: TimeInterval = 30
+
+    private let defaults: UserDefaults
+    private let storageKey: String
+    private let processId: String
+    private let appVersion: String
+    private let buildNumber: String
+    private let maxRecords: Int
+    private let timeToLive: TimeInterval
+    private let incompleteGrace: TimeInterval
+    private let now: () -> Date
+    private let lock = NSLock()
+
+    init(
+        defaults: UserDefaults = .standard,
+        storageKey: String = defaultStorageKey,
+        processId: UUID = UUID(),
+        appVersion: String,
+        buildNumber: String,
+        maxRecords: Int = defaultMaxRecords,
+        timeToLive: TimeInterval = defaultTimeToLive,
+        incompleteGrace: TimeInterval = defaultIncompleteGrace,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.defaults = defaults
+        self.storageKey = storageKey
+        self.processId = processId.uuidString.lowercased()
+        self.appVersion = Self.sanitizeBuildComponent(appVersion)
+        self.buildNumber = Self.sanitizeBuildComponent(buildNumber)
+        self.maxRecords = max(1, maxRecords)
+        self.timeToLive = max(1, timeToLive)
+        self.incompleteGrace = max(0, incompleteGrace)
+        self.now = now
+    }
+
+    func begin(kind: LiveActivityIntentDiagnosticKind) -> LiveActivityIntentDiagnosticRun {
+        let timestamp = now()
+        let record = LiveActivityIntentDiagnosticRecord(
+            schemaVersion: LiveActivityIntentDiagnosticRecord.currentSchemaVersion,
+            runId: UUID().uuidString.lowercased(),
+            processId: processId,
+            intentKind: kind,
+            appVersion: appVersion,
+            buildNumber: buildNumber,
+            startedAt: timestamp,
+            updatedAt: timestamp,
+            lastStage: .entered,
+            completionClass: nil,
+            reactRootMounted: false
+        )
+
+        mutateEnvelope { envelope in
+            envelope.records.removeAll { $0.storageKey == record.storageKey }
+            envelope.records.append(record)
+            self.pruneAndBound(&envelope, at: timestamp)
+        }
+
+        return LiveActivityIntentDiagnosticRun(
+            store: self,
+            runId: record.runId,
+            processId: record.processId
+        )
+    }
+
+    fileprivate func mark(
+        runId: String,
+        processId: String,
+        stage: LiveActivityIntentDiagnosticStage
+    ) {
+        let timestamp = now()
+        mutateEnvelope { envelope in
+            guard let index = envelope.records.firstIndex(where: {
+                $0.runId == runId && $0.processId == processId
+            }) else { return }
+            guard envelope.records[index].lastStage != .completed else { return }
+            envelope.records[index].lastStage = stage
+            envelope.records[index].updatedAt = timestamp
+            self.pruneAndBound(&envelope, at: timestamp)
+        }
+    }
+
+    fileprivate func complete(
+        runId: String,
+        processId: String,
+        completionClass: LiveActivityIntentCompletionClass
+    ) {
+        let timestamp = now()
+        mutateEnvelope { envelope in
+            guard let index = envelope.records.firstIndex(where: {
+                $0.runId == runId && $0.processId == processId
+            }) else { return }
+            guard envelope.records[index].lastStage != .completed else { return }
+            envelope.records[index].lastStage = .completed
+            envelope.records[index].completionClass = completionClass
+            envelope.records[index].updatedAt = timestamp
+            self.pruneAndBound(&envelope, at: timestamp)
+        }
+    }
+
+    /// Marks only currently-running records from this process. This is called
+    /// from a React effect after the root has committed, never at module import.
+    func markReactRootMounted() {
+        let timestamp = now()
+        mutateEnvelope { envelope in
+            for index in envelope.records.indices {
+                guard envelope.records[index].processId == self.processId,
+                      envelope.records[index].lastStage != .completed
+                else { continue }
+                envelope.records[index].reactRootMounted = true
+                envelope.records[index].updatedAt = timestamp
+            }
+            self.pruneAndBound(&envelope, at: timestamp)
+        }
+    }
+
+    /// Atomically returns and removes eligible interrupted runs. Records from
+    /// this process or within the grace window stay pending. Invalid schema,
+    /// corrupt shape, wrong-build, future-dated, and TTL-expired records are
+    /// discarded rather than reported.
+    func consumeInterruptedRuns() -> [LiveActivityIntentDiagnosticRecord] {
+        let timestamp = now()
+        var interrupted: [LiveActivityIntentDiagnosticRecord] = []
+
+        mutateEnvelope { envelope in
+            var consumedKeys = Set(
+                envelope.consumed
+                    .filter { self.isWithinTimeToLive($0.consumedAt, at: timestamp) }
+                    .map(\.storageKey)
+            )
+            var retained: [LiveActivityIntentDiagnosticRecord] = []
+
+            for record in envelope.records {
+                guard self.isValid(record, at: timestamp) else { continue }
+                guard record.lastStage != .completed else {
+                    retained.append(record)
+                    continue
+                }
+                guard record.processId != self.processId else {
+                    retained.append(record)
+                    continue
+                }
+                guard timestamp.timeIntervalSince(record.updatedAt) >= self.incompleteGrace else {
+                    retained.append(record)
+                    continue
+                }
+                guard !consumedKeys.contains(record.storageKey) else { continue }
+
+                consumedKeys.insert(record.storageKey)
+                interrupted.append(record)
+                envelope.consumed.append(
+                    ConsumedIntentDiagnostic(storageKey: record.storageKey, consumedAt: timestamp)
+                )
+            }
+
+            envelope.records = retained
+            self.pruneAndBound(&envelope, at: timestamp)
+            envelope.consumed = envelope.consumed
+                .filter { self.isWithinTimeToLive($0.consumedAt, at: timestamp) }
+                .suffix(self.maxRecords * 2)
+                .map { $0 }
+        }
+
+        return interrupted
+    }
+
+    #if BOARDSESH_TESTS
+    func recordsSnapshot() -> [LiveActivityIntentDiagnosticRecord] {
+        lock.lock()
+        defer { lock.unlock() }
+        return readEnvelope().records
+    }
+    #endif
+
+    private func mutateEnvelope(_ mutation: (inout IntentDiagnosticEnvelope) -> Void) {
+        lock.lock()
+        defer { lock.unlock() }
+        var envelope = readEnvelope()
+        mutation(&envelope)
+        writeEnvelope(envelope)
+    }
+
+    private func readEnvelope() -> IntentDiagnosticEnvelope {
+        guard let encoded = defaults.data(forKey: storageKey),
+              let envelope = try? JSONDecoder().decode(IntentDiagnosticEnvelope.self, from: encoded),
+              envelope.schemaVersion == IntentDiagnosticEnvelope.currentSchemaVersion
+        else {
+            return .empty
+        }
+        return envelope
+    }
+
+    private func writeEnvelope(_ envelope: IntentDiagnosticEnvelope) {
+        guard let encoded = try? JSONEncoder().encode(envelope) else { return }
+        defaults.set(encoded, forKey: storageKey)
+    }
+
+    private func pruneAndBound(_ envelope: inout IntentDiagnosticEnvelope, at timestamp: Date) {
+        envelope.records = envelope.records
+            .filter { self.isValid($0, at: timestamp) }
+            .suffix(maxRecords)
+            .map { $0 }
+    }
+
+    private func isValid(_ record: LiveActivityIntentDiagnosticRecord, at timestamp: Date) -> Bool {
+        guard record.schemaVersion == LiveActivityIntentDiagnosticRecord.currentSchemaVersion,
+              UUID(uuidString: record.runId) != nil,
+              UUID(uuidString: record.processId) != nil,
+              record.appVersion == appVersion,
+              record.buildNumber == buildNumber,
+              record.startedAt <= record.updatedAt,
+              record.lastStage == .completed ? record.completionClass != nil : record.completionClass == nil,
+              isWithinTimeToLive(record.startedAt, at: timestamp),
+              timestamp.timeIntervalSince(record.updatedAt) >= -300
+        else {
+            return false
+        }
+        return true
+    }
+
+    private func isWithinTimeToLive(_ date: Date, at timestamp: Date) -> Bool {
+        let age = timestamp.timeIntervalSince(date)
+        return age >= -300 && age <= timeToLive
+    }
+
+    /// Build metadata is diagnostic context, but still bounded and restricted
+    /// to a small safe alphabet before persistence or Sentry emission.
+    static func sanitizeBuildComponent(_ component: String) -> String {
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-")
+        let scalars = component.unicodeScalars.filter { allowed.contains($0) }
+        let sanitized = String(String.UnicodeScalarView(scalars)).prefix(64)
+        return sanitized.isEmpty ? "unknown" : String(sanitized)
+    }
+}
+
+/// Per-run scoped handle. `complete` is idempotent and prevents later stages
+/// from reopening a normal exit. Callers use `defer` so every normal early
+/// return is marked completed while process termination leaves it incomplete.
+final class LiveActivityIntentDiagnosticRun {
+    private let store: LiveActivityIntentDiagnosticStore
+    private let runId: String
+    private let processId: String
+    private let lock = NSLock()
+    private var isCompleted = false
+
+    fileprivate init(
+        store: LiveActivityIntentDiagnosticStore,
+        runId: String,
+        processId: String
+    ) {
+        self.store = store
+        self.runId = runId
+        self.processId = processId
+    }
+
+    func mark(_ stage: LiveActivityIntentDiagnosticStage) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !isCompleted, stage != .completed else { return }
+        store.mark(runId: runId, processId: processId, stage: stage)
+    }
+
+    func complete(_ completionClass: LiveActivityIntentCompletionClass) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !isCompleted else { return }
+        isCompleted = true
+        store.complete(
+            runId: runId,
+            processId: processId,
+            completionClass: completionClass
+        )
+    }
+}
+
+enum LiveActivityIntentDiagnostics {
+    private static let store = LiveActivityIntentDiagnosticStore(
+        processId: UUID(),
+        appVersion: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown",
+        buildNumber: Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown"
+    )
+
+    static func begin(kind: LiveActivityIntentDiagnosticKind) -> LiveActivityIntentDiagnosticRun {
+        store.begin(kind: kind)
+    }
+
+    static func markReactRootMounted() {
+        store.markReactRootMounted()
+    }
+
+    static func consumeInterruptedRuns() -> [[String: Any]] {
+        store.consumeInterruptedRuns().map(\.bridgePayload)
+    }
+}
+
+#endif

--- a/packages/mobile/modules/live-activity/ios/LiveActivityIntentDiagnostics.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityIntentDiagnostics.swift
@@ -269,10 +269,6 @@ final class LiveActivityIntentDiagnosticStore {
 
             envelope.records = retained
             self.pruneAndBound(&envelope, at: timestamp)
-            envelope.consumed = envelope.consumed
-                .filter { self.isWithinTimeToLive($0.consumedAt, at: timestamp) }
-                .suffix(self.maxRecords * 2)
-                .map { $0 }
         }
 
         return interrupted
@@ -313,6 +309,10 @@ final class LiveActivityIntentDiagnosticStore {
         envelope.records = envelope.records
             .filter { self.isValid($0, at: timestamp) }
             .suffix(maxRecords)
+            .map { $0 }
+        envelope.consumed = envelope.consumed
+            .filter { self.isWithinTimeToLive($0.consumedAt, at: timestamp) }
+            .suffix(maxRecords * 2)
             .map { $0 }
     }
 

--- a/packages/mobile/modules/live-activity/ios/LiveActivityIntentDiagnostics.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityIntentDiagnostics.swift
@@ -27,6 +27,22 @@ enum LiveActivityIntentDiagnosticStage: String, Codable, CaseIterable {
     case completed
 }
 
+/// Stages that can cross the interrupted-run bridge. `completed` is
+/// intentionally unrepresentable here: normal exits stay in native storage and
+/// are never consumed by JS.
+enum LiveActivityInterruptedIntentDiagnosticStage: String, Codable, CaseIterable {
+    case entered
+    case networkStarted
+    case networkFinishedSuccess
+    case networkFinishedRetryable
+    case networkFinishedTerminal
+    case activityKitUpdated
+    case bleStarted
+    case bleFinishedSuccess
+    case bleFinishedFailure
+    case darwinPosted
+}
+
 /// Sanitized normal-exit classes. An interrupted run has no completion class.
 enum LiveActivityIntentCompletionClass: String, Codable, CaseIterable {
     case success
@@ -57,9 +73,43 @@ struct LiveActivityIntentDiagnosticRecord: Codable, Equatable {
     var storageKey: String {
         "\(processId):\(runId)"
     }
+}
+
+/// Failable boundary between durable stored records and the JS bridge. The DTO
+/// has neither a completed stage nor a completion class, so a future change to
+/// store filtering cannot accidentally widen the consumed payload.
+struct LiveActivityInterruptedIntentDiagnostic: Equatable {
+    let schemaVersion: Int
+    let runId: String
+    let processId: String
+    let intentKind: LiveActivityIntentDiagnosticKind
+    let appVersion: String
+    let buildNumber: String
+    let startedAt: Date
+    let updatedAt: Date
+    let lastStage: LiveActivityInterruptedIntentDiagnosticStage
+    let reactRootMounted: Bool
+
+    init?(record: LiveActivityIntentDiagnosticRecord) {
+        guard record.completionClass == nil,
+              let interruptedStage = LiveActivityInterruptedIntentDiagnosticStage(rawValue: record.lastStage.rawValue)
+        else {
+            return nil
+        }
+        schemaVersion = record.schemaVersion
+        runId = record.runId
+        processId = record.processId
+        intentKind = record.intentKind
+        appVersion = record.appVersion
+        buildNumber = record.buildNumber
+        startedAt = record.startedAt
+        updatedAt = record.updatedAt
+        lastStage = interruptedStage
+        reactRootMounted = record.reactRootMounted
+    }
 
     var bridgePayload: [String: Any] {
-        var payload: [String: Any] = [
+        [
             "schemaVersion": schemaVersion,
             "runId": runId,
             "processId": processId,
@@ -71,10 +121,6 @@ struct LiveActivityIntentDiagnosticRecord: Codable, Equatable {
             "lastStage": lastStage.rawValue,
             "reactRootMounted": reactRootMounted,
         ]
-        if let completionClass {
-            payload["completionClass"] = completionClass.rawValue
-        }
-        return payload
     }
 }
 
@@ -403,7 +449,9 @@ enum LiveActivityIntentDiagnostics {
     }
 
     static func consumeInterruptedRuns() -> [[String: Any]] {
-        store.consumeInterruptedRuns().map(\.bridgePayload)
+        store.consumeInterruptedRuns()
+            .compactMap { LiveActivityInterruptedIntentDiagnostic(record: $0) }
+            .map(\.bridgePayload)
     }
 }
 

--- a/packages/mobile/modules/live-activity/ios/LiveActivityModule.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityModule.swift
@@ -106,6 +106,20 @@ public class LiveActivityModule: Module {
             return ["available": false]
         }
 
+        // Called from a React effect after the root commits. Keeping this an
+        // explicit JS→native marker distinguishes background intent launches
+        // that mounted the full React tree from minimal native-only launches.
+        AsyncFunction("markIntentReactRootMounted") { () -> Void in
+            LiveActivityIntentDiagnostics.markReactRootMounted()
+        }
+
+        // AppState's foreground observer calls this. The native store performs
+        // schema/build/TTL/grace validation and atomically consumes each
+        // previous-process interruption at most once.
+        AsyncFunction("consumeInterruptedIntentRuns") { () -> [[String: Any]] in
+            LiveActivityIntentDiagnostics.consumeInterruptedRuns()
+        }
+
         AsyncFunction("startSession") { (options: StartSessionOptions, promise: Promise) in
             self.startSession(options: options, promise: promise)
         }

--- a/packages/mobile/modules/live-activity/ios/ReconnectBoardIntent.swift
+++ b/packages/mobile/modules/live-activity/ios/ReconnectBoardIntent.swift
@@ -17,6 +17,25 @@ struct ReconnectBoardIntent: LiveActivityIntent {
 
     private static let logger = Logger(subsystem: "com.boardsesh.app", category: "LiveActivityIntent")
 
+    #if !WIDGET_EXTENSION || BOARDSESH_TESTS
+    /// A later take-control failure must not hide an earlier BLE reconnect
+    /// failure: the first failed prerequisite is the most useful diagnostic.
+    static func diagnosticCompletionClass(
+        current: LiveActivityIntentCompletionClass,
+        networkResult: WidgetNavigationResult
+    ) -> LiveActivityIntentCompletionClass {
+        guard current == .success else { return current }
+        switch networkResult {
+        case .success:
+            return .success
+        case .serverRejected:
+            return .serverRejected
+        case .retryableFailure:
+            return .retryableNetworkFailure
+        }
+    }
+    #endif
+
     func perform() async throws -> some IntentResult {
         #if !WIDGET_EXTENSION
         let diagnosticRun = LiveActivityIntentDiagnostics.begin(kind: .reconnectBoard)
@@ -58,11 +77,10 @@ struct ReconnectBoardIntent: LiveActivityIntent {
                     diagnosticRun.mark(.networkFinishedSuccess)
                 case .serverRejected:
                     diagnosticRun.mark(.networkFinishedTerminal)
-                    completionClass = .serverRejected
                 case .retryableFailure:
                     diagnosticRun.mark(.networkFinishedRetryable)
-                    completionClass = .retryableNetworkFailure
                 }
+                completionClass = Self.diagnosticCompletionClass(current: completionClass, networkResult: result)
                 #endif
                 if result == .success {
                     SharedWidgetWallControlState.save(navigationAllowed: true, isPartySession: true, to: defaults)

--- a/packages/mobile/modules/live-activity/ios/ReconnectBoardIntent.swift
+++ b/packages/mobile/modules/live-activity/ios/ReconnectBoardIntent.swift
@@ -18,6 +18,12 @@ struct ReconnectBoardIntent: LiveActivityIntent {
     private static let logger = Logger(subsystem: "com.boardsesh.app", category: "LiveActivityIntent")
 
     func perform() async throws -> some IntentResult {
+        #if !WIDGET_EXTENSION
+        let diagnosticRun = LiveActivityIntentDiagnostics.begin(kind: .reconnectBoard)
+        var completionClass = LiveActivityIntentCompletionClass.success
+        defer { diagnosticRun.complete(completionClass) }
+        #endif
+
         Self.logger.notice("ReconnectBoardIntent.perform() running process=\(ProcessInfo.processInfo.processName, privacy: .public)")
 
         // Reconnect BLE to the last board. In the main app process (the path iOS
@@ -26,7 +32,12 @@ struct ReconnectBoardIntent: LiveActivityIntent {
         // can't link BoardBleManager — fall back to a Darwin notification so the
         // live main app does the reconnect, mirroring ClimbNavigationIntent.
         #if !WIDGET_EXTENSION
-        _ = await LiveActivityBleBridge.reconnectForIntent()
+        diagnosticRun.mark(.bleStarted)
+        let reconnected = await LiveActivityBleBridge.reconnectForIntent()
+        diagnosticRun.mark(reconnected ? .bleFinishedSuccess : .bleFinishedFailure)
+        if !reconnected {
+            completionClass = .bleFailure
+        }
         #else
         postBleReconnectDarwinNotification()
         #endif
@@ -37,7 +48,22 @@ struct ReconnectBoardIntent: LiveActivityIntent {
         if let defaults = SharedConstants.sharedDefaults {
             let wallControl = SharedWidgetWallControlState.load(from: defaults)
             if wallControl.requiresServerAuthorization, !wallControl.navigationAllowed {
+                #if !WIDGET_EXTENSION
+                diagnosticRun.mark(.networkStarted)
+                #endif
                 let result = await WidgetNetworking.sendTakeControl()
+                #if !WIDGET_EXTENSION
+                switch result {
+                case .success:
+                    diagnosticRun.mark(.networkFinishedSuccess)
+                case .serverRejected:
+                    diagnosticRun.mark(.networkFinishedTerminal)
+                    completionClass = .serverRejected
+                case .retryableFailure:
+                    diagnosticRun.mark(.networkFinishedRetryable)
+                    completionClass = .retryableNetworkFailure
+                }
+                #endif
                 if result == .success {
                     SharedWidgetWallControlState.save(navigationAllowed: true, isPartySession: true, to: defaults)
                 }
@@ -45,6 +71,9 @@ struct ReconnectBoardIntent: LiveActivityIntent {
         }
 
         await refreshActivities()
+        #if !WIDGET_EXTENSION
+        diagnosticRun.mark(.activityKitUpdated)
+        #endif
         return .result()
     }
 

--- a/packages/mobile/modules/live-activity/ios/TakeControlIntent.swift
+++ b/packages/mobile/modules/live-activity/ios/TakeControlIntent.swift
@@ -10,22 +10,56 @@ struct TakeControlIntent: LiveActivityIntent {
     private static let logger = Logger(subsystem: "com.boardsesh.app", category: "LiveActivityIntent")
 
     func perform() async throws -> some IntentResult {
-        guard let defaults = SharedConstants.sharedDefaults else { return .result() }
+        #if !WIDGET_EXTENSION
+        let diagnosticRun = LiveActivityIntentDiagnostics.begin(kind: .takeControl)
+        var completionClass = LiveActivityIntentCompletionClass.success
+        defer { diagnosticRun.complete(completionClass) }
+        #endif
+
+        guard let defaults = SharedConstants.sharedDefaults else {
+            #if !WIDGET_EXTENSION
+            completionClass = .sharedDefaultsUnavailable
+            #endif
+            return .result()
+        }
 
         let wallControl = SharedWidgetWallControlState.load(from: defaults)
         switch SharedWidgetTakeControlRuntime.action(for: wallControl) {
         case .enableLocalNavigation:
             SharedWidgetTakeControlRuntime.markControlClaimed(isPartySession: false, to: defaults)
             await refreshActivities()
+            #if !WIDGET_EXTENSION
+            diagnosticRun.mark(.activityKitUpdated)
+            completionClass = .localNavigationEnabled
+            #endif
             return .result()
         case .alreadyAllowed:
             await refreshActivities()
+            #if !WIDGET_EXTENSION
+            diagnosticRun.mark(.activityKitUpdated)
+            completionClass = .alreadyAllowed
+            #endif
             return .result()
         case .requestServerAuthorization:
             break
         }
 
+        #if !WIDGET_EXTENSION
+        diagnosticRun.mark(.networkStarted)
+        #endif
         let result = await WidgetNetworking.sendTakeControl()
+        #if !WIDGET_EXTENSION
+        switch result {
+        case .success:
+            diagnosticRun.mark(.networkFinishedSuccess)
+        case .serverRejected:
+            diagnosticRun.mark(.networkFinishedTerminal)
+            completionClass = .serverRejected
+        case .retryableFailure:
+            diagnosticRun.mark(.networkFinishedRetryable)
+            completionClass = .retryableNetworkFailure
+        }
+        #endif
         guard result == .success else {
             Self.logger.notice("TakeControlIntent rejected or failed; leaving widget navigation disabled")
             return .result()
@@ -33,6 +67,9 @@ struct TakeControlIntent: LiveActivityIntent {
 
         SharedWidgetTakeControlRuntime.markControlClaimed(isPartySession: true, to: defaults)
         await refreshActivities()
+        #if !WIDGET_EXTENSION
+        diagnosticRun.mark(.activityKitUpdated)
+        #endif
         return .result()
     }
 

--- a/packages/mobile/modules/live-activity/ios/WaiterPool.swift
+++ b/packages/mobile/modules/live-activity/ios/WaiterPool.swift
@@ -17,7 +17,7 @@ import Foundation
 final class WaiterPool: @unchecked Sendable {
     private struct Waiter {
         let id: UUID
-        let continuation: CheckedContinuation<Void, Never>
+        let continuation: CheckedContinuation<Bool, Never>
         let timeoutWorkItem: DispatchWorkItem
     }
 
@@ -28,18 +28,18 @@ final class WaiterPool: @unchecked Sendable {
         self.queue = queue
     }
 
-    /// Returns immediately if `isReady()` is true when evaluated on the pool's
-    /// queue; otherwise suspends until `signalAll()` is called or `timeout`
-    /// elapses.
-    func wait(timeout: TimeInterval, isReady: @escaping () -> Bool) async {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+    /// Returns `true` immediately when `isReady()` is already satisfied, or
+    /// after `signalAll()` resumes the waiter. Returns `false` when `timeout`
+    /// elapses first.
+    func wait(timeout: TimeInterval, isReady: @escaping () -> Bool) async -> Bool {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
             queue.async { [weak self] in
                 guard let self else {
-                    continuation.resume()
+                    continuation.resume(returning: false)
                     return
                 }
                 if isReady() {
-                    continuation.resume()
+                    continuation.resume(returning: true)
                     return
                 }
                 let waiterId = UUID()
@@ -53,12 +53,12 @@ final class WaiterPool: @unchecked Sendable {
                         // traps in debug builds and hangs the awaiting Task.
                         // In practice unreachable while BoardBleManager.shared
                         // owns the pool, but the contract has to hold.
-                        continuation.resume()
+                        continuation.resume(returning: false)
                         return
                     }
                     if let index = self.waiters.firstIndex(where: { $0.id == waiterId }) {
                         let waiter = self.waiters.remove(at: index)
-                        waiter.continuation.resume()
+                        waiter.continuation.resume(returning: false)
                     }
                     // If no matching waiter is found, signalAll already
                     // resumed this continuation and removed the entry — do
@@ -79,7 +79,7 @@ final class WaiterPool: @unchecked Sendable {
         waiters = []
         for waiter in snapshot {
             waiter.timeoutWorkItem.cancel()
-            waiter.continuation.resume()
+            waiter.continuation.resume(returning: true)
         }
     }
 

--- a/packages/mobile/modules/live-activity/src/index.ts
+++ b/packages/mobile/modules/live-activity/src/index.ts
@@ -277,6 +277,38 @@ export type WidgetQueueNavigateEvent = {
   correlationId: string;
 };
 
+export type LiveActivityIntentDiagnostic = {
+  schemaVersion: 1;
+  runId: string;
+  processId: string;
+  intentKind: 'nextClimb' | 'previousClimb' | 'takeControl' | 'reconnectBoard';
+  appVersion: string;
+  buildNumber: string;
+  startedAtMs: number;
+  updatedAtMs: number;
+  lastStage:
+    | 'entered'
+    | 'networkStarted'
+    | 'networkFinishedSuccess'
+    | 'networkFinishedRetryable'
+    | 'networkFinishedTerminal'
+    | 'activityKitUpdated'
+    | 'bleStarted'
+    | 'bleFinishedSuccess'
+    | 'bleFinishedFailure'
+    | 'darwinPosted';
+  reactRootMounted: boolean;
+  completionClass?:
+    | 'success'
+    | 'sharedDefaultsUnavailable'
+    | 'navigationOutOfBounds'
+    | 'serverRejected'
+    | 'retryableNetworkFailure'
+    | 'localNavigationEnabled'
+    | 'alreadyAllowed'
+    | 'bleFailure';
+};
+
 /**
  * Android-only: a tap on the foreground-service notification's lightbulb.
  * - `reconnect`: bulb was out (heldByPeer / disconnected) → reconnect to the
@@ -295,6 +327,10 @@ type LiveActivityNativeModule = {
   endSession(): Promise<void>;
   updateActivity(options: LiveActivityUpdateOptions): Promise<void>;
   updateActivityClimb(options: LiveActivityClimbUpdateOptions): Promise<void>;
+  /** Optional for OTA compatibility with binaries predating #4077. */
+  markIntentReactRootMounted?(): Promise<void>;
+  /** Optional for OTA compatibility with binaries predating #4077. */
+  consumeInterruptedIntentRuns?(): Promise<LiveActivityIntentDiagnostic[]>;
   addListener(event: 'queueNavigate', listener: (payload: WidgetQueueNavigateEvent) => void): EventSubscription;
 };
 

--- a/packages/mobile/modules/live-activity/src/index.ts
+++ b/packages/mobile/modules/live-activity/src/index.ts
@@ -296,7 +296,8 @@ export type LiveActivityIntentDiagnostic = {
     | 'bleStarted'
     | 'bleFinishedSuccess'
     | 'bleFinishedFailure'
-    | 'darwinPosted';
+    | 'darwinPosted'
+    | 'completed';
   reactRootMounted: boolean;
   completionClass?:
     | 'success'

--- a/packages/mobile/modules/live-activity/src/index.ts
+++ b/packages/mobile/modules/live-activity/src/index.ts
@@ -277,37 +277,42 @@ export type WidgetQueueNavigateEvent = {
   correlationId: string;
 };
 
-export type LiveActivityIntentDiagnostic = {
+export type LiveActivityIntentDiagnosticKind = 'nextClimb' | 'previousClimb' | 'takeControl' | 'reconnectBoard';
+
+export type LiveActivityIntentDiagnosticStage =
+  | 'entered'
+  | 'networkStarted'
+  | 'networkFinishedSuccess'
+  | 'networkFinishedRetryable'
+  | 'networkFinishedTerminal'
+  | 'activityKitUpdated'
+  | 'bleStarted'
+  | 'bleFinishedSuccess'
+  | 'bleFinishedFailure'
+  | 'darwinPosted'
+  | 'completed';
+
+export type LiveActivityIntentCompletionClass =
+  | 'success'
+  | 'sharedDefaultsUnavailable'
+  | 'navigationOutOfBounds'
+  | 'serverRejected'
+  | 'retryableNetworkFailure'
+  | 'localNavigationEnabled'
+  | 'alreadyAllowed'
+  | 'bleFailure';
+
+export type InterruptedLiveActivityIntentDiagnostic = {
   schemaVersion: 1;
   runId: string;
   processId: string;
-  intentKind: 'nextClimb' | 'previousClimb' | 'takeControl' | 'reconnectBoard';
+  intentKind: LiveActivityIntentDiagnosticKind;
   appVersion: string;
   buildNumber: string;
   startedAtMs: number;
   updatedAtMs: number;
-  lastStage:
-    | 'entered'
-    | 'networkStarted'
-    | 'networkFinishedSuccess'
-    | 'networkFinishedRetryable'
-    | 'networkFinishedTerminal'
-    | 'activityKitUpdated'
-    | 'bleStarted'
-    | 'bleFinishedSuccess'
-    | 'bleFinishedFailure'
-    | 'darwinPosted'
-    | 'completed';
+  lastStage: Exclude<LiveActivityIntentDiagnosticStage, 'completed'>;
   reactRootMounted: boolean;
-  completionClass?:
-    | 'success'
-    | 'sharedDefaultsUnavailable'
-    | 'navigationOutOfBounds'
-    | 'serverRejected'
-    | 'retryableNetworkFailure'
-    | 'localNavigationEnabled'
-    | 'alreadyAllowed'
-    | 'bleFailure';
 };
 
 /**
@@ -331,7 +336,7 @@ type LiveActivityNativeModule = {
   /** Optional for OTA compatibility with binaries predating #4077. */
   markIntentReactRootMounted?(): Promise<void>;
   /** Optional for OTA compatibility with binaries predating #4077. */
-  consumeInterruptedIntentRuns?(): Promise<LiveActivityIntentDiagnostic[]>;
+  consumeInterruptedIntentRuns?(): Promise<InterruptedLiveActivityIntentDiagnostic[]>;
   addListener(event: 'queueNavigate', listener: (payload: WidgetQueueNavigateEvent) => void): EventSubscription;
 };
 

--- a/packages/mobile/src/components/LiveActivityIntentDiagnostics.tsx
+++ b/packages/mobile/src/components/LiveActivityIntentDiagnostics.tsx
@@ -4,9 +4,14 @@ import {
   consumeInterruptedLiveActivityIntentRuns,
   markLiveActivityIntentReactRootMounted,
 } from '../lib/live-activity/live-activity-plugin';
-import { captureLiveActivityIntentDiagnostic } from '../lib/sentry';
+import { captureLiveActivityIntentDiagnostic, isSentryEnabled } from '../lib/sentry';
 
 export async function consumeAndReportInterruptedLiveActivityIntents(): Promise<void> {
+  // Consuming is destructive — the native store drops the records — so leave
+  // them stored until a reporter exists. A production build whose Sentry DSN
+  // is missing or mis-injected must not silently destroy the evidence #4077
+  // needs; the store is ring- and TTL-bounded, so deferring costs nothing.
+  if (!isSentryEnabled) return;
   const diagnostics = await consumeInterruptedLiveActivityIntentRuns();
   for (const diagnostic of diagnostics) {
     captureLiveActivityIntentDiagnostic(diagnostic);

--- a/packages/mobile/src/components/LiveActivityIntentDiagnostics.tsx
+++ b/packages/mobile/src/components/LiveActivityIntentDiagnostics.tsx
@@ -1,0 +1,53 @@
+import { useEffect } from 'react';
+import { AppState } from 'react-native';
+import {
+  consumeInterruptedLiveActivityIntentRuns,
+  markLiveActivityIntentReactRootMounted,
+} from '../lib/live-activity/live-activity-plugin';
+import { captureLiveActivityIntentDiagnostic } from '../lib/sentry';
+
+export async function consumeAndReportInterruptedLiveActivityIntents(): Promise<void> {
+  const diagnostics = await consumeInterruptedLiveActivityIntentRuns();
+  for (const diagnostic of diagnostics) {
+    captureLiveActivityIntentDiagnostic(diagnostic);
+  }
+}
+
+/**
+ * Root-mounted lifecycle seam for #4077. Its effect proves React committed in
+ * this process, then consumes interrupted previous-process intent markers only
+ * while the app is foregrounded. It renders no UI and is safe on Android, web,
+ * Expo Go, and iOS binaries that predate the optional native methods.
+ */
+export function LiveActivityIntentDiagnostics() {
+  useEffect(() => {
+    let disposed = false;
+    let consumptionInFlight = false;
+
+    const consumeIfForegrounded = async () => {
+      if (disposed || consumptionInFlight || AppState.currentState !== 'active') return;
+      consumptionInFlight = true;
+      try {
+        await consumeAndReportInterruptedLiveActivityIntents();
+      } finally {
+        consumptionInFlight = false;
+      }
+    };
+
+    // This runs after the actual root commit, not during module evaluation.
+    void markLiveActivityIntentReactRootMounted().then(() => consumeIfForegrounded());
+
+    const subscription = AppState.addEventListener('change', (nextState) => {
+      if (nextState === 'active') {
+        void consumeIfForegrounded();
+      }
+    });
+
+    return () => {
+      disposed = true;
+      subscription.remove();
+    };
+  }, []);
+
+  return null;
+}

--- a/packages/mobile/src/components/LiveActivityIntentDiagnostics.tsx
+++ b/packages/mobile/src/components/LiveActivityIntentDiagnostics.tsx
@@ -22,6 +22,9 @@ export async function consumeAndReportInterruptedLiveActivityIntents(): Promise<
 export function LiveActivityIntentDiagnostics() {
   useEffect(() => {
     let disposed = false;
+    // AppState can emit repeated `active` notifications during one transition.
+    // Keep native consumption single-flight so the once-only store is not read
+    // concurrently and each returned diagnostic is reported at most once.
     let consumptionInFlight = false;
 
     const consumeIfForegrounded = async () => {

--- a/packages/mobile/src/components/__tests__/live-activity-intent-diagnostics.test.tsx
+++ b/packages/mobile/src/components/__tests__/live-activity-intent-diagnostics.test.tsx
@@ -14,6 +14,7 @@ const sentryDiagnostics = vi.hoisted(() => ({
 const appState = vi.hoisted(() => {
   let currentState = 'active';
   const handlers = new Set<(state: string) => void>();
+  const remove = vi.fn((handler: (state: string) => void) => handlers.delete(handler));
   return {
     getCurrentState: () => currentState,
     setState: (state: string) => {
@@ -25,11 +26,13 @@ const appState = vi.hoisted(() => {
     },
     addEventListener: vi.fn((_event: string, handler: (state: string) => void) => {
       handlers.add(handler);
-      return { remove: vi.fn(() => handlers.delete(handler)) };
+      return { remove: vi.fn(() => remove(handler)) };
     }),
+    remove,
     reset: () => {
       currentState = 'active';
       handlers.clear();
+      remove.mockClear();
     },
   };
 });
@@ -108,5 +111,22 @@ describe('LiveActivityIntentDiagnostics', () => {
 
     appState.emit('active');
     await waitFor(() => expect(nativeDiagnostics.consume).toHaveBeenCalledTimes(1));
+  });
+
+  it('removes its foreground listener and ignores a late root marker after unmount', async () => {
+    let resolveRootMarker = () => {};
+    nativeDiagnostics.markRootMounted.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveRootMarker = resolve;
+      }),
+    );
+    const { unmount } = render(<LiveActivityIntentDiagnostics />);
+
+    unmount();
+    resolveRootMarker();
+    await Promise.resolve();
+
+    expect(appState.remove).toHaveBeenCalledTimes(1);
+    expect(nativeDiagnostics.consume).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/components/__tests__/live-activity-intent-diagnostics.test.tsx
+++ b/packages/mobile/src/components/__tests__/live-activity-intent-diagnostics.test.tsx
@@ -9,6 +9,7 @@ const nativeDiagnostics = vi.hoisted(() => ({
 
 const sentryDiagnostics = vi.hoisted(() => ({
   capture: vi.fn(),
+  enabled: true,
 }));
 
 const appState = vi.hoisted(() => {
@@ -53,6 +54,9 @@ vi.mock('../../lib/live-activity/live-activity-plugin', () => ({
 
 vi.mock('../../lib/sentry', () => ({
   captureLiveActivityIntentDiagnostic: sentryDiagnostics.capture,
+  get isSentryEnabled() {
+    return sentryDiagnostics.enabled;
+  },
 }));
 
 import {
@@ -82,6 +86,17 @@ describe('LiveActivityIntentDiagnostics', () => {
     nativeDiagnostics.consume.mockReset();
     nativeDiagnostics.consume.mockResolvedValue([]);
     sentryDiagnostics.capture.mockClear();
+    sentryDiagnostics.enabled = true;
+  });
+
+  it('leaves the once-only store untouched when no Sentry reporter exists', async () => {
+    sentryDiagnostics.enabled = false;
+    nativeDiagnostics.consume.mockResolvedValueOnce([diagnostic]);
+
+    await consumeAndReportInterruptedLiveActivityIntents();
+
+    expect(nativeDiagnostics.consume).not.toHaveBeenCalled();
+    expect(sentryDiagnostics.capture).not.toHaveBeenCalled();
   });
 
   it('reports each sanitized record returned by the once-only native consumer', async () => {

--- a/packages/mobile/src/components/__tests__/live-activity-intent-diagnostics.test.tsx
+++ b/packages/mobile/src/components/__tests__/live-activity-intent-diagnostics.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, waitFor } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const nativeDiagnostics = vi.hoisted(() => ({
@@ -111,6 +111,26 @@ describe('LiveActivityIntentDiagnostics', () => {
 
     appState.emit('active');
     await waitFor(() => expect(nativeDiagnostics.consume).toHaveBeenCalledTimes(1));
+  });
+
+  it('coalesces repeated foreground signals while native consumption is in flight', async () => {
+    appState.setState('background');
+    let resolveConsumption = (_diagnostics: Array<typeof diagnostic>) => {};
+    nativeDiagnostics.consume.mockReturnValueOnce(
+      new Promise<Array<typeof diagnostic>>((resolve) => {
+        resolveConsumption = resolve;
+      }),
+    );
+    render(<LiveActivityIntentDiagnostics />);
+    await waitFor(() => expect(nativeDiagnostics.markRootMounted).toHaveBeenCalledTimes(1));
+
+    appState.emit('active');
+    appState.emit('active');
+    expect(nativeDiagnostics.consume).toHaveBeenCalledTimes(1);
+
+    await act(async () => resolveConsumption([]));
+    appState.emit('active');
+    await waitFor(() => expect(nativeDiagnostics.consume).toHaveBeenCalledTimes(2));
   });
 
   it('removes its foreground listener and ignores a late root marker after unmount', async () => {

--- a/packages/mobile/src/components/__tests__/live-activity-intent-diagnostics.test.tsx
+++ b/packages/mobile/src/components/__tests__/live-activity-intent-diagnostics.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const nativeDiagnostics = vi.hoisted(() => ({
+  markRootMounted: vi.fn(async () => {}),
+  consume: vi.fn(),
+}));
+
+const sentryDiagnostics = vi.hoisted(() => ({
+  capture: vi.fn(),
+}));
+
+const appState = vi.hoisted(() => {
+  let currentState = 'active';
+  const handlers = new Set<(state: string) => void>();
+  return {
+    getCurrentState: () => currentState,
+    setState: (state: string) => {
+      currentState = state;
+    },
+    emit: (state: string) => {
+      currentState = state;
+      for (const handler of handlers) handler(state);
+    },
+    addEventListener: vi.fn((_event: string, handler: (state: string) => void) => {
+      handlers.add(handler);
+      return { remove: vi.fn(() => handlers.delete(handler)) };
+    }),
+    reset: () => {
+      currentState = 'active';
+      handlers.clear();
+    },
+  };
+});
+
+vi.mock('react-native', () => ({
+  AppState: {
+    get currentState() {
+      return appState.getCurrentState();
+    },
+    addEventListener: appState.addEventListener,
+  },
+}));
+
+vi.mock('../../lib/live-activity/live-activity-plugin', () => ({
+  markLiveActivityIntentReactRootMounted: nativeDiagnostics.markRootMounted,
+  consumeInterruptedLiveActivityIntentRuns: nativeDiagnostics.consume,
+}));
+
+vi.mock('../../lib/sentry', () => ({
+  captureLiveActivityIntentDiagnostic: sentryDiagnostics.capture,
+}));
+
+import {
+  consumeAndReportInterruptedLiveActivityIntents,
+  LiveActivityIntentDiagnostics,
+} from '../LiveActivityIntentDiagnostics';
+
+const diagnostic = {
+  schemaVersion: 1 as const,
+  runId: '30fe8dab-7c3f-4ed0-ae20-291a87390001',
+  processId: 'b5a82684-6a2c-4bbb-a9cc-b7bfc1df0001',
+  intentKind: 'nextClimb' as const,
+  appVersion: '2.0.0',
+  buildNumber: '481',
+  startedAtMs: 1_000,
+  updatedAtMs: 3_000,
+  lastStage: 'bleStarted' as const,
+  reactRootMounted: true,
+};
+
+describe('LiveActivityIntentDiagnostics', () => {
+  beforeEach(() => {
+    appState.reset();
+    appState.addEventListener.mockClear();
+    nativeDiagnostics.markRootMounted.mockClear();
+    nativeDiagnostics.markRootMounted.mockResolvedValue(undefined);
+    nativeDiagnostics.consume.mockReset();
+    nativeDiagnostics.consume.mockResolvedValue([]);
+    sentryDiagnostics.capture.mockClear();
+  });
+
+  it('reports each sanitized record returned by the once-only native consumer', async () => {
+    const secondDiagnostic = { ...diagnostic, runId: '30fe8dab-7c3f-4ed0-ae20-291a87390002' };
+    nativeDiagnostics.consume.mockResolvedValueOnce([diagnostic, secondDiagnostic]);
+
+    await consumeAndReportInterruptedLiveActivityIntents();
+
+    expect(sentryDiagnostics.capture).toHaveBeenNthCalledWith(1, diagnostic);
+    expect(sentryDiagnostics.capture).toHaveBeenNthCalledWith(2, secondDiagnostic);
+  });
+
+  it('marks the root only after mount, then consumes while already foregrounded', async () => {
+    expect(nativeDiagnostics.markRootMounted).not.toHaveBeenCalled();
+    render(<LiveActivityIntentDiagnostics />);
+
+    await waitFor(() => expect(nativeDiagnostics.markRootMounted).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(nativeDiagnostics.consume).toHaveBeenCalledTimes(1));
+  });
+
+  it('marks a background-launched React root without consuming until foreground', async () => {
+    appState.setState('background');
+    render(<LiveActivityIntentDiagnostics />);
+
+    await waitFor(() => expect(nativeDiagnostics.markRootMounted).toHaveBeenCalledTimes(1));
+    expect(nativeDiagnostics.consume).not.toHaveBeenCalled();
+
+    appState.emit('active');
+    await waitFor(() => expect(nativeDiagnostics.consume).toHaveBeenCalledTimes(1));
+  });
+});

--- a/packages/mobile/src/lib/__tests__/sentry.test.ts
+++ b/packages/mobile/src/lib/__tests__/sentry.test.ts
@@ -10,6 +10,7 @@ vi.mock('@sentry/react-native', () => ({
   init: vi.fn(),
   withScope: vi.fn(),
   captureException: vi.fn(),
+  captureMessage: vi.fn(),
   flush: vi.fn(() => Promise.resolve(true)),
   wrap: vi.fn((component: unknown) => component),
   setTag: vi.fn(),
@@ -19,7 +20,9 @@ import * as Sentry from '@sentry/react-native';
 import {
   applyBleDiagnosticsToScope,
   applyErrorContextToScope,
+  applyLiveActivityIntentDiagnosticToScope,
   applyOtaTagsToScope,
+  captureLiveActivityIntentDiagnostic,
   captureToSentry,
   flushSentry,
   isExpoUiSheetNoHandlerRejection,
@@ -28,6 +31,7 @@ import {
   wrapWithSentry,
   isSentryEnabled,
   toSentryTag,
+  LIVE_ACTIVITY_INTENT_INTERRUPTED_FINGERPRINT,
 } from '../sentry';
 
 describe('isSentryEnabled', () => {
@@ -40,6 +44,49 @@ describe('captureToSentry (disabled build)', () => {
   it('is a no-op — never reaches the Sentry SDK', () => {
     captureToSentry(new Error('boom'), { level: 'error', tags: { source: 'react-query' } });
     expect(Sentry.withScope).not.toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+});
+
+describe('Live Activity intent diagnostic reporting', () => {
+  const diagnostic = {
+    schemaVersion: 1 as const,
+    runId: '30fe8dab-7c3f-4ed0-ae20-291a87390001',
+    processId: 'b5a82684-6a2c-4bbb-a9cc-b7bfc1df0001',
+    intentKind: 'nextClimb' as const,
+    appVersion: '2.0.0',
+    buildNumber: '481',
+    startedAtMs: 1_000,
+    updatedAtMs: 3_500,
+    lastStage: 'bleStarted' as const,
+    reactRootMounted: true,
+  };
+
+  it('maps to info level, a fixed fingerprint, fixed tags, and generated-id extras', () => {
+    const scope = {
+      setLevel: vi.fn(),
+      setFingerprint: vi.fn(),
+      setTag: vi.fn(),
+      setExtra: vi.fn(),
+    };
+
+    applyLiveActivityIntentDiagnosticToScope(scope, diagnostic);
+
+    expect(scope.setLevel).toHaveBeenCalledWith('info');
+    expect(scope.setFingerprint).toHaveBeenCalledWith([LIVE_ACTIVITY_INTENT_INTERRUPTED_FINGERPRINT]);
+    expect(scope.setTag).toHaveBeenCalledWith('source', 'live-activity-intent-diagnostics');
+    expect(scope.setTag).toHaveBeenCalledWith('intent_kind', 'nextClimb');
+    expect(scope.setTag).toHaveBeenCalledWith('last_stage', 'bleStarted');
+    expect(scope.setTag).toHaveBeenCalledWith('react_root_mounted', 'true');
+    expect(scope.setExtra).toHaveBeenCalledWith('run_id', diagnostic.runId);
+    expect(scope.setExtra).toHaveBeenCalledWith('process_id', diagnostic.processId);
+    expect(scope.setExtra).toHaveBeenCalledWith('elapsed_ms', 2_500);
+  });
+
+  it('is a no-op in disabled builds and never masquerades as an exception', () => {
+    captureLiveActivityIntentDiagnostic(diagnostic);
+    expect(Sentry.withScope).not.toHaveBeenCalled();
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
     expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/lib/__tests__/sentry.test.ts
+++ b/packages/mobile/src/lib/__tests__/sentry.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { ComponentType } from 'react';
+import type { InterruptedLiveActivityIntentDiagnostic } from '../../../modules/live-activity/src/index';
 
 // Spy on the SDK so we can assert the disabled-build contract. Under vitest
 // `__DEV__` is true (vite.config define) and no DSN is set, so `isSentryEnabled`
@@ -61,7 +62,7 @@ describe('Live Activity intent diagnostic reporting', () => {
     updatedAtMs: 3_500,
     lastStage: 'bleStarted' as const,
     reactRootMounted: true,
-  };
+  } satisfies InterruptedLiveActivityIntentDiagnostic;
 
   it('maps to info level, a fixed fingerprint, fixed tags, and generated-id extras', () => {
     const scope = {
@@ -79,6 +80,7 @@ describe('Live Activity intent diagnostic reporting', () => {
     expect(scope.setTag).toHaveBeenCalledWith('intent_kind', 'nextClimb');
     expect(scope.setTag).toHaveBeenCalledWith('last_stage', 'bleStarted');
     expect(scope.setTag).toHaveBeenCalledWith('react_root_mounted', 'true');
+    expect(scope.setTag).not.toHaveBeenCalledWith('completion_class', expect.anything());
     expect(scope.setExtra).toHaveBeenCalledWith('run_id', diagnostic.runId);
     expect(scope.setExtra).toHaveBeenCalledWith('process_id', diagnostic.processId);
     expect(scope.setExtra).toHaveBeenCalledWith('elapsed_ms', 2_500);

--- a/packages/mobile/src/lib/__tests__/sentry.test.ts
+++ b/packages/mobile/src/lib/__tests__/sentry.test.ts
@@ -21,6 +21,7 @@ import {
   applyBleDiagnosticsToScope,
   applyErrorContextToScope,
   applyLiveActivityIntentDiagnosticToScope,
+  captureEnabledLiveActivityIntentDiagnostic,
   applyOtaTagsToScope,
   captureLiveActivityIntentDiagnostic,
   captureToSentry,
@@ -87,6 +88,27 @@ describe('Live Activity intent diagnostic reporting', () => {
     captureLiveActivityIntentDiagnostic(diagnostic);
     expect(Sentry.withScope).not.toHaveBeenCalled();
     expect(Sentry.captureMessage).not.toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('captures an enabled diagnostic as an informational Sentry message', () => {
+    const scope = {
+      setLevel: vi.fn(),
+      setFingerprint: vi.fn(),
+      setTag: vi.fn(),
+      setExtra: vi.fn(),
+    };
+    vi.mocked(Sentry.withScope).mockImplementation((callback) => callback(scope as never));
+
+    captureEnabledLiveActivityIntentDiagnostic(diagnostic, Sentry.withScope, Sentry.captureMessage);
+
+    expect(Sentry.withScope).toHaveBeenCalledTimes(1);
+    expect(scope.setLevel).toHaveBeenCalledWith('info');
+    expect(scope.setFingerprint).toHaveBeenCalledWith([LIVE_ACTIVITY_INTENT_INTERRUPTED_FINGERPRINT]);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'Live Activity intent did not complete before its process ended',
+      'info',
+    );
     expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/lib/live-activity/__tests__/widget-target-drift.test.ts
+++ b/packages/mobile/src/lib/live-activity/__tests__/widget-target-drift.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
 
@@ -46,4 +46,69 @@ describe('Widget target Swift drift', () => {
       ).toBe(moduleHash);
     });
   }
+
+  it('keeps the durable recorder out of the production widget extension', () => {
+    const recorderName = 'LiveActivityIntentDiagnostics.swift';
+    const recorderSource = readFileSync(join(MODULE_IOS, recorderName), 'utf8');
+
+    // BOARDSESH_TESTS compiles the production store into the generated XCTest
+    // target only. The real widget target defines WIDGET_EXTENSION but never
+    // BOARDSESH_TESTS, so it excludes the entire file and has no copied source.
+    expect(recorderSource.trimStart().startsWith('#if !WIDGET_EXTENSION || BOARDSESH_TESTS')).toBe(true);
+    expect(existsSync(join(WIDGET_TARGET, recorderName))).toBe(false);
+  });
+
+  it('guards every shared-intent recorder call from widget compilation', () => {
+    const instrumentedFiles = ['ClimbNavigationIntent.swift', 'TakeControlIntent.swift', 'ReconnectBoardIntent.swift'];
+
+    for (const file of instrumentedFiles) {
+      const source = readFileSync(join(WIDGET_TARGET, file), 'utf8');
+      const conditionStack: boolean[] = [true];
+      const unguardedRecorderLines: string[] = [];
+
+      for (const line of source.split('\n')) {
+        const directive = line.trim();
+        if (directive === '#if !WIDGET_EXTENSION') {
+          conditionStack.push(false);
+          continue;
+        }
+        if (directive === '#else') {
+          const previous = conditionStack.pop();
+          conditionStack.push(!(previous ?? true));
+          continue;
+        }
+        if (directive === '#endif') {
+          conditionStack.pop();
+          continue;
+        }
+        if (conditionStack.every(Boolean) && /LiveActivityIntentDiagnostic|diagnosticRun|completionClass/.test(line)) {
+          unguardedRecorderLines.push(line.trim());
+        }
+      }
+
+      expect(unguardedRecorderLines, `${file} leaks recorder symbols into WIDGET_EXTENSION`).toEqual([]);
+    }
+  });
+
+  it('keeps a fixed diagnostic kind for every shared LiveActivityIntent', () => {
+    const recorderSource = readFileSync(join(MODULE_IOS, 'LiveActivityIntentDiagnostics.swift'), 'utf8');
+    const diagnosticKinds = [
+      ...recorderSource.matchAll(/^\s*case (nextClimb|previousClimb|takeControl|reconnectBoard)$/gm),
+    ]
+      .map((match) => match[1])
+      .sort();
+
+    const intentTypes = DUPLICATED_FILES.flatMap((file) => {
+      const source = readFileSync(join(MODULE_IOS, file), 'utf8');
+      return [...source.matchAll(/struct (\w+): LiveActivityIntent/g)].map((match) => match[1]);
+    }).sort();
+
+    expect(intentTypes).toEqual([
+      'NextClimbIntent',
+      'PreviousClimbIntent',
+      'ReconnectBoardIntent',
+      'TakeControlIntent',
+    ]);
+    expect(diagnosticKinds).toEqual(['nextClimb', 'previousClimb', 'reconnectBoard', 'takeControl']);
+  });
 });

--- a/packages/mobile/src/lib/live-activity/__tests__/widget-target-drift.test.ts
+++ b/packages/mobile/src/lib/live-activity/__tests__/widget-target-drift.test.ts
@@ -2,6 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
+import type {
+  InterruptedLiveActivityIntentDiagnostic,
+  LiveActivityIntentCompletionClass,
+  LiveActivityIntentDiagnosticKind,
+  LiveActivityIntentDiagnosticStage,
+} from '../../../../modules/live-activity/src/index';
 
 // Each Xcode target compiles its own binary, so the shared Swift files
 // (ActivityKit attributes, shared App Group keys, keychain helper, intent
@@ -37,37 +43,170 @@ function sha(path: string): string {
 
 const RECORDER_SYMBOL_PATTERN = /LiveActivityIntentDiagnostic|diagnosticRun|completionClass/;
 
+const PRODUCTION_WIDGET_COMPILATION_CONDITIONS = new Set(['WIDGET_EXTENSION']);
+
+const TYPESCRIPT_DIAGNOSTIC_KINDS = {
+  nextClimb: true,
+  previousClimb: true,
+  takeControl: true,
+  reconnectBoard: true,
+} as const satisfies Record<LiveActivityIntentDiagnosticKind, true>;
+
+const TYPESCRIPT_DIAGNOSTIC_STAGES = {
+  entered: true,
+  networkStarted: true,
+  networkFinishedSuccess: true,
+  networkFinishedRetryable: true,
+  networkFinishedTerminal: true,
+  activityKitUpdated: true,
+  bleStarted: true,
+  bleFinishedSuccess: true,
+  bleFinishedFailure: true,
+  darwinPosted: true,
+  completed: true,
+} as const satisfies Record<LiveActivityIntentDiagnosticStage, true>;
+
+const TYPESCRIPT_INTERRUPTED_DIAGNOSTIC_STAGES = {
+  entered: true,
+  networkStarted: true,
+  networkFinishedSuccess: true,
+  networkFinishedRetryable: true,
+  networkFinishedTerminal: true,
+  activityKitUpdated: true,
+  bleStarted: true,
+  bleFinishedSuccess: true,
+  bleFinishedFailure: true,
+  darwinPosted: true,
+} as const satisfies Record<InterruptedLiveActivityIntentDiagnostic['lastStage'], true>;
+
+const TYPESCRIPT_COMPLETION_CLASSES = {
+  success: true,
+  sharedDefaultsUnavailable: true,
+  navigationOutOfBounds: true,
+  serverRejected: true,
+  retryableNetworkFailure: true,
+  localNavigationEnabled: true,
+  alreadyAllowed: true,
+  bleFailure: true,
+} as const satisfies Record<LiveActivityIntentCompletionClass, true>;
+
+type SwiftConditionalBranch = {
+  parentIsVisible: boolean;
+  hasMatchedBranch: boolean;
+  isVisible: boolean;
+};
+
+function evaluateSwiftCompilationCondition(
+  condition: string,
+  definedConditions: ReadonlySet<string> = PRODUCTION_WIDGET_COMPILATION_CONDITIONS,
+): boolean {
+  const tokens = condition.match(/[A-Za-z_][A-Za-z0-9_]*|&&|\|\||!|\(|\)/g) ?? [];
+  let tokenPosition = 0;
+
+  function consume(expectedToken?: string): string | undefined {
+    const token = tokens[tokenPosition];
+    if (expectedToken && token !== expectedToken) {
+      throw new Error(
+        `Expected ${expectedToken} in Swift compilation condition ${condition}, received ${token ?? 'end'}`,
+      );
+    }
+    tokenPosition += 1;
+    return token;
+  }
+
+  function parsePrimary(): boolean {
+    if (tokens[tokenPosition] === '(') {
+      consume('(');
+      const nestedValue = parseOr();
+      consume(')');
+      return nestedValue;
+    }
+
+    const conditionName = consume();
+    if (!conditionName || !/^[A-Za-z_]/.test(conditionName)) {
+      throw new Error(`Expected a Swift compilation condition name in ${condition}`);
+    }
+    return definedConditions.has(conditionName);
+  }
+
+  function parseNot(): boolean {
+    if (tokens[tokenPosition] === '!') {
+      consume('!');
+      return !parseNot();
+    }
+    return parsePrimary();
+  }
+
+  function parseAnd(): boolean {
+    let result = parseNot();
+    while (tokens[tokenPosition] === '&&') {
+      consume('&&');
+      const rightOperand = parseNot();
+      result = result && rightOperand;
+    }
+    return result;
+  }
+
+  function parseOr(): boolean {
+    let result = parseAnd();
+    while (tokens[tokenPosition] === '||') {
+      consume('||');
+      const rightOperand = parseAnd();
+      result = result || rightOperand;
+    }
+    return result;
+  }
+
+  const result = parseOr();
+  if (tokenPosition !== tokens.length) {
+    throw new Error(`Unexpected Swift compilation condition token ${tokens[tokenPosition]} in ${condition}`);
+  }
+  return result;
+}
+
 function widgetVisibleRecorderLines(source: string): string[] {
-  // Each entry says whether that conditional branch is provably excluded when
-  // WIDGET_EXTENSION is defined. Looking for `some(true)` keeps an outer guard
-  // effective through nested #if/#else blocks; #elseif starts a distinct branch
-  // instead of corrupting the parent stack.
-  const widgetExcludedBranches: boolean[] = [];
+  // Model the production widget's compilation conditions: WIDGET_EXTENSION is
+  // defined, BOARDSESH_TESTS is not. Each branch tracks visibility inherited
+  // from its parent plus whether an earlier sibling branch already matched.
+  // That preserves nested #if/#elseif/#else semantics instead of treating a
+  // test-only #elseif as visible in the shipped widget extension.
+  const conditionalBranches: SwiftConditionalBranch[] = [];
   const visibleRecorderLines: string[] = [];
 
   for (const line of source.split('\n')) {
     const directive = line.trim();
     if (directive.startsWith('#if ')) {
-      widgetExcludedBranches.push(directive === '#if !WIDGET_EXTENSION');
+      const conditionResult = evaluateSwiftCompilationCondition(directive.slice('#if '.length));
+      const parentIsVisible = conditionalBranches.every((branch) => branch.isVisible);
+      conditionalBranches.push({
+        parentIsVisible,
+        hasMatchedBranch: conditionResult,
+        isVisible: parentIsVisible && conditionResult,
+      });
       continue;
     }
     if (directive.startsWith('#elseif ')) {
-      if (widgetExcludedBranches.length > 0) {
-        widgetExcludedBranches[widgetExcludedBranches.length - 1] = directive === '#elseif !WIDGET_EXTENSION';
+      const currentBranch = conditionalBranches.at(-1);
+      if (currentBranch) {
+        const conditionResult = evaluateSwiftCompilationCondition(directive.slice('#elseif '.length));
+        currentBranch.isVisible = currentBranch.parentIsVisible && !currentBranch.hasMatchedBranch && conditionResult;
+        currentBranch.hasMatchedBranch ||= conditionResult;
       }
       continue;
     }
     if (directive === '#else') {
-      if (widgetExcludedBranches.length > 0) {
-        widgetExcludedBranches[widgetExcludedBranches.length - 1] = false;
+      const currentBranch = conditionalBranches.at(-1);
+      if (currentBranch) {
+        currentBranch.isVisible = currentBranch.parentIsVisible && !currentBranch.hasMatchedBranch;
+        currentBranch.hasMatchedBranch = true;
       }
       continue;
     }
     if (directive === '#endif') {
-      widgetExcludedBranches.pop();
+      conditionalBranches.pop();
       continue;
     }
-    if (!widgetExcludedBranches.includes(true) && RECORDER_SYMBOL_PATTERN.test(line)) {
+    if (conditionalBranches.every((branch) => branch.isVisible) && RECORDER_SYMBOL_PATTERN.test(line)) {
       visibleRecorderLines.push(line.trim());
     }
   }
@@ -107,29 +246,45 @@ describe('Widget target Swift drift', () => {
     }
   });
 
-  it('keeps an outer widget guard through nested branches and handles #elseif separately', () => {
+  it('models production widget #if, #elseif, and #else branches through nested guards', () => {
     const syntheticSource = `
 #if !WIDGET_EXTENSION
   #if DEBUG
     diagnosticRun.mark(.networkStarted)
-  #else
+  #elseif BOARDSESH_TESTS
     completionClass = .serverRejected
+  #else
+    diagnosticRun.mark(.networkFinishedSuccess)
   #endif
 #elseif BOARDSESH_TESTS
   let diagnosticRun = testRecorder
+#else
+  #if DEBUG
+    completionClass = .localNavigationEnabled
+  #elseif !BOARDSESH_TESTS
+    let diagnosticRun = productionWidgetRecorder
+  #else
+    diagnosticRun.mark(.completed)
+  #endif
 #endif
 `;
 
-    expect(widgetVisibleRecorderLines(syntheticSource)).toEqual(['let diagnosticRun = testRecorder']);
+    expect(widgetVisibleRecorderLines(syntheticSource)).toEqual(['let diagnosticRun = productionWidgetRecorder']);
   });
 
-  it('keeps a fixed diagnostic kind for every shared LiveActivityIntent', () => {
+  it('keeps the TypeScript diagnostic contracts aligned with every Swift CaseIterable enum', () => {
     const recorderSource = readFileSync(join(MODULE_IOS, 'LiveActivityIntentDiagnostics.swift'), 'utf8');
-    const diagnosticKinds = [
-      ...recorderSource.matchAll(/^\s*case (nextClimb|previousClimb|takeControl|reconnectBoard)$/gm),
-    ]
-      .map((match) => match[1])
-      .sort();
+    const swiftCaseIterableMembers = (enumName: string): string[] => {
+      const enumPattern = new RegExp(`enum ${enumName}: String, Codable, CaseIterable \\{([\\s\\S]*?)\\n\\}`, 'm');
+      const enumMatch = recorderSource.match(enumPattern);
+      if (!enumMatch) throw new Error(`Could not find ${enumName} CaseIterable enum`);
+      return [...enumMatch[1].matchAll(/^\s*case (\w+)$/gm)].map((match) => match[1]).sort();
+    };
+
+    const diagnosticKinds = swiftCaseIterableMembers('LiveActivityIntentDiagnosticKind');
+    const diagnosticStages = swiftCaseIterableMembers('LiveActivityIntentDiagnosticStage');
+    const interruptedDiagnosticStages = swiftCaseIterableMembers('LiveActivityInterruptedIntentDiagnosticStage');
+    const completionClasses = swiftCaseIterableMembers('LiveActivityIntentCompletionClass');
 
     const intentTypes = DUPLICATED_FILES.flatMap((file) => {
       const source = readFileSync(join(MODULE_IOS, file), 'utf8');
@@ -142,6 +297,34 @@ describe('Widget target Swift drift', () => {
       'ReconnectBoardIntent',
       'TakeControlIntent',
     ]);
-    expect(diagnosticKinds).toEqual(['nextClimb', 'previousClimb', 'reconnectBoard', 'takeControl']);
+    expect(diagnosticKinds).toEqual(Object.keys(TYPESCRIPT_DIAGNOSTIC_KINDS).sort());
+    expect(diagnosticStages).toEqual(Object.keys(TYPESCRIPT_DIAGNOSTIC_STAGES).sort());
+    expect(interruptedDiagnosticStages).toEqual(Object.keys(TYPESCRIPT_INTERRUPTED_DIAGNOSTIC_STAGES).sort());
+    expect(interruptedDiagnosticStages).toEqual(diagnosticStages.filter((stage) => stage !== 'completed'));
+    expect(completionClasses).toEqual(Object.keys(TYPESCRIPT_COMPLETION_CLASSES).sort());
+  });
+
+  it('pins the main-app BLE budget, background-task lifetime, and Darwin ordering', () => {
+    const managerSource = readFileSync(join(MODULE_IOS, 'BoardBleManager.swift'), 'utf8');
+    const bridgeSource = readFileSync(join(MODULE_IOS, 'LiveActivityBleBridge.swift'), 'utf8');
+    const navigationSource = readFileSync(join(MODULE_IOS, 'ClimbNavigationIntent.swift'), 'utf8');
+
+    expect(managerSource).toMatch(/drainTimeout: TimeInterval = 1\.5/);
+    expect(managerSource).toContain('return drainedBeforeTimeout && displayOutcome.succeeded == true');
+    expect(bridgeSource).toContain('readyTimeout: 3.0');
+
+    const backgroundTaskBegin = bridgeSource.indexOf('task.begin(name: "ble-display-intent")');
+    const backgroundTaskDefer = bridgeSource.indexOf('defer { task.end() }', backgroundTaskBegin);
+    const managerAwait = bridgeSource.indexOf('return await BoardBleManager.shared', backgroundTaskDefer);
+    expect(backgroundTaskBegin).toBeGreaterThanOrEqual(0);
+    expect(backgroundTaskDefer).toBeGreaterThan(backgroundTaskBegin);
+    expect(managerAwait).toBeGreaterThan(backgroundTaskDefer);
+
+    const bleAwait = navigationSource.indexOf('let writeSucceeded = await bleWriteTask.value');
+    const bleDiagnostic = navigationSource.indexOf('diagnosticRun.mark(writeSucceeded ?', bleAwait);
+    const darwinPost = navigationSource.indexOf('postQueueNavigateDarwinNotification()', bleDiagnostic);
+    expect(bleAwait).toBeGreaterThanOrEqual(0);
+    expect(bleDiagnostic).toBeGreaterThan(bleAwait);
+    expect(darwinPost).toBeGreaterThan(bleDiagnostic);
   });
 });

--- a/packages/mobile/src/lib/live-activity/__tests__/widget-target-drift.test.ts
+++ b/packages/mobile/src/lib/live-activity/__tests__/widget-target-drift.test.ts
@@ -35,6 +35,46 @@ function sha(path: string): string {
   return createHash('sha256').update(readFileSync(path)).digest('hex');
 }
 
+const RECORDER_SYMBOL_PATTERN = /LiveActivityIntentDiagnostic|diagnosticRun|completionClass/;
+
+function widgetVisibleRecorderLines(source: string): string[] {
+  // Each entry says whether that conditional branch is provably excluded when
+  // WIDGET_EXTENSION is defined. Looking for `some(true)` keeps an outer guard
+  // effective through nested #if/#else blocks; #elseif starts a distinct branch
+  // instead of corrupting the parent stack.
+  const widgetExcludedBranches: boolean[] = [];
+  const visibleRecorderLines: string[] = [];
+
+  for (const line of source.split('\n')) {
+    const directive = line.trim();
+    if (directive.startsWith('#if ')) {
+      widgetExcludedBranches.push(directive === '#if !WIDGET_EXTENSION');
+      continue;
+    }
+    if (directive.startsWith('#elseif ')) {
+      if (widgetExcludedBranches.length > 0) {
+        widgetExcludedBranches[widgetExcludedBranches.length - 1] = directive === '#elseif !WIDGET_EXTENSION';
+      }
+      continue;
+    }
+    if (directive === '#else') {
+      if (widgetExcludedBranches.length > 0) {
+        widgetExcludedBranches[widgetExcludedBranches.length - 1] = false;
+      }
+      continue;
+    }
+    if (directive === '#endif') {
+      widgetExcludedBranches.pop();
+      continue;
+    }
+    if (!widgetExcludedBranches.includes(true) && RECORDER_SYMBOL_PATTERN.test(line)) {
+      visibleRecorderLines.push(line.trim());
+    }
+  }
+
+  return visibleRecorderLines;
+}
+
 describe('Widget target Swift drift', () => {
   for (const file of DUPLICATED_FILES) {
     it(`${file} stays byte-identical between module and widget target`, () => {
@@ -63,31 +103,24 @@ describe('Widget target Swift drift', () => {
 
     for (const file of instrumentedFiles) {
       const source = readFileSync(join(WIDGET_TARGET, file), 'utf8');
-      const conditionStack: boolean[] = [true];
-      const unguardedRecorderLines: string[] = [];
-
-      for (const line of source.split('\n')) {
-        const directive = line.trim();
-        if (directive === '#if !WIDGET_EXTENSION') {
-          conditionStack.push(false);
-          continue;
-        }
-        if (directive === '#else') {
-          const previous = conditionStack.pop();
-          conditionStack.push(!(previous ?? true));
-          continue;
-        }
-        if (directive === '#endif') {
-          conditionStack.pop();
-          continue;
-        }
-        if (conditionStack.every(Boolean) && /LiveActivityIntentDiagnostic|diagnosticRun|completionClass/.test(line)) {
-          unguardedRecorderLines.push(line.trim());
-        }
-      }
-
-      expect(unguardedRecorderLines, `${file} leaks recorder symbols into WIDGET_EXTENSION`).toEqual([]);
+      expect(widgetVisibleRecorderLines(source), `${file} leaks recorder symbols into WIDGET_EXTENSION`).toEqual([]);
     }
+  });
+
+  it('keeps an outer widget guard through nested branches and handles #elseif separately', () => {
+    const syntheticSource = `
+#if !WIDGET_EXTENSION
+  #if DEBUG
+    diagnosticRun.mark(.networkStarted)
+  #else
+    completionClass = .serverRejected
+  #endif
+#elseif BOARDSESH_TESTS
+  let diagnosticRun = testRecorder
+#endif
+`;
+
+    expect(widgetVisibleRecorderLines(syntheticSource)).toEqual(['let diagnosticRun = testRecorder']);
   });
 
   it('keeps a fixed diagnostic kind for every shared LiveActivityIntent', () => {

--- a/packages/mobile/src/lib/live-activity/live-activity-plugin.ts
+++ b/packages/mobile/src/lib/live-activity/live-activity-plugin.ts
@@ -7,6 +7,7 @@ import {
   type LiveActivityClimbUpdateOptions,
   type WidgetQueueNavigateEvent,
   type BoardControlEvent,
+  type LiveActivityIntentDiagnostic,
 } from '../../../modules/live-activity/src/index';
 
 // Platform-agnostic wrapper around the "session presence" native surface:
@@ -55,6 +56,32 @@ export async function updateLiveActivityClimb(options: LiveActivityClimbUpdateOp
   await sessionModule.updateActivityClimb(options);
 }
 
+/**
+ * Explicitly marks that the actual React root committed in this process. This
+ * is iOS-only and optional so an OTA bundle stays safe on an older binary.
+ * Diagnostics must never affect app startup, so native bridge failures no-op.
+ */
+export async function markLiveActivityIntentReactRootMounted(): Promise<void> {
+  try {
+    await liveActivityNative?.markIntentReactRootMounted?.();
+  } catch {
+    // Best-effort diagnostic marker only.
+  }
+}
+
+/**
+ * Atomically consumes eligible previous-process intent markers on iOS. Native
+ * owns schema/build/TTL/grace validation and once-only dedupe; JS only reports
+ * the already-sanitized records.
+ */
+export async function consumeInterruptedLiveActivityIntentRuns(): Promise<LiveActivityIntentDiagnostic[]> {
+  try {
+    return (await liveActivityNative?.consumeInterruptedIntentRuns?.()) ?? [];
+  } catch {
+    return [];
+  }
+}
+
 export function addWidgetQueueNavigateListener(callback: (event: WidgetQueueNavigateEvent) => void): () => void {
   if (!sessionModule) {
     return () => {};
@@ -76,4 +103,4 @@ export function addBoardControlListener(callback: (event: BoardControlEvent) => 
   return () => subscription.remove();
 }
 
-export type { WidgetQueueNavigateEvent, BoardControlEvent };
+export type { WidgetQueueNavigateEvent, BoardControlEvent, LiveActivityIntentDiagnostic };

--- a/packages/mobile/src/lib/live-activity/live-activity-plugin.ts
+++ b/packages/mobile/src/lib/live-activity/live-activity-plugin.ts
@@ -7,7 +7,7 @@ import {
   type LiveActivityClimbUpdateOptions,
   type WidgetQueueNavigateEvent,
   type BoardControlEvent,
-  type LiveActivityIntentDiagnostic,
+  type InterruptedLiveActivityIntentDiagnostic,
 } from '../../../modules/live-activity/src/index';
 
 // Platform-agnostic wrapper around the "session presence" native surface:
@@ -74,7 +74,7 @@ export async function markLiveActivityIntentReactRootMounted(): Promise<void> {
  * owns schema/build/TTL/grace validation and once-only dedupe; JS only reports
  * the already-sanitized records.
  */
-export async function consumeInterruptedLiveActivityIntentRuns(): Promise<LiveActivityIntentDiagnostic[]> {
+export async function consumeInterruptedLiveActivityIntentRuns(): Promise<InterruptedLiveActivityIntentDiagnostic[]> {
   try {
     return (await liveActivityNative?.consumeInterruptedIntentRuns?.()) ?? [];
   } catch {
@@ -103,4 +103,4 @@ export function addBoardControlListener(callback: (event: BoardControlEvent) => 
   return () => subscription.remove();
 }
 
-export type { WidgetQueueNavigateEvent, BoardControlEvent, LiveActivityIntentDiagnostic };
+export type { WidgetQueueNavigateEvent, BoardControlEvent, InterruptedLiveActivityIntentDiagnostic };

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -197,16 +197,33 @@ export function applyLiveActivityIntentDiagnosticToScope(
   scope.setExtra('elapsed_ms', Math.max(0, diagnostic.updatedAtMs - diagnostic.startedAtMs));
 }
 
+type LiveActivityIntentDiagnosticWithScope = (callback: (scope: LiveActivityIntentDiagnosticScope) => void) => void;
+
+type LiveActivityIntentDiagnosticCaptureMessage = (message: string, level: 'info') => void;
+
+/**
+ * Sends an intent diagnostic through an already-enabled Sentry context.
+ * Kept separate from the production enablement gate so the actual SDK emission
+ * contract remains directly testable in Vitest, where __DEV__ is inlined true.
+ */
+export function captureEnabledLiveActivityIntentDiagnostic(
+  diagnostic: LiveActivityIntentDiagnostic,
+  withScope: LiveActivityIntentDiagnosticWithScope,
+  captureMessage: LiveActivityIntentDiagnosticCaptureMessage,
+): void {
+  withScope((scope) => {
+    applyLiveActivityIntentDiagnosticToScope(scope, diagnostic);
+    captureMessage('Live Activity intent did not complete before its process ended', 'info');
+  });
+}
+
 /**
  * Reports an interrupted native intent as an informational message. It is not
  * an exception or crash and therefore cannot inflate crash-free statistics.
  */
 export function captureLiveActivityIntentDiagnostic(diagnostic: LiveActivityIntentDiagnostic): void {
   if (!isSentryEnabled) return;
-  Sentry.withScope((scope) => {
-    applyLiveActivityIntentDiagnosticToScope(scope, diagnostic);
-    Sentry.captureMessage('Live Activity intent did not complete before its process ended', 'info');
-  });
+  captureEnabledLiveActivityIntentDiagnostic(diagnostic, Sentry.withScope, Sentry.captureMessage);
 }
 
 // The global-scope tag keys written on connect, cleared together on disconnect

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -2,6 +2,7 @@ import type { ComponentType } from 'react';
 import * as Sentry from '@sentry/react-native';
 import { installGlobalErrorCapture } from './global-error-capture';
 import { resolveAppEnvironment } from './app-environment';
+import type { LiveActivityIntentDiagnostic } from './live-activity/live-activity-plugin';
 
 /**
  * Triage context attached to a reported error. Defined here (not in
@@ -154,6 +155,57 @@ export function captureToSentry(error: unknown, context?: ErrorReportContext): v
   Sentry.withScope((scope) => {
     applyErrorContextToScope(scope, context);
     Sentry.captureException(error);
+  });
+}
+
+export const LIVE_ACTIVITY_INTENT_INTERRUPTED_FINGERPRINT = 'live-activity-intent-interrupted';
+
+type LiveActivityIntentDiagnosticScope = {
+  setLevel: (level: 'info') => void;
+  setFingerprint: (fingerprint: string[]) => void;
+  setTag: (key: string, value: string | number | boolean) => void;
+  setExtra: (key: string, value: unknown) => void;
+};
+
+/**
+ * Applies the fixed grouping and bounded, native-sanitized context for one
+ * previous-process Live Activity intent marker. Extracted so CI can prove the
+ * informational-message contract even though Sentry is disabled in tests.
+ */
+export function applyLiveActivityIntentDiagnosticToScope(
+  scope: LiveActivityIntentDiagnosticScope,
+  diagnostic: LiveActivityIntentDiagnostic,
+): void {
+  scope.setLevel('info');
+  scope.setFingerprint([LIVE_ACTIVITY_INTENT_INTERRUPTED_FINGERPRINT]);
+  scope.setTag('source', 'live-activity-intent-diagnostics');
+  scope.setTag('intent_kind', diagnostic.intentKind);
+  scope.setTag('last_stage', diagnostic.lastStage);
+  scope.setTag('react_root_mounted', String(diagnostic.reactRootMounted));
+  scope.setTag('intent_schema_version', diagnostic.schemaVersion);
+  scope.setTag('app_version', diagnostic.appVersion);
+  scope.setTag('build_number', diagnostic.buildNumber);
+  if (diagnostic.completionClass) {
+    scope.setTag('completion_class', diagnostic.completionClass);
+  }
+  // Random recorder IDs are extras rather than high-cardinality indexed tags.
+  // They identify only this diagnostic run/process, never a user or session.
+  scope.setExtra('run_id', diagnostic.runId);
+  scope.setExtra('process_id', diagnostic.processId);
+  scope.setExtra('started_at_ms', diagnostic.startedAtMs);
+  scope.setExtra('updated_at_ms', diagnostic.updatedAtMs);
+  scope.setExtra('elapsed_ms', Math.max(0, diagnostic.updatedAtMs - diagnostic.startedAtMs));
+}
+
+/**
+ * Reports an interrupted native intent as an informational message. It is not
+ * an exception or crash and therefore cannot inflate crash-free statistics.
+ */
+export function captureLiveActivityIntentDiagnostic(diagnostic: LiveActivityIntentDiagnostic): void {
+  if (!isSentryEnabled) return;
+  Sentry.withScope((scope) => {
+    applyLiveActivityIntentDiagnosticToScope(scope, diagnostic);
+    Sentry.captureMessage('Live Activity intent did not complete before its process ended', 'info');
   });
 }
 

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -2,7 +2,7 @@ import type { ComponentType } from 'react';
 import * as Sentry from '@sentry/react-native';
 import { installGlobalErrorCapture } from './global-error-capture';
 import { resolveAppEnvironment } from './app-environment';
-import type { LiveActivityIntentDiagnostic } from './live-activity/live-activity-plugin';
+import type { InterruptedLiveActivityIntentDiagnostic } from './live-activity/live-activity-plugin';
 
 /**
  * Triage context attached to a reported error. Defined here (not in
@@ -174,7 +174,7 @@ type LiveActivityIntentDiagnosticScope = {
  */
 export function applyLiveActivityIntentDiagnosticToScope(
   scope: LiveActivityIntentDiagnosticScope,
-  diagnostic: LiveActivityIntentDiagnostic,
+  diagnostic: InterruptedLiveActivityIntentDiagnostic,
 ): void {
   scope.setLevel('info');
   scope.setFingerprint([LIVE_ACTIVITY_INTENT_INTERRUPTED_FINGERPRINT]);
@@ -185,9 +185,6 @@ export function applyLiveActivityIntentDiagnosticToScope(
   scope.setTag('intent_schema_version', diagnostic.schemaVersion);
   scope.setTag('app_version', diagnostic.appVersion);
   scope.setTag('build_number', diagnostic.buildNumber);
-  if (diagnostic.completionClass) {
-    scope.setTag('completion_class', diagnostic.completionClass);
-  }
   // Random recorder IDs are extras rather than high-cardinality indexed tags.
   // They identify only this diagnostic run/process, never a user or session.
   scope.setExtra('run_id', diagnostic.runId);
@@ -207,7 +204,7 @@ type LiveActivityIntentDiagnosticCaptureMessage = (message: string, level: 'info
  * contract remains directly testable in Vitest, where __DEV__ is inlined true.
  */
 export function captureEnabledLiveActivityIntentDiagnostic(
-  diagnostic: LiveActivityIntentDiagnostic,
+  diagnostic: InterruptedLiveActivityIntentDiagnostic,
   withScope: LiveActivityIntentDiagnosticWithScope,
   captureMessage: LiveActivityIntentDiagnosticCaptureMessage,
 ): void {
@@ -221,7 +218,7 @@ export function captureEnabledLiveActivityIntentDiagnostic(
  * Reports an interrupted native intent as an informational message. It is not
  * an exception or crash and therefore cannot inflate crash-free statistics.
  */
-export function captureLiveActivityIntentDiagnostic(diagnostic: LiveActivityIntentDiagnostic): void {
+export function captureLiveActivityIntentDiagnostic(diagnostic: InterruptedLiveActivityIntentDiagnostic): void {
   if (!isSentryEnabled) return;
   captureEnabledLiveActivityIntentDiagnostic(diagnostic, Sentry.withScope, Sentry.captureMessage);
 }

--- a/packages/mobile/targets/BoardseshWidgets/ClimbNavigationIntent.swift
+++ b/packages/mobile/targets/BoardseshWidgets/ClimbNavigationIntent.swift
@@ -37,12 +37,24 @@ enum ClimbNavigationIntent {
     static let httpSuccessCorrelationId = "widget-navigate"
 
     static func perform(direction: ClimbNavigationDirection, label: String) async {
+        #if !WIDGET_EXTENSION
+        let diagnosticKind: LiveActivityIntentDiagnosticKind = direction == .next ? .nextClimb : .previousClimb
+        let diagnosticRun = LiveActivityIntentDiagnostics.begin(kind: diagnosticKind)
+        var completionClass = LiveActivityIntentCompletionClass.success
+        defer { diagnosticRun.complete(completionClass) }
+        #endif
+
         // One notice per intent firing — production TestFlight builds need
         // this signal to diagnose "widget UI moved but wall didn't" reports.
         // Volume is bounded by user taps so the log isn't noisy.
         logger.notice("\(label).perform() running bundle=\(Bundle.main.bundleIdentifier ?? "unknown", privacy: .public) process=\(ProcessInfo.processInfo.processName, privacy: .public) direction=\(direction.rawValue, privacy: .public)")
 
-        guard let defaults = SharedConstants.sharedDefaults else { return }
+        guard let defaults = SharedConstants.sharedDefaults else {
+            #if !WIDGET_EXTENSION
+            completionClass = .sharedDefaultsUnavailable
+            #endif
+            return
+        }
         // No navigationAllowed gate: the widget only shows Prev/Next when this
         // device holds the board (connectedByMe — see SessionFooter), so reaching
         // here means we may drive. Gating visibility rather than the intent fixes
@@ -53,17 +65,37 @@ enum ClimbNavigationIntent {
 
         let (items, currentIndex) = SharedQueueState.load(from: defaults)
         guard let newIndex = direction.newIndex(from: currentIndex, count: items.count) else {
+            #if !WIDGET_EXTENSION
+            completionClass = .navigationOutOfBounds
+            #endif
             return
         }
 
         let navigationResult: WidgetNavigationResult
         if wallControl.requiresServerAuthorization {
+            #if !WIDGET_EXTENSION
+            diagnosticRun.mark(.networkStarted)
+            #endif
             navigationResult = await WidgetNetworking.sendNavigation(action: direction.rawValue, currentIndex: newIndex)
+            #if !WIDGET_EXTENSION
+            switch navigationResult {
+            case .success:
+                diagnosticRun.mark(.networkFinishedSuccess)
+            case .serverRejected:
+                diagnosticRun.mark(.networkFinishedTerminal)
+            case .retryableFailure:
+                diagnosticRun.mark(.networkFinishedRetryable)
+                completionClass = .retryableNetworkFailure
+            }
+            #endif
         } else {
             navigationResult = .success
         }
 
         guard navigationResult != .serverRejected else {
+            #if !WIDGET_EXTENSION
+            completionClass = .serverRejected
+            #endif
             logger.notice("\(label).perform() rejected by server; skipping local widget, BLE, and JS fallback updates")
             return
         }
@@ -91,13 +123,17 @@ enum ClimbNavigationIntent {
             let content = ActivityContent(state: newState, staleDate: Date().addingTimeInterval(SharedConstants.liveActivityStaleInterval))
             await activity.update(content)
         }
+        #if !WIDGET_EXTENSION
+        diagnosticRun.mark(.activityKitUpdated)
+        #endif
 
         // Direct BLE writes happen only after the server accepts party-session
         // navigation, or for local-only sessions. Retryable HTTP failures use
         // the Darwin/WebSocket fallback, whose mutation path owns repainting.
         #if !WIDGET_EXTENSION
-        let bleWriteTask: Task<Void, Never>?
+        let bleWriteTask: Task<Bool, Never>?
         if navigationResult == .success {
+            diagnosticRun.mark(.bleStarted)
             bleWriteTask = Task {
                 await LiveActivityBleBridge.writeBoardForIntent(items: items, currentIndex: newIndex)
             }
@@ -136,11 +172,18 @@ enum ClimbNavigationIntent {
         // re-send is a fast no-op against the wall's last-frame buffer.
         #if !WIDGET_EXTENSION
         if let bleWriteTask {
-            await bleWriteTask.value
+            let writeWasReady = await bleWriteTask.value
+            diagnosticRun.mark(writeWasReady ? .bleFinishedSuccess : .bleFinishedFailure)
+            if !writeWasReady {
+                completionClass = .bleFailure
+            }
         }
         #endif
 
         postQueueNavigateDarwinNotification()
+        #if !WIDGET_EXTENSION
+        diagnosticRun.mark(.darwinPosted)
+        #endif
     }
 
     private static func postQueueNavigateDarwinNotification() {

--- a/packages/mobile/targets/BoardseshWidgets/ClimbNavigationIntent.swift
+++ b/packages/mobile/targets/BoardseshWidgets/ClimbNavigationIntent.swift
@@ -172,9 +172,9 @@ enum ClimbNavigationIntent {
         // re-send is a fast no-op against the wall's last-frame buffer.
         #if !WIDGET_EXTENSION
         if let bleWriteTask {
-            let writeWasReady = await bleWriteTask.value
-            diagnosticRun.mark(writeWasReady ? .bleFinishedSuccess : .bleFinishedFailure)
-            if !writeWasReady {
+            let writeSucceeded = await bleWriteTask.value
+            diagnosticRun.mark(writeSucceeded ? .bleFinishedSuccess : .bleFinishedFailure)
+            if !writeSucceeded {
                 completionClass = .bleFailure
             }
         }

--- a/packages/mobile/targets/BoardseshWidgets/ReconnectBoardIntent.swift
+++ b/packages/mobile/targets/BoardseshWidgets/ReconnectBoardIntent.swift
@@ -17,6 +17,25 @@ struct ReconnectBoardIntent: LiveActivityIntent {
 
     private static let logger = Logger(subsystem: "com.boardsesh.app", category: "LiveActivityIntent")
 
+    #if !WIDGET_EXTENSION || BOARDSESH_TESTS
+    /// A later take-control failure must not hide an earlier BLE reconnect
+    /// failure: the first failed prerequisite is the most useful diagnostic.
+    static func diagnosticCompletionClass(
+        current: LiveActivityIntentCompletionClass,
+        networkResult: WidgetNavigationResult
+    ) -> LiveActivityIntentCompletionClass {
+        guard current == .success else { return current }
+        switch networkResult {
+        case .success:
+            return .success
+        case .serverRejected:
+            return .serverRejected
+        case .retryableFailure:
+            return .retryableNetworkFailure
+        }
+    }
+    #endif
+
     func perform() async throws -> some IntentResult {
         #if !WIDGET_EXTENSION
         let diagnosticRun = LiveActivityIntentDiagnostics.begin(kind: .reconnectBoard)
@@ -58,11 +77,10 @@ struct ReconnectBoardIntent: LiveActivityIntent {
                     diagnosticRun.mark(.networkFinishedSuccess)
                 case .serverRejected:
                     diagnosticRun.mark(.networkFinishedTerminal)
-                    completionClass = .serverRejected
                 case .retryableFailure:
                     diagnosticRun.mark(.networkFinishedRetryable)
-                    completionClass = .retryableNetworkFailure
                 }
+                completionClass = Self.diagnosticCompletionClass(current: completionClass, networkResult: result)
                 #endif
                 if result == .success {
                     SharedWidgetWallControlState.save(navigationAllowed: true, isPartySession: true, to: defaults)

--- a/packages/mobile/targets/BoardseshWidgets/ReconnectBoardIntent.swift
+++ b/packages/mobile/targets/BoardseshWidgets/ReconnectBoardIntent.swift
@@ -18,6 +18,12 @@ struct ReconnectBoardIntent: LiveActivityIntent {
     private static let logger = Logger(subsystem: "com.boardsesh.app", category: "LiveActivityIntent")
 
     func perform() async throws -> some IntentResult {
+        #if !WIDGET_EXTENSION
+        let diagnosticRun = LiveActivityIntentDiagnostics.begin(kind: .reconnectBoard)
+        var completionClass = LiveActivityIntentCompletionClass.success
+        defer { diagnosticRun.complete(completionClass) }
+        #endif
+
         Self.logger.notice("ReconnectBoardIntent.perform() running process=\(ProcessInfo.processInfo.processName, privacy: .public)")
 
         // Reconnect BLE to the last board. In the main app process (the path iOS
@@ -26,7 +32,12 @@ struct ReconnectBoardIntent: LiveActivityIntent {
         // can't link BoardBleManager — fall back to a Darwin notification so the
         // live main app does the reconnect, mirroring ClimbNavigationIntent.
         #if !WIDGET_EXTENSION
-        _ = await LiveActivityBleBridge.reconnectForIntent()
+        diagnosticRun.mark(.bleStarted)
+        let reconnected = await LiveActivityBleBridge.reconnectForIntent()
+        diagnosticRun.mark(reconnected ? .bleFinishedSuccess : .bleFinishedFailure)
+        if !reconnected {
+            completionClass = .bleFailure
+        }
         #else
         postBleReconnectDarwinNotification()
         #endif
@@ -37,7 +48,22 @@ struct ReconnectBoardIntent: LiveActivityIntent {
         if let defaults = SharedConstants.sharedDefaults {
             let wallControl = SharedWidgetWallControlState.load(from: defaults)
             if wallControl.requiresServerAuthorization, !wallControl.navigationAllowed {
+                #if !WIDGET_EXTENSION
+                diagnosticRun.mark(.networkStarted)
+                #endif
                 let result = await WidgetNetworking.sendTakeControl()
+                #if !WIDGET_EXTENSION
+                switch result {
+                case .success:
+                    diagnosticRun.mark(.networkFinishedSuccess)
+                case .serverRejected:
+                    diagnosticRun.mark(.networkFinishedTerminal)
+                    completionClass = .serverRejected
+                case .retryableFailure:
+                    diagnosticRun.mark(.networkFinishedRetryable)
+                    completionClass = .retryableNetworkFailure
+                }
+                #endif
                 if result == .success {
                     SharedWidgetWallControlState.save(navigationAllowed: true, isPartySession: true, to: defaults)
                 }
@@ -45,6 +71,9 @@ struct ReconnectBoardIntent: LiveActivityIntent {
         }
 
         await refreshActivities()
+        #if !WIDGET_EXTENSION
+        diagnosticRun.mark(.activityKitUpdated)
+        #endif
         return .result()
     }
 

--- a/packages/mobile/targets/BoardseshWidgets/TakeControlIntent.swift
+++ b/packages/mobile/targets/BoardseshWidgets/TakeControlIntent.swift
@@ -10,22 +10,56 @@ struct TakeControlIntent: LiveActivityIntent {
     private static let logger = Logger(subsystem: "com.boardsesh.app", category: "LiveActivityIntent")
 
     func perform() async throws -> some IntentResult {
-        guard let defaults = SharedConstants.sharedDefaults else { return .result() }
+        #if !WIDGET_EXTENSION
+        let diagnosticRun = LiveActivityIntentDiagnostics.begin(kind: .takeControl)
+        var completionClass = LiveActivityIntentCompletionClass.success
+        defer { diagnosticRun.complete(completionClass) }
+        #endif
+
+        guard let defaults = SharedConstants.sharedDefaults else {
+            #if !WIDGET_EXTENSION
+            completionClass = .sharedDefaultsUnavailable
+            #endif
+            return .result()
+        }
 
         let wallControl = SharedWidgetWallControlState.load(from: defaults)
         switch SharedWidgetTakeControlRuntime.action(for: wallControl) {
         case .enableLocalNavigation:
             SharedWidgetTakeControlRuntime.markControlClaimed(isPartySession: false, to: defaults)
             await refreshActivities()
+            #if !WIDGET_EXTENSION
+            diagnosticRun.mark(.activityKitUpdated)
+            completionClass = .localNavigationEnabled
+            #endif
             return .result()
         case .alreadyAllowed:
             await refreshActivities()
+            #if !WIDGET_EXTENSION
+            diagnosticRun.mark(.activityKitUpdated)
+            completionClass = .alreadyAllowed
+            #endif
             return .result()
         case .requestServerAuthorization:
             break
         }
 
+        #if !WIDGET_EXTENSION
+        diagnosticRun.mark(.networkStarted)
+        #endif
         let result = await WidgetNetworking.sendTakeControl()
+        #if !WIDGET_EXTENSION
+        switch result {
+        case .success:
+            diagnosticRun.mark(.networkFinishedSuccess)
+        case .serverRejected:
+            diagnosticRun.mark(.networkFinishedTerminal)
+            completionClass = .serverRejected
+        case .retryableFailure:
+            diagnosticRun.mark(.networkFinishedRetryable)
+            completionClass = .retryableNetworkFailure
+        }
+        #endif
         guard result == .success else {
             Self.logger.notice("TakeControlIntent rejected or failed; leaving widget navigation disabled")
             return .result()
@@ -33,6 +67,9 @@ struct TakeControlIntent: LiveActivityIntent {
 
         SharedWidgetTakeControlRuntime.markControlClaimed(isPartySession: true, to: defaults)
         await refreshActivities()
+        #if !WIDGET_EXTENSION
+        diagnosticRun.mark(.activityKitUpdated)
+        #endif
         return .result()
     }
 

--- a/packages/mobile/test/sentry-react-native-stub.ts
+++ b/packages/mobile/test/sentry-react-native-stub.ts
@@ -13,6 +13,7 @@
 
 type StubScope = {
   setLevel: () => void;
+  setFingerprint: () => void;
   setTag: () => void;
   setExtra: () => void;
   setContext: () => void;
@@ -35,7 +36,13 @@ export function setContext(): void {}
 export function setTag(): void {}
 
 export function withScope(callback: (scope: StubScope) => void): void {
-  callback({ setLevel: () => {}, setTag: () => {}, setExtra: () => {}, setContext: () => {} });
+  callback({
+    setLevel: () => {},
+    setFingerprint: () => {},
+    setTag: () => {},
+    setExtra: () => {},
+    setContext: () => {},
+  });
 }
 
 export function flush(): Promise<boolean> {

--- a/scripts/prepare-rn-ios-tests.mjs
+++ b/scripts/prepare-rn-ios-tests.mjs
@@ -65,6 +65,10 @@ const TEST_SOURCE_FILES = [
     projectPath: 'BoardseshTests/LiveActivitySources/WidgetNetworking.swift',
   },
   {
+    sourcePath: '../modules/live-activity/ios/LiveActivityIntentDiagnostics.swift',
+    projectPath: 'BoardseshTests/LiveActivitySources/LiveActivityIntentDiagnostics.swift',
+  },
+  {
     sourcePath: '../modules/live-activity/ios/ClimbNavigationIntent.swift',
     projectPath: 'BoardseshTests/LiveActivitySources/ClimbNavigationIntent.swift',
   },

--- a/scripts/prepare-rn-ios-tests.mjs
+++ b/scripts/prepare-rn-ios-tests.mjs
@@ -84,6 +84,10 @@ const TEST_SOURCE_FILES = [
     sourcePath: '../modules/live-activity/ios/TakeControlIntent.swift',
     projectPath: 'BoardseshTests/LiveActivitySources/TakeControlIntent.swift',
   },
+  {
+    sourcePath: '../modules/live-activity/ios/ReconnectBoardIntent.swift',
+    projectPath: 'BoardseshTests/LiveActivitySources/ReconnectBoardIntent.swift',
+  },
 ];
 
 const SYSTEM_FRAMEWORKS = [


### PR DESCRIPTION
## Summary

- record bounded, schema-versioned Live Activity intent stages and coarse outcomes in the main app target only
- consume only expired, incomplete records from a prior process, once, after the React root mounts or the app returns to the foreground
- report one privacy-safe informational Sentry event with a fixed fingerprint so cold-launch exits can be measured without changing AppIntent, BLE, timeout, or background-task behavior

This is an investigation instrument for the short-uptime, no-log terminations tracked in #4077. It deliberately does not claim a behavioral fix: the next physical-device occurrence should now identify the last completed stage instead of disappearing without evidence.

Fixes #4077

## Validation

- independent adversarial review: no findings
- focused mobile tests: 3 files, 45 tests passed
- `vp run typecheck:mobile`
- `vp check`
- Foundation-only Swift recorder parse/typecheck on Linux
- target-drift coverage verifies widget copies cannot compile recorder calls
- `git diff --check origin/main...HEAD`

## Device QA

- compile and run both generated iOS app and widget targets
- cold-launch each Live Activity intent and exercise normal early returns
- verify the 30-second grace and next-foreground once-only Sentry event on a physical iPhone/TestFlight build

## Release Notes

- [x] No release note needed (internal / technical change)
