### PR TITLE
fix(shared): restore German catalog parity in boards.json

### DIFF
--- a/packages/shared/i18n/locales/de/boards.json
+++ b/packages/shared/i18n/locales/de/boards.json
@@ -118,7 +118,6 @@
       "location": "Standort",
       "locationPlaceholder": "Zuhause, Hallenname oder Stadt",
       "useMyLocation": "Meinen Standort nutzen",
-      "locationSet": "Standort gesetzt",
       "serial": "Controller-Seriennummer",
       "serialPlaceholder": "z. B. ABC-12345",
       "serialHint": "Optional — dein Controller verknüpft sich beim ersten Verbinden selbst.",
@@ -129,7 +128,20 @@
       "timerHint": "Koppel einen Rogue-Hallentimer mit diesem Board. Solange du die Wand steuerst, startet jeder beleuchtete Boulder die Stoppuhr.",
       "timerPairCta": "Timer koppeln",
       "timerChangeCta": "Timer wechseln",
-      "timerRemoveCta": "Entfernen"
+      "timerRemoveCta": "Entfernen",
+      "gym": "Halle",
+      "gymNone": "In keiner Halle",
+      "clearLocation": "Standort entfernen",
+      "duplicate": {
+        "title": "Du hast dieses Setup schon",
+        "body": "Du hast schon „{{name}}“ mit demselben Layout, derselben Größe und denselben Hold-Sets.",
+        "bodyWithLocation": "Du hast schon „{{name}}“ in {{location}}, mit demselben Layout, derselben Größe und denselben Hold-Sets.",
+        "useExisting": "Dieses Board nutzen",
+        "addAnother": "Hier ein neues Board anlegen",
+        "addAnotherHint": "Wähl das, wenn es eine andere Wand ist — eine andere Halle, ein anderer Raum.",
+        "cancel": "Weiter bearbeiten",
+        "switchError": "Zu diesem Board ließ sich nicht wechseln. Versuch es nochmal."
+      }
     },
     "custom": {
       "board": "Board",
@@ -264,6 +276,12 @@
       "available": "Offline verfügbar",
       "pending": "Wartet auf Download",
       "bootstrapping": "Board wird geladen…",
+      "snapshotRetrying": "Schneller Download unterbrochen — neuer Versuch beim nächsten Sync",
+      "snapshotRetryingAria": "Der schnellere Offline-Download für {{name}} wurde unterbrochen. Beim nächsten Sync gibt es einen neuen Versuch.",
+      "pagedFallbackPending": "Schneller Download nicht verfügbar — langsamer Download wartet",
+      "pagedFallbackPendingAria": "Der schnellere Offline-Download für {{name}} ist nicht verfügbar. Der langsamere Download steht noch aus.",
+      "pagedFallbackActive": "Schneller Download nicht verfügbar — langsamer Download läuft",
+      "pagedFallbackActiveAria": "Der schnellere Offline-Download für {{name}} ist nicht verfügbar. Der langsamere Download läuft.",
       "downloadingCount_one": "{{count}} Boulder wird geladen",
       "downloadingCount_other": "{{count}} Boulder werden geladen",
       "makeAvailableAria": "{{name}} offline verfügbar machen",
@@ -276,6 +294,17 @@
       "pickerNoticeUnreachable": "Deine Boards sind gerade nicht erreichbar — hier sind die heruntergeladenen.",
       "pickerEmptyTitle": "Noch nichts heruntergeladen",
       "pickerEmptyBody": "Boards, die du offline verfügbar machst, tauchen hier auf. Hol dir eins, solange du Empfang hast."
+    },
+    "gymPicker": {
+      "title": "Wo steht dieses Board?",
+      "subtitle": "Wähl die Halle, in der es steht, damit Kletterer*innen es auf der Karte finden.",
+      "searchPlaceholder": "Hallen suchen",
+      "noGym": "In keiner Halle",
+      "noGymHint": "Es taucht trotzdem als eigener Pin auf der Karte auf.",
+      "addNew": "Meine Halle ist nicht dabei",
+      "empty": "Keine Hallen in der Nähe",
+      "sharedEditHint": "Das Team dieser Halle kann die Details dieses Boards dann bearbeiten.",
+      "linkError": "Diese Halle ließ sich nicht verknüpfen. Vielleicht ist sie zu weit von deinem Board entfernt. Deine anderen Änderungen wurden gespeichert."
     }
   },
   "boardEntity": {
@@ -324,12 +353,15 @@
       "submit": "Board anlegen",
       "authRequired": "Du musst angemeldet sein, um ein Board anzulegen",
       "errorMessage": "Board konnte nicht angelegt werden. Vielleicht gibt es für diese Konfiguration schon eins.",
-      "duplicateNamed": "Du hast mit diesem Setup schon ein Board namens „{{name}}“.",
       "goToExisting": "Zu deinem Board",
       "nameRequired": "Board-Name ist Pflicht",
       "createdNamed": "Board „{{name}}“ angelegt!",
       "namePlaceholder": "z. B. Home Board, Hallenname",
-      "locationPlaceholder": "z. B. Stadt, Hallenname"
+      "locationPlaceholder": "z. B. Stadt, Hallenname",
+      "duplicateTitle": "Du hast dieses Setup schon",
+      "duplicateBody": "Du hast schon „{{name}}“ mit demselben Layout, derselben Größe und denselben Hold-Sets. Leg nur dann noch eins an, wenn es eine andere Wand ist.",
+      "addAnyway": "Trotzdem anlegen",
+      "keepEditing": "Abbrechen"
     },
     "fields": {
       "name": "Board-Name",


### PR DESCRIPTION
## Summary

Today's gym-picker keys (direct push `c1e633cf7`) and the offline-download fallback keys (#4150) landed in en-US/es/fr `boards.json` only — both changes were written before the German locale (#4177) merged, so `de/boards.json` ended up 30 keys behind plus two stale keys the English catalog no longer has. The `catalog-completeness` parity test now fails on `main` for every branch that includes it, and German users would see English fall back in the gym picker, the duplicate-board prompts, and the offline download status lines.

This adds the 30 missing German strings and removes the two stale keys (`mobile.create.locationSet`, `boardForm.create.duplicateNamed`). Translations follow `docs/i18n-german-glossary.md`: Halle for gym, das Board (neuter), Hold-Sets, Kletterer*innen, du-form throughout.

## Release Notes

- Using Boardsesh in German? The gym picker, the duplicate-board prompt and the offline download status now speak German instead of falling back to English.

## Test plan

- `vp test run packages/shared/i18n` — all 90 catalog-completeness tests pass (the `de/boards.json` parity test fails on `main` today).
- Pre-commit `vp check --fix` passed on the staged catalog.
