### PR TITLE
fix(mobile): serialize same-board iOS BLE reconnects

### DIFF
--- a/packages/mobile/ios-tests/BoardBleDisconnectTests.swift
+++ b/packages/mobile/ios-tests/BoardBleDisconnectTests.swift
@@ -9,12 +9,14 @@ final class BoardBleDisconnectTests: XCTestCase {
     private var scheduler: FakeBleTimerScheduler!
     private var manager: BoardBleManager!
     private var cancelledPeripheralIds: [UUID] = []
+    private var connectedPeripheralIds: [UUID] = []
     private var stopScanCallCount = 0
     private let uartWriteCharacteristicUuid = CBUUID(string: "6E400002-B5A3-F393-E0A9-E50E24DCCA9E")
 
     override func setUp() {
         super.setUp()
         cancelledPeripheralIds = []
+        connectedPeripheralIds = []
         stopScanCallCount = 0
         scheduler = FakeBleTimerScheduler()
         manager = BoardBleManager(timerScheduler: scheduler, createCentralManagerEagerly: false)
@@ -26,6 +28,10 @@ final class BoardBleDisconnectTests: XCTestCase {
             manager.testHooks.setCancelPeripheralConnectionOverride { [weak self] peripheral in
                 self?.cancelledPeripheralIds.append(peripheral.identifier)
             }
+            manager.testHooks.setConnectPeripheralOverride { [weak self] peripheral in
+                self?.connectedPeripheralIds.append(peripheral.identifier)
+            }
+            manager.testHooks.setCentralState(.poweredOn)
         }
     }
 
@@ -33,6 +39,8 @@ final class BoardBleDisconnectTests: XCTestCase {
         manager.testHooks.sync {
             manager.testHooks.setStopScanOverride(nil)
             manager.testHooks.setCancelPeripheralConnectionOverride(nil)
+            manager.testHooks.setConnectPeripheralOverride(nil)
+            manager.testHooks.setCentralState(nil)
         }
         manager = nil
         scheduler = nil
@@ -82,6 +90,16 @@ final class BoardBleDisconnectTests: XCTestCase {
         manager.testHooks.sync {
             manager.write(data: Data([0x01])) { error, _ in onSettle(error) }
             manager.write(data: Data([0x02])) { error, _ in onSettle(error) }
+        }
+    }
+
+    private func fireLatestOneShot(label: String) {
+        manager.testHooks.sync {
+            guard let timer = scheduler.lastOneShot(label: label) else {
+                XCTFail("expected a scheduled \(label) timer")
+                return
+            }
+            timer.fire()
         }
     }
 
@@ -244,5 +262,326 @@ final class BoardBleDisconnectTests: XCTestCase {
         XCTAssertEqual(disconnectEvents.count, 1)
         XCTAssertTrue(cancelledPeripheralIds.isEmpty)
         XCTAssertEqual(stopScanCallCount, 0)
+    }
+
+    func testImmediateSamePeripheralReconnectWaitsForCancellationCallback() {
+        let peripheral = FakeWritablePeripheral()
+        var disconnectEventCount = 0
+        var disconnectCompletionCalled = false
+        var connectResults: [Result<Void, Error>] = []
+        installConnection(peripheral: peripheral) { _, _ in disconnectEventCount += 1 }
+
+        manager.testHooks.sync {
+            manager.disconnect { disconnectCompletionCalled = true }
+            manager.connect(deviceId: peripheral.identifier.uuidString) { connectResults.append($0) }
+        }
+
+        XCTAssertTrue(disconnectCompletionCalled)
+        XCTAssertTrue(connectedPeripheralIds.isEmpty)
+        XCTAssertEqual(manager.testHooks.sync { manager.testHooks.deferredConnectPeripheralId }, peripheral.identifier)
+        XCTAssertFalse(manager.testHooks.sync { manager.testHooks.hasPendingConnect })
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds },
+            Set([peripheral.identifier])
+        )
+
+        manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: nil)
+
+        XCTAssertEqual(connectedPeripheralIds, [peripheral.identifier])
+        XCTAssertNil(manager.testHooks.sync { manager.testHooks.deferredConnectPeripheralId })
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds.isEmpty })
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.hasPendingConnect })
+        XCTAssertNotNil(scheduler.lastOneShot(label: "connectTimeout"))
+        XCTAssertEqual(disconnectEventCount, 0)
+        XCTAssertTrue(connectResults.isEmpty)
+
+        manager.testHooks.fireConnectionReady(
+            peripheral: peripheral,
+            characteristic: makeWriteCharacteristic()
+        )
+        XCTAssertEqual(connectResults.count, 1)
+        if case .failure(let error) = connectResults[0] {
+            XCTFail("expected reconnect success, got \(error)")
+        }
+        XCTAssertEqual(connectedPeripheralIds, [peripheral.identifier])
+        XCTAssertEqual(disconnectEventCount, 0)
+    }
+
+    func testCancelledConnectingPeripheralSettlesBarrierThroughDidFailToConnect() {
+        let peripheral = FakeWritablePeripheral()
+        var firstConnectError: Error?
+        var reconnectResults: [Result<Void, Error>] = []
+        manager.testHooks.sync {
+            manager.testHooks.setDiscoveredPeripheral(peripheral)
+            manager.connect(deviceId: peripheral.identifier.uuidString) { result in
+                if case .failure(let error) = result { firstConnectError = error }
+            }
+            manager.disconnect()
+            manager.connect(deviceId: peripheral.identifier.uuidString) { reconnectResults.append($0) }
+        }
+
+        XCTAssertEqual(connectedPeripheralIds, [peripheral.identifier])
+        XCTAssertEqual(
+            firstConnectError?.localizedDescription,
+            BoardBleError.notConnected.localizedDescription
+        )
+        XCTAssertEqual(manager.testHooks.sync { manager.testHooks.deferredConnectPeripheralId }, peripheral.identifier)
+
+        manager.testHooks.fireDidFailToConnect(peripheral: peripheral, error: BoardBleError.notConnected)
+
+        XCTAssertEqual(connectedPeripheralIds, [peripheral.identifier, peripheral.identifier])
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.hasPendingConnect })
+        XCTAssertTrue(reconnectResults.isEmpty)
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds.isEmpty })
+    }
+
+    func testDifferentPeripheralConnectsImmediatelyWhileOldBarrierRemains() {
+        let oldPeripheral = FakeWritablePeripheral()
+        let newPeripheral = FakeWritablePeripheral()
+        var disconnectEventCount = 0
+        installConnection(peripheral: oldPeripheral) { _, _ in disconnectEventCount += 1 }
+
+        manager.testHooks.sync {
+            manager.disconnect()
+            manager.testHooks.setDiscoveredPeripheral(newPeripheral)
+            manager.connect(deviceId: newPeripheral.identifier.uuidString) { _ in }
+        }
+
+        XCTAssertEqual(connectedPeripheralIds, [newPeripheral.identifier])
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds },
+            Set([oldPeripheral.identifier])
+        )
+
+        manager.testHooks.fireDidDisconnect(peripheral: oldPeripheral, error: nil)
+
+        XCTAssertEqual(connectedPeripheralIds, [newPeripheral.identifier])
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds.isEmpty })
+        XCTAssertEqual(disconnectEventCount, 0)
+    }
+
+    func testNewestSamePeripheralDeferredRequestSupersedesOlderWaiter() {
+        let peripheral = FakeWritablePeripheral()
+        var firstError: Error?
+        var secondResults: [Result<Void, Error>] = []
+        installConnection(peripheral: peripheral) { _, _ in }
+
+        manager.testHooks.sync {
+            manager.disconnect()
+            manager.connect(deviceId: peripheral.identifier.uuidString) { result in
+                if case .failure(let error) = result { firstError = error }
+            }
+            manager.connect(deviceId: peripheral.identifier.uuidString) { secondResults.append($0) }
+        }
+
+        XCTAssertEqual(firstError?.localizedDescription, BoardBleError.superseded.localizedDescription)
+        XCTAssertTrue(secondResults.isEmpty)
+        XCTAssertTrue(connectedPeripheralIds.isEmpty)
+
+        manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: nil)
+
+        XCTAssertEqual(connectedPeripheralIds, [peripheral.identifier])
+        XCTAssertTrue(secondResults.isEmpty)
+    }
+
+    func testExplicitDisconnectRejectsDeferredConnectWithoutConsumingBarrier() {
+        let peripheral = FakeWritablePeripheral()
+        var deferredError: Error?
+        installConnection(peripheral: peripheral) { _, _ in }
+
+        manager.testHooks.sync {
+            manager.disconnect()
+            manager.connect(deviceId: peripheral.identifier.uuidString) { result in
+                if case .failure(let error) = result { deferredError = error }
+            }
+            manager.disconnect()
+        }
+
+        XCTAssertEqual(deferredError?.localizedDescription, BoardBleError.notConnected.localizedDescription)
+        XCTAssertNil(manager.testHooks.sync { manager.testHooks.deferredConnectPeripheralId })
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds },
+            Set([peripheral.identifier])
+        )
+
+        manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: nil)
+        XCTAssertTrue(connectedPeripheralIds.isEmpty)
+    }
+
+    func testBarrierWatchdogRejectsWaiterWithoutForcingConnectAndRetainsBarrier() {
+        let peripheral = FakeWritablePeripheral()
+        var deferredError: Error?
+        var retryAfterExpiryError: Error?
+        installConnection(peripheral: peripheral) { _, _ in }
+
+        manager.testHooks.sync {
+            manager.disconnect()
+            manager.connect(deviceId: peripheral.identifier.uuidString) { result in
+                if case .failure(let error) = result { deferredError = error }
+            }
+        }
+        fireLatestOneShot(label: "managerCancellationBarrierWatchdog")
+
+        XCTAssertEqual(deferredError?.localizedDescription, BoardBleError.connectTimedOut.localizedDescription)
+        XCTAssertTrue(connectedPeripheralIds.isEmpty)
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds },
+            Set([peripheral.identifier])
+        )
+
+        manager.testHooks.sync {
+            manager.connect(deviceId: peripheral.identifier.uuidString) { result in
+                if case .failure(let error) = result { retryAfterExpiryError = error }
+            }
+        }
+        XCTAssertEqual(
+            retryAfterExpiryError?.localizedDescription,
+            BoardBleError.connectTimedOut.localizedDescription
+        )
+        XCTAssertTrue(connectedPeripheralIds.isEmpty)
+
+        manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: nil)
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds.isEmpty })
+        XCTAssertTrue(connectedPeripheralIds.isEmpty)
+    }
+
+    func testBluetoothUnavailableRejectsDeferredConnectAndClearsCancellationState() {
+        let peripheral = FakeWritablePeripheral()
+        var deferredError: Error?
+        installConnection(peripheral: peripheral) { _, _ in }
+
+        manager.testHooks.sync {
+            manager.disconnect()
+            manager.connect(deviceId: peripheral.identifier.uuidString) { result in
+                if case .failure(let error) = result { deferredError = error }
+            }
+        }
+        let barrierWatchdog = scheduler.lastOneShot(label: "managerCancellationBarrierWatchdog")
+
+        manager.testHooks.fireCentralStateUpdate(.poweredOff)
+
+        XCTAssertEqual(
+            deferredError?.localizedDescription,
+            BoardBleError.bluetoothUnavailable.localizedDescription
+        )
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds.isEmpty })
+        XCTAssertNil(manager.testHooks.sync { manager.testHooks.deferredConnectPeripheralId })
+        XCTAssertNil(
+            manager.testHooks.sync {
+                manager.testHooks.intentionalDisconnectGeneration(for: peripheral.identifier)
+            }
+        )
+        XCTAssertTrue(barrierWatchdog?.cancelled ?? false)
+    }
+
+    func testWriteStallSamePeripheralWaiterJoinsExactlyOneRecoveryReconnect() {
+        let peripheral = FakeWritablePeripheral()
+        var writeError: Error?
+        var reconnectResults: [Result<Void, Error>] = []
+        var disconnectEventCount = 0
+        installConnection(peripheral: peripheral) { _, _ in disconnectEventCount += 1 }
+
+        manager.testHooks.sync {
+            manager.write(data: Data([0x01])) { error, _ in writeError = error }
+        }
+        fireLatestOneShot(label: "writeAckWatchdog")
+        manager.testHooks.sync {
+            manager.connect(deviceId: peripheral.identifier.uuidString) { reconnectResults.append($0) }
+        }
+
+        XCTAssertEqual(writeError?.localizedDescription, BoardBleError.writeTimedOut.localizedDescription)
+        XCTAssertEqual(manager.testHooks.sync { manager.testHooks.writeStallRecoveries }, 1)
+        XCTAssertEqual(manager.testHooks.sync { manager.testHooks.deferredConnectPeripheralId }, peripheral.identifier)
+        XCTAssertTrue(connectedPeripheralIds.isEmpty)
+
+        manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: nil)
+
+        XCTAssertEqual(connectedPeripheralIds, [peripheral.identifier])
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.hasPendingConnect })
+        XCTAssertTrue(
+            scheduler.lastOneShot(label: "writeStallRecoveryWatchdog")?.cancelled ?? false
+        )
+        XCTAssertEqual(disconnectEventCount, 0)
+
+        manager.testHooks.fireConnectionReady(
+            peripheral: peripheral,
+            characteristic: makeWriteCharacteristic()
+        )
+        XCTAssertEqual(reconnectResults.count, 1)
+        if case .failure(let error) = reconnectResults[0] {
+            XCTFail("expected recovery success, got \(error)")
+        }
+        XCTAssertNil(manager.testHooks.sync { manager.testHooks.writeStallRecoveringPeripheralId })
+        XCTAssertEqual(connectedPeripheralIds, [peripheral.identifier])
+        XCTAssertEqual(disconnectEventCount, 0)
+    }
+
+    func testWriteStallAutomaticReconnectFailurePreservesFailureEvent() {
+        let peripheral = FakeWritablePeripheral()
+        let reconnectError = NSError(
+            domain: "BoardBleDisconnectTests",
+            code: 91,
+            userInfo: [NSLocalizedDescriptionKey: "Recovery connect failed"]
+        )
+        var disconnectBodies: [[String: Any]?] = []
+        installConnection(peripheral: peripheral) { _, body in disconnectBodies.append(body) }
+
+        manager.testHooks.sync {
+            manager.write(data: Data([0x01])) { _, _ in }
+        }
+        fireLatestOneShot(label: "writeAckWatchdog")
+        manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: nil)
+
+        XCTAssertEqual(connectedPeripheralIds, [peripheral.identifier])
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.hasPendingConnect })
+        XCTAssertEqual(manager.testHooks.sync { manager.testHooks.writeStallRecoveries }, 1)
+        XCTAssertTrue(disconnectBodies.isEmpty)
+
+        manager.testHooks.fireDidFailToConnect(peripheral: peripheral, error: reconnectError)
+
+        XCTAssertEqual(connectedPeripheralIds, [peripheral.identifier])
+        XCTAssertFalse(manager.testHooks.sync { manager.testHooks.hasPendingConnect })
+        XCTAssertNil(manager.testHooks.sync { manager.testHooks.writeStallRecoveringPeripheralId })
+        XCTAssertEqual(manager.testHooks.sync { manager.testHooks.writeStallRecoveries }, 0)
+        XCTAssertEqual(disconnectBodies.count, 1)
+        XCTAssertEqual(disconnectBodies[0]?["context"] as? String, "write_stall_recovery_failed")
+        XCTAssertEqual(
+            disconnectBodies[0]?["errorDescription"] as? String,
+            reconnectError.localizedDescription
+        )
+    }
+
+    func testDifferentPeripheralSupersedesDeferredWriteStallReconnect() {
+        let recoveringPeripheral = FakeWritablePeripheral()
+        let winningPeripheral = FakeWritablePeripheral()
+        var recoveringWaiterError: Error?
+        installConnection(peripheral: recoveringPeripheral) { _, _ in }
+
+        manager.testHooks.sync {
+            manager.write(data: Data([0x01])) { _, _ in }
+        }
+        fireLatestOneShot(label: "writeAckWatchdog")
+        manager.testHooks.sync {
+            manager.connect(deviceId: recoveringPeripheral.identifier.uuidString) { result in
+                if case .failure(let error) = result { recoveringWaiterError = error }
+            }
+            manager.testHooks.setDiscoveredPeripheral(winningPeripheral)
+            manager.connect(deviceId: winningPeripheral.identifier.uuidString) { _ in }
+        }
+
+        XCTAssertEqual(
+            recoveringWaiterError?.localizedDescription,
+            BoardBleError.superseded.localizedDescription
+        )
+        XCTAssertEqual(connectedPeripheralIds, [winningPeripheral.identifier])
+        XCTAssertNil(manager.testHooks.sync { manager.testHooks.writeStallRecoveringPeripheralId })
+        XCTAssertEqual(manager.testHooks.sync { manager.testHooks.writeStallRecoveries }, 0)
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds },
+            Set([recoveringPeripheral.identifier])
+        )
+
+        manager.testHooks.fireDidDisconnect(peripheral: recoveringPeripheral, error: nil)
+        XCTAssertEqual(connectedPeripheralIds, [winningPeripheral.identifier])
     }
 }

