### PR TITLE
docs(store): a new App Store locale needs no manual ASC step

### DIFF
--- a/app-stores/apple/app-store-metadata.md
+++ b/app-stores/apple/app-store-metadata.md
@@ -19,11 +19,12 @@
 > in `packages/mobile/app.config.ts`. Adding a listing locale without adding it
 > there leaves the page claiming English only.
 >
-> **First run for a brand-new locale:** `deliver` writes onto the _editable_ version's
-> localizations. If a newly added locale folder doesn't show up after a
-> `Mobile Store Metadata` run, add that language to the version once in App Store
-> Connect (version → **+** next to the language selector), then re-dispatch — every
-> later release picks it up from the folder on its own.
+> **A brand-new locale needs no App Store Connect setup.** `deliver` activates the
+> language on the editable version itself — adding `de-DE/` and merging was enough
+> (`Activating version language de-DE...` in the 2026-08-03 run). What it does need
+> is an _editable_ version to write onto: between releases there often isn't one, and
+> the `ios metadata` lane skips cleanly and says so. Create the version in App Store
+> Connect first, then dispatch.
 >
 > This doc keeps the operational material that `deliver` can't upload: review
 > notes, privacy labels, and the screenshot map.


### PR DESCRIPTION
## Summary

Corrects a runbook note that today's German launch disproved.

`app-stores/apple/app-store-metadata.md` said a brand-new listing locale might need a manual "add the language to the version" step in App Store Connect. It doesn't — adding `fastlane/metadata/de-DE/` and merging was enough, and `deliver` activated the language on its own:

```
[03:16:34]: Activating version language de-DE...
[03:16:41]: Uploading metadata to App Store Connect for localized version 'de-DE'
```

(run [30781376715](https://github.com/boardsesh/boardsesh/actions/runs/30781376715), which fired automatically on the #4178 merge.)

I wrote that note defensively while building #4178 and it turned out to be wrong in the direction that costs time — it would send the next person hunting through the ASC UI for a step that doesn't exist. The note now states the precondition that *is* real: the `ios metadata` lane needs an **editable** version to write onto, and between releases there often isn't one (it skips cleanly and says so).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

Docs only. The claim is backed by the workflow log linked above.
