### PR TITLE
fix(mobile): distinguish Record live-session badge from board-connected

### DIFF
--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -226,12 +226,14 @@ vi.mock('expo-router/unstable-native-tabs', () => {
       iconColor,
       labelStyle,
       tintColor,
+      badgeBackgroundColor,
     }: {
       children?: ReactNode;
       minimizeBehavior?: string;
       iconColor?: unknown;
       labelStyle?: unknown;
       tintColor?: unknown;
+      badgeBackgroundColor?: string;
     }) =>
       createElement(
         'nav',
@@ -241,6 +243,7 @@ vi.mock('expo-router/unstable-native-tabs', () => {
           'data-icon-color': JSON.stringify(iconColor),
           'data-label-style': JSON.stringify(labelStyle),
           'data-tint-color': typeof tintColor === 'string' ? tintColor : '',
+          'data-badge-background-color': badgeBackgroundColor ?? '',
         },
         children,
       ),
@@ -792,5 +795,27 @@ describe('TabLayout', () => {
 
     expect(badge).not.toBeNull();
     expect(badge?.getAttribute('data-selected-background-color')).toBe('#FBBF24');
+  });
+
+  // `NativeTabs.Trigger.Badge`'s `selectedBackgroundColor` only reaches
+  // options.selectedBadgeBackgroundColor, which expo-router applies solely to the
+  // ['selected','focused'] item states — so it's a no-op for the badge tint while
+  // Record is NOT the focused tab (the exact moment a live-session badge needs to
+  // be visible from another tab). The normal-state tint must ride the
+  // navigator-level `badgeBackgroundColor` prop instead.
+  it('sets the navigator-level badgeBackgroundColor to the live color so the unfocused badge tint is correct', () => {
+    cfg.sessionId = 'session-1';
+    const { container } = render(<TabLayout />);
+    const tabs = container.querySelector('[data-tabs="true"]');
+
+    expect(tabs?.getAttribute('data-badge-background-color')).toBe('#FBBF24');
+  });
+
+  it('sets the navigator-level badgeBackgroundColor to the standard (success) color when only Bluetooth is connected', () => {
+    cfg.bluetoothConnected = true;
+    const { container } = render(<TabLayout />);
+    const tabs = container.querySelector('[data-tabs="true"]');
+
+    expect(tabs?.getAttribute('data-badge-background-color')).toBe('#047857');
   });
 });

--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -258,6 +258,7 @@ vi.mock('expo-router/unstable-native-tabs', () => {
 });
 
 import TabLayout, { unstable_settings } from '../_layout';
