### PR TITLE
fix(shared): stop double-counting party-session self-adds

### DIFF
--- a/packages/backend/src/__tests__/queue-sync-fixes.test.ts
+++ b/packages/backend/src/__tests__/queue-sync-fixes.test.ts
@@ -682,6 +682,38 @@ describe('order-sensitive dual-hash (stateHashOrdered)', () => {
     expect(removedCall).toBeDefined();
     expect((removedCall![1] as { clientId: string | null }).clientId).toBeNull();
   });
+
+  // Issue #4042 — the add side of the same bug: QueueItemAdded must carry the
+  // adding connection's id so subscribers can drop echoes of their own adds
+  // instead of tagging them `addedFromTab: 'peer_broadcast'` (a double count,
+  // since the local add already tracked itself with its real source tab).
+  it('publishes the adding connection id on QueueItemAdded', async () => {
+    const sessionId = uuidv4();
+    await registerAndJoinSession('client-1', sessionId, '/kilter/1/2/3/40', 'User1');
+    publishSpy.mockClear();
+
+    await queueMutations.addQueueItem({}, { item: createTestClimb() }, ctxFor(sessionId));
+    const addedCall = publishSpy.mock.calls.find(
+      (call: unknown[]) => (call[1] as { __typename: string }).__typename === 'QueueItemAdded',
+    );
+    expect(addedCall).toBeDefined();
+    expect((addedCall![1] as { clientId: string | null }).clientId).toBe('client-1');
+  });
+
+  // An anonymous publisher must send null, NOT '': peers compare defensively,
+  // and two empty-string clients would echo-suppress each other's adds.
+  it('coerces a missing connection id to null on QueueItemAdded', async () => {
+    const sessionId = uuidv4();
+    await registerAndJoinSession('client-1', sessionId, '/kilter/1/2/3/40', 'User1');
+    publishSpy.mockClear();
+
+    await queueMutations.addQueueItem({}, { item: createTestClimb() }, { ...ctxFor(sessionId), connectionId: '' });
+    const addedCall = publishSpy.mock.calls.find(
+      (call: unknown[]) => (call[1] as { __typename: string }).__typename === 'QueueItemAdded',
+    );
+    expect(addedCall).toBeDefined();
+    expect((addedCall![1] as { clientId: string | null }).clientId).toBeNull();
+  });
 });
 
 // Issue #2387 — the setQueue "redundant resync" warning must be order-aware.

