### PR TITLE
fix(mobile): let a zoomed climb pan in the player again

### DIFF
--- a/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
+++ b/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
@@ -26,7 +26,7 @@ import { BoardImageNative } from '../BoardImageNative';
 import { Icon } from '../Icon';
 import { useCarouselGesture } from './use-carousel-gesture';
 import { useZoomPanGesture } from './use-zoom-pan-gesture';
-import { computeContainedBoardSize } from './play-drawer-layout';
+import { computeContainedBoardSize, CAROUSEL_LAYER_Z } from './play-drawer-layout';
 import { timing } from '../../theme/animations';
 import { overlays } from '../../theme/tokens';
 
@@ -376,8 +376,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     // Above the stacked (next) card so the current climb is the top card. Explicit
     // because the stacked card is absolutely positioned and renders after this in
-    // source order — zIndex governs paint order on both iOS and Android.
-    zIndex: 1,
+    // source order — zIndex governs paint order on both iOS and Android. The
+    // zoom-pan overlay sits above this again; see CAROUSEL_LAYER_Z.
+    zIndex: CAROUSEL_LAYER_Z.board,
   },
   peekWrapper: {
     position: 'absolute',
@@ -387,7 +388,7 @@ const styles = StyleSheet.create({
     bottom: 0,
     justifyContent: 'center',
     alignItems: 'center',
-    zIndex: 0,
+    zIndex: CAROUSEL_LAYER_Z.peek,
   },
   zoomPanOverlay: {
     position: 'absolute',
@@ -395,12 +396,15 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     bottom: 0,
+    // Must out-rank boardWrapper: this overlay is the board's SIBLING, so a drag that
+    // starts on the board only reaches its pan when the overlay hit-tests first (#4191).
+    zIndex: CAROUSEL_LAYER_Z.zoomPan,
   },
   resetZoomWrapper: {
     position: 'absolute',
     top: 12,
     right: 12,
-    zIndex: 10,
+    zIndex: CAROUSEL_LAYER_Z.resetZoom,
   },
   resetZoomButton: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-layout.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-layout.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { computeContainedBoardSize, computeFirstScreenHeight, computeLogbookScrollTarget } from '../play-drawer-layout';
+import {
+  CAROUSEL_LAYER_Z,
+  computeContainedBoardSize,
+  computeFirstScreenHeight,
+  computeLogbookScrollTarget,
+} from '../play-drawer-layout';
 
 describe('computeContainedBoardSize', () => {
   it('height-bounds a tall board on a wide box (horizontal letterbox)', () => {
@@ -79,5 +84,25 @@ describe('computeLogbookScrollTarget', () => {
 
   it('never returns a negative offset when the section already fits below the fold', () => {
     expect(computeLogbookScrollTarget({ ...base, firstScreenHeight: 100, sectionHeight: 40, viewport: 800 })).toBe(0);
+  });
+});
+
+describe('CAROUSEL_LAYER_Z', () => {
+  // These are hit-test ranks, not decoration. The pan-while-zoomed overlay is a
+  // SIBLING of the board, so burying it under the board means a drag that starts on
+  // the board never reaches the pan — that's #4191, where zooming a climb in the
+  // player left you unable to move around it (the create board, which has no zIndex
+  // at all, kept working). Raising boardWrapper for the card-stack paint order is
+  // what buried it, so keep the whole order asserted here.
+  it('puts the zoom-pan overlay above the board so a drag on the board can pan it', () => {
+    expect(CAROUSEL_LAYER_Z.zoomPan).toBeGreaterThan(CAROUSEL_LAYER_Z.board);
+  });
+
+  it('keeps the board above the incoming peek card', () => {
+    expect(CAROUSEL_LAYER_Z.board).toBeGreaterThan(CAROUSEL_LAYER_Z.peek);
+  });
+
+  it('keeps the reset-zoom button tappable above the pan overlay', () => {
+    expect(CAROUSEL_LAYER_Z.resetZoom).toBeGreaterThan(CAROUSEL_LAYER_Z.zoomPan);
   });
 });

--- a/packages/mobile/src/components/play-drawer/__tests__/use-zoom-pan-gesture-wiring.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-zoom-pan-gesture-wiring.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+// What these tests are about: the relations the zoom hook declares with the
+// surrounding scroll. The pan only mounts while zoomed, so it must WIN a downward
+// drag from the play drawer's RNGH ScrollView — otherwise the drawer scrolls out
+// from under a zoomed board instead of panning it. The interactive create/search
+// boards pass no scrollRef and must stay relation-free.
+
+// Mirror reanimated's contract: useSharedValue returns the SAME mutable ref across
+// re-renders; animations resolve to their target synchronously.
+vi.mock('react-native-reanimated', async () => {
+  const { useRef } = await import('react');
+  return {
+    useSharedValue: (initial: unknown) => {
+      const ref = useRef<{ value: unknown } | null>(null);
+      if (ref.current === null) ref.current = { value: initial };
+      return ref.current;
+    },
+    useAnimatedStyle: (factory: () => unknown) => factory(),
+    withTiming: (toValue: unknown) => toValue,
+    cancelAnimation: () => {},
+    runOnJS:
+      (fn: (...args: unknown[]) => unknown) =>
+      (...args: unknown[]) =>
+        fn(...args),
+  };
+});
+
+// Chainable Gesture builder that records which methods were called with what, so a
+// test can assert the declared relations without a native gesture tree.
+type RecordedBuilder = { kind: string; calls: Array<{ method: string; args: unknown[] }> };
+const recordedBuilders: RecordedBuilder[] = [];
+vi.mock('react-native-gesture-handler', () => {
+  const makeBuilder = (kind: string) => {
+    const record: RecordedBuilder = { kind, calls: [] };
+    recordedBuilders.push(record);
+    const proxy: Record<string, (...args: unknown[]) => unknown> = new Proxy(
+      {},
+      {
+        get: (_target, method: string) => {
+          return (...args: unknown[]) => {
+            record.calls.push({ method, args });
+            return proxy;
+          };
+        },
+      },
+    );
+    return proxy;
+  };
+  return {
+    Gesture: { Pinch: () => makeBuilder('Pinch'), Pan: () => makeBuilder('Pan') },
+  };
+});
+
+import { useZoomPanGesture } from '../use-zoom-pan-gesture';
+
+type Options = Parameters<typeof useZoomPanGesture>[0];
+
+const scrollRef = { current: null } as unknown as NonNullable<Options['scrollRef']>;
+
+function builderOfKind(kind: string): RecordedBuilder {
+  const found = recordedBuilders.find((builder) => builder.kind === kind);
+  if (!found) throw new Error(`no Gesture.${kind}() composed`);
+  return found;
+}
+
+function methodsOf(kind: string): string[] {
+  return builderOfKind(kind).calls.map((call) => call.method);
+}
+
+describe('useZoomPanGesture scroll relations', () => {
+  beforeEach(() => {
+    recordedBuilders.length = 0;
+  });
+
+  it('makes the zoomed-only pan block the surrounding scroll', () => {
+    renderHook(() => useZoomPanGesture({ containerWidth: 320, containerHeight: 480, scrollRef }));
+
+    const blocks = builderOfKind('Pan').calls.filter((call) => call.method === 'blocksExternalGesture');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.args[0]).toBe(scrollRef);
+  });
+
+  it('keeps the pinch simultaneous with that scroll (a 2-finger zoom must not be a scroll)', () => {
+    renderHook(() => useZoomPanGesture({ containerWidth: 320, containerHeight: 480, scrollRef }));
+
+    const simultaneous = builderOfKind('Pinch').calls.filter(
+      (call) => call.method === 'simultaneousWithExternalGesture',
+    );
+    expect(simultaneous).toHaveLength(1);
+    expect(simultaneous[0]?.args[0]).toBe(scrollRef);
+  });
+
+  it('declares no scroll relation on the interactive boards, which pass no scrollRef', () => {
+    renderHook(() => useZoomPanGesture({ containerWidth: 320, containerHeight: 480 }));
+
+    expect(methodsOf('Pan')).not.toContain('blocksExternalGesture');
+    expect(methodsOf('Pinch')).not.toContain('simultaneousWithExternalGesture');
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/use-zoom-pan-gesture-wiring.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-zoom-pan-gesture-wiring.test.ts
@@ -61,9 +61,11 @@ type Options = Parameters<typeof useZoomPanGesture>[0];
 const scrollRef = { current: null } as unknown as NonNullable<Options['scrollRef']>;
 
 function builderOfKind(kind: string): RecordedBuilder {
-  const found = recordedBuilders.find((builder) => builder.kind === kind);
-  if (!found) throw new Error(`no Gesture.${kind}() composed`);
-  return found;
+  const found = recordedBuilders.filter((builder) => builder.kind === kind);
+  // Insist on exactly one so a future test that re-renders (recomposing the gesture)
+  // can't quietly assert against the discarded first build and read as green.
+  if (found.length !== 1) throw new Error(`expected 1 Gesture.${kind}(), composed ${found.length}`);
+  return found[0] as RecordedBuilder;
 }
 
 function methodsOf(kind: string): string[] {

--- a/packages/mobile/src/components/play-drawer/play-drawer-layout.ts
+++ b/packages/mobile/src/components/play-drawer/play-drawer-layout.ts
@@ -56,3 +56,20 @@ export function computeLogbookScrollTarget(params: {
   const headerToTop = sectionTopY - topInset - margin;
   return Math.max(0, Math.min(bottomIntoView, headerToTop));
 }
+
+/**
+ * Paint / hit-test order for the swipe carousel's sibling layers. RN sorts siblings by
+ * zIndex and hit-tests in reverse paint order, so these numbers decide which layer gets
+ * the touch, not just what you see.
+ *
+ * The board is raised above the incoming peek card, which means the pan-while-zoomed
+ * overlay — a SIBLING of the board, not an ancestor — has to be raised above the board
+ * too. Bury it and it never receives a touch that starts on the board, which is exactly
+ * how panning a zoomed climb died in the player (#4191).
+ */
+export const CAROUSEL_LAYER_Z = {
+  peek: 0,
+  board: 1,
+  zoomPan: 2,
+  resetZoom: 10,
+} as const;

--- a/packages/mobile/src/components/play-drawer/use-zoom-pan-gesture.ts
+++ b/packages/mobile/src/components/play-drawer/use-zoom-pan-gesture.ts
@@ -33,8 +33,9 @@ type UseZoomPanGestureOptions = {
   panActivationOffset?: number;
   /** RNGH ref to the surrounding scroll. Declares the pinch simultaneous with it
    * so a 2-finger zoom isn't cancelled by the scroll (the plain RN ScrollView the
-   * play route briefly used wasn't in RNGH's tree). Typed as RNGH's GestureRef
-   * shape so the method call needs no cast. */
+   * play route briefly used wasn't in RNGH's tree), and makes that scroll wait on
+   * the zoomed-only pan so a downward drag pans the board instead of scrolling the
+   * drawer. Typed as RNGH's GestureRef shape so the method call needs no cast. */
   scrollRef?: RefObject<ComponentType | undefined | null>;
   /** When set, the pinch gesture is tagged with this ref so the interactive
    * boards' per-hold tap/long-press detectors can mark themselves
@@ -242,8 +243,9 @@ export function useZoomPanGesture({
       });
     }
     // Declare the pinch simultaneous with the surrounding RNGH ScrollView so a
-    // 2-finger zoom isn't cancelled by the scroll. (The zoom-pan overlay lives on
-    // a separate, zoomed-only GestureDetector and needs no scroll relation.)
+    // 2-finger zoom isn't cancelled by the scroll. (The zoom-pan overlay lives on a
+    // separate, zoomed-only GestureDetector and takes the opposite relation — it
+    // BLOCKS the scroll; see zoomPanGesture below.)
     if (scrollRef) pinch.simultaneousWithExternalGesture(scrollRef);
     return pinch;
   }, [
@@ -302,6 +304,11 @@ export function useZoomPanGesture({
         .activeOffsetX([-panActivationOffset, panActivationOffset])
         .activeOffsetY([-panActivationOffset, panActivationOffset]);
     }
+    // Make the surrounding scroll wait for this pan to fail. The detector only mounts
+    // while zoomed, so claiming the drag there is exactly what we want: the board pans
+    // instead of the play drawer scrolling out from under a downward drag. Idle
+    // scrolling is untouched (no overlay, no relation).
+    if (scrollRef) pan.blocksExternalGesture(scrollRef);
     return pan;
   }, [
     scale,
@@ -312,6 +319,7 @@ export function useZoomPanGesture({
     containerWidthSV,
     containerHeightSV,
     panActivationOffset,
+    scrollRef,
   ]);
 
   const animatedZoomStyle = useAnimatedStyle(() => ({


### PR DESCRIPTION
## Summary

Closes #4191 — zooming a climb in the player left you stuck: pinch worked, but a one-finger
drag on the board did nothing. The same overlay pattern in the create-climb editor panned fine.

It's z-order, not gestures. The pan-while-zoomed overlay is a **sibling** of the board (it only
mounts while zoomed so it can't eat idle touches), and `boardWrapper` was raised to `zIndex: 1`
in f711cbabb for the card-stack paint order while the overlay kept the default `0`. RN sorts
siblings by zIndex and hit-tests in reverse paint order, so every drag starting on the board
landed in the board wrapper and bubbled to its *ancestors* — the overlay isn't one, so its pan
never saw the touch. Only drags starting in the letterbox margins could pan. `InteractiveCreateBoard`
has no zIndex anywhere, which is exactly why the editor kept working.

- Name the carousel's layer order (`CAROUSEL_LAYER_Z` in `play-drawer-layout.ts`) and raise the
  zoom-pan overlay above the board. Reset-zoom stays on top of both.
- Make the zoomed-only pan `blocksExternalGesture(scrollRef)`, so a downward drag pans the board
  instead of the drawer scrolling out from under it. The create/search boards pass no `scrollRef`
  and are untouched.
- Tests: the layer-order invariant (the guard that would have caught the regression) and the
  scroll relations the zoom hook declares.

JS-only — no native fingerprint inputs, so this rides an OTA.

## Release Notes

- Zoom into a climb in the player, then drag to move around the board — panning works again, not just in the editor.

## Test plan

- `vp run typecheck:mobile` ✅
- `vp run test:mobile` — 583 files / 5072 tests ✅ (3 new gesture-wiring tests, 3 new layer-order tests)
- `vp check` ✅ (only pre-existing `scripts/**` `ProcessEnv` errors, untouched here)
- `vp run check:mobile-bundle` ✅
- Device QA still owed — the gesture itself can't be proven in vitest. Full checklist in the
  branch's `.boardsesh/qa-notes.md`; the short version, on the `pr-` OTA preview:
  - zoom a climb in the player, drag **starting on the board**: pans both axes, drawer stays put
  - Reset zoom chip, pinch, left/right swipe at rest, pull-down-to-dismiss at rest: unchanged
  - letterbox margins (the one spot that already panned) still pan
