### PR TITLE
fix(mobile): recover evicted climb overlays

### DIFF
--- a/docs/react-native-performance.md
+++ b/docs/react-native-performance.md
@@ -226,12 +226,22 @@ remote URL.
 **Why:** The removed SVG background renderer parsed the frames string, built an SVG hold overlay,
 and painted N `<Circle>`s in `react-native-svg` on every render, on top of a remote image fetch for
 board art that should be on disk. The native path renders the holds once into a cached PNG (deduped
-by cache key, warmed from disk on launch — see the `renderedOverlays` map and
+by cache key, warmed from disk on launch — see the generation-tracked, 200-entry JS LRU and
 `warmupRenderedOverlaysOnce` in `use-native-climb-render.ts`) and stacks
 it over bundled background images via `expo-image` with `cachePolicy="memory-disk"`, so a scrolled-
 past climb is an instant cache hit with zero network and zero per-row SVG work. It also satisfies
 the no-network offline rule — missing layers render as visible gray blocks rather than silently
 fetching.
+
+The JS LRU is only a fast-path hint; native cache pruning or the OS can remove a PNG after warm-up.
+If expo-image reports an overlay load failure, the hook validates that exact managed file URI. A
+missing file invalidates only the matching `{ uri, generation }`, then all mounted consumers share
+one bounded native regeneration. The replacement receives a new generation even though native
+writes it to the same URI, and `LayeredClimbImage` uses that generation in the React `key` so
+Android performs a real reload. Existing-file decode failures are terminal rather than retrying;
+each consumer gets one missing-file retry, replenished only after the exact replacement's `onLoad`.
+The Android session notification has no expo-image callback, so it opts into synchronous file
+preflight, withholds a missing path, and keys native notification refreshes on the same generation.
 
 **Cache key shape (`buildCacheKey` in `use-native-climb-render.ts`):**
 `v<RENDERER_VERSION>_<style>_w<width>_<board>_<layout>_<size>_<setIds>_<framesHash>`. Each token is

--- a/docs/react-native-performance.md
+++ b/docs/react-native-performance.md
@@ -238,8 +238,10 @@ If expo-image reports an overlay load failure, the hook validates that exact man
 missing file invalidates only the matching `{ uri, generation }`, then all mounted consumers share
 one bounded native regeneration. The replacement receives a new generation even though native
 writes it to the same URI, and `LayeredClimbImage` uses that generation in the React `key` so
-Android performs a real reload. Existing-file decode failures are terminal rather than retrying;
-each consumer gets one missing-file retry, replenished only after the exact replacement's `onLoad`.
+Android performs a real reload. An existing-file decode failure gets one bounded same-URI remount
+and is terminal on the second failure; each consumer holds a single retry budget shared across both
+failure classes (a present-file remount consumes the same budget as a missing-file regeneration),
+replenished only after the exact replacement's `onLoad`.
 The Android session notification has no expo-image callback, so it opts into synchronous file
 preflight, withholds a missing path, and keys native notification refreshes on the same generation.
 

