### PR TITLE
test(mobile): cover iOS MoonBoard disconnects

### DIFF
--- a/packages/mobile/ios-tests/BoardBleDisconnectTests.swift
+++ b/packages/mobile/ios-tests/BoardBleDisconnectTests.swift
@@ -127,6 +127,11 @@ final class BoardBleDisconnectTests: XCTestCase {
         var settledErrors: [Error?] = []
         installConnection(peripheral: currentPeripheral) { _, _ in disconnectEventCount += 1 }
         enqueueTwoWrites { settledErrors.append($0) }
+        // Seed a generation for the stale peripheral so the guard's cleanup line
+        // (removing a non-current peripheral's entry) has something to remove.
+        manager.testHooks.sync {
+            manager.testHooks.setPeripheralGeneration(7, for: stalePeripheral.identifier)
+        }
 
         let pendingWatchdog = scheduler.lastOneShot(label: "writeAckWatchdog")
         XCTAssertEqual(manager.testHooks.sync { manager.testHooks.writeQueueDepth }, 2)
@@ -134,6 +139,9 @@ final class BoardBleDisconnectTests: XCTestCase {
 
         manager.testHooks.fireDidDisconnect(peripheral: stalePeripheral, error: nil)
 
+        XCTAssertNil(
+            manager.testHooks.sync { manager.testHooks.peripheralGeneration(for: stalePeripheral.identifier) }
+        )
         XCTAssertEqual(manager.connectedDeviceId, currentPeripheral.identifier.uuidString)
         XCTAssertEqual(manager.testHooks.sync { manager.testHooks.writeQueueDepth }, 2)
         XCTAssertTrue(manager.testHooks.sync { manager.testHooks.isWriting })
@@ -174,12 +182,19 @@ final class BoardBleDisconnectTests: XCTestCase {
         XCTAssertEqual(disconnectEvents.count, 1)
         XCTAssertEqual(disconnectEvents.first?.deviceId, peripheral.identifier.uuidString)
         XCTAssertNil(disconnectEvents.first?.body)
+        // No auto-reconnect on an unexpected drop: these boards are
+        // last-connection-wins, so a silent re-grab would steal the wall back.
+        // The manager must not cancel, rescan, or reconnect on this path.
+        XCTAssertTrue(cancelledPeripheralIds.isEmpty)
+        XCTAssertEqual(stopScanCallCount, 0)
 
         manager.testHooks.fireWriteAck(error: nil)
         manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: nil)
         pendingWatchdog?.fire()
         XCTAssertEqual(settledErrors.count, 2)
         XCTAssertEqual(disconnectEvents.count, 1)
+        XCTAssertTrue(cancelledPeripheralIds.isEmpty)
+        XCTAssertEqual(stopScanCallCount, 0)
     }
 
     func testCurrentErrorDisconnectForwardsNSErrorToWritesAndEvent() {
@@ -219,10 +234,15 @@ final class BoardBleDisconnectTests: XCTestCase {
             disconnectEvents.first?.body?["errorDescription"] as? String,
             disconnectError.localizedDescription
         )
+        // No auto-reconnect on an error drop either (same board-stealing rule).
+        XCTAssertTrue(cancelledPeripheralIds.isEmpty)
+        XCTAssertEqual(stopScanCallCount, 0)
 
         manager.testHooks.fireWriteAck(error: nil)
         pendingWatchdog?.fire()
         XCTAssertEqual(settledErrors.count, 2)
         XCTAssertEqual(disconnectEvents.count, 1)
+        XCTAssertTrue(cancelledPeripheralIds.isEmpty)
+        XCTAssertEqual(stopScanCallCount, 0)
     }
 }

