### PR TITLE
fix(ci): require location-sync integration proof

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       backend: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.backend }}
       mobile: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.mobile }}
       ocr: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.ocr }}
+      locationSync: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.locationSync }}
       sharedDeps: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.sharedDeps }}
       sharedSchema: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.sharedSchema }}
       i18nCatalogs: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.i18nCatalogs }}
@@ -53,7 +54,7 @@ jobs:
       # non-JS files (SQL migrations under packages/db, .graphql under
       # shared-schema) that wouldn't trigger anyJs but still need setup so
       # test-backend / mobile-bundle / codegen-drift can run.
-      runAny: ${{ github.event_name != 'pull_request' || steps.filter.outputs.anyJs == 'true' || steps.filter.outputs.web == 'true' || steps.filter.outputs.i18nCatalogs == 'true' || steps.filter.outputs.sharedSchema == 'true' || steps.filter.outputs.sharedDeps == 'true' || steps.filter.outputs.backend == 'true' || steps.filter.outputs.mobile == 'true' || steps.filter.outputs.ocr == 'true' || steps.filter.outputs.rootCi == 'true' }}
+      runAny: ${{ github.event_name != 'pull_request' || steps.filter.outputs.anyJs == 'true' || steps.filter.outputs.web == 'true' || steps.filter.outputs.i18nCatalogs == 'true' || steps.filter.outputs.sharedSchema == 'true' || steps.filter.outputs.sharedDeps == 'true' || steps.filter.outputs.backend == 'true' || steps.filter.outputs.mobile == 'true' || steps.filter.outputs.ocr == 'true' || steps.filter.outputs.locationSync == 'true' || steps.filter.outputs.rootCi == 'true' }}
       # NOTE: deployConfig is deliberately NOT part of runAny — the deploy-config
       # job below needs [changes] only (no bun-install/build:db setup pass), so a
       # deploy/app-subdomain-only PR doesn't pay for a `setup` run nothing else
@@ -85,6 +86,10 @@ jobs:
               - 'scripts/sync-mobile-board-renderer-wasm.sh'
             ocr:
               - 'packages/moonboard-ocr/**'
+            locationSync:
+              - 'packages/location-sync/**'
+              - 'packages/db/**'
+              - '.github/workflows/ci.yml'
             sharedDeps:
               # packages/shared/** gates test-backend (and mobile-bundle). The
               # backend test project includes the queue-client integration suite
@@ -640,6 +645,63 @@ jobs:
           path: packages/moonboard-ocr/test-results/junit-ocr.xml
           retention-days: 7
 
+  test-location-sync-integration:
+    needs: [changes, setup]
+    if: needs.changes.outputs.locationSync == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    services:
+      postgres:
+        image: ghcr.io/boardsesh/boardsesh-dev-db@sha256:ce32f2a70405112178f3b8b3e4b373175878539d8532f46dd313e04bbcb14cb4
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: main
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: 'lts'
+          cache: true
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Download built packages
+        uses: actions/download-artifact@v4
+        with:
+          name: built-packages
+      - name: Apply the full migration journal
+        env:
+          DATABASE_URL: postgres://postgres:password@localhost:5432/main
+          VERIFY_MIGRATION_JOURNAL: '1'
+        run: bun run --filter=@boardsesh/db db:migrate
+      - name: Run the required location-sync integration suite
+        env:
+          DATABASE_URL: postgres://postgres:password@localhost:5432/main
+          REQUIRE_LOCATION_SYNC_INTEGRATION: '1'
+        run: |
+          mkdir -p packages/location-sync/test-results
+          vp test run --project location-sync \
+            --reporter=verbose --reporter=github-actions \
+            --reporter=junit --outputFile.junit=./packages/location-sync/test-results/junit-location-sync.xml
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-location-sync
+          path: packages/location-sync/test-results/junit-location-sync.xml
+          retention-days: 7
+
   mobile-bundle:
     needs: [changes, setup]
     if: needs.changes.outputs.mobile == 'true' || needs.changes.outputs.sharedDeps == 'true' || needs.changes.outputs.rootCi == 'true'
