### PR TITLE
fix(mobile): keep the web loading splash off iOS and Android

### DIFF
--- a/packages/mobile/src/components/AppLoadingSplash.tsx
+++ b/packages/mobile/src/components/AppLoadingSplash.tsx
@@ -1,14 +1,19 @@
-import { View, StyleSheet } from 'react-native';
+import { Platform, View, StyleSheet } from 'react-native';
 import { BoardseshLogo } from './BoardseshLogo';
 
-// Full-screen placeholder shown while auth is still resolving. On native the OS
-// splash screen covers this until `SplashScreen.hideAsync()` runs (auth + fonts
-// ready), so it's never actually visible there. On web there is no native
-// splash, so a blank render leaves the page white until the session round-trip
-// finishes (~2s on a cold load) — this is what paints instead, giving an
-// immediate first contentful paint. Matches the expo-splash-screen config: the
-// Boardsesh mark centered on black, in both light and dark.
+// Full-screen placeholder shown while auth is still resolving — web only. On
+// web there is no native splash, so a blank render leaves the page white until
+// the session round-trip finishes (~2s on a cold load); this is what paints
+// instead, giving an immediate first contentful paint.
+//
+// On iOS / Android it renders nothing. The OS splash (expo-splash-screen) owns
+// that window and draws the same mark at `imageWidth: 200` — see the plugin
+// config in app.config.ts — so painting a second 96pt mark underneath means any
+// moment the two overlap (splash hand-off, or a later loading window such as a
+// re-auth after the splash is long gone) shows the logo jumping between sizes.
 export function AppLoadingSplash() {
+  if (Platform.OS !== 'web') return null;
+
   return (
     <View style={styles.container}>
       <BoardseshLogo size={96} />
@@ -22,7 +27,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     // Mirrors the expo-splash-screen backgroundColor (#000000, same for dark)
-    // so the hand-off from the native splash to this placeholder is seamless.
+    // so web opens on the same black the native launch screen uses.
     backgroundColor: '#000000',
   },
 });

--- a/packages/mobile/src/components/__tests__/app-loading-splash.test.tsx
+++ b/packages/mobile/src/components/__tests__/app-loading-splash.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 
@@ -26,8 +26,13 @@ vi.mock('../BoardseshLogo', () => ({
 import { AppLoadingSplash } from '../AppLoadingSplash';
 
 describe('AppLoadingSplash', () => {
-  it('paints the logo on web, where there is no OS splash to cover a blank render', () => {
+  // Each test sets the platform it needs; reset so a case that forgets can't
+  // inherit the previous one's OS.
+  beforeEach(() => {
     platformState.os = 'web';
+  });
+
+  it('paints the logo on web, where there is no OS splash to cover a blank render', () => {
     render(createElement(AppLoadingSplash));
 
     expect(screen.getByTestId('splash')).toBeTruthy();
@@ -38,6 +43,6 @@ describe('AppLoadingSplash', () => {
     platformState.os = os;
     const { container } = render(createElement(AppLoadingSplash));
 
-    expect(container.innerHTML).toBe('');
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/packages/mobile/src/components/__tests__/app-loading-splash.test.tsx
+++ b/packages/mobile/src/components/__tests__/app-loading-splash.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// Controls the platform branch under test.
+const platformState = vi.hoisted(() => ({ os: 'web' as string }));
+
+// Minimal RN surface: `View` becomes a <div> so the placeholder is queryable.
+vi.mock('react-native', () => ({
+  Platform: {
+    get OS() {
+      return platformState.os;
+    },
+  },
+  StyleSheet: { create: (styles: unknown) => styles },
+  View: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-testid': 'splash' }, children),
+}));
+
+// The real logo renders an expo-image the node/jsdom env can't load, and pulls
+// in a static png require Metro resolves but Vitest doesn't.
+vi.mock('../BoardseshLogo', () => ({
+  BoardseshLogo: ({ size }: { size?: number }) => createElement('span', { 'data-size': size }, 'logo'),
+}));
+
+import { AppLoadingSplash } from '../AppLoadingSplash';
+
+describe('AppLoadingSplash', () => {
+  it('paints the logo on web, where there is no OS splash to cover a blank render', () => {
+    platformState.os = 'web';
+    render(createElement(AppLoadingSplash));
+
+    expect(screen.getByTestId('splash')).toBeTruthy();
+    expect(screen.getByText('logo')).toBeTruthy();
+  });
+
+  it.each(['ios', 'android'])('renders nothing on %s, leaving the OS splash as the only mark', (os) => {
+    platformState.os = os;
+    const { container } = render(createElement(AppLoadingSplash));
+
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -943,7 +943,8 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
     // Not `null`: on web there's no native splash to cover a blank render, so
     // returning nothing here leaves the page white until the session round-trip
     // resolves (~2s cold). Paint the splash placeholder instead — instant FCP on
-    // web, invisible on native (the OS splash is still up). Redirect/auth logic
+    // web. AppLoadingSplash renders nothing on native, where expo-splash-screen
+    // owns this window and draws the mark at its own size. Redirect/auth logic
     // below is unchanged; it only runs once the session has actually resolved.
     return <AppLoadingSplash />;
   }


### PR DESCRIPTION
## Summary

`AppLoadingSplash` — the auth-loading placeholder added for Expo web — painted the Boardsesh mark at **96pt**, while `expo-splash-screen` draws the same mark at **`imageWidth: 200`** (`packages/mobile/app.config.ts`). Any moment the two overlap on native shows the logo jumping between sizes: the splash hand-off, or a later loading window (a re-auth that flips `isLoading` back to true) once the OS splash is long gone.

The placeholder only ever earned its keep on web, where there is no OS splash and returning `null` leaves the page white until the session round-trip resolves (~2s cold). So it now renders on web only and nothing on iOS / Android, where `expo-splash-screen` owns that window.

- `AppLoadingSplash` returns `null` unless `Platform.OS === 'web'`
- New `app-loading-splash.test.tsx` covers both branches (web paints the mark, ios/android render an empty tree)
- Comment in `auth-provider.tsx` updated — it claimed the native splash always covered this render

## Release Notes

- Fixed the app logo briefly resizing itself while the app started up.

## Test plan

- `vp run typecheck:mobile`
- `vp run test:mobile` (new `AppLoadingSplash` suite + the existing `AuthProvider loading state` suite)
- `vp run check:mobile-bundle`

Native behaviour is unchanged apart from the removed second mark — the OS splash still hides on `authReady && fontsReady` in `app/_layout.tsx`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XoE5qzC96B1VS81YE61PQ8)_