### PR TITLE
fix(mobile): measure insets at the right surface — tab bar overlap for the Start capsule, sheets, toasts

### DIFF
--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -216,6 +216,16 @@ Is it a secondary surface OVER the current screen, or its own full surface?
    the published measurement via `useBottomChromeMetrics()` — `scrollBottomPadding` for
    list/scroll content, `floatingControlBottom` for absolute overlays, `fixedFooterBottom` for
    docked footers, `preSessionFooterBottom` / `inSessionListBottom` for the session surfaces.
+
+   **Bottom-docked native sheets are the inverse case**: a sheet presents over the tab bar, so
+   the only chrome its content must clear is the **window's** bottom inset (home indicator /
+   gesture bar) — never its mount point's. A sheet mounted inside a tab inherits the per-tab
+   provider, whose 139pt inset floated the filter sheet's Apply button ~105pt up into the sheet
+   (#3776's "dead gap"). Every sheet footer/body bottom pad goes through
+   `useWindowBottomInset()` (`src/hooks/use-window-bottom-inset.ts`, fed by
+   `WindowInsetPublisher` in the root layout); the shared `Sheet` / `ModalSheet` wrappers
+   already do. Sheets mounted at the app root get the same value either way — the hook makes
+   the mount point irrelevant.
    Never hardcode what UIKit "must" have folded into an inset; constants are fallbacks for the
    pre-measurement frames only, and test fixtures carry DEVICE_VERIFIED / INFERRED provenance
    labels (`src/hooks/__tests__/bottom-chrome-metrics.test.ts` — extend its matrix when adding

--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -195,9 +195,33 @@ Is it a secondary surface OVER the current screen, or its own full surface?
 
    A **pushed route** under `NativeTabs` is different: the native tab bar remains, but route
    classification deliberately unmounts the BottomAccessory / queue chrome on screens such as
-   session detail. Its bottom layout must therefore trust the raw UIKit safe-area inset for the
+   session detail. Its bottom layout must therefore trust the UIKit safe-area inset for the
    chrome that is actually present; it must not carry the accessory reserve forward from the tab
    root or add the tab-bar height a second time.
+
+   **Bottom-chrome geometry contract.** "The UIKit inset" is ambiguous — there are two
+   sampling points with different semantics, and conflating them is the recurring bug class
+   behind #3967/#3973/#4089 and the Start-capsule regression:
+   - The **root** `SafeAreaProvider` (what `BottomChromeMetricsProvider` in `app/_layout.tsx`
+     samples) reports the _window_ inset: home indicator only. UIKit tab-bar chrome never
+     reaches it.
+   - Each tab's content sits inside a **nested per-tab `SafeAreaProvider`** (expo-router's
+     `NativeTabsView` wraps every tab in one); _that_ inset folds in the tab bar, the
+     BottomAccessory, and the live minimize state. `NativeTabContentInsetProbe` (mounted in
+     every phone tab `_layout`, focus-gated) publishes it through
+     `src/lib/native-tab-content-inset-store.ts` so root-level consumers position with the
+     measurement instead of a reconstruction.
+
+   Rules: position against the inset measured at the surface you're positioning in, or consume
+   the published measurement via `useBottomChromeMetrics()` — `scrollBottomPadding` for
+   list/scroll content, `floatingControlBottom` for absolute overlays, `fixedFooterBottom` for
+   docked footers, `preSessionFooterBottom` / `inSessionListBottom` for the session surfaces.
+   Never hardcode what UIKit "must" have folded into an inset; constants are fallbacks for the
+   pre-measurement frames only, and test fixtures carry DEVICE_VERIFIED / INFERRED provenance
+   labels (`src/hooks/__tests__/bottom-chrome-metrics.test.ts` — extend its matrix when adding
+   a chrome state). On-device verification without a rebuild: More → Diagnostics → "Bottom
+   chrome diagnostics" overlays the live values (dev, preview builds, and `pr-<N>` OTA
+   channels).
 
 3. **Board gestures and modal/sheet pan don't mix.** A full-screen board you pan/pinch (the
    `holds` and `zone` filters) is a **pushed** route, not a modal — a modal/sheet's own pan

--- a/packages/mobile/app/(tabs)/climbs/_layout.tsx
+++ b/packages/mobile/app/(tabs)/climbs/_layout.tsx
@@ -1,6 +1,7 @@
 import { Stack } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useStackScreenOptions } from '../../../src/hooks/use-stack-screen-options';
