### PR TITLE
fix(mobile): stabilize OTA native fingerprints

### DIFF
--- a/.github/actions/mobile-native-gate/action.yml
+++ b/.github/actions/mobile-native-gate/action.yml
@@ -70,8 +70,9 @@ runs:
         # Path screen: nothing in the canonical native-input set (mirrors the
         # ios-rn-ci Pods cache key) changed → skip without paying for a resolve.
         if [ -z "$(changed \
-              packages/mobile/package.json bun.lock packages/mobile/app.config.ts \
-              packages/mobile/plugins packages/mobile/modules patches)" ]; then
+              package.json packages/mobile/package.json bun.lock packages/mobile/app.config.ts \
+              packages/mobile/fingerprint.config.js packages/mobile/plugins \
+              packages/mobile/modules patches)" ]; then
           skip "no native-input files changed vs main"
         fi
 

--- a/.github/workflows/android-apk-rn.yml
+++ b/.github/workflows/android-apk-rn.yml
@@ -15,6 +15,8 @@ on:
       - 'packages/shared/**'
       - 'packages/board-constants/**'
       - 'packages/shared-schema/**'
+      - 'package.json' # root patchedDependencies and linker inputs affect the mobile native graph
+      - 'bun.lock'
       - 'patches/**' # bun patches to mobile deps live in root patches/, not under packages/mobile/**
       - '.github/workflows/android-apk-rn.yml'
   workflow_dispatch:

--- a/.github/workflows/android-pr-rn.yml
+++ b/.github/workflows/android-pr-rn.yml
@@ -32,6 +32,8 @@ on:
       - 'packages/shared/**'
       - 'packages/board-constants/**'
       - 'packages/shared-schema/**'
+      - 'package.json' # root patchedDependencies and linker inputs affect the mobile native graph
+      - 'bun.lock'
       - 'patches/**' # bun patches to mobile deps live in root patches/, not under packages/mobile/**
       - '.github/workflows/android-pr-rn.yml'
       - '.github/actions/android-rn-setup/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
             mobile:
               - 'packages/mobile/**'
               - 'packages/board-renderer/wasm/pkg/**'
+              - 'patches/**'
               - 'scripts/mobile-platform-imports-check.sh'
               - 'scripts/mobile-web-bundle-check.sh'
               - 'scripts/sync-mobile-board-renderer-wasm.sh'
@@ -749,6 +750,11 @@ jobs:
       # patched source is actually present on this cheap Linux runner.
       - name: Check native patches are applied
         run: vp run check:mobile-patches
+      # The resolver can return a valid fingerprint even when a source is silently
+      # absent/null. Assert the four autolinking configs, every discovered native
+      # module dir, the fingerprint config, and root patch bodies all contribute.
+      - name: Check mobile fingerprint inputs are complete
+        run: vp run check:mobile-fingerprint-inputs
       # Cheap source guard: no raw theme-variant magic-string compares regrew in
       # mobile components (they must route through the variant primitives/tokens —
       # see packages/mobile/src/theme/variants/README.md).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,10 @@ jobs:
               - 'scripts/mobile-platform-imports-check.sh'
               - 'scripts/mobile-web-bundle-check.sh'
               - 'scripts/sync-mobile-board-renderer-wasm.sh'
+              # The live fingerprint gates run in the mobile-bundle job; a PR
+              # editing only their logic must still trigger that job.
+              - 'scripts/mobile-fingerprint-inputs-check.ts'
+              - 'scripts/mobile-patches-check.ts'
             ocr:
               - 'packages/moonboard-ocr/**'
             locationSync:

--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -8,6 +8,8 @@ on:
       - 'packages/shared/**'
       - 'packages/board-constants/**'
       - 'packages/shared-schema/**'
+      - 'package.json' # root patchedDependencies and linker inputs affect the mobile native graph
+      - 'bun.lock'
       - 'patches/**' # bun patches to mobile deps live in root patches/, not under packages/mobile/**
       - '.github/workflows/ios-testflight-rn.yml'
   workflow_dispatch:

--- a/.github/workflows/mobile-ota-check.yml
+++ b/.github/workflows/mobile-ota-check.yml
@@ -25,6 +25,9 @@ on:
       - 'packages/shared/**'
       - 'packages/board-constants/**'
       - 'packages/shared-schema/**'
+      - 'package.json' # root patchedDependencies and linker inputs affect the mobile native graph
+      - 'bun.lock'
+      - 'patches/**'
       - '.github/workflows/mobile-ota-check.yml'
       # The check's own logic — so changes to it re-run and self-validate.
       - 'scripts/mobile-ota-compat-check.ts'

--- a/.github/workflows/mobile-ota-preview.yml
+++ b/.github/workflows/mobile-ota-preview.yml
@@ -61,6 +61,8 @@ on:
       - 'packages/shared/**'
       - 'packages/board-constants/**'
       - 'packages/shared-schema/**'
+      - 'package.json' # root patchedDependencies and linker inputs affect the mobile native graph
+      - 'bun.lock'
       - 'patches/**'
       - 'scripts/mobile-publish.ts'
       - 'scripts/lib/mobile-publish-retry.ts'

--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -21,6 +21,8 @@ on:
       - 'packages/shared/**'
       - 'packages/board-constants/**'
       - 'packages/shared-schema/**'
+      - 'package.json' # root patchedDependencies and linker inputs affect the mobile native graph
+      - 'bun.lock'
       - 'patches/**' # bun patches to mobile deps live in root patches/, not under packages/mobile/**
       - 'scripts/mobile-publish.ts'
       - 'scripts/lib/mobile-publish-retry.ts'

