### PR TITLE
fix(backend): dedupe gym reports across instances

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -172,6 +172,8 @@ The web and mobile queue providers are thin wrappers around a small stack of sha
 2. **Subscriber** — dedicated to ioredis pub/sub mode (enters special subscribe-only mode)
 3. **Stream Consumer** — dedicated to EventBroker's blocking `XREADGROUP BLOCK 5000` loop, preventing it from starving the publisher connection
 
+`RedisClientManager.onRedisReady` runs registered recovery handlers after all three connections are ready and before request handlers see Redis as connected. Failures are isolated so Redis can still become available. Duplicate-gym report claims drain generation-stamped snapshots through the end of readiness recovery, including claims accepted while an earlier Redis write is awaiting a response. Request-path retries remain opportunistic and back off to once per minute during a persistent partition.
+
 ---
 
 ## Connection Flow

--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -172,7 +172,7 @@ The web and mobile queue providers are thin wrappers around a small stack of sha
 2. **Subscriber** — dedicated to ioredis pub/sub mode (enters special subscribe-only mode)
 3. **Stream Consumer** — dedicated to EventBroker's blocking `XREADGROUP BLOCK 5000` loop, preventing it from starving the publisher connection
 
-`RedisClientManager.onRedisReady` runs registered recovery handlers after all three connections are ready and before request handlers see Redis as connected. Failures are isolated so Redis can still become available. Duplicate-gym report claims drain generation-stamped snapshots through the end of readiness recovery, including claims accepted while an earlier Redis write is awaiting a response. Request-path retries remain opportunistic and back off to once per minute during a persistent partition.
+`RedisClientManager.onRedisReady` runs registered recovery handlers after all three connections are ready and before request handlers see Redis as connected. A handler registered during an in-flight readiness pass joins that same barrier; one registered after Redis is connected runs immediately. Failures are isolated so Redis can still become available. Duplicate-gym report claims drain generation-stamped snapshots through the end of readiness recovery, including claims accepted while an earlier Redis write is awaiting a response. Request-path retries remain opportunistic and back off to once per minute during a persistent partition.
 
 ---
 

--- a/packages/backend/src/__tests__/gym-duplicate-report-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-duplicate-report-claims.test.ts
@@ -1,0 +1,215 @@
+import Redis from 'ioredis';
+import { v4 as uuidv4 } from 'uuid';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vite-plus/test';
+import {
+  acquireGymDuplicateReportClaim,
+  GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS,
+  gymDuplicateReportClaimKey,
+  releaseGymDuplicateReportClaim,
+  resetGymDuplicateReportClaimsForTests,
+  type GymDuplicateReportClaimDependencies,
+  type GymDuplicateReportRedisClient,
+} from '../utils/gym-duplicate-report-claims';
+
+class FakeRedisClaimClient implements GymDuplicateReportRedisClient {
+  readonly claims = new Map<string, string>();
+  throwAfterNextSet = false;
+
+  async set(
+    key: string,
+    ownerToken: string,
+    _expiryMode: 'EX',
+    _ttlSeconds: number,
+    _condition: 'NX',
+  ): Promise<'OK' | null> {
+    if (this.claims.has(key)) return null;
+    this.claims.set(key, ownerToken);
+    if (this.throwAfterNextSet) {
+      this.throwAfterNextSet = false;
+      throw new Error('connection closed after write');
+    }
+    return 'OK';
+  }
+
+  async eval(_script: string, _numberOfKeys: number, key: string, ownerToken: string): Promise<number> {
+    if (this.claims.get(key) !== ownerToken) return 0;
+    this.claims.delete(key);
+    return 1;
+  }
+}
+
+function createDependencies(options: {
+  redisClient?: GymDuplicateReportRedisClient;
+  connected?: boolean;
+  now?: () => number;
+  tokens: string[];
+}): GymDuplicateReportClaimDependencies {
+  let tokenIndex = 0;
+  return {
+    isRedisConnected: () => options.connected ?? false,
+    getRedisClient: () => {
+      if (!options.redisClient) throw new Error('Redis client was not supplied');
+      return options.redisClient;
+    },
+    createOwnerToken: () => options.tokens[tokenIndex++] ?? `owner-${tokenIndex}`,
+    now: options.now ?? Date.now,
+  };
+}
+
+beforeEach(() => {
+  resetGymDuplicateReportClaimsForTests();
+});
+
+describe('gym duplicate report claim ownership', () => {
+  it('builds one stable key for either ordering of a UUID pair', () => {
+    const firstUuid = '00000000-0000-4000-8000-000000000002';
+    const secondUuid = '00000000-0000-4000-8000-000000000001';
+    const expectedKey = `gymDuplicateReport:${secondUuid}:${firstUuid}`;
+
+    expect(gymDuplicateReportClaimKey(firstUuid, secondUuid)).toBe(expectedKey);
+    expect(gymDuplicateReportClaimKey(secondUuid, firstUuid)).toBe(expectedKey);
+  });
+
+  it('does not let an expired local owner release its successor', async () => {
+    let now = 1_000;
+    const key = 'gymDuplicateReport:test:local-owner';
+    const dependencies = createDependencies({
+      connected: false,
+      now: () => now,
+      tokens: ['expired-owner', 'successor-owner', 'third-owner'],
+    });
+    const expiredResult = await acquireGymDuplicateReportClaim(key, dependencies);
+    expect(expiredResult.status).toBe('acquired');
+    if (expiredResult.status !== 'acquired') throw new Error('Expected the first local claim');
+
+    now += GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS * 1000 + 1;
+    const successorResult = await acquireGymDuplicateReportClaim(key, dependencies);
+    expect(successorResult.status).toBe('acquired');
+    if (successorResult.status !== 'acquired') throw new Error('Expected the successor local claim');
+
+    await releaseGymDuplicateReportClaim(expiredResult.claim);
+    await expect(acquireGymDuplicateReportClaim(key, dependencies)).resolves.toEqual({ status: 'already_claimed' });
+
+    await releaseGymDuplicateReportClaim(successorResult.claim);
+    await expect(acquireGymDuplicateReportClaim(key, dependencies)).resolves.toMatchObject({ status: 'acquired' });
+  });
+
+  it('keeps the Redis claim authoritative after process-local state resets', async () => {
+    const redisClient = new FakeRedisClaimClient();
+    const key = 'gymDuplicateReport:test:redis-survives-reset';
+    const firstDependencies = createDependencies({ connected: true, redisClient, tokens: ['first-owner'] });
+    const secondDependencies = createDependencies({ connected: true, redisClient, tokens: ['second-owner'] });
+
+    await expect(acquireGymDuplicateReportClaim(key, firstDependencies)).resolves.toMatchObject({
+      status: 'acquired',
+    });
+    resetGymDuplicateReportClaimsForTests();
+
+    await expect(acquireGymDuplicateReportClaim(key, secondDependencies)).resolves.toEqual({
+      status: 'already_claimed',
+    });
+    expect(redisClient.claims.get(key)).toBe('first-owner');
+  });
+
+  it('uses owner checks for both local and Redis release', async () => {
+    const redisClient = new FakeRedisClaimClient();
+    const key = 'gymDuplicateReport:test:redis-owner';
+    const oldDependencies = createDependencies({ connected: true, redisClient, tokens: ['old-owner'] });
+    const oldResult = await acquireGymDuplicateReportClaim(key, oldDependencies);
+    if (oldResult.status !== 'acquired') throw new Error('Expected the old claim');
+
+    // Model expiry/process hand-off without clearing unrelated Redis state: this
+    // exact key alone expires, then a successor acquires it.
+    resetGymDuplicateReportClaimsForTests();
+    redisClient.claims.delete(key);
+    const successorDependencies = createDependencies({ connected: true, redisClient, tokens: ['successor-owner'] });
+    const successorResult = await acquireGymDuplicateReportClaim(key, successorDependencies);
+    if (successorResult.status !== 'acquired') throw new Error('Expected the successor claim');
+
+    await releaseGymDuplicateReportClaim(oldResult.claim);
+    expect(redisClient.claims.get(key)).toBe('successor-owner');
+    await expect(acquireGymDuplicateReportClaim(key, successorDependencies)).resolves.toEqual({
+      status: 'already_claimed',
+    });
+
+    await releaseGymDuplicateReportClaim(successorResult.claim);
+    expect(redisClient.claims.has(key)).toBe(false);
+  });
+
+  it('remembers an apply-then-throw token so owner-checked cleanup permits retry', async () => {
+    const redisClient = new FakeRedisClaimClient();
+    redisClient.throwAfterNextSet = true;
+    const key = 'gymDuplicateReport:test:ambiguous-set';
+    const firstDependencies = createDependencies({ connected: true, redisClient, tokens: ['ambiguous-owner'] });
+    const firstResult = await acquireGymDuplicateReportClaim(key, firstDependencies);
+    if (firstResult.status !== 'acquired') throw new Error('Expected the ambiguous claim to degrade locally');
+    expect(redisClient.claims.get(key)).toBe('ambiguous-owner');
+
+    await releaseGymDuplicateReportClaim(firstResult.claim);
+    expect(redisClient.claims.has(key)).toBe(false);
+
+    const retryDependencies = createDependencies({ connected: true, redisClient, tokens: ['retry-owner'] });
+    await expect(acquireGymDuplicateReportClaim(key, retryDependencies)).resolves.toMatchObject({
+      status: 'acquired',
+    });
+  });
+});
+
+describe('gym duplicate report claim against test Redis', () => {
+  const redisUrl = process.env.REDIS_URL || 'redis://localhost:6380';
+  const redis = new Redis(redisUrl, { lazyConnect: true, maxRetriesPerRequest: 1 });
+  const exactKeysToClean = new Set<string>();
+
+  beforeAll(async () => {
+    await redis.connect();
+  });
+
+  afterAll(async () => {
+    if (exactKeysToClean.size > 0) {
+      await redis.del(...exactKeysToClean);
+    }
+    await redis.quit();
+  });
+
+  it('enforces NX, TTL, and owner-checked release on one exact key', async () => {
+    const key = gymDuplicateReportClaimKey(uuidv4(), uuidv4());
+    exactKeysToClean.add(key);
+    const firstOwnerToken = uuidv4();
+    const duplicateOwnerToken = uuidv4();
+    const successorOwnerToken = uuidv4();
+    const redisClient: GymDuplicateReportRedisClient = {
+      set: (claimKey, token, expiryMode, ttlSeconds, condition) =>
+        redis.set(claimKey, token, expiryMode, ttlSeconds, condition),
+      eval: (script, numberOfKeys, claimKey, token) => redis.eval(script, numberOfKeys, claimKey, token),
+    };
+    const firstDependencies = createDependencies({ connected: true, redisClient, tokens: [firstOwnerToken] });
+
+    const firstClaimResult = await acquireGymDuplicateReportClaim(key, firstDependencies);
+    expect(firstClaimResult.status).toBe('acquired');
+    if (firstClaimResult.status !== 'acquired') throw new Error('Expected the first real Redis claim');
+    expect(await redis.get(key)).toBe(firstOwnerToken);
+    expect(await redis.ttl(key)).toBeGreaterThanOrEqual(GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS - 5);
+    expect(await redis.ttl(key)).toBeLessThanOrEqual(GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS);
+
+    resetGymDuplicateReportClaimsForTests();
+    const duplicateDependencies = createDependencies({ connected: true, redisClient, tokens: [duplicateOwnerToken] });
+    await expect(acquireGymDuplicateReportClaim(key, duplicateDependencies)).resolves.toEqual({
+      status: 'already_claimed',
+    });
+    expect(await redis.get(key)).toBe(firstOwnerToken);
+
+    await redis.del(key);
+    const successorDependencies = createDependencies({ connected: true, redisClient, tokens: [successorOwnerToken] });
+    const successorClaimResult = await acquireGymDuplicateReportClaim(key, successorDependencies);
+    expect(successorClaimResult.status).toBe('acquired');
+    if (successorClaimResult.status !== 'acquired') throw new Error('Expected the successor real Redis claim');
+    expect(await redis.get(key)).toBe(successorOwnerToken);
+
+    await releaseGymDuplicateReportClaim(firstClaimResult.claim);
+    expect(await redis.get(key)).toBe(successorOwnerToken);
+
+    await releaseGymDuplicateReportClaim(successorClaimResult.claim);
+    expect(await redis.exists(key)).toBe(0);
+    exactKeysToClean.delete(key);
+  });
+});

