### PR TITLE
fix(mobile): smooth custom colour slider drags

### DIFF
--- a/packages/mobile/src/components/settings/OkhslColorPicker.tsx
+++ b/packages/mobile/src/components/settings/OkhslColorPicker.tsx
@@ -213,6 +213,8 @@ const ChannelSlider = memo(function ChannelSlider({
   );
 
   useEffect(() => {
+    // React Strict Mode replays effect cleanup + setup without recreating refs,
+    // so restore the mounted flag after its development-only cleanup pass.
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;

--- a/packages/mobile/src/components/settings/OkhslColorPicker.tsx
+++ b/packages/mobile/src/components/settings/OkhslColorPicker.tsx
@@ -397,7 +397,8 @@ type OkhslColorPickerProps = {
   /**
    * Initial colour as #rrggbb. Read only on mount — OKHSL is the source of
    * truth thereafter, so the caller re-seeds by remounting via a React `key`
-   * (e.g. key per opened role) rather than pushing new values in.
+   * (e.g. key per opened role) rather than pushing new values in. This also
+   * makes a parent prop change during an active drag intentionally inert.
    */
   value: string;
   onChange: (hex: string) => void;

--- a/packages/mobile/src/components/settings/OkhslColorPicker.tsx
+++ b/packages/mobile/src/components/settings/OkhslColorPicker.tsx
@@ -45,6 +45,7 @@ type ChannelSliderProps = {
   ratio: number;
   stops: { offset: number; color: string }[];
   onChangeRatio: (ratio: number) => void;
+  /** Mutable epoch shared by all three sliders to invalidate stale gestures. */
   gestureEpochRef: { current: number };
   onDragStart: () => number;
   onDragEnd: (gestureEpoch: number) => void;
@@ -179,6 +180,8 @@ const ChannelSlider = memo(function ChannelSlider({
       applyCoordinate(latestCoordinate, layout);
     });
   }, [applyCoordinate, finishGesture]);
+  // Keep the latest callback available to its own deferred measurement
+  // completions without rebuilding the gesture responder mid-drag.
   measurePendingCoordinateRef.current = measurePendingCoordinate;
 
   const requestCoordinate = useCallback(
@@ -253,6 +256,12 @@ const ChannelSlider = memo(function ChannelSlider({
     onChangeRatioRef.current(Math.max(0, Math.min(1, ratioRef.current + delta)));
   }, []);
 
+  const handleTrackLayout = useCallback(() => {
+    layoutGenerationRef.current += 1;
+    trackLayoutRef.current = null;
+    measurePendingCoordinateRef.current();
+  }, []);
+
   return (
     <View style={styles.sliderBlock}>
       <View style={styles.sliderLabelRow}>
@@ -273,15 +282,7 @@ const ChannelSlider = memo(function ChannelSlider({
         style={styles.sliderTouchArea}
         {...panResponder.panHandlers}
       >
-        <View
-          ref={trackRef}
-          onLayout={() => {
-            layoutGenerationRef.current += 1;
-            trackLayoutRef.current = null;
-            measurePendingCoordinateRef.current();
-          }}
-          style={styles.trackContainer}
-        >
+        <View ref={trackRef} onLayout={handleTrackLayout} style={styles.trackContainer}>
           <Svg width="100%" height={TRACK_HEIGHT} style={styles.trackSvg}>
             <Defs>
               <LinearGradient id={gradientId} x1="0" y1="0" x2="1" y2="0">

--- a/packages/mobile/src/components/settings/OkhslColorPicker.tsx
+++ b/packages/mobile/src/components/settings/OkhslColorPicker.tsx
@@ -231,6 +231,7 @@ const ChannelSlider = memo(function ChannelSlider({
         onStartShouldSetPanResponder: () => true,
         onMoveShouldSetPanResponder: () => true,
         onPanResponderGrant: (event: GestureResponderEvent) => {
+          if (!mountedRef.current) return;
           gestureGenerationRef.current += 1;
           pendingCoordinateRef.current = null;
           activePickerGestureEpochRef.current = onDragStartRef.current();

--- a/packages/mobile/src/components/settings/OkhslColorPicker.tsx
+++ b/packages/mobile/src/components/settings/OkhslColorPicker.tsx
@@ -180,9 +180,14 @@ const ChannelSlider = memo(function ChannelSlider({
       applyCoordinate(latestCoordinate, layout);
     });
   }, [applyCoordinate, finishGesture]);
-  // Keep the latest callback available to its own deferred measurement
-  // completions without rebuilding the gesture responder mid-drag.
-  measurePendingCoordinateRef.current = measurePendingCoordinate;
+  useEffect(() => {
+    // Keep the latest callback available to its own deferred measurement
+    // completions without rebuilding the gesture responder mid-drag.
+    measurePendingCoordinateRef.current = measurePendingCoordinate;
+    return () => {
+      measurePendingCoordinateRef.current = () => undefined;
+    };
+  }, [measurePendingCoordinate]);
 
   const requestCoordinate = useCallback(
     (pageX: number, shouldEndGesture: boolean) => {

--- a/packages/mobile/src/components/settings/OkhslColorPicker.tsx
+++ b/packages/mobile/src/components/settings/OkhslColorPicker.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
   PanResponder,
   StyleSheet,
@@ -180,9 +180,10 @@ const ChannelSlider = memo(function ChannelSlider({
       applyCoordinate(latestCoordinate, layout);
     });
   }, [applyCoordinate, finishGesture]);
-  useEffect(() => {
+  useLayoutEffect(() => {
     // Keep the latest callback available to its own deferred measurement
-    // completions without rebuilding the gesture responder mid-drag.
+    // completions without rebuilding the gesture responder mid-drag. Install
+    // it before passive effects can deliver queued touch events on a busy frame.
     measurePendingCoordinateRef.current = measurePendingCoordinate;
     return () => {
       measurePendingCoordinateRef.current = () => undefined;

--- a/packages/mobile/src/components/settings/OkhslColorPicker.tsx
+++ b/packages/mobile/src/components/settings/OkhslColorPicker.tsx
@@ -186,6 +186,8 @@ const ChannelSlider = memo(function ChannelSlider({
     // it before passive effects can deliver queued touch events on a busy frame.
     measurePendingCoordinateRef.current = measurePendingCoordinate;
     return () => {
+      // Layout cleanup precedes the passive mountedRef cleanup, so prevent an
+      // in-flight stale result from scheduling another measurement in that gap.
       measurePendingCoordinateRef.current = () => undefined;
     };
   }, [measurePendingCoordinate]);

--- a/packages/mobile/src/components/settings/OkhslColorPicker.tsx
+++ b/packages/mobile/src/components/settings/OkhslColorPicker.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useId, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import {
   PanResponder,
   StyleSheet,
@@ -23,6 +23,7 @@ const ERROR_COLOR = iosSystemColors.systemRed;
 
 const HUE_STOPS = 13;
 const SL_STOPS = 12;
+const GRADIENT_UPDATE_INTERVAL_MS = 1000 / 30;
 const DEFAULT_OKHSL: Okhsl = { h: 0, s: 0, l: 0.5 };
 
 function sampleGradient(count: number, at: (t: number) => string): { offset: number; color: string }[] {
@@ -44,23 +45,44 @@ type ChannelSliderProps = {
   ratio: number;
   stops: { offset: number; color: string }[];
   onChangeRatio: (ratio: number) => void;
+  gestureEpochRef: { current: number };
+  onDragStart: () => number;
+  onDragEnd: (gestureEpoch: number) => void;
   /** Keyboard / screen-reader step as a fraction of the full range. */
   step: number;
 };
 
-function ChannelSlider({
+type PendingSliderCoordinate = {
+  gestureGeneration: number;
+  pickerGestureEpoch: number;
+  pageX: number;
+  shouldEndGesture: boolean;
+};
+
+const ChannelSlider = memo(function ChannelSlider({
   label,
   valueText,
   accessibilityLabel,
   ratio,
   stops,
   onChangeRatio,
+  gestureEpochRef,
+  onDragStart,
+  onDragEnd,
   step,
 }: ChannelSliderProps) {
   const { systemColors } = useTheme();
   const gradientId = `okhsl-${useId().replace(/:/g, '_')}`;
   const trackRef = useRef<View>(null);
   const trackLayoutRef = useRef<{ pageLeft: number; width: number } | null>(null);
+  const mountedRef = useRef(true);
+  const gestureGenerationRef = useRef(0);
+  const activePickerGestureEpochRef = useRef(-1);
+  const finishedGestureGenerationRef = useRef(-1);
+  const layoutGenerationRef = useRef(0);
+  const measurementInFlightRef = useRef(false);
+  const pendingCoordinateRef = useRef<PendingSliderCoordinate | null>(null);
+  const measurePendingCoordinateRef = useRef<() => void>(() => undefined);
   const clamped = Math.max(0, Math.min(1, ratio));
 
   // Mirror the latest props into refs so the gesture handlers below can stay
@@ -68,6 +90,10 @@ function ChannelSlider({
   // matches the MarkerMultiplierSlider pattern + the repo's RN perf rules.
   const onChangeRatioRef = useRef(onChangeRatio);
   onChangeRatioRef.current = onChangeRatio;
+  const onDragStartRef = useRef(onDragStart);
+  onDragStartRef.current = onDragStart;
+  const onDragEndRef = useRef(onDragEnd);
+  onDragEndRef.current = onDragEnd;
   const ratioRef = useRef(clamped);
   ratioRef.current = clamped;
   const stepRef = useRef(step);
@@ -78,36 +104,145 @@ function ChannelSlider({
     onChangeRatioRef.current(Math.max(0, Math.min(1, (pageX - layout.pageLeft) / layout.width)));
   }, []);
 
-  const measureAndApply = useCallback(
-    (pageX: number) => {
-      trackRef.current?.measure((_x, _y, width, _height, pageLeft) => {
-        if (width <= 0) return;
-        const layout = { pageLeft, width };
-        trackLayoutRef.current = layout;
-        applyPageX(pageX, layout);
-      });
+  const finishGesture = useCallback(
+    (gestureGeneration: number, pickerGestureEpoch: number) => {
+      if (
+        !mountedRef.current ||
+        gestureGeneration !== gestureGenerationRef.current ||
+        pickerGestureEpoch !== gestureEpochRef.current ||
+        finishedGestureGenerationRef.current === gestureGeneration
+      ) {
+        return;
+      }
+
+      finishedGestureGenerationRef.current = gestureGeneration;
+      onDragEndRef.current(pickerGestureEpoch);
     },
-    [applyPageX],
+    [gestureEpochRef],
   );
 
-  const setFromPageX = useCallback(
-    (pageX: number) => {
-      const layout = trackLayoutRef.current;
-      if (layout) applyPageX(pageX, layout);
-      else measureAndApply(pageX);
+  const applyCoordinate = useCallback(
+    (coordinate: PendingSliderCoordinate, layout: { pageLeft: number; width: number }) => {
+      if (
+        !mountedRef.current ||
+        coordinate.gestureGeneration !== gestureGenerationRef.current ||
+        coordinate.pickerGestureEpoch !== gestureEpochRef.current ||
+        finishedGestureGenerationRef.current === coordinate.gestureGeneration
+      ) {
+        return;
+      }
+
+      applyPageX(coordinate.pageX, layout);
+      if (coordinate.shouldEndGesture) {
+        finishGesture(coordinate.gestureGeneration, coordinate.pickerGestureEpoch);
+      }
     },
-    [applyPageX, measureAndApply],
+    [applyPageX, finishGesture, gestureEpochRef],
   );
+
+  const measurePendingCoordinate = useCallback(() => {
+    const coordinate = pendingCoordinateRef.current;
+    const track = trackRef.current;
+    if (!mountedRef.current || !coordinate || !track || measurementInFlightRef.current) return;
+
+    const measuredGestureGeneration = coordinate.gestureGeneration;
+    const measuredLayoutGeneration = layoutGenerationRef.current;
+    measurementInFlightRef.current = true;
+    track.measure((_x, _y, width, _height, pageLeft) => {
+      measurementInFlightRef.current = false;
+      if (!mountedRef.current) return;
+
+      if (
+        measuredGestureGeneration !== gestureGenerationRef.current ||
+        measuredLayoutGeneration !== layoutGenerationRef.current
+      ) {
+        measurePendingCoordinateRef.current();
+        return;
+      }
+
+      const latestCoordinate = pendingCoordinateRef.current;
+      if (!latestCoordinate || latestCoordinate.gestureGeneration !== measuredGestureGeneration) {
+        measurePendingCoordinateRef.current();
+        return;
+      }
+
+      pendingCoordinateRef.current = null;
+      if (width <= 0) {
+        if (latestCoordinate.shouldEndGesture) {
+          finishGesture(latestCoordinate.gestureGeneration, latestCoordinate.pickerGestureEpoch);
+        }
+        return;
+      }
+
+      const layout = { pageLeft, width };
+      trackLayoutRef.current = layout;
+      applyCoordinate(latestCoordinate, layout);
+    });
+  }, [applyCoordinate, finishGesture]);
+  measurePendingCoordinateRef.current = measurePendingCoordinate;
+
+  const requestCoordinate = useCallback(
+    (pageX: number, shouldEndGesture: boolean) => {
+      if (!mountedRef.current) return;
+
+      const gestureGeneration = gestureGenerationRef.current;
+      const pickerGestureEpoch = activePickerGestureEpochRef.current;
+      if (pickerGestureEpoch !== gestureEpochRef.current) return;
+      if (finishedGestureGenerationRef.current === gestureGeneration) return;
+
+      const pendingCoordinate = pendingCoordinateRef.current;
+      const coordinate = {
+        gestureGeneration,
+        pickerGestureEpoch,
+        pageX,
+        shouldEndGesture:
+          shouldEndGesture ||
+          (pendingCoordinate?.gestureGeneration === gestureGeneration && pendingCoordinate.shouldEndGesture),
+      };
+      const layout = trackLayoutRef.current;
+      if (layout) {
+        pendingCoordinateRef.current = null;
+        applyCoordinate(coordinate, layout);
+        return;
+      }
+
+      pendingCoordinateRef.current = coordinate;
+      measurePendingCoordinateRef.current();
+    },
+    [applyCoordinate, gestureEpochRef],
+  );
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      gestureGenerationRef.current += 1;
+      activePickerGestureEpochRef.current = -1;
+      measurementInFlightRef.current = false;
+      pendingCoordinateRef.current = null;
+    };
+  }, []);
 
   const panResponder = useMemo(
     () =>
       PanResponder.create({
         onStartShouldSetPanResponder: () => true,
         onMoveShouldSetPanResponder: () => true,
-        onPanResponderGrant: (event: GestureResponderEvent) => measureAndApply(event.nativeEvent.pageX),
-        onPanResponderMove: (_event, gestureState) => setFromPageX(gestureState.moveX),
+        onPanResponderGrant: (event: GestureResponderEvent) => {
+          gestureGenerationRef.current += 1;
+          pendingCoordinateRef.current = null;
+          activePickerGestureEpochRef.current = onDragStartRef.current();
+          requestCoordinate(event.nativeEvent.pageX, false);
+        },
+        onPanResponderMove: (_event, gestureState) => requestCoordinate(gestureState.moveX, false),
+        onPanResponderRelease: (event: GestureResponderEvent) => {
+          requestCoordinate(event.nativeEvent.pageX, true);
+        },
+        onPanResponderTerminate: (event: GestureResponderEvent) => {
+          requestCoordinate(event.nativeEvent.pageX, true);
+        },
       }),
-    [measureAndApply, setFromPageX],
+    [requestCoordinate],
   );
 
   const handleAccessibilityAction = useCallback((event: { nativeEvent: { actionName: string } }) => {
@@ -138,7 +273,9 @@ function ChannelSlider({
         <View
           ref={trackRef}
           onLayout={() => {
+            layoutGenerationRef.current += 1;
             trackLayoutRef.current = null;
+            measurePendingCoordinateRef.current();
           }}
           style={styles.trackContainer}
         >
@@ -173,6 +310,83 @@ function ChannelSlider({
       </View>
     </View>
   );
+});
+
+function useGradientSnapshot(initialOkhsl: Okhsl) {
+  const [gradientOkhsl, setGradientOkhsl] = useState(initialOkhsl);
+  const latestOkhslRef = useRef(initialOkhsl);
+  const gestureEpochRef = useRef(0);
+  const dragActiveRef = useRef(false);
+  const lastGradientUpdateAtRef = useRef(0);
+  const pendingGradientUpdateRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelPendingGradientUpdate = useCallback(() => {
+    if (pendingGradientUpdateRef.current === null) return;
+    clearTimeout(pendingGradientUpdateRef.current);
+    pendingGradientUpdateRef.current = null;
+  }, []);
+
+  const applyGradientSnapshot = useCallback(
+    (nextOkhsl: Okhsl) => {
+      cancelPendingGradientUpdate();
+      lastGradientUpdateAtRef.current = Date.now();
+      setGradientOkhsl(nextOkhsl);
+    },
+    [cancelPendingGradientUpdate],
+  );
+
+  const updateGradientSnapshot = useCallback(
+    (nextOkhsl: Okhsl) => {
+      latestOkhslRef.current = nextOkhsl;
+      if (!dragActiveRef.current) {
+        applyGradientSnapshot(nextOkhsl);
+        return;
+      }
+
+      const elapsedMs = Math.max(0, Date.now() - lastGradientUpdateAtRef.current);
+      if (elapsedMs >= GRADIENT_UPDATE_INTERVAL_MS) {
+        applyGradientSnapshot(nextOkhsl);
+        return;
+      }
+
+      if (pendingGradientUpdateRef.current !== null) return;
+      pendingGradientUpdateRef.current = setTimeout(() => {
+        pendingGradientUpdateRef.current = null;
+        lastGradientUpdateAtRef.current = Date.now();
+        setGradientOkhsl(latestOkhslRef.current);
+      }, GRADIENT_UPDATE_INTERVAL_MS - elapsedMs);
+    },
+    [applyGradientSnapshot],
+  );
+
+  const beginGradientDrag = useCallback(() => {
+    gestureEpochRef.current += 1;
+    cancelPendingGradientUpdate();
+    dragActiveRef.current = true;
+    lastGradientUpdateAtRef.current = Date.now();
+    setGradientOkhsl(latestOkhslRef.current);
+    return gestureEpochRef.current;
+  }, [cancelPendingGradientUpdate]);
+
+  const finishGradientDrag = useCallback(
+    (gestureEpoch: number) => {
+      if (gestureEpoch !== gestureEpochRef.current) return;
+      dragActiveRef.current = false;
+      applyGradientSnapshot(latestOkhslRef.current);
+    },
+    [applyGradientSnapshot],
+  );
+
+  useEffect(
+    () => () => {
+      gestureEpochRef.current += 1;
+      dragActiveRef.current = false;
+      cancelPendingGradientUpdate();
+    },
+    [cancelPendingGradientUpdate],
+  );
+
+  return { gradientOkhsl, gestureEpochRef, updateGradientSnapshot, beginGradientDrag, finishGradientDrag };
 }
 
 type OkhslColorPickerProps = {
@@ -197,32 +411,57 @@ export function OkhslColorPicker({ value, onChange }: OkhslColorPickerProps) {
   const { t } = useTranslation('common');
   const { systemColors } = useTheme();
   const [okhsl, setOkhsl] = useState<Okhsl>(() => hexToOkhsl(value) ?? DEFAULT_OKHSL);
+  const latestOkhslRef = useRef(okhsl);
+  const { gradientOkhsl, gestureEpochRef, updateGradientSnapshot, beginGradientDrag, finishGradientDrag } =
+    useGradientSnapshot(okhsl);
   // Show the caller's literal hex when valid (the OKHSL round-trip can be ±1 off).
   const [hexDraft, setHexDraft] = useState<string>(
     () => normalizeHexColor(value) ?? okhslToHex(hexToOkhsl(value) ?? DEFAULT_OKHSL),
   );
 
+  const applyOkhsl = useCallback(
+    (next: Okhsl) => {
+      latestOkhslRef.current = next;
+      setOkhsl(next);
+      updateGradientSnapshot(next);
+    },
+    [updateGradientSnapshot],
+  );
+
   const commit = useCallback(
     (next: Okhsl) => {
-      setOkhsl(next);
+      applyOkhsl(next);
       const hex = okhslToHex(next);
       setHexDraft(hex);
       onChange(hex);
     },
-    [onChange],
+    [applyOkhsl, onChange],
   );
 
   const lightnessStops = useMemo(
-    () => sampleGradient(SL_STOPS, (t) => okhslToHex({ h: okhsl.h, s: okhsl.s, l: t })),
-    [okhsl.h, okhsl.s],
+    () => sampleGradient(SL_STOPS, (t) => okhslToHex({ h: gradientOkhsl.h, s: gradientOkhsl.s, l: t })),
+    [gradientOkhsl.h, gradientOkhsl.s],
   );
   const saturationStops = useMemo(
-    () => sampleGradient(SL_STOPS, (t) => okhslToHex({ h: okhsl.h, s: t, l: okhsl.l })),
-    [okhsl.h, okhsl.l],
+    () => sampleGradient(SL_STOPS, (t) => okhslToHex({ h: gradientOkhsl.h, s: t, l: gradientOkhsl.l })),
+    [gradientOkhsl.h, gradientOkhsl.l],
   );
   const hueStops = useMemo(
-    () => sampleGradient(HUE_STOPS, (t) => okhslToHex({ h: t * 360, s: okhsl.s, l: okhsl.l })),
-    [okhsl.s, okhsl.l],
+    () => sampleGradient(HUE_STOPS, (t) => okhslToHex({ h: t * 360, s: gradientOkhsl.s, l: gradientOkhsl.l })),
+    [gradientOkhsl.s, gradientOkhsl.l],
+  );
+
+  const handleLightnessChange = useCallback(
+    (ratio: number) => commit({ ...latestOkhslRef.current, l: ratio }),
+    [commit],
+  );
+  const handleSaturationChange = useCallback(
+    (ratio: number) => commit({ ...latestOkhslRef.current, s: ratio }),
+    [commit],
+  );
+  const handleHueChange = useCallback(
+    (ratio: number) => commit({ ...latestOkhslRef.current, h: ratio * 360 }),
+    [commit],
   );
 
   const handleHexChange = useCallback(
@@ -232,12 +471,12 @@ export function OkhslColorPicker({ value, onChange }: OkhslColorPickerProps) {
       if (normalized) {
         const parsed = hexToOkhsl(normalized);
         if (parsed) {
-          setOkhsl(parsed);
+          applyOkhsl(parsed);
           onChange(normalized);
         }
       }
     },
-    [onChange],
+    [applyOkhsl, onChange],
   );
 
   const hexValid = normalizeHexColor(hexDraft) !== null;
@@ -260,7 +499,10 @@ export function OkhslColorPicker({ value, onChange }: OkhslColorPickerProps) {
         ratio={okhsl.l}
         stops={lightnessStops}
         step={0.05}
-        onChangeRatio={(ratio) => commit({ ...okhsl, l: ratio })}
+        onChangeRatio={handleLightnessChange}
+        gestureEpochRef={gestureEpochRef}
+        onDragStart={beginGradientDrag}
+        onDragEnd={finishGradientDrag}
       />
       <ChannelSlider
         label={t('mobile.more.accessibility.sliders.saturation')}
@@ -269,7 +511,10 @@ export function OkhslColorPicker({ value, onChange }: OkhslColorPickerProps) {
         ratio={okhsl.s}
         stops={saturationStops}
         step={0.05}
-        onChangeRatio={(ratio) => commit({ ...okhsl, s: ratio })}
+        onChangeRatio={handleSaturationChange}
+        gestureEpochRef={gestureEpochRef}
+        onDragStart={beginGradientDrag}
+        onDragEnd={finishGradientDrag}
       />
       <ChannelSlider
         label={t('mobile.more.accessibility.sliders.hue')}
@@ -278,7 +523,10 @@ export function OkhslColorPicker({ value, onChange }: OkhslColorPickerProps) {
         ratio={okhsl.h / 360}
         stops={hueStops}
         step={1 / 36}
-        onChangeRatio={(ratio) => commit({ ...okhsl, h: ratio * 360 })}
+        onChangeRatio={handleHueChange}
+        gestureEpochRef={gestureEpochRef}
+        onDragStart={beginGradientDrag}
+        onDragEnd={finishGradientDrag}
       />
       <View style={styles.hexRow}>
         <Text variant="subheadline" color={systemColors.secondaryLabel}>

--- a/packages/mobile/src/components/settings/__tests__/OkhslColorPicker.test.tsx
+++ b/packages/mobile/src/components/settings/__tests__/OkhslColorPicker.test.tsx
@@ -490,6 +490,44 @@ describe('OkhslColorPicker gradient updates', () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  it('finishes a deferred release without applying a coordinate when the track measures zero width', () => {
+    responderHarness.deferMeasurements = true;
+    const onChange = vi.fn();
+    const { container } = render(<OkhslColorPicker value="#00ff00" onChange={onChange} />);
+
+    act(() => {
+      grant(LIGHTNESS_LABEL, 30);
+      move(LIGHTNESS_LABEL, 180);
+      release(LIGHTNESS_LABEL, 270);
+    });
+
+    expect(responderHarness.measurementCallCount).toBe(1);
+    expect(responderHarness.measurementCallbacks).toHaveLength(1);
+
+    act(() => {
+      resolveNextMeasurement(0);
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(responderHarness.measurementCallCount).toBe(1);
+    expect(responderHarness.measurementCallbacks).toHaveLength(0);
+    expect(vi.getTimerCount()).toBe(0);
+
+    act(() => {
+      fireTrackLayouts();
+    });
+
+    expect(responderHarness.measurementCallCount).toBe(1);
+    expect(responderHarness.measurementCallbacks).toHaveLength(0);
+
+    // The zero-width release still ends the picker-wide drag, so a later
+    // accessibility update applies its gradient immediately instead of being
+    // left behind the drag throttle.
+    fireEvent.doubleClick(slider(container, SATURATION_LABEL));
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it('installs measurement before a queued mount-time gesture reaches passive effects', () => {
     responderHarness.mountGesture = {
       label: LIGHTNESS_LABEL,

--- a/packages/mobile/src/components/settings/__tests__/OkhslColorPicker.test.tsx
+++ b/packages/mobile/src/components/settings/__tests__/OkhslColorPicker.test.tsx
@@ -199,9 +199,6 @@ const EXPECTED_INITIAL_GRADIENT_CONVERSIONS = EXPECTED_GRADIENT_STOP_COUNTS.redu
   0,
 );
 const NON_LIGHTNESS_GRADIENT_CONVERSIONS = EXPECTED_GRADIENT_STOP_COUNTS[1] + EXPECTED_GRADIENT_STOP_COUNTS[2];
-// Mirrors the component's explicit visual contract: at most one expensive
-// gradient rebuild per 30 fps interval while thumb/value updates stay exact.
-const GRADIENT_UPDATE_INTERVAL_MS = 1000 / 30;
 
 function responderEvent(pageX: number): ResponderEvent {
   return { nativeEvent: { pageX } };
@@ -293,22 +290,37 @@ describe('OkhslColorPicker gradient updates', () => {
     expect(responderHarness.sliderRenderCounts[HUE_LABEL]).toBe(1);
     expect(vi.getTimerCount()).toBe(1);
 
-    // Fake timers schedule the fractional delay on the preceding whole
-    // millisecond, so stay one millisecond below that boundary first.
-    const wholeMillisecondsBeforeGradientUpdate = Math.floor(GRADIENT_UPDATE_INTERVAL_MS) - 1;
     act(() => {
-      vi.advanceTimersByTime(wholeMillisecondsBeforeGradientUpdate);
-    });
-    expect(okhslHarness.conversionCount).toBe(EXPECTED_INITIAL_GRADIENT_CONVERSIONS + 21);
-
-    act(() => {
-      vi.advanceTimersByTime(Math.ceil(GRADIENT_UPDATE_INTERVAL_MS) - wholeMillisecondsBeforeGradientUpdate);
+      vi.advanceTimersToNextTimer();
     });
     expect(okhslHarness.conversionCount).toBe(
       EXPECTED_INITIAL_GRADIENT_CONVERSIONS + 21 + NON_LIGHTNESS_GRADIENT_CONVERSIONS,
     );
     expect(responderHarness.sliderRenderCounts[SATURATION_LABEL]).toBe(2);
     expect(responderHarness.sliderRenderCounts[HUE_LABEL]).toBe(2);
+
+    // Keep moving after the first interval to prove each later interval also
+    // coalesces its own burst instead of degrading into per-move rebuilds.
+    act(() => {
+      move(LIGHTNESS_LABEL, 210);
+      move(LIGHTNESS_LABEL, 240);
+    });
+    expect(onChange).toHaveBeenCalledTimes(23);
+    expect(okhslHarness.conversionCount).toBe(
+      EXPECTED_INITIAL_GRADIENT_CONVERSIONS + 23 + NON_LIGHTNESS_GRADIENT_CONVERSIONS,
+    );
+    expect(responderHarness.sliderRenderCounts[SATURATION_LABEL]).toBe(2);
+    expect(responderHarness.sliderRenderCounts[HUE_LABEL]).toBe(2);
+    expect(vi.getTimerCount()).toBe(1);
+
+    act(() => {
+      vi.advanceTimersToNextTimer();
+    });
+    expect(okhslHarness.conversionCount).toBe(
+      EXPECTED_INITIAL_GRADIENT_CONVERSIONS + 23 + NON_LIGHTNESS_GRADIENT_CONVERSIONS * 2,
+    );
+    expect(responderHarness.sliderRenderCounts[SATURATION_LABEL]).toBe(3);
+    expect(responderHarness.sliderRenderCounts[HUE_LABEL]).toBe(3);
     expect(Object.keys(responderHarness.configsByLabel)).toHaveLength(3);
   });
 

--- a/packages/mobile/src/components/settings/__tests__/OkhslColorPicker.test.tsx
+++ b/packages/mobile/src/components/settings/__tests__/OkhslColorPicker.test.tsx
@@ -18,6 +18,7 @@ const responderHarness = vi.hoisted(() => ({
   deferMeasurements: false,
   measurementCallbacks: [] as MeasureCallback[],
   measurementCallCount: 0,
+  trackLayoutCallbacks: new Set<() => void>(),
   sliderRenderCounts: {} as Record<string, number>,
 }));
 const okhslHarness = vi.hoisted(() => ({ conversionCount: 0 }));
@@ -31,6 +32,7 @@ type ViewMockProps = {
   accessibilityValue?: { text?: string };
   children?: ReactNode;
   onAccessibilityAction?: (event: { nativeEvent: { actionName: string } }) => void;
+  onLayout?: () => void;
   onPanResponderGrant?: ResponderConfig['onPanResponderGrant'];
   onPanResponderMove?: ResponderConfig['onPanResponderMove'];
   onPanResponderRelease?: ResponderConfig['onPanResponderRelease'];
@@ -45,6 +47,7 @@ vi.mock('react-native', () => {
       accessibilityValue,
       children,
       onAccessibilityAction,
+      onLayout,
       onPanResponderGrant,
       onPanResponderMove,
       onPanResponderRelease,
@@ -52,6 +55,7 @@ vi.mock('react-native', () => {
     },
     ref,
   ) {
+    if (onLayout) responderHarness.trackLayoutCallbacks.add(onLayout);
     useImperativeHandle(
       ref,
       () => ({
@@ -206,6 +210,10 @@ function resolveNextMeasurement(width = 300, pageLeft = 0) {
   callback(0, 0, width, 14, pageLeft, 0);
 }
 
+function fireTrackLayouts() {
+  for (const onLayout of responderHarness.trackLayoutCallbacks) onLayout();
+}
+
 function grant(label: string, pageX: number) {
   responder(label).onPanResponderGrant?.(responderEvent(pageX));
 }
@@ -243,6 +251,7 @@ describe('OkhslColorPicker gradient updates', () => {
     responderHarness.deferMeasurements = false;
     responderHarness.measurementCallbacks.length = 0;
     responderHarness.measurementCallCount = 0;
+    responderHarness.trackLayoutCallbacks.clear();
     responderHarness.sliderRenderCounts = {};
     okhslHarness.conversionCount = 0;
   });
@@ -253,7 +262,7 @@ describe('OkhslColorPicker gradient updates', () => {
     vi.useRealTimers();
   });
 
-  it('coalesces rapid drag moves into one gradient rebuild per ~33 ms interval', () => {
+  it('coalesces rapid drag moves into one gradient rebuild per 30 fps interval', () => {
     const onChange = vi.fn();
     render(<OkhslColorPicker value="#00ff00" onChange={onChange} />);
 
@@ -404,6 +413,41 @@ describe('OkhslColorPicker gradient updates', () => {
     expect(onChange).toHaveBeenCalledTimes(1);
     const hexInput = container.querySelector<HTMLInputElement>(`[aria-label="${HEX_LABEL}"]`);
     expect(hexInput?.value).toBe(onChange.mock.lastCall?.[0]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('re-measures the latest coordinate when track layout changes during a drag', () => {
+    responderHarness.deferMeasurements = true;
+    const onChange = vi.fn();
+    const { container } = render(<OkhslColorPicker value="#00ff00" onChange={onChange} />);
+
+    act(() => {
+      grant(LIGHTNESS_LABEL, 30);
+      move(LIGHTNESS_LABEL, 180);
+      release(LIGHTNESS_LABEL, 270);
+      fireTrackLayouts();
+    });
+
+    expect(responderHarness.measurementCallCount).toBe(1);
+    expect(responderHarness.measurementCallbacks).toHaveLength(1);
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => {
+      resolveNextMeasurement();
+    });
+
+    // The result measured against the stale layout is discarded and the
+    // coalesced final coordinate is measured once more against the new layout.
+    expect(onChange).not.toHaveBeenCalled();
+    expect(responderHarness.measurementCallCount).toBe(2);
+    expect(responderHarness.measurementCallbacks).toHaveLength(1);
+
+    act(() => {
+      resolveNextMeasurement(300, 0);
+    });
+
+    expect(slider(container, LIGHTNESS_LABEL).dataset.accessibilityValue).toBe('90%');
+    expect(onChange).toHaveBeenCalledTimes(1);
     expect(vi.getTimerCount()).toBe(0);
   });
 

--- a/packages/mobile/src/components/settings/__tests__/OkhslColorPicker.test.tsx
+++ b/packages/mobile/src/components/settings/__tests__/OkhslColorPicker.test.tsx
@@ -18,6 +18,7 @@ const responderHarness = vi.hoisted(() => ({
   deferMeasurements: false,
   measurementCallbacks: [] as MeasureCallback[],
   measurementCallCount: 0,
+  mountGesture: null as { label: string; grantPageX: number; releasePageX: number } | null,
   trackLayoutCallbacks: new Set<() => void>(),
   sliderRenderCounts: {} as Record<string, number>,
 }));
@@ -62,6 +63,13 @@ vi.mock('react-native', () => {
         responderHarness.trackLayoutCallbacks.delete(onLayout);
       };
     }, [onLayout]);
+    useEffect(() => {
+      const mountGesture = responderHarness.mountGesture;
+      if (mountGesture === null || !accessible || accessibilityLabel !== mountGesture.label) return;
+      responderHarness.mountGesture = null;
+      onPanResponderGrant?.({ nativeEvent: { pageX: mountGesture.grantPageX } });
+      onPanResponderRelease?.({ nativeEvent: { pageX: mountGesture.releasePageX } });
+    }, [accessibilityLabel, accessible, onPanResponderGrant, onPanResponderRelease]);
     useImperativeHandle(
       ref,
       () => ({
@@ -257,6 +265,7 @@ describe('OkhslColorPicker gradient updates', () => {
     responderHarness.deferMeasurements = false;
     responderHarness.measurementCallbacks.length = 0;
     responderHarness.measurementCallCount = 0;
+    responderHarness.mountGesture = null;
     responderHarness.trackLayoutCallbacks.clear();
     responderHarness.sliderRenderCounts = {};
     okhslHarness.conversionCount = 0;
@@ -478,6 +487,22 @@ describe('OkhslColorPicker gradient updates', () => {
     expect(onChange).toHaveBeenCalledTimes(1);
     const hexInput = container.querySelector<HTMLInputElement>(`[aria-label="${HEX_LABEL}"]`);
     expect(hexInput?.value).toBe(onChange.mock.lastCall?.[0]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('installs measurement before a queued mount-time gesture reaches passive effects', () => {
+    responderHarness.mountGesture = {
+      label: LIGHTNESS_LABEL,
+      grantPageX: 30,
+      releasePageX: 270,
+    };
+    const onChange = vi.fn();
+    const { container } = render(<OkhslColorPicker value="#00ff00" onChange={onChange} />);
+
+    expect(responderHarness.mountGesture).toBeNull();
+    expect(responderHarness.measurementCallCount).toBe(1);
+    expect(slider(container, LIGHTNESS_LABEL).dataset.accessibilityValue).toBe('90%');
+    expect(onChange).toHaveBeenCalledTimes(2);
     expect(vi.getTimerCount()).toBe(0);
   });
 

--- a/packages/mobile/src/components/settings/__tests__/OkhslColorPicker.test.tsx
+++ b/packages/mobile/src/components/settings/__tests__/OkhslColorPicker.test.tsx
@@ -1,0 +1,486 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
+import { createElement, forwardRef, useImperativeHandle, type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Okhsl } from '../../../lib/okhsl';
+
+type ResponderEvent = { nativeEvent: { pageX: number } };
+type ResponderConfig = {
+  onPanResponderGrant?: (event: ResponderEvent) => void;
+  onPanResponderMove?: (event: ResponderEvent, gestureState: { moveX: number }) => void;
+  onPanResponderRelease?: (event: ResponderEvent) => void;
+  onPanResponderTerminate?: (event: ResponderEvent) => void;
+};
+type MeasureCallback = (x: number, y: number, width: number, height: number, pageX: number, pageY: number) => void;
+
+const responderHarness = vi.hoisted(() => ({
+  configs: [] as ResponderConfig[],
+  deferMeasurements: false,
+  measurementCallbacks: [] as MeasureCallback[],
+  measurementCallCount: 0,
+  sliderRenderCounts: {} as Record<string, number>,
+}));
+const okhslHarness = vi.hoisted(() => ({ conversionCount: 0 }));
+
+type ViewHandle = {
+  measure: (callback: MeasureCallback) => void;
+};
+type ViewMockProps = {
+  accessible?: boolean;
+  accessibilityLabel?: string;
+  accessibilityValue?: { text?: string };
+  children?: ReactNode;
+  onAccessibilityAction?: (event: { nativeEvent: { actionName: string } }) => void;
+};
+
+vi.mock('react-native', () => {
+  const View = forwardRef<ViewHandle, ViewMockProps>(function View(
+    { accessible, accessibilityLabel, accessibilityValue, children, onAccessibilityAction },
+    ref,
+  ) {
+    useImperativeHandle(
+      ref,
+      () => ({
+        measure: (callback) => {
+          responderHarness.measurementCallCount += 1;
+          if (responderHarness.deferMeasurements) {
+            responderHarness.measurementCallbacks.push(callback);
+          } else {
+            callback(0, 0, 300, 14, 0, 0);
+          }
+        },
+      }),
+      [],
+    );
+    if (accessible && accessibilityLabel) {
+      responderHarness.sliderRenderCounts[accessibilityLabel] =
+        (responderHarness.sliderRenderCounts[accessibilityLabel] ?? 0) + 1;
+    }
+    return createElement(
+      'div',
+      {
+        'data-accessibility-label': accessibilityLabel,
+        'data-accessibility-value': accessibilityValue?.text,
+        onDoubleClick: onAccessibilityAction
+          ? () => onAccessibilityAction({ nativeEvent: { actionName: 'increment' } })
+          : undefined,
+      },
+      children,
+    );
+  });
+
+  return {
+    PanResponder: {
+      create: (config: ResponderConfig) => {
+        responderHarness.configs.push(config);
+        return { panHandlers: {} };
+      },
+    },
+    StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+    View,
+  };
+});
+
+vi.mock('@expo/ui/community/bottom-sheet', () => ({
+  BottomSheetTextInput: ({
+    accessibilityLabel,
+    onChangeText,
+    value,
+  }: {
+    accessibilityLabel?: string;
+    onChangeText?: (nextValue: string) => void;
+    value?: string;
+  }) =>
+    createElement('input', {
+      'aria-label': accessibilityLabel,
+      onChange: (event: { target: { value: string } }) => onChangeText?.(event.target.value),
+      value,
+    }),
+}));
+
+type SvgMockProps = {
+  children?: ReactNode;
+  id?: string;
+  offset?: number;
+  stopColor?: string;
+};
+
+vi.mock('react-native-svg', () => ({
+  default: ({ children }: SvgMockProps) => createElement('svg', null, children),
+  Defs: ({ children }: SvgMockProps) => createElement('defs', null, children),
+  LinearGradient: ({ children, id }: SvgMockProps) => createElement('g', { 'data-gradient': id ?? '' }, children),
+  Rect: () => createElement('rect'),
+  Stop: ({ offset, stopColor }: SvgMockProps) =>
+    createElement('i', {
+      'data-color': stopColor ?? '',
+      'data-offset': String(offset ?? ''),
+      'data-stop': 'true',
+    }),
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: {
+      background: '#ffffff',
+      fill: '#eeeeee',
+      label: '#111111',
+      secondaryLabel: '#666666',
+      separator: '#cccccc',
+    },
+  }),
+}));
+
+vi.mock('../../../theme/ios-colors', () => ({
+  iosSystemColors: { systemRed: '#ff3b30' },
+}));
+
+vi.mock('../../../theme/tokens', () => ({
+  borderRadius: { md: 8 },
+  spacing: { 2: 8, 3: 12, 4: 16 },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../../lib/okhsl', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/okhsl')>();
+  return {
+    ...actual,
+    okhslToHex: (okhsl: Okhsl) => {
+      okhslHarness.conversionCount += 1;
+      return actual.okhslToHex(okhsl);
+    },
+  };
+});
+
+import { OkhslColorPicker } from '../OkhslColorPicker';
+
+const LIGHTNESS_LABEL = 'mobile.more.accessibility.sliders.lightness';
+const SATURATION_LABEL = 'mobile.more.accessibility.sliders.saturation';
+const HUE_LABEL = 'mobile.more.accessibility.sliders.hue';
+const HEX_LABEL = 'mobile.more.accessibility.hexLabel';
+
+function responderEvent(pageX: number): ResponderEvent {
+  return { nativeEvent: { pageX } };
+}
+
+function responder(index: number): ResponderConfig {
+  const config = responderHarness.configs[index];
+  if (!config) throw new Error(`Missing PanResponder config at index ${index}`);
+  return config;
+}
+
+function resolveNextMeasurement(width = 300, pageLeft = 0) {
+  const callback = responderHarness.measurementCallbacks.shift();
+  if (!callback) throw new Error('Missing deferred measurement callback');
+  callback(0, 0, width, 14, pageLeft, 0);
+}
+
+function grant(index: number, pageX: number) {
+  responder(index).onPanResponderGrant?.(responderEvent(pageX));
+}
+
+function move(index: number, moveX: number) {
+  responder(index).onPanResponderMove?.(responderEvent(moveX), { moveX });
+}
+
+function release(index: number, pageX: number) {
+  responder(index).onPanResponderRelease?.(responderEvent(pageX));
+}
+
+function terminate(index: number, pageX: number) {
+  responder(index).onPanResponderTerminate?.(responderEvent(pageX));
+}
+
+function slider(container: HTMLElement, label: string): HTMLElement {
+  const element = container.querySelector(`[data-accessibility-label="${label}"]`);
+  if (!(element instanceof HTMLElement)) throw new Error(`Missing slider ${label}`);
+  return element;
+}
+
+function gradients(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>('[data-gradient]'));
+}
+
+function gradientColors(gradient: HTMLElement): string[] {
+  return Array.from(gradient.querySelectorAll<HTMLElement>('[data-stop]'), (stop) => stop.dataset.color ?? '');
+}
+
+describe('OkhslColorPicker gradient updates', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    responderHarness.configs.length = 0;
+    responderHarness.deferMeasurements = false;
+    responderHarness.measurementCallbacks.length = 0;
+    responderHarness.measurementCallCount = 0;
+    responderHarness.sliderRenderCounts = {};
+    okhslHarness.conversionCount = 0;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('coalesces rapid drag moves into one gradient rebuild per ~33 ms interval', () => {
+    const onChange = vi.fn();
+    render(<OkhslColorPicker value="#00ff00" onChange={onChange} />);
+
+    expect(okhslHarness.conversionCount).toBe(37);
+    expect(responderHarness.configs).toHaveLength(3);
+
+    act(() => {
+      grant(0, 30);
+      for (let moveIndex = 0; moveIndex < 20; moveIndex += 1) {
+        move(0, 60 + moveIndex * 6);
+      }
+    });
+
+    // Every move still publishes one precise colour, but none of the 25
+    // dependent gradient stops rebuild before the bounded timer fires.
+    expect(onChange).toHaveBeenCalledTimes(21);
+    expect(okhslHarness.conversionCount).toBe(37 + 21);
+    expect(responderHarness.sliderRenderCounts[SATURATION_LABEL]).toBe(1);
+    expect(responderHarness.sliderRenderCounts[HUE_LABEL]).toBe(1);
+    expect(vi.getTimerCount()).toBe(1);
+
+    act(() => {
+      vi.advanceTimersByTime(32);
+    });
+    expect(okhslHarness.conversionCount).toBe(37 + 21);
+
+    act(() => {
+      vi.advanceTimersByTime(2);
+    });
+    expect(okhslHarness.conversionCount).toBe(37 + 21 + 25);
+    expect(responderHarness.sliderRenderCounts[SATURATION_LABEL]).toBe(2);
+    expect(responderHarness.sliderRenderCounts[HUE_LABEL]).toBe(2);
+    expect(responderHarness.configs).toHaveLength(3);
+  });
+
+  it('flushes the exact final gradient on release and leaves no stale trailing update', () => {
+    const onChange = vi.fn();
+    const { container } = render(<OkhslColorPicker value="#00ff00" onChange={onChange} />);
+    const initialGradientColors = gradients(container).map(gradientColors);
+
+    act(() => {
+      grant(0, 60);
+      move(0, 210);
+      vi.advanceTimersByTime(10);
+      move(0, 240);
+      release(0, 270);
+    });
+
+    expect(slider(container, LIGHTNESS_LABEL).dataset.accessibilityValue).toBe('90%');
+    const hexInput = container.querySelector<HTMLInputElement>(`[aria-label="${HEX_LABEL}"]`);
+    expect(hexInput?.value).toBe(onChange.mock.lastCall?.[0]);
+    expect(vi.getTimerCount()).toBe(0);
+
+    const releasedGradients = gradients(container);
+    expect(releasedGradients.map((gradient) => gradient.querySelectorAll('[data-stop]').length)).toEqual([12, 12, 13]);
+    for (const gradient of releasedGradients) {
+      const stops = gradient.querySelectorAll<HTMLElement>('[data-stop]');
+      expect(stops[0]?.dataset.offset).toBe('0');
+      expect(stops[stops.length - 1]?.dataset.offset).toBe('1');
+      expect(Array.from(stops).every((stop) => /^#[0-9a-f]{6}$/i.test(stop.dataset.color ?? ''))).toBe(true);
+    }
+
+    const releasedGradientColors = releasedGradients.map(gradientColors);
+    expect(releasedGradientColors[0]).toEqual(initialGradientColors[0]);
+    expect(releasedGradientColors[1]).not.toEqual(initialGradientColors[1]);
+    expect(releasedGradientColors[2]).not.toEqual(initialGradientColors[2]);
+    const conversionsAfterRelease = okhslHarness.conversionCount;
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(okhslHarness.conversionCount).toBe(conversionsAfterRelease);
+    expect(gradients(container).map(gradientColors)).toEqual(releasedGradientColors);
+  });
+
+  it('flushes termination and applies non-drag accessibility updates immediately', () => {
+    const onChange = vi.fn();
+    const { container } = render(<OkhslColorPicker value="#00ff00" onChange={onChange} />);
+
+    act(() => {
+      grant(2, 30);
+      move(2, 150);
+      vi.advanceTimersByTime(10);
+      terminate(2, 225);
+    });
+
+    expect(slider(container, HUE_LABEL).dataset.accessibilityValue).toBe('270°');
+    expect(vi.getTimerCount()).toBe(0);
+    const conversionsAfterTerminate = okhslHarness.conversionCount;
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(okhslHarness.conversionCount).toBe(conversionsAfterTerminate);
+
+    fireEvent.doubleClick(slider(container, SATURATION_LABEL));
+    expect(vi.getTimerCount()).toBe(0);
+    expect(okhslHarness.conversionCount).toBeGreaterThan(conversionsAfterTerminate);
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('cancels a pending gradient update when the picker unmounts', () => {
+    const { unmount } = render(<OkhslColorPicker value="#00ff00" onChange={vi.fn()} />);
+
+    act(() => {
+      grant(1, 30);
+      move(1, 210);
+    });
+    expect(vi.getTimerCount()).toBe(1);
+    const conversionsBeforeUnmount = okhslHarness.conversionCount;
+
+    unmount();
+    expect(vi.getTimerCount()).toBe(0);
+    vi.advanceTimersByTime(1000);
+    expect(okhslHarness.conversionCount).toBe(conversionsBeforeUnmount);
+  });
+
+  it('coalesces grant, moves, and release behind one deferred measurement', () => {
+    responderHarness.deferMeasurements = true;
+    const onChange = vi.fn();
+    const { container } = render(<OkhslColorPicker value="#00ff00" onChange={onChange} />);
+    const conversionsBeforeDrag = okhslHarness.conversionCount;
+
+    act(() => {
+      grant(0, 30);
+      move(0, 120);
+      move(0, 180);
+      release(0, 270);
+    });
+
+    expect(responderHarness.measurementCallCount).toBe(1);
+    expect(responderHarness.measurementCallbacks).toHaveLength(1);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(okhslHarness.conversionCount).toBe(conversionsBeforeDrag);
+    expect(vi.getTimerCount()).toBe(0);
+
+    act(() => {
+      resolveNextMeasurement();
+    });
+
+    expect(responderHarness.measurementCallCount).toBe(1);
+    expect(responderHarness.measurementCallbacks).toHaveLength(0);
+    expect(slider(container, LIGHTNESS_LABEL).dataset.accessibilityValue).toBe('90%');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const hexInput = container.querySelector<HTMLInputElement>(`[aria-label="${HEX_LABEL}"]`);
+    expect(hexInput?.value).toBe(onChange.mock.lastCall?.[0]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('ignores a deferred measurement after unmount', () => {
+    responderHarness.deferMeasurements = true;
+    const onChange = vi.fn();
+    const { unmount } = render(<OkhslColorPicker value="#00ff00" onChange={onChange} />);
+
+    act(() => {
+      grant(0, 30);
+      move(0, 210);
+    });
+    expect(responderHarness.measurementCallCount).toBe(1);
+    expect(responderHarness.measurementCallbacks).toHaveLength(1);
+    const conversionsBeforeUnmount = okhslHarness.conversionCount;
+
+    unmount();
+    act(() => {
+      resolveNextMeasurement();
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(okhslHarness.conversionCount).toBe(conversionsBeforeUnmount);
+    expect(responderHarness.measurementCallCount).toBe(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('ignores an old measurement when a newer drag starts before it resolves', () => {
+    responderHarness.deferMeasurements = true;
+    const onChange = vi.fn();
+    const { container } = render(<OkhslColorPicker value="#00ff00" onChange={onChange} />);
+    const conversionsBeforeDrag = okhslHarness.conversionCount;
+
+    act(() => {
+      grant(0, 30);
+      release(0, 90);
+      grant(0, 150);
+      release(0, 240);
+    });
+    expect(responderHarness.measurementCallCount).toBe(1);
+    expect(responderHarness.measurementCallbacks).toHaveLength(1);
+
+    act(() => {
+      resolveNextMeasurement();
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(okhslHarness.conversionCount).toBe(conversionsBeforeDrag);
+    expect(responderHarness.measurementCallCount).toBe(2);
+    expect(responderHarness.measurementCallbacks).toHaveLength(1);
+
+    act(() => {
+      resolveNextMeasurement();
+    });
+
+    expect(slider(container, LIGHTNESS_LABEL).dataset.accessibilityValue).toBe('80%');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(responderHarness.measurementCallbacks).toHaveLength(0);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('keeps a newer slider drag active when an old deferred release resolves', () => {
+    responderHarness.deferMeasurements = true;
+    const onChange = vi.fn();
+    const { container } = render(<OkhslColorPicker value="#00ff00" onChange={onChange} />);
+    const conversionsBeforeDrag = okhslHarness.conversionCount;
+
+    act(() => {
+      grant(0, 30);
+      release(0, 90);
+      grant(1, 60);
+      // A late termination from the old responder must be as inert as its
+      // deferred release once another channel owns the picker-wide gesture.
+      terminate(0, 120);
+    });
+
+    expect(responderHarness.measurementCallCount).toBe(2);
+    expect(responderHarness.measurementCallbacks).toHaveLength(2);
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => {
+      resolveNextMeasurement();
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(okhslHarness.conversionCount).toBe(conversionsBeforeDrag);
+    expect(responderHarness.measurementCallbacks).toHaveLength(1);
+    expect(vi.getTimerCount()).toBe(0);
+
+    act(() => {
+      resolveNextMeasurement();
+    });
+
+    expect(slider(container, SATURATION_LABEL).dataset.accessibilityValue).toBe('20%');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(okhslHarness.conversionCount).toBe(conversionsBeforeDrag + 1);
+    // The saturation update remains inside the active drag's ~30 fps
+    // throttle. A stale lightness release would flush it immediately.
+    expect(vi.getTimerCount()).toBe(1);
+
+    act(() => {
+      terminate(1, 90);
+    });
+
+    expect(slider(container, SATURATION_LABEL).dataset.accessibilityValue).toBe('30%');
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/mobile/src/components/settings/__tests__/OkhslColorPicker.test.tsx
+++ b/packages/mobile/src/components/settings/__tests__/OkhslColorPicker.test.tsx
@@ -192,7 +192,7 @@ const EXPECTED_INITIAL_GRADIENT_CONVERSIONS = EXPECTED_GRADIENT_STOP_COUNTS.redu
   (total, stopCount) => total + stopCount,
   0,
 );
-const LIGHTNESS_DEPENDENT_GRADIENT_CONVERSIONS = EXPECTED_GRADIENT_STOP_COUNTS[1] + EXPECTED_GRADIENT_STOP_COUNTS[2];
+const NON_LIGHTNESS_GRADIENT_CONVERSIONS = EXPECTED_GRADIENT_STOP_COUNTS[1] + EXPECTED_GRADIENT_STOP_COUNTS[2];
 
 function responderEvent(pageX: number): ResponderEvent {
   return { nativeEvent: { pageX } };
@@ -293,7 +293,7 @@ describe('OkhslColorPicker gradient updates', () => {
       vi.advanceTimersByTime(2);
     });
     expect(okhslHarness.conversionCount).toBe(
-      EXPECTED_INITIAL_GRADIENT_CONVERSIONS + 21 + LIGHTNESS_DEPENDENT_GRADIENT_CONVERSIONS,
+      EXPECTED_INITIAL_GRADIENT_CONVERSIONS + 21 + NON_LIGHTNESS_GRADIENT_CONVERSIONS,
     );
     expect(responderHarness.sliderRenderCounts[SATURATION_LABEL]).toBe(2);
     expect(responderHarness.sliderRenderCounts[HUE_LABEL]).toBe(2);
@@ -366,6 +366,23 @@ describe('OkhslColorPicker gradient updates', () => {
     expect(vi.getTimerCount()).toBe(0);
     expect(okhslHarness.conversionCount).toBeGreaterThan(conversionsAfterTerminate);
     expect(onChange).toHaveBeenCalled();
+  });
+
+  it('publishes the exact hue on a normal grant, move, and release', () => {
+    const onChange = vi.fn();
+    const { container } = render(<OkhslColorPicker value="#00ff00" onChange={onChange} />);
+
+    act(() => {
+      grant(HUE_LABEL, 30);
+      move(HUE_LABEL, 150);
+      release(HUE_LABEL, 225);
+    });
+
+    expect(slider(container, HUE_LABEL).dataset.accessibilityValue).toBe('270°');
+    const hexInput = container.querySelector<HTMLInputElement>(`[aria-label="${HEX_LABEL}"]`);
+    expect(hexInput?.value).toBe(onChange.mock.lastCall?.[0]);
+    expect(onChange).toHaveBeenCalledTimes(3);
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it('cancels a pending gradient update when the picker unmounts', () => {

--- a/packages/mobile/src/components/settings/__tests__/OkhslColorPicker.test.tsx
+++ b/packages/mobile/src/components/settings/__tests__/OkhslColorPicker.test.tsx
@@ -14,7 +14,7 @@ type ResponderConfig = {
 type MeasureCallback = (x: number, y: number, width: number, height: number, pageX: number, pageY: number) => void;
 
 const responderHarness = vi.hoisted(() => ({
-  configs: [] as ResponderConfig[],
+  configsByLabel: {} as Record<string, ResponderConfig>,
   deferMeasurements: false,
   measurementCallbacks: [] as MeasureCallback[],
   measurementCallCount: 0,
@@ -31,11 +31,25 @@ type ViewMockProps = {
   accessibilityValue?: { text?: string };
   children?: ReactNode;
   onAccessibilityAction?: (event: { nativeEvent: { actionName: string } }) => void;
+  onPanResponderGrant?: ResponderConfig['onPanResponderGrant'];
+  onPanResponderMove?: ResponderConfig['onPanResponderMove'];
+  onPanResponderRelease?: ResponderConfig['onPanResponderRelease'];
+  onPanResponderTerminate?: ResponderConfig['onPanResponderTerminate'];
 };
 
 vi.mock('react-native', () => {
   const View = forwardRef<ViewHandle, ViewMockProps>(function View(
-    { accessible, accessibilityLabel, accessibilityValue, children, onAccessibilityAction },
+    {
+      accessible,
+      accessibilityLabel,
+      accessibilityValue,
+      children,
+      onAccessibilityAction,
+      onPanResponderGrant,
+      onPanResponderMove,
+      onPanResponderRelease,
+      onPanResponderTerminate,
+    },
     ref,
   ) {
     useImperativeHandle(
@@ -53,6 +67,12 @@ vi.mock('react-native', () => {
       [],
     );
     if (accessible && accessibilityLabel) {
+      responderHarness.configsByLabel[accessibilityLabel] = {
+        onPanResponderGrant,
+        onPanResponderMove,
+        onPanResponderRelease,
+        onPanResponderTerminate,
+      };
       responderHarness.sliderRenderCounts[accessibilityLabel] =
         (responderHarness.sliderRenderCounts[accessibilityLabel] ?? 0) + 1;
     }
@@ -71,10 +91,7 @@ vi.mock('react-native', () => {
 
   return {
     PanResponder: {
-      create: (config: ResponderConfig) => {
-        responderHarness.configs.push(config);
-        return { panHandlers: {} };
-      },
+      create: (config: ResponderConfig) => ({ panHandlers: config }),
     },
     StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
     View,
@@ -164,14 +181,22 @@ const LIGHTNESS_LABEL = 'mobile.more.accessibility.sliders.lightness';
 const SATURATION_LABEL = 'mobile.more.accessibility.sliders.saturation';
 const HUE_LABEL = 'mobile.more.accessibility.sliders.hue';
 const HEX_LABEL = 'mobile.more.accessibility.hexLabel';
+// These are intentional visual-contract assertions: lightness and saturation
+// each sample 12 stops, while hue includes both endpoints with 13 stops.
+const EXPECTED_GRADIENT_STOP_COUNTS = [12, 12, 13] as const;
+const EXPECTED_INITIAL_GRADIENT_CONVERSIONS = EXPECTED_GRADIENT_STOP_COUNTS.reduce(
+  (total, stopCount) => total + stopCount,
+  0,
+);
+const LIGHTNESS_DEPENDENT_GRADIENT_CONVERSIONS = EXPECTED_GRADIENT_STOP_COUNTS[1] + EXPECTED_GRADIENT_STOP_COUNTS[2];
 
 function responderEvent(pageX: number): ResponderEvent {
   return { nativeEvent: { pageX } };
 }
 
-function responder(index: number): ResponderConfig {
-  const config = responderHarness.configs[index];
-  if (!config) throw new Error(`Missing PanResponder config at index ${index}`);
+function responder(label: string): ResponderConfig {
+  const config = responderHarness.configsByLabel[label];
+  if (!config) throw new Error(`Missing PanResponder config for ${label}`);
   return config;
 }
 
@@ -181,20 +206,20 @@ function resolveNextMeasurement(width = 300, pageLeft = 0) {
   callback(0, 0, width, 14, pageLeft, 0);
 }
 
-function grant(index: number, pageX: number) {
-  responder(index).onPanResponderGrant?.(responderEvent(pageX));
+function grant(label: string, pageX: number) {
+  responder(label).onPanResponderGrant?.(responderEvent(pageX));
 }
 
-function move(index: number, moveX: number) {
-  responder(index).onPanResponderMove?.(responderEvent(moveX), { moveX });
+function move(label: string, moveX: number) {
+  responder(label).onPanResponderMove?.(responderEvent(moveX), { moveX });
 }
 
-function release(index: number, pageX: number) {
-  responder(index).onPanResponderRelease?.(responderEvent(pageX));
+function release(label: string, pageX: number) {
+  responder(label).onPanResponderRelease?.(responderEvent(pageX));
 }
 
-function terminate(index: number, pageX: number) {
-  responder(index).onPanResponderTerminate?.(responderEvent(pageX));
+function terminate(label: string, pageX: number) {
+  responder(label).onPanResponderTerminate?.(responderEvent(pageX));
 }
 
 function slider(container: HTMLElement, label: string): HTMLElement {
@@ -214,7 +239,7 @@ function gradientColors(gradient: HTMLElement): string[] {
 describe('OkhslColorPicker gradient updates', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    responderHarness.configs.length = 0;
+    responderHarness.configsByLabel = {};
     responderHarness.deferMeasurements = false;
     responderHarness.measurementCallbacks.length = 0;
     responderHarness.measurementCallCount = 0;
@@ -232,20 +257,20 @@ describe('OkhslColorPicker gradient updates', () => {
     const onChange = vi.fn();
     render(<OkhslColorPicker value="#00ff00" onChange={onChange} />);
 
-    expect(okhslHarness.conversionCount).toBe(37);
-    expect(responderHarness.configs).toHaveLength(3);
+    expect(okhslHarness.conversionCount).toBe(EXPECTED_INITIAL_GRADIENT_CONVERSIONS);
+    expect(Object.keys(responderHarness.configsByLabel)).toHaveLength(3);
 
     act(() => {
-      grant(0, 30);
+      grant(LIGHTNESS_LABEL, 30);
       for (let moveIndex = 0; moveIndex < 20; moveIndex += 1) {
-        move(0, 60 + moveIndex * 6);
+        move(LIGHTNESS_LABEL, 60 + moveIndex * 6);
       }
     });
 
-    // Every move still publishes one precise colour, but none of the 25
-    // dependent gradient stops rebuild before the bounded timer fires.
+    // Every move still publishes one precise colour, but none of the dependent
+    // gradient stops rebuild before the bounded timer fires.
     expect(onChange).toHaveBeenCalledTimes(21);
-    expect(okhslHarness.conversionCount).toBe(37 + 21);
+    expect(okhslHarness.conversionCount).toBe(EXPECTED_INITIAL_GRADIENT_CONVERSIONS + 21);
     expect(responderHarness.sliderRenderCounts[SATURATION_LABEL]).toBe(1);
     expect(responderHarness.sliderRenderCounts[HUE_LABEL]).toBe(1);
     expect(vi.getTimerCount()).toBe(1);
@@ -253,15 +278,17 @@ describe('OkhslColorPicker gradient updates', () => {
     act(() => {
       vi.advanceTimersByTime(32);
     });
-    expect(okhslHarness.conversionCount).toBe(37 + 21);
+    expect(okhslHarness.conversionCount).toBe(EXPECTED_INITIAL_GRADIENT_CONVERSIONS + 21);
 
     act(() => {
       vi.advanceTimersByTime(2);
     });
-    expect(okhslHarness.conversionCount).toBe(37 + 21 + 25);
+    expect(okhslHarness.conversionCount).toBe(
+      EXPECTED_INITIAL_GRADIENT_CONVERSIONS + 21 + LIGHTNESS_DEPENDENT_GRADIENT_CONVERSIONS,
+    );
     expect(responderHarness.sliderRenderCounts[SATURATION_LABEL]).toBe(2);
     expect(responderHarness.sliderRenderCounts[HUE_LABEL]).toBe(2);
-    expect(responderHarness.configs).toHaveLength(3);
+    expect(Object.keys(responderHarness.configsByLabel)).toHaveLength(3);
   });
 
   it('flushes the exact final gradient on release and leaves no stale trailing update', () => {
@@ -270,11 +297,11 @@ describe('OkhslColorPicker gradient updates', () => {
     const initialGradientColors = gradients(container).map(gradientColors);
 
     act(() => {
-      grant(0, 60);
-      move(0, 210);
+      grant(LIGHTNESS_LABEL, 60);
+      move(LIGHTNESS_LABEL, 210);
       vi.advanceTimersByTime(10);
-      move(0, 240);
-      release(0, 270);
+      move(LIGHTNESS_LABEL, 240);
+      release(LIGHTNESS_LABEL, 270);
     });
 
     expect(slider(container, LIGHTNESS_LABEL).dataset.accessibilityValue).toBe('90%');
@@ -283,7 +310,9 @@ describe('OkhslColorPicker gradient updates', () => {
     expect(vi.getTimerCount()).toBe(0);
 
     const releasedGradients = gradients(container);
-    expect(releasedGradients.map((gradient) => gradient.querySelectorAll('[data-stop]').length)).toEqual([12, 12, 13]);
+    expect(releasedGradients.map((gradient) => gradient.querySelectorAll('[data-stop]').length)).toEqual([
+      ...EXPECTED_GRADIENT_STOP_COUNTS,
+    ]);
     for (const gradient of releasedGradients) {
       const stops = gradient.querySelectorAll<HTMLElement>('[data-stop]');
       expect(stops[0]?.dataset.offset).toBe('0');
@@ -309,10 +338,10 @@ describe('OkhslColorPicker gradient updates', () => {
     const { container } = render(<OkhslColorPicker value="#00ff00" onChange={onChange} />);
 
     act(() => {
-      grant(2, 30);
-      move(2, 150);
+      grant(HUE_LABEL, 30);
+      move(HUE_LABEL, 150);
       vi.advanceTimersByTime(10);
-      terminate(2, 225);
+      terminate(HUE_LABEL, 225);
     });
 
     expect(slider(container, HUE_LABEL).dataset.accessibilityValue).toBe('270°');
@@ -334,8 +363,8 @@ describe('OkhslColorPicker gradient updates', () => {
     const { unmount } = render(<OkhslColorPicker value="#00ff00" onChange={vi.fn()} />);
 
     act(() => {
-      grant(1, 30);
-      move(1, 210);
+      grant(SATURATION_LABEL, 30);
+      move(SATURATION_LABEL, 210);
     });
     expect(vi.getTimerCount()).toBe(1);
     const conversionsBeforeUnmount = okhslHarness.conversionCount;
@@ -353,10 +382,10 @@ describe('OkhslColorPicker gradient updates', () => {
     const conversionsBeforeDrag = okhslHarness.conversionCount;
 
     act(() => {
-      grant(0, 30);
-      move(0, 120);
-      move(0, 180);
-      release(0, 270);
+      grant(LIGHTNESS_LABEL, 30);
+      move(LIGHTNESS_LABEL, 120);
+      move(LIGHTNESS_LABEL, 180);
+      release(LIGHTNESS_LABEL, 270);
     });
 
     expect(responderHarness.measurementCallCount).toBe(1);
@@ -384,8 +413,8 @@ describe('OkhslColorPicker gradient updates', () => {
     const { unmount } = render(<OkhslColorPicker value="#00ff00" onChange={onChange} />);
 
     act(() => {
-      grant(0, 30);
-      move(0, 210);
+      grant(LIGHTNESS_LABEL, 30);
+      move(LIGHTNESS_LABEL, 210);
     });
     expect(responderHarness.measurementCallCount).toBe(1);
     expect(responderHarness.measurementCallbacks).toHaveLength(1);
@@ -409,10 +438,10 @@ describe('OkhslColorPicker gradient updates', () => {
     const conversionsBeforeDrag = okhslHarness.conversionCount;
 
     act(() => {
-      grant(0, 30);
-      release(0, 90);
-      grant(0, 150);
-      release(0, 240);
+      grant(LIGHTNESS_LABEL, 30);
+      release(LIGHTNESS_LABEL, 90);
+      grant(LIGHTNESS_LABEL, 150);
+      release(LIGHTNESS_LABEL, 240);
     });
     expect(responderHarness.measurementCallCount).toBe(1);
     expect(responderHarness.measurementCallbacks).toHaveLength(1);
@@ -443,12 +472,12 @@ describe('OkhslColorPicker gradient updates', () => {
     const conversionsBeforeDrag = okhslHarness.conversionCount;
 
     act(() => {
-      grant(0, 30);
-      release(0, 90);
-      grant(1, 60);
+      grant(LIGHTNESS_LABEL, 30);
+      release(LIGHTNESS_LABEL, 90);
+      grant(SATURATION_LABEL, 60);
       // A late termination from the old responder must be as inert as its
       // deferred release once another channel owns the picker-wide gesture.
-      terminate(0, 120);
+      terminate(LIGHTNESS_LABEL, 120);
     });
 
     expect(responderHarness.measurementCallCount).toBe(2);
@@ -476,7 +505,7 @@ describe('OkhslColorPicker gradient updates', () => {
     expect(vi.getTimerCount()).toBe(1);
 
     act(() => {
-      terminate(1, 90);
+      terminate(SATURATION_LABEL, 90);
     });
 
     expect(slider(container, SATURATION_LABEL).dataset.accessibilityValue).toBe('30%');

--- a/packages/mobile/src/components/settings/__tests__/OkhslColorPicker.test.tsx
+++ b/packages/mobile/src/components/settings/__tests__/OkhslColorPicker.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { act, cleanup, fireEvent, render } from '@testing-library/react';
-import { createElement, forwardRef, useImperativeHandle, type ReactNode } from 'react';
+import { createElement, forwardRef, useEffect, useImperativeHandle, type ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Okhsl } from '../../../lib/okhsl';
 
@@ -55,7 +55,13 @@ vi.mock('react-native', () => {
     },
     ref,
   ) {
-    if (onLayout) responderHarness.trackLayoutCallbacks.add(onLayout);
+    useEffect(() => {
+      if (!onLayout) return;
+      responderHarness.trackLayoutCallbacks.add(onLayout);
+      return () => {
+        responderHarness.trackLayoutCallbacks.delete(onLayout);
+      };
+    }, [onLayout]);
     useImperativeHandle(
       ref,
       () => ({
@@ -193,6 +199,9 @@ const EXPECTED_INITIAL_GRADIENT_CONVERSIONS = EXPECTED_GRADIENT_STOP_COUNTS.redu
   0,
 );
 const NON_LIGHTNESS_GRADIENT_CONVERSIONS = EXPECTED_GRADIENT_STOP_COUNTS[1] + EXPECTED_GRADIENT_STOP_COUNTS[2];
+// Mirrors the component's explicit visual contract: at most one expensive
+// gradient rebuild per 30 fps interval while thumb/value updates stay exact.
+const GRADIENT_UPDATE_INTERVAL_MS = 1000 / 30;
 
 function responderEvent(pageX: number): ResponderEvent {
   return { nativeEvent: { pageX } };
@@ -284,13 +293,16 @@ describe('OkhslColorPicker gradient updates', () => {
     expect(responderHarness.sliderRenderCounts[HUE_LABEL]).toBe(1);
     expect(vi.getTimerCount()).toBe(1);
 
+    // Fake timers schedule the fractional delay on the preceding whole
+    // millisecond, so stay one millisecond below that boundary first.
+    const wholeMillisecondsBeforeGradientUpdate = Math.floor(GRADIENT_UPDATE_INTERVAL_MS) - 1;
     act(() => {
-      vi.advanceTimersByTime(32);
+      vi.advanceTimersByTime(wholeMillisecondsBeforeGradientUpdate);
     });
     expect(okhslHarness.conversionCount).toBe(EXPECTED_INITIAL_GRADIENT_CONVERSIONS + 21);
 
     act(() => {
-      vi.advanceTimersByTime(2);
+      vi.advanceTimersByTime(Math.ceil(GRADIENT_UPDATE_INTERVAL_MS) - wholeMillisecondsBeforeGradientUpdate);
     });
     expect(okhslHarness.conversionCount).toBe(
       EXPECTED_INITIAL_GRADIENT_CONVERSIONS + 21 + NON_LIGHTNESS_GRADIENT_CONVERSIONS,
@@ -381,6 +393,30 @@ describe('OkhslColorPicker gradient updates', () => {
     expect(slider(container, HUE_LABEL).dataset.accessibilityValue).toBe('270°');
     const hexInput = container.querySelector<HTMLInputElement>(`[aria-label="${HEX_LABEL}"]`);
     expect(hexInput?.value).toBe(onChange.mock.lastCall?.[0]);
+    expect(onChange).toHaveBeenCalledTimes(3);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('keeps the mount-time colour as the source of truth if value changes during a drag', () => {
+    const onChange = vi.fn();
+    const { container, rerender } = render(<OkhslColorPicker value="#00ff00" onChange={onChange} />);
+
+    act(() => {
+      grant(HUE_LABEL, 30);
+    });
+    const hexInput = container.querySelector<HTMLInputElement>(`[aria-label="${HEX_LABEL}"]`);
+    const hexAfterGrant = hexInput?.value;
+
+    rerender(<OkhslColorPicker value="#ff0000" onChange={onChange} />);
+    expect(hexInput?.value).toBe(hexAfterGrant);
+
+    act(() => {
+      move(HUE_LABEL, 150);
+      release(HUE_LABEL, 225);
+    });
+
+    expect(hexInput?.value).toBe(onChange.mock.lastCall?.[0]);
+    expect(hexInput?.value).not.toBe('#ff0000');
     expect(onChange).toHaveBeenCalledTimes(3);
     expect(vi.getTimerCount()).toBe(0);
   });


### PR DESCRIPTION
## Summary

- cap expensive OKHSL gradient-track regeneration at roughly 30 updates per second during a drag while keeping the thumb, hex value, preview, and `onChange` exact on every move
- flush the exact final colour on release or cancellation and guard delayed measurements across layout changes, unmounts, repeated drags, and takeovers by a different slider
- memoize slider work and add deterministic timing/race coverage for the Android JS-thread path

Root cause: two gradient stop sets performed repeated OKHSL-to-sRGB gamut calculations for every PanResponder move. Delayed track measurements could also outlive the drag that requested them.

Closes #3216

## Release Notes

- Custom hold colours now keep up with your finger on Android.

## Test plan

- `vp test run --project mobile --reporter=agent packages/mobile/src/components/settings/__tests__/OkhslColorPicker.test.tsx` (9 tests)
- `vp run typecheck:mobile`
- scoped `vp check` on the implementation and test
- `git diff --check`
- full mobile suite (4,916 tests) and Android/iOS bundle checks passed before the final race hardening; each final delta passed the focused suite and static checks
- independent adversarial review: no remaining P0-P2 findings before automated-review follow-ups; both follow-up rounds now have focused regressions
- Metro started with the issue QA notes at `http://vibetunnel-2.tailedd9d5.ts.net:8087`

Manual gate still pending: compare frame timing and settled gradients during sustained L/S/H drags on a low-end Android device.