### PR TITLE
fix(mobile): upload OTA source maps

### DIFF
--- a/.github/workflows/mobile-ota-backport.yml
+++ b/.github/workflows/mobile-ota-backport.yml
@@ -243,7 +243,7 @@ jobs:
       - name: Validate anchored Sentry uploader support
         run: |
           set -euo pipefail
-          sentry_version="$(jq -r '.dependencies["@sentry/react-native"] // empty' packages/mobile/package.json)"
+          sentry_version="$(jq -r '.dependencies["@sentry/react-native"] // .devDependencies["@sentry/react-native"] // empty' packages/mobile/package.json)"
           if [ "$sentry_version" != "7.11.0" ]; then
             echo "::error::This anchor has @sentry/react-native $sentry_version; OTA source-map backports require exactly 7.11.0. Ship a native update instead."
             exit 1
@@ -315,6 +315,7 @@ jobs:
         id: upload_sourcemaps
         if: ${{ !inputs.dry_run && steps.publish.outcome == 'success' }}
         continue-on-error: true
+        timeout-minutes: 10
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           PLATFORM: ${{ matrix.platform }}
@@ -327,11 +328,11 @@ jobs:
         run: echo "::notice::dry_run — verified the fingerprint match for ${{ matrix.platform }} but skipped the publish. Re-run with dry_run unchecked to ship."
 
       - name: Warn that the published backport source maps are missing
-        if: ${{ always() && !inputs.dry_run && steps.upload_sourcemaps.outcome == 'failure' }}
-        run: echo "::warning::The ${{ matrix.platform }} backport OTA is live, but its Sentry source-map upload failed. Recreate the exact export before another eoas publish replaces dist."
+        if: ${{ always() && !inputs.dry_run && steps.publish.outcome == 'success' && steps.upload_sourcemaps.outcome != 'success' }}
+        run: echo "::warning::The ${{ matrix.platform }} backport OTA is live, but its Sentry source-map upload did not succeed. Recreate the exact export before another eoas publish replaces dist."
 
       - name: Require the published backport source-map upload
-        if: ${{ always() && !inputs.dry_run && steps.upload_sourcemaps.outcome == 'failure' }}
+        if: ${{ always() && !inputs.dry_run && steps.publish.outcome == 'success' && steps.upload_sourcemaps.outcome != 'success' }}
         run: |
           echo "::error::The published ${{ matrix.platform }} backport has no accepted Sentry source maps."
           exit 1

--- a/.github/workflows/mobile-ota-backport.yml
+++ b/.github/workflows/mobile-ota-backport.yml
@@ -216,6 +216,8 @@ jobs:
           cp "$tooling_root/scripts/mobile-upload-sourcemaps.ts" scripts/mobile-upload-sourcemaps.ts
           git add scripts/mobile-publish.ts scripts/lib/eoas.ts scripts/lib/mobile-publish-retry.ts scripts/mobile-upload-sourcemaps.ts
           if ! git diff --cached --quiet; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
             git commit -m "chore(ota): overlay trusted publish tooling"
           fi
           if [ -n "$(git status --porcelain)" ]; then

--- a/.github/workflows/mobile-ota-backport.yml
+++ b/.github/workflows/mobile-ota-backport.yml
@@ -130,6 +130,23 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
 
+      # The hotfix tree is about to move to an older release anchor, which may
+      # predate OTA source-map support. Snapshot the exact trusted workflow commit
+      # before that checkout; never take release tooling from a cherry-picked fix.
+      - name: Snapshot trusted OTA publish tooling
+        run: |
+          set -euo pipefail
+          tooling_root="$RUNNER_TEMP/ota-publish-tooling"
+          mkdir -p "$tooling_root/scripts/lib"
+          for source_path in \
+            scripts/mobile-publish.ts \
+            scripts/lib/eoas.ts \
+            scripts/lib/mobile-publish-retry.ts \
+            scripts/mobile-upload-sourcemaps.ts
+          do
+            git show "$GITHUB_SHA:$source_path" > "$tooling_root/$source_path"
+          done
+
       - name: Locate the release anchor and prepare the hotfix tree
         id: anchor
         env:
@@ -188,12 +205,49 @@ jobs:
           echo "Cherry-picking onto $tag: ${commits[*]}"
           git cherry-pick "${commits[@]}"
 
+      - name: Overlay trusted OTA publish tooling
+        run: |
+          set -euo pipefail
+          tooling_root="$RUNNER_TEMP/ota-publish-tooling"
+          mkdir -p scripts/lib
+          cp "$tooling_root/scripts/mobile-publish.ts" scripts/mobile-publish.ts
+          cp "$tooling_root/scripts/lib/eoas.ts" scripts/lib/eoas.ts
+          cp "$tooling_root/scripts/lib/mobile-publish-retry.ts" scripts/lib/mobile-publish-retry.ts
+          cp "$tooling_root/scripts/mobile-upload-sourcemaps.ts" scripts/mobile-upload-sourcemaps.ts
+          git add scripts/mobile-publish.ts scripts/lib/eoas.ts scripts/lib/mobile-publish-retry.ts scripts/mobile-upload-sourcemaps.ts
+          if ! git diff --cached --quiet; then
+            git commit -m "chore(ota): overlay trusted publish tooling"
+          fi
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::Trusted tooling overlay left the hotfix tree dirty; eoas would refuse to publish."
+            git status --short
+            exit 1
+          fi
+
       # Install AFTER the anchor checkout + cherry-pick so node_modules matches the
       # OLD release's lockfile, not main's. Resolving the fingerprint against
       # main's deps would diverge from what the shipped binary embedded and cause
       # a spurious mismatch (or, worse, a false match).
       - name: Install Node.js dependencies (workspace root)
         run: bun install --frozen-lockfile
+
+      # The trusted wrapper deliberately invokes the official uploader installed
+      # by the anchored app. Reject anchors that do not carry the audited 7.11.0
+      # implementation instead of changing dependencies (and the fingerprint).
+      - name: Validate anchored Sentry uploader support
+        run: |
+          set -euo pipefail
+          sentry_version="$(jq -r '.dependencies["@sentry/react-native"] // empty' packages/mobile/package.json)"
+          if [ "$sentry_version" != "7.11.0" ]; then
+            echo "::error::This anchor has @sentry/react-native $sentry_version; OTA source-map backports require exactly 7.11.0. Ship a native update instead."
+            exit 1
+          fi
+          uploader_path="$(cd packages/mobile && bun -e 'const path = require("node:path"); const packageJson = require.resolve("@sentry/react-native/package.json"); console.log(path.join(path.dirname(packageJson), "scripts", "expo-upload-sourcemaps.js"));')"
+          if [ ! -f "$uploader_path" ]; then
+            echo "::error::The anchored @sentry/react-native install has no official Expo source-map uploader."
+            exit 1
+          fi
+          echo "::notice::Anchored app has the audited @sentry/react-native 7.11.0 Expo uploader."
 
       - name: Write .env for Expo build-time inlining
         working-directory: packages/mobile
@@ -240,6 +294,7 @@ jobs:
           echo "::notice::$PLATFORM fingerprint $short matches the approved anchor — safe to publish."
 
       - name: Publish OTA to the approved release
+        id: publish
         if: ${{ !inputs.dry_run }}
         env:
           EOO_TOKEN: ${{ secrets.EOO_TOKEN }}
@@ -250,6 +305,27 @@ jobs:
         run: |
           vp run mobile:publish -- --channel production --platform "$PLATFORM" --message "Backport to v$VERSION ($FIX_COMMITS)"
 
+      - name: Upload backport OTA source maps to Sentry
+        id: upload_sourcemaps
+        if: ${{ !inputs.dry_run && steps.publish.outcome == 'success' }}
+        continue-on-error: true
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          PLATFORM: ${{ matrix.platform }}
+        # The old anchor's vite.config may not define the new task. The trusted,
+        # dependency-light helper was overlaid above, so invoke it directly.
+        run: bun scripts/mobile-upload-sourcemaps.ts --platform "$PLATFORM"
+
       - name: Dry-run note
         if: ${{ inputs.dry_run }}
         run: echo "::notice::dry_run — verified the fingerprint match for ${{ matrix.platform }} but skipped the publish. Re-run with dry_run unchecked to ship."
+
+      - name: Warn that the published backport source maps are missing
+        if: ${{ always() && !inputs.dry_run && steps.upload_sourcemaps.outcome == 'failure' }}
+        run: echo "::warning::The ${{ matrix.platform }} backport OTA is live, but its Sentry source-map upload failed. Recreate the exact export before another eoas publish replaces dist."
+
+      - name: Require the published backport source-map upload
+        if: ${{ always() && !inputs.dry_run && steps.upload_sourcemaps.outcome == 'failure' }}
+        run: |
+          echo "::error::The published ${{ matrix.platform }} backport has no accepted Sentry source maps."
+          exit 1

--- a/.github/workflows/mobile-ota-backport.yml
+++ b/.github/workflows/mobile-ota-backport.yml
@@ -144,7 +144,11 @@ jobs:
             scripts/lib/mobile-publish-retry.ts \
             scripts/mobile-upload-sourcemaps.ts
           do
-            git show "$GITHUB_SHA:$source_path" > "$tooling_root/$source_path"
+            echo "Snapshotting trusted OTA tooling: $source_path"
+            if ! git show "$GITHUB_SHA:$source_path" > "$tooling_root/$source_path"; then
+              echo "::error::Could not snapshot trusted OTA tooling file '$source_path' from $GITHUB_SHA."
+              exit 1
+            fi
           done
 
       - name: Locate the release anchor and prepare the hotfix tree

--- a/.github/workflows/mobile-ota-preview.yml
+++ b/.github/workflows/mobile-ota-preview.yml
@@ -406,6 +406,12 @@ jobs:
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
         run: vp run mobile:publish -- --channel "$CHANNEL" --platform android
 
+      # mobile:publish generates external source maps in dist for every
+      # self-hosted export, but PR-author code runs in this secret-bearing job.
+      # Intentionally do not provide SENTRY_AUTH_TOKEN or upload those maps. The
+      # next platform publish replaces dist, and the runner discards the final
+      # preview export when the job ends.
+
   # ── Map pr-<number> → its same-named branch on the self-hosted server. Channel
   # creation/mapping is a dashboard-admin action the eoo_ publish key CANNOT perform — so it
   # logs in with OTA_ADMIN_* (ota-preview-unattended environment, no reviewers). This is

--- a/.github/workflows/mobile-ota-preview.yml
+++ b/.github/workflows/mobile-ota-preview.yml
@@ -406,11 +406,9 @@ jobs:
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
         run: vp run mobile:publish -- --channel "$CHANNEL" --platform android
 
-      # mobile:publish generates external source maps in dist for every
-      # self-hosted export, but PR-author code runs in this secret-bearing job.
-      # Intentionally do not provide SENTRY_AUTH_TOKEN or upload those maps. The
-      # next platform publish replaces dist, and the runner discards the final
-      # preview export when the job ends.
+      # Only the production channel asks mobile:publish to retain external maps
+      # in dist. PR previews use pr-N channels, so they neither keep nor upload
+      # source maps; never provide SENTRY_AUTH_TOKEN to this PR-author-code job.
 
   # ── Map pr-<number> → its same-named branch on the self-hosted server. Channel
   # creation/mapping is a dashboard-admin action the eoo_ publish key CANNOT perform — so it

--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -273,6 +273,7 @@ jobs:
         id: upload_sourcemaps_ios
         if: steps.publish_ios.outcome == 'success'
         continue-on-error: true
+        timeout-minutes: 10
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: vp run mobile:upload-sourcemaps -- --platform ios
@@ -297,6 +298,7 @@ jobs:
         id: upload_sourcemaps_android
         if: steps.publish_android.outcome == 'success'
         continue-on-error: true
+        timeout-minutes: 10
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: vp run mobile:upload-sourcemaps -- --platform android

--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -502,13 +502,12 @@ jobs:
 
       # Source-map upload is deliberately non-atomic with OTA publish: by the time
       # Sentry accepts the Debug ID, the update is already live. Surface that exact
-      # degraded state before the terminal gate turns the workflow red.
+      # degraded state in the Actions log before the terminal gate turns the run
+      # red. The one Discord failure notification below includes both publish and
+      # source-map outcomes, avoiding a second alert for this same failure.
       - name: Warn that published OTA source maps are missing
         if: always() && (steps.upload_sourcemaps_ios.outcome == 'failure' || steps.upload_sourcemaps_android.outcome == 'failure')
         env:
-          DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          COMMIT_SHA: ${{ github.sha }}
           IOS_MAP_OUTCOME: ${{ steps.upload_sourcemaps_ios.outcome }}
           ANDROID_MAP_OUTCOME: ${{ steps.upload_sourcemaps_android.outcome }}
         run: |
@@ -516,15 +515,6 @@ jobs:
           [ "$IOS_MAP_OUTCOME" = "failure" ] && platforms="iOS"
           [ "$ANDROID_MAP_OUTCOME" = "failure" ] && platforms="${platforms:+$platforms, }Android"
           echo "::warning::The $platforms OTA is live, but its Sentry source-map upload failed. Recreate the exact platform export before another eoas publish replaces dist."
-          if [ -z "$DISCORD_DEPLOY_WEBHOOK" ]; then
-            echo "DISCORD_DEPLOY_WEBHOOK not set — skipping source-map warning notification"
-            exit 0
-          fi
-          CONTENT=$(printf '⚠️ **Production OTA source maps missing** on `%s`\n• platforms: %s\n• the OTA is live; affected JS crashes may remain minified\n<%s>' \
-            "${COMMIT_SHA:0:7}" "$platforms" "$RUN_URL")
-          jq -n --arg content "$CONTENT" '{content: $content, allowed_mentions: {parse: []}}' \
-            | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
-              echo "::warning::Failed to post Discord source-map warning (see status above)"
 
       - name: Require every published OTA source-map upload
         if: always() && (steps.upload_sourcemaps_ios.outcome == 'failure' || steps.upload_sourcemaps_android.outcome == 'failure')
@@ -540,13 +530,15 @@ jobs:
           COMMIT_SHA: ${{ github.sha }}
           IOS_OUTCOME: ${{ steps.publish_ios.outcome }}
           ANDROID_OUTCOME: ${{ steps.publish_android.outcome }}
+          IOS_MAP_OUTCOME: ${{ steps.upload_sourcemaps_ios.outcome }}
+          ANDROID_MAP_OUTCOME: ${{ steps.upload_sourcemaps_android.outcome }}
         run: |
           if [ -z "$DISCORD_DEPLOY_WEBHOOK" ]; then
             echo "DISCORD_DEPLOY_WEBHOOK not set — skipping notification"
             exit 0
           fi