--- a/packages/backend/src/graphql/resolvers/queue/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/queue/mutations.ts
@@ -112,6 +112,10 @@ export const queueMutations = {
         stateHashOrdered: resultStateHashOrdered,
         item: item,
         position: actualPosition,
+        // Same coercion as removeQueueItem/setCurrentClimb: an empty-string connectionId must
+        // become null, because peers compare defensively and two anonymous clients would otherwise
+        // echo-suppress each other's adds.
+        clientId: ctx.connectionId || null,
       });
     }
 

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -1291,6 +1291,7 @@ export const QUEUE_UPDATES_SUBSCRIPTION = `
         stateHashOrdered
         addedItem: item { ${SUBSCRIPTION_QUEUE_ITEM_FIELDS} }
         position
+        clientId
       }
       ... on QueueItemRemoved {
         sequence

--- a/packages/mobile/src/providers/__tests__/queue-provider-sync-gate.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-sync-gate.test.tsx
@@ -206,6 +206,7 @@ type Snapshot = {
   sessionId: string | null;
   subscribeToPlaybackEvents: ReturnType<typeof useQueue>['subscribeToPlaybackEvents'];
   removeFromQueue: ReturnType<typeof useQueue>['removeFromQueue'];
+  addToQueue: ReturnType<typeof useQueue>['addToQueue'];
 };
 
 const user = (overrides: Partial<SessionUser> = {}): SessionUser => ({
@@ -275,13 +276,22 @@ function wireFullSync(
   };
 }
 
-function wireQueueItemAdded(sequence: number, stateHash: string, item: ReturnType<typeof wireItem>) {
+// `clientId` is the adding connection's id (#4042); it is nullable on the wire,
+// so a pre-#4042 server sends null — hence the optional trailing param, which
+// keeps every existing caller unchanged.
+function wireQueueItemAdded(
+  sequence: number,
+  stateHash: string,
+  item: ReturnType<typeof wireItem>,
+  clientId: string | null = null,
+) {
   return {
     __typename: 'QueueItemAdded',
     sequence,
     stateHash,
     addedItem: item,
     position: null,
+    clientId,
   };
 }
 
@@ -362,8 +372,16 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
       sessionId: queue.sessionId,
       subscribeToPlaybackEvents: queue.subscribeToPlaybackEvents,
       removeFromQueue: queue.removeFromQueue,
+      addToQueue: queue.addToQueue,
     });
-  }, [queue.state, queue.sessionId, queue.subscribeToPlaybackEvents, queue.removeFromQueue, onSnapshot]);
+  }, [
+    queue.state,
+    queue.sessionId,
+    queue.subscribeToPlaybackEvents,
+    queue.removeFromQueue,
+    queue.addToQueue,
+    onSnapshot,
+  ]);
   return null;
 }
 
@@ -990,6 +1008,139 @@ describe('QueueItemRemoved self-echo attribution (issue #3382)', () => {
     expect(analytics.track).toHaveBeenCalledWith(
       'Climb Removed from Queue',
       expect.objectContaining({ removedBy: 'self', partyMode: false }),
+    );
+  });
+});
+
+// Issue #4042 — the add side of #3382. An add echoed back to the client that
+// issued it must NOT be tracked again: the local add already fired
+// `Climb Added to Queue` with `addedFromTab: 'mobile'` at the mutation site
+// (queue-provider.tsx), so the echo handler firing a second, peer-attributed
+// copy double counted every party-session self-add. joinSession returns
+// clientId 'client-self' in this harness, which is exactly what the backend
+// stamps onto the event — comparing against the locally generated
+// coordinator.clientId instead would compile but suppress nothing.
+describe('QueueItemAdded self-echo attribution (issue #4042)', () => {
+  const addTrackCalls = () => analytics.track.mock.calls.filter(([eventName]) => eventName === 'Climb Added to Queue');
+
+  const seedAndAdd = async (clientId: string | null) => {
+    const snapshots: Snapshot[] = [];
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(ws.getQueueUpdatesSink()).not.toBeNull();
+    });
+    const queueUpdatesSink = ws.getQueueUpdatesSink();
+    if (!queueUpdatesSink) throw new Error('queue updates sink was not captured');
+
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireFullSync(1, 'hash-1') } });
+    });
+    analytics.track.mockClear();
+    act(() => {
+      queueUpdatesSink.next({
+        data: { queueUpdates: wireQueueItemAdded(2, 'hash-2', wireItem('q1', 'c1'), clientId) },
+      });
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['q1']);
+    });
+    return snapshots;
+  };
+
+  beforeEach(() => {
+    ws.reset();
+    ws.client.on.mockClear();
+    ws.client.subscribe.mockClear();
+    activeBoard.getStoredActiveBoard.mockReset();
+    activeBoard.getStoredActiveBoard.mockResolvedValue(activeBoard.stored);
+    toast.showToast.mockClear();
+    analytics.track.mockClear();
+    for (const mutation of Object.values(queueMutations) as Array<ReturnType<typeof vi.fn>>) {
+      mutation.mockReset();
+      mutation.mockResolvedValue(undefined);
+    }
+    sessionStore.getStoredSessionId.mockReset();
+    sessionStore.getStoredSessionId.mockResolvedValue('session-1');
+    graph.execute.mockReset();
+    graph.execute.mockResolvedValue(createJoinSessionResponse());
+    http.request.mockReset();
+    routeHttpRequest(queueStateResponse([]));
+  });
+
+  it('does not track an add echoed back from this client', async () => {
+    await seedAndAdd('client-self');
+    expect(addTrackCalls()).toHaveLength(0);
+  });
+
+  it("still tracks a peer's add as addedFromTab: 'peer_broadcast'", async () => {
+    await seedAndAdd('client-peer');
+    expect(addTrackCalls()).toHaveLength(1);
+    expect(analytics.track).toHaveBeenCalledWith(
+      'Climb Added to Queue',
+      expect.objectContaining({ addedFromTab: 'peer_broadcast', partyMode: true }),
+    );
+  });
+
+  it("falls back to 'peer_broadcast' when a pre-#4042 server sends no clientId", async () => {
+    await seedAndAdd(null);
+    expect(addTrackCalls()).toHaveLength(1);
+    expect(analytics.track).toHaveBeenCalledWith(
+      'Climb Added to Queue',
+      expect.objectContaining({ addedFromTab: 'peer_broadcast' }),
+    );
+  });
+
+  // The suppressed echo used to be the only mobile add carrying `partyMode`,
+  // so the surviving self-track has to compute it or a PostHog breakdown on
+  // partyMode loses every mobile self-add.
+  const addLocally = async () => {
+    const snapshots: Snapshot[] = [];
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(ws.getQueueUpdatesSink()).not.toBeNull();
+    });
+    const queueUpdatesSink = ws.getQueueUpdatesSink();
+    if (!queueUpdatesSink) throw new Error('queue updates sink was not captured');
+
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireFullSync(1, 'hash-1') } });
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    analytics.track.mockClear();
+    act(() => {
+      snapshots.at(-1)?.addToQueue(makeQueueItem('q-local', 'c-local'));
+    });
+    await waitFor(() => {
+      expect(addTrackCalls()).toHaveLength(1);
+    });
+  };
+
+  it('tracks a local add with partyMode: true when the crew has more than one climber', async () => {
+    const joined = createJoinSessionResponse();
+    graph.execute.mockResolvedValue({
+      joinSession: {
+        ...joined.joinSession,
+        users: [...joined.joinSession.users, user({ id: 'participant-peer', username: 'Sam', userId: 'db-peer' })],
+      },
+    });
+
+    await addLocally();
+    expect(analytics.track).toHaveBeenCalledWith(
+      'Climb Added to Queue',
+      expect.objectContaining({ addedFromTab: 'mobile', partyMode: true }),
+    );
+  });
+
+  it('tracks a solo add with partyMode: false', async () => {
+    await addLocally();
+    expect(analytics.track).toHaveBeenCalledWith(
+      'Climb Added to Queue',
+      expect.objectContaining({ addedFromTab: 'mobile', partyMode: false }),
     );
   });
 });

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -809,12 +809,17 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       // session, an offline phone, or a transient WS error must NOT see "Action
       // failed" when the local queue is already correct. Dev-log only.
       dispatch({ type: 'DELTA_ADD_QUEUE_ITEM', payload: { item } });
+      // partyMode matches web's self-track (QueueContext.tsx): the crew roster
+      // holds more than one distinct human. Without it the suppressed self-echo
+      // would take `partyMode: true` with it and a PostHog breakdown on
+      // partyMode would lose every mobile self-add (#4042).
       track(SHARED_EVENTS.ClimbAddedToQueue, {
         climbUuid: item.climb.uuid,
         boardName: activeBoardRef.current?.boardType,
         layoutId: activeBoardRef.current?.layoutId,
         addedFromTab: 'mobile',
         currentQueueLength: stateRef.current.queue.length + 1,
+        partyMode: countDistinctSessionUsers(sessionRuntimeStateRef.current?.users) > 1,
       });
       // No unresolved-climb guard here: addToQueue is only ever called with a
       // fully-resolved climb from search / detail / playlist (a real user tap),

--- a/packages/mobile/src/providers/queue/use-session-realtime.ts
+++ b/packages/mobile/src/providers/queue/use-session-realtime.ts
@@ -549,17 +549,43 @@ export function useSessionRealtime({
             if (result.kind !== 'dispatch') return;
             dispatch(result.action);
             switch (result.eventType) {
-              case 'QueueItemAdded':
+              case 'QueueItemAdded': {
+                // The server echoes our own adds back to us. A locally
+                // initiated add already tracked itself with its real source tab
+                // at the mutation site (queue-provider.tsx), so tracking the
+                // echo would double count — stay silent rather than emit a
+                // second, peer-attributed copy (#4042).
+                //
+                // Both truthiness guards are load-bearing: solo/unjoined state
+                // leaves clientId as '' (createEmptySessionRuntimeState) and a
+                // pre-#4042 server sends no clientId at all. Either way we fall
+                // back to today's 'peer_broadcast' attribution.
+                //
+                // The `__typename` re-check is load-bearing, not dead code:
+                // this switch discriminates on `result.eventType`, a separate
+                // variable, so `event` is still the full union here and TS
+                // rejects `event.clientId` without it. Compare against the
+                // joinSession-returned clientId in sessionRuntimeStateRef — NOT
+                // coordinator.clientId, which is generated locally and never
+                // reaches the server.
+                const selfAddClientId = sessionRuntimeStateRef.current?.clientId;
+                if (
+                  event.__typename === 'QueueItemAdded' &&
+                  event.clientId &&
+                  selfAddClientId &&
+                  event.clientId === selfAddClientId
+                ) {
+                  break;
+                }
                 track(SHARED_EVENTS.ClimbAddedToQueue, {
                   boardName: activeBoardRef.current?.boardType,
                   layoutId: activeBoardRef.current?.layoutId,
-                  // QueueItemAdded carries no clientId on the wire yet, so a
-                  // self-add echo is still tracked here (double count) — #4042.
                   addedFromTab: 'peer_broadcast',
                   currentQueueLength: stateRef.current.queue.length + 1,
                   partyMode: true,
                 });
                 break;
+              }
               case 'QueueItemRemoved': {
                 // The server echoes our own removes back to us. A locally
                 // initiated remove already tracked itself with

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -6922,6 +6922,8 @@ type QueueItemAdded {
   item: ClimbQueueItem!
   "Position where item was inserted (null = end)"
   position: Int
+  "Connection id of the client that added the item; null when unknown (widget/controller paths, or a pre-#4042 server). Clients compare it against their own joinSession clientId to suppress self-echoes."
+  clientId: ID
 }
 
 """

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -5788,6 +5788,8 @@ export type QueueEvent =
 /** Event when an item is added to the queue. */
 export type QueueItemAdded = {
   __typename?: 'QueueItemAdded';
+  /** Connection id of the client that added the item; null when unknown (widget/controller paths, or a pre-#4042 server). Clients compare it against their own joinSession clientId to suppress self-echoes. */
+  clientId?: Maybe<Scalars['ID']['output']>;
   /** The added item */
   item: ClimbQueueItem;
   /** Position where item was inserted (null = end) */
@@ -11863,6 +11865,7 @@ export type QueueItemAddedResolvers<
   ContextType = ConnectionContext,
   ParentType extends ResolversParentTypes['QueueItemAdded'] = ResolversParentTypes['QueueItemAdded'],
 > = ResolversObject<{
+  clientId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   item?: Resolver<ResolversTypes['ClimbQueueItem'], ParentType, ContextType>;
   position?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   sequence?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;

--- a/packages/shared-schema/src/schema/events.ts
+++ b/packages/shared-schema/src/schema/events.ts
@@ -241,6 +241,8 @@ export const eventsTypeDefs = /* GraphQL */ `
     item: ClimbQueueItem!
     "Position where item was inserted (null = end)"
     position: Int