+import { NativeTabContentInsetProbe } from '../../../src/components/navigation/NativeTabContentInsetProbe';
 import { BoardArtVisibilityProvider } from '../../../src/providers/board-art-visibility-provider';
 
 export default function ClimbsLayout() {
@@ -9,6 +10,7 @@ export default function ClimbsLayout() {
 
   return (
     <BoardArtVisibilityProvider tab="climbs">
+      <NativeTabContentInsetProbe />
       <Stack screenOptions={screenOptions}>
         <Stack.Screen
           name="index"

--- a/packages/mobile/app/(tabs)/discover/_layout.tsx
+++ b/packages/mobile/app/(tabs)/discover/_layout.tsx
@@ -1,6 +1,7 @@
 import { Stack } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useStackScreenOptions } from '../../../src/hooks/use-stack-screen-options';
+import { NativeTabContentInsetProbe } from '../../../src/components/navigation/NativeTabContentInsetProbe';
 import { BoardArtVisibilityProvider } from '../../../src/providers/board-art-visibility-provider';
 
 export default function DiscoverLayout() {
@@ -9,6 +10,7 @@ export default function DiscoverLayout() {
 
   return (
     <BoardArtVisibilityProvider tab="discover">
+      <NativeTabContentInsetProbe />
       <Stack screenOptions={screenOptions}>
         <Stack.Screen
           name="index"

--- a/packages/mobile/app/(tabs)/home/_layout.tsx
+++ b/packages/mobile/app/(tabs)/home/_layout.tsx
@@ -1,11 +1,13 @@
 import { Stack } from 'expo-router';
 import { useStackScreenOptions } from '../../../src/hooks/use-stack-screen-options';
+import { NativeTabContentInsetProbe } from '../../../src/components/navigation/NativeTabContentInsetProbe';
 import { BoardArtVisibilityProvider } from '../../../src/providers/board-art-visibility-provider';
 
 export default function HomeLayout() {
   const screenOptions = useStackScreenOptions();
   return (
     <BoardArtVisibilityProvider tab="home">
+      <NativeTabContentInsetProbe />
       <Stack screenOptions={screenOptions}>
         {/* The Home feed owns its top via floating chrome (the avatar island + scope
           title), like the other tabs — so the stack header is hidden here. */}

--- a/packages/mobile/app/(tabs)/profile/_layout.tsx
+++ b/packages/mobile/app/(tabs)/profile/_layout.tsx
@@ -1,6 +1,7 @@
 import { Stack } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useStackScreenOptions } from '../../../src/hooks/use-stack-screen-options';
+import { NativeTabContentInsetProbe } from '../../../src/components/navigation/NativeTabContentInsetProbe';
 import { BoardArtVisibilityProvider } from '../../../src/providers/board-art-visibility-provider';
 
 export default function ProfileLayout() {
@@ -10,6 +11,7 @@ export default function ProfileLayout() {
 
   return (
     <BoardArtVisibilityProvider tab="profile">
+      <NativeTabContentInsetProbe />
       <Stack screenOptions={screenOptions}>
         {/* The You screen owns its top via the floating ProfileTopChrome (large
           title collapsing into a glass capsule), like the Discover/Climbs tabs —

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -31,6 +31,7 @@ import { drainMutationQueue } from '../../../src/offline/offline-sync-adapter';
 import { getHttpClient } from '../../../src/lib/graphql/client';
 import { hapticLight, hapticSelection } from '../../../src/lib/haptics';
 import { DevMetadataPanel } from '../../../src/components/DevMetadataPanel';
+import { useBottomChromeDiagnosticsEligible } from '../../../src/components/BottomChromeDebugOverlay';
 import { MoreForm } from '../../../src/components/MoreForm';
 import type { MoreButtonRow, MoreFormModel, MoreRow, MoreSection } from '../../../src/components/MoreForm.types';
 import { isPreviewBuild } from '../../../src/lib/preview-build';
@@ -75,6 +76,8 @@ export default function MoreScreen() {
   const { localePreference, setLocalePreference } = useLocalePreference();
   const { enabled: sessionRecordingEnabled, setEnabled: setSessionRecordingPreference } =
     useSessionRecordingPreference();
+  const bottomChromeDiagnosticsEligible = useBottomChromeDiagnosticsEligible();
+  const [bottomChromeDiagnostics, setBottomChromeDiagnostics] = useSetting('bottomChromeDiagnostics');
   const { enabled: showPlaylistTags, setEnabled: setShowPlaylistTags } = useShowPlaylistTagsPreference();
   const { enabled: showBoardseshGrades, setEnabled: setShowBoardseshGrades } = useBoardseshGradesPreference();
   const { enabled: showQuickActionsButton, setEnabled: setShowQuickActionsButton } = useClimbQuickActionsButton();
@@ -600,6 +603,25 @@ export default function MoreScreen() {
           setSessionRecordingEnabled(next);
         },
       },
+      // Bottom-chrome geometry overlay — dev / preview builds / pr-channel OTA
+      // testers only, so regular production users never see the row.
+      ...(bottomChromeDiagnosticsEligible
+        ? [
+            {
+              kind: 'toggle' as const,
+              key: 'bottomChromeDiagnostics',
+              // i18n-ignore-next-line — tester-only diagnostics
+              label: 'Bottom chrome diagnostics',
+              // i18n-ignore-next-line
+              subtitle: 'Overlay live tab-bar geometry values',
+              value: bottomChromeDiagnostics,
+              onValueChange: (next: boolean) => {
+                hapticSelection();
+                setBottomChromeDiagnostics(next);
+              },
+            },
+          ]
+        : []),
     ],
   });
 

--- a/packages/mobile/app/(tabs)/record/_layout.tsx
+++ b/packages/mobile/app/(tabs)/record/_layout.tsx
@@ -1,6 +1,7 @@
 import { Stack } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useStackScreenOptions } from '../../../src/hooks/use-stack-screen-options';
+import { NativeTabContentInsetProbe } from '../../../src/components/navigation/NativeTabContentInsetProbe';
 import { BoardArtVisibilityProvider } from '../../../src/providers/board-art-visibility-provider';
 
 /**
@@ -14,6 +15,7 @@ export default function RecordLayout() {
 
   return (
     <BoardArtVisibilityProvider tab="record">
+      <NativeTabContentInsetProbe />
       <Stack screenOptions={screenOptions}>
         <Stack.Screen name="index" options={{ headerShown: false }} />
         <Stack.Screen

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -82,6 +82,7 @@ import { OnboardingGate } from '../src/components/onboarding/OnboardingGate';
 import { AccessoryOnboardingTip } from '../src/components/onboarding/AccessoryOnboardingTip';
 import { FreezeDebugOverlay } from '../src/components/FreezeDebugOverlay';
 import { BottomChromeDebugOverlay } from '../src/components/BottomChromeDebugOverlay';
+import { WindowInsetPublisher } from '../src/hooks/use-window-bottom-inset';
 import { LiveActivityIntentDiagnostics } from '../src/components/LiveActivityIntentDiagnostics';
 // Side-effect import: instantiates the Android-only MemoryTrim native module
 // (expo-modules-core creates modules lazily on first JS access), whose Kotlin
@@ -679,6 +680,9 @@ function RootLayout() {
                                                             pr-channel + settings toggle). Inside the metrics provider
                                                             so it reads the same derived values consumers position with. */}
                                                                   <BottomChromeDebugOverlay />
+                                                                  {/* Root-sampled window inset for bottom-docked sheets —
+                                                            here (outside the tabs) useSafeAreaInsets IS the window's. */}
+                                                                  <WindowInsetPublisher />
                                                                 </UserDrawerProvider>
                                                               </TabBarHeightProvider>
                                                               <AnalyticsScreenTracker />

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -81,6 +81,7 @@ import { InstallReferrerTracker } from '../src/components/analytics/InstallRefer
 import { OnboardingGate } from '../src/components/onboarding/OnboardingGate';
 import { AccessoryOnboardingTip } from '../src/components/onboarding/AccessoryOnboardingTip';
 import { FreezeDebugOverlay } from '../src/components/FreezeDebugOverlay';
+import { BottomChromeDebugOverlay } from '../src/components/BottomChromeDebugOverlay';
 import { LiveActivityIntentDiagnostics } from '../src/components/LiveActivityIntentDiagnostics';
 // Side-effect import: instantiates the Android-only MemoryTrim native module
 // (expo-modules-core creates modules lazily on first JS access), whose Kotlin
@@ -674,6 +675,10 @@ function RootLayout() {
                                                             <Stack> hit-region is frozen). No-op unless built with
                                                             EXPO_PUBLIC_FREEZE_DEBUG=1. */}
                                                                   <FreezeDebugOverlay />
+                                                                  {/* Live bottom-chrome geometry readout (dev / preview /
+                                                            pr-channel + settings toggle). Inside the metrics provider
+                                                            so it reads the same derived values consumers position with. */}
+                                                                  <BottomChromeDebugOverlay />
                                                                 </UserDrawerProvider>
                                                               </TabBarHeightProvider>
                                                               <AnalyticsScreenTracker />

--- a/packages/mobile/src/components/BottomChromeDebugOverlay.tsx
+++ b/packages/mobile/src/components/BottomChromeDebugOverlay.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useSetting } from '../settings';
+import { isPreviewBuild } from '../lib/preview-build';
+import { getPreference } from '../lib/preference-store';
+import { OTA_CHANNEL_OVERRIDE_KEY } from '../lib/channel-switch';
+import { useBottomChromeMetrics } from '../hooks/use-bottom-chrome-metrics';
+import { useNativeTabBar } from '../hooks/use-bottom-accessory';
+import { useTheme } from '../providers/theme-provider';
+import {
+  useNativeTabContentInsetBottom,
+  useNativeTabContentInsetPublishCount,
+} from '../lib/native-tab-content-inset-store';
+
+/**
+ * Live readout of the bottom-chrome geometry: the ROOT safe-area inset, the
+ * in-tab measurement published by `NativeTabContentInsetProbe`, the store's
+ * publish counter, and the derived metrics every bottom-chrome consumer
+ * positions with. Bottom-chrome bugs are invisible in code review and only show
+ * on device (see bottom-chrome-metrics.ts), and they have recurred across
+ * #3967 → #2611 → #3973 → #4089 — so this overlay is a permanent diagnostic,
+ * not a one-off: it lets a tester on an OTA preview verify the geometry without
+ * a rebuild.
+ *
+ * The publish counter is the minimize-cadence gate: scroll a long list so the
+ * native bar minimizes and back; a handful of increments means UIKit delivers
+ * discrete inset events, a large jump means per-frame streaming and the store
+ * needs its coalescing enabled (see native-tab-content-inset-store.ts).
+ *
+ * Off unless BOTH hold: the persisted "Bottom chrome diagnostics" toggle
+ * (More → Diagnostics) is on, and the session is diagnostic-eligible — a dev
+ * build, an EAS preview build, or a `pr-<N>` OTA channel override (the per-PR
+ * preview a production install can switch onto).
+ */
+
+/**
+ * Whether this session may surface bottom-chrome diagnostics at all. Also gates
+ * the settings row that flips the persisted toggle, so production users outside
+ * a pr- preview never see either.
+ */
+export function useBottomChromeDiagnosticsEligible(): boolean {
+  const [hasPrChannelOverride, setHasPrChannelOverride] = useState(false);
+  useEffect(() => {
+    if (__DEV__ || isPreviewBuild()) return;
+    let cancelled = false;
+    getPreference<string>(OTA_CHANNEL_OVERRIDE_KEY)
+      .then((storedChannel) => {
+        if (!cancelled && storedChannel !== null && storedChannel.startsWith('pr-')) {
+          setHasPrChannelOverride(true);
+        }
+      })
+      // Best-effort mirror read (see preference-store.ts on rejections): a failed
+      // read just leaves the diagnostics hidden for this launch.
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return __DEV__ || isPreviewBuild() || hasPrChannelOverride;
+}
+
+export function BottomChromeDebugOverlay() {
+  const eligible = useBottomChromeDiagnosticsEligible();
+  const [enabled] = useSetting('bottomChromeDiagnostics');
+  if (!eligible || !enabled) return null;
+  return <BottomChromeDebugOverlayInner />;
+}
+
+function formatOffset(value: number): string {
+  return String(Math.round(value * 10) / 10);
+}
+
+function BottomChromeDebugOverlayInner() {
+  // This component mounts at the root, so `insets` here IS the root sampling
+  // point — the same value computeBottomChromeMetrics receives as insetsBottom.
+  const insets = useSafeAreaInsets();
+  const measured = useNativeTabContentInsetBottom();
+  const publishCount = useNativeTabContentInsetPublishCount();
+  const metrics = useBottomChromeMetrics();
+  const usesNativeTabBar = useNativeTabBar();
+  const { variant } = useTheme();
+
+  const lines = [
+    `root ${formatOffset(insets.bottom)}  probe ${measured === null ? '—' : formatOffset(measured)}  pubs ${publishCount}`,
+    `${variant}  nativeBar ${usesNativeTabBar ? 'Y' : 'N'}  inTabs ${metrics.insideTabs ? 'Y' : 'N'}  ` +
+      `acc ${metrics.nativeAccessoryVisible ? 'Y' : 'N'}  jsQ ${metrics.jsQueueToolbarVisible ? 'Y' : 'N'}`,
+    `tabBarBottom ${formatOffset(metrics.tabBarBottom)}  scroll ${formatOffset(metrics.scrollBottomPadding)}`,
+    `preSession ${formatOffset(metrics.preSessionFooterBottom)}  inSession ${formatOffset(metrics.inSessionListBottom)}`,
+    `floating ${formatOffset(metrics.floatingControlBottom)}  fixed ${formatOffset(metrics.fixedFooterBottom)}`,
+  ];
+
+  return (
+    <View pointerEvents="box-none" style={[styles.root, { top: insets.top + 4 }]}>
+      <View style={styles.panel}>
+        <Text style={styles.title}>BOTTOM CHROME</Text>
+        {lines.map((line) => (
+          <Text key={line} style={styles.metrics}>
+            {line}
+          </Text>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    position: 'absolute',
+    right: 8,
+    zIndex: 99999,
+    elevation: 99999,
+    alignItems: 'flex-end',
+  },
+  panel: {
+    backgroundColor: 'rgba(0, 0, 0, 0.82)',
+    borderColor: '#34d399',
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+  },
+  title: {
+    color: '#34d399',
+    fontSize: 10,
+    fontWeight: '700',
+    letterSpacing: 1,
+    marginBottom: 2,
+  },
+  metrics: {
+    color: '#ffffff',
+    fontSize: 11,
+    fontVariant: ['tabular-nums'],
+  },
+});

--- a/packages/mobile/src/components/BottomChromeDebugOverlay.tsx
+++ b/packages/mobile/src/components/BottomChromeDebugOverlay.tsx
@@ -81,22 +81,36 @@ function BottomChromeDebugOverlayInner() {
   const usesNativeTabBar = useNativeTabBar();
   const { variant } = useTheme();
 
-  const lines = [
-    `root ${formatOffset(insets.bottom)}  probe ${measured === null ? '—' : formatOffset(measured)}  pubs ${publishCount}`,
-    `${variant}  nativeBar ${usesNativeTabBar ? 'Y' : 'N'}  inTabs ${metrics.insideTabs ? 'Y' : 'N'}  ` +
-      `acc ${metrics.nativeAccessoryVisible ? 'Y' : 'N'}  jsQ ${metrics.jsQueueToolbarVisible ? 'Y' : 'N'}`,
-    `tabBarBottom ${formatOffset(metrics.tabBarBottom)}  scroll ${formatOffset(metrics.scrollBottomPadding)}`,
-    `preSession ${formatOffset(metrics.preSessionFooterBottom)}  inSession ${formatOffset(metrics.inSessionListBottom)}`,
-    `floating ${formatOffset(metrics.floatingControlBottom)}  fixed ${formatOffset(metrics.fixedFooterBottom)}`,
+  // Keyed by the stable row label (position in this fixed list), NOT the line
+  // content — a content key would remount every Text on each geometry change.
+  const lines: Array<[rowKey: string, text: string]> = [
+    [
+      'insets',
+      `root ${formatOffset(insets.bottom)}  probe ${measured === null ? '—' : formatOffset(measured)}  pubs ${publishCount}`,
+    ],
+    [
+      'flags',
+      `${variant}  nativeBar ${usesNativeTabBar ? 'Y' : 'N'}  inTabs ${metrics.insideTabs ? 'Y' : 'N'}  ` +
+        `acc ${metrics.nativeAccessoryVisible ? 'Y' : 'N'}  jsQ ${metrics.jsQueueToolbarVisible ? 'Y' : 'N'}`,
+    ],
+    ['bar', `tabBarBottom ${formatOffset(metrics.tabBarBottom)}  scroll ${formatOffset(metrics.scrollBottomPadding)}`],
+    [
+      'session',
+      `preSession ${formatOffset(metrics.preSessionFooterBottom)}  inSession ${formatOffset(metrics.inSessionListBottom)}`,
+    ],
+    [
+      'overlays',
+      `floating ${formatOffset(metrics.floatingControlBottom)}  fixed ${formatOffset(metrics.fixedFooterBottom)}`,
+    ],
   ];
 
   return (
     <View pointerEvents="box-none" style={[styles.root, { top: insets.top + 4 }]}>
       <View style={styles.panel}>
         <Text style={styles.title}>BOTTOM CHROME</Text>
-        {lines.map((line) => (
-          <Text key={line} style={styles.metrics}>
-            {line}
+        {lines.map(([rowKey, text]) => (
+          <Text key={rowKey} style={styles.metrics}>
+            {text}
           </Text>
         ))}
       </View>

--- a/packages/mobile/src/components/BottomChromeDebugOverlay.tsx
+++ b/packages/mobile/src/components/BottomChromeDebugOverlay.tsx
@@ -12,6 +12,7 @@ import {
   useNativeTabContentInsetBottom,
   useNativeTabContentInsetPublishCount,
 } from '../lib/native-tab-content-inset-store';
+import { usePublishedWindowInsetBottom } from '../lib/window-inset-store';
 
 /**
  * Live readout of the bottom-chrome geometry: the ROOT safe-area inset, the
@@ -77,6 +78,7 @@ function BottomChromeDebugOverlayInner() {
   const insets = useSafeAreaInsets();
   const measured = useNativeTabContentInsetBottom();
   const publishCount = useNativeTabContentInsetPublishCount();
+  const windowInset = usePublishedWindowInsetBottom();
   const metrics = useBottomChromeMetrics();
   const usesNativeTabBar = useNativeTabBar();
   const { variant } = useTheme();
@@ -88,6 +90,7 @@ function BottomChromeDebugOverlayInner() {
       'insets',
       `root ${formatOffset(insets.bottom)}  probe ${measured === null ? '—' : formatOffset(measured)}  pubs ${publishCount}`,
     ],
+    ['window', `window(sheets) ${windowInset === null ? '—' : formatOffset(windowInset)}`],
     [
       'flags',
       `${variant}  nativeBar ${usesNativeTabBar ? 'Y' : 'N'}  inTabs ${metrics.insideTabs ? 'Y' : 'N'}  ` +

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-native';
 import { BottomSheetModal, BottomSheetScrollView } from '@expo/ui/community/bottom-sheet';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useWindowBottomInset } from '../hooks/use-window-bottom-inset';
 import { useRouter, useFocusEffect } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import {
@@ -178,7 +178,11 @@ export function ClimbFilterSheet({
   const theme = useTheme();
   const { systemColors } = theme;
   const { isAuthenticated } = useAuth();
-  const insets = useSafeAreaInsets();
+  // The WINDOW inset, not this mount point's: this sheet lives in the climbs
+  // tab, whose per-tab provider folds the iOS 26 tab bar + accessory into
+  // insets.bottom — chrome the sheet covers. Padding the Apply footer with that
+  // floated it ~105pt up into the sheet (#3776's "dead gap").
+  const windowInsetBottom = useWindowBottomInset();
   const sheetRef = useRef<BottomSheetModal>(null);
   const scrollRef = useRef<ComponentRef<typeof BottomSheetScrollView>>(null);
   // Latest scroll offset, captured on scroll into a ref (no re-render).
@@ -1129,7 +1133,10 @@ export function ClimbFilterSheet({
         </BottomSheetScrollView>
 
         <View
-          style={[styles.footer, { paddingBottom: insets.bottom + spacing[3], borderTopColor: systemColors.separator }]}
+          style={[
+            styles.footer,
+            { paddingBottom: windowInsetBottom + spacing[3], borderTopColor: systemColors.separator },
+          ]}
         >
           <Button title={applyLabel} onPress={handleApply} variant="filled" size="large" style={styles.applyButton} />
         </View>

--- a/packages/mobile/src/components/EndSessionSheet.tsx
+++ b/packages/mobile/src/components/EndSessionSheet.tsx
@@ -5,7 +5,7 @@ import BottomSheet, {
   BottomSheetTextInput,
   type BottomSheetMethods,
 } from '@expo/ui/community/bottom-sheet';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useWindowBottomInset } from '../hooks/use-window-bottom-inset';
 import { useTranslation } from 'react-i18next';
 import { SESSION_NOTES_MAX_LENGTH } from '@boardsesh/shared-schema';
 import { Text } from './Text';
@@ -64,7 +64,7 @@ export function EndSessionSheet({
 }: EndSessionSheetProps) {
   const { t } = useTranslation('session');
   const { systemColors, brandColors } = useTheme();
-  const insets = useSafeAreaInsets();
+  const windowInsetBottom = useWindowBottomInset();
   const sheetRef = useRef<BottomSheetMethods>(null);
 
   // Resolved mode. A known non-creator can never reach `end`, whatever mode
@@ -107,7 +107,7 @@ export function EndSessionSheet({
       backgroundStyle={{ backgroundColor: systemColors.secondaryBackground }}
       handleIndicatorStyle={sheetStyles.indicator}
     >
-      <BottomSheetView style={[styles.content, { paddingBottom: insets.bottom + spacing[3] }]}>
+      <BottomSheetView style={[styles.content, { paddingBottom: windowInsetBottom + spacing[3] }]}>
         {/* The Compose/UIKit sheet window does not resize for the keyboard, so a
             JS-side KeyboardAvoidingView lifts the recap input + buttons above it
             on both platforms (mirrors Sheet.tsx). BottomSheetView stays the

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -18,7 +18,7 @@ import {
   BottomSheetView,
   type BottomSheetMethods,
 } from '@expo/ui/community/bottom-sheet';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useWindowBottomInset } from '../hooks/use-window-bottom-inset';
 import { hapticMedium } from '../lib/haptics';
 import { spacing } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
@@ -74,7 +74,7 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
   ref,
 ) {
   const { systemColors, sheet } = useTheme();
-  const insets = useSafeAreaInsets();
+  const windowInsetBottom = useWindowBottomInset();
   const snapPoints = useMemo(() => customSnapPoints ?? ['50%', '90%'], [customSnapPoints]);
 
   // Single-detent sheets jump to full screen on @expo/ui's Android sheet — give
@@ -128,8 +128,10 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
   // Without a pinned footer the body sits against the bottom edge, so it has to
   // clear the Android edge-to-edge navigation bar itself — the native sheet does
   // not pad content for it. With a footer the body scrolls above the footer, which
-  // already carries `insets.bottom`.
-  const bodyContentContainerStyle = useSheetBodyContentStyle(Boolean(footer), contentContainerStyle, insets.bottom);
+  // already carries the window inset — the WINDOW inset, not the mount point's:
+  // a sheet docks over the tab bar, and a tab-mounted sheet's local inset folds
+  // in iOS 26 tab chrome the sheet covers (see use-window-bottom-inset).
+  const bodyContentContainerStyle = useSheetBodyContentStyle(Boolean(footer), contentContainerStyle, windowInsetBottom);
   // #3922: measure whichever view actually carries columnStyle — the body when
   // there is no footer, the KeyboardAvoidingView below when there is.
   const bodyLayout = footer ? undefined : onColumnLayout;
@@ -161,7 +163,7 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
         {
           backgroundColor: systemColors.secondaryBackground,
           borderTopColor: systemColors.separator,
-          paddingBottom: insets.bottom + spacing[3],
+          paddingBottom: windowInsetBottom + spacing[3],
         },
       ]}
     >

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -14,7 +14,7 @@ import BottomSheet, {
   BottomSheetView,
   type BottomSheetMethods,
 } from '@expo/ui/community/bottom-sheet';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useWindowBottomInset } from '../hooks/use-window-bottom-inset';
 import { hapticMedium } from '../lib/haptics';
 import { spacing } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
@@ -74,7 +74,7 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
   ref,
 ) {
   const { systemColors, sheet: sheetChrome } = useTheme();
-  const insets = useSafeAreaInsets();
+  const windowInsetBottom = useWindowBottomInset();
   const snapPoints = useMemo(() => customSnapPoints ?? ['50%', '90%'], [customSnapPoints]);
 
   const sheetRef = useRef<BottomSheetMethods>(null);
@@ -124,8 +124,10 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
   // Without a pinned footer the body sits against the bottom edge, so it has to
   // clear the Android edge-to-edge navigation bar itself — the native sheet does
   // not pad content for it. With a footer the body scrolls above the footer, which
-  // already carries `insets.bottom`.
-  const bodyContentContainerStyle = useSheetBodyContentStyle(Boolean(footer), contentContainerStyle, insets.bottom);
+  // already carries the window inset. The WINDOW inset, not the mount point's:
+  // a sheet docks over the tab bar, and a tab-mounted sheet's local inset folds
+  // in iOS 26 tab chrome the sheet covers (see use-window-bottom-inset).
+  const bodyContentContainerStyle = useSheetBodyContentStyle(Boolean(footer), contentContainerStyle, windowInsetBottom);
   // #3922: measure whichever view actually carries columnStyle — the body when
   // there is no footer, the KeyboardAvoidingView below when there is.
   const bodyLayout = footer ? undefined : onColumnLayout;
@@ -157,7 +159,7 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
         {
           backgroundColor: systemColors.secondaryBackground,
           borderTopColor: systemColors.separator,
-          paddingBottom: insets.bottom + spacing[3],
+          paddingBottom: windowInsetBottom + spacing[3],
         },
       ]}
     >

--- a/packages/mobile/src/components/Toast.tsx
+++ b/packages/mobile/src/components/Toast.tsx
@@ -17,6 +17,7 @@ import {
 } from '../theme/layout';
 import type { UiVariant } from '../theme/resolve-ui-variant';
 import { isTabsRoute, isTopLevelTabRoute } from '../lib/route-segments';
+import { useNativeTabContentInsetBottom } from '../lib/native-tab-content-inset-store';
 import { useTheme } from '../providers/theme-provider';
 import { createVariantComponent, selectByVariant } from '../theme/variants';
 import { isBottomAccessoryAvailable, useNativeTabBar } from '../hooks/use-bottom-accessory';
@@ -74,19 +75,26 @@ function useToastBottomOffset(uiVariant: UiVariant) {
   });
   // ToastProvider sits above QueueProvider, so it cannot read current-climb state
   // from computeBottomChromeMetrics and conservatively reserves the JS queue bar.
-  // NativeTabs with BottomAccessory is different: UIKit has already folded both
-  // pieces of chrome into `insets.bottom`, so adding either reserve here recreates
-  // #3973. If a native tab bar is available but its BottomAccessory export is not,
-  // the JS PersistentQueueBar takes over on top-level tab routes; preserve that
-  // toolbar reserve without adding the native tab bar a second time. Pushed tab
-  // routes never render PersistentQueueBar, so they keep only the raw native inset.
-  // Material and the Liquid Glass JS fallback still need both explicit terms
-  // because their tab/queue bars are outside the UIKit safe-area inset.
+  // NativeTabs folds the bar (and BottomAccessory) into the IN-TAB inset only —
+  // this hook reads the ROOT provider (home indicator alone), so it clears the
+  // native chrome via the measurement NativeTabContentInsetProbe publishes; see
+  // the sampling-point contract in bottom-chrome-metrics.ts. Pre-measurement
+  // fallback reconstructs the bar from the root inset, but cannot include the
+  // accessory (no climb state up here) — a pre-publish toast may briefly sit
+  // behind the accessory platter, transient by design. If a native tab bar is
+  // available but its BottomAccessory export is not, the JS PersistentQueueBar
+  // takes over on top-level tab routes; preserve that toolbar reserve without
+  // adding the native tab bar a second time. Pushed tab routes never render
+  // PersistentQueueBar, so they keep only the native chrome clearance. Material
+  // and the Liquid Glass JS fallback still need both explicit terms because
+  // their tab/queue bars are outside every UIKit safe-area inset.
+  const measuredTabContentInsetBottom = useNativeTabContentInsetBottom();
   const tabBarHeight = selectByVariant(uiVariant, { material: MATERIAL_TAB_BAR_HEIGHT, liquidGlass: TAB_BAR_HEIGHT });
   if (!isTabsRoute(segments)) return insets.bottom + spacing[3];
   if (usesNativeTabBar) {
     const jsQueueReserve = !nativeBottomAccessoryAvailable && isTopLevelTabRoute(segments) ? toolbarReserve : 0;
-    return insets.bottom + jsQueueReserve + spacing[2];
+    const nativeChromeBottom = measuredTabContentInsetBottom ?? insets.bottom + TAB_BAR_HEIGHT;
+    return nativeChromeBottom + jsQueueReserve + spacing[2];
   }
   return insets.bottom + tabBarHeight + toolbarReserve + spacing[2];
 }

--- a/packages/mobile/src/components/__tests__/toast.test.tsx
+++ b/packages/mobile/src/components/__tests__/toast.test.tsx
@@ -9,6 +9,7 @@ const ctrl = vi.hoisted(() => ({
   nativeTabBar: false,
   nativeBottomAccessoryAvailable: true,
   insetsBottom: 34,
+  measuredTabContentInsetBottom: null as number | null,
   segments: ['(tabs)', 'climbs'] as readonly string[],
 }));
 
@@ -74,6 +75,9 @@ vi.mock('../../hooks/use-bottom-accessory', () => ({
   isBottomAccessoryAvailable: () => ctrl.nativeBottomAccessoryAvailable,
   useNativeTabBar: () => ctrl.nativeTabBar,
 }));
+vi.mock('../../lib/native-tab-content-inset-store', () => ({
+  useNativeTabContentInsetBottom: () => ctrl.measuredTabContentInsetBottom,
+}));
 
 vi.mock('../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', { 'data-text': 'true' }, children),
@@ -110,8 +114,8 @@ import { TAB_BAR_HEIGHT, TOOLBAR_RESERVE } from '../../theme/layout';
 import { spacing } from '../../theme/tokens';
 
 const toast = { id: 't1', message: 'Saved tick', variant: 'success' as const, duration: 3000 };
-// Representative iPhone native-tab inset without BottomAccessory. This is
-// realistic arithmetic, not a device-verified product contract.
+// The IN-TAB inset without BottomAccessory (root 34 + bar 49), as published by
+// NativeTabContentInsetProbe. Realistic arithmetic, INFERRED not device-verified.
 const NATIVE_TAB_ONLY_INSET = 34 + TAB_BAR_HEIGHT;
 
 describe('Toast', () => {
@@ -120,6 +124,7 @@ describe('Toast', () => {
     ctrl.nativeTabBar = false;
     ctrl.nativeBottomAccessoryAvailable = true;
     ctrl.insetsBottom = 34;
+    ctrl.measuredTabContentInsetBottom = null;
     ctrl.segments = ['(tabs)', 'climbs'];
   });
 
@@ -196,25 +201,47 @@ describe('Toast', () => {
     );
   });
 
-  it('does not add native tab or accessory chrome to the measured 139pt UIKit inset (#3973)', () => {
+  it('does not add native tab or accessory chrome to the measured 139pt in-tab inset (#3973)', () => {
     ctrl.variant = 'liquidGlass';
     ctrl.nativeTabBar = true;
-    ctrl.insetsBottom = 139;
+    // Toast samples the ROOT inset (34); the 139 accessory inset arrives as the
+    // in-tab measurement from NativeTabContentInsetProbe.
+    ctrl.insetsBottom = 34;
+    ctrl.measuredTabContentInsetBottom = 139;
     const { container } = render(<Toast toast={toast} onDismiss={() => {}} />);
     // 139 already includes the home indicator, native tab bar, and accessory;
     // Toast adds only its 8pt visual gap.
     expect(container.querySelector('[data-animated]')?.getAttribute('data-style')).toContain('"bottom":147');
   });
 
+  it('reconstructs the native bar from the root inset before the probe publishes', () => {
+    ctrl.variant = 'liquidGlass';
+    ctrl.nativeTabBar = true;
+    ctrl.insetsBottom = 34;
+    ctrl.measuredTabContentInsetBottom = null;
+    const { container } = render(<Toast toast={toast} onDismiss={() => {}} />);
+    // Pre-measurement frames: root (34) + TAB_BAR_HEIGHT + gap. The accessory
+    // cannot be reconstructed up here (no climb state above QueueProvider), so a
+    // pre-publish toast may briefly sit behind the accessory platter — see the
+    // useToastBottomOffset docblock. The accessory is available in this state, so
+    // no JS queue reserve either.
+    const expectedBottom = 34 + TAB_BAR_HEIGHT + spacing[2];
+    expect(container.querySelector('[data-animated]')?.getAttribute('data-style')).toContain(
+      `"bottom":${expectedBottom}`,
+    );
+  });
+
   it('clears the JS queue bar when NativeTabs cannot mount a BottomAccessory', () => {
     ctrl.variant = 'liquidGlass';
     ctrl.nativeTabBar = true;
     ctrl.nativeBottomAccessoryAvailable = false;
-    ctrl.insetsBottom = NATIVE_TAB_ONLY_INSET;
+    ctrl.insetsBottom = 34;
+    ctrl.measuredTabContentInsetBottom = NATIVE_TAB_ONLY_INSET;
     const { container } = render(<Toast toast={toast} onDismiss={() => {}} />);
     const expectedBottom = NATIVE_TAB_ONLY_INSET + TOOLBAR_RESERVE + spacing[2];
-    // NativeTabs owns the tab-only inset, while the unavailable BottomAccessory
-    // falls back to the JS queue tray. Do not add TAB_BAR_HEIGHT a second time.
+    // The in-tab measurement owns the tab-bar clearance, while the unavailable
+    // BottomAccessory falls back to the JS queue tray. Do not add TAB_BAR_HEIGHT
+    // a second time.
     expect(container.querySelector('[data-animated]')?.getAttribute('data-style')).toContain(
       `"bottom":${expectedBottom}`,
     );
@@ -224,7 +251,8 @@ describe('Toast', () => {
     ctrl.variant = 'liquidGlass';
     ctrl.nativeTabBar = true;
     ctrl.nativeBottomAccessoryAvailable = false;
-    ctrl.insetsBottom = NATIVE_TAB_ONLY_INSET;
+    ctrl.insetsBottom = 34;
+    ctrl.measuredTabContentInsetBottom = NATIVE_TAB_ONLY_INSET;
     ctrl.segments = ['(tabs)', 'home', 'session', '[sessionId]'];
     const { container } = render(<Toast toast={toast} onDismiss={() => {}} />);
     const expectedBottom = NATIVE_TAB_ONLY_INSET + spacing[2];

--- a/packages/mobile/src/components/create-climb/CreateDrawer.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawer.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { View, StyleSheet, useWindowDimensions, type LayoutChangeEvent } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useWindowBottomInset } from '../../hooks/use-window-bottom-inset';
 // Migrated off @gorhom/bottom-sheet to Expo's native bottom sheet (#3167). The
 // native sheet draws its own scrim + drag handle, so the measured-handle peek
 // machinery is replaced by a small fixed reserve for the native grabber.
@@ -68,6 +69,10 @@ export function CreateDrawer({
 }: CreateDrawerProps) {
   const { systemColors } = useTheme();
   const insets = useSafeAreaInsets();
+  // Bottom terms use the WINDOW inset: this drawer is a route inside the climbs
+  // tab, whose per-tab provider folds iOS 26 tab chrome the sheet covers into
+  // insets.bottom (see use-window-bottom-inset). insets.top stays local.
+  const windowInsetBottom = useWindowBottomInset();
   const { width: windowWidth, height: windowHeight } = useWindowDimensions();
   const sheetRef = useRef<BottomSheet>(null);
 
@@ -78,7 +83,7 @@ export function CreateDrawer({
   // index the user is actually at (not a one-shot reset that breaks on rotation).
   const indexRef = useRef(0);
 
-  const boardMaxHeight = Math.max(200, windowHeight - insets.top - insets.bottom - ABOVE_FOLD_CHROME);
+  const boardMaxHeight = Math.max(200, windowHeight - insets.top - windowInsetBottom - ABOVE_FOLD_CHROME);
 
   // Compute the on-screen board size up front (window width minus the board
   // section margins, capped by the height budget) so the board paints on the
@@ -104,7 +109,7 @@ export function CreateDrawer({
   // action bar) + bottom safe area + a reveal margin so a hint of the below-fold
   // form peeks.
   const peekHeight =
-    aboveFoldHeight > 0 ? NATIVE_HANDLE_RESERVE + spacing[2] + aboveFoldHeight + insets.bottom + spacing[3] : 0;
+    aboveFoldHeight > 0 ? NATIVE_HANDLE_RESERVE + spacing[2] + aboveFoldHeight + windowInsetBottom + spacing[3] : 0;
 
   // Re-snap to the current index whenever the peek height changes: the first
   // measurement (fallback → measured peek) and any re-layout (rotation resizes
@@ -142,7 +147,7 @@ export function CreateDrawer({
     >
       <BottomSheetScrollView
         style={styles.scroll}
-        contentContainerStyle={{ paddingTop: spacing[2], paddingBottom: insets.bottom + spacing[4] }}
+        contentContainerStyle={{ paddingTop: spacing[2], paddingBottom: windowInsetBottom + spacing[4] }}
         keyboardShouldPersistTaps="handled"
         keyboardDismissMode="on-drag"
       >

--- a/packages/mobile/src/components/navigation/NativeTabContentInsetProbe.tsx
+++ b/packages/mobile/src/components/navigation/NativeTabContentInsetProbe.tsx
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useFocusEffect } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useNativeTabBar } from '../../hooks/use-bottom-accessory';
+import { publishNativeTabContentInsetBottom } from '../../lib/native-tab-content-inset-store';
+
+/**
+ * Publishes the bottom safe-area inset measured INSIDE a native tab's content to
+ * `native-tab-content-inset-store`. Mount one as a sibling of the `Stack` in each
+ * phone tab layout — there it sits inside the nested `SafeAreaProvider` that
+ * expo-router's `NativeTabsView` wraps around every tab's content, so the inset
+ * it reads includes the UIKit tab bar, the BottomAccessory, and the live
+ * minimize state (unlike the root provider, which only sees the home indicator).
+ *
+ * Renders nothing, publishes nothing off the native-tab-bar path (Material,
+ * tablets, Android, iOS < 26 — `useNativeTabBar()` is the same predicate that
+ * selects the tab bar in `(tabs)/_layout`, so the two cannot disagree).
+ */
+export function NativeTabContentInsetProbe() {
+  const nativeTabBar = useNativeTabBar();
+  if (!nativeTabBar) return null;
+  return <NativeTabContentInsetPublisher />;
+}
+
+function NativeTabContentInsetPublisher() {
+  const insets = useSafeAreaInsets();
+  // Focus-gated: expo-router renders EVERY tab's screen (no freeze), each inside
+  // its own nested SafeAreaProvider, and an unfocused tab's detached native view
+  // can report a bar-less inset. With five publishers racing a last-writer-wins
+  // store, one stale unfocused write would put the Start capsule right back under
+  // the tab bar — only the focused tab's surface is the truth worth publishing.
+  const [isFocused, setIsFocused] = useState(false);
+  useFocusEffect(
+    useCallback(() => {
+      setIsFocused(true);
+      return () => setIsFocused(false);
+    }, []),
+  );
+
+  useEffect(() => {
+    if (!isFocused) return;
+    publishNativeTabContentInsetBottom(insets.bottom);
+  }, [isFocused, insets.bottom]);
+
+  return null;
+}

--- a/packages/mobile/src/components/navigation/__tests__/NativeTabContentInsetProbe.test.tsx
+++ b/packages/mobile/src/components/navigation/__tests__/NativeTabContentInsetProbe.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { useEffect } from 'react';
+import {
+  resetNativeTabContentInsetForTests,
+  useNativeTabContentInsetBottom,
+} from '../../../lib/native-tab-content-inset-store';
+
+const ctrl = vi.hoisted(() => ({
+  nativeTabBar: true,
+  focused: true,
+  insetsBottom: 83,
+}));
+
+vi.mock('expo-router', async () => {
+  const { useEffect: reactUseEffect } = await import('react');
+  return {
+    // Runs the focus effect like react-navigation does for a focused screen;
+    // flipping ctrl.focused simulates an unfocused tab (effect never fires).
+    useFocusEffect: (effect: () => void | (() => void)) => {
+      reactUseEffect(() => {
+        if (!ctrl.focused) return;
+        return effect();
+      }, [effect]);
+    },
+  };
+});
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 59, bottom: ctrl.insetsBottom, left: 0, right: 0 }),
+}));
+vi.mock('../../../hooks/use-bottom-accessory', () => ({
+  useNativeTabBar: () => ctrl.nativeTabBar,
+}));
+
+import { NativeTabContentInsetProbe } from '../NativeTabContentInsetProbe';
+
+// Store-reading harness: asserts what the probe published without reaching into
+// store internals.
+function StoreReader({ onValue }: { onValue: (value: number | null) => void }) {
+  const value = useNativeTabContentInsetBottom();
+  useEffect(() => {
+    onValue(value);
+  }, [onValue, value]);
+  return null;
+}
+
+describe('NativeTabContentInsetProbe', () => {
+  beforeEach(() => {
+    resetNativeTabContentInsetForTests();
+    ctrl.nativeTabBar = true;
+    ctrl.focused = true;
+    ctrl.insetsBottom = 83;
+  });
+
+  const lastPublished = () => {
+    let latest: number | null = null;
+    const capture = (value: number | null) => {
+      latest = value;
+    };
+    // A fresh element per (re)render so React never bails out on an identical
+    // element reference — the probe must re-read the mocked insets.
+    const tree = () => (
+      <>
+        <NativeTabContentInsetProbe />
+        <StoreReader onValue={capture} />
+      </>
+    );
+    const view = render(tree());
+    return { view, read: () => latest, rerender: () => view.rerender(tree()) };
+  };
+
+  it('publishes the in-tab inset when focused on the native tab bar', () => {
+    const { read } = lastPublished();
+    expect(read()).toBe(83);
+  });
+
+  it('renders nothing and publishes nothing off the native-tab-bar path', () => {
+    ctrl.nativeTabBar = false;
+    const { view, read } = lastPublished();
+    expect(view.container.innerHTML).toBe('');
+    expect(read()).toBeNull();
+  });
+
+  it('does not publish from an unfocused tab', () => {
+    // An unfocused tab's detached view can report a bar-less inset; a publish
+    // from it would put the Start capsule back under the bar (last-writer-wins).
+    ctrl.focused = false;
+    const { read } = lastPublished();
+    expect(read()).toBeNull();
+  });
+
+  it('re-publishes when the in-tab inset changes while focused', () => {
+    const { read, rerender } = lastPublished();
+    expect(read()).toBe(83);
+    ctrl.insetsBottom = 139;
+    rerender();
+    expect(read()).toBe(139);
+  });
+});

--- a/packages/mobile/src/components/navigation/__tests__/NativeTabContentInsetProbe.test.tsx
+++ b/packages/mobile/src/components/navigation/__tests__/NativeTabContentInsetProbe.test.tsx
@@ -1,39 +1,70 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
-import { useEffect } from 'react';
+import { useEffect, type ReactNode } from 'react';
 import {
   resetNativeTabContentInsetForTests,
   useNativeTabContentInsetBottom,
 } from '../../../lib/native-tab-content-inset-store';
 
+// Per-probe control. `currentTabIndex` is stamped by <TabHost> during render
+// (React renders depth-first, so a host's probe reads its own index before the
+// next sibling host renders); the single-probe tests never mount a TabHost and
+// run entirely on index 0.
 const ctrl = vi.hoisted(() => ({
   nativeTabBar: true,
-  focused: true,
-  insetsBottom: 83,
+  currentTabIndex: 0,
+  focusByIndex: [true] as boolean[],
+  insetsByIndex: [83] as number[],
+  focusOf(index: number): boolean {
+    return this.focusByIndex[index] ?? false;
+  },
+  insetOf(index: number): number {
+    return this.insetsByIndex[index] ?? 0;
+  },
 }));
 
 vi.mock('expo-router', async () => {
-  const { useEffect: reactUseEffect } = await import('react');
+  const { useEffect: reactUseEffect, useRef: reactUseRef } = await import('react');
   return {
     // Runs the focus effect like react-navigation does for a focused screen;
-    // flipping ctrl.focused simulates an unfocused tab (effect never fires).
+    // the per-index focus flag simulates an unfocused tab (effect cleans up /
+    // never fires). The flag is in the deps so a focus flip re-runs the effect
+    // on rerender, mirroring the focus/blur events. The index is captured ONCE
+    // at mount (ref): a state-driven re-render of one publisher happens outside
+    // its TabHost, so the module-level stamp would be stale there.
     useFocusEffect: (effect: () => void | (() => void)) => {
+      const tabIndexRef = reactUseRef(ctrl.currentTabIndex);
+      const focused = ctrl.focusOf(tabIndexRef.current);
       reactUseEffect(() => {
-        if (!ctrl.focused) return;
+        if (!focused) return;
         return effect();
-      }, [effect]);
+      }, [effect, focused]);
     },
   };
 });
-vi.mock('react-native-safe-area-context', () => ({
-  useSafeAreaInsets: () => ({ top: 59, bottom: ctrl.insetsBottom, left: 0, right: 0 }),
-}));
+vi.mock('react-native-safe-area-context', async () => {
+  const { useRef: reactUseRef } = await import('react');
+  return {
+    // Same mount-captured index as the useFocusEffect mock (see above).
+    useSafeAreaInsets: () => {
+      const tabIndexRef = reactUseRef(ctrl.currentTabIndex);
+      return { top: 59, bottom: ctrl.insetOf(tabIndexRef.current), left: 0, right: 0 };
+    },
+  };
+});
 vi.mock('../../../hooks/use-bottom-accessory', () => ({
   useNativeTabBar: () => ctrl.nativeTabBar,
 }));
 
 import { NativeTabContentInsetProbe } from '../NativeTabContentInsetProbe';
+
+// Simulates one tab's layout: stamps the index the mocked hooks resolve their
+// per-tab focus/inset values with while this subtree renders.
+function TabHost({ index, children }: { index: number; children: ReactNode }) {
+  ctrl.currentTabIndex = index;
+  return children;
+}
 
 // Store-reading harness: asserts what the probe published without reaching into
 // store internals.
@@ -49,8 +80,9 @@ describe('NativeTabContentInsetProbe', () => {
   beforeEach(() => {
     resetNativeTabContentInsetForTests();
     ctrl.nativeTabBar = true;
-    ctrl.focused = true;
-    ctrl.insetsBottom = 83;
+    ctrl.currentTabIndex = 0;
+    ctrl.focusByIndex = [true];
+    ctrl.insetsByIndex = [83];
   });
 
   const lastPublished = () => {
@@ -85,7 +117,7 @@ describe('NativeTabContentInsetProbe', () => {
   it('does not publish from an unfocused tab', () => {
     // An unfocused tab's detached view can report a bar-less inset; a publish
     // from it would put the Start capsule back under the bar (last-writer-wins).
-    ctrl.focused = false;
+    ctrl.focusByIndex = [false];
     const { read } = lastPublished();
     expect(read()).toBeNull();
   });
@@ -93,8 +125,40 @@ describe('NativeTabContentInsetProbe', () => {
   it('re-publishes when the in-tab inset changes while focused', () => {
     const { read, rerender } = lastPublished();
     expect(read()).toBe(83);
-    ctrl.insetsBottom = 139;
+    ctrl.insetsByIndex = [139];
     rerender();
     expect(read()).toBe(139);
+  });
+
+  it('lets only the focused probe win when several tabs mount probes at once', () => {
+    // expo-router mounts every tab's screen (no freeze), so all five probes are
+    // live. Tab B is unfocused and its detached view reports a bar-less inset
+    // (34) — exactly the stale value that must never reach the last-writer-wins
+    // store. Then focus moves to tab B, whose view attaches and reports the
+    // accessory inset; B's publish must now win.
+    let latest: number | null = null;
+    const capture = (value: number | null) => {
+      latest = value;
+    };
+    ctrl.focusByIndex = [true, false];
+    ctrl.insetsByIndex = [83, 34];
+    const tree = () => (
+      <>
+        <TabHost index={0}>
+          <NativeTabContentInsetProbe />
+        </TabHost>
+        <TabHost index={1}>
+          <NativeTabContentInsetProbe />
+        </TabHost>
+        <StoreReader onValue={capture} />
+      </>
+    );
+    const view = render(tree());
+    expect(latest).toBe(83);
+
+    ctrl.focusByIndex = [false, true];
+    ctrl.insetsByIndex = [83, 139];
+    view.rerender(tree());
+    expect(latest).toBe(139);
   });
 });

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -74,6 +74,7 @@ vi.mock('../../../theme/animations', () => ({ timing: { fast: 150, normal: 250 }
 vi.mock('../../../theme/layout', () => ({
   MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT: 48,
   MATERIAL_TAB_BAR_HEIGHT: 80,
+  NATIVE_BOTTOM_ACCESSORY_HEIGHT: 56,
   TAB_BAR_HEIGHT: 49,
   TOOLBAR_RESERVE: 74,
   TOOLBAR_SIDE_MARGIN: 16,

--- a/packages/mobile/src/components/search/HoldFilterPicker.tsx
+++ b/packages/mobile/src/components/search/HoldFilterPicker.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { View, Pressable, StyleSheet } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useWindowBottomInset } from '../../hooks/use-window-bottom-inset';
 import { useTranslation } from 'react-i18next';
 import type { BoardName, HoldFilterMode, HoldFilterType } from '@boardsesh/shared-schema';
 import { buildHoldFilterOptions } from '@boardsesh/climb-filters';
@@ -43,7 +43,7 @@ export function HoldFilterPicker({
 }: HoldFilterPickerProps) {
   const { t } = useTranslation('climbs');
   const { systemColors } = useTheme();
-  const insets = useSafeAreaInsets();
+  const windowInsetBottom = useWindowBottomInset();
   const {
     overrides: holdColorOverrides,
     shapes: holdShapeOverrides,
@@ -89,7 +89,10 @@ export function HoldFilterPicker({
 
   return (
     <View
-      style={[styles.section, { borderTopColor: systemColors.separator, paddingBottom: insets.bottom + spacing[3] }]}
+      style={[
+        styles.section,
+        { borderTopColor: systemColors.separator, paddingBottom: windowInsetBottom + spacing[3] },
+      ]}
     >
       <SegmentedControl
         options={applyModeOptions}

--- a/packages/mobile/src/components/session-screen/InviteSheet.tsx
+++ b/packages/mobile/src/components/session-screen/InviteSheet.tsx
@@ -3,7 +3,7 @@ import { Share, StyleSheet, View } from 'react-native';
 // SPIKE(spike/expo-bottom-sheet): swap gorhom -> Expo's native drop-in. The native
 // sheet renders its own scrim, so the custom SheetBackdrop wiring is dropped.
 import BottomSheet, { BottomSheetView, type BottomSheetMethods } from '@expo/ui/community/bottom-sheet';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useWindowBottomInset } from '../../hooks/use-window-bottom-inset';
 import { useTranslation } from 'react-i18next';
 import * as Clipboard from 'expo-clipboard';
 import QRCode from 'react-native-qrcode-svg';
@@ -33,7 +33,7 @@ export function InviteSheet({ visible, onDismiss, sessionId }: InviteSheetProps)
   const { t } = useTranslation('session');
   const { systemColors } = useTheme();
   const { showToast } = useToast();
-  const insets = useSafeAreaInsets();
+  const windowInsetBottom = useWindowBottomInset();
   const sheetRef = useRef<BottomSheetMethods>(null);
 
   const shareUrl = useMemo(() => buildSessionShareUrl(sessionId), [sessionId]);
@@ -72,7 +72,7 @@ export function InviteSheet({ visible, onDismiss, sessionId }: InviteSheetProps)
       backgroundStyle={{ backgroundColor: systemColors.secondaryBackground }}
       handleIndicatorStyle={sheetStyles.indicator}
     >
-      <BottomSheetView style={[styles.content, { paddingBottom: insets.bottom + spacing[4] }]}>
+      <BottomSheetView style={[styles.content, { paddingBottom: windowInsetBottom + spacing[4] }]}>
         <Text variant="title2" style={styles.title}>
           {t('mobile.session.inviteTitle')}
         </Text>

--- a/packages/mobile/src/components/you/LogbookEntryChooserSheet.tsx
+++ b/packages/mobile/src/components/you/LogbookEntryChooserSheet.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef, type ComponentRef } from 'react';
 import { View, Pressable, StyleSheet } from 'react-native';
 import { BottomSheetModal, BottomSheetFlatList } from '@expo/ui/community/bottom-sheet';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useWindowBottomInset } from '../../hooks/use-window-bottom-inset';
 import { useTranslation } from 'react-i18next';
 import type { AscentFeedItem } from '@boardsesh/graphql/operations';
 import { parseTickTime } from '@boardsesh/profile-stats';
@@ -49,7 +49,7 @@ const STATUS_ICON: Record<AscentFeedItem['status'], IconName> = {
 export function LogbookEntryChooserSheet({ entries, intent, onPick, onDismiss }: LogbookEntryChooserSheetProps) {
   const { t, i18n } = useTranslation('you');
   const { systemColors, brandColors } = useTheme();
-  const insets = useSafeAreaInsets();
+  const windowInsetBottom = useWindowBottomInset();
   const sheetRef = useRef<ComponentRef<typeof BottomSheetModal>>(null);
   const managed = useManagedSheet({ open: true, sheetRef, onClose: onDismiss });
   const snapPoints = useMemo(() => androidSafeSnapPoints(['45%']), []);
@@ -126,7 +126,7 @@ export function LogbookEntryChooserSheet({ entries, intent, onPick, onDismiss }:
       <BottomSheetFlatList
         data={entries}
         keyExtractor={chooserKeyExtractor}
-        contentContainerStyle={[styles.content, { paddingBottom: insets.bottom + spacing[6] }]}
+        contentContainerStyle={[styles.content, { paddingBottom: windowInsetBottom + spacing[6] }]}
         ListHeaderComponent={
           <Text variant="headline" style={styles.title}>
             {intent === 'delete' ? t('mobile.logbook.chooser.deleteTitle') : t('mobile.logbook.chooser.editTitle')}

--- a/packages/mobile/src/components/you/LogbookFilterSheet.tsx
+++ b/packages/mobile/src/components/you/LogbookFilterSheet.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ComponentRef } from 'react';
 import { View, Pressable, StyleSheet } from 'react-native';
 import { BottomSheetModal, BottomSheetScrollView } from '@expo/ui/community/bottom-sheet';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useWindowBottomInset } from '../../hooks/use-window-bottom-inset';
 import { useTranslation } from 'react-i18next';
 import type { GradeBound } from '@boardsesh/climb-filters';
 import {
@@ -70,7 +70,7 @@ export function LogbookFilterSheet({
   const { t } = useTranslation('you');
   const theme = useTheme();
   const { systemColors } = theme;
-  const insets = useSafeAreaInsets();
+  const windowInsetBottom = useWindowBottomInset();
   const sheetRef = useRef<BottomSheetModal>(null);
   const scrollRef = useRef<ComponentRef<typeof BottomSheetScrollView>>(null);
 
@@ -250,7 +250,7 @@ export function LogbookFilterSheet({
         // With a fixed 90% snap point + enableDynamicSizing off, the content must
         // flex to fill the sheet and carry generous bottom padding so the last row
         // (Benchmarks only) scrolls fully into view when both sections are expanded.
-        contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + spacing[8] }]}
+        contentContainerStyle={[styles.scrollContent, { paddingBottom: windowInsetBottom + spacing[8] }]}
       >
         {/* PRESET — the headline one-tap sort. Above Refine/Advanced. Suppressed
             when the toolbar's top-level sort chips own it (Liquid Glass), so sort

--- a/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics-provider.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics-provider.test.tsx
@@ -1,8 +1,12 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { memo } from 'react';
 import type { BottomChromeMetrics } from '../bottom-chrome-metrics';
+import {
+  publishNativeTabContentInsetBottom,
+  resetNativeTabContentInsetForTests,
+} from '../../lib/native-tab-content-inset-store';
 
 // Hoisted, per-test-configurable view of the leaf inputs the provider gathers.
 // The whole point of the provider is to read these ONCE for the whole app, so
@@ -74,6 +78,7 @@ describe('BottomChromeMetricsProvider fan-out', () => {
     cfg.hasCurrentClimb = true;
     cfg.widthClass = 'compact';
     cfg.windowWidth = 430;
+    resetNativeTabContentInsetForTests();
     for (const key of Object.keys(counts)) delete counts[key];
     for (const key of Object.keys(received)) delete received[key];
   });
@@ -116,6 +121,20 @@ describe('BottomChromeMetricsProvider fan-out', () => {
     cfg.segments = ['(tabs)', 'climbs'];
     rerender(<Harness tick={1} />);
     expect(counts).toEqual({ a: 1, b: 1, c: 1 });
+  });
+
+  it('propagates an in-tab inset publish to consumers on the native-tab-bar path', () => {
+    // The probe publishes from inside a tab (a different subtree entirely); the
+    // provider must pick it up through the store subscription without any
+    // re-render of its own parents.
+    cfg.nativeTabBar = true;
+    cfg.hasCurrentClimb = false;
+    render(<Harness tick={0} />);
+    // Pre-measurement: the native path reconstructs the bar from the root inset.
+    expect(received.a.tabBarBottom).toBe(34 + 49);
+    act(() => publishNativeTabContentInsetBottom(90));
+    expect(received.a.tabBarBottom).toBe(90);
+    expect(counts).toEqual({ a: 2, b: 2, c: 2 });
   });
 
   it('re-renders every consumer once when the geometry actually changes (presence flips)', () => {

--- a/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
+++ b/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
@@ -3,21 +3,35 @@ import { computeBottomChromeMetrics } from '../bottom-chrome-metrics';
 import {
   MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT,
   MATERIAL_TAB_BAR_HEIGHT,
+  NATIVE_BOTTOM_ACCESSORY_HEIGHT,
   TAB_BAR_HEIGHT,
   TOOLBAR_RESERVE,
   floatingContextBarBottom,
   glassSize,
 } from '../../theme/layout';
 
-// The only device-measured native inset in this suite. Do not turn inferred
-// no-accessory/minimized values into product contracts without iOS 26 hardware QA.
-const DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET = 139;
-// An intentionally non-device value used only to prove that the pure function
-// treats a native UIKit inset as opaque and does not add TAB_BAR_HEIGHT to it.
-// Keep it distinct from the 139pt device anchor so arithmetic fixtures cannot be
-// mistaken for a measured no-accessory or minimized-tab contract. The plausible
-// 83pt value (34pt home indicator + 49pt tab bar) is still inferred, not measured.
-const SYNTHETIC_NATIVE_SAFE_AREA_INSET = 100;
+// ── Inset fixtures. The provenance labels are load-bearing (see the
+// sampling-point contract in bottom-chrome-metrics.ts): DEVICE_VERIFIED values
+// may pin product contracts; INFERRED values must be upgraded via on-device QA
+// before they are treated as UIKit ground truth.
+//
+// What the ROOT provider (the window) reports on a Face ID iPhone: the home
+// indicator alone. UIKit tab-bar chrome never reaches the root inset — that is
+// what `insetsBottom` means for every native-tab case below.
+const ROOT_WINDOW_INSET = 34;
+// DEVICE_VERIFIED (iPhone 17 Pro, iOS 26, top-level tab, accessory visible):
+// the IN-TAB inset — 34 home indicator + 49 tab bar + 56 accessory — measured
+// inside the tab's nested SafeAreaProvider. An in-tab measurement, NOT a root
+// inset: the pre-#4089 suite fed this value as `insetsBottom`, which is exactly
+// the sampling-point conflation `measuredTabContentInsetBottom` now models
+// explicitly.
+const IN_TAB_MEASURED_ACCESSORY_INSET = 139;
+// INFERRED (34 + 49): the in-tab inset with the bar but no accessory. Not yet
+// measured on hardware — upgrade this comment with device-QA numbers.
+const IN_TAB_INFERRED_BAR_INSET = ROOT_WINDOW_INSET + TAB_BAR_HEIGHT;
+// An intentionally non-device root inset for total-function tests where the
+// specific geometry is irrelevant.
+const SYNTHETIC_ROOT_INSET = 100;
 
 describe('computeBottomChromeMetrics', () => {
   it('reserves nothing extra outside the tabs group', () => {
@@ -43,17 +57,18 @@ describe('computeBottomChromeMetrics', () => {
     const metrics = computeBottomChromeMetrics({
       uiVariant: 'liquidGlass',
       usesNativeTabBar: true,
-      insetsBottom: SYNTHETIC_NATIVE_SAFE_AREA_INSET,
+      insetsBottom: ROOT_WINDOW_INSET,
       insideTabs: true,
       onAccessorySurface: true,
       hasCurrentClimb: true,
       nativeAccessoryMounted: false,
+      measuredTabContentInsetBottom: IN_TAB_INFERRED_BAR_INSET,
     });
     expect(metrics.jsQueueToolbarVisible).toBe(true);
     expect(metrics.jsQueueReserve).toBe(TOOLBAR_RESERVE);
-    expect(metrics.scrollBottomPadding).toBe(SYNTHETIC_NATIVE_SAFE_AREA_INSET + TOOLBAR_RESERVE);
-    expect(metrics.floatingControlBottom).toBe(SYNTHETIC_NATIVE_SAFE_AREA_INSET + TOOLBAR_RESERVE);
-    expect(metrics.fixedFooterBottom).toBe(SYNTHETIC_NATIVE_SAFE_AREA_INSET + TOOLBAR_RESERVE);
+    expect(metrics.scrollBottomPadding).toBe(IN_TAB_INFERRED_BAR_INSET + TOOLBAR_RESERVE);
+    expect(metrics.floatingControlBottom).toBe(IN_TAB_INFERRED_BAR_INSET + TOOLBAR_RESERVE);
+    expect(metrics.fixedFooterBottom).toBe(IN_TAB_INFERRED_BAR_INSET + TOOLBAR_RESERVE);
   });
 
   it('clears the JS Material tab bar for Liquid Glass on a non-capable device', () => {
@@ -96,28 +111,29 @@ describe('computeBottomChromeMetrics', () => {
     expect(metrics.fixedFooterBottom).toBe(MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT);
   });
 
-  it('anchors every native-tab offset to the UIKit safe-area inset, including the 139pt accessory anchor (#3973)', () => {
+  it('anchors every native-tab offset to the measured in-tab inset, including the 139pt accessory anchor (#3973)', () => {
     const metrics = computeBottomChromeMetrics({
       uiVariant: 'liquidGlass',
       usesNativeTabBar: true,
-      // iPhone 17 Pro / iOS 26 with the BottomAccessory: 34 home indicator +
-      // 49 native tab bar + 56 accessory. UIKit has already included all three.
-      insetsBottom: DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET,
+      // The root window inset — the value the root-mounted provider actually
+      // samples. The 139pt accessory anchor arrives as the in-tab measurement.
+      insetsBottom: ROOT_WINDOW_INSET,
       insideTabs: true,
       onAccessorySurface: true,
       hasCurrentClimb: true,
       nativeAccessoryMounted: true,
+      measuredTabContentInsetBottom: IN_TAB_MEASURED_ACCESSORY_INSET,
     });
     expect(metrics.nativeAccessoryVisible).toBe(true);
     expect(metrics.jsQueueToolbarVisible).toBe(false);
     expect(metrics.jsQueueReserve).toBe(0);
     expect(metrics.tabBarHeight).toBe(TAB_BAR_HEIGHT);
-    expect(metrics.tabBarBottom).toBe(DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET);
+    expect(metrics.tabBarBottom).toBe(IN_TAB_MEASURED_ACCESSORY_INSET);
     expect(metrics.nativeAccessoryReserve).toBe(0);
-    expect(metrics.scrollBottomPadding).toBe(DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET);
-    expect(metrics.floatingControlBottom).toBe(DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET);
-    expect(metrics.fixedFooterBottom).toBe(DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET);
-    expect(metrics.preSessionFooterBottom).toBe(DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET);
+    expect(metrics.scrollBottomPadding).toBe(IN_TAB_MEASURED_ACCESSORY_INSET);
+    expect(metrics.floatingControlBottom).toBe(IN_TAB_MEASURED_ACCESSORY_INSET);
+    expect(metrics.fixedFooterBottom).toBe(IN_TAB_MEASURED_ACCESSORY_INSET);
+    expect(metrics.preSessionFooterBottom).toBe(IN_TAB_MEASURED_ACCESSORY_INSET);
   });
 
   it('hides the bar but keeps tab-bar clearance on a pushed sub-route (Material)', () => {
@@ -141,21 +157,25 @@ describe('computeBottomChromeMetrics', () => {
 
   it('hides both bars on a pushed sub-route even with a climb (glass)', () => {
     // On glass the accessory host unmounts off the top-level tab, so nothing shows;
-    // the tab bar still overlays content underneath.
+    // the tab bar still overlays content underneath (the probe stays mounted on
+    // pushed sub-routes, so the measurement keeps tracking the bar there).
     const metrics = computeBottomChromeMetrics({
       uiVariant: 'liquidGlass',
       usesNativeTabBar: true,
-      insetsBottom: SYNTHETIC_NATIVE_SAFE_AREA_INSET,
+      insetsBottom: ROOT_WINDOW_INSET,
       insideTabs: true,
       onAccessorySurface: false,
       hasCurrentClimb: true,
       nativeAccessoryMounted: false,
+      measuredTabContentInsetBottom: IN_TAB_INFERRED_BAR_INSET,
     });
     expect(metrics.nativeAccessoryVisible).toBe(false);
     expect(metrics.jsQueueToolbarVisible).toBe(false);
     expect(metrics.jsQueueReserve).toBe(0);
     expect(metrics.tabBarHeight).toBe(TAB_BAR_HEIGHT);
-    expect(metrics.scrollBottomPadding).toBe(SYNTHETIC_NATIVE_SAFE_AREA_INSET);
+    expect(metrics.scrollBottomPadding).toBe(IN_TAB_INFERRED_BAR_INSET);
+    // The session-detail fixed footer (the #3973 surface) clears the same bar.
+    expect(metrics.fixedFooterBottom).toBe(IN_TAB_INFERRED_BAR_INSET);
   });
 
   it('reserves no queue chrome for fixed footers outside the tabs group', () => {
@@ -182,17 +202,18 @@ describe('computeBottomChromeMetrics', () => {
     const metrics = computeBottomChromeMetrics({
       uiVariant: 'liquidGlass',
       usesNativeTabBar: true,
-      insetsBottom: SYNTHETIC_NATIVE_SAFE_AREA_INSET,
+      insetsBottom: ROOT_WINDOW_INSET,
       insideTabs: true,
       onAccessorySurface: true,
       hasCurrentClimb: false,
       nativeAccessoryMounted: true,
+      measuredTabContentInsetBottom: IN_TAB_INFERRED_BAR_INSET,
     });
     expect(metrics.jsQueueToolbarVisible).toBe(false);
     expect(metrics.nativeAccessoryVisible).toBe(false); // mounted, but no climb to show
-    expect(metrics.scrollBottomPadding).toBe(SYNTHETIC_NATIVE_SAFE_AREA_INSET);
-    expect(metrics.floatingControlBottom).toBe(SYNTHETIC_NATIVE_SAFE_AREA_INSET);
-    expect(metrics.fixedFooterBottom).toBe(SYNTHETIC_NATIVE_SAFE_AREA_INSET);
+    expect(metrics.scrollBottomPadding).toBe(IN_TAB_INFERRED_BAR_INSET);
+    expect(metrics.floatingControlBottom).toBe(IN_TAB_INFERRED_BAR_INSET);
+    expect(metrics.fixedFooterBottom).toBe(IN_TAB_INFERRED_BAR_INSET);
   });
 
   it('keeps scroll tab clearance but not fixed-footer tab clearance inside Material tabs', () => {
@@ -218,11 +239,12 @@ describe('computeBottomChromeMetrics', () => {
     const metrics = computeBottomChromeMetrics({
       uiVariant: 'liquidGlass',
       usesNativeTabBar: true,
-      insetsBottom: DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET,
+      insetsBottom: ROOT_WINDOW_INSET,
       insideTabs: true,
       onAccessorySurface: true,
       hasCurrentClimb: true,
       nativeAccessoryMounted: true,
+      measuredTabContentInsetBottom: IN_TAB_MEASURED_ACCESSORY_INSET,
     });
     expect(metrics.nativeAccessoryVisible).toBe(true);
     expect(metrics.jsQueueToolbarVisible).toBe(false);
@@ -236,7 +258,7 @@ describe('computeBottomChromeMetrics', () => {
             uiVariant: 'liquidGlass',
             usesNativeTabBar: true,
             // Geometry is irrelevant to this visibility-only total-function test.
-            insetsBottom: SYNTHETIC_NATIVE_SAFE_AREA_INSET,
+            insetsBottom: SYNTHETIC_ROOT_INSET,
             insideTabs: true,
             onAccessorySurface,
             hasCurrentClimb,
@@ -263,27 +285,27 @@ describe('computeBottomChromeMetrics', () => {
       expect(metrics.preSessionFooterBottom).toBe(metrics.fixedFooterBottom);
     });
 
-    it('anchors Liquid Glass to the raw inset and never double-counts the tab bar', () => {
-      // iPhone 17 Pro / iOS 26: the glass tab bar already extends the inset, so every
-      // bottom metric anchors to the raw value rather than adding chrome again.
+    it('anchors Liquid Glass to the measured in-tab inset and never double-counts the tab bar', () => {
+      // iPhone 17 Pro / iOS 26: the glass tab bar extends the IN-TAB inset, so
+      // every bottom metric anchors to the measurement rather than adding chrome
+      // to it again — and never to the bar-less root inset either.
       const metrics = computeBottomChromeMetrics({
         uiVariant: 'liquidGlass',
         usesNativeTabBar: true,
-        insetsBottom: DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET,
+        insetsBottom: ROOT_WINDOW_INSET,
         insideTabs: true,
         onAccessorySurface: true,
         hasCurrentClimb: true,
         nativeAccessoryMounted: true,
+        measuredTabContentInsetBottom: IN_TAB_MEASURED_ACCESSORY_INSET,
       });
-      // Before #3973, preSessionFooterBottom was intentionally smaller than
-      // fixedFooterBottom because the latter double-counted native chrome. Once the
-      // UIKit inset is treated as opaque, equality is the invariant: both consumers
-      // clear the same already-composed native tab/accessory region.
-      expect(metrics.preSessionFooterBottom).toBe(DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET);
-      expect(metrics.fixedFooterBottom).toBe(DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET);
-      // Native accessory mounted → no JS queue reserve, so the list also rides the raw inset.
+      // Both consumers clear the same already-composed native tab/accessory
+      // region, so equality is the invariant (as established by #3973).
+      expect(metrics.preSessionFooterBottom).toBe(IN_TAB_MEASURED_ACCESSORY_INSET);
+      expect(metrics.fixedFooterBottom).toBe(IN_TAB_MEASURED_ACCESSORY_INSET);
+      // Native accessory mounted → no JS queue reserve, so the list also rides the measurement.
       expect(metrics.jsQueueReserve).toBe(0);
-      expect(metrics.inSessionListBottom).toBe(DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET);
+      expect(metrics.inSessionListBottom).toBe(IN_TAB_MEASURED_ACCESSORY_INSET);
     });
 
     it('adds the JS queue reserve to both Liquid Glass session bottoms when the accessory is unavailable', () => {
@@ -302,6 +324,117 @@ describe('computeBottomChromeMetrics', () => {
       });
       expect(metrics.inSessionListBottom).toBe(34 + TOOLBAR_RESERVE);
       expect(metrics.preSessionFooterBottom).toBe(34 + TOOLBAR_RESERVE);
+    });
+  });
+
+  describe('measured in-tab inset (the sampling-point fix)', () => {
+    const nativePreSession = (overrides: { measuredTabContentInsetBottom?: number | null; insetsBottom?: number }) =>
+      computeBottomChromeMetrics({
+        uiVariant: 'liquidGlass',
+        usesNativeTabBar: true,
+        insetsBottom: ROOT_WINDOW_INSET,
+        insideTabs: true,
+        onAccessorySurface: true,
+        // Pre-session Record tab: no climb, so no accessory and no JS queue tray.
+        hasCurrentClimb: false,
+        nativeAccessoryMounted: true,
+        ...overrides,
+      });
+
+    it('keeps the Start capsule above the native tab bar (the regression this input exists for)', () => {
+      // Anchoring to the root inset put the capsule 49pt under the glass bar:
+      // the root provider never sees UIKit tab chrome. With the in-tab
+      // measurement, every footer clears the bar.
+      const metrics = nativePreSession({ measuredTabContentInsetBottom: IN_TAB_INFERRED_BAR_INSET });
+      expect(metrics.preSessionFooterBottom).toBe(IN_TAB_INFERRED_BAR_INSET);
+      expect(metrics.inSessionListBottom).toBe(IN_TAB_INFERRED_BAR_INSET);
+      expect(metrics.scrollBottomPadding).toBe(IN_TAB_INFERRED_BAR_INSET);
+      expect(metrics.preSessionFooterBottom).toBeGreaterThanOrEqual(ROOT_WINDOW_INSET + TAB_BAR_HEIGHT);
+    });
+
+    it('reconstructs the bar from the root inset while unmeasured (no accessory)', () => {
+      const metrics = nativePreSession({ measuredTabContentInsetBottom: null });
+      expect(metrics.tabBarBottom).toBe(ROOT_WINDOW_INSET + TAB_BAR_HEIGHT);
+      expect(metrics.preSessionFooterBottom).toBe(ROOT_WINDOW_INSET + TAB_BAR_HEIGHT);
+    });
+
+    it('reconstructs bar + accessory while unmeasured (accessory visible)', () => {
+      const metrics = computeBottomChromeMetrics({
+        uiVariant: 'liquidGlass',
+        usesNativeTabBar: true,
+        insetsBottom: ROOT_WINDOW_INSET,
+        insideTabs: true,
+        onAccessorySurface: true,
+        hasCurrentClimb: true,
+        nativeAccessoryMounted: true,
+        measuredTabContentInsetBottom: null,
+      });
+      // 34 + 49 + 56 — the reconstruction lands exactly on the device-verified
+      // 139, so the pre-measurement frames match the eventual measurement.
+      const reconstruction = ROOT_WINDOW_INSET + TAB_BAR_HEIGHT + NATIVE_BOTTOM_ACCESSORY_HEIGHT;
+      expect(reconstruction).toBe(IN_TAB_MEASURED_ACCESSORY_INSET);
+      expect(metrics.tabBarBottom).toBe(reconstruction);
+      expect(metrics.floatingControlBottom).toBe(reconstruction);
+      expect(metrics.preSessionFooterBottom).toBe(reconstruction);
+    });
+
+    it('rejects a physically impossible measurement (smaller than the root inset)', () => {
+      // An in-tab inset can never be below the window's own inset — such a
+      // publish (e.g. racing a provider teardown) falls back to reconstruction.
+      const metrics = nativePreSession({ measuredTabContentInsetBottom: ROOT_WINDOW_INSET - 14 });
+      expect(metrics.tabBarBottom).toBe(ROOT_WINDOW_INSET + TAB_BAR_HEIGHT);
+      expect(metrics.preSessionFooterBottom).toBe(ROOT_WINDOW_INSET + TAB_BAR_HEIGHT);
+    });
+
+    it('tracks a minimized bar for positioning but floors scroll padding (SYNTHETIC)', () => {
+      // minimizeBehavior="onScrollDown": UIKit shrinks the in-tab inset while the
+      // bar is minimized. Floating surfaces follow it (a capsule riding the
+      // minimizing bar is correct); scroll padding stays at the un-minimized
+      // reconstruction so contentContainer padding never shrinks mid-scroll and
+      // clamps the offset. The 40pt value is a spec of intended behavior, not a
+      // hardware measurement.
+      const minimizedInset = 40;
+      const metrics = nativePreSession({ measuredTabContentInsetBottom: minimizedInset });
+      expect(metrics.tabBarBottom).toBe(minimizedInset);
+      expect(metrics.floatingControlBottom).toBe(minimizedInset);
+      expect(metrics.preSessionFooterBottom).toBe(minimizedInset);
+      expect(metrics.scrollBottomPadding).toBe(ROOT_WINDOW_INSET + TAB_BAR_HEIGHT);
+    });
+
+    it('works on home-button devices where the root inset is zero', () => {
+      // insetsBottom 0 means the `>= insetsBottom` validity guard rejects
+      // nothing — the focus-gated probe is what keeps bad publishes out. A
+      // bar-only measurement (0 + 49) and the unmeasured reconstruction agree.
+      const measured = nativePreSession({ insetsBottom: 0, measuredTabContentInsetBottom: TAB_BAR_HEIGHT });
+      expect(measured.preSessionFooterBottom).toBe(TAB_BAR_HEIGHT);
+      const unmeasured = nativePreSession({ insetsBottom: 0, measuredTabContentInsetBottom: null });
+      expect(unmeasured.preSessionFooterBottom).toBe(TAB_BAR_HEIGHT);
+    });
+
+    it('is ignored on the JS-tab-bar fallback and Material paths', () => {
+      for (const uiVariant of ['liquidGlass', 'material'] as const) {
+        const withMeasurement = computeBottomChromeMetrics({
+          uiVariant,
+          usesNativeTabBar: false,
+          insetsBottom: ROOT_WINDOW_INSET,
+          insideTabs: true,
+          onAccessorySurface: true,
+          hasCurrentClimb: true,
+          nativeAccessoryMounted: false,
+          measuredTabContentInsetBottom: IN_TAB_MEASURED_ACCESSORY_INSET,
+        });
+        const withoutMeasurement = computeBottomChromeMetrics({
+          uiVariant,
+          usesNativeTabBar: false,
+          insetsBottom: ROOT_WINDOW_INSET,
+          insideTabs: true,
+          onAccessorySurface: true,
+          hasCurrentClimb: true,
+          nativeAccessoryMounted: false,
+          measuredTabContentInsetBottom: null,
+        });
+        expect(withMeasurement).toEqual(withoutMeasurement);
+      }
     });
   });
 
@@ -381,9 +514,10 @@ describe('computeBottomChromeMetrics', () => {
                       yield {
                         uiVariant,
                         usesNativeTabBar,
-                        // Synthetic for the total-function matrix: realistic device
-                        // states are pinned separately above.
-                        insetsBottom: SYNTHETIC_NATIVE_SAFE_AREA_INSET,
+                        // The realistic root inset: 83/139 measured values must
+                        // pass the `>= insetsBottom` validity guard, and the
+                        // realistic device states are pinned separately above.
+                        insetsBottom: ROOT_WINDOW_INSET,
                         insideTabs,
                         onAccessorySurface,
                         hasCurrentClimb,
@@ -404,13 +538,19 @@ describe('computeBottomChromeMetrics', () => {
     // Both invariants collect every offending input rather than asserting inside the
     // loop: a bare `expect` in a 256-iteration loop reports only "expected 34 to be
     // 100" and leaves you bisecting by hand for which combination produced it.
+    // Every invariant sweeps the measured axis too: null (pre-measurement),
+    // the inferred bar-only inset, and the device-verified accessory inset.
+    const MEASURED_AXIS = [null, IN_TAB_INFERRED_BAR_INSET, IN_TAB_MEASURED_ACCESSORY_INSET] as const;
+
     it('always reserves at least the JS queue tray when that tray is visible', () => {
       const unreserved = [];
-      for (const inputs of allInputs()) {
-        const metrics = computeBottomChromeMetrics(inputs);
-        if (!metrics.jsQueueToolbarVisible) continue;
-        if (metrics.preSessionFooterBottom < metrics.jsQueueReserve) {
-          unreserved.push({ inputs, footer: metrics.preSessionFooterBottom, reserve: metrics.jsQueueReserve });
+      for (const measuredTabContentInsetBottom of MEASURED_AXIS) {
+        for (const inputs of allInputs()) {
+          const metrics = computeBottomChromeMetrics({ ...inputs, measuredTabContentInsetBottom });
+          if (!metrics.jsQueueToolbarVisible) continue;
+          if (metrics.preSessionFooterBottom < metrics.jsQueueReserve) {
+            unreserved.push({ inputs, footer: metrics.preSessionFooterBottom, reserve: metrics.jsQueueReserve });
+          }
         }
       }
       expect(unreserved).toEqual([]);
@@ -421,40 +561,64 @@ describe('computeBottomChromeMetrics', () => {
       // bottom offsets must not drift apart — one branch being edited without the
       // other is exactly what caused #3967.
       const drifted = [];
-      for (const inputs of allInputs()) {
-        const metrics = computeBottomChromeMetrics(inputs);
-        if (metrics.preSessionFooterBottom !== metrics.inSessionListBottom) {
-          drifted.push({ inputs, footer: metrics.preSessionFooterBottom, list: metrics.inSessionListBottom });
+      for (const measuredTabContentInsetBottom of MEASURED_AXIS) {
+        for (const inputs of allInputs()) {
+          const metrics = computeBottomChromeMetrics({ ...inputs, measuredTabContentInsetBottom });
+          if (metrics.preSessionFooterBottom !== metrics.inSessionListBottom) {
+            drifted.push({ inputs, footer: metrics.preSessionFooterBottom, list: metrics.inSessionListBottom });
+          }
         }
       }
       expect(drifted).toEqual([]);
     });
 
-    it('never adds native-tab chrome beyond the UIKit safe area', () => {
-      // Use the full input cross-product at one synthetic opaque inset and at the
-      // on-device 139pt anchor. On the NativeTabs path UIKit's safe area already
-      // covers the 49pt tab bar and,
-      // when present, the 56pt BottomAccessory. The only extra bottom reserve
-      // this function may add is a JS queue tray in a transitional/fallback
-      // state; it must never add native chrome again.
-      const doubleCounted = [];
-      for (const insetsBottom of [SYNTHETIC_NATIVE_SAFE_AREA_INSET, DEVICE_VERIFIED_NATIVE_ACCESSORY_INSET]) {
+    it('anchors native-overlay cells to the in-tab inset (measured or reconstructed) exactly once', () => {
+      // On the NativeTabs path the in-tab inset covers the 49pt tab bar and, when
+      // present, the 56pt BottomAccessory. Every offset must anchor to that value
+      // (the measurement when valid, its reconstruction from the root inset when
+      // null) exactly once; the only extra bottom reserve this function may add
+      // is a JS queue tray in a transitional/fallback state. scrollBottomPadding
+      // additionally floors at the reconstruction (the mid-scroll minimize guard).
+      const misanchored = [];
+      for (const measuredTabContentInsetBottom of MEASURED_AXIS) {
         for (const inputs of allInputs()) {
           if (!inputs.usesNativeTabBar || !inputs.insideTabs || inputs.usesSidebar) continue;
-          const metrics = computeBottomChromeMetrics({ ...inputs, insetsBottom });
-          const expectedBottom = insetsBottom + metrics.jsQueueReserve;
+          const metrics = computeBottomChromeMetrics({ ...inputs, measuredTabContentInsetBottom });
+          const reconstruction =
+            inputs.insetsBottom +
+            TAB_BAR_HEIGHT +
+            (metrics.nativeAccessoryVisible ? NATIVE_BOTTOM_ACCESSORY_HEIGHT : 0);
+          const expectedAnchor = measuredTabContentInsetBottom ?? reconstruction;
+          const expectedScroll = Math.max(expectedAnchor, reconstruction) + metrics.jsQueueReserve;
+          const expectedBottom = expectedAnchor + metrics.jsQueueReserve;
           if (
-            metrics.tabBarBottom !== insetsBottom ||
+            metrics.tabBarBottom !== expectedAnchor ||
             metrics.nativeAccessoryReserve !== 0 ||
-            metrics.scrollBottomPadding !== expectedBottom ||
+            metrics.scrollBottomPadding !== expectedScroll ||
             metrics.floatingControlBottom !== expectedBottom ||
-            metrics.fixedFooterBottom !== expectedBottom
+            metrics.fixedFooterBottom !== expectedBottom ||
+            metrics.preSessionFooterBottom !== expectedBottom
           ) {
-            doubleCounted.push({ inputs: { ...inputs, insetsBottom }, metrics, expectedBottom });
+            misanchored.push({ inputs: { ...inputs, measuredTabContentInsetBottom }, metrics, expectedBottom });
           }
         }
       }
-      expect(doubleCounted).toEqual([]);
+      expect(misanchored).toEqual([]);
+    });
+
+    it('produces identical metrics for every measured value off the native-overlay path', () => {
+      const leaked = [];
+      for (const inputs of allInputs()) {
+        if (inputs.usesNativeTabBar && inputs.insideTabs && !inputs.usesSidebar) continue;
+        const baseline = computeBottomChromeMetrics({ ...inputs, measuredTabContentInsetBottom: null });
+        for (const measuredTabContentInsetBottom of MEASURED_AXIS) {
+          const metrics = computeBottomChromeMetrics({ ...inputs, measuredTabContentInsetBottom });
+          if (JSON.stringify(metrics) !== JSON.stringify(baseline)) {
+            leaked.push({ inputs: { ...inputs, measuredTabContentInsetBottom }, metrics, baseline });
+          }
+        }
+      }
+      expect(leaked).toEqual([]);
     });
   });
 
@@ -557,7 +721,7 @@ describe('computeBottomChromeMetrics', () => {
       const withFlag = computeBottomChromeMetrics({
         uiVariant: 'liquidGlass',
         usesNativeTabBar: true,
-        insetsBottom: SYNTHETIC_NATIVE_SAFE_AREA_INSET,
+        insetsBottom: SYNTHETIC_ROOT_INSET,
         insideTabs: true,
         onAccessorySurface: true,
         hasCurrentClimb: false,
@@ -567,14 +731,15 @@ describe('computeBottomChromeMetrics', () => {
       const withoutFlag = computeBottomChromeMetrics({
         uiVariant: 'liquidGlass',
         usesNativeTabBar: true,
-        insetsBottom: SYNTHETIC_NATIVE_SAFE_AREA_INSET,
+        insetsBottom: SYNTHETIC_ROOT_INSET,
         insideTabs: true,
         onAccessorySurface: true,
         hasCurrentClimb: false,
         nativeAccessoryMounted: false,
       });
       expect(withFlag).toEqual(withoutFlag);
-      expect(withoutFlag.scrollBottomPadding).toBe(SYNTHETIC_NATIVE_SAFE_AREA_INSET);
+      // No measurement supplied → the native path reconstructs the bar.
+      expect(withoutFlag.scrollBottomPadding).toBe(SYNTHETIC_ROOT_INSET + TAB_BAR_HEIGHT);
     });
   });
 });

--- a/packages/mobile/src/hooks/__tests__/use-window-bottom-inset.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-window-bottom-inset.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { act, render, renderHook } from '@testing-library/react';
+import { publishWindowInsetBottom, resetWindowInsetForTests } from '../../lib/window-inset-store';
+
+const ctrl = vi.hoisted(() => ({
+  insetsBottom: 139,
+}));
+
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 59, bottom: ctrl.insetsBottom, left: 0, right: 0 }),
+}));
+
+import { useWindowBottomInset, WindowInsetPublisher } from '../use-window-bottom-inset';
+
+describe('useWindowBottomInset', () => {
+  beforeEach(() => {
+    resetWindowInsetForTests();
+    ctrl.insetsBottom = 139;
+  });
+  afterEach(() => {
+    resetWindowInsetForTests();
+  });
+
+  it('returns the published window inset, not the mount point’s local inset', () => {
+    // The bug this hook exists for: a sheet mounted inside a tab sees a local
+    // inset of 139 (iOS 26 tab bar + accessory folded in by the per-tab
+    // provider), but the sheet docks over that chrome — it must clear only the
+    // window's 34pt home indicator.
+    const { result } = renderHook(() => useWindowBottomInset());
+    act(() => publishWindowInsetBottom(34));
+    expect(result.current).toBe(34);
+  });
+
+  it('falls back to the local inset before the first publish', () => {
+    // Pre-publish frames (no sheet can be open yet) and every existing test
+    // that mocks react-native-safe-area-context keep the local meaning.
+    const { result } = renderHook(() => useWindowBottomInset());
+    expect(result.current).toBe(139);
+  });
+
+  it('tracks a later publish (rotation, bar change)', () => {
+    const { result } = renderHook(() => useWindowBottomInset());
+    act(() => publishWindowInsetBottom(34));
+    act(() => publishWindowInsetBottom(21));
+    expect(result.current).toBe(21);
+  });
+
+  it('WindowInsetPublisher publishes its own provider’s bottom inset and renders nothing', () => {
+    // Mounted at the root layout its provider IS the window; here the mock
+    // stands in for it.
+    ctrl.insetsBottom = 34;
+    const { container } = render(<WindowInsetPublisher />);
+    expect(container.innerHTML).toBe('');
+    const { result } = renderHook(() => useWindowBottomInset());
+    // Consumers with a DIFFERENT local inset (tab-mounted sheet) now get the
+    // published window value.
+    ctrl.insetsBottom = 139;
+    expect(result.current).toBe(34);
+  });
+});

--- a/packages/mobile/src/hooks/bottom-chrome-metrics.ts
+++ b/packages/mobile/src/hooks/bottom-chrome-metrics.ts
@@ -6,6 +6,7 @@ import { selectByVariant } from '../theme/variants/select-by-variant';
 import {
   MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT,
   MATERIAL_TAB_BAR_HEIGHT,
+  NATIVE_BOTTOM_ACCESSORY_HEIGHT,
   TAB_BAR_HEIGHT,
   TOOLBAR_GAP_ABOVE_TABBAR,
   TOOLBAR_RESERVE,
@@ -21,6 +22,32 @@ import {
  * accessory — a class of bug that is invisible in code review and only shows on
  * device. (Replaces the unit-tested pure `queueSnackbarBottomOffset` that was
  * folded into the hook.)
+ *
+ * ## The geometry contract: two safe-area sampling points
+ *
+ * There are TWO places a bottom inset can be read, with different semantics, and
+ * conflating them is what caused #3967 → #3973 → #4089 → the Start-capsule
+ * regression this contract was written for:
+ *
+ * - **Root provider** (where `BottomChromeMetricsProvider` samples, above the
+ *   navigator): the window's inset — home indicator only (34 on Face ID
+ *   iPhones, 0 on home-button devices). UIKit tab-bar chrome never reaches it.
+ * - **In-tab provider**: expo-router's `NativeTabsView` wraps each tab's
+ *   content in its own nested `SafeAreaProvider`; inside it the bottom inset
+ *   additionally folds in the UIKit tab bar, the BottomAccessory, and the live
+ *   minimize state (DEVICE_VERIFIED 139 = 34 + 49 bar + 56 accessory,
+ *   iPhone 17 Pro). `NativeTabContentInsetProbe` publishes this measurement as
+ *   `measuredTabContentInsetBottom`.
+ *
+ * Provenance rule: never assume what UIKit folds into an inset. Position
+ * against the inset measured at the surface you are positioning in, or consume
+ * the published measurement; hardcoded reconstructions are fallbacks for the
+ * pre-measurement frames only. Test constants must be labeled DEVICE_VERIFIED
+ * (with device + state) or INFERRED.
+ *
+ * Known transient windows (self-correcting within frames, by design): the
+ * accessory mounting/unmounting or a rotation briefly leaves a stale
+ * measurement until the probe's effect re-fires on the next inset event.
  */
 export type BottomChromeInputs = {
   /** Resolved UI variant; controls the JS toolbar shape/reserve. */
@@ -59,6 +86,15 @@ export type BottomChromeInputs = {
    * the JS queue toolbar because the pane is suppressed there.
    */
   detailPaneOwnsQueue?: boolean;
+  /**
+   * Bottom inset measured INSIDE the focused native tab's content (see the
+   * module docblock's sampling-point contract), published by
+   * `NativeTabContentInsetProbe` via `native-tab-content-inset-store`. `null`
+   * (the default) means "no measurement yet"; the native-overlay path then
+   * reconstructs the chrome from the root inset + constants. Ignored entirely
+   * off the native-tab-bar path — the JS bars sit outside every UIKit inset.
+   */
+  measuredTabContentInsetBottom?: number | null;
 };
 
 export type BottomChromeMetrics = {
@@ -70,8 +106,10 @@ export type BottomChromeMetrics = {
   /** Physical height of the rendered bottom tab bar; zero outside tabs/sidebar mode. */
   tabBarHeight: number;
   /**
-   * Bottom clearance through the tab bar. NativeTabs returns the raw UIKit inset
-   * because it already contains native chrome; JS tabs add their in-flow height.
+   * Bottom clearance through the tab bar. NativeTabs returns the measured
+   * in-tab inset (or its reconstruction while unmeasured) because UIKit folds
+   * the bar + accessory into that inset; JS tabs add their in-flow height to
+   * the root inset.
    */
   tabBarBottom: number;
   jsQueueReserve: number;
@@ -100,18 +138,17 @@ export type BottomChromeMetrics = {
   inSessionListBottom: number;
   /**
    * Bottom offset for the pre-session Start capsule / footer. Material uses the
-   * fixed-footer reserve; Liquid Glass anchors to the raw safe-area inset plus
-   * the JS queue reserve — identical arithmetic to {@link inSessionListBottom},
-   * and it must stay in lockstep with it: both surfaces clear the same bottom
-   * chrome, and letting one branch drift is what caused #3967.
+   * fixed-footer reserve; Liquid Glass anchors to the native chrome clearance
+   * plus the JS queue reserve — identical arithmetic to
+   * {@link inSessionListBottom}, and it must stay in lockstep with it: both
+   * surfaces clear the same bottom chrome, and letting one branch drift is what
+   * caused #3967.
    *
-   * Verified on-device (iPhone 17 Pro / iOS 26): with the native tab bar + climb
-   * accessory present, the safe-area bottom inset is 139 = home indicator (34) +
-   * tab bar (49) + accessory (56) — the glass tab bar extends the UIKit safe area.
-   * Every native-tab metric starts at that raw inset, rather than adding either
-   * piece of UIKit-owned chrome again; only separately rendered JS queue chrome
-   * may add a reserve. That evidence covers the *native tab bar* path with the
-   * accessory, where `jsQueueReserve` is 0, so this stays exactly 139.
+   * On the native tab bar, the clearance is the measured in-tab inset
+   * (DEVICE_VERIFIED 139 with the accessory on an iPhone 17 Pro — see the
+   * module docblock) or its reconstruction while unmeasured. The ROOT inset
+   * alone is never enough here: it excludes the 49pt bar, and anchoring to it
+   * is exactly how the Start capsule ended up underneath the tab bar.
    *
    * On the JS-tab-bar fallback (iOS < 26, non-glass-capable iPhones, iPad in a
    * narrow split, Android forced to Liquid Glass) the floating
@@ -145,6 +182,7 @@ export function computeBottomChromeMetrics({
   nativeAccessoryMounted,
   usesSidebar = false,
   detailPaneOwnsQueue = usesSidebar,
+  measuredTabContentInsetBottom = null,
 }: BottomChromeInputs): BottomChromeMetrics {
   // Regular-width iPad with the detail pane mounted: the left sidebar replaces
   // the bottom tab bar and the selected-climb pane replaces the floating queue
@@ -187,11 +225,15 @@ export function computeBottomChromeMetrics({
   const tabBarConstant = usesNativeTabBar ? TAB_BAR_HEIGHT : MATERIAL_TAB_BAR_HEIGHT;
   const tabBarHeight = insideTabs && !usesSidebar ? tabBarConstant : 0;
   // Only the native tab bar overlays content (UIKit draws it over the scroll view);
-  // the JS `MaterialTabBar` sits in flow. NativeTabs extends UIKit's safe-area
-  // inset to include both the bar and its BottomAccessory, so neither is an
-  // additional bottom offset. On-device, that inset is 139pt with an accessory on
-  // an iPhone 17 Pro (34 home indicator + 49 tab bar + 56 accessory).
-  const tabBarOverlaysContent = insideTabs && usesNativeTabBar;
+  // the JS `MaterialTabBar` sits in flow. NativeTabs extends the IN-TAB safe-area
+  // inset to include both the bar and its BottomAccessory (DEVICE_VERIFIED 139 =
+  // 34 + 49 + 56 on an iPhone 17 Pro) — but that fold-in exists only inside the
+  // tab's nested SafeAreaProvider, never in the root `insetsBottom` this function
+  // receives. See the module docblock's sampling-point contract. The sidebar
+  // shell never renders a native bottom bar (the rail replaces it), so a
+  // synthetic "sidebar + native tab signal" call must not consume the in-tab
+  // measurement or its reconstruction — hence the `!usesSidebar` term.
+  const tabBarOverlaysContent = insideTabs && usesNativeTabBar && !usesSidebar;
   // The Material bar reserves its full height even though it's tucked ~2px into the
   // tab bar (MATERIAL_TABBAR_OVERLAP in persistent-queue-bar), so its visible height
   // above the tab bar is ~2px less. The resulting 2px of extra scroll padding is
@@ -207,7 +249,26 @@ export function computeBottomChromeMetrics({
   // "native accessory visible without NativeTabs".
   const nativeAccessoryReserve =
     nativeAccessoryVisible && !tabBarOverlaysContent ? glassSize.standard + TOOLBAR_GAP_ABOVE_TABBAR : 0;
-  const tabBarBottom = insetsBottom + (tabBarOverlaysContent ? 0 : tabBarHeight);
+  // Native-overlay clearance: prefer the live in-tab measurement (it tracks the
+  // accessory and the minimize state); reconstruct from the root inset +
+  // constants only while unmeasured. The `>= insetsBottom` guard rejects
+  // physically impossible readings (an in-tab inset can never be smaller than
+  // the window's own inset) — e.g. a probe publish that raced a provider
+  // teardown — without imposing an assumption-based floor on valid ones.
+  const nativeChromeFallback =
+    insetsBottom + TAB_BAR_HEIGHT + (nativeAccessoryVisible ? NATIVE_BOTTOM_ACCESSORY_HEIGHT : 0);
+  const nativeChromeBottom =
+    measuredTabContentInsetBottom !== null && measuredTabContentInsetBottom >= insetsBottom
+      ? measuredTabContentInsetBottom
+      : nativeChromeFallback;
+  const tabBarBottom = tabBarOverlaysContent ? nativeChromeBottom : insetsBottom + tabBarHeight;
+  // Scroll padding is floored at the un-minimized reconstruction: the gesture
+  // that minimizes the bar is the same one scrolling the list, and shrinking
+  // contentContainer padding mid-scroll can clamp/jump the scroll offset near
+  // the end of content. ≤49pt of extra padding while minimized is invisible
+  // slack; floating controls deliberately keep tracking the live value instead
+  // (a capsule following the minimizing bar is correct).
+  const scrollTabBarBottom = tabBarOverlaysContent ? Math.max(tabBarBottom, nativeChromeFallback) : tabBarBottom;
   const activeQueueChromeReserve = Math.max(jsQueueReserve, nativeAccessoryReserve);
   const contentInsetBottom = tabBarOverlaysContent || !insideTabs ? tabBarBottom : 0;
   const fixedFooterBottom = contentInsetBottom + activeQueueChromeReserve;
@@ -222,21 +283,26 @@ export function computeBottomChromeMetrics({
     tabBarBottom,
     jsQueueReserve,
     nativeAccessoryReserve,
-    scrollBottomPadding: tabBarBottom + jsQueueReserve,
+    scrollBottomPadding: scrollTabBarBottom + jsQueueReserve,
     floatingControlBottom: tabBarBottom + Math.max(jsQueueReserve, nativeAccessoryReserve),
     fixedFooterBottom,
     // selectByVariant (vs a raw ternary) keeps these exhaustive: a new UiVariant is
     // a compile error here, since this file is outside the components/ guard scope.
+    // The liquidGlass branch clears the native chrome (measured in-tab inset /
+    // reconstruction) under the native bar, and the raw inset on the JS-bar
+    // fallback where the bar is a JS overlay handled by `jsQueueReserve` (#3967).
+    // The ROOT inset alone is never correct under the native bar — it excludes
+    // the 49pt bar, which is exactly how the Start capsule sank beneath it.
     inSessionListBottom: selectByVariant(uiVariant, {
       material: fixedFooterBottom,
-      liquidGlass: insetsBottom + jsQueueReserve,
+      liquidGlass: (tabBarOverlaysContent ? tabBarBottom : insetsBottom) + jsQueueReserve,
     }),
     // Keep this branch identical to `inSessionListBottom`: the JS queue tray is an
     // overlay outside the safe area, so the Start capsule only clears it when the
     // reserve is added explicitly (#3967).
     preSessionFooterBottom: selectByVariant(uiVariant, {
       material: fixedFooterBottom,
-      liquidGlass: insetsBottom + jsQueueReserve,
+      liquidGlass: (tabBarOverlaysContent ? tabBarBottom : insetsBottom) + jsQueueReserve,
     }),
   };
 }

--- a/packages/mobile/src/hooks/use-bottom-chrome-metrics.tsx
+++ b/packages/mobile/src/hooks/use-bottom-chrome-metrics.tsx
@@ -4,6 +4,7 @@ import { useWindowDimensions } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../providers/theme-provider';
 import { isAccessorySurfaceRoute, isTabsChromeRoute } from '../lib/route-segments';
+import { useNativeTabContentInsetBottom } from '../lib/native-tab-content-inset-store';
 import { useStickyAccessoryPresence } from './use-sticky-accessory-presence';
 import { isBottomAccessoryAvailable, useNativeTabBar } from './use-bottom-accessory';
 import { useDeviceLayout } from './use-device-layout';
@@ -62,6 +63,11 @@ function useComputedBottomChromeMetrics(): BottomChromeMetrics {
   const usesSidebar = insideTabs && widthClass === 'regular';
   const detailPaneOwnsQueue =
     usesSidebar && resolveDetailPaneSurface({ width: windowWidth, widthClass, sidebarWidth: SIDEBAR_WIDTH }) === 'pane';
+  // This provider samples the ROOT safe-area inset (window / home indicator
+  // only). The in-tab inset — the one UIKit extends with the native tab bar +
+  // accessory — is published by NativeTabContentInsetProbe from inside the
+  // focused tab; see the sampling-point contract in bottom-chrome-metrics.ts.
+  const measuredTabContentInsetBottom = useNativeTabContentInsetBottom();
 
   return useMemo(
     () =>
@@ -75,6 +81,7 @@ function useComputedBottomChromeMetrics(): BottomChromeMetrics {
         nativeAccessoryMounted,
         usesSidebar,
         detailPaneOwnsQueue,
+        measuredTabContentInsetBottom,
       }),
     [
       variant,
@@ -86,6 +93,7 @@ function useComputedBottomChromeMetrics(): BottomChromeMetrics {
       nativeAccessoryMounted,
       usesSidebar,
       detailPaneOwnsQueue,
+      measuredTabContentInsetBottom,
     ],
   );
 }

--- a/packages/mobile/src/hooks/use-window-bottom-inset.ts
+++ b/packages/mobile/src/hooks/use-window-bottom-inset.ts
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { publishWindowInsetBottom, usePublishedWindowInsetBottom } from '../lib/window-inset-store';
+
+/**
+ * The bottom inset a BOTTOM-DOCKED NATIVE SHEET must clear: the window's own
+ * safe area (home indicator / Android gesture bar), never the mount point's.
+ *
+ * Every bottom-docked sheet (`Sheet`/`ModalSheet` footers and bodies, bespoke
+ * sheet footers) must use this instead of `useSafeAreaInsets().bottom`: a sheet
+ * mounted inside a tab inherits the per-tab provider, whose bottom inset folds
+ * in the iOS 26 tab bar + BottomAccessory that the sheet visually covers — the
+ * Apply-button-floating-mid-sheet bug (#3776). See the sampling-point contract
+ * in `bottom-chrome-metrics.ts`.
+ *
+ * Falls back to the local inset until the root publisher's first layout — a
+ * window in which no sheet can be open yet — and in tests, where nothing
+ * publishes and the local mock keeps its established meaning.
+ */
+export function useWindowBottomInset(): number {
+  const published = usePublishedWindowInsetBottom();
+  const insets = useSafeAreaInsets();
+  return published ?? insets.bottom;
+}
+
+/**
+ * Mount ONCE in the root layout (app/_layout.tsx), outside the (tabs) subtree:
+ * there `useSafeAreaInsets()` resolves to expo-router's root provider, whose
+ * inset IS the window's. Renders nothing.
+ */
+export function WindowInsetPublisher() {
+  const insets = useSafeAreaInsets();
+  useEffect(() => {
+    publishWindowInsetBottom(insets.bottom);
+  }, [insets.bottom]);
+  return null;
+}

--- a/packages/mobile/src/lib/__tests__/native-tab-content-inset-store.test.ts
+++ b/packages/mobile/src/lib/__tests__/native-tab-content-inset-store.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  publishNativeTabContentInsetBottom,
+  resetNativeTabContentInsetForTests,
+  useNativeTabContentInsetBottom,
+  useNativeTabContentInsetPublishCount,
+} from '../native-tab-content-inset-store';
+
+describe('native-tab-content-inset-store', () => {
+  beforeEach(() => {
+    resetNativeTabContentInsetForTests();
+  });
+
+  it('starts with no measurement', () => {
+    const { result } = renderHook(() => useNativeTabContentInsetBottom());
+    expect(result.current).toBeNull();
+  });
+
+  it('publishes a measurement to subscribers', () => {
+    const { result } = renderHook(() => useNativeTabContentInsetBottom());
+    act(() => publishNativeTabContentInsetBottom(83));
+    expect(result.current).toBe(83);
+    act(() => publishNativeTabContentInsetBottom(139));
+    expect(result.current).toBe(139);
+  });
+
+  it('ignores sub-half-pixel jitter but accepts real changes', () => {
+    const { result } = renderHook(() => useNativeTabContentInsetBottom());
+    const { result: publishCount } = renderHook(() => useNativeTabContentInsetPublishCount());
+    act(() => publishNativeTabContentInsetBottom(83));
+    act(() => publishNativeTabContentInsetBottom(83.4));
+    expect(result.current).toBe(83);
+    expect(publishCount.current).toBe(1);
+    act(() => publishNativeTabContentInsetBottom(83.5));
+    expect(result.current).toBe(83.5);
+    expect(publishCount.current).toBe(2);
+  });
+
+  it('accepts the first publish even when it matches a jitter of null', () => {
+    // The epsilon only compares against a PREVIOUS measurement — the first
+    // publish must always land, including 0 (a home-button device in-tab inset
+    // with the bar hidden would be unusual, but the store must not drop it).
+    const { result } = renderHook(() => useNativeTabContentInsetBottom());
+    act(() => publishNativeTabContentInsetBottom(0));
+    expect(result.current).toBe(0);
+  });
+
+  it('resets to the unmeasured state for tests', () => {
+    const { result } = renderHook(() => useNativeTabContentInsetBottom());
+    act(() => publishNativeTabContentInsetBottom(83));
+    act(() => resetNativeTabContentInsetForTests());
+    expect(result.current).toBeNull();
+  });
+});

--- a/packages/mobile/src/lib/native-tab-content-inset-store.ts
+++ b/packages/mobile/src/lib/native-tab-content-inset-store.ts
@@ -1,0 +1,87 @@
+import { useSyncExternalStore } from 'react';
+
+/**
+ * Live bottom safe-area inset measured INSIDE the focused iOS 26 native tab's
+ * content, published by `NativeTabContentInsetProbe` (mounted in each phone tab
+ * layout) and consumed by `useComputedBottomChromeMetrics` and `Toast`.
+ *
+ * Why this exists: there are two safe-area sampling points with different
+ * semantics. expo-router's `NativeTabsView` wraps each tab's content in its own
+ * nested `SafeAreaProvider`, so `useSafeAreaInsets().bottom` read inside a tab
+ * includes the UIKit tab bar, the BottomAccessory, and the live minimize state
+ * (139 = 34 home indicator + 49 bar + 56 accessory on an iPhone 17 Pro). The
+ * root-mounted `BottomChromeMetricsProvider` reads the ROOT provider, whose view
+ * is the window — its bottom inset is only the home indicator. Positioning tab
+ * content against the root inset is what put the pre-session Start capsule under
+ * the tab bar; assuming the root inset already contained the bar is what sank
+ * toasts and snackbars (#3973 → #4089). This store carries the in-tab
+ * measurement to the root consumers so neither has to guess.
+ *
+ * A module store (not context) on purpose: `Toast` renders above
+ * `BottomChromeMetricsProvider` in the root layout, so a context could not reach
+ * both consumers without re-ordering providers #2565 deliberately pinned.
+ *
+ * `null` means "no measurement yet" (cold start before the first focused-tab
+ * layout pass, and always on paths where the probe never publishes: Material
+ * variant, tablets, Android, iOS < 26). Consumers must fall back to explicit
+ * arithmetic in that case and must ignore the value entirely off the
+ * native-tab-bar path.
+ */
+
+let measuredBottom: number | null = null;
+const listeners = new Set<() => void>();
+// Total accepted publishes since launch, surfaced by BottomChromeDebugOverlay so
+// device QA can tell whether a tab-bar minimize animation delivers a couple of
+// discrete inset events or a per-frame stream. If QA shows per-frame publishes,
+// add coalescing (rAF / short settle debounce) inside publish() below — the
+// consumers only ever see the store through subscribe/snapshot, so the debounce
+// slots in here without touching them.
+let publishCount = 0;
+
+// Sub-half-pixel jitter is layout noise, not a geometry change; re-notifying the
+// root metrics provider for it would re-render every bottom-chrome consumer.
+const PUBLISH_EPSILON = 0.5;
+
+function notify(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): number | null {
+  return measuredBottom;
+}
+
+function getPublishCountSnapshot(): number {
+  return publishCount;
+}
+
+export function publishNativeTabContentInsetBottom(value: number): void {
+  if (measuredBottom !== null && Math.abs(measuredBottom - value) < PUBLISH_EPSILON) return;
+  measuredBottom = value;
+  publishCount += 1;
+  notify();
+}
+
+/** The latest in-tab bottom inset, or null before the first publish. */
+export function useNativeTabContentInsetBottom(): number | null {
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+/** Diagnostic-only: accepted-publish counter for BottomChromeDebugOverlay. */
+export function useNativeTabContentInsetPublishCount(): number {
+  return useSyncExternalStore(subscribe, getPublishCountSnapshot);
+}
+
+export function resetNativeTabContentInsetForTests(): void {
+  measuredBottom = null;
+  publishCount = 0;
+  notify();
+}

--- a/packages/mobile/src/lib/window-inset-store.ts
+++ b/packages/mobile/src/lib/window-inset-store.ts
@@ -1,0 +1,59 @@
+import { useSyncExternalStore } from 'react';
+
+/**
+ * The WINDOW's bottom safe-area inset (home indicator / Android gesture bar),
+ * published once from the root layout by `WindowInsetPublisher` — the mirror of
+ * `native-tab-content-inset-store`, which carries the in-tab inset the other way.
+ *
+ * Why sheets need it: a native `@expo/ui` bottom sheet docks to the WINDOW and
+ * covers the tab bar, so the only chrome its content must clear is the window's
+ * own bottom inset. But `useSafeAreaInsets()` inside a sheet resolves to the
+ * provider at the sheet's MOUNT POINT — and a sheet mounted inside a tab sits in
+ * expo-router's per-tab nested SafeAreaProvider, whose bottom inset folds in the
+ * iOS 26 tab bar and BottomAccessory (up to 139pt). Padding a sheet footer with
+ * that pushed the Apply button ~105pt up into the sheet (the #3776 "dead gap").
+ * See the sampling-point contract in `hooks/bottom-chrome-metrics.ts`.
+ *
+ * `null` until the root publisher's first layout; `useWindowBottomInset()` falls
+ * back to the local inset in that window, which also keeps every existing test
+ * (they mock react-native-safe-area-context, not this store) behaving as before.
+ */
+
+let windowInsetBottom: number | null = null;
+const listeners = new Set<() => void>();
+
+// Same sub-half-pixel dedupe as the in-tab store: layout noise, not geometry.
+const PUBLISH_EPSILON = 0.5;
+
+function notify(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): number | null {
+  return windowInsetBottom;
+}
+
+export function publishWindowInsetBottom(value: number): void {
+  if (windowInsetBottom !== null && Math.abs(windowInsetBottom - value) < PUBLISH_EPSILON) return;
+  windowInsetBottom = value;
+  notify();
+}
+
+/** The published window bottom inset, or null before the root's first publish. */
+export function usePublishedWindowInsetBottom(): number | null {
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+export function resetWindowInsetForTests(): void {
+  windowInsetBottom = null;
+  notify();
+}

--- a/packages/mobile/src/settings/defaults.ts
+++ b/packages/mobile/src/settings/defaults.ts
@@ -12,4 +12,5 @@ export const DEFAULT_SETTINGS: AppSettings = {
   notifySessionInvites: true,
   notifyClimbComments: true,
   kioskHintSeen: false,
+  bottomChromeDiagnostics: false,
 };

--- a/packages/mobile/src/settings/types.ts
+++ b/packages/mobile/src/settings/types.ts
@@ -21,6 +21,8 @@ export type AppSettings = {
   notifyClimbComments: boolean;
   /** One-shot: the "kiosk setup lives on the big screen" hint has been seen on My gyms. */
   kioskHintSeen: boolean;
+  /** Show the live bottom-chrome geometry overlay (dev / preview / pr-channel only). */
+  bottomChromeDiagnostics: boolean;
 };
 
 export type SettingsKey = keyof AppSettings;

--- a/packages/mobile/src/theme/layout.ts
+++ b/packages/mobile/src/theme/layout.ts
@@ -69,6 +69,14 @@ export const TOOLBAR_GAP = 8;
 /** Max readable width for UIKit's iOS 26 bottom accessory content. */
 export const NATIVE_BOTTOM_ACCESSORY_MAX_WIDTH = 420;
 
+/** Height UIKit's iOS 26 bottom accessory adds to the tab content's safe-area
+ *  inset (DEVICE_VERIFIED: 139 − 83 on an iPhone 17 Pro). Numerically equal to
+ *  `glassSize.hero` today, but that is a coincidence between UIKit's platter and
+ *  our FAB ladder — the bottom-chrome fallback arithmetic must reconstruct
+ *  UIKit-owned chrome, so it keys off this constant, which a ladder retune must
+ *  not move. */
+export const NATIVE_BOTTOM_ACCESSORY_HEIGHT = 56;
+
 /** Total horizontal screen gutter reserved around UIKit's iOS 26 bottom accessory. */
 export const NATIVE_BOTTOM_ACCESSORY_SCREEN_GUTTER = 32;
 


### PR DESCRIPTION
## Summary

Two mirror-image regressions from one root cause: on iOS 26 native tabs there are **two safe-area sampling points with different semantics**, and code kept reading the wrong one. expo-router's `NativeTabsView` wraps each tab's content in a nested `SafeAreaProvider` whose bottom inset folds in the tab bar + BottomAccessory + minimize state (the device-verified 139 = 34 + 49 + 56 was measured *there*), while the root-mounted `BottomChromeMetricsProvider` samples the window inset — home indicator only. Every prior fix in this family (#3967, #3973, #4089, the toast repair) guessed at one sampling point and broke the other.

**Tab content positioned with the root inset (too little)** — the pre-session Start capsule sat under the tab bar; after #4089, toasts, snackbars, and list padding lost their tab-bar clearance too:

- **`NativeTabContentInsetProbe`** — mounted in each phone tab layout, inside the per-tab provider, publishes the real in-tab inset to a module store. Focus-gated: expo-router renders every tab's screen, and an unfocused tab's detached view can report a bar-less inset that would reinstate the bug through a last-writer-wins store.
- **`computeBottomChromeMetrics`** gains `measuredTabContentInsetBottom`. On the native-overlay path all offsets anchor to the measurement; the constant reconstruction (root inset + `TAB_BAR_HEIGHT` + `NATIVE_BOTTOM_ACCESSORY_HEIGHT`) survives only as the pre-measurement fallback. `scrollBottomPadding` floors at the un-minimized reconstruction so list padding never shrinks mid-scroll. Floating surfaces track the live value, so `minimizeBehavior` and future UIKit chrome changes are handled automatically.
- **The capsule fix**: `preSessionFooterBottom` / `inSessionListBottom` (liquidGlass) now clear the native chrome instead of the bar-less root inset. Snackbars, FABs, the session-detail footer, and ~19 scroll screens are fixed through the shared `tabBarBottom`. **`Toast`** (mounts above the metrics provider) reads the same store.

**Sheet content positioned with the in-tab inset (too much)** — the inverse: a native bottom sheet docks *over* the tab bar, but a sheet mounted inside a tab inherited the per-tab 139pt inset for chrome it covers, floating the climb filter sheet's Apply button ~105pt up into the sheet (the #3776 "dead gap"):

- **`WindowInsetPublisher`** (root layout, where the provider IS the window) publishes the window inset; **`useWindowBottomInset()`** serves it to the sheet family — the `Sheet`/`ModalSheet` wrappers, `ClimbFilterSheet`, `HoldFilterPicker`, `LogbookFilterSheet`, `LogbookEntryChooserSheet`, `EndSessionSheet`, `InviteSheet`, `CreateDrawer` — with the local inset as the pre-publish fallback. Root-mounted sheets are unaffected (both values identical); the hook makes the mount point irrelevant.

**Guardrails so this stops recurring**: a permanent "Bottom chrome diagnostics" overlay (More → Diagnostics; dev, EAS preview builds, and `pr-<N>` OTA channels) showing all three sampling points, the publish counter, and every derived offset; test fixtures labeled DEVICE_VERIFIED vs INFERRED with the measured axis swept across the invariant matrix; and the sampling-point contract written into `bottom-chrome-metrics.ts` and `docs/mobile-sheets-vs-routes.md`.

JS-only — rides the `pr-<N>` OTA preview channel to existing 2.3.0 installs.

## Release Notes

- The Start button on the Record tab sits above the tab bar again on iOS 26.
- The climb filter sheet's Apply button sits at the bottom of the sheet again, without the dead gap below it.
- Toasts, snackbars, and the last rows of lists stay clear of the tab bar.

## Test plan

- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — 5061 tests pass, including new suites for both inset stores, the focus-gated probe, the window-inset hook fallback contract, provider fan-out on publish, and the measured-axis invariant matrix.
- `vp run check:mobile-bundle` — Metro bundle OK.
- Device QA on an iOS 26 iPhone via this PR's OTA preview channel (What's New → "Try a preview"):
  1. Record tab, no session, no climb → Start capsule fully above the tab bar, tappable.
  2. Set a climb (accessory appears) → capsule above the accessory platter; rapid climb set/clear settles correctly.
  3. In session → last list row clears the accessory; queue snackbar clears chrome.
  4. Scroll a long list (bar minimizes) → capsule follows the bar; no scroll jumps or content shifts.
  5. Push session detail → FAB above the bar. Trigger a toast on a tab page → above the bar. Rotate → settles.
  6. **Climbs tab → Filters** → Apply button pinned at the sheet bottom with only the home-indicator gap (with and without a current climb set). Same check on the logbook filter sheet and end-session sheet.
  7. Enable More → Diagnostics → "Bottom chrome diagnostics": report the (root, probe, window) values per state and the publish count for one minimize/expand cycle (a large jump means the store's coalescing should be enabled before un-drafting).
- Follow-up commit will upgrade INFERRED fixture labels to DEVICE_VERIFIED with the reported numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHCyw4UkJ6Y7NGRbBfNK7C