-          CONTENT=$(printf '🚨 **Production OTA workflow failed** on `%s`\n• iOS: %s\n• Android: %s\n• Any successful platform remains published; no automatic rollback was attempted.\n<%s>' \
-            "${COMMIT_SHA:0:7}" "$IOS_OUTCOME" "$ANDROID_OUTCOME" "$RUN_URL")
+          CONTENT=$(printf '🚨 **Production OTA workflow failed** on `%s`\n• iOS publish: %s · source maps: %s\n• Android publish: %s · source maps: %s\n• Any successful platform remains published; no automatic rollback was attempted.\n<%s>' \
+            "${COMMIT_SHA:0:7}" "$IOS_OUTCOME" "$IOS_MAP_OUTCOME" "$ANDROID_OUTCOME" "$ANDROID_MAP_OUTCOME" "$RUN_URL")
           jq -n --arg content "$CONTENT" '{content: $content, allowed_mentions: {parse: []}}' \
             | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
               echo "::warning::Failed to post Discord notification (see status above)"

--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -264,6 +264,19 @@ jobs:
           if [ -n "$INPUT_MESSAGE" ]; then args+=(--message "$INPUT_MESSAGE"); fi
           vp run mobile:publish -- "${args[@]}"
 
+      # eoas leaves this platform's export in packages/mobile/dist. Upload it
+      # before the Android publish, which cleans/replaces dist. Keep this
+      # non-blocking here so Android, changelog, publish notification, and health
+      # reporting still complete; the explicit terminal gate below turns the run
+      # red after those operational steps.
+      - name: Upload iOS OTA source maps to Sentry
+        id: upload_sourcemaps_ios
+        if: steps.publish_ios.outcome == 'success'
+        continue-on-error: true
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: vp run mobile:upload-sourcemaps -- --platform ios
+
       - name: Publish Android OTA
         id: publish_android
         if: always() && steps.gate.outputs.configured == 'true' && steps.generate.outcome == 'success' && (env.INPUT_PLATFORM == 'all' || env.INPUT_PLATFORM == 'android')
@@ -279,6 +292,14 @@ jobs:
           args=(--channel production --platform android)
           if [ -n "$INPUT_MESSAGE" ]; then args+=(--message "$INPUT_MESSAGE"); fi
           vp run mobile:publish -- "${args[@]}"
+
+      - name: Upload Android OTA source maps to Sentry
+        id: upload_sourcemaps_android
+        if: steps.publish_android.outcome == 'success'
+        continue-on-error: true
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: vp run mobile:upload-sourcemaps -- --platform android
 
       # Publish both requested platforms before deciding the job result. This
       # makes a partial release explicit without trying to roll back the platform
@@ -419,25 +440,6 @@ jobs:
             | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
               echo "::warning::Failed to post Discord notification (see status above)"
 
-      - name: Notify deployments channel of failure
-        if: always() && github.ref == 'refs/heads/main' && failure()
-        env:
-          DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          COMMIT_SHA: ${{ github.sha }}
-          IOS_OUTCOME: ${{ steps.publish_ios.outcome }}
-          ANDROID_OUTCOME: ${{ steps.publish_android.outcome }}
-        run: |
-          if [ -z "$DISCORD_DEPLOY_WEBHOOK" ]; then
-            echo "DISCORD_DEPLOY_WEBHOOK not set — skipping notification"
-            exit 0
-          fi
-          CONTENT=$(printf '🚨 **Production OTA publish failed** on `%s`\n• iOS: %s\n• Android: %s\n• Any successful platform remains published; no automatic rollback was attempted.\n<%s>' \
-            "${COMMIT_SHA:0:7}" "$IOS_OUTCOME" "$ANDROID_OUTCOME" "$RUN_URL")
-          jq -n --arg content "$CONTENT" '{content: $content, allowed_mentions: {parse: []}}' \
-            | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
-              echo "::warning::Failed to post Discord notification (see status above)"
-
       # Post-publish OTA health gate — NON-BLOCKING. Production OTAs publish to our
       # self-hosted server (not EAS), so `eas update:insights` can't see them.
       # Instead we read the app's own launch telemetry from PostHog
@@ -494,6 +496,57 @@ jobs:
           HEADER='🩺 **Production OTA health**'
           [ "$HEALTH_OUTCOME" = "failure" ] && HEADER='🚨 **Production OTA health — emergency-launch spike**'
           CONTENT=$(printf '%s\n%s\n<%s>' "$HEADER" "$(cat "$SUMMARY_FILE")" "$RUN_URL")
+          jq -n --arg content "$CONTENT" '{content: $content, allowed_mentions: {parse: []}}' \
+            | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
+              echo "::warning::Failed to post Discord notification (see status above)"
+
+      # Source-map upload is deliberately non-atomic with OTA publish: by the time
+      # Sentry accepts the Debug ID, the update is already live. Surface that exact
+      # degraded state before the terminal gate turns the workflow red.
+      - name: Warn that published OTA source maps are missing
+        if: always() && (steps.upload_sourcemaps_ios.outcome == 'failure' || steps.upload_sourcemaps_android.outcome == 'failure')
+        env:
+          DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+          IOS_MAP_OUTCOME: ${{ steps.upload_sourcemaps_ios.outcome }}
+          ANDROID_MAP_OUTCOME: ${{ steps.upload_sourcemaps_android.outcome }}
+        run: |
+          platforms=""
+          [ "$IOS_MAP_OUTCOME" = "failure" ] && platforms="iOS"
+          [ "$ANDROID_MAP_OUTCOME" = "failure" ] && platforms="${platforms:+$platforms, }Android"
+          echo "::warning::The $platforms OTA is live, but its Sentry source-map upload failed. Recreate the exact platform export before another eoas publish replaces dist."
+          if [ -z "$DISCORD_DEPLOY_WEBHOOK" ]; then
+            echo "DISCORD_DEPLOY_WEBHOOK not set — skipping source-map warning notification"
+            exit 0
+          fi
+          CONTENT=$(printf '⚠️ **Production OTA source maps missing** on `%s`\n• platforms: %s\n• the OTA is live; affected JS crashes may remain minified\n<%s>' \
+            "${COMMIT_SHA:0:7}" "$platforms" "$RUN_URL")
+          jq -n --arg content "$CONTENT" '{content: $content, allowed_mentions: {parse: []}}' \
+            | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
+              echo "::warning::Failed to post Discord source-map warning (see status above)"
+
+      - name: Require every published OTA source-map upload
+        if: always() && (steps.upload_sourcemaps_ios.outcome == 'failure' || steps.upload_sourcemaps_android.outcome == 'failure')
+        run: |
+          echo "::error::At least one published OTA has no accepted Sentry source maps."
+          exit 1
+
+      - name: Notify deployments channel of failure
+        if: always() && github.ref == 'refs/heads/main' && failure()
+        env:
+          DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+          IOS_OUTCOME: ${{ steps.publish_ios.outcome }}
+          ANDROID_OUTCOME: ${{ steps.publish_android.outcome }}
+        run: |
+          if [ -z "$DISCORD_DEPLOY_WEBHOOK" ]; then
+            echo "DISCORD_DEPLOY_WEBHOOK not set — skipping notification"
+            exit 0
+          fi
+          CONTENT=$(printf '🚨 **Production OTA workflow failed** on `%s`\n• iOS: %s\n• Android: %s\n• Any successful platform remains published; no automatic rollback was attempted.\n<%s>' \
+            "${COMMIT_SHA:0:7}" "$IOS_OUTCOME" "$ANDROID_OUTCOME" "$RUN_URL")
           jq -n --arg content "$CONTENT" '{content: $content, allowed_mentions: {parse: []}}' \
             | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
               echo "::warning::Failed to post Discord notification (see status above)"

--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -508,18 +508,20 @@ jobs:
       # red. The one Discord failure notification below includes both publish and
       # source-map outcomes, avoiding a second alert for this same failure.
       - name: Warn that published OTA source maps are missing
-        if: always() && (steps.upload_sourcemaps_ios.outcome == 'failure' || steps.upload_sourcemaps_android.outcome == 'failure')
+        if: always() && ((steps.publish_ios.outcome == 'success' && steps.upload_sourcemaps_ios.outcome != 'success') || (steps.publish_android.outcome == 'success' && steps.upload_sourcemaps_android.outcome != 'success'))
         env:
+          IOS_PUBLISH_OUTCOME: ${{ steps.publish_ios.outcome }}
+          ANDROID_PUBLISH_OUTCOME: ${{ steps.publish_android.outcome }}
           IOS_MAP_OUTCOME: ${{ steps.upload_sourcemaps_ios.outcome }}
           ANDROID_MAP_OUTCOME: ${{ steps.upload_sourcemaps_android.outcome }}
         run: |
           platforms=""
-          [ "$IOS_MAP_OUTCOME" = "failure" ] && platforms="iOS"
-          [ "$ANDROID_MAP_OUTCOME" = "failure" ] && platforms="${platforms:+$platforms, }Android"
-          echo "::warning::The $platforms OTA is live, but its Sentry source-map upload failed. Recreate the exact platform export before another eoas publish replaces dist."
+          [ "$IOS_PUBLISH_OUTCOME" = "success" ] && [ "$IOS_MAP_OUTCOME" != "success" ] && platforms="iOS"
+          [ "$ANDROID_PUBLISH_OUTCOME" = "success" ] && [ "$ANDROID_MAP_OUTCOME" != "success" ] && platforms="${platforms:+$platforms, }Android"
+          echo "::warning::The $platforms OTA is live, but its Sentry source-map upload did not succeed. Recreate the exact platform export before another eoas publish replaces dist."
 
       - name: Require every published OTA source-map upload
-        if: always() && (steps.upload_sourcemaps_ios.outcome == 'failure' || steps.upload_sourcemaps_android.outcome == 'failure')
+        if: always() && ((steps.publish_ios.outcome == 'success' && steps.upload_sourcemaps_ios.outcome != 'success') || (steps.publish_android.outcome == 'success' && steps.upload_sourcemaps_android.outcome != 'success'))
         run: |
           echo "::error::At least one published OTA has no accepted Sentry source maps."
           exit 1

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -145,23 +145,20 @@ SENTRY_AUTH_TOKEN=sntrys_… \
 
 The wrapper translates its `--channel production` selector to `eoas publish --branch production`.
 It deliberately does not pass eoas's deprecated `--channel` option; channel creation and mapping are
-control-plane operations described below. The publish does an `expo export` and uploads the bundle
-to our storage via the server. `eoas` reads the server URL from `updates.url` in
-`app.config.ts`, so `EXPO_UPDATES_URL` must be present. **Auth is `EOO_TOKEN`, not an Expo token:**
+control-plane operations described below. The production publish runs
+`eoas publish --branch production --dumpSourcemap --outputDir dist`, which exports the bundle plus
+its external map and uploads the OTA bundle to our storage via the server. `eoas` reads the server
+URL from `updates.url` in `app.config.ts`, so `EXPO_UPDATES_URL` must be present.
+**Auth is `EOO_TOKEN`, not an Expo token:** the V3 control-plane server rejects Expo tokens, so
+publish/rollback need an app-scoped `eoo_` key minted in the dashboard. The CLI is pinned to
+**`eoas@3.0.5`** via `EOAS_PACKAGE_SPEC` in `scripts/lib/eoas.ts` — it must match the deployed server
+version exactly (V3 routes are app-scoped; a `v2` CLI 404s). Bump the server image and the pin in
+lockstep.
 
 For Android, use `--platform android` on both commands and provide the same
 `GOOGLE_MAPS_API_KEY` used by the Android native build while publishing. Do not use `--platform all`:
 each `eoas publish` removes and recreates `packages/mobile/dist`, so the second platform would erase
 the first platform's source maps before they reached Sentry.
-
-The publish runs `eoas publish --branch production --dumpSourcemap --outputDir dist`, which exports
-the bundle plus its external map and uploads the OTA bundle to our storage via the server. `eoas`
-reads the server URL from `updates.url` in `app.config.ts`, so `EXPO_UPDATES_URL` must be present.
-**Auth is `EOO_TOKEN`, not an Expo token:**
-the V3 control-plane server rejects Expo tokens, so publish/rollback need an app-scoped `eoo_` key
-minted in the dashboard. The CLI is pinned to **`eoas@3.0.5`** via `EOAS_PACKAGE_SPEC` in
-`scripts/lib/eoas.ts` — it must match the deployed server version exactly (V3 routes are
-app-scoped; a `v2` CLI 404s). Bump the server image and the pin in lockstep.
 
 **Transient upload failures** are retried only when eoas output contains the exact S3 SlowDown XML
 response or an explicit HTTP 5xx status. Each platform gets at most four attempts, with 30, 60, and
@@ -446,8 +443,9 @@ Confirm the Android release actually shipped before relying on an Android backpo
    sees a clean tree. It then verifies the resolved fingerprint's 12-char prefix equals the anchor's
    `<shortfp>`. A mismatch means the cherry-pick or tooling changed native inputs — it aborts,
    because an OTA would resolve a fingerprint no shipped binary has and silently never land. Anchors
-   without the audited `@sentry/react-native` 7.11 uploader also abort; changing that dependency
-   would change the approved native fingerprint.
+   without the audited `@sentry/react-native` 7.11 uploader also abort. Do not change that
+   dependency on the frozen anchor: ship a native update with a supported uploader, wait for its
+   approved release anchor, and backport against that new anchor instead.
 4. Re-run with `dry_run` off to publish under the approved fingerprint and immediately upload that
    platform's Debug ID source map. It shares the `mobile-ota-production` concurrency lane, limits
    the platform matrix to one publish at a time, and never races a `main` OTA or bursts iOS and

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -50,12 +50,12 @@ Postgres and left V2 untouched. Two servers now run in parallel:
 
 ## Two hosting paths (don't mix them up)
 
