### PR TITLE
fix(mobile): keep the play drawer's background from covering the player on Android

### DIFF
--- a/packages/mobile/app/(tabs)/record/index.tsx
+++ b/packages/mobile/app/(tabs)/record/index.tsx
@@ -8,11 +8,16 @@ import { SessionScreen } from '../../../src/components/session-screen/SessionScr
  * running. A GlassSurface fills the background so the Liquid-Glass language from
  * the rest of the chrome carries through. No overlay props: there's no
  * drag/pull-to-dismiss here — switching tabs is the minimize.
+ *
+ * The fill is flat (`level0`) and non-interactive: it's a background with
+ * SessionScreen stacked on top as a sibling, and Android orders siblings by Z, so
+ * the Material branch's default `shadows.sm` cast (elevation 2) would lift it over
+ * the session content (the shape that broke the play drawer in #4209).
  */
 export default function RecordIndex() {
   return (
     <View style={styles.root}>
-      <GlassSurface glassEffectStyle="regular" style={StyleSheet.absoluteFill} />
+      <GlassSurface glassEffectStyle="regular" style={StyleSheet.absoluteFill} level="level0" pointerEvents="none" />
       <SessionScreen />
     </View>
   );

--- a/packages/mobile/app/play.tsx
+++ b/packages/mobile/app/play.tsx
@@ -125,11 +125,21 @@ export default function PlayScreen() {
       {/* Edge-to-edge glass/material background with NO radius — full-screen, not
           a card. Rendered on the first frame so the present animates over it.
           GlassSurface resolves Liquid Glass / blur / Material / Reduce-
-          Transparency-solid per device. */}
+          Transparency-solid per device.
+
+          `level0` and `pointerEvents="none"` are load-bearing, not cosmetic. This
+          surface is a BACKGROUND with the player stacked on top as a sibling, and
+          Android orders siblings by Z: GlassSurface's Material branch otherwise
+          defaults to `shadows.sm` (elevation 2), which lifts the full-screen fill
+          above the elevation-0 PlayDrawer and paints over the whole player — the
+          drawer opened showing nothing but its own tint (#4209). A background also
+          has no business taking touches. */}
       <GlassSurface
         style={StyleSheet.absoluteFill}
         glassEffectStyle="regular"
         role="low"
+        level="level0"
+        pointerEvents="none"
         fallbackColor={systemColors.secondaryBackground}
         tintColor={playDrawerMaterialTint[colorScheme]}
       />

--- a/packages/mobile/src/__tests__/background-glass-surface-flat-props.test.ts
+++ b/packages/mobile/src/__tests__/background-glass-surface-flat-props.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// GlassSurface's Material branch defaults to `shadows.sm` (elevation 2). A
+// consumer that stacks its content as a SIBLING of the surface — rather than as
+// a child — relies on Android's Z-ordering-by-elevation to keep that default
+// from lifting the surface above its own content. `level="level0"` (flat) and
+// `pointerEvents="none"` are what opt a background fill out of that footgun; the
+// glass-surface.test.tsx suite pins GlassSurface's own contract for those props,
+// but nothing else asserted that these specific call sites actually pass them —
+// so a refactor could silently drop either prop and reintroduce #4209 with no
+// test failing. This is a source-scan regression guard, not a render test: a
+// full mount of any of these screens needs their surrounding provider tree
+// (drawer-host / queue / theme), which is disproportionate for pinning two JSX
+// attributes.
+//
+// Each fixture file is asserted to have exactly one `<GlassSurface` JSX usage
+// (a background fill) so the extracted opening tag is unambiguous.
+const BACKGROUND_GLASS_SURFACE_SITES = [
+  join(__dirname, '../../app/play.tsx'),
+  join(__dirname, '../../app/(tabs)/record/index.tsx'),
+  join(__dirname, '../components/navigation/IpadSidebar.tsx'),
+];
+
+function backgroundGlassSurfaceOpeningTag(filePath: string): string {
+  const source = readFileSync(filePath, 'utf8');
+  const occurrences = [...source.matchAll(/<GlassSurface\b/g)];
+  if (occurrences.length !== 1) {
+    throw new Error(
+      `Expected exactly one <GlassSurface usage in ${filePath}, found ${occurrences.length}. ` +
+        'Update this test to disambiguate which one is the background fill.',
+    );
+  }
+  const start = occurrences[0].index;
+  const end = source.indexOf('/>', start);
+  if (end === -1) {
+    throw new Error(`Could not find the closing "/>" for <GlassSurface in ${filePath}`);
+  }
+  return source.slice(start, end + 2);
+}
+
+describe('background GlassSurface fills stay flat and non-interactive (#4209)', () => {
+  for (const filePath of BACKGROUND_GLASS_SURFACE_SITES) {
+    const relativePath = filePath.slice(filePath.indexOf('packages/mobile'));
+
+    it(`${relativePath} passes level="level0"`, () => {
+      expect(backgroundGlassSurfaceOpeningTag(filePath)).toMatch(/level="level0"/);
+    });
+
+    it(`${relativePath} passes pointerEvents="none"`, () => {
+      expect(backgroundGlassSurfaceOpeningTag(filePath)).toMatch(/pointerEvents="none"/);
+    });
+  }
+});

--- a/packages/mobile/src/components/__tests__/glass-surface.test.tsx
+++ b/packages/mobile/src/components/__tests__/glass-surface.test.tsx
@@ -83,8 +83,9 @@ vi.mock('../../theme/ios-colors', () => ({
 }));
 
 // Real tokens.ts pulls in PlatformColor via ios-colors; the material branch only
-// needs shadows.sm, so stub it.
-vi.mock('../../theme/tokens', () => ({ shadows: { sm: {} } }));
+// needs shadows.sm, so stub it — with the real `elevation: 2`, because that
+// default cast is exactly what a background surface must opt out of (#4209).
+vi.mock('../../theme/tokens', () => ({ shadows: { sm: { elevation: 2 } } }));
 
 import { GlassSurface } from '../GlassSurface';
 
@@ -248,5 +249,31 @@ describe('GlassSurface Material elevation cast vs. a consumer clip', () => {
     // the consumers that never clipped.
     const elevated = container.querySelector('[data-elevation="3"]');
     expect(elevated?.firstElementChild?.getAttribute('data-testid')).toBe('card-content');
+  });
+});
+
+// A background surface stacks its content as a SIBLING, and Android orders
+// siblings by Z — so the Material branch's default `shadows.sm` cast (elevation 2)
+// raises the fill above the elevation-0 content and paints over it. That is what
+// hid the whole play drawer behind its own tint on Android 9 (#4209).
+describe('GlassSurface as a background (flat + non-interactive)', () => {
+  beforeEach(() => {
+    ctrl.variant = 'material';
+  });
+
+  it('casts shadows.sm by default — the footgun a background must opt out of', () => {
+    const { container } = render(<GlassSurface role="low" />);
+    expect(container.querySelector('[data-elevation="2"]')).not.toBeNull();
+  });
+
+  it('renders flat with level0 so it cannot outrank its sibling content', () => {
+    const { container } = render(<GlassSurface role="low" level="level0" />);
+    expect(container.querySelector('[data-elevation="0"]')).not.toBeNull();
+    expect(container.querySelector('[data-elevation="2"]')).toBeNull();
+  });
+
+  it('forwards pointerEvents to the Material surface so a background takes no touches', () => {
+    const { container } = render(<GlassSurface role="low" level="level0" pointerEvents="none" />);
+    expect(container.querySelector('[data-elevation="0"]')?.getAttribute('data-pe')).toBe('none');
   });
 });

--- a/packages/mobile/src/components/navigation/IpadSidebar.tsx
+++ b/packages/mobile/src/components/navigation/IpadSidebar.tsx
@@ -153,10 +153,13 @@ function IpadSidebarComponent({ showWallCell = true }: { showWallCell?: boolean 
         },
       ]}
     >