+import { TAB_BADGE_CONNECTED, TAB_BADGE_LIVE } from '../../../src/components/navigation/tab-badge';
 
 describe('TabLayout', () => {
   beforeEach(() => {
@@ -697,25 +698,30 @@ describe('TabLayout', () => {
     expect(cfg.materialScreens.find((screen) => screen.name === 'record')?.options).toMatchObject({ lazy: false });
   });
 
-  it('sets the JS-Tabs Record badge to the "live" sentinel when a session is active', () => {
+  // The JS-Tabs badge value is a state marker MaterialTabBar branches its dot
+  // color on — assert the shared constants (tab-badge) so producer and consumer
+  // can't drift apart, and pin the wire values so a rename stays deliberate.
+  it('sets the JS-Tabs Record badge to the live marker when a session is active', () => {
     cfg.variant = 'material';
     cfg.sessionId = 'session-1';
 
     render(<TabLayout />);
 
+    expect(TAB_BADGE_LIVE).toBe('live');
     expect(cfg.materialScreens.find((screen) => screen.name === 'record')?.options).toMatchObject({
-      tabBarBadge: 'live',
+      tabBarBadge: TAB_BADGE_LIVE,
     });
   });
 
-  it('sets the JS-Tabs Record badge to "connected" when only Bluetooth is connected', () => {
+  it('sets the JS-Tabs Record badge to the connected marker when only Bluetooth is connected', () => {
     cfg.variant = 'material';
     cfg.bluetoothConnected = true;
 
     render(<TabLayout />);
 
+    expect(TAB_BADGE_CONNECTED).toBe('connected');
     expect(cfg.materialScreens.find((screen) => screen.name === 'record')?.options).toMatchObject({
-      tabBarBadge: 'connected',
+      tabBarBadge: TAB_BADGE_CONNECTED,
     });
   });
 
@@ -817,5 +823,20 @@ describe('TabLayout', () => {
     const tabs = container.querySelector('[data-tabs="true"]');
 
     expect(tabs?.getAttribute('data-badge-background-color')).toBe('#047857');
+  });
+
+  // `badgeBackgroundColor` above is a navigator-wide DEFAULT: it tints every
+  // trigger's badge. That's only correct while Record owns the sole badge, so lock
+  // the invariant here — a second badged trigger would silently inherit Record's
+  // session color, and this failing test is the signal to move the color onto
+  // per-trigger styling instead.
+  it('keeps Record as the only badged trigger (the navigator badge color is a shared default)', () => {
+    cfg.bluetoothConnected = true;
+    cfg.sessionId = 'session-1';
+    const { container } = render(<TabLayout />);
+    const badges = container.querySelectorAll('[data-badge="true"]');
+
+    expect(badges).toHaveLength(1);
+    expect(badges[0].closest('[data-trigger]')?.getAttribute('data-trigger')).toBe('record');
   });
 });

--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -125,10 +125,6 @@ vi.mock('../../../src/components/queue-control/QueueBottomAccessory', () => ({
   QueueBottomAccessory: () => createElement('div', { 'data-accessory': 'true' }),
 }));
 
-vi.mock('../../../src/theme/colors', () => ({
-  brandColors: { success: '#047857' },
-}));
-
 vi.mock('../../../src/providers/theme-provider', () => ({
   useTheme: () => ({
     variant: cfg.variant,
@@ -138,6 +134,10 @@ vi.mock('../../../src/providers/theme-provider', () => ({
       separator: 'rgba(60,55,75,0.18)',
     },
     m3: { outlineVariant: '#49454F' },
+    // Record badge color: green for board-connected-only, amber 'live' for a
+    // live session — read from the theme now (not a static import) so it
+    // resolves per scheme.
+    brandColors: { success: '#047857', live: '#FBBF24' },
   }),
 }));
 
@@ -210,7 +210,12 @@ vi.mock('expo-router/unstable-native-tabs', () => {
     {
       Icon: () => createElement('span', { 'data-icon': 'true' }),
       Label: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
-      Badge: ({ children }: { children?: ReactNode }) => createElement('span', { 'data-badge': 'true' }, children),
+      Badge: ({ children, selectedBackgroundColor }: { children?: ReactNode; selectedBackgroundColor?: string }) =>
+        createElement(
+          'span',
+          { 'data-badge': 'true', 'data-selected-background-color': selectedBackgroundColor ?? '' },
+          children,
+        ),
     },
   );
 
@@ -689,6 +694,28 @@ describe('TabLayout', () => {
     expect(cfg.materialScreens.find((screen) => screen.name === 'record')?.options).toMatchObject({ lazy: false });
   });
 
+  it('sets the JS-Tabs Record badge to the "live" sentinel when a session is active', () => {
+    cfg.variant = 'material';
+    cfg.sessionId = 'session-1';
+
+    render(<TabLayout />);
+
+    expect(cfg.materialScreens.find((screen) => screen.name === 'record')?.options).toMatchObject({
+      tabBarBadge: 'live',
+    });
+  });
+
+  it('sets the JS-Tabs Record badge to "connected" when only Bluetooth is connected', () => {
+    cfg.variant = 'material';
+    cfg.bluetoothConnected = true;
+
+    render(<TabLayout />);
+
+    expect(cfg.materialScreens.find((screen) => screen.name === 'record')?.options).toMatchObject({
+      tabBarBadge: 'connected',
+    });
+  });
+
   // #3153: Android/iPad keep blurred tabs' native trees resident (detach off) so a
   // switch is a re-attach, not a Fabric rebuild; iOS < 26 iPhones stay on default
   // detach where freezeOnBlur actually takes effect.
@@ -736,19 +763,34 @@ describe('TabLayout', () => {
     expect(container.querySelector('[data-tabs-material="true"]')).toBeNull();
   });
 
-  it('renders the Record badge when a session is active', () => {
+  it('renders the Record badge when a session is active, in the live color', () => {
     cfg.sessionId = 'session-1';
     const { container } = render(<TabLayout />);
     const recordTrigger = container.querySelector('[data-trigger="record"]') as HTMLElement;
+    const badge = recordTrigger.querySelector('[data-badge="true"]');
 
-    expect(recordTrigger.querySelector('[data-badge="true"]')).not.toBeNull();
+    expect(badge).not.toBeNull();
+    expect(badge?.getAttribute('data-selected-background-color')).toBe('#FBBF24');
   });
 
-  it('renders the Record badge when Bluetooth is connected', () => {
+  it('renders the Record badge when Bluetooth is connected, in the standard (success) color', () => {
     cfg.bluetoothConnected = true;
     const { container } = render(<TabLayout />);
     const recordTrigger = container.querySelector('[data-trigger="record"]') as HTMLElement;
+    const badge = recordTrigger.querySelector('[data-badge="true"]');
 
-    expect(recordTrigger.querySelector('[data-badge="true"]')).not.toBeNull();
+    expect(badge).not.toBeNull();
+    expect(badge?.getAttribute('data-selected-background-color')).toBe('#047857');
+  });
+
+  it('shows the live badge color when both Bluetooth is connected and a session is active — live takes priority', () => {
+    cfg.bluetoothConnected = true;
+    cfg.sessionId = 'session-1';
+    const { container } = render(<TabLayout />);
+    const recordTrigger = container.querySelector('[data-trigger="record"]') as HTMLElement;
+    const badge = recordTrigger.querySelector('[data-badge="true"]');
+
+    expect(badge).not.toBeNull();
+    expect(badge?.getAttribute('data-selected-background-color')).toBe('#FBBF24');
   });
 });

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -321,6 +321,17 @@ export default function TabLayout() {
       iconColor={{ default: systemColors.secondaryLabel, selected: systemColors.label }}
       labelStyle={{ default: { color: systemColors.secondaryLabel }, selected: { color: systemColors.label } }}
       tintColor={systemColors.label}
+      // `NativeTabs.Trigger.Badge`'s `selectedBackgroundColor` only reaches
+      // `options.selectedBadgeBackgroundColor`, which react-navigation-native-tabs
+      // applies solely to the ['selected','focused'] item states
+      // (appearance.ios.js `appendSelectedStyleToAppearance`). The Record badge is
+      // most useful precisely when Record ISN'T focused (a session is live while
+      // the user browses another tab), so the normal-state tint must come from the
+      // navigator-level `badgeBackgroundColor` prop, which seeds
+      // `options.badgeBackgroundColor` — applied to normal/focused/selected alike
+      // (appearance.ios.js `createStandardAppearanceFromOptions`). Safe as a
+      // navigator-wide default: Record is the only trigger that renders a badge.
+      badgeBackgroundColor={hasLiveSession ? brandColors.live : brandColors.success}
     >
       {onAccessorySurface && nativeAccessoryActive && hasCurrentClimb ? (
         <NativeTabs.BottomAccessory key="queue-bottom-accessory">

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -11,7 +11,6 @@ import { QueueBottomAccessory } from '../../src/components/queue-control/QueueBo
 import { MaterialTabBar } from '../../src/components/navigation/MaterialTabBar';
 import { useTheme } from '../../src/providers/theme-provider';
 import { selectByVariant } from '../../src/theme/variants/select-by-variant';
-import { brandColors } from '../../src/theme/colors';
 import { useNativeAccessoryActive, useNativeTabBar } from '../../src/hooks/use-bottom-accessory';
 import { useOnAccessorySurface } from '../../src/hooks/use-on-accessory-surface';
 import { useDeviceLayout } from '../../src/hooks/use-device-layout';
@@ -70,7 +69,7 @@ export default function TabLayout() {
   const { t } = useTranslation('common');
   const { t: tPlaylists } = useTranslation('playlists');
   const { t: tSession } = useTranslation('session');
-  const { systemColors, variant, m3 } = useTheme();
+  const { systemColors, variant, m3, brandColors } = useTheme();
   const nativeTabBar = useNativeTabBar();
   // Shell column separators: an M3 faint divider (outlineVariant) on Material, the
   // system hairline on Liquid Glass — so the panes read as M3 depth on Android.
@@ -104,7 +103,8 @@ export default function TabLayout() {
   // native tab-bar height; see `isAccessorySurfaceRoute`. Bottom-chrome arbitration
   // mirrors this surface, so the real mount matches the reserved metrics.
   const onAccessorySurface = useOnAccessorySurface();
-  const showRecordBadge = isBluetoothConnected || sessionId !== null;
+  const hasLiveSession = sessionId !== null;
+  const showRecordBadge = isBluetoothConnected || hasLiveSession;
   const eagerMountRecord = Platform.OS === 'android';
   // Keep blurred tabs' native (Fabric) trees resident on Android so a tab switch is a
   // re-attach, not a createNode/completeRoot rebuild (#3153). Android-only: on iOS < 26
@@ -201,7 +201,9 @@ export default function TabLayout() {
       options={{
         title: tSession('mobile.session.recordTab'),
         tabBarIcon: materialTabIcon('record-circle', 'record-circle-outline'),
-        tabBarBadge: showRecordBadge ? '' : undefined,
+        // Semantic marker string, not display text — MaterialTabBar's badge is a
+        // color dot with no text; it branches its dot color on this value.
+        tabBarBadge: showRecordBadge ? (hasLiveSession ? 'live' : 'connected') : undefined,
         // Android can stall the first lazy mount of this nested stack,
         // leaving the Record tab blank until another tab forces a remount.
         lazy: eagerMountRecord ? false : undefined,
@@ -340,7 +342,9 @@ export default function TabLayout() {
         <NativeTabs.Trigger.Icon sf="record.circle" md="radio_button_checked" />
         <NativeTabs.Trigger.Label>{tSession('mobile.session.recordTab')}</NativeTabs.Trigger.Label>
         {showRecordBadge ? (
-          <NativeTabs.Trigger.Badge selectedBackgroundColor={brandColors.success}> </NativeTabs.Trigger.Badge>
+          <NativeTabs.Trigger.Badge selectedBackgroundColor={hasLiveSession ? brandColors.live : brandColors.success}>
+            {' '}
+          </NativeTabs.Trigger.Badge>
         ) : null}
       </NativeTabs.Trigger>
 

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -9,6 +9,7 @@ import { useQueueSessionId } from '../../src/providers/queue-provider';
 import { useStickyAccessoryPresence } from '../../src/hooks/use-sticky-accessory-presence';
 import { QueueBottomAccessory } from '../../src/components/queue-control/QueueBottomAccessory';
 import { MaterialTabBar } from '../../src/components/navigation/MaterialTabBar';
+import { TAB_BADGE_CONNECTED, TAB_BADGE_LIVE } from '../../src/components/navigation/tab-badge';
 import { useTheme } from '../../src/providers/theme-provider';
 import { selectByVariant } from '../../src/theme/variants/select-by-variant';
 import { useNativeAccessoryActive, useNativeTabBar } from '../../src/hooks/use-bottom-accessory';
@@ -201,9 +202,10 @@ export default function TabLayout() {
       options={{
         title: tSession('mobile.session.recordTab'),
         tabBarIcon: materialTabIcon('record-circle', 'record-circle-outline'),
-        // Semantic marker string, not display text — MaterialTabBar's badge is a
-        // color dot with no text; it branches its dot color on this value.
-        tabBarBadge: showRecordBadge ? (hasLiveSession ? 'live' : 'connected') : undefined,
+        // State marker, not display text — MaterialTabBar's badge is a color dot
+        // with no text and branches its dot color on this value. Both ends of that
+        // contract go through src/components/navigation/tab-badge.
+        tabBarBadge: showRecordBadge ? (hasLiveSession ? TAB_BADGE_LIVE : TAB_BADGE_CONNECTED) : undefined,
         // Android can stall the first lazy mount of this nested stack,
         // leaving the Record tab blank until another tab forces a remount.
         lazy: eagerMountRecord ? false : undefined,
@@ -329,8 +331,14 @@ export default function TabLayout() {
       // the user browses another tab), so the normal-state tint must come from the
       // navigator-level `badgeBackgroundColor` prop, which seeds
       // `options.badgeBackgroundColor` — applied to normal/focused/selected alike
-      // (appearance.ios.js `createStandardAppearanceFromOptions`). Safe as a
-      // navigator-wide default: Record is the only trigger that renders a badge.
+      // (appearance.ios.js `createStandardAppearanceFromOptions`).
+      //
+      // CAUTION: this is a navigator-wide DEFAULT — it tints every
+      // `NativeTabs.Trigger.Badge` here, not just Record's. It's only correct
+      // because Record owns the sole badge (locked by the "keeps Record as the
+      // only badged trigger" test in __tests__/tab-layout.test.tsx). If another
+      // tab ever gains a badge, drop this prop and move the session color onto
+      // per-trigger styling instead of letting the new badge inherit it.
       badgeBackgroundColor={hasLiveSession ? brandColors.live : brandColors.success}
     >
       {onAccessorySurface && nativeAccessoryActive && hasCurrentClimb ? (

--- a/packages/mobile/src/components/navigation/MaterialTabBar.tsx
+++ b/packages/mobile/src/components/navigation/MaterialTabBar.tsx
@@ -94,8 +94,16 @@ export function MaterialTabBar({ state, descriptors, navigation, insets }: Botto
                   style={[
                     styles.badge,
                     // Badge dot is a FILL (no text on it) → static light brand
-                    // success, not the scheme-lifted theme value.
-                    { backgroundColor: staticBrandColors.success, borderColor: systemColors.elevatedSurface },
+                    // colors, not the scheme-lifted theme value. Record's screen
+                    // options set the 'live' sentinel string (not display text) to
+                    // distinguish a live session from a merely-connected board;
+                    // any other truthy badge value (e.g. 'connected') keeps the
+                    // existing green.
+                    {
+                      backgroundColor:
+                        options.tabBarBadge === 'live' ? staticBrandColors.live : staticBrandColors.success,
+                      borderColor: systemColors.elevatedSurface,
+                    },
                   ]}
                 />
               ) : null}

--- a/packages/mobile/src/components/navigation/MaterialTabBar.tsx
+++ b/packages/mobile/src/components/navigation/MaterialTabBar.tsx
@@ -8,6 +8,7 @@ import { useSetMeasuredTabBarHeight } from '../../providers/tab-bar-height-provi
 import { brandColors as staticBrandColors } from '../../theme/colors';
 import { material } from '../../theme/tokens';
 import { MATERIAL_TAB_BAR_HEIGHT } from '../../theme/layout';
+import { isLiveTabBadge } from './tab-badge';
 
 /**
  * Material 3 bottom navigation bar — the JS tab bar for the Material UI variant
@@ -95,13 +96,14 @@ export function MaterialTabBar({ state, descriptors, navigation, insets }: Botto
                     styles.badge,
                     // Badge dot is a FILL (no text on it) → static light brand
                     // colors, not the scheme-lifted theme value. Record's screen
-                    // options set the 'live' sentinel string (not display text) to
-                    // distinguish a live session from a merely-connected board;
-                    // any other truthy badge value (e.g. 'connected') keeps the
-                    // existing green.
+                    // options carry a state marker (not display text) on
+                    // `tabBarBadge` to tell a live session from a merely-connected
+                    // board; the producer/consumer contract lives in ./tab-badge.
+                    // Any other badge value keeps the standard green.
                     {
-                      backgroundColor:
-                        options.tabBarBadge === 'live' ? staticBrandColors.live : staticBrandColors.success,
+                      backgroundColor: isLiveTabBadge(options.tabBarBadge)
+                        ? staticBrandColors.live
+                        : staticBrandColors.success,
                       borderColor: systemColors.elevatedSurface,
                     },
                   ]}

--- a/packages/mobile/src/components/navigation/__tests__/MaterialTabBar.test.tsx
+++ b/packages/mobile/src/components/navigation/__tests__/MaterialTabBar.test.tsx
@@ -96,9 +96,10 @@ vi.mock('../../../providers/theme-provider', () => ({
       separator: '#3A3A3C',
       secondaryLabel: '#8E8E93',
     },
-    // MaterialTabBar now reads the scheme-aware brand from the theme (lifted
-    // tint in dark) rather than the static import.
-    brandColors: { primary: '#FF3B30', success: '#6B9080', live: '#FBBF24' },
+    // Scheme-aware brand from the theme — MaterialTabBar uses it for the press
+    // ripple. Seeded with the DARK-scheme values so the badge assertions below
+    // prove the dot fill comes from the static (light) brand instead.
+    brandColors: { primary: '#A78BFA', success: '#34D399', live: '#FBBF24' },
     // M3 navigation-bar roles: active icon on a secondaryContainer pill, active
     // label onSurface, inactive icon+label onSurfaceVariant.
     m3: {
@@ -110,8 +111,10 @@ vi.mock('../../../providers/theme-provider', () => ({
   }),
 }));
 
+// The real static (light-scheme) brand fills from @boardsesh/velvet-tokens — the
+// badge dot is a FILL, so it stays on these in both schemes.
 vi.mock('../../../theme/colors', () => ({
-  brandColors: { primary: '#FF3B30', success: '#6B9080', live: '#FBBF24' },
+  brandColors: { primary: '#6D28D9', success: '#047857', live: '#B45309' },
 }));
 
 vi.mock('../../../theme/tokens', () => ({
@@ -130,6 +133,7 @@ vi.mock('../../../theme/layout', () => ({
 }));
 
 import { MaterialTabBar } from '../MaterialTabBar';
+import { TAB_BADGE_CONNECTED, TAB_BADGE_LIVE } from '../tab-badge';
 
 function makeProps(overrides: {
   activeIndex?: number;
@@ -205,24 +209,37 @@ describe('MaterialTabBar', () => {
       expect(queryByTestId('badge')).toBeNull();
     });
 
-    it('uses the live color when tabBarBadge is the "live" sentinel', () => {
-      const props = makeProps({ tabBarBadge: 'live' });
+    it('uses the live color when tabBarBadge carries the live marker', () => {
+      const props = makeProps({ tabBarBadge: TAB_BADGE_LIVE });
       const { queryByTestId } = render(
         <MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />,
       );
       const style = queryByTestId('badge')?.getAttribute('data-style');
-      expect(style).toContain('#FBBF24');
-      expect(style).not.toContain('#6B9080');
+      expect(style).toContain('#B45309');
+      expect(style).not.toContain('#047857');
     });
 
-    it('keeps the standard (success) color when tabBarBadge is a non-"live" value', () => {
-      const props = makeProps({ tabBarBadge: 'connected' });
+    it('keeps the standard (success) color for the connected marker', () => {
+      const props = makeProps({ tabBarBadge: TAB_BADGE_CONNECTED });
       const { queryByTestId } = render(
         <MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />,
       );
       const style = queryByTestId('badge')?.getAttribute('data-style');
-      expect(style).toContain('#6B9080');
-      expect(style).not.toContain('#FBBF24');
+      expect(style).toContain('#047857');
+      expect(style).not.toContain('#B45309');
+    });
+
+    // Any badge value that isn't the live marker keeps the standard color — the
+    // dot never renders text, so a future count badge degrades to a plain dot
+    // rather than picking up the live tint.
+    it('keeps the standard color for an unrelated badge value', () => {
+      const props = makeProps({ tabBarBadge: 3 });
+      const { queryByTestId } = render(
+        <MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />,
+      );
+      const style = queryByTestId('badge')?.getAttribute('data-style');
+      expect(style).toContain('#047857');
+      expect(style).not.toContain('#B45309');
     });
   });
 

--- a/packages/mobile/src/components/navigation/__tests__/MaterialTabBar.test.tsx
+++ b/packages/mobile/src/components/navigation/__tests__/MaterialTabBar.test.tsx
@@ -98,7 +98,7 @@ vi.mock('../../../providers/theme-provider', () => ({
     },
     // MaterialTabBar now reads the scheme-aware brand from the theme (lifted
     // tint in dark) rather than the static import.
-    brandColors: { primary: '#FF3B30', success: '#6B9080' },
+    brandColors: { primary: '#FF3B30', success: '#6B9080', live: '#FBBF24' },
     // M3 navigation-bar roles: active icon on a secondaryContainer pill, active
     // label onSurface, inactive icon+label onSurfaceVariant.
     m3: {
@@ -111,7 +111,7 @@ vi.mock('../../../providers/theme-provider', () => ({
 }));
 
 vi.mock('../../../theme/colors', () => ({
-  brandColors: { primary: '#FF3B30', success: '#6B9080' },
+  brandColors: { primary: '#FF3B30', success: '#6B9080', live: '#FBBF24' },
 }));
 
 vi.mock('../../../theme/tokens', () => ({
@@ -203,6 +203,26 @@ describe('MaterialTabBar', () => {
         <MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />,
       );
       expect(queryByTestId('badge')).toBeNull();
+    });
+
+    it('uses the live color when tabBarBadge is the "live" sentinel', () => {
+      const props = makeProps({ tabBarBadge: 'live' });
+      const { queryByTestId } = render(
+        <MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />,
+      );
+      const style = queryByTestId('badge')?.getAttribute('data-style');
+      expect(style).toContain('#FBBF24');
+      expect(style).not.toContain('#6B9080');
+    });
+
+    it('keeps the standard (success) color when tabBarBadge is a non-"live" value', () => {
+      const props = makeProps({ tabBarBadge: 'connected' });
+      const { queryByTestId } = render(
+        <MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />,
+      );
+      const style = queryByTestId('badge')?.getAttribute('data-style');
+      expect(style).toContain('#6B9080');
+      expect(style).not.toContain('#FBBF24');
     });
   });
 

--- a/packages/mobile/src/components/navigation/tab-badge.ts
+++ b/packages/mobile/src/components/navigation/tab-badge.ts
@@ -1,0 +1,32 @@
+/**
+ * Record-tab badge state, carried on React Navigation's `tabBarBadge` screen
+ * option.
+ *
+ * `tabBarBadge` is typed `string | number` (display text on the stock bar), but
+ * `MaterialTabBar` draws the badge as a colour DOT with no text — the value is
+ * never rendered, it only selects the dot colour. That makes the option the one
+ * per-screen channel available for the state, at the cost of an implicit
+ * producer/consumer contract, so both ends go through this module:
+ *
+ * - producer: the Record `Tabs.Screen` in `app/(tabs)/_layout.tsx`
+ * - consumer: `isLiveTabBadge` in `MaterialTabBar.tsx`
+ *
+ * Record is the only screen that sets a badge. If another screen ever needs one,
+ * give it a value from here (or extend the union) rather than a bare string — a
+ * badge value that isn't `TAB_BADGE_LIVE` renders in the standard colour, and a
+ * numeric count would render as a plain dot because this bar draws no badge text.
+ */
+
+/** A live party session is running. */
+export const TAB_BADGE_LIVE = 'live';
+
+/** A board is connected over Bluetooth, no live session. */
+export const TAB_BADGE_CONNECTED = 'connected';
+
+export type TabBadgeState = typeof TAB_BADGE_LIVE | typeof TAB_BADGE_CONNECTED;
+
+/** The single place the live badge value is compared. Any other badge value
+ *  (including a future count) keeps the standard connected colour. */
+export function isLiveTabBadge(badge: unknown): boolean {
+  return badge === TAB_BADGE_LIVE;
+}

--- a/packages/mobile/src/components/queue-control/ReturnToSessionButton.tsx
+++ b/packages/mobile/src/components/queue-control/ReturnToSessionButton.tsx
@@ -1,0 +1,45 @@
+// Small icon button floated inside the persistent climb capsule's `endAction`
+// slot: while a session is live and the user is elsewhere in the app, this
+// gives a one-tap way back to the Record tab. "Minimize" is now just tab
+// switching (see #2560), so the badge alone left no return affordance — this
+// closes that gap (#2563).
+
+import { StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { PressableSurface } from '../PressableSurface';
+import { Icon } from '../Icon';
+import { useTheme } from '../../providers/theme-provider';
+import { glassSize } from '../../theme/layout';
+import { hapticLight } from '../../lib/haptics';
+
+export function ReturnToSessionButton() {
+  const { t } = useTranslation('session');
+  const { brandColors } = useTheme();
+  const router = useRouter();
+
+  const handlePress = () => {
+    hapticLight();
+    router.navigate('/(tabs)/record');
+  };
+
+  return (
+    <PressableSurface
+      onPress={handlePress}
+      feedback="opacity"
+      hitSlop={4}
+      accessibilityRole="button"
+      accessibilityLabel={t('mobile.session.returnToSession')}
+      style={[styles.action, { width: glassSize.inline, height: glassSize.inline }]}
+    >
+      <Icon name="record" size={20} color={brandColors.live} />
+    </PressableSurface>
+  );
+}
+
+const styles = StyleSheet.create({
+  action: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -19,6 +19,8 @@ const cfg = vi.hoisted(() => ({
   nativeTabBar: false,
   widthClass: 'compact' as 'compact' | 'regular',
   windowWidth: 430,
+  sessionId: null as string | null,
+  activeSegment: null as string | null,
 }));
 
 // useAccessoryClimbTap builds a preview queue item via climbToQueueItem, which
@@ -59,6 +61,7 @@ vi.mock('../../../lib/route-segments', () => ({
   // The bar's own route gate (top-level tab only) and the bottom-chrome surface gate.
   isTopLevelTabRoute: () => cfg.onTopLevelTab,
   isAccessorySurfaceRoute: () => cfg.onAccessorySurface,
+  tabsActiveSegment: () => cfg.activeSegment,
 }));
 // useBottomChromeMetrics now reads the device layout; in jsdom this test runs as
 // a compact phone (no sidebar), so the bottom-chrome arithmetic is unchanged.
@@ -68,6 +71,7 @@ vi.mock('../../../hooks/use-device-layout', () => ({
 vi.mock('../../../providers/queue-provider', () => ({
   useQueue: () => ({ state: { currentClimbQueueItem: cfg.currentClimbQueueItem } }),
   useHasActiveClimb: () => cfg.currentClimbQueueItem?.climb != null,
+  useQueueSessionId: () => ({ sessionId: cfg.sessionId }),
 }));
 vi.mock('../../../hooks/use-reduce-motion', () => ({ useReduceMotion: () => true }));
 vi.mock('../../../theme/animations', () => ({ timing: { fast: 150, normal: 250 } }));
@@ -115,11 +119,13 @@ vi.mock('../ClimbCapsule', () => ({
     height,
     surfaceTreatment,
     endAction,
+    endActionSize,
   }: {
     fillWidth?: boolean;
     height?: number;
     surfaceTreatment?: string;
     endAction?: ReactNode;
+    endActionSize?: number;
   }) =>
     createElement(
       'div',
@@ -128,6 +134,7 @@ vi.mock('../ClimbCapsule', () => ({
         'data-fill-width': fillWidth ? 'true' : 'false',
         'data-height': height == null ? '' : String(height),
         'data-surface-treatment': surfaceTreatment ?? '',
+        'data-end-action-size': endActionSize == null ? '' : String(endActionSize),
       },
       endAction,
     ),
@@ -139,6 +146,9 @@ vi.mock('../LogAscentFab', () => ({
 vi.mock('../LogAscentToolbarButton', () => ({
   LogAscentToolbarButton: ({ climb }: { climb: { uuid: string } }) =>
     createElement('div', { 'data-tick-inline': 'true', 'data-climb-uuid': climb.uuid }),
+}));
+vi.mock('../ReturnToSessionButton', () => ({
+  ReturnToSessionButton: () => createElement('div', { 'data-return-to-session': 'true' }),
 }));
 
 import { PersistentQueueBar } from '../persistent-queue-bar';
@@ -167,6 +177,8 @@ describe('PersistentQueueBar', () => {
     cfg.nativeTabBar = false;
     cfg.widthClass = 'compact';
     cfg.windowWidth = 430;
+    cfg.sessionId = null;
+    cfg.activeSegment = null;
   });
 
   it('renders nothing when no climb is current', () => {
@@ -325,5 +337,42 @@ describe('PersistentQueueBar', () => {
 
     expect(container.querySelector('[data-capsule]')).toBeNull();
     expect(container.querySelector('[data-tick]')).toBeNull();
+  });
+
+  describe('return-to-session affordance (#2563)', () => {
+    it('shows the return-to-session button in the capsule endAction when a session is live and not on Record', () => {
+      cfg.sessionId = 'session-1';
+      cfg.activeSegment = 'home';
+      const { container } = renderBar();
+      const capsule = container.querySelector('[data-capsule]');
+      expect(capsule?.querySelector('[data-return-to-session]')).not.toBeNull();
+      expect(capsule?.getAttribute('data-end-action-size')).toBe('44');
+    });
+
+    it('omits the return-to-session button when no session is live', () => {
+      cfg.sessionId = null;
+      cfg.activeSegment = 'home';
+      const { container } = renderBar();
+      const capsule = container.querySelector('[data-capsule]');
+      expect(capsule?.querySelector('[data-return-to-session]')).toBeNull();
+    });
+
+    it('omits the return-to-session button while already on the Record tab', () => {
+      cfg.sessionId = 'session-1';
+      cfg.activeSegment = 'record';
+      const { container } = renderBar();
+      const capsule = container.querySelector('[data-capsule]');
+      expect(capsule?.querySelector('[data-return-to-session]')).toBeNull();
+    });
+
+    it('keeps the Material docked bar on the inline log-ascent tick regardless of session state', () => {
+      cfg.variant = 'material';
+      cfg.sessionId = 'session-1';
+      cfg.activeSegment = 'home';
+      const { container } = renderBar();
+      const capsule = container.querySelector('[data-capsule]');
+      expect(capsule?.querySelector('[data-tick-inline]')).not.toBeNull();
+      expect(capsule?.querySelector('[data-return-to-session]')).toBeNull();
+    });
   });
 });

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -153,6 +153,10 @@ vi.mock('../ReturnToSessionButton', () => ({
 
 import { PersistentQueueBar } from '../persistent-queue-bar';
 import { BottomChromeMetricsProvider } from '../../../hooks/use-bottom-chrome-metrics';
+// Resolves to the layout mock above, which mirrors theme/layout's `glassSize`.
+// Assertions read it instead of repeating the literal, so retuning the ladder is
+// a one-line mock change rather than an opaque value mismatch.
+import { glassSize } from '../../../theme/layout';
 
 // The bar reads useBottomChromeMetrics(), which now requires the provider (the
 // geometry is computed once at the tab root). All the leaf inputs the provider
@@ -346,7 +350,7 @@ describe('PersistentQueueBar', () => {
       const { container } = renderBar();
       const capsule = container.querySelector('[data-capsule]');
       expect(capsule?.querySelector('[data-return-to-session]')).not.toBeNull();
-      expect(capsule?.getAttribute('data-end-action-size')).toBe('44');
+      expect(capsule?.getAttribute('data-end-action-size')).toBe(String(glassSize.inline));
     });
 
     it('omits the return-to-session button when no session is live', () => {

--- a/packages/mobile/src/components/queue-control/__tests__/return-to-session-button.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/return-to-session-button.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+const routerNavigate = vi.fn();
+
+vi.mock('react-native', () => ({
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+vi.mock('expo-router', () => ({
+  useRouter: () => ({ navigate: routerNavigate }),
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+vi.mock('../../../lib/haptics', () => ({ hapticLight: vi.fn() }));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ brandColors: { live: '#FBBF24' } }),
+}));
+
+vi.mock('../../../theme/layout', () => ({ glassSize: { inline: 44 } }));
+
+vi.mock('../../PressableSurface', () => ({
+  PressableSurface: ({
+    children,
+    onPress,
+    accessibilityRole,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityRole?: string;
+    accessibilityLabel?: string;
+  }) =>
+    createElement('button', { onClick: onPress, role: accessibilityRole, 'aria-label': accessibilityLabel }, children),
+}));
+
+vi.mock('../../Icon', () => ({
+  Icon: ({ name, color }: { name: string; color?: string }) =>
+    createElement('span', { 'data-icon': name, 'data-color': color ?? '' }),
+}));
+
+import { hapticLight } from '../../../lib/haptics';
+import { ReturnToSessionButton } from '../ReturnToSessionButton';
+
+describe('ReturnToSessionButton', () => {
+  it('navigates to the Record tab and fires haptic feedback on press', () => {
+    const { getByRole } = render(<ReturnToSessionButton />);
+    fireEvent.click(getByRole('button'));
+    expect(hapticLight).toHaveBeenCalledTimes(1);
+    expect(routerNavigate).toHaveBeenCalledWith('/(tabs)/record');
+  });
+
+  it('resolves its accessibility label via i18n', () => {
+    const { getByRole } = render(<ReturnToSessionButton />);
+    expect(getByRole('button').getAttribute('aria-label')).toBe('mobile.session.returnToSession');
+  });
+
+  it('renders the record icon in the live brand color', () => {
+    const { container } = render(<ReturnToSessionButton />);
+    const icon = container.querySelector('[data-icon="record"]');
+    expect(icon).not.toBeNull();
+    expect(icon?.getAttribute('data-color')).toBe('#FBBF24');
+  });
+});

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -26,16 +26,17 @@ import {
   glassSize,
 } from '../../theme/layout';
 import { resolveDetailPaneSurface } from '../../theme/size-class';
-import { useQueue } from '../../providers/queue-provider';
+import { useQueue, useQueueSessionId } from '../../providers/queue-provider';
 import { useTheme } from '../../providers/theme-provider';
 import { selectByVariant } from '../../theme/variants';
-import { isTopLevelTabRoute } from '../../lib/route-segments';
+import { isTopLevelTabRoute, tabsActiveSegment } from '../../lib/route-segments';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
 import { useDeviceLayout } from '../../hooks/use-device-layout';
 import { ActiveContextBar } from './ActiveContextBar';
 import { ClimbCapsule } from './ClimbCapsule';
 import { LogAscentFab } from './LogAscentFab';
 import { LogAscentToolbarButton } from './LogAscentToolbarButton';
+import { ReturnToSessionButton } from './ReturnToSessionButton';
 
 // Re-export so layout consumers that already import toolbar metrics from this
 // module don't need to know which file owns them. Source of truth: theme/layout.
@@ -48,6 +49,10 @@ export function PersistentQueueBar() {
   const bottomChrome = useBottomChromeMetrics();
   const { widthClass } = useDeviceLayout();
   const { width } = useWindowDimensions();
+  // sessionId-only subscription (mirrors the tab layout's own read) — a "return to
+  // session" affordance while a session is live and the user isn't already on the
+  // Record tab.
+  const { sessionId } = useQueueSessionId();
 
   // Queue head only — the wall's lit climb lives in the top "On the wall" strip.
   const currentClimb = state.currentClimbQueueItem?.climb ?? null;
@@ -85,5 +90,21 @@ export function PersistentQueueBar() {
     );
   }
 
-  return <ActiveContextBar primary={<ClimbCapsule />} trailing={<LogAscentFab climb={currentClimb} />} />;
+  // Excludes the Record tab itself — this bar renders on every top-level tab page
+  // including Record's own index, so without this guard the button would point at
+  // the screen it's already on.
+  const onRecordTab = tabsActiveSegment(segments) === 'record';
+  const showReturnToSession = sessionId !== null && !onRecordTab;
+
+  return (
+    <ActiveContextBar
+      primary={
+        <ClimbCapsule
+          endAction={showReturnToSession ? <ReturnToSessionButton /> : undefined}
+          endActionSize={showReturnToSession ? glassSize.inline : undefined}
+        />
+      }
+      trailing={<LogAscentFab climb={currentClimb} />}
+    />
+  );
 }

--- a/packages/shared/i18n/locales/de/session.json
+++ b/packages/shared/i18n/locales/de/session.json
@@ -516,6 +516,7 @@
       "editTitleAria": "Session-Namen bearbeiten",
       "minimize": "Session minimieren",
       "recordTab": "Aufnehmen",
+      "returnToSession": "Zurück zur Session",
       "preBoardLabel": "Board",
       "preGeneratorLabel": "Workout",
       "preGeneratorOff": "Aus",

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -516,6 +516,7 @@
       "editTitleAria": "Edit session name",
       "minimize": "Minimize session",
       "recordTab": "Record",
+      "returnToSession": "Return to session",
       "preBoardLabel": "Board",
       "preGeneratorLabel": "Workout",
       "preGeneratorOff": "Off",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -516,6 +516,7 @@
       "editTitleAria": "Editar el nombre de la sesión",
       "minimize": "Minimizar sesión",
       "recordTab": "Grabar",
+      "returnToSession": "Volver a la sesión",
       "preBoardLabel": "Plafón",
       "preGeneratorLabel": "Entrenamiento",
       "preGeneratorOff": "Apagado",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -516,6 +516,7 @@
       "editTitleAria": "Modifier le nom de la session",
       "minimize": "Réduire la session",
       "recordTab": "Enregistrer",
+      "returnToSession": "Retour à la session",
       "preBoardLabel": "Mur",
       "preGeneratorLabel": "Entraînement",
       "preGeneratorOff": "Désactivé",


### PR DESCRIPTION
## Summary

Deleting the full-screen session overlay in #2560 left the Record tab's badge doing double duty — the same green dot meant either "board connected" or "session live," with no way to distinguish them, and no one-tap way back to Record once you'd switched tabs.

- The Record tab badge now colors amber (`brandColors.live`) when a session is live, and stays green (`brandColors.success`) when only a board is connected — on both the iOS Liquid Glass `NativeTabs` badge and the Material `MaterialTabBar` dot (which shared the same boolean but was missed by the issue's own code snippet).
- A small "return to session" icon button appears inside the persistent floating climb capsule (Liquid Glass / fallback variant) while a session is live and you're on any tab other than Record; tapping it routes straight back to Record. The button is intentionally excluded from Record's own tab and from the Material variant's docked bar (its `endAction` slot is already the log-ascent tick).

Closes #2563

**Out of scope** (documented in the plan, flagged for reviewers):
- The iOS 26 native bottom accessory (`NativeAccessoryClimbRow`) — its tick/board-control slots are already fully reserved, and it sits in the same tab-bar chrome as Record already.
- The Material variant's docked `ClimbCapsule` bar — its `endAction` slot is already the log-ascent tick, and it docks directly above the Material tab bar (Record is one tap away).
- iPad shell — Record is already reachable via the persistent sidebar rail row.
- Any change to session start/end logic, BLE handling, or SessionScreen/InSessionView internals.

**Needs on-device verification**: native badge rendering (iOS `NativeTabs.Trigger.Badge` color contrast/legibility, and whether `selectedBackgroundColor` behaves the same for selected vs. unselected tab state) can't be confirmed from this Linux dev environment — the color-branch logic is unit-tested, but flagging per the issue's own note.

## Release Notes

- Record tab now shows a different badge color when a session is live vs. when a board is just connected, and a quick tap-back-to-session button shows up on your other tabs while you're mid-session.

## Test plan

- `vp check` — passes (pre-existing unrelated lint findings on `main` in `packages/db` / `packages/shared/offline-sync` confirmed via stash-diff, not touched by this PR).
- `vp run typecheck:mobile` — passes.
- `vp test run --project mobile` — full mobile suite passes (602 files including the fixed `tab-layout.test.tsx`, `MaterialTabBar.test.tsx`, `persistent-queue-bar.test.tsx`, and new `return-to-session-button.test.tsx`).
- `vp run check:mobile-bundle` — passes.
- `vp test run packages/shared/i18n/src/__tests__/catalog-completeness.test.ts` — passes (all 4 locales carry the new `mobile.session.returnToSession` key).
- `vp run check:i18n` — passes.
- Manual QA plan written to `.boardsesh/qa-notes.md` (dev server not started, per no-dev-server instruction for this task).
