### PR TITLE
fix(ci): report renumber push outcomes truthfully

### DIFF
--- a/.github/workflows/db-migration-renumber.yml
+++ b/.github/workflows/db-migration-renumber.yml
@@ -188,6 +188,7 @@ jobs:
             --strategy "${{ github.event.inputs.strategy || 'rebase' }}"
 
       - name: Validate the resulting migration folder
+        id: validate
         if: steps.renumber.outputs.status == 'renumbered'
         run: |
           bun .renumber-tooling/scripts/check-db-migrations.ts \
@@ -198,12 +199,14 @@ jobs:
       # the journal tail actually landed — which is what catches a migration whose
       # `when` would make it silently skipped forever.
       - name: Verify the migrations apply
+        id: apply
         if: steps.renumber.outputs.status == 'renumbered'
         env:
           VERIFY_MIGRATION_JOURNAL: '1'
         run: bun run --filter=@boardsesh/db db:migrate
 
       - name: Verify re-applying is a no-op
+        id: reapply
         if: steps.renumber.outputs.status == 'renumbered'
         run: bun run --filter=@boardsesh/db db:migrate
 
@@ -217,14 +220,21 @@ jobs:
               owner: context.repo.owner, repo: context.repo.repo,
               pull_number: Number(process.env.PR_NUMBER),
             });
-            const ok =
-              pr.state === 'open' &&
-              pr.head.sha === process.env.HEAD_SHA &&
-              !pr.labels.some((label) => label.name === 'renumber:skip');
+            const reasons = [];
+            if (pr.state !== 'open') reasons.push(`The PR is ${pr.state}.`);
+            if (pr.head.sha !== process.env.HEAD_SHA) {
+              reasons.push(`The branch moved during the final re-check (head is now ${pr.head.sha}).`);
+            }
+            if (pr.labels.some((label) => label.name === 'renumber:skip')) {
+              reasons.push('The `renumber:skip` label appeared during the final re-check.');
+            }
+            const ok = reasons.length === 0;
             core.setOutput('ok', String(ok));
-            if (!ok) core.warning(`#${process.env.PR_NUMBER} moved during the run (head is now ${pr.head.sha}) — not pushing.`);
+            core.setOutput('reason', reasons.join(' '));
+            if (!ok) core.warning(`#${process.env.PR_NUMBER}: ${reasons.join(' ')} Not pushing.`);
 
       - name: Force-push the renumbered branch
+        id: push
         if: steps.renumber.outputs.status == 'renumbered' && steps.recheck.outputs.ok == 'true'
         env:
           GH_APP_TOKEN: ${{ steps.push_token.outputs.token }}
@@ -242,16 +252,43 @@ jobs:
         uses: actions/github-script@v7
         env:
           COMMENT_B64: ${{ steps.renumber.outputs.comment_b64 }}
-          PUSHED: ${{ steps.recheck.outputs.ok }}
+          RENUMBER_STATUS: ${{ steps.renumber.outputs.status }}
+          VALIDATION_OUTCOME: ${{ steps.validate.outcome }}
+          APPLY_OUTCOME: ${{ steps.apply.outcome }}
+          REAPPLY_OUTCOME: ${{ steps.reapply.outcome }}
+          RECHECK_OUTCOME: ${{ steps.recheck.outcome }}
+          RECHECK_OK: ${{ steps.recheck.outputs.ok }}
+          RECHECK_REASON: ${{ steps.recheck.outputs.reason }}
+          PUSH_OUTCOME: ${{ steps.push.outcome }}
         with:
           script: |
-            const marker = '<!-- db-renumber -->';
-            let body = process.env.COMMENT_B64
+            // This module comes from main's trusted tooling checkout and has no
+            // package dependency, so this always() step still runs if bun install
+            // or proof-of-apply failed in the PR checkout.
+            const { renderRenumberWorkflowComment } = require(
+              `${process.env.GITHUB_WORKSPACE}/.renumber-tooling/scripts/lib/db-renumber-comment.cjs`,
+            );
+            const commentBody = process.env.COMMENT_B64
               ? Buffer.from(process.env.COMMENT_B64, 'base64').toString('utf8')
-              : `${marker}\n\n### 🚧 The renumber job failed\n\nSee the [run log](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}). Nothing was pushed.`;
-            if (process.env.PUSHED === 'false') {
-              body += '\n\n> ⚠️ The branch moved while this ran, so nothing was pushed. It will retry on the next migration merge.';
-            }
+              : '';
+            const body = renderRenumberWorkflowComment({
+              renumberStatus: process.env.RENUMBER_STATUS,
+              commentBody,
+              validationOutcome: process.env.VALIDATION_OUTCOME,
+              applyOutcome: process.env.APPLY_OUTCOME,
+              reapplyOutcome: process.env.REAPPLY_OUTCOME,
+              recheckOutcome: process.env.RECHECK_OUTCOME,
+              recheckOk: process.env.RECHECK_OK,
+              recheckReason: process.env.RECHECK_REASON,
+              pushOutcome: process.env.PUSH_OUTCOME,
+              context: {
+                serverUrl: context.serverUrl,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                runId: context.runId,
+              },
+            });
+            const marker = '<!-- db-renumber -->';
 
             // Paginated: an unpaginated first-100 lookup would miss the marker on a
             // long PR and post a duplicate comment every run instead of updating.

--- a/.github/workflows/db-migration-renumber.yml
+++ b/.github/workflows/db-migration-renumber.yml
@@ -41,7 +41,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: read
 
 concurrency:
   # NOT cancel-in-progress: being killed between the push and the comment would
