### PR TITLE
fix(mobile): record BLE connection duration

### DIFF
--- a/docs/ui/12-bluetooth.md
+++ b/docs/ui/12-bluetooth.md
@@ -11,14 +11,14 @@ The BLE connection is managed by `useBoardBluetooth` hook and exposed via `Bluet
    - Web: uses Web Bluetooth API (`navigator.bluetooth.requestDevice`).
    - Capacitor (native iOS/Android): uses `react-native-ble-plx` equivalent with a custom `DevicePickerDialog` rendered as a bottom sheet (`Dialog` on web).
 3. **Availability check** -- `adapter.isAvailable()` confirms BLE is supported.
-4. **Existing adapter cleanup** -- if a prior connection exists, emits `Bluetooth Disconnected` event with `reason: 'reconnect'`, then disconnects.
+4. **Existing adapter cleanup** -- on mobile, if a prior adapter exists, ends that generation with `reason: 'user'` and `disconnectTrigger: 'connection_replacement'`, then disconnects it before the new scan.
 5. **Device request and connect** -- `adapter.requestAndConnect(targetSerial)` opens the device picker (OS native on web, custom dialog on Capacitor with RSSI-based signal indicators).
 6. **Device name parsing** -- `parseApiLevel(deviceName)` extracts the Aurora API level from the device name (e.g., `Kilter Board#751737@3` yields API level 3). `parseSerialNumber(deviceName)` extracts the serial (e.g., `751737`).
-7. **Board configuration** -- adapters with a native background writer call `adapter.configureBoard()` with board name, layout ID, size ID, API level, device name, and colour overrides.
-8. **Disconnection listener** -- `adapter.onDisconnect(handleDisconnection)` is registered.
-9. **Initial frames** -- if provided, `sendFramesToBoard(initialFrames, mirrored)` sends the first climb immediately.
+7. **Tracked adapter generation** -- mobile installs the adapter identity and `onDisconnect` listener, then starts one transport lifetime with a snapshot of the full board config (including set IDs) and session state. The connection handle carries that immutable config snapshot, and board presence later attaches its resolved board ID only if that adapter generation is still live.
+8. **Board configuration** -- adapters with a native background writer call `adapter.configureBoard()` with board name, layout ID, size ID, API level, device name, and colour overrides.
+9. **Initial frames** -- if provided, `sendFramesToBoard(initialFrames, mirrored)` sends the first climb immediately. A link drop during this write still ends the generation even though the UI never reached `isConnected: true`.
 10. **Serial recording** -- for Aurora boards, `recordBoardSerial()` POSTs the serial-to-config mapping to `/api/internal/board-serials` for future auto-matching.
-11. **Session serial broadcast** -- `onConnectSuccess(parsedSerial)` fires, which in `BluetoothProvider` calls `setSessionBoardSerial(serial)` if a session is active.
+11. **Session serial broadcast** -- `onConnectSuccess(parsedSerial, connectionHandle)` fires. `BluetoothProvider` resolves the board using the handle's snapshotted config and calls `setSessionBoardSerial(serial)` if a session is active. An unchanged binding returns its cached ID, while same-key reconnects share an in-flight resolve. Ambiguous serial resolution stays pending through the picker choice. This lets the newest generation attach and later release the holder; stale, cancelled, invalidated, and failed resolutions return `null` and cannot populate another config.
 12. **Wake lock** -- `useWakeLock(isConnected)` keeps the screen on while connected.
 
 **Device picker dialog (`DevicePickerDialog`):**