--- a/packages/mobile/src/components/BoardImageNative.tsx
+++ b/packages/mobile/src/components/BoardImageNative.tsx
@@ -88,16 +88,17 @@ const BoardImageNative = React.memo(function BoardImageNative({
   suppressOverlayTransition,
   overlayTestID,
 }: BoardImageNativeProps) {
-  const { overlayUri, backgroundPaths, missingBackgroundCount } = useNativeClimbRender({
-    frames,
-    boardName,
-    layoutId,
-    sizeId,
-    setIds,
-    filledStyle,
-    renderWidth,
-    backgroundVariant,
-  });
+  const { overlayUri, overlayLoadKey, onOverlayLoad, onOverlayError, backgroundPaths, missingBackgroundCount } =
+    useNativeClimbRender({
+      frames,
+      boardName,
+      layoutId,
+      sizeId,
+      setIds,
+      filledStyle,
+      renderWidth,
+      backgroundVariant,
+    });
 
   const containerStyle: ViewStyle = {
     width: '100%',
@@ -109,6 +110,9 @@ const BoardImageNative = React.memo(function BoardImageNative({
     <View style={containerStyle}>
       <LayeredClimbImage
         overlayUri={overlayUri}
+        overlayLoadKey={overlayLoadKey}
+        onOverlayLoad={onOverlayLoad}
+        onOverlayError={onOverlayError}
         backgroundPaths={backgroundPaths}
         missingBackgroundCount={missingBackgroundCount}
         mirrored={mirrored}

--- a/packages/mobile/src/components/ClimbListThumbnail.tsx
+++ b/packages/mobile/src/components/ClimbListThumbnail.tsx
@@ -51,24 +51,28 @@ const ClimbListThumbnail = React.memo(function ClimbListThumbnail({
 }: ClimbListThumbnailProps) {
   const cellWidth = size?.width ?? THUMBNAIL_WIDTH;
   const cellHeight = size?.height ?? THUMBNAIL_HEIGHT;
-  const { overlayUri, backgroundPaths, missingBackgroundCount } = useNativeClimbRender({
-    frames,
-    boardName,
-    layoutId,
-    sizeId,
-    setIds,
-    filledStyle: true,
-    // Render the overlay + resolve the background at ~5× the cell width (≥400px,
-    // covering the default 76px cell at up to ~3× DPR and a ~100px hero cell at
-    // ~4×) so expo-image never has to downscale a ~1080px source on the main
-    // thread while scrolling.
-    renderWidth: Math.max(400, Math.round(cellWidth * 5)),
-  });
+  const { overlayUri, overlayLoadKey, onOverlayLoad, onOverlayError, backgroundPaths, missingBackgroundCount } =
+    useNativeClimbRender({
+      frames,
+      boardName,
+      layoutId,
+      sizeId,
+      setIds,
+      filledStyle: true,
+      // Render the overlay + resolve the background at ~5× the cell width (≥400px,
+      // covering the default 76px cell at up to ~3× DPR and a ~100px hero cell at
+      // ~4×) so expo-image never has to downscale a ~1080px source on the main
+      // thread while scrolling.
+      renderWidth: Math.max(400, Math.round(cellWidth * 5)),
+    });
 
   return (
     <View style={[styles.container, size ? { width: cellWidth, height: cellHeight } : null]}>
       <LayeredClimbImage
         overlayUri={overlayUri}
+        overlayLoadKey={overlayLoadKey}
+        onOverlayLoad={onOverlayLoad}
+        onOverlayError={onOverlayError}
         backgroundPaths={backgroundPaths}
         missingBackgroundCount={missingBackgroundCount}
         mirrored={mirrored}

--- a/packages/mobile/src/components/LayeredClimbImage.tsx
+++ b/packages/mobile/src/components/LayeredClimbImage.tsx
@@ -1,11 +1,20 @@
 import React, { useEffect, useState } from 'react';
 import { Platform, View, StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
+import type { ImageErrorEventData } from 'expo-image';
 import { useIsAppBackgrounded } from '../lib/app-visibility';
 import { useBoardArtVisible } from './board-art-visibility-context';
 
 type LayeredClimbImageProps = {
   overlayUri: string | null;
+  /**
+   * Generation + per-consumer attempt identity. React's key must change when a
+   * missing overlay is regenerated at the same URI: Android expo-image does not
+   * reliably reload that case from recyclingKey alone.
+   */
+  overlayLoadKey?: string | null;
+  onOverlayLoad?: () => void;
+  onOverlayError?: (event: ImageErrorEventData) => void;
   backgroundPaths: string[];
   /**
    * Number of background layers the cache couldn't resolve. Each missing
@@ -59,6 +68,9 @@ export function backgroundImageUri(path: string): string {
  */
 const LayeredClimbImage = React.memo(function LayeredClimbImage({
   overlayUri,
+  overlayLoadKey,
+  onOverlayLoad,
+  onOverlayError,
   backgroundPaths,
   missingBackgroundCount = 0,
   mirrored,
@@ -93,6 +105,9 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
   useEffect(() => {
     if (hidden) setOverlayPainted(false);
   }, [hidden]);
+  useEffect(() => {
+    setOverlayPainted(false);
+  }, [overlayUri, overlayLoadKey]);
   if (hidden) {
     return <View style={[styles.stack, mirrored && styles.mirrored]} />;
   }
@@ -134,6 +149,7 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
       {dimBackground && <View style={[styles.layer, styles.dim]} pointerEvents="none" />}
       {overlayUri && (
         <Image
+          key={overlayLoadKey ?? overlayUri}
           source={{ uri: overlayUri }}
           style={styles.layer}
           contentFit="contain"
@@ -144,7 +160,11 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
           // list/accessory, native for play) so no main-thread downscale
           // is needed — skip expo-image's resample.
           allowDownscaling={false}
-          onLoad={overlayTestID ? () => setOverlayPainted(true) : undefined}
+          onLoad={() => {
+            if (overlayTestID) setOverlayPainted(true);
+            onOverlayLoad?.();
+          }}
+          onError={onOverlayError}
         />
       )}
       {/* Screenshot/e2e anchor — see overlayPainted above. Transparent, full-bleed

--- a/packages/mobile/src/components/LayeredClimbImage.tsx
+++ b/packages/mobile/src/components/LayeredClimbImage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Platform, View, StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
 import type { ImageErrorEventData } from 'expo-image';
@@ -13,8 +13,8 @@ type LayeredClimbImageProps = {
    * reliably reload that case from recyclingKey alone.
    */
   overlayLoadKey?: string | null;
-  onOverlayLoad?: () => void;
-  onOverlayError?: (event: ImageErrorEventData) => void;
+  onOverlayLoad?: (loadKey: string | null) => void;
+  onOverlayError?: (event: ImageErrorEventData, loadKey: string | null) => void;
   backgroundPaths: string[];
   /**
    * Number of background layers the cache couldn't resolve. Each missing
@@ -88,6 +88,13 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
   // blank drawer. Gating on onLoad makes the anchor mean "the lit board is on
   // screen".
   const [overlayPainted, setOverlayPainted] = useState(false);
+  // Native image events can already be queued when React replaces an overlay.
+  // Keep the currently rendered attempt in a ref so an old image cannot expose
+  // the screenshot anchor after the replacement reset it. The recovery owner
+  // still receives the captured key below and independently rejects stale cache
+  // events; this guard owns the component-local painted marker.
+  const latestOverlayAttemptRef = useRef({ uri: overlayUri, loadKey: overlayLoadKey ?? null });
+  latestOverlayAttemptRef.current = { uri: overlayUri, loadKey: overlayLoadKey ?? null };
 
   // Drop the decoded board-art bitmaps whenever this surface is hidden: render an
   // empty stack so expo-image releases their GPU textures + native-heap bitmaps
@@ -161,10 +168,14 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
           // is needed — skip expo-image's resample.
           allowDownscaling={false}
           onLoad={() => {
-            if (overlayTestID) setOverlayPainted(true);
-            onOverlayLoad?.();
+            const emittingLoadKey = overlayLoadKey ?? null;
+            const latestAttempt = latestOverlayAttemptRef.current;
+            if (overlayTestID && latestAttempt.uri === overlayUri && latestAttempt.loadKey === emittingLoadKey) {
+              setOverlayPainted(true);
+            }
+            onOverlayLoad?.(emittingLoadKey);
           }}
-          onError={onOverlayError}
+          onError={(event) => onOverlayError?.(event, overlayLoadKey ?? null)}
         />
       )}
       {/* Screenshot/e2e anchor — see overlayPainted above. Transparent, full-bleed

--- a/packages/mobile/src/components/__tests__/layered-climb-image.test.tsx
+++ b/packages/mobile/src/components/__tests__/layered-climb-image.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 
 type ViewMockProps = { children?: ReactNode; testID?: string };
@@ -22,17 +22,23 @@ vi.mock('expo-image', () => ({
     testID,
     transition,
     recyclingKey,
+    onLoad,
+    onError,
   }: {
     source: { uri: string };
     testID?: string;
     transition?: number;
     recyclingKey?: string;
+    onLoad?: () => void;
+    onError?: (event: { error: string }) => void;
   }) =>
     createElement('img', {
       src: source.uri,
       'data-testid': testID ?? 'expo-image',
       'data-transition': transition,
       'data-recycling-key': recyclingKey,
+      onLoad,
+      onError: () => onError?.({ error: 'mock image failure' }),
     }),
 }));
 
@@ -119,5 +125,48 @@ describe('LayeredClimbImage', () => {
 
     const overlay = container.querySelector('img[src="file:///overlay.png"]');
     expect(overlay?.getAttribute('data-recycling-key')).toBe('climb-frames-abc');
+  });
+
+  it('forces a React remount when a regenerated overlay keeps the same URI', () => {
+    const { container, rerender } = render(
+      createElement(LayeredClimbImage, {
+        overlayUri: 'file:///overlay.png',
+        overlayLoadKey: '1:0',
+        backgroundPaths: [],
+      }),
+    );
+    const failedImage = container.querySelector('img[src="file:///overlay.png"]');
+
+    rerender(
+      createElement(LayeredClimbImage, {
+        overlayUri: 'file:///overlay.png',
+        overlayLoadKey: '2:1',
+        backgroundPaths: [],
+      }),
+    );
+
+    expect(container.querySelector('img[src="file:///overlay.png"]')).not.toBe(failedImage);
+  });
+
+  it('forwards exact load and error notifications to the cache recovery owner', () => {
+    const onOverlayLoad = vi.fn();
+    const onOverlayError = vi.fn();
+    const { container } = render(
+      createElement(LayeredClimbImage, {
+        overlayUri: 'file:///overlay.png',
+        overlayLoadKey: '1:0',
+        backgroundPaths: [],
+        onOverlayLoad,
+        onOverlayError,
+      }),
+    );
+    const overlay = container.querySelector('img[src="file:///overlay.png"]');
+    if (!overlay) throw new Error('Expected overlay image');
+
+    fireEvent.load(overlay);
+    fireEvent.error(overlay);
+
+    expect(onOverlayLoad).toHaveBeenCalledTimes(1);
+    expect(onOverlayError).toHaveBeenCalledWith({ error: 'mock image failure' });
   });
 });

--- a/packages/mobile/src/components/__tests__/layered-climb-image.test.tsx
+++ b/packages/mobile/src/components/__tests__/layered-climb-image.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, fireEvent, render } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 
@@ -52,6 +52,13 @@ vi.mock('../../lib/app-visibility', () => ({ useIsAppBackgrounded: () => false }
 import { LayeredClimbImage } from '../LayeredClimbImage';
 
 describe('LayeredClimbImage', () => {
+  beforeEach(() => {
+    // The expo-image mock records every mounted overlay's onLoad; tests that
+    // replay queued native events index into this list, so it must start empty
+    // regardless of which tests rendered an Image before them.
+    imageEvents.loadCallbacks.length = 0;
+  });
+
   it('renders a visible backing layer when no image layer is available yet', () => {
     const { container } = render(createElement(LayeredClimbImage, { overlayUri: null, backgroundPaths: [] }));
 
@@ -174,7 +181,6 @@ describe('LayeredClimbImage', () => {
   });
 
   it('does not expose the painted anchor for a queued load from a replaced overlay generation', () => {
-    imageEvents.loadCallbacks.length = 0;
     const onOverlayLoad = vi.fn();
     const { container, rerender } = render(
       createElement(LayeredClimbImage, {

--- a/packages/mobile/src/components/__tests__/layered-climb-image.test.tsx
+++ b/packages/mobile/src/components/__tests__/layered-climb-image.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from 'vitest';
-import { fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 
 type ViewMockProps = { children?: ReactNode; testID?: string };
 const platform = vi.hoisted(() => ({ os: 'ios' as 'ios' | 'web' }));
+const imageEvents = vi.hoisted(() => ({ loadCallbacks: [] as Array<() => void> }));
 
 vi.mock('react-native', () => ({
   Platform: {
@@ -31,15 +32,17 @@ vi.mock('expo-image', () => ({
     recyclingKey?: string;
     onLoad?: () => void;
     onError?: (event: { error: string }) => void;
-  }) =>
-    createElement('img', {
+  }) => {
+    if (onLoad) imageEvents.loadCallbacks.push(onLoad);
+    return createElement('img', {
       src: source.uri,
       'data-testid': testID ?? 'expo-image',
       'data-transition': transition,
       'data-recycling-key': recyclingKey,
       onLoad,
       onError: () => onError?.({ error: 'mock image failure' }),
-    }),
+    });
+  },
 }));
 
 // These tests exercise the foregrounded render path; the backgrounded blank is
@@ -166,7 +169,45 @@ describe('LayeredClimbImage', () => {
     fireEvent.load(overlay);
     fireEvent.error(overlay);
 
-    expect(onOverlayLoad).toHaveBeenCalledTimes(1);
-    expect(onOverlayError).toHaveBeenCalledWith({ error: 'mock image failure' });
+    expect(onOverlayLoad).toHaveBeenCalledExactlyOnceWith('1:0');
+    expect(onOverlayError).toHaveBeenCalledWith({ error: 'mock image failure' }, '1:0');
+  });
+
+  it('does not expose the painted anchor for a queued load from a replaced overlay generation', () => {
+    imageEvents.loadCallbacks.length = 0;
+    const onOverlayLoad = vi.fn();
+    const { container, rerender } = render(
+      createElement(LayeredClimbImage, {
+        overlayUri: 'file:///overlay.png',
+        overlayLoadKey: '1:0',
+        backgroundPaths: [],
+        overlayTestID: 'play-drawer-board-overlay',
+        onOverlayLoad,
+      }),
+    );
+    const staleOverlay = container.querySelector('img[src="file:///overlay.png"]');
+    if (!staleOverlay) throw new Error('Expected first-generation overlay image');
+
+    rerender(
+      createElement(LayeredClimbImage, {
+        overlayUri: 'file:///overlay.png',
+        overlayLoadKey: '2:0',
+        backgroundPaths: [],
+        overlayTestID: 'play-drawer-board-overlay',
+        onOverlayLoad,
+      }),
+    );
+    const currentOverlay = container.querySelector('img[src="file:///overlay.png"]');
+    if (!currentOverlay) throw new Error('Expected replacement overlay image');
+
+    act(() => imageEvents.loadCallbacks[0]?.());
+
+    expect(container.querySelector('[data-testid="play-drawer-board-overlay"]')).toBeNull();
+    expect(onOverlayLoad).toHaveBeenCalledExactlyOnceWith('1:0');
+
+    act(() => imageEvents.loadCallbacks[1]?.());
+
+    expect(container.querySelector('[data-testid="play-drawer-board-overlay"]')).toBeTruthy();
+    expect(onOverlayLoad).toHaveBeenLastCalledWith('2:0');
   });
 });

--- a/packages/mobile/src/hooks/__tests__/overlay-cache-warmup.web.test.ts
+++ b/packages/mobile/src/hooks/__tests__/overlay-cache-warmup.web.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { listOverlayCacheEntries } from '../overlay-cache-warmup.web';
+import { listOverlayCacheEntries, overlayCacheEntryExists } from '../overlay-cache-warmup.web';
 import {
   hydrateOverlayCache,
   writeOverlayToCache,
@@ -56,6 +56,10 @@ afterEach(() => {
 });
 
 describe('listOverlayCacheEntries (web warmup)', () => {
+  it('marks synchronous URI validation as unsupported instead of guessing', () => {
+    expect(overlayCacheEntryExists('blob:warm/1')).toBeNull();
+  });
+
   it('returns null before anything has hydrated', () => {
     installCaches();
     expect(listOverlayCacheEntries('board-thumbnails')).toBeNull();

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
@@ -199,7 +199,7 @@ describe('useNativeClimbRender in-flight race', () => {
     expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1);
   });
 
-  it('revalidates an unchanged notification overlay after its verified file is evicted', async () => {
+  it('revalidates an unchanged notification overlay at native use after its verified file is evicted', async () => {
     const cacheKey = cacheKeyFor(FRAMES_CACHED);
     const overlayUri = 'file:///notification-evicted-later.png';
     existingOverlayUris.add(overlayUri);
@@ -209,6 +209,17 @@ describe('useNativeClimbRender in-flight race', () => {
 
     existingOverlayUris.delete(overlayUri);
     view.rerender();
+    expect(view.result.current.overlayUri).toBe(overlayUri);
+    expect(fakeNativeModule.renderHoldsOverlay).not.toHaveBeenCalled();
+
+    act(() => {
+      expect(
+        view.result.current.verifyOverlayForNativeUse(
+          view.result.current.overlayUri,
+          view.result.current.overlayLoadKey,
+        ),
+      ).toBeNull();
+    });
 
     await waitFor(() => expect(view.result.current.overlayUri).toBeNull());
     await waitFor(() => expect(pendingRenders.has(cacheKey)).toBe(true));
@@ -223,7 +234,14 @@ describe('useNativeClimbRender in-flight race', () => {
     await waitFor(() => expect(view.result.current.overlayUri).toBe(overlayUri));
 
     existingOverlayUris.delete(overlayUri);
-    view.rerender();
+    act(() => {
+      expect(
+        view.result.current.verifyOverlayForNativeUse(
+          view.result.current.overlayUri,
+          view.result.current.overlayLoadKey,
+        ),
+      ).toBeNull();
+    });
     await waitFor(() => expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1));
     existingOverlayUris.add(overlayUri);
     await act(async () => {
@@ -233,7 +251,14 @@ describe('useNativeClimbRender in-flight race', () => {
     await waitFor(() => expect(view.result.current.overlayUri).toBe(overlayUri));
 
     existingOverlayUris.delete(overlayUri);
-    view.rerender();
+    act(() => {
+      expect(
+        view.result.current.verifyOverlayForNativeUse(
+          view.result.current.overlayUri,
+          view.result.current.overlayLoadKey,
+        ),
+      ).toBeNull();
+    });
     await waitFor(() => expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(2));
     existingOverlayUris.add(overlayUri);
     await act(async () => {

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
@@ -214,6 +214,35 @@ describe('useNativeClimbRender in-flight race', () => {
     await waitFor(() => expect(pendingRenders.has(cacheKey)).toBe(true));
   });
 
+  it('repairs two same-key native-use evictions after each exact replacement verifies', async () => {
+    const cacheKey = cacheKeyFor(FRAMES_CACHED);
+    const overlayUri = 'file:///notification-evicted-twice.png';
+    existingOverlayUris.add(overlayUri);
+    _cacheRenderedOverlayForTests(cacheKey, overlayUri);
+    const view = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED, verifyOverlayFile: true }));
+    await waitFor(() => expect(view.result.current.overlayUri).toBe(overlayUri));
+
+    existingOverlayUris.delete(overlayUri);
+    view.rerender();
+    await waitFor(() => expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1));
+    existingOverlayUris.add(overlayUri);
+    await act(async () => {
+      resolveNextRender(cacheKey, overlayUri);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(view.result.current.overlayUri).toBe(overlayUri));
+
+    existingOverlayUris.delete(overlayUri);
+    view.rerender();
+    await waitFor(() => expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(2));
+    existingOverlayUris.add(overlayUri);
+    await act(async () => {
+      resolveNextRender(cacheKey, overlayUri);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(view.result.current.overlayUri).toBe(overlayUri));
+  });
+
   it('deduplicates simultaneous repairs across mounted consumers', async () => {
     const cacheKey = cacheKeyFor(FRAMES_CACHED);
     const overlayUri = 'file:///shared.png';
@@ -337,6 +366,7 @@ describe('useNativeClimbRender in-flight race', () => {
     const { result } = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
     const initialOnLoad = result.current.onOverlayLoad;
     const initialOnError = result.current.onOverlayError;
+    const initialVerifyForNativeUse = result.current.verifyOverlayForNativeUse;
     const initialLoadKey = result.current.overlayLoadKey;
 
     act(() => result.current.onOverlayError({ error: 'Failed to load resource' }, initialLoadKey));
@@ -349,27 +379,27 @@ describe('useNativeClimbRender in-flight race', () => {
 
     expect(result.current.onOverlayLoad).toBe(initialOnLoad);
     expect(result.current.onOverlayError).toBe(initialOnError);
+    expect(result.current.verifyOverlayForNativeUse).toBe(initialVerifyForNativeUse);
   });
 
-  it('ignores a queued error from the prior generation of the same Image consumer', async () => {
+  it('remounts a present-file decode failure with the same URI and ignores its stale old attempt', () => {
     const cacheKey = cacheKeyFor(FRAMES_CACHED);
     const overlayUri = 'file:///stale-same-consumer.png';
+    existingOverlayUris.add(overlayUri);
     _cacheRenderedOverlayForTests(cacheKey, overlayUri);
     const { result } = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
     const stableOnError = result.current.onOverlayError;
     const staleLoadKey = result.current.overlayLoadKey;
 
-    act(() => stableOnError({ error: 'Generation one failed' }, staleLoadKey));
-    await waitFor(() => expect(pendingRenders.has(cacheKey)).toBe(true));
-    await act(async () => {
-      resolveNextRender(cacheKey, overlayUri);
-      await Promise.resolve();
-    });
-    await waitFor(() => expect(result.current.overlayLoadKey).not.toBe(staleLoadKey));
+    act(() => stableOnError({ error: 'Transient decode failure' }, staleLoadKey));
     const replacementLoadKey = result.current.overlayLoadKey;
-    existingOverlayUris.add(overlayUri);
 
-    act(() => stableOnError({ error: 'Queued generation-one failure' }, staleLoadKey));
+    expect(result.current.overlayUri).toBe(overlayUri);
+    expect(replacementLoadKey).not.toBe(staleLoadKey);
+    expect(_renderedOverlaysForTests.get(cacheKey)?.uri).toBe(overlayUri);
+    expect(fakeNativeModule.renderHoldsOverlay).not.toHaveBeenCalled();
+
+    act(() => stableOnError({ error: 'Queued old-attempt failure' }, staleLoadKey));
 
     expect(result.current.overlayUri).toBe(overlayUri);
     expect(result.current.overlayLoadKey).toBe(replacementLoadKey);
@@ -396,46 +426,53 @@ describe('useNativeClimbRender in-flight race', () => {
     expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1);
   });
 
-  it('replenishes the retry budget after the exact replacement loads', async () => {
+  it('replenishes the retry budget when native-use validation acknowledges the exact remount', async () => {
     const cacheKey = cacheKeyFor(FRAMES_CACHED);
     const overlayUri = 'file:///retry-reset.png';
+    existingOverlayUris.add(overlayUri);
     _cacheRenderedOverlayForTests(cacheKey, overlayUri);
-    const { result } = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
+    const { result } = renderHook(() =>
+      useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED, verifyOverlayFile: true }),
+    );
     const firstLoadKey = result.current.overlayLoadKey;
 
     act(() => result.current.onOverlayError({ error: 'Failed to load resource' }, firstLoadKey));
-    await waitFor(() => expect(pendingRenders.has(cacheKey)).toBe(true));
-    await act(async () => {
-      resolveNextRender(cacheKey, overlayUri);
-      await Promise.resolve();
-    });
-    await waitFor(() => expect(result.current.overlayUri).toBe(overlayUri));
-    act(() => result.current.onOverlayLoad(result.current.overlayLoadKey));
-    act(() => result.current.onOverlayError({ error: 'Failed to load resource' }, result.current.overlayLoadKey));
+    await waitFor(() => expect(result.current.overlayLoadKey).not.toBe(firstLoadKey));
+    const verifiedRetryLoadKey = result.current.overlayLoadKey;
+    act(() => result.current.onOverlayError({ error: 'Failed to load resource' }, verifiedRetryLoadKey));
 
-    await waitFor(() => expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(result.current.overlayLoadKey).not.toBe(verifiedRetryLoadKey));
+    expect(result.current.overlayUri).toBe(overlayUri);
+    expect(fakeNativeModule.renderHoldsOverlay).not.toHaveBeenCalled();
   });
 
-  it('treats an existing-file decode failure as terminal and reports it once without identifiers', () => {
+  it('stops a persistent existing-file decode failure after one remount and reports both classes without identifiers', () => {
     const cacheKey = cacheKeyFor(FRAMES_CACHED);
     const overlayUri = 'file:///private/cache/path.png';
     existingOverlayUris.add(overlayUri);
     _cacheRenderedOverlayForTests(cacheKey, overlayUri);
-    const first = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
-    const second = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
-    const firstLoadKey = first.result.current.overlayLoadKey;
-    const secondLoadKey = second.result.current.overlayLoadKey;
+    const { result } = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
+    const firstLoadKey = result.current.overlayLoadKey;
 
-    act(() => {
-      first.result.current.onOverlayError({ error: `decode failed at ${overlayUri}` }, firstLoadKey);
-      second.result.current.onOverlayError({ error: `decode failed at ${overlayUri}` }, secondLoadKey);
-    });
+    act(() => result.current.onOverlayError({ error: `decode failed at ${overlayUri}` }, firstLoadKey));
+    expect(result.current.overlayUri).toBe(overlayUri);
+    expect(result.current.overlayLoadKey).not.toBe(firstLoadKey);
 
-    expect(first.result.current.overlayUri).toBeNull();
-    expect(second.result.current.overlayUri).toBeNull();
+    act(() =>
+      result.current.onOverlayError(
+        { error: `persistent decode failed at ${overlayUri}` },
+        result.current.overlayLoadKey,
+      ),
+    );
+
+    expect(result.current.overlayUri).toBeNull();
     expect(fakeNativeModule.renderHoldsOverlay).not.toHaveBeenCalled();
-    expect(reportErrorMock).toHaveBeenCalledTimes(1);
-    expect(JSON.stringify(reportErrorMock.mock.calls[0])).not.toContain(overlayUri);
-    expect(JSON.stringify(reportErrorMock.mock.calls[0])).not.toContain(cacheKey);
+    expect(reportErrorMock).toHaveBeenCalledTimes(2);
+    expect(reportErrorMock.mock.calls.map(([error]) => (error as Error).message)).toEqual([
+      'Generated overlay image load failed: cache_entry_present',
+      'Generated overlay image load failed: retry_exhausted',
+    ]);
+    expect(JSON.stringify(reportErrorMock.mock.calls)).not.toContain(overlayUri);
+    expect(JSON.stringify(reportErrorMock.mock.calls)).not.toContain(cacheKey);
   });
 });

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
@@ -164,7 +164,7 @@ describe('useNativeClimbRender in-flight race', () => {
     const { result } = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
     const failedLoadKey = result.current.overlayLoadKey;
 
-    act(() => result.current.onOverlayError({ error: 'Failed to load resource' }));
+    act(() => result.current.onOverlayError({ error: 'Failed to load resource' }, failedLoadKey));
     await waitFor(() => expect(pendingRenders.has(cacheKey)).toBe(true));
     expect(result.current.overlayUri).toBeNull();
     expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1);
@@ -199,16 +199,33 @@ describe('useNativeClimbRender in-flight race', () => {
     expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1);
   });
 
+  it('revalidates an unchanged notification overlay after its verified file is evicted', async () => {
+    const cacheKey = cacheKeyFor(FRAMES_CACHED);
+    const overlayUri = 'file:///notification-evicted-later.png';
+    existingOverlayUris.add(overlayUri);
+    _cacheRenderedOverlayForTests(cacheKey, overlayUri);
+    const view = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED, verifyOverlayFile: true }));
+    await waitFor(() => expect(view.result.current.overlayUri).toBe(overlayUri));
+
+    existingOverlayUris.delete(overlayUri);
+    view.rerender();
+
+    await waitFor(() => expect(view.result.current.overlayUri).toBeNull());
+    await waitFor(() => expect(pendingRenders.has(cacheKey)).toBe(true));
+  });
+
   it('deduplicates simultaneous repairs across mounted consumers', async () => {
     const cacheKey = cacheKeyFor(FRAMES_CACHED);
     const overlayUri = 'file:///shared.png';
     _cacheRenderedOverlayForTests(cacheKey, overlayUri);
     const first = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
     const second = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
+    const firstLoadKey = first.result.current.overlayLoadKey;
+    const secondLoadKey = second.result.current.overlayLoadKey;
 
     act(() => {
-      first.result.current.onOverlayError({ error: 'Failed to load resource' });
-      second.result.current.onOverlayError({ error: 'Failed to load resource' });
+      first.result.current.onOverlayError({ error: 'Failed to load resource' }, firstLoadKey);
+      second.result.current.onOverlayError({ error: 'Failed to load resource' }, secondLoadKey);
     });
     await waitFor(() => expect(pendingRenders.has(cacheKey)).toBe(true));
     expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1);
@@ -221,6 +238,37 @@ describe('useNativeClimbRender in-flight race', () => {
     await waitFor(() => expect(second.result.current.overlayUri).toBe(overlayUri));
   });
 
+  it('lets a delayed second consumer adopt the generation committed by the first repair', async () => {
+    const cacheKey = cacheKeyFor(FRAMES_CACHED);
+    const overlayUri = 'file:///delayed-peer.png';
+    const failedEntry = _cacheRenderedOverlayForTests(cacheKey, overlayUri);
+    const first = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
+    const second = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
+    const delayedSecondError = second.result.current.onOverlayError;
+    const delayedSecondLoadKey = second.result.current.overlayLoadKey;
+
+    act(() =>
+      first.result.current.onOverlayError({ error: 'First consumer failed' }, first.result.current.overlayLoadKey),
+    );
+    await waitFor(() => expect(pendingRenders.has(cacheKey)).toBe(true));
+    await act(async () => {
+      resolveNextRender(cacheKey, overlayUri);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(first.result.current.overlayUri).toBe(overlayUri));
+    const repairedEntry = _renderedOverlaysForTests.get(cacheKey);
+    expect(repairedEntry?.generation).not.toBe(failedEntry.generation);
+    const reportsBeforeDelayedError = reportErrorMock.mock.calls.length;
+
+    act(() => delayedSecondError({ error: 'Delayed second-consumer failure' }, delayedSecondLoadKey));
+
+    expect(_renderedOverlaysForTests.get(cacheKey)).toEqual(repairedEntry);
+    expect(second.result.current.overlayUri).toBe(overlayUri);
+    expect(second.result.current.overlayLoadKey).toBe(`${repairedEntry?.generation}:1`);
+    expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1);
+    expect(reportErrorMock).toHaveBeenCalledTimes(reportsBeforeDelayedError);
+  });
+
   it('preserves a peer repair and remounts only the failed consumer', () => {
     const cacheKey = cacheKeyFor(FRAMES_CACHED);
     const overlayUri = 'file:///same-path.png';
@@ -229,7 +277,7 @@ describe('useNativeClimbRender in-flight race', () => {
     const failedLoadKey = result.current.overlayLoadKey;
     const peerReplacement = _cacheRenderedOverlayForTests(cacheKey, overlayUri);
 
-    act(() => result.current.onOverlayError({ error: 'Failed to load resource' }));
+    act(() => result.current.onOverlayError({ error: 'Failed to load resource' }, failedLoadKey));
 
     expect(_renderedOverlaysForTests.get(cacheKey)).toEqual(peerReplacement);
     expect(result.current.overlayUri).toBe(overlayUri);
@@ -251,7 +299,7 @@ describe('useNativeClimbRender in-flight race', () => {
     existingOverlayUris.add(overlayUri);
     expect(peerReplacement.generation).not.toBe(failedEntry.generation);
 
-    act(() => failedOnError({ error: 'Delayed generation A failure' }));
+    act(() => failedOnError({ error: 'Delayed generation A failure' }, failedLoadKey));
 
     expect(_renderedOverlaysForTests.get(cacheKey)).toEqual(peerReplacement);
     expect(result.current.overlayUri).toBe(overlayUri);
@@ -271,9 +319,10 @@ describe('useNativeClimbRender in-flight race', () => {
       { initialProps: { frames: FRAMES_SLOW } },
     );
     const staleOnError = result.current.onOverlayError;
+    const staleLoadKey = result.current.overlayLoadKey;
 
     rerender({ frames: FRAMES_CACHED });
-    act(() => staleOnError({ error: 'Failed to load resource' }));
+    act(() => staleOnError({ error: 'Failed to load resource' }, staleLoadKey));
 
     expect(result.current.overlayUri).toBe('file:///current.png');
     expect(_renderedOverlaysForTests.has(oldKey)).toBe(true);
@@ -281,13 +330,16 @@ describe('useNativeClimbRender in-flight race', () => {
     expect(fakeNativeModule.renderHoldsOverlay).not.toHaveBeenCalled();
   });
 
-  it('stops after one retry until the exact replacement reports onLoad', async () => {
+  it('keeps overlay callbacks stable while the current attempt changes', async () => {
     const cacheKey = cacheKeyFor(FRAMES_CACHED);
-    const overlayUri = 'file:///retry-budget.png';
+    const overlayUri = 'file:///stable-callbacks.png';
     _cacheRenderedOverlayForTests(cacheKey, overlayUri);
     const { result } = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
+    const initialOnLoad = result.current.onOverlayLoad;
+    const initialOnError = result.current.onOverlayError;
+    const initialLoadKey = result.current.overlayLoadKey;
 
-    act(() => result.current.onOverlayError({ error: 'Failed to load resource' }));
+    act(() => result.current.onOverlayError({ error: 'Failed to load resource' }, initialLoadKey));
     await waitFor(() => expect(pendingRenders.has(cacheKey)).toBe(true));
     await act(async () => {
       resolveNextRender(cacheKey, overlayUri);
@@ -295,7 +347,51 @@ describe('useNativeClimbRender in-flight race', () => {
     });
     await waitFor(() => expect(result.current.overlayUri).toBe(overlayUri));
 
-    act(() => result.current.onOverlayError({ error: 'Failed to load resource' }));
+    expect(result.current.onOverlayLoad).toBe(initialOnLoad);
+    expect(result.current.onOverlayError).toBe(initialOnError);
+  });
+
+  it('ignores a queued error from the prior generation of the same Image consumer', async () => {
+    const cacheKey = cacheKeyFor(FRAMES_CACHED);
+    const overlayUri = 'file:///stale-same-consumer.png';
+    _cacheRenderedOverlayForTests(cacheKey, overlayUri);
+    const { result } = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
+    const stableOnError = result.current.onOverlayError;
+    const staleLoadKey = result.current.overlayLoadKey;
+
+    act(() => stableOnError({ error: 'Generation one failed' }, staleLoadKey));
+    await waitFor(() => expect(pendingRenders.has(cacheKey)).toBe(true));
+    await act(async () => {
+      resolveNextRender(cacheKey, overlayUri);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.overlayLoadKey).not.toBe(staleLoadKey));
+    const replacementLoadKey = result.current.overlayLoadKey;
+    existingOverlayUris.add(overlayUri);
+
+    act(() => stableOnError({ error: 'Queued generation-one failure' }, staleLoadKey));
+
+    expect(result.current.overlayUri).toBe(overlayUri);
+    expect(result.current.overlayLoadKey).toBe(replacementLoadKey);
+    expect(_renderedOverlaysForTests.has(cacheKey)).toBe(true);
+  });
+
+  it('stops after one retry until the exact replacement reports onLoad', async () => {
+    const cacheKey = cacheKeyFor(FRAMES_CACHED);
+    const overlayUri = 'file:///retry-budget.png';
+    _cacheRenderedOverlayForTests(cacheKey, overlayUri);
+    const { result } = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
+    const firstLoadKey = result.current.overlayLoadKey;
+
+    act(() => result.current.onOverlayError({ error: 'Failed to load resource' }, firstLoadKey));
+    await waitFor(() => expect(pendingRenders.has(cacheKey)).toBe(true));
+    await act(async () => {
+      resolveNextRender(cacheKey, overlayUri);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.overlayUri).toBe(overlayUri));
+
+    act(() => result.current.onOverlayError({ error: 'Failed to load resource' }, result.current.overlayLoadKey));
     expect(result.current.overlayUri).toBeNull();
     expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1);
   });
@@ -305,16 +401,17 @@ describe('useNativeClimbRender in-flight race', () => {
     const overlayUri = 'file:///retry-reset.png';
     _cacheRenderedOverlayForTests(cacheKey, overlayUri);
     const { result } = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
+    const firstLoadKey = result.current.overlayLoadKey;
 
-    act(() => result.current.onOverlayError({ error: 'Failed to load resource' }));
+    act(() => result.current.onOverlayError({ error: 'Failed to load resource' }, firstLoadKey));
     await waitFor(() => expect(pendingRenders.has(cacheKey)).toBe(true));
     await act(async () => {
       resolveNextRender(cacheKey, overlayUri);
       await Promise.resolve();
     });
     await waitFor(() => expect(result.current.overlayUri).toBe(overlayUri));
-    act(() => result.current.onOverlayLoad());
-    act(() => result.current.onOverlayError({ error: 'Failed to load resource' }));
+    act(() => result.current.onOverlayLoad(result.current.overlayLoadKey));
+    act(() => result.current.onOverlayError({ error: 'Failed to load resource' }, result.current.overlayLoadKey));
 
     await waitFor(() => expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(2));
   });
@@ -326,10 +423,12 @@ describe('useNativeClimbRender in-flight race', () => {
     _cacheRenderedOverlayForTests(cacheKey, overlayUri);
     const first = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
     const second = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
+    const firstLoadKey = first.result.current.overlayLoadKey;
+    const secondLoadKey = second.result.current.overlayLoadKey;
 
     act(() => {
-      first.result.current.onOverlayError({ error: `decode failed at ${overlayUri}` });
-      second.result.current.onOverlayError({ error: `decode failed at ${overlayUri}` });
+      first.result.current.onOverlayError({ error: `decode failed at ${overlayUri}` }, firstLoadKey);
+      second.result.current.onOverlayError({ error: `decode failed at ${overlayUri}` }, secondLoadKey);
     });
 
     expect(first.result.current.overlayUri).toBeNull();

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
@@ -15,8 +15,17 @@ vi.mock('../../providers/theme-provider', () => ({
   useAppColorScheme: () => 'light',
 }));
 
+const existingOverlayUris = vi.hoisted(() => new Set<string>());
+class MockFile {
+  constructor(private readonly uri: string) {}
+  get exists(): boolean {
+    return existingOverlayUris.has(this.uri);
+  }
+}
+
 vi.mock('expo-file-system', () => ({
   Directory: vi.fn(() => ({ exists: false, list: () => [] })),
+  File: MockFile,
   Paths: { cache: { uri: 'file:///cache/' } },
 }));
 
@@ -33,8 +42,9 @@ vi.mock('../../lib/background-image-cache', () => ({
   ensureBackgroundsCached: vi.fn(async () => ({ paths: ['file:///bg.png'], missingCount: 0 })),
 }));
 
+const reportErrorMock = vi.hoisted(() => vi.fn());
 vi.mock('../../lib/error-reporting', () => ({
-  reportError: vi.fn(),
+  reportError: reportErrorMock,
 }));
 
 vi.mock('../../lib/hold-color-overrides', async (importOriginal) => {
@@ -59,7 +69,7 @@ vi.mock('../../lib/hold-color-overrides', async (importOriginal) => {
 // the test, keyed by the cacheKey argument. Injected via the test-only setter
 // because the hook loads the real module through a literal CJS require() that
 // the vitest mock registry can't intercept.
-const pendingRenders = new Map<string, { resolve: (uri: string) => void }>();
+const pendingRenders = new Map<string, { resolve: (uri: string) => void }[]>();
 const fakeNativeModule = {
   // Availability flag getNativeModule() checks; the hook calls the top-level
   // renderHoldsOverlay wrapper, not this object.
@@ -67,7 +77,9 @@ const fakeNativeModule = {
   renderHoldsOverlay: vi.fn(
     (_configJson: string, cacheKey: string) =>
       new Promise<string>((resolve) => {
-        pendingRenders.set(cacheKey, { resolve });
+        const pendingForKey = pendingRenders.get(cacheKey) ?? [];
+        pendingForKey.push({ resolve });
+        pendingRenders.set(cacheKey, pendingForKey);
       }),
   ),
 };
@@ -76,7 +88,9 @@ const {
   useNativeClimbRender,
   buildCacheKey,
   _renderedOverlaysForTests,
+  _cacheRenderedOverlayForTests,
   _inflightRendersForTests,
+  _resetWarmupForTests,
   _setNativeModuleForTests,
 } = await import('../use-native-climb-render');
 
@@ -95,18 +109,27 @@ function cacheKeyFor(frames: string): string {
   return buildCacheKey(BASE.boardName, BASE.layoutId, BASE.sizeId, BASE.setIds, frames, BASE.filledStyle);
 }
 
+function resolveNextRender(cacheKey: string, uri: string): void {
+  const pending = pendingRenders.get(cacheKey)?.shift();
+  if (!pending) throw new Error(`No pending render for ${cacheKey}`);
+  pending.resolve(uri);
+}
+
 describe('useNativeClimbRender in-flight race', () => {
   beforeEach(() => {
     pendingRenders.clear();
-    _renderedOverlaysForTests.clear();
+    existingOverlayUris.clear();
+    _resetWarmupForTests();
     _inflightRendersForTests.clear();
+    fakeNativeModule.renderHoldsOverlay.mockClear();
+    reportErrorMock.mockClear();
     _setNativeModuleForTests(fakeNativeModule as unknown as Parameters<typeof _setNativeModuleForTests>[0]);
   });
 
   it('discards a slow render resolution after props moved to a cached climb', async () => {
     const slowKey = cacheKeyFor(FRAMES_SLOW);
     const cachedKey = cacheKeyFor(FRAMES_CACHED);
-    _renderedOverlaysForTests.set(cachedKey, 'file:///overlay-cached.png');
+    _cacheRenderedOverlayForTests(cachedKey, 'file:///overlay-cached.png');
 
     const { result, rerender } = renderHook(
       (props: { frames: string }) => useNativeClimbRender({ ...BASE, ...props }),
@@ -123,14 +146,197 @@ describe('useNativeClimbRender in-flight race', () => {
 
     // The slow render finally resolves. It must NOT clobber the current climb.
     await act(async () => {
-      pendingRenders.get(slowKey)?.resolve('file:///overlay-slow.png');
+      resolveNextRender(slowKey, 'file:///overlay-slow.png');
       await Promise.resolve();
     });
     expect(result.current.overlayUri).toBe('file:///overlay-cached.png');
 
     // The late result still landed in the cache for an instant hit on swipe-back.
-    expect(_renderedOverlaysForTests.get(slowKey)).toBe('file:///overlay-slow.png');
+    expect(_renderedOverlaysForTests.get(slowKey)?.uri).toBe('file:///overlay-slow.png');
     rerender({ frames: FRAMES_SLOW });
     await waitFor(() => expect(result.current.overlayUri).toBe('file:///overlay-slow.png'));
+  });
+
+  it('regenerates one missing cache entry and exposes a new load key even when the URI is unchanged', async () => {
+    const cacheKey = cacheKeyFor(FRAMES_CACHED);
+    const overlayUri = 'file:///overlay-cached.png';
+    _cacheRenderedOverlayForTests(cacheKey, overlayUri);
+    const { result } = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
+    const failedLoadKey = result.current.overlayLoadKey;
+
+    act(() => result.current.onOverlayError({ error: 'Failed to load resource' }));
+    await waitFor(() => expect(pendingRenders.has(cacheKey)).toBe(true));
+    expect(result.current.overlayUri).toBeNull();
+    expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveNextRender(cacheKey, overlayUri);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.overlayUri).toBe(overlayUri));
+    expect(result.current.overlayLoadKey).not.toBe(failedLoadKey);
+  });
+
+  it('withholds and repairs a missing overlay for a non-Image notification consumer', async () => {
+    const cacheKey = cacheKeyFor(FRAMES_CACHED);
+    const overlayUri = 'file:///notification-overlay.png';
+    _cacheRenderedOverlayForTests(cacheKey, overlayUri);
+    const { result } = renderHook(() =>
+      useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED, verifyOverlayFile: true }),
+    );
+    const failedLoadKey = result.current.overlayLoadKey;
+
+    expect(result.current.overlayUri).toBeNull();
+    await waitFor(() => expect(pendingRenders.has(cacheKey)).toBe(true));
+    existingOverlayUris.add(overlayUri);
+    await act(async () => {
+      resolveNextRender(cacheKey, overlayUri);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(result.current.overlayUri).toBe(overlayUri));
+    expect(result.current.overlayLoadKey).not.toBe(failedLoadKey);
+    expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  it('deduplicates simultaneous repairs across mounted consumers', async () => {
+    const cacheKey = cacheKeyFor(FRAMES_CACHED);
+    const overlayUri = 'file:///shared.png';
+    _cacheRenderedOverlayForTests(cacheKey, overlayUri);
+    const first = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
+    const second = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
+
+    act(() => {
+      first.result.current.onOverlayError({ error: 'Failed to load resource' });
+      second.result.current.onOverlayError({ error: 'Failed to load resource' });
+    });
+    await waitFor(() => expect(pendingRenders.has(cacheKey)).toBe(true));
+    expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveNextRender(cacheKey, overlayUri);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(first.result.current.overlayUri).toBe(overlayUri));
+    await waitFor(() => expect(second.result.current.overlayUri).toBe(overlayUri));
+  });
+
+  it('preserves a peer repair and remounts only the failed consumer', () => {
+    const cacheKey = cacheKeyFor(FRAMES_CACHED);
+    const overlayUri = 'file:///same-path.png';
+    _cacheRenderedOverlayForTests(cacheKey, overlayUri);
+    const { result } = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
+    const failedLoadKey = result.current.overlayLoadKey;
+    const peerReplacement = _cacheRenderedOverlayForTests(cacheKey, overlayUri);
+
+    act(() => result.current.onOverlayError({ error: 'Failed to load resource' }));
+
+    expect(_renderedOverlaysForTests.get(cacheKey)).toEqual(peerReplacement);
+    expect(result.current.overlayUri).toBe(overlayUri);
+    expect(result.current.overlayLoadKey).not.toBe(failedLoadKey);
+    expect(fakeNativeModule.renderHoldsOverlay).not.toHaveBeenCalled();
+  });
+
+  it('adopts a same-URI peer rewrite before classifying its existing file as terminal', () => {
+    const cacheKey = cacheKeyFor(FRAMES_CACHED);
+    const overlayUri = 'file:///same-path-existing.png';
+    const failedEntry = _cacheRenderedOverlayForTests(cacheKey, overlayUri);
+    const { result } = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
+    const failedOnError = result.current.onOverlayError;
+    const failedLoadKey = result.current.overlayLoadKey;
+
+    // A peer rewrites the native cache path while generation A's Image error
+    // is still queued. The path now exists because it contains generation B.
+    const peerReplacement = _cacheRenderedOverlayForTests(cacheKey, overlayUri);
+    existingOverlayUris.add(overlayUri);
+    expect(peerReplacement.generation).not.toBe(failedEntry.generation);
+
+    act(() => failedOnError({ error: 'Delayed generation A failure' }));
+
+    expect(_renderedOverlaysForTests.get(cacheKey)).toEqual(peerReplacement);
+    expect(result.current.overlayUri).toBe(overlayUri);
+    expect(result.current.overlayLoadKey).toBe(`${peerReplacement.generation}:1`);
+    expect(result.current.overlayLoadKey).not.toBe(failedLoadKey);
+    expect(fakeNativeModule.renderHoldsOverlay).not.toHaveBeenCalled();
+    expect(reportErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores a stale error callback after props move to another cache key', () => {
+    const oldKey = cacheKeyFor(FRAMES_SLOW);
+    const currentKey = cacheKeyFor(FRAMES_CACHED);
+    _cacheRenderedOverlayForTests(oldKey, 'file:///old.png');
+    _cacheRenderedOverlayForTests(currentKey, 'file:///current.png');
+    const { result, rerender } = renderHook(
+      (props: { frames: string }) => useNativeClimbRender({ ...BASE, ...props }),
+      { initialProps: { frames: FRAMES_SLOW } },
+    );
+    const staleOnError = result.current.onOverlayError;
+
+    rerender({ frames: FRAMES_CACHED });
+    act(() => staleOnError({ error: 'Failed to load resource' }));
+
+    expect(result.current.overlayUri).toBe('file:///current.png');
+    expect(_renderedOverlaysForTests.has(oldKey)).toBe(true);
+    expect(_renderedOverlaysForTests.has(currentKey)).toBe(true);
+    expect(fakeNativeModule.renderHoldsOverlay).not.toHaveBeenCalled();
+  });
+
+  it('stops after one retry until the exact replacement reports onLoad', async () => {
+    const cacheKey = cacheKeyFor(FRAMES_CACHED);
+    const overlayUri = 'file:///retry-budget.png';
+    _cacheRenderedOverlayForTests(cacheKey, overlayUri);
+    const { result } = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
+
+    act(() => result.current.onOverlayError({ error: 'Failed to load resource' }));
+    await waitFor(() => expect(pendingRenders.has(cacheKey)).toBe(true));
+    await act(async () => {
+      resolveNextRender(cacheKey, overlayUri);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.overlayUri).toBe(overlayUri));
+
+    act(() => result.current.onOverlayError({ error: 'Failed to load resource' }));
+    expect(result.current.overlayUri).toBeNull();
+    expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  it('replenishes the retry budget after the exact replacement loads', async () => {
+    const cacheKey = cacheKeyFor(FRAMES_CACHED);
+    const overlayUri = 'file:///retry-reset.png';
+    _cacheRenderedOverlayForTests(cacheKey, overlayUri);
+    const { result } = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
+
+    act(() => result.current.onOverlayError({ error: 'Failed to load resource' }));
+    await waitFor(() => expect(pendingRenders.has(cacheKey)).toBe(true));
+    await act(async () => {
+      resolveNextRender(cacheKey, overlayUri);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.overlayUri).toBe(overlayUri));
+    act(() => result.current.onOverlayLoad());
+    act(() => result.current.onOverlayError({ error: 'Failed to load resource' }));
+
+    await waitFor(() => expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(2));
+  });
+
+  it('treats an existing-file decode failure as terminal and reports it once without identifiers', () => {
+    const cacheKey = cacheKeyFor(FRAMES_CACHED);
+    const overlayUri = 'file:///private/cache/path.png';
+    existingOverlayUris.add(overlayUri);
+    _cacheRenderedOverlayForTests(cacheKey, overlayUri);
+    const first = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
+    const second = renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_CACHED }));
+
+    act(() => {
+      first.result.current.onOverlayError({ error: `decode failed at ${overlayUri}` });
+      second.result.current.onOverlayError({ error: `decode failed at ${overlayUri}` });
+    });
+
+    expect(first.result.current.overlayUri).toBeNull();
+    expect(second.result.current.overlayUri).toBeNull();
+    expect(fakeNativeModule.renderHoldsOverlay).not.toHaveBeenCalled();
+    expect(reportErrorMock).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(reportErrorMock.mock.calls[0])).not.toContain(overlayUri);
+    expect(JSON.stringify(reportErrorMock.mock.calls[0])).not.toContain(cacheKey);
   });
 });

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render.test.ts
@@ -66,6 +66,9 @@ const {
   getOrStartInflightRender,
   _inflightRendersForTests,
   _renderedOverlaysForTests,
+  _cacheRenderedOverlayForTests,
+  _getRenderedOverlayForTests,
+  _invalidateRenderedOverlayForTests,
   _resetWarmupForTests,
   _runWarmupForTests,
   _getBoardConfigForTests,
@@ -360,7 +363,7 @@ describe('getOrStartInflightRender', () => {
   it('starts a render and returns its promise on first call', async () => {
     const startRender = vi.fn().mockResolvedValue('file:///out/a.png');
     const result = await getOrStartInflightRender('key-a', startRender);
-    expect(result).toBe('file:///out/a.png');
+    expect(result.uri).toBe('file:///out/a.png');
     expect(startRender).toHaveBeenCalledTimes(1);
   });
 
@@ -380,7 +383,7 @@ describe('getOrStartInflightRender', () => {
     expect(startRender).toHaveBeenCalledTimes(1);
 
     resolveFn?.('file:///out/a.png');
-    expect(await first).toBe('file:///out/a.png');
+    expect((await first).uri).toBe('file:///out/a.png');
   });
 
   it('removes the entry once the render settles successfully', async () => {
@@ -431,9 +434,39 @@ describe('renderedOverlays warm-up from disk cache', () => {
 
   it('exposes the populated map so a fresh hook init can hit it synchronously', () => {
     expect(_renderedOverlaysForTests).toBeInstanceOf(Map);
-    _renderedOverlaysForTests.set('v5_kilter_1_10_24_deadbeef', 'file:///prior/session.png');
-    expect(_renderedOverlaysForTests.get('v5_kilter_1_10_24_deadbeef')).toBe('file:///prior/session.png');
+    _cacheRenderedOverlayForTests('v5_kilter_1_10_24_deadbeef', 'file:///prior/session.png');
+    expect(_renderedOverlaysForTests.get('v5_kilter_1_10_24_deadbeef')?.uri).toBe('file:///prior/session.png');
     _renderedOverlaysForTests.delete('v5_kilter_1_10_24_deadbeef');
+  });
+
+  it('mints a new generation when a render replaces the same URI', () => {
+    const first = _cacheRenderedOverlayForTests('key-a', 'file:///same.png');
+    const replacement = _cacheRenderedOverlayForTests('key-a', 'file:///same.png');
+
+    expect(replacement.generation).toBeGreaterThan(first.generation);
+    expect(replacement.uri).toBe(first.uri);
+  });
+
+  it('invalidates only an exact URI and generation', () => {
+    const stale = _cacheRenderedOverlayForTests('key-a', 'file:///same.png');
+    const replacement = _cacheRenderedOverlayForTests('key-a', 'file:///same.png');
+
+    expect(_invalidateRenderedOverlayForTests('key-a', stale)).toBe(false);
+    expect(_getRenderedOverlayForTests('key-a')).toEqual(replacement);
+    expect(_invalidateRenderedOverlayForTests('key-a', replacement)).toBe(true);
+    expect(_renderedOverlaysForTests.has('key-a')).toBe(false);
+  });
+
+  it('bounds the sync cache and promotes reads in LRU order', () => {
+    for (let entryIndex = 0; entryIndex < 200; entryIndex++) {
+      _cacheRenderedOverlayForTests(`key-${entryIndex}`, `file:///overlay-${entryIndex}.png`);
+    }
+    _getRenderedOverlayForTests('key-0');
+    _cacheRenderedOverlayForTests('key-200', 'file:///overlay-200.png');
+
+    expect(_renderedOverlaysForTests.size).toBe(200);
+    expect(_renderedOverlaysForTests.has('key-0')).toBe(true);
+    expect(_renderedOverlaysForTests.has('key-1')).toBe(false);
   });
 
   it('only loads PNGs whose name starts with the current RENDERER_VERSION prefix', () => {

--- a/packages/mobile/src/hooks/overlay-cache-warmup.ts
+++ b/packages/mobile/src/hooks/overlay-cache-warmup.ts
@@ -1,4 +1,4 @@
-import { Directory, Paths } from 'expo-file-system';
+import { Directory, File, Paths } from 'expo-file-system';
 
 /**
  * A single entry from the native overlay PNG cache directory. Structurally the
@@ -27,6 +27,17 @@ export function listOverlayCacheEntries(cacheDirName: string): OverlayCacheEntry
   const cacheDir = new Directory(Paths.cache, cacheDirName);
   if (!cacheDir.exists) return null;
   return cacheDir.list() as OverlayCacheEntry[];
+}
+
+/**
+ * Confirm that a URI handed back by the native renderer still names a file.
+ * Cache-pruning and OS storage pressure can remove an individual PNG after the
+ * one-time directory warm-up populated JS's synchronous cache. This check is
+ * intentionally made only after expo-image reports a load failure, keeping the
+ * normal cache-hit path synchronous and free of filesystem I/O.
+ */
+export function overlayCacheEntryExists(uri: string): boolean {
+  return new File(uri).exists;
 }
 
 /**

--- a/packages/mobile/src/hooks/overlay-cache-warmup.web.ts
+++ b/packages/mobile/src/hooks/overlay-cache-warmup.web.ts
@@ -57,3 +57,12 @@ export function listOverlayCacheEntries(_cacheDirName: string): OverlayCacheEntr
   const entries = snapshotOverlayEntries();
   return entries.length > 0 ? entries : null;
 }
+
+/**
+ * Browser object URLs cannot be synchronously mapped back to a Cache API entry.
+ * Returning null makes an image failure terminal instead of guessing that a
+ * persisted entry vanished and entering a retry loop.
+ */
+export function overlayCacheEntryExists(_uri: string): null {
+  return null;
+}

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -1028,11 +1028,33 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
         return;
       }
 
-      // Existing files indicate a decode/format failure, not stale JS cache.
-      // Unknown validation (the web twin) is also terminal: guessing would turn
+      // A present file can still be a transient native image decode failure.
+      // Keep the exact generated entry, but remount expo-image once with a new
+      // attempt key so it retries the same URI without triggering a render.
+      if (entryExists === true) {
+        reportOverlayLoadOnce('cache_entry_present', boardName);
+        if (retryBudgetRef.current.key !== expected.key || retryBudgetRef.current.used >= 1) {
+          reportOverlayLoadOnce('retry_exhausted', boardName);
+          setNativeRender((previous) => (isExactNativeRender(previous, expected) ? null : previous));
+          return;
+        }
+        retryBudgetRef.current.used += 1;
+        setNativeRender((previous) =>
+          isExactNativeRender(previous, expected)
+            ? {
+                key: expected.key,
+                entry: expectedEntry,
+                loadAttempt: expected.loadAttempt + 1,
+              }
+            : previous,
+        );
+        return;
+      }
+
+      // Unknown validation (the web twin) is terminal: guessing would turn
       // every unsupported image into a render loop.
-      if (entryExists !== false) {
-        reportOverlayLoadOnce(entryExists === true ? 'cache_entry_present' : 'validation_unsupported', boardName);
+      if (entryExists === null) {
+        reportOverlayLoadOnce('validation_unsupported', boardName);
         setNativeRender((previous) => (isExactNativeRender(previous, expected) ? null : previous));
         return;
       }
@@ -1090,7 +1112,10 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
         return null;
       }
       try {
-        if (overlayCacheEntryExists(requestedUri) === true) return requestedUri;
+        if (overlayCacheEntryExists(requestedUri) === true) {
+          onOverlayLoad(requestedLoadKey);
+          return requestedUri;
+        }
       } catch {
         // The exact-attempt handler below classifies and reports validation
         // failures without including the private cache URI.
@@ -1098,7 +1123,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       onOverlayError({ error: 'Generated overlay failed native-use validation' }, requestedLoadKey);
       return null;
     },
-    [currentCacheKey, onOverlayError, verifyOverlayFile],
+    [currentCacheKey, onOverlayError, onOverlayLoad, verifyOverlayFile],
   );
 
   // Only surface the native URI if it matches the *current* cache key —

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -1166,7 +1166,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     setVerifiedOverlay(null);
     // verifyOverlayForNativeUse owns exact-attempt recovery. This state change
     // withholds the stale path from subsequent notification renders.
-  });
+  }, [candidateOverlayUri, currentCacheKey, overlayLoadKey, verifyOverlayFile, verifyOverlayForNativeUse]);
   // Same guard for backgrounds: a stored entry from a prior boardKey
   // (FlashList row recycle case) must not bleed through to the new climb.
   const backgroundPaths = storedBackgrounds?.key === currentBoardKey ? storedBackgrounds.paths : [];

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import type { BoardName } from '@boardsesh/shared-schema';
-import { listOverlayCacheEntries, onOverlayCacheHydrated } from './overlay-cache-warmup';
+import { listOverlayCacheEntries, onOverlayCacheHydrated, overlayCacheEntryExists } from './overlay-cache-warmup';
 import { RENDERER_VERSION } from './renderer-version';
 import { HOLD_STATE_MAP, getBoardStrokeWidthMultiplier } from '@boardsesh/board-constants/hold-states';
 import { getBoardRenderData } from '../lib/board-details';
@@ -77,6 +77,12 @@ type NativeClimbRenderParams = {
    * `full` otherwise.
    */
   backgroundVariant?: BackgroundVariant;
+  /**
+   * Synchronously verify a generated file before exposing its URI. Used by the
+   * Android session notification, which hands the path to native compositing
+   * without mounting an expo-image that could report onError.
+   */
+  verifyOverlayFile?: boolean;
 };
 
 type NativeClimbRenderResult = {
@@ -86,6 +92,14 @@ type NativeClimbRenderResult = {
    * Expo Go). Consumers stack this on top of `backgroundPaths`.
    */
   overlayUri: string | null;
+  /**
+   * Changes whenever this consumer must make expo-image perform a fresh load,
+   * including a regeneration that writes back to the same file:// URI.
+   */
+  overlayLoadKey: string | null;
+  /** Exact-attempt callbacks consumed by LayeredClimbImage's overlay Image. */
+  onOverlayLoad: () => void;
+  onOverlayError: (event: { error: string }) => void;
   /**
    * Filesystem paths (no scheme) of the bundled board background images
    * that resolved successfully. Returned synchronously when bundled-asset
@@ -111,7 +125,37 @@ type NativeClimbRenderResult = {
  * huge list scrolled before any render completes) leaving stale entries
  * if components unmount mid-render.
  */
-const inflightRenders = new Map<string, Promise<string>>();
+export type RenderedOverlayEntry = {
+  uri: string;
+  generation: number;
+};
+
+type NativeRenderState = {
+  key: string;
+  entry: RenderedOverlayEntry | null;
+  loadAttempt: number;
+};
+
+type LoadedNativeRenderState = NativeRenderState & { entry: RenderedOverlayEntry };
+
+function isLoadedNativeRender(state: NativeRenderState | null): state is LoadedNativeRenderState {
+  return state?.entry != null;
+}
+
+function isExactNativeRender(
+  current: NativeRenderState | null,
+  expected: LoadedNativeRenderState,
+): current is LoadedNativeRenderState {
+  return (
+    isLoadedNativeRender(current) &&
+    current.key === expected.key &&
+    current.entry.uri === expected.entry.uri &&
+    current.entry.generation === expected.entry.generation &&
+    current.loadAttempt === expected.loadAttempt
+  );
+}
+
+const inflightRenders = new Map<string, Promise<RenderedOverlayEntry>>();
 const INFLIGHT_RENDERS_MAX = 50;
 const unsupportedRenderSignatures = new Set<string>();
 
@@ -128,7 +172,68 @@ const BOARD_CONFIG_CACHE_MAX = 20;
  * from this map, so a cache hit displays the overlay on the very first
  * render with no useEffect-driven update.
  */
-const renderedOverlays = new Map<string, string>();
+const renderedOverlays = new Map<string, RenderedOverlayEntry>();
+const RENDERED_OVERLAYS_MAX = 200;
+let nextOverlayGeneration = 1;
+
+/**
+ * The only insertion path for the synchronous overlay cache. A generation is
+ * minted even when native rewrites the same URI, which lets mounted consumers
+ * distinguish the replacement from the missing file they just failed to load.
+ */
+function cacheRenderedOverlay(cacheKey: string, uri: string): RenderedOverlayEntry {
+  const entry = { uri, generation: nextOverlayGeneration };
+  nextOverlayGeneration += 1;
+
+  // Delete first so replacing an entry also promotes it to most-recently used.
+  renderedOverlays.delete(cacheKey);
+  if (renderedOverlays.size >= RENDERED_OVERLAYS_MAX) {
+    const oldestKey = renderedOverlays.keys().next().value;
+    if (oldestKey !== undefined) renderedOverlays.delete(oldestKey);
+  }
+  renderedOverlays.set(cacheKey, entry);
+  return entry;
+}
+
+function getRenderedOverlay(cacheKey: string): RenderedOverlayEntry | undefined {
+  const entry = renderedOverlays.get(cacheKey);
+  if (!entry) return undefined;
+  // Map iteration order is the LRU order. Reads promote without changing the
+  // immutable entry identity used by exact failure guards.
+  renderedOverlays.delete(cacheKey);
+  renderedOverlays.set(cacheKey, entry);
+  return entry;
+}
+
+function invalidateRenderedOverlay(cacheKey: string, expected: RenderedOverlayEntry): boolean {
+  const current = renderedOverlays.get(cacheKey);
+  if (!current || current.uri !== expected.uri || current.generation !== expected.generation) return false;
+  renderedOverlays.delete(cacheKey);
+  return true;
+}
+
+type OverlayLoadTelemetryKind =
+  | 'cache_entry_missing'
+  | 'retry_exhausted'
+  | 'cache_entry_present'
+  | 'validation_failed'
+  | 'validation_unsupported';
+
+const reportedOverlayLoadTelemetry = new Set<OverlayLoadTelemetryKind>();
+
+/** One privacy-safe, low-cardinality event per failure class and JS lifetime. */
+function reportOverlayLoadOnce(kind: OverlayLoadTelemetryKind, boardName: BoardName): void {
+  if (reportedOverlayLoadTelemetry.has(kind)) return;
+  reportedOverlayLoadTelemetry.add(kind);
+  reportError(new Error(`Generated overlay image load failed: ${kind}`), {
+    level: 'warning',
+    tags: {
+      feature: 'mobile_board_renderer',
+      boardName,
+      overlayLoadFailure: kind,
+    },
+  });
+}
 
 /**
  * One-time eager scan of the native module's PNG cache directory. The
@@ -174,7 +279,7 @@ function warmupRenderedOverlaysOnce(): void {
         continue;
       }
       const cacheKey = name.slice(0, -'.png'.length);
-      renderedOverlays.set(cacheKey, entry.uri);
+      cacheRenderedOverlay(cacheKey, entry.uri);
     }
   } catch {
     // Filesystem errors at startup shouldn't break the app — the hook's
@@ -198,6 +303,8 @@ onOverlayCacheHydrated(() => {
 export function _resetWarmupForTests(): void {
   warmupRun = false;
   renderedOverlays.clear();
+  nextOverlayGeneration = 1;
+  reportedOverlayLoadTelemetry.clear();
 }
 
 /** Test-only handle to invoke the warm-up explicitly (it normally runs lazily on first render). */
@@ -210,7 +317,10 @@ export function _runWarmupForTests(): void {
  * (alongside _inflightRendersForTests) so the dedup + cap contract can be
  * unit tested without spinning up a React renderer.
  */
-export function getOrStartInflightRender(cacheKey: string, startRender: () => Promise<string>): Promise<string> {
+export function getOrStartInflightRender(
+  cacheKey: string,
+  startRender: () => Promise<string>,
+): Promise<RenderedOverlayEntry> {
   const existing = inflightRenders.get(cacheKey);
   if (existing) return existing;
 
@@ -223,14 +333,14 @@ export function getOrStartInflightRender(cacheKey: string, startRender: () => Pr
     }
   }
 
-  const promise = startRender();
+  const promise = startRender().then((uri) => cacheRenderedOverlay(cacheKey, uri));
   inflightRenders.set(cacheKey, promise);
   // Run cleanup as a detached handler so it doesn't change the promise
   // returned to callers, and so callers that only attach .then can still
   // observe rejections.
   void promise
     .finally(() => {
-      inflightRenders.delete(cacheKey);
+      if (inflightRenders.get(cacheKey) === promise) inflightRenders.delete(cacheKey);
     })
     .catch(() => {
       // Swallow — the original promise's rejection is observed by the
@@ -243,6 +353,9 @@ export function getOrStartInflightRender(cacheKey: string, startRender: () => Pr
 /** Test-only handles. Not part of the public API. */
 export const _inflightRendersForTests = inflightRenders;
 export const _renderedOverlaysForTests = renderedOverlays;
+export const _cacheRenderedOverlayForTests = cacheRenderedOverlay;
+export const _getRenderedOverlayForTests = getRenderedOverlay;
+export const _invalidateRenderedOverlayForTests = invalidateRenderedOverlay;
 
 /**
  * Test-only: inject a fake native module. The real one loads via a literal
@@ -533,7 +646,17 @@ function getNativeModule() {
  * and the component shows backgrounds alone.
  */
 export function useNativeClimbRender(params: NativeClimbRenderParams): NativeClimbRenderResult {
-  const { frames, boardName, layoutId, sizeId, setIds, filledStyle = false, renderWidth, backgroundVariant } = params;
+  const {
+    frames,
+    boardName,
+    layoutId,
+    sizeId,
+    setIds,
+    filledStyle = false,
+    renderWidth,
+    backgroundVariant,
+    verifyOverlayFile = false,
+  } = params;
   const {
     overrides: holdColorOverrides,
     shapes: holdShapeOverrides,
@@ -583,10 +706,11 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
   // available on the first frame (Asset.localUri pre-populated); the
   // overlay is available if a previous render in this session — or a
   // prior app launch — produced its file.
-  const [nativeRender, setNativeRender] = useState<{ key: string; uri: string } | null>(() => {
-    const existing = renderedOverlays.get(currentCacheKey);
-    return existing ? { key: currentCacheKey, uri: existing } : null;
+  const [nativeRender, setNativeRender] = useState<NativeRenderState | null>(() => {
+    const existing = getRenderedOverlay(currentCacheKey);
+    return existing ? { key: currentCacheKey, entry: existing, loadAttempt: 0 } : null;
   });
+  const [recoveryRequest, setRecoveryRequest] = useState(0);
   // Background state combines two guards:
   //   - `key`: locks the value to a specific board config so a FlashList
   //     row recycled to a different climb can't surface the previous
@@ -622,6 +746,13 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
   // whose overlay is already cached (sync branch, no new promise) while the
   // previous climb's render is still in flight.
   const latestCacheKeyRef = useRef(currentCacheKey);
+  latestCacheKeyRef.current = currentCacheKey;
+  const nativeRenderRef = useRef(nativeRender);
+  nativeRenderRef.current = nativeRender;
+  const retryBudgetRef = useRef({ key: currentCacheKey, used: 0 });
+  if (retryBudgetRef.current.key !== currentCacheKey) {
+    retryBudgetRef.current = { key: currentCacheKey, used: 0 };
+  }
 
   useEffect(() => {
     mountedRef.current = true;
@@ -709,17 +840,27 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
   // Overlay-render effect: kick off the native render if we don't already
   // have one for this cache key in the sync map.
   useEffect(() => {
-    latestCacheKeyRef.current = currentCacheKey;
     if (!frames || unsupportedRenderSignatures.has(holdRenderSignature)) return;
 
-    if (renderedOverlays.has(currentCacheKey)) {
+    const cachedEntry = getRenderedOverlay(currentCacheKey);
+    if (cachedEntry) {
       // Sync map already has it — make sure local state reflects that
       // (covers prop changes mid-mount that pick up a previously rendered
       // overlay).
-      const uri = renderedOverlays.get(currentCacheKey);
-      if (uri && nativeRender?.key !== currentCacheKey) {
-        setNativeRender({ key: currentCacheKey, uri });
-      }
+      setNativeRender((previous) => {
+        if (
+          previous?.key === currentCacheKey &&
+          previous.entry?.uri === cachedEntry.uri &&
+          previous.entry.generation === cachedEntry.generation
+        ) {
+          return previous;
+        }
+        return {
+          key: currentCacheKey,
+          entry: cachedEntry,
+          loadAttempt: previous?.key === currentCacheKey ? previous.loadAttempt : 0,
+        };
+      });
       return;
     }
 
@@ -750,13 +891,16 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     });
 
     renderPromise
-      .then((fileUri) => {
-        renderedOverlays.set(currentCacheKey, fileUri);
+      .then((renderedEntry) => {
         // Discard a stale resolution (props moved on while this render was in
         // flight) — see latestCacheKeyRef. The sync map above still keeps the
         // file, so swiping back to this climb is an instant cache hit.
         if (mountedRef.current && latestCacheKeyRef.current === currentCacheKey) {
-          setNativeRender({ key: currentCacheKey, uri: fileUri });
+          setNativeRender((previous) => ({
+            key: currentCacheKey,
+            entry: renderedEntry,
+            loadAttempt: previous?.key === currentCacheKey ? previous.loadAttempt : 0,
+          }));
         }
       })
       .catch((error: unknown) => {
@@ -789,8 +933,9 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
           },
         });
       });
-    // nativeRender is intentionally excluded from deps: this effect *sets* it,
-    // and the only meaningful re-trigger is a cacheKey change.
+    // nativeRender is intentionally excluded from deps: this effect *sets* it.
+    // recoveryRequest is the explicit same-key re-trigger after an exact stale
+    // entry is invalidated.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     currentCacheKey,
@@ -806,14 +951,155 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     brushThickness,
     shapeSize,
     holdRenderSignature,
+    recoveryRequest,
   ]);
+
+  const onOverlayLoad = useCallback(() => {
+    const expected = nativeRender;
+    const current = nativeRenderRef.current;
+    if (!isLoadedNativeRender(expected) || expected.key !== currentCacheKey || !isExactNativeRender(current, expected))
+      return;
+
+    // A successful replacement is the only event that replenishes this
+    // consumer's retry budget. Merely finishing the native render is not proof
+    // that expo-image could load the regenerated file.
+    if (expected.loadAttempt > 0 && retryBudgetRef.current.key === expected.key) {
+      retryBudgetRef.current.used = 0;
+    }
+  }, [currentCacheKey, nativeRender]);
+
+  const onOverlayError = useCallback(
+    (_event: { error: string }) => {
+      const expected = nativeRender;
+      const current = nativeRenderRef.current;
+      if (
+        !isLoadedNativeRender(expected) ||
+        expected.key !== currentCacheKey ||
+        !isExactNativeRender(current, expected)
+      )
+        return;
+      const expectedEntry = expected.entry;
+
+      const peerReplacement = getRenderedOverlay(expected.key);
+      if (
+        peerReplacement &&
+        (peerReplacement.uri !== expectedEntry.uri || peerReplacement.generation !== expectedEntry.generation)
+      ) {
+        // A peer may have rewritten the same URI before this consumer's
+        // delayed onError arrives. The file then exists because it belongs to
+        // the newer generation, so compare generations before classifying an
+        // existing file as a terminal decode failure.
+        if (retryBudgetRef.current.key !== expected.key || retryBudgetRef.current.used >= 1) {
+          reportOverlayLoadOnce('retry_exhausted', boardName);
+          setNativeRender((previous) => (isExactNativeRender(previous, expected) ? null : previous));
+          return;
+        }
+        retryBudgetRef.current.used += 1;
+        setNativeRender((previous) =>
+          isExactNativeRender(previous, expected)
+            ? {
+                key: expected.key,
+                entry: peerReplacement,
+                loadAttempt: expected.loadAttempt + 1,
+              }
+            : previous,
+        );
+        return;
+      }
+
+      let entryExists: boolean | null;
+      try {
+        entryExists = overlayCacheEntryExists(expectedEntry.uri);
+      } catch {
+        reportOverlayLoadOnce('validation_failed', boardName);
+        setNativeRender((previous) => (isExactNativeRender(previous, expected) ? null : previous));
+        return;
+      }
+
+      // Existing files indicate a decode/format failure, not stale JS cache.
+      // Unknown validation (the web twin) is also terminal: guessing would turn
+      // every unsupported image into a render loop.
+      if (entryExists !== false) {
+        reportOverlayLoadOnce(entryExists === true ? 'cache_entry_present' : 'validation_unsupported', boardName);
+        setNativeRender((previous) => (isExactNativeRender(previous, expected) ? null : previous));
+        return;
+      }
+
+      reportOverlayLoadOnce('cache_entry_missing', boardName);
+      if (retryBudgetRef.current.key !== expected.key || retryBudgetRef.current.used >= 1) {
+        reportOverlayLoadOnce('retry_exhausted', boardName);
+        setNativeRender((previous) => (isExactNativeRender(previous, expected) ? null : previous));
+        return;
+      }
+      retryBudgetRef.current.used += 1;
+
+      invalidateRenderedOverlay(expected.key, expectedEntry);
+      const latePeerReplacement = getRenderedOverlay(expected.key);
+      if (
+        latePeerReplacement &&
+        (latePeerReplacement.uri !== expectedEntry.uri || latePeerReplacement.generation !== expectedEntry.generation)
+      ) {
+        // Another mounted surface already repaired this key. Never delete its
+        // newer generation; remount only this failed consumer against it.
+        setNativeRender((previous) =>
+          isExactNativeRender(previous, expected)
+            ? {
+                key: expected.key,
+                entry: latePeerReplacement,
+                loadAttempt: expected.loadAttempt + 1,
+              }
+            : previous,
+        );
+        return;
+      }
+
+      // Unmount the failed Image while the shared in-flight render repairs the
+      // cache. The nonce re-runs the effect without changing the climb key.
+      setNativeRender((previous) =>
+        isExactNativeRender(previous, expected)
+          ? { key: expected.key, entry: null, loadAttempt: expected.loadAttempt + 1 }
+          : previous,
+      );
+      setRecoveryRequest((request) => request + 1);
+    },
+    [boardName, currentCacheKey, nativeRender],
+  );
 
   // Only surface the native URI if it matches the *current* cache key —
   // a stale render (from before a prop change) would otherwise show.
-  const overlayUri = frames && nativeRender?.key === currentCacheKey ? nativeRender.uri : null;
+  const candidateOverlayUri =
+    frames && nativeRender?.key === currentCacheKey ? (nativeRender.entry?.uri ?? null) : null;
+  const overlayLoadKey =
+    frames && nativeRender?.key === currentCacheKey && nativeRender.entry
+      ? `${nativeRender.entry.generation}:${nativeRender.loadAttempt}`
+      : null;
+  let verifiedOverlayFile = true;
+  if (verifyOverlayFile && candidateOverlayUri) {
+    try {
+      verifiedOverlayFile = overlayCacheEntryExists(candidateOverlayUri) === true;
+    } catch {
+      verifiedOverlayFile = false;
+    }
+  }
+  const overlayUri = verifiedOverlayFile ? candidateOverlayUri : null;
+
+  useEffect(() => {
+    if (!verifyOverlayFile || !candidateOverlayUri || verifiedOverlayFile) return;
+    // The exact-attempt handler revalidates and owns invalidation, telemetry,
+    // retry budgeting, and the shared render. The preflight only withholds the
+    // stale path so the notification service never receives it.
+    onOverlayError({ error: 'Generated overlay failed preflight validation' });
+  }, [candidateOverlayUri, onOverlayError, overlayLoadKey, verifiedOverlayFile, verifyOverlayFile]);
   // Same guard for backgrounds: a stored entry from a prior boardKey
   // (FlashList row recycle case) must not bleed through to the new climb.
   const backgroundPaths = storedBackgrounds?.key === currentBoardKey ? storedBackgrounds.paths : [];
   const missingBackgroundCount = storedBackgrounds?.key === currentBoardKey ? storedBackgrounds.missingCount : 0;
-  return { overlayUri, backgroundPaths, missingBackgroundCount };
+  return {
+    overlayUri,
+    overlayLoadKey,
+    onOverlayLoad,
+    onOverlayError,
+    backgroundPaths,
+    missingBackgroundCount,
+  };
 }

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -98,8 +98,10 @@ type NativeClimbRenderResult = {
    */
   overlayLoadKey: string | null;
   /** Exact-attempt callbacks consumed by LayeredClimbImage's overlay Image. */
-  onOverlayLoad: () => void;
-  onOverlayError: (event: { error: string }) => void;
+  onOverlayLoad: (loadKey: string | null) => void;
+  onOverlayError: (event: { error: string }, loadKey: string | null) => void;
+  /** Revalidate immediately before a non-Image native consumer uses the path. */
+  verifyOverlayForNativeUse: (uri: string | null, loadKey: string | null) => string | null;
   /**
    * Filesystem paths (no scheme) of the bundled board background images
    * that resolved successfully. Returned synchronously when bundled-asset
@@ -710,6 +712,11 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     const existing = getRenderedOverlay(currentCacheKey);
     return existing ? { key: currentCacheKey, entry: existing, loadAttempt: 0 } : null;
   });
+  const [verifiedOverlay, setVerifiedOverlay] = useState<{
+    cacheKey: string;
+    uri: string;
+    loadKey: string;
+  } | null>(null);
   const [recoveryRequest, setRecoveryRequest] = useState(0);
   // Background state combines two guards:
   //   - `key`: locks the value to a specific board config so a FlashList
@@ -954,28 +961,33 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     recoveryRequest,
   ]);
 
-  const onOverlayLoad = useCallback(() => {
-    const expected = nativeRender;
-    const current = nativeRenderRef.current;
-    if (!isLoadedNativeRender(expected) || expected.key !== currentCacheKey || !isExactNativeRender(current, expected))
-      return;
-
-    // A successful replacement is the only event that replenishes this
-    // consumer's retry budget. Merely finishing the native render is not proof
-    // that expo-image could load the regenerated file.
-    if (expected.loadAttempt > 0 && retryBudgetRef.current.key === expected.key) {
-      retryBudgetRef.current.used = 0;
-    }
-  }, [currentCacheKey, nativeRender]);
-
-  const onOverlayError = useCallback(
-    (_event: { error: string }) => {
-      const expected = nativeRender;
-      const current = nativeRenderRef.current;
+  const onOverlayLoad = useCallback(
+    (emittingLoadKey: string | null) => {
+      const expected = nativeRenderRef.current;
       if (
         !isLoadedNativeRender(expected) ||
         expected.key !== currentCacheKey ||
-        !isExactNativeRender(current, expected)
+        `${expected.entry.generation}:${expected.loadAttempt}` !== emittingLoadKey
+      )
+        return;
+
+      // A successful replacement is the only event that replenishes this
+      // consumer's retry budget. Merely finishing the native render is not proof
+      // that expo-image could load the regenerated file.
+      if (expected.loadAttempt > 0 && retryBudgetRef.current.key === expected.key) {
+        retryBudgetRef.current.used = 0;
+      }
+    },
+    [currentCacheKey],
+  );
+
+  const onOverlayError = useCallback(
+    (_event: { error: string }, emittingLoadKey: string | null) => {
+      const expected = nativeRenderRef.current;
+      if (
+        !isLoadedNativeRender(expected) ||
+        expected.key !== currentCacheKey ||
+        `${expected.entry.generation}:${expected.loadAttempt}` !== emittingLoadKey
       )
         return;
       const expectedEntry = expected.entry;
@@ -1062,7 +1074,31 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       );
       setRecoveryRequest((request) => request + 1);
     },
-    [boardName, currentCacheKey, nativeRender],
+    [boardName, currentCacheKey],
+  );
+
+  const verifyOverlayForNativeUse = useCallback(
+    (requestedUri: string | null, requestedLoadKey: string | null): string | null => {
+      if (!verifyOverlayFile || !requestedUri) return requestedUri;
+      const expected = nativeRenderRef.current;
+      if (
+        !isLoadedNativeRender(expected) ||
+        expected.key !== currentCacheKey ||
+        expected.entry.uri !== requestedUri ||
+        `${expected.entry.generation}:${expected.loadAttempt}` !== requestedLoadKey
+      ) {
+        return null;
+      }
+      try {
+        if (overlayCacheEntryExists(requestedUri) === true) return requestedUri;
+      } catch {
+        // The exact-attempt handler below classifies and reports validation
+        // failures without including the private cache URI.
+      }
+      onOverlayError({ error: 'Generated overlay failed native-use validation' }, requestedLoadKey);
+      return null;
+    },
+    [currentCacheKey, onOverlayError, verifyOverlayFile],
   );
 
   // Only surface the native URI if it matches the *current* cache key —
@@ -1073,23 +1109,39 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     frames && nativeRender?.key === currentCacheKey && nativeRender.entry
       ? `${nativeRender.entry.generation}:${nativeRender.loadAttempt}`
       : null;
-  let verifiedOverlayFile = true;
-  if (verifyOverlayFile && candidateOverlayUri) {
-    try {
-      verifiedOverlayFile = overlayCacheEntryExists(candidateOverlayUri) === true;
-    } catch {
-      verifiedOverlayFile = false;
-    }
-  }
+  const verifiedOverlayFile =
+    !verifyOverlayFile ||
+    !candidateOverlayUri ||
+    (overlayLoadKey != null &&
+      verifiedOverlay?.cacheKey === currentCacheKey &&
+      verifiedOverlay.uri === candidateOverlayUri &&
+      verifiedOverlay.loadKey === overlayLoadKey);
   const overlayUri = verifiedOverlayFile ? candidateOverlayUri : null;
 
   useEffect(() => {
-    if (!verifyOverlayFile || !candidateOverlayUri || verifiedOverlayFile) return;
-    // The exact-attempt handler revalidates and owns invalidation, telemetry,
-    // retry budgeting, and the shared render. The preflight only withholds the
-    // stale path so the notification service never receives it.
-    onOverlayError({ error: 'Generated overlay failed preflight validation' });
-  }, [candidateOverlayUri, onOverlayError, overlayLoadKey, verifiedOverlayFile, verifyOverlayFile]);
+    if (!verifyOverlayFile || !candidateOverlayUri || !overlayLoadKey) {
+      setVerifiedOverlay(null);
+      return;
+    }
+
+    if (verifyOverlayForNativeUse(candidateOverlayUri, overlayLoadKey)) {
+      setVerifiedOverlay((previous) => {
+        if (
+          previous?.cacheKey === currentCacheKey &&
+          previous.uri === candidateOverlayUri &&
+          previous.loadKey === overlayLoadKey
+        ) {
+          return previous;
+        }
+        return { cacheKey: currentCacheKey, uri: candidateOverlayUri, loadKey: overlayLoadKey };
+      });
+      return;
+    }
+
+    setVerifiedOverlay(null);
+    // verifyOverlayForNativeUse owns exact-attempt recovery. This state change
+    // withholds the stale path from subsequent notification renders.
+  });
   // Same guard for backgrounds: a stored entry from a prior boardKey
   // (FlashList row recycle case) must not bleed through to the new climb.
   const backgroundPaths = storedBackgrounds?.key === currentBoardKey ? storedBackgrounds.paths : [];
@@ -1099,6 +1151,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     overlayLoadKey,
     onOverlayLoad,
     onOverlayError,
+    verifyOverlayForNativeUse,
     backgroundPaths,
     missingBackgroundCount,
   };

--- a/packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx
+++ b/packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx
@@ -59,6 +59,7 @@ const climbRender = vi.hoisted(() => ({
   overlayUri: null as string | null,
   overlayLoadKey: null as string | null,
   backgroundPaths: [] as string[],
+  verifyOverlayForNativeUse: vi.fn((uri: string | null) => uri),
   useNativeClimbRender: vi.fn(),
 }));
 
@@ -98,6 +99,7 @@ vi.mock('../../../hooks/use-native-climb-render', () => ({
       overlayLoadKey: climbRender.overlayLoadKey,
       onOverlayLoad: vi.fn(),
       onOverlayError: vi.fn(),
+      verifyOverlayForNativeUse: climbRender.verifyOverlayForNativeUse,
       backgroundPaths: climbRender.backgroundPaths,
       missingBackgroundCount: 0,
     };

--- a/packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx
+++ b/packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx
@@ -57,7 +57,9 @@ const boardState = vi.hoisted(() => ({
 
 const climbRender = vi.hoisted(() => ({
   overlayUri: null as string | null,
+  overlayLoadKey: null as string | null,
   backgroundPaths: [] as string[],
+  useNativeClimbRender: vi.fn(),
 }));
 
 const analytics = vi.hoisted(() => ({ track: vi.fn() }));
@@ -89,11 +91,17 @@ vi.mock('../../../components/ble/use-board-connection-state', () => ({
 }));
 
 vi.mock('../../../hooks/use-native-climb-render', () => ({
-  useNativeClimbRender: () => ({
-    overlayUri: climbRender.overlayUri,
-    backgroundPaths: climbRender.backgroundPaths,
-    missingBackgroundCount: 0,
-  }),
+  useNativeClimbRender: (params: unknown) => {
+    climbRender.useNativeClimbRender(params);
+    return {
+      overlayUri: climbRender.overlayUri,
+      overlayLoadKey: climbRender.overlayLoadKey,
+      onOverlayLoad: vi.fn(),
+      onOverlayError: vi.fn(),
+      backgroundPaths: climbRender.backgroundPaths,
+      missingBackgroundCount: 0,
+    };
+  },
 }));
 
 vi.mock('../use-live-activity', () => ({
@@ -263,20 +271,25 @@ describe('LiveActivityBridge lightbulb (boardControl)', () => {
     bt.reconnectDeviceIdForCurrentBoard = null;
     analytics.track.mockClear();
     climbRender.overlayUri = null;
+    climbRender.overlayLoadKey = null;
     climbRender.backgroundPaths = [];
+    climbRender.useNativeClimbRender.mockClear();
   });
 
   it('threads the on-device thumbnail (overlay + background paths) to the notification', () => {
     climbRender.overlayUri = 'file:///cache/overlay.png';
+    climbRender.overlayLoadKey = '7:0';
     climbRender.backgroundPaths = ['/assets/kilter-bg.png'];
     renderBridge();
 
     expect(widget.useLiveActivity).toHaveBeenCalledWith(
       expect.objectContaining({
         androidThumbnailOverlayPath: 'file:///cache/overlay.png',
+        androidThumbnailOverlayLoadKey: '7:0',
         androidThumbnailBackgroundPaths: ['/assets/kilter-bg.png'],
       }),
     );
+    expect(climbRender.useNativeClimbRender).toHaveBeenCalledWith(expect.objectContaining({ verifyOverlayFile: true }));
   });
 
   it('forwards the localized lightbulb labels + on-wall template to the notification', () => {

--- a/packages/mobile/src/lib/live-activity/__tests__/use-live-activity.test.tsx
+++ b/packages/mobile/src/lib/live-activity/__tests__/use-live-activity.test.tsx
@@ -121,6 +121,26 @@ describe('useLiveActivity start-failure contract', () => {
     );
   });
 
+  it('refreshes an Android thumbnail when its generation changes at the same path', async () => {
+    plugin.startLiveActivitySession.mockResolvedValue(undefined);
+    const props = activeProps({
+      androidThumbnailOverlayPath: 'file:///cache/overlay.png',
+      androidThumbnailOverlayLoadKey: '1:0',
+    });
+    const { rerender } = render(<Harness {...props} />);
+    await waitFor(() => expect(plugin.updateLiveActivity).toHaveBeenCalled());
+    plugin.updateLiveActivity.mockClear();
+    plugin.updateLiveActivityClimb.mockClear();
+
+    rerender(<Harness {...props} androidThumbnailOverlayLoadKey="2:1" />);
+
+    await waitFor(() => expect(plugin.updateLiveActivity).toHaveBeenCalledTimes(1));
+    expect(plugin.updateLiveActivity).toHaveBeenCalledWith(
+      expect.objectContaining({ androidThumbnailOverlayPath: 'file:///cache/overlay.png' }),
+    );
+    expect(plugin.updateLiveActivityClimb).not.toHaveBeenCalled();
+  });
+
   it('does not leak updates when the session fails to start', async () => {
     // e.g. Android threw MissingBluetoothPermissionException — the native session
     // never activated, so the hook must not behave as if it did.

--- a/packages/mobile/src/lib/live-activity/__tests__/use-live-activity.test.tsx
+++ b/packages/mobile/src/lib/live-activity/__tests__/use-live-activity.test.tsx
@@ -141,6 +141,32 @@ describe('useLiveActivity start-failure contract', () => {
     expect(plugin.updateLiveActivityClimb).not.toHaveBeenCalled();
   });
 
+  it('revalidates the Android overlay immediately before a later notification push', async () => {
+    plugin.startLiveActivitySession.mockResolvedValue(undefined);
+    const validateAndroidThumbnailOverlay = vi
+      .fn<(path: string | null, loadKey: string | null) => string | null>()
+      .mockImplementation((path) => path);
+    const props = activeProps({
+      androidThumbnailOverlayPath: 'file:///cache/overlay.png',
+      androidThumbnailOverlayLoadKey: '1:0',
+      validateAndroidThumbnailOverlay,
+    });
+    const { rerender } = render(<Harness {...props} />);
+    await waitFor(() => expect(plugin.updateLiveActivity).toHaveBeenCalled());
+    expect(validateAndroidThumbnailOverlay).toHaveBeenCalledWith('file:///cache/overlay.png', '1:0');
+    plugin.updateLiveActivity.mockClear();
+    plugin.updateLiveActivityClimb.mockClear();
+    validateAndroidThumbnailOverlay.mockReturnValue(null);
+
+    rerender(<Harness {...props} boardConnection="heldByPeer" />);
+
+    await waitFor(() => expect(plugin.updateLiveActivity).toHaveBeenCalledTimes(1));
+    expect(plugin.updateLiveActivity).toHaveBeenCalledWith(
+      expect.objectContaining({ androidThumbnailOverlayPath: null }),
+    );
+    expect(validateAndroidThumbnailOverlay).toHaveBeenLastCalledWith('file:///cache/overlay.png', '1:0');
+  });
+
   it('does not leak updates when the session fails to start', async () => {
     // e.g. Android threw MissingBluetoothPermissionException — the native session
     // never activated, so the hook must not behave as if it did.

--- a/packages/mobile/src/lib/live-activity/live-activity-bridge.tsx
+++ b/packages/mobile/src/lib/live-activity/live-activity-bridge.tsx
@@ -45,7 +45,7 @@ export function LiveActivityBridge({ boardName, layoutId, sizeId, setIds }: Live
   // frames — useNativeClimbRender then no-ops its render effect instead of doing
   // work iOS discards.
   const displayClimb = state.currentClimbQueueItem?.climb ?? state.queue[0]?.climb ?? null;
-  const { overlayUri, backgroundPaths } = useNativeClimbRender({
+  const { overlayUri, overlayLoadKey, backgroundPaths } = useNativeClimbRender({
     frames: isAndroidSessionPresence ? (displayClimb?.frames ?? '') : '',
     boardName: toBoardName(boardName) ?? 'kilter',
     layoutId,
@@ -57,6 +57,9 @@ export function LiveActivityBridge({ boardName, layoutId, sizeId, setIds }: Live
     // transaction limit.
     filledStyle: true,
     renderWidth: 384,
+    // This path goes straight to native bitmap compositing and never mounts an
+    // expo-image with onError, so validate/recover it in JS before forwarding.
+    verifyOverlayFile: isAndroidSessionPresence,
   });
 
   // Localized strings for the Android foreground-service notification (channel +
@@ -94,6 +97,7 @@ export function LiveActivityBridge({ boardName, layoutId, sizeId, setIds }: Live
     holderDisplayName,
     androidNotification,
     androidThumbnailOverlayPath: overlayUri,
+    androidThumbnailOverlayLoadKey: overlayLoadKey,
     androidThumbnailBackgroundPaths: backgroundPaths,
   });
 

--- a/packages/mobile/src/lib/live-activity/live-activity-bridge.tsx
+++ b/packages/mobile/src/lib/live-activity/live-activity-bridge.tsx
@@ -45,7 +45,7 @@ export function LiveActivityBridge({ boardName, layoutId, sizeId, setIds }: Live
   // frames — useNativeClimbRender then no-ops its render effect instead of doing
   // work iOS discards.
   const displayClimb = state.currentClimbQueueItem?.climb ?? state.queue[0]?.climb ?? null;
-  const { overlayUri, overlayLoadKey, backgroundPaths } = useNativeClimbRender({
+  const { overlayUri, overlayLoadKey, verifyOverlayForNativeUse, backgroundPaths } = useNativeClimbRender({
     frames: isAndroidSessionPresence ? (displayClimb?.frames ?? '') : '',
     boardName: toBoardName(boardName) ?? 'kilter',
     layoutId,
@@ -98,6 +98,7 @@ export function LiveActivityBridge({ boardName, layoutId, sizeId, setIds }: Live
     androidNotification,
     androidThumbnailOverlayPath: overlayUri,
     androidThumbnailOverlayLoadKey: overlayLoadKey,
+    validateAndroidThumbnailOverlay: verifyOverlayForNativeUse,
     androidThumbnailBackgroundPaths: backgroundPaths,
   });
 

--- a/packages/mobile/src/lib/live-activity/use-live-activity.ts
+++ b/packages/mobile/src/lib/live-activity/use-live-activity.ts
@@ -47,6 +47,8 @@ type UseLiveActivityOptions = {
   androidNotification?: AndroidNotificationStrings;
   /** Android-only on-device thumbnail (BoardRenderer overlay + bundled backgrounds). */
   androidThumbnailOverlayPath?: string | null;
+  /** Reload identity for same-path regenerated overlays. Never forwarded to native. */
+  androidThumbnailOverlayLoadKey?: string | null;
   androidThumbnailBackgroundPaths?: string[];
 };
 
@@ -143,6 +145,7 @@ export function useLiveActivity({
   holderDisplayName,
   androidNotification,
   androidThumbnailOverlayPath,
+  androidThumbnailOverlayLoadKey,
   androidThumbnailBackgroundPaths,
 }: UseLiveActivityOptions): void {
   const isActiveRef = useRef(false);
@@ -413,6 +416,7 @@ export function useLiveActivity({
       androidThumbnailBackgroundPaths,
     });
   }, [
+    androidThumbnailOverlayLoadKey,
     androidThumbnailOverlayPath,
     // Depend on backgroundsKey, not the array itself: it changes only when the
     // resolved backgrounds change, so it re-fires the push when late-resolving
@@ -454,6 +458,7 @@ export function useLiveActivity({
       androidThumbnailBackgroundPaths,
     });
   }, [
+    androidThumbnailOverlayLoadKey,
     androidThumbnailOverlayPath,
     // See Effect 1: backgroundsKey re-fires the push on a late background resolution.
     backgroundsKey,

--- a/packages/mobile/src/lib/live-activity/use-live-activity.ts
+++ b/packages/mobile/src/lib/live-activity/use-live-activity.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Platform } from 'react-native';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 import { parseSetIds, toBoardName } from '@boardsesh/board-config';
@@ -49,6 +49,8 @@ type UseLiveActivityOptions = {
   androidThumbnailOverlayPath?: string | null;
   /** Reload identity for same-path regenerated overlays. Never forwarded to native. */
   androidThumbnailOverlayLoadKey?: string | null;
+  /** Revalidate the generated file immediately before each native notification push. */
+  validateAndroidThumbnailOverlay?: (path: string | null, loadKey: string | null) => string | null;
   androidThumbnailBackgroundPaths?: string[];
 };
 
@@ -146,6 +148,7 @@ export function useLiveActivity({
   androidNotification,
   androidThumbnailOverlayPath,
   androidThumbnailOverlayLoadKey,
+  validateAndroidThumbnailOverlay,
   androidThumbnailBackgroundPaths,
 }: UseLiveActivityOptions): void {
   const isActiveRef = useRef(false);
@@ -182,12 +185,21 @@ export function useLiveActivity({
   holderDisplayNameRef.current = holderDisplayName;
   const overlayPathRef = useRef(androidThumbnailOverlayPath);
   overlayPathRef.current = androidThumbnailOverlayPath;
+  const overlayLoadKeyRef = useRef(androidThumbnailOverlayLoadKey);
+  overlayLoadKeyRef.current = androidThumbnailOverlayLoadKey;
+  const overlayValidatorRef = useRef(validateAndroidThumbnailOverlay);
+  overlayValidatorRef.current = validateAndroidThumbnailOverlay;
   const backgroundPathsRef = useRef(androidThumbnailBackgroundPaths);
   backgroundPathsRef.current = androidThumbnailBackgroundPaths;
   const queueRef = useRef(queue);
   queueRef.current = queue;
   const currentClimbRef = useRef(currentClimbQueueItem);
   currentClimbRef.current = currentClimbQueueItem;
+  const getCurrentAndroidOverlayPath = useCallback(() => {
+    const path = overlayPathRef.current ?? null;
+    const validator = overlayValidatorRef.current;
+    return validator ? validator(path, overlayLoadKeyRef.current ?? null) : path;
+  }, []);
 
   // Memoize queue serialization so it only recomputes when the queue array
   // changes, not on every currentClimbQueueItem navigation.
@@ -315,7 +327,7 @@ export function useLiveActivity({
             isPartySession: isPartySessionRef.current,
             boardConnection: boardConnectionRef.current,
             holderDisplayName: holderDisplayNameRef.current,
-            androidThumbnailOverlayPath: overlayPathRef.current,
+            androidThumbnailOverlayPath: getCurrentAndroidOverlayPath(),
             androidThumbnailBackgroundPaths: backgroundPathsRef.current,
           });
         })
@@ -412,7 +424,7 @@ export function useLiveActivity({
       isPartySession,
       boardConnection,
       holderDisplayName,
-      androidThumbnailOverlayPath,
+      androidThumbnailOverlayPath: getCurrentAndroidOverlayPath(),
       androidThumbnailBackgroundPaths,
     });
   }, [
@@ -423,6 +435,7 @@ export function useLiveActivity({
     // backgrounds arrive (the array is read at effect time).
     backgroundsKey,
     boardConnection,
+    getCurrentAndroidOverlayPath,
     holderDisplayName,
     isPartySession,
     serializedQueue,
@@ -454,7 +467,7 @@ export function useLiveActivity({
       isPartySession,
       boardConnection,
       holderDisplayName,
-      androidThumbnailOverlayPath,
+      androidThumbnailOverlayPath: getCurrentAndroidOverlayPath(),
       androidThumbnailBackgroundPaths,
     });
   }, [
@@ -464,6 +477,7 @@ export function useLiveActivity({
     backgroundsKey,
     boardConnection,
     currentClimbQueueItem,
+    getCurrentAndroidOverlayPath,
     holderDisplayName,
     isPartySession,
     queue,


### PR DESCRIPTION
## Summary

- regenerate an evicted rendered hold overlay once and remount every affected image consumer safely
- coordinate concurrent consumers with generation-aware bounded caching so stale failures cannot overwrite newer files
- recover Android notification thumbnails without adding native changes, with privacy-safe deduplicated telemetry for terminal failures

Fixes #4113

## Validation

- independent adversarial review, including a same-URI delayed-error race: passed
- 91 focused mobile tests across six files
- full mobile suite: 4,927 tests passed before final race repair; exact repaired suite passed afterward
- vp run typecheck:mobile
- vp run check:mobile-bundle for iOS and Android
- full and scoped vp check
- pre-commit hook
- post-rebase focused suite and mobile typecheck

## Release Notes

Climb hold overlays now recover when storage pressure clears their cached image, instead of leaving a blank board or stale notification thumbnail.