### PR TITLE
fix(mobile): Android warm-up segmented control not responding to taps

### DIFF
--- a/packages/mobile/src/components/SegmentedControl.android.tsx
+++ b/packages/mobile/src/components/SegmentedControl.android.tsx
@@ -79,5 +79,13 @@ export function SegmentedControl<K extends string = string>({
 const styles = StyleSheet.create({
   host: {
     width: '100%',
+    // RN Android installs a background drawable even for a transparent colour, which
+    // makes the Host itself an RNGH hit-test target (shouldHandlerlessViewBecomeTouchTarget):
+    // without any background, RNGH's Android orchestrator ignores z-order and sees straight
+    // through handler-less, background-less native subtrees, so a tap meant for the Compose
+    // SegmentedButton can be claimed by an ancestor RNGH handler instead (the Warm-up and
+    // Climb Bias controls both went unresponsive on Android before this). Zero visual effect.
+    // Same fix as FilterChipRow.android.tsx's Host (commit abf7122a9).
+    backgroundColor: 'transparent',
   },
 });


### PR DESCRIPTION
## Summary

On Android, the Record tab's pre-session "Warm-up" segmented control (None / Standard / Extended) didn't respond to taps — no visual change, no state change.

`SegmentedControl.android.tsx`'s `Host` (wrapping the Jetpack Compose `SingleChoiceSegmentedButtonRow`) had no `backgroundColor`. RNGH's Android hit-tester (`GestureHandlerOrchestrator`) ignores z-order and sees straight through handler-less, background-less native subtrees, so a tap meant for the Compose `SegmentedButton` could be claimed by a surrounding RNGH gesture handler instead. This is the same class of bug already fixed once in this codebase for `FilterChipRow.android.tsx` (#abf7122a9) — same fix applied here: give the `Host` a transparent background so it stays a valid RNGH hit-test target.

## Release Notes

- Tap through None, Standard, and Extended warm-up again when building a workout on Android

## Test plan

- `vp run typecheck:mobile` — passes
- `vp check` — passes on the changed file (unrelated pre-existing lint findings in `packages/db` test files, confirmed present on `main` without this change)
- `vp test run --project mobile --reporter=agent` — passes (2 pre-existing unrelated failures in `logbook-tab-grouped.test.tsx`, confirmed present on this branch without this change)

**On-device verification caveat:** I tried to confirm this fix live on a headless x86_64 Android emulator (software-rendered, `swiftshader_indirect`) and the result was inconclusive. With the fix applied, synthetic taps (`adb shell input tap`) still didn't register on the Warm-up control — but the same was true for the Climb Bias segmented control and even the pre-existing, already-shipped "Tall climbs only" `Switch` in the Tuning section, while plain RN `Pressable` controls (workout-type shelf cards) responded normally in the same session. Since that switch is production code that already works for real users, I read this as every `@expo/ui` Jetpack Compose `Host`-based control failing to receive synthetic taps in this specific headless/software-rendered emulator, not a real behavioural regression from this change. The fix itself is based on direct precedent from an already-merged, already-verified-on-emulator fix for the identical bug class in this repo.

Flagging for reviewer: please sanity-check on a real Android device or GPU-accelerated emulator before merging.