### PR TITLE
fix(backend): validate playback state broadcasts

### DIFF
--- a/packages/backend/src/__tests__/playback-state-validation.test.ts
+++ b/packages/backend/src/__tests__/playback-state-validation.test.ts
@@ -16,6 +16,7 @@ function playbackStateWith(overrides: Record<string, unknown>): unknown {
 
 describe('PlaybackStateInputSchema', () => {
   it('accepts the shipped playback control and GraphQL Int boundaries', () => {
+    expect(PlaybackStateInputSchema.parse(playbackStateWith({ speed: 0.5 })).speed).toBe(0.5);
     expect(
       PlaybackStateInputSchema.parse(
         playbackStateWith({
@@ -74,6 +75,16 @@ describe('PlaybackStateInputSchema', () => {
   ])('does not coerce a %s', (_description, overrides) => {
     expect(PlaybackStateInputSchema.safeParse(playbackStateWith(overrides)).success).toBe(false);
   });
+
+  it.each(['climbUuid', 'frameIndex', 'isPlaying', 'speed', 'paceMs'] as const)(
+    'rejects a missing required %s field',
+    (missingField) => {
+      const incompleteState = Object.fromEntries(
+        Object.entries(validPlaybackState).filter(([fieldName]) => fieldName !== missingField),
+      );
+      expect(PlaybackStateInputSchema.safeParse(incompleteState).success).toBe(false);
+    },
+  );
 
   it('accepts an omitted or null client identifier for connection-id fallback', () => {
     expect(PlaybackStateInputSchema.safeParse(validPlaybackState).success).toBe(true);

--- a/packages/backend/src/__tests__/playback-state-validation.test.ts
+++ b/packages/backend/src/__tests__/playback-state-validation.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { PlaybackStateInputSchema } from '../validation/schemas';
+
+const GRAPHQL_INT_MAX = 2_147_483_647;
+const validPlaybackState = {
+  climbUuid: '11111111-1111-1111-1111-111111111111',
+  frameIndex: 0,
+  isPlaying: true,
+  speed: 1,
+  paceMs: 200,
+};
+
+function playbackStateWith(overrides: Record<string, unknown>): unknown {
+  return { ...validPlaybackState, ...overrides };
+}
+
+describe('PlaybackStateInputSchema', () => {
+  it('accepts the shipped playback control and GraphQL Int boundaries', () => {
+    expect(
+      PlaybackStateInputSchema.parse(
+        playbackStateWith({
+          climbUuid: 'c'.repeat(64),
+          frameIndex: GRAPHQL_INT_MAX,
+          speed: 10,
+          paceMs: GRAPHQL_INT_MAX,
+          clientId: 'c'.repeat(128),
+        }),
+      ),
+    ).toMatchObject({
+      climbUuid: 'c'.repeat(64),
+      frameIndex: GRAPHQL_INT_MAX,
+      speed: 10,
+      paceMs: GRAPHQL_INT_MAX,
+      clientId: 'c'.repeat(128),
+    });
+  });
+
+  it.each([
+    ['negative frame index', { frameIndex: -1 }],
+    ['fractional frame index', { frameIndex: 0.5 }],
+    ['frame index above GraphQL Int maximum', { frameIndex: GRAPHQL_INT_MAX + 1 }],
+    ['speed below the control minimum', { speed: 0.49 }],
+    ['speed above the control maximum', { speed: 10.01 }],
+    ['pace below the engine floor', { paceMs: 199 }],
+    ['fractional pace', { paceMs: 200.5 }],
+    ['pace above GraphQL Int maximum', { paceMs: GRAPHQL_INT_MAX + 1 }],
+    ['empty climb identifier', { climbUuid: '' }],
+    ['overlong climb identifier', { climbUuid: 'c'.repeat(65) }],
+    ['empty client identifier', { clientId: '' }],
+    ['overlong client identifier', { clientId: 'c'.repeat(129) }],
+  ])('rejects %s', (_description, overrides) => {
+    expect(PlaybackStateInputSchema.safeParse(playbackStateWith(overrides)).success).toBe(false);
+  });
+
+  it.each([
+    ['NaN frame index', { frameIndex: Number.NaN }],
+    ['infinite frame index', { frameIndex: Infinity }],
+    ['NaN speed', { speed: Number.NaN }],
+    ['infinite speed', { speed: Infinity }],
+    ['negative infinite speed', { speed: -Infinity }],
+    ['NaN pace', { paceMs: Number.NaN }],
+    ['infinite pace', { paceMs: Infinity }],
+  ])('rejects %s', (_description, overrides) => {
+    expect(PlaybackStateInputSchema.safeParse(playbackStateWith(overrides)).success).toBe(false);
+  });
+
+  it.each([
+    ['string frame index', { frameIndex: '0' }],
+    ['string speed', { speed: '1' }],
+    ['string pace', { paceMs: '200' }],
+    ['string playing state', { isPlaying: 'true' }],
+    ['numeric climb identifier', { climbUuid: 1 }],
+    ['numeric client identifier', { clientId: 1 }],
+  ])('does not coerce a %s', (_description, overrides) => {
+    expect(PlaybackStateInputSchema.safeParse(playbackStateWith(overrides)).success).toBe(false);
+  });
+
+  it('accepts an omitted or null client identifier for connection-id fallback', () => {
+    expect(PlaybackStateInputSchema.safeParse(validPlaybackState).success).toBe(true);
+    expect(PlaybackStateInputSchema.safeParse(playbackStateWith({ clientId: null })).success).toBe(true);
+  });
+});

--- a/packages/backend/src/__tests__/publish-playback-state.test.ts
+++ b/packages/backend/src/__tests__/publish-playback-state.test.ts
@@ -59,6 +59,13 @@ function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext 
 }
 
 const climbUuid = '11111111-1111-1111-1111-111111111111';
+const validPlaybackInput = {
+  climbUuid,
+  frameIndex: 3,
+  isPlaying: true,
+  speed: 1.5,
+  paceMs: 250,
+};
 
 describe('publishPlaybackState mutation', () => {
   beforeEach(() => {
@@ -70,13 +77,7 @@ describe('publishPlaybackState mutation', () => {
     const result = await queueMutations.publishPlaybackState(
       undefined,
       {
-        input: {
-          climbUuid,
-          frameIndex: 3,
-          isPlaying: true,
-          speed: 1.5,
-          paceMs: 250,
-        },
+        input: validPlaybackInput,
       },
       makeCtx({ connectionId: 'conn-abc' }),
     );
@@ -148,5 +149,24 @@ describe('publishPlaybackState mutation', () => {
     );
     const event = pubsubMock.publishQueueEvent.mock.calls[0]?.[1] as { clientId: string | null };
     expect(event.clientId).toBe('engine-:r3:');
+  });
+
+  it.each([
+    ['negative frame index', { frameIndex: -1 }],
+    ['fractional frame index', { frameIndex: 1.5 }],
+    ['NaN speed', { speed: Number.NaN }],
+    ['infinite speed', { speed: Infinity }],
+    ['speed outside the shipped range', { speed: 10.1 }],
+    ['pace below the engine floor', { paceMs: 199 }],
+    ['fractional pace', { paceMs: 200.5 }],
+    ['infinite pace', { paceMs: Infinity }],
+    ['coerced numeric value', { paceMs: '200' }],
+    ['wrong boolean type', { isPlaying: 'true' }],
+  ])('rejects %s before publishing', async (_description, overrides) => {
+    await expect(
+      queueMutations.publishPlaybackState(undefined, { input: { ...validPlaybackInput, ...overrides } }, makeCtx()),
+    ).rejects.toThrow('Invalid input');
+
+    expect(pubsubMock.publishQueueEvent).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/graphql/resolvers/queue/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/queue/mutations.ts
@@ -14,7 +14,12 @@ import {
   RATE_LIMIT_SET_QUEUE,
   RATE_LIMIT_SET_QUEUE_OP,
 } from '../shared/helpers';
-import { ClimbQueueItemSchema, QueueIndexSchema, QueueItemIdSchema } from '../../../validation/schemas';
+import {
+  ClimbQueueItemSchema,
+  PlaybackStateInputSchema,
+  QueueIndexSchema,
+  QueueItemIdSchema,
+} from '../../../validation/schemas';
 import { withQueueVersionRetry } from '../shared/queue-retry';
 import { logMutationMetrics } from './mutation-metrics';
 import { logger } from '../../../utils/logger';
@@ -512,35 +517,21 @@ export const queueMutations = {
    * incremented, so they are non-monotonic/duplicate across playback events —
    * another reason they must never enter the replay buffer.
    */
-  publishPlaybackState: async (
-    _: unknown,
-    {
-      input,
-    }: {
-      input: {
-        climbUuid: string;
-        frameIndex: number;
-        isPlaying: boolean;
-        speed: number;
-        paceMs: number;
-        clientId?: string | null;
-      };
-    },
-    ctx: ConnectionContext,
-  ) => {
+  publishPlaybackState: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
     await applyRateLimit(ctx, RATE_LIMIT_PLAYBACK, RATE_LIMIT_PLAYBACK_OP);
     const sessionId = await requireSessionWithReconnectGrace(ctx);
+    const validatedInput = validateInput(PlaybackStateInputSchema, input, 'input');
 
     const currentState = await roomManager.getQueueState(sessionId);
 
     pubsub.publishQueueEvent(sessionId, {
       __typename: 'PlaybackStateChanged',
       sequence: currentState.sequence,
-      climbUuid: input.climbUuid,
-      frameIndex: input.frameIndex,
-      isPlaying: input.isPlaying,
-      speed: input.speed,
-      paceMs: input.paceMs,
+      climbUuid: validatedInput.climbUuid,
+      frameIndex: validatedInput.frameIndex,
+      isPlaying: validatedInput.isPlaying,
+      speed: validatedInput.speed,
+      paceMs: validatedInput.paceMs,
       anchorTimestamp: String(Date.now()),
       // Prefer the publisher-supplied client identifier (the playback engine's
       // stable id) so echo suppression on the publisher's own clients works
@@ -549,7 +540,7 @@ export const queueMutations = {
       // empty strings (from contexts with no connectionId yet) to null —
       // peers compare to null defensively and would otherwise echo-suppress
       // each other's events.
-      clientId: input.clientId || ctx.connectionId || null,
+      clientId: validatedInput.clientId || ctx.connectionId || null,
     });
 
     return true;

--- a/packages/backend/src/validation/schemas/index.ts
+++ b/packages/backend/src/validation/schemas/index.ts
@@ -17,3 +17,4 @@ export * from './feedback';
 export * from './board-presence';
 export * from './integrations';
 export * from './sync';
+export * from './playback';

--- a/packages/backend/src/validation/schemas/playback.ts
+++ b/packages/backend/src/validation/schemas/playback.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+import { ClimbUuidSchema } from './primitives';
+
+// GraphQL's built-in Int scalar is a signed 32-bit integer. Resolvers are also
+// invoked directly in tests and internal code, so retain that transport bound
+// here instead of letting those callers publish values GraphQL would reject.
+const GRAPHQL_INT_MAX = 2_147_483_647;
+
+/**
+ * Input accepted by the high-frequency playback broadcast. The bounds mirror
+ * the controls and playback engine: controls expose 0.5×–10× and the engine
+ * cannot safely advance a frame faster than its 200 ms pace floor.
+ */
+export const PlaybackStateInputSchema = z.object({
+  climbUuid: ClimbUuidSchema,
+  frameIndex: z
+    .number()
+    .finite('Frame index must be finite')
+    .int('Frame index must be an integer')
+    .min(0, 'Frame index cannot be negative')
+    .max(GRAPHQL_INT_MAX, 'Frame index is too large'),
+  isPlaying: z.boolean(),
+  speed: z
+    .number()
+    .finite('Playback speed must be finite')
+    .min(0.5, 'Playback speed must be at least 0.5×')
+    .max(10, 'Playback speed cannot exceed 10×'),
+  paceMs: z
+    .number()
+    .finite('Playback pace must be finite')
+    .int('Playback pace must be an integer')
+    .min(200, 'Playback pace must be at least 200 ms')
+    .max(GRAPHQL_INT_MAX, 'Playback pace is too large'),
+  // React's useId() includes colons, so this intentionally stays a bounded
+  // opaque string rather than adopting ParticipantIdSchema's character regex;
+  // its 128-character cap matches the adjacent participant identifier.
+  clientId: z.string().min(1, 'Client ID cannot be empty').max(128, 'Client ID too long').nullable().optional(),
+});


### PR DESCRIPTION
## Summary

- Validate every `PlaybackStateInput` field before a party-session playback event is published.
- Enforce the bounds already shipped by the mobile/web controls and shared playback engine.
- Keep malformed direct-resolver calls from reaching peers or the pubsub layer.

Closes #2428

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project backend packages/backend/src/__tests__/playback-state-validation.test.ts packages/backend/src/__tests__/publish-playback-state.test.ts --reporter=agent` (40 passed)
- `vp run typecheck:backend`
- `vp check`
- Independent QA verified shipped client/engine bounds and the no-publish-on-invalid-input invariant.