+    "Connection id of the client that added the item; null when unknown (widget/controller paths, or a pre-#4042 server). Clients compare it against their own joinSession clientId to suppress self-echoes."
+    clientId: ID
   }
 
   """

--- a/packages/shared-schema/src/types/events.ts
+++ b/packages/shared-schema/src/types/events.ts
@@ -62,6 +62,8 @@ export type QueueEvent =
       stateHashOrdered?: string | null;
       item: ClimbQueueItem;
       position?: number | null;
+      /** Connection id of the adding client; optional so legacy/replayed payloads still typecheck. */
+      clientId?: string | null;
     }
   | {
       __typename: 'QueueItemRemoved';
@@ -112,6 +114,8 @@ export type SubscriptionQueueEvent =
       stateHashOrdered?: string | null;
       addedItem: ClimbQueueItem;
       position?: number | null;
+      /** Connection id of the adding client; optional so legacy/replayed payloads still typecheck. */
+      clientId?: string | null;
     }
   | {
       __typename: 'QueueItemRemoved';

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -5785,6 +5785,8 @@ export type QueueEvent =
 /** Event when an item is added to the queue. */
 export type QueueItemAdded = {
   __typename?: 'QueueItemAdded';
+  /** Connection id of the client that added the item; null when unknown (widget/controller paths, or a pre-#4042 server). Clients compare it against their own joinSession clientId to suppress self-echoes. */
+  clientId?: Maybe<Scalars['ID']['output']>;
   /** The added item */
   item: ClimbQueueItem;
   /** Position where item was inserted (null = end) */

--- a/packages/shared/graphql/src/operations/queue-session.ts
+++ b/packages/shared/graphql/src/operations/queue-session.ts
@@ -439,6 +439,10 @@ export const EVENTS_REPLAY = `
             }
           }
         }
+        # No clientId on the add/remove fragments below, on purpose: delta replay only runs from
+        # session-connection.ts's reconnect(), so every replayed event carries the PRE-reconnect
+        # connectionId while the client already holds the new one. The self-echo comparison could
+        # never match, so the field would be dead weight (see #3382 and #4042).
         ... on QueueItemAdded {
           sequence
           stateHash
@@ -448,10 +452,6 @@ export const EVENTS_REPLAY = `
           }
           position
         }
-        # No clientId here on purpose: delta replay only runs from session-connection.ts's
-        # reconnect(), so every replayed event carries the PRE-reconnect connectionId while the
-        # client already holds the new one. The self-echo comparison could never match, so the
-        # field would be dead weight (see #3382).
         ... on QueueItemRemoved {
           sequence
           stateHash
@@ -524,6 +524,7 @@ export const QUEUE_UPDATES = `
           ${QUEUE_ITEM_FIELDS}
         }
         position
+        clientId
       }
       ... on QueueItemRemoved {
         sequence

--- a/packages/shared/queue-runtime/src/subscription-adapter.ts
+++ b/packages/shared/queue-runtime/src/subscription-adapter.ts
@@ -53,6 +53,8 @@ export type SubscriptionWireEnvelope<TWireItem> =
       sequence?: number | null;
       stateHash?: string | null;
       stateHashOrdered?: string | null;
+      /** Connection id of the adding client; read by analytics to suppress self-echoes (#4042). */
+      clientId?: string | null;
     }
   | {
       __typename: 'QueueItemRemoved';

--- a/packages/web/app/components/persistent-session/__tests__/use-peer-broadcast-analytics.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/use-peer-broadcast-analytics.test.ts
@@ -298,4 +298,77 @@ describe('usePeerBroadcastAnalytics', () => {
       expect.objectContaining({ removedBy: 'peer' }),
     );
   });
+
+  // Issue #4042 — the same double count on the add side. The local add already
+  // tracked itself with its real source tab in QueueContext.tsx, so tracking
+  // the echoed-back copy inflated every party-session self-add.
+  it('skips a QueueItemAdded echoed back from this client', () => {
+    const { subscribeToQueueEvents, emit } = createSubscribeToQueueEvents();
+    renderHook(() =>
+      usePeerBroadcastAnalytics({
+        subscribeToQueueEvents,
+        isOnBoardRoute: true,
+        boardLayoutName: 'Original',
+        queueRef: { current: new Array(2) },
+        clientId: 'conn-self',
+      }),
+    );
+
+    emit({ ...addedEvent, clientId: 'conn-self' });
+
+    expect(mockTrack).not.toHaveBeenCalled();
+  });
+
+  it("still fires 'peer_broadcast' for a QueueItemAdded from another client", () => {
+    const { subscribeToQueueEvents, emit } = createSubscribeToQueueEvents();
+    renderHook(() =>
+      usePeerBroadcastAnalytics({
+        subscribeToQueueEvents,
+        isOnBoardRoute: true,
+        boardLayoutName: 'Original',
+        queueRef: { current: new Array(2) },
+        clientId: 'conn-self',
+      }),
+    );
+
+    emit({ ...addedEvent, clientId: 'conn-peer' });
+
+    expect(mockTrack).toHaveBeenCalledTimes(1);
+    expect(mockTrack).toHaveBeenCalledWith('Climb Added to Queue', {
+      boardLayout: 'Original',
+      addedFromTab: 'peer_broadcast',
+      currentQueueLength: 3,
+      partyMode: true,
+    });
+  });
+
+  // A pre-#4042 server sends no clientId; a solo/unjoined client has none of
+  // its own. Both fall back to the historical 'peer_broadcast' attribution.
+  it("falls back to 'peer_broadcast' when either side has no clientId", () => {
+    const { subscribeToQueueEvents, emit } = createSubscribeToQueueEvents();
+    const { rerender } = renderHook(
+      (props: { clientId: string | null }) =>
+        usePeerBroadcastAnalytics({
+          subscribeToQueueEvents,
+          isOnBoardRoute: true,
+          boardLayoutName: 'Original',
+          queueRef: { current: new Array(2) },
+          clientId: props.clientId,
+        }),
+      { initialProps: { clientId: 'conn-self' } as { clientId: string | null } },
+    );
+
+    // Legacy server: event carries no clientId.
+    emit({ ...addedEvent, clientId: null });
+    expect(mockTrack).toHaveBeenCalledTimes(1);
+
+    // Unjoined client: we have no clientId of our own.
+    rerender({ clientId: null });
+    emit({ ...addedEvent, clientId: 'conn-peer' });
+    expect(mockTrack).toHaveBeenCalledTimes(2);
+    expect(mockTrack).toHaveBeenLastCalledWith(
+      'Climb Added to Queue',
+      expect.objectContaining({ addedFromTab: 'peer_broadcast' }),
+    );
+  });
 });

--- a/packages/web/app/components/persistent-session/hooks/session-connection-ports.ts
+++ b/packages/web/app/components/persistent-session/hooks/session-connection-ports.ts
@@ -60,6 +60,9 @@ import {
 export function transformToSubscriptionEvent(event: QueueEvent | SubscriptionQueueEvent): SubscriptionQueueEvent {
   switch (event.__typename) {
     case 'QueueItemAdded': {
+      // Dropping clientId here is correct: this only rebuilds replayed events, and
+      // EVENTS_REPLAY deliberately doesn't select clientId (a replayed event carries the
+      // pre-reconnect connection id, so the self-echo comparison could never match) — #4042.
       const addedItem = 'addedItem' in event ? event.addedItem : event.item;
       return {
         __typename: 'QueueItemAdded',

--- a/packages/web/app/components/persistent-session/hooks/use-peer-broadcast-analytics.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-peer-broadcast-analytics.ts
@@ -23,7 +23,7 @@ type UsePeerBroadcastAnalyticsParams = {
   /**
    * This client's joinSession-returned connection id (`lifecycle.session.clientId`),
    * or null when not in a session. Used to suppress self-echoes of our own
-   * removes. Read via a ref internally so a rejoin doesn't tear down the
+   * adds and removes. Read via a ref internally so a rejoin doesn't tear down the
    * subscription effect.
    */
   clientId: string | null;
@@ -46,12 +46,10 @@ type UsePeerBroadcastAnalyticsParams = {
  * firing off-board too, a parity regression.
  *
  * Fires on every `QueueItemAdded`/`QueueItemRemoved` event this client's
- * queue subscription receives. `QueueItemRemoved` now carries the removing
- * client's connection id (#3382), so echoes of our OWN removes are skipped —
- * the local remove already tracked itself with `removedBy: 'self'` in
+ * queue subscription receives. Both now carry the mutating client's connection
+ * id (#3382 for removes, #4042 for adds), so echoes of our OWN mutations are
+ * skipped — the local add/remove already tracked itself in
  * `graphql-queue/QueueContext.tsx`, and tracking the echo double counted.
- * `QueueItemAdded` still has no clientId on the wire, so self-adds remain
- * double counted — tracked as a follow-up in #4042.
  */
 export function usePeerBroadcastAnalytics({
   subscribeToQueueEvents,
@@ -76,6 +74,12 @@ export function usePeerBroadcastAnalytics({
         // that dispatch actually happening. Keep the parity — no state
         // change, no analytics.
         if (!event.addedItem) return;
+        // Echo of our own add: `graphql-queue/QueueContext.tsx` already tracked
+        // it with the real source tab, so tracking again would double count.
+        // Both truthiness guards matter — a solo/unjoined client has no
+        // clientId, and a pre-#4042 server sends none, so either way we fall
+        // back to the historical 'peer_broadcast' attribution.
+        if (event.clientId && clientIdRef.current && event.clientId === clientIdRef.current) return;
         track('Climb Added to Queue', {
           boardLayout: boardLayoutNameRef.current,
           addedFromTab: 'peer_broadcast',


### PR DESCRIPTION
## Summary

Closes #4042.

The server echoes every queue add back to the client that made it. `QueueItemAdded` carried no `clientId`, so neither echo handler could tell "my own add coming back" from "a crewmate's add" — both tracked a second, `peer_broadcast`-attributed `Climb Added to Queue` on top of the one the local mutation site already fired. Every add made inside a party session counted twice.

This is the add-side mirror of the remove-side fix that shipped in #4053 (issue #3382), done mechanically the same way:

- `QueueItemAdded` gains a nullable `clientId: ID`, published by `addQueueItem` as `ctx.connectionId || null` (empty string must coerce to `null`, or two anonymous clients echo-suppress each other).
- Both subscription documents select it — shared `QUEUE_UPDATES` and mobile `QUEUE_UPDATES_SUBSCRIPTION`. `EVENTS_REPLAY` deliberately does **not**: delta replay only runs from `reconnect()`, so a replayed event carries the pre-reconnect connection id and the comparison could never match. `NATIVE_IOS_QUEUE_UPDATES` is untouched (byte-compared against the Swift copy).
- Both echo handlers compare against the **joinSession-returned** clientId — `sessionRuntimeStateRef.current.clientId` on mobile, `lifecycle.session?.clientId` on web. Not mobile's locally-generated `coordinator.clientId`, which the server never sees; comparing against that compiles green and suppresses nothing.
- The echo is **skipped**, not relabelled `self`: the local site already tracked it with its real source tab, and a relabel would throw that away.
- Mobile's local `addToQueue` now computes `partyMode` — the suppressed echo used to be the only mobile add carrying it, so without this a PostHog breakdown on `partyMode` would lose every mobile self-add. Web's local add already computed it.

Deploy order is safe either way: the field is nullable and both sides fall back to today's `peer_broadcast` attribution when either clientId is missing.

**Expected metric shift:** party-session `Climb Added to Queue` drops from ~2x to 1x. Paired with #4053 (removes already at 1x) the add/remove ratio normalises, but dashboards with fixed y-axes or week-over-week comparisons will show a step. Worth a PostHog annotation on deploy.

## Release Notes

- [x] No release note needed (internal / technical change)

Analytics correctness only — no user-visible behaviour change.

## Test plan

New tests:

- **backend** `queue-sync-fixes.test.ts` — `addQueueItem` publishes `clientId: 'client-1'`; an empty-string `connectionId` publishes `null`, not `''`.
- **backend** `operations-schema-validation.test.ts` (existing, no edit) validates both the shared and the mobile subscription documents against the regenerated schema, so schema/fragment drift hard-fails.
- **web** `use-peer-broadcast-analytics.test.ts` — self-echo fires nothing; a peer add still fires `peer_broadcast` with `partyMode: true`; either side missing `clientId` falls back to firing.
- **mobile** `queue-provider-sync-gate.test.tsx` — same trio over the wire, plus two local-add cases asserting `addedFromTab: 'mobile'` with `partyMode` true (2-user roster) and false (solo). `wireQueueItemAdded` took an optional trailing `clientId` so its ~12 existing callers are unchanged.

Validation run (foreground):

- `vp run codegen` — regenerated `schema.graphql`, `shared-schema` types, `shared/graphql` types. No hand-edits.
- `vp run typecheck` — green.
- `vp check` — 28 errors / 301 warnings; the identical 28 errors are present on a stashed clean tree (pre-existing, unrelated files). The 3 added warnings are `new Array(2)` in the web test, matching the existing cases in that file.
- `vp test run --project backend` — 259/260. The one failure, `should use sequence from updateQueueOnly result`, is an unrelated pre-existing timeout; it passes in isolation, and ports 8081-8087 were held by other worktrees at the time.
- `vp run test:web` — exit 0. Scoped `use-peer-broadcast-analytics`: 14/14.
- `vp run test:mobile` — 5296/5296 across 603 files.
- `vp run check:mobile-bundle` — OK.

Not exercised on a device: the two-phone party-session flow and the PostHog event counts themselves. QA notes with those flows are in `.boardsesh/qa-notes.md`.

Out of scope, deliberately: `QueueReordered` has the same shape of bug (`reorderedBy: 'peer'` hardcoded) — worth its own issue, not bundled here. No backfill of the already-inflated historical data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Msvwztpyh4KYh7iDkHWaxQ