@@ -108,6 +108,16 @@ jobs:
     if: needs.gate.outputs.run == 'true' && vars.OTA_PUSH_APP_ID != ''
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      renumber_status: ${{ steps.renumber.outputs.status }}
+      comment_b64: ${{ steps.renumber.outputs.comment_b64 }}
+      validation_outcome: ${{ steps.validate.outcome }}
+      apply_outcome: ${{ steps.apply.outcome }}
+      reapply_outcome: ${{ steps.reapply.outcome }}
+      recheck_outcome: ${{ steps.recheck.outcome }}
+      recheck_ok: ${{ steps.recheck.outputs.ok }}
+      recheck_reason: ${{ steps.recheck.outputs.reason }}
+      push_outcome: ${{ steps.push.outcome }}
     services:
       # The only viable verification target. A from-scratch `drizzle-kit migrate` on
       # a bare Postgres cannot work: 0000_*.sql ALTERs kilter_climbs/tension_climbs,
@@ -160,10 +170,12 @@ jobs:
       # its own. Kept out of the workspace root would be tidier, but actions/checkout
       # requires a path inside it; the script stages explicitly rather than
       # `git add -A`, so this directory can never end up in the commit.
-      - name: Check out the renumber tooling from main
+      - name: Check out the trusted renumber tooling
         uses: actions/checkout@v4
         with:
-          ref: main
+          # Pin tooling to the immutable commit whose workflow is executing.
+          # A moving `main` ref could otherwise change the program mid-run.
+          ref: ${{ github.workflow_sha }}
           path: .renumber-tooling
           persist-credentials: false
 
@@ -247,26 +259,51 @@ jobs:
             "https://x-access-token:${GH_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
             "HEAD:refs/heads/$BRANCH"
 
+  # PR-controlled install/build/migration code ran in `renumber`. Never load a
+  # helper from that writable runner inside a token-bearing action: a postinstall
+  # could replace it. This fresh runner checks out only the immutable workflow
+  # commit, then renders and upserts the sticky comment with the narrow PR token.
+  comment:
+    needs: [gate, renumber]
+    if: >-
+      always() &&
+      needs.gate.result == 'success' &&
+      needs.gate.outputs.run == 'true' &&
+      needs.renumber.outputs.renumber_status != 'no-op'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      PR_NUMBER: ${{ github.event.inputs.pr }}
+    steps:
+      - name: Check out trusted comment tooling
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          sparse-checkout: scripts/lib/db-renumber-comment.cjs
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
       - name: Comment the outcome
-        if: always() && steps.renumber.outputs.status != 'no-op'
         uses: actions/github-script@v7
         env:
-          COMMENT_B64: ${{ steps.renumber.outputs.comment_b64 }}
-          RENUMBER_STATUS: ${{ steps.renumber.outputs.status }}
-          VALIDATION_OUTCOME: ${{ steps.validate.outcome }}
-          APPLY_OUTCOME: ${{ steps.apply.outcome }}
-          REAPPLY_OUTCOME: ${{ steps.reapply.outcome }}
-          RECHECK_OUTCOME: ${{ steps.recheck.outcome }}
-          RECHECK_OK: ${{ steps.recheck.outputs.ok }}
-          RECHECK_REASON: ${{ steps.recheck.outputs.reason }}
-          PUSH_OUTCOME: ${{ steps.push.outcome }}
+          COMMENT_B64: ${{ needs.renumber.outputs.comment_b64 }}
+          RENUMBER_STATUS: ${{ needs.renumber.outputs.renumber_status }}
+          VALIDATION_OUTCOME: ${{ needs.renumber.outputs.validation_outcome }}
+          APPLY_OUTCOME: ${{ needs.renumber.outputs.apply_outcome }}
+          REAPPLY_OUTCOME: ${{ needs.renumber.outputs.reapply_outcome }}
+          RECHECK_OUTCOME: ${{ needs.renumber.outputs.recheck_outcome }}
+          RECHECK_OK: ${{ needs.renumber.outputs.recheck_ok }}
+          RECHECK_REASON: ${{ needs.renumber.outputs.recheck_reason }}
+          PUSH_OUTCOME: ${{ needs.renumber.outputs.push_outcome }}
         with:
           script: |
-            // This module comes from main's trusted tooling checkout and has no
-            // package dependency, so this always() step still runs if bun install
-            // or proof-of-apply failed in the PR checkout.
+            // This dependency-free module comes from the immutable workflow
+            // commit on a fresh runner that never executed PR-controlled code.
             const { renderRenumberWorkflowComment } = require(
-              `${process.env.GITHUB_WORKSPACE}/.renumber-tooling/scripts/lib/db-renumber-comment.cjs`,
+              `${process.env.GITHUB_WORKSPACE}/scripts/lib/db-renumber-comment.cjs`,
             );
             const commentBody = process.env.COMMENT_B64
               ? Buffer.from(process.env.COMMENT_B64, 'base64').toString('utf8')

--- a/.github/workflows/db-migration-renumber.yml
+++ b/.github/workflows/db-migration-renumber.yml
@@ -60,12 +60,13 @@ jobs:
       head_sha: ${{ steps.decide.outputs.head_sha }}
       skip_reason: ${{ steps.decide.outputs.skip_reason }}
     steps:
-      # Fail loudly rather than skipping. Without this the whole `renumber` job —
-      # including its comment step — is skipped by the `vars.OTA_PUSH_APP_ID` guard,
-      # so a missing or expired App credential looks exactly like "nothing to do":
-      # the dispatch fires, the gate passes, and stranded PRs get no explanation.
-      # This is operator misconfiguration, not a per-PR condition, so a red run is
-      # the right signal.
+      # Fail loudly rather than skipping. Without this the `renumber` job is skipped
+      # by its `vars.OTA_PUSH_APP_ID` guard, so a missing or expired App credential
+      # looks exactly like "nothing to do": the dispatch fires, the gate passes, and
+      # stranded PRs get no explanation. Failing here also stops the `comment` job,
+      # which needs a successful gate — otherwise it would post a "renumbering was
+      # held" comment blaming the PR for an operator misconfiguration. A red run is
+      # the right signal for that.
       - name: Require the push credential
         if: vars.OTA_PUSH_APP_ID == ''
         run: |