@@ -818,8 +880,8 @@ jobs:
           exit 1
 
   test-report:
-    needs: [test-default, test-backend, test-ocr]
-    # Only post a report when at least one test job actually ran. If all three
+    needs: [test-default, test-backend, test-ocr, test-location-sync-integration]
+    # Only post a report when at least one test job actually ran. If all four
     # were skipped (e.g. an i18n-catalog-only PR), there's nothing to
     # download — actions/download-artifact errors on missing artifacts, so we
     # skip the whole job instead of swallowing the failure.
@@ -827,7 +889,8 @@ jobs:
       always() && github.event_name == 'pull_request' && (
         needs.test-default.result != 'skipped' ||
         needs.test-backend.result != 'skipped' ||
-        needs.test-ocr.result != 'skipped'
+        needs.test-ocr.result != 'skipped' ||
+        needs.test-location-sync-integration.result != 'skipped'
       )
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -861,6 +924,7 @@ jobs:
       - test-default
       - test-backend
       - test-ocr
+      - test-location-sync-integration
       - mobile-bundle
       - commit-lint
       - release-notes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -647,7 +647,7 @@ jobs:
 
   test-location-sync-integration:
     needs: [changes, setup]
-    if: needs.changes.outputs.locationSync == 'true'
+    if: needs.changes.outputs.locationSync == 'true' || needs.changes.outputs.sharedDeps == 'true' || needs.changes.outputs.sharedSchema == 'true' || needs.changes.outputs.rootCi == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     services:

--- a/packages/location-sync/src/integration-test-config.test.ts
+++ b/packages/location-sync/src/integration-test-config.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { resolveLocationSyncIntegrationConfig } from './integration-test-config';
+
+describe('resolveLocationSyncIntegrationConfig', () => {
+  it('self-skips a local developer run with no database', () => {
+    expect(resolveLocationSyncIntegrationConfig({})).toEqual({
+      databaseUrl: null,
+      required: false,
+      skipReason: 'DATABASE_URL is not set',
+    });
+  });
+
+  it.each([
+    ['missing', undefined],
+    ['malformed', 'not a URL'],
+    ['wrong protocol', 'https://localhost/main'],
+    ['remote', 'postgres://postgres:password@db.example.com/main'],
+  ])('fails closed in required mode when the database is %s', (_caseName, databaseUrl) => {
+    expect(() =>
+      resolveLocationSyncIntegrationConfig({
+        REQUIRE_LOCATION_SYNC_INTEGRATION: '1',
+        DATABASE_URL: databaseUrl,
+      }),
+    ).toThrow(/location-sync integration is required/);
+  });
+
+  it.each([
+    'postgres://postgres:password@localhost:5432/main',
+    'postgresql://postgres:password@127.0.0.1:5432/main',
+    'postgres://postgres:password@[::1]:5432/main',
+    'postgres://postgres:password@postgres:5432/main',
+    'postgres://postgres:password@postgres-test:5432/main',
+  ])('accepts the local PostgreSQL URL %s', (databaseUrl) => {
+    expect(
+      resolveLocationSyncIntegrationConfig({
+        REQUIRE_LOCATION_SYNC_INTEGRATION: '1',
+        DATABASE_URL: databaseUrl,
+      }),
+    ).toEqual({ databaseUrl, required: true, skipReason: null });
+  });
+
+  it('only arms required mode on the exact value 1', () => {
+    expect(
+      resolveLocationSyncIntegrationConfig({
+        REQUIRE_LOCATION_SYNC_INTEGRATION: 'true',
+        DATABASE_URL: 'postgres://postgres:password@db.example.com/main',
+      }),
+    ).toMatchObject({ databaseUrl: null, required: false });
+  });
+});

