### PR TITLE
fix(ci): widen the OTA publish backoff to outlast S3 throttling

### DIFF
--- a/.github/workflows/mobile-ota-backport.yml
+++ b/.github/workflows/mobile-ota-backport.yml
@@ -102,7 +102,11 @@ jobs:
   backport:
     needs: setup
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # One platform per matrix job, so this needs a single 34-minute backoff
+    # budget rather than production's two. Derived and enforced in
+    # mobile-ota-publish-workflow.test.ts from the ladder in
+    # scripts/lib/mobile-publish-retry.ts.
+    timeout-minutes: 90
     # Gates EOO_TOKEN + GOOGLE_MAPS_API_KEY + the EXPO_UPDATES_URL variable.
     environment: Production
     strategy:

--- a/.github/workflows/mobile-ota-preview.yml
+++ b/.github/workflows/mobile-ota-preview.yml
@@ -260,9 +260,12 @@ jobs:
     needs: gate
     if: needs.gate.outputs.action == 'publish'
     runs-on: ubuntu-latest
-    # Each platform may perform four attempts with 210 seconds of backoff. The
-    # job publishes iOS then Android, so leave room for both bounded retry sets.
-    timeout-minutes: 60
+    # Each platform may perform six attempts with 34 minutes of backoff. The job
+    # publishes iOS then Android, so leave room for both bounded retry sets — a
+    # job killed mid-backoff dies by timeout instead of reporting `s3-slowdown`.
+    # Derived and enforced in mobile-ota-publish-workflow.test.ts from the ladder
+    # in scripts/lib/mobile-publish-retry.ts.
+    timeout-minutes: 150
     # This job runs PR-author code with EOO_TOKEN, so its workflow-token scope is capped
     # at the minimum: read the tree, write the pr-preview deployment. NO issues /
     # pull-requests write — those stay on the trusted announce / cleanup jobs.

--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -101,9 +101,16 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    # Four attempts per platform can spend 210 seconds in backoff alone, before
-    # two sequential exports/uploads. Leave enough room for the bounded retries.
-    timeout-minutes: 60
+    # Six attempts per platform can spend 34 minutes in backoff alone, and iOS
+    # and Android each get that budget sequentially — a fully throttled run is
+    # ~98 minutes of publishing plus setup, changelog, source maps and the health
+    # check. This ceiling must stay above the retry budget: if the job is killed
+    # mid-backoff the run dies by timeout instead of reporting `s3-slowdown`,
+    # losing both the diagnosis and the failure notification. Derived and
+    # enforced in mobile-ota-publish-workflow.test.ts from the ladder in
+    # scripts/lib/mobile-publish-retry.ts — raise both together or not at all.
+    # Costs nothing on a healthy publish, which finishes in well under 10 minutes.
+    timeout-minutes: 150
     # Gates EOO_TOKEN + GOOGLE_MAPS_API_KEY + the EXPO_UPDATES_URL variable.
     environment: Production
 

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -161,11 +161,29 @@ each `eoas publish` removes and recreates `packages/mobile/dist`, so the second 
 the first platform's source maps before they reached Sentry.
 
 **Transient upload failures** are retried only when eoas output contains the exact S3 SlowDown XML
