### PR TITLE
chore(store): 2.3.0 App Store + Play listing copy

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,7 +1,8 @@
 New:
-- Full MoonBoard catalog — thousands of problems with grades, stars and send counts, plus Mini 2025 and the original 2010. Original MoonBoard LEDs light up over Bluetooth.
-- Tap any circuit or playlist climb and the whole list drops into your queue in order.
-- See who's on the wall when a crewmate lights up a different climb.
-- Mix your own hold colours with colour-blind previews.
+- Download a board and keep climbing with no signal. Sends sync when you're back.
+- The Boardsesh grade reads the same on Kilter, Tension and MoonBoard, built from real sends.
+- Every gym gets a public page, plus a TV wall screen at boardsesh.com/kiosk/your-gym.
+- Android tablets get the full two-pane wall layout.
+- A Random sort, a projects filter, and pinned filter shortcuts.
 
-Fixed: boards light up more reliably over Bluetooth, and live sessions reconnect after a drop.
+Fixed: faster Bluetooth, and your board shows up again on reconnect.

--- a/fastlane/metadata/android/es-ES/changelogs/default.txt
+++ b/fastlane/metadata/android/es-ES/changelogs/default.txt
@@ -1,1 +1,8 @@
-Boardsesh 2.0 está reescrita nativa: las listas ruedan suaves y la búsqueda es instantánea. Sin tirones. Busca una vía y enciende las presas por Bluetooth en Kilter, Tension, MoonBoard, Decoy, Touchstone, Grasshopper y So iLL. Acércate a un panel y mira lo que hay encendido. Empieza una sesión y tu peña comparte una cola, sin pasarse el teléfono. Monta entrenamientos Volumen, Pirámide, Escalera o Grado fijo. Apunta encadenes e importa tu logbook. Gratis, sin anuncios, código abierto.
+Novedades:
+- Descarga un plafón y sigue escalando sin cobertura. Los encadenes se sincronizan al volver.
+- El grado Boardsesh se lee igual en Kilter, Tension y MoonBoard, hecho con encadenes reales.
+- Cada rocódromo tiene página pública y pantalla de muro para la tele.
+- Las tablets Android estrenan la vista de muro a dos paneles.
+- Orden Aleatorio, filtro de proyectos y filtros fijados.
+
+Arreglado: Bluetooth más rápido y tu plafón reaparece al reconectar.

--- a/fastlane/metadata/android/fr-FR/changelogs/default.txt
+++ b/fastlane/metadata/android/fr-FR/changelogs/default.txt
@@ -1,1 +1,8 @@
-Boardsesh 2.0 est refait en natif : listes fluides, recherche instantanée, fini les ralentissements. Cherche une voie et allume les prises en Bluetooth sur Kilter, Tension, MoonBoard, Decoy, Touchstone, Grasshopper et So iLL. Arrive devant un mur et vois en direct ce qui est allumé. Lance une session, tes potes partagent une file, fini de se passer le téléphone. Monte des entraînements Volume, Pyramide, Échelle ou Cotation ciblée. Importe ton carnet Aurora. Gratuit, sans pub, open source.
+Nouveautés :
+- Télécharge une board et grimpe sans réseau. Tes croix se synchronisent à ton retour.
+- La cotation Boardsesh se lit pareil sur Kilter, Tension et MoonBoard, à partir de vraies croix.
+- Chaque salle a sa page publique et un écran de mur pour la télé.
+- Les tablettes Android passent à la vue mur en deux panneaux.
+- Un tri Aléatoire, un filtre projets et des filtres épinglés.
+
+Corrigé : Bluetooth plus rapide et ta board réapparaît à la reconnexion.

--- a/fastlane/metadata/en-US/promotional_text.txt
+++ b/fastlane/metadata/en-US/promotional_text.txt
@@ -1,1 +1,1 @@
-New: every board now has a live history. Walk up and see what's lit, who lit it, the grade, angle and recent sends, before you even connect.
+Download a board and climb with no signal. Plus the Boardsesh grade: one number that reads the same on Kilter, Tension and MoonBoard, built from real sends.

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,16 +1,19 @@
-This update is all about steadier Bluetooth, plus a new way to show off your wall on iPad.
+Three big ones this update: climb with no signal, one grade that reads the same on every board, and your gym on Boardsesh.
 