--- a/packages/location-sync/src/integration-test-config.ts
+++ b/packages/location-sync/src/integration-test-config.ts
@@ -1,0 +1,56 @@
+const LOCAL_DATABASE_HOSTS = new Set(['localhost', '127.0.0.1', '::1', 'postgres', 'postgres-test']);
+
+export type LocationSyncIntegrationConfig =
+  | {
+      databaseUrl: string;
+      required: boolean;
+      skipReason: null;
+    }
+  | {
+      databaseUrl: null;
+      required: false;
+      skipReason: string;
+    };
+
+function unavailable(required: boolean, reason: string): LocationSyncIntegrationConfig {
+  if (required) {
+    throw new Error(`location-sync integration is required, but ${reason}`);
+  }
+
+  return { databaseUrl: null, required: false, skipReason: reason };
+}
+
+/**
+ * Resolve the database used by the real location-sync tests without ever
+ * allowing the suite to touch a remote database. Local developer runs remain
+ * opt-in; the dedicated CI job arms fail-closed behavior with the exact value
+ * `REQUIRE_LOCATION_SYNC_INTEGRATION=1`.
+ */
+export function resolveLocationSyncIntegrationConfig(
+  environment: Readonly<Record<string, string | undefined>>,
+): LocationSyncIntegrationConfig {
+  const required = environment.REQUIRE_LOCATION_SYNC_INTEGRATION === '1';
+  const databaseUrl = environment.DATABASE_URL;
+
+  if (!databaseUrl) {
+    return unavailable(required, 'DATABASE_URL is not set');
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(databaseUrl);
+  } catch {
+    return unavailable(required, 'DATABASE_URL is malformed');
+  }
+
+  if (!['postgres:', 'postgresql:'].includes(parsedUrl.protocol) || !parsedUrl.hostname) {
+    return unavailable(required, 'DATABASE_URL is not a valid PostgreSQL URL');
+  }
+
+  const hostname = parsedUrl.hostname.toLowerCase().replace(/^\[(.*)\]$/, '$1');
+  if (!LOCAL_DATABASE_HOSTS.has(hostname)) {
+    return unavailable(required, `DATABASE_URL targets non-local host ${hostname}`);
+  }
+
+  return { databaseUrl, required, skipReason: null };
+}

--- a/packages/location-sync/src/upsert.freeze.integration.test.ts
+++ b/packages/location-sync/src/upsert.freeze.integration.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { sql } from 'drizzle-orm';
-import { createDb, executeRows } from '@boardsesh/db/client';
+import { closePool, createDb, executeRows } from '@boardsesh/db/client';
 import { upsertPublicBoardLocations } from './upsert';
 import type { PublicBoardLocationInput } from './types';
 import { boardUuidForSource, gymUuidForSource } from './ids';
+import { resolveLocationSyncIntegrationConfig } from './integration-test-config';
 
 /**
  * Real-DB integration test proving the sync-freeze guards: once a human curates
@@ -11,26 +13,12 @@ import { boardUuidForSource, gymUuidForSource } from './ids';
  * NOT overwrite its metadata — while still keeping the source alias and the
  * board→gym link current. An unfrozen synced row must still update normally.
  *
- * Opt-in: needs a migrated, writable PostGIS database (the location triggers
- * from migration 0127 plus the sync_frozen_at columns). Point DATABASE_URL at a
- * local Postgres and run. It self-skips otherwise, so CI stays green without a DB.
- * Everything runs inside a transaction that is rolled back, leaving no residue.
+ * Local runs are opt-in and self-skip without an eligible DATABASE_URL. The
+ * dedicated CI job sets REQUIRE_LOCATION_SYNC_INTEGRATION=1, which turns every
+ * missing/invalid prerequisite into a hard failure. Everything runs inside a
+ * transaction that is rolled back, leaving no residue.
  */
