### PR TITLE
fix(mobile-ota): retry transient publish failures

### DIFF
--- a/.github/workflows/mobile-ota-backport.yml
+++ b/.github/workflows/mobile-ota-backport.yml
@@ -102,11 +102,14 @@ jobs:
   backport:
     needs: setup
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     # Gates EOO_TOKEN + GOOGLE_MAPS_API_KEY + the EXPO_UPDATES_URL variable.
     environment: Production
     strategy:
       fail-fast: false
+      # Each eoas publish can perform four bounded attempts. Keep the platforms
+      # in one lane so a backport cannot create its own upload burst.
+      max-parallel: 1
       matrix:
         platform: ${{ fromJSON(needs.setup.outputs.platforms) }}
     # EOO_TOKEN (the app-scoped expo-open-ota publish key) is NOT a job-level env:

--- a/.github/workflows/mobile-ota-preview.yml
+++ b/.github/workflows/mobile-ota-preview.yml
@@ -62,6 +62,9 @@ on:
       - 'packages/board-constants/**'
       - 'packages/shared-schema/**'
       - 'patches/**'
+      - 'scripts/mobile-publish.ts'
+      - 'scripts/lib/mobile-publish-retry.ts'
+      - 'scripts/lib/eoas.ts'
       - '.github/workflows/mobile-ota-preview.yml'
   issue_comment:
     types: [created]

--- a/.github/workflows/mobile-ota-preview.yml
+++ b/.github/workflows/mobile-ota-preview.yml
@@ -378,9 +378,9 @@ jobs:
         run: |
           vp run check:mobile-ota-compat -- --write-env --base-dir "$RUNNER_TEMP/main-baseline"
 
-      # V3 control-plane: `eoas publish` creates the pr-<n> branch + channel but
-      # leaves them UNMAPPED, so no pre-create is needed — mapping happens in the
-      # separate trusted-base `map` job (below). iOS WITHOUT GOOGLE_MAPS_API_KEY (Apple
+      # V3 control-plane: `eoas publish` creates the pr-<n> branch. Channel creation
+      # and mapping happen in the separate trusted-base `map` job (below). iOS
+      # WITHOUT GOOGLE_MAPS_API_KEY (Apple
       # Maps), Android WITH it — the per-platform split that keeps each published
       # fingerprint equal to its shipped binary (matches mobile-ota-production.yml). A
       # native-change platform is skipped.
@@ -399,9 +399,8 @@ jobs:
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
         run: vp run mobile:publish -- --channel "$CHANNEL" --platform android
 
-  # ── Map pr-<number> → its same-named branch on the self-hosted server. `eoas publish`
-  # left the channel UNMAPPED (a client requesting it gets "No branch mapping found"),
-  # and mapping is a dashboard-admin action the eoo_ publish key CANNOT perform — so it
+  # ── Map pr-<number> → its same-named branch on the self-hosted server. Channel
+  # creation/mapping is a dashboard-admin action the eoo_ publish key CANNOT perform — so it
   # logs in with OTA_ADMIN_* (ota-preview-unattended environment, no reviewers). This is
   # a SEPARATE trusted-base job, NOT a publish step: the admin creds must never be in
   # scope while PR-author code runs. It checks out the TRUSTED BASE (never PR head),

--- a/.github/workflows/mobile-ota-preview.yml
+++ b/.github/workflows/mobile-ota-preview.yml
@@ -258,7 +258,9 @@ jobs:
     needs: gate
     if: needs.gate.outputs.action == 'publish'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Each platform may perform four attempts with 210 seconds of backoff. The
+    # job publishes iOS then Android, so leave room for both bounded retry sets.
+    timeout-minutes: 60
     # This job runs PR-author code with EOO_TOKEN, so its workflow-token scope is capped
     # at the minimum: read the tree, write the pr-preview deployment. NO issues /
     # pull-requests write — those stay on the trusted announce / cleanup jobs.

--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -243,7 +243,7 @@ jobs:
       # single `--platform all` publish with one env could only ever match one side.
       - name: Publish iOS OTA
         id: publish_ios
-        if: steps.gate.outputs.configured == 'true' && (env.INPUT_PLATFORM == 'all' || env.INPUT_PLATFORM == 'ios')
+        if: steps.gate.outputs.configured == 'true' && steps.generate.outcome == 'success' && (env.INPUT_PLATFORM == 'all' || env.INPUT_PLATFORM == 'ios')
         continue-on-error: true
         env:
           # V3 control-plane rejects Expo tokens; eoas publish authenticates with the

--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -306,6 +306,8 @@ jobs:
           if [ "$android_requested" = true ]; then
             [ "$ANDROID_OUTCOME" = success ] && any_success=true || all_success=false
           fi
