### PR TITLE
fix(shared): render relative timestamps in the app's language

### DIFF
--- a/packages/mobile/src/lib/i18n/config.ts
+++ b/packages/mobile/src/lib/i18n/config.ts
@@ -10,6 +10,7 @@ import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import { getLocales } from 'expo-localization';
 import { SUPPORTED_LOCALES, DEFAULT_LOCALE, DEFAULT_NAMESPACE, MOBILE_NAMESPACES, type Locale } from '@boardsesh/i18n';
+import { setRelativeTimeLocale } from '@boardsesh/profile-stats';
 import { SCREENSHOT_LOCALE_OVERRIDE } from '../screenshot-mode';
 
 // --- Locale catalogs from @boardsesh/i18n ---
@@ -170,9 +171,19 @@ export function detectDeviceLocale(): Locale {
   return DEFAULT_LOCALE;
 }
 
+const initialLocale = detectDeviceLocale();
+
+// dayjs keeps its active locale module-global and defaults to English, so every
+// "vor 6 Minuten" in the app rendered as "6 minutes ago" until this ran. Set it
+// alongside i18n rather than inside the formatter: the formatter is called
+// per-row during scrolling, and switching locale on every call is both wasteful
+// and a cross-request hazard for the web surfaces that share the package.
+setRelativeTimeLocale(initialLocale);
+i18n.on('languageChanged', setRelativeTimeLocale);
+
 void i18n.use(initReactI18next).init({
   resources,
-  lng: detectDeviceLocale(),
+  lng: initialLocale,
   fallbackLng: DEFAULT_LOCALE,
   defaultNS: DEFAULT_NAMESPACE,
   ns: [...MOBILE_NAMESPACES],

--- a/packages/shared/profile-stats/src/__tests__/relative-time-locale.test.ts
+++ b/packages/shared/profile-stats/src/__tests__/relative-time-locale.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { formatTickRelativeTime, setRelativeTimeLocale } from '../format-tick-time';
+
+// dayjs's active locale is module-global, so leaving it set would leak into any
+// test that runs after this file.
+afterEach(() => setRelativeTickLocaleToDefault());
+
+function setRelativeTickLocaleToDefault() {
+  setRelativeTimeLocale('en-US');
+}
+
+/** An ISO timestamp `minutes` in the past, in the naive-UTC shape ticks use. */
+function minutesAgo(minutes: number): string {
+  return new Date(Date.now() - minutes * 60_000).toISOString().replace('Z', '');
+}
+
+describe('setRelativeTimeLocale', () => {
+  it('renders relative time in the selected language', () => {
+    setRelativeTimeLocale('de');
+    expect(formatTickRelativeTime(minutesAgo(6))).toBe('vor 6 Minuten');
+
+    setRelativeTimeLocale('es');
+    expect(formatTickRelativeTime(minutesAgo(6))).toBe('hace 6 minutos');
+
+    setRelativeTimeLocale('fr');
+    expect(formatTickRelativeTime(minutesAgo(6))).toBe('il y a 6 minutes');
+  });
+
+  it('renders English for en-US', () => {
+    setRelativeTimeLocale('en-US');
+    expect(formatTickRelativeTime(minutesAgo(6))).toBe('6 minutes ago');
+  });
+
+  it('falls back to English rather than throwing on an unknown locale', () => {
+    setRelativeTimeLocale('kl-GL');
+    expect(formatTickRelativeTime(minutesAgo(6))).toBe('6 minutes ago');
+  });
+
+  it('keeps the default English until something opts in', () => {
+    // Guards the web surfaces: they never call the setter, so importing this
+    // package must not change how they render.
+    expect(formatTickRelativeTime(minutesAgo(6))).toBe('6 minutes ago');
+  });
+});

--- a/packages/shared/profile-stats/src/format-tick-time.ts
+++ b/packages/shared/profile-stats/src/format-tick-time.ts
@@ -1,9 +1,44 @@
 import dayjs, { type Dayjs } from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import utc from 'dayjs/plugin/utc';
+// Registering a locale doesn't activate it — `setRelativeTimeLocale` does that.
+// Importing them here rather than at the call site keeps them on the same dayjs
+// module instance as the formatter below, so it can't depend on the bundler
+// deduping two copies of dayjs.
+import 'dayjs/locale/de';
+import 'dayjs/locale/es';
+import 'dayjs/locale/fr';
 
 dayjs.extend(relativeTime);
 dayjs.extend(utc);
+
+/** App locale -> dayjs locale id. `en-US` is dayjs's built-in default. */
+const DAYJS_LOCALE_BY_APP_LOCALE: Record<string, string> = {
+  'en-US': 'en',
+  en: 'en',
+  de: 'de',
+  es: 'es',
+  fr: 'fr',
+};
+
+/**
+ * Points `fromNow()` at a language. Without this, `formatTickRelativeTime`
+ * renders "6 minutes ago" for every locale — dayjs defaults to `en` and nothing
+ * ever changed it, so Spanish and French have shipped English timestamps.
+ *
+ * dayjs's active locale is module-global, which is why this is opt-in rather
+ * than automatic: a server rendering several languages in one process would
+ * leak one request's locale into the next. Call it only from a single-language
+ * process (the mobile app, on i18n init and on every language change). Web
+ * surfaces render through their own `app/lib/format-tick-time` and are
+ * unaffected either way.
+ *
+ * Unknown locales fall back to `en` rather than throwing — a formatter is never
+ * worth crashing a screen over.
+ */
+export function setRelativeTimeLocale(appLocale: string): void {
+  dayjs.locale(DAYJS_LOCALE_BY_APP_LOCALE[appLocale] ?? 'en');
+}
 
 function requireString(climbedAt: string): string {
   // dayjs.utc(undefined) silently returns "now", which would corrupt sorts and

--- a/packages/shared/profile-stats/src/index.ts
+++ b/packages/shared/profile-stats/src/index.ts
@@ -23,7 +23,13 @@ export {
   parseLayoutKey,
   sortLayoutKeys,
 } from './layouts';
-export { parseTickTime, tickTimeMs, formatTickRelativeTime, formatTickAbsoluteTime } from './format-tick-time';
+export {
+  parseTickTime,
+  tickTimeMs,
+  formatTickRelativeTime,
+  formatTickAbsoluteTime,
+  setRelativeTimeLocale,
+} from './format-tick-time';
 export {
   deriveAngleLifetimeStats,
   groupEntriesByAngle,


### PR DESCRIPTION
## Summary

Relative timestamps rendered in English in every language. Caught while reviewing the German App Store screenshots from today's capture run — `00-home`, the lead image on the listing, showed **"1 Begehung · 1 Flash · a few seconds ago"**.

Not a German regression: `formatTickRelativeTime` calls `dayjs(...).fromNow()`, dayjs's active locale defaults to `en`, and **nothing in the repo ever called `dayjs.locale()`**. There's even a comment admitting it (`packages/mobile/src/lib/format-session-when.ts:36`, "dayjs locale isn't wired"). So Spanish and French have shipped English timestamps since they launched — German just put it in the hero shot.

## Approach

`setRelativeTimeLocale` lives in `@boardsesh/profile-stats`, the package that owns the dayjs instance. Two reasons it isn't done at the call site:

- **Same-instance guarantee.** The locale bundles are imported next to the formatter, so activating a locale can't depend on the bundler deduping two copies of dayjs.
- **Opt-in, not automatic.** dayjs's active locale is module-global. A server rendering several languages in one process would leak one request's locale into the next, so the setter is called only from the single-language mobile process (on i18n init and on `languageChanged`). Web surfaces render through their own `app/lib/format-tick-time` and are unaffected — there's a test pinning that importing the package doesn't change their output.

Threading a locale argument through the ~10 call sites would also work and would be leak-proof by construction, but it's a much wider change than this needed to be today. Worth revisiting if web ever adopts the shared helper.

## Release Notes

- Zeitangaben wie „vor 6 Minuten" erscheinen jetzt in deiner Sprache — bisher waren sie auf Deutsch, Spanisch und Französisch immer englisch.

## Test plan

- New `packages/shared/profile-stats/src/__tests__/relative-time-locale.test.ts`: asserts `vor 6 Minuten` / `hace 6 minutos` / `il y a 6 minutes` / `6 minutes ago`, an unknown locale falling back to English rather than throwing, and the default staying English until something opts in.
- `vp run typecheck` clean; `vp run test:mobile` 578/578; `vp test run packages/shared/profile-stats` 5/5; `vp run check:mobile-bundle` OK.

JS-only, so this ships over OTA — no native rebuild needed.

Screenshots still show the English timestamps; a fresh capture run replaces them once this lands.