-|                | Preview / dev                            | Production                                                                                                                       |
-| -------------- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| Built by       | `eas build` (`mobile:preview-build`)     | bare `expo prebuild` + xcodebuild/gradle (the `ios-testflight-rn` / `android-apk-rn` workflows)                                  |
-| Hosting        | EAS free tier (`u.expo.dev`)             | self-hosted expo-open-ota V3 (`updates.boardsesh.com`)                                                                           |
-| Channel source | `channel` in `eas.json`                  | `expo-channel-name` request header baked in by `expo prebuild`                                                                   |
-| Publish        | `vp run mobile:publish` (→ `eas update`) | auto on push to `main` (`mobile-ota-production.yml`); manual: `vp run mobile:publish -- --channel production` (→ `eoas publish`) |
+|                | Preview / dev                            | Production                                                                                                                                                                      |
+| -------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Built by       | `eas build` (`mobile:preview-build`)     | bare `expo prebuild` + xcodebuild/gradle (the `ios-testflight-rn` / `android-apk-rn` workflows)                                                                                 |
+| Hosting        | EAS free tier (`u.expo.dev`)             | self-hosted expo-open-ota V3 (`updates.boardsesh.com`)                                                                                                                          |
+| Channel source | `channel` in `eas.json`                  | `expo-channel-name` request header baked in by `expo prebuild`                                                                                                                  |
+| Publish        | `vp run mobile:publish` (→ `eas update`) | auto on push to `main` (`mobile-ota-production.yml`); manual: publish one platform, then immediately run `mobile:upload-sourcemaps` (→ `eoas publish` + Sentry Debug ID upload) |
 
 A third path rides the **same self-hosted server**: per-PR `pr-<number>` channels that let any user
 validate a specific PR on a store/TestFlight build via the in-app switcher — see
@@ -131,12 +131,16 @@ regenerating it, then `changelog-discord-summary.ts` diffs the two snapshots and
 entries grouped as New / Improved / Fixed. When nothing new shipped (changelog unchanged) it falls
 back to the triggering commit's subject.
 
-**Manual** (one branch, ad hoc) — set the V3 server URL and an app-scoped `EOO_TOKEN`:
+**Manual** (one branch, ad hoc) — publish exactly one platform, then upload that export's source
+maps before running `eoas` again:
 
 ```sh
 EXPO_UPDATES_URL=https://updates.boardsesh.com/manifest \
 EOO_TOKEN=eoo_… \
-  vp run mobile:publish -- --channel production --message "fix: <what>"
+  vp run mobile:publish -- --channel production --platform ios --message "fix: <what>"
+
+SENTRY_AUTH_TOKEN=sntrys_… \
+  vp run mobile:upload-sourcemaps -- --platform ios
 ```
 
 The wrapper translates its `--channel production` selector to `eoas publish --branch production`.
@@ -144,6 +148,16 @@ It deliberately does not pass eoas's deprecated `--channel` option; channel crea
 control-plane operations described below. The publish does an `expo export` and uploads the bundle
 to our storage via the server. `eoas` reads the server URL from `updates.url` in
 `app.config.ts`, so `EXPO_UPDATES_URL` must be present. **Auth is `EOO_TOKEN`, not an Expo token:**
