### PR TITLE
fix(ci): upload iOS dSYMs to Sentry after the archive

### DIFF
--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -186,6 +186,13 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
 
+      # Needed by the post-archive `vp run mobile:upload-dsyms` step at the end
+      # of this job; the rest of the build shells out to bunx/xcodebuild directly.
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: 'lts'
+          cache: true
+
       - name: Install Node.js dependencies (workspace root)
         run: bun install --frozen-lockfile
 
@@ -483,18 +490,20 @@ jobs:
           </plist>
           PLIST
 
-      # The @sentry/react-native build phases upload JS source maps + native
-      # dSYMs during `xcodebuild archive`. Without a token the upload errors and
-      # fails the archive (sentry-xcode.sh exits non-zero), so gate it: only
-      # enable the upload when SENTRY_AUTH_TOKEN is present, otherwise skip it and
-      # keep the build green. SENTRY_DISABLE_AUTO_UPLOAD is read by both phases.
+      # The @sentry/react-native build phases upload the JS source maps during
+      # `xcodebuild archive`. Without a token the upload errors and fails the
+      # archive (sentry-xcode.sh exits non-zero), so gate it: only enable the
+      # upload when SENTRY_AUTH_TOKEN is present, otherwise skip it and keep the
+      # build green. SENTRY_DISABLE_AUTO_UPLOAD is read by both phases, and by
+      # the post-archive dSYM upload at the end of this job — the phases run too
+      # early to see the real dSYMs (see that step's comment / #4202).
       - name: Configure Sentry source map upload
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           if [ -n "$SENTRY_AUTH_TOKEN" ]; then
             echo "SENTRY_DISABLE_AUTO_UPLOAD=false" >> "$GITHUB_ENV"
-            echo "Sentry auth token present — source maps + dSYMs will upload."
+            echo "Sentry auth token present — source maps upload during the archive, dSYMs after it."
           else
             echo "SENTRY_DISABLE_AUTO_UPLOAD=true" >> "$GITHUB_ENV"
             echo "::warning::SENTRY_AUTH_TOKEN not set — skipping Sentry source map upload."
@@ -628,6 +637,26 @@ jobs:
             echo "::error::Failed to push $tag."
             exit 1
           fi
+
+      # The @sentry/react-native "Upload Debug Symbols to Sentry" build phase runs
+      # INSIDE the app target's build, and the app's dSYM does not exist yet when
+      # it does: in run 30781376709 the phase uploaded at 03:32:14.54 and
+      # GenerateDSYMFile produced Boardsesh.app.dSYM at 03:32:16.95. So it found
+      # only the stripped executables and shipped those — symbol names, no DWARF,
+      # hence `(<unknown>)` for file and line on every native frame (#4202). The
+      # DWARF for statically linked pods (libRNScreens.a, where BOARDSESH-9K
+      # crashed) lives ONLY in the app's dSYM, so nothing that phase uploads can
+      # ever produce a line number. Don't move this back into the archive.
+      #
+      # Runs after the tag steps on purpose: this step hard-fails on a bad or
+      # missing upload, and a failure before the tags would leave the shipped
+      # fingerprint untagged, making the next push to main rebuild and re-upload
+      # the same binary to TestFlight.
+      - name: Upload iOS dSYMs to Sentry
+        if: steps.testflight_upload.outcome == 'success' && env.SENTRY_DISABLE_AUTO_UPLOAD == 'false'
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: vp run mobile:upload-dsyms -- --archive "$ARCHIVE_PATH"
 
       - name: Clean up keychain and credentials
         if: always()

--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -525,6 +525,28 @@ jobs:
             CURRENT_PROJECT_VERSION=${{ steps.build_number.outputs.value }} \
             DEVELOPMENT_TEAM=9L3HKPZBH3
 
+      # The @sentry/react-native "Upload Debug Symbols to Sentry" build phase runs
+      # INSIDE the app target's build, and the app's dSYM does not exist yet when
+      # it does: in run 30781376709 the phase uploaded at 03:32:14.54 and
+      # GenerateDSYMFile produced Boardsesh.app.dSYM at 03:32:16.95. So it found
+      # only the stripped executables and shipped those — symbol names, no DWARF,
+      # hence `(<unknown>)` for file and line on every native frame (#4202). The
+      # DWARF for statically linked pods (libRNScreens.a, where BOARDSESH-9K
+      # crashed) lives ONLY in the app's dSYM, so nothing that phase uploads can
+      # ever produce a line number. Don't move this back into the archive.
+      #
+      # Deliberately BEFORE the TestFlight export and the fingerprint tag: this
+      # step hard-fails, and after either of those a failure would be unfixable
+      # without a manual rebuild — the binary is already in TestFlight and the
+      # fingerprint tag makes the next push skip the native build, so the missing
+      # dSYMs never get a second chance. Here, a failure ships nothing and pushes
+      # no tag, so the next push simply builds and uploads again.
+      - name: Upload iOS dSYMs to Sentry
+        if: env.SENTRY_DISABLE_AUTO_UPLOAD == 'false'
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: vp run mobile:upload-dsyms -- --archive "$ARCHIVE_PATH"
+
       - name: Export archive (uploads to TestFlight)
         id: testflight_upload
         env:
@@ -637,26 +659,6 @@ jobs:
             echo "::error::Failed to push $tag."
             exit 1
           fi
-
-      # The @sentry/react-native "Upload Debug Symbols to Sentry" build phase runs
-      # INSIDE the app target's build, and the app's dSYM does not exist yet when
-      # it does: in run 30781376709 the phase uploaded at 03:32:14.54 and
-      # GenerateDSYMFile produced Boardsesh.app.dSYM at 03:32:16.95. So it found
-      # only the stripped executables and shipped those — symbol names, no DWARF,
-      # hence `(<unknown>)` for file and line on every native frame (#4202). The
-      # DWARF for statically linked pods (libRNScreens.a, where BOARDSESH-9K
-      # crashed) lives ONLY in the app's dSYM, so nothing that phase uploads can
-      # ever produce a line number. Don't move this back into the archive.
-      #
-      # Runs after the tag steps on purpose: this step hard-fails on a bad or
-      # missing upload, and a failure before the tags would leave the shipped
-      # fingerprint untagged, making the next push to main rebuild and re-upload
-      # the same binary to TestFlight.
-      - name: Upload iOS dSYMs to Sentry
-        if: steps.testflight_upload.outcome == 'success' && env.SENTRY_DISABLE_AUTO_UPLOAD == 'false'
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        run: vp run mobile:upload-dsyms -- --archive "$ARCHIVE_PATH"
 
       - name: Clean up keychain and credentials
         if: always()

--- a/docs/mobile-error-telemetry.md
+++ b/docs/mobile-error-telemetry.md
@@ -9,8 +9,9 @@ captures errors. Two reasons Sentry owns crashes:
   catches iOS/Android native faults — the board-renderer, live-activity, and BLE
   native modules, plus any Expo native module — persists them across the crash, and
   uploads on the next launch. That coverage gap is why Sentry is here.
-- **Symbolicated JS.** The CI build uploads source maps (+ dSYMs on iOS), so JS stack
-  traces resolve to real file/line instead of minified offsets.
+- **Symbolicated stacks.** The CI build uploads JS source maps and, on iOS, the
+  archive's dSYMs, so both JS and native frames resolve to real file/line instead of
+  minified offsets and bare symbol names.
 
 `src/lib/sentry.ts` calls `Sentry.init()` (gated `!!dsn && !__DEV__`, so local Metro
 dev never sends), owns the global `ErrorUtils` handler, and exposes `captureToSentry`
@@ -82,13 +83,33 @@ so events group in Sentry: `react-query`, `native-auth`, `queue-mutation`,
 
 ## Source maps / symbolication (CI)
 
