### PR TITLE
fix(backend): keep grades on climbs with no saved angle

### DIFF
--- a/packages/backend/src/__tests__/climb-stats-angle-fallback.test.ts
+++ b/packages/backend/src/__tests__/climb-stats-angle-fallback.test.ts
@@ -1,0 +1,135 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { and, eq, sql } from 'drizzle-orm';
+import * as dbSchema from '@boardsesh/db/schema';
+import { db } from '../db/client';
+import { newClimbSubscriptionResolvers } from '../graphql/resolvers/social/new-climb-subscriptions';
+import { climbStatsJoinConditions } from '../db/queries/util/climb-stats-join';
+
+const BOARD_TYPE = 'moonboard' as const;
+const LAYOUT_ID = 990220;
+const CLIMB_PREFIX = 'climb-stats-angle-fallback-';
+
+const GRADE_HARD = { difficulty: 20, name: 'V5-fallback-test' };
+const GRADE_EASY = { difficulty: 10, name: 'V2-fallback-test' };
+
+async function insertClimb(uuid: string, angle: number | null) {
+  await db.execute(sql`
+    INSERT INTO board_climbs (uuid, board_type, layout_id, name, angle, is_listed, is_draft, created_at)
+    VALUES (${uuid}, ${BOARD_TYPE}, ${LAYOUT_ID}, ${uuid}, ${angle}, true, false, '2026-01-01')
+  `);
+}
+
+async function insertStats(uuid: string, angle: number, displayDifficulty: number, ascensionistCount: number) {
+  await db.execute(sql`
+    INSERT INTO board_climb_stats (board_type, climb_uuid, angle, display_difficulty, ascensionist_count)
+    VALUES (${BOARD_TYPE}, ${uuid}, ${angle}, ${displayDifficulty}, ${ascensionistCount})
+  `);
+}
+
+async function insertGrade(difficulty: number, boulderName: string) {
+  await db.execute(sql`
+    INSERT INTO board_difficulty_grades (board_type, difficulty, boulder_name, is_listed)
+    VALUES (${BOARD_TYPE}, ${difficulty}, ${boulderName}, true)
+    ON CONFLICT (board_type, difficulty) DO UPDATE SET boulder_name = excluded.boulder_name
+  `);
+}
+
+async function cleanupClimbs() {
+  await db.execute(sql`DELETE FROM board_climb_stats WHERE climb_uuid LIKE ${CLIMB_PREFIX + '%'}`);
+  await db.execute(sql`DELETE FROM board_climbs WHERE uuid LIKE ${CLIMB_PREFIX + '%'}`);
+}
+
+async function feedItemFor(uuid: string) {
+  const result = await newClimbSubscriptionResolvers.Query.newClimbFeed(null, {
+    input: { boardType: BOARD_TYPE, layoutId: LAYOUT_ID, limit: 50, offset: 0 },
+  });
+  return result.items.find((item) => item.uuid === uuid);
+}
+
+describe('board_climb_stats angle resolution for angle-agnostic climbs', () => {
+  beforeAll(async () => {
+    await cleanupClimbs();
+    await insertGrade(GRADE_HARD.difficulty, GRADE_HARD.name);
+    await insertGrade(GRADE_EASY.difficulty, GRADE_EASY.name);
+  });
+
+  afterEach(async () => {
+    await cleanupClimbs();
+  });
+
+  afterAll(async () => {
+    await cleanupClimbs();
+    await db.execute(sql`
+      DELETE FROM board_difficulty_grades
+      WHERE board_type = ${BOARD_TYPE} AND difficulty IN (${GRADE_HARD.difficulty}, ${GRADE_EASY.difficulty})
+    `);
+  });
+
+  it('falls back to the most-ascended stats row when the climb has no angle', async () => {
+    const uuid = `${CLIMB_PREFIX}null-angle`;
+    await insertClimb(uuid, null);
+    await insertStats(uuid, 40, GRADE_HARD.difficulty, 12);
+    await insertStats(uuid, 25, GRADE_EASY.difficulty, 3);
+
+    const item = await feedItemFor(uuid);
+
+    expect(item?.difficultyName).toBe(GRADE_HARD.name);
+    expect(item?.angle).toBe(40);
+  });
+
+  it('keeps using the climb angle when it is set, even if another angle has more ascents', async () => {
+    const uuid = `${CLIMB_PREFIX}own-angle`;
+    await insertClimb(uuid, 25);
+    await insertStats(uuid, 40, GRADE_HARD.difficulty, 12);
+    await insertStats(uuid, 25, GRADE_EASY.difficulty, 3);
+
+    const item = await feedItemFor(uuid);
+
+    expect(item?.difficultyName).toBe(GRADE_EASY.name);
+    expect(item?.angle).toBe(25);
+  });
+
+  it('breaks ascent ties on the lower angle so repeated reads agree', async () => {
+    const uuid = `${CLIMB_PREFIX}tie`;
+    await insertClimb(uuid, null);
+    await insertStats(uuid, 40, GRADE_HARD.difficulty, 7);
+    await insertStats(uuid, 25, GRADE_EASY.difficulty, 7);
+
+    const item = await feedItemFor(uuid);
+
+    expect(item?.difficultyName).toBe(GRADE_EASY.name);
+    expect(item?.angle).toBe(25);
+  });
+
+  it('leaves the grade null when an angle-less climb has no stats rows at all', async () => {
+    const uuid = `${CLIMB_PREFIX}no-stats`;
+    await insertClimb(uuid, null);
+
+    const item = await feedItemFor(uuid);
+
+    expect(item).toBeDefined();
+    expect(item?.difficultyName).toBeNull();
+    expect(item?.angle).toBeNull();
+  });
+});
+
+describe('climbStatsJoinConditions SQL shape', () => {
+  it('still emits the COALESCE fallback ordered by ascensionist_count', () => {
+    const { sql: emitted } = db
+      .select({ uuid: dbSchema.boardClimbs.uuid })
+      .from(dbSchema.boardClimbs)
+      .leftJoin(dbSchema.boardClimbStats, and(...climbStatsJoinConditions()))
+      .toSQL();
+
+    const normalized = emitted.toLowerCase().replace(/\s+/g, ' ');
+    expect(normalized).toContain('coalesce');
+    expect(normalized).toContain('order by s.ascensionist_count desc nulls last, s.angle asc');
+  });
+
+  it('does not change the non-angle join predicates', () => {
+    const conditions = climbStatsJoinConditions();
+    expect(conditions).toHaveLength(3);
+    expect(conditions[0]).toEqual(eq(dbSchema.boardClimbStats.boardType, dbSchema.boardClimbs.boardType));
+    expect(conditions[1]).toEqual(eq(dbSchema.boardClimbStats.climbUuid, dbSchema.boardClimbs.uuid));
+  });
+});