--- a/packages/mobile/ios-tests/BoardBleDisconnectTests.swift
+++ b/packages/mobile/ios-tests/BoardBleDisconnectTests.swift
@@ -9,15 +9,20 @@ final class BoardBleDisconnectTests: XCTestCase {
     private var scheduler: FakeBleTimerScheduler!
     private var manager: BoardBleManager!
     private var cancelledPeripheralIds: [UUID] = []
+    private var stopScanCallCount = 0
     private let uartWriteCharacteristicUuid = CBUUID(string: "6E400002-B5A3-F393-E0A9-E50E24DCCA9E")
 
     override func setUp() {
         super.setUp()
         cancelledPeripheralIds = []
+        stopScanCallCount = 0
         scheduler = FakeBleTimerScheduler()
         manager = BoardBleManager(timerScheduler: scheduler, createCentralManagerEagerly: false)
         manager.testHooks.sync {
             manager.testHooks.setConfiguration(nil)
+            manager.testHooks.setStopScanOverride { [weak self] in
+                self?.stopScanCallCount += 1
+            }
             manager.testHooks.setCancelPeripheralConnectionOverride { [weak self] peripheral in
                 self?.cancelledPeripheralIds.append(peripheral.identifier)
             }
@@ -26,6 +31,7 @@ final class BoardBleDisconnectTests: XCTestCase {
 
     override func tearDown() {
         manager.testHooks.sync {
+            manager.testHooks.setStopScanOverride(nil)
             manager.testHooks.setCancelPeripheralConnectionOverride(nil)
         }
         manager = nil
@@ -95,6 +101,7 @@ final class BoardBleDisconnectTests: XCTestCase {
             intentionalGeneration
         )
         XCTAssertEqual(cancelledPeripheralIds, [peripheral.identifier])
+        XCTAssertEqual(stopScanCallCount, 1)
         XCTAssertNil(manager.connectedDeviceId)
         XCTAssertEqual(disconnectEventCount, 0)
 
@@ -110,6 +117,7 @@ final class BoardBleDisconnectTests: XCTestCase {
         )
         XCTAssertEqual(disconnectEventCount, 0)
         XCTAssertEqual(cancelledPeripheralIds, [peripheral.identifier])
+        XCTAssertEqual(stopScanCallCount, 1)
     }
 
     func testStaleDifferentPeripheralDisconnectLeavesCurrentWriteQueueUntouched() {

--- a/packages/mobile/ios-tests/BoardBleDisconnectTests.swift
+++ b/packages/mobile/ios-tests/BoardBleDisconnectTests.swift
@@ -1,0 +1,220 @@
+import CoreBluetooth
+import XCTest
+
+/// Characterization coverage for `didDisconnectPeripheral`. The tests drive the
+/// same queue-bound helper as CoreBluetooth's delegate callback, with no native
+/// Bluetooth stack or timing sleeps.
+@available(iOS 17.0, *)
+final class BoardBleDisconnectTests: XCTestCase {
+    private var scheduler: FakeBleTimerScheduler!
+    private var manager: BoardBleManager!
+    private var cancelledPeripheralIds: [UUID] = []
+    private let uartWriteCharacteristicUuid = CBUUID(string: "6E400002-B5A3-F393-E0A9-E50E24DCCA9E")
+
+    override func setUp() {
+        super.setUp()
+        cancelledPeripheralIds = []
+        scheduler = FakeBleTimerScheduler()
+        manager = BoardBleManager(timerScheduler: scheduler, createCentralManagerEagerly: false)
+        manager.testHooks.sync {
+            manager.testHooks.setConfiguration(nil)
+            manager.testHooks.setCancelPeripheralConnectionOverride { [weak self] peripheral in
+                self?.cancelledPeripheralIds.append(peripheral.identifier)
+            }
+        }
+    }
+
+    override func tearDown() {
+        manager.testHooks.sync {
+            manager.testHooks.setCancelPeripheralConnectionOverride(nil)
+        }
+        manager = nil
+        scheduler = nil
+        super.tearDown()
+    }
+
+    private func makeWriteCharacteristic() -> CBMutableCharacteristic {
+        CBMutableCharacteristic(
+            type: uartWriteCharacteristicUuid,
+            properties: .write,
+            value: nil,
+            permissions: [.writeable]
+        )
+    }
+
+    private func moonboardConfiguration() -> BoardBleConfiguration {
+        BoardBleConfiguration(
+            boardName: "moonboard",
+            layoutId: 0,
+            sizeId: 0,
+            apiLevel: nil,
+            deviceName: nil,
+            colorOverrides: [:],
+            numRows: nil
+        )
+    }
+
+    private func installConnection(
+        peripheral: FakeWritablePeripheral,
+        onDisconnect: @escaping (String, [String: Any]?) -> Void
+    ) {
+        manager.testHooks.sync {
+            manager.testHooks.setConfiguration(moonboardConfiguration())
+            manager.setEventHandlers(
+                onScanResult: nil,
+                onDisconnect: onDisconnect,
+                onConnected: nil
+            )
+            manager.testHooks.setConnection(
+                peripheral: peripheral,
+                characteristic: makeWriteCharacteristic()
+            )
+        }
+    }
+
+    private func enqueueTwoWrites(onSettle: @escaping (Error?) -> Void) {
+        manager.testHooks.sync {
+            manager.write(data: Data([0x01])) { error, _ in onSettle(error) }
+            manager.write(data: Data([0x02])) { error, _ in onSettle(error) }
+        }
+    }
+
+    func testIntentionalDisconnectConsumesMarkerAndSuppressesEvent() {
+        let peripheral = FakeWritablePeripheral()
+        var disconnectEventCount = 0
+        installConnection(peripheral: peripheral) { _, _ in disconnectEventCount += 1 }
+
+        manager.testHooks.sync { manager.disconnect() }
+
+        let intentionalGeneration = manager.testHooks.sync {
+            manager.testHooks.intentionalDisconnectGeneration(for: peripheral.identifier)
+        }
+        XCTAssertNotNil(intentionalGeneration)
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.peripheralGeneration(for: peripheral.identifier) },
+            intentionalGeneration
+        )
+        XCTAssertEqual(cancelledPeripheralIds, [peripheral.identifier])
+        XCTAssertNil(manager.connectedDeviceId)
+        XCTAssertEqual(disconnectEventCount, 0)
+
+        manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: nil)
+
+        XCTAssertNil(
+            manager.testHooks.sync {
+                manager.testHooks.intentionalDisconnectGeneration(for: peripheral.identifier)
+            }
+        )
+        XCTAssertNil(
+            manager.testHooks.sync { manager.testHooks.peripheralGeneration(for: peripheral.identifier) }
+        )
+        XCTAssertEqual(disconnectEventCount, 0)
+        XCTAssertEqual(cancelledPeripheralIds, [peripheral.identifier])
+    }
+
+    func testStaleDifferentPeripheralDisconnectLeavesCurrentWriteQueueUntouched() {
+        let currentPeripheral = FakeWritablePeripheral()
+        let stalePeripheral = FakeWritablePeripheral()
+        var disconnectEventCount = 0
+        var settledErrors: [Error?] = []
+        installConnection(peripheral: currentPeripheral) { _, _ in disconnectEventCount += 1 }
+        enqueueTwoWrites { settledErrors.append($0) }
+
+        let pendingWatchdog = scheduler.lastOneShot(label: "writeAckWatchdog")
+        XCTAssertEqual(manager.testHooks.sync { manager.testHooks.writeQueueDepth }, 2)
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.hasPendingWriteAck })
+
+        manager.testHooks.fireDidDisconnect(peripheral: stalePeripheral, error: nil)
+
+        XCTAssertEqual(manager.connectedDeviceId, currentPeripheral.identifier.uuidString)
+        XCTAssertEqual(manager.testHooks.sync { manager.testHooks.writeQueueDepth }, 2)
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.isWriting })
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.hasPendingWriteAck })
+        XCTAssertFalse(pendingWatchdog?.cancelled ?? true)
+        XCTAssertEqual(disconnectEventCount, 0)
+        XCTAssertTrue(settledErrors.isEmpty)
+
+        manager.testHooks.fireWriteAck(error: nil)
+        manager.testHooks.fireWriteAck(error: nil)
+
+        XCTAssertEqual(settledErrors.count, 2)
+        XCTAssertTrue(settledErrors.allSatisfy { $0 == nil })
+        XCTAssertEqual(currentPeripheral.writtenChunks.count, 2)
+    }
+
+    func testCurrentCleanDisconnectSettlesQueueCancelsWatchdogAndEmitsOnce() {
+        let peripheral = FakeWritablePeripheral()
+        var disconnectEvents: [(deviceId: String, body: [String: Any]?)] = []
+        var settledErrors: [Error?] = []
+        installConnection(peripheral: peripheral) { deviceId, body in
+            disconnectEvents.append((deviceId: deviceId, body: body))
+        }
+        enqueueTwoWrites { settledErrors.append($0) }
+        let pendingWatchdog = scheduler.lastOneShot(label: "writeAckWatchdog")
+
+        manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: nil)
+
+        XCTAssertNil(manager.connectedDeviceId)
+        XCTAssertEqual(manager.testHooks.sync { manager.testHooks.writeQueueDepth }, 0)
+        XCTAssertFalse(manager.testHooks.sync { manager.testHooks.isWriting })
+        XCTAssertFalse(manager.testHooks.sync { manager.testHooks.hasPendingWriteAck })
+        XCTAssertTrue(pendingWatchdog?.cancelled ?? false)
+        XCTAssertEqual(settledErrors.count, 2)
+        XCTAssertTrue(settledErrors.allSatisfy {
+            $0?.localizedDescription == BoardBleError.notConnected.localizedDescription
+        })
+        XCTAssertEqual(disconnectEvents.count, 1)
+        XCTAssertEqual(disconnectEvents.first?.deviceId, peripheral.identifier.uuidString)
+        XCTAssertNil(disconnectEvents.first?.body)
+
+        manager.testHooks.fireWriteAck(error: nil)
+        manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: nil)
+        pendingWatchdog?.fire()
+        XCTAssertEqual(settledErrors.count, 2)
+        XCTAssertEqual(disconnectEvents.count, 1)
+    }
+
+    func testCurrentErrorDisconnectForwardsNSErrorToWritesAndEvent() {
+        let peripheral = FakeWritablePeripheral()
+        let disconnectError = NSError(
+            domain: "BoardBleDisconnectTests",
+            code: 37,
+            userInfo: [NSLocalizedDescriptionKey: "Radio link vanished"]
+        )
+        var disconnectEvents: [(deviceId: String, body: [String: Any]?)] = []
+        var settledErrors: [Error?] = []
+        installConnection(peripheral: peripheral) { deviceId, body in
+            disconnectEvents.append((deviceId: deviceId, body: body))
+        }
+        enqueueTwoWrites { settledErrors.append($0) }
+        let pendingWatchdog = scheduler.lastOneShot(label: "writeAckWatchdog")
+
+        manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: disconnectError)
+
+        XCTAssertNil(manager.connectedDeviceId)
+        XCTAssertEqual(manager.testHooks.sync { manager.testHooks.writeQueueDepth }, 0)
+        XCTAssertFalse(manager.testHooks.sync { manager.testHooks.isWriting })
+        XCTAssertFalse(manager.testHooks.sync { manager.testHooks.hasPendingWriteAck })
+        XCTAssertTrue(pendingWatchdog?.cancelled ?? false)
+        XCTAssertEqual(settledErrors.count, 2)
+        for settledError in settledErrors {
+            let nsError = settledError as? NSError
+            XCTAssertEqual(nsError?.domain, disconnectError.domain)
+            XCTAssertEqual(nsError?.code, disconnectError.code)
+            XCTAssertEqual(nsError?.localizedDescription, disconnectError.localizedDescription)
+        }
+        XCTAssertEqual(disconnectEvents.count, 1)
+        XCTAssertEqual(disconnectEvents.first?.deviceId, peripheral.identifier.uuidString)
+        XCTAssertEqual(disconnectEvents.first?.body?["errorDomain"] as? String, disconnectError.domain)
+        XCTAssertEqual(disconnectEvents.first?.body?["errorCode"] as? Int, disconnectError.code)
+        XCTAssertEqual(
+            disconnectEvents.first?.body?["errorDescription"] as? String,
+            disconnectError.localizedDescription
+        )
+
+        manager.testHooks.fireWriteAck(error: nil)
+        pendingWatchdog?.fire()
+        XCTAssertEqual(settledErrors.count, 2)
+        XCTAssertEqual(disconnectEvents.count, 1)
+    }
+}