-response or an explicit HTTP 5xx status. Each platform gets at most four attempts, with 30, 60, and
-120 second waits. HTTP 4xx, authentication, configuration, export/build errors, unknown failures,
-and mixed permanent/retryable evidence fail immediately. Child output stays live and is not echoed
-again from a captured tail. The EAS-hosted preview path (`eas update`) is unchanged and does not use
-these retries.
+response or an explicit HTTP 5xx status. Each platform gets at most six attempts, with 1, 3, 5, 10,
+and 15 minute waits — 34 minutes of backoff per platform. HTTP 4xx, authentication, configuration,
+export/build errors, unknown failures, and mixed permanent/retryable evidence fail immediately.
+Child output stays live and is not echoed again from a captured tail. The EAS-hosted preview path
+(`eas update`) is unchanged and does not use these retries.
+
+The ladder is sized against the object store's observed cooldown rather than a guess. Two production
+incidents (2026-07-15 run 29387706795, 2026-08-03 run 30855435091) throttled every attempt across a
+~17 minute window and only published after a cool-down; the earlier 30/60/120 second ladder gave up
+about 8 minutes in, so both needed a manual re-run. Waiting is the only lever available on this side
+of the process boundary: `eoas` uploads every asset (380 in a current bundle) through one unbounded
+`Promise.all`, and its `fetchWithRetries` retries network errors only — never an HTTP status — so a
+single 503 `SlowDown` response calls `process.exit(1)` and kills the publish. A whole-command retry
+re-runs the Metro export and re-fires the identical burst, which is what trips the limit, so shorter
+waits just fail faster. This is unchanged in `eoas@3.1.1`; capping upload concurrency needs an
+upstream expo-open-ota change (tracked by the reopened [#3620](https://github.com/boardsesh/boardsesh/issues/3620)).
+
+Because both budgets are spent sequentially, a fully throttled production run can take ~98 minutes
+before it reports failure. The publish jobs' `timeout-minutes` must stay above that: a job killed
+mid-backoff dies by timeout, losing both the `s3-slowdown` diagnosis and the failure notification.
+`scripts/mobile-ota-publish-workflow.test.ts` derives each floor from the ladder via
+`minimumPublishJobTimeoutMinutes()`, so widening the budget again fails CI until the timeouts follow.
+None of this costs anything on a healthy publish, which never sleeps and finishes in under 10 minutes.
 
 When both platforms are requested, iOS then Android publish sequentially and Android still runs if
 iOS fails. The run fails unless every requested platform succeeds, but it does not automatically

--- a/scripts/lib/mobile-publish-retry.test.ts
+++ b/scripts/lib/mobile-publish-retry.test.ts
@@ -6,8 +6,10 @@ import {
   PublishFailureEvidenceScanner,
   publishPlatformsSequentially,
   publishSelfHostedPlatformWithRetry,
+  minimumPublishJobTimeoutMinutes,
   SELF_HOSTED_PUBLISH_MAX_ATTEMPTS,
   SELF_HOSTED_PUBLISH_RETRY_DELAYS_MS,
+  SELF_HOSTED_PUBLISH_WORST_CASE_MINUTES_PER_PLATFORM,
   type PublishCommandRunner,
   type TextOutput,
 } from './mobile-publish-retry';
@@ -55,8 +57,38 @@ describe('self-hosted publish failure classification', () => {
   });
 });
 
