### PR TITLE
fix: extend the multi-board-per-config rework to edits, tick attribution, and a board cap

### DIFF
--- a/packages/backend/src/__tests__/board-account-cap.test.ts
+++ b/packages/backend/src/__tests__/board-account-cap.test.ts
@@ -48,7 +48,7 @@ async function seedBoard(opts: {
   config?: { boardType: string; layoutId: number; sizeId: number; setIds: string };
   deleted?: boolean;
   name?: string;
-}): Promise<number> {
+}): Promise<{ id: number; uuid: string }> {
   const uuid = uuidv4();
   const config = opts.config ?? CONFIG;
   const result = await db.execute(sql`
@@ -58,7 +58,7 @@ async function seedBoard(opts: {
             ${config.setIds}, ${opts.name ?? 'Seeded board'}, true, ${opts.deleted ? sql`now()` : null}, now(), now())
     RETURNING id
   `);
-  return Number(Array.from(result as Iterable<{ id: number }>)[0].id);
+  return { id: Number(Array.from(result as Iterable<{ id: number }>)[0].id), uuid };
 }
 
 /** Seed `count` live boards for OWNER in one statement per board. */
@@ -187,7 +187,7 @@ describe('per-account board cap', () => {
     // at the cap — otherwise reaching the limit would lock a climber out of
     // their own boards.
     await seedBoards(MAX_BOARDS_PER_ACCOUNT - 1);
-    const existingBoardId = await seedBoard({ config: OTHER_CONFIG, name: 'The connected wall' });
+    const { id: existingBoardId } = await seedBoard({ config: OTHER_CONFIG, name: 'The connected wall' });
     resetAllRateLimits();
 
     const resolved = await boardPresenceMutations.resolveBoardForSerial(
@@ -197,6 +197,61 @@ describe('per-account board cap', () => {
     );
 
     expect(resolved.boardId).toBe(existingBoardId);
+    expect(await liveBoardCount()).toBe(MAX_BOARDS_PER_ACCOUNT);
+  });
+});
+
+describe('per-account board cap on the soft-delete restore path', () => {
+  const isDeleted = async (boardUuid: string): Promise<boolean> => {
+    const result = await db.execute(sql`SELECT deleted_at FROM user_boards WHERE uuid = ${boardUuid}`);
+    return Array.from(result as Iterable<{ deleted_at: Date | null }>)[0]?.deleted_at != null;
+  };
+
+  const restore = (boardUuid: string) =>
+    socialBoardMutations.updateBoard(null, { input: { boardUuid, name: 'Back in service' } }, authCtx(OWNER));
+
+  it('refuses to restore a deleted board when the account is already at the cap', async () => {
+    // Editing a soft-deleted board restores it, so a restore is +1 live board.
+    // Without the same toll a mint pays, delete-N/create-N/restore-N walks an
+    // account to cap+N — the cap counts live rows only.
+    await seedBoards(MAX_BOARDS_PER_ACCOUNT);
+    const { uuid: deletedBoardUuid } = await seedBoard({ deleted: true, name: 'Retired wall' });
+    resetAllRateLimits();
+
+    const extensions = await captureLimitReached(restore(deletedBoardUuid));
+
+    expect(extensions).not.toBeNull();
+    expect(extensions?.maxBoards).toBe(MAX_BOARDS_PER_ACCOUNT);
+    expect(await isDeleted(deletedBoardUuid)).toBe(true);
+    expect(await liveBoardCount()).toBe(MAX_BOARDS_PER_ACCOUNT);
+  });
+
+  it('restores the deleted board when the account has room', async () => {
+    await seedBoards(MAX_BOARDS_PER_ACCOUNT - 1);
+    const { uuid: deletedBoardUuid } = await seedBoard({ deleted: true, name: 'Retired wall' });
+    resetAllRateLimits();
+
+    const restored = await restore(deletedBoardUuid);
+
+    expect(restored.name).toBe('Back in service');
+    expect(await isDeleted(deletedBoardUuid)).toBe(false);
+    expect(await liveBoardCount()).toBe(MAX_BOARDS_PER_ACCOUNT);
+  });
+
+  it('lets the owner keep editing a LIVE board at the cap', async () => {
+    // A live board's edit adds no row, so it must never pay the toll —
+    // otherwise reaching the cap would freeze every board on the account.
+    await seedBoards(MAX_BOARDS_PER_ACCOUNT - 1);
+    const { uuid: liveBoardUuid } = await seedBoard({ name: 'Working wall' });
+    resetAllRateLimits();
+
+    const updated = await socialBoardMutations.updateBoard(
+      null,
+      { input: { boardUuid: liveBoardUuid, name: 'Working wall (left)' } },
+      authCtx(OWNER),
+    );
+
+    expect(updated.name).toBe('Working wall (left)');
     expect(await liveBoardCount()).toBe(MAX_BOARDS_PER_ACCOUNT);
   });
 });

--- a/packages/backend/src/__tests__/board-account-cap.test.ts
+++ b/packages/backend/src/__tests__/board-account-cap.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeEach } from 'vite-plus/test';
+import { v4 as uuidv4 } from 'uuid';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { socialBoardMutations } from '../graphql/resolvers/social/boards';
+import { boardPresenceMutations } from '../graphql/resolvers/board-presence/mutations';
+import { MAX_BOARDS_PER_ACCOUNT } from '../graphql/resolvers/social/board-limits';
+import { resetAllRateLimits } from '../utils/rate-limiter';
+
+/**
+ * Real-DB coverage for the per-account board cap.
+ *
+ * Until #4174 the `user_boards_unique_owner_config` index was an accidental
+ * ceiling on boards per account: the hardware catalog is finite and an owner
+ * could only have one board per configuration. Dropping it was right, but it
+ * left nothing bounding mint volume, and `allowDuplicateConfig` is a flag a
+ * client can set on every call.
+ *
+ * The cap is seeded through direct SQL rather than N resolver calls, both
+ * because createBoard's rate limiter allows only 10 per bucket and because 50
+ * round trips would dominate the suite's runtime.
+ */
+
+const OWNER = 'board-cap-owner';
+const OTHER = 'board-cap-other';
+const ALL_USERS = [OWNER, OTHER];
+
+// Real MoonBoard hardware, so `assertKnownBoardConfig` accepts it without any
+// Aurora catalog fixtures.
+const CONFIG = { boardType: 'moonboard', layoutId: 3, sizeId: 1, setIds: '5,6,7,8,9,10' };
+// A second real configuration, for the board the BLE bind path should find.
+const OTHER_CONFIG = { boardType: 'moonboard', layoutId: 2, sizeId: 1, setIds: '2,3' };
+
+let connectionCounter = 0;
+const authCtx = (userId: string): ConnectionContext =>
+  ({ connectionId: `conn-${userId}-${connectionCounter++}`, isAuthenticated: true, userId }) as ConnectionContext;
+
+const insertUser = (id: string) =>
+  db.execute(sql`
+    INSERT INTO "users" (id, email, name, created_at, updated_at)
+    VALUES (${id}, ${id + '@test.com'}, ${'User ' + id}, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `);
+
+async function seedBoard(opts: {
+  ownerId?: string;
+  config?: { boardType: string; layoutId: number; sizeId: number; setIds: string };
+  deleted?: boolean;
+  name?: string;
+}): Promise<number> {
+  const uuid = uuidv4();
+  const config = opts.config ?? CONFIG;
+  const result = await db.execute(sql`
+    INSERT INTO user_boards
+      (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, is_public, deleted_at, created_at, updated_at)
+    VALUES (${uuid}, ${uuid}, ${opts.ownerId ?? OWNER}, ${config.boardType}, ${config.layoutId}, ${config.sizeId},
+            ${config.setIds}, ${opts.name ?? 'Seeded board'}, true, ${opts.deleted ? sql`now()` : null}, now(), now())
+    RETURNING id
+  `);
+  return Number(Array.from(result as Iterable<{ id: number }>)[0].id);
+}
+
+/** Seed `count` live boards for OWNER in one statement per board. */
+async function seedBoards(count: number, opts: { deleted?: boolean } = {}): Promise<void> {
+  for (let index = 0; index < count; index++) {
+    await seedBoard({ name: `Seeded board ${index}`, deleted: opts.deleted });
+  }
+}
+
+const liveBoardCount = async (ownerId = OWNER): Promise<number> => {
+  const result = await db.execute(sql`
+    SELECT count(*)::int AS count FROM user_boards WHERE owner_id = ${ownerId} AND deleted_at IS NULL
+  `);
+  return Number(Array.from(result as Iterable<{ count: number }>)[0].count);
+};
+
+const createBoard = (input: Record<string, unknown> = {}, userId = OWNER) =>
+  socialBoardMutations.createBoard(
+    null,
+    { input: { ...CONFIG, name: 'One more board', ...input } },
+    authCtx(userId),
+  ) as Promise<{ uuid: string }>;
+
+/** The thrown error's extensions, or null when the call succeeded. Rethrows anything else. */
+async function captureLimitReached(promise: Promise<unknown>): Promise<Record<string, unknown> | null> {
+  try {
+    await promise;
+    return null;
+  } catch (error) {
+    const extensions = (error as { extensions?: Record<string, unknown> }).extensions;
+    if (extensions?.code !== 'BOARD_LIMIT_REACHED') throw error;
+    return extensions;
+  }
+}
+
+beforeEach(async () => {
+  await db.execute(sql`
+    TRUNCATE TABLE
+      "community_roles", "gym_members", "gym_follows", "location_sync_gym_sources", "user_boards", "gyms"
+    RESTART IDENTITY CASCADE
+  `);
+  await Promise.all(ALL_USERS.map(insertUser));
+  // Seeding the cap costs more calls than the createBoard bucket allows, so the
+  // limiter is cleared right before the assertion that matters.
+  resetAllRateLimits();
+});
+
+describe('per-account board cap', () => {
+  it('refuses another board once the account is at the cap, and adds no row', async () => {
+    await seedBoards(MAX_BOARDS_PER_ACCOUNT);
+    resetAllRateLimits();
+
+    const extensions = await captureLimitReached(createBoard());
+
+    expect(extensions).not.toBeNull();
+    expect(extensions?.maxBoards).toBe(MAX_BOARDS_PER_ACCOUNT);
+    expect(await liveBoardCount()).toBe(MAX_BOARDS_PER_ACCOUNT);
+  });
+
+  it('still creates the board that takes the account TO the cap', async () => {
+    // The pair to the test above: a cap that refuses one board early is a bug
+    // for every user who legitimately reaches it.
+    await seedBoards(MAX_BOARDS_PER_ACCOUNT - 1);
+    resetAllRateLimits();
+
+    const created = await createBoard({ allowDuplicateConfig: true });
+
+    expect(created.uuid).toBeTruthy();
+    expect(await liveBoardCount()).toBe(MAX_BOARDS_PER_ACCOUNT);
+  });
+
+  it('is not bypassed by allowDuplicateConfig', async () => {
+    // That flag skips the duplicate guard, which is the one path that can add
+    // unlimited same-config boards — so the cap has to sit in front of it.
+    await seedBoards(MAX_BOARDS_PER_ACCOUNT);
+    resetAllRateLimits();
+
+    const extensions = await captureLimitReached(createBoard({ allowDuplicateConfig: true }));
+
+    expect(extensions).not.toBeNull();
+    expect(await liveBoardCount()).toBe(MAX_BOARDS_PER_ACCOUNT);
+  });
+
+  it('does not count boards the user deleted', async () => {
+    // Deleting a board you no longer use is the remedy the error message names,
+    // so it has to actually free a slot.
+    await seedBoards(MAX_BOARDS_PER_ACCOUNT - 1);
+    await seedBoards(5, { deleted: true });
+    resetAllRateLimits();
+
+    const created = await createBoard({ allowDuplicateConfig: true });
+
+    expect(created.uuid).toBeTruthy();
+  });
+
+  it('does not count another account’s boards', async () => {
+    await seedBoards(MAX_BOARDS_PER_ACCOUNT);
+    resetAllRateLimits();
+
+    const created = await createBoard({}, OTHER);
+
+    expect(created.uuid).toBeTruthy();
+  });
+
+  it('refuses to mint a board for an unknown BLE serial at the cap', async () => {
+    // The serial path creates boards too, so it gets the same backstop. The
+    // seeded boards are all on CONFIG, so a serial reporting OTHER_CONFIG has
+    // nothing to bind to and takes the create branch.
+    await seedBoards(MAX_BOARDS_PER_ACCOUNT);
+    resetAllRateLimits();
+
+    const extensions = await captureLimitReached(
+      boardPresenceMutations.resolveBoardForSerial(
+        undefined,
+        { serial: 'CAP-NEW-SERIAL', ...OTHER_CONFIG },
+        authCtx(OWNER),
+      ),
+    );
+
+    expect(extensions).not.toBeNull();
+    expect(await liveBoardCount()).toBe(MAX_BOARDS_PER_ACCOUNT);
+  });
+
+  it('still binds a BLE serial onto a board the account already owns at the cap', async () => {
+    // Connecting to a wall you already have adds no row, so it must keep working
+    // at the cap — otherwise reaching the limit would lock a climber out of
+    // their own boards.
+    await seedBoards(MAX_BOARDS_PER_ACCOUNT - 1);
+    const existingBoardId = await seedBoard({ config: OTHER_CONFIG, name: 'The connected wall' });
+    resetAllRateLimits();
+
+    const resolved = await boardPresenceMutations.resolveBoardForSerial(
+      undefined,
+      { serial: 'CAP-BIND-SERIAL', ...OTHER_CONFIG },
+      authCtx(OWNER),
+    );
+
+    expect(resolved.boardId).toBe(existingBoardId);
+    expect(await liveBoardCount()).toBe(MAX_BOARDS_PER_ACCOUNT);
+  });
+});

