### PR TITLE
ci: add post-deploy production smokes for both hosts

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -436,15 +436,12 @@ jobs:
         env:
           SMOKE_KIOSK_GYM_SLUG: ${{ vars.SMOKE_KIOSK_GYM_SLUG }}
           SMOKE_EMBED_BOARD_UUID: ${{ vars.SMOKE_EMBED_BOARD_UUID }}
-        # `bunx tsx` rather than `vp run smoke:production`, matching this file's
-        # existing `bunx wrangler@4`. CLAUDE.md's no-bunx rule targets
-        # validation, which this isn't, and tsx resolves from the workspace that
-        # `bun install --frozen-lockfile` above already materialised. Reaching
-        # for vp here would mean curl-installing the toolchain onto the
-        # production deploy path — a network dependency that can red a healthy
-        # deploy after it has already shipped. `vp run smoke:production` remains
-        # the way to run this by hand.
-        run: bunx tsx scripts/production-smoke.ts
+        # Bun executes the TypeScript directly — no `bunx`, no `tsx`, nothing
+        # fetched at deploy time. `vp run smoke:production` is the same script
+        # and is how to run it by hand, but no deploy job has vp, and
+        # curl-installing the toolchain here would put a network dependency on
+        # the production deploy path that could red a deploy that shipped fine.
+        run: bun scripts/production-smoke.ts
 
   deploy-production-backend:
     needs: [detect-changes, check-rollback, build-backend, migrate]

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -744,6 +744,11 @@ jobs:
         # This puts a real browser in front of the deploy and confirms React
         # mounted into #root. Read-only — it never signs in, and it runs under
         # playwright.production.config.ts, which declares no globalSetup.
+        #
+        # No rollback guard here, unlike the www smoke. Pages has no instant-
+        # rollback signal to read; the subdomain's equivalent is the job-level
+        # APP_WEB_DEPLOY_HOLD `if:` above, which skips this whole job — this
+        # step included — so there is nothing left to guard at step level.
         env:
           PLAYWRIGHT_TEST_BASE_URL: https://app.boardsesh.com
         run: cd packages/web && bunx playwright test --config=playwright.production.config.ts

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -423,6 +423,21 @@ jobs:
           echo "Deployment URL: $URL"
           echo "url=$URL" >> "$GITHUB_OUTPUT"
 
+      - name: Post-deploy smoke against www.boardsesh.com
+        # Skipped when a rollback is pinned: `--skip-domain` means this deploy
+        # is uploaded but NOT serving, so www is still the rolled-back build.
+        # Smoking it would report on a deployment this job did not promote.
+        #
+        # This runs AFTER the deploy, so it is a detector, not a gate — it can
+        # turn the job red (and fire notify-failure) but can never block a
+        # deploy from going out. That asymmetry is deliberate: a fail-closed
+        # deploy gate stopped production deploys for two days once already.
+        if: needs.check-rollback.outputs.active != 'true'
+        env:
+          SMOKE_KIOSK_GYM_SLUG: ${{ vars.SMOKE_KIOSK_GYM_SLUG }}
+          SMOKE_EMBED_BOARD_UUID: ${{ vars.SMOKE_EMBED_BOARD_UUID }}
+        run: bunx tsx scripts/production-smoke.ts
+
   deploy-production-backend:
     needs: [detect-changes, check-rollback, build-backend, migrate]
     if: always() && needs.detect-changes.outputs.backend_changed == 'true' && needs.build-backend.result == 'success' && needs.migrate.result == 'success'
@@ -717,6 +732,21 @@ jobs:
           retry "wasm binary → 200 wasm/octet-stream"     check_wasm
           retry "index.html is NOT immutable-cached"      check_index_not_immutable
           retry "hashed _expo asset is immutable-cached"  check_hashed_asset_immutable
+
+      - name: Install Playwright chromium
+        run: cd packages/web && bunx playwright install --with-deps chromium
+
+      - name: Browser boot check against app.boardsesh.com
+        # The curl smoke above proves the transport layer; it cannot prove the
+        # bundle evaluates. A JS chunk can serve with perfect headers and still
+        # throw on boot, and `_redirects`' `/* /index.html 200` means a missing
+        # route answers 200 too. Both look healthy to curl and blank to a user.
+        # This puts a real browser in front of the deploy and confirms React
+        # mounted into #root. Read-only — it never signs in, and it runs under
+        # playwright.production.config.ts, which declares no globalSetup.
+        env:
+          PLAYWRIGHT_TEST_BASE_URL: https://app.boardsesh.com
+        run: cd packages/web && bunx playwright test --config=playwright.production.config.ts
 
   # Homelab staging-backend deploy is currently broken — re-enable once the
   # self-hosted runner is healthy. It deploys the same :staging image and is

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -436,6 +436,14 @@ jobs:
         env:
           SMOKE_KIOSK_GYM_SLUG: ${{ vars.SMOKE_KIOSK_GYM_SLUG }}
           SMOKE_EMBED_BOARD_UUID: ${{ vars.SMOKE_EMBED_BOARD_UUID }}
+        # `bunx tsx` rather than `vp run smoke:production`, matching this file's
+        # existing `bunx wrangler@4`. CLAUDE.md's no-bunx rule targets
+        # validation, which this isn't, and tsx resolves from the workspace that
+        # `bun install --frozen-lockfile` above already materialised. Reaching
+        # for vp here would mean curl-installing the toolchain onto the
+        # production deploy path — a network dependency that can red a healthy
+        # deploy after it has already shipped. `vp run smoke:production` remains
+        # the way to run this by hand.
         run: bunx tsx scripts/production-smoke.ts
 
   deploy-production-backend:

--- a/packages/web/app/__tests__/home-page-content.test.tsx
+++ b/packages/web/app/__tests__/home-page-content.test.tsx
@@ -255,4 +255,18 @@ describe('HomePageContent', () => {
       expect(await screen.findByRole('button', { name: /install from app store/i })).toBeTruthy();
     });
   });
+
+  describe('heading semantics', () => {
+    it('gives the hero title a real <h1>, not just h5 styling', () => {
+      // MUI maps variant="h5" to a literal <h5>, so this shipped with no <h1>
+      // anywhere on the site's highest-traffic indexable page. The fix is
+      // `component="h1"` — visually identical, semantically correct — and this
+      // pins it, because nothing visual changes if it regresses.
+      render(<HomePageContent {...defaultProps} />);
+
+      const levelOneHeadings = screen.getAllByRole('heading', { level: 1 });
+      expect(levelOneHeadings.length, 'homepage must server-render exactly one <h1>').toBe(1);
+      expect(levelOneHeadings[0].textContent?.trim().length ?? 0).toBeGreaterThan(0);
+    });
+  });
 });

