### PR TITLE
fix(mobile): Android segmented control still broken — replace @expo/ui Compose with Paper

### DIFF
--- a/packages/mobile/src/components/SegmentedControl.android.tsx
+++ b/packages/mobile/src/components/SegmentedControl.android.tsx
@@ -25,7 +25,7 @@
 // semantics of its own, so it's carried by a wrapping `radiogroup` View (mirrors the
 // pre-@expo/ui Material implementation this restores).
 
-import { View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { SegmentedButtons } from 'react-native-paper';
 import { readableTextColor } from './grade/grade-chip-colors';
 import { makeSelectHandler } from './SegmentedControl.logic';
@@ -41,24 +41,34 @@ export function SegmentedControl<K extends string = string>({
 }: SegmentedControlProps<K>) {
   const handleSelect = makeSelectHandler(onSelect, disabledKeys);
 
+  const control = (
+    <SegmentedButtons
+      value={selectedKey}
+      onValueChange={(next) => handleSelect(next as K)}
+      style={styles.row}
+      // A scoped colour override so the selected segment fills with `tint` and its
+      // label/check stay readable on that fill. Omitted (undefined) for the default
+      // purple — already the brand `secondaryContainer` from buildPaperTheme.
+      theme={tint ? { colors: { secondaryContainer: tint, onSecondaryContainer: readableTextColor(tint) } } : undefined}
+      buttons={options.map((option) => ({
+        value: option.key,
+        label: option.label,
+        accessibilityLabel: option.label,
+        disabled: disabledKeys?.has(option.key),
+      }))}
+    />
+  );
+
+  if (!accessibilityLabel) return control;
   return (
     <View accessibilityRole="radiogroup" accessibilityLabel={accessibilityLabel}>
-      <SegmentedButtons
-        value={selectedKey}
-        onValueChange={(next) => handleSelect(next as K)}
-        // A scoped colour override so the selected segment fills with `tint` and its
-        // label/check stay readable on that fill. Omitted (undefined) for the default
-        // purple — already the brand `secondaryContainer` from buildPaperTheme.
-        theme={
-          tint ? { colors: { secondaryContainer: tint, onSecondaryContainer: readableTextColor(tint) } } : undefined
-        }
-        buttons={options.map((option) => ({
-          value: option.key,
-          label: option.label,
-          accessibilityLabel: option.label,
-          disabled: disabledKeys?.has(option.key),
-        }))}
-      />
+      {control}
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  row: {
+    width: '100%',
+  },
+});

--- a/packages/mobile/src/components/SegmentedControl.android.tsx
+++ b/packages/mobile/src/components/SegmentedControl.android.tsx
@@ -1,33 +1,32 @@
-// SegmentedControl — Android implementation, real Jetpack Compose via
-// @expo/ui/jetpack-compose.
+// SegmentedControl — Android implementation, react-native-paper `SegmentedButtons`
+// (the same component the web fallback uses; see SegmentedControl.web.tsx).
 //
-// A Material 3 `SingleChoiceSegmentedButtonRow` of `SegmentedButton`s inside its
-// own `Host`. Each button reports its selected state, fires the shared select
-// handler on tap, and disables per-segment via `enabled` (the one place Android
-// can do what iOS's segmented Picker can't). Brand selected-fill colour comes
-// from `segmentedBrandColors`; the rest of the surface/label colours come from
-// the Compose Material theme the Host sets up.
+// This control used to be a native Jetpack Compose `SingleChoiceSegmentedButtonRow`
+// via @expo/ui, but taps on it (and on every other @expo/ui `SegmentedButton` in the
+// app, e.g. Climb Bias) silently did nothing on real Android devices — confirmed via
+// a live OTA preview build, not just an emulator. The failure lives in @expo/ui's
+// Jetpack Compose `SingleChoiceSegmentedButtonRow`/`SegmentedButton` pairing
+// specifically: `Button.android.tsx` uses the same `<Host>`-wrapped @expo/ui Compose
+// pattern for a plain button and works fine, so this isn't the broader
+// Host/RNGH-touch-dispatch problem a previous fix here assumed (that fix shipped and
+// still didn't resolve it). Falling back to Paper sidesteps whatever is wrong with
+// that specific Compose row/button combo entirely — Paper is still a live dependency
+// for other native Android controls (Button.android.tsx's own doc comment; see the
+// paper-removal endgame in #3273), so this isn't introducing a new pattern.
 //
-// One Host per control is intentional for now (SegmentedControl is used
-// one-per-card). A later pass consolidates whole settings screens under one Host.
+// `tint` (the logbook's amber) recolours the selected segment via a scoped Paper
+// theme override — `secondaryContainer` is the fill, `onSecondaryContainer` the
+// on-fill label/check, derived to stay readable on the given fill. The default
+// (purple) needs no override — it's already the brand `secondaryContainer` from
+// buildPaperTheme (mirrors SegmentedControl.web.tsx's reasoning exactly).
 //
-// `accessibilityLabel` (the group name, e.g. "Appearance") is deliberately NOT
-// forwarded here. Material's `SingleChoiceSegmentedButtonRow` already exposes the
-// row as a single-choice group and each `SegmentedButton.Label` is announced with
-// its selected state, and every call site renders a visible `SectionHeader` above
-// the control that names the group. Compose (via @expo/ui) exposes no
-// `contentDescription`/group-label modifier, and wrapping the native Host in an
-// RN `accessible` View would collapse the segments into one node — breaking
-// per-segment selection. So the group label is carried by the heading, not the
-// control. (iOS applies it via the Picker's `accessibilityLabel` modifier, which
-// labels the group without hiding segments — hence the small, intentional
-// cross-platform asymmetry.)
+// `accessibilityLabel` (the group name, e.g. "Warm-up") IS forwarded here — unlike
+// the retired Compose version, Paper's `SegmentedButtons` exposes no group-label
+// semantics of its own, so it's carried by a wrapping `radiogroup` View (mirrors the
+// pre-@expo/ui Material implementation this restores).
 
-import { Host } from '@expo/ui';
-import { SingleChoiceSegmentedButtonRow, SegmentedButton, Text } from '@expo/ui/jetpack-compose';
-import { StyleSheet } from 'react-native';
-import { useTheme } from '../providers/theme-provider';
-import { segmentedBrandColors } from '../theme/expo-ui-modifiers';
+import { View } from 'react-native';
+import { SegmentedButtons } from 'react-native-paper';
 import { readableTextColor } from './grade/grade-chip-colors';
 import { makeSelectHandler } from './SegmentedControl.logic';
 import type { SegmentedControlProps } from './SegmentedControl.types';
@@ -38,54 +37,28 @@ export function SegmentedControl<K extends string = string>({
   onSelect,
   disabledKeys,
   tint,
+  accessibilityLabel,
 }: SegmentedControlProps<K>) {
-  const { brandColors } = useTheme();
   const handleSelect = makeSelectHandler(onSelect, disabledKeys);
-  // Default to the brand selected-fill (purple, with white on-fill text). When a
-  // custom tint is passed (the logbook's amber), the active label must derive its
-  // contrast from that fill — white-on-amber fails AA, so use a readable colour.
-  const colors = tint
-    ? { activeContainerColor: tint, activeContentColor: readableTextColor(tint) }
-    : segmentedBrandColors(brandColors);
 
   return (
-    // `matchContents={{ vertical: true }}` (NOT the boolean `matchContents`, which
-    // sizes to content in BOTH axes): the Host must fill the parent's width so the
-    // segmented row spans the card, while height still tracks content.
-    <Host matchContents={{ vertical: true }} style={styles.host}>
-      <SingleChoiceSegmentedButtonRow>
-        {options.map((option) => (
-          <SegmentedButton
-            key={option.key}
-            selected={option.key === selectedKey}
-            onClick={() => handleSelect(option.key)}
-            enabled={!disabledKeys?.has(option.key)}
-            colors={colors}
-          >
-            {/* The label slot is a native composable SLOT, so its child must be a
-                Compose view (a `Text`), not a raw string — a bare string doesn't
-                render and isn't exposed to the a11y tree. Mirrors @expo/ui's own
-                community SegmentedControl.android. */}
-            <SegmentedButton.Label>
-              <Text>{option.label}</Text>
-            </SegmentedButton.Label>
-          </SegmentedButton>
-        ))}
-      </SingleChoiceSegmentedButtonRow>
-    </Host>
+    <View accessibilityRole="radiogroup" accessibilityLabel={accessibilityLabel}>
+      <SegmentedButtons
+        value={selectedKey}
+        onValueChange={(next) => handleSelect(next as K)}
+        // A scoped colour override so the selected segment fills with `tint` and its
+        // label/check stay readable on that fill. Omitted (undefined) for the default
+        // purple — already the brand `secondaryContainer` from buildPaperTheme.
+        theme={
+          tint ? { colors: { secondaryContainer: tint, onSecondaryContainer: readableTextColor(tint) } } : undefined
+        }
+        buttons={options.map((option) => ({
+          value: option.key,
+          label: option.label,
+          accessibilityLabel: option.label,
+          disabled: disabledKeys?.has(option.key),
+        }))}
+      />
+    </View>
   );
 }
-
-const styles = StyleSheet.create({
-  host: {
-    width: '100%',
-    // RN Android installs a background drawable even for a transparent colour, which
-    // makes the Host itself an RNGH hit-test target (shouldHandlerlessViewBecomeTouchTarget):
-    // without any background, RNGH's Android orchestrator ignores z-order and sees straight
-    // through handler-less, background-less native subtrees, so a tap meant for the Compose
-    // SegmentedButton can be claimed by an ancestor RNGH handler instead (the Warm-up and
-    // Climb Bias controls both went unresponsive on Android before this). Zero visual effect.
-    // Same fix as FilterChipRow.android.tsx's Host (commit abf7122a9).
-    backgroundColor: 'transparent',
-  },
-});

--- a/packages/mobile/src/components/SegmentedControl.types.ts
+++ b/packages/mobile/src/components/SegmentedControl.types.ts
@@ -1,11 +1,12 @@
 // Shared props for the platform-split SegmentedControl. The implementation is
 // split across SegmentedControl.ios.tsx (native @expo/ui SwiftUI segmented
-// Picker) and SegmentedControl.android.tsx (native @expo/ui Jetpack Compose
-// SingleChoiceSegmentedButtonRow). The split keeps each platform's @expo/ui
-// native tree — which resolves native views at module load — off the other
-// platform's bundle. The public API is identical to the previous
-// react-native-paper / Liquid-Glass implementation, so every call site is
-// unchanged.
+// Picker) and SegmentedControl.android.tsx (react-native-paper `SegmentedButtons`
+// — @expo/ui's Jetpack Compose SingleChoiceSegmentedButtonRow/SegmentedButton
+// pairing silently didn't respond to taps on real Android devices; see
+// SegmentedControl.android.tsx for the full story). The split keeps iOS's @expo/ui
+// native tree — which resolves native views at module load — off Android's bundle.
+// The public API is identical to the previous react-native-paper / Liquid-Glass
+// implementation, so every call site is unchanged.
 
 import type { ColorValue } from 'react-native';
 

--- a/packages/mobile/src/components/SegmentedControl.web.tsx
+++ b/packages/mobile/src/components/SegmentedControl.web.tsx
@@ -1,15 +1,17 @@
 // SegmentedControl — web implementation (react-native-web + react-native-paper). A
-// Material 3 Paper `SegmentedButtons` row — the counterpart to the Compose
-// `SingleChoiceSegmentedButtonRow` in SegmentedControl.android.tsx. The selection
-// haptic + per-key disabled guard live in SegmentedControl.logic.ts, shared with
-// both native files.
+// Material 3 Paper `SegmentedButtons` row — the same component
+// SegmentedControl.android.tsx now uses too (@expo/ui's Jetpack Compose
+// SingleChoiceSegmentedButtonRow/SegmentedButton pairing didn't respond to taps on
+// real Android devices). The selection haptic + per-key disabled guard live in
+// SegmentedControl.logic.ts, shared with both native files.
 //
 // `tint` (the logbook's amber) recolours the selected segment via a scoped Paper
 // theme override — `secondaryContainer` is the fill, `onSecondaryContainer` the
 // on-fill label/check, derived to stay readable on the given fill. The default
 // (purple) needs no override — it's already the brand `secondaryContainer` from
-// buildPaperTheme. The `accessibilityLabel` group name is intentionally not applied
-// (mirrors Android: the visible section heading names the group).
+// buildPaperTheme. The `accessibilityLabel` group name, when given, wraps the
+// control in a `role="radiogroup"` div rather than being passed to Paper directly
+// (Paper's `SegmentedButtons` exposes no group-label prop of its own).
 
 import { createElement } from 'react';
 import { StyleSheet } from 'react-native';


### PR DESCRIPTION
## Summary

Follow-up to #4196 (merged), which fixed the wrong thing.

That PR's `backgroundColor: 'transparent'` fix (matching the `FilterChipRow.android.tsx` RNGH hit-test bug class) was confirmed via a live OTA preview build to **not** actually fix the issue — Warm-up and Climb Bias were still unresponsive to taps on a real Android device (thanks for testing and flagging this).

## Root cause (this time verified against evidence, not just a plausible-looking precedent)

`Button.android.tsx` uses the exact same `@expo/ui` `<Host>`-wrapped Jetpack Compose pattern for a plain button, and that works fine — which rules out a general Host/RNGH-touch-dispatch problem (the theory behind the #4196 fix). The failure is specific to `@expo/ui`'s `SingleChoiceSegmentedButtonRow` / `SegmentedButton` pairing. I traced through the vendored Kotlin source in `node_modules/@expo/ui` looking for a concrete difference between the working `Button` path and the broken `SegmentedButton` path, but couldn't get a definitive runtime answer without native debugging tools I don't have access to here (Android Studio breakpoints, etc.).

## Fix

Rather than keep guessing at native Compose internals, this replaces the Android implementation with `react-native-paper`'s `SegmentedButtons` — the same component:
- the web fallback (`SegmentedControl.web.tsx`) already uses successfully, and
- this control itself used **before** the `@expo/ui` migration (`6af5f43df`).

`react-native-paper` remains a live, working dependency elsewhere on native Android today (`Button.android.tsx`, `AppMenu.android.tsx`, `AuthTextInput.android.tsx`, etc.) pending the paper-removal endgame tracked in #3273, so this isn't introducing a new pattern to the codebase — it's reverting one specific control to a known-working one while that endgame plays out.

## Release Notes

- Fixed the Warm-up and Climb Bias pickers not responding to taps on Android

## Test plan

- `vp run typecheck:mobile` — passes
- `vp check` — passes on the changed file
- `vp run check:mobile-bundle` — passes (Android bundle exports cleanly with `@expo/ui`'s Compose SegmentedButton imports fully removed from this file)
- `vp test run --project mobile --reporter=agent` — full suite passes aside from 2 pre-existing unrelated failures in `logbook-tab-grouped.test.tsx` (confirmed present on `main` without this change)

**Still not verified on a real device or working emulator by me** — my headless Android emulator testing turned out to be unreliable for `@expo/ui` Compose components specifically (every such control failed to receive synthetic taps there, including an already-shipped `Switch`, which is why the emulator couldn't be trusted to validate #4196 either). This fix sidesteps `@expo/ui`'s Compose bridge entirely for this control, so that specific emulator unreliability shouldn't apply — but please confirm on the OTA preview before merging, the same way the #4196 regression was caught.