--- a/packages/mobile/ios-tests/BoardBleDisconnectTests.swift
+++ b/packages/mobile/ios-tests/BoardBleDisconnectTests.swift
@@ -408,10 +408,10 @@ final class BoardBleDisconnectTests: XCTestCase {
         XCTAssertTrue(connectedPeripheralIds.isEmpty)
     }
 
-    func testBarrierWatchdogRejectsWaiterWithoutForcingConnectAndRetainsBarrier() {
+    func testBarrierWatchdogRejectsWaiterButFreshConnectDisplacesExpiredBarrier() {
         let peripheral = FakeWritablePeripheral()
         var deferredError: Error?
-        var retryAfterExpiryError: Error?
+        var retryResults: [Result<Void, Error>] = []
         installConnection(peripheral: peripheral) { _, _ in }
 
         manager.testHooks.sync {
@@ -422,6 +422,9 @@ final class BoardBleDisconnectTests: XCTestCase {
         }
         fireLatestOneShot(label: "managerCancellationBarrierWatchdog")
 
+        // At expiry the parked waiter is rejected (its promise must settle) and
+        // the barrier is retained: expiry alone is not evidence CoreBluetooth
+        // delivered the terminal callback.
         XCTAssertEqual(deferredError?.localizedDescription, BoardBleError.connectTimedOut.localizedDescription)
         XCTAssertTrue(connectedPeripheralIds.isEmpty)
         XCTAssertEqual(
@@ -429,20 +432,212 @@ final class BoardBleDisconnectTests: XCTestCase {
             Set([peripheral.identifier])
         )
 
+        // A fresh explicit connect AFTER expiry must proceed as a normal
+        // pending connect — never insta-fail — and displaces the expired
+        // barrier (gone from the map, tombstoned for one late callback).
         manager.testHooks.sync {
+            manager.connect(deviceId: peripheral.identifier.uuidString) { retryResults.append($0) }
+        }
+        XCTAssertTrue(retryResults.isEmpty)
+        XCTAssertEqual(connectedPeripheralIds, [peripheral.identifier])
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds.isEmpty })
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.displacedCancellationPeripheralIds },
+            Set([peripheral.identifier])
+        )
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.hasPendingConnect })
+        XCTAssertNotNil(scheduler.lastOneShot(label: "connectTimeout"))
+
+        // The retry's own didConnect retires the tombstone (in-order delivery:
+        // the old attempt's callback cannot arrive after it) and the connection
+        // completes normally.
+        manager.testHooks.fireDidConnect(peripheral: peripheral)
+        XCTAssertTrue(
+            manager.testHooks.sync { manager.testHooks.displacedCancellationPeripheralIds.isEmpty }
+        )
+        manager.testHooks.fireConnectionReady(
+            peripheral: peripheral,
+            characteristic: makeWriteCharacteristic()
+        )
+        XCTAssertEqual(retryResults.count, 1)
+        if case .failure(let error) = retryResults[0] {
+            XCTFail("expected the post-expiry connect to succeed, got \(error)")
+        }
+    }
+
+    func testConnectTimeoutThenExpiredBarrierDoesNotWedgeRetry() {
+        let peripheral = FakeWritablePeripheral()
+        var firstConnectError: Error?
+        var retryResults: [Result<Void, Error>] = []
+        var disconnectEventCount = 0
+        manager.testHooks.sync {
+            manager.setEventHandlers(
+                onScanResult: nil,
+                onDisconnect: { _, _ in disconnectEventCount += 1 },
+                onConnected: nil
+            )
+            manager.testHooks.setDiscoveredPeripheral(peripheral)
             manager.connect(deviceId: peripheral.identifier.uuidString) { result in
-                if case .failure(let error) = result { retryAfterExpiryError = error }
+                if case .failure(let error) = result { firstConnectError = error }
             }
         }
+        XCTAssertEqual(connectedPeripheralIds, [peripheral.identifier])
+
+        // Out of range: the connect timeout fires and cancels the pending
+        // OS-level connect, registering the cancellation barrier.
+        fireLatestOneShot(label: "connectTimeout")
         XCTAssertEqual(
-            retryAfterExpiryError?.localizedDescription,
+            firstConnectError?.localizedDescription,
             BoardBleError.connectTimedOut.localizedDescription
         )
-        XCTAssertTrue(connectedPeripheralIds.isEmpty)
+        XCTAssertEqual(cancelledPeripheralIds, [peripheral.identifier])
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds },
+            Set([peripheral.identifier])
+        )
 
