### PR TITLE
fix(shared): type playback subscription events

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -721,6 +721,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@boardsesh/queue": "*",
+        "@boardsesh/shared-schema": "*",
       },
       "devDependencies": {
         "typescript": "^5.9.3",

--- a/docs/mobile-play-view-roadmap.md
+++ b/docs/mobile-play-view-roadmap.md
@@ -95,7 +95,7 @@ Adds real-time collaborative climbing sessions.
 **Shipped (#2496):**
 
 - **Route/circuit playback** -- variable-speed, frame-stepped animation of multi-frame climbs (`framesCount > 1`) in the play drawer, via the shared `@boardsesh/playback-react` engine (`usePlaybackEngine` + `useClimbFrames`). Boulders are unaffected (`isAnimatable` is false).
-- **Playback party-sync** -- `PlaybackStateChanged` is forwarded through the queue provider's `subscribeToQueueEvents` seam (bypassing the reducer) and broadcast via `publishPlaybackState`, so party members see the same frame/speed/play state in real time.
+- **Playback party-sync** -- `PlaybackStateChanged` is forwarded through the queue provider's `subscribeToPlaybackEvents` seam (bypassing the reducer) and broadcast via `publishPlaybackState`, so party members see the same frame/speed/play state in real time.
 - **BLE frame mirroring** -- during route playback, the current frame is written to a connected board over BLE through a latest-wins, GATT-safe drain (mobile's `sendFramesToBoard` has no internal mutex).
 
 **Still planned:**

--- a/packages/mobile/src/components/play-drawer/__tests__/use-mobile-playback.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-mobile-playback.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import type { Climb, BoardName } from '@boardsesh/shared-schema';
+import type { BoardName, Climb, PlaybackStateChangedEvent } from '@boardsesh/shared-schema';
 
 // The orchestrator composes three I/O seams — the shared playback engine, the
 // queue provider (party-sync), and the optional Bluetooth context (BLE writes).
@@ -39,13 +39,13 @@ const mocks = vi.hoisted(() => ({
     setSpeed: vi.fn(),
   },
   lastEngineInput: { current: null as EngineInput | null },
-  queueListeners: new Set<(event: unknown) => void>(),
+  playbackEventListeners: new Set<(event: PlaybackStateChangedEvent) => void>(),
   publishPlaybackState: vi.fn((_input: Record<string, unknown>) => Promise.resolve()),
   // Stable references — the real queue provider memoises these with useCallback.
   // An unstable identity would re-run the subscription effect every render and
   // clear the externally-synced state.
-  subscribeToQueueEvents: null as unknown as (listener: (event: unknown) => void) => () => void,
-  queueValue: null as unknown as { subscribeToQueueEvents: unknown; publishPlaybackState: unknown },
+  subscribeToPlaybackEvents: null as unknown as (listener: (event: PlaybackStateChangedEvent) => void) => () => void,
+  queueValue: null as unknown as { subscribeToPlaybackEvents: unknown; publishPlaybackState: unknown },
   bluetooth: {
     isConnected: true,
     sendFramesToBoard: vi.fn() as ReturnType<typeof vi.fn>,
@@ -61,14 +61,14 @@ vi.mock('@boardsesh/playback-react', () => ({
   },
 }));
 
-mocks.subscribeToQueueEvents = (listener: (event: unknown) => void) => {
-  mocks.queueListeners.add(listener);
+mocks.subscribeToPlaybackEvents = (listener: (event: PlaybackStateChangedEvent) => void) => {
+  mocks.playbackEventListeners.add(listener);
   return () => {
-    mocks.queueListeners.delete(listener);
+    mocks.playbackEventListeners.delete(listener);
   };
 };
 mocks.queueValue = {
-  subscribeToQueueEvents: mocks.subscribeToQueueEvents,
+  subscribeToPlaybackEvents: mocks.subscribeToPlaybackEvents,
   publishPlaybackState: mocks.publishPlaybackState,
 };
 
@@ -85,22 +85,23 @@ import { useMobilePlayback } from '../use-mobile-playback';
 const KILTER = 'kilter' as BoardName;
 const climbWith = (uuid: string) => ({ uuid }) as unknown as Climb;
 
-/** Deliver a fake wire event to every active queue-event listener. */
-function emit(event: Record<string, unknown>) {
+/** Deliver a playback event to every active playback-event listener. */
+function emitPlayback(event: PlaybackStateChangedEvent) {
   act(() => {
-    for (const listener of mocks.queueListeners) listener(event);
+    for (const listener of mocks.playbackEventListeners) listener(event);
   });
 }
 
-function playbackEvent(overrides: Record<string, unknown> = {}) {
+function playbackEvent(overrides: Partial<PlaybackStateChangedEvent> = {}): PlaybackStateChangedEvent {
   return {
     __typename: 'PlaybackStateChanged',
+    sequence: 1,
     climbUuid: 'c1',
     frameIndex: 2,
     isPlaying: true,
     speed: 1.5,
     paceMs: 400,
-    anchorTimestamp: 1700,
+    anchorTimestamp: '1700',
     clientId: 'peer-1',
     ...overrides,
   };
@@ -115,7 +116,7 @@ beforeEach(() => {
   mocks.playback.isPlaying = false;
   mocks.playback.speed = 1;
   mocks.lastEngineInput.current = null;
-  mocks.queueListeners.clear();
+  mocks.playbackEventListeners.clear();
   mocks.bluetooth.isConnected = true;
   mocks.sendCalls = [];
   // Each write returns a deferred promise so a test can hold a write "in flight".
@@ -241,22 +242,21 @@ describe('useMobilePlayback — party-sync', () => {
   it('applies a matching peer playback event as external engine state', () => {
     renderPlayback(climbWith('c1'));
 
-    emit(playbackEvent({ climbUuid: 'c1', clientId: 'peer-1' }));
+    emitPlayback(playbackEvent({ climbUuid: 'c1', clientId: 'peer-1' }));
     expect(mocks.lastEngineInput.current?.externalState?.clientId).toBe('peer-1');
   });
 
-  it('ignores events for other climbs and non-playback events', () => {
+  it('ignores playback events for other climbs', () => {
     renderPlayback(climbWith('c1'));
 
-    emit(playbackEvent({ climbUuid: 'other-climb' }));
-    emit({ __typename: 'QueueItemAdded' });
+    emitPlayback(playbackEvent({ climbUuid: 'other-climb' }));
     expect(mocks.lastEngineInput.current?.externalState).toBeNull();
   });
 
   it('clears peer state when the climb changes', () => {
     const { rerender } = renderPlayback(climbWith('c1'));
 
-    emit(playbackEvent({ climbUuid: 'c1' }));
+    emitPlayback(playbackEvent({ climbUuid: 'c1' }));
     expect(mocks.lastEngineInput.current?.externalState).not.toBeNull();
 
     act(() => {

--- a/packages/mobile/src/components/play-drawer/use-mobile-playback.ts
+++ b/packages/mobile/src/components/play-drawer/use-mobile-playback.ts
@@ -52,7 +52,7 @@ export function useMobilePlayback({
   isOpen,
   onRoutePlayed,
 }: UseMobilePlaybackInput): UseMobilePlaybackOutput {
-  const { subscribeToQueueEvents, publishPlaybackState } = useQueueActions();
+  const { subscribeToPlaybackEvents, publishPlaybackState } = useQueueActions();
   const bluetooth = useOptionalBluetoothContext();
   // Stable per-hook id so the engine can suppress echoes of its own broadcasts.
   const playbackClientId = useId();
@@ -70,8 +70,7 @@ export function useMobilePlayback({
       return;
     }
     setExternalPlayback(null);
-    const unsubscribe = subscribeToQueueEvents((event) => {
-      if (event.__typename !== 'PlaybackStateChanged') return;
+    const unsubscribe = subscribeToPlaybackEvents((event) => {
       if (event.climbUuid !== climbUuid) return;
       setExternalPlayback({
         frameIndex: event.frameIndex,
@@ -83,7 +82,7 @@ export function useMobilePlayback({
       });
     });
     return unsubscribe;
-  }, [climbUuid, subscribeToQueueEvents]);
+  }, [climbUuid, subscribeToPlaybackEvents]);
 
   const handleLocalStateChange = useCallback(
     (next: ExternalPlaybackState) => {

--- a/packages/mobile/src/providers/__tests__/queue-provider-sync-gate.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-sync-gate.test.tsx
@@ -9,7 +9,7 @@ import { act, render, waitFor } from '@testing-library/react';
 import { createElement, useEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ClimbQueueItem } from '@boardsesh/queue';
-import type { SessionStatus, SessionUser, SubscriptionQueueEvent, UserBoard } from '@boardsesh/shared-schema';
+import type { PlaybackStateChangedEvent, SessionStatus, SessionUser, UserBoard } from '@boardsesh/shared-schema';
 
 const ws = vi.hoisted(() => {
   type WsEventName = 'connected' | 'closed';
@@ -204,7 +204,7 @@ import { QueueProvider, useQueue } from '../queue-provider';
 type Snapshot = {
   state: ReturnType<typeof useQueue>['state'];
   sessionId: string | null;
-  subscribeToQueueEvents: ReturnType<typeof useQueue>['subscribeToQueueEvents'];
+  subscribeToPlaybackEvents: ReturnType<typeof useQueue>['subscribeToPlaybackEvents'];
   removeFromQueue: ReturnType<typeof useQueue>['removeFromQueue'];
 };
 
@@ -301,7 +301,7 @@ function wireQueueItemRemoved(sequence: number, stateHash: string, uuid: string,
 // Wire-shaped PlaybackStateChanged matching QUEUE_UPDATES_SUBSCRIPTION's `...
 // on PlaybackStateChanged` fragment (issue #3358) — no top-level `stateHash`,
 // since this event doesn't mutate queue state.
-function wirePlaybackStateChanged(overrides: Partial<Record<string, unknown>> = {}) {
+function wirePlaybackStateChanged(overrides: Partial<PlaybackStateChangedEvent> = {}): PlaybackStateChangedEvent {
   return {
     __typename: 'PlaybackStateChanged',
     sequence: 1,
@@ -360,10 +360,10 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
     onSnapshot({
       state: queue.state,
       sessionId: queue.sessionId,
-      subscribeToQueueEvents: queue.subscribeToQueueEvents,
+      subscribeToPlaybackEvents: queue.subscribeToPlaybackEvents,
       removeFromQueue: queue.removeFromQueue,
     });
-  }, [queue.state, queue.sessionId, queue.subscribeToQueueEvents, queue.removeFromQueue, onSnapshot]);
+  }, [queue.state, queue.sessionId, queue.subscribeToPlaybackEvents, queue.removeFromQueue, onSnapshot]);
   return null;
 }
 
@@ -736,35 +736,27 @@ describe('QueueProvider queue sync gate', () => {
     });
   });
 
-  it('lets PlaybackStateChanged bypass the gate and still reach transient listeners', async () => {
+  it('lets PlaybackStateChanged bypass the gate and reach playback listeners only', async () => {
     const snapshots: Snapshot[] = [];
     renderProvider((snapshot) => snapshots.push(snapshot));
 
     await waitFor(() => {
       expect(ws.getQueueUpdatesSink()).not.toBeNull();
-      expect(snapshots.at(-1)?.subscribeToQueueEvents).toBeDefined();
+      expect(snapshots.at(-1)?.subscribeToPlaybackEvents).toBeDefined();
     });
     const queueUpdatesSink = ws.getQueueUpdatesSink();
     if (!queueUpdatesSink) throw new Error('queue updates sink was not captured');
 
-    const received: SubscriptionQueueEvent[] = [];
-    const unsubscribe = snapshots.at(-1)?.subscribeToQueueEvents((event) => received.push(event));
+    const received: PlaybackStateChangedEvent[] = [];
+    const unsubscribe = snapshots.at(-1)?.subscribeToPlaybackEvents((event) => received.push(event));
 
     act(() => {
       queueUpdatesSink.next({ data: { queueUpdates: wireFullSync(1, 'hash-1') } });
     });
 
-    // Defensive case: a `__typename`-only payload (e.g. a stale client bundle
-    // still missing the `... on PlaybackStateChanged` fragment, or a future
-    // union member this listener doesn't recognise) must still be forwarded
-    // and must not throw or otherwise disrupt the gate.
-    act(() => {
-      queueUpdatesSink.next({ data: { queueUpdates: { __typename: 'PlaybackStateChanged' } } });
-    });
-
-    // Realistic case (issue #3358): QUEUE_UPDATES_SUBSCRIPTION now selects the
-    // full `... on PlaybackStateChanged` fragment, so the real wire payload
-    // carries all 8 fields — assert they reach the listener unchanged, since
+    // QUEUE_UPDATES_SUBSCRIPTION selects the complete canonical event shape in
+    // its `... on PlaybackStateChanged` fragment, so the real wire payload
+    // carries all fields — assert they reach the listener unchanged, since
     // `use-mobile-playback.ts` reads `climbUuid`/`frameIndex`/etc directly off
     // the forwarded event.
     act(() => {
@@ -772,15 +764,13 @@ describe('QueueProvider queue sync gate', () => {
     });
 
     await waitFor(() => {
-      expect(received.filter((event) => event.__typename === 'PlaybackStateChanged')).toHaveLength(2);
+      expect(received).toHaveLength(1);
     });
-    const [minimalEvent, fullEvent] = received.filter((event) => event.__typename === 'PlaybackStateChanged');
-    expect(minimalEvent).toEqual({ __typename: 'PlaybackStateChanged' });
-    expect(fullEvent).toEqual(wirePlaybackStateChanged());
+    expect(received[0]).toEqual(wirePlaybackStateChanged());
 
     // It must not have touched the reducer or the gate's tracking: the very
     // next real delta at sequence 2 (contiguous with the FullSync's 1) still
-    // applies cleanly — proving neither PlaybackStateChanged event occupied a
+    // applies cleanly — proving the PlaybackStateChanged event occupied no
     // sequence slot or otherwise got gated.
     act(() => {
       queueUpdatesSink.next({ data: { queueUpdates: wireQueueItemAdded(2, 'hash-2', wireItem('q1', 'c1')) } });

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -17,7 +17,7 @@ import type {
 import { countDistinctSessionUsers, createJoinSessionTracker, type QueueSyncGate } from '@boardsesh/queue-runtime';
 import { useQueueMutations, type PublishPlaybackStateInput } from '@boardsesh/queue-react';
 import type { QueueItemAttribution } from '@boardsesh/queue-react/queue-item-input';
-import type { SubscriptionQueueEvent, SessionUser } from '@boardsesh/shared-schema';
+import type { SessionUser } from '@boardsesh/shared-schema';
 import { execute, isRateLimitedError } from '@boardsesh/graphql-client';
 import { buildBoardPath } from '@boardsesh/board-config';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
@@ -59,6 +59,7 @@ import {
   type QueueDataContextValue,
   type QueueActionsContextValue,
   type QueuePlaylistSuggestionContextValue,
+  type PlaybackStateChangedEvent,
 } from './queue/queue-contexts';
 import { useQueueRegrade } from './queue/use-queue-regrade';
 import { useQueueResolveClimbs } from './queue/use-queue-resolve-climbs';
@@ -449,8 +450,8 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // party-sync) doesn't mutate queue state, so the play-drawer orchestrator
   // subscribes here and the reducer path skips it. Listeners live in a ref so
   // adding/removing one never tears down the WS subscription effect below.
-  const queueEventListenersRef = useRef<Set<(event: SubscriptionQueueEvent) => void>>(new Set());
-  const subscribeToQueueEvents = useCallback((listener: (event: SubscriptionQueueEvent) => void) => {
+  const queueEventListenersRef = useRef<Set<(event: PlaybackStateChangedEvent) => void>>(new Set());
+  const subscribeToQueueEvents = useCallback((listener: (event: PlaybackStateChangedEvent) => void) => {
     queueEventListenersRef.current.add(listener);
     return () => {
       queueEventListenersRef.current.delete(listener);

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -17,7 +17,7 @@ import type {
 import { countDistinctSessionUsers, createJoinSessionTracker, type QueueSyncGate } from '@boardsesh/queue-runtime';
 import { useQueueMutations, type PublishPlaybackStateInput } from '@boardsesh/queue-react';
 import type { QueueItemAttribution } from '@boardsesh/queue-react/queue-item-input';
-import type { SessionUser } from '@boardsesh/shared-schema';
+import type { PlaybackStateChangedEvent, SessionUser } from '@boardsesh/shared-schema';
 import { execute, isRateLimitedError } from '@boardsesh/graphql-client';
 import { buildBoardPath } from '@boardsesh/board-config';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
@@ -59,7 +59,6 @@ import {
   type QueueDataContextValue,
   type QueueActionsContextValue,
   type QueuePlaylistSuggestionContextValue,
-  type PlaybackStateChangedEvent,
 } from './queue/queue-contexts';
 import { useQueueRegrade } from './queue/use-queue-regrade';
 import { useQueueResolveClimbs } from './queue/use-queue-resolve-climbs';
@@ -446,15 +445,15 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // live queue and to trigger a re-seed instead (#3878).
   const seedFailedSessionIdRef = useRef<string | null>(null);
 
-  // Transient queue-event listeners. PlaybackStateChanged (route playback
+  // Transient playback-event listeners. PlaybackStateChanged (route playback
   // party-sync) doesn't mutate queue state, so the play-drawer orchestrator
   // subscribes here and the reducer path skips it. Listeners live in a ref so
   // adding/removing one never tears down the WS subscription effect below.
-  const queueEventListenersRef = useRef<Set<(event: PlaybackStateChangedEvent) => void>>(new Set());
-  const subscribeToQueueEvents = useCallback((listener: (event: PlaybackStateChangedEvent) => void) => {
-    queueEventListenersRef.current.add(listener);
+  const playbackEventListenersRef = useRef<Set<(event: PlaybackStateChangedEvent) => void>>(new Set());
+  const subscribeToPlaybackEvents = useCallback((listener: (event: PlaybackStateChangedEvent) => void) => {
+    playbackEventListenersRef.current.add(listener);
     return () => {
-      queueEventListenersRef.current.delete(listener);
+      playbackEventListenersRef.current.delete(listener);
     };
   }, []);
 
@@ -707,7 +706,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     showToastRef,
     tRef,
     clearSessionRef,
-    queueEventListenersRef,
+    playbackEventListenersRef,
     unsubscribeRef,
     queueSyncGateRef,
     restartJoinedSubscriptionsRef,
@@ -1277,7 +1276,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       confirmClimbOnWall,
       reportWallDisconnect,
       setSessionBoardSerial,
-      subscribeToQueueEvents,
+      subscribeToPlaybackEvents,
       publishPlaybackState,
     }),
     [
@@ -1302,7 +1301,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       confirmClimbOnWall,
       reportWallDisconnect,
       setSessionBoardSerial,
-      subscribeToQueueEvents,
+      subscribeToPlaybackEvents,
       publishPlaybackState,
     ],
   );

--- a/packages/mobile/src/providers/queue/queue-contexts.ts
+++ b/packages/mobile/src/providers/queue/queue-contexts.ts
@@ -7,10 +7,8 @@ import type {
   SetCurrentClimbOptions,
 } from '@boardsesh/queue';
 import type { PublishPlaybackStateInput } from '@boardsesh/queue-react';
-import type { SessionSummary, SubscriptionQueueEvent, SessionUser, UserBoard } from '@boardsesh/shared-schema';
+import type { PlaybackStateChangedEvent, SessionSummary, SessionUser, UserBoard } from '@boardsesh/shared-schema';
 import type { SessionLiveStatsEvent } from '../../lib/graphql/operations';
-
-export type PlaybackStateChangedEvent = Extract<SubscriptionQueueEvent, { __typename: 'PlaybackStateChanged' }>;
 
 export type StartSessionConfig = {
   name?: string;
@@ -120,7 +118,7 @@ type QueueContextValue = {
   setSessionBoardSerial: (serial: string) => Promise<void>;
   /** Subscribe to transient PlaybackStateChanged events that never reach the
    * queue reducer. Returns an unsubscribe function. */
-  subscribeToQueueEvents: (listener: (event: PlaybackStateChangedEvent) => void) => () => void;
+  subscribeToPlaybackEvents: (listener: (event: PlaybackStateChangedEvent) => void) => () => void;
   /** Broadcast local route-playback state to party peers. Best-effort; no-op solo. */
   publishPlaybackState: (input: PublishPlaybackStateInput) => Promise<void>;
 };

--- a/packages/mobile/src/providers/queue/queue-contexts.ts
+++ b/packages/mobile/src/providers/queue/queue-contexts.ts
@@ -10,6 +10,8 @@ import type { PublishPlaybackStateInput } from '@boardsesh/queue-react';
 import type { SessionSummary, SubscriptionQueueEvent, SessionUser, UserBoard } from '@boardsesh/shared-schema';
 import type { SessionLiveStatsEvent } from '../../lib/graphql/operations';
 
+export type PlaybackStateChangedEvent = Extract<SubscriptionQueueEvent, { __typename: 'PlaybackStateChanged' }>;
+
 export type StartSessionConfig = {
   name?: string;
   goal?: string;
@@ -116,12 +118,9 @@ type QueueContextValue = {
    * reconnect to the same physical wall without showing the picker.
    */
   setSessionBoardSerial: (serial: string) => Promise<void>;
-  /**
-   * Subscribe to raw queue subscription events, including transient ones that
-   * never reach the reducer (PlaybackStateChanged drives route playback
-   * party-sync). Returns an unsubscribe function.
-   */
-  subscribeToQueueEvents: (listener: (event: SubscriptionQueueEvent) => void) => () => void;
+  /** Subscribe to transient PlaybackStateChanged events that never reach the
+   * queue reducer. Returns an unsubscribe function. */
+  subscribeToQueueEvents: (listener: (event: PlaybackStateChangedEvent) => void) => () => void;
   /** Broadcast local route-playback state to party peers. Best-effort; no-op solo. */
   publishPlaybackState: (input: PublishPlaybackStateInput) => Promise<void>;
 };

--- a/packages/mobile/src/providers/queue/use-session-realtime.ts
+++ b/packages/mobile/src/providers/queue/use-session-realtime.ts
@@ -15,7 +15,7 @@ import {
 } from '@boardsesh/queue-runtime';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { parseBoardPath, parseNamedBoardPath } from '@boardsesh/board-config';
-import type { SessionUser, UserBoard } from '@boardsesh/shared-schema';
+import type { PlaybackStateChangedEvent, SessionUser, UserBoard } from '@boardsesh/shared-schema';
 import { emitWallConfirm } from '@boardsesh/play-view';
 import { GraphQLOperationError, isNotSessionMemberError } from '@boardsesh/graphql-client';
 import { getWsClient } from '../../lib/graphql/ws-client';
@@ -33,7 +33,6 @@ import { toMobileSessionRuntimeEvent } from '../../lib/session-runtime-event';
 import { track } from '../../lib/analytics';
 import { reportHandledError } from '../../lib/error-reporting';
 import type { ToastVariant } from '../../components/Toast';
-import type { PlaybackStateChangedEvent } from './queue-contexts';
 
 const JOIN_SESSION_RETRY_BACKOFF_MS = [1_000, 2_500, 5_000] as const;
 // ws-client remaps a rejected-auth 4401 to the retryable AUTH_REFRESH_RETRY_CLOSE_CODE
@@ -143,7 +142,7 @@ type UseSessionRealtimeParams = {
   showToastRef: React.RefObject<(message: string, variant?: ToastVariant, duration?: number) => void>;
   tRef: React.RefObject<(key: string) => string>;
   clearSessionRef: React.RefObject<(options?: { notifyServer?: boolean }) => Promise<void>>;
-  queueEventListenersRef: React.RefObject<Set<(event: PlaybackStateChangedEvent) => void>>;
+  playbackEventListenersRef: React.RefObject<Set<(event: PlaybackStateChangedEvent) => void>>;
   unsubscribeRef: React.RefObject<(() => void) | null>;
   queueSyncGateRef: React.RefObject<QueueSyncGate | null>;
   restartJoinedSubscriptionsRef: React.RefObject<(() => void) | null>;
@@ -185,7 +184,7 @@ export function useSessionRealtime({
   showToastRef,
   tRef,
   clearSessionRef,
-  queueEventListenersRef,
+  playbackEventListenersRef,
   unsubscribeRef,
   queueSyncGateRef,
   restartJoinedSubscriptionsRef,
@@ -464,11 +463,11 @@ export function useSessionRealtime({
             // queue state. Forward it to route-playback listeners, then stop
             // before item lifting, the reducer, and sequence/hash tracking.
             if (event.__typename === 'PlaybackStateChanged') {
-              for (const listener of queueEventListenersRef.current) {
+              for (const listener of playbackEventListenersRef.current) {
                 try {
                   listener(event);
                 } catch (listenerError) {
-                  if (__DEV__) console.warn('[queue] queue-event listener threw', listenerError);
+                  if (__DEV__) console.warn('[queue] playback-event listener threw', listenerError);
                 }
               }
               return;

--- a/packages/mobile/src/providers/queue/use-session-realtime.ts
+++ b/packages/mobile/src/providers/queue/use-session-realtime.ts
@@ -15,7 +15,7 @@ import {
 } from '@boardsesh/queue-runtime';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { parseBoardPath, parseNamedBoardPath } from '@boardsesh/board-config';
-import type { SessionUser, SubscriptionQueueEvent, UserBoard } from '@boardsesh/shared-schema';
+import type { SessionUser, UserBoard } from '@boardsesh/shared-schema';
 import { emitWallConfirm } from '@boardsesh/play-view';
 import { GraphQLOperationError, isNotSessionMemberError } from '@boardsesh/graphql-client';
 import { getWsClient } from '../../lib/graphql/ws-client';
@@ -33,6 +33,7 @@ import { toMobileSessionRuntimeEvent } from '../../lib/session-runtime-event';
 import { track } from '../../lib/analytics';
 import { reportHandledError } from '../../lib/error-reporting';
 import type { ToastVariant } from '../../components/Toast';
+import type { PlaybackStateChangedEvent } from './queue-contexts';
 
 const JOIN_SESSION_RETRY_BACKOFF_MS = [1_000, 2_500, 5_000] as const;
 // ws-client remaps a rejected-auth 4401 to the retryable AUTH_REFRESH_RETRY_CLOSE_CODE
@@ -142,7 +143,7 @@ type UseSessionRealtimeParams = {
   showToastRef: React.RefObject<(message: string, variant?: ToastVariant, duration?: number) => void>;
   tRef: React.RefObject<(key: string) => string>;
   clearSessionRef: React.RefObject<(options?: { notifyServer?: boolean }) => Promise<void>>;
-  queueEventListenersRef: React.RefObject<Set<(event: SubscriptionQueueEvent) => void>>;
+  queueEventListenersRef: React.RefObject<Set<(event: PlaybackStateChangedEvent) => void>>;
   unsubscribeRef: React.RefObject<(() => void) | null>;
   queueSyncGateRef: React.RefObject<QueueSyncGate | null>;
   restartJoinedSubscriptionsRef: React.RefObject<(() => void) | null>;
@@ -459,29 +460,19 @@ export function useSessionRealtime({
           next: ({ data }) => {
             if (!data?.queueUpdates) return;
             const event = data.queueUpdates;
-            // Forward every event to transient-event listeners (route playback
-            // party-sync) before the reducer path. The wire-envelope type doesn't
-            // model PlaybackStateChanged, but the subscription selects it and the
-            // server emits it — SubscriptionQueueEvent is the canonical client
-            // union that includes it.
-            // TODO(#2507): add PlaybackStateChanged to SubscriptionWireEnvelope so
-            // this `as unknown as` cast can be removed (don't strip it before then).
-            const queueEvent = event as unknown as SubscriptionQueueEvent;
-            if (queueEventListenersRef.current.size > 0) {
+            // PlaybackStateChanged is a first-class wire variant but carries no
+            // queue state. Forward it to route-playback listeners, then stop
+            // before item lifting, the reducer, and sequence/hash tracking.
+            if (event.__typename === 'PlaybackStateChanged') {
               for (const listener of queueEventListenersRef.current) {
                 try {
-                  listener(queueEvent);
+                  listener(event);
                 } catch (listenerError) {
                   if (__DEV__) console.warn('[queue] queue-event listener threw', listenerError);
                 }
               }
+              return;
             }
-            // PlaybackStateChanged is transient — it carries no queue state and
-            // reuses the room's current sequence, so it bypasses the reducer AND
-            // the sync gate below (the gate special-cases this typename too, but
-            // returning here keeps this path a true no-op, matching pre-gate
-            // behaviour exactly).
-            if (queueEvent.__typename === 'PlaybackStateChanged') return;
 
             // A brand-new session whose local-queue seed failed
             // (createSessionWithConfig — a network blip, a rate limit, a

--- a/packages/shared-schema/src/types/events.ts
+++ b/packages/shared-schema/src/types/events.ts
@@ -16,6 +16,24 @@
 
 import type { ClimbQueueItem, QueueState } from './queue';
 
+/**
+ * Transient route-playback state carried by queue subscriptions. This shape is
+ * shared by the server-side and client-side event unions and by the
+ * renderer-agnostic subscription adapter; keep it canonical here so those
+ * consumers cannot drift independently.
+ */
+export type PlaybackStateChangedEvent = {
+  __typename: 'PlaybackStateChanged';
+  sequence: number;
+  climbUuid: string;
+  frameIndex: number;
+  isPlaying: boolean;
+  speed: number;
+  paceMs: number;
+  anchorTimestamp: string;
+  clientId: string | null;
+};
+
 // Re-export the canonical SessionEvent union from codegen so this file
 // never drifts from the GraphQL schema. The hand-written union previously
 // duplicated here was already going stale (it predated the addition of
@@ -81,17 +99,7 @@ export type QueueEvent =
       uuid?: string | null;
       mirrored: boolean;
     }
-  | {
-      __typename: 'PlaybackStateChanged';
-      sequence: number;
-      climbUuid: string;
-      frameIndex: number;
-      isPlaying: boolean;
-      speed: number;
-      paceMs: number;
-      anchorTimestamp: string;
-      clientId: string | null;
-    };
+  | PlaybackStateChangedEvent;
 
 // Client-side subscription event type - uses aliased field names to avoid GraphQL union conflicts.
 // `stateHashOrdered` mirrors the server type's optional order-sensitive (v2) hash.
@@ -141,17 +149,7 @@ export type SubscriptionQueueEvent =
       mirroredUuid?: string | null;
       mirrored: boolean;
     }
-  | {
-      __typename: 'PlaybackStateChanged';
-      sequence: number;
-      climbUuid: string;
-      frameIndex: number;
-      isPlaying: boolean;
-      speed: number;
-      paceMs: number;
-      anchorTimestamp: string;
-      clientId: string | null;
-    };
+  | PlaybackStateChangedEvent;
 
 export type ConnectionContext = {
   connectionId: string;

--- a/packages/shared/queue-runtime/package.json
+++ b/packages/shared/queue-runtime/package.json
@@ -15,7 +15,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@boardsesh/queue": "*"
+    "@boardsesh/queue": "*",
+    "@boardsesh/shared-schema": "*"
   },
   "devDependencies": {
     "typescript": "^5.9.3"

--- a/packages/shared/queue-runtime/src/__tests__/subscription-adapter.test.ts
+++ b/packages/shared/queue-runtime/src/__tests__/subscription-adapter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { ClimbQueueItem } from '@boardsesh/queue';
+import type { PlaybackStateChangedEvent } from '@boardsesh/shared-schema';
 import { mapSubscriptionEnvelopeToAction, type SubscriptionWireEnvelope } from '../subscription-adapter';
 
 type WireClimb = {
@@ -186,8 +187,8 @@ describe('mapSubscriptionEnvelopeToAction', () => {
     }
   });
 
-  it('models PlaybackStateChanged but bypasses item lifting and the reducer', () => {
-    const envelope: SubscriptionWireEnvelope<WireItem> = {
+  it('defensively ignores PlaybackStateChanged when a caller skips boundary narrowing', () => {
+    const envelope = {
       __typename: 'PlaybackStateChanged',
       sequence: 7,
       climbUuid: 'climb-1',
@@ -197,7 +198,7 @@ describe('mapSubscriptionEnvelopeToAction', () => {
       paceMs: 250,
       anchorTimestamp: '1700000000000',
       clientId: 'peer-client',
-    };
+    } satisfies PlaybackStateChangedEvent;
     let liftCalls = 0;
 
     const result = mapSubscriptionEnvelopeToAction<WireItem>(envelope, {

--- a/packages/shared/queue-runtime/src/__tests__/subscription-adapter.test.ts
+++ b/packages/shared/queue-runtime/src/__tests__/subscription-adapter.test.ts
@@ -185,4 +185,29 @@ describe('mapSubscriptionEnvelopeToAction', () => {
       expect(result.action.payload).toEqual({ uuid: 'q-1', oldIndex: 2, newIndex: 0 });
     }
   });
+
+  it('models PlaybackStateChanged but bypasses item lifting and the reducer', () => {
+    const envelope: SubscriptionWireEnvelope<WireItem> = {
+      __typename: 'PlaybackStateChanged',
+      sequence: 7,
+      climbUuid: 'climb-1',
+      frameIndex: 3,
+      isPlaying: true,
+      speed: 1.5,
+      paceMs: 250,
+      anchorTimestamp: '1700000000000',
+      clientId: 'peer-client',
+    };
+    let liftCalls = 0;
+
+    const result = mapSubscriptionEnvelopeToAction<WireItem>(envelope, {
+      mapItem: (item) => {
+        liftCalls += 1;
+        return liftToClimbItem(item);
+      },
+    });
+
+    expect(result).toEqual({ kind: 'ignore', eventType: 'PlaybackStateChanged', reason: 'transient event' });
+    expect(liftCalls).toBe(0);
+  });
 });

--- a/packages/shared/queue-runtime/src/index.ts
+++ b/packages/shared/queue-runtime/src/index.ts
@@ -4,7 +4,11 @@
 // orchestration patterns that web and mobile would otherwise duplicate.
 
 export { mapSubscriptionEnvelopeToAction } from './subscription-adapter';
-export type { SubscriptionWireEnvelope, MapEnvelopeOptions } from './subscription-adapter';
+export type {
+  SubscriptionWireEnvelope,
+  MapEnvelopeOptions,
+  SubscriptionEventMappingResult,
+} from './subscription-adapter';
 
 export { createSetCurrentClimbCoalescer } from './set-current-climb-coalescer';
 export type {

--- a/packages/shared/queue-runtime/src/subscription-adapter.ts
+++ b/packages/shared/queue-runtime/src/subscription-adapter.ts
@@ -16,6 +16,7 @@ import {
   type MapEventContext,
   type SyncQueueEvent,
 } from '@boardsesh/queue';
+import type { PlaybackStateChangedEvent } from '@boardsesh/shared-schema';
 
 /**
  * The wire envelope shape we accept. Structurally compatible with both web's
@@ -90,19 +91,7 @@ export type SubscriptionWireEnvelope<TWireItem> =
       stateHash?: string | null;
       stateHashOrdered?: string | null;
     }
-  | {
-      /** Transient playback state is forwarded to route-playback listeners,
-       * never lifted into the queue reducer or sequence/hash tracking. */
-      __typename: 'PlaybackStateChanged';
-      sequence: number;
-      climbUuid: string;
-      frameIndex: number;
-      isPlaying: boolean;
-      speed: number;
-      paceMs: number;
-      anchorTimestamp: string;
-      clientId: string | null;
-    };
+  | PlaybackStateChangedEvent;
 
 export type MapEnvelopeOptions<TWireItem> = {
   /** Lift the wire item shape to the reducer's `ClimbQueueItem`. Defaults
@@ -126,6 +115,10 @@ export function mapSubscriptionEnvelopeToAction<TWireItem>(
   envelope: SubscriptionWireEnvelope<TWireItem>,
   options: MapEnvelopeOptions<TWireItem> = {},
 ): SubscriptionEventMappingResult {
+  // Current mobile and web callers split transient playback events before
+  // invoking this reducer adapter. Keep this guard as defense-in-depth for a
+  // future or direct caller so playback can never enter item lifting or the
+  // queue reducer even if that boundary narrowing is accidentally skipped.
   if (envelope.__typename === 'PlaybackStateChanged') {
     return { kind: 'ignore', eventType: 'PlaybackStateChanged', reason: 'transient event' };
   }

--- a/packages/shared/queue-runtime/src/subscription-adapter.ts
+++ b/packages/shared/queue-runtime/src/subscription-adapter.ts
@@ -89,6 +89,19 @@ export type SubscriptionWireEnvelope<TWireItem> =
       sequence?: number | null;
       stateHash?: string | null;
       stateHashOrdered?: string | null;
+    }
+  | {
+      /** Transient playback state is forwarded to route-playback listeners,
+       * never lifted into the queue reducer or sequence/hash tracking. */
+      __typename: 'PlaybackStateChanged';
+      sequence: number;
+      climbUuid: string;
+      frameIndex: number;
+      isPlaying: boolean;
+      speed: number;
+      paceMs: number;
+      anchorTimestamp: string;
+      clientId: string | null;
     };
 
 export type MapEnvelopeOptions<TWireItem> = {
@@ -100,6 +113,10 @@ export type MapEnvelopeOptions<TWireItem> = {
   context?: MapEventContext;
 };
 
+export type SubscriptionEventMappingResult =
+  | EventMappingResult
+  | { kind: 'ignore'; eventType: 'PlaybackStateChanged'; reason: 'transient event' };
+
 /**
  * Normalise a wire subscription envelope into a reducer dispatch decision.
  * Combines the per-platform item lift with the shared
@@ -108,14 +125,22 @@ export type MapEnvelopeOptions<TWireItem> = {
 export function mapSubscriptionEnvelopeToAction<TWireItem>(
   envelope: SubscriptionWireEnvelope<TWireItem>,
   options: MapEnvelopeOptions<TWireItem> = {},
-): EventMappingResult {
+): SubscriptionEventMappingResult {
+  if (envelope.__typename === 'PlaybackStateChanged') {
+    return { kind: 'ignore', eventType: 'PlaybackStateChanged', reason: 'transient event' };
+  }
   const lift = options.mapItem ?? ((item: TWireItem) => item as unknown as ClimbQueueItem);
   const syncEvent = liftEnvelopeToSyncEvent(envelope, lift);
   return mapQueueEventToAction(syncEvent, options.context);
 }
 
+type QueueStateWireEnvelope<TWireItem> = Exclude<
+  SubscriptionWireEnvelope<TWireItem>,
+  { __typename: 'PlaybackStateChanged' }
+>;
+
 function liftEnvelopeToSyncEvent<TWireItem>(
-  envelope: SubscriptionWireEnvelope<TWireItem>,
+  envelope: QueueStateWireEnvelope<TWireItem>,
   lift: (item: TWireItem) => ClimbQueueItem,
 ): SyncQueueEvent {
   switch (envelope.__typename) {


### PR DESCRIPTION
## Summary

- Model PlaybackStateChanged as a first-class shared subscription wire event.
- Forward playback updates through a narrowly typed listener without an unsafe double cast.
- Keep transient playback events out of queue item lifting, reducer dispatch, and sequence/hash tracking.

Closes #2507

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check` on all 12 changed source, documentation, and package files; the thirteenth changed file is `bun.lock`.
- 31 focused queue-runtime/mobile tests passed.
- 223 backend operation-schema parity tests passed.
- Full mobile suite passed: 4,885 tests across 575 files.
- `vp run typecheck:shared`, `typecheck:queue-runtime`, `typecheck:mobile`, `typecheck:backend`, and `typecheck:web` passed.
- iOS and Android mobile bundle checks passed.
- Independent QA completed with no implementation findings.
