### PR TITLE
fix(sync): reject invalid climb stats

### DIFF
--- a/docs/aurora-sync.md
+++ b/docs/aurora-sync.md
@@ -177,9 +177,23 @@ same Boardsesh-owned rule. Aurora's upsert clobbers them on every sync from
 the much larger Aurora ascent population. `recomputeClimbStats` only writes
 these columns for Boardsesh-originated climbs (where Aurora never syncs);
 on Aurora climbs it leaves them untouched so Aurora's averages stay
-authoritative. `display_difficulty` mirrors `difficulty_average` in both
-writers (Aurora: `Number(item.display_difficulty || item.difficulty_average)`;
-Boardsesh: the same `AVG(bt.difficulty)` value used for `difficulty_average`).
+authoritative. Aurora accepts a valid `display_difficulty` independently and
+otherwise falls back to `difficulty_average`; the Boardsesh writer uses the
+same guarded tick average for both columns.
+
+Every Aurora difficulty field (average, display, and benchmark) is accepted
+only when it is finite and greater than 1; an invalid or missing display value
+falls back to a valid average. New zero-ascent stats payloads with no valid
+difficulty, quality, or first-ascent data are skipped. The same empty payload
+for an existing key is still applied authoritatively, clearing upstream-owned
+fields without deleting the row or changing Boardsesh counts and quality votes.
+
+Tick-driven recomputation seeds a new stats row only when the climb exists and
+the exact key has a non-detached flash/send tick. Tick existence gates INSERT
+only: existing rows are always recomputed, so deleting or detaching the last
+send clears Boardsesh-owned aggregates while retaining upstream data. Owned
+climb averages accept difficulty values greater than 1 and quality values from
+1 through 5; the latest-native quality-vote path uses the same 1–5 bounds.
 
 Aurora reports `quality_average` on a 1–3 scale, but Kilter Grips / MoonBoard
 use 1–5. Aurora's upsert normalises to 1–5 (`normalizeQualityTo5`, affine

--- a/docs/aurora-sync.md
+++ b/docs/aurora-sync.md
@@ -187,8 +187,13 @@ falls back to a valid average. New zero-ascent stats payloads with no valid
 difficulty, quality, or first-ascent data are skipped. The same empty payload
 for an existing key is still applied authoritatively, clearing upstream-owned
 fields without deleting the row or changing Boardsesh counts and quality votes.
-An omitted or malformed `ascensionist_count` is normalized to zero before this
-decision, so it cannot turn an empty row into a `NaN` database write.
+Only a non-negative safe-integer `ascensionist_count` is authoritative; an
+explicit numeric zero clears the stored upstream count, while an omitted, null,
+negative, fractional, non-finite, or wrong-type value is preserved as `NULL` so
+an existing count and its quality-blend weight survive the conflict update. The
+new-row emptiness check alone treats that `NULL` as zero: a fully empty new row
+is skipped, while a new row with other meaningful stats is inserted with a null
+upstream count.
 
 Tick-driven recomputation seeds a new stats row only when the climb exists and
 the exact key has a non-detached flash/send tick. Tick existence gates INSERT

--- a/docs/aurora-sync.md
+++ b/docs/aurora-sync.md
@@ -187,6 +187,8 @@ falls back to a valid average. New zero-ascent stats payloads with no valid
 difficulty, quality, or first-ascent data are skipped. The same empty payload
 for an existing key is still applied authoritatively, clearing upstream-owned
 fields without deleting the row or changing Boardsesh counts and quality votes.
+An omitted or malformed `ascensionist_count` is normalized to zero before this
+decision, so it cannot turn an empty row into a `NaN` database write.
 
 Tick-driven recomputation seeds a new stats row only when the climb exists and
 the exact key has a non-detached flash/send tick. Tick existence gates INSERT
@@ -201,6 +203,19 @@ use 1–5. Aurora's upsert normalises to 1–5 (`normalizeQualityTo5`, affine
 `board_climb_stats.quality_average` is one scale across every board. The
 one-time re-backfill of previously `×5/3`-scaled rows ships with the
 star-scale repair (migration 0149; see kilter-sync.md).
+
+The two providers deliberately handle sub-one positive noise differently:
+Aurora clamps a value in `(0, 1)` to its valid one-star floor before converting
+the 1–3 scale, while Kilter rejects it because Kilter's input is already on the
+1–5 scale. Zero, negative, and non-finite values remain unrated on both paths.
+
+Migration 0151 repaired only Aurora `difficulty_average = 0`; it did not cover
+the `= 1` sentinel or `display_difficulty` / `benchmark_difficulty` sentinels.
+Cursored shared syncs now overwrite those values with guarded fields as each row
+returns, so the remaining production tail self-heals without a broad cleanup
+write. Operators can quantify that lag with a read-only grouped count over those
+three predicates before deciding whether a separate cleanup migration is worth
+the write risk.
 
 If you add a new writer to `board_climb_stats`, decide which side it owns and
 recompute `ascensionist_count` in the same statement that updates that side.