+          # Keep these outputs before the failure exit below: downstream steps
+          # use them to distinguish full success from a partial publish.
           echo "all_success=$all_success" >> "$GITHUB_OUTPUT"
           echo "any_success=$any_success" >> "$GITHUB_OUTPUT"
           {

--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -22,6 +22,9 @@ on:
       - 'packages/board-constants/**'
       - 'packages/shared-schema/**'
       - 'patches/**' # bun patches to mobile deps live in root patches/, not under packages/mobile/**
+      - 'scripts/mobile-publish.ts'
+      - 'scripts/lib/mobile-publish-retry.ts'
+      - 'scripts/lib/eoas.ts'
       - '.github/workflows/mobile-ota-production.yml'
   workflow_dispatch:
     inputs:
@@ -96,7 +99,9 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Four attempts per platform can spend 210 seconds in backoff alone, before
+    # two sequential exports/uploads. Leave enough room for the bounded retries.
+    timeout-minutes: 60
     # Gates EOO_TOKEN + GOOGLE_MAPS_API_KEY + the EXPO_UPDATES_URL variable.
     environment: Production
 
@@ -239,6 +244,7 @@ jobs:
       - name: Publish iOS OTA
         id: publish_ios
         if: steps.gate.outputs.configured == 'true' && (env.INPUT_PLATFORM == 'all' || env.INPUT_PLATFORM == 'ios')
+        continue-on-error: true
         env:
           # V3 control-plane rejects Expo tokens; eoas publish authenticates with the
           # app-scoped EOO_TOKEN. The production channel→branch mapping is a one-time
@@ -258,7 +264,8 @@ jobs:
 
       - name: Publish Android OTA
         id: publish_android
-        if: steps.gate.outputs.configured == 'true' && (env.INPUT_PLATFORM == 'all' || env.INPUT_PLATFORM == 'android')
+        if: always() && steps.gate.outputs.configured == 'true' && steps.generate.outcome == 'success' && (env.INPUT_PLATFORM == 'all' || env.INPUT_PLATFORM == 'android')
+        continue-on-error: true
         env:
           EOO_TOKEN: ${{ secrets.EOO_TOKEN }}
           # Must match the Android native prebuild (android-apk-rn.yml) so the
@@ -271,21 +278,62 @@ jobs:
           if [ -n "$INPUT_MESSAGE" ]; then args+=(--message "$INPUT_MESSAGE"); fi
           vp run mobile:publish -- "${args[@]}"
 
+      # Publish both requested platforms before deciding the job result. This
+      # makes a partial release explicit without trying to roll back the platform
+      # that already succeeded (eoas has no safe cross-platform transaction).
+      - name: Summarize platform publish results
+        id: publish_summary
+        if: always() && steps.gate.outputs.configured == 'true' && steps.generate.outcome == 'success'
+        env:
+          IOS_OUTCOME: ${{ steps.publish_ios.outcome }}
+          ANDROID_OUTCOME: ${{ steps.publish_android.outcome }}
+        run: |
+          set -euo pipefail
+          ios_requested=false
+          android_requested=false
+          case "$INPUT_PLATFORM" in
+            all) ios_requested=true; android_requested=true ;;
+            ios) ios_requested=true ;;
+            android) android_requested=true ;;
+            *) echo "::error::Unknown platform '$INPUT_PLATFORM'"; exit 1 ;;
+          esac
+
+          all_success=true
+          any_success=false
+          if [ "$ios_requested" = true ]; then
+            [ "$IOS_OUTCOME" = success ] && any_success=true || all_success=false
+          fi
+          if [ "$android_requested" = true ]; then
+            [ "$ANDROID_OUTCOME" = success ] && any_success=true || all_success=false
+          fi
+          echo "all_success=$all_success" >> "$GITHUB_OUTPUT"
+          echo "any_success=$any_success" >> "$GITHUB_OUTPUT"
+          {
+            echo '### Production OTA platform results'
+            echo
+            echo "- iOS: $IOS_OUTCOME"
+            echo "- Android: $ANDROID_OUTCOME"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$all_success" != true ]; then
+            echo "::error::At least one requested platform failed. Successful platforms remain published; no automatic rollback was attempted."
+            exit 1
+          fi
+
       # Push the refreshed changelog to main so the committed copy is the single
       # source of truth (native builds bundle it; the next OTA diffs against it).
       # Runs AFTER publish, so the rebase here can't change what was just bundled.
       # The commit carries [skip ci], so this push can't re-trigger the workflow.
       # Rebase-and-retry guards a non-OTA push landing on main since checkout (OTA
       # runs are serialized on main, so two of these never race; only this workflow
-      # writes the file, so the rebase can't conflict). always() + the `changed`
-      # gate: the file still lands even if a publish failed — its entry then ships
-      # on the next OTA.
+      # writes the file, so the rebase can't conflict). The generated commit stays
+      # local when any requested platform fails; the next successful run regenerates
+      # it from merged PRs and pushes it.
       # Auth is the app token that checkout persisted (the app is in main's
       # PR-bypass list; github-actions[bot] is not, so it would 403). Skips when the
       # app isn't configured — checkout then holds only the default token, the OTA
       # already shipped, and main's committed copy is just left unchanged.
       - name: Push changelog to main
-        if: always() && github.ref == 'refs/heads/main' && steps.generate.outputs.changed == 'true' && vars.OTA_PUSH_APP_ID != ''
+        if: github.ref == 'refs/heads/main' && steps.publish_summary.outputs.all_success == 'true' && steps.generate.outputs.changed == 'true' && vars.OTA_PUSH_APP_ID != ''
         run: |
           set -euo pipefail
           cp packages/mobile/src/data/changelog.generated.json "$RUNNER_TEMP/changelog.json"
@@ -327,11 +375,11 @@ jobs:
           exit 1
 
       # Announce the publish to the Discord deploy channel (same webhook + pattern
-      # as ios-testflight-rn.yml / android-apk-rn.yml). Only when an OTA actually
-      # went out: gate wired AND at least one platform succeeded. A `--platform ios`
-      # run reports just "iOS" (the Android step is skipped, not success).
+      # as ios-testflight-rn.yml / android-apk-rn.yml). Only announce success when
+      # every requested platform succeeded. A `--platform ios` run reports just
+      # "iOS" (the Android step is skipped, not success).
       - name: Notify deployments channel
-        if: github.ref == 'refs/heads/main' && steps.gate.outputs.configured == 'true' && (steps.publish_ios.outcome == 'success' || steps.publish_android.outcome == 'success')
+        if: github.ref == 'refs/heads/main' && steps.publish_summary.outputs.all_success == 'true'
         env:
           DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -368,17 +416,20 @@ jobs:
               echo "::warning::Failed to post Discord notification (see status above)"
 
       - name: Notify deployments channel of failure
-        if: github.ref == 'refs/heads/main' && failure()
+        if: always() && github.ref == 'refs/heads/main' && failure()
         env:
           DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           COMMIT_SHA: ${{ github.sha }}
+          IOS_OUTCOME: ${{ steps.publish_ios.outcome }}
+          ANDROID_OUTCOME: ${{ steps.publish_android.outcome }}
         run: |
           if [ -z "$DISCORD_DEPLOY_WEBHOOK" ]; then
             echo "DISCORD_DEPLOY_WEBHOOK not set — skipping notification"
             exit 0
           fi
-          CONTENT=$(printf '🚨 **Production OTA publish failed** on `%s`\n<%s>' "${COMMIT_SHA:0:7}" "$RUN_URL")
+          CONTENT=$(printf '🚨 **Production OTA publish failed** on `%s`\n• iOS: %s\n• Android: %s\n• Any successful platform remains published; no automatic rollback was attempted.\n<%s>' \
+            "${COMMIT_SHA:0:7}" "$IOS_OUTCOME" "$ANDROID_OUTCOME" "$RUN_URL")
           jq -n --arg content "$CONTENT" '{content: $content, allowed_mentions: {parse: []}}' \
             | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
               echo "::warning::Failed to post Discord notification (see status above)"
@@ -401,7 +452,7 @@ jobs:
       # See docs/mobile-ota-updates.md ("Health monitoring & rollback").
       - name: OTA health check (non-blocking)
         id: health
-        if: github.ref == 'refs/heads/main' && steps.gate.outputs.configured == 'true' && (steps.publish_ios.outcome == 'success' || steps.publish_android.outcome == 'success')
+        if: always() && github.ref == 'refs/heads/main' && steps.gate.outputs.configured == 'true' && (steps.publish_ios.outcome == 'success' || steps.publish_android.outcome == 'success')
         continue-on-error: true
         env:
           POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
@@ -421,7 +472,7 @@ jobs:
       # is 'failure' only when the gate tripped (continue-on-error turned the
       # non-zero exit into a step failure without failing the job).
       - name: Notify OTA health to Discord
-        if: github.ref == 'refs/heads/main' && steps.gate.outputs.configured == 'true' && (steps.publish_ios.outcome == 'success' || steps.publish_android.outcome == 'success')
+        if: always() && github.ref == 'refs/heads/main' && steps.gate.outputs.configured == 'true' && (steps.publish_ios.outcome == 'success' || steps.publish_android.outcome == 'success')
         env:
           DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -138,24 +138,39 @@ EOO_TOKEN=eoo_… \
   vp run mobile:publish -- --channel production --message "fix: <what>"
 ```
 
-This runs `eoas publish --branch production --channel production`, which does an `expo export` and
-uploads the bundle to our storage via the server. `eoas` reads the server URL from `updates.url` in
+The wrapper translates its `--channel production` selector to `eoas publish --branch production`.
+It deliberately does not pass eoas's deprecated `--channel` option; channel creation and mapping are
+control-plane operations described below. The publish does an `expo export` and uploads the bundle
+to our storage via the server. `eoas` reads the server URL from `updates.url` in
 `app.config.ts`, so `EXPO_UPDATES_URL` must be present. **Auth is `EOO_TOKEN`, not an Expo token:**
 the V3 control-plane server rejects Expo tokens, so publish/rollback need an app-scoped `eoo_` key
 minted in the dashboard. The CLI is pinned to **`eoas@3.0.5`** via `EOAS_PACKAGE_SPEC` in
 `scripts/lib/eoas.ts` — it must match the deployed server version exactly (V3 routes are
 app-scoped; a `v2` CLI 404s). Bump the server image and the pin in lockstep.
 
-**Progressive rollouts** are a control-plane feature: `eoas publish --branch production --channel
-production --rollout-percentage N` ships to only `N%` of the channel's installs. Finish or revert
+**Transient upload failures** are retried only when eoas output contains the exact S3 SlowDown XML
+response or an explicit HTTP 5xx status. Each platform gets at most four attempts, with 30, 60, and
+120 second waits. HTTP 4xx, authentication, configuration, export/build errors, unknown failures,
+and mixed permanent/retryable evidence fail immediately. Child output stays live and is not echoed
+again from a captured tail. The EAS-hosted preview path (`eas update`) is unchanged and does not use
+these retries.
+
+When both platforms are requested, iOS then Android publish sequentially and Android still runs if
+iOS fails. The run fails unless every requested platform succeeds, but it does not automatically
+roll back a platform that already published. A single eoas invocation can still upload some objects
+before its server-row write fails; making that internal PUT/database operation atomic requires an
+upstream expo-open-ota change.
+
+**Progressive rollouts** are a control-plane feature: `eoas publish --branch production
+--rollout-percentage N` ships to only `N%` of the channel's installs. Finish or revert
 the rollout from the dashboard once it's healthy — an unfinished per-update rollout **locks**
 further publishing on that branch, so a forgotten one turns the next auto-publish red.
 
 ### Channel↔branch mapping (control-plane)
 
-In V3 the channel→branch mapping lives in Postgres, not in Expo's API. `eoas publish --branch X
---channel Y` creates the **branch** (which holds the update) and the **channel**, but leaves them
-**unmapped**. A client requesting an unmapped channel gets `No branch mapping found`. Mapping is a
+In V3 the channel→branch mapping lives in Postgres, not in Expo's API. `eoas publish --branch X`
+creates the **branch** that holds the update; channel creation and mapping happen separately. A
+client requesting an unmapped channel gets `No branch mapping found`. Mapping is a
 **dashboard-admin operation**: the app-scoped `eoo_` publish key can list branches/channels but
 **cannot map** (it 403s with "This action requires a dashboard session").
 
@@ -351,9 +366,10 @@ Confirm the Android release actually shipped before relying on an Android backpo
    resolved fingerprint's 12-char prefix equals the anchor's `<shortfp>`**. A mismatch means the
    cherry-pick touched native inputs — it aborts, because an OTA would resolve a fingerprint no
    shipped binary has and silently never land. Ship such a fix as a new native build instead.
-4. Re-run with `dry_run` off to `eoas publish --channel production` under the approved fingerprint,
-   reaching that release's installs. It shares the `mobile-ota-production` concurrency lane, so it
-   never races a `main` OTA.
+4. Re-run with `dry_run` off. The wrapper targets the `production` branch under the approved
+   fingerprint, reaching that release's installs. It shares the `mobile-ota-production` concurrency
+   lane and limits the platform matrix to one publish at a time, so it never races a `main` OTA or
+   bursts iOS and Android uploads concurrently.
 
 To find the anchor for a release: `git tag -l 'release/ios-v2.1.0-*'`.
 
@@ -434,8 +450,9 @@ with read access) to the **Production** environment — the same secret
 
 ### Post-publish CI step (non-blocking)
 
-`mobile-ota-production.yml` runs the health check after a successful publish (a short `sleep` lets
-early relaunches report), with `continue-on-error: true`, and posts the verdict to the same Discord
+`mobile-ota-production.yml` runs the health check after any platform publishes successfully, even
+when another requested platform failed (a short `sleep` lets early relaunches report), with
+`continue-on-error: true`, and posts the verdict to the same Discord
 deploy channel as the publish announcement. It's wired so it can **never** block or fail the
 publish: `continue-on-error` swallows a tripped gate, and the script no-ops (exit 0) until the
 `POSTHOG_PERSONAL_API_KEY` secret exists. The step's `outcome` going to `failure` is what flips the
@@ -603,12 +620,14 @@ be requested.
 
 `packages/mobile/src/data/changelog.generated.json` is owned **solely** by the
 `mobile-ota-production.yml` workflow. On every production OTA it regenerates the file from merged-PR
-`## Release Notes` sections, commits it, **pushes it back to `main`** (commit tagged `[skip ci]` so
-the push can't re-trigger the OTA), and only then runs `eoas publish` (which needs a clean tree).
+`## Release Notes` sections and commits it locally before `eoas publish` (which needs a clean tree).
+It **pushes the commit back to `main`** only after every requested platform succeeds (the commit is
+tagged `[skip ci]` so the push can't re-trigger the OTA). A partial or total publish failure leaves
+the local CI commit unpushed; the next run regenerates the same source-of-truth files.
 Nothing else writes the file: the native build workflows and `refresh-acknowledgements.yml` only
-_read_ it, and a CI guard (`changelog-owned` in `ci.yml`) fails any PR that edits it. The OTA still
-publishes whether or not the push-back is wired — the push-back just keeps `main`'s copy (which the
-native binaries embed) current.
+_read_ it, and a CI guard (`changelog-owned` in `ci.yml`) fails any PR that edits it. A fully
+successful OTA still publishes when the push-back identity is not wired — the push-back just keeps
+`main`'s copy (which the native binaries embed) current.
 
 ### Native-release markers + on-demand update check
 
@@ -758,10 +777,9 @@ Every PR with React Native changes can publish its JS bundle to its own self-hos
 above — no per-tester build. Workflow: `.github/workflows/mobile-ota-preview.yml` (sweep:
 `mobile-ota-preview-sweep.yml`).
 
-- **Publish + map.** For each platform the workflow runs `eoas publish --branch pr-<number> --channel
-pr-<number>` (keeping `EXPO_UPDATES_CHANNEL=production` so the runtimeVersion equals the shipped
-  binary's), then maps the channel to the branch with `scripts/ota-channel-map.ts map` — because in
-  V3 `eoas publish` leaves the channel **unmapped** and the `eoo_` key can't map it (see
+- **Publish + map.** For each platform the wrapper runs `eoas publish --branch pr-<number>` (keeping
+  `EXPO_UPDATES_CHANNEL=production` so the runtimeVersion equals the shipped binary's), then creates
+  or remaps the channel with `scripts/ota-channel-map.ts map` — because the `eoo_` key can't map it (see
   [Channel↔branch mapping](#channelbranch-mapping-control-plane)). The channel name and the baked
   header are independent: the baked `expo-channel-name=production` drives the fingerprint, `pr-<number>`
   drives where the bundle lands and what the switcher selects.

--- a/scripts/lib/mobile-publish-retry.test.ts
+++ b/scripts/lib/mobile-publish-retry.test.ts
@@ -136,4 +136,19 @@ describe('platform aggregation', () => {
       { platform: 'android', success: true, attempts: 1, failureKind: null },
     ]);
   });
+
+  it('records a thrown callback as failed and still runs the next platform', async () => {
+    const calls: string[] = [];
+    const outcomes = await publishPlatformsSequentially(['ios', 'android'], async (platform) => {
+      calls.push(platform);
+      if (platform === 'ios') throw new Error('fixture callback failure');
+      return { platform, success: true, attempts: 1, failureKind: null };
+    });
+
+    expect(calls).toEqual(['ios', 'android']);
+    expect(outcomes).toEqual([
+      { platform: 'ios', success: false, attempts: 0, failureKind: 'unknown' },
+      { platform: 'android', success: true, attempts: 1, failureKind: null },
+    ]);
+  });
 });

