### PR TITLE
fix(mobile): guard @expo/ui hide() against missing native handler

### DIFF
--- a/patches/@expo%2Fui@57.0.8.patch
+++ b/patches/@expo%2Fui@57.0.8.patch
@@ -1,5 +1,5 @@
 diff --git a/build/community/bottom-sheet/types.d.ts b/build/community/bottom-sheet/types.d.ts
-index 72fc6be..d1cf11e 100644
+index 72fc6becbc414c318799e28103d15484ed86f703..d1cf11e93b0c0d8dc77abddaafc89e14d34faccc 100644
 --- a/build/community/bottom-sheet/types.d.ts
 +++ b/build/community/bottom-sheet/types.d.ts
 @@ -159,6 +159,14 @@ export interface BottomSheetProps {
@@ -18,21 +18,27 @@ index 72fc6be..d1cf11e 100644
       * Whether the sheet can be dismissed by panning down.
       * @default false
 diff --git a/src/community/bottom-sheet/BottomSheet.android.tsx b/src/community/bottom-sheet/BottomSheet.android.tsx
-index f60ae61..4e64d1a 100644
+index f60ae61bf0c9023d41c55cdca2d9af0de7291a92..155afb2055b9e977f0651de67a4f1c812e87eef7 100644
 --- a/src/community/bottom-sheet/BottomSheet.android.tsx
 +++ b/src/community/bottom-sheet/BottomSheet.android.tsx
-@@ -11,6 +11,20 @@ import { RNHostView } from '../../jetpack-compose/RNHostView';
+@@ -11,6 +11,26 @@ import { RNHostView } from '../../jetpack-compose/RNHostView';
  
  export { useBottomSheet } from './context';
  
-+// `expand()` / `partialExpand()` are native AsyncFunctions on `ModalBottomSheetView`.
-+// A store binary whose native ExpoUI layer predates a method rejects the call with
-+// "No handler registered for AsyncFunction '<method>' on view 'ModalBottomSheetView'".
-+// These calls are fire-and-forget, so an unhandled rejection would surface as a global
-+// onunhandledrejection (crash report + noise) even though the re-snap is a harmless
-+// no-op on those binaries. Swallow it: the sheet stays where it is, which is the
-+// existing behaviour, and never wrongly expands a collapse. On binaries whose native
-+// layer has the method this never rejects. (boardsesh patch — see issue #3478.)
++// `expand()` / `partialExpand()` / `hide()` are native AsyncFunctions on
++// `ModalBottomSheetView`. A store binary whose native ExpoUI layer predates a
++// method rejects the call with "No handler registered for AsyncFunction
++// '<method>' on view 'ModalBottomSheetView'". These calls are fire-and-forget,
++// so an unhandled rejection would surface as a global onunhandledrejection
++// (crash report + noise) even though the underlying state change is a harmless
++// no-op on those binaries. Swallow it: for expand()/partialExpand() the sheet
++// stays where it is (the existing behaviour, never wrongly expanding a
++// collapse); for hide() — used by close()/forceClose()/dismiss() and the
++// snapToIndex(-1) path — the caller still runs its own cleanup afterwards
++// (setIsOpen(false) etc.), so the sheet closes in JS state even when the
++// native side silently no-ops, instead of leaving it stuck open. On binaries
++// whose native layer has the method this never rejects. (boardsesh patch —
++// see issue #3478, and issue #4108 for the hide() call sites.)
 +function swallowMissingNativeHandler(error: unknown): void {
 +  // Never rejects on a dev build (current native layer has the method), so a warning
 +  // here means something genuinely unexpected — surface it in dev, stay silent in prod.
@@ -42,7 +48,27 @@ index f60ae61..4e64d1a 100644
  function extractBackgroundColor(
    backgroundStyle: BottomSheetProps['backgroundStyle']
  ): string | undefined {
-@@ -143,9 +157,9 @@ export function BottomSheet(props: BottomSheetProps) {
+@@ -127,11 +147,14 @@ export function BottomSheet(props: BottomSheetProps) {
+   const methods: BottomSheetMethods = useMemo(() => {
+     const snapToIndex = (index: number) => {
+       if (index === -1) {
+-        sheetRef.current?.hide().then(() => {
+-          setIsOpen(false);
+-          pendingIndexRef.current = null;
+-          fireCloseCallbacks();
+-        });
++        sheetRef.current
++          ?.hide()
++          .catch(swallowMissingNativeHandler)
++          .then(() => {
++            setIsOpen(false);
++            pendingIndexRef.current = null;
++            fireCloseCallbacks();
++          });
+         return;
+       }
+       const clampedIndex = clampIndex(index);
+@@ -143,9 +166,9 @@ export function BottomSheet(props: BottomSheetProps) {
          // Native ModalBottomSheet has two states: partial (~50%) and expanded (full).
          // Map index 0 → partialExpand(), last index → expand().
          if (clampedIndex === maxIndex) {
@@ -54,8 +80,28 @@ index f60ae61..4e64d1a 100644
          }
          pendingIndexRef.current = null;
        }
+@@ -153,11 +176,14 @@ export function BottomSheet(props: BottomSheetProps) {
+     };
+ 
+     const close = () => {
+-      sheetRef.current?.hide().then(() => {
+-        setIsOpen(false);
+-        pendingIndexRef.current = null;
+-        fireCloseCallbacks();
+-      });
++      sheetRef.current
++        ?.hide()
++        .catch(swallowMissingNativeHandler)
++        .then(() => {
++          setIsOpen(false);
++          pendingIndexRef.current = null;
++          fireCloseCallbacks();
++        });
+     };
+ 
+     return {
 diff --git a/src/community/bottom-sheet/BottomSheet.ios.tsx b/src/community/bottom-sheet/BottomSheet.ios.tsx
-index d9de442..5cd8c12 100644
+index d9de442f1efd51749ff9a0e661e6979e7915fef1..5cd8c129ae199edc83733d7617d4b8c32611fc03 100644
 --- a/src/community/bottom-sheet/BottomSheet.ios.tsx
 +++ b/src/community/bottom-sheet/BottomSheet.ios.tsx
 @@ -87,6 +87,7 @@ export function BottomSheet(props: BottomSheetProps) {
@@ -91,7 +137,7 @@ index d9de442..5cd8c12 100644
              fitToContents={fitToContents}>
              <Group modifiers={modifiers}>
 diff --git a/src/community/bottom-sheet/types.ts b/src/community/bottom-sheet/types.ts
-index d7372fc..efcf425 100644
+index d7372fcb72e3717329ee8df4e27e2f537f17decb..efcf4256103d5b9f1a068e32778a92efc6fa30bc 100644
 --- a/src/community/bottom-sheet/types.ts
 +++ b/src/community/bottom-sheet/types.ts
 @@ -178,6 +178,15 @@ export interface BottomSheetProps {

--- a/patches/@expo%2Fui@57.0.8.patch
+++ b/patches/@expo%2Fui@57.0.8.patch
@@ -18,7 +18,7 @@ index 72fc6becbc414c318799e28103d15484ed86f703..d1cf11e93b0c0d8dc77abddaafc89e14
       * Whether the sheet can be dismissed by panning down.
       * @default false
 diff --git a/src/community/bottom-sheet/BottomSheet.android.tsx b/src/community/bottom-sheet/BottomSheet.android.tsx
-index f60ae61bf0c9023d41c55cdca2d9af0de7291a92..155afb2055b9e977f0651de67a4f1c812e87eef7 100644
+index f60ae61bf0c9023d41c55cdca2d9af0de7291a92..772f369cf121ca1a1fdd283f81f1326b8bfb4710 100644
 --- a/src/community/bottom-sheet/BottomSheet.android.tsx
 +++ b/src/community/bottom-sheet/BottomSheet.android.tsx
 @@ -11,6 +11,26 @@ import { RNHostView } from '../../jetpack-compose/RNHostView';
@@ -48,27 +48,37 @@ index f60ae61bf0c9023d41c55cdca2d9af0de7291a92..155afb2055b9e977f0651de67a4f1c81
  function extractBackgroundColor(
    backgroundStyle: BottomSheetProps['backgroundStyle']
  ): string | undefined {
-@@ -127,11 +147,14 @@ export function BottomSheet(props: BottomSheetProps) {
+@@ -125,13 +145,26 @@ export function BottomSheet(props: BottomSheetProps) {
+   }, [fireCloseCallbacks]);
+ 
    const methods: BottomSheetMethods = useMemo(() => {
-     const snapToIndex = (index: number) => {
-       if (index === -1) {
+-    const snapToIndex = (index: number) => {
+-      if (index === -1) {
 -        sheetRef.current?.hide().then(() => {
--          setIsOpen(false);
--          pendingIndexRef.current = null;
--          fireCloseCallbacks();
--        });
-+        sheetRef.current
-+          ?.hide()
-+          .catch(swallowMissingNativeHandler)
-+          .then(() => {
-+            setIsOpen(false);
-+            pendingIndexRef.current = null;
-+            fireCloseCallbacks();
-+          });
++    // Every programmatic dismiss funnels through here — snapToIndex(-1) and
++    // close(), which forceClose()/dismiss() alias. `.catch()` BEFORE `.then()`
++    // is load-bearing: it turns a missing-native-handler rejection into a
++    // resolved promise, so the JS-side cleanup below still runs and the sheet
++    // can't get stuck open on a store binary without the native hide().
++    // (boardsesh patch — see issue #4108.)
++    const hideSwallowingMissingNativeHandler = () => {
++      sheetRef.current
++        ?.hide()
++        .catch(swallowMissingNativeHandler)
++        .then(() => {
+           setIsOpen(false);
+           pendingIndexRef.current = null;
+           fireCloseCallbacks();
+         });
++    };
++
++    const snapToIndex = (index: number) => {
++      if (index === -1) {
++        hideSwallowingMissingNativeHandler();
          return;
        }
        const clampedIndex = clampIndex(index);
-@@ -143,9 +166,9 @@ export function BottomSheet(props: BottomSheetProps) {
+@@ -143,22 +176,16 @@ export function BottomSheet(props: BottomSheetProps) {
          // Native ModalBottomSheet has two states: partial (~50%) and expanded (full).
          // Map index 0 → partialExpand(), last index → expand().
          if (clampedIndex === maxIndex) {
@@ -80,26 +90,20 @@ index f60ae61bf0c9023d41c55cdca2d9af0de7291a92..155afb2055b9e977f0651de67a4f1c81
          }
          pendingIndexRef.current = null;
        }
-@@ -153,11 +176,14 @@ export function BottomSheet(props: BottomSheetProps) {
+       onChangeRef.current?.(clampedIndex);
      };
  
-     const close = () => {
+-    const close = () => {
 -      sheetRef.current?.hide().then(() => {
 -        setIsOpen(false);
 -        pendingIndexRef.current = null;
 -        fireCloseCallbacks();
 -      });
-+      sheetRef.current
-+        ?.hide()
-+        .catch(swallowMissingNativeHandler)
-+        .then(() => {
-+          setIsOpen(false);
-+          pendingIndexRef.current = null;
-+          fireCloseCallbacks();
-+        });
-     };
+-    };
++    const close = hideSwallowingMissingNativeHandler;
  
      return {
+       snapToIndex,
 diff --git a/src/community/bottom-sheet/BottomSheet.ios.tsx b/src/community/bottom-sheet/BottomSheet.ios.tsx
 index d9de442f1efd51749ff9a0e661e6979e7915fef1..5cd8c129ae199edc83733d7617d4b8c32611fc03 100644
 --- a/src/community/bottom-sheet/BottomSheet.ios.tsx

--- a/patches/@expo%2Fui@57.0.8.patch
+++ b/patches/@expo%2Fui@57.0.8.patch
@@ -26,22 +26,22 @@ index f60ae61bf0c9023d41c55cdca2d9af0de7291a92..772f369cf121ca1a1fdd283f81f1326b
  export { useBottomSheet } from './context';
  
 +// `expand()` / `partialExpand()` / `hide()` are native AsyncFunctions on
-+// `ModalBottomSheetView`. A store binary whose native ExpoUI layer predates a
-+// method rejects the call with "No handler registered for AsyncFunction
-+// '<method>' on view 'ModalBottomSheetView'". These calls are fire-and-forget,
-+// so an unhandled rejection would surface as a global onunhandledrejection
-+// (crash report + noise) even though the underlying state change is a harmless
-+// no-op on those binaries. Swallow it: for expand()/partialExpand() the sheet
-+// stays where it is (the existing behaviour, never wrongly expanding a
-+// collapse); for hide() — used by close()/forceClose()/dismiss() and the
-+// snapToIndex(-1) path — the caller still runs its own cleanup afterwards
-+// (setIsOpen(false) etc.), so the sheet closes in JS state even when the
-+// native side silently no-ops, instead of leaving it stuck open. On binaries
-+// whose native layer has the method this never rejects. (boardsesh patch —
-+// see issue #3478, and issue #4108 for the hide() call sites.)
++// `ModalBottomSheetView`. Their handlers exist only while Compose content is
++// registered. A lifecycle race (already dismissed, unmounted, or backgrounded
++// mid-animation), or JS running against a native ExpoUI layer that predates a
++// method, can reject with "No handler registered for AsyncFunction '<method>'
++// on view 'ModalBottomSheetView'". These calls are fire-and-forget, so an
++// unhandled rejection would become global crash-report noise even though the
++// requested transition is unavailable. Swallow it: for expand()/partialExpand()
++// the sheet stays where it is (the existing behaviour, never wrongly expanding
++// a collapse); for hide() — used by close()/forceClose()/dismiss() and the
++// snapToIndex(-1) path — a rejected call or missing ref is treated as a
++// successful dismissal, so JS cleanup closes the sheet state instead of leaving
++// it stuck open. (boardsesh patch — see issue #3478, and issue #4108 for the
++// hide() lifecycle race.)
 +function swallowMissingNativeHandler(error: unknown): void {
-+  // Never rejects on a dev build (current native layer has the method), so a warning
-+  // here means something genuinely unexpected — surface it in dev, stay silent in prod.
++  // Handler lifecycle races can occur in current dev builds too. Keep them visible
++  // during development while preventing a production unhandled rejection.
 +  if (__DEV__) console.warn('[bottom-sheet] native snap call rejected:', error);
 +}
 +
@@ -56,14 +56,14 @@ index f60ae61bf0c9023d41c55cdca2d9af0de7291a92..772f369cf121ca1a1fdd283f81f1326b
 -      if (index === -1) {
 -        sheetRef.current?.hide().then(() => {
 +    // Every programmatic dismiss funnels through here — snapToIndex(-1) and
-+    // close(), which forceClose()/dismiss() alias. `.catch()` BEFORE `.then()`
-+    // is load-bearing: it turns a missing-native-handler rejection into a
-+    // resolved promise, so the JS-side cleanup below still runs and the sheet
-+    // can't get stuck open on a store binary without the native hide().
-+    // (boardsesh patch — see issue #4108.)
++    // close(), which forceClose()/dismiss() alias. `Promise.resolve` normalizes
++    // a missing ref (the native sheet is already gone) to success, while catch
++    // turns a missing-native-handler rejection into a resolved promise. Either
++    // way the JS cleanup below runs, so state cannot stay stuck open. (boardsesh
++    // patch — see issue #4108.)
 +    const hideSwallowingMissingNativeHandler = () => {
-+      sheetRef.current
-+        ?.hide()
++      const hidePromise = sheetRef.current?.hide();
++      void Promise.resolve(hidePromise)
 +        .catch(swallowMissingNativeHandler)
 +        .then(() => {
            setIsOpen(false);

--- a/patches/@expo%2Fui@57.0.8.patch
+++ b/patches/@expo%2Fui@57.0.8.patch
@@ -18,7 +18,7 @@ index 72fc6becbc414c318799e28103d15484ed86f703..d1cf11e93b0c0d8dc77abddaafc89e14
       * Whether the sheet can be dismissed by panning down.
       * @default false
 diff --git a/src/community/bottom-sheet/BottomSheet.android.tsx b/src/community/bottom-sheet/BottomSheet.android.tsx
-index f60ae61bf0c9023d41c55cdca2d9af0de7291a92..772f369cf121ca1a1fdd283f81f1326b8bfb4710 100644
+index f60ae61bf0c9023d41c55cdca2d9af0de7291a92..9d317d23a9dce0d20ad6377d9b2a2cbdc2ad60ab 100644
 --- a/src/community/bottom-sheet/BottomSheet.android.tsx
 +++ b/src/community/bottom-sheet/BottomSheet.android.tsx
 @@ -11,6 +11,26 @@ import { RNHostView } from '../../jetpack-compose/RNHostView';

--- a/scripts/__tests__/mobile-patches-check.test.ts
+++ b/scripts/__tests__/mobile-patches-check.test.ts
@@ -135,8 +135,8 @@ describe('checkPatchesApplied', () => {
 // The @expo/ui shape: a SCOPED package, so the key carries two `@` and the
 // version is the one after the scope. Its patch is plain TS whose loss is
 // runtime-only — the sheet still typechecks and bundles, it just stops
-// swallowing the native expand()/partialExpand() rejection — so this rule is
-// the only thing between a forgotten re-key and a silent regression.
+// swallowing the native expand()/partialExpand()/hide() rejection — so this
+// rule is the only thing between a forgotten re-key and a silent regression.
 const SCOPED_PKG = '@expo/ui';
 const SCOPED_FILE = 'src/community/bottom-sheet/BottomSheet.android.tsx';
 const SCOPED_KEY = '@expo/ui@57.0.8';
@@ -193,6 +193,41 @@ describe('checkPatchesApplied on a scoped package', () => {
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]).toContain('patch NOT applied');
     expect(result.errors[0]).toContain('swallowMissingNativeHandler');
+  });
+});
+
+// Mutation test on the shipped rule, not a synthetic one: the sentinel list has
+// to distinguish the current patch from the pre-#4108 patch, which guarded
+// expand()/partialExpand() (#3478) but left hide() — every programmatic dismiss
+// — bare. `swallowMissingNativeHandler` alone is satisfied by both, so a patch
+// regenerated for a version bump could reinstate only the #3478 half and keep
+// this check green while the dismiss guard silently disappeared.
+describe('the shipped @expo/ui Android rule', () => {
+  const androidRule = REAL_RULES.find((rule) => rule.package === SCOPED_PKG && rule.file === SCOPED_FILE);
+
+  const PRE_4108_SOURCE = `
+function swallowMissingNativeHandler(error: unknown): void { /* ... */ }
+sheetRef.current?.expand()?.catch(swallowMissingNativeHandler);
+sheetRef.current?.hide().then(() => { setIsOpen(false); fireCloseCallbacks(); });
+`;
+
+  it('is registered', () => {
+    expect(androidRule).toBeDefined();
+  });
+
+  it('goes red on the pre-#4108 patch that guarded only expand()/partialExpand()', () => {
+    if (!androidRule) throw new Error('no @expo/ui Android rule registered');
+    const env = makeEnv({
+      patchedDependencies: { [androidRule.patchedKey]: SCOPED_PATCH_PATH },
+      versions: { [androidRule.package]: versionFromKey(androidRule.patchedKey) },
+      files: { [`${androidRule.package}::${androidRule.file}`]: PRE_4108_SOURCE },
+    });
+
+    const result = checkPatchesApplied([androidRule], env);
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('patch NOT applied');
+    expect(result.errors[0]).toContain('hideSwallowingMissingNativeHandler');
   });
 });
 

--- a/scripts/__tests__/mobile-patches-check.test.ts
+++ b/scripts/__tests__/mobile-patches-check.test.ts
@@ -196,12 +196,11 @@ describe('checkPatchesApplied on a scoped package', () => {
   });
 });
 
-// Mutation test on the shipped rule, not a synthetic one: the sentinel list has
-// to distinguish the current patch from the pre-#4108 patch, which guarded
-// expand()/partialExpand() (#3478) but left hide() — every programmatic dismiss
-// — bare. `swallowMissingNativeHandler` alone is satisfied by both, so a patch
-// regenerated for a version bump could reinstate only the #3478 half and keep
-// this check green while the dismiss guard silently disappeared.
+// Mutation tests on the shipped rule, not a synthetic one: the sentinel list
+// must distinguish the current patch from both the pre-#4108 patch and the
+// short-circuiting hide helper. `swallowMissingNativeHandler` alone is satisfied
+// by all three, so a regenerated patch could otherwise keep this check green
+// while the dismiss guard or its null-ref cleanup silently disappeared.
 describe('the shipped @expo/ui Android rule', () => {
   const androidRule = REAL_RULES.find((rule) => rule.package === SCOPED_PKG && rule.file === SCOPED_FILE);
 
@@ -209,6 +208,13 @@ describe('the shipped @expo/ui Android rule', () => {
 function swallowMissingNativeHandler(error: unknown): void { /* ... */ }
 sheetRef.current?.expand()?.catch(swallowMissingNativeHandler);
 sheetRef.current?.hide().then(() => { setIsOpen(false); fireCloseCallbacks(); });
+`;
+
+  const SHORT_CIRCUITING_HIDE_SOURCE = `
+function swallowMissingNativeHandler(error: unknown): void { /* ... */ }
+function hideSwallowingMissingNativeHandler(): void {
+  sheetRef.current?.hide().catch(swallowMissingNativeHandler).then(runCleanup);
+}
 `;
 
   it('is registered', () => {
@@ -228,6 +234,21 @@ sheetRef.current?.hide().then(() => { setIsOpen(false); fireCloseCallbacks(); })
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]).toContain('patch NOT applied');
     expect(result.errors[0]).toContain('hideSwallowingMissingNativeHandler');
+  });
+
+  it('goes red when a missing sheet ref can short-circuit the JS cleanup', () => {
+    if (!androidRule) throw new Error('no @expo/ui Android rule registered');
+    const env = makeEnv({
+      patchedDependencies: { [androidRule.patchedKey]: SCOPED_PATCH_PATH },
+      versions: { [androidRule.package]: versionFromKey(androidRule.patchedKey) },
+      files: { [`${androidRule.package}::${androidRule.file}`]: SHORT_CIRCUITING_HIDE_SOURCE },
+    });
+
+    const result = checkPatchesApplied([androidRule], env);
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('patch NOT applied');
+    expect(result.errors[0]).toContain('Promise.resolve(hidePromise)');
   });
 });
 

--- a/scripts/__tests__/mobile-patches-check.test.ts
+++ b/scripts/__tests__/mobile-patches-check.test.ts
@@ -197,24 +197,41 @@ describe('checkPatchesApplied on a scoped package', () => {
 });
 
 // Mutation tests on the shipped rule, not a synthetic one: the sentinel list
-// must distinguish the current patch from both the pre-#4108 patch and the
-// short-circuiting hide helper. `swallowMissingNativeHandler` alone is satisfied
-// by all three, so a regenerated patch could otherwise keep this check green
-// while the dismiss guard or its null-ref cleanup silently disappeared.
+// must distinguish the current patch from the pre-#4108 patch, the
+// short-circuiting hide helper, and a helper that normalizes a missing ref but
+// drops only the hide rejection guard. The expand catches remain in every
+// relevant fixture so none can masquerade as proof that hide itself is guarded.
 describe('the shipped @expo/ui Android rule', () => {
   const androidRule = REAL_RULES.find((rule) => rule.package === SCOPED_PKG && rule.file === SCOPED_FILE);
 
   const PRE_4108_SOURCE = `
 function swallowMissingNativeHandler(error: unknown): void { /* ... */ }
 sheetRef.current?.expand()?.catch(swallowMissingNativeHandler);
+sheetRef.current?.partialExpand()?.catch(swallowMissingNativeHandler);
 sheetRef.current?.hide().then(() => { setIsOpen(false); fireCloseCallbacks(); });
 `;
 
   const SHORT_CIRCUITING_HIDE_SOURCE = `
 function swallowMissingNativeHandler(error: unknown): void { /* ... */ }
-function hideSwallowingMissingNativeHandler(): void {
-  sheetRef.current?.hide().catch(swallowMissingNativeHandler).then(runCleanup);
-}
+sheetRef.current?.expand()?.catch(swallowMissingNativeHandler);
+sheetRef.current?.partialExpand()?.catch(swallowMissingNativeHandler);
+const hideSwallowingMissingNativeHandler = () => {
+  void sheetRef.current?.hide().catch(swallowMissingNativeHandler).then(runCleanup);
+};
+hideSwallowingMissingNativeHandler();
+const close = hideSwallowingMissingNativeHandler;
+`;
+
+  const HIDE_WITHOUT_CATCH_SOURCE = `
+function swallowMissingNativeHandler(error: unknown): void { /* ... */ }
+sheetRef.current?.expand()?.catch(swallowMissingNativeHandler);
+sheetRef.current?.partialExpand()?.catch(swallowMissingNativeHandler);
+const hideSwallowingMissingNativeHandler = () => {
+  const hidePromise = sheetRef.current?.hide();
+  void Promise.resolve(hidePromise).then(runCleanup);
+};
+hideSwallowingMissingNativeHandler();
+const close = hideSwallowingMissingNativeHandler;
 `;
 
   it('is registered', () => {
@@ -249,6 +266,23 @@ function hideSwallowingMissingNativeHandler(): void {
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]).toContain('patch NOT applied');
     expect(result.errors[0]).toContain('Promise.resolve(hidePromise)');
+  });
+
+  it('goes red when only the hide rejection catch is removed', () => {
+    if (!androidRule) throw new Error('no @expo/ui Android rule registered');
+    const env = makeEnv({
+      patchedDependencies: { [androidRule.patchedKey]: SCOPED_PATCH_PATH },
+      versions: { [androidRule.package]: versionFromKey(androidRule.patchedKey) },
+      files: { [`${androidRule.package}::${androidRule.file}`]: HIDE_WITHOUT_CATCH_SOURCE },
+    });
+
+    const result = checkPatchesApplied([androidRule], env);
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('patch NOT applied');
+    expect(result.errors[0]).toContain('.catch(swallowMissingNativeHandler)');
+    expect(result.errors[0]).not.toContain('hideSwallowingMissingNativeHandler();');
+    expect(result.errors[0]).not.toContain('const close = hideSwallowingMissingNativeHandler;');
   });
 });
 

--- a/scripts/mobile-patches-check.ts
+++ b/scripts/mobile-patches-check.ts
@@ -145,18 +145,26 @@ export const RULES: readonly PatchRule[] = [
   // unavailable or the native ExpoUI layer predates expand()/partialExpand()/hide().
   // Types are unchanged, so typecheck and the Metro bundle stay green without them.
   //
-  // The first two sentinels cover two independently-losable halves:
-  // `swallowMissingNativeHandler` is the #3478 expand()/partialExpand() guard,
-  // and `hideSwallowingMissingNativeHandler` is the #4108 dismiss path (the
-  // helper both snapToIndex(-1) and close()/forceClose()/dismiss() funnel
-  // through). A regenerated patch that reinstates only #3478 would otherwise
-  // keep this rule green while the dismiss guard silently disappeared — which
-  // is exactly the partial-coverage failure #4108 fixed. The third pins the
-  // null-ref normalization so an already-unmounted sheet still runs JS cleanup.
+  // Pin both independently-losable halves: the #3478 expand()/partialExpand()
+  // guards, and the complete #4108 dismiss path. The multi-line sentinel ties
+  // `.catch(swallowMissingNativeHandler)` to the normalized hide promise inside
+  // the helper rather than accepting one of the expand catches as proof. The
+  // final two sentinels prove snapToIndex(-1) and close()/forceClose()/dismiss()
+  // still funnel through that helper.
   {
     package: '@expo/ui',
     file: 'src/community/bottom-sheet/BottomSheet.android.tsx',
-    sentinels: ['swallowMissingNativeHandler', 'hideSwallowingMissingNativeHandler', 'Promise.resolve(hidePromise)'],
+    sentinels: [
+      'function swallowMissingNativeHandler(error: unknown): void',
+      'sheetRef.current?.expand()?.catch(swallowMissingNativeHandler)',
+      'sheetRef.current?.partialExpand()?.catch(swallowMissingNativeHandler)',
+      `const hideSwallowingMissingNativeHandler = () => {
+      const hidePromise = sheetRef.current?.hide();
+      void Promise.resolve(hidePromise)
+        .catch(swallowMissingNativeHandler)`,
+      'hideSwallowingMissingNativeHandler();',
+      'const close = hideSwallowingMissingNativeHandler;',
+    ],
     patchedKey: '@expo/ui@57.0.8',
   },
   // The iOS half wires the native post-animation dismiss signal through to the

--- a/scripts/mobile-patches-check.ts
+++ b/scripts/mobile-patches-check.ts
@@ -19,11 +19,13 @@
  * existing test, all the way into TestFlight.
  *
  * For @expo/ui, the patch adds the Android `expand()`/`partialExpand()`
- * rejection guard (#3478) and the iOS `onFullyDismissed` post-animation
- * callback. Both are plain TS that Bun drops just as silently: the Android
- * guard is pure runtime (a dropped patch turns a harmless re-snap into an
- * unhandled rejection on older store binaries) and the iOS wiring is what
- * makes `onFullyDismissed` ever fire. Neither shows up in a bundle.
+ * rejection guard (#3478), the same guard on the `hide()` dismiss path (#4108),
+ * and the iOS `onFullyDismissed` post-animation callback. All of it is plain TS
+ * that Bun drops just as silently: the Android guards are pure runtime (a
+ * dropped patch turns a harmless re-snap into an unhandled rejection on older
+ * store binaries, and leaves a dismissed sheet stuck open in JS state) and the
+ * iOS wiring is what makes `onFullyDismissed` ever fire. None of it shows up in
+ * a bundle.
  *
  * For @expo/fingerprint, the patch makes Bun's isolated-linker package roots
  * hashable and gives their files stable logical ids. Without it, Expo mistakes
@@ -138,14 +140,22 @@ export const RULES: readonly PatchRule[] = [
       },
     ],
   },
-  // The Android sheet guard is the one hunk NOTHING else can see: it only
-  // swallows a native AsyncFunction rejection at runtime on store binaries
-  // whose ExpoUI layer predates expand()/partialExpand(). Types are unchanged,
-  // so typecheck and the Metro bundle stay green without it.
+  // The Android sheet guards are the one hunk NOTHING else can see: they only
+  // swallow a native AsyncFunction rejection at runtime on store binaries whose
+  // ExpoUI layer predates expand()/partialExpand()/hide(). Types are unchanged,
+  // so typecheck and the Metro bundle stay green without them.
+  //
+  // Two sentinels, because they cover two independently-losable halves:
+  // `swallowMissingNativeHandler` is the #3478 expand()/partialExpand() guard,
+  // and `hideSwallowingMissingNativeHandler` is the #4108 dismiss path (the
+  // helper both snapToIndex(-1) and close()/forceClose()/dismiss() funnel
+  // through). A regenerated patch that reinstates only #3478 would otherwise
+  // keep this rule green while the dismiss guard silently disappeared — which
+  // is exactly the partial-coverage failure #4108 fixed.
   {
     package: '@expo/ui',
     file: 'src/community/bottom-sheet/BottomSheet.android.tsx',
-    sentinels: ['swallowMissingNativeHandler'],
+    sentinels: ['swallowMissingNativeHandler', 'hideSwallowingMissingNativeHandler'],
     patchedKey: '@expo/ui@57.0.8',
   },
   // The iOS half wires the native post-animation dismiss signal through to the

--- a/scripts/mobile-patches-check.ts
+++ b/scripts/mobile-patches-check.ts
@@ -141,21 +141,22 @@ export const RULES: readonly PatchRule[] = [
     ],
   },
   // The Android sheet guards are the one hunk NOTHING else can see: they only
-  // swallow a native AsyncFunction rejection at runtime on store binaries whose
-  // ExpoUI layer predates expand()/partialExpand()/hide(). Types are unchanged,
-  // so typecheck and the Metro bundle stay green without them.
+  // swallow a native AsyncFunction rejection at runtime when Compose content is
+  // unavailable or the native ExpoUI layer predates expand()/partialExpand()/hide().
+  // Types are unchanged, so typecheck and the Metro bundle stay green without them.
   //
-  // Two sentinels, because they cover two independently-losable halves:
+  // The first two sentinels cover two independently-losable halves:
   // `swallowMissingNativeHandler` is the #3478 expand()/partialExpand() guard,
   // and `hideSwallowingMissingNativeHandler` is the #4108 dismiss path (the
   // helper both snapToIndex(-1) and close()/forceClose()/dismiss() funnel
   // through). A regenerated patch that reinstates only #3478 would otherwise
   // keep this rule green while the dismiss guard silently disappeared — which
-  // is exactly the partial-coverage failure #4108 fixed.
+  // is exactly the partial-coverage failure #4108 fixed. The third pins the
+  // null-ref normalization so an already-unmounted sheet still runs JS cleanup.
   {
     package: '@expo/ui',
     file: 'src/community/bottom-sheet/BottomSheet.android.tsx',
-    sentinels: ['swallowMissingNativeHandler', 'hideSwallowingMissingNativeHandler'],
+    sentinels: ['swallowMissingNativeHandler', 'hideSwallowingMissingNativeHandler', 'Promise.resolve(hidePromise)'],
     patchedKey: '@expo/ui@57.0.8',
   },
   // The iOS half wires the native post-animation dismiss signal through to the


### PR DESCRIPTION
## Summary

Same defect class as #3478, one method over: `@expo/ui`'s `ModalBottomSheetView` on Android exposes `hide()` as a native `AsyncFunction`, but its handler exists only while the Compose `Content { }` block is registered. Calling `hide()` after the sheet is already dismissed or unmounted, or while it is backgrounded mid-animation, rejects with `No handler registered for AsyncFunction 'hide' on view 'ModalBottomSheetView'`. The same rejection is also possible when JS runs against a native ExpoUI layer that predates the method. #3478 guarded `expand()`/`partialExpand()`; `hide()` — used by `close()`/`forceClose()`/`dismiss()` and the `snapToIndex(-1)` path, i.e. every programmatic sheet dismiss on Android — was left exposed.

It's worse than the expand/partialExpand case was: because the old code was `sheetRef.current?.hide().then(() => { setIsOpen(false); ...; fireCloseCallbacks(); })`, a native rejection skipped `.then()` entirely, and a missing ref short-circuited the promise chain. In either lifecycle race the local cleanup never ran. Beyond the Sentry noise, that's a real bug — the sheet's JS state could get stuck "open" after the user asked to close it.

## Fix

`patches/@expo%2Fui@57.0.8.patch` (Bun patch on `@expo/ui`, edited via `bun patch @expo/ui` → `bun patch --commit`), touching only `src/community/bottom-sheet/BottomSheet.android.tsx`. Both dismiss paths now funnel through one named helper carrying the same `swallowMissingNativeHandler` guard #3478 already added for `expand()`/`partialExpand()`:

```js
const hideSwallowingMissingNativeHandler = () => {
  const hidePromise = sheetRef.current?.hide();
  void Promise.resolve(hidePromise)
    .catch(swallowMissingNativeHandler)
    .then(() => {
      setIsOpen(false);
      pendingIndexRef.current = null;
      fireCloseCallbacks();
    });
};
```

`snapToIndex(-1)` calls it; `close` (and therefore `forceClose`/`dismiss`) is it. `Promise.resolve(undefined)` treats an already-missing ref as a successful dismissal, while `.catch()` turns a native handler rejection into a resolved `undefined`. The cleanup therefore runs for both lifecycle-unavailable paths, so the sheet closes in JS state whether the native side accepts the call, rejects it, or is already gone. On the common path where the ref and handler are present, behaviour is unchanged. The helper's doc comment now covers Compose lifecycle unavailability as well as native-version skew and names `hide()`/`close()`/`dismiss()` alongside `expand()`/`partialExpand()`.

### Sentinel now pins the complete dismiss guard

`scripts/mobile-patches-check.ts` is the only thing standing between a silently-dropped Bun patch and a runtime-only regression. Its `@expo/ui` Android rule used to assert just one symbol: `swallowMissingNativeHandler`. The **pre-#4108 patch satisfies that too** — regenerate the patch for a version bump, reinstate only the #3478 half, and the check stays green while the `hide()` guard disappears. Exactly the partial-coverage failure this PR is fixing.

The shipped rule now pins the #3478 `expand()` and `partialExpand()` catches separately, then pins the `hide()` helper's normalized promise and `.catch(swallowMissingNativeHandler)` as one contiguous sentinel. It also pins both consumers independently: the `snapToIndex(-1)` invocation and the `close` alias used by `forceClose()`/`dismiss()`. Mutation tests feed the shipped rule a pre-#4108 source, a helper whose null ref short-circuits cleanup, and a helper with only the hide catch removed; all three must go red. The patch's Android result blob id was also refreshed from the verified installed source.

## Native-release train

This source PR now targets `release/next-ota` and is stacked after #4420. The `@expo/ui` package is autolinked and patched package source is included in the native fingerprint, so this change requires the new iOS and Android binaries assembled by aggregate PR #4457.

The source-PR native gate still compares the cumulative head to `main`, preserving the safety signal while the train is assembled. Final platform fingerprints and native builds are owned by #4457 after all four source PRs land.

## Why CI hadn't validated this before

The branch's base also predated the CI change that added `patches/**` to the `mobile` path filter, so `mobile-bundle` (the job that runs `vp run check:mobile-patches`), the mobile test project, and the Metro bundle check were all **skipped** on the original run — only local runs covered the edited patch. The rebase fixes that: those jobs now actually exercise the change, alongside the Android APK + Robolectric build the fingerprint move pulls in.

## Test plan

- `vp run check:mobile-patches` — pass, 6 native patch rules applied and 4 patch files accounted for
- `vp test run scripts/__tests__/mobile-patches-check.test.ts --reporter=agent` — 1 file / 40 tests pass, including the pre-#4108, null-ref, and catch-only mutations
- `vp run typecheck:mobile` — pass
- `vp run check:mobile-bundle` — Metro bundle check, iOS + Android, OK
- `vp check` on the touched files — clean
- Independent QA — PASS with no actionable findings; the final train rebase is patch-identical and the exact rebased head is `39289350d`

No new behavioural unit test for the patch itself: the vendored file can't be meaningfully exercised under Vitest (the native view needs a real Expo module host), which is why the `mobile-patches-check.ts` sentinel stands in for one — and why this PR makes that sentinel actually discriminating.

## Release Notes

Android: sheets now close reliably when the native close handler is temporarily unavailable.

Closes #4108