--- a/packages/web/app/__tests__/home-page-content.test.tsx
+++ b/packages/web/app/__tests__/home-page-content.test.tsx
@@ -264,8 +264,12 @@ describe('HomePageContent', () => {
       // pins it, because nothing visual changes if it regresses.
       render(<HomePageContent {...defaultProps} />);
 
+      // jsdom, so this pins the element the component *renders*, not what the
+      // deployed HTML contains. The SSR half is covered by the `/` check in
+      // scripts/production-smoke.ts, which reads the real response body — this
+      // one would still pass if the component became client-only.
       const levelOneHeadings = screen.getAllByRole('heading', { level: 1 });
-      expect(levelOneHeadings.length, 'homepage must server-render exactly one <h1>').toBe(1);
+      expect(levelOneHeadings.length, 'homepage must render exactly one <h1>').toBe(1);
       expect(levelOneHeadings[0].textContent?.trim().length ?? 0).toBeGreaterThan(0);
     });
   });

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -448,8 +448,14 @@ export default function HomePageContent({
         >
           {/* i18n-ignore-next-line -- brand name, not translated */}
           <Image src="/brand/boardsesh-mark.png" width={130} height={130} alt="Boardsesh" priority />
+          {/* `variant` keeps the visual size; `component` fixes the semantics.
+              MUI maps variant="h5" to a literal <h5>, so before this the
+              homepage server-rendered no <h1> at all — the highest-traffic
+              indexable page on the site had no top-level heading for a crawler
+              to read. Visual output is unchanged. */}
           <Typography
             variant="h5"
+            component="h1"
             fontWeight={themeTokens.typography.fontWeight.bold}
             sx={{ color: 'var(--bs-text-brand-primary)' }}
           >

--- a/packages/web/e2e/production/boot.spec.ts
+++ b/packages/web/e2e/production/boot.spec.ts
@@ -73,7 +73,17 @@ test.describe('app.boardsesh.com boots', () => {
     // the regression: 200, correct headers, nothing rendered.
     await page.goto('/climbs', { waitUntil: 'domcontentloaded' });
 
-    await expect(page.locator('#root').locator('> *').first()).toBeAttached({ timeout: 60_000 });
+    const root = page.locator('#root');
+    await expect(root.locator('> *').first()).toBeAttached({ timeout: 60_000 });
+    // Same bar as the root test: an empty wrapper is a mount, not a render,
+    // and the SPA fallback makes an unresolved route look exactly like that.
+    await expect
+      .poll(async () => (await root.innerText()).trim().length, {
+        timeout: 60_000,
+        message: 'deep route mounted but rendered no visible text',
+      })
+      .toBeGreaterThan(0);
+
     expect(fatalErrors, `fatal errors on deep route:\n${fatalErrors.join('\n')}`).toEqual([]);
   });
 });

--- a/packages/web/e2e/production/boot.spec.ts
+++ b/packages/web/e2e/production/boot.spec.ts
@@ -13,6 +13,11 @@
 // and must stay read-only, which is also why it lives under its own config
 // (playwright.production.config.ts) with no globalSetup.
 
