### PR TITLE
fix(mobile): stop iOS filter chips truncating their labels

### DIFF
--- a/packages/mobile/src/components/search/FilterChipRow.ios.tsx
+++ b/packages/mobile/src/components/search/FilterChipRow.ios.tsx
@@ -27,7 +27,7 @@ import { memo, useCallback } from 'react';
 import { StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { Host, HStack, ScrollView, Menu, Picker, Button, Text, Divider } from '@expo/ui/swift-ui';
-import { buttonStyle, controlSize, tint, tag, padding } from '@expo/ui/swift-ui/modifiers';
+import { buttonStyle, controlSize, tint, tag, padding, fixedSize } from '@expo/ui/swift-ui/modifiers';
 import { PROGRESS_FILTER_VALUES, SORT_OPTIONS, GRADE_ACCURACY_VALUES } from '@boardsesh/climb-filters';
 import { getFilterKey } from '../../lib/recent-filter-store';
 import {
@@ -126,8 +126,18 @@ function FilterChipRowComponent({
   return (
     <Host matchContents={{ vertical: true }} style={styles.host}>
       <ScrollView axes="horizontal" showsIndicators={false}>
-        {/* Vertical slack lets a pressed chip's Liquid Glass lens expand without the host's fixed height clipping it. */}
-        <HStack spacing={spacing[2]} modifiers={[padding({ horizontal: spacing[4], vertical: spacing[2] })]}>
+        {/* Vertical slack lets a pressed chip's Liquid Glass lens expand without the host's fixed height clipping it.
+            `fixedSize(horizontal)` is what keeps the labels whole: a horizontal ScrollView still proposes its own
+            (screen) width to the content, so without it the HStack squeezes every chip toward its minimum and the
+            labels truncate ("Filter…", "Colle…") even though the row overflows and scrolls anyway. Sizing the stack
+            to its ideal width lets each chip take the space its label needs and the ScrollView do the scrolling. */}
+        <HStack
+          spacing={spacing[2]}
+          modifiers={[
+            padding({ horizontal: spacing[4], vertical: spacing[2] }),
+            fixedSize({ horizontal: true, vertical: false }),
+          ]}
+        >
           {/* Filters · N → the long-tail sheet. A button, not a menu. */}
           <Button
             label={filtersLabel}

--- a/packages/mobile/src/components/you/LogbookChipRow.ios.tsx
+++ b/packages/mobile/src/components/you/LogbookChipRow.ios.tsx
@@ -30,6 +30,7 @@ import {
   menuActionDismissBehavior,
   labelStyle,
   accessibilityLabel,
+  fixedSize,
 } from '@expo/ui/swift-ui/modifiers';
 import { useTheme } from '../../providers/theme-provider';
 import { useGradeFormat } from '../../hooks/use-grade-format';
@@ -131,8 +132,17 @@ function LogbookChipRowComponent({
   return (
     <Host matchContents={{ vertical: true }} style={styles.host}>
       <ScrollView axes="horizontal" showsIndicators={false}>
-        {/* Vertical padding gives a pressed chip's glass lens room to expand. */}
-        <HStack spacing={spacing[2]} modifiers={[padding({ horizontal: spacing[4], vertical: spacing[2] })]}>
+        {/* Vertical padding gives a pressed chip's glass lens room to expand.
+            `fixedSize(horizontal)` keeps the labels whole: a horizontal ScrollView still proposes its own (screen)
+            width to the content, so without it the HStack squeezes every chip toward its minimum and the labels
+            truncate mid-word even though the row overflows and scrolls anyway (the same squeeze behind #3782). */}
+        <HStack
+          spacing={spacing[2]}
+          modifiers={[
+            padding({ horizontal: spacing[4], vertical: spacing[2] }),
+            fixedSize({ horizontal: true, vertical: false }),
+          ]}
+        >
           {/* Filter → the long-tail sheet. An action button, not a menu, and
               icon-only (see filterModifiers). Neutral glass until at least one
               facet is active, then amber — matching the climb search, where Filters

--- a/packages/mobile/src/components/you/__tests__/logbook-chip-row-filter-icon.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-chip-row-filter-icon.test.tsx
@@ -35,6 +35,7 @@ vi.mock('@expo/ui/swift-ui/modifiers', () => {
     menuActionDismissBehavior: make('menuActionDismissBehavior'),
     labelStyle: make('labelStyle'),
     accessibilityLabel: make('accessibilityLabel'),
+    fixedSize: make('fixedSize'),
   };
 });
 


### PR DESCRIPTION
## Summary

The quick-filter chips on the climbs list render as `Filter…`, `Rec…`, `Colle…` instead of `Filters`, `Recent`, `Collection`.

Cause is the SwiftUI layout, not the strings. A horizontal `ScrollView` still proposes its own (screen) width to its content, so the `HStack` of chips distributed that width across its children and squeezed each `Text` toward its minimum — every label truncated. The squeeze bought nothing, because there are more chips than fit either way: the row overflows and scrolls regardless.

Fix is `fixedSize({ horizontal: true, vertical: false })` on the `HStack` in both chip rows, so the stack sizes to its ideal width, each chip takes the space its label needs, and the `ScrollView` does the scrolling.

- `packages/mobile/src/components/search/FilterChipRow.ios.tsx` — the row in the screenshot.
- `packages/mobile/src/components/you/LogbookChipRow.ios.tsx` — same `Host` → horizontal `ScrollView` → `HStack` shape, same squeeze. This is also what collapsed its Filter chip to `F…` in #3782; that chip stays `labelStyle('iconOnly')` (Android parity), but the Latest / Hardest / Grade / Angle / Show / Date labels beside it were subject to the same compression.

Android is unaffected — Compose `Row` + `horizontalScroll` already gives children unbounded width. Expo-web is unaffected.

## Release Notes

- Filter chips on the climbs list and logbook show their full names again instead of cutting off mid-word

## Test plan

- `vp test run --project mobile` — 578 files, 5037 tests, all green. The first push was red here: `logbook-chip-row-filter-icon.test.tsx` stubs `@expo/ui/swift-ui/modifiers` with an explicit export list, so the new `fixedSize` import blew up all 5 cases. Added it to the mock in `c35c977`.
- `vp run typecheck:mobile` — clean.
- `vp check` on the three touched files — no format, lint, or type findings.
- Both component files are iOS-only platform forks that Vitest can't render natively; `FilterChipRow.logic.ts` is untouched, so its label tests still cover the wording. The visual result wants an eye on an iOS 26 build — chips should read `Filters` / `Recent` / `V5–V7` / `Unsent` / `Collection` in full with the row still scrolling past the right edge, and the same for You → logbook. This ships over OTA on `pr-4184`.