-- **iOS** (`ios-testflight-rn.yml`): the `@sentry/react-native` Xcode build phases
-  upload JS source maps + dSYMs when `SENTRY_AUTH_TOKEN` is present
-  (`SENTRY_DISABLE_AUTO_UPLOAD` gates it; the build stays green without the token).
-- **Android** (`android-apk-rn.yml`): JS source-map upload is **disabled**
-  (`SENTRY_DISABLE_AUTO_UPLOAD=true`) — the Gradle upload task is incompatible with
-  the Gradle version Expo prebuild generates. Native crashes are still captured;
-  Android JS symbolication is a follow-up.
+Both are gated on `SENTRY_AUTH_TOKEN`; without it the builds stay green and upload
+nothing.
+
+- **iOS JS source maps** (`ios-testflight-rn.yml`): the `@sentry/react-native` Xcode
+  build phases upload them during `xcodebuild archive`
+  (`SENTRY_DISABLE_AUTO_UPLOAD=false`).
+- **iOS dSYMs** (`ios-testflight-rn.yml`, `Upload iOS dSYMs to Sentry`): a separate
+  step after the archive, running `vp run mobile:upload-dsyms` over
+  `<archive>/dSYMs`. It has to be separate: the Sentry build phase runs inside the
+  app target's build, ~2s before `GenerateDSYMFile` writes `Boardsesh.app.dSYM`, so
+  it only ever finds the stripped executables. Those carry a symbol table (function
+  names) but no DWARF, which is why every native frame read `(<unknown>)` for file
+  and line until #4202. The DWARF for statically linked pods — `libRNScreens.a` and
+  friends — exists _only_ inside the app's dSYM.
+  `scripts/mobile-upload-dsyms.ts` fails the job if that dSYM is missing from the
+  archive, so the regression can't come back quietly.
+- **Android JS source maps**: uploaded on the **OTA** path, not the Gradle one —
+  `mobile-ota-production.yml` runs `mobile:upload-sourcemaps` for Android on every
+  published update. The in-build Gradle task stays off
+  (`SENTRY_DISABLE_AUTO_UPLOAD=true` in `android-apk-rn.yml`) because it calls an API
+  the Gradle version Expo prebuild generates doesn't have. The gap that leaves is the
+  bundle baked into the APK, i.e. JS stacks from a device that hasn't taken its first
+  OTA yet.
+- **Android native symbols**: nothing to upload. The `.so` files come from prebuilt
+  React Native / Expo AARs that ship stripped, and we build no NDK code of our own, so
+  there is no Android equivalent of the iOS dSYM fix. Native Android crashes are still
+  captured, just not symbolicated.
 
 ## Verifying
 

--- a/scripts/mobile-dsyms.test.ts
+++ b/scripts/mobile-dsyms.test.ts
@@ -185,7 +185,34 @@ describe('uploadArchiveDsyms', () => {
     } finally {
       restoreWarn.mockRestore();
     }
-    expect(warnings.join('\n')).toContain('none were reported as a debug companion');
+    expect(warnings.join('\n')).toContain('only 0 were reported as a debug companion');
+  });
+
+  // A partial count is as much of a red flag as none at all.
+  it('warns when only some of the uploaded files were debug companions', () => {
+    const fixture = createArchiveFixture();
+    const warnings: string[] = [];
+    const restoreWarn = vi.spyOn(console, 'warn').mockImplementation((message: string) => void warnings.push(message));
+    try {
+      uploadArchiveDsyms(
+        { archivePath: fixture.archivePath, mobileDir: fixture.mobileDir, environment },
+        {
+          resolveSentryCli: () => '/fake/sentry-cli',
+          spawnSentryCli: () => ({
+            status: 0,
+            stdout: [
+              '> Found 4 debug information files',
+              '> Uploaded 2 missing debug information files',
+              '  UPLOADED d69bd35e-63ce-3442-8292-e49dc3f59ace (Boardsesh.app.dSYM; arm64 debug companion)',
+              '  UPLOADED 9eef0f2c-e2a3-3b64-ba15-7b31c56bcb50 (BoardseshBeta.appex/BoardseshBeta; arm64 executable)',
+            ].join('\n'),
+          }),
+        },
+      );
+    } finally {
+      restoreWarn.mockRestore();
+    }
+    expect(warnings.join('\n')).toContain('only 1 were reported as a debug companion');
   });
 
   // A re-run against an archive Sentry already has uploads nothing and lists no

