### PR TITLE
fix(mobile): surface real cause on snapshot download failures

### DIFF
--- a/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
+++ b/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
@@ -12,6 +12,7 @@ const state = vi.hoisted(() => ({
     path: string;
     options?: { intermediates?: boolean; idempotent?: boolean; overwrite?: boolean };
   }>,
+  createDirectoryError: null as Error | null,
   downloadCalls: [] as Array<{ url: string; idempotent?: boolean }>,
   downloadError: null as Error | null,
   downloadBytes: new Uint8Array([9, 9, 9, 9]), // non-gzip payload by default
@@ -29,6 +30,7 @@ vi.mock('expo-file-system', () => {
       this.path = parts.map((part) => (part instanceof FakeDirectory ? part.path : String(part))).join('/');
     }
     create(options?: { intermediates?: boolean; idempotent?: boolean; overwrite?: boolean }) {
+      if (state.createDirectoryError) throw state.createDirectoryError;
       state.createdDirectories.push({ path: this.path, options });
     }
   }
@@ -137,6 +139,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   state.availableDiskSpace = 10_000_000_000;
   state.createdDirectories = [];
+  state.createDirectoryError = null;
   state.downloadCalls = [];
   state.downloadError = null;
   state.downloadBytes = PLAIN_SQLITE_BYTES;
@@ -203,12 +206,10 @@ describe('fetchManifest', () => {
 });
 
 describe('downloadArtifact', () => {
-  it('returns null without downloading when free disk space is below the gzip safety multiple of entry.bytes', async () => {
+  it('throws a descriptive error without downloading when free disk space is below the gzip safety multiple of entry.bytes (issue #4106: this used to swallow to null)', async () => {
     state.availableDiskSpace = ENTRY.bytes * 2; // well under the 6x safety multiplier
 
-    const result = await mobileSnapshotSource.downloadArtifact(ENTRY);
-
-    expect(result).toBeNull();
+    await expect(mobileSnapshotSource.downloadArtifact(ENTRY)).rejects.toThrow(/insufficient disk space/);
     expect(state.downloadCalls).toHaveLength(0);
   });
 
@@ -234,10 +235,17 @@ describe('downloadArtifact', () => {
     expect(result?.filePath).toContain('kilter-8-2026-06-01T00-00-00-000Z.db');
   });
 
-  it('returns null when the download itself fails', async () => {
+  it('throws a descriptive error wrapping the underlying cause when the download itself fails (issue #4106: this used to swallow to null)', async () => {
     state.downloadError = new Error('boom');
 
-    await expect(mobileSnapshotSource.downloadArtifact(ENTRY)).resolves.toBeNull();
+    await expect(mobileSnapshotSource.downloadArtifact(ENTRY)).rejects.toThrow(/downloadFileAsync failed.*boom/);
+  });
+
+  it('throws a descriptive error wrapping the underlying cause when the cache directory cannot be created', async () => {
+    state.createDirectoryError = new Error('disk is read-only');
+
+    await expect(mobileSnapshotSource.downloadArtifact(ENTRY)).rejects.toThrow(/cache directory.*disk is read-only/);
+    expect(state.downloadCalls).toHaveLength(0);
   });
 
   it('accepts a gzip-encoded entry whose downloaded bytes are already decompressed', async () => {

--- a/packages/mobile/src/offline/snapshot-source.ts
+++ b/packages/mobile/src/offline/snapshot-source.ts
@@ -11,10 +11,14 @@
 //
 // The engine only consumes what this returns — it never fetches, downloads, or
 // gunzips anything itself (see snapshot-bootstrap.ts's `SnapshotSource`
-// contract). Every failure path here (disk space, download error, a stubborn
-// gzip body) returns `null`/throws, which the engine counts as one bootstrap
-// attempt and falls back to the ordinary paged crawl (MAX_BOOTSTRAP_ATTEMPTS
-// caps it at two tries before giving up on the snapshot path for that scope).
+// contract). Every failure path here (disk space, directory creation, download
+// error, a stubborn gzip body) THROWS a descriptive Error, which the engine
+// counts as one bootstrap attempt and falls back to the ordinary paged crawl
+// (MAX_BOOTSTRAP_ATTEMPTS caps it at two tries before giving up on the
+// snapshot path for that scope) — see `runBootstrapPhase`'s `cachedDownload`
+// handling in pull-client.ts, which only captures a `cause` for Sentry when
+// this throws (issue #4106: these used to `return null` on real failures,
+// which is a legal contract but reported `cause: null` for everything).
 
 import { Directory, File, Paths } from 'expo-file-system';
 import { SnapshotPermanentMissError, type SnapshotManifestEntry, type SnapshotSource } from '@boardsesh/offline-sync';
@@ -114,17 +118,41 @@ async function fetchManifest(): Promise<unknown> {
   }
 }
 
+/** Same idiom as `formatError` in offline-sync's mutation-queue/drainer.ts. */
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * The disk-space, directory-creation, and actual-download failure branches
+ * below used to `return null` on a real error, which is a legal SnapshotSource
+ * contract (see the doc comment on downloadArtifact in snapshot-bootstrap.ts —
+ * "return null or throw, both count as an attempt"), but it meant
+ * `runBootstrapPhase`'s `cachedDownload.cause` (only ever set inside a
+ * `catch`) stayed `null` for every one of these — so Sentry's
+ * `reportSnapshotBootstrapError` reported `cause: null` for every real-world
+ * download failure, with no way to tell a 404 from a timeout from a disk-full
+ * device without reproducing it (issue #4106). Throwing instead of swallowing
+ * keeps the exact same retry/attempt/fallback semantics — only the visibility
+ * changes.
+ */
 async function downloadArtifact(entry: SnapshotManifestEntry): Promise<{ filePath: string } | null> {
   const freeSpaceSafetyMultiplier =
     entry.contentEncoding === 'gzip' ? GZIP_FREE_SPACE_SAFETY_MULTIPLIER : IDENTITY_FREE_SPACE_SAFETY_MULTIPLIER;
   const requiredBytes = entry.bytes * freeSpaceSafetyMultiplier;
-  if (Paths.availableDiskSpace < requiredBytes) return null;
+  const availableBytes = Paths.availableDiskSpace;
+  if (availableBytes < requiredBytes) {
+    throw new Error(
+      `snapshot download: insufficient disk space for ${entry.boardType}:${entry.layoutId} ` +
+        `(need ~${requiredBytes} bytes, have ${availableBytes} bytes free)`,
+    );
+  }
 
   const directory = snapshotDirectory();
   try {
     directory.create({ intermediates: true, idempotent: true });
-  } catch {
-    return null;
+  } catch (error) {
+    throw new Error(`snapshot download: failed to create cache directory: ${formatError(error)}`);
   }
 
   // Content-addressed filename (boardType/layoutId/builtAt) so a retried
@@ -136,8 +164,10 @@ async function downloadArtifact(entry: SnapshotManifestEntry): Promise<{ filePat
   let downloaded: File;
   try {
     downloaded = await File.downloadFileAsync(entry.url, destination, { idempotent: true });
-  } catch {
-    return null;
+  } catch (error) {
+    throw new Error(
+      `snapshot download: File.downloadFileAsync failed for ${entry.boardType}:${entry.layoutId}: ${formatError(error)}`,
+    );
   }
 
   if (entry.contentEncoding === 'gzip') {


### PR DESCRIPTION
## Summary

Fixes the observability gap behind #4106. `downloadArtifact()` in `packages/mobile/src/offline/snapshot-source.ts` swallowed three real failure paths — insufficient disk space, cache-directory creation failure, and `File.downloadFileAsync` throwing (network error, timeout, HTTP failure) — down to a bare `return null`. Because `runBootstrapPhase` (`packages/shared/offline-sync/src/sync/pull-client.ts`) only captures a `cause` for Sentry when `SnapshotSource.downloadArtifact` *throws*, every real download failure was reaching Sentry's `reportSnapshotBootstrapError` as `extra.cause: null` — no way to tell a 404 from a timeout from a disk-full device without reproducing it, exactly as #4106's "Fix direction #2" describes.

This PR makes all three paths throw a descriptive `Error` instead. Retry/attempt/fallback semantics are byte-for-byte unchanged (`SnapshotSource.downloadArtifact`'s own doc comment already treats "return null" and "throw" as equally valid retryable-failure signals) — only the diagnostic information that reaches Sentry changes.

Closes #4106

**Caveat on closing:** the three specific failures named in #4106 (`moonboard:5:1`, `moonboard:3:1`, `kilter:1:10`) remain **unattributed**. I verified the server side is healthy right now — the nightly export (`export-board-snapshots.yml`) has run green every night this week, and I curled all three named artifacts directly against the public snapshot URL: all three return `200 OK` with correct `Content-Length` and `Content-Type`. So the root *download*-level cause (network flake vs. something more specific) is still unknown — this PR doesn't fix a reproduced bug, it fixes the reason the bug couldn't be diagnosed. I'm using "Closes" because fix-direction #2 (attach the real cause to Sentry) is the actionable, in-scope core of the issue — but if another `snapshot-bootstrap` Sentry event fires for these boards after this ships, the `extra.cause` field will finally say why, and that's the next actionable lead if it recurs. If you'd rather keep #4106 open until a report actually lands with a populated cause, happy to re-tag this "Related to" instead — your call.

## ⚠️ Time-sensitive ops item (not fixed by this PR)

While curling the public manifest to verify the three artifacts, I found the **public-facing** `board-snapshots/v1/manifest.json` is serving stale data:

- Live manifest `generatedAt`: `2026-07-30T09:42:20.310Z`, `X-Tigris-Read-Source: cache`, `Last-Modified: Thu, 30 Jul 2026 09:42:20 GMT` — repeated fetches (including cache-busting query params) all return the same stale copy.
- But the **2026-07-31** nightly export run (`gh run view 30621458018 --log`) completed successfully and logged `manifest uploaded { entries: 22, refreshed: 22, key: 'board-snapshots/v1/manifest.json' }` at `09:54:33Z` that day, plus a prune pass afterward. The export job's own `fetchPreviousManifest` reads via an authenticated `GetObjectCommand` (bypasses the CDN entirely), so the export pipeline itself is healthy and not corrupting anything — this looks like the **public CDN edge** (Tigris, `boardsesh-board-snapshots.t3.tigrisfiles.io`) not honoring the manifest's `Cache-Control: public, max-age=300` and serving a 40+ hour stale copy.

This isn't causing the 3 reported failures today — the stale manifest still points at the 2026-07-30 artifacts, which are still valid and unpruned (14-day grace window in `pruneStaleArtifacts`). **But it will become a real, self-inflicted 404 machine once enough nights pass that the stuck manifest points at an artifact that's since been pruned** — worth checking before it does, not after. I deliberately did **not** touch `MANIFEST_CACHE_CONTROL` in `export-board-snapshots.ts` — it's a documented, runbook-governed design choice (`docs/board-snapshots.md`'s "Kill switches" section assumes clients see manifest updates within ~5 minutes), and I don't have enough certainty this is even an app-controllable cache-control issue vs. Tigris CDN behavior, so a blind change felt riskier than flagging it.

**Suggested check for @marcodejongh:**
1. `curl -sI https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1/manifest.json` — confirm whether `Last-Modified`/`generatedAt` has advanced past 2026-07-30 by the time you read this (tonight's 07:15 UTC run should have refreshed it again).
2. If it's still stuck, try a manual `workflow_dispatch` of `export-board-snapshots.yml` and re-check a few minutes later.
3. If it's still stuck after that, it's likely Tigris-side CDN caching, not our export job — worth a Tigris support ticket.

## Follow-up filed

#4116 — the My Boards download UI shows no distinct state when snapshot bootstrap exhausts its retries (it silently falls back to the slower paged crawl, which does complete, just without any user-visible signal). Deliberately kept out of this PR's scope; filed as `priority:P3` given the whole offline-download engine (`offline-board-downloads` PostHog flag) is at **0% rollout**, so live user exposure to this gap is effectively nil right now.

## Release Notes

- [x] No release note needed (internal / technical change)

This only changes what reaches Sentry's `extra.cause` field for a developer-only telemetry event — no user-visible behavior, copy, or UI changes. The whole feature is also still gated behind `offline-board-downloads` at 0% rollout.

## Test plan

- `vp run typecheck:mobile` — passed.
- `vp test run --project mobile --reporter=agent` — 575/575 test files, 4913/4913 tests passed, including 2 updated + 1 new case in `snapshot-source.test.ts` covering the disk-space, directory-creation, and download-failure throw paths.
- `vp check` — 0 errors (297 pre-existing warnings elsewhere in the repo, none in the two files this PR touches).
- Not a native-fingerprint change (pure TS in `packages/mobile/src/offline/`, no native/config files touched) — ships via OTA, no native-train handling needed.
- No visual QA needed — no UI/UX surface changed.