-      {/* Glass fill behind the rail; nav items render as siblings on top. */}
+      {/* Glass fill behind the rail; nav items render as siblings on top, so the
+          fill stays flat — Android orders siblings by Z and the Material branch's
+          default `shadows.sm` cast (elevation 2) would raise it over them (#4209). */}
       <GlassSurface
         style={StyleSheet.absoluteFill}
         fallbackColor={systemColors.secondaryBackground}
+        level="level0"
         pointerEvents="none"
       />
       {/* The primary destinations form one tab group; the account row and the


### PR DESCRIPTION
## Summary

On a Galaxy S8 running Android 9, opening a Tension climb showed nothing but the play drawer's
gray/purple background — no board, no title, no controls. The reporter's runtime diagnostics confirmed
the player, selected climb, board config, and board-render data were all mounted correctly *underneath*
it.

Root cause is a `GlassSurface` footgun. Its Material branch defaults to `shadows.sm`:

```ts
// packages/mobile/src/components/GlassSurface.tsx:135
const elevationStyle = level ? materialElevation[level] : shadows.sm;
```

`shadows.sm` carries `elevation: 2`, and Android resolves paint order between siblings by Z. In
`app/play.tsx` the full-screen background is a **sibling** of `PlayDrawer`, so the elevation-2 fill can
draw on top of the elevation-0 player and cover it. Android always resolves to the Material variant
(`resolveUiVariant` → Material off iOS), so every Android device takes this branch — though in practice
only older ones appear to order the siblings this way (see the screenshots note below). The surface also
omitted `pointerEvents`, so it defaulted to `'auto'` and could swallow touches on top of hiding content.

The fix opts the background out of both: `level="level0"` (flat — `elevation: 0`, `shadowOpacity: 0`)
and `pointerEvents="none"`. Both props already existed on `GlassSurface` and are already forwarded on
every branch, so no component change was needed. The dropped shadow is invisible by design — a
full-screen fill casts off-screen.

Two other screen-level fills stack their content as siblings in exactly the same shape, so they get the
same hardening (not device-reproduced, so treat these as defensive):

- `app/(tabs)/record/index.tsx` — the Record tab's background, above `<SessionScreen />`
- `src/components/navigation/IpadSidebar.tsx` — the rail fill behind the nav items

Deliberately left alone: the bounded-size `absoluteFill` fills inside buttons and toolbars
(`GlassIconButton`, `GlassActionToolbar`, `SearchHeader`, `AccessoryBarSurface`, `SessionStartFab`,
`GradeRail`, the playlist buttons). They share the missing `level`, but they render fine on Android
today, so touching them would be an unverified visual sweep rather than a fix. Also not changing
`GlassSurface`'s `shadows.sm` default — that would silently flatten ~15 unmigrated surfaces.

Closes #4209

## Release Notes

- Fixed the play drawer on Android opening to an empty purple screen — your climb, the board, and the
  controls are back.

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 585 files, 5088 tests, all passing
- `vp check` on the five changed files — no formatting, lint, or type errors
- `vp run check:mobile-bundle` — Android bundle OK
- New regression coverage in `src/components/__tests__/glass-surface.test.tsx` pins the contract: the
  Material branch casts `elevation: 2` by default (the footgun), `level="level0"` renders flat, and
  `pointerEvents` reaches the Material surface. The suite's `shadows.sm` stub was `{}`, which erased
  the very elevation that caused this bug — it now carries the real `elevation: 2`.
- **Device verification:** the reporter confirmed the `play.tsx` fix on the affected Galaxy S8
  (Android 9) — board, title, and controls visible again. That remains the only reproduction of the
  bug itself.
- **Screenshots (no-regression only):** the Android screenshot workflow's `main` baseline renders the
  play drawer correctly on its modern-Android emulator, so CI does **not** reproduce the Android 9
  symptom. The run on this branch is therefore a check that the play drawer and Record tab still render
  and look unchanged, not proof of the fix — no screenshots are attached to this PR because none would
  demonstrate anything the device verification above doesn't already cover.
- **Regression guard:** `background-glass-surface-flat-props.test.ts` source-scans the three fix sites
  (`app/play.tsx`, `app/(tabs)/record/index.tsx`, `IpadSidebar.tsx`) and fails if a future edit drops
  `level="level0"` or `pointerEvents="none"` from any of them.

JS-only — no native fingerprint move, so this rides OTA.