+describe('self-hosted publish backoff budget', () => {
+  // The point of the ladder is to outlast the object store's throttle, not just
+  // to retry. Run 30855435091 stayed throttled across a 17-minute window and the
+  // 30/60/120s ladder gave up ~8 minutes in; anything under 30 minutes of total
+  // backoff would reintroduce that failure.
+  const OBSERVED_THROTTLE_WINDOW_MINUTES = 17;
+
+  it('waits longer than the observed throttle window', () => {
+    const totalBackoffMinutes =
+      SELF_HOSTED_PUBLISH_RETRY_DELAYS_MS.reduce((total, delayMs) => total + delayMs, 0) / 60_000;
+    expect(totalBackoffMinutes).toBeGreaterThan(OBSERVED_THROTTLE_WINDOW_MINUTES);
+    expect(totalBackoffMinutes).toBeGreaterThanOrEqual(30);
+  });
+
+  it('grows the delays monotonically so early failures still retry quickly', () => {
+    const delays = [...SELF_HOSTED_PUBLISH_RETRY_DELAYS_MS];
+    expect(delays.length).toBeGreaterThan(0);
+    expect(delays[0]).toBeLessThanOrEqual(60_000);
+    for (let index = 1; index < delays.length; index++) {
+      expect(delays[index]).toBeGreaterThanOrEqual(delays[index - 1]);
+    }
+  });
+
+  it('derives a job timeout floor that scales with the platforms a job publishes', () => {
+    expect(minimumPublishJobTimeoutMinutes(2)).toBeGreaterThan(minimumPublishJobTimeoutMinutes(1));
+    expect(minimumPublishJobTimeoutMinutes(1)).toBeGreaterThan(SELF_HOSTED_PUBLISH_WORST_CASE_MINUTES_PER_PLATFORM);
+    expect(Number.isInteger(minimumPublishJobTimeoutMinutes(2))).toBe(true);
+  });
+});
+
 describe('self-hosted publish retries', () => {
-  it('uses four total attempts with 30/60/120 second backoff', async () => {
+  it('retries through the whole backoff ladder before succeeding', async () => {
     const attempts: number[] = [];
     const runner: PublishCommandRunner = async ({ onStderr }) => {
       attempts.push(attempts.length + 1);
@@ -75,8 +107,13 @@ describe('self-hosted publish retries', () => {
       { runner, sleeper, stdout: stdout.output, stderr: stderr.output },
     );
 
-    expect(outcome).toEqual({ platform: 'ios', success: true, attempts: 4, failureKind: null });
-    expect(attempts).toHaveLength(4);
+    expect(outcome).toEqual({
+      platform: 'ios',
+      success: true,
+      attempts: SELF_HOSTED_PUBLISH_MAX_ATTEMPTS,
+      failureKind: null,
+    });
+    expect(attempts).toHaveLength(SELF_HOSTED_PUBLISH_MAX_ATTEMPTS);
     expect(sleeper.mock.calls.map(([delayMs]) => delayMs)).toEqual([...SELF_HOSTED_PUBLISH_RETRY_DELAYS_MS]);
   });
 

--- a/scripts/lib/mobile-publish-retry.test.ts
+++ b/scripts/lib/mobile-publish-retry.test.ts
@@ -81,9 +81,17 @@ describe('self-hosted publish backoff budget', () => {
   });
 
   it('derives a job timeout floor that scales with the platforms a job publishes', () => {
-    expect(minimumPublishJobTimeoutMinutes(2)).toBeGreaterThan(minimumPublishJobTimeoutMinutes(1));
-    expect(minimumPublishJobTimeoutMinutes(1)).toBeGreaterThan(SELF_HOSTED_PUBLISH_WORST_CASE_MINUTES_PER_PLATFORM);
-    expect(Number.isInteger(minimumPublishJobTimeoutMinutes(2))).toBe(true);
+    // Each extra platform a job publishes must add that platform's whole worst
+    // case to the floor. A floor that grew by less would let a two-platform job
+    // be sized as if the second platform retried for free.
+    const onePlatformFloor = minimumPublishJobTimeoutMinutes(1);
+    const twoPlatformFloor = minimumPublishJobTimeoutMinutes(2);
+    expect(twoPlatformFloor - onePlatformFloor).toBeGreaterThanOrEqual(
+      Math.floor(SELF_HOSTED_PUBLISH_WORST_CASE_MINUTES_PER_PLATFORM),
+    );
+    // Whole minutes only — `timeout-minutes` rejects a fraction.
+    expect(Number.isInteger(twoPlatformFloor)).toBe(true);
+    expect(Number.isInteger(onePlatformFloor)).toBe(true);
   });
 });
 

--- a/scripts/lib/mobile-publish-retry.ts
+++ b/scripts/lib/mobile-publish-retry.ts
@@ -11,49 +11,35 @@
 import { spawn } from 'node:child_process';
 
 /**
- * Backoff ladder for one platform, in wait order.
- *
- * Sized against the object store's observed cooldown, not against a guess. Two
- * production incidents (2026-07-15, run 29387706795; 2026-08-03, run
- * 30855435091) both throttled every attempt across a ~17 minute window and both
- * only published after a cool-down — the second cleared somewhere between 17 and
- * 50 minutes after the first SlowDown. The previous 30/60/120s ladder gave up
- * ~8 minutes in, so it never outlasted either window and a human had to re-run.
- *
- * These waits total 34 minutes per platform, which covers the longer observed
- * cooldown. They cost nothing on a healthy publish: a first-attempt success
- * never sleeps, and the last four production runs all published on attempt 1.
- *
- * A whole-command retry re-runs the Metro export and re-fires the same burst of
- * per-asset PUTs, which is what trips the limit in the first place (eoas uploads
- * every asset through one unbounded Promise.all and never retries a 503 itself).
- * Waiting longer between attempts is therefore the only lever this side of the
- * process boundary — do not shorten these to make a throttled run finish sooner.
- *
- * Keep in step with `timeout-minutes` on the production workflow's publish job;
- * mobile-ota-publish-workflow.test.ts derives the floor from these numbers and
- * fails if the budget outgrows the job.
+ * Backoff ladder for one platform, in wait order: 34 minutes total, sized to
+ * outlast the object store's observed throttle cooldown (runs 29387706795 and
+ * 30855435091 both stayed throttled ~17 minutes; the old 30/60/120s ladder gave
+ * up ~8 minutes in and needed a manual re-run). Do not shorten these — a retry
+ * re-fires the same asset-upload burst that trips the limit, so waiting is the
+ * only lever here. Rationale and the upstream eoas bugs: docs/mobile-ota-updates.md.
  */
 export const SELF_HOSTED_PUBLISH_RETRY_DELAYS_MS = [60_000, 180_000, 300_000, 600_000, 900_000] as const;
 export const SELF_HOSTED_PUBLISH_MAX_ATTEMPTS = SELF_HOSTED_PUBLISH_RETRY_DELAYS_MS.length + 1;
 
 /**
- * Worst-case wall clock one platform can spend retrying, in minutes: every wait
- * plus a failed attempt's own export/upload before each one. ~2.5 minutes per
- * throttled attempt is the measured cost from run 30855435091 (a ~90s Metro
- * export, then uploads until the store rejects one).
+ * Measured cost of one throttled attempt (run 30855435091): a ~90s Metro export,
+ * then uploads until the store rejects one.
  */
 export const SELF_HOSTED_PUBLISH_ATTEMPT_COST_MINUTES = 2.5;
+
+/** Every wait plus the failed attempt that precedes each one. */
 export const SELF_HOSTED_PUBLISH_WORST_CASE_MINUTES_PER_PLATFORM =
   SELF_HOSTED_PUBLISH_RETRY_DELAYS_MS.reduce((total, delayMs) => total + delayMs, 0) / 60_000 +
   SELF_HOSTED_PUBLISH_MAX_ATTEMPTS * SELF_HOSTED_PUBLISH_ATTEMPT_COST_MINUTES;
 
 /**
- * Everything a publish job does around the publish steps themselves: checkout,
- * setup-vp/bun, `bun install`, the changelog build, up to two 10-minute
- * source-map uploads, and the health check.
+ * Everything a publish job does around the publish steps themselves. Dominated
+ * by the two source-map uploads, which carry their own `timeout-minutes` in the
+ * workflow; the rest (checkout, setup-vp/bun, `bun install`, changelog, health
+ * check) measured ~3 minutes in run 30855435091. mobile-ota-publish-workflow.test.ts
+ * re-reads those step timeouts and fails if they outgrow this allowance.
  */
-export const SELF_HOSTED_PUBLISH_JOB_OVERHEAD_MINUTES = 25;
+export const SELF_HOSTED_PUBLISH_JOB_OVERHEAD_MINUTES = 30;
 
 /**
  * Minimum `timeout-minutes` a publish job needs so a fully throttled run still

--- a/scripts/lib/mobile-publish-retry.ts
+++ b/scripts/lib/mobile-publish-retry.ts
@@ -10,8 +10,64 @@
 
 import { spawn } from 'node:child_process';
 
-export const SELF_HOSTED_PUBLISH_RETRY_DELAYS_MS = [30_000, 60_000, 120_000] as const;
+/**
+ * Backoff ladder for one platform, in wait order.
+ *
+ * Sized against the object store's observed cooldown, not against a guess. Two
+ * production incidents (2026-07-15, run 29387706795; 2026-08-03, run
+ * 30855435091) both throttled every attempt across a ~17 minute window and both
+ * only published after a cool-down — the second cleared somewhere between 17 and
+ * 50 minutes after the first SlowDown. The previous 30/60/120s ladder gave up
+ * ~8 minutes in, so it never outlasted either window and a human had to re-run.
+ *
+ * These waits total 34 minutes per platform, which covers the longer observed
+ * cooldown. They cost nothing on a healthy publish: a first-attempt success
+ * never sleeps, and the last four production runs all published on attempt 1.
+ *
+ * A whole-command retry re-runs the Metro export and re-fires the same burst of
+ * per-asset PUTs, which is what trips the limit in the first place (eoas uploads
+ * every asset through one unbounded Promise.all and never retries a 503 itself).
+ * Waiting longer between attempts is therefore the only lever this side of the
+ * process boundary — do not shorten these to make a throttled run finish sooner.
+ *
+ * Keep in step with `timeout-minutes` on the production workflow's publish job;
+ * mobile-ota-publish-workflow.test.ts derives the floor from these numbers and
+ * fails if the budget outgrows the job.
+ */
+export const SELF_HOSTED_PUBLISH_RETRY_DELAYS_MS = [60_000, 180_000, 300_000, 600_000, 900_000] as const;
 export const SELF_HOSTED_PUBLISH_MAX_ATTEMPTS = SELF_HOSTED_PUBLISH_RETRY_DELAYS_MS.length + 1;
+
+/**
+ * Worst-case wall clock one platform can spend retrying, in minutes: every wait
+ * plus a failed attempt's own export/upload before each one. ~2.5 minutes per
+ * throttled attempt is the measured cost from run 30855435091 (a ~90s Metro
+ * export, then uploads until the store rejects one).
+ */
+export const SELF_HOSTED_PUBLISH_ATTEMPT_COST_MINUTES = 2.5;
+export const SELF_HOSTED_PUBLISH_WORST_CASE_MINUTES_PER_PLATFORM =
+  SELF_HOSTED_PUBLISH_RETRY_DELAYS_MS.reduce((total, delayMs) => total + delayMs, 0) / 60_000 +
+  SELF_HOSTED_PUBLISH_MAX_ATTEMPTS * SELF_HOSTED_PUBLISH_ATTEMPT_COST_MINUTES;
+
+/**
+ * Everything a publish job does around the publish steps themselves: checkout,
+ * setup-vp/bun, `bun install`, the changelog build, up to two 10-minute
+ * source-map uploads, and the health check.
+ */
+export const SELF_HOSTED_PUBLISH_JOB_OVERHEAD_MINUTES = 25;
+
+/**
+ * Minimum `timeout-minutes` a publish job needs so a fully throttled run still
+ * reaches the retry wrapper's own verdict instead of being killed mid-backoff.
+ * `platforms` is how many platforms one job publishes sequentially: production
+ * and preview do iOS then Android in a single job, backport fans out one
+ * platform per matrix job.
+ */
+export function minimumPublishJobTimeoutMinutes(platforms: number): number {
+  return (
+    Math.ceil(platforms * SELF_HOSTED_PUBLISH_WORST_CASE_MINUTES_PER_PLATFORM) +
+    SELF_HOSTED_PUBLISH_JOB_OVERHEAD_MINUTES
+  );
+}
 
 export type OtaPublishPlatform = 'ios' | 'android';
 export type PublishFailureKind = 's3-slowdown' | 'http-5xx' | 'permanent' | 'unknown';

--- a/scripts/lib/mobile-publish-retry.ts
+++ b/scripts/lib/mobile-publish-retry.ts
@@ -23,7 +23,10 @@ export const SELF_HOSTED_PUBLISH_MAX_ATTEMPTS = SELF_HOSTED_PUBLISH_RETRY_DELAYS
 
 /**
  * Measured cost of one throttled attempt (run 30855435091): a ~90s Metro export,
- * then uploads until the store rejects one.
+ * then uploads until the store rejects one. This is an observed floor, not a
+ * ceiling — a bigger bundle or a slower runner pushes it up, which eats into the
+ * headroom between a job's derived timeout floor and its actual `timeout-minutes`.
+ * If publishes get materially slower, re-measure this before trusting the floor.
  */
 export const SELF_HOSTED_PUBLISH_ATTEMPT_COST_MINUTES = 2.5;
 

--- a/scripts/mobile-ota-publish-workflow.test.ts
+++ b/scripts/mobile-ota-publish-workflow.test.ts
@@ -5,7 +5,7 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-import { minimumPublishJobTimeoutMinutes } from './lib/mobile-publish-retry';
+import { minimumPublishJobTimeoutMinutes, SELF_HOSTED_PUBLISH_JOB_OVERHEAD_MINUTES } from './lib/mobile-publish-retry';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const WORKFLOW_DIR = resolve(REPO_ROOT, '.github', 'workflows');
@@ -41,6 +41,21 @@ describe('production OTA workflow reliability', () => {
     // budgets. Killed mid-backoff, the run dies by timeout and never reports
     // `s3-slowdown` or fires the failure notification.
     expect(timeout).toBeGreaterThanOrEqual(minimumPublishJobTimeoutMinutes(2));
+  });
+
+  it('keeps the job-overhead allowance above the steps it is meant to cover', () => {
+    // SELF_HOSTED_PUBLISH_JOB_OVERHEAD_MINUTES is an estimate, and the source-map
+    // uploads are the bulk of it. They carry their own `timeout-minutes`, so
+    // raising those silently erodes the headroom every publish job's timeout is
+    // derived from. Re-read them here instead of trusting the constant's comment.
+    const publishJob = jobBlock(production, 'publish');
+    const stepTimeouts = [...publishJob.matchAll(/^\s+timeout-minutes: (\d+)$/gm)]
+      .map(([, minutes]) => Number(minutes))
+      .slice(1); // drop the job's own timeout; keep the per-step ones
+    const stepTimeoutTotal = stepTimeouts.reduce((total, minutes) => total + minutes, 0);
+
+    expect(stepTimeouts.length).toBeGreaterThanOrEqual(2);
+    expect(SELF_HOSTED_PUBLISH_JOB_OVERHEAD_MINUTES).toBeGreaterThan(stepTimeoutTotal);
   });
 
   it('attempts Android after iOS and records the aggregate result', () => {

--- a/scripts/mobile-ota-publish-workflow.test.ts
+++ b/scripts/mobile-ota-publish-workflow.test.ts
@@ -5,6 +5,8 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
+import { minimumPublishJobTimeoutMinutes } from './lib/mobile-publish-retry';
+
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const WORKFLOW_DIR = resolve(REPO_ROOT, '.github', 'workflows');
 const production = readFileSync(resolve(WORKFLOW_DIR, 'mobile-ota-production.yml'), 'utf8');
@@ -35,7 +37,10 @@ describe('production OTA workflow reliability', () => {
     expect(production).toContain('group: mobile-ota-production');
     expect(production).toContain('cancel-in-progress: false');
     const timeout = Number(jobBlock(production, 'publish').match(/timeout-minutes: (\d+)/)?.[1]);
-    expect(timeout).toBeGreaterThanOrEqual(45);
+    // iOS then Android in one job, so the job must outlast two full backoff
+    // budgets. Killed mid-backoff, the run dies by timeout and never reports
+    // `s3-slowdown` or fires the failure notification.
+    expect(timeout).toBeGreaterThanOrEqual(minimumPublishJobTimeoutMinutes(2));
   });
 
   it('attempts Android after iOS and records the aggregate result', () => {
@@ -97,7 +102,8 @@ describe('production OTA workflow reliability', () => {
 
   it('gives the preview publish job enough time for bounded platform retries', () => {
     const timeout = Number(jobBlock(preview, 'publish').match(/timeout-minutes: (\d+)/)?.[1]);
-    expect(timeout).toBeGreaterThanOrEqual(45);
+    // Same shape as production: one job publishes both platforms sequentially.
+    expect(timeout).toBeGreaterThanOrEqual(minimumPublishJobTimeoutMinutes(2));
   });
 });
 
@@ -113,7 +119,9 @@ describe('backport OTA workflow upload pressure', () => {
     expect(backport).toContain('cancel-in-progress: false');
     expect(backport).toContain('max-parallel: 1');
     const timeout = Number(jobBlock(backport, 'backport').match(/timeout-minutes: (\d+)/)?.[1]);
-    expect(timeout).toBeGreaterThanOrEqual(45);
+    // `max-parallel: 1` over a platform matrix, so each job publishes one
+    // platform and needs one backoff budget rather than two.
+    expect(timeout).toBeGreaterThanOrEqual(minimumPublishJobTimeoutMinutes(1));
   });
 
   it('overlays every trusted helper required by production publish and source-map upload', () => {

--- a/scripts/mobile-ota-publish-workflow.test.ts
+++ b/scripts/mobile-ota-publish-workflow.test.ts
@@ -48,11 +48,20 @@ describe('production OTA workflow reliability', () => {
     // uploads are the bulk of it. They carry their own `timeout-minutes`, so
     // raising those silently erodes the headroom every publish job's timeout is
     // derived from. Re-read them here instead of trusting the constant's comment.
+    // Select by indentation rather than by position: a job-level key sits at 4
+    // spaces and a step-level one at 8, so this stays correct no matter what
+    // order the keys appear in.
     const publishJob = jobBlock(production, 'publish');
-    const stepTimeouts = [...publishJob.matchAll(/^\s+timeout-minutes: (\d+)$/gm)]
-      .map(([, minutes]) => Number(minutes))
-      .slice(1); // drop the job's own timeout; keep the per-step ones
+    const stepTimeouts = [...publishJob.matchAll(/^ {8}timeout-minutes: (\d+)$/gm)].map(([, minutes]) =>
+      Number(minutes),
+    );
     const stepTimeoutTotal = stepTimeouts.reduce((total, minutes) => total + minutes, 0);
+
+    // Guard the selector itself: the job-level timeout must not be in this set,
+    // otherwise the comparison below would be measuring the wrong thing.
+    const jobTimeout = Number(publishJob.match(/^ {4}timeout-minutes: (\d+)$/m)?.[1]);
+    expect(jobTimeout).toBeGreaterThan(0);
+    expect(stepTimeouts).not.toContain(jobTimeout);
 
     expect(stepTimeouts.length).toBeGreaterThanOrEqual(2);
     expect(SELF_HOSTED_PUBLISH_JOB_OVERHEAD_MINUTES).toBeGreaterThan(stepTimeoutTotal);


### PR DESCRIPTION
## Summary

Production OTA run [30855435091](https://github.com/boardsesh/boardsesh/actions/runs/30855435091) failed both platforms on `1e7932c9d`. Tigris returned `SlowDown` on asset upload for all eight attempts (4 iOS + 4 Android) across a 17-minute window. A manual re-run an hour later published both platforms on the **first** attempt, so the bundle was fine — the object store was throttling and we gave up too early.

This is the second time. Run [29387706795](https://github.com/boardsesh/boardsesh/actions/runs/29387706795) on 2026-07-15 failed the same way, which is what #3620 was filed for.

**The retry wrapper worked; it just ran out of budget.** It classified the failure as `s3-slowdown` and backed off on schedule. But the 30/60/120s ladder gives up about 8 minutes in, and both cooldowns took tens of minutes to clear — so both incidents ended with a human pressing re-run.

### What changed

**Widen the ladder to 1/3/5/10/15 minutes** — six attempts, 34 minutes of backoff per platform, which covers the observed cooldown. This costs nothing on a healthy publish: a first-attempt success never sleeps, and the four production runs before this incident all published on attempt 1.

**Raise the three publish jobs' `timeout-minutes` to match** (production and preview 60 → 150, backport 45 → 90). That coupling used to be a comment — *"Four attempts per platform can spend 210 seconds in backoff alone"* — with nothing enforcing it, and it matters: a job killed mid-backoff dies by **timeout** instead of reporting `s3-slowdown`, losing both the diagnosis and the failure notification. `minimumPublishJobTimeoutMinutes()` now derives each floor from the ladder and the workflow test asserts it per job, scaled by how many platforms that job publishes — production and preview do both in one job, backport fans out one platform per matrix job. Widening the budget again now fails CI until the timeouts follow.

### Why waiting is the only lever

I unpacked `eoas@3.0.5` to check whether we could just upload more politely. Two upstream bugs combine to make a single throttle fatal:

- `dist/commands/publish.js` uploads every asset through one unbounded `Promise.all` — 380 assets in a current bundle, so 380 concurrent PUTs in one burst. That's what trips the limit.
- `dist/lib/fetch.js` — `fetchWithRetries` has `retryOn: (attempt, error) => { if (error) return true; return false; }`. It retries **network errors only, never an HTTP status**. A 503 falls straight through to `!response.ok` → `process.exit(1)`, killing the publish on the first throttled asset.

Both are byte-identical in `eoas@3.1.1` (latest), so upgrading doesn't help. And because a whole-command retry re-runs the Metro export and re-fires the identical burst, shorter waits just fail faster.

Capping upload concurrency — item 2 of #3620, the only thing that stops the burst at the source — needs an upstream expo-open-ota change, so **#3620 stays open** for it. This PR buys reliability with patience in the meantime.

### Trade-off

A fully throttled production run now takes ~98 minutes to report failure instead of ~17, and it holds the `mobile-ota-production` concurrency lane (`cancel-in-progress: false`) for that whole time, delaying the next push's OTA. That is the cost of not needing a human to re-run. Healthy publishes are unaffected — they finish in under 10 minutes and never sleep.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run scripts/` — 39 files, 492 tests pass. New coverage: the ladder outlasts the observed 17-minute throttle window, delays grow monotonically, and the derived job-timeout floor scales with platform count.
- `vp run typecheck` — clean.
- `vp check` — 18 errors / 299 warnings against a baseline of 20 / 299 on unmodified `main`: **a strict subset, this branch adds none.** (All pre-existing `ProcessEnv.NODE_ENV` findings across the Sentry/commit-msg scripts. The 2 missing vs baseline are `@gorhom/bottom-sheet` resolution errors, an artifact of which worktree has the nested `packages/mobile/web-runtime` install — not this change.)
- Existing retry unit tests now assert against `SELF_HOSTED_PUBLISH_MAX_ATTEMPTS` rather than a hardcoded `4`, so the ladder length is no longer duplicated in test expectations.

Not exercised end-to-end: reproducing a live `SlowDown` would mean deliberately hammering the production bucket. The classifier path itself is unchanged and already covered by fixture tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCvj4xfgmq2NBnYaQQwvfN
