### PR TITLE
fix: accessibility: clarify colour changes do not work for moon boards

### DIFF
--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -18,7 +18,7 @@
       "metroServersSubtitle": "Switch between Tailnet bundlers",
       "accessibility": {
         "title": "Accessibility",
-        "description": "Pick hold colours and marker shapes that are easier to tell apart. Colour changes also light up your board; shape, size, and brush only change the in-app overlay.",
+        "description": "Pick hold colours and marker shapes that are easier to tell apart. Colour changes also light up your board (except for MoonBoards); shape, size, and brush only change the in-app overlay.",
         "rowSubtitleShort": "Hold colours and shapes for colour vision",
         "markersTitle": "Hold markers",
         "resetAll": "Reset hold markers",


### PR DESCRIPTION
## Summary

<!-- What this change does and why. Link the issue it closes (Closes #123). -->
Updates the description on the accessibility page to make it clear that custom LED colours do not work for Moon Boards, to reduce user confusion. Per [the protocol description](https://github.com/boardsesh/boardsesh/blob/main/docs/MOONBOARD_BLUETOOTH_PROTOCOL_SPEC.md#51-frame-structure) the board only receives hold types, so it's seemingly not possible for the app to request custom LED colours.

Undecided whether it's worth adding similar language to the preview caption (on line 53). I've kept the change as page-description-only for now, since that's at the top of the page, and the preview caption is already slightly ambiguous whether it's discussing how previews will display in the app or how climbs will display on the wall (so adding a moonboard disclaimer there could make things _more_ confusing without also rewording the rest of the caption).

## Release Notes

<!--
The line(s) below ship to users in the mobile "What's New" screen.

Write in climber voice. Describe what the user gets, not what the feature does:
  - "Resume a session right where you left off"  (good)
  - "Added session-resume state to the queue reducer"  (too internal)

One short line per user-facing change. The first line is the headline; any extra
lines fill in the detail. Keep it to what someone would actually notice.

Nothing user-facing (refactor, CI, deps, tests)? Tick the checkbox below instead
(or add the `skip-changelog` label). Leaving this section blank fails CI.
-->

- [x] No release note needed (internal / technical change)

## Test plan

<!-- How you verified this. Commands run, flows exercised, platforms checked. -->
N/A - text only change.