### PR TITLE
fix(sync): skip empty stats during repairs

### DIFF
--- a/packages/kilter-sync/src/sync/stats-repair.test.ts
+++ b/packages/kilter-sync/src/sync/stats-repair.test.ts
@@ -161,4 +161,45 @@ describe('repairKilterCatalogStats', () => {
       },
     ]);
   });
+
+  it('skips an empty Grips angle but preserves a zero-ascent stat with a grade', async () => {
+    mockFetchLayoutClimbStats.mockImplementation((_token: string, layoutUuid: string) => {
+      if (layoutUuid === 'layout-a') {
+        return Promise.resolve([
+          stat({
+            climbUuid: 'canon',
+            angle: 50,
+            ascentCount: 0,
+            currentDifficultyId: 0,
+            difficultyAverage: 0,
+            qualityAverage: 0,
+          }),
+          stat({ climbUuid: 'canon', angle: 40, ascentCount: 0, currentDifficultyId: 20 }),
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+    const { db, insertValues } = createDbShim({
+      selectResults: [[{ uuid: 'canon' }], []],
+      executeResults: [[], [{ changed_rows: '0' }], [{ rows_to_recompute: '0' }], { count: 0 }, []],
+    });
+
+    const summary = await repairKilterCatalogStats({
+      db: db as never,
+      tokenProvider: async () => 'token',
+      reference: reference(),
+      apply: true,
+    });
+
+    expect(summary.canonicalStatsComputed).toBe(1);
+    expect(insertValues).toHaveLength(1);
+    expect(insertValues[0]).toMatchObject([
+      {
+        climbUuid: 'canon',
+        angle: 40,
+        displayDifficulty: 20,
+        upstreamAscensionistCount: 0,
+      },
+    ]);
+  });
 });

--- a/packages/kilter-sync/src/sync/stats-repair.test.ts
+++ b/packages/kilter-sync/src/sync/stats-repair.test.ts
@@ -181,7 +181,7 @@ describe('repairKilterCatalogStats', () => {
     });
     const { db, insertValues } = createDbShim({
       selectResults: [[{ uuid: 'canon' }], []],
-      executeResults: [[], [{ changed_rows: '0' }], [{ rows_to_recompute: '0' }], { count: 0 }, []],
+      executeResults: [[], [], [{ changed_rows: '0' }], [{ rows_to_recompute: '0' }], { count: 0 }, []],
     });
 
     const summary = await repairKilterCatalogStats({
@@ -198,6 +198,104 @@ describe('repairKilterCatalogStats', () => {
         climbUuid: 'canon',
         angle: 40,
         displayDifficulty: 20,
+        upstreamAscensionistCount: 0,
+      },
+    ]);
+  });
+
+  it('reconciles an empty Grips angle to zero when its stats row already exists', async () => {
+    mockFetchLayoutClimbStats.mockImplementation((_token: string, layoutUuid: string) => {
+      if (layoutUuid !== 'layout-a') return Promise.resolve([]);
+      return Promise.resolve([
+        stat({
+          climbUuid: 'canon',
+          angle: 50,
+          ascentCount: 0,
+          currentDifficultyId: 0,
+          difficultyAverage: 0,
+          qualityAverage: 0,
+        }),
+      ]);
+    });
+    const { db, insertValues } = createDbShim({
+      selectResults: [[{ uuid: 'canon' }], []],
+      executeResults: [
+        [],
+        [{ climb_uuid: 'canon', angle: 50 }],
+        [{ changed_rows: '1', max_drop: '7' }],
+        [{ rows_to_recompute: '0' }],
+        { count: 1 },
+        [],
+      ],
+    });
+
+    const summary = await repairKilterCatalogStats({
+      db: db as never,
+      tokenProvider: async () => 'token',
+      reference: reference(),
+      apply: true,
+    });
+
+    expect(summary.canonicalStatsComputed).toBe(1);
+    expect(summary.changedKilterRows).toBe(1);
+    expect(summary.maxKilterDrop).toBe(7);
+    expect(insertValues).toHaveLength(1);
+    expect(insertValues[0]).toMatchObject([
+      {
+        climbUuid: 'canon',
+        angle: 50,
+        displayDifficulty: null,
+        upstreamAscensionistCount: 0,
+      },
+    ]);
+  });
+
+  it('does not let an existing mixed-case key authorize an absent casing variant', async () => {
+    mockBuildLayoutResolver.mockResolvedValue({
+      resolve: vi.fn((layoutUuid: string) => (layoutUuid === 'layout-a' ? 1 : 2)),
+    });
+    mockFetchLayoutClimbStats.mockImplementation((_token: string, layoutUuid: string) =>
+      Promise.resolve([
+        stat({
+          climbUuid: layoutUuid === 'layout-a' ? 'source-a' : 'source-b',
+          angle: 50,
+          ascentCount: 0,
+          currentDifficultyId: 0,
+          difficultyAverage: 0,
+          qualityAverage: 0,
+        }),
+      ]),
+    );
+    const { db, insertValues } = createDbShim({
+      selectResults: [
+        [{ uuid: 'Canon' }],
+        [{ aliasUuid: 'source-a', canonicalUuid: 'Canon' }],
+        [{ uuid: 'canon' }],
+        [{ aliasUuid: 'source-b', canonicalUuid: 'canon' }],
+      ],
+      executeResults: [
+        [],
+        [{ climb_uuid: 'Canon', angle: 50 }],
+        [{ changed_rows: '1', max_drop: '7' }],
+        [{ rows_to_recompute: '0' }],
+        { count: 1 },
+        [],
+      ],
+    });
+
+    const summary = await repairKilterCatalogStats({
+      db: db as never,
+      tokenProvider: async () => 'token',
+      reference: reference(),
+      apply: true,
+    });
+
+    expect(summary.canonicalStatsComputed).toBe(1);
+    expect(insertValues).toHaveLength(1);
+    expect(insertValues[0]).toMatchObject([
+      {
+        climbUuid: 'Canon',
+        angle: 50,
         upstreamAscensionistCount: 0,
       },
     ]);

--- a/packages/kilter-sync/src/sync/stats-repair.ts
+++ b/packages/kilter-sync/src/sync/stats-repair.ts
@@ -79,6 +79,11 @@ type FormulaCountRow = {
   rows_to_recompute: number | string | null;
 };
 
+type ExistingStatKeyRow = {
+  climb_uuid: string;
+  angle: number | string;
+};
+
 type TopRow = {
   name: string | null;
   climb_uuid: string;
@@ -200,6 +205,48 @@ function statValueFromAccum(accum: StatAccum): RepairStatValue {
     // Record that the Kilter Grips stats-repair last touched this row.
     upstreamSyncedAt: new Date().toISOString(),
   };
+}
+
+function repairStatKey(climbUuid: string, angle: number): string {
+  // board_climb_stats uses the exact text UUID in its composite primary key.
+  // Preserve casing here so an existing mixed-case key cannot authorize a
+  // distinct absent casing variant and accidentally create a phantom row.
+  return `${climbUuid}:${angle}`;
+}
+
+async function retainRepairableStats(db: DrizzleDb, stats: StatAccum[]): Promise<StatAccum[]> {
+  const emptyStats = stats.filter(shouldSkipEmptyCatalogStat);
+  if (emptyStats.length === 0) return stats;
+
+  const existingKeys = new Set<string>();
+  await processBatches(emptyStats, async (chunk) => {
+    const incoming = chunk.map((stat) => ({
+      climb_uuid: stat.canonicalUuid,
+      angle: stat.angle,
+    }));
+    const rows = rowsFromResult<ExistingStatKeyRow>(
+      await db.execute(sql`
+        WITH incoming AS (
+          SELECT *
+            FROM jsonb_to_recordset(${JSON.stringify(incoming)}::jsonb)
+              AS i(climb_uuid text, angle integer)
+        )
+        SELECT stats.climb_uuid, stats.angle
+          FROM incoming
+          JOIN board_climb_stats stats
+            ON stats.board_type = ${KILTER}
+           AND stats.climb_uuid = incoming.climb_uuid
+           AND stats.angle = incoming.angle
+      `),
+    );
+    for (const row of rows) {
+      existingKeys.add(repairStatKey(row.climb_uuid, Number(row.angle)));
+    }
+  });
+
+  return stats.filter(
+    (stat) => !shouldSkipEmptyCatalogStat(stat) || existingKeys.has(repairStatKey(stat.canonicalUuid, stat.angle)),
+  );
 }
 
 async function compareExistingStats(
@@ -374,12 +421,12 @@ export async function repairKilterCatalogStats(args: KilterStatsRepairArgs): Pro
     }
   }
 
-  // Keep repair behavior in parity with routine catalog ingest: Grips emits
-  // empty rows for unclimbed layout angles, which must not create phantom
-  // board_climb_stats rows during a repair run.
-  const statValues = [...statsByCanonicalAngle.values()]
-    .filter((accum) => !shouldSkipEmptyCatalogStat(accum))
-    .map(statValueFromAccum);
+  // Grips emits empty rows for unclimbed layout angles. Do not create new
+  // phantom board_climb_stats rows for them, but retain an empty row when its
+  // key already exists so this authoritative repair can lower a stale upstream
+  // count to zero.
+  const repairableStats = await retainRepairableStats(args.db, [...statsByCanonicalAngle.values()]);
+  const statValues = repairableStats.map(statValueFromAccum);
   const { changedRows, maxKilterDrop, maxKilterRise } = await compareExistingStats(args.db, statValues);
   const formulaRowsBeforeApply = await countFormulaMismatches(args.db);
 

--- a/packages/kilter-sync/src/sync/stats-repair.ts
+++ b/packages/kilter-sync/src/sync/stats-repair.ts
@@ -9,7 +9,7 @@ import { fetchLayoutClimbStats } from '../api/kilter-rest';
 import { KilterApiError } from '../api/errors';
 import { pullKilterReference, type KilterReferencePull } from './reference-pull';
 import { buildLayoutResolver } from './layout-resolver';
-import { catalogStatSourceKey, foldCatalogStat, type StatAccum } from './catalog-sync';
+import { catalogStatSourceKey, foldCatalogStat, shouldSkipEmptyCatalogStat, type StatAccum } from './catalog-sync';
 
 type DrizzleDb = PgDatabase<PgQueryResultHKT, Record<string, unknown>>;
 
@@ -374,7 +374,12 @@ export async function repairKilterCatalogStats(args: KilterStatsRepairArgs): Pro
     }
   }
 
-  const statValues = [...statsByCanonicalAngle.values()].map(statValueFromAccum);
+  // Keep repair behavior in parity with routine catalog ingest: Grips emits
+  // empty rows for unclimbed layout angles, which must not create phantom
+  // board_climb_stats rows during a repair run.
+  const statValues = [...statsByCanonicalAngle.values()]
+    .filter((accum) => !shouldSkipEmptyCatalogStat(accum))
+    .map(statValueFromAccum);
   const { changedRows, maxKilterDrop, maxKilterRise } = await compareExistingStats(args.db, statValues);
   const formulaRowsBeforeApply = await countFormulaMismatches(args.db);
 


### PR DESCRIPTION
## Summary

- Keep fully empty upstream angle stats from creating new phantom `board_climb_stats` rows during Kilter repair runs.
- When that exact case-sensitive `(board, canonical UUID, angle)` key already exists, retain the empty upstream result so the authoritative repair can lower a stale upstream count to zero.
- Preserve meaningful zero-ascent stats when Kilter supplies a real grade, and keep case-distinct canonical UUID keys isolated.
- Add regressions for a new empty angle, an existing count corrected to zero, and mixed-case canonical UUIDs at the same angle.

Closes #3522

## Release Notes

Keep empty board angles out of Kilter climb stats after catalog repairs.

## Test plan

- `vp test run --reporter=agent packages/kilter-sync/src/sync/stats-repair.test.ts` (5/5 passed)
- Existing catalog-stat guard suite passed in the original change
- `vp run typecheck:kilter`
- Scoped `vp check` on both changed files
- `git diff --check`
- Independent review reproduced and closed both the stale-existing-count and mixed-case UUID edge cases