-Steadier on the wall:
-- iOS 26.5: fixed Kilter and Tension boards not lighting up, so no more blank board mid-session or connect-then-disconnect churn.
-- Queued a climb from a different board? Your wall no longer flashes dark. Boardsesh skips it and lights the next one that fits your setup.
-- Clear a MoonBoard's lights straight from the app over Bluetooth.
+Climb offline:
+- Download a board and keep going with no signal — search climbs, log sends, save favorites. Everything queues on your phone and syncs when you're back. Downloads finish in seconds now, and Manage storage shows what each board takes up so you can clear the ones you're not climbing on.
 
-New, On the Wall on iPad:
-- Mount an iPad by the wall for a full-screen view of what's lit right now, who's on it, and the session's hardest send, readable from across the room. Step back and forth through the wall's history and tap to relight a climb someone bumped. The screen stays awake for the whole session.
+The Boardsesh grade:
+- One grade that reads the same across Kilter, Tension and MoonBoard, built from every logged send, with a confidence level. Turn on "Show Boardsesh grades" in Settings. Problems nobody's logged yet get an estimate from their hold layout instead of sitting there ungraded.
+
+Your gym:
+- Every gym has a public page now — follow it, or claim it if it's yours. Put your walls on a TV at boardsesh.com/kiosk/your-gym: what's lit on every board, in your logo and colors, with a code climbers scan to get Boardsesh.
 
 Also:
-- Hide MoonBoard climbs set on holds you don't own: deselect a set and those problems drop out of your results.
-- MoonBoard sends now add to a climb's community repeat count instead of wiping it, so benchmarks show their real numbers and sort back to the top.
-- Add a climb to a playlist by pressing and holding it, and spin up a new playlist right there without the sheet vanishing mid-name.
+- Shuffle your results with the new Random sort, filter down to the projects you've tried but haven't sent, and pin the filter shortcuts you actually reach for.
+- The play screen opens on your own history with the climb — your sends and attempts, right where you can see them.
+- Your logbook counts straight: duplicate Aurora ascents land once, imported Tension attempts stay attempts, and MoonBoard 2024 sends import properly.
+- Queue rows and climb rows now work with VoiceOver.
+- Steadier Bluetooth, steadier sessions with your crew, and fewer memory crashes on long iPad days.
 
 Free, no ads, open source.

--- a/fastlane/metadata/es-ES/promotional_text.txt
+++ b/fastlane/metadata/es-ES/promotional_text.txt
@@ -1,1 +1,1 @@
-Novedad: cada tabla ya tiene historial en directo. Llégate y mira qué hay encendido, quién lo encendió, el grado, el ángulo y los encadenes, antes de conectarte.
+Descarga un plafón y escala sin cobertura. Y el grado Boardsesh: un número que se lee igual en Kilter, Tension y MoonBoard, hecho con encadenes reales.

--- a/fastlane/metadata/es-ES/release_notes.txt
+++ b/fastlane/metadata/es-ES/release_notes.txt
@@ -1,16 +1,19 @@
-Esta actualización va de Bluetooth más estable, y de una forma nueva de lucir tu muro en el iPad.
+Tres cosas grandes en esta actualización: escalar sin cobertura, un grado que se lee igual en todos los plafones, y tu rocódromo en Boardsesh.
 
-Más estable en el muro:
-- iOS 26.5: arreglado que los plafones Kilter y Tension no se encendieran, sin pantallas en blanco a media sesión ni el baile de conectar y desconectar.
-- ¿Metiste en la cola una vía de otro plafón? Tu muro ya no parpadea a oscuras: Boardsesh la salta y enciende la siguiente que encaje con tu montaje.
-- Apaga las luces de tu MoonBoard directamente desde la app por Bluetooth.
+Escala sin conexión:
+- Descarga un plafón y sigue escalando sin cobertura: busca vías, registra encadenes y guarda favoritos. Todo se queda en cola en tu móvil y se sincroniza cuando vuelves. Las descargas ahora tardan segundos, y en Almacenamiento ves lo que ocupa cada plafón para borrar los que ya no escalas.
 
-Nuevo, En el muro en iPad:
-- Monta un iPad junto al muro para ver a pantalla completa lo que está encendido ahora mismo, quién lo está haciendo y el encadene más duro de la sesión, legible desde el otro lado de la sala. Avanza y retrocede por el historial del muro y toca para volver a encender una vía que alguien haya cambiado. La pantalla no se apaga en toda la sesión.
+El grado Boardsesh:
+- Un grado que se lee igual en Kilter, Tension y MoonBoard, hecho a partir de todos los encadenes registrados y con un nivel de confianza. Actívalo en Ajustes con "Mostrar grados Boardsesh". Los bloques que nadie ha registrado todavía reciben una estimación a partir de sus presas, en vez de quedarse sin grado.
+
+Tu rocódromo:
+- Cada rocódromo tiene ya su página pública: síguelo, o reclámalo si es tuyo. Pon tus muros en una tele en boardsesh.com/kiosk/tu-rocodromo: lo que está encendido en cada plafón, con tu logo y tus colores, y un código que los escaladores escanean para instalar Boardsesh.
 
 Además:
