### PR TITLE
feat(mobile): add BLE auto-disconnect

### DIFF
--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -52,6 +52,7 @@ import {
 import { replayOnboarding } from '../../../src/lib/onboarding/onboarding-storage';
 import { reportError } from '../../../src/lib/error-reporting';
 import { showSignOutFailure } from '../../../src/lib/sign-out-failure-alert';
+import { AUTO_DISCONNECT_TIMEOUT_OPTIONS } from '../../../src/lib/ble/auto-disconnect-controller';
 
 // Translations live in the shared catalog at packages/shared/i18n/locales/<locale>/.
 // We deep-link to the active language's folder so a community member lands on the
@@ -93,6 +94,8 @@ export default function MoreScreen() {
   // already in My Boards now (user chose this over a future-only default), and the
   // adopt-on-select flow auto-downloads new boards from then on.
   const [autoOfflineBoards] = useSetting('autoOfflineBoards');
+  const [autoDisconnectBle, setAutoDisconnectBle] = useSetting('autoDisconnectBle');
+  const [autoDisconnectTimeoutSeconds, setAutoDisconnectTimeoutSeconds] = useSetting('autoDisconnectTimeoutSeconds');
   const { enableBoardsOffline } = useBoardDownloads();
   const { data: myBoardsConnection } = useMyBoards(undefined, { enabled: offlineEnabled && !!profile });
   // Memoized so the empty-while-loading fallback keeps a stable identity — the
@@ -475,6 +478,54 @@ export default function MoreScreen() {
             },
           ]
         : []),
+    ],
+  });
+
+  const autoDisconnectTimeoutLabels: Record<number, string> = {
+    10: tSettings('ble.autoDisconnect.timeoutOptions.10'),
+    15: tSettings('ble.autoDisconnect.timeoutOptions.15'),
+    30: tSettings('ble.autoDisconnect.timeoutOptions.30'),
+    45: tSettings('ble.autoDisconnect.timeoutOptions.45'),
+    60: tSettings('ble.autoDisconnect.timeoutOptions.60'),
+    120: tSettings('ble.autoDisconnect.timeoutOptions.120'),
+    300: tSettings('ble.autoDisconnect.timeoutOptions.300'),
+    600: tSettings('ble.autoDisconnect.timeoutOptions.600'),
+  };
+  const autoDisconnectTimeoutOptions = AUTO_DISCONNECT_TIMEOUT_OPTIONS.map((seconds) => ({
+    key: String(seconds),
+    label: autoDisconnectTimeoutLabels[seconds],
+  }));
+
+  sections.push({
+    key: 'bluetooth',
+    title: tSettings('ble.autoDisconnect.title'),
+    footer: tSettings('ble.autoDisconnect.description'),
+    rows: [
+      {
+        kind: 'toggle',
+        key: 'autoDisconnectBle',
+        label: tSettings('ble.autoDisconnect.enabledLabel'),
+        subtitle: tSettings('ble.autoDisconnect.enabledDescription'),
+        value: autoDisconnectBle,
+        onValueChange: (next) => {
+          hapticSelection();
+          setAutoDisconnectBle(next);
+        },
+      },
+      {
+        kind: 'select',
+        key: 'autoDisconnectTimeoutSeconds',
+        label: tSettings('ble.autoDisconnect.timeoutLabel'),
+        options: autoDisconnectTimeoutOptions,
+        selectedKey: String(autoDisconnectTimeoutSeconds),
+        onSelect: (key) => {
+          const seconds = Number(key);
+          if (AUTO_DISCONNECT_TIMEOUT_OPTIONS.includes(seconds as (typeof AUTO_DISCONNECT_TIMEOUT_OPTIONS)[number])) {
+            hapticSelection();
+            setAutoDisconnectTimeoutSeconds(seconds);
+          }
+        },
+      },
     ],
   });
 

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -53,6 +53,7 @@ import { replayOnboarding } from '../../../src/lib/onboarding/onboarding-storage
 import { reportError } from '../../../src/lib/error-reporting';
 import { showSignOutFailure } from '../../../src/lib/sign-out-failure-alert';
 import { AUTO_DISCONNECT_TIMEOUT_OPTIONS } from '../../../src/lib/ble/auto-disconnect-controller';
+import { useAutoDisconnectTimeoutLabels } from '../../../src/components/ble/use-auto-disconnect-timeout-labels';
 
 // Translations live in the shared catalog at packages/shared/i18n/locales/<locale>/.
 // We deep-link to the active language's folder so a community member lands on the
@@ -96,6 +97,7 @@ export default function MoreScreen() {
   const [autoOfflineBoards] = useSetting('autoOfflineBoards');
   const [autoDisconnectBle, setAutoDisconnectBle] = useSetting('autoDisconnectBle');
   const [autoDisconnectTimeoutSeconds, setAutoDisconnectTimeoutSeconds] = useSetting('autoDisconnectTimeoutSeconds');
+  const autoDisconnectTimeoutLabels = useAutoDisconnectTimeoutLabels();
   const { enableBoardsOffline } = useBoardDownloads();
   const { data: myBoardsConnection } = useMyBoards(undefined, { enabled: offlineEnabled && !!profile });
   // Memoized so the empty-while-loading fallback keeps a stable identity — the
@@ -481,16 +483,6 @@ export default function MoreScreen() {
     ],
   });
 
-  const autoDisconnectTimeoutLabels: Record<number, string> = {
-    10: tSettings('ble.autoDisconnect.timeoutOptions.10'),
-    15: tSettings('ble.autoDisconnect.timeoutOptions.15'),
-    30: tSettings('ble.autoDisconnect.timeoutOptions.30'),
-    45: tSettings('ble.autoDisconnect.timeoutOptions.45'),
-    60: tSettings('ble.autoDisconnect.timeoutOptions.60'),
-    120: tSettings('ble.autoDisconnect.timeoutOptions.120'),
-    300: tSettings('ble.autoDisconnect.timeoutOptions.300'),
-    600: tSettings('ble.autoDisconnect.timeoutOptions.600'),
-  };
   const autoDisconnectTimeoutOptions = AUTO_DISCONNECT_TIMEOUT_OPTIONS.map((seconds) => ({
     key: String(seconds),
     label: autoDisconnectTimeoutLabels[seconds],

--- a/packages/mobile/src/components/__tests__/ble-control-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/ble-control-sheet.test.tsx
@@ -6,6 +6,7 @@ import { createElement, type ReactNode, type Ref } from 'react';
 // Capture each ListRow's title + onPress so we can fire the matching row.
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Switch: () => null,
   StyleSheet: { create: (styles: unknown) => styles },
 }));
 
@@ -41,6 +42,9 @@ const baseProps = {
   onReassert: vi.fn(),
   onClearLights: vi.fn(),
   onDisconnect: vi.fn(),
+  autoDisconnectEnabled: false,
+  autoDisconnectTimeoutLabel: '30 seconds',
+  onToggleAutoDisconnect: vi.fn(),
   onClose: vi.fn(),
 };
 
@@ -48,6 +52,7 @@ beforeEach(() => {
   baseProps.onReassert.mockClear();
   baseProps.onClearLights.mockClear();
   baseProps.onDisconnect.mockClear();
+  baseProps.onToggleAutoDisconnect.mockClear();
   baseProps.onClose.mockClear();
 });
 
