### PR TITLE
chore(mobile): harden intent diagnostics concurrency

### DIFF
--- a/docs/live-activity-push-testing.md
+++ b/docs/live-activity-push-testing.md
@@ -200,7 +200,10 @@ Source locations:
 The RN app's `packages/mobile/ios/` directory is generated and gitignored, so tracked Swift
 unit tests live in `packages/mobile/ios-tests/`. The CI workflow runs Expo prebuild, then
 `scripts/prepare-rn-ios-tests.mjs` creates a generated `BoardseshTests` XCTest target and
-stages the Live Activity Swift sources into that target before invoking `xcodebuild`.
+a `LiveActivityIntentDiagnosticsConcurrencyGate` static-library target. It stages the Live
+Activity Swift sources into the test target and stages the diagnostics source alone in the
+strict-concurrency gate. The subsequent `xcodebuild build-for-testing` invocation builds both
+targets.
 
 Swift test coverage runs in CI:
 

--- a/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
+++ b/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
@@ -1377,39 +1377,6 @@ final class BoardBleWriteFlowTests: XCTestCase {
         XCTAssertEqual(peripheral.writtenChunks.count, 1)
         XCTAssertEqual(String(data: peripheral.writtenChunks[0].data, encoding: .utf8), "l##")
     }
-}
-
-@available(iOS 17.0, *)
-final class WaiterPoolOutcomeTests: XCTestCase {
-    func testWaitReportsImmediateSignalAndTimeoutOutcomes() async {
-        let queue = DispatchQueue(label: "com.boardsesh.tests.waiter-pool")
-        let pool = WaiterPool(queue: queue)
-
-        let immediateResult = await pool.wait(timeout: 1) { true }
-        let timeoutResult = await pool.wait(timeout: 0) { false }
-        XCTAssertTrue(immediateResult)
-        XCTAssertFalse(timeoutResult)
-    }
-
-    func testWaitReportsExplicitSignal() async {
-        let queue = DispatchQueue(label: "com.boardsesh.tests.waiter-pool-signal")
-        let pool = WaiterPool(queue: queue)
-        let resultTask = Task {
-            await pool.wait(timeout: 1) { false }
-        }
-
-        var waiterWasRegistered = false
-        for _ in 0..<1_000 {
-            waiterWasRegistered = queue.sync { pool.hasPendingWaiters }
-            if waiterWasRegistered { break }
-            await Task.yield()
-        }
-        XCTAssertTrue(waiterWasRegistered)
-        queue.sync { pool.signalAll() }
-
-        let signaledResult = await resultTask.value
-        XCTAssertTrue(signaledResult)
-    }
 
     func testMoonBoardAckWatchdogStartsBoundedConnectionRecovery() {
         let hooks = manager.testHooks
@@ -1448,5 +1415,38 @@ final class WaiterPoolOutcomeTests: XCTestCase {
         XCTAssertNotNil(scheduler.lastOneShot(label: "writeStallRecoveryWatchdog"))
         XCTAssertFalse(hooks.sync { hooks.hasPendingWriteAck })
         XCTAssertEqual(disconnectEventCount, 0)
+    }
+}
+
+@available(iOS 17.0, *)
+final class WaiterPoolOutcomeTests: XCTestCase {
+    func testWaitReportsImmediateSignalAndTimeoutOutcomes() async {
+        let queue = DispatchQueue(label: "com.boardsesh.tests.waiter-pool")
+        let pool = WaiterPool(queue: queue)
+
+        let immediateResult = await pool.wait(timeout: 1) { true }
+        let timeoutResult = await pool.wait(timeout: 0) { false }
+        XCTAssertTrue(immediateResult)
+        XCTAssertFalse(timeoutResult)
+    }
+
+    func testWaitReportsExplicitSignal() async {
+        let queue = DispatchQueue(label: "com.boardsesh.tests.waiter-pool-signal")
+        let pool = WaiterPool(queue: queue)
+        let resultTask = Task {
+            await pool.wait(timeout: 1) { false }
+        }
+
+        var waiterWasRegistered = false
+        for _ in 0..<1_000 {
+            waiterWasRegistered = queue.sync { pool.hasPendingWaiters }
+            if waiterWasRegistered { break }
+            await Task.yield()
+        }
+        XCTAssertTrue(waiterWasRegistered)
+        queue.sync { pool.signalAll() }
+
+        let signaledResult = await resultTask.value
+        XCTAssertTrue(signaledResult)
     }
 }

--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -633,7 +633,9 @@ private final class IntentDiagnosticTestClock: @unchecked Sendable {
 final class LiveActivityIntentDiagnosticStoreTests: XCTestCase {
     private var suiteName: String!
     private var defaults: UserDefaults!
-    private var clock: IntentDiagnosticTestClock!
+    private var clock = IntentDiagnosticTestClock(
+        currentDate: Date(timeIntervalSince1970: 2_000_000_000)
+    )
 
     override func setUp() {
         super.setUp()
@@ -647,7 +649,6 @@ final class LiveActivityIntentDiagnosticStoreTests: XCTestCase {
         defaults.removePersistentDomain(forName: suiteName)
         defaults = nil
         suiteName = nil
-        clock = nil
         super.tearDown()
     }
 
@@ -659,7 +660,7 @@ final class LiveActivityIntentDiagnosticStoreTests: XCTestCase {
         timeToLive: TimeInterval = 24 * 60 * 60,
         incompleteGrace: TimeInterval = 30
     ) -> LiveActivityIntentDiagnosticStore {
-        let clock = clock!
+        let clock = self.clock
         return LiveActivityIntentDiagnosticStore(
             defaults: defaults,
             storageKey: "intent-diagnostic-tests",

--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -608,24 +608,46 @@ final class LiveActivityWidgetTests: XCTestCase {
 }
 
 @available(iOS 17.0, *)
+private final class IntentDiagnosticTestClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var currentDate: Date
+
+    init(currentDate: Date) {
+        self.currentDate = currentDate
+    }
+
+    func now() -> Date {
+        lock.lock()
+        defer { lock.unlock() }
+        return currentDate
+    }
+
+    func advance(by interval: TimeInterval) {
+        lock.lock()
+        defer { lock.unlock() }
+        currentDate = currentDate.addingTimeInterval(interval)
+    }
+}
+
+@available(iOS 17.0, *)
 final class LiveActivityIntentDiagnosticStoreTests: XCTestCase {
     private var suiteName: String!
     private var defaults: UserDefaults!
-    private var clockNow: Date!
+    private var clock: IntentDiagnosticTestClock!
 
     override func setUp() {
         super.setUp()
         suiteName = "com.boardsesh.rn.intent-diagnostic-tests.\(UUID().uuidString)"
         defaults = UserDefaults(suiteName: suiteName)
         defaults.removePersistentDomain(forName: suiteName)
-        clockNow = Date(timeIntervalSince1970: 2_000_000_000)
+        clock = IntentDiagnosticTestClock(currentDate: Date(timeIntervalSince1970: 2_000_000_000))
     }
 
     override func tearDown() {
         defaults.removePersistentDomain(forName: suiteName)
         defaults = nil
         suiteName = nil
-        clockNow = nil
+        clock = nil
         super.tearDown()
     }
 
@@ -637,7 +659,8 @@ final class LiveActivityIntentDiagnosticStoreTests: XCTestCase {
         timeToLive: TimeInterval = 24 * 60 * 60,
         incompleteGrace: TimeInterval = 30
     ) -> LiveActivityIntentDiagnosticStore {
-        LiveActivityIntentDiagnosticStore(
+        let clock = clock!
+        return LiveActivityIntentDiagnosticStore(
             defaults: defaults,
             storageKey: "intent-diagnostic-tests",
             processId: processId,
@@ -646,7 +669,7 @@ final class LiveActivityIntentDiagnosticStoreTests: XCTestCase {
             maxRecords: maxRecords,
             timeToLive: timeToLive,
             incompleteGrace: incompleteGrace,
-            now: { [unowned self] in self.clockNow }
+            now: { clock.now() }
         )
     }
 
@@ -676,7 +699,7 @@ final class LiveActivityIntentDiagnosticStoreTests: XCTestCase {
         _ = store.begin(kind: .previousClimb)
         let completed = store.begin(kind: .takeControl)
         completed.complete(.alreadyAllowed)
-        clockNow = clockNow.addingTimeInterval(60)
+        clock.advance(by: 60)
 
         XCTAssertTrue(store.consumeInterruptedRuns().isEmpty)
         XCTAssertEqual(store.recordsSnapshot().count, 2)
@@ -686,11 +709,11 @@ final class LiveActivityIntentDiagnosticStoreTests: XCTestCase {
         let firstProcess = makeStore(processId: UUID())
         _ = firstProcess.begin(kind: .nextClimb)
 
-        clockNow = clockNow.addingTimeInterval(29)
+        clock.advance(by: 29)
         let foregroundProcess = makeStore(processId: UUID())
         XCTAssertTrue(foregroundProcess.consumeInterruptedRuns().isEmpty)
 
-        clockNow = clockNow.addingTimeInterval(2)
+        clock.advance(by: 2)
         let consumed = foregroundProcess.consumeInterruptedRuns()
         XCTAssertEqual(consumed.count, 1)
         let interrupted = try XCTUnwrap(consumed.single)
@@ -728,7 +751,7 @@ final class LiveActivityIntentDiagnosticStoreTests: XCTestCase {
     func testTimeToLiveAndBuildValidationDiscardInsteadOfReport() {
         let oldBuild = makeStore(processId: UUID(), buildNumber: "480")
         _ = oldBuild.begin(kind: .nextClimb)
-        clockNow = clockNow.addingTimeInterval(31)
+        clock.advance(by: 31)
 
         let newBuild = makeStore(processId: UUID(), buildNumber: "481")
         XCTAssertTrue(newBuild.consumeInterruptedRuns().isEmpty)
@@ -736,7 +759,7 @@ final class LiveActivityIntentDiagnosticStoreTests: XCTestCase {
 
         let currentBuild = makeStore(processId: UUID(), timeToLive: 60)
         _ = currentBuild.begin(kind: .previousClimb)
-        clockNow = clockNow.addingTimeInterval(61)
+        clock.advance(by: 61)
         let laterProcess = makeStore(processId: UUID(), timeToLive: 60)
         XCTAssertTrue(laterProcess.consumeInterruptedRuns().isEmpty)
         XCTAssertTrue(laterProcess.recordsSnapshot().isEmpty)
@@ -758,7 +781,7 @@ final class LiveActivityIntentDiagnosticStoreTests: XCTestCase {
         let store = makeStore(maxRecords: 4)
         for index in 0..<10 {
             _ = store.begin(kind: index.isMultiple(of: 2) ? .nextClimb : .previousClimb)
-            clockNow = clockNow.addingTimeInterval(1)
+            clock.advance(by: 1)
         }
 
         let records = store.recordsSnapshot()

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -192,7 +192,10 @@ private final class BoardBleDisplayWriteOutcome: @unchecked Sendable {
 }
 
 final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate {
-    static let shared = BoardBleManager()
+    // Strict-concurrency audit: the manager is bleQueue-confined by design — all state
+    // mutation happens on that serial queue — so this global is safe without claiming
+    // (and over-claiming) Sendable for the whole class.
+    nonisolated(unsafe) static let shared = BoardBleManager()
 
     private final class ManagerCancellationBarrier {
         var watchdog: BleOneShotTimer?

--- a/packages/mobile/modules/live-activity/ios/LiveActivityIntentDiagnostics.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityIntentDiagnostics.swift
@@ -155,7 +155,9 @@ private struct IntentDiagnosticEnvelope: Codable {
 /// One encoded envelope is replaced under a process lock on each transition.
 /// `UserDefaults.set(Data, forKey:)` is a best-effort atomic replacement at the
 /// app-local persistence boundary; failures must never affect intent behavior.
-final class LiveActivityIntentDiagnosticStore {
+/// `@unchecked Sendable` is intentional: immutable configuration includes a
+/// sendable clock, and every envelope read, mutation, and write uses `lock`.
+final class LiveActivityIntentDiagnosticStore: @unchecked Sendable {
     static let defaultStorageKey = "bs_live_activity_intent_diagnostics_v1"
     static let defaultMaxRecords = 16
     static let defaultTimeToLive: TimeInterval = 24 * 60 * 60
@@ -169,7 +171,7 @@ final class LiveActivityIntentDiagnosticStore {
     private let maxRecords: Int
     private let timeToLive: TimeInterval
     private let incompleteGrace: TimeInterval
-    private let now: () -> Date
+    private let now: @Sendable () -> Date
     private let lock = NSLock()
 
     init(
@@ -181,7 +183,7 @@ final class LiveActivityIntentDiagnosticStore {
         maxRecords: Int = defaultMaxRecords,
         timeToLive: TimeInterval = defaultTimeToLive,
         incompleteGrace: TimeInterval = defaultIncompleteGrace,
-        now: @escaping () -> Date = Date.init
+        now: @escaping @Sendable () -> Date = Date.init
     ) {
         self.defaults = defaults
         self.storageKey = storageKey
@@ -396,7 +398,9 @@ final class LiveActivityIntentDiagnosticStore {
 /// Per-run scoped handle. `complete` is idempotent and prevents later stages
 /// from reopening a normal exit. Callers use `defer` so every normal early
 /// return is marked completed while process termination leaves it incomplete.
-final class LiveActivityIntentDiagnosticRun {
+/// `@unchecked Sendable` is intentional: immutable run identity targets the
+/// locked store, and this run's mutable completion state is guarded by `lock`.
+final class LiveActivityIntentDiagnosticRun: @unchecked Sendable {
     private let store: LiveActivityIntentDiagnosticStore
     private let runId: String
     private let processId: String

--- a/packages/mobile/modules/live-activity/ios/LiveActivityIntentDiagnostics.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityIntentDiagnostics.swift
@@ -183,7 +183,7 @@ final class LiveActivityIntentDiagnosticStore: @unchecked Sendable {
         maxRecords: Int = defaultMaxRecords,
         timeToLive: TimeInterval = defaultTimeToLive,
         incompleteGrace: TimeInterval = defaultIncompleteGrace,
-        now: @escaping @Sendable () -> Date = Date.init
+        now: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.defaults = defaults
         self.storageKey = storageKey

--- a/packages/mobile/modules/live-activity/ios/NextClimbIntent.swift
+++ b/packages/mobile/modules/live-activity/ios/NextClimbIntent.swift
@@ -2,8 +2,8 @@ import AppIntents
 
 @available(iOS 17.0, *)
 struct NextClimbIntent: LiveActivityIntent {
-    static var title: LocalizedStringResource = "Next Climb"
-    static var description = IntentDescription("Navigate to the next climb in the queue")
+    static let title: LocalizedStringResource = "Next Climb"
+    static let description = IntentDescription("Navigate to the next climb in the queue")
 
     func perform() async throws -> some IntentResult {
         await ClimbNavigationIntent.perform(direction: .next, label: "NextClimbIntent")

--- a/packages/mobile/modules/live-activity/ios/PreviousClimbIntent.swift
+++ b/packages/mobile/modules/live-activity/ios/PreviousClimbIntent.swift
@@ -2,8 +2,8 @@ import AppIntents
 
 @available(iOS 17.0, *)
 struct PreviousClimbIntent: LiveActivityIntent {
-    static var title: LocalizedStringResource = "Previous Climb"
-    static var description = IntentDescription("Navigate to the previous climb in the queue")
+    static let title: LocalizedStringResource = "Previous Climb"
+    static let description = IntentDescription("Navigate to the previous climb in the queue")
 
     func perform() async throws -> some IntentResult {
         await ClimbNavigationIntent.perform(direction: .previous, label: "PreviousClimbIntent")

--- a/packages/mobile/modules/live-activity/ios/ReconnectBoardIntent.swift
+++ b/packages/mobile/modules/live-activity/ios/ReconnectBoardIntent.swift
@@ -12,8 +12,8 @@ import os.log
 /// each Xcode target compiles its own binary, so keep the two copies identical.
 @available(iOS 17.0, *)
 struct ReconnectBoardIntent: LiveActivityIntent {
-    static var title: LocalizedStringResource = "Reconnect Board"
-    static var description = IntentDescription("Reconnect Bluetooth to your last board")
+    static let title: LocalizedStringResource = "Reconnect Board"
+    static let description = IntentDescription("Reconnect Bluetooth to your last board")
 
     private static let logger = Logger(subsystem: "com.boardsesh.app", category: "LiveActivityIntent")
 

--- a/packages/mobile/modules/live-activity/ios/TakeControlIntent.swift
+++ b/packages/mobile/modules/live-activity/ios/TakeControlIntent.swift
@@ -4,8 +4,8 @@ import os.log
 
 @available(iOS 17.0, *)
 struct TakeControlIntent: LiveActivityIntent {
-    static var title: LocalizedStringResource = "Take Control"
-    static var description = IntentDescription("Claim wall control for this session")
+    static let title: LocalizedStringResource = "Take Control"
+    static let description = IntentDescription("Claim wall control for this session")
 
     private static let logger = Logger(subsystem: "com.boardsesh.app", category: "LiveActivityIntent")
 

--- a/packages/mobile/targets/BoardseshWidgets/NextClimbIntent.swift
+++ b/packages/mobile/targets/BoardseshWidgets/NextClimbIntent.swift
@@ -2,8 +2,8 @@ import AppIntents
 
 @available(iOS 17.0, *)
 struct NextClimbIntent: LiveActivityIntent {
-    static var title: LocalizedStringResource = "Next Climb"
-    static var description = IntentDescription("Navigate to the next climb in the queue")
+    static let title: LocalizedStringResource = "Next Climb"
+    static let description = IntentDescription("Navigate to the next climb in the queue")
 
     func perform() async throws -> some IntentResult {
         await ClimbNavigationIntent.perform(direction: .next, label: "NextClimbIntent")

--- a/packages/mobile/targets/BoardseshWidgets/PreviousClimbIntent.swift
+++ b/packages/mobile/targets/BoardseshWidgets/PreviousClimbIntent.swift
@@ -2,8 +2,8 @@ import AppIntents
 
 @available(iOS 17.0, *)
 struct PreviousClimbIntent: LiveActivityIntent {
-    static var title: LocalizedStringResource = "Previous Climb"
-    static var description = IntentDescription("Navigate to the previous climb in the queue")
+    static let title: LocalizedStringResource = "Previous Climb"
+    static let description = IntentDescription("Navigate to the previous climb in the queue")
 
     func perform() async throws -> some IntentResult {
         await ClimbNavigationIntent.perform(direction: .previous, label: "PreviousClimbIntent")

--- a/packages/mobile/targets/BoardseshWidgets/ReconnectBoardIntent.swift
+++ b/packages/mobile/targets/BoardseshWidgets/ReconnectBoardIntent.swift
@@ -12,8 +12,8 @@ import os.log
 /// each Xcode target compiles its own binary, so keep the two copies identical.
 @available(iOS 17.0, *)
 struct ReconnectBoardIntent: LiveActivityIntent {
-    static var title: LocalizedStringResource = "Reconnect Board"
-    static var description = IntentDescription("Reconnect Bluetooth to your last board")
+    static let title: LocalizedStringResource = "Reconnect Board"
+    static let description = IntentDescription("Reconnect Bluetooth to your last board")
 
     private static let logger = Logger(subsystem: "com.boardsesh.app", category: "LiveActivityIntent")
 

--- a/packages/mobile/targets/BoardseshWidgets/TakeControlIntent.swift
+++ b/packages/mobile/targets/BoardseshWidgets/TakeControlIntent.swift
@@ -4,8 +4,8 @@ import os.log
 
 @available(iOS 17.0, *)
 struct TakeControlIntent: LiveActivityIntent {
-    static var title: LocalizedStringResource = "Take Control"
-    static var description = IntentDescription("Claim wall control for this session")
+    static let title: LocalizedStringResource = "Take Control"
+    static let description = IntentDescription("Claim wall control for this session")
 
     private static let logger = Logger(subsystem: "com.boardsesh.app", category: "LiveActivityIntent")
 

--- a/scripts/__tests__/fixtures/prepare-rn-ios-tests/Boardsesh.xcodeproj/project.pbxproj
+++ b/scripts/__tests__/fixtures/prepare-rn-ios-tests/Boardsesh.xcodeproj/project.pbxproj
@@ -1,0 +1,163 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		000000000000000000000004 /* Boardsesh.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Boardsesh.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		000000000000000000000002 = {
+			isa = PBXGroup;
+			children = (
+				000000000000000000000003 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		000000000000000000000003 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				000000000000000000000004 /* Boardsesh.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		000000000000000000000008 /* Boardsesh */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 000000000000000000000009 /* Build configuration list for PBXNativeTarget "Boardsesh" */;
+			buildPhases = (
+				000000000000000000000005 /* Sources */,
+				000000000000000000000006 /* Frameworks */,
+				000000000000000000000007 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Boardsesh;
+			productName = Boardsesh;
+			productReference = 000000000000000000000004 /* Boardsesh.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		000000000000000000000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1600;
+			};
+			buildConfigurationList = 00000000000000000000000C /* Build configuration list for PBXProject "Boardsesh" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 000000000000000000000002;
+			productRefGroup = 000000000000000000000003 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				000000000000000000000008 /* Boardsesh */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		000000000000000000000007 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		000000000000000000000006 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		000000000000000000000005 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXContainerItemProxy section */
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXTargetDependency section */
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		00000000000000000000000A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		00000000000000000000000B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		00000000000000000000000D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		00000000000000000000000E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		000000000000000000000009 /* Build configuration list for PBXNativeTarget "Boardsesh" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				00000000000000000000000A /* Debug */,
+				00000000000000000000000B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		00000000000000000000000C /* Build configuration list for PBXProject "Boardsesh" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				00000000000000000000000D /* Debug */,
+				00000000000000000000000E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 000000000000000000000001 /* Project object */;
+}

--- a/scripts/__tests__/prepare-rn-ios-tests.test.ts
+++ b/scripts/__tests__/prepare-rn-ios-tests.test.ts
@@ -1,29 +1,286 @@
 /// <reference types="node" />
 
-import { readdirSync, readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { copyFileSync, mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
-const IOS_TESTS_DIR = resolve(REPO_ROOT, 'packages/mobile/ios-tests');
+const FIXTURE_PROJECT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  'fixtures/prepare-rn-ios-tests/Boardsesh.xcodeproj/project.pbxproj',
+);
 const PREPARE_SCRIPT = resolve(REPO_ROOT, 'scripts/prepare-rn-ios-tests.mjs');
+const TEST_TARGET_NAME = 'BoardseshTests';
+const CONCURRENCY_GATE_TARGET_NAME = 'LiveActivityIntentDiagnosticsConcurrencyGate';
+const TEST_DIAGNOSTICS_PROJECT_PATH = 'BoardseshTests/LiveActivitySources/LiveActivityIntentDiagnostics.swift';
+const CONCURRENCY_GATE_DIAGNOSTICS_PROJECT_PATH =
+  'LiveActivityIntentDiagnosticsConcurrencyGate/LiveActivityIntentDiagnostics.swift';
+const SWIFT_FLAGS = '"$(inherited) -D WIDGET_EXTENSION -D BOARDSESH_TESTS"';
 
-describe('prepare-rn-ios-tests test target sources', () => {
-  it('stages every tracked top-level Swift test source', () => {
-    const prepareScript = readFileSync(PREPARE_SCRIPT, 'utf8');
-    const trackedTestSources = readdirSync(IOS_TESTS_DIR)
-      .filter((fileName) => fileName.endsWith('.swift'))
-      .sort();
+const MODULE_SOURCE_NAMES = [
+  'BoardBleManager.swift',
+  'BoardBleWriteSeams.swift',
+  'WaiterPool.swift',
+  'ClimbSessionAttributes.swift',
+  'BoardBleEncoding.swift',
+  'BoardPlacementData.swift',
+  'SharedConstants.swift',
+  'SessionQueueState.swift',
+  'SharedKeychain.swift',
+  'WidgetNetworking.swift',
+  'LiveActivityIntentDiagnostics.swift',
+  'ClimbNavigationIntent.swift',
+  'NextClimbIntent.swift',
+  'PreviousClimbIntent.swift',
+  'TakeControlIntent.swift',
+  'ReconnectBoardIntent.swift',
+];
 
-    for (const testSource of trackedTestSources) {
-      expect(prepareScript, `${testSource} is missing from TEST_SOURCE_FILES`).toContain(
-        `sourcePath: '../ios-tests/${testSource}'`,
+type PbxObject = Record<string, unknown>;
+type PbxSection = Record<string, PbxObject | string>;
+type PbxObjects = Record<string, PbxSection>;
+type PbxReference = { value: string; comment?: string };
+type XmlNode = { $?: Record<string, string>; [key: string]: XmlNode[] | Record<string, string> | undefined };
+
+const require = createRequire(import.meta.url);
+const xcode = require(join(REPO_ROOT, 'node_modules/.bun/node_modules/xcode'));
+const { parseStringPromise } = require(join(REPO_ROOT, 'node_modules/.bun/node_modules/xml2js')) as {
+  parseStringPromise: (xml: string) => Promise<XmlNode>;
+};
+
+function asObject(value: unknown, description: string): PbxObject {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Expected ${description} to be a PBX object`);
+  }
+  return value as PbxObject;
+}
+
+function asReferences(value: unknown, description: string): PbxReference[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`Expected ${description} to be a PBX reference array`);
+  }
+  return value.map((entry) => asObject(entry, description) as PbxReference);
+}
+
+function unquote(value: unknown): string {
+  return typeof value === 'string' ? value.replace(/^"|"$/g, '') : '';
+}
+
+function parseProject(projectPath: string): PbxObjects {
+  const project = xcode.project(projectPath).parseSync();
+  return project.hash.project.objects as PbxObjects;
+}
+
+function findTargets(objects: PbxObjects, targetName: string): Array<{ uuid: string; target: PbxObject }> {
+  return Object.entries(objects.PBXNativeTarget).flatMap(([uuid, target]) => {
+    if (uuid.endsWith('_comment') || typeof target === 'string') return [];
+    const targetObject = asObject(target, `${targetName} target`);
+    return unquote(targetObject.name) === targetName ? [{ uuid, target: targetObject }] : [];
+  });
+}
+
+function targetBuildSettings(objects: PbxObjects, target: PbxObject): PbxObject[] {
+  const configurationListUuid = target.buildConfigurationList;
+  if (typeof configurationListUuid !== 'string') {
+    throw new Error('Target has no build configuration list');
+  }
+  const configurationList = asObject(objects.XCConfigurationList[configurationListUuid], 'configuration list');
+  return asReferences(configurationList.buildConfigurations, 'build configurations').map((configuration) => {
+    const configurationObject = asObject(objects.XCBuildConfiguration[configuration.value], 'build configuration');
+    return asObject(configurationObject.buildSettings, 'build settings');
+  });
+}
+
+function targetSourceBuildFiles(objects: PbxObjects, target: PbxObject): PbxObject[] {
+  const sourcesPhaseReference = asReferences(target.buildPhases, 'target build phases').find((phaseReference) => {
+    return objects.PBXSourcesBuildPhase[phaseReference.value] !== undefined;
+  });
+  const sourcesPhase = sourcesPhaseReference
+    ? asObject(objects.PBXSourcesBuildPhase[sourcesPhaseReference.value], 'build phase')
+    : undefined;
+  if (!sourcesPhase) throw new Error('Target has no Sources build phase');
+
+  return asReferences(sourcesPhase.files, 'source build files').map((buildFileReference) => {
+    return asObject(objects.PBXBuildFile[buildFileReference.value], 'source build file');
+  });
+}
+
+function sourcePaths(objects: PbxObjects, target: PbxObject): string[] {
+  return targetSourceBuildFiles(objects, target).map((buildFile) => {
+    if (typeof buildFile.fileRef !== 'string') throw new Error('Source build file has no file reference');
+    const fileReference = asObject(objects.PBXFileReference[buildFile.fileRef], 'source file reference');
+    return unquote(fileReference.path);
+  });
+}
+
+function targetDependencyCount(objects: PbxObjects, target: PbxObject, dependencyTargetUuid: string): number {
+  return asReferences(target.dependencies, 'target dependencies').filter((dependency) => {
+    const dependencyObject = asObject(objects.PBXTargetDependency[dependency.value], 'target dependency');
+    return dependencyObject.target === dependencyTargetUuid;
+  }).length;
+}
+
+function xmlChildren(node: XmlNode | undefined, elementName: string): XmlNode[] {
+  const children = node?.[elementName];
+  return Array.isArray(children) ? (children as XmlNode[]) : [];
+}
+
+function copyFixtureSource(sourcePath: string, fixtureMobileRoot: string) {
+  const sourceFilePath = resolve(REPO_ROOT, 'packages/mobile', sourcePath);
+  const fixtureFilePath = resolve(fixtureMobileRoot, sourcePath);
+  mkdirSync(dirname(fixtureFilePath), { recursive: true });
+  copyFileSync(sourceFilePath, fixtureFilePath);
+}
+
+function createFixtureProject() {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'boardsesh-rn-ios-tests-'));
+  const fixtureMobileRoot = join(fixtureRoot, 'packages/mobile');
+  const projectPath = join(fixtureMobileRoot, 'ios/Boardsesh.xcodeproj/project.pbxproj');
+  mkdirSync(dirname(projectPath), { recursive: true });
+  copyFileSync(FIXTURE_PROJECT, projectPath);
+
+  for (const testSourceName of readdirSync(resolve(REPO_ROOT, 'packages/mobile/ios-tests')).filter((name) =>
+    name.endsWith('.swift'),
+  )) {
+    copyFixtureSource(`ios-tests/${testSourceName}`, fixtureMobileRoot);
+  }
+  for (const moduleSourceName of MODULE_SOURCE_NAMES) {
+    copyFixtureSource(`modules/live-activity/ios/${moduleSourceName}`, fixtureMobileRoot);
+  }
+
+  return { fixtureRoot, projectPath };
+}
+
+function runGenerator(projectPath: string) {
+  execFileSync('node', [PREPARE_SCRIPT, projectPath], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+}
+
+function seedStaleStrictConcurrencySettings(projectPath: string) {
+  const project = xcode.project(projectPath).parseSync();
+  const objects = project.hash.project.objects as PbxObjects;
+  const [testTarget] = findTargets(objects, TEST_TARGET_NAME);
+  if (!testTarget) throw new Error(`Fixture is missing ${TEST_TARGET_NAME}`);
+
+  for (const buildSettings of targetBuildSettings(objects, testTarget.target)) {
+    buildSettings.OTHER_SWIFT_FLAGS = '"$(inherited) -strict-concurrency=complete -warnings-as-errors"';
+    buildSettings.SWIFT_STRICT_CONCURRENCY = 'complete';
+    buildSettings.SWIFT_TREAT_WARNINGS_AS_ERRORS = 'YES';
+  }
+
+  const diagnosticBuildFile = targetSourceBuildFiles(objects, testTarget.target).find((buildFile) => {
+    if (typeof buildFile.fileRef !== 'string') return false;
+    const fileReference = asObject(objects.PBXFileReference[buildFile.fileRef], 'source file reference');
+    return unquote(fileReference.path) === TEST_DIAGNOSTICS_PROJECT_PATH;
+  });
+  if (!diagnosticBuildFile) throw new Error('Fixture is missing the staged diagnostics source');
+  diagnosticBuildFile.settings = { COMPILER_FLAGS: '"-strict-concurrency=complete -warnings-as-errors"' };
+
+  writeFileSync(projectPath, project.writeSync());
+}
+
+describe('prepare-rn-ios-tests generated project', () => {
+  it('creates an idempotent strict-concurrency diagnostics gate without widening BoardseshTests', async () => {
+    const { fixtureRoot, projectPath } = createFixtureProject();
+
+    try {
+      runGenerator(projectPath);
+      seedStaleStrictConcurrencySettings(projectPath);
+      runGenerator(projectPath);
+
+      const normalizedProject = readFileSync(projectPath, 'utf8');
+      const schemePath = join(dirname(projectPath), 'xcshareddata/xcschemes/BoardseshTests.xcscheme');
+      const normalizedScheme = readFileSync(schemePath, 'utf8');
+      runGenerator(projectPath);
+      expect(readFileSync(projectPath, 'utf8')).toBe(normalizedProject);
+      expect(readFileSync(schemePath, 'utf8')).toBe(normalizedScheme);
+
+      const objects = parseProject(projectPath);
+      const testTargets = findTargets(objects, TEST_TARGET_NAME);
+      const gateTargets = findTargets(objects, CONCURRENCY_GATE_TARGET_NAME);
+      expect(testTargets).toHaveLength(1);
+      expect(gateTargets).toHaveLength(1);
+
+      const [{ uuid: testTargetUuid, target: testTarget }] = testTargets;
+      const [{ uuid: gateTargetUuid, target: gateTarget }] = gateTargets;
+      const expectedTestSources = [
+        ...readdirSync(resolve(REPO_ROOT, 'packages/mobile/ios-tests'))
+          .filter((name) => name.endsWith('.swift'))
+          .sort()
+          .map((name) => `BoardseshTests/${name}`),
+        ...MODULE_SOURCE_NAMES.map((name) => `BoardseshTests/LiveActivitySources/${name}`),
+      ].sort();
+
+      expect(sourcePaths(objects, testTarget).sort()).toEqual(expectedTestSources);
+      expect(sourcePaths(objects, gateTarget)).toEqual([CONCURRENCY_GATE_DIAGNOSTICS_PROJECT_PATH]);
+      expect(sourcePaths(objects, testTarget)).toContain(TEST_DIAGNOSTICS_PROJECT_PATH);
+
+      for (const buildSettings of targetBuildSettings(objects, testTarget)) {
+        expect(buildSettings.OTHER_SWIFT_FLAGS).toBe(SWIFT_FLAGS);
+        expect(buildSettings.SWIFT_STRICT_CONCURRENCY).toBeUndefined();
+        expect(buildSettings.SWIFT_TREAT_WARNINGS_AS_ERRORS).toBeUndefined();
+      }
+      for (const buildSettings of targetBuildSettings(objects, gateTarget)) {
+        expect(buildSettings.EXECUTABLE_PREFIX).toBe('""');
+        expect(buildSettings.OTHER_SWIFT_FLAGS).toBe(SWIFT_FLAGS);
+        expect(buildSettings.IPHONEOS_DEPLOYMENT_TARGET).toBe('17.0');
+        expect(buildSettings.SUPPORTED_PLATFORMS).toBe('"iphoneos iphonesimulator"');
+        expect(buildSettings.SWIFT_VERSION).toBe('5.0');
+        expect(buildSettings.SWIFT_STRICT_CONCURRENCY).toBe('complete');
+        expect(buildSettings.SWIFT_TREAT_WARNINGS_AS_ERRORS).toBe('YES');
+      }
+
+      expect(unquote(gateTarget.productType)).toBe('com.apple.product-type.library.static');
+      if (typeof gateTarget.productReference !== 'string') {
+        throw new Error(`${CONCURRENCY_GATE_TARGET_NAME} has no product reference`);
+      }
+      const gateProductReference = asObject(
+        objects.PBXFileReference[gateTarget.productReference],
+        `${CONCURRENCY_GATE_TARGET_NAME} product reference`,
       );
-      expect(prepareScript, `${testSource} has no BoardseshTests project path`).toContain(
-        `projectPath: 'BoardseshTests/${testSource}'`,
+      expect(unquote(gateProductReference.path)).toBe(`${CONCURRENCY_GATE_TARGET_NAME}.a`);
+      expect(unquote(gateProductReference.explicitFileType)).toBe('archive.ar');
+
+      for (const target of [testTarget, gateTarget]) {
+        for (const buildFile of targetSourceBuildFiles(objects, target)) {
+          expect(asObject(buildFile.settings ?? {}, 'source build file settings').COMPILER_FLAGS).toBeUndefined();
+        }
+      }
+
+      expect(targetDependencyCount(objects, testTarget, gateTargetUuid)).toBe(1);
+
+      const parsedScheme = await parseStringPromise(normalizedScheme);
+      const scheme = parsedScheme.Scheme as unknown as XmlNode;
+      const buildActionEntries = xmlChildren(
+        xmlChildren(xmlChildren(scheme, 'BuildAction')[0], 'BuildActionEntries')[0],
+        'BuildActionEntry',
       );
+      const buildableReferences = buildActionEntries.map((entry) => {
+        return xmlChildren(entry, 'BuildableReference')[0]?.$;
+      });
+      expect(buildableReferences.map((reference) => reference?.BlueprintName)).toEqual([
+        TEST_TARGET_NAME,
+        CONCURRENCY_GATE_TARGET_NAME,
+      ]);
+      const concurrencyGateBuildableReference = buildableReferences[1];
+      expect(concurrencyGateBuildableReference?.BlueprintIdentifier).toBe(gateTargetUuid);
+      expect(concurrencyGateBuildableReference?.BuildableName).toBe(`${CONCURRENCY_GATE_TARGET_NAME}.a`);
+      const testableNames = xmlChildren(
+        xmlChildren(xmlChildren(scheme, 'TestAction')[0], 'Testables')[0],
+        'TestableReference',
+      ).map((entry) => xmlChildren(entry, 'BuildableReference')[0]?.$?.BlueprintName);
+      expect(testableNames).toEqual([TEST_TARGET_NAME]);
+      expect(testTargetUuid).not.toBe(gateTargetUuid);
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
     }
   });
 });

--- a/scripts/prepare-rn-ios-tests.mjs
+++ b/scripts/prepare-rn-ios-tests.mjs
@@ -464,6 +464,10 @@ function setConcurrencyGateBuildSettings(project, targetUuid) {
     buildSettings.SKIP_INSTALL = 'YES';
     buildSettings.SUPPORTED_PLATFORMS = '"iphoneos iphonesimulator"';
     buildSettings.SWIFT_STRICT_CONCURRENCY = 'complete';
+    // Deliberate policy: ALL Swift warnings on this gate target become errors, not
+    // just concurrency ones — a new SDK/Xcode bump can red the suite on unrelated
+    // deprecations. Accepted because the target compiles a single audited file;
+    // revisit if an SDK bump reds the suite spuriously.
     buildSettings.SWIFT_TREAT_WARNINGS_AS_ERRORS = 'YES';
     buildSettings.SWIFT_VERSION = '5.0';
     buildSettings.TARGETED_DEVICE_FAMILY = '"1,2"';

--- a/scripts/prepare-rn-ios-tests.mjs
+++ b/scripts/prepare-rn-ios-tests.mjs
@@ -339,6 +339,8 @@ function setBuildSettings(project, targetUuid) {
     buildSettings.OTHER_SWIFT_FLAGS = SWIFT_FLAGS;
     buildSettings.PRODUCT_BUNDLE_IDENTIFIER = BUNDLE_IDENTIFIER;
     buildSettings.PRODUCT_NAME = '"$(TARGET_NAME)"';
+    buildSettings.SWIFT_STRICT_CONCURRENCY = 'complete';
+    buildSettings.SWIFT_TREAT_WARNINGS_AS_ERRORS = 'YES';
     buildSettings.SWIFT_VERSION = '5.0';
     buildSettings.TEST_HOST = '""';
   }

--- a/scripts/prepare-rn-ios-tests.mjs
+++ b/scripts/prepare-rn-ios-tests.mjs
@@ -6,10 +6,15 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const TEST_TARGET_NAME = 'BoardseshTests';
+const CONCURRENCY_GATE_TARGET_NAME = 'LiveActivityIntentDiagnosticsConcurrencyGate';
 const APP_TARGET_NAME = 'Boardsesh';
 const BUNDLE_IDENTIFIER = 'com.boardsesh.app.tests';
 const DEPLOYMENT_TARGET = '17.0';
 const SWIFT_FLAGS = '"$(inherited) -D WIDGET_EXTENSION -D BOARDSESH_TESTS"';
+const DIAGNOSTICS_SOURCE_PATH = '../modules/live-activity/ios/LiveActivityIntentDiagnostics.swift';
+const TEST_DIAGNOSTICS_PROJECT_PATH = 'BoardseshTests/LiveActivitySources/LiveActivityIntentDiagnostics.swift';
+const CONCURRENCY_GATE_DIAGNOSTICS_PROJECT_PATH =
+  'LiveActivityIntentDiagnosticsConcurrencyGate/LiveActivityIntentDiagnostics.swift';
 
 const TEST_SOURCE_FILES = [
   {
@@ -69,8 +74,8 @@ const TEST_SOURCE_FILES = [
     projectPath: 'BoardseshTests/LiveActivitySources/WidgetNetworking.swift',
   },
   {
-    sourcePath: '../modules/live-activity/ios/LiveActivityIntentDiagnostics.swift',
-    projectPath: 'BoardseshTests/LiveActivitySources/LiveActivityIntentDiagnostics.swift',
+    sourcePath: DIAGNOSTICS_SOURCE_PATH,
+    projectPath: TEST_DIAGNOSTICS_PROJECT_PATH,
   },
   {
     sourcePath: '../modules/live-activity/ios/ClimbNavigationIntent.swift',
@@ -91,6 +96,13 @@ const TEST_SOURCE_FILES = [
   {
     sourcePath: '../modules/live-activity/ios/ReconnectBoardIntent.swift',
     projectPath: 'BoardseshTests/LiveActivitySources/ReconnectBoardIntent.swift',
+  },
+];
+
+const CONCURRENCY_GATE_SOURCE_FILES = [
+  {
+    sourcePath: DIAGNOSTICS_SOURCE_PATH,
+    projectPath: CONCURRENCY_GATE_DIAGNOSTICS_PROJECT_PATH,
   },
 ];
 
@@ -185,17 +197,21 @@ function ensureGroup(project, groupName) {
   return groupKey;
 }
 
-function hasSourceBuildFile(project, targetUuid, sourcePath) {
+function findSourceBuildFile(project, targetUuid, sourcePath) {
   const phase = project.pbxSourcesBuildPhaseObj(targetUuid);
   const fileReferenceSection = project.pbxFileReferenceSection();
   const buildFileSection = project.pbxBuildFileSection();
   const expectedBasename = sourcePath.split('/').at(-1);
 
-  return phase.files.some((entry) => {
+  for (const entry of phase.files) {
     const buildFile = buildFileSection[entry.value];
     const fileReference = buildFile ? fileReferenceSection[buildFile.fileRef] : null;
-    return unquote(fileReference?.path) === sourcePath || entry.comment === `${expectedBasename} in Sources`;
-  });
+    if (unquote(fileReference?.path) === sourcePath || entry.comment === `${expectedBasename} in Sources`) {
+      return buildFile;
+    }
+  }
+
+  return null;
 }
 
 function addSourceFile(project, targetUuid, groupKey, sourcePath) {
@@ -203,13 +219,101 @@ function addSourceFile(project, targetUuid, groupKey, sourcePath) {
   if (!existsSync(absolutePath)) {
     throw new Error(`Missing RN iOS test source: ${absolutePath}`);
   }
-  if (!hasSourceBuildFile(project, targetUuid, sourcePath)) {
+
+  let buildFile = findSourceBuildFile(project, targetUuid, sourcePath);
+  if (!buildFile) {
     project.addSourceFile(sourcePath, { target: targetUuid }, groupKey);
+    buildFile = findSourceBuildFile(project, targetUuid, sourcePath);
+  }
+  if (!buildFile) {
+    throw new Error(`Could not add RN iOS test source to the Sources build phase: ${sourcePath}`);
   }
 }
 
-function pruneUnexpectedSourceFiles(project, targetUuid) {
-  const allowedSourcePaths = new Set(TEST_SOURCE_FILES.map(({ projectPath }) => projectPath));
+function removePerFileCompilerFlags(project, targetUuid) {
+  const phase = project.pbxSourcesBuildPhaseObj(targetUuid);
+  const buildFileSection = project.pbxBuildFileSection();
+
+  for (const entry of phase.files) {
+    const buildFile = buildFileSection[entry.value];
+    if (buildFile?.settings?.COMPILER_FLAGS === undefined) continue;
+
+    delete buildFile.settings.COMPILER_FLAGS;
+    if (Object.keys(buildFile.settings).length === 0) {
+      delete buildFile.settings;
+    }
+  }
+}
+
+function targetBuildConfigurations(project, targetUuid) {
+  const target = project.pbxNativeTargetSection()[targetUuid];
+  const configurationList = project.pbxXCConfigurationList()[target.buildConfigurationList];
+  const buildConfigurationSection = project.pbxXCBuildConfigurationSection();
+
+  return configurationList.buildConfigurations.map((configuration) => buildConfigurationSection[configuration.value]);
+}
+
+function assertNoPerFileCompilerFlags(project, targetUuid, targetName) {
+  const phase = project.pbxSourcesBuildPhaseObj(targetUuid);
+  const buildFileSection = project.pbxBuildFileSection();
+
+  for (const entry of phase.files) {
+    const buildFile = buildFileSection[entry.value];
+    if (buildFile?.settings?.COMPILER_FLAGS !== undefined) {
+      throw new Error(`${targetName} must not use unsupported per-file compiler flags`);
+    }
+  }
+}
+
+function assertSourceFiles(project, targetUuid, targetName, sourceFiles) {
+  const phase = project.pbxSourcesBuildPhaseObj(targetUuid);
+  const fileReferenceSection = project.pbxFileReferenceSection();
+  const buildFileSection = project.pbxBuildFileSection();
+  const expectedPaths = new Set(sourceFiles.map(({ projectPath }) => projectPath));
+  const actualPaths = phase.files.map((entry) => {
+    const buildFile = buildFileSection[entry.value];
+    return unquote(fileReferenceSection[buildFile?.fileRef]?.path);
+  });
+
+  if (actualPaths.length !== expectedPaths.size || actualPaths.some((sourcePath) => !expectedPaths.has(sourcePath))) {
+    throw new Error(`${targetName} Sources phase does not match its generated source list`);
+  }
+}
+
+function assertBuildSettings(project, targetUuid, targetName, expectsStrictConcurrency) {
+  for (const configuration of targetBuildConfigurations(project, targetUuid)) {
+    const buildSettings = configuration.buildSettings;
+    if (buildSettings.OTHER_SWIFT_FLAGS !== SWIFT_FLAGS) {
+      throw new Error(`${targetName} must retain its widget and test Swift defines`);
+    }
+    if (buildSettings.IPHONEOS_DEPLOYMENT_TARGET !== DEPLOYMENT_TARGET || buildSettings.SWIFT_VERSION !== '5.0') {
+      throw new Error(`${targetName} must retain its iOS deployment target and Swift version`);
+    }
+    if (buildSettings.SUPPORTED_PLATFORMS !== '"iphoneos iphonesimulator"') {
+      throw new Error(`${targetName} must support device and simulator builds`);
+    }
+
+    if (expectsStrictConcurrency) {
+      if (
+        buildSettings.SWIFT_STRICT_CONCURRENCY !== 'complete' ||
+        buildSettings.SWIFT_TREAT_WARNINGS_AS_ERRORS !== 'YES' ||
+        buildSettings.EXECUTABLE_PREFIX !== '""'
+      ) {
+        throw new Error(
+          `${targetName} must compile with strict concurrency warnings as errors and an unprefixed executable name`,
+        );
+      }
+    } else if (
+      buildSettings.SWIFT_STRICT_CONCURRENCY !== undefined ||
+      buildSettings.SWIFT_TREAT_WARNINGS_AS_ERRORS !== undefined
+    ) {
+      throw new Error(`${targetName} must not enable strict concurrency`);
+    }
+  }
+}
+
+function pruneUnexpectedSourceFiles(project, targetUuid, sourceFiles) {
+  const allowedSourcePaths = new Set(sourceFiles.map(({ projectPath }) => projectPath));
   const phase = project.pbxSourcesBuildPhaseObj(targetUuid);
   const fileReferenceSection = project.pbxFileReferenceSection();
   const buildFileSection = project.pbxBuildFileSection();
@@ -321,14 +425,12 @@ function addFrameworkToTarget(project, targetUuid, frameworkName) {
   });
 }
 
-function setBuildSettings(project, targetUuid) {
-  const target = project.pbxNativeTargetSection()[targetUuid];
-  const configurationList = project.pbxXCConfigurationList()[target.buildConfigurationList];
-  const buildConfigurationSection = project.pbxXCBuildConfigurationSection();
-
-  for (const configuration of configurationList.buildConfigurations) {
-    const buildSettings = buildConfigurationSection[configuration.value].buildSettings;
+function setTestBuildSettings(project, targetUuid) {
+  for (const configuration of targetBuildConfigurations(project, targetUuid)) {
+    const buildSettings = configuration.buildSettings;
     delete buildSettings.INFOPLIST_FILE;
+    delete buildSettings.SWIFT_STRICT_CONCURRENCY;
+    delete buildSettings.SWIFT_TREAT_WARNINGS_AS_ERRORS;
 
     buildSettings.BUNDLE_LOADER = '""';
     buildSettings.ENABLE_TESTABILITY = 'YES';
@@ -339,10 +441,48 @@ function setBuildSettings(project, targetUuid) {
     buildSettings.OTHER_SWIFT_FLAGS = SWIFT_FLAGS;
     buildSettings.PRODUCT_BUNDLE_IDENTIFIER = BUNDLE_IDENTIFIER;
     buildSettings.PRODUCT_NAME = '"$(TARGET_NAME)"';
+    buildSettings.SUPPORTED_PLATFORMS = '"iphoneos iphonesimulator"';
+    buildSettings.SWIFT_VERSION = '5.0';
+    buildSettings.TEST_HOST = '""';
+  }
+}
+
+function setConcurrencyGateBuildSettings(project, targetUuid) {
+  for (const configuration of targetBuildConfigurations(project, targetUuid)) {
+    const buildSettings = configuration.buildSettings;
+    delete buildSettings.INFOPLIST_FILE;
+    delete buildSettings.BUNDLE_LOADER;
+    delete buildSettings.TEST_HOST;
+    delete buildSettings.PRODUCT_BUNDLE_IDENTIFIER;
+
+    buildSettings.CLANG_ENABLE_MODULES = 'YES';
+    buildSettings.EXECUTABLE_PREFIX = '""';
+    buildSettings.GENERATE_INFOPLIST_FILE = 'YES';
+    buildSettings.IPHONEOS_DEPLOYMENT_TARGET = DEPLOYMENT_TARGET;
+    buildSettings.OTHER_SWIFT_FLAGS = SWIFT_FLAGS;
+    buildSettings.PRODUCT_NAME = '"$(TARGET_NAME)"';
+    buildSettings.SKIP_INSTALL = 'YES';
+    buildSettings.SUPPORTED_PLATFORMS = '"iphoneos iphonesimulator"';
     buildSettings.SWIFT_STRICT_CONCURRENCY = 'complete';
     buildSettings.SWIFT_TREAT_WARNINGS_AS_ERRORS = 'YES';
     buildSettings.SWIFT_VERSION = '5.0';
-    buildSettings.TEST_HOST = '""';
+    buildSettings.TARGETED_DEVICE_FAMILY = '"1,2"';
+  }
+}
+
+function assertConcurrencyGateProduct(project, targetUuid) {
+  const target = project.pbxNativeTargetSection()[targetUuid];
+  if (target.productType !== '"com.apple.product-type.library.static"') {
+    throw new Error(`${CONCURRENCY_GATE_TARGET_NAME} must be a static library target`);
+  }
+
+  const productReference = project.pbxFileReferenceSection()[target.productReference];
+  if (
+    !productReference ||
+    unquote(productReference.path) !== `${CONCURRENCY_GATE_TARGET_NAME}.a` ||
+    unquote(productReference.explicitFileType) !== 'archive.ar'
+  ) {
+    throw new Error(`${CONCURRENCY_GATE_TARGET_NAME} must reference its unprefixed static library product`);
   }
 }
 
@@ -379,7 +519,8 @@ function ensureTestTarget(project) {
   ensureBuildPhase(project, targetUuid, 'PBXResourcesBuildPhase', 'Resources');
 
   const groupKey = ensureGroup(project, TEST_TARGET_NAME);
-  pruneUnexpectedSourceFiles(project, targetUuid);
+  pruneUnexpectedSourceFiles(project, targetUuid, TEST_SOURCE_FILES);
+  removePerFileCompilerFlags(project, targetUuid);
   for (const { sourcePath, projectPath } of TEST_SOURCE_FILES) {
     stageSourceFile(sourcePath, projectPath);
     addSourceFile(project, targetUuid, groupKey, projectPath);
@@ -388,24 +529,123 @@ function ensureTestTarget(project) {
     addFrameworkToTarget(project, targetUuid, frameworkName);
   }
 
-  setBuildSettings(project, targetUuid);
+  setTestBuildSettings(project, targetUuid);
+  assertSourceFiles(project, targetUuid, TEST_TARGET_NAME, TEST_SOURCE_FILES);
+  assertNoPerFileCompilerFlags(project, targetUuid, TEST_TARGET_NAME);
+  assertBuildSettings(project, targetUuid, TEST_TARGET_NAME, false);
   return targetUuid;
 }
 
-function testBuildableReference(testTargetUuid, indentation) {
+function removeTargetDependencies(project, targetUuid, dependencyTargetUuid) {
+  const target = project.pbxNativeTargetSection()[targetUuid];
+  const targetDependencySection = project.hash.project.objects.PBXTargetDependency;
+  const containerItemProxySection = project.hash.project.objects.PBXContainerItemProxy;
+
+  const dependenciesToRemove = (target.dependencies ?? []).filter((dependency) => {
+    return targetDependencySection[dependency.value]?.target === dependencyTargetUuid;
+  });
+
+  if (dependenciesToRemove.length === 0) return 0;
+
+  const dependencyUuids = new Set(dependenciesToRemove.map((dependency) => dependency.value));
+  target.dependencies = target.dependencies.filter((dependency) => !dependencyUuids.has(dependency.value));
+  for (const dependencyUuid of dependencyUuids) {
+    const targetDependency = targetDependencySection[dependencyUuid];
+    delete targetDependencySection[dependencyUuid];
+    delete targetDependencySection[`${dependencyUuid}_comment`];
+
+    if (targetDependency?.targetProxy) {
+      delete containerItemProxySection[targetDependency.targetProxy];
+      delete containerItemProxySection[`${targetDependency.targetProxy}_comment`];
+    }
+  }
+
+  return dependenciesToRemove.length;
+}
+
+function ensureConcurrencyGateDependency(project, testTargetUuid, gateTargetUuid) {
+  const nativeTargets = project.pbxNativeTargetSection();
+  for (const [targetUuid] of Object.entries(nativeTargets)) {
+    if (isCommentKey(targetUuid) || targetUuid === testTargetUuid) continue;
+    removeTargetDependencies(project, targetUuid, gateTargetUuid);
+  }
+
+  const targetDependencySection = project.hash.project.objects.PBXTargetDependency;
+  const testTarget = nativeTargets[testTargetUuid];
+  const gateDependencies = (testTarget.dependencies ?? []).filter(
+    (dependency) => targetDependencySection[dependency.value]?.target === gateTargetUuid,
+  );
+
+  if (gateDependencies.length === 1) return;
+
+  removeTargetDependencies(project, testTargetUuid, gateTargetUuid);
+  project.addTargetDependency(testTargetUuid, [gateTargetUuid]);
+}
+
+function assertConcurrencyGateDependency(project, testTargetUuid, gateTargetUuid) {
+  const targetDependencySection = project.hash.project.objects.PBXTargetDependency;
+  const testTarget = project.pbxNativeTargetSection()[testTargetUuid];
+  const gateDependencyCount = (testTarget.dependencies ?? []).filter(
+    (dependency) => targetDependencySection[dependency.value]?.target === gateTargetUuid,
+  ).length;
+
+  if (gateDependencyCount !== 1) {
+    throw new Error(`${TEST_TARGET_NAME} must depend on ${CONCURRENCY_GATE_TARGET_NAME}`);
+  }
+}
+
+function ensureConcurrencyGateTarget(project) {
+  const existingTarget = findNativeTarget(project, CONCURRENCY_GATE_TARGET_NAME);
+  const targetUuid =
+    existingTarget?.uuid ??
+    project.addTarget(CONCURRENCY_GATE_TARGET_NAME, 'static_library', CONCURRENCY_GATE_TARGET_NAME).uuid;
+
+  ensureBuildPhase(project, targetUuid, 'PBXSourcesBuildPhase', 'Sources');
+
+  const groupKey = ensureGroup(project, CONCURRENCY_GATE_TARGET_NAME);
+  pruneUnexpectedSourceFiles(project, targetUuid, CONCURRENCY_GATE_SOURCE_FILES);
+  removePerFileCompilerFlags(project, targetUuid);
+  for (const { sourcePath, projectPath } of CONCURRENCY_GATE_SOURCE_FILES) {
+    stageSourceFile(sourcePath, projectPath);
+    addSourceFile(project, targetUuid, groupKey, projectPath);
+  }
+
+  setConcurrencyGateBuildSettings(project, targetUuid);
+  assertSourceFiles(project, targetUuid, CONCURRENCY_GATE_TARGET_NAME, CONCURRENCY_GATE_SOURCE_FILES);
+  assertNoPerFileCompilerFlags(project, targetUuid, CONCURRENCY_GATE_TARGET_NAME);
+  assertBuildSettings(project, targetUuid, CONCURRENCY_GATE_TARGET_NAME, true);
+  assertConcurrencyGateProduct(project, targetUuid);
+  return targetUuid;
+}
+
+function buildableReference(targetUuid, targetName, buildableName, indentation) {
   return `${indentation}<BuildableReference
 ${indentation}   BuildableIdentifier = "primary"
-${indentation}   BlueprintIdentifier = "${testTargetUuid}"
-${indentation}   BuildableName = "${TEST_TARGET_NAME}.xctest"
-${indentation}   BlueprintName = "${TEST_TARGET_NAME}"
+${indentation}   BlueprintIdentifier = "${targetUuid}"
+${indentation}   BuildableName = "${buildableName}"
+${indentation}   BlueprintName = "${targetName}"
 ${indentation}   ReferencedContainer = "container:Boardsesh.xcodeproj">
 ${indentation}</BuildableReference>`;
 }
 
-function writeTestScheme(testTargetUuid) {
+function buildActionEntry(targetUuid, targetName, buildableName) {
+  return `         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+${buildableReference(targetUuid, targetName, buildableName, '            ')}
+         </BuildActionEntry>`;
+}
+
+function writeTestScheme(testTargetUuid, gateTargetUuid) {
   const schemeDirectory = join(projectDir, 'Boardsesh.xcodeproj/xcshareddata/xcschemes');
   const schemePath = join(schemeDirectory, `${TEST_TARGET_NAME}.xcscheme`);
   mkdirSync(schemeDirectory, { recursive: true });
+
+  const testBuildableName = `${TEST_TARGET_NAME}.xctest`;
+  const gateBuildableName = `${CONCURRENCY_GATE_TARGET_NAME}.a`;
 
   const scheme = `<?xml version="1.0" encoding="UTF-8"?>
 <Scheme
@@ -415,14 +655,8 @@ function writeTestScheme(testTargetUuid) {
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "NO"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
-${testBuildableReference(testTargetUuid, '            ')}
-         </BuildActionEntry>
+${buildActionEntry(testTargetUuid, TEST_TARGET_NAME, testBuildableName)}
+${buildActionEntry(gateTargetUuid, CONCURRENCY_GATE_TARGET_NAME, gateBuildableName)}
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -433,7 +667,7 @@ ${testBuildableReference(testTargetUuid, '            ')}
       <Testables>
          <TestableReference
             skipped = "NO">
-${testBuildableReference(testTargetUuid, '            ')}
+${buildableReference(testTargetUuid, TEST_TARGET_NAME, testBuildableName, '            ')}
          </TestableReference>
       </Testables>
    </TestAction>
@@ -465,7 +699,10 @@ ${testBuildableReference(testTargetUuid, '            ')}
 </Scheme>
 `;
 
-  if (!scheme.includes(`BlueprintIdentifier = "${testTargetUuid}"`)) {
+  if (
+    !scheme.includes(`BlueprintIdentifier = "${testTargetUuid}"`) ||
+    !scheme.includes(`BlueprintIdentifier = "${gateTargetUuid}"`)
+  ) {
     throw new Error(`Could not write ${TEST_TARGET_NAME} scheme at ${schemePath}`);
   }
 
@@ -485,8 +722,13 @@ if (!findNativeTarget(project, APP_TARGET_NAME)) {
 }
 
 const testTargetUuid = ensureTestTarget(project);
+const concurrencyGateTargetUuid = ensureConcurrencyGateTarget(project);
+ensureConcurrencyGateDependency(project, testTargetUuid, concurrencyGateTargetUuid);
+assertConcurrencyGateDependency(project, testTargetUuid, concurrencyGateTargetUuid);
 removeStaleSdkFrameworkSearchPaths(project);
 writeFileSync(projectFilePath, project.writeSync());
-writeTestScheme(testTargetUuid);
+writeTestScheme(testTargetUuid, concurrencyGateTargetUuid);
 
-console.log(`Prepared ${TEST_TARGET_NAME} (${testTargetUuid}) for RN iOS Swift tests.`);
+console.log(
+  `Prepared ${TEST_TARGET_NAME} (${testTargetUuid}) and ${CONCURRENCY_GATE_TARGET_NAME} (${concurrencyGateTargetUuid}) for RN iOS Swift tests.`,
+);


### PR DESCRIPTION
## Summary

- mark the Live Activity intent diagnostic store and run handles as explicitly Sendable, with their lock invariants documented
- require injected clocks to be Sendable and keep the XCTest clock behind its own lock
- compile the diagnostics source alone in a generated complete-strict-concurrency, warnings-as-errors gate

Follow-up to #4092 and its post-review Swift concurrency hardening.

## Validation

- focused widget target and iOS test-preparation suites: 2 files, 15 tests passed
- `vp run typecheck:mobile`
- full mobile suite and `vp check`
- mandatory pre-commit hook
- independent adversarial concurrency review passed
- exact-head macOS build pending after repairing the inherited #4140 XCTest placement failure

## Release Notes

- [x] No release note needed (internal / technical change)