--- a/scripts/lib/mobile-publish-retry.test.ts
+++ b/scripts/lib/mobile-publish-retry.test.ts
@@ -1,0 +1,139 @@
+/// <reference types="node" />
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  classifyPublishFailure,
+  PublishFailureEvidenceScanner,
+  publishPlatformsSequentially,
+  publishSelfHostedPlatformWithRetry,
+  SELF_HOSTED_PUBLISH_MAX_ATTEMPTS,
+  SELF_HOSTED_PUBLISH_RETRY_DELAYS_MS,
+  type PublishCommandRunner,
+  type TextOutput,
+} from './mobile-publish-retry';
+
+function outputCollector(): { output: TextOutput; read: () => string } {
+  const chunks: string[] = [];
+  return {
+    output: { write: (chunk) => chunks.push(chunk) },
+    read: () => chunks.join(''),
+  };
+}
+
+describe('self-hosted publish failure classification', () => {
+  it('recognizes only the complete S3 SlowDown XML evidence', () => {
+    expect(
+      classifyPublishFailure('<Error><Code>SlowDown</Code><Message>Please reduce your request rate.</Message></Error>'),
+    ).toBe('s3-slowdown');
+    expect(classifyPublishFailure('S3 SlowDown: please retry')).toBe('unknown');
+    expect(classifyPublishFailure('<Code>SlowDown</Code>')).toBe('unknown');
+  });
+
+  it('recognizes explicit HTTP 5xx statuses but not unrelated numbers', () => {
+    expect(classifyPublishFailure('request failed with HTTP/1.1 503 Service Unavailable')).toBe('http-5xx');
+    expect(classifyPublishFailure('response status: 502')).toBe('http-5xx');
+    expect(classifyPublishFailure('Response code: 503')).toBe('http-5xx');
+    expect(classifyPublishFailure('uploaded 503 assets')).toBe('unknown');
+  });
+
+  it('lets permanent evidence veto retryable evidence', () => {
+    expect(classifyPublishFailure('HTTP 503, then response status 403')).toBe('permanent');
+    expect(classifyPublishFailure('Response code: 503; retry returned Response code: 401')).toBe('permanent');
+    expect(
+      classifyPublishFailure(
+        '<Code>SlowDown</Code><Message>Please reduce your request rate.</Message><Code>AccessDenied</Code>',
+      ),
+    ).toBe('permanent');
+  });
+
+  it('classifies evidence split across output chunks', () => {
+    const scanner = new PublishFailureEvidenceScanner();
+    scanner.push('<Error><Code>Slow');
+    scanner.push('Down</Code><Message>Please reduce your request');
+    scanner.push(' rate.</Message></Error>');
+    expect(scanner.classify()).toBe('s3-slowdown');
+  });
+});
+
+describe('self-hosted publish retries', () => {
+  it('uses four total attempts with 30/60/120 second backoff', async () => {
+    const attempts: number[] = [];
+    const runner: PublishCommandRunner = async ({ onStderr }) => {
+      attempts.push(attempts.length + 1);
+      if (attempts.length < SELF_HOSTED_PUBLISH_MAX_ATTEMPTS) {
+        onStderr('HTTP 503 Service Unavailable\n');
+        return { exitCode: 1 };
+      }
+      return { exitCode: 0 };
+    };
+    const sleeper = vi.fn(async (_delayMs: number) => undefined);
+    const stdout = outputCollector();
+    const stderr = outputCollector();
+
+    const outcome = await publishSelfHostedPlatformWithRetry(
+      { platform: 'ios', command: 'bunx', args: ['eoas', 'publish'], cwd: '/repo', env: {} },
+      { runner, sleeper, stdout: stdout.output, stderr: stderr.output },
+    );
+
+    expect(outcome).toEqual({ platform: 'ios', success: true, attempts: 4, failureKind: null });
+    expect(attempts).toHaveLength(4);
+    expect(sleeper.mock.calls.map(([delayMs]) => delayMs)).toEqual([...SELF_HOSTED_PUBLISH_RETRY_DELAYS_MS]);
+  });
+
+  it('does not retry permanent or mixed evidence', async () => {
+    const runner = vi.fn<PublishCommandRunner>(async ({ onStdout, onStderr }) => {
+      onStdout('HTTP 503 Service Unavailable\n');
+      onStderr('response status: 401\n');
+      return { exitCode: 1 };
+    });
+    const sleeper = vi.fn(async () => undefined);
+    const stderr = outputCollector();
+
+    const outcome = await publishSelfHostedPlatformWithRetry(
+      { platform: 'android', command: 'bunx', args: [], cwd: '/repo', env: {} },
+      { runner, sleeper, stdout: outputCollector().output, stderr: stderr.output },
+    );
+
+    expect(outcome).toEqual({ platform: 'android', success: false, attempts: 1, failureKind: 'permanent' });
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(sleeper).not.toHaveBeenCalled();
+  });
+
+  it('streams child output once without copying a raw token into diagnostics', async () => {
+    const sensitiveOutput = 'server detail: EOO_TOKEN=eoo_fixture_secret\n';
+    const runner: PublishCommandRunner = async ({ onStderr }) => {
+      onStderr(sensitiveOutput);
+      return { exitCode: 1 };
+    };
+    const stderr = outputCollector();
+
+    await publishSelfHostedPlatformWithRetry(
+      { platform: 'ios', command: 'bunx', args: [], cwd: '/repo', env: {} },
+      { runner, stdout: outputCollector().output, stderr: stderr.output },
+    );
+
+    expect(stderr.read().match(/eoo_fixture_secret/g)).toHaveLength(1);
+    expect(stderr.read()).toContain('no retryable error evidence');
+  });
+});
+
+describe('platform aggregation', () => {
+  it('runs iOS then Android and continues after an iOS failure', async () => {
+    const calls: string[] = [];
+    const outcomes = await publishPlatformsSequentially(['ios', 'android'], async (platform) => {
+      calls.push(platform);
+      return {
+        platform,
+        success: platform === 'android',
+        attempts: 1,
+        failureKind: platform === 'ios' ? 'unknown' : null,
+      };
+    });
+
+    expect(calls).toEqual(['ios', 'android']);
+    expect(outcomes).toEqual([
+      { platform: 'ios', success: false, attempts: 1, failureKind: 'unknown' },
+      { platform: 'android', success: true, attempts: 1, failureKind: null },
+    ]);
+  });
+});