@@ -82,6 +87,13 @@ describe('BleControlSheet', () => {
     expect(baseProps.onDisconnect).toHaveBeenCalledTimes(1);
     expect(baseProps.onClearLights).not.toHaveBeenCalled();
     expect(baseProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('toggles auto-disconnect once from the long-press row', () => {
+    const { getByText } = render(<BleControlSheet {...baseProps} />);
+    fireEvent.click(getByText('ble.autoDisconnect.toggleTitle'));
+    expect(baseProps.onToggleAutoDisconnect).toHaveBeenCalledTimes(1);
+    expect(baseProps.onToggleAutoDisconnect).toHaveBeenCalledWith(true);
   });
 
   it('always renders the turn-off row (every board now has a clear-all, incl. MoonBoard)', () => {

--- a/packages/mobile/src/components/ble/BleControlSheet.tsx
+++ b/packages/mobile/src/components/ble/BleControlSheet.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, Switch } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { ModalSheet } from '../ModalSheet';
 import { ListRow } from '../ListRow';
@@ -16,13 +16,25 @@ type BleControlSheetProps = {
   onClearLights: () => void;
   /** Drop the BLE connection. */
   onDisconnect: () => void;
+  autoDisconnectEnabled: boolean;
+  autoDisconnectTimeoutLabel: string;
+  onToggleAutoDisconnect: (enabled: boolean) => void;
   onClose: () => void;
 };
 
 // Secondary BLE controls (Re-light / Turn off all lights / Disconnect) revealed
 // by long-pressing the lightbulb — keeps the destructive Disconnect behind a
 // labelled menu.
-function BleControlSheet({ visible, onReassert, onClearLights, onDisconnect, onClose }: BleControlSheetProps) {
+function BleControlSheet({
+  visible,
+  onReassert,
+  onClearLights,
+  onDisconnect,
+  autoDisconnectEnabled,
+  autoDisconnectTimeoutLabel,
+  onToggleAutoDisconnect,
+  onClose,
+}: BleControlSheetProps) {
   const { t: tSettings } = useTranslation('settings');
   const { t: tCommon } = useTranslation('common');
   const { brandColors, systemColors } = useTheme();
@@ -47,6 +59,21 @@ function BleControlSheet({ visible, onReassert, onClearLights, onDisconnect, onC
   return (
     <ModalSheet visible={visible} snapPoints={snapPoints} onClose={onClose} enablePanDownToClose>
       <View style={styles.content}>
+        <ListRow
+          title={tSettings('ble.autoDisconnect.toggleTitle')}
+          subtitle={tSettings('ble.autoDisconnect.toggleSubtitle', { timeout: autoDisconnectTimeoutLabel })}
+          leading={<Icon name="clock" size={22} color={systemColors.secondaryLabel} />}
+          trailing={
+            <Switch
+              value={autoDisconnectEnabled}
+              pointerEvents="none"
+              accessibilityLabel={tSettings('ble.autoDisconnect.toggleAccessibility')}
+            />
+          }
+          onPress={() => onToggleAutoDisconnect(!autoDisconnectEnabled)}
+          accessibilityLabel={tSettings('ble.autoDisconnect.toggleAccessibility')}
+          showSeparator
+        />
         <ListRow
           title={tSettings('ble.relightBoard')}
           leading={<Icon name="lightbulb.fill" size={22} color={brandColors.warning} />}

--- a/packages/mobile/src/components/ble/BleControlSheet.tsx
+++ b/packages/mobile/src/components/ble/BleControlSheet.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import { View, StyleSheet, Switch } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { ModalSheet } from '../ModalSheet';
@@ -54,10 +54,11 @@ function BleControlSheet({
     onClose();
   }, [onDisconnect, onClose]);
 
-  const snapPoints = useMemo(() => ['32%'], []);
-
   return (
-    <ModalSheet visible={visible} snapPoints={snapPoints} onClose={onClose} enablePanDownToClose>
+    // Size to content rather than a fixed snap point: with the auto-disconnect
+    // row added, a fixed '32%' clips the bottom Disconnect action on smaller
+    // screens and at larger accessibility text sizes.
+    <ModalSheet visible={visible} enableDynamicSizing onClose={onClose} enablePanDownToClose>
       <View style={styles.content}>
         <ListRow
           title={tSettings('ble.autoDisconnect.toggleTitle')}

--- a/packages/mobile/src/components/ble/BleControlSheetHost.tsx
+++ b/packages/mobile/src/components/ble/BleControlSheetHost.tsx
@@ -3,6 +3,7 @@ import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider'
 import { disconnectAllBluetooth } from '../../lib/ble/bluetooth-status-store';
 import { BleControlSheet } from './BleControlSheet';
 import { useSetting } from '../../settings';
+import { useAutoDisconnectTimeoutLabels } from './use-auto-disconnect-timeout-labels';
 
 type BleControlSheetHostProps = {
   visible: boolean;
@@ -23,7 +24,8 @@ export function BleControlSheetHost({ visible, onClose }: BleControlSheetHostPro
   const isConnected = bluetooth?.isConnected ?? false;
   const [autoDisconnectEnabled, setAutoDisconnectEnabled] = useSetting('autoDisconnectBle');
   const timeoutSeconds = bluetooth?.autoDisconnectTimeoutSeconds ?? 30;
-  const autoDisconnectTimeoutLabel = timeoutSeconds >= 60 ? `${timeoutSeconds / 60}m` : `${timeoutSeconds}s`;
+  const timeoutLabels = useAutoDisconnectTimeoutLabels();
+  const autoDisconnectTimeoutLabel = timeoutLabels[timeoutSeconds] ?? String(timeoutSeconds);
 
   // Close if the link drops while the sheet is open — otherwise it lingers
   // showing Re-light / Disconnect actions that no-op on a dead link.

--- a/packages/mobile/src/components/ble/BleControlSheetHost.tsx
+++ b/packages/mobile/src/components/ble/BleControlSheetHost.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect } from 'react';
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
 import { disconnectAllBluetooth } from '../../lib/ble/bluetooth-status-store';
 import { BleControlSheet } from './BleControlSheet';
+import { useSetting } from '../../settings';
 
 type BleControlSheetHostProps = {
   visible: boolean;
@@ -20,6 +21,9 @@ type BleControlSheetHostProps = {
 export function BleControlSheetHost({ visible, onClose }: BleControlSheetHostProps) {
   const bluetooth = useOptionalBluetoothContext();
   const isConnected = bluetooth?.isConnected ?? false;
+  const [autoDisconnectEnabled, setAutoDisconnectEnabled] = useSetting('autoDisconnectBle');
+  const timeoutSeconds = bluetooth?.autoDisconnectTimeoutSeconds ?? 30;
+  const autoDisconnectTimeoutLabel = timeoutSeconds >= 60 ? `${timeoutSeconds / 60}m` : `${timeoutSeconds}s`;
 
   // Close if the link drops while the sheet is open — otherwise it lingers
   // showing Re-light / Disconnect actions that no-op on a dead link.
@@ -44,6 +48,9 @@ export function BleControlSheetHost({ visible, onClose }: BleControlSheetHostPro
       onReassert={handleReassert}
       onClearLights={handleClearLights}
       onDisconnect={disconnectAllBluetooth}
+      autoDisconnectEnabled={autoDisconnectEnabled}
+      autoDisconnectTimeoutLabel={autoDisconnectTimeoutLabel}
+      onToggleAutoDisconnect={setAutoDisconnectEnabled}
       onClose={onClose}
     />
   );

--- a/packages/mobile/src/components/ble/BleLightbulbButton.tsx
+++ b/packages/mobile/src/components/ble/BleLightbulbButton.tsx
@@ -31,6 +31,8 @@ type BleLightbulbButtonProps = {
    * VoiceOver reflects what tapping does, not just the filled look.
    */
   accessibilitySelected?: boolean;
+  /** Subtle visual warning that auto-disconnect is in its final ten seconds. */
+  autoDisconnectWarning?: boolean;
   scanningAccessibilityHint?: string;
   /** Hint describing the long-press action (e.g. "Hold to disconnect"). */
   longPressAccessibilityHint?: string;
@@ -53,6 +55,7 @@ export function BleLightbulbButton({
   onLongPress,
   accessibilityLabel,
   accessibilitySelected,
+  autoDisconnectWarning = false,
   scanningAccessibilityHint,
   longPressAccessibilityHint,
   haptic = 'light',
@@ -61,6 +64,7 @@ export function BleLightbulbButton({
 }: BleLightbulbButtonProps) {
   const { systemColors, brandColors } = useTheme();
   const pulseOpacity = useSharedValue(1);
+  const warningPulse = useSharedValue(0);
 
   useEffect(() => {
     if (isScanning) {
@@ -71,8 +75,19 @@ export function BleLightbulbButton({
     }
   }, [isScanning, pulseOpacity]);
 
+  useEffect(() => {
+    if (autoDisconnectWarning) {
+      warningPulse.value = withRepeat(withTiming(1, { duration: timing.slow }), -1, true);
+    } else {
+      cancelAnimation(warningPulse);
+      warningPulse.value = withTiming(0, { duration: timing.fast });
+    }
+  }, [autoDisconnectWarning, warningPulse]);
+
   const animatedStyle = useAnimatedStyle(() => ({
     opacity: pulseOpacity.value,
+    borderWidth: warningPulse.value * 2,
+    borderColor: brandColors.warning,
   }));
 
   const handlePress = () => {

--- a/packages/mobile/src/components/ble/use-auto-disconnect-timeout-labels.ts
+++ b/packages/mobile/src/components/ble/use-auto-disconnect-timeout-labels.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Localized labels for every auto-disconnect timeout choice, keyed by seconds.
+ * Enumerated as literal keys (not a computed key) so the i18n orphan scanner
+ * sees each catalog entry.
+ */
+export function useAutoDisconnectTimeoutLabels(): Record<number, string> {
+  const { t: tSettings } = useTranslation('settings');
+  return useMemo(
+    () => ({
+      10: tSettings('ble.autoDisconnect.timeoutOptions.10'),
+      15: tSettings('ble.autoDisconnect.timeoutOptions.15'),
+      30: tSettings('ble.autoDisconnect.timeoutOptions.30'),
+      45: tSettings('ble.autoDisconnect.timeoutOptions.45'),
+      60: tSettings('ble.autoDisconnect.timeoutOptions.60'),
+      120: tSettings('ble.autoDisconnect.timeoutOptions.120'),
+      300: tSettings('ble.autoDisconnect.timeoutOptions.300'),
+      600: tSettings('ble.autoDisconnect.timeoutOptions.600'),
+    }),
+    [tSettings],
+  );
+}

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -611,14 +611,7 @@ export function PlayDrawer({
     // orientation. isConnected means this device holds the BLE link (and
     // therefore drives the wall).
     if (bluetooth?.isConnected && displayedClimb?.frames) {
-      void bluetooth
-        .sendFramesToBoard(displayedClimb.frames, nextMirrored)
-        .then((writeSucceeded) => {
-          if (writeSucceeded === true) bluetooth.notifyClimbDisplaySucceeded();
-        })
-        .catch(() => {
-          // A failed mirror write must not reset the inactivity deadline.
-        });
+      void bluetooth.sendFramesToBoard(displayedClimb.frames, nextMirrored);
     }
   }, [isMirrored, bluetooth, displayedClimb]);
 

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -611,7 +611,14 @@ export function PlayDrawer({
     // orientation. isConnected means this device holds the BLE link (and
     // therefore drives the wall).
     if (bluetooth?.isConnected && displayedClimb?.frames) {
-      void bluetooth.sendFramesToBoard(displayedClimb.frames, nextMirrored);
+      void bluetooth
+        .sendFramesToBoard(displayedClimb.frames, nextMirrored)
+        .then((writeSucceeded) => {
+          if (writeSucceeded === true) bluetooth.notifyClimbDisplaySucceeded();
+        })
+        .catch(() => {
+          // A failed mirror write must not reset the inactivity deadline.
+        });
     }
   }, [isMirrored, bluetooth, displayedClimb]);
 
@@ -992,6 +999,7 @@ export function PlayDrawer({
                         lightbulbActive={lightbulbActive}
                         lightbulbConnected={bluetoothConnected}
                         lightbulbPending={lightbulbPending}
+                        autoDisconnectWarning={bluetooth?.autoDisconnectWarning ?? false}
                         lightbulbLongPressEnabled={bluetoothConnected}
                         showLightbulb={bluetooth !== null}
                         // The on-wall banner owns the driver's face in the header

--- a/packages/mobile/src/components/play-drawer/PlayDrawerActionBar.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerActionBar.tsx
@@ -32,6 +32,7 @@ type PlayDrawerActionBarProps = {
    *  can light. */
   lightbulbConnected: boolean;
   lightbulbPending?: boolean;
+  autoDisconnectWarning?: boolean;
   lightbulbAccessibilityLabel?: string;
   lightbulbLongPressAccessibilityHint?: string;
   lightbulbLongPressEnabled?: boolean;
@@ -67,6 +68,7 @@ export const PlayDrawerActionBar = memo(function PlayDrawerActionBar({
   lightbulbActive,
   lightbulbConnected,
   lightbulbPending = false,
+  autoDisconnectWarning = false,
   lightbulbAccessibilityLabel,
   lightbulbLongPressAccessibilityHint,
   lightbulbLongPressEnabled = lightbulbActive,
@@ -186,6 +188,7 @@ export const PlayDrawerActionBar = memo(function PlayDrawerActionBar({
                 isConnected={lightbulbActive}
                 accessibilitySelected={lightbulbConnected}
                 isScanning={lightbulbPending}
+                autoDisconnectWarning={autoDisconnectWarning}
                 onPress={onLightbulb}
                 onLongPress={lightbulbLongPressEnabled ? onLightbulbLongPress : undefined}
                 accessibilityLabel={

--- a/packages/mobile/src/lib/ble/__tests__/auto-disconnect-controller.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/auto-disconnect-controller.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { AutoDisconnectController, AUTO_DISCONNECT_TIMEOUT_OPTIONS } from '../auto-disconnect-controller';
+
+describe('AutoDisconnectController', () => {
+  it('exposes the supported timeout choices', () => {
+    expect(AUTO_DISCONNECT_TIMEOUT_OPTIONS).toEqual([10, 15, 30, 45, 60, 120, 300, 600]);
+  });
+
+  function harness() {
+    let now = 0;
+    let nextTimer = 0;
+    const callbacks = new Map<number, () => void>();
+    const expired: number[] = [];
+    const controller = new AutoDisconnectController({
+      now: () => now,
+      setTimeout: (callback) => {
+        const id = ++nextTimer;
+        callbacks.set(id, callback);
+        return id as unknown as ReturnType<typeof setTimeout>;
+      },
+      clearTimeout: (timer) => callbacks.delete(timer as unknown as number),
+      onExpire: () => expired.push(now),
+    });
+    return {
+      controller,
+      callbacks,
+      expired,
+      advance(ms: number) {
+        now += ms;
+      },
+    };
+  }
+
+  it('expires once when enabled and connected', () => {
+    const test = harness();
+    test.controller.update(true, 30);
+    test.controller.connectedNow();
+    expect(test.controller.getDeadlineMs()).toBe(30_000);
+    const callback = [...test.callbacks.values()][0];
+    test.advance(30_000);
+    callback();
+    expect(test.expired).toEqual([30_000]);
+    callback();
+    expect(test.expired).toEqual([30_000]);
+  });
+
+  it('invalidates an old callback across the disconnect/reconnect race', () => {
+    const test = harness();
+    test.controller.update(true, 10);
+    test.controller.connectedNow();
+    const oldCallback = [...test.callbacks.values()][0];
+    test.controller.disconnectedNow();
+    test.controller.connectedNow();
+    const newCallback = [...test.callbacks.values()][0];
+
+    oldCallback();
+    expect(test.expired).toEqual([]);
+    test.advance(10_000);
+    newCallback();
+    expect(test.expired).toEqual([10_000]);
+  });
+
+  it('resets and resumes from the wall-clock deadline', () => {
+    const test = harness();
+    test.controller.update(true, 30);
+    test.controller.connectedNow();
+    test.advance(20_000);
+    test.controller.reset();
+    expect(test.controller.getDeadlineMs()).toBe(50_000);
+    test.advance(29_999);
+    test.controller.resume();
+    expect(test.expired).toEqual([]);
+    test.advance(1);
+    test.controller.resume();
+    expect(test.expired).toEqual([50_000]);
+  });
+
+  it('cancels on disable and timeout changes start a fresh deadline', () => {
+    const test = harness();
+    test.controller.update(true, 30);
+    test.controller.connectedNow();
+    const oldCallback = [...test.callbacks.values()][0];
+    test.controller.update(false, 60);
+    oldCallback();
+    expect(test.expired).toEqual([]);
+
+    test.controller.update(true, 60);
+    test.controller.connectedNow();
+    expect(test.controller.getDeadlineMs()).toBe(60_000);
+  });
+});

--- a/packages/mobile/src/lib/ble/auto-disconnect-controller.ts
+++ b/packages/mobile/src/lib/ble/auto-disconnect-controller.ts
@@ -1,6 +1,5 @@
 /** Timeout choices exposed by the mobile auto-disconnect setting. */
 export const AUTO_DISCONNECT_TIMEOUT_OPTIONS = [10, 15, 30, 45, 60, 120, 300, 600] as const;
-export type AutoDisconnectTimeoutSeconds = number;
 
 // Keep the controller independent of the browser-versus-native timer handle
 // shape. The mobile test runner and the native runtime return different values.

--- a/packages/mobile/src/lib/ble/auto-disconnect-controller.ts
+++ b/packages/mobile/src/lib/ble/auto-disconnect-controller.ts
@@ -1,0 +1,103 @@
+/** Timeout choices exposed by the mobile auto-disconnect setting. */
+export const AUTO_DISCONNECT_TIMEOUT_OPTIONS = [10, 15, 30, 45, 60, 120, 300, 600] as const;
+export type AutoDisconnectTimeoutSeconds = number;
+
+// Keep the controller independent of the browser-versus-native timer handle
+// shape. The mobile test runner and the native runtime return different values.
+type TimerHandle = number | object;
+
+export type AutoDisconnectControllerOptions = {
+  now?: () => number;
+  setTimeout?: (callback: () => void, delayMs: number) => TimerHandle;
+  clearTimeout?: (timer: TimerHandle) => void;
+  onExpire: () => void;
+};
+
+/**
+ * Small platform-neutral deadline controller. The generation token is checked
+ * by every callback, so a timer from a previous connection cannot disconnect a
+ * newly-established connection during a reconnect race.
+ */
+export class AutoDisconnectController {
+  private readonly now: () => number;
+  private readonly scheduleTimeout: NonNullable<AutoDisconnectControllerOptions['setTimeout']>;
+  private readonly cancelTimeout: NonNullable<AutoDisconnectControllerOptions['clearTimeout']>;
+  private readonly onExpire: () => void;
+  private timer: TimerHandle | null = null;
+  private deadlineMs: number | null = null;
+  private generation = 0;
+  private connected = false;
+  private enabled = false;
+  private timeoutSeconds = 30;
+
+  constructor(options: AutoDisconnectControllerOptions) {
+    this.now = options.now ?? Date.now;
+    this.scheduleTimeout =
+      options.setTimeout ?? ((callback, delayMs) => setTimeout(callback, delayMs) as unknown as TimerHandle);
+    this.cancelTimeout = options.clearTimeout ?? ((timer) => clearTimeout(timer as unknown as number));
+    this.onExpire = options.onExpire;
+  }
+
+  update(enabled: boolean, timeoutSeconds: number): void {
+    this.enabled = enabled;
+    this.timeoutSeconds = timeoutSeconds;
+    this.invalidate();
+    if (this.connected && enabled) this.arm();
+  }
+
+  connectedNow(): void {
+    this.connected = true;
+    this.invalidate();
+    if (this.enabled) this.arm();
+  }
+
+  disconnectedNow(): void {
+    this.connected = false;
+    this.invalidate();
+  }
+
+  reset(): void {
+    if (!this.connected || !this.enabled) return;
+    this.invalidate();
+    this.arm();
+  }
+
+  /** Re-check the wall-clock deadline after the app returns to the foreground. */
+  resume(): void {
+    if (!this.connected || !this.enabled || this.deadlineMs === null) return;
+    const existingDeadlineMs = this.deadlineMs;
+    if (existingDeadlineMs <= this.now()) {
+      this.expire(this.generation);
+      return;
+    }
+    this.invalidate();
+    this.arm(existingDeadlineMs);
+  }
+
+  /** Exposed for a focused UI/provider test without waiting for fake timers. */
+  getDeadlineMs(): number | null {
+    return this.deadlineMs;
+  }
+
+  private invalidate(): void {
+    this.generation += 1;
+    if (this.timer !== null) {
+      this.cancelTimeout(this.timer);
+      this.timer = null;
+    }
+    this.deadlineMs = null;
+  }
+
+  private arm(existingDeadlineMs?: number | null): void {
+    const token = this.generation;
+    const deadlineMs = existingDeadlineMs ?? this.now() + this.timeoutSeconds * 1000;
+    this.deadlineMs = deadlineMs;
+    this.timer = this.scheduleTimeout(() => this.expire(token), Math.max(0, deadlineMs - this.now()));
+  }
+
+  private expire(token: number): void {
+    if (token !== this.generation || !this.connected || !this.enabled) return;
+    this.invalidate();
+    this.onExpire();
+  }
+}

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -272,7 +272,14 @@ export type SendFramesToBoard = (
   sendContext?: BleSendContext,
 ) => Promise<boolean | undefined>;
 
-export type BleDisconnectTrigger = 'explicit_user' | 'config_switch' | 'connection_replacement' | 'link_drop';
+export type BluetoothDisconnectReason = 'user' | 'auto_disconnect';
+
+export type BleDisconnectTrigger =
+  | 'explicit_user'
+  | 'auto_disconnect'
+  | 'config_switch'
+  | 'connection_replacement'
+  | 'link_drop';
 
 export type BleConnectionEnded = {
   reason: 'user' | 'unexpected';
@@ -1443,13 +1450,18 @@ export function useBoardBluetooth({
     [consumeConnectionLifetime, onConnectionChange],
   );
 
-  const disconnect = useCallback(async () => {
-    // A deliberate disconnect forgets the board — only an involuntary drop or a
-    // config switch keeps the silent same-board reconnect memory alive. Clears
-    // the persisted copy too so the next launch doesn't resurrect it.
-    forgetConnectedBoard();
-    await teardownConnection('explicit_user');
-  }, [forgetConnectedBoard, teardownConnection]);
+  const disconnect = useCallback(
+    async (reason: BluetoothDisconnectReason = 'user') => {
+      // A deliberate disconnect forgets the board — only an involuntary drop or a
+      // config switch keeps the silent same-board reconnect memory alive. Clears
+      // the persisted copy too so the next launch doesn't resurrect it.
+      // Auto-disconnect also keeps the remembered handle so the lightbulb can
+      // silently reconnect to the same board.
+      if (reason === 'user') forgetConnectedBoard();
+      await teardownConnection(reason === 'user' ? 'explicit_user' : 'auto_disconnect');
+    },
+    [forgetConnectedBoard, teardownConnection],
+  );
 
   // If the active board config changes while a connection is live, tear it down.
   // BluetoothProvider is mounted once globally; without this a board/layout/size/set

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
@@ -90,6 +90,11 @@ const blePermissions = vi.hoisted(() => ({
 
 vi.mock('react-native', () => ({
   Alert: { alert: alert.alert },
+  AppState: { addEventListener: () => ({ remove: vi.fn() }) },
+}));
+
+vi.mock('../../settings', () => ({
+  useSetting: (key: string) => (key === 'autoDisconnectBle' ? [false, vi.fn()] : [30, vi.fn()]),
 }));
 
 vi.mock('@boardsesh/play-view', () => ({

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -109,6 +109,11 @@ vi.mock('react-native', () => ({
   // branches on Platform.OS; 'ios' short-circuits it to null without needing a
   // PermissionsAndroid stub here.
   Platform: { OS: 'ios', Version: 0 },
+  AppState: { addEventListener: () => ({ remove: vi.fn() }) },
+}));
+
+vi.mock('../../settings', () => ({
+  useSetting: (key: string) => (key === 'autoDisconnectBle' ? [false, vi.fn()] : [30, vi.fn()]),
 }));
 
 vi.mock('@boardsesh/play-view', () => ({

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -64,8 +64,6 @@ type BluetoothContextValue = {
   ) => Promise<boolean>;
   disconnect: (reason?: BluetoothDisconnectReason) => Promise<void>;
   sendFramesToBoard: SendFramesToBoard;
-  /** Record a confirmed direct climb re-light (for example, mirror). */
-  notifyClimbDisplaySucceeded: () => void;
   clearBoard: () => Promise<boolean | undefined>;
   /**
    * Force the auto-sender to re-push the current climb to the wall once, even
@@ -188,7 +186,6 @@ function presenceClimbToQueueInput(climb: BoardPresenceClimb): ClimbQueueItemInp
 function BluetoothAutoSender({
   sendFramesToBoard,
   onWallConfirmed,
-  onClimbDisplaySucceeded,
   reassertNonce,
   connectInitialSendRef,
   lastPhysicalFramesRef,
@@ -204,8 +201,6 @@ function BluetoothAutoSender({
    * confirm (uuid only) and report the climb to the board-presence channel.
    */
   onWallConfirmed: (item: ClimbQueueItem) => void;
-  /** Called only after an app-initiated climb packet is confirmed by BLE. */
-  onClimbDisplaySucceeded: () => void;
   reassertNonce: number;
   // One-shot seed: what connect() already wrote as initialFrames, so the
   // freshly mounted AutoSender doesn't repeat a byte-identical first send.
@@ -458,7 +453,6 @@ function BluetoothAutoSender({
               lastSentSignatureRef.current = sendSignature;
               lastPhysicalFramesRef.current = physicalFramesSignature(item.climb.frames, !!item.climb.mirrored);
               onWallConfirmedRef.current(item);
-              onClimbDisplaySucceeded();
               hapticSuccess();
             }
           } catch (error) {
@@ -478,7 +472,7 @@ function BluetoothAutoSender({
     };
 
     void drain();
-  }, [currentClimbQueueItem, sendFramesToBoard, reassertNonce, colorSignature, onClimbDisplaySucceeded]);
+  }, [currentClimbQueueItem, sendFramesToBoard, reassertNonce, colorSignature]);
 
   return null;
 }
@@ -823,6 +817,15 @@ export function BluetoothProvider({
             // occupying the new generation's still-empty attribution slot.
             if (!connection.setAnalyticsBoardId(resolved.boardId)) return;
             resolvedPresenceBoardIdRef.current = resolved.boardId;
+            // Consume the pending-resolve marker BEFORE replaying: a wall
+            // confirm landing in the microtask gap between this .then and the
+            // .finally below would otherwise still read "resolving", queue a
+            // report after the replay already ran, and orphan it forever. The
+            // .finally stays for the null/failure paths (same idempotent guard).
+            if (pendingPresenceResolveConnectionRef.current === connection) {
+              pendingPresenceResolveConnectionRef.current = null;
+              pendingPresenceResolveRef.current = false;
+            }
             replayPendingWallReport(resolved.boardId);
           })
           .catch((error: unknown) => {
@@ -951,6 +954,26 @@ export function BluetoothProvider({
     onConnectionEnded: handleBluetoothConnectionEnded,
     getConnectedViaMismatchOverride,
   });
+
+  // Every successful board write is activity for the auto-disconnect deadline,
+  // no matter which surface wrote (queue auto-sender, mirror toggle, playback
+  // scrub, climb-edit preview, clear lights). Wrapping the sender here keeps
+  // all consumers covered without each one remembering to notify.
+  const sendFramesToBoardWithActivityReset = useCallback<SendFramesToBoard>(
+    (frames, mirrored, signal, sendContext) => {
+      // Pass the hook's promise through untouched (no extra await hop in the
+      // send path); the timer reset rides a side chain that only observes
+      // success. Callers keep owning failure handling on the returned promise.
+      const sendPromise = sendFramesToBoard(frames, mirrored, signal, sendContext);
+      sendPromise
+        .then((writeSucceeded) => {
+          if (writeSucceeded === true) resetAutoDisconnect();
+        })
+        .catch(() => {});
+      return sendPromise;
+    },
+    [sendFramesToBoard, resetAutoDisconnect],
+  );
 
   const resolvedPickerBoards = useResolvedBleDeviceBoards(pickerState?.devices ?? EMPTY_PICKER_DEVICES);
   const currentBoardConfig = useMemo(() => {
@@ -1225,7 +1248,7 @@ export function BluetoothProvider({
     }
 
     lastAcceptedReportSignatureRef.current = null;
-    const writeSucceeded = await sendFramesToBoard(frames, false, undefined, {
+    const writeSucceeded = await sendFramesToBoardWithActivityReset(frames, false, undefined, {
       sendSource: 'undo',
       climbUuid: undoTarget.climbUuid,
     }).catch((error: unknown) => {
@@ -1235,7 +1258,6 @@ export function BluetoothProvider({
     if (writeSucceeded !== true) {
       return false;
     }
-    resetAutoDisconnect();
     lastPhysicalFramesRef.current = physicalFramesSignature(frames, false);
 
     const accepted = await reportClimbForBoardRef
@@ -1251,7 +1273,7 @@ export function BluetoothProvider({
     lastAcceptedReportSignatureRef.current = presenceClimbReportSignature(undoTarget);
     undoWallChangeTargetRef.current = null;
     return true;
-  }, [sendFramesToBoard, resetAutoDisconnect]);
+  }, [sendFramesToBoardWithActivityReset]);
 
   // Generalized `undoWallChange`: relight ANY presence climb (the wall kiosk's
   // "Light this" confirm), not just the captured undo target. Same BLE-first-
@@ -1272,7 +1294,7 @@ export function BluetoothProvider({
       }
 
       lastAcceptedReportSignatureRef.current = null;
-      const writeSucceeded = await sendFramesToBoard(frames, false, undefined, {
+      const writeSucceeded = await sendFramesToBoardWithActivityReset(frames, false, undefined, {
         sendSource: 'wall-relight',
         climbUuid: climb.climbUuid,
       }).catch((error: unknown) => {
@@ -1282,7 +1304,6 @@ export function BluetoothProvider({
       if (writeSucceeded !== true) {
         return false;
       }
-      resetAutoDisconnect();
       lastPhysicalFramesRef.current = physicalFramesSignature(frames, false);
 
       const accepted = await reportClimbForBoardRef
@@ -1298,12 +1319,12 @@ export function BluetoothProvider({
       lastAcceptedReportSignatureRef.current = presenceClimbReportSignature(climb);
       return true;
     },
-    [sendFramesToBoard, resetAutoDisconnect],
+    [sendFramesToBoardWithActivityReset],
   );
 
   const clearBoard = useCallback(
-    () => sendFramesToBoard('', false, undefined, { sendSource: 'clear' }),
-    [sendFramesToBoard],
+    () => sendFramesToBoardWithActivityReset('', false, undefined, { sendSource: 'clear' }),
+    [sendFramesToBoardWithActivityReset],
   );
 
   // Advance the queue past a "spill" climb (one set for a different board/layout
@@ -1478,8 +1499,7 @@ export function BluetoothProvider({
       loading,
       connect,
       disconnect: wrappedDisconnect,
-      sendFramesToBoard,
-      notifyClimbDisplaySucceeded: resetAutoDisconnect,
+      sendFramesToBoard: sendFramesToBoardWithActivityReset,
       clearBoard,
       reassertWall,
       undoWallChange,
@@ -1496,8 +1516,7 @@ export function BluetoothProvider({
       loading,
       connect,
       wrappedDisconnect,
-      sendFramesToBoard,
-      resetAutoDisconnect,
+      sendFramesToBoardWithActivityReset,
       clearBoard,
       reassertWall,
       undoWallChange,
@@ -1531,9 +1550,8 @@ export function BluetoothProvider({
           Aurora is last-connection-wins, so one phone is physically connected. */}
       {isConnected && (
         <BluetoothAutoSender
-          sendFramesToBoard={sendFramesToBoard}
+          sendFramesToBoard={sendFramesToBoardWithActivityReset}
           onWallConfirmed={handleWallConfirmed}
-          onClimbDisplaySucceeded={resetAutoDisconnect}
           reassertNonce={reassertNonce}
           connectInitialSendRef={connectInitialSendRef}
           lastPhysicalFramesRef={lastPhysicalFramesRef}

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { Alert } from 'react-native';
+import { Alert, AppState } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import type { ClimbQueueItem } from '@boardsesh/queue';
@@ -20,6 +20,7 @@ import {
   boardConfigKey,
   type BleConnectionHandle,
   type BleConnectionEnded,
+  type BluetoothDisconnectReason,
   type SendFramesToBoard,
 } from '../lib/ble/use-board-bluetooth';
 import { hasRenderableFrames } from '../lib/ble/renderable-frames';
@@ -49,6 +50,8 @@ import { DevicePickerSheet } from '../components/ble/DevicePickerSheet';
 import { BlePickerHostContext, type BlePickerHostValue } from './ble-picker-host';
 import { track } from '../lib/analytics';
 import { getBluetoothColorOverrides, useHoldColorOverrides } from '../lib/hold-color-overrides';
+import { useSetting } from '../settings';
+import { AutoDisconnectController } from '../lib/ble/auto-disconnect-controller';
 
 type BluetoothContextValue = {
   isConnected: boolean;
@@ -59,8 +62,10 @@ type BluetoothContextValue = {
     targetSerial?: string,
     targetDeviceId?: string,
   ) => Promise<boolean>;
-  disconnect: () => Promise<void>;
+  disconnect: (reason?: BluetoothDisconnectReason) => Promise<void>;
   sendFramesToBoard: SendFramesToBoard;
+  /** Record a confirmed direct climb re-light (for example, mirror). */
+  notifyClimbDisplaySucceeded: () => void;
   clearBoard: () => Promise<boolean | undefined>;
   /**
    * Force the auto-sender to re-push the current climb to the wall once, even
@@ -103,6 +108,9 @@ type BluetoothContextValue = {
    * board instead of opening the picker.
    */
   reconnectDeviceIdForCurrentBoard: string | null;
+  autoDisconnectEnabled: boolean;
+  autoDisconnectTimeoutSeconds: number;
+  autoDisconnectWarning: boolean;
 };
 
 const BluetoothContext = createContext<BluetoothContextValue | null>(null);
@@ -180,6 +188,7 @@ function presenceClimbToQueueInput(climb: BoardPresenceClimb): ClimbQueueItemInp
 function BluetoothAutoSender({
   sendFramesToBoard,
   onWallConfirmed,
+  onClimbDisplaySucceeded,
   reassertNonce,
   connectInitialSendRef,
   lastPhysicalFramesRef,
@@ -195,6 +204,8 @@ function BluetoothAutoSender({
    * confirm (uuid only) and report the climb to the board-presence channel.
    */
   onWallConfirmed: (item: ClimbQueueItem) => void;
+  /** Called only after an app-initiated climb packet is confirmed by BLE. */
+  onClimbDisplaySucceeded: () => void;
   reassertNonce: number;
   // One-shot seed: what connect() already wrote as initialFrames, so the
   // freshly mounted AutoSender doesn't repeat a byte-identical first send.
@@ -447,6 +458,7 @@ function BluetoothAutoSender({
               lastSentSignatureRef.current = sendSignature;
               lastPhysicalFramesRef.current = physicalFramesSignature(item.climb.frames, !!item.climb.mirrored);
               onWallConfirmedRef.current(item);
+              onClimbDisplaySucceeded();
               hapticSuccess();
             }
           } catch (error) {
@@ -466,7 +478,7 @@ function BluetoothAutoSender({
     };
 
     void drain();
-  }, [currentClimbQueueItem, sendFramesToBoard, reassertNonce, colorSignature]);
+  }, [currentClimbQueueItem, sendFramesToBoard, reassertNonce, colorSignature, onClimbDisplaySucceeded]);
 
   return null;
 }
@@ -510,6 +522,20 @@ export function BluetoothProvider({
   // queue changes) + toast, for advancing past a spill climb and telling the user.
   const { setCurrentClimb } = useQueueActions();
   const { showToast } = useToast();
+  const [autoDisconnectBle] = useSetting('autoDisconnectBle');
+  const [autoDisconnectTimeoutSeconds] = useSetting('autoDisconnectTimeoutSeconds');
+  const [autoDisconnectWarning, setAutoDisconnectWarning] = useState(false);
+  const autoDisconnectExpireRef = useRef<() => void>(() => {});
+  const autoDisconnectControllerRef = useRef<AutoDisconnectController | null>(null);
+  if (!autoDisconnectControllerRef.current) {
+    autoDisconnectControllerRef.current = new AutoDisconnectController({
+      onExpire: () => autoDisconnectExpireRef.current(),
+    });
+  }
+  const resetAutoDisconnect = useCallback(() => {
+    autoDisconnectControllerRef.current?.reset();
+    setAutoDisconnectWarning(false);
+  }, []);
   const { overrides: holdColorOverrides, signature: holdColorSignature } = useHoldColorOverrides();
   const bluetoothColorOverrides = useMemo(
     () => getBluetoothColorOverrides(holdColorOverrides),
@@ -1209,6 +1235,7 @@ export function BluetoothProvider({
     if (writeSucceeded !== true) {
       return false;
     }
+    resetAutoDisconnect();
     lastPhysicalFramesRef.current = physicalFramesSignature(frames, false);
 
     const accepted = await reportClimbForBoardRef
@@ -1224,7 +1251,7 @@ export function BluetoothProvider({
     lastAcceptedReportSignatureRef.current = presenceClimbReportSignature(undoTarget);
     undoWallChangeTargetRef.current = null;
     return true;
-  }, [sendFramesToBoard]);
+  }, [sendFramesToBoard, resetAutoDisconnect]);
 
   // Generalized `undoWallChange`: relight ANY presence climb (the wall kiosk's
   // "Light this" confirm), not just the captured undo target. Same BLE-first-
@@ -1255,6 +1282,7 @@ export function BluetoothProvider({
       if (writeSucceeded !== true) {
         return false;
       }
+      resetAutoDisconnect();
       lastPhysicalFramesRef.current = physicalFramesSignature(frames, false);
 
       const accepted = await reportClimbForBoardRef
@@ -1270,7 +1298,7 @@ export function BluetoothProvider({
       lastAcceptedReportSignatureRef.current = presenceClimbReportSignature(climb);
       return true;
     },
-    [sendFramesToBoard],
+    [sendFramesToBoard, resetAutoDisconnect],
   );
 
   const clearBoard = useCallback(
@@ -1361,31 +1389,75 @@ export function BluetoothProvider({
 
   // Coalesce adapter disconnect calls. The hook consumes and reports the active
   // generation synchronously before awaiting the native adapter teardown.
-  const wrappedDisconnect = useCallback(async () => {
-    const disconnectInFlight = disconnectInFlightRef.current;
-    if (disconnectInFlight) {
-      await disconnectInFlight;
-      return;
-    }
-
-    clearPendingWallReportAndUndoToastArm();
-    connectedViaMismatchOverrideRef.current = false;
-    const disconnectOperation = disconnect().catch(() => {
-      // The native iOS adapter's disconnect() can reject (e.g. peripheral
-      // already torn down). Callers `void` this promise, so an unhandled
-      // rejection would surface as error-reporting noise. Connection state is
-      // cleared before the await, so the disconnect is effectively done either way —
-      // safe to swallow, matching the keep-awake `.catch(() => {})` pattern.
-    });
-    disconnectInFlightRef.current = disconnectOperation;
-    try {
-      await disconnectOperation;
-    } finally {
-      if (disconnectInFlightRef.current === disconnectOperation) {
-        disconnectInFlightRef.current = null;
+  // Auto-disconnect reuses the same release path but keeps the remembered
+  // board handle (the hook only forgets the board on a 'user' reason).
+  const wrappedDisconnect = useCallback(
+    async (reason: BluetoothDisconnectReason = 'user') => {
+      const disconnectInFlight = disconnectInFlightRef.current;
+      if (disconnectInFlight) {
+        await disconnectInFlight;
+        return;
       }
-    }
-  }, [clearPendingWallReportAndUndoToastArm, disconnect]);
+
+      clearPendingWallReportAndUndoToastArm();
+      connectedViaMismatchOverrideRef.current = false;
+      const disconnectOperation = disconnect(reason).catch(() => {
+        // The native iOS adapter's disconnect() can reject (e.g. peripheral
+        // already torn down). Callers `void` this promise, so an unhandled
+        // rejection would surface as error-reporting noise. Connection state is
+        // cleared before the await, so the disconnect is effectively done either way —
+        // safe to swallow, matching the keep-awake `.catch(() => {})` pattern.
+      });
+      disconnectInFlightRef.current = disconnectOperation;
+      try {
+        await disconnectOperation;
+      } finally {
+        if (disconnectInFlightRef.current === disconnectOperation) {
+          disconnectInFlightRef.current = null;
+        }
+      }
+    },
+    [clearPendingWallReportAndUndoToastArm, disconnect],
+  );
+
+  const autoDisconnectOnExpire = useCallback(() => {
+    void wrappedDisconnect('auto_disconnect');
+  }, [wrappedDisconnect]);
+  autoDisconnectExpireRef.current = autoDisconnectOnExpire;
+
+  useEffect(() => {
+    autoDisconnectControllerRef.current?.update(autoDisconnectBle, autoDisconnectTimeoutSeconds);
+  }, [autoDisconnectBle, autoDisconnectTimeoutSeconds]);
+
+  useEffect(() => {
+    const controller = autoDisconnectControllerRef.current;
+    if (isConnected) controller?.connectedNow();
+    else controller?.disconnectedNow();
+    return () => controller?.disconnectedNow();
+  }, [isConnected]);
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (state) => {
+      if (state === 'active') autoDisconnectControllerRef.current?.resume();
+    });
+    return () => subscription.remove();
+  }, []);
+
+  // The deadline controller owns expiry; this lightweight poll only drives the
+  // final-ten-second visual hint. It runs while connected and updates once per
+  // second, avoiding a per-frame animation/state subscription in the provider.
+  useEffect(() => {
+    setAutoDisconnectWarning(false);
+    if (!isConnected || !autoDisconnectBle) return;
+
+    const updateWarning = () => {
+      const deadlineMs = autoDisconnectControllerRef.current?.getDeadlineMs() ?? null;
+      setAutoDisconnectWarning(deadlineMs !== null && deadlineMs - Date.now() <= 10_000);
+    };
+    updateWarning();
+    const interval = setInterval(updateWarning, 1000);
+    return () => clearInterval(interval);
+  }, [isConnected, autoDisconnectBle, autoDisconnectTimeoutSeconds]);
 
   // Register with the module-level status store so consumers rendered outside
   // this provider (e.g. the root tab bar, the long-press BLE controls sheet) can
@@ -1407,6 +1479,7 @@ export function BluetoothProvider({
       connect,
       disconnect: wrappedDisconnect,
       sendFramesToBoard,
+      notifyClimbDisplaySucceeded: resetAutoDisconnect,
       clearBoard,
       reassertWall,
       undoWallChange,
@@ -1414,6 +1487,9 @@ export function BluetoothProvider({
       armUndoWallChangeToast,
       reconnectSerialForCurrentBoard,
       reconnectDeviceIdForCurrentBoard,
+      autoDisconnectEnabled: autoDisconnectBle,
+      autoDisconnectTimeoutSeconds,
+      autoDisconnectWarning,
     }),
     [
       isConnected,
@@ -1421,6 +1497,7 @@ export function BluetoothProvider({
       connect,
       wrappedDisconnect,
       sendFramesToBoard,
+      resetAutoDisconnect,
       clearBoard,
       reassertWall,
       undoWallChange,
@@ -1428,6 +1505,9 @@ export function BluetoothProvider({
       armUndoWallChangeToast,
       reconnectSerialForCurrentBoard,
       reconnectDeviceIdForCurrentBoard,
+      autoDisconnectBle,
+      autoDisconnectTimeoutSeconds,
+      autoDisconnectWarning,
     ],
   );
 
@@ -1453,6 +1533,7 @@ export function BluetoothProvider({
         <BluetoothAutoSender
           sendFramesToBoard={sendFramesToBoard}
           onWallConfirmed={handleWallConfirmed}
+          onClimbDisplaySucceeded={resetAutoDisconnect}
           reassertNonce={reassertNonce}
           connectInitialSendRef={connectInitialSendRef}
           lastPhysicalFramesRef={lastPhysicalFramesRef}

--- a/packages/mobile/src/settings/__tests__/hooks.test.ts
+++ b/packages/mobile/src/settings/__tests__/hooks.test.ts
@@ -34,6 +34,8 @@ describe('settings', () => {
   describe('getSetting', () => {
     it('returns default when no value is stored', () => {
       expect(getSetting('autoConnectBle')).toBe(true);
+      expect(getSetting('autoDisconnectBle')).toBe(false);
+      expect(getSetting('autoDisconnectTimeoutSeconds')).toBe(30);
       expect(getSetting('theme')).toBe('system');
       expect(getSetting('defaultBoardUuid')).toBeNull();
       expect(getSetting('syncEnabledBoards')).toEqual([]);

--- a/packages/mobile/src/settings/defaults.ts
+++ b/packages/mobile/src/settings/defaults.ts
@@ -6,6 +6,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
   offlineBoardsV1: [],
   autoOfflineBoards: false,
   autoConnectBle: true,
+  autoDisconnectBle: false,
+  autoDisconnectTimeoutSeconds: 30,
   keepScreenAwake: true,
   theme: 'system',
   hapticFeedbackEnabled: true,

--- a/packages/mobile/src/settings/types.ts
+++ b/packages/mobile/src/settings/types.ts
@@ -14,6 +14,8 @@ export type AppSettings = {
   /** Keep every board the user follows/uses available offline by default. */
   autoOfflineBoards: boolean;
   autoConnectBle: boolean;
+  autoDisconnectBle: boolean;
+  autoDisconnectTimeoutSeconds: number;
   keepScreenAwake: boolean;
   theme: 'system' | 'light' | 'dark';
   hapticFeedbackEnabled: boolean;

--- a/packages/shared/i18n/locales/de/settings.json
+++ b/packages/shared/i18n/locales/de/settings.json
@@ -493,6 +493,26 @@
     "cancel": "Abbrechen",
     "connectBoard": "Board verbinden",
     "relightBoard": "Board neu beleuchten",
+    "autoDisconnect": {
+      "title": "Automatisch trennen",
+      "description": "Trennt die Verbindung zum Board, wenn für die gewählte Zeit kein Boulder angezeigt wurde.",
+      "enabledLabel": "Automatisch trennen",
+      "enabledDescription": "Lass andere Kletterer*innen verbinden, sobald der Timer abläuft.",
+      "timeoutLabel": "Trennen nach",
+      "toggleTitle": "Automatisch trennen",
+      "toggleSubtitle": "Trennen nach {{timeout}} ohne Aktivität",
+      "toggleAccessibility": "Automatisches Trennen umschalten",
+      "timeoutOptions": {
+        "10": "10 Sekunden",
+        "15": "15 Sekunden",
+        "30": "30 Sekunden",
+        "45": "45 Sekunden",
+        "60": "1 Minute",
+        "120": "2 Minuten",
+        "300": "5 Minuten",
+        "600": "10 Minuten"
+      }
+    },
     "turnOff": "Board ausschalten",
     "holdForControls": "Halten für die Board-Steuerung",
     "sendFailedTitle": "Board ließ sich nicht beleuchten",

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -493,6 +493,26 @@
     "cancel": "Cancel",
     "connectBoard": "Connect Board",
     "relightBoard": "Re-light board",
+    "autoDisconnect": {
+      "title": "Auto-disconnect",
+      "description": "Disconnect from the board after no climb has been displayed for the selected time.",
+      "enabledLabel": "Auto-disconnect",
+      "enabledDescription": "Let other climbers connect after the timer expires.",
+      "timeoutLabel": "Disconnect after",
+      "toggleTitle": "Auto-disconnect",
+      "toggleSubtitle": "Disconnect after {{timeout}} of inactivity",
+      "toggleAccessibility": "Toggle auto-disconnect",
+      "timeoutOptions": {
+        "10": "10 seconds",
+        "15": "15 seconds",
+        "30": "30 seconds",
+        "45": "45 seconds",
+        "60": "1 minute",
+        "120": "2 minutes",
+        "300": "5 minutes",
+        "600": "10 minutes"
+      }
+    },
     "turnOff": "Turn off the board",
     "holdForControls": "Hold for board controls",
     "sendFailedTitle": "Couldn't light board",

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -493,6 +493,26 @@
     "cancel": "Cancelar",
     "connectBoard": "Conectar plafón",
     "relightBoard": "Reiluminar plafón",
+    "autoDisconnect": {
+      "title": "Desconexión automática",
+      "description": "Desconecta del plafón después de no mostrar una escalada durante el tiempo elegido.",
+      "enabledLabel": "Desconexión automática",
+      "enabledDescription": "Permite que otros escaladores se conecten cuando termine el temporizador.",
+      "timeoutLabel": "Desconectar después de",
+      "toggleTitle": "Desconexión automática",
+      "toggleSubtitle": "Desconectar después de {{timeout}} de inactividad",
+      "toggleAccessibility": "Activar o desactivar la desconexión automática",
+      "timeoutOptions": {
+        "10": "10 segundos",
+        "15": "15 segundos",
+        "30": "30 segundos",
+        "45": "45 segundos",
+        "60": "1 minuto",
+        "120": "2 minutos",
+        "300": "5 minutos",
+        "600": "10 minutos"
+      }
+    },
     "turnOff": "Apagar el plafón",
     "holdForControls": "Mantén pulsado para los controles",
     "sendFailedTitle": "No se pudo iluminar el plafón",

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -495,7 +495,7 @@
     "relightBoard": "Reiluminar plafón",
     "autoDisconnect": {
       "title": "Desconexión automática",
-      "description": "Desconecta del plafón después de no mostrar una escalada durante el tiempo elegido.",
+      "description": "Desconecta del plafón cuando no se ha mostrado ningún bloque durante el tiempo elegido.",
       "enabledLabel": "Desconexión automática",
       "enabledDescription": "Permite que otros escaladores se conecten cuando termine el temporizador.",
       "timeoutLabel": "Desconectar después de",

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -495,7 +495,7 @@
     "relightBoard": "Rallumer la board",
     "autoDisconnect": {
       "title": "Déconnexion automatique",
-      "description": "Se déconnecter de la board après la durée choisie sans nouvelle escalade affichée.",
+      "description": "Se déconnecter de la board après la durée choisie sans nouveau bloc affiché.",
       "enabledLabel": "Déconnexion automatique",
       "enabledDescription": "Laisser les autres grimpeurs se connecter à l'expiration du délai.",
       "timeoutLabel": "Déconnecter après",

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -493,6 +493,26 @@
     "cancel": "Annuler",
     "connectBoard": "Connecter la board",
     "relightBoard": "Rallumer la board",
+    "autoDisconnect": {
+      "title": "Déconnexion automatique",
+      "description": "Se déconnecter de la board après la durée choisie sans nouvelle escalade affichée.",
+      "enabledLabel": "Déconnexion automatique",
+      "enabledDescription": "Laisser les autres grimpeurs se connecter à l'expiration du délai.",
+      "timeoutLabel": "Déconnecter après",
+      "toggleTitle": "Déconnexion automatique",
+      "toggleSubtitle": "Déconnexion après {{timeout}} d'inactivité",
+      "toggleAccessibility": "Activer ou désactiver la déconnexion automatique",
+      "timeoutOptions": {
+        "10": "10 secondes",
+        "15": "15 secondes",
+        "30": "30 secondes",
+        "45": "45 secondes",
+        "60": "1 minute",
+        "120": "2 minutes",
+        "300": "5 minutes",
+        "600": "10 minutes"
+      }
+    },
     "turnOff": "Éteindre la board",
     "holdForControls": "Maintenir pour les commandes",
     "sendFailedTitle": "Impossible d'allumer la board",


### PR DESCRIPTION
## Summary

Adds an optional mobile BLE auto-disconnect timer. Climbers can choose an inactivity timeout, keep the current climb lit while browsing, and let another phone connect automatically after the timeout.

## Release Notes

- Added optional auto-disconnect setting:
  - Let other climbers take over your board automatically after a configurable idle period.
  - Keep the last climb lit while you browse, then reconnect when you’re ready.

## Test plan

- passed `vp run typecheck:mobile` `vp run test:mobile`, and `vp run check:mobile-bundle` as well as commit checks
- Added unit coverage for timer start, reset, cancellation, foreground expiry, successful climb-display writes, and reconnect races.
- Verified the ESP32 test board builds, connects to Wi-Fi, advertises over BLE, and accepts the Kilter Board configuration.
- Physical iPhone BLE/OTA testing remains to be completed with the PR preview.