-
-function localDatabaseUrl(): string | null {
-  const databaseUrl = process.env.DATABASE_URL;
-  if (!databaseUrl) {
-    return null;
-  }
-  try {
-    const hostname = new URL(databaseUrl).hostname.toLowerCase();
-    return ['localhost', '127.0.0.1', 'postgres'].includes(hostname) ? databaseUrl : null;
-  } catch {
-    return null;
-  }
-}
-
-const HAS_LOCAL_DB = localDatabaseUrl() !== null;
+const integrationConfig = resolveLocationSyncIntegrationConfig(process.env);
 
 type GymStateRow = {
   id: number | string;
@@ -50,6 +38,19 @@ type BoardStateRow = {
 };
 
 type AliasRow = { gymId: number | string };
+
+type PrerequisiteRow = {
+  hasPostgis: boolean;
+  hasGymsTable: boolean;
+  hasBoardsTable: boolean;
+  hasAliasesTable: boolean;
+  hasGymFreezeColumn: boolean;
+  hasBoardFreezeColumn: boolean;
+  hasGymLocationColumn: boolean;
+  hasBoardLocationColumn: boolean;
+  hasGymLocationTrigger: boolean;
+  hasBoardLocationTrigger: boolean;
+};
 
 function baseRecord(overrides: Partial<PublicBoardLocationInput>): PublicBoardLocationInput {
   return {
@@ -93,15 +94,67 @@ async function readBoard(tx: Parameters<typeof upsertPublicBoardLocations>[0], u
   return row;
 }
 
-describe.skipIf(!HAS_LOCAL_DB)('location sync freeze guards (integration)', () => {
+describe.skipIf(integrationConfig.databaseUrl === null)('location sync freeze guards (integration)', () => {
+  beforeAll(async () => {
+    const db = createDb();
+    const [prerequisites] = await executeRows<PrerequisiteRow>(
+      db,
+      sql`SELECT
+            EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'postgis') AS "hasPostgis",
+            to_regclass('public.gyms') IS NOT NULL AS "hasGymsTable",
+            to_regclass('public.user_boards') IS NOT NULL AS "hasBoardsTable",
+            to_regclass('public.location_sync_gym_sources') IS NOT NULL AS "hasAliasesTable",
+            EXISTS (
+              SELECT 1 FROM information_schema.columns
+              WHERE table_schema = 'public' AND table_name = 'gyms' AND column_name = 'sync_frozen_at'
+            ) AS "hasGymFreezeColumn",
+            EXISTS (
+              SELECT 1 FROM information_schema.columns
+              WHERE table_schema = 'public' AND table_name = 'user_boards' AND column_name = 'sync_frozen_at'
+            ) AS "hasBoardFreezeColumn",
+            EXISTS (
+              SELECT 1 FROM information_schema.columns
+              WHERE table_schema = 'public' AND table_name = 'gyms' AND column_name = 'location'
+                AND udt_name = 'geography'
+            ) AS "hasGymLocationColumn",
+            EXISTS (
+              SELECT 1 FROM information_schema.columns
+              WHERE table_schema = 'public' AND table_name = 'user_boards' AND column_name = 'location'
+                AND udt_name = 'geography'
+            ) AS "hasBoardLocationColumn",
+            EXISTS (
+              SELECT 1 FROM pg_trigger
+              WHERE tgname = 'gyms_set_location' AND tgrelid = 'public.gyms'::regclass
+                AND NOT tgisinternal AND tgenabled <> 'D'
+            ) AS "hasGymLocationTrigger",
+            EXISTS (
+              SELECT 1 FROM pg_trigger
+              WHERE tgname = 'user_boards_set_location'
+                AND tgrelid = 'public.user_boards'::regclass
+                AND NOT tgisinternal AND tgenabled <> 'D'
+            ) AS "hasBoardLocationTrigger"`,
+    );
+
+    expect(prerequisites, 'expected the location-sync prerequisite query to return one row').toBeTruthy();
+    const missingPrerequisites = Object.entries(prerequisites ?? {})
+      .filter(([, isPresent]) => !isPresent)
+      .map(([name]) => name);
+    expect(missingPrerequisites, 'location-sync integration database is missing required schema').toEqual([]);
+  });
+
+  afterAll(async () => {
+    await closePool();
+  });
+
   it('never overwrites a human-curated gym/board, but keeps alias + link current', async () => {
     const db = createDb();
     const rollback = new Error('rollback freeze fixture');
 
     await db
       .transaction(async (tx) => {
-        const gymSourceKey = `tension:freeze-gym-${Date.now()}`;
-        const boardSourceKey = `tension:freeze-board-${Date.now()}`;
+        const fixtureId = randomUUID();
+        const gymSourceKey = `tension:freeze-gym-${fixtureId}`;
+        const boardSourceKey = `tension:freeze-board-${fixtureId}`;
         const gymUuid = gymUuidForSource(gymSourceKey);
         const boardUuid = boardUuidForSource(boardSourceKey);
 
@@ -183,8 +236,9 @@ describe.skipIf(!HAS_LOCAL_DB)('location sync freeze guards (integration)', () =
 
     await db
       .transaction(async (tx) => {
-        const gymSourceKey = `tension:open-gym-${Date.now()}`;
-        const boardSourceKey = `tension:open-board-${Date.now()}`;
+        const fixtureId = randomUUID();
+        const gymSourceKey = `tension:open-gym-${fixtureId}`;
+        const boardSourceKey = `tension:open-board-${fixtureId}`;
         const gymUuid = gymUuidForSource(gymSourceKey);
 
         await upsertPublicBoardLocations(tx, [

--- a/scripts/__tests__/ci-location-sync-workflow.test.ts
+++ b/scripts/__tests__/ci-location-sync-workflow.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
@@ -32,6 +34,13 @@ function mappingEntry(source: string, key: string, indentation: number): string 
   return lines.slice(startIndex, endIndex).join('\n');
 }
 
+function mappingLine(source: string, key: string, indentation: number): string {
+  const prefix = `${' '.repeat(indentation)}${key}:`;
+  const line = source.split('\n').find((candidate) => candidate.startsWith(prefix));
+  if (!line) throw new Error(`missing ${key} line at indentation ${indentation}`);
+  return line.trim();
+}
+
 describe('location-sync CI integration contract', () => {
   const changesJob = mappingEntry(workflowSource, 'changes', 2);
   const integrationJob = mappingEntry(workflowSource, 'test-location-sync-integration', 2);
@@ -50,8 +59,19 @@ describe('location-sync CI integration contract', () => {
     expect(locationSyncFilter).toContain("- '.github/workflows/ci.yml'");
   });
 
+  it('runs for direct changes, dependency changes, and shared CI changes', () => {
+    expect(mappingLine(integrationJob, 'if', 4)).toBe(
+      "if: needs.changes.outputs.locationSync == 'true' || needs.changes.outputs.sharedDeps == 'true' || needs.changes.outputs.sharedSchema == 'true' || needs.changes.outputs.rootCi == 'true'",
+    );
+
+    const runAny = mappingLine(changesJob, 'runAny', 6);
+    expect(runAny).toContain("steps.filter.outputs.locationSync == 'true'");
+    expect(runAny).toContain("steps.filter.outputs.sharedDeps == 'true'");
+    expect(runAny).toContain("steps.filter.outputs.sharedSchema == 'true'");
+    expect(runAny).toContain("steps.filter.outputs.rootCi == 'true'");
+  });
+
   it('runs the full project against the pinned migrated dev database', () => {
-    expect(integrationJob).toContain("if: needs.changes.outputs.locationSync == 'true'");
     expect(integrationJob).toContain(
       'image: ghcr.io/boardsesh/boardsesh-dev-db@sha256:ce32f2a70405112178f3b8b3e4b373175878539d8532f46dd313e04bbcb14cb4',
     );

--- a/scripts/__tests__/ci-location-sync-workflow.test.ts
+++ b/scripts/__tests__/ci-location-sync-workflow.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const WORKFLOW_PATH = '.github/workflows/ci.yml';
+const workflowSource = readFileSync(WORKFLOW_PATH, 'utf8');
+
+/**
+ * Return one YAML mapping entry by exact key and indentation. This deliberately
+ * understands mapping boundaries instead of matching the whole workflow with a
+ * broad regex. The repo has no directly declared YAML parser; keeping this
+ * reader tiny avoids adding dependency/lockfile churn for a CI contract test.
+ */
+function mappingEntry(source: string, key: string, indentation: number): string {
+  const lines = source.split('\n');
+  const prefix = `${' '.repeat(indentation)}${key}:`;
+  const startIndex = lines.findIndex((line) => line.startsWith(prefix));
+  if (startIndex < 0) {
+    throw new Error(`missing ${key} mapping at indentation ${indentation}`);
+  }
+
+  let endIndex = lines.length;
+  for (let lineIndex = startIndex + 1; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex];
+    if (!line.trim() || line.trimStart().startsWith('#')) continue;
+    const lineIndentation = line.length - line.trimStart().length;
+    if (lineIndentation <= indentation) {
+      endIndex = lineIndex;
+      break;
+    }
+  }
+
+  return lines.slice(startIndex, endIndex).join('\n');
+}
+
+describe('location-sync CI integration contract', () => {
+  const changesJob = mappingEntry(workflowSource, 'changes', 2);
+  const integrationJob = mappingEntry(workflowSource, 'test-location-sync-integration', 2);
+  const testReportJob = mappingEntry(workflowSource, 'test-report', 2);
+  const ciStatusJob = mappingEntry(workflowSource, 'ci-status', 2);
+
+  it('selects location-sync and database changes and includes them in runAny', () => {
+    expect(changesJob).toContain(
+      "locationSync: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.locationSync }}",
+    );
+    expect(changesJob).toContain("steps.filter.outputs.locationSync == 'true'");
+
+    const locationSyncFilter = mappingEntry(changesJob, 'locationSync', 12);
+    expect(locationSyncFilter).toContain("- 'packages/location-sync/**'");
+    expect(locationSyncFilter).toContain("- 'packages/db/**'");
+    expect(locationSyncFilter).toContain("- '.github/workflows/ci.yml'");
+  });
+
+  it('runs the full project against the pinned migrated dev database', () => {
+    expect(integrationJob).toContain("if: needs.changes.outputs.locationSync == 'true'");
+    expect(integrationJob).toContain(
+      'image: ghcr.io/boardsesh/boardsesh-dev-db@sha256:ce32f2a70405112178f3b8b3e4b373175878539d8532f46dd313e04bbcb14cb4',
+    );
+    expect(integrationJob).toContain("VERIFY_MIGRATION_JOURNAL: '1'");
+    expect(integrationJob).toContain('run: bun run --filter=@boardsesh/db db:migrate');
+    expect(integrationJob).toContain("REQUIRE_LOCATION_SYNC_INTEGRATION: '1'");
+    expect(integrationJob).toContain('vp test run --project location-sync');
+    expect(integrationJob).not.toContain('--changed');
+  });
+
+  it('publishes JUnit and makes both report and aggregate status depend on the job', () => {
+    expect(integrationJob).toContain('--reporter=junit');
+    expect(integrationJob).toContain('name: test-results-location-sync');
+    expect(integrationJob).toContain('path: packages/location-sync/test-results/junit-location-sync.xml');
+    expect(testReportJob).toContain('test-location-sync-integration');
+    expect(ciStatusJob).toContain('- test-location-sync-integration');
+  });
+});

--- a/scripts/__tests__/ci-test-default-projects.test.ts
+++ b/scripts/__tests__/ci-test-default-projects.test.ts
@@ -26,6 +26,7 @@ describe('selectTestDefaultProjects', () => {
     const paths = [
       './packages/web/vite.config.ts',
       './packages/backend/vite.config.ts',
+      './packages/location-sync/vite.config.ts',
       './packages/shared/queue/vite.config.ts',
       './packages/moonboard-ocr/vite.config.ts',
       './scripts/vite.config.ts',
@@ -33,6 +34,7 @@ describe('selectTestDefaultProjects', () => {
     const map = {
       './packages/web/vite.config.ts': projectConfig('web'),
       './packages/backend/vite.config.ts': projectConfig('backend'),
+      './packages/location-sync/vite.config.ts': projectConfig('location-sync'),
       './packages/shared/queue/vite.config.ts': projectConfig('queue'),
       './packages/moonboard-ocr/vite.config.ts': projectConfig('moonboard-ocr'),
       './scripts/vite.config.ts': projectConfig('scripts'),
@@ -95,7 +97,7 @@ describe('selectTestDefaultProjects', () => {
     expect(selectTestDefaultProjects(rootConfig(paths), reader(map), new Set(['web']))).toEqual(['queue']);
   });
 
-  it('documents the two infra projects excluded by default', () => {
-    expect([...INFRA_PROJECTS].sort()).toEqual(['backend', 'moonboard-ocr']);
+  it('documents the infra projects excluded by default', () => {
+    expect([...INFRA_PROJECTS].sort()).toEqual(['backend', 'location-sync', 'moonboard-ocr']);
   });
 });

--- a/scripts/ci-test-default-projects.ts
+++ b/scripts/ci-test-default-projects.ts
@@ -1,9 +1,9 @@
 /// <reference types="node" />
 
 // Emit the positive `--project=` flag list for the CI `test-default` job: every
-// Vitest project declared in root `vite.config.ts` EXCEPT the two that run in
+// Vitest project declared in root `vite.config.ts` EXCEPT those that run in
 // their own jobs because they need infra (`backend`: postgres + redis;
-// `moonboard-ocr`: canvas system libs).
+// `location-sync`: migrated PostGIS; `moonboard-ocr`: canvas system libs).
 //
 // Why a positive list instead of `--project '!backend'`? Vitest's `--changed`
 // selects test files from the diff, and that spec set drives project init /
@@ -29,7 +29,7 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 /** Projects with dedicated CI jobs because they need services/libs `test-default` lacks. */
-export const INFRA_PROJECTS: ReadonlySet<string> = new Set(['backend', 'moonboard-ocr']);
+export const INFRA_PROJECTS: ReadonlySet<string> = new Set(['backend', 'location-sync', 'moonboard-ocr']);
 
 /** Reads a project's `vite.config.ts` source, given its path relative to the repo root. */
 export type ConfigReader = (relativePath: string) => string;


### PR DESCRIPTION
## Summary

- add a dedicated location-sync integration job backed by the pinned populated PostGIS dev database image
- make required integration mode fail closed for missing, malformed, remote, unmigrated, or incomplete databases
- remove location-sync from the infra-free default test job and include its JUnit result in CI reporting and aggregate status
- add workflow and project-selection contract coverage so the gate cannot silently drift

## Root cause

The freeze integration suite self-skipped whenever its local-database check was not satisfied. CI did not provide a migrated PostGIS database or require the suite to run, so a green check could mean the core regression proof never executed.

Closes #3846

## Validation

- `vp test run --project location-sync --reporter=agent` (48 passed, 2 expected local integration skips)
- required mode without `DATABASE_URL` exits nonzero with a clear collection error
- `vp test run --project scripts scripts/__tests__/ci-test-default-projects.test.ts scripts/__tests__/ci-location-sync-workflow.test.ts --reporter=agent` (11 passed)
- `vp run typecheck:location-sync`
- scoped `vp check` for all changed TypeScript files
- parsed `.github/workflows/ci.yml` and verified the integration job/aggregate dependency structure
- full `vp run typecheck` reached the unrelated web build dependency and failed because this reused worktree's `packages/web/node_modules/next` symlink points outside Turbopack's filesystem root; the affected location-sync typecheck passed independently

The dev server was intentionally not started: this changes only CI orchestration and a real-database test harness. QA steps are documented in `.boardsesh/qa-notes.md`.

## Release Notes

- [x] No release note needed (internal / technical change)
