### PR TITLE
feat: auto-approve gym claims on unclaimed listings behind an admin toggle

### DIFF
--- a/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
@@ -1343,6 +1343,41 @@ describe('requestGymClaim — auto-approval', () => {
     expect(rows.filter((row) => row.status === 'pending')).toHaveLength(1);
   });
 
+  it('never leaks the internal race message out of a manual approve', async () => {
+    // Two admin-method claims on one gym, both approved at once. Whichever way
+    // the transfers interleave, the reviewer must only ever see the curated
+    // message — applyGymClaim's internal "ownership changed" throw is an
+    // implementation detail and must not reach the admin panel.
+    const claimGym = await insertGym({ ownerId: PRIOR_OWNER, name: 'Double Reviewed' });
+    const firstClaim = await insertClaim({ gymId: claimGym.id, claimantUserId: CLAIMANT, method: 'admin' });
+    const secondClaim = await insertClaim({ gymId: claimGym.id, claimantUserId: PLAIN_USER, method: 'admin' });
+
+    const outcomes = await Promise.allSettled([
+      socialGymClaimMutations.reviewGymClaim(
+        null,
+        { input: { claimId: firstClaim, decision: 'approve' } },
+        authCtx(GLOBAL_ADMIN),
+      ),
+      socialGymClaimMutations.reviewGymClaim(
+        null,
+        { input: { claimId: secondClaim, decision: 'approve' } },
+        authCtx(GLOBAL_ADMIN),
+      ),
+    ]);
+
+    for (const outcome of outcomes) {
+      if (outcome.status === 'rejected') {
+        expect(String(outcome.reason?.message)).toBe(
+          'Could not approve this claim — the gym may have been removed or it was already resolved',
+        );
+      }
+    }
+
+    // At least one approval landed, and the gym belongs to a claimant.
+    expect(outcomes.some((outcome) => outcome.status === 'fulfilled')).toBe(true);
+    expect([CLAIMANT, PLAIN_USER]).toContain(await gymOwnerId(claimGym.uuid));
+  });
+
   it('does not auto-approve a domain claim — it still has to prove the domain', async () => {
     await setAutoApprove(true);
     const claimGym = await insertGym({

--- a/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
@@ -1346,10 +1346,15 @@ describe('requestGymClaim — auto-approval', () => {
   it('queues instead of erroring once the auto-approve rate limit is spent', async () => {
     await setAutoApprove(true);
 
-    // The limiter is keyed `${userId}:${operation}`, lives in process memory,
-    // and is NOT reset between tests. Claiming as a brand-new user each run
-    // guarantees an empty budget no matter what ran first — pinning this to a
-    // shared fixture account would make the expected sequence order-dependent.
+    // Every bucket `applyRateLimit` keeps is keyed `${userId}:${operation}`, and
+    // its tier-1 in-process bucket is NOT reset between tests. Claiming as a
+    // brand-new user each run guarantees an empty budget no matter what ran
+    // first — pinning this to a shared fixture account would make the expected
+    // sequence order-dependent.
+    //
+    // Tier 1 being per-process is a test-isolation concern only: authenticated
+    // callers also pass through tier 2, a shared Redis bucket on the same key
+    // (`shared/helpers.ts`), so the production cap is global across instances.
     const claimant = `gw-rate-limited-${uuidv4()}`;
     await insertUser(claimant);
 

--- a/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
@@ -1346,9 +1346,13 @@ describe('requestGymClaim — auto-approval', () => {
   it('queues instead of erroring once the auto-approve rate limit is spent', async () => {
     await setAutoApprove(true);
 
-    // SECOND_TARGET is used by no other auto-approval test, so this account's
-    // in-memory `gymClaimAutoApprove` budget starts fresh (the limiter is
-    // per-user and is NOT reset between tests in a worker).
+    // The limiter is keyed `${userId}:${operation}`, lives in process memory,
+    // and is NOT reset between tests. Claiming as a brand-new user each run
+    // guarantees an empty budget no matter what ran first — pinning this to a
+    // shared fixture account would make the expected sequence order-dependent.
+    const claimant = `gw-rate-limited-${uuidv4()}`;
+    await insertUser(claimant);
+
     const gyms = await Promise.all(
       [1, 2, 3, 4].map((index) => insertGym({ ownerId: SYSTEM_OWNER, name: `Rate Limited ${index}` })),
     );
@@ -1358,7 +1362,7 @@ describe('requestGymClaim — auto-approval', () => {
       const result = (await socialGymClaimMutations.requestGymClaim(
         null,
         { input: { gymUuid: gym.uuid, message: 'mine' } },
-        authCtx(SECOND_TARGET),
+        authCtx(claimant),
       )) as { status: string };
       results.push(result.status);
     }

--- a/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
@@ -12,6 +12,10 @@ import {
   verifyGymClaimByToken,
   hashClaimToken,
 } from '../graphql/resolvers/social/gym-claims';
+import {
+  socialCommunitySettingsMutations,
+  socialCommunitySettingsQueries,
+} from '../graphql/resolvers/social/community-settings';
 
 /**
  * Real-DB coverage for the gym write-access (editor) role + grant/revoke
@@ -195,7 +199,7 @@ let gymUuid: string;
 beforeEach(async () => {
   await db.execute(sql`
     TRUNCATE TABLE
-      "community_roles", "gym_members", "gym_follows", "gym_claims",
+      "community_roles", "community_settings", "gym_members", "gym_follows", "gym_claims",
       "board_follows", "boardsesh_ticks", "user_boards", "gyms", "notifications"
     RESTART IDENTITY CASCADE
   `);
@@ -1178,5 +1182,216 @@ describe('claim security hardening', () => {
     );
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({ status: 'pending', method: 'admin' });
+  });
+});
+
+// ============================================================================
+// Auto-approval of admin-review claims (gym_claim_auto_approve)
+// ============================================================================
+
+/** Turn the global auto-approve setting on/off by writing the row directly. */
+const setAutoApprove = (on: boolean) =>
+  db.execute(sql`
+    INSERT INTO community_settings (scope, scope_key, key, value, created_at, updated_at)
+    VALUES ('global', '', 'gym_claim_auto_approve', ${on ? '1' : '0'}, now(), now())
+    ON CONFLICT (scope, scope_key, key) DO UPDATE SET value = EXCLUDED.value
+  `);
+
+const claimRows = async (gymId: number) =>
+  Array.from(
+    (await db.execute(sql`
+      SELECT method, status, reviewed_by FROM gym_claims WHERE gym_id = ${gymId}
+    `)) as Iterable<{ method: string; status: string; reviewed_by: string | null }>,
+  );
+
+const gymSyncFrozenAt = async (gymUuid: string): Promise<Date | null> => {
+  const result = await db.execute(sql`SELECT sync_frozen_at FROM gyms WHERE uuid = ${gymUuid} LIMIT 1`);
+  return Array.from(result as Iterable<{ sync_frozen_at: Date | null }>)[0].sync_frozen_at;
+};
+
+describe('requestGymClaim — auto-approval', () => {
+  it('leaves the claim queued when the setting is off (default)', async () => {
+    const claimGym = await insertGym({ ownerId: SYSTEM_OWNER, name: 'Unclaimed Listing' });
+
+    await expect(
+      socialGymClaimMutations.requestGymClaim(
+        null,
+        { input: { gymUuid: claimGym.uuid, message: 'mine' } },
+        authCtx(CLAIMANT),
+      ),
+    ).resolves.toEqual({ status: 'admin_review' });
+
+    expect(await gymOwnerId(claimGym.uuid)).toBe(SYSTEM_OWNER);
+    expect(await claimRows(claimGym.id)).toEqual([expect.objectContaining({ method: 'admin', status: 'pending' })]);
+    expect(sendGymClaimAdminNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('hands over an unclaimed (system-owned) listing on the spot when the setting is on', async () => {
+    await setAutoApprove(true);
+    const claimGym = await insertGym({ ownerId: SYSTEM_OWNER, name: 'Auto Listing' });
+
+    await expect(
+      socialGymClaimMutations.requestGymClaim(
+        null,
+        { input: { gymUuid: claimGym.uuid, message: 'I run this' } },
+        authCtx(CLAIMANT),
+      ),
+    ).resolves.toEqual({ status: 'approved' });
+
+    expect(await gymOwnerId(claimGym.uuid)).toBe(CLAIMANT);
+    // Taking ownership freezes the listing against location-sync clobber.
+    expect(await gymSyncFrozenAt(claimGym.uuid)).not.toBeNull();
+
+    // Auto-approved rows carry no reviewer — that's how they're told apart.
+    expect(await claimRows(claimGym.id)).toEqual([
+      expect.objectContaining({ method: 'admin', status: 'approved', reviewed_by: null }),
+    ]);
+
+    // No human was asked to look at it.
+    expect(sendGymClaimAdminNotification).not.toHaveBeenCalled();
+
+    // The claimant is told they now manage the gym.
+    const notifications = await claimApprovedNotifications(CLAIMANT);
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].entity_id).toBe(claimGym.uuid);
+  });
+
+  it('still queues a claim on a gym a real person owns, even with the setting on', async () => {
+    await setAutoApprove(true);
+    const claimGym = await insertGym({ ownerId: PRIOR_OWNER, name: 'Someone Elses Gym' });
+
+    await expect(
+      socialGymClaimMutations.requestGymClaim(
+        null,
+        { input: { gymUuid: claimGym.uuid, message: 'let me in' } },
+        authCtx(CLAIMANT),
+      ),
+    ).resolves.toEqual({ status: 'admin_review' });
+
+    // The whole point of the scope limit: no silent takeover.
+    expect(await gymOwnerId(claimGym.uuid)).toBe(PRIOR_OWNER);
+    expect(await claimRows(claimGym.id)).toEqual([expect.objectContaining({ method: 'admin', status: 'pending' })]);
+    expect(sendGymClaimAdminNotification).toHaveBeenCalledTimes(1);
+    expect(sendGymClaimOwnershipLostEmail).not.toHaveBeenCalled();
+  });
+
+  it('approves a claim that was already queued before the setting was turned on', async () => {
+    const claimGym = await insertGym({ ownerId: SYSTEM_OWNER, name: 'Queued Then Enabled' });
+
+    // Queued while auto-approval was still off.
+    await expect(
+      socialGymClaimMutations.requestGymClaim(
+        null,
+        { input: { gymUuid: claimGym.uuid, message: 'mine' } },
+        authCtx(CLAIMANT),
+      ),
+    ).resolves.toEqual({ status: 'admin_review' });
+
+    await setAutoApprove(true);
+
+    // Re-requesting now goes through instead of hitting the dedup early return.
+    await expect(
+      socialGymClaimMutations.requestGymClaim(
+        null,
+        { input: { gymUuid: claimGym.uuid, message: 'mine' } },
+        authCtx(CLAIMANT),
+      ),
+    ).resolves.toEqual({ status: 'approved' });
+
+    expect(await gymOwnerId(claimGym.uuid)).toBe(CLAIMANT);
+    expect(await claimRows(claimGym.id)).toEqual([
+      expect.objectContaining({ method: 'admin', status: 'approved', reviewed_by: null }),
+    ]);
+  });
+
+  it('does not auto-approve a domain claim — it still has to prove the domain', async () => {
+    await setAutoApprove(true);
+    const claimGym = await insertGym({
+      ownerId: SYSTEM_OWNER,
+      name: 'Domain Listing',
+      website: 'https://www.domainlisting.com',
+    });
+
+    await expect(
+      socialGymClaimMutations.requestGymClaim(
+        null,
+        { input: { gymUuid: claimGym.uuid, claimEmail: 'boss@domainlisting.com' } },
+        authCtx(CLAIMANT),
+      ),
+    ).resolves.toEqual({ status: 'email_sent', email: 'boss@domainlisting.com' });
+
+    expect(await gymOwnerId(claimGym.uuid)).toBe(SYSTEM_OWNER);
+    expect(await claimRows(claimGym.id)).toEqual([expect.objectContaining({ method: 'domain', status: 'pending' })]);
+    expect(sendGymClaimVerificationEmail).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('gym community settings — admin-only', () => {
+  const setInput = (value: string) => ({
+    input: { scope: 'global', scopeKey: '', key: 'gym_claim_auto_approve', value },
+  });
+
+  // A GLOBAL community_leader — the board-scoped KILTER_LEADER can't write a
+  // global-scope setting at all, so it would pass the gym test for the wrong
+  // reason. This user can write the non-gym keys, which is what makes the gym
+  // rejection below meaningful.
+  const insertGlobalLeader = () => insertRole(PLAIN_USER, 'community_leader', null);
+
+  it('rejects a global community_leader writing a gym setting', async () => {
+    await insertGlobalLeader();
+
+    await expect(
+      socialCommunitySettingsMutations.setCommunitySettings(null, setInput('1'), authCtx(PLAIN_USER)),
+    ).rejects.toThrow(/admin/i);
+
+    const rows = Array.from(
+      (await db.execute(sql`SELECT value FROM community_settings WHERE key = 'gym_claim_auto_approve'`)) as Iterable<{
+        value: string;
+      }>,
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it('lets a global admin write a gym setting', async () => {
+    const result = await socialCommunitySettingsMutations.setCommunitySettings(
+      null,
+      setInput('1'),
+      authCtx(GLOBAL_ADMIN),
+    );
+    expect(result).toMatchObject({ key: 'gym_claim_auto_approve', value: '1' });
+  });
+
+  it('still lets a global community_leader write a non-gym setting', async () => {
+    await insertGlobalLeader();
+
+    const result = await socialCommunitySettingsMutations.setCommunitySettings(
+      null,
+      { input: { scope: 'global', scopeKey: '', key: 'approval_threshold', value: '7' } },
+      authCtx(PLAIN_USER),
+    );
+    expect(result).toMatchObject({ key: 'approval_threshold', value: '7' });
+  });
+
+  it('hides gym settings from a non-admin reader but shows them to an admin', async () => {
+    await setAutoApprove(true);
+    await socialCommunitySettingsMutations.setCommunitySettings(
+      null,
+      { input: { scope: 'global', scopeKey: '', key: 'approval_threshold', value: '7' } },
+      authCtx(GLOBAL_ADMIN),
+    );
+
+    const asPlainUser = await socialCommunitySettingsQueries.communitySettings(
+      null,
+      { scope: 'global', scopeKey: '' },
+      authCtx(PLAIN_USER),
+    );
+    expect(asPlainUser.map((setting) => setting.key)).toEqual(['approval_threshold']);
+
+    const asAdmin = await socialCommunitySettingsQueries.communitySettings(
+      null,
+      { scope: 'global', scopeKey: '' },
+      authCtx(GLOBAL_ADMIN),
+    );
+    expect(asAdmin.map((setting) => setting.key).sort()).toEqual(['approval_threshold', 'gym_claim_auto_approve']);
   });
 });

--- a/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
@@ -1343,6 +1343,35 @@ describe('requestGymClaim — auto-approval', () => {
     expect(rows.filter((row) => row.status === 'pending')).toHaveLength(1);
   });
 
+  it('queues instead of erroring once the auto-approve rate limit is spent', async () => {
+    await setAutoApprove(true);
+
+    // SECOND_TARGET is used by no other auto-approval test, so this account's
+    // in-memory `gymClaimAutoApprove` budget starts fresh (the limiter is
+    // per-user and is NOT reset between tests in a worker).
+    const gyms = await Promise.all(
+      [1, 2, 3, 4].map((index) => insertGym({ ownerId: SYSTEM_OWNER, name: `Rate Limited ${index}` })),
+    );
+
+    const results: string[] = [];
+    for (const gym of gyms) {
+      const result = (await socialGymClaimMutations.requestGymClaim(
+        null,
+        { input: { gymUuid: gym.uuid, message: 'mine' } },
+        authCtx(SECOND_TARGET),
+      )) as { status: string };
+      results.push(result.status);
+    }
+
+    // The limit caps instant hand-overs at 3; the 4th must fall back to the
+    // queue rather than reject — its claim row is already committed, so an
+    // error would tell the user their request failed when it didn't.
+    expect(results).toEqual(['approved', 'approved', 'approved', 'admin_review']);
+
+    expect(await gymOwnerId(gyms[3].uuid)).toBe(SYSTEM_OWNER);
+    expect(await claimRows(gyms[3].id)).toEqual([expect.objectContaining({ method: 'admin', status: 'pending' })]);
+  });
+
   it('never leaks the internal race message out of a manual approve', async () => {
     // Two admin-method claims on one gym, both approved at once. Whichever way
     // the transfers interleave, the reviewer must only ever see the curated

--- a/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
@@ -1468,6 +1468,25 @@ describe('gym community settings — admin-only', () => {
     expect(result).toMatchObject({ key: 'gym_claim_auto_approve', value: '1' });
   });
 
+  it('rejects a board-scoped admin and hides gym settings from them', async () => {
+    // `admin` scoped to a single board type. Gym settings are global config and
+    // both gates resolve them without a board type, so this role must not
+    // qualify — which is exactly why the /admin Gyms tab is hidden from it.
+    await insertRole(PLAIN_USER, 'admin', 'kilter');
+    await setAutoApprove(true);
+
+    await expect(
+      socialCommunitySettingsMutations.setCommunitySettings(null, setInput('0'), authCtx(PLAIN_USER)),
+    ).rejects.toThrow(/admin/i);
+
+    const visible = await socialCommunitySettingsQueries.communitySettings(
+      null,
+      { scope: 'global', scopeKey: '' },
+      authCtx(PLAIN_USER),
+    );
+    expect(visible.map((setting) => setting.key)).not.toContain('gym_claim_auto_approve');
+  });
+
   it('still lets a global community_leader write a non-gym setting', async () => {
     await insertGlobalLeader();
 

--- a/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
@@ -1304,6 +1304,45 @@ describe('requestGymClaim — auto-approval', () => {
     ]);
   });
 
+  it('survives two users racing for the same unclaimed gym — one wins, neither errors', async () => {
+    await setAutoApprove(true);
+    const claimGym = await insertGym({ ownerId: SYSTEM_OWNER, name: 'Contested Listing' });
+
+    // Real concurrency, so the loser can take either degradation path inside
+    // applyGymClaim: it may see the new owner at the SELECT (owner-guard returns
+    // null), or pass the SELECT and lose the guarded UPDATE (throws, rolls back).
+    // Which one it takes is timing-dependent; the invariant below is not.
+    const outcomes = await Promise.allSettled([
+      socialGymClaimMutations.requestGymClaim(
+        null,
+        { input: { gymUuid: claimGym.uuid, message: 'mine' } },
+        authCtx(CLAIMANT),
+      ),
+      socialGymClaimMutations.requestGymClaim(
+        null,
+        { input: { gymUuid: claimGym.uuid, message: 'no, mine' } },
+        authCtx(PLAIN_USER),
+      ),
+    ]);
+
+    // Neither caller gets a server error — a claim that ends up queued must be
+    // reported as queued, not as a failure.
+    expect(outcomes.map((outcome) => outcome.status)).toEqual(['fulfilled', 'fulfilled']);
+
+    const statuses = outcomes
+      .map((outcome) => (outcome.status === 'fulfilled' ? (outcome.value as { status: string }).status : 'rejected'))
+      .sort();
+    expect(statuses).toEqual(['admin_review', 'approved']);
+
+    // Exactly one transfer happened, and the winner is whoever got 'approved'.
+    const owner = await gymOwnerId(claimGym.uuid);
+    expect([CLAIMANT, PLAIN_USER]).toContain(owner);
+
+    const rows = await claimRows(claimGym.id);
+    expect(rows.filter((row) => row.status === 'approved')).toHaveLength(1);
+    expect(rows.filter((row) => row.status === 'pending')).toHaveLength(1);
+  });
+
   it('does not auto-approve a domain claim — it still has to prove the domain', async () => {
     await setAutoApprove(true);
     const claimGym = await insertGym({

--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -1010,6 +1010,24 @@ export const schemaSQL = `
   );
   CREATE INDEX IF NOT EXISTS "community_roles_board_type_idx" ON "community_roles" ("board_type");
 
+  -- Scoped key/value config (scope: global | board | climb). Holds the grade
+  -- proposal thresholds and the gym_ operational settings, including
+  -- gym_claim_auto_approve, which requestGymClaim reads to decide whether an
+  -- unclaimed listing can be handed over without a human reviewing it.
+  DROP TABLE IF EXISTS "community_settings" CASCADE;
+  CREATE TABLE IF NOT EXISTS "community_settings" (
+    "id" bigserial PRIMARY KEY NOT NULL,
+    "scope" text NOT NULL,
+    "scope_key" text NOT NULL,
+    "key" text NOT NULL,
+    "value" text NOT NULL,
+    "set_by" text REFERENCES "users"("id") ON DELETE SET NULL,
+    "created_at" timestamp DEFAULT now() NOT NULL,
+    "updated_at" timestamp DEFAULT now() NOT NULL
+  );
+  CREATE UNIQUE INDEX IF NOT EXISTS "community_settings_scope_key_idx"
+    ON "community_settings" ("scope", "scope_key", "key");
+
   -- gym_members is created once, earlier (alongside the follow/member enrichment
   -- tables). The duplicate DROP+CREATE that used to sit here has been removed.
 

--- a/packages/backend/src/graphql/resolvers/social/community-settings.ts
+++ b/packages/backend/src/graphql/resolvers/social/community-settings.ts
@@ -21,7 +21,13 @@ export function isGymSettingKey(key: string): boolean {
   return key.startsWith(GYM_SETTING_PREFIX);
 }
 
-// Default community settings
+// Default community settings.
+//
+// NOTE: any key added here starting with `gym_` is automatically admin-only to
+// write AND hidden from non-admin reads (see GYM_SETTING_PREFIX above). That is
+// deliberate for claim auto-approval, but it means a harmless gym setting —
+// `gym_display_order`, say — would silently inherit the same access control.
+// Name it outside the prefix if it doesn't need admin gating.
 export const DEFAULTS: Record<string, string> = {
   approval_threshold: '5',
   outlier_min_ascents: '10',

--- a/packages/backend/src/graphql/resolvers/social/community-settings.ts
+++ b/packages/backend/src/graphql/resolvers/social/community-settings.ts
@@ -116,7 +116,11 @@ export const socialCommunitySettingsQueries = {
 
     // Gym settings are admin-only config; don't leak them (e.g. whether claim
     // auto-approval is live) to every signed-in user reading this query.
-    const visible = (await hasAdmin(ctx.userId!)) ? settings : settings.filter((row) => !isGymSettingKey(row.key));
+    // `requireAuthenticated` above only asserts the flag, not that userId is
+    // populated, so a missing id redacts rather than throwing — a redaction
+    // decision should fail closed.
+    const isAdminReader = ctx.userId ? await hasAdmin(ctx.userId) : false;
+    const visible = isAdminReader ? settings : settings.filter((row) => !isGymSettingKey(row.key));
 
     return visible.map((s) => ({
       id: s.id,

--- a/packages/backend/src/graphql/resolvers/social/community-settings.ts
+++ b/packages/backend/src/graphql/resolvers/social/community-settings.ts
@@ -4,7 +4,22 @@ import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
 import { SetCommunitySettingInputSchema } from '../../../validation/schemas';
-import { requireAdminOrLeader } from './roles';
+import { requireAdmin, requireAdminOrLeader, hasAdmin } from './roles';
+
+/**
+ * Settings under this prefix configure gym operations rather than climb-grade
+ * moderation, and they gate actions (`requireAdmin`) that community leaders
+ * cannot perform themselves. They are therefore admin-only to write and hidden
+ * from non-admin reads — otherwise a leader could flip `gym_claim_auto_approve`
+ * on and then claim a gym, escalating straight past the gym-claim admin gate.
+ */
+export const GYM_SETTING_PREFIX = 'gym_';
+
+export const GYM_CLAIM_AUTO_APPROVE_KEY = 'gym_claim_auto_approve';
+
+export function isGymSettingKey(key: string): boolean {
+  return key.startsWith(GYM_SETTING_PREFIX);
+}
 
 // Default community settings
 export const DEFAULTS: Record<string, string> = {
@@ -13,6 +28,8 @@ export const DEFAULTS: Record<string, string> = {
   outlier_grade_diff: '2',
   admin_vote_weight: '3',
   leader_vote_weight: '2',
+  // Off until an admin turns it on — auto-approval transfers gym ownership.
+  [GYM_CLAIM_AUTO_APPROVE_KEY]: '0',
 };
 
 /**
@@ -74,6 +91,16 @@ export async function resolveCommunitySetting(
   return DEFAULTS[key] || '0';
 }
 
+/**
+ * Is auto-approval of gym ownership claims turned on? Global-scope only — a gym
+ * claim isn't tied to a climb or a board type, so the cascade falls straight
+ * through to the global row and then the (off) default.
+ */
+export async function gymClaimAutoApproveEnabled(): Promise<boolean> {
+  const value = await resolveCommunitySetting(GYM_CLAIM_AUTO_APPROVE_KEY);
+  return value === '1' || value === 'true';
+}
+
 export const socialCommunitySettingsQueries = {
   communitySettings: async (
     _: unknown,
@@ -87,7 +114,11 @@ export const socialCommunitySettingsQueries = {
       .from(dbSchema.communitySettings)
       .where(and(eq(dbSchema.communitySettings.scope, scope), eq(dbSchema.communitySettings.scopeKey, scopeKey)));
 
-    return settings.map((s) => ({
+    // Gym settings are admin-only config; don't leak them (e.g. whether claim
+    // auto-approval is live) to every signed-in user reading this query.
+    const visible = (await hasAdmin(ctx.userId!)) ? settings : settings.filter((row) => !isGymSettingKey(row.key));
+
+    return visible.map((s) => ({
       id: s.id,
       scope: s.scope,
       scopeKey: s.scopeKey,
@@ -102,11 +133,21 @@ export const socialCommunitySettingsQueries = {
 
 export const socialCommunitySettingsMutations = {
   setCommunitySettings: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
-    await requireAdminOrLeader(ctx);
-    await applyRateLimit(ctx, 10, 'setCommunitySettings');
+    requireAuthenticated(ctx);
 
+    // Validate before the role check so the gate can branch on the key. Gym
+    // settings need full admin: they gate actions a community leader can't
+    // perform, so letting a leader write them would be an escalation.
     const validated = validateInput(SetCommunitySettingInputSchema, input, 'input');
     const { scope, scopeKey, key, value } = validated;
+
+    if (isGymSettingKey(key)) {
+      await requireAdmin(ctx);
+    } else {
+      await requireAdminOrLeader(ctx);
+    }
+    await applyRateLimit(ctx, 10, 'setCommunitySettings');
+
     const userId = ctx.userId!;
 
     // UPSERT

--- a/packages/backend/src/graphql/resolvers/social/community-settings.ts
+++ b/packages/backend/src/graphql/resolvers/social/community-settings.ts
@@ -150,32 +150,17 @@ export const socialCommunitySettingsMutations = {
 
     const userId = ctx.userId!;
 
-    // UPSERT
-    const [existing] = await db
-      .select()
-      .from(dbSchema.communitySettings)
-      .where(
-        and(
-          eq(dbSchema.communitySettings.scope, scope),
-          eq(dbSchema.communitySettings.scopeKey, scopeKey),
-          eq(dbSchema.communitySettings.key, key),
-        ),
-      )
-      .limit(1);
-
-    let result;
-    if (existing) {
-      [result] = await db
-        .update(dbSchema.communitySettings)
-        .set({ value, setBy: userId, updatedAt: new Date() })
-        .where(eq(dbSchema.communitySettings.id, existing.id))
-        .returning();
-    } else {
-      [result] = await db
-        .insert(dbSchema.communitySettings)
-        .values({ scope, scopeKey, key, value, setBy: userId })
-        .returning();
-    }
+    // Single-statement upsert against the (scope, scope_key, key) unique index.
+    // A SELECT-then-INSERT/UPDATE would let two concurrent admin writes to the
+    // same key race, with the loser hitting the unique constraint and erroring.
+    const [result] = await db
+      .insert(dbSchema.communitySettings)
+      .values({ scope, scopeKey, key, value, setBy: userId })
+      .onConflictDoUpdate({
+        target: [dbSchema.communitySettings.scope, dbSchema.communitySettings.scopeKey, dbSchema.communitySettings.key],
+        set: { value, setBy: userId, updatedAt: new Date() },
+      })
+      .returning();
 
     return {
       id: result.id,

--- a/packages/backend/src/graphql/resolvers/social/gym-claims.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-claims.ts
@@ -508,7 +508,22 @@ export const socialGymClaimMutations = {
       return true;
     }
 
-    const result = await applyGymClaim(claim, { reviewerId: adminUserId });
+    // Both ways this can fail mean the same thing to the reviewer — the claim
+    // wasn't applied — so fold them into one message. `applyGymClaim` returns
+    // null when the gym is gone or the claim was already resolved, and throws
+    // when a concurrent transfer beat us to the guarded UPDATE; letting that
+    // throw escape would hand the admin an internal message instead.
+    let result: ClaimApplied | null;
+    try {
+      result = await applyGymClaim(claim, { reviewerId: adminUserId });
+    } catch (error) {
+      logger.warn(
+        `[GymClaim] Manual approval of claim ${claim.id} lost an ownership race:`,
+        error instanceof Error ? error.message : error,
+      );
+      result = null;
+    }
+
     if (!result) {
       // The gym was removed, or the claim was resolved concurrently — don't
       // report a success the admin panel would show as "approved".

--- a/packages/backend/src/graphql/resolvers/social/gym-claims.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-claims.ts
@@ -195,6 +195,18 @@ export async function verifyGymClaimByToken(
  * off, gym owned by someone, or the claim was resolved concurrently) — in which
  * case the caller falls through to the normal review queue.
  *
+ * Auto-approval is an optimisation over that queue, never a precondition for it,
+ * so a failure to apply must not fail the request: the claim row is already
+ * committed as `pending` by the time we get here. `applyGymClaim` throws when a
+ * concurrent request transferred the gym out from under our read — that rolls
+ * its own transaction back (leaving the claim `pending`, which is correct), and
+ * swallowing it here degrades to `admin_review` instead of handing the user a
+ * server error for a claim that is in fact safely queued.
+ *
+ * The rate limit above is deliberately outside that catch: hitting it is a
+ * client-facing condition the caller should see, matching how requestGymClaim's
+ * own limit behaves.
+ *
  * Auto-approved rows are recognisable as `method='admin' AND status='approved'
  * AND reviewed_by IS NULL`; there's no dedicated column, so no migration.
  */
@@ -207,7 +219,17 @@ async function tryAutoApproveAdminClaim(
   // Tighter than requestGymClaim's own limit: each pass here can hand over a gym.
   await applyRateLimit(ctx, 3, 'gymClaimAutoApprove');
 
-  const result = await applyGymClaim(claim, { requireCurrentOwnerId: SYSTEM_BOARD_OWNER_ID });
+  let result: ClaimApplied | null;
+  try {
+    result = await applyGymClaim(claim, { requireCurrentOwnerId: SYSTEM_BOARD_OWNER_ID });
+  } catch (error) {
+    logger.warn(
+      `[GymClaim] Auto-approval of claim ${claim.id} on gym ${gym.uuid} failed; leaving it queued for review:`,
+      error instanceof Error ? error.message : error,
+    );
+    return null;
+  }
+
   if (result) {
     logger.info(
       `[GymClaim] Auto-approved claim ${claim.id} on gym ${gym.uuid} for user ${claim.claimantUserId} (unclaimed listing)`,

--- a/packages/backend/src/graphql/resolvers/social/gym-claims.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-claims.ts
@@ -6,6 +6,7 @@ import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
 import { requireAdmin } from './roles';
+import { gymClaimAutoApproveEnabled } from './community-settings';
 import { userCanEditGym } from './gyms';
 import { createGymManageAccessNotification } from './gym-notifications';
 import {
@@ -46,11 +47,18 @@ type ClaimApplied = {
  * returns null and does nothing, so the transfer + emails happen exactly once.
  * A real prior owner (not the system/import user) is kept on as a gym admin and
  * reported back so they can be notified. Returns null if the gym vanished.
+ *
+ * `requireCurrentOwnerId` narrows the apply to a gym still owned by that user —
+ * the auto-approval path passes the system import user so it can only ever hand
+ * over an unclaimed listing. The gym is re-checked here, inside the transaction
+ * and before the claim row is flipped, so a rejected apply leaves the claim
+ * `pending` for a human to review.
  */
 export async function applyGymClaim(
   claim: typeof dbSchema.gymClaims.$inferSelect,
-  reviewerId?: string,
+  opts: { reviewerId?: string; requireCurrentOwnerId?: string } = {},
 ): Promise<ClaimApplied | null> {
+  const { reviewerId, requireCurrentOwnerId } = opts;
   return db.transaction(async (tx) => {
     const [gym] = await tx
       .select()
@@ -58,6 +66,7 @@ export async function applyGymClaim(
       .where(and(eq(dbSchema.gyms.id, claim.gymId), isNull(dbSchema.gyms.deletedAt)))
       .limit(1);
     if (!gym) return null;
+    if (requireCurrentOwnerId !== undefined && gym.ownerId !== requireCurrentOwnerId) return null;
 
     // Claim the pending row atomically; 0 rows means someone else already resolved it.
     const flipped = await tx
@@ -72,12 +81,20 @@ export async function applyGymClaim(
     let notifyPriorOwnerId: string | null = null;
 
     if (priorOwnerId !== claimantId) {
-      await tx
+      const transferred = await tx
         .update(dbSchema.gyms)
         // Taking ownership is a strong human-curation signal — freeze the gym so
         // the location sync stops reshaping the listing the new owner now controls.
         .set({ ownerId: claimantId, syncFrozenAt: new Date(), updatedAt: new Date() })
-        .where(eq(dbSchema.gyms.id, gym.id));
+        // The gym was read above without a row lock, so re-assert the owner we
+        // based this decision on. A concurrent transfer means our read is stale:
+        // throw to roll the whole transaction back (claim flip included) rather
+        // than overwrite the winner.
+        .where(and(eq(dbSchema.gyms.id, gym.id), eq(dbSchema.gyms.ownerId, priorOwnerId)))
+        .returning({ id: dbSchema.gyms.id });
+      if (transferred.length === 0) {
+        throw new Error('Gym ownership changed while this claim was being applied');
+      }
 
       // Keep a real prior owner on as a gym admin (never the system import user).
       // Upsert to admin so an existing lower-role membership row is upgraded, not left behind.
@@ -165,6 +182,38 @@ export async function verifyGymClaimByToken(
   if (!result) return { ok: false, reason: 'used' };
   await notifyClaimApplied(result);
   return { ok: true, gymName: result.gymName, gymSlug: result.gymSlug, gymUuid: result.gymUuid };
+}
+
+/**
+ * Auto-approve an admin-review claim when the admin setting is on AND the gym is
+ * still owned by the system import user — an unclaimed location-sync listing
+ * nobody has taken. Claims that would displace a real person are deliberately
+ * left in the queue for a human, so turning the setting on can't be used to take
+ * a gym away from its owner.
+ *
+ * Returns the applied claim, or null when auto-approval didn't happen (setting
+ * off, gym owned by someone, or the claim was resolved concurrently) — in which
+ * case the caller falls through to the normal review queue.
+ *
+ * Auto-approved rows are recognisable as `method='admin' AND status='approved'
+ * AND reviewed_by IS NULL`; there's no dedicated column, so no migration.
+ */
+async function tryAutoApproveAdminClaim(
+  ctx: ConnectionContext,
+  gym: typeof dbSchema.gyms.$inferSelect,
+  claim: typeof dbSchema.gymClaims.$inferSelect,
+): Promise<ClaimApplied | null> {
+  if (!(await gymClaimAutoApproveEnabled())) return null;
+  // Tighter than requestGymClaim's own limit: each pass here can hand over a gym.
+  await applyRateLimit(ctx, 3, 'gymClaimAutoApprove');
+
+  const result = await applyGymClaim(claim, { requireCurrentOwnerId: SYSTEM_BOARD_OWNER_ID });
+  if (result) {
+    logger.info(
+      `[GymClaim] Auto-approved claim ${claim.id} on gym ${gym.uuid} for user ${claim.claimantUserId} (unclaimed listing)`,
+    );
+  }
+  return result;
 }
 
 /** The single pending claim (if any) this user has on this gym. */
@@ -350,8 +399,15 @@ export const socialGymClaimMutations = {
     }
 
     // Admin-review path: no usable email, queue for a human. Don't re-notify if a
-    // pending admin claim already exists for this (gym, user).
+    // pending admin claim already exists for this (gym, user) — but do retry
+    // auto-approval, so a claim queued before the setting was turned on can still
+    // go through when the claimant asks again.
     if (existingPending?.method === 'admin') {
+      const autoApplied = await tryAutoApproveAdminClaim(ctx, gym, existingPending);
+      if (autoApplied) {
+        await notifyClaimApplied(autoApplied);
+        return { status: 'approved' };
+      }
       return { status: 'admin_review' };
     }
 
@@ -362,6 +418,15 @@ export const socialGymClaimMutations = {
       status: 'pending',
       message: validatedInput.message ?? null,
     });
+
+    const queuedClaim = await findPendingClaim(gym.id, userId);
+    if (queuedClaim) {
+      const autoApplied = await tryAutoApproveAdminClaim(ctx, gym, queuedClaim);
+      if (autoApplied) {
+        await notifyClaimApplied(autoApplied);
+        return { status: 'approved' };
+      }
+    }
 
     // Best-effort: the claim is already queued and visible in /admin/gym-claims,
     // so a failed notification (SMTP down) must not throw — that would roll the
@@ -417,7 +482,7 @@ export const socialGymClaimMutations = {
       return true;
     }
 
-    const result = await applyGymClaim(claim, adminUserId);
+    const result = await applyGymClaim(claim, { reviewerId: adminUserId });
     if (!result) {
       // The gym was removed, or the claim was resolved concurrently — don't
       // report a success the admin panel would show as "approved".

--- a/packages/backend/src/graphql/resolvers/social/gym-claims.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-claims.ts
@@ -235,9 +235,15 @@ async function findPendingClaim(
   return existing;
 }
 
-/** Atomically replace this user's pending claim on this gym with a fresh row. */
-async function replacePendingClaim(values: typeof dbSchema.gymClaims.$inferInsert): Promise<void> {
-  await db.transaction(async (tx) => {
+/**
+ * Atomically replace this user's pending claim on this gym with a fresh row, and
+ * hand the inserted row back so a caller (auto-approval) can act on it without a
+ * second round-trip — and without a window where the row could already be gone.
+ */
+async function replacePendingClaim(
+  values: typeof dbSchema.gymClaims.$inferInsert,
+): Promise<typeof dbSchema.gymClaims.$inferSelect> {
+  return db.transaction(async (tx) => {
     await tx
       .delete(dbSchema.gymClaims)
       .where(
@@ -247,7 +253,8 @@ async function replacePendingClaim(values: typeof dbSchema.gymClaims.$inferInser
           eq(dbSchema.gymClaims.status, 'pending'),
         ),
       );
-    await tx.insert(dbSchema.gymClaims).values(values);
+    const [inserted] = await tx.insert(dbSchema.gymClaims).values(values).returning();
+    return inserted;
   });
 }
 
@@ -411,7 +418,7 @@ export const socialGymClaimMutations = {
       return { status: 'admin_review' };
     }
 
-    await replacePendingClaim({
+    const queuedClaim = await replacePendingClaim({
       gymId: gym.id,
       claimantUserId: userId,
       method: 'admin',
@@ -419,13 +426,10 @@ export const socialGymClaimMutations = {
       message: validatedInput.message ?? null,
     });
 
-    const queuedClaim = await findPendingClaim(gym.id, userId);
-    if (queuedClaim) {
-      const autoApplied = await tryAutoApproveAdminClaim(ctx, gym, queuedClaim);
-      if (autoApplied) {
-        await notifyClaimApplied(autoApplied);
-        return { status: 'approved' };
-      }
+    const autoApplied = await tryAutoApproveAdminClaim(ctx, gym, queuedClaim);
+    if (autoApplied) {
+      await notifyClaimApplied(autoApplied);
+      return { status: 'approved' };
     }
 
     // Best-effort: the claim is already queued and visible in /admin/gym-claims,

--- a/packages/backend/src/graphql/resolvers/social/gym-claims.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-claims.ts
@@ -276,6 +276,10 @@ async function replacePendingClaim(
         ),
       );
     const [inserted] = await tx.insert(dbSchema.gymClaims).values(values).returning();
+    // A successful INSERT ... RETURNING always yields a row, but the destructure
+    // is typed as possibly-undefined and the caller feeds this straight into
+    // applyGymClaim. Fail here rather than forward an undefined claim.
+    if (!inserted) throw new Error('Failed to create gym claim: insert returned no rows');
     return inserted;
   });
 }

--- a/packages/backend/src/graphql/resolvers/social/gym-claims.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-claims.ts
@@ -220,7 +220,11 @@ async function tryAutoApproveAdminClaim(
   if (!(await gymClaimAutoApproveEnabled())) return null;
 
   try {
-    // Tighter than requestGymClaim's own limit: each pass here can hand over a gym.
+    // Tighter than requestGymClaim's own limit: each pass here can hand over a
+    // gym. The cap is global rather than per-instance — the caller is always
+    // authenticated (requestGymClaim requires it), so applyRateLimit's tier-2
+    // Redis bucket on `${userId}:gymClaimAutoApprove` applies on top of the
+    // tier-1 in-process one.
     await applyRateLimit(ctx, 3, 'gymClaimAutoApprove');
 
     const result = await applyGymClaim(claim, { requireCurrentOwnerId: SYSTEM_BOARD_OWNER_ID });

--- a/packages/backend/src/graphql/resolvers/social/gym-claims.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-claims.ts
@@ -203,9 +203,11 @@ export async function verifyGymClaimByToken(
  * swallowing it here degrades to `admin_review` instead of handing the user a
  * server error for a claim that is in fact safely queued.
  *
- * The rate limit above is deliberately outside that catch: hitting it is a
- * client-facing condition the caller should see, matching how requestGymClaim's
- * own limit behaves.
+ * That includes the rate limit, which bounds how many gyms one account can be
+ * handed instantly. Unlike requestGymClaim's own limit — which runs before
+ * anything is written, so throwing leaves nothing behind — this one runs after
+ * the claim row is committed. Exhausting it therefore means "don't auto-approve
+ * this one", not "reject the request": the claim stays queued for a human.
  *
  * Auto-approved rows are recognisable as `method='admin' AND status='approved'
  * AND reviewed_by IS NULL`; there's no dedicated column, so no migration.
@@ -216,12 +218,18 @@ async function tryAutoApproveAdminClaim(
   claim: typeof dbSchema.gymClaims.$inferSelect,
 ): Promise<ClaimApplied | null> {
   if (!(await gymClaimAutoApproveEnabled())) return null;
-  // Tighter than requestGymClaim's own limit: each pass here can hand over a gym.
-  await applyRateLimit(ctx, 3, 'gymClaimAutoApprove');
 
-  let result: ClaimApplied | null;
   try {
-    result = await applyGymClaim(claim, { requireCurrentOwnerId: SYSTEM_BOARD_OWNER_ID });
+    // Tighter than requestGymClaim's own limit: each pass here can hand over a gym.
+    await applyRateLimit(ctx, 3, 'gymClaimAutoApprove');
+
+    const result = await applyGymClaim(claim, { requireCurrentOwnerId: SYSTEM_BOARD_OWNER_ID });
+    if (result) {
+      logger.info(
+        `[GymClaim] Auto-approved claim ${claim.id} on gym ${gym.uuid} for user ${claim.claimantUserId} (unclaimed listing)`,
+      );
+    }
+    return result;
   } catch (error) {
     logger.warn(
       `[GymClaim] Auto-approval of claim ${claim.id} on gym ${gym.uuid} failed; leaving it queued for review:`,
@@ -229,13 +237,6 @@ async function tryAutoApproveAdminClaim(
     );
     return null;
   }
-
-  if (result) {
-    logger.info(
-      `[GymClaim] Auto-approved claim ${claim.id} on gym ${gym.uuid} for user ${claim.claimantUserId} (unclaimed listing)`,
-    );
-  }
-  return result;
 }
 
 /** The single pending claim (if any) this user has on this gym. */

--- a/packages/backend/src/graphql/resolvers/social/gym-claims.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-claims.ts
@@ -231,10 +231,8 @@ async function tryAutoApproveAdminClaim(
     }
     return result;
   } catch (error) {
-    logger.warn(
-      `[GymClaim] Auto-approval of claim ${claim.id} on gym ${gym.uuid} failed; leaving it queued for review:`,
-      error instanceof Error ? error.message : error,
-    );
+    // Pass the Error itself, not `.message` — winston serializes the stack.
+    logger.warn(`[GymClaim] Auto-approval of claim ${claim.id} on gym ${gym.uuid} failed; leaving it queued:`, error);
     return null;
   }
 }
@@ -522,10 +520,7 @@ export const socialGymClaimMutations = {
     try {
       result = await applyGymClaim(claim, { reviewerId: adminUserId });
     } catch (error) {
-      logger.warn(
-        `[GymClaim] Manual approval of claim ${claim.id} lost an ownership race:`,
-        error instanceof Error ? error.message : error,
-      );
+      logger.warn(`[GymClaim] Manual approval of claim ${claim.id} lost an ownership race:`, error);
       result = null;
     }
 

--- a/packages/backend/src/graphql/resolvers/social/roles.ts
+++ b/packages/backend/src/graphql/resolvers/social/roles.ts
@@ -6,20 +6,27 @@ import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/h
 import { GrantRoleInputSchema, RevokeRoleInputSchema } from '../../../validation/schemas';
 
 /**
- * Check if a user has admin role (global or for a specific board type).
+ * Non-throwing check: does the user hold an admin role that is global or scoped
+ * to the given board type? Mirrors `requireAdmin` for callers that need a
+ * boolean rather than a throw (e.g. deciding whether to redact admin-only rows
+ * from a query result).
  */
-export async function requireAdmin(ctx: ConnectionContext, boardType?: string | null): Promise<void> {
-  requireAuthenticated(ctx);
-  const userId = ctx.userId!;
-
+export async function hasAdmin(userId: string, boardType?: string | null): Promise<boolean> {
   const roles = await db
     .select({ role: dbSchema.communityRoles.role, boardType: dbSchema.communityRoles.boardType })
     .from(dbSchema.communityRoles)
     .where(eq(dbSchema.communityRoles.userId, userId));
 
-  const isAdmin = roles.some((r) => r.role === 'admin' && (r.boardType === null || r.boardType === boardType));
+  return roles.some((entry) => entry.role === 'admin' && (entry.boardType === null || entry.boardType === boardType));
+}
 
-  if (!isAdmin) {
+/**
+ * Check if a user has admin role (global or for a specific board type).
+ */
+export async function requireAdmin(ctx: ConnectionContext, boardType?: string | null): Promise<void> {
+  requireAuthenticated(ctx);
+
+  if (!(await hasAdmin(ctx.userId!, boardType))) {
     throw new Error('Admin role required for this operation');
   }
 }

--- a/packages/mobile/src/components/gym-directory/ClaimGymSheet.tsx
+++ b/packages/mobile/src/components/gym-directory/ClaimGymSheet.tsx
@@ -28,7 +28,9 @@ type ClaimGymSheetProps = {
 /**
  * The ownership-claim flow, shown from the gym-edit screen when `gym.canClaim`.
  * With a work email at the gym's website domain the backend emails a verification
- * link (`email_sent`); otherwise the claim goes to admin review (`admin_review`).
+ * link (`email_sent`); otherwise the claim goes to admin review (`admin_review`),
+ * or lands straight away (`approved`) when an admin has turned on auto-approval
+ * and the gym is an unclaimed listing.
  * A domain mismatch rejects with a GraphQL error surfaced inline. Feedback stays
  * INSIDE the sheet — toasts render behind a native modal sheet — and the emailed
  * link is opened in the browser and handled by the backend, so the app does
@@ -118,7 +120,9 @@ export function ClaimGymSheet({ sheetRef, gym, onClosed }: ClaimGymSheetProps) {
           <Text variant="headline" style={styles.confirmationTitle}>
             {confirmation.status === 'email_sent'
               ? t('mobile.gymClaim.domain.sent', { email: confirmation.email ?? trimmedEmail })
-              : t('mobile.gymClaim.admin.sent')}
+              : confirmation.status === 'approved'
+                ? t('mobile.gymClaim.approved.sent', { gym: gym.name })
+                : t('mobile.gymClaim.admin.sent')}
           </Text>
           <Button title={t('mobile.gymClaim.done')} onPress={dismiss} variant="filled" size="large" />
         </View>

--- a/packages/mobile/src/components/gym-directory/__tests__/claim-gym-sheet.test.tsx
+++ b/packages/mobile/src/components/gym-directory/__tests__/claim-gym-sheet.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode, type RefObject } from 'react';
+import type { Gym } from '@boardsesh/shared-schema';
+import type { ManagedSheetHandle } from '../../../providers/sheet-presentation-provider';
+
+type Children = { children?: ReactNode };
+type PressProps = { children?: ReactNode; onPress?: () => void; accessibilityLabel?: string };
+type ButtonProps = { title?: string; onPress?: () => void };
+
+vi.mock('react-native', () => ({
+  View: ({ children }: Children) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('@expo/ui/community/bottom-sheet', () => ({
+  BottomSheetTextInput: (props: Record<string, unknown>) =>
+    createElement('input', { 'aria-label': props.placeholder as string }),
+}));
+
+vi.mock('../../ModalSheet', () => ({
+  ModalSheet: ({ children }: Children) => createElement('div', null, children),
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: Children) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement('i', { 'data-icon': name }) }));
+vi.mock('../../Button', () => ({
+  Button: ({ title, onPress }: ButtonProps) => createElement('button', { onClick: onPress, type: 'button' }, title),
+}));
+vi.mock('../../PressableSurface', () => ({
+  PressableSurface: ({ children, onPress, accessibilityLabel }: PressProps) =>
+    createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel, type: 'button' }, children),
+}));
+
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 6: 24, 8: 32 },
+  borderRadius: { sm: 6, md: 8, lg: 12, full: 9999 },
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { label: '#000', secondaryLabel: '#666', separator: '#ccc', tertiarySystemFill: '#eee' },
+    brandColors: { success: '#0a0', primary: '#6D28D9' },
+  }),
+}));
+
+// The i18n mock returns the key so assertions pin which branch rendered,
+// independent of catalog copy (parity is covered by the catalog tests).
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en-US' } }),
+}));
+
+const mockMutateAsync = vi.fn();
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useRequestGymClaim: () => ({ mutateAsync: mockMutateAsync, reset: vi.fn(), isPending: false }),
+}));
+
+vi.mock('../../../lib/graphql/extract-error-message', () => ({
+  extractGraphqlMessage: (error: unknown) => (error as Error)?.message ?? null,
+}));
+
+import { ClaimGymSheet } from '../ClaimGymSheet';
+
+// No website, so the sheet opens in admin-review mode — the only path that can
+// come back `approved`.
+const gym = { uuid: 'gym-uuid-1', name: 'Bonsist', website: null } as unknown as Gym;
+const sheetRef = { current: { dismiss: vi.fn() } } as unknown as RefObject<ManagedSheetHandle | null>;
+
+const renderSheet = () => render(<ClaimGymSheet sheetRef={sheetRef} gym={gym} />);
+
+const submit = () => fireEvent.click(screen.getByText('mobile.gymClaim.admin.submit'));
+
+describe('ClaimGymSheet — claim outcome', () => {
+  it('confirms ownership when the claim is auto-approved', async () => {
+    mockMutateAsync.mockResolvedValueOnce({ status: 'approved', email: null });
+
+    renderSheet();
+    submit();
+
+    await waitFor(() => expect(screen.getByText('mobile.gymClaim.approved.sent')).toBeTruthy());
+  });
+
+  it('shows the review message when the claim only queues', async () => {
+    mockMutateAsync.mockResolvedValueOnce({ status: 'admin_review', email: null });
+
+    renderSheet();
+    submit();
+
+    // The bug this pins: before `approved` existed, anything that wasn't
+    // `email_sent` fell into this branch — so an approved claim told the user
+    // to wait for a review that had already happened.
+    await waitFor(() => expect(screen.getByText('mobile.gymClaim.admin.sent')).toBeTruthy());
+    expect(screen.queryByText('mobile.gymClaim.approved.sent')).toBeNull();
+  });
+});

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -593,15 +593,28 @@ export function useRevokeGymWriteAccess() {
 /**
  * Start an ownership claim for a gym. With a `claimEmail` matching the gym's
  * website domain the server sends a verification email (`email_sent`); otherwise
- * the claim goes to admin review (`admin_review`). A domain mismatch rejects with
- * a GraphQL error the caller surfaces inline. No cache invalidation — ownership
- * only transfers once the emailed link is followed in the browser.
+ * the claim goes to admin review (`admin_review`), or lands immediately
+ * (`approved`) when auto-approval is on and the gym is an unclaimed listing.
+ * A domain mismatch rejects with a GraphQL error the caller surfaces inline.
+ *
+ * Only `approved` transfers ownership here, so that's the only status that
+ * invalidates: the other two resolve later (emailed link, admin queue) and leave
+ * the cached gym correct. Mirrors the `updateGym` invalidation set, since the
+ * claimant's `canClaim` / edit access and gym membership all just changed.
  */
 export function useRequestGymClaim() {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (input: RequestGymClaimInput) => {
       const response = await getHttpClient().request<RequestGymClaimMutationResponse>(REQUEST_GYM_CLAIM, { input });
       return response.requestGymClaim;
+    },
+    onSuccess: (result, input) => {
+      if (result.status !== 'approved') return;
+      void queryClient.invalidateQueries({ queryKey: ['gym', input.gymUuid] });
+      void queryClient.invalidateQueries({ queryKey: ['gymMembers', input.gymUuid] });
+      void queryClient.invalidateQueries({ queryKey: ['myGyms'] });
+      void queryClient.invalidateQueries({ queryKey: ['nearbyGyms'] });
     },
   });
 }

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -2698,6 +2698,8 @@ enum GymClaimRequestStatus {
   email_sent
   "The claim was queued for admin review and our team was notified."
   admin_review
+  "The claim was approved on the spot — the gym was an unclaimed listing and auto-approval is on. The claimant already manages the gym."
+  approved
 }
 
 """

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -2453,6 +2453,8 @@ export type GymClaimMethod =
 export type GymClaimRequestStatus =
   /** The claim was queued for admin review and our team was notified. */
   | 'admin_review'
+  /** The claim was approved on the spot — the gym was an unclaimed listing and auto-approval is on. The claimant already manages the gym. */
+  | 'approved'
   /** A verification email was sent to the claimant's work address. */
   | 'email_sent';
 

--- a/packages/shared-schema/src/schema/gyms.ts
+++ b/packages/shared-schema/src/schema/gyms.ts
@@ -32,6 +32,8 @@ export const gymsTypeDefs = /* GraphQL */ `
     email_sent
     "The claim was queued for admin review and our team was notified."
     admin_review
+    "The claim was approved on the spot — the gym was an unclaimed listing and auto-approval is on. The claimant already manages the gym."
+    approved
   }
 
   """

--- a/packages/shared-schema/src/types/gyms.ts
+++ b/packages/shared-schema/src/types/gyms.ts
@@ -6,7 +6,7 @@ export type GymClaimMethod = 'domain' | 'admin';
 
 export type GymClaimStatus = 'pending' | 'approved' | 'denied' | 'expired';
 
-export type GymClaimRequestStatus = 'email_sent' | 'admin_review';
+export type GymClaimRequestStatus = 'email_sent' | 'admin_review' | 'approved';
 
 export type GymClaimDecision = 'approve' | 'deny';
 

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -2450,6 +2450,8 @@ export type GymClaimMethod =
 export type GymClaimRequestStatus =
   /** The claim was queued for admin review and our team was notified. */
   | 'admin_review'
+  /** The claim was approved on the spot — the gym was an unclaimed listing and auto-approval is on. The claimant already manages the gym. */
+  | 'approved'
   /** A verification email was sent to the claimant's work address. */
   | 'email_sent';
 

--- a/packages/shared/i18n/locales/de/admin.json
+++ b/packages/shared/i18n/locales/de/admin.json
@@ -16,7 +16,8 @@
   },
   "tabs": {
     "roles": "Rollen",
-    "settings": "Einstellungen"
+    "settings": "Einstellungen",
+    "gyms": "Hallen"
   },
   "nav": {
     "retention": "Retention-Dashboard",
@@ -215,6 +216,20 @@
       "saved_one": "{{count}} Einstellung gespeichert",
       "saved_other": "{{count}} Einstellungen gespeichert",
       "saveFailed": "Die Einstellungen ließen sich nicht speichern"
+    }
+  },
+  "gymSettings": {
+    "heading": "Hallen-Einstellungen",
+    "autoApprove": {
+      "label": "Ansprüche automatisch bestätigen",
+      "description": "Übergib Hallen ohne Besitzer direkt an die Person, die sie beansprucht. Ansprüche auf eine Halle, die schon jemandem gehört, landen weiterhin bei dir.",
+      "queueNote": "Ansprüche, die schon in der Liste stehen, bleiben dort."
+    },
+    "snackbar": {
+      "enabled": "Automatische Bestätigung ist an.",
+      "disabled": "Automatische Bestätigung ist aus.",
+      "saveFailed": "Konnte nicht gespeichert werden. Versuch es nochmal.",
+      "loadFailed": "Hallen-Einstellungen konnten nicht geladen werden."
     }
   },
   "gymClaims": {

--- a/packages/shared/i18n/locales/de/boards.json
+++ b/packages/shared/i18n/locales/de/boards.json
@@ -279,6 +279,9 @@
         "messagePlaceholder": "Alles, was uns hilft zu prüfen, dass du diese Halle leitest",
         "submit": "Prüfung anfragen",
         "sent": "Wir haben unser Team benachrichtigt. Wir melden uns bald."
+      },
+      "approved": {
+        "sent": "{{gym}} gehört jetzt dir."
       }
     },
     "offline": {
@@ -657,6 +660,10 @@
       "messagePlaceholder": "Alles, was uns hilft zu prüfen, dass du diese Halle leitest",
       "submit": "Prüfung anfragen",
       "sent": "Wir haben unser Team benachrichtigt. Wir melden uns bald."
+    },
+    "approved": {
+      "body": "{{gym}} gehört jetzt dir. Richte sie ein, wann du willst.",
+      "manageCta": "Halle einrichten"
     }
   },
   "claimLanding": {

--- a/packages/shared/i18n/locales/en-US/admin.json
+++ b/packages/shared/i18n/locales/en-US/admin.json
@@ -16,7 +16,8 @@
   },
   "tabs": {
     "roles": "Roles",
-    "settings": "Settings"
+    "settings": "Settings",
+    "gyms": "Gyms"
   },
   "nav": {
     "retention": "Retention dashboard",
@@ -215,6 +216,20 @@
       "saved_one": "Saved {{count}} setting",
       "saved_other": "Saved {{count}} settings",
       "saveFailed": "Failed to save settings"
+    }
+  },
+  "gymSettings": {
+    "heading": "Gym Settings",
+    "autoApprove": {
+      "label": "Auto-approve ownership claims",
+      "description": "Hand unclaimed gym listings straight to whoever claims them. Claims on a gym someone already owns still come to you.",
+      "queueNote": "Claims already waiting in the queue stay there."
+    },
+    "snackbar": {
+      "enabled": "Auto-approval is on.",
+      "disabled": "Auto-approval is off.",
+      "saveFailed": "Couldn't save that. Try again.",
+      "loadFailed": "Couldn't load gym settings."
     }
   },
   "gymClaims": {

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -279,6 +279,9 @@
         "messagePlaceholder": "Anything that helps us verify you run this gym",
         "submit": "Request review",
         "sent": "We've emailed our team. They'll be in touch soon."
+      },
+      "approved": {
+        "sent": "{{gym}} is yours to manage."
       }
     },
     "offline": {
@@ -657,6 +660,10 @@
       "messagePlaceholder": "Anything that helps us verify you run this gym",
       "submit": "Request review",
       "sent": "We've emailed our team. They'll be in touch soon."
+    },
+    "approved": {
+      "body": "{{gym}} is yours. Set it up whenever you're ready.",
+      "manageCta": "Set up your gym"
     }
   },
   "claimLanding": {

--- a/packages/shared/i18n/locales/es/admin.json
+++ b/packages/shared/i18n/locales/es/admin.json
@@ -16,7 +16,8 @@
   },
   "tabs": {
     "roles": "Roles",
-    "settings": "Ajustes"
+    "settings": "Ajustes",
+    "gyms": "Gimnasios"
   },
   "roles": {
     "heading": "Roles de la comunidad",
@@ -115,6 +116,20 @@
       "saved_one": "Se guardó {{count}} ajuste",
       "saved_other": "Se guardaron {{count}} ajustes",
       "saveFailed": "No se pudieron guardar los ajustes"
+    }
+  },
+  "gymSettings": {
+    "heading": "Ajustes de gimnasios",
+    "autoApprove": {
+      "label": "Aprobar reclamaciones automáticamente",
+      "description": "Entrega los gimnasios sin dueño a quien los reclame. Las reclamaciones sobre un gimnasio que ya tiene dueño te siguen llegando a ti.",
+      "queueNote": "Las reclamaciones que ya están en la cola se quedan ahí."
+    },
+    "snackbar": {
+      "enabled": "Aprobación automática activada.",
+      "disabled": "Aprobación automática desactivada.",
+      "saveFailed": "No se pudo guardar. Inténtalo de nuevo.",
+      "loadFailed": "No se pudieron cargar los ajustes de gimnasios."
     }
   },
   "nav": {

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -279,6 +279,9 @@
         "messagePlaceholder": "Cualquier cosa que nos ayude a verificar que gestionas este gimnasio",
         "submit": "Solicitar revisión",
         "sent": "Hemos avisado a nuestro equipo. Se pondrán en contacto pronto."
+      },
+      "approved": {
+        "sent": "{{gym}} ya es tuyo."
       }
     },
     "offline": {
@@ -657,6 +660,10 @@
       "messagePlaceholder": "Cualquier cosa que nos ayude a verificar que gestionas este gimnasio",
       "submit": "Solicitar revisión",
       "sent": "Hemos avisado a nuestro equipo. Se pondrán en contacto pronto."
+    },
+    "approved": {
+      "body": "{{gym}} es tuyo. Configúralo cuando quieras.",
+      "manageCta": "Configura tu gimnasio"
     }
   },
   "claimLanding": {

--- a/packages/shared/i18n/locales/fr/admin.json
+++ b/packages/shared/i18n/locales/fr/admin.json
@@ -16,7 +16,8 @@
   },
   "tabs": {
     "roles": "Rôles",
-    "settings": "Paramètres"
+    "settings": "Paramètres",
+    "gyms": "Salles"
   },
   "nav": {
     "retention": "Tableau de rétention",
@@ -215,6 +216,20 @@
       "saved_one": "{{count}} paramètre enregistré",
       "saved_other": "{{count}} paramètres enregistrés",
       "saveFailed": "Impossible d'enregistrer les paramètres"
+    }
+  },
+  "gymSettings": {
+    "heading": "Paramètres des salles",
+    "autoApprove": {
+      "label": "Approuver automatiquement les revendications",
+      "description": "Confiez les salles sans propriétaire à la personne qui les revendique. Les revendications sur une salle déjà détenue vous reviennent toujours.",
+      "queueNote": "Les revendications déjà en file d'attente y restent."
+    },
+    "snackbar": {
+      "enabled": "Approbation automatique activée.",
+      "disabled": "Approbation automatique désactivée.",
+      "saveFailed": "Enregistrement impossible. Réessayez.",
+      "loadFailed": "Impossible de charger les paramètres des salles."
     }
   },
   "gymClaims": {

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -279,6 +279,9 @@
         "messagePlaceholder": "Tout ce qui nous aide à vérifier que tu gères cette salle",
         "submit": "Demander une vérification",
         "sent": "Nous avons prévenu notre équipe. Elle te contactera bientôt."
+      },
+      "approved": {
+        "sent": "{{gym}} est à toi."
       }
     },
     "offline": {
@@ -657,6 +660,10 @@
       "messagePlaceholder": "Tout ce qui nous aide à vérifier que vous gérez cette salle",
       "submit": "Demander une vérification",
       "sent": "Nous avons prévenu notre équipe. Elle vous contactera bientôt."
+    },
+    "approved": {
+      "body": "{{gym}} est à vous. Configurez-la quand vous voulez.",
+      "manageCta": "Configurer votre salle"
     }
   },
   "claimLanding": {

--- a/packages/web/app/admin/page.tsx
+++ b/packages/web/app/admin/page.tsx
@@ -16,6 +16,7 @@ import { GET_MY_ROLES } from '@boardsesh/graphql/operations/proposals';
 import type { CommunityRoleAssignment } from '@boardsesh/shared-schema';
 import RoleManagement from '@/app/components/admin/role-management';
 import CommunitySettingsPanel from '@/app/components/admin/community-settings-panel';
+import GymSettingsPanel from '@/app/components/admin/gym-settings-panel';
 import LocaleLink from '@/app/components/i18n/locale-link';
 
 export default function AdminPage() {
@@ -102,11 +103,13 @@ export default function AdminPage() {
         <Tabs value={tab} onChange={(_, v) => setTab(v)}>
           <Tab label={t('tabs.roles')} sx={{ textTransform: 'none' }} />
           <Tab label={t('tabs.settings')} sx={{ textTransform: 'none' }} />
+          <Tab label={t('tabs.gyms')} sx={{ textTransform: 'none' }} />
         </Tabs>
       </Box>
 
       {tab === 0 && <RoleManagement />}
       {tab === 1 && <CommunitySettingsPanel />}
+      {tab === 2 && <GymSettingsPanel />}
     </Container>
   );
 }

--- a/packages/web/app/admin/page.tsx
+++ b/packages/web/app/admin/page.tsx
@@ -24,6 +24,7 @@ export default function AdminPage() {
   const { token } = useWsAuthToken();
   const [tab, setTab] = useState(0);
   const [isAdmin, setIsAdmin] = useState(false);
+  const [isGlobalAdmin, setIsGlobalAdmin] = useState(false);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -35,10 +36,16 @@ export default function AdminPage() {
       try {
         const client = createGraphQLHttpClient(token);
         const result = await client.request<{ myRoles: CommunityRoleAssignment[] }>(GET_MY_ROLES);
-        const hasAdmin = result.myRoles.some((r) => r.role === 'admin');
-        setIsAdmin(hasAdmin);
+        setIsAdmin(result.myRoles.some((role) => role.role === 'admin'));
+        // Gym settings are global config, and the backend gates them with
+        // `requireAdmin(ctx)` / `hasAdmin(userId)` — no board type — which a
+        // board-scoped admin fails. Without this narrower check they'd see the
+        // tab, read the toggle as off whatever its real value, and hit an
+        // authorization error on every change.
+        setIsGlobalAdmin(result.myRoles.some((role) => role.role === 'admin' && role.boardType == null));
       } catch {
         setIsAdmin(false);
+        setIsGlobalAdmin(false);
       } finally {
         setLoading(false);
       }
@@ -103,13 +110,13 @@ export default function AdminPage() {
         <Tabs value={tab} onChange={(_, v) => setTab(v)}>
           <Tab label={t('tabs.roles')} sx={{ textTransform: 'none' }} />
           <Tab label={t('tabs.settings')} sx={{ textTransform: 'none' }} />
-          <Tab label={t('tabs.gyms')} sx={{ textTransform: 'none' }} />
+          {isGlobalAdmin && <Tab label={t('tabs.gyms')} sx={{ textTransform: 'none' }} />}
         </Tabs>
       </Box>
 
       {tab === 0 && <RoleManagement />}
       {tab === 1 && <CommunitySettingsPanel />}
-      {tab === 2 && <GymSettingsPanel />}
+      {tab === 2 && isGlobalAdmin && <GymSettingsPanel />}
     </Container>
   );
 }

--- a/packages/web/app/components/admin/__tests__/gym-settings-panel.test.tsx
+++ b/packages/web/app/components/admin/__tests__/gym-settings-panel.test.tsx
@@ -84,6 +84,17 @@ describe('GymSettingsPanel', () => {
     expect(getSwitch().checked).toBe(false);
   });
 
+  it('surfaces a load failure and leaves the switch disabled', async () => {
+    mockRequest.mockRejectedValueOnce(new Error('network down'));
+
+    render(<GymSettingsPanel />);
+
+    await screen.findByText("Couldn't load gym settings.");
+    // Never let a failed read look like "auto-approval is off" — the switch
+    // stays disabled so an admin can't act on a value we never received.
+    expect(getSwitch().disabled).toBe(true);
+  });
+
   it('rolls the toggle back when the write is rejected', async () => {
     mockRequest.mockResolvedValueOnce({ communitySettings: [] });
     render(<GymSettingsPanel />);

--- a/packages/web/app/components/admin/__tests__/gym-settings-panel.test.tsx
+++ b/packages/web/app/components/admin/__tests__/gym-settings-panel.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import React from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { createTestQueryClient } from '@/app/test-utils/test-providers';
 import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
 import GymSettingsPanel from '../gym-settings-panel';
 
@@ -26,6 +28,14 @@ const AUTO_APPROVE_KEY = 'gym_claim_auto_approve';
 /** The panel's only control. MUI's Switch renders its input with role="switch". */
 const getSwitch = () => screen.getByRole('switch') as HTMLInputElement;
 
+/** The panel reads and writes through React Query, so it needs a client. */
+const renderPanel = () =>
+  render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      <GymSettingsPanel />
+    </QueryClientProvider>,
+  );
+
 beforeEach(() => {
   mockRequest.mockReset();
 });
@@ -34,7 +44,7 @@ describe('GymSettingsPanel', () => {
   it('reads the saved value — an unset setting shows as off', async () => {
     mockRequest.mockResolvedValueOnce({ communitySettings: [] });
 
-    render(<GymSettingsPanel />);
+    renderPanel();
 
     await waitFor(() => expect(getSwitch().disabled).toBe(false));
     expect(getSwitch().checked).toBe(false);
@@ -45,21 +55,22 @@ describe('GymSettingsPanel', () => {
       communitySettings: [{ id: '1', scope: 'global', scopeKey: '', key: AUTO_APPROVE_KEY, value: '1' }],
     });
 
-    render(<GymSettingsPanel />);
+    renderPanel();
 
     await waitFor(() => expect(getSwitch().checked).toBe(true));
   });
 
   it('writes the global setting when toggled on', async () => {
     mockRequest.mockResolvedValueOnce({ communitySettings: [] });
-    render(<GymSettingsPanel />);
+    renderPanel();
     await waitFor(() => expect(getSwitch().disabled).toBe(false));
 
     mockRequest.mockResolvedValueOnce({ setCommunitySettings: { id: '1', key: AUTO_APPROVE_KEY, value: '1' } });
     fireEvent.click(getSwitch());
 
+    // onSettled refetches, so the write is not necessarily the last call.
     await waitFor(() =>
-      expect(mockRequest).toHaveBeenLastCalledWith(expect.anything(), {
+      expect(mockRequest).toHaveBeenCalledWith(expect.anything(), {
         input: { scope: 'global', scopeKey: '', key: AUTO_APPROVE_KEY, value: '1' },
       }),
     );
@@ -70,14 +81,15 @@ describe('GymSettingsPanel', () => {
     mockRequest.mockResolvedValueOnce({
       communitySettings: [{ id: '1', scope: 'global', scopeKey: '', key: AUTO_APPROVE_KEY, value: '1' }],
     });
-    render(<GymSettingsPanel />);
+    renderPanel();
     await waitFor(() => expect(getSwitch().checked).toBe(true));
 
     mockRequest.mockResolvedValueOnce({ setCommunitySettings: { id: '1', key: AUTO_APPROVE_KEY, value: '0' } });
     fireEvent.click(getSwitch());
 
+    // onSettled refetches, so the write is not necessarily the last call.
     await waitFor(() =>
-      expect(mockRequest).toHaveBeenLastCalledWith(expect.anything(), {
+      expect(mockRequest).toHaveBeenCalledWith(expect.anything(), {
         input: { scope: 'global', scopeKey: '', key: AUTO_APPROVE_KEY, value: '0' },
       }),
     );
@@ -87,7 +99,7 @@ describe('GymSettingsPanel', () => {
   it('surfaces a load failure and leaves the switch disabled', async () => {
     mockRequest.mockRejectedValueOnce(new Error('network down'));
 
-    render(<GymSettingsPanel />);
+    renderPanel();
 
     await screen.findByText("Couldn't load gym settings.");
     // Never let a failed read look like "auto-approval is off" — the switch
@@ -97,7 +109,7 @@ describe('GymSettingsPanel', () => {
 
   it('rolls the toggle back when the write is rejected', async () => {
     mockRequest.mockResolvedValueOnce({ communitySettings: [] });
-    render(<GymSettingsPanel />);
+    renderPanel();
     await waitFor(() => expect(getSwitch().disabled).toBe(false));
 
     // A community leader hitting the admin-only gate looks exactly like this.

--- a/packages/web/app/components/admin/__tests__/gym-settings-panel.test.tsx
+++ b/packages/web/app/components/admin/__tests__/gym-settings-panel.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import GymSettingsPanel from '../gym-settings-panel';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({ token: 'test-token', isAuthenticated: true, isLoading: false, error: null }),
+}));
+
+const mockRequest = vi.fn();
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+const AUTO_APPROVE_KEY = 'gym_claim_auto_approve';
+
+/** The panel's only control. MUI's Switch renders its input with role="switch". */
+const getSwitch = () => screen.getByRole('switch') as HTMLInputElement;
+
+beforeEach(() => {
+  mockRequest.mockReset();
+});
+
+describe('GymSettingsPanel', () => {
+  it('reads the saved value — an unset setting shows as off', async () => {
+    mockRequest.mockResolvedValueOnce({ communitySettings: [] });
+
+    render(<GymSettingsPanel />);
+
+    await waitFor(() => expect(getSwitch().disabled).toBe(false));
+    expect(getSwitch().checked).toBe(false);
+  });
+
+  it('reflects a saved value of "1" as on', async () => {
+    mockRequest.mockResolvedValueOnce({
+      communitySettings: [{ id: '1', scope: 'global', scopeKey: '', key: AUTO_APPROVE_KEY, value: '1' }],
+    });
+
+    render(<GymSettingsPanel />);
+
+    await waitFor(() => expect(getSwitch().checked).toBe(true));
+  });
+
+  it('writes the global setting when toggled on', async () => {
+    mockRequest.mockResolvedValueOnce({ communitySettings: [] });
+    render(<GymSettingsPanel />);
+    await waitFor(() => expect(getSwitch().disabled).toBe(false));
+
+    mockRequest.mockResolvedValueOnce({ setCommunitySettings: { id: '1', key: AUTO_APPROVE_KEY, value: '1' } });
+    fireEvent.click(getSwitch());
+
+    await waitFor(() =>
+      expect(mockRequest).toHaveBeenLastCalledWith(expect.anything(), {
+        input: { scope: 'global', scopeKey: '', key: AUTO_APPROVE_KEY, value: '1' },
+      }),
+    );
+    expect(getSwitch().checked).toBe(true);
+  });
+
+  it('writes "0" when toggled back off', async () => {
+    mockRequest.mockResolvedValueOnce({
+      communitySettings: [{ id: '1', scope: 'global', scopeKey: '', key: AUTO_APPROVE_KEY, value: '1' }],
+    });
+    render(<GymSettingsPanel />);
+    await waitFor(() => expect(getSwitch().checked).toBe(true));
+
+    mockRequest.mockResolvedValueOnce({ setCommunitySettings: { id: '1', key: AUTO_APPROVE_KEY, value: '0' } });
+    fireEvent.click(getSwitch());
+
+    await waitFor(() =>
+      expect(mockRequest).toHaveBeenLastCalledWith(expect.anything(), {
+        input: { scope: 'global', scopeKey: '', key: AUTO_APPROVE_KEY, value: '0' },
+      }),
+    );
+    expect(getSwitch().checked).toBe(false);
+  });
+
+  it('rolls the toggle back when the write is rejected', async () => {
+    mockRequest.mockResolvedValueOnce({ communitySettings: [] });
+    render(<GymSettingsPanel />);
+    await waitFor(() => expect(getSwitch().disabled).toBe(false));
+
+    // A community leader hitting the admin-only gate looks exactly like this.
+    mockRequest.mockRejectedValueOnce(new Error('Admin role required for this operation'));
+    fireEvent.click(getSwitch());
+
+    // The optimistic flip must not survive a rejected write, or the admin walks
+    // away believing auto-approval is on when the server never stored it.
+    await waitFor(() => expect(getSwitch().checked).toBe(false));
+  });
+});

--- a/packages/web/app/components/admin/gym-settings-panel.tsx
+++ b/packages/web/app/components/admin/gym-settings-panel.tsx
@@ -50,7 +50,11 @@ export default function GymSettingsPanel() {
 
   const setAutoApprove = useMutation({
     mutationFn: async (next: boolean) => {
-      const client = createGraphQLHttpClient(token!);
+      // The query is gated on `enabled: !!token`, but a mutation has no such
+      // gate — a toggle fired after the session expired would otherwise hand a
+      // null token to the client. Fail loudly into the error path instead.
+      if (!token) throw new Error('Not authenticated');
+      const client = createGraphQLHttpClient(token);
       await client.request(SET_COMMUNITY_SETTING, {
         input: { scope: SCOPE, scopeKey: SCOPE_KEY, key: AUTO_APPROVE_KEY, value: next ? '1' : '0' },
       });
@@ -103,7 +107,7 @@ export default function GymSettingsPanel() {
               checked={autoApprove}
               // Never let a failed or in-flight read look like "off" — an admin
               // shouldn't act on a value we haven't actually received.
-              disabled={!settingsQuery.isSuccess || setAutoApprove.isPending}
+              disabled={!token || !settingsQuery.isSuccess || setAutoApprove.isPending}
               onChange={(event) => setAutoApprove.mutate(event.target.checked)}
             />
           }

--- a/packages/web/app/components/admin/gym-settings-panel.tsx
+++ b/packages/web/app/components/admin/gym-settings-panel.tsx
@@ -25,6 +25,10 @@ const AUTO_APPROVE_KEY = 'gym_claim_auto_approve';
 
 const settingsQueryKey = ['communitySettings', SCOPE, SCOPE_KEY] as const;
 
+// Stands in for the server-assigned id on an optimistic first write. Never sent
+// anywhere and never read — the refetch replaces the row.
+const OPTIMISTIC_ROW_ID = -1;
+
 const isOn = (value: string | undefined) => value === '1' || value === 'true';
 
 export default function GymSettingsPanel() {
@@ -70,9 +74,24 @@ export default function GymSettingsPanel() {
       queryClient.setQueryData<CommunitySettingType[]>(settingsQueryKey, (current) => {
         const rows = current ?? [];
         const value = next ? '1' : '0';
-        return rows.some((setting) => setting.key === AUTO_APPROVE_KEY)
-          ? rows.map((setting) => (setting.key === AUTO_APPROVE_KEY ? { ...setting, value } : setting))
-          : [...rows, { key: AUTO_APPROVE_KEY, value, scope: SCOPE, scopeKey: SCOPE_KEY } as CommunitySettingType];
+        if (rows.some((setting) => setting.key === AUTO_APPROVE_KEY)) {
+          return rows.map((setting) => (setting.key === AUTO_APPROVE_KEY ? { ...setting, value } : setting));
+        }
+        // First-ever write: no row exists server-side yet. Build a complete
+        // placeholder rather than casting a partial one — only `key` and
+        // `value` are read here, and `onSettled`'s refetch replaces the whole
+        // row with the persisted one moments later.
+        const placeholder: CommunitySettingType = {
+          id: OPTIMISTIC_ROW_ID,
+          scope: SCOPE,
+          scopeKey: SCOPE_KEY,
+          key: AUTO_APPROVE_KEY,
+          value,
+          setBy: null,
+          createdAt: '',
+          updatedAt: '',
+        };
+        return [...rows, placeholder];
       });
       return { previous };
     },

--- a/packages/web/app/components/admin/gym-settings-panel.tsx
+++ b/packages/web/app/components/admin/gym-settings-panel.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Paper from '@mui/material/Paper';
+import Switch from '@mui/material/Switch';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+import { useTranslation } from 'react-i18next';
+import { themeTokens } from '@/app/theme/theme-config';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import { GET_COMMUNITY_SETTINGS, SET_COMMUNITY_SETTING } from '@boardsesh/graphql/operations/proposals';
+import type { CommunitySettingType } from '@boardsesh/shared-schema';
+
+// Gym settings are global-only — a gym claim isn't scoped to a board type or a
+// climb, so there's no scope selector here (unlike the community settings panel).
+const SCOPE = 'global';
+const SCOPE_KEY = '';
+
+const AUTO_APPROVE_KEY = 'gym_claim_auto_approve';
+
+export default function GymSettingsPanel() {
+  const { t } = useTranslation('admin');
+  const { token } = useWsAuthToken();
+  const [autoApprove, setAutoApprove] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [loadFailed, setLoadFailed] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [snackbar, setSnackbar] = useState('');
+
+  // Deliberately depends on `token` alone. Pulling `t` in here would re-run the
+  // effect on every render that hands back a fresh `t`, and each run re-fetches.
+  // Load failure is a flag; the copy for it is resolved in the JSX below.
+  const fetchSettings = useCallback(async () => {
+    if (!token) return;
+    try {
+      const client = createGraphQLHttpClient(token);
+      const result = await client.request<{ communitySettings: CommunitySettingType[] }>(GET_COMMUNITY_SETTINGS, {
+        scope: SCOPE,
+        scopeKey: SCOPE_KEY,
+      });
+      const saved = result.communitySettings.find((setting) => setting.key === AUTO_APPROVE_KEY)?.value;
+      setAutoApprove(saved === '1' || saved === 'true');
+      setLoadFailed(false);
+      setLoaded(true);
+    } catch (err) {
+      console.error('[GymSettings] Failed to fetch:', err);
+      setLoadFailed(true);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    void fetchSettings();
+  }, [fetchSettings]);
+
+  const handleToggle = useCallback(
+    async (next: boolean) => {
+      if (!token) return;
+      // Optimistic: flip immediately, roll back if the write is rejected.
+      setAutoApprove(next);
+      setSaving(true);
+      try {
+        const client = createGraphQLHttpClient(token);
+        await client.request(SET_COMMUNITY_SETTING, {
+          input: { scope: SCOPE, scopeKey: SCOPE_KEY, key: AUTO_APPROVE_KEY, value: next ? '1' : '0' },
+        });
+        setSnackbar(next ? t('gymSettings.snackbar.enabled') : t('gymSettings.snackbar.disabled'));
+      } catch {
+        setAutoApprove(!next);
+        setSnackbar(t('gymSettings.snackbar.saveFailed'));
+      } finally {
+        setSaving(false);
+      }
+    },
+    [token, t],
+  );
+
+  return (
+    <Box>
+      <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
+        {t('gymSettings.heading')}
+      </Typography>
+
+      {loadFailed && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {t('gymSettings.snackbar.loadFailed')}
+        </Alert>
+      )}
+
+      <Paper variant="outlined" sx={{ p: 2 }}>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={autoApprove}
+              disabled={!loaded || saving}
+              onChange={(event) => void handleToggle(event.target.checked)}
+            />
+          }
+          label={
+            <Typography variant="body2" sx={{ fontWeight: 600 }}>
+              {t('gymSettings.autoApprove.label')}
+            </Typography>
+          }
+        />
+        <Typography variant="caption" component="p" sx={{ color: themeTokens.neutral[500], mt: 0.5 }}>
+          {t('gymSettings.autoApprove.description')}
+        </Typography>
+        <Typography variant="caption" component="p" sx={{ color: themeTokens.neutral[500], mt: 1 }}>
+          {t('gymSettings.autoApprove.queueNote')}
+        </Typography>
+      </Paper>
+
+      <Snackbar open={!!snackbar} autoHideDuration={3000} onClose={() => setSnackbar('')} message={snackbar} />
+    </Box>
+  );
+}

--- a/packages/web/app/components/admin/gym-settings-panel.tsx
+++ b/packages/web/app/components/admin/gym-settings-panel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Paper from '@mui/material/Paper';
@@ -22,61 +23,66 @@ const SCOPE_KEY = '';
 
 const AUTO_APPROVE_KEY = 'gym_claim_auto_approve';
 
+const settingsQueryKey = ['communitySettings', SCOPE, SCOPE_KEY] as const;
+
+const isOn = (value: string | undefined) => value === '1' || value === 'true';
+
 export default function GymSettingsPanel() {
   const { t } = useTranslation('admin');
   const { token } = useWsAuthToken();
-  const [autoApprove, setAutoApprove] = useState(false);
-  const [loaded, setLoaded] = useState(false);
-  const [loadFailed, setLoadFailed] = useState(false);
-  const [saving, setSaving] = useState(false);
+  const queryClient = useQueryClient();
   const [snackbar, setSnackbar] = useState('');
 
-  // Deliberately depends on `token` alone. Pulling `t` in here would re-run the
-  // effect on every render that hands back a fresh `t`, and each run re-fetches.
-  // Load failure is a flag; the copy for it is resolved in the JSX below.
-  const fetchSettings = useCallback(async () => {
-    if (!token) return;
-    try {
-      const client = createGraphQLHttpClient(token);
+  const settingsQuery = useQuery({
+    queryKey: settingsQueryKey,
+    enabled: !!token,
+    queryFn: async () => {
+      const client = createGraphQLHttpClient(token!);
       const result = await client.request<{ communitySettings: CommunitySettingType[] }>(GET_COMMUNITY_SETTINGS, {
         scope: SCOPE,
         scopeKey: SCOPE_KEY,
       });
-      const saved = result.communitySettings.find((setting) => setting.key === AUTO_APPROVE_KEY)?.value;
-      setAutoApprove(saved === '1' || saved === 'true');
-      setLoadFailed(false);
-      setLoaded(true);
-    } catch (err) {
-      console.error('[GymSettings] Failed to fetch:', err);
-      setLoadFailed(true);
-    }
-  }, [token]);
-
-  useEffect(() => {
-    void fetchSettings();
-  }, [fetchSettings]);
-
-  const handleToggle = useCallback(
-    async (next: boolean) => {
-      if (!token) return;
-      // Optimistic: flip immediately, roll back if the write is rejected.
-      setAutoApprove(next);
-      setSaving(true);
-      try {
-        const client = createGraphQLHttpClient(token);
-        await client.request(SET_COMMUNITY_SETTING, {
-          input: { scope: SCOPE, scopeKey: SCOPE_KEY, key: AUTO_APPROVE_KEY, value: next ? '1' : '0' },
-        });
-        setSnackbar(next ? t('gymSettings.snackbar.enabled') : t('gymSettings.snackbar.disabled'));
-      } catch {
-        setAutoApprove(!next);
-        setSnackbar(t('gymSettings.snackbar.saveFailed'));
-      } finally {
-        setSaving(false);
-      }
+      return result.communitySettings;
     },
-    [token, t],
-  );
+  });
+
+  const autoApprove = isOn(settingsQuery.data?.find((setting) => setting.key === AUTO_APPROVE_KEY)?.value);
+
+  const setAutoApprove = useMutation({
+    mutationFn: async (next: boolean) => {
+      const client = createGraphQLHttpClient(token!);
+      await client.request(SET_COMMUNITY_SETTING, {
+        input: { scope: SCOPE, scopeKey: SCOPE_KEY, key: AUTO_APPROVE_KEY, value: next ? '1' : '0' },
+      });
+      return next;
+    },
+    // Optimistic flip with a snapshot rollback: React Query restores the
+    // previous cache on error, so a rejected write (e.g. a community leader
+    // hitting the admin-only gate) can't leave the switch showing a value the
+    // server never stored.
+    onMutate: async (next: boolean) => {
+      await queryClient.cancelQueries({ queryKey: settingsQueryKey });
+      const previous = queryClient.getQueryData<CommunitySettingType[]>(settingsQueryKey);
+      queryClient.setQueryData<CommunitySettingType[]>(settingsQueryKey, (current) => {
+        const rows = current ?? [];
+        const value = next ? '1' : '0';
+        return rows.some((setting) => setting.key === AUTO_APPROVE_KEY)
+          ? rows.map((setting) => (setting.key === AUTO_APPROVE_KEY ? { ...setting, value } : setting))
+          : [...rows, { key: AUTO_APPROVE_KEY, value, scope: SCOPE, scopeKey: SCOPE_KEY } as CommunitySettingType];
+      });
+      return { previous };
+    },
+    onError: (_error, _next, context) => {
+      queryClient.setQueryData(settingsQueryKey, context?.previous);
+      setSnackbar(t('gymSettings.snackbar.saveFailed'));
+    },
+    onSuccess: (next) => {
+      setSnackbar(next ? t('gymSettings.snackbar.enabled') : t('gymSettings.snackbar.disabled'));
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: settingsQueryKey });
+    },
+  });
 
   return (
     <Box>
@@ -84,7 +90,7 @@ export default function GymSettingsPanel() {
         {t('gymSettings.heading')}
       </Typography>
 
-      {loadFailed && (
+      {settingsQuery.isError && (
         <Alert severity="error" sx={{ mb: 2 }}>
           {t('gymSettings.snackbar.loadFailed')}
         </Alert>
@@ -95,8 +101,10 @@ export default function GymSettingsPanel() {
           control={
             <Switch
               checked={autoApprove}
-              disabled={!loaded || saving}
-              onChange={(event) => void handleToggle(event.target.checked)}
+              // Never let a failed or in-flight read look like "off" — an admin
+              // shouldn't act on a value we haven't actually received.
+              disabled={!settingsQuery.isSuccess || setAutoApprove.isPending}
+              onChange={(event) => setAutoApprove.mutate(event.target.checked)}
             />
           }
           label={

--- a/packages/web/app/components/gym-entity/__tests__/claim-gym-dialog.test.tsx
+++ b/packages/web/app/components/gym-entity/__tests__/claim-gym-dialog.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { createTestQueryClient } from '@/app/test-utils/test-providers';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import ClaimGymDialog from '../claim-gym-dialog';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({ token: 'test-token', isAuthenticated: true, isLoading: false, error: null }),
+}));
+
+const mockRefresh = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: mockRefresh, push: vi.fn(), replace: vi.fn() }),
+}));
+
+const mockRequest = vi.fn();
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+const GYM_UUID = 'gym-uuid-1';
+
+// No website, so the dialog opens straight into the admin-review mode — the only
+// path that can come back `approved`.
+const renderDialog = () =>
+  render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      <ClaimGymDialog gymUuid={GYM_UUID} gymName="Bonsist" website={null} open onClose={vi.fn()} />
+    </QueryClientProvider>,
+  );
+
+const submit = async () => {
+  fireEvent.click(await screen.findByText('Request review'));
+};
+
+beforeEach(() => {
+  mockRequest.mockReset();
+  mockRefresh.mockReset();
+});
+
+describe('ClaimGymDialog — auto-approved claim', () => {
+  it('confirms ownership and links to the manage page', async () => {
+    mockRequest.mockResolvedValueOnce({ requestGymClaim: { status: 'approved', email: null } });
+
+    renderDialog();
+    await submit();
+
+    await screen.findByText("Bonsist is yours. Set it up whenever you're ready.");
+
+    // The CTA has to be a real link, not a click handler, so it is crawlable
+    // and middle-clickable like the rest of the app's navigation.
+    const manageLink = screen.getByRole('link', { name: 'Set up your gym' });
+    expect(manageLink.getAttribute('href')).toContain(`/gym/${GYM_UUID}/manage`);
+  });
+
+  it('refreshes the server-rendered page so the claim CTA clears', async () => {
+    mockRequest.mockResolvedValueOnce({ requestGymClaim: { status: 'approved', email: null } });
+
+    renderDialog();
+    await submit();
+
+    // `canClaim` is computed server-side, so without this the page behind the
+    // dialog keeps offering a claim the viewer has already won.
+    await waitFor(() => expect(mockRefresh).toHaveBeenCalled());
+  });
+
+  it('still shows the review message when the claim only queues', async () => {
+    mockRequest.mockResolvedValueOnce({ requestGymClaim: { status: 'admin_review', email: null } });
+
+    renderDialog();
+    await submit();
+
+    await screen.findByText("We've emailed our team. They'll be in touch soon.");
+    // Nothing was transferred, so there is nothing to refresh.
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/components/gym-entity/claim-gym-dialog.tsx
+++ b/packages/web/app/components/gym-entity/claim-gym-dialog.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
@@ -47,6 +49,8 @@ function graphqlErrorMessage(error: unknown): string | null {
 export default function ClaimGymDialog({ gymUuid, gymName, website, open, onClose }: ClaimGymDialogProps) {
   const { t } = useTranslation('boards');
   const { token } = useWsAuthToken();
+  const router = useRouter();
+  const queryClient = useQueryClient();
   const domain = extractDomain(website);
   const canUseDomain = isClaimableDomain(website);
 
@@ -95,6 +99,13 @@ export default function ClaimGymDialog({ gymUuid, gymName, website, open, onClos
         setSentTo(data.requestGymClaim.email ?? email);
       } else if (data.requestGymClaim.status === 'approved') {
         setApproved(true);
+        // Ownership just moved, so everything the viewer sees about this gym is
+        // stale. `canClaim` is computed server-side on the gym page, so a cache
+        // invalidation alone wouldn't clear the claim CTA — refresh the server
+        // component. `myGyms` is the one React Query key on web that this
+        // affects (there is no per-gym key here, unlike mobile).
+        router.refresh();
+        void queryClient.invalidateQueries({ queryKey: ['myGyms'] });
       } else {
         setAdminSent(true);
       }

--- a/packages/web/app/components/gym-entity/claim-gym-dialog.tsx
+++ b/packages/web/app/components/gym-entity/claim-gym-dialog.tsx
@@ -22,6 +22,7 @@ import {
 } from '@boardsesh/gym-claim';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import LocaleLink from '@/app/components/i18n/locale-link';
 import {
   REQUEST_GYM_CLAIM,
   type RequestGymClaimMutationResponse,
@@ -56,6 +57,7 @@ export default function ClaimGymDialog({ gymUuid, gymName, website, open, onClos
   const [error, setError] = useState<string | null>(null);
   const [sentTo, setSentTo] = useState<string | null>(null);
   const [adminSent, setAdminSent] = useState(false);
+  const [approved, setApproved] = useState(false);
 
   const reset = useCallback(() => {
     setMode(canUseDomain ? 'domain' : 'admin');
@@ -65,6 +67,7 @@ export default function ClaimGymDialog({ gymUuid, gymName, website, open, onClos
     setError(null);
     setSentTo(null);
     setAdminSent(false);
+    setApproved(false);
   }, [canUseDomain]);
 
   // A single GymDetail/ClaimGymDialog instance is reused across gyms, so re-init
@@ -90,6 +93,8 @@ export default function ClaimGymDialog({ gymUuid, gymName, website, open, onClos
       );
       if (data.requestGymClaim.status === 'email_sent') {
         setSentTo(data.requestGymClaim.email ?? email);
+      } else if (data.requestGymClaim.status === 'approved') {
+        setApproved(true);
       } else {
         setAdminSent(true);
       }
@@ -111,10 +116,22 @@ export default function ClaimGymDialog({ gymUuid, gymName, website, open, onClos
     void submit({ input: { gymUuid, claimEmail: trimmed } });
   };
 
-  const succeeded = sentTo !== null || adminSent;
+  const succeeded = sentTo !== null || adminSent || approved;
 
   let body: React.ReactNode;
-  if (sentTo) {
+  if (approved) {
+    body = (
+      <Box
+        sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1.5, py: 2, textAlign: 'center' }}
+      >
+        <CheckCircleOutlined color="success" sx={{ fontSize: 40 }} />
+        <DialogContentText>{t('claimGym.approved.body', { gym: gymName })}</DialogContentText>
+        <MuiButton component={LocaleLink} href={`/gym/${gymUuid}/manage`} variant="contained" sx={{ mt: 1 }}>
+          {t('claimGym.approved.manageCta')}
+        </MuiButton>
+      </Box>
+    );
+  } else if (sentTo) {
     body = (
       <Box
         sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1.5, py: 2, textAlign: 'center' }}

--- a/packages/web/app/components/social/__tests__/vote-button.test.tsx
+++ b/packages/web/app/components/social/__tests__/vote-button.test.tsx
@@ -233,6 +233,16 @@ describe('VoteButton', () => {
       });
     }
 
+    // The vote buttons are `disabled={isLoading}`, so a second click fired while
+    // the first mutation is still in flight lands on a disabled button and is
+    // silently dropped. Waiting only for the request to have been *made* isn't
+    // enough — wait for the button to come back before clicking again.
+    async function clickWhenEnabled(label: string) {
+      const button = screen.getByLabelText(label) as HTMLButtonElement;
+      await waitFor(() => expect(button.disabled).toBe(false));
+      fireEvent.click(button);
+    }
+
     it('sends value: 1 on first upvote, then value: 1 again to un-vote (never 0)', async () => {
       renderVoteButton({ initialUserVote: 0, initialUpvotes: 0, initialDownvotes: 0 });
 
@@ -245,7 +255,7 @@ describe('VoteButton', () => {
       );
 
       mockVoteResponse({ upvotes: 0, downvotes: 0, voteScore: 0, userVote: 0 });
-      fireEvent.click(screen.getByLabelText('Upvote'));
+      await clickWhenEnabled('Upvote');
       await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(2));
       expect(mockRequest).toHaveBeenLastCalledWith('VOTE', {
         input: { entityType: 'climb', entityId: 'climb-1', value: 1 },
@@ -264,7 +274,7 @@ describe('VoteButton', () => {
       );
 
       mockVoteResponse({ upvotes: 0, downvotes: 0, voteScore: 0, userVote: 0 });
-      fireEvent.click(screen.getByLabelText('Downvote'));
+      await clickWhenEnabled('Downvote');
       await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(2));
       expect(mockRequest).toHaveBeenLastCalledWith('VOTE', {
         input: { entityType: 'climb', entityId: 'climb-1', value: -1 },


### PR DESCRIPTION
## Summary

Every gym ownership claim that can't self-verify by email domain lands in `/admin/gym-claims` and needs a manual **Approve**. Most of those are someone taking over a location-sync listing nobody owns, so approving them is pure clicking.

Adds a global `gym_claim_auto_approve` setting, **off by default**, with a new **Gyms** tab on `/admin` to flip it.

Worth naming what this actually is, because "gym approval" is misleading: gyms themselves are never approved. `createGym` inserts a live row and location-sync imports gyms directly. The only Approve button in the product is `reviewGymClaim` — approving a request to take *ownership* of an existing listing.

### The safety scope

Approving transfers `gyms.ownerId`, so blanket auto-approval would let anyone take over any public gym. Auto-approval is therefore limited to the safe case:

```
requestGymClaim (admin-review path)
  ├─ setting OFF ──────────────────────► queue (unchanged)
  └─ setting ON
       ├─ gym owned by SYSTEM import user ──► applied immediately
       └─ gym owned by a real person ───────► queue (still needs a human)
```

A claim that would displace a real person still goes to the queue, so turning this on can't be used to take a gym away from its owner. Domain-method claims are untouched — they already self-verify via the emailed token.

Flipping the toggle on does **not** drain claims already sitting in the queue; those were filed under review-required rules. A claimant who re-requests will go through, but the queue itself is cleared by hand.

### Privilege split

`setCommunitySettings` is `requireAdminOrLeader`, but gym claims are `requireAdmin`. Without a split, a community leader could enable auto-approval and then claim a gym, escalating straight past the gate on the claim resolvers. So `gym_`-prefixed keys now require full admin to write, and are filtered out of `communitySettings` reads for non-admins. The grade-proposal keys keep their existing leader access.

### Drive-by hardening

`applyGymClaim` read the gym without a row lock and then wrote `ownerId` unconditionally. The UPDATE now re-asserts the owner it based the decision on and rolls the transaction back if a concurrent transfer won. This closes a pre-existing TOCTOU on the manual approve path too.

No migration — the setting rides the existing `community_settings` table. Auto-approved rows are identifiable as `method='admin' AND status='approved' AND reviewed_by IS NULL`.

## Release Notes

- Claim an unclaimed gym and it's yours on the spot, no waiting for a review

## Test plan

- `vp check` — clean (the 30 pre-existing errors on `main` are all in files this PR doesn't touch)
- `vp run typecheck` — passes
- `vp test run --project backend` — `gym-write-access-and-claims.test.ts`: **66 passed**, including 9 new cases
- `vp run test:web` — **478 files / 5888 tests passed**
- `vp run test:mobile` — **598 files / 5251 tests passed**
- `vp run check:i18n` + `check:i18n:orphans` — both OK
- `catalog-completeness` — 90 passed (en-US/es/fr/de parity)
- `vp run check:mobile-bundle` — OK

New backend coverage:
- setting off (default) → claim still queues and stays `pending` (regression guard)
- setting on + system-owned gym → `approved`, ownership moves, `sync_frozen_at` set, `reviewed_by` null, no admin email
- setting on + gym owned by a real person → still queues, ownership unchanged
- claim queued before the setting was turned on → re-request goes through
- domain claims unaffected → still `email_sent`
- `gym_` keys reject a global `community_leader`, accept an admin; non-gym keys still accept a leader
- `communitySettings` hides `gym_` rows from a non-admin, shows them to an admin

New web coverage: `gym-settings-panel.test.tsx` — reads saved value, writes `1`/`0` on toggle, and rolls the switch back when the write is rejected.

Not yet run: manual pass against the dev DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UDT9hz3SH1niTKccW679E
