### PR TITLE
fix(backend): keep Aurora duplicate mutations together

### DIFF
--- a/packages/aurora-sync/src/sync/apply-user-logbook.test.ts
+++ b/packages/aurora-sync/src/sync/apply-user-logbook.test.ts
@@ -6,7 +6,7 @@ import type { SQL } from 'drizzle-orm';
 // cross-source claim exercises the actual matching logic.
 vi.mock('@boardsesh/db/queries', async (importActual) => {
   const actual = await importActual<typeof import('@boardsesh/db/queries')>();
-  return { ...actual, recomputeClimbStatsBulk: vi.fn() };
+  return { ...actual, acquireUserTickMutationLock: vi.fn(), recomputeClimbStatsBulk: vi.fn() };
 });
 
 import { recomputeClimbStatsBulk } from '@boardsesh/db/queries';

--- a/packages/aurora-sync/src/sync/apply-user-logbook.ts
+++ b/packages/aurora-sync/src/sync/apply-user-logbook.ts
@@ -9,6 +9,7 @@ import {
   adoptionMatchScoreSeconds,
   MAX_USER_UTC_OFFSET_SECONDS,
   NATURAL_KEY_TOLERANCE_SECONDS,
+  acquireUserTickMutationLock,
   type ClimbStatsKey,
   type TickTimeSample,
 } from '@boardsesh/db/queries';
@@ -749,6 +750,7 @@ async function applyLogbookChunk(
       -- but keeps the never-cross-users invariant enforced at the write itself.
       WHERE t.uuid = u.uuid
         AND t.user_id = ${userId}
+        AND (t.aurora_synced_at IS NULL OR t.updated_at <= t.aurora_synced_at)
     `);
   };
 
@@ -809,6 +811,11 @@ async function applyLogbookChunk(
       -- the write itself.
       WHERE t.aurora_id = u.aurora_id
         AND t.user_id = ${userId}
+        -- Re-check at write time. A rolling-deploy node that does not yet take
+        -- the shared advisory lock can edit after the SELECT above; comparing
+        -- timestamp columns here also preserves Postgres microseconds that JS
+        -- Date.parse cannot represent.
+        AND (t.aurora_synced_at IS NULL OR t.updated_at <= t.aurora_synced_at)
     `);
   };
 
@@ -962,6 +969,10 @@ export async function applyAuroraAscents(
     }
   }
 
+  // Shared with updateTick/deleteTick and Kilter log apply. The caller owns
+  // the transaction; take this before the first target/tombstone SELECT.
+  await acquireUserTickMutationLock(db, userId);
+
   touchedKeys.push(...(await applyAuroraTombstones(db, boardName, userId, tombstoneIds)));
 
   const unique = dedupeByAuroraId(live);
@@ -1010,6 +1021,8 @@ export async function applyAuroraBids(
       skips.push(skipFromNormalizeError(item, error, 'bids', userId, boardName));
     }
   }