@@ -302,7 +303,9 @@ jobs:
           script: |
             // This dependency-free module comes from the immutable workflow
             // commit on a fresh runner that never executed PR-controlled code.
-            const { renderRenumberWorkflowComment } = require(
+            // Take the sticky marker from it too — a second copy here would drift
+            // and turn every upsert into a duplicate comment.
+            const { STICKY_MARKER, renderRenumberWorkflowComment } = require(
               `${process.env.GITHUB_WORKSPACE}/scripts/lib/db-renumber-comment.cjs`,
             );
             const commentBody = process.env.COMMENT_B64
@@ -325,14 +328,13 @@ jobs:
                 runId: context.runId,
               },
             });
-            const marker = '<!-- db-renumber -->';
 
             // Paginated: an unpaginated first-100 lookup would miss the marker on a
             // long PR and post a duplicate comment every run instead of updating.
             const comments = await github.paginate(github.rest.issues.listComments, {
               ...context.repo, issue_number: Number(process.env.PR_NUMBER), per_page: 100,
             });
-            const existing = comments.find((comment) => comment.body?.includes(marker));
+            const existing = comments.find((comment) => comment.body?.includes(STICKY_MARKER));
             if (existing) {
               await github.rest.issues.updateComment({ ...context.repo, comment_id: existing.id, body });
             } else {

--- a/docs/db-migrations.md
+++ b/docs/db-migrations.md
@@ -57,7 +57,9 @@ and git history carries 26 hand-written renumber commits.
 migration lands on main, `.github/workflows/db-migration-renumber-dispatch.yml` fans out
 a renumber run for every stranded PR. The bot rebases you onto main, moves your
 migration to the next free number, proves it still applies against Postgres, and
-force-pushes. Your SQL is never rewritten.
+force-pushes. Your SQL is never rewritten. Its PR comment says the renumber landed
+only after that force-push succeeds; a failed validation, proof, re-check, or push
+leaves a "Nothing was pushed" comment with the action run to inspect.
 
 To do it yourself, or when the bot stops:
 

--- a/scripts/db-renumber-migration.test.ts
+++ b/scripts/db-renumber-migration.test.ts
@@ -219,6 +219,8 @@ describe('parseArgs', () => {
   });
 });
 
