### PR TITLE
fix(backend): stop losing bug reports to enrichment validation

### DIFF
--- a/packages/backend/src/__tests__/feedback-validation.test.ts
+++ b/packages/backend/src/__tests__/feedback-validation.test.ts
@@ -136,44 +136,116 @@ describe('SubmitAppFeedbackInputSchema', () => {
       expect(result.success).toBe(true);
     });
 
-    it('rejects a board name longer than 100 chars (cheap abuse guard)', () => {
+    it('accepts an arbitrary number of setIds (BOARDSESH-84: the 16 cap ate bug reports)', () => {
       const result = SubmitAppFeedbackInputSchema.safeParse({
         ...BASE,
-        rating: 5,
-        source: 'prompt',
-        boardName: 'x'.repeat(101),
+        comment: 'switch board did nothing',
+        source: 'shake-bug',
+        setIds: Array.from({ length: 20 }, (_, index) => index + 1),
       });
-      expect(result.success).toBe(false);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.setIds).toHaveLength(20);
+      }
     });
 
-    it('rejects an empty-string board name (use null instead of "")', () => {
+    it('truncates an absurd setIds list rather than dropping the report', () => {
       const result = SubmitAppFeedbackInputSchema.safeParse({
         ...BASE,
-        rating: 5,
-        source: 'prompt',
+        comment: 'switch board did nothing',
+        source: 'shake-bug',
+        setIds: Array.from({ length: 500 }, (_, index) => index + 1),
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.setIds).toHaveLength(64);
+      }
+    });
+  });
+
+  // The report is the payload; the board context around it is triage garnish. No
+  // enrichment field may fail the parse — see the `bestEffort` note in
+  // validation/schemas/feedback.ts and Sentry BOARDSESH-84.
+  describe('enrichment degrades instead of rejecting', () => {
+    const BUG = { ...BASE, comment: 'switch board did nothing', source: 'shake-bug' as const };
+
+    it('drops a board name past the abuse guard', () => {
+      const result = SubmitAppFeedbackInputSchema.safeParse({ ...BUG, boardName: 'x'.repeat(101) });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.boardName).toBeNull();
+    });
+
+    it('drops an empty-string board name', () => {
+      const result = SubmitAppFeedbackInputSchema.safeParse({ ...BUG, boardName: '' });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.boardName).toBeNull();
+    });
+
+    it('drops an out-of-range angle', () => {
+      const result = SubmitAppFeedbackInputSchema.safeParse({ ...BUG, angle: 360 });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.angle).toBeNull();
+    });
+
+    it('drops a wrong-typed layoutId', () => {
+      const result = SubmitAppFeedbackInputSchema.safeParse({ ...BUG, layoutId: 'one' });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.layoutId).toBeNull();
+    });
+
+    it('strips unknown context keys instead of rejecting (newer client, older server)', () => {
+      const result = SubmitAppFeedbackInputSchema.safeParse({
+        ...BUG,
+        context: { sessionId: 'sess-1', sneaky: 'payload' },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.context?.sessionId).toBe('sess-1');
+        expect(result.data.context).not.toHaveProperty('sneaky');
+      }
+    });
+
+    it('drops context entirely when it is not even an object', () => {
+      const result = SubmitAppFeedbackInputSchema.safeParse({ ...BUG, context: 'nope' });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.context).toBeNull();
+    });
+
+    it('survives every enrichment field being garbage at once', () => {
+      const result = SubmitAppFeedbackInputSchema.safeParse({
+        ...BUG,
+        appVersion: 'v'.repeat(200),
         boardName: '',
+        layoutId: {},
+        sizeId: 'big',
+        setIds: 'not-an-array',
+        angle: -5,
+        context: 42,
+        contactConsent: 'yes',
       });
-      expect(result.success).toBe(false);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.comment).toBe('switch board did nothing');
+        expect(result.data.source).toBe('shake-bug');
+      }
     });
 
-    it('rejects an out-of-range angle', () => {
+    it('clips an over-long comment rather than losing the report', () => {
       const result = SubmitAppFeedbackInputSchema.safeParse({
         ...BASE,
-        rating: 5,
-        source: 'prompt',
-        angle: 360,
+        comment: 'x'.repeat(5000),
+        source: 'shake-bug',
       });
-      expect(result.success).toBe(false);
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.comment).toHaveLength(2000);
     });
 
-    it('rejects context with unknown keys', () => {
-      const result = SubmitAppFeedbackInputSchema.safeParse({
-        ...BASE,
-        rating: 5,
-        source: 'prompt',
-        context: { sneaky: 'payload' },
-      });
-      expect(result.success).toBe(false);
+    it('still rejects a submission missing the load-bearing fields', () => {
+      expect(SubmitAppFeedbackInputSchema.safeParse({ ...BASE, source: 'shake-bug' }).success).toBe(false);
+      expect(SubmitAppFeedbackInputSchema.safeParse({ ...BASE, rating: 5 }).success).toBe(false);
+      expect(SubmitAppFeedbackInputSchema.safeParse({ comment: 'a'.repeat(20), source: 'shake-bug' }).success).toBe(
+        false,
+      );
     });
   });
 });

