### PR TITLE
test(mobile): drive the sqlite init retries on fake timers

### DIFF
--- a/packages/mobile/src/db/__tests__/connection-test-seam.test.ts
+++ b/packages/mobile/src/db/__tests__/connection-test-seam.test.ts
@@ -1,0 +1,52 @@
+// `resetDatabaseInitializationForTests` drops the single-flight guard that keeps one
+// database lifecycle per process. Calling it from the app would let a remount start a
+// second retry chain against the same file — the #4104 contention the guard exists to
+// prevent. A JSDoc "test-only" label doesn't stop that, so the boundary is checked
+// here: only the module that defines it, the ./testing barrel, and tests may reach it.
+
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = fileURLToPath(new URL('../../../', import.meta.url));
+const SCANNED_ROOTS = ['src', 'app'];
+const TESTING_BARREL = join(packageRoot, 'src', 'db', 'testing');
+const ALLOWED_FILES = [join('src', 'db', 'connection.ts'), join('src', 'db', 'testing.ts')];
+
+function listApplicationFiles(root: string): string[] {
+  return readdirSync(join(packageRoot, root), { recursive: true, encoding: 'utf8' })
+    .filter((entry) => /(?<!\.test)\.tsx?$/.test(entry))
+    .map((entry) => join(root, entry))
+    .filter((entry) => !entry.split(sep).includes('__tests__') && !ALLOWED_FILES.includes(entry));
+}
+
+/** Resolves a relative or `@/`-aliased specifier (see tsconfig paths) to an absolute path. */
+function resolveSpecifier(file: string, specifier: string): string {
+  if (specifier.startsWith('@/')) return join(packageRoot, 'src', specifier.slice(2));
+  if (specifier.startsWith('.')) return resolve(dirname(join(packageRoot, file)), specifier);
+  return specifier;
+}
+
+describe('database test seam', () => {
+  const applicationFiles = SCANNED_ROOTS.flatMap(listApplicationFiles);
+
+  it('scans the mobile source tree', () => {
+    // A walk that silently matched nothing would make the guard below vacuous.
+    expect(applicationFiles.length).toBeGreaterThan(100);
+  });
+
+  it('keeps the init-guard reset out of application code', () => {
+    const offenders = applicationFiles.filter((file) => {
+      const source = readFileSync(join(packageRoot, file), 'utf8');
+      if (source.includes('resetDatabaseInitializationForTests')) return true;
+      // Also the `import * as` / re-export forms that never spell the name out —
+      // src/db/index.ts, the production barrel, is one of the files scanned here.
+      return [...source.matchAll(/from\s+'([^']+)'/g)].some(
+        ([, specifier]) => resolveSpecifier(file, specifier) === TESTING_BARREL,
+      );
+    });
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/mobile/src/db/__tests__/connection-test-seam.test.ts
+++ b/packages/mobile/src/db/__tests__/connection-test-seam.test.ts
@@ -46,7 +46,9 @@ describe('database test seam', () => {
       if (source.includes('resetDatabaseInitializationForTests')) return true;
       // Also the `import * as` / re-export forms that never spell the name out —
       // src/db/index.ts, the production barrel, is one of the files scanned here.
-      return [...source.matchAll(/from\s+['"]([^'"]+)['"]/g)].some(
+      // Covers static `from '…'`, bare `import '…'`, and the dynamic `import(…)` /
+      // `require(…)` forms that would otherwise reach the module without naming it.
+      return [...source.matchAll(/(?:from|import|require)\s*\(?\s*['"]([^'"]+)['"]/g)].some(
         ([, specifier]) => resolveSpecifier(file, specifier) === TESTING_BARREL,
       );
     });

--- a/packages/mobile/src/db/__tests__/connection-test-seam.test.ts
+++ b/packages/mobile/src/db/__tests__/connection-test-seam.test.ts
@@ -42,7 +42,7 @@ describe('database test seam', () => {
       if (source.includes('resetDatabaseInitializationForTests')) return true;
       // Also the `import * as` / re-export forms that never spell the name out —
       // src/db/index.ts, the production barrel, is one of the files scanned here.
-      return [...source.matchAll(/from\s+'([^']+)'/g)].some(
+      return [...source.matchAll(/from\s+['"]([^'"]+)['"]/g)].some(
         ([, specifier]) => resolveSpecifier(file, specifier) === TESTING_BARREL,
       );
     });

--- a/packages/mobile/src/db/__tests__/connection-test-seam.test.ts
+++ b/packages/mobile/src/db/__tests__/connection-test-seam.test.ts
@@ -21,11 +21,15 @@ function listApplicationFiles(root: string): string[] {
     .filter((entry) => !entry.split(sep).includes('__tests__') && !ALLOWED_FILES.includes(entry));
 }
 
-/** Resolves a relative or `@/`-aliased specifier (see tsconfig paths) to an absolute path. */
+/**
+ * Resolves a relative or `@/`-aliased specifier (see tsconfig paths) to an absolute path,
+ * extensionless so `'../db/testing'` and `'../db/testing.ts'` compare equal.
+ */
 function resolveSpecifier(file: string, specifier: string): string {
-  if (specifier.startsWith('@/')) return join(packageRoot, 'src', specifier.slice(2));
-  if (specifier.startsWith('.')) return resolve(dirname(join(packageRoot, file)), specifier);
-  return specifier;
+  const target = specifier.replace(/\.tsx?$/, '');
+  if (target.startsWith('@/')) return join(packageRoot, 'src', target.slice(2));
+  if (target.startsWith('.')) return resolve(dirname(join(packageRoot, file)), target);
+  return target;
 }
 
 describe('database test seam', () => {

--- a/packages/mobile/src/db/__tests__/connection.test.ts
+++ b/packages/mobile/src/db/__tests__/connection.test.ts
@@ -15,13 +15,8 @@ const reportErrorMock = vi.hoisted(() => vi.fn());
 vi.mock('../../lib/error-reporting', () => ({ reportError: reportErrorMock }));
 
 import type { SQLiteDatabase } from 'expo-sqlite';
-import {
-  clearUserData,
-  getDatabaseHandle,
-  initializeDatabase,
-  resetDatabaseInitializationForTests,
-  setDatabaseHandle,
-} from '../connection';
+import { clearUserData, getDatabaseHandle, initializeDatabase, setDatabaseHandle } from '../connection';
+import { resetDatabaseInitializationForTests } from '../testing';
 import {
   runMigrations,
   setCheckpoint,
@@ -174,6 +169,11 @@ describe('initializeDatabase connection PRAGMAs', () => {
 // published the handle, and never tried again — one transient collision disabled
 // offline storage for the whole session. These drive that exact interleaving.
 describe('initializeDatabase lock contention (#4104)', () => {
+  // Mirrors INIT_RETRY_DELAYS_MS[0] in connection.ts — the gap before the first retry.
+  // Advancing the fake clock by exactly this much runs attempt 2 and nothing else; if
+  // the production backoff changes, these tests fail loudly instead of flaking.
+  const FIRST_RETRY_DELAY_MS = 500;
+
   let dbDir: string;
   let realDb: TestSqliteDb;
 
@@ -223,6 +223,10 @@ describe('initializeDatabase lock contention (#4104)', () => {
   });
 
   it('does not block app launch on the retry, leaving the handle unpublished for now', async () => {
+    // This test deliberately walks away mid-chain, so the retry it leaves pending must
+    // sit on the fake clock: afterEach's useRealTimers() discards it, instead of a real
+    // timer firing into a later test and publishing a handle or reporting an error there.
+    vi.useFakeTimers();
     const contended = createContendedDatabase();
 
     // Resolves as soon as the FIRST attempt settles — SQLiteProvider renders nothing
@@ -236,6 +240,9 @@ describe('initializeDatabase lock contention (#4104)', () => {
   });
 
   it('publishes the handle once a retry wins, instead of staying dead for the session', async () => {
+    // Fake timers, not a real sleep: the gap before the first retry is exactly
+    // FIRST_RETRY_DELAY_MS, and a real wait would race the attempt itself under CI load.
+    vi.useFakeTimers();
     const contended = createContendedDatabase();
 
     await initializeDatabase(contended.db);
@@ -243,13 +250,14 @@ describe('initializeDatabase lock contention (#4104)', () => {
 
     // The contending writer finishes (VACUUM done, import committed).
     contended.unlock();
-    await new Promise((resolve) => setTimeout(resolve, 750));
+    await vi.advanceTimersByTimeAsync(FIRST_RETRY_DELAY_MS);
 
     expect(getDatabaseHandle()).toBe(contended.db);
     expect(reportErrorMock).not.toHaveBeenCalled();
   });
 
   it('shares one lifecycle across a remount mid-retry rather than starting a second chain', async () => {
+    vi.useFakeTimers();
     const first = createContendedDatabase();
     const second = createContendedDatabase();
 
@@ -264,7 +272,7 @@ describe('initializeDatabase lock contention (#4104)', () => {
     expect(remount).toBe(initial);
 
     first.unlock();
-    await new Promise((resolve) => setTimeout(resolve, 750));
+    await vi.advanceTimersByTimeAsync(FIRST_RETRY_DELAY_MS);
 
     expect(getDatabaseHandle()).toBe(first.db);
     // The second database was never touched.

--- a/packages/mobile/src/db/__tests__/connection.test.ts
+++ b/packages/mobile/src/db/__tests__/connection.test.ts
@@ -15,7 +15,13 @@ const reportErrorMock = vi.hoisted(() => vi.fn());
 vi.mock('../../lib/error-reporting', () => ({ reportError: reportErrorMock }));
 
 import type { SQLiteDatabase } from 'expo-sqlite';
-import { clearUserData, getDatabaseHandle, initializeDatabase, setDatabaseHandle } from '../connection';
+import {
+  clearUserData,
+  getDatabaseHandle,
+  initializeDatabase,
+  INIT_RETRY_DELAYS_MS,
+  setDatabaseHandle,
+} from '../connection';
 import { resetDatabaseInitializationForTests } from '../testing';
 import {
   runMigrations,
@@ -169,10 +175,10 @@ describe('initializeDatabase connection PRAGMAs', () => {
 // published the handle, and never tried again — one transient collision disabled
 // offline storage for the whole session. These drive that exact interleaving.
 describe('initializeDatabase lock contention (#4104)', () => {
-  // Mirrors INIT_RETRY_DELAYS_MS[0] in connection.ts — the gap before the first retry.
-  // Advancing the fake clock by exactly this much runs attempt 2 and nothing else; if
-  // the production backoff changes, these tests fail loudly instead of flaking.
-  const FIRST_RETRY_DELAY_MS = 500;
+  // The real gap before the first retry, read from the production backoff rather than
+  // mirrored as a literal. Advancing the fake clock by exactly this much runs attempt 2
+  // and nothing else, and it keeps tracking if the backoff is ever retuned.
+  const FIRST_RETRY_DELAY_MS = INIT_RETRY_DELAYS_MS[0];
 
   let dbDir: string;
   let realDb: TestSqliteDb;

--- a/packages/mobile/src/db/connection.ts
+++ b/packages/mobile/src/db/connection.ts
@@ -57,7 +57,9 @@ export function getDatabaseHandle(): SQLiteDatabase | null {
  */
 const MAX_INIT_ATTEMPTS = 5;
 const MAX_INIT_WINDOW_MS = 30_000;
-const INIT_RETRY_DELAYS_MS = [500, 2_000, 5_000, 10_000];
+// Exported so the retry tests advance their fake clock by the real gap rather than
+// mirroring these numbers in a literal that silently drifts from them.
+export const INIT_RETRY_DELAYS_MS = [500, 2_000, 5_000, 10_000];
 
 /**
  * Single-flight guard spanning the ENTIRE init lifecycle, background retries

--- a/packages/mobile/src/db/connection.ts
+++ b/packages/mobile/src/db/connection.ts
@@ -211,6 +211,10 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
 /**
  * Test-only: drops the single-flight guard so each test can drive a fresh
  * initialization. Production has exactly one database for the process lifetime.
+ *
+ * It is defined here because the guard's state is module-local, but the sanctioned
+ * import path is `./testing`; neither this name nor that module may be reached from
+ * application code, which `connection-test-seam.test.ts` enforces.
  */
 export function resetDatabaseInitializationForTests(): void {
   activeInitialization = null;

--- a/packages/mobile/src/db/testing.ts
+++ b/packages/mobile/src/db/testing.ts
@@ -1,0 +1,7 @@
+// Test-only entry point for the database lifecycle. Nothing here may be imported
+// from application code — `connection-test-seam.test.ts` fails the build if it is.
+//
+// The reset lives in connection.ts because that is where the single-flight guard's
+// state lives; this barrel exists so the sanctioned import path for it is visibly a
+// test path, and so the production barrel (./index.ts) can stay free of it.
+export { resetDatabaseInitializationForTests } from './connection';


### PR DESCRIPTION
## Summary

Two tests in `packages/mobile/src/db/__tests__/connection.test.ts` crossed the SQLite init backoff with a real 750 ms sleep. The first retry delay is 500 ms, so only 250 ms of margin was left for `attemptInitialization` itself — thin enough to flake under CI load. `gives up after the bounded attempt window`, in the same describe, already used `vi.useFakeTimers()` + `vi.advanceTimersByTimeAsync`; the other two now do the same.

- `publishes the handle once a retry wins` and `shares one lifecycle across a remount mid-retry` install fake timers and advance by `INIT_RETRY_DELAYS_MS[0]`, read from the production backoff rather than mirrored as a literal, so a retuned backoff carries the tests with it.
- `does not block app launch on the retry` moves to the fake clock too. It deliberately walks away mid-chain, so on real timers it armed a retry that kept going for ~17.5 s after the test finished and ended by calling `reportError` — able to land inside a later test that asserts `reportErrorMock` call counts. On the fake clock, `afterEach`'s `useRealTimers()` discards it.

The review also flagged that `resetDatabaseInitializationForTests` is exported from a production module with only a JSDoc "Test-only" label guarding it. Calling it from the app would let a remount start a second retry chain against the same file — the #4104 contention the single-flight guard exists to prevent. The reset stays in `connection.ts` (that's where the guard's state lives), but:

- `src/db/testing.ts` is the sanctioned import path, and the test imports from there. The production barrel `src/db/index.ts` already omits the symbol.
- A re-export alone doesn't stop a careless caller, so `connection-test-seam.test.ts` enforces it: it walks every `.ts`/`.tsx` file under `src/` and `app/` (excluding tests, `connection.ts`, `testing.ts`) and fails if any names the symbol or resolves an import to `src/db/testing`. The specifier match covers static `from '…'`, bare `import '…'`, dynamic `import(…)`, and `require(…)`, in either quote style, with or without an explicit `.ts`/`.tsx` extension, and resolves `@/`-aliased paths. A "scans the mobile source tree" meta-test keeps the guard from silently becoming vacuous. This follows the source-level assertion pattern already in `connection.test.ts` for the #3646 seed retirement.

The only production change is exporting `INIT_RETRY_DELAYS_MS` (inert data, previously module-private) plus comments. No behaviour changes.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run test:mobile` — 604 files, 5293 tests passed.
- `vp run typecheck:mobile` — clean.
- `vp check packages/mobile/src/db` — 14 files, no format/lint/type findings.
- `vp run check:mobile-bundle` — iOS OK (14.7 MB), Android OK (14.8 MB).
- Verified the timer advance is load-bearing, not incidental microtask flushing: temporarily setting the advance to 100 ms fails both tests (handle still `null`); at the real 500 ms they pass. The db suites now run in ~900 ms instead of sleeping 1.5 s of real time.
- Verified the seam guard both ways: it passes on the current tree (926 files scanned, production barrel included) and flags every probe form it claims to cover — named import from `../db/connection`, relative and `@/`-aliased `import * as`, double-quoted specifier, explicit `.ts`/`.tsx` extension, `await import(…)`, and `require(…)`.
- Repo-wide `vp check` reports 297 findings in this sandbox, but the count is identical with and without this branch's changes (baseline measured with the work stashed) and none are in the files touched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUbmidMLskbkSwsVzTCSH5)_