### PR TITLE
feat(mobile): ask before queueing a climb from another board

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -912,7 +912,7 @@ function ClimbListInner() {
 
   const handleAddToQueue = useCallback(
     (climb: Climb) => {
-      addToQueue({ uuid: randomUUID(), climb });
+      void addToQueue({ uuid: randomUUID(), climb });
     },
     [addToQueue],
   );

--- a/packages/mobile/src/components/climb-actions/use-climb-actions.ts
+++ b/packages/mobile/src/components/climb-actions/use-climb-actions.ts
@@ -201,7 +201,9 @@ export function useClimbActions({
       icon: 'add',
       color: successColor,
       run: () => {
-        addToQueue({ uuid: randomUUID(), climb });
+        // Fire-and-forget: the cross-board prompt (when it fires) sits above
+        // the dismissed sheet, so `after()` must not wait on it.
+        void addToQueue({ uuid: randomUUID(), climb });
         after();
       },
     });

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -763,8 +763,13 @@ export function PlayDrawer({
   }, []);
 
   const handleSimilarClimbPress = useCallback(
-    (similarClimb: Climb) => {
+    async (similarClimb: Climb) => {
       const queueItem = climbToQueueItem(similarClimb);
+      // A similar climb can be set on another board, so this add may raise the
+      // cross-board prompt. Wait for it: backing out has to leave the drawer on
+      // the climb they were already looking at, not activate the one they just
+      // declined to queue.
+      if ((await addToQueue(queueItem)) === 'cancelled') return;
       // Tapping a similar climb activates it (commit), so it's never a preview —
       // clear any preview that was showing.
       setDrawerPreviewItem(null);
@@ -772,7 +777,6 @@ export function PlayDrawer({
       setIsMirrored(false);
       // The favorite override is cleared by the climb-change effect.
       setIsTickBarActive(false);
-      addToQueue(queueItem);
       setCurrentClimb(queueItem, { playlistSuggestionSource: null });
     },
     [addToQueue, setCurrentClimb],
@@ -1059,7 +1063,7 @@ export function PlayDrawer({
           angle={angle}
           onAddToQueue={() => {
             if (displayedClimb) {
-              addToQueue({
+              void addToQueue({
                 uuid: randomUUID(),
                 climb: displayedClimb,
               });

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -38,6 +38,7 @@ import {
   type FavoritesQueryResponse,
 } from '@boardsesh/graphql/operations/favorites';
 import { BOULDER_GRADES } from '@boardsesh/board-config';
+import { myBoardsQueryKey } from '../query-keys';
 import { getDatabaseHandle } from '../../../db';
 import { offlineAwareRequest } from '../offline-request';
 import { useOfflineDownloadsEnabled } from '../../../providers/feature-flags-provider';
@@ -215,9 +216,14 @@ export function useUpdateProfile() {
 // Board Queries
 // ============================================
 
+// The key lives in `../query-keys` because `useCrossBoardAddGate` reads this
+// roster imperatively out of the cache; both sides import the one helper so the
+// shape can't drift apart. Re-exported here for callers already on this barrel.
+export { myBoardsQueryKey };
+
 export function useMyBoards(input?: MyBoardsInput, options?: { enabled?: boolean }) {
   return useQuery({
-    queryKey: ['myBoards', input],
+    queryKey: myBoardsQueryKey(input),
     queryFn: () => getHttpClient().request<GetMyBoardsQueryResponse>(GET_MY_BOARDS, { input }),
     select: (data) => data.myBoards,
     enabled: options?.enabled ?? true,

--- a/packages/mobile/src/lib/graphql/query-keys.ts
+++ b/packages/mobile/src/lib/graphql/query-keys.ts
@@ -1,0 +1,19 @@
+import type { MyBoardsInput } from '@boardsesh/shared-schema';
+
+/**
+ * React Query keys that more than one module has to agree on.
+ *
+ * A key that only its own hook uses stays next to that hook (see
+ * `ACTIVE_BOARD_QUERY_KEY` in `use-active-board.ts`). A key lands here once
+ * something reads the cache imperatively — `queryClient.getQueryData(...)` from
+ * a tap handler that must not subscribe — because that reader has no compiler
+ * link to the hook that wrote the entry, and a key change would leave it
+ * silently resolving `undefined` forever.
+ *
+ * This file is a leaf on purpose: types only, no hooks, no providers. The
+ * imperative readers live deep in provider land, and pulling the `hooks` barrel
+ * in for a key would drag half the app's module graph with it.
+ */
+
+/** Key `useMyBoards(input)` writes under; call with no argument for the plain roster. */
+export const myBoardsQueryKey = (input?: MyBoardsInput) => ['myBoards', input] as const;

--- a/packages/mobile/src/providers/__tests__/dialog-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/dialog-provider.test.tsx
@@ -12,14 +12,16 @@ const alertMock = vi.hoisted(() => ({
   calls: [] as Array<{ title: string; message?: string; buttons: AlertButton[]; onDismiss?: () => void }>,
 }));
 
-// The provider needs Alert + Platform from react-native; mock both (Platform.OS is
-// controllable because the Paper dialog is Android-Material-only — iOS uses Alert).
+// The provider needs Alert + Platform + StyleSheet from react-native; mock them
+// (Platform.OS is controllable because the Paper dialog is Android-Material-only
+// — iOS uses Alert).
 vi.mock('react-native', () => ({
   Platform: {
     get OS() {
       return ctrl.os;
     },
   },
+  StyleSheet: { create: (sheet: Record<string, unknown>) => sheet },
   Alert: {
     alert: (
       title: string,
@@ -52,13 +54,27 @@ vi.mock('../theme-provider', () => ({
   useTheme: () => ({ variant: ctrl.variant, m3: { error: '#B00020' } }),
 }));
 
-import { DialogProvider, useConfirm } from '../dialog-provider';
+import { DialogProvider, useChoose, useConfirm, type ChooseOptions } from '../dialog-provider';
 
 let confirmFn: ReturnType<typeof useConfirm>;
+let chooseFn: ReturnType<typeof useChoose>;
 function Consumer() {
   confirmFn = useConfirm();
+  chooseFn = useChoose();
   return null;
 }
+
+type CrossBoardValue = 'add' | 'switch' | 'cancel';
+const CROSS_BOARD: ChooseOptions<CrossBoardValue> = {
+  title: 'Climb from another board',
+  message: 'This one is set on Tension.',
+  options: [
+    { value: 'add', label: 'Add anyway' },
+    { value: 'switch', label: 'Switch board' },
+    { value: 'cancel', label: 'Cancel', cancel: true },
+  ],
+  cancelValue: 'cancel',
+};
 
 function setup() {
   return render(createElement(DialogProvider, null, createElement(Consumer)));
@@ -191,5 +207,91 @@ describe('useConfirm — Liquid Glass (native Alert)', () => {
     });
     act(() => alertMock.calls[1].onDismiss?.());
     await expect(dismissed).resolves.toBe(false);
+  });
+});
+
+describe('useChoose — three actions on Android Material (Paper Dialog)', () => {
+  it('resolves the picked action, not a boolean', async () => {
+    const { container } = setup();
+    let promise!: Promise<CrossBoardValue>;
+    act(() => {
+      promise = chooseFn(CROSS_BOARD);
+    });
+    // All three actions are rendered, in the order given.
+    expect([...container.querySelectorAll('button')].map((b) => b.textContent)).toEqual([
+      'Add anyway',
+      'Switch board',
+      'Cancel',
+    ]);
+    act(() => materialButton(container, 'Switch board').click());
+    await expect(promise).resolves.toBe('switch');
+  });
+
+  it('settles three concurrent prompts each with their OWN value', async () => {
+    const { container } = setup();
+    let first!: Promise<CrossBoardValue>;
+    let second!: Promise<CrossBoardValue>;
+    let third!: Promise<CrossBoardValue>;
+    act(() => {
+      first = chooseFn({ ...CROSS_BOARD, title: 'First' });
+      second = chooseFn({ ...CROSS_BOARD, title: 'Second' });
+      third = chooseFn({ ...CROSS_BOARD, title: 'Third' });
+    });
+    act(() => materialButton(container, 'Add anyway').click());
+    await expect(first).resolves.toBe('add');
+    act(() => materialButton(container, 'Switch board').click());
+    await expect(second).resolves.toBe('switch');
+    act(() => materialButton(container, 'Cancel').click());
+    await expect(third).resolves.toBe('cancel');
+  });
+
+  it('settles once per prompt — a double-tap cannot answer the next one too', async () => {
+    const { container } = setup();
+    let first!: Promise<CrossBoardValue>;
+    let second!: Promise<CrossBoardValue>;
+    act(() => {
+      first = chooseFn({ ...CROSS_BOARD, title: 'First' });
+      second = chooseFn({ ...CROSS_BOARD, title: 'Second' });
+    });
+    const addButton = materialButton(container, 'Add anyway');
+    act(() => {
+      addButton.click();
+      addButton.click();
+    });
+    await expect(first).resolves.toBe('add');
+    // The second prompt survived the double-tap and answers independently.
+    act(() => materialButton(container, 'Switch board').click());
+    await expect(second).resolves.toBe('switch');
+  });
+});
+
+describe('useChoose — three actions on the native Alert', () => {
+  beforeEach(() => {
+    ctrl.variant = 'liquidGlass';
+  });
+
+  it('hands Alert all three buttons with cancel styled last', async () => {
+    setup();
+    let promise!: Promise<CrossBoardValue>;
+    act(() => {
+      promise = chooseFn(CROSS_BOARD);
+    });
+    expect(alertMock.calls).toHaveLength(1);
+    const { buttons } = alertMock.calls[0];
+    expect(buttons.map((button) => button.text)).toEqual(['Add anyway', 'Switch board', 'Cancel']);
+    expect(buttons[0].style).toBeUndefined();
+    expect(buttons[2].style).toBe('cancel');
+    act(() => buttons[0].onPress?.());
+    await expect(promise).resolves.toBe('add');
+  });
+
+  it('resolves cancelValue on scrim / back dismiss', async () => {
+    setup();
+    let promise!: Promise<CrossBoardValue>;
+    act(() => {
+      promise = chooseFn(CROSS_BOARD);
+    });
+    act(() => alertMock.calls[0].onDismiss?.());
+    await expect(promise).resolves.toBe('cancel');
   });
 });

--- a/packages/mobile/src/providers/__tests__/queue-provider-attribution.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-attribution.test.tsx
@@ -152,6 +152,12 @@ vi.mock('../toast-provider', () => ({ useToast: () => ({ showToast: toast.showTo
 vi.mock('../queue-snackbar-provider', () => ({ useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }) }));
 // A signed-in climber with a resolved party profile — the only state in which
 // this device stamps identity at all.
+// The cross-board add gate calls useChoose()/useQueryClient()/expo-router, none of
+// which this harness mounts. Pass every add straight through — the gate's own
+// behaviour is covered by queue-provider-cross-board-add.test.tsx.
+vi.mock('../queue/use-cross-board-add-gate', () => ({
+  useCrossBoardAddGate: () => async () => ({ outcome: 'add' }),
+}));
 vi.mock('../party-profile-provider', () => ({
   usePartyProfile: () => ({
     profile: { id: 'party-uuid-1' },

--- a/packages/mobile/src/providers/__tests__/queue-provider-backgrounded-join.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-backgrounded-join.test.tsx
@@ -207,6 +207,12 @@ vi.mock('../queue-snackbar-provider', () => ({
   useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }),
 }));
 
+// The cross-board add gate calls useChoose()/useQueryClient()/expo-router, none of
+// which this harness mounts. Pass every add straight through — the gate's own
+// behaviour is covered by queue-provider-cross-board-add.test.tsx.
+vi.mock('../queue/use-cross-board-add-gate', () => ({
+  useCrossBoardAddGate: () => async () => ({ outcome: 'add' }),
+}));
 vi.mock('../party-profile-provider', () => ({
   usePartyProfile: () => ({ username: undefined, avatarUrl: undefined }),
 }));

--- a/packages/mobile/src/providers/__tests__/queue-provider-cross-board-add.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-cross-board-add.test.tsx
@@ -1,0 +1,424 @@
+// @vitest-environment jsdom
+import { act, render, waitFor } from '@testing-library/react';
+import { createElement, useEffect } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildBoardPath } from '@boardsesh/board-config';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import type { ClimbQueueItem } from '@boardsesh/queue';
+
+// QueueProvider harness for the CROSS-BOARD add gate (#3994): adding a climb set
+// on a board the queue isn't on asks first — add anyway / switch board / cancel.
+// The real `useCrossBoardAddGate` runs here (only the dialog, the board roster
+// cache and the router are stubbed), so the one-prompt-per-board dedup and the
+// switch side effects are covered end to end.
+
+const ws = vi.hoisted(() => ({
+  client: {
+    on: vi.fn(() => vi.fn()),
+    subscribe: vi.fn(() => vi.fn()),
+  },
+}));
+
+const graph = vi.hoisted(() => ({ execute: vi.fn() }));
+const http = vi.hoisted(() => ({ request: vi.fn() }));
+
+const boards = vi.hoisted(() => {
+  const base = {
+    uuid: 'board-kilter',
+    slug: 'board-kilter',
+    ownerId: 'owner-1',
+    boardType: 'kilter',
+    layoutId: 1,
+    sizeId: 10,
+    setIds: '1,2',
+    name: 'Home Kilter',
+    isPublic: true,
+    isUnlisted: false,
+    hideLocation: false,
+    isOwned: true,
+    angle: 40,
+    isAngleAdjustable: true,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    totalAscents: 0,
+    uniqueClimbers: 0,
+    followerCount: 0,
+    commentCount: 0,
+    isFollowedByMe: false,
+    canEdit: false,
+  };
+  return {
+    kilter: base,
+    // A DIFFERENT stored angle from the active board's 40 — the switch must keep
+    // the board's own angle, never synthesise 0.
+    tension: {
+      ...base,
+      uuid: 'board-tension',
+      slug: 'board-tension',
+      boardType: 'tension',
+      layoutId: 8,
+      sizeId: 12,
+      setIds: '3,4',
+      name: 'Gym Tension',
+      angle: 25,
+    },
+  };
+});
+
+const roster = vi.hoisted(() => ({ boards: [] as unknown[] }));
+const setActiveBoard = vi.hoisted(() => vi.fn(async (_board: unknown) => {}));
+const routerPush = vi.hoisted(() => vi.fn());
+const analytics = vi.hoisted(() => ({ track: vi.fn() }));
+const snackbar = vi.hoisted(() => ({ showQueueAddedSnackbar: vi.fn() }));
+
+// A controllable `choose()`: every prompt parks its resolver so the test decides
+// when (and whether) the climber answers.
+const dialog = vi.hoisted(() => {
+  const resolvers: Array<(value: string) => void> = [];
+  return {
+    resolvers,
+    choose: vi.fn(
+      (_options: unknown) =>
+        new Promise<string>((resolve) => {
+          resolvers.push(resolve);
+        }),
+    ),
+  };
+});
+
+const queueMutations = vi.hoisted(() => ({
+  addQueueItem: vi.fn(async () => {}),
+  removeQueueItem: vi.fn(async () => {}),
+  reorderQueueItem: vi.fn(async () => {}),
+  setCurrentClimb: vi.fn(async () => {}),
+  mirrorCurrentClimb: vi.fn(async () => {}),
+  publishPlaybackState: vi.fn(async () => {}),
+  setQueue: vi.fn(async () => {}),
+  replaceQueueItem: vi.fn(async () => {}),
+  reportWallDisconnect: vi.fn(async () => {}),
+  confirmClimbOnWall: vi.fn(async () => {}),
+  setSessionBoardSerial: vi.fn(async () => {}),
+  setSessionBoardPath: vi.fn(async (_boardPath: string) => {}),
+}));
+
+const sessionStore = vi.hoisted(() => ({
+  getStoredSessionId: vi.fn(async (): Promise<string | null> => null),
+  setStoredSessionId: vi.fn(async () => {}),
+  clearStoredSessionId: vi.fn(async () => {}),
+  getStoredCreatedSessionId: vi.fn(async (): Promise<string | null> => null),
+  setStoredCreatedSessionId: vi.fn(async () => {}),
+  clearStoredCreatedSessionId: vi.fn(async () => {}),
+}));
+
+const queueSnapshotStore = vi.hoisted(() => ({
+  getStoredQueueSnapshot: vi.fn(async (): Promise<null> => null),
+  setStoredQueueSnapshot: vi.fn(async () => {}),
+  clearStoredQueueSnapshot: vi.fn(async () => {}),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios', select: (options: Record<string, unknown>) => options.ios ?? options.default },
+  AppState: { addEventListener: vi.fn(() => ({ remove: vi.fn() })) },
+}));
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'test-correlation-id' }));
+vi.mock('expo-router', () => ({ router: { push: routerPush } }));
+// Only the cache read the gate does is stubbed; QueueProvider itself reads the
+// real QueryClientContext elsewhere.
+vi.mock('@tanstack/react-query', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@tanstack/react-query')>()),
+  useQueryClient: () => ({ getQueryData: () => ({ myBoards: { boards: roster.boards } }) }),
+}));
+vi.mock('@boardsesh/graphql-client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/graphql-client')>()),
+  execute: graph.execute,
+}));
+vi.mock('@boardsesh/queue-react', () => ({
+  useQueueMutations: () => queueMutations,
+}));
+vi.mock('@boardsesh/play-view', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/play-view')>()),
+  emitWallConfirm: vi.fn(),
+}));
+vi.mock('../../lib/graphql/ws-client', () => ({ getWsClient: () => ws.client }));
+vi.mock('../../lib/session-store', () => sessionStore);
+vi.mock('../../lib/queue-snapshot-store', () => queueSnapshotStore);
+vi.mock('../../lib/active-board-store', () => ({ getStoredActiveBoard: async () => boards.kilter }));
+vi.mock('../../lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: boards.kilter }),
+  useSetActiveBoard: () => setActiveBoard,
+}));
+vi.mock('../../lib/graphql/client', () => ({ getHttpClient: () => ({ request: http.request }) }));
+vi.mock('../../lib/analytics', () => ({ track: analytics.track }));
+vi.mock('../../lib/error-reporting', () => ({ reportError: vi.fn(), reportHandledError: vi.fn() }));
+vi.mock('../toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('../queue-snackbar-provider', () => ({
+  useQueueSnackbar: () => ({ showQueueAddedSnackbar: snackbar.showQueueAddedSnackbar }),
+}));
+vi.mock('../dialog-provider', () => ({ useChoose: () => dialog.choose }));
+vi.mock('../party-profile-provider', () => ({
+  usePartyProfile: () => ({ username: undefined, avatarUrl: undefined }),
+}));
+
+import { QueueProvider, useQueue } from '../queue-provider';
+
+type Snapshot = {
+  queue: ClimbQueueItem[];
+  addToQueue: ReturnType<typeof useQueue>['addToQueue'];
+};
+
+function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
+  const queue = useQueue();
+  useEffect(() => {
+    onSnapshot({ queue: queue.state.queue, addToQueue: queue.addToQueue });
+  }, [queue.state, queue.addToQueue, onSnapshot]);
+  return null;
+}
+
+function makeQueueItem(uuid: string, board: { boardType?: string; layoutId?: number }): ClimbQueueItem {
+  return {
+    uuid,
+    climb: {
+      uuid: `climb-${uuid}`,
+      name: `Climb ${uuid}`,
+      frames: 'p1r12',
+      setter_username: 'setter',
+      angle: 40,
+      ascensionist_count: 0,
+      difficulty: 'V3',
+      quality_average: '3.0',
+      stars: 3,
+      difficulty_error: '0.3',
+      benchmark_difficulty: null,
+      ...board,
+    },
+    suggested: false,
+  };
+}
+
+const kilterItem = (uuid: string) => makeQueueItem(uuid, { boardType: 'kilter', layoutId: 1 });
+const tensionItem = (uuid: string) => makeQueueItem(uuid, { boardType: 'tension', layoutId: 8 });
+
+async function mountProvider() {
+  const snapshots: Snapshot[] = [];
+  render(createElement(QueueProvider, null, createElement(Probe, { onSnapshot: (s) => snapshots.push(s) })));
+  await waitFor(() => {
+    expect(snapshots.length).toBeGreaterThan(0);
+  });
+  return {
+    latest: () => {
+      const snapshot = snapshots.at(-1);
+      if (!snapshot) throw new Error('provider never rendered');
+      return snapshot;
+    },
+  };
+}
+
+/** Answer the Nth open prompt and let the awaiting add finish. */
+async function answerPrompt(index: number, value: 'add' | 'switch' | 'cancel') {
+  await act(async () => {
+    dialog.resolvers[index](value);
+    await Promise.resolve();
+  });
+}
+
+function queueUuids(snapshot: Snapshot): string[] {
+  return snapshot.queue.map((item) => item.uuid);
+}
+
+describe('QueueProvider cross-board add gate', () => {
+  beforeEach(() => {
+    dialog.resolvers.length = 0;
+    dialog.choose.mockClear();
+    roster.boards = [boards.kilter, boards.tension];
+    setActiveBoard.mockClear();
+    routerPush.mockClear();
+    analytics.track.mockClear();
+    snackbar.showQueueAddedSnackbar.mockClear();
+    for (const mutation of Object.values(queueMutations) as Array<ReturnType<typeof vi.fn>>) {
+      mutation.mockClear();
+    }
+    graph.execute.mockReset();
+    http.request.mockReset();
+    http.request.mockResolvedValue({ createSession: { id: 'session-new' } });
+  });
+
+  it('adds a climb from the active board with no prompt at all', async () => {
+    const provider = await mountProvider();
+
+    await act(async () => {
+      await expect(provider.latest().addToQueue(kilterItem('same-board'))).resolves.toBe('added');
+    });
+
+    expect(dialog.choose).not.toHaveBeenCalled();
+    expect(queueUuids(provider.latest())).toEqual(['same-board']);
+    expect(queueMutations.addQueueItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('adds a climb with no board metadata rather than prompting', async () => {
+    const provider = await mountProvider();
+
+    await act(async () => {
+      await provider.latest().addToQueue(makeQueueItem('no-metadata', {}));
+    });
+
+    expect(dialog.choose).not.toHaveBeenCalled();
+    expect(queueUuids(provider.latest())).toEqual(['no-metadata']);
+  });
+
+  it('prompts once for a foreign board and queues it on "add anyway"', async () => {
+    const provider = await mountProvider();
+
+    let pending!: Promise<'added' | 'cancelled'>;
+    act(() => {
+      pending = provider.latest().addToQueue(tensionItem('foreign'));
+    });
+    expect(dialog.choose).toHaveBeenCalledTimes(1);
+    // Nothing lands until they answer.
+    expect(queueUuids(provider.latest())).toEqual([]);
+
+    await answerPrompt(0, 'add');
+    await expect(pending).resolves.toBe('added');
+
+    expect(queueUuids(provider.latest())).toEqual(['foreign']);
+    expect(queueMutations.addQueueItem).toHaveBeenCalledTimes(1);
+    expect(analytics.track).toHaveBeenCalledWith(
+      SHARED_EVENTS.CrossBoardQueueAddPrompted,
+      expect.objectContaining({ outcome: 'add', climbBoardName: 'tension', climbLayoutId: 8 }),
+    );
+  });
+
+  it('cancelling leaves the queue untouched, unsynced, untracked and unsnackbarred', async () => {
+    const provider = await mountProvider();
+
+    let pending!: Promise<'added' | 'cancelled'>;
+    act(() => {
+      pending = provider.latest().addToQueue(tensionItem('foreign'));
+    });
+    await answerPrompt(0, 'cancel');
+    await expect(pending).resolves.toBe('cancelled');
+
+    expect(queueUuids(provider.latest())).toEqual([]);
+    expect(queueMutations.addQueueItem).not.toHaveBeenCalled();
+    expect(snackbar.showQueueAddedSnackbar).not.toHaveBeenCalled();
+    expect(analytics.track).not.toHaveBeenCalledWith(SHARED_EVENTS.ClimbAddedToQueue, expect.anything());
+  });
+
+  it('switching activates the owned board at ITS OWN angle, queues the climb, and tells peers', async () => {
+    const provider = await mountProvider();
+
+    let pending!: Promise<'added' | 'cancelled'>;
+    act(() => {
+      pending = provider.latest().addToQueue(tensionItem('foreign'));
+    });
+    await answerPrompt(0, 'switch');
+    await expect(pending).resolves.toBe('added');
+
+    expect(setActiveBoard).toHaveBeenCalledWith(boards.tension);
+    // Its stored 25°, never a synthesised 0.
+    expect(queueMutations.setSessionBoardPath).toHaveBeenCalledWith(buildBoardPath('tension', 8, 12, '3,4', 25));
+    // The add is the SAME synced body, not a local-only dispatch.
+    expect(queueUuids(provider.latest())).toEqual(['foreign']);
+    expect(queueMutations.addQueueItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes to the board picker and cancels the add when they do not own that board', async () => {
+    roster.boards = [boards.kilter];
+    const provider = await mountProvider();
+
+    let pending!: Promise<'added' | 'cancelled'>;
+    act(() => {
+      pending = provider.latest().addToQueue(tensionItem('foreign'));
+    });
+    await answerPrompt(0, 'switch');
+    await expect(pending).resolves.toBe('cancelled');
+
+    expect(routerPush).toHaveBeenCalledWith('/boards');
+    expect(setActiveBoard).not.toHaveBeenCalled();
+    expect(queueUuids(provider.latest())).toEqual([]);
+  });
+
+  it('raises ONE prompt for a burst of adds from the same foreign board', async () => {
+    const provider = await mountProvider();
+
+    let first!: Promise<'added' | 'cancelled'>;
+    let second!: Promise<'added' | 'cancelled'>;
+    let third!: Promise<'added' | 'cancelled'>;
+    act(() => {
+      const { addToQueue } = provider.latest();
+      first = addToQueue(tensionItem('bulk-1'));
+      second = addToQueue(tensionItem('bulk-2'));
+      third = addToQueue(tensionItem('bulk-3'));
+    });
+    expect(dialog.choose).toHaveBeenCalledTimes(1);
+
+    await answerPrompt(0, 'add');
+    await act(async () => {
+      await expect(Promise.all([first, second, third])).resolves.toEqual(['added', 'added', 'added']);
+    });
+
+    expect(queueUuids(provider.latest())).toEqual(['bulk-1', 'bulk-2', 'bulk-3']);
+    expect(queueMutations.addQueueItem).toHaveBeenCalledTimes(3);
+  });
+
+  it('keeps an unrelated add made while the prompt is open (no stale queue snapshot)', async () => {
+    const provider = await mountProvider();
+
+    let foreign!: Promise<'added' | 'cancelled'>;
+    act(() => {
+      foreign = provider.latest().addToQueue(tensionItem('foreign'));
+    });
+    // Same-board add lands immediately, while the prompt is still up.
+    await act(async () => {
+      await provider.latest().addToQueue(kilterItem('meanwhile'));
+    });
+    expect(queueUuids(provider.latest())).toEqual(['meanwhile']);
+
+    await answerPrompt(0, 'add');
+    await expect(foreign).resolves.toBe('added');
+
+    expect(queueUuids(provider.latest())).toEqual(['meanwhile', 'foreign']);
+  });
+
+  it('never re-prompts for a board already sitting in the queue', async () => {
+    const provider = await mountProvider();
+
+    let first!: Promise<'added' | 'cancelled'>;
+    act(() => {
+      first = provider.latest().addToQueue(tensionItem('foreign-1'));
+    });
+    await answerPrompt(0, 'add');
+    await expect(first).resolves.toBe('added');
+    expect(dialog.choose).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await expect(provider.latest().addToQueue(tensionItem('foreign-2'))).resolves.toBe('added');
+    });
+
+    // deriveAcceptedConfigs saw tension:8 in the live queue — no second dialog.
+    expect(dialog.choose).toHaveBeenCalledTimes(1);
+    expect(queueUuids(provider.latest())).toEqual(['foreign-1', 'foreign-2']);
+  });
+
+  it('prompts again for a DIFFERENT foreign board', async () => {
+    const provider = await mountProvider();
+
+    let first!: Promise<'added' | 'cancelled'>;
+    act(() => {
+      first = provider.latest().addToQueue(tensionItem('tension-climb'));
+    });
+    await answerPrompt(0, 'add');
+    await expect(first).resolves.toBe('added');
+
+    let second!: Promise<'added' | 'cancelled'>;
+    act(() => {
+      second = provider.latest().addToQueue(makeQueueItem('moon-climb', { boardType: 'moonboard', layoutId: 17 }));
+    });
+    expect(dialog.choose).toHaveBeenCalledTimes(2);
+    await answerPrompt(1, 'cancel');
+    await expect(second).resolves.toBe('cancelled');
+
+    expect(queueUuids(provider.latest())).toEqual(['tension-climb']);
+  });
+});

--- a/packages/mobile/src/providers/__tests__/queue-provider-cross-board-add.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-cross-board-add.test.tsx
@@ -64,6 +64,8 @@ const boards = vi.hoisted(() => {
   };
 });
 
+const errorReporting = vi.hoisted(() => ({ reportError: vi.fn(), reportHandledError: vi.fn() }));
+
 const roster = vi.hoisted(() => ({ boards: [] as unknown[] }));
 const setActiveBoard = vi.hoisted(() => vi.fn(async (_board: unknown) => {}));
 const routerPush = vi.hoisted(() => vi.fn());
@@ -151,7 +153,7 @@ vi.mock('../../lib/graphql/use-active-board', () => ({
 }));
 vi.mock('../../lib/graphql/client', () => ({ getHttpClient: () => ({ request: http.request }) }));
 vi.mock('../../lib/analytics', () => ({ track: analytics.track }));
-vi.mock('../../lib/error-reporting', () => ({ reportError: vi.fn(), reportHandledError: vi.fn() }));
+vi.mock('../../lib/error-reporting', () => errorReporting);
 vi.mock('../toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
 vi.mock('../queue-snackbar-provider', () => ({
   useQueueSnackbar: () => ({ showQueueAddedSnackbar: snackbar.showQueueAddedSnackbar }),
@@ -234,6 +236,8 @@ describe('QueueProvider cross-board add gate', () => {
     roster.boards = [boards.kilter, boards.tension];
     setActiveBoard.mockClear();
     routerPush.mockClear();
+    errorReporting.reportHandledError.mockClear();
+    queueMutations.setSessionBoardPath.mockImplementation(async () => {});
     analytics.track.mockClear();
     snackbar.showQueueAddedSnackbar.mockClear();
     for (const mutation of Object.values(queueMutations) as Array<ReturnType<typeof vi.fn>>) {
@@ -321,6 +325,29 @@ describe('QueueProvider cross-board add gate', () => {
     // The add is the SAME synced body, not a local-only dispatch.
     expect(queueUuids(provider.latest())).toEqual(['foreign']);
     expect(queueMutations.addQueueItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a failed peer broadcast instead of splitting the party in silence', async () => {
+    queueMutations.setSessionBoardPath.mockImplementation(async () => {
+      throw new Error('join failed');
+    });
+    const provider = await mountProvider();
+
+    let pending!: Promise<'added' | 'cancelled'>;
+    act(() => {
+      pending = provider.latest().addToQueue(tensionItem('foreign'));
+    });
+    await answerPrompt(0, 'switch');
+    // The local add still succeeds — only the peers' follow is lost.
+    await expect(pending).resolves.toBe('added');
+    expect(queueUuids(provider.latest())).toEqual(['foreign']);
+
+    await waitFor(() => {
+      expect(errorReporting.reportHandledError).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({ tags: expect.objectContaining({ op: 'set-board-path-switch' }) }),
+      );
+    });
   });
 
   it('routes to the board picker and cancels the add when they do not own that board', async () => {

--- a/packages/mobile/src/providers/__tests__/queue-provider-cross-board-add.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-cross-board-add.test.tsx
@@ -65,6 +65,7 @@ const boards = vi.hoisted(() => {
 });
 
 const errorReporting = vi.hoisted(() => ({ reportError: vi.fn(), reportHandledError: vi.fn() }));
+const toast = vi.hoisted(() => ({ showToast: vi.fn() }));
 
 const roster = vi.hoisted(() => ({ boards: [] as unknown[] }));
 const setActiveBoard = vi.hoisted(() => vi.fn(async (_board: unknown) => {}));
@@ -154,7 +155,7 @@ vi.mock('../../lib/graphql/use-active-board', () => ({
 vi.mock('../../lib/graphql/client', () => ({ getHttpClient: () => ({ request: http.request }) }));
 vi.mock('../../lib/analytics', () => ({ track: analytics.track }));
 vi.mock('../../lib/error-reporting', () => errorReporting);
-vi.mock('../toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('../toast-provider', () => ({ useToast: () => ({ showToast: toast.showToast }) }));
 vi.mock('../queue-snackbar-provider', () => ({
   useQueueSnackbar: () => ({ showQueueAddedSnackbar: snackbar.showQueueAddedSnackbar }),
 }));
@@ -237,6 +238,8 @@ describe('QueueProvider cross-board add gate', () => {
     setActiveBoard.mockClear();
     routerPush.mockClear();
     errorReporting.reportHandledError.mockClear();
+    toast.showToast.mockClear();
+    setActiveBoard.mockImplementation(async () => {});
     queueMutations.setSessionBoardPath.mockImplementation(async () => {});
     analytics.track.mockClear();
     snackbar.showQueueAddedSnackbar.mockClear();
@@ -348,6 +351,36 @@ describe('QueueProvider cross-board add gate', () => {
         expect.objectContaining({ tags: expect.objectContaining({ op: 'set-board-path-switch' }) }),
       );
     });
+  });
+
+  it('cancels the add when activating the board fails, rather than rejecting into the void', async () => {
+    setActiveBoard.mockImplementation(async () => {
+      throw new Error('activation failed');
+    });
+    const provider = await mountProvider();
+
+    let pending!: Promise<'added' | 'cancelled'>;
+    act(() => {
+      // Every real call site fires this as `void addToQueue(...)`, so a
+      // rejection here would land as an unhandled rejection.
+      pending = provider.latest().addToQueue(tensionItem('foreign'));
+    });
+    await answerPrompt(0, 'switch');
+    await expect(pending).resolves.toBe('cancelled');
+
+    // The queue is still on the old board, so nothing foreign got queued onto it.
+    expect(queueUuids(provider.latest())).toEqual([]);
+    expect(queueMutations.addQueueItem).not.toHaveBeenCalled();
+    expect(queueMutations.setSessionBoardPath).not.toHaveBeenCalled();
+    expect(toast.showToast).toHaveBeenCalledWith('mobile.crossBoardAdd.switchFailed', 'error');
+    expect(errorReporting.reportHandledError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ tags: expect.objectContaining({ op: 'cross-board-switch' }) }),
+    );
+    expect(analytics.track).toHaveBeenCalledWith(
+      SHARED_EVENTS.CrossBoardQueueAddPrompted,
+      expect.objectContaining({ outcome: 'cancel' }),
+    );
   });
 
   it('routes to the board picker and cancels the add when they do not own that board', async () => {

--- a/packages/mobile/src/providers/__tests__/queue-provider-join-session-ended.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-join-session-ended.test.tsx
@@ -208,6 +208,12 @@ vi.mock('../queue-snackbar-provider', () => ({
   useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }),
 }));
 
+// The cross-board add gate calls useChoose()/useQueryClient()/expo-router, none of
+// which this harness mounts. Pass every add straight through — the gate's own
+// behaviour is covered by queue-provider-cross-board-add.test.tsx.
+vi.mock('../queue/use-cross-board-add-gate', () => ({
+  useCrossBoardAddGate: () => async () => ({ outcome: 'add' }),
+}));
 vi.mock('../party-profile-provider', () => ({
   usePartyProfile: () => ({ username: undefined, avatarUrl: undefined }),
 }));

--- a/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
@@ -102,6 +102,12 @@ vi.mock('../../lib/graphql/client', () => ({ getHttpClient: () => ({ request: ht
 vi.mock('../../lib/analytics', () => ({ track: vi.fn() }));
 vi.mock('../toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
 vi.mock('../queue-snackbar-provider', () => ({ useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }) }));
+// The cross-board add gate calls useChoose()/useQueryClient()/expo-router, none of
+// which this harness mounts. Pass every add straight through — the gate's own
+// behaviour is covered by queue-provider-cross-board-add.test.tsx.
+vi.mock('../queue/use-cross-board-add-gate', () => ({
+  useCrossBoardAddGate: () => async () => ({ outcome: 'add' }),
+}));
 vi.mock('../party-profile-provider', () => ({
   usePartyProfile: () => ({ username: undefined, avatarUrl: undefined }),
 }));

--- a/packages/mobile/src/providers/__tests__/queue-provider-local-queue.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-local-queue.test.tsx
@@ -139,6 +139,12 @@ vi.mock('../../lib/error-reporting', () => ({
 }));
 vi.mock('../toast-provider', () => ({ useToast: () => ({ showToast: toast.showToast }) }));
 vi.mock('../queue-snackbar-provider', () => ({ useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }) }));
+// The cross-board add gate calls useChoose()/useQueryClient()/expo-router, none of
+// which this harness mounts. Pass every add straight through — the gate's own
+// behaviour is covered by queue-provider-cross-board-add.test.tsx.
+vi.mock('../queue/use-cross-board-add-gate', () => ({
+  useCrossBoardAddGate: () => async () => ({ outcome: 'add' }),
+}));
 vi.mock('../party-profile-provider', () => ({
   usePartyProfile: () => ({ username: undefined, avatarUrl: undefined }),
 }));

--- a/packages/mobile/src/providers/__tests__/queue-provider-narrow-contexts.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-narrow-contexts.test.tsx
@@ -136,6 +136,12 @@ vi.mock('../../lib/error-reporting', () => ({
 }));
 vi.mock('../toast-provider', () => ({ useToast: () => ({ showToast: toast.showToast }) }));
 vi.mock('../queue-snackbar-provider', () => ({ useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }) }));
+// The cross-board add gate calls useChoose()/useQueryClient()/expo-router, none of
+// which this harness mounts. Pass every add straight through — the gate's own
+// behaviour is covered by queue-provider-cross-board-add.test.tsx.
+vi.mock('../queue/use-cross-board-add-gate', () => ({
+  useCrossBoardAddGate: () => async () => ({ outcome: 'add' }),
+}));
 vi.mock('../party-profile-provider', () => ({
   usePartyProfile: () => ({ username: undefined, avatarUrl: undefined }),
 }));

--- a/packages/mobile/src/providers/__tests__/queue-provider-regrade.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-regrade.test.tsx
@@ -97,6 +97,12 @@ vi.mock('../../lib/graphql/client', () => ({ getHttpClient: () => ({ request: ht
 vi.mock('../../lib/analytics', () => ({ track: vi.fn() }));
 vi.mock('../toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
 vi.mock('../queue-snackbar-provider', () => ({ useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }) }));
+// The cross-board add gate calls useChoose()/useQueryClient()/expo-router, none of
+// which this harness mounts. Pass every add straight through — the gate's own
+// behaviour is covered by queue-provider-cross-board-add.test.tsx.
+vi.mock('../queue/use-cross-board-add-gate', () => ({
+  useCrossBoardAddGate: () => async () => ({ outcome: 'add' }),
+}));
 vi.mock('../party-profile-provider', () => ({
   usePartyProfile: () => ({ username: undefined, avatarUrl: undefined }),
 }));

--- a/packages/mobile/src/providers/__tests__/queue-provider-resolve-climbs.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-resolve-climbs.test.tsx
@@ -97,6 +97,12 @@ vi.mock('../../lib/graphql/client', () => ({ getHttpClient: () => ({ request: ht
 vi.mock('../../lib/analytics', () => ({ track: vi.fn() }));
 vi.mock('../toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
 vi.mock('../queue-snackbar-provider', () => ({ useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }) }));
+// The cross-board add gate calls useChoose()/useQueryClient()/expo-router, none of
+// which this harness mounts. Pass every add straight through — the gate's own
+// behaviour is covered by queue-provider-cross-board-add.test.tsx.
+vi.mock('../queue/use-cross-board-add-gate', () => ({
+  useCrossBoardAddGate: () => async () => ({ outcome: 'add' }),
+}));
 vi.mock('../party-profile-provider', () => ({
   usePartyProfile: () => ({ username: undefined, avatarUrl: undefined }),
 }));

--- a/packages/mobile/src/providers/__tests__/queue-provider-seed-failure.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-seed-failure.test.tsx
@@ -199,6 +199,12 @@ vi.mock('../queue-snackbar-provider', () => ({
   useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }),
 }));
 
+// The cross-board add gate calls useChoose()/useQueryClient()/expo-router, none of
+// which this harness mounts. Pass every add straight through — the gate's own
+// behaviour is covered by queue-provider-cross-board-add.test.tsx.
+vi.mock('../queue/use-cross-board-add-gate', () => ({
+  useCrossBoardAddGate: () => async () => ({ outcome: 'add' }),
+}));
 vi.mock('../party-profile-provider', () => ({
   usePartyProfile: () => ({ username: undefined, avatarUrl: undefined }),
 }));

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -199,6 +199,12 @@ vi.mock('../queue-snackbar-provider', () => ({
   useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }),
 }));
 
+// The cross-board add gate calls useChoose()/useQueryClient()/expo-router, none of
+// which this harness mounts. Pass every add straight through — the gate's own
+// behaviour is covered by queue-provider-cross-board-add.test.tsx.
+vi.mock('../queue/use-cross-board-add-gate', () => ({
+  useCrossBoardAddGate: () => async () => ({ outcome: 'add' }),
+}));
 vi.mock('../party-profile-provider', () => ({
   usePartyProfile: () => ({ username: partyProfile.username, avatarUrl: partyProfile.avatarUrl }),
 }));

--- a/packages/mobile/src/providers/__tests__/queue-provider-sync-gate.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-sync-gate.test.tsx
@@ -190,6 +190,12 @@ vi.mock('../queue-snackbar-provider', () => ({
   useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }),
 }));
 
+// The cross-board add gate calls useChoose()/useQueryClient()/expo-router, none of
+// which this harness mounts. Pass every add straight through — the gate's own
+// behaviour is covered by queue-provider-cross-board-add.test.tsx.
+vi.mock('../queue/use-cross-board-add-gate', () => ({
+  useCrossBoardAddGate: () => async () => ({ outcome: 'add' }),
+}));
 vi.mock('../party-profile-provider', () => ({
   usePartyProfile: () => ({ username: undefined, avatarUrl: undefined }),
 }));

--- a/packages/mobile/src/providers/dialog-provider.tsx
+++ b/packages/mobile/src/providers/dialog-provider.tsx
@@ -1,7 +1,28 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import { Alert, Platform } from 'react-native';
+import { Alert, Platform, StyleSheet } from 'react-native';
 import { Button, Dialog, Portal, Text } from 'react-native-paper';
 import { useTheme } from './theme-provider';
+
+/** One action in a `choose()` prompt. Rendered in the order given. */
+export type ChooseOption<TValue extends string> = {
+  /** What `choose()` resolves to when this action is picked. */
+  value: TValue;
+  label: string;
+  /** Style as destructive (M3 error tint / iOS destructive). */
+  destructive?: boolean;
+  /** The dismissive action (iOS `cancel` style). At most one. */
+  cancel?: boolean;
+};
+
+export type ChooseOptions<TValue extends string> = {
+  title: string;
+  /** Optional supporting text under the title. */
+  message?: string;
+  /** Two or three actions, in display order. */
+  options: ReadonlyArray<ChooseOption<TValue>>;
+  /** Resolved on scrim / back / swipe dismiss — no action was picked. */
+  cancelValue: TValue;
+};
 
 export type ConfirmOptions = {
   title: string;
@@ -18,43 +39,68 @@ export type ConfirmOptions = {
 type DialogContextValue = {
   /** Resolve `true` if the user confirms, `false` on cancel / scrim / back dismiss. */
   confirm: (options: ConfirmOptions) => Promise<boolean>;
+  /** Resolve the picked option's `value`, or `cancelValue` on scrim / back dismiss. */
+  choose: <TValue extends string>(options: ChooseOptions<TValue>) => Promise<TValue>;
 };
 
 const DialogContext = createContext<DialogContextValue | null>(null);
 
-type PendingConfirm = ConfirmOptions & { id: number; resolve: (value: boolean) => void };
+// The queue is heterogeneous in its value type, so it carries the erased `string`
+// form; `choose()`'s generic signature is what callers actually see.
+type PendingChoice = ChooseOptions<string> & { id: number; resolve: (value: string) => void };
+
+const CONFIRM_VALUE = 'confirm';
+const CANCEL_VALUE = 'cancel';
+
+/** Map an option to the native Alert button style (cancel wins over destructive). */
+function alertButtonStyle(option: ChooseOption<string>): 'cancel' | 'destructive' | undefined {
+  if (option.cancel) return 'cancel';
+  if (option.destructive) return 'destructive';
+  return undefined;
+}
+
+const styles = StyleSheet.create({
+  // Three actions plus long localised labels overflow a single Material row on a
+  // narrow phone; wrapping keeps every action reachable instead of clipping one.
+  actions: { flexWrap: 'wrap' },
+});
 
 /**
- * One imperative confirm dialog for the whole app, rendered the right way per UI
+ * One imperative dialog for the whole app, rendered the right way per UI
  * variant: a Material 3 Paper `Dialog` (in a `Portal`) on Material, and the native
- * iOS `Alert` on Liquid Glass — both behind `useConfirm()`, which returns a promise
- * so callers can `if (await confirm(...))`.
+ * iOS `Alert` on Liquid Glass — behind `useConfirm()` (yes/no) and `useChoose()`
+ * (two or three named actions), which return promises so callers can
+ * `if (await confirm(...))` / `switch (await choose(...))`.
+ *
+ * `confirm` is a thin wrapper over `choose`, so the queueing, one-shot settling
+ * and per-variant rendering below have exactly one implementation.
  *
  * It's a provider (not a `createVariantComponent`) because the API is imperative
  * context, not a rendered element — and it must be reachable from other providers
- * (e.g. the Bluetooth board-config flow), not just screens. Mount it inside
- * `MaterialThemeProvider` (so the Paper `Dialog`/`Portal` has a host) and above any
- * provider that calls `confirm`. Providers are exempt from the variant guard, so the
- * `variant ===` branch here is the sanctioned place to resolve it.
+ * (e.g. the Bluetooth board-config flow, the cross-board queue gate), not just
+ * screens. Mount it inside `MaterialThemeProvider` (so the Paper `Dialog`/`Portal`
+ * has a host) and above any provider that prompts. Providers are exempt from the
+ * variant guard, so the `variant ===` branch here is the sanctioned place to
+ * resolve it.
  *
  * The Paper `Dialog` is used on **Android Material only**. On iOS we always fall back
- * to the native `Alert` — even on the Material variant — because confirms are often
+ * to the native `Alert` — even on the Material variant — because prompts are often
  * launched from a sheet rendered in a `FullWindowOverlay` (iOS-only), and the Paper
  * `Portal` lives in the normal React tree *underneath* that overlay: the dialog would
  * be invisible and its promise would never resolve. The native `Alert` always sits on
  * top. iOS Material is a forced-variant edge case, so the lost M3 chrome there is an
- * acceptable trade for a confirm that actually works.
+ * acceptable trade for a prompt that actually works.
  *
- * Concurrent confirms queue (one Android dialog shows at a time; the native Alert
- * queues itself). Each confirm settles exactly once, by id — a double-tap, or an
- * action racing `onDismiss`, can't drop a different queued confirm or leave a caller
- * awaiting forever. Scrim / back dismiss resolves `false`.
+ * Concurrent prompts queue (one Android dialog shows at a time; the native Alert
+ * queues itself). Each prompt settles exactly once, by id — a double-tap, or an
+ * action racing `onDismiss`, can't drop a different queued prompt or leave a caller
+ * awaiting forever. Scrim / back dismiss resolves `cancelValue`.
  */
 export function DialogProvider({ children }: { children: ReactNode }) {
   const { variant, m3 } = useTheme();
-  const [queue, setQueue] = useState<PendingConfirm[]>([]);
+  const [queue, setQueue] = useState<PendingChoice[]>([]);
   const idRef = useRef(0);
-  // One-shot guard: a confirm settles at most once even if its dialog fires
+  // One-shot guard: a prompt settles at most once even if its dialog fires
   // onPress and onDismiss in the same tick, or is double-tapped before re-render.
   const settledIdsRef = useRef<Set<number>>(new Set());
 
@@ -62,41 +108,62 @@ export function DialogProvider({ children }: { children: ReactNode }) {
   // the FullWindowOverlay note above). The Paper dialog queue is Android-Material only.
   const useNativeAlert = variant === 'liquidGlass' || Platform.OS === 'ios';
 
-  const confirm = useCallback(
-    (options: ConfirmOptions) =>
-      new Promise<boolean>((resolve) => {
+  const choose = useCallback(
+    <TValue extends string>(options: ChooseOptions<TValue>) =>
+      new Promise<TValue>((resolve) => {
         if (useNativeAlert) {
           Alert.alert(
             options.title,
             options.message,
-            [
-              { text: options.cancelLabel, style: 'cancel', onPress: () => resolve(false) },
-              {
-                text: options.confirmLabel,
-                style: options.destructive ? 'destructive' : 'default',
-                onPress: () => resolve(true),
-              },
-            ],
-            { onDismiss: () => resolve(false) },
+            options.options.map((option) => ({
+              text: option.label,
+              style: alertButtonStyle(option),
+              onPress: () => resolve(option.value),
+            })),
+            { onDismiss: () => resolve(options.cancelValue) },
           );
           return;
         }
+        // Snapshot the id HERE, not inside the updater: React defers a queued
+        // updater to render time, so `idRef.current` read in there would be
+        // whatever the last concurrent caller left behind — three prompts raised
+        // in one tick would share an id, and settling one would drop the others
+        // with their promises left hanging forever.
         idRef.current += 1;
-        setQueue((q) => [...q, { ...options, id: idRef.current, resolve }]);
+        const id = idRef.current;
+        setQueue((pending) => [...pending, { ...options, id, resolve: resolve as (value: string) => void }]);
       }),
     [useNativeAlert],
   );
 
-  const value = useMemo<DialogContextValue>(() => ({ confirm }), [confirm]);
+  const confirm = useCallback(
+    async (options: ConfirmOptions) => {
+      const picked = await choose({
+        title: options.title,
+        message: options.message,
+        // Cancel first: for a two-button prompt that's the established layout on
+        // both the native Alert and the Paper actions row.
+        options: [
+          { value: CANCEL_VALUE, label: options.cancelLabel, cancel: true },
+          { value: CONFIRM_VALUE, label: options.confirmLabel, destructive: options.destructive },
+        ],
+        cancelValue: CANCEL_VALUE,
+      });
+      return picked === CONFIRM_VALUE;
+    },
+    [choose],
+  );
 
-  // Resolve a SPECIFIC pending confirm by id and drop just that one from the queue.
+  const value = useMemo<DialogContextValue>(() => ({ confirm, choose }), [confirm, choose]);
+
+  // Resolve a SPECIFIC pending prompt by id and drop just that one from the queue.
   // Stable (no `current` dep) and one-shot, so racing handlers can't slice the wrong
   // entry or resolve twice.
-  const settle = useCallback((target: PendingConfirm, result: boolean) => {
+  const settle = useCallback((target: PendingChoice, result: string) => {
     if (settledIdsRef.current.has(target.id)) return;
     settledIdsRef.current.add(target.id);
     target.resolve(result);
-    setQueue((q) => q.filter((item) => item.id !== target.id));
+    setQueue((pending) => pending.filter((item) => item.id !== target.id));
   }, []);
 
   // Keep the one-shot guard bounded without a side effect in the updater above.
@@ -114,23 +181,28 @@ export function DialogProvider({ children }: { children: ReactNode }) {
   return (
     <DialogContext value={value}>
       {children}
-      {/* Only the Android-Material path ever queues a confirm; guarding on the same
+      {/* Only the Android-Material path ever queues a prompt; guarding on the same
           `!useNativeAlert` condition keeps the Paper dialog off Liquid Glass / iOS
-          even if the variant flips while a confirm is mid-flight. */}
+          even if the variant flips while a prompt is mid-flight. */}
       {!useNativeAlert && current ? (
         <Portal>
-          <Dialog visible onDismiss={() => settle(current, false)}>
+          <Dialog visible onDismiss={() => settle(current, current.cancelValue)}>
             <Dialog.Title>{current.title}</Dialog.Title>
             {current.message ? (
               <Dialog.Content>
                 <Text variant="bodyMedium">{current.message}</Text>
               </Dialog.Content>
             ) : null}
-            <Dialog.Actions>
-              <Button onPress={() => settle(current, false)}>{current.cancelLabel}</Button>
-              <Button textColor={current.destructive ? m3.error : undefined} onPress={() => settle(current, true)}>
-                {current.confirmLabel}
-              </Button>
+            <Dialog.Actions style={styles.actions}>
+              {current.options.map((option) => (
+                <Button
+                  key={option.value}
+                  textColor={option.destructive ? m3.error : undefined}
+                  onPress={() => settle(current, option.value)}
+                >
+                  {option.label}
+                </Button>
+              ))}
             </Dialog.Actions>
           </Dialog>
         </Portal>
@@ -149,4 +221,20 @@ export function useConfirm(): DialogContextValue['confirm'] {
     throw new Error('useConfirm must be used within a DialogProvider');
   }
   return ctx.confirm;
+}
+
+/**
+ * Imperative multi-choice dialog (two or three named actions). Returns a promise
+ * that resolves the picked option's `value`, or `cancelValue` when the prompt is
+ * dismissed without a pick.
+ *
+ * Throws without a provider on purpose: a nullable context that silently resolves
+ * to `null` is how PR #1633's confirm never fired on the local-session path.
+ */
+export function useChoose(): DialogContextValue['choose'] {
+  const ctx = useContext(DialogContext);
+  if (!ctx) {
+    throw new Error('useChoose must be used within a DialogProvider');
+  }
+  return ctx.choose;
 }

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -707,7 +707,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
 
   const handleBoardSheetAddToQueue = useCallback(
     (action: BoardSheetClimbAction) => {
-      addToQueue(climbToQueueItem(action.climb));
+      void addToQueue(climbToQueueItem(action.climb));
     },
     [addToQueue],
   );

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -7,6 +7,8 @@ import {
   generateClientId,
   isPlaylistPeekQueueItemUuid,
   playlistSuggestionSourceMatches,
+  decideAdd,
+  deriveAcceptedConfigs,
 } from '@boardsesh/queue';
 import type {
   QueueSearchParams,
@@ -19,7 +21,7 @@ import { useQueueMutations, type PublishPlaybackStateInput } from '@boardsesh/qu
 import type { QueueItemAttribution } from '@boardsesh/queue-react/queue-item-input';
 import type { PlaybackStateChangedEvent, SessionUser } from '@boardsesh/shared-schema';
 import { execute, isRateLimitedError } from '@boardsesh/graphql-client';
-import { buildBoardPath } from '@boardsesh/board-config';
+import { buildBoardPath, classifyClimbBoardCompatibility, toBoardName } from '@boardsesh/board-config';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { JOIN_SESSION, UPDATE_USERNAME } from '@boardsesh/graphql/operations/queue-session';
 import { getWsClient } from '../lib/graphql/ws-client';
@@ -60,6 +62,7 @@ import {
   type QueueActionsContextValue,
   type QueuePlaylistSuggestionContextValue,
 } from './queue/queue-contexts';
+import { useCrossBoardAddGate } from './queue/use-cross-board-add-gate';
 import { useQueueRegrade } from './queue/use-queue-regrade';
 import { useQueueResolveClimbs } from './queue/use-queue-resolve-climbs';
 import { useQueuePersistence } from './queue/use-queue-persistence';
@@ -301,6 +304,10 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // callbacks on every board switch — mirror it into a ref the handlers read.
   const activeBoardRef = useRef(activeBoard);
   activeBoardRef.current = activeBoard;
+
+  // "This climb is on another board — add anyway / switch / cancel". Stable
+  // identity, so `addToQueue` (and the memoized actions context) never churns.
+  const requestCrossBoardAdd = useCrossBoardAddGate();
 
   // JOIN_SESSION cache, keyed by (sessionId, connection epoch). Built once
   // per mount so its inFlight state survives re-renders. Web has a separate
@@ -796,7 +803,9 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     void resyncQueueFromServerRef.current();
   }, [state.needsResync]);
 
-  const addToQueue = useCallback(
+  // The committed half of an add. Everything here re-reads live state, so it is
+  // safe to run after an await on the cross-board prompt.
+  const commitQueueAdd = useCallback(
     (rawItem: ClimbQueueItem) => {
       // Whoever tapped "add" owns this climb — stamp identity before the dispatch
       // so the local queue and the broadcast carry the same object (#3995).
@@ -831,6 +840,53 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       showQueueAddedSnackbar();
     },
     [attributeNewItem, mutations, reconcileFailedContentMutation, showQueueAddedSnackbar],
+  );
+
+  /**
+   * Add a climb to the queue, asking first when it belongs to a board the queue
+   * isn't on (see `decideAdd` in @boardsesh/queue). This is the ONE seam every
+   * add path goes through — search rows, the climb-action sheet, the play drawer,
+   * the board sheet — so a new call site can't skip the gate.
+   *
+   * Resolves `'cancelled'` only when the climber backed out of that prompt; the
+   * same-board path never awaits anything, so a normal add costs nothing extra.
+   */
+  const addToQueue = useCallback(
+    async (rawItem: ClimbQueueItem): Promise<'added' | 'cancelled'> => {
+      const activeBoard = activeBoardRef.current;
+      const activeBoardName = activeBoard ? toBoardName(activeBoard.boardType) : null;
+      const activeConfig =
+        activeBoardName && activeBoard ? { boardName: activeBoardName, layoutId: activeBoard.layoutId } : undefined;
+      const decision = decideAdd({
+        climb: rawItem.climb,
+        activeConfig,
+        acceptedConfigKeys: deriveAcceptedConfigs(stateRef.current.queue, activeConfig),
+        classify: classifyClimbBoardCompatibility,
+      });
+
+      if (decision.kind === 'confirm') {
+        const result = await requestCrossBoardAdd({
+          climbConfigKey: decision.climbConfigKey,
+          climbBoardName: decision.climbBoardName,
+          climbLayoutId: decision.climbLayoutId,
+          activeBoardName: activeBoard?.boardType,
+        });
+        if (result.outcome === 'cancel') return 'cancelled';
+        if (result.outcome === 'switch') {
+          // The queue followed them onto the new board, so peers must too — a
+          // local-only switch would leave the session's board path (and every
+          // peer's wall) pointing at the board we just left.
+          const { boardType, layoutId, sizeId, setIds, angle } = result.board;
+          void setSessionBoardPath(buildBoardPath(boardType, layoutId, sizeId, setIds, angle)).catch((error) => {
+            if (__DEV__) console.warn('[queue] setSessionBoardPath after board switch failed', error);
+          });
+        }
+      }
+
+      commitQueueAdd(rawItem);
+      return 'added';
+    },
+    [commitQueueAdd, requestCrossBoardAdd, setSessionBoardPath],
   );
 
   const removeFromQueue = useCallback(

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -867,6 +867,15 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       const activeBoardName = activeBoard ? toBoardName(activeBoard.boardType) : null;
       const activeConfig =
         activeBoardName && activeBoard ? { boardName: activeBoardName, layoutId: activeBoard.layoutId } : undefined;
+      // `stateRef.current` is reassigned during render, so between a dispatch
+      // and its commit this reads the pre-add queue — a second add from the
+      // same foreign board inside that sub-frame window would prompt twice.
+      // Left as is on purpose: the burst case that can actually fire that fast
+      // (several taps before anyone answers) is already collapsed to one prompt
+      // by the gate's in-flight dedup, the remaining window needs a second tap
+      // within a frame of answering the dialog, and the cost if it ever lands
+      // is one extra dialog. Shadowing the accepted set in a ref would trade
+      // that for a hand-maintained mirror of reducer state that can drift.
       const decision = decideAdd({
         climb: rawItem.climb,
         activeConfig,

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -496,8 +496,18 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     // queue-adds) must not alarm: the local reducer already applied the change
     // and the WS subscription reconciles. Dev-log only — a user-facing "Action
     // failed" on a swipe-to-queue or a rapid current-climb change is noise.
+    //
+    // `setSessionBoardPath` is the exception. Nothing reconciles it: a dropped
+    // board-path broadcast leaves this climber on one wall and the rest of the
+    // party on another, indefinitely and invisibly. Report it (still no toast —
+    // the local move already succeeded and there is nothing to retry by hand).
+    // It only fires on an angle change or a board switch, so the Sentry volume
+    // stays tiny next to the per-swipe actions above.
     onBestEffortError: (action, error) => {
       if (__DEV__) console.warn(`[queue] best-effort ${action} failed`, error);
+      if (action === 'setSessionBoardPath') {
+        reportHandledError(error, { tags: { source: 'queue-sync', op: 'set-board-path' } });
+      }
     },
   });
 
@@ -877,8 +887,14 @@ export function QueueProvider({ children }: { children: ReactNode }) {
           // local-only switch would leave the session's board path (and every
           // peer's wall) pointing at the board we just left.
           const { boardType, layoutId, sizeId, setIds, angle } = result.board;
+          // The shared mutation swallows its own transport errors into
+          // `onBestEffortError` (which reports them), so what lands here is the
+          // rarer pre-send failure — ensureJoined rejecting. Report that too
+          // rather than dropping it, or a party that silently never followed
+          // the switch leaves no trace at all.
           void setSessionBoardPath(buildBoardPath(boardType, layoutId, sizeId, setIds, angle)).catch((error) => {
             if (__DEV__) console.warn('[queue] setSessionBoardPath after board switch failed', error);
+            reportHandledError(error, { tags: { source: 'queue-sync', op: 'set-board-path-switch' } });
           });
         }
       }

--- a/packages/mobile/src/providers/queue/queue-contexts.ts
+++ b/packages/mobile/src/providers/queue/queue-contexts.ts
@@ -34,7 +34,13 @@ type QueueContextValue = {
    * the lightbulb's lit indicator; the current climb is never cleared by either.
    */
   isSessionWallLit: boolean;
-  addToQueue: (item: ClimbQueueItem) => void;
+  /**
+   * Queue a climb. Resolves `'cancelled'` when the climb belongs to another
+   * board and the climber backed out of the cross-board prompt — callers that
+   * sequence something on the add (activating the climb, closing a sheet)
+   * should await it; fire-and-forget callers can `void` it.
+   */
+  addToQueue: (item: ClimbQueueItem) => Promise<'added' | 'cancelled'>;
   removeFromQueue: (uuid: string) => void;
   reorderQueue: (uuid: string, oldIndex: number, newIndex: number) => void;
   clearQueue: () => void;

--- a/packages/mobile/src/providers/queue/use-cross-board-add-gate.ts
+++ b/packages/mobile/src/providers/queue/use-cross-board-add-gate.ts
@@ -10,6 +10,8 @@ import { useSetActiveBoard } from '../../lib/graphql/use-active-board';
 import { myBoardsQueryKey } from '../../lib/graphql/query-keys';
 import type { GetMyBoardsQueryResponse } from '../../lib/graphql/operations';
 import { track } from '../../lib/analytics';
+import { reportHandledError } from '../../lib/error-reporting';
+import { useToast } from '../toast-provider';
 import { useChoose } from '../dialog-provider';
 
 /** What the climber picked, plus what the app has to do about it. */
@@ -59,6 +61,7 @@ const MY_BOARDS_QUERY_KEY = myBoardsQueryKey();
 export function useCrossBoardAddGate(): (request: CrossBoardAddRequest) => Promise<CrossBoardAddResult> {
   const { t } = useTranslation('climbs');
   const choose = useChoose();
+  const { showToast } = useToast();
   const setActiveBoard = useSetActiveBoard();
   const queryClient = useQueryClient();
   const inFlightRef = useRef<Map<string, Promise<CrossBoardAddResult>>>(new Map());
@@ -108,11 +111,25 @@ export function useCrossBoardAddGate(): (request: CrossBoardAddRequest) => Promi
         return { outcome: 'cancel' };
       }
 
+      try {
+        await setActiveBoard(owned);
+      } catch (error) {
+        // The activation mutation failed, so the queue is still on the old
+        // board. Queueing the climb now would drop a foreign climb onto it —
+        // exactly what the prompt exists to prevent — and letting the rejection
+        // through would surface as an unhandled rejection, because every add
+        // path fires this as `void addToQueue(...)`. Back out and say so; the
+        // switch is theirs to retry.
+        reportHandledError(error, { tags: { source: 'queue-sync', op: 'cross-board-switch' } });
+        showToast(t('mobile.crossBoardAdd.switchFailed', { board: boardLabel }), 'error');
+        trackOutcome('cancel');
+        return { outcome: 'cancel' };
+      }
+
       trackOutcome('switch');
-      await setActiveBoard(owned);
       return { outcome: 'switch', board: owned };
     },
-    [choose, queryClient, setActiveBoard, t],
+    [choose, queryClient, setActiveBoard, showToast, t],
   );
 
   return useCallback(

--- a/packages/mobile/src/providers/queue/use-cross-board-add-gate.ts
+++ b/packages/mobile/src/providers/queue/use-cross-board-add-gate.ts
@@ -1,0 +1,128 @@
+import { useCallback, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
+import { router } from 'expo-router';
+import { formatBoardDisplayName } from '@boardsesh/board-config';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { boardLooselyMatches } from '../../lib/boards/board-matches';
+import { useSetActiveBoard } from '../../lib/graphql/use-active-board';
+import type { GetMyBoardsQueryResponse } from '../../lib/graphql/operations';
+import { track } from '../../lib/analytics';
+import { useChoose } from '../dialog-provider';
+
+/** What the climber picked, plus what the app has to do about it. */
+export type CrossBoardAddResult =
+  /** Queue it on the board they're already on — the queue goes mixed. */
+  | { outcome: 'add' }
+  /** The active board is now `board`; queue the climb on it. */
+  | { outcome: 'switch'; board: UserBoard }
+  /** Don't queue anything (also covers "they were sent to the board picker"). */
+  | { outcome: 'cancel' };
+
+export type CrossBoardAddRequest = {
+  /** From `decideAdd` — the in-flight key, so one prompt covers a bulk add. */
+  climbConfigKey: string;
+  climbBoardName: string;
+  climbLayoutId: number;
+  /** For analytics only: the board the queue is currently on. */
+  activeBoardName?: string;
+};
+
+type ChoiceValue = 'add' | 'switch' | 'cancel';
+
+// `useMyBoards()` caches under ['myBoards', input] with input undefined for the
+// roster fetch drawer-host-provider keeps warm. Read it at tap time rather than
+// subscribing, so QueueProvider doesn't re-render on roster churn.
+const MY_BOARDS_QUERY_KEY = ['myBoards', undefined] as const;
+
+/**
+ * The prompt behind a cross-board queue add: "this climb is on another board —
+ * add it anyway, switch to that board, or cancel?"
+ *
+ * Three things live here rather than in QueueProvider:
+ *
+ * - **One prompt per board, not per climb.** Adds are keyed by
+ *   `climbConfigKey` while a prompt is open, so queueing eight climbs from the
+ *   same foreign board raises one dialog and all eight awaiters settle on its
+ *   answer.
+ * - **Board names are trademark-correct.** `formatBoardDisplayName` renders
+ *   "MoonBoard", never the `charAt(0).toUpperCase()` "Moonboard".
+ * - **Switching keeps the board's own angle.** It mirrors
+ *   `handleSwitchBoardFromDrawer`: activate the owned board as stored (never a
+ *   synthesised angle 0), or route to the board picker when the climber doesn't
+ *   own that board yet — which resolves `cancel`, since nothing can be queued
+ *   against a board they haven't set up.
+ */
+export function useCrossBoardAddGate(): (request: CrossBoardAddRequest) => Promise<CrossBoardAddResult> {
+  const { t } = useTranslation('climbs');
+  const choose = useChoose();
+  const setActiveBoard = useSetActiveBoard();
+  const queryClient = useQueryClient();
+  const inFlightRef = useRef<Map<string, Promise<CrossBoardAddResult>>>(new Map());
+
+  const runPrompt = useCallback(
+    async (request: CrossBoardAddRequest): Promise<CrossBoardAddResult> => {
+      const boardLabel = formatBoardDisplayName(request.climbBoardName);
+      const picked = await choose<ChoiceValue>({
+        title: t('mobile.crossBoardAdd.title', { board: boardLabel }),
+        message: t('mobile.crossBoardAdd.message', { board: boardLabel }),
+        options: [
+          { value: 'add', label: t('mobile.crossBoardAdd.addAnyway') },
+          { value: 'switch', label: t('mobile.crossBoardAdd.switchBoard', { board: boardLabel }) },
+          { value: 'cancel', label: t('mobile.crossBoardAdd.cancel'), cancel: true },
+        ],
+        cancelValue: 'cancel',
+      });
+
+      const trackOutcome = (outcome: ChoiceValue) => {
+        track(SHARED_EVENTS.CrossBoardQueueAddPrompted, {
+          outcome,
+          activeBoardName: request.activeBoardName,
+          climbBoardName: request.climbBoardName,
+          climbLayoutId: request.climbLayoutId,
+        });
+      };
+
+      if (picked !== 'switch') {
+        trackOutcome(picked);
+        return picked === 'add' ? { outcome: 'add' } : { outcome: 'cancel' };
+      }
+
+      const owned = queryClient
+        .getQueryData<GetMyBoardsQueryResponse>(MY_BOARDS_QUERY_KEY)
+        ?.myBoards.boards.find((board) =>
+          boardLooselyMatches(
+            { boardName: board.boardType, layoutId: board.layoutId },
+            { boardName: request.climbBoardName, layoutId: request.climbLayoutId },
+          ),
+        );
+
+      if (!owned) {
+        // They don't have that board set up (or the roster hasn't loaded).
+        // Send them to the picker; there's nothing to queue against yet.
+        trackOutcome('cancel');
+        router.push('/boards');
+        return { outcome: 'cancel' };
+      }
+
+      trackOutcome('switch');
+      await setActiveBoard(owned);
+      return { outcome: 'switch', board: owned };
+    },
+    [choose, queryClient, setActiveBoard, t],
+  );
+
+  return useCallback(
+    (request: CrossBoardAddRequest) => {
+      const existing = inFlightRef.current.get(request.climbConfigKey);
+      if (existing) return existing;
+      const pending = runPrompt(request).finally(() => {
+        inFlightRef.current.delete(request.climbConfigKey);
+      });
+      inFlightRef.current.set(request.climbConfigKey, pending);
+      return pending;
+    },
+    [runPrompt],
+  );
+}

--- a/packages/mobile/src/providers/queue/use-cross-board-add-gate.ts
+++ b/packages/mobile/src/providers/queue/use-cross-board-add-gate.ts
@@ -7,6 +7,7 @@ import { SHARED_EVENTS } from '@boardsesh/analytics';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { boardLooselyMatches } from '../../lib/boards/board-matches';
 import { useSetActiveBoard } from '../../lib/graphql/use-active-board';
+import { myBoardsQueryKey } from '../../lib/graphql/query-keys';
 import type { GetMyBoardsQueryResponse } from '../../lib/graphql/operations';
 import { track } from '../../lib/analytics';
 import { useChoose } from '../dialog-provider';
@@ -31,10 +32,11 @@ export type CrossBoardAddRequest = {
 
 type ChoiceValue = 'add' | 'switch' | 'cancel';
 
-// `useMyBoards()` caches under ['myBoards', input] with input undefined for the
-// roster fetch drawer-host-provider keeps warm. Read it at tap time rather than
-// subscribing, so QueueProvider doesn't re-render on roster churn.
-const MY_BOARDS_QUERY_KEY = ['myBoards', undefined] as const;
+// The roster drawer-host-provider keeps warm is `useMyBoards()` — no input. Key
+// it through the same helper that hook keys its query with, so the two can't
+// drift. Read at tap time rather than subscribed, so QueueProvider doesn't
+// re-render on roster churn.
+const MY_BOARDS_QUERY_KEY = myBoardsQueryKey();
 
 /**
  * The prompt behind a cross-board queue add: "this climb is on another board —

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -27,6 +27,12 @@ export const SHARED_EVENTS = {
   // Queue / session
   AddToQueue: 'Add to Queue',
   ClimbAddedToQueue: 'Climb Added to Queue',
+  // A climb from a DIFFERENT board than the queue is on was tapped, so the
+  // cross-board prompt was raised. Props: { outcome: 'add' | 'switch' | 'cancel',
+  // activeBoardName?, climbBoardName, climbLayoutId }. The outcome split is the
+  // signal: mostly `switch` means people keep landing on the wrong board first;
+  // mostly `cancel` means the prompt is firing where it isn't wanted.
+  CrossBoardQueueAddPrompted: 'Cross Board Queue Add Prompted',
   ClimbRemovedFromQueue: 'Climb Removed from Queue',
   QueueReordered: 'Queue Reordered',
   QueueCleared: 'Queue Cleared',

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -930,6 +930,7 @@
       "message": "Deine Warteschlange läuft auf einem anderen Board. Füge ihn trotzdem hinzu, dann wartet er dort, bis du auf {{board}} bist, oder wechsle jetzt.",
       "addAnyway": "Trotzdem hinzufügen",
       "switchBoard": "Zu {{board}} wechseln",
+      "switchFailed": "Wechsel zu {{board}} hat nicht geklappt. Versuch es nochmal.",
       "cancel": "Abbrechen"
     }
   }

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -924,6 +924,13 @@
         "bottomRight": "Ecke unten rechts",
         "hint": "Wisch nach oben oder unten, um den Bereich von dieser Ecke aus zu vergrößern oder zu verkleinern."
       }
+    },
+    "crossBoardAdd": {
+      "title": "Dieser Boulder ist auf {{board}}",
+      "message": "Deine Warteschlange läuft auf einem anderen Board. Füge ihn trotzdem hinzu, dann wartet er dort, bis du auf {{board}} bist, oder wechsle jetzt.",
+      "addAnyway": "Trotzdem hinzufügen",
+      "switchBoard": "Zu {{board}} wechseln",
+      "cancel": "Abbrechen"
     }
   }
 }

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -930,6 +930,7 @@
       "message": "Your queue is on a different board. Add it anyway and it waits there until you're on {{board}}, or switch over now.",
       "addAnyway": "Add anyway",
       "switchBoard": "Switch to {{board}}",
+      "switchFailed": "Couldn't switch to {{board}}. Try again.",
       "cancel": "Cancel"
     }
   }

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -924,6 +924,13 @@
         "bottomRight": "Bottom-right corner",
         "hint": "Swipe up or down to grow or shrink the region from this corner."
       }
+    },
+    "crossBoardAdd": {
+      "title": "This climb is on {{board}}",
+      "message": "Your queue is on a different board. Add it anyway and it waits there until you're on {{board}}, or switch over now.",
+      "addAnyway": "Add anyway",
+      "switchBoard": "Switch to {{board}}",
+      "cancel": "Cancel"
     }
   }
 }

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -924,6 +924,13 @@
         "bottomRight": "Esquina inferior derecha",
         "hint": "Desliza hacia arriba o abajo para agrandar o reducir la zona desde esta esquina."
       }
+    },
+    "crossBoardAdd": {
+      "title": "Este bloque es de {{board}}",
+      "message": "Tu cola está en otro plafón. Añádelo igual y se queda esperando hasta que estés en {{board}}, o cámbiate ahora.",
+      "addAnyway": "Añadir igual",
+      "switchBoard": "Cambiar a {{board}}",
+      "cancel": "Cancelar"
     }
   }
 }

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -930,6 +930,7 @@
       "message": "Tu cola está en otro plafón. Añádelo igual y se queda esperando hasta que estés en {{board}}, o cámbiate ahora.",
       "addAnyway": "Añadir igual",
       "switchBoard": "Cambiar a {{board}}",
+      "switchFailed": "No se pudo cambiar a {{board}}. Inténtalo de nuevo.",
       "cancel": "Cancelar"
     }
   }

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -924,6 +924,13 @@
         "bottomRight": "Coin inférieur droit",
         "hint": "Balayez vers le haut ou le bas pour agrandir ou réduire la zone depuis ce coin."
       }
+    },
+    "crossBoardAdd": {
+      "title": "Ce bloc est sur {{board}}",
+      "message": "Ta file d'attente est sur une autre board. Ajoute-le quand même et il t'attendra jusqu'à ce que tu sois sur {{board}}, ou change de board maintenant.",
+      "addAnyway": "Ajouter quand même",
+      "switchBoard": "Passer sur {{board}}",
+      "cancel": "Annuler"
     }
   }
 }

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -930,6 +930,7 @@
       "message": "Ta file d'attente est sur une autre board. Ajoute-le quand même et il t'attendra jusqu'à ce que tu sois sur {{board}}, ou change de board maintenant.",
       "addAnyway": "Ajouter quand même",
       "switchBoard": "Passer sur {{board}}",
+      "switchFailed": "Impossible de passer sur {{board}}. Réessaie.",
       "cancel": "Annuler"
     }
   }

--- a/packages/shared/queue-react/src/create-queue-mutations.ts
+++ b/packages/shared/queue-react/src/create-queue-mutations.ts
@@ -57,6 +57,22 @@ export type PublishPlaybackStateInput = {
 
 const NOT_CONNECTED = 'Not connected to session';
 
+/**
+ * Every action whose transport error is swallowed here and handed to
+ * `onBestEffortError`. A union rather than `string` because callers legitimately
+ * branch on it — mobile reports `setSessionBoardPath` failures and dev-logs the
+ * rest — and a bare `string` would let a rename here silently turn such a branch
+ * into dead code.
+ */
+export type BestEffortAction =
+  | 'setCurrentClimb'
+  | 'addQueueItem'
+  | 'publishPlaybackState'
+  | 'confirmClimbOnWall'
+  | 'reportWallDisconnect'
+  | 'setSessionBoardSerial'
+  | 'setSessionBoardPath';
+
 export type QueueMutationsDeps<TItem> = {
   /** Live GraphQL client getter (web: clientRef.current; mobile: getWsClient()). */
   getClient: () => Client | null;
@@ -94,7 +110,7 @@ export type QueueMutationsDeps<TItem> = {
    */
   ensureReady?: (capturedSessionId: string | null) => Promise<string | null>;
   /** Sink for swallowed transport errors (best-effort actions + coalescer drains). */
-  onBestEffortError?: (action: string, error: unknown) => void;
+  onBestEffortError?: (action: BestEffortAction, error: unknown) => void;
   /**
    * Notified when a queue mutation is throttled and `execute` is backing off to
    * retry it (not on the final give-up). Web wires a debounced "catching up"

--- a/packages/shared/queue-react/src/index.ts
+++ b/packages/shared/queue-react/src/index.ts
@@ -8,7 +8,12 @@
 
 export { useQueueMutations } from './use-queue-mutations';
 export { createQueueMutations } from './create-queue-mutations';
-export type { QueueMutationsActions, QueueMutationsDeps, PublishPlaybackStateInput } from './create-queue-mutations';
+export type {
+  QueueMutationsActions,
+  QueueMutationsDeps,
+  PublishPlaybackStateInput,
+  BestEffortAction,
+} from './create-queue-mutations';
 // Re-exported for discoverability only. Consumers import the dedicated
 // `@boardsesh/queue-react/queue-item-input` subpath instead: nine mobile provider
 // suites whole-module-mock this barrel, and a barrel import of the mapper would

--- a/packages/shared/queue/src/__tests__/cross-board.test.ts
+++ b/packages/shared/queue/src/__tests__/cross-board.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  configKey,
+  climbConfigKey,
+  deriveAcceptedConfigs,
+  decideAdd,
+  type ClimbBoardCompatibility,
+  type ClimbBoardIdentityLike,
+} from '../cross-board';
+
+const KILTER = { boardName: 'kilter', layoutId: 1 };
+
+function climbItem(boardType?: string | null, layoutId?: number | null) {
+  return { climb: { boardType, layoutId } };
+}
+
+function classifyStub(result: ClimbBoardCompatibility) {
+  return vi.fn(() => result);
+}
+
+describe('configKey / climbConfigKey', () => {
+  it('keys a board by name + layout only (size and sets are deliberately excluded)', () => {
+    expect(configKey(KILTER)).toBe('kilter:1');
+    expect(configKey({ boardName: 'kilter', layoutId: 8 })).toBe('kilter:8');
+    expect(configKey({ boardName: 'tension', layoutId: 1 })).toBe('tension:1');
+  });
+
+  it('is stable across calls with an equal-but-not-identical config', () => {
+    expect(configKey({ ...KILTER })).toBe(configKey(KILTER));
+  });
+
+  it('reads a climb key only when BOTH board name and layout are present', () => {
+    expect(climbConfigKey({ boardType: 'tension', layoutId: 10 })).toBe('tension:10');
+    expect(climbConfigKey({})).toBeNull();
+    expect(climbConfigKey({ boardType: 'tension' })).toBeNull();
+    expect(climbConfigKey({ layoutId: 10 })).toBeNull();
+    expect(climbConfigKey({ boardType: '', layoutId: 10 })).toBeNull();
+    expect(climbConfigKey({ boardType: 'tension', layoutId: null })).toBeNull();
+  });
+
+  it('treats layout 0 as a real layout, not a missing one', () => {
+    expect(climbConfigKey({ boardType: 'kilter', layoutId: 0 })).toBe('kilter:0');
+  });
+});
+
+describe('deriveAcceptedConfigs', () => {
+  it('is empty for an empty queue with no active board', () => {
+    expect([...deriveAcceptedConfigs([])]).toEqual([]);
+  });
+
+  it('holds only the active board for an empty queue', () => {
+    expect([...deriveAcceptedConfigs([], KILTER)]).toEqual(['kilter:1']);
+  });
+
+  it('ignores queue items with no usable board metadata', () => {
+    const accepted = deriveAcceptedConfigs([climbItem(), climbItem('kilter'), climbItem(null, 1)]);
+    expect([...accepted]).toEqual([]);
+  });
+
+  it('collects every distinct board already in a mixed queue, plus the active board', () => {
+    const accepted = deriveAcceptedConfigs(
+      [climbItem('kilter', 1), climbItem('tension', 10), climbItem('tension', 10), climbItem('moonboard', 17)],
+      KILTER,
+    );
+    expect([...accepted].sort()).toEqual(['kilter:1', 'moonboard:17', 'tension:10']);
+  });
+
+  it('still collects the queue boards when no active board is set', () => {
+    const accepted = deriveAcceptedConfigs([climbItem('tension', 10)]);
+    expect([...accepted]).toEqual(['tension:10']);
+  });
+});
+
+describe('decideAdd', () => {
+  const foreignClimb: ClimbBoardIdentityLike = { boardType: 'tension', layoutId: 10 };
+
+  it('adds a compatible climb without consulting the accepted set', () => {
+    const classify = classifyStub('compatible');
+    expect(
+      decideAdd({
+        climb: { boardType: 'kilter', layoutId: 1 },
+        activeConfig: KILTER,
+        acceptedConfigKeys: new Set(),
+        classify,
+      }),
+    ).toEqual({ kind: 'add', reason: 'compatible' });
+    expect(classify).toHaveBeenCalledTimes(1);
+  });
+
+  it('adds a climb with no board signal rather than blocking on missing metadata', () => {
+    expect(
+      decideAdd({ climb: {}, activeConfig: KILTER, acceptedConfigKeys: new Set(), classify: classifyStub('unknown') }),
+    ).toEqual({ kind: 'add', reason: 'unknown' });
+  });
+
+  it('confirms a foreign-board climb the queue has never accepted', () => {
+    expect(
+      decideAdd({
+        climb: foreignClimb,
+        activeConfig: KILTER,
+        acceptedConfigKeys: new Set(['kilter:1']),
+        classify: classifyStub('incompatible'),
+      }),
+    ).toEqual({ kind: 'confirm', climbConfigKey: 'tension:10', climbBoardName: 'tension', climbLayoutId: 10 });
+  });
+
+  it('short-circuits to add when that board is already in the queue (no second prompt)', () => {
+    expect(
+      decideAdd({
+        climb: foreignClimb,
+        activeConfig: KILTER,
+        acceptedConfigKeys: new Set(['kilter:1', 'tension:10']),
+        classify: classifyStub('incompatible'),
+      }),
+    ).toEqual({ kind: 'add', reason: 'already-mixed' });
+  });
+
+  it('adds an incompatible climb we cannot name (half-known metadata) instead of prompting', () => {
+    // There would be nothing to put in the prompt and nothing to remember
+    // afterwards, so a prompt here could only repeat forever.
+    expect(
+      decideAdd({
+        climb: { boardType: 'tension' },
+        activeConfig: KILTER,
+        acceptedConfigKeys: new Set(),
+        classify: classifyStub('incompatible'),
+      }),
+    ).toEqual({ kind: 'add', reason: 'unknown' });
+  });
+
+  it('passes the active config straight through to the injected classifier', () => {
+    const classify = classifyStub('compatible');
+    decideAdd({ climb: foreignClimb, activeConfig: KILTER, acceptedConfigKeys: new Set(), classify });
+    expect(classify).toHaveBeenCalledWith(KILTER, foreignClimb);
+  });
+
+  it('accepts a classifier typed with a NARROWER board union (contravariance contract)', () => {
+    // `classifyClimbBoardCompatibility` in @boardsesh/board-config declares its
+    // active board as `{ boardName: BoardName; layoutId: number }`. This package
+    // can't import it (dependencies: {} on purpose), so pin the same shape here:
+    // if `decideAdd` stopped being generic over the board type, this stops
+    // compiling under strictFunctionTypes.
+    type BoardName = 'kilter' | 'tension' | 'moonboard';
+    const realShapeClassify = (
+      activeConfig: { boardName: BoardName; layoutId: number } | undefined,
+      climb: ClimbBoardIdentityLike,
+    ): ClimbBoardCompatibility => {
+      if (!activeConfig) return 'unknown';
+      if (climb.boardType == null && climb.layoutId == null) return 'unknown';
+      if (climb.boardType != null && climb.boardType !== activeConfig.boardName) return 'incompatible';
+      if (climb.layoutId != null && climb.layoutId !== activeConfig.layoutId) return 'incompatible';
+      return 'compatible';
+    };
+    const activeConfig = { boardName: 'kilter' as BoardName, layoutId: 1 };
+
+    expect(
+      decideAdd({
+        climb: { boardType: 'kilter', layoutId: 1 },
+        activeConfig,
+        acceptedConfigKeys: new Set(),
+        classify: realShapeClassify,
+      }),
+    ).toEqual({ kind: 'add', reason: 'compatible' });
+
+    expect(
+      decideAdd({
+        climb: foreignClimb,
+        activeConfig,
+        acceptedConfigKeys: deriveAcceptedConfigs([], activeConfig),
+        classify: realShapeClassify,
+      }),
+    ).toEqual({ kind: 'confirm', climbConfigKey: 'tension:10', climbBoardName: 'tension', climbLayoutId: 10 });
+  });
+
+  it('adds without a prompt when no board is active (nothing to be foreign to)', () => {
+    expect(
+      decideAdd({
+        climb: foreignClimb,
+        activeConfig: undefined,
+        acceptedConfigKeys: deriveAcceptedConfigs([]),
+        classify: classifyStub('unknown'),
+      }),
+    ).toEqual({ kind: 'add', reason: 'unknown' });
+  });
+});

--- a/packages/shared/queue/src/cross-board.ts
+++ b/packages/shared/queue/src/cross-board.ts
@@ -1,0 +1,129 @@
+/**
+ * Cross-board queue decisions: should adding this climb raise a "that's a
+ * different board" prompt, or just go in?
+ *
+ * A queue is allowed to hold climbs from more than one board — the BLE senders
+ * already skip an item that doesn't match the connected wall instead of
+ * dark-firing it (`classifyClimbBoardCompatibility` /
+ * `findNextCompatibleQueueItem` in `@boardsesh/board-config`). What was missing
+ * is the deliberate act: the climber says "yes, queue it anyway" (or "switch me
+ * to that board") instead of a foreign climb landing silently.
+ *
+ * Two deliberate design choices:
+ *
+ * 1. **The compatibility classifier is injected.** This package has
+ *    `dependencies: {}` on purpose (the backend imports it), so it must not
+ *    grow a `@boardsesh/board-config` edge. Callers pass
+ *    `classifyClimbBoardCompatibility` in, the same way `createPlaylistSuggestionSource`
+ *    takes an injected `isClimbable`.
+ * 2. **"Add anyway" is remembered by queue contents, not by extra state.**
+ *    `deriveAcceptedConfigs` reads the boards already represented in the live
+ *    queue, so the second climb from a board you just accepted never re-prompts.
+ *    Remove the last climb from that board and the next add prompts again —
+ *    that is the trade for having no acceptance flag that can go stale against
+ *    a party-synced queue.
+ *
+ * `configKey` is board MODEL identity (board name + layout) only. A `Climb`
+ * carries no size, so a same-layout/different-size mismatch can't be seen from
+ * queue metadata at all; `canAddClimbToBoard`'s hold-ID containment already
+ * catches that at send time.
+ */
+
+/** The active board's model identity — what a queue is "on". */
+export type QueueBoardIdentity = {
+  boardName: string;
+  layoutId: number;
+};
+
+/** The climb fields carrying board identity. Both are optional on most fetch paths. */
+export type ClimbBoardIdentityLike = {
+  boardType?: string | null;
+  layoutId?: number | null;
+};
+
+/** Mirrors `ClimbBoardCompatibility` in `@boardsesh/board-config` (injected, not imported). */
+export type ClimbBoardCompatibility = 'compatible' | 'incompatible' | 'unknown';
+
+/** Stable string identity for a board model. Board name + layout, nothing else. */
+export function configKey(config: QueueBoardIdentity): string {
+  return `${config.boardName}:${config.layoutId}`;
+}
+
+/**
+ * The board-model key a climb belongs to, or `null` when it carries no usable
+ * board signal. Both halves are required: a climb with a board name but no
+ * layout can't be pinned to a board model, and treating it as its own key would
+ * let a half-known climb silently widen the accepted set.
+ */
+export function climbConfigKey(climb: ClimbBoardIdentityLike): string | null {
+  if (!climb.boardType || climb.layoutId == null) return null;
+  return configKey({ boardName: climb.boardType, layoutId: climb.layoutId });
+}
+
+/**
+ * Every board model the queue is already known to hold, plus the active board.
+ * A climb whose key is in here has been accepted into this queue once already,
+ * so adding another of its siblings needs no second prompt.
+ */
+export function deriveAcceptedConfigs(
+  queue: ReadonlyArray<{ climb: ClimbBoardIdentityLike }>,
+  activeConfig?: QueueBoardIdentity,
+): ReadonlySet<string> {
+  const accepted = new Set<string>();
+  if (activeConfig) accepted.add(configKey(activeConfig));
+  for (const item of queue) {
+    const key = climbConfigKey(item.climb);
+    if (key) accepted.add(key);
+  }
+  return accepted;
+}
+
+/** Add it now, and why — `already-mixed` means this board is already in the queue. */
+export type AddDecision =
+  | { kind: 'add'; reason: 'compatible' | 'unknown' | 'already-mixed' }
+  | { kind: 'confirm'; climbConfigKey: string; climbBoardName: string; climbLayoutId: number };
+
+export type DecideAddInput<TBoard extends QueueBoardIdentity> = {
+  climb: ClimbBoardIdentityLike;
+  /** The board the queue is on. `undefined` when the climber hasn't picked one. */
+  activeConfig: TBoard | undefined;
+  /** From `deriveAcceptedConfigs`. */
+  acceptedConfigKeys: ReadonlySet<string>;
+  /** Injected — pass `classifyClimbBoardCompatibility` from `@boardsesh/board-config`. */
+  classify: (activeConfig: TBoard | undefined, climb: ClimbBoardIdentityLike) => ClimbBoardCompatibility;
+};
+
+/**
+ * Decide whether an add needs the cross-board prompt.
+ *
+ * - `compatible` / `unknown` → add, no prompt. Never block on missing metadata:
+ *   older queue items and party-synced climbs legitimately have none.
+ * - `incompatible` but the climb's board is already in the queue → add, no
+ *   prompt (the climber already said yes to this board).
+ * - `incompatible` and unrecognised board metadata (no `climbConfigKey`) → add.
+ *   We'd have nothing to name in the prompt or remember afterwards.
+ * - otherwise → confirm.
+ *
+ * `TBoard` is generic so a caller whose active board is typed with the narrower
+ * `BoardName` union can still hand in `classifyClimbBoardCompatibility` under
+ * `strictFunctionTypes` parameter contravariance.
+ */
+export function decideAdd<TBoard extends QueueBoardIdentity>({
+  climb,
+  activeConfig,
+  acceptedConfigKeys,
+  classify,
+}: DecideAddInput<TBoard>): AddDecision {
+  const compatibility = classify(activeConfig, climb);
+  if (compatibility === 'compatible') return { kind: 'add', reason: 'compatible' };
+  if (compatibility === 'unknown') return { kind: 'add', reason: 'unknown' };
+
+  const climbBoardName = climb.boardType;
+  const climbLayoutId = climb.layoutId;
+  if (!climbBoardName || climbLayoutId == null) return { kind: 'add', reason: 'unknown' };
+
+  const key = configKey({ boardName: climbBoardName, layoutId: climbLayoutId });
+  if (acceptedConfigKeys.has(key)) return { kind: 'add', reason: 'already-mixed' };
+
+  return { kind: 'confirm', climbConfigKey: key, climbBoardName, climbLayoutId };
+}

--- a/packages/shared/queue/src/index.ts
+++ b/packages/shared/queue/src/index.ts
@@ -37,6 +37,17 @@ export {
 } from './playlist-suggestions';
 export type { QueueBoardKeyTarget } from './playlist-suggestions';
 
+// Cross-board queue decisions (board-model identity + the add/confirm call).
+// The compatibility classifier is injected so this package stays dependency-free.
+export { configKey, climbConfigKey, deriveAcceptedConfigs, decideAdd } from './cross-board';
+export type {
+  QueueBoardIdentity,
+  ClimbBoardIdentityLike,
+  ClimbBoardCompatibility,
+  AddDecision,
+  DecideAddInput,
+} from './cross-board';
+
 export {
   createQueueSyncCoordinator,
   mapQueueEventToAction,

--- a/packages/web/app/components/board-lock/board-switch-confirm-provider.tsx
+++ b/packages/web/app/components/board-lock/board-switch-confirm-provider.tsx
@@ -10,7 +10,7 @@ import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
 import type { BoardDetails, BoardRouteIdentity } from '@/app/lib/types';
 import type { BoardLockReason } from './use-active-board-lock';
-import { capitalizeFirst } from '@/app/lib/string-utils';
+import { formatBoardDisplayName } from '@/app/lib/string-utils';
 
 type ConfirmArgs = {
   reason: BoardLockReason;
@@ -37,7 +37,7 @@ export function useBoardSwitchConfirm(): BoardSwitchConfirmContextValue | null {
 }
 
 function formatBoardLabel(board: BoardDetails | BoardRouteIdentity): string {
-  const parts = [capitalizeFirst(board.board_name)];
+  const parts = [formatBoardDisplayName(board.board_name)];
   if (board.layout_name) parts.push(board.layout_name);
   if (board.size_name) parts.push(board.size_name);
   return parts.join(' · ');

--- a/packages/web/app/components/board-lock/queue-add-error-messages.ts
+++ b/packages/web/app/components/board-lock/queue-add-error-messages.ts
@@ -1,16 +1,16 @@
 import type { Climb, BoardDetails } from '@/app/lib/types';
 import type { BoardCompatibilityResult } from '@/app/lib/board-compatibility';
-import { capitalizeFirst } from '@/app/lib/string-utils';
+import { formatBoardDisplayName } from '@/app/lib/string-utils';
 
 type QueueAddFailure = Extract<BoardCompatibilityResult, { ok: false }>;
 
 function climbBoardLabel(climb: Climb): string {
-  if (climb.boardType) return capitalizeFirst(climb.boardType);
+  if (climb.boardType) return formatBoardDisplayName(climb.boardType);
   return 'a different board';
 }
 
 function targetBoardLabel(target: BoardDetails): string {
-  return capitalizeFirst(target.board_name);
+  return formatBoardDisplayName(target.board_name);
 }
 
 function targetSizeLabel(target: BoardDetails): string {


### PR DESCRIPTION
## Summary

Queueing a climb that belongs to a **different board than your queue is on** now
asks first: **Add anyway / Switch to \<Board\> / Cancel**. Until now a foreign-board
climb landed in the queue silently — tolerated end to end (the BLE sender already
skips a mismatched climb rather than dark-firing the wall), but never a deliberate
choice.

Closes #3994. Respec of #2651 / PR #1633, which was 100% `packages/web`; under the
current architecture the decision logic is shared and the UI is mobile.

### What landed where

- **`@boardsesh/queue` (pure TS)** — `configKey` / `climbConfigKey` /
  `deriveAcceptedConfigs` / `decideAdd`. The compatibility classifier is
  **injected**, not imported: the package has `dependencies: {}` on purpose (the
  backend imports it), so it must not grow an edge onto `@boardsesh/board-config`.
  Same pattern as the existing `isClimbable` predicate in `playlist-suggestions`.
- **`dialog-provider`** — `useChoose()` for two or three named actions;
  `useConfirm()` is now a thin wrapper over it, so the queueing / settle-once /
  per-variant rendering has one implementation.
- **`use-cross-board-add-gate`** (new, mobile) — the prompt, the one-prompt-per-board
  dedup, and the switch side effect.
- **`addToQueue`** — the single seam every add path already goes through.

### Reviewer defects from #1633, closed up front

1. **Provider ordering** — `useChoose()` *throws* without `DialogProvider` (which
   already mounts above `QueueProvider` in `app/_layout.tsx`). No nullable context
   that silently resolves to `null` on the local-session path.
2. **Race on bulk add** — adds are keyed by board config in an in-flight ref while
   the dialog is open: eight climbs from the same foreign board raise **one** dialog
   and all eight settle on its answer. No resolver is dropped.
3. **Party-mode `switch` was local-only** — it now runs the same synced add body
   (`dispatch` + `addQueueItem` + reconcile-on-failure) *and* broadcasts the new
   `setSessionBoardPath`, so peers follow instead of diverging.
4. **Stale queue snapshot after the await** — everything after the prompt re-reads
   `stateRef.current` and re-runs `attributeNewItem`. Test: an unrelated add made
   while the dialog is open survives.
5. **Trademark** — copy uses `formatBoardDisplayName` ("MoonBoard", "So iLL"), never
   `charAt(0).toUpperCase()`. Also fixed at its two live sites on `main`
   (`board-lock/board-switch-confirm-provider.tsx`, `board-lock/queue-add-error-messages.ts`),
   which render "Moonboard" today.
6. **Angle fallback of `0`** — switching activates the owned board **as stored**, at
   its own angle. Test pins a board whose angle (25°) differs from the active one (40°).
7. **`useQueueAddValidator`** — deliberately left intact. It has a live board-lock job
   at `graphql-queue/QueueContext.tsx:459` and its own suite; re-decided against the
   current hook rather than blindly re-applying #1633's gutting.
8. **Design tokens in `start-sesh-drawer`** — already fixed on `main`, nothing to do.
9. **E2E** — no spec. The e2e workflow is no longer per-PR (#2630); coverage is unit
   tests on `decideAdd` / `deriveAcceptedConfigs` plus a QueueProvider harness.

### Also fixed along the way

`DialogProvider` read its pending id **inside** the `setState` updater, which React
defers to render time — three prompts raised in one tick all took the last id, so
settling one dropped the others and left their callers awaiting forever. The id is
snapshotted at call time now, with a three-concurrent-prompts regression test.

### Deliberately out of scope

- **No web cross-board UI.** The web climbing surface is deprecated (#3122). If web
  parity is wanted it's a second PR consuming the same `@boardsesh/queue` primitives.
- **No `@boardsesh/queue-react` package.** With one consumer, an injected-prompt React
  package is speculative; extract it the day web needs it.
- **Cross-size gating.** A `Climb` carries no size, so a size mismatch can't be seen
  from queue metadata; `canAddClimbToBoard`'s hold-ID containment already catches it
  at send time. `configKey` is board + layout only.
- **`setCurrentClimb` / `setQueue` / `appendGeneratedSession`** — only `addToQueue` is
  gated. The play drawer already has a board-mismatch overlay with a switch affordance.
- No DB migration, no schema change, no Bluetooth code.

### Known trade-off

"Add anyway" is remembered by **queue contents**, not by a separate flag — remove the
last climb from that board and the next add prompts again. That's the price of having
no acceptance state that can go stale against a party-synced queue; documented in the
module header.

## Release Notes

- Queue climbs from more than one board in the same session. Tap a climb that's set on
  another board and you get the choice: add it anyway, switch over to that board, or
  back out.

## Test plan

- `vp run typecheck` — pass (full monorepo).
- `vp run test:mobile` — 602 files / 5278 tests, all pass.
- `vp test run --project queue --project i18n` — 221 tests, pass (includes the new
  `cross-board.test.ts` and the four-locale catalog-parity gate).
- `vp test run --project web board-lock` — 20 tests, pass.
- `vp run check:i18n` + `vp run check:i18n:orphans` — pass.
- `vp check` — pass on every file this PR touches.
- New: `packages/shared/queue/src/__tests__/cross-board.test.ts` (16 cases incl. the
  injected-classifier contravariance contract) and
  `packages/mobile/src/providers/__tests__/queue-provider-cross-board-add.test.tsx`
  (10 cases: never prompts same-board, prompts once, cancel leaves nothing behind,
  switch fires `setActiveBoard` + `addQueueItem` + `setSessionBoardPath`, one prompt
  for a burst, an unrelated add survives the await, no re-prompt for a board already
  in the queue, board-picker fallback).
- Full `vp run test:web` had 19 timeout-shaped failures in unrelated components
  (gym-detail, session-summary, auth forms) under parallel load; each passes on its own
  and none touch the two board-lock files this PR changes.
- Not run: device/simulator QA. `.boardsesh/qa-notes.md` lists the flows (same-board
  no-prompt path, each of the three outcomes, party-mode peers, Android Material's
  three-button dialog, the four locales).
