### PR TITLE
fix(mobile): return the MoonBoard watchdog test to its own class

### DIFF
--- a/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
+++ b/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
@@ -1377,39 +1377,6 @@ final class BoardBleWriteFlowTests: XCTestCase {
         XCTAssertEqual(peripheral.writtenChunks.count, 1)
         XCTAssertEqual(String(data: peripheral.writtenChunks[0].data, encoding: .utf8), "l##")
     }
-}
-
-@available(iOS 17.0, *)
-final class WaiterPoolOutcomeTests: XCTestCase {
-    func testWaitReportsImmediateSignalAndTimeoutOutcomes() async {
-        let queue = DispatchQueue(label: "com.boardsesh.tests.waiter-pool")
-        let pool = WaiterPool(queue: queue)
-
-        let immediateResult = await pool.wait(timeout: 1) { true }
-        let timeoutResult = await pool.wait(timeout: 0) { false }
-        XCTAssertTrue(immediateResult)
-        XCTAssertFalse(timeoutResult)
-    }
-
-    func testWaitReportsExplicitSignal() async {
-        let queue = DispatchQueue(label: "com.boardsesh.tests.waiter-pool-signal")
-        let pool = WaiterPool(queue: queue)
-        let resultTask = Task {
-            await pool.wait(timeout: 1) { false }
-        }
-
-        var waiterWasRegistered = false
-        for _ in 0..<1_000 {
-            waiterWasRegistered = queue.sync { pool.hasPendingWaiters }
-            if waiterWasRegistered { break }
-            await Task.yield()
-        }
-        XCTAssertTrue(waiterWasRegistered)
-        queue.sync { pool.signalAll() }
-
-        let signaledResult = await resultTask.value
-        XCTAssertTrue(signaledResult)
-    }
 
     func testMoonBoardAckWatchdogStartsBoundedConnectionRecovery() {
         let hooks = manager.testHooks
@@ -1448,5 +1415,38 @@ final class WaiterPoolOutcomeTests: XCTestCase {
         XCTAssertNotNil(scheduler.lastOneShot(label: "writeStallRecoveryWatchdog"))
         XCTAssertFalse(hooks.sync { hooks.hasPendingWriteAck })
         XCTAssertEqual(disconnectEventCount, 0)
+    }
+}
+
+@available(iOS 17.0, *)
+final class WaiterPoolOutcomeTests: XCTestCase {
+    func testWaitReportsImmediateSignalAndTimeoutOutcomes() async {
+        let queue = DispatchQueue(label: "com.boardsesh.tests.waiter-pool")
+        let pool = WaiterPool(queue: queue)
+
+        let immediateResult = await pool.wait(timeout: 1) { true }
+        let timeoutResult = await pool.wait(timeout: 0) { false }
+        XCTAssertTrue(immediateResult)
+        XCTAssertFalse(timeoutResult)
+    }
+
+    func testWaitReportsExplicitSignal() async {
+        let queue = DispatchQueue(label: "com.boardsesh.tests.waiter-pool-signal")
+        let pool = WaiterPool(queue: queue)
+        let resultTask = Task {
+            await pool.wait(timeout: 1) { false }
+        }
+
+        var waiterWasRegistered = false
+        for _ in 0..<1_000 {
+            waiterWasRegistered = queue.sync { pool.hasPendingWaiters }
+            if waiterWasRegistered { break }
+            await Task.yield()
+        }
+        XCTAssertTrue(waiterWasRegistered)
+        queue.sync { pool.signalAll() }
+
+        let signaledResult = await resultTask.value
+        XCTAssertTrue(signaledResult)
     }
 }


### PR DESCRIPTION
## Summary

The #4140 rebase onto main resolved a `BoardBleWriteFlowTests.swift` conflict by splicing the incoming MoonBoard watchdog test after the WaiterPool tests main had just gained from #4092 — landing it inside `WaiterPoolOutcomeTests`, where the write-flow fixtures (`manager`, `scheduler`, `makeCharacteristic`) don't exist. Braces stayed balanced so nothing flagged it locally, and `ios-rn-ci` has `branches-ignore: [main]`, so main's Swift suite has been failing to compile silently; every branch rebased onto current main (first hit: #4114) reds `build-and-test` with "cannot find 'manager' in scope".

This moves the test back into `BoardBleWriteFlowTests`. Pure move — no test content changes (`git diff` is 33 lines out, same 33 lines in).

## Test plan

- [x] Brace balance and class layout verified (`BoardBleWriteFlowTests` 138–1419, watchdog test at 1381; `WaiterPoolOutcomeTests` 1422–1452)
- [ ] `ios-rn-ci` `build-and-test` (macOS) green on this PR — the authoritative compile + XCTest check

## Release Notes

- [x] No release note needed (internal / technical change)