-- Oculta las vías de MoonBoard montadas sobre presas que no tienes: deselecciona un set y esos bloques desaparecen de tus resultados.
-- Los encadenes de MoonBoard ahora suman al número de repeticiones de la comunidad en vez de borrarlo, así los benchmarks muestran sus cifras reales y vuelven a lo más alto.
-- Añade una vía a una playlist manteniéndola pulsada, y crea una playlist nueva ahí mismo sin que el panel desaparezca a medias.
+- Mezcla tus resultados con el nuevo orden Aleatorio, filtra por los proyectos que has intentado pero no encadenado, y fija los filtros que de verdad usas.
+- La pantalla de escalada abre con tu propio historial de esa vía: tus encadenes e intentos, ahí donde puedes verlos.
+- Tu logbook cuenta bien: los ascensos duplicados de Aurora se cuentan una vez, los intentos importados de Tension siguen siendo intentos, y los encadenes de MoonBoard 2024 se importan como toca.
+- Las filas de la cola y de las vías ya funcionan con VoiceOver.
+- Bluetooth más estable, sesiones con tu gente más estables, y menos cierres por memoria en días largos de iPad.
 
 Gratis, sin anuncios, código abierto.

--- a/fastlane/metadata/es-MX/promotional_text.txt
+++ b/fastlane/metadata/es-MX/promotional_text.txt
@@ -1,1 +1,1 @@
-Novedad: cada tabla ya tiene historial en directo. Llégate y mira qué hay encendido, quién lo encendió, el grado, el ángulo y los encadenes, antes de conectarte.
+Descarga un plafón y escala sin cobertura. Y el grado Boardsesh: un número que se lee igual en Kilter, Tension y MoonBoard, hecho con encadenes reales.

--- a/fastlane/metadata/es-MX/release_notes.txt
+++ b/fastlane/metadata/es-MX/release_notes.txt
@@ -1,16 +1,19 @@
-Esta actualización va de Bluetooth más estable, y de una forma nueva de lucir tu muro en el iPad.
+Tres cosas grandes en esta actualización: escalar sin cobertura, un grado que se lee igual en todos los plafones, y tu rocódromo en Boardsesh.
 
-Más estable en el muro:
-- iOS 26.5: arreglado que los plafones Kilter y Tension no se encendieran, sin pantallas en blanco a media sesión ni el baile de conectar y desconectar.
-- ¿Metiste en la cola una vía de otro plafón? Tu muro ya no parpadea a oscuras: Boardsesh la salta y enciende la siguiente que encaje con tu montaje.
-- Apaga las luces de tu MoonBoard directamente desde la app por Bluetooth.
+Escala sin conexión:
+- Descarga un plafón y sigue escalando sin cobertura: busca vías, registra encadenes y guarda favoritos. Todo se queda en cola en tu móvil y se sincroniza cuando vuelves. Las descargas ahora tardan segundos, y en Almacenamiento ves lo que ocupa cada plafón para borrar los que ya no escalas.
 
-Nuevo, En el muro en iPad:
-- Monta un iPad junto al muro para ver a pantalla completa lo que está encendido ahora mismo, quién lo está haciendo y el encadene más duro de la sesión, legible desde el otro lado de la sala. Avanza y retrocede por el historial del muro y toca para volver a encender una vía que alguien haya cambiado. La pantalla no se apaga en toda la sesión.
+El grado Boardsesh:
+- Un grado que se lee igual en Kilter, Tension y MoonBoard, hecho a partir de todos los encadenes registrados y con un nivel de confianza. Actívalo en Ajustes con "Mostrar grados Boardsesh". Los bloques que nadie ha registrado todavía reciben una estimación a partir de sus presas, en vez de quedarse sin grado.
+
+Tu rocódromo:
+- Cada rocódromo tiene ya su página pública: síguelo, o reclámalo si es tuyo. Pon tus muros en una tele en boardsesh.com/kiosk/tu-rocodromo: lo que está encendido en cada plafón, con tu logo y tus colores, y un código que los escaladores escanean para instalar Boardsesh.
 
 Además:
