### PR TITLE
fix(sync): retry transient shared sync failures

### DIFF
--- a/docs/aurora-sync.md
+++ b/docs/aurora-sync.md
@@ -8,7 +8,7 @@ The `@boardsesh/aurora-sync` package provides the shared sync implementation. It
 
 1. **CLI** - For local debugging and manual sync runs
 2. **Daemon CLI on a VM** - `aurora-sync daemon` as a long-lived process: picks one user per cycle, syncs their per-user tables, then runs a board-wide shared sync using their fresh Aurora token. This is the production deployment.
-3. **Backend / Vercel cron** - (Removed) Previously a `POST /sync-cron` backend handler and a `/api/internal/user-sync-cron` Vercel route; both removed in favour of the long-lived daemon, which the catalog piggyback's in-memory cooldown needs to survive across cycles.
+3. **Backend / Vercel cron** - (Removed) Previously a `POST /sync-cron` backend handler and a `/api/internal/user-sync-cron` Vercel route; both removed in favour of the long-lived daemon. The shared-sync cooldown is persisted in Postgres, so deploys and overlapping daemon instances share the same per-board gate.
 
 ## Architecture
 
@@ -111,6 +111,22 @@ After every successful per-user sync, the daemon also runs a shared sync for tha
 | kits                       | board_kits                         |
 
 When the climbs upsert sees previously-unseen UUIDs, the daemon also writes `new_climbs_synced` rows into the `notifications` table for each follower of the climb's setter (`setter_follows` and any linked `user_follows` accounts).
+
+The board-wide pull is gated by a synthetic cursor in `board_shared_syncs`.
+PostgreSQL writes the UTC marker and a fresh UUID atomically; each claim returns
+that complete value as its ownership token, and completion updates use it as a
+compare-and-set fence. Client clock skew and duplicate millisecond timestamps
+cannot reuse an identity. If a stalled daemon finishes after another daemon has
+reclaimed the board, the stale finisher cannot replace the newer marker.
+
+The normal cooldown is one hour from the end of the run (configurable through
+`sharedSyncCooldownMs`). Successful runs and permanent or unknown failures keep
+that full cooldown. A canonical `AuroraRequestError` caused by a timeout,
+network failure, rate limit, HTTP 429, or HTTP 500–599 retries after five minutes
+or the configured full cooldown, whichever is shorter. Other 4xx responses,
+invalid credentials, invalid responses, statusless HTTP failures, database
+errors, and arbitrary throws keep the full cooldown. Location refresh failures
+use the same classification because they are part of the board-wide run.
 
 #### Public board locations
 
@@ -263,9 +279,8 @@ op run --env-file=packages/aurora-sync/.env.1password -- bunx aurora-sync daemon
 
 Run `aurora-sync daemon` as a long-lived process (systemd unit, a small VM, or a
 Railway/Fly worker). It loops internally — there is no HTTP endpoint and no
-`CRON_SECRET`; nothing fronts it. A long-lived process is required so the shared-sync
-piggyback's in-memory cooldown holds across cycles (a per-request handler would
-reset it and re-pull the catalog every invocation — see kilter-sync.md).
+`CRON_SECRET`; nothing fronts it. The per-board shared-sync cooldown lives in
+Postgres and remains effective across daemon restarts and overlapping deploys.
 
 ### 1. Environment Variables
 

--- a/docs/branch-deploys.md
+++ b/docs/branch-deploys.md
@@ -1231,7 +1231,7 @@ Sync runs as **long-lived daemon CLIs on a VM**, not as HTTP crons:
 - `aurora-sync daemon` (Kilter/Tension via the Aurora API)
 - `kilter-sync daemon` (Kilter Grips via Keycloak + PowerSync + REST)
 
-The daemons loop internally (one user per cycle, quiet hours, shared/catalog sync piggybacked) and authenticate with stored per-user credentials — nothing fronts them, so there is no `CRON_SECRET`. The earlier Vercel crons (`/api/internal/user-sync-cron`, etc.) and backend handlers (`/sync-cron`, `/kilter-sync-cron`) were removed; a long-lived process is required so the shared/catalog piggyback's in-memory cooldown survives across cycles.
+The daemons loop internally (one user per cycle, quiet hours, shared/catalog sync piggybacked) and authenticate with stored per-user credentials — nothing fronts them, so there is no `CRON_SECRET`. The earlier Vercel crons (`/api/internal/user-sync-cron`, etc.) and backend handlers (`/sync-cron`, `/kilter-sync-cron`) were removed. Shared/catalog cooldowns are persisted in Postgres with per-board compare-and-set claims, so they survive restarts and coordinate overlapping daemon instances.
 
 MoonBoard public locations use a separate manual CLI, `moonboard-sync locations`, because there is no per-user MoonBoard daemon yet.
 

--- a/docs/kilter-sync.md
+++ b/docs/kilter-sync.md
@@ -165,7 +165,15 @@ Wire JSON is **camelCase**. Across 19 listed layouts the catalog is ~424k climbs
 
 ### Cooldown + piggyback
 
-In-memory cooldown (`Map<board, lastRunMs>`, default 1h via `sharedSyncCooldownMs`) mirroring aurora-sync's `maybeRunSharedSync`. After a successful per-user cycle, `runCycleForCredential` calls `maybeRunCatalogSync` with that user's token; a catalog failure is caught and never poisons the user's credential. (Note: aurora-sync uses an in-memory cooldown for this, not `board_shared_syncs`; `board_shared_syncs` stays a per-table watermark store.)
+The per-board cooldown is persisted in `board_shared_syncs` (default 1h via
+`sharedSyncCooldownMs`) and claimed with a single-statement compare-and-set.
+PostgreSQL writes each cursor timestamp with a fresh UUID and returns that
+complete value to fence the completion update, so duplicate or skewed client
+clocks cannot let a stalled finisher overwrite a newer daemon's claim. After a
+successful per-user cycle, `runCycleForCredential` calls `maybeRunCatalogSync`
+with that user's token; success and failure both keep the full cooldown from
+the end of the catalog run, and a catalog failure never poisons the user's
+credential.
 
 ### Prerequisite: fingerprint backfill
 
