### PR TITLE
fix(web): allow Next.js dev server to accept Tailscale hostname origins

### DIFF
--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -43,6 +43,14 @@ export function resolveExpoWebDevOrigin(rawOrigin) {
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
+  // Dev-only: let the HMR + RSC-debug WebSockets complete when the page is
+  // opened via the machine's Tailscale hostname. Next dev only allows
+  // localhost origins by default and hangs the WS handshake for anything else;
+  // because the RSC debug channel rides the same transport, a blocked origin
+  // stops hydration entirely (SSR renders, zero client-side execution).
+  // scripts/dev-with-tailscale.ts sets DEV_ALLOWED_ORIGINS to the resolved
+  // Tailscale hostname; empty outside that flow (localhost stays allowed).
+  allowedDevOrigins: process.env.DEV_ALLOWED_ORIGINS ? process.env.DEV_ALLOWED_ORIGINS.split(',') : [],
   typescript: {
     // ignoreBuildErrors: true,
   },

--- a/packages/web/scripts/dev-with-tailscale.ts
+++ b/packages/web/scripts/dev-with-tailscale.ts
@@ -69,6 +69,11 @@ function main(): void {
   // the actual page origin in Tailscale / auto-incremented-port mode.
   overrideEnv('NEXTAUTH_URL', webOrigin);
   overrideEnv('BASE_URL', webOrigin);
+  // Next dev blocks non-localhost request origins by default, which hangs the
+  // HMR / RSC-debug WebSocket handshake and silently prevents hydration when
+  // the page is opened via the Tailscale hostname. next.config.mjs reads this
+  // into allowedDevOrigins.
+  overrideEnv('DEV_ALLOWED_ORIGINS', resolution.hostname);
 
   console.info(`[dev] Hostname: ${resolution.hostname} (${resolution.source})`);
   if (resolution.reason) {


### PR DESCRIPTION
## Summary

Next.js dev blocks non-localhost request origins for the HMR / RSC-debug WebSocket by default. When the dev server is accessed via a Tailscale hostname (via `dev-with-tailscale.ts`), the WS handshake hangs, preventing all client-side hydration — SSR renders the page but JS never executes.

- **`next.config.mjs`**: Reads the `DEV_ALLOWED_ORIGINS` env var (comma-separated) into Next.js's `allowedDevOrigins` config. This is a dev-only key — ignored in production builds.
- **`dev-with-tailscale.ts`**: Sets `DEV_ALLOWED_ORIGINS` to the resolved Tailscale hostname before spawning `next dev`.

Localhost dev is unaffected — `allowedDevOrigins` is an additive allowlist on top of localhost, and when the env var is unset the config defaults to `[]` (no-op).

## Release Notes

Tailscale dev servers now hydrate correctly — no more blank white pages when connecting over the tailnet.

## Test plan

- Ran `vp run dev` via localhost — confirmed HMR and client hydration work as before.
- Ran `vp run dev-with-tailscale` on a Tailscale-connected machine, accessed via the tailnet hostname — confirmed the page hydrates and HMR WebSocket connects.
- Verified that omitting `DEV_ALLOWED_ORIGINS` (no env var set) falls back to the default `[]`, leaving localhost dev unchanged.
