### PR TITLE
fix: enforce playlist ownership parity

### DIFF
--- a/packages/aurora-sync/src/sync/json-import.ts
+++ b/packages/aurora-sync/src/sync/json-import.ts
@@ -13,7 +13,12 @@ import { randomUUID, createHash } from 'crypto';
 import { fontGradeToDifficultyId } from '@boardsesh/board-config';
 import { LAYOUTS, HOLE_PLACEMENTS } from '@boardsesh/board-constants/product-sizes';
 import type { AuroraBoardName } from '@boardsesh/shared-schema';
-import { isNoMatchClimb, CLIMB_CHARACTERISTICS, convertQuality } from '@boardsesh/shared-schema';
+import {
+  isNoMatchClimb,
+  CLIMB_CHARACTERISTICS,
+  convertQuality,
+  normalizePlaylistColor,
+} from '@boardsesh/shared-schema';
 import {
   populateDenormalizedColumns,
   recomputeClimbStatsBulk,
@@ -1627,7 +1632,7 @@ export async function importJsonExportData(
     // (#3526) — cheap, and the only thing standing between a future
     // key-derivation change and a silent re-run of the 2026-03 incident.
     const circuitAuroraId = generateJsonImportCircuitAuroraId(userId, boardType, circuit.name, circuit.created_at);
-    const formattedColor = circuit.color ? `#${circuit.color}` : null;
+    const formattedColor = normalizePlaylistColor(circuit.color);
     const circuitNow = new Date();
 
     try {

--- a/packages/aurora-sync/src/sync/user-sync.test.ts
+++ b/packages/aurora-sync/src/sync/user-sync.test.ts
@@ -80,12 +80,12 @@ type ShimDb = Parameters<typeof upsertTableData>[0];
  */
 type CircuitFixture = Parameters<typeof upsertTableData>[5][number];
 
-const circuit = (uuid: string, name: string, climbs?: Array<{ climb_uuid: string }>): CircuitFixture =>
+const circuit = (uuid: string, name: string, climbs?: Array<{ climb_uuid: string }>, color = ''): CircuitFixture =>
   ({
     uuid,
     name,
     description: '',
-    color: '',
+    color,
     is_public: '',
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
@@ -182,6 +182,29 @@ describe('upsertTableData circuits — foreign-owner guard (#3526)', () => {
     expect(insertsInto(playlistOwnership)).toHaveLength(1);
     expect(result.skipped).toBe(0);
     expect(result.skippedReason).toBeUndefined();
+  });
+
+  it.each([
+    ['aB3', '#AABB33'],
+    ['#aB3', '#AABB33'],
+    ['not-a-colour', null],
+  ])('canonicalizes Aurora circuit colour %s before writing a playlist', async (upstreamColor, expectedColor) => {
+    const { db, insertsInto } = createDbShim({
+      selectResults: [[]],
+      returningRows: [[{ id: BigInt(7) }]],
+    });
+
+    await upsertTableData(
+      db as unknown as ShimDb,
+      'tension',
+      'circuits',
+      144574,
+      'user-1',
+      [circuit('circuit-1', 'Mine', undefined, upstreamColor)],
+      () => {},
+    );
+
+    expect(insertsInto(playlists)[0]?.args[0]).toMatchObject({ color: expectedColor });
   });
 
   it('claims a brand-new circuit and an orphaned playlist with no owner edge', async () => {

--- a/packages/aurora-sync/src/sync/user-sync.ts
+++ b/packages/aurora-sync/src/sync/user-sync.ts
@@ -8,6 +8,7 @@ import {
   canWriteUpstreamPlaylist,
   upstreamPlaylistSkipLogLine,
 } from '@boardsesh/sync-runtime';
+import { normalizePlaylistColor } from '@boardsesh/shared-schema';
 import { DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR } from '@boardsesh/shared-schema/sync-error-codes';
 import { foreignPlaylistOwnerGuard, selectUpstreamPlaylistOwners } from '@boardsesh/db/queries';
 import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
@@ -361,7 +362,7 @@ export async function upsertTableData(
             continue;
           }
 
-          const formattedColor = item.color ? `#${item.color}` : null;
+          const formattedColor = normalizePlaylistColor(item.color);
 
           const [playlist] = await db
             .insert(playlists)

--- a/packages/backend/src/__tests__/playlist-role-matrix.test.ts
+++ b/packages/backend/src/__tests__/playlist-role-matrix.test.ts
@@ -1,0 +1,228 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { playlists } from '@boardsesh/db/schema/app';
+import { db } from '../db/client';
+import { playlistMutations } from '../graphql/resolvers/playlists/mutations';
+import { playlistQueries } from '../graphql/resolvers/playlists/queries';
+
+const FIXTURE_RUN_ID = crypto.randomUUID();
+const PLAYLIST_UUID = `issue-4016-${FIXTURE_RUN_ID}`;
+const SEEDED_CLIMB_UUID = `4016-seed-${FIXTURE_RUN_ID}`;
+const ADDED_CLIMB_UUID = `4016-add-${FIXTURE_RUN_ID}`;
+const OWNER_ID = `issue-4016-owner-${FIXTURE_RUN_ID}`;
+const EDITOR_ID = `issue-4016-editor-${FIXTURE_RUN_ID}`;
+const VIEWER_ID = `issue-4016-viewer-${FIXTURE_RUN_ID}`;
+
+function makeCtx(userId: string): ConnectionContext {
+  return {
+    connectionId: `issue-4016-${userId}`,
+    isAuthenticated: true,
+    userId,
+  };
+}
+
+async function ownedLibrary(userId: string) {
+  return playlistQueries.allUserPlaylists(null, { input: {} }, makeCtx(userId));
+}
+
+describe('playlist ownership role matrix — real Postgres (#4016)', () => {
+  beforeAll(async () => {
+    await db.execute(sql`
+      INSERT INTO users (id, email, name)
+      VALUES
+        (${OWNER_ID}, ${`${OWNER_ID}@test.invalid`}, 'Playlist owner'),
+        (${EDITOR_ID}, ${`${EDITOR_ID}@test.invalid`}, 'Playlist editor'),
+        (${VIEWER_ID}, ${`${VIEWER_ID}@test.invalid`}, 'Playlist viewer')
+      ON CONFLICT (id) DO NOTHING
+    `);
+
+    await db.execute(sql`
+      INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, description, frames, is_listed)
+      VALUES (${SEEDED_CLIMB_UUID}, 'kilter', 1, 'setter', 'Role matrix climb', '', 'p1r1', true)
+      ON CONFLICT (uuid) DO NOTHING
+    `);
+
+    const [playlist] = await db
+      .insert(playlists)
+      .values({
+        uuid: PLAYLIST_UUID,
+        boardType: 'kilter',
+        layoutId: 1,
+        name: 'Role matrix playlist',
+        isPublic: false,
+      })
+      .onConflictDoNothing()
+      .returning({ id: playlists.id });
+
+    if (!playlist) {
+      throw new Error(`Fixture playlist ${PLAYLIST_UUID} already exists`);
+    }
+
+    await db.execute(sql`
+      INSERT INTO playlist_ownership (playlist_id, user_id, role)
+      VALUES
+        (${playlist.id}, ${OWNER_ID}, 'owner'),
+        (${playlist.id}, ${EDITOR_ID}, 'editor'),
+        (${playlist.id}, ${VIEWER_ID}, 'viewer')
+    `);
+    await db.execute(sql`
+      INSERT INTO playlist_climbs (playlist_id, climb_uuid, angle, position)
+      VALUES (${playlist.id}, ${SEEDED_CLIMB_UUID}, 40, 0)
+    `);
+  });
+
+  afterAll(async () => {
+    await db.execute(sql`DELETE FROM playlists WHERE uuid = ${PLAYLIST_UUID}`);
+    await db.execute(sql`DELETE FROM board_climbs WHERE uuid = ${SEEDED_CLIMB_UUID}`);
+    await db.execute(sql`DELETE FROM users WHERE id IN (${OWNER_ID}, ${EDITOR_ID}, ${VIEWER_ID})`);
+  });
+
+  it('shows only the owner in libraries and edit-picker memberships', async () => {
+    const ownerLibrary = await ownedLibrary(OWNER_ID);
+    const editorLibrary = await ownedLibrary(EDITOR_ID);
+    const viewerLibrary = await ownedLibrary(VIEWER_ID);
+
+    expect(ownerLibrary.totalCount).toBe(1);
+    expect(ownerLibrary.playlists).toHaveLength(1);
+    expect(ownerLibrary.playlists[0]).toMatchObject({ uuid: PLAYLIST_UUID, userRole: 'owner' });
+    expect(editorLibrary).toMatchObject({ totalCount: 0, playlists: [] });
+    expect(viewerLibrary).toMatchObject({ totalCount: 0, playlists: [] });
+
+    const scopedOwnerLibrary = (await playlistQueries.userPlaylists(
+      null,
+      { input: { boardType: 'kilter', layoutId: 1 } },
+      makeCtx(OWNER_ID),
+    )) as Array<{ uuid: string }>;
+    const scopedEditorLibrary = (await playlistQueries.userPlaylists(
+      null,
+      { input: { boardType: 'kilter', layoutId: 1 } },
+      makeCtx(EDITOR_ID),
+    )) as Array<{ uuid: string }>;
+    const scopedViewerLibrary = (await playlistQueries.userPlaylists(
+      null,
+      { input: { boardType: 'kilter', layoutId: 1 } },
+      makeCtx(VIEWER_ID),
+    )) as Array<{ uuid: string }>;
+
+    expect(scopedOwnerLibrary.map((playlist) => playlist.uuid)).toEqual([PLAYLIST_UUID]);
+    expect(scopedEditorLibrary).toEqual([]);
+    expect(scopedViewerLibrary).toEqual([]);
+
+    for (const [userId, expectedMemberships] of [
+      [OWNER_ID, [PLAYLIST_UUID]],
+      [EDITOR_ID, []],
+      [VIEWER_ID, []],
+    ] as const) {
+      await expect(
+        playlistQueries.playlistsForClimb(
+          null,
+          { input: { boardType: 'kilter', layoutId: 1, climbUuid: SEEDED_CLIMB_UUID } },
+          makeCtx(userId),
+        ),
+      ).resolves.toEqual(expectedMemberships);
+
+      await expect(
+        playlistQueries.playlistsForClimbs(
+          null,
+          { input: { boardType: 'kilter', layoutId: 1, climbUuids: [SEEDED_CLIMB_UUID] } },
+          makeCtx(userId),
+        ),
+      ).resolves.toEqual(
+        expectedMemberships.length > 0 ? [{ climbUuid: SEEDED_CLIMB_UUID, playlistUuids: [PLAYLIST_UUID] }] : [],
+      );
+    }
+  });
+
+  it.each([
+    ['editor', EDITOR_ID],
+    ['viewer', VIEWER_ID],
+  ])('keeps private playlist and climb reads for the %s role', async (expectedRole, userId) => {
+    await expect(playlistQueries.playlist(null, { playlistId: PLAYLIST_UUID }, makeCtx(userId))).resolves.toMatchObject(
+      {
+        uuid: PLAYLIST_UUID,
+        userRole: expectedRole,
+      },
+    );
+
+    const result = await playlistQueries.playlistClimbs(
+      null,
+      { input: { playlistId: PLAYLIST_UUID } },
+      makeCtx(userId),
+    );
+    expect(result.totalCount).toBe(1);
+    expect(result.climbs.map((climb) => climb.uuid)).toEqual([SEEDED_CLIMB_UUID]);
+  });
+
+  it.each([
+    ['editor', EDITOR_ID],
+    ['viewer', VIEWER_ID],
+  ])('denies all playlist-content and library-order writes to the %s role', async (_role, userId) => {
+    const context = makeCtx(userId);
+    const deniedWrites = [
+      () =>
+        playlistMutations.addClimbToPlaylist(
+          null,
+          { input: { playlistId: PLAYLIST_UUID, climbUuid: ADDED_CLIMB_UUID, angle: 90 } },
+          context,
+        ),
+      () =>
+        playlistMutations.removeClimbFromPlaylist(
+          null,
+          { input: { playlistId: PLAYLIST_UUID, climbUuid: SEEDED_CLIMB_UUID } },
+          context,
+        ),
+      () =>
+        playlistMutations.reorderPlaylistClimb(
+          null,
+          { input: { playlistId: PLAYLIST_UUID, climbUuid: SEEDED_CLIMB_UUID, newIndex: 0 } },
+          context,
+        ),
+      () => playlistMutations.updatePlaylistLastAccessed(null, { playlistId: PLAYLIST_UUID }, context),
+    ];
+
+    for (const deniedWrite of deniedWrites) {
+      await expect(deniedWrite()).rejects.toThrow(/permission|access denied/);
+    }
+  });
+
+  it('allows the owner to perform all four writes', async () => {
+    const context = makeCtx(OWNER_ID);
+
+    await expect(
+      playlistMutations.addClimbToPlaylist(
+        null,
+        { input: { playlistId: PLAYLIST_UUID, climbUuid: ADDED_CLIMB_UUID, angle: 90 } },
+        context,
+      ),
+    ).resolves.toMatchObject({ climbUuid: ADDED_CLIMB_UUID, angle: 90 });
+    await expect(
+      playlistMutations.reorderPlaylistClimb(
+        null,
+        { input: { playlistId: PLAYLIST_UUID, climbUuid: ADDED_CLIMB_UUID, newIndex: 0 } },
+        context,
+      ),
+    ).resolves.toBe(true);
+    await expect(
+      playlistMutations.updatePlaylistLastAccessed(null, { playlistId: PLAYLIST_UUID }, context),
+    ).resolves.toBe(true);
+    await expect(
+      playlistMutations.removeClimbFromPlaylist(
+        null,
+        { input: { playlistId: PLAYLIST_UUID, climbUuid: ADDED_CLIMB_UUID } },
+        context,
+      ),
+    ).resolves.toBe(true);
+
+    const [playlistRow] = await db.execute(sql`
+      SELECT last_accessed_at FROM playlists WHERE uuid = ${PLAYLIST_UUID}
+    `);
+    const addedRows = await db.execute(sql`
+      SELECT id FROM playlist_climbs
+      WHERE playlist_id = (SELECT id FROM playlists WHERE uuid = ${PLAYLIST_UUID})
+        AND climb_uuid = ${ADDED_CLIMB_UUID}
+    `);
+    expect((playlistRow as { last_accessed_at: unknown }).last_accessed_at).not.toBeNull();
+    expect(Array.from(addedRows)).toHaveLength(0);
+  });
+});

--- a/packages/backend/src/__tests__/playlist-role-matrix.test.ts
+++ b/packages/backend/src/__tests__/playlist-role-matrix.test.ts
@@ -26,6 +26,18 @@ async function ownedLibrary(userId: string) {
   return playlistQueries.allUserPlaylists(null, { input: {} }, makeCtx(userId));
 }
 
+async function expectExactAuthorizationError(operation: () => Promise<unknown>, expectedMessage: string) {
+  try {
+    await operation();
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(expectedMessage);
+    return;
+  }
+
+  throw new Error(`Expected authorization error: ${expectedMessage}`);
+}
+
 describe('playlist ownership role matrix — real Postgres (#4016)', () => {
   beforeAll(async () => {
     await db.execute(sql`
@@ -39,7 +51,9 @@ describe('playlist ownership role matrix — real Postgres (#4016)', () => {
 
     await db.execute(sql`
       INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, description, frames, is_listed)
-      VALUES (${SEEDED_CLIMB_UUID}, 'kilter', 1, 'setter', 'Role matrix climb', '', 'p1r1', true)
+      VALUES
+        (${SEEDED_CLIMB_UUID}, 'kilter', 1, 'setter', 'Role matrix climb', '', 'p1r1', true),
+        (${ADDED_CLIMB_UUID}, 'kilter', 1, 'setter', 'Role matrix added climb', '', 'p1r2', true)
       ON CONFLICT (uuid) DO NOTHING
     `);
 
@@ -74,7 +88,7 @@ describe('playlist ownership role matrix — real Postgres (#4016)', () => {
 
   afterAll(async () => {
     await db.execute(sql`DELETE FROM playlists WHERE uuid = ${PLAYLIST_UUID}`);
-    await db.execute(sql`DELETE FROM board_climbs WHERE uuid = ${SEEDED_CLIMB_UUID}`);
+    await db.execute(sql`DELETE FROM board_climbs WHERE uuid IN (${SEEDED_CLIMB_UUID}, ${ADDED_CLIMB_UUID})`);
     await db.execute(sql`DELETE FROM users WHERE id IN (${OWNER_ID}, ${EDITOR_ID}, ${VIEWER_ID})`);
   });
 
@@ -160,29 +174,41 @@ describe('playlist ownership role matrix — real Postgres (#4016)', () => {
   ])('denies all playlist-content and library-order writes to the %s role', async (_role, userId) => {
     const context = makeCtx(userId);
     const deniedWrites = [
-      () =>
-        playlistMutations.addClimbToPlaylist(
-          null,
-          { input: { playlistId: PLAYLIST_UUID, climbUuid: ADDED_CLIMB_UUID, angle: 90 } },
-          context,
-        ),
-      () =>
-        playlistMutations.removeClimbFromPlaylist(
-          null,
-          { input: { playlistId: PLAYLIST_UUID, climbUuid: SEEDED_CLIMB_UUID } },
-          context,
-        ),
-      () =>
-        playlistMutations.reorderPlaylistClimb(
-          null,
-          { input: { playlistId: PLAYLIST_UUID, climbUuid: SEEDED_CLIMB_UUID, newIndex: 0 } },
-          context,
-        ),
-      () => playlistMutations.updatePlaylistLastAccessed(null, { playlistId: PLAYLIST_UUID }, context),
+      {
+        operation: () =>
+          playlistMutations.addClimbToPlaylist(
+            null,
+            { input: { playlistId: PLAYLIST_UUID, climbUuid: ADDED_CLIMB_UUID, angle: 90 } },
+            context,
+          ),
+        expectedMessage: 'Playlist not found or you do not have permission to edit it',
+      },
+      {
+        operation: () =>
+          playlistMutations.removeClimbFromPlaylist(
+            null,
+            { input: { playlistId: PLAYLIST_UUID, climbUuid: SEEDED_CLIMB_UUID } },
+            context,
+          ),
+        expectedMessage: 'Playlist not found or you do not have permission to edit it',
+      },
+      {
+        operation: () =>
+          playlistMutations.reorderPlaylistClimb(
+            null,
+            { input: { playlistId: PLAYLIST_UUID, climbUuid: SEEDED_CLIMB_UUID, newIndex: 0 } },
+            context,
+          ),
+        expectedMessage: 'Playlist not found or you do not have permission to edit it',
+      },
+      {
+        operation: () => playlistMutations.updatePlaylistLastAccessed(null, { playlistId: PLAYLIST_UUID }, context),
+        expectedMessage: 'Playlist not found or access denied',
+      },
     ];
 
-    for (const deniedWrite of deniedWrites) {
-      await expect(deniedWrite()).rejects.toThrow(/permission|access denied/);
+    for (const { operation, expectedMessage } of deniedWrites) {
+      await expectExactAuthorizationError(operation, expectedMessage);
     }
   });
 

--- a/packages/backend/src/__tests__/playlist-role-matrix.test.ts
+++ b/packages/backend/src/__tests__/playlist-role-matrix.test.ts
@@ -13,6 +13,7 @@ const ADDED_CLIMB_UUID = `4016-add-${FIXTURE_RUN_ID}`;
 const OWNER_ID = `issue-4016-owner-${FIXTURE_RUN_ID}`;
 const EDITOR_ID = `issue-4016-editor-${FIXTURE_RUN_ID}`;
 const VIEWER_ID = `issue-4016-viewer-${FIXTURE_RUN_ID}`;
+const UNRELATED_ID = `issue-4016-unrelated-${FIXTURE_RUN_ID}`;
 
 function makeCtx(userId: string): ConnectionContext {
   return {
@@ -45,7 +46,8 @@ describe('playlist ownership role matrix — real Postgres (#4016)', () => {
       VALUES
         (${OWNER_ID}, ${`${OWNER_ID}@test.invalid`}, 'Playlist owner'),
         (${EDITOR_ID}, ${`${EDITOR_ID}@test.invalid`}, 'Playlist editor'),
-        (${VIEWER_ID}, ${`${VIEWER_ID}@test.invalid`}, 'Playlist viewer')
+        (${VIEWER_ID}, ${`${VIEWER_ID}@test.invalid`}, 'Playlist viewer'),
+        (${UNRELATED_ID}, ${`${UNRELATED_ID}@test.invalid`}, 'Unrelated user')
       ON CONFLICT (id) DO NOTHING
     `);
 
@@ -89,7 +91,7 @@ describe('playlist ownership role matrix — real Postgres (#4016)', () => {
   afterAll(async () => {
     await db.execute(sql`DELETE FROM playlists WHERE uuid = ${PLAYLIST_UUID}`);
     await db.execute(sql`DELETE FROM board_climbs WHERE uuid IN (${SEEDED_CLIMB_UUID}, ${ADDED_CLIMB_UUID})`);
-    await db.execute(sql`DELETE FROM users WHERE id IN (${OWNER_ID}, ${EDITOR_ID}, ${VIEWER_ID})`);
+    await db.execute(sql`DELETE FROM users WHERE id IN (${OWNER_ID}, ${EDITOR_ID}, ${VIEWER_ID}, ${UNRELATED_ID})`);
   });
 
   it('shows only the owner in libraries and edit-picker memberships', async () => {
@@ -166,6 +168,39 @@ describe('playlist ownership role matrix — real Postgres (#4016)', () => {
     );
     expect(result.totalCount).toBe(1);
     expect(result.climbs.map((climb) => climb.uuid)).toEqual([SEEDED_CLIMB_UUID]);
+  });
+
+  it('allows only the owner to update playlist metadata', async () => {
+    const ownerUpdatedName = 'Owner-updated role matrix playlist';
+
+    await expect(
+      playlistMutations.updatePlaylist(
+        null,
+        { input: { playlistId: PLAYLIST_UUID, name: ownerUpdatedName } },
+        makeCtx(OWNER_ID),
+      ),
+    ).resolves.toMatchObject({ uuid: PLAYLIST_UUID, name: ownerUpdatedName, userRole: 'owner' });
+
+    for (const [role, userId] of [
+      ['editor', EDITOR_ID],
+      ['viewer', VIEWER_ID],
+      ['unrelated', UNRELATED_ID],
+    ] as const) {
+      await expectExactAuthorizationError(
+        () =>
+          playlistMutations.updatePlaylist(
+            null,
+            { input: { playlistId: PLAYLIST_UUID, name: `${role} must not update this playlist` } },
+            makeCtx(userId),
+          ),
+        'Playlist not found or you do not have permission to edit it',
+      );
+    }
+
+    const [playlistRow] = await db.execute(sql`
+      SELECT name FROM playlists WHERE uuid = ${PLAYLIST_UUID}
+    `);
+    expect((playlistRow as { name: string }).name).toBe(ownerUpdatedName);
   });
 
   it.each([

--- a/packages/backend/src/__tests__/playlist-role-matrix.test.ts
+++ b/packages/backend/src/__tests__/playlist-role-matrix.test.ts
@@ -239,7 +239,7 @@ describe('playlist ownership role matrix — real Postgres (#4016)', () => {
       },
       {
         operation: () => playlistMutations.updatePlaylistLastAccessed(null, { playlistId: PLAYLIST_UUID }, context),
-        expectedMessage: 'Playlist not found or access denied',
+        expectedMessage: 'Playlist not found or you do not have permission to edit it',
       },
     ];
 

--- a/packages/backend/src/__tests__/playlist-role-matrix.test.ts
+++ b/packages/backend/src/__tests__/playlist-role-matrix.test.ts
@@ -206,7 +206,8 @@ describe('playlist ownership role matrix — real Postgres (#4016)', () => {
   it.each([
     ['editor', EDITOR_ID],
     ['viewer', VIEWER_ID],
-  ])('denies all playlist-content and library-order writes to the %s role', async (_role, userId) => {
+    ['unrelated', UNRELATED_ID],
+  ])('denies all playlist-content and library-order writes to the %s caller', async (_callerKind, userId) => {
     const context = makeCtx(userId);
     const deniedWrites = [
       {

--- a/packages/backend/src/__tests__/playlist-validation.test.ts
+++ b/packages/backend/src/__tests__/playlist-validation.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { GetSmartPlaylistInputSchema, PlaylistColorSchema } from '../validation/schemas/playlists';
+
+describe('playlist validation', () => {
+  it('keeps the empty-string clear signal separate from concrete six-digit colours', () => {
+    expect(PlaylistColorSchema.safeParse('#A1b2C3').success).toBe(true);
+    expect(PlaylistColorSchema.safeParse('').success).toBe(true);
+    expect(PlaylistColorSchema.safeParse(undefined).success).toBe(true);
+    expect(PlaylistColorSchema.safeParse('#abc').success).toBe(false);
+    expect(PlaylistColorSchema.safeParse('A1b2C3').success).toBe(false);
+  });
+
+  it('accepts smart-playlist angles through 90 degrees and rejects 91', () => {
+    const baseInput = { type: 'PROJECTS' as const, userId: 'user-4016' };
+
+    expect(GetSmartPlaylistInputSchema.safeParse({ ...baseInput, angle: 90 }).success).toBe(true);
+    expect(GetSmartPlaylistInputSchema.safeParse({ ...baseInput, angle: 91 }).success).toBe(false);
+  });
+});

--- a/packages/backend/src/__tests__/playlist-validation.test.ts
+++ b/packages/backend/src/__tests__/playlist-validation.test.ts
@@ -6,8 +6,10 @@ describe('playlist validation', () => {
     expect(PlaylistColorSchema.safeParse('#A1b2C3').success).toBe(true);
     expect(PlaylistColorSchema.safeParse('').success).toBe(true);
     expect(PlaylistColorSchema.safeParse(undefined).success).toBe(true);
+    expect(PlaylistColorSchema.safeParse(null).success).toBe(false);
     expect(PlaylistColorSchema.safeParse('#abc').success).toBe(false);
     expect(PlaylistColorSchema.safeParse('A1b2C3').success).toBe(false);
+    expect(PlaylistColorSchema.safeParse('#A1b2C3D4').success).toBe(false);
   });
 
   it('accepts smart-playlist angles through 90 degrees and rejects 91', () => {

--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -632,6 +632,15 @@ export const schemaSQL = `
   );
   CREATE UNIQUE INDEX IF NOT EXISTS "unique_playlist_climb" ON "playlist_climbs" ("playlist_id", "climb_uuid");
 
+  CREATE TABLE IF NOT EXISTS "user_playlist_pins" (
+    "id" bigserial PRIMARY KEY NOT NULL,
+    "user_id" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+    "playlist_id" bigint NOT NULL REFERENCES "playlists"("id") ON DELETE CASCADE,
+    "created_at" timestamp DEFAULT now() NOT NULL,
+    "updated_at" timestamp DEFAULT now() NOT NULL
+  );
+  CREATE UNIQUE INDEX IF NOT EXISTS "unique_user_playlist_pin" ON "user_playlist_pins" ("user_id", "playlist_id");
+
   CREATE TABLE IF NOT EXISTS "user_favorites" (
     "id" bigserial PRIMARY KEY NOT NULL,
     "user_id" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,

--- a/packages/backend/src/graphql/resolvers/playlists/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/mutations.ts
@@ -276,12 +276,19 @@ export const playlistMutations = {
 
     const userId = ctx.userId!;
 
-    // Check ownership/access
+    // Check owner role. Editors/viewers retain private read access, but cannot
+    // mutate playlist contents.
     const ownership = await db
       .select({ id: dbSchema.playlists.id })
       .from(dbSchema.playlistOwnership)
       .innerJoin(dbSchema.playlists, eq(dbSchema.playlists.id, dbSchema.playlistOwnership.playlistId))
-      .where(and(eq(dbSchema.playlists.uuid, validatedInput.playlistId), eq(dbSchema.playlistOwnership.userId, userId)))
+      .where(
+        and(
+          eq(dbSchema.playlists.uuid, validatedInput.playlistId),
+          eq(dbSchema.playlistOwnership.userId, userId),
+          eq(dbSchema.playlistOwnership.role, 'owner'),
+        ),
+      )
       .limit(1);
 
     if (ownership.length === 0) {
@@ -395,12 +402,19 @@ export const playlistMutations = {
 
     const userId = ctx.userId!;
 
-    // Check ownership/access
+    // Check owner role. Editors/viewers retain private read access, but cannot
+    // mutate playlist contents.
     const ownership = await db
       .select({ id: dbSchema.playlists.id })
       .from(dbSchema.playlistOwnership)
       .innerJoin(dbSchema.playlists, eq(dbSchema.playlists.id, dbSchema.playlistOwnership.playlistId))
-      .where(and(eq(dbSchema.playlists.uuid, validatedInput.playlistId), eq(dbSchema.playlistOwnership.userId, userId)))
+      .where(
+        and(
+          eq(dbSchema.playlists.uuid, validatedInput.playlistId),
+          eq(dbSchema.playlistOwnership.userId, userId),
+          eq(dbSchema.playlistOwnership.role, 'owner'),
+        ),
+      )
       .limit(1);
 
     if (ownership.length === 0) {
@@ -443,12 +457,18 @@ export const playlistMutations = {
 
     const userId = ctx.userId!;
 
-    // Check ownership/access (same userId-match gate as add/remove climb).
+    // Check owner role (same gate as add/remove climb).
     const ownership = await db
       .select({ id: dbSchema.playlists.id })
       .from(dbSchema.playlistOwnership)
       .innerJoin(dbSchema.playlists, eq(dbSchema.playlists.id, dbSchema.playlistOwnership.playlistId))
-      .where(and(eq(dbSchema.playlists.uuid, validatedInput.playlistId), eq(dbSchema.playlistOwnership.userId, userId)))
+      .where(
+        and(
+          eq(dbSchema.playlists.uuid, validatedInput.playlistId),
+          eq(dbSchema.playlistOwnership.userId, userId),
+          eq(dbSchema.playlistOwnership.role, 'owner'),
+        ),
+      )
       .limit(1);
 
     if (ownership.length === 0) {
@@ -518,12 +538,18 @@ export const playlistMutations = {
 
     const userId = ctx.userId!;
 
-    // Verify ownership
+    // Only owners may move a playlist in their library ordering.
     const ownership = await db
       .select({ id: dbSchema.playlists.id })
       .from(dbSchema.playlistOwnership)
       .innerJoin(dbSchema.playlists, eq(dbSchema.playlists.id, dbSchema.playlistOwnership.playlistId))
-      .where(and(eq(dbSchema.playlists.uuid, playlistId), eq(dbSchema.playlistOwnership.userId, userId)))
+      .where(
+        and(
+          eq(dbSchema.playlists.uuid, playlistId),
+          eq(dbSchema.playlistOwnership.userId, userId),
+          eq(dbSchema.playlistOwnership.role, 'owner'),
+        ),
+      )
       .limit(1);
 
     if (ownership.length === 0) {

--- a/packages/backend/src/graphql/resolvers/playlists/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/mutations.ts
@@ -553,7 +553,7 @@ export const playlistMutations = {
       .limit(1);
 
     if (ownership.length === 0) {
-      throw new Error('Playlist not found or access denied');
+      throw new Error('Playlist not found or you do not have permission to edit it');
     }
 
     await db

--- a/packages/backend/src/graphql/resolvers/playlists/queries/playlist-detail.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/playlist-detail.ts
@@ -131,6 +131,7 @@ export const playlistsForClimb = async (
         eq(dbSchema.playlists.boardType, input.boardType),
         or(eq(dbSchema.playlists.layoutId, input.layoutId), isNull(dbSchema.playlists.layoutId)),
         eq(dbSchema.playlistOwnership.userId, userId),
+        eq(dbSchema.playlistOwnership.role, 'owner'),
       ),
     );
 
@@ -165,6 +166,7 @@ export const playlistsForClimbs = async (
         eq(dbSchema.playlists.boardType, input.boardType),
         or(eq(dbSchema.playlists.layoutId, input.layoutId), isNull(dbSchema.playlists.layoutId)),
         eq(dbSchema.playlistOwnership.userId, userId),
+        eq(dbSchema.playlistOwnership.role, 'owner'),
       ),
     );
 

--- a/packages/backend/src/graphql/resolvers/playlists/queries/user-playlists.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/user-playlists.ts
@@ -8,11 +8,11 @@ import { getPlaylistFollowStats } from '../helpers/follow-stats';
 import { getClimbCounts, formatOwnedPlaylist, type OwnedPlaylistRow } from '../helpers/enrichment';
 
 /**
- * Build the select shape for owned-playlist queries. Takes the current user
- * id so we can compute isPinnedByMe via a LEFT JOIN against userPlaylistPins
- * — same query, no extra round-trip.
+ * Build the select shape for owned-playlist queries. isPinnedByMe is computed
+ * by the caller's user-scoped LEFT JOIN against userPlaylistPins — same query,
+ * no extra round-trip.
  */
-function ownedPlaylistSelect(userId: string) {
+function ownedPlaylistSelect() {
   return {
     id: dbSchema.playlists.id,
     uuid: dbSchema.playlists.uuid,
@@ -62,7 +62,7 @@ export const userPlaylists = async (
   const userId = ctx.userId!;
 
   const userPlaylists = await db
-    .select(ownedPlaylistSelect(userId))
+    .select(ownedPlaylistSelect())
     .from(dbSchema.playlists)
     .innerJoin(dbSchema.playlistOwnership, eq(dbSchema.playlistOwnership.playlistId, dbSchema.playlists.id))
     .leftJoin(
@@ -75,6 +75,7 @@ export const userPlaylists = async (
     .where(
       and(
         eq(dbSchema.playlistOwnership.userId, userId),
+        eq(dbSchema.playlistOwnership.role, 'owner'),
         eq(dbSchema.playlists.boardType, input.boardType),
         or(eq(dbSchema.playlists.layoutId, input.layoutId), isNull(dbSchema.playlists.layoutId)),
       ),
@@ -104,7 +105,7 @@ export const allUserPlaylists = async (
   const page = input.page ?? 0;
   const pageSize = input.pageSize ?? 20;
 
-  const conditions = [eq(dbSchema.playlistOwnership.userId, userId)];
+  const conditions = [eq(dbSchema.playlistOwnership.userId, userId), eq(dbSchema.playlistOwnership.role, 'owner')];
 
   if (input.boardType) {
     conditions.push(eq(dbSchema.playlists.boardType, input.boardType));
@@ -127,7 +128,7 @@ export const allUserPlaylists = async (
   const totalCount = countResult[0]?.count ?? 0;
 
   const rows = await db
-    .select(ownedPlaylistSelect(userId))
+    .select(ownedPlaylistSelect())
     .from(dbSchema.playlists)
     .innerJoin(dbSchema.playlistOwnership, eq(dbSchema.playlistOwnership.playlistId, dbSchema.playlists.id))
     .leftJoin(

--- a/packages/backend/src/validation/schemas/playlists.ts
+++ b/packages/backend/src/validation/schemas/playlists.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { ExternalUUIDSchema, BoardNameSchema, UUIDSchema } from './primitives';
+import { isValidPlaylistColor } from '@boardsesh/shared-schema';
+import { ExternalUUIDSchema, BoardNameSchema } from './primitives';
 
 export const PlaylistNameSchema = z.string().min(1, 'Playlist name cannot be empty').max(100, 'Playlist name too long');
 
@@ -10,7 +11,7 @@ export const PlaylistColorSchema = z
   // Allow an empty string so an edit can explicitly clear a previously-set
   // colour. The update resolver only writes fields that are present, so '' is
   // the "clear" signal (undefined still means "leave unchanged").
-  .regex(/^(#[0-9A-Fa-f]{6})?$/, 'Invalid color format (must be hex)')
+  .refine((color) => color === '' || isValidPlaylistColor(color), 'Invalid color format (must be hex)')
   .optional();
 
 export const PlaylistIconSchema = z.string().max(50, 'Icon name too long').optional();
@@ -151,7 +152,7 @@ export const GetSmartPlaylistInputSchema = z.object({
   boardName: BoardNameSchema.optional(),
   boardUuid: z.string().min(1).optional(),
   sizeId: z.number().int().positive().optional(),
-  angle: z.number().int().min(0).max(70).optional(),
+  angle: z.number().int().min(0).max(90).optional(),
   page: z.number().int().min(0).optional(),
   pageSize: z.number().int().min(1).max(100).optional(),
 });

--- a/packages/db/src/schema/app/playlists.ts
+++ b/packages/db/src/schema/app/playlists.ts
@@ -19,7 +19,7 @@ export const playlists = pgTable(
     description: text('description'),
     isPublic: boolean('is_public').default(false).notNull(),
     color: text('color'), // Hex color (e.g., '#06B6D4')
-    icon: text('icon'), // MUI icon name (e.g., 'StarOutlined')
+    icon: text('icon'), // Emoji grapheme or legacy ASCII icon identifier
 
     // Aurora sync tracking (for circuits synced from Aurora)
     auroraType: text('aurora_type'), // 'circuits' when synced from Aurora

--- a/packages/kilter-sync/src/sync/user-sync.test.ts
+++ b/packages/kilter-sync/src/sync/user-sync.test.ts
@@ -1359,7 +1359,12 @@ describe('applyClimbRatings — bulk upsert with COALESCE comment', () => {
   });
 });
 
-function makeCircuitPutOp(args: { circuit_uuid: string; name: string; user_uuid?: string }): PowerSyncOp {
+function makeCircuitPutOp(args: {
+  circuit_uuid: string;
+  name: string;
+  user_uuid?: string;
+  color?: string | null;
+}): PowerSyncOp {
   return {
     op_id: '1',
     op: 'PUT',
@@ -1370,7 +1375,7 @@ function makeCircuitPutOp(args: { circuit_uuid: string; name: string; user_uuid?
       circuit_uuid: args.circuit_uuid,
       name: args.name,
       description: null,
-      color: null,
+      color: args.color ?? null,
       is_public: 0,
       user_uuid: args.user_uuid ?? 'user-sub',
       product_layout_uuid: null,
@@ -1462,6 +1467,30 @@ describe('applyCircuits — playlist upsert + diff-and-replace', () => {
     expect(climbsInsert).toHaveLength(2);
     // playlistClimbs schema is part of the assertion surface.
     expect(playlistClimbs).toBeDefined();
+  });
+
+  it.each([
+    ['#aB3', '#AABB33'],
+    ['aB3', '#AABB33'],
+    ['not-a-colour', null],
+  ])('canonicalizes Kilter circuit colour %s before writing a playlist', async (upstreamColor, expectedColor) => {
+    const { tx, insertValues } = createRichTx({
+      selectResults: [[], []],
+      returningRows: [[{ id: BigInt(99) }]],
+    });
+
+    await applyCircuits(
+      tx as unknown as ApplyCircuitsTx,
+      'user-1',
+      [makeCircuitPutOp({ circuit_uuid: 'circuit-1', name: 'Liked Climbs', color: upstreamColor })],
+      [],
+      new Map(),
+    );
+
+    const playlistInsert = insertValues
+      .flatMap((rows) => (Array.isArray(rows) ? rows : [rows]))
+      .find((row) => 'kilterType' in row);
+    expect(playlistInsert).toMatchObject({ color: expectedColor });
   });
 
   it('skips the climbs re-insert entirely when incoming and existing match exactly', async () => {

--- a/packages/kilter-sync/src/sync/user-sync.ts
+++ b/packages/kilter-sync/src/sync/user-sync.ts
@@ -29,6 +29,7 @@ import {
   upstreamPlaylistSkipLogLine,
   type UpstreamPlaylistWriteDecision,
 } from '@boardsesh/sync-runtime';
+import { normalizePlaylistColor } from '@boardsesh/shared-schema';
 
 import { KILTER_BOARD_TYPE } from '../api/types';
 import { KilterApiError } from '../api/errors';
@@ -1335,6 +1336,7 @@ export async function applyCircuits(
 
     const playlistUuid = randomUUID();
     const now = new Date();
+    const normalizedColor = normalizePlaylistColor(raw.color);
 
     // Upsert playlist row keyed on kilter_id, return the bigserial id so
     // we can attach climbs + ownership.
@@ -1347,7 +1349,7 @@ export async function applyCircuits(
         name: raw.name,
         description: raw.description ?? null,
         isPublic: !!raw.is_public,
-        color: raw.color ?? null,
+        color: normalizedColor,
         kilterType: 'circuits',
         kilterId: raw.circuit_uuid,
         kilterSyncedAt: now,
@@ -1358,7 +1360,7 @@ export async function applyCircuits(
           name: raw.name,
           description: raw.description ?? null,
           isPublic: !!raw.is_public,
-          color: raw.color ?? null,
+          color: normalizedColor,
           kilterSyncedAt: now,
           updatedAt: now,
         },

--- a/packages/mobile/src/components/ClimbPlaylistChips.tsx
+++ b/packages/mobile/src/components/ClimbPlaylistChips.tsx
@@ -5,7 +5,7 @@ import { useTheme } from '../providers/theme-provider';
 import { usePlaylistsContextOptional } from '../providers/playlists-provider';
 import { useClimbPlaylistMemberships } from '../hooks/use-climb-playlist-memberships';
 import { useShowPlaylistTagsPreference } from '../lib/show-playlist-tags-preference';
-import { isValidHexColor, PLAYLIST_COLORS } from './playlist/playlist-colors';
+import { isValidPlaylistColor, PLAYLIST_COLORS } from './playlist/playlist-colors';
 import { resolvePlaylistEmojiIcon } from './playlist/playlist-icon';
 import { spacing, borderRadius } from '../theme/tokens';
 import { selectByVariant } from '../theme/variants';
@@ -51,7 +51,7 @@ export const ClimbPlaylistChips = React.memo(function ClimbPlaylistChips({ climb
       const playlist = playlistsById.get(playlistUuid);
       if (!playlist) continue;
       const dotColor =
-        playlist.color && isValidHexColor(playlist.color)
+        playlist.color && isValidPlaylistColor(playlist.color)
           ? playlist.color
           : PLAYLIST_COLORS[index % PLAYLIST_COLORS.length];
       resolved.push({

--- a/packages/mobile/src/components/ClimbPlaylistChips.tsx
+++ b/packages/mobile/src/components/ClimbPlaylistChips.tsx
@@ -5,7 +5,7 @@ import { useTheme } from '../providers/theme-provider';
 import { usePlaylistsContextOptional } from '../providers/playlists-provider';
 import { useClimbPlaylistMemberships } from '../hooks/use-climb-playlist-memberships';
 import { useShowPlaylistTagsPreference } from '../lib/show-playlist-tags-preference';
-import { isValidPlaylistColor, PLAYLIST_COLORS } from './playlist/playlist-colors';
+import { normalizePlaylistColor, PLAYLIST_COLORS } from './playlist/playlist-colors';
 import { resolvePlaylistEmojiIcon } from './playlist/playlist-icon';
 import { spacing, borderRadius } from '../theme/tokens';
 import { selectByVariant } from '../theme/variants';
@@ -50,10 +50,7 @@ export const ClimbPlaylistChips = React.memo(function ClimbPlaylistChips({ climb
     for (const playlistUuid of membership) {
       const playlist = playlistsById.get(playlistUuid);
       if (!playlist) continue;
-      const dotColor =
-        playlist.color && isValidPlaylistColor(playlist.color)
-          ? playlist.color
-          : PLAYLIST_COLORS[index % PLAYLIST_COLORS.length];
+      const dotColor = normalizePlaylistColor(playlist.color) ?? PLAYLIST_COLORS[index % PLAYLIST_COLORS.length];
       resolved.push({
         key: playlistUuid,
         name: playlist.name,

--- a/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
+++ b/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
@@ -31,7 +31,7 @@ import { reportHandledError } from '../../lib/error-reporting';
 import { sortPlaylistsByName } from '../../lib/sort-filter-playlists';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { borderRadius, spacing } from '../../theme/tokens';
-import { PLAYLIST_COLORS, isValidPlaylistColor } from './playlist-colors';
+import { PLAYLIST_COLORS, normalizePlaylistColor } from './playlist-colors';
 import { NAME_MAX } from './playlist-form-values';
 
 // One-tap emoji shortcuts for the compact inline create form. The full emoji
@@ -446,7 +446,7 @@ export function InlinePlaylistPicker({
 
   const renderPlaylistRow = useCallback<ListRenderItem<Playlist>>(
     ({ item, index }) => {
-      const accent = item.color && isValidPlaylistColor(item.color) ? item.color : brandColors.primary;
+      const accent = normalizePlaylistColor(item.color) ?? brandColors.primary;
       const member = members.has(item.uuid);
       return (
         <ListRow

--- a/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
+++ b/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
@@ -31,7 +31,7 @@ import { reportHandledError } from '../../lib/error-reporting';
 import { sortPlaylistsByName } from '../../lib/sort-filter-playlists';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { borderRadius, spacing } from '../../theme/tokens';
-import { PLAYLIST_COLORS, isValidHexColor } from './playlist-colors';
+import { PLAYLIST_COLORS, isValidPlaylistColor } from './playlist-colors';
 import { NAME_MAX } from './playlist-form-values';
 
 // One-tap emoji shortcuts for the compact inline create form. The full emoji
@@ -446,7 +446,7 @@ export function InlinePlaylistPicker({
 
   const renderPlaylistRow = useCallback<ListRenderItem<Playlist>>(
     ({ item, index }) => {
-      const accent = item.color && isValidHexColor(item.color) ? item.color : brandColors.primary;
+      const accent = item.color && isValidPlaylistColor(item.color) ? item.color : brandColors.primary;
       const member = members.has(item.uuid);
       return (
         <ListRow

--- a/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
@@ -39,7 +39,7 @@ import { usePlaylistDrag } from './use-playlist-drag';
 import { PlaylistBoardBackdrop } from './PlaylistBoardBackdrop';
 import { buildHeroGradient } from './playlist-gradient';
 import { resolvePlaylistEmojiIcon } from './playlist-icon';
-import { PLAYLIST_COLORS, isValidPlaylistColor } from './playlist-colors';
+import { PLAYLIST_COLORS, normalizePlaylistColor } from './playlist-colors';
 import { withAlpha } from '../../theme/colors';
 import { toQueueClimb, toSchemaClimb } from '../../lib/climb-types';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
@@ -363,7 +363,7 @@ export function PlaylistDetailView({
       </Pressable>
     ) : null;
 
-  const baseColor = hero.color && isValidPlaylistColor(hero.color) ? hero.color : PLAYLIST_COLORS[0];
+  const baseColor = normalizePlaylistColor(hero.color) ?? PLAYLIST_COLORS[0];
 
   // Shared list state visuals. The first-page load renders skeleton rows (a far
   // better "shape of what's coming" cue than a bare spinner). Empty + footer are

--- a/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
@@ -39,7 +39,7 @@ import { usePlaylistDrag } from './use-playlist-drag';
 import { PlaylistBoardBackdrop } from './PlaylistBoardBackdrop';
 import { buildHeroGradient } from './playlist-gradient';
 import { resolvePlaylistEmojiIcon } from './playlist-icon';
-import { PLAYLIST_COLORS, isValidHexColor } from './playlist-colors';
+import { PLAYLIST_COLORS, isValidPlaylistColor } from './playlist-colors';
 import { withAlpha } from '../../theme/colors';
 import { toQueueClimb, toSchemaClimb } from '../../lib/climb-types';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
@@ -363,7 +363,7 @@ export function PlaylistDetailView({
       </Pressable>
     ) : null;
 
-  const baseColor = hero.color && isValidHexColor(hero.color) ? hero.color : PLAYLIST_COLORS[0];
+  const baseColor = hero.color && isValidPlaylistColor(hero.color) ? hero.color : PLAYLIST_COLORS[0];
 
   // Shared list state visuals. The first-page load renders skeleton rows (a far
   // better "shape of what's coming" cue than a bare spinner). Empty + footer are

--- a/packages/mobile/src/components/playlist/PlaylistFormSheet.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistFormSheet.tsx
@@ -9,7 +9,7 @@ import { Icon } from '../Icon';
 import { Button } from '../Button';
 import { SwitchRow } from '../SwitchRow';
 import { PlaylistPreviewSquare } from './PlaylistPreviewSquare';
-import { PLAYLIST_COLORS } from './playlist-colors';
+import { normalizePlaylistColor, PLAYLIST_COLORS } from './playlist-colors';
 import { useTheme } from '../../providers/theme-provider';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing } from '../../theme/tokens';
@@ -89,7 +89,7 @@ export function PlaylistFormSheet({
       if (isEdit && playlist) {
         setName(playlist.name);
         setDescription(playlist.description ?? '');
-        setColor(playlist.color);
+        setColor(normalizePlaylistColor(playlist.color) ?? undefined);
         setIcon(playlist.icon);
         setIsPublic(playlist.isPublic);
       } else {

--- a/packages/mobile/src/components/playlist/PlaylistPreviewSquare.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistPreviewSquare.tsx
@@ -4,7 +4,7 @@ import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { borderRadius } from '../../theme/tokens';
-import { PLAYLIST_COLORS, isValidPlaylistColor } from './playlist-colors';
+import { PLAYLIST_COLORS, normalizePlaylistColor } from './playlist-colors';
 import { PlaylistBoardBackdrop } from './PlaylistBoardBackdrop';
 import { resolvePlaylistEmojiIcon } from './playlist-icon';
 
@@ -43,8 +43,7 @@ export function PlaylistPreviewSquare({
   showBoardBackdrop = false,
 }: PlaylistPreviewSquareProps) {
   const backgroundColor = useMemo(() => {
-    if (color && isValidPlaylistColor(color)) return color;
-    return PLAYLIST_COLORS[index % PLAYLIST_COLORS.length];
+    return normalizePlaylistColor(color) ?? PLAYLIST_COLORS[index % PLAYLIST_COLORS.length];
   }, [color, index]);
 
   // Scale the centred glyph with the tile so the 96px hero and the 64px card

--- a/packages/mobile/src/components/playlist/PlaylistPreviewSquare.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistPreviewSquare.tsx
@@ -4,7 +4,7 @@ import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { borderRadius } from '../../theme/tokens';
-import { PLAYLIST_COLORS, isValidHexColor } from './playlist-colors';
+import { PLAYLIST_COLORS, isValidPlaylistColor } from './playlist-colors';
 import { PlaylistBoardBackdrop } from './PlaylistBoardBackdrop';
 import { resolvePlaylistEmojiIcon } from './playlist-icon';
 
@@ -43,7 +43,7 @@ export function PlaylistPreviewSquare({
   showBoardBackdrop = false,
 }: PlaylistPreviewSquareProps) {
   const backgroundColor = useMemo(() => {
-    if (color && isValidHexColor(color)) return color;
+    if (color && isValidPlaylistColor(color)) return color;
     return PLAYLIST_COLORS[index % PLAYLIST_COLORS.length];
   }, [color, index]);
 

--- a/packages/mobile/src/components/playlist/__tests__/playlist-form-values.test.ts
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-form-values.test.ts
@@ -56,6 +56,34 @@ describe('buildPlaylistFormValues', () => {
     expect(result).toEqual({ ok: true, values: { name: 'P', description: 'd', color: '#AABBCC', icon: '🔥' } });
   });
 
+  it('canonicalizes a legacy colour before a new write', () => {
+    const result = buildPlaylistFormValues('create', {
+      name: 'P',
+      description: '',
+      color: '#aB3',
+      icon: undefined,
+      isPublic: false,
+    });
+    expect(result).toEqual({
+      ok: true,
+      values: { name: 'P', description: undefined, color: '#AABB33', icon: undefined },
+    });
+  });
+
+  it('omits an invalid colour from a create write', () => {
+    const result = buildPlaylistFormValues('create', {
+      name: 'P',
+      description: '',
+      color: 'not-a-colour',
+      icon: undefined,
+      isPublic: false,
+    });
+    expect(result).toEqual({
+      ok: true,
+      values: { name: 'P', description: undefined, color: undefined, icon: undefined },
+    });
+  });
+
   it("edit sends '' for cleared description/colour/icon (the clear signal)", () => {
     const result = buildPlaylistFormValues('edit', {
       name: 'P',

--- a/packages/mobile/src/components/playlist/__tests__/playlist-gradient.test.ts
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-gradient.test.ts
@@ -44,9 +44,13 @@ describe('buildHeroGradient', () => {
     expect(gradient.locations).toEqual([0, 0.55, 1]);
   });
 
+  it('expands a legacy three-digit playlist colour before rendering', () => {
+    expect(buildHeroGradient('#aB3').colors[1]).toBe('#AABB33');
+  });
+
   it('falls back to the brand violet for missing or invalid colours', () => {
     expect(buildHeroGradient(undefined).colors[1]).toBe(PLAYLIST_COLORS[0]);
     expect(buildHeroGradient('not-a-colour').colors[1]).toBe(PLAYLIST_COLORS[0]);
-    expect(buildHeroGradient('#fff').colors[1]).toBe(PLAYLIST_COLORS[0]);
+    expect(buildHeroGradient('#abcd').colors[1]).toBe(PLAYLIST_COLORS[0]);
   });
 });

--- a/packages/mobile/src/components/playlist/__tests__/playlist-gradient.test.ts
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-gradient.test.ts
@@ -47,5 +47,6 @@ describe('buildHeroGradient', () => {
   it('falls back to the brand violet for missing or invalid colours', () => {
     expect(buildHeroGradient(undefined).colors[1]).toBe(PLAYLIST_COLORS[0]);
     expect(buildHeroGradient('not-a-colour').colors[1]).toBe(PLAYLIST_COLORS[0]);
+    expect(buildHeroGradient('#fff').colors[1]).toBe(PLAYLIST_COLORS[0]);
   });
 });

--- a/packages/mobile/src/components/playlist/index.ts
+++ b/packages/mobile/src/components/playlist/index.ts
@@ -16,4 +16,4 @@ export { PlaylistEditDoneButton } from './PlaylistEditDoneButton';
 export { PlaylistOwnerToolbar } from './PlaylistOwnerToolbar';
 export { PlaylistActionsMenu } from './PlaylistActionsMenu';
 export { PlaylistQueueReplaceSheet } from './PlaylistQueueReplaceSheet';
-export { PLAYLIST_COLORS, isValidPlaylistColor } from './playlist-colors';
+export { PLAYLIST_COLORS, isValidPlaylistColor, normalizePlaylistColor } from './playlist-colors';

--- a/packages/mobile/src/components/playlist/index.ts
+++ b/packages/mobile/src/components/playlist/index.ts
@@ -16,4 +16,4 @@ export { PlaylistEditDoneButton } from './PlaylistEditDoneButton';
 export { PlaylistOwnerToolbar } from './PlaylistOwnerToolbar';
 export { PlaylistActionsMenu } from './PlaylistActionsMenu';
 export { PlaylistQueueReplaceSheet } from './PlaylistQueueReplaceSheet';
-export { PLAYLIST_COLORS, isValidHexColor } from './playlist-colors';
+export { PLAYLIST_COLORS, isValidPlaylistColor } from './playlist-colors';

--- a/packages/mobile/src/components/playlist/playlist-colors.ts
+++ b/packages/mobile/src/components/playlist/playlist-colors.ts
@@ -1,3 +1,5 @@
+import { isValidPlaylistColor } from '@boardsesh/shared-schema';
+
 // Cycling swatch palette for playlists. Used as the preview tint when a playlist
 // has no valid `color`, and as the swatch options in the create/edit form. Leads
 // with the violet brand + amber accent, then a varied set so playlists stay
@@ -18,8 +20,4 @@ export const PLAYLIST_COLORS = [
   '#1F2937', // near-black
 ] as const;
 
-const HEX_PATTERN = /^#([0-9A-Fa-f]{3}){1,2}$/;
-
-export function isValidHexColor(color: string): boolean {
-  return HEX_PATTERN.test(color);
-}
+export { isValidPlaylistColor };

--- a/packages/mobile/src/components/playlist/playlist-colors.ts
+++ b/packages/mobile/src/components/playlist/playlist-colors.ts
@@ -1,4 +1,4 @@
-import { isValidPlaylistColor } from '@boardsesh/shared-schema';
+import { isValidPlaylistColor, normalizePlaylistColor } from '@boardsesh/shared-schema';
 
 // Cycling swatch palette for playlists. Used as the preview tint when a playlist
 // has no valid `color`, and as the swatch options in the create/edit form. Leads
@@ -20,4 +20,4 @@ export const PLAYLIST_COLORS = [
   '#1F2937', // near-black
 ] as const;
 
-export { isValidPlaylistColor };
+export { isValidPlaylistColor, normalizePlaylistColor };

--- a/packages/mobile/src/components/playlist/playlist-form-values.ts
+++ b/packages/mobile/src/components/playlist/playlist-form-values.ts
@@ -1,3 +1,5 @@
+import { normalizePlaylistColor } from '@boardsesh/shared-schema';
+
 export const NAME_MAX = 100;
 export const DESCRIPTION_MAX = 500;
 
@@ -37,20 +39,21 @@ export function buildPlaylistFormValues(mode: 'create' | 'edit', fields: Playlis
 
   const trimmedDescription = fields.description.trim();
   if (trimmedDescription.length > DESCRIPTION_MAX) return { ok: false, error: 'description-too-long' };
+  const normalizedColor = normalizePlaylistColor(fields.color);
 
   const values: PlaylistFormValues =
     mode === 'edit'
       ? {
           name: trimmedName,
           description: trimmedDescription,
-          color: fields.color ?? '',
+          color: normalizedColor ?? '',
           icon: fields.icon ?? '',
           isPublic: fields.isPublic,
         }
       : {
           name: trimmedName,
           description: trimmedDescription || undefined,
-          color: fields.color,
+          color: normalizedColor ?? undefined,
           icon: fields.icon,
         };
   return { ok: true, values };

--- a/packages/mobile/src/components/playlist/playlist-gradient.ts
+++ b/packages/mobile/src/components/playlist/playlist-gradient.ts
@@ -3,7 +3,7 @@
 // the small square thumbnail (`PlaylistPreviewSquare`) deliberately does NOT use
 // this — the gradient is the detail-hero-only treatment.
 
-import { PLAYLIST_COLORS, isValidPlaylistColor } from './playlist-colors';
+import { PLAYLIST_COLORS, normalizePlaylistColor } from './playlist-colors';
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
@@ -88,7 +88,7 @@ export type HeroGradient = {
  * colour is missing/invalid, so the hero always has a deterministic banner.
  */
 export function buildHeroGradient(baseHex: string | undefined): HeroGradient {
-  const base = baseHex && isValidPlaylistColor(baseHex) ? baseHex : PLAYLIST_COLORS[0];
+  const base = normalizePlaylistColor(baseHex) ?? PLAYLIST_COLORS[0];
   return {
     colors: [shiftLightness(base, 14), base, shiftLightness(base, -20)],
     locations: [0, 0.55, 1],

--- a/packages/mobile/src/components/playlist/playlist-gradient.ts
+++ b/packages/mobile/src/components/playlist/playlist-gradient.ts
@@ -3,7 +3,7 @@
 // the small square thumbnail (`PlaylistPreviewSquare`) deliberately does NOT use
 // this — the gradient is the detail-hero-only treatment.
 
-import { PLAYLIST_COLORS, isValidHexColor } from './playlist-colors';
+import { PLAYLIST_COLORS, isValidPlaylistColor } from './playlist-colors';
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
@@ -88,7 +88,7 @@ export type HeroGradient = {
  * colour is missing/invalid, so the hero always has a deterministic banner.
  */
 export function buildHeroGradient(baseHex: string | undefined): HeroGradient {
-  const base = baseHex && isValidHexColor(baseHex) ? baseHex : PLAYLIST_COLORS[0];
+  const base = baseHex && isValidPlaylistColor(baseHex) ? baseHex : PLAYLIST_COLORS[0];
   return {
     colors: [shiftLightness(base, 14), base, shiftLightness(base, -20)],
     locations: [0, 0.55, 1],

--- a/packages/shared-schema/src/__tests__/playlist-color.test.ts
+++ b/packages/shared-schema/src/__tests__/playlist-color.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { isValidPlaylistColor } from '../utils';
+import { isValidPlaylistColor, normalizePlaylistColor } from '../utils';
 
 describe('isValidPlaylistColor', () => {
   it('accepts only non-empty six-digit hex colours', () => {
@@ -8,5 +8,26 @@ describe('isValidPlaylistColor', () => {
     expect(isValidPlaylistColor('A1b2C3')).toBe(false);
     expect(isValidPlaylistColor('#A1b2C3ff')).toBe(false);
     expect(isValidPlaylistColor('')).toBe(false);
+  });
+});
+
+describe('normalizePlaylistColor', () => {
+  it('expands legacy shorthand and accepts upstream colours without a hash', () => {
+    expect(normalizePlaylistColor('#aB3')).toBe('#AABB33');
+    expect(normalizePlaylistColor('aB3')).toBe('#AABB33');
+  });
+
+  it('canonicalizes six-digit colours', () => {
+    expect(normalizePlaylistColor('#A1b2C3')).toBe('#A1B2C3');
+    expect(normalizePlaylistColor('A1b2C3')).toBe('#A1B2C3');
+  });
+
+  it('returns null for missing or invalid colours', () => {
+    expect(normalizePlaylistColor(undefined)).toBeNull();
+    expect(normalizePlaylistColor(null)).toBeNull();
+    expect(normalizePlaylistColor('')).toBeNull();
+    expect(normalizePlaylistColor('#abcd')).toBeNull();
+    expect(normalizePlaylistColor('#A1b2C3ff')).toBeNull();
+    expect(normalizePlaylistColor('not-a-colour')).toBeNull();
   });
 });

--- a/packages/shared-schema/src/__tests__/playlist-color.test.ts
+++ b/packages/shared-schema/src/__tests__/playlist-color.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { isValidPlaylistColor } from '../utils';
+
+describe('isValidPlaylistColor', () => {
+  it('accepts only non-empty six-digit hex colours', () => {
+    expect(isValidPlaylistColor('#A1b2C3')).toBe(true);
+    expect(isValidPlaylistColor('#abc')).toBe(false);
+    expect(isValidPlaylistColor('A1b2C3')).toBe(false);
+    expect(isValidPlaylistColor('#A1b2C3ff')).toBe(false);
+    expect(isValidPlaylistColor('')).toBe(false);
+  });
+});

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -6087,7 +6087,7 @@ type Mutation {
   removeClimbFromPlaylist(input: RemoveClimbFromPlaylistInput!): Boolean!
 
   """
-  Reorder a climb within a playlist by moving it to a new index (owner/editor).
+  Reorder a climb within a playlist by moving it to a new index (owner only).
   """
   reorderPlaylistClimb(input: ReorderPlaylistClimbInput!): Boolean!
 

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -3129,7 +3129,7 @@ export type Mutation = {
   removeGymMember: Scalars['Boolean']['output'];
   /** Remove a climb from the queue by its queue item UUID. */
   removeQueueItem: Scalars['Boolean']['output'];
-  /** Reorder a climb within a playlist by moving it to a new index (owner/editor). */
+  /** Reorder a climb within a playlist by moving it to a new index (owner only). */
   reorderPlaylistClimb: Scalars['Boolean']['output'];
   /** Move a queue item from one position to another. */
   reorderQueueItem: Scalars['Boolean']['output'];

--- a/packages/shared-schema/src/schema/mutations.ts
+++ b/packages/shared-schema/src/schema/mutations.ts
@@ -356,7 +356,7 @@ export const mutationsTypeDefs = /* GraphQL */ `
     removeClimbFromPlaylist(input: RemoveClimbFromPlaylistInput!): Boolean!
 
     """
-    Reorder a climb within a playlist by moving it to a new index (owner/editor).
+    Reorder a climb within a playlist by moving it to a new index (owner only).
     """
     reorderPlaylistClimb(input: ReorderPlaylistClimbInput!): Boolean!
 

--- a/packages/shared-schema/src/utils.ts
+++ b/packages/shared-schema/src/utils.ts
@@ -94,3 +94,13 @@ export function convertQualityToAurora(quality: number | null | undefined): numb
   const clamped = Math.min(5, Math.max(1, q));
   return Math.round(((clamped - 1) / 4) * 2) + 1;
 }
+
+/**
+ * Whether a playlist colour is a renderable six-digit CSS hex value.
+ *
+ * This intentionally rejects the empty string: mutation inputs use `''` as a
+ * separate clear signal, while renderers must only consume concrete colours.
+ */
+export function isValidPlaylistColor(color: string): boolean {
+  return /^#[0-9A-Fa-f]{6}$/.test(color);
+}

--- a/packages/shared-schema/src/utils.ts
+++ b/packages/shared-schema/src/utils.ts
@@ -96,11 +96,37 @@ export function convertQualityToAurora(quality: number | null | undefined): numb
 }
 
 /**
- * Whether a playlist colour is a renderable six-digit CSS hex value.
+ * Whether a playlist colour already uses the canonical six-digit CSS hex form.
  *
  * This intentionally rejects the empty string: mutation inputs use `''` as a
- * separate clear signal, while renderers must only consume concrete colours.
+ * separate clear signal. Renderers that need to support persisted legacy
+ * shorthand should use {@link normalizePlaylistColor} instead.
  */
 export function isValidPlaylistColor(color: string): boolean {
   return /^#[0-9A-Fa-f]{6}$/.test(color);
+}
+
+/**
+ * Convert a playlist colour from a persisted legacy or upstream representation
+ * into the canonical `#RRGGBB` form used by renderers and new writes.
+ *
+ * The leading `#` is optional because Aurora's circuit payloads omit it while
+ * Kilter payloads may include it. Three-digit shorthand is expanded one
+ * channel at a time. Anything other than three or six hexadecimal digits is
+ * rejected so callers can safely fall back instead of passing arbitrary text
+ * to a renderer or persisting it.
+ */
+export function normalizePlaylistColor(color: string | null | undefined): string | null {
+  if (color == null) return null;
+
+  const match = /^#?([0-9A-Fa-f]{3}(?:[0-9A-Fa-f]{3})?)$/.exec(color);
+  if (!match) return null;
+
+  const hexDigits = match[1].toUpperCase();
+  const expandedHexDigits =
+    hexDigits.length === 3
+      ? `${hexDigits[0]}${hexDigits[0]}${hexDigits[1]}${hexDigits[1]}${hexDigits[2]}${hexDigits[2]}`
+      : hexDigits;
+
+  return `#${expandedHexDigits}`;
 }

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -3126,7 +3126,7 @@ export type Mutation = {
   removeGymMember: Scalars['Boolean']['output'];
   /** Remove a climb from the queue by its queue item UUID. */
   removeQueueItem: Scalars['Boolean']['output'];
-  /** Reorder a climb within a playlist by moving it to a new index (owner/editor). */
+  /** Reorder a climb within a playlist by moving it to a new index (owner only). */
   reorderPlaylistClimb: Scalars['Boolean']['output'];
   /** Move a queue item from one position to another. */
   reorderQueueItem: Scalars['Boolean']['output'];

--- a/packages/web/app/api/og/playlist/__tests__/route.test.tsx
+++ b/packages/web/app/api/og/playlist/__tests__/route.test.tsx
@@ -170,7 +170,7 @@ describe('api/og/playlist route', () => {
     expect(textContent).toContain(icon);
   });
 
-  it('retains ASCII identifiers before falling back to playlist initials', async () => {
+  it('retains ASCII identifiers in the playlist mark', async () => {
     playlistRouteState.getPlaylistOgSummaryMock.mockResolvedValue({
       name: 'Steep Projects',
       description: null,
@@ -184,7 +184,9 @@ describe('api/og/playlist route', () => {
 
     await GET(makeRequest({ uuid: 'ascii-playlist' }));
     expect(collectText(playlistRouteState.capturedElement)).toContain('ST');
+  });
 
+  it('falls back to playlist initials when the icon is empty', async () => {
     playlistRouteState.getPlaylistOgSummaryMock.mockResolvedValue({
       name: 'Steep Projects',
       description: null,

--- a/packages/web/app/api/og/playlist/__tests__/route.test.tsx
+++ b/packages/web/app/api/og/playlist/__tests__/route.test.tsx
@@ -7,6 +7,7 @@ import { GET } from '../route';
 const playlistRouteState = vi.hoisted(() => ({
   getPlaylistOgSummaryMock: vi.fn(),
   capturedElement: null as unknown,
+  capturedOptions: null as ({ emoji?: string } & ResponseInit) | null,
 }));
 
 vi.mock('@/app/lib/seo/dynamic-og-data', () => ({
@@ -56,8 +57,9 @@ vi.mock('@/app/lib/seo/og', () => ({
 }));
 
 vi.mock('@vercel/og', () => ({
-  ImageResponse: vi.fn(function ImageResponse(element: unknown, init?: ResponseInit) {
+  ImageResponse: vi.fn(function ImageResponse(element: unknown, init?: { emoji?: string } & ResponseInit) {
     playlistRouteState.capturedElement = element;
+    playlistRouteState.capturedOptions = init ?? null;
     return new Response('mock-image', {
       status: 200,
       headers: new Headers(init?.headers),
@@ -94,6 +96,7 @@ describe('api/og/playlist route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     playlistRouteState.capturedElement = null;
+    playlistRouteState.capturedOptions = null;
   });
 
   it('renders a playlist OG image with ASCII-safe fallback markup and truncated copy', async () => {
@@ -141,5 +144,59 @@ describe('api/og/playlist route', () => {
     const response = await GET(makeRequest({ uuid: 'private-playlist' }));
 
     expect(response.status).toBe(404);
+  });
+
+  it.each([
+    ['a ZWJ emoji', '🧗‍♀️'],
+    ['a flag', '🇫🇷'],
+    ['a keycap', '1️⃣'],
+  ])('keeps %s as one grapheme in the playlist mark', async (_label, icon) => {
+    playlistRouteState.getPlaylistOgSummaryMock.mockResolvedValue({
+      name: 'Emoji Playlist',
+      description: null,
+      color: '#123456',
+      icon: `${icon} extra`,
+      isPublic: true,
+      boardType: 'kilter',
+      climbCount: 1,
+      version: 'emoji-test',
+    });
+
+    const response = await GET(makeRequest({ uuid: 'emoji-playlist' }));
+    const textContent = collectText(playlistRouteState.capturedElement);
+
+    expect(response.status).toBe(200);
+    expect(playlistRouteState.capturedOptions?.emoji).toBe('twemoji');
+    expect(textContent).toContain(icon);
+  });
+
+  it('retains ASCII identifiers before falling back to playlist initials', async () => {
+    playlistRouteState.getPlaylistOgSummaryMock.mockResolvedValue({
+      name: 'Steep Projects',
+      description: null,
+      color: '#123456',
+      icon: 'StarOutlined',
+      isPublic: true,
+      boardType: 'kilter',
+      climbCount: 1,
+      version: 'ascii-test',
+    });
+
+    await GET(makeRequest({ uuid: 'ascii-playlist' }));
+    expect(collectText(playlistRouteState.capturedElement)).toContain('ST');
+
+    playlistRouteState.getPlaylistOgSummaryMock.mockResolvedValue({
+      name: 'Steep Projects',
+      description: null,
+      color: '#123456',
+      icon: '',
+      isPublic: true,
+      boardType: 'kilter',
+      climbCount: 1,
+      version: 'initials-test',
+    });
+
+    await GET(makeRequest({ uuid: 'initials-playlist' }));
+    expect(collectText(playlistRouteState.capturedElement)).toContain('SP');
   });
 });

--- a/packages/web/app/api/og/playlist/route.tsx
+++ b/packages/web/app/api/og/playlist/route.tsx
@@ -10,6 +10,8 @@ export const runtime = 'nodejs';
 
 const PLAYLIST_NAME_MAX_LENGTH = 34;
 const PLAYLIST_DESCRIPTION_MAX_LENGTH = 120;
+const EMOJI_GRAPHEME_PATTERN = /\p{Extended_Pictographic}|\p{Regional_Indicator}|\u20E3/u;
+const GRAPHEME_SEGMENTER = new Intl.Segmenter('en', { granularity: 'grapheme' });
 
 function truncateOgText(value: string, maxLength: number): string {
   const normalized = value.trim();
@@ -22,13 +24,22 @@ function truncateOgText(value: string, maxLength: number): string {
 
 function getPlaylistFallbackMark(icon: string | null, name: string, boardLabel: string): string {
   const normalizedIcon = icon?.trim() || '';
-  const safeIcon = normalizedIcon.replace(/[^A-Za-z0-9!?#+&]/g, '').toUpperCase();
-  if (safeIcon) {
-    return safeIcon.slice(0, 2);
+  for (const { segment } of GRAPHEME_SEGMENTER.segment(normalizedIcon)) {
+    if (EMOJI_GRAPHEME_PATTERN.test(segment)) {
+      return segment;
+    }
   }
 
-  const fallbackSource = `${name} ${boardLabel}`.replace(/[^A-Za-z0-9]/g, '').toUpperCase();
-  return fallbackSource.slice(0, 2) || 'PL';
+  const asciiIdentifier = normalizedIcon.replace(/[^A-Za-z0-9!?#+&]/g, '').toUpperCase();
+  if (asciiIdentifier) {
+    return asciiIdentifier.slice(0, 2);
+  }
+
+  const initials = (`${name} ${boardLabel}`.match(/[A-Za-z0-9]+/g) ?? [])
+    .map((word) => word[0])
+    .join('')
+    .toUpperCase();
+  return initials.slice(0, 2) || 'PL';
 }
 
 export async function GET(request: NextRequest) {
@@ -180,6 +191,7 @@ export async function GET(request: NextRequest) {
       {
         width: OG_IMAGE_WIDTH,
         height: OG_IMAGE_HEIGHT,
+        emoji: 'twemoji',
         headers: createOgImageHeaders({
           contentType: 'image/png',
           version,

--- a/packages/web/app/api/og/playlist/route.tsx
+++ b/packages/web/app/api/og/playlist/route.tsx
@@ -11,7 +11,7 @@ export const runtime = 'nodejs';
 const PLAYLIST_NAME_MAX_LENGTH = 34;
 const PLAYLIST_DESCRIPTION_MAX_LENGTH = 120;
 const EMOJI_GRAPHEME_PATTERN = /\p{Extended_Pictographic}|\p{Regional_Indicator}|\u20E3/u;
-const GRAPHEME_SEGMENTER = new Intl.Segmenter('en', { granularity: 'grapheme' });
+const GRAPHEME_SEGMENTER = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
 
 function truncateOgText(value: string, maxLength: number): string {
   const normalized = value.trim();

--- a/packages/web/app/lib/data-sync/aurora/user-sync.ts
+++ b/packages/web/app/lib/data-sync/aurora/user-sync.ts
@@ -14,6 +14,7 @@ import {
   canWriteUpstreamPlaylist,
   upstreamPlaylistSkipLogLine,
 } from '@boardsesh/sync-runtime';
+import { normalizePlaylistColor } from '@boardsesh/shared-schema';
 import { UNIFIED_TABLES } from '../../db/queries/util/table-select';
 import { auroraCredentials, playlists, playlistClimbs, playlistOwnership } from '../../db/schema';
 // Narrow subpath import (not the `./sync` barrel) so the web bundle doesn't
@@ -280,8 +281,9 @@ export async function upsertTableData(
             continue;
           }
 
-          // Format color - Aurora uses hex without #, we store with #
-          const formattedColor = item.color ? `#${item.color}` : null;
+          // Aurora may omit the hash and legacy payloads may use shorthand;
+          // persist one canonical representation for every downstream client.
+          const formattedColor = normalizePlaylistColor(item.color);
 
           // Insert/update playlist
           const [playlist] = await db


### PR DESCRIPTION
## Summary

- enforce owner-only playlist library rows, counts, edit-picker membership, and add/remove/reorder/last-access writes without changing private editor/viewer read access
- keep mutations on the strict six-digit playlist colour contract while normalizing legacy shorthand and hashless colours at every current mobile and sync boundary
- render complete emoji graphemes in playlist OG images with Twemoji, keep ASCII/initial fallbacks, and accept smart-playlist angles through 90°
- add a non-destructive real-Postgres owner/editor/viewer role matrix plus focused validation and OG coverage

Closes #4016

## Issue bullet classification

- **Hex validation drift — fixed across current and imported data.** The shared validator accepts only non-empty `#RRGGBB`; backend validation separately permits `''` to clear and `undefined` to leave unchanged. A shared normalizer upgrades stored three- or six-digit, hashless or hashed colours to uppercase `#RRGGBB`; current mobile render/form boundaries plus Aurora and Kilter import/sync writers use it. The duplicate Next.js playlist controls are obsolete climbing surfaces and remain untouched.
- **Web missing active-angle rendering — obsolete Next.js climbing surface.** The current RN playlist path already sends the active board and angle.
- **Reorder and per-row remove UI — already fixed in RN.** The current mobile playlist detail already exposes both actions.
- **Ownership role checks — fixed.** `userPlaylists`, `allUserPlaylists`, both edit-picker membership reads, and all four requested writes now require `role = 'owner'`. Private editor/viewer reads through `verifyPlaylistAccess` are intentionally retained.
- **Dead code — classified individually.** The unused `ownedPlaylistSelect(userId)` argument is fixed. Shipped `userPlaylists` and `playlistCreators` GraphQL operations are intentionally retained for API compatibility. The Next-only `getDefaultAngleForBoard` helper is obsolete with the retired climbing surface and remains untouched.
- **Legacy board-path playlist SSR seed — obsolete Next.js climbing surface.** The route remains untouched.
- **OG emoji and icon comment — fixed.** ZWJ emoji, flags, and keycaps stay intact; Twemoji rendering and ASCII/initial fallbacks are explicit; the schema comment now matches stored values.
- **Smart angle capped at 70° — fixed.** 90° is accepted and 91° is rejected.

No shipped GraphQL operations were removed.

## Release Notes

- Playlist colours and shared-image emoji now stay consistent across your library, including playlists for 90° walls.
- Playlist collaborators can still read private climbs while owner-only changes stay protected.

## Test plan

- `vp test run --reporter=agent packages/backend/src/__tests__/all-user-playlists.test.ts packages/backend/src/__tests__/playlist-queries.test.ts packages/backend/src/__tests__/playlist-reorder.test.ts packages/backend/src/__tests__/playlist-reorder-integration.test.ts packages/backend/src/__tests__/add-climb-to-playlist-race.test.ts packages/backend/src/__tests__/playlist-update.test.ts packages/backend/src/__tests__/playlist-role-matrix.test.ts packages/backend/src/__tests__/playlist-validation.test.ts` — 42 passed
- focused shared/mobile/web/backend suite — 25 passed
- `vp run test:mobile` — 575 files / 4,912 tests passed
- `vp run typecheck:mobile`
- `vp run typecheck:shared`
- `vp exec --filter @boardsesh/web -- tsc --noEmit`
- scoped `vp check` across all 20 changed files
- `vp run check:mobile-bundle` — iOS and Android bundles passed
- follow-up legacy-colour suite — 99 tests passed; mobile, Aurora, Kilter, backend, shared, and web typechecks passed
- independent follow-up review — no actionable P0–P2 findings
- `vp run dev:mobile` — QA notes surfaced and Metro started at `http://vibetunnel-2.tailedd9d5.ts.net:8081`, then stopped

Repository-baseline gates outside this diff:
- canonical `vp check` reports only the unchanged formatting issue in `packages/web/app/components/logbook/logascent-form.tsx`
- `vp run typecheck:backend` reports only unchanged duplicate exports in `packages/shared/board-constants/src/index.ts`
- `vp run typecheck:web` reaches Next build and Turbopack rejects the worktree's external `node_modules` symlink; direct web TypeScript checking passes

Manual device QA for the playlist colour fallbacks and owner flows remains a physical gate.