--- a/packages/backend/src/__tests__/board-gym-edit-authorization.test.ts
+++ b/packages/backend/src/__tests__/board-gym-edit-authorization.test.ts
@@ -69,6 +69,7 @@ const insertBoard = async (opts: {
   boardType?: string;
   name?: string;
   isPublic?: boolean;
+  locationName?: string | null;
 }): Promise<number> => {
   const {
     uuid,
@@ -80,11 +81,12 @@ const insertBoard = async (opts: {
     boardType = 'kilter',
     name = 'Board',
     isPublic = true,
+    locationName = null,
   } = opts;
   const result = await db.execute(sql`
     INSERT INTO user_boards
-      (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, gym_id, is_public, created_at, updated_at)
-    VALUES (${uuid}, ${uuid}, ${ownerId}, ${boardType}, ${layoutId}, ${sizeId}, ${setIds}, ${name}, ${gymId}, ${isPublic}, now(), now())
+      (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, gym_id, is_public, location_name, created_at, updated_at)
+    VALUES (${uuid}, ${uuid}, ${ownerId}, ${boardType}, ${layoutId}, ${sizeId}, ${setIds}, ${name}, ${gymId}, ${isPublic}, ${locationName}, now(), now())
     RETURNING id
   `);
   return Number(Array.from(result as Iterable<{ id: number }>)[0].id);
@@ -304,8 +306,12 @@ describe('updateBoard config change with existing ticks', () => {
 });
 
 describe('updateBoard duplicate-config uniqueness keys off the board owner', () => {
-  it('blocks a config change that collides with another board owned by the BOARD OWNER', async () => {
-    // The board's owner (SYS_OWNER) already has a second board with this config.
+  // A named place on the sibling, so the leak the masking closes is visible in
+  // the assertions: a location the non-owner editor must not be handed.
+  const OWNER_SIBLING_LOCATION = "Owner's garage";
+
+  /** Seeds a second SYS_OWNER board on the config the edits below move onto. */
+  const seedOwnerSibling = async (): Promise<string> => {
     const ownerSecondBoardUuid = uuidv4();
     await insertBoard({
       uuid: ownerSecondBoardUuid,
@@ -314,26 +320,67 @@ describe('updateBoard duplicate-config uniqueness keys off the board owner', () 
       sizeId: 11,
       setIds: '3,4',
       name: 'Owner second board',
+      locationName: OWNER_SIBLING_LOCATION,
     });
+    return ownerSecondBoardUuid;
+  };
 
-    // Neither fixture board says where it is, and two placeless boards count as
-    // the same place — so the config change still collides. What the
-    // config-tuple rework changed is the SHAPE of the refusal: a typed
-    // BOARD_DUPLICATE_CONFIG naming the colliding board, which the client turns
-    // into a "save anyway?" prompt instead of a dead end.
-    const thrown = await socialBoardMutations
+  /** The edit that moves kilterBoard onto the sibling's config AND its place. */
+  const captureUpdateError = (userId: string) =>
+    socialBoardMutations
       .updateBoard(
         null,
-        { input: { boardUuid: kilterBoardUuid, layoutId: 2, sizeId: 11, setIds: '3,4' } },
-        authCtx(GLOBAL_ADMIN),
+        {
+          input: {
+            boardUuid: kilterBoardUuid,
+            layoutId: 2,
+            sizeId: 11,
+            setIds: '3,4',
+            locationName: OWNER_SIBLING_LOCATION,
+          },
+        },
+        authCtx(userId),
       )
       .then(
         () => null,
         (error: unknown) => error as { extensions?: Record<string, unknown> },
       );
 
+  it('blocks a config change that collides with another board owned by the BOARD OWNER', async () => {
+    // The board's owner (SYS_OWNER) already has a second board with this config.
+    const ownerSecondBoardUuid = await seedOwnerSibling();
+
+    // The edit moves the board onto both the sibling's config and its place, so
+    // it collides. What the config-tuple rework changed is the SHAPE of the
+    // refusal: a typed BOARD_DUPLICATE_CONFIG naming the colliding board, which
+    // the client turns into a "save anyway?" prompt instead of a dead end.
+    const thrown = await captureUpdateError(SYS_OWNER);
+
     expect(thrown?.extensions?.code).toBe('BOARD_DUPLICATE_CONFIG');
     expect(thrown?.extensions?.existingBoardUuid).toBe(ownerSecondBoardUuid);
+    expect(thrown?.extensions?.existingBoardName).toBe('Owner second board');
+    expect(thrown?.extensions?.existingBoardLocationName).toBe(OWNER_SIBLING_LOCATION);
+  });
+
+  it('tells a NON-OWNER editor only that the config is taken, never which board', async () => {
+    // The probe searches the OWNER's boards, but updateBoard is reachable by gym
+    // admins and community moderators. Handing them the colliding board's name,
+    // slug and location would disclose a board they may have no read access to —
+    // a private home wall, or one whose location `hideLocation` masks. Same leak
+    // class as the private-gym probe finding in the #4174 round.
+    await seedOwnerSibling();
+
+    const thrown = await captureUpdateError(GLOBAL_ADMIN);
+
+    expect(thrown?.extensions?.code).toBe('BOARD_DUPLICATE_CONFIG');
+    expect(thrown?.extensions?.existingBoardUuid).toBeUndefined();
+    expect(thrown?.extensions?.existingBoardSlug).toBeUndefined();
+    expect(thrown?.extensions?.existingBoardName).toBeUndefined();
+    expect(thrown?.extensions?.existingBoardLocationName).toBeUndefined();
+    expect(thrown?.extensions?.existingBoardAngle).toBeUndefined();
+
+    // The edit is still refused — masking the identity must not weaken the guard.
+    expect(await boardConfig(kilterBoardUuid)).toMatchObject({ layoutId: 1, sizeId: 10, setIds: '1,2' });
   });
 
   it('does NOT block when only the editing admin owns a board with the target config', async () => {

--- a/packages/backend/src/__tests__/board-gym-edit-authorization.test.ts
+++ b/packages/backend/src/__tests__/board-gym-edit-authorization.test.ts
@@ -306,8 +306,9 @@ describe('updateBoard config change with existing ticks', () => {
 describe('updateBoard duplicate-config uniqueness keys off the board owner', () => {
   it('blocks a config change that collides with another board owned by the BOARD OWNER', async () => {
     // The board's owner (SYS_OWNER) already has a second board with this config.
+    const ownerSecondBoardUuid = uuidv4();
     await insertBoard({
-      uuid: uuidv4(),
+      uuid: ownerSecondBoardUuid,
       ownerId: SYS_OWNER,
       layoutId: 2,
       sizeId: 11,
@@ -315,13 +316,24 @@ describe('updateBoard duplicate-config uniqueness keys off the board owner', () 
       name: 'Owner second board',
     });
 
-    await expect(
-      socialBoardMutations.updateBoard(
+    // Neither fixture board says where it is, and two placeless boards count as
+    // the same place — so the config change still collides. What the
+    // config-tuple rework changed is the SHAPE of the refusal: a typed
+    // BOARD_DUPLICATE_CONFIG naming the colliding board, which the client turns
+    // into a "save anyway?" prompt instead of a dead end.
+    const thrown = await socialBoardMutations
+      .updateBoard(
         null,
         { input: { boardUuid: kilterBoardUuid, layoutId: 2, sizeId: 11, setIds: '3,4' } },
         authCtx(GLOBAL_ADMIN),
-      ),
-    ).rejects.toThrow(/already has a board with this configuration/);
+      )
+      .then(
+        () => null,
+        (error: unknown) => error as { extensions?: Record<string, unknown> },
+      );
+
+    expect(thrown?.extensions?.code).toBe('BOARD_DUPLICATE_CONFIG');
+    expect(thrown?.extensions?.existingBoardUuid).toBe(ownerSecondBoardUuid);
   });
 
   it('does NOT block when only the editing admin owns a board with the target config', async () => {

--- a/packages/backend/src/__tests__/legacy-tick-board-attribution.test.ts
+++ b/packages/backend/src/__tests__/legacy-tick-board-attribution.test.ts
@@ -33,9 +33,10 @@ import { tickMutations } from '../graphql/resolvers/ticks/mutations';
  * prefers the board the tick's session is being held on — the one signal that
  * actually knows which of the two walls the climber is standing at.
  *
- * The "insert the right board second" idiom is borrowed from
- * board-serial-config-preference.test.ts: an unordered limit(1) tends to return
- * the first row, so the expected board is inserted last.
+ * Where a case is about the ORDER of the pick, the boards carry explicit ids and
+ * the HIGHER id is inserted first, so an unordered scan returns the wrong board
+ * and the case fails on the old code. Seeding ascending — the obvious way to
+ * write it — passes either way and proves nothing.
  */
 
 const USER_ID = 'legacy-attr-user';
@@ -44,6 +45,12 @@ const PREFIX = 'LEGACY-ATTR-';
 const CLIMB_UUID = `${PREFIX}CLIMB`;
 
 const CONFIG = { boardType: 'kilter', layoutId: 8, sizeId: 25, setIds: '1,2' };
+
+// Explicit ids for the ordering case, well clear of the `user_boards_id_seq`
+// range so pinning them can't collide with a serial-assigned row (this suite
+// shares the worker DB and deletes only its own rows, never truncating).
+const LOWER_BOARD_ID = 900_000_100;
+const HIGHER_BOARD_ID = 900_000_200;
 
 function authCtx(userId = USER_ID): ConnectionContext {
   return {
@@ -78,12 +85,17 @@ async function insertBoard(opts: {
   setIds?: string;
   layoutId?: number;
   name: string;
+  id?: number;
 }): Promise<number> {
   const uuid = uuidv4();
+  // `id` is pinned only where the test is about the pick's ORDER; everywhere
+  // else the serial assigns it.
+  const idColumn = opts.id == null ? sql`` : sql`id, `;
+  const idValue = opts.id == null ? sql`` : sql`${opts.id}, `;
   const result = await db.execute(sql`
     INSERT INTO user_boards
-      (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, is_public, created_at, updated_at)
-    VALUES (${uuid}, ${uuid}, ${opts.ownerId ?? USER_ID}, ${CONFIG.boardType}, ${opts.layoutId ?? CONFIG.layoutId},
+      (${idColumn}uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, is_public, created_at, updated_at)
+    VALUES (${idValue}${uuid}, ${uuid}, ${opts.ownerId ?? USER_ID}, ${CONFIG.boardType}, ${opts.layoutId ?? CONFIG.layoutId},
             ${CONFIG.sizeId}, ${opts.setIds ?? CONFIG.setIds}, ${opts.name}, true, now(), now())
     RETURNING id
   `);
@@ -152,13 +164,16 @@ describe('legacy tick board attribution', () => {
   });
 
   it('picks the same board every time when the owner has two with this config', async () => {
-    const firstId = await insertBoard({ name: 'Home wall' });
-    await insertBoard({ name: 'Gym wall' });
+    // Seeded highest-id-FIRST: an unordered pick takes the row it happens to
+    // reach first, which is the gym wall, so this case only passes on a lookup
+    // that really orders by id.
+    await insertBoard({ id: HIGHER_BOARD_ID, name: 'Gym wall' });
+    await insertBoard({ id: LOWER_BOARD_ID, name: 'Home wall' });
 
     // Lowest id wins, and keeps winning — a climber's history for one wall must
     // not scatter across its twin between two logs of the same climb.
-    expect((await saveTick()).boardId).toBe(firstId);
-    expect((await saveTick()).boardId).toBe(firstId);
+    expect((await saveTick()).boardId).toBe(LOWER_BOARD_ID);
+    expect((await saveTick()).boardId).toBe(LOWER_BOARD_ID);
   });
 
   it("prefers the session's board over the config lookup's pick", async () => {

--- a/packages/backend/src/__tests__/legacy-tick-board-attribution.test.ts
+++ b/packages/backend/src/__tests__/legacy-tick-board-attribution.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vite-plus/test';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import { sql } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
@@ -129,6 +129,14 @@ async function saveTick(overrides: Record<string, unknown> = {}, userId = USER_I
 describe('legacy tick board attribution', () => {
   beforeAll(async () => {
     await setupWorkerDatabase();
+  });
+
+  // Re-seeded per test, not once in beforeAll: sibling suites TRUNCATE these
+  // same shared tables in their own beforeEach, and this file's tests can
+  // interleave with theirs within a worker's shared DB. Seeding in beforeAll
+  // left a window where a cross-file TRUNCATE could strand this suite mid-run
+  // with its users/climb gone and no test left to put them back.
+  beforeEach(async () => {
     for (const id of [USER_ID, OTHER_USER_ID]) {
       await db.execute(sql`
         INSERT INTO users (id, email, name, created_at, updated_at)

--- a/packages/backend/src/__tests__/legacy-tick-board-attribution.test.ts
+++ b/packages/backend/src/__tests__/legacy-tick-board-attribution.test.ts
@@ -1,0 +1,206 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import { v4 as uuidv4 } from 'uuid';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { setupWorkerDatabase } from './worker-db';
+
+// Side effects saveTick fires after the insert. None of them are under test and
+// they'd otherwise pull in Redis / the social event bus.
+vi.mock('../events', () => ({ publishSocialEvent: vi.fn(async () => undefined) }));
+vi.mock('../graphql/resolvers/ticks/debounced-climb-stats-publisher', () => ({
+  queueClimbStatsRecompute: vi.fn(),
+}));
+vi.mock('../graphql/resolvers/sessions/debounced-stats-publisher', () => ({
+  publishDebouncedSessionStats: vi.fn(),
+}));
+vi.mock('../graphql/resolvers/board-presence/stats', () => ({ queueBoardStatsPublish: vi.fn() }));
+vi.mock('../services/analytics/posthog', () => ({ captureBackendEvent: vi.fn(() => true) }));
+
+import { db } from '../db/client';
+import { tickMutations } from '../graphql/resolvers/ticks/mutations';
+
+/**
+ * Real-DB coverage for how a legacy `/[board_name]/[layout_id]/...` tick finds
+ * its board.
+ *
+ * #4174 let one owner hold several boards of the same configuration, which broke
+ * the config lookup two ways: it compared set ids as a raw string (so a board
+ * stored '2,1' never matched a tick sending '1,2' — the tick was recorded with
+ * no board at all), and it took `.limit(1)` with no ORDER BY, so a climber with
+ * two same-config walls had their ticks split arbitrarily between them.
+ *
+ * The lookup now normalises set ids and picks the lowest id, and saveTick
+ * prefers the board the tick's session is being held on — the one signal that
+ * actually knows which of the two walls the climber is standing at.
+ *
+ * The "insert the right board second" idiom is borrowed from
+ * board-serial-config-preference.test.ts: an unordered limit(1) tends to return
+ * the first row, so the expected board is inserted last.
+ */
+
+const USER_ID = 'legacy-attr-user';
+const OTHER_USER_ID = 'legacy-attr-other';
+const PREFIX = 'LEGACY-ATTR-';
+const CLIMB_UUID = `${PREFIX}CLIMB`;
+
+const CONFIG = { boardType: 'kilter', layoutId: 8, sizeId: 25, setIds: '1,2' };
+
+function authCtx(userId = USER_ID): ConnectionContext {
+  return {
+    connectionId: `conn-${Math.random().toString(36).slice(2)}`,
+    isAuthenticated: true,
+    userId,
+  } as ConnectionContext;
+}
+
+function tickInput(overrides: Record<string, unknown> = {}) {
+  return {
+    boardType: CONFIG.boardType,
+    climbUuid: CLIMB_UUID,
+    angle: 40,
+    isMirror: false,
+    status: 'send',
+    attemptCount: 1,
+    quality: null,
+    difficulty: 17,
+    isBenchmark: false,
+    comment: '',
+    climbedAt: new Date().toISOString(),
+    layoutId: CONFIG.layoutId,
+    sizeId: CONFIG.sizeId,
+    setIds: CONFIG.setIds,
+    ...overrides,
+  };
+}
+
+async function insertBoard(opts: {
+  ownerId?: string;
+  setIds?: string;
+  layoutId?: number;
+  name: string;
+}): Promise<number> {
+  const uuid = uuidv4();
+  const result = await db.execute(sql`
+    INSERT INTO user_boards
+      (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, is_public, created_at, updated_at)
+    VALUES (${uuid}, ${uuid}, ${opts.ownerId ?? USER_ID}, ${CONFIG.boardType}, ${opts.layoutId ?? CONFIG.layoutId},
+            ${CONFIG.sizeId}, ${opts.setIds ?? CONFIG.setIds}, ${opts.name}, true, now(), now())
+    RETURNING id
+  `);
+  return Number(Array.from(result as Iterable<{ id: number }>)[0].id);
+}
+
+async function insertSession(opts: { boardId: number | null }): Promise<string> {
+  const id = `sess-${uuidv4()}`;
+  await db.execute(sql`
+    INSERT INTO board_sessions (id, board_path, board_id, created_by_user_id, status, created_at, last_activity)
+    VALUES (${id}, ${'/kilter/8/25/1,2/40'}, ${opts.boardId}, ${USER_ID}, 'active', now(), now())
+  `);
+  return id;
+}
+
+/** The board_id and session_id the tick actually landed on. */
+async function tickAttribution(tickUuid: string): Promise<{ boardId: number | null; sessionId: string | null }> {
+  const result = await db.execute(sql`
+    SELECT board_id, session_id FROM boardsesh_ticks WHERE uuid = ${tickUuid}
+  `);
+  const row = Array.from(result as Iterable<{ board_id: number | null; session_id: string | null }>)[0];
+  return { boardId: row.board_id == null ? null : Number(row.board_id), sessionId: row.session_id };
+}
+
+async function saveTick(overrides: Record<string, unknown> = {}, userId = USER_ID) {
+  const uuid = uuidv4();
+  await tickMutations.saveTick(undefined, { input: { uuid, ...tickInput(overrides) } }, authCtx(userId));
+  return tickAttribution(uuid);
+}
+
+describe('legacy tick board attribution', () => {
+  beforeAll(async () => {
+    await setupWorkerDatabase();
+    for (const id of [USER_ID, OTHER_USER_ID]) {
+      await db.execute(sql`
+        INSERT INTO users (id, email, name, created_at, updated_at)
+        VALUES (${id}, ${`${id}@test.com`}, ${`User ${id}`}, now(), now())
+        ON CONFLICT (id) DO NOTHING
+      `);
+    }
+    await db.execute(sql`
+      INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, description, frames, is_listed)
+      VALUES (${CLIMB_UUID}, ${CONFIG.boardType}, ${CONFIG.layoutId}, 'setter', 'Test Climb', '', 'p1r1', true)
+      ON CONFLICT (uuid) DO NOTHING
+    `);
+  });
+
+  afterAll(async () => {
+    await db.execute(sql`DELETE FROM board_climbs WHERE uuid = ${CLIMB_UUID}`);
+    await db.execute(sql`DELETE FROM users WHERE id IN (${USER_ID}, ${OTHER_USER_ID})`);
+  });
+
+  afterEach(async () => {
+    await db.execute(sql`DELETE FROM boardsesh_ticks WHERE user_id = ${USER_ID}`);
+    await db.execute(sql`DELETE FROM board_sessions WHERE created_by_user_id = ${USER_ID}`);
+    await db.execute(sql`DELETE FROM user_boards WHERE owner_id IN (${USER_ID}, ${OTHER_USER_ID})`);
+  });
+
+  it('attributes a tick whose hold sets arrive in a different order than they were stored', async () => {
+    // Stored '2,1' vs a tick sending '1,2': the same wall, but the old raw-string
+    // SQL comparison called them different boards and recorded the tick with no
+    // board at all — invisible on the board's leaderboard, forever.
+    const boardId = await insertBoard({ setIds: '2,1', name: 'Home wall' });
+
+    expect((await saveTick({ setIds: '1,2' })).boardId).toBe(boardId);
+  });
+
+  it('picks the same board every time when the owner has two with this config', async () => {
+    const firstId = await insertBoard({ name: 'Home wall' });
+    await insertBoard({ name: 'Gym wall' });
+
+    // Lowest id wins, and keeps winning — a climber's history for one wall must
+    // not scatter across its twin between two logs of the same climb.
+    expect((await saveTick()).boardId).toBe(firstId);
+    expect((await saveTick()).boardId).toBe(firstId);
+  });
+
+  it("prefers the session's board over the config lookup's pick", async () => {
+    await insertBoard({ name: 'Home wall' });
+    const gymBoardId = await insertBoard({ name: 'Gym wall' });
+    const sessionId = await insertSession({ boardId: gymBoardId });
+
+    // The config lookup alone would have taken the lower-id home wall; the
+    // session says the climber is at the gym.
+    const attribution = await saveTick({ sessionId });
+    expect(attribution.boardId).toBe(gymBoardId);
+    expect(attribution.sessionId).toBe(sessionId);
+  });
+
+  it("attributes to a session board the climber doesn't own", async () => {
+    // Party mode: the session is held on someone else's wall, and that wall is
+    // still the physical board this send happened on.
+    const hostBoardId = await insertBoard({ ownerId: OTHER_USER_ID, name: "Host's wall" });
+    const sessionId = await insertSession({ boardId: hostBoardId });
+
+    expect((await saveTick({ sessionId })).boardId).toBe(hostBoardId);
+  });
+
+  it('ignores a session board whose configuration does not match the tick', async () => {
+    // A session left open on another wall must not stamp this tick onto it.
+    const otherConfigBoardId = await insertBoard({ layoutId: 1, name: 'Other layout' });
+    const matchingBoardId = await insertBoard({ name: 'Home wall' });
+    const sessionId = await insertSession({ boardId: otherConfigBoardId });
+
+    const attribution = await saveTick({ sessionId });
+    expect(attribution.boardId).toBe(matchingBoardId);
+    expect(attribution.boardId).not.toBe(otherConfigBoardId);
+  });
+
+  it('still attributes by config when the sessionId is stale', async () => {
+    // Offline replay of a tick whose session has since gone: the reference is
+    // dropped rather than FK-violating the insert (#2386), and the board lookup
+    // still runs.
+    const boardId = await insertBoard({ name: 'Home wall' });
+
+    const attribution = await saveTick({ sessionId: `sess-${uuidv4()}` });
+    expect(attribution.sessionId).toBeNull();
+    expect(attribution.boardId).toBe(boardId);
+  });
+});

--- a/packages/backend/src/__tests__/update-board-duplicate-guard.test.ts
+++ b/packages/backend/src/__tests__/update-board-duplicate-guard.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, beforeEach } from 'vite-plus/test';
+import { v4 as uuidv4 } from 'uuid';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { socialBoardMutations } from '../graphql/resolvers/social/boards';
+import { SYSTEM_BOARD_OWNER_ID } from '../graphql/resolvers/board-presence/shared';
+import { resetAllRateLimits } from '../utils/rate-limiter';
+
+/**
+ * Real-DB coverage for updateBoard's duplicate-config guard.
+ *
+ * updateBoard used to enforce the strict per-owner config uniqueness that #4174
+ * removed from createBoard and from the database: no place dimension, no
+ * override, raw-string set-id equality, and a plain Error the clients could only
+ * string-match. A gym reconfiguring one wall to match another of its own walls
+ * hard-failed, and the only workaround (delete + recreate) threw away the
+ * board's tick history.
+ *
+ * The rule here is now createBoard's: same config AND same place, overridable
+ * once the user confirms, and skipped outright when the config didn't actually
+ * move (the clients resend layout/size/setIds on every edit).
+ *
+ * Seeds through the resolver and via raw SQL, against the per-worker test DB —
+ * mirrors create-board-duplicate-guard.test.ts.
+ */
+
+const OWNER = 'update-dup-owner';
+const MODERATOR = 'update-dup-moderator';
+const ALL_USERS = [OWNER, MODERATOR, SYSTEM_BOARD_OWNER_ID];
+
+const BASE = { latitude: 47.0, longitude: 8.0 };
+const LAT_60M = 47.0 + 0.00054; // ~60 m — same building
+const LAT_2KM = 47.0 + 0.018; // ~2 km — a different gym
+
+// Two configurations of the same board type, both real MoonBoard hardware so
+// `assertKnownBoardConfig` accepts them. STARTING is what the board under test
+// begins on; TARGET is what the edit moves it to.
+const BOARD_TYPE = 'moonboard';
+const STARTING = { boardType: BOARD_TYPE, layoutId: 3, sizeId: 1, setIds: '5,6,7' };
+const TARGET = { boardType: BOARD_TYPE, layoutId: 3, sizeId: 1, setIds: '5,6,7,8,9,10' };
+
+let connectionCounter = 0;
+const authCtx = (userId: string): ConnectionContext =>
+  ({ connectionId: `conn-${userId}-${connectionCounter++}`, isAuthenticated: true, userId }) as ConnectionContext;
+
+const insertUser = (id: string) =>
+  db.execute(sql`
+    INSERT INTO "users" (id, email, name, created_at, updated_at)
+    VALUES (${id}, ${id + '@test.com'}, ${'User ' + id}, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `);
+
+type BoardRow = { uuid: string; name: string; layoutId: number; sizeId: number; setIds: string };
+
+const createBoard = (input: Record<string, unknown>, userId = OWNER) =>
+  socialBoardMutations.createBoard(
+    null,
+    { input: { ...STARTING, name: 'A board', ...input } },
+    authCtx(userId),
+  ) as Promise<BoardRow>;
+
+const updateBoard = (input: Record<string, unknown>, userId = OWNER) =>
+  socialBoardMutations.updateBoard(null, { input }, authCtx(userId)) as Promise<BoardRow>;
+
+/** The stored config of a board, so a refused edit can be shown not to have landed. */
+async function storedConfig(boardUuid: string): Promise<{ setIds: string; layoutId: number; name: string }> {
+  const result = await db.execute(sql`
+    SELECT set_ids, layout_id, name FROM user_boards WHERE uuid = ${boardUuid}
+  `);
+  const row = Array.from(result as Iterable<{ set_ids: string; layout_id: number; name: string }>)[0];
+  return { setIds: row.set_ids, layoutId: Number(row.layout_id), name: row.name };
+}
+
+/**
+ * The thrown GraphQLError's extensions, or null when the call succeeded.
+ * Anything that is NOT a duplicate rejection is rethrown — an unrelated failure
+ * must fail the test rather than read as "no duplicate".
+ */
+async function captureDuplicate(promise: Promise<unknown>): Promise<Record<string, unknown> | null> {
+  try {
+    await promise;
+    return null;
+  } catch (error) {
+    const extensions = (error as { extensions?: Record<string, unknown> }).extensions;
+    if (extensions?.code !== 'BOARD_DUPLICATE_CONFIG') throw error;
+    return extensions;
+  }
+}
+
+beforeEach(async () => {
+  resetAllRateLimits();
+  await db.execute(sql`
+    TRUNCATE TABLE
+      "community_roles", "gym_members", "gym_follows", "location_sync_gym_sources", "user_boards", "gyms"
+    RESTART IDENTITY CASCADE
+  `);
+  await Promise.all(ALL_USERS.map(insertUser));
+});
+
+describe('updateBoard duplicate-config guard', () => {
+  it('refuses a config change that lands on a sibling at the same place, naming it', async () => {
+    const sibling = await createBoard({
+      ...TARGET,
+      name: 'Klimmuur MoonBoard 2024',
+      locationName: 'Klimmuur',
+      ...BASE,
+    });
+    const edited = await createBoard({
+      name: 'Klimmuur MoonBoard (old sets)',
+      locationName: 'Klimmuur',
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+    });
+
+    const extensions = await captureDuplicate(updateBoard({ boardUuid: edited.uuid, setIds: TARGET.setIds }));
+
+    expect(extensions).not.toBeNull();
+    // The client offers "save anyway" straight off the error, so the colliding
+    // board's identity has to travel with it.
+    expect(extensions?.existingBoardUuid).toBe(sibling.uuid);
+    expect(extensions?.existingBoardName).toBe('Klimmuur MoonBoard 2024');
+    expect(extensions?.existingBoardLocationName).toBe('Klimmuur');
+    // Nothing landed.
+    expect(await storedConfig(edited.uuid)).toMatchObject({ setIds: STARTING.setIds });
+  });
+
+  it('allows the same config change when the sibling is ~2 km away', async () => {
+    await createBoard({ ...TARGET, name: 'Boulder Space MoonBoard', locationName: 'Boulder Space', ...BASE });
+    const edited = await createBoard({
+      name: 'Klimmuur MoonBoard',
+      locationName: 'Klimmuur',
+      latitude: LAT_2KM,
+      longitude: BASE.longitude,
+    });
+
+    const updated = await updateBoard({ boardUuid: edited.uuid, setIds: TARGET.setIds });
+
+    expect(updated.setIds).toBe(TARGET.setIds);
+  });
+
+  it('saves anyway when the user confirms the two walls are different', async () => {
+    await createBoard({ ...TARGET, name: 'Wall A', locationName: 'Klimmuur', ...BASE });
+    const edited = await createBoard({ name: 'Wall B', locationName: 'Klimmuur', ...BASE });
+
+    const updated = await updateBoard({
+      boardUuid: edited.uuid,
+      setIds: TARGET.setIds,
+      allowDuplicateConfig: true,
+    });
+
+    expect(updated.setIds).toBe(TARGET.setIds);
+    expect(await storedConfig(edited.uuid)).toMatchObject({ setIds: TARGET.setIds });
+  });
+
+  it('lets an owner of two identical boards rename one — the config resend regression', async () => {
+    // The clients send layout/size/setIds on every edit whether or not they
+    // moved. Under the old strict guard that meant an owner of two same-config
+    // boards could never save ANY edit to either: a rename was refused for
+    // colliding with the sibling.
+    const shared = { locationName: 'Klimmuur', ...BASE };
+    await createBoard({ name: 'MoonBoard 1', ...shared });
+    const second = await createBoard({ name: 'MoonBoard 2', ...shared, allowDuplicateConfig: true });
+
+    const updated = await updateBoard({ boardUuid: second.uuid, name: 'MoonBoard 2 (left)', ...STARTING });
+
+    expect(updated.name).toBe('MoonBoard 2 (left)');
+    expect(await storedConfig(second.uuid)).toMatchObject({ name: 'MoonBoard 2 (left)', setIds: STARTING.setIds });
+  });
+
+  it('recognises the sibling when the same hold sets arrive in a different order', async () => {
+    await createBoard({ ...TARGET, setIds: '10,9,8,7,6,5', name: 'Sibling', locationName: 'Klimmuur', ...BASE });
+    const edited = await createBoard({ name: 'Edited', locationName: 'Klimmuur', ...BASE });
+
+    const extensions = await captureDuplicate(updateBoard({ boardUuid: edited.uuid, setIds: '5,6,7,8,9,10' }));
+
+    expect(extensions).not.toBeNull();
+    expect(await storedConfig(edited.uuid)).toMatchObject({ setIds: STARTING.setIds });
+  });
+
+  // The next two cases run on named-but-uncoordinated boards, the shape most
+  // real boards have: the coordinate fields sit behind "More options" and can
+  // only be filled by "Use my location", i.e. by standing at the wall.
+  it('judges the collision on the POST-update location — moving away is allowed', async () => {
+    await createBoard({ ...TARGET, name: 'Sibling', locationName: 'Klimmuur' });
+    const edited = await createBoard({ name: 'Edited', locationName: 'Klimmuur' });
+
+    // The same config change that would be refused in place: the board is also
+    // moving to another gym, which is exactly the reconfiguration this guard
+    // must not block. Judged on the stored location it would have been refused.
+    const updated = await updateBoard({
+      boardUuid: edited.uuid,
+      setIds: TARGET.setIds,
+      locationName: 'Boulder Space',
+    });
+
+    expect(updated.setIds).toBe(TARGET.setIds);
+  });
+
+  it('judges the collision on the POST-update location — moving onto the sibling is refused', async () => {
+    const sibling = await createBoard({ ...TARGET, name: 'Sibling', locationName: 'Klimmuur' });
+    const edited = await createBoard({ name: 'Edited', locationName: 'Boulder Space' });
+
+    // Judged on the stored location this would have been allowed; the edit puts
+    // the board at Klimmuur, where the sibling already runs that config.
+    const extensions = await captureDuplicate(
+      updateBoard({ boardUuid: edited.uuid, setIds: TARGET.setIds, locationName: 'Klimmuur' }),
+    );
+
+    expect(extensions?.existingBoardUuid).toBe(sibling.uuid);
+    expect(await storedConfig(edited.uuid)).toMatchObject({ setIds: STARTING.setIds });
+  });
+
+  it('never blocks a board with itself', async () => {
+    const only = await createBoard({ name: 'Only wall', locationName: 'Klimmuur', ...BASE });
+
+    // A real config change with no sibling anywhere: the board's own row is the
+    // only candidate, and it must be excluded from the probe.
+    const changed = await updateBoard({ boardUuid: only.uuid, setIds: TARGET.setIds });
+    expect(changed.setIds).toBe(TARGET.setIds);
+
+    // And the resend-verbatim shape stays a no-op edit.
+    const resent = await updateBoard({ boardUuid: only.uuid, ...TARGET, name: 'Only wall (renamed)' });
+    expect(resent.name).toBe('Only wall (renamed)');
+    expect(resent.setIds).toBe(TARGET.setIds);
+  });
+
+  it('exempts the system catalog owner, whose boards legitimately share a config', async () => {
+    // Seeded catalog boards all belong to the system user and many gyms run the
+    // identical wall, so the guard must never stand between a moderator and a
+    // catalog fix.
+    const siblingUuid = uuidv4();
+    const catalogUuid = uuidv4();
+    for (const [uuid, setIds, name] of [
+      [siblingUuid, TARGET.setIds, 'Catalog sibling'],
+      [catalogUuid, STARTING.setIds, 'Catalog board'],
+    ] as const) {
+      await db.execute(sql`
+        INSERT INTO user_boards
+          (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, is_public, created_at, updated_at)
+        VALUES (${uuid}, ${uuid}, ${SYSTEM_BOARD_OWNER_ID}, ${BOARD_TYPE}, ${TARGET.layoutId}, ${TARGET.sizeId},
+                ${setIds}, ${name}, true, now(), now())
+      `);
+    }
+    await db.execute(sql`
+      INSERT INTO community_roles (user_id, role, board_type, created_at)
+      VALUES (${MODERATOR}, 'admin', NULL, now())
+    `);
+
+    const updated = await updateBoard({ boardUuid: catalogUuid, setIds: TARGET.setIds }, MODERATOR);
+
+    expect(updated.setIds).toBe(TARGET.setIds);
+  });
+});

--- a/packages/backend/src/graphql/resolvers/board-presence/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/mutations.ts
@@ -17,6 +17,7 @@ import {
   ReportBoardClimbInputSchema,
 } from '../../../validation/schemas';
 import { generateUniqueSlug } from '../social/boards';
+import { assertBoardCapNotReached } from '../social/board-limits';
 import { assertKnownBoardConfig } from './board-catalog';
 import { logger } from '../../../utils/logger';
 import { pubsub } from '../../../pubsub/index';
@@ -160,6 +161,11 @@ async function bindOrCreateOwnBoardForSerial(
       throw serialAlreadyBoundError();
     }
   }
+
+  // Only the create branch is capped. Binding a serial onto a board the caller
+  // already owns adds no row, so an account at the cap must still be able to
+  // connect to the walls it has.
+  await assertBoardCapNotReached(userId);
 
   await assertKnownBoardConfig(config.boardType, config.layoutId, config.sizeId, config.setIds);
   const uuid = uuidv4();

--- a/packages/backend/src/graphql/resolvers/social/board-limits.ts
+++ b/packages/backend/src/graphql/resolvers/social/board-limits.ts
@@ -1,0 +1,55 @@
+import { and, eq, isNull, sql } from 'drizzle-orm';
+import { GraphQLError } from 'graphql';
+import { db } from '../../../db/client';
+import * as dbSchema from '@boardsesh/db/schema';
+import { SYSTEM_BOARD_OWNER_ID } from '../board-presence/shared';
+
+/**
+ * Live boards one account may hold.
+ *
+ * Until #4174 the `user_boards_unique_owner_config` index was an accidental
+ * ceiling — an owner could not have two boards of the same configuration, so the
+ * hardware catalog bounded the total. Dropping it was right (the same MoonBoard
+ * exists at every gym that owns one), but it left nothing bounding mint volume,
+ * and `allowDuplicateConfig` is a flag any client can set on every call.
+ *
+ * 50 sits well above any real climber or gym — the busiest gyms in the data hold
+ * a handful of walls — and in line with the other per-account ceilings
+ * (`MAX_AUTO_MINTED_GYMS_PER_OWNER = 25`, `MAX_FOREIGN_GYM_LINKS = 20`).
+ */
+export const MAX_BOARDS_PER_ACCOUNT = 50;
+
+export function boardLimitReachedError(): GraphQLError {
+  return new GraphQLError(
+    `You've reached the limit of ${MAX_BOARDS_PER_ACCOUNT} boards on one account. ` +
+      `Delete a board you no longer use to add another.`,
+    { extensions: { code: 'BOARD_LIMIT_REACHED', maxBoards: MAX_BOARDS_PER_ACCOUNT } },
+  );
+}
+
+/**
+ * Refuse to add another board once the caller is at the cap.
+ *
+ * Deliberately a plain read outside any transaction, the same posture as the
+ * gym mint cap in `gym-matching.ts`: two concurrent creates can both see 49 and
+ * both land, so the cap is approximate by design. It exists to stop a runaway,
+ * not to hold an invariant — paying for row locks on every create to make it
+ * exact would be the wrong trade.
+ *
+ * Unlike the gym cap, which quietly stops attaching a gym, this one THROWS: a
+ * board the user explicitly asked for must not silently not exist.
+ *
+ * The system catalog owner is exempt — it holds every seeded board there is.
+ */
+export async function assertBoardCapNotReached(ownerId: string): Promise<void> {
+  if (ownerId === SYSTEM_BOARD_OWNER_ID) return;
+
+  const [{ count: ownedBoardCount }] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(dbSchema.userBoards)
+    .where(and(eq(dbSchema.userBoards.ownerId, ownerId), isNull(dbSchema.userBoards.deletedAt)));
+
+  if (ownedBoardCount >= MAX_BOARDS_PER_ACCOUNT) {
+    throw boardLimitReachedError();
+  }
+}

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -160,19 +160,33 @@ async function findOwnedBlockingDuplicate(opts: {
  * has this wall at this place. The existing board travels with the error so the
  * client can offer "use that one" without scanning its paginated myBoards cache
  * — which defaults to 20 and so can't find a match for a user with more boards.
+ *
+ * `includeIdentity` is false whenever the caller is not the board's owner. The
+ * probe keys on the OWNER's boards, but updateBoard is reachable by gym admins
+ * and community moderators, so attaching the colliding board's name, slug and
+ * location would hand a non-owner the identity of a board they may not be able
+ * to see at all — a private home wall, or one whose location `enrichBoard`
+ * masks behind `hideLocation`. Same leak class as the private-gym probe finding
+ * in the #4174 round: an error's extensions are a read channel, and they have
+ * to respect the same visibility rules the read resolvers do.
  */
-function duplicateBoardConfigError(existing: DuplicateBoardCandidate): GraphQLError {
+function duplicateBoardConfigError(
+  existing: DuplicateBoardCandidate,
+  { includeIdentity }: { includeIdentity: boolean },
+): GraphQLError {
   return new GraphQLError('You already have this board at this location', {
-    extensions: {
-      code: 'BOARD_DUPLICATE_CONFIG',
-      existingBoardUuid: existing.uuid,
-      existingBoardSlug: existing.slug,
-      existingBoardName: existing.name,
-      existingBoardLocationName: existing.locationName,
-      // Web's "go to your board" links to /b/<slug>/<angle>; without the
-      // board's own angle it would land on the board type's default.
-      existingBoardAngle: existing.angle,
-    },
+    extensions: includeIdentity
+      ? {
+          code: 'BOARD_DUPLICATE_CONFIG',
+          existingBoardUuid: existing.uuid,
+          existingBoardSlug: existing.slug,
+          existingBoardName: existing.name,
+          existingBoardLocationName: existing.locationName,
+          // Web's "go to your board" links to /b/<slug>/<angle>; without the
+          // board's own angle it would land on the board type's default.
+          existingBoardAngle: existing.angle,
+        }
+      : { code: 'BOARD_DUPLICATE_CONFIG' },
   });
 }
 
@@ -1749,7 +1763,8 @@ export const socialBoardMutations = {
       });
 
       if (existing) {
-        throw duplicateBoardConfigError(existing);
+        // The caller is always the owner here, so the full identity is theirs to see.
+        throw duplicateBoardConfigError(existing, { includeIdentity: true });
       }
     }
 
@@ -1938,6 +1953,14 @@ export const socialBoardMutations = {
     // owner/admin may edit. Community moderators can fix outdated catalog boards.
     await requireBoardEditAccess(ctx, board);
 
+    // Editing a soft-deleted board restores it (see `updateValues.deletedAt`
+    // below), and the cap counts live rows only — so a restore is +1 live board
+    // and pays the same toll as a mint. Without this, delete-N/create-N/restore-N
+    // walks an account to cap+N. Editing an already-live board never gets here.
+    if (board.deletedAt) {
+      await assertBoardCapNotReached(board.ownerId);
+    }
+
     // Config field changes (layoutId, sizeId, setIds). Authorized editors may
     // change these even when the board has logged climbs — a config change
     // reflects a real physical reconfiguration. Old boardsesh_ticks rows are
@@ -2034,7 +2057,11 @@ export const socialBoardMutations = {
           });
 
           if (existing) {
-            throw duplicateBoardConfigError(existing);
+            // The colliding board belongs to this board's OWNER. A gym admin or
+            // community moderator editing someone else's board gets the bare
+            // rejection code — enough to render "this config is taken", nothing
+            // that names or locates a board they have no read access to.
+            throw duplicateBoardConfigError(existing, { includeIdentity: board.ownerId === userId });
           }
         }
       }

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { eq, and, count, isNull, sql, ilike, or, asc, desc, inArray, like } from 'drizzle-orm';
+import { eq, ne, and, count, isNull, sql, ilike, or, asc, desc, inArray, like } from 'drizzle-orm';
 import { GraphQLError } from 'graphql';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { normaliseSetIds } from '@boardsesh/board-config';
@@ -22,7 +22,7 @@ import {
 } from '../../../validation/schemas';
 import { generateUniqueGymSlug, requireBoardGymLinkAccess, userCanEditGym } from './gyms';
 import { resolveAutoGymForBoard } from './gym-matching';
-import { findBlockingDuplicate } from './board-duplicates';
+import { findBlockingDuplicate, type BoardLocation } from './board-duplicates';
 import { getUserCommunityRoles, hasAdminOrLeader, rolesGrantAdminOrLeader } from './roles';
 import { SYSTEM_BOARD_OWNER_ID, isRowAnonReadable, requireAnonReadableBoard } from '../board-presence/shared';
 import { assertKnownBoardConfig } from '../board-presence/board-catalog';
@@ -87,6 +87,87 @@ export async function generateUniqueSlug(name: string): Promise<string> {
 
   // Fallback: append UUID fragment
   return `${baseSlug}-${uuidv4().slice(0, 8)}`;
+}
+
+type DuplicateBoardCandidate = {
+  uuid: string;
+  slug: string;
+  name: string;
+  setIds: string;
+  angle: number;
+  latitude: number | null;
+  longitude: number | null;
+  locationName: string | null;
+};
+
+/**
+ * The owner's other live board that a create/edit would collide with, or
+ * undefined.
+ *
+ * SQL narrows to owner + type + layout + size only; set-id equality and the
+ * place comparison are settled in JS by `findBlockingDuplicate`, because the
+ * stored set-id order is whatever the board was created with ('25,26,27,24' and
+ * '24,25,26,27' are the same wall but not the same string).
+ *
+ * `excludeBoardId` is the row being edited — a board must never block itself.
+ */
+async function findOwnedBlockingDuplicate(opts: {
+  ownerId: string;
+  boardType: string;
+  layoutId: number;
+  sizeId: number;
+  incoming: BoardLocation & { setIds: string };
+  excludeBoardId?: number;
+}): Promise<DuplicateBoardCandidate | undefined> {
+  const ownedWithConfig = await db
+    .select({
+      uuid: dbSchema.userBoards.uuid,
+      slug: dbSchema.userBoards.slug,
+      name: dbSchema.userBoards.name,
+      setIds: dbSchema.userBoards.setIds,
+      angle: dbSchema.userBoards.angle,
+      latitude: dbSchema.userBoards.latitude,
+      longitude: dbSchema.userBoards.longitude,
+      locationName: dbSchema.userBoards.locationName,
+    })
+    .from(dbSchema.userBoards)
+    .where(
+      and(
+        eq(dbSchema.userBoards.ownerId, opts.ownerId),
+        eq(dbSchema.userBoards.boardType, opts.boardType),
+        eq(dbSchema.userBoards.layoutId, opts.layoutId),
+        eq(dbSchema.userBoards.sizeId, opts.sizeId),
+        isNull(dbSchema.userBoards.deletedAt),
+        opts.excludeBoardId != null ? ne(dbSchema.userBoards.id, opts.excludeBoardId) : undefined,
+      ),
+    )
+    // Already narrowed to one owner's boards of one exact type/layout/size,
+    // so this is a handful of rows; the cap is just a safety net against a
+    // pathological account.
+    .limit(100);
+
+  return findBlockingDuplicate(ownedWithConfig, opts.incoming);
+}
+
+/**
+ * The rejection both createBoard and updateBoard raise when the owner already
+ * has this wall at this place. The existing board travels with the error so the
+ * client can offer "use that one" without scanning its paginated myBoards cache
+ * — which defaults to 20 and so can't find a match for a user with more boards.
+ */
+function duplicateBoardConfigError(existing: DuplicateBoardCandidate): GraphQLError {
+  return new GraphQLError('You already have this board at this location', {
+    extensions: {
+      code: 'BOARD_DUPLICATE_CONFIG',
+      existingBoardUuid: existing.uuid,
+      existingBoardSlug: existing.slug,
+      existingBoardName: existing.name,
+      existingBoardLocationName: existing.locationName,
+      // Web's "go to your board" links to /b/<slug>/<angle>; without the
+      // board's own angle it would land on the board type's default.
+      existingBoardAngle: existing.angle,
+    },
+  });
 }
 
 /**
@@ -1633,53 +1714,16 @@ export const socialBoardMutations = {
           !!validatedInput.locationName || (validatedInput.latitude != null && validatedInput.longitude != null),
       });
     } else {
-      const ownedWithConfig = await db
-        .select({
-          uuid: dbSchema.userBoards.uuid,
-          slug: dbSchema.userBoards.slug,
-          name: dbSchema.userBoards.name,
-          setIds: dbSchema.userBoards.setIds,
-          angle: dbSchema.userBoards.angle,
-          latitude: dbSchema.userBoards.latitude,
-          longitude: dbSchema.userBoards.longitude,
-          locationName: dbSchema.userBoards.locationName,
-        })
-        .from(dbSchema.userBoards)
-        .where(
-          and(
-            eq(dbSchema.userBoards.ownerId, userId),
-            eq(dbSchema.userBoards.boardType, validatedInput.boardType),
-            eq(dbSchema.userBoards.layoutId, validatedInput.layoutId),
-            eq(dbSchema.userBoards.sizeId, validatedInput.sizeId),
-            isNull(dbSchema.userBoards.deletedAt),
-          ),
-        )
-        // Already narrowed to one owner's boards of one exact type/layout/size,
-        // so this is a handful of rows; the cap is just a safety net against a
-        // pathological account.
-        .limit(100);
-
-      const existing = findBlockingDuplicate(ownedWithConfig, {
-        setIds: validatedInput.setIds,
-        ...incomingLocation,
+      const existing = await findOwnedBlockingDuplicate({
+        ownerId: userId,
+        boardType: validatedInput.boardType,
+        layoutId: validatedInput.layoutId,
+        sizeId: validatedInput.sizeId,
+        incoming: { setIds: validatedInput.setIds, ...incomingLocation },
       });
 
       if (existing) {
-        // The existing board travels with the error so the client can offer
-        // "use that one" without scanning its paginated myBoards cache — which
-        // defaults to 20 and so can't find a match for a user with more boards.
-        throw new GraphQLError('You already have this board at this location', {
-          extensions: {
-            code: 'BOARD_DUPLICATE_CONFIG',
-            existingBoardUuid: existing.uuid,
-            existingBoardSlug: existing.slug,
-            existingBoardName: existing.name,
-            existingBoardLocationName: existing.locationName,
-            // Web's "go to your board" links to /b/<slug>/<angle>; without the
-            // board's own angle it would land on the board type's default.
-            existingBoardAngle: existing.angle,
-          },
-        });
+        throw duplicateBoardConfigError(existing);
       }
     }
 
@@ -1910,31 +1954,62 @@ export const socialBoardMutations = {
     if (validatedInput.timerName !== undefined) updateValues.timerName = validatedInput.timerName;
 
     if (hasConfigChange) {
-      // Check the unique constraint: no other active board with the same config
-      // for the board's OWNER (not the caller — a moderator may be editing a
-      // board owned by a system/import user). The DB's partial unique index
-      // exempts the system catalog owner (many gyms legitimately share a
-      // config), so skip the pre-check there or we'd block the very catalog
-      // fixes this feature exists for.
-      if (board.ownerId !== SYSTEM_BOARD_OWNER_ID) {
-        const [configConflict] = await db
-          .select({ id: dbSchema.userBoards.id })
-          .from(dbSchema.userBoards)
-          .where(
-            and(
-              eq(dbSchema.userBoards.ownerId, board.ownerId),
-              eq(dbSchema.userBoards.boardType, board.boardType),
-              eq(dbSchema.userBoards.layoutId, newLayoutId),
-              eq(dbSchema.userBoards.sizeId, newSizeId),
-              eq(dbSchema.userBoards.setIds, newSetIds),
-              isNull(dbSchema.userBoards.deletedAt),
-              sql`${dbSchema.userBoards.id} != ${board.id}`,
-            ),
-          )
-          .limit(1);
+      // The clients resend layout/size/setIds on every edit whenever the config
+      // section is unlocked, so `hasConfigChange` says "config fields were
+      // present", not "the config moved". Compare the effective values —
+      // set ids normalised, since the stored order is whatever the board was
+      // created with — and skip the guard when nothing actually changed.
+      // Without this skip, an owner of two same-config boards could never save
+      // ANY edit to either one: renaming a board would be rejected for
+      // colliding with its sibling.
+      const configActuallyChanged =
+        newLayoutId !== board.layoutId ||
+        newSizeId !== board.sizeId ||
+        normaliseSetIds(newSetIds) !== normaliseSetIds(board.setIds);
 
-        if (configConflict) {
-          throw new Error("The board's owner already has a board with this configuration");
+      // Keyed off the board's OWNER, not the caller — a moderator or gym admin
+      // may be editing someone else's board. The system catalog owner is exempt:
+      // many gyms legitimately share one config there, and blocking that would
+      // break the catalog fixes moderation exists for.
+      if (configActuallyChanged && board.ownerId !== SYSTEM_BOARD_OWNER_ID) {
+        if (validatedInput.allowDuplicateConfig) {
+          // Same trail as createBoard: this is the one path that lets an edit
+          // land on a config the owner already has at the same place, so record
+          // that a human confirmed it rather than leaving it indistinguishable
+          // from a script setting the flag on every call.
+          logger.info('updateBoard: duplicate-config guard bypassed by explicit confirmation', {
+            userId,
+            boardId: board.id,
+            ownerId: board.ownerId,
+            boardType: board.boardType,
+            layoutId: newLayoutId,
+            sizeId: newSizeId,
+          });
+        } else {
+          // Probe with the POST-update location, so an edit that moves this
+          // board onto a sibling's site is caught and one that moves it away is
+          // allowed. A location-only edit is deliberately NOT guarded at all
+          // (it never reaches here): as with createBoard after #4166, we block
+          // the accident of re-submitting a wall, not every way two rows can end
+          // up looking alike.
+          const existing = await findOwnedBlockingDuplicate({
+            ownerId: board.ownerId,
+            boardType: board.boardType,
+            layoutId: newLayoutId,
+            sizeId: newSizeId,
+            excludeBoardId: board.id,
+            incoming: {
+              setIds: newSetIds,
+              locationName:
+                validatedInput.locationName !== undefined ? validatedInput.locationName : board.locationName,
+              latitude: validatedInput.latitude !== undefined ? validatedInput.latitude : board.latitude,
+              longitude: validatedInput.longitude !== undefined ? validatedInput.longitude : board.longitude,
+            },
+          });
+
+          if (existing) {
+            throw duplicateBoardConfigError(existing);
+          }
         }
       }
 

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -24,7 +24,12 @@ import { generateUniqueGymSlug, requireBoardGymLinkAccess, userCanEditGym } from
 import { resolveAutoGymForBoard } from './gym-matching';
 import { findBlockingDuplicate, type BoardLocation } from './board-duplicates';
 import { getUserCommunityRoles, hasAdminOrLeader, rolesGrantAdminOrLeader } from './roles';
-import { SYSTEM_BOARD_OWNER_ID, isRowAnonReadable, requireAnonReadableBoard } from '../board-presence/shared';
+import {
+  SYSTEM_BOARD_OWNER_ID,
+  isRowAnonReadable,
+  normalizeSetIds,
+  requireAnonReadableBoard,
+} from '../board-presence/shared';
 import { assertKnownBoardConfig } from '../board-presence/board-catalog';
 import { publishBoardQueuePreviewTombstoneForBoard } from '../../../services/board-queue-preview';
 import { logger } from '../../../utils/logger';
@@ -171,8 +176,21 @@ function duplicateBoardConfigError(existing: DuplicateBoardCandidate): GraphQLEr
 }
 
 /**
- * Resolve a board ID from user + board config.
- * Used by tick logging to auto-populate boardId.
+ * Resolve a board ID from user + board config. Used by tick logging on the
+ * legacy `/[board_name]/[layout_id]/...` route, which names a configuration
+ * rather than a board entity.
+ *
+ * Set-id equality is settled in JS, not SQL. The stored value keeps the order
+ * the board was created with, so a SQL `eq()` called '25,26,27,24' and
+ * '24,25,26,27' different boards and the tick was recorded with no board at all.
+ *
+ * Since #4174 an owner may hold several boards of one configuration, so the pick
+ * has to be stable: `asc(id)` means the same tick always lands on the same
+ * board, and a climber's history for that wall doesn't split across siblings.
+ * Preferring the board the user most recently ticked was considered and left
+ * out — it can flip the moment they tick a sibling through the boardUuid route,
+ * which is less stable, not more. The session rung in saveTick is the signal
+ * that actually knows which wall the climber is on.
  */
 export async function resolveBoardFromPath(
   userId: string,
@@ -181,8 +199,8 @@ export async function resolveBoardFromPath(
   sizeId: number,
   setIds: string,
 ): Promise<number | null> {
-  const [board] = await db
-    .select({ id: dbSchema.userBoards.id })
+  const candidates = await db
+    .select({ id: dbSchema.userBoards.id, setIds: dbSchema.userBoards.setIds })
     .from(dbSchema.userBoards)
     .where(
       and(
@@ -190,13 +208,16 @@ export async function resolveBoardFromPath(
         eq(dbSchema.userBoards.boardType, boardType),
         eq(dbSchema.userBoards.layoutId, layoutId),
         eq(dbSchema.userBoards.sizeId, sizeId),
-        eq(dbSchema.userBoards.setIds, setIds),
         isNull(dbSchema.userBoards.deletedAt),
       ),
     )
-    .limit(1);
+    .orderBy(asc(dbSchema.userBoards.id))
+    // One owner's boards of one exact type/layout/size — a handful of rows; the
+    // cap is a safety net against a pathological account.
+    .limit(100);
 
-  return board?.id ?? null;
+  const targetSetIds = normalizeSetIds(setIds);
+  return candidates.find((candidate) => normalizeSetIds(candidate.setIds) === targetSetIds)?.id ?? null;
 }
 
 /**

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -23,6 +23,7 @@ import {
 import { generateUniqueGymSlug, requireBoardGymLinkAccess, userCanEditGym } from './gyms';
 import { resolveAutoGymForBoard } from './gym-matching';
 import { findBlockingDuplicate, type BoardLocation } from './board-duplicates';
+import { assertBoardCapNotReached } from './board-limits';
 import { getUserCommunityRoles, hasAdminOrLeader, rolesGrantAdminOrLeader } from './roles';
 import {
   SYSTEM_BOARD_OWNER_ID,
@@ -1707,6 +1708,10 @@ export const socialBoardMutations = {
       validatedInput.setIds,
     );
     const userId = ctx.userId!;
+
+    // Before the duplicate guard, so the `allowDuplicateConfig` bypass — the one
+    // path that can add unlimited same-config boards — is capped too.
+    await assertBoardCapNotReached(userId);
 
     const incomingLocation = {
       latitude: validatedInput.latitude ?? null,

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -566,8 +566,31 @@ export const tickMutations = {
       validatedInput.angle,
     );
 
-    // Resolve the tick's board_id. Two explicit-board inputs feed the same FK,
-    // each from a different surface:
+    // A stale/unknown sessionId (session ended, or never existed on this
+    // backend — e.g. an offline-replayed tick) would otherwise FK-violate the
+    // insert and lose the whole tick (#2386). Same best-effort drop-the-ref
+    // trade-off as the board resolution below; no ownership check, since
+    // party-mode ticks legitimately reference sessions other users made.
+    // Resolved BEFORE the board, so the session's own board can disambiguate a
+    // legacy config tick (rung 3).
+    let resolvedSessionId: string | null = null;
+    let sessionBoardId: number | null = null;
+    if (validatedInput.sessionId) {
+      const [session] = await db
+        .select({ id: dbSchema.boardSessions.id, boardId: dbSchema.boardSessions.boardId })
+        .from(dbSchema.boardSessions)
+        .where(eq(dbSchema.boardSessions.id, validatedInput.sessionId))
+        .limit(1);
+
+      if (session) {
+        resolvedSessionId = session.id;
+        sessionBoardId = session.boardId;
+      } else {
+        logger.warn(`[saveTick] Dropping stale sessionId ${validatedInput.sessionId} — session not found`);
+      }
+    }
+
+    // Resolve the tick's board_id. Four rungs, most specific first:
     //  1. boardUuid — a named-board route (`/b/<slug>/...`); attaches to that
     //     exact board entity even when the climber doesn't own it (e.g. a
     //     seeded gym board owned by the system user). Best-effort: a deleted or
@@ -576,7 +599,14 @@ export const tickMutations = {
     //  2. boardId — the board-presence connected wall (resolveBoardForSerial),
     //     flag-gated. On a stale/mismatched id we warn and fall back to the
     //     config lookup rather than surfacing a raw FK/type mismatch.
-    // Absent both, the legacy `/[board_name]/[layout_id]/...` config lookup runs.
+    //  3. the session's board — a session is held on one physical wall, so a
+    //     tick logged into it belongs to that wall. Config-gated exactly like
+    //     rung 2, and deliberately not ownership-gated: in party mode the
+    //     session names someone else's board, and that board is still the wall
+    //     the climber is standing at.
+    //  4. the legacy `/[board_name]/[layout_id]/...` config lookup, which names
+    //     a configuration rather than a board; it takes the owner's lowest-id
+    //     board with that config.
     let boardId: number | null = null;
     if (validatedInput.boardUuid) {
       const [board] = await db
@@ -619,10 +649,37 @@ export const tickMutations = {
       }
     }
 
-    // Legacy `/[board_name]/[layout_id]/...` route (no specific board entity),
-    // plus the fallback when a board-presence boardId didn't match. A
-    // best-effort boardUuid that resolved to nothing is intentionally left
-    // unassociated (handled above), so it does not fall through to here.
+    // Rung 3: the wall the session is being held on. This is what tells two
+    // same-config boards apart — since #4174 an owner can have the same wall at
+    // home and at a gym, and the config lookup below cannot see which one the
+    // climber is at, while the session can.
+    if (
+      boardId == null &&
+      !validatedInput.boardUuid &&
+      sessionBoardId != null &&
+      validatedInput.layoutId &&
+      validatedInput.sizeId &&
+      validatedInput.setIds
+    ) {
+      const sessionBoard = await findActiveBoardById(sessionBoardId);
+      // Same full-config gate as rung 2: a session left open on another wall
+      // must not stamp this tick onto it.
+      const configMatches =
+        sessionBoard != null &&
+        sessionBoard.boardType === validatedInput.boardType &&
+        sessionBoard.layoutId === validatedInput.layoutId &&
+        sessionBoard.sizeId === validatedInput.sizeId &&
+        normalizeSetIds(sessionBoard.setIds) === normalizeSetIds(validatedInput.setIds);
+      if (configMatches) {
+        boardId = sessionBoard.id;
+      }
+    }
+
+    // Rung 4: legacy `/[board_name]/[layout_id]/...` route (no specific board
+    // entity), plus the fallback when a board-presence boardId or the session's
+    // board didn't match. A best-effort boardUuid that resolved to nothing is
+    // intentionally left unassociated (handled above), so it does not fall
+    // through to here.
     if (
       boardId == null &&
       !validatedInput.boardUuid &&
@@ -637,26 +694,6 @@ export const tickMutations = {
         validatedInput.sizeId,
         validatedInput.setIds,
       );
-    }
-
-    // A stale/unknown sessionId (session ended, or never existed on this
-    // backend — e.g. an offline-replayed tick) would otherwise FK-violate the
-    // insert and lose the whole tick (#2386). Same best-effort drop-the-ref
-    // trade-off as the boardUuid/boardId resolution above; no ownership check,
-    // since party-mode ticks legitimately reference sessions other users made.
-    let resolvedSessionId: string | null = null;
-    if (validatedInput.sessionId) {
-      const [session] = await db
-        .select({ id: dbSchema.boardSessions.id })
-        .from(dbSchema.boardSessions)
-        .where(eq(dbSchema.boardSessions.id, validatedInput.sessionId))
-        .limit(1);
-
-      if (session) {
-        resolvedSessionId = session.id;
-      } else {
-        logger.warn(`[saveTick] Dropping stale sessionId ${validatedInput.sessionId} — session not found`);
-      }
     }
 
     // Run write-time beta-link validation before opening the transaction so a

--- a/packages/backend/src/validation/schemas/boards.ts
+++ b/packages/backend/src/validation/schemas/boards.ts
@@ -76,6 +76,11 @@ export const UpdateBoardInputSchema = z.object({
   setIds: NumericCsvSchema.optional(),
   serialNumber: NullableBoardSerialInputSchema,
   timerName: z.string().min(1).max(200, 'Timer name too long').optional().nullable(),
+  // Set only by a client that has shown the user the duplicate prompt and had
+  // them confirm the edited board is a different physical wall from the sibling
+  // it now matches. Skips the duplicate-config guard entirely — see
+  // board-duplicates.ts.
+  allowDuplicateConfig: z.boolean().optional(),
 });
 
 /**

--- a/packages/mobile/app/boards/__tests__/create.test.tsx
+++ b/packages/mobile/app/boards/__tests__/create.test.tsx
@@ -225,6 +225,31 @@ describe('CreateBoard', () => {
     expect(createBoardMock).toHaveBeenCalledTimes(1);
   });
 
+  it('names the account cap instead of echoing the server message', async () => {
+    // 'board_limit' has to stay out of the 'exception' bucket: retrying will
+    // never clear it, and the way out (delete a board) belongs in our own copy.
+    createBoardMock.mockRejectedValueOnce({
+      response: {
+        errors: [
+          {
+            message: 'You have reached the maximum of 50 boards for one account',
+            extensions: { code: 'BOARD_LIMIT_REACHED', maxBoards: 50 },
+          },
+        ],
+      },
+    });
+    render(createElement(CreateBoard));
+    fireEvent.click(screen.getByText('submit'));
+
+    await waitFor(() => expect(screen.getByTestId('error')).toBeTruthy());
+    expect(screen.getByTestId('error').textContent).toBe('mobile.create.limitReached');
+    expect(trackMock).toHaveBeenCalledWith(
+      'Board Create Failed',
+      expect.objectContaining({ error_reason: 'board_limit' }),
+    );
+    expect(dismissToMock).not.toHaveBeenCalled();
+  });
+
   it('shows a non-duplicate failure inline rather than as an invisible toast', async () => {
     // This screen is a `presentation: 'modal'` route, and the toast overlay
     // renders behind those — a toast here would never be seen.

--- a/packages/mobile/app/boards/__tests__/edit.test.tsx
+++ b/packages/mobile/app/boards/__tests__/edit.test.tsx
@@ -1,0 +1,248 @@
+// @vitest-environment jsdom
+//
+// Editing a board used to flatten every server rejection to an inline string.
+// After #4174 dropped the per-owner config unique index, `updateBoard` answers a
+// config collision with a typed BOARD_DUPLICATE_CONFIG the user is meant to be
+// able to override — so a gym reconfiguring one wall to match another of the
+// owner's boards gets asked instead of blocked.
+//
+// The other half of the contract: when the editor is NOT the board's owner (a
+// gym admin, a community moderator), the server strips the colliding board's
+// identity out of the extensions. The prompt still has to work.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+type Children = { children?: ReactNode };
+type AlertButton = { text: string; style?: string; onPress?: () => void };
+
+const updateBoardMock = vi.hoisted(() => vi.fn());
+const linkBoardToGymMock = vi.hoisted(() => vi.fn());
+const setActiveBoardMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const backMock = vi.hoisted(() => vi.fn());
+const trackMock = vi.hoisted(() => vi.fn());
+const alertMock = vi.hoisted(() => vi.fn());
+const buildUpdateInputMock = vi.hoisted(() => vi.fn());
+
+const board = {
+  uuid: 'board-uuid',
+  boardType: 'moonboard',
+  layoutId: 3,
+  sizeId: 1,
+  setIds: '5,6,7',
+  name: 'Klimmuur MoonBoard',
+  gymUuid: null,
+  canEdit: true,
+} as unknown as UserBoard;
+
+/** A graphql-request ClientError carrying the server's duplicate rejection. */
+function duplicateError(extensions: Record<string, unknown>) {
+  return {
+    response: {
+      errors: [{ message: 'You already have this board at this location', extensions }],
+    },
+  };
+}
+
+const ownerDuplicate = duplicateError({
+  code: 'BOARD_DUPLICATE_CONFIG',
+  existingBoardUuid: 'sibling-uuid',
+  existingBoardName: 'Garage MoonBoard',
+  existingBoardSlug: 'garage-moonboard',
+  existingBoardLocationName: 'My Garage',
+});
+
+/** What a gym admin or moderator sees: the code, and nothing that names a board. */
+const strippedDuplicate = duplicateError({ code: 'BOARD_DUPLICATE_CONFIG' });
+
+vi.mock('expo-router', () => ({
+  useRouter: () => ({ back: backMock }),
+  useLocalSearchParams: () => ({ boardUuid: 'board-uuid' }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: Record<string, unknown>) => (values ? `${key}:${JSON.stringify(values)}` : key),
+  }),
+}));
+
+vi.mock('../../../src/lib/graphql/hooks', () => ({
+  useBoard: () => ({ data: board, isLoading: false }),
+  useProfile: () => ({ data: { displayName: 'Marco' } }),
+  useUpdateBoard: () => ({ mutateAsync: updateBoardMock }),
+  useLinkBoardToGym: () => ({ mutateAsync: linkBoardToGymMock }),
+}));
+
+vi.mock('../../../src/lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: null }),
+  useSetActiveBoard: () => setActiveBoardMock,
+}));
+
+vi.mock('../../../src/lib/analytics', () => ({ track: trackMock }));
+
+vi.mock('../../../src/providers/auth-provider', () => ({
+  useAuth: () => ({ isAuthenticated: true }),
+}));
+
+vi.mock('../../../src/lib/haptics', () => ({ hapticSelection: vi.fn() }));
+
+// The builder has its own suite; here it only has to hand back a valid input so
+// the screen's control flow is what's under test.
+vi.mock('../../../src/components/board-discovery/use-board-builder', () => ({
+  useBoardBuilder: () => ({
+    boardName: 'moonboard',
+    sizes: [],
+    sizeId: 1,
+    rawLayoutName: 'Standard',
+    selectedGym: null,
+    buildUpdateInput: buildUpdateInputMock,
+  }),
+}));
+
+vi.mock('../../../src/components/board-discovery/board-builder-labels', () => ({
+  formatDefaultBoardName: () => 'Default name',
+}));
+
+vi.mock('../../../src/components/board-discovery/BoardForm', () => ({
+  BoardForm: ({ onSubmit, errorMessage }: { onSubmit: () => void; errorMessage?: string | null }) =>
+    createElement('div', null, [
+      createElement('button', { key: 'submit', type: 'button', onClick: onSubmit }, 'submit'),
+      errorMessage ? createElement('span', { key: 'error', 'data-testid': 'error' }, errorMessage) : null,
+    ]),
+}));
+
+vi.mock('../../../src/components/Text', () => ({
+  Text: ({ children }: Children) => createElement('span', null, children),
+}));
+vi.mock('../../../src/components/Icon', () => ({ Icon: () => null }));
+vi.mock('../../../src/components/Button', () => ({ Button: () => null }));
+vi.mock('../../../src/components/ActivityIndicator', () => ({ ActivityIndicator: () => null }));
+vi.mock('../../../src/providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { background: '#000' } }),
+}));
+
+vi.mock('@boardsesh/board-config', () => ({ toBoardName: (value: string) => value }));
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  // `src/theme/colors` resolves the iOS palette at import time.
+  PlatformColor: (name: string) => name,
+  Alert: { alert: (...args: unknown[]) => alertMock(...args) },
+  View: ({ children }: Children) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+
+const { default: EditBoard } = await import('../edit');
+
+/** The buttons handed to the last `Alert.alert` call. */
+function alertButtons(): AlertButton[] {
+  return alertMock.mock.calls.at(-1)?.[2] as AlertButton[];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  buildUpdateInputMock.mockReturnValue({ boardUuid: 'board-uuid', name: 'Klimmuur MoonBoard' });
+  updateBoardMock.mockResolvedValue({ uuid: 'board-uuid', name: 'Klimmuur MoonBoard' } as unknown as UserBoard);
+});
+
+describe('EditBoard', () => {
+  it('passes the board on file so an unchanged config is left out of the input', async () => {
+    render(createElement(EditBoard));
+    fireEvent.click(screen.getByText('submit'));
+
+    await waitFor(() => expect(updateBoardMock).toHaveBeenCalledTimes(1));
+    expect(buildUpdateInputMock).toHaveBeenCalledWith(
+      'board-uuid',
+      expect.objectContaining({ currentConfig: { layoutId: 3, sizeId: 1, setIds: '5,6,7' } }),
+    );
+    expect(updateBoardMock.mock.calls[0][0].allowDuplicateConfig).toBeUndefined();
+  });
+
+  it('asks instead of failing when the config collides with a sibling board', async () => {
+    updateBoardMock.mockRejectedValueOnce(ownerDuplicate);
+    render(createElement(EditBoard));
+    fireEvent.click(screen.getByText('submit'));
+
+    await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
+    const [title, body] = alertMock.mock.calls[0];
+    expect(title).toBe('mobile.edit.duplicate.title');
+    // Both the name and the place are known here, so the body names both.
+    expect(body).toContain('mobile.edit.duplicate.bodyWithLocation');
+    expect(body).toContain('Garage MoonBoard');
+    expect(body).toContain('My Garage');
+    expect(trackMock).toHaveBeenCalledWith(
+      'Board Duplicate Prompted',
+      expect.objectContaining({ source: 'mobile_edit', boardType: 'moonboard' }),
+    );
+    // Not a dead end and not a navigation: the edit is still on screen.
+    expect(backMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('error')).toBeNull();
+  });
+
+  it('names only the board when the server withheld its location', async () => {
+    updateBoardMock.mockRejectedValueOnce(
+      duplicateError({
+        code: 'BOARD_DUPLICATE_CONFIG',
+        existingBoardUuid: 'sibling-uuid',
+        existingBoardName: 'Garage MoonBoard',
+      }),
+    );
+    render(createElement(EditBoard));
+    fireEvent.click(screen.getByText('submit'));
+
+    await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
+    const body = alertMock.mock.calls[0][1] as string;
+    expect(body).toContain('mobile.edit.duplicate.body:');
+    expect(body).toContain('Garage MoonBoard');
+  });
+
+  it('falls back to a generic body when the server stripped the board identity', async () => {
+    // A gym admin editing someone else's board never learns which board it hit.
+    updateBoardMock.mockRejectedValueOnce(strippedDuplicate);
+    render(createElement(EditBoard));
+    fireEvent.click(screen.getByText('submit'));
+
+    await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
+    expect(alertMock.mock.calls[0][1]).toBe('mobile.edit.duplicate.bodyGeneric');
+    expect(screen.queryByTestId('error')).toBeNull();
+  });
+
+  it('resends with allowDuplicateConfig when the user saves anyway', async () => {
+    updateBoardMock.mockRejectedValueOnce(ownerDuplicate);
+    render(createElement(EditBoard));
+    fireEvent.click(screen.getByText('submit'));
+
+    await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
+    const buttons = alertButtons();
+    expect(buttons[0]).toMatchObject({ text: 'mobile.edit.duplicate.keepEditing', style: 'cancel' });
+
+    buttons[1].onPress?.();
+
+    await waitFor(() => expect(updateBoardMock).toHaveBeenCalledTimes(2));
+    expect(updateBoardMock.mock.calls[1][0].allowDuplicateConfig).toBe(true);
+    await waitFor(() => expect(backMock).toHaveBeenCalled());
+  });
+
+  it('leaves the edit untouched when the user keeps editing', async () => {
+    updateBoardMock.mockRejectedValueOnce(ownerDuplicate);
+    render(createElement(EditBoard));
+    fireEvent.click(screen.getByText('submit'));
+
+    await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
+    alertButtons()[0].onPress?.();
+
+    expect(updateBoardMock).toHaveBeenCalledTimes(1);
+    expect(backMock).not.toHaveBeenCalled();
+  });
+
+  it('still reports a non-duplicate failure inline', async () => {
+    updateBoardMock.mockRejectedValueOnce(new Error('boom'));
+    render(createElement(EditBoard));
+    fireEvent.click(screen.getByText('submit'));
+
+    await waitFor(() => expect(screen.getByTestId('error')).toBeTruthy());
+    expect(alertMock).not.toHaveBeenCalled();
+    expect(backMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/app/boards/__tests__/edit.test.tsx
+++ b/packages/mobile/app/boards/__tests__/edit.test.tsx
@@ -245,4 +245,27 @@ describe('EditBoard', () => {
     expect(alertMock).not.toHaveBeenCalled();
     expect(backMock).not.toHaveBeenCalled();
   });
+
+  it('names the account cap instead of echoing the server message', async () => {
+    // Restoring a soft-deleted board adds a live board, so an edit can hit the
+    // same 50-board cap a create does. Same actionable copy as create — not
+    // the raw server message, which never explains the fix.
+    updateBoardMock.mockRejectedValueOnce({
+      response: {
+        errors: [
+          {
+            message: 'You have reached the maximum of 50 boards for one account',
+            extensions: { code: 'BOARD_LIMIT_REACHED', maxBoards: 50 },
+          },
+        ],
+      },
+    });
+    render(createElement(EditBoard));
+    fireEvent.click(screen.getByText('submit'));
+
+    await waitFor(() => expect(screen.getByTestId('error')).toBeTruthy());
+    expect(screen.getByTestId('error').textContent).toBe('mobile.create.limitReached');
+    expect(alertMock).not.toHaveBeenCalled();
+    expect(backMock).not.toHaveBeenCalled();
+  });
 });

--- a/packages/mobile/app/boards/create.tsx
+++ b/packages/mobile/app/boards/create.tsx
@@ -10,6 +10,7 @@ import {
   extractGraphqlMessage,
   isGraphqlRateLimitedError,
   isExpectedAuthError,
+  isBoardLimitError,
   readDuplicateBoardError,
   type DuplicateBoardError,
 } from '../../src/lib/graphql/extract-error-message';
@@ -39,9 +40,12 @@ function describeInput(input: CreateBoardInput, source: 'popular_seed' | 'scratc
   };
 }
 
-function classifyCreateFailure(error: unknown): 'rate_limited' | 'auth' | 'exception' {
+function classifyCreateFailure(error: unknown): 'rate_limited' | 'auth' | 'board_limit' | 'exception' {
   if (isGraphqlRateLimitedError(error)) return 'rate_limited';
   if (isExpectedAuthError(error)) return 'auth';
+  // Ahead of the catch-all so the account cap doesn't disappear into
+  // `exception` — it needs its own copy, and retrying will never clear it.
+  if (isBoardLimitError(error)) return 'board_limit';
   return 'exception';
 }
 
@@ -155,14 +159,21 @@ export default function CreateBoard() {
           setSubmitting(false);
           return;
         }
+        const reason = classifyCreateFailure(error);
         track(SHARED_EVENTS.BoardCreateFailed, {
           boardType: input.boardType,
           source,
-          error_reason: classifyCreateFailure(error),
+          error_reason: reason,
         });
         // Inline, never a toast: this screen is a `presentation: 'modal'` route
         // and the toast overlay renders behind it, so a toast here is invisible.
-        setCreateError(extractGraphqlMessage(error) ?? t('mobile.create.createError'));
+        // The cap gets our own copy rather than the server's message: what the
+        // climber needs is the way out (delete one you don't use), not the number.
+        setCreateError(
+          reason === 'board_limit'
+            ? t('mobile.create.limitReached')
+            : (extractGraphqlMessage(error) ?? t('mobile.create.createError')),
+        );
         inFlightRef.current = false;
         setSubmitting(false);
       }

--- a/packages/mobile/app/boards/edit.tsx
+++ b/packages/mobile/app/boards/edit.tsx
@@ -171,7 +171,7 @@ function EditBoardForm({ board }: { board: UserBoard }) {
       try {
         const updated = await updateBoard.mutateAsync({
           ...input,
-          allowDuplicateConfig: options?.allowDuplicateConfig || undefined,
+          allowDuplicateConfig: options?.allowDuplicateConfig,
         });
 
         // `UpdateBoardInput` carries no gym, so a changed gym is its own mutation.

--- a/packages/mobile/app/boards/edit.tsx
+++ b/packages/mobile/app/boards/edit.tsx
@@ -9,6 +9,7 @@ import { useBoard, useProfile, useUpdateBoard, useLinkBoardToGym } from '../../s
 import { useActiveBoard, useSetActiveBoard } from '../../src/lib/graphql/use-active-board';
 import {
   extractGraphqlMessage,
+  isBoardLimitError,
   isDuplicateBoardError,
   readDuplicateBoardError,
 } from '../../src/lib/graphql/extract-error-message';
@@ -234,6 +235,16 @@ function EditBoardForm({ board }: { board: UserBoard }) {
               },
             ],
           );
+          return;
+        }
+        // Restoring a soft-deleted board while the owner is already at the
+        // 50-board cap adds a live board, so the server can reject an edit the
+        // same way it rejects a create. Same actionable copy as create's cap
+        // message — the fix is the same (delete one you don't use) — rather
+        // than the raw server message.
+        if (isBoardLimitError(error)) {
+          setUpdateError(t('mobile.create.limitReached'));
+          setSubmitting(false);
           return;
         }
         // Covers the config-locked race and everything else the server enforces

--- a/packages/mobile/app/boards/edit.tsx
+++ b/packages/mobile/app/boards/edit.tsx
@@ -1,12 +1,18 @@
-import { useCallback, useMemo, useState } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { Alert, View, StyleSheet } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { toBoardName } from '@boardsesh/board-config';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { useBoard, useProfile, useUpdateBoard, useLinkBoardToGym } from '../../src/lib/graphql/hooks';
 import { useActiveBoard, useSetActiveBoard } from '../../src/lib/graphql/use-active-board';
-import { extractGraphqlMessage } from '../../src/lib/graphql/extract-error-message';
+import {
+  extractGraphqlMessage,
+  isDuplicateBoardError,
+  readDuplicateBoardError,
+} from '../../src/lib/graphql/extract-error-message';
+import { track } from '../../src/lib/analytics';
 import { useAuth } from '../../src/providers/auth-provider';
 import { hapticSelection } from '../../src/lib/haptics';
 import { useBoardBuilder, type BoardBuilderSeed } from '../../src/components/board-discovery/use-board-builder';
@@ -143,63 +149,120 @@ function EditBoardForm({ board }: { board: UserBoard }) {
   const [submitting, setSubmitting] = useState(false);
   const [updateError, setUpdateError] = useState<string | null>(null);
 
-  const handleUpdate = useCallback(async () => {
-    if (submitting) return;
-    const input = builder.buildUpdateInput(board.uuid, { lockedConfig, fallbackName: defaultName });
-    if (!input) return;
-    setSubmitting(true);
-    setUpdateError(null);
-    hapticSelection();
-    try {
-      const updated = await updateBoard.mutateAsync(input);
+  // `Alert.alert`'s confirm fires long after `handleUpdate` returns, so the
+  // "save anyway" retry can't call `handleUpdate` from inside its own body. The
+  // ref always points at the current one, and by the time the user taps,
+  // `submitting` has been cleared so the retry isn't swallowed by the guard.
+  const handleUpdateRef = useRef<((options?: { allowDuplicateConfig?: boolean }) => Promise<void>) | null>(null);
 
-      // `UpdateBoardInput` carries no gym, so a changed gym is its own mutation.
-      // It can be rejected on its own terms (too far from a gym the user doesn't
-      // run), so it's reported separately rather than failing the whole save.
-      const nextGymUuid = builder.selectedGym?.uuid ?? null;
-      let gymLinkError: string | null = null;
-      if (nextGymUuid !== (board.gymUuid ?? null)) {
-        try {
-          await linkBoardToGym.mutateAsync({ boardUuid: board.uuid, gymUuid: nextGymUuid });
-        } catch (error) {
-          gymLinkError = extractGraphqlMessage(error) ?? t('mobile.gymPicker.linkError');
+  const handleUpdate = useCallback(
+    async (options?: { allowDuplicateConfig?: boolean }) => {
+      if (submitting) return;
+      const input = builder.buildUpdateInput(board.uuid, {
+        lockedConfig,
+        fallbackName: defaultName,
+        currentConfig: { layoutId: board.layoutId, sizeId: board.sizeId, setIds: board.setIds },
+      });
+      if (!input) return;
+      setSubmitting(true);
+      setUpdateError(null);
+      hapticSelection();
+      try {
+        const updated = await updateBoard.mutateAsync({
+          ...input,
+          allowDuplicateConfig: options?.allowDuplicateConfig || undefined,
+        });
+
+        // `UpdateBoardInput` carries no gym, so a changed gym is its own mutation.
+        // It can be rejected on its own terms (too far from a gym the user doesn't
+        // run), so it's reported separately rather than failing the whole save.
+        const nextGymUuid = builder.selectedGym?.uuid ?? null;
+        let gymLinkError: string | null = null;
+        if (nextGymUuid !== (board.gymUuid ?? null)) {
+          try {
+            await linkBoardToGym.mutateAsync({ boardUuid: board.uuid, gymUuid: nextGymUuid });
+          } catch (error) {
+            gymLinkError = extractGraphqlMessage(error) ?? t('mobile.gymPicker.linkError');
+          }
         }
-      }
 
-      // The active board is a denormalised AsyncStorage copy — re-persist it so
-      // the rename / angle / visibility change reaches BLE + the play drawer.
-      // This runs even when the gym link failed: the rest of the edit DID save,
-      // and bailing early left the stored copy stale against the server.
-      if (activeBoard?.uuid === updated.uuid) await setActiveBoard(updated);
+        // The active board is a denormalised AsyncStorage copy — re-persist it so
+        // the rename / angle / visibility change reaches BLE + the play drawer.
+        // This runs even when the gym link failed: the rest of the edit DID save,
+        // and bailing early left the stored copy stale against the server.
+        if (activeBoard?.uuid === updated.uuid) await setActiveBoard(updated);
 
-      if (gymLinkError) {
-        setUpdateError(gymLinkError);
+        if (gymLinkError) {
+          setUpdateError(gymLinkError);
+          setSubmitting(false);
+          return;
+        }
+        router.back();
+        // Navigated away on success — leave `submitting` set (unmounting).
+      } catch (error) {
+        // A duplicate config is a question, not a failure: the same wall really
+        // can exist twice (home and gym), so ask before refusing the edit. Not
+        // BoardDuplicatePromptSheet — its "use that board instead" is a create
+        // -flow escape hatch, and there is nothing to switch to when the user is
+        // editing a board they already have open.
+        if (isDuplicateBoardError(error)) {
+          // Null whenever the editor is not the board's owner — the server
+          // withholds the colliding board's name and place from gym admins and
+          // moderators, so the prompt has to work without them.
+          const duplicate = readDuplicateBoardError(error);
+          track(SHARED_EVENTS.BoardDuplicatePrompted, {
+            boardType: board.boardType,
+            source: 'mobile_edit',
+            hasLocation: !!input.locationName,
+          });
+          setSubmitting(false);
+          Alert.alert(
+            t('mobile.edit.duplicate.title'),
+            duplicate?.boardName
+              ? duplicate.locationName
+                ? t('mobile.edit.duplicate.bodyWithLocation', {
+                    name: duplicate.boardName,
+                    location: duplicate.locationName,
+                  })
+                : t('mobile.edit.duplicate.body', { name: duplicate.boardName })
+              : t('mobile.edit.duplicate.bodyGeneric'),
+            [
+              { text: t('mobile.edit.duplicate.keepEditing'), style: 'cancel' },
+              {
+                text: t('mobile.edit.duplicate.saveAnyway'),
+                onPress: () => void handleUpdateRef.current?.({ allowDuplicateConfig: true }),
+              },
+            ],
+          );
+          return;
+        }
+        // Covers the config-locked race and everything else the server enforces
+        // authoritatively. Inline, not a toast: this is a `presentation: 'modal'`
+        // route and the toast overlay draws behind it.
+        setUpdateError(extractGraphqlMessage(error) ?? t('mobile.edit.updateError'));
         setSubmitting(false);
-        return;
       }
-      router.back();
-      // Navigated away on success — leave `submitting` set (unmounting).
-    } catch (error) {
-      // Covers the config-locked race and the duplicate-config guard, both of
-      // which the server enforces authoritatively. Inline, not a toast: this is
-      // a `presentation: 'modal'` route and the toast overlay draws behind it.
-      setUpdateError(extractGraphqlMessage(error) ?? t('mobile.edit.updateError'));
-      setSubmitting(false);
-    }
-  }, [
-    submitting,
-    builder,
-    board.uuid,
-    board.gymUuid,
-    lockedConfig,
-    defaultName,
-    updateBoard,
-    linkBoardToGym,
-    activeBoard?.uuid,
-    setActiveBoard,
-    router,
-    t,
-  ]);
+    },
+    [
+      submitting,
+      builder,
+      board.uuid,
+      board.gymUuid,
+      board.boardType,
+      board.layoutId,
+      board.sizeId,
+      board.setIds,
+      lockedConfig,
+      defaultName,
+      updateBoard,
+      linkBoardToGym,
+      activeBoard?.uuid,
+      setActiveBoard,
+      router,
+      t,
+    ],
+  );
+  handleUpdateRef.current = handleUpdate;
 
   return (
     <BoardForm

--- a/packages/mobile/src/components/board-discovery/__tests__/use-board-builder.test.tsx
+++ b/packages/mobile/src/components/board-discovery/__tests__/use-board-builder.test.tsx
@@ -185,4 +185,54 @@ describe('useBoardBuilder', () => {
     const { result } = renderHook(() => useBoardBuilder());
     expect(result.current.buildUpdateInput('board-uuid-1')).toBeNull();
   });
+
+  // Without this the form resent the board's own config on every save, the server
+  // read that as a config change and ran its duplicate guard — so an owner of two
+  // same-config boards could not even rename one of them.
+  it('omits the config from the update input when it matches the board on file', () => {
+    const { result } = renderHook(() =>
+      useBoardBuilder({ boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '20,1' }),
+    );
+    const input = result.current.buildUpdateInput('board-uuid-1', {
+      currentConfig: { layoutId: 1, sizeId: 10, setIds: '20,1' },
+    });
+    expect(input?.name).toBeDefined();
+    expect(input?.layoutId).toBeUndefined();
+    expect(input?.sizeId).toBeUndefined();
+    expect(input?.setIds).toBeUndefined();
+  });
+
+  it('treats a reordered stored setIds as unchanged', () => {
+    // Stored order is whatever the board was created with, so the comparison has
+    // to normalise both sides or every save of an old board looks like a change.
+    const { result } = renderHook(() =>
+      useBoardBuilder({ boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '20,1' }),
+    );
+    const input = result.current.buildUpdateInput('board-uuid-1', {
+      currentConfig: { layoutId: 1, sizeId: 10, setIds: '1,20' },
+    });
+    expect(input?.setIds).toBeUndefined();
+  });
+
+  it('includes the config when it differs from the board on file', () => {
+    const { result } = renderHook(() =>
+      useBoardBuilder({ boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '20,1' }),
+    );
+    const input = result.current.buildUpdateInput('board-uuid-1', {
+      currentConfig: { layoutId: 1, sizeId: 11, setIds: '20,1' },
+    });
+    expect(input?.layoutId).toBe(1);
+    expect(input?.sizeId).toBe(10);
+    expect(input?.setIds).toBe('1,20');
+  });
+
+  it('includes the config when no current config is supplied', () => {
+    const { result } = renderHook(() =>
+      useBoardBuilder({ boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '20,1' }),
+    );
+    const input = result.current.buildUpdateInput('board-uuid-1');
+    expect(input?.layoutId).toBe(1);
+    expect(input?.sizeId).toBe(10);
+    expect(input?.setIds).toBe('1,20');
+  });
 });

--- a/packages/mobile/src/components/board-discovery/use-board-builder.ts
+++ b/packages/mobile/src/components/board-discovery/use-board-builder.ts
@@ -218,16 +218,28 @@ export function useBoardBuilder(seed?: BoardBuilderSeed | null) {
 
   /**
    * The validated UpdateBoardInput for `boardUuid`, or null when the config is
-   * incomplete. Name/angle/visibility/location/serial are always editable. The
-   * config (layout/size/sets) is sent only when `lockedConfig` is false — the
-   * server rejects config changes on boards that already have ticks, and an
-   * unchanged config would still trip its duplicate-config guard, so we omit it.
+   * incomplete. Name/angle/visibility/location/serial are always editable.
+   *
+   * The config (layout/size/sets) is sent only when it is both unlocked and
+   * genuinely different from `currentConfig`. `lockedConfig` means the viewer may
+   * not change it at all. The unchanged case matters just as much: the form is
+   * seeded with the board's own config, so every save used to resend it, the
+   * server saw "config fields present" and ran its duplicate-config guard against
+   * a config that never moved — which is how renaming one of two same-config
+   * boards ended up rejected for colliding with its sibling. Set ids are compared
+   * normalised, since the stored order is whatever the board was created with.
+   *
    * Emptied location/serial are sent as `null` so editing them to blank clears
    * the stored value (vs `buildCreateInput`, which has nothing to clear).
    */
   const buildUpdateInput = (
     boardUuid: string,
-    options?: { lockedConfig?: boolean; fallbackName?: string },
+    options?: {
+      lockedConfig?: boolean;
+      fallbackName?: string;
+      /** The board's stored config, so an unchanged config is left out of the input. */
+      currentConfig?: { layoutId: number; sizeId: number; setIds: string };
+    },
   ): UpdateBoardInput | null => {
     if (layoutId == null || sizeId == null || setIds.length === 0) return null;
     const input: UpdateBoardInput = {
@@ -247,10 +259,17 @@ export function useBoardBuilder(seed?: BoardBuilderSeed | null) {
       latitude: coords?.latitude,
       longitude: coords?.longitude,
     };
-    if (!options?.lockedConfig) {
+    const nextSetIds = normaliseSetIds(setIds.join(','));
+    const currentConfig = options?.currentConfig;
+    const configUnchanged =
+      currentConfig != null &&
+      currentConfig.layoutId === layoutId &&
+      currentConfig.sizeId === sizeId &&
+      normaliseSetIds(currentConfig.setIds) === nextSetIds;
+    if (!options?.lockedConfig && !configUnchanged) {
       input.layoutId = layoutId;
       input.sizeId = sizeId;
-      input.setIds = normaliseSetIds(setIds.join(','));
+      input.setIds = nextSetIds;
     }
     return input;
   };

--- a/packages/mobile/src/lib/graphql/extract-error-message.ts
+++ b/packages/mobile/src/lib/graphql/extract-error-message.ts
@@ -83,7 +83,7 @@ export function isExpectedBetaValidationError(error: unknown): boolean {
   );
 }
 
-// createBoard's duplicate rejection is parsed in @boardsesh/graphql so web and
-// mobile branch on the same shape. Re-exported here so board screens keep a
-// single import for GraphQL error handling.
-export { readDuplicateBoardError, type DuplicateBoardError } from '@boardsesh/graphql/errors';
+// The board-mutation rejections clients branch on are parsed in
+// @boardsesh/graphql so web and mobile read the same shapes. Re-exported here so
+// board screens keep a single import for GraphQL error handling.
+export { readDuplicateBoardError, isBoardLimitError, type DuplicateBoardError } from '@boardsesh/graphql/errors';

--- a/packages/mobile/src/lib/graphql/extract-error-message.ts
+++ b/packages/mobile/src/lib/graphql/extract-error-message.ts
@@ -86,4 +86,9 @@ export function isExpectedBetaValidationError(error: unknown): boolean {
 // The board-mutation rejections clients branch on are parsed in
 // @boardsesh/graphql so web and mobile read the same shapes. Re-exported here so
 // board screens keep a single import for GraphQL error handling.
-export { readDuplicateBoardError, isBoardLimitError, type DuplicateBoardError } from '@boardsesh/graphql/errors';
+export {
+  isDuplicateBoardError,
+  readDuplicateBoardError,
+  isBoardLimitError,
+  type DuplicateBoardError,
+} from '@boardsesh/graphql/errors';

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -2518,6 +2518,13 @@ input UpdateBoardInput {
   serialNumber: String
   "Paired Rogue Fitness timer's advertised BLE name"
   timerName: String
+  """
+  Save this edit even though the board's owner already has another board with
+  the resulting configuration at the same place. Set only after the user has
+  confirmed it is a physically different wall (another gym, another room) —
+  never by default.
+  """
+  allowDuplicateConfig: Boolean
 }
 
 """

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -7395,6 +7395,13 @@ export type UpdateAppFeedbackStatusInput = {
 
 /** Input for updating a board. */
 export type UpdateBoardInput = {
+  /**
+   * Save this edit even though the board's owner already has another board with
+   * the resulting configuration at the same place. Set only after the user has
+   * confirmed it is a physically different wall (another gym, another room) —
+   * never by default.
+   */
+  allowDuplicateConfig?: InputMaybe<Scalars['Boolean']['input']>;
   /** New default angle */
   angle?: InputMaybe<Scalars['Int']['input']>;
   /** Board UUID to update */

--- a/packages/shared-schema/src/schema/board-entities.ts
+++ b/packages/shared-schema/src/schema/board-entities.ts
@@ -251,6 +251,13 @@ export const boardEntitiesTypeDefs = /* GraphQL */ `
     serialNumber: String
     "Paired Rogue Fitness timer's advertised BLE name"
     timerName: String
+    """
+    Save this edit even though the board's owner already has another board with
+    the resulting configuration at the same place. Set only after the user has
+    confirmed it is a physically different wall (another gym, another room) —
+    never by default.
+    """
+    allowDuplicateConfig: Boolean
   }
 
   """

--- a/packages/shared-schema/src/types/board-entities.ts
+++ b/packages/shared-schema/src/types/board-entities.ts
@@ -118,6 +118,12 @@ export type UpdateBoardInput = {
   setIds?: string;
   serialNumber?: string | null;
   timerName?: string | null;
+  /**
+   * Save even though the owner already has another board with the resulting
+   * configuration at this place. Set only after the user confirms it is a
+   * different physical wall.
+   */
+  allowDuplicateConfig?: boolean;
 };
 
 export type BoardLeaderboardInput = {

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -258,15 +258,21 @@ export const SHARED_EVENTS = {
   //          hasLocationName, hasCoords, hasGym, source, allowedDuplicate }.
   BoardCreated: 'Board Created',
   // Props: { boardType, source, error_reason: 'duplicate_config' | 'rate_limited'
-  //          | 'auth' | 'exception' }.
+  //          | 'auth' | 'board_limit' | 'exception' }. 'board_limit' is the
+  //          per-account board cap: a refusal no retry can clear, so it is worth
+  //          keeping out of the 'exception' bucket.
   BoardCreateFailed: 'Board Create Failed',
   // The user already owned this board, so nothing was created and we activated
   // the existing one instead. Props: { boardType, source }.
   BoardCreateReusedExisting: 'Board Create Reused Existing',
-  // The duplicate choice sheet was shown. The watchdog for #4166 is that
+  // The duplicate choice prompt was shown. The watchdog for #4166 is that
   // Prompted >= ReusedExisting + Created{allowedDuplicate}: if prompts stop
   // converting, creation is silently dead-ending again.
-  // Props: { boardType, source, hasLocation }.
+  // Props: { boardType, source, hasLocation }. `source` names the surface AND the
+  // flow: 'popular_seed' / 'scratch' / 'web_drawer' are creates; 'mobile_edit' /
+  // 'web_edit_drawer' are edits, where the choice is save-anyway vs keep-editing
+  // (there is no existing board to switch to), so they never convert to
+  // ReusedExisting — split on `source` before reading that ratio.
   BoardDuplicatePrompted: 'Board Duplicate Prompted',
   // Board presence — "now on the wall" (board-level collaboration, keyed on the
   // shared board_id resolved from the BLE serial). `boardId` is attached as an

--- a/packages/shared/graphql/src/errors.ts
+++ b/packages/shared/graphql/src/errors.ts
@@ -34,10 +34,24 @@ export type DuplicateBoardError = {
 };
 
 /**
- * The "you already own this board at this place" rejection, with the existing
- * board's identity attached. Both `createBoard` and `updateBoard` throw it —
- * create when a new board would land on one you own, update when a config change
- * would make an existing board match a sibling.
+ * The "you already own this board at this place" rejection, whether or not the
+ * server attached the colliding board's identity. Both `createBoard` and
+ * `updateBoard` throw it — create when a new board would land on one you own,
+ * update when a config change would make an existing board match a sibling.
+ *
+ * Use this to decide WHETHER to prompt, and `readDuplicateBoardError` to decide
+ * what to name in the prompt: `updateBoard` strips the identity extensions when
+ * the editor is not the board's owner (a gym admin, a community moderator), so
+ * a duplicate that a non-owner hit carries the code and nothing else.
+ */
+export function isDuplicateBoardError(error: unknown): boolean {
+  return getGraphqlErrors(error).some((graphqlError) => graphqlError.extensions?.code === 'BOARD_DUPLICATE_CONFIG');
+}
+
+/**
+ * The identity of the board the server refused to duplicate, or null when the
+ * server withheld it (see `isDuplicateBoardError` — a non-owner editor gets the
+ * bare code) or the error is something else entirely.
  *
  * Not a failure to report — the user chooses between using that board and
  * keeping a genuinely different one, and the mutation is retried with

--- a/packages/shared/graphql/src/errors.ts
+++ b/packages/shared/graphql/src/errors.ts
@@ -23,7 +23,7 @@ function asString(value: unknown): string | null {
   return typeof value === 'string' && value.length > 0 ? value : null;
 }
 
-/** The board `createBoard` refused to duplicate, as named by the server. */
+/** The board the server refused to duplicate, as named by the server. */
 export type DuplicateBoardError = {
   boardUuid: string;
   boardName: string;
@@ -34,11 +34,13 @@ export type DuplicateBoardError = {
 };
 
 /**
- * `createBoard`'s "you already own this board at this place" rejection, with the
- * existing board's identity attached.
+ * The "you already own this board at this place" rejection, with the existing
+ * board's identity attached. Both `createBoard` and `updateBoard` throw it —
+ * create when a new board would land on one you own, update when a config change
+ * would make an existing board match a sibling.
  *
- * Not a failure to report — the user chooses between using that board and adding
- * a genuinely different one, and the create is retried with
+ * Not a failure to report — the user chooses between using that board and
+ * keeping a genuinely different one, and the mutation is retried with
  * `allowDuplicateConfig`. The board's identity comes off the error rather than
  * out of a client's `myBoards` cache, which is paginated and can't be searched
  * reliably (#4166).

--- a/packages/shared/graphql/src/errors.ts
+++ b/packages/shared/graphql/src/errors.ts
@@ -63,3 +63,12 @@ export function readDuplicateBoardError(error: unknown): DuplicateBoardError | n
   }
   return null;
 }
+
+/**
+ * The server refusing to add another board because the account is at its
+ * ceiling. Worth branching on rather than surfacing as a generic failure: the
+ * fix is to delete a board the climber no longer uses, not to retry.
+ */
+export function isBoardLimitError(error: unknown): boolean {
+  return getGraphqlErrors(error).some((graphqlError) => graphqlError.extensions?.code === 'BOARD_LIMIT_REACHED');
+}

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -7392,6 +7392,13 @@ export type UpdateAppFeedbackStatusInput = {
 
 /** Input for updating a board. */
 export type UpdateBoardInput = {
+  /**
+   * Save this edit even though the board's owner already has another board with
+   * the resulting configuration at the same place. Set only after the user has
+   * confirmed it is a physically different wall (another gym, another room) —
+   * never by default.
+   */
+  allowDuplicateConfig?: InputMaybe<Scalars['Boolean']['input']>;
   /** New default angle */
   angle?: InputMaybe<Scalars['Int']['input']>;
   /** Board UUID to update */

--- a/packages/shared/i18n/locales/de/boards.json
+++ b/packages/shared/i18n/locales/de/boards.json
@@ -362,6 +362,7 @@
       "submit": "Board anlegen",
       "authRequired": "Du musst angemeldet sein, um ein Board anzulegen",
       "errorMessage": "Board konnte nicht angelegt werden. Vielleicht gibt es für diese Konfiguration schon eins.",
+      "limitReached": "Du hast die maximale Anzahl Boards für ein Konto erreicht. Lösch ein Board, das du nicht mehr nutzt, um ein neues anzulegen.",
       "goToExisting": "Zu deinem Board",
       "nameRequired": "Board-Name ist Pflicht",
       "createdNamed": "Board „{{name}}“ angelegt!",
@@ -405,6 +406,13 @@
       "location": "Standort",
       "setup": "Setup",
       "visibility": "Sichtbarkeit"
+    },
+    "edit": {
+      "duplicateTitle": "Dieses Setup hast du schon",
+      "duplicateBody": "Mit dieser Änderung ist das Board identisch mit „{{name}}“ — gleiches Layout, gleiche Größe, gleiche Hold-Sets.",
+      "duplicateBodyGeneric": "Mit dieser Änderung ist das Board identisch mit einem anderen Board desselben Kontos.",
+      "saveAnyway": "Trotzdem speichern",
+      "keepEditing": "Abbrechen"
     }
   },
   "editBoard": {

--- a/packages/shared/i18n/locales/de/boards.json
+++ b/packages/shared/i18n/locales/de/boards.json
@@ -118,7 +118,6 @@
       "location": "Standort",
       "locationPlaceholder": "Zuhause, Hallenname oder Stadt",
       "useMyLocation": "Meinen Standort nutzen",
-      "locationSet": "Standort gesetzt",
       "serial": "Controller-Seriennummer",
       "serialPlaceholder": "z. B. ABC-12345",
       "serialHint": "Optional — dein Controller verknüpft sich beim ersten Verbinden selbst.",
@@ -129,7 +128,20 @@
       "timerHint": "Koppel einen Rogue-Hallentimer mit diesem Board. Solange du die Wand steuerst, startet jeder beleuchtete Boulder die Stoppuhr.",
       "timerPairCta": "Timer koppeln",
       "timerChangeCta": "Timer wechseln",
-      "timerRemoveCta": "Entfernen"
+      "timerRemoveCta": "Entfernen",
+      "gym": "Halle",
+      "gymNone": "Nicht in einer Halle",
+      "clearLocation": "Standort löschen",
+      "duplicate": {
+        "title": "Dieses Setup hast du schon",
+        "body": "Du hast „{{name}}“ schon — gleiches Layout, gleiche Größe, gleiche Hold-Sets.",
+        "bodyWithLocation": "Du hast „{{name}}“ schon in {{location}} — gleiches Layout, gleiche Größe, gleiche Hold-Sets.",
+        "useExisting": "Dieses Board nutzen",
+        "addAnother": "Neues Board hier anlegen",
+        "addAnotherHint": "Nimm das, wenn es eine andere Wand ist — andere Halle, anderer Raum.",
+        "cancel": "Weiter bearbeiten",
+        "switchError": "Zu diesem Board konnte nicht gewechselt werden. Versuch es nochmal."
+      }
     },
     "custom": {
       "board": "Board",
@@ -264,6 +276,12 @@
       "available": "Offline verfügbar",
       "pending": "Wartet auf Download",
       "bootstrapping": "Board wird geladen…",
+      "snapshotRetrying": "Schnellerer Download unterbrochen — neuer Versuch beim nächsten Sync",
+      "snapshotRetryingAria": "Der schnellere Offline-Download für {{name}} wurde unterbrochen. Beim nächsten Sync folgt ein neuer Versuch.",
+      "pagedFallbackPending": "Schnellerer Download nicht verfügbar — langsamerer Download wartet",
+      "pagedFallbackPendingAria": "Der schnellere Offline-Download für {{name}} ist nicht verfügbar. Der langsamere Download wartet.",
+      "pagedFallbackActive": "Schnellerer Download nicht verfügbar — läuft über den langsameren",
+      "pagedFallbackActiveAria": "Der schnellere Offline-Download für {{name}} ist nicht verfügbar. Der langsamere Download läuft.",
       "downloadingCount_one": "{{count}} Boulder wird geladen",
       "downloadingCount_other": "{{count}} Boulder werden geladen",
       "makeAvailableAria": "{{name}} offline verfügbar machen",
@@ -276,6 +294,17 @@
       "pickerNoticeUnreachable": "Deine Boards sind gerade nicht erreichbar — hier sind die heruntergeladenen.",
       "pickerEmptyTitle": "Noch nichts heruntergeladen",
       "pickerEmptyBody": "Boards, die du offline verfügbar machst, tauchen hier auf. Hol dir eins, solange du Empfang hast."
+    },
+    "gymPicker": {
+      "title": "Wo steht dieses Board?",
+      "subtitle": "Wähl die Halle, in der es steht, damit Kletterer*innen es auf der Karte finden.",
+      "searchPlaceholder": "Hallen suchen",
+      "noGym": "Nicht in einer Halle",
+      "noGymHint": "Es erscheint trotzdem als eigener Pin auf der Karte.",
+      "addNew": "Meine Halle fehlt in der Liste",
+      "empty": "Keine Hallen in der Nähe",
+      "sharedEditHint": "Das Team dieser Halle kann die Details dieses Boards bearbeiten.",
+      "linkError": "Diese Halle ließ sich nicht verknüpfen. Vielleicht ist sie zu weit von deinem Board entfernt. Deine übrigen Änderungen wurden gespeichert."
     }
   },
   "boardEntity": {
@@ -324,12 +353,15 @@
       "submit": "Board anlegen",
       "authRequired": "Du musst angemeldet sein, um ein Board anzulegen",
       "errorMessage": "Board konnte nicht angelegt werden. Vielleicht gibt es für diese Konfiguration schon eins.",
-      "duplicateNamed": "Du hast mit diesem Setup schon ein Board namens „{{name}}“.",
       "goToExisting": "Zu deinem Board",
       "nameRequired": "Board-Name ist Pflicht",
       "createdNamed": "Board „{{name}}“ angelegt!",
       "namePlaceholder": "z. B. Home Board, Hallenname",
-      "locationPlaceholder": "z. B. Stadt, Hallenname"
+      "locationPlaceholder": "z. B. Stadt, Hallenname",
+      "duplicateTitle": "Dieses Setup hast du schon",
+      "duplicateBody": "Du hast „{{name}}“ schon — gleiches Layout, gleiche Größe, gleiche Hold-Sets. Leg nur dann noch eins an, wenn es eine andere Wand ist.",
+      "addAnyway": "Trotzdem anlegen",
+      "keepEditing": "Abbrechen"
     },
     "fields": {
       "name": "Board-Name",

--- a/packages/shared/i18n/locales/de/boards.json
+++ b/packages/shared/i18n/locales/de/boards.json
@@ -410,6 +410,7 @@
     "edit": {
       "duplicateTitle": "Dieses Setup hast du schon",
       "duplicateBody": "Mit dieser Änderung ist das Board identisch mit „{{name}}“ — gleiches Layout, gleiche Größe, gleiche Hold-Sets.",
+      "duplicateBodyWithLocation": "Mit dieser Änderung ist das Board identisch mit „{{name}}“ in {{location}} — gleiches Layout, gleiche Größe, gleiche Hold-Sets.",
       "duplicateBodyGeneric": "Mit dieser Änderung ist das Board identisch mit einem anderen Board desselben Kontos.",
       "saveAnyway": "Trotzdem speichern",
       "cancel": "Abbrechen"

--- a/packages/shared/i18n/locales/de/boards.json
+++ b/packages/shared/i18n/locales/de/boards.json
@@ -412,7 +412,7 @@
       "duplicateBody": "Mit dieser Änderung ist das Board identisch mit „{{name}}“ — gleiches Layout, gleiche Größe, gleiche Hold-Sets.",
       "duplicateBodyGeneric": "Mit dieser Änderung ist das Board identisch mit einem anderen Board desselben Kontos.",
       "saveAnyway": "Trotzdem speichern",
-      "keepEditing": "Abbrechen"
+      "cancel": "Abbrechen"
     }
   },
   "editBoard": {

--- a/packages/shared/i18n/locales/de/boards.json
+++ b/packages/shared/i18n/locales/de/boards.json
@@ -37,7 +37,15 @@
       "notFound": "Dieses Board haben wir nicht gefunden",
       "noAccess": "Du darfst dieses Board nicht bearbeiten",
       "back": "Zurück",
-      "configLockedHint": "Du darfst Layout, Größe und Hold-Sets dieses Boards nicht ändern."
+      "configLockedHint": "Du darfst Layout, Größe und Hold-Sets dieses Boards nicht ändern.",
+      "duplicate": {
+        "title": "Dieses Setup hast du schon",
+        "body": "Mit dieser Änderung ist das Board identisch mit „{{name}}“ — gleiches Layout, gleiche Größe, gleiche Hold-Sets.",
+        "bodyWithLocation": "Mit dieser Änderung ist das Board identisch mit „{{name}}“ in {{location}} — gleiches Layout, gleiche Größe, gleiche Hold-Sets.",
+        "bodyGeneric": "Mit dieser Änderung ist das Board identisch mit einem anderen Board desselben Kontos.",
+        "saveAnyway": "Trotzdem speichern",
+        "keepEditing": "Weiter bearbeiten"
+      }
     },
     "gymEdit": {
       "screenTitle": "Halle bearbeiten",
@@ -123,6 +131,7 @@
       "serialHint": "Optional — dein Controller verknüpft sich beim ersten Verbinden selbst.",
       "save": "Mein Board speichern",
       "createError": "Dieses Board ließ sich nicht anlegen. Versuch es nochmal.",
+      "limitReached": "Du hast die maximale Anzahl Boards für ein Konto erreicht. Lösch ein Board, das du nicht mehr nutzt, um ein neues anzulegen.",
       "timer": "Workout-Timer",
       "timerNone": "Kein Timer gekoppelt",
       "timerHint": "Koppel einen Rogue-Hallentimer mit diesem Board. Solange du die Wand steuerst, startet jeder beleuchtete Boulder die Stoppuhr.",

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -412,7 +412,7 @@
       "duplicateBody": "This change makes the board match \"{{name}}\" — same layout, size and hold sets.",
       "duplicateBodyGeneric": "This change matches a board setup the owner already has.",
       "saveAnyway": "Save anyway",
-      "keepEditing": "Cancel"
+      "cancel": "Cancel"
     }
   },
   "editBoard": {

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -37,7 +37,15 @@
       "notFound": "We couldn't find that board",
       "noAccess": "You don't have permission to edit this board",
       "back": "Go back",
-      "configLockedHint": "You don't have permission to change this board's layout, size, or hold sets."
+      "configLockedHint": "You don't have permission to change this board's layout, size, or hold sets.",
+      "duplicate": {
+        "title": "You already have this setup",
+        "body": "This change makes the board match \"{{name}}\" — same layout, size and hold sets.",
+        "bodyWithLocation": "This change makes the board match \"{{name}}\" at {{location}} — same layout, size and hold sets.",
+        "bodyGeneric": "This change matches a board setup the owner already has.",
+        "saveAnyway": "Save anyway",
+        "keepEditing": "Keep editing"
+      }
     },
     "gymEdit": {
       "screenTitle": "Edit gym",
@@ -123,6 +131,7 @@
       "serialHint": "Optional — your controller links itself the first time you connect.",
       "save": "Save my board",
       "createError": "Couldn't create that board. Try again.",
+      "limitReached": "You've reached the maximum number of boards for one account. Delete a board you no longer use to add another.",
       "timer": "Workout timer",
       "timerNone": "No timer paired",
       "timerHint": "Pair a Rogue gym timer to this board. While you're driving the wall, every send starts its stopwatch.",

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -410,6 +410,7 @@
     "edit": {
       "duplicateTitle": "You already have this setup",
       "duplicateBody": "This change makes the board match \"{{name}}\" — same layout, size and hold sets.",
+      "duplicateBodyWithLocation": "This change makes the board match \"{{name}}\" at {{location}} — same layout, size and hold sets.",
       "duplicateBodyGeneric": "This change matches a board setup the owner already has.",
       "saveAnyway": "Save anyway",
       "cancel": "Cancel"

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -362,6 +362,7 @@
       "submit": "Create Board",
       "authRequired": "You must be signed in to create a board",
       "errorMessage": "Failed to create board. It may already exist for this configuration.",
+      "limitReached": "You've reached the maximum number of boards for one account. Delete a board you no longer use to add another.",
       "goToExisting": "Go to your board",
       "nameRequired": "Board name is required",
       "createdNamed": "Board \"{{name}}\" created!",
@@ -405,6 +406,13 @@
       "location": "Location",
       "setup": "Setup",
       "visibility": "Visibility"
+    },
+    "edit": {
+      "duplicateTitle": "You already have this setup",
+      "duplicateBody": "This change makes the board match \"{{name}}\" — same layout, size and hold sets.",
+      "duplicateBodyGeneric": "This change matches a board setup the owner already has.",
+      "saveAnyway": "Save anyway",
+      "keepEditing": "Cancel"
     }
   },
   "editBoard": {

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -362,6 +362,7 @@
       "submit": "Crear plafón",
       "authRequired": "Debes iniciar sesión para crear un plafón",
       "errorMessage": "Error al crear el plafón. Puede que ya exista para esta configuración.",
+      "limitReached": "Has llegado al número máximo de plafones para una cuenta. Borra uno que ya no uses para añadir otro.",
       "goToExisting": "Ir a tu plafón",
       "nameRequired": "Se requiere el nombre del plafón",
       "createdNamed": "¡Plafón \"{{name}}\" creado!",
@@ -405,6 +406,13 @@
       "location": "Ubicación",
       "setup": "Configuración",
       "visibility": "Visibilidad"
+    },
+    "edit": {
+      "duplicateTitle": "Ya tienes esta configuración",
+      "duplicateBody": "Con este cambio el plafón queda igual que «{{name}}»: mismo layout, tamaño y sets de presas.",
+      "duplicateBodyGeneric": "Con este cambio el plafón queda igual que otro que su propietario ya tiene.",
+      "saveAnyway": "Guardar igualmente",
+      "keepEditing": "Cancelar"
     }
   },
   "editBoard": {

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -37,7 +37,15 @@
       "notFound": "No encontramos ese plafón",
       "noAccess": "No tienes permiso para editar este plafón",
       "back": "Volver",
-      "configLockedHint": "No tienes permiso para cambiar el layout, el tamaño ni los sets de este plafón."
+      "configLockedHint": "No tienes permiso para cambiar el layout, el tamaño ni los sets de este plafón.",
+      "duplicate": {
+        "title": "Ya tienes esta configuración",
+        "body": "Con este cambio el plafón queda igual que «{{name}}»: mismo layout, tamaño y sets de presas.",
+        "bodyWithLocation": "Con este cambio el plafón queda igual que «{{name}}» en {{location}}: mismo layout, tamaño y sets de presas.",
+        "bodyGeneric": "Con este cambio el plafón queda igual que otro que su propietario ya tiene.",
+        "saveAnyway": "Guardar igualmente",
+        "keepEditing": "Seguir editando"
+      }
     },
     "gymEdit": {
       "screenTitle": "Editar gimnasio",
@@ -123,6 +131,7 @@
       "serialHint": "Opcional: tu controlador se vincula solo la primera vez que conectas.",
       "save": "Guardar mi plafón",
       "createError": "No se pudo crear ese plafón. Inténtalo de nuevo.",
+      "limitReached": "Has llegado al número máximo de plafones para una cuenta. Borra uno que ya no uses para añadir otro.",
       "timer": "Temporizador de entrenamiento",
       "timerNone": "Sin temporizador vinculado",
       "timerHint": "Vincula un temporizador Rogue a este plafón. Mientras controlas el muro, cada encadene arranca su cronómetro.",

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -410,6 +410,7 @@
     "edit": {
       "duplicateTitle": "Ya tienes esta configuración",
       "duplicateBody": "Con este cambio el plafón queda igual que «{{name}}»: mismo layout, tamaño y sets de presas.",
+      "duplicateBodyWithLocation": "Con este cambio el plafón queda igual que «{{name}}» en {{location}}: mismo layout, tamaño y sets de presas.",
       "duplicateBodyGeneric": "Con este cambio el plafón queda igual que otro que su propietario ya tiene.",
       "saveAnyway": "Guardar igualmente",
       "cancel": "Cancelar"

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -412,7 +412,7 @@
       "duplicateBody": "Con este cambio el plafón queda igual que «{{name}}»: mismo layout, tamaño y sets de presas.",
       "duplicateBodyGeneric": "Con este cambio el plafón queda igual que otro que su propietario ya tiene.",
       "saveAnyway": "Guardar igualmente",
-      "keepEditing": "Cancelar"
+      "cancel": "Cancelar"
     }
   },
   "editBoard": {

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -362,6 +362,7 @@
       "submit": "Créer la board",
       "authRequired": "Vous devez être connecté pour créer une board",
       "errorMessage": "Impossible de créer la board. Elle existe peut-être déjà pour cette configuration.",
+      "limitReached": "Vous avez atteint le nombre maximum de boards pour un compte. Supprimez une board que vous n'utilisez plus pour en ajouter une autre.",
       "goToExisting": "Aller à votre board",
       "nameRequired": "Le nom de la board est obligatoire",
       "createdNamed": "Board « {{name}} » créée !",
@@ -405,6 +406,13 @@
       "location": "Emplacement",
       "setup": "Configuration",
       "visibility": "Visibilité"
+    },
+    "edit": {
+      "duplicateTitle": "Vous avez déjà cette configuration",
+      "duplicateBody": "Avec ce changement, la board devient identique à « {{name}} » : même layout, même taille et mêmes sets de prises.",
+      "duplicateBodyGeneric": "Avec ce changement, la board devient identique à une autre que son propriétaire a déjà.",
+      "saveAnyway": "Enregistrer quand même",
+      "keepEditing": "Annuler"
     }
   },
   "editBoard": {

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -39,7 +39,7 @@
       "back": "Retour",
       "configLockedHint": "Vous n'avez pas la permission de modifier le layout, la taille ou les sets de cette board.",
       "duplicate": {
-        "title": "Tu as déjà cette configuration",
+        "title": "Vous avez déjà cette configuration",
         "body": "Avec ce changement, la board devient identique à « {{name}} » : même layout, même taille et mêmes sets de prises.",
         "bodyWithLocation": "Avec ce changement, la board devient identique à « {{name}} » à {{location}} : même layout, même taille et mêmes sets de prises.",
         "bodyGeneric": "Avec ce changement, la board devient identique à une autre que son propriétaire a déjà.",
@@ -412,7 +412,7 @@
       "duplicateBody": "Avec ce changement, la board devient identique à « {{name}} » : même layout, même taille et mêmes sets de prises.",
       "duplicateBodyGeneric": "Avec ce changement, la board devient identique à une autre que son propriétaire a déjà.",
       "saveAnyway": "Enregistrer quand même",
-      "keepEditing": "Annuler"
+      "cancel": "Annuler"
     }
   },
   "editBoard": {

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -410,6 +410,7 @@
     "edit": {
       "duplicateTitle": "Vous avez déjà cette configuration",
       "duplicateBody": "Avec ce changement, la board devient identique à « {{name}} » : même layout, même taille et mêmes sets de prises.",
+      "duplicateBodyWithLocation": "Avec ce changement, la board devient identique à « {{name}} » à {{location}} : même layout, même taille et mêmes sets de prises.",
       "duplicateBodyGeneric": "Avec ce changement, la board devient identique à une autre que son propriétaire a déjà.",
       "saveAnyway": "Enregistrer quand même",
       "cancel": "Annuler"

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -37,7 +37,15 @@
       "notFound": "Board introuvable",
       "noAccess": "Vous n'avez pas la permission de modifier cette board",
       "back": "Retour",
-      "configLockedHint": "Vous n'avez pas la permission de modifier le layout, la taille ou les sets de cette board."
+      "configLockedHint": "Vous n'avez pas la permission de modifier le layout, la taille ou les sets de cette board.",
+      "duplicate": {
+        "title": "Tu as déjà cette configuration",
+        "body": "Avec ce changement, la board devient identique à « {{name}} » : même layout, même taille et mêmes sets de prises.",
+        "bodyWithLocation": "Avec ce changement, la board devient identique à « {{name}} » à {{location}} : même layout, même taille et mêmes sets de prises.",
+        "bodyGeneric": "Avec ce changement, la board devient identique à une autre que son propriétaire a déjà.",
+        "saveAnyway": "Enregistrer quand même",
+        "keepEditing": "Continuer à modifier"
+      }
     },
     "gymEdit": {
       "screenTitle": "Modifier la salle",
@@ -123,6 +131,7 @@
       "serialHint": "Optionnel — ton contrôleur se lie tout seul à la première connexion.",
       "save": "Enregistrer ma board",
       "createError": "Impossible de créer cette board. Réessaie.",
+      "limitReached": "Tu as atteint le nombre maximum de boards pour un compte. Supprime une board que tu n'utilises plus pour en ajouter une autre.",
       "timer": "Minuteur d'entraînement",
       "timerNone": "Aucun minuteur associé",
       "timerHint": "Associe un minuteur Rogue à cette board. Quand tu pilotes le mur, chaque croix démarre son chronomètre.",

--- a/packages/web/app/components/board-entity/__tests__/create-board-form.test.tsx
+++ b/packages/web/app/components/board-entity/__tests__/create-board-form.test.tsx
@@ -189,6 +189,37 @@ describe('CreateBoardForm — handleCreateError', () => {
     expect(screen.queryByText('Add it anyway')).toBeNull();
   });
 
+  it('names the account cap instead of echoing the server message', async () => {
+    // 'board_limit' has to stay out of the 'exception' bucket: no retry clears
+    // it, and the way out (delete a board) belongs in our own copy.
+    const onError = renderAndGetOnError();
+
+    await act(async () => {
+      await onError(
+        {
+          response: {
+            errors: [
+              {
+                message: 'You have reached the maximum of 50 boards for one account',
+                extensions: { code: 'BOARD_LIMIT_REACHED', maxBoards: 50 },
+              },
+            ],
+          },
+        },
+        'You have reached the maximum of 50 boards for one account',
+      );
+    });
+
+    expect(mockShowMessage).toHaveBeenCalledWith(
+      "You've reached the maximum number of boards for one account. Delete a board you no longer use to add another.",
+      'error',
+    );
+    expect(mockTrack).toHaveBeenCalledWith(
+      'Board Create Failed',
+      expect.objectContaining({ error_reason: 'board_limit' }),
+    );
+  });
+
   it('ignores a malformed duplicate payload with no board uuid', async () => {
     const onError = renderAndGetOnError();
 

--- a/packages/web/app/components/board-entity/__tests__/edit-board-form.test.tsx
+++ b/packages/web/app/components/board-entity/__tests__/edit-board-form.test.tsx
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, act, screen } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import EditBoardForm from '../edit-board-form';
+
+// Editing a board reported the duplicate-config guard as a flat "Failed to
+// update board" with no way past it. Since #4174 an owner can hold the same wall
+// twice (home and gym) and `updateBoard` takes `allowDuplicateConfig`, so the
+// refusal is a question now.
+//
+// The other half: `updateBoard` is reachable by gym admins and community
+// moderators, and the server strips the colliding board's identity for them —
+// so the dialog also has to render with no board to name.
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+// vi.hoisted: the component is imported at the top of this file, so these mock
+// factories run before a plain `const` below would have initialised. (CI also
+// typechecks test files, so no spread-wrapped vi.fn.)
+const mockShowMessage = vi.hoisted(() => vi.fn());
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: mockShowMessage }),
+}));
+
+const mockTrack = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/analytics', () => ({ track: mockTrack }));
+
+const mockExecute = vi.hoisted(() => vi.fn());
+const errorHolder = vi.hoisted(() => ({
+  onError: null as ((error: unknown, serverMessage: string | null) => void) | null,
+}));
+vi.mock('@/app/hooks/use-entity-mutation', () => ({
+  useEntityMutation: (_mutation: unknown, opts: { onError?: (e: unknown, s: string | null) => void }) => {
+    errorHolder.onError = opts.onError ?? null;
+    return { execute: mockExecute };
+  },
+}));
+
+const SUBMIT_VALUES = {
+  name: 'Home Wall',
+  slug: 'home-wall',
+  description: '',
+  locationName: 'Garage',
+  isPublic: true,
+  isUnlisted: false,
+  hideLocation: false,
+  isOwned: true,
+  angle: 40,
+  layoutId: 1,
+  sizeId: 2,
+  setIds: 'set-1',
+};
+vi.mock('../board-form', () => ({
+  default: ({ onSubmit }: { onSubmit: (values: typeof SUBMIT_VALUES) => void }) =>
+    React.createElement(
+      'button',
+      { 'data-testid': 'board-form', type: 'button', onClick: () => onSubmit(SUBMIT_VALUES) },
+      'submit form',
+    ),
+}));
+
+vi.mock('@boardsesh/graphql/operations', () => ({ UPDATE_BOARD: 'UPDATE_BOARD' }));
+
+const board = {
+  uuid: 'board-uuid',
+  boardType: 'kilter',
+  slug: 'home-wall',
+  name: 'Home Wall',
+  description: null,
+  locationName: 'Garage',
+  latitude: null,
+  longitude: null,
+  isPublic: true,
+  isUnlisted: false,
+  hideLocation: false,
+  isOwned: true,
+  angle: 40,
+  isAngleAdjustable: true,
+  layoutId: 1,
+  sizeId: 2,
+  setIds: 'set-1',
+  serialNumber: null,
+  canEdit: true,
+} as unknown as import('@boardsesh/shared-schema').UserBoard;
+
+/** A graphql-request ClientError carrying the server's duplicate rejection. */
+function duplicateError(extensions: Record<string, unknown>) {
+  return {
+    response: {
+      errors: [{ message: 'You already have this board at this location', extensions }],
+    },
+  };
+}
+
+const ownerDuplicate = duplicateError({
+  code: 'BOARD_DUPLICATE_CONFIG',
+  existingBoardUuid: 'sibling-uuid',
+  existingBoardName: 'Garage Kilter',
+  existingBoardSlug: 'garage-kilter',
+  existingBoardLocationName: 'My Garage',
+});
+
+function renderAndGetOnError() {
+  render(React.createElement(EditBoardForm, { board }));
+  return errorHolder.onError!;
+}
+
+describe('EditBoardForm — duplicate config', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    errorHolder.onError = null;
+  });
+
+  it('sends no confirmation flag on a first save', async () => {
+    render(React.createElement(EditBoardForm, { board }));
+
+    await act(async () => {
+      screen.getByTestId('board-form').click();
+    });
+
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    expect(mockExecute.mock.calls[0][0].input.allowDuplicateConfig).toBeUndefined();
+  });
+
+  it('opens a dialog naming the colliding board instead of a failure toast', async () => {
+    const onError = renderAndGetOnError();
+
+    await act(async () => {
+      onError(ownerDuplicate, 'You already have this board at this location');
+    });
+
+    expect(screen.getByText(/Garage Kilter/)).toBeTruthy();
+    expect(mockShowMessage).not.toHaveBeenCalled();
+    expect(mockTrack).toHaveBeenCalledWith(
+      'Board Duplicate Prompted',
+      expect.objectContaining({ source: 'web_edit_drawer', boardType: 'kilter' }),
+    );
+  });
+
+  it('falls back to a generic body when the server stripped the board identity', async () => {
+    // What a gym admin or moderator gets: the code, and nothing that names a
+    // board they may have no read access to.
+    const onError = renderAndGetOnError();
+
+    await act(async () => {
+      onError(duplicateError({ code: 'BOARD_DUPLICATE_CONFIG' }), null);
+    });
+
+    expect(screen.getByText('This change matches a board setup the owner already has.')).toBeTruthy();
+    expect(mockShowMessage).not.toHaveBeenCalled();
+  });
+
+  it('replays the edit with allowDuplicateConfig when the user saves anyway', async () => {
+    const onError = renderAndGetOnError();
+
+    await act(async () => {
+      screen.getByTestId('board-form').click();
+    });
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      onError(ownerDuplicate, null);
+    });
+
+    await act(async () => {
+      screen.getByText('Save anyway').click();
+    });
+
+    expect(mockExecute).toHaveBeenCalledTimes(2);
+    // Same edit, now with the user's confirmation attached.
+    expect(mockExecute.mock.calls[1][0].input).toMatchObject({
+      boardUuid: 'board-uuid',
+      name: 'Home Wall',
+      allowDuplicateConfig: true,
+    });
+  });
+
+  it('leaves the edit alone when the user cancels', async () => {
+    const onError = renderAndGetOnError();
+
+    await act(async () => {
+      screen.getByTestId('board-form').click();
+    });
+
+    await act(async () => {
+      onError(ownerDuplicate, null);
+    });
+
+    await act(async () => {
+      screen.getByText('Cancel').click();
+    });
+
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it('still reports a non-duplicate failure through the snackbar', async () => {
+    const onError = renderAndGetOnError();
+
+    await act(async () => {
+      onError({ response: { errors: [{ extensions: { code: 'RATE_LIMITED' } }] } }, 'slow down');
+    });
+
+    expect(mockShowMessage).toHaveBeenCalledWith('slow down', 'error');
+    expect(screen.queryByText('Save anyway')).toBeNull();
+  });
+
+  it('falls back to the i18n error key when there is no server message', async () => {
+    const onError = renderAndGetOnError();
+
+    await act(async () => {
+      onError(new Error('boom'), null);
+    });
+
+    expect(mockShowMessage).toHaveBeenCalledWith('Failed to update board', 'error');
+  });
+});

--- a/packages/web/app/components/board-entity/__tests__/edit-board-form.test.tsx
+++ b/packages/web/app/components/board-entity/__tests__/edit-board-form.test.tsx
@@ -249,6 +249,38 @@ describe('EditBoardForm — duplicate config', () => {
     expect(mockExecute).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps the specific body on screen through the close transition instead of flashing the generic one', async () => {
+    // MUI's Dialog fade-out re-renders the still-mounted body while closing, so
+    // clearing the duplicate data on the same tick as the click used to swap
+    // the specific copy for the generic fallback for the ~300ms of the
+    // transition. The data now only clears on `onExited`, once the transition
+    // has actually finished, so it has to still be there right after the click.
+    const onError = renderAndGetOnError();
+
+    await act(async () => {
+      onError(ownerDuplicate, null);
+    });
+    expect(
+      screen.getByText(
+        'This change makes the board match "Garage Kilter" at My Garage — same layout, size and hold sets.',
+      ),
+    ).toBeTruthy();
+
+    await act(async () => {
+      screen.getByText('Cancel').click();
+    });
+
+    // The transition's `onExited` hasn't fired yet (it needs a real transition
+    // end, not just the click), so the specific body should still be showing —
+    // not the generic fallback the bug flashed instead.
+    expect(
+      screen.getByText(
+        'This change makes the board match "Garage Kilter" at My Garage — same layout, size and hold sets.',
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText('This change matches a board setup the owner already has.')).toBeNull();
+  });
+
   it('still reports a non-duplicate failure through the snackbar', async () => {
     const onError = renderAndGetOnError();
 

--- a/packages/web/app/components/board-entity/__tests__/edit-board-form.test.tsx
+++ b/packages/web/app/components/board-entity/__tests__/edit-board-form.test.tsx
@@ -182,6 +182,29 @@ describe('EditBoardForm — duplicate config', () => {
     });
   });
 
+  it('guards against a double-click on "Save anyway" firing two mutations', async () => {
+    const onError = renderAndGetOnError();
+
+    await act(async () => {
+      screen.getByTestId('board-form').click();
+    });
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      onError(ownerDuplicate, null);
+    });
+
+    // Two rapid clicks, fired before either retry has resolved — the
+    // in-flight guard should let only the first one through.
+    await act(async () => {
+      const saveAnyway = screen.getByText('Save anyway');
+      saveAnyway.click();
+      saveAnyway.click();
+    });
+
+    expect(mockExecute).toHaveBeenCalledTimes(2);
+  });
+
   it('leaves the edit alone when the user cancels', async () => {
     const onError = renderAndGetOnError();
 

--- a/packages/web/app/components/board-entity/__tests__/edit-board-form.test.tsx
+++ b/packages/web/app/components/board-entity/__tests__/edit-board-form.test.tsx
@@ -281,6 +281,23 @@ describe('EditBoardForm — duplicate config', () => {
     expect(screen.queryByText('This change matches a board setup the owner already has.')).toBeNull();
   });
 
+  it('toasts the account-cap copy instead of the dialog when restoring a soft-deleted board hits the limit', async () => {
+    // Saving a soft-deleted board restores it, which can land the owner back at
+    // the 50-board cap. Same copy as board creation — retrying never clears it,
+    // deleting a board does.
+    const onError = renderAndGetOnError();
+
+    await act(async () => {
+      onError(duplicateError({ code: 'BOARD_LIMIT_REACHED' }), null);
+    });
+
+    expect(mockShowMessage).toHaveBeenCalledWith(
+      "You've reached the maximum number of boards for one account. Delete a board you no longer use to add another.",
+      'error',
+    );
+    expect(screen.queryByText('Save anyway')).toBeNull();
+  });
+
   it('still reports a non-duplicate failure through the snackbar', async () => {
     const onError = renderAndGetOnError();
 

--- a/packages/web/app/components/board-entity/__tests__/edit-board-form.test.tsx
+++ b/packages/web/app/components/board-entity/__tests__/edit-board-form.test.tsx
@@ -107,6 +107,15 @@ const ownerDuplicate = duplicateError({
   existingBoardLocationName: 'My Garage',
 });
 
+// Same collision, but the sibling board has no location on file — the dialog
+// falls back to the name-only body instead of naming a place.
+const ownerDuplicateNoLocation = duplicateError({
+  code: 'BOARD_DUPLICATE_CONFIG',
+  existingBoardUuid: 'sibling-uuid',
+  existingBoardName: 'Garage Kilter',
+  existingBoardSlug: 'garage-kilter',
+});
+
 function renderAndGetOnError() {
   render(React.createElement(EditBoardForm, { board }));
   return errorHolder.onError!;
@@ -129,19 +138,36 @@ describe('EditBoardForm — duplicate config', () => {
     expect(mockExecute.mock.calls[0][0].input.allowDuplicateConfig).toBeUndefined();
   });
 
-  it('opens a dialog naming the colliding board instead of a failure toast', async () => {
+  it('names both the colliding board and its location instead of a failure toast', async () => {
     const onError = renderAndGetOnError();
 
     await act(async () => {
       onError(ownerDuplicate, 'You already have this board at this location');
     });
 
-    expect(screen.getByText(/Garage Kilter/)).toBeTruthy();
+    expect(
+      screen.getByText(
+        'This change makes the board match "Garage Kilter" at My Garage — same layout, size and hold sets.',
+      ),
+    ).toBeTruthy();
     expect(mockShowMessage).not.toHaveBeenCalled();
     expect(mockTrack).toHaveBeenCalledWith(
       'Board Duplicate Prompted',
       expect.objectContaining({ source: 'web_edit_drawer', boardType: 'kilter' }),
     );
+  });
+
+  it('falls back to the name-only body when the colliding board has no location on file', async () => {
+    const onError = renderAndGetOnError();
+
+    await act(async () => {
+      onError(ownerDuplicateNoLocation, null);
+    });
+
+    expect(
+      screen.getByText('This change makes the board match "Garage Kilter" — same layout, size and hold sets.'),
+    ).toBeTruthy();
+    expect(mockShowMessage).not.toHaveBeenCalled();
   });
 
   it('falls back to a generic body when the server stripped the board identity', async () => {

--- a/packages/web/app/components/board-entity/create-board-form.tsx
+++ b/packages/web/app/components/board-entity/create-board-form.tsx
@@ -15,7 +15,7 @@ import {
   type CreateBoardMutationVariables,
   type CreateBoardMutationResponse,
 } from '@boardsesh/graphql/operations';
-import { readDuplicateBoardError, type DuplicateBoardError } from '@boardsesh/graphql/errors';
+import { isBoardLimitError, readDuplicateBoardError, type DuplicateBoardError } from '@boardsesh/graphql/errors';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { track } from '@/app/lib/analytics';
 import { useLocaleRouter } from '@/app/lib/i18n/use-locale-router';
@@ -86,6 +86,18 @@ export default function CreateBoardForm({
       if (duplicateError) {
         track(SHARED_EVENTS.BoardDuplicatePrompted, { boardType, source: 'web_drawer' });
         setDuplicate(duplicateError);
+        return;
+      }
+      // The account cap gets its own copy: the server's message names the number,
+      // but what the climber needs is the way out — delete a board you don't use.
+      // Retrying will never clear this one, so it doesn't belong in 'exception'.
+      if (isBoardLimitError(error)) {
+        track(SHARED_EVENTS.BoardCreateFailed, {
+          boardType,
+          source: 'web_drawer',
+          error_reason: 'board_limit',
+        });
+        showMessage(t('boardForm.create.limitReached'), 'error');
         return;
       }
       track(SHARED_EVENTS.BoardCreateFailed, {

--- a/packages/web/app/components/board-entity/edit-board-form.tsx
+++ b/packages/web/app/components/board-entity/edit-board-form.tsx
@@ -70,6 +70,13 @@ export default function EditBoardForm({ board, onSuccess, onCancel, formId, onSu
   // moderator), so the dialog has to work without a board to name.
   const [duplicate, setDuplicate] = useState<{ name: string | null } | null>(null);
   const lastValuesRef = useRef<EditBoardFormValues | null>(null);
+  // `runUpdate` fires from two places — the drawer's Save button and the
+  // duplicate dialog's "Save anyway" retry — and neither is disabled while the
+  // other is in flight. A double-click on "Save anyway" during the dialog's
+  // close transition, or a Save click while a retry is still pending, could
+  // fire two updateBoard mutations. Mirrors the inFlightRef idiom in
+  // packages/mobile/app/boards/create.tsx.
+  const inFlightRef = useRef(false);
 
   const handleUpdateError = useCallback(
     (error: unknown, serverMessage: string | null) => {
@@ -78,7 +85,11 @@ export default function EditBoardForm({ board, onSuccess, onCancel, formId, onSu
       // through on a second pass with the user's confirmation attached.
       if (isDuplicateBoardError(error)) {
         setDuplicate({ name: readDuplicateBoardError(error)?.boardName || null });
-        track(SHARED_EVENTS.BoardDuplicatePrompted, { boardType: board.boardType, source: 'web_edit_drawer' });
+        track(SHARED_EVENTS.BoardDuplicatePrompted, {
+          boardType: board.boardType,
+          source: 'web_edit_drawer',
+          hasLocation: !!lastValuesRef.current?.locationName,
+        });
         return;
       }
       showMessage(serverMessage ?? t('editBoard.snackbar.updateFailed'), 'error');
@@ -103,35 +114,41 @@ export default function EditBoardForm({ board, onSuccess, onCancel, formId, onSu
 
   const runUpdate = useCallback(
     async (values: EditBoardFormValues, allowDuplicateConfig?: boolean) => {
-      const data = await execute({
-        input: {
-          boardUuid: board.uuid,
-          name: values.name,
-          slug: values.slug || undefined,
-          description: values.description || undefined,
-          locationName: values.locationName || undefined,
-          latitude: values.latitude ?? undefined,
-          longitude: values.longitude ?? undefined,
-          isPublic: values.isPublic,
-          isUnlisted: values.isUnlisted,
-          hideLocation: values.hideLocation,
-          isOwned: values.isOwned,
-          angle: values.angle,
-          isAngleAdjustable: values.isAngleAdjustable,
-          ...(configEditable
-            ? {
-                layoutId: values.layoutId,
-                sizeId: values.sizeId,
-                setIds: values.setIds,
-              }
-            : {}),
-          serialNumber: values.serialNumber,
-          allowDuplicateConfig: allowDuplicateConfig || undefined,
-        },
-      });
+      if (inFlightRef.current) return;
+      inFlightRef.current = true;
+      try {
+        const data = await execute({
+          input: {
+            boardUuid: board.uuid,
+            name: values.name,
+            slug: values.slug || undefined,
+            description: values.description || undefined,
+            locationName: values.locationName || undefined,
+            latitude: values.latitude ?? undefined,
+            longitude: values.longitude ?? undefined,
+            isPublic: values.isPublic,
+            isUnlisted: values.isUnlisted,
+            hideLocation: values.hideLocation,
+            isOwned: values.isOwned,
+            angle: values.angle,
+            isAngleAdjustable: values.isAngleAdjustable,
+            ...(configEditable
+              ? {
+                  layoutId: values.layoutId,
+                  sizeId: values.sizeId,
+                  setIds: values.setIds,
+                }
+              : {}),
+            serialNumber: values.serialNumber,
+            allowDuplicateConfig: allowDuplicateConfig || undefined,
+          },
+        });
 
-      if (data) {
-        onSuccess?.(data.updateBoard);
+        if (data) {
+          onSuccess?.(data.updateBoard);
+        }
+      } finally {
+        inFlightRef.current = false;
       }
     },
     [execute, board.uuid, onSuccess, configEditable],
@@ -203,7 +220,7 @@ export default function EditBoardForm({ board, onSuccess, onCancel, formId, onSu
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setDuplicate(null)}>{t('boardForm.edit.keepEditing')}</Button>
+          <Button onClick={() => setDuplicate(null)}>{t('boardForm.edit.cancel')}</Button>
           <Button onClick={() => void handleSaveAnyway()} variant="contained">
             {t('boardForm.edit.saveAnyway')}
           </Button>

--- a/packages/web/app/components/board-entity/edit-board-form.tsx
+++ b/packages/web/app/components/board-entity/edit-board-form.tsx
@@ -15,7 +15,7 @@ import {
   type UpdateBoardMutationVariables,
   type UpdateBoardMutationResponse,
 } from '@boardsesh/graphql/operations';
-import { isDuplicateBoardError, readDuplicateBoardError } from '@boardsesh/graphql/errors';
+import { isBoardLimitError, isDuplicateBoardError, readDuplicateBoardError } from '@boardsesh/graphql/errors';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { track } from '@/app/lib/analytics';
 import type { UserBoard } from '@boardsesh/shared-schema';
@@ -102,6 +102,13 @@ export default function EditBoardForm({ board, onSuccess, onCancel, formId, onSu
         });
         return;
       }
+      // Saving a soft-deleted board restores it, which can land the owner back
+      // at the 50-board cap. Same account-cap copy as board creation, since the
+      // way out (delete a board you don't use) is identical.
+      if (isBoardLimitError(error)) {
+        showMessage(t('boardForm.create.limitReached'), 'error');
+        return;
+      }
       showMessage(serverMessage ?? t('editBoard.snackbar.updateFailed'), 'error');
     },
     [board.boardType, showMessage, t],
@@ -149,7 +156,7 @@ export default function EditBoardForm({ board, onSuccess, onCancel, formId, onSu
                 }
               : {}),
             serialNumber: values.serialNumber,
-            allowDuplicateConfig: allowDuplicateConfig || undefined,
+            allowDuplicateConfig,
           },
         });
 

--- a/packages/web/app/components/board-entity/edit-board-form.tsx
+++ b/packages/web/app/components/board-entity/edit-board-form.tsx
@@ -1,7 +1,13 @@
 'use client';
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { useEntityMutation } from '@/app/hooks/use-entity-mutation';
 import {
@@ -9,11 +15,34 @@ import {
   type UpdateBoardMutationVariables,
   type UpdateBoardMutationResponse,
 } from '@boardsesh/graphql/operations';
+import { isDuplicateBoardError, readDuplicateBoardError } from '@boardsesh/graphql/errors';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { track } from '@/app/lib/analytics';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import type { BoardName } from '@/app/lib/types';
 import { ANGLES } from '@/app/lib/board-data';
 import { getBoardSelectorOptions } from '@/app/lib/board-constants';
 import BoardForm, { type BoardFormSubmitState } from './board-form';
+
+/** The values BoardForm hands back on submit. */
+type EditBoardFormValues = {
+  name: string;
+  slug?: string;
+  description: string;
+  locationName: string;
+  latitude?: number | null;
+  longitude?: number | null;
+  isPublic: boolean;
+  isUnlisted: boolean;
+  hideLocation: boolean;
+  isOwned: boolean;
+  angle?: number;
+  isAngleAdjustable?: boolean;
+  layoutId?: number;
+  sizeId?: number;
+  setIds?: string;
+  serialNumber?: string;
+};
 
 type EditBoardFormProps = {
   board: UserBoard;
@@ -35,9 +64,32 @@ export default function EditBoardForm({ board, onSuccess, onCancel, formId, onSu
 
   const availableAngles = ANGLES[board.boardType as BoardName] ?? [];
 
+  // The pending duplicate, if the last save was refused for that reason. `name`
+  // is null when the server withheld the colliding board's identity — it does
+  // that whenever the editor is not the board's owner (a gym admin, a community
+  // moderator), so the dialog has to work without a board to name.
+  const [duplicate, setDuplicate] = useState<{ name: string | null } | null>(null);
+  const lastValuesRef = useRef<EditBoardFormValues | null>(null);
+
+  const handleUpdateError = useCallback(
+    (error: unknown, serverMessage: string | null) => {
+      // A config collision is a question, not a failure: since #4174 the same
+      // wall can legitimately exist twice (home and gym), and the save goes
+      // through on a second pass with the user's confirmation attached.
+      if (isDuplicateBoardError(error)) {
+        setDuplicate({ name: readDuplicateBoardError(error)?.boardName || null });
+        track(SHARED_EVENTS.BoardDuplicatePrompted, { boardType: board.boardType, source: 'web_edit_drawer' });
+        return;
+      }
+      showMessage(serverMessage ?? t('editBoard.snackbar.updateFailed'), 'error');
+    },
+    [board.boardType, showMessage, t],
+  );
+
   const { execute } = useEntityMutation<UpdateBoardMutationResponse, UpdateBoardMutationVariables>(UPDATE_BOARD, {
     successMessage: t('editBoard.snackbar.updated'),
     errorMessage: t('editBoard.snackbar.updateFailed'),
+    onError: handleUpdateError,
   });
 
   const configEditable = useMemo(() => {
@@ -49,30 +101,8 @@ export default function EditBoardForm({ board, onSuccess, onCancel, formId, onSu
     return { boardType, layouts, sizes: options.sizes, sets: options.sets };
   }, [board.canEdit, board.boardType]);
 
-  const handleSubmit = useCallback(
-    async (values: {
-      name: string;
-      slug?: string;
-      description: string;
-      locationName: string;
-      latitude?: number | null;
-      longitude?: number | null;
-      isPublic: boolean;
-      isUnlisted: boolean;
-      hideLocation: boolean;
-      isOwned: boolean;
-      angle?: number;
-      isAngleAdjustable?: boolean;
-      layoutId?: number;
-      sizeId?: number;
-      setIds?: string;
-      serialNumber?: string;
-    }) => {
-      if (!values.name) {
-        showMessage(t('boardForm.create.nameRequired'), 'error');
-        return;
-      }
-
+  const runUpdate = useCallback(
+    async (values: EditBoardFormValues, allowDuplicateConfig?: boolean) => {
       const data = await execute({
         input: {
           boardUuid: board.uuid,
@@ -96,6 +126,7 @@ export default function EditBoardForm({ board, onSuccess, onCancel, formId, onSu
               }
             : {}),
           serialNumber: values.serialNumber,
+          allowDuplicateConfig: allowDuplicateConfig || undefined,
         },
       });
 
@@ -103,40 +134,81 @@ export default function EditBoardForm({ board, onSuccess, onCancel, formId, onSu
         onSuccess?.(data.updateBoard);
       }
     },
-    [execute, board.uuid, showMessage, onSuccess, configEditable, t],
+    [execute, board.uuid, onSuccess, configEditable],
   );
 
+  const handleSubmit = useCallback(
+    async (values: EditBoardFormValues) => {
+      if (!values.name) {
+        showMessage(t('boardForm.create.nameRequired'), 'error');
+        return;
+      }
+      // Kept so "save anyway" can replay the exact same edit.
+      lastValuesRef.current = values;
+      await runUpdate(values);
+    },
+    [runUpdate, showMessage, t],
+  );
+
+  const handleSaveAnyway = useCallback(async () => {
+    const values = lastValuesRef.current;
+    setDuplicate(null);
+    if (!values) return;
+    await runUpdate(values, true);
+  }, [runUpdate]);
+
   return (
-    <BoardForm
-      // The host drawer titles the surface + hosts the action bar when it asks
-      // for submit-state reporting; drop the in-form title so it isn't doubled.
-      title={onSubmitStateChange ? '' : t('editBoard.title')}
-      submitLabel={t('editBoard.submitLabel')}
-      initialValues={{
-        name: board.name,
-        slug: board.slug,
-        description: board.description ?? '',
-        locationName: board.locationName ?? '',
-        latitude: board.latitude ?? null,
-        longitude: board.longitude ?? null,
-        isPublic: board.isPublic,
-        isUnlisted: board.isUnlisted,
-        hideLocation: board.hideLocation,
-        isOwned: board.isOwned,
-        angle: board.angle,
-        isAngleAdjustable: board.isAngleAdjustable,
-        layoutId: board.layoutId,
-        sizeId: board.sizeId,
-        setIds: board.setIds,
-        serialNumber: board.serialNumber ?? '',
-      }}
-      showSlugField
-      availableAngles={availableAngles}
-      configEditable={configEditable}
-      onSubmit={handleSubmit}
-      onCancel={onCancel}
-      formId={formId}
-      onSubmitStateChange={onSubmitStateChange}
-    />
+    <>
+      <BoardForm
+        // The host drawer titles the surface + hosts the action bar when it asks
+        // for submit-state reporting; drop the in-form title so it isn't doubled.
+        title={onSubmitStateChange ? '' : t('editBoard.title')}
+        submitLabel={t('editBoard.submitLabel')}
+        initialValues={{
+          name: board.name,
+          slug: board.slug,
+          description: board.description ?? '',
+          locationName: board.locationName ?? '',
+          latitude: board.latitude ?? null,
+          longitude: board.longitude ?? null,
+          isPublic: board.isPublic,
+          isUnlisted: board.isUnlisted,
+          hideLocation: board.hideLocation,
+          isOwned: board.isOwned,
+          angle: board.angle,
+          isAngleAdjustable: board.isAngleAdjustable,
+          layoutId: board.layoutId,
+          sizeId: board.sizeId,
+          setIds: board.setIds,
+          serialNumber: board.serialNumber ?? '',
+        }}
+        showSlugField
+        availableAngles={availableAngles}
+        configEditable={configEditable}
+        onSubmit={handleSubmit}
+        onCancel={onCancel}
+        formId={formId}
+        onSubmitStateChange={onSubmitStateChange}
+      />
+      {/* A dialog, not a snackbar: this is a choice, and the snackbar's single
+          action slot can't carry one. Before this the guard was a flat
+          "Failed to update board" with no way past it. */}
+      <Dialog open={duplicate !== null} onClose={() => setDuplicate(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>{t('boardForm.edit.duplicateTitle')}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {duplicate?.name
+              ? t('boardForm.edit.duplicateBody', { name: duplicate.name })
+              : t('boardForm.edit.duplicateBodyGeneric')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDuplicate(null)}>{t('boardForm.edit.keepEditing')}</Button>
+          <Button onClick={() => void handleSaveAnyway()} variant="contained">
+            {t('boardForm.edit.saveAnyway')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
   );
 }

--- a/packages/web/app/components/board-entity/edit-board-form.tsx
+++ b/packages/web/app/components/board-entity/edit-board-form.tsx
@@ -68,7 +68,15 @@ export default function EditBoardForm({ board, onSuccess, onCancel, formId, onSu
   // fields are null when the server withheld the colliding board's identity —
   // it does that whenever the editor is not the board's owner (a gym admin, a
   // community moderator), so the dialog has to work without a board to name.
+  //
+  // `duplicate` and `duplicateDialogOpen` are split so the dialog's ~300ms fade
+  // -out transition still has content to render: closing sets only `open` to
+  // false, and `duplicate` itself is cleared from `TransitionProps.onExited`,
+  // once the exit animation actually finishes. Clearing both at once (the
+  // original approach) let MUI re-render the closing dialog's body against
+  // `duplicate === null` mid-fade, flashing the generic fallback copy.
   const [duplicate, setDuplicate] = useState<{ name: string | null; locationName: string | null } | null>(null);
+  const [duplicateDialogOpen, setDuplicateDialogOpen] = useState(false);
   const lastValuesRef = useRef<EditBoardFormValues | null>(null);
   // `runUpdate` fires from two places — the drawer's Save button and the
   // duplicate dialog's "Save anyway" retry — and neither is disabled while the
@@ -86,6 +94,7 @@ export default function EditBoardForm({ board, onSuccess, onCancel, formId, onSu
       if (isDuplicateBoardError(error)) {
         const duplicateError = readDuplicateBoardError(error);
         setDuplicate({ name: duplicateError?.boardName || null, locationName: duplicateError?.locationName || null });
+        setDuplicateDialogOpen(true);
         track(SHARED_EVENTS.BoardDuplicatePrompted, {
           boardType: board.boardType,
           source: 'web_edit_drawer',
@@ -169,7 +178,7 @@ export default function EditBoardForm({ board, onSuccess, onCancel, formId, onSu
 
   const handleSaveAnyway = useCallback(async () => {
     const values = lastValuesRef.current;
-    setDuplicate(null);
+    setDuplicateDialogOpen(false);
     if (!values) return;
     await runUpdate(values, true);
   }, [runUpdate]);
@@ -210,7 +219,13 @@ export default function EditBoardForm({ board, onSuccess, onCancel, formId, onSu
       {/* A dialog, not a snackbar: this is a choice, and the snackbar's single
           action slot can't carry one. Before this the guard was a flat
           "Failed to update board" with no way past it. */}
-      <Dialog open={duplicate !== null} onClose={() => setDuplicate(null)} maxWidth="xs" fullWidth>
+      <Dialog
+        open={duplicateDialogOpen}
+        onClose={() => setDuplicateDialogOpen(false)}
+        TransitionProps={{ onExited: () => setDuplicate(null) }}
+        maxWidth="xs"
+        fullWidth
+      >
         <DialogTitle>{t('boardForm.edit.duplicateTitle')}</DialogTitle>
         <DialogContent>
           <DialogContentText>
@@ -225,7 +240,7 @@ export default function EditBoardForm({ board, onSuccess, onCancel, formId, onSu
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setDuplicate(null)}>{t('boardForm.edit.cancel')}</Button>
+          <Button onClick={() => setDuplicateDialogOpen(false)}>{t('boardForm.edit.cancel')}</Button>
           <Button onClick={() => void handleSaveAnyway()} variant="contained">
             {t('boardForm.edit.saveAnyway')}
           </Button>

--- a/packages/web/app/components/board-entity/edit-board-form.tsx
+++ b/packages/web/app/components/board-entity/edit-board-form.tsx
@@ -64,11 +64,11 @@ export default function EditBoardForm({ board, onSuccess, onCancel, formId, onSu
 
   const availableAngles = ANGLES[board.boardType as BoardName] ?? [];
 
-  // The pending duplicate, if the last save was refused for that reason. `name`
-  // is null when the server withheld the colliding board's identity — it does
-  // that whenever the editor is not the board's owner (a gym admin, a community
-  // moderator), so the dialog has to work without a board to name.
-  const [duplicate, setDuplicate] = useState<{ name: string | null } | null>(null);
+  // The pending duplicate, if the last save was refused for that reason. Both
+  // fields are null when the server withheld the colliding board's identity —
+  // it does that whenever the editor is not the board's owner (a gym admin, a
+  // community moderator), so the dialog has to work without a board to name.
+  const [duplicate, setDuplicate] = useState<{ name: string | null; locationName: string | null } | null>(null);
   const lastValuesRef = useRef<EditBoardFormValues | null>(null);
   // `runUpdate` fires from two places — the drawer's Save button and the
   // duplicate dialog's "Save anyway" retry — and neither is disabled while the
@@ -84,7 +84,8 @@ export default function EditBoardForm({ board, onSuccess, onCancel, formId, onSu
       // wall can legitimately exist twice (home and gym), and the save goes
       // through on a second pass with the user's confirmation attached.
       if (isDuplicateBoardError(error)) {
-        setDuplicate({ name: readDuplicateBoardError(error)?.boardName || null });
+        const duplicateError = readDuplicateBoardError(error);
+        setDuplicate({ name: duplicateError?.boardName || null, locationName: duplicateError?.locationName || null });
         track(SHARED_EVENTS.BoardDuplicatePrompted, {
           boardType: board.boardType,
           source: 'web_edit_drawer',
@@ -99,7 +100,6 @@ export default function EditBoardForm({ board, onSuccess, onCancel, formId, onSu
 
   const { execute } = useEntityMutation<UpdateBoardMutationResponse, UpdateBoardMutationVariables>(UPDATE_BOARD, {
     successMessage: t('editBoard.snackbar.updated'),
-    errorMessage: t('editBoard.snackbar.updateFailed'),
     onError: handleUpdateError,
   });
 
@@ -214,9 +214,14 @@ export default function EditBoardForm({ board, onSuccess, onCancel, formId, onSu
         <DialogTitle>{t('boardForm.edit.duplicateTitle')}</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            {duplicate?.name
-              ? t('boardForm.edit.duplicateBody', { name: duplicate.name })
-              : t('boardForm.edit.duplicateBodyGeneric')}
+            {duplicate?.name && duplicate.locationName
+              ? t('boardForm.edit.duplicateBodyWithLocation', {
+                  name: duplicate.name,
+                  location: duplicate.locationName,
+                })
+              : duplicate?.name
+                ? t('boardForm.edit.duplicateBody', { name: duplicate.name })
+                : t('boardForm.edit.duplicateBodyGeneric')}
           </DialogContentText>
         </DialogContent>
         <DialogActions>

--- a/packages/web/app/hooks/use-entity-mutation.ts
+++ b/packages/web/app/hooks/use-entity-mutation.ts
@@ -9,22 +9,31 @@ import { extractGraphQLErrorMessage } from '@/app/lib/graphql/extract-error-mess
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import type { Variables } from 'graphql-request';
 
-type UseEntityMutationOptions = {
-  successMessage?: string;
-  errorMessage: string;
-  authRequiredMessage?: string;
-  // Called when the mutation throws. `serverMessage` is the resolver's
-  // user-facing message when the failure is a GraphQL error (e.g. "You already
-  // have a board with this configuration"), otherwise null. When provided, the
-  // caller owns the error toast; otherwise the hook shows `serverMessage` (when
-  // present) and falls back to the generic `errorMessage`.
-  onError?: (error: unknown, serverMessage: string | null) => void | Promise<void>;
-};
+// `errorMessage` is required unless `onError` is provided: without a
+// caller-owned handler the hook is the one showing the toast on failure, and
+// it needs a message to show. When `onError` is set, the caller owns the
+// error toast (and its own i18n fallback — see `handleUpdateError`-style
+// callbacks), so `errorMessage` becomes optional and is only used to label the
+// `console.error` on failure.
+type UseEntityMutationOptions =
+  | {
+      successMessage?: string;
+      errorMessage: string;
+      authRequiredMessage?: string;
+      onError?: undefined;
+    }
+  | {
+      successMessage?: string;
+      errorMessage?: string;
+      authRequiredMessage?: string;
+      onError: (error: unknown, serverMessage: string | null) => void | Promise<void>;
+    };
 
 export function useEntityMutation<TResponse, TVariables extends Variables = Variables>(
   mutation: TypedDocumentNode | string,
-  { successMessage, errorMessage, authRequiredMessage, onError }: UseEntityMutationOptions,
+  options: UseEntityMutationOptions,
 ) {
+  const { successMessage, authRequiredMessage } = options;
   const { token } = useWsAuthToken();
   const { showMessage } = useSnackbar();
   const { t } = useTranslation('common');
@@ -45,17 +54,17 @@ export function useEntityMutation<TResponse, TVariables extends Variables = Vari
         }
         return data;
       } catch (error) {
-        console.error(errorMessage, error);
+        console.error(options.errorMessage, error);
         const serverMessage = extractGraphQLErrorMessage(error);
-        if (onError) {
-          await onError(error, serverMessage);
+        if (options.onError) {
+          await options.onError(error, serverMessage);
         } else {
-          showMessage(serverMessage ?? errorMessage, 'error');
+          showMessage(serverMessage ?? options.errorMessage, 'error');
         }
         return null;
       }
     },
-    [token, mutation, successMessage, errorMessage, resolvedAuthRequiredMessage, onError, showMessage],
+    [token, mutation, successMessage, options.errorMessage, resolvedAuthRequiredMessage, options.onError, showMessage],
   );
 
   return { execute, token };

--- a/packages/web/app/hooks/use-entity-mutation.ts
+++ b/packages/web/app/hooks/use-entity-mutation.ts
@@ -33,7 +33,7 @@ export function useEntityMutation<TResponse, TVariables extends Variables = Vari
   mutation: TypedDocumentNode | string,
   options: UseEntityMutationOptions,
 ) {
-  const { successMessage, authRequiredMessage } = options;
+  const { successMessage, errorMessage, authRequiredMessage, onError } = options;
   const { token } = useWsAuthToken();
   const { showMessage } = useSnackbar();
   const { t } = useTranslation('common');
@@ -54,17 +54,17 @@ export function useEntityMutation<TResponse, TVariables extends Variables = Vari
         }
         return data;
       } catch (error) {
-        console.error(options.errorMessage, error);
+        console.error(errorMessage, error);
         const serverMessage = extractGraphQLErrorMessage(error);
-        if (options.onError) {
-          await options.onError(error, serverMessage);
+        if (onError) {
+          await onError(error, serverMessage);
         } else {
-          showMessage(serverMessage ?? options.errorMessage, 'error');
+          showMessage(serverMessage ?? errorMessage, 'error');
         }
         return null;
       }
     },
-    [token, mutation, successMessage, options.errorMessage, resolvedAuthRequiredMessage, options.onError, showMessage],
+    [token, mutation, successMessage, errorMessage, resolvedAuthRequiredMessage, onError, showMessage],
   );
 
   return { execute, token };


### PR DESCRIPTION
Follow-up to #4174, which dropped `user_boards_unique_owner_config` so an owner can hold the same board config at different places. That PR's review round left three pre-existing paths for their own change; this PR fixes all three, plus what its own review rounds surfaced.

## updateBoard parity with createBoard

The old strict guard refused any config change that matched another of the owner's boards — no place dimension, no override, plain `Error`. A gym reconfiguring one wall to match another of the owner's walls hard-failed, and the delete+recreate workaround loses tick linkage.

Now `updateBoard` uses the same rule as `createBoard`: the duplicate probe runs `findBlockingDuplicate` over the owner's same-type/layout/size boards (excluding the board being edited) against the **post-update** location, is bypassable with `allowDuplicateConfig`, and throws the same `BOARD_DUPLICATE_CONFIG` error. The guard also skips entirely when the effective config didn't change — mobile resends the config on every edit, so without that skip an owner of two same-config boards could never save *any* edit, not even a rename.

Both clients handle the new error: mobile edit shows a native confirm (keep editing / save anyway), web's edit drawer gets the same dialog the create form has. "Save anyway" retries with `allowDuplicateConfig: true`.

**Found in this PR's own review round** (same class as the #4174 private-gym probe finding): the duplicate error's extensions carry the blocking board's name, slug, and human-readable location. `updateBoard` is reachable by non-owner editors (gym admins, community leaders), so that would have let an editor enumerate an owner's *other* boards — including a private home wall's location — by probing configs. Identity fields are now stripped unless the caller is the owner; clients show a generic message in that case. Regression-tested with an owner/non-owner contrast pair.

## Deterministic legacy tick attribution

`resolveBoardFromPath` (the fallback when a tick arrives with neither `boardUuid` nor a presence `boardId`) had two defects once same-config duplicates became legal:

- `setIds` was compared as a raw SQL string, while the stored value keeps creation order — `'25,26,27,24'` vs `'24,25,26,27'` silently returned null and the tick landed unattributed. Equality is now settled in JS via the same `normalizeSetIds` the other resolution rungs use.
- `.limit(1)` with no `ORDER BY` picked an arbitrary board among same-config siblings, and unstably — two ticks in one session could land on two different boards. The pick is now `asc(id)`, and a new rung was added above the config lookup: if the tick carries a `sessionId`, the session's own `board_id` wins (validated against the tick's full config, exactly like the presence-boardId rung; no ownership requirement, since party-mode sessions legitimately reference another user's wall). An MRU-by-ticks preference was considered and deliberately left out — it can flip when the user ticks a sibling board via the modern path, making the legacy pick less stable, not more.

The ordering test is mutation-tested: seeded with explicit descending ids so the old unordered pick returns the wrong board.

## Per-account board cap

The dropped unique index was an implicit ceiling on boards per account; `allowDuplicateConfig` is otherwise an unlimited mint. `MAX_BOARDS_PER_ACCOUNT = 50` (repo precedent: 20 distinct foreign gyms, 25 auto-minted gyms, 100 treated as pathological). Enforced in `createBoard` (before the duplicate guard, outside the bypass) and in the BLE serial auto-create branch — binding to an already-owned board is never capped, so connecting to your own wall keeps working at the cap. Same TOCTOU-approximate stance as the gym mint cap (a runaway backstop, not an invariant), but this one throws: a board the user asked for must not silently not exist. Error code `BOARD_LIMIT_REACHED`; both clients show a typed message instead of the raw server string.

The review round also closed a bypass: `updateBoard`'s soft-delete restore path revived boards without a cap check (delete 10, mint 10, restore 10 → 60 live). A restore now pays the same toll as a mint.

## Also in here

- **German catalog repair**: `de/boards.json` was missing 30 keys (red on `main`'s parity test) and carried 2 stale ones. Translated per `docs/i18n-german-glossary.md`. ⚠️ The German strings (and the new es/fr keys) are glossary-checked but machine-translated — flagging for native review, cc Axel.
- `buildUpdateInput` on mobile now omits an unchanged config (defense-in-depth; the server-side skip is the load-bearing fix).
- French register: new keys use vous to match their screen siblings.

## Deliberately left / follow-up material

- `updateBoard` hard-fails a location edit on a no-PostGIS deployment where `createBoard` degrades gracefully — pre-existing asymmetry, untouched.
- The `boardUuid` tick rung attributes to any board by uuid with no config gate (pre-existing; the new session rung is strictly more constrained).
- At the cap, a duplicate resubmit reports the cap error rather than the duplicate error (cap runs first by design).
- `normalizeSetIds` (board-presence) and `normaliseSetIds` (@boardsesh/board-config) now coexist in `social/boards.ts`; each comparison uses one helper on both sides, but consolidating them is a worthwhile cleanup.

## Release Notes

- Changing a board's setup no longer gets blocked just because you own the same setup somewhere else — the app asks you to confirm instead.
- Climbs logged from the classic board pages now land on the right board when you own more than one with the same setup — and if you're in a session, on the wall that session is running on.
- The app now speaks German on the boards screens it was missing it on.