+// Measured against live app.boardsesh.com on 2026-08-02: root boot 5.3s, deep
+// route 1.8s. The 60s polls below are ~10x that, so they are headroom for a
+// cold edge rather than a value anything is expected to approach. If a future
+// splash screen renders with no text at all, this is the test that will say so
+// — which is the point; a splash with no visible text is not a booted app.
 import { expect, test, type Page } from '@playwright/test';
 
 /**

--- a/packages/web/e2e/production/boot.spec.ts
+++ b/packages/web/e2e/production/boot.spec.ts
@@ -1,0 +1,79 @@
+// Production boot smoke for app.boardsesh.com.
+//
+// The curl smoke in production-deploy.yml already proves the transport layer:
+// the shell 200s, a deep route falls back to it, the WASM binary serves, and a
+// content-hashed asset comes back immutable. What none of that can prove is
+// that the bundle actually *boots* — a JS chunk can serve with perfect headers
+// and still throw on evaluation, and `_redirects`' `/* /index.html 200` means
+// even a missing route answers 200. Both failures look healthy to curl and
+// blank to a user.
+//
+// So this is deliberately one thing: put a real browser in front of the deploy
+// and confirm React mounted. It never signs in — this runs against production
+// and must stay read-only, which is also why it lives under its own config
+// (playwright.production.config.ts) with no globalSetup.
+
+import { expect, test, type Page } from '@playwright/test';
+
+/**
+ * Errors that mean the app is broken rather than noisy. Kept narrow on purpose:
+ * a production smoke that fails on any console error becomes a flake generator
+ * (third-party scripts, extensions, aborted requests on unload) and then gets
+ * ignored, which is worse than not having it.
+ */
+const FATAL_CONSOLE_PATTERNS = [
+  /Unable to get view config/i,
+  /No QueryClient set/i,
+  /Maximum update depth exceeded/i,
+  /ChunkLoadError/i,
+  /Failed to fetch dynamically imported module/i,
+];
+
+function collectFatalErrors(page: Page): string[] {
+  const fatal: string[] = [];
+  page.on('console', (message) => {
+    if (message.type() !== 'error') return;
+    const text = message.text();
+    if (FATAL_CONSOLE_PATTERNS.some((pattern) => pattern.test(text))) fatal.push(text);
+  });
+  // An uncaught exception is always fatal — that is a bundle that failed to boot.
+  page.on('pageerror', (error) => fatal.push(`pageerror: ${String(error)}`));
+  return fatal;
+}
+
+test.describe('app.boardsesh.com boots', () => {
+  test('mounts React into #root and renders visible content', async ({ page }) => {
+    const fatalErrors = collectFatalErrors(page);
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+    // The shell ships `<div id="root"></div>` empty; anything inside it is
+    // proof the bundle downloaded, evaluated and rendered. This is the check
+    // that separates "assets serve" from "the app works".
+    const root = page.locator('#root');
+    await expect(root).toBeAttached();
+    await expect(root.locator('> *').first()).toBeAttached({ timeout: 60_000 });
+
+    // Rendered *something a human would see*, not just an empty wrapper tree.
+    await expect
+      .poll(async () => (await root.innerText()).trim().length, {
+        timeout: 60_000,
+        message: '#root mounted but rendered no visible text',
+      })
+      .toBeGreaterThan(0);
+
+    expect(fatalErrors, `fatal errors during boot:\n${fatalErrors.join('\n')}`).toEqual([]);
+  });
+
+  test('serves the SPA shell for a deep route without a hard error', async ({ page }) => {
+    const fatalErrors = collectFatalErrors(page);
+
+    // `_redirects` answers `/* /index.html 200`, so this must boot the same
+    // shell rather than a 404 page. A route that resolves to a blank body is
+    // the regression: 200, correct headers, nothing rendered.
+    await page.goto('/climbs', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#root').locator('> *').first()).toBeAttached({ timeout: 60_000 });
+    expect(fatalErrors, `fatal errors on deep route:\n${fatalErrors.join('\n')}`).toEqual([]);
+  });
+});

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -60,7 +60,14 @@ export default defineConfig({
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
-      testIgnore: ['**/layout-screenshots.spec.ts', '**/help-screenshots.spec.ts', '**/expo-web/**'],
+      // `production/` runs against a deployed host under its own config
+      // (playwright.production.config.ts) — never against the local dev server.
+      testIgnore: [
+        '**/layout-screenshots.spec.ts',
+        '**/help-screenshots.spec.ts',
+        '**/expo-web/**',
+        '**/production/**',
+      ],
     },
 
     // Expo-web smoke — drives the mobile app compiled for the browser at /app.

--- a/packages/web/playwright.production.config.ts
+++ b/packages/web/playwright.production.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Production boot smoke — a browser, pointed at a deployed host, and nothing else.
+ *
+ * Deliberately a SEPARATE config from playwright.config.ts rather than another
+ * project inside it. That config carries `globalSetup`, which seeds data and
+ * logs the test user in against whatever `baseURL` resolves to; running it
+ * against production would write to production. There is no per-project opt-out
+ * for globalSetup, so the only safe answer is a config that never declares one.
+ *
+ * No `webServer` either: the target is already deployed, and auto-starting a
+ * local dev server would silently smoke localhost instead of the deploy.
+ *
+ *   PLAYWRIGHT_TEST_BASE_URL=https://app.boardsesh.com \
+ *     bunx playwright test --config=playwright.production.config.ts
+ */
+export default defineConfig({
+  testDir: './e2e/production',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  // One retry: the edge can lag a few seconds behind a fresh deploy, and a
+  // cold serverless route can miss the first navigation budget.
+  retries: 1,
+  workers: 1,
+  timeout: 90_000,
+  expect: { timeout: 20_000 },
+  reporter: process.env.CI ? [['github'], ['list']] : 'list',
+  use: {
+    baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL,
+    trace: 'on-all-retries',
+    screenshot: 'only-on-failure',
+    navigationTimeout: 60_000,
+    ...devices['Desktop Chrome'],
+  },
+});

--- a/packages/web/playwright.production.config.ts
+++ b/packages/web/playwright.production.config.ts
@@ -15,6 +15,17 @@ import { defineConfig, devices } from '@playwright/test';
  *   PLAYWRIGHT_TEST_BASE_URL=https://app.boardsesh.com \
  *     bunx playwright test --config=playwright.production.config.ts
  */
+// Required rather than defaulted. Defaulting to production would mean a bare
+// `playwright test --config=…` silently drives the live site, which is a
+// surprising thing for a config to do on its own; an unset var should say so.
+const baseURL = process.env.PLAYWRIGHT_TEST_BASE_URL;
+if (!baseURL) {
+  throw new Error(
+    'PLAYWRIGHT_TEST_BASE_URL is required for the production smoke — ' +
+      'run `vp run smoke:app-boot`, or set it to the host you mean to check.',
+  );
+}
+
 export default defineConfig({
   testDir: './e2e/production',
   fullyParallel: false,
@@ -27,7 +38,7 @@ export default defineConfig({
   expect: { timeout: 20_000 },
   reporter: process.env.CI ? [['github'], ['list']] : 'list',
   use: {
-    baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL,
+    baseURL,
     trace: 'on-all-retries',
     screenshot: 'only-on-failure',
     navigationTimeout: 60_000,

--- a/scripts/production-smoke.test.ts
+++ b/scripts/production-smoke.test.ts
@@ -58,6 +58,17 @@ describe('www production smoke checks', () => {
     expect(check.assert(response({ contentType: 'application/xml', body: '<urlset></urlset>' }))).toMatch(/loc/);
   });
 
+  it('rejects a session endpoint that 200s with an error payload', () => {
+    const check = checkNamed('auth session');
+    expect(check.assert(response({ contentType: 'application/json', body: '{}' }))).toBeNull();
+    // NextAuth answers 200 for an anonymous session, so status alone proves
+    // nothing here — the body is the only place a failure shows up.
+    expect(check.assert(response({ contentType: 'application/json', body: '{"error":"db down"}' }))).toMatch(/db down/);
+    expect(check.assert(response({ contentType: 'application/json', body: '<html>502</html>' }))).toMatch(
+      /not valid JSON/,
+    );
+  });
+
   it('rejects a ws-auth response that is not the anonymous payload shape', () => {
     const check = checkNamed('ws-auth');
     const healthy = response({

--- a/scripts/production-smoke.test.ts
+++ b/scripts/production-smoke.test.ts
@@ -85,6 +85,20 @@ describe('www production smoke checks', () => {
     expect(check.assert(response({ status: 401, contentType: 'application/json', body: '{}' }))).toMatch(/401/);
   });
 
+  it('rejects an error shell on the kiosk and embed pages', () => {
+    // A Next error page is a well-formed 200 text/html document, so status and
+    // content-type alone accept it. The kiosk is an unattended gym screen that
+    // reloads daily — a regression there sits broken for up to 24h unwatched.
+    for (const name of ['kiosk page', 'board embed']) {
+      const check = checkNamed(name);
+      expect(
+        check.assert(response({ body: '<html><body>x</body></html>' })),
+        `${name} accepted an error shell`,
+      ).toMatch(/error shell/);
+      expect(check.assert(response({ body: `<html>${'x'.repeat(5000)}</html>` }))).toBeNull();
+    }
+  });
+
   it('skips fixture-backed checks rather than failing when the fixture is unset', () => {
     // Fail-closed on missing config is how #3977 stopped production deploys for
     // two days. Every fixture-backed check must declare its env var and have a

--- a/scripts/production-smoke.test.ts
+++ b/scripts/production-smoke.test.ts
@@ -1,0 +1,92 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from 'vitest';
+import { FIXTURE_PATHS, WWW_CHECKS, type SmokeResponse } from './production-smoke';
+
+// The assertions are the whole product here: the runner is a retry loop, but
+// the check table is what decides whether a broken deploy is caught. These
+// tests exist so a check can't be silently weakened into a tautology — every
+// one of them must reject at least one realistic failure, not just accept a
+// healthy response.
+
+function response(overrides: Partial<SmokeResponse> = {}): SmokeResponse {
+  return { status: 200, contentType: 'text/html; charset=utf-8', body: '<h1>Boardsesh</h1>', ...overrides };
+}
+
+/**
+ * Ambiguity is a failure, not a first-match. "sitemap" matches both the sitemap
+ * check and the robots check that points at it, and silently resolving to the
+ * wrong one means these assertions would pass while testing nothing.
+ */
+function checkNamed(fragment: string) {
+  const matches = WWW_CHECKS.filter((check) => check.name.includes(fragment));
+  if (matches.length === 0) throw new Error(`no check matching "${fragment}"`);
+  if (matches.length > 1) {
+    throw new Error(`"${fragment}" is ambiguous: ${matches.map((check) => check.name).join(' | ')}`);
+  }
+  return matches[0];
+}
+
+describe('www production smoke checks', () => {
+  it('covers the surfaces other systems depend on', () => {
+    const paths = WWW_CHECKS.filter((check) => !check.fixtureEnvVar).map((check) => check.path);
+    expect(paths).toEqual(
+      expect.arrayContaining(['/', '/robots.txt', '/sitemap.xml', '/api/auth/session', '/api/internal/ws-auth']),
+    );
+  });
+
+  it('rejects a homepage that 200s with a spinner-only shell', () => {
+    const check = checkNamed('homepage');
+    expect(check.assert(response())).toBeNull();
+    // The exact regression this catches: real status, real content type, no SSR.
+    expect(check.assert(response({ body: '<div id="root"></div>' }))).toMatch(/<h1>/);
+    expect(check.assert(response({ status: 500 }))).toMatch(/500/);
+  });
+
+  it('rejects a robots.txt with no sitemap directive', () => {
+    const check = checkNamed('robots.txt serves');
+    const healthy = response({ contentType: 'text/plain', body: 'User-agent: *\nSitemap: https://x/sitemap.xml\n' });
+    expect(check.assert(healthy)).toBeNull();
+    expect(check.assert(response({ contentType: 'text/plain', body: 'User-agent: *\n' }))).toMatch(/Sitemap/);
+  });
+
+  it('rejects an empty sitemap', () => {
+    const check = checkNamed('sitemap.xml serves');
+    expect(
+      check.assert(response({ contentType: 'application/xml', body: '<urlset><loc>x</loc></urlset>' })),
+    ).toBeNull();
+    expect(check.assert(response({ contentType: 'application/xml', body: '<urlset></urlset>' }))).toMatch(/loc/);
+  });
+
+  it('rejects a ws-auth response that is not the anonymous payload shape', () => {
+    const check = checkNamed('ws-auth');
+    const healthy = response({
+      contentType: 'application/json',
+      body: JSON.stringify({ token: null, authenticated: false }),
+    });
+    expect(check.assert(healthy)).toBeNull();
+    // A 200 that returns an error page instead of JSON — the shape a proxy
+    // misconfiguration produces, and the one a status-only check would miss.
+    expect(check.assert(response({ contentType: 'application/json', body: 'Internal Server Error' }))).toMatch(
+      /not valid JSON/,
+    );
+    expect(check.assert(response({ contentType: 'application/json', body: '{"ok":true}' }))).toMatch(/authenticated/);
+    expect(check.assert(response({ status: 401, contentType: 'application/json', body: '{}' }))).toMatch(/401/);
+  });
+
+  it('skips fixture-backed checks rather than failing when the fixture is unset', () => {
+    // Fail-closed on missing config is how #3977 stopped production deploys for
+    // two days. Every fixture-backed check must declare its env var and have a
+    // path builder, so an unset var is a skip and never a red deploy.
+    const fixtureChecks = WWW_CHECKS.filter((check) => check.fixtureEnvVar);
+    expect(fixtureChecks.length).toBeGreaterThan(0);
+    for (const check of fixtureChecks) {
+      expect(FIXTURE_PATHS[check.fixtureEnvVar as string], `${check.name} has no path builder`).toBeDefined();
+    }
+  });
+
+  it('builds fixture paths from the configured value', () => {
+    expect(FIXTURE_PATHS.SMOKE_KIOSK_GYM_SLUG('movement-lu')).toBe('/kiosk/movement-lu');
+    expect(FIXTURE_PATHS.SMOKE_EMBED_BOARD_UUID('abc-123')).toBe('/embed/board/abc-123');
+  });
+});

--- a/scripts/production-smoke.test.ts
+++ b/scripts/production-smoke.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 
 import { describe, expect, it } from 'vitest';
-import { FIXTURE_PATHS, WWW_CHECKS, type SmokeResponse } from './production-smoke';
+import { FIXTURE_PATHS, WWW_CHECKS, parseBaseUrl, type SmokeResponse } from './production-smoke';
 
 // The assertions are the whole product here: the runner is a retry loop, but
 // the check table is what decides whether a broken deploy is caught. These
@@ -120,5 +120,27 @@ describe('www production smoke checks', () => {
   it('builds fixture paths from the configured value', () => {
     expect(FIXTURE_PATHS.SMOKE_KIOSK_GYM_SLUG('movement-lu')).toBe('/kiosk/movement-lu');
     expect(FIXTURE_PATHS.SMOKE_EMBED_BOARD_UUID('abc-123')).toBe('/embed/board/abc-123');
+  });
+});
+
+describe('parseBaseUrl', () => {
+  it('defaults to production when no --base is given', () => {
+    expect(parseBaseUrl([])).toBe('https://www.boardsesh.com');
+  });
+
+  it('takes the --base value and strips a trailing slash', () => {
+    // The slash matters: paths are concatenated, so `…com/` + `/robots.txt`
+    // would request `//robots.txt`.
+    expect(parseBaseUrl(['--base', 'https://preview.example.com'])).toBe('https://preview.example.com');
+    expect(parseBaseUrl(['--base', 'https://preview.example.com/'])).toBe('https://preview.example.com');
+  });
+
+  it('rejects a --base with no value', () => {
+    expect(() => parseBaseUrl(['--base'])).toThrow(/needs a URL/);
+  });
+
+  it('rejects a malformed --base rather than failing three retries deep', () => {
+    expect(() => parseBaseUrl(['--base', 'www.boardsesh.com'])).toThrow(/not a valid URL/);
+    expect(() => parseBaseUrl(['--base', 'not a url at all'])).toThrow(/not a valid URL/);
   });
 });

--- a/scripts/production-smoke.test.ts
+++ b/scripts/production-smoke.test.ts
@@ -41,6 +41,13 @@ describe('www production smoke checks', () => {
     // The exact regression this catches: real status, real content type, no SSR.
     expect(check.assert(response({ body: '<div id="root"></div>' }))).toMatch(/<h1>/);
     expect(check.assert(response({ status: 500 }))).toMatch(/500/);
+
+    // Attributes are the normal case, not the exception — MUI serves
+    // `<h1 class="MuiTypography-root …">`, so matching a bare `<h1>` would
+    // miss the very element this check exists to find.
+    expect(check.assert(response({ body: '<h1 class="MuiTypography-root">Boardsesh</h1>' }))).toBeNull();
+    // ...but the prefix must still not swallow a longer tag name.
+    expect(check.assert(response({ body: '<h10>not a heading</h10>' }))).toMatch(/<h1>/);
   });
 
   it('rejects a robots.txt with no sitemap directive', () => {

--- a/scripts/production-smoke.ts
+++ b/scripts/production-smoke.ts
@@ -74,6 +74,17 @@ function expectBodyContains(response: SmokeResponse, needle: string, label: stri
   return response.body.includes(needle) ? null : `response body has no ${label}`;
 }
 
+/** Parses the body as JSON, or explains why it isn't. */
+function expectJsonBody(response: SmokeResponse): { payload: Record<string, unknown> } | string {
+  try {
+    const parsed: unknown = JSON.parse(response.body);
+    if (typeof parsed !== 'object' || parsed === null) return `payload is not a JSON object: ${typeof parsed}`;
+    return { payload: parsed as Record<string, unknown> };
+  } catch {
+    return `payload is not valid JSON: ${response.body.slice(0, 120)}`;
+  }
+}
+
 /** First non-null failure reason, or null when every assertion passed. */
 function firstFailure(...reasons: (string | null)[]): string | null {
   return reasons.find((reason) => reason !== null) ?? null;
@@ -115,7 +126,17 @@ export const WWW_CHECKS: SmokeCheck[] = [
   {
     name: 'auth session endpoint answers anonymously',
     path: '/api/auth/session',
-    assert: (response) => firstFailure(expectStatus(response, 200), expectContentType(response, 'application/json')),
+    // Body shape matters as much as status: this is the SPA's identity
+    // provider, and a 200 carrying `{"error":"..."}` — or an HTML error page
+    // with a JSON content type — is exactly the failure a status-only check
+    // waves through.
+    assert: (response) => {
+      const failure = firstFailure(expectStatus(response, 200), expectContentType(response, 'application/json'));
+      if (failure) return failure;
+      const parsed = expectJsonBody(response);
+      if (typeof parsed === 'string') return parsed;
+      return 'error' in parsed.payload ? `session endpoint returned an error: ${String(parsed.payload.error)}` : null;
+    },
   },
   {
     name: 'ws-auth answers anonymously (kiosk + embed depend on it)',
@@ -126,15 +147,9 @@ export const WWW_CHECKS: SmokeCheck[] = [
     assert: (response) => {
       const failure = firstFailure(expectStatus(response, 200), expectContentType(response, 'application/json'));
       if (failure) return failure;
-      try {
-        const payload: unknown = JSON.parse(response.body);
-        if (typeof payload !== 'object' || payload === null || !('authenticated' in payload)) {
-          return 'payload has no `authenticated` field';
-        }
-        return null;
-      } catch {
-        return `payload is not valid JSON: ${response.body.slice(0, 120)}`;
-      }
+      const parsed = expectJsonBody(response);
+      if (typeof parsed === 'string') return parsed;
+      return 'authenticated' in parsed.payload ? null : 'payload has no `authenticated` field';
     },
   },
   {

--- a/scripts/production-smoke.ts
+++ b/scripts/production-smoke.ts
@@ -1,0 +1,262 @@
+#!/usr/bin/env tsx
+/// <reference types="node" />
+
+/**
+ * Post-deploy smoke for www.boardsesh.com.
+ *
+ * `deploy-web` had no post-deploy verification at all: a deploy that built and
+ * uploaded cleanly but 500s on every request reported success, and the first
+ * signal was a user. This script is the detector — it runs after the deploy,
+ * so it cannot block one, but it turns the job red and fires notify-failure.
+ *
+ * Scope is deliberately shallow. These are reachability and shape checks over
+ * the surfaces that (a) carry organic traffic, (b) other systems depend on, or
+ * (c) are load-bearing for the Expo Web Program's front door. Anything needing
+ * a session, a mutation, or seeded data belongs in e2e, not here — this runs
+ * against production and must stay read-only.
+ *
+ *   vp run smoke:production                    # www.boardsesh.com
+ *   vp run smoke:production -- --base <url>    # a preview deployment
+ *
+ * Fixture-dependent checks (kiosk, embed) need a real gym slug / board uuid.
+ * They are configured through SMOKE_KIOSK_GYM_SLUG / SMOKE_EMBED_BOARD_UUID and
+ * report as skipped when unset. They are NOT fail-closed on missing config:
+ * a deploy gate that fails because someone forgot a repo variable stops
+ * production deploys for days (see #3977), and that cure is worse than the
+ * disease this script treats.
+ */
+
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_BASE_URL = 'https://www.boardsesh.com';
+
+/** Per-request ceiling. Generous: a cold serverless route can be slow. */
+const REQUEST_TIMEOUT_MS = 30_000;
+/** Attempts per check, to ride out a single edge/CDN blip. */
+const ATTEMPTS = 3;
+const RETRY_DELAY_MS = 5_000;
+
+export type SmokeResponse = {
+  status: number;
+  contentType: string;
+  body: string;
+};
+
+export type SmokeCheck = {
+  /** Human-readable, appears in the pass/fail log. */
+  name: string;
+  /** Path appended to the base URL. */
+  path: string;
+  /**
+   * Returns null when the check passes, or a reason string when it fails.
+   * Never throws — a thrown error is reported as an infrastructure failure
+   * rather than an assertion failure, which reads very differently on-call.
+   */
+  assert: (response: SmokeResponse) => string | null;
+  /**
+   * Env var holding the fixture this check needs. When set on the check and
+   * absent from the environment, the check is skipped rather than failed.
+   */
+  fixtureEnvVar?: string;
+};
+
+function expectStatus(response: SmokeResponse, expected: number): string | null {
+  return response.status === expected ? null : `expected HTTP ${expected}, got ${response.status}`;
+}
+
+function expectContentType(response: SmokeResponse, fragment: string): string | null {
+  return response.contentType.includes(fragment)
+    ? null
+    : `expected content-type containing "${fragment}", got "${response.contentType}"`;
+}
+
+function expectBodyContains(response: SmokeResponse, needle: string, label: string): string | null {
+  return response.body.includes(needle) ? null : `response body has no ${label}`;
+}
+
+/** First non-null failure reason, or null when every assertion passed. */
+function firstFailure(...reasons: (string | null)[]): string | null {
+  return reasons.find((reason) => reason !== null) ?? null;
+}
+
+export const WWW_CHECKS: SmokeCheck[] = [
+  {
+    name: 'homepage renders server-side',
+    path: '/',
+    // A spinner-only shell is the failure this catches: the page 200s, but the
+    // crawlable payload is gone. An <h1> is the cheapest proof of real SSR.
+    assert: (response) =>
+      firstFailure(
+        expectStatus(response, 200),
+        expectContentType(response, 'text/html'),
+        expectBodyContains(response, '<h1', 'server-rendered <h1>'),
+      ),
+  },
+  {
+    name: 'robots.txt serves and points at the sitemap',
+    path: '/robots.txt',
+    assert: (response) =>
+      firstFailure(
+        expectStatus(response, 200),
+        expectContentType(response, 'text/plain'),
+        expectBodyContains(response, 'Sitemap:', 'Sitemap: directive'),
+      ),
+  },
+  {
+    name: 'sitemap.xml serves at least one URL',
+    path: '/sitemap.xml',
+    assert: (response) =>
+      firstFailure(
+        expectStatus(response, 200),
+        expectContentType(response, 'xml'),
+        expectBodyContains(response, '<loc>', '<loc> entry'),
+      ),
+  },
+  {
+    name: 'auth session endpoint answers anonymously',
+    path: '/api/auth/session',
+    assert: (response) => firstFailure(expectStatus(response, 200), expectContentType(response, 'application/json')),
+  },
+  {
+    name: 'ws-auth answers anonymously (kiosk + embed depend on it)',
+    path: '/api/internal/ws-auth',
+    // Kiosks and embeds open a presence socket with no session. If this starts
+    // 401ing or 500ing, every unattended gym screen goes dark — and nobody is
+    // watching a kiosk to report it.
+    assert: (response) => {
+      const failure = firstFailure(expectStatus(response, 200), expectContentType(response, 'application/json'));
+      if (failure) return failure;
+      try {
+        const payload: unknown = JSON.parse(response.body);
+        if (typeof payload !== 'object' || payload === null || !('authenticated' in payload)) {
+          return 'payload has no `authenticated` field';
+        }
+        return null;
+      } catch {
+        return `payload is not valid JSON: ${response.body.slice(0, 120)}`;
+      }
+    },
+  },
+  {
+    name: 'kiosk page renders for a real gym',
+    path: '',
+    fixtureEnvVar: 'SMOKE_KIOSK_GYM_SLUG',
+    assert: (response) => firstFailure(expectStatus(response, 200), expectContentType(response, 'text/html')),
+  },
+  {
+    name: 'board embed renders for a real board',
+    path: '',
+    fixtureEnvVar: 'SMOKE_EMBED_BOARD_UUID',
+    assert: (response) => firstFailure(expectStatus(response, 200), expectContentType(response, 'text/html')),
+  },
+];
+
+/** Fixture-backed paths, kept next to the checks that consume them. */
+export const FIXTURE_PATHS: Record<string, (value: string) => string> = {
+  SMOKE_KIOSK_GYM_SLUG: (slug) => `/kiosk/${slug}`,
+  SMOKE_EMBED_BOARD_UUID: (uuid) => `/embed/board/${uuid}`,
+};
+
+function resolvePath(check: SmokeCheck, env: NodeJS.ProcessEnv): string | null {
+  if (!check.fixtureEnvVar) return check.path;
+  const fixtureValue = env[check.fixtureEnvVar];
+  if (!fixtureValue) return null;
+  const buildPath = FIXTURE_PATHS[check.fixtureEnvVar];
+  return buildPath ? buildPath(fixtureValue) : null;
+}
+
+async function fetchOnce(url: string): Promise<SmokeResponse> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      redirect: 'follow',
+      headers: {
+        // Identify the smoke in access logs, and ask for the uncached answer —
+        // a CDN hit would happily serve the *previous* deploy's HTML and mask
+        // exactly the regression this exists to catch.
+        'User-Agent': 'boardsesh-production-smoke/1.0',
+        'Cache-Control': 'no-cache',
+      },
+    });
+    return {
+      status: response.status,
+      contentType: response.headers.get('content-type') ?? '',
+      body: await response.text(),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+type CheckOutcome = { name: string; state: 'pass' | 'fail' | 'skip'; detail: string };
+
+async function runCheck(check: SmokeCheck, baseUrl: string, env: NodeJS.ProcessEnv): Promise<CheckOutcome> {
+  const path = resolvePath(check, env);
+  if (path === null) {
+    return { name: check.name, state: 'skip', detail: `${check.fixtureEnvVar} not set` };
+  }
+
+  const url = `${baseUrl}${path}`;
+  let lastDetail = '';
+
+  for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
+    try {
+      const response = await fetchOnce(url);
+      const failure = check.assert(response);
+      if (failure === null) return { name: check.name, state: 'pass', detail: path };
+      lastDetail = failure;
+    } catch (error) {
+      lastDetail = `request failed: ${error instanceof Error ? error.message : String(error)}`;
+    }
+    if (attempt < ATTEMPTS) {
+      console.log(`  ${check.name}: attempt ${attempt} failed (${lastDetail}); retrying in 5s...`);
+      await delay(RETRY_DELAY_MS);
+    }
+  }
+
+  return { name: check.name, state: 'fail', detail: `${path} — ${lastDetail}` };
+}
+
+function parseBaseUrl(argv: string[]): string {
+  const flagIndex = argv.indexOf('--base');
+  if (flagIndex === -1) return process.env.SMOKE_BASE_URL || DEFAULT_BASE_URL;
+  const value = argv[flagIndex + 1];
+  if (!value) throw new Error('--base needs a URL');
+  return value.replace(/\/$/, '');
+}
+
+async function main(): Promise<void> {
+  const baseUrl = parseBaseUrl(process.argv.slice(2));
+  console.log(`Production smoke against ${baseUrl}\n`);
+
+  const outcomes: CheckOutcome[] = [];
+  for (const check of WWW_CHECKS) {
+    const outcome = await runCheck(check, baseUrl, process.env);
+    outcomes.push(outcome);
+    const marker = outcome.state === 'pass' ? 'ok' : outcome.state === 'skip' ? '--' : 'FAIL';
+    console.log(`${marker.padEnd(4)} ${outcome.name}${outcome.state === 'pass' ? '' : ` (${outcome.detail})`}`);
+  }
+
+  const failures = outcomes.filter((outcome) => outcome.state === 'fail');
+  const skipped = outcomes.filter((outcome) => outcome.state === 'skip');
+  console.log(
+    `\n${outcomes.length - failures.length - skipped.length} passed, ${failures.length} failed, ${skipped.length} skipped`,
+  );
+
+  for (const failure of failures) {
+    console.log(`::error::production smoke failed: ${failure.name} — ${failure.detail}`);
+  }
+  if (failures.length > 0) process.exit(1);
+}
+
+// Only run when invoked directly, so the test can import the check table.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`::error::production smoke crashed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  });
+}

--- a/scripts/production-smoke.ts
+++ b/scripts/production-smoke.ts
@@ -74,6 +74,13 @@ function expectBodyContains(response: SmokeResponse, needle: string, label: stri
   return response.body.includes(needle) ? null : `response body has no ${label}`;
 }
 
+/**
+ * An open `<h1>` tag, with or without attributes. Neither plain substring is
+ * right on its own: `'<h1>'` misses the MUI output this page actually serves
+ * (`<h1 class="MuiTypography-root …">`), and `'<h1'` would also match `<h10`.
+ */
+const OPEN_H1_TAG = /<h1[\s>]/i;
+
 /** Parses the body as JSON, or explains why it isn't. */
 function expectJsonBody(response: SmokeResponse): { payload: Record<string, unknown> } | string {
   try {
@@ -123,7 +130,7 @@ export const WWW_CHECKS: SmokeCheck[] = [
       firstFailure(
         expectStatus(response, 200),
         expectContentType(response, 'text/html'),
-        expectBodyContains(response, '<h1', 'server-rendered <h1>'),
+        OPEN_H1_TAG.test(response.body) ? null : 'response body has no server-rendered <h1>',
       ),
   },
   {

--- a/scripts/production-smoke.ts
+++ b/scripts/production-smoke.ts
@@ -45,7 +45,10 @@ export type SmokeResponse = {
 export type SmokeCheck = {
   /** Human-readable, appears in the pass/fail log. */
   name: string;
-  /** Path appended to the base URL. */
+  /**
+   * Path appended to the base URL. Empty for a fixture-backed check, which
+   * builds its path from `FIXTURE_PATHS` once the fixture value is known.
+   */
   path: string;
   /**
    * Returns null when the check passes, or a reason string when it fails.

--- a/scripts/production-smoke.ts
+++ b/scripts/production-smoke.ts
@@ -267,7 +267,7 @@ async function runCheck(check: SmokeCheck, baseUrl: string, env: NodeJS.ProcessE
 }
 
 /** `--base` is the only override — one documented way to point this elsewhere. */
-function parseBaseUrl(argv: string[]): string {
+export function parseBaseUrl(argv: string[]): string {
   const flagIndex = argv.indexOf('--base');
   if (flagIndex === -1) return DEFAULT_BASE_URL;
   const value = argv[flagIndex + 1];

--- a/scripts/production-smoke.ts
+++ b/scripts/production-smoke.ts
@@ -101,15 +101,15 @@ function firstFailure(...reasons: (string | null)[]): string | null {
  * `<h1>` or a known class would be guessing at markup this script can't see.
  * An error shell is a couple of KB; a rendered board page is far larger.
  */
-const MIN_RENDERED_PAGE_BYTES = 4_000;
+const MIN_RENDERED_PAGE_CHARS = 4_000;
 
 function renderedHtmlPage(response: SmokeResponse): string | null {
   return firstFailure(
     expectStatus(response, 200),
     expectContentType(response, 'text/html'),
-    response.body.length >= MIN_RENDERED_PAGE_BYTES
+    response.body.length >= MIN_RENDERED_PAGE_CHARS
       ? null
-      : `page is ${response.body.length} bytes, under the ${MIN_RENDERED_PAGE_BYTES}-byte floor — likely an error shell, not a render`,
+      : `page is ${response.body.length} chars, under the ${MIN_RENDERED_PAGE_CHARS}-char floor — likely an error shell, not a render`,
   );
 }
 
@@ -265,6 +265,13 @@ function parseBaseUrl(argv: string[]): string {
   if (flagIndex === -1) return DEFAULT_BASE_URL;
   const value = argv[flagIndex + 1];
   if (!value) throw new Error('--base needs a URL');
+  // Validate here rather than letting a typo surface three retries deep as a
+  // fetch error that reads like the site is down.
+  try {
+    new URL(value);
+  } catch {
+    throw new Error(`--base is not a valid URL: ${value} (did you include the scheme?)`);
+  }
   return value.replace(/\/$/, '');
 }
 

--- a/scripts/production-smoke.ts
+++ b/scripts/production-smoke.ts
@@ -90,6 +90,29 @@ function firstFailure(...reasons: (string | null)[]): string | null {
   return reasons.find((reason) => reason !== null) ?? null;
 }
 
+/**
+ * A Next error shell is a well-formed 200-ish HTML document, so status and
+ * content-type alone accept it. The kiosk especially needs more than that —
+ * it is an unattended gym screen that reloads daily, so a render regression
+ * there sits broken for up to 24h with nobody watching.
+ *
+ * The floor is on body size rather than on specific markup, because these two
+ * checks only run against a fixture configured per-environment: asserting an
+ * `<h1>` or a known class would be guessing at markup this script can't see.
+ * An error shell is a couple of KB; a rendered board page is far larger.
+ */
+const MIN_RENDERED_PAGE_BYTES = 4_000;
+
+function renderedHtmlPage(response: SmokeResponse): string | null {
+  return firstFailure(
+    expectStatus(response, 200),
+    expectContentType(response, 'text/html'),
+    response.body.length >= MIN_RENDERED_PAGE_BYTES
+      ? null
+      : `page is ${response.body.length} bytes, under the ${MIN_RENDERED_PAGE_BYTES}-byte floor — likely an error shell, not a render`,
+  );
+}
+
 export const WWW_CHECKS: SmokeCheck[] = [
   {
     name: 'homepage renders server-side',
@@ -156,13 +179,13 @@ export const WWW_CHECKS: SmokeCheck[] = [
     name: 'kiosk page renders for a real gym',
     path: '',
     fixtureEnvVar: 'SMOKE_KIOSK_GYM_SLUG',
-    assert: (response) => firstFailure(expectStatus(response, 200), expectContentType(response, 'text/html')),
+    assert: renderedHtmlPage,
   },
   {
     name: 'board embed renders for a real board',
     path: '',
     fixtureEnvVar: 'SMOKE_EMBED_BOARD_UUID',
-    assert: (response) => firstFailure(expectStatus(response, 200), expectContentType(response, 'text/html')),
+    assert: renderedHtmlPage,
   },
 ];
 
@@ -236,9 +259,10 @@ async function runCheck(check: SmokeCheck, baseUrl: string, env: NodeJS.ProcessE
   return { name: check.name, state: 'fail', detail: `${path} — ${lastDetail}` };
 }
 
+/** `--base` is the only override — one documented way to point this elsewhere. */
 function parseBaseUrl(argv: string[]): string {
   const flagIndex = argv.indexOf('--base');
-  if (flagIndex === -1) return process.env.SMOKE_BASE_URL || DEFAULT_BASE_URL;
+  if (flagIndex === -1) return DEFAULT_BASE_URL;
   const value = argv[flagIndex + 1];
   if (!value) throw new Error('--base needs a URL');
   return value.replace(/\/$/, '');

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -839,6 +839,26 @@ export default defineConfig({
         dependsOn: ['db:up', 'mobile:web-runtime:install'],
         cache: false,
       },
+
+      // --- Post-deploy production smokes ---
+      // Read-only reachability checks against a deployed host. Run by
+      // production-deploy.yml after each deploy; safe to run by hand against
+      // production or a preview (`vp run smoke:production -- --base https://…`).
+      // Never cached — the point is to observe the live deploy, not to memoise
+      // an answer from the last one.
+      'smoke:production': {
+        command: 'tsx scripts/production-smoke.ts',
+        cache: false,
+      },
+      // Browser boot check for app.boardsesh.com — proves the bundle evaluates
+      // and React mounts, which the curl smoke in production-deploy.yml cannot
+      // see. Uses its own Playwright config (no globalSetup, no webServer) so
+      // it can never seed or sign in against a production host.
+      'smoke:app-boot': {
+        command:
+          'cd packages/web && PLAYWRIGHT_TEST_BASE_URL=${PLAYWRIGHT_TEST_BASE_URL:-https://app.boardsesh.com} bunx playwright test --config=playwright.production.config.ts',
+        cache: false,
+      },
     },
   },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -854,9 +854,11 @@ export default defineConfig({
       // and React mounts, which the curl smoke in production-deploy.yml cannot
       // see. Uses its own Playwright config (no globalSetup, no webServer) so
       // it can never seed or sign in against a production host.
+      // To point this at a preview instead, run playwright directly with
+      // PLAYWRIGHT_TEST_BASE_URL set — the config requires it and says so.
       'smoke:app-boot': {
         command:
-          'cd packages/web && PLAYWRIGHT_TEST_BASE_URL=${PLAYWRIGHT_TEST_BASE_URL:-https://app.boardsesh.com} bunx playwright test --config=playwright.production.config.ts',
+          'cd packages/web && PLAYWRIGHT_TEST_BASE_URL=https://app.boardsesh.com bunx playwright test --config=playwright.production.config.ts',
         cache: false,
       },
     },


### PR DESCRIPTION
Part of the Expo Web Program phases 4–6 (W-04). Post-deploy verification for both production hosts.

## www had no post-deploy check at all

`deploy-web` ended at `vercel deploy` and reported success. A deploy that built and uploaded cleanly but 500s on every request looked identical to a healthy one, and the first signal would have been a user.

`scripts/production-smoke.ts` now runs after the deploy and checks the surfaces that carry organic traffic or that other systems depend on:

| Check | Why it's here |
|---|---|
| `/` → 200 + a server-rendered `<h1>` | A spinner-only shell 200s. The `<h1>` is the cheapest proof SSR still works. |
| `/robots.txt` → 200 + `Sitemap:` | Silent loss of the sitemap pointer is invisible for weeks. |
| `/sitemap.xml` → 200 + ≥1 `<loc>` | An empty sitemap still parses. |
| `/api/auth/session` → 200 JSON | The SPA's identity provider. `www` down means nobody signs into the app. |
| `/api/internal/ws-auth` → 200 with `authenticated:false` | Kiosks and embeds open a presence socket with **no** session. If this 401s, every unattended gym screen goes dark and nobody is watching a kiosk to report it. |
| `/kiosk/{gym}`, `/embed/board/{uuid}` | 200 + `text/html` + a body-size floor, because a Next error shell is a well-formed 200 HTML document. Fixture-backed, skipped unless configured (below). |

Two deliberate safety properties:

- **It runs after the deploy, so it is a detector, not a gate.** It turns the job red and fires `notify-failure`, but it can never block a deploy from shipping. #3977 stopped production deploys for two days by being fail-closed; that cure was worse than the disease.
- **Missing fixture config skips, never fails.** `SMOKE_KIOSK_GYM_SLUG` / `SMOKE_EMBED_BOARD_UUID` are repo variables; unset means those two checks report `--`. A red deploy because someone forgot a variable is the same failure mode in a smaller costume. Set them to turn the checks on — no code change needed.

It's also skipped when an instant rollback is pinned: that path deploys with `--skip-domain`, so `www` is still serving the rolled-back build and smoking it would report on a deployment this job didn't promote.

## The app host could boot broken and still pass

`deploy-app-web`'s existing curl smoke (six checks, added in #4065) proves the transport layer — shell 200s, deep route falls back, WASM serves, hashed asset is immutable. It cannot prove the bundle *evaluates*. A JS chunk can serve with perfect headers and still throw on evaluation, and `_redirects`' `/* /index.html 200` means a missing route answers 200 too. Both look healthy to curl and blank to a user.

So there's now a real browser in front of it: navigate, wait for React to mount into `#root`, assert it rendered visible text, and fail on any uncaught `pageerror`.

This runs under a **separate** `playwright.production.config.ts`, not a new project in the existing config. That config declares `globalSetup`, which seeds data and signs the test user in against whatever `baseURL` resolves to — pointing it at production would write to production, and Playwright has no per-project opt-out for `globalSetup`. The only safe answer is a config that never declares one. It also declares no `webServer`, so it can't silently smoke localhost instead of the deploy.

## The homepage had no `<h1>`

Found by running the smoke against production before wiring it up — the first run failed on the homepage check. Verified against the live HTML: `www.boardsesh.com/` server-renders **zero `<h1>` and zero `<h2>`**, only an `<h5>`.

The hero title is `<Typography variant="h5">`, and MUI maps `variant` to a matching element, so it rendered a literal `<h5>`. The site's highest-traffic indexable page had no top-level heading for a crawler to read. Fixed with `component="h1"` — visually identical, semantically correct — plus a unit test, because nothing visual changes if it regresses.

This is adjacent to W-04's stated scope. I fixed it here rather than filing it because the alternative was weakening the smoke to match a broken page, and a check written around a known defect stops being a check.

## What a reviewer should check

- The rollback guard: with `check-rollback.outputs.active == 'true'`, the www smoke step skips.
- `scripts/production-smoke.test.ts` — each check must reject a realistic failure, not just accept a healthy response. The ws-auth case is the interesting one: a 200 that returns an error page instead of JSON, which a status-only check would wave through.
- Nothing in `e2e/production/` can reach `globalSetup`. The `chromium` project's `testIgnore` also excludes it, so a normal e2e run won't try it against localhost.

Run it by hand any time: `vp run smoke:production`, or `vp run smoke:production -- --base https://<preview>`.

## Release Notes

none