--- a/packages/backend/src/db/queries/util/climb-stats-join.ts
+++ b/packages/backend/src/db/queries/util/climb-stats-join.ts
@@ -1,0 +1,52 @@
+import { eq, sql, type SQL } from 'drizzle-orm';
+import { boardClimbs, boardClimbStats } from '@boardsesh/db/schema';
+
+/**
+ * Angle resolution for joins from `board_climbs` to `board_climb_stats`.
+ *
+ * `board_climbs.angle` is nullable while `board_climb_stats.angle` is NOT NULL
+ * and part of the stats primary key, so a plain
+ * `eq(boardClimbStats.angle, boardClimbs.angle)` join silently drops every
+ * stats row (and therefore the grade) for an angle-agnostic climb. MoonBoard
+ * problems are set at whatever angle the wall happens to be at, so they are the
+ * ones that end up with a NULL climb angle.
+ *
+ * The fallback picks the most-ascended stats row for the climb, with the lower
+ * angle winning ties so repeated reads are deterministic. `COALESCE`
+ * short-circuits: a climb with a non-null angle never evaluates the subquery,
+ * so Kilter/Tension behaviour and query plans are unchanged.
+ */
+export const climbStatsEffectiveAngleSql: SQL<number | null> = sql<number | null>`COALESCE(${boardClimbs.angle}, (
+  SELECT s.angle FROM board_climb_stats s
+  WHERE s.board_type = ${boardClimbs.boardType}
+    AND s.climb_uuid = ${boardClimbs.uuid}
+  ORDER BY s.ascensionist_count DESC NULLS LAST, s.angle ASC
+  LIMIT 1
+))`;
+// The inner copy of `board_climb_stats` is written as a bare `FROM
+// board_climb_stats s` rather than an interpolated table reference so the
+// correlation stays alias-stable even where the outer query already joins the
+// unaliased table.
+
+/** `board_climb_stats.angle` matches the climb's own angle, or the fallback above. */
+export function climbStatsAngleMatch(): SQL {
+  return eq(boardClimbStats.angle, climbStatsEffectiveAngleSql);
+}
+
+/**
+ * Full join predicate set for `leftJoin(boardClimbStats, and(...climbStatsJoinConditions()))`
+ * from a query whose `from` is `boardClimbs`.
+ */
+export function climbStatsJoinConditions(): SQL[] {
+  return [
+    eq(boardClimbStats.boardType, boardClimbs.boardType),
+    eq(boardClimbStats.climbUuid, boardClimbs.uuid),
+    climbStatsAngleMatch(),
+  ];
+}
+
+/**
+ * Angle to report alongside a grade resolved through the join above, so the
+ * displayed angle agrees with the difficulty that was actually read.
+ */
+export const resolvedClimbAngleSql = sql<number | null>`COALESCE(${boardClimbs.angle}, ${boardClimbStats.angle})`;