--- a/packages/backend/src/validation/schemas/feedback.ts
+++ b/packages/backend/src/validation/schemas/feedback.ts
@@ -3,32 +3,72 @@ import { z } from 'zod';
 const RATING_SOURCES = ['prompt', 'drawer-feedback'] as const;
 const BUG_SOURCES = ['shake-bug', 'drawer-bug'] as const;
 
-const FeedbackContextInputSchema = z
-  .object({
-    climbUuid: z.string().max(64).optional().nullable(),
-    climbName: z.string().max(200).optional().nullable(),
-    difficulty: z.string().max(32).optional().nullable(),
-    sessionId: z.string().max(64).optional().nullable(),
-    sessionName: z.string().max(200).optional().nullable(),
-    url: z.string().max(1000).optional().nullable(),
-    userAgent: z.string().max(512).optional().nullable(),
-  })
-  .strict();
+const COMMENT_MAX = 2000;
+// An abuse bound, not a domain bound. Real boards carry a handful of sets; the
+// old bound of 16 was sized to the domain and a board that exceeded it cost us
+// the whole report (see `bestEffort`).
+const SET_IDS_MAX = 64;
+
+/**
+ * Diagnostic enrichment is never fatal.
+ *
+ * The report itself — `source`, `comment`, `platform` — is the payload. The board
+ * context wrapped around it (which board, which layout, what angle) is a
+ * nice-to-have that helps triage. Rejecting the mutation because one of those
+ * optional fields failed validation throws away the thing we actually wanted.
+ *
+ * That is not hypothetical: `setIds` was capped at 16 entries, and on 2026-08-03 a
+ * user on a board with more sets than that hit the cap four times in a row while
+ * trying to report a crash (Sentry BOARDSESH-84). Every one of those reports was
+ * discarded, and the user got a generic failure.
+ *
+ * So each enrichment field degrades to `null` instead of failing the parse. Widen
+ * the bounds too where they were domain-sized, but the `catch` is the real
+ * guarantee: a newer client that sends a field shape this server has never seen
+ * still gets its bug report filed.
+ */
+function bestEffort<T extends z.ZodType>(schema: T) {
+  return schema.optional().nullable().catch(null);
+}
+
+const FeedbackContextInputSchema = z.object({
+  climbUuid: bestEffort(z.string().max(64)),
+  climbName: bestEffort(z.string().max(200)),
+  difficulty: bestEffort(z.string().max(32)),
+  sessionId: bestEffort(z.string().max(64)),
+  sessionName: bestEffort(z.string().max(200)),
+  url: bestEffort(z.string().max(1000)),
+  userAgent: bestEffort(z.string().max(512)),
+});
+// Deliberately NOT `.strict()`: an unknown key is a newer client talking to an
+// older server, and that must not cost the report. Zod strips unknown keys, and
+// `normalizeContext` in the resolver only reads keys it knows about.
 
 export const SubmitAppFeedbackInputSchema = z
   .object({
-    rating: z.number().int().min(1).max(5).optional().nullable(),
-    comment: z.string().trim().max(2000).optional().nullable(),
+    rating: bestEffort(z.number().int().min(1).max(5)),
+    // Clipped, not rejected — an over-long comment is still a bug report, and the
+    // `.refine` below reads the clipped value.
+    comment: z
+      .string()
+      .trim()
+      .transform((value) => (value.length > COMMENT_MAX ? value.slice(0, COMMENT_MAX) : value))
+      .optional()
+      .nullable(),
     platform: z.enum(['ios', 'android', 'web']),
-    appVersion: z.string().max(64).optional().nullable(),
     source: z.enum([...RATING_SOURCES, ...BUG_SOURCES]),
-    boardName: z.string().min(1).max(100).optional().nullable(),
-    layoutId: z.number().int().optional().nullable(),
-    sizeId: z.number().int().optional().nullable(),
-    setIds: z.array(z.number().int()).max(16).optional().nullable(),
-    angle: z.number().int().min(0).max(180).optional().nullable(),
-    context: FeedbackContextInputSchema.optional().nullable(),
-    contactConsent: z.boolean().optional().nullable(),
+    appVersion: bestEffort(z.string().max(64)),
+    boardName: bestEffort(z.string().min(1).max(100)),
+    layoutId: bestEffort(z.number().int()),
+    sizeId: bestEffort(z.number().int()),
+    setIds: bestEffort(
+      z
+        .array(z.number().int())
+        .transform((setIds) => (setIds.length > SET_IDS_MAX ? setIds.slice(0, SET_IDS_MAX) : setIds)),
+    ),
+    angle: bestEffort(z.number().int().min(0).max(180)),
+    context: bestEffort(FeedbackContextInputSchema),
+    contactConsent: bestEffort(z.boolean()),
   })
   .refine((data) => !(RATING_SOURCES as readonly string[]).includes(data.source) || (data.rating ?? null) !== null, {
     message: 'rating is required for rating-source feedback',

--- a/packages/shared/i18n/locales/de/settings.json
+++ b/packages/shared/i18n/locales/de/settings.json
@@ -381,7 +381,7 @@
     "submitBug": "Fehlerbericht senden",
     "successRating": "Danke — ist notiert.",
     "successBug": "Fehler notiert — danke.",
-    "errorRating": "Ging nicht raus — wir heben dein Feedback auf.",
+    "errorRating": "Ging nicht raus — versuch es gleich noch mal.",
     "closeAria": "Schließen",
     "joinDiscord": "Discord beitreten"
   },

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -381,7 +381,7 @@
     "submitBug": "Send bug report",
     "successRating": "Thanks — logged.",
     "successBug": "Bug logged — thanks.",
-    "errorRating": "Couldn't send — we'll keep your feedback.",
+    "errorRating": "Couldn't send that — try again in a moment.",
     "closeAria": "Close",
     "joinDiscord": "Join Discord"
   },

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -381,7 +381,7 @@
     "submitBug": "Enviar reporte",
     "successRating": "Gracias — registrado.",
     "successBug": "Fallo registrado — gracias.",
