### PR TITLE
fix(sync): keep empty-response writes pending

### DIFF
--- a/packages/mobile/src/lib/__tests__/error-reporting.test.ts
+++ b/packages/mobile/src/lib/__tests__/error-reporting.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { GRAPHQL_EMPTY_RESPONSE_ERROR_NAME } from '@boardsesh/offline-sync/error-classification';
 import { reportError, reportHandledError } from '../error-reporting';
 import { captureToSentry } from '../sentry';
 
@@ -159,7 +160,7 @@ describe('reportHandledError', () => {
 
   it('downgrades a GraphQLEmptyResponseError (2xx with an empty/truncated body) to a warning tagged network (#3190)', () => {
     const emptyBody = Object.assign(new Error('GraphQL response body was empty or not valid JSON (HTTP 200)'), {
-      name: 'GraphQLEmptyResponseError',
+      name: GRAPHQL_EMPTY_RESPONSE_ERROR_NAME,
     });
     reportHandledError(emptyBody, { tags: { source: 'react-query', kind: 'query' } });
     expect(mockedCaptureToSentry).toHaveBeenCalledWith(emptyBody, {

--- a/packages/mobile/src/lib/error-reporting.ts
+++ b/packages/mobile/src/lib/error-reporting.ts
@@ -40,7 +40,7 @@ function isCancellation(error: unknown): boolean {
  *     `response.status` (a `response` present but with a non-numeric status);
  *   - our GraphQL client throws a typed `GraphQLEmptyResponseError` (see
  *     `./graphql/client.ts`) when a nominally-2xx response body arrives empty or
- *     truncated — the same offline blip signature, just caught a layer up (#3190);
+ *     truncated; the shared classifier treats its stable name as transport-shaped;
  *   - every other transport rejection — RN's `TypeError: Network request failed`,
  *     the WinterCG `Error: "fetch failed: <cause>"` wrapper (graphql-ws HTTP),
  *     Android `UnknownHostException`, and bare iOS NSURLError descriptions — is
@@ -50,8 +50,6 @@ function isCancellation(error: unknown): boolean {
  */
 function isNetworkError(error: unknown): boolean {
   if (typeof error !== 'object' || error === null) return false;
-  const name = (error as { name?: unknown }).name;
-  if (name === 'GraphQLEmptyResponseError') return true;
   const response = (error as { response?: unknown }).response;
   // Preserve statusless ClientError as a transport signal while allowing a
   // status nested in response.errors[].extensions to win over message prose.

--- a/packages/mobile/src/lib/graphql/__tests__/client.test.ts
+++ b/packages/mobile/src/lib/graphql/__tests__/client.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
-import { getErrorStatus, isNetworkError } from '@boardsesh/offline-sync/error-classification';
+import {
+  GRAPHQL_EMPTY_RESPONSE_ERROR_NAME,
+  getErrorStatus,
+  isNetworkError,
+} from '@boardsesh/offline-sync/error-classification';
 
 // The guard wraps authenticatedFetch — mock it directly so we can hand back
 // whatever Response shape the test wants without touching auth/token plumbing
@@ -56,7 +60,7 @@ describe('graphqlFetchWithEmptyBodyGuard', () => {
     const request = graphqlFetchWithEmptyBodyGuard('https://api.example.com/graphql');
 
     await expect(request).rejects.toMatchObject({
-      name: 'GraphQLEmptyResponseError',
+      name: GRAPHQL_EMPTY_RESPONSE_ERROR_NAME,
       message: expect.stringContaining('200'),
       status: 200,
     });

--- a/packages/mobile/src/lib/graphql/__tests__/client.test.ts
+++ b/packages/mobile/src/lib/graphql/__tests__/client.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { getErrorStatus, isNetworkError } from '@boardsesh/offline-sync/error-classification';
 
 // The guard wraps authenticatedFetch — mock it directly so we can hand back
 // whatever Response shape the test wants without touching auth/token plumbing
@@ -49,13 +50,20 @@ describe('graphqlFetchWithEmptyBodyGuard', () => {
     );
   });
 
-  it('names the thrown error GraphQLEmptyResponseError and includes the HTTP status', async () => {
+  it('keeps the 2xx status while classifying the typed empty response as a network stop', async () => {
     mockAuthenticatedFetch.mockResolvedValue(new Response('', { status: 200 }));
 
-    await expect(graphqlFetchWithEmptyBodyGuard('https://api.example.com/graphql')).rejects.toMatchObject({
+    const request = graphqlFetchWithEmptyBodyGuard('https://api.example.com/graphql');
+
+    await expect(request).rejects.toMatchObject({
       name: 'GraphQLEmptyResponseError',
       message: expect.stringContaining('200'),
+      status: 200,
     });
+
+    const error = new GraphQLEmptyResponseError(200);
+    expect(getErrorStatus(error)).toBe(200);
+    expect(isNetworkError(error)).toBe(true);
   });
 
   it('passes a valid JSON object body straight through untouched', async () => {

--- a/packages/mobile/src/lib/graphql/client.ts
+++ b/packages/mobile/src/lib/graphql/client.ts
@@ -12,14 +12,17 @@ export function getGraphQLHttpUrl(): string {
  * committed, body truncated) rather than a real GraphQL answer. Common on
  * flaky mobile networks going offline mid-request (#3190).
  *
- * `name` is checked by `isNetworkError` in `../error-reporting.ts` so this
- * gets the same "warning, tagged network" Sentry treatment as other
- * transport failures instead of showing up as a raw crash.
+ * `name` is checked by the shared offline-sync classifier so this gets the
+ * same network-stop treatment in the mutation drainer and the same
+ * "warning, tagged network" Sentry treatment as other transport failures.
  */
 export class GraphQLEmptyResponseError extends Error {
+  readonly status: number;
+
   constructor(status: number) {
     super(`GraphQL response body was empty or not valid JSON (HTTP ${status})`);
     this.name = 'GraphQLEmptyResponseError';
+    this.status = status;
   }
 }
 

--- a/packages/mobile/src/lib/graphql/client.ts
+++ b/packages/mobile/src/lib/graphql/client.ts
@@ -1,4 +1,5 @@
 import { GraphQLClient } from 'graphql-request';
+import { GRAPHQL_EMPTY_RESPONSE_ERROR_NAME } from '@boardsesh/offline-sync/error-classification';
 import { authenticatedFetch } from '../auth-interceptor';
 import { BACKEND_URL } from '../env';
 
@@ -21,7 +22,7 @@ export class GraphQLEmptyResponseError extends Error {
 
   constructor(status: number) {
     super(`GraphQL response body was empty or not valid JSON (HTTP ${status})`);
-    this.name = 'GraphQLEmptyResponseError';
+    this.name = GRAPHQL_EMPTY_RESPONSE_ERROR_NAME;
     this.status = status;
   }
 }

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -50,7 +50,12 @@ export type { DrainOptions } from './mutation-queue/drainer';
 export { ensureMutationQueueTable, MUTATION_QUEUE_SCHEMA } from './mutation-queue/schema';
 export { processMutation } from './mutation-queue/handlers';
 export type { GraphQLFetch } from './mutation-queue/handlers';
-export { isRetryable, isNetworkError, getErrorStatus } from './mutation-queue/error-classification';
+export {
+  GRAPHQL_EMPTY_RESPONSE_ERROR_NAME,
+  isRetryable,
+  isNetworkError,
+  getErrorStatus,
+} from './mutation-queue/error-classification';
 
 // --- Pull sync -----------------------------------------------------------------
 export { pullSync, toSqliteValue, multiRowChunkSize } from './sync/pull-client';

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer-empty-response.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer-empty-response.test.ts
@@ -14,6 +14,7 @@ vi.mock('../handlers', () => ({
 }));
 
 import { __resetDrainerStateForTests, drainMutationQueue } from '../drainer';
+import { GRAPHQL_EMPTY_RESPONSE_ERROR_NAME } from '../error-classification';
 import { processMutation } from '../handlers';
 import { markCompleted, markDeadLetter, peekPending, recordFailure } from '../queue';
 
@@ -55,7 +56,7 @@ describe('drainMutationQueue with the real error classifier', () => {
     const emptyResponseError = Object.assign(
       new Error('GraphQL response body was empty or not valid JSON (HTTP 200)'),
       {
-        name: 'GraphQLEmptyResponseError',
+        name: GRAPHQL_EMPTY_RESPONSE_ERROR_NAME,
         status: 200,
       },
     );
@@ -65,6 +66,7 @@ describe('drainMutationQueue with the real error classifier', () => {
 
     await drainMutationQueue(mockDb, queryClient, graphqlFetch, { isOnline: () => true });
 
+    expect(mockPeekPending).toHaveBeenCalledWith(mockDb, 10);
     expect(mockProcessMutation).toHaveBeenCalledOnce();
     expect(mockRecordFailure).not.toHaveBeenCalled();
     expect(mockMarkDeadLetter).not.toHaveBeenCalled();

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer-empty-response.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer-empty-response.test.ts
@@ -13,7 +13,7 @@ vi.mock('../handlers', () => ({
   processMutation: vi.fn(),
 }));
 
-import { __resetDrainerStateForTests, drainMutationQueue } from '../drainer';
+import { __resetDrainerStateForTests, drainMutationQueue, setBackgrounded, setSigningOut } from '../drainer';
 import { GRAPHQL_EMPTY_RESPONSE_ERROR_NAME } from '../error-classification';
 import { processMutation } from '../handlers';
 import { markCompleted, markDeadLetter, peekPending, recordFailure } from '../queue';
@@ -30,7 +30,7 @@ const queryClient = {
 } as unknown as QueryInvalidator;
 const graphqlFetch = vi.fn().mockResolvedValue({});
 
-function makeMutation(): PendingMutation {
+function makeMutation(overrides: Partial<PendingMutation> = {}): PendingMutation {
   return {
     id: 1,
     table_name: 'boardsesh_ticks',
@@ -42,7 +42,15 @@ function makeMutation(): PendingMutation {
     max_retries: 10,
     last_error: null,
     status: 'pending',
+    ...overrides,
   };
+}
+
+function makeEmptyResponseError(): Error {
+  return Object.assign(new Error('GraphQL response body was empty or not valid JSON (HTTP 200)'), {
+    name: GRAPHQL_EMPTY_RESPONSE_ERROR_NAME,
+    status: 200,
+  });
 }
 
 describe('drainMutationQueue with the real error classifier', () => {
@@ -51,25 +59,157 @@ describe('drainMutationQueue with the real error classifier', () => {
     __resetDrainerStateForTests();
   });
 
-  it('leaves a mutation pending when its 2xx GraphQL response body is truncated', async () => {
+  it('retries an empty 2xx response in-cycle and completes without failure bookkeeping', async () => {
     const mutation = makeMutation();
-    const emptyResponseError = Object.assign(
-      new Error('GraphQL response body was empty or not valid JSON (HTTP 200)'),
-      {
-        name: GRAPHQL_EMPTY_RESPONSE_ERROR_NAME,
-        status: 200,
-      },
-    );
+    const sleep = vi.fn().mockResolvedValue(undefined);
 
-    mockPeekPending.mockResolvedValueOnce([mutation]);
-    mockProcessMutation.mockRejectedValueOnce(emptyResponseError);
+    mockPeekPending.mockResolvedValueOnce([mutation]).mockResolvedValueOnce([mutation]).mockResolvedValueOnce([]);
+    mockProcessMutation.mockRejectedValueOnce(makeEmptyResponseError()).mockResolvedValueOnce(undefined);
 
-    await drainMutationQueue(mockDb, queryClient, graphqlFetch, { isOnline: () => true });
+    await drainMutationQueue(mockDb, queryClient, graphqlFetch, {
+      isOnline: () => true,
+      sleep,
+      maxCycleAttempts: 3,
+    });
 
     expect(mockPeekPending).toHaveBeenCalledWith(mockDb, 10);
-    expect(mockProcessMutation).toHaveBeenCalledOnce();
+    expect(mockPeekPending).toHaveBeenCalledTimes(3);
+    expect(mockProcessMutation).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledOnce();
+    expect(mockRecordFailure).not.toHaveBeenCalled();
+    expect(mockMarkDeadLetter).not.toHaveBeenCalled();
+    expect(mockMarkCompleted).toHaveBeenCalledOnce();
+    expect(mockMarkCompleted).toHaveBeenCalledWith(mockDb, mutation.id);
+  });
+
+  it('bounds persistent empty responses without advancing to a later FIFO row', async () => {
+    const firstMutation = makeMutation({ id: 1, idempotency_key: 'tick-key-1' });
+    const laterMutation = makeMutation({ id: 2, idempotency_key: 'tick-key-2' });
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const maxCycleAttempts = 3;
+
+    mockPeekPending.mockResolvedValue([firstMutation, laterMutation]);
+    mockProcessMutation.mockRejectedValue(makeEmptyResponseError());
+
+    await drainMutationQueue(mockDb, queryClient, graphqlFetch, {
+      isOnline: () => true,
+      sleep,
+      maxCycleAttempts,
+    });
+
+    expect(mockProcessMutation).toHaveBeenCalledTimes(maxCycleAttempts + 1);
+    expect(mockProcessMutation.mock.calls.every(([mutation]) => mutation === firstMutation)).toBe(true);
+    expect(mockPeekPending).toHaveBeenCalledTimes(maxCycleAttempts + 1);
+    expect(sleep).toHaveBeenCalledTimes(maxCycleAttempts);
     expect(mockRecordFailure).not.toHaveBeenCalled();
     expect(mockMarkDeadLetter).not.toHaveBeenCalled();
     expect(mockMarkCompleted).not.toHaveBeenCalled();
+  });
+
+  it('does not sleep or re-peek when the empty-response retry budget is zero', async () => {
+    const mutation = makeMutation();
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    mockPeekPending.mockResolvedValue([mutation]);
+    mockProcessMutation.mockRejectedValue(makeEmptyResponseError());
+
+    await drainMutationQueue(mockDb, queryClient, graphqlFetch, {
+      isOnline: () => true,
+      sleep,
+      maxCycleAttempts: 0,
+    });
+
+    expect(mockPeekPending).toHaveBeenCalledOnce();
+    expect(mockProcessMutation).toHaveBeenCalledOnce();
+    expect(sleep).not.toHaveBeenCalled();
+    expect(mockRecordFailure).not.toHaveBeenCalled();
+    expect(mockMarkDeadLetter).not.toHaveBeenCalled();
+    expect(mockMarkCompleted).not.toHaveBeenCalled();
+  });
+
+  it('stops immediately on an ordinary transport failure', async () => {
+    const mutation = makeMutation();
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    mockPeekPending.mockResolvedValueOnce([mutation]);
+    mockProcessMutation.mockRejectedValueOnce(new TypeError('Network request failed'));
+
+    await drainMutationQueue(mockDb, queryClient, graphqlFetch, {
+      isOnline: () => true,
+      sleep,
+      maxCycleAttempts: 3,
+    });
+
+    expect(mockProcessMutation).toHaveBeenCalledOnce();
+    expect(mockPeekPending).toHaveBeenCalledOnce();
+    expect(sleep).not.toHaveBeenCalled();
+    expect(mockRecordFailure).not.toHaveBeenCalled();
+    expect(mockMarkDeadLetter).not.toHaveBeenCalled();
+  });
+
+  it('does not retry after a sign-out starts and completes during empty-response backoff', async () => {
+    const mutation = makeMutation();
+    const sleep = vi.fn().mockImplementation(async () => {
+      setSigningOut(true);
+      setSigningOut(false);
+    });
+
+    mockPeekPending.mockResolvedValue([mutation]);
+    mockProcessMutation.mockRejectedValue(makeEmptyResponseError());
+
+    await drainMutationQueue(mockDb, queryClient, graphqlFetch, {
+      isOnline: () => true,
+      sleep,
+      maxCycleAttempts: 3,
+    });
+
+    expect(mockProcessMutation).toHaveBeenCalledOnce();
+    expect(sleep).toHaveBeenCalledOnce();
+    expect(mockRecordFailure).not.toHaveBeenCalled();
+  });
+
+  it('does not retry after the app backgrounds during empty-response backoff', async () => {
+    const mutation = makeMutation();
+    const sleep = vi.fn().mockImplementation(async () => {
+      setBackgrounded(true);
+    });
+
+    mockPeekPending.mockResolvedValue([mutation]);
+    mockProcessMutation.mockRejectedValue(makeEmptyResponseError());
+
+    try {
+      await drainMutationQueue(mockDb, queryClient, graphqlFetch, {
+        isOnline: () => true,
+        sleep,
+        maxCycleAttempts: 3,
+      });
+
+      expect(mockProcessMutation).toHaveBeenCalledOnce();
+      expect(sleep).toHaveBeenCalledOnce();
+      expect(mockRecordFailure).not.toHaveBeenCalled();
+    } finally {
+      setBackgrounded(false);
+    }
+  });
+
+  it('does not retry after connectivity drops during empty-response backoff', async () => {
+    const mutation = makeMutation();
+    let isOnline = true;
+    const sleep = vi.fn().mockImplementation(async () => {
+      isOnline = false;
+    });
+
+    mockPeekPending.mockResolvedValue([mutation]);
+    mockProcessMutation.mockRejectedValue(makeEmptyResponseError());
+
+    await drainMutationQueue(mockDb, queryClient, graphqlFetch, {
+      isOnline: () => isOnline,
+      sleep,
+      maxCycleAttempts: 3,
+    });
+
+    expect(mockProcessMutation).toHaveBeenCalledOnce();
+    expect(sleep).toHaveBeenCalledOnce();
+    expect(mockRecordFailure).not.toHaveBeenCalled();
   });
 });

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer-empty-response.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer-empty-response.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OfflineDatabase, QueryInvalidator } from '../../database';
+import type { PendingMutation } from '../queue';
+
+vi.mock('../queue', () => ({
+  peekPending: vi.fn(),
+  markCompleted: vi.fn().mockResolvedValue(undefined),
+  recordFailure: vi.fn().mockResolvedValue(undefined),
+  markDeadLetter: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../handlers', () => ({
+  processMutation: vi.fn(),
+}));
+
+import { __resetDrainerStateForTests, drainMutationQueue } from '../drainer';
+import { processMutation } from '../handlers';
+import { markCompleted, markDeadLetter, peekPending, recordFailure } from '../queue';
+
+const mockPeekPending = vi.mocked(peekPending);
+const mockMarkCompleted = vi.mocked(markCompleted);
+const mockRecordFailure = vi.mocked(recordFailure);
+const mockMarkDeadLetter = vi.mocked(markDeadLetter);
+const mockProcessMutation = vi.mocked(processMutation);
+
+const mockDb = {} as OfflineDatabase;
+const queryClient = {
+  invalidateQueries: vi.fn().mockResolvedValue(undefined),
+} as unknown as QueryInvalidator;
+const graphqlFetch = vi.fn().mockResolvedValue({});
+
+function makeMutation(): PendingMutation {
+  return {
+    id: 1,
+    table_name: 'boardsesh_ticks',
+    operation: 'create',
+    payload: '{}',
+    idempotency_key: 'tick-key-1',
+    created_at: '2026-08-01T00:00:00Z',
+    retry_count: 0,
+    max_retries: 10,
+    last_error: null,
+    status: 'pending',
+  };
+}
+
+describe('drainMutationQueue with the real error classifier', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetDrainerStateForTests();
+  });
+
+  it('leaves a mutation pending when its 2xx GraphQL response body is truncated', async () => {
+    const mutation = makeMutation();
+    const emptyResponseError = Object.assign(
+      new Error('GraphQL response body was empty or not valid JSON (HTTP 200)'),
+      {
+        name: 'GraphQLEmptyResponseError',
+        status: 200,
+      },
+    );
+
+    mockPeekPending.mockResolvedValueOnce([mutation]);
+    mockProcessMutation.mockRejectedValueOnce(emptyResponseError);
+
+    await drainMutationQueue(mockDb, queryClient, graphqlFetch, { isOnline: () => true });
+
+    expect(mockProcessMutation).toHaveBeenCalledOnce();
+    expect(mockRecordFailure).not.toHaveBeenCalled();
+    expect(mockMarkDeadLetter).not.toHaveBeenCalled();
+    expect(mockMarkCompleted).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer.test.ts
@@ -14,6 +14,7 @@ vi.mock('../handlers', () => ({
 }));
 
 vi.mock('../error-classification', () => ({
+  isGraphQLEmptyResponseError: vi.fn().mockReturnValue(false),
   isRetryable: vi.fn().mockReturnValue(false),
   isNetworkError: vi.fn().mockReturnValue(false),
 }));
@@ -21,13 +22,14 @@ vi.mock('../error-classification', () => ({
 import { drainMutationQueue, __resetDrainerStateForTests, setSigningOut, setBackgrounded } from '../drainer';
 import { peekPending, markCompleted, recordFailure, markDeadLetter } from '../queue';
 import { processMutation } from '../handlers';
-import { isRetryable, isNetworkError } from '../error-classification';
+import { isGraphQLEmptyResponseError, isRetryable, isNetworkError } from '../error-classification';
 
 const mockPeekPending = peekPending as ReturnType<typeof vi.fn>;
 const mockMarkCompleted = markCompleted as ReturnType<typeof vi.fn>;
 const mockRecordFailure = recordFailure as ReturnType<typeof vi.fn>;
 const mockMarkDeadLetter = markDeadLetter as ReturnType<typeof vi.fn>;
 const mockProcessMutation = processMutation as ReturnType<typeof vi.fn>;
+const mockIsGraphQLEmptyResponseError = isGraphQLEmptyResponseError as ReturnType<typeof vi.fn>;
 const mockIsRetryable = isRetryable as ReturnType<typeof vi.fn>;
 const mockIsNetworkError = isNetworkError as ReturnType<typeof vi.fn>;
 
@@ -68,6 +70,7 @@ describe('drainMutationQueue', () => {
     mockPeekPending.mockResolvedValue([]);
     // Re-assert the factory defaults each test (clearAllMocks keeps implementations,
     // so a prior test's mockReturnValue(true) would otherwise leak forward).
+    mockIsGraphQLEmptyResponseError.mockReturnValue(false);
     mockIsRetryable.mockReturnValue(false);
     mockIsNetworkError.mockReturnValue(false);
   });

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
@@ -249,6 +249,17 @@ describe('isTransportNetworkError', () => {
 });
 
 describe('isNetworkError', () => {
+  it('treats a named GraphQL empty 2xx response as transport-shaped even with its status attached', () => {
+    const error = Object.assign(new Error('GraphQL response body was empty or not valid JSON (HTTP 200)'), {
+      name: 'GraphQLEmptyResponseError',
+      status: 200,
+    });
+
+    expect(getErrorStatus(error)).toBe(200);
+    expect(isNetworkError(error)).toBe(true);
+    expect(isRetryable(error)).toBe(true);
+  });
+
   it('still treats an AbortError (by name) as a network failure — replaying is safe', () => {
     const aborted = new Error('Aborted');
     aborted.name = 'AbortError';

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 
-import { isRetryable, getErrorStatus, isNetworkError, isTransportNetworkError } from '../error-classification';
+import {
+  GRAPHQL_EMPTY_RESPONSE_ERROR_NAME,
+  isRetryable,
+  getErrorStatus,
+  isNetworkError,
+  isTransportNetworkError,
+} from '../error-classification';
 
 describe('getErrorStatus', () => {
   it('extracts status from Response object', () => {
@@ -251,7 +257,7 @@ describe('isTransportNetworkError', () => {
 describe('isNetworkError', () => {
   it('treats a named GraphQL empty 2xx response as transport-shaped even with its status attached', () => {
     const error = Object.assign(new Error('GraphQL response body was empty or not valid JSON (HTTP 200)'), {
-      name: 'GraphQLEmptyResponseError',
+      name: GRAPHQL_EMPTY_RESPONSE_ERROR_NAME,
       status: 200,
     });
 

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
@@ -2,11 +2,29 @@ import { describe, it, expect } from 'vitest';
 
 import {
   GRAPHQL_EMPTY_RESPONSE_ERROR_NAME,
+  isGraphQLEmptyResponseError,
   isRetryable,
   getErrorStatus,
   isNetworkError,
   isTransportNetworkError,
 } from '../error-classification';
+
+describe('isGraphQLEmptyResponseError', () => {
+  it('matches the platform error directly and through a cause wrapper', () => {
+    const emptyResponseError = Object.assign(new Error('empty GraphQL response'), {
+      name: GRAPHQL_EMPTY_RESPONSE_ERROR_NAME,
+      status: 200,
+    });
+    const wrappedError = Object.assign(new Error('request failed'), { cause: emptyResponseError });
+
+    expect(isGraphQLEmptyResponseError(emptyResponseError)).toBe(true);
+    expect(isGraphQLEmptyResponseError(wrappedError)).toBe(true);
+  });
+
+  it('does not match an ordinary transport failure', () => {
+    expect(isGraphQLEmptyResponseError(new TypeError('Network request failed'))).toBe(false);
+  });
+});
 
 describe('getErrorStatus', () => {
   it('extracts status from Response object', () => {

--- a/packages/shared/offline-sync/src/mutation-queue/drainer.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/drainer.ts
@@ -2,7 +2,7 @@ import type { OfflineDatabase, QueryInvalidator } from '../database';
 import type { GraphQLFetch } from './handlers';
 import { processMutation } from './handlers';
 import { peekPending, markCompleted, recordFailure, markDeadLetter } from './queue';
-import { isRetryable, isNetworkError } from './error-classification';
+import { isGraphQLEmptyResponseError, isRetryable, isNetworkError } from './error-classification';
 
 // Module-level singletons (drain flag, sign-out guard, wipe epoch): correct as
 // long as exactly one app runtime consumes this package per JS context — the
@@ -222,6 +222,17 @@ export async function drainMutationQueue(
         } catch (error: unknown) {
           const errorMessage = formatError(error);
 
+          if (isGraphQLEmptyResponseError(error)) {
+            // A 2xx response with no usable GraphQL body is ambiguous: the
+            // idempotent write may have landed, but no server verdict reached
+            // the client. Retry it within this cycle's existing bounded budget
+            // without consuming the mutation's persistent retry/dead-letter
+            // budget. Unlike a reachability failure, this does not require an
+            // offline→online transition before another attempt can succeed.
+            retryableHit = true;
+            break;
+          }
+
           if (isNetworkError(error)) {
             // The connection dropped mid-drain. Leave this mutation PENDING without
             // advancing retry_count — an offline write must never dead-letter for
@@ -264,8 +275,14 @@ export async function drainMutationQueue(
         // Give up this cycle once the in-cycle attempt budget is spent; the next
         // external trigger (or the scheduler's own retrigger) starts fresh.
         if (retryAttempts >= maxCycleAttempts) break;
+        // Lifecycle/connectivity may change after the failed request but before
+        // backoff starts. Avoid sleeping when this cycle can no longer retry.
+        if (_isSigningOut || _wipeEpoch !== startEpoch || _isBackgrounded || !options.isOnline()) break;
         await sleep(backoffDelay(retryAttempts, baseDelayMs, maxDelayMs));
         retryAttempts += 1;
+        // The app may sign out, background, or lose connectivity during the
+        // sleep. Re-check before touching SQLite or sending the mutation again.
+        if (_isSigningOut || _wipeEpoch !== startEpoch || _isBackgrounded || !options.isOnline()) break;
         continue;
       }
 

--- a/packages/shared/offline-sync/src/mutation-queue/error-classification.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/error-classification.ts
@@ -91,6 +91,9 @@ const IOS_NSURL_ENGLISH_DESCRIPTIONS =
 
 const MAX_CAUSE_DEPTH = 3;
 
+/** Stable cross-client identifier for a truncated successful GraphQL response. */
+export const GRAPHQL_EMPTY_RESPONSE_ERROR_NAME = 'GraphQLEmptyResponseError';
+
 /**
  * Locale-independent half of the transport check: errno-style codes and the
  * always-English fetch/polyfill wrapper strings / Java exception class names
@@ -108,7 +111,7 @@ function isLocaleIndependentTransportSignal(error: unknown, depth = 0): boolean 
   // so queued writes must stop without advancing toward the dead-letter. Match
   // structurally to keep this renderer-agnostic package independent of mobile.
   const name = (error as { name?: unknown }).name;
-  if (name === 'GraphQLEmptyResponseError') return true;
+  if (name === GRAPHQL_EMPTY_RESPONSE_ERROR_NAME) return true;
 
   const code = (error as { code?: unknown }).code;
   if (typeof code === 'string' && TRANSPORT_NETWORK_CODES.has(code)) return true;

--- a/packages/shared/offline-sync/src/mutation-queue/error-classification.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/error-classification.ts
@@ -103,6 +103,13 @@ const MAX_CAUSE_DEPTH = 3;
 function isLocaleIndependentTransportSignal(error: unknown, depth = 0): boolean {
   if (error === null || typeof error !== 'object') return false;
 
+  // The mobile GraphQL guard throws this stable named error after receiving
+  // response headers but no usable 2xx body. The server verdict never arrived,
+  // so queued writes must stop without advancing toward the dead-letter. Match
+  // structurally to keep this renderer-agnostic package independent of mobile.
+  const name = (error as { name?: unknown }).name;
+  if (name === 'GraphQLEmptyResponseError') return true;
+
   const code = (error as { code?: unknown }).code;
   if (typeof code === 'string' && TRANSPORT_NETWORK_CODES.has(code)) return true;
 

--- a/packages/shared/offline-sync/src/mutation-queue/error-classification.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/error-classification.ts
@@ -95,6 +95,32 @@ const MAX_CAUSE_DEPTH = 3;
 export const GRAPHQL_EMPTY_RESPONSE_ERROR_NAME = 'GraphQLEmptyResponseError';
 
 /**
+ * A successful GraphQL HTTP response whose body was empty or truncated before
+ * the client could read a server verdict. Match structurally so this package
+ * remains independent of the platform-specific error class, and follow bounded
+ * `.cause` chains because fetch wrappers may preserve the original error there.
+ */
+function isGraphQLEmptyResponseErrorAtDepth(error: unknown, depth: number): boolean {
+  if (error === null || typeof error !== 'object') return false;
+
+  const name = (error as { name?: unknown }).name;
+  if (name === GRAPHQL_EMPTY_RESPONSE_ERROR_NAME) return true;
+
+  if (depth < MAX_CAUSE_DEPTH) {
+    const cause = (error as { cause?: unknown }).cause;
+    if (cause !== undefined && cause !== error) {
+      return isGraphQLEmptyResponseErrorAtDepth(cause, depth + 1);
+    }
+  }
+
+  return false;
+}
+
+export function isGraphQLEmptyResponseError(error: unknown): boolean {
+  return isGraphQLEmptyResponseErrorAtDepth(error, 0);
+}
+
+/**
  * Locale-independent half of the transport check: errno-style codes and the
  * always-English fetch/polyfill wrapper strings / Java exception class names
  * (never localized prose — see TRANSPORT_NETWORK_MARKERS above). Recurses into
@@ -108,10 +134,9 @@ function isLocaleIndependentTransportSignal(error: unknown, depth = 0): boolean 
 
   // The mobile GraphQL guard throws this stable named error after receiving
   // response headers but no usable 2xx body. The server verdict never arrived,
-  // so queued writes must stop without advancing toward the dead-letter. Match
-  // structurally to keep this renderer-agnostic package independent of mobile.
-  const name = (error as { name?: unknown }).name;
-  if (name === GRAPHQL_EMPTY_RESPONSE_ERROR_NAME) return true;
+  // so queued writes must not advance toward the dead-letter. Match structurally
+  // to keep this renderer-agnostic package independent of mobile.
+  if (isGraphQLEmptyResponseErrorAtDepth(error, depth)) return true;
 
   const code = (error as { code?: unknown }).code;
   if (typeof code === 'string' && TRANSPORT_NETWORK_CODES.has(code)) return true;


### PR DESCRIPTION
## Summary

- Preserve the HTTP status on typed GraphQL empty-response failures.
- Classify a truncated 2xx response as a transport stop in the shared offline drainer.
- Keep mobile telemetry and offline mutation handling on the same classifier.
- Prove a queued write stays pending without a retry bump, dead-letter, or false completion.

Closes #4099

## Release Notes

Ticks and favorites waiting to sync now stay queued when a mobile connection drops after response headers, instead of being discarded.

## Test plan

- Shared offline-sync focused tests: 52 passed
- Mobile GraphQL and telemetry focused tests: 36 passed
- Complete mobile project: 575 files, 4,912 tests passed
- `vp run typecheck:mobile`
- `vp run check:mobile-bundle`: iOS and Android passed
- Scoped `vp check` and `git diff --check`
- Independent adversarial review: PASS
- `vp run dev:mobile` started with `.boardsesh/qa-notes.md`; Metro: `http://vibetunnel-2.tailedd9d5.ts.net:8081`
- Full unscoped `vp check` is currently blocked by an unrelated formatting issue on current main in `packages/web/app/components/logbook/logascent-form.tsx`; every changed file passes the scoped check