+
+For Android, use `--platform android` on both commands and provide the same
+`GOOGLE_MAPS_API_KEY` used by the Android native build while publishing. Do not use `--platform all`:
+each `eoas publish` removes and recreates `packages/mobile/dist`, so the second platform would erase
+the first platform's source maps before they reached Sentry.
+
+The publish runs `eoas publish --branch production --dumpSourcemap --outputDir dist`, which exports
+the bundle plus its external map and uploads the OTA bundle to our storage via the server. `eoas`
+reads the server URL from `updates.url` in `app.config.ts`, so `EXPO_UPDATES_URL` must be present.
+**Auth is `EOO_TOKEN`, not an Expo token:**
 the V3 control-plane server rejects Expo tokens, so publish/rollback need an app-scoped `eoo_` key
 minted in the dashboard. The CLI is pinned to **`eoas@3.0.5`** via `EOAS_PACKAGE_SPEC` in
 `scripts/lib/eoas.ts` — it must match the deployed server version exactly (V3 routes are
@@ -161,6 +175,30 @@ iOS fails. The run fails unless every requested platform succeeds, but it does n
 roll back a platform that already published. A single eoas invocation can still upload some objects
 before its server-row write fails; making that internal PUT/database operation atomic requires an
 upstream expo-open-ota change.
+
+### OTA source maps and Sentry
+
+Production and approved-release backport workflows publish and upload in this order: iOS OTA → iOS
+maps → Android OTA → Android maps. The wrapper derives executable bundles from the requested
+platform in `dist/metadata.json` (the primary bundle plus declared DOM component JavaScript), then
+validates each bundle/map pair and map Debug ID. Public-folder JavaScript is not update executable
+metadata and is ignored. Only validated pairs are staged for the official `@sentry/react-native`
+7.11 Expo uploader, whose recursive scan cannot see other files in `dist`. Sentry matches the running
+OTA bundle to its map by Debug ID. It deliberately receives no synthetic release or dist, so the
+SDK's native release/dist continue to describe the installed store binary.
+
+Expo 57 declares DOM component JavaScript under `www.bundle`, but independently content-hashes its
+map filename. Sentry 7.11 can only group an exact adjacent `<bundle>.map`, so the wrapper rejects
+such an export with an actionable error instead of silently omitting executable code. Boardsesh does
+not currently use Expo DOM components; add an audited pairing/upload path before introducing one.
+
+Publishing and source-map acceptance are **not atomic**. The OTA can already be live when Sentry
+rejects its map. CI therefore lets changelog, deployment notice, and health reporting finish, warns
+that crash frames may remain minified, and then fails the workflow. For a manual retry, return to the
+exact same commit/tree, platform, and build environment that produced the live OTA, rerun that one
+platform's publish to regenerate `dist`, and immediately run `mobile:upload-sourcemaps` before any
+other `eoas publish`. A newer tree or different environment can produce a different Debug ID and
+cannot repair the already-published artifact.
 
 **Progressive rollouts** are a control-plane feature: `eoas publish --branch production
 --rollout-percentage N` ships to only `N%` of the channel's installs. Finish or revert
@@ -403,14 +441,17 @@ Confirm the Android release actually shipped before relying on an Android backpo
 2. Run the **Mobile OTA Backport** workflow (`mobile-ota-backport.yml`, `workflow_dispatch`) with the
    approved `version` (e.g. `2.1.0`), the `platform` (`all`/`ios`/`android`), and the fix commit
    SHA(s). Leave `dry_run` on for the first pass.
-3. It checks out `release/<platform>-v<version>-<shortfp>`, cherry-picks the fix, and **verifies the
-   resolved fingerprint's 12-char prefix equals the anchor's `<shortfp>`**. A mismatch means the
-   cherry-pick touched native inputs — it aborts, because an OTA would resolve a fingerprint no
-   shipped binary has and silently never land. Ship such a fix as a new native build instead.
-4. Re-run with `dry_run` off. The wrapper targets the `production` branch under the approved
-   fingerprint, reaching that release's installs. It shares the `mobile-ota-production` concurrency
-   lane and limits the platform matrix to one publish at a time, so it never races a `main` OTA or
-   bursts iOS and Android uploads concurrently.
+3. It checks out `release/<platform>-v<version>-<shortfp>`, cherry-picks the fix, overlays the exact
+   workflow commit's dependency-light publish/source-map tooling, and commits that overlay so `eoas`
+   sees a clean tree. It then verifies the resolved fingerprint's 12-char prefix equals the anchor's
+   `<shortfp>`. A mismatch means the cherry-pick or tooling changed native inputs — it aborts,
+   because an OTA would resolve a fingerprint no shipped binary has and silently never land. Anchors
+   without the audited `@sentry/react-native` 7.11 uploader also abort; changing that dependency
+   would change the approved native fingerprint.
+4. Re-run with `dry_run` off to publish under the approved fingerprint and immediately upload that
+   platform's Debug ID source map. It shares the `mobile-ota-production` concurrency lane, limits
+   the platform matrix to one publish at a time, and never races a `main` OTA or bursts iOS and
+   Android uploads concurrently. A dry run neither publishes nor uploads.
 
 To find the anchor for a release: `git tag -l 'release/ios-v2.1.0-*'`.
 
@@ -736,8 +777,13 @@ EXPO_UPDATES_URL=https://example.test/manifest EXPO_UPDATES_CHANNEL=production b
 3. Ship one native TestFlight build from `main` (bakes in the fingerprint runtimeVersion + server
    URL + cert). Existing `appVersion`-era installs won't receive fingerprint OTAs — they update
    from the store once.
-4. Make a trivial JS change, push to `main` (or `vp run mobile:publish -- --channel production`),
-   relaunch the TestFlight app, and confirm the OTA downloads and applies.
+4. Make a trivial JS change, push to `main` (or publish and upload one platform with the manual
+   commands above), relaunch the TestFlight/internal-track app, and confirm the OTA downloads and
+   applies.
+5. On one TestFlight iOS install and one internal/store Android install running the new OTA, use the
+   tester crash tool to send a JavaScript error. Confirm both events resolve to
+   `packages/mobile/src/...` source lines, their Debug IDs match the uploaded OTA maps, and the
+   events' native release/dist still identify the installed store binaries rather than the OTA.
 
 ## In-app channel switcher ("Try a preview", production builds)
 
@@ -824,6 +870,10 @@ above — no per-tester build. Workflow: `.github/workflows/mobile-ota-preview.y
   [Channel↔branch mapping](#channelbranch-mapping-control-plane)). The channel name and the baked
   header are independent: the baked `expo-channel-name=production` drives the fingerprint, `pr-<number>`
   drives where the bundle lands and what the switcher selects.
+- **Source maps stay local to the runner.** The shared publisher generates external maps for these
+  exports, but the preview workflow intentionally has no `SENTRY_AUTH_TOKEN` and never uploads them.
+  It runs PR-authored code, so granting a Sentry upload credential would cross the preview security
+  boundary. The next platform publish replaces `dist`; the runner discards the final copy.
 - **Fingerprint parity.** A native-change PR resolves a new fingerprint no shipped binary has, so
   that platform is **skipped** — `vp run check:mobile-ota-compat` (the same engine as
   `mobile-ota-check.yml`) gates each platform, and the PR comment says so. The env is held

--- a/scripts/mobile-ota-publish-workflow.test.ts
+++ b/scripts/mobile-ota-publish-workflow.test.ts
@@ -115,4 +115,13 @@ describe('backport OTA workflow upload pressure', () => {
     const timeout = Number(jobBlock(backport, 'backport').match(/timeout-minutes: (\d+)/)?.[1]);
     expect(timeout).toBeGreaterThanOrEqual(45);
   });
+
+  it('overlays the retry implementation required by the trusted publish wrapper', () => {
+    const snapshot = stepBlock(backport, 'Snapshot trusted OTA publish tooling');
+    const overlay = stepBlock(backport, 'Overlay trusted OTA publish tooling');
+
+    expect(snapshot).toContain('scripts/lib/mobile-publish-retry.ts');
+    expect(overlay).toContain('scripts/lib/mobile-publish-retry.ts');
+    expect(overlay).toMatch(/git add .*scripts\/lib\/mobile-publish-retry\.ts/);
+  });
 });

--- a/scripts/mobile-ota-publish-workflow.test.ts
+++ b/scripts/mobile-ota-publish-workflow.test.ts
@@ -121,7 +121,12 @@ describe('backport OTA workflow upload pressure', () => {
     const overlay = stepBlock(backport, 'Overlay trusted OTA publish tooling');
     const gitAddLine = overlay.split('\n').find((line) => line.trimStart().startsWith('git add '));
 
-    for (const implementationPath of ['scripts/lib/mobile-publish-retry.ts', 'scripts/mobile-upload-sourcemaps.ts']) {
+    for (const implementationPath of [
+      'scripts/mobile-publish.ts',
+      'scripts/lib/eoas.ts',
+      'scripts/lib/mobile-publish-retry.ts',
+      'scripts/mobile-upload-sourcemaps.ts',
+    ]) {
       expect(snapshot).toContain(implementationPath);
       expect(overlay).toContain(implementationPath);
       expect(gitAddLine).toContain(implementationPath);

--- a/scripts/mobile-ota-publish-workflow.test.ts
+++ b/scripts/mobile-ota-publish-workflow.test.ts
@@ -116,12 +116,15 @@ describe('backport OTA workflow upload pressure', () => {
     expect(timeout).toBeGreaterThanOrEqual(45);
   });
 
-  it('overlays the retry implementation required by the trusted publish wrapper', () => {
+  it('overlays every trusted helper required by production publish and source-map upload', () => {
     const snapshot = stepBlock(backport, 'Snapshot trusted OTA publish tooling');
     const overlay = stepBlock(backport, 'Overlay trusted OTA publish tooling');
+    const gitAddLine = overlay.split('\n').find((line) => line.trimStart().startsWith('git add '));
 
-    expect(snapshot).toContain('scripts/lib/mobile-publish-retry.ts');
-    expect(overlay).toContain('scripts/lib/mobile-publish-retry.ts');
-    expect(overlay).toMatch(/git add .*scripts\/lib\/mobile-publish-retry\.ts/);
+    for (const implementationPath of ['scripts/lib/mobile-publish-retry.ts', 'scripts/mobile-upload-sourcemaps.ts']) {
+      expect(snapshot).toContain(implementationPath);
+      expect(overlay).toContain(implementationPath);
+      expect(gitAddLine).toContain(implementationPath);
+    }
   });
 });

--- a/scripts/mobile-publish.test.ts
+++ b/scripts/mobile-publish.test.ts
@@ -1,18 +1,30 @@
 /// <reference types="node" />
 
 import { describe, expect, it } from 'vitest';
+import { EOAS_PACKAGE_SPEC } from './lib/eoas';
 import { buildEasUpdateArgs, buildSelfHostedEoasArgs, parseArgs, requestedSelfHostedPlatforms } from './mobile-publish';
 
 describe('mobile publish argument routing', () => {
   it('maps the wrapper channel selector to an eoas branch without a deprecated channel flag', () => {
     const args = buildSelfHostedEoasArgs('production', 'ios', 'fix the queue');
 
-    expect(args).toContain('--branch');
-    expect(args[args.indexOf('--branch') + 1]).toBe('production');
+    expect(args).toEqual([
+      EOAS_PACKAGE_SPEC,
+      'publish',
+      '--branch',
+      'production',
+      '--platform',
+      'ios',
+      '--message',
+      'fix the queue',
+      '--dumpSourcemap',
+      '--outputDir',
+      'dist',
+      '--nonInteractive',
+      '--packageRunner',
+      'bunx',
+    ]);
     expect(args).not.toContain('--channel');
-    expect(args[args.indexOf('--platform') + 1]).toBe('ios');
-    expect(args).toContain('--nonInteractive');
-    expect(args[args.indexOf('--packageRunner') + 1]).toBe('bunx');
   });
 
   it('keeps the EAS preview command arguments unchanged', () => {

--- a/scripts/mobile-publish.ts
+++ b/scripts/mobile-publish.ts
@@ -88,6 +88,12 @@ export function buildSelfHostedEoasArgs(
     platform,
     '--message',
     updateMessage,
+    // Keep the exact Expo export that eoas uploads on disk with external source
+    // maps. The platform-specific workflow uploads this directory to Sentry
+    // immediately; the next eoas publish removes/replaces `dist`.
+    '--dumpSourcemap',
+    '--outputDir',
+    'dist',
     '--nonInteractive',
     // The repo uses bun; force bunx so eoas spawns `bunx expo export` regardless
     // of the nearest package.json's packageManager field.

--- a/scripts/mobile-publish.ts
+++ b/scripts/mobile-publish.ts
@@ -79,6 +79,17 @@ export function buildSelfHostedEoasArgs(
   platform: OtaPublishPlatform,
   updateMessage: string,
 ): string[] {
+  const sourceMapArgs =
+    channelName === 'production'
+      ? [
+          // Keep the exact production export that eoas uploads on disk with
+          // external source maps. The platform-specific workflow uploads this
+          // directory to Sentry immediately; the next publish replaces `dist`.
+          '--dumpSourcemap',
+          '--outputDir',
+          'dist',
+        ]
+      : [];
   return [
     EOAS_PACKAGE_SPEC,
     'publish',
@@ -88,12 +99,7 @@ export function buildSelfHostedEoasArgs(
     platform,
     '--message',
     updateMessage,
-    // Keep the exact Expo export that eoas uploads on disk with external source
-    // maps. The platform-specific workflow uploads this directory to Sentry
-    // immediately; the next eoas publish removes/replaces `dist`.
-    '--dumpSourcemap',
-    '--outputDir',
-    'dist',
+    ...sourceMapArgs,
     '--nonInteractive',
     // The repo uses bun; force bunx so eoas spawns `bunx expo export` regardless
     // of the nearest package.json's packageManager field.

--- a/scripts/mobile-sourcemaps.test.ts
+++ b/scripts/mobile-sourcemaps.test.ts
@@ -629,14 +629,17 @@ describe('source-map CLI arguments', () => {
 });
 
 describe('self-hosted OTA publisher and workflow contracts', () => {
-  it('always retains EOAS source maps in dist without changing the EAS preview path', () => {
-    const selfHostedArgs = buildSelfHostedEoasArgs('production', 'ios', 'source-map contract');
+  it('retains production EOAS source maps without adding export work to either preview path', () => {
+    const productionArgs = buildSelfHostedEoasArgs('production', 'ios', 'source-map contract');
+    const selfHostedPreviewArgs = buildSelfHostedEoasArgs('pr-4134', 'ios', 'preview contract');
     const easArgs = buildEasUpdateArgs('preview', 'preview contract', 'ios');
 
-    expect(selfHostedArgs.filter((argument) => argument === '--dumpSourcemap')).toEqual(['--dumpSourcemap']);
+    expect(productionArgs.filter((argument) => argument === '--dumpSourcemap')).toEqual(['--dumpSourcemap']);
     expect(
-      selfHostedArgs.slice(selfHostedArgs.indexOf('--outputDir'), selfHostedArgs.indexOf('--outputDir') + 2),
+      productionArgs.slice(productionArgs.indexOf('--outputDir'), productionArgs.indexOf('--outputDir') + 2),
     ).toEqual(['--outputDir', 'dist']);
+    expect(selfHostedPreviewArgs).not.toContain('--dumpSourcemap');
+    expect(selfHostedPreviewArgs).not.toContain('--outputDir');
     expect(easArgs).not.toContain('--dumpSourcemap');
     expect(easArgs).not.toContain('--outputDir');
   });
@@ -663,6 +666,7 @@ describe('self-hosted OTA publisher and workflow contracts', () => {
     for (const stepName of ['Upload iOS OTA source maps to Sentry', 'Upload Android OTA source maps to Sentry']) {
       const step = workflowStep(workflow, stepName);
       expect(step).toContain('continue-on-error: true');
+      expect(step).toContain('timeout-minutes: 10');
       expect(step).toMatch(/^\s+SENTRY_AUTH_TOKEN:\s*\$\{\{ secrets\.SENTRY_AUTH_TOKEN \}\}$/m);
       expect(step).toContain('vp run mobile:upload-sourcemaps');
     }

--- a/scripts/mobile-sourcemaps.test.ts
+++ b/scripts/mobile-sourcemaps.test.ts
@@ -557,8 +557,9 @@ describe('official Sentry uploader invocation', () => {
           stagedFiles: string[];
         }
       | undefined;
+    let invocationCount = 0;
 
-    uploadMobileSourceMaps(
+    const validatedArtifacts = uploadMobileSourceMaps(
       {
         platform: 'android',
         mobileDir: fixture.mobileDir,
@@ -572,6 +573,7 @@ describe('official Sentry uploader invocation', () => {
       {
         resolveUploader: () => fakeUploaderPath,
         spawnUploader: (executable, args, options) => {
+          invocationCount += 1;
           invocation = {
             executable,
             args,
@@ -586,6 +588,11 @@ describe('official Sentry uploader invocation', () => {
       },
     );
 
+    // The official uploader accepts one staging directory. One invocation must
+    // therefore contain every pair validation accepted, rather than silently
+    // dropping a pair or launching a partially independent upload.
+    expect(invocationCount).toBe(1);
+    expect(validatedArtifacts).toHaveLength(2);
     expect(invocation).toBeDefined();
     expect(invocation?.executable).toBe('node');
     expect(invocation?.args[0]).toBe(fakeUploaderPath);
@@ -669,6 +676,13 @@ describe('self-hosted OTA publisher and workflow contracts', () => {
     const failureNotification = workflowStep(workflow, 'Notify deployments channel of failure');
     expect(failureNotification).toContain('Production OTA workflow failed');
     expect(failureNotification).not.toContain('Production OTA publish failed');
+    expect(failureNotification).toContain('IOS_MAP_OUTCOME: ${{ steps.upload_sourcemaps_ios.outcome }}');
+    expect(failureNotification).toContain('ANDROID_MAP_OUTCOME: ${{ steps.upload_sourcemaps_android.outcome }}');
+    expect(failureNotification).toContain('iOS publish: %s · source maps: %s');
+    expect(failureNotification).toContain('Android publish: %s · source maps: %s');
+    expect(workflowStep(workflow, 'Warn that published OTA source maps are missing')).not.toContain(
+      'DISCORD_DEPLOY_WEBHOOK',
+    );
   });
 
   it('overlays trusted tooling before authoritative backport verification and never uploads on dry-run', () => {
@@ -713,6 +727,9 @@ describe('self-hosted OTA publisher and workflow contracts', () => {
     expect(overlayNamePosition).toBeLessThan(overlayCommitPosition);
     expect(overlayEmailPosition).toBeLessThan(overlayCommitPosition);
     expect(overlayStep).toContain('git status --porcelain');
+    expect(workflowStep(workflow, 'Snapshot trusted OTA publish tooling')).toContain(
+      "Could not snapshot trusted OTA tooling file '$source_path'",
+    );
     expect(workflowStep(workflow, 'Validate anchored Sentry uploader support')).toContain('7.11.0');
 
     const uploadStep = workflowStep(workflow, 'Upload backport OTA source maps to Sentry');

--- a/scripts/mobile-sourcemaps.test.ts
+++ b/scripts/mobile-sourcemaps.test.ts
@@ -418,6 +418,23 @@ describe('official Sentry uploader invocation', () => {
     );
   });
 
+  it('reports missing mobile directories and installed uploader files clearly', () => {
+    const fixture = createMobileFixture();
+    const sentryRoot = join(fixture.mobileDir, 'node_modules', '@sentry', 'react-native');
+    mkdirSync(sentryRoot, { recursive: true });
+    writeFileSync(
+      join(sentryRoot, 'package.json'),
+      JSON.stringify({ name: '@sentry/react-native', version: '7.11.0' }),
+    );
+
+    expect(() => resolveInstalledSentryUploader(join(fixture.mobileDir, 'missing'))).toThrow(
+      'Mobile directory does not exist or is not a directory',
+    );
+    expect(() => resolveInstalledSentryUploader(fixture.mobileDir)).toThrow(
+      'Official Sentry Expo source-map uploader is missing',
+    );
+  });
+
   it('fixes org/project/url and removes release, dist, and CLI overrides', () => {
     const environment = createSentryUploadEnvironment({
       SENTRY_AUTH_TOKEN: ' token ',
@@ -621,6 +638,7 @@ describe('official Sentry uploader invocation', () => {
 describe('source-map CLI arguments', () => {
   it('requires one native platform', () => {
     expect(parseUploadArgs(['--platform', 'ios'])).toBe('ios');
+    expect(parseUploadArgs(['-p', 'ios'])).toBe('ios');
     expect(parseUploadArgs(['--platform=android'])).toBe('android');
     expect(() => parseUploadArgs([])).toThrow('--platform is required');
     expect(() => parseUploadArgs(['--platform', 'all'])).toThrow('--platform is required');

--- a/scripts/mobile-sourcemaps.test.ts
+++ b/scripts/mobile-sourcemaps.test.ts
@@ -473,6 +473,60 @@ describe('official Sentry uploader invocation', () => {
     expect(spawnCalled).toBe(false);
   });
 
+  it('surfaces uploader startup errors and cleans its temporary directories', () => {
+    const fixture = createMobileFixture('ios');
+    let temporaryWorkingDirectory: string | undefined;
+    let stagingDirectory: string | undefined;
+
+    expect(() =>
+      uploadMobileSourceMaps(
+        {
+          platform: 'ios',
+          mobileDir: fixture.mobileDir,
+          outputDir: fixture.outputDir,
+          environment: { SENTRY_AUTH_TOKEN: 'secret-token' },
+        },
+        {
+          resolveUploader: () => join(fixture.mobileDir, 'fake-uploader.js'),
+          spawnUploader: (_executable, args, options) => {
+            temporaryWorkingDirectory = options.cwd;
+            stagingDirectory = args[1];
+            return { status: null, error: new Error('spawn EACCES') };
+          },
+        },
+      ),
+    ).toThrow('Could not start the official Sentry uploader: spawn EACCES');
+    expect(existsSync(temporaryWorkingDirectory ?? '')).toBe(false);
+    expect(existsSync(stagingDirectory ?? '')).toBe(false);
+  });
+
+  it('surfaces nonzero uploader exits and cleans its temporary directories', () => {
+    const fixture = createMobileFixture('android');
+    let temporaryWorkingDirectory: string | undefined;
+    let stagingDirectory: string | undefined;
+
+    expect(() =>
+      uploadMobileSourceMaps(
+        {
+          platform: 'android',
+          mobileDir: fixture.mobileDir,
+          outputDir: fixture.outputDir,
+          environment: { SENTRY_AUTH_TOKEN: 'secret-token' },
+        },
+        {
+          resolveUploader: () => join(fixture.mobileDir, 'fake-uploader.js'),
+          spawnUploader: (_executable, args, options) => {
+            temporaryWorkingDirectory = options.cwd;
+            stagingDirectory = args[1];
+            return { status: 17 };
+          },
+        },
+      ),
+    ).toThrow('Official Sentry uploader failed with exit code 17');
+    expect(existsSync(temporaryWorkingDirectory ?? '')).toBe(false);
+    expect(existsSync(stagingDirectory ?? '')).toBe(false);
+  });
+
   it('stages exactly declared executable groups, uses a fresh cwd, and cleans only its temporary root', () => {
     const fixture = createMobileFixture('android');
     const fakeUploaderPath = join(fixture.mobileDir, 'fake-uploader.js');
@@ -647,6 +701,17 @@ describe('self-hosted OTA publisher and workflow contracts', () => {
     expect(overlayStep).toContain(
       'git add scripts/mobile-publish.ts scripts/lib/eoas.ts scripts/lib/mobile-publish-retry.ts',
     );
+    const overlayCommitGuardPosition = overlayStep.indexOf('if ! git diff --cached --quiet; then');
+    const overlayNamePosition = overlayStep.indexOf('git config user.name "github-actions[bot]"');
+    const overlayEmailPosition = overlayStep.indexOf(
+      'git config user.email "github-actions[bot]@users.noreply.github.com"',
+    );
+    const overlayCommitPosition = overlayStep.indexOf('git commit -m "chore(ota): overlay trusted publish tooling"');
+    expect(overlayCommitGuardPosition).toBeGreaterThanOrEqual(0);
+    expect(overlayNamePosition).toBeGreaterThan(overlayCommitGuardPosition);
+    expect(overlayEmailPosition).toBeGreaterThan(overlayCommitGuardPosition);
+    expect(overlayNamePosition).toBeLessThan(overlayCommitPosition);
+    expect(overlayEmailPosition).toBeLessThan(overlayCommitPosition);
     expect(overlayStep).toContain('git status --porcelain');
     expect(workflowStep(workflow, 'Validate anchored Sentry uploader support')).toContain('7.11.0');
 

--- a/scripts/mobile-sourcemaps.test.ts
+++ b/scripts/mobile-sourcemaps.test.ts
@@ -1,0 +1,668 @@
+/// <reference types="node" />
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildEasUpdateArgs, buildSelfHostedEoasArgs } from './mobile-publish';
+import {
+  createSentryUploadEnvironment,
+  parseUploadArgs,
+  resolveInstalledSentryUploader,
+  uploadMobileSourceMaps,
+  validateSourceMapOutput,
+  type MobilePlatform,
+} from './mobile-upload-sourcemaps';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const VALID_DEBUG_ID = '12345678-1234-4abc-9def-1234567890ab';
+const createdDirectories: string[] = [];
+
+interface MobileFixture {
+  mobileDir: string;
+  outputDir: string;
+  bundlePath: string;
+  sourceMapPath: string;
+  relativeBundlePath: string;
+}
+
+function createMobileFixture(platform: MobilePlatform = 'ios', bundleExtension: 'hbc' | 'js' = 'hbc'): MobileFixture {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'boardsesh-mobile-sourcemaps-test-'));
+  createdDirectories.push(fixtureRoot);
+  const mobileDir = join(fixtureRoot, 'mobile');
+  const outputDir = join(mobileDir, 'dist');
+  const relativeBundlePath = `_expo/static/js/${platform}/entry-test.${bundleExtension}`;
+  const bundlePath = join(outputDir, relativeBundlePath);
+  const sourceMapPath = `${bundlePath}.map`;
+  mkdirSync(dirname(bundlePath), { recursive: true });
+  writeFileSync(join(mobileDir, 'package.json'), '{"name":"fixture"}\n');
+  writeFileSync(bundlePath, 'hermes bytecode');
+  writeFileSync(
+    sourceMapPath,
+    JSON.stringify({ version: 3, sources: ['../../src/example.ts'], mappings: '', debugId: VALID_DEBUG_ID }),
+  );
+  writeFileSync(
+    join(outputDir, 'metadata.json'),
+    JSON.stringify({
+      version: 0,
+      bundler: 'metro',
+      fileMetadata: { [platform]: { bundle: relativeBundlePath, assets: [] } },
+    }),
+  );
+  return { mobileDir, outputDir, bundlePath, sourceMapPath, relativeBundlePath };
+}
+
+function rewriteMetadata(fixture: MobileFixture, fileMetadata: Record<string, unknown>): void {
+  writeFileSync(
+    join(fixture.outputDir, 'metadata.json'),
+    JSON.stringify({ version: 0, bundler: 'metro', fileMetadata }),
+  );
+}
+
+function readRepositoryFile(relativePath: string): string {
+  return readFileSync(resolve(REPO_ROOT, relativePath), 'utf8');
+}
+
+function listRelativeFiles(directoryPath: string, relativeDirectory = ''): string[] {
+  return readdirSync(join(directoryPath, relativeDirectory), { withFileTypes: true }).flatMap((entry) => {
+    const relativePath = join(relativeDirectory, entry.name);
+    return entry.isDirectory() ? listRelativeFiles(directoryPath, relativePath) : [relativePath];
+  });
+}
+
+function workflowStep(workflow: string, name: string): string {
+  const stepStart = workflow.indexOf(`      - name: ${name}`);
+  expect(stepStart, `Missing workflow step: ${name}`).toBeGreaterThanOrEqual(0);
+  const nextStep = workflow.indexOf('\n      - ', stepStart + 1);
+  return workflow.slice(stepStart, nextStep === -1 ? undefined : nextStep);
+}
+
+afterEach(() => {
+  while (createdDirectories.length > 0) {
+    const directoryPath = createdDirectories.pop();
+    if (directoryPath) rmSync(directoryPath, { recursive: true, force: true });
+  }
+});
+
+describe('OTA source-map artifact validation', () => {
+  it.each(['hbc', 'js'] as const)('accepts a complete requested-platform %s bundle with a Debug ID', (extension) => {
+    const fixture = createMobileFixture('ios', extension);
+    expect(validateSourceMapOutput(fixture.mobileDir, fixture.outputDir, 'ios')).toEqual([
+      {
+        bundlePath: fixture.bundlePath,
+        sourceMapPath: fixture.sourceMapPath,
+        relativeBundlePath: fixture.relativeBundlePath,
+        relativeSourceMapPath: `${fixture.relativeBundlePath}.map`,
+        debugId: VALID_DEBUG_ID,
+      },
+    ]);
+  });
+
+  it('requires an output directory and Expo Metro metadata', () => {
+    const fixture = createMobileFixture('ios');
+    expect(() => validateSourceMapOutput(fixture.mobileDir, join(fixture.mobileDir, 'missing'), 'ios')).toThrow(
+      'output directory does not exist',
+    );
+
+    writeFileSync(
+      join(fixture.outputDir, 'metadata.json'),
+      JSON.stringify({ version: 1, bundler: 'other', fileMetadata: {} }),
+    );
+    expect(() => validateSourceMapOutput(fixture.mobileDir, fixture.outputDir, 'ios')).toThrow(
+      'Expo Metro metadata version 0',
+    );
+  });
+
+  it('requires metadata.json to contain exactly the requested platform', () => {
+    const fixture = createMobileFixture('ios');
+    rewriteMetadata(fixture, {
+      ios: { bundle: fixture.relativeBundlePath, assets: [] },
+      android: { bundle: '_expo/static/js/android/entry-test.hbc', assets: [] },
+    });
+    expect(() => validateSourceMapOutput(fixture.mobileDir, fixture.outputDir, 'ios')).toThrow(
+      'exactly the requested platform "ios"',
+    );
+
+    rewriteMetadata(fixture, { android: { bundle: fixture.relativeBundlePath, assets: [] } });
+    expect(() => validateSourceMapOutput(fixture.mobileDir, fixture.outputDir, 'ios')).toThrow(
+      'exactly the requested platform "ios"',
+    );
+  });
+
+  it('rejects metadata bundle paths that escape the output directory', () => {
+    const fixture = createMobileFixture('ios');
+    writeFileSync(join(fixture.mobileDir, 'outside.hbc'), 'outside');
+    rewriteMetadata(fixture, { ios: { bundle: '../outside.hbc', assets: [] } });
+    expect(() => validateSourceMapOutput(fixture.mobileDir, fixture.outputDir, 'ios')).toThrow(
+      'bundle path escapes the output directory',
+    );
+  });
+
+  it('rejects metadata whose primary bundle is not executable', () => {
+    const fixture = createMobileFixture('ios');
+    const otherBundlePath = join(dirname(fixture.bundlePath), 'other.hbc');
+    writeFileSync(otherBundlePath, 'other bytecode');
+    writeFileSync(
+      `${otherBundlePath}.map`,
+      JSON.stringify({ version: 3, sources: [], mappings: '', debugId: VALID_DEBUG_ID }),
+    );
+    const nonBundlePath = join(dirname(fixture.bundlePath), 'not-an-upload-bundle.txt');
+    writeFileSync(nonBundlePath, 'not an uploader bundle');
+    rewriteMetadata(fixture, { ios: { bundle: '_expo/static/js/ios/not-an-upload-bundle.txt', assets: [] } });
+    expect(() => validateSourceMapOutput(fixture.mobileDir, fixture.outputDir, 'ios')).toThrow(
+      'metadata.json platform bundle must end in .js or .hbc',
+    );
+  });
+
+  it('ignores Expo-copied public JavaScript that metadata does not declare executable', () => {
+    const fixture = createMobileFixture('android');
+    const publicWorkerPath = join(fixture.outputDir, 'wasm', 'board-render.worker.js');
+    const publicGluePath = join(fixture.outputDir, 'wasm', 'board_renderer_wasm.js');
+    mkdirSync(dirname(publicWorkerPath), { recursive: true });
+    writeFileSync(publicWorkerPath, 'self.onmessage = () => {};');
+    writeFileSync(publicGluePath, 'export default function init() {}');
+
+    expect(validateSourceMapOutput(fixture.mobileDir, fixture.outputDir, 'android')).toHaveLength(1);
+  });
+
+  it('validates metadata-declared executable assets when exact bundle/map pairs are present', () => {
+    const fixture = createMobileFixture('ios');
+    const relativeDomBundlePath = 'www.bundle/1234567890abcdef.js';
+    const domBundlePath = join(fixture.outputDir, relativeDomBundlePath);
+    mkdirSync(dirname(domBundlePath), { recursive: true });
+    writeFileSync(domBundlePath, 'dom component bundle');
+    writeFileSync(
+      `${domBundlePath}.map`,
+      JSON.stringify({ version: 3, sources: [], mappings: '', debugId: VALID_DEBUG_ID }),
+    );
+    rewriteMetadata(fixture, {
+      ios: {
+        bundle: fixture.relativeBundlePath,
+        assets: [
+          { path: 'assets/image-hash', ext: 'png' },
+          { path: relativeDomBundlePath, ext: 'js' },
+          { path: 'www.bundle/component.html', ext: 'html' },
+        ],
+      },
+    });
+    mkdirSync(join(fixture.outputDir, 'assets'), { recursive: true });
+    writeFileSync(join(fixture.outputDir, 'assets', 'image-hash'), 'image');
+    mkdirSync(join(fixture.outputDir, 'www.bundle'), { recursive: true });
+    writeFileSync(join(fixture.outputDir, 'www.bundle', 'component.html'), '<html></html>');
+
+    expect(validateSourceMapOutput(fixture.mobileDir, fixture.outputDir, 'ios')).toHaveLength(2);
+  });
+
+  it('fails closed for Expo 57 DOM metadata whose independently hashed map is not an exact pair', () => {
+    const fixture = createMobileFixture('ios');
+    const relativeDomBundlePath = 'www.bundle/11111111111111111111111111111111.js';
+    const relativeDomMapPath = 'www.bundle/22222222222222222222222222222222.map';
+    mkdirSync(join(fixture.outputDir, 'www.bundle'), { recursive: true });
+    writeFileSync(join(fixture.outputDir, relativeDomBundlePath), 'dom component bundle');
+    writeFileSync(
+      join(fixture.outputDir, relativeDomMapPath),
+      JSON.stringify({ version: 3, sources: [], mappings: '', debugId: VALID_DEBUG_ID }),
+    );
+    rewriteMetadata(fixture, {
+      ios: {
+        bundle: fixture.relativeBundlePath,
+        // Expo 57 declares non-map DOM artifacts in metadata. Its map is
+        // independently content-hashed and excluded from this assets array.
+        assets: [
+          { path: relativeDomBundlePath, ext: 'js' },
+          { path: 'www.bundle/33333333333333333333333333333333.html', ext: 'html' },
+        ],
+      },
+    });
+    writeFileSync(join(fixture.outputDir, 'www.bundle', '33333333333333333333333333333333.html'), '<html></html>');
+
+    expect(() => validateSourceMapOutput(fixture.mobileDir, fixture.outputDir, 'ios')).toThrow(
+      `${relativeDomBundlePath}.map`,
+    );
+  });
+
+  it('rejects zero, metadata-declared partial, and empty uploader groups', () => {
+    const noBundleFixture = createMobileFixture('ios');
+    rmSync(noBundleFixture.bundlePath);
+    rmSync(noBundleFixture.sourceMapPath);
+    expect(() => validateSourceMapOutput(noBundleFixture.mobileDir, noBundleFixture.outputDir, 'ios')).toThrow();
+
+    const partialFixture = createMobileFixture('ios');
+    const relativeOrphanPath = 'www.bundle/orphan.js';
+    mkdirSync(dirname(join(partialFixture.outputDir, relativeOrphanPath)), { recursive: true });
+    writeFileSync(join(partialFixture.outputDir, relativeOrphanPath), 'javascript');
+    rewriteMetadata(partialFixture, {
+      ios: {
+        bundle: partialFixture.relativeBundlePath,
+        assets: [{ path: relativeOrphanPath, ext: 'js' }],
+      },
+    });
+    expect(() => validateSourceMapOutput(partialFixture.mobileDir, partialFixture.outputDir, 'ios')).toThrow(
+      'Metadata-declared executable asset requires an exact adjacent source map',
+    );
+
+    const emptyMapFixture = createMobileFixture('ios');
+    const relativeEmptyMapBundlePath = 'www.bundle/empty-map.js';
+    const emptyMapBundlePath = join(emptyMapFixture.outputDir, relativeEmptyMapBundlePath);
+    mkdirSync(dirname(emptyMapBundlePath), { recursive: true });
+    writeFileSync(emptyMapBundlePath, 'dom component bundle');
+    writeFileSync(`${emptyMapBundlePath}.map`, '');
+    rewriteMetadata(emptyMapFixture, {
+      ios: {
+        bundle: emptyMapFixture.relativeBundlePath,
+        assets: [{ path: relativeEmptyMapBundlePath, ext: 'js' }],
+      },
+    });
+    expect(() => validateSourceMapOutput(emptyMapFixture.mobileDir, emptyMapFixture.outputDir, 'ios')).toThrow(
+      'Source map is empty',
+    );
+
+    const emptyBundleFixture = createMobileFixture('ios');
+    const relativeEmptyBundlePath = 'www.bundle/empty-bundle.js';
+    const emptyBundlePath = join(emptyBundleFixture.outputDir, relativeEmptyBundlePath);
+    mkdirSync(dirname(emptyBundlePath), { recursive: true });
+    writeFileSync(emptyBundlePath, '');
+    writeFileSync(
+      `${emptyBundlePath}.map`,
+      JSON.stringify({ version: 3, sources: [], mappings: '', debugId: VALID_DEBUG_ID }),
+    );
+    rewriteMetadata(emptyBundleFixture, {
+      ios: {
+        bundle: emptyBundleFixture.relativeBundlePath,
+        assets: [{ path: relativeEmptyBundlePath, ext: 'js' }],
+      },
+    });
+    expect(() => validateSourceMapOutput(emptyBundleFixture.mobileDir, emptyBundleFixture.outputDir, 'ios')).toThrow(
+      'Bundle is empty',
+    );
+  });
+
+  it('rejects invalid maps for metadata-declared executable DOM assets', () => {
+    const fixture = createMobileFixture('ios');
+    const relativeDomBundlePath = 'www.bundle/invalid.js';
+    const domBundlePath = join(fixture.outputDir, relativeDomBundlePath);
+    mkdirSync(dirname(domBundlePath), { recursive: true });
+    writeFileSync(domBundlePath, 'dom component bundle');
+    writeFileSync(`${domBundlePath}.map`, JSON.stringify({ version: 3, debugId: 'invalid' }));
+    rewriteMetadata(fixture, {
+      ios: {
+        bundle: fixture.relativeBundlePath,
+        assets: [{ path: relativeDomBundlePath, ext: 'js' }],
+      },
+    });
+
+    expect(() => validateSourceMapOutput(fixture.mobileDir, fixture.outputDir, 'ios')).toThrow('no valid Debug ID');
+  });
+
+  it('rejects metadata-declared orphan maps, path escapes, symlinks, duplicates, and collisions', () => {
+    const orphanMapFixture = createMobileFixture('ios');
+    const relativeOrphanMapPath = 'www.bundle/orphan.js.map';
+    mkdirSync(join(orphanMapFixture.outputDir, 'www.bundle'), { recursive: true });
+    writeFileSync(join(orphanMapFixture.outputDir, relativeOrphanMapPath), '{}');
+    rewriteMetadata(orphanMapFixture, {
+      ios: {
+        bundle: orphanMapFixture.relativeBundlePath,
+        assets: [{ path: relativeOrphanMapPath, ext: 'map' }],
+      },
+    });
+    expect(() => validateSourceMapOutput(orphanMapFixture.mobileDir, orphanMapFixture.outputDir, 'ios')).toThrow(
+      'source map has no matching executable',
+    );
+
+    const escapeFixture = createMobileFixture('ios');
+    writeFileSync(join(escapeFixture.mobileDir, 'outside.js'), 'outside');
+    rewriteMetadata(escapeFixture, {
+      ios: {
+        bundle: escapeFixture.relativeBundlePath,
+        assets: [{ path: '../outside.js', ext: 'js' }],
+      },
+    });
+    expect(() => validateSourceMapOutput(escapeFixture.mobileDir, escapeFixture.outputDir, 'ios')).toThrow(
+      'escapes the output directory',
+    );
+
+    const symlinkFixture = createMobileFixture('ios');
+    const realAssetPath = join(symlinkFixture.outputDir, 'www.bundle', 'real.js');
+    const symlinkAssetPath = join(symlinkFixture.outputDir, 'www.bundle', 'linked.js');
+    mkdirSync(dirname(realAssetPath), { recursive: true });
+    writeFileSync(realAssetPath, 'real');
+    symlinkSync(realAssetPath, symlinkAssetPath);
+    rewriteMetadata(symlinkFixture, {
+      ios: {
+        bundle: symlinkFixture.relativeBundlePath,
+        assets: [{ path: 'www.bundle/linked.js', ext: 'js' }],
+      },
+    });
+    expect(() => validateSourceMapOutput(symlinkFixture.mobileDir, symlinkFixture.outputDir, 'ios')).toThrow(
+      'contains a symbolic link',
+    );
+
+    const duplicateFixture = createMobileFixture('ios');
+    rewriteMetadata(duplicateFixture, {
+      ios: {
+        bundle: duplicateFixture.relativeBundlePath,
+        assets: [{ path: duplicateFixture.relativeBundlePath, ext: 'hbc' }],
+      },
+    });
+    expect(() => validateSourceMapOutput(duplicateFixture.mobileDir, duplicateFixture.outputDir, 'ios')).toThrow(
+      'duplicate path',
+    );
+
+    const collisionFixture = createMobileFixture('ios');
+    const lowerCasePath = 'www.bundle/chunk.js';
+    const upperCasePath = 'www.bundle/CHUNK.js';
+    mkdirSync(join(collisionFixture.outputDir, 'www.bundle'), { recursive: true });
+    writeFileSync(join(collisionFixture.outputDir, lowerCasePath), 'lower');
+    writeFileSync(join(collisionFixture.outputDir, upperCasePath), 'upper');
+    rewriteMetadata(collisionFixture, {
+      ios: {
+        bundle: collisionFixture.relativeBundlePath,
+        assets: [
+          { path: lowerCasePath, ext: 'js' },
+          { path: upperCasePath, ext: 'js' },
+        ],
+      },
+    });
+    expect(() => validateSourceMapOutput(collisionFixture.mobileDir, collisionFixture.outputDir, 'ios')).toThrow(
+      'paths collide',
+    );
+  });
+
+  it('rejects missing, malformed, and inconsistent Debug IDs', () => {
+    const fixture = createMobileFixture('android');
+    writeFileSync(fixture.sourceMapPath, JSON.stringify({ version: 3, mappings: '' }));
+    expect(() => validateSourceMapOutput(fixture.mobileDir, fixture.outputDir, 'android')).toThrow('no valid Debug ID');
+
+    writeFileSync(fixture.sourceMapPath, JSON.stringify({ version: 3, debugId: 'not-a-debug-id' }));
+    expect(() => validateSourceMapOutput(fixture.mobileDir, fixture.outputDir, 'android')).toThrow('no valid Debug ID');
+
+    writeFileSync(
+      fixture.sourceMapPath,
+      JSON.stringify({ version: 3, debugId: VALID_DEBUG_ID, debug_id: '87654321-4321-4abc-9def-1234567890ab' }),
+    );
+    expect(() => validateSourceMapOutput(fixture.mobileDir, fixture.outputDir, 'android')).toThrow(
+      'mismatched debugId and debug_id',
+    );
+  });
+});
+
+describe('official Sentry uploader invocation', () => {
+  it('pins the installed Sentry React Native uploader to 7.11.0', () => {
+    const fixture = createMobileFixture();
+    const sentryRoot = join(fixture.mobileDir, 'node_modules', '@sentry', 'react-native');
+    const uploaderPath = join(sentryRoot, 'scripts', 'expo-upload-sourcemaps.js');
+    mkdirSync(dirname(uploaderPath), { recursive: true });
+    writeFileSync(
+      join(sentryRoot, 'package.json'),
+      JSON.stringify({ name: '@sentry/react-native', version: '7.11.0' }),
+    );
+    writeFileSync(uploaderPath, '#!/usr/bin/env node\n');
+    expect(resolveInstalledSentryUploader(fixture.mobileDir)).toBe(uploaderPath);
+
+    writeFileSync(
+      join(sentryRoot, 'package.json'),
+      JSON.stringify({ name: '@sentry/react-native', version: '7.12.0' }),
+    );
+    expect(() => resolveInstalledSentryUploader(fixture.mobileDir)).toThrow(
+      'Unsupported @sentry/react-native version 7.12.0',
+    );
+  });
+
+  it('fixes org/project/url and removes release, dist, and CLI overrides', () => {
+    const environment = createSentryUploadEnvironment({
+      SENTRY_AUTH_TOKEN: ' token ',
+      SENTRY_ORG: 'wrong',
+      SENTRY_PROJECT: 'wrong',
+      SENTRY_URL: 'https://wrong.invalid/',
+      SENTRY_RELEASE: 'synthetic-release',
+      SENTRY_DIST: 'synthetic-dist',
+      SENTRY_CLI_EXECUTABLE: '/tmp/untrusted-cli',
+    });
+    expect(environment).toMatchObject({
+      SENTRY_AUTH_TOKEN: 'token',
+      SENTRY_ORG: 'boardsesh',
+      SENTRY_PROJECT: 'boardsesh',
+      SENTRY_URL: 'https://sentry.io/',
+    });
+    expect(environment.SENTRY_RELEASE).toBeUndefined();
+    expect(environment.SENTRY_DIST).toBeUndefined();
+    expect(environment.SENTRY_CLI_EXECUTABLE).toBeUndefined();
+  });
+
+  it('requires the auth token before starting the uploader', () => {
+    expect(() => createSentryUploadEnvironment({})).toThrow('SENTRY_AUTH_TOKEN is required');
+  });
+
+  it('fails validation before resolving or starting the official uploader', () => {
+    const fixture = createMobileFixture('ios');
+    rmSync(fixture.sourceMapPath);
+    let resolverCalled = false;
+    let spawnCalled = false;
+
+    expect(() =>
+      uploadMobileSourceMaps(
+        {
+          platform: 'ios',
+          mobileDir: fixture.mobileDir,
+          outputDir: fixture.outputDir,
+          environment: { SENTRY_AUTH_TOKEN: 'secret-token' },
+        },
+        {
+          resolveUploader: () => {
+            resolverCalled = true;
+            return join(fixture.mobileDir, 'fake-uploader.js');
+          },
+          spawnUploader: () => {
+            spawnCalled = true;
+            return { status: 0 };
+          },
+        },
+      ),
+    ).toThrow('Primary OTA bundle requires an exact adjacent source map');
+    expect(resolverCalled).toBe(false);
+    expect(spawnCalled).toBe(false);
+  });
+
+  it('stages exactly declared executable groups, uses a fresh cwd, and cleans only its temporary root', () => {
+    const fixture = createMobileFixture('android');
+    const fakeUploaderPath = join(fixture.mobileDir, 'fake-uploader.js');
+    const relativeDomBundlePath = 'www.bundle/component.js';
+    const domBundlePath = join(fixture.outputDir, relativeDomBundlePath);
+    const publicWorkerPath = join(fixture.outputDir, 'wasm', 'board-render.worker.js');
+    mkdirSync(dirname(domBundlePath), { recursive: true });
+    mkdirSync(dirname(publicWorkerPath), { recursive: true });
+    writeFileSync(domBundlePath, 'dom component bundle');
+    writeFileSync(
+      `${domBundlePath}.map`,
+      JSON.stringify({ version: 3, sources: [], mappings: '', debugId: VALID_DEBUG_ID }),
+    );
+    writeFileSync(publicWorkerPath, 'unmapped public worker');
+    rewriteMetadata(fixture, {
+      android: {
+        bundle: fixture.relativeBundlePath,
+        assets: [{ path: relativeDomBundlePath, ext: 'js' }],
+      },
+    });
+    let invocation:
+      | {
+          executable: string;
+          args: string[];
+          cwd: string;
+          environment: NodeJS.ProcessEnv;
+          cwdEntries: string[];
+          stagedFiles: string[];
+        }
+      | undefined;
+
+    uploadMobileSourceMaps(
+      {
+        platform: 'android',
+        mobileDir: fixture.mobileDir,
+        outputDir: fixture.outputDir,
+        environment: {
+          SENTRY_AUTH_TOKEN: 'secret-token',
+          SENTRY_RELEASE: 'remove-me',
+          SENTRY_DIST: 'remove-me-too',
+        },
+      },
+      {
+        resolveUploader: () => fakeUploaderPath,
+        spawnUploader: (executable, args, options) => {
+          invocation = {
+            executable,
+            args,
+            cwd: options.cwd,
+            environment: options.env,
+            cwdEntries: readdirSync(options.cwd),
+            stagedFiles: listRelativeFiles(args[1]).sort(),
+          };
+          writeFileSync(join(args[1], `${fixture.relativeBundlePath}.map`), 'mutated staged map');
+          return { status: 0 };
+        },
+      },
+    );
+
+    expect(invocation).toBeDefined();
+    expect(invocation?.executable).toBe('node');
+    expect(invocation?.args[0]).toBe(fakeUploaderPath);
+    expect(invocation?.args[1]).not.toBe(fixture.outputDir);
+    expect(invocation?.cwdEntries).toEqual([]);
+    expect(invocation?.stagedFiles).toEqual(
+      [
+        fixture.relativeBundlePath,
+        `${fixture.relativeBundlePath}.map`,
+        relativeDomBundlePath,
+        `${relativeDomBundlePath}.map`,
+      ].sort(),
+    );
+    expect(invocation?.environment.SENTRY_AUTH_TOKEN).toBe('secret-token');
+    expect(invocation?.environment.SENTRY_RELEASE).toBeUndefined();
+    expect(invocation?.environment.SENTRY_DIST).toBeUndefined();
+    expect(invocation?.cwd).toContain('boardsesh-sentry-upload-');
+    expect(existsSync(invocation?.cwd ?? '')).toBe(false);
+    expect(existsSync(invocation?.args[1] ?? '')).toBe(false);
+    expect(existsSync(fixture.outputDir)).toBe(true);
+    expect(existsSync(publicWorkerPath)).toBe(true);
+    expect(readFileSync(fixture.sourceMapPath, 'utf8')).toContain(VALID_DEBUG_ID);
+  });
+});
+
+describe('source-map CLI arguments', () => {
+  it('requires one native platform', () => {
+    expect(parseUploadArgs(['--platform', 'ios'])).toBe('ios');
+    expect(parseUploadArgs(['--platform=android'])).toBe('android');
+    expect(() => parseUploadArgs([])).toThrow('--platform is required');
+    expect(() => parseUploadArgs(['--platform', 'all'])).toThrow('--platform is required');
+    expect(() => parseUploadArgs(['--other'])).toThrow('Unknown argument');
+  });
+});
+
+describe('self-hosted OTA publisher and workflow contracts', () => {
+  it('always retains EOAS source maps in dist without changing the EAS preview path', () => {
+    const selfHostedArgs = buildSelfHostedEoasArgs('production', 'ios', 'source-map contract');
+    const easArgs = buildEasUpdateArgs('preview', 'preview contract', 'ios');
+
+    expect(selfHostedArgs.filter((argument) => argument === '--dumpSourcemap')).toEqual(['--dumpSourcemap']);
+    expect(
+      selfHostedArgs.slice(selfHostedArgs.indexOf('--outputDir'), selfHostedArgs.indexOf('--outputDir') + 2),
+    ).toEqual(['--outputDir', 'dist']);
+    expect(easArgs).not.toContain('--dumpSourcemap');
+    expect(easArgs).not.toContain('--outputDir');
+  });
+
+  it('publishes and uploads each production platform before the next export cleans dist', () => {
+    const workflow = readRepositoryFile('.github/workflows/mobile-ota-production.yml');
+    const orderedSteps = [
+      'Publish iOS OTA',
+      'Upload iOS OTA source maps to Sentry',
+      'Publish Android OTA',
+      'Upload Android OTA source maps to Sentry',
+      'Push changelog to main',
+      'Notify deployments channel',
+      'OTA health check (non-blocking)',
+      'Notify OTA health to Discord',
+      'Warn that published OTA source maps are missing',
+      'Require every published OTA source-map upload',
+      'Notify deployments channel of failure',
+    ];
+    const positions = orderedSteps.map((stepName) => workflow.indexOf(`- name: ${stepName}`));
+    expect(positions.every((position) => position >= 0)).toBe(true);
+    expect(positions).toEqual([...positions].sort((left, right) => left - right));
+
+    for (const stepName of ['Upload iOS OTA source maps to Sentry', 'Upload Android OTA source maps to Sentry']) {
+      const step = workflowStep(workflow, stepName);
+      expect(step).toContain('continue-on-error: true');
+      expect(step).toMatch(/^\s+SENTRY_AUTH_TOKEN:\s*\$\{\{ secrets\.SENTRY_AUTH_TOKEN \}\}$/m);
+      expect(step).toContain('vp run mobile:upload-sourcemaps');
+    }
+    expect((workflow.match(/^\s+SENTRY_AUTH_TOKEN:/gm) ?? []).length).toBe(2);
+    expect(workflowStep(workflow, 'Require every published OTA source-map upload')).toContain(
+      "steps.upload_sourcemaps_ios.outcome == 'failure'",
+    );
+    expect(workflowStep(workflow, 'Require every published OTA source-map upload')).toContain(
+      "steps.upload_sourcemaps_android.outcome == 'failure'",
+    );
+    const failureNotification = workflowStep(workflow, 'Notify deployments channel of failure');
+    expect(failureNotification).toContain('Production OTA workflow failed');
+    expect(failureNotification).not.toContain('Production OTA publish failed');
+  });
+
+  it('overlays trusted tooling before authoritative backport verification and never uploads on dry-run', () => {
+    const workflow = readRepositoryFile('.github/workflows/mobile-ota-backport.yml');
+    const orderedSteps = [
+      'Snapshot trusted OTA publish tooling',
+      'Locate the release anchor and prepare the hotfix tree',
+      'Overlay trusted OTA publish tooling',
+      'Validate anchored Sentry uploader support',
+      'Resolve fingerprint and verify it matches the approved anchor',
+      'Publish OTA to the approved release',
+      'Upload backport OTA source maps to Sentry',
+      'Warn that the published backport source maps are missing',
+      'Require the published backport source-map upload',
+    ];
+    const positions = orderedSteps.map((stepName) => workflow.indexOf(`- name: ${stepName}`));
+    expect(positions.every((position) => position >= 0)).toBe(true);
+    expect(positions).toEqual([...positions].sort((left, right) => left - right));
+
+    const snapshotStep = workflowStep(workflow, 'Snapshot trusted OTA publish tooling');
+    expect(snapshotStep).toContain('git show "$GITHUB_SHA:$source_path"');
+    expect(snapshotStep).toContain('scripts/mobile-publish.ts');
+    expect(snapshotStep).toContain('scripts/lib/eoas.ts');
+    expect(snapshotStep).toContain('scripts/lib/mobile-publish-retry.ts');
+    expect(snapshotStep).toContain('scripts/mobile-upload-sourcemaps.ts');
+    const overlayStep = workflowStep(workflow, 'Overlay trusted OTA publish tooling');
+    expect(overlayStep).toContain(
+      'cp "$tooling_root/scripts/lib/mobile-publish-retry.ts" scripts/lib/mobile-publish-retry.ts',
+    );
+    expect(overlayStep).toContain(
+      'git add scripts/mobile-publish.ts scripts/lib/eoas.ts scripts/lib/mobile-publish-retry.ts',
+    );
+    expect(overlayStep).toContain('git status --porcelain');
+    expect(workflowStep(workflow, 'Validate anchored Sentry uploader support')).toContain('7.11.0');
+
+    const uploadStep = workflowStep(workflow, 'Upload backport OTA source maps to Sentry');
+    expect(uploadStep).toContain("!inputs.dry_run && steps.publish.outcome == 'success'");
+    expect(uploadStep).toContain('continue-on-error: true');
+    expect(uploadStep).toContain('run: bun scripts/mobile-upload-sourcemaps.ts');
+    expect((workflow.match(/^\s+SENTRY_AUTH_TOKEN:/gm) ?? []).length).toBe(1);
+    expect(workflowStep(workflow, 'Require the published backport source-map upload')).toContain('!inputs.dry_run');
+  });
+
+  it('generates but never uploads source maps or exposes a Sentry token in PR previews', () => {
+    const previewWorkflow = readRepositoryFile('.github/workflows/mobile-ota-preview.yml');
+    expect(previewWorkflow).toContain('vp run mobile:publish');
+    expect(previewWorkflow).not.toContain('mobile:upload-sourcemaps');
+    expect(previewWorkflow).not.toContain('mobile-upload-sourcemaps.ts');
+    expect(previewWorkflow).not.toMatch(/^\s+SENTRY_AUTH_TOKEN:/gm);
+  });
+});

--- a/scripts/mobile-sourcemaps.test.ts
+++ b/scripts/mobile-sourcemaps.test.ts
@@ -671,12 +671,16 @@ describe('self-hosted OTA publisher and workflow contracts', () => {
       expect(step).toContain('vp run mobile:upload-sourcemaps');
     }
     expect((workflow.match(/^\s+SENTRY_AUTH_TOKEN:/gm) ?? []).length).toBe(2);
-    expect(workflowStep(workflow, 'Require every published OTA source-map upload')).toContain(
-      "steps.upload_sourcemaps_ios.outcome == 'failure'",
-    );
-    expect(workflowStep(workflow, 'Require every published OTA source-map upload')).toContain(
-      "steps.upload_sourcemaps_android.outcome == 'failure'",
-    );
+    for (const gateStepName of [
+      'Warn that published OTA source maps are missing',
+      'Require every published OTA source-map upload',
+    ]) {
+      const sourceMapGate = workflowStep(workflow, gateStepName);
+      for (const platform of ['ios', 'android']) {
+        expect(sourceMapGate).toContain(`steps.publish_${platform}.outcome == 'success'`);
+        expect(sourceMapGate).toContain(`steps.upload_sourcemaps_${platform}.outcome != 'success'`);
+      }
+    }
     const failureNotification = workflowStep(workflow, 'Notify deployments channel of failure');
     expect(failureNotification).toContain('Production OTA workflow failed');
     expect(failureNotification).not.toContain('Production OTA publish failed');
@@ -739,12 +743,19 @@ describe('self-hosted OTA publisher and workflow contracts', () => {
     const uploadStep = workflowStep(workflow, 'Upload backport OTA source maps to Sentry');
     expect(uploadStep).toContain("!inputs.dry_run && steps.publish.outcome == 'success'");
     expect(uploadStep).toContain('continue-on-error: true');
+    expect(uploadStep).toContain('timeout-minutes: 10');
     expect(uploadStep).toContain('run: bun scripts/mobile-upload-sourcemaps.ts');
     expect((workflow.match(/^\s+SENTRY_AUTH_TOKEN:/gm) ?? []).length).toBe(1);
-    expect(workflowStep(workflow, 'Require the published backport source-map upload')).toContain('!inputs.dry_run');
+    const backportGate = workflowStep(workflow, 'Require the published backport source-map upload');
+    expect(backportGate).toContain('!inputs.dry_run');
+    expect(backportGate).toContain("steps.publish.outcome == 'success'");
+    expect(backportGate).toContain("steps.upload_sourcemaps.outcome != 'success'");
+    expect(workflowStep(workflow, 'Validate anchored Sentry uploader support')).toContain(
+      '.devDependencies["@sentry/react-native"]',
+    );
   });
 
-  it('generates but never uploads source maps or exposes a Sentry token in PR previews', () => {
+  it('never uploads source maps or exposes a Sentry token in PR previews', () => {
     const previewWorkflow = readRepositoryFile('.github/workflows/mobile-ota-preview.yml');
     expect(previewWorkflow).toContain('vp run mobile:publish');
     expect(previewWorkflow).not.toContain('mobile:upload-sourcemaps');

--- a/scripts/mobile-upload-sourcemaps.ts
+++ b/scripts/mobile-upload-sourcemaps.ts
@@ -333,7 +333,11 @@ function stageValidatedArtifacts(artifacts: ValidatedSourceMapArtifact[], stagin
 }
 
 export function resolveInstalledSentryUploader(mobileDirInput: string): string {
-  const mobileDir = realpathSync(resolve(mobileDirInput));
+  const requestedMobileDir = resolve(mobileDirInput);
+  if (!existsSync(requestedMobileDir) || !statSync(requestedMobileDir).isDirectory()) {
+    throw new Error(`Mobile directory does not exist or is not a directory: ${requestedMobileDir}`);
+  }
+  const mobileDir = realpathSync(requestedMobileDir);
   const requireFromMobile = createRequire(join(mobileDir, 'package.json'));
   let sentryPackageJsonPath: string;
   try {

--- a/scripts/mobile-upload-sourcemaps.ts
+++ b/scripts/mobile-upload-sourcemaps.ts
@@ -1,0 +1,456 @@
+/// <reference types="node" />
+
+/**
+ * Uploads source maps from one self-hosted Expo OTA export to Sentry.
+ *
+ * `@sentry/react-native`'s official Expo uploader intentionally skips incomplete
+ * bundle/map groups and still exits zero. That is convenient interactively but
+ * unsafe for a production OTA gate, so this wrapper validates the complete Expo
+ * artifact first and only then invokes the pinned installed uploader.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import {
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const DEFAULT_MOBILE_DIR = resolve(REPO_ROOT, 'packages', 'mobile');
+const SUPPORTED_SENTRY_REACT_NATIVE_VERSION = '7.11.0';
+const VALID_DEBUG_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export type MobilePlatform = 'ios' | 'android';
+
+type JsonObject = Record<string, unknown>;
+
+type SpawnUploader = (
+  executable: string,
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv; stdio: 'inherit' },
+) => { status: number | null; error?: Error };
+
+export interface UploadSourceMapsOptions {
+  platform: MobilePlatform;
+  mobileDir?: string;
+  outputDir?: string;
+  environment?: NodeJS.ProcessEnv;
+}
+
+export interface UploadSourceMapsDependencies {
+  resolveUploader?: (mobileDir: string) => string;
+  spawnUploader?: SpawnUploader;
+}
+
+export interface ValidatedSourceMapArtifact {
+  bundlePath: string;
+  sourceMapPath: string;
+  relativeBundlePath: string;
+  relativeSourceMapPath: string;
+  debugId: string;
+}
+
+interface DeclaredMetadataPath {
+  absolutePath: string;
+  extension: string;
+  relativePath: string;
+  type: 'asset' | 'bundle';
+}
+
+function isJsonObject(input: unknown): input is JsonObject {
+  return typeof input === 'object' && input !== null && !Array.isArray(input);
+}
+
+function parseJsonObject(filePath: string, label: string): JsonObject {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(filePath, 'utf8')) as unknown;
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`${label} is not valid JSON: ${reason}`);
+  }
+  if (!isJsonObject(parsed)) {
+    throw new Error(`${label} must contain a JSON object.`);
+  }
+  return parsed;
+}
+
+function pathIsWithin(rootPath: string, candidatePath: string): boolean {
+  const relativePath = relative(rootPath, candidatePath);
+  return (
+    relativePath === '' || (!relativePath.startsWith(`..${sep}`) && relativePath !== '..' && !isAbsolute(relativePath))
+  );
+}
+
+function existingPathWithin(rootPath: string, candidatePath: string, label: string): string {
+  const realRootPath = realpathSync(rootPath);
+  const realCandidatePath = realpathSync(candidatePath);
+  if (!pathIsWithin(realRootPath, realCandidatePath)) {
+    throw new Error(`${label} escapes ${realRootPath}: ${candidatePath}`);
+  }
+  return realCandidatePath;
+}
+
+function normalizeDeclaredPath(outputDir: string, declaredPath: string, label: string): string {
+  if (
+    !declaredPath ||
+    isAbsolute(declaredPath) ||
+    declaredPath.includes('\0') ||
+    declaredPath.includes('\\') ||
+    /^[a-z]:[/\\]/i.test(declaredPath)
+  ) {
+    throw new Error(`${label} is invalid: ${JSON.stringify(declaredPath)}.`);
+  }
+  const candidatePath = resolve(outputDir, declaredPath);
+  if (!pathIsWithin(resolve(outputDir), candidatePath)) {
+    throw new Error(`${label} escapes the output directory: ${declaredPath}.`);
+  }
+  const normalizedPath = relative(resolve(outputDir), candidatePath).split(sep).join('/');
+  if (normalizedPath !== declaredPath) {
+    throw new Error(`${label} must be a normalized relative path: ${declaredPath}.`);
+  }
+  return normalizedPath;
+}
+
+function assertRegularFileWithoutSymbolicLinks(outputDir: string, relativePath: string, label: string): string {
+  let currentPath = outputDir;
+  for (const pathSegment of relativePath.split('/')) {
+    currentPath = join(currentPath, pathSegment);
+    if (!existsSync(currentPath)) {
+      throw new Error(`${label} does not exist in the output directory: ${relativePath}.`);
+    }
+    if (lstatSync(currentPath).isSymbolicLink()) {
+      throw new Error(`${label} contains a symbolic link: ${relativePath}.`);
+    }
+  }
+  if (!statSync(currentPath).isFile()) {
+    throw new Error(`${label} is not a regular file: ${relativePath}.`);
+  }
+  return existingPathWithin(outputDir, currentPath, label);
+}
+
+function extensionFromExecutablePath(relativePath: string): 'js' | 'hbc' | null {
+  if (relativePath.endsWith('.js')) return 'js';
+  if (relativePath.endsWith('.hbc')) return 'hbc';
+  return null;
+}
+
+function parseDeclaredMetadataPaths(
+  outputDir: string,
+  platformMetadata: JsonObject,
+): { executablePaths: DeclaredMetadataPath[]; declaredMapPaths: Set<string>; allDeclaredPaths: Set<string> } {
+  if (typeof platformMetadata.bundle !== 'string') {
+    throw new Error('metadata.json has no platform bundle.');
+  }
+  if (!Array.isArray(platformMetadata.assets)) {
+    throw new Error('metadata.json platform assets must be an array.');
+  }
+
+  const executablePaths: DeclaredMetadataPath[] = [];
+  const declaredMapPaths = new Set<string>();
+  const allDeclaredPaths = new Set<string>();
+  const caseInsensitivePaths = new Map<string, string>();
+
+  const addDeclaredPath = (relativePathInput: string, extension: string, type: 'asset' | 'bundle'): void => {
+    const label = type === 'bundle' ? 'metadata.json bundle path' : 'metadata.json asset path';
+    const relativePath = normalizeDeclaredPath(outputDir, relativePathInput, label);
+    if (allDeclaredPaths.has(relativePath)) {
+      throw new Error(`metadata.json declares a duplicate path: ${relativePath}.`);
+    }
+    const caseInsensitivePath = relativePath.toLocaleLowerCase('en-US');
+    const collidingPath = caseInsensitivePaths.get(caseInsensitivePath);
+    if (collidingPath) {
+      throw new Error(`metadata.json paths collide: ${collidingPath} and ${relativePath}.`);
+    }
+    allDeclaredPaths.add(relativePath);
+    caseInsensitivePaths.set(caseInsensitivePath, relativePath);
+
+    const absolutePath = assertRegularFileWithoutSymbolicLinks(outputDir, relativePath, label);
+    const executableExtension = extensionFromExecutablePath(relativePath);
+    const declaresExecutable = extension === 'js' || extension === 'hbc';
+    if (
+      declaresExecutable !== Boolean(executableExtension) ||
+      (executableExtension && extension !== executableExtension)
+    ) {
+      throw new Error(`metadata.json executable extension does not match its path: ${relativePath} (${extension}).`);
+    }
+    const declaresSourceMap = extension === 'map' || relativePath.endsWith('.map');
+    if (declaresSourceMap && (extension !== 'map' || !relativePath.endsWith('.map'))) {
+      throw new Error(`metadata.json source-map extension does not match its path: ${relativePath} (${extension}).`);
+    }
+    if (declaresExecutable && executableExtension) {
+      executablePaths.push({ absolutePath, extension, relativePath, type });
+    } else if (declaresSourceMap) {
+      declaredMapPaths.add(relativePath);
+    }
+  };
+
+  const bundleExtension = extensionFromExecutablePath(platformMetadata.bundle);
+  if (!bundleExtension) {
+    throw new Error(`metadata.json platform bundle must end in .js or .hbc: ${platformMetadata.bundle}.`);
+  }
+  addDeclaredPath(platformMetadata.bundle, bundleExtension, 'bundle');
+
+  for (const [assetIndex, assetInput] of platformMetadata.assets.entries()) {
+    if (!isJsonObject(assetInput) || typeof assetInput.path !== 'string' || typeof assetInput.ext !== 'string') {
+      throw new Error(`metadata.json asset ${assetIndex} must contain string path and ext fields.`);
+    }
+    addDeclaredPath(assetInput.path, assetInput.ext, 'asset');
+  }
+
+  return { executablePaths, declaredMapPaths, allDeclaredPaths };
+}
+
+function readDebugId(sourceMapPath: string): string {
+  const sourceMap = parseJsonObject(sourceMapPath, `Source map ${sourceMapPath}`);
+  const camelCaseDebugId = sourceMap.debugId;
+  const snakeCaseDebugId = sourceMap.debug_id;
+  if (
+    typeof camelCaseDebugId === 'string' &&
+    typeof snakeCaseDebugId === 'string' &&
+    camelCaseDebugId !== snakeCaseDebugId
+  ) {
+    throw new Error(`Source map has mismatched debugId and debug_id values: ${sourceMapPath}`);
+  }
+  const debugId = typeof camelCaseDebugId === 'string' ? camelCaseDebugId : snakeCaseDebugId;
+  if (typeof debugId !== 'string' || !VALID_DEBUG_ID.test(debugId)) {
+    throw new Error(`Source map has no valid Debug ID: ${sourceMapPath}`);
+  }
+  return debugId;
+}
+
+export function validateSourceMapOutput(
+  mobileDirInput: string,
+  outputDirInput: string,
+  platform: MobilePlatform,
+): ValidatedSourceMapArtifact[] {
+  const mobileDir = realpathSync(resolve(mobileDirInput));
+  const outputDir = resolve(outputDirInput);
+  if (!existsSync(outputDir) || !statSync(outputDir).isDirectory()) {
+    throw new Error(`Source-map output directory does not exist: ${outputDir}`);
+  }
+  if (lstatSync(outputDir).isSymbolicLink()) {
+    throw new Error(`Refusing symbolic-link source-map output directory: ${outputDir}`);
+  }
+  const realOutputDir = existingPathWithin(mobileDir, outputDir, 'Source-map output directory');
+
+  const metadataPath = join(realOutputDir, 'metadata.json');
+  if (!existsSync(metadataPath) || !statSync(metadataPath).isFile()) {
+    throw new Error(`Expo export metadata is missing: ${metadataPath}`);
+  }
+  if (lstatSync(metadataPath).isSymbolicLink()) {
+    throw new Error(`Refusing symbolic-link metadata.json: ${metadataPath}`);
+  }
+
+  const metadata = parseJsonObject(metadataPath, 'metadata.json');
+  if (metadata.version !== 0 || metadata.bundler !== 'metro') {
+    throw new Error('metadata.json must be Expo Metro metadata version 0.');
+  }
+  if (!isJsonObject(metadata.fileMetadata)) {
+    throw new Error('metadata.json must contain a fileMetadata object.');
+  }
+  const metadataPlatforms = Object.keys(metadata.fileMetadata);
+  if (metadataPlatforms.length !== 1 || metadataPlatforms[0] !== platform) {
+    throw new Error(
+      `metadata.json must contain exactly the requested platform "${platform}"; found: ${metadataPlatforms.join(', ') || '(none)'}.`,
+    );
+  }
+  const platformMetadata = metadata.fileMetadata[platform];
+  if (!isJsonObject(platformMetadata)) {
+    throw new Error(`metadata.json has no bundle for platform "${platform}".`);
+  }
+  const { executablePaths, declaredMapPaths, allDeclaredPaths } = parseDeclaredMetadataPaths(
+    realOutputDir,
+    platformMetadata,
+  );
+  const executablePathSet = new Set(executablePaths.map(({ relativePath }) => relativePath));
+  for (const declaredMapPath of declaredMapPaths) {
+    if (!executablePathSet.has(declaredMapPath.slice(0, -'.map'.length))) {
+      throw new Error(`Metadata-declared source map has no matching executable: ${declaredMapPath}.`);
+    }
+  }
+
+  // EOAS 3.0.5 delegates to Expo 57's external-map export. Metro names the
+  // initial pair `<name>.js` + `<name>.js.map`; Hermes then changes both suffixes
+  // to `<name>.hbc` + `<name>.hbc.map`. In either case the official Sentry
+  // uploader groups the pair by the exact `${bundlePath}.map` convention.
+  return executablePaths.map(({ absolutePath: bundlePath, relativePath: relativeBundlePath, type }) => {
+    if (statSync(bundlePath).size === 0) {
+      throw new Error(`Bundle is empty: ${bundlePath}`);
+    }
+    const relativeSourceMapPath = `${relativeBundlePath}.map`;
+    if (allDeclaredPaths.has(relativeSourceMapPath) && !declaredMapPaths.has(relativeSourceMapPath)) {
+      throw new Error(`Metadata path collides with the required source map: ${relativeSourceMapPath}.`);
+    }
+    if (!existsSync(join(realOutputDir, relativeSourceMapPath))) {
+      const executableLabel = type === 'bundle' ? 'Primary OTA bundle' : 'Metadata-declared executable asset';
+      throw new Error(
+        `${executableLabel} requires an exact adjacent source map at ${relativeSourceMapPath}. ` +
+          'The installed Sentry 7.11 uploader cannot safely group an independently named map.',
+      );
+    }
+    const sourceMapPath = assertRegularFileWithoutSymbolicLinks(realOutputDir, relativeSourceMapPath, 'Source map');
+    if (statSync(sourceMapPath).size === 0) {
+      throw new Error(`Source map is empty: ${sourceMapPath}`);
+    }
+    return {
+      bundlePath,
+      sourceMapPath,
+      relativeBundlePath,
+      relativeSourceMapPath,
+      debugId: readDebugId(sourceMapPath),
+    };
+  });
+}
+
+function stageValidatedArtifacts(artifacts: ValidatedSourceMapArtifact[], stagingDirectory: string): void {
+  const stagedPaths = new Set<string>();
+  for (const artifact of artifacts) {
+    for (const [sourcePath, relativePath] of [
+      [artifact.bundlePath, artifact.relativeBundlePath],
+      [artifact.sourceMapPath, artifact.relativeSourceMapPath],
+    ] as const) {
+      const destinationPath = resolve(stagingDirectory, relativePath);
+      if (!pathIsWithin(stagingDirectory, destinationPath) || stagedPaths.has(destinationPath)) {
+        throw new Error(`Validated source-map staging path collides or escapes: ${relativePath}.`);
+      }
+      stagedPaths.add(destinationPath);
+      mkdirSync(dirname(destinationPath), { recursive: true });
+      copyFileSync(sourcePath, destinationPath);
+    }
+  }
+}
+
+export function resolveInstalledSentryUploader(mobileDirInput: string): string {
+  const mobileDir = realpathSync(resolve(mobileDirInput));
+  const requireFromMobile = createRequire(join(mobileDir, 'package.json'));
+  let sentryPackageJsonPath: string;
+  try {
+    sentryPackageJsonPath = requireFromMobile.resolve('@sentry/react-native/package.json');
+  } catch {
+    throw new Error(
+      `Could not resolve installed @sentry/react-native from ${mobileDir}. Run the workspace install first.`,
+    );
+  }
+  const sentryPackage = parseJsonObject(sentryPackageJsonPath, '@sentry/react-native package.json');
+  if (sentryPackage.version !== SUPPORTED_SENTRY_REACT_NATIVE_VERSION) {
+    throw new Error(
+      `Unsupported @sentry/react-native version ${String(sentryPackage.version)}; expected ${SUPPORTED_SENTRY_REACT_NATIVE_VERSION}.`,
+    );
+  }
+  const packageRoot = realpathSync(dirname(sentryPackageJsonPath));
+  const uploaderPath = join(packageRoot, 'scripts', 'expo-upload-sourcemaps.js');
+  if (!existsSync(uploaderPath) || !statSync(uploaderPath).isFile()) {
+    throw new Error(`Official Sentry Expo source-map uploader is missing: ${uploaderPath}`);
+  }
+  return existingPathWithin(packageRoot, uploaderPath, 'Official Sentry uploader');
+}
+
+export function createSentryUploadEnvironment(environment: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const authToken = environment.SENTRY_AUTH_TOKEN?.trim();
+  if (!authToken) {
+    throw new Error('SENTRY_AUTH_TOKEN is required to upload OTA source maps.');
+  }
+  const uploaderEnvironment: NodeJS.ProcessEnv = {
+    ...environment,
+    SENTRY_AUTH_TOKEN: authToken,
+    SENTRY_ORG: 'boardsesh',
+    SENTRY_PROJECT: 'boardsesh',
+    SENTRY_URL: 'https://sentry.io/',
+  };
+  delete uploaderEnvironment.SENTRY_RELEASE;
+  delete uploaderEnvironment.SENTRY_DIST;
+  delete uploaderEnvironment.SENTRY_CLI_EXECUTABLE;
+  return uploaderEnvironment;
+}
+
+export function uploadMobileSourceMaps(
+  options: UploadSourceMapsOptions,
+  dependencies: UploadSourceMapsDependencies = {},
+): ValidatedSourceMapArtifact[] {
+  const mobileDir = resolve(options.mobileDir ?? DEFAULT_MOBILE_DIR);
+  const outputDir = resolve(options.outputDir ?? join(mobileDir, 'dist'));
+  const uploaderEnvironment = createSentryUploadEnvironment(options.environment ?? process.env);
+  const validatedArtifacts = validateSourceMapOutput(mobileDir, outputDir, options.platform);
+  const uploaderPath = (dependencies.resolveUploader ?? resolveInstalledSentryUploader)(mobileDir);
+  const temporaryRoot = mkdtempSync(join(tmpdir(), 'boardsesh-sentry-upload-'));
+  const temporaryWorkingDirectory = join(temporaryRoot, 'cwd');
+  const stagingDirectory = join(temporaryRoot, 'artifacts');
+
+  console.log(
+    `[mobile:upload-sourcemaps] Uploading ${validatedArtifacts.length} ${options.platform} bundle/map pair(s) by Debug ID.`,
+  );
+  try {
+    mkdirSync(temporaryWorkingDirectory);
+    mkdirSync(stagingDirectory);
+    stageValidatedArtifacts(validatedArtifacts, stagingDirectory);
+    const spawnUploader: SpawnUploader =
+      dependencies.spawnUploader ?? ((executable, args, spawnOptions) => spawnSync(executable, args, spawnOptions));
+    // The wrapper is also invoked with Bun by old-anchor backport workflows, but
+    // Sentry ships this uploader as a Node/CommonJS entrypoint. GitHub runners and
+    // local vp installs provide Node, so keep the uploader runtime explicit and
+    // identical on both paths.
+    const uploadResult = spawnUploader('node', [uploaderPath, stagingDirectory], {
+      cwd: temporaryWorkingDirectory,
+      env: uploaderEnvironment,
+      stdio: 'inherit',
+    });
+    if (uploadResult.error) {
+      throw new Error(`Could not start the official Sentry uploader: ${uploadResult.error.message}`);
+    }
+    if (uploadResult.status !== 0) {
+      throw new Error(`Official Sentry uploader failed with exit code ${uploadResult.status ?? 'unknown'}.`);
+    }
+  } finally {
+    rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+  console.log(`[mobile:upload-sourcemaps] Uploaded ${options.platform} OTA source maps successfully.`);
+  return validatedArtifacts;
+}
+
+export function parseUploadArgs(args: string[]): MobilePlatform {
+  let platform: string | null = null;
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index];
+    if (argument === '--') continue;
+    if (argument === '--platform' || argument === '-p') {
+      platform = args[++index] ?? null;
+      continue;
+    }
+    if (argument.startsWith('--platform=')) {
+      platform = argument.slice('--platform='.length);
+      continue;
+    }
+    throw new Error(`Unknown argument: ${argument}`);
+  }
+  if (platform !== 'ios' && platform !== 'android') {
+    throw new Error('--platform is required and must be either ios or android.');
+  }
+  return platform;
+}
+
+function isMainModule(): boolean {
+  const entryPath = process.argv[1];
+  return Boolean(entryPath) && resolve(entryPath) === fileURLToPath(import.meta.url);
+}
+
+if (isMainModule()) {
+  try {
+    uploadMobileSourceMaps({ platform: parseUploadArgs(process.argv.slice(2)) });
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    console.error(`[mobile:upload-sourcemaps] ${reason}`);
+    process.exitCode = 1;
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -752,6 +752,10 @@ export default defineConfig({
         command: 'tsx scripts/mobile-publish.ts',
         cache: false,
       },
+      'mobile:upload-sourcemaps': {
+        command: 'tsx scripts/mobile-upload-sourcemaps.ts',
+        cache: false,
+      },
       'mobile:ota-setup': {
         command: 'tsx scripts/mobile-ota-setup.ts',
         cache: false,


### PR DESCRIPTION
## Summary

Fixes #4112.

- Ask EOAS/Expo 57 for external source maps for every self-hosted iOS and Android OTA export.
- Validate the requested platform's metadata-declared executable artifacts, exact adjacent maps, and Debug IDs before invoking the pinned official Sentry React Native 7.11 uploader.
- Upload only validated bundle/map pairs from an isolated temporary staging tree, with fixed Boardsesh Sentry scope and no release/dist override.
- Keep production changelog, notification, and health-check cleanup running after an upload failure, then fail the workflow explicitly; backports use the same trusted tooling, while PR previews never receive the Sentry token or upload.
- Ignore Expo-copied public JavaScript that is not declared executable in update metadata. Metadata-declared DOM JavaScript fails closed when Expo's independently hashed map cannot be paired safely.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- Independent high-effort implementation and final QA review; the initial public-WASM artifact blocker was reproduced, remediated, and re-reviewed cleanly
- `vp test run --reporter=agent scripts/mobile-sourcemaps.test.ts scripts/mobile-ci-env-parity.test.ts` (58 focused/parity tests passed)
- Full scripts suite (547 tests passed)
- `vp run typecheck`
- Scoped `vp check` across all eight changed files
- `git diff --check`
- `vp run dev:mobile` confirmed `.boardsesh/qa-notes.md` and Metro startup on port 8082
- No publish, upload, Sentry mutation, or production change was performed; final acceptance requires one real iOS and Android OTA followed by Sentry symbolication verification
