### PR TITLE
fix(mobile): show board write activity

### DIFF
--- a/packages/mobile/src/components/ble/BleLightbulbButton.tsx
+++ b/packages/mobile/src/components/ble/BleLightbulbButton.tsx
@@ -8,10 +8,16 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import { Icon } from '../Icon';
+import { ActivityIndicator } from '../ActivityIndicator';
 import { hapticLight, hapticMedium } from '../../lib/haptics';
 import { useTheme } from '../../providers/theme-provider';
+import { useBluetoothWriteInProgress } from '../../providers/bluetooth-write-activity';
 import { timing } from '../../theme/animations';
-import { getBleLightbulbAccessibilityHint, getBleLightbulbVisualState } from './ble-lightbulb-button-state';
+import {
+  getBleLightbulbAccessibilityHint,
+  getBleLightbulbDisplayMode,
+  getBleLightbulbVisualState,
+} from './ble-lightbulb-button-state';
 
 type BleLightbulbButtonProps = {
   isConnected: boolean;
@@ -34,6 +40,8 @@ type BleLightbulbButtonProps = {
   /** Subtle visual warning that auto-disconnect is in its final ten seconds. */
   autoDisconnectWarning?: boolean;
   scanningAccessibilityHint?: string;
+  /** Announces the foreground wall write while preserving the button's action label. */
+  writingAccessibilityHint?: string;
   /** Hint describing the long-press action (e.g. "Hold to disconnect"). */
   longPressAccessibilityHint?: string;
   haptic?: 'light' | 'medium' | 'none';
@@ -57,12 +65,14 @@ export function BleLightbulbButton({
   accessibilitySelected,
   autoDisconnectWarning = false,
   scanningAccessibilityHint,
+  writingAccessibilityHint,
   longPressAccessibilityHint,
   haptic = 'light',
   size = 24,
   containerSize = 44,
 }: BleLightbulbButtonProps) {
   const { systemColors, brandColors } = useTheme();
+  const isWriting = useBluetoothWriteInProgress();
   const pulseOpacity = useSharedValue(1);
   const warningPulse = useSharedValue(0);
 
@@ -113,6 +123,7 @@ export function BleLightbulbButton({
     connectedColor: brandColors.warning,
     disconnectedColor: systemColors.secondaryLabel,
   });
+  const displayMode = getBleLightbulbDisplayMode(isScanning, isWriting);
 
   return (
     <AnimatedPressable
@@ -122,10 +133,12 @@ export function BleLightbulbButton({
       accessibilityLabel={accessibilityLabel}
       accessibilityHint={getBleLightbulbAccessibilityHint(
         isScanning,
+        isWriting,
         scanningAccessibilityHint,
+        writingAccessibilityHint,
         longPressAccessibilityHint,
       )}
-      accessibilityState={{ selected: accessibilitySelected ?? isConnected }}
+      accessibilityState={{ selected: accessibilitySelected ?? isConnected, busy: displayMode !== 'idle' }}
       hitSlop={8}
       style={({ pressed }: PressableStateCallbackType) => [
         styles.container,
@@ -139,7 +152,11 @@ export function BleLightbulbButton({
         pressed && styles.pressed,
       ]}
     >
-      <Icon name={visualState.iconName} size={size} color={visualState.iconColor} />
+      {displayMode === 'writing' ? (
+        <ActivityIndicator accessible={false} size="small" color={brandColors.warning} />
+      ) : (
+        <Icon name={visualState.iconName} size={size} color={visualState.iconColor} />
+      )}
     </AnimatedPressable>
   );
 }

--- a/packages/mobile/src/components/ble/BleLightbulbButton.tsx
+++ b/packages/mobile/src/components/ble/BleLightbulbButton.tsx
@@ -16,6 +16,7 @@ import { timing } from '../../theme/animations';
 import {
   getBleLightbulbAccessibilityHint,
   getBleLightbulbDisplayMode,
+  getBleLightbulbSpinnerSize,
   getBleLightbulbVisualState,
 } from './ble-lightbulb-button-state';
 
@@ -153,7 +154,7 @@ export function BleLightbulbButton({
       ]}
     >
       {displayMode === 'writing' ? (
-        <ActivityIndicator accessible={false} size="small" color={brandColors.warning} />
+        <ActivityIndicator accessible={false} size={getBleLightbulbSpinnerSize(size)} color={brandColors.warning} />
       ) : (
         <Icon name={visualState.iconName} size={size} color={visualState.iconColor} />
       )}

--- a/packages/mobile/src/components/ble/__tests__/BleLightbulbButton-render.test.tsx
+++ b/packages/mobile/src/components/ble/__tests__/BleLightbulbButton-render.test.tsx
@@ -121,7 +121,6 @@ describe('BleLightbulbButton write activity', () => {
 
   it('keeps the scanning pulse/icon and hint ahead of write feedback', () => {
     const store = createBleWriteActivityStore();
-    store.begin();
     const view = render(
       createElement(
         BluetoothWriteActivityProvider,
@@ -136,11 +135,17 @@ describe('BleLightbulbButton write activity', () => {
         }),
       ),
     );
+    let release = () => {};
+    act(() => {
+      release = store.begin();
+    });
 
     const button = view.getByRole('button');
     expect(view.container.querySelector('[data-spinner="true"]')).toBeNull();
     expect(view.container.querySelector('[data-icon="lightbulb.fill"]')).toBeTruthy();
     expect(button.getAttribute('data-busy')).toBe('true');
     expect(button.getAttribute('data-hint')).toBe('Scanning for boards nearby');
+
+    act(() => release());
   });
 });

--- a/packages/mobile/src/components/ble/__tests__/BleLightbulbButton-render.test.tsx
+++ b/packages/mobile/src/components/ble/__tests__/BleLightbulbButton-render.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type PressableMockProps = {
+  children?: ReactNode;
+  onPress?: () => void;
+  onLongPress?: () => void;
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
+  accessibilityState?: { busy?: boolean; selected?: boolean };
+  style?: unknown;
+};
+
+vi.mock('react-native', () => ({
+  Pressable: ({
+    children,
+    onPress,
+    onLongPress,
+    accessibilityLabel,
+    accessibilityHint,
+    accessibilityState,
+  }: PressableMockProps) =>
+    createElement(
+      'button',
+      {
+        onClick: onPress,
+        onDoubleClick: onLongPress,
+        'data-label': accessibilityLabel,
+        'data-hint': accessibilityHint ?? '',
+        'data-busy': String(accessibilityState?.busy ?? false),
+        'data-selected': String(accessibilityState?.selected ?? false),
+      },
+      children,
+    ),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+vi.mock('react-native-reanimated', () => ({
+  default: { createAnimatedComponent: (component: unknown) => component },
+  cancelAnimation: vi.fn(),
+  useAnimatedStyle: (factory: () => unknown) => factory(),
+  useSharedValue: (initial: unknown) => ({ value: initial }),
+  withRepeat: (value: unknown) => value,
+  withTiming: (value: unknown) => value,
+}));
+
+const haptics = vi.hoisted(() => ({ light: vi.fn(), medium: vi.fn() }));
+vi.mock('../../../lib/haptics', () => ({ hapticLight: haptics.light, hapticMedium: haptics.medium }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { secondaryLabel: '#8e8e93' },
+    brandColors: { warning: '#ffcc00' },
+  }),
+}));
+vi.mock('../../../theme/animations', () => ({ timing: { slow: 400, fast: 100 } }));
+vi.mock('../../Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }),
+}));
+vi.mock('../../ActivityIndicator', () => ({
+  ActivityIndicator: ({ color }: { color?: string }) =>
+    createElement('span', { 'data-spinner': 'true', 'data-color': color }),
+}));
+
+import { createBleWriteActivityStore } from '../../../lib/ble/write-activity-store';
+import { BluetoothWriteActivityProvider } from '../../../providers/bluetooth-write-activity';
+import { BleLightbulbButton } from '../BleLightbulbButton';
+
+describe('BleLightbulbButton write activity', () => {
+  beforeEach(() => {
+    haptics.light.mockClear();
+    haptics.medium.mockClear();
+  });
+
+  it('shows a busy native spinner while writing without disabling either press action', () => {
+    const store = createBleWriteActivityStore();
+    const onPress = vi.fn();
+    const onLongPress = vi.fn();
+    const view = render(
+      createElement(
+        BluetoothWriteActivityProvider,
+        { store },
+        createElement(BleLightbulbButton, {
+          isConnected: true,
+          isScanning: false,
+          onPress,
+          onLongPress,
+          accessibilityLabel: 'Disconnect board',
+          writingAccessibilityHint: 'Lighting the board',
+          longPressAccessibilityHint: 'Hold for controls',
+        }),
+      ),
+    );
+
+    let release = () => {};
+    act(() => {
+      release = store.begin();
+    });
+
+    const button = view.getByRole('button');
+    expect(view.container.querySelector('[data-spinner="true"]')).toBeTruthy();
+    expect(view.container.querySelector('[data-icon]')).toBeNull();
+    expect(button.getAttribute('data-busy')).toBe('true');
+    expect(button.getAttribute('data-label')).toBe('Disconnect board');
+    expect(button.getAttribute('data-hint')).toBe('Lighting the board');
+
+    fireEvent.click(button);
+    fireEvent.doubleClick(button);
+    expect(onPress).toHaveBeenCalledOnce();
+    expect(onLongPress).toHaveBeenCalledOnce();
+    expect(haptics.light).toHaveBeenCalledOnce();
+    expect(haptics.medium).toHaveBeenCalledOnce();
+
+    act(() => release());
+    expect(view.container.querySelector('[data-spinner="true"]')).toBeNull();
+    expect(view.container.querySelector('[data-icon="lightbulb.fill"]')).toBeTruthy();
+    expect(button.getAttribute('data-busy')).toBe('false');
+    expect(button.getAttribute('data-hint')).toBe('Hold for controls');
+  });
+
+  it('keeps the scanning pulse/icon and hint ahead of write feedback', () => {
+    const store = createBleWriteActivityStore();
+    store.begin();
+    const view = render(
+      createElement(
+        BluetoothWriteActivityProvider,
+        { store },
+        createElement(BleLightbulbButton, {
+          isConnected: true,
+          isScanning: true,
+          onPress: vi.fn(),
+          accessibilityLabel: 'Disconnect board',
+          scanningAccessibilityHint: 'Scanning for boards nearby',
+          writingAccessibilityHint: 'Lighting the board',
+        }),
+      ),
+    );
+
+    const button = view.getByRole('button');
+    expect(view.container.querySelector('[data-spinner="true"]')).toBeNull();
+    expect(view.container.querySelector('[data-icon="lightbulb.fill"]')).toBeTruthy();
+    expect(button.getAttribute('data-busy')).toBe('true');
+    expect(button.getAttribute('data-hint')).toBe('Scanning for boards nearby');
+  });
+});

--- a/packages/mobile/src/components/ble/__tests__/BleLightbulbButton.test.ts
+++ b/packages/mobile/src/components/ble/__tests__/BleLightbulbButton.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { getBleLightbulbAccessibilityHint, getBleLightbulbVisualState } from '../ble-lightbulb-button-state';
+import {
+  getBleLightbulbAccessibilityHint,
+  getBleLightbulbDisplayMode,
+  getBleLightbulbVisualState,
+} from '../ble-lightbulb-button-state';
 
 describe('BleLightbulbButton state helpers', () => {
   it('uses the outline lightbulb and neutral color when disconnected', () => {
@@ -30,18 +34,47 @@ describe('BleLightbulbButton state helpers', () => {
     });
   });
 
-  it('exposes the scanning hint while scanning, the long-press hint otherwise', () => {
-    expect(getBleLightbulbAccessibilityHint(true, 'Scanning for boards nearby', 'Hold for controls')).toBe(
-      'Scanning for boards nearby',
-    );
-    expect(getBleLightbulbAccessibilityHint(false, 'Scanning for boards nearby', 'Hold for controls')).toBe(
-      'Hold for controls',
-    );
+  it('resolves scanning before writing before the long-press hint', () => {
+    expect(
+      getBleLightbulbAccessibilityHint(
+        true,
+        true,
+        'Scanning for boards nearby',
+        'Lighting the board',
+        'Hold for controls',
+      ),
+    ).toBe('Scanning for boards nearby');
+    expect(
+      getBleLightbulbAccessibilityHint(
+        false,
+        true,
+        'Scanning for boards nearby',
+        'Lighting the board',
+        'Hold for controls',
+      ),
+    ).toBe('Lighting the board');
+    expect(
+      getBleLightbulbAccessibilityHint(
+        false,
+        false,
+        'Scanning for boards nearby',
+        'Lighting the board',
+        'Hold for controls',
+      ),
+    ).toBe('Hold for controls');
   });
 
   it('does not fall back to the long-press hint while scanning without a scanning hint', () => {
     // Scanning takes precedence: a missing scanning hint must not read as the
     // long-press action (the bug the third arg guards against).
-    expect(getBleLightbulbAccessibilityHint(true, undefined, 'Hold for controls')).toBeUndefined();
+    expect(
+      getBleLightbulbAccessibilityHint(true, true, undefined, 'Lighting the board', 'Hold for controls'),
+    ).toBeUndefined();
+  });
+
+  it('uses scanning before writing before idle for the display mode', () => {
+    expect(getBleLightbulbDisplayMode(true, true)).toBe('scanning');
+    expect(getBleLightbulbDisplayMode(false, true)).toBe('writing');
+    expect(getBleLightbulbDisplayMode(false, false)).toBe('idle');
   });
 });

--- a/packages/mobile/src/components/ble/__tests__/BleLightbulbButton.test.ts
+++ b/packages/mobile/src/components/ble/__tests__/BleLightbulbButton.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   getBleLightbulbAccessibilityHint,
   getBleLightbulbDisplayMode,
+  getBleLightbulbSpinnerSize,
   getBleLightbulbVisualState,
 } from '../ble-lightbulb-button-state';
 
@@ -76,5 +77,15 @@ describe('BleLightbulbButton state helpers', () => {
     expect(getBleLightbulbDisplayMode(true, true)).toBe('scanning');
     expect(getBleLightbulbDisplayMode(false, true)).toBe('writing');
     expect(getBleLightbulbDisplayMode(false, false)).toBe('idle');
+  });
+
+  it('scales the spinner with the icon size instead of pinning it small', () => {
+    // Both shipping call sites pass 24 and keep the 20pt spinner.
+    expect(getBleLightbulbSpinnerSize(24)).toBe('small');
+    expect(getBleLightbulbSpinnerSize(31)).toBe('small');
+    // A larger icon swaps to the 36pt spinner so the control doesn't visibly
+    // shrink mid-write.
+    expect(getBleLightbulbSpinnerSize(32)).toBe('large');
+    expect(getBleLightbulbSpinnerSize(48)).toBe('large');
   });
 });

--- a/packages/mobile/src/components/ble/ble-lightbulb-button-state.ts
+++ b/packages/mobile/src/components/ble/ble-lightbulb-button-state.ts
@@ -14,6 +14,14 @@ type BleLightbulbVisualState = {
   shadowColor?: string;
 };
 
+export type BleLightbulbDisplayMode = 'scanning' | 'writing' | 'idle';
+
+export function getBleLightbulbDisplayMode(isScanning: boolean, isWriting: boolean): BleLightbulbDisplayMode {
+  if (isScanning) return 'scanning';
+  if (isWriting) return 'writing';
+  return 'idle';
+}
+
 export function getBleLightbulbVisualState({
   isConnected,
   connectedColor,
@@ -40,9 +48,12 @@ export function getBleLightbulbVisualState({
 // the long-press action.
 export function getBleLightbulbAccessibilityHint(
   isScanning: boolean,
+  isWriting: boolean,
   scanningAccessibilityHint?: string,
+  writingAccessibilityHint?: string,
   longPressAccessibilityHint?: string,
 ): string | undefined {
   if (isScanning) return scanningAccessibilityHint;
+  if (isWriting) return writingAccessibilityHint;
   return longPressAccessibilityHint;
 }

--- a/packages/mobile/src/components/ble/ble-lightbulb-button-state.ts
+++ b/packages/mobile/src/components/ble/ble-lightbulb-button-state.ts
@@ -22,6 +22,15 @@ export function getBleLightbulbDisplayMode(isScanning: boolean, isWriting: boole
   return 'idle';
 }
 
+// Maps the icon `size` prop onto a spinner size. We can't hand the raw number
+// to ActivityIndicator: on iOS a numeric size only resizes the wrapper box and
+// leaves the 20pt glyph unscaled, so a large caller would get a small spinner
+// floating in a big square. RN's two native sizes are 20pt and 36pt; 32 is the
+// midpoint above which 'large' is the closer match to the icon it replaces.
+export function getBleLightbulbSpinnerSize(size: number): 'small' | 'large' {
+  return size >= 32 ? 'large' : 'small';
+}
+
 export function getBleLightbulbVisualState({
   isConnected,
   connectedColor,

--- a/packages/mobile/src/components/create-climb/CreateDrawerHeader.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawerHeader.tsx
@@ -90,6 +90,7 @@ export const CreateDrawerHeader = memo(function CreateDrawerHeader({
         onPress={onToggleBle}
         accessibilityLabel={bleConnected ? tCommon('lightControl.disconnect') : tSettings('ble.connectBoard')}
         scanningAccessibilityHint={tSettings('ble.scanning')}
+        writingAccessibilityHint={tSettings('ble.writing')}
         haptic="medium"
         size={24}
         containerSize={44}

--- a/packages/mobile/src/components/play-drawer/PlayDrawerActionBar.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerActionBar.tsx
@@ -196,6 +196,7 @@ export const PlayDrawerActionBar = memo(function PlayDrawerActionBar({
                   (lightbulbConnected ? tSettings('ble.turnOff') : tSettings('ble.connectBoard'))
                 }
                 scanningAccessibilityHint={tSettings('ble.scanning')}
+                writingAccessibilityHint={tSettings('ble.writing')}
                 longPressAccessibilityHint={
                   lightbulbLongPressEnabled
                     ? (lightbulbLongPressAccessibilityHint ?? tSettings('ble.holdForControls'))

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -143,6 +143,7 @@ import {
 } from '../use-board-bluetooth';
 import type { BleWriteDiagnostics } from '../types';
 import { reportHandledError } from '../../error-reporting';
+import { createBleWriteActivityStore } from '../write-activity-store';
 
 // ── Factory helpers ────────────────────────────────────────────────────────
 
@@ -405,6 +406,7 @@ describe('useBoardBluetooth', () => {
   });
 
   it('serialises overlapping sendFramesToBoard calls so chunks never interleave', async () => {
+    const writeActivityStore = createBleWriteActivityStore();
     const writeEvents: string[] = [];
     let releaseFirstWrite!: () => void;
     const write = vi.fn((packet: Uint8Array) => {
@@ -429,7 +431,9 @@ describe('useBoardBluetooth', () => {
       .mockReturnValueOnce({ packet: new Uint8Array([1]) })
       .mockReturnValueOnce({ packet: new Uint8Array([2]) });
 
-    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'moonboard', layoutId: 1, sizeId: 1 }));
+    const { result } = renderHook(() =>
+      useBoardBluetooth({ boardName: 'moonboard', layoutId: 1, sizeId: 1, writeActivityStore }),
+    );
 
     await act(async () => {
       await result.current.connect();
@@ -444,11 +448,217 @@ describe('useBoardBluetooth', () => {
       await Promise.resolve();
       await Promise.resolve();
       expect(writeEvents).toEqual(['start-1']);
+      expect(writeActivityStore.getSnapshot()).toBe(true);
       releaseFirstWrite();
       await Promise.all([firstSend, secondSend]);
     });
 
     expect(writeEvents).toEqual(['start-1', 'end-1', 'start-2', 'end-2']);
+    expect(writeActivityStore.getSnapshot()).toBe(false);
+  });
+
+  it('does not report write activity for the early no-adapter guard', async () => {
+    const writeActivityStore = createBleWriteActivityStore();
+    const listener = vi.fn();
+    writeActivityStore.subscribe(listener);
+    const { result } = renderHook(() =>
+      useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1, writeActivityStore }),
+    );
+
+    let sendResult: boolean | undefined = true;
+    await act(async () => {
+      sendResult = await result.current.sendFramesToBoard('p1r12');
+    });
+
+    expect(sendResult).toBeUndefined();
+    expect(writeActivityStore.getSnapshot()).toBe(false);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('releases write activity when an adapter write rejects', async () => {
+    const writeActivityStore = createBleWriteActivityStore();
+    const activityListener = vi.fn();
+    writeActivityStore.subscribe(activityListener);
+    const fakeAdapter = makeFakeAdapter({ write: vi.fn().mockRejectedValue(new Error('transient write failure')) });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockGetMoonboardBluetoothPacket.mockReturnValue({
+      packet: new Uint8Array([1]),
+      skippedRoleCount: 0,
+      skippedPositionCount: 0,
+      totalPlacements: 1,
+      isClear: false,
+    });
+    const { result } = renderHook(() =>
+      useBoardBluetooth({ boardName: 'moonboard', layoutId: 1, sizeId: 1, writeActivityStore }),
+    );
+
+    await act(async () => {
+      await result.current.connect();
+    });
+    let sendResult: boolean | undefined = true;
+    await act(async () => {
+      sendResult = await result.current.sendFramesToBoard('p1r12');
+    });
+
+    expect(sendResult).toBe(false);
+    expect(writeActivityStore.getSnapshot()).toBe(false);
+    expect(activityListener).toHaveBeenCalledTimes(2);
+  });
+
+  it('tracks connect-initial MoonBoard frames until the adapter write settles', async () => {
+    const writeActivityStore = createBleWriteActivityStore();
+    let resolveWrite!: () => void;
+    const fakeAdapter = makeFakeAdapter({
+      write: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveWrite = resolve;
+          }),
+      ),
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockGetMoonboardBluetoothPacket.mockReturnValue({
+      packet: new Uint8Array([1]),
+      skippedRoleCount: 0,
+      skippedPositionCount: 0,
+      totalPlacements: 1,
+      isClear: false,
+    });
+    const { result } = renderHook(() =>
+      useBoardBluetooth({ boardName: 'moonboard', layoutId: 1, sizeId: 1, writeActivityStore }),
+    );
+
+    let connectPromise!: Promise<boolean>;
+    act(() => {
+      connectPromise = result.current.connect('p1r12');
+    });
+    await waitFor(() => expect(writeActivityStore.getSnapshot()).toBe(true));
+
+    await act(async () => {
+      resolveWrite();
+      await connectPromise;
+    });
+
+    expect(result.current.isConnected).toBe(true);
+    expect(writeActivityStore.getSnapshot()).toBe(false);
+  });
+
+  it('resets a dropped generation and ignores its late release after a new write begins', async () => {
+    const writeActivityStore = createBleWriteActivityStore();
+    let resolveOldWrite!: () => void;
+    let resolveNewWrite!: () => void;
+    const oldAdapter = makeFakeAdapter({
+      write: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveOldWrite = resolve;
+          }),
+      ),
+    });
+    const newAdapter = makeFakeAdapter({
+      write: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveNewWrite = resolve;
+          }),
+      ),
+    });
+    vi.mocked(createBluetoothAdapter)
+      .mockReturnValueOnce(oldAdapter as unknown as ReturnType<typeof createBluetoothAdapter>)
+      .mockReturnValueOnce(newAdapter as unknown as ReturnType<typeof createBluetoothAdapter>);
+    mockGetMoonboardBluetoothPacket.mockReturnValue({
+      packet: new Uint8Array([1]),
+      skippedRoleCount: 0,
+      skippedPositionCount: 0,
+      totalPlacements: 1,
+      isClear: false,
+    });
+    const { result } = renderHook(() =>
+      useBoardBluetooth({ boardName: 'moonboard', layoutId: 1, sizeId: 1, writeActivityStore }),
+    );
+
+    await act(async () => {
+      await result.current.connect();
+    });
+    let oldSend!: Promise<boolean | undefined>;
+    act(() => {
+      oldSend = result.current.sendFramesToBoard('p1r12');
+    });
+    await waitFor(() => expect(writeActivityStore.getSnapshot()).toBe(true));
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+    expect(writeActivityStore.getSnapshot()).toBe(false);
+
+    await act(async () => {
+      await result.current.connect();
+    });
+    let newSend!: Promise<boolean | undefined>;
+    act(() => {
+      newSend = result.current.sendFramesToBoard('p2r12');
+    });
+    await waitFor(() => expect(writeActivityStore.getSnapshot()).toBe(true));
+
+    await act(async () => {
+      resolveOldWrite();
+      await oldSend;
+    });
+    expect(writeActivityStore.getSnapshot()).toBe(true);
+
+    await act(async () => {
+      resolveNewWrite();
+      await newSend;
+    });
+    expect(writeActivityStore.getSnapshot()).toBe(false);
+  });
+
+  it('resets write activity on hook unmount even when an adapter ignores abort', async () => {
+    const writeActivityStore = createBleWriteActivityStore();
+    let resolveWrite!: () => void;
+    const fakeAdapter = makeFakeAdapter({
+      write: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveWrite = resolve;
+          }),
+      ),
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockGetMoonboardBluetoothPacket.mockReturnValue({
+      packet: new Uint8Array([1]),
+      skippedRoleCount: 0,
+      skippedPositionCount: 0,
+      totalPlacements: 1,
+      isClear: false,
+    });
+    const { result, unmount } = renderHook(() =>
+      useBoardBluetooth({ boardName: 'moonboard', layoutId: 1, sizeId: 1, writeActivityStore }),
+    );
+
+    await act(async () => {
+      await result.current.connect();
+    });
+    let send!: Promise<boolean | undefined>;
+    act(() => {
+      send = result.current.sendFramesToBoard('p1r12');
+    });
+    await waitFor(() => expect(writeActivityStore.getSnapshot()).toBe(true));
+
+    unmount();
+    expect(writeActivityStore.getSnapshot()).toBe(false);
+
+    await act(async () => {
+      resolveWrite();
+      await send;
+    });
+    expect(writeActivityStore.getSnapshot()).toBe(false);
   });
 
   it('refuses a mirrored send on a mirroring board when holdsData is missing (never sends un-mirrored frames)', async () => {
@@ -845,13 +1055,18 @@ describe('useBoardBluetooth', () => {
   it('fires Board Lights Cleared on an Aurora deliberate clear (#3420)', async () => {
     // The Aurora clear branch is separate from dispatchMoonboardPacket, so its
     // sendSource-gated tracking needs its own pin.
+    const writeActivityStore = createBleWriteActivityStore();
+    const activityListener = vi.fn();
+    writeActivityStore.subscribe(activityListener);
     const fakeAdapter = makeFakeAdapter();
     vi.mocked(createBluetoothAdapter).mockReturnValue(
       fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
     );
     mockGetAuroraBluetoothPacket.mockReturnValue({ packet: new Uint8Array([0x01, 0x02]) });
 
-    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+    const { result } = renderHook(() =>
+      useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1, writeActivityStore }),
+    );
     await act(async () => {
       await result.current.connect();
     });
@@ -862,6 +1077,8 @@ describe('useBoardBluetooth', () => {
 
     expect(cleared).toBe(true);
     expect(fakeAdapter.write).toHaveBeenCalled();
+    expect(writeActivityStore.getSnapshot()).toBe(false);
+    expect(activityListener).toHaveBeenCalledTimes(2);
     const clearedCall = mockTrack.mock.calls.find(([name]) => name === 'Board Lights Cleared');
     expect(clearedCall?.[1]).toMatchObject({ boardName: 'kilter', sendSource: 'clear' });
     expect(mockTrack.mock.calls.find(([name]) => name === 'Climb Sent to Board Success')).toBeUndefined();

--- a/packages/mobile/src/lib/ble/__tests__/write-activity-store.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/write-activity-store.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createBleWriteActivityStore } from '../write-activity-store';
+
+describe('createBleWriteActivityStore', () => {
+  it('notifies only on boolean busy-state edges across overlapping tokens', () => {
+    const store = createBleWriteActivityStore();
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    const releaseFirst = store.begin();
+    expect(store.getSnapshot()).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    const releaseSecond = store.begin();
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    releaseFirst();
+    expect(store.getSnapshot()).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    releaseSecond();
+    expect(store.getSnapshot()).toBe(false);
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('makes releases idempotent and unsubscribe effective', () => {
+    const store = createBleWriteActivityStore();
+    const listener = vi.fn();
+    const unsubscribe = store.subscribe(listener);
+    const release = store.begin();
+
+    release();
+    release();
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    store.begin();
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('resets the old epoch without letting a late release clear a new write', () => {
+    const store = createBleWriteActivityStore();
+    const listener = vi.fn();
+    store.subscribe(listener);
+    const releaseOldWrite = store.begin();
+
+    store.reset();
+    expect(store.getSnapshot()).toBe(false);
+
+    const releaseNewWrite = store.begin();
+    releaseOldWrite();
+    expect(store.getSnapshot()).toBe(true);
+
+    releaseNewWrite();
+    expect(store.getSnapshot()).toBe(false);
+    expect(listener).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not notify for a reset while already idle', () => {
+    const store = createBleWriteActivityStore();
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    store.reset();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -51,6 +51,7 @@ import {
   setStoredLastConnectedBoard,
   type StoredLastConnectedBoard,
 } from './last-connected-board-store';
+import type { BleWriteActivityStore } from './write-activity-store';
 
 // Exported for testing. Decides how a connect-failure category reaches error
 // tracking:
@@ -345,6 +346,8 @@ type UseBoardBluetoothOptions = {
   /** Reads whether this connection was made via the mismatch "Connect anyway"
    *  override, attached to connection + send analytics. */
   getConnectedViaMismatchOverride?: () => boolean;
+  /** Provider-scoped external store for foreground JS write feedback. */
+  writeActivityStore?: BleWriteActivityStore;
 };
 
 const KEEP_AWAKE_TAG = 'boardsesh-ble';
@@ -435,6 +438,7 @@ export function useBoardBluetooth({
   onConnectionChange,
   onConnectSuccess,
   getConnectedViaMismatchOverride,
+  writeActivityStore,
 }: UseBoardBluetoothOptions) {
   const { t } = useTranslation('settings');
   // Connect-failure copy lives in the shared `common.bluetooth.*` keys so web
@@ -676,6 +680,7 @@ export function useBoardBluetooth({
       writeAbortRef.current?.abort();
       writeAbortRef.current = null;
       writeChainRef.current = Promise.resolve();
+      writeActivityStore?.reset();
       moonboardWriteFailureStreakRef.current = 0;
       setIsConnected(false);
       onConnectionChange?.(false);
@@ -689,7 +694,7 @@ export function useBoardBluetooth({
       // native link would otherwise leak — dispose explicitly.
       void expectedAdapter.disconnect().catch(() => {});
     },
-    [onConnectionChange],
+    [onConnectionChange, writeActivityStore],
   );
 
   const handleDisconnection = useCallback(
@@ -988,12 +993,17 @@ export function useBoardBluetooth({
       // coerces both outcomes), so a single fulfilled-arm .then suffices here;
       // the rejected arm below is belt-and-suspenders so a future edit that
       // lets performSend throw still can't wedge the chain.
+      const releaseWriteActivity = writeActivityStore?.begin();
       const queuedSend = writeChainRef.current.then(performSend);
       writeChainRef.current = queuedSend.then(
         () => undefined,
         () => undefined,
       );
-      return queuedSend;
+      try {
+        return await queuedSend;
+      } finally {
+        releaseWriteActivity?.();
+      }
     },
     [
       boardName,
@@ -1004,6 +1014,7 @@ export function useBoardBluetooth({
       analyticsBoardId,
       handleDisconnection,
       getConnectedViaMismatchOverride,
+      writeActivityStore,
       t,
     ],
   );
@@ -1060,6 +1071,7 @@ export function useBoardBluetooth({
         writeAbortRef.current?.abort();
         writeAbortRef.current = null;
         writeChainRef.current = Promise.resolve();
+        writeActivityStore?.reset();
         // Fresh connection generation — a stale dead-link streak must not carry over.
         moonboardWriteFailureStreakRef.current = 0;
 
@@ -1414,6 +1426,7 @@ export function useBoardBluetooth({
       sendFramesToBoard,
       sanitizedColorOverrides,
       colorSignature,
+      writeActivityStore,
       devicePicker,
       t,
       tCommon,
@@ -1442,12 +1455,13 @@ export function useBoardBluetooth({
       writeAbortRef.current?.abort();
       writeAbortRef.current = null;
       writeChainRef.current = Promise.resolve();
+      writeActivityStore?.reset();
       setIsConnected(false);
       onConnectionChange?.(false);
       clearBleDiagnosticsTags();
       await adapter?.disconnect();
     },
-    [consumeConnectionLifetime, onConnectionChange],
+    [consumeConnectionLifetime, onConnectionChange, writeActivityStore],
   );
 
   const disconnect = useCallback(
@@ -1686,6 +1700,7 @@ export function useBoardBluetooth({
       unsubDisconnectRef.current?.();
       unsubDisconnectRef.current = null;
       writeAbortRef.current?.abort();
+      writeActivityStore?.reset();
       const adapter = adapterRef.current;
       const lifetime = activeConnectionLifetimeRef.current;
       if (adapter && lifetime?.adapter === adapter) {
@@ -1700,7 +1715,7 @@ export function useBoardBluetooth({
       adapterRef.current = null;
       void adapter?.disconnect();
     };
-  }, [consumeConnectionLifetime]);
+  }, [consumeConnectionLifetime, writeActivityStore]);
 
   return {
     isConnected,

--- a/packages/mobile/src/lib/ble/write-activity-store.ts
+++ b/packages/mobile/src/lib/ble/write-activity-store.ts
@@ -1,0 +1,65 @@
+export type BleWriteActivityStore = {
+  /** Register a listener for boolean busy-state edges. */
+  subscribe: (listener: () => void) => () => void;
+  /** Whether at least one foreground JS write request is active. */
+  getSnapshot: () => boolean;
+  /** Begin one write request and return its idempotent release callback. */
+  begin: () => () => void;
+  /** Retire every token from the previous connection generation. */
+  reset: () => void;
+};
+
+type WriteToken = {
+  epoch: number;
+  id: symbol;
+};
+
+/**
+ * A tiny external store for foreground BLE write activity.
+ *
+ * Tokens make overlapping and write-chain-queued requests ref-count correctly.
+ * The epoch makes a generation reset safe even when an adapter ignores abort
+ * long enough for an old request's `finally` to release after a new write began.
+ */
+export function createBleWriteActivityStore(): BleWriteActivityStore {
+  const listeners = new Set<() => void>();
+  const activeTokenIds = new Set<symbol>();
+  let epoch = 0;
+
+  const notify = () => {
+    for (const listener of listeners) listener();
+  };
+
+  const getSnapshot = () => activeTokenIds.size > 0;
+
+  return {
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    getSnapshot,
+    begin() {
+      const token: WriteToken = { epoch, id: Symbol('ble-write') };
+      const wasWriting = getSnapshot();
+      activeTokenIds.add(token.id);
+      if (!wasWriting) notify();
+
+      let released = false;
+      return () => {
+        if (released) return;
+        released = true;
+        if (token.epoch !== epoch) return;
+
+        const wasActive = getSnapshot();
+        activeTokenIds.delete(token.id);
+        if (wasActive && !getSnapshot()) notify();
+      };
+    },
+    reset() {
+      const wasWriting = getSnapshot();
+      epoch += 1;
+      activeTokenIds.clear();
+      if (wasWriting) notify();
+    },
+  };
+}

--- a/packages/mobile/src/providers/__tests__/bluetooth-write-activity.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-write-activity.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { act, render } from '@testing-library/react';
+import { createElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { createBleWriteActivityStore } from '../../lib/ble/write-activity-store';
+import {
+  BluetoothWriteActivityProvider,
+  getBleWriteActivityServerSnapshot,
+  useBluetoothWriteInProgress,
+} from '../bluetooth-write-activity';
+
+function ActivityProbe({ onRender }: { onRender?: () => void }) {
+  onRender?.();
+  const isWriting = useBluetoothWriteInProgress();
+  return createElement('span', { 'data-writing': String(isWriting) });
+}
+
+function PassiveSibling({ onRender }: { onRender: () => void }) {
+  onRender();
+  return createElement('span', { 'data-passive': 'true' });
+}
+
+describe('BluetoothWriteActivityProvider', () => {
+  it('rerenders only the activity subscriber when the external store changes', () => {
+    const store = createBleWriteActivityStore();
+    const activityRender = vi.fn();
+    const passiveRender = vi.fn();
+    const view = render(
+      createElement(
+        BluetoothWriteActivityProvider,
+        { store },
+        createElement(ActivityProbe, { onRender: activityRender }),
+        createElement(PassiveSibling, { onRender: passiveRender }),
+      ),
+    );
+
+    expect(activityRender).toHaveBeenCalledTimes(1);
+    expect(passiveRender).toHaveBeenCalledTimes(1);
+
+    let release = () => {};
+    act(() => {
+      release = store.begin();
+    });
+    expect(view.container.querySelector('[data-writing="true"]')).toBeTruthy();
+    expect(activityRender).toHaveBeenCalledTimes(2);
+    expect(passiveRender).toHaveBeenCalledTimes(1);
+
+    act(() => release());
+    expect(view.container.querySelector('[data-writing="false"]')).toBeTruthy();
+    expect(activityRender).toHaveBeenCalledTimes(3);
+    expect(passiveRender).toHaveBeenCalledTimes(1);
+  });
+
+  it('is idle outside a provider and exposes an idle server snapshot', () => {
+    const noProvider = render(createElement(ActivityProbe));
+    expect(noProvider.container.querySelector('[data-writing="false"]')).toBeTruthy();
+    expect(getBleWriteActivityServerSnapshot()).toBe(false);
+  });
+});

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -52,6 +52,8 @@ import { track } from '../lib/analytics';
 import { getBluetoothColorOverrides, useHoldColorOverrides } from '../lib/hold-color-overrides';
 import { useSetting } from '../settings';
 import { AutoDisconnectController } from '../lib/ble/auto-disconnect-controller';
+import { createBleWriteActivityStore } from '../lib/ble/write-activity-store';
+import { BluetoothWriteActivityProvider } from './bluetooth-write-activity';
 
 type BluetoothContextValue = {
   isConnected: boolean;
@@ -494,6 +496,7 @@ export function BluetoothProvider({
   boardUuid,
   children,
 }: BluetoothProviderProps) {
+  const [writeActivityStore] = useState(createBleWriteActivityStore);
   const { sessionId, confirmClimbOnWall, reportWallDisconnect, setSessionBoardSerial, lastConnectedBoardSerial } =
     useQueueSessionControls();
   const { t } = useTranslation('settings');
@@ -953,6 +956,7 @@ export function BluetoothProvider({
     onConnectSuccess: handleConnectSuccess,
     onConnectionEnded: handleBluetoothConnectionEnded,
     getConnectedViaMismatchOverride,
+    writeActivityStore,
   });
 
   // Every successful board write is activity for the auto-disconnect deadline,
@@ -1545,36 +1549,38 @@ export function BluetoothProvider({
 
   return (
     <BluetoothContext.Provider value={value}>
-      {/* Holder model: anyone connected writes the wall (always-take), so the
-          auto-sender mounts on isConnected alone — no driver/preview write-gate.
-          Aurora is last-connection-wins, so one phone is physically connected. */}
-      {isConnected && (
-        <BluetoothAutoSender
-          sendFramesToBoard={sendFramesToBoardWithActivityReset}
-          onWallConfirmed={handleWallConfirmed}
-          reassertNonce={reassertNonce}
-          connectInitialSendRef={connectInitialSendRef}
-          lastPhysicalFramesRef={lastPhysicalFramesRef}
-          colorSignature={holdColorSignature}
-          activeConfig={currentBoardConfig}
-          onSkipSpillClimb={handleSkipSpillClimb}
-          onUnresolvedCurrentClimb={handleUnresolvedCurrentClimb}
-        />
-      )}
-      <BlePickerHostContext.Provider value={pickerHostValue}>{children}</BlePickerHostContext.Provider>
-      {/* App-root picker, for connects off the tab screens / accessory bar.
-          Suppressed while a route (the player) hosts its own — see
-          DevicePickerSheetHost. */}
-      {pickerState && !pickerHostedExternally && (
-        <DevicePickerSheet
-          devices={pickerState.devices}
-          onSelect={handlePickerSelect}
-          onDismiss={pickerState.handleCancel}
-          isScanning={pickerState.isScanning}
-          resolvedBoards={resolvedPickerBoards}
-          currentBoardConfig={currentBoardConfig}
-        />
-      )}
+      <BluetoothWriteActivityProvider store={writeActivityStore}>
+        {/* Holder model: anyone connected writes the wall (always-take), so the
+            auto-sender mounts on isConnected alone — no driver/preview write-gate.
+            Aurora is last-connection-wins, so one phone is physically connected. */}
+        {isConnected && (
+          <BluetoothAutoSender
+            sendFramesToBoard={sendFramesToBoardWithActivityReset}
+            onWallConfirmed={handleWallConfirmed}
+            reassertNonce={reassertNonce}
+            connectInitialSendRef={connectInitialSendRef}
+            lastPhysicalFramesRef={lastPhysicalFramesRef}
+            colorSignature={holdColorSignature}
+            activeConfig={currentBoardConfig}
+            onSkipSpillClimb={handleSkipSpillClimb}
+            onUnresolvedCurrentClimb={handleUnresolvedCurrentClimb}
+          />
+        )}
+        <BlePickerHostContext.Provider value={pickerHostValue}>{children}</BlePickerHostContext.Provider>
+        {/* App-root picker, for connects off the tab screens / accessory bar.
+            Suppressed while a route (the player) hosts its own — see
+            DevicePickerSheetHost. */}
+        {pickerState && !pickerHostedExternally && (
+          <DevicePickerSheet
+            devices={pickerState.devices}
+            onSelect={handlePickerSelect}
+            onDismiss={pickerState.handleCancel}
+            isScanning={pickerState.isScanning}
+            resolvedBoards={resolvedPickerBoards}
+            currentBoardConfig={currentBoardConfig}
+          />
+        )}
+      </BluetoothWriteActivityProvider>
     </BluetoothContext.Provider>
   );
 }

--- a/packages/mobile/src/providers/bluetooth-write-activity.tsx
+++ b/packages/mobile/src/providers/bluetooth-write-activity.tsx
@@ -1,0 +1,31 @@
+import { createContext, type ReactNode, useContext, useSyncExternalStore } from 'react';
+import type { BleWriteActivityStore } from '../lib/ble/write-activity-store';
+
+const BluetoothWriteActivityContext = createContext<BleWriteActivityStore | null>(null);
+
+const subscribeToNothing = () => () => {};
+export const getBleWriteActivityServerSnapshot = () => false;
+
+export function BluetoothWriteActivityProvider({
+  store,
+  children,
+}: {
+  store: BleWriteActivityStore;
+  children?: ReactNode;
+}) {
+  return <BluetoothWriteActivityContext.Provider value={store}>{children}</BluetoothWriteActivityContext.Provider>;
+}
+
+/**
+ * Subscribe only the leaf that paints BLE write feedback. The main Bluetooth
+ * context intentionally excludes this volatile state so a packet does not
+ * rerender the navigation tree.
+ */
+export function useBluetoothWriteInProgress(): boolean {
+  const store = useContext(BluetoothWriteActivityContext);
+  return useSyncExternalStore(
+    store?.subscribe ?? subscribeToNothing,
+    store?.getSnapshot ?? getBleWriteActivityServerSnapshot,
+    getBleWriteActivityServerSnapshot,
+  );
+}

--- a/packages/shared/i18n/locales/de/settings.json
+++ b/packages/shared/i18n/locales/de/settings.json
@@ -479,6 +479,7 @@
   },
   "ble": {
     "scanning": "Suche nach Boards in der Nähe…",
+    "writing": "Board wird beleuchtet…",
     "selectBoard": "Board auswählen",
     "devicesFound_one": "{{count}} Board gefunden",
     "devicesFound_other": "{{count}} Boards gefunden",

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -479,6 +479,7 @@
   },
   "ble": {
     "scanning": "Scanning for boards nearby…",
+    "writing": "Lighting the board…",
     "selectBoard": "Select Board",
     "devicesFound_one": "{{count}} board found",
     "devicesFound_other": "{{count}} boards found",

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -479,6 +479,7 @@
   },
   "ble": {
     "scanning": "Buscando plafones cercanos…",
+    "writing": "Iluminando el plafón…",
     "selectBoard": "Seleccionar plafón",
     "devicesFound_one": "{{count}} plafón encontrado",
     "devicesFound_other": "{{count}} plafones encontrados",

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -479,6 +479,7 @@
   },
   "ble": {
     "scanning": "Recherche de boards à proximité…",
+    "writing": "Allumage de la board…",
     "selectBoard": "Sélectionner une board",
     "devicesFound_one": "{{count}} board trouvée",
     "devicesFound_other": "{{count}} boards trouvées",


### PR DESCRIPTION
## Summary

- Track queued and active foreground Bluetooth writes with a provider-scoped token store that survives stale releases across connection generations.
- Show a spinner in the connected lightbulb while a climb is being written, without rerendering the main Bluetooth context or changing tap and long-press behavior.
- Announce the busy state and write progress in English, Spanish, French, and German, with scanning taking visual and accessibility priority.

Closes #4145

## Release Notes

- The lightbulb now spins while Boardsesh writes a climb to your wall, so you know your tap landed.

## Test plan

- Rebased onto current `main` (auto-disconnect landed since): the provider conflict resolves by keeping main's `sendFramesToBoardWithActivityReset` wrapper and nesting the auto-sender inside `BluetoothWriteActivityProvider`. All four write-activity `reset()` teardown paths in `use-board-bluetooth.ts` survived the rebase intact.
- Dropped the #4213 cherry-pick this branch was carrying — that parity fix has landed on `main` and moved on since, and the stale copy was the merge conflict. The German `boards.json` now comes from `main` wholesale.
- Full mobile suite on the rebased branch: 5,278 tests across 604 files, all passing — including main's connection-lifetime and auto-disconnect tests running against the merged code.
- `vp run typecheck:mobile`, the `@boardsesh/i18n` catalog-parity suite (90 tests), `vp check` (no diagnostics in any file this PR touches), and `vp run check:mobile-bundle` (iOS + Android) pass locally.
- Added the German `ble.writing` string (`Board wird beleuchtet…`) — the `de` locale landed on `main` after this branch was cut.
- GitHub's OTA compatibility check confirms the iOS and Android fingerprints match `main`; this ships to existing builds without a native rebuild.
- **Fable BLE review: done.** The repository-policy review ran in a Fable 5 session and is recorded as a comment on this PR (verdict: approve; protocol-untouched, token/epoch lifecycle verified across all four teardown paths).

## Remaining QA gates (hardware only)

- Confirm real write timing, rapid queued sends, and teardown mid-write on Kilter, Tension, and MoonBoard hardware across iOS and Android.
- Confirm spoken feedback in VoiceOver and TalkBack on device.
## Fable BLE review

Reviewed per the CLAUDE.md rule that Bluetooth changes need a Fable review before merge. This is that review, running as Fable 5 in a Claude Code session — it replaces the "literal Fable review unavailable" blocker recorded earlier on this PR. **Verdict: approve**, with the rebase and follow-ups noted below.

### Protocol safety

No change to anything the board sees. Packet construction (`getAuroraBluetoothPacket`, `dispatchMoonboardPacket`), chunking, write types, abort signals, and the `writeChainRef` serialization are untouched — the write-activity store is JS bookkeeping wrapped around the existing chain. The MoonBoard failure-streak logic and the disconnect classification paths are unchanged. Zero risk to Kilter / Tension / MoonBoard write behaviour, and no fingerprint impact (JS-only, confirmed by the OTA gate).

### Correctness of the activity tracking

- Token ref-counting handles overlapping and queued writes; `notify` fires only on boolean edges, so subscribers rerender at most twice per busy episode.
- The epoch guard is right: a stale release surviving past a generation reset (adapter that ignores abort, late `finally`) becomes a no-op instead of clearing a new write's token. Idempotent release covers double-calls.
- `begin()` sits after the early no-adapter/no-config guard, so a skipped send never leaks a token; release lives in `finally`, so success, failure, and abort all release.
- Every teardown path resets the store: link-drop cleanup, fresh connect (new generation), deliberate teardown, and hook unmount. Verified again after rebasing onto the connection-lifetime refactor from current `main` — the reset calls sit in the refactored `clearConnectionAfterDrop(expectedAdapter)`, `teardownConnection(trigger)`, and the unmount cleanup, and the full mobile suite (5,130 tests) passes on the rebased branch.
- Render isolation holds: the store identity is stable (`useState` initializer), only the lightbulb leaf subscribes via `useSyncExternalStore`, and the main `BluetoothContext` value is untouched, so a write cannot rerender the navigation tree.

### UX judgment call, endorsed

The spinner covers queue-wait plus write (tap-to-settlement), so a rapid second tap shows a spinner for longer than its own physical write. That is the right reading of #4145 — the missing affordance was "did my tap land", and a queued tap has landed. Scanning keeps visual and announcement priority over writing, which is correct: connect feedback is rarer and more actionable.

### Accessibility

`accessibilityState.busy` now reflects scanning-or-writing, hint precedence is scanning → writing → long-press, the spinner itself is `accessible={false}`, and tap/long-press behaviour is unchanged while busy — all pinned by the render test.

### What I changed while finishing

1. **Rebased onto current `main`** over the connection-lifetime refactor; four conflict hunks in `use-board-bluetooth.ts` resolved by keeping main's adapter-guard semantics and re-adding the `reset()` calls.
2. **Added the German `ble.writing` key** (`Board wird beleuchtet…`, per the glossary) — the `de` locale landed after this branch was cut and catalog parity would have failed.
3. **PR #4213** fixes a pre-existing `de/boards.json` parity break on `main` (unrelated to this PR) that was redding `test-default` for every branch.

### Review follow-ups (applied after the review above)

- **Blocking item cleared.** Rebased onto `main` over the auto-disconnect work and dropped the stale #4213 cherry-pick, so `de/boards.json` is now main's version verbatim. The branch is `MERGEABLE`.
- **Spinner nit fixed.** The lightbulb no longer pins the spinner to `size="small"` while the icon it replaces honors `size`. `getBleLightbulbSpinnerSize` maps the icon size onto RN's two native spinner sizes (20pt / 36pt, crossover at 32) rather than passing the raw number — on iOS a numeric `size` only resizes the wrapper box and leaves the glyph unscaled, so passing it through would have looked worse, not better. Both shipping call sites pass 24 and keep the 20pt spinner; covered by four new cases in `BleLightbulbButton.test.ts`.

### Still open (hardware-only)

Real-board timing on Kilter / Tension / MoonBoard across iOS and Android, and spoken feedback under VoiceOver / TalkBack, remain hardware QA — nothing in this review substitutes for them, but none of them block a JS-only OTA-revertible change of this shape.