-    "errorRating": "No se pudo enviar — guardamos tus comentarios.",
+    "errorRating": "No se pudo enviar — inténtalo de nuevo en un momento.",
     "closeAria": "Cerrar",
     "joinDiscord": "Únete a Discord"
   },

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -381,7 +381,7 @@
     "submitBug": "Envoyer le rapport de bug",
     "successRating": "Merci, c'est noté.",
     "successBug": "Bug enregistré, merci.",
-    "errorRating": "Envoi impossible. On garde votre retour.",
+    "errorRating": "Envoi impossible. Réessayez dans un instant.",
     "closeAria": "Fermer",
     "joinDiscord": "Rejoindre Discord"
   },


### PR DESCRIPTION
## Summary

`submitAppFeedback` rejected the entire mutation when any optional board-context field failed validation, so a bug report could be thrown away because of the metadata wrapped around it.

That is not hypothetical. On 2026-08-03 a user on a board with more than 16 sets tripped the `setIds: z.array(...).max(16)` cap **four times in a row** while trying to report a crash — `Invalid input: Too big: expected array to have <=16 items`, path `submitAppFeedback` (Sentry [BOARDSESH-84](https://boardsesh.sentry.io/issues/BOARDSESH-84), 19:08:08–19:08:38 UTC). They were mid-crash-loop on [BOARDSESH-9K](https://boardsesh.sentry.io/issues/BOARDSESH-9K) at the time. Every one of those reports is gone.

The report is the payload; the board context around it is triage garnish. This change makes that split explicit:

- **Enrichment never fails the parse.** `appVersion`, `boardName`, `layoutId`, `sizeId`, `setIds`, `angle`, `context`, `contactConsent`, and `rating` degrade to `null` via a small `bestEffort()` wrapper instead of rejecting.
- **`setIds` is bounded for abuse, not for the domain.** 16 was sized to what we thought real boards carry. It's now 64, and an over-long list truncates rather than rejecting.
- **The context object no longer uses `.strict()`.** An unknown key means a newer client is talking to an older server, and that must not cost the report. Zod strips unknown keys, and `normalizeContext` in the resolver only reads keys it knows about.
- **An over-long comment is clipped, not rejected.** The `.refine()` for bug sources reads the clipped value.
- `source`, `platform`, and a ≥10-character comment on bug reports stay load-bearing and still reject.

Also fixes the failure toast, which told users **"Couldn't send — we'll keep your feedback."** while the report was being discarded. Corrected in all four locales.

## Release Notes

- Bug reports get through now, whatever board you're on — a board with lots of hold sets used to make the report vanish
- The "couldn't send" message no longer claims we saved your report when we didn't

## Test plan

- `vp test run --project backend --reporter=agent feedback-validation` — 23 passed. Existing cases that asserted the old reject-on-bad-enrichment behaviour were rewritten to assert the field is dropped and the report survives; new cases cover 20 setIds (the real-world case), 500 setIds truncating to 64, unknown context keys being stripped, non-object context, and every enrichment field being garbage at once.
- `vp test run --project backend --reporter=agent github-feedback` — 13 passed (the issue/email side effect reads the same fields).
- `vp run test:web --reporter=agent feedback` — 48 passed across 6 files; web posts the same mutation.
- `vp run typecheck:backend`, `vp run check:i18n`, catalog-completeness (90 passed) for the locale edits.
- `vp check` reports 20 errors / 299 warnings — byte-identical to the count on a clean `origin/main`, none in the changed files.

Not covered: no end-to-end submit against a live board with >16 sets. Worth watching BOARDSESH-84 after deploy for new `submitAppFeedback` validation events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqJiEtn1BFUDKfS4w91A3W
