### PR TITLE
fix(mobile): nest climb-type i18n keys under mobile.filter.climbType

### DIFF
--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -495,9 +495,9 @@ export function ClimbFilterSheet({
   );
   const climbTypeOptions = useMemo(
     () => [
-      { key: 'boulders', label: t('mobile.filter.boulders') },
-      { key: 'routes', label: t('mobile.filter.routes') },
-      { key: 'both', label: t('mobile.filter.both') },
+      { key: 'boulders', label: t('mobile.filter.climbType.boulders') },
+      { key: 'routes', label: t('mobile.filter.climbType.routes') },
+      { key: 'both', label: t('mobile.filter.climbType.all') },
     ],
     [t],
   );
@@ -942,7 +942,7 @@ export function ClimbFilterSheet({
               </Text>
               <View style={styles.pinnableLabelRow}>
                 <Text variant="footnote" style={styles.subsectionLabel}>
-                  {t('mobile.filter.climbType')}
+                  {t('mobile.filter.climbType.label')}
                 </Text>
                 <PinToggle kind="climbType" />
               </View>

--- a/packages/mobile/src/components/search/FilterChipRow.android.tsx
+++ b/packages/mobile/src/components/search/FilterChipRow.android.tsx
@@ -382,7 +382,7 @@ function FilterChipRowComponent({
               boulders-only, so the resting chip reads "Climb type". Opt-in. */}
           {pinnedChips.includes('climbType') ? (
             <MenuChip
-              label={climbType === 'boulders' ? t('mobile.filter.climbType') : climbTypeChipLabel(climbType, t)}
+              label={climbType === 'boulders' ? t('mobile.filter.climbType.label') : climbTypeChipLabel(climbType, t)}
               selected={climbType !== 'boulders'}
               colors={chipColors}
               renderItems={(close) => (

--- a/packages/mobile/src/components/search/FilterChipRow.ios.tsx
+++ b/packages/mobile/src/components/search/FilterChipRow.ios.tsx
@@ -254,7 +254,7 @@ function FilterChipRowComponent({
               boulders-only, so the resting chip reads "Climb type" and is inactive. */}
           {pinnedChips.includes('climbType') ? (
             <Menu
-              label={climbType === 'boulders' ? t('mobile.filter.climbType') : climbTypeChipLabel(climbType, t)}
+              label={climbType === 'boulders' ? t('mobile.filter.climbType.label') : climbTypeChipLabel(climbType, t)}
               modifiers={chipModifiers(climbType !== 'boulders')}
             >
               <Picker

--- a/packages/mobile/src/components/search/FilterChipRow.logic.ts
+++ b/packages/mobile/src/components/search/FilterChipRow.logic.ts
@@ -69,11 +69,11 @@ export function isAccuracyTag(value: string): value is GradeAccuracyValue | 'off
 export function climbTypeChipLabel(value: ClimbTypeFilter, t: TFunction<'climbs'>): string {
   switch (value) {
     case 'boulders':
-      return t('mobile.filter.boulders');
+      return t('mobile.filter.climbType.boulders');
     case 'routes':
-      return t('mobile.filter.routes');
+      return t('mobile.filter.climbType.routes');
     case 'both':
-      return t('mobile.filter.both');
+      return t('mobile.filter.climbType.all');
   }
 }
 

--- a/packages/mobile/src/components/search/FilterChipRow.web.tsx
+++ b/packages/mobile/src/components/search/FilterChipRow.web.tsx
@@ -260,7 +260,7 @@ function FilterChipRowComponent({
             boulders-only, so the resting chip reads "Climb type". Opt-in. */}
         {pinnedChips.includes('climbType') ? (
           <MenuChip
-            label={climbType === 'boulders' ? t('mobile.filter.climbType') : climbTypeChipLabel(climbType, t)}
+            label={climbType === 'boulders' ? t('mobile.filter.climbType.label') : climbTypeChipLabel(climbType, t)}
             selected={climbType !== 'boulders'}
           >
             {(close) =>

--- a/packages/mobile/src/components/search/__tests__/FilterChipRow.logic.test.ts
+++ b/packages/mobile/src/components/search/__tests__/FilterChipRow.logic.test.ts
@@ -156,9 +156,9 @@ describe('collectionChipLabel', () => {
 
 describe('climbTypeChipLabel / isClimbType', () => {
   it('labels each climb-type value', () => {
-    expect(climbTypeChipLabel('boulders', mockT)).toBe('mobile.filter.boulders');
-    expect(climbTypeChipLabel('routes', mockT)).toBe('mobile.filter.routes');
-    expect(climbTypeChipLabel('both', mockT)).toBe('mobile.filter.both');
+    expect(climbTypeChipLabel('boulders', mockT)).toBe('mobile.filter.climbType.boulders');
+    expect(climbTypeChipLabel('routes', mockT)).toBe('mobile.filter.climbType.routes');
+    expect(climbTypeChipLabel('both', mockT)).toBe('mobile.filter.climbType.all');
   });
 
   it('accepts the three values and rejects others', () => {

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -672,10 +672,12 @@
       "moreTriesAria": "Ein Versuch mehr"
     },
     "filter": {
-      "climbType": "Typ",
-      "boulders": "Boulder",
-      "routes": "Routen",
-      "both": "Beide",
+      "climbType": {
+        "label": "Typ",
+        "all": "Beide",
+        "boulders": "Boulder",
+        "routes": "Routen"
+      },
       "title": "Filter",
       "sortBy": "Sortieren nach",
       "grade": "Grad",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -672,10 +672,12 @@
       "moreTriesAria": "One more try"
     },
     "filter": {
-      "climbType": "Climb Type",
-      "boulders": "Boulders",
-      "routes": "Routes",
-      "both": "Both",
+      "climbType": {
+        "label": "Climb Type",
+        "all": "Both",
+        "boulders": "Boulders",
+        "routes": "Routes"
+      },
       "title": "Filters",
       "sortBy": "Sort by",
       "grade": "Grade",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -672,10 +672,12 @@
       "moreTriesAria": "Un intento más"
     },
     "filter": {
-      "climbType": "Tipo",
-      "boulders": "Bloques",
-      "routes": "Rutas",
-      "both": "Ambos",
+      "climbType": {
+        "label": "Tipo",
+        "all": "Ambos",
+        "boulders": "Bloques",
+        "routes": "Rutas"
+      },
       "title": "Filtros",
       "sortBy": "Ordenar por",
       "grade": "Grado",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -672,10 +672,12 @@
       "moreTriesAria": "Un essai de plus"
     },
     "filter": {
-      "climbType": "Type",
-      "boulders": "Blocs",
-      "routes": "Voies",
-      "both": "Les deux",
+      "climbType": {
+        "label": "Type",
+        "all": "Les deux",
+        "boulders": "Blocs",
+        "routes": "Voies"
+      },
       "title": "Filtres",
       "sortBy": "Trier par",
       "grade": "Cotation",


### PR DESCRIPTION
## Summary

Renames the flat `mobile.filter.climbType` / `.boulders` / `.routes` / `.both`
i18n keys to a nested `mobile.filter.climbType.{label,boulders,routes,all}`
shape, across all four locale catalogs (`en-US`, `es`, `fr`, `de`) and every
usage site in `packages/mobile`. This is the only remaining scope from #2636
per the issue's 2026-07-30 comment — the 3-way climb-type control, live
result count, removable filter chips, and the `toClimbSearchInput`
both-selected fix all shipped separately (#3976, main's #2496).

No wording changes: translated text (e.g. en-US "Both") is unchanged, only
the key path moved.

Closes #2636

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check` — pass (no findings in touched files; unrelated pre-existing
  warnings in `packages/db` untouched by this PR)
- `vp run typecheck:mobile` — pass
- `vp run typecheck:shared` — pass
- `vp run test:mobile` (`vp test run --project mobile`) — 601 test files,
  5263 tests, all pass
- `vp test run catalog-completeness` — 90 tests pass (confirms key parity
  across all four locales)
- `vp run check:i18n` — pass (no hardcoded strings)
- `vp run check:i18n:orphans` — pass (every catalog key has a live reference,
  no orphaned flat keys left behind)
- `vp run check:mobile-bundle` — both iOS and Android bundles OK