+// Intentionally source-based and test-load-bearing: workflow job-boundary or
+// formatting changes fail closed so the privileged path gets deliberate review.
 describe('workflow comment trust boundary', () => {
   const workflowSource = readFileSync(
     resolve(dirname(fileURLToPath(import.meta.url)), '../.github/workflows/db-migration-renumber.yml'),

--- a/scripts/db-renumber-migration.test.ts
+++ b/scripts/db-renumber-migration.test.ts
@@ -219,6 +219,112 @@ describe('parseArgs', () => {
   });
 });
 
+function sliceWorkflowJob(workflowSource: string, jobName: string): string {
+  const jobMarker = `\n  ${jobName}:\n`;
+  const jobStart = workflowSource.indexOf(jobMarker);
+  if (jobStart === -1) return '';
+
+  const jobContentStart = jobStart + jobMarker.length;
+  const nextSiblingOffset = workflowSource.slice(jobContentStart).search(/\n  [A-Za-z_][A-Za-z0-9_-]*:\n/);
+  const jobEnd = nextSiblingOffset === -1 ? workflowSource.length : jobContentStart + nextSiblingOffset;
+  return workflowSource.slice(jobStart, jobEnd);
+}
+
+const FORCE_PUSH_STEP_NAME = 'Force-push the renumbered branch';
+const EXPECTED_FORCE_PUSH_CONDITION =
+  "steps.renumber.outputs.status == 'renumbered' && steps.recheck.outputs.ok == 'true'";
+const EXPECTED_PROOF_STEP_CONDITION = "steps.renumber.outputs.status == 'renumbered'";
+const EXPECTED_COMMENT_JOB_CONDITION =
+  "always() && needs.gate.result == 'success' && needs.gate.outputs.run == 'true' && needs.renumber.outputs.renumber_status != 'no-op'";
+const PROOF_STEP_NAMES = [
+  'Validate the resulting migration folder',
+  'Verify the migrations apply',
+  'Verify re-applying is a no-op',
+  'Re-check the PR immediately before pushing',
+] as const;
+
+function sliceWorkflowStep(jobSource: string, stepName: string): string {
+  const stepMarker = `\n      - name: ${stepName}\n`;
+  const stepStart = jobSource.indexOf(stepMarker);
+  if (stepStart === -1) return '';
+
+  const stepContentStart = stepStart + stepMarker.length;
+  const nextStepOffset = jobSource.slice(stepContentStart).search(/\n      - /);
+  const stepEnd = nextStepOffset === -1 ? jobSource.length : stepContentStart + nextStepOffset;
+  return jobSource.slice(stepStart, stepEnd);
+}
+
+function normalizedWorkflowConditions(workflowSource: string, indentation: number): string[] {
+  const lines = workflowSource.split('\n');
+  const conditions: string[] = [];
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const conditionMatch = lines[lineIndex]?.match(/^( *)(?:if|'if'|"if"):\s*(.*)$/);
+    if (!conditionMatch || conditionMatch[1]?.length !== indentation) continue;
+
+    const rawCondition = conditionMatch[2]?.trim() ?? '';
+    if (!/^[>|][+-]?$/.test(rawCondition)) {
+      conditions.push(rawCondition.replace(/\s+/g, ' '));
+      continue;
+    }
+
+    const foldedLines: string[] = [];
+    for (let foldedLineIndex = lineIndex + 1; foldedLineIndex < lines.length; foldedLineIndex += 1) {
+      const foldedLine = lines[foldedLineIndex] ?? '';
+      const foldedIndentation = foldedLine.match(/^ */)?.[0].length ?? 0;
+      if (foldedLine.trim().length > 0 && foldedIndentation <= indentation) break;
+      foldedLines.push(foldedLine.trim());
+      lineIndex = foldedLineIndex;
+    }
+    conditions.push(foldedLines.filter(Boolean).join(' ').replace(/\s+/g, ' '));
+  }
+
+  return conditions;
+}
+
+function renumberPushContractViolations(renumberJobSource: string): string[] {
+  const violations: string[] = [];
+  const pushStepMarker = `\n      - name: ${FORCE_PUSH_STEP_NAME}\n`;
+  const pushStepStart = renumberJobSource.indexOf(pushStepMarker);
+  const pushStep = sliceWorkflowStep(renumberJobSource, FORCE_PUSH_STEP_NAME);
+  const pushConditions = normalizedWorkflowConditions(pushStep, 8);
+
+  if (pushStepStart === -1 || pushStep.length === 0) {
+    violations.push('force-push step is missing');
+  } else if (pushConditions.length !== 1 || pushConditions[0] !== EXPECTED_FORCE_PUSH_CONDITION) {
+    violations.push('force-push condition changed');
+  }
+
+  for (const proofStepName of PROOF_STEP_NAMES) {
+    const proofStepMarker = `\n      - name: ${proofStepName}\n`;
+    const proofStepStart = renumberJobSource.indexOf(proofStepMarker);
+    const proofStep = sliceWorkflowStep(renumberJobSource, proofStepName);
+    if (proofStepStart === -1 || proofStep.length === 0) {
+      violations.push(`${proofStepName} is missing`);
+      continue;
+    }
+    if (pushStepStart !== -1 && proofStepStart >= pushStepStart) {
+      violations.push(`${proofStepName} does not precede force-push`);
+    }
+    const proofConditions = normalizedWorkflowConditions(proofStep, 8);
+    if (proofConditions.length !== 1 || proofConditions[0] !== EXPECTED_PROOF_STEP_CONDITION) {
+      violations.push(`${proofStepName} condition changed`);
+    }
+    if (/^\s*(?:continue-on-error|'continue-on-error'|"continue-on-error")\s*:/m.test(proofStep)) {
+      violations.push(`${proofStepName} permits continue-on-error`);
+    }
+  }
+
+  return violations;
+}
+
+function commentJobContractViolations(commentJobSource: string): string[] {
+  const commentConditions = normalizedWorkflowConditions(commentJobSource, 4);
+  return commentConditions.length === 1 && commentConditions[0] === EXPECTED_COMMENT_JOB_CONDITION
+    ? []
+    : ['comment job condition changed'];
+}
+
 // Intentionally source-based and test-load-bearing: workflow job-boundary or
 // formatting changes fail closed so the privileged path gets deliberate review.
 describe('workflow comment trust boundary', () => {
@@ -228,8 +334,8 @@ describe('workflow comment trust boundary', () => {
   );
   const renumberJobStart = workflowSource.indexOf('\n  renumber:\n');
   const commentJobStart = workflowSource.indexOf('\n  comment:\n');
-  const renumberJob = workflowSource.slice(renumberJobStart, commentJobStart);
-  const commentJob = workflowSource.slice(commentJobStart);
+  const renumberJob = sliceWorkflowJob(workflowSource, 'renumber');
+  const commentJob = sliceWorkflowJob(workflowSource, 'comment');
 
   it('keeps PR-controlled work out of the pull-request-write job', () => {
     expect(renumberJobStart).toBeGreaterThan(-1);
@@ -238,6 +344,55 @@ describe('workflow comment trust boundary', () => {
     expect(renumberJob).not.toContain('renderRenumberWorkflowComment');
     expect(commentJob).toContain('needs: [gate, renumber]');
     expect(commentJob).toContain('pull-requests: write');
+    expect(commentJobContractViolations(commentJob)).toEqual([]);
+  });
+
+  it('keeps force-push behind every proof step and the implicit success guard', () => {
+    expect(renumberPushContractViolations(renumberJob)).toEqual([]);
+  });
+
+  it('rejects a status-function escape in the force-push condition', () => {
+    const escapedConditionJob = renumberJob.replace(
+      `if: ${EXPECTED_FORCE_PUSH_CONDITION}`,
+      `if: ${EXPECTED_FORCE_PUSH_CONDITION} || !success()`,
+    );
+    expect(escapedConditionJob).not.toBe(renumberJob);
+    expect(renumberPushContractViolations(escapedConditionJob)).toContain('force-push condition changed');
+  });
+
+  it('rejects continue-on-error on every proof step', () => {
+    for (const proofStepName of PROOF_STEP_NAMES) {
+      for (const continueOnErrorKey of ['continue-on-error', "'continue-on-error'", '"continue-on-error"']) {
+        const proofStepMarker = `\n      - name: ${proofStepName}\n`;
+        const continueOnErrorJob = renumberJob.replace(
+          proofStepMarker,
+          `${proofStepMarker}        ${continueOnErrorKey}: true\n`,
+        );
+        expect(continueOnErrorJob, `${proofStepName} mutation should apply`).not.toBe(renumberJob);
+        expect(renumberPushContractViolations(continueOnErrorJob)).toContain(
+          `${proofStepName} permits continue-on-error`,
+        );
+      }
+    }
+  });
+
+  it('rejects a false condition on every proof step', () => {
+    for (const proofStepName of PROOF_STEP_NAMES) {
+      const proofStep = sliceWorkflowStep(renumberJob, proofStepName);
+      const falseConditionStep = proofStep.replace(`if: ${EXPECTED_PROOF_STEP_CONDITION}`, 'if: false');
+      expect(falseConditionStep, `${proofStepName} mutation should apply`).not.toBe(proofStep);
+      const falseConditionJob = renumberJob.replace(proofStep, falseConditionStep);
+      expect(renumberPushContractViolations(falseConditionJob)).toContain(`${proofStepName} condition changed`);
+    }
+  });
+
+  it('rejects an always-true escape in the comment job condition', () => {
+    const escapedCommentJob = commentJob.replace(
+      "needs.renumber.outputs.renumber_status != 'no-op'",
+      "needs.renumber.outputs.renumber_status != 'no-op' || true",
+    );
+    expect(escapedCommentJob).not.toBe(commentJob);
+    expect(commentJobContractViolations(escapedCommentJob)).toEqual(['comment job condition changed']);
   });
 
   it('loads the helper from the immutable workflow commit on the fresh comment runner', () => {
@@ -247,5 +402,11 @@ describe('workflow comment trust boundary', () => {
     expect(commentJob).toContain('persist-credentials: false');
     expect(commentJob).toContain('`${process.env.GITHUB_WORKSPACE}/scripts/lib/db-renumber-comment.cjs`');
     expect(commentJob).not.toContain('.renumber-tooling');
+  });
+
+  it('stops the comment-job slice before a future sibling job', () => {
+    const workflowWithLaterJob = `${workflowSource.trimEnd()}\n  later_job:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo .renumber-tooling\n`;
+    expect(workflowWithLaterJob).toContain('.renumber-tooling');
+    expect(sliceWorkflowJob(workflowWithLaterJob, 'comment')).not.toContain('.renumber-tooling');
   });
 });

--- a/scripts/db-renumber-migration.test.ts
+++ b/scripts/db-renumber-migration.test.ts
@@ -218,3 +218,32 @@ describe('parseArgs', () => {
     expect(() => parseArgs(['--force'])).toThrow(/unknown argument/);
   });
 });
+
+describe('workflow comment trust boundary', () => {
+  const workflowSource = readFileSync(
+    resolve(dirname(fileURLToPath(import.meta.url)), '../.github/workflows/db-migration-renumber.yml'),
+    'utf8',
+  );
+  const renumberJobStart = workflowSource.indexOf('\n  renumber:\n');
+  const commentJobStart = workflowSource.indexOf('\n  comment:\n');
+  const renumberJob = workflowSource.slice(renumberJobStart, commentJobStart);
+  const commentJob = workflowSource.slice(commentJobStart);
+
+  it('keeps PR-controlled work out of the pull-request-write job', () => {
+    expect(renumberJobStart).toBeGreaterThan(-1);
+    expect(commentJobStart).toBeGreaterThan(renumberJobStart);
+    expect(workflowSource.slice(0, renumberJobStart)).toContain('pull-requests: read');
+    expect(renumberJob).not.toContain('renderRenumberWorkflowComment');
+    expect(commentJob).toContain('needs: [gate, renumber]');
+    expect(commentJob).toContain('pull-requests: write');
+  });
+
+  it('loads the helper from the immutable workflow commit on the fresh comment runner', () => {
+    expect(commentJob).toContain('always() &&');
+    expect(commentJob).toContain('ref: ${{ github.workflow_sha }}');
+    expect(commentJob).toContain('sparse-checkout: scripts/lib/db-renumber-comment.cjs');
+    expect(commentJob).toContain('persist-credentials: false');
+    expect(commentJob).toContain('`${process.env.GITHUB_WORKSPACE}/scripts/lib/db-renumber-comment.cjs`');
+    expect(commentJob).not.toContain('.renumber-tooling');
+  });
+});

--- a/scripts/db-renumber-migration.test.ts
+++ b/scripts/db-renumber-migration.test.ts
@@ -404,6 +404,14 @@ describe('workflow comment trust boundary', () => {
     expect(commentJob).not.toContain('.renumber-tooling');
   });
 
+  it('takes the sticky marker from the shared module rather than redefining it', () => {
+    // A literal copy here drifts silently: the upsert lookup stops matching the
+    // script-written comment and the bot posts a duplicate on every run.
+    expect(commentJob).toContain('const { STICKY_MARKER, renderRenumberWorkflowComment } = require(');
+    expect(commentJob).toContain('comment.body?.includes(STICKY_MARKER)');
+    expect(commentJob).not.toContain(`'${STICKY_MARKER}'`);
+  });
+
   it('stops the comment-job slice before a future sibling job', () => {
     const workflowWithLaterJob = `${workflowSource.trimEnd()}\n  later_job:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo .renumber-tooling\n`;
     expect(workflowWithLaterJob).toContain('.renumber-tooling');

--- a/scripts/lib/db-renumber-comment.cjs
+++ b/scripts/lib/db-renumber-comment.cjs
@@ -87,16 +87,7 @@ function renderRenumberWorkflowComment(input) {
     return heldBody(context, recheckReason || 'The PR changed or was opted out during the final re-check.');
   }
 
-  if (pushOutcome === 'failure') {
-    return heldBody(context, 'Force-pushing the locally renumbered branch failed.');
-  }
-
-  return heldBody(
-    context,
-    pushOutcome === 'skipped' || !pushOutcome
-      ? 'The force-push was skipped after local renumbering.'
-      : `The force-push did not succeed (step outcome: ${pushOutcome}).`,
-  );
+  return heldBody(context, `The force-push ${failedStepState(pushOutcome)} after local renumbering.`);
 }
 
 module.exports = { STICKY_MARKER, renderRenumberWorkflowComment };

--- a/scripts/lib/db-renumber-comment.cjs
+++ b/scripts/lib/db-renumber-comment.cjs
@@ -1,0 +1,102 @@
+/**
+ * The comment decision used by db-migration-renumber.yml.
+ *
+ * This stays dependency-free CommonJS so `actions/github-script` can load it
+ * from the checked-out default-branch tooling even when installing the PR's
+ * dependencies or proving its migrations has failed.
+ */
+
+const STICKY_MARKER = '<!-- db-renumber -->';
+
+function runUrl({ serverUrl, owner, repo, runId }) {
+  return `${serverUrl}/${owner}/${repo}/actions/runs/${runId}`;
+}
+
+function heldBody(context, detail) {
+  return [
+    STICKY_MARKER,
+    '',
+    '### 🚧 Renumbering was held',
+    '',
+    detail,
+    '',
+    `See the [run log](${runUrl(context)}). Nothing was pushed.`,
+  ].join('\n');
+}
+
+function failedStepState(outcome) {
+  if (outcome === 'failure') return 'failed';
+  if (outcome === 'skipped' || !outcome) return 'was skipped';
+  return `did not succeed (step outcome: ${outcome})`;
+}
+
+/**
+ * PURE: decide which sticky comment truthfully describes the action outcome.
+ *
+ * GitHub exposes `outcome` even for steps reached through `always()`; absent
+ * outputs must still be treated as held rather than as evidence of a push.
+ */
+function renderRenumberWorkflowComment(input) {
+  const {
+    renumberStatus,
+    commentBody,
+    validationOutcome,
+    applyOutcome,
+    reapplyOutcome,
+    recheckOutcome,
+    recheckOk,
+    recheckReason,
+    pushOutcome,
+    context,
+  } = input;
+
+  if (renumberStatus !== 'renumbered') {
+    return commentBody || heldBody(context, 'The renumber job failed before it could finish.');
+  }
+
+  if (pushOutcome === 'success') {
+    return (
+      commentBody ||
+      [
+        STICKY_MARKER,
+        '',
+        '### ✅ Renumbered migration pushed',
+        '',
+        `The renumbered branch was pushed. See the [run log](${runUrl(context)}).`,
+      ].join('\n')
+    );
+  }
+
+  if (validationOutcome !== 'success') {
+    return heldBody(
+      context,
+      `Migration-folder validation ${failedStepState(validationOutcome)} after local renumbering.`,
+    );
+  }
+
+  if (applyOutcome !== 'success' || reapplyOutcome !== 'success') {
+    const state = failedStepState(applyOutcome !== 'success' ? applyOutcome : reapplyOutcome);
+    return heldBody(context, `Proof-of-apply ${state} after local renumbering.`);
+  }
+
+  if (recheckOutcome !== 'success') {
+    return heldBody(context, `The final PR re-check ${failedStepState(recheckOutcome)} after local renumbering.`);
+  }
+
+  if (recheckOutcome === 'success' && recheckOk !== 'true') {
+    return heldBody(context, recheckReason || 'The PR changed or was opted out during the final re-check.');
+  }
+
+  if (pushOutcome === 'failure') {
+    return heldBody(context, 'Force-pushing the locally renumbered branch failed.');
+  }
+
+  return heldBody(
+    context,
+    pushOutcome === 'skipped' || !pushOutcome
+      ? 'The force-push was skipped after local renumbering.'
+      : `The force-push did not succeed (step outcome: ${pushOutcome}).`,
+  );
+}
+
+module.exports = { STICKY_MARKER, renderRenumberWorkflowComment };

--- a/scripts/lib/db-renumber-comment.cjs
+++ b/scripts/lib/db-renumber-comment.cjs
@@ -54,6 +54,11 @@ function renderRenumberWorkflowComment(input) {
     return commentBody || heldBody(context, 'The renumber job failed before it could finish.');
   }
 
+  // Load-bearing precedence: a successful push is the terminal fact. The
+  // workflow places this step after every proof step and its `if` keeps
+  // GitHub's implicit success() guard, so contradictory earlier outcomes are
+  // unreachable. Keep this first so we never claim "Nothing was pushed" after
+  // the branch was actually updated.
   if (pushOutcome === 'success') {
     return (
       commentBody ||

--- a/scripts/lib/db-renumber-comment.cjs
+++ b/scripts/lib/db-renumber-comment.cjs
@@ -83,7 +83,7 @@ function renderRenumberWorkflowComment(input) {
     return heldBody(context, `The final PR re-check ${failedStepState(recheckOutcome)} after local renumbering.`);
   }
 
-  if (recheckOutcome === 'success' && recheckOk !== 'true') {
+  if (recheckOk !== 'true') {
     return heldBody(context, recheckReason || 'The PR changed or was opted out during the final re-check.');
   }
 

--- a/scripts/lib/db-renumber-comment.test.ts
+++ b/scripts/lib/db-renumber-comment.test.ts
@@ -11,6 +11,18 @@ const context = {
 
 const successfulComment = `${STICKY_MARKER}\n\n### 🔢 Renumbered onto \`main\``;
 
+function heldComment(detail: string) {
+  return [
+    STICKY_MARKER,
+    '',
+    '### 🚧 Renumbering was held',
+    '',
+    detail,
+    '',
+    'See the [run log](https://github.com/boardsesh/boardsesh/actions/runs/123). Nothing was pushed.',
+  ].join('\n');
+}
+
 function decide(overrides: Record<string, string> = {}) {
   return renderRenumberWorkflowComment({
     renumberStatus: 'renumbered',
@@ -100,25 +112,13 @@ describe('renderRenumberWorkflowComment', () => {
     expect(body).not.toContain('Renumbered onto');
   });
 
-  it('reports a real force-push failure rather than claiming the local renumber landed', () => {
-    const body = decide({ pushOutcome: 'failure' });
-
-    expect(body).toContain('Force-pushing');
-    expect(body).toContain('Nothing was pushed.');
-    expect(body).not.toContain('Renumbered onto');
-  });
-
-  it('treats an empty/skipped push outcome under always() as held', () => {
-    for (const pushOutcome of ['', 'skipped']) {
-      expect(decide({ pushOutcome })).toContain('Nothing was pushed.');
-    }
-  });
-
-  it('reports a cancelled force-push as held', () => {
-    const body = decide({ pushOutcome: 'cancelled' });
-
-    expect(body).toContain('step outcome: cancelled');
-    expect(body).toContain('Nothing was pushed.');
+  it.each([
+    ['failure', 'failure', 'The force-push failed after local renumbering.'],
+    ['skipped', 'skipped', 'The force-push was skipped after local renumbering.'],
+    ['empty', '', 'The force-push was skipped after local renumbering.'],
+    ['cancelled', 'cancelled', 'The force-push did not succeed (step outcome: cancelled) after local renumbering.'],
+  ])('reports a %s force-push outcome as held', (_caseName, pushOutcome, detail) => {
+    expect(decide({ pushOutcome })).toBe(heldComment(detail));
   });
 
   it('falls back to a held comment when renumbering fails without script output', () => {

--- a/scripts/lib/db-renumber-comment.test.ts
+++ b/scripts/lib/db-renumber-comment.test.ts
@@ -34,7 +34,13 @@ describe('renderRenumberWorkflowComment', () => {
 
   it('holds the branch when validation or proof-of-apply fails, without reusing success copy', () => {
     const heldOutcomes: Array<Record<string, string>> = [
-      { validationOutcome: 'failure', pushOutcome: 'skipped' },
+      {
+        validationOutcome: 'failure',
+        applyOutcome: 'skipped',
+        reapplyOutcome: 'skipped',
+        recheckOutcome: 'skipped',
+        pushOutcome: 'skipped',
+      },
       { applyOutcome: 'failure', reapplyOutcome: 'skipped', pushOutcome: 'skipped' },
       { reapplyOutcome: 'failure', pushOutcome: 'skipped' },
     ];
@@ -93,6 +99,21 @@ describe('renderRenumberWorkflowComment', () => {
     for (const pushOutcome of ['', 'skipped']) {
       expect(decide({ pushOutcome })).toContain('Nothing was pushed.');
     }
+  });
+
+  it('reports a cancelled force-push as held', () => {
+    const body = decide({ pushOutcome: 'cancelled' });
+
+    expect(body).toContain('step outcome: cancelled');
+    expect(body).toContain('Nothing was pushed.');
+  });
+
+  it('falls back to a held comment when renumbering fails without script output', () => {
+    const body = decide({ renumberStatus: 'failure', commentBody: '' });
+
+    expect(body).toContain('failed before it could finish');
+    expect(body).toContain('actions/runs/123');
+    expect(body).toContain('Nothing was pushed.');
   });
 
   it('preserves the script-produced blocked and no-op bodies', () => {

--- a/scripts/lib/db-renumber-comment.test.ts
+++ b/scripts/lib/db-renumber-comment.test.ts
@@ -41,8 +41,13 @@ describe('renderRenumberWorkflowComment', () => {
         recheckOutcome: 'skipped',
         pushOutcome: 'skipped',
       },
-      { applyOutcome: 'failure', reapplyOutcome: 'skipped', pushOutcome: 'skipped' },
-      { reapplyOutcome: 'failure', pushOutcome: 'skipped' },
+      {
+        applyOutcome: 'failure',
+        reapplyOutcome: 'skipped',
+        recheckOutcome: 'skipped',
+        pushOutcome: 'skipped',
+      },
+      { reapplyOutcome: 'failure', recheckOutcome: 'skipped', pushOutcome: 'skipped' },
     ];
 
     for (const overrides of heldOutcomes) {
@@ -87,6 +92,14 @@ describe('renderRenumberWorkflowComment', () => {
     expect(body).toContain('Nothing was pushed.');
   });
 
+  it('reports a failed final re-check before considering the push outcome', () => {
+    const body = decide({ recheckOutcome: 'failure', recheckOk: '', pushOutcome: 'skipped' });
+
+    expect(body).toContain('final PR re-check failed');
+    expect(body).toContain('Nothing was pushed.');
+    expect(body).not.toContain('Renumbered onto');
+  });
+
   it('reports a real force-push failure rather than claiming the local renumber landed', () => {
     const body = decide({ pushOutcome: 'failure' });
 
@@ -109,7 +122,7 @@ describe('renderRenumberWorkflowComment', () => {
   });
 
   it('falls back to a held comment when renumbering fails without script output', () => {
-    const body = decide({ renumberStatus: 'failure', commentBody: '' });
+    const body = decide({ renumberStatus: '', commentBody: '' });
 
     expect(body).toContain('failed before it could finish');
     expect(body).toContain('actions/runs/123');

--- a/scripts/lib/db-renumber-comment.test.ts
+++ b/scripts/lib/db-renumber-comment.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+
+import { STICKY_MARKER, renderRenumberWorkflowComment } from './db-renumber-comment.cjs';
+
+const context = {
+  serverUrl: 'https://github.com',
+  owner: 'boardsesh',
+  repo: 'boardsesh',
+  runId: '123',
+};
+
+const successfulComment = `${STICKY_MARKER}\n\n### 🔢 Renumbered onto \`main\``;
+
+function decide(overrides: Record<string, string> = {}) {
+  return renderRenumberWorkflowComment({
+    renumberStatus: 'renumbered',
+    commentBody: successfulComment,
+    validationOutcome: 'success',
+    applyOutcome: 'success',
+    reapplyOutcome: 'success',
+    recheckOutcome: 'success',
+    recheckOk: 'true',
+    recheckReason: '',
+    pushOutcome: 'success',
+    context,
+    ...overrides,
+  });
+}
+
+describe('renderRenumberWorkflowComment', () => {
+  it('posts the local renumber-success comment only after the force-push succeeds', () => {
+    expect(decide()).toBe(successfulComment);
+  });
+
+  it('holds the branch when validation or proof-of-apply fails, without reusing success copy', () => {
+    const heldOutcomes: Array<Record<string, string>> = [
+      { validationOutcome: 'failure', pushOutcome: 'skipped' },
+      { applyOutcome: 'failure', reapplyOutcome: 'skipped', pushOutcome: 'skipped' },
+      { reapplyOutcome: 'failure', pushOutcome: 'skipped' },
+    ];
+
+    for (const overrides of heldOutcomes) {
+      const body = decide(overrides);
+      expect(body).toContain('Nothing was pushed.');
+      expect(body).toContain('actions/runs/123');
+      expect(body).not.toContain('Renumbered onto');
+    }
+  });
+
+  it('treats skipped or empty proof outcomes under always() as held', () => {
+    const skippedProofOutcomes: Array<Record<string, string>> = [
+      { applyOutcome: 'skipped', pushOutcome: 'skipped' },
+      { reapplyOutcome: '', pushOutcome: '' },
+    ];
+
+    for (const overrides of skippedProofOutcomes) {
+      expect(decide(overrides)).toContain('Proof-of-apply was skipped');
+    }
+  });
+
+  it('reports a final re-check rejection as a branch move or opt-out, without a push', () => {
+    const body = decide({
+      recheckOk: 'false',
+      recheckReason: 'The branch moved during the final re-check.',
+      pushOutcome: 'skipped',
+    });
+
+    expect(body).toContain('branch moved during the final re-check');
+    expect(body).toContain('Nothing was pushed.');
+    expect(body).not.toContain('Renumbered onto');
+  });
+
+  it('names a renumber:skip label that appears during the final re-check', () => {
+    const body = decide({
+      recheckOk: 'false',
+      recheckReason: 'The `renumber:skip` label appeared during the final re-check.',
+      pushOutcome: 'skipped',
+    });
+
+    expect(body).toContain('`renumber:skip` label appeared');
+    expect(body).toContain('Nothing was pushed.');
+  });
+
+  it('reports a real force-push failure rather than claiming the local renumber landed', () => {
+    const body = decide({ pushOutcome: 'failure' });
+
+    expect(body).toContain('Force-pushing');
+    expect(body).toContain('Nothing was pushed.');
+    expect(body).not.toContain('Renumbered onto');
+  });
+
+  it('treats an empty/skipped push outcome under always() as held', () => {
+    for (const pushOutcome of ['', 'skipped']) {
+      expect(decide({ pushOutcome })).toContain('Nothing was pushed.');
+    }
+  });
+
+  it('preserves the script-produced blocked and no-op bodies', () => {
+    const blocked = `${STICKY_MARKER}\n\n### 🚧 Couldn’t renumber this migration automatically\n\nNothing was pushed.`;
+    const noOp = `${STICKY_MARKER}\n\n### ✅ Migration number is already free`;
+
+    expect(decide({ renumberStatus: 'blocked', commentBody: blocked })).toBe(blocked);
+    expect(decide({ renumberStatus: 'no-op', commentBody: noOp })).toBe(noOp);
+  });
+});

--- a/scripts/lib/db-renumber-comment.test.ts
+++ b/scripts/lib/db-renumber-comment.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { STICKY_MARKER as SCRIPT_STICKY_MARKER } from '../db-renumber-migration';
 import { STICKY_MARKER, renderRenumberWorkflowComment } from './db-renumber-comment.cjs';
 
 const context = {
@@ -38,6 +39,15 @@ function decide(overrides: Record<string, string> = {}) {
     ...overrides,
   });
 }
+
+describe('STICKY_MARKER', () => {
+  it('matches the marker the renumber script embeds in its own bodies', () => {
+    // The workflow upserts by searching every PR comment for this marker. If the
+    // two copies drift, the lookup stops finding the script-written comment and
+    // the bot posts a fresh duplicate on every run.
+    expect(STICKY_MARKER).toBe(SCRIPT_STICKY_MARKER);
+  });
+});
 
 describe('renderRenumberWorkflowComment', () => {
   it('posts the local renumber-success comment only after the force-push succeeds', () => {

--- a/scripts/lib/db-renumber-comment.test.ts
+++ b/scripts/lib/db-renumber-comment.test.ts
@@ -129,11 +129,17 @@ describe('renderRenumberWorkflowComment', () => {
     expect(body).toContain('Nothing was pushed.');
   });
 
-  it('preserves the script-produced blocked and no-op bodies', () => {
+  it('preserves the script-produced blocked body', () => {
     const blocked = `${STICKY_MARKER}\n\n### 🚧 Couldn’t renumber this migration automatically\n\nNothing was pushed.`;
-    const noOp = `${STICKY_MARKER}\n\n### ✅ Migration number is already free`;
 
     expect(decide({ renumberStatus: 'blocked', commentBody: blocked })).toBe(blocked);
+  });
+
+  it('defensively preserves a no-op body when the helper is called directly', () => {
+    // The workflow filters no-op before invoking this helper; preserving the
+    // body here keeps the pure function safe if another caller reuses it.
+    const noOp = `${STICKY_MARKER}\n\n### ✅ Migration number is already free`;
+
     expect(decide({ renumberStatus: 'no-op', commentBody: noOp })).toBe(noOp);
   });
 });


### PR DESCRIPTION
## Summary

Closes #4100.

- Make the migration renumber sticky comment depend on the actual force-push step outcome, rather than the pre-push re-check.
- Post a specific held comment with the action-run link when validation, proof-of-apply, re-check, or push does not complete; retain the existing paginated sticky upsert and blocked/no-op behavior.
- The dev-DB migration-ledger recovery remains separately owned by #3978/#3979. This PR does not make the bot operational while proof-of-apply still fails on that ledger gap.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run scripts/db-renumber-migration.test.ts scripts/lib/db-renumber-comment.test.ts --reporter=agent`
- `vp check scripts/lib/db-renumber-comment.cjs scripts/lib/db-renumber-comment.test.ts`
- `vp run typecheck`
- Scoped QA exception: this is workflow-only, so no `vp run dev` was started; that would exercise unrelated Docker-backed services and Docker access was declined.
