### PR TITLE
feat(mobile): fold away the beta-video rows anywhere they show

### DIFF
--- a/packages/mobile/app/(tabs)/home/index.tsx
+++ b/packages/mobile/app/(tabs)/home/index.tsx
@@ -12,6 +12,7 @@ import { Text } from '../../../src/components/Text';
 import { Icon } from '../../../src/components/Icon';
 import type { IconName } from '../../../src/components/icon-map';
 import { Card } from '../../../src/components/Card';
+import { SectionDisclosureChevron } from '../../../src/components/SectionDisclosureChevron';
 import { Button } from '../../../src/components/Button';
 import { SessionFeedCard } from '../../../src/components/you/SessionFeedCard';
 import { CommentSheet } from '../../../src/components/you/CommentSheet';
@@ -35,6 +36,7 @@ import { buildVoteSummaryMap, voteSummaryKey, type VoteSummary } from '../../../
 import { openClimbInPlayDrawer } from '../../../src/lib/open-climb-in-play-drawer';
 import { openValidatedUrl } from '../../../src/lib/open-external-link';
 import { hapticLight } from '../../../src/lib/haptics';
+import { useBetaShelfCollapse } from '../../../src/lib/beta-shelf-collapse';
 import { navigateToSessionFeedItem } from '../../../src/lib/session-feed-navigation';
 import { iosSystemColors } from '../../../src/theme/ios-colors';
 import { borderRadius, spacing } from '../../../src/theme/tokens';
