### PR TITLE
feat(mobile): open a discussion thread on public playlists

### DIFF
--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { View, StyleSheet, Alert, Pressable } from 'react-native';
 import { useLocalSearchParams, useNavigation } from 'expo-router';
+import type { BottomSheet } from '@expo/ui/community/bottom-sheet';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import {
@@ -32,10 +33,13 @@ import {
   PlaylistOwnerToolbar,
   PlaylistBackFab,
   PlaylistQueueReplaceSheet,
+  PlaylistDiscussionRow,
   type PlaylistFormValues,
 } from '../../../src/components/playlist';
+import { CommentSheet } from '../../../src/components/you/CommentSheet';
 import { GlassIconButton } from '../../../src/components/GlassIconButton';
 import { getHttpClient } from '../../../src/lib/graphql/client';
+import { useComments } from '../../../src/lib/graphql/hooks';
 import { useActiveBoard } from '../../../src/lib/graphql/use-active-board';
 import { usePlaylistActivation } from '../../../src/lib/playlists/use-playlist-activation';
 import { usePlaylistRenderBoard } from '../../../src/lib/playlists/use-playlist-render-board';
@@ -166,6 +170,25 @@ export default function PlaylistDetail() {
 
   const isOwner = playlist?.userRole === 'owner';
   const isFollowable = !!playlist?.isPublic && !isOwner;
+
+  // General playlist discussion — the same `<uuid>:_all` entity web's
+  // CommentSection uses, and only on public playlists (web gates the same way).
+  const discussionEntityId = playlist?.isPublic ? `${playlistUuid}:_all` : null;
+  const commentSheetRef = useRef<BottomSheet | null>(null);
+  const [discussionOpen, setDiscussionOpen] = useState(false);
+  // Shares its react-query key with the sheet's own useComments, so opening the
+  // sheet reads the cache instead of firing a second request.
+  const discussionQuery = useComments('playlist_climb', discussionEntityId ?? undefined, !!discussionEntityId);
+  const commentCount = discussionQuery.data?.totalCount ?? 0;
+
+  const openDiscussion = useCallback(() => {
+    setDiscussionOpen(true);
+    // Stacked native sheets must be presented imperatively; a `visible`-prop
+    // effect is a silent no-op here.
+    commentSheetRef.current?.snapToIndex(0);
+  }, []);
+
+  const closeDiscussion = useCallback(() => setDiscussionOpen(false), []);
 
   // Interactive state seeded from the loaded playlist, updated optimistically.
   const [isPinned, setIsPinned] = useState(false);
@@ -635,6 +658,11 @@ export default function PlaylistDetail() {
         onReorderClimb={handleReorderClimb}
         onRemoveClimb={handleRemoveClimb}
         onEditDetails={openEditDetails}
+        headerSlot={
+          discussionEntityId && !editMode ? (
+            <PlaylistDiscussionRow commentCount={commentCount} onPress={openDiscussion} />
+          ) : null
+        }
       />
 
       <PlaylistActionsMenu
@@ -660,6 +688,14 @@ export default function PlaylistDetail() {
       />
 
       <PlaylistQueueReplaceSheet {...playlistActivation.queueReplaceSheet} />
+
+      <CommentSheet
+        sheetRef={commentSheetRef}
+        entityType="playlist_climb"
+        entityId={discussionOpen ? discussionEntityId : null}
+        canComment={isAuthenticated}
+        onClose={closeDiscussion}
+      />
     </>
   );
 }

--- a/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
@@ -39,6 +39,40 @@ vi.mock('../../../../src/lib/graphql/client', () => ({
   getHttpClient: () => ({ request: requestMock }),
 }));
 
+// Discussion thread: capture the useComments args so the private-playlist case
+// can prove the query never runs.
+const commentsMock = vi.hoisted(() => ({
+  calls: [] as Array<{ entityType: string; entityId: string | undefined; enabled: boolean }>,
+  totalCount: 0,
+}));
+vi.mock('../../../../src/lib/graphql/hooks', () => ({
+  useComments: (entityType: string, entityId: string | undefined, enabled = true) => {
+    commentsMock.calls.push({ entityType, entityId, enabled });
+    return { data: enabled && entityId ? { comments: [], totalCount: commentsMock.totalCount } : undefined };
+  },
+}));
+
+const commentSheetProps = vi.hoisted(() => ({
+  current: null as { entityType?: string; entityId: string | null; canComment?: boolean } | null,
+}));
+const snapToIndex = vi.hoisted(() => vi.fn());
+vi.mock('../../../../src/components/you/CommentSheet', () => ({
+  CommentSheet: (props: {
+    sheetRef: { current: { snapToIndex: (index: number) => void } | null };
+    entityType?: string;
+    entityId: string | null;
+    canComment?: boolean;
+  }) => {
+    commentSheetProps.current = {
+      entityType: props.entityType,
+      entityId: props.entityId,
+      canComment: props.canComment,
+    };
+    props.sheetRef.current = { snapToIndex };
+    return createElement('div', { 'data-comment-sheet': 'true', 'data-entity-id': props.entityId ?? '' });
+  },
+}));
+
 // usePlaylistClimbs: the climbs infinite query. The detail screen only reads
 // query.refetch (for the retry) and allClimbs here.
 const climbsRefetch = vi.hoisted(() => vi.fn());
@@ -97,7 +131,8 @@ vi.mock('../../../../src/theme/ios-colors', () => ({
 vi.mock('../../../../src/providers/theme-provider', () => ({
   useTheme: () => ({ systemColors: { label: '#000', fill: '#eee' }, brandColors: { primary: '#6D28D9' } }),
 }));
-vi.mock('../../../../src/providers/auth-provider', () => ({ useAuth: () => ({ isAuthenticated: true }) }));
+const authMock = vi.hoisted(() => ({ isAuthenticated: true }));
+vi.mock('../../../../src/providers/auth-provider', () => ({ useAuth: () => authMock }));
 vi.mock('../../../../src/providers/toast-provider', () => ({ useToast: () => toast }));
 vi.mock('../../../../src/lib/playlists/use-playlist-activation', () => ({
   usePlaylistActivation: (options: CapturedActivationOptions) => {
@@ -136,8 +171,21 @@ vi.mock('../../../../src/components/GlassIconButton', () => ({
 // PlaylistDetailView surfaces the hero title so we can prove the error branch
 // renders *instead of* a fallback-titled hero.
 vi.mock('../../../../src/components/playlist', () => ({
-  PlaylistDetailView: ({ hero }: { hero: { name: string } }) =>
-    createElement('div', { 'data-detail-view': 'true', 'data-hero-name': hero.name }),
+  PlaylistDetailView: ({
+    hero,
+    headerSlot,
+    actions,
+  }: {
+    hero: { name: string };
+    headerSlot?: ReactNode;
+    actions?: (collapsed: boolean) => ReactNode;
+  }) => createElement('div', { 'data-detail-view': 'true', 'data-hero-name': hero.name }, actions?.(false), headerSlot),
+  PlaylistDiscussionRow: ({ commentCount, onPress }: { commentCount: number; onPress: () => void }) =>
+    createElement(
+      'button',
+      { 'data-discussion-row': 'true', 'data-comment-count': String(commentCount), onClick: onPress },
+      'discussion',
+    ),
   SKELETON_PLACEHOLDERS: ['a', 'b'],
   // Surface the edit submit so the cache-patch test can drive handleEditSubmit
   // without the real gorhom sheet.
@@ -165,7 +213,10 @@ vi.mock('../../../../src/components/playlist', () => ({
   PlaylistActionsMenu: () => null,
   PlaylistFollowButton: () => null,
   PlaylistEditDoneButton: () => null,
-  PlaylistOwnerToolbar: () => null,
+  // Surfaces onEdit so a test can enter the climbs edit mode without the real
+  // glass toolbar.
+  PlaylistOwnerToolbar: ({ onEdit }: { onEdit?: () => void }) =>
+    createElement('button', { 'data-owner-edit': 'true', onClick: onEdit }, 'edit-climbs'),
   PlaylistBackFab: () => createElement('div', { 'data-back-fab': 'true' }),
   PlaylistQueueReplaceSheet: () => null,
 }));
@@ -191,6 +242,11 @@ beforeEach(() => {
   playlistMocks.allClimbs = [];
   playlistMocks.activationOptions = null;
   playlistMocks.renderBoardResult = { renderBoard: null, banner: null };
+  commentsMock.calls = [];
+  commentsMock.totalCount = 0;
+  commentSheetProps.current = null;
+  snapToIndex.mockClear();
+  authMock.isAuthenticated = true;
 });
 
 function makePlaylist(overrides: Record<string, unknown> = {}) {
@@ -347,5 +403,58 @@ describe('PlaylistDetail edit cache propagation', () => {
     });
     // A root toast would render behind the native sheet and be invisible.
     expect(toast.showToast).not.toHaveBeenCalledWith('edit.messages.updateFailed', 'error');
+  });
+});
+
+describe('PlaylistDetail discussion thread', () => {
+  it('renders the discussion row and wires the sheet to the `<uuid>:_all` entity on a public playlist', async () => {
+    commentsMock.totalCount = 4;
+    requestMock.mockResolvedValue({ playlist: makePlaylist({ isPublic: true }) });
+
+    const { container } = renderDetail();
+
+    await waitFor(() => expect(container.querySelector('[data-discussion-row="true"]')).not.toBeNull());
+    expect(container.querySelector('[data-discussion-row="true"]')?.getAttribute('data-comment-count')).toBe('4');
+    expect(commentsMock.calls.some((call) => call.entityType === 'playlist_climb' && call.enabled)).toBe(true);
+    // Closed until tapped, but already pointed at the right entity type.
+    expect(commentSheetProps.current?.entityType).toBe('playlist_climb');
+    expect(commentSheetProps.current?.entityId).toBeNull();
+
+    fireEvent.click(container.querySelector('[data-discussion-row="true"]') as HTMLButtonElement);
+
+    // Stacked native sheets are opened imperatively, not via a `visible` prop.
+    await waitFor(() => expect(snapToIndex).toHaveBeenCalledWith(0));
+    await waitFor(() => expect(commentSheetProps.current?.entityId).toBe('p-1:_all'));
+  });
+
+  it('renders no discussion row and never enables the comments query on a private playlist', async () => {
+    requestMock.mockResolvedValue({ playlist: makePlaylist({ isPublic: false }) });
+
+    const { container } = renderDetail();
+
+    await waitFor(() => expect(container.querySelector('[data-detail-view="true"]')).not.toBeNull());
+    expect(container.querySelector('[data-discussion-row="true"]')).toBeNull();
+    expect(commentsMock.calls.every((call) => call.enabled === false)).toBe(true);
+    expect(commentSheetProps.current?.entityId).toBeNull();
+  });
+
+  it('passes canComment=false through when the viewer is logged out', async () => {
+    requestMock.mockResolvedValue({ playlist: makePlaylist({ isPublic: true }) });
+    authMock.isAuthenticated = false;
+
+    renderDetail();
+
+    await waitFor(() => expect(commentSheetProps.current?.canComment).toBe(false));
+  });
+
+  it('hides the discussion row while the climbs edit mode is open', async () => {
+    requestMock.mockResolvedValue({ playlist: makePlaylist({ isPublic: true, userRole: 'owner' }) });
+
+    const { container } = renderDetail();
+
+    await waitFor(() => expect(container.querySelector('[data-discussion-row="true"]')).not.toBeNull());
+    fireEvent.click(container.querySelector('[data-owner-edit="true"]') as HTMLButtonElement);
+
+    await waitFor(() => expect(container.querySelector('[data-discussion-row="true"]')).toBeNull());
   });
 });

--- a/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
@@ -135,6 +135,10 @@ export type PlaylistDetailViewProps = {
   onRemoveClimb?: (climbUuid: string) => void;
   /** In edit mode, a cog next to the playlist name opens the edit-details sheet. */
   onEditDetails?: () => void;
+  /** Extra content rendered inside `ListHeaderComponent`, below the hero and the
+   *  board-mismatch banner. Stays inside the existing FlashList header so no
+   *  second scroll container is introduced. */
+  headerSlot?: ReactNode;
 };
 
 const noopReorder = (_climbUuid: string, _newIndex: number) => {};
@@ -183,6 +187,7 @@ export function PlaylistDetailView({
   onReorderClimb,
   onRemoveClimb,
   onEditDetails,
+  headerSlot,
 }: PlaylistDetailViewProps) {
   const { t } = useTranslation('playlists');
   const { t: tCommon } = useTranslation('common');
@@ -466,6 +471,7 @@ export function PlaylistDetailView({
                 ) : null}
               </View>
               {bannerNode}
+              {headerSlot}
             </>
           }
           ListFooterComponent={listFooterComponent}
@@ -621,6 +627,7 @@ export function PlaylistDetailView({
           <>
             {header}
             {bannerNode}
+            {headerSlot}
           </>
         }
         ListFooterComponent={listFooterComponent}

--- a/packages/mobile/src/components/playlist/PlaylistDiscussionRow.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistDiscussionRow.tsx
@@ -1,0 +1,46 @@
+import { memo } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { ListRow } from '../ListRow';
+import { Icon } from '../Icon';
+import { spacing } from '../../theme/tokens';
+import { useTheme } from '../../providers/theme-provider';
+
+type PlaylistDiscussionRowProps = {
+  /** Comments on the playlist's general thread (`<uuid>:_all`). */
+  commentCount: number;
+  onPress: () => void;
+};
+
+/**
+ * Entry point to a public playlist's discussion thread, rendered in the detail
+ * list header. Web puts its `CommentSection` at the very bottom of the page; on
+ * mobile a footer under a paginating list is unreachable for a long playlist, so
+ * the thread lives behind a row just under the hero.
+ */
+export const PlaylistDiscussionRow = memo(function PlaylistDiscussionRow({
+  commentCount,
+  onPress,
+}: PlaylistDiscussionRowProps) {
+  const { t } = useTranslation('playlists');
+  const { t: tCommon } = useTranslation('common');
+  const { systemColors } = useTheme();
+
+  return (
+    <View style={styles.container}>
+      <ListRow
+        title={t('detail.discussion')}
+        subtitle={tCommon('comment.count', { count: commentCount })}
+        leading={<Icon name="comment" size={20} color={systemColors.secondaryLabel} />}
+        showChevron
+        showSeparator={false}
+        onPress={onPress}
+        accessibilityLabel={t('detail.discussion')}
+      />
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  container: { paddingHorizontal: spacing[2], paddingBottom: spacing[2] },
+});

--- a/packages/mobile/src/components/playlist/__tests__/playlist-discussion-row.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-discussion-row.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, absoluteFill: {}, hairlineWidth: 1 },
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { count?: number }) =>
+      options && typeof options.count === 'number' ? `${key}:${options.count}` : key,
+  }),
+}));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { label: '#000', secondaryLabel: '#666' } }),
+}));
+vi.mock('../../../theme/tokens', () => ({ spacing: { 1: 4, 2: 8, 3: 12 } }));
+vi.mock('../../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }) }));
+
+type ListRowProps = {
+  title: string;
+  subtitle?: string;
+  leading?: ReactNode;
+  onPress?: () => void;
+  accessibilityLabel?: string;
+};
+vi.mock('../../ListRow', () => ({
+  ListRow: ({ title, subtitle, leading, onPress, accessibilityLabel }: ListRowProps) =>
+    createElement(
+      'button',
+      { 'data-list-row': 'true', onClick: onPress, 'aria-label': accessibilityLabel },
+      leading,
+      createElement('span', { 'data-title': 'true' }, title),
+      createElement('span', { 'data-subtitle': 'true' }, subtitle),
+    ),
+}));
+
+import { PlaylistDiscussionRow } from '../PlaylistDiscussionRow';
+
+const subtitleOf = (root: HTMLElement) => root.querySelector('[data-subtitle]')?.textContent;
+
+describe('PlaylistDiscussionRow', () => {
+  it('renders the discussion title and a comment icon', () => {
+    const { container } = render(<PlaylistDiscussionRow commentCount={3} onPress={vi.fn()} />);
+    expect(container.querySelector('[data-title]')?.textContent).toBe('detail.discussion');
+    expect(container.querySelector('[data-icon="comment"]')).not.toBeNull();
+  });
+
+  it('passes the comment count through to the pluralised count key', () => {
+    expect(subtitleOf(render(<PlaylistDiscussionRow commentCount={0} onPress={vi.fn()} />).container)).toBe(
+      'comment.count:0',
+    );
+    expect(subtitleOf(render(<PlaylistDiscussionRow commentCount={1} onPress={vi.fn()} />).container)).toBe(
+      'comment.count:1',
+    );
+    expect(subtitleOf(render(<PlaylistDiscussionRow commentCount={12} onPress={vi.fn()} />).container)).toBe(
+      'comment.count:12',
+    );
+  });
+
+  it('fires onPress once when tapped', () => {
+    const onPress = vi.fn();
+    const { container } = render(<PlaylistDiscussionRow commentCount={2} onPress={onPress} />);
+    fireEvent.click(container.querySelector('[data-list-row]') as HTMLButtonElement);
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mobile/src/components/playlist/index.ts
+++ b/packages/mobile/src/components/playlist/index.ts
@@ -16,4 +16,5 @@ export { PlaylistEditDoneButton } from './PlaylistEditDoneButton';
 export { PlaylistOwnerToolbar } from './PlaylistOwnerToolbar';
 export { PlaylistActionsMenu } from './PlaylistActionsMenu';
 export { PlaylistQueueReplaceSheet } from './PlaylistQueueReplaceSheet';
+export { PlaylistDiscussionRow } from './PlaylistDiscussionRow';
 export { PLAYLIST_COLORS, isValidPlaylistColor, normalizePlaylistColor } from './playlist-colors';

--- a/packages/mobile/src/components/you/CommentSheet.tsx
+++ b/packages/mobile/src/components/you/CommentSheet.tsx
@@ -21,12 +21,23 @@ type CommentSheetProps = {
   entityId: string | null;
   /** Defaults to `'session'` so existing session call sites stay unchanged. */
   entityType?: SocialEntityType;
+  /** When false the composer is swapped for a sign-in prompt. Defaults to true
+   *  so the session/tick call sites keep their composer untouched. Playlist
+   *  threads are readable while logged out, hence the read-only state. */
+  canComment?: boolean;
   onClose: () => void;
 };
 
-/** Comment thread for a social entity (session or tick), with an inline composer. */
-export function CommentSheet({ sheetRef, entityId, entityType = 'session', onClose }: CommentSheetProps) {
+/** Comment thread for a social entity (session, tick or playlist), with an inline composer. */
+export function CommentSheet({
+  sheetRef,
+  entityId,
+  entityType = 'session',
+  canComment = true,
+  onClose,
+}: CommentSheetProps) {
   const { t } = useTranslation('you');
+  const { t: tCommon } = useTranslation('common');
   const { systemColors, brandColors } = useTheme();
   const { showToast } = useToast();
   const [draft, setDraft] = useState('');
@@ -58,28 +69,34 @@ export function CommentSheet({ sheetRef, entityId, entityType = 'session', onClo
       scrollable
       onClose={onClose}
       footer={
-        <View style={styles.composer}>
-          <BottomSheetTextInput
-            style={[styles.input, { backgroundColor: systemColors.fill, color: systemColors.label }]}
-            placeholder={t('mobile.comments.placeholder')}
-            placeholderTextColor={systemColors.tertiaryLabel}
-            value={draft}
-            onChangeText={setDraft}
-            multiline
-          />
-          <Pressable
-            onPress={submit}
-            disabled={draft.trim().length === 0 || addComment.isPending}
-            style={styles.send}
-            accessibilityRole="button"
-          >
-            <Icon
-              name="send"
-              size={22}
-              color={draft.trim().length > 0 ? brandColors.primary : systemColors.tertiaryLabel}
+        canComment ? (
+          <View style={styles.composer}>
+            <BottomSheetTextInput
+              style={[styles.input, { backgroundColor: systemColors.fill, color: systemColors.label }]}
+              placeholder={t('mobile.comments.placeholder')}
+              placeholderTextColor={systemColors.tertiaryLabel}
+              value={draft}
+              onChangeText={setDraft}
+              multiline
             />
-          </Pressable>
-        </View>
+            <Pressable
+              onPress={submit}
+              disabled={draft.trim().length === 0 || addComment.isPending}
+              style={styles.send}
+              accessibilityRole="button"
+            >
+              <Icon
+                name="send"
+                size={22}
+                color={draft.trim().length > 0 ? brandColors.primary : systemColors.tertiaryLabel}
+              />
+            </Pressable>
+          </View>
+        ) : (
+          <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.signInPrompt}>
+            {tCommon('comment.signInPrompt')}
+          </Text>
+        )
       }
     >
       <Text variant="title3" style={styles.title}>
@@ -144,4 +161,5 @@ const styles = StyleSheet.create({
     fontSize: 15,
   },
   send: { paddingBottom: spacing[2] },
+  signInPrompt: { paddingVertical: spacing[2], textAlign: 'center' },
 });

--- a/packages/mobile/src/components/you/__tests__/comment-sheet-read-only.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/comment-sheet-read-only.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+const addComment = vi.hoisted(() => ({ mutate: vi.fn(), isPending: false }));
+const toast = vi.hoisted(() => ({ showToast: vi.fn() }));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useComments: () => ({ data: { comments: [], totalCount: 0 }, isPending: false }),
+  useAddComment: () => addComment,
+}));
+vi.mock('../../../providers/toast-provider', () => ({ useToast: () => toast }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { fill: '#eee', label: '#000', tertiaryLabel: '#999', secondaryLabel: '#666' },
+    brandColors: { primary: '#6D28D9' },
+  }),
+}));
+vi.mock('../../../lib/haptics', () => ({ hapticLight: vi.fn() }));
+vi.mock('@boardsesh/profile-stats', () => ({ formatTickRelativeTime: () => 'now' }));
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({ children, onPress, disabled }: { children?: ReactNode; onPress?: () => void; disabled?: boolean }) =>
+    createElement('button', { onClick: onPress, disabled, 'data-testid': 'send' }, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+}));
+vi.mock('../../Sheet', () => ({
+  Sheet: ({ children, footer }: { children?: ReactNode; footer?: ReactNode }) =>
+    createElement('div', null, children, footer),
+}));
+vi.mock('@expo/ui/community/bottom-sheet', () => ({
+  BottomSheetTextInput: () => createElement('input', { 'data-testid': 'comment-input' }),
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../PressableAvatar', () => ({ PressableAvatar: () => createElement('div', null) }));
+vi.mock('../../Icon', () => ({ Icon: () => createElement('i', null) }));
+vi.mock('../../ActivityIndicator', () => ({ ActivityIndicator: () => createElement('div', null) }));
+
+const { CommentSheet } = await import('../CommentSheet');
+
+const sheetRef = { current: null };
+
+describe('CommentSheet read-only mode', () => {
+  it('swaps the composer for a sign-in prompt when canComment is false', () => {
+    const { queryByTestId, container } = render(
+      <CommentSheet
+        sheetRef={sheetRef}
+        entityId="playlist-1:_all"
+        entityType="playlist_climb"
+        canComment={false}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(container.textContent).toContain('comment.signInPrompt');
+    expect(queryByTestId('comment-input')).toBeNull();
+    expect(queryByTestId('send')).toBeNull();
+  });
+
+  it('keeps the composer by default so the session/tick call sites are unchanged', () => {
+    const { queryByTestId, container } = render(
+      <CommentSheet sheetRef={sheetRef} entityId="session-1" onClose={() => {}} />,
+    );
+
+    expect(queryByTestId('comment-input')).not.toBeNull();
+    expect(queryByTestId('send')).not.toBeNull();
+    expect(container.textContent).not.toContain('comment.signInPrompt');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2473.

Six of the seven deferred follow-ups from #2473 already landed on `main` (playlist
create/edit/delete, pin/unpin, follow/unfollow, the board-background preview
render, the mobile recents store, and the web queue-bridge refactor onto the
shared `findNextQueueItemWithSuggestions`). The one still missing was **playlist
comments** — web renders a `CommentSection` at the bottom of
`/playlists/[uuid]`, mobile had no discussion surface at all.

This wires the mobile playlist detail screen up to the same thread:

- **`PlaylistDiscussionRow`** — a memoized `ListRow` ("Discussion · N comments")
  rendered in the detail list header, just under the hero and the board-mismatch
  banner. Web puts its section at the very bottom of the page; on mobile a footer
  under a paginating `FlashList` is unreachable for a long playlist, so the entry
  point moved to the header. Swapping to a footer later is a one-line change to
  the same prop shape.
- **`PlaylistDetailView` gains an optional `headerSlot`**, rendered inside the
  existing `ListHeaderComponent` in **both** the Material 3 and Liquid Glass
  branches. No new list, no extra scroll container, no change to `renderItem` or
  `keyExtractor` deps.
- **`CommentSheet` gains `canComment`** (defaults to `true`). When false the
  composer is swapped for "Sign in to leave a comment." — public playlist threads
  are readable while logged out. The home-feed, Sessions-tab and session-detail
  call sites are untouched by the default.
- The screen targets the `playlist_climb` entity `<playlistUuid>:_all` — the exact
  entity web posts to, so comments are shared across platforms. It's already
  handled by `entity-validation.ts` on the backend, so there's **no schema
  change, no migration, no codegen**. Every string reuses an existing key, so
  **no i18n catalog edits** either.

Gated to public playlists (web gates the same way), hidden in the owner's climbs
edit mode. The row's count query shares its react-query key
(`['comments','playlist_climb', id]`) with the sheet's own, so opening the sheet
reads the cache instead of firing a second request.

### Known parity gaps (deliberately out of scope)

- No live subscription on mobile — web's `CommentSection` subscribes to
  `COMMENT_UPDATES_SUBSCRIPTION`; a second commenter's message lands on refetch here.
- No replies, votes, edit or delete in the mobile sheet — it stays a flat thread
  plus composer.
- Only the general `:_all` thread; no per-climb threads (same as web).
- No pagination past the backend's default 20 comments.
- Pre-existing and unchanged: `entity-validation.ts` only checks that the playlist
  row exists for the `_all` form, it does not require `isPublic`. Both platforms
  gate in the UI. Tightening that is a backend authorization change that deserves
  its own PR.

## Release Notes

- Talk beta on public playlists — every playlist now has a discussion thread, shared with the web app.
- Signed out? You can still read the thread; sign in to join it.

## Test plan

- `vp run test:mobile` — 603 files, 5272 tests, all passing (full mobile suite).
- `vp run typecheck:mobile` — clean.
- `vp check` — no findings in any file this PR touches.
- `vp run check:mobile-bundle` — android bundle OK.
- New tests:
  - `playlist-discussion-row.test.tsx` — title, comment icon, pluralised count
    for 0/1/N, one `onPress` per tap.
  - `comment-sheet-read-only.test.tsx` — `canComment={false}` renders the
    sign-in prompt with no input and no send button; the default still renders
    the composer.
  - `playlist-uuid.test.tsx` (extended) — public playlist renders the row and
    hands the sheet `playlist_climb` + `p-1:_all`; tapping calls `snapToIndex(0)`
    on the ref rather than toggling a `visible` prop; private playlist renders
    nothing and never enables the comments query; logged-out viewers get
    `canComment={false}`; edit mode hides the row.
- Manual QA plan (not yet run — no simulator in this environment):
  `.boardsesh/qa-notes.md`. The important one is **checking both theme variants**,
  since `PlaylistDetailView` has two full render branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Msvwztpyh4KYh7iDkHWaxQ