+
+  await acquireUserTickMutationLock(db, userId);
 
   const unique = dedupeByAuroraId(live);
   for (const batch of chunk(unique, WRITE_CHUNK_SIZE)) {

--- a/packages/backend/src/__tests__/aurora-twin-dedup.test.ts
+++ b/packages/backend/src/__tests__/aurora-twin-dedup.test.ts
@@ -338,8 +338,8 @@ describe('#3535 Aurora-side duplicate ascents', () => {
    * hiding. `isLocallyEdited` then makes every later pull skip that row, so
    * payload parity is never restored and a strict payload rule would resurrect
    * the duplicates permanently — making it look like rating a send created
-   * them. `updateTick` writes in place and knows nothing about the group, so
-   * the predicate has to absorb this itself.
+   * them. `updateTick` fans visible direct twins out as one logical ascent, so
+   * the predicate must continue to absorb the local edit on its survivor.
    */
   const localEdits: Array<[string, SQL]> = [
     ['rated', sql`quality = 5`],
@@ -418,6 +418,23 @@ describe('#3535 Aurora-side duplicate ascents', () => {
       expect.objectContaining({ angle: ANGLE + 5, climbed_at: '2026-05-02 08:02:03' }),
     ]);
     expect(await visibleAuroraIds()).toEqual(['aur-1']);
+  });
+
+  it('preserves six climbedAt fractional digits while normalizing its offset across direct twins', async () => {
+    const survivorUuid = await insertTick({ auroraId: 'aur-1' });
+    await insertTick({ auroraId: 'aur-2' });
+
+    await tickMutations.updateTick(
+      null,
+      { uuid: survivorUuid, input: { climbedAt: '2026-05-02T01:02:03.123456-07:00' } },
+      authenticatedContext,
+    );
+
+    const rows = await db.execute(sql`
+      SELECT climbed_at::text AS climbed_at
+      FROM boardsesh_ticks WHERE user_id = ${USER_ID} ORDER BY aurora_id
+    `);
+    expect(rows).toEqual([{ climbed_at: '2026-05-02 08:02:03.123456' }, { climbed_at: '2026-05-02 08:02:03.123456' }]);
   });
 
   it('moves beta links for every edited member, invalidates once, and recomputes distinct old/new keys', async () => {
@@ -620,6 +637,7 @@ describe('#3535 Aurora-side duplicate ascents', () => {
       ORDER BY record_id
     `);
     expect(tombstones).toEqual(tickUuids.sort().map((recordId) => ({ record_id: recordId })));
+    expect(mutationSideEffects.invalidateRecentBetaLinksCache).toHaveBeenCalledTimes(1);
   });
 
   it('fans only supplied fields across the group and enforces flash attempts', async () => {
@@ -834,6 +852,34 @@ describe('#3535 Aurora-side duplicate ascents', () => {
       { aurora_id: 'aur-c', angle: ANGLE },
     ]);
     expect(await visibleAuroraIds()).toEqual(['aur-a', 'aur-c']);
+  });
+
+  it('keeps inverse NULL-kilter witnesses single-row for updates', async () => {
+    const nullKilterTargetUuid = await insertTick({ auroraId: 'aur-a' });
+    await insertTick({ auroraId: 'aur-b', kilterId: 'kil-b' });
+    await insertTick({ auroraId: 'aur-c', kilterId: 'kil-c' });
+    expect(await visibleAuroraIds()).toEqual(['aur-a']);
+
+    await tickMutations.updateTick(null, { uuid: nullKilterTargetUuid, input: { angle: 45 } }, authenticatedContext);
+
+    const rows = await db.execute(sql`
+      SELECT aurora_id, angle FROM boardsesh_ticks WHERE user_id = ${USER_ID} ORDER BY aurora_id
+    `);
+    expect(rows).toEqual([
+      { aurora_id: 'aur-a', angle: 45 },
+      { aurora_id: 'aur-b', angle: ANGLE },
+      { aurora_id: 'aur-c', angle: ANGLE },
+    ]);
+  });
+
+  it('keeps inverse NULL-kilter witnesses single-row for deletes', async () => {
+    const nullKilterTargetUuid = await insertTick({ auroraId: 'aur-a' });
+    await insertTick({ auroraId: 'aur-b', kilterId: 'kil-b' });
+    await insertTick({ auroraId: 'aur-c', kilterId: 'kil-c' });
+
+    await tickMutations.deleteTick(null, { uuid: nullKilterTargetUuid }, authenticatedContext);
+
+    expect(await storedAuroraIds()).toEqual(['aur-b', 'aur-c']);
   });
 
   it('keeps single-row semantics when a hidden UUID is addressed directly', async () => {

--- a/packages/backend/src/__tests__/aurora-twin-dedup.test.ts
+++ b/packages/backend/src/__tests__/aurora-twin-dedup.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { beforeAll, afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import { eq, sql, type SQL } from 'drizzle-orm';
 import { applyAuroraAscents } from '@boardsesh/aurora-sync/apply-user-logbook';
+import { acquireUserTickMutationLock } from '@boardsesh/db/queries';
 import { applyLogs, type PowerSyncOp } from '@boardsesh/kilter-sync';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 
@@ -641,8 +642,16 @@ describe('#3535 Aurora-side duplicate ascents', () => {
   });
 
   it('fans only supplied fields across the group and enforces flash attempts', async () => {
-    const survivorUuid = await insertTick({ auroraId: 'aur-1', quality: 4, difficulty: 22 });
-    await insertTick({ auroraId: 'aur-2', quality: 4, difficulty: 22 });
+    const survivorUuid = await insertTick({
+      auroraId: 'aur-1',
+      attemptCount: 1,
+      quality: 4,
+      difficulty: 22,
+      // The survivor's local edit relaxes editable-payload parity, so it can
+      // directly hide the otherwise identical twin with a different count.
+      updatedAt: '2026-05-01T18:22:38.000Z',
+    });
+    await insertTick({ auroraId: 'aur-2', attemptCount: 2, quality: 4, difficulty: 22 });
 
     await tickMutations.updateTick(
       null,
@@ -976,6 +985,40 @@ describe('#3535 Aurora-side duplicate ascents', () => {
     await db.transaction((tx) => applyAuroraAscents(tx as unknown as typeof applyDb, BOARD, USER_ID, payload));
     expect(await storedAuroraIds()).toEqual(['aur-a', 'aur-b']);
     expect(await visibleAuroraIds()).toEqual(['aur-a']);
+  });
+
+  it('waits on the legacy advisory key before taking the extended rollout key', async () => {
+    let releaseLegacyLock!: () => void;
+    const legacyLockRelease = new Promise<void>((resolve) => {
+      releaseLegacyLock = resolve;
+    });
+    let signalLegacyLockHeld!: () => void;
+    const legacyLockHeld = new Promise<void>((resolve) => {
+      signalLegacyLockHeld = resolve;
+    });
+    const legacyLockTransaction = db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT pg_advisory_xact_lock(${0x5449434b}, hashtext(${USER_ID}))`);
+      signalLegacyLockHeld();
+      await legacyLockRelease;
+    });
+    await legacyLockHeld;
+
+    let compatibleAcquisitionSettled = false;
+    const compatibleAcquisition = db
+      .transaction(async (tx) => {
+        await acquireUserTickMutationLock(tx as unknown as Parameters<typeof acquireUserTickMutationLock>[0], USER_ID);
+      })
+      .finally(() => {
+        compatibleAcquisitionSettled = true;
+      });
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 75));
+      expect(compatibleAcquisitionSettled).toBe(false);
+    } finally {
+      releaseLegacyLock();
+    }
+
+    await Promise.all([legacyLockTransaction, compatibleAcquisition]);
   });
 
   it('Aurora apply and updateTick serialize over two connections', async () => {

--- a/packages/backend/src/__tests__/aurora-twin-dedup.test.ts
+++ b/packages/backend/src/__tests__/aurora-twin-dedup.test.ts
@@ -1,11 +1,35 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { beforeAll, afterEach, describe, expect, it } from 'vite-plus/test';
-import { sql, type SQL } from 'drizzle-orm';
+import { beforeAll, afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { eq, sql, type SQL } from 'drizzle-orm';
 import { applyAuroraAscents } from '@boardsesh/aurora-sync/apply-user-logbook';
+import { applyLogs, type PowerSyncOp } from '@boardsesh/kilter-sync';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+
+const mutationSideEffects = vi.hoisted(() => ({
+  invalidateRecentBetaLinksCache: vi.fn(() => Promise.resolve()),
+  publishDebouncedSessionStats: vi.fn(),
+  queueBoardStatsPublish: vi.fn(),
+  queueClimbStatsRecompute: vi.fn(),
+}));
+
+vi.mock('../graphql/resolvers/ticks/debounced-climb-stats-publisher', () => ({
+  queueClimbStatsRecompute: mutationSideEffects.queueClimbStatsRecompute,
+}));
+vi.mock('../graphql/resolvers/board-presence/stats', () => ({
+  queueBoardStatsPublish: mutationSideEffects.queueBoardStatsPublish,
+}));
+vi.mock('../graphql/resolvers/sessions/debounced-stats-publisher', () => ({
+  publishDebouncedSessionStats: mutationSideEffects.publishDebouncedSessionStats,
+}));
+vi.mock('../graphql/resolvers/beta-videos/queries', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../graphql/resolvers/beta-videos/queries')>()),
+  invalidateRecentBetaLinksCache: mutationSideEffects.invalidateRecentBetaLinksCache,
+}));
 import { db } from '../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { tickQueries } from '../graphql/resolvers/ticks/queries';
+import { tickMutations } from '../graphql/resolvers/ticks/mutations';
 import { setupWorkerDatabase } from './worker-db';
 
 /**
@@ -43,10 +67,11 @@ function byAuroraId(left: string | null, right: string | null): number {
 
 let tickSeq = 0;
 
-async function insertTick(overrides: TickOverrides = {}): Promise<void> {
+async function insertTick(overrides: TickOverrides = {}): Promise<string> {
   tickSeq += 1;
+  const uuid = overrides.uuid ?? `twin3535-tick-${tickSeq}`;
   await db.insert(dbSchema.boardseshTicks).values({
-    uuid: `twin3535-tick-${tickSeq}`,
+    uuid,
     userId: USER_ID,
     boardType: BOARD,
     climbUuid: CLIMB_UUID,
@@ -69,7 +94,15 @@ async function insertTick(overrides: TickOverrides = {}): Promise<void> {
     auroraSyncedAt: CLIMBED_AT,
     ...overrides,
   });
+  return uuid;
 }
+
+const authenticatedContext: ConnectionContext = {
+  connectionId: 'aurora-twin-mutation-test',
+  transport: 'ws',
+  isAuthenticated: true,
+  userId: USER_ID,
+};
 
 /** aurora_ids the public per-user tick list (the You page's source) shows. */
 async function visibleAuroraIds(): Promise<Array<string | null>> {
@@ -108,7 +141,25 @@ beforeAll(async () => {
 });
 
 afterEach(async () => {
-  await db.execute(sql`DELETE FROM boardsesh_ticks WHERE user_id = ${USER_ID}`);
+  await db.execute(sql`
+    DELETE FROM notifications
+    WHERE entity_id LIKE 'twin3535-tick-%'
+       OR comment_id IN (SELECT id FROM comments WHERE entity_id LIKE 'twin3535-tick-%')
+  `);
+  await db.execute(sql`DELETE FROM feed_items WHERE entity_id LIKE 'twin3535-tick-%'`);
+  await db.execute(sql`DELETE FROM votes WHERE entity_id LIKE 'twin3535-tick-%'`);
+  await db.execute(sql`DELETE FROM vote_counts WHERE entity_id LIKE 'twin3535-tick-%'`);
+  await db.execute(sql`DELETE FROM comments WHERE entity_id LIKE 'twin3535-tick-%'`);
+  await db.execute(sql`DELETE FROM board_beta_links WHERE climb_uuid = ${CLIMB_UUID}`);
+  await db.execute(sql`DELETE FROM boardsesh_ticks WHERE user_id IN (${USER_ID}, ${USER_ID + '-foreign'})`);
+  await db.execute(sql`DELETE FROM board_sessions WHERE id LIKE 'twin3535-session-%'`);
+  await db.execute(sql`DELETE FROM user_boards WHERE uuid LIKE 'twin3535-board-%'`);
+  await db.execute(sql`DELETE FROM sync_deletions WHERE user_id IN (${USER_ID}, ${USER_ID + '-foreign'})`);
+  await db.execute(sql`DELETE FROM users WHERE id = ${USER_ID + '-foreign'}`);
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
 });
 
 /**
@@ -141,13 +192,13 @@ describe('#3535 payload column list stays in step with the pull', () => {
     );
     const predicateBody = bodyBetween(
       sourceOf('packages/db/src/queries/ticks/aurora-twin-dedup.ts'),
-      'export function notAuroraTwinDuplicate',
+      'export function isDirectAuroraTwin',
       '\n}',
     );
 
     const pullColumns = new Set(Array.from(pullBody.matchAll(/\bstored\.(\w+)/g), (match) => match[1]));
     const predicateColumns = new Set(
-      Array.from(predicateBody.matchAll(/\b(?:ticks|twin)\.(\w+)/g), (match) => match[1]),
+      Array.from(predicateBody.matchAll(/\b(?:smaller|larger)\.(\w+)/g), (match) => match[1]),
     );
 
     // Sanity-check the extraction itself before trusting the comparison.
@@ -347,33 +398,459 @@ describe('#3535 Aurora-side duplicate ascents', () => {
     expect(await visibleAuroraIds()).toEqual(['aur-1', 'aur-2']);
   });
 
-  it('resurfaces the twins when the survivor is moved off the natural key (recorded behaviour)', async () => {
-    await insertTick({ auroraId: 'aur-1' });
+  it('fans angle and date edits across direct twins so the logical ascent stays one visible row', async () => {
+    const survivorUuid = await insertTick({ auroraId: 'aur-1' });
     await insertTick({ auroraId: 'aur-2' });
     expect(await visibleAuroraIds()).toEqual(['aur-1']);
 
-    // `updateTick` also accepts `angle` and `climbedAt`. Either moves the
-    // survivor out of the group entirely, so the rows it was hiding come back —
-    // the relaxation only covers payload columns. Recorded, not fixed — #4060.
-    await db.execute(
-      sql`UPDATE boardsesh_ticks SET angle = ${ANGLE + 5}, updated_at = now() WHERE aurora_id = 'aur-1'`,
+    await tickMutations.updateTick(
+      null,
+      { uuid: survivorUuid, input: { angle: ANGLE + 5, climbedAt: '2026-05-02T01:02:03-07:00' } },
+      authenticatedContext,
     );
 
-    expect(await visibleAuroraIds()).toEqual(['aur-1', 'aur-2']);
+    const rows = await db.execute(sql`
+      SELECT angle, climbed_at::text AS climbed_at
+      FROM boardsesh_ticks WHERE user_id = ${USER_ID} ORDER BY aurora_id
+    `);
+    expect(rows).toEqual([
+      expect.objectContaining({ angle: ANGLE + 5, climbed_at: '2026-05-02 08:02:03' }),
+      expect.objectContaining({ angle: ANGLE + 5, climbed_at: '2026-05-02 08:02:03' }),
+    ]);
+    expect(await visibleAuroraIds()).toEqual(['aur-1']);
   });
 
-  it('reveals the next twin when the visible tick is deleted (recorded behaviour)', async () => {
-    await insertTick({ auroraId: 'aur-1' });
-    await insertTick({ auroraId: 'aur-2' });
+  it('moves beta links for every edited member, invalidates once, and recomputes distinct old/new keys', async () => {
+    const survivorUuid = await insertTick({ auroraId: 'aur-1' });
+    const twinUuid = await insertTick({ auroraId: 'aur-2' });
+    await db.insert(dbSchema.boardBetaLinks).values(
+      [survivorUuid, twinUuid].map((tickUuid) => ({
+        boardType: BOARD,
+        climbUuid: CLIMB_UUID,
+        link: `https://example.com/angle-${tickUuid}`,
+        tickUuid,
+        angle: ANGLE,
+      })),
+    );
+
+    await tickMutations.updateTick(null, { uuid: survivorUuid, input: { angle: 45 } }, authenticatedContext);
+
+    const betaRows = await db.execute(sql`
+      SELECT angle FROM board_beta_links WHERE climb_uuid = ${CLIMB_UUID} ORDER BY link
+    `);
+    expect(betaRows).toEqual([{ angle: 45 }, { angle: 45 }]);
+    expect(mutationSideEffects.invalidateRecentBetaLinksCache).toHaveBeenCalledTimes(1);
+    expect(mutationSideEffects.queueClimbStatsRecompute.mock.calls).toEqual([
+      [BOARD, CLIMB_UUID, ANGLE],
+      [BOARD, CLIMB_UUID, 45],
+    ]);
+  });
+
+  it('deletes every direct twin when the visible survivor is deleted', async () => {
+    const survivorUuid = await insertTick({ auroraId: 'aur-1' });
+    const twinUuid = await insertTick({ auroraId: 'aur-2' });
     expect(await visibleAuroraIds()).toEqual(['aur-1']);
 
-    // deleteTick removes one row. The group is unaware of it, so the next id is
-    // promoted and the entry stays on screen. Known limitation, recorded here
-    // so a future reader does not mistake it for a predicate bug; the honest
-    // fix is a group-aware delete, tracked in #4059.
-    await db.execute(sql`DELETE FROM boardsesh_ticks WHERE aurora_id = 'aur-1'`);
+    await tickMutations.deleteTick(null, { uuid: survivorUuid }, authenticatedContext);
 
-    expect(await visibleAuroraIds()).toEqual(['aur-2']);
+    expect(await storedAuroraIds()).toEqual([]);
+    const tombstones = await db.execute(sql`
+      SELECT record_id FROM sync_deletions
+      WHERE table_name = 'boardsesh_ticks' AND user_id = ${USER_ID}
+        AND record_id IN (${survivorUuid}, ${twinUuid})
+      ORDER BY record_id
+    `);
+    expect(tombstones).toEqual([{ record_id: survivorUuid }, { record_id: twinUuid }]);
+  });
+
+  it('cleans every twin dependent, preserves beta rows, and fans session/board side effects out once each', async () => {
+    const boardRows = await db
+      .insert(dbSchema.userBoards)
+      .values([
+        {
+          uuid: 'twin3535-board-a',
+          slug: 'twin3535-board-a',
+          ownerId: USER_ID,
+          boardType: BOARD,
+          layoutId: 1,
+          sizeId: 1,
+          setIds: '1',
+          name: 'Twin board A',
+          angle: ANGLE,
+        },
+        {
+          uuid: 'twin3535-board-b',
+          slug: 'twin3535-board-b',
+          ownerId: USER_ID,
+          boardType: BOARD,
+          layoutId: 2,
+          sizeId: 1,
+          setIds: '1',
+          name: 'Twin board B',
+          angle: ANGLE,
+        },
+      ])
+      .returning({ id: dbSchema.userBoards.id });
+    await db.insert(dbSchema.boardSessions).values([
+      { id: 'twin3535-session-a', boardPath: '/tension/1/1/1/40', lastActivity: new Date('2020-01-01') },
+      { id: 'twin3535-session-b', boardPath: '/tension/2/1/1/40', lastActivity: new Date('2020-01-01') },
+    ]);
+
+    const survivorUuid = await insertTick({
+      auroraId: 'aur-1',
+      boardId: boardRows[0].id,
+      sessionId: 'twin3535-session-a',
+    });
+    const twinUuid = await insertTick({
+      auroraId: 'aur-2',
+      boardId: boardRows[1].id,
+      sessionId: 'twin3535-session-b',
+    });
+    const tickUuids = [survivorUuid, twinUuid];
+
+    await db.insert(dbSchema.boardBetaLinks).values(
+      tickUuids.map((tickUuid) => ({
+        boardType: BOARD,
+        climbUuid: CLIMB_UUID,
+        link: `https://example.com/${tickUuid}`,
+        tickUuid,
+        angle: ANGLE,
+      })),
+    );
+    const commentRows = await db
+      .insert(dbSchema.comments)
+      .values(
+        tickUuids.map((tickUuid) => ({
+          uuid: `comment-${tickUuid}`,
+          userId: USER_ID,
+          entityType: 'tick' as const,
+          entityId: tickUuid,
+          body: 'beta',
+        })),
+      )
+      .returning({ id: dbSchema.comments.id });
+    await db
+      .insert(dbSchema.votes)
+      .values(
+        tickUuids.map((tickUuid) => ({ userId: USER_ID, entityType: 'tick' as const, entityId: tickUuid, value: 1 })),
+      );
+    await db.insert(dbSchema.voteCounts).values(
+      tickUuids.map((tickUuid) => ({
+        entityType: 'tick' as const,
+        entityId: tickUuid,
+        upvotes: 1,
+        downvotes: 0,
+        score: 1,
+        hotScore: 1,
+        createdAt: new Date(),
+      })),
+    );
+    await db.insert(dbSchema.feedItems).values(
+      tickUuids.map((tickUuid) => ({
+        recipientId: USER_ID,
+        actorId: USER_ID,
+        type: 'ascent' as const,
+        entityType: 'tick' as const,
+        entityId: tickUuid,
+      })),
+    );
+    await db.insert(dbSchema.notifications).values([
+      ...tickUuids.map((tickUuid) => ({
+        uuid: `notification-${tickUuid}`,
+        recipientId: USER_ID,
+        actorId: USER_ID,
+        type: 'vote_on_tick' as const,
+        entityType: 'tick' as const,
+        entityId: tickUuid,
+      })),
+      ...commentRows.map((comment, index) => ({
+        uuid: `notification-comment-${index}`,
+        recipientId: USER_ID,
+        actorId: USER_ID,
+        type: 'comment_on_tick' as const,
+        entityType: 'tick' as const,
+        entityId: tickUuids[index],
+        commentId: comment.id,
+      })),
+    ]);
+
+    await tickMutations.deleteTick(null, { uuid: survivorUuid }, authenticatedContext);
+
+    const tickUuidList = sql.join(
+      tickUuids.map((tickUuid) => sql`${tickUuid}`),
+      sql`, `,
+    );
+    const dependentCounts = await db.execute(sql`
+      SELECT
+        (SELECT count(*)::int FROM comments WHERE entity_id IN (${tickUuidList})) AS comments,
+        (SELECT count(*)::int FROM votes WHERE entity_id IN (${tickUuidList})) AS votes,
+        (SELECT count(*)::int FROM vote_counts WHERE entity_id IN (${tickUuidList})) AS vote_counts,
+        (SELECT count(*)::int FROM feed_items WHERE entity_id IN (${tickUuidList})) AS feed_items,
+        (SELECT count(*)::int FROM notifications WHERE entity_id IN (${tickUuidList})) AS notifications
+    `);
+    expect(dependentCounts).toEqual([{ comments: 0, votes: 0, vote_counts: 0, feed_items: 0, notifications: 0 }]);
+    const betaRows = await db.execute(sql`
+      SELECT tick_uuid, angle FROM board_beta_links WHERE climb_uuid = ${CLIMB_UUID} ORDER BY link
+    `);
+    expect(betaRows).toEqual([
+      { tick_uuid: null, angle: ANGLE },
+      { tick_uuid: null, angle: ANGLE },
+    ]);
+    const sessions = await db.execute(sql`
+      SELECT id, last_activity > '2020-01-01'::timestamp AS touched
+      FROM board_sessions WHERE id LIKE 'twin3535-session-%' ORDER BY id
+    `);
+    expect(sessions).toEqual([
+      { id: 'twin3535-session-a', touched: true },
+      { id: 'twin3535-session-b', touched: true },
+    ]);
+    expect(
+      mutationSideEffects.publishDebouncedSessionStats.mock.calls
+        .map(([sessionId]) => sessionId)
+        .sort((left, right) => left.localeCompare(right)),
+    ).toEqual(['twin3535-session-a', 'twin3535-session-b']);
+    expect(
+      mutationSideEffects.queueBoardStatsPublish.mock.calls
+        .map(([boardId]) => boardId)
+        .sort((left, right) => left - right),
+    ).toEqual(boardRows.map((board) => board.id).sort((left, right) => left - right));
+    const tombstones = await db.execute(sql`
+      SELECT record_id FROM sync_deletions
+      WHERE table_name = 'boardsesh_ticks' AND record_id IN (${tickUuidList})
+      ORDER BY record_id
+    `);
+    expect(tombstones).toEqual(tickUuids.sort().map((recordId) => ({ record_id: recordId })));
+  });
+
+  it('fans only supplied fields across the group and enforces flash attempts', async () => {
+    const survivorUuid = await insertTick({ auroraId: 'aur-1', quality: 4, difficulty: 22 });
+    await insertTick({ auroraId: 'aur-2', quality: 4, difficulty: 22 });
+
+    await tickMutations.updateTick(
+      null,
+      { uuid: survivorUuid, input: { comment: 'one logical send' } },
+      authenticatedContext,
+    );
+    await tickMutations.updateTick(null, { uuid: survivorUuid, input: { status: 'flash' } }, authenticatedContext);
+
+    const rows = await db.execute(sql`
+      SELECT status, attempt_count, quality, difficulty, comment
+      FROM boardsesh_ticks WHERE user_id = ${USER_ID} ORDER BY aurora_id
+    `);
+    expect(rows).toEqual([
+      { status: 'flash', attempt_count: 1, quality: 4, difficulty: 22, comment: 'one logical send' },
+      { status: 'flash', attempt_count: 1, quality: 4, difficulty: 22, comment: 'one logical send' },
+    ]);
+    expect(await visibleAuroraIds()).toEqual(['aur-1']);
+  });
+
+  it('groups equal stored microseconds in SQL without absorbing the next microsecond', async () => {
+    const survivorUuid = await insertTick({ auroraId: 'aur-1', climbedAt: '2026-05-01T18:22:37.000001Z' });
+    await insertTick({ auroraId: 'aur-2', climbedAt: '2026-05-01T18:22:37.000001Z' });
+    await insertTick({ auroraId: 'aur-3', climbedAt: '2026-05-01T18:22:37.000002Z' });
+
+    await tickMutations.updateTick(null, { uuid: survivorUuid, input: { angle: 45 } }, authenticatedContext);
+
+    const rows = await db.execute(sql`
+      SELECT aurora_id, angle, climbed_at::text AS climbed_at
+      FROM boardsesh_ticks WHERE user_id = ${USER_ID} ORDER BY aurora_id
+    `);
+    expect(rows).toEqual([
+      { aurora_id: 'aur-1', angle: 45, climbed_at: '2026-05-01 18:22:37.000001' },
+      { aurora_id: 'aur-2', angle: 45, climbed_at: '2026-05-01 18:22:37.000001' },
+      { aurora_id: 'aur-3', angle: ANGLE, climbed_at: '2026-05-01 18:22:37.000002' },
+    ]);
+  });
+
+  it('keeps an Aurora local edit one microsecond newer than the sync watermark', async () => {
+    const tickUuid = await insertTick({
+      auroraId: 'aur-microsecond-stale',
+      comment: 'local microsecond edit',
+      climbedAt: '2026-05-05T18:22:37.000Z',
+    });
+    // Both timestamps collapse to the same millisecond in Date.parse, so the
+    // pre-write JS check intentionally admits the incoming update. The SQL
+    // predicate must make the final decision with Postgres precision.
+    await db.execute(sql`
+      UPDATE boardsesh_ticks
+      SET updated_at = '2026-05-05 19:00:00.000001'::timestamp,
+          aurora_synced_at = '2026-05-05 19:00:00.000000'::timestamp
+      WHERE uuid = ${tickUuid}
+    `);
+    const payload = [
+      {
+        uuid: 'aur-microsecond-stale',
+        climb_uuid: CLIMB_UUID,
+        angle: ANGLE,
+        is_mirror: false,
+        attempt_id: 2,
+        bid_count: 2,
+        quality: null,
+        difficulty: 21,
+        is_benchmark: false,
+        comment: 'stale upstream edit',
+        climbed_at: '2026-05-05 18:22:37',
+        created_at: '2026-05-05 18:25:00',
+        is_listed: true,
+      },
+    ];
+    const applyDb = db as unknown as Parameters<typeof applyAuroraAscents>[0];
+
+    await db.transaction((tx) => applyAuroraAscents(tx as unknown as typeof applyDb, BOARD, USER_ID, payload));
+
+    const rows = await db.execute(sql`
+      SELECT comment, updated_at::text AS updated_at, aurora_synced_at::text AS aurora_synced_at
+      FROM boardsesh_ticks WHERE uuid = ${tickUuid}
+    `);
+    expect(rows).toEqual([
+      {
+        comment: 'local microsecond edit',
+        updated_at: '2026-05-05 19:00:00.000001',
+        aurora_synced_at: '2026-05-05 19:00:00',
+      },
+    ]);
+  });
+
+  it('keeps a Kilter local edit one microsecond newer than the sync watermark', async () => {
+    const kilterId = 'kilter-microsecond-stale';
+    const tickUuid = await insertTick({
+      auroraId: null,
+      auroraType: null,
+      auroraSyncedAt: null,
+      boardType: 'kilter',
+      origin: 'kilter_pull',
+      kilterId,
+      kilterType: 'logs',
+      kilterSyncedAt: '2026-05-06T19:00:00.000Z',
+      climbedAt: '2026-05-06T18:22:37.000Z',
+      attemptCount: 9,
+    });
+    await db.execute(sql`
+      UPDATE boardsesh_ticks
+      SET updated_at = '2026-05-06 19:00:00.000001'::timestamp,
+          kilter_synced_at = '2026-05-06 19:00:00.000000'::timestamp
+      WHERE uuid = ${tickUuid}
+    `);
+    const op: PowerSyncOp = {
+      op_id: '1',
+      op: 'PUT',
+      object_type: 'logs',
+      object_id: kilterId,
+      data: {
+        id: '1',
+        log_uuid: kilterId,
+        climb_uuid: CLIMB_UUID,
+        user_uuid: USER_ID,
+        gym_uuid: null,
+        wall_uuid: null,
+        product_layout_uuid: null,
+        angle: ANGLE,
+        flashed: 0,
+        topped: 1,
+        attempts: 2,
+        created_at: '2026-05-06T18:22:37.000Z',
+      },
+    };
+
+    await db.transaction((tx) =>
+      applyLogs(
+        tx as unknown as Parameters<typeof applyLogs>[0],
+        USER_ID,
+        [op],
+        new Map([[`kilter:${CLIMB_UUID}`, CLIMB_UUID]]),
+        () => {},
+      ),
+    );
+
+    const rows = await db.execute(sql`
+      SELECT attempt_count, updated_at::text AS updated_at, kilter_synced_at::text AS kilter_synced_at
+      FROM boardsesh_ticks WHERE uuid = ${tickUuid}
+    `);
+    expect(rows).toEqual([
+      {
+        attempt_count: 9,
+        updated_at: '2026-05-06 19:00:00.000001',
+        kilter_synced_at: '2026-05-06 19:00:00',
+      },
+    ]);
+  });
+
+  it('keeps native, JSON, bid/ascent, foreign-user and two-Kilter-link rows outside the group', async () => {
+    const survivorUuid = await insertTick({ auroraId: 'aur-1', kilterId: 'kil-1' });
+    await insertTick({ auroraId: 'aur-2' }); // one Kilter link: direct twin
+    await insertTick({ auroraId: null, origin: 'native', auroraType: null, auroraSyncedAt: null });
+    await insertTick({ auroraId: 'json-import-a', origin: 'json_import' });
+    await insertTick({ auroraId: 'aur-3', auroraType: 'bids' });
+    await insertTick({ auroraId: 'aur-4', kilterId: 'kil-4' });
+
+    const foreignUser = `${USER_ID}-foreign`;
+    await db.execute(sql`
+      INSERT INTO users (id, email, name, created_at, updated_at)
+      VALUES (${foreignUser}, ${foreignUser + '@test.com'}, 'Foreign Twin', now(), now())
+      ON CONFLICT (id) DO NOTHING
+    `);
+    await insertTick({ auroraId: 'aur-foreign', userId: foreignUser });
+
+    await tickMutations.updateTick(
+      null,
+      { uuid: survivorUuid, input: { comment: 'group edit' } },
+      authenticatedContext,
+    );
+
+    const rows = await db.execute(sql`
+      SELECT aurora_id, origin::text AS origin, comment
+      FROM boardsesh_ticks WHERE user_id = ${USER_ID}
+      ORDER BY aurora_id NULLS LAST
+    `);
+    expect(rows).toEqual([
+      { aurora_id: 'aur-1', origin: 'aurora_pull', comment: 'group edit' },
+      { aurora_id: 'aur-2', origin: 'aurora_pull', comment: 'group edit' },
+      { aurora_id: 'aur-3', origin: 'aurora_pull', comment: 'crimpy' },
+      { aurora_id: 'aur-4', origin: 'aurora_pull', comment: 'crimpy' },
+      { aurora_id: 'json-import-a', origin: 'json_import', comment: 'crimpy' },
+      { aurora_id: null, origin: 'native', comment: 'crimpy' },
+    ]);
+    const foreign = await db.execute(sql`
+      SELECT comment FROM boardsesh_ticks WHERE user_id = ${foreignUser}
+    `);
+    expect(foreign).toEqual([{ comment: 'crimpy' }]);
+    await db.execute(sql`DELETE FROM users WHERE id = ${foreignUser}`);
+  });
+
+  it('uses only direct pairs: A(kilter)/B(no kilter)/C(kilter) never closes transitively', async () => {
+    const survivorUuid = await insertTick({ auroraId: 'aur-a', kilterId: 'kil-a' });
+    await insertTick({ auroraId: 'aur-b' });
+    await insertTick({ auroraId: 'aur-c', kilterId: 'kil-c' });
+    expect(await visibleAuroraIds()).toEqual(['aur-a']);
+
+    await tickMutations.updateTick(null, { uuid: survivorUuid, input: { angle: 45 } }, authenticatedContext);
+
+    const rows = await db.execute(sql`
+      SELECT aurora_id, angle FROM boardsesh_ticks WHERE user_id = ${USER_ID} ORDER BY aurora_id
+    `);
+    expect(rows).toEqual([
+      { aurora_id: 'aur-a', angle: 45 },
+      { aurora_id: 'aur-b', angle: 45 },
+      { aurora_id: 'aur-c', angle: ANGLE },
+    ]);
+    expect(await visibleAuroraIds()).toEqual(['aur-a', 'aur-c']);
+  });
+
+  it('keeps single-row semantics when a hidden UUID is addressed directly', async () => {
+    await insertTick({ auroraId: 'aur-a' });
+    const hiddenUuid = await insertTick({ auroraId: 'aur-b' });
+    await insertTick({ auroraId: 'aur-c' });
+
+    await tickMutations.updateTick(null, { uuid: hiddenUuid, input: { angle: 45 } }, authenticatedContext);
+
+    const rows = await db.execute(sql`
+      SELECT aurora_id, angle FROM boardsesh_ticks WHERE user_id = ${USER_ID} ORDER BY aurora_id
+    `);
+    expect(rows).toEqual([
+      { aurora_id: 'aur-a', angle: ANGLE },
+      { aurora_id: 'aur-b', angle: 45 },
+      { aurora_id: 'aur-c', angle: ANGLE },
+    ]);
   });
 
   it('applies the same duplicate payload twice with no second-cycle churn', async () => {
@@ -396,7 +873,7 @@ describe('#3535 Aurora-side duplicate ascents', () => {
 
     const applyDb = db as unknown as Parameters<typeof applyAuroraAscents>[0];
 
-    await applyAuroraAscents(applyDb, BOARD, USER_ID, payload);
+    await db.transaction((tx) => applyAuroraAscents(tx as unknown as typeof applyDb, BOARD, USER_ID, payload));
     const afterFirst = await db
       .select({ uuid: dbSchema.boardseshTicks.uuid, auroraId: dbSchema.boardseshTicks.auroraId })
       .from(dbSchema.boardseshTicks)
@@ -407,7 +884,7 @@ describe('#3535 Aurora-side duplicate ascents', () => {
     expect(await visibleAuroraIds()).toEqual(['aur-a']);
 
     // Second cycle: identical payload, as an incremental re-pull would deliver.
-    await applyAuroraAscents(applyDb, BOARD, USER_ID, payload);
+    await db.transaction((tx) => applyAuroraAscents(tx as unknown as typeof applyDb, BOARD, USER_ID, payload));
     const afterSecond = await db
       .select({ uuid: dbSchema.boardseshTicks.uuid, auroraId: dbSchema.boardseshTicks.auroraId })
       .from(dbSchema.boardseshTicks)
@@ -420,5 +897,163 @@ describe('#3535 Aurora-side duplicate ascents', () => {
     expect(new Set(afterSecond.map((row) => row.uuid))).toEqual(new Set(afterFirst.map((row) => row.uuid)));
     expect(await visibleAuroraIds()).toEqual(['aur-a']);
     expect(await feedTotalCount()).toBe(1);
+  });
+
+  it('documents resurrection only when Aurora genuinely redelivers the deleted upstream payload', async () => {
+    const payload = ['aur-a', 'aur-b'].map((auroraId) => ({
+      uuid: auroraId,
+      climb_uuid: CLIMB_UUID,
+      angle: ANGLE,
+      is_mirror: false,
+      attempt_id: 2,
+      bid_count: 2,
+      quality: null,
+      difficulty: 21,
+      is_benchmark: false,
+      comment: 'redelivered',
+      climbed_at: '2026-05-01 18:22:37',
+      created_at: '2026-05-01 18:25:00',
+      is_listed: true,
+    }));
+    const applyDb = db as unknown as Parameters<typeof applyAuroraAscents>[0];
+    await db.transaction((tx) => applyAuroraAscents(tx as unknown as typeof applyDb, BOARD, USER_ID, payload));
+    const [survivor] = await db
+      .select({ uuid: dbSchema.boardseshTicks.uuid })
+      .from(dbSchema.boardseshTicks)
+      .where(sql`aurora_id = 'aur-a'`);
+
+    await tickMutations.deleteTick(null, { uuid: survivor.uuid }, authenticatedContext);
+    expect(await storedAuroraIds()).toEqual([]);
+
+    // No suppression ledger is intended: a later payload carrying the real,
+    // still-live Aurora ids is authoritative and resurrects the logical ascent.
+    await db.transaction((tx) => applyAuroraAscents(tx as unknown as typeof applyDb, BOARD, USER_ID, payload));
+    expect(await storedAuroraIds()).toEqual(['aur-a', 'aur-b']);
+    expect(await visibleAuroraIds()).toEqual(['aur-a']);
+  });
+
+  it('Aurora apply and updateTick serialize over two connections', async () => {
+    const payload = [
+      {
+        uuid: 'aur-concurrent',
+        climb_uuid: CLIMB_UUID,
+        angle: ANGLE,
+        is_mirror: false,
+        attempt_id: 2,
+        bid_count: 2,
+        quality: null,
+        difficulty: 21,
+        is_benchmark: false,
+        comment: 'upstream',
+        climbed_at: '2026-05-03 18:22:37',
+        created_at: '2026-05-03 18:25:00',
+        is_listed: true,
+      },
+    ];
+    let releaseImport!: () => void;
+    const importRelease = new Promise<void>((resolve) => {
+      releaseImport = resolve;
+    });
+    let importReady!: (uuid: string) => void;
+    const importedUuid = new Promise<string>((resolve) => {
+      importReady = resolve;
+    });
+    const applyDb = db as unknown as Parameters<typeof applyAuroraAscents>[0];
+    const importTransaction = db.transaction(async (tx) => {
+      await applyAuroraAscents(tx as unknown as typeof applyDb, BOARD, USER_ID, payload);
+      const [row] = await tx
+        .select({ uuid: dbSchema.boardseshTicks.uuid })
+        .from(dbSchema.boardseshTicks)
+        .where(sql`aurora_id = 'aur-concurrent'`);
+      importReady(row.uuid);
+      await importRelease;
+    });
+    const tickUuid = await importedUuid;
+
+    let mutationSettled = false;
+    const mutation = tickMutations
+      .updateTick(null, { uuid: tickUuid, input: { comment: 'local wins' } }, authenticatedContext)
+      .finally(() => {
+        mutationSettled = true;
+      });
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 75));
+      expect(mutationSettled).toBe(false);
+    } finally {
+      releaseImport();
+    }
+    await Promise.all([importTransaction, mutation]);
+    const [stored] = await db
+      .select({ comment: dbSchema.boardseshTicks.comment })
+      .from(dbSchema.boardseshTicks)
+      .where(eq(dbSchema.boardseshTicks.uuid, tickUuid));
+    expect(stored.comment).toBe('local wins');
+  });
+
+  it('Kilter log apply and updateTick serialize over two connections', async () => {
+    const logUuid = 'kilter-concurrent';
+    const op: PowerSyncOp = {
+      op_id: '1',
+      op: 'PUT',
+      object_type: 'logs',
+      object_id: logUuid,
+      data: {
+        id: '1',
+        log_uuid: logUuid,
+        climb_uuid: CLIMB_UUID,
+        user_uuid: USER_ID,
+        gym_uuid: null,
+        wall_uuid: null,
+        product_layout_uuid: null,
+        angle: ANGLE,
+        flashed: 0,
+        topped: 1,
+        attempts: 2,
+        created_at: '2026-05-04T18:22:37.000Z',
+      },
+    };
+    let releaseImport!: () => void;
+    const importRelease = new Promise<void>((resolve) => {
+      releaseImport = resolve;
+    });
+    let importReady!: (uuid: string) => void;
+    const importedUuid = new Promise<string>((resolve) => {
+      importReady = resolve;
+    });
+    const importTransaction = db.transaction(async (tx) => {
+      await applyLogs(
+        tx as unknown as Parameters<typeof applyLogs>[0],
+        USER_ID,
+        [op],
+        new Map([[`kilter:${CLIMB_UUID}`, CLIMB_UUID]]),
+        () => {},
+      );
+      const [row] = await tx
+        .select({ uuid: dbSchema.boardseshTicks.uuid })
+        .from(dbSchema.boardseshTicks)
+        .where(eq(dbSchema.boardseshTicks.kilterId, logUuid));
+      importReady(row.uuid);
+      await importRelease;
+    });
+    const tickUuid = await importedUuid;
+
+    let mutationSettled = false;
+    const mutation = tickMutations
+      .updateTick(null, { uuid: tickUuid, input: { comment: 'local after Kilter' } }, authenticatedContext)
+      .finally(() => {
+        mutationSettled = true;
+      });
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 75));
+      expect(mutationSettled).toBe(false);
+    } finally {
+      releaseImport();
+    }
+    await Promise.all([importTransaction, mutation]);
+    const [stored] = await db
+      .select({ comment: dbSchema.boardseshTicks.comment })
+      .from(dbSchema.boardseshTicks)
+      .where(eq(dbSchema.boardseshTicks.uuid, tickUuid));
+    expect(stored.comment).toBe('local after Kilter');
   });
 });

--- a/packages/backend/src/__tests__/aurora-twin-dedup.test.ts
+++ b/packages/backend/src/__tests__/aurora-twin-dedup.test.ts
@@ -1082,33 +1082,44 @@ describe('#3535 Aurora-side duplicate ascents', () => {
     expect(await visibleAuroraIds()).toEqual(['aur-a']);
   });
 
-  it('waits on the legacy advisory key before taking the extended rollout key', async () => {
-    let releaseLegacyLock!: () => void;
-    const legacyLockRelease = new Promise<void>((resolve) => {
-      releaseLegacyLock = resolve;
+  it('blocks a second holder of the same user key while letting another user through', async () => {
+    let releaseHolder!: () => void;
+    const holderRelease = new Promise<void>((resolve) => {
+      releaseHolder = resolve;
     });
-    let signalLegacyLockHeld!: (backendPid: number) => void;
-    const legacyLockHeld = new Promise<number>((resolve) => {
-      signalLegacyLockHeld = resolve;
+    let signalHolderReady!: (backendPid: number) => void;
+    const holderReady = new Promise<number>((resolve) => {
+      signalHolderReady = resolve;
     });
-    const legacyLockTransaction = db.transaction(async (tx) => {
-      await tx.execute(sql`SELECT pg_advisory_xact_lock(${0x5449434b}, hashtext(${USER_ID}))`);
+    const holderTransaction = db.transaction(async (tx) => {
+      await acquireUserTickMutationLock(tx as unknown as Parameters<typeof acquireUserTickMutationLock>[0], USER_ID);
       const [{ backendPid }] = rowsOf<{ backendPid: number }>(
         await tx.execute(sql`SELECT pg_backend_pid() AS "backendPid"`),
       );
-      signalLegacyLockHeld(backendPid);
-      await legacyLockRelease;
+      signalHolderReady(backendPid);
+      await holderRelease;
       return backendPid;
     });
-    const legacyBackendPid = await legacyLockHeld;
-    const compatibleAcquisition = db.transaction(async (tx) => {
+    const holderBackendPid = await holderReady;
+
+    // The key is per user, not a global logbook gate: a second climber's
+    // mutation must not queue behind this one. If the seed/hash ever stopped
+    // depending on the user id, this acquisition would hang here instead.
+    await db.transaction(async (tx) => {
+      await acquireUserTickMutationLock(
+        tx as unknown as Parameters<typeof acquireUserTickMutationLock>[0],
+        `${USER_ID}-other`,
+      );
+    });
+
+    const contender = db.transaction(async (tx) => {
       await acquireUserTickMutationLock(tx as unknown as Parameters<typeof acquireUserTickMutationLock>[0], USER_ID);
     });
     await verifyContentionAndRelease({
-      holderBackendPid: legacyBackendPid,
-      holder: legacyLockTransaction,
-      contender: compatibleAcquisition,
-      releaseHolder: releaseLegacyLock,
+      holderBackendPid,
+      holder: holderTransaction,
+      contender,
+      releaseHolder,
     });
   });
 

--- a/packages/backend/src/__tests__/aurora-twin-dedup.test.ts
+++ b/packages/backend/src/__tests__/aurora-twin-dedup.test.ts
@@ -55,8 +55,103 @@ const CLIMB_NAME = 'Twin Test Climb';
 const ANGLE = 40;
 // Millisecond-precision instant: the twins share it exactly.
 const CLIMBED_AT = '2026-05-01T18:22:37.000Z';
+const LOCK_WAIT_TIMEOUT_MS = 4_000;
+const LOCK_WAIT_POLL_INTERVAL_MS = 20;
 
 type TickOverrides = Partial<typeof dbSchema.boardseshTicks.$inferInsert>;
+
+function rowsOf<Row>(result: unknown): Row[] {
+  return Array.from(result as Iterable<Row>);
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+/**
+ * Proves that a second connection is actually waiting for the transaction
+ * holding a user lock. A fixed delay only proves that the scheduler happened
+ * not to run the contender yet, which made these serialization tests flaky.
+ */
+async function waitForContenderToBlockOn(holderBackendPid: number, contender: Promise<unknown>): Promise<void> {
+  let stopPolling = false;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const contenderSettledEarly = contender.then(
+    () => {
+      throw new Error('The lock contender settled before PostgreSQL reported its wait');
+    },
+    (error: unknown) => {
+      throw new Error('The lock contender rejected before PostgreSQL reported its wait', { cause: error });
+    },
+  );
+  const observedWait = (async () => {
+    while (!stopPolling) {
+      const result = await db.execute(sql`
+        SELECT waiting.pid
+        FROM pg_locks AS waiting
+        JOIN pg_locks AS held
+          ON held.pid = ${holderBackendPid}
+         AND held.locktype = 'advisory'
+         AND held.granted = true
+         AND held.database IS NOT DISTINCT FROM waiting.database
+         AND held.classid IS NOT DISTINCT FROM waiting.classid
+         AND held.objid IS NOT DISTINCT FROM waiting.objid
+         AND held.objsubid IS NOT DISTINCT FROM waiting.objsubid
+        JOIN pg_stat_activity AS activity ON activity.pid = waiting.pid
+        WHERE waiting.locktype = 'advisory'
+          AND waiting.granted = false
+          AND activity.datname = current_database()
+          AND activity.wait_event_type = 'Lock'
+          AND activity.wait_event = 'advisory'
+          AND ${holderBackendPid} = ANY(pg_blocking_pids(activity.pid))
+      `);
+      if (rowsOf<{ pid: number }>(result).length > 0) return;
+      await delay(LOCK_WAIT_POLL_INTERVAL_MS);
+    }
+  })();
+  const hangGuard = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(
+        new Error(
+          `Timed out after ${LOCK_WAIT_TIMEOUT_MS}ms waiting for a contender blocked by PostgreSQL backend ${holderBackendPid}`,
+        ),
+      );
+    }, LOCK_WAIT_TIMEOUT_MS);
+  });
+
+  try {
+    await Promise.race([observedWait, contenderSettledEarly, hangGuard]);
+  } finally {
+    stopPolling = true;
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
+async function verifyContentionAndRelease(params: {
+  holderBackendPid: number;
+  holder: Promise<unknown>;
+  contender: Promise<unknown>;
+  releaseHolder: () => void;
+}): Promise<void> {
+  const { holderBackendPid, holder, contender, releaseHolder } = params;
+  let observationFailure: { error: unknown } | undefined;
+  try {
+    await waitForContenderToBlockOn(holderBackendPid, contender);
+  } catch (error: unknown) {
+    observationFailure = { error };
+  } finally {
+    releaseHolder();
+  }
+
+  const operationResults = await Promise.allSettled([holder, contender]);
+  if (observationFailure) throw observationFailure.error;
+
+  const operationFailures = operationResults.flatMap((result) => (result.status === 'rejected' ? [result.reason] : []));
+  if (operationFailures.length === 1) throw operationFailures[0];
+  if (operationFailures.length > 1) {
+    throw new AggregateError(operationFailures, 'The lock holder and contender both rejected');
+  }
+}
 
 /** Stable ordering for assertions; a native tick's NULL aurora_id sorts last. */
 function byAuroraId(left: string | null, right: string | null): number {
@@ -992,33 +1087,29 @@ describe('#3535 Aurora-side duplicate ascents', () => {
     const legacyLockRelease = new Promise<void>((resolve) => {
       releaseLegacyLock = resolve;
     });
-    let signalLegacyLockHeld!: () => void;
-    const legacyLockHeld = new Promise<void>((resolve) => {
+    let signalLegacyLockHeld!: (backendPid: number) => void;
+    const legacyLockHeld = new Promise<number>((resolve) => {
       signalLegacyLockHeld = resolve;
     });
     const legacyLockTransaction = db.transaction(async (tx) => {
       await tx.execute(sql`SELECT pg_advisory_xact_lock(${0x5449434b}, hashtext(${USER_ID}))`);
-      signalLegacyLockHeld();
+      const [{ backendPid }] = rowsOf<{ backendPid: number }>(
+        await tx.execute(sql`SELECT pg_backend_pid() AS "backendPid"`),
+      );
+      signalLegacyLockHeld(backendPid);
       await legacyLockRelease;
+      return backendPid;
     });
-    await legacyLockHeld;
-
-    let compatibleAcquisitionSettled = false;
-    const compatibleAcquisition = db
-      .transaction(async (tx) => {
-        await acquireUserTickMutationLock(tx as unknown as Parameters<typeof acquireUserTickMutationLock>[0], USER_ID);
-      })
-      .finally(() => {
-        compatibleAcquisitionSettled = true;
-      });
-    try {
-      await new Promise((resolve) => setTimeout(resolve, 75));
-      expect(compatibleAcquisitionSettled).toBe(false);
-    } finally {
-      releaseLegacyLock();
-    }
-
-    await Promise.all([legacyLockTransaction, compatibleAcquisition]);
+    const legacyBackendPid = await legacyLockHeld;
+    const compatibleAcquisition = db.transaction(async (tx) => {
+      await acquireUserTickMutationLock(tx as unknown as Parameters<typeof acquireUserTickMutationLock>[0], USER_ID);
+    });
+    await verifyContentionAndRelease({
+      holderBackendPid: legacyBackendPid,
+      holder: legacyLockTransaction,
+      contender: compatibleAcquisition,
+      releaseHolder: releaseLegacyLock,
+    });
   });
 
   it('Aurora apply and updateTick serialize over two connections', async () => {
@@ -1043,9 +1134,9 @@ describe('#3535 Aurora-side duplicate ascents', () => {
     const importRelease = new Promise<void>((resolve) => {
       releaseImport = resolve;
     });
-    let importReady!: (uuid: string) => void;
-    const importedUuid = new Promise<string>((resolve) => {
-      importReady = resolve;
+    let signalImportReady!: (result: { tickUuid: string; backendPid: number }) => void;
+    const importedTick = new Promise<{ tickUuid: string; backendPid: number }>((resolve) => {
+      signalImportReady = resolve;
     });
     const applyDb = db as unknown as Parameters<typeof applyAuroraAscents>[0];
     const importTransaction = db.transaction(async (tx) => {
@@ -1054,24 +1145,25 @@ describe('#3535 Aurora-side duplicate ascents', () => {
         .select({ uuid: dbSchema.boardseshTicks.uuid })
         .from(dbSchema.boardseshTicks)
         .where(sql`aurora_id = 'aur-concurrent'`);
-      importReady(row.uuid);
+      const [{ backendPid }] = rowsOf<{ backendPid: number }>(
+        await tx.execute(sql`SELECT pg_backend_pid() AS "backendPid"`),
+      );
+      signalImportReady({ tickUuid: row.uuid, backendPid });
       await importRelease;
     });
-    const tickUuid = await importedUuid;
+    const { tickUuid, backendPid } = await importedTick;
 
-    let mutationSettled = false;
-    const mutation = tickMutations
-      .updateTick(null, { uuid: tickUuid, input: { comment: 'local wins' } }, authenticatedContext)
-      .finally(() => {
-        mutationSettled = true;
-      });
-    try {
-      await new Promise((resolve) => setTimeout(resolve, 75));
-      expect(mutationSettled).toBe(false);
-    } finally {
-      releaseImport();
-    }
-    await Promise.all([importTransaction, mutation]);
+    const mutation = tickMutations.updateTick(
+      null,
+      { uuid: tickUuid, input: { comment: 'local wins' } },
+      authenticatedContext,
+    );
+    await verifyContentionAndRelease({
+      holderBackendPid: backendPid,
+      holder: importTransaction,
+      contender: mutation,
+      releaseHolder: releaseImport,
+    });
     const [stored] = await db
       .select({ comment: dbSchema.boardseshTicks.comment })
       .from(dbSchema.boardseshTicks)
@@ -1105,9 +1197,9 @@ describe('#3535 Aurora-side duplicate ascents', () => {
     const importRelease = new Promise<void>((resolve) => {
       releaseImport = resolve;
     });
-    let importReady!: (uuid: string) => void;
-    const importedUuid = new Promise<string>((resolve) => {
-      importReady = resolve;
+    let signalImportReady!: (result: { tickUuid: string; backendPid: number }) => void;
+    const importedTick = new Promise<{ tickUuid: string; backendPid: number }>((resolve) => {
+      signalImportReady = resolve;
     });
     const importTransaction = db.transaction(async (tx) => {
       await applyLogs(
@@ -1121,24 +1213,25 @@ describe('#3535 Aurora-side duplicate ascents', () => {
         .select({ uuid: dbSchema.boardseshTicks.uuid })
         .from(dbSchema.boardseshTicks)
         .where(eq(dbSchema.boardseshTicks.kilterId, logUuid));
-      importReady(row.uuid);
+      const [{ backendPid }] = rowsOf<{ backendPid: number }>(
+        await tx.execute(sql`SELECT pg_backend_pid() AS "backendPid"`),
+      );
+      signalImportReady({ tickUuid: row.uuid, backendPid });
       await importRelease;
     });
-    const tickUuid = await importedUuid;
+    const { tickUuid, backendPid } = await importedTick;
 
-    let mutationSettled = false;
-    const mutation = tickMutations
-      .updateTick(null, { uuid: tickUuid, input: { comment: 'local after Kilter' } }, authenticatedContext)
-      .finally(() => {
-        mutationSettled = true;
-      });
-    try {
-      await new Promise((resolve) => setTimeout(resolve, 75));
-      expect(mutationSettled).toBe(false);
-    } finally {
-      releaseImport();
-    }
-    await Promise.all([importTransaction, mutation]);
+    const mutation = tickMutations.updateTick(
+      null,
+      { uuid: tickUuid, input: { comment: 'local after Kilter' } },
+      authenticatedContext,
+    );
+    await verifyContentionAndRelease({
+      holderBackendPid: backendPid,
+      holder: importTransaction,
+      contender: mutation,
+      releaseHolder: releaseImport,
+    });
     const [stored] = await db
       .select({ comment: dbSchema.boardseshTicks.comment })
       .from(dbSchema.boardseshTicks)

--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -990,6 +990,9 @@ export const schemaSQL = `
     "board_id" bigint,
     "video_identity" text
   );
+  ALTER TABLE "board_beta_links"
+    ADD CONSTRAINT "board_beta_links_tick_uuid_boardsesh_ticks_uuid_fk"
+    FOREIGN KEY ("tick_uuid") REFERENCES "boardsesh_ticks"("uuid") ON DELETE SET NULL;
   CREATE UNIQUE INDEX IF NOT EXISTS "board_beta_links_video_identity_unique" ON "board_beta_links" ("video_identity") WHERE "video_identity" IS NOT NULL;
   CREATE UNIQUE INDEX IF NOT EXISTS "board_beta_links_tick_uuid_unique" ON "board_beta_links" ("tick_uuid") WHERE "tick_uuid" IS NOT NULL;
   CREATE INDEX IF NOT EXISTS "board_beta_links_board_id_idx" ON "board_beta_links" ("board_id") WHERE "board_id" IS NOT NULL;

--- a/packages/backend/src/__tests__/sync-mutations.test.ts
+++ b/packages/backend/src/__tests__/sync-mutations.test.ts
@@ -187,7 +187,7 @@ describe('deleteTick / updateTick typed errors', () => {
   });
 });
 
-describe('saveTick idempotent replay', () => {
+describe('saveTick persistence and idempotent replay', () => {
   const baseInput = {
     boardType: 'kilter',
     climbUuid: 'tick-climb-1',
@@ -231,6 +231,21 @@ describe('saveTick idempotent replay', () => {
 
     expect(a.uuid).not.toBe(b.uuid);
     expect(recomputeSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('preserves six climbedAt fractional digits while normalizing its offset', async () => {
+    const saved = (await tickMutations.saveTick(
+      undefined,
+      { input: { ...baseInput, climbedAt: '2026-05-02T01:02:03.123456-07:00' } },
+      ctx(),
+    )) as TickRow;
+
+    const rows = await db.execute(sql`
+      SELECT climbed_at::text AS climbed_at
+      FROM boardsesh_ticks
+      WHERE uuid = ${saved.uuid}
+    `);
+    expect(rows).toEqual([{ climbed_at: '2026-05-02 08:02:03.123456' }]);
   });
 });
 

--- a/packages/backend/src/__tests__/tick-validation.test.ts
+++ b/packages/backend/src/__tests__/tick-validation.test.ts
@@ -189,6 +189,40 @@ describe('UpdateTickInputSchema', () => {
   });
 });
 
+describe('tickMutations.saveTick validation', () => {
+  it('rejects an invalid climbed-at timestamp before querying or writing the database', async () => {
+    const selectSpy = vi.spyOn(db, 'select');
+    const transactionSpy = vi.spyOn(db, 'transaction');
+
+    try {
+      await expect(
+        tickMutations.saveTick(
+          null,
+          {
+            input: {
+              boardType: 'kilter',
+              climbUuid: TEST_CLIMB_UUID,
+              angle: 40,
+              isMirror: false,
+              status: 'attempt',
+              attemptCount: 1,
+              isBenchmark: false,
+              comment: '',
+              climbedAt: 'not a date',
+            },
+          },
+          authenticatedContext,
+        ),
+      ).rejects.toThrowError(/Climbed at must be a valid date/);
+      expect(selectSpy).not.toHaveBeenCalled();
+      expect(transactionSpy).not.toHaveBeenCalled();
+    } finally {
+      selectSpy.mockRestore();
+      transactionSpy.mockRestore();
+    }
+  });
+});
+
 describeWithDatabase('tickMutations.updateTick', () => {
   beforeEach(async () => {
     await cleanupTickValidationRows();

--- a/packages/backend/src/__tests__/tick-validation.test.ts
+++ b/packages/backend/src/__tests__/tick-validation.test.ts
@@ -28,7 +28,7 @@ vi.mock('../graphql/resolvers/beta-videos/queries', () => betaMocks);
 
 import { db } from '../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
-import { UpdateTickInputSchema } from '../validation/schemas/ticks';
+import { UpdateTickInputSchema, readTimestampFractionalSeconds } from '../validation/schemas/ticks';
 import { tickMutations } from '../graphql/resolvers/ticks/mutations';
 
 const TEST_USER_ID = 'tick-validation-test-user';
@@ -186,6 +186,32 @@ describe('UpdateTickInputSchema', () => {
         angle: 27.5,
       }),
     ).toThrow();
+  });
+});
+
+describe('readTimestampFractionalSeconds', () => {
+  // One pattern feeds both the six-digit precision refine and the resolver's
+  // normalizeClimbedAt. A zone shape it fails to read passes the refine
+  // vacuously and then gets stored as `.000`, so every form `new Date()`
+  // accepts alongside a fraction has to match.
+  it.each([
+    ['2026-05-02T01:02:03.123456Z', '123456'],
+    ['2026-05-02T01:02:03.123456', '123456'],
+    ['2026-05-02T01:02:03.123456+07:00', '123456'],
+    ['2026-05-02T01:02:03.123456+0700', '123456'],
+    ['2026-05-02 01:02:03.123456+07', '123456'],
+    ['2026-05-02 01:02:03.123456 +07:00', '123456'],
+  ])('reads the fraction out of %s', (value, expected) => {
+    expect(Number.isNaN(new Date(value).getTime())).toBe(false);
+    expect(readTimestampFractionalSeconds(value)).toBe(expected);
+  });
+
+  it('rejects a seven-digit fraction sitting behind an hour-only offset', () => {
+    expect(() =>
+      UpdateTickInputSchema.parse({
+        climbedAt: '2026-05-02 01:02:03.1234567+07',
+      }),
+    ).toThrowError(/at most six fractional-second digits/);
   });
 });
 

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -621,8 +621,6 @@ export const tickMutations = {
       publishDebouncedSessionStats(sessionId);
     }
 
-    logger.info(`[deleteTick] deleted tick=${uuid} user=${userId} rows=${deletedTicks.length}`);
-
     return true;
   },
 
@@ -1084,14 +1082,14 @@ export const tickMutations = {
 
       const finalStatus = validatedInput.status ?? targetTick.status;
       const finalAttemptCount = validatedInput.attemptCount ?? targetTick.attemptCount;
-      if (finalStatus === 'flash' && finalAttemptCount !== 1) {
-        logger.warn('[updateTick] Coerced flash tick attemptCount to 1', {
-          tickUuid: uuid,
-          userId,
-          previousAttemptCount: finalAttemptCount,
-        });
-        updates.attemptCount = 1;
-      } else if (finalStatus === 'flash') {
+      if (finalStatus === 'flash') {
+        if (finalAttemptCount !== 1) {
+          logger.warn('[updateTick] Coerced flash tick attemptCount to 1', {
+            tickUuid: uuid,
+            userId,
+            previousAttemptCount: finalAttemptCount,
+          });
+        }
         // A locally edited survivor can directly hide rows whose editable
         // payload differs. Reassert the flash invariant across every member.
         updates.attemptCount = 1;

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -422,12 +422,41 @@ const auroraMutationTwin = aliasedTable(dbSchema.boardseshTicks, 'aurora_mutatio
 type TickMutationTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
 /**
+ * Convert a client timestamp to the UTC wall-clock text PostgreSQL stores for
+ * `timestamp without time zone`, without serializing its fraction through a
+ * JavaScript Date.
+ *
+ * JavaScript Dates retain milliseconds only.  They are still useful for
+ * resolving a numeric UTC offset, but their formatted fraction must never be
+ * used here: a client is allowed to supply PostgreSQL's full six digits.
+ */
+function normalizeClimbedAt(value: string): string {
+  const parsed = new Date(value);
+  const utcDate = [
+    String(parsed.getUTCFullYear()).padStart(4, '0'),
+    String(parsed.getUTCMonth() + 1).padStart(2, '0'),
+    String(parsed.getUTCDate()).padStart(2, '0'),
+  ].join('-');
+  const utcTime = [
+    String(parsed.getUTCHours()).padStart(2, '0'),
+    String(parsed.getUTCMinutes()).padStart(2, '0'),
+    String(parsed.getUTCSeconds()).padStart(2, '0'),
+  ].join(':');
+  const utcSecond = `${utcDate}T${utcTime}`;
+  const fractionalSeconds = /[Tt ]\d{2}:\d{2}:\d{2}\.(\d{1,6})(?:[Zz]|[+-]\d{2}:?\d{2})?$/.exec(value)?.[1];
+
+  return fractionalSeconds ? `${utcSecond}.${fractionalSeconds}Z` : `${utcSecond}.000Z`;
+}
+
+/**
  * Resolve the exact rows an authenticated tick mutation may affect.
  *
  * Lock order is global and shared by update/delete: per-user advisory lock,
  * addressed row, then direct twins ordered by UUID. The target expands only
  * when it is the currently visible, real Aurora-pull survivor. Hidden/stale
  * UUIDs and every non-Aurora origin deliberately retain single-row semantics.
+ * A group is also refused when its pairwise witnesses would join two different
+ * real Kilter ids through a NULL-link hub: those are distinct upstream facts.
  */
 async function selectTickMutationGroupForUpdate(
   tx: TickMutationTransaction,
@@ -465,7 +494,15 @@ async function selectTickMutationGroupForUpdate(
     .orderBy(auroraMutationTwin.uuid)
     .for('update');
 
-  return [targetResult.tick, ...directTwins.map((row) => row.tick)];
+  const mutationGroup = [targetResult.tick, ...directTwins.map((row) => row.tick)];
+  const kilterIds = new Set(mutationGroup.flatMap((tick) => (tick.kilterId ? [tick.kilterId] : [])));
+
+  // `isDirectAuroraTwin` intentionally permits one NULL Kilter link. That is
+  // safe pairwise, but a NULL target can individually witness two different
+  // real links. Do not turn that V shape into one mutable logical ascent.
+  if (kilterIds.size > 1) return [targetResult.tick];
+
+  return mutationGroup;
 }
 
 function distinctTickStatsKeys(ticks: dbSchema.BoardseshTick[]): Array<{
@@ -505,7 +542,7 @@ export const tickMutations = {
     requireAuthenticated(ctx);
     const userId = ctx.userId!;
 
-    const deletedTicks = await db.transaction(async (tx) => {
+    const mutationResult = await db.transaction(async (tx) => {
       await acquireUserTickMutationLock(tx, userId);
       const affectedTicks = await selectTickMutationGroupForUpdate(tx, uuid, userId, 'delete');
       const affectedUuids = affectedTicks.map((tick) => tick.uuid);
@@ -541,8 +578,16 @@ export const tickMutations = {
         .where(
           and(eq(dbSchema.notifications.entityType, 'tick'), inArray(dbSchema.notifications.entityId, affectedUuids)),
         );
-      // board_beta_links.tick_uuid intentionally relies on its existing ON
-      // DELETE SET NULL FK. The trigger writes one offline tombstone per UUID.
+      // Detach explicitly instead of relying only on ON DELETE SET NULL, so a
+      // successful-ascent beta disappearing from its tick invalidates the
+      // 24-hour recent-beta cache after commit.
+      const detachedBetaLinks = await tx
+        .update(dbSchema.boardBetaLinks)
+        .set({ tickUuid: null })
+        .where(inArray(dbSchema.boardBetaLinks.tickUuid, affectedUuids))
+        .returning({ link: dbSchema.boardBetaLinks.link });
+
+      // The trigger writes one offline tombstone per UUID.
       await tx.delete(dbSchema.boardseshTicks).where(inArray(dbSchema.boardseshTicks.uuid, affectedUuids));
 
       const sessionIds = distinctTickSessions(affectedTicks);
@@ -550,8 +595,10 @@ export const tickMutations = {
         await tx.update(sessions).set({ lastActivity: new Date() }).where(inArray(sessions.id, sessionIds));
       }
 
-      return affectedTicks;
+      return { affectedTicks, detachedBetaLinks: detachedBetaLinks.length > 0 };
     });
+
+    const { affectedTicks: deletedTicks, detachedBetaLinks } = mutationResult;
 
     const targetTick = deletedTicks.find((tick) => tick.uuid === uuid)!;
     logger.info(
@@ -560,6 +607,11 @@ export const tickMutations = {
 
     for (const key of distinctTickStatsKeys(deletedTicks)) {
       queueClimbStatsRecompute(key.boardType, key.climbUuid, key.angle);
+    }
+    if (detachedBetaLinks) {
+      invalidateRecentBetaLinksCache().catch((err) => {
+        logger.error('[deleteTick] recent-beta-links cache invalidation failed:', err);
+      });
     }
 
     for (const { boardId, boardType } of distinctTickBoards(deletedTicks)) {
@@ -591,7 +643,7 @@ export const tickMutations = {
     );
     const uuid = validatedInput.uuid ?? uuidv4();
     const now = new Date().toISOString();
-    const climbedAt = new Date(validatedInput.climbedAt).toISOString();
+    const climbedAt = normalizeClimbedAt(validatedInput.climbedAt);
 
     if (validatedInput.uuid) {
       const [existingTick] = await db
@@ -1007,7 +1059,7 @@ export const tickMutations = {
 
     const validatedInput = validateInput(UpdateTickInputSchema, input, 'input');
     const canonicalClimbedAt =
-      validatedInput.climbedAt === undefined ? undefined : new Date(validatedInput.climbedAt).toISOString();
+      validatedInput.climbedAt === undefined ? undefined : normalizeClimbedAt(validatedInput.climbedAt);
 
     const changedFields = Object.keys(validatedInput);
     logger.info(`[updateTick] user=${userId} tick=${uuid} fields=[${changedFields.join(',')}]`);

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { eq, and, inArray, isNull } from 'drizzle-orm';
+import { eq, and, inArray, isNull, sql } from 'drizzle-orm';
 import { aliasedTable } from 'drizzle-orm/alias';
 import { GraphQLError } from 'graphql';
 import { betaLinkIdentity, type ConnectionContext, type TickStatus } from '@boardsesh/shared-schema';
@@ -26,6 +26,12 @@ import { invalidateRecentBetaLinksCache } from '../beta-videos/queries';
 import { resolveClimbCatalogPresence } from '../../../db/queries/climbs';
 import { captureBackendEvent } from '../../../services/analytics/posthog';
 import { logger } from '../../../utils/logger';
+import {
+  acquireUserTickMutationLock,
+  isDirectAuroraTwin,
+  isRealAuroraPullRow,
+  notAuroraTwinDuplicate,
+} from '@boardsesh/db/queries';
 
 // Beta links are only attached on successful ascents (flash / send), never
 // on `attempt`. Returns the URL to attach, or null if the tick shouldn't
@@ -411,6 +417,85 @@ function tickResult(tick: dbSchema.BoardseshTick): Record<string, unknown> {
   };
 }
 
+const auroraMutationTwin = aliasedTable(dbSchema.boardseshTicks, 'aurora_mutation_twin');
+
+type TickMutationTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/**
+ * Resolve the exact rows an authenticated tick mutation may affect.
+ *
+ * Lock order is global and shared by update/delete: per-user advisory lock,
+ * addressed row, then direct twins ordered by UUID. The target expands only
+ * when it is the currently visible, real Aurora-pull survivor. Hidden/stale
+ * UUIDs and every non-Aurora origin deliberately retain single-row semantics.
+ */
+async function selectTickMutationGroupForUpdate(
+  tx: TickMutationTransaction,
+  uuid: string,
+  userId: string,
+  action: 'update' | 'delete',
+): Promise<dbSchema.BoardseshTick[]> {
+  const [targetResult] = await tx
+    .select({
+      tick: dbSchema.boardseshTicks,
+      isVisible: sql<boolean>`${notAuroraTwinDuplicate(dbSchema.boardseshTicks)}`,
+      isRealAuroraPull: sql<boolean>`${isRealAuroraPullRow(dbSchema.boardseshTicks)}`,
+    })
+    .from(dbSchema.boardseshTicks)
+    .where(eq(dbSchema.boardseshTicks.uuid, uuid))
+    .for('update');
+
+  if (!targetResult) {
+    throw new GraphQLError('Tick not found', { extensions: { code: 'TICK_NOT_FOUND' } });
+  }
+  if (targetResult.tick.userId !== userId) {
+    const message = action === 'delete' ? 'You can only delete your own ticks' : 'Not authorized to update this tick';
+    throw new GraphQLError(message, { extensions: { code: 'FORBIDDEN' } });
+  }
+
+  if (!targetResult.isVisible || !targetResult.isRealAuroraPull) return [targetResult.tick];
+
+  // Directional and pairwise on purpose: the addressed target must itself be
+  // the smaller witness for every member. Never walk through a middle row.
+  const directTwins = await tx
+    .select({ tick: auroraMutationTwin })
+    .from(auroraMutationTwin)
+    .innerJoin(dbSchema.boardseshTicks, eq(dbSchema.boardseshTicks.uuid, uuid))
+    .where(isDirectAuroraTwin(dbSchema.boardseshTicks, auroraMutationTwin))
+    .orderBy(auroraMutationTwin.uuid)
+    .for('update');
+
+  return [targetResult.tick, ...directTwins.map((row) => row.tick)];
+}
+
+function distinctTickStatsKeys(ticks: dbSchema.BoardseshTick[]): Array<{
+  boardType: string;
+  climbUuid: string;
+  angle: number;
+}> {
+  const keys = new Map<string, { boardType: string; climbUuid: string; angle: number }>();
+  for (const tick of ticks) {
+    keys.set(`${tick.boardType}\u0000${tick.climbUuid}\u0000${tick.angle}`, {
+      boardType: tick.boardType,
+      climbUuid: tick.climbUuid,
+      angle: tick.angle,
+    });
+  }
+  return [...keys.values()];
+}
+
+function distinctTickSessions(ticks: dbSchema.BoardseshTick[]): string[] {
+  return [...new Set(ticks.flatMap((tick) => (tick.sessionId ? [tick.sessionId] : [])))];
+}
+
+function distinctTickBoards(ticks: dbSchema.BoardseshTick[]): Array<{ boardId: number; boardType: string }> {
+  const boards = new Map<number, string>();
+  for (const tick of ticks) {
+    if (tick.boardId != null) boards.set(tick.boardId, tick.boardType);
+  }
+  return [...boards].map(([boardId, boardType]) => ({ boardId, boardType }));
+}
+
 export const tickMutations = {
   /**
    * Delete a tick (climb attempt/ascent) for the authenticated user.
@@ -420,37 +505,17 @@ export const tickMutations = {
     requireAuthenticated(ctx);
     const userId = ctx.userId!;
 
-    const [tick] = await db
-      .select({
-        uuid: dbSchema.boardseshTicks.uuid,
-        userId: dbSchema.boardseshTicks.userId,
-        sessionId: dbSchema.boardseshTicks.sessionId,
-        boardType: dbSchema.boardseshTicks.boardType,
-        climbUuid: dbSchema.boardseshTicks.climbUuid,
-        angle: dbSchema.boardseshTicks.angle,
-        boardId: dbSchema.boardseshTicks.boardId,
-      })
-      .from(dbSchema.boardseshTicks)
-      .where(eq(dbSchema.boardseshTicks.uuid, uuid))
-      .limit(1);
+    const deletedTicks = await db.transaction(async (tx) => {
+      await acquireUserTickMutationLock(tx, userId);
+      const affectedTicks = await selectTickMutationGroupForUpdate(tx, uuid, userId, 'delete');
+      const affectedUuids = affectedTicks.map((tick) => tick.uuid);
 
-    if (!tick) {
-      throw new GraphQLError('Tick not found', { extensions: { code: 'TICK_NOT_FOUND' } });
-    }
-    if (tick.userId !== userId) {
-      throw new GraphQLError('You can only delete your own ticks', { extensions: { code: 'FORBIDDEN' } });
-    }
-
-    logger.info(
-      `[deleteTick] user=${userId} tick=${uuid} ${tick.boardType}/${tick.climbUuid.slice(0, 8)}/${tick.angle}`,
-    );
-
-    await db.transaction(async (tx) => {
-      // Collect comment IDs on this tick so we can clean up their notifications
+      // Collect comment IDs across the logical ascent so their notifications
+      // are removed before the comments themselves.
       const tickComments = await tx
         .select({ id: dbSchema.comments.id })
         .from(dbSchema.comments)
-        .where(and(eq(dbSchema.comments.entityType, 'tick'), eq(dbSchema.comments.entityId, uuid)));
+        .where(and(eq(dbSchema.comments.entityType, 'tick'), inArray(dbSchema.comments.entityId, affectedUuids)));
       const commentIds = tickComments.map((c) => c.id);
 
       // Delete notifications referencing these comments (commentId FK is SET NULL, so we must delete explicitly)
@@ -461,40 +526,50 @@ export const tickMutations = {
       // Delete related social data for the tick itself
       await tx
         .delete(dbSchema.feedItems)
-        .where(and(eq(dbSchema.feedItems.entityType, 'tick'), eq(dbSchema.feedItems.entityId, uuid)));
+        .where(and(eq(dbSchema.feedItems.entityType, 'tick'), inArray(dbSchema.feedItems.entityId, affectedUuids)));
       await tx
         .delete(dbSchema.votes)
-        .where(and(eq(dbSchema.votes.entityType, 'tick'), eq(dbSchema.votes.entityId, uuid)));
+        .where(and(eq(dbSchema.votes.entityType, 'tick'), inArray(dbSchema.votes.entityId, affectedUuids)));
       await tx
         .delete(dbSchema.voteCounts)
-        .where(and(eq(dbSchema.voteCounts.entityType, 'tick'), eq(dbSchema.voteCounts.entityId, uuid)));
+        .where(and(eq(dbSchema.voteCounts.entityType, 'tick'), inArray(dbSchema.voteCounts.entityId, affectedUuids)));
       await tx
         .delete(dbSchema.comments)
-        .where(and(eq(dbSchema.comments.entityType, 'tick'), eq(dbSchema.comments.entityId, uuid)));
+        .where(and(eq(dbSchema.comments.entityType, 'tick'), inArray(dbSchema.comments.entityId, affectedUuids)));
       await tx
         .delete(dbSchema.notifications)
-        .where(and(eq(dbSchema.notifications.entityType, 'tick'), eq(dbSchema.notifications.entityId, uuid)));
-      // Delete the tick itself
-      await tx.delete(dbSchema.boardseshTicks).where(eq(dbSchema.boardseshTicks.uuid, uuid));
+        .where(
+          and(eq(dbSchema.notifications.entityType, 'tick'), inArray(dbSchema.notifications.entityId, affectedUuids)),
+        );
+      // board_beta_links.tick_uuid intentionally relies on its existing ON
+      // DELETE SET NULL FK. The trigger writes one offline tombstone per UUID.
+      await tx.delete(dbSchema.boardseshTicks).where(inArray(dbSchema.boardseshTicks.uuid, affectedUuids));
 
-      if (tick.sessionId) {
-        await tx.update(sessions).set({ lastActivity: new Date() }).where(eq(sessions.id, tick.sessionId));
+      const sessionIds = distinctTickSessions(affectedTicks);
+      if (sessionIds.length > 0) {
+        await tx.update(sessions).set({ lastActivity: new Date() }).where(inArray(sessions.id, sessionIds));
       }
+
+      return affectedTicks;
     });
 
-    // Recompute the stats row so a deleted ascent doesn't leave the count
-    // inflated or the FA pinned to a now-vanished tick.
-    queueClimbStatsRecompute(tick.boardType, tick.climbUuid, tick.angle);
+    const targetTick = deletedTicks.find((tick) => tick.uuid === uuid)!;
+    logger.info(
+      `[deleteTick] user=${userId} tick=${uuid} ${targetTick.boardType}/${targetTick.climbUuid.slice(0, 8)}/${targetTick.angle} rows=${deletedTicks.length}`,
+    );
 
-    // Board presence: a deleted tick on a connected wall changes that wall's
-    // durable stats (sends / climbers / hardest / top grade) — refresh the
-    // live tiles + cache the same way saveTick does. See the longer comment
-    // on the saveTick call site below.
-    if (tick.boardId != null) {
-      queueBoardStatsPublish(tick.boardId, tick.boardType);
+    for (const key of distinctTickStatsKeys(deletedTicks)) {
+      queueClimbStatsRecompute(key.boardType, key.climbUuid, key.angle);
     }
 
-    logger.info(`[deleteTick] deleted tick=${uuid} user=${userId}`);
+    for (const { boardId, boardType } of distinctTickBoards(deletedTicks)) {
+      queueBoardStatsPublish(boardId, boardType);
+    }
+    for (const sessionId of distinctTickSessions(deletedTicks)) {
+      publishDebouncedSessionStats(sessionId);
+    }
+
+    logger.info(`[deleteTick] deleted tick=${uuid} user=${userId} rows=${deletedTicks.length}`);
 
     return true;
   },
@@ -931,97 +1006,86 @@ export const tickMutations = {
     const userId = ctx.userId!;
 
     const validatedInput = validateInput(UpdateTickInputSchema, input, 'input');
-
-    // Verify ownership and get current tick
-    const existing = await db
-      .select()
-      .from(dbSchema.boardseshTicks)
-      .where(eq(dbSchema.boardseshTicks.uuid, uuid))
-      .limit(1);
-
-    if (existing.length === 0) {
-      throw new GraphQLError('Tick not found', { extensions: { code: 'TICK_NOT_FOUND' } });
-    }
-    if (existing[0].userId !== userId) {
-      throw new GraphQLError('Not authorized to update this tick', { extensions: { code: 'FORBIDDEN' } });
-    }
+    const canonicalClimbedAt =
+      validatedInput.climbedAt === undefined ? undefined : new Date(validatedInput.climbedAt).toISOString();
 
     const changedFields = Object.keys(validatedInput);
     logger.info(`[updateTick] user=${userId} tick=${uuid} fields=[${changedFields.join(',')}]`);
 
-    const updates: Record<string, unknown> = {
-      updatedAt: new Date().toISOString(),
-    };
+    const mutationResult = await db.transaction(async (tx) => {
+      await acquireUserTickMutationLock(tx, userId);
+      const existingTicks = await selectTickMutationGroupForUpdate(tx, uuid, userId, 'update');
+      const targetTick = existingTicks.find((tick) => tick.uuid === uuid)!;
+      const affectedUuids = existingTicks.map((tick) => tick.uuid);
 
-    if (validatedInput.status !== undefined) updates.status = validatedInput.status;
-    if (validatedInput.attemptCount !== undefined) updates.attemptCount = validatedInput.attemptCount;
-    if (validatedInput.quality !== undefined) updates.quality = validatedInput.quality;
-    if (validatedInput.difficulty !== undefined) updates.difficulty = validatedInput.difficulty;
-    if (validatedInput.isBenchmark !== undefined) updates.isBenchmark = validatedInput.isBenchmark;
-    if (validatedInput.comment !== undefined) updates.comment = validatedInput.comment;
-    if (validatedInput.climbedAt !== undefined) updates.climbedAt = validatedInput.climbedAt;
-    if (validatedInput.angle !== undefined) updates.angle = validatedInput.angle;
+      const updates: Partial<typeof dbSchema.boardseshTicks.$inferInsert> = {
+        updatedAt: new Date().toISOString(),
+      };
+      if (validatedInput.status !== undefined) updates.status = validatedInput.status;
+      if (validatedInput.attemptCount !== undefined) updates.attemptCount = validatedInput.attemptCount;
+      if (validatedInput.quality !== undefined) updates.quality = validatedInput.quality;
+      if (validatedInput.difficulty !== undefined) updates.difficulty = validatedInput.difficulty;
+      if (validatedInput.isBenchmark !== undefined) updates.isBenchmark = validatedInput.isBenchmark;
+      if (validatedInput.comment !== undefined) updates.comment = validatedInput.comment;
+      if (canonicalClimbedAt !== undefined) updates.climbedAt = canonicalClimbedAt;
+      if (validatedInput.angle !== undefined) updates.angle = validatedInput.angle;
 
-    const finalStatus = validatedInput.status ?? existing[0].status;
-    const finalAttemptCount = validatedInput.attemptCount ?? existing[0].attemptCount;
-    if (finalStatus === 'flash' && finalAttemptCount !== 1) {
-      logger.warn('[updateTick] Coerced flash tick attemptCount to 1', {
-        tickUuid: uuid,
-        userId,
-        previousAttemptCount: finalAttemptCount,
-      });
-      updates.attemptCount = 1;
-    }
-
-    const [updated] = await db
-      .update(dbSchema.boardseshTicks)
-      .set(updates)
-      .where(eq(dbSchema.boardseshTicks.uuid, uuid))
-      .returning();
-
-    // Status edits (attempt → send and back) flip whether this tick counts
-    // toward ascensionist_count, and a quality/difficulty/comment edit can
-    // also change downstream derived stats once we aggregate those. Recompute.
-    queueClimbStatsRecompute(updated.boardType, updated.climbUuid, updated.angle);
-
-    // An angle edit moves this tick between two INDEPENDENT board_climb_stats
-    // buckets (keyed on board_type + climb_uuid + angle). The recompute above
-    // only re-derives the NEW angle's bucket from boardsesh_ticks — it can't
-    // see that a tick just left the OLD angle, because the row's angle column
-    // has already been updated by the time it runs. Without this second call,
-    // the old angle's ascensionist_count / quality_average stay permanently
-    // stale (over-counting the moved tick): there's no self-heal path for it,
-    // since the self-heal job keys off ticks at their CURRENT angle too.
-    if (updated.angle !== existing[0].angle) {
-      queueClimbStatsRecompute(updated.boardType, updated.climbUuid, existing[0].angle);
-    }
-
-    // A tick with a directly linked beta video stamps its angle onto that
-    // board_beta_links row — saveTick and attachBetaLink both persist the tick's
-    // angle there alongside tick_uuid. The mobile home feed opens the video at
-    // the beta row's angle, so correcting a tick from 40° to 25° must move its
-    // beta with it or the video keeps opening at the old angle. Only touch the
-    // row (and bust the recent-beta strip cache) when the angle actually moved
-    // and a linked beta exists.
-    if (updated.angle !== existing[0].angle) {
-      const [movedBetaLink] = await db
-        .update(dbSchema.boardBetaLinks)
-        .set({ angle: updated.angle })
-        .where(eq(dbSchema.boardBetaLinks.tickUuid, uuid))
-        .returning({ link: dbSchema.boardBetaLinks.link });
-      if (movedBetaLink) {
-        invalidateRecentBetaLinksCache().catch((err) => {
-          logger.error('[updateTick] recent-beta-links cache invalidation failed:', err);
+      const finalStatus = validatedInput.status ?? targetTick.status;
+      const finalAttemptCount = validatedInput.attemptCount ?? targetTick.attemptCount;
+      if (finalStatus === 'flash' && finalAttemptCount !== 1) {
+        logger.warn('[updateTick] Coerced flash tick attemptCount to 1', {
+          tickUuid: uuid,
+          userId,
+          previousAttemptCount: finalAttemptCount,
         });
+        updates.attemptCount = 1;
+      } else if (finalStatus === 'flash') {
+        // A locally edited survivor can directly hide rows whose editable
+        // payload differs. Reassert the flash invariant across every member.
+        updates.attemptCount = 1;
       }
+
+      const updatedTicks = await tx
+        .update(dbSchema.boardseshTicks)
+        .set(updates)
+        .where(inArray(dbSchema.boardseshTicks.uuid, affectedUuids))
+        .returning();
+      const updatedTarget = updatedTicks.find((tick) => tick.uuid === uuid)!;
+
+      let movedBetaLinks = false;
+      if (existingTicks.some((tick) => tick.angle !== updatedTarget.angle)) {
+        const moved = await tx
+          .update(dbSchema.boardBetaLinks)
+          .set({ angle: updatedTarget.angle })
+          .where(inArray(dbSchema.boardBetaLinks.tickUuid, affectedUuids))
+          .returning({ link: dbSchema.boardBetaLinks.link });
+        movedBetaLinks = moved.length > 0;
+      }
+
+      const sessionIds = distinctTickSessions(existingTicks);
+      if (sessionIds.length > 0) {
+        await tx.update(sessions).set({ lastActivity: new Date() }).where(inArray(sessions.id, sessionIds));
+      }
+
+      return { existingTicks, updatedTicks, updatedTarget, movedBetaLinks };
+    });
+
+    for (const key of distinctTickStatsKeys([...mutationResult.existingTicks, ...mutationResult.updatedTicks])) {
+      queueClimbStatsRecompute(key.boardType, key.climbUuid, key.angle);
+    }
+    if (mutationResult.movedBetaLinks) {
+      invalidateRecentBetaLinksCache().catch((err) => {
+        logger.error('[updateTick] recent-beta-links cache invalidation failed:', err);
+      });
+    }
+    for (const { boardId, boardType } of distinctTickBoards(mutationResult.updatedTicks)) {
+      queueBoardStatsPublish(boardId, boardType);
+    }
+    for (const sessionId of distinctTickSessions(mutationResult.existingTicks)) {
+      publishDebouncedSessionStats(sessionId);
     }
 
-    // Board presence: an edited tick on a connected wall can change that
-    // wall's durable stats (e.g. attempt -> send). See the longer comment on
-    // the saveTick call site above.
-    if (updated.boardId != null) {
-      queueBoardStatsPublish(updated.boardId, updated.boardType);
-    }
+    const updated = mutationResult.updatedTarget;
 
     logger.info(
       `[updateTick] updated tick=${updated.uuid} user=${userId} ` +

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -8,7 +8,12 @@ import * as dbSchema from '@boardsesh/db/schema';
 import { sessions } from '../../../db/schema';
 import { applyRateLimit, requireAuthenticated, validateInput, isNoMatchClimb } from '../shared/helpers';
 import { getConsensusDifficultyName } from '../shared/sql-expressions';
-import { SaveTickInputSchema, UpdateTickInputSchema, AttachBetaLinkInputSchema } from '../../../validation/schemas';
+import {
+  SaveTickInputSchema,
+  UpdateTickInputSchema,
+  AttachBetaLinkInputSchema,
+  readTimestampFractionalSeconds,
+} from '../../../validation/schemas';
 import { resolveBoardFromPath } from '../social/boards';
 import { findActiveBoardById, normalizeSetIds } from '../board-presence/shared';
 import { queueBoardStatsPublish } from '../board-presence/stats';
@@ -429,6 +434,12 @@ type TickMutationTransaction = Parameters<Parameters<typeof db.transaction>[0]>[
  * JavaScript Dates retain milliseconds only.  They are still useful for
  * resolving a numeric UTC offset, but their formatted fraction must never be
  * used here: a client is allowed to supply PostgreSQL's full six digits.
+ *
+ * The fraction is read with the same pattern the validator uses, so a shape it
+ * fails to recognise can't be one that already passed the six-digit refine.
+ * Callers must validate first; the slice is belt-and-braces against a caller
+ * that forgets and would otherwise hand PostgreSQL a fraction it silently
+ * rounds.
  */
 function normalizeClimbedAt(value: string): string {
   const parsed = new Date(value);
@@ -443,7 +454,7 @@ function normalizeClimbedAt(value: string): string {
     String(parsed.getUTCSeconds()).padStart(2, '0'),
   ].join(':');
   const utcSecond = `${utcDate}T${utcTime}`;
-  const fractionalSeconds = /[Tt ]\d{2}:\d{2}:\d{2}\.(\d{1,6})(?:[Zz]|[+-]\d{2}:?\d{2})?$/.exec(value)?.[1];
+  const fractionalSeconds = readTimestampFractionalSeconds(value)?.slice(0, 6);
 
   return fractionalSeconds ? `${utcSecond}.${fractionalSeconds}Z` : `${utcSecond}.000Z`;
 }

--- a/packages/backend/src/validation/schemas/ticks.ts
+++ b/packages/backend/src/validation/schemas/ticks.ts
@@ -3,6 +3,12 @@ import { BETA_VIDEO_URL_REGEX, BETA_VIDEO_URL_VALIDATION_MESSAGE } from '@boards
 import { ExternalUUIDSchema, BoardNameSchema, UUIDSchema } from './primitives';
 
 const CLIMBED_AT_FUTURE_TOLERANCE_MS = 60_000;
+const POSTGRES_TIMESTAMP_FRACTION_PATTERN = /[Tt ]\d{2}:\d{2}:\d{2}\.(\d+)(?:[Zz]|[+-]\d{2}:?\d{2})?$/;
+
+function hasSupportedPostgresTimestampPrecision(value: string): boolean {
+  const fractionalSeconds = POSTGRES_TIMESTAMP_FRACTION_PATTERN.exec(value)?.[1];
+  return fractionalSeconds === undefined || fractionalSeconds.length <= 6;
+}
 
 /**
  * Tick status validation schema
@@ -27,7 +33,9 @@ export const SaveTickInputSchema = z
     difficulty: z.number().int().optional().nullable(),
     isBenchmark: z.boolean(),
     comment: z.string().max(2000),
-    climbedAt: z.string(),
+    climbedAt: z
+      .string()
+      .refine(hasSupportedPostgresTimestampPrecision, 'Climbed at supports at most six fractional-second digits'),
     sessionId: z.string().optional(),
     layoutId: z.number().int().positive().optional(),
     sizeId: z.number().int().positive().optional(),
@@ -152,6 +160,7 @@ export const UpdateTickInputSchema = z
     climbedAt: z
       .string()
       .refine((value) => !Number.isNaN(new Date(value).getTime()), 'Climbed at must be a valid date')
+      .refine(hasSupportedPostgresTimestampPrecision, 'Climbed at supports at most six fractional-second digits')
       .refine(
         (value) => new Date(value).getTime() <= Date.now() + CLIMBED_AT_FUTURE_TOLERANCE_MS,
         'Climbed at cannot be in the future',

--- a/packages/backend/src/validation/schemas/ticks.ts
+++ b/packages/backend/src/validation/schemas/ticks.ts
@@ -3,10 +3,25 @@ import { BETA_VIDEO_URL_REGEX, BETA_VIDEO_URL_VALIDATION_MESSAGE } from '@boards
 import { ExternalUUIDSchema, BoardNameSchema, UUIDSchema } from './primitives';
 
 const CLIMBED_AT_FUTURE_TOLERANCE_MS = 60_000;
-const POSTGRES_TIMESTAMP_FRACTION_PATTERN = /[Tt ]\d{2}:\d{2}:\d{2}\.(\d+)(?:[Zz]|[+-]\d{2}:?\d{2})?$/;
+
+/**
+ * Fractional seconds of a client timestamp, capture group 1.
+ *
+ * The trailing zone alternatives cover every shape `new Date()` accepts
+ * alongside a fraction: bare, `Z`, and a `+hh` / `+hhmm` / `+hh:mm` offset that
+ * a space may precede. Missing one of those would let a timestamp through with
+ * its fraction unread — the precision refine below would pass vacuously and
+ * `normalizeClimbedAt` would store `.000`, so validator and normalizer share
+ * this one pattern rather than each keeping a copy.
+ */
+export const POSTGRES_TIMESTAMP_FRACTION_PATTERN = /[Tt ]\d{2}:\d{2}:\d{2}\.(\d+)\s*(?:[Zz]|[+-]\d{2}(?::?\d{2})?)?$/;
+
+export function readTimestampFractionalSeconds(value: string): string | undefined {
+  return POSTGRES_TIMESTAMP_FRACTION_PATTERN.exec(value)?.[1];
+}
 
 function hasSupportedPostgresTimestampPrecision(value: string): boolean {
-  const fractionalSeconds = POSTGRES_TIMESTAMP_FRACTION_PATTERN.exec(value)?.[1];
+  const fractionalSeconds = readTimestampFractionalSeconds(value);
   return fractionalSeconds === undefined || fractionalSeconds.length <= 6;
 }
 

--- a/packages/backend/src/validation/schemas/ticks.ts
+++ b/packages/backend/src/validation/schemas/ticks.ts
@@ -35,6 +35,7 @@ export const SaveTickInputSchema = z
     comment: z.string().max(2000),
     climbedAt: z
       .string()
+      .refine((value) => !Number.isNaN(new Date(value).getTime()), 'Climbed at must be a valid date')
       .refine(hasSupportedPostgresTimestampPrecision, 'Climbed at supports at most six fractional-second digits'),
     sessionId: z.string().optional(),
     layoutId: z.number().int().positive().optional(),

--- a/packages/db/src/queries/ticks/__tests__/user-tick-mutation-lock.test.ts
+++ b/packages/db/src/queries/ticks/__tests__/user-tick-mutation-lock.test.ts
@@ -4,11 +4,11 @@ import type { SQL } from 'drizzle-orm';
 import { PgDialect } from 'drizzle-orm/pg-core';
 import { acquireUserTickMutationLock } from '../user-tick-mutation-lock';
 
-const USER_TICK_MUTATION_LOCK_NAMESPACE = 0x5449434b;
+const USER_TICK_MUTATION_LOCK_SEED = 0x5449434b;
 const dialect = new PgDialect();
 
 void describe('acquireUserTickMutationLock', () => {
-  void test('acquires the legacy key before the extended 64-bit key', async () => {
+  void test('takes exactly one transaction-scoped 64-bit key seeded on the user id', async () => {
     const statements: SQL[] = [];
     const fakeDb = {
       execute: async (statement: SQL) => {
@@ -22,11 +22,9 @@ void describe('acquireUserTickMutationLock', () => {
       'rollout-user',
     );
 
-    assert.equal(statements.length, 2);
-    const renderedStatements = statements.map((statement) => dialect.sqlToQuery(statement));
-    assert.match(renderedStatements[0].sql, /pg_advisory_xact_lock\(\$1, hashtext\(\$2\)\)/);
-    assert.deepEqual(renderedStatements[0].params, [USER_TICK_MUTATION_LOCK_NAMESPACE, 'rollout-user']);
-    assert.match(renderedStatements[1].sql, /pg_advisory_xact_lock\(hashtextextended\(\$1, \$2::bigint\)\)/);
-    assert.deepEqual(renderedStatements[1].params, ['rollout-user', USER_TICK_MUTATION_LOCK_NAMESPACE]);
+    assert.equal(statements.length, 1);
+    const rendered = dialect.sqlToQuery(statements[0]);
+    assert.match(rendered.sql, /pg_advisory_xact_lock\(hashtextextended\(\$1, \$2::bigint\)\)/);
+    assert.deepEqual(rendered.params, ['rollout-user', USER_TICK_MUTATION_LOCK_SEED]);
   });
 });

--- a/packages/db/src/queries/ticks/__tests__/user-tick-mutation-lock.test.ts
+++ b/packages/db/src/queries/ticks/__tests__/user-tick-mutation-lock.test.ts
@@ -1,0 +1,32 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { acquireUserTickMutationLock } from '../user-tick-mutation-lock';
+
+const USER_TICK_MUTATION_LOCK_NAMESPACE = 0x5449434b;
+const dialect = new PgDialect();
+
+void describe('acquireUserTickMutationLock', () => {
+  void test('acquires the legacy key before the extended 64-bit key', async () => {
+    const statements: SQL[] = [];
+    const fakeDb = {
+      execute: async (statement: SQL) => {
+        statements.push(statement);
+        return [];
+      },
+    };
+
+    await acquireUserTickMutationLock(
+      fakeDb as unknown as Parameters<typeof acquireUserTickMutationLock>[0],
+      'rollout-user',
+    );
+
+    assert.equal(statements.length, 2);
+    const renderedStatements = statements.map((statement) => dialect.sqlToQuery(statement));
+    assert.match(renderedStatements[0].sql, /pg_advisory_xact_lock\(\$1, hashtext\(\$2\)\)/);
+    assert.deepEqual(renderedStatements[0].params, [USER_TICK_MUTATION_LOCK_NAMESPACE, 'rollout-user']);
+    assert.match(renderedStatements[1].sql, /pg_advisory_xact_lock\(hashtextextended\(\$1, \$2::bigint\)\)/);
+    assert.deepEqual(renderedStatements[1].params, ['rollout-user', USER_TICK_MUTATION_LOCK_NAMESPACE]);
+  });
+});

--- a/packages/db/src/queries/ticks/aurora-twin-dedup.ts
+++ b/packages/db/src/queries/ticks/aurora-twin-dedup.ts
@@ -87,11 +87,72 @@ function isLocallyEdited(ticks: { updatedAt: Column; auroraSyncedAt: Column }): 
  * columns structurally so it accepts both the base table and the self-join
  * alias (drizzle bakes the table name into a column's type).
  */
-function isRealAuroraPullRow(ticks: { origin: Column; auroraId: Column }): SQL {
+export function isRealAuroraPullRow(ticks: { origin: Column; auroraId: Column }): SQL {
   return and(
     eq(ticks.origin, 'aurora_pull'),
     isNotNull(ticks.auroraId),
     sql`${ticks.auroraId} NOT LIKE ${SYNTHETIC_AURORA_ID_PATTERN}`,
+  )!;
+}
+
+type AuroraTwinComparableRow = {
+  origin: Column;
+  auroraId: Column;
+  userId: Column;
+  boardType: Column;
+  climbUuid: Column;
+  angle: Column;
+  climbedAt: Column;
+  status: Column;
+  auroraType: Column;
+  updatedAt: Column;
+  auroraSyncedAt: Column;
+  isMirror: Column;
+  attemptCount: Column;
+  quality: Column;
+  difficulty: Column;
+  isBenchmark: Column;
+  comment: Column;
+  kilterId: Column;
+};
+
+/**
+ * Exact, directional pair predicate shared by read collapse and mutations.
+ *
+ * `smaller` is a direct witness that hides `larger`; the direction matters
+ * because only the smaller row's local-edit timestamp relaxes payload parity.
+ * Keep every rule here pairwise. In particular, callers must not build a
+ * transitive closure through an intermediate row: A hiding B and B hiding C
+ * does not imply that a mutation addressed to A may change C.
+ */
+export function isDirectAuroraTwin(smaller: AuroraTwinComparableRow, larger: AuroraTwinComparableRow): SQL {
+  return and(
+    isRealAuroraPullRow(smaller),
+    isRealAuroraPullRow(larger),
+    eq(smaller.userId, larger.userId),
+    eq(smaller.boardType, larger.boardType),
+    eq(smaller.climbUuid, larger.climbUuid),
+    eq(smaller.angle, larger.angle),
+    // Exact timestamp-without-time-zone comparison stays inside Postgres.
+    // Converting either side to a JS Date would truncate stored microseconds.
+    eq(smaller.climbedAt, larger.climbedAt),
+    // These identify different upstream facts and are never edit-relaxed.
+    eq(smaller.status, larger.status),
+    sql`${smaller.auroraType} IS NOT DISTINCT FROM ${larger.auroraType}`,
+    or(
+      isLocallyEdited(smaller),
+      and(
+        sql`COALESCE(${smaller.isMirror}, false) = COALESCE(${larger.isMirror}, false)`,
+        sql`${smaller.attemptCount} IS NOT DISTINCT FROM ${larger.attemptCount}`,
+        sql`${smaller.quality} IS NOT DISTINCT FROM ${larger.quality}`,
+        sql`${smaller.difficulty} IS NOT DISTINCT FROM ${larger.difficulty}`,
+        sql`COALESCE(${smaller.isBenchmark}, false) = COALESCE(${larger.isBenchmark}, false)`,
+        sql`COALESCE(${smaller.comment}, '') = COALESCE(${larger.comment}, '')`,
+      ),
+    ),
+    sql`${smaller.auroraId} < ${larger.auroraId}`,
+    // Never bridge two distinct real Kilter links.
+    sql`(${smaller.kilterId} IS NULL OR ${larger.kilterId} IS NULL)`,
   )!;
 }
 
@@ -113,59 +174,10 @@ export function notAuroraTwinDuplicate(ticks: TicksTable = boardseshTicks): SQL 
     .select({ one: sql`1` })
     .from(twin)
     .where(
-      and(
-        // The outer row must itself be a real Aurora-pull row. Testing it here
-        // rather than as an `or(not(...), notExists(...))` wrapper keeps the
-        // whole condition a plain NOT EXISTS, which Postgres plans as a hash
-        // anti-join; the wrapper form forces a per-row SubPlan and costs ~50×
-        // on the unbounded count/list reads (You page, logbook). Same truth
-        // table: for a non-Aurora-pull outer row the subquery is empty, so
-        // NOT EXISTS is true and the row is kept.
-        isRealAuroraPullRow(ticks),
-        isRealAuroraPullRow(twin),
-        eq(twin.userId, ticks.userId),
-        eq(twin.boardType, ticks.boardType),
-        eq(twin.climbUuid, ticks.climbUuid),
-        eq(twin.angle, ticks.angle),
-        // Exact instant. `climbed_at` is `timestamp without time zone` on both
-        // sides, written by the same normaliser — a plain `=` is the whole rule.
-        eq(twin.climbedAt, ticks.climbedAt),
-        // Invariants no local edit may bridge. An attempt and a send, or an
-        // `ascents` row and a `bids` row, are two different upstream facts even
-        // at one instant, so they sit OUTSIDE the relaxation below: an edited
-        // send must never be able to swallow a real logged attempt.
-        eq(twin.status, ticks.status),
-        sql`${twin.auroraType} IS NOT DISTINCT FROM ${ticks.auroraType}`,
-        // Verbatim payload — same column set as payloadDiffersFromStored —
-        // UNLESS the survivor has since been edited here. Rating or commenting
-        // on the one visible tick is the most ordinary thing a climber does with
-        // a logbook entry, and it drifts the survivor's payload away from its
-        // twins; `isLocallyEdited` then makes the pull skip that row forever, so
-        // a strict payload rule would resurrect the duplicates permanently and
-        // make it look like the edit created them. Relaxing it is safe because
-        // the natural key above is the load-bearing guard: two genuine sends of
-        // one climb at one angle at the same instant are physically impossible.
-        // Only the SURVIVOR's edits relax the rule. If the hidden row is the one
-        // that changed, that is a deliberate divergence and it should surface
-        // rather than be swallowed.
-        or(
-          isLocallyEdited(twin),
-          and(
-            sql`COALESCE(${twin.isMirror}, false) = COALESCE(${ticks.isMirror}, false)`,
-            sql`${twin.attemptCount} IS NOT DISTINCT FROM ${ticks.attemptCount}`,
-            sql`${twin.quality} IS NOT DISTINCT FROM ${ticks.quality}`,
-            sql`${twin.difficulty} IS NOT DISTINCT FROM ${ticks.difficulty}`,
-            sql`COALESCE(${twin.isBenchmark}, false) = COALESCE(${ticks.isBenchmark}, false)`,
-            sql`COALESCE(${twin.comment}, '') = COALESCE(${ticks.comment}, '')`,
-          ),
-        ),
-        // Survivor = smallest aurora_id. Strict `<` also makes the row-vs-itself
-        // comparison false, so a group of one always survives.
-        sql`${twin.auroraId} < ${ticks.auroraId}`,
-        // Two distinct real Kilter links are two real upstream ascents; hiding
-        // one would lose a link. Mirrors migration 0166's twin guard.
-        sql`(${twin.kilterId} IS NULL OR ${ticks.kilterId} IS NULL)`,
-      ),
+      // The outer row must itself be a real Aurora-pull row. Keeping that test
+      // inside the direct pair predicate preserves the plain NOT EXISTS shape,
+      // which Postgres plans as a hash anti-join instead of a per-row SubPlan.
+      isDirectAuroraTwin(twin, ticks),
     );
 
   return notExists(smallerTwinExists);

--- a/packages/db/src/queries/ticks/index.ts
+++ b/packages/db/src/queries/ticks/index.ts
@@ -1,1 +1,2 @@
 export * from './aurora-twin-dedup';
+export * from './user-tick-mutation-lock';

--- a/packages/db/src/queries/ticks/user-tick-mutation-lock.ts
+++ b/packages/db/src/queries/ticks/user-tick-mutation-lock.ts
@@ -3,8 +3,15 @@ import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
 
 type AdvisoryLockDb = Pick<PgDatabase<PgQueryResultHKT, Record<string, unknown>>, 'execute'>;
 
-/** Shared namespace/seed for both rollout lock keys: ASCII "TICK". */
-const USER_TICK_MUTATION_LOCK_NAMESPACE = 0x5449434b;
+/**
+ * Seed for the 64-bit lock key: ASCII "TICK". `hashtextextended` folds the user
+ * id into a bigint with this seed, so the key can't collide with another
+ * feature's per-user hash. The single-bigint `pg_advisory_xact_lock` overload
+ * also occupies a different lock space from the two-int overload the
+ * climb-duplicate, push-token, and board-link gates use, so those can't collide
+ * with this one either.
+ */
+const USER_TICK_MUTATION_LOCK_SEED = 0x5449434b;
 
 /**
  * Serialize update/delete with Aurora and Kilter pull writers, including pull
@@ -14,21 +21,18 @@ const USER_TICK_MUTATION_LOCK_NAMESPACE = 0x5449434b;
  * This is transaction-scoped: callers must pass an existing transaction and
  * acquire it before selecting or locking any boardsesh_ticks row.
  *
- * Rolling-deploy compatibility requires TWO lock keys in this exact order:
- * first the legacy two-int key used by already-deployed nodes, then the 64-bit
- * extended-hash key new nodes use. Separate awaited statements make acquisition
- * order deterministic; SQL SELECT-list evaluation order must not be relied on.
- * Keep the legacy acquisition until every node capable of running the old
- * helper has drained in a later rollout.
+ * The global order is user lock, addressed row, then direct twins in UUID
+ * order. A future operation spanning multiple users must acquire the lock for
+ * each user in lexicographic user-id order before taking any row lock; current
+ * callers each touch one user.
  *
- * The global order is legacy user lock, extended user lock, addressed row, then
- * direct twins in UUID order. A future operation spanning multiple users must
- * acquire both locks for each user in lexicographic user-id order before taking
- * any row lock; current callers each touch one user.
+ * While this first ships, nodes still running the previous build take no lock
+ * at all, so the lock alone can't serialize against them. The pull writers'
+ * write-time `updated_at <= *_synced_at` guards cover that window and stay
+ * correct once the fleet has drained.
  */
 export async function acquireUserTickMutationLock(db: AdvisoryLockDb, userId: string): Promise<void> {
-  await db.execute(sql`SELECT pg_advisory_xact_lock(${USER_TICK_MUTATION_LOCK_NAMESPACE}, hashtext(${userId}))`);
   await db.execute(
-    sql`SELECT pg_advisory_xact_lock(hashtextextended(${userId}, ${USER_TICK_MUTATION_LOCK_NAMESPACE}::bigint))`,
+    sql`SELECT pg_advisory_xact_lock(hashtextextended(${userId}, ${USER_TICK_MUTATION_LOCK_SEED}::bigint))`,
   );
 }

--- a/packages/db/src/queries/ticks/user-tick-mutation-lock.ts
+++ b/packages/db/src/queries/ticks/user-tick-mutation-lock.ts
@@ -3,19 +3,32 @@ import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
 
 type AdvisoryLockDb = Pick<PgDatabase<PgQueryResultHKT, Record<string, unknown>>, 'execute'>;
 
-/** Two-key advisory-lock namespace: ASCII "TICK". */
+/** Shared namespace/seed for both rollout lock keys: ASCII "TICK". */
 const USER_TICK_MUTATION_LOCK_NAMESPACE = 0x5449434b;
 
 /**
- * Serialize every writer that can mutate a user's logbook identity/payload.
+ * Serialize update/delete with Aurora and Kilter pull writers, including pull
+ * inserts as well as mutations of existing logbook rows. Native saveTick
+ * inserts and Kilter push-back do not participate in this protocol.
  *
  * This is transaction-scoped: callers must pass an existing transaction and
- * acquire it before selecting or locking any boardsesh_ticks row. The global
- * order is advisory user lock first, then the addressed row, then direct twins
- * in UUID order. A future operation spanning multiple users must acquire these
- * locks in lexicographic user-id order before taking any row lock; current
- * callers each touch one user.
+ * acquire it before selecting or locking any boardsesh_ticks row.
+ *
+ * Rolling-deploy compatibility requires TWO lock keys in this exact order:
+ * first the legacy two-int key used by already-deployed nodes, then the 64-bit
+ * extended-hash key new nodes use. Separate awaited statements make acquisition
+ * order deterministic; SQL SELECT-list evaluation order must not be relied on.
+ * Keep the legacy acquisition until every node capable of running the old
+ * helper has drained in a later rollout.
+ *
+ * The global order is legacy user lock, extended user lock, addressed row, then
+ * direct twins in UUID order. A future operation spanning multiple users must
+ * acquire both locks for each user in lexicographic user-id order before taking
+ * any row lock; current callers each touch one user.
  */
 export async function acquireUserTickMutationLock(db: AdvisoryLockDb, userId: string): Promise<void> {
   await db.execute(sql`SELECT pg_advisory_xact_lock(${USER_TICK_MUTATION_LOCK_NAMESPACE}, hashtext(${userId}))`);
+  await db.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtextextended(${userId}, ${USER_TICK_MUTATION_LOCK_NAMESPACE}::bigint))`,
+  );
 }

--- a/packages/db/src/queries/ticks/user-tick-mutation-lock.ts
+++ b/packages/db/src/queries/ticks/user-tick-mutation-lock.ts
@@ -1,0 +1,21 @@
+import { sql } from 'drizzle-orm';
+import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
+
+type AdvisoryLockDb = Pick<PgDatabase<PgQueryResultHKT, Record<string, unknown>>, 'execute'>;
+
+/** Two-key advisory-lock namespace: ASCII "TICK". */
+const USER_TICK_MUTATION_LOCK_NAMESPACE = 0x5449434b;
+
+/**
+ * Serialize every writer that can mutate a user's logbook identity/payload.
+ *
+ * This is transaction-scoped: callers must pass an existing transaction and
+ * acquire it before selecting or locking any boardsesh_ticks row. The global
+ * order is advisory user lock first, then the addressed row, then direct twins
+ * in UUID order. A future operation spanning multiple users must acquire these
+ * locks in lexicographic user-id order before taking any row lock; current
+ * callers each touch one user.
+ */
+export async function acquireUserTickMutationLock(db: AdvisoryLockDb, userId: string): Promise<void> {
+  await db.execute(sql`SELECT pg_advisory_xact_lock(${USER_TICK_MUTATION_LOCK_NAMESPACE}, hashtext(${userId}))`);
+}

--- a/packages/kilter-sync/src/sync/index.ts
+++ b/packages/kilter-sync/src/sync/index.ts
@@ -1,11 +1,12 @@
 export {
   syncKilterUserData,
-  // Exported for the real-Postgres tests in packages/backend: the ratings
-  // conflict clause (created_at from upstream + the setWhere change guard)
-  // and the REMOVE soft-detach
+  // Exported for the real-Postgres tests in packages/backend: log mutation
+  // serialization, the ratings conflict clause (created_at from upstream +
+  // the setWhere change guard), and the REMOVE soft-detach
   // (backend/src/__tests__/climb-ratings-remove-detach.test.ts) can only be
   // verified against an actual database. The package only exposes the '.'
   // and './sync' subpaths, so a deep import into user-sync isn't an option.
+  applyLogs,
   applyClimbRatings,
   type SyncKilterUserDataArgs,
   type SyncKilterUserDataResult,

--- a/packages/kilter-sync/src/sync/user-sync.test.ts
+++ b/packages/kilter-sync/src/sync/user-sync.test.ts
@@ -7,7 +7,7 @@ import type { PowerSyncOp } from '../api/powersync-client';
 // resolveCanonicalClimbUuid stays real (pre-seeded alias cache → no DB hit).
 vi.mock('@boardsesh/db/queries', async (importActual) => {
   const actual = await importActual<typeof import('@boardsesh/db/queries')>();
-  return { ...actual, recomputeClimbStatsBulk: vi.fn() };
+  return { ...actual, acquireUserTickMutationLock: vi.fn(), recomputeClimbStatsBulk: vi.fn() };
 });
 
 import { recomputeClimbStatsBulk, type ClimbStatsKey } from '@boardsesh/db/queries';

--- a/packages/kilter-sync/src/sync/user-sync.ts
+++ b/packages/kilter-sync/src/sync/user-sync.ts
@@ -19,6 +19,7 @@ import {
   foreignPlaylistOwnerGuard,
   myPlaylistOwnerEdge,
   selectUpstreamPlaylistOwners,
+  acquireUserTickMutationLock,
   type ClimbStatsKey,
   type TickTimeSample,
 } from '@boardsesh/db/queries';
@@ -522,6 +523,11 @@ export async function applyLogs(
 ): Promise<void> {
   if (ops.length === 0) return;
 
+  // Global logbook lock order is user advisory lock before any tick row read
+  // or write. updateTick/deleteTick and Aurora's ascents/bids use this exact
+  // same transaction-scoped key.
+  await acquireUserTickMutationLock(tx, userId);
+
   // Distinct (climb, angle) keys touched this flush — inserts, updates,
   // adoptions, and soft-detached removes can all change what
   // board_climb_stats should show, so recompute every one at the end.
@@ -934,6 +940,10 @@ export async function applyLogs(
         updated_at text
       )
       WHERE t.uuid = u.uuid
+        -- Defence in depth for rolling deploys: a stale node without the
+        -- advisory-lock protocol may have made a local edit after our SELECT.
+        -- Keep this comparison inside Postgres so microseconds are not lost.
+        AND (t.kilter_synced_at IS NULL OR t.updated_at <= t.kilter_synced_at)
     `);
   }
 


### PR DESCRIPTION
## Summary

- make edits and deletes apply to the visible Aurora ascent and its directly hidden duplicate rows
- keep distinct Kilter-linked ascents separate, including the null-ID target orientation
- preserve PostgreSQL microseconds on date edits and fan out dependent cleanup, stats, beta links, tombstones, and cache invalidation
- serialize local mutations with Aurora and Kilter imports through the same per-user transaction lock

Closes #4059.
Closes #4060.

## Release Notes

Editing or deleting an ascent imported more than once now sticks instead of revealing hidden copies.

## Test plan

- `vp test run --project backend packages/backend/src/__tests__/aurora-twin-dedup.test.ts packages/backend/src/__tests__/tick-validation.test.ts --reporter=agent` — 67 passed against real PostgreSQL
- `vp test run --project backend packages/backend/src/__tests__/sync-mutations.test.ts packages/backend/src/__tests__/tick-queries.test.ts --reporter=agent` — 79 passed
- `vp test run --reporter=agent packages/aurora-sync packages/kilter-sync` — 418 passed, 1 skipped
- `vp run --filter=@boardsesh/db test` — advisory-lock SQL-render test passes (3 unrelated `createClimbFilters` MoonBoard failures reproduce on `origin/main` untouched)
- `vp run typecheck:backend`, `vp run typecheck:db`
- `vp check`
- independent adversarial review: PASS
- attempted `vp run dev` with `.boardsesh/qa-notes.md`; startup is currently blocked before the app launches because the shared dev DB has migration 0187's schema without its ledger row (#3978), so the launcher retries a non-idempotent table create
