### PR TITLE
chore(shared): cull unread PostHog events

### DIFF
--- a/packages/backend/src/__tests__/live-activity-analytics.test.ts
+++ b/packages/backend/src/__tests__/live-activity-analytics.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+const posthogMocks = vi.hoisted(() => ({
+  captureBackendEvent: vi.fn(),
+}));
+
+vi.mock('../services/analytics/posthog', () => ({
+  captureBackendEvent: posthogMocks.captureBackendEvent,
+}));
+
+// Matches apns-analytics.test.ts: reset + dynamic import so the hoisted mock is
+// the module the subject binds to. A static top-level import binds the real one.
+async function loadLiveActivityModule(): Promise<typeof import('../services/analytics/live-activity')> {
+  vi.resetModules();
+  return import('../services/analytics/live-activity');
+}
+
+function pushDelivery(overrides: { failedCount?: number; staleCount?: number } = {}) {
+  return {
+    userId: 'user-1',
+    sessionId: 'session-1',
+    event: 'update' as const,
+    source: 'heartbeat' as const,
+    tokenCount: 3,
+    sentCount: 3,
+    failedCount: 0,
+    staleCount: 0,
+    elapsedMs: 42,
+    ...overrides,
+  };
+}
+
+describe('trackLiveActivityPushDelivery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not capture a delivery where nothing failed or went stale', async () => {
+    const { trackLiveActivityPushDelivery } = await loadLiveActivityModule();
+    trackLiveActivityPushDelivery(pushDelivery());
+
+    expect(posthogMocks.captureBackendEvent).not.toHaveBeenCalled();
+  });
+
+  it('captures a delivery with failures', async () => {
+    const { trackLiveActivityPushDelivery } = await loadLiveActivityModule();
+    trackLiveActivityPushDelivery(pushDelivery({ failedCount: 2 }));
+
+    expect(posthogMocks.captureBackendEvent).toHaveBeenCalledWith(
+      'Live Activity Push Delivery',
+      expect.objectContaining({
+        distinctId: 'user-1',
+        properties: expect.objectContaining({ failedCount: 2, staleCount: 0 }),
+      }),
+    );
+  });
+
+  it('captures a delivery with stale tokens', async () => {
+    const { trackLiveActivityPushDelivery } = await loadLiveActivityModule();
+    trackLiveActivityPushDelivery(pushDelivery({ staleCount: 1 }));
+
+    expect(posthogMocks.captureBackendEvent).toHaveBeenCalledWith(
+      'Live Activity Push Delivery',
+      expect.objectContaining({
+        properties: expect.objectContaining({ failedCount: 0, staleCount: 1 }),
+      }),
+    );
+  });
+});

--- a/packages/backend/src/services/analytics/live-activity.ts
+++ b/packages/backend/src/services/analytics/live-activity.ts
@@ -155,7 +155,15 @@ export function trackLiveActivityWidgetNavigationAttributionGap(
   });
 }
 