@@ -112,7 +114,10 @@ export default function HomeTab() {
   // fires the unscoped global feed first (initial state is gym + no board) and
   // then refetches the scoped/crew query — that double-fetch flickered the feed.
   const scopeReady = !isResolvingHomeBoard;
-  const betaVideos = useRecentBetaLinks(RECENT_BETA_LIMIT, betaBoardType, betaLayoutId, scopeReady);
+  // A folded-away shelf costs no request: the header renders unconditionally, so
+  // gating the fetch can't strand the user with no way to unfold it (#4229).
+  const { expanded: betaExpanded, toggle: toggleBetaShelf } = useBetaShelfCollapse();
+  const betaVideos = useRecentBetaLinks(RECENT_BETA_LIMIT, betaBoardType, betaLayoutId, scopeReady && betaExpanded);
   const feed = useSessionGroupedFeed(feedInput, isAuthenticated && scopeReady);
 
   const sessions = useMemo(
@@ -334,6 +339,8 @@ export default function HomeTab() {
           isError={betaVideos.isError}
           onRetry={() => void betaVideos.refetch()}
           onOpenClimb={handleBetaOpenClimb}
+          expanded={betaExpanded}
+          onToggleExpanded={toggleBetaShelf}
         />
         <Text variant="title3" style={styles.feedHeading}>
           {sessionsHeading}
@@ -348,6 +355,8 @@ export default function HomeTab() {
       betaVideos.refetch,
       handleBetaOpenClimb,
       sessionsHeading,
+      betaExpanded,
+      toggleBetaShelf,
     ],
   );
 
@@ -513,6 +522,8 @@ function RecentBetaShelf({
   isError,
   onRetry,
   onOpenClimb,
+  expanded,
+  onToggleExpanded,
 }: {
   heading: string;
   videos: RecentBetaVideo[];
@@ -520,6 +531,8 @@ function RecentBetaShelf({
   isError: boolean;
   onRetry: () => void;
   onOpenClimb: (video: RecentBetaVideo) => void;
+  expanded: boolean;
+  onToggleExpanded: () => void;
 }) {
   const { t } = useTranslation('feed');
   const { t: tCommon } = useTranslation('common');
@@ -527,10 +540,20 @@ function RecentBetaShelf({
 
   return (
     <View style={styles.shelfSection}>
-      <View style={styles.sectionHeaderRow}>
+      {/* Keeps the home screen's own `title3` heading rather than adopting
+          `SectionHeader`, which would restyle the row to the group caption. */}
+      <Pressable
+        onPress={onToggleExpanded}
+        accessibilityRole="button"
+        accessibilityLabel={heading}
+        accessibilityState={{ expanded }}
+        hitSlop={8}
+        style={styles.sectionHeaderRow}
+      >
         <Text variant="title3">{heading}</Text>
-      </View>
-      {isLoading ? (
+        <SectionDisclosureChevron expanded={expanded} size={18} />
+      </Pressable>
+      {!expanded ? null : isLoading ? (
         <FlatList
           horizontal
           data={BETA_SKELETON_KEYS}
@@ -690,6 +713,10 @@ const styles = StyleSheet.create({
     paddingBottom: spacing[5],
   },
   sectionHeaderRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    gap: spacing[2],
     paddingHorizontal: spacing[4],
     paddingBottom: spacing[2],
   },

--- a/packages/mobile/app/(tabs)/home/index.tsx
+++ b/packages/mobile/app/(tabs)/home/index.tsx
@@ -116,8 +116,16 @@ export default function HomeTab() {
   const scopeReady = !isResolvingHomeBoard;
   // A folded-away shelf costs no request: the header renders unconditionally, so
   // gating the fetch can't strand the user with no way to unfold it (#4229).
-  const { expanded: betaExpanded, toggle: toggleBetaShelf } = useBetaShelfCollapse();
-  const betaVideos = useRecentBetaLinks(RECENT_BETA_LIMIT, betaBoardType, betaLayoutId, scopeReady && betaExpanded);
+  // `betaReady` is the persisted-store read; until it lands `betaExpanded` is
+  // only the default guess, so this is the one surface that paints before the
+  // store can load and must not act on a guess it may have to visibly undo.
+  const { expanded: betaExpanded, toggle: toggleBetaShelf, loaded: betaReady } = useBetaShelfCollapse();
+  const betaVideos = useRecentBetaLinks(
+    RECENT_BETA_LIMIT,
+    betaBoardType,
+    betaLayoutId,
+    scopeReady && betaReady && betaExpanded,
+  );
   const feed = useSessionGroupedFeed(feedInput, isAuthenticated && scopeReady);
 
   const sessions = useMemo(
@@ -341,6 +349,7 @@ export default function HomeTab() {
           onOpenClimb={handleBetaOpenClimb}
           expanded={betaExpanded}
           onToggleExpanded={toggleBetaShelf}
+          ready={betaReady}
         />
         <Text variant="title3" style={styles.feedHeading}>
           {sessionsHeading}
@@ -357,6 +366,7 @@ export default function HomeTab() {
       sessionsHeading,
       betaExpanded,
       toggleBetaShelf,
+      betaReady,
     ],
   );
 
@@ -524,6 +534,7 @@ function RecentBetaShelf({
   onOpenClimb,
   expanded,
   onToggleExpanded,
+  ready,
 }: {
   heading: string;
   videos: RecentBetaVideo[];
@@ -533,6 +544,7 @@ function RecentBetaShelf({
   onOpenClimb: (video: RecentBetaVideo) => void;
   expanded: boolean;
   onToggleExpanded: () => void;
+  ready: boolean;
 }) {
   const { t } = useTranslation('feed');
   const { t: tCommon } = useTranslation('common');
@@ -553,7 +565,11 @@ function RecentBetaShelf({
         <Text variant="title3">{heading}</Text>
         <SectionDisclosureChevron expanded={expanded} size={18} />
       </Pressable>
-      {!expanded ? null : isLoading ? (
+      {/* Nothing until the stored state lands: rendering the default and then
+          correcting it is the cold-start flash this avoids. One AsyncStorage
+          read, so the gap is imperceptible — and it keeps startup off the
+          splash's critical path. */}
+      {!ready || !expanded ? null : isLoading ? (
         <FlatList
           horizontal
           data={BETA_SKELETON_KEYS}
@@ -715,7 +731,8 @@ const styles = StyleSheet.create({
   sectionHeaderRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    alignSelf: 'flex-start',
+    // Full row, not `alignSelf: 'flex-start'` — the whole heading is the tap
+    // target here, matching the disclosure in SectionHeader.
     gap: spacing[2],
     paddingHorizontal: spacing[4],
     paddingBottom: spacing[2],

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -426,6 +426,7 @@ function ThemedNavigation({ children }: { children: ReactNode }) {
 function RootLayout() {
   const [authReady, setAuthReady] = useState(false);
   const [fontsReady, setFontsReady] = useState(false);
+  const [prefsReady, setPrefsReady] = useState(false);
 
   // Flush decoded board-art bitmaps on background / memory warning (#3479).
   useImageCacheMemoryManagement();
@@ -447,12 +448,22 @@ function RootLayout() {
   // Warm the collapsed-section map before the first tab paints. Without this it
   // loads lazily on the first section's mount, so a climber who folded the home
   // beta shelf away would watch it render open and then snap shut on every cold
-  // start (#4229). Nothing waits on it — the splash is already held for auth and
-  // fonts, both far slower than one AsyncStorage read.
+  // start (#4229). Gated into the splash rather than left to race it: auth and
+  // fonts are normally far slower than one AsyncStorage read, but "normally"
+  // isn't a guarantee, and losing that race is exactly the flash this prevents.
+  // `.finally` mirrors the fonts path so a failed or missing read still releases.
   useEffect(() => {
-    void loadSectionExpandState().catch((error: unknown) => {
-      reportError(error);
-    });
+    let cancelled = false;
+    void loadSectionExpandState()
+      .catch((error: unknown) => {
+        reportError(error);
+      })
+      .finally(() => {
+        if (!cancelled) setPrefsReady(true);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const onAuthReady = useCallback(() => {
@@ -460,9 +471,9 @@ function RootLayout() {
   }, []);
 
   useEffect(() => {
-    if (!authReady || !fontsReady) return;
+    if (!authReady || !fontsReady || !prefsReady) return;
     void SplashScreen.hideAsync();
-  }, [authReady, fontsReady]);
+  }, [authReady, fontsReady, prefsReady]);
 
   return (
     <GestureHandlerRootView style={layoutStyles.root}>

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -426,7 +426,6 @@ function ThemedNavigation({ children }: { children: ReactNode }) {
 function RootLayout() {
   const [authReady, setAuthReady] = useState(false);
   const [fontsReady, setFontsReady] = useState(false);
-  const [prefsReady, setPrefsReady] = useState(false);
 
   // Flush decoded board-art bitmaps on background / memory warning (#3479).
   useImageCacheMemoryManagement();
@@ -445,25 +444,17 @@ function RootLayout() {
     };
   }, []);
 
-  // Warm the collapsed-section map before the first tab paints. Without this it
-  // loads lazily on the first section's mount, so a climber who folded the home
-  // beta shelf away would watch it render open and then snap shut on every cold
-  // start (#4229). Gated into the splash rather than left to race it: auth and
-  // fonts are normally far slower than one AsyncStorage read, but "normally"
-  // isn't a guarantee, and losing that race is exactly the flash this prevents.
-  // `.finally` mirrors the fonts path so a failed or missing read still releases.
+  // Warm the collapsed-section map early so the sections a climber navigates to
+  // later (play drawer, profile, session detail) mount against a loaded store
+  // instead of each triggering the lazy read (#4229). Deliberately NOT a splash
+  // gate: startup must not wait on a preference read. The one surface that
+  // paints before this can resolve — the home beta shelf — waits on the store's
+  // own `loaded` flag instead, so it renders nothing rather than guessing
+  // expanded and visibly correcting itself.
   useEffect(() => {
-    let cancelled = false;
-    void loadSectionExpandState()
-      .catch((error: unknown) => {
-        reportError(error);
-      })
-      .finally(() => {
-        if (!cancelled) setPrefsReady(true);
-      });
-    return () => {
-      cancelled = true;
-    };
+    void loadSectionExpandState().catch((error: unknown) => {
+      reportError(error);
+    });
   }, []);
 
   const onAuthReady = useCallback(() => {
@@ -471,9 +462,9 @@ function RootLayout() {
   }, []);
 
   useEffect(() => {
-    if (!authReady || !fontsReady || !prefsReady) return;
+    if (!authReady || !fontsReady) return;
     void SplashScreen.hideAsync();
-  }, [authReady, fontsReady, prefsReady]);
+  }, [authReady, fontsReady]);
 
   return (
     <GestureHandlerRootView style={layoutStyles.root}>

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -71,6 +71,7 @@ import { reportError, reportHandledError } from '../src/lib/error-reporting';
 import { track, getAnalyticsClient } from '../src/lib/analytics';
 import { performOtaRecovery, type OtaRecoveryPhase } from '../src/lib/ota-recovery';
 import { loadRequiredFonts } from '../src/lib/required-fonts';
+import { loadSectionExpandState } from '../src/lib/section-expand-store';
 import { useImageCacheMemoryManagement } from '../src/hooks/use-image-cache-memory-management';
 import { AnalyticsProvider } from '../src/components/analytics/AnalyticsProvider';
 import { AnalyticsScreenTracker } from '../src/components/analytics/AnalyticsScreenTracker';
@@ -441,6 +442,17 @@ function RootLayout() {
     return () => {
       cancelled = true;
     };
+  }, []);
+
+  // Warm the collapsed-section map before the first tab paints. Without this it
+  // loads lazily on the first section's mount, so a climber who folded the home
+  // beta shelf away would watch it render open and then snap shut on every cold
+  // start (#4229). Nothing waits on it — the splash is already held for auth and
+  // fonts, both far slower than one AsyncStorage read.
+  useEffect(() => {
+    void loadSectionExpandState().catch((error: unknown) => {
+      reportError(error);
+    });
   }, []);
 
   const onAuthReady = useCallback(() => {

--- a/packages/mobile/src/components/CollapsibleSection.tsx
+++ b/packages/mobile/src/components/CollapsibleSection.tsx
@@ -175,27 +175,42 @@ function CollapsibleSectionInternal({
 
   return (
     <View style={styles.container}>
-      <Pressable
-        onPress={toggleExpanded}
-        accessibilityRole="button"
-        accessibilityLabel={title}
-        accessibilityState={{ expanded }}
-        style={styles.header}
-        onLayout={onHeaderLayoutEvent}
-      >
-        <Text variant="headline" style={styles.title}>
-          {title}
-        </Text>
-        {!expanded && summary ? (
-          <Text variant="footnote" style={styles.summary} numberOfLines={1}>
-            {summary}
+      {/* `headerAction` sits BETWEEN two toggle targets rather than inside one.
+          Nesting it in the header pressable would leave its taps arbitrated by
+          the responder system; as a sibling it simply owns them, so the Beta
+          Videos "+" can never fold the section by accident. Visual order (title
+          … action, chevron) is unchanged. */}
+      <View style={styles.header} onLayout={onHeaderLayoutEvent}>
+        <Pressable
+          onPress={toggleExpanded}
+          accessibilityRole="button"
+          accessibilityLabel={title}
+          accessibilityState={{ expanded }}
+          style={styles.headerPress}
+        >
+          <Text variant="headline" style={styles.title}>
+            {title}
           </Text>
-        ) : null}
+          {!expanded && summary ? (
+            <Text variant="footnote" style={styles.summary} numberOfLines={1}>
+              {summary}
+            </Text>
+          ) : null}
+        </Pressable>
         {headerAction}
-        <Animated.View style={chevronStyle}>
-          <Icon name="chevron.down" size={16} color={iosSystemColors.systemGray} />
-        </Animated.View>
-      </Pressable>
+        <Pressable
+          onPress={toggleExpanded}
+          // The title pressable above already announces the section and its
+          // expanded state; a second identical button would just be noise.
+          accessibilityElementsHidden
+          importantForAccessibility="no"
+          hitSlop={8}
+        >
+          <Animated.View style={chevronStyle}>
+            <Icon name="chevron.down" size={16} color={iosSystemColors.systemGray} />
+          </Animated.View>
+        </Pressable>
+      </View>
 
       {/* Plain View, not a FadeIn/FadeOut Animated.View: inside a FlashList header
           the iOS entering animation settles at ~0 height and paints the body blank. */}
@@ -216,6 +231,13 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     paddingHorizontal: spacing[4],
     paddingVertical: spacing[3],
+  },
+  // Takes the row's spare width so the title, the summary, and the dead space
+  // between them all toggle the section — only the action is carved out.
+  headerPress: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
   },
   title: {
     flex: 1,

--- a/packages/mobile/src/components/CollapsibleSection.tsx
+++ b/packages/mobile/src/components/CollapsibleSection.tsx
@@ -202,8 +202,11 @@ function CollapsibleSectionInternal({
           onPress={toggleExpanded}
           // The title pressable above already announces the section and its
           // expanded state; a second identical button would just be noise.
+          // Hidden from a11y means it has no accessible name, so tests reach it
+          // by testID rather than by role+name.
           accessibilityElementsHidden
           importantForAccessibility="no"
+          testID="collapsible-section-chevron"
           hitSlop={8}
         >
           <Animated.View style={chevronStyle}>

--- a/packages/mobile/src/components/HorizontalScrollSection.tsx
+++ b/packages/mobile/src/components/HorizontalScrollSection.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react';
 import { View, ScrollView, StyleSheet } from 'react-native';
-import { SectionHeader } from './SectionHeader';
+import { SectionHeader, type SectionDisclosure } from './SectionHeader';
 import { ActivityIndicator } from './ActivityIndicator';
 import { spacing } from '../theme/tokens';
 
@@ -20,11 +20,9 @@ export type HorizontalScrollSectionProps = {
   /** Height of the loading row / minimum shelf height, sized to the cards the
    *  shelf holds (120-tall playlist cards vs 192-tall beta cards). */
   minHeight?: number;
-  /** Disclosure state. When paired with `onToggleExpanded` the header becomes
-   *  tappable and a collapsed shelf renders the header alone — the scroller is
-   *  unmounted, so `onEndReached` pagination can't fire while it's folded. */
-  expanded?: boolean;
-  onToggleExpanded?: () => void;
+  /** Makes the shelf collapsible. A collapsed shelf renders the header alone —
+   *  the scroller is unmounted, so `onEndReached` pagination can't fire. */
+  disclosure?: SectionDisclosure;
 };
 
 // Right-edge slop (px) at which onEndReached fires, so the next page starts
@@ -48,20 +46,13 @@ export function HorizontalScrollSection({
   actionLabel,
   onActionPress,
   minHeight = DEFAULT_MIN_HEIGHT,
-  expanded,
-  onToggleExpanded,
+  disclosure,
 }: HorizontalScrollSectionProps) {
-  const collapsed = expanded === false && !!onToggleExpanded;
+  const collapsed = disclosure?.expanded === false;
 
   return (
     <View style={styles.section}>
-      <SectionHeader
-        title={title}
-        actionLabel={actionLabel}
-        onActionPress={onActionPress}
-        expanded={expanded}
-        onToggleExpanded={onToggleExpanded}
-      />
+      <SectionHeader title={title} actionLabel={actionLabel} onActionPress={onActionPress} disclosure={disclosure} />
       {collapsed ? null : loading ? (
         <View style={[styles.loadingRow, { height: minHeight }]}>
           <ActivityIndicator size="small" />

--- a/packages/mobile/src/components/HorizontalScrollSection.tsx
+++ b/packages/mobile/src/components/HorizontalScrollSection.tsx
@@ -20,6 +20,11 @@ export type HorizontalScrollSectionProps = {
   /** Height of the loading row / minimum shelf height, sized to the cards the
    *  shelf holds (120-tall playlist cards vs 192-tall beta cards). */
   minHeight?: number;
+  /** Disclosure state. When paired with `onToggleExpanded` the header becomes
+   *  tappable and a collapsed shelf renders the header alone — the scroller is
+   *  unmounted, so `onEndReached` pagination can't fire while it's folded. */
+  expanded?: boolean;
+  onToggleExpanded?: () => void;
 };
 
 // Right-edge slop (px) at which onEndReached fires, so the next page starts
@@ -43,11 +48,21 @@ export function HorizontalScrollSection({
   actionLabel,
   onActionPress,
   minHeight = DEFAULT_MIN_HEIGHT,
+  expanded,
+  onToggleExpanded,
 }: HorizontalScrollSectionProps) {
+  const collapsed = expanded === false && !!onToggleExpanded;
+
   return (
     <View style={styles.section}>
-      <SectionHeader title={title} actionLabel={actionLabel} onActionPress={onActionPress} />
-      {loading ? (
+      <SectionHeader
+        title={title}
+        actionLabel={actionLabel}
+        onActionPress={onActionPress}
+        expanded={expanded}
+        onToggleExpanded={onToggleExpanded}
+      />
+      {collapsed ? null : loading ? (
         <View style={[styles.loadingRow, { height: minHeight }]}>
           <ActivityIndicator size="small" />
         </View>

--- a/packages/mobile/src/components/SectionDisclosureChevron.tsx
+++ b/packages/mobile/src/components/SectionDisclosureChevron.tsx
@@ -1,0 +1,33 @@
+import Animated, { useAnimatedStyle, useDerivedValue, withTiming } from 'react-native-reanimated';
+import { Icon } from './Icon';
+import { iosSystemColors } from '../theme/ios-colors';
+import { timing } from '../theme/animations';
+
+type SectionDisclosureChevronProps = {
+  expanded: boolean;
+  size?: number;
+};
+
+/**
+ * The rotating disclosure chevron shared by collapsible section headers —
+ * extracted from `CollapsibleSection` so headers that can't adopt that
+ * component (the beta shelves, whose card chrome and content padding would
+ * break their edge-to-edge horizontal scrollers) still animate identically.
+ *
+ * Driven by `useDerivedValue` off the `expanded` prop rather than a shared value
+ * the caller mutates, so a header can stay stateless and let the persisted store
+ * be the single source of truth.
+ */
+export function SectionDisclosureChevron({ expanded, size = 16 }: SectionDisclosureChevronProps) {
+  const rotation = useDerivedValue(() => withTiming(expanded ? 1 : 0, { duration: timing.normal }), [expanded]);
+
+  const style = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${rotation.value * 180}deg` }],
+  }));
+
+  return (
+    <Animated.View style={style}>
+      <Icon name="chevron.down" size={size} color={iosSystemColors.systemGray} />
+    </Animated.View>
+  );
+}

--- a/packages/mobile/src/components/SectionHeader.tsx
+++ b/packages/mobile/src/components/SectionHeader.tsx
@@ -104,7 +104,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing[1],
-    flexShrink: 1,
+    // Takes the row's spare width so the whole heading toggles, not just the
+    // glyphs. Any action ("See all") still keeps its own space on the right.
+    flex: 1,
   },
   action: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/SectionHeader.tsx
+++ b/packages/mobile/src/components/SectionHeader.tsx
@@ -2,6 +2,7 @@ import { View, StyleSheet } from 'react-native';
 import { Text } from './Text';
 import { Icon } from './Icon';
 import { PressableSurface } from './PressableSurface';
+import { SectionDisclosureChevron } from './SectionDisclosureChevron';
 import { useTheme } from '../providers/theme-provider';
 import { selectByVariant } from '../theme/variants';
 import { applySectionCaption } from '../theme/variants/variant-tokens';
@@ -13,9 +14,14 @@ type SectionHeaderProps = {
    *  the right of the header when paired with `onActionPress`. */
   actionLabel?: string;
   onActionPress?: () => void;
+  /** Current disclosure state. Paired with `onToggleExpanded`, turns the title
+   *  into a tappable disclosure with a rotating chevron. The action (if any)
+   *  stays a separate sibling target, so "See all" never toggles the section. */
+  expanded?: boolean;
+  onToggleExpanded?: () => void;
 };
 
-export function SectionHeader({ title, actionLabel, onActionPress }: SectionHeaderProps) {
+export function SectionHeader({ title, actionLabel, onActionPress, expanded, onToggleExpanded }: SectionHeaderProps) {
   const { brandColors, variant, m3, sectionCaption } = useTheme();
   // M3 list/section headers are sentence-case titleSmall in onSurfaceVariant — not
   // the iOS group caption (uppercased, dimmed, tracked-out footnote). The uppercase
@@ -27,12 +33,37 @@ export function SectionHeader({ title, actionLabel, onActionPress }: SectionHead
   const textColor = selectByVariant(variant, { liquidGlass: undefined, material: m3.onSurfaceVariant });
   const weightStyle = selectByVariant(variant, { liquidGlass: undefined, material: styles.materialText });
   const showAction = !!actionLabel && !!onActionPress;
+  const collapsible = expanded !== undefined && !!onToggleExpanded;
+
+  const titleText = (
+    <Text variant={textVariant} color={textColor} style={[caption.style, weightStyle]}>
+      {caption.text}
+    </Text>
+  );
 
   return (
-    <View style={[styles.container, showAction && styles.containerWithAction]}>
-      <Text variant={textVariant} color={textColor} style={[caption.style, weightStyle]}>
-        {caption.text}
-      </Text>
+    <View style={[styles.container, (showAction || collapsible) && styles.containerWithAction]}>
+      {collapsible ? (
+        // Only the title + chevron cluster is tappable — keeping the action a
+        // sibling rather than nesting it inside this pressable avoids the
+        // nested-touch ambiguity that bites on Android.
+        <PressableSurface
+          onPress={onToggleExpanded}
+          feedback="opacity"
+          hitSlop={8}
+          accessibilityRole="button"
+          // The raw title, not the uppercased caption, so VoiceOver/TalkBack
+          // don't spell it out letter by letter.
+          accessibilityLabel={title}
+          accessibilityState={{ expanded }}
+          style={styles.disclosure}
+        >
+          {titleText}
+          <SectionDisclosureChevron expanded={expanded} size={14} />
+        </PressableSurface>
+      ) : (
+        titleText
+      )}
       {showAction ? (
         <PressableSurface
           onPress={onActionPress}
@@ -68,6 +99,12 @@ const styles = StyleSheet.create({
   // onSurfaceVariant carries the hierarchy on Material.
   materialText: {
     fontWeight: '500',
+  },
+  disclosure: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[1],
+    flexShrink: 1,
   },
   action: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/SectionHeader.tsx
+++ b/packages/mobile/src/components/SectionHeader.tsx
@@ -8,20 +8,28 @@ import { selectByVariant } from '../theme/variants';
 import { applySectionCaption } from '../theme/variants/variant-tokens';
 import { spacing } from '../theme/tokens';
 
+/**
+ * Makes a section header a disclosure. One object rather than two loose props:
+ * `expanded` without a toggle renders a section nobody can open, and a toggle
+ * without `expanded` has nothing to drive the chevron — bundling them makes
+ * that half-specified state unrepresentable instead of silently wrong.
+ */
+export type SectionDisclosure = {
+  expanded: boolean;
+  onToggle: () => void;
+};
+
 type SectionHeaderProps = {
   title: string;
   /** Trailing affordance label (e.g. "See all"). Renders a tappable action on
    *  the right of the header when paired with `onActionPress`. */
   actionLabel?: string;
   onActionPress?: () => void;
-  /** Current disclosure state. Paired with `onToggleExpanded`, turns the title
-   *  into a tappable disclosure with a rotating chevron. The action (if any)
-   *  stays a separate sibling target, so "See all" never toggles the section. */
-  expanded?: boolean;
-  onToggleExpanded?: () => void;
+  /** Omit for a plain, non-collapsible header. */
+  disclosure?: SectionDisclosure;
 };
 
-export function SectionHeader({ title, actionLabel, onActionPress, expanded, onToggleExpanded }: SectionHeaderProps) {
+export function SectionHeader({ title, actionLabel, onActionPress, disclosure }: SectionHeaderProps) {
   const { brandColors, variant, m3, sectionCaption } = useTheme();
   // M3 list/section headers are sentence-case titleSmall in onSurfaceVariant — not
   // the iOS group caption (uppercased, dimmed, tracked-out footnote). The uppercase
@@ -33,7 +41,7 @@ export function SectionHeader({ title, actionLabel, onActionPress, expanded, onT
   const textColor = selectByVariant(variant, { liquidGlass: undefined, material: m3.onSurfaceVariant });
   const weightStyle = selectByVariant(variant, { liquidGlass: undefined, material: styles.materialText });
   const showAction = !!actionLabel && !!onActionPress;
-  const collapsible = expanded !== undefined && !!onToggleExpanded;
+  const collapsible = disclosure !== undefined;
 
   const titleText = (
     <Text variant={textVariant} color={textColor} style={[caption.style, weightStyle]}>
@@ -48,18 +56,18 @@ export function SectionHeader({ title, actionLabel, onActionPress, expanded, onT
         // sibling rather than nesting it inside this pressable avoids the
         // nested-touch ambiguity that bites on Android.
         <PressableSurface
-          onPress={onToggleExpanded}
+          onPress={disclosure.onToggle}
           feedback="opacity"
           hitSlop={8}
           accessibilityRole="button"
           // The raw title, not the uppercased caption, so VoiceOver/TalkBack
           // don't spell it out letter by letter.
           accessibilityLabel={title}
-          accessibilityState={{ expanded }}
+          accessibilityState={{ expanded: disclosure.expanded }}
           style={styles.disclosure}
         >
           {titleText}
-          <SectionDisclosureChevron expanded={expanded} size={14} />
+          <SectionDisclosureChevron expanded={disclosure.expanded} size={14} />
         </PressableSurface>
       ) : (
         titleText

--- a/packages/mobile/src/components/__tests__/collapsible-section-persist.test.tsx
+++ b/packages/mobile/src/components/__tests__/collapsible-section-persist.test.tsx
@@ -29,8 +29,25 @@ vi.mock('@react-native-async-storage/async-storage', () => {
 
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
-  Pressable: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
-    createElement('button', { onClick: () => onPress?.() }, children),
+  // Forwards accessibilityLabel so tests can target the title vs the chevron by
+  // name instead of by position — adding a headerAction would otherwise shift
+  // indices and turn these into false passes.
+  Pressable: ({
+    children,
+    onPress,
+    accessibilityLabel,
+    testID,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityLabel?: string;
+    testID?: string;
+  }) =>
+    createElement(
+      'button',
+      { onClick: () => onPress?.(), 'aria-label': accessibilityLabel, 'data-testid': testID },
+      children,
+    ),
   StyleSheet: { create: (styles: unknown) => styles },
   Platform: { OS: 'ios' },
   PlatformColor: (name: string) => name,
@@ -108,7 +125,7 @@ describe('CollapsibleSection persistence', () => {
     // This is the signal the play drawer keys its scroll-into-view off, so it
     // must fire on the tap (and NOT on mount / persisted reconciliation).
     const onToggle = vi.fn();
-    const { getAllByRole } = render(
+    const { getByRole } = render(
       createElement(CollapsibleSection, {
         title: 'Logbook',
         defaultExpanded: false,
@@ -119,7 +136,7 @@ describe('CollapsibleSection persistence', () => {
 
     // Two toggle targets: the title cluster and the chevron (the header action,
     // when present, sits between them and owns its own taps).
-    const title = () => getAllByRole('button')[0];
+    const title = () => getByRole('button', { name: 'Logbook' });
     expect(onToggle).not.toHaveBeenCalled();
     fireEvent.click(title());
     expect(onToggle).toHaveBeenLastCalledWith(true);
@@ -140,7 +157,7 @@ describe('CollapsibleSection body rendering', () => {
   // this change fixes — that is verified on-device. It does pin that the body
   // renders when expanded and unmounts when collapsed.
   it('renders the body only while expanded, toggling on header tap', () => {
-    const { getAllByRole, queryByText } = render(
+    const { getByRole, queryByText } = render(
       createElement(CollapsibleSection, {
         title: 'Logbook',
         defaultExpanded: false,
@@ -148,7 +165,7 @@ describe('CollapsibleSection body rendering', () => {
       }),
     );
 
-    const title = () => getAllByRole('button')[0];
+    const title = () => getByRole('button', { name: 'Logbook' });
     // Collapsed by default → body absent.
     expect(queryByText(BODY)).toBeNull();
     // Tap to expand → body present (plain View, no FadeIn gate).
@@ -160,7 +177,7 @@ describe('CollapsibleSection body rendering', () => {
   });
 
   it('toggles from the chevron as well as the title', () => {
-    const { getAllByRole, queryByText } = render(
+    const { getByTestId, queryByText } = render(
       createElement(CollapsibleSection, {
         title: 'Logbook',
         defaultExpanded: false,
@@ -168,7 +185,7 @@ describe('CollapsibleSection body rendering', () => {
       }),
     );
 
-    fireEvent.click(getAllByRole('button')[1]);
+    fireEvent.click(getByTestId('collapsible-section-chevron'));
     expect(queryByText(BODY)).toBeTruthy();
   });
 

--- a/packages/mobile/src/components/__tests__/collapsible-section-persist.test.tsx
+++ b/packages/mobile/src/components/__tests__/collapsible-section-persist.test.tsx
@@ -176,17 +176,19 @@ describe('CollapsibleSection body rendering', () => {
     // The Beta Videos "+" lives in this slot. It must add a video, not collapse
     // the section out from under the user (#4229).
     const onActionPress = vi.fn();
-    const { getAllByRole, queryByText } = render(
+    // Anchored by its own label rather than a positional index, so restructuring
+    // the header can't silently retarget this at the wrong button.
+    const { getByText, queryByText } = render(
       createElement(CollapsibleSection, {
         title: 'Beta Videos',
         defaultExpanded: true,
-        headerAction: createElement('button', { onClick: onActionPress }, 'add'),
+        headerAction: createElement('button', { onClick: onActionPress }, 'ADD_BETA'),
         children: createElement('span', null, BODY),
       }),
     );
 
     expect(queryByText(BODY)).toBeTruthy();
-    fireEvent.click(getAllByRole('button')[1]); // the action, between title and chevron
+    fireEvent.click(getByText('ADD_BETA'));
     expect(onActionPress).toHaveBeenCalledTimes(1);
     expect(queryByText(BODY)).toBeTruthy();
   });

--- a/packages/mobile/src/components/__tests__/collapsible-section-persist.test.tsx
+++ b/packages/mobile/src/components/__tests__/collapsible-section-persist.test.tsx
@@ -108,7 +108,7 @@ describe('CollapsibleSection persistence', () => {
     // This is the signal the play drawer keys its scroll-into-view off, so it
     // must fire on the tap (and NOT on mount / persisted reconciliation).
     const onToggle = vi.fn();
-    const { getByRole } = render(
+    const { getAllByRole } = render(
       createElement(CollapsibleSection, {
         title: 'Logbook',
         defaultExpanded: false,
@@ -117,10 +117,13 @@ describe('CollapsibleSection persistence', () => {
       }),
     );
 
+    // Two toggle targets: the title cluster and the chevron (the header action,
+    // when present, sits between them and owns its own taps).
+    const title = () => getAllByRole('button')[0];
     expect(onToggle).not.toHaveBeenCalled();
-    fireEvent.click(getByRole('button'));
+    fireEvent.click(title());
     expect(onToggle).toHaveBeenLastCalledWith(true);
-    fireEvent.click(getByRole('button'));
+    fireEvent.click(title());
     expect(onToggle).toHaveBeenLastCalledWith(false);
   });
 });
@@ -137,7 +140,7 @@ describe('CollapsibleSection body rendering', () => {
   // this change fixes — that is verified on-device. It does pin that the body
   // renders when expanded and unmounts when collapsed.
   it('renders the body only while expanded, toggling on header tap', () => {
-    const { getByRole, queryByText } = render(
+    const { getAllByRole, queryByText } = render(
       createElement(CollapsibleSection, {
         title: 'Logbook',
         defaultExpanded: false,
@@ -145,13 +148,46 @@ describe('CollapsibleSection body rendering', () => {
       }),
     );
 
+    const title = () => getAllByRole('button')[0];
     // Collapsed by default → body absent.
     expect(queryByText(BODY)).toBeNull();
     // Tap to expand → body present (plain View, no FadeIn gate).
-    fireEvent.click(getByRole('button'));
+    fireEvent.click(title());
     expect(queryByText(BODY)).toBeTruthy();
     // Tap again to collapse → body removed.
-    fireEvent.click(getByRole('button'));
+    fireEvent.click(title());
     expect(queryByText(BODY)).toBeNull();
+  });
+
+  it('toggles from the chevron as well as the title', () => {
+    const { getAllByRole, queryByText } = render(
+      createElement(CollapsibleSection, {
+        title: 'Logbook',
+        defaultExpanded: false,
+        children: createElement('span', null, BODY),
+      }),
+    );
+
+    fireEvent.click(getAllByRole('button')[1]);
+    expect(queryByText(BODY)).toBeTruthy();
+  });
+
+  it('lets a headerAction press through without folding the section', () => {
+    // The Beta Videos "+" lives in this slot. It must add a video, not collapse
+    // the section out from under the user (#4229).
+    const onActionPress = vi.fn();
+    const { getAllByRole, queryByText } = render(
+      createElement(CollapsibleSection, {
+        title: 'Beta Videos',
+        defaultExpanded: true,
+        headerAction: createElement('button', { onClick: onActionPress }, 'add'),
+        children: createElement('span', null, BODY),
+      }),
+    );
+
+    expect(queryByText(BODY)).toBeTruthy();
+    fireEvent.click(getAllByRole('button')[1]); // the action, between title and chevron
+    expect(onActionPress).toHaveBeenCalledTimes(1);
+    expect(queryByText(BODY)).toBeTruthy();
   });
 });

--- a/packages/mobile/src/components/__tests__/horizontal-scroll-section-collapse.test.tsx
+++ b/packages/mobile/src/components/__tests__/horizontal-scroll-section-collapse.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  ScrollView: ({ children }: { children?: ReactNode }) =>
+    createElement('div', { 'data-testid': 'shelf-scroll' }, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+}));
+vi.mock('../SectionHeader', () => ({
+  SectionHeader: ({ title, expanded }: { title: string; expanded?: boolean }) =>
+    createElement(
+      'div',
+      { 'data-testid': 'section-header', 'data-expanded': expanded === undefined ? undefined : String(expanded) },
+      title,
+    ),
+}));
+vi.mock('../ActivityIndicator', () => ({
+  ActivityIndicator: () => createElement('div', { 'data-testid': 'spinner' }),
+}));
+
+import { HorizontalScrollSection } from '../HorizontalScrollSection';
+
+const CARD = 'SHELF_CARD';
+
+function renderShelf(props: Record<string, unknown>) {
+  return render(
+    createElement(HorizontalScrollSection, {
+      title: 'Beta videos',
+      children: createElement('span', null, CARD),
+      ...props,
+    }),
+  );
+}
+
+describe('HorizontalScrollSection collapse', () => {
+  it('renders its scroller when no disclosure props are given', () => {
+    const { getByTestId, getByText } = renderShelf({});
+    expect(getByTestId('shelf-scroll')).toBeTruthy();
+    expect(getByText(CARD)).toBeTruthy();
+  });
+
+  it('renders the scroller while expanded', () => {
+    const { getByTestId } = renderShelf({ expanded: true, onToggleExpanded: vi.fn() });
+    expect(getByTestId('shelf-scroll')).toBeTruthy();
+  });
+
+  it('drops the scroller but keeps the header when collapsed', () => {
+    // The header is the only way back — it must outlive the collapse (#4229).
+    const { queryByTestId, getByTestId, queryByText } = renderShelf({
+      expanded: false,
+      onToggleExpanded: vi.fn(),
+    });
+
+    expect(getByTestId('section-header')).toBeTruthy();
+    expect(queryByTestId('shelf-scroll')).toBeNull();
+    expect(queryByText(CARD)).toBeNull();
+  });
+
+  it('suppresses the loading spinner while collapsed', () => {
+    // A folded shelf that still spins would advertise work the user opted out of.
+    const { queryByTestId } = renderShelf({ expanded: false, onToggleExpanded: vi.fn(), loading: true });
+    expect(queryByTestId('spinner')).toBeNull();
+  });
+
+  it('forwards the disclosure state to the header', () => {
+    const { getByTestId } = renderShelf({ expanded: false, onToggleExpanded: vi.fn() });
+    expect(getByTestId('section-header').getAttribute('data-expanded')).toBe('false');
+  });
+});

--- a/packages/mobile/src/components/__tests__/horizontal-scroll-section-collapse.test.tsx
+++ b/packages/mobile/src/components/__tests__/horizontal-scroll-section-collapse.test.tsx
@@ -12,10 +12,13 @@ vi.mock('react-native', () => ({
   PlatformColor: (name: string) => name,
 }));
 vi.mock('../SectionHeader', () => ({
-  SectionHeader: ({ title, expanded }: { title: string; expanded?: boolean }) =>
+  SectionHeader: ({ title, disclosure }: { title: string; disclosure?: { expanded: boolean } }) =>
     createElement(
       'div',
-      { 'data-testid': 'section-header', 'data-expanded': expanded === undefined ? undefined : String(expanded) },
+      {
+        'data-testid': 'section-header',
+        'data-expanded': disclosure === undefined ? undefined : String(disclosure.expanded),
+      },
       title,
     ),
 }));
@@ -45,15 +48,14 @@ describe('HorizontalScrollSection collapse', () => {
   });
 
   it('renders the scroller while expanded', () => {
-    const { getByTestId } = renderShelf({ expanded: true, onToggleExpanded: vi.fn() });
+    const { getByTestId } = renderShelf({ disclosure: { expanded: true, onToggle: vi.fn() } });
     expect(getByTestId('shelf-scroll')).toBeTruthy();
   });
 
   it('drops the scroller but keeps the header when collapsed', () => {
     // The header is the only way back — it must outlive the collapse (#4229).
     const { queryByTestId, getByTestId, queryByText } = renderShelf({
-      expanded: false,
-      onToggleExpanded: vi.fn(),
+      disclosure: { expanded: false, onToggle: vi.fn() },
     });
 
     expect(getByTestId('section-header')).toBeTruthy();
@@ -63,12 +65,12 @@ describe('HorizontalScrollSection collapse', () => {
 
   it('suppresses the loading spinner while collapsed', () => {
     // A folded shelf that still spins would advertise work the user opted out of.
-    const { queryByTestId } = renderShelf({ expanded: false, onToggleExpanded: vi.fn(), loading: true });
+    const { queryByTestId } = renderShelf({ disclosure: { expanded: false, onToggle: vi.fn() }, loading: true });
     expect(queryByTestId('spinner')).toBeNull();
   });
 
   it('forwards the disclosure state to the header', () => {
-    const { getByTestId } = renderShelf({ expanded: false, onToggleExpanded: vi.fn() });
+    const { getByTestId } = renderShelf({ disclosure: { expanded: false, onToggle: vi.fn() } });
     expect(getByTestId('section-header').getAttribute('data-expanded')).toBe('false');
   });
 });

--- a/packages/mobile/src/components/__tests__/section-disclosure-chevron.test.tsx
+++ b/packages/mobile/src/components/__tests__/section-disclosure-chevron.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// Reanimated's ESM entry isn't resolvable under vitest, so it's stubbed — but
+// faithfully: `useDerivedValue` runs its factory and `withTiming` returns the
+// target, so the rotation actually computed from `expanded` is observable. That
+// is the one piece of logic this component owns; the native animation itself is
+// a device concern.
+vi.mock('react-native-reanimated', () => ({
+  default: {
+    View: ({ children, style }: { children?: ReactNode; style?: Record<string, unknown> }) =>
+      createElement('div', { 'data-transform': JSON.stringify(style?.transform ?? null) }, children),
+  },
+  useDerivedValue: (factory: () => number) => ({ value: factory() }),
+  useAnimatedStyle: (factory: () => Record<string, unknown>) => factory(),
+  withTiming: (value: number) => value,
+}));
+vi.mock('../Icon', () => ({
+  Icon: ({ name, size }: { name: string; size?: number }) =>
+    createElement('i', { 'data-icon': name, 'data-size': String(size) }),
+}));
+vi.mock('react-native', () => ({
+  StyleSheet: { create: (styles: unknown) => styles },
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+}));
+
+import { SectionDisclosureChevron } from '../SectionDisclosureChevron';
+
+function transformOf(container: HTMLElement): string | null {
+  return container.querySelector('[data-transform]')?.getAttribute('data-transform') ?? null;
+}
+
+describe('SectionDisclosureChevron', () => {
+  it('points down (0deg) when collapsed', () => {
+    const { container } = render(createElement(SectionDisclosureChevron, { expanded: false }));
+    expect(transformOf(container)).toContain('0deg');
+  });
+
+  it('flips 180deg when expanded', () => {
+    const { container } = render(createElement(SectionDisclosureChevron, { expanded: true }));
+    expect(transformOf(container)).toContain('180deg');
+  });
+
+  it('rotates when the expanded prop changes', () => {
+    const { container, rerender } = render(createElement(SectionDisclosureChevron, { expanded: false }));
+    expect(transformOf(container)).toContain('0deg');
+
+    rerender(createElement(SectionDisclosureChevron, { expanded: true }));
+    expect(transformOf(container)).toContain('180deg');
+  });
+
+  it('renders the chevron glyph at the requested size', () => {
+    const { container } = render(createElement(SectionDisclosureChevron, { expanded: true, size: 18 }));
+    const icon = container.querySelector('[data-icon]');
+    expect(icon?.getAttribute('data-icon')).toBe('chevron.down');
+    expect(icon?.getAttribute('data-size')).toBe('18');
+  });
+});

--- a/packages/mobile/src/components/__tests__/section-header-disclosure.test.tsx
+++ b/packages/mobile/src/components/__tests__/section-header-disclosure.test.tsx
@@ -59,7 +59,7 @@ describe('SectionHeader disclosure', () => {
 
   it('renders a chevron and exposes the expanded state to screen readers', () => {
     const { getByTestId, getByLabelText } = render(
-      createElement(SectionHeader, { title: 'Fresh beta', expanded: false, onToggleExpanded: vi.fn() }),
+      createElement(SectionHeader, { title: 'Fresh beta', disclosure: { expanded: false, onToggle: vi.fn() } }),
     );
 
     expect(getByTestId('chevron').getAttribute('data-expanded')).toBe('false');
@@ -68,25 +68,24 @@ describe('SectionHeader disclosure', () => {
   });
 
   it('toggles when the title is tapped', () => {
-    const onToggleExpanded = vi.fn();
+    const onToggle = vi.fn();
     const { getByLabelText } = render(
-      createElement(SectionHeader, { title: 'Fresh beta', expanded: true, onToggleExpanded }),
+      createElement(SectionHeader, { title: 'Fresh beta', disclosure: { expanded: true, onToggle } }),
     );
 
     fireEvent.click(getByLabelText('Fresh beta'));
-    expect(onToggleExpanded).toHaveBeenCalledTimes(1);
+    expect(onToggle).toHaveBeenCalledTimes(1);
   });
 
   it('keeps "See all" independent of the disclosure', () => {
     // The action is a sibling of the disclosure, not nested inside it — pressing
     // it must navigate without also folding the shelf away.
-    const onToggleExpanded = vi.fn();
+    const onToggle = vi.fn();
     const onActionPress = vi.fn();
     const { getByLabelText } = render(
       createElement(SectionHeader, {
         title: 'Fresh beta',
-        expanded: true,
-        onToggleExpanded,
+        disclosure: { expanded: true, onToggle },
         actionLabel: 'See all',
         onActionPress,
       }),
@@ -94,6 +93,6 @@ describe('SectionHeader disclosure', () => {
 
     fireEvent.click(getByLabelText('See all'));
     expect(onActionPress).toHaveBeenCalledTimes(1);
-    expect(onToggleExpanded).not.toHaveBeenCalled();
+    expect(onToggle).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/components/__tests__/section-header-disclosure.test.tsx
+++ b/packages/mobile/src/components/__tests__/section-header-disclosure.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+}));
+vi.mock('../Text', () => ({ Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children) }));
+vi.mock('../Icon', () => ({ Icon: () => createElement('i', null) }));
+// Keep the two press targets distinguishable, and carry through the a11y props
+// the disclosure sets so they can be asserted.
+vi.mock('../PressableSurface', () => ({
+  PressableSurface: ({
+    children,
+    onPress,
+    accessibilityLabel,
+    accessibilityState,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityLabel?: string;
+    accessibilityState?: { expanded?: boolean };
+  }) =>
+    createElement(
+      'button',
+      {
+        onClick: () => onPress?.(),
+        'aria-label': accessibilityLabel,
+        'data-expanded': accessibilityState?.expanded === undefined ? undefined : String(accessibilityState.expanded),
+      },
+      children,
+    ),
+}));
+vi.mock('../SectionDisclosureChevron', () => ({
+  SectionDisclosureChevron: ({ expanded }: { expanded: boolean }) =>
+    createElement('i', { 'data-testid': 'chevron', 'data-expanded': String(expanded) }),
+}));
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    variant: 'material' as const,
+    brandColors: { primary: '#6D28D9' },
+    m3: { onSurfaceVariant: '#49454F' },
+    sectionCaption: { uppercase: false, opacity: 1, letterSpacing: 0 },
+  }),
+}));
+
+import { SectionHeader } from '../SectionHeader';
+
+describe('SectionHeader disclosure', () => {
+  it('stays a plain header when no disclosure props are passed', () => {
+    const { queryByTestId, queryByRole } = render(createElement(SectionHeader, { title: 'Fresh beta' }));
+    expect(queryByTestId('chevron')).toBeNull();
+    expect(queryByRole('button')).toBeNull();
+  });
+
+  it('renders a chevron and exposes the expanded state to screen readers', () => {
+    const { getByTestId, getByLabelText } = render(
+      createElement(SectionHeader, { title: 'Fresh beta', expanded: false, onToggleExpanded: vi.fn() }),
+    );
+
+    expect(getByTestId('chevron').getAttribute('data-expanded')).toBe('false');
+    // Labelled with the raw title, not the transformed caption.
+    expect(getByLabelText('Fresh beta').getAttribute('data-expanded')).toBe('false');
+  });
+
+  it('toggles when the title is tapped', () => {
+    const onToggleExpanded = vi.fn();
+    const { getByLabelText } = render(
+      createElement(SectionHeader, { title: 'Fresh beta', expanded: true, onToggleExpanded }),
+    );
+
+    fireEvent.click(getByLabelText('Fresh beta'));
+    expect(onToggleExpanded).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps "See all" independent of the disclosure', () => {
+    // The action is a sibling of the disclosure, not nested inside it — pressing
+    // it must navigate without also folding the shelf away.
+    const onToggleExpanded = vi.fn();
+    const onActionPress = vi.fn();
+    const { getByLabelText } = render(
+      createElement(SectionHeader, {
+        title: 'Fresh beta',
+        expanded: true,
+        onToggleExpanded,
+        actionLabel: 'See all',
+        onActionPress,
+      }),
+    );
+
+    fireEvent.click(getByLabelText('See all'));
+    expect(onActionPress).toHaveBeenCalledTimes(1);
+    expect(onToggleExpanded).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/components/__tests__/section-header.test.tsx
+++ b/packages/mobile/src/components/__tests__/section-header.test.tsx
@@ -22,6 +22,10 @@ vi.mock('../Icon', () => ({ Icon: () => createElement('i', null) }));
 vi.mock('../PressableSurface', () => ({
   PressableSurface: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
 }));
+// Stubbed so this file doesn't drag in react-native-reanimated (its ESM entry
+// isn't resolvable under vitest). The chevron's own behaviour is covered in
+// `section-header-disclosure.test.tsx`.
+vi.mock('../SectionDisclosureChevron', () => ({ SectionDisclosureChevron: () => createElement('i', null) }));
 vi.mock('../../providers/theme-provider', () => ({
   useTheme: () => ({
     variant: ctrl.variant,

--- a/packages/mobile/src/components/play-drawer/DeferredSections.tsx
+++ b/packages/mobile/src/components/play-drawer/DeferredSections.tsx
@@ -21,6 +21,7 @@ import { useBoardseshGrade, useClimbStatsHistory } from '../../lib/graphql/hooks
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useDeferredAfterInteractions } from '../../hooks/use-deferred-after-interactions';
+import { BETA_SHELF_SECTION_KEY } from '../../lib/beta-shelf-collapse';
 
 type DeferredSectionsProps = {
   climb: Climb;
@@ -203,7 +204,8 @@ export const DeferredSections = memo(function DeferredSections({
         <>
           <CollapsibleSection
             title={t('mobile.betaVideos.title')}
-            keepExpanded
+            defaultExpanded
+            persistKey={BETA_SHELF_SECTION_KEY}
             headerAction={
               isAuthenticated && onAddBetaVideo ? (
                 <Pressable

--- a/packages/mobile/src/components/session/SessionBetaCarousel.tsx
+++ b/packages/mobile/src/components/session/SessionBetaCarousel.tsx
@@ -56,7 +56,7 @@ export function SessionBetaCarousel({ ticks, participantById, isMultiUser }: Ses
 
   return (
     <View>
-      <SectionHeader title={t('mobile.betaVideos.crewTitle')} expanded={expanded} onToggleExpanded={toggle} />
+      <SectionHeader title={t('mobile.betaVideos.crewTitle')} disclosure={{ expanded, onToggle: toggle }} />
       {!expanded ? null : (
         <ScrollView
           horizontal

--- a/packages/mobile/src/components/session/SessionBetaCarousel.tsx
+++ b/packages/mobile/src/components/session/SessionBetaCarousel.tsx
@@ -6,6 +6,7 @@ import { SectionHeader } from '../SectionHeader';
 import { betaLinkIdentity, isBetaVideoUrl, mapBetaLink } from '../../lib/beta-video-url';
 import { spacing } from '../../theme/tokens';
 import { BetaVideoCard, BETA_CARD_WIDTH } from '../play-drawer/BetaVideoCard';
+import { useBetaShelfCollapse } from '../../lib/beta-shelf-collapse';
 
 type CrewBetaItem = { betaLink: BetaLink; uploaderName: string | null; uploaderAvatarUrl: string | null };
 
@@ -28,6 +29,7 @@ const CARD_GAP = spacing[3];
  */
 export function SessionBetaCarousel({ ticks, participantById, isMultiUser }: SessionBetaCarouselProps) {
   const { t } = useTranslation('session');
+  const { expanded, toggle } = useBetaShelfCollapse();
 
   const items = useMemo<CrewBetaItem[]>(() => {
     const result: CrewBetaItem[] = [];
@@ -54,24 +56,26 @@ export function SessionBetaCarousel({ ticks, participantById, isMultiUser }: Ses
 
   return (
     <View>
-      <SectionHeader title={t('mobile.betaVideos.crewTitle')} />
-      <ScrollView
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        contentContainerStyle={styles.scrollContent}
-        snapToInterval={BETA_CARD_WIDTH + CARD_GAP}
-        decelerationRate="fast"
-        snapToAlignment="start"
-      >
-        {items.map((item) => (
-          <BetaVideoCard
-            key={betaLinkIdentity(item.betaLink.link)}
-            link={item.betaLink}
-            uploaderName={item.uploaderName}
-            uploaderAvatarUrl={item.uploaderAvatarUrl}
-          />
-        ))}
-      </ScrollView>
+      <SectionHeader title={t('mobile.betaVideos.crewTitle')} expanded={expanded} onToggleExpanded={toggle} />
+      {!expanded ? null : (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.scrollContent}
+          snapToInterval={BETA_CARD_WIDTH + CARD_GAP}
+          decelerationRate="fast"
+          snapToAlignment="start"
+        >
+          {items.map((item) => (
+            <BetaVideoCard
+              key={betaLinkIdentity(item.betaLink.link)}
+              link={item.betaLink}
+              uploaderName={item.uploaderName}
+              uploaderAvatarUrl={item.uploaderAvatarUrl}
+            />
+          ))}
+        </ScrollView>
+      )}
     </View>
   );
 }

--- a/packages/mobile/src/components/session/__tests__/SessionBetaCarousel.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionBetaCarousel.test.tsx
@@ -12,6 +12,14 @@ const cards = vi.hoisted(() => ({
   rendered: [] as Array<{ link: string; uploaderName: string | null | undefined }>,
 }));
 
+// Shared beta-shelf collapse state (#4229). Stubbed rather than driven through
+// the real store so this file stays about selection/attribution; the store
+// itself is covered in `src/lib/__tests__/beta-shelf-collapse.test.tsx`.
+const collapse = vi.hoisted(() => ({ expanded: true }));
+vi.mock('../../../lib/beta-shelf-collapse', () => ({
+  useBetaShelfCollapse: () => ({ expanded: collapse.expanded, toggle: vi.fn() }),
+}));
+
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   ScrollView: ({ children }: { children?: ReactNode }) =>
@@ -84,6 +92,7 @@ const SOLO = { participantById: new Map<string, SessionFeedParticipant>(), isMul
 
 beforeEach(() => {
   cards.rendered = [];
+  collapse.expanded = true;
 });
 
 describe('SessionBetaCarousel', () => {
@@ -163,5 +172,21 @@ describe('SessionBetaCarousel', () => {
       }),
     );
     expect(cards.rendered).toEqual([{ link: 'https://www.instagram.com/reel/aaa/', uploaderName: null }]);
+  });
+
+  it('drops the scroller but keeps the header when the shared shelf is collapsed', () => {
+    // The header has to survive, otherwise there is nothing left to tap to
+    // unfold the crew beta again (#4229).
+    collapse.expanded = false;
+    const { queryByTestId, getByTestId } = render(
+      createElement(SessionBetaCarousel, {
+        ...SOLO,
+        ticks: [tick([betaRow({ link: 'https://www.instagram.com/reel/aaa/' })])],
+      }),
+    );
+
+    expect(getByTestId('section-header')).toBeTruthy();
+    expect(queryByTestId('beta-scroll')).toBeNull();
+    expect(cards.rendered).toEqual([]);
   });
 });

--- a/packages/mobile/src/components/session/__tests__/SessionBetaCarousel.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionBetaCarousel.test.tsx
@@ -17,7 +17,7 @@ const cards = vi.hoisted(() => ({
 // itself is covered in `src/lib/__tests__/beta-shelf-collapse.test.tsx`.
 const collapse = vi.hoisted(() => ({ expanded: true }));
 vi.mock('../../../lib/beta-shelf-collapse', () => ({
-  useBetaShelfCollapse: () => ({ expanded: collapse.expanded, toggle: vi.fn() }),
+  useBetaShelfCollapse: () => ({ expanded: collapse.expanded, toggle: vi.fn(), loaded: true }),
 }));
 
 vi.mock('react-native', () => ({

--- a/packages/mobile/src/components/you/ProfileBetaShelf.tsx
+++ b/packages/mobile/src/components/you/ProfileBetaShelf.tsx
@@ -5,6 +5,7 @@ import { betaLinkIdentity } from '@boardsesh/shared-schema';
 import { HorizontalScrollSection } from '../HorizontalScrollSection';
 import { BetaVideoCard, BETA_CARD_COMPACT_HEIGHT } from '../play-drawer/BetaVideoCard';
 import { useUserBetaLinks } from '../../lib/graphql/hooks';
+import { useBetaShelfCollapse } from '../../lib/beta-shelf-collapse';
 
 type ProfileBetaShelfProps = {
   /** The climber whose beta videos to show (own id on the You tab). */
@@ -19,7 +20,11 @@ type ProfileBetaShelfProps = {
  */
 export const ProfileBetaShelf = memo(function ProfileBetaShelf({ userId }: ProfileBetaShelfProps) {
   const { t } = useTranslation('you');
+  // Deliberately not gated on `expanded`: this shelf hides itself entirely when
+  // the climber has no beta, so skipping the query while collapsed would strip
+  // the header too and leave no way to unfold it again.
   const { videos, isLoading, isLoadingMore, loadMore } = useUserBetaLinks(userId);
+  const { expanded, toggle } = useBetaShelfCollapse();
 
   const handleSeeAll = useCallback(() => {
     router.push({ pathname: '/users/[userId]/beta', params: { userId } });
@@ -39,6 +44,8 @@ export const ProfileBetaShelf = memo(function ProfileBetaShelf({ userId }: Profi
       isLoadingMore={isLoadingMore}
       onEndReached={loadMore}
       minHeight={BETA_CARD_COMPACT_HEIGHT}
+      expanded={expanded}
+      onToggleExpanded={toggle}
     >
       {videos.map((video) => (
         <BetaVideoCard key={betaLinkIdentity(video.betaLink.link)} link={video.betaLink} size="compact" />

--- a/packages/mobile/src/components/you/ProfileBetaShelf.tsx
+++ b/packages/mobile/src/components/you/ProfileBetaShelf.tsx
@@ -47,8 +47,7 @@ export const ProfileBetaShelf = memo(function ProfileBetaShelf({ userId }: Profi
       isLoadingMore={isLoadingMore}
       onEndReached={loadMore}
       minHeight={BETA_CARD_COMPACT_HEIGHT}
-      expanded={expanded}
-      onToggleExpanded={toggle}
+      disclosure={{ expanded, onToggle: toggle }}
     >
       {videos.map((video) => (
         <BetaVideoCard key={betaLinkIdentity(video.betaLink.link)} link={video.betaLink} size="compact" />

--- a/packages/mobile/src/components/you/ProfileBetaShelf.tsx
+++ b/packages/mobile/src/components/you/ProfileBetaShelf.tsx
@@ -22,7 +22,10 @@ export const ProfileBetaShelf = memo(function ProfileBetaShelf({ userId }: Profi
   const { t } = useTranslation('you');
   // Deliberately not gated on `expanded`: this shelf hides itself entirely when
   // the climber has no beta, so skipping the query while collapsed would strip
-  // the header too and leave no way to unfold it again.
+  // the header too and leave no way to unfold it again. That protection leans on
+  // the empty-state guard below staying keyed to *real* results — if
+  // `useUserBetaLinks` ever returns placeholder rows while loading, revisit both
+  // together. Covered by `__tests__/profile-beta-shelf-collapse.test.tsx`.
   const { videos, isLoading, isLoadingMore, loadMore } = useUserBetaLinks(userId);
   const { expanded, toggle } = useBetaShelfCollapse();
 

--- a/packages/mobile/src/components/you/__tests__/profile-beta-shelf-collapse.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/profile-beta-shelf-collapse.test.tsx
@@ -38,19 +38,19 @@ vi.mock('../../HorizontalScrollSection', () => ({
   HorizontalScrollSection: ({
     title,
     children,
-    expanded,
+    disclosure,
     actionLabel,
   }: {
     title: string;
     children?: ReactNode;
-    expanded?: boolean;
+    disclosure?: { expanded: boolean };
     actionLabel?: string;
   }) =>
     createElement(
       'div',
       null,
       createElement('div', { 'data-testid': 'section-header', 'data-action': actionLabel }, title),
-      expanded === false ? null : createElement('div', { 'data-testid': 'shelf-scroll' }, children),
+      disclosure?.expanded === false ? null : createElement('div', { 'data-testid': 'shelf-scroll' }, children),
     ),
 }));
 

--- a/packages/mobile/src/components/you/__tests__/profile-beta-shelf-collapse.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/profile-beta-shelf-collapse.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { BetaLink } from '@boardsesh/shared-schema';
+
+const collapse = vi.hoisted(() => ({ expanded: true }));
+const links = vi.hoisted(() => ({
+  videos: [] as Array<{ betaLink: BetaLink }>,
+  isLoading: false,
+  calls: 0,
+}));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+}));
+vi.mock('expo-router', () => ({ router: { push: vi.fn() } }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../../../lib/beta-shelf-collapse', () => ({
+  useBetaShelfCollapse: () => ({ expanded: collapse.expanded, toggle: vi.fn() }),
+}));
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useUserBetaLinks: () => {
+    links.calls += 1;
+    return { videos: links.videos, isLoading: links.isLoading, isLoadingMore: false, loadMore: vi.fn() };
+  },
+}));
+vi.mock('../../play-drawer/BetaVideoCard', () => ({
+  BETA_CARD_COMPACT_HEIGHT: 96,
+  BetaVideoCard: ({ link }: { link: BetaLink }) =>
+    createElement('div', { 'data-testid': 'beta-card', 'data-link': link.link }),
+}));
+// Mirrors the real wrapper's contract: header always, scroller only when open.
+vi.mock('../../HorizontalScrollSection', () => ({
+  HorizontalScrollSection: ({
+    title,
+    children,
+    expanded,
+    actionLabel,
+  }: {
+    title: string;
+    children?: ReactNode;
+    expanded?: boolean;
+    actionLabel?: string;
+  }) =>
+    createElement(
+      'div',
+      null,
+      createElement('div', { 'data-testid': 'section-header', 'data-action': actionLabel }, title),
+      expanded === false ? null : createElement('div', { 'data-testid': 'shelf-scroll' }, children),
+    ),
+}));
+
+import { ProfileBetaShelf } from '../ProfileBetaShelf';
+
+function betaLink(link: string): { betaLink: BetaLink } {
+  return {
+    betaLink: {
+      link,
+      climb_uuid: 'climb-1',
+      angle: 40,
+      foreign_username: 'setter',
+      thumbnail: null,
+      is_listed: true,
+      created_at: '2026-06-12T00:00:00.000Z',
+    } as unknown as BetaLink,
+  };
+}
+
+describe('ProfileBetaShelf collapse', () => {
+  beforeEach(() => {
+    collapse.expanded = true;
+    links.videos = [betaLink('https://www.instagram.com/reel/aaa/')];
+    links.isLoading = false;
+    links.calls = 0;
+  });
+
+  it('renders its cards while expanded', () => {
+    const { getAllByTestId } = render(createElement(ProfileBetaShelf, { userId: 'user-1' }));
+    expect(getAllByTestId('beta-card')).toHaveLength(1);
+  });
+
+  it('drops the cards but keeps the header when collapsed', () => {
+    collapse.expanded = false;
+    const { getByTestId, queryByTestId } = render(createElement(ProfileBetaShelf, { userId: 'user-1' }));
+
+    expect(getByTestId('section-header')).toBeTruthy();
+    expect(queryByTestId('shelf-scroll')).toBeNull();
+    expect(queryByTestId('beta-card')).toBeNull();
+  });
+
+  it('keeps fetching while collapsed so the header survives', () => {
+    // Load-bearing: the shelf self-hides when a climber has no beta, so gating
+    // the query on `expanded` would strip the header too and leave no way to
+    // unfold it. If this ever starts skipping the fetch, that guard is broken.
+    collapse.expanded = false;
+    render(createElement(ProfileBetaShelf, { userId: 'user-1' }));
+    expect(links.calls).toBeGreaterThan(0);
+  });
+
+  it('still hides itself entirely for a climber with no beta', () => {
+    // The self-hide predates this change and must survive it — no stray header
+    // on profiles that have nothing to show.
+    links.videos = [];
+    links.isLoading = false;
+    const { queryByTestId } = render(createElement(ProfileBetaShelf, { userId: 'user-1' }));
+    expect(queryByTestId('section-header')).toBeNull();
+  });
+});

--- a/packages/mobile/src/components/you/__tests__/profile-beta-shelf-collapse.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/profile-beta-shelf-collapse.test.tsx
@@ -20,7 +20,7 @@ vi.mock('react-native', () => ({
 vi.mock('expo-router', () => ({ router: { push: vi.fn() } }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('../../../lib/beta-shelf-collapse', () => ({
-  useBetaShelfCollapse: () => ({ expanded: collapse.expanded, toggle: vi.fn() }),
+  useBetaShelfCollapse: () => ({ expanded: collapse.expanded, toggle: vi.fn(), loaded: true }),
 }));
 vi.mock('../../../lib/graphql/hooks', () => ({
   useUserBetaLinks: () => {

--- a/packages/mobile/src/lib/__tests__/beta-shelf-collapse.test.tsx
+++ b/packages/mobile/src/lib/__tests__/beta-shelf-collapse.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor, fireEvent, act } from '@testing-library/react';
+import { createElement } from 'react';
+
+// AsyncStorage backs the shared expand map. Same in-memory double the
+// CollapsibleSection persistence test uses, so both exercise the real store.
+vi.mock('@react-native-async-storage/async-storage', () => {
+  let storage: Record<string, string> = {};
+  return {
+    default: {
+      getItem: vi.fn(async (key: string) => storage[key] ?? null),
+      setItem: vi.fn(async (key: string, value: string) => {
+        storage[key] = value;
+      }),
+      removeItem: vi.fn(async (key: string) => {
+        delete storage[key];
+      }),
+      __reset: () => {
+        storage = {};
+      },
+      __setRaw: (key: string, value: string) => {
+        storage[key] = value;
+      },
+      __read: (key: string) => storage[key],
+    },
+  };
+});
+vi.mock('../haptics', () => ({ hapticSelection: vi.fn() }));
+
+import { BETA_SHELF_SECTION_KEY, BETA_SHELF_DEFAULT_EXPANDED, useBetaShelfCollapse } from '../beta-shelf-collapse';
+import { resetSectionExpandStoreForTests, setSectionExpanded, STORAGE_KEY } from '../section-expand-store';
+
+async function getMockStorage() {
+  return (await import('@react-native-async-storage/async-storage')).default as unknown as {
+    __reset: () => void;
+    __setRaw: (key: string, value: string) => void;
+    __read: (key: string) => string | undefined;
+  };
+}
+
+// Stands in for any of the four shelves: renders its expand state and a header
+// tap target, exactly like the real surfaces do.
+function Shelf({ name }: { name: string }) {
+  const { expanded, toggle } = useBetaShelfCollapse();
+  return createElement(
+    'div',
+    null,
+    createElement('button', { onClick: toggle }, `toggle-${name}`),
+    createElement('span', null, `${name}:${expanded ? 'expanded' : 'collapsed'}`),
+  );
+}
+
+describe('useBetaShelfCollapse', () => {
+  beforeEach(async () => {
+    resetSectionExpandStoreForTests();
+    (await getMockStorage()).__reset();
+  });
+
+  it('defaults to expanded so the shelf is never hidden from existing users', () => {
+    expect(BETA_SHELF_DEFAULT_EXPANDED).toBe(true);
+    const { getByText } = render(createElement(Shelf, { name: 'home' }));
+    expect(getByText('home:expanded')).toBeTruthy();
+  });
+
+  it('collapses on toggle and persists under the shared section key', async () => {
+    const { getByText } = render(createElement(Shelf, { name: 'home' }));
+
+    fireEvent.click(getByText('toggle-home'));
+    expect(getByText('home:collapsed')).toBeTruthy();
+
+    const storage = await getMockStorage();
+    await waitFor(() => {
+      expect(JSON.parse(storage.__read(STORAGE_KEY) ?? '{}')).toMatchObject({
+        [BETA_SHELF_SECTION_KEY]: false,
+      });
+    });
+  });
+
+  it('shares one state across every surface — collapsing on one folds them all', () => {
+    // The core promise of #4229: "collapsible anywhere it shows" means one
+    // preference, not four. Mount two shelves and toggle only the first.
+    const { getByText } = render(
+      createElement('div', null, createElement(Shelf, { name: 'home' }), createElement(Shelf, { name: 'profile' })),
+    );
+
+    expect(getByText('home:expanded')).toBeTruthy();
+    expect(getByText('profile:expanded')).toBeTruthy();
+
+    fireEvent.click(getByText('toggle-home'));
+
+    expect(getByText('home:collapsed')).toBeTruthy();
+    expect(getByText('profile:collapsed')).toBeTruthy();
+  });
+
+  it('picks up an external write to the same key (e.g. the play-drawer section)', () => {
+    // The play drawer collapses through CollapsibleSection's own persistKey
+    // rather than this hook, so a write from there must reach the shelves.
+    const { getByText } = render(createElement(Shelf, { name: 'home' }));
+    expect(getByText('home:expanded')).toBeTruthy();
+
+    act(() => {
+      setSectionExpanded(BETA_SHELF_SECTION_KEY, false);
+    });
+
+    expect(getByText('home:collapsed')).toBeTruthy();
+  });
+
+  it('reconciles to a collapsed value stored before launch', async () => {
+    // Cold store: the value arrives from AsyncStorage after first paint.
+    (await getMockStorage()).__setRaw(STORAGE_KEY, JSON.stringify({ [BETA_SHELF_SECTION_KEY]: false }));
+
+    const { getByText } = render(createElement(Shelf, { name: 'home' }));
+
+    await waitFor(() => expect(getByText('home:collapsed')).toBeTruthy());
+  });
+});

--- a/packages/mobile/src/lib/__tests__/beta-shelf-collapse.test.tsx
+++ b/packages/mobile/src/lib/__tests__/beta-shelf-collapse.test.tsx
@@ -42,12 +42,13 @@ async function getMockStorage() {
 // Stands in for any of the four shelves: renders its expand state and a header
 // tap target, exactly like the real surfaces do.
 function Shelf({ name }: { name: string }) {
-  const { expanded, toggle } = useBetaShelfCollapse();
+  const { expanded, toggle, loaded } = useBetaShelfCollapse();
   return createElement(
     'div',
     null,
     createElement('button', { onClick: toggle }, `toggle-${name}`),
     createElement('span', null, `${name}:${expanded ? 'expanded' : 'collapsed'}`),
+    createElement('span', null, `${name}-loaded:${loaded ? 'yes' : 'no'}`),
   );
 }
 
@@ -104,6 +105,18 @@ describe('useBetaShelfCollapse', () => {
     });
 
     expect(getByText('home:collapsed')).toBeTruthy();
+  });
+
+  it('reports loaded:false until the store has been read', async () => {
+    // The home shelf renders nothing while this is false — that flag is what
+    // keeps a stored "collapsed" from flashing open on a cold start, without
+    // putting an AsyncStorage read on the splash's critical path.
+    (await getMockStorage()).__setRaw(STORAGE_KEY, JSON.stringify({ [BETA_SHELF_SECTION_KEY]: false }));
+
+    const { getByText } = render(createElement(Shelf, { name: 'home' }));
+
+    expect(getByText('home-loaded:no')).toBeTruthy();
+    await waitFor(() => expect(getByText('home-loaded:yes')).toBeTruthy());
   });
 
   it('reconciles to a collapsed value stored before launch', async () => {

--- a/packages/mobile/src/lib/beta-shelf-collapse.ts
+++ b/packages/mobile/src/lib/beta-shelf-collapse.ts
@@ -1,0 +1,46 @@
+// Collapse state for the beta-video shelves. Every surface that renders a row
+// of `BetaVideoCard`s — the home shelf, the play-drawer section, "Beta from this
+// crew" on session detail, and the profile shelf — shares this one key, so
+// folding the row away in one place folds it everywhere (issue #4229).
+//
+// Backed by the existing `section-expand-store` map rather than a store of its
+// own: that store is already a single `Record<string, boolean>` behind one
+// AsyncStorage slot, so an extra key costs no extra read, write, or subscription.
+
+import { useCallback } from 'react';
+import { hapticSelection } from './haptics';
+import { setSectionExpanded, useSectionExpanded } from './section-expand-store';
+
+/** Shared across all four beta shelves. Sits alongside the climb-card section
+ *  keys (`logbook`, `boardseshGrade`, `community`, `similarClimbs`) in the same map. */
+export const BETA_SHELF_SECTION_KEY = 'betaVideos';
+
+/** Expanded until the user says otherwise — adding a disclosure must not hide
+ *  content from climbers who were happy with the shelf. */
+export const BETA_SHELF_DEFAULT_EXPANDED = true;
+
+export type BetaShelfCollapse = {
+  expanded: boolean;
+  toggle: () => void;
+};
+
+/**
+ * Reads and toggles the shared beta-shelf expand state.
+ *
+ * No local mirror state: `setSectionExpanded` notifies synchronously and the
+ * store is read through `useSyncExternalStore`, so every mounted shelf
+ * re-renders on the same tick as the tap. (`CollapsibleSection` keeps a mirror
+ * only because it also has to service `defaultExpanded`/`resetKey` and drive a
+ * Reanimated shared value from the reconciliation.)
+ */
+export function useBetaShelfCollapse(): BetaShelfCollapse {
+  const { expanded: persisted } = useSectionExpanded(BETA_SHELF_SECTION_KEY);
+  const expanded = persisted ?? BETA_SHELF_DEFAULT_EXPANDED;
+
+  const toggle = useCallback(() => {
+    hapticSelection();
+    setSectionExpanded(BETA_SHELF_SECTION_KEY, !expanded);
+  }, [expanded]);
+
+  return { expanded, toggle };
+}

--- a/packages/mobile/src/lib/beta-shelf-collapse.ts
+++ b/packages/mobile/src/lib/beta-shelf-collapse.ts
@@ -22,6 +22,10 @@ export const BETA_SHELF_DEFAULT_EXPANDED = true;
 export type BetaShelfCollapse = {
   expanded: boolean;
   toggle: () => void;
+  /** False until the stored value has been read. `expanded` is only a default
+   *  guess before then, so a first-paint surface should render neither state
+   *  rather than guess and correct itself visibly. */
+  loaded: boolean;
 };
 
 /**
@@ -34,7 +38,7 @@ export type BetaShelfCollapse = {
  * Reanimated shared value from the reconciliation.)
  */
 export function useBetaShelfCollapse(): BetaShelfCollapse {
-  const { expanded: persisted } = useSectionExpanded(BETA_SHELF_SECTION_KEY);
+  const { expanded: persisted, loaded } = useSectionExpanded(BETA_SHELF_SECTION_KEY);
   const expanded = persisted ?? BETA_SHELF_DEFAULT_EXPANDED;
 
   const toggle = useCallback(() => {
@@ -42,5 +46,5 @@ export function useBetaShelfCollapse(): BetaShelfCollapse {
     setSectionExpanded(BETA_SHELF_SECTION_KEY, !expanded);
   }, [expanded]);
 
-  return { expanded, toggle };
+  return { expanded, toggle, loaded };
 }


### PR DESCRIPTION
## Summary

The beta-video rows had no way out — they sat at the top of the home tab whether or not you wanted them there. This makes them foldable everywhere they appear, off one shared preference that survives restarts.

Closes #4229

Marco's call on the issue was "make it collapsible, and persist the expand/collapse state", applied anywhere the row shows rather than only on home. Mobile only.

**One preference, four surfaces.** Fold the row in any one place and it folds in all of them:

| Surface | Where |
| --- | --- |
| Home shelf ("Fresh beta") | `app/(tabs)/home/index.tsx` |
| Play drawer "Beta Videos" | `play-drawer/DeferredSections.tsx` |
| "Beta from this crew" | `session/SessionBetaCarousel.tsx` |
| Profile shelf | `you/ProfileBetaShelf.tsx` |

Left alone on purpose: the full-page "See all" grid (`/users/<id>/beta`), whose entire reason to exist is that grid, and the single beta thumbnail inside a feed card.

Default stays **expanded**, so nobody loses content silently.

### Notes for review

**No new store, no new storage key.** `section-expand-store` is already one `Record<string, boolean>` behind a single AsyncStorage slot, so the shelves just take a key in it (`betaVideos`) alongside the existing climb-card sections. That's what makes the state shared for free — the play drawer goes through `CollapsibleSection`'s own `persistKey`, the other three through a small `useBetaShelfCollapse()` hook, and both land in the same map.

**Cold-launch flash.** Nothing preloaded that map — it loaded lazily on the first section's mount. A climber who folded the home shelf away would have watched it render open and snap shut on every cold start, on the first screen they see.

The fix gates the *shelf*, not the app: the store already reports whether it's been read, and the home shelf renders nothing until that lands rather than painting its default and correcting it. One AsyncStorage read, so the gap is imperceptible. The root layout still warms the map at boot, but only so the later surfaces (play drawer, profile, session) mount against a loaded store — deliberately **not** a splash gate, since startup shouldn't wait on a preference read for a shelf most people never fold. (An earlier revision did gate the splash; that traded the flash for a worse problem on low-end devices.)

**Why not just wrap the shelves in `CollapsibleSection`.** Its rounded card background and content padding would have restyled all three shelves and killed their edge-to-edge horizontal scroll. The disclosure went into the shared `SectionHeader` instead, with a small extracted `SectionDisclosureChevron` so the animation and a11y stay identical.

**Header actions are siblings, not children.** In both `SectionHeader` and `CollapsibleSection`, the action ("See all", and the play drawer's "+") now sits beside the toggle target rather than inside it. The "+" in particular has never been inside a tappable header before — Beta Videos was pinned open with `keepExpanded` — so rather than leave its taps to responder-system arbitration, it structurally owns them. Visual order is unchanged, and it's now testable.

**Asymmetric query gating, deliberately.** Home skips its beta request entirely while folded (its header renders unconditionally, so there's no way to strand yourself). The profile shelf keeps its query: it hides itself when the climber has no beta, so a disabled query would strip the header too and leave no way to unfold it. There's a test for the header surviving a collapse on both paths.

## Release Notes

- Tuck the beta-video row away when you don't want it — tap the heading on the home feed, a climb, a session, or a profile and it folds. Fold it once and it stays folded everywhere until you open it back up.

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 604 files / 5280 tests pass (up from 601 / 5256)
- `vp check` — no findings in any touched file
- `vp run check:mobile-bundle` — iOS + Android bundles OK

New coverage:

- `beta-shelf-collapse.test.tsx` — defaults expanded; toggle persists under the shared key; **two shelves mounted together fold as one**; an external write from the play drawer's `persistKey` reaches the shelves; a value stored before launch reconciles in.
- `section-header-disclosure.test.tsx` — chevron + `accessibilityState.expanded`; title toggles; **"See all" fires its own handler and does not fold the shelf**.
- `collapsible-section-persist.test.tsx` — **a `headerAction` press does not fold the section** (the "+" case); chevron toggles as well as the title.
- `horizontal-scroll-section-collapse.test.tsx` — collapsed drops the scroller and the spinner but keeps the header.
- `SessionBetaCarousel.test.tsx` — collapsed drops the scroller, keeps the header.
- `profile-beta-shelf-collapse.test.tsx` — collapsed drops the cards and keeps the header; **the query keeps firing while collapsed** (the self-hide guard); a climber with no beta still gets no stray header.
- `beta-shelf-collapse.test.tsx` — `loaded` is false until the store is read, so the home shelf has something to wait on.

Device QA still wanted, per `.boardsesh/qa-notes.md`: the play-drawer "+" and profile "See all" tap routing on both platforms.

Accepted, not fixed: only the home shelf waits on the store's `loaded` flag. The session and profile shelves read `expanded` directly, so a deep link straight to one of those before the boot warm-up finishes could in principle flash. Both sit behind navigation and a network query, so the window is effectively nil in practice — noting it here rather than complicating three surfaces for a theoretical frame.

One known gap: there's no render test asserting home stops fetching while folded (the symmetric case to the profile-shelf test above). `home/index.tsx` has 38 imports and `RecentBetaShelf` is local to it, so covering it would mean either exporting an internal component for tests or mocking the whole route — neither felt worth it for a single boolean conjunction. Flagging rather than hiding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9StSuJPdcxgxSk6fvg8aN