--- a/scripts/lib/mobile-publish-retry.test.ts
+++ b/scripts/lib/mobile-publish-retry.test.ts
@@ -99,6 +99,29 @@ describe('self-hosted publish retries', () => {
     expect(sleeper).not.toHaveBeenCalled();
   });
 
+  it('preserves classified evidence when the retry sleeper rejects without exposing the thrown detail', async () => {
+    const runner = vi.fn<PublishCommandRunner>(async ({ onStderr }) => {
+      onStderr('HTTP 503 Service Unavailable\n');
+      return { exitCode: 1 };
+    });
+    const sleeper = vi.fn(async () => {
+      throw new Error('EOO_TOKEN=eoo_fixture_sleep_secret');
+    });
+    const stderr = outputCollector();
+
+    const outcome = await publishSelfHostedPlatformWithRetry(
+      { platform: 'ios', command: 'bunx', args: [], cwd: '/repo', env: {} },
+      { runner, sleeper, stdout: outputCollector().output, stderr: stderr.output },
+    );
+
+    expect(outcome).toEqual({ platform: 'ios', success: false, attempts: 1, failureKind: 'http-5xx' });
+    expect(runner).toHaveBeenCalledOnce();
+    expect(sleeper).toHaveBeenCalledOnce();
+    expect(sleeper).toHaveBeenCalledWith(SELF_HOSTED_PUBLISH_RETRY_DELAYS_MS[0]);
+    expect(stderr.read()).toContain('retry wait failed; not retrying');
+    expect(stderr.read()).not.toContain('eoo_fixture_sleep_secret');
+  });
+
   it('streams child output once without copying a raw token into diagnostics', async () => {
     const sensitiveOutput = 'server detail: EOO_TOKEN=eoo_fixture_secret\n';
     const runner: PublishCommandRunner = async ({ onStderr }) => {

--- a/scripts/lib/mobile-publish-retry.ts
+++ b/scripts/lib/mobile-publish-retry.ts
@@ -1,0 +1,267 @@
+/// <reference types="node" />
+
+/**
+ * Bounded retry support for self-hosted `eoas publish` calls.
+ *
+ * The EAS preview path deliberately does not import or call this helper. A
+ * whole-command retry is safe only for the narrowly classified transient
+ * failures below; every other non-zero exit remains a hard failure.
+ */
+
+import { spawn } from 'node:child_process';
+
+export const SELF_HOSTED_PUBLISH_MAX_ATTEMPTS = 4;
+export const SELF_HOSTED_PUBLISH_RETRY_DELAYS_MS = [30_000, 60_000, 120_000] as const;
+
+export type OtaPublishPlatform = 'ios' | 'android';
+export type PublishFailureKind = 's3-slowdown' | 'http-5xx' | 'permanent' | 'unknown';
+
+export type TextOutput = {
+  write(chunk: string): unknown;
+};
+
+export type PublishCommandRequest = {
+  command: string;
+  args: readonly string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  onStdout: (chunk: string) => void;
+  onStderr: (chunk: string) => void;
+};
+
+export type PublishCommandResult = {
+  exitCode: number;
+};
+
+export type PublishCommandRunner = (request: PublishCommandRequest) => Promise<PublishCommandResult>;
+export type PublishSleeper = (delayMs: number) => Promise<void>;
+
+export type PublishRetryInvocation = {
+  platform: OtaPublishPlatform;
+  command: string;
+  args: readonly string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+};
+
+export type PlatformPublishOutcome = {
+  platform: OtaPublishPlatform;
+  success: boolean;
+  attempts: number;
+  failureKind: PublishFailureKind | null;
+};
+
+export type PublishRetryDependencies = {
+  runner?: PublishCommandRunner;
+  sleeper?: PublishSleeper;
+  stdout?: TextOutput;
+  stderr?: TextOutput;
+};
+
+const CLASSIFIER_WINDOW_CHARS = 4096;
+
+const EXPLICIT_HTTP_5XX =
+  /(?:\bHTTP(?:\/\d(?:\.\d)?)?\s+|\b(?:status|statusCode|status code|response (?:status|code))\s*[:=]?\s*)5\d{2}\b/i;
+const EXPLICIT_HTTP_4XX =
+  /(?:\bHTTP(?:\/\d(?:\.\d)?)?\s+|\b(?:status|statusCode|status code|response (?:status|code))\s*[:=]?\s*)4\d{2}\b/i;
+const S3_SLOWDOWN_CODE = /<Code>\s*SlowDown\s*<\/Code>/i;
+const S3_SLOWDOWN_MESSAGE = /<Message>\s*Please reduce your request rate\.?\s*<\/Message>/i;
+const PERMANENT_S3_CODE =
+  /<Code>\s*(?:AccessDenied|AuthorizationHeaderMalformed|ExpiredToken|InvalidAccessKeyId|InvalidArgument|InvalidRequest|InvalidToken|NoSuchBucket|SignatureDoesNotMatch)\s*<\/Code>/i;
+const PERMANENT_AUTH_ERROR =
+  /\b(?:authentication failed|invalid (?:api[ -]?)?(?:key|token|credentials)|permission denied|unauthorized|forbidden)\b/i;
+const PERMANENT_INPUT_ERROR =
+  /\b(?:configuration error|invalid (?:argument|configuration|option|request)|missing required|validation error)\b/i;
+const PERMANENT_BUILD_ERROR = /\b(?:expo export|bundle|build) failed\b|\b(?:ReferenceError|SyntaxError|TypeError):/i;
+
+type FailureEvidence = {
+  hasSlowDownCode: boolean;
+  hasSlowDownMessage: boolean;
+  hasHttp5xx: boolean;
+  hasPermanent: boolean;
+};
+
+function emptyEvidence(): FailureEvidence {
+  return {
+    hasSlowDownCode: false,
+    hasSlowDownMessage: false,
+    hasHttp5xx: false,
+    hasPermanent: false,
+  };
+}
+
+/**
+ * Incrementally classifies output while retaining only a small rolling window.
+ * Evidence bits survive after text falls out of the window, so the helper never
+ * needs a raw log tail to make or explain a retry decision.
+ */
+export class PublishFailureEvidenceScanner {
+  private evidence = emptyEvidence();
+  private window = '';
+
+  push(chunk: string): void {
+    const searchable = `${this.window}${chunk}`;
+    this.evidence.hasSlowDownCode ||= S3_SLOWDOWN_CODE.test(searchable);
+    this.evidence.hasSlowDownMessage ||= S3_SLOWDOWN_MESSAGE.test(searchable);
+    this.evidence.hasHttp5xx ||= EXPLICIT_HTTP_5XX.test(searchable);
+    this.evidence.hasPermanent ||=
+      EXPLICIT_HTTP_4XX.test(searchable) ||
+      PERMANENT_S3_CODE.test(searchable) ||
+      PERMANENT_AUTH_ERROR.test(searchable) ||
+      PERMANENT_INPUT_ERROR.test(searchable) ||
+      PERMANENT_BUILD_ERROR.test(searchable);
+    this.window = searchable.slice(-CLASSIFIER_WINDOW_CHARS);
+  }
+
+  classify(): PublishFailureKind {
+    // Any permanent signal vetoes a retry, even when a retryable marker also
+    // appeared earlier in the same command's mixed output.
+    if (this.evidence.hasPermanent) return 'permanent';
+    if (this.evidence.hasSlowDownCode && this.evidence.hasSlowDownMessage) return 's3-slowdown';
+    if (this.evidence.hasHttp5xx) return 'http-5xx';
+    return 'unknown';
+  }
+}
+
+/** Convenience entry point for fixture/unit classification. */
+export function classifyPublishFailure(output: string): PublishFailureKind {
+  const scanner = new PublishFailureEvidenceScanner();
+  scanner.push(output);
+  return scanner.classify();
+}
+
+/**
+ * Real child runner: stdout/stderr are piped so callers can both stream them
+ * immediately and feed the evidence scanner. It never prints or summarizes an
+ * error itself, which prevents a captured secret-bearing tail from being echoed
+ * a second time.
+ */
+export const runStreamingPublishCommand: PublishCommandRunner = (request) =>
+  new Promise((resolve) => {
+    let settled = false;
+    const settle = (exitCode: number) => {
+      if (settled) return;
+      settled = true;
+      resolve({ exitCode });
+    };
+
+    try {
+      const child = spawn(request.command, [...request.args], {
+        cwd: request.cwd,
+        env: request.env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      child.stdout.setEncoding('utf8');
+      child.stderr.setEncoding('utf8');
+      child.stdout.on('data', request.onStdout);
+      child.stderr.on('data', request.onStderr);
+      child.once('error', () => settle(1));
+      child.once('close', (exitCode) => settle(exitCode ?? 1));
+    } catch {
+      settle(1);
+    }
+  });
+
+export const sleepForPublishRetry: PublishSleeper = (delayMs) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+
+function platformLabel(platform: OtaPublishPlatform): string {
+  return platform === 'ios' ? 'iOS' : 'Android';
+}
+
+function failureDescription(kind: PublishFailureKind): string {
+  if (kind === 's3-slowdown') return 'S3 SlowDown';
+  if (kind === 'http-5xx') return 'HTTP 5xx';
+  if (kind === 'permanent') return 'permanent error evidence';
+  return 'no retryable error evidence';
+}
+
+/**
+ * Run one platform's self-hosted publish with four total attempts. Only exact
+ * S3 SlowDown XML or an explicit HTTP 5xx is retryable. Output is streamed once
+ * as it arrives; notices contain classification metadata only.
+ */
+export async function publishSelfHostedPlatformWithRetry(
+  invocation: PublishRetryInvocation,
+  dependencies: PublishRetryDependencies = {},
+): Promise<PlatformPublishOutcome> {
+  const runner = dependencies.runner ?? runStreamingPublishCommand;
+  const sleeper = dependencies.sleeper ?? sleepForPublishRetry;
+  const stdout = dependencies.stdout ?? process.stdout;
+  const stderr = dependencies.stderr ?? process.stderr;
+  const label = platformLabel(invocation.platform);
+
+  for (let attempt = 1; attempt <= SELF_HOSTED_PUBLISH_MAX_ATTEMPTS; attempt++) {
+    const scanner = new PublishFailureEvidenceScanner();
+    let exitCode = 1;
+    try {
+      const result = await runner({
+        command: invocation.command,
+        args: invocation.args,
+        cwd: invocation.cwd,
+        env: invocation.env,
+        onStdout: (chunk) => {
+          stdout.write(chunk);
+          scanner.push(chunk);
+        },
+        onStderr: (chunk) => {
+          stderr.write(chunk);
+          scanner.push(chunk);
+        },
+      });
+      exitCode = result.exitCode;
+    } catch {
+      // A runner failure has no retryable server evidence. Keep the diagnostic
+      // intentionally generic: thrown errors can embed argv/env or a raw tail.
+      stderr.write(`[mobile:publish] ${label} publish process failed to run; not retrying.\n`);
+      return { platform: invocation.platform, success: false, attempts: attempt, failureKind: 'unknown' };
+    }
+
+    if (exitCode === 0) {
+      return { platform: invocation.platform, success: true, attempts: attempt, failureKind: null };
+    }
+
+    const failureKind = scanner.classify();
+    const retryable = failureKind === 's3-slowdown' || failureKind === 'http-5xx';
+    if (!retryable || attempt === SELF_HOSTED_PUBLISH_MAX_ATTEMPTS) {
+      const exhausted = retryable ? ' after exhausting the retry budget' : '';
+      stderr.write(
+        `[mobile:publish] ${label} publish failed (${failureDescription(failureKind)})${exhausted}; not retrying.\n`,
+      );
+      return { platform: invocation.platform, success: false, attempts: attempt, failureKind };
+    }
+
+    const delayMs = SELF_HOSTED_PUBLISH_RETRY_DELAYS_MS[attempt - 1];
+    stderr.write(
+      `[mobile:publish] ${label} publish attempt ${attempt}/${SELF_HOSTED_PUBLISH_MAX_ATTEMPTS} failed with ${failureDescription(failureKind)}; retrying in ${delayMs / 1000}s.\n`,
+    );
+    try {
+      await sleeper(delayMs);
+    } catch {
+      stderr.write(`[mobile:publish] ${label} retry wait failed; not retrying.\n`);
+      return { platform: invocation.platform, success: false, attempts: attempt, failureKind: 'unknown' };
+    }
+  }
+
+  // The loop always returns. Keep a defensive result so a future attempt-count
+  // refactor cannot turn an empty loop into accidental success.
+  return { platform: invocation.platform, success: false, attempts: 0, failureKind: 'unknown' };
+}
+
+/** Run every requested platform in order, even after an earlier failure. */
+export async function publishPlatformsSequentially(
+  platforms: readonly OtaPublishPlatform[],
+  publishPlatform: (platform: OtaPublishPlatform) => Promise<PlatformPublishOutcome>,
+): Promise<PlatformPublishOutcome[]> {
+  const outcomes: PlatformPublishOutcome[] = [];
+  for (const platform of platforms) {
+    try {
+      outcomes.push(await publishPlatform(platform));
+    } catch {
+      outcomes.push({ platform, success: false, attempts: 0, failureKind: 'unknown' });
+    }
+  }
+  return outcomes;
+}

--- a/scripts/lib/mobile-publish-retry.ts
+++ b/scripts/lib/mobile-publish-retry.ts
@@ -10,8 +10,8 @@
 
 import { spawn } from 'node:child_process';
 
-export const SELF_HOSTED_PUBLISH_MAX_ATTEMPTS = 4;
 export const SELF_HOSTED_PUBLISH_RETRY_DELAYS_MS = [30_000, 60_000, 120_000] as const;
+export const SELF_HOSTED_PUBLISH_MAX_ATTEMPTS = SELF_HOSTED_PUBLISH_RETRY_DELAYS_MS.length + 1;
 
 export type OtaPublishPlatform = 'ios' | 'android';
 export type PublishFailureKind = 's3-slowdown' | 'http-5xx' | 'permanent' | 'unknown';
@@ -241,7 +241,7 @@ export async function publishSelfHostedPlatformWithRetry(
       await sleeper(delayMs);
     } catch {
       stderr.write(`[mobile:publish] ${label} retry wait failed; not retrying.\n`);
-      return { platform: invocation.platform, success: false, attempts: attempt, failureKind: 'unknown' };
+      return { platform: invocation.platform, success: false, attempts: attempt, failureKind };
     }
   }
 

--- a/scripts/lib/mobile-publish-retry.ts
+++ b/scripts/lib/mobile-publish-retry.ts
@@ -247,7 +247,12 @@ export async function publishSelfHostedPlatformWithRetry(
 
   // The loop always returns. Keep a defensive result so a future attempt-count
   // refactor cannot turn an empty loop into accidental success.
-  return { platform: invocation.platform, success: false, attempts: 0, failureKind: 'unknown' };
+  return {
+    platform: invocation.platform,
+    success: false,
+    attempts: SELF_HOSTED_PUBLISH_MAX_ATTEMPTS,
+    failureKind: 'unknown',
+  };
 }
 
 /** Run every requested platform in order, even after an earlier failure. */

--- a/scripts/mobile-ota-publish-workflow.test.ts
+++ b/scripts/mobile-ota-publish-workflow.test.ts
@@ -43,8 +43,10 @@ describe('production OTA workflow reliability', () => {
     const android = stepBlock(production, 'Publish Android OTA');
     const summary = stepBlock(production, 'Summarize platform publish results');
 
+    expect(ios).toContain("steps.generate.outcome == 'success'");
     expect(ios).toContain('continue-on-error: true');
     expect(android).toContain('if: always()');
+    expect(android).toContain("steps.generate.outcome == 'success'");
     expect(android).toContain('continue-on-error: true');
     expect(summary).toContain('all_success');
     expect(summary).toContain('any_success');

--- a/scripts/mobile-ota-publish-workflow.test.ts
+++ b/scripts/mobile-ota-publish-workflow.test.ts
@@ -1,0 +1,73 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const WORKFLOW_DIR = resolve(REPO_ROOT, '.github', 'workflows');
+const production = readFileSync(resolve(WORKFLOW_DIR, 'mobile-ota-production.yml'), 'utf8');
+const backport = readFileSync(resolve(WORKFLOW_DIR, 'mobile-ota-backport.yml'), 'utf8');
+
+function stepBlock(workflow: string, stepName: string, nextStepName: string): string {
+  const start = workflow.indexOf(`      - name: ${stepName}`);
+  const end = workflow.indexOf(`      - name: ${nextStepName}`, start + 1);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return workflow.slice(start, end);
+}
+
+describe('production OTA workflow reliability', () => {
+  it('serializes runs without cancelling an active publish and has enough retry time', () => {
+    expect(production).toContain('group: mobile-ota-production');
+    expect(production).toContain('cancel-in-progress: false');
+    const timeout = Number(production.match(/timeout-minutes: (\d+)/)?.[1]);
+    expect(timeout).toBeGreaterThanOrEqual(45);
+  });
+
+  it('attempts Android after iOS and records the aggregate result', () => {
+    const ios = stepBlock(production, 'Publish iOS OTA', 'Publish Android OTA');
+    const android = stepBlock(production, 'Publish Android OTA', 'Summarize platform publish results');
+    const summary = stepBlock(production, 'Summarize platform publish results', 'Push changelog to main');
+
+    expect(ios).toContain('continue-on-error: true');
+    expect(android).toContain('if: always()');
+    expect(android).toContain('continue-on-error: true');
+    expect(summary).toContain('all_success');
+    expect(summary).toContain('any_success');
+    expect(summary).toContain('no automatic rollback was attempted');
+  });
+
+  it('pushes the changelog and announces success only after every requested platform succeeds', () => {
+    const push = stepBlock(production, 'Push changelog to main', 'Notify deployments channel');
+    const success = stepBlock(production, 'Notify deployments channel', 'Notify deployments channel of failure');
+
+    expect(push).toContain("steps.publish_summary.outputs.all_success == 'true'");
+    expect(push).not.toContain('if: always()');
+    expect(success).toContain("steps.publish_summary.outputs.all_success == 'true'");
+    expect(success).not.toContain("steps.publish_ios.outcome == 'success' ||");
+  });
+
+  it('runs the health check after any successful platform, including partial success', () => {
+    const health = stepBlock(production, 'OTA health check (non-blocking)', 'Notify OTA health to Discord');
+
+    expect(health).toContain('if: always()');
+    expect(health).toContain("steps.publish_ios.outcome == 'success' || steps.publish_android.outcome == 'success'");
+  });
+
+  it('reruns when the self-hosted publish implementation changes', () => {
+    expect(production).toContain("- 'scripts/mobile-publish.ts'");
+    expect(production).toContain("- 'scripts/lib/mobile-publish-retry.ts'");
+  });
+});
+
+describe('backport OTA workflow upload pressure', () => {
+  it('shares the production lane and limits the platform matrix to one publish', () => {
+    expect(backport).toContain('group: mobile-ota-production');
+    expect(backport).toContain('cancel-in-progress: false');
+    expect(backport).toContain('max-parallel: 1');
+    const timeout = Number(backport.match(/timeout-minutes: (\d+)/)?.[1]);
+    expect(timeout).toBeGreaterThanOrEqual(45);
+  });
+});

--- a/scripts/mobile-ota-publish-workflow.test.ts
+++ b/scripts/mobile-ota-publish-workflow.test.ts
@@ -9,6 +9,17 @@ const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const WORKFLOW_DIR = resolve(REPO_ROOT, '.github', 'workflows');
 const production = readFileSync(resolve(WORKFLOW_DIR, 'mobile-ota-production.yml'), 'utf8');
 const backport = readFileSync(resolve(WORKFLOW_DIR, 'mobile-ota-backport.yml'), 'utf8');
+const preview = readFileSync(resolve(WORKFLOW_DIR, 'mobile-ota-preview.yml'), 'utf8');
+
+function jobBlock(workflow: string, jobName: string): string {
+  const jobsStart = workflow.indexOf('\njobs:\n');
+  const start = workflow.indexOf(`\n  ${jobName}:\n`, jobsStart);
+  const remainingWorkflow = workflow.slice(start + 1);
+  const nextJobOffset = remainingWorkflow.search(/\n  [a-zA-Z0-9_-]+:\n/);
+  expect(jobsStart).toBeGreaterThanOrEqual(0);
+  expect(start).toBeGreaterThan(jobsStart);
+  return nextJobOffset >= 0 ? workflow.slice(start, start + 1 + nextJobOffset) : workflow.slice(start);
+}
 
 function stepBlock(workflow: string, stepName: string, nextStepName: string): string {
   const start = workflow.indexOf(`      - name: ${stepName}`);
@@ -22,7 +33,7 @@ describe('production OTA workflow reliability', () => {
   it('serializes runs without cancelling an active publish and has enough retry time', () => {
     expect(production).toContain('group: mobile-ota-production');
     expect(production).toContain('cancel-in-progress: false');
-    const timeout = Number(production.match(/timeout-minutes: (\d+)/)?.[1]);
+    const timeout = Number(jobBlock(production, 'publish').match(/timeout-minutes: (\d+)/)?.[1]);
     expect(timeout).toBeGreaterThanOrEqual(45);
   });
 
@@ -57,8 +68,14 @@ describe('production OTA workflow reliability', () => {
   });
 
   it('reruns when the self-hosted publish implementation changes', () => {
-    expect(production).toContain("- 'scripts/mobile-publish.ts'");
-    expect(production).toContain("- 'scripts/lib/mobile-publish-retry.ts'");
+    for (const implementationPath of [
+      'scripts/mobile-publish.ts',
+      'scripts/lib/mobile-publish-retry.ts',
+      'scripts/lib/eoas.ts',
+    ]) {
+      expect(production).toContain(`- '${implementationPath}'`);
+      expect(preview).toContain(`- '${implementationPath}'`);
+    }
   });
 });
 
@@ -67,7 +84,7 @@ describe('backport OTA workflow upload pressure', () => {
     expect(backport).toContain('group: mobile-ota-production');
     expect(backport).toContain('cancel-in-progress: false');
     expect(backport).toContain('max-parallel: 1');
-    const timeout = Number(backport.match(/timeout-minutes: (\d+)/)?.[1]);
+    const timeout = Number(jobBlock(backport, 'backport').match(/timeout-minutes: (\d+)/)?.[1]);
     expect(timeout).toBeGreaterThanOrEqual(45);
   });
 });

--- a/scripts/mobile-ota-publish-workflow.test.ts
+++ b/scripts/mobile-ota-publish-workflow.test.ts
@@ -51,6 +51,20 @@ describe('production OTA workflow reliability', () => {
     expect(summary).toContain('all_success');
     expect(summary).toContain('any_success');
     expect(summary).toContain('no automatic rollback was attempted');
+    const allSuccessOutputIndex = summary.indexOf('echo "all_success=$all_success" >> "$GITHUB_OUTPUT"');
+    const anySuccessOutputIndex = summary.indexOf('echo "any_success=$any_success" >> "$GITHUB_OUTPUT"');
+    const failureGuardIndex = summary.indexOf('if [ "$all_success" != true ]; then');
+    const failureExitIndex = summary.indexOf('exit 1', failureGuardIndex);
+    const failureGuardEndIndex = summary.indexOf('\n          fi', failureGuardIndex);
+    expect(allSuccessOutputIndex).toBeGreaterThanOrEqual(0);
+    expect(anySuccessOutputIndex).toBeGreaterThanOrEqual(0);
+    expect(failureGuardIndex).toBeGreaterThanOrEqual(0);
+    expect(failureExitIndex).toBeGreaterThan(failureGuardIndex);
+    expect(failureGuardEndIndex).toBeGreaterThan(failureExitIndex);
+    expect(failureGuardIndex).toBeGreaterThan(allSuccessOutputIndex);
+    expect(failureGuardIndex).toBeGreaterThan(anySuccessOutputIndex);
+    expect(failureExitIndex).toBeGreaterThan(allSuccessOutputIndex);
+    expect(failureExitIndex).toBeGreaterThan(anySuccessOutputIndex);
   });
 
   it('pushes the changelog and announces success only after every requested platform succeeds', () => {

--- a/scripts/mobile-ota-publish-workflow.test.ts
+++ b/scripts/mobile-ota-publish-workflow.test.ts
@@ -21,9 +21,10 @@ function jobBlock(workflow: string, jobName: string): string {
   return nextJobOffset >= 0 ? workflow.slice(start, start + 1 + nextJobOffset) : workflow.slice(start);
 }
 
-function stepBlock(workflow: string, stepName: string, nextStepName: string): string {
+function stepBlock(workflow: string, stepName: string): string {
   const start = workflow.indexOf(`      - name: ${stepName}`);
-  const end = workflow.indexOf(`      - name: ${nextStepName}`, start + 1);
+  const nextStepOffset = workflow.slice(start + 1).indexOf('\n      - name: ');
+  const end = nextStepOffset >= 0 ? start + 1 + nextStepOffset : workflow.length;
   expect(start).toBeGreaterThanOrEqual(0);
   expect(end).toBeGreaterThan(start);
   return workflow.slice(start, end);
@@ -38,9 +39,9 @@ describe('production OTA workflow reliability', () => {
   });
 
   it('attempts Android after iOS and records the aggregate result', () => {
-    const ios = stepBlock(production, 'Publish iOS OTA', 'Publish Android OTA');
-    const android = stepBlock(production, 'Publish Android OTA', 'Summarize platform publish results');
-    const summary = stepBlock(production, 'Summarize platform publish results', 'Push changelog to main');
+    const ios = stepBlock(production, 'Publish iOS OTA');
+    const android = stepBlock(production, 'Publish Android OTA');
+    const summary = stepBlock(production, 'Summarize platform publish results');
 
     expect(ios).toContain('continue-on-error: true');
     expect(android).toContain('if: always()');
@@ -51,8 +52,8 @@ describe('production OTA workflow reliability', () => {
   });
 
   it('pushes the changelog and announces success only after every requested platform succeeds', () => {
-    const push = stepBlock(production, 'Push changelog to main', 'Notify deployments channel');
-    const success = stepBlock(production, 'Notify deployments channel', 'Notify deployments channel of failure');
+    const push = stepBlock(production, 'Push changelog to main');
+    const success = stepBlock(production, 'Notify deployments channel');
 
     expect(push).toContain("steps.publish_summary.outputs.all_success == 'true'");
     expect(push).not.toContain('if: always()');
@@ -61,7 +62,7 @@ describe('production OTA workflow reliability', () => {
   });
 
   it('runs the health check after any successful platform, including partial success', () => {
-    const health = stepBlock(production, 'OTA health check (non-blocking)', 'Notify OTA health to Discord');
+    const health = stepBlock(production, 'OTA health check (non-blocking)');
 
     expect(health).toContain('if: always()');
     expect(health).toContain("steps.publish_ios.outcome == 'success' || steps.publish_android.outcome == 'success'");
@@ -85,6 +86,12 @@ describe('production OTA workflow reliability', () => {
 });
 
 describe('backport OTA workflow upload pressure', () => {
+  it('stays manual-only while publishing through the shared wrapper', () => {
+    expect(backport).toContain('on:\n  workflow_dispatch:');
+    expect(backport).not.toContain('on:\n  push:');
+    expect(backport).toContain('vp run mobile:publish -- --channel production');
+  });
+
   it('shares the production lane and limits the platform matrix to one publish', () => {
     expect(backport).toContain('group: mobile-ota-production');
     expect(backport).toContain('cancel-in-progress: false');

--- a/scripts/mobile-ota-publish-workflow.test.ts
+++ b/scripts/mobile-ota-publish-workflow.test.ts
@@ -77,6 +77,11 @@ describe('production OTA workflow reliability', () => {
       expect(preview).toContain(`- '${implementationPath}'`);
     }
   });
+
+  it('gives the preview publish job enough time for bounded platform retries', () => {
+    const timeout = Number(jobBlock(preview, 'publish').match(/timeout-minutes: (\d+)/)?.[1]);
+    expect(timeout).toBeGreaterThanOrEqual(45);
+  });
 });
 
 describe('backport OTA workflow upload pressure', () => {

--- a/scripts/mobile-publish.test.ts
+++ b/scripts/mobile-publish.test.ts
@@ -29,7 +29,12 @@ describe('mobile publish argument routing', () => {
 
   it('expands all to sequential iOS and Android targets', () => {
     expect(requestedSelfHostedPlatforms('all')).toEqual(['ios', 'android']);
+    expect(requestedSelfHostedPlatforms('ios')).toEqual(['ios']);
     expect(requestedSelfHostedPlatforms('android')).toEqual(['android']);
+  });
+
+  it('rejects an invalid self-hosted platform at the exported helper boundary', () => {
+    expect(() => requestedSelfHostedPlatforms('windows')).toThrow('Unsupported self-hosted publish platform');
   });
 
   it('parses the wrapper selector separately from the EAS branch', () => {

--- a/scripts/mobile-publish.test.ts
+++ b/scripts/mobile-publish.test.ts
@@ -11,6 +11,8 @@ describe('mobile publish argument routing', () => {
     expect(args[args.indexOf('--branch') + 1]).toBe('production');
     expect(args).not.toContain('--channel');
     expect(args[args.indexOf('--platform') + 1]).toBe('ios');
+    expect(args).toContain('--nonInteractive');
+    expect(args[args.indexOf('--packageRunner') + 1]).toBe('bunx');
   });
 
   it('keeps the EAS preview command arguments unchanged', () => {

--- a/scripts/mobile-publish.test.ts
+++ b/scripts/mobile-publish.test.ts
@@ -1,0 +1,43 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from 'vitest';
+import { buildEasUpdateArgs, buildSelfHostedEoasArgs, parseArgs, requestedSelfHostedPlatforms } from './mobile-publish';
+
+describe('mobile publish argument routing', () => {
+  it('maps the wrapper channel selector to an eoas branch without a deprecated channel flag', () => {
+    const args = buildSelfHostedEoasArgs('production', 'ios', 'fix the queue');
+
+    expect(args).toContain('--branch');
+    expect(args[args.indexOf('--branch') + 1]).toBe('production');
+    expect(args).not.toContain('--channel');
+    expect(args[args.indexOf('--platform') + 1]).toBe('ios');
+  });
+
+  it('keeps the EAS preview command arguments unchanged', () => {
+    expect(buildEasUpdateArgs('fix-branch', 'preview message', 'all')).toEqual([
+      'eas-cli@16',
+      'update',
+      '--branch',
+      'fix-branch',
+      '--message',
+      'preview message',
+      '--platform',
+      'all',
+      '--non-interactive',
+    ]);
+  });
+
+  it('expands all to sequential iOS and Android targets', () => {
+    expect(requestedSelfHostedPlatforms('all')).toEqual(['ios', 'android']);
+    expect(requestedSelfHostedPlatforms('android')).toEqual(['android']);
+  });
+
+  it('parses the wrapper selector separately from the EAS branch', () => {
+    expect(parseArgs(['--channel', 'production', '--platform=ios', '--message', 'release'])).toEqual({
+      branch: null,
+      channel: 'production',
+      message: 'release',
+      platform: 'ios',
+    });
+  });
+});

--- a/scripts/mobile-publish.ts
+++ b/scripts/mobile-publish.ts
@@ -320,7 +320,14 @@ export async function main(args: string[] = process.argv.slice(2)): Promise<numb
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  void main().then((exitCode) => {
-    process.exitCode = exitCode;
-  });
+  void main()
+    .then((exitCode) => {
+      process.exitCode = exitCode;
+    })
+    .catch(() => {
+      // Keep this generic: an unexpected error can contain child argv, env, or
+      // server output that must not be echoed as a captured diagnostic.
+      console.error('[mobile:publish] Unexpected publish failure.');
+      process.exitCode = 1;
+    });
 }

--- a/scripts/mobile-publish.ts
+++ b/scripts/mobile-publish.ts
@@ -97,7 +97,9 @@ export function buildSelfHostedEoasArgs(
 }
 
 export function requestedSelfHostedPlatforms(platform: string): OtaPublishPlatform[] {
-  return platform === 'all' ? ['ios', 'android'] : [platform as OtaPublishPlatform];
+  if (platform === 'all') return ['ios', 'android'];
+  if (platform === 'ios' || platform === 'android') return [platform];
+  throw new Error(`Unsupported self-hosted publish platform: ${platform}`);
 }
 
 function summarizePlatformOutcome(outcome: PlatformPublishOutcome): string {

--- a/scripts/mobile-publish.ts
+++ b/scripts/mobile-publish.ts
@@ -25,8 +25,14 @@
 
 import { execFileSync, spawnSync } from 'node:child_process';
 import { resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { EOAS_PACKAGE_SPEC, pathWithoutBrokenBunxShims } from './lib/eoas';
+import {
+  publishPlatformsSequentially,
+  publishSelfHostedPlatformWithRetry,
+  type OtaPublishPlatform,
+  type PlatformPublishOutcome,
+} from './lib/mobile-publish-retry';
 
 const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const MOBILE_DIR = resolve(ROOT_DIR, 'packages', 'mobile');
@@ -68,7 +74,43 @@ function getCommitSubject(): string {
   }
 }
 
-function publishToSelfHostedChannel(channelName: string, platform: string, explicitMessage: string | null): never {
+export function buildSelfHostedEoasArgs(
+  channelName: string,
+  platform: OtaPublishPlatform,
+  updateMessage: string,
+): string[] {
+  return [
+    EOAS_PACKAGE_SPEC,
+    'publish',
+    '--branch',
+    channelName,
+    '--platform',
+    platform,
+    '--message',
+    updateMessage,
+    '--nonInteractive',
+    // The repo uses bun; force bunx so eoas spawns `bunx expo export` regardless
+    // of the nearest package.json's packageManager field.
+    '--packageRunner',
+    'bunx',
+  ];
+}
+
+export function requestedSelfHostedPlatforms(platform: string): OtaPublishPlatform[] {
+  return platform === 'all' ? ['ios', 'android'] : [platform as OtaPublishPlatform];
+}
+
+function summarizePlatformOutcome(outcome: PlatformPublishOutcome): string {
+  if (outcome.success)
+    return `${outcome.platform}=success (${outcome.attempts} attempt${outcome.attempts === 1 ? '' : 's'})`;
+  return `${outcome.platform}=failed (${outcome.attempts} attempt${outcome.attempts === 1 ? '' : 's'}, ${outcome.failureKind ?? 'unknown'})`;
+}
+
+async function publishToSelfHostedChannel(
+  channelName: string,
+  platform: string,
+  explicitMessage: string | null,
+): Promise<number> {
   const serverUrl = process.env.EXPO_UPDATES_URL;
   if (!serverUrl) {
     console.error('[mobile:publish] --channel requires EXPO_UPDATES_URL (the expo-open-ota manifest endpoint,');
@@ -76,13 +118,13 @@ function publishToSelfHostedChannel(channelName: string, platform: string, expli
       '[mobile:publish] e.g. https://updates.boardsesh.com/manifest). eoas derives the upload host from it.',
     );
     console.error('[mobile:publish] See docs/mobile-ota-updates.md.');
-    process.exit(1);
+    return 1;
   }
   if (!process.env.EOO_TOKEN) {
     console.error('[mobile:publish] --channel requires EOO_TOKEN (an app-scoped expo-open-ota API key).');
     console.error('[mobile:publish] The V3 control-plane server rejects Expo tokens; mint a key in the dashboard');
     console.error('[mobile:publish] and set EOO_TOKEN locally / in CI. See docs/mobile-ota-updates.md.');
-    process.exit(1);
+    return 1;
   }
 
   const commitHash = getShortCommitHash();
@@ -99,30 +141,11 @@ function publishToSelfHostedChannel(channelName: string, platform: string, expli
   // (--rollout-percentage targets a branch's runtimeVersion), not channel scoped.
   // EOAS_PACKAGE_SPEC pins the CLI to the exact deployed V3 server version
   // (control-plane requires an exact match); see scripts/lib/eoas.ts.
-  const eoasArgs = [
-    EOAS_PACKAGE_SPEC,
-    'publish',
-    '--branch',
-    channelName,
-    '--platform',
-    platform,
-    '--message',
-    updateMessage,
-    '--nonInteractive',
-    // The repo uses bun; force bunx so eoas spawns `bunx expo export` regardless
-    // of the nearest package.json's packageManager field.
-    '--packageRunner',
-    'bunx',
-  ];
-
   console.log(`[mobile:publish] Mode:     production (self-hosted expo-open-ota)`);
   console.log(`[mobile:publish] Server:   ${serverUrl}`);
   console.log(`[mobile:publish] Branch:   ${channelName}`);
   console.log(`[mobile:publish] Message:  ${updateMessage}`);
   console.log(`[mobile:publish] Platform: ${platform}`);
-  console.log('');
-  console.log(`[mobile:publish] Running: bunx ${eoasArgs.join(' ')}`);
-  console.log('');
 
   // EXPO_UPDATES_URL must resolve in app.config so eoas finds the server.
   // EAS_BUILD must be unset or app.config returns the EAS URL and eoas would
@@ -134,25 +157,36 @@ function publishToSelfHostedChannel(channelName: string, platform: string, expli
   // spawns via --packageRunner bunx — resolve a working bunx.
   eoasEnv.PATH = pathWithoutBrokenBunxShims(process.env.PATH);
 
-  const result = spawnSync('bunx', eoasArgs, {
-    cwd: MOBILE_DIR,
-    stdio: 'inherit',
-    env: eoasEnv,
+  const platforms = requestedSelfHostedPlatforms(platform);
+  const outcomes = await publishPlatformsSequentially(platforms, async (requestedPlatform) => {
+    const platformEnv = { ...eoasEnv };
+    if (requestedPlatform === 'ios') delete platformEnv.GOOGLE_MAPS_API_KEY;
+    const eoasArgs = buildSelfHostedEoasArgs(channelName, requestedPlatform, updateMessage);
+    console.log('');
+    console.log(`[mobile:publish] Running ${requestedPlatform}: bunx ${eoasArgs.join(' ')}`);
+    console.log('');
+    return publishSelfHostedPlatformWithRetry({
+      platform: requestedPlatform,
+      command: 'bunx',
+      args: eoasArgs,
+      cwd: MOBILE_DIR,
+      env: platformEnv,
+    });
   });
 
-  if (result.status !== 0) {
-    console.error('');
-    console.error('[mobile:publish] eoas publish failed.');
-    process.exit(result.status ?? 1);
+  console.log('');
+  console.log(`[mobile:publish] Platform results: ${outcomes.map(summarizePlatformOutcome).join(', ')}`);
+  if (outcomes.some((outcome) => !outcome.success)) {
+    console.error('[mobile:publish] One or more platform publishes failed; successful platforms were not rolled back.');
+    return 1;
   }
 
-  console.log('');
-  console.log(`[mobile:publish] Published to self-hosted channel "${channelName}".`);
+  console.log(`[mobile:publish] Published every requested platform to self-hosted channel "${channelName}".`);
   console.log(`[mobile:publish] Testers on a build baked with this channel receive it on next launch.`);
-  process.exit(0);
+  return 0;
 }
 
-function parseArgs(args: string[]): {
+export function parseArgs(args: string[]): {
   branch: string | null;
   message: string | null;
   platform: string;
@@ -209,69 +243,82 @@ function parseArgs(args: string[]): {
 
 const VALID_PLATFORMS = ['ios', 'android', 'all'] as const;
 
-const { branch: explicitBranch, message: explicitMessage, platform, channel } = parseArgs(process.argv.slice(2));
-
-if (!VALID_PLATFORMS.includes(platform as (typeof VALID_PLATFORMS)[number])) {
-  console.error(`[mobile:publish] Invalid platform "${platform}". Must be one of: ${VALID_PLATFORMS.join(', ')}`);
-  process.exit(1);
+export function buildEasUpdateArgs(sanitizedBranch: string, updateMessage: string, platform: string): string[] {
+  return [
+    'eas-cli@16',
+    'update',
+    '--branch',
+    sanitizedBranch,
+    '--message',
+    updateMessage,
+    '--platform',
+    platform,
+    '--non-interactive',
+  ];
 }
 
-// Production path: publish to the self-hosted expo-open-ota server via eoas.
-// The channel name maps to a same-named branch on the server.
-if (channel) {
-  publishToSelfHostedChannel(channel, platform, explicitMessage);
-}
+export async function main(args: string[] = process.argv.slice(2)): Promise<number> {
+  const { branch: explicitBranch, message: explicitMessage, platform, channel } = parseArgs(args);
 
-const branchName = explicitBranch ?? resolveCurrentBranchName();
-if (!branchName) {
-  console.error('[mobile:publish] Could not determine branch name. Use --branch <name> or run from a git branch.');
-  process.exit(1);
-}
-
-const sanitizedBranch = branchName.replace(/[^a-zA-Z0-9._-]/g, '-');
-const commitHash = getShortCommitHash();
-const commitSubject = getCommitSubject();
-const updateMessage = explicitMessage ?? `${commitHash} ${commitSubject}`.trim();
-
-console.log(`[mobile:publish] Branch:   ${sanitizedBranch}`);
-console.log(`[mobile:publish] Message:  ${updateMessage}`);
-console.log(`[mobile:publish] Platform: ${platform}`);
-console.log('');
-
-const easArgs = [
-  'eas-cli@16',
-  'update',
-  '--branch',
-  sanitizedBranch,
-  '--message',
-  updateMessage,
-  '--platform',
-  platform,
-  '--non-interactive',
-];
-
-console.log(`[mobile:publish] Running: bunx ${easArgs.join(' ')}`);
-console.log('');
-
-const result = spawnSync('bunx', easArgs, {
-  cwd: MOBILE_DIR,
-  stdio: 'inherit',
-  env: { ...process.env, PATH: pathWithoutBrokenBunxShims(process.env.PATH) },
-});
-
-if (result.status !== 0) {
-  console.error('');
-  console.error('[mobile:publish] Update failed.');
-  if (result.status === 1) {
-    console.error('[mobile:publish] Make sure you are logged in: bunx eas login');
-    console.error('[mobile:publish] And the project is linked: bunx eas init (from packages/mobile/)');
+  if (!VALID_PLATFORMS.includes(platform as (typeof VALID_PLATFORMS)[number])) {
+    console.error(`[mobile:publish] Invalid platform "${platform}". Must be one of: ${VALID_PLATFORMS.join(', ')}`);
+    return 1;
   }
-  process.exit(result.status ?? 1);
+
+  // Production path: publish to the self-hosted expo-open-ota server via eoas.
+  // The channel name maps to a same-named branch on the server.
+  if (channel) {
+    return publishToSelfHostedChannel(channel, platform, explicitMessage);
+  }
+
+  const branchName = explicitBranch ?? resolveCurrentBranchName();
+  if (!branchName) {
+    console.error('[mobile:publish] Could not determine branch name. Use --branch <name> or run from a git branch.');
+    return 1;
+  }
+
+  const sanitizedBranch = branchName.replace(/[^a-zA-Z0-9._-]/g, '-');
+  const commitHash = getShortCommitHash();
+  const commitSubject = getCommitSubject();
+  const updateMessage = explicitMessage ?? `${commitHash} ${commitSubject}`.trim();
+
+  console.log(`[mobile:publish] Branch:   ${sanitizedBranch}`);
+  console.log(`[mobile:publish] Message:  ${updateMessage}`);
+  console.log(`[mobile:publish] Platform: ${platform}`);
+  console.log('');
+
+  const easArgs = buildEasUpdateArgs(sanitizedBranch, updateMessage, platform);
+
+  console.log(`[mobile:publish] Running: bunx ${easArgs.join(' ')}`);
+  console.log('');
+
+  const result = spawnSync('bunx', easArgs, {
+    cwd: MOBILE_DIR,
+    stdio: 'inherit',
+    env: { ...process.env, PATH: pathWithoutBrokenBunxShims(process.env.PATH) },
+  });
+
+  if (result.status !== 0) {
+    console.error('');
+    console.error('[mobile:publish] Update failed.');
+    if (result.status === 1) {
+      console.error('[mobile:publish] Make sure you are logged in: bunx eas login');
+      console.error('[mobile:publish] And the project is linked: bunx eas init (from packages/mobile/)');
+    }
+    return result.status ?? 1;
+  }
+
+  console.log('');
+  console.log(`[mobile:publish] Published to branch "${sanitizedBranch}".`);
+  console.log(`[mobile:publish] Testers on the "preview" build will receive this update.`);
+  console.log('');
+  console.log(`[mobile:publish] To point a preview build at this branch:`);
+  console.log(`  bunx eas-cli@16 channel:edit preview --branch ${sanitizedBranch}`);
+  return 0;
 }
 
-console.log('');
-console.log(`[mobile:publish] Published to branch "${sanitizedBranch}".`);
-console.log(`[mobile:publish] Testers on the "preview" build will receive this update.`);
-console.log('');
-console.log(`[mobile:publish] To point a preview build at this branch:`);
-console.log(`  bunx eas-cli@16 channel:edit preview --branch ${sanitizedBranch}`);
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main().then((exitCode) => {
+    process.exitCode = exitCode;
+  });
+}


### PR DESCRIPTION
## Summary

- retry self-hosted eoas publishes only for exact S3 SlowDown responses or explicit HTTP 5xx statuses, with four bounded attempts and streamed output
- publish requested platforms sequentially, report partial success without an unsafe rollback, and gate changelog push/success notifications on complete success
- reduce OTA upload pressure in production/backport workflows and document the failure policy

Closes #3620

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project scripts --reporter=agent` (41 files, 545 tests)
- `vp run typecheck:mobile`
- scoped `vp check` for all changed files
- independent adversarial review: ACCEPT
- no manual OTA publish or release mutation performed