+// Only deliveries that actually went wrong are captured. Every push used to fire
+// one of these — 26.6k events across 191 users in a 30-day window, of which 34
+// carried a failure, and a third were `source: 'heartbeat'` keep-alives. Nothing
+// read the clean rows: no insight, dashboard, or alert referenced this event.
+// The failure/stale rate is the question this event exists to answer, so the
+// denominator lives in the APNs logs rather than in PostHog's event budget.
 export function trackLiveActivityPushDelivery(event: LiveActivityPushDeliveryEvent): void {
+  if (event.failedCount === 0 && event.staleCount === 0) return;
+
   captureBackendEvent('Live Activity Push Delivery', {
     distinctId: event.userId,
     properties: {

--- a/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
@@ -367,27 +367,17 @@ describe('ClimbList keyboard handling', () => {
   });
 });
 
-describe('ClimbList search result selection tracking', () => {
-  it('tracks the rank of the first result when it is pressed', async () => {
-    const { findByText } = render(<ClimbList />);
-
-    fireEvent.click(await findByText('Moonage'));
-
-    expect(mocks.track).toHaveBeenCalledWith(
-      'Search Result Selected',
-      expect.objectContaining({ rank: 0, loadedResultCount: 2, boardName: 'kilter', angle: 40 }),
-    );
-  });
-
-  it('tracks the rank of a later result when it is pressed', async () => {
+describe('ClimbList search result selection', () => {
+  // Pressing a row activates the climb but emits NO per-press analytics event.
+  // `Search Result Selected` fired here on every tap (53.8k events / 30 days)
+  // and no insight ever read it; `Climb Search Performed` still covers search.
+  it('activates a pressed result without firing a per-result event', async () => {
     const { findByText } = render(<ClimbList />);
 
     fireEvent.click(await findByText('Zenith'));
 
-    expect(mocks.track).toHaveBeenCalledWith(
-      'Search Result Selected',
-      expect.objectContaining({ rank: 1, loadedResultCount: 2, boardName: 'kilter', angle: 40 }),
-    );
+    expect(mocks.activateClimb).toHaveBeenCalled();
+    expect(mocks.track).not.toHaveBeenCalledWith('Search Result Selected', expect.anything());
   });
 });
 

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -12,7 +12,6 @@ import {
   mergeBoardFilters,
   countActiveFilters,
   hasActiveBoardFilters,
-  describeGradeFilter,
   flagsToProgress,
   progressToFlags,
   applyStatusChange,
@@ -20,7 +19,6 @@ import {
   DEFAULT_CLIMB_FILTER_STATE,
   DEFAULT_CLIMB_BOARD_FILTER_STATE,
   type ClimbBoardFilterState,
-  type GradeTapMeta,
   type ProgressFilter,
   type SortOption,
   type GradeAccuracyValue,
@@ -456,12 +454,6 @@ function ClimbListInner() {
   const gradesRef = useRef(gradesData);
   gradesRef.current = gradesData;
   const grades = useMemo(() => gradesData ?? [], [gradesData]);
-  // Ascending difficulty ids — feeds describeGradeFilter so the `Grade Filter
-  // Changed` event reports a range's size the same way web does.
-  const gradeIds = useMemo(
-    () => grades.map((grade) => grade.difficultyId).sort((first, second) => first - second),
-    [grades],
-  );
   const { formatGradeByDifficultyId } = useGradeFormat();
 
   const boardConfig = useMemo(
@@ -616,24 +608,19 @@ function ClimbListInner() {
   } = useInfiniteSearchClimbs(searchInput, searchReady);
   const isLoadingMoreRef = useRef(false);
 
-  // climbRankByUuid is built in the same pass as the dedup so a row's rank (its
-  // position in the loaded/deduped list) is a cheap Map lookup at press time —
-  // avoids threading an `index` prop through renderClimbItem's row chain, which
-  // would mean a fresh onPress closure per row (see the mobile perf rule against
-  // inline closures in renderItem, docs/react-native-performance.md).
-  const { visibleClimbs, climbRankByUuid } = useMemo(() => {
+  // Dedup across pages: the same climb can repeat when a page boundary shifts
+  // between fetches.
+  const visibleClimbs = useMemo(() => {
     const seenUuids = new Set<string>();
     const climbs: Climb[] = [];
-    const rankByUuid = new Map<string, number>();
     for (const page of searchPages?.pages ?? []) {
       for (const climb of page.climbs) {
         if (seenUuids.has(climb.uuid)) continue;
         seenUuids.add(climb.uuid);
-        rankByUuid.set(climb.uuid, climbs.length);
         climbs.push(climb);
       }
     }
-    return { visibleClimbs: climbs, climbRankByUuid: rankByUuid };
+    return climbs;
   }, [searchPages?.pages]);
 
   const firstSearchPage = searchPages?.pages[0];
@@ -783,59 +770,9 @@ function ClimbListInner() {
     refreshErrorMessage: 'Failed to refresh climb-list suggestions:',
   });
 
-  // Latest search context for the SearchResultSelected press handler, read via
-  // ref rather than useCallback deps so handleClimbPress keeps the stable
-  // identity it had before (activateClimbListClimb + blurSearchInputs only) —
-  // putting climbRankByUuid/visibleClimbs.length in the deps would recreate the
-  // callback (and therefore every row's onPress prop) on every page load,
-  // against the renderItem-chain stability rule in
-  // docs/react-native-performance.md.
-  const searchTrackingContextRef = useRef({
-    climbRankByUuid,
-    visibleResultCount: visibleClimbs.length,
-    boardName,
-    angle,
-    name,
-    filters,
-    boardFilters,
-  });
-  searchTrackingContextRef.current = {
-    climbRankByUuid,
-    visibleResultCount: visibleClimbs.length,
-    boardName,
-    angle,
-    name,
-    filters,
-    boardFilters,
-  };
-
   const handleClimbPress = useCallback(
     (climb: Climb) => {
       blurSearchInputs();
-      const {
-        climbRankByUuid: currentClimbRankByUuid,
-        visibleResultCount,
-        boardName: currentBoardName,
-        angle: currentAngle,
-        name: currentName,
-        filters: currentFilters,
-        boardFilters: currentBoardFilters,
-      } = searchTrackingContextRef.current;
-      // Rank/position in the loaded result list (undefined only if the climb
-      // isn't in the current search results at all, which shouldn't happen for
-      // a row-driven press).
-      const rank = currentClimbRankByUuid.get(climb.uuid);
-      if (rank !== undefined) {
-        track(SHARED_EVENTS.SearchResultSelected, {
-          rank,
-          loadedResultCount: visibleResultCount,
-          boardName: currentBoardName,
-          angle: currentAngle,
-          hasQuery: currentName.length > 0,
-          queryLengthBucket: queryLengthBucket(currentName),
-          activeFilterCount: countActiveFilters(currentFilters, currentBoardFilters),
-        });
-      }
       void activateClimbListClimb.activate(toQueueClimb(climb));
     },
     [activateClimbListClimb, blurSearchInputs],
@@ -917,41 +854,8 @@ function ClimbListInner() {
     [addToQueue],
   );
 
-  // Mirror web's `Grade Filter Changed` payload (snake_case so both platforms
-  // land in one PostHog funnel — issue #3290) and add a mobile-only `source` so
-  // we can split the discoverable chrome rail from the buried filter sheet
-  // (the #3281 discoverability question).
-  const trackGradeFilterChanged = useCallback(
-    (previous: GradeBound, next: GradeBound, source: 'chrome_rail' | 'filter_sheet', meta?: GradeTapMeta) => {
-      const previousShape = describeGradeFilter(previous, gradeIds);
-      const nextShape = describeGradeFilter(next, gradeIds);
-      track(SHARED_EVENTS.GradeFilterChanged, {
-        filter_kind: nextShape.kind,
-        min_grade_id: next.minGradeId ?? null,
-        max_grade_id: next.maxGradeId ?? null,
-        range_size: nextShape.size,
-        previous_filter_kind: previousShape.kind,
-        previous_min_grade_id: previous.minGradeId ?? null,
-        previous_max_grade_id: previous.maxGradeId ?? null,
-        extended_range_within_window: meta?.extendedRangeWithinWindow ?? null,
-        board_name: boardName,
-        source,
-      });
-    },
-    [gradeIds, boardName],
-  );
-
   const handleApplyFilters = useCallback(
     (newFilters: ClimbFilters, newBoardFilters: ClimbBoardFilterState) => {
-      // Fire one grade event if the sheet's Apply actually changed the bound
-      // (the sheet is a draft batch-apply, so no per-tap meta to carry).
-      if (newFilters.minGrade !== filters.minGrade || newFilters.maxGrade !== filters.maxGrade) {
-        trackGradeFilterChanged(
-          { minGradeId: filters.minGrade, maxGradeId: filters.maxGrade },
-          { minGradeId: newFilters.minGrade, maxGradeId: newFilters.maxGrade },
-          'filter_sheet',
-        );
-      }
       setFilters(newFilters);
       setBoardFilters(newBoardFilters);
       setShowFilters(false);
@@ -967,16 +871,7 @@ function ClimbListInner() {
           .catch(() => {});
       }
     },
-    [
-      t,
-      isAuthenticated,
-      name,
-      setFilters,
-      setBoardFilters,
-      trackGradeFilterChanged,
-      filters.minGrade,
-      filters.maxGrade,
-    ],
+    [t, isAuthenticated, name, setFilters, setBoardFilters],
   );
 
   const handleApplyRecentFilter = useCallback(
@@ -1014,13 +909,10 @@ function ClimbListInner() {
   }, [replaceSearch, name, filters.minGrade, filters.maxGrade]);
 
   const handleGradeChange = useCallback(
-    (next: GradeBound, meta?: GradeTapMeta) => {
-      // Capture the committed bound before setGrade() kicks off the re-render.
-      const previous: GradeBound = { minGradeId: filters.minGrade, maxGradeId: filters.maxGrade };
+    (next: GradeBound) => {
       setGrade(next);
-      trackGradeFilterChanged(previous, next, 'chrome_rail', meta);
     },
-    [setGrade, trackGradeFilterChanged, filters.minGrade, filters.maxGrade],
+    [setGrade],
   );
 
   // Remember the grade the climber filters by (from any path — the chip rail,

--- a/packages/mobile/src/components/LogAscentSheet.tsx
+++ b/packages/mobile/src/components/LogAscentSheet.tsx
@@ -65,7 +65,7 @@ export function LogAscentSheet({
   const { t } = useTranslation('climbs');
 
   // Tracks whether the open tick got saved, so handleClose below can tell a
-  // completed save (QuickTickSaved already covers it) apart from a genuine
+  // completed save (TickLogged already covers it) apart from a genuine
   // abandon via the close button / pan-down / backdrop tap (none of which call
   // back into the form, so it can't distinguish these itself).
   const savedRef = useRef(false);

--- a/packages/mobile/src/components/ble/__tests__/use-lightbulb-control.test.ts
+++ b/packages/mobile/src/components/ble/__tests__/use-lightbulb-control.test.ts
@@ -63,7 +63,7 @@ const wrapper = ({ children }: { children: ReactNode }) =>
   createElement(BoardPresenceCurrentContext.Provider, { value: ctrl.presence }, children);
 
 function renderControl() {
-  return renderHook(() => useLightbulbControl({}), { wrapper });
+  return renderHook(() => useLightbulbControl(), { wrapper });
 }
 
 beforeEach(() => {

--- a/packages/mobile/src/components/ble/__tests__/use-lightbulb-control.test.ts
+++ b/packages/mobile/src/components/ble/__tests__/use-lightbulb-control.test.ts
@@ -62,8 +62,8 @@ const holderPresenceFor = (userId: string): BoardPresenceCurrentState =>
 const wrapper = ({ children }: { children: ReactNode }) =>
   createElement(BoardPresenceCurrentContext.Provider, { value: ctrl.presence }, children);
 
-function renderControl(source: 'lightbulb_toolbar' | 'lightbulb_drawer' = 'lightbulb_toolbar') {
-  return renderHook(() => useLightbulbControl({ source }), { wrapper });
+function renderControl() {
+  return renderHook(() => useLightbulbControl({}), { wrapper });
 }
 
 beforeEach(() => {
@@ -175,17 +175,16 @@ describe('useLightbulbControl lit state', () => {
 });
 
 describe('useLightbulbControl press action', () => {
-  it('connects, arms the undo toast, and tracks when disconnected', () => {
+  it('connects and arms the undo toast when disconnected', () => {
     ctrl.bluetooth = makeBluetooth({ isConnected: false, reconnectSerialForCurrentBoard: 'serial-1' });
     const { result } = renderControl();
     result.current.onPress();
     expect(ctrl.bluetooth?.armUndoWallChangeToast).toHaveBeenCalledOnce();
     expect(ctrl.bluetooth?.connect).toHaveBeenCalledWith(undefined, undefined, 'serial-1', undefined);
     expect(ctrl.bluetooth?.disconnect).not.toHaveBeenCalled();
-    expect(trackMock).toHaveBeenCalledWith(
-      'Board Lightbulb Connect',
-      expect.objectContaining({ source: 'lightbulb_toolbar' }),
-    );
+    // The connect ATTEMPT is deliberately untracked — Bluetooth Connection
+    // Success / Failed carry the outcome.
+    expect(trackMock).not.toHaveBeenCalled();
   });
 
   it('reconnects a MoonBoard by its remembered device id (no serial)', () => {
@@ -197,7 +196,7 @@ describe('useLightbulbControl press action', () => {
     expect(ctrl.bluetooth?.connect).toHaveBeenCalledWith(undefined, undefined, undefined, 'moon-abc');
   });
 
-  it('disconnects (no connect, no track) when already connected', () => {
+  it('disconnects (no connect) when already connected', () => {
     ctrl.bluetooth = makeBluetooth({ isConnected: true });
     const { result } = renderControl();
     result.current.onPress();

--- a/packages/mobile/src/components/ble/use-lightbulb-control.ts
+++ b/packages/mobile/src/components/ble/use-lightbulb-control.ts
@@ -50,7 +50,7 @@ export type LightbulbControl = {
  * (`useOptionalBluetoothContext`, the raw board-presence context); the session
  * controls and board-presence controls are always present under the tab tree.
  */
-export function useLightbulbControl(options: UseLightbulbControlOptions): LightbulbControl {
+export function useLightbulbControl(options: UseLightbulbControlOptions = {}): LightbulbControl {
   const { onOpenControls } = options;
   // Ownership/lit derivation is shared with the Live Activity bridge via this
   // hook so the in-app bulb and the lock-screen bulb can never disagree.

--- a/packages/mobile/src/components/ble/use-lightbulb-control.ts
+++ b/packages/mobile/src/components/ble/use-lightbulb-control.ts
@@ -1,18 +1,9 @@
 import { useCallback } from 'react';
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
-import { track } from '../../lib/analytics';
 import { derivePlayDrawerLightbulbPressAction } from '../play-drawer/lightbulb-control';
 import { useBoardConnectionState } from './use-board-connection-state';
 
-type LightbulbControlSource = 'lightbulb_toolbar' | 'lightbulb_drawer';
-
 type UseLightbulbControlOptions = {
-  /** Where the tap originated, for the connect analytics event. */
-  source: LightbulbControlSource;
-  /** Board layout key for analytics (the drawer has it; the toolbar doesn't). */
-  boardLayout?: string;
-  /** Climb the bulb is acting on, for analytics. Null when none is in view. */
-  climbUuid?: string | null;
   /**
    * Opens the BLE controls sheet (Re-light / Turn off all lights / Disconnect).
    * Wired to the returned `onLongPress` so every lightbulb shares one gesture
@@ -60,10 +51,10 @@ export type LightbulbControl = {
  * controls and board-presence controls are always present under the tab tree.
  */
 export function useLightbulbControl(options: UseLightbulbControlOptions): LightbulbControl {
-  const { source, boardLayout, climbUuid, onOpenControls } = options;
+  const { onOpenControls } = options;
   // Ownership/lit derivation is shared with the Live Activity bridge via this
   // hook so the in-app bulb and the lock-screen bulb can never disagree.
-  const { bluetooth, lit, localConnected, pending, sessionId } = useBoardConnectionState();
+  const { bluetooth, lit, localConnected, pending } = useBoardConnectionState();
 
   const onPress = useCallback(() => {
     if (!bluetooth) return;
@@ -84,12 +75,9 @@ export function useLightbulbControl(options: UseLightbulbControlOptions): Lightb
     // auto-pushes the displayed climb on connect, which reports to board presence
     // and makes this device the holder; on disconnect the bluetooth provider
     // fires the release itself, so we don't report here.
-    track('Board Lightbulb Connect', {
-      source,
-      mode: sessionId !== null ? 'party' : 'solo',
-      boardLayout: boardLayout ?? null,
-      climbUuid: climbUuid ?? null,
-    });
+    // The connect ATTEMPT is not tracked — Bluetooth Connection Success / Failed
+    // record the outcome a few hundred ms later, which is the question the BLE
+    // health dashboard actually asks.
     bluetooth.armUndoWallChangeToast();
     // Reconnect straight to the same board — by serial (Aurora) or device id
     // (MoonBoard). With neither remembered, the adapter opens the picker.
@@ -99,7 +87,7 @@ export function useLightbulbControl(options: UseLightbulbControlOptions): Lightb
       bluetooth.reconnectSerialForCurrentBoard ?? undefined,
       bluetooth.reconnectDeviceIdForCurrentBoard ?? undefined,
     );
-  }, [bluetooth, source, sessionId, boardLayout, climbUuid]);
+  }, [bluetooth]);
 
   const onLongPress = useCallback(() => {
     // Long-press is a power-user shortcut into the controls sheet; only meaningful

--- a/packages/mobile/src/components/chrome/LightbulbToolbarAction.tsx
+++ b/packages/mobile/src/components/chrome/LightbulbToolbarAction.tsx
@@ -24,7 +24,6 @@ export function LightbulbToolbarAction() {
   const { t: tSettings } = useTranslation('settings');
   const { open: openControls } = useBleControlSheet();
   const { bluetooth, lit, localConnected, onPress, onLongPress } = useLightbulbControl({
-    source: 'lightbulb_toolbar',
     onOpenControls: openControls,
   });
 

--- a/packages/mobile/src/components/chrome/MaterialBoardActions.tsx
+++ b/packages/mobile/src/components/chrome/MaterialBoardActions.tsx
@@ -60,7 +60,6 @@ export function MaterialLightbulbAction() {
   const { t: tSettings } = useTranslation('settings');
   const { open: openControls } = useBleControlSheet();
   const { bluetooth, lit, localConnected, onPress, onLongPress } = useLightbulbControl({
-    source: 'lightbulb_toolbar',
     onOpenControls: openControls,
   });
 

--- a/packages/mobile/src/components/climb-actions/__tests__/use-climb-actions.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/use-climb-actions.test.tsx
@@ -256,7 +256,7 @@ describe('useClimbActions colours and dispatch', () => {
     const { result } = renderActions({ climb, boardConfig: kilterBoard, isAuthenticated: false });
     result.current.find((action) => action.id === 'preview')?.run();
     expect(openers.openPlayDrawer).toHaveBeenCalledTimes(1);
-    expect(openers.openPlayDrawer).toHaveBeenCalledWith(climb, expect.objectContaining({ source: 'climb_view' }));
+    expect(openers.openPlayDrawer).toHaveBeenCalledWith(climb, expect.any(Object));
   });
 });
 

--- a/packages/mobile/src/components/climb-actions/use-climb-actions.ts
+++ b/packages/mobile/src/components/climb-actions/use-climb-actions.ts
@@ -189,7 +189,6 @@ export function useClimbActions({
         openPlayDrawer(climb, {
           previewQueueItem: climbToQueueItem(climb),
           boardConfig: override,
-          source: 'climb_view',
         });
         after();
       },

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -69,7 +69,6 @@ import { getBoardRenderData } from '../../lib/board-details';
 import { hapticSuccess } from '../../lib/haptics';
 import { usePlayDrawerWakeLock } from './use-play-drawer-wake-lock';
 import { resolveFavoriteRollback } from './favorite-rollback';
-import { buildPlayDrawerBoardLayout } from './lightbulb-control';
 import { getViewOnlyPreviewNavigationTarget } from './play-drawer-navigation';
 import { useLightbulbControl } from '../ble/use-lightbulb-control';
 import { track } from '../../lib/analytics';
@@ -352,11 +351,6 @@ export function PlayDrawer({
 
   usePlayDrawerWakeLock(isSheetOpen);
 
-  const boardLayout = useMemo(
-    () => buildPlayDrawerBoardLayout({ boardName, layoutId, sizeId }),
-    [boardName, layoutId, sizeId],
-  );
-
   const boardRenderData = useMemo(() => {
     const parsedSetIds = setIds.split(',').map(Number);
     return getBoardRenderData({
@@ -394,11 +388,7 @@ export function PlayDrawer({
     localConnected: bluetoothConnected,
     pending: lightbulbPending,
     onPress: handleLightbulb,
-  } = useLightbulbControl({
-    source: 'lightbulb_drawer',
-    boardLayout,
-    climbUuid: displayedClimb?.uuid ?? null,
-  });
+  } = useLightbulbControl({});
   const navigationSuggestionSource = drawerPreviewSuggestionSource ?? playlistSuggestionSource;
   const navigationState = useMemo(
     () => computeNavigationStateWithSuggestions(queue, displayedQueueItem, navigationSuggestionSource),

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -388,7 +388,7 @@ export function PlayDrawer({
     localConnected: bluetoothConnected,
     pending: lightbulbPending,
     onPress: handleLightbulb,
-  } = useLightbulbControl({});
+  } = useLightbulbControl();
   const navigationSuggestionSource = drawerPreviewSuggestionSource ?? playlistSuggestionSource;
   const navigationState = useMemo(
     () => computeNavigationStateWithSuggestions(queue, displayedQueueItem, navigationSuggestionSource),

--- a/packages/mobile/src/components/play-drawer/__tests__/lightbulb-control.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/lightbulb-control.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  buildPlayDrawerBoardLayout,
-  deriveBoardConnection,
-  deriveLightbulbLit,
-  derivePlayDrawerLightbulbPressAction,
-} from '../lightbulb-control';
+import { deriveBoardConnection, deriveLightbulbLit, derivePlayDrawerLightbulbPressAction } from '../lightbulb-control';
 
 describe('play drawer lightbulb control', () => {
   it('derives the connect/disconnect tap action', () => {
@@ -43,10 +38,6 @@ describe('play drawer lightbulb control', () => {
         isBluetoothLoading: false,
       }),
     ).toBe('disconnect');
-  });
-
-  it('builds the analytics board-layout key', () => {
-    expect(buildPlayDrawerBoardLayout({ boardName: 'kilter', layoutId: 1, sizeId: 10 })).toBe('kilter:1:10');
   });
 });
 

--- a/packages/mobile/src/components/play-drawer/__tests__/use-quick-tick-form.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-quick-tick-form.test.tsx
@@ -26,7 +26,7 @@ const gradesState = vi.hoisted(() => ({
 }));
 
 // Stable save mock so a test can assert on the input passed to saveTick.mutate.
-// Invokes onSuccess by default (so the QuickTickSaved track call and the
+// Invokes onSuccess by default (so the TickLogged track call and the
 // savedRef/onDismiss wiring fire the way the real mutation would); flip
 // `failure` to drive the onError path instead.
 const saveMock = vi.hoisted(() => {
@@ -57,8 +57,6 @@ vi.mock('@boardsesh/board-config', async (importOriginal) => {
 });
 vi.mock('@boardsesh/analytics', () => ({
   SHARED_EVENTS: {
-    TickButtonClicked: 'Tick Button Clicked',
-    QuickTickSaved: 'Quick Tick Saved',
     QuickTickFailed: 'Quick Tick Failed',
     TickLogged: 'Tick Logged',
   },
@@ -306,7 +304,7 @@ describe('useQuickTickForm climbedAt', () => {
   });
 });
 
-describe('useQuickTickForm grade value on Quick Tick Saved', () => {
+describe('useQuickTickForm grade value on Tick Logged', () => {
   it('resolves the picked numeric difficulty id to a human grade label', () => {
     boardState.current = null;
     gradesState.current = [{ difficultyId: 5, name: 'V5' }];
@@ -316,7 +314,7 @@ describe('useQuickTickForm grade value on Quick Tick Saved', () => {
     fireEvent.click(getByTestId('save'));
 
     expect(track).toHaveBeenCalledWith(
-      'Quick Tick Saved',
+      'Tick Logged',
       expect.objectContaining({ difficulty: 5, grade: 'V5', hasDifficulty: true }),
     );
   });
@@ -327,7 +325,7 @@ describe('useQuickTickForm grade value on Quick Tick Saved', () => {
 
     fireEvent.click(getByTestId('save'));
 
-    expect(track).toHaveBeenCalledWith('Quick Tick Saved', expect.objectContaining({ grade: null, difficulty: null }));
+    expect(track).toHaveBeenCalledWith('Tick Logged', expect.objectContaining({ grade: null, difficulty: null }));
   });
 });
 
@@ -376,20 +374,19 @@ describe('useQuickTickForm dismiss-analytics plumbing (savedRef / fieldSnapshotR
 });
 
 describe('useQuickTickForm analytics', () => {
-  it('fires the canonical TickLogged event alongside QuickTickSaved on a successful save', () => {
+  it('fires exactly one event per committed tick — the canonical TickLogged', () => {
     boardState.current = null;
     const { getByTestId } = renderForm();
 
     fireEvent.click(getByTestId('save'));
 
     expect(track).toHaveBeenCalledWith(
-      SHARED_EVENTS.QuickTickSaved,
-      expect.objectContaining({ climbUuid: CLIMB_UUID }),
-    );
-    expect(track).toHaveBeenCalledWith(
       SHARED_EVENTS.TickLogged,
       expect.objectContaining({ climbUuid: CLIMB_UUID, platform: 'mobile', surface: 'mobile_quick_tick' }),
     );
+    // The old Tick Button Clicked (save-intent) and Quick Tick Saved
+    // (same onSuccess as TickLogged) companions are gone.
+    expect(vi.mocked(track).mock.calls.map(([eventName]) => eventName)).toEqual(['Tick Logged']);
   });
 });
 
@@ -456,7 +453,7 @@ describe('useQuickTickForm tries count', () => {
     fireEvent.click(getByTestId('save'));
 
     expect(track).toHaveBeenCalledWith(
-      SHARED_EVENTS.QuickTickSaved,
+      SHARED_EVENTS.TickLogged,
       expect.objectContaining({ status: 'send', attemptCount: 1 }),
     );
   });

--- a/packages/mobile/src/components/play-drawer/lightbulb-control.ts
+++ b/packages/mobile/src/components/play-drawer/lightbulb-control.ts
@@ -86,7 +86,3 @@ export function deriveLightbulbLit(args: {
 }): boolean {
   return deriveBoardConnection(args) !== 'disconnected';
 }
-
-export function buildPlayDrawerBoardLayout(args: { boardName: string; layoutId: number; sizeId: number }): string {
-  return `${args.boardName}:${args.layoutId}:${args.sizeId}`;
-}

--- a/packages/mobile/src/components/play-drawer/use-quick-tick-form.ts
+++ b/packages/mobile/src/components/play-drawer/use-quick-tick-form.ts
@@ -265,7 +265,6 @@ export function useQuickTickForm({
   const handleSaveWithStatus = useCallback(
     (status: TickStatus) => {
       if (saveTick.isPending) return;
-      track(SHARED_EVENTS.TickButtonClicked, { climbUuid, layoutId: layoutId ?? null });
       setLastError(null);
 
       // Mirrors the server's flash-is-one-try rule; a no-op for every value the picker can show.
@@ -294,23 +293,23 @@ export function useQuickTickForm({
         },
         {
           onSuccess: () => {
-            track(SHARED_EVENTS.QuickTickSaved, {
-              climbUuid,
-              layoutId: layoutId ?? null,
-              status,
-              attemptCount: finalAttempts,
-              hasQuality: tickState.quality != null && tickState.quality > 0,
-              hasDifficulty: tickState.difficulty != null,
-              difficulty: tickState.difficulty ?? null,
-              grade: resolvedGradeName ?? null,
-              hasComment: comment.length > 0,
-            });
+            // One event per committed tick. This used to fire QuickTickSaved and
+            // TickLogged back to back with the same climb/status, plus a
+            // TickButtonClicked on the way in — four events per tick once
+            // QuickTickOpened is counted. TickLogged is the canonical
+            // cross-platform join event, so it absorbed QuickTickSaved's payload.
             track(SHARED_EVENTS.TickLogged, {
               climbUuid,
               layoutId: layoutId ?? null,
               status,
               platform: 'mobile',
               surface: 'mobile_quick_tick',
+              attemptCount: finalAttempts,
+              hasQuality: tickState.quality != null && tickState.quality > 0,
+              hasDifficulty: tickState.difficulty != null,
+              difficulty: tickState.difficulty ?? null,
+              grade: resolvedGradeName ?? null,
+              hasComment: comment.length > 0,
             });
             hapticSuccess();
             // Kick off the paired gym timer's stopwatch. No-op unless a Rogue

--- a/packages/mobile/src/components/queue-control/BoardControlIndicator.tsx
+++ b/packages/mobile/src/components/queue-control/BoardControlIndicator.tsx
@@ -48,9 +48,10 @@ export function BoardControlIndicator({
   const { systemColors, brandColors } = useTheme();
   const { boardConnection, holderDisplayName, bluetooth } = useBoardConnectionState();
   const { open: openBoardControls } = useBleControlSheet();
-  // Shared connect/disconnect path so analytics + undo-arming match the drawer +
-  // toolbar lightbulbs: connectedByMe → disconnect, disconnected → connect.
-  const { onPress: lightbulbPress } = useLightbulbControl({});
+  // Shared connect/disconnect path so undo-arming and the press semantics match
+  // the drawer + toolbar lightbulbs: connectedByMe → disconnect, disconnected →
+  // connect. (Connect outcome telemetry is emitted inside bluetooth.connect().)
+  const { onPress: lightbulbPress } = useLightbulbControl();
   const { openPlay } = useAccessoryClimbTap();
 
   const handlePress = useCallback(() => {

--- a/packages/mobile/src/components/queue-control/BoardControlIndicator.tsx
+++ b/packages/mobile/src/components/queue-control/BoardControlIndicator.tsx
@@ -50,7 +50,7 @@ export function BoardControlIndicator({
   const { open: openBoardControls } = useBleControlSheet();
   // Shared connect/disconnect path so analytics + undo-arming match the drawer +
   // toolbar lightbulbs: connectedByMe → disconnect, disconnected → connect.
-  const { onPress: lightbulbPress } = useLightbulbControl({ source: 'lightbulb_toolbar' });
+  const { onPress: lightbulbPress } = useLightbulbControl({});
   const { openPlay } = useAccessoryClimbTap();
 
   const handlePress = useCallback(() => {

--- a/packages/mobile/src/components/queue-control/__tests__/use-accessory-climb-tap.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/use-accessory-climb-tap.test.tsx
@@ -75,9 +75,7 @@ describe('useAccessoryClimbTap', () => {
   it('opens the local queue head active on tap (it already is current — never the wall climb)', () => {
     renderHook(() => useAccessoryClimbTap());
     tap.onEnd?.();
-    expect(drawer.openPlayDrawer).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'climb-head' }), {
-      source: 'current_queue_item',
-    });
+    expect(drawer.openPlayDrawer).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'climb-head' }), {});
   });
 
   it('does nothing on tap when there is no queue head to open', () => {

--- a/packages/mobile/src/components/queue-control/__tests__/use-open-wall-preview.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/use-open-wall-preview.test.tsx
@@ -47,7 +47,6 @@ describe('useOpenWallPreview', () => {
       expect.objectContaining({
         previewIsWallClimb: true,
         previewQueueItem: expect.objectContaining({ climb: expect.objectContaining({ uuid: 'wall-1' }) }),
-        source: 'board_presence',
       }),
     );
   });

--- a/packages/mobile/src/components/queue-control/use-accessory-climb-tap.ts
+++ b/packages/mobile/src/components/queue-control/use-accessory-climb-tap.ts
@@ -33,7 +33,7 @@ export function useAccessoryClimbTap(): AccessoryClimbTap {
     if (!accessoryClimb) return;
     hapticLight();
     // It already IS current, so openDrawer won't re-append it.
-    openPlayDrawer(accessoryClimb, { source: 'current_queue_item' });
+    openPlayDrawer(accessoryClimb, {});
   }, [openPlayDrawer, accessoryClimb]);
 
   const openGesture = useMemo(

--- a/packages/mobile/src/components/queue-control/use-open-wall-preview.ts
+++ b/packages/mobile/src/components/queue-control/use-open-wall-preview.ts
@@ -18,9 +18,6 @@ export function useOpenWallPreview(): (wallClimb: Climb) => void {
       openPlayDrawer(wallClimb, {
         previewQueueItem: climbToQueueItem(wallClimb),
         previewIsWallClimb: true,
-        // Distinct from a queue-item open — this is a peek at what's lit on the
-        // wall (often a teammate's), opened from the "On the wall" capsule.
-        source: 'board_presence',
       });
     },
     [openPlayDrawer],

--- a/packages/mobile/src/lib/__tests__/open-climb-in-play-drawer.test.ts
+++ b/packages/mobile/src/lib/__tests__/open-climb-in-play-drawer.test.ts
@@ -50,7 +50,6 @@ describe('openClimbInPlayDrawer', () => {
     openClimbInPlayDrawer({ kind: 'climb', climb, boardConfig }, deps);
     expect(deps.openPlayDrawer).toHaveBeenCalledWith(climb, {
       boardConfig,
-      source: 'climb_view',
     });
     expect(deps.router.push).not.toHaveBeenCalled();
   });
@@ -63,7 +62,6 @@ describe('openClimbInPlayDrawer', () => {
     expect(deps.openPlayDrawer).toHaveBeenCalledWith(climb, {
       previewQueueItem: expect.objectContaining({ climb: expect.objectContaining({ uuid: 'c-1' }) }),
       boardConfig,
-      source: 'climb_view',
     });
   });
 
@@ -75,7 +73,6 @@ describe('openClimbInPlayDrawer', () => {
     const [, options] = deps.openPlayDrawer.mock.calls[0];
     expect(options).toMatchObject({
       boardConfig: { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,20,33', angle: 50 },
-      source: 'climb_view',
     });
     expect(options.previewQueueItem).toBeUndefined();
     expect(deps.router.push).not.toHaveBeenCalled();

--- a/packages/mobile/src/lib/analytics.ts
+++ b/packages/mobile/src/lib/analytics.ts
@@ -2,9 +2,14 @@ import type { PostHog } from 'posthog-react-native';
 import { createAnalytics } from '@boardsesh/analytics';
 import { getPostHogClient, registerAppSuperProperties } from './posthog-client';
 
+// `sendEvent: false` suppresses the SDK's `$feature_flag_called` capture. Verified
+// in @posthog/core 1.46.1 (shared by posthog-react-native and posthog-js-lite):
+// `_getFeatureFlagResult` gates the capture on it, and both `getFeatureFlag` and
+// `isFeatureEnabled` forward it. Flag VALUES are unaffected.
+type FeatureFlagReadOptions = { sendEvent?: boolean };
 type PosthogFeatureFlagClient = {
-  getFeatureFlag?: (key: string) => unknown;
-  isFeatureEnabled?: (key: string) => unknown;
+  getFeatureFlag?: (key: string, options?: FeatureFlagReadOptions) => unknown;
+  isFeatureEnabled?: (key: string, options?: FeatureFlagReadOptions) => unknown;
   reloadFeatureFlags?: () => unknown;
   onFeatureFlags?: (callback: () => void) => unknown;
 };
@@ -71,6 +76,15 @@ function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
   return typeof thenValue === 'function';
 }
 
+// FeatureFlagsProvider re-reads the WHOLE flag catalog on every flags-changed
+// tick, so leaving exposure events on cost ~173k events / 30 days across mobile +
+// web — 13% of the project's entire volume — for a signal nothing consumed: the
+// project runs no experiments, and the only insights referencing
+// `$feature_flag_called` are PostHog's auto-generated "<flag> Usage" boilerplate.
+// Drop the option at a specific call site if that flag ever needs real exposure
+// analysis (an experiment reads these events to assign variants to outcomes).
+const READ_WITHOUT_EXPOSURE_EVENT: FeatureFlagReadOptions = { sendEvent: false };
+
 export function readPosthogFeatureFlags(keys: readonly string[]): Record<string, boolean> {
   const posthog = getClient();
   if (!posthog) return {};
@@ -80,9 +94,9 @@ export function readPosthogFeatureFlags(keys: readonly string[]): Record<string,
   for (const key of keys) {
     let rawFlagValue: unknown;
     if (typeof featureFlagClient.getFeatureFlag === 'function') {
-      rawFlagValue = featureFlagClient.getFeatureFlag(key);
+      rawFlagValue = featureFlagClient.getFeatureFlag(key, READ_WITHOUT_EXPOSURE_EVENT);
     } else if (typeof featureFlagClient.isFeatureEnabled === 'function') {
-      rawFlagValue = featureFlagClient.isFeatureEnabled(key);
+      rawFlagValue = featureFlagClient.isFeatureEnabled(key, READ_WITHOUT_EXPOSURE_EVENT);
     }
     const flagValue = coerceFeatureFlagBoolean(rawFlagValue);
     if (flagValue !== undefined) {

--- a/packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx
+++ b/packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx
@@ -319,25 +319,6 @@ describe('LiveActivityBridge lightbulb (boardControl)', () => {
     expect(bt.connect).toHaveBeenCalledTimes(1);
     expect(bt.connect).toHaveBeenCalledWith(undefined, undefined, 'serial-123', undefined);
     expect(bt.reassertWall).not.toHaveBeenCalled();
-    // The lock-screen reconnect is measured like the in-app bulb.
-    expect(analytics.track).toHaveBeenCalledWith(
-      'Board Lightbulb Connect',
-      expect.objectContaining({ source: 'notification', mode: 'party' }),
-    );
-  });
-
-  it('reconnect: tags the analytics mode as solo when not in a party session', () => {
-    queue.sessionId = null;
-    renderBridge();
-
-    act(() => {
-      widget.boardControlListener?.({ action: 'reconnect', correlationId: 'bulb-solo' });
-    });
-
-    expect(analytics.track).toHaveBeenCalledWith(
-      'Board Lightbulb Connect',
-      expect.objectContaining({ source: 'notification', mode: 'solo' }),
-    );
   });
 
   it('reconnect: falls back to undefined serial (board picker) when none is remembered', () => {

--- a/packages/mobile/src/lib/live-activity/live-activity-bridge.tsx
+++ b/packages/mobile/src/lib/live-activity/live-activity-bridge.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toBoardName } from '@boardsesh/board-config';
-import { track } from '../../lib/analytics';
 import { useQueue } from '../../providers/queue-provider';
 import { useBoardConnectionState } from '../../components/ble/use-board-connection-state';
 import { useNativeClimbRender } from '../../hooks/use-native-climb-render';
@@ -146,25 +145,14 @@ export function LiveActivityBridge({ boardName, layoutId, sizeId, setIds }: Live
   // changes when a board is (de)selected).
   const bluetoothRef = useRef(bluetooth);
   bluetoothRef.current = bluetooth;
-  // Refs so the once-subscribed listener reads the latest session/climb for the
-  // reconnect analytics without re-registering.
-  const sessionIdRef = useRef(sessionId);
-  sessionIdRef.current = sessionId;
-  const climbUuidRef = useRef(displayClimb?.uuid);
-  climbUuidRef.current = displayClimb?.uuid;
-
   useEffect(() => {
     const unsubscribe = addBoardControlListener((event) => {
       const bluetoothCtx = bluetoothRef.current;
       if (!bluetoothCtx) return;
       if (event.action === 'reconnect') {
-        // Measure the lock-screen reconnect like the in-app bulb (source-tagged).
-        track('Board Lightbulb Connect', {
-          source: 'notification',
-          mode: sessionIdRef.current !== null ? 'party' : 'solo',
-          boardLayout: null,
-          climbUuid: climbUuidRef.current ?? null,
-        });
+        // The connect ATTEMPT is not tracked — Bluetooth Connection Success /
+        // Failed record the outcome a few hundred ms later, which is the question
+        // the BLE health dashboard actually asks.
         bluetoothCtx.armUndoWallChangeToast();
         // By serial (Aurora) or device id (MoonBoard); neither → adapter picker.
         void bluetoothCtx.connect(

--- a/packages/mobile/src/lib/open-climb-in-play-drawer.ts
+++ b/packages/mobile/src/lib/open-climb-in-play-drawer.ts
@@ -74,7 +74,6 @@ export function openClimbInPlayDrawer(args: OpenClimbArgs, deps: OpenClimbDeps, 
     openPlayDrawer(args.climb, {
       ...openModeOptions(args.climb, preview),
       boardConfig: args.boardConfig,
-      source: 'climb_view',
     });
     return;
   }
@@ -92,7 +91,6 @@ export function openClimbInPlayDrawer(args: OpenClimbArgs, deps: OpenClimbDeps, 
           setIds: config.setIds.join(','),
           angle: args.tick.angle,
         },
-        source: 'climb_view',
       });
       return;
     }

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -2,7 +2,6 @@
 import { act, render, waitFor } from '@testing-library/react';
 import { createElement, useEffect, type ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { SHARED_EVENTS } from '@boardsesh/analytics';
 import type { ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
 import type { Climb, UserBoard } from '@boardsesh/shared-schema';
 
@@ -809,41 +808,8 @@ describe('DrawerHostProvider climb actions', () => {
   });
 });
 
-describe('DrawerHostProvider play drawer open analytics source', () => {
-  it('tags a climb-view open with source:climb_view', async () => {
-    const hosts: Array<HostValue> = [];
-    renderHost((host) => hosts.push(host));
-    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
-
-    const climb = makeQueueItem('queue-x', 'climb-view-1').climb as unknown as Climb;
-    const previewItem = makeQueueItem('queue-preview-1', 'climb-view-1');
-    act(() => {
-      hosts.at(-1)?.openPlayDrawer(climb, { previewQueueItem: previewItem, source: 'climb_view' });
-    });
-
-    expect(analytics.track).toHaveBeenCalledWith(
-      SHARED_EVENTS.PlayDrawerOpened,
-      expect.objectContaining({ climbUuid: 'climb-view-1', source: 'climb_view' }),
-    );
-  });
-
-  it('defaults a queue-nav open (committedExternally, no source) to current_queue_item', async () => {
-    const hosts: Array<HostValue> = [];
-    renderHost((host) => hosts.push(host));
-    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
-
-    const climb = makeQueueItem('queue-x', 'queue-nav-1').climb as unknown as Climb;
-    act(() => {
-      hosts.at(-1)?.openPlayDrawer(climb, { committedExternally: true });
-    });
-
-    expect(analytics.track).toHaveBeenCalledWith(
-      SHARED_EVENTS.PlayDrawerOpened,
-      expect.objectContaining({ climbUuid: 'queue-nav-1', source: 'current_queue_item' }),
-    );
-  });
-
-  it('does not leak source (or boardConfig) into the open target', async () => {
+describe('DrawerHostProvider play drawer open target', () => {
+  it('does not leak boardConfig into the open target', async () => {
     const hosts: Array<HostValue> = [];
     const routes: Array<RouteValue> = [];
     renderHost(
@@ -854,11 +820,11 @@ describe('DrawerHostProvider play drawer open analytics source', () => {
 
     const climb = makeQueueItem('queue-x', 'climb-view-2').climb as unknown as Climb;
     act(() => {
-      hosts.at(-1)?.openPlayDrawer(climb, { committedExternally: true, source: 'climb_view' });
+      hosts.at(-1)?.openPlayDrawer(climb, { committedExternally: true });
     });
 
-    // No board override → no override set; `source` was pulled out and must not
-    // reach the open target the route applies.
+    // No board override → no override set, and `boardConfig` must not reach the
+    // open target the route applies.
     await waitFor(() => expect(routes.at(-1)?.playTarget?.climb).toBe(climb));
     expect(routes.at(-1)?.playTarget?.options).toEqual({ committedExternally: true });
   });
@@ -1087,7 +1053,7 @@ describe('DrawerHostProvider iPad pane open (regular width)', () => {
     act(() => {
       // Feed / beta / climb-view preview: show it in the pane; PlayDrawer decides
       // whether to commit from openTarget.options (the host doesn't).
-      hosts.at(-1)?.openPlayDrawer(climb, { previewQueueItem: previewItem, source: 'climb_view' });
+      hosts.at(-1)?.openPlayDrawer(climb, { previewQueueItem: previewItem });
     });
 
     await waitFor(() => {
@@ -1119,7 +1085,6 @@ describe('DrawerHostProvider iPad pane open (regular width)', () => {
       hosts.at(-1)?.openPlayDrawer(previewItem.climb as unknown as Climb, {
         previewQueueItem: previewItem,
         playlistSuggestionSource,
-        source: 'climb_view',
       });
     });
 

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -118,13 +118,6 @@ export type OpenPlayDrawerOptions = PlayDrawerOpenOptions & {
    *  default). The override is applied via state, so the actual open happens
    *  after the new boardConfig has propagated to PlayDrawer's props. */
   boardConfig?: BoardConfig;
-  /** Analytics-only tag for the `Play Drawer Opened` event's `source`. Lets a
-   *  real climb-view (feed/session/beta/playlist) be distinguished from a
-   *  queue-nav / accessory tap — the latter open `committedExternally` or with a
-   *  `previewQueueItem`, so the default `current_queue_item`/`mobile` heuristic
-   *  can't tell them apart. Pulled out before the rest of the options reach
-   *  `PlayDrawer.open`, so it never leaks into the drawer itself. */
-  source?: 'climb_view' | 'current_queue_item' | 'mobile' | 'board_presence';
 };
 
 /** Props the iPad right-column PlayDrawer pane consumes (regular width). Mirrors
@@ -425,18 +418,8 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   myBoardsRef.current = myBoardsConn;
 
   const openPlayDrawer = useCallback((climb: Climb, options?: OpenPlayDrawerOptions) => {
-    // Pull `source` out alongside `boardConfig` so neither reaches the open target
-    // — `source` is analytics-only and would otherwise leak into the drawer.
-    const { boardConfig: override, source: openSource, ...openOptions } = options ?? {};
-    const boardConfig = override ?? storedActiveBoardConfigRef.current;
-    track(SHARED_EVENTS.PlayDrawerOpened, {
-      climbUuid: climb.uuid,
-      boardName: boardConfig?.boardName,
-      layoutId: boardConfig?.layoutId,
-      source:
-        openSource ??
-        (openOptions.committedExternally || openOptions.previewQueueItem != null ? 'current_queue_item' : 'mobile'),
-    });
+    // Pull `boardConfig` out so it doesn't reach the open target.
+    const { boardConfig: override, ...openOptions } = options ?? {};
     // Set the board override BEFORE navigating so the route reads the right board
     // from `activeBoardConfig` (reactive) on mount — no requestAnimationFrame /
     // pending-replay dance. Only set an override that genuinely differs from the

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -30,10 +30,14 @@ export const SHARED_EVENTS = {
   ClimbRemovedFromQueue: 'Climb Removed from Queue',
   QueueReordered: 'Queue Reordered',
   QueueCleared: 'Queue Cleared',
+  // Fired on every queue advance, including the broadcast advances that used to
+  // ALSO fire a separate `Wall Advance`. That pair fired back-to-back from the
+  // same handler at all four web call sites with overlapping props, so it was
+  // folded in here: `sessionMode: 'party' | 'solo'` carries what `Wall Advance`
+  // added, and `method` already encoded what its `source` re-encoded. Round-trip
+  // success stays a separate question — see `Wall Confirmed` / `Wall Confirm Timeout`.
   QueueNavigation: 'Queue Navigation',
-  WallAdvance: 'Wall Advance',
   SetActiveClimb: 'Set Active Climb',
-  PlayDrawerOpened: 'Play Drawer Opened',
   SessionStarted: 'Session Started',
   SessionEnded: 'Session Ended',
   // A climber dropped out of a session WITHOUT ending it for everyone else —
@@ -114,23 +118,31 @@ export const SHARED_EVENTS = {
   LogbookEntryEdited: 'Logbook Entry Edited',
   LogbookEntryDeleted: 'Logbook Entry Deleted',
   // Ticks / logbook
-  // Mobile-only: fired at every explicit tick-sheet open (play-drawer FAB,
-  // climb-actions menu, queue bar), with a `source` prop. Gives the invariant
-  // Dismissed + Saved <= Opened; a violation means the sheet presented without
-  // user intent (the phantom-reopen bug this event was added to watchdog).
+  //
+  // The funnel is deliberately TWO events per platform: open, then outcome. It
+  // used to be four (Opened + TickButtonClicked + QuickTickSaved + TickLogged on
+  // mobile), where TickButtonClicked fired on save-intent immediately before the
+  // mutation and QuickTickSaved fired in the same onSuccess callback as
+  // TickLogged. Web fired the same TickButtonClicked name for a DIFFERENT moment
+  // — the sheet opening — so one name covered two meanings across platforms.
+  //
+  // Fired at every explicit tick-sheet open, with a `source` prop: mobile
+  // 'play_fab' | 'climb_actions' | 'queue_bar', web 'climb_actions' |
+  // 'logbook_tick_button'. Gives the invariant Dismissed + Logged <= Opened; a
+  // violation means the sheet presented without user intent (the phantom-reopen
+  // bug this event was added to watchdog).
   QuickTickOpened: 'Quick Tick Opened',
-  TickButtonClicked: 'Tick Button Clicked',
-  QuickTickSaved: 'Quick Tick Saved',
   QuickTickFailed: 'Quick Tick Failed',
   // Mobile-only for now: fired when the tick sheet is closed (X button,
   // pan-down, backdrop tap) without a save completing. Props include a
   // field-completeness snapshot so abandonment can be measured directly
-  // instead of inferred from TickButtonClicked - QuickTickSaved - QuickTickFailed.
+  // instead of inferred from QuickTickOpened - TickLogged - QuickTickFailed.
   QuickTickDismissed: 'Quick Tick Dismissed',
-  // Canonical "a climb was logged" join event, fired on every successful tick
-  // save on both platforms alongside each flow's own event above. Required
-  // props: { climbUuid, status, platform: 'web' | 'mobile', surface:
-  // 'web_full_form' | 'web_quick_modal' | 'mobile_quick_tick' }.
+  // Canonical "a climb was logged" join event and the single commit event on both
+  // platforms — it absorbed QuickTickSaved's payload. Required props: { climbUuid,
+  // status, platform: 'web' | 'mobile', surface: 'web_full_form' |
+  // 'web_quick_modal' | 'mobile_quick_tick' }, plus the tick detail
+  // (attemptCount, hasQuality, hasDifficulty, difficulty, grade, hasComment).
   TickLogged: 'Tick Logged',
   // Bluetooth / hardware
   BluetoothConnectionSuccess: 'Bluetooth Connection Success',
@@ -209,15 +221,11 @@ export const SHARED_EVENTS = {
   BleBoardConfigMismatchShown: 'BLE Board Config Mismatch Shown',
   BleBoardConfigMismatchResolved: 'BLE Board Config Mismatch Resolved',
   // Search
+  // Fired once per resolved search/filter result set, keyed on the search text +
+  // filter signature (not per keystroke, not per page). Carries hasQuery,
+  // queryLengthBucket, activeFilterCount and the result count, so search coverage
+  // and zero-result rate stay measurable without a per-tap companion event.
   ClimbSearchPerformed: 'Climb Search Performed',
-  // Fired when a user opens a climb from the search result list. Carries the
-  // tapped result's rank/position so the App Success dashboard can measure
-  // search relevance, not just coverage.
-  SearchResultSelected: 'Search Result Selected',
-  // Grade-range control changed (web's GradeRangePicker / mobile's GradeRangeRail).
-  // Shared so the native event lands in the same PostHog funnel as web's — the
-  // gap #3290 closed: web fired this 10,933× on the legacy webview, native 0×.
-  GradeFilterChanged: 'Grade Filter Changed',
   SearchHoldFilterChanged: 'Search Hold Filter Changed',
   SearchHoldFilterCleared: 'Search Hold Filter Cleared',
   SearchZoneEnabled: 'Search Zone Enabled',

--- a/packages/shared/climb-filters/src/__tests__/grade-range.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/grade-range.test.ts
@@ -8,7 +8,6 @@ import {
   isGradeInRange,
   isGradeEndpoint,
   computeGradeTap,
-  describeGradeFilter,
   type GradeBound,
 } from '../grade-range';
 
@@ -217,37 +216,5 @@ describe('computeGradeTap — rule 6: range outside collapse', () => {
     expect(computeGradeTap(range, gradeIds, 20, true)).toEqual({
       next: { minGradeId: 20, maxGradeId: 20 },
     });
-  });
-});
-
-describe('describeGradeFilter', () => {
-  it('classifies a cleared bound as "any" with null size', () => {
-    expect(describeGradeFilter(any, gradeIds)).toEqual({ kind: 'any', size: null });
-  });
-
-  it('classifies an equal bound as a single grade of size 1', () => {
-    expect(describeGradeFilter({ minGradeId: 14, maxGradeId: 14 }, gradeIds)).toEqual({ kind: 'single', size: 1 });
-  });
-
-  it('classifies a true range and counts the grades it spans inclusively', () => {
-    // 12..18 spans indices 1..4 → 4 grades.
-    expect(describeGradeFilter({ minGradeId: 12, maxGradeId: 18 }, gradeIds)).toEqual({ kind: 'range', size: 4 });
-    // Full span 10..20 → all 6 grades.
-    expect(describeGradeFilter({ minGradeId: 10, maxGradeId: 20 }, gradeIds)).toEqual({ kind: 'range', size: 6 });
-  });
-
-  it('treats a one-sided bound (legacy slider bookmark) as a range with null size', () => {
-    expect(describeGradeFilter({ minGradeId: 12, maxGradeId: undefined }, gradeIds)).toEqual({
-      kind: 'range',
-      size: null,
-    });
-    expect(describeGradeFilter({ minGradeId: undefined, maxGradeId: 18 }, gradeIds)).toEqual({
-      kind: 'range',
-      size: null,
-    });
-  });
-
-  it('returns a null size when a bound id is absent from the grade list', () => {
-    expect(describeGradeFilter({ minGradeId: 11, maxGradeId: 18 }, gradeIds)).toEqual({ kind: 'range', size: null });
   });
 });

--- a/packages/shared/climb-filters/src/grade-range.ts
+++ b/packages/shared/climb-filters/src/grade-range.ts
@@ -35,31 +35,6 @@ export type GradeTapMeta = {
 
 export type GradeTapResult = { next: GradeBound; meta?: GradeTapMeta };
 
-/** The shape of a grade bound, for analytics. */
-export type GradeFilterShape = { kind: 'any' | 'single' | 'range'; size: number | null };
-
-/**
- * Classify a grade bound for analytics: "any" (cleared), "single" (one grade,
- * size 1), or "range" (size = count of grades spanned, inclusive). `gradeIds`
- * MUST be ascending difficulty_ids; ids absent from it (legacy one-sided
- * bookmarks) fall through to a range with null size. Shared so web and mobile
- * classify the `Grade Filter Changed` event identically.
- */
-export function describeGradeFilter(bound: GradeBound, gradeIds: readonly number[]): GradeFilterShape {
-  const { minGradeId, maxGradeId } = bound;
-  if (minGradeId === undefined && maxGradeId === undefined) {
-    return { kind: 'any', size: null };
-  }
-  if (minGradeId !== undefined && maxGradeId !== undefined) {
-    if (minGradeId === maxGradeId) return { kind: 'single', size: 1 };
-    const minIdx = gradeIds.indexOf(minGradeId);
-    const maxIdx = gradeIds.indexOf(maxGradeId);
-    const size = minIdx >= 0 && maxIdx >= 0 ? maxIdx - minIdx + 1 : null;
-    return { kind: 'range', size };
-  }
-  return { kind: 'range', size: null };
-}
-
 /** Both bounds undefined = "Any" (filter cleared). */
 export function isAnyGrade(bound: GradeBound): boolean {
   return bound.minGradeId === undefined && bound.maxGradeId === undefined;

--- a/packages/web/app/components/climb-actions/__tests__/tick-action.test.tsx
+++ b/packages/web/app/components/climb-actions/__tests__/tick-action.test.tsx
@@ -809,7 +809,7 @@ describe('TickAction', () => {
   });
 
   describe('analytics tracking', () => {
-    it('tracks tick button click with board layout info', async () => {
+    it('tracks the tick sheet opening with board layout info', async () => {
       setupMocks({ hasBoardProvider: true, isAuthenticated: true });
       render(<TestTickAction {...defaultProps} />);
 
@@ -817,10 +817,14 @@ describe('TickAction', () => {
         screen.getByRole('button', { name: /log ascent/i }).click();
       });
 
-      expect(mockTrack).toHaveBeenCalledWith('Tick Button Clicked', {
-        boardLayout: 'Original',
-        existingAscentCount: 0,
-      });
+      expect(mockTrack).toHaveBeenCalledWith(
+        'Quick Tick Opened',
+        expect.objectContaining({
+          boardLayout: 'Original',
+          existingAscentCount: 0,
+          source: 'climb_actions',
+        }),
+      );
     });
 
     it('calls onComplete callback when drawer is closed', async () => {

--- a/packages/web/app/components/climb-actions/actions/tick-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/tick-action.tsx
@@ -16,6 +16,7 @@ import { useOptionalBoardProvider, BoardProvider } from '../../board-provider/bo
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import { LogAscentForm } from '../../logbook/logascent-form';
 import { track } from '@/app/lib/analytics';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { constructClimbInfoUrl } from '@/app/lib/url-utils';
 import { openExternalUrl } from '@/app/lib/open-external-url';
 import { themeTokens } from '@/app/theme/theme-config';
@@ -95,9 +96,14 @@ export function TickAction({
       e?.stopPropagation();
       e?.preventDefault();
 
-      track('Tick Button Clicked', {
+      // Web's old `Tick Button Clicked` fired here, on OPEN — the same moment
+      // mobile reports as Quick Tick Opened, under a different name. Unified so
+      // one funnel covers both platforms: open → Tick Logged / Quick Tick Failed.
+      track(SHARED_EVENTS.QuickTickOpened, {
+        climbUuid: climb.uuid,
         boardLayout: boardDetails.layout_name || '',
         existingAscentCount: badgeCount,
+        source: 'climb_actions',
       });
 
       if (onTickAction) {

--- a/packages/web/app/components/logbook/__tests__/logascent-form-0deg.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/logascent-form-0deg.test.tsx
@@ -190,6 +190,15 @@ describe('LogAscentForm — 0° regression', () => {
         expect.objectContaining({ climbUuid: 'climb-1', platform: 'web', surface: 'web_full_form' }),
       ),
     );
+
+    // Tick Logged is the single commit event across all three tick surfaces, so
+    // a `surface` breakdown is only comparable if each one reports the same
+    // fields — this form used to omit these four.
+    const [, properties] = mockTrack.mock.calls.find(([eventName]) => eventName === SHARED_EVENTS.TickLogged) ?? [];
+    expect(properties).toHaveProperty('attemptCount');
+    expect(properties).toHaveProperty('hasQuality');
+    expect(properties).toHaveProperty('grade');
+    expect(properties).toHaveProperty('hasComment');
   });
 
   it('disables submit when no angle resolved (null), with the helper text spelled out', () => {

--- a/packages/web/app/components/logbook/logascent-form.tsx
+++ b/packages/web/app/components/logbook/logascent-form.tsx
@@ -237,14 +237,23 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({
         videoUrl: logType === 'ascent' && trimmedVideoUrl ? trimmedVideoUrl : undefined,
       });
 
+      // Carries the same payload as the other two tick surfaces (web quick modal,
+      // mobile quick tick) — Tick Logged is the single commit event since the
+      // analytics cull, so a surface breakdown is only comparable if every
+      // surface reports the same fields.
+      const loggedDifficulty = logType === 'ascent' ? (values.difficulty ?? null) : null;
       track(SHARED_EVENTS.TickLogged, {
         climbUuid: currentClimb.uuid,
         boardLayout: boardDetails.layout_name || '',
         status,
-        hasDifficulty: logType === 'ascent' && values.difficulty !== undefined,
-        difficulty: logType === 'ascent' ? (values.difficulty ?? null) : null,
         platform: 'web',
         surface: 'web_full_form',
+        attemptCount: values.attempts,
+        hasQuality: logType === 'ascent' && !!values.quality,
+        hasDifficulty: logType === 'ascent' && values.difficulty !== undefined,
+        difficulty: loggedDifficulty,
+        grade: grades.find((grade) => grade.difficulty_id === loggedDifficulty)?.difficulty_name ?? null,
+        hasComment: (values.notes ?? '').length > 0,
       });
 
       setFormValues(getInitialValues());

--- a/packages/web/app/components/logbook/tick-button.tsx
+++ b/packages/web/app/components/logbook/tick-button.tsx
@@ -14,6 +14,7 @@ import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
 import LoginOutlined from '@mui/icons-material/LoginOutlined';
 import AppsOutlined from '@mui/icons-material/AppsOutlined';
 import { track } from '@/app/lib/analytics';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { LogAscentDrawer } from './log-ascent-drawer';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import { constructClimbInfoUrl } from '@/app/lib/url-utils';
@@ -60,9 +61,13 @@ export const TickButton: React.FC<TickButtonProps> = ({
   );
 
   const showDrawer = (e?: React.MouseEvent<HTMLButtonElement>) => {
-    track('Tick Button Clicked', {
+    // Fires on OPEN, matching mobile's Quick Tick Opened (this used to be web's
+    // separately-named `Tick Button Clicked`). See tick-action.tsx.
+    track(SHARED_EVENTS.QuickTickOpened, {
+      climbUuid: currentClimb?.uuid ?? null,
       boardLayout: boardDetails.layout_name || '',
       existingAscentCount: badgeCount,
+      source: 'logbook_tick_button',
     });
 
     // When tick mode is already active, save the tick

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -295,11 +295,11 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     (item: ClimbQueueItem, method: 'swipePlayViewDrawer' | 'playViewDrawer', direction: 'next' | 'previous') => {
       setDrawerDisplayedItem?.(null);
       setCurrentClimbQueueItem(item);
-      track('Queue Navigation', { direction, method, mode: 'broadcast' });
-      track('Wall Advance', {
-        source: method === 'swipePlayViewDrawer' ? 'drawer_swipe' : 'drawer_button',
+      track('Queue Navigation', {
         direction,
-        mode: isPersistentSessionActive ? 'party' : 'solo',
+        method,
+        mode: 'broadcast',
+        sessionMode: isPersistentSessionActive ? 'party' : 'solo',
         boardLayout: boardDetails.layout_name ?? '',
       });
     },

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -298,7 +298,6 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
       track('Queue Navigation', {
         direction,
         method,
-        mode: 'broadcast',
         sessionMode: isPersistentSessionActive ? 'party' : 'solo',
         boardLayout: boardDetails.layout_name ?? '',
       });

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-swipe-advance.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-swipe-advance.test.tsx
@@ -1,0 +1,374 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, act } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import QueueControlBar from '../queue-control-bar';
+import { track } from '@/app/lib/analytics';
+
+// -- All mocks before imports --
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string | readonly string[]) => ({
+    i18n: { language: 'en-US' },
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+  }),
+}));
+
+const mockShowMessage = vi.fn();
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: mockShowMessage }),
+}));
+
+const mockGetPreference = vi.fn().mockResolvedValue(null);
+const mockSetPreference = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/app/lib/user-preferences-db', () => ({
+  getPreference: (...args: unknown[]) => mockGetPreference(...args),
+  setPreference: (...args: unknown[]) => mockSetPreference(...args),
+}));
+
+let mockQueueContext: Record<string, unknown> = {};
+vi.mock('@/app/components/graphql-queue', () => ({
+  useQueueContext: () => mockQueueContext,
+  useQueueActions: () => mockQueueContext,
+  useCurrentClimb: () => ({
+    currentClimb: mockQueueContext.currentClimb,
+  }),
+  useQueueList: () => ({
+    queue: mockQueueContext.queue,
+    suggestedClimbs: [],
+  }),
+  useSessionData: () => ({
+    viewOnlyMode: mockQueueContext.viewOnlyMode ?? false,
+    isSessionActive: !!mockQueueContext.sessionId,
+    // Drives the `sessionMode` prop on the advance event.
+    isPersistentSessionActive: mockQueueContext.isPersistentSessionActive ?? false,
+    sessionId: mockQueueContext.sessionId ?? null,
+    sessionSummary: null,
+    sessionGoal: null,
+    connectionState: mockQueueContext.connectionState ?? 'idle',
+    canMutate: mockQueueContext.canMutate ?? true,
+    isDisconnected: mockQueueContext.isDisconnected ?? false,
+    users: mockQueueContext.users ?? [],
+    clientId: null,
+    isLeader: true,
+    isBackendMode: false,
+    hasConnected: true,
+    connectionError: null,
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/kilter/1/1/1/40',
+  useParams: () => ({
+    board_name: 'kilter',
+    layout_id: '1',
+    size_id: '1',
+    set_ids: '1',
+    angle: '40',
+  }),
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) =>
+    React.createElement('a', props, children),
+}));
+
+vi.mock('@/app/lib/analytics', () => ({ track: vi.fn() }));
+
+// Capture the swipe callbacks so a test can fire them directly — the real hook
+// needs touch gestures jsdom won't produce. vi.hoisted so the hoisted vi.mock
+// factory below can reach it.
+const swipeCallbacks = vi.hoisted(() => ({
+  onSwipeNext: undefined as (() => void) | undefined,
+  onSwipePrevious: undefined as (() => void) | undefined,
+}));
+
+vi.mock('@/app/hooks/use-card-swipe-navigation', () => ({
+  useCardSwipeNavigation: (options: { onSwipeNext?: () => void; onSwipePrevious?: () => void }) => {
+    swipeCallbacks.onSwipeNext = options?.onSwipeNext;
+    swipeCallbacks.onSwipePrevious = options?.onSwipePrevious;
+    return {
+      swipeHandlers: {},
+      swipeOffset: 0,
+      isAnimating: false,
+      navigateToNext: vi.fn(),
+      navigateToPrev: vi.fn(),
+      peekIsNext: true,
+      exitOffset: 0,
+      enterDirection: null,
+      clearEnterAnimation: vi.fn(),
+    };
+  },
+  EXIT_DURATION: 300,
+  SNAP_BACK_DURATION: 200,
+  ENTER_ANIMATION_DURATION: 300,
+}));
+
+vi.mock('@/app/hooks/use-color-mode', () => ({
+  useColorMode: () => ({ mode: 'light' }),
+}));
+
+vi.mock('@/app/lib/grade-colors', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    getGradeTintColor: () => null,
+  };
+});
+
+vi.mock('@/app/components/climb-card/climb-thumbnail', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'climb-thumbnail' }),
+}));
+
+vi.mock('@/app/components/climb-card/climb-title', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'climb-title' }),
+}));
+
+vi.mock('@/app/components/queue-control/queue-list', () => ({
+  default: React.forwardRef(() => React.createElement('div', { 'data-testid': 'queue-list' })),
+}));
+
+vi.mock('@/app/components/swipeable-drawer/swipeable-drawer', () => ({
+  default: ({ open, children }: { open?: boolean; children?: React.ReactNode }) =>
+    React.createElement('div', { 'data-testid': 'queue-drawer', 'data-open': open ? 'true' : 'false' }, children),
+}));
+
+// queue-control-bar now uses the single `queue-nav-button` for both prev and
+// next (next-climb-button.tsx / previous-climb-button.tsx were removed during
+// the queue pivot). Mock the new module with a no-op so unit tests don't have
+// to satisfy its hooks.
+vi.mock('@/app/components/queue-control/queue-nav-button', () => ({
+  default: ({ direction }: { direction: 'next' | 'previous' }) =>
+    React.createElement('button', { 'data-testid': `${direction}-climb` }),
+}));
+
+vi.mock('@/app/components/logbook/tick-button', () => ({
+  TickButton: (props: { onActivateTickBar?: () => void; tickBarActive?: boolean }) =>
+    React.createElement('button', {
+      'data-testid': 'tick-button',
+      onClick: props.onActivateTickBar,
+      'data-tick-active': props.tickBarActive,
+    }),
+}));
+
+vi.mock('@/app/components/play-view/play-view-drawer', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/components/onboarding/onboarding-tour-events', () => ({
+  TOUR_CLOSE_PLAY_VIEW_EVENT: 'onboarding:close-play-view',
+}));
+
+vi.mock('@/app/components/ui/confirm-popover', () => ({
+  ConfirmPopover: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ status: 'unauthenticated', data: null }),
+}));
+
+let mockPersistentSessionState: Record<string, unknown> = {
+  activeSession: null,
+  localBoardDetails: null,
+  localCurrentClimbQueueItem: null,
+  session: null,
+  users: [],
+};
+vi.mock('@/app/components/persistent-session/persistent-session-context', () => ({
+  usePersistentSessionState: () => mockPersistentSessionState,
+}));
+
+vi.mock('@/app/components/board-bluetooth-control/bluetooth-context', () => ({
+  useBluetoothContext: () => ({
+    isConnected: false,
+    isConnecting: false,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    sendLedUpdate: vi.fn(),
+  }),
+}));
+
+vi.mock('@/app/components/board-provider/board-provider-context', () => ({
+  useBoardProvider: () => ({ logbook: [] }),
+}));
+
+vi.mock('@/app/components/logbook/quick-tick-bar', () => ({
+  QuickTickBar: React.forwardRef((_props: unknown, _ref: unknown) =>
+    React.createElement('div', { 'data-testid': 'quick-tick-bar' }),
+  ),
+}));
+
+vi.mock('@/app/hooks/use-tick-save', () => ({
+  hasPriorHistoryForClimb: () => false,
+}));
+
+vi.mock('@/app/components/session-creation/start-sesh-drawer', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/components/sesh-settings/sesh-settings-drawer-event', () => ({
+  dispatchOpenSeshSettingsDrawer: vi.fn(),
+}));
+
+vi.mock('@/app/lib/session-utils', () => ({
+  generateSessionName: () => 'Test Session',
+}));
+
+vi.mock('qrcode.react', () => ({
+  QRCodeSVG: () => null,
+}));
+
+vi.mock('@/app/lib/share-utils', () => ({
+  shareWithFallback: vi.fn(),
+}));
+
+// jsdom doesn't provide window.matchMedia — stub it before the component
+// accesses it (the swipe-hint effect calls matchMedia on mount).
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+// Import after mocks
+
+const mockClimb = {
+  uuid: 'climb-1',
+  setter_username: 'setter1',
+  name: 'Test Climb',
+  description: '',
+  frames: '',
+  angle: 40,
+  ascensionist_count: 5,
+  difficulty: '7',
+  quality_average: '3.5',
+  stars: 3,
+  difficulty_error: '',
+  mirrored: false,
+  benchmark_difficulty: null,
+  userAscents: 0,
+  userAttempts: 0,
+};
+
+const makeQueueItem = (uuid: string) => ({
+  uuid,
+  climb: { ...mockClimb, uuid: `climb-${uuid}` },
+  addedBy: 'user-1',
+  suggested: false,
+});
+
+const baseQueueContext = {
+  queue: [makeQueueItem('item-1')],
+  currentClimbQueueItem: makeQueueItem('item-1'),
+  currentClimb: mockClimb,
+  climbSearchResults: [],
+  suggestedClimbs: [],
+  isFetchingClimbs: false,
+  isFetchingNextPage: false,
+  hasDoneFirstFetch: true,
+  viewOnlyMode: false,
+  parsedParams: { board_name: 'kilter', layout_id: '1', size_id: '1', set_ids: ['1'], angle: '40' },
+  connectionState: 'connected',
+  sessionId: 'session-1',
+  canMutate: true,
+  isDisconnected: false,
+  users: [],
+  endSession: vi.fn(),
+  disconnect: vi.fn(),
+  addToQueue: vi.fn(),
+  removeFromQueue: vi.fn(),
+  setCurrentClimb: vi.fn(),
+  setCurrentClimbQueueItem: vi.fn(),
+  setClimbSearchParams: vi.fn(),
+  setCountSearchParams: vi.fn(),
+  mirrorClimb: vi.fn(),
+  fetchMoreClimbs: vi.fn(),
+  getNextClimbQueueItem: vi.fn().mockReturnValue(null),
+  getPreviousClimbQueueItem: vi.fn().mockReturnValue(null),
+  setQueue: vi.fn(),
+};
+
+const defaultProps = {
+  angle: '40' as unknown as number,
+  boardDetails: {
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 1,
+    set_ids: '1',
+    images_to_holds: {},
+    layout_name: 'Original',
+    size_name: '12x12',
+    size_description: 'Standard',
+    set_names: ['Base'],
+    edge_left: 0,
+    edge_right: 0,
+    edge_bottom: 0,
+    edge_top: 0,
+  } as never,
+};
+
+describe('QueueControlBar swipe advance analytics', () => {
+  // A bar swipe is the same broadcast advance as the nav button, so it emits the
+  // same single `Queue Navigation` event. The separate `Wall Advance` that used
+  // to fire alongside it was folded in; `sessionMode` carries what it added.
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueueContext = {
+      ...baseQueueContext,
+      getNextClimbQueueItem: vi.fn().mockReturnValue(makeQueueItem('item-2')),
+      getPreviousClimbQueueItem: vi.fn().mockReturnValue(makeQueueItem('item-0')),
+    };
+    mockPersistentSessionState = {
+      activeSession: null,
+      localBoardDetails: null,
+      localCurrentClimbQueueItem: null,
+      session: null,
+      users: [],
+    };
+    mockGetPreference.mockResolvedValue(null);
+    mockSetPreference.mockResolvedValue(undefined);
+  });
+
+  it('emits one Queue Navigation per forward swipe, with sessionMode=solo', async () => {
+    render(React.createElement(QueueControlBar, defaultProps));
+
+    await act(async () => {
+      swipeCallbacks.onSwipeNext?.();
+    });
+
+    expect(vi.mocked(track)).toHaveBeenCalledWith('Queue Navigation', {
+      direction: 'next',
+      method: 'swipeQueueBar',
+      sessionMode: 'solo',
+      boardLayout: 'Original',
+    });
+    expect(vi.mocked(track).mock.calls.filter(([eventName]) => eventName === 'Queue Navigation')).toHaveLength(1);
+    expect(vi.mocked(track)).not.toHaveBeenCalledWith('Wall Advance', expect.anything());
+  });
+
+  it('emits sessionMode=party on a backward swipe inside a persistent session', async () => {
+    mockQueueContext = { ...mockQueueContext, isPersistentSessionActive: true };
+    render(React.createElement(QueueControlBar, defaultProps));
+
+    await act(async () => {
+      swipeCallbacks.onSwipePrevious?.();
+    });
+
+    expect(vi.mocked(track)).toHaveBeenCalledWith('Queue Navigation', {
+      direction: 'previous',
+      method: 'swipeQueueBar',
+      sessionMode: 'party',
+      boardLayout: 'Original',
+    });
+  });
+});

--- a/packages/web/app/components/queue-control/__tests__/queue-nav-button-advance.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-nav-button-advance.test.tsx
@@ -77,11 +77,11 @@ const sampleItem: ClimbQueueItem = {
 
 const boardDetails = { layout_name: 'Original' } as Parameters<typeof QueueNavButton>[0]['boardDetails'];
 
-function findWallAdvanceCall() {
-  return mockTrack.mock.calls.find((args) => args[0] === 'Wall Advance');
+function findQueueNavigationCall() {
+  return mockTrack.mock.calls.find((args) => args[0] === 'Queue Navigation');
 }
 
-describe('QueueNavButton Wall Advance event', () => {
+describe('QueueNavButton advance event', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetNextClimbQueueItem.mockReturnValue(sampleItem);
@@ -89,50 +89,48 @@ describe('QueueNavButton Wall Advance event', () => {
     sessionDataMock = { viewOnlyMode: false, isPersistentSessionActive: false };
   });
 
-  it('fires Wall Advance with bar_button source in solo mode', () => {
+  it('fires Queue Navigation with sessionMode=solo outside a party session', () => {
     render(<QueueNavButton direction="next" boardDetails={boardDetails} />);
 
     fireEvent.click(screen.getByRole('button'));
 
-    const call = findWallAdvanceCall();
+    const call = findQueueNavigationCall();
     expect(call).toBeTruthy();
     // Always-live model: no pressedByRole — every press is an unqualified
     // broadcast advance.
     expect(call?.[1]).toMatchObject({
-      source: 'bar_button',
+      method: 'button',
       direction: 'next',
-      mode: 'solo',
+      sessionMode: 'solo',
       boardLayout: 'Original',
     });
     expect(call?.[1]).not.toHaveProperty('pressedByRole');
   });
 
-  it('fires Wall Advance with mode=party when any participant presses in a party session', () => {
+  it('fires sessionMode=party when any participant presses in a party session', () => {
     sessionDataMock = { viewOnlyMode: false, isPersistentSessionActive: true };
     render(<QueueNavButton direction="previous" boardDetails={boardDetails} />);
 
     fireEvent.click(screen.getByRole('button'));
 
-    const call = findWallAdvanceCall();
+    const call = findQueueNavigationCall();
     expect(call).toBeTruthy();
     expect(call?.[1]).toMatchObject({
-      source: 'bar_button',
+      method: 'button',
       direction: 'previous',
-      mode: 'party',
+      sessionMode: 'party',
       boardLayout: 'Original',
     });
     expect(call?.[1]).not.toHaveProperty('pressedByRole');
   });
 
-  it('still fires Queue Navigation alongside Wall Advance (analytics continuity)', () => {
+  it('fires exactly one advance event — the separate Wall Advance was folded in', () => {
     render(<QueueNavButton direction="next" boardDetails={boardDetails} />);
 
     fireEvent.click(screen.getByRole('button'));
 
-    const queueNavCall = mockTrack.mock.calls.find((args) => args[0] === 'Queue Navigation');
-    const wallAdvanceCall = findWallAdvanceCall();
-    expect(queueNavCall).toBeTruthy();
-    expect(wallAdvanceCall).toBeTruthy();
+    expect(mockTrack.mock.calls.filter((args) => args[0] === 'Queue Navigation')).toHaveLength(1);
+    expect(mockTrack.mock.calls.find((args) => args[0] === 'Wall Advance')).toBeUndefined();
   });
 
   it('disables the button when there is no advance target', () => {
@@ -142,6 +140,6 @@ describe('QueueNavButton Wall Advance event', () => {
     const button = screen.getByRole('button') as HTMLButtonElement;
     expect(button.disabled).toBe(true);
     fireEvent.click(button);
-    expect(findWallAdvanceCall()).toBeUndefined();
+    expect(findQueueNavigationCall()).toBeUndefined();
   });
 });

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -300,17 +300,12 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
 
     setCurrentClimbQueueItem(nextClimb);
     const boardLayout = boardDetails?.layout_name || '';
+    // Bar swipe is a broadcast advance just like the bar button. Always-live
+    // model: anyone in the session can swipe to advance the wall climb.
     track('Queue Navigation', {
       direction: 'next',
       method: 'swipeQueueBar',
-      boardLayout,
-    });
-    // Bar swipe is a broadcast advance just like the bar button. Always-live
-    // model: anyone in the session can swipe to advance the wall climb.
-    track('Wall Advance', {
-      source: 'bar_swipe',
-      direction: 'next',
-      mode: isPersistentSessionActive ? 'party' : 'solo',
+      sessionMode: isPersistentSessionActive ? 'party' : 'solo',
       boardLayout,
     });
   }, [nextClimb, viewOnlyMode, setCurrentClimbQueueItem, boardDetails, isPersistentSessionActive]);
@@ -323,12 +318,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     track('Queue Navigation', {
       direction: 'previous',
       method: 'swipeQueueBar',
-      boardLayout,
-    });
-    track('Wall Advance', {
-      source: 'bar_swipe',
-      direction: 'previous',
-      mode: isPersistentSessionActive ? 'party' : 'solo',
+      sessionMode: isPersistentSessionActive ? 'party' : 'solo',
       boardLayout,
     });
   }, [previousClimb, viewOnlyMode, setCurrentClimbQueueItem, boardDetails, isPersistentSessionActive]);
@@ -586,11 +576,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     // opens in browse mode on the wall climb; the bar's ON WALL chip stays
     // visible behind it so wall-climb identity is never hidden.
     dispatchOpenPlayDrawer();
-    track('Play Drawer Opened', {
-      boardLayout: boardDetails.layout_name || '',
-      source: 'bar_tap',
-    });
-  }, [currentClimb, viewOnlyMode, boardDetails.layout_name]);
+  }, [currentClimb, viewOnlyMode]);
 
   // Transition style shared by current and peek text
   const getTextTransitionStyle = () => {

--- a/packages/web/app/components/queue-control/queue-nav-button.tsx
+++ b/packages/web/app/components/queue-control/queue-nav-button.tsx
@@ -42,24 +42,18 @@ export default function QueueNavButton({ direction, boardDetails }: QueueNavButt
     if (!target || viewOnlyMode) return;
     setCurrentClimbQueueItem(target);
     const boardLayout = boardDetails?.layout_name || '';
+    // Every successful broadcast advance. Always-live model: any participant can
+    // advance the wall climb.
+    //
+    // Fired BEFORE the mutation acks, so a transient network failure can produce
+    // an event without a corresponding wall change. Consistent with other queue
+    // analytics and intentional: we'd rather count user intent than gate on
+    // round-trip success. Watch the ratio against `Wall Confirmed` if this
+    // becomes a misleading signal.
     track('Queue Navigation', {
       direction,
       method: 'button',
-      boardLayout,
-    });
-    // Wall Advance fires on every successful broadcast advance. Always-live
-    // model: any participant can advance the wall climb.
-    //
-    // Fired BEFORE the mutation acks — matches the existing `Queue Navigation`
-    // fire-on-call pattern (above). Means a transient network failure can
-    // produce a `Wall Advance` event without a corresponding wall change.
-    // Consistent with other queue analytics and intentional: we'd rather
-    // count user intent than gate on round-trip success. Watch the ratio of
-    // `Wall Advance` to `Wall Confirmed` if this becomes a misleading signal.
-    track('Wall Advance', {
-      source: 'bar_button',
-      direction,
-      mode: isPersistentSessionActive ? 'party' : 'solo',
+      sessionMode: isPersistentSessionActive ? 'party' : 'solo',
       boardLayout,
     });
   }, [target, viewOnlyMode, setCurrentClimbQueueItem, boardDetails?.layout_name, direction, isPersistentSessionActive]);

--- a/packages/web/app/components/search-drawer/__tests__/accordion-search-form-handlers.test.tsx
+++ b/packages/web/app/components/search-drawer/__tests__/accordion-search-form-handlers.test.tsx
@@ -310,57 +310,6 @@ describe('AccordionSearchForm — quality filter controls', () => {
       expect(mockUpdateFilters.mock.calls.at(-1)?.[0]).toEqual({ minGrade: 24, maxGrade: 24 });
     });
 
-    it('fires "Grade Filter Changed" analytics with single-grade properties on a one-tap collapse', () => {
-      render(<AccordionSearchForm boardDetails={boardDetails} />);
-      tapChip('V6');
-      expect(mockTrack).toHaveBeenCalledWith('Grade Filter Changed', {
-        filter_kind: 'single',
-        min_grade_id: 22,
-        max_grade_id: 22,
-        range_size: 1,
-        previous_filter_kind: 'any',
-        previous_min_grade_id: null,
-        previous_max_grade_id: null,
-        extended_range_within_window: null,
-        board_name: 'kilter',
-      });
-    });
-
-    it('fires "Grade Filter Changed" with filter_kind="range" + extended_range_within_window=true when extending within window', () => {
-      mockUISearchParams = { ...DEFAULT_SEARCH_PARAMS, minGrade: 22, maxGrade: 22 };
-      render(<AccordionSearchForm boardDetails={boardDetails} />);
-      tapChip('V11');
-      // V6..V11 spans difficulty_ids 22..28 → indices 12..18 in Kilter → 7 grades.
-      expect(mockTrack).toHaveBeenCalledWith('Grade Filter Changed', {
-        filter_kind: 'range',
-        min_grade_id: 22,
-        max_grade_id: 28,
-        range_size: 7,
-        previous_filter_kind: 'single',
-        previous_min_grade_id: 22,
-        previous_max_grade_id: 22,
-        extended_range_within_window: true,
-        board_name: 'kilter',
-      });
-    });
-
-    it('fires "Grade Filter Changed" with filter_kind="any" + previous_filter_kind="range" on clear', () => {
-      mockUISearchParams = { ...DEFAULT_SEARCH_PARAMS, minGrade: 22, maxGrade: 28 };
-      render(<AccordionSearchForm boardDetails={boardDetails} />);
-      tapChip('Any');
-      expect(mockTrack).toHaveBeenCalledWith('Grade Filter Changed', {
-        filter_kind: 'any',
-        min_grade_id: null,
-        max_grade_id: null,
-        range_size: null,
-        previous_filter_kind: 'range',
-        previous_min_grade_id: 22,
-        previous_max_grade_id: 28,
-        extended_range_within_window: null,
-        board_name: 'kilter',
-      });
-    });
-
     it('does not persist a "last used grade" — the URL params already capture the range', () => {
       render(<AccordionSearchForm boardDetails={boardDetails} />);
       tapChip('V6');

--- a/packages/web/app/components/search-drawer/accordion-search-form.tsx
+++ b/packages/web/app/components/search-drawer/accordion-search-form.tsx
@@ -16,7 +16,7 @@ import ArrowUpwardOutlined from '@mui/icons-material/ArrowUpwardOutlined';
 import Shuffle from '@mui/icons-material/Shuffle';
 import { getGradesForBoard } from '@/app/lib/board-data';
 import MinAscentsBucketPicker from '@/app/components/climb-quality-filter/min-ascents-bucket-picker';
-import { GradeRangePicker, type GradeRangeChangeMeta } from '@/app/components/grade-picker/grade-range-picker';
+import { GradeRangePicker } from '@/app/components/grade-picker/grade-range-picker';
 import { InlineStarPicker } from '@/app/components/logbook/tick-controls';
 import { useUISearchParams } from '@/app/components/queue-control/ui-searchparams-provider';
 import { useBoardProvider } from '@/app/components/board-provider/board-provider-context';
@@ -26,9 +26,7 @@ import SetterNameSelect from './setter-name-select';
 import ClimbSearchForm from './climb-search-form';
 import type { BoardDetails } from '@/app/lib/types';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
-import { track } from '@/app/lib/analytics';
-import { SHARED_EVENTS } from '@boardsesh/analytics';
-import { describeGradeFilter, newSortSeed } from '@boardsesh/climb-filters';
+import { newSortSeed } from '@boardsesh/climb-filters';
 import {
   getQualityPanelSummary,
   getStatusPanelSummary,
@@ -80,43 +78,17 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({ boardDetails,
   const minGradeForPicker = uiSearchParams.minGrade > 0 ? uiSearchParams.minGrade : undefined;
   const maxGradeForPicker = uiSearchParams.maxGrade > 0 ? uiSearchParams.maxGrade : undefined;
 
-  // Ascending difficulty ids — feeds the shared describeGradeFilter so web and
-  // mobile classify the `Grade Filter Changed` event identically. Sorted
-  // defensively (like mobile) so range_size stays correct even if the source
-  // list ever arrives out of order.
-  const gradeIds = grades.map((g) => g.difficulty_id).sort((first, second) => first - second);
-
   // The filter shape uses `0` as the "no grade" sentinel. `updateFilters` strips
   // `undefined` from updates, so we coerce both bounds to concrete numbers
   // (`0` when the picker is at the extreme) before sending.
-  const handleGradeRangeChange = (
-    { minGradeId, maxGradeId }: { minGradeId: number | undefined; maxGradeId: number | undefined },
-    meta?: GradeRangeChangeMeta,
-  ) => {
-    // `minGradeForPicker` / `maxGradeForPicker` still reflect the PREVIOUS
-    // state here — updateFilters() below kicks off the re-render that will
-    // refresh them. Capture them now so the analytics event carries the
-    // before/after for funnel/rage-pattern analysis later.
-    const previous = describeGradeFilter({ minGradeId: minGradeForPicker, maxGradeId: maxGradeForPicker }, gradeIds);
-    const next = describeGradeFilter({ minGradeId, maxGradeId }, gradeIds);
-
+  const handleGradeRangeChange = ({
+    minGradeId,
+    maxGradeId,
+  }: {
+    minGradeId: number | undefined;
+    maxGradeId: number | undefined;
+  }) => {
     updateFilters({ minGrade: minGradeId ?? 0, maxGrade: maxGradeId ?? 0 });
-
-    track(SHARED_EVENTS.GradeFilterChanged, {
-      filter_kind: next.kind,
-      min_grade_id: minGradeId ?? null,
-      max_grade_id: maxGradeId ?? null,
-      range_size: next.size,
-      previous_filter_kind: previous.kind,
-      previous_min_grade_id: minGradeForPicker ?? null,
-      previous_max_grade_id: maxGradeForPicker ?? null,
-      // Set only when the picker fired Rule 3 (tap-from-single-grade).
-      // true  = range extended within the 3s window.
-      // false = window expired, switched single grade instead (no accidental range).
-      // null  = Rule 3 didn't fire.
-      extended_range_within_window: meta?.extendedRangeWithinWindow ?? null,
-      board_name: boardDetails.board_name,
-    });
   };
 
   // Boulder/route switches share one invariant: at least one of the two must

--- a/packages/web/app/hooks/__tests__/use-tick-save.test.ts
+++ b/packages/web/app/hooks/__tests__/use-tick-save.test.ts
@@ -357,7 +357,7 @@ describe('useTickSave', () => {
     expect(call.status).toBe('send');
   });
 
-  it('save() fires the canonical TickLogged event alongside Quick Tick Saved on success', async () => {
+  it('save() fires exactly one commit event — the canonical TickLogged', async () => {
     const opts = makeOptions({
       tickTarget: {
         climb: makeClimb(),
@@ -371,13 +371,15 @@ describe('useTickSave', () => {
 
     await act(async () => {
       result.current.save();
-      await vi.waitFor(() => expect(mockTrack).toHaveBeenCalledWith(SHARED_EVENTS.QuickTickSaved, expect.anything()));
+      await vi.waitFor(() => expect(mockTrack).toHaveBeenCalledWith(SHARED_EVENTS.TickLogged, expect.anything()));
     });
 
     expect(mockTrack).toHaveBeenCalledWith(
       SHARED_EVENTS.TickLogged,
       expect.objectContaining({ climbUuid: 'climb-1', status: 'send', platform: 'web', surface: 'web_quick_modal' }),
     );
+    // The old Quick Tick Saved companion fired from this same .then() block.
+    expect(mockTrack).not.toHaveBeenCalledWith('Quick Tick Saved', expect.anything());
   });
 
   it('save() sends status send when attemptCount > 1', () => {
@@ -422,7 +424,7 @@ describe('useTickSave', () => {
     expect(call.status).toBe('attempt');
   });
 
-  it('save() sends the resolved grade label alongside the numeric difficulty on Quick Tick Saved', async () => {
+  it('save() sends the resolved grade label alongside the numeric difficulty on Tick Logged', async () => {
     const opts = makeOptions({
       difficulty: 5,
       gradeName: 'V5',
@@ -438,11 +440,11 @@ describe('useTickSave', () => {
 
     await act(async () => {
       result.current.save();
-      await vi.waitFor(() => expect(track).toHaveBeenCalledWith('Quick Tick Saved', expect.anything()));
+      await vi.waitFor(() => expect(track).toHaveBeenCalledWith('Tick Logged', expect.anything()));
     });
 
     expect(track).toHaveBeenCalledWith(
-      'Quick Tick Saved',
+      'Tick Logged',
       expect.objectContaining({ difficulty: 5, grade: 'V5', hasDifficulty: true }),
     );
   });
@@ -461,10 +463,10 @@ describe('useTickSave', () => {
 
     await act(async () => {
       result.current.save();
-      await vi.waitFor(() => expect(track).toHaveBeenCalledWith('Quick Tick Saved', expect.anything()));
+      await vi.waitFor(() => expect(track).toHaveBeenCalledWith('Tick Logged', expect.anything()));
     });
 
-    expect(track).toHaveBeenCalledWith('Quick Tick Saved', expect.objectContaining({ grade: null }));
+    expect(track).toHaveBeenCalledWith('Tick Logged', expect.objectContaining({ grade: null }));
   });
 
   describe('confetti variant selection', () => {

--- a/packages/web/app/hooks/use-tick-save.ts
+++ b/packages/web/app/hooks/use-tick-save.ts
@@ -29,7 +29,7 @@ export type UseTickSaveOptions = {
   /** Explicit ascent type. When provided, overrides the inferred status logic. */
   ascentType?: TickStatus;
   /** Human-readable grade label (e.g. "V5") resolved by the caller from its own
-   * loaded grades list, for the Quick Tick Saved analytics event. */
+   * loaded grades list, for the Tick Logged analytics event. */
   gradeName?: string;
   onSave: () => void;
   onError?: () => void;
@@ -163,22 +163,21 @@ export function useTickSave(options: UseTickSaveOptions): {
         ...(presenceBoardId !== null ? { boardId: presenceBoardId } : {}),
       })
         .then(() => {
-          track('Quick Tick Saved', {
-            boardLayout: targetBoard.layout_name || '',
-            status,
-            attemptCount,
-            hasQuality: quality !== null,
-            hasDifficulty: difficulty !== undefined,
-            difficulty: difficulty ?? null,
-            grade: gradeName ?? null,
-            hasComment: comment.length > 0,
-          });
+          // One event per committed tick. This used to fire Quick Tick Saved and
+          // TickLogged back to back with the same climb/status; TickLogged is the
+          // canonical cross-platform join event, so it absorbed the other's payload.
           track(SHARED_EVENTS.TickLogged, {
             climbUuid: climb.uuid,
             boardLayout: targetBoard.layout_name || '',
             status,
             platform: 'web',
             surface: 'web_quick_modal',
+            attemptCount,
+            hasQuality: quality !== null,
+            hasDifficulty: difficulty !== undefined,
+            difficulty: difficulty ?? null,
+            grade: gradeName ?? null,
+            hasComment: comment.length > 0,
           });
           void clearTickDraft(climb.uuid, Number(targetAngle));
           saving.current = false;

--- a/packages/web/app/lib/analytics.ts
+++ b/packages/web/app/lib/analytics.ts
@@ -83,9 +83,14 @@ function getPosthog(): PostHog | null {
 }
 
 type PosthogProperties = Record<string, string | number | boolean | null>;
+// `sendEvent: false` suppresses the SDK's `$feature_flag_called` capture. Verified
+// in @posthog/core 1.46.1 (shared by posthog-js-lite and posthog-react-native):
+// `_getFeatureFlagResult` gates the capture on it, and both `getFeatureFlag` and
+// `isFeatureEnabled` forward it. Flag VALUES are unaffected.
+type FeatureFlagReadOptions = { sendEvent?: boolean };
 type PosthogFeatureFlagClient = {
-  getFeatureFlag?: (key: string) => unknown;
-  isFeatureEnabled?: (key: string) => unknown;
+  getFeatureFlag?: (key: string, options?: FeatureFlagReadOptions) => unknown;
+  isFeatureEnabled?: (key: string, options?: FeatureFlagReadOptions) => unknown;
   reloadFeatureFlags?: () => unknown;
   onFeatureFlags?: (callback: () => void) => unknown;
 };
@@ -195,6 +200,14 @@ function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
   return typeof thenValue === 'function';
 }
 
+// This provider re-reads the WHOLE flag catalog on every flags-changed tick, so
+// leaving exposure events on cost ~173k events / 30 days across web + mobile —
+// 13% of the project's entire volume — for a signal nothing consumed: the project
+// runs no experiments, and the only insights referencing `$feature_flag_called`
+// are PostHog's auto-generated "<flag> Usage" boilerplate. Drop the option at a
+// specific call site if that flag ever needs real exposure analysis.
+const READ_WITHOUT_EXPOSURE_EVENT: FeatureFlagReadOptions = { sendEvent: false };
+
 export function readPosthogFeatureFlags(keys: readonly string[]): Record<string, boolean> {
   const posthog = getPosthog();
   if (!posthog) return {};
@@ -204,9 +217,9 @@ export function readPosthogFeatureFlags(keys: readonly string[]): Record<string,
   for (const key of keys) {
     let rawFlagValue: unknown;
     if (typeof featureFlagClient.getFeatureFlag === 'function') {
-      rawFlagValue = featureFlagClient.getFeatureFlag(key);
+      rawFlagValue = featureFlagClient.getFeatureFlag(key, READ_WITHOUT_EXPOSURE_EVENT);
     } else if (typeof featureFlagClient.isFeatureEnabled === 'function') {
-      rawFlagValue = featureFlagClient.isFeatureEnabled(key);
+      rawFlagValue = featureFlagClient.isFeatureEnabled(key, READ_WITHOUT_EXPOSURE_EVENT);
     }
     const flagValue = coerceFeatureFlagBoolean(rawFlagValue);
     if (flagValue !== undefined) {


### PR DESCRIPTION
## Summary

Our PostHog event projection has been climbing, so I audited what we actually emit against what anything reads.

**Method:** 30 days of volume (1.32M events), cross-referenced against every saved insight in project 412845 — event names extracted server-side with `extractAll` over `system.insights.query`, so no truncation blind spots — plus `system.actions`, `system.dashboards`, and `system.experiments`.

Two findings drove the change:

- **The project runs no experiments at all.** `$feature_flag_called` (172,684/30d, **13% of all volume**) therefore has no exposure consumer. The only insights referencing it are PostHog's auto-generated "`<flag>` Usage" boilerplate.
- **`Live Activity Push Delivery` was the worst ratio in the project**: 26,609 events across 191 users (83.5/user), of which **34** carried a failure. A third were `heartbeat` keep-alives.

Estimated reduction **~434k events / 30 days (~33%)**, with no consumed metric lost except one insight rewiring (below).

### What changed

| Change | 30d volume | Consumers before |
|---|---|---|
| `Live Activity Push Delivery` → fires only when `failedCount > 0 \|\| staleCount > 0` | 26,575 removed | none |
| `$feature_flag_called` → suppressed via `sendEvent: false` (both platforms) | 172,684 | 20 auto-generated flag dashboards |
| `Wall Advance` → folded into `Queue Navigation` | 2,213 | none |
| `Tick Button Clicked` + `Quick Tick Saved` → collapsed into `Tick Logged` | 36,263 | 1 + 5 insights |
| `Play Drawer Opened`, `Search Result Selected`, `Board Lightbulb Connect`, `Grade Filter Changed` → removed | 172,306 | none |

**Flag suppression** is verified against `@posthog/core` 1.46.1 (shared by `posthog-react-native` 4.61.2 and `posthog-js-lite` 4.10.1, both declaring `^1.46.1`): `_getFeatureFlagResult` gates the `capture('$feature_flag_called')` on `sendEvent`, and both `getFeatureFlag` and `isFeatureEnabled` forward it. **Flag values are unaffected** — only the exposure event stops. Drop the option at a call site if a flag ever needs real exposure analysis.

**The tick funnel** went from four events per tick to two. Worth calling out: web's `Tick Button Clicked` fired on the sheet **opening**, while mobile's fired on **save-intent** — one event name covering two different moments across platforms. Both platforms now share one funnel: `Quick Tick Opened` → `Tick Logged` / `Quick Tick Failed`.

### Deliberately left alone

- `Climb Sent to Board Success` (118,048) — 16 insights read it **and** it feeds `packages/db/scripts/refresh-recommendations.ts` → `board_climb_send_stats`.
- `$screen` (287,581) — highest single event, but 8 insights depend on it and it's already deduped in `AnalyticsScreenTracker`.
- `Bluetooth Connection Success` / `Failed` — the BLE health dashboard (1874713).
- `OTA Update Status` / `Downloaded` — no insight consumers, but only 1.4–1.8 events/user and the only production OTA rollout-health signal. Not worth blinding that.
- `Quick Tick Opened` — documented watchdog invariant for the phantom-reopen bug.

### Already fixed, draining on their own — no code change needed

`Board Now Playing Received` (39k), `Board Climb Reported` (22k), `Board History Catch Up` (24.7k, already gated on `recoveredThroughSeqDelta > 0`), and the `Application Backgrounded/Became Active/Opened/Installed/Updated` family (~35k) emit **zero** from the current build. They only come from the older shipped binary and drain as the fleet updates.

### Dead code removed with them

`describeGradeFilter` (+ its tests), `buildPlayDrawerBoardLayout`, the `openPlayDrawer` `source` option, the analytics-only `source`/`boardLayout`/`climbUuid` options on `useLightbulbControl`, and the per-row search rank index in the climbs list.

`GradeTapMeta` / `extendedRangeWithinWindow` are **kept**: they're now unused by production code, but they're an optional second callback arg and the grade-picker rule-3 tests assert them as tap semantics, not analytics.

### PostHog insights — done

All saved insights referencing a removed event have been repointed. It was **7**, not the 5 the plan estimated:

| Insight | Dashboard | Change |
|---|---|---|
| `[Engagement] Core actions per day` | Mobile App Rollout | tick series → `Tick Logged` |
| `[North-Star] Weekly Active Climbers (WAC) — guardrail` | App Success | → `Tick Logged` |
| `[North-Star] Hardware reliance — WAB / WAC` | App Success | → `Tick Logged` |
| `[Retention] Do tick-loggers come back?` | App Success | cohort entity → `Tick Logged` |
| `[Engagement] Send → tick logging rate` | App Success | → `Tick Logged` |
| `[Engagement] Tick richness by status` | App Success | → `Tick Logged` |
| `[Boards] Climb engagement funnel` | Board Sessions & Hardware | open step → `Quick Tick Opened` |

Verified: zero saved insights now reference `Quick Tick Saved`, `Tick Button Clicked`, `Wall Advance`, `Play Drawer Opened`, `Search Result Selected`, `Board Lightbulb Connect`, or `Grade Filter Changed`.

**Known step in the data:** `Tick Logged` runs ~7.5% below `Quick Tick Saved` historically (16,630 vs 17,976 on RN) because older shipped binaries fire the old event but not the canonical one — the tick tiles will show a modest step down until the fleet updates. `status` has full history on `Tick Logged`; `hasQuality` / `hasComment` only start with this release (noted in the affected insight's description).

The auto-generated flag-usage dashboards will also go quiet — expected, per the flag-suppression trade-off above.

### Note on when this lands

94% of current volume comes from binaries reporting `posthog-react-native` **4.46.8**, while the current build reports **4.61.2**. The backend change (`Live Activity Push Delivery`) bites immediately on deploy; the client-side savings arrive as the fleet picks up this JS.

> ✅ **Fable BLE review: APPROVE** — [full review in the comments](https://github.com/boardsesh/boardsesh/pull/4208#issuecomment-5222255466). No behaviour-change findings: `packages/mobile/src/lib/ble/` and `packages/shared/ble-protocol/` have an empty diff, the `onPress` dependency narrowing is sound, and the connect call order and arguments are unchanged. It confirmed `Bluetooth Connection Success/Failed` genuinely cover these paths, and flagged two accepted observability trade-offs (silent-hang detection, and losing the entry-point split on the notification reconnect). Its nits are applied in `11baa658`.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck` — green across all packages
- `vp run test:mobile` — 582 files, 5061 tests passing
- `vp run test:web` — 473 files, 5854 tests passing
- `vp test run --project backend` — the new `live-activity-analytics.test.ts` passes; the 86 local failures are environment contention (shared worker DBs on `:5433`, ports 8081–8089 held by other worktrees' dev servers) and every affected file passes when run in isolation
- shared packages — 15 files, 206 tests passing
- `vp check` — 28 errors / 299 warnings vs. 30 / 299 on clean `main`; two fewer errors from deleted code, zero new findings
- `vp run check:mobile-bundle` — Metro bundle OK
- Added `packages/backend/src/__tests__/live-activity-analytics.test.ts` covering the new failure/stale gate
- Added `queue-control-bar-swipe-advance.test.tsx` asserting both swipe directions emit exactly one `Queue Navigation` with the right `sessionMode` and no `Wall Advance` (review follow-up)
- Fable BLE review ran `typecheck:mobile`, `use-lightbulb-control` (13 tests) and `live-activity-bridge` (17 tests) independently — all green