@@ -364,7 +372,7 @@ The split exists because the error classifier fails open — a non-`KilterApiErr
 
 The daemon loop primitives (`resolveDaemonOptions`, `runDaemonLoop`, quiet-hours math) live in the neutral `@boardsesh/sync-runtime` package; both aurora-sync and kilter-sync consume them. Only the per-cycle work differs.
 
-It runs as a **long-lived CLI process on a VM** — `bunx kilter-sync daemon` (see [CLI](#cli)) — not as a backend HTTP endpoint. A long-lived process is required for the catalog piggyback's in-memory cooldown to hold across cycles; a per-request backend handler would reset it and re-pull the full catalog every invocation. The earlier `/kilter-sync-cron` backend handler (and the aurora `/sync-cron`) were removed in favour of this model, so the backend no longer depends on the sync packages. `CRON_SECRET` is no longer needed for kilter sync — the daemon authenticates to Kilter with the stored per-user refresh token, nothing fronts it.
+It runs as a **long-lived CLI process on a VM** — `bunx kilter-sync daemon` (see [CLI](#cli)) — not as a backend HTTP endpoint. The catalog piggyback's cooldown is persisted in Postgres, so restarts and overlapping deploys share the same per-board gate. The earlier `/kilter-sync-cron` backend handler (and the aurora `/sync-cron`) were removed in favour of this model, so the backend no longer depends on the sync packages. `CRON_SECRET` is no longer needed for kilter sync — the daemon authenticates to Kilter with the stored per-user refresh token, nothing fronts it.
 
 ## CLI
 

--- a/packages/aurora-sync/src/api/errors.test.ts
+++ b/packages/aurora-sync/src/api/errors.test.ts
@@ -5,6 +5,7 @@ import {
   createAuroraResponseError,
   createAuroraTimeoutError,
   isTransientAuroraError,
+  isTransientSharedSyncAuroraError,
 } from './errors';
 
 describe('AuroraRequestError', () => {
@@ -54,5 +55,34 @@ describe('AuroraRequestError', () => {
   it('treats timeout and network failures as transient', () => {
     expect(isTransientAuroraError(createAuroraTimeoutError('https://decoyboardapp.com/sync'))).toBe(true);
     expect(isTransientAuroraError(createAuroraNetworkError('https://decoyboardapp.com/sync'))).toBe(true);
+  });
+});
+
+describe('isTransientSharedSyncAuroraError', () => {
+  it.each([
+    { code: 'timeout', status: undefined, expected: true },
+    { code: 'network', status: undefined, expected: true },
+    { code: 'rate_limited', status: undefined, expected: true },
+    { code: 'http', status: 429, expected: true },
+    { code: 'http', status: 499, expected: false },
+    { code: 'http', status: 500, expected: true },
+    { code: 'http', status: 599, expected: true },
+    { code: 'http', status: 600, expected: false },
+    { code: 'http', status: undefined, expected: false },
+    { code: 'invalid_credentials', status: 422, expected: false },
+    { code: 'invalid_response', status: undefined, expected: false },
+  ] as const)('classifies $code with HTTP $status as transient=$expected', ({ code, status, expected }) => {
+    const error = new AuroraRequestError({
+      code,
+      message: `${code} failure`,
+      status,
+    });
+
+    expect(isTransientSharedSyncAuroraError(error)).toBe(expected);
+  });
+
+  it('rejects arbitrary errors and Aurora-shaped plain objects', () => {
+    expect(isTransientSharedSyncAuroraError(new Error('database unavailable'))).toBe(false);
+    expect(isTransientSharedSyncAuroraError({ code: 'timeout', transient: true })).toBe(false);
   });
 });

--- a/packages/aurora-sync/src/api/errors.ts
+++ b/packages/aurora-sync/src/api/errors.ts
@@ -57,6 +57,31 @@ export function isTransientAuroraError(error: unknown): error is AuroraRequestEr
   return isAuroraRequestError(error) && error.transient;
 }
 
+/**
+ * Narrow retry classifier for the board-wide shared sync.
+ *
+ * The general Aurora classifier intentionally treats every HTTP error and an
+ * invalid response as transient for credential login. Shared sync has a
+ * different failure contract: shortening its persisted cooldown is safe only
+ * for canonical transport/rate-limit failures and server-side HTTP failures.
+ * Unknown throws, malformed responses, statusless HTTP errors and client-side
+ * HTTP failures keep the full cooldown so a deterministic failure cannot loop
+ * every daemon cycle.
+ */
+export function isTransientSharedSyncAuroraError(error: unknown): error is AuroraRequestError {
+  if (!isAuroraRequestError(error)) return false;
+
+  if (error.code === 'timeout' || error.code === 'network' || error.code === 'rate_limited') {
+    return true;
+  }
+
+  return (
+    error.code === 'http' &&
+    error.status !== undefined &&
+    (error.status === 429 || (error.status >= 500 && error.status <= 599))
+  );
+}
+
 export async function assertAuroraResponseOk(
   response: Response,
   url: string,

--- a/packages/aurora-sync/src/runner/sync-runner.test.ts
+++ b/packages/aurora-sync/src/runner/sync-runner.test.ts
@@ -2,7 +2,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR } from '@boardsesh/shared-schema/sync-error-codes';
 import { SHARED_SYNC_COOLDOWN_CURSOR } from '@boardsesh/db/queries';
 import { AuroraRequestError } from '../api/errors';
-import { CredentialSyncError, formatSyncHealthSummary, SyncRunner, type SyncHealthSnapshot } from './sync-runner';
+import {
+  CredentialSyncError,
+  formatSyncHealthSummary,
+  sharedSyncCooldownAfterError,
+  SyncRunner,
+  type SyncHealthSnapshot,
+} from './sync-runner';
 import type { AuroraBoardName } from '../api/types';
 import type { CredentialRecord, SyncErrorContext } from './types';
 
@@ -373,7 +379,7 @@ describe('SyncRunner shared-sync per-board throttle', () => {
     mockSyncAuroraBoardLocations.mockResolvedValue({ boardsSeen: 0, boardsUpserted: 0, boardsSkipped: 0 });
     mockClaimSharedSyncSlot.mockReset();
     mockStampSharedSyncFinished.mockReset();
-    mockStampSharedSyncFinished.mockResolvedValue(undefined);
+    mockStampSharedSyncFinished.mockResolvedValue(true);
     mockReadSharedSyncCursor.mockReset();
     mockReadSharedSyncCursor.mockResolvedValue(new Date(Date.now() - 60_000));
     // postgres-js is lazy; getClient() builds a client object but won't open a
@@ -383,7 +389,7 @@ describe('SyncRunner shared-sync per-board throttle', () => {
   });
 
   it('claims the persisted cooldown slot before running, keyed on the board', async () => {
-    mockClaimSharedSyncSlot.mockResolvedValue(true);
+    mockClaimSharedSyncSlot.mockResolvedValue('2026-07-31 23:00:00.000000');
     const runner = new SyncRunner({ sharedSyncCooldownMs: 60_000 });
     const runnerPrivates = runner as unknown as SyncRunnerPrivates;
 
@@ -402,7 +408,7 @@ describe('SyncRunner shared-sync per-board throttle', () => {
 
   it('skips the whole run when the slot is already claimed', async () => {
     // The refusal every instance-2 and every within-cooldown cycle gets.
-    mockClaimSharedSyncSlot.mockResolvedValue(false);
+    mockClaimSharedSyncSlot.mockResolvedValue(null);
     const runner = new SyncRunner({ sharedSyncCooldownMs: 60_000 });
     const runnerPrivates = runner as unknown as SyncRunnerPrivates;
 
@@ -416,7 +422,7 @@ describe('SyncRunner shared-sync per-board throttle', () => {
   });
 
   it('re-stamps the cursor after a successful run so the cooldown starts at the end', async () => {
-    mockClaimSharedSyncSlot.mockResolvedValue(true);
+    mockClaimSharedSyncSlot.mockResolvedValue('2026-07-31 23:00:00.000000');
     const runner = new SyncRunner({ sharedSyncCooldownMs: 60_000 });
     const runnerPrivates = runner as unknown as SyncRunnerPrivates;
 
@@ -426,11 +432,14 @@ describe('SyncRunner shared-sync per-board throttle', () => {
     expect(mockStampSharedSyncFinished.mock.calls[0][1]).toMatchObject({
       boardType: 'decoy',
       cursorName: SHARED_SYNC_COOLDOWN_CURSOR,
+      claimToken: '2026-07-31 23:00:00.000000',
+      fullCooldownMs: 60_000,
+      nextCooldownMs: 60_000,
     });
   });
 
-  it('re-stamps the cursor when the run failed, so a broken board does not loop every cycle', async () => {
-    mockClaimSharedSyncSlot.mockResolvedValue(true);
+  it('keeps the full cooldown after an unknown failure, so a broken board does not loop every cycle', async () => {
+    mockClaimSharedSyncSlot.mockResolvedValue('2026-07-31 23:00:00.000000');
     mockSyncSharedData.mockRejectedValueOnce(new Error('aurora down'));
     const runner = new SyncRunner({ sharedSyncCooldownMs: 60_000 });
     const runnerPrivates = runner as unknown as SyncRunnerPrivates;
@@ -439,6 +448,89 @@ describe('SyncRunner shared-sync per-board throttle', () => {
 
     expect(mockSyncAuroraBoardLocations).not.toHaveBeenCalled();
     expect(mockStampSharedSyncFinished).toHaveBeenCalledTimes(1);
+    expect(mockStampSharedSyncFinished.mock.calls[0][1]).toMatchObject({
+      fullCooldownMs: 60_000,
+      nextCooldownMs: 60_000,
+    });
+  });
+
+  it('uses a five-minute cooldown after a transient Aurora shared-sync failure', async () => {
+    mockClaimSharedSyncSlot.mockResolvedValue('2026-07-31 23:00:00.000000');
+    mockSyncSharedData.mockRejectedValueOnce(
+      new AuroraRequestError({
+        code: 'http',
+        message: 'Aurora HTTP 503 Service Unavailable',
+        status: 503,
+      }),
+    );
+    const runner = new SyncRunner({ sharedSyncCooldownMs: 60 * 60 * 1000 });
+    const runnerPrivates = runner as unknown as SyncRunnerPrivates;
+
+    await runnerPrivates.maybeRunSharedSync('decoy', 'tok', 'u1');
+
+    expect(mockStampSharedSyncFinished.mock.calls[0][1]).toMatchObject({
+      fullCooldownMs: 60 * 60 * 1000,
+      nextCooldownMs: 5 * 60 * 1000,
+    });
+  });
+
+  it('keeps the full cooldown after a permanent Aurora client failure', async () => {
+    mockClaimSharedSyncSlot.mockResolvedValue('2026-07-31 23:00:00.000000');
+    mockSyncSharedData.mockRejectedValueOnce(
+      new AuroraRequestError({
+        code: 'http',
+        message: 'Aurora HTTP 404 Not Found',
+        status: 404,
+      }),
+    );
+    const runner = new SyncRunner({ sharedSyncCooldownMs: 60 * 60 * 1000 });
+    const runnerPrivates = runner as unknown as SyncRunnerPrivates;
+
+    await runnerPrivates.maybeRunSharedSync('decoy', 'tok', 'u1');
+
+    expect(mockStampSharedSyncFinished.mock.calls[0][1]).toMatchObject({
+      fullCooldownMs: 60 * 60 * 1000,
+      nextCooldownMs: 60 * 60 * 1000,
+    });
+  });
+
+  it('uses the transient cooldown when the location refresh fails with a canonical network error', async () => {
+    mockClaimSharedSyncSlot.mockResolvedValue('2026-07-31 23:00:00.000000');
+    mockSyncAuroraBoardLocations.mockRejectedValueOnce(
+      new AuroraRequestError({
+        code: 'network',
+        message: 'Aurora pins request failed',
+      }),
+    );
+    const runner = new SyncRunner({ sharedSyncCooldownMs: 60 * 60 * 1000 });
+    const runnerPrivates = runner as unknown as SyncRunnerPrivates;
+
+    await runnerPrivates.maybeRunSharedSync('decoy', 'tok', 'u1');
+
+    expect(mockSyncSharedData).toHaveBeenCalledTimes(1);
+    expect(mockSyncAuroraBoardLocations).toHaveBeenCalledTimes(1);
+    expect(mockStampSharedSyncFinished.mock.calls[0][1]).toMatchObject({
+      fullCooldownMs: 60 * 60 * 1000,
+      nextCooldownMs: 5 * 60 * 1000,
+    });
+  });
+
+  it('swallows lost claim ownership without reporting a credential failure', async () => {
+    mockClaimSharedSyncSlot.mockResolvedValue('2026-07-31 23:00:00.000000');
+    mockStampSharedSyncFinished.mockResolvedValue(false);
+    const onError = vi.fn();
+    const logs: string[] = [];
+    const runner = new SyncRunner({
+      sharedSyncCooldownMs: 60_000,
+      onError,
+      onLog: (message) => logs.push(message),
+    });
+    const runnerPrivates = runner as unknown as SyncRunnerPrivates;
+
+    await expect(runnerPrivates.maybeRunSharedSync('decoy', 'tok', 'u1')).resolves.toBeUndefined();
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(logs.some((message) => message.includes('leaving the newer cursor intact'))).toBe(true);
   });
 
   it('a claim DB error never escapes into the credential status', async () => {
@@ -460,7 +552,7 @@ describe('SyncRunner shared-sync per-board throttle', () => {
   it('a re-stamp DB error never escapes either, on the success path or the failure path', async () => {
     // Same reasoning for the finally-block stamp. Worst case of a missed stamp
     // is that the cooldown measures from the start of the run instead of its end.
-    mockClaimSharedSyncSlot.mockResolvedValue(true);
+    mockClaimSharedSyncSlot.mockResolvedValue('2026-07-31 23:00:00.000000');
     mockStampSharedSyncFinished.mockRejectedValue(new Error('connection reset'));
     const onError = vi.fn();
     const runner = new SyncRunner({ sharedSyncCooldownMs: 60_000, onError });
@@ -478,7 +570,7 @@ describe('SyncRunner shared-sync per-board throttle', () => {
   });
 
   it('claims per board independently', async () => {
-    mockClaimSharedSyncSlot.mockResolvedValue(true);
+    mockClaimSharedSyncSlot.mockResolvedValue('2026-07-31 23:00:00.000000');
     const runner = new SyncRunner({ sharedSyncCooldownMs: 60_000 });
     const runnerPrivates = runner as unknown as SyncRunnerPrivates;
 
@@ -493,6 +585,26 @@ describe('SyncRunner shared-sync per-board throttle', () => {
       'grasshopper',
     ]);
     expect(mockSyncSharedData.mock.calls.map((call) => call[1])).toEqual(['decoy', 'tension', 'grasshopper']);
+  });
+});
+
+describe('sharedSyncCooldownAfterError', () => {
+  const transientError = new AuroraRequestError({
+    code: 'timeout',
+    message: 'Aurora request timed out',
+  });
+
+  it('clamps the transient retry to five minutes for the default one-hour cooldown', () => {
+    expect(sharedSyncCooldownAfterError(transientError, 60 * 60 * 1000)).toBe(5 * 60 * 1000);
+  });
+
+  it('does not lengthen a configured cooldown shorter than five minutes', () => {
+    expect(sharedSyncCooldownAfterError(transientError, 60_000)).toBe(60_000);
+  });
+
+  it('keeps the full configured cooldown at the five-minute boundary and for unknown errors', () => {
+    expect(sharedSyncCooldownAfterError(transientError, 5 * 60 * 1000)).toBe(5 * 60 * 1000);
+    expect(sharedSyncCooldownAfterError(new Error('database failed'), 60 * 60 * 1000)).toBe(60 * 60 * 1000);
   });
 });
 

--- a/packages/aurora-sync/src/runner/sync-runner.ts
+++ b/packages/aurora-sync/src/runner/sync-runner.ts
@@ -17,6 +17,7 @@ import {
   releaseDaemonLease,
   selfHealStaleClimbStats,
   stampSharedSyncFinished,
+  type SharedSyncClaimToken,
 } from '@boardsesh/db/queries';
 import { DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR } from '@boardsesh/shared-schema/sync-error-codes';
 import { syncUserData, hasForeignOwnedCircuitPlaylists } from '../sync/user-sync';
@@ -28,7 +29,7 @@ import {
   type AuroraLocationBoardName,
 } from '../sync/locations-sync';
 import { AuroraClimbingClient } from '../api/aurora-client';
-import { isAuroraRequestError, isTransientAuroraError } from '../api/errors';
+import { isAuroraRequestError, isTransientAuroraError, isTransientSharedSyncAuroraError } from '../api/errors';
 import { decrypt, encrypt } from '@boardsesh/crypto';
 import type { LocationSyncSummary } from '@boardsesh/location-sync';
 import type { AuroraBoardName } from '../api/types';
@@ -46,7 +47,22 @@ type RunnerDb = ReturnType<typeof drizzle>;
 // 1 hour matches the smallest unit of meaningful change for board-wide data
 // (climbs, climb_stats); tune via SyncRunnerConfig.sharedSyncCooldownMs.
 const DEFAULT_SHARED_SYNC_COOLDOWN_MS = 60 * 60 * 1000;
+const TRANSIENT_SHARED_SYNC_COOLDOWN_MS = 5 * 60 * 1000;
 const MAX_CREDENTIAL_FAILURES = 2;
+
+/**
+ * Resolve the cooldown to apply after a failed shared sync. Only the narrow
+ * canonical Aurora failures classified as retryable get the five-minute path;
+ * every other throw keeps the configured full cooldown. The retry is clamped
+ * to the full cooldown so a test/local configuration below five minutes is
+ * never lengthened by failure handling.
+ */
+export function sharedSyncCooldownAfterError(error: unknown, configuredCooldownMs: number): number {
+  const fullCooldownMs = Math.max(0, configuredCooldownMs);
+  return isTransientSharedSyncAuroraError(error)
+    ? Math.min(TRANSIENT_SHARED_SYNC_COOLDOWN_MS, fullCooldownMs)
+    : fullCooldownMs;
+}
 
 // aurora-sync owns every board EXCEPT kilter (which kilter-sync drives via its
 // own OAuth flow), so every credential query here excludes this board_type.
@@ -146,7 +162,7 @@ export class SyncRunner {
   }
 
   private getSharedSyncCooldownMs(): number {
-    return this.config.sharedSyncCooldownMs ?? DEFAULT_SHARED_SYNC_COOLDOWN_MS;
+    return Math.max(0, this.config.sharedSyncCooldownMs ?? DEFAULT_SHARED_SYNC_COOLDOWN_MS);
   }
 
   private getClient(): { client: RunnerClient; db: RunnerDb } {
@@ -630,10 +646,10 @@ export class SyncRunner {
     // committed and been marked active, and letting the claim throw would
     // bubble into syncSingleCredential's caller and record a spurious
     // credential failure for a user whose sync actually succeeded.
-    let claimed = false;
+    let claimToken: SharedSyncClaimToken | null = null;
     try {
-      claimed = await claimSharedSyncSlot(db, { ...cursor, cooldownMs });
-      if (!claimed) {
+      claimToken = await claimSharedSyncSlot(db, { ...cursor, cooldownMs });
+      if (claimToken === null) {
         const lastRunAt = await readSharedSyncCursor(db, cursor);
         const agoSeconds = lastRunAt ? Math.round((Date.now() - lastRunAt.getTime()) / 1000) : null;
         this.log(
@@ -652,8 +668,9 @@ export class SyncRunner {
       return;
     }
 
-    if (!claimed) return;
+    if (claimToken === null) return;
 
+    let nextCooldownMs = cooldownMs;
     try {
       this.log(`[SyncRunner] Running shared sync for ${boardType} using ${userId}'s token...`);
       await syncSharedData(client, boardType, token, this.log.bind(this));