+        // Cancelling a PENDING connect legitimately yields NO terminal
+        // callback, so the barrier watchdog expires with nothing to consume.
+        fireLatestOneShot(label: "managerCancellationBarrierWatchdog")
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds },
+            Set([peripheral.identifier])
+        )
+
+        // The user walks back into range and retries. The retry must proceed
+        // as a normal pending connect, not insta-fail for the rest of the app
+        // session (the pre-fix wedge).
+        manager.testHooks.sync {
+            manager.connect(deviceId: peripheral.identifier.uuidString) { retryResults.append($0) }
+        }
+        XCTAssertTrue(retryResults.isEmpty)
+        XCTAssertEqual(connectedPeripheralIds, [peripheral.identifier, peripheral.identifier])
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds.isEmpty })
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.hasPendingConnect })
+
+        // A late didDisconnect for the OLD cancelled attempt is a no-op: it
+        // must not fail the retry, emit a disconnect event, or cancel the
+        // retry's OS-level connect.
+        manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: nil)
+        XCTAssertTrue(retryResults.isEmpty)
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.hasPendingConnect })
+        XCTAssertEqual(disconnectEventCount, 0)
+        XCTAssertEqual(cancelledPeripheralIds, [peripheral.identifier])
+        XCTAssertTrue(
+            manager.testHooks.sync { manager.testHooks.displacedCancellationPeripheralIds.isEmpty }
+        )
+
+        // The retry completes as a normal connect.
+        manager.testHooks.fireDidConnect(peripheral: peripheral)
+        manager.testHooks.fireConnectionReady(
+            peripheral: peripheral,
+            characteristic: makeWriteCharacteristic()
+        )
+        XCTAssertEqual(retryResults.count, 1)
+        if case .failure(let error) = retryResults[0] {
+            XCTFail("expected the retry to succeed, got \(error)")
+        }
+        XCTAssertEqual(disconnectEventCount, 0)
+    }
+
+    func testStaleDidConnectUnderActiveBarrierStillIssuesConcreteCancel() {
+        let peripheral = FakeWritablePeripheral()
+        var firstConnectError: Error?
+        var disconnectEventCount = 0
+        manager.testHooks.sync {
+            manager.setEventHandlers(
+                onScanResult: nil,
+                onDisconnect: { _, _ in disconnectEventCount += 1 },
+                onConnected: nil
+            )
+            manager.testHooks.setDiscoveredPeripheral(peripheral)
+            manager.connect(deviceId: peripheral.identifier.uuidString) { result in
+                if case .failure(let error) = result { firstConnectError = error }
+            }
+        }
+        fireLatestOneShot(label: "connectTimeout")
+        XCTAssertEqual(
+            firstConnectError?.localizedDescription,
+            BoardBleError.connectTimedOut.localizedDescription
+        )
+        XCTAssertEqual(cancelledPeripheralIds, [peripheral.identifier])
+        XCTAssertEqual(scheduler.oneShots(label: "managerCancellationBarrierWatchdog").count, 1)
+
+        // The OS finished the connect anyway, racing the cancel: the system now
+        // holds a live connection no generation owns. The corrective cancel
+        // must go out even though this UUID's barrier is already registered —
+        // skipping it left the connection blocking the wall.
+        manager.testHooks.fireDidConnect(peripheral: peripheral)
+        XCTAssertEqual(cancelledPeripheralIds, [peripheral.identifier, peripheral.identifier])
+        // No second barrier: the existing one still owns the terminal callback.
+        XCTAssertEqual(scheduler.oneShots(label: "managerCancellationBarrierWatchdog").count, 1)
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds },
+            Set([peripheral.identifier])
+        )
+
+        // Cancelling a CONNECTED peripheral yields exactly one didDisconnect,
+        // which the existing barrier consumes silently.
         manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: nil)
         XCTAssertTrue(manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds.isEmpty })