--- a/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
+++ b/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
@@ -1411,7 +1411,6 @@ final class WaiterPoolOutcomeTests: XCTestCase {
         XCTAssertTrue(signaledResult)
     }
 
-    // 13
     func testMoonBoardAckWatchdogStartsBoundedConnectionRecovery() {
         let hooks = manager.testHooks
         let peripheral = FakeWritablePeripheral(canSendDefault: true, maxWriteValueLength: 20)

--- a/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
+++ b/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
@@ -14,7 +14,7 @@ final class FakeWritablePeripheral: WritableBlePeripheral {
     var canSendDefault: Bool
     var canSendScript: [Bool]
     var maxWriteValueLength: Int
-    private(set) var writtenChunks: [(data: Data, type: CBCharacteristicWriteType)] = []
+    private(set) var writtenChunks: [(data: Data, characteristicUuid: CBUUID, type: CBCharacteristicWriteType)] = []
 
     init(
         identifier: UUID = UUID(),
@@ -41,8 +41,8 @@ final class FakeWritablePeripheral: WritableBlePeripheral {
         maxWriteValueLength
     }
 
-    func writeValue(_ data: Data, for _: CBCharacteristic, type: CBCharacteristicWriteType) {
-        writtenChunks.append((data: data, type: type))
+    func writeValue(_ data: Data, for characteristic: CBCharacteristic, type: CBCharacteristicWriteType) {
+        writtenChunks.append((data: data, characteristicUuid: characteristic.uuid, type: type))
     }
 }
 
@@ -168,9 +168,12 @@ final class BoardBleWriteFlowTests: XCTestCase {
         super.tearDown()
     }
 
-    private func makeCharacteristic(properties: CBCharacteristicProperties = .writeWithoutResponse) -> CBMutableCharacteristic {
+    private func makeCharacteristic(
+        uuid: CBUUID? = nil,
+        properties: CBCharacteristicProperties = .writeWithoutResponse
+    ) -> CBMutableCharacteristic {
         CBMutableCharacteristic(
-            type: uartWriteCharacteristicUuid,
+            type: uuid ?? uartWriteCharacteristicUuid,
             properties: properties,
             value: nil,
             permissions: [.writeable]
@@ -1142,8 +1145,14 @@ final class BoardBleWriteFlowTests: XCTestCase {
     func testWithResponseWritePacesOnAckAndArmsAckWatchdog() {
         let hooks = manager.testHooks
         let peripheral = FakeWritablePeripheral(canSendDefault: true, maxWriteValueLength: 20)
-        // MoonBoard + `.write`-only characteristic -> the with-response path.
-        let characteristic = makeCharacteristic(properties: .write)
+        let redBearLabServiceUuid = CBUUID(string: "713D0000-503E-4C75-BA94-3148F18D941E")
+        let expectedWriteUuid = CBUUID(string: "713D0003-503E-4C75-BA94-3148F18D941E")
+        let selectedWriteUuid = hooks.writeCharacteristicUuidForTesting(serviceUuid: redBearLabServiceUuid)
+        XCTAssertEqual(selectedWriteUuid, expectedWriteUuid)
+
+        // The production RedBearLab service mapping selects 713D0003. Its
+        // `.write`-only property must use ACK-paced write-with-response.
+        let characteristic = makeCharacteristic(uuid: selectedWriteUuid, properties: .write)
         let payload = Data((0 ..< 40).map { UInt8($0) })
 
         var completionError: Error?
@@ -1162,6 +1171,7 @@ final class BoardBleWriteFlowTests: XCTestCase {
 
         // First chunk out with-response; paced on the ack, not chunkDelay.
         XCTAssertEqual(peripheral.writtenChunks.count, 1)
+        XCTAssertEqual(peripheral.writtenChunks[0].characteristicUuid, expectedWriteUuid)
         XCTAssertEqual(peripheral.writtenChunks[0].type, .withResponse)
         XCTAssertEqual(peripheral.writtenChunks[0].data.count, 20)
         XCTAssertNotNil(scheduler.lastOneShot(label: "writeAckWatchdog"))
@@ -1173,6 +1183,7 @@ final class BoardBleWriteFlowTests: XCTestCase {
         hooks.fireWriteAck(error: nil) // -> completion
         XCTAssertEqual(peripheral.writtenChunks.count, 2)
         XCTAssertTrue(peripheral.writtenChunks.allSatisfy { $0.type == .withResponse })
+        XCTAssertTrue(peripheral.writtenChunks.allSatisfy { $0.characteristicUuid == expectedWriteUuid })
         XCTAssertEqual(completionCount, 1)
         XCTAssertNil(completionError)
         XCTAssertEqual(completionTelemetry?.writeType, "withResponse")
@@ -1398,5 +1409,45 @@ final class WaiterPoolOutcomeTests: XCTestCase {
 
         let signaledResult = await resultTask.value
         XCTAssertTrue(signaledResult)
+    }
+
+    // 13
+    func testMoonBoardAckWatchdogStartsBoundedConnectionRecovery() {
+        let hooks = manager.testHooks
+        let peripheral = FakeWritablePeripheral(canSendDefault: true, maxWriteValueLength: 20)
+        let characteristic = makeCharacteristic(properties: .write)
+        let payload = Data((0 ..< 10).map { UInt8($0) })
+
+        var completionError: Error?
+        var completionCount = 0
+        var disconnectEventCount = 0
+
+        hooks.sync {
+            manager.setEventHandlers(
+                onScanResult: nil,
+                onDisconnect: { _, _ in disconnectEventCount += 1 }
+            )
+            hooks.setConfiguration(moonboardConfiguration())
+            hooks.setConnection(peripheral: peripheral, characteristic: characteristic)
+            manager.write(data: payload) { error, _ in
+                completionError = error
+                completionCount += 1
+            }
+        }
+
+        XCTAssertEqual(peripheral.writtenChunks.map(\.type), [.withResponse])
+        XCTAssertFalse(hooks.sync { hooks.forceWriteWithResponse })
+        XCTAssertTrue(hooks.sync { hooks.hasPendingWriteAck })
+
+        fireLatestOneShot(label: "writeAckWatchdog")
+
+        XCTAssertEqual(completionCount, 1)
+        XCTAssertEqual(completionError?.localizedDescription, BoardBleError.writeTimedOut.localizedDescription)
+        XCTAssertEqual(cancelledPeripheralIds, [peripheral.identifier])
+        XCTAssertEqual(hooks.sync { hooks.writeStallRecoveries }, 1)
+        XCTAssertEqual(hooks.sync { hooks.writeStallRecoveringPeripheralId }, peripheral.identifier)
+        XCTAssertNotNil(scheduler.lastOneShot(label: "writeStallRecoveryWatchdog"))
+        XCTAssertFalse(hooks.sync { hooks.hasPendingWriteAck })
+        XCTAssertEqual(disconnectEventCount, 0)
     }
 }

--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -605,11 +605,6 @@ final class LiveActivityWidgetTests: XCTestCase {
         XCTAssertEqual(BoardBleEncoding.parseApiLevel(deviceName: "Board@x@5"), 5)
     }
 
-    func testRedBearLabWriteCharacteristicUsesWriteWithResponse() {
-        // The original MoonBoard (RedBearLab) write characteristic (713d0003)
-        // advertises `.write` only, so iOS must pace it with write-with-response.
-        XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: .write, boardName: "moonboard"), .withResponse)
-    }
 }
 
 @available(iOS 17.0, *)

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -1251,6 +1251,14 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     }
 
     func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
+        handleDidDisconnectOnBleQueue(peripheral: peripheral, error: error)
+    }
+
+    /// Shared delegate body for real CoreBluetooth callbacks and the native
+    /// XCTest seam. Keeping the state transition here lets tests exercise the
+    /// exact callback path without manufacturing a `CBCentralManager` or
+    /// `CBPeripheral`.
+    private func handleDidDisconnectOnBleQueue(peripheral: WritableBlePeripheral, error: Error?) {
         let deviceId = peripheral.identifier.uuidString
         let wasCurrentPeripheral = connectedPeripheral?.identifier == peripheral.identifier
         let intentionalDisconnectGeneration = intentionalDisconnectGenerations.removeValue(forKey: peripheral.identifier)
@@ -2435,6 +2443,14 @@ extension BoardBleManager {
             manager.runOnBleQueueSync { manager.handleDidWriteValueOnBleQueue(error: error) }
         }
 
+        /// Fire the exact `didDisconnectPeripheral` state transition without a
+        /// concrete CoreBluetooth central or peripheral.
+        func fireDidDisconnect(peripheral: WritableBlePeripheral, error: Error?) {
+            manager.runOnBleQueueSync {
+                manager.handleDidDisconnectOnBleQueue(peripheral: peripheral, error: error)
+            }
+        }
+
         /// Exercise the pure service-discovery decision (retry-then-fail
         /// fallback) without a real `CBPeripheral` (#3480).
         func serviceDiscoveryDecision(
@@ -2451,7 +2467,14 @@ extension BoardBleManager {
         /// so tests can assert the decision without hardcoding them.
         var writeServiceUuidsForTesting: [CBUUID] { manager.writeServiceUuids() }
 
+        /// Exercise the production service→write-characteristic mapping used by
+        /// `didDiscoverCharacteristicsFor`.
+        func writeCharacteristicUuidForTesting(serviceUuid: CBUUID) -> CBUUID {
+            manager.writeCharacteristicUuid(for: serviceUuid)
+        }
+
         var hasPendingWriteResume: Bool { manager.pendingWriteResume != nil }
+        var hasPendingWriteAck: Bool { manager.pendingWriteAck != nil }
         var capturedPendingWriteResume: (() -> Void)? { manager.pendingWriteResume }
         var isWriting: Bool { manager.isWriting }
         var writeQueueDepth: Int { manager.writeQueue.count }
@@ -2463,6 +2486,14 @@ extension BoardBleManager {
         var forceWriteWithResponse: Bool { manager.forceWriteWithResponse }
         var forceWriteWithResponseSource: BoardBleWriteTypeSource? { manager.forceWriteWithResponseSource }
         var writeWithResponsePeripheralIds: Set<UUID> { manager.writeWithResponsePeripheralIds }
+
+        func intentionalDisconnectGeneration(for peripheralId: UUID) -> UInt64? {
+            manager.intentionalDisconnectGenerations[peripheralId]
+        }
+
+        func peripheralGeneration(for peripheralId: UUID) -> UInt64? {
+            manager.peripheralGenerations[peripheralId]
+        }
 
         func setLearnedWriteWithResponseEntry(
             identity: String,

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -386,6 +386,11 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private lazy var timerScheduler: BleTimerScheduling = DispatchBleTimerScheduler(queue: bleQueue)
 
     #if DEBUG || BOARDSESH_TESTS
+    /// Test-only interception of the CoreBluetooth scan teardown. The production
+    /// path still clears `scanRequested` before reaching this seam; tests use it
+    /// only to avoid touching the lazy `CBCentralManager` in an XCTest host that
+    /// has no bluetooth-central background mode.
+    private var stopScanOverrideForTesting: (() -> Void)?
     /// Test-only interception of the single concrete `cancelPeripheralConnection`
     /// call site so a fake peripheral never has to be a real `CBPeripheral` and no
     /// `CBCentralManager` is instantiated. nil in production/dev; set only through
@@ -672,6 +677,12 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
     private func stopScanOnBleQueue() {
         scanRequested = false
+        #if DEBUG || BOARDSESH_TESTS
+        if let overrideForTesting = stopScanOverrideForTesting {
+            overrideForTesting()
+            return
+        }
+        #endif
         if centralManager.isScanning {
             centralManager.stopScan()
         }
@@ -2431,6 +2442,13 @@ extension BoardBleManager {
         /// fake peripheral never has to be a real `CBPeripheral`.
         func setCancelPeripheralConnectionOverride(_ handler: ((WritableBlePeripheral) -> Void)?) {
             manager.cancelPeripheralConnectionOverrideForTesting = handler
+        }
+
+        /// Intercept the concrete CoreBluetooth scan teardown while preserving
+        /// the production `scanRequested = false` transition in
+        /// `stopScanOnBleQueue`.
+        func setStopScanOverride(_ handler: (() -> Void)?) {
+            manager.stopScanOverrideForTesting = handler
         }
 
         /// Fire the `peripheralIsReady(toSendWriteWithoutResponse:)` delegate body.

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -2513,6 +2513,12 @@ extension BoardBleManager {
             manager.peripheralGenerations[peripheralId]
         }
 
+        /// Seed a generation entry directly, so a test can prove a disconnect
+        /// path removes (or preserves) it without driving the full connect flow.
+        func setPeripheralGeneration(_ generation: UInt64, for peripheralId: UUID) {
+            manager.peripheralGenerations[peripheralId] = generation
+        }
+
         func setLearnedWriteWithResponseEntry(
             identity: String,
             learnedAt: TimeInterval

--- a/scripts/__tests__/prepare-rn-ios-tests.test.ts
+++ b/scripts/__tests__/prepare-rn-ios-tests.test.ts
@@ -1,0 +1,29 @@
+/// <reference types="node" />
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const IOS_TESTS_DIR = resolve(REPO_ROOT, 'packages/mobile/ios-tests');
+const PREPARE_SCRIPT = resolve(REPO_ROOT, 'scripts/prepare-rn-ios-tests.mjs');
+
+describe('prepare-rn-ios-tests test target sources', () => {
+  it('stages every tracked top-level Swift test source', () => {
+    const prepareScript = readFileSync(PREPARE_SCRIPT, 'utf8');
+    const trackedTestSources = readdirSync(IOS_TESTS_DIR)
+      .filter((fileName) => fileName.endsWith('.swift'))
+      .sort();
+
+    for (const testSource of trackedTestSources) {
+      expect(prepareScript, `${testSource} is missing from TEST_SOURCE_FILES`).toContain(
+        `sourcePath: '../ios-tests/${testSource}'`,
+      );
+      expect(prepareScript, `${testSource} has no BoardseshTests project path`).toContain(
+        `projectPath: 'BoardseshTests/${testSource}'`,
+      );
+    }
+  });
+});

--- a/scripts/prepare-rn-ios-tests.mjs
+++ b/scripts/prepare-rn-ios-tests.mjs
@@ -21,6 +21,10 @@ const TEST_SOURCE_FILES = [
     projectPath: 'BoardseshTests/BoardBleWriteFlowTests.swift',
   },
   {
+    sourcePath: '../ios-tests/BoardBleDisconnectTests.swift',
+    projectPath: 'BoardseshTests/BoardBleDisconnectTests.swift',
+  },
+  {
     sourcePath: '../ios-tests/BoardBleServiceDiscoveryTests.swift',
     projectPath: 'BoardseshTests/BoardBleServiceDiscoveryTests.swift',
   },


### PR DESCRIPTION
## Summary

- route the real CoreBluetooth disconnect callback body through a queue-bound seam and cover intentional, stale-other-peripheral, clean-current, and NSError-current callbacks without inventing generation information
- prove MoonBoard ACK timeouts enter bounded write-stall recovery, and pin the original RedBearLab `713D0000` service to an actual `.withResponse` write on `713D0003`
- stage every tracked iOS XCTest source and add a drift check so future native test files cannot silently disappear from the generated Xcode target

Closes #3925

The separately discovered immediate same-UUID reconnect race is tracked in #4139; this coverage PR does not falsely claim to solve it.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project scripts scripts/__tests__/prepare-rn-ios-tests.test.ts --reporter=agent` (1 passed)
- `vp run typecheck:mobile`
- `vp run test:mobile` (575 files, 4,912 tests passed)
- `vp run check:mobile-bundle` (iOS and Android passed)
- scoped `vp check` on changed JavaScript/TypeScript files
- `vp run check:mobile-board-art-network`
- `git diff --check`
- independent adversarial BLE review passed with no correctness, fidelity, deadlock, or isolation findings
- started `vp run dev:mobile`; Metro loaded `.boardsesh/qa-notes.md` at the printed URL
- macOS `BoardseshTests` XCTest execution remains required in CI; physical original RedBearLab hardware remains follow-up evidence

Fable is unavailable in this environment, so an independent high-scrutiny Sol review was used as the available substitute; this does not claim literal Fable-policy compliance.