### PR TITLE
fix(mobile): recover Android OAuth callbacks

### DIFF
--- a/docs/mobile-auth-flow.md
+++ b/docs/mobile-auth-flow.md
@@ -11,7 +11,7 @@ See [`expo-web-deployment.md`](./expo-web-deployment.md#browser-authentication).
 
 ## Token exchange flow
 
-1. The mobile app opens the OAuth provider (Google/Apple) in a system browser via `expo-web-browser`'s `openAuthSessionAsync(url, 'com.boardsesh.app://auth/callback')` (`packages/mobile/src/lib/auth.ts`).
+1. The mobile app first uses the native Google/Apple provider SDK. If that SDK hits a supported presentation/configuration failure, the browser fallback opens the web app's `/auth/native-start` flow with `expo-web-browser`'s `openBrowserAsync` (`packages/mobile/src/lib/auth.ts`).
 2. The OAuth callback on the Next.js web app creates a **transfer token** -- an HMAC-SHA256 signed payload containing the authenticated `userId`, `iat`, and `exp`. The token is valid for 120 seconds.
 3. The web app redirects to `com.boardsesh.app://auth/callback?transferToken=...`. How that callback reaches the app differs by platform -- see [Callback delivery](#callback-delivery-ios-vs-android) below.
 4. The mobile app sends the transfer token to `POST /auth/native/exchange`.
@@ -20,14 +20,16 @@ See [`expo-web-deployment.md`](./expo-web-deployment.md#browser-authentication).
 
 ## Callback delivery (iOS vs Android)
 
-The redirect to the `com.boardsesh.app://auth/callback` scheme is **not** uniformly delivered as a deep link:
+The browser fallback registers its `Linking` callback listener before opening the browser on both platforms. `app/+native-intent.ts` returns an empty route for this callback so Expo Router does not also navigate to a non-existent `/auth/callback` screen. `raceBrowserSignIn` owns parsing and exchanging the one-time transfer token.
 
-- **iOS:** `openAuthSessionAsync` uses `ASWebAuthenticationSession`, which _consumes_ the redirect and returns it as the function's result: `{ type: 'success', url: 'com.boardsesh.app://auth/callback?transferToken=...' }`. The OS never delivers the URL to the app as a deep link, so expo-router never routes it. The login screen (`packages/mobile/app/auth/login.tsx`) must parse `result.url` (via `parseAuthCallbackParams` in `packages/mobile/src/lib/auth-callback-url.ts`) and route the token to the `/auth/callback` screen itself.
-- **Android:** `openAuthSessionAsync` is polyfilled with a Custom Tab plus a `Linking` URL listener. The redirect arrives as a real deep link, which expo-router _also_ routes -- so `/auth/callback` can mount twice for the same token: once from expo-router's own deep-link handling and once from the login screen's explicit navigation.
+- **iOS:** `openBrowserAsync` remains pending until its `SFSafariViewController` closes. A matching `Linking` callback wins the race and dismisses the controller. A terminal browser resolution without a callback is a user cancel, and a browser rejection is `browser_unavailable`. The Android AppState and timeout rules are not registered on iOS.
+- **Android:** `openBrowserAsync` resolves with `{ type: 'opened' }` as soon as the Custom Tab launches. That result is nonterminal: the callback and AppState listeners stay registered. Only an observed post-registration `background` -> `active` transition starts a one-second callback grace; a matching callback wins, otherwise the attempt is cancelled. Unrelated URLs and lone `active` events are ignored. A second `background` event cancels a pending grace until the app becomes active again.
 
-Because transfer tokens are one-time use, `app/auth/callback.tsx` deduplicates the exchange with a module-level `Set` of already-exchanged tokens. The duplicate mount shows the spinner until `AuthProvider` redirects out of the auth group; without the dedup, the second exchange would hit the replay guard (`409`) and flash an error after a successful login. The set grows by one short string per login attempt for the process lifetime, which is negligible.
+Android also has a five-minute bound. If it expires while the app is backgrounded, settlement waits for the next foreground plus the same one-second callback grace so a resumed `Linking` event can still win. Otherwise it gives one final one-second grace and returns the distinct `browser_timeout` failure. Browser rejections remain `browser_unavailable`; terminal cancel/dismiss and unknown terminal results cancel without hanging.
 
-A `?error=...` query param on the callback (e.g. `session_missing`, `token_issue_failed`) means the web side could not issue a token; the login screen surfaces it as a translated error.
+While either browser fallback wrapper is pending, `AuthProvider` reference-counts the attempts and skips only its generic foreground auth read. This prevents Android's early `active` event from reading credentials before the transfer-token exchange. A successful wrapper still performs its explicit auth read after exchange; cancellation and failure release the suppression.
+
+A `?error=...` query param on the callback (for example `session_missing` or `token_issue_failed`) means the web side could not issue a token; the login screen surfaces it as a translated error.
 
 ## Token format
 
@@ -216,6 +218,7 @@ Revoke all refresh tokens for the user associated with the submitted token (full
 
 ## Known limitations
 
+- **Cold-start/process-death callback recovery is not implemented.** The fallback listeners and in-flight state live in the app process. If Android kills the process while the Custom Tab is open, a later callback can cold-start the app without the original race available to exchange it. Recovering that callback needs a durable pending-attempt record plus cold-start token handoff and is a separate follow-up; this change only fixes warm-process Custom Tab returns.
 - **JWTs cannot be revoked before expiry (7-day window).** Once issued, a JWT is valid until it expires. If a JWT is stolen, it can be used for up to 7 days. Mitigation: short lifetime (7 days instead of 30) combined with refresh token rotation means the window is bounded and a revoke call invalidates future refreshes immediately.
 - **Token validation results are cached for up to 60 seconds.** Successful validation results are cached in-process for up to 60 seconds. A revoked JWT may continue to authenticate for up to 60 seconds after revocation. This is standard for JWT-based systems and is the trade-off for avoiding cryptographic verification on every request. Failed validations are not cached, so transient errors (e.g. secret unset during restart) resolve as soon as the underlying issue is fixed.
 - **Rate limiting is per-instance when not behind a single proxy.** The IP-based rate limiter uses an in-memory map, so each backend instance maintains its own counters. In a multi-instance deployment without a shared proxy, an attacker could spread requests across instances to exceed the intended limit. Mitigation: Redis-backed replay prevention covers the highest-risk path (transfer token exchange), and refresh token rotation is inherently safe against replay.

--- a/packages/mobile/src/hooks/__tests__/use-native-oauth-sign-in.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-oauth-sign-in.test.tsx
@@ -464,6 +464,38 @@ describe('useNativeOAuthSignIn — Android Google config-class fallback (#3100)'
     expect(reportErrorMock).not.toHaveBeenCalled();
   });
 
+  it('reports browser timeout as a warning failure with the generic OAuth copy', async () => {
+    signInWithGoogleMock.mockRejectedValue(Object.assign(new Error('developer error'), { code: 'DEVELOPER_ERROR' }));
+    signInWithGoogleWebMock.mockResolvedValue({ success: false, status: null, error: 'browser_timeout' });
+
+    const setError = await runSignIn('google');
+
+    expect(trackedEvents()).toContainEqual({
+      event: 'Login Failed',
+      flow: 'web_fallback',
+      reason: 'browser_timeout',
+      recoverable: undefined,
+      mechanism: 'browser_deeplink',
+    });
+    expect(trackedEvents()).not.toContainEqual(
+      expect.objectContaining({ event: 'Login Cancelled', flow: 'web_fallback' }),
+    );
+    expect(trackedEvents()).not.toContainEqual(
+      expect.objectContaining({ flow: 'web_fallback', reason: 'browser_unavailable' }),
+    );
+    expect(reportErrorMock).toHaveBeenCalledWith(expect.any(Error), {
+      level: 'warning',
+      tags: {
+        source: 'native-auth',
+        provider: 'google',
+        flow: 'web_fallback',
+        failure_reason: 'browser_timeout',
+      },
+      extra: { status: null, server_error: 'browser_timeout' },
+    });
+    expect(setError).toHaveBeenLastCalledWith('nativeStart.oauthError');
+  });
+
   it('surfaces the native error (no fallback) for a non-config Google throw — NETWORK_ERROR (7)', async () => {
     // Strict scope: only DEVELOPER_ERROR / INTERNAL_ERROR recover. A transient
     // NETWORK_ERROR keeps surfacing its native error rather than bouncing to a browser.

--- a/packages/mobile/src/hooks/use-native-oauth-sign-in.ts
+++ b/packages/mobile/src/hooks/use-native-oauth-sign-in.ts
@@ -70,8 +70,9 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
       // the flow dying programmatically (sub-second).
       const attemptStartedAt = Date.now();
 
-      // Browser-OAuth fallback, iOS-only, for both Google and Apple. The native
-      // SDK can fail before any network call — Google on iOS 26.5.1 (GIDSignIn
+      // Browser-OAuth fallback for both providers on iOS and for recoverable
+      // Android Google config errors. The native SDK can fail before any network
+      // call — Google on iOS 26.5.1 (GIDSignIn
       // "Unable to open Safari"), Apple on ASAuthorizationError.unknown (code
       // 1000: device not signed into iCloud, 2FA disabled, transient Apple ID
       // issues) — and that failure isn't fatal: the web NextAuth handoff completes
@@ -79,11 +80,9 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
       // flow: 'web_fallback' so we can measure how often it rescues a native
       // failure, and fully owns the outcome (success returns, a browser cancel
       // stays silent, a real failure reaches error tracking + the error region).
-      // Not used on Android: the redirect to com.boardsesh.app://auth/callback
-      // doesn't reliably return through openAuthSessionAsync there, an Android
-      // native Google failure is almost always an unregistered signing-cert SHA-1
-      // (a Google Cloud fix), and Apple sign-in isn't offered on Android at all —
-      // so we surface the real error instead (see auth.ts).
+      // Android's Google fallback keeps its Custom Tab deep-link listener alive
+      // after `opened`; it remains deliberately limited to the config-class
+      // failures below. Apple sign-in is not offered on Android.
       // Keyed by provider so the map is exhaustive: extending Provider without a
       // web fn here is a type error, rather than silently routing the new provider
       // to the Google flow.
@@ -155,7 +154,7 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
           ...registrationProps,
         });
         reportError(new Error(`Web-fallback ${provider} sign-in failed: ${fallback.error}`), {
-          level: fallback.error === 'network' ? 'warning' : 'error',
+          level: fallback.error === 'network' || fallback.error === 'browser_timeout' ? 'warning' : 'error',
           tags: { source: 'native-auth', provider, flow: 'web_fallback', failure_reason: fallbackReason },
           extra: { status: fallback.status, server_error: fallback.error },
         });

--- a/packages/mobile/src/lib/__tests__/auth-google-web.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth-google-web.test.ts
@@ -179,25 +179,31 @@ describe('signInWithGoogleWeb', () => {
   });
 
   it('keeps the Android listener alive after opened and exchanges the callback after foregrounding', async () => {
-    platformState.OS = 'android';
-    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(okExchange());
+    vi.useFakeTimers();
+    try {
+      platformState.OS = 'android';
+      const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(okExchange());
 
-    const racePromise = signInWithGoogleWeb();
-    resolveBrowserResult({ type: 'opened' });
-    await Promise.resolve();
-    expect(removeListenerMock).not.toHaveBeenCalled();
+      const racePromise = signInWithGoogleWeb();
+      resolveBrowserResult({ type: 'opened' });
+      await Promise.resolve();
+      expect(removeListenerMock).not.toHaveBeenCalled();
 
-    fireAppState('background');
-    fireAppState('active');
-    fireDeepLink(`${CALLBACK_SCHEME}?transferToken=android-tok`);
+      fireAppState('background');
+      fireAppState('active');
+      fireDeepLink(`${CALLBACK_SCHEME}?transferToken=android-tok`);
 
-    await expect(racePromise).resolves.toEqual({ success: true });
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://backend.test/auth/native/exchange',
-      expect.objectContaining({ body: JSON.stringify({ transferToken: 'android-tok' }) }),
-    );
-    expect(removeListenerMock).toHaveBeenCalledOnce();
-    expect(removeAppStateListenerMock).toHaveBeenCalledOnce();
+      await expect(racePromise).resolves.toEqual({ success: true });
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://backend.test/auth/native/exchange',
+        expect.objectContaining({ body: JSON.stringify({ transferToken: 'android-tok' }) }),
+      );
+      expect(removeListenerMock).toHaveBeenCalledOnce();
+      expect(removeAppStateListenerMock).toHaveBeenCalledOnce();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('maps an exhausted Android callback race to browser_timeout', async () => {

--- a/packages/mobile/src/lib/__tests__/auth-google-web.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth-google-web.test.ts
@@ -11,8 +11,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // the browser promise, letting each test fire the deep link, close the browser,
 // or fail it to open — in any order.
 let urlListener: ((event: { url: string }) => void) | null = null;
-let resolveBrowser: (() => void) | null = null;
+let appStateListener: ((state: 'active' | 'background' | 'inactive' | 'unknown' | 'extension') => void) | null = null;
+let currentAppState: 'active' | 'background' | 'inactive' | 'unknown' | 'extension' | null = 'active';
+let resolveBrowser: ((result: unknown) => void) | null = null;
 let rejectBrowser: ((reason: unknown) => void) | null = null;
+const platformState = { OS: 'ios' };
 
 const removeListenerMock = vi.fn(() => {
   urlListener = null;
@@ -21,9 +24,27 @@ const addEventListenerMock = vi.fn((_event: string, listener: (event: { url: str
   urlListener = listener;
   return { remove: removeListenerMock };
 });
+const removeAppStateListenerMock = vi.fn(() => {
+  appStateListener = null;
+});
+const addAppStateEventListenerMock = vi.fn(
+  (_event: string, listener: (state: 'active' | 'background' | 'inactive' | 'unknown' | 'extension') => void) => {
+    appStateListener = listener;
+    return { remove: removeAppStateListenerMock };
+  },
+);
 
 vi.mock('react-native', () => ({
-  Platform: { OS: 'ios' },
+  Platform: platformState,
+  AppState: {
+    get currentState() {
+      return currentAppState;
+    },
+    addEventListener: (
+      event: string,
+      listener: (state: 'active' | 'background' | 'inactive' | 'unknown' | 'extension') => void,
+    ) => addAppStateEventListenerMock(event, listener),
+  },
   Linking: {
     addEventListener: (event: string, listener: (event: { url: string }) => void) =>
       addEventListenerMock(event, listener),
@@ -82,15 +103,20 @@ const CALLBACK_SCHEME = 'com.boardsesh.app://auth/callback';
 function armBrowser() {
   openBrowserAsyncMock.mockImplementation(
     () =>
-      new Promise<void>((resolve, reject) => {
+      new Promise<unknown>((resolve, reject) => {
         resolveBrowser = resolve;
         rejectBrowser = reject;
       }),
   );
 }
 const fireDeepLink = (url: string) => urlListener?.({ url });
-const closeBrowser = () => resolveBrowser?.();
+const resolveBrowserResult = (result: unknown) => resolveBrowser?.(result);
+const closeBrowser = () => resolveBrowserResult({ type: 'dismiss' });
 const failBrowser = (reason: unknown) => rejectBrowser?.(reason);
+const fireAppState = (state: 'active' | 'background' | 'inactive' | 'unknown' | 'extension') => {
+  currentAppState = state;
+  appStateListener?.(state);
+};
 
 const okExchange = () =>
   new Response(JSON.stringify({ jwt: 'jwt-1', refreshToken: 'refresh-1', expiresAt: '2026-01-01T00:00:00.000Z' }), {
@@ -99,6 +125,9 @@ const okExchange = () =>
 
 function resetMocks() {
   urlListener = null;
+  appStateListener = null;
+  currentAppState = 'active';
+  platformState.OS = 'ios';
   resolveBrowser = null;
   rejectBrowser = null;
   openBrowserAsyncMock.mockReset();
@@ -106,6 +135,8 @@ function resetMocks() {
   dismissBrowserMock.mockResolvedValue(undefined);
   removeListenerMock.mockClear();
   addEventListenerMock.mockClear();
+  removeAppStateListenerMock.mockClear();
+  addAppStateEventListenerMock.mockClear();
   storeTokensMock.mockReset();
   clearTokensForGenerationMock.mockReset();
   clearTokensForGenerationMock.mockResolvedValue(true);
@@ -145,6 +176,46 @@ describe('signInWithGoogleWeb', () => {
       expect.objectContaining({ method: 'POST', body: JSON.stringify({ transferToken: 'tok-123' }) }),
     );
     expect(storeTokensMock).toHaveBeenCalledWith('jwt-1', 'refresh-1', '2026-01-01T00:00:00.000Z');
+  });
+
+  it('keeps the Android listener alive after opened and exchanges the callback after foregrounding', async () => {
+    platformState.OS = 'android';
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(okExchange());
+
+    const racePromise = signInWithGoogleWeb();
+    resolveBrowserResult({ type: 'opened' });
+    await Promise.resolve();
+    expect(removeListenerMock).not.toHaveBeenCalled();
+
+    fireAppState('background');
+    fireAppState('active');
+    fireDeepLink(`${CALLBACK_SCHEME}?transferToken=android-tok`);
+
+    await expect(racePromise).resolves.toEqual({ success: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://backend.test/auth/native/exchange',
+      expect.objectContaining({ body: JSON.stringify({ transferToken: 'android-tok' }) }),
+    );
+    expect(removeListenerMock).toHaveBeenCalledOnce();
+    expect(removeAppStateListenerMock).toHaveBeenCalledOnce();
+  });
+
+  it('maps an exhausted Android callback race to browser_timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      platformState.OS = 'android';
+      const fetchMock = vi.spyOn(global, 'fetch');
+
+      const racePromise = signInWithGoogleWeb();
+      resolveBrowserResult({ type: 'opened' });
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(5 * 60_000 + 1_000);
+
+      await expect(racePromise).resolves.toEqual({ success: false, status: null, error: 'browser_timeout' });
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('treats a closed browser (no callback deep link) as a cancellation and never exchanges', async () => {

--- a/packages/mobile/src/lib/__tests__/auth-session-race.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth-session-race.test.ts
@@ -255,6 +255,33 @@ describe('raceBrowserSignIn — Android', () => {
     expect(harness.clearTimer).toHaveBeenCalledTimes(2);
   });
 
+  it('replaces an active cancel grace with the deadline timeout grace', async () => {
+    const harness = createIoHarness();
+    const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+    harness.resolveBrowser({ type: 'opened' });
+
+    await vi.advanceTimersByTimeAsync(AUTH_DEADLINE_MS - 500);
+    harness.fireAppState('background');
+    harness.fireAppState('active');
+    expect(harness.setTimer).toHaveBeenLastCalledWith(expect.any(Function), CALLBACK_GRACE_MS);
+
+    await vi.advanceTimersByTimeAsync(500);
+    await expectPending(racePromise);
+    expect(harness.clearTimer).toHaveBeenCalledOnce();
+
+    // The old cancel grace would have fired here. The deadline replaces it with
+    // a fresh timeout grace so a final Linking callback still gets a full turn.
+    await vi.advanceTimersByTimeAsync(500);
+    await expectPending(racePromise);
+    await vi.advanceTimersByTimeAsync(500);
+
+    await expect(racePromise).resolves.toEqual({ type: 'timeout' });
+    expect(harness.removeUrlListener).toHaveBeenCalledOnce();
+    expect(harness.removeAppStateListener).toHaveBeenCalledOnce();
+    expect(harness.clearTimer).toHaveBeenCalledTimes(3);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it('ignores unrelated URLs throughout the foreground grace', async () => {
     const harness = createIoHarness();
     const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);

--- a/packages/mobile/src/lib/__tests__/auth-session-race.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth-session-race.test.ts
@@ -1,96 +1,360 @@
-import { describe, expect, it, vi } from 'vitest';
-import { raceBrowserSignIn, type AuthSessionRaceIo } from '../auth-session-race';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { raceBrowserSignIn, type AuthSessionAppState, type AuthSessionRaceIo } from '../auth-session-race';
 
 const CALLBACK_PREFIX = 'com.boardsesh.app://auth/callback';
-const AUTH_URL = 'https://www.boardsesh.com/auth/native-start?provider=apple';
+const AUTH_URL = 'https://www.boardsesh.com/auth/native-start?provider=google';
+const CALLBACK_GRACE_MS = 1_000;
+const AUTH_DEADLINE_MS = 5 * 60_000;
 
-// Harness exposing the registered URL listener and a controllable browser
-// promise, so each test can fire the deep link / close the browser in any order.
-function createIoHarness() {
+function createIoHarness({
+  platform = 'android',
+  initialAppState = 'active',
+}: {
+  platform?: 'ios' | 'android';
+  initialAppState?: AuthSessionAppState | null;
+} = {}) {
   let urlListener: ((event: { url: string }) => void) | null = null;
-  let resolveBrowser: (() => void) | null = null;
+  let appStateListener: ((state: AuthSessionAppState) => void) | null = null;
+  let retainedUrlListener: ((event: { url: string }) => void) | null = null;
+  let retainedAppStateListener: ((state: AuthSessionAppState) => void) | null = null;
+  let currentAppState = initialAppState;
+  let resolveBrowser: ((result: unknown) => void) | null = null;
   let rejectBrowser: ((reason: unknown) => void) | null = null;
 
-  const removeListener = vi.fn(() => {
+  const removeUrlListener = vi.fn(() => {
     urlListener = null;
   });
+  const removeAppStateListener = vi.fn(() => {
+    appStateListener = null;
+  });
+  const addUrlListener = vi.fn((listener: (event: { url: string }) => void) => {
+    urlListener = listener;
+    retainedUrlListener = listener;
+    return { remove: removeUrlListener };
+  });
+  const addAppStateListener = vi.fn((listener: (state: AuthSessionAppState) => void) => {
+    appStateListener = listener;
+    retainedAppStateListener = listener;
+    return { remove: removeAppStateListener };
+  });
   const dismissBrowser = vi.fn(() => Promise.resolve());
-  const io: AuthSessionRaceIo = {
-    addUrlListener: (listener) => {
-      urlListener = listener;
-      return { remove: removeListener };
-    },
-    openBrowser: () =>
-      new Promise<void>((resolve, reject) => {
+  const openBrowser = vi.fn(
+    () =>
+      new Promise<unknown>((resolve, reject) => {
         resolveBrowser = resolve;
         rejectBrowser = reject;
       }),
+  );
+  const setTimer = vi.fn((callback: () => void, delayMs: number) => setTimeout(callback, delayMs));
+  const clearTimer = vi.fn((timer: ReturnType<typeof setTimeout>) => clearTimeout(timer));
+  const io: AuthSessionRaceIo = {
+    platform,
+    addUrlListener,
+    addAppStateListener,
+    getCurrentAppState: () => currentAppState,
+    openBrowser,
     dismissBrowser,
+    setTimer,
+    clearTimer,
   };
 
   return {
     io,
-    removeListener,
+    addUrlListener,
+    addAppStateListener,
+    openBrowser,
+    removeUrlListener,
+    removeAppStateListener,
     dismissBrowser,
+    setTimer,
+    clearTimer,
     fireDeepLink: (url: string) => urlListener?.({ url }),
-    closeBrowser: () => resolveBrowser?.(),
+    fireAppState: (state: AuthSessionAppState) => {
+      currentAppState = state;
+      appStateListener?.(state);
+    },
+    resolveBrowser: (result: unknown) => resolveBrowser?.(result),
     failBrowser: (reason: unknown) => rejectBrowser?.(reason),
+    fireRetainedDeepLink: (url: string) => retainedUrlListener?.({ url }),
+    fireRetainedAppState: (state: AuthSessionAppState) => {
+      currentAppState = state;
+      retainedAppStateListener?.(state);
+    },
   };
 }
 
-describe('raceBrowserSignIn', () => {
-  it('resolves success with the callback URL and dismisses the browser when the deep link arrives', async () => {
+async function expectPending(promise: Promise<unknown>) {
+  const resolution = vi.fn();
+  void promise.then(resolution);
+  await Promise.resolve();
+  expect(resolution).not.toHaveBeenCalled();
+}
+
+describe('raceBrowserSignIn — Android', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('registers both listeners before opening and keeps {type: opened} pending', async () => {
     const harness = createIoHarness();
     const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
 
-    const callbackUrl = `${CALLBACK_PREFIX}?transferToken=tok-1`;
+    expect(harness.addUrlListener.mock.invocationCallOrder[0]).toBeLessThan(
+      harness.openBrowser.mock.invocationCallOrder[0],
+    );
+    expect(harness.addAppStateListener.mock.invocationCallOrder[0]).toBeLessThan(
+      harness.openBrowser.mock.invocationCallOrder[0],
+    );
+    expect(harness.setTimer).toHaveBeenCalledWith(expect.any(Function), AUTH_DEADLINE_MS);
+
+    harness.resolveBrowser({ type: 'opened' });
+    await expectPending(racePromise);
+
+    const callbackUrl = `${CALLBACK_PREFIX}?transferToken=opened-tok`;
+    harness.fireDeepLink(callbackUrl);
+    await expect(racePromise).resolves.toEqual({ type: 'success', url: callbackUrl });
+  });
+
+  it('lets a callback arriving before foreground win and dismisses the Custom Tab', async () => {
+    const harness = createIoHarness();
+    const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+    harness.resolveBrowser({ type: 'opened' });
+    harness.fireAppState('background');
+
+    const callbackUrl = `${CALLBACK_PREFIX}?transferToken=before-active`;
     harness.fireDeepLink(callbackUrl);
 
     await expect(racePromise).resolves.toEqual({ type: 'success', url: callbackUrl });
-    expect(harness.dismissBrowser).toHaveBeenCalledTimes(1);
-    expect(harness.removeListener).toHaveBeenCalledTimes(1);
+    expect(harness.dismissBrowser).toHaveBeenCalledOnce();
+    expect(harness.removeUrlListener).toHaveBeenCalledOnce();
+    expect(harness.removeAppStateListener).toHaveBeenCalledOnce();
+    expect(harness.clearTimer).toHaveBeenCalledOnce();
   });
 
-  it('ignores deep links that are not the auth callback', async () => {
+  it('lets a callback arriving after foreground beat the one-second cancel grace', async () => {
     const harness = createIoHarness();
     const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+    harness.resolveBrowser({ type: 'opened' });
+    harness.fireAppState('background');
+    harness.fireAppState('active');
 
-    harness.fireDeepLink('com.boardsesh.app://join/some-session');
-    harness.fireDeepLink(`${CALLBACK_PREFIX}?transferToken=tok-2`);
+    expect(harness.setTimer).toHaveBeenLastCalledWith(expect.any(Function), CALLBACK_GRACE_MS);
+    await vi.advanceTimersByTimeAsync(CALLBACK_GRACE_MS - 1);
+    const callbackUrl = `${CALLBACK_PREFIX}?transferToken=after-active`;
+    harness.fireDeepLink(callbackUrl);
 
-    await expect(racePromise).resolves.toEqual({
-      type: 'success',
-      url: `${CALLBACK_PREFIX}?transferToken=tok-2`,
-    });
+    await expect(racePromise).resolves.toEqual({ type: 'success', url: callbackUrl });
+    expect(harness.clearTimer).toHaveBeenCalledTimes(2);
+    expect(harness.removeUrlListener).toHaveBeenCalledOnce();
+    expect(harness.removeAppStateListener).toHaveBeenCalledOnce();
   });
 
-  it('resolves cancel when the browser closes without a callback deep link', async () => {
+  it('cancels after an observed background-to-active return and callback grace', async () => {
     const harness = createIoHarness();
     const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+    harness.resolveBrowser({ type: 'opened' });
+    harness.fireAppState('background');
+    harness.fireAppState('active');
 
-    harness.closeBrowser();
+    await vi.advanceTimersByTimeAsync(CALLBACK_GRACE_MS);
 
     await expect(racePromise).resolves.toEqual({ type: 'cancel' });
     expect(harness.dismissBrowser).not.toHaveBeenCalled();
-    expect(harness.removeListener).toHaveBeenCalledTimes(1);
+    expect(harness.removeUrlListener).toHaveBeenCalledOnce();
+    expect(harness.removeAppStateListener).toHaveBeenCalledOnce();
+    expect(harness.clearTimer).toHaveBeenCalledTimes(2);
   });
 
-  it('keeps the success result when the dismissed browser later resolves', async () => {
+  it('ignores lone active plus initial null, unknown, and inactive states', async () => {
+    const harness = createIoHarness({ initialAppState: null });
+    const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+    harness.resolveBrowser({ type: 'opened' });
+
+    harness.fireAppState('active');
+    harness.fireAppState('unknown');
+    harness.fireAppState('inactive');
+    harness.fireAppState('active');
+    await vi.advanceTimersByTimeAsync(CALLBACK_GRACE_MS);
+    await expectPending(racePromise);
+
+    const callbackUrl = `${CALLBACK_PREFIX}?transferToken=ignored-states`;
+    harness.fireDeepLink(callbackUrl);
+    await expect(racePromise).resolves.toEqual({ type: 'success', url: callbackUrl });
+  });
+
+  it('cancels pending foreground grace when the app backgrounds again', async () => {
+    const harness = createIoHarness();
+    const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+    harness.resolveBrowser({ type: 'opened' });
+    harness.fireAppState('background');
+    harness.fireAppState('active');
+    await vi.advanceTimersByTimeAsync(500);
+
+    harness.fireAppState('background');
+    await vi.advanceTimersByTimeAsync(CALLBACK_GRACE_MS);
+    await expectPending(racePromise);
+
+    harness.fireAppState('active');
+    await vi.advanceTimersByTimeAsync(CALLBACK_GRACE_MS);
+    await expect(racePromise).resolves.toEqual({ type: 'cancel' });
+  });
+
+  it('waits through a backgrounded deadline, then times out after resumed callback grace', async () => {
+    const harness = createIoHarness();
+    const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+    harness.resolveBrowser({ type: 'opened' });
+    harness.fireAppState('background');
+
+    await vi.advanceTimersByTimeAsync(AUTH_DEADLINE_MS);
+    await vi.advanceTimersByTimeAsync(CALLBACK_GRACE_MS * 10);
+    await expectPending(racePromise);
+
+    harness.fireAppState('active');
+    await vi.advanceTimersByTimeAsync(CALLBACK_GRACE_MS - 1);
+    await expectPending(racePromise);
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(racePromise).resolves.toEqual({ type: 'timeout' });
+    expect(harness.removeUrlListener).toHaveBeenCalledOnce();
+    expect(harness.removeAppStateListener).toHaveBeenCalledOnce();
+    expect(harness.clearTimer).toHaveBeenCalledTimes(2);
+  });
+
+  it('lets a resumed Linking callback beat deadline settlement', async () => {
+    const harness = createIoHarness();
+    const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+    harness.resolveBrowser({ type: 'opened' });
+    harness.fireAppState('background');
+    await vi.advanceTimersByTimeAsync(AUTH_DEADLINE_MS);
+
+    harness.fireAppState('active');
+    await vi.advanceTimersByTimeAsync(CALLBACK_GRACE_MS - 1);
+    const callbackUrl = `${CALLBACK_PREFIX}?transferToken=resumed-deadline`;
+    harness.fireDeepLink(callbackUrl);
+
+    await expect(racePromise).resolves.toEqual({ type: 'success', url: callbackUrl });
+    expect(harness.clearTimer).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns a distinct timeout after the never-backgrounded deadline and final grace', async () => {
+    const harness = createIoHarness();
+    const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+    harness.resolveBrowser({ type: 'opened' });
+
+    await vi.advanceTimersByTimeAsync(AUTH_DEADLINE_MS);
+    await expectPending(racePromise);
+    await vi.advanceTimersByTimeAsync(CALLBACK_GRACE_MS);
+
+    await expect(racePromise).resolves.toEqual({ type: 'timeout' });
+    expect(harness.removeUrlListener).toHaveBeenCalledOnce();
+    expect(harness.removeAppStateListener).toHaveBeenCalledOnce();
+    expect(harness.clearTimer).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores unrelated URLs throughout the foreground grace', async () => {
+    const harness = createIoHarness();
+    const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+    harness.resolveBrowser({ type: 'opened' });
+    harness.fireAppState('background');
+    harness.fireAppState('active');
+    harness.fireDeepLink('com.boardsesh.app://join/some-session');
+
+    await vi.advanceTimersByTimeAsync(CALLBACK_GRACE_MS);
+    await expect(racePromise).resolves.toEqual({ type: 'cancel' });
+    expect(harness.dismissBrowser).not.toHaveBeenCalled();
+  });
+
+  it.each([{ type: 'cancel' }, { type: 'dismiss' }, { type: 'future-terminal-result' }, null])(
+    'treats terminal or unknown browser result $type as cancel',
+    async (browserResult) => {
+      const harness = createIoHarness();
+      const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+
+      harness.resolveBrowser(browserResult);
+
+      await expect(racePromise).resolves.toEqual({ type: 'cancel' });
+      expect(harness.removeUrlListener).toHaveBeenCalledOnce();
+      expect(harness.removeAppStateListener).toHaveBeenCalledOnce();
+      expect(harness.clearTimer).toHaveBeenCalledOnce();
+    },
+  );
+
+  it('returns browser-open errors and cleans up exactly once', async () => {
     const harness = createIoHarness();
     const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
 
-    harness.fireDeepLink(`${CALLBACK_PREFIX}?transferToken=tok-3`);
-    // dismissBrowser() closing the browser resolves openBrowser afterwards.
-    harness.closeBrowser();
+    harness.failBrowser(new Error('Custom Tab unavailable'));
 
-    await expect(racePromise).resolves.toEqual({
-      type: 'success',
-      url: `${CALLBACK_PREFIX}?transferToken=tok-3`,
-    });
+    await expect(racePromise).resolves.toEqual({ type: 'error', message: 'Custom Tab unavailable' });
+    expect(harness.removeUrlListener).toHaveBeenCalledOnce();
+    expect(harness.removeAppStateListener).toHaveBeenCalledOnce();
+    expect(harness.clearTimer).toHaveBeenCalledOnce();
   });
 
-  it('resolves error with the message when the browser fails to open', async () => {
+  it('keeps retained URL and AppState callbacks side-effect free after settlement', async () => {
     const harness = createIoHarness();
+    const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+    harness.resolveBrowser({ type: 'opened' });
+    harness.fireAppState('background');
+
+    const callbackUrl = `${CALLBACK_PREFIX}?transferToken=settled-token`;
+    harness.fireDeepLink(callbackUrl);
+    await expect(racePromise).resolves.toEqual({ type: 'success', url: callbackUrl });
+
+    expect(harness.dismissBrowser).toHaveBeenCalledOnce();
+    expect(harness.setTimer).toHaveBeenCalledOnce();
+    expect(harness.clearTimer).toHaveBeenCalledOnce();
+    expect(harness.removeUrlListener).toHaveBeenCalledOnce();
+    expect(harness.removeAppStateListener).toHaveBeenCalledOnce();
+
+    harness.fireRetainedAppState('active');
+    harness.fireRetainedAppState('background');
+    harness.fireRetainedDeepLink(`${CALLBACK_PREFIX}?transferToken=late-token`);
+    await vi.advanceTimersByTimeAsync(CALLBACK_GRACE_MS);
+
+    expect(harness.dismissBrowser).toHaveBeenCalledOnce();
+    expect(harness.setTimer).toHaveBeenCalledOnce();
+    expect(harness.clearTimer).toHaveBeenCalledOnce();
+    expect(harness.removeUrlListener).toHaveBeenCalledOnce();
+    expect(harness.removeAppStateListener).toHaveBeenCalledOnce();
+  });
+});
+
+describe('raceBrowserSignIn — unchanged iOS semantics', () => {
+  it('lets the matching callback win, dismisses, and removes only the URL listener', async () => {
+    const harness = createIoHarness({ platform: 'ios' });
+    const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+    const callbackUrl = `${CALLBACK_PREFIX}?transferToken=ios-token`;
+
+    harness.fireDeepLink('com.boardsesh.app://join/some-session');
+    harness.fireDeepLink(callbackUrl);
+    harness.resolveBrowser({ type: 'dismiss' });
+
+    await expect(racePromise).resolves.toEqual({ type: 'success', url: callbackUrl });
+    expect(harness.dismissBrowser).toHaveBeenCalledOnce();
+    expect(harness.removeUrlListener).toHaveBeenCalledOnce();
+    expect(harness.addAppStateListener).not.toHaveBeenCalled();
+    expect(harness.setTimer).not.toHaveBeenCalled();
+  });
+
+  it('treats every browser resolution, including opened, as cancel', async () => {
+    const harness = createIoHarness({ platform: 'ios' });
+    const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+
+    harness.resolveBrowser({ type: 'opened' });
+
+    await expect(racePromise).resolves.toEqual({ type: 'cancel' });
+    expect(harness.removeUrlListener).toHaveBeenCalledOnce();
+    expect(harness.addAppStateListener).not.toHaveBeenCalled();
+    expect(harness.setTimer).not.toHaveBeenCalled();
+  });
+
+  it('keeps browser rejection as an error with the original message', async () => {
+    const harness = createIoHarness({ platform: 'ios' });
     const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
 
     harness.failBrowser(new Error('Another WebBrowser is already being presented.'));
@@ -99,11 +363,12 @@ describe('raceBrowserSignIn', () => {
       type: 'error',
       message: 'Another WebBrowser is already being presented.',
     });
-    expect(harness.removeListener).toHaveBeenCalledTimes(1);
+    expect(harness.addAppStateListener).not.toHaveBeenCalled();
+    expect(harness.setTimer).not.toHaveBeenCalled();
   });
 
-  it('falls back to a generic message for non-Error rejections', async () => {
-    const harness = createIoHarness();
+  it('keeps the generic browser rejection message for non-Errors', async () => {
+    const harness = createIoHarness({ platform: 'ios' });
     const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
 
     harness.failBrowser('boom');

--- a/packages/mobile/src/lib/__tests__/auth.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth.test.ts
@@ -43,6 +43,12 @@ describe('classifyNativeAuthFailureReason', () => {
     ).toBe('browser_unavailable');
   });
 
+  it('keeps an exhausted Android browser race distinct from browser presentation failures', () => {
+    expect(classifyNativeAuthFailureReason({ success: false, status: null, error: 'browser_timeout' }, 'oauth')).toBe(
+      'browser_timeout',
+    );
+  });
+
   // Regression: the classifier used to string-match the 401 body against
   // 'Invalid credentials', but the backend says 'Invalid email or password' —
   // every real wrong-password attempt was mislabelled. Classify by endpoint.

--- a/packages/mobile/src/lib/auth-session-race.ts
+++ b/packages/mobile/src/lib/auth-session-race.ts
@@ -1,4 +1,4 @@
-// Drives the iOS sign-in hand-off: open the OAuth page in an in-app browser
+// Drives the native sign-in hand-off: open the OAuth page in an in-app browser
 // and wait for the OS deep link that the server's callback page fires
 // (com.boardsesh.app://auth/callback?transferToken=...). All platform I/O is
 // injected so unit tests need no expo-web-browser or react-native mocks.
@@ -14,15 +14,32 @@
 export type AuthSessionRaceResult =
   | { type: 'success'; url: string }
   | { type: 'cancel' }
+  | { type: 'timeout' }
   | { type: 'error'; message: string };
 
 type UrlEventSubscription = { remove: () => void };
+type AppStateEventSubscription = { remove: () => void };
+type TimerHandle = ReturnType<typeof setTimeout>;
+
+export type AuthSessionAppState = 'active' | 'background' | 'inactive' | 'unknown' | 'extension';
+
+const ANDROID_CALLBACK_GRACE_MS = 1_000;
+const ANDROID_AUTH_DEADLINE_MS = 5 * 60_000;
 
 export type AuthSessionRaceIo = {
+  platform: 'ios' | 'android';
   addUrlListener: (listener: (event: { url: string }) => void) => UrlEventSubscription;
+  addAppStateListener: (listener: (state: AuthSessionAppState) => void) => AppStateEventSubscription;
+  getCurrentAppState: () => AuthSessionAppState | null;
   openBrowser: (url: string) => Promise<unknown>;
   dismissBrowser: () => Promise<unknown>;
+  setTimer: (callback: () => void, delayMs: number) => TimerHandle;
+  clearTimer: (timer: TimerHandle) => void;
 };
+
+function isOpenedBrowserResult(result: unknown): boolean {
+  return typeof result === 'object' && result !== null && (result as { type?: unknown }).type === 'opened';
+}
 
 export function raceBrowserSignIn(
   io: AuthSessionRaceIo,
@@ -30,16 +47,33 @@ export function raceBrowserSignIn(
   callbackUrlPrefix: string,
 ): Promise<AuthSessionRaceResult> {
   return new Promise((resolve) => {
-    let subscription: UrlEventSubscription | null = null;
+    let urlSubscription: UrlEventSubscription | null = null;
+    let appStateSubscription: AppStateEventSubscription | null = null;
+    let authDeadlineTimer: TimerHandle | null = null;
+    let callbackGraceTimer: TimerHandle | null = null;
     let settled = false;
+
+    const clearCallbackGrace = () => {
+      if (callbackGraceTimer === null) return;
+      io.clearTimer(callbackGraceTimer);
+      callbackGraceTimer = null;
+    };
+
     const settle = (result: AuthSessionRaceResult) => {
       if (settled) return;
       settled = true;
-      subscription?.remove();
+      urlSubscription?.remove();
+      appStateSubscription?.remove();
+      if (authDeadlineTimer !== null) {
+        io.clearTimer(authDeadlineTimer);
+        authDeadlineTimer = null;
+      }
+      clearCallbackGrace();
       resolve(result);
     };
 
-    subscription = io.addUrlListener(({ url }) => {
+    urlSubscription = io.addUrlListener(({ url }) => {
+      if (settled) return;
       if (!url.startsWith(callbackUrlPrefix)) return;
       // Close the browser left behind under the deep-link hand-off. Best-effort:
       // its own resolution below is a no-op once settled.
@@ -47,10 +81,77 @@ export function raceBrowserSignIn(
       settle({ type: 'success', url });
     });
 
+    // iOS openBrowser resolves only when its SFSafariViewController closes, so
+    // preserve the original behavior exactly: the callback wins and dismisses;
+    // any browser resolution is a cancel; a rejection means it could not open.
+    // Android's AppState/timer completion rules must never affect this branch.
+    if (io.platform === 'ios') {
+      io.openBrowser(authUrl).then(
+        () => settle({ type: 'cancel' }),
+        (openBrowserError: unknown) =>
+          settle({
+            type: 'error',
+            message: openBrowserError instanceof Error ? openBrowserError.message : 'browser failed to open',
+          }),
+      );
+      return;
+    }
+
+    let backgroundObserved = false;
+    let deadlineExpired = false;
+    let deadlineWaitingForActive = false;
+
+    const startCallbackGrace = (result: AuthSessionRaceResult) => {
+      if (settled) return;
+      clearCallbackGrace();
+      callbackGraceTimer = io.setTimer(() => settle(result), ANDROID_CALLBACK_GRACE_MS);
+    };
+
+    // Android returns {type: 'opened'} as soon as the Custom Tab launches. The
+    // only reliable close signal is the app actually leaving and later becoming
+    // active, so a lone/initial active event is deliberately ignored.
+    appStateSubscription = io.addAppStateListener((nextAppState) => {
+      if (settled) return;
+      if (nextAppState === 'background') {
+        backgroundObserved = true;
+        deadlineWaitingForActive = deadlineExpired;
+        clearCallbackGrace();
+        return;
+      }
+      if (nextAppState !== 'active') return;
+
+      if (deadlineWaitingForActive) {
+        deadlineWaitingForActive = false;
+        backgroundObserved = false;
+        startCallbackGrace({ type: 'timeout' });
+        return;
+      }
+      if (!backgroundObserved) return;
+
+      backgroundObserved = false;
+      startCallbackGrace(deadlineExpired ? { type: 'timeout' } : { type: 'cancel' });
+    });
+
+    authDeadlineTimer = io.setTimer(() => {
+      if (settled) return;
+      deadlineExpired = true;
+      if (io.getCurrentAppState() === 'background' || backgroundObserved) {
+        deadlineWaitingForActive = true;
+        clearCallbackGrace();
+        return;
+      }
+      // Linking delivery may follow the foreground/deadline signal. Keep the URL
+      // listener alive for one final turn before reporting the distinct timeout.
+      startCallbackGrace({ type: 'timeout' });
+    }, ANDROID_AUTH_DEADLINE_MS);
+
     io.openBrowser(authUrl).then(
-      // Resolves when the browser closes. Reaching this un-settled means no
-      // callback deep link arrived — the user closed it without finishing.
-      () => settle({ type: 'cancel' }),
+      (browserResult) => {
+        // Android resolves with `opened` immediately after launching the tab;
+        // every other/unknown resolution is terminal so a future SDK result
+        // cannot leave the race hanging forever.
+        if (!isOpenedBrowserResult(browserResult)) settle({ type: 'cancel' });
+      },
       (openBrowserError: unknown) =>
         settle({
           type: 'error',

--- a/packages/mobile/src/lib/auth.ts
+++ b/packages/mobile/src/lib/auth.ts
@@ -1,4 +1,4 @@
-import { Linking, Platform } from 'react-native';
+import { AppState, Linking, Platform } from 'react-native';
 import * as AppleAuthentication from 'expo-apple-authentication';
 import * as WebBrowser from 'expo-web-browser';
 import { getRandomBytes, digestStringAsync, CryptoDigestAlgorithm, CryptoEncoding } from 'expo-crypto';
@@ -275,8 +275,9 @@ async function exchangeTransferToken(transferToken: string): Promise<OAuthSignIn
  * SFSafariViewController that presents reliably, and the server's callback page
  * (packages/web/app/api/auth/native/callback/route.ts) deep-links back via a
  * JS/meta-refresh redirect built for exactly this hand-off — the same one the
- * legacy Capacitor app shipped with. This is the restoration of the proven flow
- * from PR #2721, scoped to the fallback.
+ * legacy Capacitor app shipped with. Android keeps listening after its Custom
+ * Tab reports `opened`, then uses an observed background/foreground round trip
+ * plus a bounded callback grace to distinguish a returned callback from cancel.
  *
  * Never throws: every outcome maps to an OAuthSignInResult (success / cancelled /
  * failure) so the caller treats it exactly like the native path.
@@ -290,9 +291,14 @@ async function signInWithProviderWeb(provider: AuthProvider): Promise<OAuthSignI
   // wrapped so a synchronous throw from it can't reject the race's success branch.
   const race = await raceBrowserSignIn(
     {
+      platform: Platform.OS === 'android' ? 'android' : 'ios',
       addUrlListener: (listener) => Linking.addEventListener('url', listener),
+      addAppStateListener: (listener) => AppState.addEventListener('change', listener),
+      getCurrentAppState: () => AppState.currentState,
       openBrowser: (url) => WebBrowser.openBrowserAsync(url),
       dismissBrowser: async () => WebBrowser.dismissBrowser(),
+      setTimer: (callback, delayMs) => setTimeout(callback, delayMs),
+      clearTimer: (timer) => clearTimeout(timer),
     },
     startUrl,
     NATIVE_OAUTH_REDIRECT,
@@ -302,6 +308,11 @@ async function signInWithProviderWeb(provider: AuthProvider): Promise<OAuthSignI
   // fixing — a real "couldn't open the browser", not a user cancel and not a
   // network-class server failure. Its own analytics reason so it's visible.
   if (race.type === 'error') return { success: false, status: null, error: 'browser_unavailable' };
+
+  // The Android Custom Tab opened but neither a callback nor a terminal close
+  // signal arrived within the bounded race. Keep this distinct from both a
+  // browser presentation error and an intentional user cancellation.
+  if (race.type === 'timeout') return { success: false, status: null, error: 'browser_timeout' };
 
   // The user closed the browser before the callback deep link arrived.
   if (race.type === 'cancel') return { success: false, cancelled: true };

--- a/packages/mobile/src/lib/native-auth-analytics.ts
+++ b/packages/mobile/src/lib/native-auth-analytics.ts
@@ -1,6 +1,7 @@
 export type NativeAuthFailureReason =
   | 'network'
   | 'browser_unavailable'
+  | 'browser_timeout'
   | 'invalid_credentials'
   | 'invalid_oauth_token'
   | 'invalid_request'
@@ -27,6 +28,7 @@ export function classifyNativeAuthFailureReason(
   // The web-OAuth fallback's in-app browser couldn't present (iOS 26). Carries no
   // HTTP status — classify off the sentinel error string before the status checks.
   if (failure.error === 'browser_unavailable') return 'browser_unavailable';
+  if (failure.error === 'browser_timeout') return 'browser_timeout';
   if (failure.status === 400) return 'invalid_request';
   if (failure.status === 401) {
     return source === 'credentials' ? 'invalid_credentials' : 'invalid_oauth_token';

--- a/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
@@ -690,7 +690,7 @@ describe('AuthProvider browser-fallback foreground checks', () => {
       );
     };
 
-  it('suppresses the generic active read while pending, then runs exactly the explicit success read', async () => {
+  it('subsumes an earlier suppressed active event into exactly the explicit success read', async () => {
     let finishFallback!: (result: { success: true }) => void;
     authSignInWithGoogleWebMock.mockReturnValue(
       new Promise((resolve) => {
@@ -716,8 +716,44 @@ describe('AuthProvider browser-fallback foreground checks', () => {
     expect(getAuthTokenMock).toHaveBeenCalledTimes(authReadsBeforeFallback + 1);
   });
 
-  it('releases foreground checks after a cancelled fallback', async () => {
-    let finishFallback!: (result: { success: false; cancelled: true }) => void;
+  it('defers an active event that arrives during the explicit success read until release', async () => {
+    let finishFallback!: (result: { success: true }) => void;
+    let finishExplicitAuthRead!: (token: string) => void;
+    authSignInWithGoogleWebMock.mockReturnValue(
+      new Promise((resolve) => {
+        finishFallback = resolve;
+      }),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper(queryClient) });
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+    const authReadsBeforeFallback = getAuthTokenMock.mock.calls.length;
+    getAuthTokenMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishExplicitAuthRead = resolve;
+        }),
+    );
+
+    const fallbackPromise = result.current.signInWithGoogleWeb();
+    act(() => appStateState.listener?.('active'));
+    act(() => finishFallback({ success: true }));
+    await vi.waitFor(() => expect(getAuthTokenMock).toHaveBeenCalledTimes(authReadsBeforeFallback + 1));
+
+    act(() => appStateState.listener?.('active'));
+    await act(async () => {
+      finishExplicitAuthRead('jwt-token');
+      await fallbackPromise;
+    });
+
+    expect(getAuthTokenMock).toHaveBeenCalledTimes(authReadsBeforeFallback + 2);
+  });
+
+  it.each([
+    ['a cancelled fallback', { success: false, cancelled: true }],
+    ['a timed-out fallback', { success: false, status: null, error: 'browser_timeout' }],
+  ])('runs one deferred foreground check after %s releases', async (_description, fallbackResult) => {
+    let finishFallback!: (result: typeof fallbackResult) => void;
     authSignInWithGoogleWebMock.mockReturnValue(
       new Promise((resolve) => {
         finishFallback = resolve;
@@ -730,15 +766,72 @@ describe('AuthProvider browser-fallback foreground checks', () => {
 
     const fallbackPromise = result.current.signInWithGoogleWeb();
     act(() => appStateState.listener?.('active'));
+    act(() => appStateState.listener?.('active'));
     await Promise.resolve();
     expect(getAuthTokenMock).toHaveBeenCalledTimes(authReadsBeforeFallback);
 
     await act(async () => {
+      finishFallback(fallbackResult);
+      await fallbackPromise;
+    });
+    expect(getAuthTokenMock).toHaveBeenCalledTimes(authReadsBeforeFallback + 1);
+  });
+
+  it('runs one deferred foreground check after a failed fallback releases', async () => {
+    let failFallback!: (error: Error) => void;
+    authSignInWithGoogleWebMock.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        failFallback = reject;
+      }),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper(queryClient) });
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+    const authReadsBeforeFallback = getAuthTokenMock.mock.calls.length;
+
+    const fallbackPromise = result.current.signInWithGoogleWeb();
+    act(() => appStateState.listener?.('active'));
+    act(() => appStateState.listener?.('active'));
+    await Promise.resolve();
+    expect(getAuthTokenMock).toHaveBeenCalledTimes(authReadsBeforeFallback);
+
+    await act(async () => {
+      failFallback(new Error('browser failed'));
+      await expect(fallbackPromise).rejects.toThrow('browser failed');
+    });
+    expect(getAuthTokenMock).toHaveBeenCalledTimes(authReadsBeforeFallback + 1);
+  });
+
+  it('drops a deferred foreground check when the provider unmounts before cancellation settles', async () => {
+    let finishFallback!: (result: { success: false; cancelled: true }) => void;
+    authSignInWithGoogleWebMock.mockReturnValue(
+      new Promise((resolve) => {
+        finishFallback = resolve;
+      }),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result, unmount } = renderHook(() => useAuth(), { wrapper: createWrapper(queryClient) });
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+
+    const fallbackPromise = result.current.signInWithGoogleWeb();
+    act(() => appStateState.listener?.('active'));
+    await Promise.resolve();
+    const authReadsBeforeUnmount = getAuthTokenMock.mock.calls.length;
+    const sessionClearsBeforeUnmount = clearStoredSessionIdMock.mock.calls.length;
+    const activeBoardClearsBeforeUnmount = clearStoredActiveBoardMock.mock.calls.length;
+    const queueClearsBeforeUnmount = clearStoredQueueSnapshotMock.mock.calls.length;
+
+    unmount();
+    getAuthTokenMock.mockResolvedValue(null);
+    await act(async () => {
       finishFallback({ success: false, cancelled: true });
       await fallbackPromise;
     });
-    act(() => appStateState.listener?.('active'));
-    await waitFor(() => expect(getAuthTokenMock).toHaveBeenCalledTimes(authReadsBeforeFallback + 1));
+
+    expect(getAuthTokenMock).toHaveBeenCalledTimes(authReadsBeforeUnmount);
+    expect(clearStoredSessionIdMock).toHaveBeenCalledTimes(sessionClearsBeforeUnmount);
+    expect(clearStoredActiveBoardMock).toHaveBeenCalledTimes(activeBoardClearsBeforeUnmount);
+    expect(clearStoredQueueSnapshotMock).toHaveBeenCalledTimes(queueClearsBeforeUnmount);
   });
 
   it('keeps active checks suppressed until all overlapping fallbacks finish', async () => {
@@ -773,8 +866,7 @@ describe('AuthProvider browser-fallback foreground checks', () => {
       finishApple({ success: false, cancelled: true });
       await appleFallback;
     });
-    act(() => appStateState.listener?.('active'));
-    await waitFor(() => expect(getAuthTokenMock).toHaveBeenCalledTimes(authReadsBeforeFallbacks + 1));
+    expect(getAuthTokenMock).toHaveBeenCalledTimes(authReadsBeforeFallbacks + 1);
   });
 });
 

--- a/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
@@ -138,6 +138,8 @@ beforeEach(() => {
   captureAuthCredentialGenerationMock.mockReset();
   captureAuthCredentialGenerationMock.mockReturnValue(1);
   authSignInWithCredentialsMock.mockReset();
+  authSignInWithGoogleWebMock.mockReset();
+  authSignInWithAppleWebMock.mockReset();
   clearStoredQueueSnapshotMock.mockReset();
   clearStoredQueueSnapshotMock.mockResolvedValue(undefined);
   clearAllCreateClimbDraftsMock.mockReset();
@@ -188,11 +190,13 @@ vi.mock('../../lib/oauth-return', () => ({
 const authSignOutMock = vi.fn();
 const authRegisterMock = vi.fn();
 const authSignInWithCredentialsMock = vi.fn();
+const authSignInWithGoogleWebMock = vi.fn();
+const authSignInWithAppleWebMock = vi.fn();
 vi.mock('../../lib/auth', () => ({
   signInWithApple: vi.fn(),
   signInWithGoogle: vi.fn(),
-  signInWithGoogleWeb: vi.fn(),
-  signInWithAppleWeb: vi.fn(),
+  signInWithGoogleWeb: (...args: unknown[]) => authSignInWithGoogleWebMock(...args),
+  signInWithAppleWeb: (...args: unknown[]) => authSignInWithAppleWebMock(...args),
   signOutForGeneration: (...args: unknown[]) => authSignOutMock(...args),
   signInWithCredentials: (...args: unknown[]) => authSignInWithCredentialsMock(...args),
   registerWithCredentials: (...args: unknown[]) => authRegisterMock(...args),
@@ -665,6 +669,112 @@ describe('AuthProvider.register', () => {
     });
 
     expect(getAuthTokenMock).toHaveBeenCalledTimes(authReadsBeforeRegistration);
+  });
+});
+
+describe('AuthProvider browser-fallback foreground checks', () => {
+  beforeEach(() => {
+    platformState.OS = 'android';
+    getAuthTokenMock.mockReset();
+    getAuthTokenMock.mockResolvedValue('jwt-token');
+    isTokenExpiringSoonMock.mockReset();
+    isTokenExpiringSoonMock.mockResolvedValue(false);
+  });
+
+  const createWrapper = (queryClient: QueryClient) =>
+    function Wrapper({ children }: { children: ReactNode }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          <AuthProvider>{children}</AuthProvider>
+        </QueryClientProvider>
+      );
+    };
+
+  it('suppresses the generic active read while pending, then runs exactly the explicit success read', async () => {
+    let finishFallback!: (result: { success: true }) => void;
+    authSignInWithGoogleWebMock.mockReturnValue(
+      new Promise((resolve) => {
+        finishFallback = resolve;
+      }),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper(queryClient) });
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+    const authReadsBeforeFallback = getAuthTokenMock.mock.calls.length;
+
+    const fallbackPromise = result.current.signInWithGoogleWeb();
+    await vi.waitFor(() => expect(authSignInWithGoogleWebMock).toHaveBeenCalledOnce());
+    act(() => appStateState.listener?.('active'));
+    await Promise.resolve();
+    expect(getAuthTokenMock).toHaveBeenCalledTimes(authReadsBeforeFallback);
+
+    await act(async () => {
+      finishFallback({ success: true });
+      await fallbackPromise;
+    });
+
+    expect(getAuthTokenMock).toHaveBeenCalledTimes(authReadsBeforeFallback + 1);
+  });
+
+  it('releases foreground checks after a cancelled fallback', async () => {
+    let finishFallback!: (result: { success: false; cancelled: true }) => void;
+    authSignInWithGoogleWebMock.mockReturnValue(
+      new Promise((resolve) => {
+        finishFallback = resolve;
+      }),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper(queryClient) });
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+    const authReadsBeforeFallback = getAuthTokenMock.mock.calls.length;
+
+    const fallbackPromise = result.current.signInWithGoogleWeb();
+    act(() => appStateState.listener?.('active'));
+    await Promise.resolve();
+    expect(getAuthTokenMock).toHaveBeenCalledTimes(authReadsBeforeFallback);
+
+    await act(async () => {
+      finishFallback({ success: false, cancelled: true });
+      await fallbackPromise;
+    });
+    act(() => appStateState.listener?.('active'));
+    await waitFor(() => expect(getAuthTokenMock).toHaveBeenCalledTimes(authReadsBeforeFallback + 1));
+  });
+
+  it('keeps active checks suppressed until all overlapping fallbacks finish', async () => {
+    let finishGoogle!: (result: { success: false; cancelled: true }) => void;
+    let finishApple!: (result: { success: false; cancelled: true }) => void;
+    authSignInWithGoogleWebMock.mockReturnValue(
+      new Promise((resolve) => {
+        finishGoogle = resolve;
+      }),
+    );
+    authSignInWithAppleWebMock.mockReturnValue(
+      new Promise((resolve) => {
+        finishApple = resolve;
+      }),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper(queryClient) });
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+    const authReadsBeforeFallbacks = getAuthTokenMock.mock.calls.length;
+
+    const googleFallback = result.current.signInWithGoogleWeb();
+    const appleFallback = result.current.signInWithAppleWeb();
+    await act(async () => {
+      finishGoogle({ success: false, cancelled: true });
+      await googleFallback;
+    });
+    act(() => appStateState.listener?.('active'));
+    await Promise.resolve();
+    expect(getAuthTokenMock).toHaveBeenCalledTimes(authReadsBeforeFallbacks);
+
+    await act(async () => {
+      finishApple({ success: false, cancelled: true });
+      await appleFallback;
+    });
+    act(() => appStateState.listener?.('active'));
+    await waitFor(() => expect(getAuthTokenMock).toHaveBeenCalledTimes(authReadsBeforeFallbacks + 1));
   });
 });
 

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -46,7 +46,7 @@ type AuthState = {
   isLoading: boolean;
   signInWithApple: (webAttemptId?: string, isRegistration?: boolean) => Promise<OAuthSignInResult>;
   signInWithGoogle: (webAttemptId?: string, isRegistration?: boolean) => Promise<OAuthSignInResult>;
-  // Browser-OAuth fallback for when native Google sign-in can't present (iOS 26.5.1).
+  // Browser-OAuth fallback for supported native Google presentation/config failures.
   signInWithGoogleWeb: (isRegistration?: boolean) => Promise<OAuthSignInResult>;
   // Browser-OAuth fallback for when native Sign in with Apple throws (code 1000).
   signInWithAppleWeb: (isRegistration?: boolean) => Promise<OAuthSignInResult>;
@@ -111,6 +111,11 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
   const remoteRevalidationRef = useRef<Promise<void> | null>(null);
   const nativeSessionDegradedRef = useRef(false);
   const reconnectAuthCheckRef = useRef<Promise<void> | null>(null);
+  // Android returns to `active` before Linking delivers the browser OAuth
+  // callback. Suppress only the provider's generic foreground read while a
+  // fallback owns that hand-off; each successful wrapper still runs its own
+  // explicit check after the transfer token has been exchanged.
+  const browserFallbackAuthChecksRef = useRef(0);
 
   const updateNativeSessionDegraded = useCallback((degraded: boolean) => {
     nativeSessionDegradedRef.current = degraded;
@@ -565,7 +570,7 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
 
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (nextAppState) => {
-      if (nextAppState === 'active') {
+      if (nextAppState === 'active' && browserFallbackAuthChecksRef.current === 0) {
         void checkAuth();
       }
     });
@@ -611,16 +616,21 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
     return result;
   }, [checkAuth]);
 
-  // Browser-based Google fallback (native SDK can't present the OAuth browser on
-  // iOS 26.5.1). Same success contract as the native flow: re-run checkAuth so the
-  // provider flips to the authenticated UI.
+  // Browser-based Google fallback for supported iOS presentation and Android
+  // config failures. Same success contract as the native flow: re-run checkAuth
+  // so the provider flips to the authenticated UI.
   const signInWithGoogleWeb = useCallback(
     async (isRegistration = false): Promise<OAuthSignInResult> => {
-      const result = await authSignInWithGoogleWeb(isRegistration);
-      if (result.success) {
-        await checkAuth();
+      browserFallbackAuthChecksRef.current += 1;
+      try {
+        const result = await authSignInWithGoogleWeb(isRegistration);
+        if (result.success) {
+          await checkAuth();
+        }
+        return result;
+      } finally {
+        browserFallbackAuthChecksRef.current -= 1;
       }
-      return result;
     },
     [checkAuth],
   );
@@ -630,11 +640,16 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
   // provider flips to the authenticated UI.
   const signInWithAppleWeb = useCallback(
     async (isRegistration = false): Promise<OAuthSignInResult> => {
-      const result = await authSignInWithAppleWeb(isRegistration);
-      if (result.success) {
-        await checkAuth();
+      browserFallbackAuthChecksRef.current += 1;
+      try {
+        const result = await authSignInWithAppleWeb(isRegistration);
+        if (result.success) {
+          await checkAuth();
+        }
+        return result;
+      } finally {
+        browserFallbackAuthChecksRef.current -= 1;
       }
-      return result;
     },
     [checkAuth],
   );

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -114,8 +114,23 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
   // Android returns to `active` before Linking delivers the browser OAuth
   // callback. Suppress only the provider's generic foreground read while a
   // fallback owns that hand-off; each successful wrapper still runs its own
-  // explicit check after the transfer token has been exchanged.
+  // explicit check after the transfer token has been exchanged. A suppressed
+  // active event is retained as one deferred check so a keychain read that
+  // became available while the browser was open is not lost.
   const browserFallbackAuthChecksRef = useRef(0);
+  const deferredBrowserFallbackAuthCheckRef = useRef(false);
+  const authProviderMountedRef = useRef(true);
+
+  useEffect(() => {
+    // React StrictMode replays effects without recreating refs, so restore the
+    // mounted bit in setup as well as clearing it during cleanup.
+    authProviderMountedRef.current = true;
+    return () => {
+      authProviderMountedRef.current = false;
+      browserFallbackAuthChecksRef.current = 0;
+      deferredBrowserFallbackAuthCheckRef.current = false;
+    };
+  }, []);
 
   const updateNativeSessionDegraded = useCallback((degraded: boolean) => {
     nativeSessionDegradedRef.current = degraded;
@@ -562,6 +577,26 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
     return enqueueAuthTransition(() => checkAuthForTransition(transitionEpoch));
   }, [beginAuthTransition, checkAuthForTransition, enqueueAuthTransition]);
 
+  const checkAuthAfterSuccessfulBrowserFallback = useCallback(async (): Promise<void> => {
+    if (!authProviderMountedRef.current) return;
+    // The explicit success read subsumes active events that happened before it.
+    // Keep suppression held during the await so a newer active event can re-arm
+    // the deferred read for the final fallback release.
+    deferredBrowserFallbackAuthCheckRef.current = false;
+    await checkAuth();
+  }, [checkAuth]);
+
+  const releaseBrowserFallbackAuthCheckSuppression = useCallback(async (): Promise<void> => {
+    if (!authProviderMountedRef.current) return;
+    browserFallbackAuthChecksRef.current = Math.max(0, browserFallbackAuthChecksRef.current - 1);
+    if (browserFallbackAuthChecksRef.current !== 0 || !deferredBrowserFallbackAuthCheckRef.current) return;
+
+    // Coalesce every active event suppressed by this group of overlapping
+    // fallbacks into exactly one read after the last fallback has released.
+    deferredBrowserFallbackAuthCheckRef.current = false;
+    await checkAuth();
+  }, [checkAuth]);
+
   useEffect(() => {
     // Belt-and-braces: checkAuth already resolves its own rejections, but keep
     // the invocation from producing an unhandled rejection if that ever changes.
@@ -570,9 +605,13 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
 
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (nextAppState) => {
-      if (nextAppState === 'active' && browserFallbackAuthChecksRef.current === 0) {
-        void checkAuth();
+      if (!authProviderMountedRef.current) return;
+      if (nextAppState !== 'active') return;
+      if (browserFallbackAuthChecksRef.current > 0) {
+        deferredBrowserFallbackAuthCheckRef.current = true;
+        return;
       }
+      void checkAuth();
     });
     return () => subscription.remove();
   }, [checkAuth]);
@@ -625,14 +664,14 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
       try {
         const result = await authSignInWithGoogleWeb(isRegistration);
         if (result.success) {
-          await checkAuth();
+          await checkAuthAfterSuccessfulBrowserFallback();
         }
         return result;
       } finally {
-        browserFallbackAuthChecksRef.current -= 1;
+        await releaseBrowserFallbackAuthCheckSuppression();
       }
     },
-    [checkAuth],
+    [checkAuthAfterSuccessfulBrowserFallback, releaseBrowserFallbackAuthCheckSuppression],
   );
 
   // Browser-based Apple fallback (native Sign in with Apple threw a non-cancel
@@ -644,14 +683,14 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
       try {
         const result = await authSignInWithAppleWeb(isRegistration);
         if (result.success) {
-          await checkAuth();
+          await checkAuthAfterSuccessfulBrowserFallback();
         }
         return result;
       } finally {
-        browserFallbackAuthChecksRef.current -= 1;
+        await releaseBrowserFallbackAuthCheckSuppression();
       }
     },
-    [checkAuth],
+    [checkAuthAfterSuccessfulBrowserFallback, releaseBrowserFallbackAuthCheckSuppression],
   );
 
   const signInWithCredentials = useCallback(


### PR DESCRIPTION
## Summary

- keep Android Google sign-in pending across the Custom Tab background-to-foreground transition and allow a bounded callback grace window
- revalidate auth exactly once after successful fallback handling, with reference-counted foreground work for overlapping attempts
- make settlement cleanup exact-once and make retained late URL/AppState callbacks strict no-ops
- preserve the existing iOS callback race and document the remaining cold-start/process-death limitation

Closes #4142.

## QA

- focused mobile suites: 120/120 passed
- late-callback regression: 5/5 stress runs passed
- full mobile suite: 575 files, 4,932 tests passed before the final narrow regression; focused post-fix suite passed
- `vp run typecheck:mobile`
- touched-file `vp check`
- `vp run check:mobile-bundle` for iOS and Android
- `git diff --no-ext-diff --check origin/main`
- two independent Sol xhigh reviews; final verdict PASS

## Device verification gate

A real Android device still needs the native Google `DEVELOPER_ERROR`/`INTERNAL_ERROR` reproduction, warm-process callback/AppState ordering, cancellation, and foreground revalidation checks from `.boardsesh/qa-notes.md`. Cold-start/process-death callback recovery is explicitly not solved by this OTA-safe change.

## Release Notes

Android Google sign-in now waits for the browser callback when the app resumes instead of failing early.