-        XCTAssertTrue(connectedPeripheralIds.isEmpty)
+        XCTAssertEqual(disconnectEventCount, 0)
+        // No auto-reconnect follows the corrective cancel.
+        XCTAssertEqual(connectedPeripheralIds, [peripheral.identifier])
+    }
+
+    func testDeferredConnectSupersedesPendingDifferentBoardConnect() {
+        let barrieredPeripheral = FakeWritablePeripheral()
+        let otherPeripheral = FakeWritablePeripheral()
+        var otherConnectError: Error?
+        var deferredResults: [Result<Void, Error>] = []
+        var disconnectEventCount = 0
+        installConnection(peripheral: barrieredPeripheral) { _, _ in disconnectEventCount += 1 }
+
+        manager.testHooks.sync {
+            manager.disconnect()
+            manager.testHooks.setDiscoveredPeripheral(otherPeripheral)
+            manager.connect(deviceId: otherPeripheral.identifier.uuidString) { result in
+                if case .failure(let error) = result { otherConnectError = error }
+            }
+        }
+        XCTAssertEqual(connectedPeripheralIds, [otherPeripheral.identifier])
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.hasPendingConnect })
+        let otherConnectTimeout = scheduler.lastOneShot(label: "connectTimeout")
+
+        manager.testHooks.sync {
+            manager.connect(deviceId: barrieredPeripheral.identifier.uuidString) { deferredResults.append($0) }
+        }
+
+        // Deferring behind the barrier must settle the in-flight different-board
+        // connect NOW — left alone it keeps racing for up to the connect
+        // timeout and can light the wall before the deferred connect wins.
+        XCTAssertEqual(
+            otherConnectError?.localizedDescription,
+            BoardBleError.superseded.localizedDescription
+        )
+        XCTAssertFalse(manager.testHooks.sync { manager.testHooks.hasPendingConnect })
+        XCTAssertTrue(otherConnectTimeout?.cancelled ?? false)
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.deferredConnectPeripheralId },
+            barrieredPeripheral.identifier
+        )
+        XCTAssertNil(manager.connectedDeviceId)
+
+        // The superseded board's late didConnect is stale → corrective cancel.
+        manager.testHooks.fireDidConnect(peripheral: otherPeripheral)
+        XCTAssertEqual(
+            cancelledPeripheralIds,
+            [barrieredPeripheral.identifier, otherPeripheral.identifier]
+        )
+
+        // The barrier settles → the deferred same-board connect starts.
+        manager.testHooks.fireDidDisconnect(peripheral: barrieredPeripheral, error: nil)
+        XCTAssertEqual(
+            connectedPeripheralIds,
+            [otherPeripheral.identifier, barrieredPeripheral.identifier]
+        )
+        XCTAssertTrue(deferredResults.isEmpty)
+        XCTAssertEqual(disconnectEventCount, 0)
     }
 
     func testBluetoothUnavailableRejectsDeferredConnectAndClearsCancellationState() {

--- a/packages/mobile/ios-tests/BoardBleDisconnectTests.swift
+++ b/packages/mobile/ios-tests/BoardBleDisconnectTests.swift
@@ -474,6 +474,42 @@ final class BoardBleDisconnectTests: XCTestCase {
         XCTAssertTrue(barrierWatchdog?.cancelled ?? false)
     }
 
+    func testBluetoothUnavailableClearsExpiredBarrierWithoutResettlingWaiter() {
+        let peripheral = FakeWritablePeripheral()
+        var deferredResults: [Result<Void, Error>] = []
+        installConnection(peripheral: peripheral) { _, _ in }
+
+        manager.testHooks.sync {
+            manager.disconnect()
+            manager.connect(deviceId: peripheral.identifier.uuidString) { deferredResults.append($0) }
+        }
+        let barrierWatchdog = scheduler.lastOneShot(label: "managerCancellationBarrierWatchdog")
+        fireLatestOneShot(label: "managerCancellationBarrierWatchdog")
+
+        XCTAssertEqual(deferredResults.count, 1)
+        if case .failure(let error) = deferredResults[0] {
+            XCTAssertEqual(error.localizedDescription, BoardBleError.connectTimedOut.localizedDescription)
+        } else {
+            XCTFail("expected the expired barrier to time out its waiter")
+        }
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds },
+            Set([peripheral.identifier])
+        )
+
+        manager.testHooks.fireCentralStateUpdate(.poweredOff)
+
+        XCTAssertEqual(deferredResults.count, 1)
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds.isEmpty })
+        XCTAssertNil(manager.testHooks.sync { manager.testHooks.deferredConnectPeripheralId })
+        XCTAssertNil(
+            manager.testHooks.sync {
+                manager.testHooks.intentionalDisconnectGeneration(for: peripheral.identifier)
+            }
+        )
+        XCTAssertTrue(barrierWatchdog?.cancelled ?? false)
+    }
+
     func testWriteStallSamePeripheralWaiterJoinsExactlyOneRecoveryReconnect() {
         let peripheral = FakeWritablePeripheral()
         var writeError: Error?

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -194,6 +194,17 @@ private final class BoardBleDisplayWriteOutcome: @unchecked Sendable {
 final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate {
     static let shared = BoardBleManager()
 
+    private final class ManagerCancellationBarrier {
+        var watchdog: BleOneShotTimer?
+        var hasExpired = false
+    }
+
+    private struct DeferredConnectRequest {
+        let deviceId: String
+        let peripheralId: UUID
+        let completion: (Result<Void, Error>) -> Void
+    }
+
     private struct WriteRequest {
         let chunks: [Data]
         // Static preferred write type and chunk size are snapshotted at enqueue
@@ -258,7 +269,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         options: [CBCentralManagerOptionRestoreIdentifierKey: "com.boardsesh.app.board-ble"]
     )
 
-    private var discoveredPeripherals: [String: CBPeripheral] = [:]
+    private var discoveredPeripherals: [String: WritableBlePeripheral] = [:]
     private var discoveredNames: [String: String] = [:]
     // What was last emitted to JS for each device in the CURRENT scan
     // (name + advertised UUIDs). With allow-duplicates on and (on newer JS)
@@ -269,7 +280,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private var connectedPeripheral: WritableBlePeripheral?
     private var writeCharacteristic: CBCharacteristic?
     private var pendingConnectCompletion: ((Result<Void, Error>) -> Void)?
-    private var connectTimeoutWorkItem: DispatchWorkItem?
+    private var connectTimeoutTimer: BleOneShotTimer?
     private var scanRequested = false
     private var scanServices: [CBUUID] = []
     // Set while the Live Activity lightbulb's reconnect-by-last-known-board is
@@ -278,6 +289,14 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private var reconnectScanCompletion: ((Result<Void, Error>) -> Void)?
     private var reconnectScanTimeoutWorkItem: DispatchWorkItem?
     private var intentionalDisconnectGenerations: [UUID: UInt64] = [:]
+    // CoreBluetooth's terminal callback for a manager-initiated cancellation can
+    // arrive after `cancelPeripheralConnection` returns. Because the callback has
+    // no connection-generation token, never start a new connection to the same
+    // UUID until didDisconnect/didFailToConnect consumes this barrier. Different
+    // UUIDs remain independent. One global deferred request is enough because
+    // connect is last-request-wins throughout the manager.
+    private var managerCancellationBarriers: [UUID: ManagerCancellationBarrier] = [:]
+    private var deferredConnectRequest: DeferredConnectRequest?
     private var peripheralGenerations: [UUID: UInt64] = [:]
     private var connectionGeneration: UInt64 = 0
     // Peripherals whose targeted service probe (discoverServices([uart,
@@ -396,6 +415,12 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     /// `CBCentralManager` is instantiated. nil in production/dev; set only through
     /// `TestHooks.setCancelPeripheralConnectionOverride` (same-file extension).
     private var cancelPeripheralConnectionOverrideForTesting: ((WritableBlePeripheral) -> Void)?
+    /// Test-only interception of `CBCentralManager.connect`, paired with the
+    /// cancellation seam above so native tests can drive the complete callback
+    /// state machine without instantiating CoreBluetooth.
+    private var connectPeripheralOverrideForTesting: ((WritableBlePeripheral) -> Void)?
+    /// Test-only central state. nil keeps production/dev on the real manager.
+    private var centralStateOverrideForTesting: CBManagerState?
     #endif
 
     private var onScanResult: ((BoardBleScanResult) -> Void)?
@@ -639,7 +664,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     }
 
     private var isAvailableOnBleQueue: Bool {
-        switch centralManager.state {
+        switch centralStateOnBleQueue {
         case .poweredOn, .unknown, .resetting:
             return true
         case .poweredOff, .unsupported, .unauthorized:
@@ -647,6 +672,15 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         @unknown default:
             return false
         }
+    }
+
+    private var centralStateOnBleQueue: CBManagerState {
+        #if DEBUG || BOARDSESH_TESTS
+        if let centralStateOverrideForTesting {
+            return centralStateOverrideForTesting
+        }
+        #endif
+        return centralManager.state
     }
 
     private func startScanOnBleQueue(serviceUuids: [String], completion: @escaping (Result<Void, Error>) -> Void) {
@@ -659,7 +693,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         scanRequested = true
         emittedScanResults = [:]
 
-        guard centralManager.state == .poweredOn else {
+        guard centralStateOnBleQueue == .poweredOn else {
             if isAvailableOnBleQueue {
                 completion(.success(()))
             } else {
@@ -695,10 +729,40 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // connect interleaves instead of letting it linger until its timeout.
         failReconnectScan(BoardBleError.notConnected)
 
-        guard centralManager.state == .poweredOn else {
+        guard centralStateOnBleQueue == .poweredOn else {
             completion(.failure(BoardBleError.bluetoothUnavailable))
             return
         }
+
+        let requestedPeripheralId = UUID(uuidString: deviceId)
+        if let recoveringPeripheralId = writeStallRecoveringPeripheralId,
+           requestedPeripheralId != recoveringPeripheralId {
+            writeStallRecoveringPeripheralId = nil
+            writeStallRecoveries = 0
+            writeStallRecoveryWatchdog?.cancel()
+            writeStallRecoveryWatchdog = nil
+        }
+
+        // A manager cancellation for this UUID is not settled until
+        // didDisconnect/didFailToConnect arrives. Starting another same-UUID
+        // generation sooner is unsafe because CoreBluetooth does not identify
+        // which generation owns the late callback. Retain only the newest
+        // request; an unrelated UUID is free to connect immediately.
+        if let peripheralId = requestedPeripheralId,
+           let cancellationBarrier = managerCancellationBarriers[peripheralId] {
+            deferConnectUntilCancellationSettles(
+                deviceId: deviceId,
+                peripheralId: peripheralId,
+                barrier: cancellationBarrier,
+                completion: completion
+            )
+            return
+        }
+
+        // A new request to an unblocked UUID wins over a request parked behind a
+        // different UUID's barrier. The old barrier itself remains until its
+        // terminal callback arrives.
+        failDeferredConnect(BoardBleError.superseded)
 
         if connectedPeripheral?.identifier.uuidString == deviceId, writeCharacteristic != nil {
             completion(.success(()))
@@ -729,11 +793,11 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // Settle any still-pending connect before starting this one. Silently
         // overwriting pendingConnectCompletion would orphan the prior attempt's
         // JS promise (it would never resolve), and its still-scheduled timeout
-        // work item could later misfire against THIS attempt: for a different
+        // timer could later misfire against THIS attempt: for a different
         // target device the old peripheral's generation entry survives the
         // bump below, so the stale timeout's guards both pass and it would
         // call completePendingConnect against the new completion.
-        // completePendingConnect also cancels that stale timeout work item.
+        // completePendingConnect also cancels that stale timeout timer.
         completePendingConnect(.failure(BoardBleError.superseded))
         connectionGeneration += 1
         let generation = connectionGeneration
@@ -742,9 +806,9 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         connectedPeripheral = peripheral
         writeCharacteristic = nil
         peripheralGenerations[peripheral.identifier] = generation
-        peripheral.delegate = self
+        preparePeripheralForConnection(peripheral)
 
-        let timeoutWorkItem = DispatchWorkItem { [weak self] in
+        connectTimeoutTimer = timerScheduler.scheduleOneShot(after: connectTimeout, label: "connectTimeout") { [weak self] in
             guard let self else { return }
             guard self.pendingConnectCompletion != nil else { return }
             guard self.peripheralGenerations[peripheral.identifier] == generation else { return }
@@ -753,15 +817,34 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                 self.connectedPeripheral = nil
                 self.writeCharacteristic = nil
             }
-            self.centralManager.cancelPeripheralConnection(peripheral)
+            self.cancelPeripheralConnection(peripheral)
             self.completePendingConnect(.failure(BoardBleError.connectTimedOut))
         }
-        connectTimeoutWorkItem = timeoutWorkItem
-        bleQueue.asyncAfter(deadline: .now() + connectTimeout, execute: timeoutWorkItem)
+        connectPeripheral(peripheral)
+    }
 
-        centralManager.connect(peripheral, options: [
-            CBConnectPeripheralOptionNotifyOnDisconnectionKey: true,
-        ])
+    private func deferConnectUntilCancellationSettles(
+        deviceId: String,
+        peripheralId: UUID,
+        barrier: ManagerCancellationBarrier,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        failDeferredConnect(BoardBleError.superseded)
+        guard !barrier.hasExpired else {
+            completion(.failure(BoardBleError.connectTimedOut))
+            return
+        }
+        deferredConnectRequest = DeferredConnectRequest(
+            deviceId: deviceId,
+            peripheralId: peripheralId,
+            completion: completion
+        )
+    }
+
+    private func failDeferredConnect(_ error: Error) {
+        guard let deferredConnectRequest else { return }
+        self.deferredConnectRequest = nil
+        deferredConnectRequest.completion(.failure(error))
     }
 
     private func reconnectToLastKnownBoardOnBleQueue(completion: @escaping (Result<Void, Error>) -> Void) {
@@ -771,7 +854,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             displaySharedCurrentItemOnBleQueue()
             return
         }
-        guard centralManager.state == .poweredOn else {
+        guard centralStateOnBleQueue == .poweredOn else {
             completion(.failure(BoardBleError.bluetoothUnavailable))
             return
         }
@@ -835,7 +918,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         completion(.failure(error))
     }
 
-    private func persistLastConnectedPeripheral(_ peripheral: CBPeripheral) {
+    private func persistLastConnectedPeripheral(_ peripheral: WritableBlePeripheral) {
         SharedConstants.sharedDefaults?.set(
             peripheral.identifier.uuidString,
             forKey: SharedConstants.bleLastPeripheralUuidKey
@@ -860,6 +943,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         stopScanOnBleQueue()
         failQueuedWrites(BoardBleError.notConnected)
         completePendingConnect(.failure(BoardBleError.notConnected))
+        failDeferredConnect(BoardBleError.notConnected)
 
         guard let peripheral = connectedPeripheral else {
             writeCharacteristic = nil
@@ -1079,7 +1163,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     // MARK: - CBCentralManagerDelegate
 
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
-        if central.state == .poweredOn {
+        handleCentralStateUpdateOnBleQueue(state: central.state) {
             // Defensive: during state restoration after an intent-driven
             // background launch, `didDiscoverCharacteristicsFor` (which
             // normally calls `readyWaiters.signalAll()`) can land before
@@ -1097,6 +1181,15 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                     CBCentralManagerScanOptionAllowDuplicatesKey: true,
                 ])
             }
+        }
+    }
+
+    /// Shared state-update body for the real delegate and the native XCTest
+    /// seam. The powered-on closure keeps the concrete central manager out of
+    /// tests while the unavailable transition exercises the production cleanup.
+    private func handleCentralStateUpdateOnBleQueue(state: CBManagerState, onPoweredOn: () -> Void = {}) {
+        if state == .poweredOn {
+            onPoweredOn()
         } else {
             // Bluetooth went away mid-recovery: the deferred reconnect's
             // didDisconnect may never arrive, so close the write-stall recovery
@@ -1106,21 +1199,36 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             // with a depleted budget (#3181).
             writeStallRecoveringPeripheralId = nil
             writeStallRecoveries = 0
+            writeStallRecoveryWatchdog?.cancel()
+            writeStallRecoveryWatchdog = nil
+
+            // Below .poweredOn CoreBluetooth may discard manager-initiated
+            // cancellations without either terminal callback. This is the one
+            // boundary where dropping all UUID barriers is safe: every old link
+            // generation is invalid, and any waiter must fail explicitly rather
+            // than remain parked across the next powered-on session.
+            managerCancellationBarriers.values.forEach { $0.watchdog?.cancel() }
+            managerCancellationBarriers.removeAll()
+            intentionalDisconnectGenerations.removeAll()
+            failDeferredConnect(BoardBleError.bluetoothUnavailable)
+            failReconnectScan(BoardBleError.bluetoothUnavailable)
+            completePendingConnect(.failure(BoardBleError.bluetoothUnavailable))
 
             // Below .poweredOn iOS invalidates every peripheral WITHOUT
             // delivering didDisconnectPeripheral, so an active link vanishes
             // silently — JS would keep showing "connected" until the next write
             // failed. Surface it as an explicit disconnect with a context marker
             // so analytics can tell bluetooth-off apart from a link loss.
-            if let peripheral = connectedPeripheral {
+            let disconnectedPeripheral = connectedPeripheral
+            connectedPeripheral = nil
+            writeCharacteristic = nil
+            peripheralGenerations.removeAll()
+            failQueuedWrites(BoardBleError.bluetoothUnavailable)
+            if let peripheral = disconnectedPeripheral {
                 let deviceId = peripheral.identifier.uuidString
-                peripheralGenerations.removeValue(forKey: peripheral.identifier)
-                connectedPeripheral = nil
-                writeCharacteristic = nil
-                failQueuedWrites(BoardBleError.bluetoothUnavailable)
                 onDisconnect?(deviceId, [
                     "context": "bluetooth_unavailable",
-                    "errorDescription": "central state \(central.state.rawValue)",
+                    "errorDescription": "central state \(state.rawValue)",
                 ])
             }
         }
@@ -1139,7 +1247,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // are last-connection-wins, so a phantom link blocks the wall.
         for extra in peripherals.dropFirst() {
             logger.info("Cancelling extra restored BLE peripheral \(extra.identifier.uuidString, privacy: .public)")
-            central.cancelPeripheralConnection(extra)
+            cancelPeripheralConnection(extra)
         }
 
         let deviceId = peripheral.identifier.uuidString
@@ -1239,7 +1347,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
     func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
         guard peripheralGenerations[peripheral.identifier] == connectionGeneration else {
-            central.cancelPeripheralConnection(peripheral)
+            cancelPeripheralConnection(peripheral)
             return
         }
         peripheral.delegate = self
@@ -1248,6 +1356,17 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     }
 
     func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
+        handleDidFailToConnectOnBleQueue(peripheral: peripheral, error: error)
+    }
+
+    /// Shared delegate body for real CoreBluetooth callbacks and the native
+    /// XCTest seam. A cancellation terminal callback is consumed before the
+    /// normal generation guard because the old generation was intentionally
+    /// removed before cancelling.
+    private func handleDidFailToConnectOnBleQueue(peripheral: WritableBlePeripheral, error: Error?) {
+        if consumeManagerCancellationBarrierOnBleQueue(peripheralId: peripheral.identifier) {
+            return
+        }
         guard peripheralGenerations[peripheral.identifier] == connectionGeneration else { return }
         // Every connect attempt (user-initiated picker connect, or the Live Activity
         // lightbulb's reconnectToLastKnownBoard) sets pendingConnectCompletion, so a
@@ -1272,41 +1391,16 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private func handleDidDisconnectOnBleQueue(peripheral: WritableBlePeripheral, error: Error?) {
         let deviceId = peripheral.identifier.uuidString
         let wasCurrentPeripheral = connectedPeripheral?.identifier == peripheral.identifier
+
+        if consumeManagerCancellationBarrierOnBleQueue(peripheralId: peripheral.identifier) {
+            return
+        }
+
         let intentionalDisconnectGeneration = intentionalDisconnectGenerations.removeValue(forKey: peripheral.identifier)
 
         if let intentionalDisconnectGeneration {
             if peripheralGenerations[peripheral.identifier] == intentionalDisconnectGeneration {
                 peripheralGenerations.removeValue(forKey: peripheral.identifier)
-            }
-            // Write-stall recovery (#3181): the congested link we deliberately
-            // dropped is now fully torn down, so reconnect to the same board.
-            // Gated on the peripheral id so an unrelated intentional disconnect
-            // (user disconnect, a different board's connect supersede) can't be
-            // mistaken for a stall recovery. Deferring to here (rather than
-            // reconnecting inside handleWriteStall) serialises
-            // teardown-then-reconnect for the same peripheral id and avoids a late
-            // didDisconnect tearing the new link back down. didDisconnect already
-            // consumed the intentional flag above, so this fires at most once per
-            // cancel. On success, didDiscoverCharacteristicsFor clears the window
-            // and re-lights the wall (the counter resets when that write drains);
-            // on failure we surface the disconnect to JS and reset the budget.
-            if writeStallRecoveringPeripheralId == peripheral.identifier {
-                // The reconnect is starting; its own connect timeout now owns the
-                // deadline, so retire the cancel→didDisconnect safety net.
-                writeStallRecoveryWatchdog?.cancel()
-                writeStallRecoveryWatchdog = nil
-                reconnectToLastKnownBoardOnBleQueue { [weak self] result in
-                    guard let self else { return }
-                    if case .failure(let error) = result {
-                        self.logger.error("BLE write-stall reconnect failed: \(error.localizedDescription, privacy: .public)")
-                        self.writeStallRecoveringPeripheralId = nil
-                        self.writeStallRecoveries = 0
-                        self.onDisconnect?(deviceId, [
-                            "context": "write_stall_recovery_failed",
-                            "errorDescription": error.localizedDescription,
-                        ])
-                    }
-                }
             }
             return
         }
@@ -1326,6 +1420,73 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // ping-pong that flickers the LEDs. Reconnection is user-initiated only:
         // the in-app device picker, or the Live Activity lightbulb
         // (reconnectToLastKnownBoard).
+    }
+
+    /// Consume exactly one UUID barrier and decide the sole follow-up. A queued
+    /// user connect owns the reconnect when present; otherwise write-stall
+    /// recovery resumes automatically. Both paths share the same normal connect
+    /// timeout and connection-ready success point.
+    @discardableResult
+    private func consumeManagerCancellationBarrierOnBleQueue(peripheralId: UUID) -> Bool {
+        guard let cancellationBarrier = managerCancellationBarriers.removeValue(forKey: peripheralId) else {
+            return false
+        }
+
+        cancellationBarrier.watchdog?.cancel()
+        intentionalDisconnectGenerations.removeValue(forKey: peripheralId)
+        peripheralGenerations.removeValue(forKey: peripheralId)
+
+        let deferredRequest: DeferredConnectRequest?
+        if deferredConnectRequest?.peripheralId == peripheralId {
+            deferredRequest = deferredConnectRequest
+            deferredConnectRequest = nil
+        } else {
+            deferredRequest = nil
+        }
+
+        if writeStallRecoveringPeripheralId == peripheralId {
+            // The normal connection timeout owns the deadline from here.
+            writeStallRecoveryWatchdog?.cancel()
+            writeStallRecoveryWatchdog = nil
+        }
+
+        if let deferredRequest {
+            let isJoiningWriteStallRecovery = writeStallRecoveringPeripheralId == peripheralId
+            connectOnBleQueue(deviceId: deferredRequest.deviceId) { [weak self] result in
+                deferredRequest.completion(result)
+                if isJoiningWriteStallRecovery {
+                    self?.finishWriteStallReconnectOnBleQueue(peripheralId: peripheralId, result: result)
+                }
+            }
+        } else if writeStallRecoveringPeripheralId == peripheralId {
+            beginWriteStallReconnectOnBleQueue(peripheralId: peripheralId)
+        }
+        return true
+    }
+
+    private func beginWriteStallReconnectOnBleQueue(peripheralId: UUID) {
+        let completion: (Result<Void, Error>) -> Void = { [weak self] result in
+            self?.finishWriteStallReconnectOnBleQueue(peripheralId: peripheralId, result: result)
+        }
+        let deviceId = peripheralId.uuidString
+        if discoveredPeripherals[deviceId] != nil {
+            connectOnBleQueue(deviceId: deviceId, completion: completion)
+        } else {
+            reconnectToLastKnownBoardOnBleQueue(completion: completion)
+        }
+    }
+
+    private func finishWriteStallReconnectOnBleQueue(peripheralId: UUID, result: Result<Void, Error>) {
+        guard case .failure(let error) = result,
+              writeStallRecoveringPeripheralId == peripheralId
+        else { return }
+        logger.error("BLE write-stall reconnect failed: \(error.localizedDescription, privacy: .public)")
+        writeStallRecoveringPeripheralId = nil
+        writeStallRecoveries = 0
+        onDisconnect?(peripheralId.uuidString, [
+            "context": "write_stall_recovery_failed",
+            "errorDescription": error.localizedDescription,
+        ])
     }
 
     // MARK: - CBPeripheralDelegate
@@ -1448,7 +1609,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             connectedPeripheral = nil
             writeCharacteristic = nil
         }
-        centralManager.cancelPeripheralConnection(peripheral)
+        cancelPeripheralConnection(peripheral)
         completePendingConnect(.failure(error))
     }
 
@@ -1473,6 +1634,16 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             return
         }
 
+        finishConnectionSetupOnBleQueue(peripheral: peripheral, characteristic: characteristic)
+    }
+
+    /// Single write-ready success point shared by CoreBluetooth discovery and
+    /// deterministic native tests. All completion, relight, persistence, and
+    /// event behavior remains production behavior exercised through this helper.
+    private func finishConnectionSetupOnBleQueue(
+        peripheral: WritableBlePeripheral,
+        characteristic: CBCharacteristic
+    ) {
         connectedPeripheral = peripheral
         writeCharacteristic = characteristic
         // Any successful (re)connect closes a write-stall recovery window (#3181)
@@ -1653,7 +1824,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     }
 
     private var isReadyForWrite: Bool {
-        centralManager.state == .poweredOn
+        centralStateOnBleQueue == .poweredOn
             && connectedPeripheral != nil
             && writeCharacteristic != nil
     }
@@ -1732,8 +1903,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     }
 
     private func completePendingConnect(_ result: Result<Void, Error>) {
-        connectTimeoutWorkItem?.cancel()
-        connectTimeoutWorkItem = nil
+        connectTimeoutTimer?.cancel()
+        connectTimeoutTimer = nil
         let completion = pendingConnectCompletion
         pendingConnectCompletion = nil
         completion?(result)
@@ -2317,6 +2488,13 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     /// the write flow-control suite observe intentional cancels without a real
     /// CoreBluetooth peripheral.
     private func cancelPeripheralConnection(_ peripheral: WritableBlePeripheral) {
+        // A barrier means this UUID already has a manager cancel awaiting its
+        // sole terminal callback. Reissuing cancel in a didConnect race could
+        // manufacture a second callback that no generation token can classify,
+        // so the first cancellation owns teardown until the barrier settles.
+        guard registerManagerCancellationBarrierOnBleQueue(peripheralId: peripheral.identifier) else {
+            return
+        }
         #if DEBUG || BOARDSESH_TESTS
         if let overrideForTesting = cancelPeripheralConnectionOverrideForTesting {
             overrideForTesting(peripheral)
@@ -2328,6 +2506,56 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             return
         }
         centralManager.cancelPeripheralConnection(concretePeripheral)
+    }
+
+    private func registerManagerCancellationBarrierOnBleQueue(peripheralId: UUID) -> Bool {
+        guard managerCancellationBarriers[peripheralId] == nil else { return false }
+        let cancellationBarrier = ManagerCancellationBarrier()
+        managerCancellationBarriers[peripheralId] = cancellationBarrier
+        cancellationBarrier.watchdog = timerScheduler.scheduleOneShot(
+            after: connectTimeout,
+            label: "managerCancellationBarrierWatchdog"
+        ) { [weak self, weak cancellationBarrier] in
+            guard let self, let cancellationBarrier,
+                  self.managerCancellationBarriers[peripheralId] === cancellationBarrier
+            else { return }
+            // Timeout protects promises, not ordering. A disconnected peripheral
+            // state is not evidence that CoreBluetooth delivered the terminal
+            // callback, so retain the barrier and never force a connect here.
+            cancellationBarrier.hasExpired = true
+            guard self.deferredConnectRequest?.peripheralId == peripheralId else { return }
+            self.failDeferredConnect(BoardBleError.connectTimedOut)
+        }
+        return true
+    }
+
+    private func preparePeripheralForConnection(_ peripheral: WritableBlePeripheral) {
+        #if DEBUG || BOARDSESH_TESTS
+        if !(peripheral is CBPeripheral) {
+            return
+        }
+        #endif
+        guard let concretePeripheral = peripheral as? CBPeripheral else {
+            assertionFailure("WritableBlePeripheral is always CBPeripheral outside tests")
+            return
+        }
+        concretePeripheral.delegate = self
+    }
+
+    private func connectPeripheral(_ peripheral: WritableBlePeripheral) {
+        #if DEBUG || BOARDSESH_TESTS
+        if let overrideForTesting = connectPeripheralOverrideForTesting {
+            overrideForTesting(peripheral)
+            return
+        }
+        #endif
+        guard let concretePeripheral = peripheral as? CBPeripheral else {
+            assertionFailure("WritableBlePeripheral is always CBPeripheral outside tests")
+            return
+        }
+        centralManager.connect(concretePeripheral, options: [
+            CBConnectPeripheralOptionNotifyOnDisconnectionKey: true,
+        ])
     }
 
     private func readConfiguration() -> BoardBleConfiguration? {
@@ -2413,6 +2641,9 @@ extension BoardBleManager {
         func setConnection(peripheral: WritableBlePeripheral?, characteristic: CBCharacteristic?) {
             manager.connectedPeripheral = peripheral
             manager.writeCharacteristic = characteristic
+            if let peripheral {
+                manager.discoveredPeripherals[peripheral.identifier.uuidString] = peripheral
+            }
             // Mirror the production reset in didDiscoverCharacteristicsFor so a
             // reconnect in a test starts with the gate re-armed and the
             // with-response latch re-seeded from what the session has learned.
@@ -2444,6 +2675,21 @@ extension BoardBleManager {
             manager.cancelPeripheralConnectionOverrideForTesting = handler
         }
 
+        /// Intercept the concrete CoreBluetooth connect call.
+        func setConnectPeripheralOverride(_ handler: ((WritableBlePeripheral) -> Void)?) {
+            manager.connectPeripheralOverrideForTesting = handler
+        }
+
+        /// Set the central state without instantiating `CBCentralManager`.
+        func setCentralState(_ state: CBManagerState?) {
+            manager.centralStateOverrideForTesting = state
+        }
+
+        /// Make a fake peripheral discoverable by the production connect path.
+        func setDiscoveredPeripheral(_ peripheral: WritableBlePeripheral) {
+            manager.discoveredPeripherals[peripheral.identifier.uuidString] = peripheral
+        }
+
         /// Intercept the concrete CoreBluetooth scan teardown while preserving
         /// the production `scanRequested = false` transition in
         /// `stopScanOnBleQueue`.
@@ -2466,6 +2712,31 @@ extension BoardBleManager {
         func fireDidDisconnect(peripheral: WritableBlePeripheral, error: Error?) {
             manager.runOnBleQueueSync {
                 manager.handleDidDisconnectOnBleQueue(peripheral: peripheral, error: error)
+            }
+        }
+
+        /// Fire the exact `didFailToConnect` state transition.
+        func fireDidFailToConnect(peripheral: WritableBlePeripheral, error: Error?) {
+            manager.runOnBleQueueSync {
+                manager.handleDidFailToConnectOnBleQueue(peripheral: peripheral, error: error)
+            }
+        }
+
+        /// Fire the unavailable half of `centralManagerDidUpdateState`.
+        func fireCentralStateUpdate(_ state: CBManagerState) {
+            manager.runOnBleQueueSync {
+                manager.centralStateOverrideForTesting = state
+                manager.handleCentralStateUpdateOnBleQueue(state: state)
+            }
+        }
+
+        /// Fire the production write-ready success point after a test connect.
+        func fireConnectionReady(peripheral: WritableBlePeripheral, characteristic: CBCharacteristic) {
+            manager.runOnBleQueueSync {
+                manager.finishConnectionSetupOnBleQueue(
+                    peripheral: peripheral,
+                    characteristic: characteristic
+                )
             }
         }
 
@@ -2504,6 +2775,9 @@ extension BoardBleManager {
         var forceWriteWithResponse: Bool { manager.forceWriteWithResponse }
         var forceWriteWithResponseSource: BoardBleWriteTypeSource? { manager.forceWriteWithResponseSource }
         var writeWithResponsePeripheralIds: Set<UUID> { manager.writeWithResponsePeripheralIds }
+        var hasPendingConnect: Bool { manager.pendingConnectCompletion != nil }
+        var deferredConnectPeripheralId: UUID? { manager.deferredConnectRequest?.peripheralId }
+        var managerCancellationBarrierIds: Set<UUID> { Set(manager.managerCancellationBarriers.keys) }
 
         func intentionalDisconnectGeneration(for peripheralId: UUID) -> UInt64? {
             manager.intentionalDisconnectGenerations[peripheralId]

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -296,6 +296,18 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     // UUIDs remain independent. One global deferred request is enough because
     // connect is last-request-wins throughout the manager.
     private var managerCancellationBarriers: [UUID: ManagerCancellationBarrier] = [:]
+    // UUIDs whose EXPIRED cancellation barrier was displaced by a fresh explicit
+    // connect (see connectOnBleQueue). The cancelled attempt's terminal callback
+    // usually never arrives — that's why the barrier expired — but if it lands
+    // late it must be ignored: the fresh attempt owns all live state for the
+    // UUID, and without this marker the late didDisconnect would pass the
+    // wasCurrentPeripheral check (the fresh attempt optimistically re-set
+    // connectedPeripheral to the same UUID) and tear the new attempt down.
+    // Cleared by the swallow itself, by the fresh attempt's didConnect
+    // (CoreBluetooth delivers a peripheral's callbacks in order, so the old
+    // attempt's callback cannot arrive after the new attempt's didConnect), and
+    // below .poweredOn (every old link generation is invalid there).
+    private var displacedCancellationPeripheralIds: Set<UUID> = []
     private var deferredConnectRequest: DeferredConnectRequest?
     private var peripheralGenerations: [UUID: UInt64] = [:]
     private var connectionGeneration: UInt64 = 0
@@ -750,13 +762,28 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // request; an unrelated UUID is free to connect immediately.
         if let peripheralId = requestedPeripheralId,
            let cancellationBarrier = managerCancellationBarriers[peripheralId] {
-            deferConnectUntilCancellationSettles(
-                deviceId: deviceId,
-                peripheralId: peripheralId,
-                barrier: cancellationBarrier,
-                completion: completion
-            )
-            return
+            if cancellationBarrier.hasExpired {
+                // The watchdog expired with no terminal callback — which
+                // CoreBluetooth legitimately never delivers for a cancelled
+                // PENDING connect. An expired barrier must not block a fresh
+                // explicit connect: insta-failing here left the board
+                // permanently unconnectable for the rest of the app session
+                // (picker, Live Activity lightbulb, and write-stall recovery
+                // all route through this path). Displace the expired barrier
+                // and proceed with a normal connect; the tombstone below
+                // swallows the old cancel's terminal callback in the unlikely
+                // case it still arrives.
+                cancellationBarrier.watchdog?.cancel()
+                managerCancellationBarriers.removeValue(forKey: peripheralId)
+                displacedCancellationPeripheralIds.insert(peripheralId)
+            } else {
+                deferConnectUntilCancellationSettles(
+                    deviceId: deviceId,
+                    peripheralId: peripheralId,
+                    completion: completion
+                )
+                return
+            }
         }
 
         // A new request to an unblocked UUID wins over a request parked behind a
@@ -826,13 +853,22 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private func deferConnectUntilCancellationSettles(
         deviceId: String,
         peripheralId: UUID,
-        barrier: ManagerCancellationBarrier,
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         failDeferredConnect(BoardBleError.superseded)
-        guard !barrier.hasExpired else {
-            completion(.failure(BoardBleError.connectTimedOut))
-            return
+        // A pending connect to a DIFFERENT board must not keep racing while
+        // this newer request waits out the barrier: left alone it could
+        // connect, emit onConnected, and light the wall for up to the connect
+        // timeout before the deferred request wins. Mirror the non-deferred
+        // supersede: settle its promise now and bump the generation so its
+        // late didConnect hits the stale branch's corrective cancel. (The
+        // pending connect can never target the barriered UUID itself — every
+        // barrier registration settles the pending connect first.)
+        if pendingConnectCompletion != nil {
+            completePendingConnect(.failure(BoardBleError.superseded))
+            connectionGeneration += 1
+            connectedPeripheral = nil
+            writeCharacteristic = nil
         }
         deferredConnectRequest = DeferredConnectRequest(
             deviceId: deviceId,
@@ -1209,6 +1245,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             // than remain parked across the next powered-on session.
             managerCancellationBarriers.values.forEach { $0.watchdog?.cancel() }
             managerCancellationBarriers.removeAll()
+            displacedCancellationPeripheralIds.removeAll()
             intentionalDisconnectGenerations.removeAll()
             failDeferredConnect(BoardBleError.bluetoothUnavailable)
             failReconnectScan(BoardBleError.bluetoothUnavailable)
@@ -1346,13 +1383,43 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     }
 
     func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        handleDidConnectOnBleQueue(peripheral: peripheral) {
+            peripheral.delegate = self
+            peripheral.discoverServices(writeServiceUuids())
+        }
+    }
+
+    /// Shared delegate body for the real `didConnect` callback and the native
+    /// XCTest seam. Service discovery needs a concrete `CBPeripheral`, so it
+    /// stays in the delegate's closure; every manager-state decision lives here.
+    private func handleDidConnectOnBleQueue(
+        peripheral: WritableBlePeripheral,
+        beginServiceDiscovery: () -> Void
+    ) {
         guard peripheralGenerations[peripheral.identifier] == connectionGeneration else {
-            cancelPeripheralConnection(peripheral)
+            // The system finished bringing up a link no live generation owns
+            // (e.g. a connect that raced its own cancellation). It MUST be
+            // cancelled concretely or it lingers as a system-held connection
+            // that blocks the wall — these boards are last-connection-wins.
+            // Cancelling a CONNECTED peripheral yields exactly one
+            // didDisconnect, so when this UUID's barrier is already awaiting a
+            // terminal callback the corrective cancel still goes out (it can't
+            // manufacture a second callback here) and the existing barrier
+            // consumes the resulting didDisconnect; no second barrier is
+            // registered.
+            if !registerManagerCancellationBarrierOnBleQueue(peripheralId: peripheral.identifier) {
+                logger.info("Stale BLE didConnect for \(peripheral.identifier.uuidString, privacy: .public) raced an in-flight cancellation; reissuing the concrete cancel under the existing barrier")
+            }
+            performCancelPeripheralConnection(peripheral)
             return
         }
-        peripheral.delegate = self
+        // The live attempt reached didConnect. A displaced cancellation's late
+        // terminal callback would have been delivered before this (CoreBluetooth
+        // delivers a peripheral's callbacks in order), so the tombstone is done —
+        // clear it so a later genuine drop of THIS link is never swallowed.
+        displacedCancellationPeripheralIds.remove(peripheral.identifier)
         retriedFullServiceDiscovery.remove(peripheral.identifier)
-        peripheral.discoverServices(writeServiceUuids())
+        beginServiceDiscovery()
     }
 
     func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
@@ -1393,6 +1460,15 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         let wasCurrentPeripheral = connectedPeripheral?.identifier == peripheral.identifier
 
         if consumeManagerCancellationBarrierOnBleQueue(peripheralId: peripheral.identifier) {
+            return
+        }
+
+        // Late terminal callback from a cancelled attempt whose EXPIRED barrier
+        // was displaced by a fresh explicit connect (see connectOnBleQueue).
+        // The fresh attempt owns all live state for this UUID — without this
+        // check the callback would pass wasCurrentPeripheral (the fresh attempt
+        // re-set connectedPeripheral to the same UUID) and wrongly tear it down.
+        if displacedCancellationPeripheralIds.remove(peripheral.identifier) != nil {
             return
         }
 
@@ -2481,19 +2557,27 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         connectedPeripheral = nil
     }
 
-    /// The single concrete `CBCentralManager.cancelPeripheralConnection` call
-    /// site. Every `WritableBlePeripheral` is a `CBPeripheral` outside tests, so
-    /// in production this is exactly the old inline call. The test override lets
-    /// the write flow-control suite observe intentional cancels without a real
-    /// CoreBluetooth peripheral.
+    /// Barrier-gated cancel used by every teardown path except the stale
+    /// didConnect branch. A barrier means this UUID already has a manager
+    /// cancel awaiting its sole terminal callback; reissuing a cancel for a
+    /// still-PENDING connect could manufacture a second callback that no
+    /// generation token can classify, so the first cancellation owns teardown
+    /// until the barrier settles.
     private func cancelPeripheralConnection(_ peripheral: WritableBlePeripheral) {
-        // A barrier means this UUID already has a manager cancel awaiting its
-        // sole terminal callback. Reissuing cancel in a didConnect race could
-        // manufacture a second callback that no generation token can classify,
-        // so the first cancellation owns teardown until the barrier settles.
         guard registerManagerCancellationBarrierOnBleQueue(peripheralId: peripheral.identifier) else {
             return
         }
+        performCancelPeripheralConnection(peripheral)
+    }
+
+    /// The single concrete `CBCentralManager.cancelPeripheralConnection` call
+    /// site, with no barrier bookkeeping. Every `WritableBlePeripheral` is a
+    /// `CBPeripheral` outside tests, so in production this is exactly the old
+    /// inline call. The stale didConnect branch calls this directly because its
+    /// corrective cancel of a CONNECTED peripheral must go out even when the
+    /// UUID's barrier is already registered. The test override lets the native
+    /// suites observe cancels without a real CoreBluetooth peripheral.
+    private func performCancelPeripheralConnection(_ peripheral: WritableBlePeripheral) {
         #if DEBUG || BOARDSESH_TESTS
         if let overrideForTesting = cancelPeripheralConnectionOverrideForTesting {
             overrideForTesting(peripheral)
@@ -2521,6 +2605,11 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             // Timeout protects promises, not ordering. A disconnected peripheral
             // state is not evidence that CoreBluetooth delivered the terminal
             // callback, so retain the barrier and never force a connect here.
+            // The retained barrier stays effective against DEFERRED waiters
+            // only until a fresh explicit connect displaces it — an expired
+            // barrier must not make the board permanently unconnectable when
+            // CoreBluetooth never delivers a callback for a cancelled pending
+            // connect (see connectOnBleQueue).
             cancellationBarrier.hasExpired = true
             guard self.deferredConnectRequest?.peripheralId == peripheralId else { return }
             self.failDeferredConnect(BoardBleError.connectTimedOut)
@@ -2721,6 +2810,17 @@ extension BoardBleManager {
             }
         }
 
+        /// Fire the exact `didConnect` decision (stale-generation corrective
+        /// cancel vs current-generation bookkeeping). Service discovery needs a
+        /// concrete `CBPeripheral`, so the current-generation arm's discovery
+        /// closure is a no-op here; drive `fireConnectionReady` afterwards to
+        /// reach the write-ready success point.
+        func fireDidConnect(peripheral: WritableBlePeripheral) {
+            manager.runOnBleQueueSync {
+                manager.handleDidConnectOnBleQueue(peripheral: peripheral) {}
+            }
+        }
+
         /// Fire the unavailable half of `centralManagerDidUpdateState`.
         func fireCentralStateUpdate(_ state: CBManagerState) {
             manager.runOnBleQueueSync {
@@ -2779,6 +2879,7 @@ extension BoardBleManager {
         var hasPendingConnect: Bool { manager.pendingConnectCompletion != nil }
         var deferredConnectPeripheralId: UUID? { manager.deferredConnectRequest?.peripheralId }
         var managerCancellationBarrierIds: Set<UUID> { Set(manager.managerCancellationBarriers.keys) }
+        var displacedCancellationPeripheralIds: Set<UUID> { manager.displacedCancellationPeripheralIds }
 
         func intentionalDisconnectGeneration(for peripheralId: UUID) -> UInt64? {
             manager.intentionalDisconnectGenerations[peripheralId]

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -2725,7 +2725,9 @@ extension BoardBleManager {
         /// Fire the unavailable half of `centralManagerDidUpdateState`.
         func fireCentralStateUpdate(_ state: CBManagerState) {
             manager.runOnBleQueueSync {
+                let previousStateOverride = manager.centralStateOverrideForTesting
                 manager.centralStateOverrideForTesting = state
+                defer { manager.centralStateOverrideForTesting = previousStateOverride }
                 manager.handleCentralStateUpdateOnBleQueue(state: state)
             }
         }

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -1426,7 +1426,6 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     /// user connect owns the reconnect when present; otherwise write-stall
     /// recovery resumes automatically. Both paths share the same normal connect
     /// timeout and connection-ready success point.
-    @discardableResult
     private func consumeManagerCancellationBarrierOnBleQueue(peripheralId: UUID) -> Bool {
         guard let cancellationBarrier = managerCancellationBarriers.removeValue(forKey: peripheralId) else {
             return false

--- a/packages/mobile/modules/live-activity/ios/BoardBleWriteSeams.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleWriteSeams.swift
@@ -34,8 +34,10 @@ protocol BleRepeatingTimer: AnyObject {
 /// Factory for the write flow-control timers. Production hands back GCD-backed
 /// timers scheduled on the BLE queue; tests hand back fakes they fire inline.
 protocol BleTimerScheduling: AnyObject {
-    /// `label` names the call site ("writeResumeWatchdog" | "chunkDelay" |
-    /// "writeAckWatchdog" | "writeStallRecoveryWatchdog"); tests key on it.
+    /// `label` names the call site (including "connectTimeout",
+    /// "managerCancellationBarrierWatchdog", "writeResumeWatchdog",
+    /// "chunkDelay", "writeAckWatchdog", and
+    /// "writeStallRecoveryWatchdog"); tests key on it.
     func scheduleOneShot(after delay: TimeInterval, label: String, _ handler: @escaping () -> Void) -> BleOneShotTimer
     func makeRepeatingTimer() -> BleRepeatingTimer
 }


### PR DESCRIPTION
## Summary

- place every manager-initiated CoreBluetooth cancellation behind a per-peripheral barrier
- defer only same-UUID reconnects until the old cancellation callback settles, while different boards still connect immediately
- make the newest deferred request win and safely complete superseded callers
- consume disconnect/fail callbacks before generation handling, reset the barrier on BLE-off, and preserve write-stall recovery
- deliberate behavior change beyond the title: when the central drops below `.poweredOn`, an in-flight connect now fails immediately with `bluetoothUnavailable` and peripheral generations are cleared, instead of letting the 8 s connect timeout own the failure as on `main`
- an expired cancellation barrier (watchdog fired with no terminal callback, which CoreBluetooth legitimately never delivers for a cancelled pending connect) no longer blocks later connects: a fresh explicit connect displaces it and proceeds, so an out-of-range connect timeout can't leave the board unconnectable for the rest of the session
- add deterministic native coverage for immediate reconnects, late callbacks, watchdogs, config drift, and write-stall composition

Closes #4139.

## Stack

This PR is intentionally based on #4140 (`fix/3925-ios-moonboard-ble-tests`) because it extends that native disconnect/write-stall test seam. The branch DAG now uses the actual #4140 commits; the PR diff is only the three #4139 Swift files. Rebase onto `main` after #4140 merges.

## QA

- independent Sol xhigh state-machine review: PASS
- `vp run typecheck:mobile`
- mobile suite: 575 files, 4,912 tests passed
- focused native-preparation/widget drift tests passed
- `vp run check:mobile-bundle` for iOS and Android
- touched pre-commit checks and `git diff --no-ext-diff --check`
- Metro QA notes: http://vibetunnel-2.tailedd9d5.ts.net:8086

## Native verification gates

Linux cannot compile or execute `BoardseshTests`. Before merge, run the native XCTest target on macOS and exercise explicit disconnect → immediate same-board reconnect, different-board reconnect, BLE-off reset, write-stall recovery, and out-of-range connect timeout → walk back into range → retry connects normally, on a physical iPhone. Fable is unavailable in this runtime and remains a literal BLE review blocker; the Sol review is recorded as a substitute, not as Fable.

## Release Notes

Reconnecting to the same board on iPhone no longer lets a late disconnect from the old connection knock the new link offline.