--- a/packages/backend/src/events/feed-fanout.ts
+++ b/packages/backend/src/events/feed-fanout.ts
@@ -5,6 +5,7 @@ import * as dbSchema from '@boardsesh/db/schema';
 import { and, eq, or } from 'drizzle-orm';
 import { buildFeedItemMetadata } from './feed-metadata';
 import { isNoMatchClimb } from '../graphql/resolvers/shared/helpers';
+import { climbStatsJoinConditions, resolvedClimbAngleSql } from '../db/queries/util/climb-stats-join';
 
 export { buildFeedItemMetadata } from './feed-metadata';
 
@@ -130,7 +131,7 @@ async function buildNewClimbMetadata(event: SocialEvent): Promise<Record<string,
       boardType: dbSchema.boardClimbs.boardType,
       layoutId: dbSchema.boardClimbs.layoutId,
       setterUsername: dbSchema.boardClimbs.setterUsername,
-      angle: dbSchema.boardClimbs.angle,
+      angle: resolvedClimbAngleSql,
       frames: dbSchema.boardClimbs.frames,
       description: dbSchema.boardClimbs.description,
       isDraft: dbSchema.boardClimbs.isDraft,
@@ -138,14 +139,7 @@ async function buildNewClimbMetadata(event: SocialEvent): Promise<Record<string,
       difficultyName: dbSchema.boardDifficultyGrades.boulderName,
     })
     .from(dbSchema.boardClimbs)
