### PR TITLE
feat(mobile): report the board-sheet switch-board tap

### DIFF
--- a/packages/mobile/src/components/board-presence/NowOnTheWallPanel.tsx
+++ b/packages/mobile/src/components/board-presence/NowOnTheWallPanel.tsx
@@ -470,19 +470,13 @@ function NowOnTheWallPanelComponent(
     onClose?.();
   }, [invalidatePendingActions, onClose]);
 
-  // Mirrored into a ref rather than listed as a dep: a list `.length` in a
-  // callback's deps rebuilds it on every page of history (see the perf checklist
-  // in docs/react-native-performance.md). Assigning during render is the standard
-  // latest-value ref pattern.
+  // A ref, not a dep: a list `.length` in a callback's deps rebuilds it on every
+  // page of history (docs/react-native-performance.md).
   const historyCountRef = useRef(combinedHistory.length);
   historyCountRef.current = combinedHistory.length;
 
-  // Track BEFORE `invalidatePendingActions()` and before handing off to the host,
-  // so this event means "the tap reached JS" and nothing more. Paired with the
-  // host's BoardSwapInvokedFromSheet it separates an unreachable control from a
-  // broken handler — see the SHARED_EVENTS.BoardSwapTapped note. `historyCount`
-  // rides along because the footer sits below the history list, so a dead tap
-  // correlated with a long list points at layout rather than hit-testing.
+  // Tracks before any other work, so it means "the tap reached JS" and nothing
+  // more — see the SHARED_EVENTS.BoardSwapTapped note for what the pairing buys.
   const handleSwitchBoard = useCallback(() => {
     track(SHARED_EVENTS.BoardSwapTapped, {
       boardId: boardPresenceBoardId ?? undefined,

--- a/packages/mobile/src/components/board-presence/NowOnTheWallPanel.tsx
+++ b/packages/mobile/src/components/board-presence/NowOnTheWallPanel.tsx
@@ -470,10 +470,27 @@ function NowOnTheWallPanelComponent(
     onClose?.();
   }, [invalidatePendingActions, onClose]);
 
+  // Mirrored into a ref rather than listed as a dep: a list `.length` in a
+  // callback's deps rebuilds it on every page of history (see the perf checklist
+  // in docs/react-native-performance.md). Assigning during render is the standard
+  // latest-value ref pattern.
+  const historyCountRef = useRef(combinedHistory.length);
+  historyCountRef.current = combinedHistory.length;
+
+  // Track BEFORE `invalidatePendingActions()` and before handing off to the host,
+  // so this event means "the tap reached JS" and nothing more. Paired with the
+  // host's BoardSwapInvokedFromSheet it separates an unreachable control from a
+  // broken handler — see the SHARED_EVENTS.BoardSwapTapped note. `historyCount`
+  // rides along because the footer sits below the history list, so a dead tap
+  // correlated with a long list points at layout rather than hit-testing.
   const handleSwitchBoard = useCallback(() => {
+    track(SHARED_EVENTS.BoardSwapTapped, {
+      boardId: boardPresenceBoardId ?? undefined,
+      historyCount: historyCountRef.current,
+    });
     invalidatePendingActions();
     onSwitchBoard();
-  }, [invalidatePendingActions, onSwitchBoard]);
+  }, [boardPresenceBoardId, invalidatePendingActions, onSwitchBoard]);
 
   const renderHistoryItem = useCallback(
     ({ item }: { item: BoardPresenceClimb }) => {

--- a/packages/mobile/src/components/board-presence/__tests__/now-on-the-wall-panel.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/now-on-the-wall-panel.test.tsx
@@ -315,6 +315,8 @@ describe('NowOnTheWallPanel', () => {
     toast.showToast.mockClear();
     pressableAvatar.mockClear();
     presence.refresh.mockClear();
+    // mockReset, not mockClear: the tap-ordering test installs an implementation.
+    analytics.track.mockReset();
   });
 
   it('adds the bottom safe-area inset to the switch-board footer in both sheet and inline variants', () => {
@@ -330,6 +332,22 @@ describe('NowOnTheWallPanel', () => {
     rerender(panelElement({ variant: 'column' }));
 
     expect(getByLabelText('mobile.boardPresence.switchBoardAria').getAttribute('data-padding-bottom')).toBe('46');
+  });
+
+  // The point of this event is to be provable evidence that the tap reached JS.
+  // If it ever fires only alongside the host handler it stops discriminating, so
+  // assert the ordering rather than just the call.
+  it('reports the switch-board tap before handing off to the host', () => {
+    presence.history = [makeClimb('one', 1), makeClimb('two', 2)];
+    const callOrder: string[] = [];
+    analytics.track.mockImplementation((event: string) => callOrder.push(`track:${event}`));
+    const onSwitchBoard = vi.fn(() => callOrder.push('onSwitchBoard'));
+
+    const { getByLabelText } = render(panelElement({ onSwitchBoard }));
+    fireEvent.click(getByLabelText('mobile.boardPresence.switchBoardAria'));
+
+    expect(callOrder).toEqual(['track:Board Swap Tapped', 'onSwitchBoard']);
+    expect(analytics.track).toHaveBeenCalledWith('Board Swap Tapped', expect.objectContaining({ historyCount: 2 }));
   });
 
   it('drops in-flight action results and clears loading when the board config changes', async () => {

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -257,6 +257,15 @@ export const SHARED_EVENTS = {
   // noisy for PostHog's event budget.
   BoardSheetOpened: 'Board Sheet Opened',
   BoardHistoryViewed: 'Board History Viewed',
+  // Fired from the switch-board control's own `onPress`, before any other work.
+  // Deliberately redundant with BoardSwapInvokedFromSheet (which fires one call
+  // deeper, in the drawer host): the PAIR is the diagnostic. A session with
+  // BoardSheetOpened but neither of these means the control was never reachable
+  // — occluded, laid out past the sheet's detent, or swallowed by a wedged
+  // presentation. This one alone means the handler chain broke in between.
+  // Without the pair, a "switching boards did nothing" report is unfalsifiable.
+  // Props: { boardId?, historyCount }.
+  BoardSwapTapped: 'Board Swap Tapped',
   BoardSwapInvokedFromSheet: 'Board Swap Invoked From Sheet',
   // Fired after a board-history catch-up completes. Props:
   // { boardId?, reason: 'gap' | 'reconnect' | 'foreground' | 'manual',


### PR DESCRIPTION
## Summary

A session on 2026-08-03 (13:39–15:20 Brisbane) logged `Board Sheet Opened` **3×** — 03:46:34, 04:15:59, 04:16:07 UTC — and `Board Swap Invoked From Sheet` **0×**, with the active board stuck on `kilter` for the whole session. The app was alive throughout: 5× `Climb Sent to Board Success` at 04:17, ticks at 04:24/04:43/04:51/04:56, a clean `Session Ended` at 04:57. So switching boards genuinely did nothing, and `track()` is the first statement in `handleSwitchBoardFromSheet`, so the handler never ran.

What the telemetry can't say is **why**. Two very different bugs produce the same silence:

1. the control was never reachable — occluded, laid out past the sheet's detent, or swallowed by a wedged presentation;
2. the press landed and the handler chain broke between the `Pressable` and the drawer host.

This adds `Board Swap Tapped`, fired from the switch-board `Pressable`'s own `onPress` before `invalidatePendingActions()` and before the host handoff. The **pair** is the diagnostic:

| `Board Swap Tapped` | `Board Swap Invoked From Sheet` | reading |
| --- | --- | --- |
| ✗ | ✗ | the control was never reachable |
| ✓ | ✗ | handler chain broke in between |
| ✓ | ✓ | working |

`historyCount` rides along because the footer sits *below* the history list in `NowOnTheWallPanel`. If dead taps correlate with long history, that points at layout rather than hit-testing.

### One thing this deliberately does not fix

There is a visible asymmetry worth a look on device, but not worth a speculative change without a repro: in the `variant === 'column'` branch the history list gets `style={styles.fillList}` (`flex: 1`) with the comment *"Fill the bounded height between the header and the switch-board footer"* — the **`variant === 'sheet'` branch has no such style**, while the sheet is a fixed `snapPoints={['55%', '92%']}` with `enableDynamicSizing={false}`. If the list is unbounded there, it grows with content and pushes the footer past the detent.

Quick check on a real device: open the board sheet on a wall with 20+ climbs of history and see whether the "Switch board" footer is still visible and tappable at the 55% detent. If it isn't, that's the bug, and the fix is to bound the list the way the column branch does.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run test:mobile --reporter=agent` — 5065 passed across 582 files.
- New test in `now-on-the-wall-panel.test.tsx` asserts the **ordering** (`track` before `onSwitchBoard`), not just that the event fires — if it ever fires alongside the host handler instead of ahead of it, it stops discriminating. Also asserts `historyCount`. Added `analytics.track.mockReset()` to `beforeEach` since the new test installs an implementation.
- `vp run typecheck:mobile` — clean.
- `vp run check:mobile-bundle` — android bundle OK.
- `vp check` — no findings in the changed files; the repo-wide error/warning counts are unchanged from `origin/main`.
- The callback reads `historyCount` from a ref rather than listing `combinedHistory.length` in its deps, per the perf checklist in `docs/react-native-performance.md`.

Not verified: no device run — this box is Linux, so the footer-reachability question above is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqJiEtn1BFUDKfS4w91A3W