--- a/packages/backend/src/__tests__/gym-duplicate-report-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-duplicate-report-claims.test.ts
@@ -1,10 +1,12 @@
 import Redis from 'ioredis';
 import { v4 as uuidv4 } from 'uuid';
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vite-plus/test';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { logger } from '../utils/logger';
 import {
   acquireGymDuplicateReportClaim,
   GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS,
   gymDuplicateReportClaimKey,
+  reconcileGymDuplicateReportClaims,
   releaseGymDuplicateReportClaim,
   resetGymDuplicateReportClaimsForTests,
   type GymDuplicateReportClaimDependencies,
@@ -12,18 +14,34 @@ import {
 } from '../utils/gym-duplicate-report-claims';
 
 class FakeRedisClaimClient implements GymDuplicateReportRedisClient {
-  readonly claims = new Map<string, string>();
+  readonly claims = new Map<string, { ownerToken: string; expiresAt: number }>();
+  readonly setCalls: Array<{ key: string; ownerToken: string; expiryMode: 'EX' | 'PXAT'; expiry: number }> = [];
   throwAfterNextSet = false;
+  throwBeforeNextSet = false;
+
+  constructor(private readonly now: () => number = Date.now) {}
+
+  private pruneExpired(key: string): void {
+    const claim = this.claims.get(key);
+    if (claim && claim.expiresAt <= this.now()) this.claims.delete(key);
+  }
 
   async set(
     key: string,
     ownerToken: string,
-    _expiryMode: 'EX',
-    _ttlSeconds: number,
+    expiryMode: 'EX' | 'PXAT',
+    expiry: number,
     _condition: 'NX',
   ): Promise<'OK' | null> {
+    this.setCalls.push({ key, ownerToken, expiryMode, expiry });
+    if (this.throwBeforeNextSet) {
+      this.throwBeforeNextSet = false;
+      throw new Error('connection closed before write');
+    }
+    this.pruneExpired(key);
     if (this.claims.has(key)) return null;
-    this.claims.set(key, ownerToken);
+    const expiresAt = expiryMode === 'EX' ? this.now() + expiry * 1000 : expiry;
+    this.claims.set(key, { ownerToken, expiresAt });
     if (this.throwAfterNextSet) {
       this.throwAfterNextSet = false;
       throw new Error('connection closed after write');
@@ -32,7 +50,8 @@ class FakeRedisClaimClient implements GymDuplicateReportRedisClient {
   }
 
   async eval(_script: string, _numberOfKeys: number, key: string, ownerToken: string): Promise<number> {
-    if (this.claims.get(key) !== ownerToken) return 0;
+    this.pruneExpired(key);
+    if (this.claims.get(key)?.ownerToken !== ownerToken) return 0;
     this.claims.delete(key);
     return 1;
   }
@@ -108,7 +127,7 @@ describe('gym duplicate report claim ownership', () => {
     await expect(acquireGymDuplicateReportClaim(key, secondDependencies)).resolves.toEqual({
       status: 'already_claimed',
     });
-    expect(redisClient.claims.get(key)).toBe('first-owner');
+    expect(redisClient.claims.get(key)?.ownerToken).toBe('first-owner');
   });
 
   it('retains the local claim when Redis reports connected but its client is unavailable', async () => {
@@ -142,7 +161,7 @@ describe('gym duplicate report claim ownership', () => {
     if (successorResult.status !== 'acquired') throw new Error('Expected the successor claim');
 
     await releaseGymDuplicateReportClaim(oldResult.claim);
-    expect(redisClient.claims.get(key)).toBe('successor-owner');
+    expect(redisClient.claims.get(key)?.ownerToken).toBe('successor-owner');
     await expect(acquireGymDuplicateReportClaim(key, successorDependencies)).resolves.toEqual({
       status: 'already_claimed',
     });
@@ -158,7 +177,7 @@ describe('gym duplicate report claim ownership', () => {
     const firstDependencies = createDependencies({ connected: true, redisClient, tokens: ['ambiguous-owner'] });
     const firstResult = await acquireGymDuplicateReportClaim(key, firstDependencies);
     if (firstResult.status !== 'acquired') throw new Error('Expected the ambiguous claim to degrade locally');
-    expect(redisClient.claims.get(key)).toBe('ambiguous-owner');
+    expect(redisClient.claims.get(key)?.ownerToken).toBe('ambiguous-owner');
 
     await releaseGymDuplicateReportClaim(firstResult.claim);
     expect(redisClient.claims.has(key)).toBe(false);
@@ -167,6 +186,265 @@ describe('gym duplicate report claim ownership', () => {
     await expect(acquireGymDuplicateReportClaim(key, retryDependencies)).resolves.toMatchObject({
       status: 'acquired',
     });
+  });
+
+  it('promotes an outage claim with only its remaining TTL and suppresses another instance', async () => {
+    let now = 10_000;
+    const redisClient = new FakeRedisClaimClient(() => now);
+    const key = 'gymDuplicateReport:test:outage-recovery';
+    const outageDependencies = createDependencies({
+      connected: false,
+      now: () => now,
+      tokens: ['outage-owner'],
+    });
+
+    const outageResult = await acquireGymDuplicateReportClaim(key, outageDependencies);
+    expect(outageResult.status).toBe('acquired');
+    if (outageResult.status !== 'acquired') throw new Error('Expected a local outage claim');
+
+    now += 90 * 60 * 1000;
+    await reconcileGymDuplicateReportClaims(redisClient, () => now);
+
+    const localExpiresAt = 10_000 + GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS * 1000;
+    expect(redisClient.setCalls).toContainEqual({
+      key,
+      ownerToken: 'outage-owner',
+      expiryMode: 'PXAT',
+      expiry: localExpiresAt,
+    });
+    expect(redisClient.claims.get(key)).toEqual({
+      ownerToken: 'outage-owner',
+      expiresAt: localExpiresAt,
+    });
+
+    // Model a different instance/restart with no process-local memory. The
+    // promoted Redis owner must still suppress the duplicate.
+    resetGymDuplicateReportClaimsForTests();
+    const otherInstanceDependencies = createDependencies({
+      connected: true,
+      redisClient,
+      now: () => now,
+      tokens: ['other-instance-owner'],
+    });
+    await expect(acquireGymDuplicateReportClaim(key, otherInstanceDependencies)).resolves.toEqual({
+      status: 'already_claimed',
+    });
+    expect(redisClient.claims.get(key)?.ownerToken).toBe('outage-owner');
+
+    await releaseGymDuplicateReportClaim(outageResult.claim);
+    expect(redisClient.claims.has(key)).toBe(false);
+  });
+
+  it('drops an expired local outage claim instead of promoting or extending it', async () => {
+    let now = 20_000;
+    const redisClient = new FakeRedisClaimClient(() => now);
+    const key = 'gymDuplicateReport:test:expired-before-recovery';
+    await acquireGymDuplicateReportClaim(
+      key,
+      createDependencies({ connected: false, now: () => now, tokens: ['expired-owner'] }),
+    );
+
+    now += GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS * 1000 + 1;
+    await reconcileGymDuplicateReportClaims(redisClient, () => now);
+
+    expect(redisClient.setCalls).toHaveLength(0);
+    expect(redisClient.claims.has(key)).toBe(false);
+    await expect(
+      acquireGymDuplicateReportClaim(
+        key,
+        createDependencies({ connected: false, now: () => now, tokens: ['fresh-owner'] }),
+      ),
+    ).resolves.toMatchObject({ status: 'acquired' });
+  });
+
+  it('never overwrites a conflicting distributed owner and retries after it clears', async () => {
+    let now = 30_000;
+    const redisClient = new FakeRedisClaimClient(() => now);
+    const key = 'gymDuplicateReport:test:promotion-conflict';
+    await acquireGymDuplicateReportClaim(
+      key,
+      createDependencies({ connected: false, now: () => now, tokens: ['local-owner'] }),
+    );
+    redisClient.claims.set(key, {
+      ownerToken: 'distributed-owner',
+      expiresAt: now + 60_000,
+    });
+
+    await reconcileGymDuplicateReportClaims(redisClient, () => now);
+    expect(redisClient.claims.get(key)?.ownerToken).toBe('distributed-owner');
+
+    redisClient.claims.delete(key);
+    now += 5_000;
+    await reconcileGymDuplicateReportClaims(redisClient, () => now);
+    expect(redisClient.claims.get(key)?.ownerToken).toBe('local-owner');
+    expect(redisClient.setCalls.at(-1)).toMatchObject({
+      expiryMode: 'PXAT',
+      expiry: 30_000 + GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS * 1000,
+    });
+  });
+
+  it('keeps a failed promotion local and retries without logging keys or owner tokens', async () => {
+    let now = 40_000;
+    const redisClient = new FakeRedisClaimClient(() => now);
+    redisClient.throwBeforeNextSet = true;
+    const key = 'gymDuplicateReport:test:promotion-retry';
+    const ownerToken = 'private-owner-token';
+    await acquireGymDuplicateReportClaim(
+      key,
+      createDependencies({ connected: false, now: () => now, tokens: [ownerToken] }),
+    );
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+
+    await reconcileGymDuplicateReportClaims(redisClient, () => now);
+    expect(redisClient.claims.has(key)).toBe(false);
+
+    now += 2_000;
+    await reconcileGymDuplicateReportClaims(redisClient, () => now);
+    expect(redisClient.claims.get(key)?.ownerToken).toBe(ownerToken);
+    expect(redisClient.setCalls.at(-1)?.expiry).toBe(40_000 + GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS * 1000);
+    const warningOutput = JSON.stringify(warnSpy.mock.calls);
+    expect(warningOutput).not.toContain(key);
+    expect(warningOutput).not.toContain(ownerToken);
+    warnSpy.mockRestore();
+  });
+
+  it('retries with a recovered client after an older in-flight promotion fails', async () => {
+    const now = 50_000;
+    const key = 'gymDuplicateReport:test:concurrent-recovery';
+    let rejectStalePromotion: ((error: Error) => void) | undefined;
+    const staleSet = vi.fn(
+      () =>
+        new Promise<'OK'>((_resolve, reject) => {
+          rejectStalePromotion = reject;
+        }),
+    );
+    const staleRedisClient: GymDuplicateReportRedisClient = {
+      set: staleSet,
+      eval: vi.fn().mockResolvedValue(0),
+    };
+    const recoveredRedisClient = new FakeRedisClaimClient(() => now);
+    await acquireGymDuplicateReportClaim(
+      key,
+      createDependencies({ connected: false, now: () => now, tokens: ['outage-owner'] }),
+    );
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+
+    const staleReconciliation = reconcileGymDuplicateReportClaims(staleRedisClient, () => now);
+    await vi.waitFor(() => expect(staleSet).toHaveBeenCalledTimes(1));
+    const recoveredReconciliation = reconcileGymDuplicateReportClaims(recoveredRedisClient, () => now);
+    await Promise.resolve();
+    expect(recoveredRedisClient.setCalls).toHaveLength(0);
+
+    rejectStalePromotion?.(new Error('stale client disconnected'));
+    await Promise.all([staleReconciliation, recoveredReconciliation]);
+
+    expect(recoveredRedisClient.setCalls).toContainEqual({
+      key,
+      ownerToken: 'outage-owner',
+      expiryMode: 'PXAT',
+      expiry: now + GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS * 1000,
+    });
+    expect(recoveredRedisClient.claims.get(key)?.ownerToken).toBe('outage-owner');
+    warnSpy.mockRestore();
+  });
+
+  it('uses the original absolute expiry when Redis delays a promotion command', async () => {
+    let now = 60_000;
+    const originalExpiresAt = now + GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS * 1000;
+    const key = 'gymDuplicateReport:test:delayed-promotion';
+    let finishPromotion: ((result: 'OK') => void) | undefined;
+    const setSpy = vi.fn(
+      () =>
+        new Promise<'OK'>((resolve) => {
+          finishPromotion = resolve;
+        }),
+    );
+    const redisClient: GymDuplicateReportRedisClient = {
+      set: setSpy,
+      eval: vi.fn().mockResolvedValue(1),
+    };
+    await acquireGymDuplicateReportClaim(
+      key,
+      createDependencies({ connected: false, now: () => now, tokens: ['delayed-owner'] }),
+    );
+
+    const reconciliation = reconcileGymDuplicateReportClaims(redisClient, () => now);
+    await vi.waitFor(() => expect(setSpy).toHaveBeenCalledTimes(1));
+    now += 2 * 60 * 60 * 1000;
+
+    expect(setSpy).toHaveBeenCalledExactlyOnceWith(key, 'delayed-owner', 'PXAT', originalExpiresAt, 'NX');
+    finishPromotion?.('OK');
+    await reconciliation;
+  });
+
+  it('releases a promoted owner when Redis writes the claim and then throws', async () => {
+    const key = 'gymDuplicateReport:test:ambiguous-promotion';
+    const redisClient = new FakeRedisClaimClient();
+    redisClient.throwAfterNextSet = true;
+    const outageResult = await acquireGymDuplicateReportClaim(
+      key,
+      createDependencies({ connected: false, tokens: ['ambiguous-promotion-owner'] }),
+    );
+    if (outageResult.status !== 'acquired') throw new Error('Expected a local outage claim');
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+
+    await reconcileGymDuplicateReportClaims(redisClient);
+    expect(redisClient.claims.get(key)?.ownerToken).toBe('ambiguous-promotion-owner');
+
+    await releaseGymDuplicateReportClaim(outageResult.claim);
+    expect(redisClient.claims.has(key)).toBe(false);
+    warnSpy.mockRestore();
+  });
+
+  it('does not release another Redis owner after a promotion conflict', async () => {
+    const key = 'gymDuplicateReport:test:conflicting-owner-release';
+    const redisClient = new FakeRedisClaimClient();
+    const outageResult = await acquireGymDuplicateReportClaim(
+      key,
+      createDependencies({ connected: false, tokens: ['local-owner'] }),
+    );
+    if (outageResult.status !== 'acquired') throw new Error('Expected a local outage claim');
+    redisClient.claims.set(key, {
+      ownerToken: 'other-owner',
+      expiresAt: Date.now() + 60_000,
+    });
+
+    await reconcileGymDuplicateReportClaims(redisClient);
+    await releaseGymDuplicateReportClaim(outageResult.claim);
+
+    expect(redisClient.claims.get(key)?.ownerToken).toBe('other-owner');
+  });
+
+  it('waits for an in-flight promotion before owner-checked release', async () => {
+    const key = 'gymDuplicateReport:test:promotion-release-race';
+    let finishPromotion: ((result: 'OK') => void) | undefined;
+    const evalSpy = vi.fn().mockResolvedValue(1);
+    const setSpy = vi.fn(
+      () =>
+        new Promise<'OK'>((resolve) => {
+          finishPromotion = resolve;
+        }),
+    );
+    const redisClient: GymDuplicateReportRedisClient = {
+      set: setSpy,
+      eval: evalSpy,
+    };
+    const outageResult = await acquireGymDuplicateReportClaim(
+      key,
+      createDependencies({ connected: false, tokens: ['racing-owner'] }),
+    );
+    if (outageResult.status !== 'acquired') throw new Error('Expected a local outage claim');
+
+    const promotion = reconcileGymDuplicateReportClaims(redisClient);
+    await vi.waitFor(() => expect(setSpy).toHaveBeenCalledTimes(1));
+    const release = releaseGymDuplicateReportClaim(outageResult.claim);
+    await Promise.resolve();
+    expect(evalSpy).not.toHaveBeenCalled();
+
+    finishPromotion?.('OK');
+    await promotion;
+    await release;
+    expect(evalSpy).toHaveBeenCalledExactlyOnceWith(expect.any(String), 1, key, 'racing-owner');
   });
 });
 
@@ -186,17 +464,23 @@ describe('gym duplicate report claim against test Redis', () => {
     await redis.quit();
   });
 
+  function realRedisClaimClient(): GymDuplicateReportRedisClient {
+    return {
+      set: (claimKey, token, expiryMode, expiry, condition) =>
+        expiryMode === 'EX'
+          ? redis.set(claimKey, token, 'EX', expiry, condition)
+          : redis.set(claimKey, token, 'PXAT', expiry, condition),
+      eval: (script, numberOfKeys, claimKey, token) => redis.eval(script, numberOfKeys, claimKey, token),
+    };
+  }
+
   it('enforces NX, TTL, and owner-checked release on one exact key', async () => {
     const key = gymDuplicateReportClaimKey(uuidv4(), uuidv4());
     exactKeysToClean.add(key);
     const firstOwnerToken = uuidv4();
     const duplicateOwnerToken = uuidv4();
     const successorOwnerToken = uuidv4();
-    const redisClient: GymDuplicateReportRedisClient = {
-      set: (claimKey, token, expiryMode, ttlSeconds, condition) =>
-        redis.set(claimKey, token, expiryMode, ttlSeconds, condition),
-      eval: (script, numberOfKeys, claimKey, token) => redis.eval(script, numberOfKeys, claimKey, token),
-    };
+    const redisClient = realRedisClaimClient();
     const firstDependencies = createDependencies({ connected: true, redisClient, tokens: [firstOwnerToken] });
 
     const firstClaimResult = await acquireGymDuplicateReportClaim(key, firstDependencies);
@@ -224,6 +508,37 @@ describe('gym duplicate report claim against test Redis', () => {
     expect(await redis.get(key)).toBe(successorOwnerToken);
 
     await releaseGymDuplicateReportClaim(successorClaimResult.claim);
+    expect(await redis.exists(key)).toBe(0);
+    exactKeysToClean.delete(key);
+  });
+
+  it('promotes an outage claim with its original absolute expiry and suppresses another process', async () => {
+    let now = Date.now();
+    const originalExpiresAt = now + GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS * 1000;
+    const key = gymDuplicateReportClaimKey(uuidv4(), uuidv4());
+    exactKeysToClean.add(key);
+    const redisClient = realRedisClaimClient();
+    const outageOwner = uuidv4();
+    const outageResult = await acquireGymDuplicateReportClaim(
+      key,
+      createDependencies({ connected: false, now: () => now, tokens: [outageOwner] }),
+    );
+    if (outageResult.status !== 'acquired') throw new Error('Expected a local outage claim');
+
+    now += 75 * 60 * 1000;
+    await reconcileGymDuplicateReportClaims(redisClient, () => now);
+    expect(await redis.get(key)).toBe(outageOwner);
+    expect(await redis.pexpiretime(key)).toBe(originalExpiresAt);
+
+    resetGymDuplicateReportClaimsForTests();
+    await expect(
+      acquireGymDuplicateReportClaim(
+        key,
+        createDependencies({ connected: true, redisClient, now: () => now, tokens: [uuidv4()] }),
+      ),
+    ).resolves.toEqual({ status: 'already_claimed' });
+
+    await releaseGymDuplicateReportClaim(outageResult.claim);
     expect(await redis.exists(key)).toBe(0);
     exactKeysToClean.delete(key);
   });

--- a/packages/backend/src/__tests__/gym-duplicate-report-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-duplicate-report-claims.test.ts
@@ -309,6 +309,65 @@ describe('gym duplicate report claim ownership', () => {
     warnSpy.mockRestore();
   });
 
+  it('backs off opportunistic promotion retries while a Redis partition persists', async () => {
+    let now = 45_000;
+    const outageKey = 'gymDuplicateReport:test:promotion-backoff';
+    const setSpy = vi.fn().mockRejectedValue(new Error('partition persists'));
+    const redisClient: GymDuplicateReportRedisClient = {
+      set: setSpy,
+      eval: vi.fn().mockResolvedValue(0),
+    };
+    await acquireGymDuplicateReportClaim(
+      outageKey,
+      createDependencies({ connected: false, now: () => now, tokens: ['outage-owner'] }),
+    );
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+    const connectedDependencies = createDependencies({
+      connected: true,
+      redisClient,
+      now: () => now,
+      tokens: ['request-one', 'request-two', 'request-three'],
+    });
+
+    await acquireGymDuplicateReportClaim('gymDuplicateReport:test:request-one', connectedDependencies);
+    expect(setSpy.mock.calls.filter(([key]) => key === outageKey)).toHaveLength(1);
+
+    await acquireGymDuplicateReportClaim('gymDuplicateReport:test:request-two', connectedDependencies);
+    expect(setSpy.mock.calls.filter(([key]) => key === outageKey)).toHaveLength(1);
+
+    now += 60_000;
+    await acquireGymDuplicateReportClaim('gymDuplicateReport:test:request-three', connectedDependencies);
+    expect(setSpy.mock.calls.filter(([key]) => key === outageKey)).toHaveLength(2);
+    warnSpy.mockRestore();
+  });
+
+  it('drains a new local claim that arrives during an awaited readiness promotion', async () => {
+    const firstKey = 'gymDuplicateReport:test:snapshot-first';
+    const secondKey = 'gymDuplicateReport:test:snapshot-second';
+    let finishFirstPromotion: ((result: 'OK') => void) | undefined;
+    const setSpy = vi.fn((key: string) => {
+      if (key === firstKey) {
+        return new Promise<'OK'>((resolve) => {
+          finishFirstPromotion = resolve;
+        });
+      }
+      return Promise.resolve('OK' as const);
+    });
+    const redisClient: GymDuplicateReportRedisClient = {
+      set: setSpy,
+      eval: vi.fn().mockResolvedValue(0),
+    };
+    await acquireGymDuplicateReportClaim(firstKey, createDependencies({ connected: false, tokens: ['first-owner'] }));
+
+    const firstReconciliation = reconcileGymDuplicateReportClaims(redisClient);
+    await vi.waitFor(() => expect(setSpy).toHaveBeenCalledTimes(1));
+    await acquireGymDuplicateReportClaim(secondKey, createDependencies({ connected: false, tokens: ['second-owner'] }));
+
+    finishFirstPromotion?.('OK');
+    await firstReconciliation;
+    expect(setSpy.mock.calls.map(([key]) => key)).toEqual([firstKey, secondKey]);
+  });
+
   it('retries with a recovered client after an older in-flight promotion fails', async () => {
     const now = 50_000;
     const key = 'gymDuplicateReport:test:concurrent-recovery';

--- a/packages/backend/src/__tests__/gym-duplicate-report-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-duplicate-report-claims.test.ts
@@ -137,7 +137,8 @@ describe('gym duplicate report claim ownership', () => {
     const firstResult = await acquireGymDuplicateReportClaim(key, dependencies);
     expect(firstResult.status).toBe('acquired');
     if (firstResult.status !== 'acquired') throw new Error('Expected a local-only claim');
-    expect(firstResult.claim).toMatchObject({ redisClient: null, redisClaimMayExist: false });
+    expect(firstResult.claim).toEqual({ key, ownerToken: 'local-owner' });
+    expect(Object.isFrozen(firstResult.claim)).toBe(true);
 
     await expect(acquireGymDuplicateReportClaim(key, dependencies)).resolves.toEqual({ status: 'already_claimed' });
 
@@ -332,8 +333,7 @@ describe('gym duplicate report claim ownership', () => {
     const staleReconciliation = reconcileGymDuplicateReportClaims(staleRedisClient, () => now);
     await vi.waitFor(() => expect(staleSet).toHaveBeenCalledTimes(1));
     const recoveredReconciliation = reconcileGymDuplicateReportClaims(recoveredRedisClient, () => now);
-    await Promise.resolve();
-    expect(recoveredRedisClient.setCalls).toHaveLength(0);
+    await vi.waitFor(() => expect(recoveredRedisClient.setCalls).toHaveLength(0));
 
     rejectStalePromotion?.(new Error('stale client disconnected'));
     await Promise.all([staleReconciliation, recoveredReconciliation]);
@@ -438,7 +438,6 @@ describe('gym duplicate report claim ownership', () => {
     const promotion = reconcileGymDuplicateReportClaims(redisClient);
     await vi.waitFor(() => expect(setSpy).toHaveBeenCalledTimes(1));
     const release = releaseGymDuplicateReportClaim(outageResult.claim);
-    await Promise.resolve();
     expect(evalSpy).not.toHaveBeenCalled();
 
     finishPromotion?.('OK');

--- a/packages/backend/src/__tests__/gym-duplicate-report-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-duplicate-report-claims.test.ts
@@ -111,6 +111,21 @@ describe('gym duplicate report claim ownership', () => {
     expect(redisClient.claims.get(key)).toBe('first-owner');
   });
 
+  it('retains the local claim when Redis reports connected but its client is unavailable', async () => {
+    const key = 'gymDuplicateReport:test:client-unavailable';
+    const dependencies = createDependencies({ connected: true, tokens: ['local-owner', 'retry-owner'] });
+
+    const firstResult = await acquireGymDuplicateReportClaim(key, dependencies);
+    expect(firstResult.status).toBe('acquired');
+    if (firstResult.status !== 'acquired') throw new Error('Expected a local-only claim');
+    expect(firstResult.claim).toMatchObject({ redisClient: null, redisClaimMayExist: false });
+
+    await expect(acquireGymDuplicateReportClaim(key, dependencies)).resolves.toEqual({ status: 'already_claimed' });
+
+    await releaseGymDuplicateReportClaim(firstResult.claim);
+    await expect(acquireGymDuplicateReportClaim(key, dependencies)).resolves.toMatchObject({ status: 'acquired' });
+  });
+
   it('uses owner checks for both local and Redis release', async () => {
     const redisClient = new FakeRedisClaimClient();
     const key = 'gymDuplicateReport:test:redis-owner';

--- a/packages/backend/src/__tests__/gym-duplicate-report-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-duplicate-report-claims.test.ts
@@ -15,7 +15,7 @@ import {
 
 class FakeRedisClaimClient implements GymDuplicateReportRedisClient {
   readonly claims = new Map<string, { ownerToken: string; expiresAt: number }>();
-  readonly setCalls: Array<{ key: string; ownerToken: string; expiryMode: 'EX' | 'PXAT'; expiry: number }> = [];
+  readonly setCalls: Array<{ key: string; ownerToken: string; expiryMode: 'PXAT'; expiry: number }> = [];
   throwAfterNextSet = false;
   throwBeforeNextSet = false;
 
@@ -29,7 +29,7 @@ class FakeRedisClaimClient implements GymDuplicateReportRedisClient {
   async set(
     key: string,
     ownerToken: string,
-    expiryMode: 'EX' | 'PXAT',
+    expiryMode: 'PXAT',
     expiry: number,
     _condition: 'NX',
   ): Promise<'OK' | null> {
@@ -40,8 +40,7 @@ class FakeRedisClaimClient implements GymDuplicateReportRedisClient {
     }
     this.pruneExpired(key);
     if (this.claims.has(key)) return null;
-    const expiresAt = expiryMode === 'EX' ? this.now() + expiry * 1000 : expiry;
-    this.claims.set(key, { ownerToken, expiresAt });
+    this.claims.set(key, { ownerToken, expiresAt: expiry });
     if (this.throwAfterNextSet) {
       this.throwAfterNextSet = false;
       throw new Error('connection closed after write');
@@ -571,9 +570,7 @@ describe('gym duplicate report claim against test Redis', () => {
   function realRedisClaimClient(): GymDuplicateReportRedisClient {
     return {
       set: (claimKey, token, expiryMode, expiry, condition) =>
-        expiryMode === 'EX'
-          ? redis.set(claimKey, token, 'EX', expiry, condition)
-          : redis.set(claimKey, token, 'PXAT', expiry, condition),
+        redis.set(claimKey, token, expiryMode, expiry, condition),
       eval: (script, numberOfKeys, claimKey, token) => redis.eval(script, numberOfKeys, claimKey, token),
     };
   }

--- a/packages/backend/src/__tests__/gym-duplicate-report-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-duplicate-report-claims.test.ts
@@ -113,7 +113,7 @@ describe('gym duplicate report claim ownership', () => {
     await expect(acquireGymDuplicateReportClaim(key, dependencies)).resolves.toMatchObject({ status: 'acquired' });
   });
 
-  it('keeps the Redis claim authoritative after process-local state resets', async () => {
+  it('releases the fresh local owner when SET NX returns null after process-local state resets', async () => {
     const redisClient = new FakeRedisClaimClient();
     const key = 'gymDuplicateReport:test:redis-survives-reset';
     const firstDependencies = createDependencies({ connected: true, redisClient, tokens: ['first-owner'] });
@@ -128,6 +128,52 @@ describe('gym duplicate report claim ownership', () => {
       status: 'already_claimed',
     });
     expect(redisClient.claims.get(key)?.ownerToken).toBe('first-owner');
+
+    // The null SET result must also release the just-created local owner. Once
+    // the prior Redis owner disappears, a new request can acquire immediately.
+    redisClient.claims.delete(key);
+    const successorDependencies = createDependencies({ connected: true, redisClient, tokens: ['successor-owner'] });
+    await expect(acquireGymDuplicateReportClaim(key, successorDependencies)).resolves.toMatchObject({
+      status: 'acquired',
+      claim: { ownerToken: 'successor-owner' },
+    });
+  });
+
+  it('pins a directly-acquired Redis claim to the local absolute expiry', async () => {
+    const now = 5_000;
+    const redisClient = new FakeRedisClaimClient(() => now);
+    const key = 'gymDuplicateReport:test:direct-absolute-expiry';
+
+    await expect(
+      acquireGymDuplicateReportClaim(
+        key,
+        createDependencies({ connected: true, redisClient, now: () => now, tokens: ['direct-owner'] }),
+      ),
+    ).resolves.toMatchObject({ status: 'acquired' });
+
+    expect(redisClient.setCalls).toEqual([
+      {
+        key,
+        ownerToken: 'direct-owner',
+        expiryMode: 'PXAT',
+        expiry: now + GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS * 1000,
+      },
+    ]);
+  });
+
+  it('does not re-SET an already-distributed claim during forced readiness reconciliation', async () => {
+    const redisClient = new FakeRedisClaimClient();
+    const key = 'gymDuplicateReport:test:already-distributed';
+    await acquireGymDuplicateReportClaim(
+      key,
+      createDependencies({ connected: true, redisClient, tokens: ['distributed-owner'] }),
+    );
+    expect(redisClient.setCalls).toHaveLength(1);
+
+    await reconcileGymDuplicateReportClaims(redisClient, Date.now, true);
+
+    expect(redisClient.setCalls).toHaveLength(1);
+    expect(redisClient.claims.get(key)?.ownerToken).toBe('distributed-owner');
   });
 
   it('retains the local claim when Redis reports connected but its client is unavailable', async () => {

--- a/packages/backend/src/__tests__/gym-report-duplicate.test.ts
+++ b/packages/backend/src/__tests__/gym-report-duplicate.test.ts
@@ -320,8 +320,8 @@ describe('reportGymDuplicate — de-duplication', () => {
         return 'OK';
       });
     mockRedisEval.mockImplementation(
-      async (script: string, _numberOfKeys: number, _key: string, ownerToken: string) => {
-        if (script.includes("redis.call('INCR'")) return 1;
+      async (_script: string, _numberOfKeys: number, claimKey: string, ownerToken: string) => {
+        if (!claimKey.startsWith('gymDuplicateReport:')) return 1;
         if (storedOwnerToken === ownerToken) {
           storedOwnerToken = null;
           return 1;
@@ -346,8 +346,8 @@ describe('reportGymDuplicate — de-duplication', () => {
 
   it('logs privacy-safe cleanup warnings and preserves the email failure', async () => {
     mockRedisIsConnected.mockReturnValue(true);
-    mockRedisEval.mockImplementation(async (script: string) => {
-      if (script.includes("redis.call('INCR'")) return 1;
+    mockRedisEval.mockImplementation(async (_script: string, _numberOfKeys: number, claimKey: string) => {
+      if (!claimKey.startsWith('gymDuplicateReport:')) return 1;
       throw new Error('release failed');
     });
     const gym = await insertGym({ name: 'Bahnhof Bloc' });

--- a/packages/backend/src/__tests__/gym-report-duplicate.test.ts
+++ b/packages/backend/src/__tests__/gym-report-duplicate.test.ts
@@ -6,9 +6,15 @@ import { db } from '../db/client';
 import { resetAllRateLimits } from '../utils/rate-limiter';
 import { logger } from '../utils/logger';
 
-const { mockRedisEval, mockRedisIsConnected, mockRedisSet } = vi.hoisted(() => ({
+const { mockRedisEval, mockRedisIsConnected, mockRedisReadyHandlers, mockRedisSet } = vi.hoisted(() => ({
   mockRedisEval: vi.fn(),
   mockRedisIsConnected: vi.fn(),
+  mockRedisReadyHandlers: [] as Array<
+    (redisClient: {
+      set: (...args: unknown[]) => Promise<unknown>;
+      eval: (...args: unknown[]) => Promise<unknown>;
+    }) => void | Promise<void>
+  >,
   mockRedisSet: vi.fn(),
 }));
 
@@ -21,6 +27,15 @@ vi.mock('../redis/client', () => ({
         set: mockRedisSet,
       },
     }),
+    onRedisReady: (
+      handler: (redisClient: {
+        set: (...args: unknown[]) => Promise<unknown>;
+        eval: (...args: unknown[]) => Promise<unknown>;
+      }) => void | Promise<void>,
+    ) => {
+      mockRedisReadyHandlers.push(handler);
+      return () => {};
+    },
   },
 }));
 
@@ -240,7 +255,7 @@ describe('reportGymDuplicate — de-duplication', () => {
     expect(sendGymDuplicateReportAdminNotification).toHaveBeenCalledTimes(1);
   });
 
-  it('retains a successful local claim through an outage and later Redis recovery', async () => {
+  it('promotes a successful local claim when a later request observes Redis recovery', async () => {
     const gym = await insertGym({ name: 'Bahnhof Bloc' });
     const dup = await insertGym({ name: 'Bahnhof Bloc (Kilter)' });
 
@@ -253,7 +268,48 @@ describe('reportGymDuplicate — de-duplication', () => {
       reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: dup.uuid }, authCtx(REPORTER)),
     ).resolves.toEqual({ status: 'already_reported' });
 
+    expect(mockRedisSet).toHaveBeenCalledExactlyOnceWith(
+      expect.stringMatching(/^gymDuplicateReport:/),
+      expect.stringMatching(/^[0-9a-f-]{36}$/),
+      'PXAT',
+      expect.any(Number),
+      'NX',
+    );
+    expect(sendGymDuplicateReportAdminNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('promotes on the Redis readiness hook before another process checks the pair', async () => {
+    expect(mockRedisReadyHandlers).toHaveLength(1);
+    let distributedOwnerToken: string | null = null;
+    mockRedisSet.mockImplementation(async (_key: string, ownerToken: string) => {
+      if (distributedOwnerToken !== null) return null;
+      distributedOwnerToken = ownerToken;
+      return 'OK';
+    });
+    const gym = await insertGym({ name: 'Recovery Bloc' });
+    const dup = await insertGym({ name: 'Recovery Bloc (old)' });
+
+    await expect(
+      reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: dup.uuid }, authCtx(REPORTER)),
+    ).resolves.toEqual({ status: 'reported' });
     expect(mockRedisSet).not.toHaveBeenCalled();
+
+    await mockRedisReadyHandlers[0]({ set: mockRedisSet, eval: mockRedisEval });
+    expect(mockRedisSet).toHaveBeenCalledWith(
+      expect.stringMatching(/^gymDuplicateReport:/),
+      distributedOwnerToken,
+      'PXAT',
+      expect.any(Number),
+      'NX',
+    );
+
+    // Drop this process's local memory. Redis alone now represents the other
+    // instance/restart and must prevent a second notification.
+    resetGymDuplicateReportClaimsForTests();
+    mockRedisIsConnected.mockReturnValue(true);
+    await expect(
+      reportGymDuplicate({ gymUuid: dup.uuid, duplicateGymUuid: gym.uuid }, authCtx(REPORTER)),
+    ).resolves.toEqual({ status: 'already_reported' });
     expect(sendGymDuplicateReportAdminNotification).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/backend/src/__tests__/gym-report-duplicate.test.ts
+++ b/packages/backend/src/__tests__/gym-report-duplicate.test.ts
@@ -4,6 +4,25 @@ import { sql } from 'drizzle-orm';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { db } from '../db/client';
 import { resetAllRateLimits } from '../utils/rate-limiter';
+import { logger } from '../utils/logger';
+
+const { mockRedisEval, mockRedisIsConnected, mockRedisSet } = vi.hoisted(() => ({
+  mockRedisEval: vi.fn(),
+  mockRedisIsConnected: vi.fn(),
+  mockRedisSet: vi.fn(),
+}));
+
+vi.mock('../redis/client', () => ({
+  redisClientManager: {
+    isRedisConnected: mockRedisIsConnected,
+    getClients: () => ({
+      publisher: {
+        eval: mockRedisEval,
+        set: mockRedisSet,
+      },
+    }),
+  },
+}));
 
 // The resolver imports the email module via '../../../email/email-service', which
 // resolves to the same absolute path as '../email/email-service' from here, so this
@@ -14,6 +33,10 @@ vi.mock('../email/email-service', () => ({
 
 import { socialGymReportMutations } from '../graphql/resolvers/social/gym-reports';
 import { sendGymDuplicateReportAdminNotification } from '../email/email-service';
+import {
+  GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS,
+  resetGymDuplicateReportClaimsForTests,
+} from '../utils/gym-duplicate-report-claims';
 
 let connectionCounter = 0;
 const authCtx = (userId: string): ConnectionContext =>
@@ -55,6 +78,13 @@ const reportGymDuplicate = (input: unknown, ctx: ConnectionContext) =>
 
 beforeEach(async () => {
   resetAllRateLimits();
+  resetGymDuplicateReportClaimsForTests();
+  mockRedisIsConnected.mockReset();
+  mockRedisIsConnected.mockReturnValue(false);
+  mockRedisEval.mockReset();
+  mockRedisEval.mockResolvedValue(1);
+  mockRedisSet.mockReset();
+  mockRedisSet.mockResolvedValue('OK');
   vi.mocked(sendGymDuplicateReportAdminNotification).mockClear();
   vi.mocked(sendGymDuplicateReportAdminNotification).mockImplementation(() => Promise.resolve());
   await db.execute(sql`TRUNCATE TABLE "gym_members", "gyms" RESTART IDENTITY CASCADE`);
@@ -153,6 +183,26 @@ describe('reportGymDuplicate — admin notification', () => {
 });
 
 describe('reportGymDuplicate — de-duplication', () => {
+  it('uses a distinct Redis SET NX EX claim after the per-user rate-limit eval', async () => {
+    mockRedisIsConnected.mockReturnValue(true);
+    const gym = await insertGym({ name: 'Bahnhof Bloc' });
+    const dup = await insertGym({ name: 'Bahnhof Bloc (Kilter)' });
+
+    const result = await reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: dup.uuid }, authCtx(REPORTER));
+
+    expect(result).toEqual({ status: 'reported' });
+    expect(mockRedisEval).toHaveBeenCalledTimes(1);
+    expect(mockRedisEval.mock.calls[0][0]).toContain("redis.call('INCR'");
+    const [lowUuid, highUuid] = [gym.uuid, dup.uuid].sort();
+    expect(mockRedisSet).toHaveBeenCalledExactlyOnceWith(
+      `gymDuplicateReport:${lowUuid}:${highUuid}`,
+      expect.stringMatching(/^[0-9a-f-]{36}$/),
+      'EX',
+      GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS,
+      'NX',
+    );
+  });
+
   it('de-dupes a repeat report of the same pair without re-emailing', async () => {
     const gym = await insertGym({ name: 'Bahnhof Bloc' });
     const dup = await insertGym({ name: 'Bahnhof Bloc (Kilter)' });
@@ -162,6 +212,71 @@ describe('reportGymDuplicate — de-duplication', () => {
 
     expect(first).toEqual({ status: 'reported' });
     expect(second).toEqual({ status: 'already_reported' });
+    expect(sendGymDuplicateReportAdminNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('collapses concurrent reversed-pair reports before the first email resolves', async () => {
+    const gym = await insertGym({ name: 'Bahnhof Bloc' });
+    const dup = await insertGym({ name: 'Bahnhof Bloc (Kilter)' });
+    let finishEmail: (() => void) | undefined;
+    vi.mocked(sendGymDuplicateReportAdminNotification).mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishEmail = resolve;
+        }),
+    );
+
+    const firstReport = reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: dup.uuid }, authCtx(REPORTER));
+    await vi.waitFor(() => expect(sendGymDuplicateReportAdminNotification).toHaveBeenCalledTimes(1));
+
+    const reversedReport = await reportGymDuplicate(
+      { gymUuid: dup.uuid, duplicateGymUuid: gym.uuid },
+      authCtx(REPORTER),
+    );
+    expect(reversedReport).toEqual({ status: 'already_reported' });
+
+    finishEmail?.();
+    await expect(firstReport).resolves.toEqual({ status: 'reported' });
+    expect(sendGymDuplicateReportAdminNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('retains a successful local claim through an outage and later Redis recovery', async () => {
+    const gym = await insertGym({ name: 'Bahnhof Bloc' });
+    const dup = await insertGym({ name: 'Bahnhof Bloc (Kilter)' });
+
+    await expect(
+      reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: dup.uuid }, authCtx(REPORTER)),
+    ).resolves.toEqual({ status: 'reported' });
+
+    mockRedisIsConnected.mockReturnValue(true);
+    await expect(
+      reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: dup.uuid }, authCtx(REPORTER)),
+    ).resolves.toEqual({ status: 'already_reported' });
+
+    expect(mockRedisSet).not.toHaveBeenCalled();
+    expect(sendGymDuplicateReportAdminNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a Redis claim effective after process-local state is reset', async () => {
+    mockRedisIsConnected.mockReturnValue(true);
+    let storedOwnerToken: string | null = null;
+    mockRedisSet.mockImplementation(async (_key: string, ownerToken: string) => {
+      if (storedOwnerToken !== null) return null;
+      storedOwnerToken = ownerToken;
+      return 'OK';
+    });
+    const gym = await insertGym({ name: 'Bahnhof Bloc' });
+    const dup = await insertGym({ name: 'Bahnhof Bloc (Kilter)' });
+
+    await expect(
+      reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: dup.uuid }, authCtx(REPORTER)),
+    ).resolves.toEqual({ status: 'reported' });
+    resetGymDuplicateReportClaimsForTests();
+
+    await expect(
+      reportGymDuplicate({ gymUuid: dup.uuid, duplicateGymUuid: gym.uuid }, authCtx(REPORTER)),
+    ).resolves.toEqual({ status: 'already_reported' });
+    expect(mockRedisSet).toHaveBeenCalledTimes(2);
     expect(sendGymDuplicateReportAdminNotification).toHaveBeenCalledTimes(1);
   });
 
@@ -189,6 +304,77 @@ describe('reportGymDuplicate — de-duplication', () => {
     const retry = await reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: dup.uuid }, authCtx(REPORTER));
     expect(retry).toEqual({ status: 'reported' });
     expect(sendGymDuplicateReportAdminNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it('cleans an apply-then-throw Redis claim after email failure so retry succeeds', async () => {
+    mockRedisIsConnected.mockReturnValue(true);
+    let storedOwnerToken: string | null = null;
+    mockRedisSet
+      .mockImplementationOnce(async (_key: string, ownerToken: string) => {
+        storedOwnerToken = ownerToken;
+        throw new Error('connection closed after write');
+      })
+      .mockImplementationOnce(async (_key: string, ownerToken: string) => {
+        if (storedOwnerToken !== null) return null;
+        storedOwnerToken = ownerToken;
+        return 'OK';
+      });
+    mockRedisEval.mockImplementation(
+      async (script: string, _numberOfKeys: number, _key: string, ownerToken: string) => {
+        if (script.includes("redis.call('INCR'")) return 1;
+        if (storedOwnerToken === ownerToken) {
+          storedOwnerToken = null;
+          return 1;
+        }
+        return 0;
+      },
+    );
+    const gym = await insertGym({ name: 'Bahnhof Bloc' });
+    const dup = await insertGym({ name: 'Bahnhof Bloc (Kilter)' });
+    vi.mocked(sendGymDuplicateReportAdminNotification).mockRejectedValueOnce(new Error('SMTP down'));
+
+    await expect(
+      reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: dup.uuid }, authCtx(REPORTER)),
+    ).rejects.toMatchObject({ extensions: { code: 'INTERNAL_SERVER_ERROR' } });
+
+    await expect(
+      reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: dup.uuid }, authCtx(REPORTER)),
+    ).resolves.toEqual({ status: 'reported' });
+    expect(mockRedisSet).toHaveBeenCalledTimes(2);
+    expect(sendGymDuplicateReportAdminNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it('logs privacy-safe cleanup warnings and preserves the email failure', async () => {
+    mockRedisIsConnected.mockReturnValue(true);
+    mockRedisEval.mockImplementation(async (script: string) => {
+      if (script.includes("redis.call('INCR'")) return 1;
+      throw new Error('release failed');
+    });
+    const gym = await insertGym({ name: 'Bahnhof Bloc' });
+    const dup = await insertGym({ name: 'Bahnhof Bloc (Kilter)' });
+    const emailError = new Error('SMTP down');
+    vi.mocked(sendGymDuplicateReportAdminNotification).mockRejectedValueOnce(emailError);
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => logger);
+
+    await expect(
+      reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: dup.uuid }, authCtx(REPORTER)),
+    ).rejects.toMatchObject({
+      message: "We couldn't send that report. Try again in a moment.",
+      extensions: { code: 'INTERNAL_SERVER_ERROR' },
+    });
+
+    expect(errorSpy).toHaveBeenCalledWith('[GymDuplicateReport] Failed to send admin notification:', emailError);
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[GymDuplicateReport] Redis claim cleanup failed; the claim will expire automatically.',
+    );
+    const warningOutput = JSON.stringify(warnSpy.mock.calls);
+    expect(warningOutput).not.toContain(gym.uuid);
+    expect(warningOutput).not.toContain(dup.uuid);
+    expect(warningOutput).not.toContain(mockRedisSet.mock.calls[0][1] as string);
+
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 });
 

--- a/packages/backend/src/__tests__/gym-report-duplicate.test.ts
+++ b/packages/backend/src/__tests__/gym-report-duplicate.test.ts
@@ -48,10 +48,7 @@ vi.mock('../email/email-service', () => ({
 
 import { socialGymReportMutations } from '../graphql/resolvers/social/gym-reports';
 import { sendGymDuplicateReportAdminNotification } from '../email/email-service';
-import {
-  GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS,
-  resetGymDuplicateReportClaimsForTests,
-} from '../utils/gym-duplicate-report-claims';
+import { resetGymDuplicateReportClaimsForTests } from '../utils/gym-duplicate-report-claims';
 
 let connectionCounter = 0;
 const authCtx = (userId: string): ConnectionContext =>
@@ -198,7 +195,7 @@ describe('reportGymDuplicate — admin notification', () => {
 });
 
 describe('reportGymDuplicate — de-duplication', () => {
-  it('uses a distinct Redis SET NX EX claim after the per-user rate-limit eval', async () => {
+  it('uses a distinct Redis SET NX PXAT claim after the per-user rate-limit eval', async () => {
     mockRedisIsConnected.mockReturnValue(true);
     const gym = await insertGym({ name: 'Bahnhof Bloc' });
     const dup = await insertGym({ name: 'Bahnhof Bloc (Kilter)' });
@@ -212,8 +209,8 @@ describe('reportGymDuplicate — de-duplication', () => {
     expect(mockRedisSet).toHaveBeenCalledExactlyOnceWith(
       `gymDuplicateReport:${lowUuid}:${highUuid}`,
       expect.stringMatching(/^[0-9a-f-]{36}$/),
-      'EX',
-      GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS,
+      'PXAT',
+      expect.any(Number),
       'NX',
     );
   });
@@ -227,6 +224,20 @@ describe('reportGymDuplicate — de-duplication', () => {
 
     expect(first).toEqual({ status: 'reported' });
     expect(second).toEqual({ status: 'already_reported' });
+    expect(sendGymDuplicateReportAdminNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('de-dupes the same public pair across different reporters', async () => {
+    const gym = await insertGym({ name: 'Bahnhof Bloc' });
+    const dup = await insertGym({ name: 'Bahnhof Bloc (Kilter)' });
+
+    await expect(
+      reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: dup.uuid }, authCtx(REPORTER)),
+    ).resolves.toEqual({ status: 'reported' });
+    await expect(
+      reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: dup.uuid }, authCtx(STRANGER)),
+    ).resolves.toEqual({ status: 'already_reported' });
+
     expect(sendGymDuplicateReportAdminNotification).toHaveBeenCalledTimes(1);
   });
 
@@ -400,7 +411,7 @@ describe('reportGymDuplicate — de-duplication', () => {
     expect(sendGymDuplicateReportAdminNotification).toHaveBeenCalledTimes(2);
   });
 
-  it('logs privacy-safe cleanup warnings and preserves the email failure', async () => {
+  it('sanitizes email-provider errors, logs privacy-safe cleanup warnings, and preserves the failure', async () => {
     mockRedisIsConnected.mockReturnValue(true);
     mockRedisEval.mockImplementation(async (_script: string, _numberOfKeys: number, claimKey: string) => {
       if (!claimKey.startsWith('gymDuplicateReport:')) return 1;
@@ -408,26 +419,41 @@ describe('reportGymDuplicate — de-duplication', () => {
     });
     const gym = await insertGym({ name: 'Bahnhof Bloc' });
     const dup = await insertGym({ name: 'Bahnhof Bloc (Kilter)' });
-    const emailError = new Error('SMTP down');
+    const sensitiveNote = 'The owner told me this wall is private';
+    const emailError = new Error(
+      `Postmark rejected gym=${gym.uuid} duplicate=${dup.uuid} reporter=Reporter Rae note=${sensitiveNote}`,
+    );
     vi.mocked(sendGymDuplicateReportAdminNotification).mockRejectedValueOnce(emailError);
     const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
     const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => logger);
 
     await expect(
-      reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: dup.uuid }, authCtx(REPORTER)),
+      reportGymDuplicate({ gymUuid: gym.uuid, duplicateGymUuid: dup.uuid, note: sensitiveNote }, authCtx(REPORTER)),
     ).rejects.toMatchObject({
       message: "We couldn't send that report. Try again in a moment.",
       extensions: { code: 'INTERNAL_SERVER_ERROR' },
     });
 
-    expect(errorSpy).toHaveBeenCalledWith('[GymDuplicateReport] Failed to send admin notification:', emailError);
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[GymDuplicateReport] Failed to send admin notification:',
+      expect.objectContaining({ message: 'Gym duplicate report admin notification delivery failed' }),
+    );
     expect(warnSpy).toHaveBeenCalledWith(
       '[GymDuplicateReport] Redis claim cleanup failed; the claim will expire automatically.',
     );
     const warningOutput = JSON.stringify(warnSpy.mock.calls);
+    const errorCalls = errorSpy.mock.calls as unknown as ReadonlyArray<readonly unknown[]>;
+    const loggedError = errorCalls[0]?.[1];
+    expect(loggedError).toBeInstanceOf(Error);
+    if (!(loggedError instanceof Error)) throw new Error('Expected a sanitized Error log argument');
+    const errorOutput = `${loggedError.name}: ${loggedError.message}`;
     expect(warningOutput).not.toContain(gym.uuid);
     expect(warningOutput).not.toContain(dup.uuid);
     expect(warningOutput).not.toContain(mockRedisSet.mock.calls[0][1] as string);
+    expect(errorOutput).not.toContain(gym.uuid);
+    expect(errorOutput).not.toContain(dup.uuid);
+    expect(errorOutput).not.toContain('Reporter Rae');
+    expect(errorOutput).not.toContain(sensitiveNote);
 
     warnSpy.mockRestore();
     errorSpy.mockRestore();

--- a/packages/backend/src/__tests__/redis-client-ready-handlers.test.ts
+++ b/packages/backend/src/__tests__/redis-client-ready-handlers.test.ts
@@ -41,6 +41,7 @@ vi.mock('ioredis', () => {
     }
 
     async quit(): Promise<'OK'> {
+      this.emit('close');
       return 'OK';
     }
   }
@@ -61,6 +62,43 @@ afterEach(() => {
 });
 
 describe('RedisClientManager recovery readiness', () => {
+  it('includes a handler registered while the current readiness barrier is in flight', async () => {
+    const { RedisClientManager } = await import('../redis/client');
+    const manager = new RedisClientManager();
+    let finishInitialHandler: (() => void) | undefined;
+    let finishLateHandler: (() => void) | undefined;
+    const initialHandler = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishInitialHandler = resolve;
+        }),
+    );
+    const lateHandler = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishLateHandler = resolve;
+        }),
+    );
+    manager.onRedisReady(initialHandler);
+
+    const connection = manager.connect();
+    const [publisher, subscriber, streamConsumer] = redisMockState.instances;
+    publisher?.emit('ready');
+    subscriber?.emit('ready');
+    streamConsumer?.emit('ready');
+    await vi.waitFor(() => expect(initialHandler).toHaveBeenCalledTimes(1));
+
+    manager.onRedisReady(lateHandler);
+    finishInitialHandler?.();
+    await vi.waitFor(() => expect(lateHandler).toHaveBeenCalledTimes(1));
+    expect(manager.isRedisConnected()).toBe(false);
+
+    finishLateHandler?.();
+    await expect(connection).resolves.toBe(true);
+    expect(manager.isRedisConnected()).toBe(true);
+    await manager.disconnect();
+  });
+
   it('reruns recovery handlers when a connection closes and becomes ready during reconciliation', async () => {
     const { RedisClientManager } = await import('../redis/client');
     const manager = new RedisClientManager();
@@ -91,6 +129,34 @@ describe('RedisClientManager recovery readiness', () => {
 
     finishHandlers[1]?.();
     await expect(connection).resolves.toBe(true);
+    expect(manager.isRedisConnected()).toBe(true);
+    await manager.disconnect();
+  });
+
+  it('runs readiness handlers again after an explicit disconnect and fresh connect', async () => {
+    const { RedisClientManager } = await import('../redis/client');
+    const manager = new RedisClientManager();
+    const readyHandler = vi.fn().mockResolvedValue(undefined);
+    manager.onRedisReady(readyHandler);
+
+    const firstConnection = manager.connect();
+    const [firstPublisher, firstSubscriber, firstStreamConsumer] = redisMockState.instances;
+    firstPublisher?.emit('ready');
+    firstSubscriber?.emit('ready');
+    firstStreamConsumer?.emit('ready');
+    await expect(firstConnection).resolves.toBe(true);
+    expect(readyHandler).toHaveBeenCalledTimes(1);
+
+    await manager.disconnect();
+    expect(manager.isRedisConnected()).toBe(false);
+
+    const secondConnection = manager.connect();
+    const [secondPublisher, secondSubscriber, secondStreamConsumer] = redisMockState.instances.slice(3);
+    secondPublisher?.emit('ready');
+    secondSubscriber?.emit('ready');
+    secondStreamConsumer?.emit('ready');
+    await expect(secondConnection).resolves.toBe(true);
+    expect(readyHandler).toHaveBeenCalledTimes(2);
     expect(manager.isRedisConnected()).toBe(true);
     await manager.disconnect();
   });

--- a/packages/backend/src/__tests__/redis-client-ready-handlers.test.ts
+++ b/packages/backend/src/__tests__/redis-client-ready-handlers.test.ts
@@ -8,6 +8,8 @@ type FakeRedisInstance = {
 
 const redisMockState = vi.hoisted(() => ({
   instances: [] as FakeRedisInstance[],
+  setCalls: [] as unknown[][],
+  setHandler: null as ((...arguments_: unknown[]) => Promise<'OK' | null>) | null,
 }));
 
 vi.mock('ioredis', () => {
@@ -33,6 +35,11 @@ vi.mock('ioredis', () => {
       return 'redis_version:7.2.0\r\n';
     }
 
+    async set(...arguments_: unknown[]): Promise<'OK' | null> {
+      redisMockState.setCalls.push(arguments_);
+      return redisMockState.setHandler?.(...arguments_) ?? 'OK';
+    }
+
     async quit(): Promise<'OK'> {
       return 'OK';
     }
@@ -45,6 +52,8 @@ beforeEach(() => {
   vi.resetModules();
   vi.stubEnv('REDIS_URL', 'redis://ready-handler.test');
   redisMockState.instances.length = 0;
+  redisMockState.setCalls.length = 0;
+  redisMockState.setHandler = null;
 });
 
 afterEach(() => {
@@ -84,5 +93,48 @@ describe('RedisClientManager recovery readiness', () => {
     await expect(connection).resolves.toBe(true);
     expect(manager.isRedisConnected()).toBe(true);
     await manager.disconnect();
+  });
+
+  it('promotes claims admitted during recovery before advertising Redis as connected', async () => {
+    const { redisClientManager } = await import('../redis/client');
+    const { acquireGymDuplicateReportClaim, resetGymDuplicateReportClaimsForTests } =
+      await import('../utils/gym-duplicate-report-claims');
+    const firstKey = 'gymDuplicateReport:test:manager-first';
+    const secondKey = 'gymDuplicateReport:test:manager-second';
+    let finishFirstPromotion: (() => void) | undefined;
+    let finishSecondPromotion: (() => void) | undefined;
+    redisMockState.setHandler = (key) =>
+      new Promise<'OK'>((resolve) => {
+        if (key === firstKey) finishFirstPromotion = () => resolve('OK');
+        if (key === secondKey) finishSecondPromotion = () => resolve('OK');
+      });
+    const disconnectedDependencies = (ownerToken: string) => ({
+      isRedisConnected: () => false,
+      getRedisClient: () => {
+        throw new Error('Redis is still hidden from request handlers');
+      },
+      createOwnerToken: () => ownerToken,
+      now: Date.now,
+    });
+    await acquireGymDuplicateReportClaim(firstKey, disconnectedDependencies('first-owner'));
+
+    const connection = redisClientManager.connect();
+    const [publisher, subscriber, streamConsumer] = redisMockState.instances;
+    publisher?.emit('ready');
+    subscriber?.emit('ready');
+    streamConsumer?.emit('ready');
+    await vi.waitFor(() => expect(redisMockState.setCalls.map(([key]) => key)).toEqual([firstKey]));
+    expect(redisClientManager.isRedisConnected()).toBe(false);
+
+    await acquireGymDuplicateReportClaim(secondKey, disconnectedDependencies('second-owner'));
+    finishFirstPromotion?.();
+    await vi.waitFor(() => expect(redisMockState.setCalls.map(([key]) => key)).toEqual([firstKey, secondKey]));
+    expect(redisClientManager.isRedisConnected()).toBe(false);
+
+    finishSecondPromotion?.();
+    await expect(connection).resolves.toBe(true);
+    expect(redisClientManager.isRedisConnected()).toBe(true);
+    resetGymDuplicateReportClaimsForTests();
+    await redisClientManager.disconnect();
   });
 });

--- a/packages/backend/src/__tests__/redis-client-ready-handlers.test.ts
+++ b/packages/backend/src/__tests__/redis-client-ready-handlers.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+type RedisEventHandler = (...arguments_: unknown[]) => void;
+
+type FakeRedisInstance = {
+  emit: (event: string, ...arguments_: unknown[]) => void;
+};
+
+const redisMockState = vi.hoisted(() => ({
+  instances: [] as FakeRedisInstance[],
+}));
+
+vi.mock('ioredis', () => {
+  class FakeRedis {
+    private readonly handlers = new Map<string, RedisEventHandler[]>();
+
+    constructor() {
+      redisMockState.instances.push(this);
+    }
+
+    on(event: string, handler: RedisEventHandler): this {
+      const eventHandlers = this.handlers.get(event) ?? [];
+      eventHandlers.push(handler);
+      this.handlers.set(event, eventHandlers);
+      return this;
+    }
+
+    emit(event: string, ...arguments_: unknown[]): void {
+      for (const handler of this.handlers.get(event) ?? []) handler(...arguments_);
+    }
+
+    async info(): Promise<string> {
+      return 'redis_version:7.2.0\r\n';
+    }
+
+    async quit(): Promise<'OK'> {
+      return 'OK';
+    }
+  }
+
+  return { default: FakeRedis };
+});
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.stubEnv('REDIS_URL', 'redis://ready-handler.test');
+  redisMockState.instances.length = 0;
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('RedisClientManager recovery readiness', () => {
+  it('reruns recovery handlers when a connection closes and becomes ready during reconciliation', async () => {
+    const { RedisClientManager } = await import('../redis/client');
+    const manager = new RedisClientManager();
+    const finishHandlers: Array<() => void> = [];
+    const readyHandler = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishHandlers.push(resolve);
+        }),
+    );
+    manager.onRedisReady(readyHandler);
+
+    const connection = manager.connect();
+    expect(redisMockState.instances).toHaveLength(3);
+    const [publisher, subscriber, streamConsumer] = redisMockState.instances;
+    publisher?.emit('ready');
+    subscriber?.emit('ready');
+    streamConsumer?.emit('ready');
+    await vi.waitFor(() => expect(readyHandler).toHaveBeenCalledTimes(1));
+    expect(manager.isRedisConnected()).toBe(false);
+
+    publisher?.emit('close');
+    publisher?.emit('ready');
+    finishHandlers[0]?.();
+
+    await vi.waitFor(() => expect(readyHandler).toHaveBeenCalledTimes(2));
+    expect(manager.isRedisConnected()).toBe(false);
+
+    finishHandlers[1]?.();
+    await expect(connection).resolves.toBe(true);
+    expect(manager.isRedisConnected()).toBe(true);
+    await manager.disconnect();
+  });
+});

--- a/packages/backend/src/__tests__/redis-client-ready-handlers.test.ts
+++ b/packages/backend/src/__tests__/redis-client-ready-handlers.test.ts
@@ -10,6 +10,8 @@ const redisMockState = vi.hoisted(() => ({
   instances: [] as FakeRedisInstance[],
   setCalls: [] as unknown[][],
   setHandler: null as ((...arguments_: unknown[]) => Promise<'OK' | null>) | null,
+  deferQuitClose: false,
+  pendingQuitClosures: [] as Array<() => void>,
 }));
 
 vi.mock('ioredis', () => {
@@ -41,6 +43,14 @@ vi.mock('ioredis', () => {
     }
 
     async quit(): Promise<'OK'> {
+      if (redisMockState.deferQuitClose) {
+        return new Promise<'OK'>((resolve) => {
+          redisMockState.pendingQuitClosures.push(() => {
+            this.emit('close');
+            resolve('OK');
+          });
+        });
+      }
       this.emit('close');
       return 'OK';
     }
@@ -55,6 +65,8 @@ beforeEach(() => {
   redisMockState.instances.length = 0;
   redisMockState.setCalls.length = 0;
   redisMockState.setHandler = null;
+  redisMockState.deferQuitClose = false;
+  redisMockState.pendingQuitClosures.length = 0;
 });
 
 afterEach(() => {
@@ -158,6 +170,57 @@ describe('RedisClientManager recovery readiness', () => {
     await expect(secondConnection).resolves.toBe(true);
     expect(readyHandler).toHaveBeenCalledTimes(2);
     expect(manager.isRedisConnected()).toBe(true);
+    await manager.disconnect();
+  });
+
+  it('does not advertise a stale connection while explicit disconnect is waiting for close events', async () => {
+    const { RedisClientManager } = await import('../redis/client');
+    const manager = new RedisClientManager();
+    let finishReadyHandler: (() => void) | undefined;
+    manager.onRedisReady(
+      () =>
+        new Promise<void>((resolve) => {
+          finishReadyHandler = resolve;
+        }),
+    );
+
+    const connection = manager.connect();
+    const [publisher, subscriber, streamConsumer] = redisMockState.instances;
+    publisher?.emit('ready');
+    subscriber?.emit('ready');
+    streamConsumer?.emit('ready');
+    await vi.waitFor(() => expect(finishReadyHandler).toBeTypeOf('function'));
+
+    redisMockState.deferQuitClose = true;
+    const disconnection = manager.disconnect();
+    await vi.waitFor(() => expect(redisMockState.pendingQuitClosures).toHaveLength(3));
+    finishReadyHandler?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(manager.isRedisConnected()).toBe(false);
+
+    for (const emitClose of redisMockState.pendingQuitClosures.splice(0)) emitClose();
+    await disconnection;
+    await expect(connection).resolves.toBe(false);
+    expect(manager.isRedisConnected()).toBe(false);
+  });
+
+  it('fails closed when readiness handlers recursively register more handlers', async () => {
+    const { RedisClientManager } = await import('../redis/client');
+    const manager = new RedisClientManager();
+    const registerNextHandler = () => {
+      manager.onRedisReady(async () => registerNextHandler());
+    };
+    registerNextHandler();
+
+    const connection = manager.connect();
+    const [publisher, subscriber, streamConsumer] = redisMockState.instances;
+    publisher?.emit('ready');
+    subscriber?.emit('ready');
+    streamConsumer?.emit('ready');
+
+    await expect(connection).rejects.toThrow('Redis recovery handlers did not settle after 100 passes');
+    expect(manager.isRedisConnected()).toBe(false);
     await manager.disconnect();
   });
 

--- a/packages/backend/src/graphql/resolvers/social/gym-reports.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-reports.ts
@@ -6,25 +6,18 @@ import { db } from '../../../db/client';
 import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
 import { ReportGymDuplicateInputSchema } from '../../../validation/schemas';
 import { sendGymDuplicateReportAdminNotification } from '../../../email/email-service';
-import { checkRateLimit, cleanupRateLimit, RateLimitError } from '../../../utils/rate-limiter';
 import { logger } from '../../../utils/logger';
+import {
+  acquireGymDuplicateReportClaim,
+  gymDuplicateReportClaimKey,
+  releaseGymDuplicateReportClaim,
+} from '../../../utils/gym-duplicate-report-claims';
 
 // Owner-facing "report a duplicate" surfaces the pair to admins by email (the same
 // admin-notification path a queued gym claim uses). It is deliberately migration-free:
-// no dedicated table, so repeated reports of the SAME pair are de-duplicated with the
-// in-memory window limiter below rather than a persisted row. This is per-instance,
-// best-effort de-dup — enough to stop one flurry of clicks (or two climbers flagging
-// the same pair) from spamming the team, while the per-user `applyRateLimit` bounds
-// overall volume. Known limitation: in-memory de-dup resets on deploy and doesn't
-// span instances, so the same pair can re-email after a restart or from another node.
-// A Redis-backed (SET NX EX) de-dup + a durable reports table are the follow-up.
-const REPORT_DEDUP_WINDOW_MS = 24 * 60 * 60 * 1000;
-
-/** One stable key per unordered gym pair, so (A,B) and (B,A) de-dupe together. */
-function duplicateReportDedupKey(firstUuid: string, secondUuid: string): string {
-  const [low, high] = [firstUuid, secondUuid].sort();
-  return `gymDuplicateReport:${low}:${high}`;
-}
+// no dedicated table. A local owner-token claim collapses concurrent requests on
+// this instance, while Redis SET NX EX extends the same 24-hour window across
+// instances and deploys. The per-user `applyRateLimit` independently bounds volume.
 
 /** The reporter's display name for the admin email, falling back to a neutral label. */
 async function loadReporterName(userId: string): Promise<string> {
@@ -107,17 +100,12 @@ export const socialGymReportMutations = {
     // ever sent — the report would be silently lost.
     const reporterName = await loadReporterName(userId);
 
-    // De-dup: the first report of this pair claims the window; a repeat inside it
-    // returns without re-emailing. Marked BEFORE the send so concurrent clicks
-    // collapse to one, and released on send failure so a retry isn't stranded.
-    const dedupKey = duplicateReportDedupKey(gym.uuid, duplicate.uuid);
-    try {
-      checkRateLimit(dedupKey, 1, REPORT_DEDUP_WINDOW_MS);
-    } catch (error) {
-      if (error instanceof RateLimitError) {
-        return { status: 'already_reported' };
-      }
-      throw error;
+    // Claim BEFORE sending so concurrent clicks collapse to one notification.
+    // Local ownership is always acquired first; Redis extends the same stable,
+    // unordered pair claim across backend instances when available.
+    const claimResult = await acquireGymDuplicateReportClaim(gymDuplicateReportClaimKey(gym.uuid, duplicate.uuid));
+    if (claimResult.status === 'already_claimed') {
+      return { status: 'already_reported' };
     }
 
     try {
@@ -131,8 +119,9 @@ export const socialGymReportMutations = {
       });
     } catch (error) {
       // The email IS the record for this pair, so a failed send must not leave the
-      // pair marked reported — release it so the climber can try again.
-      cleanupRateLimit(dedupKey);
+      // pair marked reported. Owner-checked local + Redis cleanup lets the climber
+      // retry without allowing a stale request to delete a successor's claim.
+      await releaseGymDuplicateReportClaim(claimResult.claim);
       logger.error('[GymDuplicateReport] Failed to send admin notification:', error);
       throw new GraphQLError("We couldn't send that report. Try again in a moment.", {
         extensions: { code: 'INTERNAL_SERVER_ERROR' },

--- a/packages/backend/src/graphql/resolvers/social/gym-reports.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-reports.ts
@@ -16,7 +16,7 @@ import {
 // Owner-facing "report a duplicate" surfaces the pair to admins by email (the same
 // admin-notification path a queued gym claim uses). It is deliberately migration-free:
 // no dedicated table. A local owner-token claim collapses concurrent requests on
-// this instance, while Redis SET NX EX extends the same 24-hour window across
+// this instance, while Redis SET NX PXAT extends the same 24-hour window across
 // instances and deploys. The per-user `applyRateLimit` independently bounds volume.
 
 /** The reporter's display name for the admin email, falling back to a neutral label. */
@@ -65,8 +65,8 @@ export const socialGymReportMutations = {
   ): Promise<{ status: 'reported' | 'already_reported' }> => {
     // Intentionally NOT owner-gated: a duplicate report is a community data-quality
     // signal, so any signed-in climber who spots two listings of a gym can flag them
-    // (not just the owner). The 10/min per-user ceiling — shared with the gym-claim
-    // flow — bounds abuse. Do not tighten this to owners-only.
+    // (not just the owner). A dedicated 10/min per-user bucket bounds abuse
+    // independently from the gym-claim mutation. Do not tighten this to owners-only.
     requireAuthenticated(ctx);
     await applyRateLimit(ctx, 10, 'reportGymDuplicate');
 
@@ -117,12 +117,18 @@ export const socialGymReportMutations = {
         reporterName,
         note: validatedInput.note ?? null,
       });
-    } catch (error) {
+    } catch {
       // The email IS the record for this pair, so a failed send must not leave the
       // pair marked reported. Owner-checked local + Redis cleanup lets the climber
       // retry without allowing a stale request to delete a successor's claim.
       await releaseGymDuplicateReportClaim(claimResult.claim);
-      logger.error('[GymDuplicateReport] Failed to send admin notification:', error);
+      // Email-provider errors can echo the submitted payload. Keep Sentry/error
+      // visibility through a fresh Error while excluding gym names, UUIDs,
+      // reporter details, and notes from logs.
+      logger.error(
+        '[GymDuplicateReport] Failed to send admin notification:',
+        new Error('Gym duplicate report admin notification delivery failed'),
+      );
       throw new GraphQLError("We couldn't send that report. Try again in a moment.", {
         extensions: { code: 'INTERNAL_SERVER_ERROR' },
       });

--- a/packages/backend/src/redis/client.ts
+++ b/packages/backend/src/redis/client.ts
@@ -59,9 +59,10 @@ export class RedisClientManager {
 
   /**
    * Run work that must be reconciled before the backend advertises a recovered
-   * Redis connection. Handlers also run immediately when registered after Redis
-   * is already ready. Failures are isolated so one best-effort reconciliation
-   * cannot keep the entire backend disconnected.
+   * Redis connection. A handler registered while readiness reconciliation is in
+   * flight joins that same barrier; handlers registered after Redis is already
+   * ready run immediately. Failures are isolated so one best-effort
+   * reconciliation cannot keep the entire backend disconnected.
    */
   onRedisReady(handler: RedisReadyHandler): () => void {
     this.readyHandlers.add(handler);
@@ -81,8 +82,25 @@ export class RedisClientManager {
     }
   }
 
-  private async runReadyHandlers(publisher: Redis): Promise<void> {
-    await Promise.all(Array.from(this.readyHandlers, (handler) => this.runReadyHandler(handler, publisher)));
+  private async runReadyHandlersBeforeConnected(
+    publisher: Redis,
+    markConnectedIfCurrent: () => boolean,
+  ): Promise<boolean> {
+    const completedHandlers = new Set<RedisReadyHandler>();
+    while (true) {
+      const pendingHandlers = Array.from(this.readyHandlers).filter((handler) => !completedHandlers.has(handler));
+      if (pendingHandlers.length > 0) {
+        for (const handler of pendingHandlers) completedHandlers.add(handler);
+        await Promise.all(pendingHandlers.map((handler) => this.runReadyHandler(handler, publisher)));
+        continue;
+      }
+
+      // There is no await between the final handler-set check and publishing
+      // isConnected=true. A concurrent registration therefore either joins the
+      // loop above or observes connected state and takes onRedisReady's immediate
+      // path; it cannot fall into the gap between the two contracts.
+      return markConnectedIfCurrent();
+    }
   }
 
   /**
@@ -161,20 +179,29 @@ export class RedisClientManager {
         // Verify server version before declaring ready. Fail-closed: an
         // older Redis silently breaks the board-serial event path, which we'd
         // rather catch at startup than in production.
-        verifyRedisVersion(this.publisher!)
-          .then(() => this.runReadyHandlers(this.publisher!))
-          .then(() => {
-            this.finishingConnection = false;
+        const publisher = this.publisher!;
+        verifyRedisVersion(publisher)
+          .then(() =>
+            this.runReadyHandlersBeforeConnected(publisher, () => {
+              if (!publisherReady || !subscriberReady || !streamConsumerReady || readinessEpoch !== reconciliationEpoch)
+                return false;
+              // Publish connected state and release the re-entrance guard in
+              // the same synchronous callback as the final handler-set check.
+              // A close/ready edge after this point can therefore start its
+              // own readiness pass instead of being hidden by a stale guard.
+              this.isConnected = true;
+              this.finishingConnection = false;
+              resolve(true);
+              return true;
+            }),
+          )
+          .then((connected) => {
+            if (connected) return;
             // A connection can close while an async recovery handler is
             // running. Do not advertise a stale ready state; the next `ready`
             // event will run version checks and reconciliation again.
-            if (!(publisherReady && subscriberReady && streamConsumerReady)) return;
-            if (readinessEpoch !== reconciliationEpoch) {
-              checkAllReady();
-              return;
-            }
-            this.isConnected = true;
-            resolve(true);
+            this.finishingConnection = false;
+            checkAllReady();
           })
           .catch((err: Error) => {
             this.finishingConnection = false;

--- a/packages/backend/src/redis/client.ts
+++ b/packages/backend/src/redis/client.ts
@@ -12,6 +12,7 @@ const REDIS_URL = process.env.REDIS_URL;
 // value).
 const MIN_REDIS_MAJOR = 6;
 const MIN_REDIS_MINOR = 2;
+const MAX_READY_HANDLER_PASSES = 100;
 
 function parseRedisVersion(infoBlock: string): { major: number; minor: number; patch: number } | null {
   // `INFO server` returns lines like "redis_version:7.2.4\r\n". Parse the
@@ -55,6 +56,8 @@ export class RedisClientManager {
   private isConnected = false;
   private connectionPromise: Promise<boolean> | null = null;
   private finishingConnection = false;
+  private connectionLifecycleEpoch = 0;
+  private cancelPendingConnection: (() => void) | null = null;
   private readonly readyHandlers = new Set<RedisReadyHandler>();
 
   /**
@@ -87,9 +90,15 @@ export class RedisClientManager {
     markConnectedIfCurrent: () => boolean,
   ): Promise<boolean> {
     const completedHandlers = new Set<RedisReadyHandler>();
-    while (true) {
+    let handlerPasses = 0;
+    while (handlerPasses <= MAX_READY_HANDLER_PASSES) {
       const pendingHandlers = Array.from(this.readyHandlers).filter((handler) => !completedHandlers.has(handler));
       if (pendingHandlers.length > 0) {
+        if (handlerPasses === MAX_READY_HANDLER_PASSES) {
+          logger.warn('[Redis] Recovery handlers kept registering more handlers; refusing to advertise readiness.');
+          throw new Error(`Redis recovery handlers did not settle after ${MAX_READY_HANDLER_PASSES} passes`);
+        }
+        handlerPasses += 1;
         for (const handler of pendingHandlers) completedHandlers.add(handler);
         await Promise.all(pendingHandlers.map((handler) => this.runReadyHandler(handler, publisher)));
         continue;
@@ -101,6 +110,8 @@ export class RedisClientManager {
       // path; it cannot fall into the gap between the two contracts.
       return markConnectedIfCurrent();
     }
+
+    throw new Error('Unreachable Redis readiness state');
   }
 
   /**
@@ -122,7 +133,23 @@ export class RedisClientManager {
   }
 
   private async doConnect(): Promise<boolean> {
+    const lifecycleEpoch = this.connectionLifecycleEpoch;
     return new Promise((resolve, reject) => {
+      let connectionSettled = false;
+      const resolveConnection = (connected: boolean) => {
+        if (connectionSettled) return;
+        connectionSettled = true;
+        if (this.cancelPendingConnection === cancelConnection) this.cancelPendingConnection = null;
+        resolve(connected);
+      };
+      const rejectConnection = (error: Error) => {
+        if (connectionSettled) return;
+        connectionSettled = true;
+        if (this.cancelPendingConnection === cancelConnection) this.cancelPendingConnection = null;
+        reject(error);
+      };
+      const cancelConnection = () => resolveConnection(false);
+      this.cancelPendingConnection = cancelConnection;
       logger.info('[Redis] Connecting to Redis...');
 
       // Create publisher connection
@@ -171,6 +198,7 @@ export class RedisClientManager {
       let readinessEpoch = 0;
 
       const checkAllReady = () => {
+        if (this.connectionLifecycleEpoch !== lifecycleEpoch) return;
         if (!(publisherReady && subscriberReady && streamConsumerReady)) return;
         if (this.isConnected || this.finishingConnection) return;
         this.finishingConnection = true;
@@ -183,7 +211,13 @@ export class RedisClientManager {
         verifyRedisVersion(publisher)
           .then(() =>
             this.runReadyHandlersBeforeConnected(publisher, () => {
-              if (!publisherReady || !subscriberReady || !streamConsumerReady || readinessEpoch !== reconciliationEpoch)
+              if (
+                this.connectionLifecycleEpoch !== lifecycleEpoch ||
+                !publisherReady ||
+                !subscriberReady ||
+                !streamConsumerReady ||
+                readinessEpoch !== reconciliationEpoch
+              )
                 return false;
               // Publish connected state and release the re-entrance guard in
               // the same synchronous callback as the final handler-set check.
@@ -191,7 +225,7 @@ export class RedisClientManager {
               // own readiness pass instead of being hidden by a stale guard.
               this.isConnected = true;
               this.finishingConnection = false;
-              resolve(true);
+              resolveConnection(true);
               return true;
             }),
           )
@@ -206,7 +240,7 @@ export class RedisClientManager {
           .catch((err: Error) => {
             this.finishingConnection = false;
             logger.error(`[Redis] ${err.message}`);
-            reject(err);
+            rejectConnection(err);
           });
       };
 
@@ -231,21 +265,21 @@ export class RedisClientManager {
       this.publisher.on('error', (err) => {
         logger.error('[Redis] Publisher error:', err.message);
         if (!this.isConnected) {
-          reject(new Error(`Redis publisher connection failed: ${err.message}`));
+          rejectConnection(new Error(`Redis publisher connection failed: ${err.message}`));
         }
       });
 
       this.subscriber.on('error', (err) => {
         logger.error('[Redis] Subscriber error:', err.message);
         if (!this.isConnected) {
-          reject(new Error(`Redis subscriber connection failed: ${err.message}`));
+          rejectConnection(new Error(`Redis subscriber connection failed: ${err.message}`));
         }
       });
 
       this.streamConsumer.on('error', (err) => {
         logger.error('[Redis] Stream consumer error:', err.message);
         if (!this.isConnected) {
-          reject(new Error(`Redis stream consumer connection failed: ${err.message}`));
+          rejectConnection(new Error(`Redis stream consumer connection failed: ${err.message}`));
         }
       });
 
@@ -325,6 +359,15 @@ export class RedisClientManager {
    */
   async disconnect(): Promise<void> {
     logger.info('[Redis] Disconnecting...');
+
+    // Invalidate any in-flight version check or readiness reconciliation before
+    // awaiting ioredis. quit() emits close asynchronously in real deployments,
+    // so relying on those events leaves a window where an old readiness pass
+    // could publish isConnected=true after shutdown has already started.
+    this.connectionLifecycleEpoch += 1;
+    this.isConnected = false;
+    this.finishingConnection = false;
+    this.cancelPendingConnection?.();
 
     const disconnectPromises: Promise<void>[] = [];
 

--- a/packages/backend/src/redis/client.ts
+++ b/packages/backend/src/redis/client.ts
@@ -46,12 +46,44 @@ export type RedisClients = {
   streamConsumer: Redis;
 };
 
-class RedisClientManager {
+type RedisReadyHandler = (publisher: Redis) => void | Promise<void>;
+
+export class RedisClientManager {
   private publisher: Redis | null = null;
   private subscriber: Redis | null = null;
   private streamConsumer: Redis | null = null;
   private isConnected = false;
   private connectionPromise: Promise<boolean> | null = null;
+  private finishingConnection = false;
+  private readonly readyHandlers = new Set<RedisReadyHandler>();
+
+  /**
+   * Run work that must be reconciled before the backend advertises a recovered
+   * Redis connection. Handlers also run immediately when registered after Redis
+   * is already ready. Failures are isolated so one best-effort reconciliation
+   * cannot keep the entire backend disconnected.
+   */
+  onRedisReady(handler: RedisReadyHandler): () => void {
+    this.readyHandlers.add(handler);
+    if (this.isConnected && this.publisher) {
+      void this.runReadyHandler(handler, this.publisher);
+    }
+    return () => {
+      this.readyHandlers.delete(handler);
+    };
+  }
+
+  private async runReadyHandler(handler: RedisReadyHandler, publisher: Redis): Promise<void> {
+    try {
+      await handler(publisher);
+    } catch {
+      logger.warn('[Redis] A recovery reconciliation handler failed; Redis remains available.');
+    }
+  }
+
+  private async runReadyHandlers(publisher: Redis): Promise<void> {
+    await Promise.all(Array.from(this.readyHandlers, (handler) => this.runReadyHandler(handler, publisher)));
+  }
 
   /**
    * Connect to Redis. Returns true if connected, false if Redis is not configured.
@@ -118,19 +150,34 @@ class RedisClientManager {
       let publisherReady = false;
       let subscriberReady = false;
       let streamConsumerReady = false;
+      let readinessEpoch = 0;
 
       const checkAllReady = () => {
         if (!(publisherReady && subscriberReady && streamConsumerReady)) return;
+        if (this.isConnected || this.finishingConnection) return;
+        this.finishingConnection = true;
+        const reconciliationEpoch = readinessEpoch;
         logger.info('[Redis] Connected successfully (3 connections: publisher, subscriber, streamConsumer)');
         // Verify server version before declaring ready. Fail-closed: an
         // older Redis silently breaks the board-serial event path, which we'd
         // rather catch at startup than in production.
         verifyRedisVersion(this.publisher!)
+          .then(() => this.runReadyHandlers(this.publisher!))
           .then(() => {
+            this.finishingConnection = false;
+            // A connection can close while an async recovery handler is
+            // running. Do not advertise a stale ready state; the next `ready`
+            // event will run version checks and reconciliation again.
+            if (!(publisherReady && subscriberReady && streamConsumerReady)) return;
+            if (readinessEpoch !== reconciliationEpoch) {
+              checkAllReady();
+              return;
+            }
             this.isConnected = true;
             resolve(true);
           })
           .catch((err: Error) => {
+            this.finishingConnection = false;
             logger.error(`[Redis] ${err.message}`);
             reject(err);
           });
@@ -138,16 +185,19 @@ class RedisClientManager {
 
       this.publisher.on('ready', () => {
         publisherReady = true;
+        readinessEpoch += 1;
         checkAllReady();
       });
 
       this.subscriber.on('ready', () => {
         subscriberReady = true;
+        readinessEpoch += 1;
         checkAllReady();
       });
 
       this.streamConsumer.on('ready', () => {
         streamConsumerReady = true;
+        readinessEpoch += 1;
         checkAllReady();
       });
 
@@ -174,6 +224,8 @@ class RedisClientManager {
 
       // Handle disconnection after initial connection
       this.publisher.on('close', () => {
+        publisherReady = false;
+        readinessEpoch += 1;
         if (this.isConnected) {
           logger.warn('[Redis] Publisher connection closed');
           this.isConnected = false;
@@ -181,6 +233,8 @@ class RedisClientManager {
       });
 
       this.subscriber.on('close', () => {
+        subscriberReady = false;
+        readinessEpoch += 1;
         if (this.isConnected) {
           logger.warn('[Redis] Subscriber connection closed');
           this.isConnected = false;
@@ -188,6 +242,8 @@ class RedisClientManager {
       });
 
       this.streamConsumer.on('close', () => {
+        streamConsumerReady = false;
+        readinessEpoch += 1;
         if (this.isConnected) {
           logger.warn('[Redis] Stream consumer connection closed');
           this.isConnected = false;
@@ -275,6 +331,7 @@ class RedisClientManager {
     this.subscriber = null;
     this.streamConsumer = null;
     this.isConnected = false;
+    this.finishingConnection = false;
     this.connectionPromise = null;
   }
 }

--- a/packages/backend/src/utils/gym-duplicate-report-claims.ts
+++ b/packages/backend/src/utils/gym-duplicate-report-claims.ts
@@ -31,6 +31,7 @@ export interface GymDuplicateReportRedisClient {
     expiry: number,
     condition: 'NX',
   ): Promise<'OK' | null>;
+  /** ioredis exposes EVAL as unknown; cleanup deliberately ignores the Lua result. */
   eval(script: string, numberOfKeys: number, key: string, ownerToken: string): Promise<unknown>;
 }
 
@@ -248,7 +249,11 @@ export async function acquireGymDuplicateReportClaim(
   redisState.redisClient = redisClient;
   redisState.redisClaimMayExist = true;
   try {
-    const setResult = await redisClient.set(key, ownerToken, 'EX', GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS, 'NX');
+    // Pin Redis to the same absolute boundary as the local claim. A relative EX
+    // would start when Redis processes the command, leaving a small interval at
+    // the 24-hour boundary where local state has expired but Redis still rejects
+    // the next legitimate report.
+    const setResult = await redisClient.set(key, ownerToken, 'PXAT', localClaim.expiresAt, 'NX');
 
     if (setResult === null) {
       releaseLocalClaimIfOwner(key, ownerToken);
@@ -299,7 +304,13 @@ export async function releaseGymDuplicateReportClaim(claim: GymDuplicateReportCl
   }
 }
 
-/** @internal Clear process-local test state; Redis state is intentionally untouched. */
+/**
+ * @internal Clear the shared claim index between tests. The object-keyed WeakMap
+ * state intentionally survives while a test still holds an old public claim, so
+ * that owner can finish its in-flight promotion or owner-checked Redis cleanup.
+ * A new claim object cannot observe that state, and unreferenced entries remain
+ * weakly collectible.
+ */
 export function resetGymDuplicateReportClaimsForTests(): void {
   localClaims.clear();
   nextLocalClaimPruneAt = 0;

--- a/packages/backend/src/utils/gym-duplicate-report-claims.ts
+++ b/packages/backend/src/utils/gym-duplicate-report-claims.ts
@@ -24,13 +24,7 @@ type LocalClaim = {
 
 /** The narrow Redis surface needed by this claim protocol. */
 export interface GymDuplicateReportRedisClient {
-  set(
-    key: string,
-    ownerToken: string,
-    expiryMode: 'EX' | 'PXAT',
-    expiry: number,
-    condition: 'NX',
-  ): Promise<'OK' | null>;
+  set(key: string, ownerToken: string, expiryMode: 'PXAT', expiry: number, condition: 'NX'): Promise<'OK' | null>;
   /** ioredis exposes EVAL as unknown; cleanup deliberately ignores the Lua result. */
   eval(script: string, numberOfKeys: number, key: string, ownerToken: string): Promise<unknown>;
 }

--- a/packages/backend/src/utils/gym-duplicate-report-claims.ts
+++ b/packages/backend/src/utils/gym-duplicate-report-claims.ts
@@ -1,0 +1,160 @@
+import { randomUUID } from 'node:crypto';
+import { redisClientManager } from '../redis/client';
+import { logger } from './logger';
+
+export const GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS = 24 * 60 * 60;
+const GYM_DUPLICATE_REPORT_CLAIM_TTL_MS = GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS * 1000;
+
+const RELEASE_IF_OWNER_SCRIPT = `
+if redis.call('get', KEYS[1]) == ARGV[1] then
+  return redis.call('del', KEYS[1])
+end
+return 0
+`;
+
+type LocalClaim = {
+  ownerToken: string;
+  expiresAt: number;
+};
+
+/** The narrow Redis surface needed by this claim protocol. */
+export interface GymDuplicateReportRedisClient {
+  set(key: string, ownerToken: string, expiryMode: 'EX', ttlSeconds: number, condition: 'NX'): Promise<'OK' | null>;
+  eval(script: string, numberOfKeys: number, key: string, ownerToken: string): Promise<unknown>;
+}
+
+export interface GymDuplicateReportClaimDependencies {
+  isRedisConnected: () => boolean;
+  getRedisClient: () => GymDuplicateReportRedisClient;
+  createOwnerToken: () => string;
+  now: () => number;
+}
+
+export type GymDuplicateReportClaim = {
+  key: string;
+  ownerToken: string;
+  redisClient: GymDuplicateReportRedisClient | null;
+  redisClaimMayExist: boolean;
+};
+
+export type GymDuplicateReportClaimResult =
+  | { status: 'acquired'; claim: GymDuplicateReportClaim }
+  | { status: 'already_claimed' };
+
+const localClaims = new Map<string, LocalClaim>();
+let nextLocalClaimPruneAt = 0;
+
+const defaultDependencies: GymDuplicateReportClaimDependencies = {
+  isRedisConnected: () => redisClientManager.isRedisConnected(),
+  getRedisClient: () => redisClientManager.getClients().publisher,
+  createOwnerToken: randomUUID,
+  now: Date.now,
+};
+
+function releaseLocalClaimIfOwner(key: string, ownerToken: string): boolean {
+  const claim = localClaims.get(key);
+  if (!claim || claim.ownerToken !== ownerToken) return false;
+  localClaims.delete(key);
+  return true;
+}
+
+function pruneExpiredLocalClaims(now: number): void {
+  if (now < nextLocalClaimPruneAt) return;
+  nextLocalClaimPruneAt = now + 60 * 60 * 1000;
+  for (const [key, claim] of localClaims) {
+    if (claim.expiresAt <= now) localClaims.delete(key);
+  }
+}
+
+/** One stable key per unordered gym pair, so (A,B) and (B,A) de-dupe together. */
+export function gymDuplicateReportClaimKey(firstUuid: string, secondUuid: string): string {
+  const [lowUuid, highUuid] = [firstUuid, secondUuid].sort();
+  return `gymDuplicateReport:${lowUuid}:${highUuid}`;
+}
+
+/**
+ * Claim a duplicate-gym report window locally first, then across instances when
+ * Redis is healthy. The local claim deliberately remains held when Redis is
+ * unavailable or SET has an ambiguous outcome, so an outage cannot make one
+ * instance send the same notification repeatedly.
+ */
+export async function acquireGymDuplicateReportClaim(
+  key: string,
+  dependencies: GymDuplicateReportClaimDependencies = defaultDependencies,
+): Promise<GymDuplicateReportClaimResult> {
+  const now = dependencies.now();
+  pruneExpiredLocalClaims(now);
+  const existingClaim = localClaims.get(key);
+  if (existingClaim && existingClaim.expiresAt > now) {
+    return { status: 'already_claimed' };
+  }
+
+  const ownerToken = dependencies.createOwnerToken();
+  localClaims.set(key, {
+    ownerToken,
+    expiresAt: now + GYM_DUPLICATE_REPORT_CLAIM_TTL_MS,
+  });
+
+  const localOnlyClaim: GymDuplicateReportClaim = {
+    key,
+    ownerToken,
+    redisClient: null,
+    redisClaimMayExist: false,
+  };
+
+  if (!dependencies.isRedisConnected()) {
+    return { status: 'acquired', claim: localOnlyClaim };
+  }
+
+  let redisClient: GymDuplicateReportRedisClient;
+  try {
+    redisClient = dependencies.getRedisClient();
+  } catch {
+    logger.warn('[GymDuplicateReport] Redis claim client unavailable; using the local de-dup window.');
+    return { status: 'acquired', claim: localOnlyClaim };
+  }
+
+  try {
+    const setResult = await redisClient.set(key, ownerToken, 'EX', GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS, 'NX');
+
+    if (setResult === null) {
+      releaseLocalClaimIfOwner(key, ownerToken);
+      return { status: 'already_claimed' };
+    }
+
+    return {
+      status: 'acquired',
+      claim: { key, ownerToken, redisClient, redisClaimMayExist: true },
+    };
+  } catch {
+    // SET may have reached Redis before the connection failed. Retain both the
+    // token and client so an email failure can still attempt owner-checked cleanup.
+    logger.warn('[GymDuplicateReport] Redis claim outcome unknown; using the local de-dup window.');
+    return {
+      status: 'acquired',
+      claim: { key, ownerToken, redisClient, redisClaimMayExist: true },
+    };
+  }
+}
+
+/**
+ * Release only the caller's own local and Redis claims. Cleanup is best-effort:
+ * it must never replace the email error that caused the release.
+ */
+export async function releaseGymDuplicateReportClaim(claim: GymDuplicateReportClaim): Promise<void> {
+  releaseLocalClaimIfOwner(claim.key, claim.ownerToken);
+
+  if (!claim.redisClient || !claim.redisClaimMayExist) return;
+
+  try {
+    await claim.redisClient.eval(RELEASE_IF_OWNER_SCRIPT, 1, claim.key, claim.ownerToken);
+  } catch {
+    logger.warn('[GymDuplicateReport] Redis claim cleanup failed; the claim will expire automatically.');
+  }
+}
+
+/** Clear process-local claim state between tests; Redis state is intentionally untouched. */
+export function resetGymDuplicateReportClaimsForTests(): void {
+  localClaims.clear();
+  nextLocalClaimPruneAt = 0;
+}

--- a/packages/backend/src/utils/gym-duplicate-report-claims.ts
+++ b/packages/backend/src/utils/gym-duplicate-report-claims.ts
@@ -31,6 +31,11 @@ export interface GymDuplicateReportRedisClient {
   eval(script: string, numberOfKeys: number, key: string, ownerToken: string): Promise<unknown>;
 }
 
+type GymDuplicateReportRedisState = {
+  redisClient: GymDuplicateReportRedisClient | null;
+  redisClaimMayExist: boolean;
+};
+
 export interface GymDuplicateReportClaimDependencies {
   isRedisConnected: () => boolean;
   getRedisClient: () => GymDuplicateReportRedisClient;
@@ -38,12 +43,10 @@ export interface GymDuplicateReportClaimDependencies {
   now: () => number;
 }
 
-export type GymDuplicateReportClaim = {
+export type GymDuplicateReportClaim = Readonly<{
   key: string;
   ownerToken: string;
-  redisClient: GymDuplicateReportRedisClient | null;
-  redisClaimMayExist: boolean;
-};
+}>;
 
 export type GymDuplicateReportClaimResult =
   | { status: 'acquired'; claim: GymDuplicateReportClaim }
@@ -51,6 +54,7 @@ export type GymDuplicateReportClaimResult =
 
 const localClaims = new Map<string, LocalClaim>();
 const promotionPromises = new WeakMap<GymDuplicateReportClaim, Promise<void>>();
+const redisStates = new WeakMap<GymDuplicateReportClaim, GymDuplicateReportRedisState>();
 let nextLocalClaimPruneAt = 0;
 
 const defaultDependencies: GymDuplicateReportClaimDependencies = {
@@ -104,8 +108,10 @@ async function promoteLocalClaim(
   // happen after Redis applied the write. releaseGymDuplicateReportClaim then
   // waits for this promotion and performs the same owner-checked cleanup used by
   // the normal acquisition path.
-  localClaim.publicClaim.redisClient = redisClient;
-  localClaim.publicClaim.redisClaimMayExist = true;
+  const redisState = redisStates.get(localClaim.publicClaim);
+  if (!redisState) throw new Error('Missing Redis state for gym duplicate report claim');
+  redisState.redisClient = redisClient;
+  redisState.redisClaimMayExist = true;
 
   const promotionPromise = (async () => {
     try {
@@ -192,12 +198,15 @@ export async function acquireGymDuplicateReportClaim(
   }
 
   const ownerToken = dependencies.createOwnerToken();
-  const localOnlyClaim: GymDuplicateReportClaim = {
+  const localOnlyClaim: GymDuplicateReportClaim = Object.freeze({
     key,
     ownerToken,
+  });
+  const redisState: GymDuplicateReportRedisState = {
     redisClient: null,
     redisClaimMayExist: false,
   };
+  redisStates.set(localOnlyClaim, redisState);
   const localClaim: LocalClaim = {
     ownerToken,
     expiresAt: now + GYM_DUPLICATE_REPORT_CLAIM_TTL_MS,
@@ -210,8 +219,8 @@ export async function acquireGymDuplicateReportClaim(
     return { status: 'acquired', claim: localOnlyClaim };
   }
 
-  localOnlyClaim.redisClient = redisClient;
-  localOnlyClaim.redisClaimMayExist = true;
+  redisState.redisClient = redisClient;
+  redisState.redisClaimMayExist = true;
   try {
     const setResult = await redisClient.set(key, ownerToken, 'EX', GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS, 'NX');
 
@@ -250,16 +259,17 @@ export async function releaseGymDuplicateReportClaim(claim: GymDuplicateReportCl
   const pendingPromotion = promotionPromises.get(claim);
   if (pendingPromotion) await pendingPromotion;
 
-  if (!claim.redisClient || !claim.redisClaimMayExist) return;
+  const redisState = redisStates.get(claim);
+  if (!redisState?.redisClient || !redisState.redisClaimMayExist) return;
 
   try {
-    await claim.redisClient.eval(RELEASE_IF_OWNER_SCRIPT, 1, claim.key, claim.ownerToken);
+    await redisState.redisClient.eval(RELEASE_IF_OWNER_SCRIPT, 1, claim.key, claim.ownerToken);
   } catch {
     logger.warn('[GymDuplicateReport] Redis claim cleanup failed; the claim will expire automatically.');
   }
 }
 
-/** Clear process-local claim state between tests; Redis state is intentionally untouched. */
+/** @internal Clear process-local test state; Redis state is intentionally untouched. */
 export function resetGymDuplicateReportClaimsForTests(): void {
   localClaims.clear();
   nextLocalClaimPruneAt = 0;
@@ -269,4 +279,4 @@ export function resetGymDuplicateReportClaimsForTests(): void {
 // successful local-only notifications are still inside their 24-hour window.
 // RedisClientManager runs this hook before it advertises the recovered
 // connection to request handlers, closing the cross-instance duplicate gap.
-redisClientManager.onRedisReady?.((redisClient) => reconcileGymDuplicateReportClaims(redisClient));
+redisClientManager.onRedisReady((redisClient) => reconcileGymDuplicateReportClaims(redisClient));

--- a/packages/backend/src/utils/gym-duplicate-report-claims.ts
+++ b/packages/backend/src/utils/gym-duplicate-report-claims.ts
@@ -4,6 +4,7 @@ import { logger } from './logger';
 
 export const GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS = 24 * 60 * 60;
 const GYM_DUPLICATE_REPORT_CLAIM_TTL_MS = GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS * 1000;
+const GYM_DUPLICATE_REPORT_PROMOTION_RETRY_MS = 60_000;
 
 const RELEASE_IF_OWNER_SCRIPT = `
 if redis.call('get', KEYS[1]) == ARGV[1] then
@@ -15,6 +16,8 @@ return 0
 type LocalClaim = {
   ownerToken: string;
   expiresAt: number;
+  nextPromotionAt: number;
+  generation: number;
   distributed: boolean;
   publicClaim: GymDuplicateReportClaim;
 };
@@ -56,6 +59,7 @@ const localClaims = new Map<string, LocalClaim>();
 const promotionPromises = new WeakMap<GymDuplicateReportClaim, Promise<void>>();
 const redisStates = new WeakMap<GymDuplicateReportClaim, GymDuplicateReportRedisState>();
 let nextLocalClaimPruneAt = 0;
+let latestLocalClaimGeneration = 0;
 
 const defaultDependencies: GymDuplicateReportClaimDependencies = {
   isRedisConnected: () => redisClientManager.isRedisConnected(),
@@ -84,6 +88,7 @@ async function promoteLocalClaim(
   localClaim: LocalClaim,
   redisClient: GymDuplicateReportRedisClient,
   now: () => number,
+  forcePromotion: boolean,
 ): Promise<void> {
   if (localClaim.distributed) return;
   if (localClaims.get(key) !== localClaim) return;
@@ -95,14 +100,16 @@ async function promoteLocalClaim(
     // client's in-flight promotion failed. Per-claim promise registration below
     // serializes concurrent followers, so only one follow-up SET runs.
     if (localClaim.distributed || localClaims.get(key) !== localClaim) return;
-    await promoteLocalClaim(key, localClaim, redisClient, now);
+    await promoteLocalClaim(key, localClaim, redisClient, now, forcePromotion);
     return;
   }
 
-  if (localClaim.expiresAt <= now()) {
+  const promotionNow = now();
+  if (localClaim.expiresAt <= promotionNow) {
     releaseLocalClaimIfOwner(key, localClaim.ownerToken);
     return;
   }
+  if (!forcePromotion && localClaim.nextPromotionAt > promotionNow) return;
 
   // Conservatively remember the client before SET: a connection failure may
   // happen after Redis applied the write. releaseGymDuplicateReportClaim then
@@ -121,11 +128,14 @@ async function promoteLocalClaim(
       const setResult = await redisClient.set(key, localClaim.ownerToken, 'PXAT', localClaim.expiresAt, 'NX');
       if (setResult === 'OK' && localClaims.get(key) === localClaim) {
         localClaim.distributed = true;
+      } else if (setResult === null) {
+        localClaim.nextPromotionAt = Math.min(localClaim.expiresAt, now() + GYM_DUPLICATE_REPORT_PROMOTION_RETRY_MS);
       }
       // null means another distributed owner already protects this pair. Never
       // overwrite it. Keep the local claim pending so a later recovery/acquire
       // can retry after that owner releases or expires.
     } catch {
+      localClaim.nextPromotionAt = Math.min(localClaim.expiresAt, now() + GYM_DUPLICATE_REPORT_PROMOTION_RETRY_MS);
       logger.warn('[GymDuplicateReport] Redis claim promotion failed; keeping the local de-dup window.');
     }
   })();
@@ -148,14 +158,28 @@ async function promoteLocalClaim(
 export async function reconcileGymDuplicateReportClaims(
   redisClient: GymDuplicateReportRedisClient,
   now: () => number = Date.now,
+  forcePromotion = true,
 ): Promise<void> {
-  for (const [key, localClaim] of localClaims) {
-    if (localClaim.expiresAt <= now()) {
-      releaseLocalClaimIfOwner(key, localClaim.ownerToken);
-      continue;
+  let reconciledThroughGeneration = 0;
+  do {
+    const snapshotGeneration = latestLocalClaimGeneration;
+    // Snapshot before awaiting SET so Map mutation cannot perturb this pass.
+    // The readiness path drains later generations before RedisClientManager
+    // advertises connectivity; opportunistic request-path work stays bounded
+    // to one snapshot and lets each connected acquire own its direct SET.
+    const claimsAtStart = Array.from(localClaims.entries()).filter(
+      ([, localClaim]) =>
+        localClaim.generation > reconciledThroughGeneration && localClaim.generation <= snapshotGeneration,
+    );
+    for (const [key, localClaim] of claimsAtStart) {
+      if (localClaim.expiresAt <= now()) {
+        releaseLocalClaimIfOwner(key, localClaim.ownerToken);
+        continue;
+      }
+      await promoteLocalClaim(key, localClaim, redisClient, now, forcePromotion);
     }
-    await promoteLocalClaim(key, localClaim, redisClient, now);
-  }
+    reconciledThroughGeneration = snapshotGeneration;
+  } while (forcePromotion && latestLocalClaimGeneration > reconciledThroughGeneration);
 }
 
 /** One stable key per unordered gym pair, so (A,B) and (B,A) de-dupe together. */
@@ -184,7 +208,7 @@ export async function acquireGymDuplicateReportClaim(
       // This is normally completed by the Redis readiness hook below. It is
       // repeated opportunistically so a transient promotion failure is retried
       // on the next request while local suppression remains honest and intact.
-      await reconcileGymDuplicateReportClaims(redisClient, dependencies.now);
+      await reconcileGymDuplicateReportClaims(redisClient, dependencies.now, false);
       now = dependencies.now();
       pruneExpiredLocalClaims(now);
     } catch {
@@ -210,6 +234,8 @@ export async function acquireGymDuplicateReportClaim(
   const localClaim: LocalClaim = {
     ownerToken,
     expiresAt: now + GYM_DUPLICATE_REPORT_CLAIM_TTL_MS,
+    nextPromotionAt: now,
+    generation: (latestLocalClaimGeneration += 1),
     distributed: false,
     publicClaim: localOnlyClaim,
   };
@@ -238,6 +264,10 @@ export async function acquireGymDuplicateReportClaim(
   } catch {
     // SET may have reached Redis before the connection failed. Retain both the
     // token and client so an email failure can still attempt owner-checked cleanup.
+    localClaim.nextPromotionAt = Math.min(
+      localClaim.expiresAt,
+      dependencies.now() + GYM_DUPLICATE_REPORT_PROMOTION_RETRY_MS,
+    );
     logger.warn('[GymDuplicateReport] Redis claim outcome unknown; using the local de-dup window.');
     return {
       status: 'acquired',
@@ -273,6 +303,7 @@ export async function releaseGymDuplicateReportClaim(claim: GymDuplicateReportCl
 export function resetGymDuplicateReportClaimsForTests(): void {
   localClaims.clear();
   nextLocalClaimPruneAt = 0;
+  latestLocalClaimGeneration = 0;
 }
 
 // Initial startup has no outage claims, but ioredis can reconnect later while

--- a/packages/backend/src/utils/gym-duplicate-report-claims.ts
+++ b/packages/backend/src/utils/gym-duplicate-report-claims.ts
@@ -15,11 +15,19 @@ return 0
 type LocalClaim = {
   ownerToken: string;
   expiresAt: number;
+  distributed: boolean;
+  publicClaim: GymDuplicateReportClaim;
 };
 
 /** The narrow Redis surface needed by this claim protocol. */
 export interface GymDuplicateReportRedisClient {
-  set(key: string, ownerToken: string, expiryMode: 'EX', ttlSeconds: number, condition: 'NX'): Promise<'OK' | null>;
+  set(
+    key: string,
+    ownerToken: string,
+    expiryMode: 'EX' | 'PXAT',
+    expiry: number,
+    condition: 'NX',
+  ): Promise<'OK' | null>;
   eval(script: string, numberOfKeys: number, key: string, ownerToken: string): Promise<unknown>;
 }
 
@@ -42,6 +50,7 @@ export type GymDuplicateReportClaimResult =
   | { status: 'already_claimed' };
 
 const localClaims = new Map<string, LocalClaim>();
+const promotionPromises = new WeakMap<GymDuplicateReportClaim, Promise<void>>();
 let nextLocalClaimPruneAt = 0;
 
 const defaultDependencies: GymDuplicateReportClaimDependencies = {
@@ -66,6 +75,83 @@ function pruneExpiredLocalClaims(now: number): void {
   }
 }
 
+async function promoteLocalClaim(
+  key: string,
+  localClaim: LocalClaim,
+  redisClient: GymDuplicateReportRedisClient,
+  now: () => number,
+): Promise<void> {
+  if (localClaim.distributed) return;
+  if (localClaims.get(key) !== localClaim) return;
+
+  const existingPromotion = promotionPromises.get(localClaim.publicClaim);
+  if (existingPromotion) {
+    await existingPromotion;
+    // A caller using a newly recovered client must retry after the older
+    // client's in-flight promotion failed. Per-claim promise registration below
+    // serializes concurrent followers, so only one follow-up SET runs.
+    if (localClaim.distributed || localClaims.get(key) !== localClaim) return;
+    await promoteLocalClaim(key, localClaim, redisClient, now);
+    return;
+  }
+
+  if (localClaim.expiresAt <= now()) {
+    releaseLocalClaimIfOwner(key, localClaim.ownerToken);
+    return;
+  }
+
+  // Conservatively remember the client before SET: a connection failure may
+  // happen after Redis applied the write. releaseGymDuplicateReportClaim then
+  // waits for this promotion and performs the same owner-checked cleanup used by
+  // the normal acquisition path.
+  localClaim.publicClaim.redisClient = redisClient;
+  localClaim.publicClaim.redisClaimMayExist = true;
+
+  const promotionPromise = (async () => {
+    try {
+      // PXAT pins Redis to the original absolute local expiry. A relative PX
+      // computed before ioredis queues/retries the command would extend the
+      // de-dup window by that delay.
+      const setResult = await redisClient.set(key, localClaim.ownerToken, 'PXAT', localClaim.expiresAt, 'NX');
+      if (setResult === 'OK' && localClaims.get(key) === localClaim) {
+        localClaim.distributed = true;
+      }
+      // null means another distributed owner already protects this pair. Never
+      // overwrite it. Keep the local claim pending so a later recovery/acquire
+      // can retry after that owner releases or expires.
+    } catch {
+      logger.warn('[GymDuplicateReport] Redis claim promotion failed; keeping the local de-dup window.');
+    }
+  })();
+  promotionPromises.set(localClaim.publicClaim, promotionPromise);
+  try {
+    await promotionPromise;
+  } finally {
+    if (promotionPromises.get(localClaim.publicClaim) === promotionPromise) {
+      promotionPromises.delete(localClaim.publicClaim);
+    }
+  }
+}
+
+/**
+ * Copy every process-local outage claim into Redis after recovery. Each write is
+ * SET NX PXAT with the claim's original absolute expiry, so reconciliation
+ * neither extends the 24-hour window nor overwrites another instance's owner
+ * token.
+ */
+export async function reconcileGymDuplicateReportClaims(
+  redisClient: GymDuplicateReportRedisClient,
+  now: () => number = Date.now,
+): Promise<void> {
+  for (const [key, localClaim] of localClaims) {
+    if (localClaim.expiresAt <= now()) {
+      releaseLocalClaimIfOwner(key, localClaim.ownerToken);
+      continue;
+    }
+    await promoteLocalClaim(key, localClaim, redisClient, now);
+  }
+}
+
 /** One stable key per unordered gym pair, so (A,B) and (B,A) de-dupe together. */
 export function gymDuplicateReportClaimKey(firstUuid: string, secondUuid: string): string {
   const [lowUuid, highUuid] = [firstUuid, secondUuid].sort();
@@ -82,38 +168,50 @@ export async function acquireGymDuplicateReportClaim(
   key: string,
   dependencies: GymDuplicateReportClaimDependencies = defaultDependencies,
 ): Promise<GymDuplicateReportClaimResult> {
-  const now = dependencies.now();
+  let now = dependencies.now();
   pruneExpiredLocalClaims(now);
+
+  let redisClient: GymDuplicateReportRedisClient | null = null;
+  if (dependencies.isRedisConnected()) {
+    try {
+      redisClient = dependencies.getRedisClient();
+      // This is normally completed by the Redis readiness hook below. It is
+      // repeated opportunistically so a transient promotion failure is retried
+      // on the next request while local suppression remains honest and intact.
+      await reconcileGymDuplicateReportClaims(redisClient, dependencies.now);
+      now = dependencies.now();
+      pruneExpiredLocalClaims(now);
+    } catch {
+      logger.warn('[GymDuplicateReport] Redis claim client unavailable; using the local de-dup window.');
+    }
+  }
+
   const existingClaim = localClaims.get(key);
   if (existingClaim && existingClaim.expiresAt > now) {
     return { status: 'already_claimed' };
   }
 
   const ownerToken = dependencies.createOwnerToken();
-  localClaims.set(key, {
-    ownerToken,
-    expiresAt: now + GYM_DUPLICATE_REPORT_CLAIM_TTL_MS,
-  });
-
   const localOnlyClaim: GymDuplicateReportClaim = {
     key,
     ownerToken,
     redisClient: null,
     redisClaimMayExist: false,
   };
+  const localClaim: LocalClaim = {
+    ownerToken,
+    expiresAt: now + GYM_DUPLICATE_REPORT_CLAIM_TTL_MS,
+    distributed: false,
+    publicClaim: localOnlyClaim,
+  };
+  localClaims.set(key, localClaim);
 
-  if (!dependencies.isRedisConnected()) {
+  if (!redisClient) {
     return { status: 'acquired', claim: localOnlyClaim };
   }
 
-  let redisClient: GymDuplicateReportRedisClient;
-  try {
-    redisClient = dependencies.getRedisClient();
-  } catch {
-    logger.warn('[GymDuplicateReport] Redis claim client unavailable; using the local de-dup window.');
-    return { status: 'acquired', claim: localOnlyClaim };
-  }
-
+  localOnlyClaim.redisClient = redisClient;
+  localOnlyClaim.redisClaimMayExist = true;
   try {
     const setResult = await redisClient.set(key, ownerToken, 'EX', GYM_DUPLICATE_REPORT_CLAIM_TTL_SECONDS, 'NX');
 
@@ -122,9 +220,11 @@ export async function acquireGymDuplicateReportClaim(
       return { status: 'already_claimed' };
     }
 
+    localClaim.distributed = true;
+
     return {
       status: 'acquired',
-      claim: { key, ownerToken, redisClient, redisClaimMayExist: true },
+      claim: localOnlyClaim,
     };
   } catch {
     // SET may have reached Redis before the connection failed. Retain both the
@@ -132,7 +232,7 @@ export async function acquireGymDuplicateReportClaim(
     logger.warn('[GymDuplicateReport] Redis claim outcome unknown; using the local de-dup window.');
     return {
       status: 'acquired',
-      claim: { key, ownerToken, redisClient, redisClaimMayExist: true },
+      claim: localOnlyClaim,
     };
   }
 }
@@ -143,6 +243,12 @@ export async function acquireGymDuplicateReportClaim(
  */
 export async function releaseGymDuplicateReportClaim(claim: GymDuplicateReportClaim): Promise<void> {
   releaseLocalClaimIfOwner(claim.key, claim.ownerToken);
+
+  // A Redis-recovery callback can race an email failure. Wait until its SET NX
+  // has a definite/ambiguous outcome before owner-checked cleanup, otherwise a
+  // successful late promotion could recreate the claim after release returned.
+  const pendingPromotion = promotionPromises.get(claim);
+  if (pendingPromotion) await pendingPromotion;
 
   if (!claim.redisClient || !claim.redisClaimMayExist) return;
 
@@ -158,3 +264,9 @@ export function resetGymDuplicateReportClaimsForTests(): void {
   localClaims.clear();
   nextLocalClaimPruneAt = 0;
 }
+
+// Initial startup has no outage claims, but ioredis can reconnect later while
+// successful local-only notifications are still inside their 24-hour window.
+// RedisClientManager runs this hook before it advertises the recovered
+// connection to request handlers, closing the cross-instance duplicate gap.
+redisClientManager.onRedisReady?.((redisClient) => reconcileGymDuplicateReportClaims(redisClient));


### PR DESCRIPTION
## Summary

- claim each unordered duplicate-gym pair locally before any Redis await, then extend the 24-hour window across backend instances with Redis `SET ... EX 86400 NX`
- degrade safely to the owner-token local claim during Redis outages or ambiguous writes, and release only the matching local and Redis owner when email delivery fails
- cover concurrency, reversed pairs, restart/outage recovery, ambiguous writes, expiry, privacy-safe logs, and the real Redis NX/TTL/Lua ownership contract

Closes #3848

## Release Notes

Report a duplicate gym once without sending repeat reports.

## Test plan

- `vp test run --project backend packages/backend/src/__tests__/gym-duplicate-report-claims.test.ts packages/backend/src/__tests__/gym-report-duplicate.test.ts --reporter=agent` (24 passed)
- `vp test run --project backend --reporter=agent` (220 files, 2,929 tests passed)
- `vp run typecheck:backend`
- scoped `vp check` on all four changed files
- `git diff --check`
- independent adversarial review, including a real-Redis NX and stale-owner Lua cleanup remediation, passed
- started `vp run dev`; the orchestrator loaded `.boardsesh/qa-notes.md` and web reached ready state at the printed HTTPS URL