--- a/bun.lock
+++ b/bun.lock
@@ -314,6 +314,7 @@
       },
       "devDependencies": {
         "@bacons/apple-targets": "^4.0.7",
+        "@expo/fingerprint": "0.20.6",
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19.2.18",
         "babel-plugin-react-compiler": "1.0.0",
@@ -895,6 +896,7 @@
   "patchedDependencies": {
     "@expo/ui@57.0.8": "patches/@expo%2Fui@57.0.8.patch",
     "expo-dev-launcher@57.0.10": "patches/expo-dev-launcher@57.0.10.patch",
+    "@expo/fingerprint@0.20.6": "patches/@expo%2Ffingerprint@0.20.6.patch",
     "react-native-screens@4.26.2": "patches/react-native-screens@4.26.2.patch",
   },
   "overrides": {

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -86,7 +86,8 @@ install, since the device couldn't verify the manifest came from us.
    (see [Channel↔branch mapping](#channelbranch-mapping-control-plane) below); the app verifies the
    signature against the embedded cert and applies it on next launch.
 3. **runtimeVersion** uses the **`fingerprint`** policy — a hash of the native project (deps,
-   config plugins, entitlements, native dirs), resolved by Expo's bundled `@expo/fingerprint`. An
+   config plugins, entitlements, native dirs), resolved by the exact-pinned, patched
+   `@expo/fingerprint@0.20.6` installation behind Expo's `expo/fingerprint` export. An
    update only reaches a binary with the **same** fingerprint, so a JS-only change keeps the same
    fingerprint (the OTA lands) while **any native change yields a new fingerprint** — the OTA is
    intrinsically incompatible with old binaries and isn't delivered (they keep their embedded
@@ -207,8 +208,9 @@ correctly excluded. Two things make that hold:
   do exactly that — a crash** — so `scripts/mobile-ci-env-parity.test.ts` asserts the publish never
   sets the override.
 
-The fingerprint hashes the **resolved Expo config** and native files — **not** the JS bundle — so the
-publish must resolve `app.config.ts` to the same config the native `expo prebuild` did. The
+The fingerprint hashes the **resolved Expo config**, native files, the fingerprint config, and root
+Bun patch bodies — **not** the JS bundle — so the publish must resolve `app.config.ts` to the same
+config the native `expo prebuild` did. The
 config-affecting env that must match is `EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID` (drives the google-signin
 plugin's native `iosUrlScheme`), `GOOGLE_MAPS_API_KEY` (drives `android.config`), and
 `EXPO_UPDATES_URL`/`EXPO_UPDATES_CHANNEL`. The other `EXPO_PUBLIC_*` are inlined into the JS bundle;
@@ -225,6 +227,45 @@ bug, not a delivery failure. Mechanisms, all enforced/handled in CI:
   Apple Maps) and it changes the resolved config — hence the fingerprint — for the Android side. So
   the workflow publishes iOS **without** the key and Android **with** it, in separate steps. A single
   `--platform all` publish with one env could only ever match one side.
+
+### Bun isolated-linker normalization and complete native inputs
+
+Bun's isolated linker stores a package at a path like
+`node_modules/.bun/expo@57.0.9+5d294320467232ea/node_modules/expo`. The terminal hex suffix identifies
+the package's peer-resolution set. A JS/devDependency change can alter that suffix without changing
+the package name, version, or native code. Raw Expo autolinking config includes these store paths, so
+hashing them verbatim made unrelated dependency changes move runtimeVersion.
+
+`packages/mobile/fingerprint.config.js` normalizes this without hiding real native changes:
+
+- Its content hook runs for exactly four serialized sources:
+  `expoAutolinkingConfig:{ios,android}` and `rncoreAutolinkingConfig:{ios,android}`. It parses the JSON,
+  walks nested objects and arrays, and removes only the final 16-hex Bun peer suffix from a
+  SemVer-shaped `.bun/<encoded-package>@<version>/node_modules/<matching-package>` boundary. Package
+  names, prereleases, and build metadata remain in the hash. A single terminal `+<16 hex>` token is
+  necessarily treated as Bun's peer token because a path alone cannot distinguish it from SemVer
+  build metadata; when build metadata precedes a peer token, it is preserved. Malformed store entries,
+  mismatched package paths, file sources, `expoConfig`, and every other contents source are untouched.
+- Its `extraSources` hash `fingerprint.config.js` itself and the monorepo-root `../../patches`
+  directory under stable keys. Expo's built-in patch discovery only checks
+  `packages/mobile/patches`, while this repo's Bun `patchedDependencies` live at the root; without
+  the explicit source, editing native iOS/Android patch code at an unchanged package version would
+  look OTA-compatible.
+
+Expo's default `**/node_modules/**/node_modules/**` ignore also mistakes Bun's store wrapper for a
+genuine nested dependency. The exact-pinned Bun patch
+`patches/@expo%2Ffingerprint@0.20.6.patch` collapses only
+`node_modules/.bun/<entry>/node_modules/` wrappers when matching ignores and building file/directory
+hash ids. Autolinked native directories therefore contribute non-null hashes with stable logical
+ids, while a real `node_modules/package/node_modules/transitive` subtree stays ignored. The mobile
+patch check asserts both patch sentinels are installed, and the fingerprint tests assert that the
+direct mobile resolver and Expo's `expo/fingerprint` export reach the same real package path.
+
+**Native-train boundary.** Adding this coverage intentionally moves both platform fingerprints once:
+previous binaries hashed null native directories and did not include the config or root patches.
+The landing PR must stay marked `native-fingerprint`, and matching iOS and Android store builds must
+ship before OTAs under the new hashes can reach users. Do not force or backport the new JS under an
+old runtimeVersion; old binaries keep their embedded bundle until they install the new store build.
 
 **`EXPO_PUBLIC_USE_RN_FETCH=1` — pin RN's fetch, not expo/fetch.** Expo 57's WinterCG runtime installs
 `expo/fetch` as the global `fetch` unless this flag is `'1'`. `expo/fetch`'s native `NativeResponse`

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   },
   "packageManager": "bun@1.3.14",
   "patchedDependencies": {
+    "@expo/fingerprint@0.20.6": "patches/@expo%2Ffingerprint@0.20.6.patch",
     "@expo/ui@57.0.8": "patches/@expo%2Fui@57.0.8.patch",
     "expo-dev-launcher@57.0.10": "patches/expo-dev-launcher@57.0.10.patch",
     "react-native-screens@4.26.2": "patches/react-native-screens@4.26.2.patch"

--- a/packages/mobile/fingerprint.config.js
+++ b/packages/mobile/fingerprint.config.js
@@ -84,6 +84,10 @@ module.exports = {
       filePath: '../../patches',
       reasons: ['bunPatchedDependencies'],
       overrideHashKey: 'bunPatchedDependencies',
+      // The whole dir is hashed, so a future patch to a WEB-ONLY dependency
+      // would also move the fingerprint and force a store-build train. That
+      // fails in the safe direction (over-triggering); if web patches ever
+      // become common, narrow this to the mobile-reachable patch files.
     },
   ],
   fileHookTransform,

--- a/packages/mobile/fingerprint.config.js
+++ b/packages/mobile/fingerprint.config.js
@@ -29,6 +29,7 @@ const BUN_STORE_ENTRY_WITH_PEER_SUFFIX = new RegExp(
 function decodeBunStorePackageName(encodedPackageName) {
   if (!encodedPackageName.startsWith('@')) return encodedPackageName;
   const scopeSeparator = encodedPackageName.indexOf('+');
+  if (scopeSeparator === -1) return encodedPackageName;
   return `${encodedPackageName.slice(0, scopeSeparator)}/${encodedPackageName.slice(scopeSeparator + 1)}`;
 }
 
@@ -90,6 +91,7 @@ module.exports = {
   // tests so the exact allowlist and normalization boundary cannot widen silently.
   __test: {
     AUTOLINKING_SOURCE_IDS,
+    decodeBunStorePackageName,
     normalizeAutolinkingValue,
     normalizeTerminalBunPeerSuffixes,
   },

--- a/packages/mobile/fingerprint.config.js
+++ b/packages/mobile/fingerprint.config.js
@@ -1,0 +1,96 @@
+const AUTOLINKING_SOURCE_IDS = new Set([
+  'expoAutolinkingConfig:ios',
+  'expoAutolinkingConfig:android',
+  'rncoreAutolinkingConfig:ios',
+  'rncoreAutolinkingConfig:android',
+]);
+
+// Bun's isolated linker appends a peer-resolution hash to a package's store
+// directory. It describes the JS install graph, not native compatibility. Match
+// the full store boundary so arbitrary `.bun/<text>+<hex>` strings cannot be
+// rewritten, and verify that the encoded store package is the package installed
+// below node_modules before removing the final peer token.
+const BUN_STORE_MODULE_BOUNDARY =
+  /((?:^|[/\\])node_modules[/\\]\.bun[/\\])([^/\\]+)([/\\]node_modules[/\\])((?:@[^/\\]+[/\\])?[^/\\]+)/g;
+const ENCODED_PACKAGE_NAME = '((?:@[a-z0-9][a-z0-9._~-]*\\+)?[a-z0-9][a-z0-9._~-]*)';
+const SEMVER_NUMERIC_IDENTIFIER = '(?:0|[1-9]\\d*)';
+const SEMVER_NON_NUMERIC_IDENTIFIER = '(?:\\d*[A-Za-z-][0-9A-Za-z-]*)';
+const SEMVER_PRERELEASE_IDENTIFIER = `(?:${SEMVER_NUMERIC_IDENTIFIER}|${SEMVER_NON_NUMERIC_IDENTIFIER})`;
+const SEMVER_BUILD_IDENTIFIER = '[0-9A-Za-z-]+';
+const SEMVER_SHAPED_VERSION =
+  `((?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)` +
+  `(?:-${SEMVER_PRERELEASE_IDENTIFIER}(?:\\.${SEMVER_PRERELEASE_IDENTIFIER})*)?` +
+  `(?:\\+${SEMVER_BUILD_IDENTIFIER}(?:\\.${SEMVER_BUILD_IDENTIFIER})*)?)`;
+const BUN_STORE_ENTRY_WITH_PEER_SUFFIX = new RegExp(
+  `^${ENCODED_PACKAGE_NAME}@${SEMVER_SHAPED_VERSION}\\+([0-9a-f]{16})$`,
+  'i',
+);
+
+function decodeBunStorePackageName(encodedPackageName) {
+  if (!encodedPackageName.startsWith('@')) return encodedPackageName;
+  const scopeSeparator = encodedPackageName.indexOf('+');
+  return `${encodedPackageName.slice(0, scopeSeparator)}/${encodedPackageName.slice(scopeSeparator + 1)}`;
+}
+
+function normalizeTerminalBunPeerSuffixes(filePath) {
+  return filePath.replace(
+    BUN_STORE_MODULE_BOUNDARY,
+    (storePath, storePrefix, storeEntry, nodeModulesBoundary, installedPackagePath) => {
+      const entryMatch = storeEntry.match(BUN_STORE_ENTRY_WITH_PEER_SUFFIX);
+      if (entryMatch === null) return storePath;
+
+      const [, encodedPackageName, version] = entryMatch;
+      const installedPackageName = installedPackagePath.replaceAll('\\', '/');
+      if (decodeBunStorePackageName(encodedPackageName) !== installedPackageName) return storePath;
+
+      return `${storePrefix}${encodedPackageName}@${version}${nodeModulesBoundary}${installedPackagePath}`;
+    },
+  );
+}
+
+function normalizeAutolinkingValue(value) {
+  if (typeof value === 'string') return normalizeTerminalBunPeerSuffixes(value);
+  if (Array.isArray(value)) return value.map(normalizeAutolinkingValue);
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [key, normalizeAutolinkingValue(nestedValue)]),
+    );
+  }
+  return value;
+}
+
+function fileHookTransform(source, chunk) {
+  if (source.type !== 'contents' || !AUTOLINKING_SOURCE_IDS.has(source.id) || typeof chunk !== 'string') {
+    return chunk;
+  }
+  return JSON.stringify(normalizeAutolinkingValue(JSON.parse(chunk)));
+}
+
+module.exports = {
+  // @expo/fingerprint discovers patches only below packages/mobile by default.
+  // Bun's patchedDependencies live at the monorepo root, so make their bodies a
+  // first-class native input. Hash this config too: otherwise edits to the hook
+  // could silently move runtimeVersion without showing which input changed.
+  extraSources: [
+    {
+      type: 'file',
+      filePath: 'fingerprint.config.js',
+      reasons: ['boardseshFingerprintConfig'],
+      overrideHashKey: 'boardseshFingerprintConfig',
+    },
+    {
+      type: 'dir',
+      filePath: '../../patches',
+      reasons: ['bunPatchedDependencies'],
+      overrideHashKey: 'bunPatchedDependencies',
+    },
+  ],
+  fileHookTransform,
+  // Ignored by @expo/fingerprint's config loader; exported only for focused unit
+  // tests so the exact allowlist and normalization boundary cannot widen silently.
+  __test: {
+    AUTOLINKING_SOURCE_IDS,
+    normalizeAutolinkingValue,
+    normalizeTerminalBunPeerSuffixes,
+  },
+};

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -108,6 +108,7 @@
   },
   "devDependencies": {
     "@bacons/apple-targets": "^4.0.7",
+    "@expo/fingerprint": "0.20.6",
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.18",
     "babel-plugin-react-compiler": "1.0.0",

--- a/patches/@expo%2Ffingerprint@0.20.6.patch
+++ b/patches/@expo%2Ffingerprint@0.20.6.patch
@@ -1,0 +1,98 @@
+diff --git a/build/hash/Hash.js b/build/hash/Hash.js
+index f3c867f..f5b65a6 100644
+--- a/build/hash/Hash.js
++++ b/build/hash/Hash.js
+@@ -132,6 +132,6 @@ async function createFileHashResultsAsync(filePath, limiter, projectRoot, option
+                     resolve({
+                         type: 'file',
+-                        id: filePath,
++                        id: (0, Path_1.normalizeBunIsolatedModulePath)(filePath),
+                         hex,
+                         ...(debugInfo ? { debugInfo } : undefined),
+                     });
+@@ -175,6 +175,6 @@ async function createDirHashResultsAsync(dirPath, limiter, projectRoot, options,
+     const children = [];
+     for (const result of results) {
+-        hasher.update(result.id);
++        hasher.update((0, Path_1.normalizeBunIsolatedModulePath)(result.id));
+         hasher.update(result.hex);
+         children.push(result.debugInfo);
+     }
+@@ -222,10 +222,10 @@ function createSourceId(source) {
+     switch (source.type) {
+         case 'contents':
+             return source.id;
+         case 'file':
+-            return source.overrideHashKey ?? source.filePath;
++            return source.overrideHashKey ?? (0, Path_1.normalizeBunIsolatedModulePath)(source.filePath);
+         case 'dir':
+-            return source.overrideHashKey ?? source.filePath;
++            return source.overrideHashKey ?? (0, Path_1.normalizeBunIsolatedModulePath)(source.filePath);
+         default:
+             throw new Error('Unsupported source type');
+     }
+diff --git a/build/utils/Path.d.ts b/build/utils/Path.d.ts
+index 99b6b43..157bb0d 100644
+--- a/build/utils/Path.d.ts
++++ b/build/utils/Path.d.ts
+@@ -31,6 +31,11 @@ export declare function isIgnoredPathWithMatchObjects(filePath: string, matchObj
+  * @param options.stripParentPrefix
+  */
+ export declare function normalizeFilePath(filePath: string, options: { stripParentPrefix: boolean }): string;
++/**
++ * Collapse Bun isolated-linker store wrappers to their logical node_modules
++ * path so peer-resolution hashes do not affect source ids or ignore matching.
++ */
++export declare function normalizeBunIsolatedModulePath(filePath: string): string;
+ /**
+  * Convert any platform-specific path to a POSIX path.
+  */
+diff --git a/build/utils/Path.js b/build/utils/Path.js
+index 1cbfb5f..f49915e 100644
+--- a/build/utils/Path.js
++++ b/build/utils/Path.js
+@@ -7,6 +7,7 @@ exports.appendIgnorePath = appendIgnorePath;
+ exports.buildDirMatchObjects = buildDirMatchObjects;
+ exports.isIgnoredPathWithMatchObjects = isIgnoredPathWithMatchObjects;
+ exports.normalizeFilePath = normalizeFilePath;
++exports.normalizeBunIsolatedModulePath = normalizeBunIsolatedModulePath;
+ exports.toPosixPath = toPosixPath;
+ exports.pathExistsAsync = pathExistsAsync;
+ const promises_1 = __importDefault(require("fs/promises"));
+@@ -99,17 +100,34 @@ function isSubDirectory(parent, child) {
+ const STRIP_PARENT_PREFIX_REGEX = /^(\.\.\/)+/g;
+ /**
+  * Normalize the given `filePath` to be used for matching against `ignorePaths`.
+  *
+  * @param filePath The file path to normalize.
+  * @param options.stripParentPrefix
+  *   When people use fingerprint inside a monorepo, they may get source files from parent directories.
+  *   However, minimatch '**' doesn't match the parent directories.
+  *   We need to strip the `../` prefix to match the node_modules from parent directories.
+  */
+ function normalizeFilePath(filePath, options) {
++    let normalizedPath = filePath;
+     if (options.stripParentPrefix) {
+-        return filePath.replace(STRIP_PARENT_PREFIX_REGEX, '');
++        normalizedPath = normalizedPath.replace(STRIP_PARENT_PREFIX_REGEX, '');
+     }
+-    return filePath;
++    return normalizeBunIsolatedModulePath(normalizedPath);
++}
++// Bun's isolated linker stores a real package below
++// node_modules/.bun/<name>@<version>+<peer-hash>/node_modules/<name>. Expo's
++// default nested-node_modules ignore treats that implementation wrapper as a
++// nested dependency and drops the entire native source directory. Collapse the
++// wrapper before matching and before building hash ids. Repeat to support a Bun
++// store path nested below another isolated store entry.
++const BUN_ISOLATED_MODULE_ROOT_REGEX = /(^|[\\/])node_modules[\\/]\.bun[\\/][^\\/]+[\\/]node_modules[\\/]/g;
++function normalizeBunIsolatedModulePath(filePath) {
++    let normalizedPath = filePath;
++    let previousPath;
++    do {
++        previousPath = normalizedPath;
++        normalizedPath = normalizedPath.replace(BUN_ISOLATED_MODULE_ROOT_REGEX, '$1node_modules/');
++    } while (normalizedPath !== previousPath);
++    return normalizedPath;
+ }
+ const REGEXP_REPLACE_SLASHES = /\\/g;

--- a/scripts/mobile-ci-env-parity.test.ts
+++ b/scripts/mobile-ci-env-parity.test.ts
@@ -236,6 +236,10 @@ describe('mobile CI env parity (OTA fingerprint invariant)', () => {
       expect(source, `${name} must react to isolated-linker lock changes`).toContain("- 'bun.lock'");
       expect(source, `${name} must react to native patch body changes`).toContain("- 'patches/**'");
     }
+
+    expect(readWorkflow(OTA_CHECK), 'OTA compatibility must react to fingerprint config edits').toContain(
+      "- 'packages/mobile/**'",
+    );
   });
 
   it('screens root package and fingerprint-config edits inside the composite native gate', () => {

--- a/scripts/mobile-ci-env-parity.test.ts
+++ b/scripts/mobile-ci-env-parity.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
@@ -46,6 +46,11 @@ const OTA_PREVIEW = 'mobile-ota-preview.yml';
 // native builds too, or the assertion diverges from the value the shipped binary
 // actually embeds.
 const OTA_BACKPORT = 'mobile-ota-backport.yml';
+const ANDROID_PR = 'android-pr-rn.yml';
+const IOS_PR = 'ios-rn-ci.yml';
+const CI = 'ci.yml';
+const NATIVE_GATE = resolve(REPO_ROOT, '.github/actions/mobile-native-gate/action.yml');
+const OTA_COMPAT_SCRIPT = resolve(REPO_ROOT, 'scripts/mobile-ota-compat-check.ts');
 
 // Workflow-level env keys that feed the resolved config (fingerprint) and/or the
 // inlined JS bundle (runtime correctness). Every one must be declared identically
@@ -190,6 +195,83 @@ describe('mobile CI env parity (OTA fingerprint invariant)', () => {
     expect(ios).toMatch(/fingerprint-ios-/);
     expect(android).toMatch(/runtimeversion:resolve --platform android/);
     expect(android).toMatch(/fingerprint-android-/);
+  });
+
+  it('resolves every explicit workflow fingerprint through expo-updates from packages/mobile', () => {
+    const expectedWorkflowResolvers = [
+      { name: NATIVE_IOS, platform: 'ios' },
+      { name: NATIVE_ANDROID, platform: 'android' },
+      { name: OTA_BACKPORT, platform: '"$PLATFORM"' },
+    ];
+    for (const { name, platform } of expectedWorkflowResolvers) {
+      const source = readWorkflow(name);
+      const resolverCalls = source.match(/bunx expo-updates runtimeversion:resolve/g) ?? [];
+      expect(resolverCalls, `${name} must have exactly one explicit runtimeVersion resolver`).toHaveLength(1);
+      expect(source).toContain(`cd packages/mobile && bunx expo-updates runtimeversion:resolve --platform ${platform}`);
+    }
+
+    const nativeGate = readFileSync(NATIVE_GATE, 'utf8');
+    expect(nativeGate.match(/bunx expo-updates runtimeversion:resolve/g) ?? []).toHaveLength(1);
+    expect(nativeGate).toMatch(
+      /cd "\$1\/packages\/mobile"[\s\\]+&& TAILSCALE_HOSTS='' bunx expo-updates runtimeversion:resolve/,
+    );
+
+    const otaCompat = readFileSync(OTA_COMPAT_SCRIPT, 'utf8');
+    expect(otaCompat).toMatch(
+      /execFileSync\('bunx', \['expo-updates', 'runtimeversion:resolve', '--platform', platform\], \{\s*cwd: mobileDir,/,
+    );
+
+    const workflowSources = readdirSync(WORKFLOW_DIR)
+      .filter((name) => name.endsWith('.yml'))
+      .map(readWorkflow)
+      .join('\n');
+    expect(workflowSources).not.toMatch(/(?:bunx|npx) (?:@expo\/fingerprint|fingerprint:generate)/);
+  });
+
+  it('runs every automatic fingerprint surface when root linker or patch inputs change', () => {
+    const automaticFingerprintWorkflows = [NATIVE_IOS, NATIVE_ANDROID, OTA, OTA_CHECK, OTA_PREVIEW, ANDROID_PR, IOS_PR];
+    for (const name of automaticFingerprintWorkflows) {
+      const source = readWorkflow(name);
+      expect(source, `${name} must react to root patchedDependencies edits`).toContain("- 'package.json'");
+      expect(source, `${name} must react to isolated-linker lock changes`).toContain("- 'bun.lock'");
+      expect(source, `${name} must react to native patch body changes`).toContain("- 'patches/**'");
+    }
+  });
+
+  it('screens root package and fingerprint-config edits inside the composite native gate', () => {
+    const nativeGate = readFileSync(NATIVE_GATE, 'utf8');
+    const pathScreen = nativeGate.match(/# Path screen:[\s\S]*?# A candidate changed/)?.[0];
+    expect(pathScreen, 'mobile-native-gate must retain a candidate-input path screen').toBeTruthy();
+
+    const changedArguments = pathScreen?.match(/\$\(changed \\\n([\s\S]*?)\)" \]; then/)?.[1];
+    expect(changedArguments, 'could not read the composite gate changed(...) arguments').toBeTruthy();
+    const candidateInputs = changedArguments?.replaceAll('\\', ' ').trim().split(/\s+/) ?? [];
+
+    expect(candidateInputs).toEqual(
+      expect.arrayContaining([
+        'package.json',
+        'packages/mobile/package.json',
+        'bun.lock',
+        'packages/mobile/app.config.ts',
+        'packages/mobile/fingerprint.config.js',
+        'packages/mobile/plugins',
+        'packages/mobile/modules',
+        'patches',
+      ]),
+    );
+  });
+
+  it('routes patch-only PRs through the mobile fingerprint and patch sentinels', () => {
+    const ci = readWorkflow(CI);
+    const mobileFilter = ci.match(/^ {12}mobile:\n(?:^ {14}.*\n)+/m)?.[0];
+    expect(mobileFilter, 'ci.yml must retain a mobile paths-filter mapping').toBeTruthy();
+    expect(mobileFilter).toContain("- 'patches/**'");
+
+    const mobileBundleJob = ci.match(/^  mobile-bundle:\n[\s\S]*?(?=^  [a-z][a-z0-9-]*:\n|(?![\s\S]))/m)?.[0];
+    expect(mobileBundleJob, 'ci.yml must retain the mobile-bundle job').toBeTruthy();
+    expect(mobileBundleJob).toMatch(/if:.*needs\.changes\.outputs\.mobile == 'true'/);
+    expect(mobileBundleJob).toContain('run: vp run check:mobile-patches');
+    expect(mobileBundleJob).toContain('run: vp run check:mobile-fingerprint-inputs');
   });
 
   it('forces the binary onto the gate fingerprint, and the OTA publish resolves fresh (never pinned)', () => {

--- a/scripts/mobile-fingerprint-config.test.ts
+++ b/scripts/mobile-fingerprint-config.test.ts
@@ -1,0 +1,350 @@
+import { createRequire } from 'node:module';
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+type HookSource = { type: 'file'; filePath: string } | { type: 'contents'; id: string };
+type HookChunk = Buffer | string | null;
+type HashSource = {
+  type: 'file' | 'dir';
+  filePath: string;
+  reasons: string[];
+  overrideHashKey?: string;
+};
+type ExtraSource = HashSource & { overrideHashKey: string };
+type FingerprintConfig = {
+  extraSources: ExtraSource[];
+  fileHookTransform(source: HookSource, chunk: HookChunk): HookChunk;
+  __test: {
+    AUTOLINKING_SOURCE_IDS: Set<string>;
+    normalizeAutolinkingValue(value: unknown): unknown;
+    normalizeTerminalBunPeerSuffixes(filePath: string): string;
+  };
+};
+type FingerprintSource = {
+  type: string;
+  filePath?: string;
+  reasons?: string[];
+  overrideHashKey?: string;
+  hash: string | null;
+};
+type FingerprintResult = { hash: string; sources: FingerprintSource[] };
+type FingerprintApi = {
+  DEFAULT_IGNORE_PATHS: string[];
+};
+type FingerprintHashApi = {
+  createFingerprintFromSourcesAsync(
+    sources: HashSource[],
+    projectRoot: string,
+    options: Record<string, unknown>,
+  ): Promise<FingerprintResult>;
+  createSourceId(source: HashSource | FingerprintSource): string;
+};
+type PatchedPathApi = {
+  buildDirMatchObjects(matchObjects: unknown[]): unknown[];
+  buildPathMatchObjects(paths: string[]): unknown[];
+  isIgnoredPath(filePath: string, ignorePaths: string[]): boolean;
+  normalizeBunIsolatedModulePath(filePath: string): string;
+};
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const MOBILE_ROOT = resolve(REPO_ROOT, 'packages/mobile');
+const MOBILE_PACKAGE_JSON = resolve(MOBILE_ROOT, 'package.json');
+const requireFromMobile = createRequire(MOBILE_PACKAGE_JSON);
+const fingerprintConfig = requireFromMobile(resolve(MOBILE_ROOT, 'fingerprint.config.js')) as FingerprintConfig;
+const fingerprintPackageJsonPath = requireFromMobile.resolve('@expo/fingerprint/package.json');
+const fingerprintPackageRoot = dirname(fingerprintPackageJsonPath);
+const fingerprintApi = requireFromMobile('@expo/fingerprint') as FingerprintApi;
+const fingerprintHashApi = requireFromMobile(
+  resolve(fingerprintPackageRoot, 'build/hash/Hash.js'),
+) as FingerprintHashApi;
+const patchedPathApi = requireFromMobile(resolve(fingerprintPackageRoot, 'build/utils/Path.js')) as PatchedPathApi;
+
+const temporaryRoots: string[] = [];
+
+function createTemporaryRoot(): string {
+  const projectRoot = mkdtempSync(join(tmpdir(), 'boardsesh-fingerprint-'));
+  temporaryRoots.push(projectRoot);
+  return projectRoot;
+}
+
+function writeFixtureFile(projectRoot: string, relativePath: string, contents: string): void {
+  const absolutePath = resolve(projectRoot, relativePath);
+  mkdirSync(dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, contents);
+}
+
+function createHashOptions(): Record<string, unknown> {
+  const ignorePathMatchObjects = patchedPathApi.buildPathMatchObjects(fingerprintApi.DEFAULT_IGNORE_PATHS);
+  return {
+    concurrentIoLimit: 4,
+    debug: false,
+    enableReactImportsPatcher: false,
+    fileHookTransform: undefined,
+    hashAlgorithm: 'sha1',
+    ignoreDirMatchObjects: patchedPathApi.buildDirMatchObjects(ignorePathMatchObjects),
+    ignorePathMatchObjects,
+  };
+}
+
+afterEach(() => {
+  for (const projectRoot of temporaryRoots.splice(0)) rmSync(projectRoot, { recursive: true, force: true });
+});
+
+describe('mobile fingerprint config', () => {
+  it('normalizes matching package@version paths for exactly the four platform autolinking content ids', () => {
+    expect([...fingerprintConfig.__test.AUTOLINKING_SOURCE_IDS].sort()).toEqual([
+      'expoAutolinkingConfig:android',
+      'expoAutolinkingConfig:ios',
+      'rncoreAutolinkingConfig:android',
+      'rncoreAutolinkingConfig:ios',
+    ]);
+
+    const input = JSON.stringify({
+      modules: {
+        paths: [
+          '../../node_modules/.bun/expo@57.0.9-rc.2+aaaaaaaaaaaaaaaa/node_modules/expo/android',
+          '../../node_modules/.bun/@expo+metro-runtime@57.0.8+build.20260801+bbbbbbbbbbbbbbbb/' +
+            'node_modules/@expo/metro-runtime',
+        ],
+      },
+      version: '57.0.9',
+    });
+    const expected = {
+      modules: {
+        paths: [
+          '../../node_modules/.bun/expo@57.0.9-rc.2/node_modules/expo/android',
+          '../../node_modules/.bun/@expo+metro-runtime@57.0.8+build.20260801/' + 'node_modules/@expo/metro-runtime',
+        ],
+      },
+      version: '57.0.9',
+    };
+
+    for (const id of fingerprintConfig.__test.AUTOLINKING_SOURCE_IDS) {
+      const transformed = fingerprintConfig.fileHookTransform({ type: 'contents', id }, input);
+      expect(JSON.parse(String(transformed))).toEqual(expected);
+    }
+  });
+
+  it('preserves build metadata before the final peer token and documents the terminal-hex boundary', () => {
+    const buildMetadataThenPeer =
+      '../../node_modules/.bun/native@1.2.3+abcdefabcdefabcd+bbbbbbbbbbbbbbbb/node_modules/native/ios';
+    expect(fingerprintConfig.__test.normalizeTerminalBunPeerSuffixes(buildMetadataThenPeer)).toBe(
+      '../../node_modules/.bun/native@1.2.3+abcdefabcdefabcd/node_modules/native/ios',
+    );
+
+    // A lone terminal 16-hex token has the same path shape whether it is Bun's
+    // peer hash or SemVer build metadata. The hook deliberately treats this one
+    // ambiguous terminal position as Bun's peer token; preceding metadata stays.
+    const loneTerminalHex = '../../node_modules/.bun/native@1.2.3+abcdefabcdefabcd/node_modules/native/ios';
+    expect(fingerprintConfig.__test.normalizeTerminalBunPeerSuffixes(loneTerminalHex)).toBe(
+      '../../node_modules/.bun/native@1.2.3/node_modules/native/ios',
+    );
+  });
+
+  it('does not normalize malformed, mismatched, non-terminal, or non-allowlisted paths', () => {
+    const nonTerminal = '../../node_modules/.bun/expo@57.0.9+aaaaaaaaaaaaaaaa/cache/expo';
+    expect(fingerprintConfig.__test.normalizeTerminalBunPeerSuffixes(nonTerminal)).toBe(nonTerminal);
+
+    const malformedStoreEntry = '../../node_modules/.bun/cache-key+aaaaaaaaaaaaaaaa/node_modules/cache-key/native';
+    expect(fingerprintConfig.__test.normalizeTerminalBunPeerSuffixes(malformedStoreEntry)).toBe(malformedStoreEntry);
+
+    const nonSemverStoreEntry = '../../node_modules/.bun/native@latest+aaaaaaaaaaaaaaaa/node_modules/native/ios';
+    expect(fingerprintConfig.__test.normalizeTerminalBunPeerSuffixes(nonSemverStoreEntry)).toBe(nonSemverStoreEntry);
+
+    const offStoreBoundary = '../../cache/.bun/native@1.2.3+aaaaaaaaaaaaaaaa/node_modules/native/ios';
+    expect(fingerprintConfig.__test.normalizeTerminalBunPeerSuffixes(offStoreBoundary)).toBe(offStoreBoundary);
+
+    const leadingZeroPrerelease = '../../node_modules/.bun/native@1.2.3-01+aaaaaaaaaaaaaaaa/node_modules/native/ios';
+    expect(fingerprintConfig.__test.normalizeTerminalBunPeerSuffixes(leadingZeroPrerelease)).toBe(
+      leadingZeroPrerelease,
+    );
+
+    const leadingZeroPrereleaseSegment =
+      '../../node_modules/.bun/native@1.2.3-alpha.01+aaaaaaaaaaaaaaaa/node_modules/native/ios';
+    expect(fingerprintConfig.__test.normalizeTerminalBunPeerSuffixes(leadingZeroPrereleaseSegment)).toBe(
+      leadingZeroPrereleaseSegment,
+    );
+
+    const mismatchedInstalledPackage =
+      '../../node_modules/.bun/@scope+native@1.2.3+aaaaaaaaaaaaaaaa/node_modules/@scope/not-native/ios';
+    expect(fingerprintConfig.__test.normalizeTerminalBunPeerSuffixes(mismatchedInstalledPackage)).toBe(
+      mismatchedInstalledPackage,
+    );
+
+    const ordinaryBuildMetadata = '../../node_modules/.bun/native@1.2.3+build.20260801/node_modules/native/ios';
+    expect(fingerprintConfig.__test.normalizeTerminalBunPeerSuffixes(ordinaryBuildMetadata)).toBe(
+      ordinaryBuildMetadata,
+    );
+
+    const serialized = JSON.stringify({ path: nonTerminal.replace('/cache/', '/node_modules/') });
+    expect(fingerprintConfig.fileHookTransform({ type: 'contents', id: 'expoConfig' }, serialized)).toBe(serialized);
+    expect(fingerprintConfig.fileHookTransform({ type: 'file', filePath: 'autolinking.json' }, serialized)).toBe(
+      serialized,
+    );
+
+    const binaryChunk = Buffer.from(serialized);
+    expect(
+      fingerprintConfig.fileHookTransform({ type: 'contents', id: 'rncoreAutolinkingConfig:ios' }, binaryChunk),
+    ).toBe(binaryChunk);
+  });
+
+  it('fails closed when an allowlisted autolinking source is not valid JSON', () => {
+    expect(() =>
+      fingerprintConfig.fileHookTransform({ type: 'contents', id: 'expoAutolinkingConfig:ios' }, 'not-json'),
+    ).toThrow();
+  });
+
+  it('hashes the config itself and the monorepo root patches with stable keys', () => {
+    expect(fingerprintConfig.extraSources).toEqual([
+      {
+        type: 'file',
+        filePath: 'fingerprint.config.js',
+        reasons: ['boardseshFingerprintConfig'],
+        overrideHashKey: 'boardseshFingerprintConfig',
+      },
+      {
+        type: 'dir',
+        filePath: '../../patches',
+        reasons: ['bunPatchedDependencies'],
+        overrideHashKey: 'bunPatchedDependencies',
+      },
+    ]);
+  });
+});
+
+describe('patched @expo/fingerprint Bun path handling', () => {
+  it('collapses isolated store wrappers recursively but preserves genuine nested node_modules', () => {
+    const bunPath =
+      '../../node_modules/.bun/parent@1.0.0+aaaaaaaaaaaaaaaa/node_modules/parent/' +
+      'node_modules/.bun/child@2.0.0+bbbbbbbbbbbbbbbb/node_modules/child/ios';
+    expect(patchedPathApi.normalizeBunIsolatedModulePath(bunPath)).toBe(
+      '../../node_modules/parent/node_modules/child/ios',
+    );
+
+    const nestedPath = '../../node_modules/parent/node_modules/child/ios';
+    expect(patchedPathApi.normalizeBunIsolatedModulePath(nestedPath)).toBe(nestedPath);
+  });
+
+  it("unblocks Bun native dirs without weakening Expo's genuine nested-dependency ignore", () => {
+    const nestedIgnore = ['**/node_modules/**/node_modules/**'];
+    expect(
+      patchedPathApi.isIgnoredPath(
+        '../../node_modules/.bun/expo@57.0.9+aaaaaaaaaaaaaaaa/node_modules/expo/ios',
+        nestedIgnore,
+      ),
+    ).toBe(false);
+    expect(patchedPathApi.isIgnoredPath('../../node_modules/expo/node_modules/transitive/ios', nestedIgnore)).toBe(
+      true,
+    );
+  });
+
+  it('uses the production source id for stable peer variants and still hashes native body changes', async () => {
+    const projectRoot = createTemporaryRoot();
+    const firstPath = 'node_modules/.bun/native@1.0.0+aaaaaaaaaaaaaaaa/node_modules/native/ios';
+    const secondPath = 'node_modules/.bun/native@1.0.0+bbbbbbbbbbbbbbbb/node_modules/native/ios';
+    writeFixtureFile(projectRoot, `${firstPath}/Native.m`, '@interface Native : NSObject\n@end\n');
+    writeFixtureFile(projectRoot, `${secondPath}/Native.m`, '@interface Native : NSObject\n@end\n');
+
+    const resolveFor = (filePath: string) =>
+      fingerprintHashApi.createFingerprintFromSourcesAsync(
+        [
+          {
+            type: 'dir',
+            filePath,
+            reasons: ['testNativeModule'],
+          },
+        ],
+        projectRoot,
+        createHashOptions(),
+      );
+    const [first, second] = await Promise.all([resolveFor(firstPath), resolveFor(secondPath)]);
+    const firstNativeSource = first.sources.find((source) => source.filePath === firstPath);
+    const secondNativeSource = second.sources.find((source) => source.filePath === secondPath);
+
+    expect(firstNativeSource).not.toHaveProperty('overrideHashKey');
+    expect(secondNativeSource).not.toHaveProperty('overrideHashKey');
+    expect(firstNativeSource?.hash).toMatch(/^[0-9a-f]{40}$/);
+    expect(secondNativeSource?.hash).toBe(firstNativeSource?.hash);
+    expect(fingerprintHashApi.createSourceId(firstNativeSource!)).toBe('node_modules/native/ios');
+    expect(fingerprintHashApi.createSourceId(secondNativeSource!)).toBe('node_modules/native/ios');
+    expect(second.hash).toBe(first.hash);
+
+    writeFixtureFile(projectRoot, `${secondPath}/Native.m`, '@interface NativeV2 : NSObject\n@end\n');
+    const changed = await resolveFor(secondPath);
+    const changedNativeSource = changed.sources.find((source) => source.filePath === secondPath);
+
+    expect(changedNativeSource?.hash).not.toBe(firstNativeSource?.hash);
+    expect(fingerprintHashApi.createSourceId(changedNativeSource!)).toBe('node_modules/native/ios');
+    expect(changed.hash).not.toBe(first.hash);
+  });
+
+  it('changes the fingerprint when either the config or a root patch body changes', async () => {
+    async function fixtureFingerprint(configMarker: string, patchBody: string): Promise<string> {
+      const projectRoot = createTemporaryRoot();
+      writeFixtureFile(
+        projectRoot,
+        'fingerprint.config.js',
+        `// ${configMarker}\nmodule.exports = { extraSources: [` +
+          `{ type: 'file', filePath: 'fingerprint.config.js', reasons: ['config'], overrideHashKey: 'config' },` +
+          `{ type: 'dir', filePath: 'patches', reasons: ['patches'], overrideHashKey: 'patches' }` +
+          `] };\n`,
+      );
+      writeFixtureFile(projectRoot, 'patches/native.patch', patchBody);
+      return (
+        await fingerprintHashApi.createFingerprintFromSourcesAsync(
+          [
+            {
+              type: 'file',
+              filePath: 'fingerprint.config.js',
+              reasons: ['config'],
+              overrideHashKey: 'config',
+            },
+            {
+              type: 'dir',
+              filePath: 'patches',
+              reasons: ['patches'],
+              overrideHashKey: 'patches',
+            },
+          ],
+          projectRoot,
+          createHashOptions(),
+        )
+      ).hash;
+    }
+
+    const baseline = await fixtureFingerprint('config-v1', 'native patch v1\n');
+    const configChanged = await fixtureFingerprint('config-v2', 'native patch v1\n');
+    const patchChanged = await fixtureFingerprint('config-v1', 'native patch v2\n');
+
+    expect(configChanged).not.toBe(baseline);
+    expect(patchChanged).not.toBe(baseline);
+  });
+});
+
+describe('@expo/fingerprint resolver parity', () => {
+  it('exact-pins and patches the same installation loaded by expo/fingerprint', () => {
+    const mobilePackage = JSON.parse(readFileSync(MOBILE_PACKAGE_JSON, 'utf8')) as {
+      devDependencies?: Record<string, string>;
+    };
+    const rootPackage = JSON.parse(readFileSync(resolve(REPO_ROOT, 'package.json'), 'utf8')) as {
+      patchedDependencies?: Record<string, string>;
+    };
+    const installedPackage = JSON.parse(readFileSync(fingerprintPackageJsonPath, 'utf8')) as { version?: string };
+    const expoPackageJsonPath = requireFromMobile.resolve('expo/package.json');
+    const requireFromExpo = createRequire(expoPackageJsonPath);
+    const expoFingerprintPath = requireFromExpo.resolve('@expo/fingerprint/package.json');
+
+    expect(mobilePackage.devDependencies?.['@expo/fingerprint']).toBe('0.20.6');
+    expect(rootPackage.patchedDependencies?.['@expo/fingerprint@0.20.6']).toBe(
+      'patches/@expo%2Ffingerprint@0.20.6.patch',
+    );
+    expect(installedPackage.version).toBe('0.20.6');
+    expect(realpathSync(expoFingerprintPath)).toBe(realpathSync(fingerprintPackageJsonPath));
+    expect(readFileSync(resolve(dirname(expoPackageJsonPath), 'fingerprint.js'), 'utf8').trim()).toBe(
+      "module.exports = require('@expo/fingerprint');",
+    );
+  });
+});

--- a/scripts/mobile-fingerprint-config.test.ts
+++ b/scripts/mobile-fingerprint-config.test.ts
@@ -19,6 +19,7 @@ type FingerprintConfig = {
   fileHookTransform(source: HookSource, chunk: HookChunk): HookChunk;
   __test: {
     AUTOLINKING_SOURCE_IDS: Set<string>;
+    decodeBunStorePackageName(encodedPackageName: string): string;
     normalizeAutolinkingValue(value: unknown): unknown;
     normalizeTerminalBunPeerSuffixes(filePath: string): string;
   };
@@ -94,6 +95,11 @@ afterEach(() => {
 });
 
 describe('mobile fingerprint config', () => {
+  it('fails closed when a scoped store name lacks its encoded scope separator', () => {
+    expect(fingerprintConfig.__test.decodeBunStorePackageName('@scope-name')).toBe('@scope-name');
+    expect(fingerprintConfig.__test.decodeBunStorePackageName('@scope+name')).toBe('@scope/name');
+  });
+
   it('normalizes matching package@version paths for exactly the four platform autolinking content ids', () => {
     expect([...fingerprintConfig.__test.AUTOLINKING_SOURCE_IDS].sort()).toEqual([
       'expoAutolinkingConfig:android',

--- a/scripts/mobile-fingerprint-inputs-check.test.ts
+++ b/scripts/mobile-fingerprint-inputs-check.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { validateFingerprintSources, type FingerprintSource } from './mobile-fingerprint-inputs-check';
+import {
+  parseResolverOutput,
+  validateFingerprintSources,
+  type FingerprintSource,
+} from './mobile-fingerprint-inputs-check';
 
 function completeSources(platform: 'ios' | 'android'): FingerprintSource[] {
   const platformLabel = platform === 'ios' ? 'Ios' : 'Android';
@@ -64,5 +68,82 @@ describe('validateFingerprintSources', () => {
       'android: expected exactly one expoAutolinkingConfig:android contents source, found 2',
       'android: expected exactly one rncoreAutolinkingConfig:android contents source, found 0',
     ]);
+  });
+});
+
+describe('parseResolverOutput', () => {
+  const resolverResult = {
+    runtimeVersion: 'fingerprint:abc123',
+    fingerprintSources: [{ type: 'contents', id: 'source-with-} brace' }],
+  };
+
+  it('parses clean resolver JSON', () => {
+    expect(parseResolverOutput(JSON.stringify(resolverResult))).toEqual(resolverResult);
+  });
+
+  it('extracts the balanced resolver object from noisy output with unrelated braces', () => {
+    const stdout = [
+      'warning: diagnostic {not valid JSON}',
+      JSON.stringify(resolverResult),
+      'debug: finished {after payload}',
+    ].join('\n');
+
+    expect(parseResolverOutput(stdout)).toEqual(resolverResult);
+  });
+
+  it('skips a valid partial diagnostic object before the complete resolver payload', () => {
+    const stdout = [JSON.stringify({ runtimeVersion: 'diagnostic-only' }), JSON.stringify(resolverResult)].join('\n');
+
+    expect(parseResolverOutput(stdout)).toEqual(resolverResult);
+  });
+
+  it('rejects ambiguous output with two complete resolver-shaped objects', () => {
+    const diagnostic = { runtimeVersion: 'diagnostic', fingerprintSources: [] };
+    const stdout = [JSON.stringify(diagnostic), JSON.stringify(resolverResult)].join('\n');
+
+    expect(() => parseResolverOutput(stdout)).toThrow('Multiple runtimeVersion resolver JSON objects');
+  });
+
+  it('recovers from unmatched diagnostic quotes and braces before the payload', () => {
+    const stdout = ['warning unmatched " quote', '{unmatched diagnostic', JSON.stringify(resolverResult)].join('\n');
+
+    expect(parseResolverOutput(stdout)).toEqual(resolverResult);
+  });
+
+  it('recovers when unmatched diagnostic braces directly contain the payload', () => {
+    expect(parseResolverOutput(`{unmatched diagnostic ${JSON.stringify(resolverResult)}`)).toEqual(resolverResult);
+    expect(parseResolverOutput(`{unmatched diagnostic\n  ${JSON.stringify(resolverResult)}`)).toEqual(resolverResult);
+  });
+
+  it('accepts either resolver property order and still detects ambiguity', () => {
+    const reversedResult = {
+      fingerprintSources: resolverResult.fingerprintSources,
+      runtimeVersion: resolverResult.runtimeVersion,
+    };
+
+    expect(parseResolverOutput(`notice ${JSON.stringify(reversedResult)}`)).toEqual(reversedResult);
+    expect(() =>
+      parseResolverOutput(`${JSON.stringify(resolverResult)} notice ${JSON.stringify(reversedResult)}`),
+    ).toThrow('Multiple runtimeVersion resolver JSON objects');
+  });
+
+  it('ignores escaped quotes and nested braces inside resolver strings', () => {
+    const nestedResult = {
+      runtimeVersion: 'fingerprint:{abc123}',
+      fingerprintSources: [
+        {
+          type: 'contents',
+          metadata: { message: 'escaped quote: " and slash: \\ and braces: {still-a-string}' },
+        },
+      ],
+    };
+
+    expect(parseResolverOutput(`diagnostic {before}\n${JSON.stringify(nestedResult)}\n{after}`)).toEqual(nestedResult);
+  });
+
+  it('rejects output without a resolver result object', () => {
+    expect(() => parseResolverOutput('warning {"message":"not the payload"} done')).toThrow(
+      'Could not find a runtimeVersion resolver JSON object',
+    );
   });
 });

--- a/scripts/mobile-fingerprint-inputs-check.test.ts
+++ b/scripts/mobile-fingerprint-inputs-check.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { validateFingerprintSources, type FingerprintSource } from './mobile-fingerprint-inputs-check';
+
+function completeSources(platform: 'ios' | 'android'): FingerprintSource[] {
+  const platformLabel = platform === 'ios' ? 'Ios' : 'Android';
+  return [
+    {
+      type: 'contents',
+      id: `expoAutolinkingConfig:${platform}`,
+      hash: 'expo-config-hash',
+      reasons: [`expoAutolinking${platformLabel}`],
+    },
+    {
+      type: 'contents',
+      id: `rncoreAutolinkingConfig:${platform}`,
+      hash: 'rn-config-hash',
+      reasons: [`rncoreAutolinking${platformLabel}`],
+    },
+    {
+      type: 'dir',
+      filePath: `node_modules/native/${platform}`,
+      hash: 'native-hash',
+      reasons: [`expoAutolinking${platformLabel}`],
+    },
+    {
+      type: 'file',
+      filePath: 'fingerprint.config.js',
+      overrideHashKey: 'boardseshFingerprintConfig',
+      hash: 'config-hash',
+    },
+    {
+      type: 'dir',
+      filePath: '../../patches',
+      overrideHashKey: 'bunPatchedDependencies',
+      hash: 'patch-hash',
+    },
+  ];
+}
+
+describe('validateFingerprintSources', () => {
+  it.each(['ios', 'android'] as const)('accepts complete %s inputs', (platform) => {
+    expect(validateFingerprintSources(platform, completeSources(platform))).toEqual([]);
+  });
+
+  it('reports null native directories and missing config/patch sources', () => {
+    const sources = completeSources('ios').filter(
+      (source) => !['boardseshFingerprintConfig', 'bunPatchedDependencies'].includes(String(source.overrideHashKey)),
+    );
+    const nativeDirectory = sources.find((source) => source.type === 'dir');
+    if (nativeDirectory) nativeDirectory.hash = null;
+
+    expect(validateFingerprintSources('ios', sources)).toEqual([
+      expect.stringContaining('1/1 autolinked native directories have null hashes'),
+      'ios: expected exactly one boardseshFingerprintConfig source, found 0',
+      'ios: expected exactly one bunPatchedDependencies source, found 0',
+    ]);
+  });
+
+  it('requires exactly the platform-specific pair of config content sources', () => {
+    const sources = completeSources('android').filter((source) => source.id !== 'rncoreAutolinkingConfig:android');
+    sources.push({ type: 'contents', id: 'expoAutolinkingConfig:android', hash: 'duplicate' });
+
+    expect(validateFingerprintSources('android', sources)).toEqual([
+      'android: expected exactly one expoAutolinkingConfig:android contents source, found 2',
+      'android: expected exactly one rncoreAutolinkingConfig:android contents source, found 0',
+    ]);
+  });
+});

--- a/scripts/mobile-fingerprint-inputs-check.ts
+++ b/scripts/mobile-fingerprint-inputs-check.ts
@@ -1,0 +1,161 @@
+/// <reference types="node" />
+
+/**
+ * Verifies the real expo-updates runtimeVersion resolver sees every Boardsesh
+ * fingerprint hardening input. This catches regressions that unit tests cannot:
+ * a changed Expo source id, a dropped Bun patch, or an extraSources path that no
+ * longer resolves would otherwise produce a valid-looking hash with missing
+ * native coverage.
+ *
+ * Usage: vp run check:mobile-fingerprint-inputs
+ */
+
+import { execFileSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+export type Platform = 'ios' | 'android';
+
+export interface FingerprintSource {
+  type?: unknown;
+  id?: unknown;
+  filePath?: unknown;
+  overrideHashKey?: unknown;
+  hash?: unknown;
+  reasons?: unknown;
+}
+
+interface RuntimeVersionResult {
+  runtimeVersion?: unknown;
+  fingerprintSources?: unknown;
+}
+
+const AUTOLINKING_REASON_BY_PLATFORM: Record<Platform, Set<string>> = {
+  ios: new Set(['expoAutolinkingIos', 'rncoreAutolinkingIos']),
+  android: new Set(['expoAutolinkingAndroid', 'rncoreAutolinkingAndroid']),
+};
+
+function hasAutolinkingReason(source: FingerprintSource, platform: Platform): boolean {
+  return (
+    Array.isArray(source.reasons) &&
+    source.reasons.some((reason) => typeof reason === 'string' && AUTOLINKING_REASON_BY_PLATFORM[platform].has(reason))
+  );
+}
+
+/** Pure invariant check for one resolver result. Empty means complete coverage. */
+export function validateFingerprintSources(platform: Platform, sources: readonly FingerprintSource[]): string[] {
+  const errors: string[] = [];
+  const expectedContentsIds = [`expoAutolinkingConfig:${platform}`, `rncoreAutolinkingConfig:${platform}`];
+
+  for (const id of expectedContentsIds) {
+    const matches = sources.filter((source) => source.type === 'contents' && source.id === id);
+    if (matches.length !== 1) {
+      errors.push(`${platform}: expected exactly one ${id} contents source, found ${matches.length}`);
+    } else if (typeof matches[0]?.hash !== 'string') {
+      errors.push(`${platform}: ${id} has a null hash`);
+    }
+  }
+
+  const nativeDirectories = sources.filter((source) => source.type === 'dir' && hasAutolinkingReason(source, platform));
+  if (nativeDirectories.length === 0) {
+    errors.push(`${platform}: no autolinked native directory sources were discovered`);
+  }
+  const nullNativeDirectories = nativeDirectories.filter((source) => typeof source.hash !== 'string');
+  if (nullNativeDirectories.length > 0) {
+    const examples = nullNativeDirectories
+      .slice(0, 3)
+      .map((source) => String(source.filePath))
+      .join(', ');
+    errors.push(
+      `${platform}: ${nullNativeDirectories.length}/${nativeDirectories.length} autolinked native directories ` +
+        `have null hashes (for example: ${examples})`,
+    );
+  }
+
+  const expectedExtraSources = [
+    {
+      overrideHashKey: 'boardseshFingerprintConfig',
+      type: 'file',
+      filePath: 'fingerprint.config.js',
+    },
+    {
+      overrideHashKey: 'bunPatchedDependencies',
+      type: 'dir',
+      filePath: '../../patches',
+    },
+  ];
+  for (const expected of expectedExtraSources) {
+    const matches = sources.filter(
+      (source) =>
+        source.overrideHashKey === expected.overrideHashKey &&
+        source.type === expected.type &&
+        source.filePath === expected.filePath,
+    );
+    if (matches.length !== 1) {
+      errors.push(`${platform}: expected exactly one ${expected.overrideHashKey} source, found ${matches.length}`);
+    } else if (typeof matches[0]?.hash !== 'string') {
+      errors.push(`${platform}: ${expected.overrideHashKey} has a null hash`);
+    }
+  }
+
+  return errors;
+}
+
+function parseResolverOutput(stdout: string): RuntimeVersionResult {
+  const trimmed = stdout.trim();
+  const candidate = trimmed.match(/\{[\s\S]*\}/)?.[0] ?? trimmed;
+  return JSON.parse(candidate) as RuntimeVersionResult;
+}
+
+function resolveFingerprintSources(mobileRoot: string, platform: Platform): FingerprintSource[] {
+  const childEnv = { ...process.env };
+  if (platform === 'ios') delete childEnv.GOOGLE_MAPS_API_KEY;
+  const stdout = execFileSync('bunx', ['expo-updates', 'runtimeversion:resolve', '--platform', platform], {
+    cwd: mobileRoot,
+    encoding: 'utf8',
+    env: childEnv,
+    maxBuffer: 32 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'inherit'],
+  });
+  const parsed = parseResolverOutput(stdout);
+  if (typeof parsed.runtimeVersion !== 'string' || !Array.isArray(parsed.fingerprintSources)) {
+    throw new Error(`${platform}: resolver returned no runtimeVersion/fingerprintSources`);
+  }
+  return parsed.fingerprintSources as FingerprintSource[];
+}
+
+export function main(): number {
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+  const mobileRoot = resolve(repoRoot, 'packages/mobile');
+  const errors: string[] = [];
+
+  for (const platform of ['ios', 'android'] as const) {
+    try {
+      const sources = resolveFingerprintSources(mobileRoot, platform);
+      const platformErrors = validateFingerprintSources(platform, sources);
+      errors.push(...platformErrors);
+      if (platformErrors.length === 0) {
+        const nativeDirectoryCount = sources.filter(
+          (source) => source.type === 'dir' && hasAutolinkingReason(source, platform),
+        ).length;
+        console.log(
+          `[mobile-fingerprint-inputs] ${platform}: ${nativeDirectoryCount} autolinked native dirs + config + patches hashed.`,
+        );
+      }
+    } catch (error) {
+      errors.push(`${platform}: resolver failed (${(error as Error).message})`);
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error('[mobile-fingerprint-inputs] FAILED:');
+    for (const error of errors) console.error(`  ✗ ${error}`);
+    return 1;
+  }
+  console.log('[mobile-fingerprint-inputs] OK — fingerprint inputs are complete on both platforms.');
+  return 0;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(main());
+}

--- a/scripts/mobile-fingerprint-inputs-check.ts
+++ b/scripts/mobile-fingerprint-inputs-check.ts
@@ -101,10 +101,116 @@ export function validateFingerprintSources(platform: Platform, sources: readonly
   return errors;
 }
 
-function parseResolverOutput(stdout: string): RuntimeVersionResult {
+function isRuntimeVersionResult(candidate: unknown): candidate is RuntimeVersionResult {
+  return (
+    typeof candidate === 'object' &&
+    candidate !== null &&
+    'runtimeVersion' in candidate &&
+    typeof candidate.runtimeVersion === 'string' &&
+    'fingerprintSources' in candidate &&
+    Array.isArray(candidate.fingerprintSources)
+  );
+}
+
+export function parseResolverOutput(stdout: string): RuntimeVersionResult {
   const trimmed = stdout.trim();
-  const candidate = trimmed.match(/\{[\s\S]*\}/)?.[0] ?? trimmed;
-  return JSON.parse(candidate) as RuntimeVersionResult;
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (isRuntimeVersionResult(parsed)) return parsed;
+  } catch {
+    // Resolver wrappers may print diagnostics before or after the JSON payload.
+  }
+
+  type ObjectCandidate = {
+    start: number;
+    hasRuntimeVersionKey: boolean;
+    hasFingerprintSourcesKey: boolean;
+  };
+
+  const objectCandidates: ObjectCandidate[] = [];
+  let insideString = false;
+  let escaped = false;
+  let stringStart = -1;
+  let pendingKey: { candidate: ObjectCandidate; name: 'runtimeVersion' | 'fingerprintSources' } | undefined;
+  let matchedResult: RuntimeVersionResult | null = null;
+  let remainingParseBudget = trimmed.length * 2;
+  for (let index = 0; index < trimmed.length; index += 1) {
+    const character = trimmed[index];
+
+    if (insideString) {
+      if (character === '\n' || character === '\r') {
+        // JSON strings cannot contain raw newlines. Recover from an unmatched
+        // quote in a diagnostic without discarding balanced objects spanning
+        // otherwise-valid pretty-printed JSON lines.
+        insideString = false;
+        escaped = false;
+        stringStart = -1;
+        pendingKey = undefined;
+        objectCandidates.length = 0;
+      } else if (escaped) {
+        escaped = false;
+      } else if (character === '\\') {
+        escaped = true;
+      } else if (character === '"') {
+        insideString = false;
+        const rawString = trimmed.slice(stringStart + 1, index);
+        const candidate = objectCandidates.at(-1);
+        if (candidate && (rawString === 'runtimeVersion' || rawString === 'fingerprintSources')) {
+          pendingKey = { candidate, name: rawString };
+        }
+        stringStart = -1;
+      }
+      continue;
+    }
+
+    if (pendingKey) {
+      if (/\s/.test(character)) continue;
+      if (character === ':' && objectCandidates.at(-1) === pendingKey.candidate) {
+        if (pendingKey.name === 'runtimeVersion') pendingKey.candidate.hasRuntimeVersionKey = true;
+        else pendingKey.candidate.hasFingerprintSourcesKey = true;
+      }
+      pendingKey = undefined;
+    }
+
+    if (character === '"') {
+      insideString = true;
+      stringStart = index;
+      continue;
+    }
+
+    if (character === '{') {
+      objectCandidates.push({
+        start: index,
+        hasRuntimeVersionKey: false,
+        hasFingerprintSourcesKey: false,
+      });
+      continue;
+    }
+    if (character !== '}') continue;
+    const completedCandidate = objectCandidates.pop();
+    if (!completedCandidate) continue;
+    if (!completedCandidate.hasRuntimeVersionKey || !completedCandidate.hasFingerprintSourcesKey) continue;
+
+    const candidate = trimmed.slice(completedCandidate.start, index + 1);
+    remainingParseBudget -= candidate.length;
+    if (remainingParseBudget < 0) {
+      throw new Error('Too many resolver-shaped JSON objects found in stdout');
+    }
+    try {
+      const parsed = JSON.parse(candidate) as unknown;
+      if (!isRuntimeVersionResult(parsed)) continue;
+      if (matchedResult !== null) {
+        throw new Error('Multiple runtimeVersion resolver JSON objects found in stdout');
+      }
+      matchedResult = parsed;
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith('Multiple runtimeVersion')) throw error;
+      // Keep scanning: a diagnostic may contain braces before the payload.
+    }
+  }
+
+  if (matchedResult !== null) return matchedResult;
+  throw new Error('Could not find a runtimeVersion resolver JSON object in stdout');
 }
 
 function resolveFingerprintSources(mobileRoot: string, platform: Platform): FingerprintSource[] {

--- a/scripts/mobile-patches-check.ts
+++ b/scripts/mobile-patches-check.ts
@@ -25,6 +25,11 @@
  * unhandled rejection on older store binaries) and the iOS wiring is what
  * makes `onFullyDismissed` ever fire. Neither shows up in a bundle.
  *
+ * For @expo/fingerprint, the patch makes Bun's isolated-linker package roots
+ * hashable and gives their files stable logical ids. Without it, Expo mistakes
+ * every autolinked native module for a nested node_modules directory and hashes
+ * the source as null; peer-resolution store suffixes also leak into hash ids.
+ *
  * This check resolves the COPY packages/mobile actually uses (the same one
  * CocoaPods compiles) and asserts the patch's sentinel symbols are present in
  * the installed source. It fails the PR on a cheap Linux runner the instant a
@@ -62,6 +67,18 @@ export interface PatchRule {
  * patch stays unguarded. Guarding it needs resolution via its parent first.
  */
 export const RULES: readonly PatchRule[] = [
+  {
+    package: '@expo/fingerprint',
+    file: 'build/utils/Path.js',
+    sentinels: ['normalizeBunIsolatedModulePath', 'BUN_ISOLATED_MODULE_ROOT_REGEX'],
+    patchedKey: '@expo/fingerprint@0.20.6',
+  },
+  {
+    package: '@expo/fingerprint',
+    file: 'build/hash/Hash.js',
+    sentinels: ['normalizeBunIsolatedModulePath'],
+    patchedKey: '@expo/fingerprint@0.20.6',
+  },
   {
     package: 'react-native-screens',
     file: 'ios/helpers/scroll-view/RNSScrollViewFinder.mm',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -665,6 +665,10 @@ export default defineConfig({
         command: 'tsx scripts/mobile-ota-compat-check.ts',
         cache: false,
       },
+      'check:mobile-fingerprint-inputs': {
+        command: 'tsx scripts/mobile-fingerprint-inputs-check.ts',
+        cache: false,
+      },
       'check:mobile-patches': {
         command: 'tsx scripts/mobile-patches-check.ts',
         cache: false,


### PR DESCRIPTION
## Summary

- normalize only Bun peer-resolution suffixes in the four native autolinking fingerprint sources while preserving package names and valid SemVer
- make direct native module directories, the fingerprint configuration, and root patch bodies contribute to both platform fingerprints
- gate every OTA/native workflow on the complete input set, enforce it in CI, and document the one-time native-train boundary

Closes #4122

## Release Notes

Keep receiving over-the-air fixes after JavaScript-only dependency updates.

## Test plan

- independent adversarial implementation review and focused re-review: pass
- `vp test run scripts/mobile-fingerprint-config.test.ts scripts/mobile-fingerprint-inputs-check.test.ts scripts/mobile-ci-env-parity.test.ts` — 48 tests pass after rebase
- `vp node scripts/mobile-fingerprint-inputs-check.ts` — 67 iOS and 68 Android native directories plus config and patches are hashed
- `vp node scripts/mobile-patches-check.ts` — all six native patches are applied
- `vp run typecheck:mobile`
- `vp run test:mobile` — 575 files / 4,912 tests pass
- `vp run check:mobile-bundle` — iOS and Android bundles pass
- touched-file `vp check`, `git diff --check`, and the mandatory pre-commit hook

This intentionally changes the native fingerprint once. Matching iOS and Android store builds must ship before OTAs produced from the new fingerprint can reach users.