@@ -112,20 +112,22 @@ Long-pressing the lightbulb opens the `LightControlDrawer` (`light-control-drawe
 **User-initiated disconnect (`disconnect` callback):**
 
 - Updates state synchronously for immediate UI feedback.
-- Clears `connectedAtRef`, unsubscribes disconnect listener, nulls adapter ref.
-- Fires `Bluetooth Disconnected` analytics with `reason: 'user'`, `disconnectReason: 'user_initiated'`, and `connectionDurationSec`.
+- Consumes the active adapter generation exactly once, unsubscribes the adapter disconnect listener, and nulls the adapter ref.
+- Fires `Bluetooth Disconnected` analytics with `reason: 'user'`, a low-cardinality `disconnectTrigger` (`explicit_user`, `config_switch`, or `connection_replacement`), and `connectionDurationSec`.
+- Uses the board config and analytics session state captured when that generation started. Its board ID is attached only through the matching generation's guarded resolve, including cached identities for already-bound reconnects, so every holder is released while a config switch still releases the old wall, never the newly rendered route.
+- Calls session wall-disconnect cleanup unconditionally against the current queue session (a no-op in solo). This safely handles a connection that opened solo and joined later, or moved from one session to another; the snapshotted session boolean remains analytics-only.
 
 **Unexpected disconnect (`handleDisconnection` callback):**
 
-- Fires when the adapter reports `gattserverdisconnected`.
-- Only runs on unexpected drops (signal loss, board power-off, OS BLE stack reset) because user-initiated disconnects null the listener first.
-- Fires analytics with `reason: 'lost'`, `disconnectReason: 'gatt_error'`.
+- Fires when native iOS or ble-plx reports a link drop, or when a write failure tears down the connection.
+- Consumes only when both adapter identity and generation match, so duplicate or stale callbacks cannot end a replacement link.
+- Fires analytics with `reason: 'unexpected'`, `disconnectTrigger: 'link_drop'`, the available platform-specific `disconnect*` fields, and the same `connectionDurationSec` lifetime property. Platform fields and `disconnectCategory` are absent from deliberate disconnects.
 
-**Navigation disconnect (unmount cleanup):**
+**Unmount cleanup:**
 
 - Rejects any pending picker promise.
-- If still connected at unmount, fires analytics with `reason: 'navigation'`, `disconnectReason: 'unknown'`.
-- Calls `adapter.disconnect()`.
+- Silently consumes the generation, unsubscribes the adapter disconnect listener, aborts pending writes, and calls `adapter.disconnect()`.
+- Does not emit `Bluetooth Disconnected` for component teardown; tracked mobile disconnects remain `user` or `unexpected`.
 
 **Status store (`bluetooth-status-store.ts`):**
 

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -139,6 +139,7 @@ import {
   moonboardNumRowsForNative,
   resolveWriteSignal,
   useBoardBluetooth,
+  type BleConnectionHandle,
 } from '../use-board-bluetooth';
 import type { BleWriteDiagnostics } from '../types';
 import { reportHandledError } from '../../error-reporting';
@@ -169,6 +170,10 @@ describe('useBoardBluetooth', () => {
     vi.clearAllMocks();
     resetReactNativePermissionHarness();
     mockBleManager.state.mockResolvedValue('PoweredOn');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('shows permission copy and stops before adapter availability when Android BLE permission is denied', async () => {
@@ -1207,6 +1212,142 @@ describe('useBoardBluetooth', () => {
     // The reconnect forwards the device id as the second requestAndConnect arg.
     expect(requestAndConnect.mock.calls.at(-1)).toEqual([undefined, 'moon-abc']);
   });
+
+  it('ends an explicitly disconnected generation exactly once', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
+    const fakeAdapter = makeFakeAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    const onConnectionEnded = vi.fn();
+    const { result } = renderHook(() =>
+      useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1, onConnectionEnded }),
+    );
+
+    await act(async () => {
+      await result.current.connect();
+    });
+    vi.setSystemTime(new Date('2026-08-01T00:00:06.600Z'));
+    await act(async () => {
+      await Promise.all([result.current.disconnect(), result.current.disconnect()]);
+    });
+
+    expect(onConnectionEnded).toHaveBeenCalledOnce();
+    expect(onConnectionEnded).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: 'user',
+        disconnectTrigger: 'explicit_user',
+        connectionDurationSec: 7,
+        boardName: 'kilter',
+      }),
+    );
+    expect(fakeAdapter.disconnect).toHaveBeenCalledOnce();
+  });
+
+  it('attributes adapter replacement to the old generation', async () => {
+    const firstAdapter = makeFakeAdapter();
+    const secondAdapter = makeFakeAdapter({
+      requestAndConnect: vi.fn().mockResolvedValue({ deviceId: 'device-2', deviceName: 'Kilter Board#456@3' }),
+    });
+    vi.mocked(createBluetoothAdapter)
+      .mockReturnValueOnce(firstAdapter as unknown as ReturnType<typeof createBluetoothAdapter>)
+      .mockReturnValueOnce(secondAdapter as unknown as ReturnType<typeof createBluetoothAdapter>);
+    const onConnectionEnded = vi.fn();
+    const onConnectSuccess = vi.fn((_serial: string | null, connection: BleConnectionHandle) => {
+      connection.setAnalyticsBoardId(41);
+    });
+    const { result } = renderHook(() =>
+      useBoardBluetooth({
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 1,
+        onConnectSuccess,
+        onConnectionEnded,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.connect();
+      await result.current.connect();
+    });
+
+    expect(onConnectionEnded).toHaveBeenCalledOnce();
+    expect(onConnectionEnded).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: 'user',
+        disconnectTrigger: 'connection_replacement',
+        boardId: 41,
+      }),
+    );
+    expect(firstAdapter.disconnect).toHaveBeenCalledOnce();
+    expect(result.current.isConnected).toBe(true);
+  });
+
+  it('rejects a generation-one board id that resolves during generation two, then accepts generation two', async () => {
+    const firstAdapter = makeFakeAdapter();
+    const secondAdapter = makeFakeAdapter({
+      requestAndConnect: vi.fn().mockResolvedValue({ deviceId: 'device-2', deviceName: 'Kilter Board#456@3' }),
+    });
+    vi.mocked(createBluetoothAdapter)
+      .mockReturnValueOnce(firstAdapter as unknown as ReturnType<typeof createBluetoothAdapter>)
+      .mockReturnValueOnce(secondAdapter as unknown as ReturnType<typeof createBluetoothAdapter>);
+    const onConnectionEnded = vi.fn();
+    const connectionHandles: BleConnectionHandle[] = [];
+    const onConnectSuccess = vi.fn((_serial: string | null, connection: BleConnectionHandle) => {
+      connectionHandles.push(connection);
+    });
+    const { result } = renderHook(() =>
+      useBoardBluetooth({
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 1,
+        setIds: '1,20',
+        onConnectSuccess,
+        onConnectionEnded,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.connect();
+      await result.current.connect();
+    });
+    expect(connectionHandles).toHaveLength(2);
+    expect(connectionHandles[0]?.generation).not.toBe(connectionHandles[1]?.generation);
+    expect(connectionHandles[0]?.configIdentity).toBe(connectionHandles[1]?.configIdentity);
+    expect(connectionHandles[1]?.config).toEqual({
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 1,
+      setIds: '1,20',
+    });
+    expect(connectionHandles[0]?.setAnalyticsBoardId(41)).toBe(false);
+    expect(connectionHandles[1]?.setAnalyticsBoardId(55)).toBe(true);
+    await act(async () => {
+      await result.current.disconnect();
+    });
+
+    expect(onConnectionEnded).toHaveBeenCalledWith(expect.objectContaining({ boardId: 55 }));
+  });
+
+  it('consumes a live generation silently on unmount', async () => {
+    const fakeAdapter = makeFakeAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    const onConnectionEnded = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1, onConnectionEnded }),
+    );
+
+    await act(async () => {
+      await result.current.connect();
+    });
+    unmount();
+
+    expect(fakeAdapter.disconnect).toHaveBeenCalledOnce();
+    expect(onConnectionEnded).not.toHaveBeenCalled();
+  });
 });
 
 // ── Native connection adoption (iOS) ───────────────────────────────────────
@@ -1239,6 +1380,7 @@ describe('useBoardBluetooth native connection adoption', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.mocked(subscribeNativeBleConnected).mockImplementation(() => null);
     vi.mocked(getNativeBleConnectedDevice).mockImplementation(async () => null);
     vi.mocked(isNativeIosBleAdapter).mockReturnValue(false);
@@ -1336,6 +1478,8 @@ describe('useBoardBluetooth native connection adoption', () => {
   });
 
   it('clears stale adapters after native disconnects so later native connections can be adopted', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
     let firstDisconnectCallback: (() => void) | null = null;
     const firstAdapter = {
       ...makeAdoptableAdapter(),
@@ -1349,17 +1493,43 @@ describe('useBoardBluetooth native connection adoption', () => {
       .mockReturnValueOnce(firstAdapter as unknown as ReturnType<typeof createBluetoothAdapter>)
       .mockReturnValueOnce(secondAdapter as unknown as ReturnType<typeof createBluetoothAdapter>);
 
-    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+    const onConnectionEnded = vi.fn();
+    const onConnectSuccess = vi.fn((_serial: string | null, connection: BleConnectionHandle) => {
+      connection.setAnalyticsBoardId(99);
+    });
+    const { result } = renderHook(() =>
+      useBoardBluetooth({
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 1,
+        setIds: '1,20',
+        analyticsInSession: true,
+        onConnectSuccess,
+        onConnectionEnded,
+      }),
+    );
 
     await act(async () => {
       connectedListener?.({ deviceId: 'native-dev-1', deviceName: 'Kilter Board#9@3' });
     });
     expect(result.current.isConnected).toBe(true);
 
+    vi.setSystemTime(new Date('2026-08-01T00:00:09.600Z'));
     await act(async () => {
       firstDisconnectCallback?.();
     });
     expect(result.current.isConnected).toBe(false);
+    expect(onConnectionEnded).toHaveBeenCalledWith({
+      reason: 'unexpected',
+      disconnectTrigger: 'link_drop',
+      connectionDurationSec: 10,
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 1,
+      setIds: '1,20',
+      boardId: 99,
+      inSession: true,
+    });
 
     await act(async () => {
       connectedListener?.({ deviceId: 'native-dev-2', deviceName: 'Kilter Board#9@3' });
@@ -1367,6 +1537,14 @@ describe('useBoardBluetooth native connection adoption', () => {
 
     expect(secondAdapter.adoptConnection).toHaveBeenCalledWith('native-dev-2');
     expect(result.current.isConnected).toBe(true);
+
+    // A duplicate callback retained by the old native adapter cannot consume or
+    // clear the newly adopted generation.
+    await act(async () => {
+      firstDisconnectCallback?.();
+    });
+    expect(result.current.isConnected).toBe(true);
+    expect(onConnectionEnded).toHaveBeenCalledTimes(1);
   });
 
   it('adopts a nameless native reconnect when it matches the remembered current-board config', async () => {
@@ -1401,7 +1579,14 @@ describe('useBoardBluetooth native connection adoption', () => {
 
     expect(secondAdapter.adoptConnection).toHaveBeenCalledWith('native-dev-2');
     expect(result.current.isConnected).toBe(true);
-    expect(onConnectSuccess).toHaveBeenLastCalledWith('9');
+    expect(onConnectSuccess).toHaveBeenLastCalledWith(
+      '9',
+      expect.objectContaining({
+        generation: 2,
+        config: { boardName: 'kilter', layoutId: 1, sizeId: 1, setIds: undefined },
+        setAnalyticsBoardId: expect.any(Function),
+      }),
+    );
   });
 
   it('does not re-adopt after an explicit disconnect until the next deliberate connect', async () => {
@@ -1455,6 +1640,7 @@ describe('useBoardBluetooth config-switch teardown', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.mocked(subscribeNativeBleConnected).mockImplementation(() => null);
     vi.mocked(getNativeBleConnectedDevice).mockImplementation(async () => null);
     vi.mocked(isNativeIosBleAdapter).mockReturnValue(false);
@@ -1463,13 +1649,27 @@ describe('useBoardBluetooth config-switch teardown', () => {
   });
 
   it('tears down the live connection when the board config switches', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
     const fakeAdapter = makeFakeAdapter();
     vi.mocked(createBluetoothAdapter).mockReturnValue(
       fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
     );
 
+    const onConnectionEnded = vi.fn();
+    const onConnectSuccess = vi.fn((_serial: string | null, connection: BleConnectionHandle) => {
+      connection.setAnalyticsBoardId(41);
+    });
     const { result, rerender } = renderHook((props) => useBoardBluetooth(props), {
-      initialProps: { boardName: 'kilter', layoutId: 1, sizeId: 1 },
+      initialProps: {
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 1,
+        setIds: '1,20',
+        analyticsInSession: true,
+        onConnectSuccess,
+        onConnectionEnded,
+      },
     });
 
     await act(async () => {
@@ -1477,12 +1677,78 @@ describe('useBoardBluetooth config-switch teardown', () => {
     });
     expect(result.current.isConnected).toBe(true);
 
+    vi.setSystemTime(new Date('2026-08-01T00:00:04.600Z'));
     await act(async () => {
-      rerender({ boardName: 'kilter', layoutId: 2, sizeId: 1 });
+      rerender({
+        boardName: 'tension',
+        layoutId: 2,
+        sizeId: 1,
+        setIds: '9',
+        analyticsInSession: false,
+        onConnectSuccess,
+        onConnectionEnded,
+      });
     });
 
     expect(fakeAdapter.disconnect).toHaveBeenCalled();
     expect(result.current.isConnected).toBe(false);
+    expect(onConnectionEnded).toHaveBeenCalledOnce();
+    expect(onConnectionEnded).toHaveBeenCalledWith({
+      reason: 'user',
+      disconnectTrigger: 'config_switch',
+      connectionDurationSec: 5,
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 1,
+      setIds: '1,20',
+      boardId: 41,
+      inSession: true,
+    });
+  });
+
+  it('treats a set-ids-only change as a config switch and preserves the old set attribution', async () => {
+    const fakeAdapter = makeFakeAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    const onConnectionEnded = vi.fn();
+    const onConnectSuccess = vi.fn((_serial: string | null, connection: BleConnectionHandle) => {
+      connection.setAnalyticsBoardId(41);
+    });
+    const { result, rerender } = renderHook((props) => useBoardBluetooth(props), {
+      initialProps: {
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 1,
+        setIds: '1,20',
+        onConnectSuccess,
+        onConnectionEnded,
+      },
+    });
+
+    await act(async () => {
+      await result.current.connect();
+    });
+    await act(async () => {
+      rerender({
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 1,
+        setIds: '9',
+        onConnectSuccess,
+        onConnectionEnded,
+      });
+    });
+
+    expect(result.current.isConnected).toBe(false);
+    expect(onConnectionEnded).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: 'user',
+        disconnectTrigger: 'config_switch',
+        setIds: '1,20',
+        boardId: 41,
+      }),
+    );
   });
 
   it('restores the silent reconnect serial when the config switches back', async () => {
@@ -1579,7 +1845,7 @@ describe('useBoardBluetooth config-switch teardown', () => {
 
   it('defers config-switch teardown until after an in-flight connect completes', async () => {
     // Race: config changes WHILE connect is awaiting requestAndConnect.
-    // adapterRef and connectedConfigKeyRef are both null at that point, so the
+    // adapterRef and connectedConfigIdentityRef are both null at that point, so the
     // config-switch effect must return early. Once the connect resolves and
     // isConnected flips to true the effect re-runs, finds the mismatch, and
     // calls teardown.
@@ -1740,6 +2006,10 @@ describe('useBoardBluetooth connect() initial frame write (#3875)', () => {
     mockBleManager.state.mockResolvedValue('PoweredOn');
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   function mockAuroraSendable() {
     mockGetLedPlacements.mockReturnValue({ 100: 7, 999: 8 });
     mockGetAuroraBluetoothPacket.mockReturnValue({
@@ -1785,6 +2055,8 @@ describe('useBoardBluetooth connect() initial frame write (#3875)', () => {
   });
 
   it('fails the connect when a drop event lands during the initial write (#3875)', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
     // The write itself RESOLVES — the adapter's own disconnect event fires while
     // it is in flight. sendFramesToBoard therefore returns true, so the return
     // value cannot see this at all; only the adapter identity can. If this test
@@ -1798,6 +2070,7 @@ describe('useBoardBluetooth connect() initial frame write (#3875)', () => {
         return () => {};
       }),
       write: vi.fn(async () => {
+        vi.setSystemTime(new Date('2026-08-01T00:00:02.600Z'));
         dropLink?.();
       }),
     };
@@ -1806,7 +2079,18 @@ describe('useBoardBluetooth connect() initial frame write (#3875)', () => {
     );
     mockAuroraSendable();
 
-    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+    const onConnectionEnded = vi.fn();
+    const { result } = renderHook(() =>
+      useBoardBluetooth({
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 1,
+        setIds: '1,20',
+        analyticsBoardId: 99,
+        analyticsInSession: true,
+        onConnectionEnded,
+      }),
+    );
 
     let connected: boolean | undefined;
     await act(async () => {
@@ -1827,6 +2111,25 @@ describe('useBoardBluetooth connect() initial frame write (#3875)', () => {
     // event, but the explicit disconnect is what stops a half-alive native link
     // and the onDeviceDisconnected subscription leaking.
     expect(fakeAdapter.disconnect).toHaveBeenCalled();
+    expect(onConnectionEnded).toHaveBeenCalledOnce();
+    expect(onConnectionEnded).toHaveBeenCalledWith({
+      reason: 'unexpected',
+      disconnectTrigger: 'link_drop',
+      connectionDurationSec: 3,
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 1,
+      setIds: '1,20',
+      inSession: true,
+      disconnectInfo: { source: 'adapter-event' },
+    });
+
+    // The adapter may deliver the same native drop again after explicit cleanup;
+    // the generation has already been consumed.
+    await act(async () => {
+      dropLink?.();
+    });
+    expect(onConnectionEnded).toHaveBeenCalledTimes(1);
   });
 
   it('still connects when the initial climb is incompatible with the board (#3875)', async () => {
@@ -1972,7 +2275,7 @@ describe('useBoardBluetooth connect() initial frame write (#3875)', () => {
   });
 
   it('fails the connect when the board config switches during the initial write (#3875)', async () => {
-    // The guard for commit 1 (connectedConfigKeyRef assigned when the link opens
+    // The guard for commit 1 (connectedConfigIdentityRef assigned when the link opens
     // rather than after the initial send). That move is what makes this path
     // reachable at all: the config-switch effect early-returns while the ref is
     // null, so before it, a board switch landing inside the awaited write left
@@ -2008,7 +2311,7 @@ describe('useBoardBluetooth connect() initial frame write (#3875)', () => {
     });
 
     // Park connect() on the initial write. Only then is adapterRef (and, thanks
-    // to commit 1, connectedConfigKeyRef) set, which is what stops the
+    // to commit 1, connectedConfigIdentityRef) set, which is what stops the
     // config-switch effect early-returning and makes this test non-vacuous.
     let pending: Promise<boolean> | undefined;
     await act(async () => {

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -1245,6 +1245,62 @@ describe('useBoardBluetooth', () => {
     expect(fakeAdapter.disconnect).toHaveBeenCalledOnce();
   });
 
+  it('uses the session state current when a pending connect opens its lifetime', async () => {
+    let resolveConnect!: (connection: { deviceId: string; deviceName?: string }) => void;
+    const fakeAdapter = makeFakeAdapter({
+      requestAndConnect: vi.fn(
+        () =>
+          new Promise<{ deviceId: string; deviceName?: string }>((resolve) => {
+            resolveConnect = resolve;
+          }),
+      ),
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    const onConnectionEnded = vi.fn();
+    const { result, rerender } = renderHook((props) => useBoardBluetooth(props), {
+      initialProps: {
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 1,
+        analyticsInSession: false,
+        onConnectionEnded,
+      },
+    });
+
+    let connectPromise!: Promise<boolean>;
+    await act(async () => {
+      connectPromise = result.current.connect();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      rerender({
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 1,
+        analyticsInSession: true,
+        onConnectionEnded,
+      });
+    });
+
+    await act(async () => {
+      resolveConnect({ deviceId: 'device-1', deviceName: 'Kilter Board#123@3' });
+      await connectPromise;
+      await result.current.disconnect();
+    });
+
+    expect(onConnectionEnded).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: 'user',
+        disconnectTrigger: 'explicit_user',
+        inSession: true,
+      }),
+    );
+  });
+
   it('attributes adapter replacement to the old generation', async () => {
     const firstAdapter = makeFakeAdapter();
     const secondAdapter = makeFakeAdapter({

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -510,6 +510,11 @@ export function useBoardBluetooth({
   const activeConnectionLifetimeRef = useRef<ActiveBleConnectionLifetime | null>(null);
   const onConnectionEndedRef = useRef(onConnectionEnded);
   onConnectionEndedRef.current = onConnectionEnded;
+  // A connect callback can outlive the render which started its asynchronous
+  // adapter request. Read session attribution when that request actually opens
+  // a physical-link generation, rather than from the callback's stale closure.
+  const analyticsInSessionRef = useRef(analyticsInSession);
+  analyticsInSessionRef.current = analyticsInSession;
 
   const beginConnectionLifetime = useCallback(
     (adapter: BluetoothAdapter, generation: number, configIdentity: string) => {
@@ -523,11 +528,11 @@ export function useBoardBluetooth({
           layoutId,
           sizeId,
           setIds,
-          inSession: analyticsInSession,
+          inSession: analyticsInSessionRef.current,
         },
       };
     },
-    [analyticsInSession, boardName, layoutId, setIds, sizeId],
+    [boardName, layoutId, setIds, sizeId],
   );
 
   const createConnectionHandle = useCallback(

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -272,6 +272,50 @@ export type SendFramesToBoard = (
   sendContext?: BleSendContext,
 ) => Promise<boolean | undefined>;
 
+export type BleDisconnectTrigger = 'explicit_user' | 'config_switch' | 'connection_replacement' | 'link_drop';
+
+export type BleConnectionEnded = {
+  reason: 'user' | 'unexpected';
+  disconnectTrigger: BleDisconnectTrigger;
+  connectionDurationSec: number;
+  boardName: string;
+  layoutId?: number;
+  sizeId?: number;
+  setIds?: string;
+  boardId?: number;
+  inSession: boolean;
+  /** Present only for unexpected transport drops. */
+  disconnectInfo?: BleDisconnectInfo;
+};
+
+export type BleConnectionConfigSnapshot = {
+  readonly boardName: string;
+  readonly layoutId?: number;
+  readonly sizeId?: number;
+  readonly setIds?: string;
+};
+
+export type BleConnectionHandle = {
+  generation: number;
+  configIdentity: string;
+  /** Immutable board config captured beside the adapter generation. Consumers
+   * must use this for asynchronous connection work instead of rendered refs. */
+  config: BleConnectionConfigSnapshot;
+  /**
+   * Attach the board-presence ID resolved for this exact connection. Returns
+   * false when the generation/config is stale or a different ID already won.
+   */
+  setAnalyticsBoardId: (boardId: number) => boolean;
+};
+
+type ActiveBleConnectionLifetime = {
+  adapter: BluetoothAdapter;
+  generation: number;
+  configIdentity: string;
+  startedAtMs: number;
+  attribution: Omit<BleConnectionEnded, 'reason' | 'disconnectTrigger' | 'connectionDurationSec' | 'disconnectInfo'>;
+};
+
 type UseBoardBluetoothOptions = {
   boardName?: string;
   layoutId?: number;
@@ -283,18 +327,29 @@ type UseBoardBluetoothOptions = {
   holdsData?: HoldPlacement[];
   ledColorOverrides?: LedColorOverrides;
   analyticsBoardId?: number | null;
+  analyticsInSession?: boolean;
+  onConnectionEnded?: (connection: BleConnectionEnded) => void;
   /** Fired on every connection-state edge. A consumer must tolerate a `false`
    *  with no preceding `true`: when connect()'s initial write kills the link,
    *  the drop teardown fires `false` and connect() then bails before it would
    *  ever have fired `true` (#3875). */
   onConnectionChange?: (connected: boolean) => void;
-  onConnectSuccess?: (serial: string | null) => void;
+  onConnectSuccess?: (serial: string | null, connection: BleConnectionHandle) => void;
   /** Reads whether this connection was made via the mismatch "Connect anyway"
    *  override, attached to connection + send analytics. */
   getConnectedViaMismatchOverride?: () => boolean;
 };
 
 const KEEP_AWAKE_TAG = 'boardsesh-ble';
+
+function connectionConfigIdentity(
+  boardName: string | undefined,
+  layoutId: number | undefined,
+  sizeId: number | undefined,
+  setIds: string | undefined,
+): string {
+  return `${boardName ?? ''}:${layoutId ?? ''}:${sizeId ?? ''}:${setIds ?? ''}`;
+}
 
 /**
  * Create a single AbortSignal that fires when either of the two input signals
@@ -368,6 +423,8 @@ export function useBoardBluetooth({
   holdsData,
   ledColorOverrides,
   analyticsBoardId,
+  analyticsInSession = false,
+  onConnectionEnded,
   onConnectionChange,
   onConnectSuccess,
   getConnectedViaMismatchOverride,
@@ -435,16 +492,103 @@ export function useBoardBluetooth({
   // would otherwise race the in-flight native disconnect and re-establish the
   // connection the user just closed.
   const adoptionSuppressedRef = useRef(false);
-  // The configKey the live connection was established for. Lets the
-  // config-switch effect tell a genuine board/layout/size change (tear down)
-  // from an unrelated re-render (no-op), and is the key cleared on every drop.
-  const connectedConfigKeyRef = useRef<string | null>(null);
+  // Full config identity the live connection was established for. Includes set
+  // IDs so a set-only route switch ends the old attribution generation rather
+  // than allowing its asynchronous board resolve to bleed into the new setup.
+  const connectedConfigIdentityRef = useRef<string | null>(null);
   // What connect() pushed as its initialFrames write, if any. The AutoSender
   // (mounted right after isConnected flips true) reads this one-shot seed so a
   // byte-identical current climb doesn't get re-sent immediately on connect —
   // a redundant full-frame write plus a doubled success haptic.
   const connectInitialSendRef = useRef<{ frames: string; mirrored: boolean; colorSignature: string } | null>(null);
   const configuredDeviceNameRef = useRef<string | undefined>(undefined);
+  // The physical-link lifetime belongs to the adapter generation, not React's
+  // rendered `isConnected` edge. It begins as soon as the adapter identity and
+  // disconnect subscription are installed, before native configuration or the
+  // initial frame write, and is consumed exactly once by a matching end path.
+  const nextConnectionGenerationRef = useRef(0);
+  const activeConnectionLifetimeRef = useRef<ActiveBleConnectionLifetime | null>(null);
+  const onConnectionEndedRef = useRef(onConnectionEnded);
+  onConnectionEndedRef.current = onConnectionEnded;
+
+  const beginConnectionLifetime = useCallback(
+    (adapter: BluetoothAdapter, generation: number, configIdentity: string) => {
+      activeConnectionLifetimeRef.current = {
+        adapter,
+        generation,
+        configIdentity,
+        startedAtMs: Date.now(),
+        attribution: {
+          boardName: boardName ?? '',
+          layoutId,
+          sizeId,
+          setIds,
+          inSession: analyticsInSession,
+        },
+      };
+    },
+    [analyticsInSession, boardName, layoutId, setIds, sizeId],
+  );
+
+  const createConnectionHandle = useCallback(
+    (
+      adapter: BluetoothAdapter,
+      generation: number,
+      configIdentity: string,
+      config: BleConnectionConfigSnapshot,
+    ): BleConnectionHandle => ({
+      generation,
+      configIdentity,
+      config,
+      setAnalyticsBoardId: (boardId: number): boolean => {
+        const lifetime = activeConnectionLifetimeRef.current;
+        if (
+          !lifetime ||
+          lifetime.adapter !== adapter ||
+          lifetime.generation !== generation ||
+          lifetime.configIdentity !== configIdentity
+        ) {
+          return false;
+        }
+        const existingBoardId = lifetime.attribution.boardId;
+        if (existingBoardId !== undefined) {
+          return existingBoardId === boardId;
+        }
+        lifetime.attribution.boardId = boardId;
+        return true;
+      },
+    }),
+    [],
+  );
+
+  const consumeConnectionLifetime = useCallback(
+    (
+      expectedAdapter: BluetoothAdapter,
+      expectedGeneration: number,
+      reason: BleConnectionEnded['reason'],
+      disconnectTrigger: BleDisconnectTrigger,
+      disconnectInfo?: BleDisconnectInfo,
+      notify: boolean = true,
+    ): boolean => {
+      const lifetime = activeConnectionLifetimeRef.current;
+      if (!lifetime || lifetime.adapter !== expectedAdapter || lifetime.generation !== expectedGeneration) {
+        return false;
+      }
+
+      activeConnectionLifetimeRef.current = null;
+      if (notify) {
+        onConnectionEndedRef.current?.({
+          ...lifetime.attribution,
+          reason,
+          disconnectTrigger,
+          connectionDurationSec: Math.max(0, Math.round((Date.now() - lifetime.startedAtMs) / 1000)),
+          ...(reason === 'unexpected' && disconnectInfo ? { disconnectInfo } : {}),
+        });
+      }
+      return true;
+    },
+    [],
+  );
 
   // ledColorOverrides narrowed to string values, shared by the connect and
   // adoption configureBoard calls so both push identical overrides natively.
@@ -508,43 +652,50 @@ export function useBoardBluetooth({
     });
   }, []);
 
-  const clearConnectionAfterDrop = useCallback(() => {
-    unsubDisconnectRef.current?.();
-    unsubDisconnectRef.current = null;
-    const adapter = adapterRef.current;
-    adapterRef.current = null;
-    configuredDeviceNameRef.current = undefined;
-    connectedConfigKeyRef.current = null;
-    writeAbortRef.current?.abort();
-    writeAbortRef.current = null;
-    writeChainRef.current = Promise.resolve();
-    moonboardWriteFailureStreakRef.current = 0;
-    setIsConnected(false);
-    onConnectionChange?.(false);
-    // Drop the connect-time BLE diagnostic tags so a later unrelated error
-    // doesn't carry stale ble_* tags from this (now-dead) connection.
-    clearBleDiagnosticsTags();
-    // Two callers reach here: the adapter's own disconnect event (the adapter
-    // already self-cleaned, so disconnect() is now a no-op), and the
-    // write-failure drop path (isDisconnectionError). In the latter the
-    // RNBleAdapter's onDeviceDisconnected subscription and a possibly half-alive
-    // native link would otherwise leak — dispose explicitly.
-    void adapter?.disconnect().catch(() => {});
-  }, [onConnectionChange]);
-
-  // Stash the most recent drop's reason so the provider's isConnected-transition
-  // effect — which actually fires the `Bluetooth Disconnected` analytics event —
-  // can attach it. Set synchronously here, before clearConnectionAfterDrop flips
-  // isConnected, so it's current when that effect reads it. Reset on a fresh
-  // connect so a later clean transition can't inherit a stale reason.
-  const lastDisconnectInfoRef = useRef<BleDisconnectInfo | null>(null);
+  const clearConnectionAfterDrop = useCallback(
+    (expectedAdapter: BluetoothAdapter, expectedGeneration: number) => {
+      // A callback from a replaced adapter must not tear down the new link.
+      if (adapterRef.current !== expectedAdapter) return;
+      unsubDisconnectRef.current?.();
+      unsubDisconnectRef.current = null;
+      consumeConnectionLifetime(expectedAdapter, expectedGeneration, 'unexpected', 'link_drop');
+      adapterRef.current = null;
+      configuredDeviceNameRef.current = undefined;
+      connectedConfigIdentityRef.current = null;
+      writeAbortRef.current?.abort();
+      writeAbortRef.current = null;
+      writeChainRef.current = Promise.resolve();
+      moonboardWriteFailureStreakRef.current = 0;
+      setIsConnected(false);
+      onConnectionChange?.(false);
+      // Drop the connect-time BLE diagnostic tags so a later unrelated error
+      // doesn't carry stale ble_* tags from this (now-dead) connection.
+      clearBleDiagnosticsTags();
+      // Two callers reach here: the adapter's own disconnect event (the adapter
+      // already self-cleaned, so disconnect() is now a no-op), and the
+      // write-failure drop path (isDisconnectionError). In the latter the
+      // RNBleAdapter's onDeviceDisconnected subscription and a possibly half-alive
+      // native link would otherwise leak — dispose explicitly.
+      void expectedAdapter.disconnect().catch(() => {});
+    },
+    [consumeConnectionLifetime, onConnectionChange],
+  );
 
   const handleDisconnection = useCallback(
-    (info?: BleDisconnectInfo) => {
-      lastDisconnectInfoRef.current = info ?? null;
-      clearConnectionAfterDrop();
+    (expectedAdapter: BluetoothAdapter, expectedGeneration: number, info?: BleDisconnectInfo) => {
+      const lifetime = activeConnectionLifetimeRef.current;
+      if (
+        adapterRef.current !== expectedAdapter ||
+        !lifetime ||
+        lifetime.adapter !== expectedAdapter ||
+        lifetime.generation !== expectedGeneration
+      ) {
+        return;
+      }
+      consumeConnectionLifetime(expectedAdapter, expectedGeneration, 'unexpected', 'link_drop', info);
+      clearConnectionAfterDrop(expectedAdapter, expectedGeneration);
     },
-    [clearConnectionAfterDrop],
+    [clearConnectionAfterDrop, consumeConnectionLifetime],
   );
 
   const sendFramesToBoard = useCallback(
@@ -601,6 +752,7 @@ export function useBoardBluetooth({
         // race that way are exactly the ones whose diagnostics matter. Never
         // let the fetch itself fail an already-settled send.
         let sendAdapter: BluetoothAdapter | null = null;
+        let sendGeneration: number | null = null;
         const fetchWriteDiagnostics = async (): Promise<BleWriteDiagnostics | null> =>
           (await sendAdapter?.getLastWriteDiagnostics?.().catch(() => null)) ?? null;
         try {
@@ -619,6 +771,8 @@ export function useBoardBluetooth({
             return;
           }
           sendAdapter = adapterRef.current;
+          const activeLifetime = activeConnectionLifetimeRef.current;
+          sendGeneration = activeLifetime?.adapter === sendAdapter ? activeLifetime.generation : null;
 
           if (boardName === 'moonboard') {
             const sent = await dispatchMoonboardPacket(
@@ -808,7 +962,9 @@ export function useBoardBluetooth({
             if (lostLink) {
               track(SHARED_EVENTS.BluetoothConnectionStolen, { boardName, layoutId, sizeId });
             }
-            handleDisconnection({ source: 'write-failure' });
+            if (sendAdapter && sendGeneration !== null) {
+              handleDisconnection(sendAdapter, sendGeneration, { source: 'write-failure' });
+            }
           }
           return false;
         } finally {
@@ -896,11 +1052,22 @@ export function useBoardBluetooth({
         // Fresh connection generation — a stale dead-link streak must not carry over.
         moonboardWriteFailureStreakRef.current = 0;
 
-        // Clean up any existing adapter
+        // Clean up any existing adapter. A live link replaced by a new connect
+        // is a deliberate end of the old generation and keeps the old board's
+        // snapshotted attribution.
         if (adapterRef.current) {
+          const previousAdapter = adapterRef.current;
+          const previousLifetime = activeConnectionLifetimeRef.current;
+          if (previousLifetime?.adapter === previousAdapter) {
+            consumeConnectionLifetime(previousAdapter, previousLifetime.generation, 'user', 'connection_replacement');
+          }
           unsubDisconnectRef.current?.();
+          unsubDisconnectRef.current = null;
+          adapterRef.current = null;
+          connectedConfigIdentityRef.current = null;
+          configuredDeviceNameRef.current = undefined;
           try {
-            await adapterRef.current.disconnect();
+            await previousAdapter.disconnect();
           } catch {
             // The previous adapter may already be torn down — e.g. after a
             // write-failure disconnect (another device grabbed the board) the
@@ -924,16 +1091,28 @@ export function useBoardBluetooth({
         apiLevelRef.current = parseApiLevel(connection.deviceName);
         configuredDeviceNameRef.current = connection.deviceName;
 
-        unsubDisconnectRef.current = adapter.onDisconnect(handleDisconnection);
+        const connectionGeneration = nextConnectionGenerationRef.current + 1;
+        nextConnectionGenerationRef.current = connectionGeneration;
         adapterRef.current = adapter;
         // Assigned here, beside adapterRef, rather than after the initial send:
         // the physical link exists from this line on, and the config-switch effect
         // early-returns while this ref is null. Leaving it null across the awaited
-        // initial write meant a board/layout/size change landing in that window
+        // initial write meant a board/layout/size/set change landing in that window
         // couldn't tear the (now-wrong) connection down. Both drop paths
         // (clearConnectionAfterDrop, teardownConnection) already clear it.
-        connectedConfigKeyRef.current =
-          layoutId !== undefined && sizeId !== undefined ? boardConfigKey(boardName, layoutId, sizeId) : null;
+        const connectionConfig = { boardName: boardName ?? '', layoutId, sizeId, setIds };
+        const connectionIdentity = connectionConfigIdentity(boardName, layoutId, sizeId, setIds);
+        connectedConfigIdentityRef.current = connectionIdentity;
+        unsubDisconnectRef.current = adapter.onDisconnect((info) => {
+          handleDisconnection(adapter, connectionGeneration, info);
+        });
+        beginConnectionLifetime(adapter, connectionGeneration, connectionIdentity);
+        const connectionHandle = createConnectionHandle(
+          adapter,
+          connectionGeneration,
+          connectionIdentity,
+          connectionConfig,
+        );
 
         // Push board configuration into the native BoardBleManager so the
         // Dynamic Island widget intent path (next/prev tapped while the app
@@ -1014,9 +1193,9 @@ export function useBoardBluetooth({
         // in board presence that we cannot write to (#3875).
         //
         // A third, non-drop route reaches this bail: the config-switch effect
-        // below. Its deps (boardName/layoutId/sizeId) are route-derived provider
+        // below. Its deps (boardName/layoutId/sizeId/setIds) are route-derived provider
         // state, so navigating to a different board while the awaited write is in
-        // flight re-runs it, and — since connectedConfigKeyRef is now assigned when
+        // flight re-runs it, and — since connectedConfigIdentityRef is assigned when
         // the link opens rather than after this send — it tears the now-stale
         // connection down. Bailing is right (the adapter really is gone), but the
         // alert then reads "move closer" for what was a deliberate switch. Accepted:
@@ -1074,10 +1253,9 @@ export function useBoardBluetooth({
             ? { frames: initialFrames, mirrored: !!mirrored, colorSignature }
             : null;
 
-        lastDisconnectInfoRef.current = null;
         setIsConnected(true);
         onConnectionChange?.(true);
-        onConnectSuccess?.(parsedSerial);
+        onConnectSuccess?.(parsedSerial, connectionHandle);
         // Connect-time BLE write diagnostics (iOS native adapter only; null on
         // Android/web and on binaries too old to report them). Set as global
         // Sentry tags so they ride any later write-stall report, and recorded on
@@ -1209,6 +1387,9 @@ export function useBoardBluetooth({
     },
     [
       handleDisconnection,
+      beginConnectionLifetime,
+      consumeConnectionLifetime,
+      createConnectionHandle,
       boardName,
       layoutId,
       sizeId,
@@ -1228,61 +1409,67 @@ export function useBoardBluetooth({
     ],
   );
 
-  const teardownConnection = useCallback(async () => {
-    // Suppress native-connection adoption until the next deliberate connect:
-    // the native disconnect below is async, so a backgrounding/foregrounding
-    // app could otherwise see getConnectedDevice still report the device this
-    // teardown is closing and silently re-adopt it.
-    adoptionSuppressedRef.current = true;
-    unsubDisconnectRef.current?.();
-    unsubDisconnectRef.current = null;
-    const adapter = adapterRef.current;
-    adapterRef.current = null;
-    configuredDeviceNameRef.current = undefined;
-    connectedConfigKeyRef.current = null;
-    // Cancel every in-flight and queued write of this connection generation,
-    // and unblock the write chain for the next connect.
-    writeAbortRef.current?.abort();
-    writeAbortRef.current = null;
-    writeChainRef.current = Promise.resolve();
-    setIsConnected(false);
-    onConnectionChange?.(false);
-    clearBleDiagnosticsTags();
-    await adapter?.disconnect();
-  }, [onConnectionChange]);
+  const teardownConnection = useCallback(
+    async (disconnectTrigger: Exclude<BleDisconnectTrigger, 'link_drop'>) => {
+      // Suppress native-connection adoption until the next deliberate connect:
+      // the native disconnect below is async, so a backgrounding/foregrounding
+      // app could otherwise see getConnectedDevice still report the device this
+      // teardown is closing and silently re-adopt it.
+      adoptionSuppressedRef.current = true;
+      unsubDisconnectRef.current?.();
+      unsubDisconnectRef.current = null;
+      const adapter = adapterRef.current;
+      const lifetime = activeConnectionLifetimeRef.current;
+      if (adapter && lifetime?.adapter === adapter) {
+        consumeConnectionLifetime(adapter, lifetime.generation, 'user', disconnectTrigger);
+      }
+      adapterRef.current = null;
+      configuredDeviceNameRef.current = undefined;
+      connectedConfigIdentityRef.current = null;
+      // Cancel every in-flight and queued write of this connection generation,
+      // and unblock the write chain for the next connect.
+      writeAbortRef.current?.abort();
+      writeAbortRef.current = null;
+      writeChainRef.current = Promise.resolve();
+      setIsConnected(false);
+      onConnectionChange?.(false);
+      clearBleDiagnosticsTags();
+      await adapter?.disconnect();
+    },
+    [consumeConnectionLifetime, onConnectionChange],
+  );
 
   const disconnect = useCallback(async () => {
     // A deliberate disconnect forgets the board — only an involuntary drop or a
     // config switch keeps the silent same-board reconnect memory alive. Clears
     // the persisted copy too so the next launch doesn't resurrect it.
     forgetConnectedBoard();
-    await teardownConnection();
+    await teardownConnection('explicit_user');
   }, [forgetConnectedBoard, teardownConnection]);
 
   // If the active board config changes while a connection is live, tear it down.
-  // BluetoothProvider is mounted once globally; without this a board/layout/size
+  // BluetoothProvider is mounted once globally; without this a board/layout/size/set
   // switch would keep the old physical link but encode sends with the NEW
   // config's LED placement map — wrong-format packets streamed to the OLD wall.
   useEffect(() => {
-    const connectedKey = connectedConfigKeyRef.current;
-    if (!adapterRef.current || !connectedKey) return;
-    const activeKey =
-      boardName && layoutId !== undefined && sizeId !== undefined ? boardConfigKey(boardName, layoutId, sizeId) : null;
-    if (activeKey === connectedKey) return;
+    const connectedIdentity = connectedConfigIdentityRef.current;
+    if (!adapterRef.current || !connectedIdentity) return;
+    const activeIdentity = connectionConfigIdentity(boardName, layoutId, sizeId, setIds);
+    if (activeIdentity === connectedIdentity) return;
     // teardownConnection sets adoptionSuppressedRef on purpose: the named-device
     // adopt guard is boardType-granular only, so a same-family layout switch
     // (kilter/8/17 -> kilter/8/25) could otherwise race the async native
     // disconnect and re-adopt the old wall. A deliberate connect re-arms
     // adoption. lastConnectedBoard is PRESERVED so switching back offers a silent
     // reconnect (reconnectSerialForCurrentBoard self-guards on configKey).
-    void teardownConnection().catch(() => {});
+    void teardownConnection('config_switch').catch(() => {});
     // isConnected is a dep so a config switch that lands while a connect is
     // still in flight (adapterRef not yet set when this effect last ran) is
     // re-checked the moment the connect completes and flips isConnected.
     // clearConnectionAfterDrop can also race here: if a native drop already
     // nulled adapterRef.current the early-return above prevents a double
     // teardown, which is intentional.
-  }, [boardName, layoutId, sizeId, isConnected, teardownConnection]);
+  }, [boardName, layoutId, sizeId, setIds, isConnected, teardownConnection]);
 
   // iOS-only: adopt a connection the native BoardBleManager established
   // outside JS — the Dynamic Island lightbulb's reconnect-by-last-known-board,
@@ -1310,6 +1497,8 @@ export function useBoardBluetooth({
       // advertisement name.
       const adoptedBoardType = parseAnyBoardTypeFromDeviceName(deviceName);
       const currentConfigKey = boardConfigKey(boardName, layoutId, sizeId);
+      const currentConnectionConfig = { boardName, layoutId, sizeId, setIds };
+      const currentConnectionIdentity = connectionConfigIdentity(boardName, layoutId, sizeId, setIds);
       const rememberedBoard = lastConnectedBoardRef.current;
       const canAdoptNamelessRememberedBoard = !adoptedBoardType && rememberedBoard?.configKey === currentConfigKey;
       if (
@@ -1324,8 +1513,20 @@ export function useBoardBluetooth({
       adapter.adoptConnection(deviceId);
       apiLevelRef.current = parseApiLevel(deviceName);
       configuredDeviceNameRef.current = deviceName;
-      unsubDisconnectRef.current = adapter.onDisconnect(handleDisconnection);
+      const connectionGeneration = nextConnectionGenerationRef.current + 1;
+      nextConnectionGenerationRef.current = connectionGeneration;
       adapterRef.current = adapter;
+      connectedConfigIdentityRef.current = currentConnectionIdentity;
+      unsubDisconnectRef.current = adapter.onDisconnect((info) => {
+        handleDisconnection(adapter, connectionGeneration, info);
+      });
+      beginConnectionLifetime(adapter, connectionGeneration, currentConnectionIdentity);
+      const connectionHandle = createConnectionHandle(
+        adapter,
+        connectionGeneration,
+        currentConnectionIdentity,
+        currentConnectionConfig,
+      );
       void adapter
         .configureBoard({
           boardName,
@@ -1344,11 +1545,9 @@ export function useBoardBluetooth({
       } else if (boardName === 'moonboard') {
         rememberConnectedBoard({ configKey: currentConfigKey, deviceId });
       }
-      connectedConfigKeyRef.current = currentConfigKey;
-      lastDisconnectInfoRef.current = null;
       setIsConnected(true);
       onConnectionChange?.(true);
-      onConnectSuccess?.(serial);
+      onConnectSuccess?.(serial, connectionHandle);
       // Surface this adopted connection's write diagnostics to Sentry too
       // (widget reconnect / state restoration paths, not just JS connect).
       // Fire-and-forget; a native rejection is intentionally ignored.
@@ -1387,8 +1586,11 @@ export function useBoardBluetooth({
     };
   }, [
     boardName,
+    beginConnectionLifetime,
+    createConnectionHandle,
     layoutId,
     sizeId,
+    setIds,
     devicePicker,
     handleDisconnection,
     onConnectionChange,
@@ -1420,12 +1622,10 @@ export function useBoardBluetooth({
   // when nothing is remembered or the user switched boards (in which case the
   // caller opens the device picker instead).
   //
-  // Deliberately keyed on board+layout+size only — NOT set_ids, which web's
-  // boardIdentityKey also folds in. The mobile BluetoothProvider is handed a
-  // single global activeBoard (no set_ids), and the LED placement map keys on
-  // layout+size alone, so a same-board reconnect renders identically regardless
-  // of set_ids. Don't thread set_ids in here without also passing it to the
-  // provider.
+  // Deliberately keyed on board+layout+size only — NOT set_ids, which the tracked
+  // connection identity above does include. Reconnect targeting identifies the
+  // same physical controller and the LED placement map keys on layout+size; the
+  // lifetime still ends on a set-only route switch so attribution cannot bleed.
   const currentConfigKey =
     boardName && layoutId !== undefined && sizeId !== undefined ? boardConfigKey(boardName, layoutId, sizeId) : null;
   // The remembered board only counts while the route still points at the same
@@ -1468,10 +1668,17 @@ export function useBoardBluetooth({
       pickerRejectRef.current?.(new Error('Device selection cancelled'));
       pickerRejectRef.current = null;
       unsubDisconnectRef.current?.();
+      unsubDisconnectRef.current = null;
       writeAbortRef.current?.abort();
-      void adapterRef.current?.disconnect();
+      const adapter = adapterRef.current;
+      const lifetime = activeConnectionLifetimeRef.current;
+      if (adapter && lifetime?.adapter === adapter) {
+        consumeConnectionLifetime(adapter, lifetime.generation, 'user', 'explicit_user', undefined, false);
+      }
+      adapterRef.current = null;
+      void adapter?.disconnect();
     };
-  }, []);
+  }, [consumeConnectionLifetime]);
 
   return {
     isConnected,
@@ -1483,6 +1690,5 @@ export function useBoardBluetooth({
     reconnectSerialForCurrentBoard,
     reconnectDeviceIdForCurrentBoard,
     connectInitialSendRef,
-    lastDisconnectInfoRef,
   };
 }

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -653,12 +653,11 @@ export function useBoardBluetooth({
   }, []);
 
   const clearConnectionAfterDrop = useCallback(
-    (expectedAdapter: BluetoothAdapter, expectedGeneration: number) => {
+    (expectedAdapter: BluetoothAdapter) => {
       // A callback from a replaced adapter must not tear down the new link.
       if (adapterRef.current !== expectedAdapter) return;
       unsubDisconnectRef.current?.();
       unsubDisconnectRef.current = null;
-      consumeConnectionLifetime(expectedAdapter, expectedGeneration, 'unexpected', 'link_drop');
       adapterRef.current = null;
       configuredDeviceNameRef.current = undefined;
       connectedConfigIdentityRef.current = null;
@@ -678,7 +677,7 @@ export function useBoardBluetooth({
       // native link would otherwise leak — dispose explicitly.
       void expectedAdapter.disconnect().catch(() => {});
     },
-    [consumeConnectionLifetime, onConnectionChange],
+    [onConnectionChange],
   );
 
   const handleDisconnection = useCallback(
@@ -693,7 +692,7 @@ export function useBoardBluetooth({
         return;
       }
       consumeConnectionLifetime(expectedAdapter, expectedGeneration, 'unexpected', 'link_drop', info);
-      clearConnectionAfterDrop(expectedAdapter, expectedGeneration);
+      clearConnectionAfterDrop(expectedAdapter);
     },
     [clearConnectionAfterDrop, consumeConnectionLifetime],
   );
@@ -1673,6 +1672,12 @@ export function useBoardBluetooth({
       const adapter = adapterRef.current;
       const lifetime = activeConnectionLifetimeRef.current;
       if (adapter && lifetime?.adapter === adapter) {
+        // A provider unmount is component teardown, not an observed BLE end:
+        // its analytics/presence callback owners are unmounting too. Ordinary
+        // navigation keeps this global provider mounted, while user-triggered
+        // disconnects go through teardownConnection and do notify. Consume this
+        // lifetime silently so the native disconnect callback cannot emit it
+        // later after the subscription and owners are gone.
         consumeConnectionLifetime(adapter, lifetime.generation, 'user', 'explicit_user', undefined, false);
       }
       adapterRef.current = null;

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
@@ -7,7 +7,6 @@ import type { BoardSerialConfig } from '@boardsesh/graphql/operations';
 import type { BoardPresenceClimb, UserBoard } from '@boardsesh/shared-schema';
 import type { ResolvedBoardEntry } from '../../lib/ble/resolve-serials';
 import type { BleConnectionHandle, PickerState } from '../../lib/ble/use-board-bluetooth';
-import type { BleDisconnectInfo } from '../../lib/ble/types';
 
 type BluetoothHookOptions = {
   onConnectSuccess?: (serial: string | null, connection: BleConnectionHandle) => void;
@@ -47,7 +46,6 @@ const bluetooth = vi.hoisted(() => {
       pickerState: null as PickerState | null,
       reconnectSerialForCurrentBoard: null,
       connectInitialSendRef: { current: null as { frames: string; mirrored: boolean; colorSignature: string } | null },
-      lastDisconnectInfoRef: { current: null as BleDisconnectInfo | null },
     },
     useBoardBluetooth: vi.fn((options: BluetoothHookOptions) => {
       mock.options = options;

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
@@ -6,11 +6,11 @@ import type { ClimbQueueItem } from '@boardsesh/queue';
 import type { BoardSerialConfig } from '@boardsesh/graphql/operations';
 import type { BoardPresenceClimb, UserBoard } from '@boardsesh/shared-schema';
 import type { ResolvedBoardEntry } from '../../lib/ble/resolve-serials';
-import type { PickerState } from '../../lib/ble/use-board-bluetooth';
+import type { BleConnectionHandle, PickerState } from '../../lib/ble/use-board-bluetooth';
 import type { BleDisconnectInfo } from '../../lib/ble/types';
 
 type BluetoothHookOptions = {
-  onConnectSuccess?: (serial: string | null) => void;
+  onConnectSuccess?: (serial: string | null, connection: BleConnectionHandle) => void;
   holdsData?: unknown;
 };
 

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -6,16 +6,29 @@ import type { ClimbQueueItem } from '@boardsesh/queue';
 import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
 import type { BoardSerialConfig } from '@boardsesh/graphql/operations';
 import type { ResolvedBoardEntry } from '../../lib/ble/resolve-serials';
-import type { PickerState } from '../../lib/ble/use-board-bluetooth';
-import type { BleDisconnectInfo } from '../../lib/ble/types';
+import type { BleConnectionEnded, BleConnectionHandle, PickerState } from '../../lib/ble/use-board-bluetooth';
 import { setHoldColorOverridesPreference } from '../../lib/hold-color-overrides';
 
 type TestResolvedBoard = { boardId: number };
 
 type BluetoothHookOptions = {
-  onConnectSuccess?: (serial: string | null) => void;
+  onConnectSuccess?: (serial: string | null, connection: BleConnectionHandle) => void;
+  onConnectionEnded?: (connection: BleConnectionEnded) => void;
   holdsData?: unknown;
 };
+
+function makeConnectionHandle(
+  generation: number = 1,
+  setIds: string = '1,20',
+  setAnalyticsBoardId: (boardId: number) => boolean = () => true,
+): BleConnectionHandle {
+  return {
+    generation,
+    configIdentity: `kilter:1:10:${setIds}`,
+    config: { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds },
+    setAnalyticsBoardId,
+  };
+}
 type SendFramesToBoard = (
   frames: string,
   mirrored?: boolean,
@@ -41,7 +54,7 @@ const queue = vi.hoisted(() => ({
   participantId: 'participant-self' as string | null,
   lastConnectedBoardSerial: null as string | null,
   confirmClimbOnWall: vi.fn(async () => {}),
-  reportWallDisconnect: vi.fn(async () => {}),
+  reportWallDisconnect: vi.fn(async (_sessionId?: string | null) => {}),
   setSessionBoardSerial: vi.fn(async () => {}),
 }));
 
@@ -57,7 +70,6 @@ const bluetooth = vi.hoisted(() => {
       pickerState: null as PickerState | null,
       reconnectSerialForCurrentBoard: null,
       connectInitialSendRef: { current: null as { frames: string; mirrored: boolean; colorSignature: string } | null },
-      lastDisconnectInfoRef: { current: null as BleDisconnectInfo | null },
     },
     useBoardBluetooth: vi.fn((options: BluetoothHookOptions) => {
       mock.options = options;
@@ -179,14 +191,17 @@ vi.mock('../queue-provider', () => ({
     state: { currentClimbQueueItem: queue.currentClimbQueueItem, queue: [] },
   }),
   useQueueActions: () => ({ setCurrentClimb: vi.fn() }),
-  useQueueSessionControls: () => ({
-    sessionId: queue.sessionId,
-    participantId: queue.participantId,
-    lastConnectedBoardSerial: queue.lastConnectedBoardSerial,
-    confirmClimbOnWall: queue.confirmClimbOnWall,
-    reportWallDisconnect: queue.reportWallDisconnect,
-    setSessionBoardSerial: queue.setSessionBoardSerial,
-  }),
+  useQueueSessionControls: () => {
+    const activeSessionId = queue.sessionId;
+    return {
+      sessionId: activeSessionId,
+      participantId: queue.participantId,
+      lastConnectedBoardSerial: queue.lastConnectedBoardSerial,
+      confirmClimbOnWall: queue.confirmClimbOnWall,
+      reportWallDisconnect: () => queue.reportWallDisconnect(activeSessionId),
+      setSessionBoardSerial: queue.setSessionBoardSerial,
+    };
+  },
 }));
 
 vi.mock('../toast-provider', () => ({
@@ -294,6 +309,8 @@ describe('BluetoothProvider wall-confirm integration', () => {
     bluetooth.state.loading = false;
     bluetooth.state.pickerState = null;
     bluetooth.state.reconnectSerialForCurrentBoard = null;
+    bluetooth.state.disconnect.mockReset();
+    bluetooth.state.disconnect.mockResolvedValue(undefined);
     bluetooth.state.sendFramesToBoard.mockReset();
     bluetooth.state.sendFramesToBoard.mockResolvedValue(true);
     bluetooth.state.connectInitialSendRef.current = null;
@@ -309,6 +326,8 @@ describe('BluetoothProvider wall-confirm integration', () => {
     presence.resolveAndBindBoardByUuid.mockResolvedValue(null);
     presence.reportClimbForBoard.mockClear();
     presence.reportClimbForBoard.mockResolvedValue(true);
+    presence.reportDisconnectForBoard.mockClear();
+    presence.reportDisconnectForBoard.mockResolvedValue(true);
     presence.showUndoWallChangeSnackbar.mockClear();
     capturedBluetooth = null;
   });
@@ -581,7 +600,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
   it('stores a newly connected board serial on active sessions', () => {
     renderProvider();
 
-    bluetooth.options?.onConnectSuccess?.('SERIAL-1');
+    bluetooth.options?.onConnectSuccess?.('SERIAL-1', makeConnectionHandle());
 
     expect(queue.setSessionBoardSerial).toHaveBeenCalledWith('SERIAL-1');
     expect(analytics.track).toHaveBeenCalledWith('Session Board Serial Set', {
@@ -596,7 +615,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
     queue.sessionId = null;
     renderProvider();
 
-    bluetooth.options?.onConnectSuccess?.('SERIAL-1');
+    bluetooth.options?.onConnectSuccess?.('SERIAL-1', makeConnectionHandle());
     expect(queue.setSessionBoardSerial).not.toHaveBeenCalled();
 
     queue.sessionId = 'session-1';
@@ -604,7 +623,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
     cleanup();
     renderProvider();
 
-    bluetooth.options?.onConnectSuccess?.('SERIAL-1');
+    bluetooth.options?.onConnectSuccess?.('SERIAL-1', makeConnectionHandle());
     expect(queue.setSessionBoardSerial).not.toHaveBeenCalled();
   });
 
@@ -635,7 +654,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
       presence.enabled = true;
       renderProvider();
 
-      bluetooth.options?.onConnectSuccess?.('SERIAL-1');
+      bluetooth.options?.onConnectSuccess?.('SERIAL-1', makeConnectionHandle());
 
       expect(presence.resolveAndBindBoard).toHaveBeenCalledWith({
         serial: 'SERIAL-1',
@@ -646,11 +665,127 @@ describe('BluetoothProvider wall-confirm integration', () => {
       });
     });
 
+    it('resolves against the immutable connection snapshot after the rendered route changes', () => {
+      presence.enabled = true;
+      const connection = makeConnectionHandle();
+      const { rerender } = renderProvider();
+      rerender(
+        createElement(BluetoothProvider, {
+          boardName: 'tension',
+          layoutId: 8,
+          sizeId: 12,
+          setIds: '3,4',
+          children: createElement('div', null),
+        }),
+      );
+
+      act(() => {
+        bluetooth.options?.onConnectSuccess?.('SERIAL-1', connection);
+      });
+
+      expect(presence.resolveAndBindBoard).toHaveBeenCalledWith({
+        serial: 'SERIAL-1',
+        boardType: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,20',
+      });
+    });
+
+    it('attaches a cached board binding to a reconnect generation and releases that holder on disconnect', async () => {
+      presence.enabled = true;
+      presence.boardId = 99;
+      presence.resolveAndBindBoard.mockResolvedValueOnce({ boardId: 99 });
+      bluetooth.state.isConnected = false;
+      let attachedBoardId: number | undefined;
+      const connection = makeConnectionHandle(2, '1,20', (boardId) => {
+        attachedBoardId = boardId;
+        return true;
+      });
+      const { rerender } = renderProvider();
+
+      act(() => {
+        bluetooth.options?.onConnectSuccess?.('SERIAL-1', connection);
+      });
+      await waitFor(() => {
+        expect(attachedBoardId).toBe(99);
+      });
+
+      bluetooth.state.isConnected = true;
+      rerender(
+        createElement(BluetoothProvider, {
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,20',
+          children: createElement('div', null),
+        }),
+      );
+      await waitFor(() => {
+        expect(presence.reportClimbForBoard).toHaveBeenCalledWith(
+          99,
+          { uuid: 'queue-climb-1', climb: { uuid: 'climb-1' } },
+          40,
+        );
+      });
+
+      act(() => {
+        bluetooth.options?.onConnectionEnded?.({
+          reason: 'unexpected',
+          disconnectTrigger: 'link_drop',
+          connectionDurationSec: 8,
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,20',
+          boardId: attachedBoardId,
+          inSession: true,
+        });
+      });
+
+      expect(presence.reportDisconnectForBoard).toHaveBeenCalledWith(99);
+    });
+
+    it('does not attach a rendered board id when the connection resolver returns null', async () => {
+      presence.enabled = true;
+      presence.boardId = 99;
+      let finishResolve: (binding: TestResolvedBoard | null) => void = () => {};
+      presence.resolveAndBindBoard.mockReturnValueOnce(
+        new Promise((resolve) => {
+          finishResolve = resolve;
+        }),
+      );
+      const setAnalyticsBoardId = vi.fn(() => true);
+      renderProvider();
+
+      act(() => {
+        bluetooth.options?.onConnectSuccess?.('DIFFERENT-SERIAL', makeConnectionHandle(2, '1,20', setAnalyticsBoardId));
+      });
+      await act(async () => {
+        finishResolve(null);
+      });
+
+      expect(setAnalyticsBoardId).not.toHaveBeenCalled();
+      act(() => {
+        bluetooth.options?.onConnectionEnded?.({
+          reason: 'unexpected',
+          disconnectTrigger: 'link_drop',
+          connectionDurationSec: 3,
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,20',
+          inSession: false,
+        });
+      });
+      expect(presence.reportDisconnectForBoard).not.toHaveBeenCalled();
+    });
+
     it('does NOT resolve the board on connect when the flag is off', () => {
       presence.enabled = false;
       renderProvider();
 
-      bluetooth.options?.onConnectSuccess?.('SERIAL-1');
+      bluetooth.options?.onConnectSuccess?.('SERIAL-1', makeConnectionHandle());
 
       expect(presence.resolveAndBindBoard).not.toHaveBeenCalled();
     });
@@ -659,7 +794,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
       presence.enabled = true;
       renderProvider();
 
-      bluetooth.options?.onConnectSuccess?.(null);
+      bluetooth.options?.onConnectSuccess?.(null, makeConnectionHandle());
 
       expect(presence.resolveAndBindBoard).not.toHaveBeenCalled();
       expect(presence.resolveAndBindBoardByConfig).toHaveBeenCalledWith({
@@ -692,137 +827,113 @@ describe('BluetoothProvider wall-confirm integration', () => {
       expect(presence.showUndoWallChangeSnackbar).not.toHaveBeenCalled();
     });
 
-    it('attaches the captured disconnect reason to the unexpected-drop analytics event', async () => {
-      // Start connected so the next transition reads as a real drop, not the
-      // initial mount.
-      presence.boardId = 99;
-      bluetooth.state.isConnected = true;
-      bluetooth.state.lastDisconnectInfoRef.current = null;
-
-      const { rerender } = renderProvider(createElement(BluetoothProbe));
-      analytics.track.mockClear();
-
-      // The hook stashes a native-iOS peer-terminated drop (CBError 7 — what a
-      // takeover looks like) just before the link goes down.
-      bluetooth.state.lastDisconnectInfoRef.current = {
-        source: 'native-ios',
-        iosErrorCode: 7,
-        errorDomain: 'CBErrorDomain',
-        description: 'The specified device has disconnected from us.',
-      };
-      bluetooth.state.isConnected = false;
-      rerender(
-        createElement(BluetoothProvider, {
-          boardName: 'kilter',
-          layoutId: 1,
-          sizeId: 10,
-          setIds: '1,20',
-          children: createElement(BluetoothProbe),
-        }),
-      );
-
-      await waitFor(() => {
-        expect(analytics.track).toHaveBeenCalledWith(
-          'Bluetooth Disconnected',
-          expect.objectContaining({
-            reason: 'unexpected',
-            boardId: 99,
-            disconnectSource: 'native-ios',
-            disconnectIosCode: 7,
-            disconnectErrorDomain: 'CBErrorDomain',
-            disconnectReason: 'The specified device has disconnected from us.',
-            disconnectCategory: 'peer_terminated',
-          }),
-        );
-      });
-    });
-
-    it('tags a write-failure drop with disconnectSource write-failure', async () => {
-      bluetooth.state.isConnected = true;
-      bluetooth.state.lastDisconnectInfoRef.current = null;
-
-      const { rerender } = renderProvider(createElement(BluetoothProbe));
-      analytics.track.mockClear();
-
-      // The write-failure path (use-board-bluetooth) stashes this shape before
-      // flipping the link down — no platform codes, just the source.
-      bluetooth.state.lastDisconnectInfoRef.current = { source: 'write-failure' };
-      bluetooth.state.isConnected = false;
-      rerender(
-        createElement(BluetoothProvider, {
-          boardName: 'kilter',
-          layoutId: 1,
-          sizeId: 10,
-          setIds: '1,20',
-          children: createElement(BluetoothProbe),
-        }),
-      );
-
-      await waitFor(() => {
-        expect(analytics.track).toHaveBeenCalledWith(
-          'Bluetooth Disconnected',
-          expect.objectContaining({
-            reason: 'unexpected',
-            disconnectSource: 'write-failure',
-            disconnectCategory: 'write_failure',
-          }),
-        );
-      });
-    });
-
-    it('omits reason fields when no disconnect info was captured', async () => {
-      bluetooth.state.isConnected = true;
-      bluetooth.state.lastDisconnectInfoRef.current = null;
-
-      const { rerender } = renderProvider(createElement(BluetoothProbe));
-      analytics.track.mockClear();
-
-      // Ref stays null (a drop the adapters didn't classify) — the event still
-      // fires, just without any disconnect* reason fields.
-      bluetooth.state.isConnected = false;
-      rerender(
-        createElement(BluetoothProvider, {
-          boardName: 'kilter',
-          layoutId: 1,
-          sizeId: 10,
-          setIds: '1,20',
-          children: createElement(BluetoothProbe),
-        }),
-      );
-
-      await waitFor(() => {
-        expect(analytics.track).toHaveBeenCalledWith(
-          'Bluetooth Disconnected',
-          expect.objectContaining({ reason: 'unexpected' }),
-        );
-      });
-      const disconnectCall = analytics.track.mock.calls.find(([event]) => event === 'Bluetooth Disconnected');
-      expect(disconnectCall?.[1].disconnectSource).toBeUndefined();
-      expect(disconnectCall?.[1].disconnectIosCode).toBeUndefined();
-      // The category is always present on unexpected drops — an unclassifiable
-      // one reads 'unknown' so its share stays measurable in PostHog.
-      expect(disconnectCall?.[1].disconnectCategory).toBe('unknown');
-    });
-
-    it('tags a user-initiated disconnect with the resolved board id', async () => {
-      presence.boardId = 99;
-      bluetooth.state.isConnected = true;
-
+    it('maps an unexpected hook end record to analytics and releases its snapshotted board', () => {
       renderProvider(createElement(BluetoothProbe));
       analytics.track.mockClear();
+      queue.reportWallDisconnect.mockClear();
+      presence.reportDisconnectForBoard.mockClear();
 
-      await act(async () => {
-        await capturedBluetooth?.disconnect();
+      bluetooth.options?.onConnectionEnded?.({
+        reason: 'unexpected',
+        disconnectTrigger: 'link_drop',
+        connectionDurationSec: 151,
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,20',
+        boardId: 99,
+        inSession: true,
+        disconnectInfo: {
+          source: 'native-ios',
+          iosErrorCode: 7,
+          errorDomain: 'CBErrorDomain',
+          description: 'The specified device has disconnected from us.',
+        },
       });
 
-      expect(analytics.track).toHaveBeenCalledWith(
-        'Bluetooth Disconnected',
-        expect.objectContaining({ reason: 'user', boardId: 99 }),
+      expect(queue.reportWallDisconnect).toHaveBeenCalledOnce();
+      expect(presence.reportDisconnectForBoard).toHaveBeenCalledWith(99);
+      expect(analytics.track).toHaveBeenCalledWith('Bluetooth Disconnected', {
+        reason: 'unexpected',
+        disconnectTrigger: 'link_drop',
+        connectionDurationSec: 151,
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,20',
+        boardId: 99,
+        inSession: true,
+        disconnectSource: 'native-ios',
+        disconnectReason: 'The specified device has disconnected from us.',
+        disconnectContext: undefined,
+        disconnectIosCode: 7,
+        disconnectAndroidCode: undefined,
+        disconnectBleCode: undefined,
+        disconnectErrorDomain: 'CBErrorDomain',
+        disconnectCategory: 'peer_terminated',
+      });
+    });
+
+    it('uses old-board attribution for a deliberate config switch and omits transport fields', () => {
+      presence.boardId = 222;
+      renderProvider(createElement(BluetoothProbe));
+      analytics.track.mockClear();
+      presence.reportDisconnectForBoard.mockClear();
+
+      bluetooth.options?.onConnectionEnded?.({
+        reason: 'user',
+        disconnectTrigger: 'config_switch',
+        connectionDurationSec: 12,
+        boardName: 'tension',
+        layoutId: 8,
+        sizeId: 12,
+        setIds: '3,4',
+        boardId: 111,
+        inSession: false,
+      });
+
+      expect(queue.reportWallDisconnect).toHaveBeenCalledWith('session-1');
+      expect(presence.reportDisconnectForBoard).toHaveBeenCalledWith(111);
+      const disconnectProperties = analytics.track.mock.calls.find(
+        ([event]) => event === 'Bluetooth Disconnected',
+      )?.[1];
+      expect(disconnectProperties).toEqual(
+        expect.objectContaining({
+          reason: 'user',
+          disconnectTrigger: 'config_switch',
+          boardName: 'tension',
+          boardId: 111,
+          connectionDurationSec: 12,
+        }),
       );
-      // Deliberate disconnects have nothing to classify — the category is an
-      // unexpected-drop-only field, so queries read its absence as "user chose".
-      const userDisconnectCall = analytics.track.mock.calls.find(([event]) => event === 'Bluetooth Disconnected');
-      expect(userDisconnectCall?.[1].disconnectCategory).toBeUndefined();
+      expect(disconnectProperties).not.toHaveProperty('disconnectCategory');
+      expect(disconnectProperties).not.toHaveProperty('disconnectSource');
+    });
+
+    it('coalesces repeated user disconnects while the adapter teardown is pending', async () => {
+      let resolveAdapterDisconnect: () => void = () => {};
+      bluetooth.state.disconnect.mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolveAdapterDisconnect = resolve;
+        }),
+      );
+      bluetooth.state.isConnected = true;
+      renderProvider(createElement(BluetoothProbe));
+
+      let firstDisconnect: Promise<void> | undefined;
+      let secondDisconnect: Promise<void> | undefined;
+      act(() => {
+        firstDisconnect = capturedBluetooth?.disconnect();
+        secondDisconnect = capturedBluetooth?.disconnect();
+      });
+
+      expect(bluetooth.state.disconnect).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        resolveAdapterDisconnect();
+        await Promise.all([firstDisconnect, secondDisconnect]);
+      });
+      expect(bluetooth.state.disconnect).toHaveBeenCalledTimes(1);
     });
 
     it('shows the Undo snackbar once after an armed control gain reports a wall change', async () => {
@@ -1012,7 +1123,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
       );
 
       const { rerender } = renderProvider();
-      bluetooth.options?.onConnectSuccess?.('SERIAL-PENDING');
+      bluetooth.options?.onConnectSuccess?.('SERIAL-PENDING', makeConnectionHandle());
 
       bluetooth.state.isConnected = true;
       rerender(
@@ -1040,6 +1151,134 @@ describe('BluetoothProvider wall-confirm integration', () => {
       });
     });
 
+    it('ignores a generation-one resolve that lands during generation two, then accepts generation two', async () => {
+      presence.enabled = true;
+      presence.boardId = null;
+      bluetooth.state.isConnected = false;
+      let resolveGenerationOne: (value: { boardId: number }) => void = () => {};
+      let resolveGenerationTwo: (value: { boardId: number }) => void = () => {};
+      presence.resolveAndBindBoard
+        .mockReturnValueOnce(
+          new Promise((resolve) => {
+            resolveGenerationOne = resolve;
+          }),
+        )
+        .mockReturnValueOnce(
+          new Promise((resolve) => {
+            resolveGenerationTwo = resolve;
+          }),
+        );
+      const setGenerationOneBoardId = vi.fn(() => false);
+      const setGenerationTwoBoardId = vi.fn(() => true);
+      const generationOne = makeConnectionHandle(1, '1,20', setGenerationOneBoardId);
+      const generationTwo = makeConnectionHandle(2, '1,20', setGenerationTwoBoardId);
+
+      const { rerender } = renderProvider();
+      bluetooth.options?.onConnectSuccess?.('SERIAL-ONE', generationOne);
+      bluetooth.options?.onConnectSuccess?.('SERIAL-TWO', generationTwo);
+
+      bluetooth.state.isConnected = true;
+      rerender(
+        createElement(BluetoothProvider, {
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,20',
+          children: createElement('div', null),
+        }),
+      );
+      await waitFor(() => {
+        expect(wallConfirm.emitWallConfirm).toHaveBeenCalledWith('climb-1');
+      });
+
+      await act(async () => {
+        resolveGenerationOne({ boardId: 111 });
+      });
+      expect(setGenerationOneBoardId).toHaveBeenCalledWith(111);
+      expect(presence.reportClimbForBoard).not.toHaveBeenCalled();
+
+      await act(async () => {
+        resolveGenerationTwo({ boardId: 222 });
+      });
+      expect(setGenerationTwoBoardId).toHaveBeenCalledWith(222);
+      await waitFor(() => {
+        expect(presence.reportClimbForBoard).toHaveBeenCalledWith(
+          222,
+          { uuid: 'queue-climb-1', climb: { uuid: 'climb-1' } },
+          40,
+        );
+      });
+    });
+
+    it('attaches a shared pending same-wall resolve to generation two and releases its holder', async () => {
+      presence.enabled = true;
+      presence.boardId = null;
+      bluetooth.state.isConnected = false;
+      let resolveSharedBinding: (value: { boardId: number }) => void = () => {};
+      const sharedBindingPromise = new Promise<{ boardId: number }>((resolve) => {
+        resolveSharedBinding = resolve;
+      });
+      presence.resolveAndBindBoard.mockReturnValue(sharedBindingPromise);
+      const setGenerationOneBoardId = vi.fn(() => false);
+      let generationTwoBoardId: number | undefined;
+      const setGenerationTwoBoardId = vi.fn((boardId: number) => {
+        generationTwoBoardId = boardId;
+        return true;
+      });
+      const generationOne = makeConnectionHandle(1, '1,20', setGenerationOneBoardId);
+      const generationTwo = makeConnectionHandle(2, '1,20', setGenerationTwoBoardId);
+
+      const { rerender } = renderProvider();
+      bluetooth.options?.onConnectSuccess?.('SAME-SERIAL', generationOne);
+      bluetooth.options?.onConnectSuccess?.('SAME-SERIAL', generationTwo);
+      expect(presence.resolveAndBindBoard).toHaveBeenCalledTimes(2);
+
+      bluetooth.state.isConnected = true;
+      rerender(
+        createElement(BluetoothProvider, {
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,20',
+          children: createElement('div', null),
+        }),
+      );
+      await waitFor(() => {
+        expect(wallConfirm.emitWallConfirm).toHaveBeenCalledWith('climb-1');
+      });
+      expect(presence.reportClimbForBoard).not.toHaveBeenCalled();
+
+      await act(async () => {
+        resolveSharedBinding({ boardId: 321 });
+      });
+      expect(setGenerationOneBoardId).toHaveBeenCalledWith(321);
+      expect(setGenerationTwoBoardId).toHaveBeenCalledWith(321);
+      await waitFor(() => {
+        expect(presence.reportClimbForBoard).toHaveBeenCalledWith(
+          321,
+          { uuid: 'queue-climb-1', climb: { uuid: 'climb-1' } },
+          40,
+        );
+      });
+
+      presence.reportDisconnectForBoard.mockClear();
+      act(() => {
+        bluetooth.options?.onConnectionEnded?.({
+          reason: 'unexpected',
+          disconnectTrigger: 'link_drop',
+          connectionDurationSec: 6,
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,20',
+          boardId: generationTwoBoardId,
+          inSession: true,
+        });
+      });
+      expect(generationTwoBoardId).toBe(321);
+      expect(presence.reportDisconnectForBoard).toHaveBeenCalledWith(321);
+    });
+
     it('preserves the armed Undo snackbar while a wall report waits for board resolution', async () => {
       presence.enabled = true;
       presence.boardId = null;
@@ -1053,7 +1292,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
       );
 
       const { rerender } = renderProvider(createElement(BluetoothProbe));
-      bluetooth.options?.onConnectSuccess?.('SERIAL-PENDING');
+      bluetooth.options?.onConnectSuccess?.('SERIAL-PENDING', makeConnectionHandle());
       capturedBluetooth?.armUndoWallChangeToast();
 
       bluetooth.state.isConnected = true;
@@ -1093,7 +1332,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
       );
 
       const { rerender } = renderProvider(createElement(BluetoothProbe));
-      bluetooth.options?.onConnectSuccess?.('SERIAL-PENDING');
+      bluetooth.options?.onConnectSuccess?.('SERIAL-PENDING', makeConnectionHandle());
       capturedBluetooth?.armUndoWallChangeToast();
 
       bluetooth.state.isConnected = true;
@@ -1232,7 +1471,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
       presence.resolveAndBindBoard.mockResolvedValueOnce({ boardId: 99 });
       renderProvider();
 
-      bluetooth.options?.onConnectSuccess?.('SERIAL-SECRET-123');
+      bluetooth.options?.onConnectSuccess?.('SERIAL-SECRET-123', makeConnectionHandle());
 
       await waitFor(() => {
         expect(presence.reportClimbForBoard).toHaveBeenCalledTimes(1);
@@ -1291,6 +1530,18 @@ describe('BluetoothProvider wall-confirm integration', () => {
         expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalled();
       });
       queue.reportWallDisconnect.mockClear();
+      bluetooth.state.disconnect.mockImplementation(async () => {
+        bluetooth.options?.onConnectionEnded?.({
+          reason: 'user',
+          disconnectTrigger: 'explicit_user',
+          connectionDurationSec: 4,
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,20',
+          inSession: true,
+        });
+      });
 
       await act(async () => {
         await capturedBluetooth?.disconnect();
@@ -1300,30 +1551,92 @@ describe('BluetoothProvider wall-confirm integration', () => {
     });
 
     it('reports wall disconnect to the session on an unexpected BLE drop', async () => {
-      const { rerender } = renderProvider();
+      renderProvider();
 
       await waitFor(() => {
         expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalled();
       });
       queue.reportWallDisconnect.mockClear();
 
-      // Simulate an involuntary drop: isConnected flips true -> false with no
-      // user-initiated disconnect in flight. The drop effect frees the board
-      // hold and broadcasts WallDisconnected to the session.
-      bluetooth.state.isConnected = false;
-      await act(async () => {
-        rerender(
-          createElement(BluetoothProvider, {
-            boardName: 'kilter',
-            layoutId: 1,
-            sizeId: 10,
-            setIds: '1,20',
-            children: createElement('div', null),
-          }),
-        );
+      act(() => {
+        bluetooth.options?.onConnectionEnded?.({
+          reason: 'unexpected',
+          disconnectTrigger: 'link_drop',
+          connectionDurationSec: 4,
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,20',
+          inSession: true,
+          disconnectInfo: { source: 'ble-plx' },
+        });
       });
 
       expect(queue.reportWallDisconnect).toHaveBeenCalled();
+    });
+
+    it('clears the current session when the BLE connection opened solo and joined later', () => {
+      queue.sessionId = null;
+      const { rerender } = renderProvider();
+      queue.sessionId = 'session-B';
+      rerender(
+        createElement(BluetoothProvider, {
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,20',
+          children: createElement('div', null),
+        }),
+      );
+      queue.reportWallDisconnect.mockClear();
+
+      act(() => {
+        bluetooth.options?.onConnectionEnded?.({
+          reason: 'unexpected',
+          disconnectTrigger: 'link_drop',
+          connectionDurationSec: 8,
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,20',
+          inSession: false,
+        });
+      });
+
+      expect(queue.reportWallDisconnect).toHaveBeenCalledWith('session-B');
+    });
+
+    it('clears session B rather than stale session A after the active session changes', () => {
+      queue.sessionId = 'session-A';
+      const { rerender } = renderProvider();
+      queue.sessionId = 'session-B';
+      rerender(
+        createElement(BluetoothProvider, {
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,20',
+          children: createElement('div', null),
+        }),
+      );
+      queue.reportWallDisconnect.mockClear();
+
+      act(() => {
+        bluetooth.options?.onConnectionEnded?.({
+          reason: 'user',
+          disconnectTrigger: 'explicit_user',
+          connectionDurationSec: 8,
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,20',
+          inSession: true,
+        });
+      });
+
+      expect(queue.reportWallDisconnect).toHaveBeenCalledOnce();
+      expect(queue.reportWallDisconnect).toHaveBeenCalledWith('session-B');
+      expect(queue.reportWallDisconnect).not.toHaveBeenCalledWith('session-A');
     });
   });
 });

--- a/packages/mobile/src/providers/__tests__/board-presence-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/board-presence-provider.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, act, waitFor } from '@testing-library/react';
 import { createElement, useEffect, type ReactNode } from 'react';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
-import type { ClimbQueueItemInput, ResolvedBoard } from '@boardsesh/shared-schema';
+import type { BoardCandidate, ClimbQueueItemInput, ResolvedBoard } from '@boardsesh/shared-schema';
 
 const transport = vi.hoisted(() => ({
   resolveBoardForSerial: vi.fn(
@@ -29,6 +29,14 @@ const sharedProvider = vi.hoisted(() => ({
 // spy — so we can assert the foreground sync and catch-up telemetry wiring.
 const refreshMock = vi.hoisted(() => vi.fn());
 const trackMock = vi.hoisted(() => vi.fn());
+const disambiguationSheet = vi.hoisted(() => ({
+  props: null as {
+    visible: boolean;
+    candidates: BoardCandidate[];
+    onPick: (boardId: number) => void;
+    onCancel: () => void;
+  } | null,
+}));
 // Capture the AppState 'change' handler so a test can fire 'active'/'background'.
 const appState = vi.hoisted(() => {
   const ref: { handler: ((state: string) => void) | null } = { handler: null };
@@ -73,7 +81,10 @@ vi.mock('../../lib/graphql/ws-client', () => ({ getWsClient: () => ({}) }));
 // Keep react-native host components (the disambiguation Modal) out of this
 // jsdom suite — it asserts provider logic, not the picker UI.
 vi.mock('../../components/board-discovery/BoardDisambiguationSheet', () => ({
-  BoardDisambiguationSheet: () => null,
+  BoardDisambiguationSheet: (props: NonNullable<typeof disambiguationSheet.props>) => {
+    disambiguationSheet.props = props;
+    return null;
+  },
 }));
 
 // Capture the boardId handed to the shared provider so we can assert it updates
@@ -96,7 +107,11 @@ vi.mock('@boardsesh/board-presence-react', () => ({
   useBoardPresenceActions: () => ({ refresh: refreshMock }),
 }));
 
-import { MobileBoardPresenceProvider, useBoardPresenceControls } from '../board-presence-provider';
+import {
+  MobileBoardPresenceProvider,
+  useBoardPresenceControls,
+  type BoardBindingIdentity,
+} from '../board-presence-provider';
 
 let capturedControls: ReturnType<typeof useBoardPresenceControls> | null = null;
 function Probe() {
@@ -145,6 +160,7 @@ describe('MobileBoardPresenceProvider', () => {
     refreshMock.mockClear();
     trackMock.mockClear();
     appState.addEventListener.mockClear();
+    disambiguationSheet.props = null;
     capturedControls = null;
   });
 
@@ -194,13 +210,73 @@ describe('MobileBoardPresenceProvider', () => {
     await act(async () => {
       await capturedControls?.resolveAndBindBoard(args);
     });
+    let cachedBinding: BoardBindingIdentity | null | undefined;
     await act(async () => {
-      await capturedControls?.resolveAndBindBoard(args);
+      cachedBinding = await capturedControls?.resolveAndBindBoard(args);
     });
+    expect(cachedBinding).toEqual({ boardId: 42 });
     expect(transport.resolveBoardCandidatesForSerial).toHaveBeenCalledTimes(1);
   });
 
-  it('does not bind a board when the serial maps to several candidates (awaits the pick)', async () => {
+  it('re-resolves the same serial when its board config changes', async () => {
+    renderProvider();
+    const originalArgs = { serial: 'SERIAL-1', boardType: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2' };
+
+    await act(async () => {
+      await capturedControls?.resolveAndBindBoard(originalArgs);
+    });
+    await waitFor(() => {
+      expect(sharedProvider.lastBoardId).toBe(42);
+    });
+
+    transport.resolveBoardCandidatesForSerial.mockResolvedValueOnce({
+      board: { boardId: 45, boardName: 'Reset Wall' },
+      candidates: null,
+    } as unknown as { board: ResolvedBoard | null; candidates: unknown[] | null });
+    let rebound: BoardBindingIdentity | null | undefined;
+    await act(async () => {
+      rebound = await capturedControls?.resolveAndBindBoard({ ...originalArgs, setIds: '3,4' });
+    });
+
+    expect(rebound).toEqual(expect.objectContaining({ boardId: 45 }));
+    expect(transport.resolveBoardCandidatesForSerial).toHaveBeenCalledTimes(2);
+    expect(sharedProvider.lastBoardId).toBe(45);
+  });
+
+  it('shares an in-flight serial+config result with a same-wall reconnect', async () => {
+    let resolveBoard: ((value: { board: ResolvedBoard; candidates: null }) => void) | null = null;
+    transport.resolveBoardCandidatesForSerial.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveBoard = resolve;
+        }),
+    );
+    renderProvider();
+    const args = { serial: 'SERIAL-1', boardType: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2' };
+
+    let firstPromise: Promise<BoardBindingIdentity | null> | undefined;
+    let reconnectPromise: Promise<BoardBindingIdentity | null> | undefined;
+    act(() => {
+      firstPromise = capturedControls?.resolveAndBindBoard(args);
+      reconnectPromise = capturedControls?.resolveAndBindBoard(args);
+    });
+    expect(transport.resolveBoardCandidatesForSerial).toHaveBeenCalledTimes(1);
+
+    let firstBinding: BoardBindingIdentity | null | undefined;
+    let reconnectBinding: BoardBindingIdentity | null | undefined;
+    await act(async () => {
+      resolveBoard?.({
+        board: { boardId: 42, boardName: 'Garage Wall' } as unknown as ResolvedBoard,
+        candidates: null,
+      });
+      [firstBinding, reconnectBinding] = await Promise.all([firstPromise, reconnectPromise]);
+    });
+
+    expect(firstBinding).toEqual({ boardId: 42 });
+    expect(reconnectBinding).toEqual({ boardId: 42 });
+  });
+
+  it('shares an ambiguous serial resolution until the picker binds a board', async () => {
     transport.resolveBoardCandidatesForSerial.mockResolvedValue({
       board: null,
       candidates: [
@@ -210,18 +286,109 @@ describe('MobileBoardPresenceProvider', () => {
     } as unknown as { board: ResolvedBoard | null; candidates: unknown[] | null });
     renderProvider();
 
+    const args = {
+      serial: 'SHARED-SERIAL',
+      boardType: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '1,2',
+    };
+    let firstPromise: Promise<BoardBindingIdentity | null> | undefined;
+    let reconnectPromise: Promise<BoardBindingIdentity | null> | undefined;
+    act(() => {
+      firstPromise = capturedControls?.resolveAndBindBoard(args);
+    });
+    await waitFor(() => {
+      expect(disambiguationSheet.props?.visible).toBe(true);
+    });
+    act(() => {
+      reconnectPromise = capturedControls?.resolveAndBindBoard(args);
+    });
+    expect(transport.resolveBoardCandidatesForSerial).toHaveBeenCalledTimes(1);
+
+    let firstBinding: BoardBindingIdentity | null | undefined;
+    let reconnectBinding: BoardBindingIdentity | null | undefined;
     await act(async () => {
-      const resolved = await capturedControls?.resolveAndBindBoard({
+      disambiguationSheet.props?.onPick(2);
+      [firstBinding, reconnectBinding] = await Promise.all([firstPromise, reconnectPromise]);
+    });
+
+    expect(transport.chooseBoardForSerial).toHaveBeenCalledWith({ boardId: 2, serial: 'SHARED-SERIAL' });
+    expect(firstBinding).toEqual({ boardId: 77 });
+    expect(reconnectBinding).toEqual({ boardId: 77 });
+    expect(sharedProvider.lastBoardId).toBe(77);
+  });
+
+  it('settles an ambiguous serial resolution with null when the picker is cancelled', async () => {
+    transport.resolveBoardCandidatesForSerial.mockResolvedValue({
+      board: null,
+      candidates: [
+        { boardId: 1, boardUuid: 'a', boardName: 'Home', boardType: 'kilter', isOwnedByMe: true, isPublic: false },
+      ],
+    } as unknown as { board: ResolvedBoard | null; candidates: unknown[] | null });
+    renderProvider();
+
+    let bindingPromise: Promise<BoardBindingIdentity | null> | undefined;
+    act(() => {
+      bindingPromise = capturedControls?.resolveAndBindBoard({
         serial: 'SHARED-SERIAL',
         boardType: 'kilter',
         layoutId: 1,
         sizeId: 10,
         setIds: '1,2',
       });
-      // Ambiguous → no board bound yet; the user must pick via the prompt.
-      expect(resolved).toBeNull();
     });
+    await waitFor(() => {
+      expect(disambiguationSheet.props?.visible).toBe(true);
+    });
+
+    let binding: BoardBindingIdentity | null | undefined;
+    await act(async () => {
+      disambiguationSheet.props?.onCancel();
+      binding = await bindingPromise;
+    });
+
+    expect(binding).toBeNull();
     expect(sharedProvider.lastBoardId).toBeNull();
+    expect(disambiguationSheet.props?.visible).toBe(false);
+  });
+
+  it('invalidates an ambiguous serial deferred when a different binding key starts', async () => {
+    transport.resolveBoardCandidatesForSerial.mockResolvedValue({
+      board: null,
+      candidates: [
+        { boardId: 1, boardUuid: 'a', boardName: 'Home', boardType: 'kilter', isOwnedByMe: true, isPublic: false },
+      ],
+    } as unknown as { board: ResolvedBoard | null; candidates: unknown[] | null });
+    renderProvider();
+
+    let serialPromise: Promise<BoardBindingIdentity | null> | undefined;
+    act(() => {
+      serialPromise = capturedControls?.resolveAndBindBoard({
+        serial: 'SHARED-SERIAL',
+        boardType: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,2',
+      });
+    });
+    await waitFor(() => {
+      expect(disambiguationSheet.props?.visible).toBe(true);
+    });
+
+    let uuidBinding: BoardBindingIdentity | null | undefined;
+    let serialBinding: BoardBindingIdentity | null | undefined;
+    await act(async () => {
+      const uuidPromise = capturedControls?.resolveAndBindBoardByUuid({
+        boardUuid: '11111111-1111-4111-8111-111111111111',
+      });
+      [serialBinding, uuidBinding] = await Promise.all([serialPromise, uuidPromise]);
+    });
+
+    expect(serialBinding).toBeNull();
+    expect(uuidBinding).toEqual({ boardId: 44 });
+    expect(disambiguationSheet.props?.visible).toBe(false);
+    expect(sharedProvider.lastBoardId).toBe(44);
   });
 
   it('resolves+binds by config when no serial is available', async () => {
@@ -266,7 +433,27 @@ describe('MobileBoardPresenceProvider', () => {
     });
   });
 
-  it('does not start a second uuid resolve while the same uuid is pending', async () => {
+  it('returns the cached board identity without re-resolving an unchanged uuid', async () => {
+    renderProvider();
+    const args = { boardUuid: '11111111-1111-4111-8111-111111111111' };
+
+    await act(async () => {
+      await capturedControls?.resolveAndBindBoardByUuid(args);
+    });
+    await waitFor(() => {
+      expect(sharedProvider.lastBoardId).toBe(44);
+    });
+
+    let cachedBinding: BoardBindingIdentity | null | undefined;
+    await act(async () => {
+      cachedBinding = await capturedControls?.resolveAndBindBoardByUuid(args);
+    });
+
+    expect(cachedBinding).toEqual({ boardId: 44 });
+    expect(transport.resolveBoardForUuid).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares the in-flight result without starting a second uuid resolve', async () => {
     let resolveBoard: ((value: ResolvedBoard) => void) | null = null;
     transport.resolveBoardForUuid.mockImplementationOnce(
       () =>
@@ -276,27 +463,30 @@ describe('MobileBoardPresenceProvider', () => {
     );
     renderProvider();
 
-    let firstPromise: Promise<ResolvedBoard | null> | undefined;
+    let firstPromise: Promise<BoardBindingIdentity | null> | undefined;
     act(() => {
       firstPromise = capturedControls?.resolveAndBindBoardByUuid({
         boardUuid: '11111111-1111-4111-8111-111111111111',
       });
     });
 
-    let secondResult: ResolvedBoard | null | undefined;
-    await act(async () => {
-      secondResult = await capturedControls?.resolveAndBindBoardByUuid({
+    let secondPromise: Promise<BoardBindingIdentity | null> | undefined;
+    act(() => {
+      secondPromise = capturedControls?.resolveAndBindBoardByUuid({
         boardUuid: '11111111-1111-4111-8111-111111111111',
       });
     });
 
-    expect(secondResult).toBeNull();
     expect(transport.resolveBoardForUuid).toHaveBeenCalledTimes(1);
 
+    let firstResult: BoardBindingIdentity | null | undefined;
+    let secondResult: BoardBindingIdentity | null | undefined;
     await act(async () => {
       resolveBoard?.({ boardId: 44, boardName: 'Named Board' } as unknown as ResolvedBoard);
-      await firstPromise;
+      [firstResult, secondResult] = await Promise.all([firstPromise, secondPromise]);
     });
+    expect(firstResult).toEqual({ boardId: 44 });
+    expect(secondResult).toEqual({ boardId: 44 });
     await waitFor(() => {
       expect(sharedProvider.lastBoardId).toBe(44);
     });
@@ -320,9 +510,39 @@ describe('MobileBoardPresenceProvider', () => {
 
     await act(async () => {
       const resolved = await capturedControls?.resolveAndBindBoardByConfig(args);
-      expect(resolved).toBeNull();
+      expect(resolved).toEqual({ boardId: 43 });
     });
     expect(transport.resolveBoardForConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares an in-flight config result with a same-wall reconnect', async () => {
+    let resolveBoard: ((value: ResolvedBoard) => void) | null = null;
+    transport.resolveBoardForConfig.mockImplementationOnce(
+      () =>
+        new Promise<ResolvedBoard>((resolve) => {
+          resolveBoard = resolve;
+        }),
+    );
+    renderProvider();
+    const args = { boardType: 'moonboard', layoutId: 1, sizeId: 1, setIds: '2019' };
+
+    let firstPromise: Promise<BoardBindingIdentity | null> | undefined;
+    let reconnectPromise: Promise<BoardBindingIdentity | null> | undefined;
+    act(() => {
+      firstPromise = capturedControls?.resolveAndBindBoardByConfig(args);
+      reconnectPromise = capturedControls?.resolveAndBindBoardByConfig(args);
+    });
+    expect(transport.resolveBoardForConfig).toHaveBeenCalledTimes(1);
+
+    let firstBinding: BoardBindingIdentity | null | undefined;
+    let reconnectBinding: BoardBindingIdentity | null | undefined;
+    await act(async () => {
+      resolveBoard?.({ boardId: 43, boardName: 'MoonBoard 40' } as unknown as ResolvedBoard);
+      [firstBinding, reconnectBinding] = await Promise.all([firstPromise, reconnectPromise]);
+    });
+
+    expect(firstBinding).toEqual({ boardId: 43 });
+    expect(reconnectBinding).toEqual({ boardId: 43 });
   });
 
   it('ignores stale config resolve results after a newer selected config resolves', async () => {
@@ -341,8 +561,8 @@ describe('MobileBoardPresenceProvider', () => {
     );
     renderProvider();
 
-    let firstPromise: Promise<ResolvedBoard | null> | undefined;
-    let secondPromise: Promise<ResolvedBoard | null> | undefined;
+    let firstPromise: Promise<BoardBindingIdentity | null> | undefined;
+    let secondPromise: Promise<BoardBindingIdentity | null> | undefined;
     act(() => {
       firstPromise = capturedControls?.resolveAndBindBoardByConfig({
         boardType: 'moonboard',
@@ -358,6 +578,12 @@ describe('MobileBoardPresenceProvider', () => {
       });
     });
 
+    let invalidatedFirstResult: BoardBindingIdentity | null | undefined;
+    await act(async () => {
+      invalidatedFirstResult = await firstPromise;
+    });
+    expect(invalidatedFirstResult).toBeNull();
+
     await act(async () => {
       resolveSecond?.({ boardId: 44, boardName: 'Kilter' } as unknown as ResolvedBoard);
       await secondPromise;
@@ -366,7 +592,7 @@ describe('MobileBoardPresenceProvider', () => {
       expect(sharedProvider.lastBoardId).toBe(44);
     });
 
-    let firstResult: ResolvedBoard | null | undefined;
+    let firstResult: BoardBindingIdentity | null | undefined;
     await act(async () => {
       resolveFirst?.({ boardId: 43, boardName: 'MoonBoard 40' } as unknown as ResolvedBoard);
       firstResult = await firstPromise;
@@ -374,6 +600,39 @@ describe('MobileBoardPresenceProvider', () => {
 
     expect(firstResult).toBeNull();
     expect(sharedProvider.lastBoardId).toBe(44);
+  });
+
+  it('settles a pending resolution with null on reset and ignores its late result', async () => {
+    let resolveBoard: ((value: ResolvedBoard) => void) | null = null;
+    transport.resolveBoardForConfig.mockImplementationOnce(
+      () =>
+        new Promise<ResolvedBoard>((resolve) => {
+          resolveBoard = resolve;
+        }),
+    );
+    renderProvider();
+
+    let bindingPromise: Promise<BoardBindingIdentity | null> | undefined;
+    act(() => {
+      bindingPromise = capturedControls?.resolveAndBindBoardByConfig({
+        boardType: 'moonboard',
+        layoutId: 1,
+        sizeId: 1,
+        setIds: '2019',
+      });
+      capturedControls?.resetPresence();
+    });
+
+    let binding: BoardBindingIdentity | null | undefined;
+    await act(async () => {
+      binding = await bindingPromise;
+    });
+    expect(binding).toBeNull();
+
+    await act(async () => {
+      resolveBoard?.({ boardId: 43, boardName: 'Late MoonBoard' } as unknown as ResolvedBoard);
+    });
+    expect(sharedProvider.lastBoardId).toBeNull();
   });
 
   it('clears the bound board while a different uuid resolve is pending', async () => {
@@ -423,7 +682,7 @@ describe('MobileBoardPresenceProvider', () => {
     );
     renderProvider();
 
-    let serialPromise: Promise<ResolvedBoard | null> | undefined;
+    let serialPromise: Promise<BoardBindingIdentity | null> | undefined;
     await act(async () => {
       serialPromise = capturedControls?.resolveAndBindBoard({
         serial: 'SERIAL-1',
@@ -440,7 +699,7 @@ describe('MobileBoardPresenceProvider', () => {
       expect(sharedProvider.lastBoardId).toBe(44);
     });
 
-    let serialResult: ResolvedBoard | null | undefined;
+    let serialResult: BoardBindingIdentity | null | undefined;
     await act(async () => {
       resolveSerial?.({ boardId: 42, boardName: 'Serial Board' } as unknown as ResolvedBoard);
       serialResult = await serialPromise;

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -15,7 +15,13 @@ import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { useBoardPresenceCurrent } from '@boardsesh/board-presence-react';
 import type { BoardPresenceClimb, ClimbQueueItemInput } from '@boardsesh/shared-schema';
 import { emitWallConfirm } from '@boardsesh/play-view';
-import { useBoardBluetooth, boardConfigKey, type SendFramesToBoard } from '../lib/ble/use-board-bluetooth';
+import {
+  useBoardBluetooth,
+  boardConfigKey,
+  type BleConnectionHandle,
+  type BleConnectionEnded,
+  type SendFramesToBoard,
+} from '../lib/ble/use-board-bluetooth';
 import { hasRenderableFrames } from '../lib/ble/renderable-frames';
 import { useResolvedBleDeviceBoards } from '../lib/ble/resolve-serials';
 import { classifyBleDisconnect } from '../lib/ble/disconnect-category';
@@ -513,16 +519,15 @@ export function BluetoothProvider({
     [holdColorSignature],
   );
 
-  // Mirror the board config props so the empty-dep-ish connect callback resolves
-  // the serial against the board currently in view without churning identity.
+  // Mirror the rendered board config for identity-stable send/skip analytics.
+  // Connection resolution uses BleConnectionHandle.config instead (the exact
+  // adapter-generation snapshot), never these mutable route refs.
   const boardNameRef = useRef(boardName);
   boardNameRef.current = boardName;
   const layoutIdRef = useRef(layoutId);
   layoutIdRef.current = layoutId;
   const sizeIdRef = useRef(sizeId);
   sizeIdRef.current = sizeId;
-  const setIdsRef = useRef(setIds);
-  setIdsRef.current = setIds;
   const sessionIdRef = useRef(sessionId);
   useEffect(() => {
     sessionIdRef.current = sessionId;
@@ -563,6 +568,7 @@ export function BluetoothProvider({
   const pendingReportSignatureRef = useRef<string | null>(null);
   const pendingWallReportRef = useRef<PendingWallReport | null>(null);
   const pendingPresenceResolveRef = useRef(false);
+  const pendingPresenceResolveConnectionRef = useRef<BleConnectionHandle | null>(null);
   const resolvedPresenceBoardIdRef = useRef<number | null>(presenceBoardId);
   const undoWallChangeTargetRef = useRef<BoardPresenceClimb | null>(null);
   const previousPresenceBoardIdRef = useRef<number | null>(presenceBoardId);
@@ -754,7 +760,7 @@ export function BluetoothProvider({
   );
 
   const handleConnectSuccess = useCallback(
-    (serial: string | null) => {
+    (serial: string | null, connection: BleConnectionHandle) => {
       lastAcceptedReportSignatureRef.current = null;
       lastAcceptedWallSignatureRef.current = null;
       pendingReportSignatureRef.current = null;
@@ -762,16 +768,22 @@ export function BluetoothProvider({
       undoWallChangeTargetRef.current = null;
       resolvedPresenceBoardIdRef.current = null;
 
-      const boardType = boardNameRef.current;
-      const layoutId = layoutIdRef.current;
-      const sizeId = sizeIdRef.current;
-      const setIds = setIdsRef.current ?? '';
+      // Resolver arguments come from the immutable adapter-generation snapshot,
+      // never mutable route refs. A route/config change can render while a
+      // connect is completing; its board identity must not be assigned to the
+      // older physical link.
+      const { boardName: boardType, layoutId, sizeId, setIds: connectionSetIds } = connection.config;
+      const setIds = connectionSetIds ?? '';
 
       // Resolve+bind the shared board so the wall feed subscribes. Aurora uses
       // its controller serial; serial-less boards use the per-config fallback
-      // when the backend supports it. This is independent of party sessions.
+      // when the backend supports it. An unchanged binding returns its cached
+      // identity instead of resolving over the network, because every new BLE
+      // generation still needs to attach that board ID for holder release.
+      // This is independent of party sessions.
       if (presenceEnabledRef.current && boardType && layoutId != null && layoutId > 0 && sizeId != null && sizeId > 0) {
         pendingPresenceResolveRef.current = true;
+        pendingPresenceResolveConnectionRef.current = connection;
         const resolvePromise =
           serial && serial.length > 0
             ? resolveAndBindBoard({ serial, boardType, layoutId, sizeId, setIds })
@@ -779,6 +791,11 @@ export function BluetoothProvider({
         void resolvePromise
           .then((resolved) => {
             if (!resolved) return;
+            // The resolver belongs to the generation that initiated it. An old
+            // controller can resolve after a replacement connection with the
+            // same layout/size; its guarded handle rejects the stale ID without
+            // occupying the new generation's still-empty attribution slot.
+            if (!connection.setAnalyticsBoardId(resolved.boardId)) return;
             resolvedPresenceBoardIdRef.current = resolved.boardId;
             replayPendingWallReport(resolved.boardId);
           })
@@ -786,7 +803,10 @@ export function BluetoothProvider({
             console.warn('[board-presence] board resolve failed', error);
           })
           .finally(() => {
-            pendingPresenceResolveRef.current = false;
+            if (pendingPresenceResolveConnectionRef.current === connection) {
+              pendingPresenceResolveConnectionRef.current = null;
+              pendingPresenceResolveRef.current = false;
+            }
           });
       }
 
@@ -798,11 +818,11 @@ export function BluetoothProvider({
       track('Session Board Serial Set', {
         mode: 'party',
         previousSerialKnown: previousSerial != null,
-        boardLayout: boardName ?? '',
+        boardLayout: boardType,
         boardId: resolvedPresenceBoardIdRef.current ?? presenceBoardIdRef.current ?? undefined,
       });
     },
-    [boardName, setSessionBoardSerial, resolveAndBindBoard, resolveAndBindBoardByConfig, replayPendingWallReport],
+    [setSessionBoardSerial, resolveAndBindBoard, resolveAndBindBoardByConfig, replayPendingWallReport],
   );
 
   // Hold placements for the active board, required by the hook's
@@ -830,6 +850,57 @@ export function BluetoothProvider({
   // and send analytics without re-creating its callbacks when the flag flips.
   const getConnectedViaMismatchOverride = useCallback(() => connectedViaMismatchOverrideRef.current, []);
 
+  // The BLE hook owns the physical adapter lifetime and hands us the attribution
+  // captured when that exact generation opened. Release and analytics must use
+  // that snapshot: the provider may already be rendering a different route by
+  // the time a config-switch teardown completes.
+  const handleBluetoothConnectionEnded = useCallback(
+    (connection: BleConnectionEnded) => {
+      clearPendingWallReportAndUndoToastArm();
+      connectedViaMismatchOverrideRef.current = false;
+
+      // reportWallDisconnect targets the queue provider's CURRENT session and
+      // is a no-op in solo. Calling it unconditionally avoids skipping cleanup
+      // when a connection opened solo and later joined, and avoids pretending
+      // the snapshotted analytics boolean identifies a mutable session.
+      void reportWallDisconnectRef.current();
+      if (connection.boardId !== undefined) {
+        void reportDisconnectForBoardRef.current(connection.boardId);
+      }
+
+      const commonProperties = {
+        boardName: connection.boardName,
+        layoutId: connection.layoutId,
+        sizeId: connection.sizeId,
+        setIds: connection.setIds,
+        boardId: connection.boardId,
+        reason: connection.reason,
+        disconnectTrigger: connection.disconnectTrigger,
+        inSession: connection.inSession,
+        connectionDurationSec: connection.connectionDurationSec,
+      };
+
+      if (connection.reason === 'unexpected') {
+        const disconnectInfo = connection.disconnectInfo;
+        track(SHARED_EVENTS.BluetoothDisconnected, {
+          ...commonProperties,
+          disconnectSource: disconnectInfo?.source,
+          disconnectReason: disconnectInfo?.description,
+          disconnectContext: disconnectInfo?.context,
+          disconnectIosCode: disconnectInfo?.iosErrorCode,
+          disconnectAndroidCode: disconnectInfo?.androidErrorCode,
+          disconnectBleCode: disconnectInfo?.bleErrorCode,
+          disconnectErrorDomain: disconnectInfo?.errorDomain,
+          disconnectCategory: classifyBleDisconnect(disconnectInfo),
+        });
+        return;
+      }
+
+      track(SHARED_EVENTS.BluetoothDisconnected, commonProperties);
+    },
+    [clearPendingWallReportAndUndoToastArm],
+  );
+
   const {
     isConnected,
     loading,
@@ -840,7 +911,6 @@ export function BluetoothProvider({
     reconnectSerialForCurrentBoard,
     reconnectDeviceIdForCurrentBoard,
     connectInitialSendRef,
-    lastDisconnectInfoRef,
   } = useBoardBluetooth({
     boardName,
     layoutId,
@@ -848,9 +918,11 @@ export function BluetoothProvider({
     setIds,
     boardUuid,
     holdsData,
-    analyticsBoardId: presenceBoardId,
+    analyticsBoardId: resolvedPresenceBoardIdRef.current ?? presenceBoardId,
+    analyticsInSession: sessionIdRef.current != null,
     ledColorOverrides: bluetoothColorOverrides,
     onConnectSuccess: handleConnectSuccess,
+    onConnectionEnded: handleBluetoothConnectionEnded,
     getConnectedViaMismatchOverride,
   });
 
@@ -1285,50 +1357,35 @@ export function BluetoothProvider({
   const [reassertNonce, setReassertNonce] = useState(0);
   const reassertWall = useCallback(() => setReassertNonce((nonce) => nonce + 1), []);
 
-  // Detect an unexpected drop (connected → disconnected without a user-initiated
-  // disconnect) for telemetry only. `isUserDisconnectRef` suppresses deliberate ones.
-  const wasConnectedRef = useRef(false);
-  const isUserDisconnectRef = useRef(false);
+  const disconnectInFlightRef = useRef<Promise<void> | null>(null);
 
-  // Free this client's board-connection hold when the BLE link goes down (the
-  // holder = last sender, so a disconnect means we're no longer writing the
-  // wall). Best-effort and idempotent: the server clear is a compare-and-delete,
-  // so it's a no-op once another phone took over (last-connection-wins). The
-  // binding stays so a reconnect re-takes. Also broadcast the session-scoped
-  // WallDisconnected so every member's lightbulb clears (the current climb is
-  // preserved); a true no-op in solo (reportWallDisconnect no-ops without a
-  // session), so it's safe to fire unconditionally on any drop.
-  const releaseBoardHolder = useCallback(() => {
-    void reportWallDisconnectRef.current();
-    const boardId = resolvedPresenceBoardIdRef.current ?? presenceBoardIdRef.current;
-    if (boardId === null) return;
-    void reportDisconnectForBoardRef.current(boardId);
-  }, []);
-
-  // Wrap disconnect to track user-initiated disconnects
+  // Coalesce adapter disconnect calls. The hook consumes and reports the active
+  // generation synchronously before awaiting the native adapter teardown.
   const wrappedDisconnect = useCallback(async () => {
+    const disconnectInFlight = disconnectInFlightRef.current;
+    if (disconnectInFlight) {
+      await disconnectInFlight;
+      return;
+    }
+
     clearPendingWallReportAndUndoToastArm();
-    releaseBoardHolder();
     connectedViaMismatchOverrideRef.current = false;
-    isUserDisconnectRef.current = true;
-    track(SHARED_EVENTS.BluetoothDisconnected, {
-      boardName,
-      boardId: resolvedPresenceBoardIdRef.current ?? presenceBoardIdRef.current ?? undefined,
-      reason: 'user',
-      inSession: sessionIdRef.current != null,
-    });
-    try {
-      await disconnect();
-    } catch {
+    const disconnectOperation = disconnect().catch(() => {
       // The native iOS adapter's disconnect() can reject (e.g. peripheral
       // already torn down). Callers `void` this promise, so an unhandled
       // rejection would surface as error-reporting noise. Connection state is
       // cleared before the await, so the disconnect is effectively done either way —
       // safe to swallow, matching the keep-awake `.catch(() => {})` pattern.
+    });
+    disconnectInFlightRef.current = disconnectOperation;
+    try {
+      await disconnectOperation;
     } finally {
-      isUserDisconnectRef.current = false;
+      if (disconnectInFlightRef.current === disconnectOperation) {
+        disconnectInFlightRef.current = null;
+      }
     }
-  }, [clearPendingWallReportAndUndoToastArm, releaseBoardHolder, disconnect, boardName]);
+  }, [clearPendingWallReportAndUndoToastArm, disconnect]);
 
   // Register with the module-level status store so consumers rendered outside
   // this provider (e.g. the root tab bar, the long-press BLE controls sheet) can
@@ -1342,47 +1399,6 @@ export function BluetoothProvider({
     });
     return release;
   }, [isConnected, wrappedDisconnect]);
-
-  // Losing the BLE link is expected (RF noise, or another climber grabbing the
-  // last-connection-wins board), so an unexpected drop just lets the lightbulb go
-  // unlit (driven by isConnected) — we never auto-reconnect, buzz an error, or pop
-  // the device picker. Reconnecting stays a deliberate lightbulb tap. Recorded so
-  // drop frequency stays visible in analytics.
-  useEffect(() => {
-    if (wasConnectedRef.current && !isConnected && !isUserDisconnectRef.current) {
-      clearPendingWallReportAndUndoToastArm();
-      connectedViaMismatchOverrideRef.current = false;
-      // An unexpected drop also frees our board hold (the booted phone is no
-      // longer writing the wall). Compare-and-delete server-side, so if another
-      // phone already took over this is a no-op.
-      releaseBoardHolder();
-      // The hook stashed the drop's platform reason (CoreBluetooth / ble-plx
-      // code, or a write-stall context) on this ref before flipping isConnected.
-      // Flattened onto the event so analytics can tell a takeover apart from a
-      // range/idle timeout — the gap that left `disconnectReason` null before.
-      const disconnectInfo = lastDisconnectInfoRef.current;
-      track(SHARED_EVENTS.BluetoothDisconnected, {
-        boardName,
-        // The resolved DB board id (same value the send events carry), so
-        // takeover analysis can join disconnects to another user's connect on
-        // the SAME board instead of a fragile last-connect join per user.
-        boardId: resolvedPresenceBoardIdRef.current ?? presenceBoardIdRef.current ?? undefined,
-        reason: 'unexpected',
-        inSession: sessionIdRef.current != null,
-        disconnectSource: disconnectInfo?.source,
-        disconnectReason: disconnectInfo?.description,
-        disconnectContext: disconnectInfo?.context,
-        disconnectIosCode: disconnectInfo?.iosErrorCode,
-        disconnectAndroidCode: disconnectInfo?.androidErrorCode,
-        disconnectBleCode: disconnectInfo?.bleErrorCode,
-        disconnectErrorDomain: disconnectInfo?.errorDomain,
-        disconnectCategory: classifyBleDisconnect(disconnectInfo),
-      });
-    }
-    wasConnectedRef.current = isConnected;
-    // lastDisconnectInfoRef is a stable ref (read via .current), so it's
-    // intentionally not a dependency — the isConnected transition is the trigger.
-  }, [clearPendingWallReportAndUndoToastArm, releaseBoardHolder, isConnected, boardName]);
 
   const value = useMemo<BluetoothContextValue>(
     () => ({

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -918,7 +918,7 @@ export function BluetoothProvider({
     setIds,
     boardUuid,
     holdsData,
-    analyticsBoardId: resolvedPresenceBoardIdRef.current ?? presenceBoardId,
+    analyticsBoardId: presenceBoardId,
     analyticsInSession: sessionIdRef.current != null,
     ledColorOverrides: bluetoothColorOverrides,
     onConnectSuccess: handleConnectSuccess,

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -919,7 +919,7 @@ export function BluetoothProvider({
     boardUuid,
     holdsData,
     analyticsBoardId: presenceBoardId,
-    analyticsInSession: sessionIdRef.current != null,
+    analyticsInSession: sessionId != null,
     ledColorOverrides: bluetoothColorOverrides,
     onConnectSuccess: handleConnectSuccess,
     onConnectionEnded: handleBluetoothConnectionEnded,

--- a/packages/mobile/src/providers/board-presence-provider.tsx
+++ b/packages/mobile/src/providers/board-presence-provider.tsx
@@ -56,8 +56,52 @@ export type ResolveBoardUuidArgs = {
   boardUuid: string;
 };
 
+/** Stable identity needed by BLE lifetime attribution. Resolver callers must
+ * not depend on the backend's richer board payload. */
+export type BoardBindingIdentity = Pick<ResolvedBoard, 'boardId'>;
+
+type BoardBindingResolutionKind = 'serial' | 'config' | 'uuid';
+
+type PendingBoardBindingResolution = {
+  key: string;
+  kind: BoardBindingResolutionKind;
+  promise: Promise<BoardBindingIdentity | null>;
+  settle: (binding: BoardBindingIdentity | null) => void;
+  choiceInFlight: boolean;
+};
+
+function createPendingBoardBindingResolution(
+  key: string,
+  kind: BoardBindingResolutionKind,
+): PendingBoardBindingResolution {
+  let resolvePromise: (binding: BoardBindingIdentity | null) => void = () => {};
+  let settled = false;
+  const promise = new Promise<BoardBindingIdentity | null>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    key,
+    kind,
+    promise,
+    choiceInFlight: false,
+    settle: (binding) => {
+      if (settled) return;
+      settled = true;
+      resolvePromise(binding);
+    },
+  };
+}
+
 function boardConfigResolveKey({ boardType, layoutId, sizeId, setIds }: ResolveBoardConfigArgs): string {
-  return `${boardType}:${layoutId}:${sizeId}:${setIds}`;
+  return `config:${boardType}:${layoutId}:${sizeId}:${setIds}`;
+}
+
+function boardSerialResolveKey(args: ResolveBoardArgs): string {
+  return `serial:${args.serial}:${args.boardType}:${args.layoutId}:${args.sizeId}:${args.setIds}`;
+}
+
+function boardUuidResolveKey({ boardUuid }: ResolveBoardUuidArgs): string {
+  return `uuid:${boardUuid}`;
 }
 
 type BoardPresenceControlsValue = {
@@ -70,19 +114,25 @@ type BoardPresenceControlsValue = {
    * Resolve (and bind) the shared board for a just-connected serial, then store
    * its boardId so the wall feed subscribes. No-op (resolves null) when no
    * transport/client is available (e.g. the outside-provider fallback).
-   * Idempotent for an unchanged serial.
+   * An unchanged, already-bound serial/config returns its cached board identity
+   * without another transport request so a new BLE generation can attribute
+   * its eventual release. Same-key callers share an in-flight resolution,
+   * including the deferred serial-disambiguation choice.
    */
-  resolveAndBindBoard: (args: ResolveBoardArgs) => Promise<ResolvedBoard | null>;
+  resolveAndBindBoard: (args: ResolveBoardArgs) => Promise<BoardBindingIdentity | null>;
   /**
    * Resolve a board by config when no serial is available, then store its
-   * boardId. No-op when the active transport does not support config fallback.
+   * boardId. An unchanged bound config returns its cached identity, and
+   * same-key callers share an in-flight result. No-op when the active transport
+   * does not support config fallback.
    */
-  resolveAndBindBoardByConfig: (args: ResolveBoardConfigArgs) => Promise<ResolvedBoard | null>;
+  resolveAndBindBoardByConfig: (args: ResolveBoardConfigArgs) => Promise<BoardBindingIdentity | null>;
   /**
    * Resolve a selected named board by UUID, then store its boardId. This is the
-   * preferred non-BLE path for board sheet stats/history.
+   * preferred non-BLE path for board sheet stats/history. An unchanged bound
+   * UUID returns its cached identity; same-key callers share an in-flight result.
    */
-  resolveAndBindBoardByUuid: (args: ResolveBoardUuidArgs) => Promise<ResolvedBoard | null>;
+  resolveAndBindBoardByUuid: (args: ResolveBoardUuidArgs) => Promise<BoardBindingIdentity | null>;
   /**
    * Report directly to a specific board id. Used immediately after a connect
    * resolve when the React boardId context has not re-rendered yet.
@@ -119,6 +169,7 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
   // for the choice.
   const [pendingDisambiguation, setPendingDisambiguation] = useState<{
     serial: string;
+    resolutionKey: string;
     candidates: BoardCandidate[];
   } | null>(null);
 
@@ -136,11 +187,13 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
   const clientRef = useRef(client);
   clientRef.current = client;
 
-  // The serial last resolved, so a reconnect to the same wall doesn't re-resolve.
-  const lastResolvedSerialRef = useRef<string | null>(null);
-  const lastResolvedConfigKeyRef = useRef<string | null>(null);
-  const lastResolvedBoardUuidRef = useRef<string | null>(null);
-  const resolveGenerationRef = useRef(0);
+  // A bound identity is cached by the exact resolver key. A same-key reconnect
+  // can reuse it; a different serial/config/UUID must resolve independently.
+  const boundBoardBindingRef = useRef<{ resolutionKey: string; boardId: number } | null>(null);
+  // Every exact key has at most one deferred resolution. Same-wall reconnects
+  // share this promise so the newest BLE generation can attach the eventual ID
+  // even when an older generation started the network request or picker.
+  const pendingBoardBindingResolutionRef = useRef<PendingBoardBindingResolution | null>(null);
   const enabledRef = useRef(enabled);
   enabledRef.current = enabled;
   // Mirror boardId into a ref so the empty-dep callback can read it without
@@ -152,120 +205,177 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
   const pendingDisambiguationRef = useRef(pendingDisambiguation);
   pendingDisambiguationRef.current = pendingDisambiguation;
 
-  const resetPresence = useCallback(() => {
-    lastResolvedSerialRef.current = null;
-    lastResolvedConfigKeyRef.current = null;
-    lastResolvedBoardUuidRef.current = null;
-    resolveGenerationRef.current += 1;
-    setPendingDisambiguation(null);
-    setBoardId(null);
-  }, []);
-
-  const resolveAndBindBoard = useCallback(async (args: ResolveBoardArgs): Promise<ResolvedBoard | null> => {
-    const activeClient = clientRef.current;
-    if (!enabledRef.current || activeClient === null) {
-      return null;
-    }
-    if (lastResolvedSerialRef.current === args.serial && boardIdRef.current !== null) {
-      return null;
-    }
-    const resolveGeneration = resolveGenerationRef.current + 1;
-    resolveGenerationRef.current = resolveGeneration;
-    lastResolvedConfigKeyRef.current = null;
-    lastResolvedBoardUuidRef.current = null;
-    lastResolvedSerialRef.current = args.serial;
-    setBoardId(null);
-    try {
-      const result = await activeClient.resolveBoardCandidatesForSerial(args);
-      if (resolveGenerationRef.current !== resolveGeneration) {
-        return null;
+  const settleActiveResolution = useCallback(
+    (pendingResolution: PendingBoardBindingResolution, binding: BoardBindingIdentity | null): boolean => {
+      if (pendingBoardBindingResolutionRef.current !== pendingResolution) {
+        return false;
       }
-      if (result.board) {
-        setPendingDisambiguation(null);
-        setBoardId(result.board.boardId);
-        return result.board;
+      pendingBoardBindingResolutionRef.current = null;
+      setPendingDisambiguation(null);
+      if (binding) {
+        boundBoardBindingRef.current = {
+          resolutionKey: pendingResolution.key,
+          boardId: binding.boardId,
+        };
+        boardIdRef.current = binding.boardId;
+        setBoardId(binding.boardId);
+      } else {
+        boundBoardBindingRef.current = null;
+        boardIdRef.current = null;
+        setBoardId(null);
       }
-      if (result.candidates && result.candidates.length > 0) {
-        // Several boards share this serial — ask the user which wall they're at.
-        // Binding waits for `chooseBoard`; leave boardId null so the wall feed
-        // stays inert until then.
-        setPendingDisambiguation({ serial: args.serial, candidates: result.candidates });
-        // Allow a later reconnect to re-prompt if they dismiss without picking.
-        lastResolvedSerialRef.current = null;
-        return null;
-      }
-      return null;
-    } catch (error) {
-      if (resolveGenerationRef.current === resolveGeneration) {
-        lastResolvedSerialRef.current = null;
-      }
-      console.warn('[board-presence] resolveBoardCandidatesForSerial failed', error);
-      return null;
-    }
-  }, []);
-
-  const resolveAndBindBoardByUuid = useCallback(async (args: ResolveBoardUuidArgs): Promise<ResolvedBoard | null> => {
-    const activeClient = clientRef.current;
-    if (!enabledRef.current || activeClient === null || !activeClient.resolveBoardForUuid) {
-      return null;
-    }
-    if (lastResolvedBoardUuidRef.current === args.boardUuid) {
-      return null;
-    }
-    const resolveGeneration = resolveGenerationRef.current + 1;
-    resolveGenerationRef.current = resolveGeneration;
-    lastResolvedBoardUuidRef.current = args.boardUuid;
-    lastResolvedConfigKeyRef.current = null;
-    lastResolvedSerialRef.current = null;
-    setBoardId(null);
-    try {
-      const resolved = await activeClient.resolveBoardForUuid(args);
-      if (resolveGenerationRef.current !== resolveGeneration) {
-        return null;
-      }
-      setBoardId(resolved.boardId);
-      return resolved;
-    } catch (error) {
-      if (resolveGenerationRef.current === resolveGeneration) {
-        lastResolvedBoardUuidRef.current = null;
-      }
-      console.warn('[board-presence] resolveBoardForUuid failed', error);
-      return null;
-    }
-  }, []);
-
-  const resolveAndBindBoardByConfig = useCallback(
-    async (args: ResolveBoardConfigArgs): Promise<ResolvedBoard | null> => {
-      const activeClient = clientRef.current;
-      if (!enabledRef.current || activeClient === null || !activeClient.resolveBoardForConfig) {
-        return null;
-      }
-      const configKey = boardConfigResolveKey(args);
-      if (lastResolvedConfigKeyRef.current === configKey && boardIdRef.current !== null) {
-        return null;
-      }
-      const resolveGeneration = resolveGenerationRef.current + 1;
-      resolveGenerationRef.current = resolveGeneration;
-      lastResolvedConfigKeyRef.current = configKey;
-      lastResolvedBoardUuidRef.current = null;
-      lastResolvedSerialRef.current = null;
-      setBoardId(null);
-      try {
-        const resolved = await activeClient.resolveBoardForConfig(args);
-        if (resolveGenerationRef.current !== resolveGeneration || lastResolvedConfigKeyRef.current !== configKey) {
-          return null;
-        }
-        setBoardId(resolved.boardId);
-        return resolved;
-      } catch (error) {
-        if (resolveGenerationRef.current === resolveGeneration && lastResolvedConfigKeyRef.current === configKey) {
-          lastResolvedConfigKeyRef.current = null;
-        }
-        console.warn('[board-presence] resolveBoardForConfig failed', error);
-        return null;
-      }
+      pendingResolution.settle(binding);
+      return true;
     },
     [],
+  );
+
+  const beginResolution = useCallback(
+    (resolutionKey: string, kind: BoardBindingResolutionKind): PendingBoardBindingResolution => {
+      const previousResolution = pendingBoardBindingResolutionRef.current;
+      if (previousResolution) {
+        pendingBoardBindingResolutionRef.current = null;
+        previousResolution.settle(null);
+      }
+      setPendingDisambiguation(null);
+      boundBoardBindingRef.current = null;
+      boardIdRef.current = null;
+      setBoardId(null);
+      const pendingResolution = createPendingBoardBindingResolution(resolutionKey, kind);
+      pendingBoardBindingResolutionRef.current = pendingResolution;
+      return pendingResolution;
+    },
+    [],
+  );
+
+  const resetPresence = useCallback(() => {
+    const pendingResolution = pendingBoardBindingResolutionRef.current;
+    pendingBoardBindingResolutionRef.current = null;
+    pendingResolution?.settle(null);
+    boundBoardBindingRef.current = null;
+    setPendingDisambiguation(null);
+    boardIdRef.current = null;
+    setBoardId(null);
+  }, []);
+
+  // A provider teardown must not leave a serial-disambiguation promise (and its
+  // Bluetooth callers) pending forever. Avoid state writes during unmount.
+  useEffect(
+    () => () => {
+      const pendingResolution = pendingBoardBindingResolutionRef.current;
+      pendingBoardBindingResolutionRef.current = null;
+      pendingResolution?.settle(null);
+    },
+    [],
+  );
+
+  const resolveAndBindBoard = useCallback(
+    (args: ResolveBoardArgs): Promise<BoardBindingIdentity | null> => {
+      const activeClient = clientRef.current;
+      if (!enabledRef.current || activeClient === null) {
+        return Promise.resolve(null);
+      }
+      const resolutionKey = boardSerialResolveKey(args);
+      const pendingResolution = pendingBoardBindingResolutionRef.current;
+      if (pendingResolution?.key === resolutionKey) {
+        return pendingResolution.promise;
+      }
+      const boundBinding = boundBoardBindingRef.current;
+      if (boundBinding?.resolutionKey === resolutionKey) {
+        return Promise.resolve({ boardId: boundBinding.boardId });
+      }
+
+      const newResolution = beginResolution(resolutionKey, 'serial');
+      void activeClient
+        .resolveBoardCandidatesForSerial(args)
+        .then((result) => {
+          if (pendingBoardBindingResolutionRef.current !== newResolution) return;
+          if (result.board) {
+            settleActiveResolution(newResolution, { boardId: result.board.boardId });
+            return;
+          }
+          if (result.candidates && result.candidates.length > 0) {
+            // Keep the keyed promise pending through disambiguation. A same-wall
+            // reconnect shares it and can attach the chosen ID to its newer BLE
+            // generation; cancel/different-key/reset settle it with null.
+            setPendingDisambiguation({
+              serial: args.serial,
+              resolutionKey,
+              candidates: result.candidates,
+            });
+            return;
+          }
+          settleActiveResolution(newResolution, null);
+        })
+        .catch((error: unknown) => {
+          settleActiveResolution(newResolution, null);
+          console.warn('[board-presence] resolveBoardCandidatesForSerial failed', error);
+        });
+      return newResolution.promise;
+    },
+    [beginResolution, settleActiveResolution],
+  );
+
+  const resolveAndBindBoardByUuid = useCallback(
+    (args: ResolveBoardUuidArgs): Promise<BoardBindingIdentity | null> => {
+      const activeClient = clientRef.current;
+      if (!enabledRef.current || activeClient === null || !activeClient.resolveBoardForUuid) {
+        return Promise.resolve(null);
+      }
+      const resolutionKey = boardUuidResolveKey(args);
+      const pendingResolution = pendingBoardBindingResolutionRef.current;
+      if (pendingResolution?.key === resolutionKey) {
+        return pendingResolution.promise;
+      }
+      const boundBinding = boundBoardBindingRef.current;
+      if (boundBinding?.resolutionKey === resolutionKey) {
+        return Promise.resolve({ boardId: boundBinding.boardId });
+      }
+
+      const newResolution = beginResolution(resolutionKey, 'uuid');
+      void activeClient
+        .resolveBoardForUuid(args)
+        .then((resolved) => {
+          settleActiveResolution(newResolution, { boardId: resolved.boardId });
+        })
+        .catch((error: unknown) => {
+          settleActiveResolution(newResolution, null);
+          console.warn('[board-presence] resolveBoardForUuid failed', error);
+        });
+      return newResolution.promise;
+    },
+    [beginResolution, settleActiveResolution],
+  );
+
+  const resolveAndBindBoardByConfig = useCallback(
+    (args: ResolveBoardConfigArgs): Promise<BoardBindingIdentity | null> => {
+      const activeClient = clientRef.current;
+      if (!enabledRef.current || activeClient === null || !activeClient.resolveBoardForConfig) {
+        return Promise.resolve(null);
+      }
+      const resolutionKey = boardConfigResolveKey(args);
+      const pendingResolution = pendingBoardBindingResolutionRef.current;
+      if (pendingResolution?.key === resolutionKey) {
+        return pendingResolution.promise;
+      }
+      const boundBinding = boundBoardBindingRef.current;
+      if (boundBinding?.resolutionKey === resolutionKey) {
+        return Promise.resolve({ boardId: boundBinding.boardId });
+      }
+
+      const newResolution = beginResolution(resolutionKey, 'config');
+      void activeClient
+        .resolveBoardForConfig(args)
+        .then((resolved) => {
+          settleActiveResolution(newResolution, { boardId: resolved.boardId });
+        })
+        .catch((error: unknown) => {
+          settleActiveResolution(newResolution, null);
+          console.warn('[board-presence] resolveBoardForConfig failed', error);
+        });
+      return newResolution.promise;
+    },
+    [beginResolution, settleActiveResolution],
   );
 
   const reportClimbForBoard = useCallback(
@@ -299,30 +409,49 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
 
   // Confirm the board the user picked from the disambiguation prompt: remember
   // the choice server-side and bind it as the active wall.
-  const chooseDisambiguatedBoard = useCallback(async (chosenBoardId: number): Promise<void> => {
-    const activeClient = clientRef.current;
-    const pending = pendingDisambiguationRef.current;
-    if (!enabledRef.current || activeClient === null || pending === null) {
-      return;
-    }
-    const resolveGeneration = resolveGenerationRef.current + 1;
-    resolveGenerationRef.current = resolveGeneration;
-    try {
-      const resolved = await activeClient.chooseBoardForSerial({ boardId: chosenBoardId, serial: pending.serial });
-      if (resolveGenerationRef.current !== resolveGeneration) {
+  const chooseDisambiguatedBoard = useCallback(
+    async (chosenBoardId: number): Promise<void> => {
+      const activeClient = clientRef.current;
+      const pendingDisambiguationState = pendingDisambiguationRef.current;
+      const pendingResolution = pendingBoardBindingResolutionRef.current;
+      if (
+        !enabledRef.current ||
+        activeClient === null ||
+        pendingDisambiguationState === null ||
+        pendingResolution?.kind !== 'serial' ||
+        pendingResolution.key !== pendingDisambiguationState.resolutionKey ||
+        pendingResolution.choiceInFlight
+      ) {
         return;
       }
-      lastResolvedSerialRef.current = pending.serial;
-      setPendingDisambiguation(null);
-      setBoardId(resolved.boardId);
-    } catch (error) {
-      console.warn('[board-presence] chooseBoardForSerial failed', error);
-    }
-  }, []);
+      pendingResolution.choiceInFlight = true;
+      try {
+        const resolved = await activeClient.chooseBoardForSerial({
+          boardId: chosenBoardId,
+          serial: pendingDisambiguationState.serial,
+        });
+        settleActiveResolution(pendingResolution, { boardId: resolved.boardId });
+      } catch (error) {
+        settleActiveResolution(pendingResolution, null);
+        console.warn('[board-presence] chooseBoardForSerial failed', error);
+      }
+    },
+    [settleActiveResolution],
+  );
 
   const cancelDisambiguation = useCallback(() => {
+    const pendingDisambiguationState = pendingDisambiguationRef.current;
+    const pendingResolution = pendingBoardBindingResolutionRef.current;
+    if (
+      pendingDisambiguationState &&
+      pendingResolution?.kind === 'serial' &&
+      pendingResolution.key === pendingDisambiguationState.resolutionKey
+    ) {
+      settleActiveResolution(pendingResolution, null);
+      return;
+    }
     setPendingDisambiguation(null);
-  }, []);
+  }, [settleActiveResolution]);
 
   // Telemetry only when a catch-up recovered missed wall events. Foreground and
   // reconnect catch-ups with a zero delta happen often and add no product signal.


### PR DESCRIPTION
## Summary

Fixes #3924.

- Measure each mobile BLE adapter generation from connection setup through its single terminal path and add non-negative `connectionDurationSec` to `Bluetooth Disconnected` on both native adapter paths.
- Distinguish explicit user disconnects, configuration switches, connection replacement, and link drops while keeping platform disconnect diagnostics on unexpected drops.
- Snapshot board/layout/size/set configuration with the adapter generation so a route change cannot misattribute a late resolution or disconnect.
- Attach the resolved Boardsesh board ID only to the matching live generation, and use keyed single-flight board-presence resolution so rapid reconnects and ambiguous serial choices cannot leak or release the wrong wall holder.
- Document the mobile disconnect event contract and lifecycle boundaries.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- Paired implementation QA plus independent high-effort final review; both previously identified same-key reconnect and mutable-route races were reproduced and closed
- Four focused mobile files: 182 tests passed during implementation; independent review reran 163 tests
- Full mobile suite: 4,930 tests passed
- `vp run typecheck:mobile`
- `vp run check:mobile-web-bundle`
- Native iOS and Android Metro bundle checks
- Scoped `vp check` across all eight changed files
- `git diff --check origin/main`
- `vp run dev:mobile` confirmed `.boardsesh/qa-notes.md` and Metro startup on port 8082
- Physical BLE QA remains required for explicit disconnect, link-drop duration, configuration switching, and ambiguous-controller selection on supported controllers