--- a/scripts/mobile-dsyms.test.ts
+++ b/scripts/mobile-dsyms.test.ts
@@ -1,0 +1,264 @@
+/// <reference types="node" />
+
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  collectArchiveDsyms,
+  parseUploadDsymsArgs,
+  parseUploadSummary,
+  resolveSentryCli,
+  uploadArchiveDsyms,
+} from './mobile-upload-dsyms';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const createdDirectories: string[] = [];
+
+/** The real output from run 30781376709 — the #4202 symptom, executables only. */
+const EXECUTABLES_ONLY_OUTPUT = [
+  '> Found 31 debug information files',
+  '> Prepared debug information files for upload',
+  '> Uploaded 3 missing debug information files',
+  '> File upload complete:',
+  '',
+  '  UPLOADED d69bd35e-63ce-3442-8292-e49dc3f59ace (Boardsesh.app/Boardsesh; arm64 executable)',
+  '  UPLOADED 9eef0f2c-e2a3-3b64-ba15-7b31c56bcb50 (BoardseshBeta.appex/BoardseshBeta; arm64 executable)',
+  '  UPLOADED e165a021-6f84-3980-a05f-c0c3b66c5a6c (BoardseshWidgets.appex/BoardseshWidgets; arm64 executable)',
+].join('\n');
+
+/** What the fixed step must produce instead. */
+const DEBUG_COMPANIONS_OUTPUT = [
+  '> Found 4 debug information files',
+  '> Uploaded 2 missing debug information files',
+  '> File upload complete:',
+  '',
+  '  UPLOADED d69bd35e-63ce-3442-8292-e49dc3f59ace (Boardsesh.app.dSYM; arm64 debug companion)',
+  '  UPLOADED 9eef0f2c-e2a3-3b64-ba15-7b31c56bcb50 (BoardseshBeta.appex.dSYM; arm64 debug companion)',
+].join('\n');
+
+interface ArchiveFixture {
+  archivePath: string;
+  dsymsDir: string;
+  mobileDir: string;
+}
+
+function createArchiveFixture(bundleNames: readonly string[] = ['Boardsesh.app.dSYM']): ArchiveFixture {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'boardsesh-dsyms-test-'));
+  createdDirectories.push(fixtureRoot);
+  const archivePath = join(fixtureRoot, 'Boardsesh.xcarchive');
+  const dsymsDir = join(archivePath, 'dSYMs');
+  mkdirSync(dsymsDir, { recursive: true });
+  for (const bundleName of bundleNames) addDsymBundle(dsymsDir, bundleName);
+  const mobileDir = join(fixtureRoot, 'mobile');
+  mkdirSync(mobileDir);
+  writeFileSync(join(mobileDir, 'package.json'), '{"name":"fixture"}\n');
+  return { archivePath, dsymsDir, mobileDir };
+}
+
+function addDsymBundle(dsymsDir: string, bundleName: string, dwarfContents = 'DWARF'): string {
+  const dwarfDir = join(dsymsDir, bundleName, 'Contents', 'Resources', 'DWARF');
+  mkdirSync(dwarfDir, { recursive: true });
+  writeFileSync(join(dwarfDir, bundleName.replace(/\.(app|appex|framework)?\.dSYM$/, '')), dwarfContents);
+  return join(dsymsDir, bundleName);
+}
+
+function readRepositoryFile(relativePath: string): string {
+  return readFileSync(resolve(REPO_ROOT, relativePath), 'utf8');
+}
+
+afterEach(() => {
+  while (createdDirectories.length > 0) {
+    const directoryPath = createdDirectories.pop();
+    if (directoryPath) rmSync(directoryPath, { recursive: true, force: true });
+  }
+});
+
+describe('archive dSYM validation', () => {
+  it('collects every dSYM bundle that carries a DWARF payload', () => {
+    const fixture = createArchiveFixture(['Boardsesh.app.dSYM', 'BoardseshWidgets.appex.dSYM']);
+    expect(collectArchiveDsyms(fixture.archivePath)).toEqual({
+      dsymsDir: fixture.dsymsDir,
+      bundleNames: ['Boardsesh.app.dSYM', 'BoardseshWidgets.appex.dSYM'],
+      appBundleNames: ['Boardsesh.app.dSYM'],
+    });
+  });
+
+  it('rejects a missing archive or a missing dSYMs directory', () => {
+    const fixture = createArchiveFixture();
+    expect(() => collectArchiveDsyms(join(fixture.archivePath, 'nope.xcarchive'))).toThrow('Xcode archive does not');
+    rmSync(fixture.dsymsDir, { recursive: true, force: true });
+    expect(() => collectArchiveDsyms(fixture.archivePath)).toThrow("Archive's dSYMs directory does not exist");
+  });
+
+  it('rejects a symlinked dSYMs directory', () => {
+    const fixture = createArchiveFixture();
+    const decoyArchive = join(dirname(fixture.archivePath), 'Decoy.xcarchive');
+    mkdirSync(decoyArchive);
+    symlinkSync(fixture.dsymsDir, join(decoyArchive, 'dSYMs'));
+    expect(() => collectArchiveDsyms(decoyArchive)).toThrow('Refusing symbolic-link');
+  });
+
+  it('rejects bundles with no DWARF payload', () => {
+    const fixture = createArchiveFixture([]);
+    mkdirSync(join(fixture.dsymsDir, 'Boardsesh.app.dSYM', 'Contents', 'Resources', 'DWARF'), { recursive: true });
+    expect(() => collectArchiveDsyms(fixture.archivePath)).toThrow('No dSYM bundles with a DWARF payload');
+  });
+
+  // The #4202 regression itself: the appexes' dSYMs existed early enough to be
+  // uploaded, the app's did not — and only the app's carries the DWARF for
+  // statically linked pods like libRNScreens.a.
+  it('rejects an archive whose only dSYMs are extensions', () => {
+    const fixture = createArchiveFixture(['BoardseshBeta.appex.dSYM', 'BoardseshWidgets.appex.dSYM']);
+    expect(() => collectArchiveDsyms(fixture.archivePath)).toThrow('No *.app.dSYM');
+  });
+});
+
+describe('sentry-cli upload output', () => {
+  it('reads the counts and tells executables apart from debug companions', () => {
+    expect(parseUploadSummary(EXECUTABLES_ONLY_OUTPUT)).toEqual({ found: 31, uploaded: 3, debugCompanions: 0 });
+    expect(parseUploadSummary(DEBUG_COMPANIONS_OUTPUT)).toEqual({ found: 4, uploaded: 2, debugCompanions: 2 });
+  });
+
+  it('reports zero for output with no counts at all', () => {
+    expect(parseUploadSummary('')).toEqual({ found: 0, uploaded: 0, debugCompanions: 0 });
+  });
+});
+
+describe('uploadArchiveDsyms', () => {
+  const environment = { SENTRY_AUTH_TOKEN: 'test-token' };
+
+  it('invokes sentry-cli against the archive dSYMs with the boardsesh Sentry env', () => {
+    const fixture = createArchiveFixture(['Boardsesh.app.dSYM', 'BoardseshBeta.appex.dSYM']);
+    const invocations: { executable: string; args: string[]; env: NodeJS.ProcessEnv }[] = [];
+
+    const result = uploadArchiveDsyms(
+      { archivePath: fixture.archivePath, mobileDir: fixture.mobileDir, environment },
+      {
+        resolveSentryCli: () => '/fake/sentry-cli',
+        spawnSentryCli: (executable, args, options) => {
+          invocations.push({ executable, args, env: options.env });
+          return { status: 0, stdout: DEBUG_COMPANIONS_OUTPUT };
+        },
+      },
+    );
+
+    expect(invocations).toHaveLength(1);
+    expect(invocations[0].executable).toBe('/fake/sentry-cli');
+    expect(invocations[0].args).toEqual(['debug-files', 'upload', fixture.dsymsDir]);
+    expect(invocations[0].env).toMatchObject({
+      SENTRY_AUTH_TOKEN: 'test-token',
+      SENTRY_ORG: 'boardsesh',
+      SENTRY_PROJECT: 'boardsesh',
+    });
+    expect(result).toMatchObject({ found: 4, uploaded: 2, debugCompanions: 2 });
+  });
+
+  it('accepts a run where Sentry already had every dSYM', () => {
+    const fixture = createArchiveFixture();
+    const result = uploadArchiveDsyms(
+      { archivePath: fixture.archivePath, mobileDir: fixture.mobileDir, environment },
+      {
+        resolveSentryCli: () => '/fake/sentry-cli',
+        spawnSentryCli: () => ({
+          status: 0,
+          stdout: '> Found 4 debug information files\n> Uploaded 0 missing debug information files\n',
+        }),
+      },
+    );
+    expect(result).toMatchObject({ found: 4, uploaded: 0, debugCompanions: 0 });
+  });
+
+  it('fails on a non-zero exit, an unstartable CLI, or an empty local scan', () => {
+    const fixture = createArchiveFixture();
+    const dependencies = { resolveSentryCli: () => '/fake/sentry-cli' };
+    const options = { archivePath: fixture.archivePath, mobileDir: fixture.mobileDir, environment };
+
+    expect(() =>
+      uploadArchiveDsyms(options, {
+        ...dependencies,
+        spawnSentryCli: () => ({ status: 1, stderr: 'error: API request failed' }),
+      }),
+    ).toThrow('exit code 1');
+
+    expect(() =>
+      uploadArchiveDsyms(options, {
+        ...dependencies,
+        spawnSentryCli: () => ({ status: null, error: new Error('ENOENT') }),
+      }),
+    ).toThrow('Could not start sentry-cli');
+
+    expect(() =>
+      uploadArchiveDsyms(options, {
+        ...dependencies,
+        spawnSentryCli: () => ({ status: 0, stdout: '> Found 0 debug information files\n' }),
+      }),
+    ).toThrow('found no debug information files');
+  });
+
+  // Validating the archive before the token means a local run without
+  // SENTRY_AUTH_TOKEN still reports the real problem.
+  it('validates the archive before requiring an auth token', () => {
+    const fixture = createArchiveFixture(['BoardseshWidgets.appex.dSYM']);
+    expect(() =>
+      uploadArchiveDsyms({ archivePath: fixture.archivePath, mobileDir: fixture.mobileDir, environment: {} }),
+    ).toThrow('No *.app.dSYM');
+  });
+
+  it('requires an auth token once the archive checks out', () => {
+    const fixture = createArchiveFixture();
+    expect(() =>
+      uploadArchiveDsyms({ archivePath: fixture.archivePath, mobileDir: fixture.mobileDir, environment: {} }),
+    ).toThrow('SENTRY_AUTH_TOKEN is required');
+  });
+});
+
+describe('sentry-cli resolution', () => {
+  it('resolves the installed binary from packages/mobile', () => {
+    const executablePath = resolveSentryCli(resolve(REPO_ROOT, 'packages/mobile'));
+    expect(executablePath).toContain('sentry-cli');
+  });
+
+  it('explains the direct-dependency requirement when it cannot resolve', () => {
+    const fixture = createArchiveFixture();
+    expect(() => resolveSentryCli(fixture.mobileDir)).toThrow('direct dependency');
+  });
+});
+
+describe('argument parsing', () => {
+  it('accepts both --archive forms and defaults to the workflow archive path', () => {
+    expect(parseUploadDsymsArgs(['--archive', '/tmp/A.xcarchive'])).toEqual({ archivePath: '/tmp/A.xcarchive' });
+    expect(parseUploadDsymsArgs(['--', '--archive=/tmp/B.xcarchive'])).toEqual({ archivePath: '/tmp/B.xcarchive' });
+    expect(parseUploadDsymsArgs([]).archivePath).toBe(
+      resolve(REPO_ROOT, 'packages/mobile/ios/build/Boardsesh.xcarchive'),
+    );
+  });
+
+  it('rejects unknown and empty arguments', () => {
+    expect(() => parseUploadDsymsArgs(['--platform', 'ios'])).toThrow('Unknown argument');
+    expect(() => parseUploadDsymsArgs(['--archive', ''])).toThrow('--archive requires a path');
+  });
+});
+
+describe('iOS TestFlight workflow wiring', () => {
+  const workflow = readRepositoryFile('.github/workflows/ios-testflight-rn.yml');
+
+  it('uploads the dSYMs from the finished archive, not from the build phase', () => {
+    expect(workflow).toContain('run: vp run mobile:upload-dsyms -- --archive "$ARCHIVE_PATH"');
+    // vp is not otherwise set up in this macOS job.
+    expect(workflow).toContain('voidzero-dev/setup-vp@v1');
+  });
+
+  // A failure here must not skip the tag steps: without the fingerprint tag the
+  // next push to main rebuilds and re-uploads the same binary to TestFlight.
+  it('runs the upload after the fingerprint and build-number tags', () => {
+    expect(workflow.indexOf('- name: Upload iOS dSYMs to Sentry')).toBeGreaterThan(
+      workflow.indexOf('- name: Tag the uploaded iOS build number'),
+    );
+  });
+
+  it('registers the vp task the workflow calls', () => {
+    expect(readRepositoryFile('vite.config.ts')).toContain("'mobile:upload-dsyms'");
+  });
+});