--- a/packages/aurora-sync/src/api/sync-api-types.ts
+++ b/packages/aurora-sync/src/api/sync-api-types.ts
@@ -133,13 +133,13 @@ export type ProductSize = {
 export type ClimbStats = {
   climb_uuid: string;
   angle: number;
-  display_difficulty: number;
-  benchmark_difficulty: number;
+  display_difficulty: number | null;
+  benchmark_difficulty: number | null;
   ascensionist_count: number;
-  difficulty_average: number;
-  quality_average: number;
-  fa_username: string;
-  fa_at: string;
+  difficulty_average: number | null;
+  quality_average: number | null;
+  fa_username: string | null;
+  fa_at: string | null;
 };
 
 export type Hole = {

--- a/packages/aurora-sync/src/api/sync-api-types.ts
+++ b/packages/aurora-sync/src/api/sync-api-types.ts
@@ -135,7 +135,7 @@ export type ClimbStats = {
   angle: number;
   display_difficulty: number | null;
   benchmark_difficulty: number | null;
-  ascensionist_count: number;
+  ascensionist_count?: number | null;
   difficulty_average: number | null;
   quality_average: number | null;
   fa_username: string | null;

--- a/packages/aurora-sync/src/sync/shared-sync.test.ts
+++ b/packages/aurora-sync/src/sync/shared-sync.test.ts
@@ -702,6 +702,16 @@ describe('board_climb_stats empty-row guard (issue #4068)', () => {
     expect(shimConflictSets.filter((set) => 'upstreamQualityAverage' in set)).toHaveLength(0);
   });
 
+  it('treats an omitted ascensionist count as zero instead of writing NaN', async () => {
+    const statWithoutCount = emptyStat();
+    delete (statWithoutCount as Partial<ClimbStats>).ascensionist_count;
+    mockSharedSync.mockResolvedValueOnce(complete({ climb_stats: [statWithoutCount] }));
+
+    await syncSharedData(fakePostgresClient(), 'decoy', 'token');
+
+    expect(writtenStatsRows()).toHaveLength(0);
+  });
+
   it('bounds the existing-row pre-read by both candidate UUID and angle', async () => {
     mockSharedSync.mockResolvedValueOnce(
       complete({

--- a/packages/aurora-sync/src/sync/shared-sync.test.ts
+++ b/packages/aurora-sync/src/sync/shared-sync.test.ts
@@ -909,6 +909,19 @@ describe('board_climb_stats empty-row guard (issue #4068)', () => {
     expect(predicateQuery.params).toEqual(['decoy', 'ANGLE-40', 'ANGLE-50', 40, 50]);
   });
 
+  it('skips the existing-row pre-read entirely when every payload in the batch is non-empty', async () => {
+    mockSharedSync.mockResolvedValueOnce(
+      complete({
+        climb_stats: [stat({ climb_uuid: 'GRADED-40', angle: 40, difficulty_average: 18 })],
+      }),
+    );
+
+    await syncSharedData(fakePostgresClient(), 'decoy', 'token');
+
+    expect(shimClimbStatSelectPredicates).toHaveLength(0);
+    expect(writtenStatsRows()).toHaveLength(1);
+  });
+
   it('sanitizes invalid FA data before deciding a NEW row is empty', async () => {
     mockSharedSync.mockResolvedValueOnce(
       complete({

--- a/packages/aurora-sync/src/sync/shared-sync.test.ts
+++ b/packages/aurora-sync/src/sync/shared-sync.test.ts
@@ -1,23 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { notifications, setterFollows, userBoardMappings, userFollows } from '@boardsesh/db/schema';
-import type { SyncData } from '../api/sync-api-types';
+import type { ClimbStats, SyncData } from '../api/sync-api-types';
 import type { SyncOptions } from '../api/types';
 
-const {
-  mockSharedSync,
-  mockPopulateDenormalizedColumns,
-  mockConvertLitUpHolds,
-  mockBlendedQualityAverageSql,
-  mockSnapshotHistory,
-} = vi.hoisted(() => ({
-  mockSharedSync: vi.fn(),
-  mockPopulateDenormalizedColumns: vi.fn().mockResolvedValue(undefined),
-  mockConvertLitUpHolds: vi.fn().mockReturnValue({}),
-  // Never invoked here (these tests process no climb_stats); stubbed only so
-  // the shared-sync import of blendedQualityAverageSql resolves.
-  mockBlendedQualityAverageSql: vi.fn(),
-  mockSnapshotHistory: vi.fn().mockResolvedValue({ written: 0, skipped: true }),
-}));
+const { mockSharedSync, mockPopulateDenormalizedColumns, mockConvertLitUpHolds, mockSnapshotHistory } = vi.hoisted(
+  () => ({
+    mockSharedSync: vi.fn(),
+    mockPopulateDenormalizedColumns: vi.fn().mockResolvedValue(undefined),
+    mockConvertLitUpHolds: vi.fn().mockReturnValue({}),
+    mockSnapshotHistory: vi.fn().mockResolvedValue({ written: 0, skipped: true }),
+  }),
+);
 
 vi.mock('../api/shared-sync-api', () => ({
   sharedSync: mockSharedSync,
@@ -31,7 +24,6 @@ vi.mock('@boardsesh/db/queries', async (importOriginal) => {
     // moment shared-sync.ts reaches for one.
     ...actual,
     populateDenormalizedColumns: mockPopulateDenormalizedColumns,
-    blendedQualityAverageSql: mockBlendedQualityAverageSql,
     snapshotClimbStatsHistoryIfDue: mockSnapshotHistory,
     // setterSyncNotificationUuid deliberately NOT stubbed: the deterministic
     // uuid IS the duplicate-notification backstop, so a stub would stop
@@ -94,6 +86,7 @@ const shimInsertedRows: Array<Record<string, unknown>> = [];
  * even if the write path stops using the helper.
  */
 const shimConflictSets: Array<Record<string, unknown>> = [];
+const shimExistingClimbStatRows: Array<{ climbUuid: string; angle: number }> = [];
 
 function createDbShim() {
   const fluent: Record<string, unknown> = {};
@@ -105,6 +98,20 @@ function createDbShim() {
         return async (cb: (tx: typeof shim) => Promise<void>) => cb(shim);
       }
       if (prop === 'execute') return async () => undefined;
+      if (prop === 'select') {
+        return (selectedColumns: Record<string, unknown>) => {
+          const rows =
+            'climbUuid' in selectedColumns && 'angle' in selectedColumns ? [...shimExistingClimbStatRows] : [];
+          const terminal = Object.assign(Promise.resolve(rows), {
+            limit: () => Promise.resolve(rows),
+          });
+          return {
+            from: () => ({
+              where: () => terminal,
+            }),
+          };
+        };
+      }
       // Every method (insert, select, values, where, onConflictDoUpdate, etc.)
       // returns the same fluent object, so chains keep flowing. The terminal
       // `await` resolves to whatever the proxy is — fine for INSERTs (we don't
@@ -589,31 +596,171 @@ describe('createSetterSyncNotifications', () => {
 
 describe('parseDifficultyFields', () => {
   it('passes through numeric difficulty and display values', () => {
-    expect(parseDifficultyFields({ difficulty_average: 15.4, display_difficulty: 16 })).toEqual({
+    expect(
+      parseDifficultyFields({ difficulty_average: 15.4, display_difficulty: 16, benchmark_difficulty: 17 }),
+    ).toEqual({
       difficultyAverage: 15.4,
       displayDifficulty: 16,
+      benchmarkDifficulty: 17,
     });
   });
+
+  it.each([0, 1, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    'rejects invalid average/display/benchmark difficulty %s',
+    (difficulty) => {
+      expect(
+        parseDifficultyFields({
+          difficulty_average: difficulty,
+          display_difficulty: difficulty,
+          benchmark_difficulty: difficulty,
+        }),
+      ).toEqual({ difficultyAverage: null, displayDifficulty: null, benchmarkDifficulty: null });
+    },
+  );
 
   it('preserves NULL difficulty instead of coercing to grade 0', () => {
-    expect(parseDifficultyFields({ difficulty_average: null, display_difficulty: null })).toEqual({
+    expect(
+      parseDifficultyFields({ difficulty_average: null, display_difficulty: null, benchmark_difficulty: null }),
+    ).toEqual({
       difficultyAverage: null,
       displayDifficulty: null,
+      benchmarkDifficulty: null,
     });
   });
 
-  it('falls back display_difficulty to the average when Aurora omits it', () => {
-    expect(parseDifficultyFields({ difficulty_average: 22.1, display_difficulty: null })).toEqual({
+  it.each([null, 0, 1, Number.NaN])('falls back display_difficulty %s to the valid average', (displayDifficulty) => {
+    expect(
+      parseDifficultyFields({
+        difficulty_average: 22.1,
+        display_difficulty: displayDifficulty,
+        benchmark_difficulty: null,
+      }),
+    ).toEqual({
       difficultyAverage: 22.1,
       displayDifficulty: 22.1,
+      benchmarkDifficulty: null,
     });
   });
 
   it('keeps an explicit display value when the average is null', () => {
-    expect(parseDifficultyFields({ difficulty_average: null, display_difficulty: 18 })).toEqual({
+    expect(
+      parseDifficultyFields({ difficulty_average: null, display_difficulty: 18, benchmark_difficulty: 1 }),
+    ).toEqual({
       difficultyAverage: null,
       displayDifficulty: 18,
+      benchmarkDifficulty: null,
     });
+  });
+});
+
+describe('board_climb_stats empty-row guard (issue #4068)', () => {
+  const dialect = new PgDialect();
+  const render = (fragment: Parameters<typeof dialect.sqlToQuery>[0]) => dialect.sqlToQuery(fragment).sql.toLowerCase();
+
+  beforeEach(() => {
+    mockSharedSync.mockReset();
+    mockPopulateDenormalizedColumns.mockReset();
+    mockPopulateDenormalizedColumns.mockResolvedValue(undefined);
+    shimInsertedRows.length = 0;
+    shimConflictSets.length = 0;
+    shimExistingClimbStatRows.length = 0;
+  });
+
+  function stat(overrides: Partial<ClimbStats> = {}) {
+    return { ...emptyStat(), ...overrides };
+  }
+
+  function emptyStat(): ClimbStats {
+    return {
+      climb_uuid: 'EMPTY-STAT',
+      angle: 40,
+      display_difficulty: null,
+      benchmark_difficulty: null,
+      ascensionist_count: 0,
+      difficulty_average: null,
+      quality_average: null,
+      fa_username: null,
+      fa_at: null,
+    };
+  }
+
+  function writtenStatsRows() {
+    return shimInsertedRows.filter((row) => 'upstreamQualityAverage' in row);
+  }
+
+  it('skips a fully empty NEW stats key', async () => {
+    mockSharedSync.mockResolvedValueOnce(complete({ climb_stats: [emptyStat()] }));
+
+    await syncSharedData(fakePostgresClient(), 'decoy', 'token');
+
+    expect(writtenStatsRows()).toHaveLength(0);
+    expect(shimConflictSets.filter((set) => 'upstreamQualityAverage' in set)).toHaveLength(0);
+  });
+
+  it('sanitizes invalid FA data before deciding a NEW row is empty', async () => {
+    mockSharedSync.mockResolvedValueOnce(
+      complete({
+        climb_stats: [stat({ fa_username: 'Garbage', fa_at: '2033-01-01T00:00:00.000Z' })],
+      }),
+    );
+
+    await syncSharedData(fakePostgresClient(), 'decoy', 'token');
+
+    expect(writtenStatsRows()).toHaveLength(0);
+  });
+
+  it.each([
+    ['grade', { difficulty_average: 18 }],
+    ['benchmark', { benchmark_difficulty: 20 }],
+    ['quality', { quality_average: 2 }],
+    ['first ascent', { fa_username: 'Ari', fa_at: '2024-01-01T00:00:00.000Z' }],
+  ])('retains a zero-count NEW row with %s data', async (_label, overrides) => {
+    mockSharedSync.mockResolvedValueOnce(complete({ climb_stats: [stat(overrides)] }));
+
+    await syncSharedData(fakePostgresClient(), 'decoy', 'token');
+
+    expect(writtenStatsRows()).toHaveLength(1);
+  });
+
+  it('retains every positive-count NEW row even when display fields are empty', async () => {
+    mockSharedSync.mockResolvedValueOnce(complete({ climb_stats: [stat({ ascensionist_count: 1 })] }));
+
+    await syncSharedData(fakePostgresClient(), 'decoy', 'token');
+
+    expect(writtenStatsRows()).toHaveLength(1);
+  });
+
+  it('sends an empty EXISTING row through conflict update and preserves Boardsesh-owned terms', async () => {
+    shimExistingClimbStatRows.push({ climbUuid: 'EMPTY-STAT', angle: 40 });
+    mockSharedSync.mockResolvedValueOnce(complete({ climb_stats: [emptyStat()] }));
+
+    await syncSharedData(fakePostgresClient(), 'decoy', 'token');
+
+    expect(writtenStatsRows()).toEqual([
+      expect.objectContaining({
+        climbUuid: 'EMPTY-STAT',
+        upstreamAscensionistCount: 0,
+        ascensionistCount: 0,
+        difficultyAverage: null,
+        displayDifficulty: null,
+        benchmarkDifficulty: null,
+        qualityAverage: null,
+        upstreamQualityAverage: null,
+        faUsername: null,
+        faAt: null,
+      }),
+    ]);
+
+    const [statsConflictSet] = shimConflictSets.filter((set) => 'upstreamQualityAverage' in set) as Array<
+      Record<string, SQL>
+    >;
+    expect(statsConflictSet).toBeDefined();
+    expect(render(statsConflictSet.ascensionistCount)).toContain('boardsesh_ascensionist_count');
+    expect(render(statsConflictSet.qualityAverage)).toContain('boardsesh_quality_sum');
+    expect(render(statsConflictSet.qualityAverage)).toContain('boardsesh_quality_count');
+    expect(statsConflictSet).not.toHaveProperty('boardseshAscensionistCount');
+    expect(statsConflictSet).not.toHaveProperty('boardseshQualitySum');
+    expect(statsConflictSet).not.toHaveProperty('boardseshQualityCount');
   });
 });
 

--- a/packages/aurora-sync/src/sync/shared-sync.test.ts
+++ b/packages/aurora-sync/src/sync/shared-sync.test.ts
@@ -661,6 +661,87 @@ describe('board_climb_stats empty-row guard (issue #4068)', () => {
   const dialect = new PgDialect();
   const render = (fragment: Parameters<typeof dialect.sqlToQuery>[0]) => dialect.sqlToQuery(fragment).sql.toLowerCase();
 
+  type RecordedStatsConflictSet = {
+    upstreamAscensionistCount: SQL;
+    ascensionistCount: SQL;
+    qualityAverage: SQL;
+  };
+
+  type RecordedStatsPolicyInput = {
+    incomingUpstreamCount: number | null;
+    storedUpstreamCount: number | null;
+    boardseshAscensionistCount: number;
+    upstreamQualityAverage: number | null;
+    boardseshQualitySum: number;
+    boardseshQualityCount: number;
+  };
+
+  function normalizeSql(fragment: SQL): string {
+    return render(fragment).replace(/\s+/g, ' ').trim();
+  }
+
+  function recordedStatsConflictSet(): RecordedStatsConflictSet {
+    const statsConflictSets = shimConflictSets.filter((set) => 'upstreamQualityAverage' in set);
+    expect(statsConflictSets).toHaveLength(1);
+    return statsConflictSets[0] as unknown as RecordedStatsConflictSet;
+  }
+
+  function evaluateRenderedUpstreamCount(
+    rendered: string,
+    incomingUpstreamCount: number | null,
+    storedUpstreamCount: number | null,
+  ): number {
+    const coalesceMatch = rendered.match(/^coalesce\(([^()]*)\)$/);
+    if (!coalesceMatch) throw new Error(`not a bare COALESCE expression: ${rendered}`);
+
+    for (const argument of coalesceMatch[1].split(',').map((part) => part.trim())) {
+      if (argument === 'excluded.upstream_ascensionist_count') {
+        if (incomingUpstreamCount != null) return incomingUpstreamCount;
+      } else if (argument === '"board_climb_stats"."upstream_ascensionist_count"') {
+        if (storedUpstreamCount != null) return storedUpstreamCount;
+      } else {
+        return Number(argument);
+      }
+    }
+
+    throw new Error(`no COALESCE argument resolved in: ${rendered}`);
+  }
+
+  function evaluateRecordedStatsPolicy(
+    conflictSet: RecordedStatsConflictSet,
+    input: RecordedStatsPolicyInput,
+  ): { upstreamCount: number; totalCount: number; blendedQualityAverage: number | null } {
+    const effectiveCountSql = normalizeSql(conflictSet.upstreamAscensionistCount);
+    const totalCountSql = normalizeSql(conflictSet.ascensionistCount);
+    const blendSql = normalizeSql(conflictSet.qualityAverage);
+
+    // The total and BOTH upstream-weight positions in the recorded blend must
+    // reuse the exact incoming-first COALESCE emitted for the count update.
+    // That ties these behavioral assertions to the query builder path that ran,
+    // rather than to a separately reconstructed helper expression.
+    expect(totalCountSql).toBe(
+      `${effectiveCountSql} + coalesce("board_climb_stats"."boardsesh_ascensionist_count", 0)`,
+    );
+    expect(blendSql.split(effectiveCountSql)).toHaveLength(3);
+    expect(blendSql).toContain('coalesce("board_climb_stats"."boardsesh_quality_sum", 0)');
+    expect(blendSql).toContain('coalesce("board_climb_stats"."boardsesh_quality_count", 0)');
+
+    const upstreamCount = evaluateRenderedUpstreamCount(
+      effectiveCountSql,
+      input.incomingUpstreamCount,
+      input.storedUpstreamCount,
+    );
+    const totalCount = upstreamCount + input.boardseshAscensionistCount;
+    const upstreamWeight = input.upstreamQualityAverage == null ? 0 : upstreamCount;
+    const blendWeight = upstreamWeight + input.boardseshQualityCount;
+    const weightedQualitySum =
+      (input.upstreamQualityAverage == null ? 0 : input.upstreamQualityAverage * upstreamCount) +
+      input.boardseshQualitySum;
+    const blendedQualityAverage = blendWeight === 0 ? input.upstreamQualityAverage : weightedQualitySum / blendWeight;
+
+    return { upstreamCount, totalCount, blendedQualityAverage };
+  }
+
   beforeEach(() => {
     mockSharedSync.mockReset();
     mockPopulateDenormalizedColumns.mockReset();
@@ -673,6 +754,10 @@ describe('board_climb_stats empty-row guard (issue #4068)', () => {
 
   function stat(overrides: Partial<ClimbStats> = {}) {
     return { ...emptyStat(), ...overrides };
+  }
+
+  function statWithRawCount(rawCount: unknown, overrides: Partial<ClimbStats> = {}): ClimbStats {
+    return { ...stat(overrides), ascensionist_count: rawCount } as unknown as ClimbStats;
   }
 
   function emptyStat(): ClimbStats {
@@ -702,15 +787,111 @@ describe('board_climb_stats empty-row guard (issue #4068)', () => {
     expect(shimConflictSets.filter((set) => 'upstreamQualityAverage' in set)).toHaveLength(0);
   });
 
-  it('treats an omitted ascensionist count as zero instead of writing NaN', async () => {
+  it('treats an omitted count as zero only when deciding a fully empty NEW row is empty', async () => {
     const statWithoutCount = emptyStat();
-    delete (statWithoutCount as Partial<ClimbStats>).ascensionist_count;
+    delete statWithoutCount.ascensionist_count;
     mockSharedSync.mockResolvedValueOnce(complete({ climb_stats: [statWithoutCount] }));
 
     await syncSharedData(fakePostgresClient(), 'decoy', 'token');
 
     expect(writtenStatsRows()).toHaveLength(0);
   });
+
+  it('inserts NULL counts when a NEW row omits its count but has other meaningful stats', async () => {
+    const meaningfulStatWithoutCount = stat({ difficulty_average: 18 });
+    delete meaningfulStatWithoutCount.ascensionist_count;
+    mockSharedSync.mockResolvedValueOnce(complete({ climb_stats: [meaningfulStatWithoutCount] }));
+
+    await syncSharedData(fakePostgresClient(), 'decoy', 'token');
+
+    expect(writtenStatsRows()).toEqual([
+      expect.objectContaining({
+        climbUuid: 'EMPTY-STAT',
+        difficultyAverage: 18,
+        upstreamAscensionistCount: null,
+        ascensionistCount: null,
+      }),
+    ]);
+  });
+
+  it.each([
+    { label: 'omitted', rawCount: undefined, omitCount: true },
+    { label: 'undefined', rawCount: undefined },
+    { label: 'null', rawCount: null },
+    { label: 'negative', rawCount: -1 },
+    { label: 'fractional', rawCount: 1.5 },
+    { label: 'NaN', rawCount: Number.NaN },
+    { label: 'positive infinity', rawCount: Number.POSITIVE_INFINITY },
+    { label: 'negative infinity', rawCount: Number.NEGATIVE_INFINITY },
+    { label: 'unsafe integer', rawCount: Number.MAX_SAFE_INTEGER + 1 },
+    { label: 'numeric string', rawCount: '7' },
+    { label: 'boolean', rawCount: true },
+  ])(
+    "maps an EXISTING row's $label count to NULL so stored count and blend weight survive",
+    async ({ rawCount, omitCount }) => {
+      shimExistingClimbStatRows.push({ climbUuid: 'EMPTY-STAT', angle: 40 });
+      const incomingStat = statWithRawCount(rawCount, { quality_average: 2 });
+      if (omitCount) delete incomingStat.ascensionist_count;
+      mockSharedSync.mockResolvedValueOnce(complete({ climb_stats: [incomingStat] }));
+
+      await syncSharedData(fakePostgresClient(), 'decoy', 'token');
+
+      expect(writtenStatsRows()).toEqual([
+        expect.objectContaining({
+          upstreamAscensionistCount: null,
+          ascensionistCount: null,
+          upstreamQualityAverage: 3,
+        }),
+      ]);
+      expect(
+        evaluateRecordedStatsPolicy(recordedStatsConflictSet(), {
+          incomingUpstreamCount: null,
+          storedUpstreamCount: 8,
+          boardseshAscensionistCount: 2,
+          upstreamQualityAverage: 3,
+          boardseshQualitySum: 10,
+          boardseshQualityCount: 2,
+        }),
+      ).toEqual({ upstreamCount: 8, totalCount: 10, blendedQualityAverage: 3.4 });
+    },
+  );
+
+  it.each([
+    ['explicit zero', 0, 0, 2, 5],
+    ['positive safe integer', 4, 4, 6, 22 / 6],
+  ] as const)(
+    'keeps %s authoritative for an EXISTING row and its blend weight',
+    async (_label, incomingCount, expectedUpstreamCount, expectedTotalCount, expectedBlend) => {
+      shimExistingClimbStatRows.push({ climbUuid: 'EMPTY-STAT', angle: 40 });
+      mockSharedSync.mockResolvedValueOnce(
+        complete({ climb_stats: [stat({ ascensionist_count: incomingCount, quality_average: 2 })] }),
+      );
+
+      await syncSharedData(fakePostgresClient(), 'decoy', 'token');
+
+      expect(writtenStatsRows()).toEqual([
+        expect.objectContaining({
+          upstreamAscensionistCount: incomingCount,
+          ascensionistCount: incomingCount,
+          upstreamQualityAverage: 3,
+        }),
+      ]);
+      expect(
+        evaluateRecordedStatsPolicy(recordedStatsConflictSet(), {
+          incomingUpstreamCount: incomingCount,
+          storedUpstreamCount: 8,
+          boardseshAscensionistCount: 2,
+          upstreamQualityAverage: 3,
+          boardseshQualitySum: 10,
+          boardseshQualityCount: 2,
+        }),
+      ).toEqual({
+        upstreamCount: expectedUpstreamCount,
+        totalCount: expectedTotalCount,
+        blendedQualityAverage: expectedBlend,
+      });
+    },
+  );
 
   it('bounds the existing-row pre-read by both candidate UUID and angle', async () => {
     mockSharedSync.mockResolvedValueOnce(

--- a/packages/aurora-sync/src/sync/shared-sync.test.ts
+++ b/packages/aurora-sync/src/sync/shared-sync.test.ts
@@ -87,6 +87,7 @@ const shimInsertedRows: Array<Record<string, unknown>> = [];
  */
 const shimConflictSets: Array<Record<string, unknown>> = [];
 const shimExistingClimbStatRows: Array<{ climbUuid: string; angle: number }> = [];
+const shimClimbStatSelectPredicates: SQL[] = [];
 
 function createDbShim() {
   const fluent: Record<string, unknown> = {};
@@ -100,14 +101,17 @@ function createDbShim() {
       if (prop === 'execute') return async () => undefined;
       if (prop === 'select') {
         return (selectedColumns: Record<string, unknown>) => {
-          const rows =
-            'climbUuid' in selectedColumns && 'angle' in selectedColumns ? [...shimExistingClimbStatRows] : [];
+          const isClimbStatKeySelect = 'climbUuid' in selectedColumns && 'angle' in selectedColumns;
+          const rows = isClimbStatKeySelect ? [...shimExistingClimbStatRows] : [];
           const terminal = Object.assign(Promise.resolve(rows), {
             limit: () => Promise.resolve(rows),
           });
           return {
             from: () => ({
-              where: () => terminal,
+              where: (predicate: SQL) => {
+                if (isClimbStatKeySelect) shimClimbStatSelectPredicates.push(predicate);
+                return terminal;
+              },
             }),
           };
         };
@@ -664,6 +668,7 @@ describe('board_climb_stats empty-row guard (issue #4068)', () => {
     shimInsertedRows.length = 0;
     shimConflictSets.length = 0;
     shimExistingClimbStatRows.length = 0;
+    shimClimbStatSelectPredicates.length = 0;
   });
 
   function stat(overrides: Partial<ClimbStats> = {}) {
@@ -695,6 +700,22 @@ describe('board_climb_stats empty-row guard (issue #4068)', () => {
 
     expect(writtenStatsRows()).toHaveLength(0);
     expect(shimConflictSets.filter((set) => 'upstreamQualityAverage' in set)).toHaveLength(0);
+  });
+
+  it('bounds the existing-row pre-read by both candidate UUID and angle', async () => {
+    mockSharedSync.mockResolvedValueOnce(
+      complete({
+        climb_stats: [stat({ climb_uuid: 'ANGLE-40', angle: 40 }), stat({ climb_uuid: 'ANGLE-50', angle: 50 })],
+      }),
+    );
+
+    await syncSharedData(fakePostgresClient(), 'decoy', 'token');
+
+    expect(shimClimbStatSelectPredicates).toHaveLength(1);
+    const predicateQuery = dialect.sqlToQuery(shimClimbStatSelectPredicates[0]);
+    expect(predicateQuery.sql).toContain('"climb_uuid" in');
+    expect(predicateQuery.sql).toContain('"angle" in');
+    expect(predicateQuery.params).toEqual(['decoy', 'ANGLE-40', 'ANGLE-50', 40, 50]);
   });
 
   it('sanitizes invalid FA data before deciding a NEW row is empty', async () => {

--- a/packages/aurora-sync/src/sync/shared-sync.ts
+++ b/packages/aurora-sync/src/sync/shared-sync.ts
@@ -503,8 +503,8 @@ type MappedClimbStat = {
   angle: number;
   displayDifficulty: number | null;
   benchmarkDifficulty: number | null;
-  ascensionistCount: number;
-  upstreamAscensionistCount: number;
+  ascensionistCount: number | null;
+  upstreamAscensionistCount: number | null;
   difficultyAverage: number | null;
   qualityAverage: number | null;
   qualityNormalized: true;
@@ -512,15 +512,14 @@ type MappedClimbStat = {
   faAt: string | null;
 };
 
-function normalizeAscensionistCount(count: number | null | undefined): number {
-  const numericCount = Number(count ?? 0);
-  return Number.isSafeInteger(numericCount) && numericCount >= 0 ? numericCount : 0;
+function normalizeAscensionistCount(count: unknown): number | null {
+  return typeof count === 'number' && Number.isSafeInteger(count) && count >= 0 ? count : null;
 }
 
 function mapClimbStat(board: AuroraBoardName, item: ClimbStats): MappedClimbStat {
-  // Some Aurora rows omit this nominally-required field. Treat missing or
-  // malformed counts as the same zero sentinel as the other empty-row fields;
-  // never let NaN turn an empty row into a batch-failing INSERT.
+  // Some Aurora rows omit this field or carry malformed values. Preserve that
+  // distinction as NULL: ON CONFLICT treats it as "no count update", while an
+  // explicit numeric 0 remains an authoritative reset.
   const upstreamAscensionistCount = normalizeAscensionistCount(item.ascensionist_count);
   const { difficultyAverage, displayDifficulty, benchmarkDifficulty } = parseDifficultyFields(item);
   return {
@@ -545,7 +544,7 @@ function climbStatKey(climbUuid: string, angle: number): string {
 
 function isEmptyUpstreamClimbStat(value: MappedClimbStat): boolean {
   return (
-    value.upstreamAscensionistCount === 0 &&
+    (value.upstreamAscensionistCount ?? 0) === 0 &&
     value.difficultyAverage == null &&
     value.displayDifficulty == null &&
     value.benchmarkDifficulty == null &&
@@ -573,9 +572,11 @@ async function upsertClimbStats(db: DrizzleDb, board: AuroraBoardName, data: Cli
     // explicitly for ticks-driven updates.
     // Normalize and sanitize the whole payload before deciding whether it has
     // meaningful upstream data. An empty payload is skipped only for a NEW
-    // key: for an existing key it is authoritative and must reach ON CONFLICT
-    // to clear the upstream count/difficulty/quality/FA fields. Boardsesh-owned
-    // counts and quality votes are preserved by the conflict SET below.
+    // key: for an existing key it must reach ON CONFLICT to apply the other
+    // upstream-owned fields. An explicit count 0 clears the stored upstream
+    // count; a missing or malformed count maps to NULL and preserves it.
+    // Boardsesh-owned counts and quality votes are preserved by the conflict
+    // SET below.
     const mappedValues = batch.map((item) => mapClimbStat(board, item));
     const candidateClimbUuids = [...new Set(mappedValues.map((value) => value.climbUuid))];
     const candidateAngles = [...new Set(mappedValues.map((value) => value.angle))];

--- a/packages/aurora-sync/src/sync/shared-sync.ts
+++ b/packages/aurora-sync/src/sync/shared-sync.ts
@@ -512,8 +512,16 @@ type MappedClimbStat = {
   faAt: string | null;
 };
 
+function normalizeAscensionistCount(count: number | null | undefined): number {
+  const numericCount = Number(count ?? 0);
+  return Number.isSafeInteger(numericCount) && numericCount >= 0 ? numericCount : 0;
+}
+
 function mapClimbStat(board: AuroraBoardName, item: ClimbStats): MappedClimbStat {
-  const upstreamAscensionistCount = Number(item.ascensionist_count);
+  // Some Aurora rows omit this nominally-required field. Treat missing or
+  // malformed counts as the same zero sentinel as the other empty-row fields;
+  // never let NaN turn an empty row into a batch-failing INSERT.
+  const upstreamAscensionistCount = normalizeAscensionistCount(item.ascensionist_count);
   const { difficultyAverage, displayDifficulty, benchmarkDifficulty } = parseDifficultyFields(item);
   return {
     boardType: board,

--- a/packages/aurora-sync/src/sync/shared-sync.ts
+++ b/packages/aurora-sync/src/sync/shared-sync.ts
@@ -142,7 +142,7 @@ export function climbStatsUpstreamConflictSet() {
  * Conflict policy for board_climb_stats.fa_username / fa_at on the Aurora
  * shared sync. Deliberately a bare `excluded.*` — the incoming value is
  * already sanitized once at INSERT-value construction time (sanitizeFirstAscent,
- * applied in upsertClimbStats' values.map), so `excluded.*` in this same
+ * applied in upsertClimbStats' mappedValues construction), so `excluded.*` in this same
  * statement reflects that sanitized value; no SQL-side range check is needed
  * or wanted here (see @boardsesh/sync-runtime's sanitizeFirstAscent docs for
  * why duplicating the range logic in SQL would risk drifting out of sync).
@@ -473,22 +473,78 @@ async function upsertAttempts(db: DrizzleDb, board: AuroraBoardName, data: Attem
   });
 }
 
-// Preserve NULL difficulty instead of coercing it to 0. `Number(null)` is 0,
-// and difficulty id 0 doesn't exist (valid ids are ~10-33), so coercing stamps
-// a bogus 0 grade whenever Aurora omits the field — legacy rows are cleaned up
-// by the sentinel migration. display_difficulty falls back to the average when
-// Aurora omits it, mirroring how Aurora derives display FROM the average.
-// Exported for unit tests.
-// The ClimbStats type declares these fields as plain `number`, but Aurora
-// really does send null (that's the bug this guards against), so the parameter
-// is typed to reality rather than to the wire type.
-export function parseDifficultyFields(item: { difficulty_average: number | null; display_difficulty: number | null }): {
+// Aurora uses 0/1 as missing-difficulty sentinels; neither is a real difficulty
+// id. Apply one guard to every upstream difficulty field so average, display,
+// and benchmark cannot drift. Non-finite values are rejected before they reach
+// Postgres. display_difficulty falls back to a valid normalized average when
+// Aurora omits it or sends an invalid sentinel.
+export function normalizeDifficulty(difficulty: number | null | undefined): number | null {
+  if (difficulty == null) return null;
+  const numericDifficulty = Number(difficulty);
+  return Number.isFinite(numericDifficulty) && numericDifficulty > 1 ? numericDifficulty : null;
+}
+
+export function parseDifficultyFields(
+  item: Pick<ClimbStats, 'difficulty_average' | 'display_difficulty' | 'benchmark_difficulty'>,
+): {
   difficultyAverage: number | null;
   displayDifficulty: number | null;
+  benchmarkDifficulty: number | null;
 } {
-  const difficultyAverage = item.difficulty_average != null ? Number(item.difficulty_average) : null;
-  const displayDifficulty = item.display_difficulty != null ? Number(item.display_difficulty) : difficultyAverage;
-  return { difficultyAverage, displayDifficulty };
+  const difficultyAverage = normalizeDifficulty(item.difficulty_average);
+  const displayDifficulty = normalizeDifficulty(item.display_difficulty) ?? difficultyAverage;
+  const benchmarkDifficulty = normalizeDifficulty(item.benchmark_difficulty);
+  return { difficultyAverage, displayDifficulty, benchmarkDifficulty };
+}
+
+type MappedClimbStat = {
+  boardType: AuroraBoardName;
+  climbUuid: string;
+  angle: number;
+  displayDifficulty: number | null;
+  benchmarkDifficulty: number | null;
+  ascensionistCount: number;
+  upstreamAscensionistCount: number;
+  difficultyAverage: number | null;
+  qualityAverage: number | null;
+  qualityNormalized: true;
+  faUsername: string | null;
+  faAt: string | null;
+};
+
+function mapClimbStat(board: AuroraBoardName, item: ClimbStats): MappedClimbStat {
+  const upstreamAscensionistCount = Number(item.ascensionist_count);
+  const { difficultyAverage, displayDifficulty, benchmarkDifficulty } = parseDifficultyFields(item);
+  return {
+    boardType: board,
+    climbUuid: item.climb_uuid,
+    angle: Number(item.angle),
+    displayDifficulty,
+    benchmarkDifficulty,
+    ascensionistCount: upstreamAscensionistCount,
+    upstreamAscensionistCount,
+    difficultyAverage,
+    // Keep normalizeQualityTo5's established clamp semantics unchanged.
+    qualityAverage: normalizeQualityTo5(item.quality_average),
+    qualityNormalized: true,
+    ...sanitizeFirstAscent({ faUsername: item.fa_username, faAt: item.fa_at }),
+  };
+}
+
+function climbStatKey(climbUuid: string, angle: number): string {
+  return JSON.stringify([climbUuid, angle]);
+}
+
+function isEmptyUpstreamClimbStat(value: MappedClimbStat): boolean {
+  return (
+    value.upstreamAscensionistCount === 0 &&
+    value.difficultyAverage == null &&
+    value.displayDifficulty == null &&
+    value.benchmarkDifficulty == null &&
+    value.qualityAverage == null &&
+    value.faUsername == null &&
+    value.faAt == null
+  );
 }
 
 async function upsertClimbStats(db: DrizzleDb, board: AuroraBoardName, data: ClimbStats[]) {
@@ -507,34 +563,23 @@ async function upsertClimbStats(db: DrizzleDb, board: AuroraBoardName, data: Cli
     // Boardsesh-supplied FA on those climbs cannot be clobbered here.
     // recomputeClimbStats is the one that handles the ownership branch
     // explicitly for ticks-driven updates.
-    const values = batch.map((item) => {
-      const auroraCount = Number(item.ascensionist_count);
-      const { difficultyAverage, displayDifficulty } = parseDifficultyFields(item);
-      return {
-        boardType: board,
-        climbUuid: item.climb_uuid,
-        angle: Number(item.angle),
-        displayDifficulty,
-        benchmarkDifficulty: item.benchmark_difficulty != null ? Number(item.benchmark_difficulty) : null,
-        ascensionistCount: auroraCount,
-        upstreamAscensionistCount: auroraCount,
-        difficultyAverage,
-        // Aurora reports quality on a 1–3 scale; Kilter Grips and MoonBoard use
-        // 1–5. Normalise every board to 1–5 with the affine map 2q−1 (1→1, 2→3,
-        // 3→5) so board_climb_stats.quality_average is one scale the UI renders
-        // uniformly. Because AVG is linear, 2·avg−1 is the correct rescale of an
-        // average (the old ×5/3 inflated low-rated climbs). quality_average is a
-        // stored average (double), so it stays continuous rather than rounded.
-        qualityAverage: normalizeQualityTo5(item.quality_average),
-        // We just normalised quality_average to 1-5, so the row is on the
-        // canonical scale — the one-time 1-3→1-5 backfill must skip it.
-        qualityNormalized: true,
-        // Guard against impossible upstream fa_at values (future/pre-2016
-        // dates) before they reach the INSERT/ON CONFLICT — see
-        // sanitizeFirstAscent for why nulling (not clamping) is correct here.
-        ...sanitizeFirstAscent({ faUsername: item.fa_username, faAt: item.fa_at }),
-      };
-    });
+    // Normalize and sanitize the whole payload before deciding whether it has
+    // meaningful upstream data. An empty payload is skipped only for a NEW
+    // key: for an existing key it is authoritative and must reach ON CONFLICT
+    // to clear the upstream count/difficulty/quality/FA fields. Boardsesh-owned
+    // counts and quality votes are preserved by the conflict SET below.
+    const mappedValues = batch.map((item) => mapClimbStat(board, item));
+    const candidateClimbUuids = [...new Set(mappedValues.map((value) => value.climbUuid))];
+    const existingRows = await db
+      .select({ climbUuid: climbStatsSchema.climbUuid, angle: climbStatsSchema.angle })
+      .from(climbStatsSchema)
+      .where(and(eq(climbStatsSchema.boardType, board), inArray(climbStatsSchema.climbUuid, candidateClimbUuids)));
+    const existingKeys = new Set(existingRows.map((row) => climbStatKey(row.climbUuid, row.angle)));
+    const values = mappedValues.filter(
+      (value) => !isEmptyUpstreamClimbStat(value) || existingKeys.has(climbStatKey(value.climbUuid, value.angle)),
+    );
+
+    if (values.length === 0) return;
 
     // Stamp upstream_synced_at on the stats row (records that a manufacturer
     // sync just touched it). upstream_quality_average carries the normalized
@@ -552,8 +597,8 @@ async function upsertClimbStats(db: DrizzleDb, board: AuroraBoardName, data: Cli
     }));
 
     // The upstream conflict policy (climbStatsUpstreamConflictSet): take the
-    // incoming cursored count verbatim so a legitimate decrease propagates; a
-    // NULL incoming preserves the stored count. Resolved ONCE and reused for the
+    // incoming cursored count verbatim so a legitimate decrease propagates.
+    // Resolved ONCE and reused for the
     // count SET, the total, AND the blend weight, because a Postgres SET
     // expression sees the OLD row value of a bare column — the blend must weight
     // by this NEW upstream count, not the stale stored one. Single source keeps

--- a/packages/aurora-sync/src/sync/shared-sync.ts
+++ b/packages/aurora-sync/src/sync/shared-sync.ts
@@ -478,7 +478,7 @@ async function upsertAttempts(db: DrizzleDb, board: AuroraBoardName, data: Attem
 // and benchmark cannot drift. Non-finite values are rejected before they reach
 // Postgres. display_difficulty falls back to a valid normalized average when
 // Aurora omits it or sends an invalid sentinel.
-export function normalizeDifficulty(difficulty: number | null | undefined): number | null {
+export function normalizeDifficulty(difficulty: number | null): number | null {
   if (difficulty == null) return null;
   const numericDifficulty = Number(difficulty);
   return Number.isFinite(numericDifficulty) && numericDifficulty > 1 ? numericDifficulty : null;
@@ -570,10 +570,17 @@ async function upsertClimbStats(db: DrizzleDb, board: AuroraBoardName, data: Cli
     // counts and quality votes are preserved by the conflict SET below.
     const mappedValues = batch.map((item) => mapClimbStat(board, item));
     const candidateClimbUuids = [...new Set(mappedValues.map((value) => value.climbUuid))];
+    const candidateAngles = [...new Set(mappedValues.map((value) => value.angle))];
     const existingRows = await db
       .select({ climbUuid: climbStatsSchema.climbUuid, angle: climbStatsSchema.angle })
       .from(climbStatsSchema)
-      .where(and(eq(climbStatsSchema.boardType, board), inArray(climbStatsSchema.climbUuid, candidateClimbUuids)));
+      .where(
+        and(
+          eq(climbStatsSchema.boardType, board),
+          inArray(climbStatsSchema.climbUuid, candidateClimbUuids),
+          inArray(climbStatsSchema.angle, candidateAngles),
+        ),
+      );
     const existingKeys = new Set(existingRows.map((row) => climbStatKey(row.climbUuid, row.angle)));
     const values = mappedValues.filter(
       (value) => !isEmptyUpstreamClimbStat(value) || existingKeys.has(climbStatKey(value.climbUuid, value.angle)),

--- a/packages/aurora-sync/src/sync/shared-sync.ts
+++ b/packages/aurora-sync/src/sync/shared-sync.ts
@@ -578,19 +578,28 @@ async function upsertClimbStats(db: DrizzleDb, board: AuroraBoardName, data: Cli
     // Boardsesh-owned counts and quality votes are preserved by the conflict
     // SET below.
     const mappedValues = batch.map((item) => mapClimbStat(board, item));
-    const candidateClimbUuids = [...new Set(mappedValues.map((value) => value.climbUuid))];
-    const candidateAngles = [...new Set(mappedValues.map((value) => value.angle))];
-    const existingRows = await db
-      .select({ climbUuid: climbStatsSchema.climbUuid, angle: climbStatsSchema.angle })
-      .from(climbStatsSchema)
-      .where(
-        and(
-          eq(climbStatsSchema.boardType, board),
-          inArray(climbStatsSchema.climbUuid, candidateClimbUuids),
-          inArray(climbStatsSchema.angle, candidateAngles),
-        ),
-      );
-    const existingKeys = new Set(existingRows.map((row) => climbStatKey(row.climbUuid, row.angle)));
+    // existingKeys is only consulted below for empty payloads (the filter's
+    // first disjunct short-circuits for non-empty rows), so bound the
+    // pre-read to just the empty candidates and skip the SELECT entirely
+    // when there are none — in a real catalog sync almost every stats row is
+    // non-empty, so this keeps the common case free of a batch-wide pre-read.
+    const emptyMappedValues = mappedValues.filter((value) => isEmptyUpstreamClimbStat(value));
+    const existingKeys = new Set<string>();
+    if (emptyMappedValues.length > 0) {
+      const candidateClimbUuids = [...new Set(emptyMappedValues.map((value) => value.climbUuid))];
+      const candidateAngles = [...new Set(emptyMappedValues.map((value) => value.angle))];
+      const existingRows = await db
+        .select({ climbUuid: climbStatsSchema.climbUuid, angle: climbStatsSchema.angle })
+        .from(climbStatsSchema)
+        .where(
+          and(
+            eq(climbStatsSchema.boardType, board),
+            inArray(climbStatsSchema.climbUuid, candidateClimbUuids),
+            inArray(climbStatsSchema.angle, candidateAngles),
+          ),
+        );
+      for (const row of existingRows) existingKeys.add(climbStatKey(row.climbUuid, row.angle));
+    }
     const values = mappedValues.filter(
       (value) => !isEmptyUpstreamClimbStat(value) || existingKeys.has(climbStatKey(value.climbUuid, value.angle)),
     );

--- a/packages/backend/src/__tests__/recompute-climb-stats.test.ts
+++ b/packages/backend/src/__tests__/recompute-climb-stats.test.ts
@@ -1050,7 +1050,7 @@ describe('recomputeClimbStats — provenance matrix (real DB)', () => {
     }
   });
 
-  it('single + bulk: owned averages exclude difficulty 0/1 and quality outside 1..5', async () => {
+  it('single + bulk: owned averages defensively exclude legacy/impossible rating sentinels', async () => {
     await seedUser('u-valid-rating', 'Val');
     await seedUser('u-low-rating', 'Lo');
     await seedUser('u-high-rating', 'Hi');
@@ -1058,6 +1058,9 @@ describe('recomputeClimbStats — provenance matrix (real DB)', () => {
     async function seedInvalidAverageFixture(uuid: string) {
       await seedClimb(KEY.boardType, uuid, 'u-valid-rating');
       await seedStats(KEY.boardType, uuid, KEY.angle, { upstream: 0 });
+      // The production CHECK rejects quality 6. This intentionally reduced test
+      // schema omits that constraint so the query-level defence stays covered for
+      // legacy rows or fixtures loaded with constraints disabled.
       await seedTick({
         boardType: KEY.boardType,
         climbUuid: uuid,

--- a/packages/backend/src/__tests__/recompute-climb-stats.test.ts
+++ b/packages/backend/src/__tests__/recompute-climb-stats.test.ts
@@ -33,10 +33,10 @@ describe('recomputeClimbStats', () => {
   // The seed's behaviour is asserted end to end against real Postgres in the
   // provenance-matrix block below (a phantom key seeds nothing; a real climb at
   // a new angle still does; quality_normalized). What this one pins is the
-  // SHAPE: the seed must stay an INSERT ... SELECT FROM board_climbs so the
-  // catalog lookup IS the guard (#3528). A regression to a plain VALUES insert
-  // — which cannot carry a WHERE — silently un-guards it.
-  it('seeds via INSERT ... SELECT FROM board_climbs so the catalog lookup guards it', async () => {
+  // SHAPE: the seed must stay an INSERT ... SELECT FROM board_climbs with the
+  // correlated qualifying-tick EXISTS. A regression to a plain VALUES insert
+  // — which cannot carry either guard — silently reintroduces phantom rows.
+  it('seeds only through a real climb with a matching non-detached send/flash tick', async () => {
     const executed: unknown[] = [];
     mockDb.transaction.mockImplementation(async (callback: (tx: unknown) => Promise<void>) => {
       const tx = {
@@ -59,6 +59,9 @@ describe('recomputeClimbStats', () => {
     expect(seedSql).toMatch(/SELECT[\s\S]*FROM board_climbs bc/);
     expect(seedSql).toMatch(/WHERE bc\.uuid =/);
     expect(seedSql).toMatch(/AND bc\.board_type =/);
+    expect(seedSql).toContain('FROM boardsesh_ticks seed_tick');
+    expect(seedSql).toContain("seed_tick.status IN ('flash','send')");
+    expect(seedSql).toContain('seed_tick.kilter_detached_at IS NULL');
     expect(seedSql).toContain('quality_normalized');
   });
 
@@ -158,11 +161,10 @@ describe('recomputeClimbStats', () => {
 
     const sql = sqlText(capturedQuery);
 
-    // The agg CTE must compute the averages — Postgres AVG skips NULL inputs,
-    // so a single rated tick is enough to populate the column. quality = 0 is a
-    // legacy sentinel, excluded via NULLIF so it never drags the average down.
-    expect(sql).toMatch(/AVG\(NULLIF\(bt\.quality, 0\)\)\s+AS avg_quality/);
-    expect(sql).toMatch(/AVG\(bt\.difficulty\)\s+AS avg_difficulty/);
+    // The aggregate rejects sentinel/impossible values instead of letting them
+    // drag an owned climb's averages out of range.
+    expect(sql).toMatch(/AVG\(bt\.quality\) FILTER \(WHERE bt\.quality BETWEEN 1 AND 5\)\s+AS avg_quality/);
+    expect(sql).toMatch(/AVG\(bt\.difficulty\) FILTER \(WHERE bt\.difficulty > 1\)\s+AS avg_difficulty/);
 
     // difficulty/display stay ownership-CASE-guarded so Aurora's averages
     // survive untouched on Aurora-synced climbs.
@@ -180,6 +182,8 @@ describe('recomputeClimbStats', () => {
     expect(sql).toMatch(/boardsesh_quality_count\s*=\s*CASE[\s\S]+?NULLIF\(bq\.bs_quality_count, 0\)/);
     expect(sql).toMatch(/DISTINCT ON \(bt\.user_id\)/);
     expect(sql).toContain("bt.origin     = 'native'");
+    expect(sql).toContain('bt.quality <= 5');
+    expect(sql).toMatch(/bs_quality AS \([\s\S]*?bt\.quality <= 5\s+AND bt\.kilter_detached_at IS NULL\s+ORDER BY/);
     expect(sql).toMatch(/ORDER BY bt\.user_id, bt\.climbed_at DESC, bt\.id DESC/);
   });
 
@@ -335,23 +339,27 @@ describe('recomputeClimbStats — provenance matrix (real DB)', () => {
     climbedAt: string;
     kilterId?: string | null;
     kilterSyncedAt?: string | null;
+    kilterDetachedAt?: string | null;
   };
 
   async function seedTick(t: SeedTick) {
     await db.execute(sql`
-      INSERT INTO boardsesh_ticks (uuid, user_id, board_type, climb_uuid, angle, status, origin, attempt_count, quality, difficulty, climbed_at, created_at, updated_at, kilter_id, kilter_synced_at)
-      VALUES (gen_random_uuid()::text, ${t.userId}, ${t.boardType}, ${t.climbUuid}, ${t.angle}, ${t.status}::tick_status, ${t.origin}::tick_origin, 1, ${t.quality ?? null}, ${t.difficulty ?? null}, ${t.climbedAt}, now(), now(), ${t.kilterId ?? null}, ${t.kilterSyncedAt ?? null})
+      INSERT INTO boardsesh_ticks (uuid, user_id, board_type, climb_uuid, angle, status, origin, attempt_count, quality, difficulty, climbed_at, created_at, updated_at, kilter_id, kilter_synced_at, kilter_detached_at)
+      VALUES (gen_random_uuid()::text, ${t.userId}, ${t.boardType}, ${t.climbUuid}, ${t.angle}, ${t.status}::tick_status, ${t.origin}::tick_origin, 1, ${t.quality ?? null}, ${t.difficulty ?? null}, ${t.climbedAt}, now(), now(), ${t.kilterId ?? null}, ${t.kilterSyncedAt ?? null}, ${t.kilterDetachedAt ?? null})
     `);
   }
 
   async function statsRow(boardType: string, uuid: string, angle: number) {
     const rows = (await db.execute(sql`
-      SELECT boardsesh_ascensionist_count AS bs, ascensionist_count AS total, fa_username AS fa, fa_at AS fa_at,
+      SELECT upstream_ascensionist_count AS upstream, boardsesh_ascensionist_count AS bs,
+             ascensionist_count AS total, fa_username AS fa, fa_at AS fa_at,
              quality_average AS quality, upstream_quality_average AS upstream_quality,
-             boardsesh_quality_sum AS bs_quality_sum, boardsesh_quality_count AS bs_quality_count
+             boardsesh_quality_sum AS bs_quality_sum, boardsesh_quality_count AS bs_quality_count,
+             difficulty_average AS difficulty, display_difficulty AS display_difficulty
         FROM board_climb_stats
        WHERE board_type = ${boardType} AND climb_uuid = ${uuid} AND angle = ${angle}
     `)) as unknown as Array<{
+      upstream: number | string | null;
       bs: number | string | null;
       total: number | string | null;
       fa: string | null;
@@ -360,6 +368,8 @@ describe('recomputeClimbStats — provenance matrix (real DB)', () => {
       upstream_quality: number | string | null;
       bs_quality_sum: number | string | null;
       bs_quality_count: number | string | null;
+      difficulty: number | string | null;
+      display_difficulty: number | string | null;
     }>;
     const [row] = Array.isArray(rows) ? rows : (rows as { rows: typeof rows }).rows;
     return row;
@@ -946,6 +956,160 @@ describe('recomputeClimbStats — provenance matrix (real DB)', () => {
     expect(Number(bulk.bs_quality_count)).toBe(Number(single.bs_quality_count));
   });
 
+  it('single + bulk: deleting the last send clears Boardsesh stats but retains upstream count/quality', async () => {
+    await seedUser('u-last-send', 'Lena');
+    for (const uuid of ['CLIMB-LAST-SINGLE', 'CLIMB-LAST-BULK']) {
+      await seedClimb(KEY.boardType, uuid, null);
+      await seedStats(KEY.boardType, uuid, KEY.angle, { upstream: 7, upstreamQuality: 4 });
+      await seedTick({
+        boardType: KEY.boardType,
+        climbUuid: uuid,
+        angle: KEY.angle,
+        userId: 'u-last-send',
+        status: 'send',
+        origin: 'native',
+        quality: 5,
+        climbedAt: '2026-03-01 00:00:00',
+      });
+    }
+
+    await recomputeClimbStatsCore(db, KEY.boardType, 'CLIMB-LAST-SINGLE', KEY.angle);
+    await recomputeClimbStatsBulk(db, [{ boardType: KEY.boardType, climbUuid: 'CLIMB-LAST-BULK', angle: KEY.angle }]);
+    await db.execute(sql`
+      DELETE FROM boardsesh_ticks
+       WHERE board_type = ${KEY.boardType}
+         AND climb_uuid IN ('CLIMB-LAST-SINGLE', 'CLIMB-LAST-BULK')
+         AND angle = ${KEY.angle}
+    `);
+
+    await recomputeClimbStatsCore(db, KEY.boardType, 'CLIMB-LAST-SINGLE', KEY.angle);
+    await recomputeClimbStatsBulk(db, [{ boardType: KEY.boardType, climbUuid: 'CLIMB-LAST-BULK', angle: KEY.angle }]);
+
+    for (const uuid of ['CLIMB-LAST-SINGLE', 'CLIMB-LAST-BULK']) {
+      const row = await statsRow(KEY.boardType, uuid, KEY.angle);
+      expect(Number(row.upstream)).toBe(7);
+      expect(Number(row.bs)).toBe(0);
+      expect(Number(row.total)).toBe(7);
+      expect(Number(row.upstream_quality)).toBe(4);
+      expect(Number(row.quality)).toBe(4);
+      expect(row.bs_quality_sum).toBe(null);
+      expect(row.bs_quality_count).toBe(null);
+    }
+  });
+
+  it('single + bulk: detaching the last rated send clears Boardsesh stats but retains upstream terms', async () => {
+    await seedUser('u-last-attached', 'Della');
+    for (const uuid of ['CLIMB-DETACH-SINGLE', 'CLIMB-DETACH-BULK']) {
+      await seedClimb(KEY.boardType, uuid, null);
+      await seedStats(KEY.boardType, uuid, KEY.angle, { upstream: 7, upstreamQuality: 4 });
+      await seedTick({
+        boardType: KEY.boardType,
+        climbUuid: uuid,
+        angle: KEY.angle,
+        userId: 'u-last-attached',
+        status: 'send',
+        origin: 'native',
+        quality: 5,
+        climbedAt: '2026-03-01 00:00:00',
+      });
+    }
+
+    await recomputeClimbStatsCore(db, KEY.boardType, 'CLIMB-DETACH-SINGLE', KEY.angle);
+    await recomputeClimbStatsBulk(db, [{ boardType: KEY.boardType, climbUuid: 'CLIMB-DETACH-BULK', angle: KEY.angle }]);
+
+    for (const uuid of ['CLIMB-DETACH-SINGLE', 'CLIMB-DETACH-BULK']) {
+      const attached = await statsRow(KEY.boardType, uuid, KEY.angle);
+      expect(Number(attached.upstream)).toBe(7);
+      expect(Number(attached.bs)).toBe(1);
+      expect(Number(attached.total)).toBe(8);
+      expect(Number(attached.bs_quality_sum)).toBe(5);
+      expect(Number(attached.bs_quality_count)).toBe(1);
+      expect(Number(attached.quality)).toBeCloseTo(33 / 8, 6);
+    }
+
+    await db.execute(sql`
+      UPDATE boardsesh_ticks
+         SET kilter_detached_at = '2026-03-02 00:00:00'
+       WHERE board_type = ${KEY.boardType}
+         AND climb_uuid IN ('CLIMB-DETACH-SINGLE', 'CLIMB-DETACH-BULK')
+         AND angle = ${KEY.angle}
+    `);
+
+    await recomputeClimbStatsCore(db, KEY.boardType, 'CLIMB-DETACH-SINGLE', KEY.angle);
+    await recomputeClimbStatsBulk(db, [{ boardType: KEY.boardType, climbUuid: 'CLIMB-DETACH-BULK', angle: KEY.angle }]);
+
+    for (const uuid of ['CLIMB-DETACH-SINGLE', 'CLIMB-DETACH-BULK']) {
+      const detached = await statsRow(KEY.boardType, uuid, KEY.angle);
+      expect(Number(detached.upstream)).toBe(7);
+      expect(Number(detached.bs)).toBe(0);
+      expect(Number(detached.total)).toBe(7);
+      expect(Number(detached.upstream_quality)).toBe(4);
+      expect(Number(detached.quality)).toBe(4);
+      expect(detached.bs_quality_sum).toBe(null);
+      expect(detached.bs_quality_count).toBe(null);
+    }
+  });
+
+  it('single + bulk: owned averages exclude difficulty 0/1 and quality outside 1..5', async () => {
+    await seedUser('u-valid-rating', 'Val');
+    await seedUser('u-low-rating', 'Lo');
+    await seedUser('u-high-rating', 'Hi');
+
+    async function seedInvalidAverageFixture(uuid: string) {
+      await seedClimb(KEY.boardType, uuid, 'u-valid-rating');
+      await seedStats(KEY.boardType, uuid, KEY.angle, { upstream: 0 });
+      await seedTick({
+        boardType: KEY.boardType,
+        climbUuid: uuid,
+        angle: KEY.angle,
+        userId: 'u-valid-rating',
+        status: 'send',
+        origin: 'native',
+        quality: 3,
+        difficulty: 10,
+        climbedAt: '2026-01-01 00:00:00',
+      });
+      await seedTick({
+        boardType: KEY.boardType,
+        climbUuid: uuid,
+        angle: KEY.angle,
+        userId: 'u-low-rating',
+        status: 'send',
+        origin: 'native',
+        quality: 0,
+        difficulty: 0,
+        climbedAt: '2026-01-02 00:00:00',
+      });
+      await seedTick({
+        boardType: KEY.boardType,
+        climbUuid: uuid,
+        angle: KEY.angle,
+        userId: 'u-high-rating',
+        status: 'send',
+        origin: 'native',
+        quality: 6,
+        difficulty: 1,
+        climbedAt: '2026-01-03 00:00:00',
+      });
+    }
+
+    await seedInvalidAverageFixture('CLIMB-GUARD-SINGLE');
+    await seedInvalidAverageFixture('CLIMB-GUARD-BULK');
+    await recomputeClimbStatsCore(db, KEY.boardType, 'CLIMB-GUARD-SINGLE', KEY.angle);
+    await recomputeClimbStatsBulk(db, [{ boardType: KEY.boardType, climbUuid: 'CLIMB-GUARD-BULK', angle: KEY.angle }]);
+
+    const single = await statsRow(KEY.boardType, 'CLIMB-GUARD-SINGLE', KEY.angle);
+    const bulk = await statsRow(KEY.boardType, 'CLIMB-GUARD-BULK', KEY.angle);
+    for (const row of [single, bulk]) {
+      expect(Number(row.difficulty)).toBe(10);
+      expect(Number(row.display_difficulty)).toBe(10);
+      expect(Number(row.quality)).toBe(3);
+    }
+    expect(Number(bulk.difficulty)).toBe(Number(single.difficulty));
+    expect(Number(bulk.display_difficulty)).toBe(Number(single.display_difficulty));
+    expect(Number(bulk.quality)).toBe(Number(single.quality));
+  });
+
   it('single-key recompute produces the same counting result and returns a diff', async () => {
     await seedUser('u-native', 'Nadia');
     await seedUser('u-pull', 'Pedro');
@@ -1072,6 +1236,46 @@ describe('recomputeClimbStats — provenance matrix (real DB)', () => {
     return Number(row.n);
   }
 
+  it('single + bulk: a valid climb with no tick does not seed a stats row', async () => {
+    await seedClimb('kilter', 'CLIMB-NO-TICK-SINGLE', null);
+    await seedClimb('kilter', 'CLIMB-NO-TICK-BULK', null);
+
+    await recomputeClimbStatsCore(db, 'kilter', 'CLIMB-NO-TICK-SINGLE', 40);
+    await recomputeClimbStatsBulk(db, [{ boardType: 'kilter', climbUuid: 'CLIMB-NO-TICK-BULK', angle: 40 }]);
+
+    expect(await statsRowCount('kilter', 'CLIMB-NO-TICK-SINGLE', 40)).toBe(0);
+    expect(await statsRowCount('kilter', 'CLIMB-NO-TICK-BULK', 40)).toBe(0);
+  });
+
+  it('single + bulk: attempt-only and detached-only keys do not seed stats rows', async () => {
+    await seedUser('u-no-seed', 'Nora');
+    const fixtures = [
+      { uuid: 'CLIMB-ATTEMPT-SINGLE', mode: 'single' as const, status: 'attempt' as const },
+      { uuid: 'CLIMB-ATTEMPT-BULK', mode: 'bulk' as const, status: 'attempt' as const },
+      { uuid: 'CLIMB-DETACHED-SINGLE', mode: 'single' as const, status: 'send' as const },
+      { uuid: 'CLIMB-DETACHED-BULK', mode: 'bulk' as const, status: 'send' as const },
+    ];
+    for (const fixture of fixtures) {
+      await seedClimb('kilter', fixture.uuid, null);
+      await seedTick({
+        boardType: 'kilter',
+        climbUuid: fixture.uuid,
+        angle: 40,
+        userId: 'u-no-seed',
+        status: fixture.status,
+        origin: 'native',
+        climbedAt: '2026-01-01 00:00:00',
+        kilterDetachedAt: fixture.uuid.includes('DETACHED') ? '2026-01-02 00:00:00' : null,
+      });
+      if (fixture.mode === 'single') {
+        await recomputeClimbStatsCore(db, 'kilter', fixture.uuid, 40);
+      } else {
+        await recomputeClimbStatsBulk(db, [{ boardType: 'kilter', climbUuid: fixture.uuid, angle: 40 }]);
+      }
+      expect(await statsRowCount('kilter', fixture.uuid, 40)).toBe(0);
+    }
+  });
+
   it('single-key: a tick on a climb missing from board_climbs seeds NO stats row', async () => {
     await seedUser('u-ghost', 'Gia');
     // Deliberately no seedClimb — this is the phantom-UUID case.
@@ -1135,25 +1339,30 @@ describe('recomputeClimbStats — provenance matrix (real DB)', () => {
   // at an angle the catalog has no stats row for still gets one. Anyone who
   // "hardens" the guard from (climb) to (climb, angle) breaks real ticks, and
   // this is the test that tells them.
-  it('a real climb ticked at an angle with no stats row STILL seeds one', async () => {
+  it('single + bulk: a real climb sent at an angle with no stats row STILL seeds one', async () => {
     await seedUser('u-newangle', 'Nia');
-    await seedClimb('kilter', 'CLIMB-ANGLES', null);
-    await seedStats('kilter', 'CLIMB-ANGLES', 40, { upstream: 5 });
-    await seedTick({
-      boardType: 'kilter',
-      climbUuid: 'CLIMB-ANGLES',
-      angle: 25,
-      userId: 'u-newangle',
-      status: 'send',
-      origin: 'native',
-      climbedAt: '2026-01-01 00:00:00',
-    });
+    for (const uuid of ['CLIMB-ANGLES-SINGLE', 'CLIMB-ANGLES-BULK']) {
+      await seedClimb('kilter', uuid, null);
+      await seedStats('kilter', uuid, 40, { upstream: 5 });
+      await seedTick({
+        boardType: 'kilter',
+        climbUuid: uuid,
+        angle: 25,
+        userId: 'u-newangle',
+        status: 'send',
+        origin: 'native',
+        climbedAt: '2026-01-01 00:00:00',
+      });
+    }
 
-    await recomputeClimbStatsCore(db, 'kilter', 'CLIMB-ANGLES', 25);
+    await recomputeClimbStatsCore(db, 'kilter', 'CLIMB-ANGLES-SINGLE', 25);
+    await recomputeClimbStatsBulk(db, [{ boardType: 'kilter', climbUuid: 'CLIMB-ANGLES-BULK', angle: 25 }]);
 
-    const seeded = await statsRow('kilter', 'CLIMB-ANGLES', 25);
-    expect(Number(seeded.bs)).toBe(1);
-    expect(Number(seeded.total)).toBe(1); // no upstream at 25° — 0 + 1 native
+    for (const uuid of ['CLIMB-ANGLES-SINGLE', 'CLIMB-ANGLES-BULK']) {
+      const seeded = await statsRow('kilter', uuid, 25);
+      expect(Number(seeded.bs)).toBe(1);
+      expect(Number(seeded.total)).toBe(1); // no upstream at 25° — 0 + 1 native
+    }
   });
 
   it('seeded rows are marked quality_normalized (the #3529 seed half)', async () => {

--- a/packages/db/scripts/import-aurora-board-unified.ts
+++ b/packages/db/scripts/import-aurora-board-unified.ts
@@ -720,7 +720,7 @@ async function main() {
       // pass a re-run zeroes boardsesh_ascensionist_count AND the quality blend's
       // boardsesh_quality_sum/count (leaving quality_average a stale pure-upstream
       // value). Re-derive them from boardsesh_ticks for every key with >=1
-      // flash/send tick on this board — recomputeClimbStatsBulk rebuilds the
+      // attached flash/send tick on this board — recomputeClimbStatsBulk rebuilds the
       // Boardsesh count, the materialized ascensionist total, the Boardsesh quality
       // terms and the blended quality_average in one set-based pass, updating both
       // the reinserted upstream rows and the preserved owned-climb rows in place;

--- a/packages/db/src/queries/climb-stats/__tests__/recompute.test.ts
+++ b/packages/db/src/queries/climb-stats/__tests__/recompute.test.ts
@@ -35,18 +35,22 @@ void describe('recomputeClimbStatsBulk', () => {
     assert.equal(db.queries.length, 2);
     const seedSql = sqlText(db.queries[0]);
     assert.match(seedSql, /INSERT INTO board_climb_stats/);
-    // Smoke test only — the guard's BEHAVIOUR (phantom key seeds nothing; the
-    // real key beside it in the same chunk is untouched; a real climb ticked at
-    // a new angle still seeds) is asserted against real Postgres in
+    // Smoke test only — the guards' BEHAVIOUR (phantom/no-send keys seed
+    // nothing; a real climb ticked at a new angle still seeds) is asserted
+    // against real Postgres in
     // packages/backend/src/__tests__/recompute-climb-stats.test.ts, because
     // this package has no vitest project and CI never runs its tsx --test suite.
     assert.match(seedSql, /WHERE EXISTS \(\s*SELECT 1\s*FROM board_climbs bc/);
     assert.match(seedSql, /bc\.uuid = k\.climb_uuid/);
     assert.match(seedSql, /bc\.board_type = k\.board_type/);
+    assert.match(seedSql, /FROM boardsesh_ticks seed_tick/);
+    assert.match(seedSql, /seed_tick\.status IN \('flash','send'\)/);
+    assert.match(seedSql, /seed_tick\.kilter_detached_at IS NULL/);
     // Seeded rows are on the 1-5 scale from birth (#3529, seed half).
     assert.match(seedSql, /quality_normalized/);
     const updateSql = sqlText(db.queries[1]);
     assert.match(updateSql, /UPDATE board_climb_stats/);
+    assert.doesNotMatch(updateSql, /seed_tick/);
     // The counting rule + provenance guard must be present in the UPDATE. The
     // upstream-represented flag is scoped to imported FLASH/SEND ticks (an
     // imported bid must not disqualify a native send — upstream ascent counts
@@ -55,8 +59,9 @@ void describe('recomputeClimbStatsBulk', () => {
     // contributing).
     assert.match(updateSql, /bool_or\(bt\.origin <> 'native' AND bt\.status IN \('flash','send'\)\)/);
     assert.match(updateSql, /has_unabsorbed_native_send AND NOT has_upstream/);
-    // Owned-climb quality: quality = 0 sentinel excluded; ascensionist = upstream + boardsesh.
-    assert.match(updateSql, /AVG\(NULLIF\(bt\.quality, 0\)\)/);
+    // Owned-climb averages reject invalid difficulty/quality values.
+    assert.match(updateSql, /AVG\(bt\.quality\) FILTER \(WHERE bt\.quality BETWEEN 1 AND 5\)/);
+    assert.match(updateSql, /AVG\(bt\.difficulty\) FILTER \(WHERE bt\.difficulty > 1\)/);
     // Kilter-detached (upstream-deleted) rows must be excluded from the count.
     assert.match(updateSql, /kilter_detached_at IS NULL/);
     // Quality blend — the Boardsesh side (one vote per climber = LATEST rated
@@ -75,6 +80,8 @@ void describe('recomputeClimbStatsBulk', () => {
     assert.match(updateSql, /DISTINCT ON \(bt\.board_type, bt\.climb_uuid, bt\.angle, bt\.user_id\)/);
     assert.match(updateSql, /bt\.origin = 'native'/);
     assert.match(updateSql, /bt\.quality >= 1/);
+    assert.match(updateSql, /bt\.quality <= 5/);
+    assert.match(updateSql, /bs_quality AS \([\s\S]*?bt\.quality <= 5\s+AND bt\.kilter_detached_at IS NULL\s+ORDER BY/);
     assert.match(updateSql, /ORDER BY[\s\S]*bt\.climbed_at DESC, bt\.id DESC/);
     // Non-owned quality_average is the blend (division by the summed weights),
     // NOT the plain upstream value.

--- a/packages/db/src/queries/climb-stats/recompute.ts
+++ b/packages/db/src/queries/climb-stats/recompute.ts
@@ -372,8 +372,9 @@ function dedupeKeys(keys: ClimbStatsKey[]): ClimbStatsKey[] {
  * noise. Callers pass the DISTINCT keys of the flash/send ticks they wrote.
  *
  * Idempotent: safe to call on a passed transaction (the writer's tx) or a
- * top-level db. Does not open its own transaction — the seed + update are
- * individually idempotent, so a re-run repairs any partial state.
+ * top-level db. Does not open its own transaction. With a top-level db the seed
+ * and update are not atomic; an interruption can leave an empty seed until the
+ * next call, whose individually idempotent statements repair that partial state.
  *
  * Offline propagation: the UPDATE below is a plain SQL UPDATE, so every row
  * whose values actually change fires the BEFORE UPDATE trigger

--- a/packages/db/src/queries/climb-stats/recompute.ts
+++ b/packages/db/src/queries/climb-stats/recompute.ts
@@ -61,22 +61,24 @@ type DrizzleDb = PgDatabase<PgQueryResultHKT, Record<string, unknown>>;
  * Boardsesh's native ratings (blendedQualityAverageSql, quality-blend.ts) — the
  * mirror of how ascensionist_count blends upstream + Boardsesh counts:
  *   - OWNED climbs (board_climbs.user_id NOT NULL): no upstream side, so
- *     quality_average stays a plain AVG(NULLIF(quality, 0)) over ALL flash/send
- *     ticks of any origin. quality = 0 is a legacy sentinel excluded via NULLIF.
+ *     quality_average stays a plain AVG(quality) FILTER (WHERE quality BETWEEN
+ *     1 AND 5) over ALL flash/send ticks of any origin.
  *   - NON-owned climbs: quality_average = blend(upstream_quality_average,
  *     upstream_ascensionist_count, boardsesh_quality_sum, boardsesh_quality_count),
  *     rewritten in the SAME statement that recomputes the Boardsesh terms.
  *
  * The recompute OWNS boardsesh_quality_sum / boardsesh_quality_count (the blend's
  * Boardsesh side), computed as one vote per climber: each climber's LATEST rated
- * native flash/send tick (max climbed_at, tie-break max id) with quality >= 1 and
- * origin = 'native'. A climber re-ticking the same climb does NOT multiply their
- * vote — only their latest rating counts. Imported ratings (aurora_pull /
- * kilter_pull / json_import) are already reflected in upstream_quality_average and
- * are deliberately excluded here so they are not double-counted. The recompute
- * never writes upstream_quality_average (the upstream syncs own it).
+ * native flash/send tick (max climbed_at, tie-break max id) with quality 1..5 and
+ * origin = 'native', excluding detached ticks. A climber re-ticking the same
+ * climb does NOT multiply their vote — only their latest attached rating counts.
+ * Imported ratings (aurora_pull / kilter_pull / json_import) are already reflected
+ * in upstream_quality_average and are deliberately excluded here so they are not
+ * double-counted. The recompute never writes upstream_quality_average (the upstream
+ * syncs own it).
  *
- * The defensive seed is GUARDED on the climb existing in board_climbs (#3528).
+ * The defensive seed is GUARDED on the climb existing in board_climbs (#3528)
+ * AND a matching non-detached flash/send tick still existing at the key.
  * A tick can carry any string as its climb_uuid — saveTick's Zod schema is
  * shape-only and boardsesh_ticks has no FK to board_climbs — so an unguarded
  * seed minted a permanent board_climb_stats row for whatever key a tick landed
@@ -84,11 +86,10 @@ type DrizzleDb = PgDatabase<PgQueryResultHKT, Record<string, unknown>>;
  * orphan rows in prod). Both seeds now insert only when board_climbs has a row
  * for (board_type, climb_uuid); the lookup rides board_climbs_pkey.
  *
- * Deliberately guarded on the CLIMB, not on (climb, angle): a tick at an angle
- * the catalog has no stats row for is legitimate and must still seed — that is
- * the whole reason the seed exists. Tightening this to (climb, angle) would
- * break real ticks. (MoonBoard's wrong-angle rows, #3529, are an identity
- * problem, not an existence one; they belong to the angle-dedup work.)
+ * The tick-existence guard applies ONLY to INSERT. The UPDATE always receives
+ * every requested key so deleting/detaching/downgrading the final send clears
+ * an existing row's Boardsesh-owned aggregates while preserving its upstream
+ * fields. A matching send at a new angle remains legitimate and seeds a row.
  *
  * Seeded rows carry quality_normalized = TRUE. Every value the row can ever
  * hold is on the canonical 1-5 scale: the Boardsesh blend is built from native
@@ -146,12 +147,12 @@ export async function recomputeClimbStats(
     // Defensive seed: set upstream/boardsesh counts to 0 explicitly so the
     // recompute and any later upstream sync both see a sensible baseline.
     //
-    // INSERT ... SELECT FROM board_climbs makes the catalog lookup the guard
-    // itself: board_climbs.uuid is the primary key, so the SELECT yields
-    // exactly one row for a real climb and zero rows for a phantom one, and a
-    // phantom key seeds nothing. When nothing is seeded the UPDATE below simply
-    // matches no row and this function returns undefined — the documented
-    // "UPDATE matched no row" path.
+    // INSERT ... SELECT FROM board_climbs makes the catalog lookup one guard;
+    // the correlated tick EXISTS is the second. The SELECT yields exactly one
+    // row only for a real climb with a matching attached flash/send. When
+    // nothing is seeded the UPDATE below still runs, so an existing row can be
+    // cleared after its final send disappears; a never-seeded key simply
+    // matches no row and this function returns undefined.
     //
     // Raw SQL rather than the drizzle insert builder, and not for lack of
     // trying: `.values()` cannot carry a WHERE at all, and `.insert().select()`
@@ -168,6 +169,15 @@ export async function recomputeClimbStats(
         FROM board_climbs bc
        WHERE bc.uuid = ${climbUuid}
          AND bc.board_type = ${boardType}
+         AND EXISTS (
+           SELECT 1
+             FROM boardsesh_ticks seed_tick
+            WHERE seed_tick.board_type = ${boardType}
+              AND seed_tick.climb_uuid = ${climbUuid}
+              AND seed_tick.angle = ${angle}
+              AND seed_tick.status IN ('flash','send')
+              AND seed_tick.kilter_detached_at IS NULL
+         )
       ON CONFLICT (board_type, climb_uuid, angle) DO NOTHING;
     `);
 
@@ -230,8 +240,8 @@ export async function recomputeClimbStats(
           -- written to boardsesh-OWNED climbs (see the ownership CASE below),
           -- which have no upstream average to double-count against — so every
           -- rating on the climb contributes, wherever the tick later synced.
-          AVG(NULLIF(bt.quality, 0))   AS avg_quality,
-          AVG(bt.difficulty)           AS avg_difficulty,
+          AVG(bt.quality) FILTER (WHERE bt.quality BETWEEN 1 AND 5) AS avg_quality,
+          AVG(bt.difficulty) FILTER (WHERE bt.difficulty > 1)       AS avg_difficulty,
           (SELECT COALESCE(up.display_name, u.name)
              FROM boardsesh_ticks bt2
              JOIN users            u  ON u.id      = bt2.user_id
@@ -267,6 +277,8 @@ export async function recomputeClimbStats(
                AND bt.status IN ('flash','send')
                AND bt.quality IS NOT NULL
                AND bt.quality >= 1
+               AND bt.quality <= 5
+               AND bt.kilter_detached_at IS NULL
              ORDER BY bt.user_id, bt.climbed_at DESC, bt.id DESC
           ) latest
       ),
@@ -395,9 +407,10 @@ export async function recomputeClimbStatsBulk(db: DrizzleDb, keys: ClimbStatsKey
     );
 
     // Defensive seed for keys whose stats row doesn't exist yet (ticks can
-    // arrive at angles the saveClimb seed didn't cover). Guarded on the climb
-    // existing in board_climbs (#3528) — see the module doc. The EXISTS rides
-    // board_climbs_pkey, one probe per key.
+    // arrive at angles the saveClimb seed didn't cover). Guarded on both the
+    // climb existing in board_climbs (#3528) and a matching attached flash/send
+    // tick — see the module doc. Existing keys still reach the UPDATE below
+    // even when that tick guard is now false.
     await db.execute(sql`
       INSERT INTO board_climb_stats (board_type, climb_uuid, angle,
                                      ascensionist_count, upstream_ascensionist_count, boardsesh_ascensionist_count,
@@ -410,6 +423,15 @@ export async function recomputeClimbStatsBulk(db: DrizzleDb, keys: ClimbStatsKey
           WHERE bc.uuid = k.climb_uuid
             AND bc.board_type = k.board_type
        )
+         AND EXISTS (
+           SELECT 1
+             FROM boardsesh_ticks seed_tick
+            WHERE seed_tick.board_type = k.board_type
+              AND seed_tick.climb_uuid = k.climb_uuid
+              AND seed_tick.angle = k.angle
+              AND seed_tick.status IN ('flash','send')
+              AND seed_tick.kilter_detached_at IS NULL
+         )
       ON CONFLICT (board_type, climb_uuid, angle) DO NOTHING;
     `);
 
@@ -467,8 +489,8 @@ export async function recomputeClimbStatsBulk(db: DrizzleDb, keys: ClimbStatsKey
       sends AS (
         SELECT bt.board_type, bt.climb_uuid, bt.angle,
                MIN(bt.climbed_at)                                     AS first_at,
-               AVG(NULLIF(bt.quality, 0))                             AS avg_quality,
-               AVG(bt.difficulty)                                     AS avg_difficulty
+               AVG(bt.quality) FILTER (WHERE bt.quality BETWEEN 1 AND 5) AS avg_quality,
+               AVG(bt.difficulty) FILTER (WHERE bt.difficulty > 1)       AS avg_difficulty
           FROM boardsesh_ticks bt
           JOIN keys k
             ON k.board_type = bt.board_type AND k.climb_uuid = bt.climb_uuid AND k.angle = bt.angle
@@ -506,6 +528,8 @@ export async function recomputeClimbStatsBulk(db: DrizzleDb, keys: ClimbStatsKey
                AND bt.status IN ('flash','send')
                AND bt.quality IS NOT NULL
                AND bt.quality >= 1
+               AND bt.quality <= 5
+               AND bt.kilter_detached_at IS NULL
              ORDER BY bt.board_type, bt.climb_uuid, bt.angle, bt.user_id, bt.climbed_at DESC, bt.id DESC
           ) latest
          GROUP BY latest.board_type, latest.climb_uuid, latest.angle

--- a/packages/db/src/schema/boards/unified.ts
+++ b/packages/db/src/schema/boards/unified.ts
@@ -697,9 +697,9 @@ export const boardClimbStats = pgTable(
     upstreamQualityAverage: doublePrecision('upstream_quality_average'),
     // The blend's Boardsesh numerator: SUM of one vote per climber — each
     // climber's LATEST rated native flash/send tick (max climbed_at, tie-break
-    // max id) with quality >= 1 and origin = 'native'. double so the sum stays
-    // fractional-safe (ratings are integers 1-5 today, but the vote basis may
-    // change). Owned by recomputeClimbStats; upstream writers never touch it.
+    // max id) with quality in 1..5 and origin = 'native'. double so the sum
+    // stays fractional-safe (ratings are integers 1-5 today, but the vote basis
+    // may change). Owned by recomputeClimbStats; upstream writers never touch it.
     boardseshQualitySum: doublePrecision('boardsesh_quality_sum'),
     // The blend's Boardsesh weight: COUNT of the distinct climbers feeding
     // boardsesh_quality_sum (one vote per climber). Owned by recomputeClimbStats.


### PR DESCRIPTION
## Summary

- Normalize Aurora average, display, and benchmark difficulty consistently, rejecting non-finite and sentinel values at or below 1.
- Skip brand-new empty catalog-stat rows while allowing an empty update to clear stale upstream fields without changing Boardsesh contributions.
- Seed recomputed stats only from a real climb with a matching attached send or flash.
- Exclude invalid difficulty, out-of-range quality, and detached ticks from both single-key and bulk recomputation.
- Bound the empty-row existence pre-read to only the empty payloads in a batch, and skip the query entirely when a batch has none — in a real catalog sync almost every stats row is non-empty, so the previous version ran a whole-batch `IN`-list SELECT that was nearly always unused overhead.

Closes #4068

## Release Notes

Climb grades and ratings stay accurate when an upstream board sends empty, invalid, or detached stats.

## Test plan

- Aurora shared-sync: 51 passed
- Backend recompute against real PostgreSQL: 41 passed
- DB recompute SQL-shape block: 5 passed
- `vp run typecheck:aurora`, `vp run typecheck:db`, and `vp run typecheck:backend`
- Scoped `vp check` on all changed files and `git diff --check`
- Independent adversarial review: merge with nits; all nits addressed
- Follow-up automated review: no correctness bugs
- Fable review: existence pre-read narrowed to empty-only candidates, addressed and covered by a new test
- [x] Normal full CI: 2,675 passed, 4 skipped

## Operations note

Migration 0151 repaired only Aurora `difficulty_average = 0`; it did not cover `= 1` or display/benchmark sentinels. This environment has no production database credential, so no production count or mutation was attempted. The normal cursored Aurora re-sync clears those invalid values as it revisits rows; we accept that bounded healing lag rather than add a manual cleanup without measured production scope.

Dev-server smoke skipped: blocked by open #3978 (dev-DB image has `0187_sad_freak`'s schema but not its ledger row, so `vp run dev` stops before startup). Not required for this backend/sync-only change, which is covered by real-Postgres integration tests instead.