@@ -661,20 +678,23 @@ export class SyncRunner {
         await syncAuroraBoardLocations({ db, board: boardType, log: this.log.bind(this) });
       }
     } catch (sharedError) {
+      nextCooldownMs = sharedSyncCooldownAfterError(sharedError, cooldownMs);
       const sharedErrorMessage = this.formatErrorMessage(sharedError);
       this.handleError(sharedError instanceof Error ? sharedError : new Error(sharedErrorMessage), {
         board: boardType,
         userId,
       });
-      this.log(`[SyncRunner] Shared sync for ${boardType} failed (user sync was OK): ${sharedErrorMessage}`);
+      this.log(
+        `[SyncRunner] Shared sync for ${boardType} failed (user sync was OK; retry cooldown ${Math.round(
+          nextCooldownMs / 1000,
+        )}s): ${sharedErrorMessage}`,
+      );
     } finally {
-      // Stamp on success AND failure, so the cooldown runs from the END of the
-      // work and a permanently failing board doesn't re-fire every cycle. In a
-      // `finally` with its own error handling: this runs after the user-half has
-      // already committed and been marked active, so a DB error here must never
-      // escape into syncSingleCredential's caller and record a credential
-      // failure for a user whose sync actually succeeded.
-      await this.stampSharedSyncFinishedSafely(db, cursor, boardType);
+      // Success and permanent/unknown failures get the full cooldown from the
+      // end of the work. Canonical transient Aurora failures get the shorter
+      // retry cooldown. Finalization is fenced by claimToken, so a stalled
+      // finisher cannot overwrite a newer claimant's full marker.
+      await this.stampSharedSyncFinishedSafely(db, cursor, boardType, claimToken, cooldownMs, nextCooldownMs);
     }
   }
 
