### PR TITLE
fix(backend): identify and guard remaining parallel-query DSM paths

### DIFF
--- a/packages/backend/src/__tests__/mask-error.test.ts
+++ b/packages/backend/src/__tests__/mask-error.test.ts
@@ -103,3 +103,79 @@ describe('maskDatabaseError', () => {
     expect(sentryCaptureMock).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * #4105: the DSM-exhaustion issue could not be diagnosed because the mask
+ * reported only `unwrapCause(error)` — the bare PostgresError — so every
+ * resolver's DB failures collapsed into one anonymous Sentry issue with no SQL
+ * and no field path. These assert the evidence is attached to the event while
+ * the client-facing message stays SQL-free (#3183).
+ */
+describe('maskDatabaseError diagnostic context (#4105)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function captureOptions() {
+    return sentryCaptureMock.mock.calls[0][1] as {
+      tags?: Record<string, string>;
+      extra?: Record<string, unknown>;
+    };
+  }
+
+  it('tags the GraphQL field path so the offending resolver is named', () => {
+    const drizzle = makeDrizzleError(makePgError('53100'));
+    const located = new GraphQLError(drizzle.message, { originalError: drizzle, path: ['searchClimbs', 'totalCount'] });
+
+    maskDatabaseError(located);
+
+    expect(captureOptions().tags?.graphqlPath).toBe('searchClimbs.totalCount');
+  });
+
+  it('attaches the drizzle SQL that unwrapCause drops', () => {
+    const drizzle = makeDrizzleError(makePgError('53100'));
+    const located = new GraphQLError(drizzle.message, { originalError: drizzle, path: ['setterStats'] });
+
+    maskDatabaseError(located);
+
+    expect(captureOptions().extra?.failedQuery).toBe(drizzle.message);
+  });
+
+  it('still reports the pg cause itself, so the existing issue grouping is unchanged', () => {
+    // Sentry fingerprints on the captured exception, not on tags/extra. Capturing
+    // the cause (not the wrapper) is what keeps BOARDSESH-AK's history continuous.
+    const pgError = makePgError('53100');
+    const located = new GraphQLError('boom', { originalError: makeDrizzleError(pgError), path: ['trendingFeed'] });
+
+    maskDatabaseError(located);
+
+    expect(sentryCaptureMock).toHaveBeenCalledWith(pgError, expect.anything());
+  });
+
+  it('never leaks the SQL to the client even though it is on the Sentry event', () => {
+    const drizzle = makeDrizzleError(makePgError('53100'));
+    const located = new GraphQLError(drizzle.message, { originalError: drizzle, path: ['sessionGroupedFeed'] });
+
+    const masked = maskDatabaseError(located);
+
+    expect(captureOptions().extra?.failedQuery).toContain('select');
+    expect(masked.message).toBe('Something went wrong on our end. Please try again.');
+    expect(JSON.stringify(masked)).not.toMatch(/select|Failed query/i);
+  });
+
+  it('truncates a pathological query so the event cannot be dropped for size', () => {
+    const huge = Object.assign(new Error(`Failed query: select * from t where id in (${'1,'.repeat(5000)})`), {
+      cause: makePgError('53100'),
+    });
+
+    maskDatabaseError(huge);
+
+    expect((captureOptions().extra?.failedQuery as string).length).toBe(2000);
+  });
+
+  it('omits the path tag for an error that never reached graphql-js', () => {
+    maskDatabaseError(makeDrizzleError(makePgError('53100')));
+
+    expect(captureOptions().tags).not.toHaveProperty('graphqlPath');
+  });
+});

--- a/packages/backend/src/__tests__/serial-plan-guard.test.ts
+++ b/packages/backend/src/__tests__/serial-plan-guard.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Regression net for the Postgres parallel-query DSM guard (#1969 / #2378 /
+ * #3856 / #4105).
+ *
+ * Postgres allocates a dynamic-shared-memory segment per parallel worker; on a
+ * container with a small /dev/shm a burst of concurrent parallel hash joins
+ * raises `could not resize shared memory segment` (pgCode 53100) and the request
+ * fails. The fix is `SET LOCAL max_parallel_workers_per_gather = 0`, which only
+ * takes effect inside a transaction.
+ *
+ * These live in the backend suite on purpose: `packages/db` runs on node's test
+ * runner and is not wired into CI, so a guard test placed next to the query
+ * would never gate a PR.
+ */
+
+import { describe, it, expect } from 'vite-plus/test';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { is, getTableName, Table, type SQL } from 'drizzle-orm';
+import { withSerialPlan, getSetterStats, type SerialPlanDb } from '@boardsesh/db/queries';
+import { boardClimbs } from '@boardsesh/db/schema';
+import type { DbInstance } from '@boardsesh/db/client';
+
+const dialect = new PgDialect();
+const GUARD_PATTERN = /SET LOCAL max_parallel_workers_per_gather\s*=\s*0/i;
+
+type RecordedQuery = { table: string | null };
+
+/**
+ * Minimal stand-in for a top-level Drizzle instance. Every select-chain method
+ * returns the same builder, and awaiting it records that the query ran — so a
+ * test can assert the SELECT executed AFTER the guard rather than instead of it.
+ */
+function createFakeDb() {
+  const callOrder: string[] = [];
+  const executedStatements: SQL[] = [];
+  const queries: RecordedQuery[] = [];
+
+  const makeSelectBuilder = () => {
+    const recorded: RecordedQuery = { table: null };
+    const builder: Record<string, unknown> = {};
+    for (const method of ['innerJoin', 'leftJoin', 'where', 'groupBy', 'orderBy', 'limit', 'offset']) {
+      builder[method] = () => builder;
+    }
+    builder.from = (source: unknown) => {
+      recorded.table = is(source, Table) ? getTableName(source) : null;
+      return builder;
+    };
+    builder.then = (
+      onFulfilled?: ((value: unknown) => unknown) | null,
+      onRejected?: ((reason: unknown) => unknown) | null,
+    ) => {
+      callOrder.push('select');
+      queries.push(recorded);
+      return Promise.resolve([]).then(onFulfilled, onRejected);
+    };
+    return builder;
+  };
+
+  const tx = {
+    execute: (statement: SQL) => {
+      callOrder.push('execute');
+      executedStatements.push(statement);
+      return Promise.resolve([]);
+    },
+    select: () => makeSelectBuilder(),
+    selectDistinct: () => makeSelectBuilder(),
+  };
+
+  const fakeDb = {
+    transaction: (callback: (transactionDb: typeof tx) => unknown) => callback(tx),
+  };
+
+  return { fakeDb, tx, callOrder, executedStatements, queries };
+}
+
+function renderedGuards(statements: SQL[]): string[] {
+  return statements.map((statement) => dialect.sqlToQuery(statement).sql);
+}
+
+describe('withSerialPlan', () => {
+  it('opens a transaction and issues the guard before running the query', async () => {
+    const { fakeDb, callOrder, executedStatements } = createFakeDb();
+
+    await withSerialPlan(fakeDb as unknown as SerialPlanDb, (tx) => tx.select().from(boardClimbs));
+
+    expect(callOrder).toEqual(['execute', 'select']);
+    expect(renderedGuards(executedStatements)[0]).toMatch(GUARD_PATTERN);
+  });
+
+  it('runs the query inside the transaction, not on the outer handle', async () => {
+    // SET LOCAL is scoped to the transaction, so a query issued on the original
+    // db handle would run on a different connection with parallelism still on.
+    const { fakeDb, tx } = createFakeDb();
+    let received: unknown;
+
+    await withSerialPlan(fakeDb as unknown as SerialPlanDb, async (transactionDb) => {
+      received = transactionDb;
+      return [];
+    });
+
+    expect(received).toBe(tx);
+  });
+
+  it('returns the query result untouched', async () => {
+    const { fakeDb } = createFakeDb();
+
+    const result = await withSerialPlan(fakeDb as unknown as SerialPlanDb, async () => ['a', 'b']);
+
+    expect(result).toEqual(['a', 'b']);
+  });
+
+  it('propagates a query failure and does not swallow it', async () => {
+    const { fakeDb } = createFakeDb();
+
+    await expect(
+      withSerialPlan(fakeDb as unknown as SerialPlanDb, async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+  });
+
+  it('falls back to a bare execute for an execute-only test double', async () => {
+    const executed: SQL[] = [];
+    const executeOnly = {
+      execute: (statement: SQL) => {
+        executed.push(statement);
+        return Promise.resolve([]);
+      },
+    };
+
+    await withSerialPlan(executeOnly as unknown as SerialPlanDb, async () => 'ok');
+
+    expect(renderedGuards(executed)[0]).toMatch(GUARD_PATTERN);
+  });
+});
+
+describe('getSetterStats guard (#4105)', () => {
+  it('issues the guard before the board_climbs aggregate', async () => {
+    // This query hash-joins board_climbs x board_climb_stats over a whole layout
+    // and groups by setter. It fires from the same search drawer as searchClimbs,
+    // so it kept exhausting /dev/shm after #3856 guarded the search paths.
+    const { fakeDb, callOrder, executedStatements, queries } = createFakeDb();
+
+    await getSetterStats(fakeDb as unknown as DbInstance, {
+      board_name: 'kilter',
+      layout_id: 1,
+      size_id: 10,
+      set_ids: [1, 20],
+      angle: 40,
+    });
+
+    expect(callOrder).toEqual(['execute', 'select']);
+    expect(queries[0].table).toBe('board_climbs');
+    expect(renderedGuards(executedStatements)[0]).toMatch(GUARD_PATTERN);
+  });
+
+  it('still guards the autocomplete branch that adds an ILIKE on setter_username', async () => {
+    // The leading-wildcard ILIKE removes the last index-friendly predicate, which
+    // makes a parallel plan *more* likely, not less.
+    const { fakeDb, callOrder, executedStatements } = createFakeDb();
+
+    await getSetterStats(
+      fakeDb as unknown as DbInstance,
+      { board_name: 'kilter', layout_id: 1, size_id: 10, set_ids: [1, 20], angle: 40 },
+      'jack',
+    );
+
+    expect(callOrder).toEqual(['execute', 'select']);
+    expect(renderedGuards(executedStatements)[0]).toMatch(GUARD_PATTERN);
+  });
+});

--- a/packages/backend/src/__tests__/serial-plan-guard.test.ts
+++ b/packages/backend/src/__tests__/serial-plan-guard.test.ts
@@ -45,6 +45,9 @@ function createFakeDb() {
       recorded.table = is(source, Table) ? getTableName(source) : null;
       return builder;
     };
+    // Deliberate: drizzle's query builder is awaitable, so the fake has to be a
+    // real thenable for `await tx.select()...` to resolve like a genuine query.
+    // oxlint-disable-next-line no-thenable
     builder.then = (
       onFulfilled?: ((value: unknown) => unknown) | null,
       onRejected?: ((reason: unknown) => unknown) | null,

--- a/packages/backend/src/__tests__/session-feed-board-scope.test.ts
+++ b/packages/backend/src/__tests__/session-feed-board-scope.test.ts
@@ -6,6 +6,27 @@ import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 
 const boardScopeTestState = vi.hoisted(() => {
   const executeMock = vi.fn();
+  const guardMock = vi.fn();
+
+  // sessionGroupedFeed's main query runs inside withSerialPlan, which issues
+  // SET LOCAL max_parallel_workers_per_gather = 0 first (#4105). Route that
+  // statement to its own spy so the executeMock sequence these tests index into
+  // stays the resolver's own queries — while still being assertable.
+  const guardText = (query: unknown): string => {
+    if (!query || typeof query !== 'object') return '';
+    const chunks = (query as { queryChunks?: unknown[] }).queryChunks;
+    if (!Array.isArray(chunks)) return '';
+    return chunks
+      .map((chunk) => {
+        if (!chunk || typeof chunk !== 'object') return '';
+        const typed = chunk as { value?: unknown; queryChunks?: unknown[] };
+        if (Array.isArray(typed.value)) return typed.value.join('');
+        if (Array.isArray(typed.queryChunks)) return guardText(chunk);
+        return '';
+      })
+      .join('');
+  };
+  const isSerialPlanGuard = (query: unknown) => guardText(query).includes('max_parallel_workers_per_gather');
   // dbRead.select() is used twice per board-scoped call:
   //   1. board lookup:  .select({id}).from(userBoards).where(...).limit(1).then()
   //   2. session meta:  .select({...}).from(boardSessions).where(inArray(...))  (awaited)
@@ -20,13 +41,26 @@ const boardScopeTestState = vi.hoisted(() => {
     return { from: () => ({ where: () => whereResult }) };
   });
 
-  return { executeMock, selectMock, selectQueue };
+  return { executeMock, selectMock, selectQueue, guardMock, isSerialPlanGuard };
 });
 
 vi.mock('../db/client', () => {
+  const transaction = (callback: (tx: unknown) => unknown) =>
+    callback({
+      execute: (statement: unknown) => {
+        if (boardScopeTestState.isSerialPlanGuard(statement)) {
+          boardScopeTestState.guardMock(statement);
+          return Promise.resolve([]);
+        }
+        return boardScopeTestState.executeMock(statement);
+      },
+      select: boardScopeTestState.selectMock,
+    });
+
   const fakeDb = {
     execute: boardScopeTestState.executeMock,
     select: boardScopeTestState.selectMock,
+    transaction,
   };
   return { db: fakeDb, dbRead: fakeDb };
 });
@@ -110,7 +144,19 @@ describe('sessionGroupedFeed board scoping (exact board_id)', () => {
     // queue from a prior test so each test owns the full execute() call sequence.
     boardScopeTestState.executeMock.mockReset();
     boardScopeTestState.selectMock.mockClear();
+    boardScopeTestState.guardMock.mockClear();
     boardScopeTestState.selectQueue.length = 0;
+  });
+
+  it('runs the main feed query behind the parallel-worker guard (#4105)', async () => {
+    // The only test that would catch someone unwrapping sessionGroupedFeed from
+    // withSerialPlan — the other assertions here deliberately look past the guard.
+    boardScopeTestState.selectQueue.push([], []);
+    primeFeedExecuteMocks();
+
+    await sessionGroupedFeed(null, { input: { limit: 5 } });
+
+    expect(boardScopeTestState.guardMock).toHaveBeenCalledTimes(1);
   });
 
   it('scopes to the resolved board id via t.board_id, not board_type/layout', async () => {

--- a/packages/backend/src/__tests__/session-feed-query.test.ts
+++ b/packages/backend/src/__tests__/session-feed-query.test.ts
@@ -10,18 +10,55 @@ const sessionFeedTestState = vi.hoisted(() => {
     from: selectFromMock,
   }));
 
+  const guardMock = vi.fn();
+
+  // sessionGroupedFeed's main query runs inside withSerialPlan, which issues
+  // SET LOCAL max_parallel_workers_per_gather = 0 first (#4105). Route that
+  // statement to its own spy so the executeMock sequence these tests index into
+  // stays the resolver's own queries — while still being assertable.
+  const guardText = (query: unknown): string => {
+    if (!query || typeof query !== 'object') return '';
+    const chunks = (query as { queryChunks?: unknown[] }).queryChunks;
+    if (!Array.isArray(chunks)) return '';
+    return chunks
+      .map((chunk) => {
+        if (!chunk || typeof chunk !== 'object') return '';
+        const typed = chunk as { value?: unknown; queryChunks?: unknown[] };
+        if (Array.isArray(typed.value)) return typed.value.join('');
+        if (Array.isArray(typed.queryChunks)) return guardText(chunk);
+        return '';
+      })
+      .join('');
+  };
+  const isSerialPlanGuard = (query: unknown) => guardText(query).includes('max_parallel_workers_per_gather');
+
   return {
     executeMock,
     selectWhereMock,
     selectFromMock,
     selectMock,
+    guardMock,
+    isSerialPlanGuard,
   };
 });
 
 vi.mock('../db/client', () => {
+  const transaction = (callback: (tx: unknown) => unknown) =>
+    callback({
+      execute: (statement: unknown) => {
+        if (sessionFeedTestState.isSerialPlanGuard(statement)) {
+          sessionFeedTestState.guardMock(statement);
+          return Promise.resolve([]);
+        }
+        return sessionFeedTestState.executeMock(statement);
+      },
+      select: sessionFeedTestState.selectMock,
+    });
+
   const fakeDb = {
     execute: sessionFeedTestState.executeMock,
     select: sessionFeedTestState.selectMock,
+    transaction,
   };
   // sessionGroupedFeed reads from `dbRead`; alias it to the same fake so the
   // existing call assertions still hit `executeMock` / `selectMock`.

--- a/packages/backend/src/db/queries/climbs/count-climbs.ts
+++ b/packages/backend/src/db/queries/climbs/count-climbs.ts
@@ -1,7 +1,12 @@
 import { sql, and } from 'drizzle-orm';
 import { dbRead } from '../../client';
 import { boardClimbs, boardClimbStats } from '@boardsesh/db/schema';
-import { createClimbFilters, type BoardRouteParams, type ClimbSearchParams } from '@boardsesh/db/queries';
+import {
+  createClimbFilters,
+  withSerialPlan,
+  type BoardRouteParams,
+  type ClimbSearchParams,
+} from '@boardsesh/db/queries';
 import { logger } from '../../../utils/logger';
 
 /**
@@ -37,16 +42,14 @@ export const countClimbs = async (
 
   // This broad LEFT JOIN count is the same plan shape that exhausted /dev/shm in the
   // PR #1969 incident — a filtered count goes parallel (Gather) and each worker
-  // allocates a DSM segment. Disable per-gather parallelism inside a transaction
-  // (SET LOCAL needs a transaction; the client runs prepare:false behind PgBouncer
-  // transaction pooling), mirroring searchClimbs' standardSearch guard. Reproduced
-  // live on prod: a bare board_climbs aggregate raised "could not resize shared
-  // memory segment". The unused board_climb_stats join is left in place — Postgres
-  // already eliminates it via the stats PK when no condition references stats columns
+  // allocates a DSM segment. `withSerialPlan` disables per-gather parallelism inside
+  // a transaction, mirroring searchClimbs' standardSearch guard. Reproduced live on
+  // prod: a bare board_climbs aggregate raised "could not resize shared memory
+  // segment". The unused board_climb_stats join is left in place — Postgres already
+  // eliminates it via the stats PK when no condition references stats columns
   // (verified by the EXPLAIN harness), so there's nothing to hand-optimize.
   try {
-    return await dbRead.transaction(async (tx) => {
-      await tx.execute(sql`SET LOCAL max_parallel_workers_per_gather = 0`);
+    return await withSerialPlan(dbRead, async (tx) => {
       const result = await tx
         .select({ count: sql<number>`count(*)` })
         .from(boardClimbs)

--- a/packages/backend/src/graphql/mask-error.ts
+++ b/packages/backend/src/graphql/mask-error.ts
@@ -9,6 +9,11 @@ import { markErrorReported, wasErrorReported } from '../utils/sentry-dedupe';
 // the top-level error or on its GraphQL `originalError`.
 const FAILED_QUERY_PREFIX = 'Failed query:';
 
+// Upper bound on the SQL we attach to a Sentry event. Long enough to identify
+// the plan shape, short enough that a pathological IN (...) list can't bloat the
+// payload past Sentry's per-event limit and get the whole event dropped.
+const MAX_REPORTED_QUERY_LENGTH = 2000;
+
 function getOriginalError(error: unknown): unknown {
   if (error && typeof error === 'object' && 'originalError' in error) {
     return (error as { originalError?: unknown }).originalError;
@@ -33,6 +38,35 @@ export function isDatabaseLeakError(error: unknown): boolean {
     if (getPostgresErrorCode(candidate) !== undefined) return true;
   }
   return false;
+}
+
+/**
+ * The GraphQL field path of a located error ("searchClimbs", "user.ticks"), or
+ * undefined for an error that never reached graphql-js. This is what names the
+ * offending resolver on an otherwise anonymous driver error.
+ */
+function getGraphqlPath(error: unknown): string | undefined {
+  if (error && typeof error === 'object' && 'path' in error) {
+    const { path } = error as { path?: unknown };
+    if (Array.isArray(path) && path.length > 0) {
+      return path.join('.');
+    }
+  }
+  return undefined;
+}
+
+/**
+ * drizzle's "Failed query: ..." wrapper message, truncated. `unwrapCause` reports
+ * the driver error (see below), which deliberately drops this — so we re-attach
+ * it as event context instead of losing the only copy of the SQL.
+ */
+function getFailedQuery(error: unknown): string | undefined {
+  for (const candidate of [error, getOriginalError(error)]) {
+    if (candidate instanceof Error && messageLeaksQuery(candidate)) {
+      return candidate.message.slice(0, MAX_REPORTED_QUERY_LENGTH);
+    }
+  }
+  return undefined;
 }
 
 function unwrapCause(error: unknown): unknown {
@@ -63,8 +97,22 @@ export function maskDatabaseError(error: unknown): Error {
       // it lands on the tag even when the top-level error is the located
       // GraphQLError (whose own cause chain doesn't reach the driver error).
       const pgCode = getPostgresErrorCode(getOriginalError(error) ?? error);
+      // We still capture the unwrapped driver error, so Sentry's fingerprint (and
+      // therefore the existing issue's history) is unchanged — tags and extra do
+      // not affect grouping. But reporting the cause alone is what made
+      // BOARDSESH-AK an anonymous bucket that every resolver's DB failures fell
+      // into, with no way to tell which query blew up (#4105). Attach the field
+      // path and the SQL as event context. This is server-side only; the client
+      // still gets the generic message below, so #3183's info-leak fix holds.
+      const graphqlPath = getGraphqlPath(error);
+      const failedQuery = getFailedQuery(error);
       Sentry.captureException(unwrapCause(error), {
-        tags: { source: 'graphql-yoga-mask', pgCode: pgCode ?? 'unknown' },
+        tags: {
+          source: 'graphql-yoga-mask',
+          pgCode: pgCode ?? 'unknown',
+          ...(graphqlPath ? { graphqlPath } : {}),
+        },
+        ...(failedQuery ? { extra: { failedQuery } } : {}),
       });
       markErrorReported(error);
     }

--- a/packages/backend/src/graphql/resolvers/social/activity-feed.ts
+++ b/packages/backend/src/graphql/resolvers/social/activity-feed.ts
@@ -2,6 +2,7 @@ import { eq, and, desc, sql, or, isNull } from 'drizzle-orm';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
+import { withSerialPlan } from '@boardsesh/db/queries';
 import { requireAuthenticated, validateInput, isNoMatchClimb } from '../shared/helpers';
 import { ActivityFeedInputSchema } from '../../../validation/schemas';
 import { encodeCursor, decodeCursor } from '../../../utils/feed-cursor';
@@ -234,56 +235,62 @@ export const activityFeedQueries = {
     }
 
     const whereClause = and(...conditions);
-    const results = await db
-      .select({
-        tick: dbSchema.boardseshTicks,
-        userName: dbSchema.users.name,
-        userImage: dbSchema.users.image,
-        userDisplayName: dbSchema.userProfiles.displayName,
-        userAvatarUrl: dbSchema.userProfiles.avatarUrl,
-        climbName: dbSchema.boardClimbs.name,
-        climbDescription: dbSchema.boardClimbs.description,
-        setterUsername: dbSchema.boardClimbs.setterUsername,
-        layoutId: dbSchema.boardClimbs.layoutId,
-        frames: dbSchema.boardClimbs.frames,
-        difficultyName: dbSchema.boardDifficultyGrades.boulderName,
-      })
-      .from(dbSchema.boardseshTicks)
-      .innerJoin(dbSchema.users, eq(dbSchema.boardseshTicks.userId, dbSchema.users.id))
-      .leftJoin(dbSchema.userProfiles, eq(dbSchema.boardseshTicks.userId, dbSchema.userProfiles.userId))
-      // Resolve dedup-merged climbs to their canonical UUID before joining
-      // board_climbs. A tick may point at an alias UUID that was deduplicated
-      // away (no board_climbs row); the alias table maps it to the canonical.
-      // Ticks already on a canonical have no alias row, so COALESCE falls back to
-      // the tick's own climb_uuid. The PK (board_type, alias_uuid) keeps the join
-      // to ≤1 row, so it never fans out. Otherwise these ticks render "Unknown
-      // Climb" in the trending feed.
-      .leftJoin(
-        dbSchema.boardClimbAliases,
-        and(
-          eq(dbSchema.boardseshTicks.climbUuid, dbSchema.boardClimbAliases.aliasUuid),
-          eq(dbSchema.boardseshTicks.boardType, dbSchema.boardClimbAliases.boardType),
-        ),
-      )
-      .innerJoin(
-        dbSchema.boardClimbs,
-        and(
-          sql`COALESCE(${dbSchema.boardClimbAliases.canonicalUuid}, ${dbSchema.boardseshTicks.climbUuid}) = ${dbSchema.boardClimbs.uuid}`,
-          eq(dbSchema.boardseshTicks.boardType, dbSchema.boardClimbs.boardType),
-          sql`${dbSchema.boardClimbs.isDraft} IS NOT TRUE`,
-          sql`${dbSchema.boardClimbs.isListed} IS NOT FALSE`,
-        ),
-      )
-      .leftJoin(
-        dbSchema.boardDifficultyGrades,
-        and(
-          eq(dbSchema.boardseshTicks.difficulty, dbSchema.boardDifficultyGrades.difficulty),
-          eq(dbSchema.boardseshTicks.boardType, dbSchema.boardDifficultyGrades.boardType),
-        ),
-      )
-      .where(whereClause)
-      .orderBy(desc(dbSchema.boardseshTicks.climbedAt), desc(dbSchema.boardseshTicks.id))
-      .limit(limit + 1);
+    // board_climbs INNER JOIN boardsesh_ticks is two large tables with no
+    // selective predicate when no boardUuid is supplied — the planner picks a
+    // parallel hash join, and this feed is public, unauthenticated and rate-limit
+    // free, so a burst of home-screen loads can exhaust /dev/shm (#4105).
+    const results = await withSerialPlan(db, (tx) =>
+      tx
+        .select({
+          tick: dbSchema.boardseshTicks,
+          userName: dbSchema.users.name,
+          userImage: dbSchema.users.image,
+          userDisplayName: dbSchema.userProfiles.displayName,
+          userAvatarUrl: dbSchema.userProfiles.avatarUrl,
+          climbName: dbSchema.boardClimbs.name,
+          climbDescription: dbSchema.boardClimbs.description,
+          setterUsername: dbSchema.boardClimbs.setterUsername,
+          layoutId: dbSchema.boardClimbs.layoutId,
+          frames: dbSchema.boardClimbs.frames,
+          difficultyName: dbSchema.boardDifficultyGrades.boulderName,
+        })
+        .from(dbSchema.boardseshTicks)
+        .innerJoin(dbSchema.users, eq(dbSchema.boardseshTicks.userId, dbSchema.users.id))
+        .leftJoin(dbSchema.userProfiles, eq(dbSchema.boardseshTicks.userId, dbSchema.userProfiles.userId))
+        // Resolve dedup-merged climbs to their canonical UUID before joining
+        // board_climbs. A tick may point at an alias UUID that was deduplicated
+        // away (no board_climbs row); the alias table maps it to the canonical.
+        // Ticks already on a canonical have no alias row, so COALESCE falls back to
+        // the tick's own climb_uuid. The PK (board_type, alias_uuid) keeps the join
+        // to ≤1 row, so it never fans out. Otherwise these ticks render "Unknown
+        // Climb" in the trending feed.
+        .leftJoin(
+          dbSchema.boardClimbAliases,
+          and(
+            eq(dbSchema.boardseshTicks.climbUuid, dbSchema.boardClimbAliases.aliasUuid),
+            eq(dbSchema.boardseshTicks.boardType, dbSchema.boardClimbAliases.boardType),
+          ),
+        )
+        .innerJoin(
+          dbSchema.boardClimbs,
+          and(
+            sql`COALESCE(${dbSchema.boardClimbAliases.canonicalUuid}, ${dbSchema.boardseshTicks.climbUuid}) = ${dbSchema.boardClimbs.uuid}`,
+            eq(dbSchema.boardseshTicks.boardType, dbSchema.boardClimbs.boardType),
+            sql`${dbSchema.boardClimbs.isDraft} IS NOT TRUE`,
+            sql`${dbSchema.boardClimbs.isListed} IS NOT FALSE`,
+          ),
+        )
+        .leftJoin(
+          dbSchema.boardDifficultyGrades,
+          and(
+            eq(dbSchema.boardseshTicks.difficulty, dbSchema.boardDifficultyGrades.difficulty),
+            eq(dbSchema.boardseshTicks.boardType, dbSchema.boardDifficultyGrades.boardType),
+          ),
+        )
+        .where(whereClause)
+        .orderBy(desc(dbSchema.boardseshTicks.climbedAt), desc(dbSchema.boardseshTicks.id))
+        .limit(limit + 1),
+    );
 
     const hasMore = results.length > limit;
     const resultRows = hasMore ? results.slice(0, limit) : results;

--- a/packages/backend/src/graphql/resolvers/social/session-feed.ts
+++ b/packages/backend/src/graphql/resolvers/social/session-feed.ts
@@ -1,7 +1,7 @@
 import { eq, and, desc, sql, count as drizzleCount, isNull, inArray, type SQL } from 'drizzle-orm';
 import { dbRead } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
-import { getGradeLabel, toConfidenceTier } from '@boardsesh/db/queries';
+import { getGradeLabel, toConfidenceTier, withSerialPlan } from '@boardsesh/db/queries';
 import { rowsFromResult } from '@boardsesh/db/client';
 import { requireAuthenticated, validateInput, isNoMatchClimb } from '../shared/helpers';
 import { boardseshDifficultyExpr, boardseshConfidenceExpr, boardseshGradeTickJoin } from '../shared/sql-expressions';
@@ -311,7 +311,13 @@ export const sessionFeedQueries = {
         )
         `;
 
-      sessionRows = await dbRead.execute(sql`
+      // session_base hash-aggregates the ENTIRE boardsesh_ticks table by
+      // session_id whenever no user/board filter is set — i.e. the public home
+      // feed — and with daily highlights adds a second pass plus a window
+      // function. That is exactly the parallel-hash shape that exhausts /dev/shm,
+      // on an unauthenticated endpoint with no rate limit (#4105).
+      sessionRows = await withSerialPlan(dbRead, (tx) =>
+        tx.execute(sql`
         WITH
         ${eligibleUsersCte}
         ${eligibleSessionsCte}
@@ -359,7 +365,8 @@ export const sessionFeedQueries = {
         ORDER BY session_last_tick DESC
         OFFSET ${offset}
         LIMIT ${limit + 1}
-      `);
+      `),
+      );
     } catch (err) {
       logger.error('[sessionGroupedFeed] SQL error:', err);
       throw err;

--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -8,7 +8,7 @@ import {
 } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
-import { toConfidenceTier, notAuroraTwinDuplicate } from '@boardsesh/db/queries';
+import { toConfidenceTier, notAuroraTwinDuplicate, withSerialPlan } from '@boardsesh/db/queries';
 import { requireAuthenticated, applyRateLimit, validateInput, isNoMatchClimb } from '../shared/helpers';
 import {
   consensusDifficultyNameExpr,
@@ -1290,75 +1290,87 @@ export const tickQueries = {
         ne(dbSchema.boardseshTicks.status, 'attempt'),
       );
 
-      // Run three queries in parallel for this board type:
+      // Run three queries for this board type:
       // - gradeResults: counts per (layout, effective difficulty) for the chart
       // - distinctByLayout: per-layout distinct climb count (correct even when one
       //   climb appears across multiple grade buckets — e.g. logged at multiple
       //   angles whose consensus differs)
       // - distinctClimbs: global distinct climbs for `totalDistinctClimbs`
-      const [gradeResults, distinctByLayout, distinctClimbs] = await Promise.all([
-        db
-          .select({
-            layoutId: dbSchema.boardClimbs.layoutId,
-            difficulty: effectiveDifficultyExpr.as('effective_difficulty'),
-            distinctCount: sql<number>`count(distinct ${dbSchema.boardseshTicks.climbUuid})`.as('distinct_count'),
-          })
-          .from(dbSchema.boardseshTicks)
-          // Resolve dedup-merged climbs to their canonical UUID so the layout +
-          // stats lookups land on the canonical row. See the `ticks` resolver.
-          .leftJoin(
-            dbSchema.boardClimbAliases,
-            and(
-              eq(dbSchema.boardseshTicks.climbUuid, dbSchema.boardClimbAliases.aliasUuid),
-              eq(dbSchema.boardClimbAliases.boardType, boardType),
-            ),
-          )
-          .leftJoin(
-            dbSchema.boardClimbs,
-            and(
-              sql`COALESCE(${dbSchema.boardClimbAliases.canonicalUuid}, ${dbSchema.boardseshTicks.climbUuid}) = ${dbSchema.boardClimbs.uuid}`,
-              eq(dbSchema.boardClimbs.boardType, boardType),
-            ),
-          )
-          .leftJoin(
-            dbSchema.boardClimbStats,
-            and(
-              sql`COALESCE(${dbSchema.boardClimbAliases.canonicalUuid}, ${dbSchema.boardseshTicks.climbUuid}) = ${dbSchema.boardClimbStats.climbUuid}`,
-              eq(dbSchema.boardseshTicks.boardType, dbSchema.boardClimbStats.boardType),
-              eq(dbSchema.boardseshTicks.angle, dbSchema.boardClimbStats.angle),
-            ),
-          )
-          .where(baseConditions)
-          .groupBy(dbSchema.boardClimbs.layoutId, effectiveDifficultyExpr),
+      //
+      // All three run inside ONE withSerialPlan transaction per board type. This
+      // resolver fans out over every SUPPORTED_BOARDS entry, so it was issuing up
+      // to 21 concurrent aggregates over boardsesh_ticks ⋈ board_climbs ⋈
+      // board_climb_stats — the highest concurrent DSM demand in the codebase, and
+      // enough for a single profile load to exhaust /dev/shm (#4105). Sharing one
+      // transaction also caps concurrency at one connection per board type rather
+      // than three, which matters against a `max: 10` pool. Queries on a single
+      // postgres.js connection run sequentially, so this trades a little latency
+      // on the You page for not falling over.
+      const [gradeResults, distinctByLayout, distinctClimbs] = await withSerialPlan(db, (tx) =>
+        Promise.all([
+          tx
+            .select({
+              layoutId: dbSchema.boardClimbs.layoutId,
+              difficulty: effectiveDifficultyExpr.as('effective_difficulty'),
+              distinctCount: sql<number>`count(distinct ${dbSchema.boardseshTicks.climbUuid})`.as('distinct_count'),
+            })
+            .from(dbSchema.boardseshTicks)
+            // Resolve dedup-merged climbs to their canonical UUID so the layout +
+            // stats lookups land on the canonical row. See the `ticks` resolver.
+            .leftJoin(
+              dbSchema.boardClimbAliases,
+              and(
+                eq(dbSchema.boardseshTicks.climbUuid, dbSchema.boardClimbAliases.aliasUuid),
+                eq(dbSchema.boardClimbAliases.boardType, boardType),
+              ),
+            )
+            .leftJoin(
+              dbSchema.boardClimbs,
+              and(
+                sql`COALESCE(${dbSchema.boardClimbAliases.canonicalUuid}, ${dbSchema.boardseshTicks.climbUuid}) = ${dbSchema.boardClimbs.uuid}`,
+                eq(dbSchema.boardClimbs.boardType, boardType),
+              ),
+            )
+            .leftJoin(
+              dbSchema.boardClimbStats,
+              and(
+                sql`COALESCE(${dbSchema.boardClimbAliases.canonicalUuid}, ${dbSchema.boardseshTicks.climbUuid}) = ${dbSchema.boardClimbStats.climbUuid}`,
+                eq(dbSchema.boardseshTicks.boardType, dbSchema.boardClimbStats.boardType),
+                eq(dbSchema.boardseshTicks.angle, dbSchema.boardClimbStats.angle),
+              ),
+            )
+            .where(baseConditions)
+            .groupBy(dbSchema.boardClimbs.layoutId, effectiveDifficultyExpr),
 
-        db
-          .select({
-            layoutId: dbSchema.boardClimbs.layoutId,
-            distinctCount: sql<number>`count(distinct ${dbSchema.boardseshTicks.climbUuid})`.as('distinct_count'),
-          })
-          .from(dbSchema.boardseshTicks)
-          .leftJoin(
-            dbSchema.boardClimbAliases,
-            and(
-              eq(dbSchema.boardseshTicks.climbUuid, dbSchema.boardClimbAliases.aliasUuid),
-              eq(dbSchema.boardClimbAliases.boardType, boardType),
-            ),
-          )
-          .leftJoin(
-            dbSchema.boardClimbs,
-            and(
-              sql`COALESCE(${dbSchema.boardClimbAliases.canonicalUuid}, ${dbSchema.boardseshTicks.climbUuid}) = ${dbSchema.boardClimbs.uuid}`,
-              eq(dbSchema.boardClimbs.boardType, boardType),
-            ),
-          )
-          .where(baseConditions)
-          .groupBy(dbSchema.boardClimbs.layoutId),
+          tx
+            .select({
+              layoutId: dbSchema.boardClimbs.layoutId,
+              distinctCount: sql<number>`count(distinct ${dbSchema.boardseshTicks.climbUuid})`.as('distinct_count'),
+            })
+            .from(dbSchema.boardseshTicks)
+            .leftJoin(
+              dbSchema.boardClimbAliases,
+              and(
+                eq(dbSchema.boardseshTicks.climbUuid, dbSchema.boardClimbAliases.aliasUuid),
+                eq(dbSchema.boardClimbAliases.boardType, boardType),
+              ),
+            )
+            .leftJoin(
+              dbSchema.boardClimbs,
+              and(
+                sql`COALESCE(${dbSchema.boardClimbAliases.canonicalUuid}, ${dbSchema.boardseshTicks.climbUuid}) = ${dbSchema.boardClimbs.uuid}`,
+                eq(dbSchema.boardClimbs.boardType, boardType),
+              ),
+            )
+            .where(baseConditions)
+            .groupBy(dbSchema.boardClimbs.layoutId),
 
-        db
-          .selectDistinct({ climbUuid: dbSchema.boardseshTicks.climbUuid })
-          .from(dbSchema.boardseshTicks)
-          .where(baseConditions),
-      ]);
+          tx
+            .selectDistinct({ climbUuid: dbSchema.boardseshTicks.climbUuid })
+            .from(dbSchema.boardseshTicks)
+            .where(baseConditions),
+        ]),
+      );
 
       return { gradeResults, distinctByLayout, distinctClimbs, boardType };
     };

--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -1,6 +1,7 @@
 import { desc, sql, and, eq } from 'drizzle-orm';
 import type { DbInstance } from '../../client/postgres';
 import { boardClimbs, boardClimbStats, boardClimbGrades } from '../../schema/index';
+import { withSerialPlan } from '../util/serial-plan';
 import { createClimbFilters } from './create-climb-filters';
 import { getClimbStars } from './climb-stars';
 import { getGradeLabel } from './grade-lookup';
@@ -88,8 +89,6 @@ function mapResultToClimbRow(result: RawSelectResult, params: BoardRouteParams):
 
 type TransactionDb = Parameters<Parameters<DbInstance['transaction']>[0]>[0];
 type SearchDb = DbInstance | TransactionDb;
-type SearchDbTransaction = DbInstance['transaction'];
-type SearchDbExecute = (query: unknown) => Promise<unknown>;
 export type StatsDrivenSort = 'ascents' | 'quality';
 
 /**
@@ -110,16 +109,6 @@ export function getStatsDrivenSort(sortBy: string, sortOrder: 'asc' | 'desc'): S
   if (sortOrder !== 'desc') return null;
   if (sortBy === 'ascents' || sortBy === 'quality') return sortBy;
   return null;
-}
-
-function getTransaction(db: SearchDb): SearchDbTransaction | null {
-  const candidate = db as SearchDb & { transaction?: unknown };
-  return typeof candidate.transaction === 'function' ? (candidate.transaction.bind(db) as SearchDbTransaction) : null;
-}
-
-function getExecute(db: SearchDb): SearchDbExecute | null {
-  const candidate = db as SearchDb & { execute?: unknown };
-  return typeof candidate.execute === 'function' ? (candidate.execute.bind(db) as SearchDbExecute) : null;
 }
 
 /**
@@ -266,9 +255,8 @@ export function chooseSearchPath(input: {
  * stops after pageSize+1 qualifying rows — but with a narrow grade band + size
  * predicates + a larger pageSize + a page>0 OFFSET, the planner can still pick a
  * parallel plan, and each worker's DSM allocation can exhaust a small /dev/shm
- * (#3856). Disable per-gather parallelism inside a transaction (SET LOCAL needs
- * one; the pool runs prepare:false behind PgBouncer transaction pooling),
- * mirroring the standardSearch / countClimbs / getHoldHeatmapData guards.
+ * (#3856). `withSerialPlan` disables per-gather parallelism inside a transaction,
+ * the same guard standardSearch / countClimbs / getSetterStats use.
  *
  * The INNER JOIN excludes climbs without a stats row at this angle. The caller
  * (`searchClimbs`) compensates on any page without stats filters, whenever this
@@ -287,24 +275,7 @@ async function statsDrivenSearch(
   page: number,
   pageSize: number,
 ): Promise<ClimbSearchResult> {
-  const transaction = getTransaction(db);
-  if (transaction) {
-    return transaction(async (transactionDb) => {
-      await transactionDb.execute(sql`SET LOCAL max_parallel_workers_per_gather = 0`);
-      return runStatsDrivenSearch(transactionDb, params, filters, sortBy, page, pageSize);
-    });
-  }
-
-  // Reached only by execute-only query test doubles. Production call sites pass
-  // top-level DbInstance values so the transaction branch scopes SET LOCAL
-  // correctly; do not broaden searchClimbs to TransactionDb without revisiting
-  // that planner guard.
-  const execute = getExecute(db);
-  if (execute) {
-    await execute(sql`SET LOCAL max_parallel_workers_per_gather = 0`);
-  }
-
-  return runStatsDrivenSearch(db, params, filters, sortBy, page, pageSize);
+  return withSerialPlan(db, (tx) => runStatsDrivenSearch(tx, params, filters, sortBy, page, pageSize));
 }
 
 async function runStatsDrivenSearch(
@@ -412,45 +383,19 @@ async function standardSearch(
   pageSize: number,
   orderStatsHavingFirst: boolean,
 ): Promise<ClimbSearchResult> {
-  const transaction = getTransaction(db);
-  if (transaction) {
-    return transaction(async (transactionDb) => {
-      await transactionDb.execute(sql`SET LOCAL max_parallel_workers_per_gather = 0`);
-      return runStandardSearch(
-        transactionDb,
-        params,
-        searchParams,
-        filters,
-        sortBy,
-        sortOrder,
-        isDraftsQuery,
-        page,
-        pageSize,
-        orderStatsHavingFirst,
-      );
-    });
-  }
-
-  // Reached only by execute-only query test doubles. Production call sites pass
-  // top-level DbInstance values so the transaction branch scopes SET LOCAL
-  // correctly; do not broaden searchClimbs to TransactionDb without revisiting
-  // that planner guard.
-  const execute = getExecute(db);
-  if (execute) {
-    await execute(sql`SET LOCAL max_parallel_workers_per_gather = 0`);
-  }
-
-  return runStandardSearch(
-    db,
-    params,
-    searchParams,
-    filters,
-    sortBy,
-    sortOrder,
-    isDraftsQuery,
-    page,
-    pageSize,
-    orderStatsHavingFirst,
+  return withSerialPlan(db, (tx) =>
+    runStandardSearch(
+      tx,
+      params,
+      searchParams,
+      filters,
+      sortBy,
+      sortOrder,
+      isDraftsQuery,
+      page,
+      pageSize,
+      orderStatsHavingFirst,
+    ),
   );
 }
 

--- a/packages/db/src/queries/climbs/setter-stats.ts
+++ b/packages/db/src/queries/climbs/setter-stats.ts
@@ -1,6 +1,7 @@
 import { and, eq, ilike, sql } from 'drizzle-orm';
 import type { DbInstance } from '../../client/postgres';
 import { boardClimbs, boardClimbStats } from '../../schema/index';
+import { withSerialPlan } from '../util/serial-plan';
 import type { BoardRouteParams } from './types';
 
 /**
@@ -23,6 +24,13 @@ export type SetterStat = {
  * setter usernames with a case-insensitive substring match for autocomplete.
  *
  * Capped at 50 rows ordered by descending climb count for UI performance.
+ *
+ * Runs under `withSerialPlan`: this hash-joins the two biggest catalog tables
+ * over a whole layout and aggregates them, which the planner is happy to run as
+ * a parallel hash join. It fires from the same search drawer as `searchClimbs`
+ * on the same table pair, so it kept exhausting `/dev/shm` after #3856 guarded
+ * the search paths themselves (#4105). The LIMIT 50 applies after the GROUP BY,
+ * so it does not bound the scan.
  */
 export const getSetterStats = async (
   db: DbInstance,
@@ -42,20 +50,22 @@ export const getSetterStats = async (
     whereConditions.push(ilike(boardClimbs.setterUsername, `%${searchQuery}%`));
   }
 
-  const result = await db
-    .select({
-      setter_username: boardClimbs.setterUsername,
-      climb_count: sql<number>`count(*)::int`,
-    })
-    .from(boardClimbs)
-    .innerJoin(
-      boardClimbStats,
-      and(eq(boardClimbStats.climbUuid, boardClimbs.uuid), eq(boardClimbStats.boardType, params.board_name)),
-    )
-    .where(and(...whereConditions))
-    .groupBy(boardClimbs.setterUsername)
-    .orderBy(sql`count(*) DESC`)
-    .limit(50);
+  const result = await withSerialPlan(db, (tx) =>
+    tx
+      .select({
+        setter_username: boardClimbs.setterUsername,
+        climb_count: sql<number>`count(*)::int`,
+      })
+      .from(boardClimbs)
+      .innerJoin(
+        boardClimbStats,
+        and(eq(boardClimbStats.climbUuid, boardClimbs.uuid), eq(boardClimbStats.boardType, params.board_name)),
+      )
+      .where(and(...whereConditions))
+      .groupBy(boardClimbs.setterUsername)
+      .orderBy(sql`count(*) DESC`)
+      .limit(50),
+  );
 
   // Strip any nulls — they're filtered out in the WHERE clause but the
   // column is nullable in the schema so TS doesn't know that.

--- a/packages/db/src/queries/index.ts
+++ b/packages/db/src/queries/index.ts
@@ -16,3 +16,4 @@ export * from './grade-model/index';
 export * from './sessions/index';
 export * from './ticks/index';
 export * from './util/rows';
+export * from './util/serial-plan';

--- a/packages/db/src/queries/util/serial-plan.ts
+++ b/packages/db/src/queries/util/serial-plan.ts
@@ -1,0 +1,70 @@
+import { sql } from 'drizzle-orm';
+import type { DbInstance } from '../../client/postgres';
+
+/**
+ * A drizzle transaction handle, derived from `DbInstance` so this stays in step
+ * with the schema-typed client instead of hand-rolling the shape.
+ */
+type TransactionDb = Parameters<Parameters<DbInstance['transaction']>[0]>[0];
+
+/** A top-level drizzle client, an open transaction, or an execute-only test double. */
+export type SerialPlanDb = DbInstance | TransactionDb;
+
+type SerialPlanTransaction = DbInstance['transaction'];
+type SerialPlanExecute = (query: unknown) => Promise<unknown>;
+
+/** The statement every guarded query runs before its SELECT. Exported for tests. */
+export const SERIAL_PLAN_STATEMENT = 'SET LOCAL max_parallel_workers_per_gather = 0';
+
+function getTransaction(db: SerialPlanDb): SerialPlanTransaction | null {
+  const candidate = db as SerialPlanDb & { transaction?: unknown };
+  return typeof candidate.transaction === 'function' ? (candidate.transaction.bind(db) as SerialPlanTransaction) : null;
+}
+
+function getExecute(db: SerialPlanDb): SerialPlanExecute | null {
+  const candidate = db as SerialPlanDb & { execute?: unknown };
+  return typeof candidate.execute === 'function' ? (candidate.execute.bind(db) as SerialPlanExecute) : null;
+}
+
+/**
+ * Run `query` with per-gather parallelism disabled.
+ *
+ * Postgres allocates a dynamic-shared-memory segment per parallel worker. On a
+ * container with a small `/dev/shm` (our Railway Postgres), a handful of
+ * concurrent parallel plans exhaust the budget and the driver raises
+ * `could not resize shared memory segment ... No space left on device`
+ * (pgCode 53100) — issues #1969, #2378, #3856, #4105. The failure mode is a
+ * *parallel hash join*: the shared hash table grows its DSA segment by doubling
+ * (1 MB → 2 MB → 4 MB), which is exactly the segment-size ladder those incidents
+ * report.
+ *
+ * `SET LOCAL` needs a transaction, and the pool runs `prepare: false` behind
+ * PgBouncer transaction pooling, so the guard has to open one explicitly rather
+ * than relying on a session-level `SET` (PgBouncer's `DISCARD ALL` on release
+ * would wipe it, and it could leak across clients before it did).
+ *
+ * Apply this to reads that hash-join two large tables (`board_climbs`,
+ * `board_climb_stats`, `boardsesh_ticks`) or aggregate across one. A plan that
+ * was already serial is unaffected; a plan that was parallel runs single-threaded,
+ * which cannot change results — only, at worst, latency.
+ *
+ * The execute-only fallback exists for query test doubles that expose `execute`
+ * but not `transaction`; production call sites always pass a real client, so the
+ * transaction branch is what scopes `SET LOCAL` correctly.
+ */
+export async function withSerialPlan<T>(db: SerialPlanDb, query: (tx: SerialPlanDb) => Promise<T>): Promise<T> {
+  const transaction = getTransaction(db);
+  if (transaction) {
+    return transaction(async (transactionDb) => {
+      await transactionDb.execute(sql`SET LOCAL max_parallel_workers_per_gather = 0`);
+      return query(transactionDb);
+    });
+  }
+
+  const execute = getExecute(db);
+  if (execute) {
+    await execute(sql`SET LOCAL max_parallel_workers_per_gather = 0`);
+  }
+
+  return query(db);
+}


### PR DESCRIPTION
## What this fixes

Postgres parallel-query shared-memory exhaustion kept hitting `POST /graphql` after #3856:

```
PostgresError: could not resize shared memory segment "/PostgreSQL.3299586270"
to 2097152 bytes: No space left on device
```

The issue asked which *other* query was still unguarded. Investigating it turned up something more useful: **we couldn't name the query because our own error handler throws the evidence away.**

`packages/backend/src/graphql/mask-error.ts` reports `unwrapCause(error)` — the bare `PostgresError`. drizzle surfaces a driver failure as an Error whose `.message` *is* the SQL (`Failed query: select ...`) with the real `PostgresError` on `.cause`, so capturing the cause alone drops the only copy of the query text and the resolver identity.

That explains the whole timeline in the issue:

- **BOARDSESH-AJ** (has SQL) comes from a different path — `logger.error('Error in searchClimbs:', error)` at `packages/backend/src/db/queries/climbs/search-climbs.ts:33`, where the winston→Sentry transport captures the *wrapper*. Only two query wrappers in the repo do that (`searchClimbs`, `countClimbs`). #3856 fixed exactly those paths, so AJ went quiet.
- **BOARDSESH-AK** (no SQL) is the masked-error grouping. It is not one query — it is a **catch-all bucket that every resolver's DB failures fall into**. That's why it didn't stop, and why the event counts differ (AK 292 > AJ 135).

So "find the one remaining path" was the wrong frame. A sweep of every resolver found **~50 parallel-eligible queries** reachable from `POST /graphql` against **3** guarded call sites.

## Part 1 — stop discarding the evidence

Keep capturing the cause, so Sentry's fingerprint and BOARDSESH-AK's history are unchanged (tags and extra don't affect grouping), but attach:

- `graphqlPath` tag — the located `GraphQLError.path`, e.g. `searchClimbs.totalCount`. Names the offending resolver.
- `failedQuery` extra — drizzle's wrapper message, truncated to 2000 chars so a pathological `IN (...)` list can't blow the event past Sentry's size limit.

Server-side only. The client still gets the generic masked message, so #3183's info-leak fix is intact — and that's now asserted explicitly rather than implied.

## Part 2 — guard the parallel-hash-join paths

The segment sizes in the issue (1 MB → 2 MB → 4 MB) are the DSA doubling signature of a **parallel hash join** growing its shared hash table. That narrows the suspects to queries hash-joining two large tables, which is how these four were picked:

| Query | Shape | Why it survived #3856 |
|---|---|---|
| `getSetterStats` | `board_climbs ⋈ board_climb_stats` over a whole layout, `GROUP BY setter_username` | Fires from the **same search drawer** as `searchClimbs`, on the **same table pair**. #3856 guarded the search; this kept firing beside it. |
| `trendingFeed` | `boardsesh_ticks ⋈ board_climbs` | Public, unauthenticated, no rate limit, home screen. |
| `sessionGroupedFeed` | hash-aggregates the **entire** ticks table by `session_id` | Public home feed; with daily highlights adds a second pass plus a window function. |
| `userProfileStats` | ticks ⋈ aliases ⋈ climbs ⋈ stats, fanned out per board | Was issuing **up to 21 concurrent aggregates in a single request** — enough for one profile load to exhaust `/dev/shm` on its own. |

Rather than a fourth copy of the same block, the `SET LOCAL max_parallel_workers_per_gather = 0` guard that #1969/#3856 duplicated across three call sites is extracted into `withSerialPlan` (`packages/db/src/queries/util/serial-plan.ts`), and the three existing sites now use it too. One named concept instead of five hand-rolled transactions.

`userProfileStats` runs its three per-board queries inside **one** transaction rather than three, which also caps concurrency at one connection per board type instead of three — the pool is `max: 10`.

Disabling per-gather parallelism cannot change results. A plan that was already serial is unaffected; a plan that was parallel runs single-threaded.

## Why not set it pool-wide (the issue's fix-direction #2)

Tempting, and I tried to make it work — but it's an outage risk we can't discharge from here, so recording the reasoning rather than leaving it silent:

- postgres.js has no `onconnect` hook. The only pool-level route is the `connection: {}` **startup packet**.
- PgBouncer ≥1.21 **rejects unknown startup parameters and fails the connection** unless they're in `track_extra_parameters`.
- We don't know whether a pooler is even in front of prod. `docs/neon-migration.md:48` still carries the open TODO: *"confirm whether the Railway plan exposes a managed pooled URL out of the box, or whether you need to deploy the bitnami/pgbouncer template."*

If that resolves to "no pooler" or "pooler with the param tracked", the one-line pool change beats everything here and I'd happily follow up. Shipping it blind on a P1 trades intermittent 500s for a total outage.

A **role-level** setting avoids the startup-packet problem entirely and survives PgBouncer's `DISCARD ALL` (because `RESET ALL` restores role defaults) — see the checklist below. That one is a prod write, so it's your call, not something this PR does.

## For @marcodejongh — read-only prod checks

All `SHOW`/`SELECT`, nothing mutating. I did not run any of these.

```sql
-- 1. Confirm the current setting and the parallel budget
SHOW max_parallel_workers_per_gather;
SHOW max_parallel_workers;
SHOW work_mem;
SHOW dynamic_shared_memory_type;

-- 2. Which role the app connects as (needed for the ALTER ROLE option below)
SELECT current_user, session_user;

-- 3. The ranked-suspect list, checked against reality.
--    Look for plans joining boardsesh_ticks / board_climbs / board_climb_stats.
SELECT calls, total_exec_time, mean_exec_time, left(query, 200) AS query
FROM pg_stat_statements
ORDER BY total_exec_time DESC
LIMIT 30;
```

Also worth an eyeball outside SQL: `df -h /dev/shm` on the Postgres container. The DSA doubling ladder (1 → 2 → 4 MB) in the Sentry events is a parallel hash join growing its shared hash table, so the budget matters as much as the number of parallel plans.

**Optional one-liner that kills the whole class:**

```sql
ALTER ROLE <app_role> SET max_parallel_workers_per_gather = 0;
```

Tradeoff, stated plainly: it closes every unguarded path at once and survives PgBouncer connection reuse, but it disables parallelism for **everything that role does** — including the nightly board-snapshot export and the sync daemons, which genuinely benefit from parallel scans. If those share the app role, prefer a separate role for the batch jobs before doing this.

## Residual monitoring

This does not claim to have zeroed BOARDSESH-AK. Four of ~50 candidate paths are guarded, chosen on plan shape and traffic. The point of Part 1 is that the **next** occurrence arrives with a resolver name and its SQL attached, so the remaining tail gets closed with evidence instead of ranking. Given it fires in bursts, a week of quiet is the realistic signal — and if it does fire, the event will say exactly where.

## Testing

- `packages/backend/src/__tests__/serial-plan-guard.test.ts` (new) — `withSerialPlan` opens a transaction, issues the guard *before* the query, runs the query on the transaction handle rather than the outer one, propagates failures, and falls back correctly for execute-only doubles; plus `getSetterStats` coverage on both the plain and ILIKE-autocomplete branches.
- `packages/backend/src/__tests__/mask-error.test.ts` (extended) — field path tagged, SQL attached, cause still captured (grouping continuity), truncation at 2000 chars, path tag omitted when absent, **and the SQL never reaches the client even though it's on the Sentry event**.
- These live in the backend suite deliberately: `packages/db` runs on node's test runner and isn't wired into CI, so a guard test next to the query would never gate a PR.
- Verified load-bearing by mutation: removing the guard and the SQL attachment turns 6 of them red.
- `vp run typecheck:backend`, full `vp test run --project backend`, `vp check` — the only `vp check` errors are pre-existing `@gorhom/bottom-sheet` resolution in the mobile web-runtime nested install, untouched here.

## Release Notes

- [x] No release note needed (internal / technical change)

Closes #4105