-- Oculta las vías de MoonBoard montadas sobre presas que no tienes: deselecciona un set y esos bloques desaparecen de tus resultados.
-- Los encadenes de MoonBoard ahora suman al número de repeticiones de la comunidad en vez de borrarlo, así los benchmarks muestran sus cifras reales y vuelven a lo más alto.
-- Añade una vía a una playlist manteniéndola pulsada, y crea una playlist nueva ahí mismo sin que el panel desaparezca a medias.
+- Mezcla tus resultados con el nuevo orden Aleatorio, filtra por los proyectos que has intentado pero no encadenado, y fija los filtros que de verdad usas.
+- La pantalla de escalada abre con tu propio historial de esa vía: tus encadenes e intentos, ahí donde puedes verlos.
+- Tu logbook cuenta bien: los ascensos duplicados de Aurora se cuentan una vez, los intentos importados de Tension siguen siendo intentos, y los encadenes de MoonBoard 2024 se importan como toca.
+- Las filas de la cola y de las vías ya funcionan con VoiceOver.
+- Bluetooth más estable, sesiones con tu gente más estables, y menos cierres por memoria en días largos de iPad.
 
 Gratis, sin anuncios, código abierto.

--- a/fastlane/metadata/fr-FR/promotional_text.txt
+++ b/fastlane/metadata/fr-FR/promotional_text.txt
@@ -1,1 +1,1 @@
-Nouveau : chaque board a un historique live. Arrive et vois ce qui est allumé, qui l'a allumé, la cotation, l'inclinaison et les sends récents, avant de te connecter.
+Télécharge une board et grimpe sans réseau. Et la cotation Boardsesh : un chiffre qui se lit pareil sur Kilter, Tension et MoonBoard, à partir de vraies croix.

--- a/fastlane/metadata/fr-FR/release_notes.txt
+++ b/fastlane/metadata/fr-FR/release_notes.txt
@@ -1,16 +1,19 @@
-Cette mise à jour, c'est surtout du Bluetooth plus stable, et une nouvelle façon de mettre ton mur en valeur sur iPad.
+Trois grosses nouveautés dans cette mise à jour : grimper sans réseau, une cotation qui se lit pareil sur toutes les boards, et ta salle sur Boardsesh.
 
-Plus stable sur le mur :
-- iOS 26.5 : corrigé les boards Kilter et Tension qui ne s'allumaient plus, fini le mur vide en pleine séance et le yo-yo connexion-déconnexion.
-- Une voie d'une autre board dans ta file ? Ton mur ne clignote plus dans le noir : Boardsesh la saute et allume la suivante qui correspond à ton install.
-- Éteins les lumières de ton MoonBoard directement depuis l'appli en Bluetooth.
+Grimpe hors ligne :
+- Télécharge une board et continue sans réseau : cherche des voies, enregistre tes croix, mets des favoris. Tout se met en file sur ton téléphone et se synchronise dès que tu reviens. Les téléchargements prennent maintenant quelques secondes, et Stockage te montre ce que pèse chaque board pour effacer celles que tu ne grimpes plus.
 
-Nouveau, Sur le mur sur iPad :
-- Pose un iPad près du mur pour voir en plein écran ce qui est allumé en ce moment, qui est dessus et la plus grosse croix de la séance, lisible depuis l'autre bout de la salle. Reviens en arrière et en avant dans l'historique du mur et touche pour rallumer une voie que quelqu'un a changée. L'écran reste allumé toute la séance.
+La cotation Boardsesh :
+- Une cotation qui se lit pareil sur Kilter, Tension et MoonBoard, construite à partir de toutes les croix enregistrées, avec un niveau de confiance. Active « Afficher les grades Boardsesh » dans les Réglages. Les blocs que personne n'a encore enregistrés reçoivent une estimation à partir de leurs prises, au lieu de rester sans cotation.
+
+Ta salle :
+- Chaque salle a maintenant sa page publique : abonne-toi, ou revendique-la si c'est la tienne. Mets tes murs sur un écran avec boardsesh.com/kiosk/ta-salle : ce qui est allumé sur chaque board, avec ton logo et tes couleurs, et un code que les grimpeurs scannent pour installer Boardsesh.
 
 Aussi :