@@ -689,9 +709,20 @@ export class SyncRunner {
     db: RunnerDb,
     cursor: { boardType: string; cursorName: string },
     boardType: string,
+    claimToken: SharedSyncClaimToken,
+    fullCooldownMs: number,
+    nextCooldownMs: number,
   ): Promise<void> {
     try {
-      await stampSharedSyncFinished(db, cursor);
+      const finalized = await stampSharedSyncFinished(db, {
+        ...cursor,
+        claimToken,
+        fullCooldownMs,
+        nextCooldownMs,
+      });
+      if (!finalized) {
+        this.log(`[SyncRunner] Shared-sync claim ownership changed for ${boardType}; leaving the newer cursor intact`);
+      }
     } catch (stampError) {
       const stampErrorMessage = this.formatErrorMessage(stampError);
       this.handleError(stampError instanceof Error ? stampError : new Error(stampErrorMessage), { board: boardType });

--- a/packages/aurora-sync/src/runner/sync-runner.ts
+++ b/packages/aurora-sync/src/runner/sync-runner.ts
@@ -657,6 +657,7 @@ export class SyncRunner {
             agoSeconds === null ? 'unknown' : `${agoSeconds}s`
           } ago; cooldown ${Math.round(cooldownMs / 1000)}s)`,
         );
+        return;
       }
     } catch (claimError) {
       const claimErrorMessage = this.formatErrorMessage(claimError);
@@ -667,8 +668,6 @@ export class SyncRunner {
       this.log(`[SyncRunner] Could not claim the shared-sync slot for ${boardType}: ${claimErrorMessage}`);
       return;
     }
-
-    if (claimToken === null) return;
 
     let nextCooldownMs = cooldownMs;
     try {

--- a/packages/backend/src/__tests__/shared-sync-cooldown-cas.test.ts
+++ b/packages/backend/src/__tests__/shared-sync-cooldown-cas.test.ts
@@ -30,9 +30,31 @@ import {
 const BOARD = 'cooldown-cas-test-board';
 const COOLDOWN_MS = 60 * 60 * 1000;
 const CURSOR = { boardType: BOARD, cursorName: SHARED_SYNC_COOLDOWN_CURSOR };
+const DB_CLOCK_TOLERANCE_MS = 5_000;
+
+async function claimCursor(): Promise<string> {
+  const claimToken = await claimSharedSyncSlot(db, { ...CURSOR, cooldownMs: COOLDOWN_MS });
+  expect(claimToken).not.toBeNull();
+  if (claimToken === null) throw new Error('Expected the shared-sync cooldown claim to succeed');
+  return claimToken;
+}
 
 async function clearFixtures(): Promise<void> {
   await db.delete(boardSharedSyncs).where(eq(boardSharedSyncs.boardType, BOARD));
+}
+
+async function readRawCursor(): Promise<string | null> {
+  const rows = await db
+    .select({ lastSynchronizedAt: boardSharedSyncs.lastSynchronizedAt })
+    .from(boardSharedSyncs)
+    .where(and(eq(boardSharedSyncs.boardType, BOARD), eq(boardSharedSyncs.tableName, SHARED_SYNC_COOLDOWN_CURSOR)));
+  return rows[0]?.lastSynchronizedAt ?? null;
+}
+
+function expectMarkerNear(marker: Date | null, expectedAtMs: number): void {
+  expect(marker).not.toBeNull();
+  if (marker === null) return;
+  expect(Math.abs(marker.getTime() - expectedAtMs)).toBeLessThanOrEqual(DB_CLOCK_TOLERANCE_MS);
 }
 
 /** Backdate the cursor so the cooldown reads as elapsed, without waiting an hour. */
@@ -40,7 +62,7 @@ async function backdateCursor(interval: string): Promise<void> {
   await db
     .update(boardSharedSyncs)
     .set({
-      lastSynchronizedAt: sql`to_char((now() at time zone 'utc') - ${sql.raw(interval)}, 'YYYY-MM-DD HH24:MI:SS.US')`,
+      lastSynchronizedAt: sql`to_char((clock_timestamp() at time zone 'utc') - ${sql.raw(interval)}, 'YYYY-MM-DD HH24:MI:SS.US')`,
     })
     .where(and(eq(boardSharedSyncs.boardType, BOARD), eq(boardSharedSyncs.tableName, SHARED_SYNC_COOLDOWN_CURSOR)));
 }
@@ -50,23 +72,23 @@ describe('shared-sync cooldown compare-and-set (real DB)', () => {
   afterEach(clearFixtures);
 
   it('claims a cursor that has never run, then refuses the immediate second claim', async () => {
-    expect(await claimSharedSyncSlot(db, { ...CURSOR, cooldownMs: COOLDOWN_MS })).toBe(true);
-    expect(await claimSharedSyncSlot(db, { ...CURSOR, cooldownMs: COOLDOWN_MS })).toBe(false);
+    await claimCursor();
+    expect(await claimSharedSyncSlot(db, { ...CURSOR, cooldownMs: COOLDOWN_MS })).toBeNull();
   });
 
   it('survives a restart: a fresh process claims nothing while the cursor is warm', async () => {
-    expect(await claimSharedSyncSlot(db, { ...CURSOR, cooldownMs: COOLDOWN_MS })).toBe(true);
+    await claimCursor();
 
     // Nothing is carried in memory — a brand-new SyncRunner in a brand-new
     // container asks the same question of the same row and is turned away. This
     // is the "every deploy re-fires a full shared sync" half of the bug.
-    expect(await claimSharedSyncSlot(db, { ...CURSOR, cooldownMs: COOLDOWN_MS })).toBe(false);
+    expect(await claimSharedSyncSlot(db, { ...CURSOR, cooldownMs: COOLDOWN_MS })).toBeNull();
   });
 
   it('re-claims once the cooldown has elapsed', async () => {
-    expect(await claimSharedSyncSlot(db, { ...CURSOR, cooldownMs: COOLDOWN_MS })).toBe(true);
+    await claimCursor();
     await backdateCursor(`interval '90 minutes'`);
-    expect(await claimSharedSyncSlot(db, { ...CURSOR, cooldownMs: COOLDOWN_MS })).toBe(true);
+    await claimCursor();
   });
 
   it('exactly one of five parallel claims wins on a cold cursor', async () => {
@@ -77,11 +99,11 @@ describe('shared-sync cooldown compare-and-set (real DB)', () => {
       Array.from({ length: 5 }, () => claimSharedSyncSlot(db, { ...CURSOR, cooldownMs: COOLDOWN_MS })),
     );
 
-    expect(outcomes.filter(Boolean)).toHaveLength(1);
+    expect(outcomes.filter((claimToken) => claimToken !== null)).toHaveLength(1);
   });
 
   it('exactly one of five parallel claims wins on a cursor whose cooldown just elapsed', async () => {
-    expect(await claimSharedSyncSlot(db, { ...CURSOR, cooldownMs: COOLDOWN_MS })).toBe(true);
+    await claimCursor();
     await backdateCursor(`interval '90 minutes'`);
 
     // The UPDATE path of the CAS, not the INSERT path — the case two
@@ -90,32 +112,136 @@ describe('shared-sync cooldown compare-and-set (real DB)', () => {
       Array.from({ length: 5 }, () => claimSharedSyncSlot(db, { ...CURSOR, cooldownMs: COOLDOWN_MS })),
     );
 
-    expect(outcomes.filter(Boolean)).toHaveLength(1);
+    expect(outcomes.filter((claimToken) => claimToken !== null)).toHaveLength(1);
   });
 
   it('re-stamps on completion so the cooldown runs from the end of the work', async () => {
-    expect(await claimSharedSyncSlot(db, { ...CURSOR, cooldownMs: COOLDOWN_MS })).toBe(true);
-    const atClaim = await readSharedSyncCursor(db, CURSOR);
-    expect(atClaim).not.toBeNull();
-
-    // A long shared sync: pretend it ran for 20 minutes, then finish.
-    await backdateCursor(`interval '20 minutes'`);
-    await stampSharedSyncFinished(db, CURSOR);
+    const claimToken = await claimCursor();
+    const completionStartedAtMs = Date.now();
+    expect(
+      await stampSharedSyncFinished(db, {
+        ...CURSOR,
+        claimToken,
+        fullCooldownMs: COOLDOWN_MS,
+      }),
+    ).toBe(true);
 
     const atFinish = await readSharedSyncCursor(db, CURSOR);
-    expect(atFinish).not.toBeNull();
-    expect(atFinish!.getTime()).toBeGreaterThan(atClaim!.getTime() - 60_000);
+    expectMarkerNear(atFinish, completionStartedAtMs);
+    expect(await readRawCursor()).toContain('#finished:');
     // And the full cooldown still applies from the finish, not the start.
-    expect(await claimSharedSyncSlot(db, { ...CURSOR, cooldownMs: COOLDOWN_MS })).toBe(false);
+    expect(await claimSharedSyncSlot(db, { ...CURSOR, cooldownMs: COOLDOWN_MS })).toBeNull();
+  });
+
+  it('allows exactly one parallel finisher to consume a claim token', async () => {
+    const claimToken = await claimCursor();
+
+    const outcomes = await Promise.all(
+      Array.from({ length: 5 }, () =>
+        stampSharedSyncFinished(db, {
+          ...CURSOR,
+          claimToken,
+          fullCooldownMs: COOLDOWN_MS,
+        }),
+      ),
+    );
+
+    expect(outcomes.filter((finalized) => finalized)).toHaveLength(1);
+  });
+
+  it('rejects a stale finisher when duplicate skewed client timestamps are reused', async () => {
+    // This is the adversarial case the old client-clock token could not fence:
+    // both claims were minted from the same millisecond in 2099, so the stale
+    // token equalled the replacement token. The `now` compatibility input is
+    // deliberately ignored; Postgres supplies both time and a fresh UUID.
+    const duplicateSkewedClientNow = new Date('2099-01-01T00:00:00.123Z');
+    const staleClaimToken = await claimSharedSyncSlot(db, {
+      ...CURSOR,
+      cooldownMs: COOLDOWN_MS,
+      now: duplicateSkewedClientNow,
+    });
+    if (staleClaimToken === null) throw new Error('Expected the stale claim to succeed');
+    await backdateCursor(`interval '90 minutes'`);
+    const currentClaimToken = await claimSharedSyncSlot(db, {
+      ...CURSOR,
+      cooldownMs: COOLDOWN_MS,
+      now: duplicateSkewedClientNow,
+    });
+    if (currentClaimToken === null) throw new Error('Expected the replacement claim to succeed');
+
+    expect(currentClaimToken).not.toBe(staleClaimToken);
+    expect(currentClaimToken).toContain('#claim:');
+    expectMarkerNear(await readSharedSyncCursor(db, CURSOR), Date.now());
+
+    expect(
+      await stampSharedSyncFinished(db, {
+        ...CURSOR,
+        claimToken: currentClaimToken,
+        fullCooldownMs: COOLDOWN_MS,
+        nextCooldownMs: COOLDOWN_MS,
+        now: duplicateSkewedClientNow,
+      }),
+    ).toBe(true);
+    const currentFullMarker = await readRawCursor();
+    expect(currentFullMarker).toContain('#finished:');
+
+    expect(
+      await stampSharedSyncFinished(db, {
+        ...CURSOR,
+        claimToken: staleClaimToken,
+        fullCooldownMs: COOLDOWN_MS,
+        nextCooldownMs: 5 * 60 * 1000,
+        now: duplicateSkewedClientNow,
+      }),
+    ).toBe(false);
+    expect(await readRawCursor()).toBe(currentFullMarker);
+    expect(await claimSharedSyncSlot(db, { ...CURSOR, cooldownMs: COOLDOWN_MS })).toBeNull();
+  });
+
+  it('encodes a shorter completion cooldown and clamps it to the configured full cooldown', async () => {
+    const claimToken = await claimCursor();
+    const transientCompletionStartedAtMs = Date.now();
+
+    expect(
+      await stampSharedSyncFinished(db, {
+        ...CURSOR,
+        claimToken,
+        fullCooldownMs: COOLDOWN_MS,
+        nextCooldownMs: 5 * 60 * 1000,
+      }),
+    ).toBe(true);
+    expectMarkerNear(
+      await readSharedSyncCursor(db, CURSOR),
+      transientCompletionStartedAtMs - (COOLDOWN_MS - 5 * 60 * 1000),
+    );
+
+    await clearFixtures();
+    const shortFullCooldownMs = 60_000;
+    const shortClaimToken = await claimSharedSyncSlot(db, {
+      ...CURSOR,
+      cooldownMs: shortFullCooldownMs,
+    });
+    if (shortClaimToken === null) throw new Error('Expected the short cooldown claim to succeed');
+    const clampedCompletionStartedAtMs = Date.now();
+
+    expect(
+      await stampSharedSyncFinished(db, {
+        ...CURSOR,
+        claimToken: shortClaimToken,
+        fullCooldownMs: shortFullCooldownMs,
+        nextCooldownMs: 5 * 60 * 1000,
+      }),
+    ).toBe(true);
+    expectMarkerNear(await readSharedSyncCursor(db, CURSOR), clampedCompletionStartedAtMs);
   });
 
   it('keeps different boards independent', async () => {
-    expect(await claimSharedSyncSlot(db, { ...CURSOR, cooldownMs: COOLDOWN_MS })).toBe(true);
+    await claimCursor();
     // A second board's cursor is a different row and must not be throttled by
     // the first — the runners key the cursor per board.
     const otherBoard = { boardType: `${BOARD}-2`, cursorName: SHARED_SYNC_COOLDOWN_CURSOR };
     try {
-      expect(await claimSharedSyncSlot(db, { ...otherBoard, cooldownMs: COOLDOWN_MS })).toBe(true);
+      expect(await claimSharedSyncSlot(db, { ...otherBoard, cooldownMs: COOLDOWN_MS })).not.toBeNull();
     } finally {
       await db.delete(boardSharedSyncs).where(eq(boardSharedSyncs.boardType, otherBoard.boardType));
     }

--- a/packages/db/src/queries/sync/shared-sync-cooldown.ts
+++ b/packages/db/src/queries/sync/shared-sync-cooldown.ts
@@ -13,23 +13,28 @@ type DrizzleDb = PgDatabase<PgQueryResultHKT, Record<string, unknown>>;
 export const SHARED_SYNC_COOLDOWN_CURSOR = '__local_shared_sync__';
 export const CATALOG_SYNC_COOLDOWN_CURSOR = '__local_catalog_sync__';
 
+export type SharedSyncClaimToken = string;
+
 /**
  * `last_synchronized_at` is TEXT across this table, holding Aurora's
- * `YYYY-MM-DD HH:MM:SS.ffffff` (no zone, UTC). We write the `__local_*` rows
- * ourselves in exactly that shape, so the `::timestamp` cast in the CAS below
- * only ever sees values this module produced.
+ * `YYYY-MM-DD HH:MM:SS.ffffff` (no zone, UTC). Synthetic cooldown rows append
+ * `#claim:<uuid>` or `#finished:<uuid>` to that timestamp. The UUID is generated
+ * by PostgreSQL in the same statement as the marker write, so even callers
+ * with identical or badly skewed clocks can never reuse an ownership token.
+ * Existing timestamp-only rows remain compatible: every read/cast uses the
+ * portion before the first `#`.
  */
-function nowCursorText(now: Date): string {
-  // toISOString() gives 3 fractional digits; Aurora writes 6. Pad so a
-  // `__local_*` row is byte-compatible with the Aurora-written rows sharing
-  // this column. Both parse identically — this is about not leaving two
-  // formats in one column for whoever reads it next.
-  return `${now.toISOString().replace('T', ' ').replace('Z', '')}000`;
+function dbCursorValue(kind: 'claim' | 'finished', backdateMs = 0) {
+  return sql<string>`to_char(
+    (clock_timestamp() at time zone 'utc')
+      - make_interval(secs => ${backdateMs / 1000}::double precision),
+    'YYYY-MM-DD HH24:MI:SS.US'
+  ) || ${`#${kind}:`} || gen_random_uuid()::text`;
 }
 
 /**
- * Try to claim the right to run a board-wide sync, returning true only for the
- * caller that wins.
+ * Try to claim the right to run a board-wide sync, returning the exact cursor
+ * token only to the caller that wins (and null to every refused caller).
  *
  * Replaces the per-process in-memory cooldown `Map`s both runners used to keep.
  * Those had two failure modes that this fixes: a restart reset the map, so the
@@ -47,45 +52,83 @@ function nowCursorText(now: Date): string {
  */
 export async function claimSharedSyncSlot(
   db: DrizzleDb,
-  options: { boardType: string; cursorName: string; cooldownMs: number; now?: Date },
-): Promise<boolean> {
-  const now = options.now ?? new Date();
+  options: {
+    boardType: string;
+    cursorName: string;
+    cooldownMs: number;
+    /** @deprecated Ignored. PostgreSQL is the sole clock and identity source. */
+    now?: Date;
+  },
+): Promise<SharedSyncClaimToken | null> {
+  const claimToken = dbCursorValue('claim');
   const rows = await db
     .insert(boardSharedSyncs)
     .values({
       boardType: options.boardType,
       tableName: options.cursorName,
-      lastSynchronizedAt: nowCursorText(now),
+      lastSynchronizedAt: claimToken,
     })
     .onConflictDoUpdate({
       target: [boardSharedSyncs.boardType, boardSharedSyncs.tableName],
-      set: { lastSynchronizedAt: sql`excluded.last_synchronized_at` },
-      // The cast on the bind parameter is deliberate: an untyped parameter can
-      // arrive as `text` through postgres-js, and make_interval's `secs` is
-      // double precision.
+      // Generate a fresh value on the UPDATE path too. Reusing
+      // excluded.last_synchronized_at would still be DB-clock based, but this
+      // makes the ownership identity local to the lock-protected winning write.
+      set: { lastSynchronizedAt: dbCursorValue('claim') },
       setWhere: sql`${boardSharedSyncs.lastSynchronizedAt} IS NULL
-        OR ${boardSharedSyncs.lastSynchronizedAt}::timestamp
-             < (now() at time zone 'utc') - make_interval(secs => ${options.cooldownMs / 1000}::double precision)`,
+        OR split_part(${boardSharedSyncs.lastSynchronizedAt}, '#', 1)::timestamp
+             < (clock_timestamp() at time zone 'utc')
+               - make_interval(secs => ${options.cooldownMs / 1000}::double precision)`,
     })
-    .returning({ tableName: boardSharedSyncs.tableName });
+    .returning({ claimToken: boardSharedSyncs.lastSynchronizedAt });
 
-  return rows.length > 0;
+  return rows[0]?.claimToken ?? null;
 }
 
 /**
- * Re-stamp the cursor once the run finishes, success or failure, so the
- * cooldown is measured from the END of a run. Matches what the in-memory maps
- * did (stamp before, stamp again after) — a slow or permanently failing
- * board-wide sync must not re-fire on the next cycle.
+ * Re-stamp the cursor once the run finishes so the next cooldown is measured
+ * from the END of the run. The stored value remains a synthetic
+ * "last-synchronized" timestamp: a cooldown shorter than the configured full
+ * cooldown is represented by backdating the marker by the difference.
+ *
+ * Finalization is fenced by the exact token returned from
+ * {@link claimSharedSyncSlot}. A stalled caller that finishes after another
+ * daemon has reclaimed the row cannot overwrite that newer claim. Returning
+ * false means ownership changed and the cursor was deliberately left alone.
+ *
+ * `nextCooldownMs` is clamped to the range 0..`fullCooldownMs`. This keeps an
+ * accidental longer value from pushing the synthetic marker into the future,
+ * and lets callers safely request a five-minute retry when the configured full
+ * cooldown is already shorter than five minutes.
  */
 export async function stampSharedSyncFinished(
   db: DrizzleDb,
-  options: { boardType: string; cursorName: string; now?: Date },
-): Promise<void> {
-  await db
+  options: {
+    boardType: string;
+    cursorName: string;
+    claimToken: SharedSyncClaimToken;
+    fullCooldownMs: number;
+    nextCooldownMs?: number;
+    /** @deprecated Ignored. PostgreSQL is the sole clock source. */
+    now?: Date;
+  },
+): Promise<boolean> {
+  const fullCooldownMs = Math.max(0, options.fullCooldownMs);
+  const requestedNextCooldownMs = options.nextCooldownMs ?? fullCooldownMs;
+  const nextCooldownMs = Math.max(0, Math.min(requestedNextCooldownMs, fullCooldownMs));
+  const eligibilityBackdateMs = fullCooldownMs - nextCooldownMs;
+  const rows = await db
     .update(boardSharedSyncs)
-    .set({ lastSynchronizedAt: nowCursorText(options.now ?? new Date()) })
-    .where(and(eq(boardSharedSyncs.boardType, options.boardType), eq(boardSharedSyncs.tableName, options.cursorName)));
+    .set({ lastSynchronizedAt: dbCursorValue('finished', eligibilityBackdateMs) })
+    .where(
+      and(
+        eq(boardSharedSyncs.boardType, options.boardType),
+        eq(boardSharedSyncs.tableName, options.cursorName),
+        eq(boardSharedSyncs.lastSynchronizedAt, options.claimToken),
+      ),
+    )
+    .returning({ tableName: boardSharedSyncs.tableName });
+
+  return rows.length > 0;
 }
 
 /** Read the cursor back — used by tests and by the runners' skip logging. */
@@ -100,9 +143,11 @@ export async function readSharedSyncCursor(
 
   const raw = rows[0]?.lastSynchronizedAt;
   if (!raw) return null;
-  // Stored as `YYYY-MM-DD HH:MM:SS.ffffff` (space-separated, no zone, UTC).
+  // Stored as `YYYY-MM-DD HH:MM:SS.ffffff` (space-separated, no zone, UTC),
+  // optionally followed by the synthetic marker's unique identity suffix.
   // Restore the 'T' before appending 'Z' so this is real ISO 8601 rather than
   // relying on V8 accepting the space-separated form.
-  const parsed = Date.parse(`${raw.replace(' ', 'T')}Z`);
+  const timestampText = raw.split('#', 1)[0];
+  const parsed = Date.parse(`${timestampText.replace(' ', 'T')}Z`);
   return Number.isNaN(parsed) ? null : new Date(parsed);
 }

--- a/packages/kilter-sync/src/runner/sync-runner.test.ts
+++ b/packages/kilter-sync/src/runner/sync-runner.test.ts
@@ -83,6 +83,8 @@ type SyncRunnerPrivates = {
   runCycleForCredential: (db: RunnerDb, cred: KilterCredentialRecord) => Promise<void>;
   getClient: () => { client: unknown; db: RunnerDb };
   maybeRunCatalogSync: (db: RunnerDb, cred: KilterCredentialRecord, currentToken: string) => Promise<void>;
+  maybeRepairKilterStats: (...args: unknown[]) => Promise<void>;
+  maybeSnapshotHistory: (...args: unknown[]) => Promise<void>;
 };
 
 type UpdateCall = { table: unknown; set: Record<string, unknown> };
@@ -544,6 +546,27 @@ describe('SyncRunner catalog-sync cooldown claim', () => {
     });
   });
 
+  it('leaves a newer cursor intact when catalog-sync claim ownership changes', async () => {
+    mockClaimSharedSyncSlot.mockResolvedValue('2026-07-31 23:00:00.000000');
+    mockStampSharedSyncFinished.mockResolvedValue(false);
+    const onError = vi.fn();
+    const logs: string[] = [];
+    const runner = new SyncRunner({
+      sharedSyncCooldownMs: 60_000,
+      onError,
+      onLog: (message) => logs.push(message),
+    });
+    const privates = runner as unknown as SyncRunnerPrivates;
+    const { db } = createDbShim();
+    vi.spyOn(privates, 'maybeRepairKilterStats').mockResolvedValue(undefined);
+    vi.spyOn(privates, 'maybeSnapshotHistory').mockResolvedValue(undefined);
+
+    await expect(privates.maybeRunCatalogSync(db, credential(), 'access-token')).resolves.toBeUndefined();
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(logs.some((message) => message.includes('leaving the newer cursor intact'))).toBe(true);
+  });
+
   it('re-stamps when the pull failed, so a broken catalog does not loop every cycle', async () => {
     mockClaimSharedSyncSlot.mockResolvedValue('2026-07-31 23:00:00.000000');
     mockSyncKilterCatalog.mockRejectedValueOnce(new Error('kilter down'));
@@ -556,6 +579,7 @@ describe('SyncRunner catalog-sync cooldown claim', () => {
 
     expect(onError).toHaveBeenCalled();
     expect(mockStampSharedSyncFinished).toHaveBeenCalledTimes(1);
+    expect(mockStampSharedSyncFinished.mock.calls[0][1]).not.toHaveProperty('nextCooldownMs');
   });
 
   it('a claim DB error never escapes into the credential status', async () => {

--- a/packages/kilter-sync/src/runner/sync-runner.test.ts
+++ b/packages/kilter-sync/src/runner/sync-runner.test.ts
@@ -486,7 +486,7 @@ describe('SyncRunner catalog-sync cooldown claim', () => {
     mockSyncKilterCatalog.mockResolvedValue(undefined);
     mockClaimSharedSyncSlot.mockReset();
     mockStampSharedSyncFinished.mockReset();
-    mockStampSharedSyncFinished.mockResolvedValue(undefined);
+    mockStampSharedSyncFinished.mockResolvedValue(true);
     mockReadSharedSyncCursor.mockReset();
     mockReadSharedSyncCursor.mockResolvedValue(new Date(Date.now() - 60_000));
     process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgres://test:test@localhost:5432/test';
@@ -494,7 +494,7 @@ describe('SyncRunner catalog-sync cooldown claim', () => {
   });
 
   it('claims the persisted cooldown slot before pulling the catalog', async () => {
-    mockClaimSharedSyncSlot.mockResolvedValue(true);
+    mockClaimSharedSyncSlot.mockResolvedValue('2026-07-31 23:00:00.000000');
     const runner = new SyncRunner({ sharedSyncCooldownMs: 60_000 });
     const privates = runner as unknown as SyncRunnerPrivates;
     const { db } = createDbShim();
@@ -514,7 +514,7 @@ describe('SyncRunner catalog-sync cooldown claim', () => {
     // The refusal every instance-2 and every within-cooldown cycle gets. Before
     // the cooldown was persisted, a second container had its own empty Map and
     // would run a full catalog pull here.
-    mockClaimSharedSyncSlot.mockResolvedValue(false);
+    mockClaimSharedSyncSlot.mockResolvedValue(null);
     const runner = new SyncRunner({ sharedSyncCooldownMs: 60_000 });
     const privates = runner as unknown as SyncRunnerPrivates;
     const { db } = createDbShim();
@@ -528,7 +528,7 @@ describe('SyncRunner catalog-sync cooldown claim', () => {
   });
 
   it('re-stamps the cursor after a successful pull so the cooldown starts at the end', async () => {
-    mockClaimSharedSyncSlot.mockResolvedValue(true);
+    mockClaimSharedSyncSlot.mockResolvedValue('2026-07-31 23:00:00.000000');
     const runner = new SyncRunner({ sharedSyncCooldownMs: 60_000 });
     const privates = runner as unknown as SyncRunnerPrivates;
     const { db } = createDbShim();
@@ -539,11 +539,13 @@ describe('SyncRunner catalog-sync cooldown claim', () => {
     expect(mockStampSharedSyncFinished.mock.calls[0][1]).toMatchObject({
       boardType: KILTER_BOARD_TYPE,
       cursorName: CATALOG_SYNC_COOLDOWN_CURSOR,
+      claimToken: '2026-07-31 23:00:00.000000',
+      fullCooldownMs: 60_000,
     });
   });
 
   it('re-stamps when the pull failed, so a broken catalog does not loop every cycle', async () => {
-    mockClaimSharedSyncSlot.mockResolvedValue(true);
+    mockClaimSharedSyncSlot.mockResolvedValue('2026-07-31 23:00:00.000000');
     mockSyncKilterCatalog.mockRejectedValueOnce(new Error('kilter down'));
     const onError = vi.fn();
     const runner = new SyncRunner({ sharedSyncCooldownMs: 60_000, onError });
@@ -575,7 +577,7 @@ describe('SyncRunner catalog-sync cooldown claim', () => {
   it('a re-stamp DB error never escapes either', async () => {
     // Same reasoning for the finally-block stamp: the worst case of a missed
     // stamp is that the cooldown measures from the start of the run.
-    mockClaimSharedSyncSlot.mockResolvedValue(true);
+    mockClaimSharedSyncSlot.mockResolvedValue('2026-07-31 23:00:00.000000');
     mockStampSharedSyncFinished.mockRejectedValue(new Error('connection reset'));
     const onError = vi.fn();
     const runner = new SyncRunner({ sharedSyncCooldownMs: 60_000, onError });

--- a/packages/kilter-sync/src/runner/sync-runner.ts
+++ b/packages/kilter-sync/src/runner/sync-runner.ts
@@ -17,6 +17,7 @@ import {
   stampSharedSyncFinished,
   isWeeklyCursorDue,
   markWeeklyCursorDone,
+  type SharedSyncClaimToken,
 } from '@boardsesh/db/queries';
 import { decrypt, encrypt } from '@boardsesh/crypto';
 import {
@@ -329,10 +330,10 @@ export class SyncRunner {
     // A DB error here must not escape: the user-half of this cycle has already
     // committed and been marked active, so letting the claim throw would record
     // a spurious credential failure for a user whose sync actually succeeded.
-    let claimed = false;
+    let claimToken: SharedSyncClaimToken | null = null;
     try {
-      claimed = await claimSharedSyncSlot(db, { ...cursor, cooldownMs });
-      if (!claimed) {
+      claimToken = await claimSharedSyncSlot(db, { ...cursor, cooldownMs });
+      if (claimToken === null) {
         const lastRun = await readSharedSyncCursor(db, cursor);
         const remainingMinutes = lastRun
           ? Math.max(0, Math.round((cooldownMs - (Date.now() - lastRun.getTime())) / 60000))
@@ -348,7 +349,7 @@ export class SyncRunner {
       return;
     }
 
-    if (!claimed) return;
+    if (claimToken === null) return;
 
     // Reuse the just-minted user token first, then re-mint on demand (the
     // catalog pull can outlast a single access-token TTL).
@@ -386,7 +387,7 @@ export class SyncRunner {
       // Error-swallowing by design: this runs after the user-half has committed
       // and been marked active, so a DB error here must not escape and record a
       // credential failure for a user whose sync actually succeeded.
-      await this.stampCatalogSyncFinishedSafely(db, cursor);
+      await this.stampCatalogSyncFinishedSafely(db, cursor, claimToken, cooldownMs);
     }
   }
 
@@ -400,9 +401,15 @@ export class SyncRunner {
   private async stampCatalogSyncFinishedSafely(
     db: RunnerDb,
     cursor: { boardType: string; cursorName: string },
+    claimToken: SharedSyncClaimToken,
+    cooldownMs: number,
   ): Promise<void> {
     try {
-      await stampSharedSyncFinished(db, cursor);
+      await stampSharedSyncFinished(db, {
+        ...cursor,
+        claimToken,
+        fullCooldownMs: cooldownMs,
+      });
     } catch (stampError) {
       this.handleError(stampError instanceof Error ? stampError : new Error(String(stampError)), {
         board: KILTER_BOARD_TYPE,

--- a/packages/kilter-sync/src/runner/sync-runner.ts
+++ b/packages/kilter-sync/src/runner/sync-runner.ts
@@ -343,13 +343,12 @@ export class SyncRunner {
             remainingMinutes === null ? 'held by another instance' : `${remainingMinutes}m left`
           })`,
         );
+        return;
       }
     } catch (claimError) {
       this.handleError(claimError instanceof Error ? claimError : new Error(String(claimError)), { board });
       return;
     }
-
-    if (claimToken === null) return;
 
     // Reuse the just-minted user token first, then re-mint on demand (the
     // catalog pull can outlast a single access-token TTL).
@@ -405,11 +404,16 @@ export class SyncRunner {
     cooldownMs: number,
   ): Promise<void> {
     try {
-      await stampSharedSyncFinished(db, {
+      const finalized = await stampSharedSyncFinished(db, {
         ...cursor,
         claimToken,
         fullCooldownMs: cooldownMs,
       });
+      if (!finalized) {
+        this.log(
+          `[KilterSyncRunner] Catalog-sync claim ownership changed for ${KILTER_BOARD_TYPE}; leaving the newer cursor intact`,
+        );
+      }
     } catch (stampError) {
       this.handleError(stampError instanceof Error ? stampError : new Error(String(stampError)), {
         board: KILTER_BOARD_TYPE,


### PR DESCRIPTION
## Summary

Closes #1976.

- Retry Aurora's shared board-catalog sync after a short cooldown when the upstream failure is transient, instead of making a network blip or 5xx response wait the full shared-sync window.
- Keep authentication, malformed-response, and other permanent failures on the normal cooldown so a permanently failing board cannot loop every cycle.
- Fence shared-sync completion with database-generated claim identities so an older Aurora or Kilter worker cannot overwrite a newer attempt's cursor.
- Keep Kilter catalog success and failure on its documented full cooldown. If Kilter loses completion ownership, log it and leave the newer cursor intact rather than reporting a false runner failure.
- Simplify the null-claim branches in both runners without changing their held-slot behavior.

## Release Notes

- Board climbs catch up sooner after temporary Aurora sync outages

## Test plan

- Aurora/Kilter error and runner coverage: 70/70 passed before rebase
- Shared cooldown compare-and-set integration against Postgres: 10/10 passed
- Post-rebase Aurora/Kilter runner regression: 55/55 passed
- `vp run typecheck:aurora`
- `vp run typecheck:kilter`
- `vp run typecheck:db`
- `vp run typecheck:backend`
- Targeted `vp check` and `git diff --check`
- Independent follow-up QA verified ownership-loss handling, the intentional Kilter cooldown divergence, and null-claim control flow
