### PR TITLE
fix(mobile): Record tab crash on app.boardsesh.com — missing web session-store exports

### DIFF
--- a/packages/mobile/src/lib/__tests__/user-scoped-core-storage.web.test.ts
+++ b/packages/mobile/src/lib/__tests__/user-scoped-core-storage.web.test.ts
@@ -83,6 +83,24 @@ describe('browser login-scoped core persistence', () => {
     await expect(getStoredQueueSnapshot()).resolves.toBeNull();
   });
 
+  it('round-trips the created-session id and scopes it per login (regression: web build lacked these exports)', async () => {
+    const { setCurrentUserStorageOwner } = await import('../user-storage-owner.web');
+    const { getStoredCreatedSessionId, setStoredCreatedSessionId, clearStoredCreatedSessionId } =
+      await import('../session-store.web');
+
+    setCurrentUserStorageOwner(userALogin);
+    await expect(getStoredCreatedSessionId()).resolves.toBeNull();
+    await setStoredCreatedSessionId('session-a');
+    await expect(getStoredCreatedSessionId()).resolves.toBe('session-a');
+
+    setCurrentUserStorageOwner(userBLogin);
+    await expect(getStoredCreatedSessionId()).resolves.toBeNull();
+
+    setCurrentUserStorageOwner(userALogin);
+    await clearStoredCreatedSessionId();
+    await expect(getStoredCreatedSessionId()).resolves.toBeNull();
+  });
+
   it('ignores legacy unowned values instead of assigning them to the next login', async () => {
     storageState.secure.set('boardsesh_active_session_id', 'legacy-session');
     storageState.preferences.set('boardsesh_active_board_v2', JSON.stringify(boardA));

--- a/packages/mobile/src/lib/session-store.web.ts
+++ b/packages/mobile/src/lib/session-store.web.ts
@@ -26,3 +26,34 @@ export function clearStoredSessionId(owner?: UserStorageOwner | null): Promise<v
   if (!storageKey) return Promise.resolve();
   return SecureStore.deleteItemAsync(storageKey);
 }
+
+/**
+ * Id of the session THIS DEVICE started (as opposed to joined) — web
+ * counterpart of session-store.ts's getStoredCreatedSessionId/set/clear. See
+ * that file for the full rationale (device provenance, why losing it is
+ * harmless). Scoped per signed-in user like the active-session keys above,
+ * via the current owner set by setCurrentUserStorageOwner.
+ */
+const CREATED_SESSION_ID_KEY = 'boardsesh_created_session_id';
+
+export async function getStoredCreatedSessionId(): Promise<string | null> {
+  const storageKey = userScopedStorageKey(CREATED_SESSION_ID_KEY);
+  if (!storageKey) return null;
+  try {
+    return await SecureStore.getItemAsync(storageKey);
+  } catch {
+    return null;
+  }
+}
+
+export function setStoredCreatedSessionId(sessionId: string): Promise<void> {
+  const storageKey = userScopedStorageKey(CREATED_SESSION_ID_KEY);
+  if (!storageKey) return Promise.resolve();
+  return SecureStore.setItemAsync(storageKey, sessionId, SECURE_STORE_WRITE_OPTIONS);
+}
+
+export function clearStoredCreatedSessionId(): Promise<void> {
+  const storageKey = userScopedStorageKey(CREATED_SESSION_ID_KEY);
+  if (!storageKey) return Promise.resolve();
+  return SecureStore.deleteItemAsync(storageKey);
+}


### PR DESCRIPTION
## Summary

The Record tab crashed on app.boardsesh.com (Expo web) with:
```
TypeError: (0 , u.getStoredCreatedSessionId) is not a function
```

#3502 added `getStoredCreatedSessionId` / `setStoredCreatedSessionId` / `clearStoredCreatedSessionId` to `packages/mobile/src/lib/session-store.ts` (the native implementation) but never ported them to `session-store.web.ts`. Metro resolves the `.web.ts` file for the browser build, so on web those three exports were simply missing from the resolved module — matching the exact `is not a function` symptom. Native (iOS/Android) was unaffected since it resolves `session-store.ts`, which already had them.

## Fix

Added matching SecureStore-backed, user-scoped implementations of the three functions to `session-store.web.ts`, mirroring the existing `getStoredSessionId`/`setStoredSessionId`/`clearStoredSessionId` pattern already in that file (same `userScopedStorageKey` scoping via the current signed-in owner).

## Release Notes

- Fixed a crash opening the Record tab in the browser app

## Test plan

- `vp run typecheck:mobile` — passes
- `vp check` — passes on both changed files
- Added a regression test to `user-scoped-core-storage.web.test.ts` covering get/set/clear of the created-session id and per-login scoping; ran it directly with vitest — 6/6 pass (was 5/5 before)
- `vp test run --project mobile --reporter=agent` — full suite passes aside from 2 pre-existing unrelated failures in `logbook-tab-grouped.test.tsx` (confirmed present on `main` without this change)

Not verified live against app.boardsesh.com (no way to run the Expo-web dev target end-to-end in this environment) — the regression test exercises the exact function signatures/behavior the Record tab flow calls (`use-session-exit-options.ts`, `use-session-commands.ts`).