### PR TITLE
fix(shared): retry transient web GATT connects

### DIFF
--- a/packages/mobile/src/lib/ble/__tests__/web-adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/web-adapter.test.ts
@@ -119,6 +119,61 @@ describe('requestAndConnect', () => {
     expect(connection).toEqual({ deviceId: 'device-abc', deviceName: 'Kilter Board' });
   });
 
+  it('retries a transient GATT NetworkError without reopening the browser chooser', async () => {
+    vi.useFakeTimers();
+    try {
+      const { device, server } = makeDevice({ [UART_SERVICE_UUID]: makeCharacteristic() });
+      server.connected = false;
+      server.connect.mockRejectedValueOnce(
+        Object.assign(new Error('Connection attempt failed'), { name: 'NetworkError' }),
+      );
+      server.connect.mockResolvedValueOnce(server);
+      const requestDevice = vi.fn().mockResolvedValue(device);
+      stubBluetooth(requestDevice);
+
+      const connectionPromise = new WebBluetoothAdapter('aurora').requestAndConnect();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(requestDevice).toHaveBeenCalledTimes(1);
+      expect(server.connect).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(499);
+      expect(server.connect).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(connectionPromise).resolves.toEqual({
+        deviceId: 'device-abc',
+        deviceName: 'Kilter Board',
+      });
+      expect(requestDevice).toHaveBeenCalledTimes(1);
+      expect(server.connect).toHaveBeenCalledTimes(2);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('propagates chooser cancellation without retrying the chooser or connecting GATT', async () => {
+    vi.useFakeTimers();
+    try {
+      const { server } = makeDevice({ [UART_SERVICE_UUID]: makeCharacteristic() });
+      server.connected = false;
+      const chooserError = Object.assign(new Error('User cancelled the browser chooser'), {
+        name: 'NotFoundError',
+      });
+      const requestDevice = vi.fn().mockRejectedValue(chooserError);
+      stubBluetooth(requestDevice);
+
+      await expect(new WebBluetoothAdapter('aurora').requestAndConnect()).rejects.toBe(chooserError);
+
+      expect(requestDevice).toHaveBeenCalledTimes(1);
+      expect(server.connect).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('resolves the MoonBoard write characteristic via the RedBearLab fallback', async () => {
     // Only the RedBearLab service is present — UART probing rejects first.
     const redbearChar = makeCharacteristic(false);

--- a/packages/mobile/src/lib/ble/__tests__/web-adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/web-adapter.test.ts
@@ -109,7 +109,7 @@ describe('requestDeviceOptionsForFamily', () => {
 
 describe('requestAndConnect', () => {
   it('requests with the Aurora filter shape and returns the connection identity', async () => {
-    const { device } = makeDevice({ [UART_SERVICE_UUID]: makeCharacteristic() });
+    const { device, server } = makeDevice({ [UART_SERVICE_UUID]: makeCharacteristic() });
     const requestDevice = vi.fn().mockResolvedValue(device);
     stubBluetooth(requestDevice);
 
@@ -117,6 +117,7 @@ describe('requestAndConnect', () => {
 
     expect(requestDevice).toHaveBeenCalledWith(requestDeviceOptionsForFamily('aurora'));
     expect(connection).toEqual({ deviceId: 'device-abc', deviceName: 'Kilter Board' });
+    expect(server.connect).not.toHaveBeenCalled();
   });
 
   it('retries a transient GATT NetworkError without reopening the browser chooser', async () => {
@@ -177,13 +178,14 @@ describe('requestAndConnect', () => {
   it('resolves the MoonBoard write characteristic via the RedBearLab fallback', async () => {
     // Only the RedBearLab service is present — UART probing rejects first.
     const redbearChar = makeCharacteristic(false);
-    const { device } = makeDevice({ [REDBEARLAB_SERVICE_UUID]: redbearChar });
+    const { device, server } = makeDevice({ [REDBEARLAB_SERVICE_UUID]: redbearChar });
     const requestDevice = vi.fn().mockResolvedValue(device);
     stubBluetooth(requestDevice);
 
     const connection = await new WebBluetoothAdapter('moonboard').requestAndConnect();
     expect(requestDevice).toHaveBeenCalledWith(requestDeviceOptionsForFamily('moonboard'));
     expect(connection.deviceId).toBe('device-abc');
+    expect(server.connect).not.toHaveBeenCalled();
   });
 
   it('rejects with the explicit message when MoonBoard exposes neither controller', async () => {

--- a/packages/shared/ble-protocol/src/__tests__/web-transport.test.ts
+++ b/packages/shared/ble-protocol/src/__tests__/web-transport.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { REDBEARLAB_SERVICE_UUID, UART_SERVICE_UUID } from '../transport';
+import {
+  getMoonboardWriteCharacteristic,
+  getUartCharacteristic,
+  type WebBluetoothDevice,
+  type WebBluetoothRemoteGATTCharacteristic,
+  type WebBluetoothRemoteGATTServer,
+} from '../web-transport';
+
+const GATT_CONNECT_RETRY_DELAY_MS = 500;
+
+type ProbeCharacteristic = (device: WebBluetoothDevice) => Promise<WebBluetoothRemoteGATTCharacteristic | undefined>;
+
+function namedError(name: string): Error {
+  return Object.assign(new Error(`${name} from browser`), { name });
+}
+
+function makeCharacteristic(): WebBluetoothRemoteGATTCharacteristic {
+  return {
+    writeValueWithResponse: vi.fn().mockResolvedValue(undefined),
+    writeValueWithoutResponse: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeDevice(
+  characteristicsByService: Record<string, WebBluetoothRemoteGATTCharacteristic>,
+  options: { connected?: boolean } = {},
+) {
+  const server = {
+    connected: options.connected ?? false,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    getPrimaryService: vi.fn(async (serviceUuid: string) => {
+      const characteristic = characteristicsByService[serviceUuid];
+      if (!characteristic) throw new Error(`No service ${serviceUuid}`);
+      return {
+        getCharacteristic: vi.fn(async () => characteristic),
+      };
+    }),
+  } as WebBluetoothRemoteGATTServer & {
+    connect: ReturnType<typeof vi.fn>;
+    disconnect: ReturnType<typeof vi.fn>;
+    getPrimaryService: ReturnType<typeof vi.fn>;
+  };
+  server.connect.mockResolvedValue(server);
+
+  const device = {
+    id: 'already-granted-device',
+    gatt: server,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WebBluetoothDevice;
+
+  return { device, server };
+}
+
+async function expectNetworkErrorRetry(
+  probeCharacteristic: ProbeCharacteristic,
+  characteristicsByService: Record<string, WebBluetoothRemoteGATTCharacteristic>,
+): Promise<void> {
+  const expectedCharacteristic = Object.values(characteristicsByService)[0];
+  const { device, server } = makeDevice(characteristicsByService);
+  server.connect.mockRejectedValueOnce(namedError('NetworkError')).mockResolvedValueOnce(server);
+
+  const probePromise = probeCharacteristic(device);
+  await Promise.resolve();
+
+  expect(server.connect).toHaveBeenCalledTimes(1);
+  expect(server.disconnect).not.toHaveBeenCalled();
+  expect(vi.getTimerCount()).toBe(1);
+
+  await vi.advanceTimersByTimeAsync(GATT_CONNECT_RETRY_DELAY_MS - 1);
+  expect(server.connect).toHaveBeenCalledTimes(1);
+  expect(server.disconnect).not.toHaveBeenCalled();
+
+  await vi.advanceTimersByTimeAsync(1);
+  await expect(probePromise).resolves.toBe(expectedCharacteristic);
+  expect(server.connect).toHaveBeenCalledTimes(2);
+  expect(server.disconnect).not.toHaveBeenCalled();
+  expect(vi.getTimerCount()).toBe(0);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('Web Bluetooth GATT connection retry (#4144)', () => {
+  it('retries an Aurora UART connect NetworkError once after the exact backoff', async () => {
+    await expectNetworkErrorRetry(getUartCharacteristic, { [UART_SERVICE_UUID]: makeCharacteristic() });
+  });
+
+  it('retries a MoonBoard connect NetworkError before probing its UART path', async () => {
+    await expectNetworkErrorRetry(getMoonboardWriteCharacteristic, { [UART_SERVICE_UUID]: makeCharacteristic() });
+  });
+
+  it('keeps MoonBoard RedBearLab fallback behavior after a recovered connection', async () => {
+    await expectNetworkErrorRetry(getMoonboardWriteCharacteristic, { [REDBEARLAB_SERVICE_UUID]: makeCharacteristic() });
+  });
+
+  it.each(['NotFoundError', 'SecurityError', 'NotSupportedError', 'InvalidStateError', 'AbortError', 'Error'])(
+    'does not retry a %s GATT connect rejection',
+    async (errorName) => {
+      const { device, server } = makeDevice({ [UART_SERVICE_UUID]: makeCharacteristic() });
+      const error = namedError(errorName);
+      server.connect.mockRejectedValueOnce(error);
+
+      await expect(getUartCharacteristic(device)).rejects.toBe(error);
+
+      expect(server.connect).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+
+  it('does not retry a real TypeError GATT connect rejection', async () => {
+    const { device, server } = makeDevice({ [UART_SERVICE_UUID]: makeCharacteristic() });
+    const error = new TypeError('Bluetooth permission was denied');
+    server.connect.mockRejectedValueOnce(error);
+
+    await expect(getUartCharacteristic(device)).rejects.toBe(error);
+
+    expect(server.connect).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('does not retry a downstream Aurora service rejection', async () => {
+    const { device, server } = makeDevice({ [UART_SERVICE_UUID]: makeCharacteristic() });
+    const serviceError = new Error('UART service failed after connect');
+    server.getPrimaryService.mockRejectedValueOnce(serviceError);
+
+    await expect(getUartCharacteristic(device)).rejects.toBe(serviceError);
+
+    expect(server.connect).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('does not retry a downstream Aurora characteristic rejection', async () => {
+    const { device, server } = makeDevice({ [UART_SERVICE_UUID]: makeCharacteristic() });
+    const characteristicError = new Error('UART characteristic failed after connect');
+    server.getPrimaryService.mockResolvedValueOnce({
+      getCharacteristic: vi.fn().mockRejectedValueOnce(characteristicError),
+    });
+
+    await expect(getUartCharacteristic(device)).rejects.toBe(characteristicError);
+
+    expect(server.connect).toHaveBeenCalledTimes(1);
+    expect(server.getPrimaryService).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('does not retry MoonBoard service probing failures', async () => {
+    const { device, server } = makeDevice({});
+
+    await expect(getMoonboardWriteCharacteristic(device)).resolves.toBeUndefined();
+
+    expect(server.connect).toHaveBeenCalledTimes(1);
+    expect(server.getPrimaryService).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('uses an already-connected GATT server without reconnecting', async () => {
+    const characteristic = makeCharacteristic();
+    const { device, server } = makeDevice({ [UART_SERVICE_UUID]: characteristic }, { connected: true });
+
+    await expect(getUartCharacteristic(device)).resolves.toBe(characteristic);
+
+    expect(server.connect).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('preserves the no-GATT undefined result without scheduling a retry', async () => {
+    const device = { id: 'no-gatt', addEventListener: vi.fn(), removeEventListener: vi.fn() } as WebBluetoothDevice;
+
+    await expect(getUartCharacteristic(device)).resolves.toBeUndefined();
+    await expect(getMoonboardWriteCharacteristic(device)).resolves.toBeUndefined();
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('rethrows the second NetworkError and leaves no retry timer behind', async () => {
+    const { device, server } = makeDevice({ [UART_SERVICE_UUID]: makeCharacteristic() });
+    const firstError = namedError('NetworkError');
+    const secondError = namedError('NetworkError');
+    server.connect.mockRejectedValueOnce(firstError).mockRejectedValueOnce(secondError);
+
+    const probePromise = getUartCharacteristic(device);
+    const settledProbe = probePromise.catch((error: unknown) => error);
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(GATT_CONNECT_RETRY_DELAY_MS);
+
+    await expect(settledProbe).resolves.toBe(secondError);
+    expect(server.connect).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/shared/ble-protocol/src/__tests__/web-transport.test.ts
+++ b/packages/shared/ble-protocol/src/__tests__/web-transport.test.ts
@@ -8,7 +8,9 @@ import {
   type WebBluetoothRemoteGATTServer,
 } from '../web-transport';
 
-const GATT_CONNECT_RETRY_DELAY_MS = 500;
+// Deliberately independent of the private source constant: 500 ms is the issue
+// contract, so these tests must fail if production timing drifts from it.
+const EXPECTED_GATT_CONNECT_RETRY_DELAY_MS = 500;
 
 type ProbeCharacteristic = (device: WebBluetoothDevice) => Promise<WebBluetoothRemoteGATTCharacteristic | undefined>;
 
@@ -70,7 +72,7 @@ async function expectNetworkErrorRetry(
   expect(server.disconnect).not.toHaveBeenCalled();
   expect(vi.getTimerCount()).toBe(1);
 
-  await vi.advanceTimersByTimeAsync(GATT_CONNECT_RETRY_DELAY_MS - 1);
+  await vi.advanceTimersByTimeAsync(EXPECTED_GATT_CONNECT_RETRY_DELAY_MS - 1);
   expect(server.connect).toHaveBeenCalledTimes(1);
   expect(server.disconnect).not.toHaveBeenCalled();
 
@@ -191,7 +193,7 @@ describe('Web Bluetooth GATT connection retry (#4144)', () => {
     const probePromise = getUartCharacteristic(device);
     const settledProbe = probePromise.catch((error: unknown) => error);
     await Promise.resolve();
-    await vi.advanceTimersByTimeAsync(GATT_CONNECT_RETRY_DELAY_MS);
+    await vi.advanceTimersByTimeAsync(EXPECTED_GATT_CONNECT_RETRY_DELAY_MS);
 
     await expect(settledProbe).resolves.toBe(secondError);
     expect(server.connect).toHaveBeenCalledTimes(2);

--- a/packages/shared/ble-protocol/src/web-transport.ts
+++ b/packages/shared/ble-protocol/src/web-transport.ts
@@ -76,7 +76,6 @@ const delay = (milliseconds: number) => new Promise<void>((resolve) => setTimeou
 // NetworkError, then accept the same granted device handle moments later. Keep
 // this deliberately small: one retry is enough for that race, without turning a
 // genuinely unreachable board into a long-running retry loop.
-const GATT_CONNECT_MAX_ATTEMPTS = 2;
 const GATT_CONNECT_RETRY_DELAY_MS = 500;
 
 function isRetryableGattConnectError(error: unknown): boolean {
@@ -103,19 +102,14 @@ async function connectWebBluetoothGattServer(
   const gatt = device.gatt;
   if (!gatt || gatt.connected) return gatt;
 
-  for (let attempt = 1; attempt <= GATT_CONNECT_MAX_ATTEMPTS; attempt++) {
-    try {
-      return await gatt.connect();
-    } catch (error) {
-      if (attempt === GATT_CONNECT_MAX_ATTEMPTS || !isRetryableGattConnectError(error)) {
-        throw error;
-      }
-      await delay(GATT_CONNECT_RETRY_DELAY_MS);
-    }
+  try {
+    return await gatt.connect();
+  } catch (error) {
+    if (!isRetryableGattConnectError(error)) throw error;
   }
 
-  // The loop either returns from connect() or throws its final rejection.
-  throw new Error('Unreachable GATT connection state');
+  await delay(GATT_CONNECT_RETRY_DELAY_MS);
+  return gatt.connect();
 }
 
 // --- Availability + device request ------------------------------------------

--- a/packages/shared/ble-protocol/src/web-transport.ts
+++ b/packages/shared/ble-protocol/src/web-transport.ts
@@ -72,6 +72,52 @@ interface WebBluetooth {
 
 const delay = (milliseconds: number) => new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
 
+// Android Chrome can reject the first GATT connection attempt with a transient
+// NetworkError, then accept the same granted device handle moments later. Keep
+// this deliberately small: one retry is enough for that race, without turning a
+// genuinely unreachable board into a long-running retry loop.
+const GATT_CONNECT_MAX_ATTEMPTS = 2;
+const GATT_CONNECT_RETRY_DELAY_MS = 500;
+
+function isRetryableGattConnectError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    (error as { name?: unknown }).name === 'NetworkError'
+  );
+}
+
+/**
+ * Connect an already-granted device without ever reopening the chooser.
+ *
+ * Web Bluetooth does not expose an AbortSignal or a safe cancellation API for
+ * a pending `connect()`, so this bounds only settled, retryable failures: one
+ * 500 ms wait and one more call on the same GATT handle. Do not add a racing
+ * timeout here; retrying while the original browser operation is still pending
+ * can itself produce "GATT operation already in progress" failures.
+ */
+async function connectWebBluetoothGattServer(
+  device: WebBluetoothDevice,
+): Promise<WebBluetoothRemoteGATTServer | undefined> {
+  const gatt = device.gatt;
+  if (!gatt || gatt.connected) return gatt;
+
+  for (let attempt = 1; attempt <= GATT_CONNECT_MAX_ATTEMPTS; attempt++) {
+    try {
+      return await gatt.connect();
+    } catch (error) {
+      if (attempt === GATT_CONNECT_MAX_ATTEMPTS || !isRetryableGattConnectError(error)) {
+        throw error;
+      }
+      await delay(GATT_CONNECT_RETRY_DELAY_MS);
+    }
+  }
+
+  // The loop either returns from connect() or throws its final rejection.
+  throw new Error('Unreachable GATT connection state');
+}
+
 // --- Availability + device request ------------------------------------------
 
 /**
@@ -134,7 +180,7 @@ export function requestDeviceOptionsForFamily(scanFamily: 'aurora' | 'moonboard'
 export async function getUartCharacteristic(
   device: WebBluetoothDevice,
 ): Promise<WebBluetoothRemoteGATTCharacteristic | undefined> {
-  const server = await device.gatt?.connect();
+  const server = await connectWebBluetoothGattServer(device);
   const service = await server?.getPrimaryService(UART_SERVICE_UUID);
   return service?.getCharacteristic(UART_WRITE_CHARACTERISTIC_UUID);
 }
@@ -162,7 +208,7 @@ async function tryGetWriteCharacteristic(
 export async function getMoonboardWriteCharacteristic(
   device: WebBluetoothDevice,
 ): Promise<WebBluetoothRemoteGATTCharacteristic | undefined> {
-  const server = await device.gatt?.connect();
+  const server = await connectWebBluetoothGattServer(device);
   if (!server) return undefined;
   const uart = await tryGetWriteCharacteristic(server, UART_SERVICE_UUID, UART_WRITE_CHARACTERISTIC_UUID);
   if (uart) return uart;


### PR DESCRIPTION
## Summary

- retry one rejected Web Bluetooth `gatt.connect()` after 500 ms only when the error name is exactly `NetworkError`
- reuse the already granted device/GATT handle without reopening the chooser or disconnecting between attempts
- share the helper across Aurora UART and MoonBoard UART/RedBearLab probing
- skip connect when GATT is already connected and preserve existing no-GATT behavior
- keep chooser, permission, unsupported, invalid-state, abort, TypeError, generic, service, and characteristic failures single-attempt

Closes #4144.

## Scope

The live Expo browser adapter imports this shared transport. No retired `packages/web` climbing-surface source changed; the old surface inherits the shared fix incidentally.

## QA

- final independent Sol xhigh review: PASS
- shared BLE suite: 278 tests passed
- Expo web-adapter focused suite: 21 tests passed
- full mobile suite: 575 files, 4,914 tests passed
- shared, BLE-protocol, and mobile typechecks
- `vp run check:mobile-web-bundle` and native mobile bundle checks
- touched-file `vp check`, pre-commit hooks, and diff check
- deterministic fake-timer coverage leaves zero timers after success/failure

## Browser verification gates

Before merge, exercise Expo web on Android Chrome with a real transient first connect failure and confirm recovery uses one chooser; also smoke picker dismissal, unsupported browsers, missing characteristics, and MoonBoard RedBearLab fallback. Fable is unavailable in this runtime and remains a literal shared-BLE review blocker; the Sol review is a substitute record, not Fable sign-off.

## Release Notes

Browser board connections now retry one brief GATT failure without making you choose the board again.