-- Masque les voies MoonBoard montées sur des prises que tu n'as pas : désélectionne un set et ces blocs disparaissent de tes résultats.
-- Les croix sur MoonBoard s'ajoutent maintenant au nombre de répétitions de la communauté au lieu de l'effacer, donc les benchmarks affichent leurs vrais chiffres et remontent en haut.
-- Ajoute une voie à une playlist en appuyant longuement dessus, et crée une nouvelle playlist ici même sans que le panneau disparaisse en plein milieu.
+- Mélange tes résultats avec le nouveau tri Aléatoire, filtre sur les projets que tu as essayés sans les enchaîner, et épingle les filtres que tu utilises vraiment.
+- L'écran de grimpe s'ouvre sur ton propre historique de la voie : tes croix et tes essais, là où tu peux les voir.
+- Ton logbook compte juste : les ascensions Aurora en double ne comptent qu'une fois, les essais importés de Tension restent des essais, et les croix MoonBoard 2024 s'importent correctement.
+- Les lignes de la file et des voies fonctionnent maintenant avec VoiceOver.
+- Bluetooth plus stable, séances avec tes potes plus stables, et moins de plantages mémoire sur les longues journées iPad.
 
 Gratuit, sans pub, open source.


### PR DESCRIPTION
## Summary

Refreshes the App Store and Play Store listing copy for the upcoming 2.3.0 release: What's New (`release_notes.txt`), promotional text, and the Play changelog, across all four store locales (`en-US`, `es-ES`, `es-MX`, `fr-FR` / Android `en-US`, `es-ES`, `fr-FR`).

**Why now:** the listing text has been stale since 2.2. `release_notes.txt` was last written on 2026-07-06 (#3476) and 2.2.1 + 2.2.2 both shipped without a copy refresh, so the live App Store "What's New" still describes the 2.2 Bluetooth + iPad work. `packages/mobile/app.config.ts` has been on `2.3.0` since the OTA V3 migration (#3969).

**Window covered:** everything merged since the 2.2 notes. Most of it already reached store users over the air — that's expected and fine, since the store listing is what people read when they update or land on the page cold, not a diff of native-only changes.

**What it leads with**, the three surfaces genuinely absent from the current listing:

1. **Offline board downloads** — verified the `offline-board-downloads` flag is at **100% rollout** (since 2026-07-17) before headlining it, since that flag gates the entire offline engine.
2. **The Boardsesh grade** — cross-board grade with a confidence level, plus the hold-layout estimate for unlogged problems. Quotes the real in-app Settings label per locale so people can find the toggle.
3. **Gym pages and the TV kiosk** — public gym page, follow/claim, `boardsesh.com/kiosk/<gym>`.

Then a short "Also" block: Random sort, projects filter, pinned filter shortcuts, per-climb history on the play screen, logbook accuracy (duplicate Aurora ascents, Tension attempts, MoonBoard 2024 import), VoiceOver on queue/climb rows, and the Bluetooth/session/memory fixes.

**Drive-by glossary fixes** in the existing promotional text, both caught against `docs/i18n-spanish-glossary.md` / `docs/i18n-french-glossary.md`:

- es used **"tabla"** for a climbing board — must be **"plafón"**.
- fr used **"les sends récents"** — French climbers don't "send"; must be **"les croix"**.

Android-only note: the Play changelog calls out the two-pane tablet wall layout, which doesn't apply to the iOS notes.

## Release Notes

- [x] No release note needed (internal / technical change)

This PR *is* the store release notes — it ships no app code, so there's nothing for the in-app "What's New" screen to show.

## Test plan

- Character limits checked against store maxima:
  - App Store What's New (4000): en-US 1573, es-ES/es-MX 1773, fr-FR 1888.
  - App Store promotional text (170): en-US 156, es-ES/es-MX 151, fr-FR 159.
  - Play "What's new" (500): en-US 456, es-ES 461, fr-FR 465. All three first drafts blew the limit (502/545/546) and were trimmed.
- `es-MX` verified byte-identical to `es-ES` for both `release_notes.txt` and `promotional_text.txt`, matching how the screenshot pipeline writes the Spanish app locale to both ASC folders.
- Spanish and French copy checked term-by-term against the glossary docs: plafón / muro / vía / encadene / intento / rocódromo / presas, and croix / essais / allumer / salle / ouvreur.
- Settings toggle quoted from the live catalogs, not translated fresh — `common.json` `boardseshGrades`: "Mostrar grados Boardsesh" (es), « Afficher les grades Boardsesh » (fr).
- Content sourced from `CHANGELOG.md` for the 2026-07-06 → 2026-08-02 window; the offline headline was gated on reading the PostHog flag rather than assuming from the changelog text (which still says "for testers on the offline-downloads flag").

Merging this to `main` triggers `mobile-store-metadata.yml`, which pushes the text to both stores — iOS text lands on the editable App Store version without submitting for review; Android sends the listing for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PKzKVnyedJgHcB1AZ861G9