--- a/scripts/mobile-dsyms.test.ts
+++ b/scripts/mobile-dsyms.test.ts
@@ -250,12 +250,15 @@ describe('iOS TestFlight workflow wiring', () => {
     expect(workflow).toContain('voidzero-dev/setup-vp@v1');
   });
 
-  // A failure here must not skip the tag steps: without the fingerprint tag the
-  // next push to main rebuilds and re-uploads the same binary to TestFlight.
-  it('runs the upload after the fingerprint and build-number tags', () => {
-    expect(workflow.indexOf('- name: Upload iOS dSYMs to Sentry')).toBeGreaterThan(
-      workflow.indexOf('- name: Tag the uploaded iOS build number'),
-    );
+  // The step hard-fails, so it has to run while a failure is still recoverable:
+  // after the TestFlight export the binary has shipped, and after the
+  // fingerprint tag the next push skips the native build entirely — either way
+  // the dSYMs would never get a second chance without a manual rebuild.
+  it('runs the upload before the TestFlight export and the fingerprint tag', () => {
+    const uploadIndex = workflow.indexOf('- name: Upload iOS dSYMs to Sentry');
+    expect(uploadIndex).toBeGreaterThan(workflow.indexOf('- name: Archive'));
+    expect(uploadIndex).toBeLessThan(workflow.indexOf('- name: Export archive (uploads to TestFlight)'));
+    expect(uploadIndex).toBeLessThan(workflow.indexOf('- name: Tag the shipped iOS fingerprint'));
   });
 
   it('registers the vp task the workflow calls', () => {

--- a/scripts/mobile-dsyms.test.ts
+++ b/scripts/mobile-dsyms.test.ts
@@ -4,7 +4,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSyn
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   collectArchiveDsyms,
   parseUploadDsymsArgs,
@@ -155,6 +155,48 @@ describe('uploadArchiveDsyms', () => {
     expect(result).toMatchObject({ found: 4, uploaded: 2, debugCompanions: 2 });
   });
 
+  // Uploading something that isn't a debug companion is the #4202 signature.
+  // Warned, not thrown: this step gates the TestFlight upload and the check
+  // depends on sentry-cli's output wording, which must not block a release.
+  it('warns when it uploaded files but none were debug companions', () => {
+    const fixture = createArchiveFixture();
+    const warnings: string[] = [];
+    const restoreWarn = vi.spyOn(console, 'warn').mockImplementation((message: string) => void warnings.push(message));
+    try {
+      const result = uploadArchiveDsyms(
+        { archivePath: fixture.archivePath, mobileDir: fixture.mobileDir, environment },
+        {
+          resolveSentryCli: () => '/fake/sentry-cli',
+          spawnSentryCli: () => ({ status: 0, stdout: EXECUTABLES_ONLY_OUTPUT }),
+        },
+      );
+      expect(result).toMatchObject({ uploaded: 3, debugCompanions: 0 });
+    } finally {
+      restoreWarn.mockRestore();
+    }
+    expect(warnings.join('\n')).toContain('none were reported as a debug companion');
+  });
+
+  it('does not warn when Sentry already had every dSYM', () => {
+    const fixture = createArchiveFixture();
+    const restoreWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      uploadArchiveDsyms(
+        { archivePath: fixture.archivePath, mobileDir: fixture.mobileDir, environment },
+        {
+          resolveSentryCli: () => '/fake/sentry-cli',
+          spawnSentryCli: () => ({
+            status: 0,
+            stdout: '> Found 4 debug information files\n> Uploaded 0 missing debug information files\n',
+          }),
+        },
+      );
+      expect(restoreWarn).not.toHaveBeenCalled();
+    } finally {
+      restoreWarn.mockRestore();
+    }
+  });
+
   it('accepts a run where Sentry already had every dSYM', () => {
     const fixture = createArchiveFixture();
     const result = uploadArchiveDsyms(
@@ -235,9 +277,11 @@ describe('argument parsing', () => {
     );
   });
 
-  it('rejects unknown and empty arguments', () => {
+  it('rejects unknown, empty, and value-less arguments', () => {
     expect(() => parseUploadDsymsArgs(['--platform', 'ios'])).toThrow('Unknown argument');
     expect(() => parseUploadDsymsArgs(['--archive', ''])).toThrow('--archive requires a path');
+    // Must not silently fall back to the default archive.
+    expect(() => parseUploadDsymsArgs(['--archive'])).toThrow('--archive requires a path');
   });
 });
 

--- a/scripts/mobile-dsyms.test.ts
+++ b/scripts/mobile-dsyms.test.ts
@@ -142,14 +142,14 @@ describe('uploadArchiveDsyms', () => {
 
   it('invokes sentry-cli against the archive dSYMs with the boardsesh Sentry env', () => {
     const fixture = createArchiveFixture(['Boardsesh.app.dSYM', 'BoardseshBeta.appex.dSYM']);
-    const invocations: { executable: string; args: string[]; env: NodeJS.ProcessEnv }[] = [];
+    const invocations: { executable: string; args: string[]; options: Record<string, unknown> }[] = [];
 
     const result = uploadArchiveDsyms(
       { archivePath: fixture.archivePath, mobileDir: fixture.mobileDir, environment },
       {
         resolveSentryCli: () => '/fake/sentry-cli',
         spawnSentryCli: (executable, args, options) => {
-          invocations.push({ executable, args, env: options.env });
+          invocations.push({ executable, args, options });
           return { status: 0, stdout: DEBUG_COMPANIONS_OUTPUT };
         },
       },
@@ -158,11 +158,15 @@ describe('uploadArchiveDsyms', () => {
     expect(invocations).toHaveLength(1);
     expect(invocations[0].executable).toBe('/fake/sentry-cli');
     expect(invocations[0].args).toEqual(['debug-files', 'upload', fixture.dsymsDir]);
-    expect(invocations[0].env).toMatchObject({
+    expect(invocations[0].options.env).toMatchObject({
       SENTRY_AUTH_TOKEN: 'test-token',
       SENTRY_ORG: 'boardsesh',
       SENTRY_PROJECT: 'boardsesh',
     });
+    // Bounded: this step gates the TestFlight export, so it must not hang, and
+    // Node's 1 MB default maxBuffer must not kill a healthy upload.
+    expect(invocations[0].options.timeout).toBe(600_000);
+    expect(invocations[0].options.maxBuffer).toBeGreaterThanOrEqual(32 * 1024 * 1024);
     expect(result).toMatchObject({ found: 4, uploaded: 2, debugCompanions: 2 });
   });
 
@@ -255,7 +259,18 @@ describe('uploadArchiveDsyms', () => {
         ...dependencies,
         spawnSentryCli: () => ({ status: null, error: new Error('ENOENT') }),
       }),
-    ).toThrow('Could not start sentry-cli');
+    ).toThrow('Could not run sentry-cli');
+
+    // A hung upload would otherwise hold the TestFlight export until the job's
+    // own timeout, so the kill must be reported as what it is.
+    const timeoutError: NodeJS.ErrnoException = new Error('spawnSync ETIMEDOUT');
+    timeoutError.code = 'ETIMEDOUT';
+    expect(() =>
+      uploadArchiveDsyms(options, {
+        ...dependencies,
+        spawnSentryCli: () => ({ status: null, error: timeoutError }),
+      }),
+    ).toThrow('did not finish within 10 minutes');
 
     expect(() =>
       uploadArchiveDsyms(options, {

--- a/scripts/mobile-dsyms.test.ts
+++ b/scripts/mobile-dsyms.test.ts
@@ -106,6 +106,17 @@ describe('archive dSYM validation', () => {
     expect(() => collectArchiveDsyms(fixture.archivePath)).toThrow('No dSYM bundles with a DWARF payload');
   });
 
+  // A link can't stand in for the debug information we're asserting on.
+  it('does not count a symlinked DWARF entry as a payload', () => {
+    const fixture = createArchiveFixture([]);
+    const dwarfDir = join(fixture.dsymsDir, 'Boardsesh.app.dSYM', 'Contents', 'Resources', 'DWARF');
+    mkdirSync(dwarfDir, { recursive: true });
+    const realPayload = join(dirname(fixture.archivePath), 'elsewhere-dwarf');
+    writeFileSync(realPayload, 'DWARF');
+    symlinkSync(realPayload, join(dwarfDir, 'Boardsesh'));
+    expect(() => collectArchiveDsyms(fixture.archivePath)).toThrow('No dSYM bundles with a DWARF payload');
+  });
+
   // The #4202 regression itself: the appexes' dSYMs existed early enough to be
   // uploaded, the app's did not — and only the app's carries the DWARF for
   // statically linked pods like libRNScreens.a.
@@ -177,11 +188,13 @@ describe('uploadArchiveDsyms', () => {
     expect(warnings.join('\n')).toContain('none were reported as a debug companion');
   });
 
-  it('does not warn when Sentry already had every dSYM', () => {
+  // A re-run against an archive Sentry already has uploads nothing and lists no
+  // companions — that's expected, and must not trip the warning above.
+  it('accepts a run where Sentry already had every dSYM, without warning', () => {
     const fixture = createArchiveFixture();
-    const restoreWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     try {
-      uploadArchiveDsyms(
+      const result = uploadArchiveDsyms(
         { archivePath: fixture.archivePath, mobileDir: fixture.mobileDir, environment },
         {
           resolveSentryCli: () => '/fake/sentry-cli',
@@ -191,25 +204,11 @@ describe('uploadArchiveDsyms', () => {
           }),
         },
       );
-      expect(restoreWarn).not.toHaveBeenCalled();
+      expect(result).toMatchObject({ found: 4, uploaded: 0, debugCompanions: 0 });
+      expect(warnSpy).not.toHaveBeenCalled();
     } finally {
-      restoreWarn.mockRestore();
+      warnSpy.mockRestore();
     }
-  });
-
-  it('accepts a run where Sentry already had every dSYM', () => {
-    const fixture = createArchiveFixture();
-    const result = uploadArchiveDsyms(
-      { archivePath: fixture.archivePath, mobileDir: fixture.mobileDir, environment },
-      {
-        resolveSentryCli: () => '/fake/sentry-cli',
-        spawnSentryCli: () => ({
-          status: 0,
-          stdout: '> Found 4 debug information files\n> Uploaded 0 missing debug information files\n',
-        }),
-      },
-    );
-    expect(result).toMatchObject({ found: 4, uploaded: 0, debugCompanions: 0 });
   });
 
   it('fails on a non-zero exit, an unstartable CLI, or an empty local scan', () => {

--- a/scripts/mobile-upload-dsyms.ts
+++ b/scripts/mobile-upload-dsyms.ts
@@ -87,8 +87,8 @@ function hasDwarfPayload(bundlePath: string): boolean {
   const dwarfDir = join(bundlePath, 'Contents', 'Resources', 'DWARF');
   if (!existsSync(dwarfDir) || !statSync(dwarfDir).isDirectory()) return false;
   return readdirSync(dwarfDir).some((entryName) => {
-    const entryPath = join(dwarfDir, entryName);
-    return statSync(entryPath).isFile() && statSync(entryPath).size > 0;
+    const entryStats = statSync(join(dwarfDir, entryName));
+    return entryStats.isFile() && entryStats.size > 0;
   });
 }
 
@@ -222,6 +222,21 @@ export function uploadArchiveDsyms(
     );
   }
 
+  // Everything fed to sentry-cli here came out of `<archive>/dSYMs`, so anything
+  // it newly uploads should be a debug companion. Uploading something that isn't
+  // one is the #4202 signature (stripped executables reaching Sentry instead of
+  // DWARF) and worth shouting about. It's a warning rather than a failure on
+  // purpose: this step gates the TestFlight upload, and unlike the structural
+  // checks above, this one depends on sentry-cli's exact output wording — a
+  // cosmetic change upstream must not be able to block a release.
+  if (summary.uploaded > 0 && summary.debugCompanions === 0) {
+    console.warn(
+      `::warning::sentry-cli uploaded ${summary.uploaded} file(s) from ${archiveDsyms.dsymsDir} but none were ` +
+        'reported as a debug companion. Native crashes may again arrive without file/line — check the output above ' +
+        'against #4202 before trusting the next crash report.',
+    );
+  }
+
   console.log(
     `[mobile:upload-dsyms] sentry-cli found ${summary.found} debug information file(s), uploaded ${summary.uploaded} ` +
       `missing (${summary.debugCompanions} debug companion). Zero uploaded means Sentry already had them.`,
@@ -235,7 +250,11 @@ export function parseUploadDsymsArgs(args: string[]): { archivePath: string } {
     const argument = args[index];
     if (argument === '--') continue;
     if (argument === '--archive') {
-      archivePath = args[++index] ?? null;
+      const nextArgument = args[++index];
+      if (nextArgument === undefined) {
+        throw new Error('--archive requires a path to an .xcarchive.');
+      }
+      archivePath = nextArgument;
       continue;
     }
     if (argument.startsWith('--archive=')) {

--- a/scripts/mobile-upload-dsyms.ts
+++ b/scripts/mobile-upload-dsyms.ts
@@ -30,10 +30,20 @@ const DEFAULT_MOBILE_DIR = resolve(REPO_ROOT, 'packages', 'mobile');
 /** Matches ARCHIVE_PATH in .github/workflows/ios-testflight-rn.yml. */
 const DEFAULT_ARCHIVE_PATH = resolve(DEFAULT_MOBILE_DIR, 'ios', 'build', 'Boardsesh.xcarchive');
 
+/**
+ * Bound the upload. This step gates the TestFlight export, so a sentry-cli that
+ * hangs on a network stall would otherwise hold the release until the job's own
+ * 60-minute timeout. Ten minutes is far longer than the ~1.4s the real upload
+ * takes (run 30781376709) while still leaving room for a slow-but-alive run.
+ */
+const UPLOAD_TIMEOUT_MS = 10 * 60 * 1000;
+/** Node's 1 MB default would kill a healthy upload whose listing grew past it. */
+const UPLOAD_MAX_BUFFER_BYTES = 32 * 1024 * 1024;
+
 type SpawnSentryCli = (
   executable: string,
   args: string[],
-  options: { cwd: string; env: NodeJS.ProcessEnv; encoding: 'utf8' },
+  options: { cwd: string; env: NodeJS.ProcessEnv; encoding: 'utf8'; timeout: number; maxBuffer: number },
 ) => { status: number | null; stdout?: string; stderr?: string; error?: Error };
 
 export interface UploadDsymsOptions {
@@ -208,9 +218,16 @@ export function uploadArchiveDsyms(
     cwd: mobileDir,
     env: uploadEnvironment,
     encoding: 'utf8',
+    timeout: UPLOAD_TIMEOUT_MS,
+    maxBuffer: UPLOAD_MAX_BUFFER_BYTES,
   });
   if (uploadResult.error) {
-    throw new Error(`Could not start sentry-cli: ${uploadResult.error.message}`);
+    const { code } = uploadResult.error as NodeJS.ErrnoException;
+    throw new Error(
+      code === 'ETIMEDOUT'
+        ? `sentry-cli did not finish within ${UPLOAD_TIMEOUT_MS / 60_000} minutes and was killed: ${uploadResult.error.message}`
+        : `Could not run sentry-cli: ${uploadResult.error.message}`,
+    );
   }
   // Echo stderr on stderr (and first) so a failure is the thing you see in the
   // CI log, not something buried under the upload listing.

--- a/scripts/mobile-upload-dsyms.ts
+++ b/scripts/mobile-upload-dsyms.ts
@@ -1,0 +1,266 @@
+/// <reference types="node" />
+
+/**
+ * Uploads the iOS dSYMs from a finished `.xcarchive` to Sentry.
+ *
+ * The `@sentry/react-native` "Upload Debug Symbols to Sentry" Xcode build phase
+ * runs INSIDE the app target's build, before `GenerateDSYMFile` produces
+ * `Boardsesh.app.dSYM` (measured 2.4s apart in run 30781376709). It therefore
+ * scans `$DWARF_DSYM_FOLDER_PATH` while it still holds only the stripped
+ * executables and uploads those: a symbol table gives Sentry function names,
+ * but only DWARF gives file and line, so every native frame arrived as
+ * `(<unknown>)`. See issue #4202.
+ *
+ * The archive's `dSYMs/` directory is assembled at the end of the archive
+ * action and IS complete, so the fix is to upload from there once xcodebuild
+ * has finished. This wrapper validates that directory before spending a network
+ * round trip, so a build-order regression fails loudly instead of silently
+ * uploading nothing useful again.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { existsSync, lstatSync, readdirSync, realpathSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createSentryUploadEnvironment } from './mobile-upload-sourcemaps';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const DEFAULT_MOBILE_DIR = resolve(REPO_ROOT, 'packages', 'mobile');
+/** Matches ARCHIVE_PATH in .github/workflows/ios-testflight-rn.yml. */
+const DEFAULT_ARCHIVE_PATH = resolve(DEFAULT_MOBILE_DIR, 'ios', 'build', 'Boardsesh.xcarchive');
+
+type SpawnSentryCli = (
+  executable: string,
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv; encoding: 'utf8' },
+) => { status: number | null; stdout?: string; stderr?: string; error?: Error };
+
+export interface UploadDsymsOptions {
+  archivePath?: string;
+  mobileDir?: string;
+  environment?: NodeJS.ProcessEnv;
+}
+
+export interface UploadDsymsDependencies {
+  resolveSentryCli?: (mobileDir: string) => string;
+  spawnSentryCli?: SpawnSentryCli;
+}
+
+export interface ArchiveDsyms {
+  /** Absolute path to `<archive>/dSYMs`, the directory handed to sentry-cli. */
+  dsymsDir: string;
+  /** Every `*.dSYM` bundle in it that actually carries a DWARF payload. */
+  bundleNames: string[];
+  /** The subset named `*.app.dSYM` — the main app, where statically linked pods' DWARF lives. */
+  appBundleNames: string[];
+}
+
+export interface UploadSummary {
+  /** `Found N debug information files` — everything sentry-cli discovered locally. */
+  found: number;
+  /** `Uploaded N missing debug information files` — the subset Sentry did not already have. */
+  uploaded: number;
+  /** How many of the uploaded entries were real dSYMs (`arm64 debug companion`). */
+  debugCompanions: number;
+}
+
+export interface UploadDsymsResult extends UploadSummary {
+  archiveDsyms: ArchiveDsyms;
+}
+
+function assertRealDirectoryWithoutSymbolicLinks(candidatePath: string, label: string): string {
+  if (!existsSync(candidatePath)) {
+    throw new Error(`${label} does not exist: ${candidatePath}`);
+  }
+  if (lstatSync(candidatePath).isSymbolicLink()) {
+    throw new Error(`Refusing symbolic-link ${label.toLocaleLowerCase('en-US')}: ${candidatePath}`);
+  }
+  if (!statSync(candidatePath).isDirectory()) {
+    throw new Error(`${label} is not a directory: ${candidatePath}`);
+  }
+  return realpathSync(candidatePath);
+}
+
+/** True when the bundle holds at least one non-empty `Contents/Resources/DWARF/*` payload. */
+function hasDwarfPayload(bundlePath: string): boolean {
+  const dwarfDir = join(bundlePath, 'Contents', 'Resources', 'DWARF');
+  if (!existsSync(dwarfDir) || !statSync(dwarfDir).isDirectory()) return false;
+  return readdirSync(dwarfDir).some((entryName) => {
+    const entryPath = join(dwarfDir, entryName);
+    return statSync(entryPath).isFile() && statSync(entryPath).size > 0;
+  });
+}
+
+/**
+ * Validate `<archive>/dSYMs` and enumerate the bundles worth uploading.
+ *
+ * Requiring an `*.app.dSYM` is the regression guard for #4202: the appex dSYMs
+ * were already being produced early enough to be uploaded, but the app's — which
+ * is the only place the DWARF for statically linked pods like `libRNScreens.a`
+ * ends up — was not. Its absence means we are looking at the wrong directory or
+ * at a mid-build snapshot again.
+ */
+export function collectArchiveDsyms(archivePathInput: string): ArchiveDsyms {
+  const archivePath = resolve(archivePathInput);
+  assertRealDirectoryWithoutSymbolicLinks(archivePath, 'Xcode archive');
+  const dsymsDir = assertRealDirectoryWithoutSymbolicLinks(join(archivePath, 'dSYMs'), "Archive's dSYMs directory");
+
+  const bundleNames = readdirSync(dsymsDir)
+    .filter((entryName) => entryName.endsWith('.dSYM'))
+    .filter((entryName) => {
+      const bundlePath = join(dsymsDir, entryName);
+      return !lstatSync(bundlePath).isSymbolicLink() && statSync(bundlePath).isDirectory();
+    })
+    .filter((entryName) => hasDwarfPayload(join(dsymsDir, entryName)))
+    .sort();
+
+  if (bundleNames.length === 0) {
+    throw new Error(
+      `No dSYM bundles with a DWARF payload in ${dsymsDir}. The archive carries no debug information — ` +
+        'check that DEBUG_INFORMATION_FORMAT is dwarf-with-dsym and that xcodebuild archive completed.',
+    );
+  }
+
+  const appBundleNames = bundleNames.filter((entryName) => entryName.endsWith('.app.dSYM'));
+  if (appBundleNames.length === 0) {
+    throw new Error(
+      `No *.app.dSYM in ${dsymsDir} (found: ${bundleNames.join(', ')}). The main app's dSYM is the only place ` +
+        'the DWARF for statically linked pods lives, so without it native frames stay unsymbolicated (#4202).',
+    );
+  }
+
+  return { dsymsDir, bundleNames, appBundleNames };
+}
+
+/**
+ * Resolve the sentry-cli binary the same way the iOS build phase does: from
+ * packages/mobile, where `@sentry/cli` is a direct dependency so Bun's isolated
+ * linker actually surfaces it (guarded by scripts/mobile-native-deps-check.ts).
+ */
+export function resolveSentryCli(mobileDirInput: string): string {
+  const mobileDir = resolve(mobileDirInput);
+  if (!existsSync(mobileDir) || !statSync(mobileDir).isDirectory()) {
+    throw new Error(`Mobile directory does not exist or is not a directory: ${mobileDir}`);
+  }
+  const requireFromMobile = createRequire(join(realpathSync(mobileDir), 'package.json'));
+  let sentryCliModule: unknown;
+  try {
+    sentryCliModule = requireFromMobile('@sentry/cli');
+  } catch {
+    throw new Error(
+      `Could not resolve @sentry/cli from ${mobileDir}. It must stay a direct dependency in ` +
+        "packages/mobile/package.json (Bun's isolated linker does not surface transitive deps there).",
+    );
+  }
+  const getPath = (sentryCliModule as { getPath?: () => string }).getPath;
+  if (typeof getPath !== 'function') {
+    throw new Error('The installed @sentry/cli does not expose getPath(); cannot locate the sentry-cli binary.');
+  }
+  const executablePath = getPath();
+  if (!executablePath || !existsSync(executablePath) || !statSync(executablePath).isFile()) {
+    throw new Error(`@sentry/cli reported a sentry-cli binary that does not exist: ${executablePath}`);
+  }
+  return executablePath;
+}
+
+/**
+ * Read the counts out of `sentry-cli debug-files upload` output.
+ *
+ * `debug companion` is the line an actual dSYM produces; `executable` is the
+ * stripped binary that #4202 was uploading instead. Note that a re-run against
+ * an archive Sentry already has legitimately reports zero of both — the command
+ * only lists what it newly uploaded — so this is reported, not asserted.
+ */
+export function parseUploadSummary(output: string): UploadSummary {
+  const foundMatch = output.match(/Found (\d+) debug information file/);
+  const uploadedMatch = output.match(/Uploaded (\d+) missing debug information file/);
+  return {
+    found: foundMatch ? Number(foundMatch[1]) : 0,
+    uploaded: uploadedMatch ? Number(uploadedMatch[1]) : 0,
+    debugCompanions: (output.match(/debug companion\)/g) ?? []).length,
+  };
+}
+
+export function uploadArchiveDsyms(
+  options: UploadDsymsOptions = {},
+  dependencies: UploadDsymsDependencies = {},
+): UploadDsymsResult {
+  const mobileDir = resolve(options.mobileDir ?? DEFAULT_MOBILE_DIR);
+  // Validate the archive BEFORE the token check so a local run without
+  // SENTRY_AUTH_TOKEN still exercises every local assertion.
+  const archiveDsyms = collectArchiveDsyms(options.archivePath ?? DEFAULT_ARCHIVE_PATH);
+  const uploadEnvironment = createSentryUploadEnvironment(options.environment ?? process.env);
+  const executablePath = (dependencies.resolveSentryCli ?? resolveSentryCli)(mobileDir);
+
+  console.log(
+    `[mobile:upload-dsyms] Uploading ${archiveDsyms.bundleNames.length} dSYM bundle(s) from ${archiveDsyms.dsymsDir}: ` +
+      archiveDsyms.bundleNames.join(', '),
+  );
+
+  const spawnSentryCli: SpawnSentryCli =
+    dependencies.spawnSentryCli ?? ((executable, args, spawnOptions) => spawnSync(executable, args, spawnOptions));
+  const uploadResult = spawnSentryCli(executablePath, ['debug-files', 'upload', archiveDsyms.dsymsDir], {
+    cwd: mobileDir,
+    env: uploadEnvironment,
+    encoding: 'utf8',
+  });
+  if (uploadResult.error) {
+    throw new Error(`Could not start sentry-cli: ${uploadResult.error.message}`);
+  }
+  const output = `${uploadResult.stdout ?? ''}${uploadResult.stderr ?? ''}`;
+  if (output) console.log(output.trimEnd());
+  if (uploadResult.status !== 0) {
+    throw new Error(`sentry-cli debug-files upload failed with exit code ${uploadResult.status ?? 'unknown'}.`);
+  }
+
+  const summary = parseUploadSummary(output);
+  if (summary.found < 1) {
+    throw new Error(
+      `sentry-cli found no debug information files in ${archiveDsyms.dsymsDir}, but the directory holds ` +
+        `${archiveDsyms.bundleNames.length} dSYM bundle(s). Something is wrong with the archive or the CLI invocation.`,
+    );
+  }
+
+  console.log(
+    `[mobile:upload-dsyms] sentry-cli found ${summary.found} debug information file(s), uploaded ${summary.uploaded} ` +
+      `missing (${summary.debugCompanions} debug companion). Zero uploaded means Sentry already had them.`,
+  );
+  return { ...summary, archiveDsyms };
+}
+
+export function parseUploadDsymsArgs(args: string[]): { archivePath: string } {
+  let archivePath: string | null = null;
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index];
+    if (argument === '--') continue;
+    if (argument === '--archive') {
+      archivePath = args[++index] ?? null;
+      continue;
+    }
+    if (argument.startsWith('--archive=')) {
+      archivePath = argument.slice('--archive='.length);
+      continue;
+    }
+    throw new Error(`Unknown argument: ${argument}`);
+  }
+  if (archivePath !== null && archivePath.trim() === '') {
+    throw new Error('--archive requires a path to an .xcarchive.');
+  }
+  return { archivePath: archivePath ?? DEFAULT_ARCHIVE_PATH };
+}
+
+function isMainModule(): boolean {
+  const entryPath = process.argv[1];
+  return Boolean(entryPath) && resolve(entryPath) === fileURLToPath(import.meta.url);
+}
+
+if (isMainModule()) {
+  try {
+    uploadArchiveDsyms(parseUploadDsymsArgs(process.argv.slice(2)));
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    console.error(`[mobile:upload-dsyms] ${reason}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/mobile-upload-dsyms.ts
+++ b/scripts/mobile-upload-dsyms.ts
@@ -212,8 +212,11 @@ export function uploadArchiveDsyms(
   if (uploadResult.error) {
     throw new Error(`Could not start sentry-cli: ${uploadResult.error.message}`);
   }
+  // Echo stderr on stderr (and first) so a failure is the thing you see in the
+  // CI log, not something buried under the upload listing.
+  if (uploadResult.stderr) console.error(uploadResult.stderr.trimEnd());
+  if (uploadResult.stdout) console.log(uploadResult.stdout.trimEnd());
   const output = `${uploadResult.stdout ?? ''}${uploadResult.stderr ?? ''}`;
-  if (output) console.log(output.trimEnd());
   if (uploadResult.status !== 0) {
     throw new Error(`sentry-cli debug-files upload failed with exit code ${uploadResult.status ?? 'unknown'}.`);
   }
@@ -226,18 +229,19 @@ export function uploadArchiveDsyms(
     );
   }
 
-  // Everything fed to sentry-cli here came out of `<archive>/dSYMs`, so anything
-  // it newly uploads should be a debug companion. Uploading something that isn't
-  // one is the #4202 signature (stripped executables reaching Sentry instead of
-  // DWARF) and worth shouting about. It's a warning rather than a failure on
-  // purpose: this step gates the TestFlight upload, and unlike the structural
-  // checks above, this one depends on sentry-cli's exact output wording — a
-  // cosmetic change upstream must not be able to block a release.
-  if (summary.uploaded > 0 && summary.debugCompanions === 0) {
+  // Everything fed to sentry-cli here came out of `<archive>/dSYMs`, so EVERY
+  // file it newly uploads should be a debug companion — a partial count is as
+  // much of a red flag as none at all. Uploading something that isn't one is the
+  // #4202 signature (stripped executables reaching Sentry instead of DWARF).
+  // It's a warning rather than a failure on purpose: this step gates the
+  // TestFlight upload, and unlike the structural checks above, this one depends
+  // on sentry-cli's exact output wording — a cosmetic change upstream must not
+  // be able to block a release.
+  if (summary.uploaded > summary.debugCompanions) {
     console.warn(
-      `::warning::sentry-cli uploaded ${summary.uploaded} file(s) from ${archiveDsyms.dsymsDir} but none were ` +
-        'reported as a debug companion. Native crashes may again arrive without file/line — check the output above ' +
-        'against #4202 before trusting the next crash report.',
+      `::warning::sentry-cli uploaded ${summary.uploaded} file(s) from ${archiveDsyms.dsymsDir} but only ` +
+        `${summary.debugCompanions} were reported as a debug companion. Native crashes may again arrive without ` +
+        'file/line — check the output above against #4202 before trusting the next crash report.',
     );
   }
 

--- a/scripts/mobile-upload-dsyms.ts
+++ b/scripts/mobile-upload-dsyms.ts
@@ -74,7 +74,7 @@ function assertRealDirectoryWithoutSymbolicLinks(candidatePath: string, label: s
     throw new Error(`${label} does not exist: ${candidatePath}`);
   }
   if (lstatSync(candidatePath).isSymbolicLink()) {
-    throw new Error(`Refusing symbolic-link ${label.toLocaleLowerCase('en-US')}: ${candidatePath}`);
+    throw new Error(`Refusing symbolic-link path for ${label}: ${candidatePath}`);
   }
   if (!statSync(candidatePath).isDirectory()) {
     throw new Error(`${label} is not a directory: ${candidatePath}`);
@@ -82,12 +82,16 @@ function assertRealDirectoryWithoutSymbolicLinks(candidatePath: string, label: s
   return realpathSync(candidatePath);
 }
 
-/** True when the bundle holds at least one non-empty `Contents/Resources/DWARF/*` payload. */
+/**
+ * True when the bundle holds at least one non-empty `Contents/Resources/DWARF/*`
+ * payload. Symlinked entries don't count — same posture as the directory checks
+ * above, so a link can't stand in for the debug information we're asserting on.
+ */
 function hasDwarfPayload(bundlePath: string): boolean {
   const dwarfDir = join(bundlePath, 'Contents', 'Resources', 'DWARF');
-  if (!existsSync(dwarfDir) || !statSync(dwarfDir).isDirectory()) return false;
+  if (!existsSync(dwarfDir) || lstatSync(dwarfDir).isSymbolicLink() || !statSync(dwarfDir).isDirectory()) return false;
   return readdirSync(dwarfDir).some((entryName) => {
-    const entryStats = statSync(join(dwarfDir, entryName));
+    const entryStats = lstatSync(join(dwarfDir, entryName));
     return entryStats.isFile() && entryStats.size > 0;
   });
 }

--- a/scripts/mobile-upload-sourcemaps.ts
+++ b/scripts/mobile-upload-sourcemaps.ts
@@ -361,10 +361,11 @@ export function resolveInstalledSentryUploader(mobileDirInput: string): string {
   return existingPathWithin(packageRoot, uploaderPath, 'Official Sentry uploader');
 }
 
+/** Shared by the OTA source-map upload and the iOS dSYM upload (mobile-upload-dsyms.ts). */
 export function createSentryUploadEnvironment(environment: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const authToken = environment.SENTRY_AUTH_TOKEN?.trim();
   if (!authToken) {
-    throw new Error('SENTRY_AUTH_TOKEN is required to upload OTA source maps.');
+    throw new Error('SENTRY_AUTH_TOKEN is required to upload to Sentry.');
   }
   const uploaderEnvironment: NodeJS.ProcessEnv = {
     ...environment,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -756,6 +756,10 @@ export default defineConfig({
         command: 'tsx scripts/mobile-upload-sourcemaps.ts',
         cache: false,
       },
+      'mobile:upload-dsyms': {
+        command: 'tsx scripts/mobile-upload-dsyms.ts',
+        cache: false,
+      },
       'mobile:ota-setup': {
         command: 'tsx scripts/mobile-ota-setup.ts',
         cache: false,


### PR DESCRIPTION
## Summary

Sentry had symbol names but no file/line for every native iOS frame. The upload was running — it was uploading the wrong artifact.

Confirmed in the log for run [30781376709](https://github.com/boardsesh/boardsesh/actions/runs/30781376709) (job 91586633499):

- `03:32:14.54` — the `@sentry/react-native` **Upload Debug Symbols to Sentry** build phase runs `sentry-cli debug-files upload <BuildProductsPath/Release-iphoneos>` → `Found 31 … Uploaded 3 missing`, all three `arm64 executable`.
- `03:32:16.95` — `GenerateDSYMFile … Boardsesh.app.dSYM`.

The phase uploads 2.4 seconds before the app's dSYM exists. An executable carries a symbol table (function names); only the dSYM carries DWARF (file + line). And the DWARF for statically linked pods — `libRNScreens.a`, where [BOARDSESH-9K](https://boardsesh.sentry.io/issues/BOARDSESH-9K) crashed — lives *only* inside `Boardsesh.app.dSYM`, so nothing that phase can find will ever produce `RNSTabsHostComponentView.mm:448`.

The archive's `dSYMs/` directory is complete. This uploads from there, after `xcodebuild archive` finishes.

### What changed

- **`scripts/mobile-upload-dsyms.ts`** (new) + **`vp run mobile:upload-dsyms`** — same shape as the existing `mobile-upload-sourcemaps.ts`: validate the artifact, resolve the pinned `sentry-cli` from `packages/mobile` the way the build phase does, upload, then check the result. It hard-fails when `<archive>/dSYMs` is missing, holds no DWARF, or holds **no `*.app.dSYM`** — that last check is the regression guard, since the appex dSYMs *were* already early enough to be uploaded and the app's was the one that wasn't.
- **`ios-testflight-rn.yml`** — `setup-vp` (the job had no `vp`) and an `Upload iOS dSYMs to Sentry` step, placed between `Archive` and `Export archive`. The step hard-fails, so it has to run while a failure is still recoverable: past the export the binary has already shipped, and past the fingerprint tag the next push skips the native build entirely, so the dSYMs would never get a second chance without a manual dispatch. Here a failure ships nothing and tags nothing, and the next push retries on its own. (Thanks to the Codex review for catching that — the first version ran after the tags.)
- The in-archive Sentry build phase is left alone — it also uploads the JS source maps, and the redundant executables are harmless (Sentry keeps both files for a debug id and prefers the one with DWARF).
- **`docs/mobile-error-telemetry.md`** — corrected. Also answers the issue's "check Android too": Android's `.so` files come from prebuilt RN/Expo AARs that ship stripped and we build no NDK code, so **there is no Android equivalent of this fix**. Its JS source maps do already upload, on the OTA path (`mobile-ota-production.yml`), not the Gradle one — the doc previously said they weren't uploaded at all.

Nothing under `packages/mobile/`, so the native fingerprint doesn't move.

Closes #4202

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project scripts` — 683 passed, incl. 19 new in `scripts/mobile-dsyms.test.ts` (archive validation, symlink refusal, appex-only archive rejected, injected-spawn argv/env, non-zero exit, `parseUploadSummary` against the real `arm64 executable` output from run 30781376709 and a `debug companion` sample, workflow wiring).
- `vp check` and `vp run typecheck` clean.
- Ran the task against fixture archives: missing archive, appex-only (`No *.app.dSYM …`), and a valid one reaching the token check — confirming the archive is validated *before* `SENTRY_AUTH_TOKEN`, so a local run without a token still reports the real problem.

**Verification after merge needs a manual `workflow_dispatch`** of *iOS TestFlight Deploy (React Native)*. The workflow file is in its own `paths` trigger, but a CI-only change doesn't move the fingerprint, so the `gate` job would skip the build; a dispatch forces it. On that run the new step must list `arm64 debug companion` entries rather than `arm64 executable`, and the next native crash should carry `<file>.mm:<line>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqJiEtn1BFUDKfS4w91A3W
