### PR TITLE
fix(mobile): ignore displaced iOS BLE failures

### DIFF
--- a/packages/mobile/ios-tests/BoardBleDisconnectTests.swift
+++ b/packages/mobile/ios-tests/BoardBleDisconnectTests.swift
@@ -641,8 +641,9 @@ final class BoardBleDisconnectTests: XCTestCase {
         XCTAssertEqual(connectedEventCount, 0)
         XCTAssertEqual(disconnectEventCount, 0)
 
-        // A one-shot timer cannot settle B, reconnect, disconnect, or cancel
-        // again after it has already produced the new barrier.
+        // A duplicate fire is inert at the timer itself (FakeOneShotTimer
+        // mirrors a real one-shot DispatchSourceTimer), so it cannot settle B,
+        // reconnect, disconnect, or cancel again.
         manager.testHooks.sync {
             retryTimeout?.fire()
         }
@@ -712,6 +713,131 @@ final class BoardBleDisconnectTests: XCTestCase {
         XCTAssertTrue(manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds.isEmpty })
         XCTAssertEqual(retryResults.count, 1)
         XCTAssertEqual(connectedPeripheralIds, [peripheral.identifier, peripheral.identifier])
+        XCTAssertEqual(disconnectEventCount, 0)
+    }
+
+    func testDisplacedDidDisconnectSwallowThenGenuineDidFailSettlesRetryImmediately() {
+        let peripheral = FakeWritablePeripheral()
+        let genuineFailure = NSError(
+            domain: "BoardBleDisconnectTests",
+            code: 93,
+            userInfo: [NSLocalizedDescriptionKey: "Genuine retry failure"]
+        )
+        var firstConnectError: Error?
+        var retryResults: [Result<Void, Error>] = []
+        var disconnectEventCount = 0
+        manager.testHooks.sync {
+            manager.setEventHandlers(
+                onScanResult: nil,
+                onDisconnect: { _, _ in disconnectEventCount += 1 },
+                onConnected: nil
+            )
+            manager.testHooks.setDiscoveredPeripheral(peripheral)
+            manager.connect(deviceId: peripheral.identifier.uuidString) { result in
+                if case .failure(let error) = result { firstConnectError = error }
+            }
+        }
+
+        // Attempt A times out, its cancellation barrier expires without a
+        // terminal callback, and retry B displaces the expired barrier.
+        fireLatestOneShot(label: "connectTimeout")
+        XCTAssertEqual(
+            firstConnectError?.localizedDescription,
+            BoardBleError.connectTimedOut.localizedDescription
+        )
+        fireLatestOneShot(label: "managerCancellationBarrierWatchdog")
+        manager.testHooks.sync {
+            manager.connect(deviceId: peripheral.identifier.uuidString) { retryResults.append($0) }
+        }
+        XCTAssertEqual(connectedPeripheralIds, [peripheral.identifier, peripheral.identifier])
+
+        // A's late didDisconnect is the one unattributable callback after the
+        // displacement: swallowed, tombstone consumed, retry B untouched.
+        manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: nil)
+        XCTAssertTrue(retryResults.isEmpty)
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.hasPendingConnect })
+        XCTAssertEqual(disconnectEventCount, 0)
+        XCTAssertEqual(cancelledPeripheralIds, [peripheral.identifier])
+        XCTAssertTrue(
+            manager.testHooks.sync { manager.testHooks.displacedCancellationPeripheralIds.isEmpty }
+        )
+
+        // The swallow is single-shot: B's own genuine didFailToConnect now
+        // settles B immediately with the real error — no timeout wait.
+        manager.testHooks.fireDidFailToConnect(peripheral: peripheral, error: genuineFailure)
+        XCTAssertEqual(retryResults.count, 1)
+        if case .failure(let error) = retryResults[0] {
+            XCTAssertEqual(error.localizedDescription, genuineFailure.localizedDescription)
+        } else {
+            XCTFail("expected retry B to fail with the genuine error")
+        }
+        XCTAssertFalse(manager.testHooks.sync { manager.testHooks.hasPendingConnect })
+        XCTAssertNil(manager.connectedDeviceId)
+        XCTAssertNil(
+            manager.testHooks.sync { manager.testHooks.peripheralGeneration(for: peripheral.identifier) }
+        )
+        XCTAssertTrue(scheduler.lastOneShot(label: "connectTimeout")?.cancelled ?? false)
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds.isEmpty })
+        XCTAssertEqual(cancelledPeripheralIds, [peripheral.identifier])
+        XCTAssertEqual(disconnectEventCount, 0)
+    }
+
+    func testDisplacedDidFailSwallowThenRetryDidConnectSucceeds() {
+        let peripheral = FakeWritablePeripheral()
+        let lateFailure = NSError(
+            domain: "BoardBleDisconnectTests",
+            code: 94,
+            userInfo: [NSLocalizedDescriptionKey: "Late displaced failure"]
+        )
+        var firstConnectError: Error?
+        var retryResults: [Result<Void, Error>] = []
+        var disconnectEventCount = 0
+        manager.testHooks.sync {
+            manager.setEventHandlers(
+                onScanResult: nil,
+                onDisconnect: { _, _ in disconnectEventCount += 1 },
+                onConnected: nil
+            )
+            manager.testHooks.setDiscoveredPeripheral(peripheral)
+            manager.connect(deviceId: peripheral.identifier.uuidString) { result in
+                if case .failure(let error) = result { firstConnectError = error }
+            }
+        }
+
+        // Attempt A times out, its cancellation barrier expires without a
+        // terminal callback, and retry B displaces the expired barrier.
+        fireLatestOneShot(label: "connectTimeout")
+        XCTAssertEqual(
+            firstConnectError?.localizedDescription,
+            BoardBleError.connectTimedOut.localizedDescription
+        )
+        fireLatestOneShot(label: "managerCancellationBarrierWatchdog")
+        manager.testHooks.sync {
+            manager.connect(deviceId: peripheral.identifier.uuidString) { retryResults.append($0) }
+        }
+
+        // A late didFailToConnect (the release-note scenario) is swallowed and
+        // must not knock out retry B: no settlement, no OS-level cancel.
+        manager.testHooks.fireDidFailToConnect(peripheral: peripheral, error: lateFailure)
+        XCTAssertTrue(retryResults.isEmpty)
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.hasPendingConnect })
+        XCTAssertEqual(cancelledPeripheralIds, [peripheral.identifier])
+        XCTAssertTrue(
+            manager.testHooks.sync { manager.testHooks.displacedCancellationPeripheralIds.isEmpty }
+        )
+
+        // B's own didConnect + readiness completes the reconnect end-to-end.
+        manager.testHooks.fireDidConnect(peripheral: peripheral)
+        manager.testHooks.fireConnectionReady(
+            peripheral: peripheral,
+            characteristic: makeWriteCharacteristic()
+        )
+        XCTAssertEqual(retryResults.count, 1)
+        if case .failure(let error) = retryResults[0] {
+            XCTFail("expected retry B to succeed after the swallowed late failure, got \(error)")
+        }
+        XCTAssertEqual(manager.connectedDeviceId, peripheral.identifier.uuidString)
+        XCTAssertEqual(cancelledPeripheralIds, [peripheral.identifier])
         XCTAssertEqual(disconnectEventCount, 0)
     }
 

--- a/packages/mobile/ios-tests/BoardBleDisconnectTests.swift
+++ b/packages/mobile/ios-tests/BoardBleDisconnectTests.swift
@@ -540,6 +540,181 @@ final class BoardBleDisconnectTests: XCTestCase {
         XCTAssertEqual(disconnectEventCount, 0)
     }
 
+    func testConnectTimeoutThenExpiredBarrierSwallowsAmbiguousDidFailUntilRetryTimesOut() {
+        let peripheral = FakeWritablePeripheral()
+        let lateFailure = NSError(
+            domain: "BoardBleDisconnectTests",
+            code: 92,
+            userInfo: [NSLocalizedDescriptionKey: "Ambiguous terminal failure"]
+        )
+        var firstConnectError: Error?
+        var retryResults: [Result<Void, Error>] = []
+        var disconnectEventCount = 0
+        var connectedEventCount = 0
+        manager.testHooks.sync {
+            manager.setEventHandlers(
+                onScanResult: nil,
+                onDisconnect: { _, _ in disconnectEventCount += 1 },
+                onConnected: { _, _ in connectedEventCount += 1 }
+            )
+            manager.testHooks.setDiscoveredPeripheral(peripheral)
+            manager.connect(deviceId: peripheral.identifier.uuidString) { result in
+                if case .failure(let error) = result { firstConnectError = error }
+            }
+        }
+
+        // Attempt A times out, its cancellation barrier expires without a
+        // terminal callback, and retry B displaces the expired barrier.
+        fireLatestOneShot(label: "connectTimeout")
+        XCTAssertEqual(
+            firstConnectError?.localizedDescription,
+            BoardBleError.connectTimedOut.localizedDescription
+        )
+        fireLatestOneShot(label: "managerCancellationBarrierWatchdog")
+        manager.testHooks.sync {
+            manager.connect(deviceId: peripheral.identifier.uuidString) { retryResults.append($0) }
+        }
+
+        let retryGeneration = manager.testHooks.sync {
+            manager.testHooks.peripheralGeneration(for: peripheral.identifier)
+        }
+        let retryTimeout = scheduler.lastOneShot(label: "connectTimeout")
+        XCTAssertNotNil(retryGeneration)
+        XCTAssertFalse(retryTimeout?.cancelled ?? true)
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.displacedCancellationPeripheralIds },
+            Set([peripheral.identifier])
+        )
+
+        // CoreBluetooth supplies no attempt identity. This first terminal
+        // callback after displacement is unattributable and conservatively
+        // swallowed, even though it could be B's genuine failure. B keeps its
+        // generation, timeout, pending completion, and concrete OS-level connect;
+        // B's still-live timeout settles it once.
+        manager.testHooks.fireDidFailToConnect(peripheral: peripheral, error: lateFailure)
+
+        XCTAssertTrue(retryResults.isEmpty)
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.hasPendingConnect })
+        XCTAssertEqual(manager.connectedDeviceId, peripheral.identifier.uuidString)
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.peripheralGeneration(for: peripheral.identifier) },
+            retryGeneration
+        )
+        XCTAssertFalse(retryTimeout?.cancelled ?? true)
+        XCTAssertEqual(disconnectEventCount, 0)
+        XCTAssertEqual(connectedEventCount, 0)
+        XCTAssertEqual(cancelledPeripheralIds, [peripheral.identifier])
+        XCTAssertTrue(
+            manager.testHooks.sync { manager.testHooks.displacedCancellationPeripheralIds.isEmpty }
+        )
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds.isEmpty })
+
+        // The still-live retry timeout is the only settlement path. It fails B
+        // exactly once, issues B's one required cancellation, clears the
+        // tombstone, and installs B's new cancellation barrier for the next
+        // terminal callback.
+        manager.testHooks.sync {
+            retryTimeout?.fire()
+        }
+        XCTAssertEqual(retryResults.count, 1)
+        if case .failure(let error) = retryResults[0] {
+            XCTAssertEqual(error.localizedDescription, BoardBleError.connectTimedOut.localizedDescription)
+        } else {
+            XCTFail("expected retry B to time out")
+        }
+        XCTAssertFalse(manager.testHooks.sync { manager.testHooks.hasPendingConnect })
+        XCTAssertNil(manager.connectedDeviceId)
+        XCTAssertNil(
+            manager.testHooks.sync { manager.testHooks.peripheralGeneration(for: peripheral.identifier) }
+        )
+        XCTAssertTrue(
+            manager.testHooks.sync { manager.testHooks.displacedCancellationPeripheralIds.isEmpty }
+        )
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds },
+            Set([peripheral.identifier])
+        )
+        XCTAssertEqual(scheduler.oneShots(label: "managerCancellationBarrierWatchdog").count, 2)
+        XCTAssertFalse(scheduler.lastOneShot(label: "managerCancellationBarrierWatchdog")?.cancelled ?? true)
+        XCTAssertEqual(cancelledPeripheralIds, [peripheral.identifier, peripheral.identifier])
+        XCTAssertEqual(connectedPeripheralIds, [peripheral.identifier, peripheral.identifier])
+        XCTAssertEqual(connectedEventCount, 0)
+        XCTAssertEqual(disconnectEventCount, 0)
+
+        // A one-shot timer cannot settle B, reconnect, disconnect, or cancel
+        // again after it has already produced the new barrier.
+        manager.testHooks.sync {
+            retryTimeout?.fire()
+        }
+        XCTAssertEqual(retryResults.count, 1)
+        XCTAssertEqual(cancelledPeripheralIds, [peripheral.identifier, peripheral.identifier])
+        XCTAssertEqual(connectedEventCount, 0)
+        XCTAssertEqual(disconnectEventCount, 0)
+    }
+
+    func testRetryTimeoutClearsDisplacedTombstoneBeforeRegisteringNewBarrier() {
+        let peripheral = FakeWritablePeripheral()
+        var firstConnectError: Error?
+        var retryResults: [Result<Void, Error>] = []
+        var disconnectEventCount = 0
+        manager.testHooks.sync {
+            manager.setEventHandlers(
+                onScanResult: nil,
+                onDisconnect: { _, _ in disconnectEventCount += 1 },
+                onConnected: nil
+            )
+            manager.testHooks.setDiscoveredPeripheral(peripheral)
+            manager.connect(deviceId: peripheral.identifier.uuidString) { result in
+                if case .failure(let error) = result { firstConnectError = error }
+            }
+        }
+
+        fireLatestOneShot(label: "connectTimeout")
+        XCTAssertEqual(
+            firstConnectError?.localizedDescription,
+            BoardBleError.connectTimedOut.localizedDescription
+        )
+        fireLatestOneShot(label: "managerCancellationBarrierWatchdog")
+        manager.testHooks.sync {
+            manager.connect(deviceId: peripheral.identifier.uuidString) { retryResults.append($0) }
+        }
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.displacedCancellationPeripheralIds },
+            Set([peripheral.identifier])
+        )
+
+        // Retry B also times out before either attempt reports a terminal
+        // callback. Its new barrier owns the next callback, so A's displaced
+        // tombstone must not survive alongside it.
+        fireLatestOneShot(label: "connectTimeout")
+
+        XCTAssertEqual(retryResults.count, 1)
+        if case .failure(let error) = retryResults[0] {
+            XCTAssertEqual(error.localizedDescription, BoardBleError.connectTimedOut.localizedDescription)
+        } else {
+            XCTFail("expected retry B to time out")
+        }
+        XCTAssertEqual(cancelledPeripheralIds, [peripheral.identifier, peripheral.identifier])
+        XCTAssertTrue(
+            manager.testHooks.sync { manager.testHooks.displacedCancellationPeripheralIds.isEmpty }
+        )
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds },
+            Set([peripheral.identifier])
+        )
+        XCTAssertFalse(manager.testHooks.sync { manager.testHooks.hasPendingConnect })
+        XCTAssertNil(
+            manager.testHooks.sync { manager.testHooks.peripheralGeneration(for: peripheral.identifier) }
+        )
+        XCTAssertEqual(disconnectEventCount, 0)
+
+        manager.testHooks.fireDidFailToConnect(peripheral: peripheral, error: BoardBleError.notConnected)
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.managerCancellationBarrierIds.isEmpty })
+        XCTAssertEqual(retryResults.count, 1)
+        XCTAssertEqual(connectedPeripheralIds, [peripheral.identifier, peripheral.identifier])
+        XCTAssertEqual(disconnectEventCount, 0)
+    }
+
     func testStaleDidConnectUnderActiveBarrierStillIssuesConcreteCancel() {
         let peripheral = FakeWritablePeripheral()
         var firstConnectError: Error?

--- a/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
+++ b/packages/mobile/ios-tests/BoardBleWriteFlowTests.swift
@@ -1377,39 +1377,6 @@ final class BoardBleWriteFlowTests: XCTestCase {
         XCTAssertEqual(peripheral.writtenChunks.count, 1)
         XCTAssertEqual(String(data: peripheral.writtenChunks[0].data, encoding: .utf8), "l##")
     }
-}
-
-@available(iOS 17.0, *)
-final class WaiterPoolOutcomeTests: XCTestCase {
-    func testWaitReportsImmediateSignalAndTimeoutOutcomes() async {
-        let queue = DispatchQueue(label: "com.boardsesh.tests.waiter-pool")
-        let pool = WaiterPool(queue: queue)
-
-        let immediateResult = await pool.wait(timeout: 1) { true }
-        let timeoutResult = await pool.wait(timeout: 0) { false }
-        XCTAssertTrue(immediateResult)
-        XCTAssertFalse(timeoutResult)
-    }
-
-    func testWaitReportsExplicitSignal() async {
-        let queue = DispatchQueue(label: "com.boardsesh.tests.waiter-pool-signal")
-        let pool = WaiterPool(queue: queue)
-        let resultTask = Task {
-            await pool.wait(timeout: 1) { false }
-        }
-
-        var waiterWasRegistered = false
-        for _ in 0..<1_000 {
-            waiterWasRegistered = queue.sync { pool.hasPendingWaiters }
-            if waiterWasRegistered { break }
-            await Task.yield()
-        }
-        XCTAssertTrue(waiterWasRegistered)
-        queue.sync { pool.signalAll() }
-
-        let signaledResult = await resultTask.value
-        XCTAssertTrue(signaledResult)
-    }
 
     func testMoonBoardAckWatchdogStartsBoundedConnectionRecovery() {
         let hooks = manager.testHooks
@@ -1448,5 +1415,38 @@ final class WaiterPoolOutcomeTests: XCTestCase {
         XCTAssertNotNil(scheduler.lastOneShot(label: "writeStallRecoveryWatchdog"))
         XCTAssertFalse(hooks.sync { hooks.hasPendingWriteAck })
         XCTAssertEqual(disconnectEventCount, 0)
+    }
+}
+
+@available(iOS 17.0, *)
+final class WaiterPoolOutcomeTests: XCTestCase {
+    func testWaitReportsImmediateSignalAndTimeoutOutcomes() async {
+        let queue = DispatchQueue(label: "com.boardsesh.tests.waiter-pool")
+        let pool = WaiterPool(queue: queue)
+
+        let immediateResult = await pool.wait(timeout: 1) { true }
+        let timeoutResult = await pool.wait(timeout: 0) { false }
+        XCTAssertTrue(immediateResult)
+        XCTAssertFalse(timeoutResult)
+    }
+
+    func testWaitReportsExplicitSignal() async {
+        let queue = DispatchQueue(label: "com.boardsesh.tests.waiter-pool-signal")
+        let pool = WaiterPool(queue: queue)
+        let resultTask = Task {
+            await pool.wait(timeout: 1) { false }
+        }
+
+        var waiterWasRegistered = false
+        for _ in 0..<1_000 {
+            waiterWasRegistered = queue.sync { pool.hasPendingWaiters }
+            if waiterWasRegistered { break }
+            await Task.yield()
+        }
+        XCTAssertTrue(waiterWasRegistered)
+        queue.sync { pool.signalAll() }
+
+        let signaledResult = await resultTask.value
+        XCTAssertTrue(signaledResult)
     }
 }

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -1435,7 +1435,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // CoreBluetooth supplies no attempt identity, so the first terminal
         // callback after an expired barrier is displaced is unattributable and
         // conservatively swallowed. If it was the retry's genuine failure, the
-        // retry's still-live timeout settles it once.
+        // retry's still-live timeout settles it once, with up to the 8-second
+        // connect-timeout latency accepted to avoid failing the wrong attempt.
         if displacedCancellationPeripheralIds.remove(peripheral.identifier) != nil {
             return
         }

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -297,15 +297,11 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     // connect is last-request-wins throughout the manager.
     private var managerCancellationBarriers: [UUID: ManagerCancellationBarrier] = [:]
     // UUIDs whose EXPIRED cancellation barrier was displaced by a fresh explicit
-    // connect (see connectOnBleQueue). The cancelled attempt's terminal callback
-    // usually never arrives — that's why the barrier expired — but if it lands
-    // late it must be ignored: the fresh attempt owns all live state for the
-    // UUID, and without this marker the late didDisconnect would pass the
-    // wasCurrentPeripheral check (the fresh attempt optimistically re-set
-    // connectedPeripheral to the same UUID) and tear the new attempt down.
-    // Cleared by the swallow itself, by the fresh attempt's didConnect
-    // (CoreBluetooth delivers a peripheral's callbacks in order, so the old
-    // attempt's callback cannot arrive after the new attempt's didConnect), and
+    // connect (see connectOnBleQueue). CoreBluetooth supplies no attempt
+    // identity, so the first terminal callback after displacement is
+    // unattributable and conservatively swallowed. If it was the retry's
+    // genuine failure, the retry's still-live timeout settles it once. Cleared
+    // by that swallow, by didConnect, by a newer cancellation barrier, and
     // below .poweredOn (every old link generation is invalid there).
     private var displacedCancellationPeripheralIds: Set<UUID> = []
     private var deferredConnectRequest: DeferredConnectRequest?
@@ -770,9 +766,11 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                 // permanently unconnectable for the rest of the app session
                 // (picker, Live Activity lightbulb, and write-stall recovery
                 // all route through this path). Displace the expired barrier
-                // and proceed with a normal connect; the tombstone below
-                // swallows the old cancel's terminal callback in the unlikely
-                // case it still arrives.
+                // and proceed with a normal connect. CoreBluetooth supplies no
+                // attempt identity, so the first terminal callback after this
+                // displacement is unattributable and conservatively swallowed;
+                // a genuine retry failure remains live for its timeout to
+                // settle once.
                 cancellationBarrier.watchdog?.cancel()
                 managerCancellationBarriers.removeValue(forKey: peripheralId)
                 displacedCancellationPeripheralIds.insert(peripheralId)
@@ -1434,6 +1432,13 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         if consumeManagerCancellationBarrierOnBleQueue(peripheralId: peripheral.identifier) {
             return
         }
+        // CoreBluetooth supplies no attempt identity, so the first terminal
+        // callback after an expired barrier is displaced is unattributable and
+        // conservatively swallowed. If it was the retry's genuine failure, the
+        // retry's still-live timeout settles it once.
+        if displacedCancellationPeripheralIds.remove(peripheral.identifier) != nil {
+            return
+        }
         guard peripheralGenerations[peripheral.identifier] == connectionGeneration else { return }
         // Every connect attempt (user-initiated picker connect, or the Live Activity
         // lightbulb's reconnectToLastKnownBoard) sets pendingConnectCompletion, so a
@@ -1463,11 +1468,11 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             return
         }
 
