### PR TITLE
fix: never destroy the old avatar before the new one is saved

### DIFF
--- a/packages/backend/src/__tests__/avatar-upload-s3.test.ts
+++ b/packages/backend/src/__tests__/avatar-upload-s3.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { once } from 'node:events';
+
+const validateTokenMock = vi.hoisted(() => vi.fn());
+const isS3ConfiguredMock = vi.hoisted(() => vi.fn());
+const uploadToS3Mock = vi.hoisted(() => vi.fn());
+const deleteUserAvatarsFromS3Mock = vi.hoisted(() => vi.fn());
+
+vi.mock('../middleware/auth', () => ({
+  validateToken: validateTokenMock,
+}));
+
+vi.mock('../storage/s3', () => ({
+  isS3Configured: isS3ConfiguredMock,
+  uploadToS3: uploadToS3Mock,
+  deleteUserAvatarsFromS3: deleteUserAvatarsFromS3Mock,
+}));
+
+const { handleAvatarUpload } = await import('../handlers/avatars');
+
+const USER_ID = '22222222-2222-4222-8222-222222222222';
+const JPEG_BYTES = Buffer.from([0xff, 0xd8, 0xff, 0xdb, 0x00, 0x43, 0xff, 0xd9]);
+
+async function startAvatarServer(): Promise<{ baseUrl: string; server: Server }> {
+  const server = createServer((req, res) => {
+    void handleAvatarUpload(req, res).catch(() => {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Unhandled' }));
+    });
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address() as AddressInfo;
+  return { baseUrl: `http://127.0.0.1:${address.port}`, server };
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+async function uploadJpegAvatar(baseUrl: string): Promise<Response> {
+  const formData = new FormData();
+  formData.set('userId', USER_ID);
+  formData.set('avatar', new Blob([JPEG_BYTES], { type: 'image/jpeg' }), 'avatar.jpg');
+  return fetch(`${baseUrl}/api/avatars`, {
+    method: 'POST',
+    headers: { Authorization: 'Bearer avatar-token' },
+    body: formData,
+  });
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('avatar upload S3 path (write-first, clean-after)', () => {
+  it('uploads the new avatar before deleting stale extensions', async () => {
+    validateTokenMock.mockResolvedValue({ userId: USER_ID });
+    isS3ConfiguredMock.mockReturnValue(true);
+    const callOrder: string[] = [];
+    uploadToS3Mock.mockImplementation(async () => {
+      callOrder.push('upload');
+    });
+    deleteUserAvatarsFromS3Mock.mockImplementation(async () => {
+      callOrder.push('delete');
+    });
+
+    const { baseUrl, server } = await startAvatarServer();
+    try {
+      const response = await uploadJpegAvatar(baseUrl);
+
+      expect(response.status).toBe(200);
+      expect(callOrder).toEqual(['upload', 'delete']);
+      expect(uploadToS3Mock).toHaveBeenCalledWith(expect.any(Buffer), `avatars/${USER_ID}.jpg`, 'image/jpeg');
+      // keepExt must match the freshly written file so it is never deleted.
+      expect(deleteUserAvatarsFromS3Mock).toHaveBeenCalledWith(USER_ID, 'jpg');
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('never deletes the existing avatar when the S3 upload fails', async () => {
+    validateTokenMock.mockResolvedValue({ userId: USER_ID });
+    isS3ConfiguredMock.mockReturnValue(true);
+    uploadToS3Mock.mockRejectedValue(new Error('S3 unavailable'));
+
+    const { baseUrl, server } = await startAvatarServer();
+    try {
+      const response = await uploadJpegAvatar(baseUrl);
+
+      expect(response.status).toBe(500);
+      expect(deleteUserAvatarsFromS3Mock).not.toHaveBeenCalled();
+    } finally {
+      await closeServer(server);
+    }
+  });
+});

--- a/packages/backend/src/__tests__/avatar-upload.test.ts
+++ b/packages/backend/src/__tests__/avatar-upload.test.ts
@@ -56,7 +56,7 @@ function closeServer(server: Server): Promise<void> {
 
 async function removeUploadedAvatar(): Promise<void> {
   for (const ext of ['jpg', 'png', 'gif', 'webp']) {
-    await rm(path.join(getAvatarsDir(), `${USER_ID}.${ext}`), { force: true, recursive: true });
+    await rm(path.join(getAvatarsDir(), `${USER_ID}.${ext}`), { force: true });
   }
 }
 
@@ -140,15 +140,20 @@ describe('avatar upload routes', () => {
       const jpegBody = (await jpegResponse.json()) as { avatarUrl?: string };
 
       // Force the .png write to fail by occupying its path with a directory.
-      await mkdir(path.join(getAvatarsDir(), `${USER_ID}.png`));
+      const blockingDir = path.join(getAvatarsDir(), `${USER_ID}.png`);
+      await mkdir(blockingDir);
 
-      const pngResponse = await uploadAvatar(baseUrl, new Blob([PNG_BYTES], { type: 'image/png' }), 'avatar.png');
-      expect(pngResponse.status).toBe(500);
+      try {
+        const pngResponse = await uploadAvatar(baseUrl, new Blob([PNG_BYTES], { type: 'image/png' }), 'avatar.png');
+        expect(pngResponse.status).toBe(500);
 
-      // The previously uploaded avatar the stored avatarUrl points at must survive.
-      const staticResponse = await fetch(`${baseUrl}${jpegBody.avatarUrl}`);
-      expect(staticResponse.status).toBe(200);
-      expect(Buffer.from(await staticResponse.arrayBuffer())).toEqual(JPEG_BYTES);
+        // The previously uploaded avatar the stored avatarUrl points at must survive.
+        const staticResponse = await fetch(`${baseUrl}${jpegBody.avatarUrl}`);
+        expect(staticResponse.status).toBe(200);
+        expect(Buffer.from(await staticResponse.arrayBuffer())).toEqual(JPEG_BYTES);
+      } finally {
+        await rm(blockingDir, { recursive: true, force: true });
+      }
     } finally {
       await closeServer(server);
     }

--- a/packages/backend/src/__tests__/avatar-upload.test.ts
+++ b/packages/backend/src/__tests__/avatar-upload.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { once } from 'node:events';
-import { access, mkdir, rm } from 'node:fs/promises';
+import { access, mkdir, readdir, rm } from 'node:fs/promises';
 import path from 'node:path';
 
 const validateTokenMock = vi.hoisted(() => vi.fn());
@@ -126,6 +126,35 @@ describe('avatar upload routes', () => {
 
       // The stale .jpg from the first upload must be cleaned up.
       await expect(access(path.join(getAvatarsDir(), `${USER_ID}.jpg`))).rejects.toThrow();
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('concurrent cross-extension uploads leave exactly one avatar (never zero)', async () => {
+    validateTokenMock.mockResolvedValue({ userId: USER_ID });
+    const { baseUrl, server } = await startAvatarServer();
+    try {
+      // Unserialized, each request writes its own file and then deletes the
+      // other's fresh one — both 200 with zero files left on disk.
+      const [jpegResponse, pngResponse] = await Promise.all([
+        uploadAvatar(baseUrl, new Blob([JPEG_BYTES], { type: 'image/jpeg' }), 'avatar.jpg'),
+        uploadAvatar(baseUrl, new Blob([PNG_BYTES], { type: 'image/png' }), 'avatar.png'),
+      ]);
+      expect(jpegResponse.status).toBe(200);
+      expect(pngResponse.status).toBe(200);
+
+      const survivors = (await readdir(getAvatarsDir())).filter((fileName) => fileName.startsWith(USER_ID));
+      expect(survivors).toHaveLength(1);
+
+      // The surviving file must be one of the two that were just uploaded and
+      // must actually serve.
+      const survivorExt = path.extname(survivors[0]).slice(1);
+      expect(['jpg', 'png']).toContain(survivorExt);
+      const survivorBody = survivorExt === 'jpg' ? await jpegResponse.json() : await pngResponse.json();
+      const { avatarUrl } = survivorBody as { avatarUrl: string };
+      const staticResponse = await fetch(`${baseUrl}${avatarUrl}`);
+      expect(staticResponse.status).toBe(200);
     } finally {
       await closeServer(server);
     }

--- a/packages/backend/src/__tests__/avatar-upload.test.ts
+++ b/packages/backend/src/__tests__/avatar-upload.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { once } from 'node:events';
-import { rm } from 'node:fs/promises';
+import { access, mkdir, rm } from 'node:fs/promises';
 import path from 'node:path';
 
 const validateTokenMock = vi.hoisted(() => vi.fn());
@@ -17,6 +17,7 @@ const { parseSizeParam } = await import('../lib/image-resize');
 
 const USER_ID = '11111111-1111-4111-8111-111111111111';
 const JPEG_BYTES = Buffer.from([0xff, 0xd8, 0xff, 0xdb, 0x00, 0x43, 0xff, 0xd9]);
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
 async function startAvatarServer(): Promise<{ baseUrl: string; server: Server }> {
   const server = createServer((req, res) => {
@@ -54,7 +55,20 @@ function closeServer(server: Server): Promise<void> {
 }
 
 async function removeUploadedAvatar(): Promise<void> {
-  await rm(path.join(getAvatarsDir(), `${USER_ID}.jpg`), { force: true });
+  for (const ext of ['jpg', 'png', 'gif', 'webp']) {
+    await rm(path.join(getAvatarsDir(), `${USER_ID}.${ext}`), { force: true, recursive: true });
+  }
+}
+
+async function uploadAvatar(baseUrl: string, blob: Blob, fileName: string): Promise<Response> {
+  const formData = new FormData();
+  formData.set('userId', USER_ID);
+  formData.set('avatar', blob, fileName);
+  return fetch(`${baseUrl}/api/avatars`, {
+    method: 'POST',
+    headers: { Authorization: 'Bearer avatar-token' },
+    body: formData,
+  });
 }
 
 afterEach(async () => {
@@ -88,6 +102,52 @@ describe('avatar upload routes', () => {
 
       expect(staticResponse.status).toBe(200);
       expect(staticResponse.headers.get('content-type')).toBe('image/jpeg');
+      expect(Buffer.from(await staticResponse.arrayBuffer())).toEqual(JPEG_BYTES);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('re-uploading at a different extension removes the stale file and serves the new one', async () => {
+    validateTokenMock.mockResolvedValue({ userId: USER_ID });
+    const { baseUrl, server } = await startAvatarServer();
+    try {
+      const jpegResponse = await uploadAvatar(baseUrl, new Blob([JPEG_BYTES], { type: 'image/jpeg' }), 'avatar.jpg');
+      expect(jpegResponse.status).toBe(200);
+
+      const pngResponse = await uploadAvatar(baseUrl, new Blob([PNG_BYTES], { type: 'image/png' }), 'avatar.png');
+      expect(pngResponse.status).toBe(200);
+      const pngBody = (await pngResponse.json()) as { avatarUrl?: string };
+      expect(pngBody.avatarUrl).toMatch(/\.png\?v=/);
+
+      const staticResponse = await fetch(`${baseUrl}${pngBody.avatarUrl}`);
+      expect(staticResponse.status).toBe(200);
+      expect(Buffer.from(await staticResponse.arrayBuffer())).toEqual(PNG_BYTES);
+
+      // The stale .jpg from the first upload must be cleaned up.
+      await expect(access(path.join(getAvatarsDir(), `${USER_ID}.jpg`))).rejects.toThrow();
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('a failed replacement upload preserves the existing avatar (write-first, clean-after)', async () => {
+    validateTokenMock.mockResolvedValue({ userId: USER_ID });
+    const { baseUrl, server } = await startAvatarServer();
+    try {
+      const jpegResponse = await uploadAvatar(baseUrl, new Blob([JPEG_BYTES], { type: 'image/jpeg' }), 'avatar.jpg');
+      expect(jpegResponse.status).toBe(200);
+      const jpegBody = (await jpegResponse.json()) as { avatarUrl?: string };
+
+      // Force the .png write to fail by occupying its path with a directory.
+      await mkdir(path.join(getAvatarsDir(), `${USER_ID}.png`));
+
+      const pngResponse = await uploadAvatar(baseUrl, new Blob([PNG_BYTES], { type: 'image/png' }), 'avatar.png');
+      expect(pngResponse.status).toBe(500);
+
+      // The previously uploaded avatar the stored avatarUrl points at must survive.
+      const staticResponse = await fetch(`${baseUrl}${jpegBody.avatarUrl}`);
+      expect(staticResponse.status).toBe(200);
       expect(Buffer.from(await staticResponse.arrayBuffer())).toEqual(JPEG_BYTES);
     } finally {
       await closeServer(server);

--- a/packages/backend/src/handlers/avatars.ts
+++ b/packages/backend/src/handlers/avatars.ts
@@ -27,6 +27,25 @@ function validateUserId(userId: string): boolean {
   return UUID_REGEX.test(userId);
 }
 
+// Serialize save-and-clean per user: two overlapping replacements at different
+// extensions would otherwise each write their own file and then delete the
+// other request's fresh one — both 200, both files gone. In-process only, which
+// covers the realistic double-fire from a single client; cross-instance races
+// would need a distributed lock and aren't worth it for avatars.
+const userUploadChains = new Map<string, Promise<unknown>>();
+
+function serializePerUser<T>(userId: string, task: () => Promise<T>): Promise<T> {
+  const previous = userUploadChains.get(userId) ?? Promise.resolve();
+  const run = previous.then(task, task);
+  const chainEntry: Promise<unknown> = run
+    .catch(() => {})
+    .finally(() => {
+      if (userUploadChains.get(userId) === chainEntry) userUploadChains.delete(userId);
+    });
+  userUploadChains.set(userId, chainEntry);
+  return run;
+}
+
 // Track if directory has been initialized
 let avatarsDirInitialized = false;
 
@@ -237,8 +256,14 @@ export async function handleAvatarUpload(req: IncomingMessage, res: ServerRespon
         return;
       }
 
+      // Capture the narrowed values so the serialized closure below keeps
+      // their non-null types.
+      const uploadBuffer = fileBuffer;
+      const uploadMimeType = mimeType;
+      const uploadUserId = userId;
+
       // Determine file extension
-      const ext = MIME_TO_EXT[mimeType] || 'jpg';
+      const ext = MIME_TO_EXT[uploadMimeType] || 'jpg';
       const avatarFileName = `${userId}.${ext}`;
       let avatarUrl: string;
 
@@ -246,21 +271,20 @@ export async function handleAvatarUpload(req: IncomingMessage, res: ServerRespon
         // Write-first, clean-after: the new avatar must be saved before any
         // stale file is deleted, so a failed upload can never destroy the
         // avatar the user's stored avatarUrl still points at.
-        if (useS3) {
-          const s3Key = `avatars/${avatarFileName}`;
-          await uploadToS3(fileBuffer, s3Key, mimeType);
-          // Return backend-relative URL instead of direct S3 URL
-          // This allows the backend to proxy the image, avoiding S3 public access requirements
-          avatarUrl = buildStaticAvatarUrl(avatarFileName, randomUUID());
-
-          await deleteUserAvatarsFromS3(userId, ext);
-        } else {
-          const filePath = path.join(AVATARS_DIR, avatarFileName);
-          await writeFile(filePath, fileBuffer);
-          avatarUrl = buildStaticAvatarUrl(avatarFileName, randomUUID());
-
-          await deleteExistingAvatars(userId, ext);
-        }
+        avatarUrl = await serializePerUser(uploadUserId, async () => {
+          if (useS3) {
+            const s3Key = `avatars/${avatarFileName}`;
+            await uploadToS3(uploadBuffer, s3Key, uploadMimeType);
+            await deleteUserAvatarsFromS3(uploadUserId, ext);
+          } else {
+            const filePath = path.join(AVATARS_DIR, avatarFileName);
+            await writeFile(filePath, uploadBuffer);
+            await deleteExistingAvatars(uploadUserId, ext);
+          }
+          // Backend-relative URL instead of a direct S3 URL, so the backend
+          // proxies the image and S3 public access isn't needed.
+          return buildStaticAvatarUrl(avatarFileName, randomUUID());
+        });
       } catch (saveErr) {
         logger.error('Failed to save avatar:', saveErr);
         res.writeHead(500, { 'Content-Type': 'application/json' });

--- a/packages/backend/src/handlers/avatars.ts
+++ b/packages/backend/src/handlers/avatars.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage, ServerResponse } from 'http';
 import Busboy from 'busboy';
 import path from 'path';
 import { randomUUID } from 'crypto';
-import { mkdir, writeFile, unlink, access } from 'fs/promises';
+import { mkdir, writeFile, unlink } from 'fs/promises';
 import { applyCorsHeaders } from './cors';
 import { validateToken } from '../middleware/auth';
 import { isS3Configured, uploadToS3, deleteUserAvatarsFromS3 } from '../storage/s3';
@@ -72,13 +72,9 @@ async function deleteExistingAvatars(userId: string, keepExt?: string): Promise<
   for (const ext of extensions) {
     const filePath = path.join(AVATARS_DIR, `${userId}.${ext}`);
     try {
-      await access(filePath);
-    } catch {
-      continue; // File doesn't exist — nothing to clean up
-    }
-    try {
       await unlink(filePath);
     } catch (deleteError) {
+      if ((deleteError as NodeJS.ErrnoException).code === 'ENOENT') continue; // Nothing to clean up
       // The new avatar is already saved; a leftover stale-ext file is
       // unreferenced, so log for observability and carry on.
       logger.warn(`Failed to delete stale avatar ${filePath}:`, deleteError);

--- a/packages/backend/src/handlers/avatars.ts
+++ b/packages/backend/src/handlers/avatars.ts
@@ -73,9 +73,15 @@ async function deleteExistingAvatars(userId: string, keepExt?: string): Promise<
     const filePath = path.join(AVATARS_DIR, `${userId}.${ext}`);
     try {
       await access(filePath);
-      await unlink(filePath);
     } catch {
-      // File doesn't exist, ignore
+      continue; // File doesn't exist — nothing to clean up
+    }
+    try {
+      await unlink(filePath);
+    } catch (deleteError) {
+      // The new avatar is already saved; a leftover stale-ext file is
+      // unreferenced, so log for observability and carry on.
+      logger.warn(`Failed to delete stale avatar ${filePath}:`, deleteError);
     }
   }
 }

--- a/packages/backend/src/handlers/avatars.ts
+++ b/packages/backend/src/handlers/avatars.ts
@@ -62,10 +62,13 @@ function extractAuthTokenFromHeader(req: IncomingMessage): string | null {
 }
 
 /**
- * Helper to delete existing avatars for a user (all extensions)
+ * Delete a user's stale avatar files from local storage. Called AFTER the new
+ * avatar is written, with `keepExt` set to the new file's extension, so a
+ * failed replacement never destroys the existing avatar (write-first,
+ * clean-after — same contract as deleteUserAvatarsFromS3).
  */
-async function deleteExistingAvatars(userId: string): Promise<void> {
-  const extensions = ['jpg', 'png', 'gif', 'webp'];
+async function deleteExistingAvatars(userId: string, keepExt?: string): Promise<void> {
+  const extensions = ['jpg', 'png', 'gif', 'webp'].filter((ext) => ext !== keepExt);
   for (const ext of extensions) {
     const filePath = path.join(AVATARS_DIR, `${userId}.${ext}`);
     try {
@@ -238,24 +241,23 @@ export async function handleAvatarUpload(req: IncomingMessage, res: ServerRespon
       let avatarUrl: string;
 
       try {
+        // Write-first, clean-after: the new avatar must be saved before any
+        // stale file is deleted, so a failed upload can never destroy the
+        // avatar the user's stored avatarUrl still points at.
         if (useS3) {
-          // Delete existing avatars from S3
-          await deleteUserAvatarsFromS3(userId);
-
-          // Upload to S3
           const s3Key = `avatars/${avatarFileName}`;
           await uploadToS3(fileBuffer, s3Key, mimeType);
           // Return backend-relative URL instead of direct S3 URL
           // This allows the backend to proxy the image, avoiding S3 public access requirements
           avatarUrl = buildStaticAvatarUrl(avatarFileName, randomUUID());
-        } else {
-          // Delete any existing avatars for this user (all extensions) from local storage
-          await deleteExistingAvatars(userId);
 
-          // Save to local file system
+          await deleteUserAvatarsFromS3(userId, ext);
+        } else {
           const filePath = path.join(AVATARS_DIR, avatarFileName);
           await writeFile(filePath, fileBuffer);
           avatarUrl = buildStaticAvatarUrl(avatarFileName, randomUUID());
+
+          await deleteExistingAvatars(userId, ext);
         }
       } catch (saveErr) {
         logger.error('Failed to save avatar:', saveErr);

--- a/packages/backend/src/storage/__tests__/delete-user-avatars.test.ts
+++ b/packages/backend/src/storage/__tests__/delete-user-avatars.test.ts
@@ -46,6 +46,20 @@ describe('deleteUserAvatarsFromS3', () => {
     expect(deletedKeys.sort()).toEqual([`avatars/${USER_ID}.gif`, `avatars/${USER_ID}.png`, `avatars/${USER_ID}.webp`]);
   });
 
+  it('deletes every extension when no keepExt is given', async () => {
+    sendMock.mockResolvedValue({});
+
+    await deleteUserAvatarsFromS3(USER_ID);
+
+    const deletedKeys = sendMock.mock.calls.map((call) => (call[0] as { input: { Key: string } }).input.Key);
+    expect(deletedKeys.sort()).toEqual([
+      `avatars/${USER_ID}.gif`,
+      `avatars/${USER_ID}.jpg`,
+      `avatars/${USER_ID}.png`,
+      `avatars/${USER_ID}.webp`,
+    ]);
+  });
+
   it('logs a warning and resolves when a delete fails (new avatar is already saved)', async () => {
     sendMock.mockRejectedValue(new Error('S3 unavailable'));
 

--- a/packages/backend/src/storage/__tests__/delete-user-avatars.test.ts
+++ b/packages/backend/src/storage/__tests__/delete-user-avatars.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+const sendMock = vi.hoisted(() => vi.fn());
+const loggerWarnMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@aws-sdk/client-s3', () => ({
+  S3Client: class {
+    send = sendMock;
+  },
+  PutObjectCommand: class {},
+  DeleteObjectCommand: class {
+    constructor(public input: { Bucket: string; Key: string }) {}
+  },
+  GetObjectCommand: class {},
+  HeadObjectCommand: class {},
+  ListObjectsV2Command: class {},
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { warn: loggerWarnMock, error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+const { deleteUserAvatarsFromS3 } = await import('../s3');
+
+const USER_ID = '33333333-3333-4333-8333-333333333333';
+
+beforeEach(() => {
+  vi.stubEnv('AWS_S3_BUCKET_NAME', 'test-bucket');
+  vi.stubEnv('AWS_ACCESS_KEY_ID', 'test-key');
+  vi.stubEnv('AWS_SECRET_ACCESS_KEY', 'test-secret');
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe('deleteUserAvatarsFromS3', () => {
+  it('skips the extension of the freshly written avatar', async () => {
+    sendMock.mockResolvedValue({});
+
+    await deleteUserAvatarsFromS3(USER_ID, 'jpg');
+
+    const deleteCommands = sendMock.mock.calls.map((call) => call[0] as { input: { Key: string } });
+    const deletedKeys = deleteCommands.map((command) => command.input.Key);
+    expect(deletedKeys.sort()).toEqual([`avatars/${USER_ID}.gif`, `avatars/${USER_ID}.png`, `avatars/${USER_ID}.webp`]);
+  });
+
+  it('logs a warning and resolves when a delete fails (new avatar is already saved)', async () => {
+    sendMock.mockRejectedValue(new Error('S3 unavailable'));
+
+    await expect(deleteUserAvatarsFromS3(USER_ID, 'jpg')).resolves.toBeUndefined();
+
+    expect(loggerWarnMock).toHaveBeenCalledTimes(3);
+    expect(loggerWarnMock).toHaveBeenCalledWith(expect.stringContaining(`avatars/${USER_ID}.png`), expect.any(Error));
+  });
+});

--- a/packages/backend/src/storage/s3.ts
+++ b/packages/backend/src/storage/s3.ts
@@ -274,17 +274,26 @@ export async function listS3Objects(prefix: string): Promise<S3ObjectSummary[]> 
 }
 
 /**
- * Delete all avatar files for a user (all extensions)
+ * Delete a user's avatar files (the key is `avatars/<userId>.<ext>`). Called
+ * AFTER a new avatar is written, with `keepExt` set to the new file's
+ * extension, so a re-upload at a different extension can't leave a stale file
+ * behind — and a failed replacement never destroys the existing avatar
+ * (write-first, clean-after; same contract as deleteGymLogosFromS3).
+ *
+ * S3 DeleteObject is idempotent (deleting a missing key succeeds), so any error
+ * here is a real failure (network/auth), not "already gone" — it's logged and
+ * swallowed: the new avatar is already saved, and a leftover stale-ext object
+ * is unreferenced (the stored avatarUrl points at the new key).
  */
-export async function deleteUserAvatarsFromS3(userId: string): Promise<void> {
-  const extensions = ['jpg', 'png', 'gif', 'webp'];
+export async function deleteUserAvatarsFromS3(userId: string, keepExt?: string): Promise<void> {
+  const extensions = ['jpg', 'png', 'gif', 'webp'].filter((ext) => ext !== keepExt);
 
   await Promise.all(
     extensions.map(async (ext) => {
       try {
         await deleteFromS3(`avatars/${userId}.${ext}`);
-      } catch {
-        // File doesn't exist, ignore
+      } catch (deleteError) {
+        logger.warn(`Failed to delete stale avatar avatars/${userId}.${ext} from S3:`, deleteError);
       }
     }),
   );

--- a/packages/mobile/src/components/Avatar.tsx
+++ b/packages/mobile/src/components/Avatar.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { View, Image, StyleSheet, PixelRatio } from 'react-native';
 import { snapToAllowedImageSize } from '@boardsesh/shared-schema';
 import { Text } from './Text';
@@ -32,7 +33,13 @@ export function Avatar({ uri, name, size = 40, accessibilityLabel: accessibility
 
   const accessibilityLabel = accessibilityLabelProp ?? name ?? undefined;
 
-  if (uri) {
+  // Fall back to initials when the image fails to load (404/unreachable host —
+  // e.g. a stored avatarUrl whose backing file is gone). Tracking the failed
+  // uri (rather than a boolean) auto-retries when a re-upload produces a new
+  // `?v=`-versioned URL.
+  const [failedUri, setFailedUri] = useState<string | null>(null);
+
+  if (uri && uri !== failedUri) {
     return (
       // Uses react-native's core <Image> (not expo-image), so there's no
       // allowDownscaling prop — but none is needed: RCTImageLoader decodes
@@ -42,6 +49,7 @@ export function Avatar({ uri, name, size = 40, accessibilityLabel: accessibility
       <Image
         source={{ uri: sizedAvatarUri(uri, size) }}
         accessibilityLabel={accessibilityLabel}
+        onError={() => setFailedUri(uri)}
         style={[styles.image, { width: size, height: size, borderRadius }]}
       />
     );

--- a/packages/mobile/src/components/__tests__/avatar-fallback.test.tsx
+++ b/packages/mobile/src/components/__tests__/avatar-fallback.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+vi.mock('react-native', () => ({
+  Image: ({
+    source,
+    onError,
+    accessibilityLabel,
+  }: {
+    source: { uri: string };
+    onError?: () => void;
+    accessibilityLabel?: string;
+  }) => createElement('img', { src: source.uri, onError, 'aria-label': accessibilityLabel }),
+  PixelRatio: { get: () => 3 },
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+  StyleSheet: { create: (styles: unknown) => styles },
+  View: ({ children, accessibilityLabel }: { children?: ReactNode; accessibilityLabel?: string }) =>
+    createElement('div', { 'data-fallback': true, 'aria-label': accessibilityLabel }, children),
+}));
+
+vi.mock('../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', { 'data-initials': true }, children),
+}));
+
+import { Avatar } from '../Avatar';
+
+const AVATAR_URI = 'https://ws.example.com/static/avatars/user-1.jpg?v=upload-1';
+
+describe('Avatar image-error fallback', () => {
+  it('renders the image while it loads fine', () => {
+    const { container } = render(<Avatar uri={AVATAR_URI} name="Alex Honnold" />);
+    expect(container.querySelector('img')).not.toBeNull();
+    expect(container.querySelector('[data-initials]')).toBeNull();
+  });
+
+  it('falls back to initials when the image fails to load', () => {
+    const { container } = render(<Avatar uri={AVATAR_URI} name="Alex Honnold" />);
+    fireEvent.error(container.querySelector('img') as HTMLImageElement);
+
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('[data-initials]')?.textContent).toBe('AH');
+  });
+
+  it('retries the image when a re-upload produces a new versioned uri', () => {
+    const { container, rerender } = render(<Avatar uri={AVATAR_URI} name="Alex Honnold" />);
+    fireEvent.error(container.querySelector('img') as HTMLImageElement);
+    expect(container.querySelector('img')).toBeNull();
+
+    rerender(<Avatar uri="https://ws.example.com/static/avatars/user-1.jpg?v=upload-2" name="Alex Honnold" />);
+    expect(container.querySelector('img')).not.toBeNull();
+  });
+
+  it('renders initials directly when there is no uri', () => {
+    const { container } = render(<Avatar uri={null} name="Alex Honnold" />);
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('[data-initials]')?.textContent).toBe('AH');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #4193 — an Android user reported their profile picture never appears on the You page (in-app feedback #10197).

Two defects, both fixed:

1. **Avatar re-upload could permanently destroy the picture.** `POST /api/avatars` deleted the user's existing avatar (S3 object or local file) *before* writing the replacement. If the write failed — or succeeded but the follow-up `updateProfile` mutation never landed (the mobile edit screen warns and proceeds on upload failure) — the stored `avatar_url` pointed at a deleted object: a permanent 404. Both storage paths now write the new file first and clean up stale extensions after, mirroring the gym-logo handler's write-first, clean-after contract (`deleteUserAvatarsFromS3(userId, keepExt)`).
2. **A broken avatar URL rendered as a silent gray circle.** The mobile `Avatar` primitive had no `onError` handler, so a 404 showed only the placeholder background — never the initials fallback. It now latches the failed uri and falls back to initials; a re-upload mints a new `?v=`-versioned URL, which automatically retries the image. Every avatar surface (You tab toolbar, drawer, public profile, edit-profile preview, feed) goes through this one component.

Avatars already lost to the old race are unrecoverable (the object is gone) — affected users will see their initials and need to re-upload once this ships. JS + backend only, no native change, so it rides OTA.

## Release Notes

- Fixed a bug where a failed avatar upload could wipe your profile picture for good — your old picture now stays put until the new one is safely saved.
- If your profile picture ever can't load, you'll see your initials instead of a blank gray circle.

## Test plan

- `packages/backend/src/__tests__/avatar-upload.test.ts` — re-upload at a different extension cleans up the stale file; a failed replacement write preserves the existing avatar. Both new tests fail against the pre-fix handler (verified by stashing the fix).
- `packages/backend/src/__tests__/avatar-upload-s3.test.ts` — S3 path ordering: upload before delete, `keepExt` matches the new file, and no delete at all when the upload fails.
- `packages/mobile/src/components/__tests__/avatar-fallback.test.tsx` — image `onError` renders initials; a new versioned uri retries the image; no-uri renders initials directly.
- `vp run typecheck:backend` / `vp run typecheck:mobile` clean; full `vp run test:mobile` (585 files / 5083 tests) green; `vp run check:mobile-bundle` OK.
- Manual QA notes in `.boardsesh/qa-notes.md` (web settings upload/re-upload/oversized-file failure; mobile broken-URL fallback + re-upload recovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wnwg8g3J7x33QwwHNzNLBq