-    .leftJoin(
-      dbSchema.boardClimbStats,
-      and(
-        eq(dbSchema.boardClimbStats.boardType, dbSchema.boardClimbs.boardType),
-        eq(dbSchema.boardClimbStats.climbUuid, dbSchema.boardClimbs.uuid),
-        eq(dbSchema.boardClimbStats.angle, dbSchema.boardClimbs.angle),
-      ),
-    )
+    .leftJoin(dbSchema.boardClimbStats, and(...climbStatsJoinConditions()))
     .leftJoin(
       dbSchema.boardDifficultyGrades,
       and(

--- a/packages/backend/src/events/index.ts
+++ b/packages/backend/src/events/index.ts
@@ -17,6 +17,7 @@ import {
 } from './recipient-resolution';
 import { isNoMatchClimb } from '../graphql/resolvers/shared/helpers';
 import { logger } from '../utils/logger';
+import { climbStatsJoinConditions, resolvedClimbAngleSql } from '../db/queries/util/climb-stats-join';
 
 export const eventBroker = new EventBroker();
 
@@ -154,7 +155,7 @@ async function createInlineNotification(event: SocialEvent): Promise<void> {
             name: dbSchema.boardClimbs.name,
             description: dbSchema.boardClimbs.description,
             layoutId: dbSchema.boardClimbs.layoutId,
-            angle: dbSchema.boardClimbs.angle,
+            angle: resolvedClimbAngleSql,
             frames: dbSchema.boardClimbs.frames,
             createdAt: dbSchema.boardClimbs.createdAt,
             isDraft: dbSchema.boardClimbs.isDraft,
@@ -166,14 +167,7 @@ async function createInlineNotification(event: SocialEvent): Promise<void> {
           .from(dbSchema.boardClimbs)
           .leftJoin(dbSchema.users, eq(dbSchema.boardClimbs.userId, dbSchema.users.id))
           .leftJoin(dbSchema.userProfiles, eq(dbSchema.users.id, dbSchema.userProfiles.userId))
-          .leftJoin(
-            dbSchema.boardClimbStats,
-            and(
-              eq(dbSchema.boardClimbStats.boardType, dbSchema.boardClimbs.boardType),
-              eq(dbSchema.boardClimbStats.climbUuid, dbSchema.boardClimbs.uuid),
-              eq(dbSchema.boardClimbStats.angle, dbSchema.boardClimbs.angle),
-            ),
-          )
+          .leftJoin(dbSchema.boardClimbStats, and(...climbStatsJoinConditions()))
           .leftJoin(
             dbSchema.boardDifficultyGrades,
             and(

--- a/packages/backend/src/events/notification-worker.ts
+++ b/packages/backend/src/events/notification-worker.ts
@@ -18,6 +18,7 @@ import {
   resolveClimbCreatedSubscriptionRecipients,
 } from './recipient-resolution';
 import { logger } from '../utils/logger';
+import { climbStatsJoinConditions, resolvedClimbAngleSql } from '../db/queries/util/climb-stats-join';
 import {
   fanoutCommentFeedItems,
   fanoutFeedItems,
@@ -263,7 +264,7 @@ export class NotificationWorker {
         name: dbSchema.boardClimbs.name,
         description: dbSchema.boardClimbs.description,
         layoutId: dbSchema.boardClimbs.layoutId,
-        angle: dbSchema.boardClimbs.angle,
+        angle: resolvedClimbAngleSql,
         frames: dbSchema.boardClimbs.frames,
         createdAt: dbSchema.boardClimbs.createdAt,
         isDraft: dbSchema.boardClimbs.isDraft,
@@ -275,14 +276,7 @@ export class NotificationWorker {
       .from(dbSchema.boardClimbs)
       .leftJoin(dbSchema.users, eq(dbSchema.boardClimbs.userId, dbSchema.users.id))
       .leftJoin(dbSchema.userProfiles, eq(dbSchema.users.id, dbSchema.userProfiles.userId))
-      .leftJoin(
-        dbSchema.boardClimbStats,
-        and(
-          eq(dbSchema.boardClimbStats.boardType, dbSchema.boardClimbs.boardType),
-          eq(dbSchema.boardClimbStats.climbUuid, dbSchema.boardClimbs.uuid),
-          eq(dbSchema.boardClimbStats.angle, dbSchema.boardClimbs.angle),
-        ),
-      )
+      .leftJoin(dbSchema.boardClimbStats, and(...climbStatsJoinConditions()))
       .leftJoin(
         dbSchema.boardDifficultyGrades,
         and(

--- a/packages/backend/src/graphql/resolvers/climbs/climb-similarity.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/climb-similarity.ts
@@ -9,6 +9,7 @@ import {
 import type { BoardName } from '@boardsesh/board-constants';
 import { executeRows } from '@boardsesh/db/client';
 import { db } from '../../../db/client';
+import { climbStatsEffectiveAngleSql } from '../../../db/queries/util/climb-stats-join';
 
 /**
  * Anything that can run a SQL query — the connection-pool `db` or a
@@ -181,7 +182,7 @@ export async function findExactDuplicateMatch({
       LEFT JOIN ${dbSchema.boardClimbStats}
         ON ${dbSchema.boardClimbStats.boardType} = ${dbSchema.boardClimbs.boardType}
        AND ${dbSchema.boardClimbStats.climbUuid} = ${dbSchema.boardClimbs.uuid}
-       AND ${dbSchema.boardClimbStats.angle} = ${dbSchema.boardClimbs.angle}
+       AND ${dbSchema.boardClimbStats.angle} = ${climbStatsEffectiveAngleSql}
       WHERE ${dbSchema.boardClimbs.boardType} = ${boardType}
         AND ${dbSchema.boardClimbs.layoutId} = ${layoutId}
         -- Angle is deliberately NOT a predicate. A climb is the same physical

--- a/packages/backend/src/graphql/resolvers/climbs/moonboard-duplicates.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/moonboard-duplicates.ts
@@ -8,6 +8,7 @@ import * as dbSchema from '@boardsesh/db/schema';
 import { executeRows } from '@boardsesh/db/client';
 import { db } from '../../../db/client';
 import { convertLitUpHoldsStringToMap } from '../../../db/queries/util/hold-state';
+import { climbStatsEffectiveAngleSql } from '../../../db/queries/util/climb-stats-join';
 
 type MoonBoardHoldState = 'STARTING' | 'HAND' | 'FINISH';
 
@@ -171,7 +172,7 @@ export async function findMoonBoardDuplicateMatches(
       LEFT JOIN ${dbSchema.boardClimbStats}
         ON ${dbSchema.boardClimbStats.boardType} = ${dbSchema.boardClimbs.boardType}
        AND ${dbSchema.boardClimbStats.climbUuid} = ${dbSchema.boardClimbs.uuid}
-       AND ${dbSchema.boardClimbStats.angle} = ${dbSchema.boardClimbs.angle}
+       AND ${dbSchema.boardClimbStats.angle} = ${climbStatsEffectiveAngleSql}
       WHERE ${dbSchema.boardClimbs.boardType} = 'moonboard'
         AND ${dbSchema.boardClimbs.layoutId} = ${layoutId}
         AND ${dbSchema.boardClimbs.angle} = ${angle}
@@ -213,7 +214,7 @@ export async function findMoonBoardDuplicateMatches(
       LEFT JOIN ${dbSchema.boardClimbStats}
         ON ${dbSchema.boardClimbStats.boardType} = ${dbSchema.boardClimbs.boardType}
        AND ${dbSchema.boardClimbStats.climbUuid} = ${dbSchema.boardClimbs.uuid}
-       AND ${dbSchema.boardClimbStats.angle} = ${dbSchema.boardClimbs.angle}
+       AND ${dbSchema.boardClimbStats.angle} = ${climbStatsEffectiveAngleSql}
       WHERE ${dbSchema.boardClimbs.boardType} = 'moonboard'
         AND ${dbSchema.boardClimbs.layoutId} = ${layoutId}
         AND ${dbSchema.boardClimbs.angle} = ${angle}

--- a/packages/backend/src/graphql/resolvers/social/new-climb-subscriptions.ts
+++ b/packages/backend/src/graphql/resolvers/social/new-climb-subscriptions.ts
@@ -10,6 +10,7 @@ import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, applyRateLimit, validateInput, isNoMatchClimb } from '../shared/helpers';
 import { NewClimbFeedInputSchema, NewClimbSubscriptionInputSchema } from '../../../validation/schemas';
+import { climbStatsJoinConditions, resolvedClimbAngleSql } from '../../../db/queries/util/climb-stats-join';
 
 export const newClimbSubscriptionResolvers = {
   Query: {
@@ -29,7 +30,7 @@ export const newClimbSubscriptionResolvers = {
           description: dbSchema.boardClimbs.description,
           boardType: dbSchema.boardClimbs.boardType,
           layoutId: dbSchema.boardClimbs.layoutId,
-          angle: dbSchema.boardClimbs.angle,
+          angle: resolvedClimbAngleSql,
           frames: dbSchema.boardClimbs.frames,
           createdAt: dbSchema.boardClimbs.createdAt,
           setterDisplayName: sql<
@@ -41,14 +42,7 @@ export const newClimbSubscriptionResolvers = {
         .from(dbSchema.boardClimbs)
         .leftJoin(dbSchema.users, eq(dbSchema.boardClimbs.userId, dbSchema.users.id))
         .leftJoin(dbSchema.userProfiles, eq(dbSchema.users.id, dbSchema.userProfiles.userId))
-        .leftJoin(
-          dbSchema.boardClimbStats,
-          and(
-            eq(dbSchema.boardClimbStats.boardType, dbSchema.boardClimbs.boardType),
-            eq(dbSchema.boardClimbStats.climbUuid, dbSchema.boardClimbs.uuid),
-            eq(dbSchema.boardClimbStats.angle, dbSchema.boardClimbs.angle),
-          ),
-        )
+        .leftJoin(dbSchema.boardClimbStats, and(...climbStatsJoinConditions()))
         .leftJoin(
           dbSchema.boardDifficultyGrades,
           and(


### PR DESCRIPTION
## Summary

Closes #4220.

`board_climbs.angle` is nullable. `board_climb_stats.angle` is `NOT NULL` and part of the stats primary key. Five backend reads joined the two tables on `board_climb_stats.angle = board_climbs.angle`, so a climb saved without an angle matched no stats row at all and its grade silently came back `null` — in the new-climbs feed, in the fanned-out feed entry, in the `climb.created` notification, and in MoonBoard duplicate detection.

This adds one shared angle-resolution expression (`packages/backend/src/db/queries/util/climb-stats-join.ts`) and uses it at every one of those sites:

```
COALESCE(board_climbs.angle, (
  SELECT s.angle FROM board_climb_stats s
  WHERE s.board_type = board_climbs.board_type AND s.climb_uuid = board_climbs.uuid
  ORDER BY s.ascensionist_count DESC NULLS LAST, s.angle ASC
  LIMIT 1
))
```

`COALESCE` short-circuits, so every Kilter and Tension climb — all of which carry an angle — never evaluates the subquery and its query plan is unchanged. The `s.angle ASC` tie-break makes repeated reads agree when two angles have the same ascent count. The pattern is lifted from `playlists/helpers/hydrate-climbs.ts`, which already did this correctly.

The four feed/notification sites also now report `COALESCE(climbs.angle, stats.angle)` as the item's angle, so the angle shown beside a grade is the angle that grade was actually read at.

Sites changed:

- `graphql/resolvers/social/new-climb-subscriptions.ts` — `newClimbFeed`
- `events/feed-fanout.ts` — `buildNewClimbMetadata`
- `events/notification-worker.ts` — `climb.created`
- `events/index.ts` — inline `climb.created` handler
- `graphql/resolvers/climbs/moonboard-duplicates.ts` (both lookup queries)
- `graphql/resolvers/climbs/climb-similarity.ts`

No schema, migration, GraphQL, or i18n changes.

This is preventative: #3851 (`moonboard-importer-angle-agnostic`) is the branch that starts writing angle-less MoonBoard rows, and it hasn't merged, so nothing in production hits this path yet. Landing the read side first means that importer can run without every imported problem showing up ungraded.

Deliberately out of scope: `moonboard-duplicates.ts` also filters `WHERE board_climbs.angle = <angle>`, which will hide angle-less climbs from duplicate detection entirely once #3851 lands. That's a second bug and gets its own issue.

## Release Notes

- MoonBoard problems keep their grade in the new-climbs feed and in setter notifications, even when the problem isn't pinned to one wall angle.

## Test plan

- New: `packages/backend/src/__tests__/climb-stats-angle-fallback.test.ts` — integration against the backend test Postgres.
  - Angle-less climb with stats at 40° (12 ascents) and 25° (3 ascents) resolves the 40° grade and reports angle 40.
  - A climb with `angle = 25` keeps its own angle and grade even though 40° has more ascents — the fallback must not fire.
  - Equal ascent counts resolve to the lower angle, so repeated reads agree.
  - Angle-less climb with zero stats rows keeps a `null` grade (correct, not a regression).
  - `.toSQL()` shape assertions so a future refactor that drops the fallback fails loudly without a database.
- Reverted the helper to the old `eq(stats.angle, climbs.angle)` locally to confirm the new tests actually fail (3 of 6 failed), then restored it.
- `vp test run --project backend --reporter=agent climb-stats-angle-fallback moonboard-duplicates climb-similarity feed-fanout hydrate-climbs notifications` → 6 files, 66 tests passed.
- `vp run typecheck` → clean.
- `vp check` → no findings in any touched file (the repo-wide count is unchanged from `main`).
