### PR TITLE
fix: stop discarding a new board when you already own that config

### DIFF
--- a/packages/backend/src/__tests__/board-catalog-validation.test.ts
+++ b/packages/backend/src/__tests__/board-catalog-validation.test.ts
@@ -636,7 +636,13 @@ describe('social board create catalog gate', () => {
     const submittedSetIds = `${SET_B_ID},${SET_A_ID},${SET_B_ID}`;
     const created = await socialBoardMutations.createBoard(
       undefined,
-      { input: createInput({ setIds: submittedSetIds }) },
+      // A location name is what puts this on the mint path now. #4166 changed
+      // auto-gym from per-user ("the caller owns no gyms") to per-location, so a
+      // board that says nothing about where it is no longer mints a gym — the
+      // old rule produced one named after the BOARD with null coordinates, which
+      // could never surface in proximity search. The transaction path this test
+      // exists to cover is unchanged; it just needs a place to mint for.
+      { input: createInput({ setIds: submittedSetIds, locationName: 'Catalog Test Gym' }) },
       authCtx(AUTO_GYM_USER_ID),
     );
 

--- a/packages/backend/src/__tests__/board-duplicates.test.ts
+++ b/packages/backend/src/__tests__/board-duplicates.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isSameBoardLocation,
+  findBlockingDuplicate,
+  DUPLICATE_BOARD_RADIUS_METERS,
+} from '../graphql/resolvers/social/board-duplicates';
+
+// Pure — no DB. The rule under test is "same config AND same place", which is
+// what lets a climber own the same board configuration at two different gyms
+// (#4166) while a genuine double-submit is still caught.
+
+const NOWHERE = { latitude: null, longitude: null, locationName: null };
+
+// ~111 m north of the first point (1 degree of latitude ≈ 111.32 km).
+const GYM_A = { latitude: 52.37, longitude: 4.89, locationName: 'Klimmuur' };
+const GYM_A_NEARBY = { latitude: 52.371, longitude: 4.89, locationName: 'Klimmuur' };
+// Roughly 2 km away — a different building.
+const GYM_B = { latitude: 52.388, longitude: 4.89, locationName: 'Boulder Space' };
+
+describe('isSameBoardLocation', () => {
+  describe('when both sides have coordinates', () => {
+    it('treats boards within the radius as the same place', () => {
+      expect(isSameBoardLocation(GYM_A, GYM_A_NEARBY)).toBe(true);
+    });
+
+    it('treats boards beyond the radius as different places', () => {
+      expect(isSameBoardLocation(GYM_A, GYM_B)).toBe(false);
+    });
+
+    it('ignores the location name when coordinates are available', () => {
+      // Same spot, different label — still one place. The reverse (same label,
+      // far apart) is covered by the GYM_A/GYM_B case above.
+      expect(isSameBoardLocation(GYM_A, { ...GYM_A_NEARBY, locationName: 'Something else' })).toBe(true);
+    });
+
+    it('uses a radius the resolver and gym matching agree on', () => {
+      expect(DUPLICATE_BOARD_RADIUS_METERS).toBe(150);
+    });
+  });
+
+  describe('when only names are available', () => {
+    it('matches the same name case- and whitespace-insensitively', () => {
+      expect(
+        isSameBoardLocation(
+          { latitude: null, longitude: null, locationName: 'Boulder Space' },
+          { latitude: null, longitude: null, locationName: '  boulder space  ' },
+        ),
+      ).toBe(true);
+    });
+
+    it('treats different names as different places', () => {
+      expect(
+        isSameBoardLocation(
+          { latitude: null, longitude: null, locationName: 'Boulder Space' },
+          { latitude: null, longitude: null, locationName: 'Klimmuur' },
+        ),
+      ).toBe(false);
+    });
+
+    it('treats a blank name as no name at all', () => {
+      // Both sides are effectively placeless, so they fall through to the
+      // placeless tier and count as the same place.
+      expect(
+        isSameBoardLocation(
+          { latitude: null, longitude: null, locationName: '   ' },
+          { latitude: null, longitude: null, locationName: '' },
+        ),
+      ).toBe(true);
+    });
+
+    it('treats a blank name against a real one as different', () => {
+      expect(
+        isSameBoardLocation(
+          { latitude: null, longitude: null, locationName: '   ' },
+          { latitude: null, longitude: null, locationName: 'Klimmuur' },
+        ),
+      ).toBe(false);
+    });
+  });
+
+  it('treats two placeless boards as the same place', () => {
+    // Nothing distinguishes them, and this is the shape a double-submit takes.
+    expect(isSameBoardLocation(NOWHERE, NOWHERE)).toBe(true);
+  });
+
+  it('treats a placed board and a placeless one as different', () => {
+    // The permissive reading: never silently block a board that says where it is
+    // against one that doesn't.
+    expect(isSameBoardLocation(GYM_A, NOWHERE)).toBe(false);
+    expect(isSameBoardLocation(NOWHERE, GYM_A)).toBe(false);
+  });
+
+  it('treats coordinates-only against name-only as different', () => {
+    expect(
+      isSameBoardLocation(
+        { latitude: 52.37, longitude: 4.89, locationName: null },
+        { latitude: null, longitude: null, locationName: 'Klimmuur' },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('findBlockingDuplicate', () => {
+  it('matches set ids regardless of stored order', () => {
+    // The stored order is whatever the board was created with; the client sends
+    // a canonical order. A raw SQL string compare called these different, which
+    // let a near-duplicate through the guard.
+    const candidates = [{ ...GYM_A, setIds: '25,26,27,24' }];
+    expect(findBlockingDuplicate(candidates, { ...GYM_A, setIds: '24,25,26,27' })).toBe(candidates[0]);
+  });
+
+  it('tolerates whitespace and repeats in set ids', () => {
+    const candidates = [{ ...GYM_A, setIds: ' 26, 24 ,25,24 ' }];
+    expect(findBlockingDuplicate(candidates, { ...GYM_A, setIds: '24,25,26' })).toBe(candidates[0]);
+  });
+
+  it('does not block a different set of holds at the same place', () => {
+    const candidates = [{ ...GYM_A, setIds: '24,25' }];
+    expect(findBlockingDuplicate(candidates, { ...GYM_A, setIds: '24,25,26' })).toBeUndefined();
+  });
+
+  it('does not block the same config at a different place', () => {
+    // The reported bug: a second MoonBoard 2024 at a new gym.
+    const candidates = [{ ...GYM_A, setIds: '24,25,26' }];
+    expect(findBlockingDuplicate(candidates, { ...GYM_B, setIds: '24,25,26' })).toBeUndefined();
+  });
+
+  it('picks the matching candidate out of several', () => {
+    const candidates = [
+      { ...GYM_B, setIds: '24,25,26' },
+      { ...GYM_A, setIds: '24,25,26' },
+    ];
+    expect(findBlockingDuplicate(candidates, { ...GYM_A, setIds: '24,25,26' })).toBe(candidates[1]);
+  });
+
+  it('returns undefined when the owner has no boards of this config', () => {
+    expect(findBlockingDuplicate([], { ...GYM_A, setIds: '24,25,26' })).toBeUndefined();
+  });
+});

--- a/packages/backend/src/__tests__/board-gym-edit-authorization.test.ts
+++ b/packages/backend/src/__tests__/board-gym-edit-authorization.test.ts
@@ -743,6 +743,11 @@ describe('community moderators cannot delete boards/gyms or link boards', () => 
   });
 
   it('rejects a moderator linking their own board into a gym they do not own/admin', async () => {
+    // Neither this board nor kilterGym carries coordinates, so the self-service
+    // proximity path added in #4166 cannot apply and the owner/admin gate is the
+    // only way in. A community role still grants no gym-management power: what
+    // that change opened up is available to every board owner equally (their own
+    // board, within 150 m of a PUBLIC gym), never to moderators as moderators.
     const adminBoardUuid = uuidv4();
     await db.execute(sql`
       INSERT INTO user_boards
@@ -755,6 +760,10 @@ describe('community moderators cannot delete boards/gyms or link boards', () => 
         { input: { boardUuid: adminBoardUuid, gymUuid: kilterGymUuid } },
         authCtx(GLOBAL_ADMIN),
       ),
-    ).rejects.toThrow(/Not authorized: must be gym owner or admin/);
+    ).rejects.toThrow(/Not authorized to link board to this gym/);
+
+    // Assert the outcome, not just the message — the board must stay unlinked.
+    const linked = await db.execute(sql`SELECT gym_id FROM user_boards WHERE uuid = ${adminBoardUuid}`);
+    expect(Array.from(linked as Iterable<{ gym_id: number | null }>)[0]?.gym_id).toBeNull();
   });
 });

--- a/packages/backend/src/__tests__/board-gym-self-link.test.ts
+++ b/packages/backend/src/__tests__/board-gym-self-link.test.ts
@@ -151,6 +151,17 @@ describe('linkBoardToGym — self-service proximity path', () => {
     await expect(linkBoardToGym(fourth, gym.uuid, OWNER)).resolves.toBe(true);
   });
 
+  it('does not charge a gym owner the self-service rate bucket', async () => {
+    // The 5/min bucket belongs to the non-owner path. Charging it at the call
+    // site throttled a gym owner adding a sixth board to their OWN gym, under a
+    // limit named for a path they were never on.
+    const gym = await insertGym({ ownerId: OWNER, name: 'My Gym' });
+    for (let index = 0; index < 8; index++) {
+      const boardUuid = await insertBoard({ ownerId: OWNER });
+      await expect(linkBoardToGym(boardUuid, gym.uuid, OWNER)).resolves.toBe(true);
+    }
+  });
+
   it('unlinking stays the board owner’s own call and needs no proximity', async () => {
     const gym = await insertGym({ ownerId: STRANGER, name: 'Klimmuur', ...BASE });
     const boardUuid = await insertBoard({ ownerId: OWNER, latitude: LAT_60M, longitude: BASE.longitude });

--- a/packages/backend/src/__tests__/board-gym-self-link.test.ts
+++ b/packages/backend/src/__tests__/board-gym-self-link.test.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { sql } from 'drizzle-orm';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { db } from '../db/client';
-import { socialGymMutations } from '../graphql/resolvers/social/gyms';
+import { socialGymMutations, MAX_BOARDS_PER_FOREIGN_GYM } from '../graphql/resolvers/social/gyms';
 import { socialGymStrayBoardMutations } from '../graphql/resolvers/social/gym-stray-boards';
 import { resetAllRateLimits } from '../utils/rate-limiter';
 
@@ -121,6 +121,44 @@ describe('linkBoardToGym — self-service proximity path', () => {
     const boardUuid = await insertBoard({ ownerId: OWNER, latitude: LAT_60M, longitude: BASE.longitude });
 
     await expect(linkBoardToGym(boardUuid, gym.uuid, OWNER)).rejects.toThrow(/Gym not found/);
+  });
+
+  it('does not spend the rate bucket on a private gym, so it cannot be told from a missing one', async () => {
+    // The shared message alone isn't enough. A missing gym throws before the
+    // bucket is charged, so charging on the private branch let an attacker
+    // distinguish the two: probe five times, then watch whether a sixth call
+    // reports a rate limit ("live private gym") or a plain refusal ("no such gym").
+    const privateGym = await insertGym({
+      ownerId: STRANGER,
+      name: 'Secret Home Wall',
+      ...BASE,
+      isPublic: false,
+    });
+    const boardUuid = await insertBoard({ ownerId: OWNER, latitude: LAT_60M, longitude: BASE.longitude });
+
+    for (let probe = 0; probe < 6; probe++) {
+      await expect(linkBoardToGym(boardUuid, privateGym.uuid, OWNER)).rejects.toThrow(/Gym not found/);
+    }
+
+    // Bucket untouched, so a genuine self-service link still goes through.
+    const publicGym = await insertGym({ ownerId: STRANGER, name: 'Klimmuur', ...BASE });
+    await expect(linkBoardToGym(boardUuid, publicGym.uuid, OWNER)).resolves.toBe(true);
+  });
+
+  it('caps how many of one owner’s boards can be listed at a single foreign gym', async () => {
+    // The distinct-gym cap deliberately excludes the gym being linked, so without
+    // this one a single listing could be flooded without limit.
+    const gym = await insertGym({ ownerId: STRANGER, name: 'Klimmuur', ...BASE });
+    for (let index = 0; index < MAX_BOARDS_PER_FOREIGN_GYM; index++) {
+      const boardUuid = await insertBoard({ ownerId: OWNER, latitude: LAT_60M, longitude: BASE.longitude });
+      await expect(linkBoardToGym(boardUuid, gym.uuid, OWNER)).resolves.toBe(true);
+    }
+
+    // Filling the cap also spends the 5/min bucket, which would mask the refusal
+    // under test. Clear it so the assertion is about the depth cap alone.
+    resetAllRateLimits();
+    const overflow = await insertBoard({ ownerId: OWNER, latitude: LAT_60M, longitude: BASE.longitude });
+    await expect(linkBoardToGym(overflow, gym.uuid, OWNER)).rejects.toThrow(/Not authorized to link board/);
   });
 
   it("refuses to move somebody else's board, however close it is", async () => {

--- a/packages/backend/src/__tests__/board-gym-self-link.test.ts
+++ b/packages/backend/src/__tests__/board-gym-self-link.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach } from 'vite-plus/test';
+import { v4 as uuidv4 } from 'uuid';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { socialGymMutations } from '../graphql/resolvers/social/gyms';
+import { socialGymStrayBoardMutations } from '../graphql/resolvers/social/gym-stray-boards';
+import { resetAllRateLimits } from '../utils/rate-limiter';
+
+/**
+ * The self-service half of `requireBoardGymLinkAccess` (#4166): a climber can
+ * list their own board at the gym they actually climb at, without being staff
+ * there. Before this, `linkBoardToGym` was owner/admin-only, which made the main
+ * use case — "there's a MoonBoard at this gym someone else listed" — impossible.
+ *
+ * Proximity is friction, not a security boundary (board coordinates come from
+ * the caller), so the tests below pin the things that actually bound it: public
+ * gyms only, own boards only, a per-caller cap, and a gym-side detach.
+ */
+
+const OWNER = 'self-link-owner';
+const STRANGER = 'self-link-stranger';
+const ALL_USERS = [OWNER, STRANGER];
+
+const BASE = { latitude: 47.0, longitude: 8.0 };
+const LAT_60M = 47.0 + 0.00054; // ~60 m — inside the 150 m radius
+const LAT_300M = 47.0 + 0.0027; // ~301 m — outside it
+
+let connectionCounter = 0;
+const authCtx = (userId: string): ConnectionContext =>
+  ({ connectionId: `conn-${userId}-${connectionCounter++}`, isAuthenticated: true, userId }) as ConnectionContext;
+
+const insertUser = (id: string) =>
+  db.execute(sql`
+    INSERT INTO "users" (id, email, name, created_at, updated_at)
+    VALUES (${id}, ${id + '@test.com'}, ${'User ' + id}, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `);
+
+const insertGym = async (opts: {
+  ownerId: string;
+  name: string;
+  latitude?: number | null;
+  longitude?: number | null;
+  isPublic?: boolean;
+}): Promise<{ id: number; uuid: string }> => {
+  const { ownerId, name, latitude = null, longitude = null, isPublic = true } = opts;
+  const uuid = uuidv4();
+  const result = await db.execute(sql`
+    INSERT INTO gyms (uuid, name, slug, owner_id, is_public, latitude, longitude, created_at, updated_at)
+    VALUES (${uuid}, ${name}, ${uuid}, ${ownerId}, ${isPublic}, ${latitude}, ${longitude}, now(), now())
+    RETURNING id
+  `);
+  return { id: Number(Array.from(result as Iterable<{ id: number }>)[0].id), uuid };
+};
+
+let boardConfigCounter = 0;
+const insertBoard = async (opts: {
+  ownerId: string;
+  latitude?: number | null;
+  longitude?: number | null;
+  gymId?: number | null;
+}): Promise<string> => {
+  const { ownerId, latitude = null, longitude = null, gymId = null } = opts;
+  const uuid = uuidv4();
+  await db.execute(sql`
+    INSERT INTO user_boards
+      (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, is_public, latitude, longitude, gym_id, created_at, updated_at)
+    VALUES (${uuid}, ${uuid}, ${ownerId}, 'kilter', 1, ${700 + boardConfigCounter++}, '1,2', 'A board', true,
+            ${latitude}, ${longitude}, ${gymId}, now(), now())
+  `);
+  return uuid;
+};
+
+const gymIdOfBoard = async (uuid: string): Promise<number | null> => {
+  const result = await db.execute(sql`SELECT gym_id FROM user_boards WHERE uuid = ${uuid}`);
+  const value = Array.from(result as Iterable<{ gym_id: number | string | null }>)[0]?.gym_id;
+  return value == null ? null : Number(value);
+};
+
+const linkBoardToGym = (boardUuid: string, gymUuid: string | null, userId: string) =>
+  socialGymMutations.linkBoardToGym(null, { input: { boardUuid, gymUuid } }, authCtx(userId)) as Promise<boolean>;
+
+beforeEach(async () => {
+  resetAllRateLimits();
+  await db.execute(sql`
+    TRUNCATE TABLE "community_roles", "gym_members", "gym_follows", "user_boards", "gyms"
+    RESTART IDENTITY CASCADE
+  `);
+  await Promise.all(ALL_USERS.map(insertUser));
+});
+
+describe('linkBoardToGym — self-service proximity path', () => {
+  it("links your own board to a stranger's public gym 60 m away", async () => {
+    const gym = await insertGym({ ownerId: STRANGER, name: 'Klimmuur', ...BASE });
+    const boardUuid = await insertBoard({ ownerId: OWNER, latitude: LAT_60M, longitude: BASE.longitude });
+
+    await expect(linkBoardToGym(boardUuid, gym.uuid, OWNER)).resolves.toBe(true);
+    expect(await gymIdOfBoard(boardUuid)).toBe(gym.id);
+  });
+
+  it('refuses when the board is 300 m away', async () => {
+    const gym = await insertGym({ ownerId: STRANGER, name: 'Klimmuur', ...BASE });
+    const boardUuid = await insertBoard({ ownerId: OWNER, latitude: LAT_300M, longitude: BASE.longitude });
+
+    await expect(linkBoardToGym(boardUuid, gym.uuid, OWNER)).rejects.toThrow(/Not authorized to link board/);
+    expect(await gymIdOfBoard(boardUuid)).toBeNull();
+  });
+
+  it('refuses when the board has no coordinates to check', async () => {
+    const gym = await insertGym({ ownerId: STRANGER, name: 'Klimmuur', ...BASE });
+    const boardUuid = await insertBoard({ ownerId: OWNER });
+
+    await expect(linkBoardToGym(boardUuid, gym.uuid, OWNER)).rejects.toThrow(/Not authorized to link board/);
+  });
+
+  it("hides a stranger's PRIVATE gym behind 'Gym not found'", async () => {
+    // Must be indistinguishable from a gym that doesn't exist, or this becomes a
+    // probe for private home-wall gyms.
+    const gym = await insertGym({ ownerId: STRANGER, name: 'Secret Home Wall', ...BASE, isPublic: false });
+    const boardUuid = await insertBoard({ ownerId: OWNER, latitude: LAT_60M, longitude: BASE.longitude });
+
+    await expect(linkBoardToGym(boardUuid, gym.uuid, OWNER)).rejects.toThrow(/Gym not found/);
+  });
+
+  it("refuses to move somebody else's board, however close it is", async () => {
+    const gym = await insertGym({ ownerId: STRANGER, name: 'Klimmuur', ...BASE });
+    const strangersBoard = await insertBoard({ ownerId: STRANGER, latitude: LAT_60M, longitude: BASE.longitude });
+
+    await expect(linkBoardToGym(strangersBoard, gym.uuid, OWNER)).rejects.toThrow(
+      /Not authorized to modify this board/,
+    );
+  });
+
+  it('still lets a gym owner link with no coordinates anywhere (no regression)', async () => {
+    const gym = await insertGym({ ownerId: OWNER, name: 'My Gym' });
+    const boardUuid = await insertBoard({ ownerId: OWNER });
+
+    await expect(linkBoardToGym(boardUuid, gym.uuid, OWNER)).resolves.toBe(true);
+    expect(await gymIdOfBoard(boardUuid)).toBe(gym.id);
+  });
+
+  it('counts DISTINCT foreign gyms, so several boards at one gym cost one slot', async () => {
+    const gym = await insertGym({ ownerId: STRANGER, name: 'Klimmuur', ...BASE });
+    for (let index = 0; index < 3; index++) {
+      const boardUuid = await insertBoard({ ownerId: OWNER, latitude: LAT_60M, longitude: BASE.longitude });
+      await expect(linkBoardToGym(boardUuid, gym.uuid, OWNER)).resolves.toBe(true);
+    }
+    // A fourth board at the SAME gym is still fine — the cap is per gym.
+    const fourth = await insertBoard({ ownerId: OWNER, latitude: LAT_60M, longitude: BASE.longitude });
+    await expect(linkBoardToGym(fourth, gym.uuid, OWNER)).resolves.toBe(true);
+  });
+
+  it('unlinking stays the board owner’s own call and needs no proximity', async () => {
+    const gym = await insertGym({ ownerId: STRANGER, name: 'Klimmuur', ...BASE });
+    const boardUuid = await insertBoard({ ownerId: OWNER, latitude: LAT_60M, longitude: BASE.longitude });
+    await linkBoardToGym(boardUuid, gym.uuid, OWNER);
+
+    await expect(linkBoardToGym(boardUuid, null, OWNER)).resolves.toBe(true);
+    expect(await gymIdOfBoard(boardUuid)).toBeNull();
+  });
+});
+
+describe('detachBoardFromGym', () => {
+  const detach = (gymUuid: string, boardUuid: string, userId: string) =>
+    socialGymStrayBoardMutations.detachBoardFromGym(
+      null,
+      { input: { gymUuid, boardUuid } },
+      authCtx(userId),
+    ) as Promise<boolean>;
+
+  it('lets gym staff remove a board someone self-linked', async () => {
+    // The counterbalance to the proximity path: without this, a gym had no way
+    // to undo an unwanted link (only deleteGym cleared gym_id).
+    const gym = await insertGym({ ownerId: STRANGER, name: 'Klimmuur', ...BASE });
+    const boardUuid = await insertBoard({ ownerId: OWNER, latitude: LAT_60M, longitude: BASE.longitude });
+    await linkBoardToGym(boardUuid, gym.uuid, OWNER);
+
+    await expect(detach(gym.uuid, boardUuid, STRANGER)).resolves.toBe(true);
+    expect(await gymIdOfBoard(boardUuid)).toBeNull();
+  });
+
+  it('refuses a caller with no edit access to the gym', async () => {
+    const gym = await insertGym({ ownerId: STRANGER, name: 'Klimmuur', ...BASE });
+    const boardUuid = await insertBoard({ ownerId: OWNER, latitude: LAT_60M, longitude: BASE.longitude });
+    await linkBoardToGym(boardUuid, gym.uuid, OWNER);
+
+    await expect(detach(gym.uuid, boardUuid, OWNER)).rejects.toThrow(/Not authorized to edit this gym/);
+    expect(await gymIdOfBoard(boardUuid)).toBe(gym.id);
+  });
+
+  it('refuses a board that is not listed at this gym', async () => {
+    const gym = await insertGym({ ownerId: STRANGER, name: 'Klimmuur', ...BASE });
+    const unlinked = await insertBoard({ ownerId: OWNER });
+
+    await expect(detach(gym.uuid, unlinked, STRANGER)).rejects.toThrow(/not listed at this gym/);
+  });
+});

--- a/packages/backend/src/__tests__/board-serial-config-preference.test.ts
+++ b/packages/backend/src/__tests__/board-serial-config-preference.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach } from 'vite-plus/test';
+import { v4 as uuidv4 } from 'uuid';
+import { sql } from 'drizzle-orm';
+import { db } from '../db/client';
+import { findOwnActiveBoardByConfig } from '../graphql/resolvers/board-presence/shared';
+
+/**
+ * #4166 dropped the per-owner config unique index, so one owner can now hold
+ * several boards of the same configuration — the same MoonBoard 2024 at home and
+ * at a gym. `findOwnActiveBoardByConfig` backs the BLE serial-bind path, and it
+ * was `.limit(1)` with no ordering, so with two such boards the pick was
+ * arbitrary. Two user-visible failures followed:
+ *
+ *  - picking the board bound to the OTHER controller made `bindOrCreateOwnBoardForSerial`
+ *    throw "already linked to another wall serial" — the climber simply could not
+ *    connect to their own board;
+ *  - picking the wrong unbound board stamped this wall's serial onto it, silently
+ *    misattributing every later presence event and tick.
+ *
+ * The lookup now takes the serial and prefers: bound-to-it → unbound → bound
+ * elsewhere, with `id` breaking ties so repeat calls agree.
+ */
+
+const OWNER = 'serial-pref-owner';
+
+const CONFIG = { boardType: 'kilter', layoutId: 1, sizeId: 42, setIds: '1,2' };
+
+const insertUser = (id: string) =>
+  db.execute(sql`
+    INSERT INTO "users" (id, email, name, created_at, updated_at)
+    VALUES (${id}, ${id + '@test.com'}, ${'User ' + id}, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `);
+
+async function insertBoard(opts: { name: string; serial: string | null }): Promise<number> {
+  const uuid = uuidv4();
+  const [row] = await db.execute(sql`
+    INSERT INTO user_boards
+      (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, serial_number, is_public, created_at, updated_at)
+    VALUES (${uuid}, ${uuid}, ${OWNER}, ${CONFIG.boardType}, ${CONFIG.layoutId}, ${CONFIG.sizeId}, ${CONFIG.setIds},
+            ${opts.name}, ${opts.serial}, true, now(), now())
+    RETURNING id
+  `);
+  return Number((row as { id: number }).id);
+}
+
+const lookup = (preferredSerial?: string) =>
+  findOwnActiveBoardByConfig(OWNER, CONFIG.boardType, CONFIG.layoutId, CONFIG.sizeId, CONFIG.setIds, preferredSerial);
+
+beforeEach(async () => {
+  await db.execute(sql`TRUNCATE TABLE "user_boards" RESTART IDENTITY CASCADE`);
+  await insertUser(OWNER);
+});
+
+describe('findOwnActiveBoardByConfig — serial preference across same-config boards', () => {
+  it('returns the board already bound to this serial, not an arbitrary sibling', async () => {
+    // Insert the bound board SECOND so an unordered `.limit(1)` would tend to
+    // return the other one.
+    const homeId = await insertBoard({ name: 'Home wall', serial: null });
+    const gymId = await insertBoard({ name: 'Gym wall', serial: 'GYM-SERIAL' });
+
+    const found = await lookup('GYM-SERIAL');
+    expect(found?.id).toBe(gymId);
+    expect(found?.id).not.toBe(homeId);
+  });
+
+  it('prefers an UNBOUND board over one bound to a different serial', async () => {
+    // The reported break: connecting a second wall used to hit the board bound to
+    // the first controller and throw "already linked to another wall serial",
+    // locking the climber out of a board they own and could legitimately bind.
+    const boundElsewhereId = await insertBoard({ name: 'Home wall', serial: 'HOME-SERIAL' });
+    const freeId = await insertBoard({ name: 'Gym wall', serial: null });
+
+    const found = await lookup('GYM-SERIAL');
+    expect(found?.id).toBe(freeId);
+    expect(found?.serialNumber).toBeNull();
+    expect(found?.id).not.toBe(boundElsewhereId);
+  });
+
+  it('falls back to a board bound elsewhere only when nothing better exists', async () => {
+    // This is the genuine "already linked to another wall" case, and the caller
+    // still needs to see it so it can refuse.
+    const boundElsewhereId = await insertBoard({ name: 'Home wall', serial: 'HOME-SERIAL' });
+
+    const found = await lookup('GYM-SERIAL');
+    expect(found?.id).toBe(boundElsewhereId);
+    expect(found?.serialNumber).toBe('HOME-SERIAL');
+  });
+
+  it('is deterministic across repeat calls when several boards are unbound', async () => {
+    // Nondeterminism here meant the serial could land on a different board each
+    // attempt. Lowest id wins, consistently.
+    const firstId = await insertBoard({ name: 'Wall A', serial: null });
+    await insertBoard({ name: 'Wall B', serial: null });
+
+    expect((await lookup('NEW-SERIAL'))?.id).toBe(firstId);
+    expect((await lookup('NEW-SERIAL'))?.id).toBe(firstId);
+  });
+
+  it('still finds the single board when the owner has only one', async () => {
+    const onlyId = await insertBoard({ name: 'Only wall', serial: null });
+    expect((await lookup('ANY-SERIAL'))?.id).toBe(onlyId);
+    // And without a preferred serial at all (the pre-existing call shape).
+    expect((await lookup())?.id).toBe(onlyId);
+  });
+
+  it('ignores soft-deleted boards', async () => {
+    const liveId = await insertBoard({ name: 'Live wall', serial: null });
+    const deletedId = await insertBoard({ name: 'Deleted wall', serial: 'GYM-SERIAL' });
+    await db.execute(sql`UPDATE user_boards SET deleted_at = now() WHERE id = ${deletedId}`);
+
+    // Even though the deleted one carries the exact serial.
+    expect((await lookup('GYM-SERIAL'))?.id).toBe(liveId);
+  });
+});

--- a/packages/backend/src/__tests__/create-board-duplicate-guard.test.ts
+++ b/packages/backend/src/__tests__/create-board-duplicate-guard.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { socialBoardMutations } from '../graphql/resolvers/social/boards';
+import { resetAllRateLimits } from '../utils/rate-limiter';
+
+/**
+ * Real-DB coverage for createBoard's duplicate-config guard.
+ *
+ * The rule is "same config AND same place", not "same config" — issue #4166 was
+ * a climber who owned a MoonBoard 2024 Standard at one gym and spent a week
+ * failing to add another at a new gym. The `sameConfigFarApart` case below is
+ * the regression test for that; it fails against the old resolver AND the old
+ * `user_boards_unique_owner_config` index, both of which this change removed.
+ *
+ * Seeds via raw SQL and calls the resolver directly against the per-worker test
+ * DB (plain postgres — no PostGIS), mirroring find-similar-gyms-and-auto-gym.
+ */
+
+const OWNER = 'dup-guard-owner';
+const OTHER = 'dup-guard-other';
+const ALL_USERS = [OWNER, OTHER];
+
+const BASE = { latitude: 47.0, longitude: 8.0 };
+const LAT_60M = 47.0 + 0.00054; // ~60 m — same building
+const LAT_2KM = 47.0 + 0.018; // ~2 km — a different gym
+
+let connectionCounter = 0;
+const authCtx = (userId: string): ConnectionContext =>
+  ({ connectionId: `conn-${userId}-${connectionCounter++}`, isAuthenticated: true, userId }) as ConnectionContext;
+
+const insertUser = (id: string) =>
+  db.execute(sql`
+    INSERT INTO "users" (id, email, name, created_at, updated_at)
+    VALUES (${id}, ${id + '@test.com'}, ${'User ' + id}, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `);
+
+type CreatedBoard = { uuid: string; name: string; gymId: number | null };
+
+/** The same physical configuration every time — the guard's other half is location. */
+const CONFIG = { boardType: 'moonboard', layoutId: 3, sizeId: 1, setIds: '5,6,7,8,9,10' };
+
+const createBoard = (input: Record<string, unknown>, userId = OWNER) =>
+  socialBoardMutations.createBoard(
+    null,
+    { input: { ...CONFIG, name: 'A board', ...input } },
+    authCtx(userId),
+  ) as Promise<CreatedBoard>;
+
+const countBoards = async (): Promise<number> => {
+  const result = await db.execute(sql`SELECT count(*)::int AS count FROM user_boards WHERE deleted_at IS NULL`);
+  return Number(Array.from(result as Iterable<{ count: number }>)[0].count);
+};
+
+/** The thrown GraphQLError's extensions, or null when it wasn't a duplicate rejection. */
+async function captureDuplicate(promise: Promise<unknown>): Promise<Record<string, unknown> | null> {
+  try {
+    await promise;
+    return null;
+  } catch (error) {
+    const extensions = (error as { extensions?: Record<string, unknown> }).extensions;
+    return extensions?.code === 'BOARD_DUPLICATE_CONFIG' ? extensions : null;
+  }
+}
+
+beforeEach(async () => {
+  resetAllRateLimits();
+  await db.execute(sql`
+    TRUNCATE TABLE
+      "community_roles", "gym_members", "gym_follows", "location_sync_gym_sources", "user_boards", "gyms"
+    RESTART IDENTITY CASCADE
+  `);
+  await Promise.all(ALL_USERS.map(insertUser));
+});
+
+describe('createBoard duplicate-config guard', () => {
+  it('rejects the same config at the same coordinates, naming the existing board', async () => {
+    const first = await createBoard({
+      name: 'Klimmuur MoonBoard',
+      locationName: 'Klimmuur',
+      latitude: BASE.latitude,
+      longitude: BASE.longitude,
+    });
+
+    const extensions = await captureDuplicate(
+      createBoard({
+        name: 'Another MoonBoard',
+        locationName: 'Klimmuur',
+        latitude: LAT_60M,
+        longitude: BASE.longitude,
+      }),
+    );
+
+    expect(extensions).not.toBeNull();
+    // The client offers "use that board" straight from the error, so the
+    // existing board's identity has to travel with it.
+    expect(extensions?.existingBoardUuid).toBe(first.uuid);
+    expect(extensions?.existingBoardName).toBe('Klimmuur MoonBoard');
+    expect(extensions?.existingBoardLocationName).toBe('Klimmuur');
+    expect(await countBoards()).toBe(1);
+  });
+
+  it('allows the same config ~2 km away — the #4166 regression', async () => {
+    await createBoard({
+      name: 'Klimmuur MoonBoard',
+      locationName: 'Klimmuur',
+      latitude: BASE.latitude,
+      longitude: BASE.longitude,
+    });
+
+    const second = await createBoard({
+      name: 'Boulder Space MoonBoard',
+      locationName: 'Boulder Space',
+      latitude: LAT_2KM,
+      longitude: BASE.longitude,
+    });
+
+    expect(second.name).toBe('Boulder Space MoonBoard');
+    expect(await countBoards()).toBe(2);
+  });
+
+  it('allows the same config under a different location name when neither has coordinates', async () => {
+    await createBoard({ name: 'Home wall', locationName: 'Garage' });
+    await createBoard({ name: 'Gym wall', locationName: 'Klimmuur' });
+    expect(await countBoards()).toBe(2);
+  });
+
+  it('rejects the same config when neither board says where it is', async () => {
+    await createBoard({ name: 'First' });
+    const extensions = await captureDuplicate(createBoard({ name: 'Second' }));
+    expect(extensions).not.toBeNull();
+    expect(await countBoards()).toBe(1);
+  });
+
+  it('creates anyway when the user confirms it is a different wall', async () => {
+    await createBoard({ name: 'First' });
+    const second = await createBoard({ name: 'Second', allowDuplicateConfig: true });
+    expect(second.name).toBe('Second');
+    expect(await countBoards()).toBe(2);
+  });
+
+  it('creates two identical boards at the same place when confirmed', async () => {
+    // Two of the same wall in one gym is legal. Proves no unique index survives:
+    // with `user_boards_unique_owner_config` in place this fails on a 23505.
+    const shared = { locationName: 'Klimmuur', latitude: BASE.latitude, longitude: BASE.longitude };
+    await createBoard({ name: 'MoonBoard 1', ...shared });
+    await createBoard({ name: 'MoonBoard 2', ...shared, allowDuplicateConfig: true });
+    expect(await countBoards()).toBe(2);
+  });
+
+  it('recognises the same hold sets stored in a different order', async () => {
+    // The old guard compared set_ids as a raw string, so a re-ticked set could
+    // slip past it while the client's normalised check said it was a duplicate.
+    await createBoard({ name: 'First', setIds: '10,9,8,7,6,5' });
+    const extensions = await captureDuplicate(createBoard({ name: 'Second', setIds: '5,6,7,8,9,10' }));
+    expect(extensions).not.toBeNull();
+    expect(await countBoards()).toBe(1);
+  });
+
+  it('does not block one user because another owns the same board', async () => {
+    await createBoard({ name: 'Shared setup' }, OWNER);
+    const other = await createBoard({ name: 'Shared setup' }, OTHER);
+    expect(other.uuid).toBeTruthy();
+    expect(await countBoards()).toBe(2);
+  });
+
+  it('does not block a genuinely different configuration', async () => {
+    await createBoard({ name: 'First' });
+    await createBoard({ name: 'Second', setIds: '5,6,7' });
+    expect(await countBoards()).toBe(2);
+  });
+});

--- a/packages/backend/src/__tests__/find-similar-gyms-and-auto-gym.test.ts
+++ b/packages/backend/src/__tests__/find-similar-gyms-and-auto-gym.test.ts
@@ -526,6 +526,23 @@ describe('createBoard auto-gym — per-location minting', () => {
     expect(board.gymId).toBeNull();
   });
 
+  it('converges onto the caller’s own same-named gym even when that gym has no coordinates', async () => {
+    // Board 1 names a place but can't stamp coordinates (you have to be standing
+    // there), so its gym is minted with none. Board 2 at the same place, this
+    // time with coordinates, must reuse that gym — the SQL bounding box excludes
+    // null-coordinate rows, so filtering there minted a twin.
+    const first = await createBoard({ name: 'First board', locationName: 'Klimmuur' }, authCtx(QUERIER));
+    const afterFirst = await countGyms();
+
+    const second = await createBoard(
+      { name: 'Second board', locationName: 'Klimmuur', latitude: BASE.latitude, longitude: BASE.longitude },
+      authCtx(QUERIER),
+    );
+
+    expect(second.gymId).toBe(first.gymId);
+    expect(await countGyms()).toBe(afterFirst);
+  });
+
   it('stops minting once the caller is at the gym cap, still creating the board', async () => {
     // The runaway backstop. Approximate by design (read outside the insert
     // transaction), so this pins the threshold behaviour, not exactness.

--- a/packages/backend/src/__tests__/find-similar-gyms-and-auto-gym.test.ts
+++ b/packages/backend/src/__tests__/find-similar-gyms-and-auto-gym.test.ts
@@ -437,7 +437,15 @@ describe('createBoard auto-gym — per-location minting', () => {
     const afterFirst = await countGyms();
 
     const second = await createBoard(
-      { name: 'Second board', locationName: 'Klimmuur', latitude: LAT_60M, longitude: BASE.longitude },
+      // Same config at the same place: a real duplicate, which is the user's
+      // call to make. The flag isolates what's under test — gym resolution.
+      {
+        name: 'Second board',
+        locationName: 'Klimmuur',
+        latitude: LAT_60M,
+        longitude: BASE.longitude,
+        allowDuplicateConfig: true,
+      },
       authCtx(QUERIER),
     );
 
@@ -535,7 +543,13 @@ describe('createBoard auto-gym — per-location minting', () => {
     const afterFirst = await countGyms();
 
     const second = await createBoard(
-      { name: 'Second board', locationName: 'Klimmuur', latitude: BASE.latitude, longitude: BASE.longitude },
+      {
+        name: 'Second board',
+        locationName: 'Klimmuur',
+        latitude: BASE.latitude,
+        longitude: BASE.longitude,
+        allowDuplicateConfig: true,
+      },
       authCtx(QUERIER),
     );
 
@@ -567,7 +581,10 @@ describe('createBoard auto-gym — per-location minting', () => {
     expect(await countGyms()).toBe(before + 1);
 
     // A second board at the same typed name converges rather than minting a twin.
-    const second = await createBoard({ name: 'Garage board 2', locationName: 'My Garage' }, authCtx(QUERIER));
+    const second = await createBoard(
+      { name: 'Garage board 2', locationName: 'My Garage', allowDuplicateConfig: true },
+      authCtx(QUERIER),
+    );
     expect(second.gymId).toBe(board.gymId);
     expect(await countGyms()).toBe(before + 1);
   });

--- a/packages/backend/src/__tests__/find-similar-gyms-and-auto-gym.test.ts
+++ b/packages/backend/src/__tests__/find-similar-gyms-and-auto-gym.test.ts
@@ -395,5 +395,145 @@ describe('createBoard auto-gym guard (end-to-end mutation)', () => {
 
     // The board must NOT be linked to the stranger's claimable "Home Wall" pin.
     expect(board.gymId).not.toBe(systemGeneric.id);
+    // ...and a separate gym IS minted for it, so the board still lands somewhere.
+    expect(board.gymId).not.toBeNull();
+  });
+});
+
+/**
+ * Auto-gym resolves per LOCATION, not per user. Until #4166 a gym was minted only
+ * when the caller owned zero gyms, so every second-and-later board landed with
+ * `gym_id = NULL` — 29% of real user boards in production — and showed on the map
+ * as a bare pin instead of under the gym the user had just named.
+ *
+ * These also cover the transaction restructure: the PostGIS `location` writes now
+ * run after the transaction, each guarded. Previously they were inside it, and
+ * since this test DB has no PostGIS the whole mint rolled back — which is why the
+ * mint path had never actually executed under test.
+ */
+describe('createBoard auto-gym — per-location minting', () => {
+  it('mints a SECOND gym for a second board at a different location', async () => {
+    await createBoard(
+      { name: 'First board', locationName: 'Klimmuur', latitude: BASE.latitude, longitude: BASE.longitude },
+      authCtx(QUERIER),
+    );
+    const afterFirst = await countGyms();
+
+    const second = await createBoard(
+      { name: 'Second board', locationName: 'Boulder Space', latitude: LAT_2KM, longitude: BASE.longitude },
+      authCtx(QUERIER),
+    );
+
+    expect(second.gymId).not.toBeNull();
+    expect(await countGyms()).toBe(afterFirst + 1);
+  });
+
+  it('converges a second board at the same named location onto the same gym', async () => {
+    const first = await createBoard(
+      { name: 'First board', locationName: 'Klimmuur', latitude: BASE.latitude, longitude: BASE.longitude },
+      authCtx(QUERIER),
+    );
+    const afterFirst = await countGyms();
+
+    const second = await createBoard(
+      { name: 'Second board', locationName: 'Klimmuur', latitude: LAT_60M, longitude: BASE.longitude },
+      authCtx(QUERIER),
+    );
+
+    expect(second.gymId).toBe(first.gymId);
+    expect(await countGyms()).toBe(afterFirst);
+  });
+
+  it('converges on the caller’s own same-named gym a couple of km away', async () => {
+    const first = await createBoard(
+      { name: 'First board', locationName: 'Klimmuur', latitude: BASE.latitude, longitude: BASE.longitude },
+      authCtx(QUERIER),
+    );
+    const second = await createBoard(
+      { name: 'Second board', locationName: 'Klimmuur', latitude: LAT_2KM, longitude: BASE.longitude },
+      authCtx(QUERIER),
+    );
+    // Within the 5 km own-gym ceiling — one gym, two boards.
+    expect(second.gymId).toBe(first.gymId);
+  });
+
+  it('mints a separate gym for the same name 8 km away', async () => {
+    const first = await createBoard(
+      { name: 'First board', locationName: 'Klimmuur', latitude: BASE.latitude, longitude: BASE.longitude },
+      authCtx(QUERIER),
+    );
+    const second = await createBoard(
+      { name: 'Second board', locationName: 'Klimmuur', latitude: LAT_8KM, longitude: BASE.longitude },
+      authCtx(QUERIER),
+    );
+    expect(second.gymId).not.toBe(first.gymId);
+    expect(second.gymId).not.toBeNull();
+  });
+
+  it('leaves a board with no location at all unlinked', async () => {
+    // Previously this minted a gym named after the BOARD, with null coordinates —
+    // a row that can never appear in proximity search.
+    const before = await countGyms();
+    const board = await createBoard({ name: 'Nameless place board' }, authCtx(QUERIER));
+    expect(board.gymId).toBeNull();
+    expect(await countGyms()).toBe(before);
+  });
+
+  it('attaches on coordinates alone when exactly one nearby gym is reusable', async () => {
+    const systemGym = await insertGym({
+      ownerId: SYSTEM_OWNER,
+      name: 'Boulder Central',
+      latitude: BASE.latitude,
+      longitude: BASE.longitude,
+    });
+    const before = await countGyms();
+
+    const board = await createBoard(
+      { name: 'My Kilter', latitude: LAT_60M, longitude: BASE.longitude },
+      authCtx(QUERIER),
+    );
+
+    expect(board.gymId).toBe(systemGym.id);
+    expect(await countGyms()).toBe(before);
+  });
+
+  it('declines to guess when two nearby gyms are reusable', async () => {
+    await insertGym({
+      ownerId: SYSTEM_OWNER,
+      name: 'Boulder Central',
+      latitude: BASE.latitude,
+      longitude: BASE.longitude,
+    });
+    await insertGym({ ownerId: SYSTEM_OWNER, name: 'Other Wall', latitude: LAT_60M, longitude: BASE.longitude });
+    const before = await countGyms();
+
+    const board = await createBoard(
+      { name: 'My Kilter', latitude: LAT_120M, longitude: BASE.longitude },
+      authCtx(QUERIER),
+    );
+
+    expect(board.gymId).toBeNull();
+    expect(await countGyms()).toBe(before);
+  });
+
+  it('does not attach to another user’s gym on coordinates alone', async () => {
+    await insertGym({ ownerId: OTHER, name: 'Their Gym', latitude: BASE.latitude, longitude: BASE.longitude });
+    const board = await createBoard(
+      { name: 'My Kilter', latitude: LAT_60M, longitude: BASE.longitude },
+      authCtx(QUERIER),
+    );
+    expect(board.gymId).toBeNull();
+  });
+
+  it('mints with null coordinates when only a location name is given', async () => {
+    const before = await countGyms();
+    const board = await createBoard({ name: 'Garage board', locationName: 'My Garage' }, authCtx(QUERIER));
+    expect(board.gymId).not.toBeNull();
+    expect(await countGyms()).toBe(before + 1);
+
+    // A second board at the same typed name converges rather than minting a twin.
+    const second = await createBoard({ name: 'Garage board 2', locationName: 'My Garage' }, authCtx(QUERIER));
+    expect(second.gymId).toBe(board.gymId);
+    expect(await countGyms()).toBe(before + 1);
   });
 });

--- a/packages/backend/src/__tests__/find-similar-gyms-and-auto-gym.test.ts
+++ b/packages/backend/src/__tests__/find-similar-gyms-and-auto-gym.test.ts
@@ -7,6 +7,7 @@ import { socialGymMatchQueries } from '../graphql/resolvers/social/gym-matching'
 import {
   findExactNameMatchesWithin,
   decideAutoGymAttachment,
+  MAX_AUTO_MINTED_GYMS_PER_OWNER,
   type SimilarGymResult,
 } from '../graphql/resolvers/social/gym-matching';
 import { socialBoardMutations } from '../graphql/resolvers/social/boards';
@@ -523,6 +524,23 @@ describe('createBoard auto-gym — per-location minting', () => {
       authCtx(QUERIER),
     );
     expect(board.gymId).toBeNull();
+  });
+
+  it('stops minting once the caller is at the gym cap, still creating the board', async () => {
+    // The runaway backstop. Approximate by design (read outside the insert
+    // transaction), so this pins the threshold behaviour, not exactness.
+    for (let index = 0; index < MAX_AUTO_MINTED_GYMS_PER_OWNER; index++) {
+      await insertGym({ ownerId: QUERIER, name: `Capped Gym ${index}` });
+    }
+    const before = await countGyms();
+
+    const board = await createBoard(
+      { name: 'One board too many', locationName: 'A brand new place' },
+      authCtx(QUERIER),
+    );
+
+    expect(board.gymId).toBeNull();
+    expect(await countGyms()).toBe(before);
   });
 
   it('mints with null coordinates when only a location name is given', async () => {

--- a/packages/backend/src/__tests__/gym-branding-and-boards.test.ts
+++ b/packages/backend/src/__tests__/gym-branding-and-boards.test.ts
@@ -57,9 +57,11 @@ const insertGym = async (opts: {
   return { id: Number(Array.from(result as Iterable<{ id: number }>)[0].id), uuid };
 };
 
-// Each board gets a distinct size_id so the (owner, type, layout, size, set_ids)
-// unique constraint (user_boards_unique_owner_config) never trips across the
-// several boards a single owner has in this suite.
+// Each board gets a distinct size_id so a single owner's several boards in this
+// suite stay distinguishable. These rows are inserted directly rather than via
+// createBoard, and the DB unique index was dropped in #4166, so nothing enforces
+// config uniqueness on them any more — the distinct size_id is now just a
+// readable-fixture convention.
 let boardConfigCounter = 0;
 const insertBoard = async (opts: {
   gymId: number;

--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -760,10 +760,16 @@ export const schemaSQL = `
   CREATE INDEX IF NOT EXISTS "user_boards_serial_idx"
     ON "user_boards" ("serial_number")
     WHERE "serial_number" IS NOT NULL AND "serial_number" <> '' AND "deleted_at" IS NULL;
-  -- One active board per owner per config (mirrors the prod partial unique index).
-  CREATE UNIQUE INDEX IF NOT EXISTS "user_boards_unique_owner_config"
+  -- Owner+config lookup for createBoard's duplicate check (mirrors the prod
+  -- partial index). NOT unique: the same config legitimately exists at two
+  -- different gyms (#4166), so createBoard enforces "same config AND same
+  -- place" in the resolver instead. The DROP handles a test DB created before
+  -- migration 0189, where the old unique index would still be present and
+  -- CREATE INDEX IF NOT EXISTS would silently leave it in place.
+  DROP INDEX IF EXISTS "user_boards_unique_owner_config";
+  CREATE INDEX IF NOT EXISTS "user_boards_owner_config_idx"
     ON "user_boards" ("owner_id", "board_type", "layout_id", "size_id", "set_ids")
-    WHERE "deleted_at" IS NULL AND "owner_id" != '00000000-0000-0000-0000-000000000000';
+    WHERE "deleted_at" IS NULL;
   CREATE UNIQUE INDEX IF NOT EXISTS "user_boards_unique_slug"
     ON "user_boards" ("slug")
     WHERE "deleted_at" IS NULL;

--- a/packages/backend/src/graphql/resolvers/board-presence/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/mutations.ts
@@ -92,7 +92,15 @@ function toBoardCandidate(
 /**
  * No board carries this serial yet: bind it onto the caller's own board for
  * this config, or create a fresh owned board. (Branches (b)+(c) of the old
- * resolver; the per-owner unique index keeps a same-owner bind race fail-safe.)
+ * resolver.)
+ *
+ * The caller may own SEVERAL boards of this config since #4166 (the same wall at
+ * home and at a gym), so `findOwnActiveBoardByConfig` gets the serial and returns
+ * the board this one should bind to — already bound to it, else unbound, else one
+ * bound elsewhere. Without that preference the pick was arbitrary, and this could
+ * refuse to connect a perfectly bindable board or stamp the serial onto the wrong
+ * one. The same-owner bind race stays fail-safe via `user_boards_unique_owner_serial`
+ * (the per-owner *config* index this comment used to cite is gone).
  */
 async function bindOrCreateOwnBoardForSerial(
   userId: string,
@@ -105,6 +113,7 @@ async function bindOrCreateOwnBoardForSerial(
     config.layoutId,
     config.sizeId,
     config.setIds,
+    serial,
   );
   if (ownBoard) {
     if (ownBoard.serialNumber && ownBoard.serialNumber !== serial) {
@@ -128,6 +137,7 @@ async function bindOrCreateOwnBoardForSerial(
           config.layoutId,
           config.sizeId,
           config.setIds,
+          serial,
         );
         if (winner?.serialNumber === serial) {
           return winner;
@@ -141,6 +151,7 @@ async function bindOrCreateOwnBoardForSerial(
       config.layoutId,
       config.sizeId,
       config.setIds,
+      serial,
     );
     if (refreshed?.serialNumber === serial) {
       return refreshed;
@@ -179,6 +190,7 @@ async function bindOrCreateOwnBoardForSerial(
         config.layoutId,
         config.sizeId,
         config.setIds,
+        serial,
       );
       if (winner?.serialNumber === serial) {
         return winner;

--- a/packages/backend/src/graphql/resolvers/board-presence/shared.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/shared.ts
@@ -416,12 +416,32 @@ export function assertAnonReadableBoard(board: BoardVisibility, viewerUserId: st
   }
 }
 
+/**
+ * The caller's own live board for this config — preferring the one this serial
+ * should bind to.
+ *
+ * An owner can hold several boards of one configuration since #4166 dropped the
+ * per-owner config unique index (the same MoonBoard 2024 at home and at a gym).
+ * This was `.limit(1)` with no ordering, so with two such boards the pick was
+ * arbitrary and the serial-bind caller would either refuse to connect — throwing
+ * "already linked to another wall serial" because it happened to pick the board
+ * bound to the OTHER controller — or stamp this wall's serial onto the wrong
+ * board, silently misattributing every later presence event and tick.
+ *
+ * Ordering makes it deterministic and correct:
+ *   1. already bound to `preferredSerial` — the board actually being connected;
+ *   2. unbound — free to take this serial;
+ *   3. bound to a different serial — reached only when nothing better exists,
+ *      which is the genuine "already linked elsewhere" case.
+ * `id` breaks remaining ties so repeat calls agree with each other.
+ */
 export async function findOwnActiveBoardByConfig(
   ownerId: string,
   boardType: string,
   layoutId: number,
   sizeId: number,
   setIds: string,
+  preferredSerial?: string,
 ): Promise<ActivePresenceBoard | undefined> {
   const normalizedSetIds = normalizeSetIds(setIds);
   const [board] = await db
@@ -445,6 +465,15 @@ export async function findOwnActiveBoardByConfig(
         eq(dbSchema.userBoards.setIds, normalizedSetIds),
         isNull(dbSchema.userBoards.deletedAt),
       ),
+    )
+    .orderBy(
+      sql`CASE
+            WHEN ${preferredSerial ?? null}::text IS NOT NULL
+             AND ${dbSchema.userBoards.serialNumber} = ${preferredSerial ?? null}::text THEN 0
+            WHEN ${dbSchema.userBoards.serialNumber} IS NULL THEN 1
+            ELSE 2
+          END`,
+      asc(dbSchema.userBoards.id),
     )
     .limit(1);
   return board;

--- a/packages/backend/src/graphql/resolvers/social/board-duplicates.ts
+++ b/packages/backend/src/graphql/resolvers/social/board-duplicates.ts
@@ -1,0 +1,107 @@
+import { normaliseSetIds } from '@boardsesh/board-config';
+import { distanceMeters } from '@boardsesh/db/queries';
+
+// ============================================
+// createBoard duplicate detection
+// ============================================
+//
+// A board's *configuration* (board type, layout, size, hold sets) does not
+// identify a physical board. The same MoonBoard 2024 Standard config exists at
+// every gym that owns one, so an owner legitimately has two of them — see #4166,
+// where a climber tried for a week to add a second one at a new gym and the app
+// silently activated their existing board instead.
+//
+// What identifies a board is config AND place. This module decides "are these
+// the same physical board?" so `createBoard` can block the genuine accident
+// (submitting the same board twice) without blocking the legitimate case.
+//
+// Kept pure and DB-free — the caller supplies the candidate rows — so it is
+// unit-testable without postgres, and portable: `distanceMeters` is a JS
+// Haversine, matching the no-PostGIS approach in `gym-matching.ts`.
+
+/**
+ * Two boards this close together, with the same config, are treated as the same
+ * physical board. Shares a value with `AUTO_GYM_MATCH_RADIUS_METERS` so "same
+ * place" means the same thing here as it does for gym matching.
+ *
+ * Two boards in one large gym can sit inside this radius and still be distinct;
+ * those users get the confirmation prompt and continue, which is exactly what
+ * the `allowDuplicateConfig` opt-in is for.
+ */
+export const DUPLICATE_BOARD_RADIUS_METERS = 150;
+
+export type BoardLocation = {
+  latitude: number | null;
+  longitude: number | null;
+  locationName: string | null;
+};
+
+function hasCoordinates(location: BoardLocation): boolean {
+  return location.latitude != null && location.longitude != null;
+}
+
+function normalisedLocationName(location: BoardLocation): string | null {
+  const trimmed = location.locationName?.trim().toLowerCase();
+  return trimmed ? trimmed : null;
+}
+
+/**
+ * Whether two boards sit in the same place, most-precise signal first.
+ *
+ * Coordinates win when both sides have them. Failing that, a matching typed
+ * location name counts — most boards never get coordinates, because the field
+ * lives behind "More options" and can only be filled by "Use my location",
+ * which requires standing at the wall.
+ *
+ * Two boards with no location at all are treated as the SAME place: there is no
+ * evidence they differ, and the common accident this guard exists to catch (a
+ * double submit) produces exactly that shape. The user can still override.
+ *
+ * A placed board and a placeless one are treated as DIFFERENT. That is the
+ * permissive reading, chosen deliberately: silently blocking a real board is
+ * the failure this issue is about, and the prompt is still available on every
+ * tier that does match.
+ */
+export function isSameBoardLocation(first: BoardLocation, second: BoardLocation): boolean {
+  if (hasCoordinates(first) && hasCoordinates(second)) {
+    return (
+      distanceMeters(
+        { latitude: first.latitude!, longitude: first.longitude! },
+        { latitude: second.latitude!, longitude: second.longitude! },
+      ) <= DUPLICATE_BOARD_RADIUS_METERS
+    );
+  }
+
+  const firstName = normalisedLocationName(first);
+  const secondName = normalisedLocationName(second);
+  if (firstName != null && secondName != null) {
+    return firstName === secondName;
+  }
+
+  const firstPlaced = hasCoordinates(first) || firstName != null;
+  const secondPlaced = hasCoordinates(second) || secondName != null;
+  return !firstPlaced && !secondPlaced;
+}
+
+/**
+ * The already-owned board that should block this create, or undefined.
+ *
+ * Callers pass candidates already narrowed in SQL to the same owner, board type,
+ * layout and size. Set-id equality is decided HERE rather than in the query,
+ * because the stored value is whatever order the board was created with:
+ * `'25,26,27,24'` and `'24,25,26,27'` are the same physical board, but a SQL
+ * `eq()` calls them different. `normaliseSetIds` is the same helper the mobile
+ * builder uses, so both ends now agree.
+ *
+ * Angle is deliberately not compared — one wall runs at many angles, so it can
+ * never distinguish two boards.
+ */
+export function findBlockingDuplicate<Candidate extends BoardLocation & { setIds: string }>(
+  candidates: Candidate[],
+  incoming: BoardLocation & { setIds: string },
+): Candidate | undefined {
+  const incomingSetIds = normaliseSetIds(incoming.setIds);
+  return candidates.find(
+    (candidate) => normaliseSetIds(candidate.setIds) === incomingSetIds && isSameBoardLocation(candidate, incoming),
+  );
+}

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -1697,6 +1697,7 @@ export const socialBoardMutations = {
 
     if (validatedInput.gymUuid) {
       const gym = await requireBoardGymLinkAccess({
+        ctx,
         gymUuid: validatedInput.gymUuid,
         userId,
         boardLatitude: incomingLocation.latitude,

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -1629,6 +1629,7 @@ export const socialBoardMutations = {
           slug: dbSchema.userBoards.slug,
           name: dbSchema.userBoards.name,
           setIds: dbSchema.userBoards.setIds,
+          angle: dbSchema.userBoards.angle,
           latitude: dbSchema.userBoards.latitude,
           longitude: dbSchema.userBoards.longitude,
           locationName: dbSchema.userBoards.locationName,
@@ -1642,7 +1643,11 @@ export const socialBoardMutations = {
             eq(dbSchema.userBoards.sizeId, validatedInput.sizeId),
             isNull(dbSchema.userBoards.deletedAt),
           ),
-        );
+        )
+        // Already narrowed to one owner's boards of one exact type/layout/size,
+        // so this is a handful of rows; the cap is just a safety net against a
+        // pathological account.
+        .limit(100);
 
       const existing = findBlockingDuplicate(ownedWithConfig, {
         setIds: validatedInput.setIds,
@@ -1660,6 +1665,9 @@ export const socialBoardMutations = {
             existingBoardSlug: existing.slug,
             existingBoardName: existing.name,
             existingBoardLocationName: existing.locationName,
+            // Web's "go to your board" links to /b/<slug>/<angle>; without the
+            // board's own angle it would land on the board type's default.
+            existingBoardAngle: existing.angle,
           },
         });
       }

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -20,9 +20,9 @@ import {
   RecordBoardSerialInputSchema,
   UUIDSchema,
 } from '../../../validation/schemas';
-import { generateUniqueGymSlug, userCanEditGym } from './gyms';
-import { findExactNameMatchesWithin, decideAutoGymAttachment, AUTO_GYM_MATCH_RADIUS_METERS } from './gym-matching';
-import { isGenericGymName } from '@boardsesh/db/queries';
+import { generateUniqueGymSlug, requireBoardGymLinkAccess, userCanEditGym } from './gyms';
+import { resolveAutoGymForBoard } from './gym-matching';
+import { findBlockingDuplicate } from './board-duplicates';
 import { getUserCommunityRoles, hasAdminOrLeader, rolesGrantAdminOrLeader } from './roles';
 import { SYSTEM_BOARD_OWNER_ID, isRowAnonReadable, requireAnonReadableBoard } from '../board-presence/shared';
 import { assertKnownBoardConfig } from '../board-presence/board-catalog';
@@ -1609,224 +1609,203 @@ export const socialBoardMutations = {
     );
     const userId = ctx.userId!;
 
-    // Check for duplicate config
-    const [existing] = await db
-      .select({ id: dbSchema.userBoards.id })
-      .from(dbSchema.userBoards)
-      .where(
-        and(
-          eq(dbSchema.userBoards.ownerId, userId),
-          eq(dbSchema.userBoards.boardType, validatedInput.boardType),
-          eq(dbSchema.userBoards.layoutId, validatedInput.layoutId),
-          eq(dbSchema.userBoards.sizeId, validatedInput.sizeId),
-          eq(dbSchema.userBoards.setIds, validatedInput.setIds),
-          isNull(dbSchema.userBoards.deletedAt),
-        ),
-      )
-      .limit(1);
+    const incomingLocation = {
+      latitude: validatedInput.latitude ?? null,
+      longitude: validatedInput.longitude ?? null,
+      locationName: validatedInput.locationName ?? null,
+    };
 
-    if (existing) {
-      throw new Error('You already have a board with this configuration');
+    // Reject an accidental re-submit, but never a genuine second board. A config
+    // tuple alone doesn't identify a wall — the same MoonBoard 2024 exists at
+    // every gym that owns one — so the guard is config AND place, and the user
+    // can override it once they've confirmed the two walls really are different
+    // (#4166). Set-id equality is settled in JS, not SQL: the stored order is
+    // whatever the board was created with, so '25,26,27,24' and '24,25,26,27'
+    // are the same board but not the same string.
+    if (!validatedInput.allowDuplicateConfig) {
+      const ownedWithConfig = await db
+        .select({
+          uuid: dbSchema.userBoards.uuid,
+          slug: dbSchema.userBoards.slug,
+          name: dbSchema.userBoards.name,
+          setIds: dbSchema.userBoards.setIds,
+          latitude: dbSchema.userBoards.latitude,
+          longitude: dbSchema.userBoards.longitude,
+          locationName: dbSchema.userBoards.locationName,
+        })
+        .from(dbSchema.userBoards)
+        .where(
+          and(
+            eq(dbSchema.userBoards.ownerId, userId),
+            eq(dbSchema.userBoards.boardType, validatedInput.boardType),
+            eq(dbSchema.userBoards.layoutId, validatedInput.layoutId),
+            eq(dbSchema.userBoards.sizeId, validatedInput.sizeId),
+            isNull(dbSchema.userBoards.deletedAt),
+          ),
+        );
+
+      const existing = findBlockingDuplicate(ownedWithConfig, {
+        setIds: validatedInput.setIds,
+        ...incomingLocation,
+      });
+
+      if (existing) {
+        // The existing board travels with the error so the client can offer
+        // "use that one" without scanning its paginated myBoards cache — which
+        // defaults to 20 and so can't find a match for a user with more boards.
+        throw new GraphQLError('You already have this board at this location', {
+          extensions: {
+            code: 'BOARD_DUPLICATE_CONFIG',
+            existingBoardUuid: existing.uuid,
+            existingBoardSlug: existing.slug,
+            existingBoardName: existing.name,
+            existingBoardLocationName: existing.locationName,
+          },
+        });
+      }
     }
 
     const uuid = uuidv4();
     const slug = await generateUniqueSlug(validatedInput.name);
 
-    // Resolve gymId from gymUuid if provided
+    // Resolve the gym this board belongs to. An explicit gymUuid goes through the
+    // shared link gate (owner/admin, or a nearby public gym the caller is adding
+    // their own board to); otherwise infer one from the location.
     let gymId: number | null = null;
+    let mintGymNamed: string | null = null;
+
     if (validatedInput.gymUuid) {
-      const [gym] = await db
-        .select({ id: dbSchema.gyms.id, ownerId: dbSchema.gyms.ownerId })
-        .from(dbSchema.gyms)
-        .where(and(eq(dbSchema.gyms.uuid, validatedInput.gymUuid), isNull(dbSchema.gyms.deletedAt)))
-        .limit(1);
-
-      if (!gym) {
-        throw new Error('Gym not found');
-      }
-
-      // Verify user is owner or admin of the gym
-      if (gym.ownerId !== userId) {
-        const [member] = await db
-          .select({ role: dbSchema.gymMembers.role })
-          .from(dbSchema.gymMembers)
-          .where(
-            and(
-              eq(dbSchema.gymMembers.gymId, gym.id),
-              eq(dbSchema.gymMembers.userId, userId),
-              eq(dbSchema.gymMembers.role, 'admin'),
-            ),
-          )
-          .limit(1);
-
-        if (!member) {
-          throw new Error('Not authorized to link board to this gym');
-        }
-      }
-
+      const gym = await requireBoardGymLinkAccess({
+        gymUuid: validatedInput.gymUuid,
+        userId,
+        boardLatitude: incomingLocation.latitude,
+        boardLongitude: incomingLocation.longitude,
+      });
       gymId = gym.id;
     } else {
-      // Auto-create a gym if user has zero gyms
-      const [existingGym] = await db
-        .select({ id: dbSchema.gyms.id })
-        .from(dbSchema.gyms)
-        .where(and(eq(dbSchema.gyms.ownerId, userId), isNull(dbSchema.gyms.deletedAt)))
-        .limit(1);
-
-      if (!existingGym) {
-        const gymName = validatedInput.locationName || validatedInput.name;
-
-        // Dedup guard: before minting a fresh gym for the user's first board,
-        // look for a live gym of ANY owner at these exact coordinates + name
-        // (mirrors findSimilarGyms's physical-proximity tier). A SYSTEM-synced
-        // gym or one the user already owns is attached instead of duplicated —
-        // UNLESS the name is generic (home wall / garage / bare board brands),
-        // which collides across unrelated walls. Another user's gym, or a generic
-        // match, is left alone (mint a fresh gym as before) but logged so the
-        // admin dedup queue gets a signal.
-        if (validatedInput.latitude != null && validatedInput.longitude != null) {
-          const physicalMatches = await findExactNameMatchesWithin({
-            name: gymName,
-            latitude: validatedInput.latitude,
-            longitude: validatedInput.longitude,
-            radiusMeters: AUTO_GYM_MATCH_RADIUS_METERS,
-          });
-          const nearest = physicalMatches[0];
-          const decision = decideAutoGymAttachment(nearest, userId);
-          if (decision.action === 'attach') {
-            // Fall through to the normal board insert below, which links `gymId`.
-            gymId = decision.gymId;
-          } else if (nearest) {
-            logger.warn('createBoard auto-gym: nearby name match not auto-attached; minting a separate gym', {
-              userId,
-              gymName,
-              matchedGymId: nearest.id,
-              matchedGymUuid: nearest.uuid,
-              matchedOwnerId: nearest.ownerId,
-              matchedOwnerIsSystem: nearest.ownerId === SYSTEM_BOARD_OWNER_ID,
-              genericName: isGenericGymName(nearest.name),
-              distanceMeters: Math.round(nearest.distanceMeters ?? 0),
-            });
-          }
-        }
-      }
-
-      if (!existingGym && gymId === null) {
-        // Auto-create a gym for the user. If this fails, fall through
-        // and create the board without a gym link rather than failing entirely.
-        try {
-          const gymName = validatedInput.locationName || validatedInput.name;
-          const gymUuid = uuidv4();
-          const gymSlug = await generateUniqueGymSlug(gymName);
-
-          // Use transaction to atomically create gym + board
-          const board = await db.transaction(async (tx) => {
-            const [newGym] = await tx
-              .insert(dbSchema.gyms)
-              .values({
-                uuid: gymUuid,
-                slug: gymSlug,
-                ownerId: userId,
-                name: gymName,
-                isPublic: validatedInput.isPublic ?? true,
-                latitude: validatedInput.latitude ?? null,
-                longitude: validatedInput.longitude ?? null,
-              })
-              .returning();
-
-            if (validatedInput.latitude != null && validatedInput.longitude != null) {
-              await tx.execute(
-                sql`UPDATE gyms SET location = ST_MakePoint(${validatedInput.longitude}, ${validatedInput.latitude})::geography WHERE id = ${newGym.id}`,
-              );
-            }
-
-            const [newBoard] = await tx
-              .insert(dbSchema.userBoards)
-              .values({
-                uuid,
-                slug,
-                ownerId: userId,
-                boardType: validatedInput.boardType,
-                layoutId: validatedInput.layoutId,
-                sizeId: validatedInput.sizeId,
-                setIds: validatedInput.setIds,
-                name: validatedInput.name,
-                description: validatedInput.description ?? null,
-                locationName: validatedInput.locationName ?? null,
-                latitude: validatedInput.latitude ?? null,
-                longitude: validatedInput.longitude ?? null,
-                isPublic: validatedInput.isPublic ?? true,
-                isUnlisted: validatedInput.isUnlisted ?? false,
-                hideLocation: validatedInput.hideLocation ?? false,
-                isOwned: validatedInput.isOwned ?? true,
-                angle: validatedInput.angle ?? 40,
-                isAngleAdjustable: validatedInput.isAngleAdjustable ?? true,
-                serialNumber: validatedInput.serialNumber ?? null,
-                timerName: validatedInput.timerName ?? null,
-                gymId: newGym.id,
-              })
-              .returning();
-
-            if (validatedInput.latitude != null && validatedInput.longitude != null) {
-              await tx.execute(
-                sql`UPDATE user_boards SET location = ST_MakePoint(${validatedInput.longitude}, ${validatedInput.latitude})::geography WHERE id = ${newBoard.id}`,
-              );
-            }
-
-            return newBoard;
-          });
-
-          return await enrichBoard(board, userId);
-        } catch (error) {
-          throwIfBoardSerialConflict(error);
-          // Auto-gym creation failed; continue to create the board without a gym
-          logger.error('Auto-gym creation failed, creating board without gym:', error);
-        }
+      const resolution = await resolveAutoGymForBoard({
+        userId,
+        locationName: incomingLocation.locationName,
+        latitude: incomingLocation.latitude,
+        longitude: incomingLocation.longitude,
+      });
+      if (resolution.action === 'attach') {
+        gymId = resolution.gymId;
+      } else if (resolution.action === 'mint') {
+        mintGymNamed = resolution.name;
       }
     }
 
+    // One insert path for every case. The gym mint, when there is one, shares the
+    // board's transaction so we never leave a gym with no board behind. The
+    // PostGIS writes deliberately sit OUTSIDE it — see below.
     let board: typeof dbSchema.userBoards.$inferSelect;
-    try {
-      [board] = await db
-        .insert(dbSchema.userBoards)
-        .values({
-          uuid,
-          slug,
-          ownerId: userId,
-          boardType: validatedInput.boardType,
-          layoutId: validatedInput.layoutId,
-          sizeId: validatedInput.sizeId,
-          setIds: validatedInput.setIds,
-          name: validatedInput.name,
-          description: validatedInput.description ?? null,
-          locationName: validatedInput.locationName ?? null,
-          latitude: validatedInput.latitude ?? null,
-          longitude: validatedInput.longitude ?? null,
-          isPublic: validatedInput.isPublic ?? true,
-          isUnlisted: validatedInput.isUnlisted ?? false,
-          hideLocation: validatedInput.hideLocation ?? false,
-          isOwned: validatedInput.isOwned ?? true,
-          angle: validatedInput.angle ?? 40,
-          isAngleAdjustable: validatedInput.isAngleAdjustable ?? true,
-          serialNumber: validatedInput.serialNumber ?? null,
-          timerName: validatedInput.timerName ?? null,
-          gymId,
-        })
-        .returning();
-    } catch (error) {
-      throwIfBoardSerialConflict(error);
-      throw error;
+    let mintedGymId: number | null = null;
+
+    const boardValues = {
+      uuid,
+      slug,
+      ownerId: userId,
+      boardType: validatedInput.boardType,
+      layoutId: validatedInput.layoutId,
+      sizeId: validatedInput.sizeId,
+      setIds: validatedInput.setIds,
+      name: validatedInput.name,
+      description: validatedInput.description ?? null,
+      locationName: incomingLocation.locationName,
+      latitude: incomingLocation.latitude,
+      longitude: incomingLocation.longitude,
+      isPublic: validatedInput.isPublic ?? true,
+      isUnlisted: validatedInput.isUnlisted ?? false,
+      hideLocation: validatedInput.hideLocation ?? false,
+      isOwned: validatedInput.isOwned ?? true,
+      angle: validatedInput.angle ?? 40,
+      isAngleAdjustable: validatedInput.isAngleAdjustable ?? true,
+      serialNumber: validatedInput.serialNumber ?? null,
+      timerName: validatedInput.timerName ?? null,
+    };
+
+    if (mintGymNamed != null) {
+      const gymName = mintGymNamed;
+      try {
+        const gymUuid = uuidv4();
+        const gymSlug = await generateUniqueGymSlug(gymName);
+        const result = await db.transaction(async (tx) => {
+          const [newGym] = await tx
+            .insert(dbSchema.gyms)
+            .values({
+              uuid: gymUuid,
+              slug: gymSlug,
+              ownerId: userId,
+              name: gymName,
+              isPublic: validatedInput.isPublic ?? true,
+              latitude: incomingLocation.latitude,
+              longitude: incomingLocation.longitude,
+            })
+            .returning();
+
+          const [newBoard] = await tx
+            .insert(dbSchema.userBoards)
+            .values({ ...boardValues, gymId: newGym.id })
+            .returning();
+
+          return { newGym, newBoard };
+        });
+        mintedGymId = result.newGym.id;
+        board = result.newBoard;
+      } catch (error) {
+        throwIfBoardSerialConflict(error);
+        // The gym couldn't be minted; still create the board, unlinked, rather
+        // than failing the whole create.
+        logger.error('Auto-gym creation failed, creating board without gym:', error);
+        try {
+          [board] = await db
+            .insert(dbSchema.userBoards)
+            .values({ ...boardValues, gymId: null })
+            .returning();
+        } catch (fallbackError) {
+          throwIfBoardSerialConflict(fallbackError);
+          throw fallbackError;
+        }
+      }
+    } else {
+      try {
+        [board] = await db
+          .insert(dbSchema.userBoards)
+          .values({ ...boardValues, gymId })
+          .returning();
+      } catch (error) {
+        throwIfBoardSerialConflict(error);
+        throw error;
+      }
     }
 
-    // Populate the PostGIS location column if lat/lon provided. This is a
-    // denormalization used by proximity search — a failure here (e.g. PostGIS not
-    // installed) must not fail an otherwise-created board; log and continue, the
-    // column can be backfilled. Mirrors the auto-gym mint path, which already
-    // tolerates a location-write failure by falling through.
-    if (validatedInput.latitude != null && validatedInput.longitude != null) {
+    // Populate the PostGIS `location` columns. These are denormalizations used by
+    // proximity search, and they run AFTER the transaction, each guarded on its
+    // own. Inside the transaction a PostGIS failure (the column is absent in the
+    // backend test DB, and the extension can be missing anywhere) rolled the
+    // whole thing back and silently cost the user their gym; out here the worst
+    // case is a null `location` that a backfill can repair. The board id is
+    // logged so that backfill is a one-liner.
+    if (incomingLocation.latitude != null && incomingLocation.longitude != null) {
+      const { latitude, longitude } = incomingLocation;
+
+      if (mintedGymId != null) {
+        try {
+          await db.execute(
+            sql`UPDATE gyms SET location = ST_MakePoint(${longitude}, ${latitude})::geography WHERE id = ${mintedGymId}`,
+          );
+        } catch (error) {
+          logger.warn('createBoard: failed to set gym location geography; leaving it null', {
+            gymId: mintedGymId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+
       try {
         await db.execute(
-          sql`UPDATE user_boards SET location = ST_MakePoint(${validatedInput.longitude}, ${validatedInput.latitude})::geography WHERE id = ${board.id}`,
+          sql`UPDATE user_boards SET location = ST_MakePoint(${longitude}, ${latitude})::geography WHERE id = ${board.id}`,
         );
       } catch (error) {
         logger.warn('createBoard: failed to set board location geography; leaving it null', {

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -1622,7 +1622,20 @@ export const socialBoardMutations = {
     // (#4166). Set-id equality is settled in JS, not SQL: the stored order is
     // whatever the board was created with, so '25,26,27,24' and '24,25,26,27'
     // are the same board but not the same string.
-    if (!validatedInput.allowDuplicateConfig) {
+    if (validatedInput.allowDuplicateConfig) {
+      // The guard is skipped only on the user's say-so, so leave a trail: this is
+      // the one path that can add an unlimited number of same-config boards, and
+      // without a log there'd be nothing separating a genuine two-gym create from
+      // a script setting the flag on every call.
+      logger.info('createBoard: duplicate-config guard bypassed by explicit confirmation', {
+        userId,
+        boardType: validatedInput.boardType,
+        layoutId: validatedInput.layoutId,
+        sizeId: validatedInput.sizeId,
+        hasLocation:
+          !!validatedInput.locationName || (validatedInput.latitude != null && validatedInput.longitude != null),
+      });
+    } else {
       const ownedWithConfig = await db
         .select({
           uuid: dbSchema.userBoards.uuid,

--- a/packages/backend/src/graphql/resolvers/social/gym-matching.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-matching.ts
@@ -186,6 +186,11 @@ async function findOwnGymsByExactName(opts: {
   if (normalized.length === 0) return [];
 
   const hasCoords = latitude != null && longitude != null;
+  // No bounding box in SQL: it requires non-null lat/lng, which would drop the
+  // caller's OWN same-named gym when that gym has no coordinates — and a gym
+  // minted from a location name alone has none. Dropping it meant a second board
+  // at the same typed place, this time with coordinates, minted a twin instead of
+  // converging. Distance is applied below, and only where there is one.
   const rows = await db
     .select(gymColumns)
     .from(dbSchema.gyms)
@@ -194,7 +199,6 @@ async function findOwnGymsByExactName(opts: {
         isNull(dbSchema.gyms.deletedAt),
         eq(dbSchema.gyms.ownerId, userId),
         sql`${normalizedNameExpr} = ${normalized}`,
-        ...(hasCoords ? [withinBoundingBox(latitude, longitude, radiusMeters)] : []),
       ),
     );
 
@@ -204,7 +208,7 @@ async function findOwnGymsByExactName(opts: {
     return rows.map((row) => ({ ...row, distanceMeters: null })).sort((first, second) => first.id - second.id);
   }
 
-  return rows
+  const placed = rows
     .filter(
       (row): row is typeof row & { latitude: number; longitude: number } =>
         row.latitude != null && row.longitude != null,
@@ -212,6 +216,15 @@ async function findOwnGymsByExactName(opts: {
     .map((row) => ({ ...row, distanceMeters: haversineTo({ latitude, longitude }, row) }))
     .filter((row) => row.distanceMeters <= radiusMeters)
     .sort((first, second) => first.distanceMeters - second.distanceMeters);
+  if (placed.length > 0) return placed;
+
+  // Fall back to the caller's same-named gyms that carry no coordinates at all.
+  // Their name is the only evidence available, and it's their own gym, so reusing
+  // it beats minting a duplicate. A later edit can give it coordinates.
+  return rows
+    .filter((row) => row.latitude == null || row.longitude == null)
+    .map((row) => ({ ...row, distanceMeters: null }))
+    .sort((first, second) => first.id - second.id);
 }
 
 /** Live gyms of any owner within `radiusMeters`, regardless of name. Nearest-first. */

--- a/packages/backend/src/graphql/resolvers/social/gym-matching.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-matching.ts
@@ -318,7 +318,11 @@ export async function resolveAutoGymForBoard(opts: {
   }
 
   // Backstop against a scripted create loop minting a gym per call. Rate limiting
-  // caps the rate; this caps the total.
+  // caps the rate; this caps the total. Deliberately a plain read outside the
+  // insert transaction: two concurrent creates can both see 24 and both mint, so
+  // the cap is approximate by design. It exists to stop a runaway, not to hold an
+  // invariant — paying for row locks on every create to make it exact would be
+  // the wrong trade.
   const [{ count: ownedGymCount }] = await db
     .select({ count: sql<number>`count(*)::int` })
     .from(dbSchema.gyms)

--- a/packages/backend/src/graphql/resolvers/social/gym-matching.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-matching.ts
@@ -5,6 +5,7 @@ import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
 import { FindSimilarGymsInputSchema } from '../../../validation/schemas';
+import { logger } from '../../../utils/logger';
 import { SYSTEM_BOARD_OWNER_ID } from '../board-presence/shared';
 import { getUserCommunityRoles, rolesGrantAdminOrLeader } from './roles';
 
@@ -162,6 +163,175 @@ export function decideAutoGymAttachment(
     return { action: 'attach', gymId: nearestMatch.id };
   }
   return { action: 'mint' };
+}
+
+/** Beyond this many live gyms, stop minting new ones for a caller automatically. */
+export const MAX_AUTO_MINTED_GYMS_PER_OWNER = 25;
+
+export type AutoGymResolution =
+  | { action: 'attach'; gymId: number }
+  | { action: 'mint'; name: string }
+  | { action: 'none' };
+
+/** Live gyms owned by `userId` whose normalized name equals `name`, nearest-first when coordinates are given. */
+async function findOwnGymsByExactName(opts: {
+  userId: string;
+  name: string;
+  latitude: number | null;
+  longitude: number | null;
+  radiusMeters: number;
+}): Promise<GymNameMatch[]> {
+  const { userId, name, latitude, longitude, radiusMeters } = opts;
+  const normalized = normalizeGymName(name);
+  if (normalized.length === 0) return [];
+
+  const hasCoords = latitude != null && longitude != null;
+  const rows = await db
+    .select(gymColumns)
+    .from(dbSchema.gyms)
+    .where(
+      and(
+        isNull(dbSchema.gyms.deletedAt),
+        eq(dbSchema.gyms.ownerId, userId),
+        sql`${normalizedNameExpr} = ${normalized}`,
+        ...(hasCoords ? [withinBoundingBox(latitude, longitude, radiusMeters)] : []),
+      ),
+    );
+
+  if (!hasCoords) {
+    // Name-only match: no distance to compute, so any of the caller's same-named
+    // gyms will do. Deterministic order so repeat creates converge on one gym.
+    return rows.map((row) => ({ ...row, distanceMeters: null })).sort((first, second) => first.id - second.id);
+  }
+
+  return rows
+    .filter(
+      (row): row is typeof row & { latitude: number; longitude: number } =>
+        row.latitude != null && row.longitude != null,
+    )
+    .map((row) => ({ ...row, distanceMeters: haversineTo({ latitude, longitude }, row) }))
+    .filter((row) => row.distanceMeters <= radiusMeters)
+    .sort((first, second) => first.distanceMeters - second.distanceMeters);
+}
+
+/** Live gyms of any owner within `radiusMeters`, regardless of name. Nearest-first. */
+async function findGymsWithin(opts: {
+  latitude: number;
+  longitude: number;
+  radiusMeters: number;
+}): Promise<GymNameMatch[]> {
+  const { latitude, longitude, radiusMeters } = opts;
+  const rows = await db
+    .select(gymColumns)
+    .from(dbSchema.gyms)
+    .where(and(isNull(dbSchema.gyms.deletedAt), withinBoundingBox(latitude, longitude, radiusMeters)));
+
+  return rows
+    .filter(
+      (row): row is typeof row & { latitude: number; longitude: number } =>
+        row.latitude != null && row.longitude != null,
+    )
+    .map((row) => ({ ...row, distanceMeters: haversineTo({ latitude, longitude }, row) }))
+    .filter((row) => row.distanceMeters <= radiusMeters)
+    .sort((first, second) => first.distanceMeters - second.distanceMeters);
+}
+
+/**
+ * Which gym a newly created board belongs to, when the caller didn't name one.
+ *
+ * This resolves per LOCATION, not per user. It used to mint a gym only when the
+ * caller owned zero gyms, so every second-and-later board landed with
+ * `gym_id = NULL` — 29% of real user boards at the time of #4166 — and showed on
+ * the map as a bare board pin instead of under the gym the user had just typed.
+ *
+ * The dedup tiers below are what keep per-location minting from spraying
+ * duplicate gyms across the map.
+ */
+export async function resolveAutoGymForBoard(opts: {
+  userId: string;
+  locationName: string | null;
+  latitude: number | null;
+  longitude: number | null;
+}): Promise<AutoGymResolution> {
+  const { userId, latitude, longitude } = opts;
+  const locationName = opts.locationName?.trim() || null;
+  const hasCoords = latitude != null && longitude != null;
+
+  // No location of any kind: nothing to identify a gym by. Previously this minted
+  // a gym named after the BOARD ("Marco's Kilter Original 12×12") with null
+  // coordinates — a row that can never surface in proximity search. The board
+  // still gets its own standalone map pin.
+  if (locationName == null && !hasCoords) return { action: 'none' };
+
+  // Coordinates but no name: we can't mint (no name to give it), but we can
+  // attach when the answer is unambiguous — exactly one nearby gym that is safe
+  // to reuse. Two or more candidates and we decline rather than guess.
+  if (locationName == null) {
+    const nearby = await findGymsWithin({
+      latitude: latitude!,
+      longitude: longitude!,
+      radiusMeters: AUTO_GYM_MATCH_RADIUS_METERS,
+    });
+    const reusable = nearby.filter(
+      (gym) => !isGenericGymName(gym.name) && (gym.ownerId === SYSTEM_BOARD_OWNER_ID || gym.ownerId === userId),
+    );
+    return reusable.length === 1 ? { action: 'attach', gymId: reusable[0].id } : { action: 'none' };
+  }
+
+  // Named. First converge on the caller's OWN gym of that name — this is what
+  // makes a second board at a gym they already added land on the same gym rather
+  // than minting a twin. Own-gym only, so the generic-name guard doesn't apply:
+  // there's no cross-user capture risk in reusing your own "home wall".
+  const ownMatches = await findOwnGymsByExactName({
+    userId,
+    name: locationName,
+    latitude,
+    longitude,
+    radiusMeters: EXACT_NAME_MATCH_RADIUS_METERS,
+  });
+  if (ownMatches.length > 0) return { action: 'attach', gymId: ownMatches[0].id };
+
+  // Then the existing cross-owner physical tier: a SYSTEM-synced gym (or one of
+  // the caller's, already handled above) at these exact coordinates and name.
+  if (hasCoords) {
+    const physicalMatches = await findExactNameMatchesWithin({
+      name: locationName,
+      latitude: latitude!,
+      longitude: longitude!,
+      radiusMeters: AUTO_GYM_MATCH_RADIUS_METERS,
+    });
+    const nearest = physicalMatches[0];
+    const decision = decideAutoGymAttachment(nearest, userId);
+    if (decision.action === 'attach') return { action: 'attach', gymId: decision.gymId };
+    if (nearest) {
+      logger.warn('createBoard auto-gym: nearby name match not auto-attached; minting a separate gym', {
+        userId,
+        gymName: locationName,
+        matchedGymId: nearest.id,
+        matchedGymUuid: nearest.uuid,
+        matchedOwnerId: nearest.ownerId,
+        matchedOwnerIsSystem: nearest.ownerId === SYSTEM_BOARD_OWNER_ID,
+        genericName: isGenericGymName(nearest.name),
+        distanceMeters: Math.round(nearest.distanceMeters ?? 0),
+      });
+    }
+  }
+
+  // Backstop against a scripted create loop minting a gym per call. Rate limiting
+  // caps the rate; this caps the total.
+  const [{ count: ownedGymCount }] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(dbSchema.gyms)
+    .where(and(eq(dbSchema.gyms.ownerId, userId), isNull(dbSchema.gyms.deletedAt)));
+  if (ownedGymCount >= MAX_AUTO_MINTED_GYMS_PER_OWNER) {
+    logger.warn('createBoard auto-gym: owner at gym cap, creating board without a gym', {
+      userId,
+      ownedGymCount,
+    });
+    return { action: 'none' };
+  }
+
+  return { action: 'mint', name: locationName };
 }
 
 /**

--- a/packages/backend/src/graphql/resolvers/social/gym-stray-boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-stray-boards.ts
@@ -5,7 +5,7 @@ import { distanceMeters } from '@boardsesh/db/queries';
 import * as dbSchema from '@boardsesh/db/schema';
 import { db } from '../../../db/client';
 import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
-import { AttachBoardToGymInputSchema, UUIDSchema } from '../../../validation/schemas';
+import { AttachBoardToGymInputSchema, DetachBoardFromGymInputSchema, UUIDSchema } from '../../../validation/schemas';
 import { SYSTEM_BOARD_OWNER_ID } from '../board-presence/shared';
 import { requireGymEditAccess } from './gyms';
 import { PROXIMITY_MATCH_RADIUS_METERS } from './gym-matching';
@@ -285,6 +285,51 @@ export const socialGymStrayBoardMutations = {
 
     if (updated.length === 0) {
       throw new GraphQLError('This board changed before it could be attached. Refresh and try again.', {
+        extensions: { code: 'CONFLICT' },
+      });
+    }
+    return true;
+  },
+
+  /**
+   * Remove a board from this gym's listing. The counterbalance to a board owner
+   * self-linking to a gym they don't run (`requireBoardGymLinkAccess`): that gate
+   * rests on board coordinates the caller supplies, so it can't be the only
+   * control. Gym staff need a way to undo a wrong or unwanted link, and until
+   * #4166 none existed — `linkBoardToGym`'s unlink branch is board-owner-only and
+   * `deleteGym` was the only other thing that cleared `gym_id`.
+   *
+   * Only clears the link; the board itself is untouched and stays its owner's.
+   */
+  detachBoardFromGym: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext): Promise<boolean> => {
+    requireAuthenticated(ctx);
+    await applyRateLimit(ctx, 20, 'detachBoardFromGym');
+    const validatedInput = validateInput(DetachBoardFromGymInputSchema, input, 'input');
+    const userId = ctx.userId!;
+
+    const gym = await requireGymEditAccess(validatedInput.gymUuid, userId);
+
+    const [board] = await db
+      .select({ id: dbSchema.userBoards.id, gymId: dbSchema.userBoards.gymId })
+      .from(dbSchema.userBoards)
+      .where(and(eq(dbSchema.userBoards.uuid, validatedInput.boardUuid), isNull(dbSchema.userBoards.deletedAt)))
+      .limit(1);
+
+    if (!board || board.gymId !== gym.id) {
+      throw new GraphQLError('This board is not listed at this gym.', {
+        extensions: { code: 'BAD_USER_INPUT' },
+      });
+    }
+
+    // Compare-and-swap so a concurrent re-link isn't silently clobbered.
+    const updated = await db
+      .update(dbSchema.userBoards)
+      .set({ gymId: null })
+      .where(and(eq(dbSchema.userBoards.id, board.id), eq(dbSchema.userBoards.gymId, gym.id)))
+      .returning({ id: dbSchema.userBoards.id });
+
+    if (updated.length === 0) {
+      throw new GraphQLError('This board changed before it could be detached. Refresh and try again.', {
         extensions: { code: 'CONFLICT' },
       });
     }

--- a/packages/backend/src/graphql/resolvers/social/gyms.ts
+++ b/packages/backend/src/graphql/resolvers/social/gyms.ts
@@ -449,6 +449,14 @@ export const SELF_LINK_PROXIMITY_METERS = PROXIMITY_MATCH_RADIUS_METERS;
 export const MAX_FOREIGN_GYM_LINKS = 20;
 
 /**
+ * Beyond this many of the caller's own boards listed at ONE gym they don't run,
+ * stop allowing more. Bounds how far a single listing can be flooded, which the
+ * distinct-gym cap above deliberately does not (it excludes the target gym so
+ * several walls at your home gym cost one slot).
+ */
+export const MAX_BOARDS_PER_FOREIGN_GYM = 5;
+
+/**
  * Gate for attaching a board the caller OWNS to a gym: owner/admin of the gym as
  * before, plus a self-service path so a climber can put their board on the gym
  * they actually climb at without being staff there. Before #4166 this was
@@ -478,14 +486,21 @@ export async function requireBoardGymLinkAccess(opts: {
   // no coordinates at all, which would otherwise fail the proximity test.
   if (isOwner || memberRole === 'admin') return gym;
 
+  // A private gym must be indistinguishable from a non-existent one, or this
+  // becomes a probe for private home-wall gyms.
+  //
+  // This MUST stay above the rate limit. A missing gym throws out of
+  // loadGymWithMemberRole without ever reaching the bucket, so charging before
+  // this check made the two cases distinguishable by bucket state even though
+  // they share a message: probe five times, then call once against a known
+  // public gym — "rate limit exceeded" means the uuid is a live private gym,
+  // "not authorized" means it doesn't exist.
+  if (!gym.isPublic) throw new Error('Gym not found');
+
   // The tight bucket belongs to the self-service path only. Charged here rather
   // than at the call site so a gym owner adding several boards to their OWN gym
   // isn't throttled by a limit named for a path they're not on.
   await applyRateLimit(ctx, 5, 'linkBoardToForeignGym');
-
-  // A private gym must be indistinguishable from a non-existent one, or this
-  // becomes a probe for private home-wall gyms.
-  if (!gym.isPublic) throw new Error('Gym not found');
 
   if (boardLatitude == null || boardLongitude == null || gym.latitude == null || gym.longitude == null) {
     throw new Error('Not authorized to link board to this gym');
@@ -531,12 +546,32 @@ export async function requireBoardGymLinkAccess(opts: {
     throw new Error('Not authorized to link board to this gym');
   }
 
+  // Depth, not just breadth. The count above deliberately excludes this gym so
+  // several boards at the gym you actually climb at cost one slot — but that
+  // left the number of boards one account can push onto a SINGLE gym's listing
+  // unbounded. A climber has a handful of walls at one gym; a flood is someone
+  // else's problem to clean up by hand, one detach at a time.
+  const [{ count: boardsAtThisGym }] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(dbSchema.userBoards)
+    .where(
+      and(
+        eq(dbSchema.userBoards.ownerId, userId),
+        eq(dbSchema.userBoards.gymId, gym.id),
+        isNull(dbSchema.userBoards.deletedAt),
+      ),
+    );
+  if (boardsAtThisGym >= MAX_BOARDS_PER_FOREIGN_GYM) {
+    throw new Error('Not authorized to link board to this gym');
+  }
+
   logger.warn('board linked to a gym the owner does not administer', {
     userId,
     gymId: gym.id,
     gymUuid: gym.uuid,
     distanceMeters: Math.round(distance),
     existingForeignGyms: foreignGyms,
+    existingBoardsAtThisGym: boardsAtThisGym,
   });
 
   return gym;

--- a/packages/backend/src/graphql/resolvers/social/gyms.ts
+++ b/packages/backend/src/graphql/resolvers/social/gyms.ts
@@ -21,6 +21,9 @@ import {
   RevokeGymWriteAccessInputSchema,
   UUIDSchema,
 } from '../../../validation/schemas';
+import { distanceMeters } from '@boardsesh/db/queries';
+import { logger } from '../../../utils/logger';
+import { PROXIMITY_MATCH_RADIUS_METERS } from './gym-matching';
 
 // ============================================
 // Helpers
@@ -426,6 +429,88 @@ async function requireGymOwnerOrAdmin(gymUuid: string, userId: string): Promise<
   if (!isOwner && memberRole !== 'admin') {
     throw new Error('Not authorized: must be gym owner or admin');
   }
+  return gym;
+}
+
+/**
+ * How close a board must be to a gym for its owner to self-link it, when they
+ * don't own or administer that gym. Shares the stray-board matching radius so
+ * "at this gym" means one thing across the codebase.
+ */
+export const SELF_LINK_PROXIMITY_METERS = PROXIMITY_MATCH_RADIUS_METERS;
+
+/** Beyond this many links to gyms the caller neither owns nor admins, stop allowing more. */
+export const MAX_FOREIGN_GYM_LINKS = 5;
+
+/**
+ * Gate for attaching a board the caller OWNS to a gym: owner/admin of the gym as
+ * before, plus a self-service path so a climber can put their board on the gym
+ * they actually climb at without being staff there. Before #4166 this was
+ * owner-or-admin only, which made the common case — "there's a MoonBoard at this
+ * gym someone else listed, let me add it" — impossible.
+ *
+ * The proximity check is NOT a security boundary: the board's coordinates come
+ * from the caller and a public gym's are readable by anyone, so it stops honest
+ * mistakes, not deliberate spam. What actually bounds abuse is the combination
+ * of public-gyms-only, own-boards-only, the per-caller cap, the dedicated rate
+ * limit at the call site, and `detachBoardFromGym` letting gym staff undo it.
+ *
+ * Note a real consequence to surface in the UI: linking hands the gym's admins
+ * edit rights over the board (see `viewerCanAdminGym` → `requireBoardEditAccess`).
+ */
+export async function requireBoardGymLinkAccess(opts: {
+  gymUuid: string;
+  userId: string;
+  boardLatitude: number | null;
+  boardLongitude: number | null;
+}): Promise<typeof dbSchema.gyms.$inferSelect> {
+  const { gymUuid, userId, boardLatitude, boardLongitude } = opts;
+  const { gym, isOwner, memberRole } = await loadGymWithMemberRole(gymUuid, userId);
+
+  // Staff keep the unconditional path — including for gyms or boards that have
+  // no coordinates at all, which would otherwise fail the proximity test.
+  if (isOwner || memberRole === 'admin') return gym;
+
+  // A private gym must be indistinguishable from a non-existent one, or this
+  // becomes a probe for private home-wall gyms.
+  if (!gym.isPublic) throw new Error('Gym not found');
+
+  if (boardLatitude == null || boardLongitude == null || gym.latitude == null || gym.longitude == null) {
+    throw new Error('Not authorized to link board to this gym');
+  }
+
+  const distance = distanceMeters(
+    { latitude: boardLatitude, longitude: boardLongitude },
+    { latitude: gym.latitude, longitude: gym.longitude },
+  );
+  if (distance > SELF_LINK_PROXIMITY_METERS) {
+    throw new Error('Not authorized to link board to this gym');
+  }
+
+  const [{ count: foreignLinks }] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(dbSchema.userBoards)
+    .innerJoin(dbSchema.gyms, eq(dbSchema.userBoards.gymId, dbSchema.gyms.id))
+    .where(
+      and(
+        eq(dbSchema.userBoards.ownerId, userId),
+        isNull(dbSchema.userBoards.deletedAt),
+        sql`${dbSchema.gyms.ownerId} <> ${userId}`,
+        sql`NOT EXISTS (SELECT 1 FROM gym_members gm WHERE gm.gym_id = ${dbSchema.gyms.id} AND gm.user_id = ${userId} AND gm.role = 'admin')`,
+      ),
+    );
+  if (foreignLinks >= MAX_FOREIGN_GYM_LINKS) {
+    throw new Error('Not authorized to link board to this gym');
+  }
+
+  logger.warn('board linked to a gym the owner does not administer', {
+    userId,
+    gymId: gym.id,
+    gymUuid: gym.uuid,
+    distanceMeters: Math.round(distance),
+    existingForeignLinks: foreignLinks,
+  });
+
   return gym;
 }
 
@@ -1153,7 +1238,12 @@ export const socialGymMutations = {
 
     // Verify board ownership
     const [board] = await db
-      .select({ id: dbSchema.userBoards.id, ownerId: dbSchema.userBoards.ownerId })
+      .select({
+        id: dbSchema.userBoards.id,
+        ownerId: dbSchema.userBoards.ownerId,
+        latitude: dbSchema.userBoards.latitude,
+        longitude: dbSchema.userBoards.longitude,
+      })
       .from(dbSchema.userBoards)
       .where(and(eq(dbSchema.userBoards.uuid, validatedInput.boardUuid), isNull(dbSchema.userBoards.deletedAt)))
       .limit(1);
@@ -1167,12 +1257,20 @@ export const socialGymMutations = {
     }
 
     if (validatedInput.gymUuid) {
-      // Link to gym — verify gym ownership/admin
-      const gym = await requireGymOwnerOrAdmin(validatedInput.gymUuid, userId);
+      // Linking to a gym the caller doesn't run is the common case (a climber
+      // putting their board on the gym they climb at), so it gets its own,
+      // tighter rate bucket than the 20/min this mutation otherwise allows.
+      await applyRateLimit(ctx, 5, 'linkBoardToForeignGym');
+      const gym = await requireBoardGymLinkAccess({
+        gymUuid: validatedInput.gymUuid,
+        userId,
+        boardLatitude: board.latitude,
+        boardLongitude: board.longitude,
+      });
 
       await db.update(dbSchema.userBoards).set({ gymId: gym.id }).where(eq(dbSchema.userBoards.id, board.id));
     } else {
-      // Unlink from gym
+      // Unlink from gym — always the board owner's own call.
       await db.update(dbSchema.userBoards).set({ gymId: null }).where(eq(dbSchema.userBoards.id, board.id));
     }
 

--- a/packages/backend/src/graphql/resolvers/social/gyms.ts
+++ b/packages/backend/src/graphql/resolvers/social/gyms.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { eq, and, count, isNull, isNotNull, sql, ilike, or, desc, inArray, type SQL } from 'drizzle-orm';
+import { eq, ne, and, count, isNull, isNotNull, notExists, sql, ilike, or, desc, inArray, type SQL } from 'drizzle-orm';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { rowsFromResult } from '@boardsesh/db/client';
 import { db } from '../../../db/client';
@@ -465,17 +465,23 @@ export const MAX_FOREIGN_GYM_LINKS = 20;
  * edit rights over the board (see `viewerCanAdminGym` → `requireBoardEditAccess`).
  */
 export async function requireBoardGymLinkAccess(opts: {
+  ctx: ConnectionContext;
   gymUuid: string;
   userId: string;
   boardLatitude: number | null;
   boardLongitude: number | null;
 }): Promise<typeof dbSchema.gyms.$inferSelect> {
-  const { gymUuid, userId, boardLatitude, boardLongitude } = opts;
+  const { ctx, gymUuid, userId, boardLatitude, boardLongitude } = opts;
   const { gym, isOwner, memberRole } = await loadGymWithMemberRole(gymUuid, userId);
 
   // Staff keep the unconditional path — including for gyms or boards that have
   // no coordinates at all, which would otherwise fail the proximity test.
   if (isOwner || memberRole === 'admin') return gym;
+
+  // The tight bucket belongs to the self-service path only. Charged here rather
+  // than at the call site so a gym owner adding several boards to their OWN gym
+  // isn't throttled by a limit named for a path they're not on.
+  await applyRateLimit(ctx, 5, 'linkBoardToForeignGym');
 
   // A private gym must be indistinguishable from a non-existent one, or this
   // becomes a probe for private home-wall gyms.
@@ -505,9 +511,20 @@ export async function requireBoardGymLinkAccess(opts: {
         eq(dbSchema.userBoards.ownerId, userId),
         isNull(dbSchema.userBoards.deletedAt),
         isNull(dbSchema.gyms.deletedAt),
-        sql`${dbSchema.gyms.id} <> ${gym.id}`,
-        sql`${dbSchema.gyms.ownerId} <> ${userId}`,
-        sql`NOT EXISTS (SELECT 1 FROM gym_members gm WHERE gm.gym_id = ${dbSchema.gyms.id} AND gm.user_id = ${userId} AND gm.role = 'admin')`,
+        ne(dbSchema.gyms.id, gym.id),
+        ne(dbSchema.gyms.ownerId, userId),
+        notExists(
+          db
+            .select({ one: sql`1` })
+            .from(dbSchema.gymMembers)
+            .where(
+              and(
+                eq(dbSchema.gymMembers.gymId, dbSchema.gyms.id),
+                eq(dbSchema.gymMembers.userId, userId),
+                eq(dbSchema.gymMembers.role, 'admin'),
+              ),
+            ),
+        ),
       ),
     );
   if (foreignGyms >= MAX_FOREIGN_GYM_LINKS) {
@@ -1268,11 +1285,8 @@ export const socialGymMutations = {
     }
 
     if (validatedInput.gymUuid) {
-      // Linking to a gym the caller doesn't run is the common case (a climber
-      // putting their board on the gym they climb at), so it gets its own,
-      // tighter rate bucket than the 20/min this mutation otherwise allows.
-      await applyRateLimit(ctx, 5, 'linkBoardToForeignGym');
       const gym = await requireBoardGymLinkAccess({
+        ctx,
         gymUuid: validatedInput.gymUuid,
         userId,
         boardLatitude: board.latitude,

--- a/packages/backend/src/graphql/resolvers/social/gyms.ts
+++ b/packages/backend/src/graphql/resolvers/social/gyms.ts
@@ -439,8 +439,14 @@ async function requireGymOwnerOrAdmin(gymUuid: string, userId: string): Promise<
  */
 export const SELF_LINK_PROXIMITY_METERS = PROXIMITY_MATCH_RADIUS_METERS;
 
-/** Beyond this many links to gyms the caller neither owns nor admins, stop allowing more. */
-export const MAX_FOREIGN_GYM_LINKS = 5;
+/**
+ * Beyond this many DISTINCT gyms the caller neither owns nor admins, stop
+ * allowing more. Counted per gym, not per board, so someone with three boards at
+ * one gym spends one of their allowance rather than three. Set high enough to be
+ * invisible to a real climber (who travels to a handful of gyms) while still
+ * bounding a scripted spray across many listings.
+ */
+export const MAX_FOREIGN_GYM_LINKS = 20;
 
 /**
  * Gate for attaching a board the caller OWNS to a gym: owner/admin of the gym as
@@ -487,19 +493,24 @@ export async function requireBoardGymLinkAccess(opts: {
     throw new Error('Not authorized to link board to this gym');
   }
 
-  const [{ count: foreignLinks }] = await db
-    .select({ count: sql<number>`count(*)::int` })
+  // Distinct gyms, and live ones only: counting rows would spend three of the
+  // allowance on three boards at one gym, and counting soft-deleted gyms would
+  // permanently block someone whose past gyms were since removed.
+  const [{ count: foreignGyms }] = await db
+    .select({ count: sql<number>`count(DISTINCT ${dbSchema.gyms.id})::int` })
     .from(dbSchema.userBoards)
     .innerJoin(dbSchema.gyms, eq(dbSchema.userBoards.gymId, dbSchema.gyms.id))
     .where(
       and(
         eq(dbSchema.userBoards.ownerId, userId),
         isNull(dbSchema.userBoards.deletedAt),
+        isNull(dbSchema.gyms.deletedAt),
+        sql`${dbSchema.gyms.id} <> ${gym.id}`,
         sql`${dbSchema.gyms.ownerId} <> ${userId}`,
         sql`NOT EXISTS (SELECT 1 FROM gym_members gm WHERE gm.gym_id = ${dbSchema.gyms.id} AND gm.user_id = ${userId} AND gm.role = 'admin')`,
       ),
     );
-  if (foreignLinks >= MAX_FOREIGN_GYM_LINKS) {
+  if (foreignGyms >= MAX_FOREIGN_GYM_LINKS) {
     throw new Error('Not authorized to link board to this gym');
   }
 
@@ -508,7 +519,7 @@ export async function requireBoardGymLinkAccess(opts: {
     gymId: gym.id,
     gymUuid: gym.uuid,
     distanceMeters: Math.round(distance),
-    existingForeignLinks: foreignLinks,
+    existingForeignGyms: foreignGyms,
   });
 
   return gym;

--- a/packages/backend/src/validation/schemas/boards.ts
+++ b/packages/backend/src/validation/schemas/boards.ts
@@ -48,6 +48,10 @@ export const CreateBoardInputSchema = z.object({
   // is meaningless (the "no timer" sentinel is null/absent, and the mobile
   // builder already coerces blank → omitted).
   timerName: z.string().min(1).max(200, 'Timer name too long').optional(),
+  // Set only by a client that has shown the user the duplicate prompt and had
+  // them confirm this is a different physical wall. Skips the duplicate-config
+  // guard entirely — see board-duplicates.ts.
+  allowDuplicateConfig: z.boolean().optional(),
 });
 
 /**

--- a/packages/backend/src/validation/schemas/gyms.ts
+++ b/packages/backend/src/validation/schemas/gyms.ts
@@ -237,6 +237,15 @@ export const AttachBoardToGymInputSchema = z.object({
 });
 
 /**
+ * Detach board from gym input validation schema. Same shape as attach; the
+ * resolver gates on gym edit access and on the board actually being listed there.
+ */
+export const DetachBoardFromGymInputSchema = z.object({
+  gymUuid: UUIDSchema,
+  boardUuid: UUIDSchema,
+});
+
+/**
  * Gym insights (owner activity dashboard) input validation schema. `period`
  * chooses the window length; the resolver derives the day count and the equally
  * long prior comparison window from it.

--- a/packages/db/drizzle/0189_allow_duplicate_board_configs.sql
+++ b/packages/db/drizzle/0189_allow_duplicate_board_configs.sql
@@ -1,2 +1,2 @@
-DROP INDEX "user_boards_unique_owner_config";--> statement-breakpoint
+DROP INDEX IF EXISTS "user_boards_unique_owner_config";--> statement-breakpoint
 CREATE INDEX "user_boards_owner_config_idx" ON "user_boards" USING btree ("owner_id","board_type","layout_id","size_id","set_ids") WHERE "user_boards"."deleted_at" IS NULL;

--- a/packages/db/drizzle/0189_allow_duplicate_board_configs.sql
+++ b/packages/db/drizzle/0189_allow_duplicate_board_configs.sql
@@ -1,0 +1,2 @@
+DROP INDEX "user_boards_unique_owner_config";--> statement-breakpoint
+CREATE INDEX "user_boards_owner_config_idx" ON "user_boards" USING btree ("owner_id","board_type","layout_id","size_id","set_ids") WHERE "user_boards"."deleted_at" IS NULL;

--- a/packages/db/drizzle/meta/0189_snapshot.json
+++ b/packages/db/drizzle/meta/0189_snapshot.json
@@ -1,0 +1,12318 @@
+{
+  "id": "0b165712-1164-48bf-9840-16bbf0593c36",
+  "prevId": "5599f9f2-1586-4bc7-b779-8997da2a92a5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.board_attempts": {
+      "name": "board_attempts",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_attempts_board_type_id_pk": {
+          "name": "board_attempts_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_beta_links": {
+      "name": "board_beta_links",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "foreign_username": {
+          "name": "foreign_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tick_uuid": {
+          "name": "tick_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shortcode": {
+          "name": "shortcode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_identity": {
+          "name": "video_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_beta_links_shortcode_idx": {
+          "name": "board_beta_links_shortcode_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shortcode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_beta_links\".\"shortcode\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_beta_links_created_by_idx": {
+          "name": "board_beta_links_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_beta_links\".\"created_by_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_beta_links_video_identity_unique": {
+          "name": "board_beta_links_video_identity_unique",
+          "columns": [
+            {
+              "expression": "video_identity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"board_beta_links\".\"video_identity\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_beta_links_tick_uuid_unique": {
+          "name": "board_beta_links_tick_uuid_unique",
+          "columns": [
+            {
+              "expression": "tick_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"board_beta_links\".\"tick_uuid\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_beta_links_board_id_idx": {
+          "name": "board_beta_links_board_id_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_beta_links\".\"board_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_beta_links_board_type_climb_uuid_link_pk": {
+          "name": "board_beta_links_board_type_climb_uuid_link_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid",
+            "link"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_circuits": {
+      "name": "board_circuits",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_circuits_user_idx": {
+          "name": "board_circuits_user_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_circuits_user_fk": {
+          "name": "board_circuits_user_fk",
+          "tableFrom": "board_circuits",
+          "tableTo": "board_users",
+          "columnsFrom": [
+            "board_type",
+            "user_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_circuits_board_type_uuid_pk": {
+          "name": "board_circuits_board_type_uuid_pk",
+          "columns": [
+            "board_type",
+            "uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_circuits_climbs": {
+      "name": "board_circuits_climbs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "circuit_uuid": {
+          "name": "circuit_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_circuits_climbs_circuit_fk": {
+          "name": "board_circuits_climbs_circuit_fk",
+          "tableFrom": "board_circuits_climbs",
+          "tableTo": "board_circuits",
+          "columnsFrom": [
+            "board_type",
+            "circuit_uuid"
+          ],
+          "columnsTo": [
+            "board_type",
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_circuits_climbs_climb_fk": {
+          "name": "board_circuits_climbs_climb_fk",
+          "tableFrom": "board_circuits_climbs",
+          "tableTo": "board_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk": {
+          "name": "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk",
+          "columns": [
+            "board_type",
+            "circuit_uuid",
+            "climb_uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_aliases": {
+      "name": "board_climb_aliases",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias_uuid": {
+          "name": "alias_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_uuid": {
+          "name": "canonical_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_aliases_canonical_idx": {
+          "name": "board_climb_aliases_canonical_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "canonical_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climb_aliases_canonical_fk": {
+          "name": "board_climb_aliases_canonical_fk",
+          "tableFrom": "board_climb_aliases",
+          "tableTo": "board_climbs",
+          "columnsFrom": [
+            "canonical_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_climb_aliases_board_type_alias_uuid_pk": {
+          "name": "board_climb_aliases_board_type_alias_uuid_pk",
+          "columns": [
+            "board_type",
+            "alias_uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "board_climb_aliases_uuids_non_empty": {
+          "name": "board_climb_aliases_uuids_non_empty",
+          "value": "\"board_climb_aliases\".\"alias_uuid\" <> '' AND \"board_climb_aliases\".\"canonical_uuid\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.board_climb_holds": {
+      "name": "board_climb_holds",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_number": {
+          "name": "frame_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_state": {
+          "name": "hold_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_holds_search_idx": {
+          "name": "board_climb_holds_search_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climb_holds_climb_fk": {
+          "name": "board_climb_holds_climb_fk",
+          "tableFrom": "board_climb_holds",
+          "tableTo": "board_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_climb_holds_board_type_climb_uuid_hold_id_pk": {
+          "name": "board_climb_holds_board_type_climb_uuid_hold_id_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid",
+            "hold_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_ingest_skips": {
+      "name": "board_climb_ingest_skips",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_layout_uuid": {
+          "name": "source_layout_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_holds": {
+          "name": "raw_holds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frames_count": {
+          "name": "frames_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "climb_name": {
+          "name": "climb_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_climb_ingest_skips_open_idx": {
+          "name": "board_climb_ingest_skips_open_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_climb_ingest_skips_board_type_climb_uuid_pk": {
+          "name": "board_climb_ingest_skips_board_type_climb_uuid_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_ratings": {
+      "name": "board_climb_ratings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_grade_id": {
+          "name": "difficulty_grade_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_id": {
+          "name": "kilter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_detached_at": {
+          "name": "kilter_detached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_ratings_user_climb_angle_idx": {
+          "name": "board_climb_ratings_user_climb_angle_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_ratings_kilter_id_unique": {
+          "name": "board_climb_ratings_kilter_id_unique",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"board_climb_ratings\".\"kilter_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_ratings_aurora_id_unique": {
+          "name": "board_climb_ratings_aurora_id_unique",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"board_climb_ratings\".\"aurora_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_ratings_user_kilter_idx": {
+          "name": "board_climb_ratings_user_kilter_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_climb_ratings\".\"kilter_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climb_ratings_user_id_users_id_fk": {
+          "name": "board_climb_ratings_user_id_users_id_fk",
+          "tableFrom": "board_climb_ratings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "board_climb_ratings_rating_range": {
+          "name": "board_climb_ratings_rating_range",
+          "value": "\"board_climb_ratings\".\"rating\" IS NULL OR (\"board_climb_ratings\".\"rating\" >= 1 AND \"board_climb_ratings\".\"rating\" <= 5)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.board_climb_stats": {
+      "name": "board_climb_stats",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_ascensionist_count": {
+          "name": "upstream_ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boardsesh_ascensionist_count": {
+          "name": "boardsesh_ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_quality_average": {
+          "name": "upstream_quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boardsesh_quality_sum": {
+          "name": "boardsesh_quality_sum",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boardsesh_quality_count": {
+          "name": "boardsesh_quality_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_normalized": {
+          "name": "quality_normalized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_synced_at": {
+          "name": "upstream_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sync_seq": {
+          "name": "sync_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "board_climb_stats_sync_cursor_idx": {
+          "name": "board_climb_stats_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sync_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_climb_stats_board_type_climb_uuid_angle_pk": {
+          "name": "board_climb_stats_board_type_climb_uuid_angle_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid",
+            "angle"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_stats_history": {
+      "name": "board_climb_stats_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_stats_history_lookup_idx": {
+          "name": "board_climb_stats_history_lookup_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climbs": {
+      "name": "board_climbs",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setter_id": {
+          "name": "setter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frames_count": {
+          "name": "frames_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "frames_pace": {
+          "name": "frames_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "frames": {
+          "name": "frames",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced": {
+          "name": "synced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_set_ids": {
+          "name": "required_set_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compatible_size_ids": {
+          "name": "compatible_size_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hold_fingerprint": {
+          "name": "hold_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "characteristics": {
+          "name": "characteristics",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sync_seq": {
+          "name": "sync_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "board_climbs_board_type_idx": {
+          "name": "board_climbs_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_sync_cursor_idx": {
+          "name": "board_climbs_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sync_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_hold_fingerprint_idx": {
+          "name": "board_climbs_hold_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_search_filter_idx": {
+          "name": "board_climbs_search_filter_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_listed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_draft",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frames_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_left",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_right",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_bottom",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_top",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_setter_username_idx": {
+          "name": "board_climbs_setter_username_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_user_id_idx": {
+          "name": "board_climbs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_climbs\".\"user_id\" IS NOT NULL AND \"board_climbs\".\"is_draft\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_name_idx": {
+          "name": "board_climbs_name_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climbs_user_id_users_id_fk": {
+          "name": "board_climbs_user_id_users_id_fk",
+          "tableFrom": "board_climbs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_difficulty_grades": {
+      "name": "board_difficulty_grades",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boulder_name": {
+          "name": "boulder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_name": {
+          "name": "route_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_difficulty_grades_board_type_difficulty_pk": {
+          "name": "board_difficulty_grades_board_type_difficulty_pk",
+          "columns": [
+            "board_type",
+            "difficulty"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_holes": {
+      "name": "board_holes",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirrored_hole_id": {
+          "name": "mirrored_hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirror_group": {
+          "name": "mirror_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_holes_product_fk": {
+          "name": "board_holes_product_fk",
+          "tableFrom": "board_holes",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_holes_board_type_id_pk": {
+          "name": "board_holes_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_kits": {
+      "name": "board_kits",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_autoconnect": {
+          "name": "is_autoconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_kits_board_type_serial_number_pk": {
+          "name": "board_kits_board_type_serial_number_pk",
+          "columns": [
+            "board_type",
+            "serial_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_layout_aliases": {
+      "name": "board_layout_aliases",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_uuid": {
+          "name": "layout_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_layout_aliases_layout_idx": {
+          "name": "board_layout_aliases_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_layout_aliases_layout_fk": {
+          "name": "board_layout_aliases_layout_fk",
+          "tableFrom": "board_layout_aliases",
+          "tableTo": "board_layouts",
+          "columnsFrom": [
+            "board_type",
+            "layout_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_layout_aliases_board_type_layout_uuid_pk": {
+          "name": "board_layout_aliases_board_type_layout_uuid_pk",
+          "columns": [
+            "board_type",
+            "layout_uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "board_layout_aliases_uuid_non_empty": {
+          "name": "board_layout_aliases_uuid_non_empty",
+          "value": "\"board_layout_aliases\".\"layout_uuid\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.board_layouts": {
+      "name": "board_layouts",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_caption": {
+          "name": "instagram_caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirrored": {
+          "name": "is_mirrored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_layouts_product_fk": {
+          "name": "board_layouts_product_fk",
+          "tableFrom": "board_layouts",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_layouts_board_type_id_pk": {
+          "name": "board_layouts_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_leds": {
+      "name": "board_leds",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_leds_product_size_fk": {
+          "name": "board_leds_product_size_fk",
+          "tableFrom": "board_leds",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": [
+            "board_type",
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_leds_hole_fk": {
+          "name": "board_leds_hole_fk",
+          "tableFrom": "board_leds",
+          "tableTo": "board_holes",
+          "columnsFrom": [
+            "board_type",
+            "hole_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_leds_board_type_id_pk": {
+          "name": "board_leds_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_placement_roles": {
+      "name": "board_placement_roles",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "led_color": {
+          "name": "led_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_color": {
+          "name": "screen_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_placement_roles_product_fk": {
+          "name": "board_placement_roles_product_fk",
+          "tableFrom": "board_placement_roles",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_placement_roles_board_type_id_pk": {
+          "name": "board_placement_roles_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_placements": {
+      "name": "board_placements",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_placement_role_id": {
+          "name": "default_placement_role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_placements_board_type_layout_id_set_hole_idx": {
+          "name": "board_placements_board_type_layout_id_set_hole_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hole_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_placements_board_type_layout_id_hole_id_idx": {
+          "name": "board_placements_board_type_layout_id_hole_id_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hole_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_placements_layout_fk": {
+          "name": "board_placements_layout_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_layouts",
+          "columnsFrom": [
+            "board_type",
+            "layout_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_hole_fk": {
+          "name": "board_placements_hole_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_holes",
+          "columnsFrom": [
+            "board_type",
+            "hole_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_set_fk": {
+          "name": "board_placements_set_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_sets",
+          "columnsFrom": [
+            "board_type",
+            "set_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_role_fk": {
+          "name": "board_placements_role_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_placement_roles",
+          "columnsFrom": [
+            "board_type",
+            "default_placement_role_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_placements_board_type_id_pk": {
+          "name": "board_placements_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_product_sizes": {
+      "name": "board_product_sizes",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_product_sizes_product_fk": {
+          "name": "board_product_sizes_product_fk",
+          "tableFrom": "board_product_sizes",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_product_sizes_board_type_id_pk": {
+          "name": "board_product_sizes_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_product_sizes_layouts_sets": {
+      "name": "board_product_sizes_layouts_sets",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_psls_product_size_fk": {
+          "name": "board_psls_product_size_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": [
+            "board_type",
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_psls_layout_fk": {
+          "name": "board_psls_layout_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_layouts",
+          "columnsFrom": [
+            "board_type",
+            "layout_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_psls_set_fk": {
+          "name": "board_psls_set_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_sets",
+          "columnsFrom": [
+            "board_type",
+            "set_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_product_sizes_layouts_sets_board_type_id_pk": {
+          "name": "board_product_sizes_layouts_sets_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_products": {
+      "name": "board_products",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_count_in_frame": {
+          "name": "min_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_count_in_frame": {
+          "name": "max_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_products_board_type_id_pk": {
+          "name": "board_products_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_sets": {
+      "name": "board_sets",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_sets_board_type_id_pk": {
+          "name": "board_sets_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_shared_syncs": {
+      "name": "board_shared_syncs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_shared_syncs_board_type_table_name_pk": {
+          "name": "board_shared_syncs_board_type_table_name_pk",
+          "columns": [
+            "board_type",
+            "table_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_tags": {
+      "name": "board_tags",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_uuid": {
+          "name": "entity_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_tags_board_type_entity_uuid_user_id_name_pk": {
+          "name": "board_tags_board_type_entity_uuid_user_id_name_pk",
+          "columns": [
+            "board_type",
+            "entity_uuid",
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_user_syncs": {
+      "name": "board_user_syncs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_user_syncs_user_fk": {
+          "name": "board_user_syncs_user_fk",
+          "tableFrom": "board_user_syncs",
+          "tableTo": "board_users",
+          "columnsFrom": [
+            "board_type",
+            "user_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_user_syncs_board_type_user_id_table_name_pk": {
+          "name": "board_user_syncs_board_type_user_id_table_name_pk",
+          "columns": [
+            "board_type",
+            "user_id",
+            "table_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_users": {
+      "name": "board_users",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_users_board_type_id_pk": {
+          "name": "board_users_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_walls": {
+      "name": "board_walls",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_adjustable": {
+          "name": "is_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_walls_user_fk": {
+          "name": "board_walls_user_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_users",
+          "columnsFrom": [
+            "board_type",
+            "user_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_walls_product_fk": {
+          "name": "board_walls_product_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "board_walls_layout_fk": {
+          "name": "board_walls_layout_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_layouts",
+          "columnsFrom": [
+            "board_type",
+            "layout_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "board_walls_product_size_fk": {
+          "name": "board_walls_product_size_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": [
+            "board_type",
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_walls_board_type_uuid_pk": {
+          "name": "board_walls_board_type_uuid_pk",
+          "columns": [
+            "board_type",
+            "uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_providerAccountId_pk": {
+          "name": "accounts_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_userId_users_id_fk": {
+          "name": "sessions_userId_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationTokens": {
+      "name": "verificationTokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationTokens_identifier_token_pk": {
+          "name": "verificationTokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_credentials": {
+      "name": "user_credentials",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_credentials_user_id_users_id_fk": {
+          "name": "user_credentials_user_id_users_id_fk",
+          "tableFrom": "user_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_url": {
+          "name": "instagram_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.aurora_credentials": {
+      "name": "aurora_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_username": {
+          "name": "encrypted_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_password": {
+          "name": "encrypted_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_refresh_token": {
+          "name": "encrypted_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_user_id": {
+          "name": "aurora_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_token": {
+          "name": "aurora_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_attempt_at": {
+          "name": "last_sync_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_failure_count": {
+          "name": "credential_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_credential_failure_at": {
+          "name": "last_credential_failure_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_board_credential": {
+          "name": "unique_user_board_credential",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "aurora_credentials_user_idx": {
+          "name": "aurora_credentials_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "aurora_credentials_sync_priority_idx": {
+          "name": "aurora_credentials_sync_priority_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sync_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_sync_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"aurora_credentials\".\"sync_status\" IN ('pending', 'active', 'error')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "aurora_credentials_sync_attempt_priority_idx": {
+          "name": "aurora_credentials_sync_attempt_priority_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sync_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_sync_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"aurora_credentials\".\"sync_status\" IN ('pending', 'active', 'error')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "aurora_credentials_user_id_users_id_fk": {
+          "name": "aurora_credentials_user_id_users_id_fk",
+          "tableFrom": "aurora_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_board_mappings": {
+      "name": "user_board_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_user_id": {
+          "name": "board_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_user_id_text": {
+          "name": "board_user_id_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_username": {
+          "name": "board_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_board_mapping": {
+          "name": "unique_user_board_mapping",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_user_mapping_idx": {
+          "name": "board_user_mapping_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_user_mapping_text_idx": {
+          "name": "board_user_mapping_text_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_user_id_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_board_mappings_user_id_users_id_fk": {
+          "name": "user_board_mappings_user_id_users_id_fk",
+          "tableFrom": "user_board_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mobile_refresh_tokens": {
+      "name": "mobile_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mobile_refresh_tokens_token_hash_idx": {
+          "name": "mobile_refresh_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mobile_refresh_tokens_user_id_idx": {
+          "name": "mobile_refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mobile_refresh_tokens_expires_at_idx": {
+          "name": "mobile_refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mobile_refresh_tokens_revoked_at_partial_idx": {
+          "name": "mobile_refresh_tokens_revoked_at_partial_idx",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"revoked_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mobile_refresh_tokens_user_id_users_id_fk": {
+          "name": "mobile_refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "mobile_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_credentials": {
+      "name": "integration_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_refresh_token": {
+          "name": "encrypted_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_account_name": {
+          "name": "external_account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_sync_enabled": {
+          "name": "auto_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_integration": {
+          "name": "unique_user_integration",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_credentials_user_id_users_id_fk": {
+          "name": "integration_credentials_user_id_users_id_fk",
+          "tableFrom": "integration_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_claims": {
+      "name": "gym_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimant_user_id": {
+          "name": "claimant_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "gym_claim_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "gym_claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "claim_email": {
+          "name": "claim_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gym_claims_gym_idx": {
+          "name": "gym_claims_gym_idx",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gym_claims_claimant_idx": {
+          "name": "gym_claims_claimant_idx",
+          "columns": [
+            {
+              "expression": "claimant_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gym_claims_status_idx": {
+          "name": "gym_claims_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gym_claims_token_hash_idx": {
+          "name": "gym_claims_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gym_claims\".\"token_hash\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gym_claims_unique_pending": {
+          "name": "gym_claims_unique_pending",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claimant_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gym_claims\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gym_claims_gym_id_gyms_id_fk": {
+          "name": "gym_claims_gym_id_gyms_id_fk",
+          "tableFrom": "gym_claims",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gym_claims_claimant_user_id_users_id_fk": {
+          "name": "gym_claims_claimant_user_id_users_id_fk",
+          "tableFrom": "gym_claims",
+          "tableTo": "users",
+          "columnsFrom": [
+            "claimant_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gym_claims_reviewed_by_users_id_fk": {
+          "name": "gym_claims_reviewed_by_users_id_fk",
+          "tableFrom": "gym_claims",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_follows": {
+      "name": "gym_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gym_follows_unique_gym_user": {
+          "name": "gym_follows_unique_gym_user",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gym_follows_gym_id_gyms_id_fk": {
+          "name": "gym_follows_gym_id_gyms_id_fk",
+          "tableFrom": "gym_follows",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gym_follows_user_id_users_id_fk": {
+          "name": "gym_follows_user_id_users_id_fk",
+          "tableFrom": "gym_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_members": {
+      "name": "gym_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "gym_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gym_members_unique_gym_user": {
+          "name": "gym_members_unique_gym_user",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gym_members_gym_id_gyms_id_fk": {
+          "name": "gym_members_gym_id_gyms_id_fk",
+          "tableFrom": "gym_members",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gym_members_user_id_users_id_fk": {
+          "name": "gym_members_user_id_users_id_fk",
+          "tableFrom": "gym_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gyms": {
+      "name": "gyms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_primary_color": {
+          "name": "brand_primary_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_accent_color": {
+          "name": "brand_accent_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_background_color": {
+          "name": "brand_background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_into_gym_id": {
+          "name": "merged_into_gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_frozen_at": {
+          "name": "sync_frozen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gyms_unique_slug": {
+          "name": "gyms_unique_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_uuid_idx": {
+          "name": "gyms_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_owner_idx": {
+          "name": "gyms_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_public_idx": {
+          "name": "gyms_public_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_merged_into_idx": {
+          "name": "gyms_merged_into_idx",
+          "columns": [
+            {
+              "expression": "merged_into_gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gyms\".\"merged_into_gym_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gyms_owner_id_users_id_fk": {
+          "name": "gyms_owner_id_users_id_fk",
+          "tableFrom": "gyms",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gyms_merged_into_gym_id_gyms_id_fk": {
+          "name": "gyms_merged_into_gym_id_gyms_id_fk",
+          "tableFrom": "gyms",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "merged_into_gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gyms_uuid_unique": {
+          "name": "gyms_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_kiosks": {
+      "name": "gym_kiosks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"version\":1,\"boards\":[],\"leaderboard\":null}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gym_kiosks_unique_gym_slug": {
+          "name": "gym_kiosks_unique_gym_slug",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gym_kiosks\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gym_kiosks_gym_idx": {
+          "name": "gym_kiosks_gym_idx",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gym_kiosks\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gym_kiosks_gym_id_gyms_id_fk": {
+          "name": "gym_kiosks_gym_id_gyms_id_fk",
+          "tableFrom": "gym_kiosks",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gym_kiosks_uuid_unique": {
+          "name": "gym_kiosks_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_merge_audit": {
+      "name": "gym_merge_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "gym_merge_audit_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_gym_id": {
+          "name": "canonical_gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duplicate_gym_id": {
+          "name": "duplicate_gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_signature": {
+          "name": "cluster_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moved_counts": {
+          "name": "moved_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moved_rows": {
+          "name": "moved_rows",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gym_merge_audit_signature_action_idx": {
+          "name": "gym_merge_audit_signature_action_idx",
+          "columns": [
+            {
+              "expression": "cluster_signature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gym_merge_audit_canonical_idx": {
+          "name": "gym_merge_audit_canonical_idx",
+          "columns": [
+            {
+              "expression": "canonical_gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gym_merge_audit_canonical_gym_id_gyms_id_fk": {
+          "name": "gym_merge_audit_canonical_gym_id_gyms_id_fk",
+          "tableFrom": "gym_merge_audit",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "canonical_gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gym_merge_audit_duplicate_gym_id_gyms_id_fk": {
+          "name": "gym_merge_audit_duplicate_gym_id_gyms_id_fk",
+          "tableFrom": "gym_merge_audit",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "duplicate_gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gym_merge_audit_performed_by_users_id_fk": {
+          "name": "gym_merge_audit_performed_by_users_id_fk",
+          "tableFrom": "gym_merge_audit",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_follows": {
+      "name": "board_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_follows_unique_user_board": {
+          "name": "board_follows_unique_user_board",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_follows_user_idx": {
+          "name": "board_follows_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_follows_board_uuid_idx": {
+          "name": "board_follows_board_uuid_idx",
+          "columns": [
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_follows_user_id_users_id_fk": {
+          "name": "board_follows_user_id_users_id_fk",
+          "tableFrom": "board_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "board_follows_board_uuid_user_boards_uuid_fk": {
+          "name": "board_follows_board_uuid_user_boards_uuid_fk",
+          "tableFrom": "board_follows",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_boards": {
+      "name": "user_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_unlisted": {
+          "name": "is_unlisted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hide_location": {
+          "name": "hide_location",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_owned": {
+          "name": "is_owned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 40
+        },
+        "is_angle_adjustable": {
+          "name": "is_angle_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timer_name": {
+          "name": "timer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_frozen_at": {
+          "name": "sync_frozen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_boards_gym_idx": {
+          "name": "user_boards_gym_idx",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_owner_config_idx": {
+          "name": "user_boards_owner_config_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "set_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_owner_owned_idx": {
+          "name": "user_boards_owner_owned_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_owned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_public_idx": {
+          "name": "user_boards_public_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_unique_slug": {
+          "name": "user_boards_unique_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_uuid_idx": {
+          "name": "user_boards_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_unique_owner_serial": {
+          "name": "user_boards_unique_owner_serial",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_boards\".\"serial_number\" IS NOT NULL AND \"user_boards\".\"serial_number\" <> '' AND \"user_boards\".\"deleted_at\" IS NULL AND \"user_boards\".\"owner_id\" != '00000000-0000-0000-0000-000000000000'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_serial_idx": {
+          "name": "user_boards_serial_idx",
+          "columns": [
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_boards\".\"serial_number\" IS NOT NULL AND \"user_boards\".\"serial_number\" <> '' AND \"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_boards_owner_id_users_id_fk": {
+          "name": "user_boards_owner_id_users_id_fk",
+          "tableFrom": "user_boards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_boards_gym_id_gyms_id_fk": {
+          "name": "user_boards_gym_id_gyms_id_fk",
+          "tableFrom": "user_boards",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_boards_uuid_unique": {
+          "name": "user_boards_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_board_serials": {
+      "name": "user_board_serials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_level": {
+          "name": "api_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_board_serials_unique_user_serial": {
+          "name": "user_board_serials_unique_user_serial",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_board_serials_serial_idx": {
+          "name": "user_board_serials_serial_idx",
+          "columns": [
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_board_serials_board_uuid_idx": {
+          "name": "user_board_serials_board_uuid_idx",
+          "columns": [
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_board_serials_user_id_users_id_fk": {
+          "name": "user_board_serials_user_id_users_id_fk",
+          "tableFrom": "user_board_serials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_board_serials_board_uuid_user_boards_uuid_fk": {
+          "name": "user_board_serials_board_uuid_user_boards_uuid_fk",
+          "tableFrom": "user_board_serials",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_queues": {
+      "name": "board_session_queues",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queue": {
+          "name": "queue",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "current_climb_queue_item": {
+          "name": "current_climb_queue_item",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_session_queues_session_id_board_sessions_id_fk": {
+          "name": "board_session_queues_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_queues",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_sessions": {
+      "name": "board_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_path": {
+          "name": "board_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity": {
+          "name": "last_activity",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discoverable": {
+          "name": "discoverable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal": {
+          "name": "goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_permanent": {
+          "name": "is_permanent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_sessions_location_idx": {
+          "name": "board_sessions_location_idx",
+          "columns": [
+            {
+              "expression": "latitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "longitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_discoverable_idx": {
+          "name": "board_sessions_discoverable_idx",
+          "columns": [
+            {
+              "expression": "discoverable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_user_idx": {
+          "name": "board_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_status_idx": {
+          "name": "board_sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_last_activity_idx": {
+          "name": "board_sessions_last_activity_idx",
+          "columns": [
+            {
+              "expression": "last_activity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_discovery_idx": {
+          "name": "board_sessions_discovery_idx",
+          "columns": [
+            {
+              "expression": "discoverable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_sessions_created_by_user_id_users_id_fk": {
+          "name": "board_sessions_created_by_user_id_users_id_fk",
+          "tableFrom": "board_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "board_sessions_board_id_user_boards_id_fk": {
+          "name": "board_sessions_board_id_user_boards_id_fk",
+          "tableFrom": "board_sessions",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_boards": {
+      "name": "session_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_boards_session_board_idx": {
+          "name": "session_boards_session_board_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_boards_session_idx": {
+          "name": "session_boards_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_boards_board_idx": {
+          "name": "session_boards_board_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_boards_session_id_board_sessions_id_fk": {
+          "name": "session_boards_session_id_board_sessions_id_fk",
+          "tableFrom": "session_boards",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_boards_board_id_user_boards_id_fk": {
+          "name": "session_boards_board_id_user_boards_id_fk",
+          "tableFrom": "session_boards",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_health_kit_workouts": {
+      "name": "session_health_kit_workouts",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_health_kit_workouts_session_idx": {
+          "name": "session_health_kit_workouts_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_health_kit_workouts_user_idx": {
+          "name": "session_health_kit_workouts_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_health_kit_workouts_session_id_board_sessions_id_fk": {
+          "name": "session_health_kit_workouts_session_id_board_sessions_id_fk",
+          "tableFrom": "session_health_kit_workouts",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_health_kit_workouts_user_id_users_id_fk": {
+          "name": "session_health_kit_workouts_user_id_users_id_fk",
+          "tableFrom": "session_health_kit_workouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_health_kit_workouts_session_id_user_id_pk": {
+          "name": "session_health_kit_workouts_session_id_user_id_pk",
+          "columns": [
+            "session_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_favorite": {
+          "name": "unique_user_favorite",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_user_idx": {
+          "name": "user_favorites_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_climb_idx": {
+          "name": "user_favorites_climb_idx",
+          "columns": [
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_sync_cursor_idx": {
+          "name": "user_favorites_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boardsesh_ticks": {
+      "name": "boardsesh_ticks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_mirror": {
+          "name": "is_mirror",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "tick_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "status": {
+          "name": "status",
+          "type": "tick_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "climbed_at": {
+          "name": "climbed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_type": {
+          "name": "aurora_type",
+          "type": "aurora_table_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_synced_at": {
+          "name": "aurora_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_sync_error": {
+          "name": "aurora_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_type": {
+          "name": "kilter_type",
+          "type": "kilter_table_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_id": {
+          "name": "kilter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_synced_at": {
+          "name": "kilter_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_sync_error": {
+          "name": "kilter_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_detached_at": {
+          "name": "kilter_detached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "boardsesh_ticks_user_board_idx": {
+          "name": "boardsesh_ticks_user_board_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_climb_idx": {
+          "name": "boardsesh_ticks_climb_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_aurora_id_unique": {
+          "name": "boardsesh_ticks_aurora_id_unique",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_sync_pending_idx": {
+          "name": "boardsesh_ticks_sync_pending_idx",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_kilter_id_unique": {
+          "name": "boardsesh_ticks_kilter_id_unique",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_kilter_sync_pending_idx": {
+          "name": "boardsesh_ticks_kilter_sync_pending_idx",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_session_idx": {
+          "name": "boardsesh_ticks_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_climbed_at_idx": {
+          "name": "boardsesh_ticks_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_user_climbed_at_idx": {
+          "name": "boardsesh_ticks_user_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_board_climbed_at_idx": {
+          "name": "boardsesh_ticks_board_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_board_user_idx": {
+          "name": "boardsesh_ticks_board_user_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_user_climb_lookup_idx": {
+          "name": "boardsesh_ticks_user_climb_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_sync_cursor_idx": {
+          "name": "boardsesh_ticks_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_flash_send_updated_at_idx": {
+          "name": "boardsesh_ticks_flash_send_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"boardsesh_ticks\".\"status\" IN ('flash','send')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boardsesh_ticks_user_id_users_id_fk": {
+          "name": "boardsesh_ticks_user_id_users_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_session_id_board_sessions_id_fk": {
+          "name": "boardsesh_ticks_session_id_board_sessions_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_board_id_user_boards_id_fk": {
+          "name": "boardsesh_ticks_board_id_user_boards_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boardsesh_ticks_uuid_unique": {
+          "name": "boardsesh_ticks_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "boardsesh_ticks_quality_range": {
+          "name": "boardsesh_ticks_quality_range",
+          "value": "\"boardsesh_ticks\".\"quality\" IS NULL OR (\"boardsesh_ticks\".\"quality\" >= 1 AND \"boardsesh_ticks\".\"quality\" <= 5)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.board_climb_events": {
+      "name": "board_climb_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frames": {
+          "name": "frames",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter": {
+          "name": "setter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_events_board_confirmed_at_idx": {
+          "name": "board_climb_events_board_confirmed_at_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "confirmed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_events_board_seq_unique": {
+          "name": "board_climb_events_board_seq_unique",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_events_session_idx": {
+          "name": "board_climb_events_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_events_board_climb_idx": {
+          "name": "board_climb_events_board_climb_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climb_events_board_id_user_boards_id_fk": {
+          "name": "board_climb_events_board_id_user_boards_id_fk",
+          "tableFrom": "board_climb_events",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "board_climb_events_user_id_users_id_fk": {
+          "name": "board_climb_events_user_id_users_id_fk",
+          "tableFrom": "board_climb_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "board_climb_events_session_id_board_sessions_id_fk": {
+          "name": "board_climb_events_session_id_board_sessions_id_fk",
+          "tableFrom": "board_climb_events",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_climbs": {
+      "name": "playlist_climbs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_climb": {
+          "name": "unique_playlist_climb",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_climbs_climb_idx": {
+          "name": "playlist_climbs_climb_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_climbs_position_idx": {
+          "name": "playlist_climbs_position_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_climbs_sync_cursor_idx": {
+          "name": "playlist_climbs_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_climbs_playlist_id_playlists_id_fk": {
+          "name": "playlist_climbs_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_climbs",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_ownership": {
+      "name": "playlist_ownership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_ownership": {
+          "name": "unique_playlist_ownership",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_ownership_user_idx": {
+          "name": "playlist_ownership_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_ownership_playlist_id_playlists_id_fk": {
+          "name": "playlist_ownership_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_ownership",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_ownership_user_id_users_id_fk": {
+          "name": "playlist_ownership_user_id_users_id_fk",
+          "tableFrom": "playlist_ownership",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlists": {
+      "name": "playlists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_type": {
+          "name": "aurora_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_synced_at": {
+          "name": "aurora_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_type": {
+          "name": "kilter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_id": {
+          "name": "kilter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_synced_at": {
+          "name": "kilter_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_recommendation": {
+          "name": "generated_recommendation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "playlists_board_layout_idx": {
+          "name": "playlists_board_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_generated_recommendation_idx": {
+          "name": "playlists_generated_recommendation_idx",
+          "columns": [
+            {
+              "expression": "generated_recommendation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_uuid_idx": {
+          "name": "playlists_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_updated_at_idx": {
+          "name": "playlists_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_sync_cursor_idx": {
+          "name": "playlists_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_last_accessed_at_idx": {
+          "name": "playlists_last_accessed_at_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_aurora_id_idx": {
+          "name": "playlists_aurora_id_idx",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_kilter_id_idx": {
+          "name": "playlists_kilter_id_idx",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playlists_uuid_unique": {
+          "name": "playlists_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_playlist_pins": {
+      "name": "user_playlist_pins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_playlist_pin": {
+          "name": "unique_user_playlist_pin",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_playlist_pins_user_idx": {
+          "name": "user_playlist_pins_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_playlist_pins_playlist_idx": {
+          "name": "user_playlist_pins_playlist_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_playlist_pins_user_id_users_id_fk": {
+          "name": "user_playlist_pins_user_id_users_id_fk",
+          "tableFrom": "user_playlist_pins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_playlist_pins_playlist_id_playlists_id_fk": {
+          "name": "user_playlist_pins_playlist_id_playlists_id_fk",
+          "tableFrom": "user_playlist_pins",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_hold_classifications": {
+      "name": "user_hold_classifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_type": {
+          "name": "hold_type",
+          "type": "hold_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hand_rating": {
+          "name": "hand_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "foot_rating": {
+          "name": "foot_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_direction": {
+          "name": "pull_direction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_hold_classifications_user_board_idx": {
+          "name": "user_hold_classifications_user_board_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hold_classifications_unique_idx": {
+          "name": "user_hold_classifications_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hold_classifications_hold_idx": {
+          "name": "user_hold_classifications_hold_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_hold_classifications_user_id_users_id_fk": {
+          "name": "user_hold_classifications_user_id_users_id_fk",
+          "tableFrom": "user_hold_classifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esp32_controllers": {
+      "name": "esp32_controllers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorized_session_id": {
+          "name": "authorized_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "esp32_controllers_user_idx": {
+          "name": "esp32_controllers_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "esp32_controllers_api_key_idx": {
+          "name": "esp32_controllers_api_key_idx",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "esp32_controllers_session_idx": {
+          "name": "esp32_controllers_session_idx",
+          "columns": [
+            {
+              "expression": "authorized_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esp32_controllers_user_id_users_id_fk": {
+          "name": "esp32_controllers_user_id_users_id_fk",
+          "tableFrom": "esp32_controllers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "esp32_controllers_api_key_unique": {
+          "name": "esp32_controllers_api_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "api_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_follows": {
+      "name": "playlist_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playlist_uuid": {
+          "name": "playlist_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_follow": {
+          "name": "unique_playlist_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "playlist_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_follows_follower_idx": {
+          "name": "playlist_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_follows_playlist_idx": {
+          "name": "playlist_follows_playlist_idx",
+          "columns": [
+            {
+              "expression": "playlist_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_follows_sync_cursor_idx": {
+          "name": "playlist_follows_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_follows_follower_id_users_id_fk": {
+          "name": "playlist_follows_follower_id_users_id_fk",
+          "tableFrom": "playlist_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_follows_playlist_uuid_playlists_uuid_fk": {
+          "name": "playlist_follows_playlist_uuid_playlists_uuid_fk",
+          "tableFrom": "playlist_follows",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setter_follows": {
+      "name": "setter_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_setter_follow": {
+          "name": "unique_setter_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setter_follows_follower_idx": {
+          "name": "setter_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setter_follows_setter_idx": {
+          "name": "setter_follows_setter_idx",
+          "columns": [
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setter_follows_sync_cursor_idx": {
+          "name": "setter_follows_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "setter_follows_follower_id_users_id_fk": {
+          "name": "setter_follows_follower_id_users_id_fk",
+          "tableFrom": "setter_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_follow": {
+          "name": "unique_user_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_following_idx": {
+          "name": "user_follows_following_idx",
+          "columns": [
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_sync_cursor_idx": {
+          "name": "user_follows_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_follows_follower_id_users_id_fk": {
+          "name": "user_follows_follower_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_follows_following_id_users_id_fk": {
+          "name": "user_follows_following_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_follow": {
+          "name": "no_self_follow",
+          "value": "\"user_follows\".\"follower_id\" != \"user_follows\".\"following_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_comment_id": {
+          "name": "parent_comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "comments_entity_created_at_idx": {
+          "name": "comments_entity_created_at_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_user_created_at_idx": {
+          "name": "comments_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_parent_comment_idx": {
+          "name": "comments_parent_comment_idx",
+          "columns": [
+            {
+              "expression": "parent_comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comments_user_id_users_id_fk": {
+          "name": "comments_user_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comments_uuid_unique": {
+          "name": "comments_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "votes_unique_user_entity": {
+          "name": "votes_unique_user_entity",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_entity_idx": {
+          "name": "votes_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_user_idx": {
+          "name": "votes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "votes_user_id_users_id_fk": {
+          "name": "votes_user_id_users_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vote_value_check": {
+          "name": "vote_value_check",
+          "value": "\"votes\".\"value\" IN (1, -1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_unread_idx": {
+          "name": "notifications_recipient_unread_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_recipient_created_at_idx": {
+          "name": "notifications_recipient_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_dedup_idx": {
+          "name": "notifications_dedup_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_recipient_id_users_id_fk": {
+          "name": "notifications_recipient_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actor_id_users_id_fk": {
+          "name": "notifications_actor_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notifications_comment_id_comments_id_fk": {
+          "name": "notifications_comment_id_comments_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notifications_uuid_unique": {
+          "name": "notifications_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_items": {
+      "name": "feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "feed_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feed_items_recipient_created_at_idx": {
+          "name": "feed_items_recipient_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_recipient_board_created_at_idx": {
+          "name": "feed_items_recipient_board_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_actor_created_at_idx": {
+          "name": "feed_items_actor_created_at_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_created_at_idx": {
+          "name": "feed_items_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_entity_type_entity_id_idx": {
+          "name": "feed_items_entity_type_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feed_items_recipient_id_users_id_fk": {
+          "name": "feed_items_recipient_id_users_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feed_items_actor_id_users_id_fk": {
+          "name": "feed_items_actor_id_users_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_classic_status": {
+      "name": "climb_classic_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_classic": {
+          "name": "is_classic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_proposal_id": {
+          "name": "last_proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "climb_classic_status_unique_idx": {
+          "name": "climb_classic_status_unique_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_classic_status_last_proposal_id_climb_proposals_id_fk": {
+          "name": "climb_classic_status_last_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "climb_classic_status",
+          "tableTo": "climb_proposals",
+          "columnsFrom": [
+            "last_proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_community_status": {
+      "name": "climb_community_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_grade": {
+          "name": "community_grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_proposal_id": {
+          "name": "last_proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "climb_community_status_unique_idx": {
+          "name": "climb_community_status_unique_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_community_status_last_proposal_id_climb_proposals_id_fk": {
+          "name": "climb_community_status_last_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "climb_community_status",
+          "tableTo": "climb_proposals",
+          "columnsFrom": [
+            "last_proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_proposals": {
+      "name": "climb_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "proposal_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_value": {
+          "name": "proposed_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_value": {
+          "name": "current_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "climb_proposals_climb_angle_type_idx": {
+          "name": "climb_proposals_climb_angle_type_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_status_idx": {
+          "name": "climb_proposals_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_proposer_idx": {
+          "name": "climb_proposals_proposer_idx",
+          "columns": [
+            {
+              "expression": "proposer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_board_type_idx": {
+          "name": "climb_proposals_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_created_at_idx": {
+          "name": "climb_proposals_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_proposals_proposer_id_users_id_fk": {
+          "name": "climb_proposals_proposer_id_users_id_fk",
+          "tableFrom": "climb_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "climb_proposals_resolved_by_users_id_fk": {
+          "name": "climb_proposals_resolved_by_users_id_fk",
+          "tableFrom": "climb_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "climb_proposals_uuid_unique": {
+          "name": "climb_proposals_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_roles": {
+      "name": "community_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "community_role_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_roles_board_type_idx": {
+          "name": "community_roles_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_roles_user_id_users_id_fk": {
+          "name": "community_roles_user_id_users_id_fk",
+          "tableFrom": "community_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_roles_granted_by_users_id_fk": {
+          "name": "community_roles_granted_by_users_id_fk",
+          "tableFrom": "community_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_roles_user_role_board_idx": {
+          "name": "community_roles_user_role_board_idx",
+          "nullsNotDistinct": true,
+          "columns": [
+            "user_id",
+            "role",
+            "board_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_settings": {
+      "name": "community_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_by": {
+          "name": "set_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_settings_scope_key_idx": {
+          "name": "community_settings_scope_key_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_settings_set_by_users_id_fk": {
+          "name": "community_settings_set_by_users_id_fk",
+          "tableFrom": "community_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "set_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_votes": {
+      "name": "proposal_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proposal_votes_unique_user_proposal": {
+          "name": "proposal_votes_unique_user_proposal",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_proposal_idx": {
+          "name": "proposal_votes_proposal_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_votes_proposal_id_climb_proposals_id_fk": {
+          "name": "proposal_votes_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "climb_proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_votes_user_id_users_id_fk": {
+          "name": "proposal_votes_user_id_users_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proposal_vote_value_check": {
+          "name": "proposal_vote_value_check",
+          "value": "\"proposal_votes\".\"value\" IN (1, -1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.new_climb_subscriptions": {
+      "name": "new_climb_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "new_climb_subscriptions_unique_user_board_layout": {
+          "name": "new_climb_subscriptions_unique_user_board_layout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "new_climb_subscriptions_user_idx": {
+          "name": "new_climb_subscriptions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "new_climb_subscriptions_board_layout_idx": {
+          "name": "new_climb_subscriptions_board_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "new_climb_subscriptions_user_id_users_id_fk": {
+          "name": "new_climb_subscriptions_user_id_users_id_fk",
+          "tableFrom": "new_climb_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote_counts": {
+      "name": "vote_counts",
+      "schema": "",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hot_score": {
+          "name": "hot_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "vote_counts_score_idx": {
+          "name": "vote_counts_score_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vote_counts_hot_score_idx": {
+          "name": "vote_counts_hot_score_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hot_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "vote_counts_entity_type_entity_id_pk": {
+          "name": "vote_counts_entity_type_entity_id_pk",
+          "columns": [
+            "entity_type",
+            "entity_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_participants": {
+      "name": "board_session_participants",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_session_participants_session_idx": {
+          "name": "board_session_participants_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_session_participants_user_idx": {
+          "name": "board_session_participants_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_session_participants_session_id_board_sessions_id_fk": {
+          "name": "board_session_participants_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_participants",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "board_session_participants_user_id_users_id_fk": {
+          "name": "board_session_participants_user_id_users_id_fk",
+          "tableFrom": "board_session_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_session_participants_session_id_user_id_pk": {
+          "name": "board_session_participants_session_id_user_id_pk",
+          "columns": [
+            "session_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_feedback": {
+      "name": "app_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_consent": {
+          "name": "contact_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "app_feedback_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_number": {
+          "name": "github_issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_feedback_created_at_idx": {
+          "name": "app_feedback_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_feedback_user_idx": {
+          "name": "app_feedback_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_feedback_board_idx": {
+          "name": "app_feedback_board_idx",
+          "columns": [
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_feedback_status_idx": {
+          "name": "app_feedback_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_feedback_user_id_users_id_fk": {
+          "name": "app_feedback_user_id_users_id_fk",
+          "tableFrom": "app_feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "app_feedback_resolved_by_users_id_fk": {
+          "name": "app_feedback_resolved_by_users_id_fk",
+          "tableFrom": "app_feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_climb_percentiles": {
+      "name": "user_climb_percentiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "total_distinct_climbs": {
+          "name": "total_distinct_climbs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "percentile": {
+          "name": "percentile",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_active_users": {
+          "name": "total_active_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_climb_percentiles_user_id_users_id_fk": {
+          "name": "user_climb_percentiles_user_id_users_id_fk",
+          "tableFrom": "user_climb_percentiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_push_tokens": {
+      "name": "activity_push_tokens",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_push_tokens_session_idx": {
+          "name": "activity_push_tokens_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_push_tokens_user_idx": {
+          "name": "activity_push_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_push_tokens_updated_at_idx": {
+          "name": "activity_push_tokens_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_push_tokens_session_id_board_sessions_id_fk": {
+          "name": "activity_push_tokens_session_id_board_sessions_id_fk",
+          "tableFrom": "activity_push_tokens",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_push_tokens_user_id_users_id_fk": {
+          "name": "activity_push_tokens_user_id_users_id_fk",
+          "tableFrom": "activity_push_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_send_stats": {
+      "name": "board_climb_send_stats",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "send_count_30d": {
+          "name": "send_count_30d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sender_count_30d": {
+          "name": "sender_count_30d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "send_count_90d": {
+          "name": "send_count_90d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_send_stats_trending_idx": {
+          "name": "board_climb_send_stats_trending_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "send_count_30d",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_climb_send_stats_board_type_climb_uuid_pk": {
+          "name": "board_climb_send_stats_board_type_climb_uuid_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_setter_stats": {
+      "name": "board_setter_stats",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_count": {
+          "name": "climb_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_ascents": {
+          "name": "total_ascents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "avg_ascents_per_climb": {
+          "name": "avg_ascents_per_climb",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "avg_quality": {
+          "name": "avg_quality",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_score": {
+          "name": "setter_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_setter_stats_score_idx": {
+          "name": "board_setter_stats_score_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "setter_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_setter_stats_board_type_setter_username_pk": {
+          "name": "board_setter_stats_board_type_setter_username_pk",
+          "columns": [
+            "board_type",
+            "setter_username"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_grades": {
+      "name": "board_climb_grades",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_grade": {
+          "name": "local_grade",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "universal_grade": {
+          "name": "universal_grade",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_low": {
+          "name": "grade_low",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_high": {
+          "name": "grade_high",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "content_prior": {
+          "name": "content_prior",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coeff_version": {
+          "name": "coeff_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sync_seq": {
+          "name": "sync_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "board_climb_grades_confidence_idx": {
+          "name": "board_climb_grades_confidence_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "confidence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_grades_sync_cursor_idx": {
+          "name": "board_climb_grades_sync_cursor_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "computed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sync_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_climb_grades_board_type_climb_uuid_angle_pk": {
+          "name": "board_climb_grades_board_type_climb_uuid_angle_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid",
+            "angle"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_grade_coefficients": {
+      "name": "board_grade_coefficients",
+      "schema": "",
+      "columns": {
+        "coeff_version": {
+          "name": "coeff_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_grade_coefficients_coeff_version_kind_key_pk": {
+          "name": "board_grade_coefficients_coeff_version_kind_key_pk",
+          "columns": [
+            "coeff_version",
+            "kind",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_hold_features": {
+      "name": "board_hold_features",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placement_id": {
+          "name": "placement_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "norm_x": {
+          "name": "norm_x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "norm_y": {
+          "name": "norm_y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_dist": {
+          "name": "edge_dist",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "neighbor_dist": {
+          "name": "neighbor_dist",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_kickboard": {
+          "name": "is_kickboard",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hand_difficulty": {
+          "name": "hand_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "foot_difficulty": {
+          "name": "foot_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hand_sample_count": {
+          "name": "hand_sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "foot_sample_count": {
+          "name": "foot_sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pull_direction": {
+          "name": "pull_direction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coarse_type": {
+          "name": "coarse_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_version": {
+          "name": "feature_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_hold_features_board_layout_idx": {
+          "name": "board_hold_features_board_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_hold_features_board_type_placement_id_pk": {
+          "name": "board_hold_features_board_type_placement_id_pk",
+          "columns": [
+            "board_type",
+            "placement_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_embeddings": {
+      "name": "board_climb_embeddings",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_prior": {
+          "name": "content_prior",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_sd": {
+          "name": "content_sd",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "real[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sync_seq": {
+          "name": "sync_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "board_climb_embeddings_board_idx": {
+          "name": "board_climb_embeddings_board_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_climb_embeddings_board_type_climb_uuid_angle_pk": {
+          "name": "board_climb_embeddings_board_type_climb_uuid_angle_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid",
+            "angle"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_similar": {
+      "name": "board_climb_similar",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "neighbor_uuid": {
+          "name": "neighbor_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_similar_lookup_idx": {
+          "name": "board_climb_similar_lookup_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_climb_similar_board_type_climb_uuid_angle_neighbor_uuid_pk": {
+          "name": "board_climb_similar_board_type_climb_uuid_angle_neighbor_uuid_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid",
+            "angle",
+            "neighbor_uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_exports": {
+      "name": "integration_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_type": {
+          "name": "session_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_activity_id": {
+          "name": "external_activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_integration_export": {
+          "name": "unique_integration_export",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_exports_user_provider_idx": {
+          "name": "integration_exports_user_provider_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_exports_session_idx": {
+          "name": "integration_exports_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_exports_user_id_users_id_fk": {
+          "name": "integration_exports_user_id_users_id_fk",
+          "tableFrom": "integration_exports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_sync_gym_sources": {
+      "name": "location_sync_gym_sources",
+      "schema": "",
+      "columns": {
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "location_sync_gym_sources_gym_idx": {
+          "name": "location_sync_gym_sources_gym_idx",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_sync_gym_sources_gym_id_gyms_id_fk": {
+          "name": "location_sync_gym_sources_gym_id_gyms_id_fk",
+          "tableFrom": "location_sync_gym_sources",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_deletions": {
+      "name": "sync_deletions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_deletions_user_since_idx": {
+          "name": "sync_deletions_user_since_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_deletions_null_scope_idx": {
+          "name": "sync_deletions_null_scope_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sync_deletions\".\"user_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_deletions_deleted_at_idx": {
+          "name": "sync_deletions_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_daemon_leases": {
+      "name": "sync_daemon_leases",
+      "schema": "",
+      "columns": {
+        "daemon_name": {
+          "name": "daemon_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "holder_id": {
+          "name": "holder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logbook_sync_skips": {
+      "name": "logbook_sync_skips",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aurora_type": {
+          "name": "aurora_type",
+          "type": "aurora_table_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "logbook_sync_skip_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "seen_count": {
+          "name": "seen_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "logbook_sync_skips_row_unique": {
+          "name": "logbook_sync_skips_row_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "aurora_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "logbook_sync_skips_user_board_idx": {
+          "name": "logbook_sync_skips_user_board_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "logbook_sync_skips_reason_seen_idx": {
+          "name": "logbook_sync_skips_reason_seen_idx",
+          "columns": [
+            {
+              "expression": "reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "logbook_sync_skips_user_id_users_id_fk": {
+          "name": "logbook_sync_skips_user_id_users_id_fk",
+          "tableFrom": "logbook_sync_skips",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.gym_claim_method": {
+      "name": "gym_claim_method",
+      "schema": "public",
+      "values": [
+        "domain",
+        "admin"
+      ]
+    },
+    "public.gym_claim_status": {
+      "name": "gym_claim_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied",
+        "expired"
+      ]
+    },
+    "public.gym_member_role": {
+      "name": "gym_member_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "editor",
+        "member"
+      ]
+    },
+    "public.gym_merge_audit_action": {
+      "name": "gym_merge_audit_action",
+      "schema": "public",
+      "values": [
+        "merged",
+        "dismissed"
+      ]
+    },
+    "public.aurora_table_type": {
+      "name": "aurora_table_type",
+      "schema": "public",
+      "values": [
+        "ascents",
+        "bids"
+      ]
+    },
+    "public.kilter_table_type": {
+      "name": "kilter_table_type",
+      "schema": "public",
+      "values": [
+        "logs",
+        "attempts"
+      ]
+    },
+    "public.tick_origin": {
+      "name": "tick_origin",
+      "schema": "public",
+      "values": [
+        "native",
+        "aurora_pull",
+        "kilter_pull",
+        "json_import",
+        "moonboard_import"
+      ]
+    },
+    "public.tick_status": {
+      "name": "tick_status",
+      "schema": "public",
+      "values": [
+        "flash",
+        "send",
+        "attempt"
+      ]
+    },
+    "public.hold_type": {
+      "name": "hold_type",
+      "schema": "public",
+      "values": [
+        "jug",
+        "sloper",
+        "pinch",
+        "crimp",
+        "pocket"
+      ]
+    },
+    "public.social_entity_type": {
+      "name": "social_entity_type",
+      "schema": "public",
+      "values": [
+        "playlist_climb",
+        "climb",
+        "tick",
+        "comment",
+        "proposal",
+        "board",
+        "gym",
+        "session"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "new_follower",
+        "comment_reply",
+        "comment_on_tick",
+        "comment_on_climb",
+        "vote_on_tick",
+        "vote_on_comment",
+        "new_climb",
+        "new_climb_global",
+        "proposal_approved",
+        "proposal_rejected",
+        "proposal_vote",
+        "proposal_created",
+        "new_climbs_synced",
+        "gym_claim_approved"
+      ]
+    },
+    "public.feed_item_type": {
+      "name": "feed_item_type",
+      "schema": "public",
+      "values": [
+        "ascent",
+        "new_climb",
+        "comment",
+        "proposal_approved",
+        "session_summary"
+      ]
+    },
+    "public.community_role_type": {
+      "name": "community_role_type",
+      "schema": "public",
+      "values": [
+        "admin",
+        "community_leader",
+        "tester"
+      ]
+    },
+    "public.proposal_status": {
+      "name": "proposal_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "approved",
+        "rejected",
+        "superseded"
+      ]
+    },
+    "public.proposal_type": {
+      "name": "proposal_type",
+      "schema": "public",
+      "values": [
+        "grade",
+        "classic",
+        "benchmark"
+      ]
+    },
+    "public.app_feedback_status": {
+      "name": "app_feedback_status",
+      "schema": "public",
+      "values": [
+        "new",
+        "in_progress",
+        "resolved",
+        "wont_fix"
+      ]
+    },
+    "public.logbook_sync_skip_reason": {
+      "name": "logbook_sync_skip_reason",
+      "schema": "public",
+      "values": [
+        "invalid_angle",
+        "invalid_identity",
+        "normalize_failed",
+        "db_write_rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1324,6 +1324,13 @@
       "when": 1785459112299,
       "tag": "0188_puzzling_kabuki",
       "breakpoints": true
+    },
+    {
+      "idx": 189,
+      "version": "7",
+      "when": 1785641394370,
+      "tag": "0189_allow_duplicate_board_configs",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/scripts/user-boards-serial-uniqueness.integration.test.ts
+++ b/packages/db/scripts/user-boards-serial-uniqueness.integration.test.ts
@@ -53,8 +53,8 @@ function* errorChain(error: unknown): Generator<ErrorRecord> {
 
 // Assert on the structured Postgres fields rather than error message text. A
 // message match on "duplicate key" is satisfied by any unique violation on the
-// table — including user_boards_unique_owner_config and the uuid primary key —
-// so it would go green without proving anything about the serial index.
+// table — the uuid primary key and user_boards_unique_slug both qualify — so it
+// would go green without proving anything about the serial index.
 // Both fields must come from the SAME chain node: a code read off one wrapper and
 // a constraint name off another would let two unrelated failures satisfy the
 // assertion together.
@@ -118,11 +118,13 @@ async function ensureUser(commandDb: ExecuteDb, id: string, email: string, name 
   `);
 }
 
-// `layoutId` varies so two boards owned by the same non-system user can differ in
-// board config. Without that, a second insert would also collide with
-// user_boards_unique_owner_config (owner_id, board_type, layout_id, size_id,
-// set_ids) and Postgres would report that constraint instead — the rejection
-// would prove nothing about the serial index under test.
+// `layoutId` varies so two boards owned by the same non-system user differ in
+// board config. This used to be load-bearing: a second insert would otherwise
+// collide with the user_boards_unique_owner_config index and Postgres would
+// report that constraint instead, proving nothing about the serial index. That
+// index was dropped in #4166 (a config tuple no longer identifies a board), so
+// the variation is now belt-and-braces — keep it so the fixtures stay honest
+// about representing distinct boards.
 async function insertBoard(
   commandDb: ExecuteDb,
   values: { uuid: string; slug: string; ownerId: string; serial: string; layoutId: number },
@@ -210,8 +212,8 @@ describe('user_boards serial uniqueness — system catalog exemption', () => {
             slug: 'serialuniq-other-2',
             ownerId: otherOwnerId,
             serial: sharedSerial,
-            // A different layout so user_boards_unique_owner_config cannot fire
-            // and only the serial index can reject this row.
+            // A different layout, so this row is unambiguously a distinct board
+            // and only the serial index can reject it.
             layoutId: 2,
           }),
         (error: unknown) => violatesConstraint(error, SERIAL_UNIQUENESS_INDEX),

--- a/packages/db/src/schema/app/boards.ts
+++ b/packages/db/src/schema/app/boards.ts
@@ -56,12 +56,15 @@ export const userBoards = pgTable(
   (table) => ({
     // Gym lookup
     gymIdx: index('user_boards_gym_idx').on(table.gymId),
-    // Unique partial: one active board per owner per config.
-    // Excludes the system user (seeded public boards) so multiple gyms
-    // can have the same board configuration.
-    uniqueOwnerConfigIdx: uniqueIndex('user_boards_unique_owner_config')
+    // Owner+config lookup for createBoard's duplicate check. Deliberately NOT
+    // unique: a config tuple does not identify a physical board. The same
+    // layout/size/set combination legitimately exists at two different gyms
+    // (see #4166), so uniqueness here made adding the second one impossible.
+    // createBoard enforces the real rule instead — same config AND same place,
+    // overridable by an explicit user confirmation (`allowDuplicateConfig`).
+    ownerConfigIdx: index('user_boards_owner_config_idx')
       .on(table.ownerId, table.boardType, table.layoutId, table.sizeId, table.setIds)
-      .where(sql`${table.deletedAt} IS NULL AND ${table.ownerId} != '00000000-0000-0000-0000-000000000000'`),
+      .where(sql`${table.deletedAt} IS NULL`),
     // Owner's owned boards
     ownerOwnedIdx: index('user_boards_owner_owned_idx')
       .on(table.ownerId, table.isOwned)

--- a/packages/mobile/app/boards/__tests__/create.test.tsx
+++ b/packages/mobile/app/boards/__tests__/create.test.tsx
@@ -1,0 +1,238 @@
+// @vitest-environment jsdom
+//
+// #4166. Creating a board silently did nothing: `handleCreate` looked for an
+// already-owned board with the same (type, layout, size, sets) and, on a match,
+// skipped the mutation entirely — discarding the filled-in form, activating the
+// OLD board and dismissing on the happy path. A climber adding a second
+// MoonBoard 2024 at a new gym got switched to their existing one, with no
+// message either way.
+//
+// The contract now: every submit reaches the server, and a duplicate is the
+// user's decision, not the client's.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+type Children = { children?: ReactNode };
+
+const createBoardMock = vi.hoisted(() => vi.fn());
+const setActiveBoardMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const fetchBoardByUuidMock = vi.hoisted(() => vi.fn());
+const dismissToMock = vi.hoisted(() => vi.fn());
+const trackMock = vi.hoisted(() => vi.fn());
+
+const state = vi.hoisted(() => ({
+  params: {} as Record<string, string | undefined>,
+}));
+
+const existingBoard = {
+  uuid: 'existing-uuid',
+  name: 'Boulder Space - MoonBoard 2024 Standard',
+} as unknown as UserBoard;
+
+/** A graphql-request ClientError carrying the server's duplicate rejection. */
+function duplicateError() {
+  return {
+    response: {
+      errors: [
+        {
+          message: 'You already have this board at this location',
+          extensions: {
+            code: 'BOARD_DUPLICATE_CONFIG',
+            existingBoardUuid: 'existing-uuid',
+            existingBoardName: 'Boulder Space - MoonBoard 2024 Standard',
+            existingBoardSlug: 'boulder-space-moonboard',
+            existingBoardLocationName: 'Boulder Space',
+          },
+        },
+      ],
+    },
+  };
+}
+
+vi.mock('expo-router', () => ({
+  useRouter: () => ({ dismissTo: dismissToMock }),
+  useLocalSearchParams: () => state.params,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../../src/lib/graphql/hooks', () => ({
+  useCreateBoard: () => ({ mutateAsync: createBoardMock }),
+  useProfile: () => ({ data: { displayName: 'Marco' } }),
+  fetchBoardByUuid: fetchBoardByUuidMock,
+}));
+
+vi.mock('../../../src/lib/graphql/use-active-board', () => ({
+  useSetActiveBoard: () => setActiveBoardMock,
+}));
+
+vi.mock('../../../src/lib/analytics', () => ({ track: trackMock }));
+
+vi.mock('../../../src/providers/auth-provider', () => ({
+  useAuth: () => ({ isAuthenticated: true }),
+}));
+
+vi.mock('../../../src/lib/haptics', () => ({ hapticSelection: vi.fn() }));
+
+// The builder is exercised in its own suite; here it just has to produce a valid
+// input so the screen's control flow is what's under test.
+vi.mock('../../../src/components/board-discovery/use-board-builder', () => ({
+  useBoardBuilder: () => ({
+    boardName: 'moonboard',
+    sizes: [],
+    sizeId: 1,
+    rawLayoutName: 'Standard',
+    coords: null,
+    selectedGym: null,
+    buildCreateInput: () => ({
+      boardType: 'moonboard',
+      layoutId: 3,
+      sizeId: 1,
+      setIds: '5,6,7,8,9,10',
+      name: 'Klimmuur MoonBoard',
+      angle: 25,
+      locationName: 'Klimmuur',
+    }),
+  }),
+}));
+
+vi.mock('../../../src/components/board-discovery/board-builder-labels', () => ({
+  formatDefaultBoardName: () => 'Default name',
+}));
+
+// Stand-ins that expose just enough DOM to drive the flow.
+vi.mock('../../../src/components/board-discovery/BoardForm', () => ({
+  BoardForm: ({ onSubmit, errorMessage }: { onSubmit: () => void; errorMessage?: string | null }) =>
+    createElement('div', null, [
+      createElement('button', { key: 'submit', type: 'button', onClick: onSubmit }, 'submit'),
+      errorMessage ? createElement('span', { key: 'error', 'data-testid': 'error' }, errorMessage) : null,
+    ]),
+}));
+
+vi.mock('../../../src/components/board-discovery/BoardDuplicatePromptSheet', () => ({
+  BoardDuplicatePromptSheet: ({
+    duplicate,
+    onUseExisting,
+    onAddAnother,
+  }: {
+    duplicate: { boardName: string };
+    onUseExisting: () => void;
+    onAddAnother: () => void;
+  }) =>
+    createElement('div', { 'data-testid': 'duplicate-prompt' }, [
+      createElement('span', { key: 'name' }, duplicate.boardName),
+      createElement('button', { key: 'use', type: 'button', onClick: onUseExisting }, 'use existing'),
+      createElement('button', { key: 'add', type: 'button', onClick: onAddAnother }, 'add another'),
+    ]),
+}));
+
+vi.mock('@boardsesh/board-config', () => ({ toBoardName: (value: string) => value }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: Children) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+
+const { default: CreateBoard } = await import('../create');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.params = {};
+  createBoardMock.mockResolvedValue({ uuid: 'new-uuid', name: 'Klimmuur MoonBoard' } as unknown as UserBoard);
+  fetchBoardByUuidMock.mockResolvedValue(existingBoard);
+});
+
+describe('CreateBoard', () => {
+  it('always calls the server, even when the config matches an owned board', async () => {
+    // The #4166 repro: previously an owned config match short-circuited here and
+    // the mutation was never reached.
+    render(createElement(CreateBoard));
+    fireEvent.click(screen.getByText('submit'));
+
+    await waitFor(() => expect(createBoardMock).toHaveBeenCalledTimes(1));
+    // The user's typed values reach the server rather than being discarded.
+    expect(createBoardMock.mock.calls[0][0]).toMatchObject({
+      name: 'Klimmuur MoonBoard',
+      angle: 25,
+      locationName: 'Klimmuur',
+    });
+    expect(createBoardMock.mock.calls[0][0].allowDuplicateConfig).toBeUndefined();
+  });
+
+  it('activates the new board and dismisses on success', async () => {
+    render(createElement(CreateBoard));
+    fireEvent.click(screen.getByText('submit'));
+
+    await waitFor(() =>
+      expect(setActiveBoardMock).toHaveBeenCalledWith({ uuid: 'new-uuid', name: 'Klimmuur MoonBoard' }),
+    );
+    expect(dismissToMock).toHaveBeenCalled();
+  });
+
+  it('still calls the server when seeded from a Popular config', async () => {
+    // The seeded path used to keep a silent auto-activate; it does not any more.
+    state.params = {
+      seedBoardName: 'moonboard',
+      seedLayoutId: '3',
+      seedSizeId: '1',
+      seedSetIds: '5,6,7,8,9,10',
+    };
+    render(createElement(CreateBoard));
+    fireEvent.click(screen.getByText('submit'));
+
+    await waitFor(() => expect(createBoardMock).toHaveBeenCalledTimes(1));
+  });
+
+  it('prompts instead of navigating when the server reports a duplicate', async () => {
+    createBoardMock.mockRejectedValueOnce(duplicateError());
+    render(createElement(CreateBoard));
+    fireEvent.click(screen.getByText('submit'));
+
+    await waitFor(() => expect(screen.getByTestId('duplicate-prompt')).toBeTruthy());
+    expect(screen.getByText('Boulder Space - MoonBoard 2024 Standard')).toBeTruthy();
+    // Critically: no silent switch and no dismissal.
+    expect(setActiveBoardMock).not.toHaveBeenCalled();
+    expect(dismissToMock).not.toHaveBeenCalled();
+  });
+
+  it('retries with allowDuplicateConfig when the user says it is a different wall', async () => {
+    createBoardMock.mockRejectedValueOnce(duplicateError());
+    render(createElement(CreateBoard));
+    fireEvent.click(screen.getByText('submit'));
+
+    await waitFor(() => expect(screen.getByTestId('duplicate-prompt')).toBeTruthy());
+    fireEvent.click(screen.getByText('add another'));
+
+    await waitFor(() => expect(createBoardMock).toHaveBeenCalledTimes(2));
+    expect(createBoardMock.mock.calls[1][0].allowDuplicateConfig).toBe(true);
+    await waitFor(() => expect(dismissToMock).toHaveBeenCalled());
+  });
+
+  it('switches to the existing board when the user picks it', async () => {
+    createBoardMock.mockRejectedValueOnce(duplicateError());
+    render(createElement(CreateBoard));
+    fireEvent.click(screen.getByText('submit'));
+
+    await waitFor(() => expect(screen.getByTestId('duplicate-prompt')).toBeTruthy());
+    fireEvent.click(screen.getByText('use existing'));
+
+    await waitFor(() => expect(setActiveBoardMock).toHaveBeenCalledWith(existingBoard));
+    expect(fetchBoardByUuidMock).toHaveBeenCalledWith('existing-uuid');
+    expect(createBoardMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a non-duplicate failure inline rather than as an invisible toast', async () => {
+    // This screen is a `presentation: 'modal'` route, and the toast overlay
+    // renders behind those — a toast here would never be seen.
+    createBoardMock.mockRejectedValueOnce(new Error('boom'));
+    render(createElement(CreateBoard));
+    fireEvent.click(screen.getByText('submit'));
+
+    await waitFor(() => expect(screen.getByTestId('error')).toBeTruthy());
+    expect(dismissToMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/app/boards/create.tsx
+++ b/packages/mobile/app/boards/create.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { toBoardName } from '@boardsesh/board-config';
@@ -99,6 +99,11 @@ export default function CreateBoard() {
   const [submitting, setSubmitting] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
   const [duplicate, setDuplicate] = useState<DuplicateBoardError | null>(null);
+  // `submitting` is only accurate on the NEXT render, so it can't guard a call
+  // that fires in the same tick as the state update — which is exactly what
+  // "add a new board here" does (dismiss the sheet, then create). This ref is
+  // set synchronously and is the real in-flight lock.
+  const inFlightRef = useRef(false);
 
   const finish = useCallback(
     async (board: UserBoard) => {
@@ -118,9 +123,10 @@ export default function CreateBoard() {
    */
   const handleCreate = useCallback(
     async (options?: { allowDuplicateConfig?: boolean }) => {
-      if (submitting) return;
+      if (inFlightRef.current) return;
       const input = builder.buildCreateInput(defaultName);
       if (!input) return;
+      inFlightRef.current = true;
       setSubmitting(true);
       setCreateError(null);
       hapticSelection();
@@ -145,6 +151,7 @@ export default function CreateBoard() {
             hasLocation: !!input.locationName || (input.latitude != null && input.longitude != null),
           });
           setDuplicate(duplicateError);
+          inFlightRef.current = false;
           setSubmitting(false);
           return;
         }
@@ -156,14 +163,16 @@ export default function CreateBoard() {
         // Inline, never a toast: this screen is a `presentation: 'modal'` route
         // and the toast overlay renders behind it, so a toast here is invisible.
         setCreateError(extractGraphqlMessage(error) ?? t('mobile.create.createError'));
+        inFlightRef.current = false;
         setSubmitting(false);
       }
     },
-    [submitting, builder, defaultName, createBoard, finish, source, t],
+    [builder, defaultName, createBoard, finish, source, t],
   );
 
   const handleUseExisting = useCallback(async () => {
-    if (!duplicate) return;
+    if (!duplicate || inFlightRef.current) return;
+    inFlightRef.current = true;
     setSubmitting(true);
     try {
       const board = await fetchBoardByUuid(duplicate.boardUuid);
@@ -174,6 +183,7 @@ export default function CreateBoard() {
     } catch {
       setDuplicate(null);
       setCreateError(t('mobile.create.duplicate.switchError'));
+      inFlightRef.current = false;
       setSubmitting(false);
     }
   }, [duplicate, builder.boardName, source, finish, t]);
@@ -185,6 +195,7 @@ export default function CreateBoard() {
 
   const handleDismissDuplicate = useCallback(() => {
     setDuplicate(null);
+    inFlightRef.current = false;
     setSubmitting(false);
   }, []);
 

--- a/packages/mobile/app/boards/create.tsx
+++ b/packages/mobile/app/boards/create.tsx
@@ -2,16 +2,48 @@ import { useCallback, useMemo, useState } from 'react';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { toBoardName } from '@boardsesh/board-config';
-import { useMyBoards, useCreateBoard, useProfile } from '../../src/lib/graphql/hooks';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import type { CreateBoardInput, UserBoard } from '@boardsesh/shared-schema';
+import { useCreateBoard, useProfile, fetchBoardByUuid } from '../../src/lib/graphql/hooks';
 import { useSetActiveBoard } from '../../src/lib/graphql/use-active-board';
+import {
+  extractGraphqlMessage,
+  isGraphqlRateLimitedError,
+  isExpectedAuthError,
+  readDuplicateBoardError,
+  type DuplicateBoardError,
+} from '../../src/lib/graphql/extract-error-message';
+import { track } from '../../src/lib/analytics';
 import { useAuth } from '../../src/providers/auth-provider';
-import { useToast } from '../../src/providers/toast-provider';
 import { hapticSelection } from '../../src/lib/haptics';
 import { resolveBoardReturnTo } from '../../src/lib/boards/board-return-to';
 import { useBoardBuilder, type BoardBuilderSeed } from '../../src/components/board-discovery/use-board-builder';
 import { BoardForm } from '../../src/components/board-discovery/BoardForm';
+import { BoardDuplicatePromptSheet } from '../../src/components/board-discovery/BoardDuplicatePromptSheet';
 import { formatDefaultBoardName } from '../../src/components/board-discovery/board-builder-labels';
-import { findOwnedBoardForConfig } from '../../src/components/board-discovery/board-items';
+
+/** Analytics properties describing a create attempt. Never carries free text or coordinates. */
+function describeInput(input: CreateBoardInput, source: 'popular_seed' | 'scratch') {
+  return {
+    boardType: input.boardType,
+    layoutId: input.layoutId,
+    sizeId: input.sizeId,
+    setCount: input.setIds.split(',').filter(Boolean).length,
+    angle: input.angle,
+    isOwned: input.isOwned,
+    isPublic: input.isPublic,
+    hasLocationName: !!input.locationName,
+    hasCoords: input.latitude != null && input.longitude != null,
+    hasGym: !!input.gymUuid,
+    source,
+  };
+}
+
+function classifyCreateFailure(error: unknown): 'rate_limited' | 'auth' | 'exception' {
+  if (isGraphqlRateLimitedError(error)) return 'rate_limited';
+  if (isExpectedAuthError(error)) return 'auth';
+  return 'exception';
+}
 
 export default function CreateBoard() {
   const router = useRouter();
@@ -25,13 +57,10 @@ export default function CreateBoard() {
   const boardReturnTo = resolveBoardReturnTo(params.returnTo);
   const { isAuthenticated } = useAuth();
   const { t } = useTranslation('boards');
-  const { showToast } = useToast();
 
   const setActiveBoard = useSetActiveBoard();
   const createBoard = useCreateBoard();
   const { data: profile } = useProfile({ enabled: isAuthenticated });
-  const { data: boardConnection } = useMyBoards(undefined, { enabled: isAuthenticated });
-  const myBoards = boardConnection?.boards ?? [];
 
   // Pre-fill when opened from a Popular config. Memoised so the builder doesn't
   // re-seed (and wipe edits) on every render.
@@ -46,6 +75,7 @@ export default function CreateBoard() {
     };
   }, [params.seedBoardName, params.seedLayoutId, params.seedSizeId, params.seedSetIds]);
 
+  const source = seed ? 'popular_seed' : 'scratch';
   const builder = useBoardBuilder(seed);
 
   // Auto-generated default name, e.g. "Marco's Kilter Original 12×12", from the
@@ -67,39 +97,116 @@ export default function CreateBoard() {
   );
 
   const [submitting, setSubmitting] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [duplicate, setDuplicate] = useState<DuplicateBoardError | null>(null);
 
-  const handleCreate = useCallback(async () => {
-    if (submitting) return;
-    const input = builder.buildCreateInput(defaultName);
-    if (!input) return;
-    setSubmitting(true);
-    hapticSelection();
-    try {
-      // Activate an already-owned matching board instead of hitting the server's
-      // duplicate-config guard.
-      const owned = findOwnedBoardForConfig(myBoards, {
-        boardType: input.boardType,
-        layoutId: input.layoutId,
-        sizeId: input.sizeId,
-        setIds: input.setIds,
-      });
-      const board = owned ?? (await createBoard.mutateAsync(input));
+  const finish = useCallback(
+    async (board: UserBoard) => {
       await setActiveBoard(board);
       router.dismissTo(boardReturnTo);
-      // Navigated away on success — no need to clear `submitting` (unmounting).
+    },
+    [setActiveBoard, router, boardReturnTo],
+  );
+
+  /**
+   * Always calls the server. The old short-circuit — activate an owned board
+   * whose config matched and skip the mutation — is what made #4166 look like a
+   * success while silently discarding the form, so there is deliberately no
+   * client-side path that can complete a create without a server round trip.
+   * The server decides whether this is a duplicate, and the user decides what to
+   * do about it.
+   */
+  const handleCreate = useCallback(
+    async (options?: { allowDuplicateConfig?: boolean }) => {
+      if (submitting) return;
+      const input = builder.buildCreateInput(defaultName);
+      if (!input) return;
+      setSubmitting(true);
+      setCreateError(null);
+      hapticSelection();
+
+      try {
+        const board = await createBoard.mutateAsync({
+          ...input,
+          allowDuplicateConfig: options?.allowDuplicateConfig || undefined,
+        });
+        track(SHARED_EVENTS.BoardCreated, {
+          ...describeInput(input, source),
+          allowedDuplicate: !!options?.allowDuplicateConfig,
+        });
+        await finish(board);
+        // Navigated away on success — no need to clear `submitting` (unmounting).
+      } catch (error) {
+        const duplicateError = readDuplicateBoardError(error);
+        if (duplicateError) {
+          track(SHARED_EVENTS.BoardDuplicatePrompted, {
+            boardType: input.boardType,
+            source,
+            hasLocation: !!input.locationName || (input.latitude != null && input.longitude != null),
+          });
+          setDuplicate(duplicateError);
+          setSubmitting(false);
+          return;
+        }
+        track(SHARED_EVENTS.BoardCreateFailed, {
+          boardType: input.boardType,
+          source,
+          error_reason: classifyCreateFailure(error),
+        });
+        // Inline, never a toast: this screen is a `presentation: 'modal'` route
+        // and the toast overlay renders behind it, so a toast here is invisible.
+        setCreateError(extractGraphqlMessage(error) ?? t('mobile.create.createError'));
+        setSubmitting(false);
+      }
+    },
+    [submitting, builder, defaultName, createBoard, finish, source, t],
+  );
+
+  const handleUseExisting = useCallback(async () => {
+    if (!duplicate) return;
+    setSubmitting(true);
+    try {
+      const board = await fetchBoardByUuid(duplicate.boardUuid);
+      if (!board) throw new Error('Board not found');
+      track(SHARED_EVENTS.BoardCreateReusedExisting, { boardType: builder.boardName, source });
+      setDuplicate(null);
+      await finish(board);
     } catch {
-      showToast(t('mobile.create.createError'), 'error');
+      setDuplicate(null);
+      setCreateError(t('mobile.create.duplicate.switchError'));
       setSubmitting(false);
     }
-  }, [submitting, builder, defaultName, myBoards, createBoard, setActiveBoard, router, boardReturnTo, showToast, t]);
+  }, [duplicate, builder.boardName, source, finish, t]);
+
+  const handleAddAnother = useCallback(() => {
+    setDuplicate(null);
+    void handleCreate({ allowDuplicateConfig: true });
+  }, [handleCreate]);
+
+  const handleDismissDuplicate = useCallback(() => {
+    setDuplicate(null);
+    setSubmitting(false);
+  }, []);
 
   return (
-    <BoardForm
-      builder={builder}
-      defaultName={defaultName}
-      submitting={submitting}
-      onSubmit={() => void handleCreate()}
-      submitLabel={t('mobile.create.save')}
-    />
+    <>
+      <BoardForm
+        builder={builder}
+        defaultName={defaultName}
+        submitting={submitting}
+        errorMessage={createError}
+        onSubmit={() => void handleCreate()}
+        submitLabel={t('mobile.create.save')}
+      />
+      {duplicate && (
+        <BoardDuplicatePromptSheet
+          duplicate={duplicate}
+          busy={submitting}
+          onUseExisting={() => void handleUseExisting()}
+          onAddAnother={handleAddAnother}
+          onDismiss={handleDismissDuplicate}
+        />
+      )}
+    </>
   );
 }

--- a/packages/mobile/app/boards/edit.tsx
+++ b/packages/mobile/app/boards/edit.tsx
@@ -4,10 +4,10 @@ import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { toBoardName } from '@boardsesh/board-config';
 import type { UserBoard } from '@boardsesh/shared-schema';
-import { useBoard, useProfile, useUpdateBoard } from '../../src/lib/graphql/hooks';
+import { useBoard, useProfile, useUpdateBoard, useLinkBoardToGym } from '../../src/lib/graphql/hooks';
 import { useActiveBoard, useSetActiveBoard } from '../../src/lib/graphql/use-active-board';
+import { extractGraphqlMessage } from '../../src/lib/graphql/extract-error-message';
 import { useAuth } from '../../src/providers/auth-provider';
-import { useToast } from '../../src/providers/toast-provider';
 import { hapticSelection } from '../../src/lib/haptics';
 import { useBoardBuilder, type BoardBuilderSeed } from '../../src/components/board-discovery/use-board-builder';
 import { BoardForm } from '../../src/components/board-discovery/BoardForm';
@@ -85,12 +85,12 @@ function EditBoardForm({ board }: { board: UserBoard }) {
   const router = useRouter();
   const { isAuthenticated } = useAuth();
   const { t } = useTranslation('boards');
-  const { showToast } = useToast();
 
   const { data: profile } = useProfile({ enabled: isAuthenticated });
   const { data: activeBoard } = useActiveBoard();
   const setActiveBoard = useSetActiveBoard();
   const updateBoard = useUpdateBoard();
+  const linkBoardToGym = useLinkBoardToGym();
 
   // Authorized editors (owner, or a community admin/leader for this board type —
   // the server reports this as `canEdit`) may change the config even when the
@@ -118,6 +118,8 @@ function EditBoardForm({ board }: { board: UserBoard }) {
       longitude: board.longitude ?? undefined,
       serialNumber: board.serialNumber ?? undefined,
       timerName: board.timerName ?? undefined,
+      gymUuid: board.gymUuid,
+      gymName: board.gymName,
     };
   }, [board]);
 
@@ -139,37 +141,56 @@ function EditBoardForm({ board }: { board: UserBoard }) {
   );
 
   const [submitting, setSubmitting] = useState(false);
+  const [updateError, setUpdateError] = useState<string | null>(null);
 
   const handleUpdate = useCallback(async () => {
     if (submitting) return;
     const input = builder.buildUpdateInput(board.uuid, { lockedConfig, fallbackName: defaultName });
     if (!input) return;
     setSubmitting(true);
+    setUpdateError(null);
     hapticSelection();
     try {
       const updated = await updateBoard.mutateAsync(input);
+
+      // `UpdateBoardInput` carries no gym, so a changed gym is its own mutation.
+      // It can be rejected on its own terms (too far from a gym the user doesn't
+      // run), so it's reported separately rather than failing the whole save.
+      const nextGymUuid = builder.selectedGym?.uuid ?? null;
+      if (nextGymUuid !== (board.gymUuid ?? null)) {
+        try {
+          await linkBoardToGym.mutateAsync({ boardUuid: board.uuid, gymUuid: nextGymUuid });
+        } catch (error) {
+          setUpdateError(extractGraphqlMessage(error) ?? t('mobile.gymPicker.linkError'));
+          setSubmitting(false);
+          return;
+        }
+      }
+
       // The active board is a denormalised AsyncStorage copy — re-persist it so
       // the rename / angle / visibility change reaches BLE + the play drawer.
       if (activeBoard?.uuid === updated.uuid) await setActiveBoard(updated);
       router.back();
       // Navigated away on success — leave `submitting` set (unmounting).
-    } catch {
+    } catch (error) {
       // Covers the config-locked race and the duplicate-config guard, both of
-      // which the server enforces authoritatively.
-      showToast(t('mobile.edit.updateError'), 'error');
+      // which the server enforces authoritatively. Inline, not a toast: this is
+      // a `presentation: 'modal'` route and the toast overlay draws behind it.
+      setUpdateError(extractGraphqlMessage(error) ?? t('mobile.edit.updateError'));
       setSubmitting(false);
     }
   }, [
     submitting,
     builder,
     board.uuid,
+    board.gymUuid,
     lockedConfig,
     defaultName,
     updateBoard,
+    linkBoardToGym,
     activeBoard?.uuid,
     setActiveBoard,
     router,
-    showToast,
     t,
   ]);
 
@@ -178,6 +199,7 @@ function EditBoardForm({ board }: { board: UserBoard }) {
       builder={builder}
       defaultName={defaultName}
       submitting={submitting}
+      errorMessage={updateError}
       onSubmit={() => void handleUpdate()}
       submitLabel={t('mobile.edit.save')}
       lockedConfig={lockedConfig}

--- a/packages/mobile/app/boards/edit.tsx
+++ b/packages/mobile/app/boards/edit.tsx
@@ -157,19 +157,26 @@ function EditBoardForm({ board }: { board: UserBoard }) {
       // It can be rejected on its own terms (too far from a gym the user doesn't
       // run), so it's reported separately rather than failing the whole save.
       const nextGymUuid = builder.selectedGym?.uuid ?? null;
+      let gymLinkError: string | null = null;
       if (nextGymUuid !== (board.gymUuid ?? null)) {
         try {
           await linkBoardToGym.mutateAsync({ boardUuid: board.uuid, gymUuid: nextGymUuid });
         } catch (error) {
-          setUpdateError(extractGraphqlMessage(error) ?? t('mobile.gymPicker.linkError'));
-          setSubmitting(false);
-          return;
+          gymLinkError = extractGraphqlMessage(error) ?? t('mobile.gymPicker.linkError');
         }
       }
 
       // The active board is a denormalised AsyncStorage copy — re-persist it so
       // the rename / angle / visibility change reaches BLE + the play drawer.
+      // This runs even when the gym link failed: the rest of the edit DID save,
+      // and bailing early left the stored copy stale against the server.
       if (activeBoard?.uuid === updated.uuid) await setActiveBoard(updated);
+
+      if (gymLinkError) {
+        setUpdateError(gymLinkError);
+        setSubmitting(false);
+        return;
+      }
       router.back();
       // Navigated away on success — leave `submitting` set (unmounting).
     } catch (error) {

--- a/packages/mobile/src/components/board-discovery/BoardDuplicatePromptSheet.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardDuplicatePromptSheet.tsx
@@ -1,0 +1,144 @@
+// Shown when createBoard reports the user already owns a board with this
+// configuration at this place. Replaces the silent auto-activate that caused
+// #4166, where a climber's new-gym board was thrown away and their OLD board was
+// quietly made active instead — with no message either way.
+//
+// Three outcomes, all explicit. Deliberately not `useConfirm()`: a two-button
+// confirm has to map a scrim/back dismissal onto one of the real choices, and
+// choosing silently on the user's behalf is the exact bug being fixed here.
+// Dismissing this sheet means "keep editing" and nothing else.
+
+import { useCallback, useMemo, useRef } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { BottomSheetModal, BottomSheetView } from '@expo/ui/community/bottom-sheet';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+import type { DuplicateBoardError } from '../../lib/graphql/extract-error-message';
+import { useManagedSheet } from '../../providers/sheet-presentation-provider';
+import { androidSafeSnapPoints } from '../sheet-snap-points';
+import { Text } from '../Text';
+import { Button } from '../Button';
+import { useTheme } from '../../providers/theme-provider';
+import { spacing } from '../../theme/tokens';
+import { iosSystemColors } from '../../theme/ios-colors';
+
+type BoardDuplicatePromptSheetProps = {
+  duplicate: DuplicateBoardError;
+  /** True while "use that board" is resolving the existing board. */
+  busy?: boolean;
+  onUseExisting: () => void;
+  onAddAnother: () => void;
+  onDismiss: () => void;
+};
+
+export function BoardDuplicatePromptSheet({
+  duplicate,
+  busy = false,
+  onUseExisting,
+  onAddAnother,
+  onDismiss,
+}: BoardDuplicatePromptSheetProps) {
+  const { t } = useTranslation('boards');
+  const { systemColors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const sheetRef = useRef<BottomSheetModal>(null);
+
+  const snapPoints = useMemo(() => androidSafeSnapPoints(['45%']), []);
+  // Presence-driven: the host mounts this only while a duplicate is pending, so
+  // `open` is constant true and the coordinator handles present/dismiss. An
+  // imperative present() from a visible-prop effect is a silent no-op here.
+  const managed = useManagedSheet({ open: true, sheetRef, onClose: onDismiss });
+
+  const handleUseExisting = useCallback(() => {
+    if (busy) return;
+    onUseExisting();
+  }, [busy, onUseExisting]);
+
+  const handleAddAnother = useCallback(() => {
+    if (busy) return;
+    onAddAnother();
+  }, [busy, onAddAnother]);
+
+  const body = duplicate.locationName
+    ? t('mobile.create.duplicate.bodyWithLocation', {
+        name: duplicate.boardName,
+        location: duplicate.locationName,
+      })
+    : t('mobile.create.duplicate.body', { name: duplicate.boardName });
+
+  return (
+    <BottomSheetModal
+      ref={sheetRef}
+      index={0}
+      snapPoints={snapPoints}
+      enablePanDownToClose
+      onChange={managed.onChange}
+      onFullyDismissed={managed.onFullyDismissed}
+      handleIndicatorStyle={styles.indicator}
+    >
+      <BottomSheetView style={styles.header}>
+        <Text variant="title3" color={systemColors.label}>
+          {t('mobile.create.duplicate.title')}
+        </Text>
+        <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.centered}>
+          {body}
+        </Text>
+      </BottomSheetView>
+
+      <View style={[styles.actions, { paddingBottom: insets.bottom + spacing[3] }]}>
+        <Button
+          title={t('mobile.create.duplicate.useExisting')}
+          onPress={handleUseExisting}
+          disabled={busy}
+          loading={busy}
+          size="medium"
+        />
+        <View style={styles.addAnother}>
+          <Button
+            title={t('mobile.create.duplicate.addAnother')}
+            onPress={handleAddAnother}
+            disabled={busy}
+            variant="tonal"
+            size="medium"
+          />
+          <Text variant="caption1" color={systemColors.secondaryLabel} style={styles.centered}>
+            {t('mobile.create.duplicate.addAnotherHint')}
+          </Text>
+        </View>
+        <Button
+          title={t('mobile.create.duplicate.cancel')}
+          onPress={onDismiss}
+          variant="text"
+          size="medium"
+          role="cancel"
+        />
+      </View>
+    </BottomSheetModal>
+  );
+}
+
+const styles = StyleSheet.create({
+  indicator: {
+    backgroundColor: iosSystemColors.separator,
+    width: 36,
+    height: 5,
+    borderRadius: 3,
+  },
+  header: {
+    paddingHorizontal: spacing[4],
+    paddingBottom: spacing[3],
+    alignItems: 'center',
+    gap: 4,
+  },
+  centered: {
+    textAlign: 'center',
+  },
+  actions: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[2],
+    gap: spacing[3],
+  },
+  addAnother: {
+    gap: 4,
+  },
+});

--- a/packages/mobile/src/components/board-discovery/BoardDuplicatePromptSheet.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardDuplicatePromptSheet.tsx
@@ -71,7 +71,8 @@ export function BoardDuplicatePromptSheet({
       ref={sheetRef}
       index={0}
       snapPoints={snapPoints}
-      enablePanDownToClose
+      // Pan-down is a second route to the same cancel, so it closes too.
+      enablePanDownToClose={!busy}
       onChange={managed.onChange}
       onFullyDismissed={managed.onFullyDismissed}
       handleIndicatorStyle={styles.indicator}
@@ -105,9 +106,14 @@ export function BoardDuplicatePromptSheet({
             {t('mobile.create.duplicate.addAnotherHint')}
           </Text>
         </View>
+        {/* Also disabled while busy: cancelling mid-switch used to release the
+            in-flight lock while the board fetch was still running, and the
+            resolved fetch then activated the old board and threw the form away —
+            the #4166 symptom, through this sheet. */}
         <Button
           title={t('mobile.create.duplicate.cancel')}
           onPress={onDismiss}
+          disabled={busy}
           variant="text"
           size="medium"
           role="cancel"

--- a/packages/mobile/src/components/board-discovery/BoardForm.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardForm.tsx
@@ -29,7 +29,9 @@ import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { Button } from '../Button';
 import { TimerPairingSheet } from '../ble/TimerPairingSheet';
+import { GymPickerSheet } from './GymPickerSheet';
 import { spacing, borderRadius } from '../../theme/tokens';
+import { iosSystemColors } from '../../theme/ios-colors';
 
 const PREVIEW_MAX_HEIGHT = 260;
 
@@ -47,6 +49,12 @@ type BoardFormProps = {
    * ticks — the server rejects config changes on those). Shows a hint.
    */
   lockedConfig?: boolean;
+  /**
+   * A submit failure, rendered inline above the action. The create/edit screens
+   * are `presentation: 'modal'` routes and the toast overlay draws behind those,
+   * so a toast here would never be seen (#4166) — feedback lives in the form.
+   */
+  errorMessage?: string | null;
 };
 
 /**
@@ -63,6 +71,7 @@ export function BoardForm({
   onSubmit,
   submitLabel,
   lockedConfig = false,
+  errorMessage = null,
 }: BoardFormProps) {
   const { t } = useTranslation('boards');
   const { systemColors } = useTheme();
@@ -71,11 +80,13 @@ export function BoardForm({
   const { width: windowWidth } = useWindowDimensions();
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [timerPairingOpen, setTimerPairingOpen] = useState(false);
+  const [gymPickerOpen, setGymPickerOpen] = useState(false);
 
   const { setCoords } = builder;
   const location = useDeviceLocation();
   const requestLocation = location.request;
   const onUseMyLocation = useCallback(() => void requestLocation(), [requestLocation]);
+  const onClearLocation = useCallback(() => setCoords(null), [setCoords]);
   useEffect(() => {
     // location.coords stays null until the user taps "Use my location" (request
     // is explicit), so this only stamps coords once they've opted in.
@@ -230,6 +241,33 @@ export function BoardForm({
               maxLength={100}
               returnKeyType="done"
             />
+
+            {/* Gym lives in the MAIN form, not behind "More options": attaching
+                the board to its gym is what puts it on the map under that gym,
+                and burying it is how boards ended up as lone pins (#4166). */}
+            <SectionLabel>{t('mobile.create.gym')}</SectionLabel>
+            <Pressable
+              onPress={() => setGymPickerOpen(true)}
+              accessibilityRole="button"
+              accessibilityLabel={t('mobile.create.gym')}
+              style={({ pressed }) => [
+                styles.gymRow,
+                {
+                  backgroundColor: pressed ? systemColors.tertiaryBackground : systemColors.secondaryBackground,
+                  borderColor: systemColors.separator,
+                },
+              ]}
+            >
+              <Text
+                variant="body"
+                color={builder.selectedGym ? systemColors.label : systemColors.secondaryLabel}
+                numberOfLines={1}
+                style={styles.gymRowLabel}
+              >
+                {builder.selectedGym?.name ?? t('mobile.create.gymNone')}
+              </Text>
+              <Icon name="chevron.right" size={16} color={systemColors.tertiaryLabel} />
+            </Pressable>
           </>
         ) : null}
 
@@ -284,12 +322,18 @@ export function BoardForm({
               accessibilityLabel={t('mobile.create.location')}
               maxLength={120}
             />
-            <Button
-              title={builder.coords ? t('mobile.create.locationSet') : t('mobile.create.useMyLocation')}
-              variant="text"
-              onPress={onUseMyLocation}
-              disabled={builder.coords != null}
-            />
+            {/* Stamping coordinates used to be one-way — the button simply went
+                disabled, leaving no way to undo a wrong location. */}
+            {builder.coords ? (
+              <Button
+                title={t('mobile.create.clearLocation')}
+                variant="text"
+                onPress={onClearLocation}
+                role="destructive"
+              />
+            ) : (
+              <Button title={t('mobile.create.useMyLocation')} variant="text" onPress={onUseMyLocation} />
+            )}
 
             <SectionLabel>{t('mobile.create.serial')}</SectionLabel>
             <BuilderTextInput
@@ -348,6 +392,25 @@ export function BoardForm({
         />
       ) : null}
 
+      {/* Presence-driven, like TimerPairingSheet — the two are never open at
+          once and the sheet coordinator serialises them. */}
+      {gymPickerOpen ? (
+        <GymPickerSheet
+          selectedUuid={builder.selectedGym?.uuid ?? null}
+          boardCoords={builder.coords}
+          onSelect={(gym) => {
+            builder.setSelectedGym(gym);
+            setGymPickerOpen(false);
+          }}
+          onRequestManualLocation={() => {
+            builder.setSelectedGym(null);
+            setGymPickerOpen(false);
+            setAdvancedOpen(true);
+          }}
+          onDismiss={() => setGymPickerOpen(false)}
+        />
+      ) : null}
+
       {/* Pinned, safe-area-aware primary action. */}
       <View
         style={[
@@ -359,6 +422,16 @@ export function BoardForm({
           },
         ]}
       >
+        {errorMessage ? (
+          <Text
+            variant="footnote"
+            color={iosSystemColors.systemRed}
+            style={styles.errorMessage}
+            accessibilityLiveRegion="polite"
+          >
+            {errorMessage}
+          </Text>
+        ) : null}
         <Button
           title={submitLabel}
           onPress={onSubmit}
@@ -534,5 +607,21 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing[4],
     paddingTop: spacing[3],
     borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  errorMessage: {
+    marginBottom: spacing[2],
+    textAlign: 'center',
+  },
+  gymRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[3],
+    borderRadius: borderRadius.md,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  gymRowLabel: {
+    flex: 1,
   },
 });

--- a/packages/mobile/src/components/board-discovery/GymPickerSheet.tsx
+++ b/packages/mobile/src/components/board-discovery/GymPickerSheet.tsx
@@ -1,0 +1,298 @@
+// Picks the gym a board sits in, so it lands on the map under that gym instead
+// of as a lone pin. Before #4166 mobile never set `gymUuid` at all and a board's
+// only tie to a place was a free-text location name.
+//
+// There is deliberately no "create a gym" form here. Choosing "my gym isn't
+// listed" hands the typed name to the server, whose auto-gym path applies the
+// nearby-name dedup guards before minting. A raw create-gym form in the app
+// would bypass those and become a fresh source of duplicate gyms.
+
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { View, Pressable, ActivityIndicator, StyleSheet } from 'react-native';
+import {
+  BottomSheetModal,
+  BottomSheetView,
+  BottomSheetFlatList,
+  BottomSheetTextInput,
+} from '@expo/ui/community/bottom-sheet';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+import type { Gym } from '@boardsesh/shared-schema';
+import { useNearbyGyms } from '../../lib/graphql/hooks';
+import { useDeviceLocation } from '../../lib/use-device-location';
+import { useManagedSheet } from '../../providers/sheet-presentation-provider';
+import { androidSafeSnapPoints } from '../sheet-snap-points';
+import { Text } from '../Text';
+import { Button } from '../Button';
+import { Icon } from '../Icon';
+import { useTheme } from '../../providers/theme-provider';
+import { hapticLight } from '../../lib/haptics';
+import { spacing, borderRadius } from '../../theme/tokens';
+import { iosSystemColors } from '../../theme/ios-colors';
+
+export type PickedGym = {
+  uuid: string;
+  name: string;
+  latitude?: number | null;
+  longitude?: number | null;
+};
+
+type GymPickerSheetProps = {
+  /** Currently selected gym uuid, so the row can render as chosen. */
+  selectedUuid: string | null;
+  /** Board coordinates when known — the picker centres on these before asking for device location. */
+  boardCoords: { latitude: number; longitude: number } | null;
+  onSelect: (gym: PickedGym | null) => void;
+  /** "My gym isn't listed" — clears the link and sends the user back to the location field. */
+  onRequestManualLocation: () => void;
+  onDismiss: () => void;
+};
+
+const keyExtractor = (gym: Gym) => gym.uuid;
+
+const GymRow = memo(function GymRow({
+  gym,
+  isSelected,
+  onSelect,
+}: {
+  gym: Gym;
+  isSelected: boolean;
+  onSelect: (gym: Gym) => void;
+}) {
+  const { systemColors, brandColors } = useTheme();
+  const handlePress = useCallback(() => {
+    hapticLight();
+    onSelect(gym);
+  }, [gym, onSelect]);
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      accessibilityRole="button"
+      accessibilityState={{ selected: isSelected }}
+      style={({ pressed }) => [
+        styles.row,
+        { backgroundColor: pressed ? systemColors.tertiaryBackground : 'transparent' },
+      ]}
+    >
+      <View style={styles.rowText}>
+        <Text variant="body" color={systemColors.label} numberOfLines={1}>
+          {gym.name}
+        </Text>
+        {gym.address ? (
+          <Text variant="footnote" color={systemColors.secondaryLabel} numberOfLines={1}>
+            {gym.address}
+          </Text>
+        ) : null}
+      </View>
+      {isSelected ? <Icon name="check.small" size={20} color={brandColors.primary} /> : null}
+    </Pressable>
+  );
+});
+
+export function GymPickerSheet({
+  selectedUuid,
+  boardCoords,
+  onSelect,
+  onRequestManualLocation,
+  onDismiss,
+}: GymPickerSheetProps) {
+  const { t } = useTranslation('boards');
+  const { systemColors, brandColors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const sheetRef = useRef<BottomSheetModal>(null);
+
+  const snapPoints = useMemo(() => androidSafeSnapPoints(['75%']), []);
+  const managed = useManagedSheet({ open: true, sheetRef, onClose: onDismiss });
+
+  const [search, setSearch] = useState('');
+  const deviceLocation = useDeviceLocation();
+
+  // Prefer coordinates the board already carries; otherwise ask the device once.
+  const coords = boardCoords ?? deviceLocation.coords;
+  useEffect(() => {
+    if (boardCoords == null) void deviceLocation.request();
+  }, [boardCoords, deviceLocation]);
+
+  // With no coordinates the query still runs as a text search, so someone who
+  // declined location can find their gym by typing.
+  const { data: gymConnection, isLoading } = useNearbyGyms(coords, 50, search);
+  // `searchGyms` already orders by distance, so the server's order is the right
+  // order — no client-side distance maths.
+  const gyms = useMemo(() => gymConnection?.gyms ?? [], [gymConnection?.gyms]);
+
+  const handleSelectGym = useCallback(
+    (gym: Gym) => {
+      onSelect({ uuid: gym.uuid, name: gym.name, latitude: gym.latitude, longitude: gym.longitude });
+    },
+    [onSelect],
+  );
+
+  const handleSelectNone = useCallback(() => {
+    hapticLight();
+    onSelect(null);
+  }, [onSelect]);
+
+  const renderItem = useCallback(
+    ({ item }: { item: Gym }) => (
+      <GymRow gym={item} isSelected={item.uuid === selectedUuid} onSelect={handleSelectGym} />
+    ),
+    [selectedUuid, handleSelectGym],
+  );
+
+  const needsLocation = coords == null && search.trim().length === 0;
+
+  return (
+    <BottomSheetModal
+      ref={sheetRef}
+      index={0}
+      snapPoints={snapPoints}
+      enablePanDownToClose
+      onChange={managed.onChange}
+      onFullyDismissed={managed.onFullyDismissed}
+      handleIndicatorStyle={styles.indicator}
+    >
+      <BottomSheetView style={styles.header}>
+        <Text variant="title3" color={systemColors.label}>
+          {t('mobile.gymPicker.title')}
+        </Text>
+        <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.centered}>
+          {t('mobile.gymPicker.subtitle')}
+        </Text>
+      </BottomSheetView>
+
+      <BottomSheetView style={styles.searchWrapper}>
+        <BottomSheetTextInput
+          value={search}
+          onChangeText={setSearch}
+          placeholder={t('mobile.gymPicker.searchPlaceholder')}
+          placeholderTextColor={systemColors.tertiaryLabel}
+          accessibilityLabel={t('mobile.gymPicker.searchPlaceholder')}
+          autoCorrect={false}
+          style={[styles.searchInput, { backgroundColor: systemColors.tertiaryBackground, color: systemColors.label }]}
+        />
+      </BottomSheetView>
+
+      <Pressable
+        onPress={handleSelectNone}
+        accessibilityRole="button"
+        accessibilityState={{ selected: selectedUuid == null }}
+        style={({ pressed }) => [
+          styles.row,
+          styles.noGymRow,
+          { backgroundColor: pressed ? systemColors.tertiaryBackground : 'transparent' },
+        ]}
+      >
+        <View style={styles.rowText}>
+          <Text variant="body" color={systemColors.label}>
+            {t('mobile.gymPicker.noGym')}
+          </Text>
+          <Text variant="footnote" color={systemColors.secondaryLabel}>
+            {t('mobile.gymPicker.noGymHint')}
+          </Text>
+        </View>
+        {selectedUuid == null ? <Icon name="check.small" size={20} color={brandColors.primary} /> : null}
+      </Pressable>
+
+      {needsLocation ? (
+        <View style={styles.centerState}>
+          <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.centered}>
+            {t('mobile.gyms.locationNeeded')}
+          </Text>
+          <Button
+            title={t('mobile.gyms.grantLocation')}
+            onPress={() => void deviceLocation.request()}
+            variant="tonal"
+            size="medium"
+          />
+        </View>
+      ) : isLoading ? (
+        <View style={styles.centerState}>
+          <ActivityIndicator size="small" color={brandColors.primary} />
+        </View>
+      ) : gyms.length === 0 ? (
+        <View style={styles.centerState}>
+          <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.centered}>
+            {t('mobile.gymPicker.empty')}
+          </Text>
+        </View>
+      ) : (
+        <BottomSheetFlatList
+          data={gyms}
+          keyExtractor={keyExtractor}
+          renderItem={renderItem}
+          contentContainerStyle={[styles.listContent, { paddingBottom: insets.bottom + spacing[4] }]}
+          showsVerticalScrollIndicator={false}
+        />
+      )}
+
+      <View style={[styles.footer, { paddingBottom: insets.bottom + spacing[3] }]}>
+        <Text variant="caption1" color={systemColors.secondaryLabel} style={styles.centered}>
+          {t('mobile.gymPicker.sharedEditHint')}
+        </Text>
+        <Button title={t('mobile.gymPicker.addNew')} onPress={onRequestManualLocation} variant="text" size="medium" />
+      </View>
+    </BottomSheetModal>
+  );
+}
+
+const styles = StyleSheet.create({
+  indicator: {
+    backgroundColor: iosSystemColors.separator,
+    width: 36,
+    height: 5,
+    borderRadius: 3,
+  },
+  header: {
+    paddingHorizontal: spacing[4],
+    paddingBottom: spacing[2],
+    alignItems: 'center',
+    gap: 4,
+  },
+  centered: {
+    textAlign: 'center',
+  },
+  searchWrapper: {
+    paddingHorizontal: spacing[4],
+    paddingBottom: spacing[2],
+  },
+  searchInput: {
+    borderRadius: borderRadius.md,
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+    fontSize: 16,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[3],
+  },
+  noGymRow: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: iosSystemColors.separator,
+  },
+  rowText: {
+    flex: 1,
+    gap: 2,
+  },
+  centerState: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing[3],
+    paddingVertical: spacing[8],
+    paddingHorizontal: spacing[6],
+  },
+  listContent: {
+    paddingTop: spacing[1],
+  },
+  footer: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[2],
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: iosSystemColors.separator,
+    gap: spacing[1],
+  },
+});

--- a/packages/mobile/src/components/board-discovery/GymPickerSheet.tsx
+++ b/packages/mobile/src/components/board-discovery/GymPickerSheet.tsx
@@ -110,9 +110,12 @@ export function GymPickerSheet({
 
   // Prefer coordinates the board already carries; otherwise ask the device once.
   const coords = boardCoords ?? deviceLocation.coords;
+  // Depend on `request` (a stable useCallback), not the whole hook result — that
+  // object is a fresh reference every render, which re-fired this on each one.
+  const requestLocation = deviceLocation.request;
   useEffect(() => {
-    if (boardCoords == null) void deviceLocation.request();
-  }, [boardCoords, deviceLocation]);
+    if (boardCoords == null) void requestLocation();
+  }, [boardCoords, requestLocation]);
 
   // With no coordinates the query still runs as a text search, so someone who
   // declined location can find their gym by typing.

--- a/packages/mobile/src/components/board-discovery/use-board-builder.ts
+++ b/packages/mobile/src/components/board-discovery/use-board-builder.ts
@@ -159,17 +159,30 @@ export function useBoardBuilder(seed?: BoardBuilderSeed | null) {
   /**
    * Pick (or clear) the board's gym. Stamping the gym's own coordinates onto the
    * board is what lets the server's proximity check pass for a gym the user
-   * doesn't run, and it's the more accurate value anyway. A location name the
-   * user already typed is left alone.
+   * doesn't run, and it's the more accurate value anyway.
+   *
+   * The location name is back-filled from the gym only when it's blank or still
+   * holds the name this function last put there. Guarding on "blank" alone made
+   * the back-fill sticky: pick gym A, switch to gym B, and the board ends up
+   * linked to B but labelled A. Anything the user typed themselves is left alone.
    */
+  const autoFilledLocationRef = useRef<string | null>(null);
   const setSelectedGym = useCallback(
     (gym: { uuid: string; name: string; latitude?: number | null; longitude?: number | null } | null) => {
       setSelectedGymState(gym ? { uuid: gym.uuid, name: gym.name } : null);
       if (!gym) return;
       if (gym.latitude != null && gym.longitude != null) {
         setCoords({ latitude: gym.latitude, longitude: gym.longitude });
+      } else {
+        // A gym with no coordinates can't vouch for the previous gym's, and a
+        // stale pair would aim the server's proximity check at the wrong place.
+        setCoords(null);
       }
-      setLocationName((previous) => (previous.trim().length > 0 ? previous : gym.name));
+      setLocationName((previous) => {
+        const isOurs = previous.trim().length === 0 || previous === autoFilledLocationRef.current;
+        return isOurs ? gym.name : previous;
+      });
+      autoFilledLocationRef.current = gym.name;
     },
     [],
   );

--- a/packages/mobile/src/components/board-discovery/use-board-builder.ts
+++ b/packages/mobile/src/components/board-discovery/use-board-builder.ts
@@ -37,6 +37,9 @@ export type BoardBuilderSeed = {
   serialNumber?: string;
   /** Advertised BLE name of the Rogue workout timer paired to this board. */
   timerName?: string;
+  /** The gym this board is already linked to (edit only). */
+  gymUuid?: string | null;
+  gymName?: string | null;
 };
 
 function defaultAngle(boardName: BoardName): number {
@@ -80,6 +83,11 @@ export function useBoardBuilder(seed?: BoardBuilderSeed | null) {
   );
   const [serialNumber, setSerialNumber] = useState(seed?.serialNumber ?? '');
   const [timerName, setTimerName] = useState(seed?.timerName ?? '');
+  // The gym this board sits in. Picking one is what gets the board onto the map
+  // under a gym rather than as a lone pin (#4166).
+  const [selectedGym, setSelectedGymState] = useState<{ uuid: string; name: string } | null>(
+    seed?.gymUuid && seed?.gymName ? { uuid: seed.gymUuid, name: seed.gymName } : null,
+  );
 
   // Re-seed when the seed's VALUES change (opened from a different Popular
   // config). Keyed on the serialized seed, not its object identity, so an
@@ -149,6 +157,24 @@ export function useBoardBuilder(seed?: BoardBuilderSeed | null) {
   const canCreate = layoutId != null && sizeId != null && setIds.length > 0;
 
   /**
+   * Pick (or clear) the board's gym. Stamping the gym's own coordinates onto the
+   * board is what lets the server's proximity check pass for a gym the user
+   * doesn't run, and it's the more accurate value anyway. A location name the
+   * user already typed is left alone.
+   */
+  const setSelectedGym = useCallback(
+    (gym: { uuid: string; name: string; latitude?: number | null; longitude?: number | null } | null) => {
+      setSelectedGymState(gym ? { uuid: gym.uuid, name: gym.name } : null);
+      if (!gym) return;
+      if (gym.latitude != null && gym.longitude != null) {
+        setCoords({ latitude: gym.latitude, longitude: gym.longitude });
+      }
+      setLocationName((previous) => (previous.trim().length > 0 ? previous : gym.name));
+    },
+    [],
+  );
+
+  /**
    * The validated CreateBoardInput, or null when the config is incomplete.
    * `fallbackName` (e.g. an auto-generated "Marco's Kilter Original 12×12") is
    * used when the user left the name blank; defaults to the cleaned layout name.
@@ -173,6 +199,7 @@ export function useBoardBuilder(seed?: BoardBuilderSeed | null) {
       locationName: locationName.trim() || undefined,
       latitude: coords?.latitude,
       longitude: coords?.longitude,
+      gymUuid: selectedGym?.uuid,
     };
   };
 
@@ -233,6 +260,7 @@ export function useBoardBuilder(seed?: BoardBuilderSeed | null) {
     coords,
     serialNumber,
     timerName,
+    selectedGym,
     // derived
     layouts,
     sizes,
@@ -256,6 +284,7 @@ export function useBoardBuilder(seed?: BoardBuilderSeed | null) {
     setCoords,
     setSerialNumber,
     setTimerName,
+    setSelectedGym,
     buildCreateInput,
     buildUpdateInput,
   };

--- a/packages/mobile/src/lib/graphql/extract-error-message.ts
+++ b/packages/mobile/src/lib/graphql/extract-error-message.ts
@@ -82,3 +82,8 @@ export function isExpectedBetaValidationError(error: unknown): boolean {
       EXPECTED_BETA_VALIDATION_CODES.has(graphqlError.extensions.code),
   );
 }
+
+// createBoard's duplicate rejection is parsed in @boardsesh/graphql so web and
+// mobile branch on the same shape. Re-exported here so board screens keep a
+// single import for GraphQL error handling.
+export { readDuplicateBoardError, type DuplicateBoardError } from '@boardsesh/graphql/errors';

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -58,10 +58,12 @@ import {
   GRANT_GYM_WRITE_ACCESS,
   REVOKE_GYM_WRITE_ACCESS,
   REQUEST_GYM_CLAIM,
+  LINK_BOARD_TO_GYM,
   type SearchGymsQueryResponse,
   type GetGymQueryResponse,
   type GetMyGymsQueryResponse,
   type UpdateGymMutationResponse,
+  type LinkBoardToGymMutationResponse,
   type GetGymMembersQueryResponse,
   type GrantGymWriteAccessMutationResponse,
   type RevokeGymWriteAccessMutationResponse,
@@ -232,6 +234,17 @@ export function useBoard(boardUuid: string | null) {
 }
 
 /**
+ * One board by uuid, fetched imperatively. For the moments a board is identified
+ * mid-interaction rather than at render — the duplicate-board prompt names an
+ * existing board the user may not have in any loaded page (myBoards is
+ * paginated), and it has to be resolved inside the tap handler.
+ */
+export async function fetchBoardByUuid(boardUuid: string) {
+  const data = await getHttpClient().request<GetBoardQueryResponse>(GET_BOARD, { boardUuid });
+  return data.board;
+}
+
+/**
  * A single gym by uuid, including the viewer's `canEdit` flag. Backs the
  * gym-edit screen (moderators reach it from the wall finder's edit affordance).
  * Disabled until a uuid resolves so the edit screen can pass `null` while routing.
@@ -390,6 +403,7 @@ export function useNearbyGyms(
   sizeIds?: number[],
   // Restrict to gyms with two or more distinct board types.
   multiBoardTypeOnly?: boolean,
+  options?: { enabled?: boolean },
 ) {
   const nameFilter = query && query.trim().length > 0 ? query.trim() : undefined;
   const typeFilter = boardTypes && boardTypes.length > 0 ? boardTypes : undefined;
@@ -422,7 +436,10 @@ export function useNearbyGyms(
         },
       }),
     select: (data) => data.searchGyms,
-    enabled: coords !== null,
+    // A name search stands on its own: `searchGyms` falls back to a text-only
+    // lookup without coordinates, so the gym picker still works for someone who
+    // declined location permission.
+    enabled: (options?.enabled ?? true) && (coords !== null || nameFilter !== undefined),
     // See useNearbyBoards: keep prior gyms on screen while a panned center
     // refetches so markers/list don't flicker.
     placeholderData: keepPreviousData,
@@ -490,6 +507,29 @@ export function useUpdateGym() {
       void queryClient.invalidateQueries({ queryKey: ['nearbyBoards'] });
       void queryClient.invalidateQueries({ queryKey: ['myBoards'] });
       void queryClient.invalidateQueries({ queryKey: ['myGyms'] });
+    },
+  });
+}
+
+/**
+ * Link a board you own to a gym, or unlink it by passing `gymUuid: null`.
+ * Linking to a gym you don't run is allowed when the board sits within 150 m of
+ * it — the server decides, and rejects with "not authorized" when it's too far,
+ * so the caller should surface that failure rather than assume success.
+ */
+export function useLinkBoardToGym() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: { boardUuid: string; gymUuid: string | null }) => {
+      const response = await getHttpClient().request<LinkBoardToGymMutationResponse>(LINK_BOARD_TO_GYM, { input });
+      return response.linkBoardToGym;
+    },
+    onSuccess: (_result, variables) => {
+      void queryClient.invalidateQueries({ queryKey: ['board', variables.boardUuid] });
+      void queryClient.invalidateQueries({ queryKey: ['myBoards'] });
+      void queryClient.invalidateQueries({ queryKey: ['nearbyBoards'] });
+      void queryClient.invalidateQueries({ queryKey: ['nearbyGyms'] });
+      void queryClient.invalidateQueries({ queryKey: ['gymBoards'] });
     },
   });
 }

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -2470,6 +2470,12 @@ input CreateBoardInput {
   serialNumber: String
   "Paired Rogue Fitness timer's advertised BLE name"
   timerName: String
+  """
+  Create this board even though the caller already owns one with the same
+  configuration at the same place. Set only after the user has confirmed it is
+  a physically different wall (another gym, another room) — never by default.
+  """
+  allowDuplicateConfig: Boolean
 }
 
 """
@@ -3037,6 +3043,18 @@ input AttachBoardToGymInput {
   "Gym UUID to attach the board to"
   gymUuid: ID!
   "Stray board UUID to attach"
+  boardUuid: ID!
+}
+
+"""
+Input for removing a board from a gym's listing. The gate is edit access to the
+gym; the board must currently be listed at it. Clears the link only — the board
+itself is untouched and stays its owner's.
+"""
+input DetachBoardFromGymInput {
+  "Gym UUID to detach the board from"
+  gymUuid: ID!
+  "Board UUID to detach"
   boardUuid: ID!
 }
 
@@ -6294,7 +6312,10 @@ type Mutation {
   unfollowGym(input: FollowGymInput!): Boolean!
 
   """
-  Link or unlink a board to/from a gym.
+  Link or unlink a board you own to/from a gym. Unlinking is always yours to
+  do. Linking needs either owner/admin rights on the gym, or — so a climber can
+  list their board at the gym they actually climb at — a public gym within
+  150 m of the board's coordinates, subject to a per-caller cap.
   """
   linkBoardToGym(input: LinkBoardToGymInput!): Boolean!
 
@@ -6305,6 +6326,13 @@ type Mutation {
   stray candidate for it (a merged-twin board or a nearby unlinked/SYSTEM one).
   """
   attachBoardToGym(input: AttachBoardToGymInput!): Boolean!
+
+  """
+  Remove a board from this gym's listing. Gated on edit access to the gym, and
+  the board must currently be listed at it. Lets gym staff undo an unwanted
+  self-link; clears gym_id only, leaving the board with its owner.
+  """
+  detachBoardFromGym(input: DetachBoardFromGymInput!): Boolean!
 
   """
   Grant a user write (editor) access to a gym: edit details only, no

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -1425,6 +1425,12 @@ export type ControllerRegistration = {
 
 /** Input for creating a board. */
 export type CreateBoardInput = {
+  /**
+   * Create this board even though the caller already owns one with the same
+   * configuration at the same place. Set only after the user has confirmed it is
+   * a physically different wall (another gym, another room) — never by default.
+   */
+  allowDuplicateConfig?: InputMaybe<Scalars['Boolean']['input']>;
   /** Default angle for this board (default 40) */
   angle?: InputMaybe<Scalars['Int']['input']>;
   /** Board type */
@@ -1587,6 +1593,18 @@ export type DeleteAccountInput = {
 
 export type DeleteProposalInput = {
   proposalUuid: Scalars['ID']['input'];
+};
+
+/**
+ * Input for removing a board from a gym's listing. The gate is edit access to the
+ * gym; the board must currently be listed at it. Clears the link only — the board
+ * itself is untouched and stays its owner's.
+ */
+export type DetachBoardFromGymInput = {
+  /** Board UUID to detach */
+  boardUuid: Scalars['ID']['input'];
+  /** Gym UUID to detach the board from */
+  gymUuid: Scalars['ID']['input'];
 };
 
 export type DeviceLogEntry = {
@@ -3073,6 +3091,12 @@ export type Mutation = {
   /** Delete a tick (climb attempt record). Only the owner can delete. */
   deleteTick: Scalars['Boolean']['output'];
   /**
+   * Remove a board from this gym's listing. Gated on edit access to the gym, and
+   * the board must currently be listed at it. Lets gym staff undo an unwanted
+   * self-link; clears gym_id only, leaving the board with its owner.
+   */
+  detachBoardFromGym: Scalars['Boolean']['output'];
+  /**
    * Unlink an external platform integration. Revokes the token on the
    * provider's side (best-effort) and deletes the stored credentials.
    * Requires authentication.
@@ -3124,7 +3148,12 @@ export type Mutation = {
   kioskHeartbeat: Scalars['Boolean']['output'];
   /** Leave the current session. */
   leaveSession: Scalars['Boolean']['output'];
-  /** Link or unlink a board to/from a gym. */
+  /**
+   * Link or unlink a board you own to/from a gym. Unlinking is always yours to
+   * do. Linking needs either owner/admin rights on the gym, or — so a climber can
+   * list their board at the gym they actually climb at — a public gym within
+   * 150 m of the board's coordinates, subject to a per-caller cap.
+   */
   linkBoardToGym: Scalars['Boolean']['output'];
   /** Mark all notifications as read. */
   markAllNotificationsRead: Scalars['Boolean']['output'];
@@ -3572,6 +3601,11 @@ export type MutationDeleteProposalArgs = {
 /** Root mutation type for all write operations. */
 export type MutationDeleteTickArgs = {
   uuid: Scalars['ID']['input'];
+};
+
+/** Root mutation type for all write operations. */
+export type MutationDetachBoardFromGymArgs = {
+  input: DetachBoardFromGymInput;
 };
 
 /** Root mutation type for all write operations. */
@@ -8021,6 +8055,7 @@ export type ResolversTypes = ResolversObject<{
   DeleteAccountInfo: ResolverTypeWrapper<DeleteAccountInfo>;
   DeleteAccountInput: DeleteAccountInput;
   DeleteProposalInput: DeleteProposalInput;
+  DetachBoardFromGymInput: DetachBoardFromGymInput;
   DeviceLogEntry: DeviceLogEntry;
   DiscoverPlaylistsInput: DiscoverPlaylistsInput;
   DiscoverPlaylistsResult: ResolverTypeWrapper<DiscoverPlaylistsResult>;
@@ -8385,6 +8420,7 @@ export type ResolversParentTypes = ResolversObject<{
   DeleteAccountInfo: DeleteAccountInfo;
   DeleteAccountInput: DeleteAccountInput;
   DeleteProposalInput: DeleteProposalInput;
+  DetachBoardFromGymInput: DetachBoardFromGymInput;
   DeviceLogEntry: DeviceLogEntry;
   DiscoverPlaylistsInput: DiscoverPlaylistsInput;
   DiscoverPlaylistsResult: DiscoverPlaylistsResult;
@@ -10300,6 +10336,12 @@ export type MutationResolvers<
     ParentType,
     ContextType,
     RequireFields<MutationDeleteTickArgs, 'uuid'>
+  >;
+  detachBoardFromGym?: Resolver<
+    ResolversTypes['Boolean'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationDetachBoardFromGymArgs, 'input'>
   >;
   disconnectIntegration?: Resolver<
     ResolversTypes['Boolean'],

--- a/packages/shared-schema/src/schema/board-entities.ts
+++ b/packages/shared-schema/src/schema/board-entities.ts
@@ -203,6 +203,12 @@ export const boardEntitiesTypeDefs = /* GraphQL */ `
     serialNumber: String
     "Paired Rogue Fitness timer's advertised BLE name"
     timerName: String
+    """
+    Create this board even though the caller already owns one with the same
+    configuration at the same place. Set only after the user has confirmed it is
+    a physically different wall (another gym, another room) — never by default.
+    """
+    allowDuplicateConfig: Boolean
   }
 
   """

--- a/packages/shared-schema/src/schema/gyms.ts
+++ b/packages/shared-schema/src/schema/gyms.ts
@@ -388,6 +388,18 @@ export const gymsTypeDefs = /* GraphQL */ `
   }
 
   """
+  Input for removing a board from a gym's listing. The gate is edit access to the
+  gym; the board must currently be listed at it. Clears the link only — the board
+  itself is untouched and stays its owner's.
+  """
+  input DetachBoardFromGymInput {
+    "Gym UUID to detach the board from"
+    gymUuid: ID!
+    "Board UUID to detach"
+    boardUuid: ID!
+  }
+
+  """
   Input for granting a user write (editor) access to a gym.
   """
   input GrantGymWriteAccessInput {

--- a/packages/shared-schema/src/schema/mutations.ts
+++ b/packages/shared-schema/src/schema/mutations.ts
@@ -505,7 +505,10 @@ export const mutationsTypeDefs = /* GraphQL */ `
     unfollowGym(input: FollowGymInput!): Boolean!
 
     """
-    Link or unlink a board to/from a gym.
+    Link or unlink a board you own to/from a gym. Unlinking is always yours to
+    do. Linking needs either owner/admin rights on the gym, or — so a climber can
+    list their board at the gym they actually climb at — a public gym within
+    150 m of the board's coordinates, subject to a per-caller cap.
     """
     linkBoardToGym(input: LinkBoardToGymInput!): Boolean!
 
@@ -516,6 +519,13 @@ export const mutationsTypeDefs = /* GraphQL */ `
     stray candidate for it (a merged-twin board or a nearby unlinked/SYSTEM one).
     """
     attachBoardToGym(input: AttachBoardToGymInput!): Boolean!
+
+    """
+    Remove a board from this gym's listing. Gated on edit access to the gym, and
+    the board must currently be listed at it. Lets gym staff undo an unwanted
+    self-link; clears gym_id only, leaving the board with its owner.
+    """
+    detachBoardFromGym(input: DetachBoardFromGymInput!): Boolean!
 
     """
     Grant a user write (editor) access to a gym: edit details only, no

--- a/packages/shared-schema/src/types/board-entities.ts
+++ b/packages/shared-schema/src/types/board-entities.ts
@@ -88,6 +88,11 @@ export type CreateBoardInput = {
   isAngleAdjustable?: boolean;
   serialNumber?: string;
   timerName?: string | null;
+  /**
+   * Create even though the caller already owns this configuration at this
+   * place. Set only after the user confirms it is a different physical wall.
+   */
+  allowDuplicateConfig?: boolean;
 };
 
 export type UpdateBoardInput = {

--- a/packages/shared-schema/src/types/gyms.ts
+++ b/packages/shared-schema/src/types/gyms.ts
@@ -113,6 +113,11 @@ export type AttachBoardToGymInput = {
   boardUuid: string;
 };
 
+export type DetachBoardFromGymInput = {
+  gymUuid: string;
+  boardUuid: string;
+};
+
 export type CreateGymInput = {
   name: string;
   description?: string;

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -250,6 +250,24 @@ export const SHARED_EVENTS = {
   // through the framing screen. Props: { boardType, source: 'onboarding' }.
   OnboardingBoardActivated: 'Onboarding Board Activated',
   BetaVideoAdded: 'Beta Video Added',
+  // Board ENTITY creation — adding a wall to your boards (distinct from the
+  // board-presence events below, which are about being on one). Added with
+  // #4166: this flow had zero telemetry, so a bug that created no rows at all
+  // for weeks was invisible in both PostHog and error tracking.
+  // Props: { boardType, layoutId, sizeId, setCount, angle, isOwned, isPublic,
+  //          hasLocationName, hasCoords, hasGym, source, allowedDuplicate }.
+  BoardCreated: 'Board Created',
+  // Props: { boardType, source, error_reason: 'duplicate_config' | 'rate_limited'
+  //          | 'auth' | 'exception' }.
+  BoardCreateFailed: 'Board Create Failed',
+  // The user already owned this board, so nothing was created and we activated
+  // the existing one instead. Props: { boardType, source }.
+  BoardCreateReusedExisting: 'Board Create Reused Existing',
+  // The duplicate choice sheet was shown. The watchdog for #4166 is that
+  // Prompted >= ReusedExisting + Created{allowedDuplicate}: if prompts stop
+  // converting, creation is silently dead-ending again.
+  // Props: { boardType, source, hasLocation }.
+  BoardDuplicatePrompted: 'Board Duplicate Prompted',
   // Board presence — "now on the wall" (board-level collaboration, keyed on the
   // shared board_id resolved from the BLE serial). `boardId` is attached as an
   // event PROPERTY at the call sites — never the raw serial. Keep these to user

--- a/packages/shared/graphql/package.json
+++ b/packages/shared/graphql/package.json
@@ -11,6 +11,11 @@
       "import": "./src/index.ts",
       "default": "./src/index.ts"
     },
+    "./errors": {
+      "types": "./src/errors.ts",
+      "import": "./src/errors.ts",
+      "default": "./src/errors.ts"
+    },
     "./operations": {
       "types": "./src/operations/index.ts",
       "import": "./src/operations/index.ts",

--- a/packages/shared/graphql/src/errors.ts
+++ b/packages/shared/graphql/src/errors.ts
@@ -1,0 +1,57 @@
+// Typed readers for server errors that both clients have to branch on, rather
+// than string-matching English prose. graphql-request throws ClientError-shaped
+// errors carrying `response.errors[]`; some call sites re-throw with
+// `graphqlErrors`, so both shapes are accepted.
+
+type GraphqlErrorLike = {
+  message?: string;
+  extensions?: {
+    code?: unknown;
+    [key: string]: unknown;
+  } | null;
+};
+
+function getGraphqlErrors(error: unknown): GraphqlErrorLike[] {
+  if (!error || typeof error !== 'object') return [];
+  const response = (error as { response?: { errors?: GraphqlErrorLike[] } }).response;
+  if (Array.isArray(response?.errors)) return response.errors;
+  const graphqlErrors = (error as { graphqlErrors?: GraphqlErrorLike[] }).graphqlErrors;
+  return Array.isArray(graphqlErrors) ? graphqlErrors : [];
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/** The board `createBoard` refused to duplicate, as named by the server. */
+export type DuplicateBoardError = {
+  boardUuid: string;
+  boardName: string;
+  boardSlug: string | null;
+  locationName: string | null;
+};
+
+/**
+ * `createBoard`'s "you already own this board at this place" rejection, with the
+ * existing board's identity attached.
+ *
+ * Not a failure to report — the user chooses between using that board and adding
+ * a genuinely different one, and the create is retried with
+ * `allowDuplicateConfig`. The board's identity comes off the error rather than
+ * out of a client's `myBoards` cache, which is paginated and can't be searched
+ * reliably (#4166).
+ */
+export function readDuplicateBoardError(error: unknown): DuplicateBoardError | null {
+  for (const graphqlError of getGraphqlErrors(error)) {
+    if (graphqlError.extensions?.code !== 'BOARD_DUPLICATE_CONFIG') continue;
+    const boardUuid = asString(graphqlError.extensions.existingBoardUuid);
+    if (!boardUuid) continue;
+    return {
+      boardUuid,
+      boardName: asString(graphqlError.extensions.existingBoardName) ?? '',
+      boardSlug: asString(graphqlError.extensions.existingBoardSlug),
+      locationName: asString(graphqlError.extensions.existingBoardLocationName),
+    };
+  }
+  return null;
+}

--- a/packages/shared/graphql/src/errors.ts
+++ b/packages/shared/graphql/src/errors.ts
@@ -29,6 +29,8 @@ export type DuplicateBoardError = {
   boardName: string;
   boardSlug: string | null;
   locationName: string | null;
+  /** The existing board's own angle, so a link to it doesn't land on the type default. */
+  angle: number | null;
 };
 
 /**
@@ -51,6 +53,10 @@ export function readDuplicateBoardError(error: unknown): DuplicateBoardError | n
       boardName: asString(graphqlError.extensions.existingBoardName) ?? '',
       boardSlug: asString(graphqlError.extensions.existingBoardSlug),
       locationName: asString(graphqlError.extensions.existingBoardLocationName),
+      angle:
+        typeof graphqlError.extensions.existingBoardAngle === 'number'
+          ? graphqlError.extensions.existingBoardAngle
+          : null,
     };
   }
   return null;

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -1422,6 +1422,12 @@ export type ControllerRegistration = {
 
 /** Input for creating a board. */
 export type CreateBoardInput = {
+  /**
+   * Create this board even though the caller already owns one with the same
+   * configuration at the same place. Set only after the user has confirmed it is
+   * a physically different wall (another gym, another room) — never by default.
+   */
+  allowDuplicateConfig?: InputMaybe<Scalars['Boolean']['input']>;
   /** Default angle for this board (default 40) */
   angle?: InputMaybe<Scalars['Int']['input']>;
   /** Board type */
@@ -1584,6 +1590,18 @@ export type DeleteAccountInput = {
 
 export type DeleteProposalInput = {
   proposalUuid: Scalars['ID']['input'];
+};
+
+/**
+ * Input for removing a board from a gym's listing. The gate is edit access to the
+ * gym; the board must currently be listed at it. Clears the link only — the board
+ * itself is untouched and stays its owner's.
+ */
+export type DetachBoardFromGymInput = {
+  /** Board UUID to detach */
+  boardUuid: Scalars['ID']['input'];
+  /** Gym UUID to detach the board from */
+  gymUuid: Scalars['ID']['input'];
 };
 
 export type DeviceLogEntry = {
@@ -3070,6 +3088,12 @@ export type Mutation = {
   /** Delete a tick (climb attempt record). Only the owner can delete. */
   deleteTick: Scalars['Boolean']['output'];
   /**
+   * Remove a board from this gym's listing. Gated on edit access to the gym, and
+   * the board must currently be listed at it. Lets gym staff undo an unwanted
+   * self-link; clears gym_id only, leaving the board with its owner.
+   */
+  detachBoardFromGym: Scalars['Boolean']['output'];
+  /**
    * Unlink an external platform integration. Revokes the token on the
    * provider's side (best-effort) and deletes the stored credentials.
    * Requires authentication.
@@ -3121,7 +3145,12 @@ export type Mutation = {
   kioskHeartbeat: Scalars['Boolean']['output'];
   /** Leave the current session. */
   leaveSession: Scalars['Boolean']['output'];
-  /** Link or unlink a board to/from a gym. */
+  /**
+   * Link or unlink a board you own to/from a gym. Unlinking is always yours to
+   * do. Linking needs either owner/admin rights on the gym, or — so a climber can
+   * list their board at the gym they actually climb at — a public gym within
+   * 150 m of the board's coordinates, subject to a per-caller cap.
+   */
   linkBoardToGym: Scalars['Boolean']['output'];
   /** Mark all notifications as read. */
   markAllNotificationsRead: Scalars['Boolean']['output'];
@@ -3569,6 +3598,11 @@ export type MutationDeleteProposalArgs = {
 /** Root mutation type for all write operations. */
 export type MutationDeleteTickArgs = {
   uuid: Scalars['ID']['input'];
+};
+
+/** Root mutation type for all write operations. */
+export type MutationDetachBoardFromGymArgs = {
+  input: DetachBoardFromGymInput;
 };
 
 /** Root mutation type for all write operations. */

--- a/packages/shared/graphql/src/index.ts
+++ b/packages/shared/graphql/src/index.ts
@@ -1,1 +1,2 @@
 export * from './operations';
+export * from './errors';

--- a/packages/shared/graphql/src/operations/gyms.ts
+++ b/packages/shared/graphql/src/operations/gyms.ts
@@ -287,6 +287,12 @@ export const ATTACH_BOARD_TO_GYM = gql`
   }
 `;
 
+export const DETACH_BOARD_FROM_GYM = gql`
+  mutation DetachBoardFromGym($input: DetachBoardFromGymInput!) {
+    detachBoardFromGym(input: $input)
+  }
+`;
+
 export const GRANT_GYM_WRITE_ACCESS = gql`
   mutation GrantGymWriteAccess($input: GrantGymWriteAccessInput!) {
     grantGymWriteAccess(input: $input)

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -118,7 +118,6 @@
       "location": "Location",
       "locationPlaceholder": "Home, gym name, or city",
       "useMyLocation": "Use my location",
-      "locationSet": "Location set",
       "serial": "Controller serial",
       "serialPlaceholder": "e.g. ABC-12345",
       "serialHint": "Optional — your controller links itself the first time you connect.",
@@ -129,7 +128,20 @@
       "timerHint": "Pair a Rogue gym timer to this board. While you're driving the wall, every send starts its stopwatch.",
       "timerPairCta": "Pair a timer",
       "timerChangeCta": "Change timer",
-      "timerRemoveCta": "Remove"
+      "timerRemoveCta": "Remove",
+      "gym": "Gym",
+      "gymNone": "Not at a gym",
+      "clearLocation": "Clear location",
+      "duplicate": {
+        "title": "You already have this setup",
+        "body": "You already have \"{{name}}\" with the same layout, size and hold sets.",
+        "bodyWithLocation": "You already have \"{{name}}\" at {{location}}, with the same layout, size and hold sets.",
+        "useExisting": "Use that board",
+        "addAnother": "Add a new board here",
+        "addAnotherHint": "Pick this if it's a different wall — another gym, another room.",
+        "cancel": "Keep editing",
+        "switchError": "Couldn't switch to that board. Try again."
+      }
     },
     "custom": {
       "board": "Board",
@@ -276,6 +288,16 @@
       "pickerNoticeUnreachable": "Can't reach your boards right now — here are the ones you've downloaded.",
       "pickerEmptyTitle": "Nothing downloaded yet",
       "pickerEmptyBody": "Boards you make available offline show up here. Grab one while you have signal."
+    },
+    "gymPicker": {
+      "title": "Where is this board?",
+      "subtitle": "Pick the gym it's in so climbers find it on the map.",
+      "searchPlaceholder": "Search gyms",
+      "noGym": "Not at a gym",
+      "noGymHint": "It'll still show on the map as its own pin.",
+      "addNew": "My gym isn't listed",
+      "empty": "No gyms nearby",
+      "sharedEditHint": "This gym's staff will be able to edit this board's details."
     }
   },
   "boardEntity": {
@@ -324,12 +346,15 @@
       "submit": "Create Board",
       "authRequired": "You must be signed in to create a board",
       "errorMessage": "Failed to create board. It may already exist for this configuration.",
-      "duplicateNamed": "You already have a board called \"{{name}}\" with this setup.",
       "goToExisting": "Go to your board",
       "nameRequired": "Board name is required",
       "createdNamed": "Board \"{{name}}\" created!",
       "namePlaceholder": "e.g., Home Board, Gym Name",
-      "locationPlaceholder": "e.g., City, Gym Name"
+      "locationPlaceholder": "e.g., City, Gym Name",
+      "duplicateTitle": "You already have this setup",
+      "duplicateBody": "You already have \"{{name}}\" with the same layout, size and hold sets. Add another only if it’s a different wall.",
+      "addAnyway": "Add it anyway",
+      "keepEditing": "Cancel"
     },
     "fields": {
       "name": "Board Name",

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -297,7 +297,8 @@
       "noGymHint": "It'll still show on the map as its own pin.",
       "addNew": "My gym isn't listed",
       "empty": "No gyms nearby",
-      "sharedEditHint": "This gym's staff will be able to edit this board's details."
+      "sharedEditHint": "This gym's staff will be able to edit this board's details.",
+      "linkError": "Couldn't link that gym. It may be too far from your board. Your other changes were saved."
     }
   },
   "boardEntity": {

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -297,7 +297,8 @@
       "noGymHint": "Seguirá apareciendo en el mapa con su propio marcador.",
       "addNew": "Mi gimnasio no aparece",
       "empty": "No hay gimnasios cerca",
-      "sharedEditHint": "El personal de este gimnasio podrá editar los datos de este plafón."
+      "sharedEditHint": "El personal de este gimnasio podrá editar los datos de este plafón.",
+      "linkError": "No se pudo vincular ese gimnasio. Puede estar demasiado lejos de tu plafón. El resto de cambios sí se guardaron."
     }
   },
   "boardEntity": {

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -118,7 +118,6 @@
       "location": "Ubicación",
       "locationPlaceholder": "Casa, nombre del gimnasio o ciudad",
       "useMyLocation": "Usar mi ubicación",
-      "locationSet": "Ubicación guardada",
       "serial": "Número de serie del controlador",
       "serialPlaceholder": "p. ej. ABC-12345",
       "serialHint": "Opcional: tu controlador se vincula solo la primera vez que conectas.",
@@ -129,7 +128,20 @@
       "timerHint": "Vincula un temporizador Rogue a este plafón. Mientras controlas el muro, cada encadene arranca su cronómetro.",
       "timerPairCta": "Vincular temporizador",
       "timerChangeCta": "Cambiar temporizador",
-      "timerRemoveCta": "Quitar"
+      "timerRemoveCta": "Quitar",
+      "gym": "Gimnasio",
+      "gymNone": "No está en un gimnasio",
+      "clearLocation": "Borrar ubicación",
+      "duplicate": {
+        "title": "Ya tienes esta configuración",
+        "body": "Ya tienes «{{name}}» con el mismo layout, tamaño y sets de presas.",
+        "bodyWithLocation": "Ya tienes «{{name}}» en {{location}}, con el mismo layout, tamaño y sets de presas.",
+        "useExisting": "Usar ese plafón",
+        "addAnother": "Añadir un plafón nuevo aquí",
+        "addAnotherHint": "Elige esto si es otro muro: otro gimnasio, otra sala.",
+        "cancel": "Seguir editando",
+        "switchError": "No se pudo cambiar a ese plafón. Inténtalo de nuevo."
+      }
     },
     "custom": {
       "board": "Plafón",
@@ -276,6 +288,16 @@
       "pickerNoticeUnreachable": "Ahora mismo no podemos cargar tus plafones: estos son los que has descargado.",
       "pickerEmptyTitle": "Todavía no has descargado nada",
       "pickerEmptyBody": "Los plafones que dejes disponibles sin conexión aparecen aquí. Descarga uno cuando tengas conexión."
+    },
+    "gymPicker": {
+      "title": "¿Dónde está este plafón?",
+      "subtitle": "Elige el gimnasio donde está para que los escaladores lo encuentren en el mapa.",
+      "searchPlaceholder": "Buscar gimnasios",
+      "noGym": "No está en un gimnasio",
+      "noGymHint": "Seguirá apareciendo en el mapa con su propio marcador.",
+      "addNew": "Mi gimnasio no aparece",
+      "empty": "No hay gimnasios cerca",
+      "sharedEditHint": "El personal de este gimnasio podrá editar los datos de este plafón."
     }
   },
   "boardEntity": {
@@ -324,12 +346,15 @@
       "submit": "Crear plafón",
       "authRequired": "Debes iniciar sesión para crear un plafón",
       "errorMessage": "Error al crear el plafón. Puede que ya exista para esta configuración.",
-      "duplicateNamed": "Ya tienes un plafón llamado «{{name}}» con esta configuración.",
       "goToExisting": "Ir a tu plafón",
       "nameRequired": "Se requiere el nombre del plafón",
       "createdNamed": "¡Plafón \"{{name}}\" creado!",
       "namePlaceholder": "p. ej., Plafón de casa, Nombre del gimnasio",
-      "locationPlaceholder": "p. ej., Ciudad, Nombre del gimnasio"
+      "locationPlaceholder": "p. ej., Ciudad, Nombre del gimnasio",
+      "duplicateTitle": "Ya tienes esta configuración",
+      "duplicateBody": "Ya tienes «{{name}}» con el mismo layout, tamaño y sets de presas. Añade otro solo si es otro muro.",
+      "addAnyway": "Añadirlo igualmente",
+      "keepEditing": "Cancelar"
     },
     "fields": {
       "name": "Nombre del plafón",

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -118,7 +118,6 @@
       "location": "Emplacement",
       "locationPlaceholder": "Maison, nom de la salle ou ville",
       "useMyLocation": "Utiliser ma position",
-      "locationSet": "Position enregistrée",
       "serial": "Numéro de série du contrôleur",
       "serialPlaceholder": "p. ex. ABC-12345",
       "serialHint": "Optionnel — ton contrôleur se lie tout seul à la première connexion.",
@@ -129,7 +128,20 @@
       "timerHint": "Associe un minuteur Rogue à cette board. Quand tu pilotes le mur, chaque croix démarre son chronomètre.",
       "timerPairCta": "Associer un minuteur",
       "timerChangeCta": "Changer de minuteur",
-      "timerRemoveCta": "Retirer"
+      "timerRemoveCta": "Retirer",
+      "gym": "Salle",
+      "gymNone": "Pas dans une salle",
+      "clearLocation": "Effacer la position",
+      "duplicate": {
+        "title": "Tu as déjà cette configuration",
+        "body": "Tu as déjà « {{name}} » avec le même layout, la même taille et les mêmes sets de prises.",
+        "bodyWithLocation": "Tu as déjà « {{name}} » à {{location}}, avec le même layout, la même taille et les mêmes sets de prises.",
+        "useExisting": "Utiliser cette board",
+        "addAnother": "Ajouter une nouvelle board ici",
+        "addAnotherHint": "Choisis ça si c'est un autre mur : une autre salle, une autre pièce.",
+        "cancel": "Continuer à modifier",
+        "switchError": "Impossible de basculer sur cette board. Réessaie."
+      }
     },
     "custom": {
       "board": "Board",
@@ -276,6 +288,16 @@
       "pickerNoticeUnreachable": "Impossible de charger tes boards pour l'instant — voici celles que tu as téléchargées.",
       "pickerEmptyTitle": "Rien de téléchargé pour le moment",
       "pickerEmptyBody": "Les boards que tu rends disponibles hors ligne apparaissent ici. Télécharge-en une quand tu as du réseau."
+    },
+    "gymPicker": {
+      "title": "Où se trouve cette board ?",
+      "subtitle": "Choisis la salle où elle se trouve pour que les grimpeurs la trouvent sur la carte.",
+      "searchPlaceholder": "Rechercher une salle",
+      "noGym": "Pas dans une salle",
+      "noGymHint": "Elle apparaîtra quand même sur la carte avec son propre repère.",
+      "addNew": "Ma salle n'est pas listée",
+      "empty": "Aucune salle à proximité",
+      "sharedEditHint": "L'équipe de cette salle pourra modifier les infos de cette board."
     }
   },
   "boardEntity": {
@@ -324,12 +346,15 @@
       "submit": "Créer la board",
       "authRequired": "Vous devez être connecté pour créer une board",
       "errorMessage": "Impossible de créer la board. Elle existe peut-être déjà pour cette configuration.",
-      "duplicateNamed": "Vous avez déjà une board nommée « {{name}} » avec cette configuration.",
       "goToExisting": "Aller à votre board",
       "nameRequired": "Le nom de la board est obligatoire",
       "createdNamed": "Board « {{name}} » créée !",
       "namePlaceholder": "ex. Home Board, nom de la salle",
-      "locationPlaceholder": "ex. ville, nom de la salle"
+      "locationPlaceholder": "ex. ville, nom de la salle",
+      "duplicateTitle": "Tu as déjà cette configuration",
+      "duplicateBody": "Tu as déjà « {{name}} » avec le même layout, la même taille et les mêmes sets de prises. N’en ajoute une autre que si c’est un autre mur.",
+      "addAnyway": "L'ajouter quand même",
+      "keepEditing": "Annuler"
     },
     "fields": {
       "name": "Nom de la board",

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -297,7 +297,8 @@
       "noGymHint": "Elle apparaîtra quand même sur la carte avec son propre repère.",
       "addNew": "Ma salle n'est pas listée",
       "empty": "Aucune salle à proximité",
-      "sharedEditHint": "L'équipe de cette salle pourra modifier les infos de cette board."
+      "sharedEditHint": "L'équipe de cette salle pourra modifier les infos de cette board.",
+      "linkError": "Impossible d'associer cette salle. Elle est peut-être trop loin de ta board. Tes autres modifications ont bien été enregistrées."
     }
   },
   "boardEntity": {
@@ -351,8 +352,8 @@
       "createdNamed": "Board « {{name}} » créée !",
       "namePlaceholder": "ex. Home Board, nom de la salle",
       "locationPlaceholder": "ex. ville, nom de la salle",
-      "duplicateTitle": "Tu as déjà cette configuration",
-      "duplicateBody": "Tu as déjà « {{name}} » avec le même layout, la même taille et les mêmes sets de prises. N’en ajoute une autre que si c’est un autre mur.",
+      "duplicateTitle": "Vous avez déjà cette configuration",
+      "duplicateBody": "Vous avez déjà « {{name}} » avec le même layout, la même taille et les mêmes sets de prises. N'en ajoutez une autre que si c'est un autre mur.",
       "addAnyway": "L'ajouter quand même",
       "keepEditing": "Annuler"
     },

--- a/packages/web/app/components/board-entity/__tests__/create-board-form.test.tsx
+++ b/packages/web/app/components/board-entity/__tests__/create-board-form.test.tsx
@@ -1,9 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
-import { render, act } from '@testing-library/react';
+import { render, act, screen } from '@testing-library/react';
 import React from 'react';
 import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
-import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import CreateBoardForm from '../create-board-form';
+
+// #4166. This used to look the user's boards up on EVERY create failure and call
+// anything with a matching config a duplicate — so a rate-limit or auth failure
+// reported itself as a duplicate whenever such a board happened to exist. The
+// server now says so explicitly with a BOARD_DUPLICATE_CONFIG code carrying the
+// existing board's identity, so the 20-page myBoards scan is gone and the branch
+// keys off the code alone.
 
 vi.mock('react-i18next', () => ({
   useTranslation: (ns?: string) => ({
@@ -13,41 +19,56 @@ vi.mock('react-i18next', () => ({
   Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
 }));
 
-const mockShowMessage = vi.fn();
+// vi.hoisted: the component is imported at the top of this file, which runs
+// these mock factories before a plain `const` on the line below would have
+// initialised. (CI also typechecks test files, so no spread-wrapped vi.fn.)
+const mockShowMessage = vi.hoisted(() => vi.fn());
 vi.mock('@/app/components/providers/snackbar-provider', () => ({
   useSnackbar: () => ({ showMessage: mockShowMessage }),
 }));
 
-vi.mock('@/app/hooks/use-ws-auth-token', () => ({
-  useWsAuthToken: vi.fn(),
-}));
-const mockUseWsAuthToken = vi.mocked(useWsAuthToken);
-
-const mockRequest = vi.fn();
-vi.mock('@/app/lib/graphql/client', () => ({
-  createGraphQLHttpClient: () => ({ request: mockRequest }),
-}));
-
+const mockPush = vi.hoisted(() => vi.fn());
 vi.mock('@/app/lib/i18n/use-locale-router', () => ({
-  useLocaleRouter: () => ({ push: vi.fn() }),
+  useLocaleRouter: () => ({ push: mockPush }),
 }));
 
-let capturedOnError: ((error: unknown, serverMessage: string | null) => Promise<void>) | null = null;
+const mockTrack = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/analytics', () => ({ track: mockTrack }));
+
+const mockExecute = vi.hoisted(() => vi.fn());
+const errorHolder = vi.hoisted(() => ({
+  onError: null as ((error: unknown, serverMessage: string | null) => Promise<void>) | null,
+}));
 vi.mock('@/app/hooks/use-entity-mutation', () => ({
   useEntityMutation: (_mutation: unknown, opts: { onError?: (e: unknown, s: string | null) => Promise<void> }) => {
-    capturedOnError = opts.onError ?? null;
-    return { execute: vi.fn(), token: 'test-token' };
+    errorHolder.onError = opts.onError ?? null;
+    return { execute: mockExecute };
   },
 }));
 
+// Exposes onSubmit so a test can drive a real submit — "add it anyway" replays
+// the values from the attempt that was refused, so it only means anything after
+// one.
+const SUBMIT_VALUES = {
+  name: 'Home Wall',
+  description: '',
+  locationName: 'Garage',
+  isPublic: true,
+  isUnlisted: false,
+  hideLocation: false,
+  isOwned: true,
+  angle: 40,
+};
 vi.mock('../board-form', () => ({
-  default: () => React.createElement('div', { 'data-testid': 'board-form' }),
+  default: ({ onSubmit }: { onSubmit: (values: typeof SUBMIT_VALUES) => void }) =>
+    React.createElement(
+      'button',
+      { 'data-testid': 'board-form', type: 'button', onClick: () => onSubmit(SUBMIT_VALUES) },
+      'submit form',
+    ),
 }));
 
-vi.mock('@boardsesh/graphql/operations', () => ({
-  CREATE_BOARD: 'CREATE_BOARD',
-  GET_MY_BOARDS: 'GET_MY_BOARDS',
-}));
+vi.mock('@boardsesh/graphql/operations', () => ({ CREATE_BOARD: 'CREATE_BOARD' }));
 
 const defaultProps = {
   boardType: 'kilter',
@@ -57,70 +78,93 @@ const defaultProps = {
   defaultAngle: 40,
 };
 
-const matchingBoard = {
-  name: 'Home Wall',
-  boardType: 'kilter',
-  layoutId: 1,
-  sizeId: 2,
-  setIds: 'set-1',
-  slug: 'home-wall',
-  angle: 40,
-};
+/** A graphql-request ClientError carrying the server's duplicate rejection. */
+function duplicateError(overrides: Record<string, unknown> = {}) {
+  return {
+    response: {
+      errors: [
+        {
+          message: 'You already have this board at this location',
+          extensions: {
+            code: 'BOARD_DUPLICATE_CONFIG',
+            existingBoardUuid: 'existing-uuid',
+            existingBoardName: 'Home Wall',
+            existingBoardSlug: 'home-wall',
+            existingBoardLocationName: 'Garage',
+            ...overrides,
+          },
+        },
+      ],
+    },
+  };
+}
 
 function renderAndGetOnError(props = defaultProps) {
   render(React.createElement(CreateBoardForm, props));
-  return capturedOnError!;
+  return errorHolder.onError!;
 }
 
 describe('CreateBoardForm — handleCreateError', () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks();
-    mockRequest.mockReset();
-    capturedOnError = null;
-    mockUseWsAuthToken.mockReturnValue({
-      token: 'test-token',
-      isAuthenticated: true,
-      isLoading: false,
-      error: null,
-    });
+    errorHolder.onError = null;
   });
 
-  it('shows duplicate snackbar with Go to your board action when match found', async () => {
+  it('opens the duplicate dialog naming the existing board', async () => {
     const onError = renderAndGetOnError();
-    mockRequest.mockResolvedValueOnce({
-      myBoards: { boards: [matchingBoard], hasMore: false, totalCount: 1 },
+
+    await act(async () => {
+      await onError(duplicateError(), 'You already have this board at this location');
+    });
+
+    expect(screen.getByText(/Home Wall/)).toBeTruthy();
+    // The dialog replaces the snackbar entirely: this needs three outcomes and
+    // the snackbar only has one action slot.
+    expect(mockShowMessage).not.toHaveBeenCalled();
+  });
+
+  it('offers "add it anyway", which retries with allowDuplicateConfig', async () => {
+    const onError = renderAndGetOnError();
+
+    // A real submit first: execute resolves undefined (the mutation hook swallows
+    // the failure and routes it to onError), which is what the server refusing a
+    // duplicate looks like from here.
+    await act(async () => {
+      screen.getByTestId('board-form').click();
+    });
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    expect(mockExecute.mock.calls[0][0].input.allowDuplicateConfig).toBeUndefined();
+
+    await act(async () => {
+      await onError(duplicateError(), null);
     });
 
     await act(async () => {
-      await onError(new Error('duplicate'), 'You already have a board with this configuration');
+      screen.getByText('Add it anyway').click();
     });
 
-    expect(mockShowMessage).toHaveBeenCalledTimes(1);
-    const [message, severity, action, duration] = mockShowMessage.mock.calls[0];
-    expect(severity).toBe('error');
-    expect(duration).toBe(8000);
-    expect(message).toContain('Home Wall');
-    expect(action).toMatchObject({ label: expect.any(String) });
+    expect(mockExecute).toHaveBeenCalledTimes(2);
+    // Same values, now with the user's confirmation attached.
+    expect(mockExecute.mock.calls[1][0].input).toMatchObject({
+      name: 'Home Wall',
+      locationName: 'Garage',
+      allowDuplicateConfig: true,
+    });
   });
 
-  it('falls back to serverMessage when no matching board found', async () => {
+  it('falls back to serverMessage for a NON-duplicate failure', async () => {
     const onError = renderAndGetOnError();
-    mockRequest.mockResolvedValueOnce({
-      myBoards: { boards: [], hasMore: false, totalCount: 0 },
-    });
 
     await act(async () => {
-      await onError(new Error('error'), 'server error message');
+      await onError(new Error('rate limited'), 'server error message');
     });
 
     expect(mockShowMessage).toHaveBeenCalledWith('server error message', 'error');
+    expect(screen.queryByText(/Home Wall/)).toBeNull();
   });
 
-  it('falls back to i18n error key when no match and no serverMessage', async () => {
+  it('falls back to the i18n error key when there is no serverMessage', async () => {
     const onError = renderAndGetOnError();
-    mockRequest.mockResolvedValueOnce({
-      myBoards: { boards: [], hasMore: false, totalCount: 0 },
-    });
 
     await act(async () => {
       await onError(new Error('error'), null);
@@ -132,57 +176,26 @@ describe('CreateBoardForm — handleCreateError', () => {
     );
   });
 
-  it('falls back to serverMessage when findBoardForConfig throws', async () => {
+  it('does not treat an unrelated error as a duplicate', async () => {
+    // The old behaviour: any error plus an owned board of this config read as a
+    // duplicate. Only the server's code decides now.
     const onError = renderAndGetOnError();
-    mockRequest.mockRejectedValueOnce(new Error('network failure'));
 
     await act(async () => {
-      await onError(new Error('error'), 'server error message');
+      await onError({ response: { errors: [{ extensions: { code: 'RATE_LIMITED' } }] } }, 'slow down');
+    });
+
+    expect(mockShowMessage).toHaveBeenCalledWith('slow down', 'error');
+    expect(screen.queryByText('Add it anyway')).toBeNull();
+  });
+
+  it('ignores a malformed duplicate payload with no board uuid', async () => {
+    const onError = renderAndGetOnError();
+
+    await act(async () => {
+      await onError(duplicateError({ existingBoardUuid: undefined }), 'server error message');
     });
 
     expect(mockShowMessage).toHaveBeenCalledWith('server error message', 'error');
-  });
-
-  it('skips board lookup and falls back to serverMessage when token is null', async () => {
-    mockUseWsAuthToken.mockReturnValue({
-      token: null,
-      isAuthenticated: false,
-      isLoading: false,
-      error: null,
-    });
-    const onError = renderAndGetOnError();
-
-    await act(async () => {
-      await onError(new Error('error'), 'server error message');
-    });
-
-    expect(mockRequest).not.toHaveBeenCalled();
-    expect(mockShowMessage).toHaveBeenCalledWith('server error message', 'error');
-  });
-
-  it('paginates until a match is found across multiple pages', async () => {
-    const onError = renderAndGetOnError();
-    // First page: no match, hasMore true
-    mockRequest.mockResolvedValueOnce({
-      myBoards: {
-        boards: [{ ...matchingBoard, boardType: 'tension', setIds: 'other' }],
-        hasMore: true,
-        totalCount: 51,
-      },
-    });
-    // Second page: contains the match
-    mockRequest.mockResolvedValueOnce({
-      myBoards: { boards: [matchingBoard], hasMore: false, totalCount: 51 },
-    });
-
-    await act(async () => {
-      await onError(new Error('duplicate'), 'You already have a board with this configuration');
-    });
-
-    expect(mockRequest).toHaveBeenCalledTimes(2);
-    const [message, severity, , duration] = mockShowMessage.mock.calls[0];
-    expect(severity).toBe('error');
-    expect(duration).toBe(8000);
-    expect(message).toContain('Home Wall');
   });
 });

--- a/packages/web/app/components/board-entity/create-board-form.tsx
+++ b/packages/web/app/components/board-entity/create-board-form.tsx
@@ -1,55 +1,44 @@
 'use client';
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { useEntityMutation } from '@/app/hooks/use-entity-mutation';
 import {
   CREATE_BOARD,
-  GET_MY_BOARDS,
   type CreateBoardMutationVariables,
   type CreateBoardMutationResponse,
-  type GetMyBoardsQueryResponse,
 } from '@boardsesh/graphql/operations';
+import { readDuplicateBoardError, type DuplicateBoardError } from '@boardsesh/graphql/errors';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { track } from '@/app/lib/analytics';
 import { useLocaleRouter } from '@/app/lib/i18n/use-locale-router';
-import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
-import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import { constructBoardSlugListUrl } from '@/app/lib/url-utils';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import type { BoardName } from '@/app/lib/types';
 import { ANGLES } from '@/app/lib/board-data';
 import BoardForm, { type BoardFormSubmitState } from './board-form';
 
-type BoardConfig = { boardType: string; layoutId: number; sizeId: number; setIds: string };
-
-// Looked up only on a create failure, so the happy path doesn't pay for it. The
-// duplicate error doesn't carry the existing board's slug, so we fetch the
-// user's boards and match the config to offer a jump to it. A lookup failure
-// must not mask the original error, so we swallow it and fall back to the message.
-async function findBoardForConfig(token: string, config: BoardConfig): Promise<UserBoard | null> {
-  try {
-    const client = createGraphQLHttpClient(token);
-    const pageSize = 50;
-    const maxPages = 20;
-    for (let page = 0; page < maxPages; page++) {
-      const data = await client.request<GetMyBoardsQueryResponse>(GET_MY_BOARDS, {
-        input: { limit: pageSize, offset: page * pageSize },
-      });
-      const match = data.myBoards.boards.find(
-        (board) =>
-          board.boardType === config.boardType &&
-          board.layoutId === config.layoutId &&
-          board.sizeId === config.sizeId &&
-          board.setIds === config.setIds,
-      );
-      if (match) return match;
-      if (!data.myBoards.hasMore) return null;
-    }
-    return null;
-  } catch {
-    return null;
-  }
-}
+/** The values BoardForm hands back on submit. */
+type CreateBoardFormValues = {
+  name: string;
+  description: string;
+  locationName: string;
+  latitude?: number | null;
+  longitude?: number | null;
+  isPublic: boolean;
+  isUnlisted: boolean;
+  hideLocation: boolean;
+  isOwned: boolean;
+  angle?: number;
+  isAngleAdjustable?: boolean;
+};
 
 type CreateBoardFormProps = {
   boardType: string;
@@ -79,28 +68,34 @@ export default function CreateBoardForm({
   const { t } = useTranslation('boards');
   const { showMessage } = useSnackbar();
   const router = useLocaleRouter();
-  const { token } = useWsAuthToken();
 
   const availableAngles = ANGLES[boardType as BoardName] ?? [];
 
+  // The pending duplicate, if the last create was refused for that reason. Held
+  // so the dialog can offer "add it anyway", which re-runs the create with the
+  // confirmation flag.
+  const [duplicate, setDuplicate] = useState<DuplicateBoardError | null>(null);
+  const lastValuesRef = useRef<CreateBoardFormValues | null>(null);
+
   const handleCreateError = useCallback(
-    async (_error: unknown, serverMessage: string | null) => {
-      const existing = token ? await findBoardForConfig(token, { boardType, layoutId, sizeId, setIds }) : null;
-      if (existing) {
-        showMessage(
-          t('boardForm.create.duplicateNamed', { name: existing.name }),
-          'error',
-          {
-            label: t('boardForm.create.goToExisting'),
-            onClick: () => router.push(constructBoardSlugListUrl(existing.slug, existing.angle)),
-          },
-          8000,
-        );
+    async (error: unknown, serverMessage: string | null) => {
+      // Gate strictly on the server's code. This used to look up an owned board
+      // matching the config on EVERY error, so a rate-limit or auth failure
+      // reported itself as a duplicate whenever such a board happened to exist.
+      const duplicateError = readDuplicateBoardError(error);
+      if (duplicateError) {
+        track(SHARED_EVENTS.BoardDuplicatePrompted, { boardType, source: 'web_drawer' });
+        setDuplicate(duplicateError);
         return;
       }
+      track(SHARED_EVENTS.BoardCreateFailed, {
+        boardType,
+        source: 'web_drawer',
+        error_reason: 'exception',
+      });
       showMessage(serverMessage ?? t('boardForm.create.errorMessage'), 'error');
     },
-    [token, boardType, layoutId, sizeId, setIds, showMessage, router, t],
+    [boardType, showMessage, t],
   );
 
   const { execute } = useEntityMutation<CreateBoardMutationResponse, CreateBoardMutationVariables>(CREATE_BOARD, {
@@ -109,25 +104,8 @@ export default function CreateBoardForm({
     onError: handleCreateError,
   });
 
-  const handleSubmit = useCallback(
-    async (values: {
-      name: string;
-      description: string;
-      locationName: string;
-      latitude?: number | null;
-      longitude?: number | null;
-      isPublic: boolean;
-      isUnlisted: boolean;
-      hideLocation: boolean;
-      isOwned: boolean;
-      angle?: number;
-      isAngleAdjustable?: boolean;
-    }) => {
-      if (!values.name) {
-        showMessage(t('boardForm.create.nameRequired'), 'error');
-        return;
-      }
-
+  const runCreate = useCallback(
+    async (values: CreateBoardFormValues, allowDuplicateConfig?: boolean) => {
       const data = await execute({
         input: {
           boardType,
@@ -145,11 +123,25 @@ export default function CreateBoardForm({
           isOwned: values.isOwned,
           angle: values.angle,
           isAngleAdjustable: values.isAngleAdjustable,
+          allowDuplicateConfig: allowDuplicateConfig || undefined,
         },
       });
 
       if (data) {
         const board = data.createBoard;
+        track(SHARED_EVENTS.BoardCreated, {
+          boardType,
+          layoutId,
+          sizeId,
+          setCount: setIds.split(',').filter(Boolean).length,
+          angle: values.angle,
+          isOwned: values.isOwned,
+          isPublic: values.isPublic,
+          hasLocationName: !!values.locationName,
+          hasCoords: values.latitude != null && values.longitude != null,
+          source: 'web_drawer',
+          allowedDuplicate: !!allowDuplicateConfig,
+        });
         showMessage(t('boardForm.create.createdNamed', { name: board.name }), 'success');
 
         if (onSuccess) {
@@ -162,26 +154,74 @@ export default function CreateBoardForm({
     [execute, boardType, layoutId, sizeId, setIds, defaultAngle, showMessage, router, onSuccess, t],
   );
 
+  const handleSubmit = useCallback(
+    async (values: CreateBoardFormValues) => {
+      if (!values.name) {
+        showMessage(t('boardForm.create.nameRequired'), 'error');
+        return;
+      }
+      // Kept so "add it anyway" can replay the exact same values.
+      lastValuesRef.current = values;
+      await runCreate(values);
+    },
+    [runCreate, showMessage, t],
+  );
+
+  const handleGoToExisting = useCallback(() => {
+    if (!duplicate?.boardSlug) return;
+    setDuplicate(null);
+    router.push(constructBoardSlugListUrl(duplicate.boardSlug, defaultAngle));
+  }, [duplicate, router, defaultAngle]);
+
+  const handleAddAnyway = useCallback(async () => {
+    const values = lastValuesRef.current;
+    setDuplicate(null);
+    if (!values) return;
+    await runCreate(values, true);
+  }, [runCreate]);
+
   return (
-    <BoardForm
-      title=""
-      submitLabel={t('boardForm.create.submit')}
-      initialValues={{
-        name: '',
-        description: '',
-        locationName: '',
-        isPublic: true,
-        isUnlisted: false,
-        hideLocation: false,
-        isOwned: true,
-      }}
-      namePlaceholder={t('boardForm.create.namePlaceholder')}
-      locationPlaceholder={t('boardForm.create.locationPlaceholder')}
-      availableAngles={availableAngles}
-      onSubmit={handleSubmit}
-      onCancel={onCancel}
-      formId={formId}
-      onSubmitStateChange={onSubmitStateChange}
-    />
+    <>
+      <BoardForm
+        title=""
+        submitLabel={t('boardForm.create.submit')}
+        initialValues={{
+          name: '',
+          description: '',
+          locationName: '',
+          isPublic: true,
+          isUnlisted: false,
+          hideLocation: false,
+          isOwned: true,
+        }}
+        namePlaceholder={t('boardForm.create.namePlaceholder')}
+        locationPlaceholder={t('boardForm.create.locationPlaceholder')}
+        availableAngles={availableAngles}
+        onSubmit={handleSubmit}
+        onCancel={onCancel}
+        formId={formId}
+        onSubmitStateChange={onSubmitStateChange}
+      />
+      {/* A dialog, not a snackbar: the snackbar has one action slot and this
+          needs three outcomes. Before #4166 there was no "add it anyway" at all,
+          so a second board of the same setup at a new gym was unreachable. */}
+      <Dialog open={duplicate !== null} onClose={() => setDuplicate(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>{t('boardForm.create.duplicateTitle')}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {t('boardForm.create.duplicateBody', { name: duplicate?.boardName ?? '' })}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDuplicate(null)}>{t('boardForm.create.keepEditing')}</Button>
+          {duplicate?.boardSlug ? (
+            <Button onClick={handleGoToExisting}>{t('boardForm.create.goToExisting')}</Button>
+          ) : null}
+          <Button onClick={() => void handleAddAnyway()} variant="contained">
+            {t('boardForm.create.addAnyway')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
   );
 }

--- a/packages/web/app/components/board-entity/create-board-form.tsx
+++ b/packages/web/app/components/board-entity/create-board-form.tsx
@@ -170,7 +170,9 @@ export default function CreateBoardForm({
   const handleGoToExisting = useCallback(() => {
     if (!duplicate?.boardSlug) return;
     setDuplicate(null);
-    router.push(constructBoardSlugListUrl(duplicate.boardSlug, defaultAngle));
+    // The board's OWN angle, not this board type's default — the two rarely
+    // match, and landing on the wrong one shows an empty-looking wall.
+    router.push(constructBoardSlugListUrl(duplicate.boardSlug, duplicate.angle ?? defaultAngle));
   }, [duplicate, router, defaultAngle]);
 
   const handleAddAnyway = useCallback(async () => {


### PR DESCRIPTION
## Summary

Closes #4166.

ES-Alexander reported that adding a board for a new gym "seems to succeed at the time", but the **my boards** list then shows a *different*, previously-connected board of the same type at a different angle, and the new board never appears on the map. The report is accurate and the failure is total: **no board row was ever created.**

### What the telemetry and the DB say

On 2026-08-01 they opened `/boards/create` six times across two sessions, each time bouncing straight back to `/boards/manage`, with rageclicks on the `/boards/manage` ↔ `/boards/edit` loop minutes before filing. **No exception was raised, and no board-creation event exists in the taxonomy at all.**

Production confirms it — they own exactly two boards, neither created that day:

| id | name | created | gym_id |
|----|------|---------|--------|
| 3065 | Power Up Alabang - Moon 2019 | 2026-04-29 | 2952 |
| 201245 | Boulder Space - MoonBoard 2024 Standard | 2026-06-28 | **NULL** |

Board 201245 is `moonboard / layout 3 / size 1 / sets 5,6,7,8,9,10` — exactly the config they were re-adding at a new gym, which is why the app activated "Boulder Space" instead. That is the "different board, same type, different angle" from the report, verbatim.

### Root cause — four layers

1. **The client never called the mutation.** `app/boards/create.tsx` ran `const board = owned ?? (await createBoard.mutateAsync(input))`. On a config match the whole filled-in form — name, angle, location, serial — was discarded, `setActiveBoard(owned)` re-pointed the app at the old board, and the screen dismissed on the happy path. Added for #2455, whose intent was narrow (don't dead-end when you re-tap a Popular card you own), but it fired on every submit.
2. **The server guard keyed on config alone.** `(ownerId, boardType, layoutId, sizeId, setIds)` — angle- and location-blind, so two MoonBoard 2024s at different gyms were indistinguishable. It also compared `setIds` with a raw string `eq()` while the client normalises order, so the two layers could disagree.
3. **`user_boards_unique_owner_config` enforced the same wrong invariant in Postgres.** Relaxing only the resolver would have turned the rejection into a raw 23505 surfaced as "Something went wrong on our end."
4. **The error toast was invisible.** `toast-provider.tsx` documents that the overlay renders behind any `presentation: 'modal'` route, and `/boards` is registered exactly that way — so even a genuine failure said nothing.

### Also fixed: why it never reached the map

`createBoard` minted a gym only when the caller owned **zero** gyms, so every 2nd-and-later board got `gym_id = NULL` even with a typed location and coordinates. **658 of 2,264 real user boards (29%)** are gym-less because of this, including the reporter's own board 201245.

Auto-gym now resolves per **location** rather than per user, reusing the existing nearby-name dedup helpers. The PostGIS `location` writes also moved out of the mint transaction: inside it, a failure rolled back and silently cost the user their gym — and since the backend test DB has no PostGIS, that is why **the mint path had never actually executed under test**.

### Changes

- **DB** — `user_boards_unique_owner_config` dropped to a plain index (migration `0189`). A config tuple does not identify a physical board; enforcement moves into the resolver. ⚠️ One-way: once duplicate rows exist, the unique index can't be restored without a cleanup. Today all 20 duplicate-config groups in prod are system-owned, so no real user has ever had one.
- **Backend** — new `board-duplicates.ts` decides "same config AND same place" (coordinates → location name → both-placeless), fixing the set-id ordering mismatch on the way. The guard throws a typed `BOARD_DUPLICATE_CONFIG` carrying the existing board's identity, so clients don't have to scan a paginated `myBoards`. New `allowDuplicateConfig` input skips it once the user confirms.
- **Backend** — a board owner can now link to a nearby public gym they don't run (proximity + per-caller cap + its own rate bucket). Proximity is *not* a security boundary — coordinates are caller-supplied — so `detachBoardFromGym` is added to give gym staff a way to undo it; previously only `deleteGym` cleared `gym_id`.
- **Mobile** — create always calls the server; a duplicate opens a three-way prompt (use that board / add a new one here / keep editing). Failures render inline. New gym picker (mobile never set `gymUuid` at all), and the location field can finally be cleared.
- **Web** — the duplicate branch now gates on the error code instead of firing for any error that happened to have a config match, drops a 20-page `myBoards` scan, and gains an "Add it anyway" dialog.
- **Analytics** — `Board Created` / `Board Create Failed` / `Board Create Reused Existing` / `Board Duplicate Prompted`, on both platforms. Board creation had **zero** telemetry, which is why this ran for weeks unseen.

### Review rounds

Three passes from the review bot; fixes pushed for the migration missing `IF EXISTS` (a deploy-blocker), the foreign-gym cap counting rows and soft-deleted gyms, web navigating to the wrong angle, a mobile double-tap window, an unbounded query, a gym-convergence bug where a coordinate-less gym was skipped and a twin minted, an effect firing every render, and a missing audit log. Three reported items were assessed and deliberately left — see the commit messages for the reasoning on each.

## Release Notes

- Adding a second board with the same setup at a different gym now works — you'll be asked whether it's a new wall or the one you already have
- New boards land under the right gym on the map, and you can pick that gym while adding them
- Board creation tells you when something goes wrong instead of quietly doing nothing

## Test plan

- `vp run typecheck` — clean.
- `vp check` — clean for every file in this change (12 pre-existing errors remain in `scripts/`, untouched here).
- **New:** `board-duplicates.test.ts` (20 pure cases), `create-board-duplicate-guard.test.ts` (9 real-DB cases incl. the #4166 regression: same config ~2 km apart now creates), `app/boards/__tests__/create.test.tsx` (7 cases — the mutation is reached, the prompt appears without navigating, "add another" retries with the flag).
- **Extended:** `find-similar-gyms-and-auto-gym.test.ts` +9 per-location minting cases. The "second board at a different location mints a second gym" case fails on `main` for two independent reasons (the zero-gyms short-circuit *and* the PostGIS rollback).
- `vp test run --project backend` — the touched suites pass (24/24 auto-gym, 29/29 duplicate).
- `vp run test:mobile` — full suite green, 4958 tests.
- `board-path-to-user-board.test.ts` deliberately untouched and still passing: proof the party-session join flow, which relies on the angle-blind config match, wasn't broken.

- `vp run check:mobile-bundle` — Android bundle OK, so every new module (`GymPickerSheet`, `BoardDuplicatePromptSheet`) resolves under Metro.

### Still wanted: eyes on a device

**I could not run the on-device pass.** The Android emulator segfaults in its software GPU renderer on this host (`xvfb-run: Segmentation fault (core dumped)`), with and without the sandbox and on two renderers — the documented "some hosts can't run the emulator's software GPU at all" case. So the duplicate prompt and gym picker have **not** been seen rendering.

That matters more than usual here: sheet presentation is exactly the class of thing that typechecks and bundles cleanly and then no-ops at runtime. Both new sheets use the presence-driven `useManagedSheet({ open: true, … })` pattern copied from `TimerPairingSheet`, which is already rendered from this same screen, and the state flow around them is unit-tested — but that is an argument, not a sighting. Worth a few minutes on a real device or a working emulator before merge.

**Follow-up, not in this PR:** the 658 existing gym-less boards want a backfill reusing `resolveAutoGymForBoard` in dry-run first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Puf7K1meNgjANZKtvms5NE
