### PR TITLE
fix(sync): retry contended sqlite init instead of killing offline for the session

### DIFF
--- a/packages/mobile/src/db/__tests__/connection.test.ts
+++ b/packages/mobile/src/db/__tests__/connection.test.ts
@@ -5,14 +5,23 @@
 // Also guards the #3646 retirement: no bundled-seed machinery may come back into
 // the DB lifecycle.
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+const reportErrorMock = vi.hoisted(() => vi.fn());
+vi.mock('../../lib/error-reporting', () => ({ reportError: reportErrorMock }));
+
 import type { SQLiteDatabase } from 'expo-sqlite';
-import { clearUserData, initializeDatabase } from '../connection';
+import {
+  clearUserData,
+  getDatabaseHandle,
+  initializeDatabase,
+  resetDatabaseInitializationForTests,
+  setDatabaseHandle,
+} from '../connection';
 import {
   runMigrations,
   setCheckpoint,
@@ -122,6 +131,11 @@ describe('initializeDatabase connection PRAGMAs', () => {
   let dbPath: string;
 
   beforeEach(() => {
+    // initializeDatabase is single-flight for the process (see activeInitialization),
+    // so each test has to start from a clean lifecycle.
+    resetDatabaseInitializationForTests();
+    setDatabaseHandle(null);
+    reportErrorMock.mockClear();
     dbDir = mkdtempSync(join(tmpdir(), 'bs-conn-'));
     dbPath = join(dbDir, 'boardsesh.db');
     fileDb = createTestDatabase(dbPath) as unknown as TestSqliteDb & SQLiteDatabase;
@@ -151,5 +165,153 @@ describe('initializeDatabase connection PRAGMAs', () => {
     expect(journal?.journal_mode?.toLowerCase()).toBe('wal');
     const busy = await other.getFirstAsync<{ timeout: number }>('PRAGMA busy_timeout');
     expect(busy?.timeout).toBe(0);
+  });
+});
+
+// #4104: startup DDL needs SQLite's single write lock, so a long writer already
+// holding the file (a VACUUM, a snapshot import, a teardown still draining across a
+// remount or OTA reload) made initializeDatabase throw. It swallowed the error, never
+// published the handle, and never tried again — one transient collision disabled
+// offline storage for the whole session. These drive that exact interleaving.
+describe('initializeDatabase lock contention (#4104)', () => {
+  let dbDir: string;
+  let realDb: TestSqliteDb;
+
+  // Stands in for the contended connection: the mutation-queue DDL — the first write
+  // initializeDatabase issues — fails with the real Sentry message until `unlock()`.
+  function createContendedDatabase(options: { error?: Error } = {}) {
+    const failure =
+      options.error ?? new Error("Calling the 'execAsync' function has failed → Error code 5: database is locked");
+    let locked = true;
+    let failures = 0;
+
+    const wrapper = {
+      execAsync: async (source: string): Promise<void> => {
+        if (locked && /pending_mutations/i.test(source)) {
+          failures += 1;
+          throw failure;
+        }
+        await realDb.execAsync(source);
+      },
+      getFirstAsync: <T>(source: string, ...params: unknown[]): Promise<T | null> =>
+        realDb.getFirstAsync<T>(source, ...(params as never[])),
+      runAsync: (source: string, ...params: unknown[]) => realDb.runAsync(source, ...(params as never[])),
+      withExclusiveTransactionAsync: (task: (txn: unknown) => Promise<void>) =>
+        realDb.withExclusiveTransactionAsync(task as never),
+    };
+
+    return {
+      db: wrapper as unknown as SQLiteDatabase,
+      unlock: () => {
+        locked = false;
+      },
+      failures: () => failures,
+    };
+  }
+
+  beforeEach(() => {
+    resetDatabaseInitializationForTests();
+    setDatabaseHandle(null);
+    reportErrorMock.mockClear();
+    dbDir = mkdtempSync(join(tmpdir(), 'bs-lock-'));
+    realDb = createTestDatabase(join(dbDir, 'boardsesh.db'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    rmSync(dbDir, { recursive: true, force: true });
+  });
+
+  it('does not block app launch on the retry, leaving the handle unpublished for now', async () => {
+    const contended = createContendedDatabase();
+
+    // Resolves as soon as the FIRST attempt settles — SQLiteProvider renders nothing
+    // until onInit resolves, so waiting for retries here would be a black screen.
+    await expect(initializeDatabase(contended.db)).resolves.toBeUndefined();
+
+    expect(contended.failures()).toBe(1);
+    expect(getDatabaseHandle()).toBeNull();
+    // A launch that is still retrying is not yet newsworthy.
+    expect(reportErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('publishes the handle once a retry wins, instead of staying dead for the session', async () => {
+    const contended = createContendedDatabase();
+
+    await initializeDatabase(contended.db);
+    expect(getDatabaseHandle()).toBeNull();
+
+    // The contending writer finishes (VACUUM done, import committed).
+    contended.unlock();
+    await new Promise((resolve) => setTimeout(resolve, 750));
+
+    expect(getDatabaseHandle()).toBe(contended.db);
+    expect(reportErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('shares one lifecycle across a remount mid-retry rather than starting a second chain', async () => {
+    const first = createContendedDatabase();
+    const second = createContendedDatabase();
+
+    const initial = initializeDatabase(first.db);
+    await initial;
+
+    // A remount lands while the retry chain is still pending. SQLiteProvider has no
+    // re-entrancy guard, so without the single-flight this would run a second chain —
+    // two migration transactions against the one file, i.e. more of the contention
+    // being fixed.
+    const remount = initializeDatabase(second.db);
+    expect(remount).toBe(initial);
+
+    first.unlock();
+    await new Promise((resolve) => setTimeout(resolve, 750));
+
+    expect(getDatabaseHandle()).toBe(first.db);
+    // The second database was never touched.
+    expect(second.failures()).toBe(0);
+  });
+
+  it('gives up after the bounded attempt window and reports once, tagged with the phase', async () => {
+    vi.useFakeTimers();
+    const contended = createContendedDatabase();
+
+    await initializeDatabase(contended.db);
+    // Drive the whole backoff chain (500 + 2000 + 5000 + 10000 = 17.5s, inside the 30s ceiling).
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(contended.failures()).toBe(5);
+    expect(getDatabaseHandle()).toBeNull();
+    expect(reportErrorMock).toHaveBeenCalledTimes(1);
+    const [, context] = reportErrorMock.mock.calls[0];
+    expect(context.tags).toMatchObject({ source: 'offline-sync', kind: 'sqlite-init', phase: 'queue-table' });
+    expect(context.extra).toMatchObject({ attempts: 5, retryable: true });
+  });
+
+  it('does not retry a failure that is not lock contention', async () => {
+    // A full disk or a corrupt file fails identically forever; burning the window on
+    // it would just delay the report.
+    const contended = createContendedDatabase({ error: new Error('disk I/O error') });
+
+    await initializeDatabase(contended.db);
+
+    expect(contended.failures()).toBe(1);
+    expect(reportErrorMock).toHaveBeenCalledTimes(1);
+    const [, context] = reportErrorMock.mock.calls[0];
+    expect(context.extra).toMatchObject({ attempts: 1, retryable: false });
+  });
+
+  it('lets a later mount try again after the window is exhausted', async () => {
+    const exhausted = createContendedDatabase({ error: new Error('disk I/O error') });
+    const initial = initializeDatabase(exhausted.db);
+    await initial;
+
+    // The chain is over, so the guard must not pin a dead lifecycle for the process.
+    const healthy = createContendedDatabase();
+    healthy.unlock();
+    const retryMount = initializeDatabase(healthy.db);
+    expect(retryMount).not.toBe(initial);
+    await retryMount;
+
+    expect(getDatabaseHandle()).toBe(healthy.db);
   });
 });

--- a/packages/mobile/src/db/connection.ts
+++ b/packages/mobile/src/db/connection.ts
@@ -44,10 +44,70 @@ export function getDatabaseHandle(): SQLiteDatabase | null {
 }
 
 /**
+ * How many times the whole setup sequence is attempted before giving up, and the
+ * hard wall-clock ceiling across all of them.
+ *
+ * Sized against the longest writer that can legitimately hold the file while the app
+ * starts: `vacuumDatabase` documents an exclusive lock of 5-20s on a 200-400MB
+ * database, and a snapshot import is the same order. 30s therefore outlasts a genuine
+ * one, while anything still locked past it is wedged rather than busy — further
+ * retries would only burn battery on a launch that has already fallen back to
+ * network-only. The delays are the gaps BETWEEN attempts; the deadline is checked
+ * before each sleep so a slow attempt cannot overrun the window.
+ */
+const MAX_INIT_ATTEMPTS = 5;
+const MAX_INIT_WINDOW_MS = 30_000;
+const INIT_RETRY_DELAYS_MS = [500, 2_000, 5_000, 10_000];
+
+/**
+ * Single-flight guard spanning the ENTIRE init lifecycle, background retries
+ * included. `SQLiteProvider`'s effect has no re-entrancy guard of its own — a remount
+ * while `onInit` is still in flight leaves the first connection unclosed and starts a
+ * second setup — so without this, two remounts during a contended init would run two
+ * retry chains and two migration transactions against one file, which is the very
+ * contention being fixed.
+ */
+let activeInitialization: Promise<void> | null = null;
+
+/**
+ * Which step of the setup sequence failed. Tagged on the Sentry report so the next
+ * triage can tell a refused WAL switch from a locked migration — #4104 could not,
+ * because all three steps shared a single catch.
+ */
+type InitPhase = 'wal' | 'queue-table' | 'migrations';
+
+type InitOutcome = { status: 'ready' } | { status: 'failed'; phase: InitPhase; error: unknown; retryable: boolean };
+
+/**
+ * A lock contention (SQLITE_BUSY code 5 / SQLITE_LOCKED code 6) — transient by
+ * definition, so worth retrying. Anything else (a full disk, a corrupt file, missing
+ * permissions) would fail identically forever, so it is reported at once instead.
+ */
+function isDatabaseLockedError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /database (?:table )?is locked/i.test(message);
+}
+
+function delay(durationMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, durationMs));
+}
+
+/**
  * Prepares an opened database for use: ensures the mutation queue table exists,
  * runs pending schema migrations, and publishes the handle for non-React callers.
  * Intended as the `SQLiteProvider` `onInit` callback. Idempotent — safe on every
  * launch and after a hot reload.
+ *
+ * Never rejects: `SQLiteProvider` leaves the app stuck rendering null if its `onInit`
+ * promise rejects (loading stays true even when `onError` is supplied), which would
+ * white-screen the whole app over non-essential offline storage.
+ *
+ * The setup DDL needs SQLite's single write lock, so a long writer already holding the
+ * file at launch — a `VACUUM`, a snapshot import, a scope teardown still draining from
+ * before a remount or OTA reload — makes it fail. That used to disable offline storage
+ * for the entire session on one transient collision (#4104); it now retries in the
+ * background within a bounded window and publishes the handle as soon as one attempt
+ * wins. Concurrent callers share one lifecycle (see `activeInitialization`).
  *
  * Board reference data is filled in on demand by the per-scope download (nightly
  * CDN snapshot, then paged deltas — see docs/board-snapshots.md). The old bundled
@@ -55,28 +115,105 @@ export function getDatabaseHandle(): SQLiteDatabase | null {
  * producer, and the snapshot bootstrap covers the same head start per (board,
  * layout, size) scope.
  */
-export async function initializeDatabase(db: SQLiteDatabase): Promise<void> {
-  // Never reject: SQLiteProvider leaves the app stuck rendering null if its
-  // onInit promise rejects (loading stays true even when onError is supplied),
-  // which would white-screen the whole app over non-essential offline storage.
-  // On failure we log (dev) and leave the handle unpublished, so getDatabaseHandle()
-  // returns null and offline reads/writes degrade to no-ops instead of crashing.
+export function initializeDatabase(db: SQLiteDatabase): Promise<void> {
+  activeInitialization ??= beginInitialization(db);
+  return activeInitialization;
+}
+
+/**
+ * Runs the setup sequence once. Never throws — the caller decides whether the
+ * failure is worth another attempt.
+ */
+async function attemptInitialization(db: SQLiteDatabase): Promise<InitOutcome> {
+  let phase: InitPhase = 'wal';
   try {
     // WAL (persists on the file, so every later connection inherits it) + busy_timeout
     // on the main connection. Runs first, in autocommit: journal_mode can't change
     // inside a transaction, and ensureMutationQueueTable/runMigrations open one.
+    // Does not throw on a refused WAL switch — see configureMainConnection.
     await configureMainConnection(db);
+    phase = 'queue-table';
     await ensureMutationQueueTable(db);
+    phase = 'migrations';
     await runMigrations(db);
+    // Published only once the schema is actually in place: a handle whose migrations
+    // never ran would hand every consumer a database with no tables.
     setDatabaseHandle(db);
+    return { status: 'ready' };
   } catch (error) {
-    if (__DEV__) {
-      console.warn('[SQLite] initializeDatabase failed; offline storage disabled this session:', error);
-    }
-    // In production a silent null handle just switches every offline feature
-    // off with no trace — report it so a spike is diagnosable from telemetry.
-    reportError(error, { tags: { source: 'offline-sync', kind: 'sqlite-init' } });
+    return { status: 'failed', phase, error, retryable: isDatabaseLockedError(error) };
   }
+}
+
+/**
+ * Drives the attempt sequence, resolving the returned promise as soon as the FIRST
+ * attempt settles so app launch never waits on a retry — `SQLiteProvider` renders
+ * nothing until `onInit` resolves, so blocking here is a black screen. Retries
+ * continue detached and publish the handle the moment one wins; every consumer of
+ * `getDatabaseHandle()` already null-checks and falls back to the network, so a late
+ * handle degrades exactly like the old permanent failure did, then recovers.
+ */
+function beginInitialization(db: SQLiteDatabase): Promise<void> {
+  let releaseLaunch: () => void = () => {};
+  const launchGate = new Promise<void>((resolve) => {
+    releaseLaunch = resolve;
+  });
+
+  void (async () => {
+    const deadline = Date.now() + MAX_INIT_WINDOW_MS;
+
+    for (let attempt = 1; attempt <= MAX_INIT_ATTEMPTS; attempt += 1) {
+      const outcome = await attemptInitialization(db);
+
+      // Unblock the provider once, whatever the first attempt did.
+      if (attempt === 1) {
+        releaseLaunch();
+      }
+
+      if (outcome.status === 'ready') {
+        return;
+      }
+
+      const retryDelayMs = INIT_RETRY_DELAYS_MS[attempt - 1];
+      const outOfRoad =
+        !outcome.retryable ||
+        attempt === MAX_INIT_ATTEMPTS ||
+        retryDelayMs === undefined ||
+        Date.now() + retryDelayMs >= deadline;
+
+      if (outOfRoad) {
+        if (__DEV__) {
+          console.warn(
+            `[SQLite] initializeDatabase failed in phase "${outcome.phase}" after ${attempt} attempt(s); ` +
+              'offline storage disabled this session:',
+            outcome.error,
+          );
+        }
+        // In production a silent null handle just switches every offline feature off
+        // with no trace — report it so a spike is diagnosable from telemetry. Only the
+        // final attempt reports, so a retried-and-recovered launch stays quiet.
+        reportError(outcome.error, {
+          tags: { source: 'offline-sync', kind: 'sqlite-init', phase: outcome.phase },
+          extra: { attempts: attempt, retryable: outcome.retryable },
+        });
+        // Let a genuinely new mount try again rather than staying dead for the process.
+        activeInitialization = null;
+        return;
+      }
+
+      await delay(retryDelayMs);
+    }
+  })();
+
+  return launchGate;
+}
+
+/**
+ * Test-only: drops the single-flight guard so each test can drive a fresh
+ * initialization. Production has exactly one database for the process lifetime.
+ */
+export function resetDatabaseInitializationForTests(): void {
+  activeInitialization = null;
 }
 
 /**

--- a/packages/shared/offline-sync/src/db/__tests__/pragmas.test.ts
+++ b/packages/shared/offline-sync/src/db/__tests__/pragmas.test.ts
@@ -7,7 +7,12 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { OFFLINE_DB_BUSY_TIMEOUT_MS, applyBusyTimeout, configureMainConnection } from '../pragmas';
+import {
+  OFFLINE_DB_BUSY_TIMEOUT_MS,
+  OFFLINE_DB_WAL_SWITCH_TIMEOUT_MS,
+  applyBusyTimeout,
+  configureMainConnection,
+} from '../pragmas';
 import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
 
 let workDir: string;
@@ -58,6 +63,125 @@ describe('configureMainConnection', () => {
     expect(journal?.journal_mode?.toLowerCase()).toBe('wal');
     const busy = await other.getFirstAsync<{ timeout: number }>('PRAGMA busy_timeout');
     expect(busy?.timeout).toBe(0);
+  });
+});
+
+// #4104: the WAL switch used to be the FIRST statement of app startup and ran with
+// busy_timeout still at 0, and any failure propagated out of initializeDatabase and
+// disabled offline storage for the whole session. These pin both halves of the fix
+// against a REAL contending connection rather than a mock.
+describe('configureMainConnection under contention', () => {
+  // A database still in rollback-journal mode — the only state in which the WAL
+  // switch does real work, i.e. the first launch after install or upgrade.
+  async function createRollbackJournalDatabase(path: string): Promise<TestSqliteDb> {
+    const fresh = createTestDatabase(path);
+    await fresh.execAsync('PRAGMA journal_mode = delete');
+    await fresh.execAsync('CREATE TABLE probe (id INTEGER PRIMARY KEY)');
+    return fresh;
+  }
+
+  it('sets busy_timeout before it touches journal_mode', async () => {
+    const statements: string[] = [];
+    const recorder = {
+      execAsync: async (source: string) => {
+        statements.push(source);
+        await db.execAsync(source);
+      },
+      getFirstAsync: async <T>(source: string): Promise<T | null> => {
+        statements.push(source);
+        return db.getFirstAsync<T>(source);
+      },
+    };
+
+    await configureMainConnection(recorder as unknown as TestSqliteDb);
+
+    const firstBusyTimeout = statements.findIndex((sql) => /busy_timeout/i.test(sql));
+    const journalSwitch = statements.findIndex((sql) => /journal_mode\s*=/i.test(sql));
+    expect(firstBusyTimeout).toBeGreaterThanOrEqual(0);
+    expect(journalSwitch).toBeGreaterThanOrEqual(0);
+    // The whole point: no statement runs at busy_timeout = 0 any more.
+    expect(firstBusyTimeout).toBeLessThan(journalSwitch);
+  });
+
+  it('uses the short window for the switch, then raises it for the rest of init', async () => {
+    const timeouts: number[] = [];
+    const recorder = {
+      execAsync: async (source: string) => {
+        const match = /busy_timeout\s*=\s*(\d+)/i.exec(source);
+        if (match) timeouts.push(Number(match[1]));
+        await db.execAsync(source);
+      },
+      getFirstAsync: async <T>(source: string): Promise<T | null> => db.getFirstAsync<T>(source),
+    };
+
+    await configureMainConnection(recorder as unknown as TestSqliteDb);
+
+    // A contending READER makes the switch wait out the whole timeout before failing,
+    // so the switch runs under the short one; everything after it wants the full 5s.
+    expect(timeouts).toEqual([OFFLINE_DB_WAL_SWITCH_TIMEOUT_MS, OFFLINE_DB_BUSY_TIMEOUT_MS]);
+  });
+
+  it('survives a contending writer refusing the WAL switch, and still arms busy_timeout', async () => {
+    const contendedPath = join(workDir, 'contended.db');
+    const seed = await createRollbackJournalDatabase(contendedPath);
+    seed.close();
+
+    const main = createTestDatabase(contendedPath);
+    const contender = createTestDatabase(contendedPath);
+    // Hold the write lock, exactly like a VACUUM / snapshot import straddling launch.
+    await contender.execAsync('BEGIN IMMEDIATE');
+    await contender.execAsync('INSERT INTO probe (id) VALUES (1)');
+
+    try {
+      // Before the fix this threw "database is locked" straight out of init.
+      await expect(configureMainConnection(main)).resolves.toBeUndefined();
+
+      // The switch lost — the file is still in rollback mode, which is CORRECT and
+      // survivable. What matters is that init can carry on from here.
+      const journal = await main.getFirstAsync<{ journal_mode: string }>('PRAGMA journal_mode');
+      expect(journal?.journal_mode?.toLowerCase()).toBe('delete');
+      const busy = await main.getFirstAsync<{ timeout: number }>('PRAGMA busy_timeout');
+      expect(busy?.timeout).toBe(OFFLINE_DB_BUSY_TIMEOUT_MS);
+    } finally {
+      await contender.execAsync('ROLLBACK');
+      contender.close();
+      main.close();
+    }
+  });
+
+  it('still switches to WAL when nothing is contending', async () => {
+    const quietPath = join(workDir, 'quiet.db');
+    const seed = await createRollbackJournalDatabase(quietPath);
+    seed.close();
+
+    const main = createTestDatabase(quietPath);
+    try {
+      await configureMainConnection(main);
+      const journal = await main.getFirstAsync<{ journal_mode: string }>('PRAGMA journal_mode');
+      expect(journal?.journal_mode?.toLowerCase()).toBe('wal');
+    } finally {
+      main.close();
+    }
+  });
+
+  it('is a free no-op on a database already in WAL, even with a writer holding the lock', async () => {
+    // Why the switch is a first-launch-only risk: once the file header says WAL the
+    // pragma takes no lock at all, so post-#3858 devices never contend on it.
+    await configureMainConnection(db);
+
+    const contender = createTestDatabase(dbPath);
+    await contender.execAsync('CREATE TABLE probe (id INTEGER PRIMARY KEY)');
+    await contender.execAsync('BEGIN IMMEDIATE');
+    await contender.execAsync('INSERT INTO probe (id) VALUES (1)');
+
+    try {
+      await expect(configureMainConnection(db)).resolves.toBeUndefined();
+      const journal = await db.getFirstAsync<{ journal_mode: string }>('PRAGMA journal_mode');
+      expect(journal?.journal_mode?.toLowerCase()).toBe('wal');
+    } finally {
+      await contender.execAsync('ROLLBACK');
+      contender.close();
+    }
   });
 });
 

--- a/packages/shared/offline-sync/src/db/pragmas.ts
+++ b/packages/shared/offline-sync/src/db/pragmas.ts
@@ -2,8 +2,12 @@
 //
 // The engine runs many connections against one `boardsesh.db`: the app's main
 // connection (react-query reads, VACUUM, wal_checkpoint) plus a fresh native
-// connection per `withExclusiveTransactionAsync` task (`useNewConnection: true`),
-// which opens `BEGIN EXCLUSIVE`. Two settings keep those from colliding:
+// connection per `withExclusiveTransactionAsync` task (`useNewConnection: true`).
+// That task connection opens a plain deferred `BEGIN` — expo-sqlite's "exclusive"
+// means one JS task owns the connection, NOT SQLite's `BEGIN EXCLUSIVE` — so it
+// takes no lock until its first real statement, which is why applying the timeout
+// as the task's first statement is early enough. Two settings keep these from
+// colliding:
 //
 // - `journal_mode = WAL` PERSISTS in the database file header, so it is set ONCE
 //   on the main connection (configureMainConnection) and every later connection —
@@ -27,6 +31,21 @@ import type { SqlExecutor } from '../database';
 export const OFFLINE_DB_BUSY_TIMEOUT_MS = 5000;
 
 /**
+ * The `busy_timeout` in force *only* while the one-shot WAL switch is attempted.
+ *
+ * Switching a rollback-journal file to WAL needs a lock no other connection holds,
+ * and SQLite's behaviour under contention is asymmetric (measured against real
+ * SQLite for #4104):
+ *   - a contending WRITER makes the switch fail INSTANTLY — `busy_timeout` is never
+ *     consulted, so a longer timeout buys exactly nothing;
+ *   - a contending READER makes it wait out the whole `busy_timeout` and THEN fail.
+ * Running the switch under the full 5s would therefore add a five-second stall to
+ * app launch (`SQLiteProvider` renders nothing until `onInit` resolves) and still
+ * fail. A quarter second absorbs a brief blip without a visibly slow launch.
+ */
+export const OFFLINE_DB_WAL_SWITCH_TIMEOUT_MS = 250;
+
+/**
  * Set `busy_timeout` on a connection. Call as the first statement of every
  * `withExclusiveTransactionAsync` task — the task runs on its own native
  * connection, which starts at `busy_timeout = 0`.
@@ -41,17 +60,39 @@ export async function applyBusyTimeout(db: SqlExecutor): Promise<void> {
  * `busy_timeout`. Must run in autocommit — `journal_mode` cannot change inside a
  * transaction — so call it before any table creation or migration.
  *
- * WAL should always succeed on the local app-sandbox filesystem; a device that
- * refuses it (returns something other than `wal`) still works, just without the
- * reader/writer concurrency win, so this reads the result back and warns in dev
- * rather than throwing.
+ * Never throws. The WAL switch is an OPTIMISATION, not a prerequisite: a database
+ * still in rollback-journal mode works correctly, it just serialises readers against
+ * the writer. Letting a contended switch abort startup is what took the whole of
+ * `initializeDatabase` down with it and left offline storage disabled for the entire
+ * session (#4104), so a refused switch is logged in dev and stepped over.
+ *
+ * Note the switch is genuinely one-shot in practice: on a file ALREADY in WAL the
+ * pragma is a free no-op that takes no lock and cannot fail, even with another
+ * connection mid-write. Only the first launch after install/upgrade can contend.
  */
 export async function configureMainConnection(db: SqlExecutor): Promise<void> {
-  const result = await db.getFirstAsync<{ journal_mode: string }>('PRAGMA journal_mode = WAL');
-  // NODE_ENV is the platform-free stand-in for RN's __DEV__ — this package carries
-  // no react-native globals, and Metro inlines it the same way.
-  if (process.env.NODE_ENV !== 'production' && result?.journal_mode?.toLowerCase() !== 'wal') {
-    console.warn(`[SQLite] journal_mode is "${result?.journal_mode}", expected "wal" — reads may contend with writes`);
+  // busy_timeout FIRST — every statement below wants it, and the pragma itself is a
+  // connection-local setting that takes no lock and cannot fail. The short window is
+  // deliberate: see OFFLINE_DB_WAL_SWITCH_TIMEOUT_MS for why a longer one is worse.
+  await db.execAsync(`PRAGMA busy_timeout = ${OFFLINE_DB_WAL_SWITCH_TIMEOUT_MS}`);
+
+  try {
+    const result = await db.getFirstAsync<{ journal_mode: string }>('PRAGMA journal_mode = WAL');
+    // NODE_ENV is the platform-free stand-in for RN's __DEV__ — this package carries
+    // no react-native globals, and Metro inlines it the same way.
+    if (process.env.NODE_ENV !== 'production' && result?.journal_mode?.toLowerCase() !== 'wal') {
+      console.warn(
+        `[SQLite] journal_mode is "${result?.journal_mode}", expected "wal" — reads may contend with writes`,
+      );
+    }
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(
+        '[SQLite] could not switch to WAL (another connection holds the file); continuing without it:',
+        error,
+      );
+    }
   }
+
   await applyBusyTimeout(db);
 }


### PR DESCRIPTION
## Summary

`database is locked` kept firing after #3858, tagged `kind: sqlite-init` on both platforms (BOARDSESH-A9 / AB / AX on iOS, 6V on Android — roughly 155 events across 105 users in 14d, still on `2.3.0+2000783`).

`kind: sqlite-init` has exactly one throw site: the catch in `initializeDatabase` (`packages/mobile/src/db/connection.ts`). It wrapped three steps in one `try`, so the existing telemetry could not say which one failed.

**Root cause.** `initializeDatabase` issues write DDL — `CREATE TABLE` for the mutation queue, then the schema migrations. Those need SQLite's single write lock. When a long writer already holds the file at launch, that DDL throws, the catch swallows it, `setDatabaseHandle` is never called, and **there was no retry** — so one transient collision disabled offline storage for the entire session. The writers that hold the lock long enough are real and documented: `vacuumDatabase` takes an exclusive lock for **5-20s** on a 200-400MB database (`packages/shared/offline-sync/src/db/vacuum.ts`), and a snapshot import or scope teardown is the same order.

**The interleaving.** Connection A (the main one, from `SQLiteProvider`) runs the setup DDL while connection B — a `useNewConnection: true` transaction connection, which expo-sqlite deliberately excludes from its native connection cache (`SQLiteModule.kt:113`, `SQLiteModule.swift:108`) — is still draining a snapshot import, pull page, or VACUUM from before a remount or an OTA reload. A's DDL waits out `busy_timeout` and throws. `getFirstAsync` surfaces it as `prepareAsync`/`finalizeAsync`, `execAsync` as itself, which is exactly the spread of the four Sentry issues.

## What changed

- **`busy_timeout` is set before `journal_mode` is touched.** No init statement runs at `busy_timeout = 0` any more.
- **The WAL switch is non-fatal.** It is an optimisation, not a prerequisite: a rollback-journal database still works, it just serialises readers against the writer. Letting a contended switch abort startup took the whole init down with it.
- **Init retries in the background** — 5 attempts inside a hard 30s ceiling — and publishes the handle as soon as one wins. The returned promise resolves after the *first* attempt, so launch never waits on a retry (`SQLiteProvider` renders nothing until `onInit` resolves; blocking there is a black screen).
- **One single-flight promise covers the whole lifecycle, retry chain included.** `SQLiteProvider`'s effect has no re-entrancy guard, so a remount mid-init previously could start a second setup; now it joins the existing one instead of running two migration transactions against one file.
- **Sentry reports carry a `phase` tag** (`wal` / `queue-table` / `migrations`) and only fire once the window is exhausted, so a retried-and-recovered launch stays quiet.

## Why this departs from the issue's fix direction #3

The issue proposed applying `busy_timeout` to every connection so the WAL switch waits instead of failing. I measured this against real SQLite before implementing, and it does not hold:

| Case | Result |
|---|---|
| WAL switch, DB **already in WAL**, writer holding the lock | **OK, 1ms** — free no-op, takes no lock, cannot fail |
| WAL switch, DB **already in WAL**, reader holding the lock | **OK, 0ms** |
| WAL switch on rollback-journal DB, **writer** contending, `busy_timeout = 0` | throws `database is locked` **instantly** |
| WAL switch on rollback-journal DB, **writer** contending, `busy_timeout = 5000` | throws `database is locked` **instantly (0ms)** — the timeout is never consulted |
| WAL switch on rollback-journal DB, **reader** contending, `busy_timeout = 5000` | waits **5226ms**, then throws anyway |
| `CREATE TABLE` in **WAL** mode, writer contending, `busy_timeout = 5000` | waits **5020ms**, then throws |

Two consequences. First, raising `busy_timeout` around the WAL switch buys nothing against a writer and, against a reader, converts an instant failure into a **five-second black-screen stall that still fails** — which is why the switch now runs under a short 250ms window and is wrapped rather than awaited-and-trusted. Second, since WAL persists in the file header and #3858 shipped on 2026-07-25, essentially every device is already in WAL, so the switch is a first-launch-only risk and **was not the ongoing cause**. The residual failures are the DDL after it, which is what the retry addresses.

## Why I did not implement the issue's fix direction #4

The issue asks to make `finalizeAsync` failures non-fatal, on the reading that a statement failing to finalise is teardown noise. That is not what those events are. `sqlite3_finalize` returns the error code of the *most recent step* of the statement it is finalising, so a `finalizeAsync` throwing `database is locked` is the same lock error as the `prepareAsync`/`execAsync` ones, just surfaced at a later call. Swallowing it would hide genuine query failures across the whole offline layer while doing nothing about the contention. The retry plus the non-fatal WAL switch covers the observed events instead.

## Follow-up (not in this PR)

Gating the sync scheduler so it does not start a cycle while an init retry is pending is deliberately out of scope. The new `phase` tag makes it decidable: if Sentry shows retries losing to sync cycles rather than to VACUUM/import, that is the next lever.

## Test plan

New regression coverage drives the real interleaving rather than mocking it — the `node:sqlite` harness opens genuine second connections that hold a write lock.

`packages/shared/offline-sync/src/db/__tests__/pragmas.test.ts`:
- `busy_timeout` is set before `journal_mode` is touched, and uses the short window for the switch then the full 5s for the rest.
- A contending writer refusing the WAL switch no longer throws; the file stays in rollback mode and `busy_timeout` is still armed.
- The switch still succeeds when nothing is contending, and is a free no-op on an already-WAL file with a writer holding the lock.

`packages/mobile/src/db/__tests__/connection.test.ts`:
- Launch is not blocked by the retry, and the handle stays unpublished with nothing reported yet.
- A retry that wins publishes the handle instead of the session staying dead.
- A remount mid-retry returns the *same* promise and never touches the second database.
- The window is bounded: exactly 5 attempts, reported once, tagged `phase: 'queue-table'` with `attempts: 5`.
- A non-lock failure (disk I/O error) is not retried and reports immediately.
- A later mount can try again after the window is exhausted.

Commands run, all green:
- `vp run typecheck:mobile`
- `vp run test:mobile` — 575 files, 4918 tests passed
- `vp test run packages/shared/offline-sync` — 20 files, 304 tests passed
- `vp check` — 0 errors
- `vp run check:mobile-bundle` — android bundle OK

Not device-tested. No UI surface changes, so no visual QA. Worth confirming on a low-end Android device (the original report came from a OnePlus 8 Pro, `device.class: low`) where init and first sync overlap most.

**OTA-safe:** TypeScript only, under `packages/mobile/src` and `packages/shared/offline-sync/src`. Nothing in `ios/`, `android/`, `modules/`, `plugins/`, `patches/`, or `app.config.ts`, and no native dependency changes, so the native fingerprint does not move and this ships as an OTA.

## Release Notes

- Logging climbs offline no longer goes quiet for the rest of the session when the app starts up mid-cleanup. Offline storage now recovers on its own instead of staying switched off until you restart.

Closes #4104