-        // Late terminal callback from a cancelled attempt whose EXPIRED barrier
-        // was displaced by a fresh explicit connect (see connectOnBleQueue).
-        // The fresh attempt owns all live state for this UUID — without this
-        // check the callback would pass wasCurrentPeripheral (the fresh attempt
-        // re-set connectedPeripheral to the same UUID) and wrongly tear it down.
+        // CoreBluetooth supplies no attempt identity, so the first terminal
+        // callback after an expired barrier is displaced is unattributable and
+        // conservatively swallowed. If it was the retry's genuine failure, the
+        // retry's still-live timeout settles it once. This is the didDisconnect
+        // half of the same tombstone consumed by didFailToConnect above.
         if displacedCancellationPeripheralIds.remove(peripheral.identifier) != nil {
             return
         }
@@ -2593,6 +2598,12 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
     private func registerManagerCancellationBarrierOnBleQueue(peripheralId: UUID) -> Bool {
         guard managerCancellationBarriers[peripheralId] == nil else { return false }
+        // A fresh manager cancellation becomes the sole owner of the next
+        // terminal callback for this UUID. Retire any displaced-attempt
+        // tombstone first so it cannot survive this barrier and swallow a later
+        // genuine terminal callback (for example when the retry itself times
+        // out before either attempt reports one).
+        displacedCancellationPeripheralIds.remove(peripheralId)
         let cancellationBarrier = ManagerCancellationBarrier()
         managerCancellationBarriers[peripheralId] = cancellationBarrier
         cancellationBarrier.watchdog = timerScheduler.scheduleOneShot(

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -1438,6 +1438,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // retry's still-live timeout settles it once, with up to the 8-second
         // connect-timeout latency accepted to avoid failing the wrong attempt.
         if displacedCancellationPeripheralIds.remove(peripheral.identifier) != nil {
+            logger.info("Swallowed unattributable BLE didFailToConnect for displaced \(peripheral.identifier.uuidString, privacy: .public): \(error?.localizedDescription ?? "no error", privacy: .public)")
             return
         }
         guard peripheralGenerations[peripheral.identifier] == connectionGeneration else { return }
@@ -1475,6 +1476,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // retry's still-live timeout settles it once. This is the didDisconnect
         // half of the same tombstone consumed by didFailToConnect above.
         if displacedCancellationPeripheralIds.remove(peripheral.identifier) != nil {
+            logger.info("Swallowed unattributable BLE didDisconnect for displaced \(deviceId, privacy: .public): \(error?.localizedDescription ?? "no error", privacy: .public)")
             return
         }
 


### PR DESCRIPTION
## Summary

- conservatively ignore one unattributed terminal callback after an expired iOS BLE cancellation barrier is displaced by an explicit retry
- keep the retry's generation, timeout, and completion intact, then clear stale tombstones before its own timeout registers a new barrier
- add regressions for late failure, ambiguous failure-to-timeout, late disconnect, and single-settlement behavior
- move the MoonBoard acknowledgement-watchdog test back into the XCTest fixture that owns its manager and scheduler

Follow-up to the post-merge findings on #4152 and the inherited native test compile failure from #4140.

## Validation

- independent adversarial BLE QA passed after one revision
- focused iOS preparation/drift contracts: 15 tests passed
- `vp run typecheck:mobile`
- full mobile suite on the production patch: 577 files, 4,951 tests passed
- iOS and Android `vp run check:mobile-bundle`
- scoped `vp check`, `git diff --check`, and mandatory pre-commit hook
- literal Fable review, macOS XCTest, and physical CoreBluetooth QA remain required before this leaves draft

## Release Notes

- Keep an iPhone board reconnect from being knocked out by a late Bluetooth failure from the previous attempt.