### PR TITLE
fix(mobile): survive a second cache-file vanish rendering overlays

### DIFF
--- a/packages/mobile/ios-tests/BoardRendererErrorClassificationTests.swift
+++ b/packages/mobile/ios-tests/BoardRendererErrorClassificationTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import XCTest
+
+/// Verifies `BoardRendererErrorClassification` — the gate for #4107's bounded
+/// whole-pipeline re-render — against what Foundation *actually* throws, not
+/// just hand-built errors. The headline test performs the real failing
+/// operation the production path hits: `Data.write(to:options:.atomic)` into a
+/// directory that existed and was then deleted, exactly how iOS reclaiming
+/// `Library/Caches` mid-session surfaces in `BoardRendererModule`.
+@available(iOS 17.0, *)
+final class BoardRendererErrorClassificationTests: XCTestCase {
+  /// Creates a real scratch directory under the test runner's temp dir and
+  /// registers its cleanup. Each test gets a unique path so parallel or
+  /// re-run executions can't collide.
+  private func makeScratchDirectory() throws -> URL {
+    let scratchDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("board-renderer-classification-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: scratchDir, withIntermediateDirectories: true)
+    addTeardownBlock {
+      try? FileManager.default.removeItem(at: scratchDir)
+    }
+    return scratchDir
+  }
+
+  /// Nests `error` under `layers` unrelated Cocoa wrappers via
+  /// `NSUnderlyingErrorKey`, mimicking how Foundation chains causes.
+  private func wrapped(_ error: NSError, inLayers layers: Int) -> NSError {
+    var current = error
+    for _ in 0..<layers {
+      current = NSError(
+        domain: NSCocoaErrorDomain,
+        code: NSFileWriteUnknownError,
+        userInfo: [NSUnderlyingErrorKey: current]
+      )
+    }
+    return current
+  }
+
+  // MARK: - Functional: the real production failure shape
+
+  func testAtomicWriteIntoDeletedDirectoryClassifiesAsVanished() throws {
+    let scratchDir = try makeScratchDirectory()
+    let doomedDir = scratchDir.appendingPathComponent("board-thumbnails", isDirectory: true)
+    try FileManager.default.createDirectory(at: doomedDir, withIntermediateDirectories: true)
+    // The reclaim: the directory existed when the "render" started and is gone
+    // by the time the write lands — the exact #4107 sequence.
+    try FileManager.default.removeItem(at: doomedDir)
+
+    let outputUrl = doomedDir.appendingPathComponent("climb.png")
+    do {
+      try Data([0x01]).write(to: outputUrl, options: .atomic)
+      XCTFail("Writing into a deleted directory should throw")
+    } catch {
+      XCTAssertTrue(
+        BoardRendererErrorClassification.isFileVanishedError(error),
+        "A real atomic write into a vanished directory must classify as retryable, got: \(error)"
+      )
+    }
+  }
+
+  func testAtomicWriteThroughRegularFileClassifiesAsNotVanished() throws {
+    // A genuinely different real failure: the parent path exists but is a
+    // regular file, not a directory (POSIX ENOTDIR, not ENOENT). Nothing
+    // vanished, so a re-render can't fix it and it must not retry.
+    let scratchDir = try makeScratchDirectory()
+    let blockingFile = scratchDir.appendingPathComponent("blocker")
+    try Data([0x02]).write(to: blockingFile)
+
+    let outputUrl = blockingFile.appendingPathComponent("climb.png")
+    do {
+      try Data([0x01]).write(to: outputUrl, options: .atomic)
+      XCTFail("Writing through a regular file should throw")
+    } catch {
+      XCTAssertFalse(
+        BoardRendererErrorClassification.isFileVanishedError(error),
+        "A not-a-directory failure is not a vanished cache entry, got: \(error)"
+      )
+    }
+  }
+
+  // MARK: - Classification table
+
+  func testTopLevelNoSuchFileShapesClassifyTrue() {
+    let cocoaNoSuchFile = NSError(domain: NSCocoaErrorDomain, code: NSFileNoSuchFileError)
+    let cocoaReadNoSuchFile = NSError(domain: NSCocoaErrorDomain, code: NSFileReadNoSuchFileError)
+    let posixNoSuchFile = NSError(domain: NSPOSIXErrorDomain, code: Int(ENOENT))
+
+    XCTAssertTrue(BoardRendererErrorClassification.isFileVanishedError(cocoaNoSuchFile))
+    XCTAssertTrue(BoardRendererErrorClassification.isFileVanishedError(cocoaReadNoSuchFile))
+    XCTAssertTrue(BoardRendererErrorClassification.isFileVanishedError(posixNoSuchFile))
+  }
+
+  func testUnwrapsPosixEnoentBuriedUnderCocoaWrappers() {
+    // Foundation write failures can surface as a Cocoa-domain wrapper (e.g.
+    // NSFileWriteUnknownError) carrying the real POSIX ENOENT in
+    // userInfo[NSUnderlyingErrorKey]; the classifier must find it there.
+    let buriedEnoent = wrapped(
+      NSError(domain: NSPOSIXErrorDomain, code: Int(ENOENT)), inLayers: 2
+    )
+    XCTAssertTrue(BoardRendererErrorClassification.isFileVanishedError(buriedEnoent))
+  }
+
+  func testUnderlyingUnwrapIsBounded() {
+    // ENOENT nested deeper than the classifier's unwrap bound stays
+    // unclassified — the bound guarantees termination on pathological chains.
+    let tooDeepEnoent = wrapped(
+      NSError(domain: NSPOSIXErrorDomain, code: Int(ENOENT)), inLayers: 4
+    )
+    XCTAssertFalse(BoardRendererErrorClassification.isFileVanishedError(tooDeepEnoent))
+  }
+
+  func testUnrelatedErrorsClassifyFalse() {
+    // The module's own render/encode failures (Rust render, CGImage wrap, PNG
+    // encoding) share the "BoardRenderer" domain; retrying those would waste
+    // a full render on a deterministic bug.
+    let renderFailure = NSError(
+      domain: "BoardRenderer", code: -3,
+      userInfo: [NSLocalizedDescriptionKey: "Failed to wrap RGBA buffer as CGImage"]
+    )
+    let outOfSpace = NSError(domain: NSCocoaErrorDomain, code: NSFileWriteOutOfSpaceError)
+    let permissionDenied = NSError(domain: NSPOSIXErrorDomain, code: Int(EACCES))
+    let wrappedOutOfSpace = wrapped(
+      NSError(domain: NSPOSIXErrorDomain, code: Int(ENOSPC)), inLayers: 1
+    )
+
+    XCTAssertFalse(BoardRendererErrorClassification.isFileVanishedError(renderFailure))
+    XCTAssertFalse(BoardRendererErrorClassification.isFileVanishedError(outOfSpace))
+    XCTAssertFalse(BoardRendererErrorClassification.isFileVanishedError(permissionDenied))
+    XCTAssertFalse(BoardRendererErrorClassification.isFileVanishedError(wrappedOutOfSpace))
+  }
+}

--- a/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/BoardRendererModule.kt
+++ b/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/BoardRendererModule.kt
@@ -46,19 +46,32 @@ class BoardRendererModule : Module() {
      * and that second [java.io.FileNotFoundException] was previously
      * unguarded, reaching JS as a rejected `renderHoldsOverlay` promise.
      * This wraps the *entire* pipeline — fast-path check, render, and write
-     * — in one more bounded retry: on a vanished-file failure, treat the
+     * — in one more bounded retry: on a vanished-cache failure, treat the
      * cache entry as invalidated and re-run the whole thing exactly once
-     * from scratch. See [CacheMissRecovery] for why this is scoped to
-     * `FileNotFoundException` specifically, narrower than
-     * [CacheDirRecovery]'s own `IOException` contract.
+     * from scratch. See [CacheMissRecovery] for the classification — a
+     * `FileNotFoundException`, or a plain `IOException` caught while the
+     * cache directory is missing (how `File.createTempFile` and the wrapped
+     * `Os.rename` ENOENT actually surface a second vanish) — and for why a
+     * dir-present `IOException` (out-of-space, permissions) stays
+     * non-retryable, narrower than [CacheDirRecovery]'s own `IOException`
+     * contract.
      */
     private fun renderOverlay(configJson: String, cacheKey: String): String {
         ensurePruned()
-        return CacheMissRecovery.retryOnceOnFileNotFound(
-            onRecovered = { failure ->
+        return CacheMissRecovery.retryOnceOnCacheVanish(
+            isCacheDirMissing = { !cacheDir.isDirectory },
+            onRecovered = { failure, cacheDirMissing ->
+                // Log what was actually observed: the gate checked the
+                // directory at catch time, so "dir was missing" is a
+                // verified fact here, not an assumption.
+                val observedCause = if (cacheDirMissing) {
+                    "cache dir ${cacheDir.absolutePath} was missing at failure time"
+                } else {
+                    "cache file path vanished with the dir still in place"
+                }
                 android.util.Log.w(
                     "BoardRenderer",
-                    "Overlay cache file vanished mid-request for $cacheKey; invalidating and re-rendering once",
+                    "Overlay render failed for $cacheKey ($observedCause); invalidating and re-rendering once",
                     failure,
                 )
             },

--- a/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/BoardRendererModule.kt
+++ b/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/BoardRendererModule.kt
@@ -16,27 +16,58 @@ class BoardRendererModule : Module() {
     @Volatile
     private var pruned = false
 
-    private fun renderOverlay(configJson: String, cacheKey: String): String {
-        if (!pruned) {
-            synchronized(this@BoardRendererModule) {
-                if (!pruned) {
-                    val result = CachePruner.pruneCacheIfNeeded(cacheDir, CACHE_CAP_BYTES)
-                    if (result.orphanedTempFilesRemoved > 0) {
-                        android.util.Log.i(
-                            "BoardRenderer",
-                            "Swept ${result.orphanedTempFilesRemoved} orphaned temp file(s) from a prior crash",
-                        )
-                    }
-                    if (result.cacheEntriesEvicted > 0) {
-                        android.util.Log.i(
-                            "BoardRenderer",
-                            "Pruned ${result.cacheEntriesEvicted} cached PNGs; new total ${result.finalTotalBytes} bytes",
-                        )
-                    }
-                    pruned = true
+    private fun ensurePruned() {
+        if (pruned) return
+        synchronized(this@BoardRendererModule) {
+            if (!pruned) {
+                val result = CachePruner.pruneCacheIfNeeded(cacheDir, CACHE_CAP_BYTES)
+                if (result.orphanedTempFilesRemoved > 0) {
+                    android.util.Log.i(
+                        "BoardRenderer",
+                        "Swept ${result.orphanedTempFilesRemoved} orphaned temp file(s) from a prior crash",
+                    )
                 }
+                if (result.cacheEntriesEvicted > 0) {
+                    android.util.Log.i(
+                        "BoardRenderer",
+                        "Pruned ${result.cacheEntriesEvicted} cached PNGs; new total ${result.finalTotalBytes} bytes",
+                    )
+                }
+                pruned = true
             }
         }
+    }
+
+    /**
+     * #4107: [CacheDirRecovery] already retries the write once if the cache
+     * directory vanishes mid-request, but under sustained storage pressure
+     * that single retry can lose too — the recreated directory (or a fresh
+     * temp file inside it) can vanish again before the retried write lands,
+     * and that second [java.io.FileNotFoundException] was previously
+     * unguarded, reaching JS as a rejected `renderHoldsOverlay` promise.
+     * This wraps the *entire* pipeline — fast-path check, render, and write
+     * — in one more bounded retry: on a vanished-file failure, treat the
+     * cache entry as invalidated and re-run the whole thing exactly once
+     * from scratch. See [CacheMissRecovery] for why this is scoped to
+     * `FileNotFoundException` specifically, narrower than
+     * [CacheDirRecovery]'s own `IOException` contract.
+     */
+    private fun renderOverlay(configJson: String, cacheKey: String): String {
+        ensurePruned()
+        return CacheMissRecovery.retryOnceOnFileNotFound(
+            onRecovered = { failure ->
+                android.util.Log.w(
+                    "BoardRenderer",
+                    "Overlay cache file vanished mid-request for $cacheKey; invalidating and re-rendering once",
+                    failure,
+                )
+            },
+        ) {
+            renderOverlayOnce(configJson, cacheKey)
+        }
+    }
+
+    private fun renderOverlayOnce(configJson: String, cacheKey: String): String {
         val outputFile = File(cacheDir, "$cacheKey.png")
 
         if (outputFile.exists()) {

--- a/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/CacheMissRecovery.kt
+++ b/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/CacheMissRecovery.kt
@@ -20,38 +20,61 @@ import java.io.IOException
  * defense-in-depth if a future change to the fast path ever adds a real
  * read.
  *
- * Deliberately narrower than [CacheDirRecovery]: this only retries
- * [FileNotFoundException] specifically — "the cache file/dir isn't there
- * right now" — not the broader [IOException] contract [CacheDirRecovery]
- * accepts (which also covers e.g. an out-of-space failure with the
- * directory in place the whole time). A vanished cache entry is recoverable
- * by re-rendering; an out-of-space condition usually isn't, and silently
- * retrying the entire pipeline for it would double the wasted work without
- * fixing anything. [CacheDirRecovery] keeps owning that broader,
- * write-scoped retry as its own inner concern.
+ * The retry gate is a *vanished cache*, classified two ways:
  *
- * Pure Kotlin, no Android framework calls, no `File`-specific coupling — it
- * just retries a callable once on a specific exception type — so
+ * 1. [FileNotFoundException] — the classic "the cache file/dir isn't there
+ *    right now" signal, kept as an explicit retry trigger in its own right
+ *    (it is an [IOException] subclass, so it would also pass the second
+ *    check whenever the directory is gone, but the intent — a missing
+ *    *path*, retry-worthy regardless of directory state at catch time — is
+ *    preserved explicitly).
+ * 2. A plain [IOException] thrown while the cache directory is missing
+ *    ([isCacheDirMissing] returns true at catch time). In the current
+ *    atomic-write pipeline most second-vanish failures surface this way,
+ *    not as FNF: `File.createTempFile` into a vanished directory throws a
+ *    plain `IOException("No such file or directory")`, and an ENOENT
+ *    `ErrnoException` from `Os.rename` is wrapped in a plain [IOException]
+ *    by [AndroidAtomicFileCommitter].
+ *
+ * A plain [IOException] with the directory still in place — out-of-space,
+ * permissions — is deliberately NOT retried: that failure mode is not a
+ * vanished cache entry, re-rendering can't fix it, and silently retrying
+ * the entire pipeline for it would double the wasted work without fixing
+ * anything. This keeps the contract narrower than [CacheDirRecovery]'s
+ * broad `IOException` acceptance, which stays that helper's own inner,
+ * write-scoped concern.
+ *
+ * Pure Kotlin, no Android framework calls, no `File`-specific coupling —
+ * the directory check is injected as [isCacheDirMissing] (the call site in
+ * [BoardRendererModule] supplies the real `!cacheDir.isDirectory`) — so
  * [CacheMissRecoveryTest] needs neither Robolectric nor a real cache
  * directory, matching [CacheDirRecovery]'s approach for its sibling helper.
  */
 object CacheMissRecovery {
     /**
-     * Runs [action]. If it throws [FileNotFoundException], invokes
-     * [onRecovered] with the original failure and runs [action] exactly one
-     * more time. Any other exception — including a broader [IOException] —
-     * propagates immediately, untouched. A second [FileNotFoundException]
-     * also propagates: the retry is bounded to one extra attempt, so a
-     * persistently vanished cache path still fails fast instead of looping.
+     * Runs [action]. If it throws a retryable failure — a
+     * [FileNotFoundException], or any other [IOException] while
+     * [isCacheDirMissing] reports the cache directory gone — invokes
+     * [onRecovered] with the original failure plus the directory-missing
+     * verdict (so the call site can log what actually happened), and runs
+     * [action] exactly one more time. A non-retryable failure — a plain
+     * [IOException] with the directory still present, or anything that isn't
+     * an [IOException] at all — propagates immediately, untouched. A second
+     * retryable failure also propagates: the retry is bounded to one extra
+     * attempt, so a persistently vanished cache path still fails fast
+     * instead of looping.
      */
-    fun <T> retryOnceOnFileNotFound(
-        onRecovered: (FileNotFoundException) -> Unit = {},
+    fun <T> retryOnceOnCacheVanish(
+        isCacheDirMissing: () -> Boolean,
+        onRecovered: (failure: IOException, cacheDirMissing: Boolean) -> Unit = { _, _ -> },
         action: () -> T,
     ): T {
         return try {
             action()
-        } catch (failure: FileNotFoundException) {
-            onRecovered(failure)
+        } catch (failure: IOException) {
+            val cacheDirMissing = isCacheDirMissing()
+            if (failure !is FileNotFoundException && !cacheDirMissing) throw failure
+            onRecovered(failure, cacheDirMissing)
             action()
         }
     }

--- a/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/CacheMissRecovery.kt
+++ b/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/CacheMissRecovery.kt
@@ -1,0 +1,58 @@
+package com.boardsesh.boardrenderer
+
+import java.io.FileNotFoundException
+import java.io.IOException
+
+/**
+ * Bounds retry for the *whole* overlay-cache pipeline (fast-path check,
+ * render, and write), not just the write step [CacheDirRecovery] already
+ * guards.
+ *
+ * #4107: even with #4041's directory-recreation retry and #3748's atomic
+ * write, a single retry can still lose to *sustained* storage pressure —
+ * the just-recreated directory (or a freshly created temp file inside it)
+ * can vanish a second time before the retried write lands. That second
+ * failure was previously unguarded and reached JS as a rejected
+ * `renderHoldsOverlay` promise. Investigation for #4107 also confirmed the
+ * fast-path cache-hit check (`outputFile.exists()` / `.length()` /
+ * `.setLastModified()`) is metadata-only and never throws on its own — so
+ * this wrapper exists to survive a second write-side vanish, and as
+ * defense-in-depth if a future change to the fast path ever adds a real
+ * read.
+ *
+ * Deliberately narrower than [CacheDirRecovery]: this only retries
+ * [FileNotFoundException] specifically — "the cache file/dir isn't there
+ * right now" — not the broader [IOException] contract [CacheDirRecovery]
+ * accepts (which also covers e.g. an out-of-space failure with the
+ * directory in place the whole time). A vanished cache entry is recoverable
+ * by re-rendering; an out-of-space condition usually isn't, and silently
+ * retrying the entire pipeline for it would double the wasted work without
+ * fixing anything. [CacheDirRecovery] keeps owning that broader,
+ * write-scoped retry as its own inner concern.
+ *
+ * Pure Kotlin, no Android framework calls, no `File`-specific coupling — it
+ * just retries a callable once on a specific exception type — so
+ * [CacheMissRecoveryTest] needs neither Robolectric nor a real cache
+ * directory, matching [CacheDirRecovery]'s approach for its sibling helper.
+ */
+object CacheMissRecovery {
+    /**
+     * Runs [action]. If it throws [FileNotFoundException], invokes
+     * [onRecovered] with the original failure and runs [action] exactly one
+     * more time. Any other exception — including a broader [IOException] —
+     * propagates immediately, untouched. A second [FileNotFoundException]
+     * also propagates: the retry is bounded to one extra attempt, so a
+     * persistently vanished cache path still fails fast instead of looping.
+     */
+    fun <T> retryOnceOnFileNotFound(
+        onRecovered: (FileNotFoundException) -> Unit = {},
+        action: () -> T,
+    ): T {
+        return try {
+            action()
+        } catch (failure: FileNotFoundException) {
+            onRecovered(failure)
+            action()
+        }
+    }
+}

--- a/packages/mobile/modules/board-renderer/android/src/test/java/com/boardsesh/boardrenderer/CacheMissRecoveryTest.kt
+++ b/packages/mobile/modules/board-renderer/android/src/test/java/com/boardsesh/boardrenderer/CacheMissRecoveryTest.kt
@@ -1,0 +1,99 @@
+package com.boardsesh.boardrenderer
+
+import java.io.FileNotFoundException
+import java.io.IOException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+/**
+ * Covers [CacheMissRecovery] in isolation. The guard's single call site —
+ * `CacheMissRecovery.retryOnceOnFileNotFound { renderOverlayOnce(...) }`
+ * wrapping the whole cache-check-render-write pipeline in
+ * `BoardRendererModule.renderOverlay` — is *not* covered here, for the same
+ * reason [CacheDirRecoveryTest] doesn't cover its own call site: exercising
+ * it needs a real `Bitmap` (JNI) plus a `Module` appContext, i.e. a
+ * Robolectric harness, which is disproportionate for this fix. Keep the
+ * wrapper at that one call site; deleting it re-opens #4107 without failing
+ * anything below.
+ */
+class CacheMissRecoveryTest {
+    @Test
+    fun `retries exactly once when the action throws FileNotFoundException`() {
+        var attempts = 0
+        var recoveredFrom: FileNotFoundException? = null
+        val originalFailure = FileNotFoundException("cache file vanished")
+
+        val result = CacheMissRecovery.retryOnceOnFileNotFound(
+            onRecovered = { failure -> recoveredFrom = failure },
+        ) {
+            attempts++
+            if (attempts == 1) throw originalFailure
+            "file:///cache/climb.png"
+        }
+
+        assertEquals("action ran once, failed, then ran again", 2, attempts)
+        assertEquals("file:///cache/climb.png", result)
+        assertSame("the call site gets the original failure to log", originalFailure, recoveredFrom)
+    }
+
+    @Test
+    fun `a second FileNotFoundException propagates instead of looping`() {
+        var attempts = 0
+
+        val failure = try {
+            CacheMissRecovery.retryOnceOnFileNotFound {
+                attempts++
+                throw FileNotFoundException("still gone")
+            }
+            null
+        } catch (thrown: FileNotFoundException) {
+            thrown
+        }
+
+        assertEquals("retry is bounded to one extra attempt", 2, attempts)
+        assertEquals("still gone", failure?.message)
+    }
+
+    @Test
+    fun `a broader IOException is not retried`() {
+        var attempts = 0
+        var recovered = false
+        val originalFailure = IOException("disk full")
+
+        val failure = try {
+            CacheMissRecovery.retryOnceOnFileNotFound(
+                onRecovered = { recovered = true },
+            ) {
+                attempts++
+                throw originalFailure
+            }
+            null
+        } catch (thrown: IOException) {
+            thrown
+        }
+
+        assertEquals("no retry for a non-FileNotFoundException failure", 1, attempts)
+        assertFalse("nothing to log when there was no recovery", recovered)
+        assertSame(originalFailure, failure)
+    }
+
+    @Test
+    fun `passes the value through untouched on the happy path`() {
+        var attempts = 0
+        var recoveredFrom: FileNotFoundException? = null
+
+        val result = CacheMissRecovery.retryOnceOnFileNotFound(
+            onRecovered = { failure -> recoveredFrom = failure },
+        ) {
+            attempts++
+            "file:///cache/climb.png"
+        }
+
+        assertEquals(1, attempts)
+        assertEquals("file:///cache/climb.png", result)
+        assertNull("no recovery on the hot path", recoveredFrom)
+    }
+}

--- a/packages/mobile/modules/board-renderer/android/src/test/java/com/boardsesh/boardrenderer/CacheMissRecoveryTest.kt
+++ b/packages/mobile/modules/board-renderer/android/src/test/java/com/boardsesh/boardrenderer/CacheMissRecoveryTest.kt
@@ -6,11 +6,12 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
  * Covers [CacheMissRecovery] in isolation. The guard's single call site —
- * `CacheMissRecovery.retryOnceOnFileNotFound { renderOverlayOnce(...) }`
+ * `CacheMissRecovery.retryOnceOnCacheVanish(...) { renderOverlayOnce(...) }`
  * wrapping the whole cache-check-render-write pipeline in
  * `BoardRendererModule.renderOverlay` — is *not* covered here, for the same
  * reason [CacheDirRecoveryTest] doesn't cover its own call site: exercising
@@ -23,11 +24,12 @@ class CacheMissRecoveryTest {
     @Test
     fun `retries exactly once when the action throws FileNotFoundException`() {
         var attempts = 0
-        var recoveredFrom: FileNotFoundException? = null
+        var recoveredFrom: IOException? = null
         val originalFailure = FileNotFoundException("cache file vanished")
 
-        val result = CacheMissRecovery.retryOnceOnFileNotFound(
-            onRecovered = { failure -> recoveredFrom = failure },
+        val result = CacheMissRecovery.retryOnceOnCacheVanish(
+            isCacheDirMissing = { true },
+            onRecovered = { failure, _ -> recoveredFrom = failure },
         ) {
             attempts++
             if (attempts == 1) throw originalFailure
@@ -40,11 +42,97 @@ class CacheMissRecoveryTest {
     }
 
     @Test
+    fun `FileNotFoundException retries even when the cache dir is back at catch time`() {
+        // FNF stays an explicit retry signal in its own right: the path was
+        // missing when the action ran, and a concurrent CacheDirRecovery (or
+        // the OS) restoring the directory before our catch runs must not
+        // disqualify the retry.
+        var attempts = 0
+        var reportedDirMissing: Boolean? = null
+
+        val result = CacheMissRecovery.retryOnceOnCacheVanish(
+            isCacheDirMissing = { false },
+            onRecovered = { _, cacheDirMissing -> reportedDirMissing = cacheDirMissing },
+        ) {
+            attempts++
+            if (attempts == 1) throw FileNotFoundException("file vanished, dir already restored")
+            "file:///cache/climb.png"
+        }
+
+        assertEquals(2, attempts)
+        assertEquals("file:///cache/climb.png", result)
+        assertEquals("the call site is told the dir was present again", false, reportedDirMissing)
+    }
+
+    @Test
+    fun `a plain IOException with the cache dir missing retries exactly once`() {
+        // How a second vanish actually surfaces in the atomic-write pipeline:
+        // File.createTempFile into a vanished dir throws plain IOException,
+        // and AndroidAtomicFileCommitter wraps Os.rename's ENOENT
+        // ErrnoException in plain IOException — neither is an FNF.
+        var attempts = 0
+        var recoveredFrom: IOException? = null
+        var reportedDirMissing: Boolean? = null
+        val originalFailure = IOException("No such file or directory")
+
+        val result = CacheMissRecovery.retryOnceOnCacheVanish(
+            isCacheDirMissing = { true },
+            onRecovered = { failure, cacheDirMissing ->
+                recoveredFrom = failure
+                reportedDirMissing = cacheDirMissing
+            },
+        ) {
+            attempts++
+            if (attempts == 1) throw originalFailure
+            "file:///cache/climb.png"
+        }
+
+        assertEquals("action ran once, failed, then ran again", 2, attempts)
+        assertEquals("file:///cache/climb.png", result)
+        assertSame(originalFailure, recoveredFrom)
+        assertEquals("the call site can truthfully log the missing dir", true, reportedDirMissing)
+    }
+
+    @Test
+    fun `a plain IOException with the cache dir present is not retried`() {
+        // Out-of-space or permission failures with the directory in place the
+        // whole time are not a vanished cache entry; re-rendering can't fix
+        // them, so the broad-IOException contract stays rejected here.
+        var attempts = 0
+        var recovered = false
+        var dirChecked = false
+        val originalFailure = IOException("disk full")
+
+        val failure = try {
+            CacheMissRecovery.retryOnceOnCacheVanish(
+                isCacheDirMissing = {
+                    dirChecked = true
+                    false
+                },
+                onRecovered = { _, _ -> recovered = true },
+            ) {
+                attempts++
+                throw originalFailure
+            }
+            null
+        } catch (thrown: IOException) {
+            thrown
+        }
+
+        assertEquals("no retry for a dir-present IOException", 1, attempts)
+        assertTrue("the gate consulted the injected dir check", dirChecked)
+        assertFalse("nothing to log when there was no recovery", recovered)
+        assertSame(originalFailure, failure)
+    }
+
+    @Test
     fun `a second FileNotFoundException propagates instead of looping`() {
         var attempts = 0
 
         val failure = try {
-            CacheMissRecovery.retryOnceOnFileNotFound {
+            CacheMissRecovery.retryOnceOnCacheVanish(
+                isCacheDirMissing = { true },
+            ) {
                 attempts++
                 throw FileNotFoundException("still gone")
             }
@@ -58,35 +146,61 @@ class CacheMissRecoveryTest {
     }
 
     @Test
-    fun `a broader IOException is not retried`() {
+    fun `a second dir-missing IOException propagates instead of looping`() {
         var attempts = 0
-        var recovered = false
-        val originalFailure = IOException("disk full")
 
         val failure = try {
-            CacheMissRecovery.retryOnceOnFileNotFound(
-                onRecovered = { recovered = true },
+            CacheMissRecovery.retryOnceOnCacheVanish(
+                isCacheDirMissing = { true },
             ) {
                 attempts++
-                throw originalFailure
+                throw IOException("dir keeps vanishing")
             }
             null
         } catch (thrown: IOException) {
             thrown
         }
 
-        assertEquals("no retry for a non-FileNotFoundException failure", 1, attempts)
-        assertFalse("nothing to log when there was no recovery", recovered)
+        assertEquals("retry is bounded to one extra attempt", 2, attempts)
+        assertEquals("dir keeps vanishing", failure?.message)
+    }
+
+    @Test
+    fun `a non-IOException failure propagates untouched`() {
+        var attempts = 0
+        var recovered = false
+        val originalFailure = IllegalStateException("Rust render failed")
+
+        val failure = try {
+            CacheMissRecovery.retryOnceOnCacheVanish(
+                isCacheDirMissing = { true },
+                onRecovered = { _, _ -> recovered = true },
+            ) {
+                attempts++
+                throw originalFailure
+            }
+            null
+        } catch (thrown: IllegalStateException) {
+            thrown
+        }
+
+        assertEquals("no retry for a non-IO failure, even with the dir missing", 1, attempts)
+        assertFalse(recovered)
         assertSame(originalFailure, failure)
     }
 
     @Test
     fun `passes the value through untouched on the happy path`() {
         var attempts = 0
-        var recoveredFrom: FileNotFoundException? = null
+        var recoveredFrom: IOException? = null
+        var dirChecked = false
 
-        val result = CacheMissRecovery.retryOnceOnFileNotFound(
-            onRecovered = { failure -> recoveredFrom = failure },
+        val result = CacheMissRecovery.retryOnceOnCacheVanish(
+            isCacheDirMissing = {
+                dirChecked = true
+                true
+            },
+            onRecovered = { failure, _ -> recoveredFrom = failure },
         ) {
             attempts++
             "file:///cache/climb.png"
@@ -95,5 +209,6 @@ class CacheMissRecoveryTest {
         assertEquals(1, attempts)
         assertEquals("file:///cache/climb.png", result)
         assertNull("no recovery on the hot path", recoveredFrom)
+        assertFalse("the dir check only runs after a failure", dirChecked)
     }
 }

--- a/packages/mobile/modules/board-renderer/ios/BoardRendererErrorClassification.swift
+++ b/packages/mobile/modules/board-renderer/ios/BoardRendererErrorClassification.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Classifies the errors `BoardRendererModule`'s bounded whole-pipeline retry
+/// (#4107) is allowed to treat as "the cache file/dir vanished, re-render once".
+///
+/// Foundation-only on purpose: this file is also compiled into the
+/// `BoardseshTests` XCTest target (see `scripts/prepare-rn-ios-tests.mjs`), so
+/// `BoardRendererErrorClassificationTests` can exercise it against errors a real
+/// `Data.write(to:options:.atomic)` into a deleted directory actually throws —
+/// without dragging ExpoModulesCore or the Rust renderer into the test build.
+enum BoardRendererErrorClassification {
+  /// How many `NSUnderlyingErrorKey` links to follow. Foundation nests at most
+  /// a couple of levels in practice (e.g. a Cocoa write error wrapping the
+  /// POSIX cause); the bound just guarantees termination on a pathological
+  /// self-referencing chain.
+  private static let maxUnderlyingErrorDepth = 4
+
+  /// True when `error` means "the file or its directory isn't there" — the only
+  /// failure shape the #4107 retry treats as a vanished, re-renderable cache
+  /// entry:
+  ///
+  /// - `NSCocoaErrorDomain` / `NSFileNoSuchFileError` or
+  ///   `NSFileReadNoSuchFileError` — what Foundation's file APIs report for a
+  ///   missing path at the Cocoa layer, or
+  /// - `NSPOSIXErrorDomain` / `ENOENT` — the lower-level POSIX shape.
+  ///
+  /// Foundation write failures don't always surface those at the top level: a
+  /// Cocoa-domain wrapper (e.g. `NSFileWriteUnknownError`) can carry the real
+  /// POSIX `ENOENT` in `userInfo[NSUnderlyingErrorKey]`, so the chain of
+  /// underlying errors is unwrapped (bounded) and classified too.
+  ///
+  /// Everything else stays non-retryable: out-of-space and permission failures
+  /// aren't fixed by re-rendering, and the three `"BoardRenderer"`-domain
+  /// `NSError`s (Rust render failure, failed `CGImage` wrap, failed PNG
+  /// encoding) are a different domain entirely — retrying a genuine encoder or
+  /// render bug would waste work without fixing anything.
+  static func isFileVanishedError(_ error: Error) -> Bool {
+    var current = error as NSError
+    for _ in 0..<maxUnderlyingErrorDepth {
+      if matchesFileVanished(current) { return true }
+      guard let underlying = current.userInfo[NSUnderlyingErrorKey] as? NSError else {
+        return false
+      }
+      current = underlying
+    }
+    return false
+  }
+
+  private static func matchesFileVanished(_ nsError: NSError) -> Bool {
+    if nsError.domain == NSCocoaErrorDomain,
+      nsError.code == NSFileNoSuchFileError || nsError.code == NSFileReadNoSuchFileError
+    {
+      return true
+    }
+    if nsError.domain == NSPOSIXErrorDomain, nsError.code == Int(ENOENT) {
+      return true
+    }
+    return false
+  }
+}

--- a/packages/mobile/modules/board-renderer/ios/BoardRendererModule.swift
+++ b/packages/mobile/modules/board-renderer/ios/BoardRendererModule.swift
@@ -108,37 +108,19 @@ public class BoardRendererModule: Module {
   /// invalidated and re-run the whole thing exactly once from scratch.
   ///
   /// Deliberately narrow, mirroring the Android twin `CacheMissRecovery`:
-  /// only a file-not-found-shaped error is retried — `NSCocoaErrorDomain` /
-  /// `NSFileNoSuchFileError` (what `Data.write(to:options:.atomic)` throws
-  /// for a missing directory) or `NSPOSIXErrorDomain` / `ENOENT` (in case the
-  /// underlying implementation surfaces a lower-level POSIX error instead).
-  /// The exact domain/code Foundation uses here is unverified against a real
-  /// device or simulator — no Mac was available while writing this — so both
-  /// are checked defensively; narrow it further once confirmed. The three
-  /// `"BoardRenderer"`-domain `NSError`s below (Rust render failure, failed
-  /// `CGImage` wrap, failed PNG encoding) are a different domain entirely and
-  /// so are never matched here — retrying a genuine encoder or render bug
-  /// would waste work without fixing anything.
-  private func isFileVanishedError(_ error: Error) -> Bool {
-    let nsError = error as NSError
-    if nsError.domain == NSCocoaErrorDomain,
-      nsError.code == NSFileNoSuchFileError || nsError.code == NSFileReadNoSuchFileError
-    {
-      return true
-    }
-    if nsError.domain == NSPOSIXErrorDomain, nsError.code == Int(ENOENT) {
-      return true
-    }
-    return false
-  }
-
+  /// only a file-not-found-shaped error is retried. The classification —
+  /// Cocoa no-such-file codes, POSIX `ENOENT`, and a bounded unwrap of
+  /// `NSUnderlyingErrorKey` for Cocoa wrappers that carry the POSIX cause —
+  /// lives in `BoardRendererErrorClassification`, which is compiled into the
+  /// `BoardseshTests` XCTest target and verified there against the error a
+  /// real `Data.write(to:options:.atomic)` into a deleted directory throws.
   private func renderOverlay(configJson: String, cacheKey: String) throws -> String {
     do {
       return try renderOverlayOnce(configJson: configJson, cacheKey: cacheKey)
     } catch {
-      guard isFileVanishedError(error) else { throw error }
+      guard BoardRendererErrorClassification.isFileVanishedError(error) else { throw error }
       NSLog(
-        "[BoardRenderer] Overlay cache file vanished mid-request for \(cacheKey); invalidating and re-rendering once"
+        "[BoardRenderer] Overlay cache file vanished mid-request for \(cacheKey) (\(error)); invalidating and re-rendering once"
       )
       return try renderOverlayOnce(configJson: configJson, cacheKey: cacheKey)
     }

--- a/packages/mobile/modules/board-renderer/ios/BoardRendererModule.swift
+++ b/packages/mobile/modules/board-renderer/ios/BoardRendererModule.swift
@@ -97,7 +97,54 @@ public class BoardRendererModule: Module {
     }
   }
 
+  /// #4107: `retryOnceAfterRecreatingCacheDir` already retries the write once
+  /// if the cache directory vanishes mid-request, but under sustained storage
+  /// pressure that single retry can lose too — the recreated directory (or a
+  /// fresh temp file inside it) can vanish again before the retried write
+  /// lands, and that second file-not-found error was previously unguarded,
+  /// reaching JS as a rejected `renderHoldsOverlay` promise. This wraps the
+  /// *entire* pipeline — fast-path check, render, and write — in one more
+  /// bounded retry: on a vanished-file failure, treat the cache entry as
+  /// invalidated and re-run the whole thing exactly once from scratch.
+  ///
+  /// Deliberately narrow, mirroring the Android twin `CacheMissRecovery`:
+  /// only a file-not-found-shaped error is retried — `NSCocoaErrorDomain` /
+  /// `NSFileNoSuchFileError` (what `Data.write(to:options:.atomic)` throws
+  /// for a missing directory) or `NSPOSIXErrorDomain` / `ENOENT` (in case the
+  /// underlying implementation surfaces a lower-level POSIX error instead).
+  /// The exact domain/code Foundation uses here is unverified against a real
+  /// device or simulator — no Mac was available while writing this — so both
+  /// are checked defensively; narrow it further once confirmed. The three
+  /// `"BoardRenderer"`-domain `NSError`s below (Rust render failure, failed
+  /// `CGImage` wrap, failed PNG encoding) are a different domain entirely and
+  /// so are never matched here — retrying a genuine encoder or render bug
+  /// would waste work without fixing anything.
+  private func isFileVanishedError(_ error: Error) -> Bool {
+    let nsError = error as NSError
+    if nsError.domain == NSCocoaErrorDomain,
+      nsError.code == NSFileNoSuchFileError || nsError.code == NSFileReadNoSuchFileError
+    {
+      return true
+    }
+    if nsError.domain == NSPOSIXErrorDomain, nsError.code == Int(ENOENT) {
+      return true
+    }
+    return false
+  }
+
   private func renderOverlay(configJson: String, cacheKey: String) throws -> String {
+    do {
+      return try renderOverlayOnce(configJson: configJson, cacheKey: cacheKey)
+    } catch {
+      guard isFileVanishedError(error) else { throw error }
+      NSLog(
+        "[BoardRenderer] Overlay cache file vanished mid-request for \(cacheKey); invalidating and re-rendering once"
+      )
+      return try renderOverlayOnce(configJson: configJson, cacheKey: cacheKey)
+    }
+  }
+
+  private func renderOverlayOnce(configJson: String, cacheKey: String) throws -> String {
     _ = self.pruneOnce
     let outputUrl = self.cacheDir.appendingPathComponent("\(cacheKey).png")
 

--- a/scripts/prepare-rn-ios-tests.mjs
+++ b/scripts/prepare-rn-ios-tests.mjs
@@ -34,6 +34,14 @@ const TEST_SOURCE_FILES = [
     projectPath: 'BoardseshTests/BoardBleServiceDiscoveryTests.swift',
   },
   {
+    sourcePath: '../ios-tests/BoardRendererErrorClassificationTests.swift',
+    projectPath: 'BoardseshTests/BoardRendererErrorClassificationTests.swift',
+  },
+  {
+    sourcePath: '../modules/board-renderer/ios/BoardRendererErrorClassification.swift',
+    projectPath: 'BoardseshTests/BoardRendererSources/BoardRendererErrorClassification.swift',
+  },
+  {
     sourcePath: '../modules/live-activity/ios/BoardBleManager.swift',
     projectPath: 'BoardseshTests/LiveActivitySources/BoardBleManager.swift',
   },


### PR DESCRIPTION
> [!IMPORTANT]
> **[native-train]** — this PR touches native Kotlin (`modules/board-renderer/android/`) and Swift (`modules/board-renderer/ios/`) and moves the Expo native fingerprint. Per repo policy, `main` must stay OTA-compatible with store binaries, so this PR **stays a draft** and rides the next native release train — do not mark it ready for review or merge it on its own schedule.

## Summary

Closes #4107.

`BoardRenderer.renderHoldsOverlay` still throws `FileNotFoundException: ... open failed: ENOENT` on rare occasions after #4041's cache-directory recovery and #3748/#4073/#4081's atomic write — 1230 events / 9 users over 14 days in Sentry's `BOARDSESH-6V` bucket.

### Correcting the issue's TOCTOU framing before it outlives the fix

#4107 frames the residual bug as: `outputFile.exists()` → `setLastModified()` → return can race a concurrent evict/reclaim, i.e. a check-then-use gap on the **read** side. Investigation for this PR found that framing doesn't hold up against the current code on either platform:

- Android's fast path (`outputFile.exists()` / `.length()` / `.setLastModified()`) and iOS's (`attributesOfItem(atPath:)` / `setAttributes`) are all filesystem **metadata** ops. None of them call `open()`, so none of them can throw `FileNotFoundException: ... open failed: ENOENT` — that message format is specific to opening a stream. The actual file *read* happens downstream, in the JS `<Image>` that consumes the returned `file://` URI, outside this promise entirely.
- The real throw site is the **write** pipeline, and the real gap is that its retry is bounded to exactly one attempt: `CacheDirRecovery.retryOnceAfterRecreating` (Android) / `retryOnceAfterRecreatingCacheDir` (iOS) each recreate the cache dir and retry the write **once**. Under sustained storage pressure, the just-recreated directory (or a fresh temp file inside it) can vanish again before the retried write lands, and that second failure was unguarded — it propagated straight out as the rejected `renderHoldsOverlay` promise. This matches the issue's own hypothesis #1 ("the retry runs and fails again... directory reclaimed faster than one retry can win").

Also worth stating plainly for the record: the Sentry window (last-seen 2026-07-29) entirely **predates** #4073/#4081 landing on main (2026-07-31/08-01). Those PRs replaced the old direct `FileOutputStream(outputFile)`-on-the-final-path write (the exact crash #3748 originally documented) with a temp-file-then-rename. A meaningful share of the 1230 events almost certainly reflects binaries shipped before that fix — and `BOARDSESH-6V` is flagged as an over-merged bucket (#4101) — so the residual volume this PR is actually closing is smaller than the raw count suggests. Re-check the bucket after this ships in a native release before drawing conclusions from it.

### The fix

One more bounded retry, wrapping the **entire** cache-check-render-write pipeline (not just the write step `CacheDirRecovery` already guards):

- **Android** — new `CacheMissRecovery.retryOnceOnFileNotFound { … }` (pure Kotlin, no Android framework calls, no `File` coupling). `BoardRendererModule.renderOverlay` now wraps the renamed `renderOverlayOnce` in this retry: on `FileNotFoundException`, log and re-run the whole pipeline exactly once from scratch (fresh fast-path check, fresh render, fresh write — including a fresh inner `CacheDirRecovery` pass). Deliberately narrower than `CacheDirRecovery`'s `IOException` contract: only a vanished-file failure is recoverable by re-rendering; a broader `IOException` (e.g. genuine out-of-space) isn't, and retrying the whole pipeline for it would double the wasted work without fixing anything.
- **iOS** — mirrors the same shape: `isFileVanishedError(_:)` checks for `NSCocoaErrorDomain`/`NSFileNoSuchFileError` (what `Data.write(to:options:.atomic)` throws for a missing directory) or `NSPOSIXErrorDomain`/`ENOENT` (in case the underlying call surfaces a lower-level POSIX error instead), and `renderOverlay` retries `renderOverlayOnce` once on a match. **Flagging the uncertainty explicitly**: the exact domain/code Foundation raises here is unverified against a real device or simulator — no Mac was available while writing this — both are checked defensively as a reasonable superset. The three `"BoardRenderer"`-domain `NSError`s (Rust render failure, failed `CGImage` wrap, failed PNG encoding) are a different domain entirely and are never matched, so a genuine render/encoder bug is never masked by a pointless retry.

### Follow-up filed (not in scope here)

Investigation surfaced a related but distinct issue: `use-native-climb-render.ts`'s `renderedOverlays` map can hand `<Image>` a `file://` URI for an entry that `CachePruner`'s 200MB LRU cap evicts moments later — that fails silently (blank overlay, no crash, no Sentry event), so it's a different symptom than this issue's thrown exception. Filed separately: #4113.

## Release Notes

- Board hold overlays recover instead of erroring when the phone reclaims cache storage mid-render.

## Test plan

**Green `vp` checks below do not cover this fix.** This is pure native Kotlin/Swift; nothing in `vp check` / `vp run typecheck:mobile` / `vp run test:mobile` / `vp run check:mobile-bundle` compiles or exercises either platform's code — confirmed both pass unchanged (no JS/TS touched).

- **Android**: new `CacheMissRecoveryTest.kt` (plain JUnit, no Robolectric, matches `CacheDirRecoveryTest`/`AtomicFileWriteTest` style) — retried exactly once on `FileNotFoundException`, and on a plain `IOException` caught while the cache dir is missing (how a second vanish actually surfaces from `File.createTempFile` / the wrapped `Os.rename` ENOENT); a second vanish-shaped failure propagates instead of looping; a dir-present `IOException` (out-of-space, permissions) and non-IO failures are *not* retried; happy path passes through untouched. Runs in CI via `android-pr-rn.yml`'s existing `board-renderer:testDebugUnitTest` job — no workflow change needed, it already targets this module.
- **iOS**: new `BoardRendererErrorClassificationTests.swift` (XCTest, compiled into the `BoardseshTests` target alongside the extracted `BoardRendererErrorClassification.swift` via `scripts/prepare-rn-ios-tests.mjs`; runs on a macOS simulator in `ios-rn-ci.yml`) — the headline test is *functional*: it performs the real failing operation (atomic `Data.write` into a directory that existed and was then deleted, the exact reclaim sequence) and asserts `isFileVanishedError` classifies it retryable, so the classifier is verified against what Foundation actually throws. A real not-a-directory failure plus hand-built render/out-of-space/permission errors classify non-retryable, and a Cocoa write wrapper carrying POSIX `ENOENT` under `NSUnderlyingErrorKey` is unwrapped (bounded) and classified retryable.
- `vp run typecheck:mobile` — passed (234s, no errors).
- `vp check` — passed for all touched files; the 2 pre-existing lint errors in the full-repo run are in unrelated `packages/db/scripts/*.test.ts` files, untouched by this PR.

