### PR TITLE
feat(mobile): filter climbs by the stars I gave them

### DIFF
--- a/packages/backend/src/__tests__/climb-queries.test.ts
+++ b/packages/backend/src/__tests__/climb-queries.test.ts
@@ -855,4 +855,146 @@ describe('Climb Query Functions', () => {
       expect(await countClimbs(boundaryParams, statsFiltered)).toBe(2);
     });
   });
+
+  // Personal rating filters (#2645): "min stars I gave" + "only climbs I rated",
+  // read straight off boardsesh_ticks at the browsed angle. Latest rating wins,
+  // never-rated climbs stay visible unless onlyRatedByMe is on.
+  describe('personal rating filters (#2645)', () => {
+    const PREFIX = 'user-rating-';
+    const id = (suffix: string) => PREFIX + suffix;
+    const USER_ID = 'user-rating-tester';
+    const OTHER_USER_ID = 'user-rating-bystander';
+
+    const ratingParams: ParsedBoardRouteParameters = {
+      board_name: 'kilter',
+      layout_id: 1,
+      // Isolated on a size/set key no real catalog climb carries, so the
+      // assertions can enumerate the fixtures exactly (same trick as F4 above).
+      size_id: 98,
+      set_ids: [98],
+      angle: 40,
+    };
+
+    const search = (overrides: Partial<ClimbSearchParams> = {}): ClimbSearchParams => ({
+      page: 0,
+      pageSize: 100,
+      sortBy: 'creation',
+      sortOrder: 'desc',
+      ...overrides,
+    });
+
+    // Only the seeded climbs — the shared dev DB carries plenty of others at this key.
+    const seededUuids = async (searchParams: ClimbSearchParams, userId?: string): Promise<string[]> => {
+      const result = await searchClimbs(ratingParams, searchParams, userId);
+      return result.climbs
+        .map((climb) => climb.uuid)
+        .filter((uuid) => uuid.startsWith(PREFIX))
+        .sort();
+    };
+
+    const ALL_SEEDED = [
+      id('rated-5'),
+      id('rated-2'),
+      id('re-rated-up'),
+      id('re-rated-down'),
+      id('sent-unrated'),
+      id('untouched'),
+      id('other-angle'),
+      id('other-user'),
+    ].sort();
+
+    beforeAll(async () => {
+      await db.execute(sql`
+        INSERT INTO users (id, email, name, created_at, updated_at)
+        VALUES
+          (${USER_ID}, ${USER_ID + '@test.com'}, 'Rating Tester', now(), now()),
+          (${OTHER_USER_ID}, ${OTHER_USER_ID + '@test.com'}, 'Rating Bystander', now(), now())
+        ON CONFLICT (id) DO NOTHING
+      `);
+
+      await db.execute(sql`
+        INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, frames, frames_count, is_draft, is_listed, edge_left, edge_right, edge_bottom, edge_top, created_at, required_set_ids, compatible_size_ids)
+        VALUES
+          (${id('rated-5')}, 'kilter', 1, 'ur', 'Rated 5', 'p600r12', 1, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[98], ARRAY[98]),
+          (${id('rated-2')}, 'kilter', 1, 'ur', 'Rated 2', 'p601r12', 1, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[98], ARRAY[98]),
+          (${id('re-rated-up')}, 'kilter', 1, 'ur', 'Re-rated Up', 'p602r12', 1, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[98], ARRAY[98]),
+          (${id('re-rated-down')}, 'kilter', 1, 'ur', 'Re-rated Down', 'p603r12', 1, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[98], ARRAY[98]),
+          (${id('sent-unrated')}, 'kilter', 1, 'ur', 'Sent Unrated', 'p604r12', 1, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[98], ARRAY[98]),
+          (${id('untouched')}, 'kilter', 1, 'ur', 'Untouched', 'p605r12', 1, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[98], ARRAY[98]),
+          (${id('other-angle')}, 'kilter', 1, 'ur', 'Other Angle', 'p606r12', 1, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[98], ARRAY[98]),
+          (${id('other-user')}, 'kilter', 1, 'ur', 'Other User', 'p607r12', 1, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[98], ARRAY[98])
+        ON CONFLICT DO NOTHING
+      `);
+
+      // Ratings the filter reads. `re-rated-*` carry two ticks apiece so the
+      // latest-wins rule is exercised in both directions.
+      await db.execute(sql`
+        INSERT INTO boardsesh_ticks (uuid, user_id, board_type, climb_uuid, angle, status, attempt_count, quality, climbed_at)
+        VALUES
+          (${id('tick-rated-5')}, ${USER_ID}, 'kilter', ${id('rated-5')}, 40, 'send', 1, 5, '2024-03-01'),
+          (${id('tick-rated-2')}, ${USER_ID}, 'kilter', ${id('rated-2')}, 40, 'send', 1, 2, '2024-03-01'),
+          (${id('tick-up-old')}, ${USER_ID}, 'kilter', ${id('re-rated-up')}, 40, 'send', 1, 2, '2024-01-01'),
+          (${id('tick-up-new')}, ${USER_ID}, 'kilter', ${id('re-rated-up')}, 40, 'send', 1, 5, '2024-03-01'),
+          (${id('tick-down-old')}, ${USER_ID}, 'kilter', ${id('re-rated-down')}, 40, 'send', 1, 5, '2024-01-01'),
+          (${id('tick-down-new')}, ${USER_ID}, 'kilter', ${id('re-rated-down')}, 40, 'send', 1, 2, '2024-03-01'),
+          (${id('tick-unrated')}, ${USER_ID}, 'kilter', ${id('sent-unrated')}, 40, 'send', 1, NULL, '2024-03-01'),
+          (${id('tick-other-angle')}, ${USER_ID}, 'kilter', ${id('other-angle')}, 20, 'send', 1, 5, '2024-03-01'),
+          (${id('tick-other-user')}, ${OTHER_USER_ID}, 'kilter', ${id('other-user')}, 40, 'send', 1, 5, '2024-03-01')
+        ON CONFLICT DO NOTHING
+      `);
+    });
+
+    afterAll(async () => {
+      await db.execute(sql`DELETE FROM boardsesh_ticks WHERE uuid LIKE ${PREFIX + '%'}`);
+      await db.execute(sql`DELETE FROM board_climbs WHERE uuid LIKE ${PREFIX + '%'}`);
+      await db.execute(sql`DELETE FROM users WHERE id IN (${USER_ID}, ${OTHER_USER_ID})`);
+    });
+
+    it('seeds every fixture climb when no rating filter is applied', async () => {
+      expect(await seededUuids(search(), USER_ID)).toEqual(ALL_SEEDED);
+    });
+
+    it('minUserRating keeps unrated climbs and drops only the ones rated below it', async () => {
+      const uuids = await seededUuids(search({ minUserRating: 4 }), USER_ID);
+
+      expect(uuids).toEqual(
+        [
+          id('rated-5'),
+          id('re-rated-up'), // 2 → 5: the newer rating wins, so it's back in
+          id('sent-unrated'), // ticked but never rated
+          id('untouched'),
+          id('other-angle'), // rated 5 at 20°, unrated at the browsed 40°
+          id('other-user'), // someone else's 5 is not mine
+        ].sort(),
+      );
+      expect(uuids).not.toContain(id('rated-2'));
+      expect(uuids).not.toContain(id('re-rated-down')); // 5 → 2: latest rating is below 4
+    });
+
+    it('onlyRatedByMe keeps every climb I rated at this angle, whatever the stars', async () => {
+      const uuids = await seededUuids(search({ onlyRatedByMe: true }), USER_ID);
+
+      expect(uuids).toEqual([id('rated-5'), id('rated-2'), id('re-rated-up'), id('re-rated-down')].sort());
+    });
+
+    it('minUserRating with onlyRatedByMe drops the unrated climbs too', async () => {
+      const searchParams = search({ minUserRating: 4, onlyRatedByMe: true });
+
+      expect(await seededUuids(searchParams, USER_ID)).toEqual([id('rated-5'), id('re-rated-up')].sort());
+    });
+
+    it('countClimbs agrees with the list for the combined filter', async () => {
+      const searchParams = search({ minUserRating: 4, onlyRatedByMe: true });
+      const listed = await seededUuids(searchParams, USER_ID);
+
+      // Nothing but the fixtures can match — no other user rates as this test user.
+      expect(await countClimbs(ratingParams, searchParams, USER_ID)).toBe(listed.length);
+    });
+
+    it('is a no-op without a userId, so an anonymous search stays unfiltered', async () => {
+      const searchParams = search({ minUserRating: 5, onlyRatedByMe: true });
+
+      expect(await seededUuids(searchParams)).toEqual(ALL_SEEDED);
+    });
+  });
 });

--- a/packages/backend/src/__tests__/climb-search-validation.test.ts
+++ b/packages/backend/src/__tests__/climb-search-validation.test.ts
@@ -42,3 +42,30 @@ describe('ClimbSearchInputSchema holdsFilter cap', () => {
     }
   });
 });
+
+describe('ClimbSearchInputSchema personal rating filters (#2645)', () => {
+  it('accepts a 1-5 star minimum, matching the boardsesh_ticks quality range', () => {
+    for (const minUserRating of [1, 2, 3, 4, 5]) {
+      expect(ClimbSearchInputSchema.safeParse({ ...base, minUserRating }).success).toBe(true);
+    }
+  });
+
+  it('accepts 0 as "no minimum" so a client sending the default cannot 400 the search', () => {
+    expect(ClimbSearchInputSchema.safeParse({ ...base, minUserRating: 0 }).success).toBe(true);
+  });
+
+  it('rejects out-of-range and fractional star minimums', () => {
+    expect(ClimbSearchInputSchema.safeParse({ ...base, minUserRating: 6 }).success).toBe(false);
+    expect(ClimbSearchInputSchema.safeParse({ ...base, minUserRating: -1 }).success).toBe(false);
+    expect(ClimbSearchInputSchema.safeParse({ ...base, minUserRating: 3.5 }).success).toBe(false);
+  });
+
+  it('accepts onlyRatedByMe as a boolean only', () => {
+    expect(ClimbSearchInputSchema.safeParse({ ...base, onlyRatedByMe: true }).success).toBe(true);
+    expect(ClimbSearchInputSchema.safeParse({ ...base, onlyRatedByMe: 'true' }).success).toBe(false);
+  });
+
+  it('leaves both filters optional', () => {
+    expect(ClimbSearchInputSchema.safeParse(base).success).toBe(true);
+  });
+});

--- a/packages/backend/src/validation/schemas/climbs.ts
+++ b/packages/backend/src/validation/schemas/climbs.ts
@@ -198,6 +198,12 @@ export const ClimbSearchInputSchema = z.object({
   hideCompleted: z.boolean().optional(),
   showOnlyAttempted: z.boolean().optional(),
   showOnlyCompleted: z.boolean().optional(),
+  // 1-5 matches the boardsesh_ticks_quality_range CHECK. 0 is accepted and
+  // means "no minimum" (mapSearchInputToParams collapses it), mirroring the
+  // community minRating whose default is 0 — a client sending the default
+  // must not 400 the whole search.
+  minUserRating: z.number().int().min(0).max(5).optional(),
+  onlyRatedByMe: z.boolean().optional(),
   onlyDrafts: z.boolean().optional(),
   projectsOnly: z.boolean().optional(),
   // Intended to default to boulders-only so non-web GraphQL callers (mobile,

--- a/packages/db/src/queries/climbs/create-climb-filters.ts
+++ b/packages/db/src/queries/climbs/create-climb-filters.ts
@@ -484,6 +484,59 @@ export const createClimbFilters = (params: BoardRouteParams, searchParams: Climb
         )`,
       );
     }
+
+    // Personal rating filters, read straight off the user's ticks at the
+    // browsed angle (same scope as the four flags above, and the same scope the
+    // community quality_average is stored at).
+    //
+    // Both cases are written as EXISTS / NOT EXISTS on purpose. A scalar
+    // `(SELECT quality … ORDER BY climbed_at DESC LIMIT 1)` correlated
+    // subquery cannot be unnested, so Postgres runs it once per candidate
+    // climb — measured at 2-3x the unfiltered baseline on the dev DB
+    // (220k candidates). These forms unnest into semi/anti joins that the
+    // planner can drive from boardsesh_ticks instead, landing at or below
+    // baseline.
+    if (searchParams.onlyRatedByMe) {
+      personalProgressConditions.push(
+        sql`EXISTS (
+          SELECT 1 FROM ${boardseshTicks}
+          WHERE ${boardseshTicks.climbUuid} = ${boardClimbs.uuid}
+          AND ${boardseshTicks.userId} = ${userId}
+          AND ${boardseshTicks.boardType} = ${params.board_name}
+          AND ${boardseshTicks.angle} = ${params.angle}
+          AND ${boardseshTicks.quality} IS NOT NULL
+        )`,
+      );
+    }
+
+    if (searchParams.minUserRating) {
+      // "The user's LATEST rating is not below N", expressed as an anti-join:
+      // exclude the climb when a rated tick below N exists that no newer rated
+      // tick supersedes. Re-rating a climb upward therefore lets it back in,
+      // and a climb the user never rated has no offending tick, so it stays
+      // visible (pair with onlyRatedByMe to drop those too). The (climbed_at,
+      // id) row comparison breaks same-timestamp ties by insertion order.
+      personalProgressConditions.push(
+        sql`NOT EXISTS (
+          SELECT 1 FROM ${boardseshTicks} AS rating_below
+          WHERE rating_below.climb_uuid = ${boardClimbs.uuid}
+          AND rating_below.user_id = ${userId}
+          AND rating_below.board_type = ${params.board_name}
+          AND rating_below.angle = ${params.angle}
+          AND rating_below.quality IS NOT NULL
+          AND rating_below.quality < ${searchParams.minUserRating}
+          AND NOT EXISTS (
+            SELECT 1 FROM ${boardseshTicks} AS rating_newer
+            WHERE rating_newer.climb_uuid = rating_below.climb_uuid
+            AND rating_newer.user_id = rating_below.user_id
+            AND rating_newer.board_type = rating_below.board_type
+            AND rating_newer.angle = rating_below.angle
+            AND rating_newer.quality IS NOT NULL
+            AND (rating_newer.climbed_at, rating_newer.id) > (rating_below.climbed_at, rating_below.id)
+          )
+        )`,
+      );
+    }
   }
 
   // User-specific logbook data selectors using boardsesh_ticks

--- a/packages/db/src/queries/climbs/types.ts
+++ b/packages/db/src/queries/climbs/types.ts
@@ -61,6 +61,11 @@ export type ClimbSearchParams = {
   hideCompleted?: boolean;
   showOnlyAttempted?: boolean;
   showOnlyCompleted?: boolean;
+  // Personal rating filters over the user's own ticks at the browsed angle.
+  // `minUserRating` (1-5) hides climbs whose latest rating is below it while
+  // keeping never-rated climbs; `onlyRatedByMe` keeps only rated climbs.
+  minUserRating?: number;
+  onlyRatedByMe?: boolean;
   onlyDrafts?: boolean;
   projectsOnly?: boolean;
   // Climb-type toggles. Default to undefined (treated as both selected → no
@@ -107,6 +112,8 @@ export type ClimbSearchInputLike = {
   hideCompleted?: boolean | null;
   showOnlyAttempted?: boolean | null;
   showOnlyCompleted?: boolean | null;
+  minUserRating?: number | null;
+  onlyRatedByMe?: boolean | null;
   onlyDrafts?: boolean | null;
   projectsOnly?: boolean | null;
   boulders?: boolean | null;
@@ -176,6 +183,10 @@ export function mapSearchInputToParams(input: ClimbSearchInputLike): ClimbSearch
     hideCompleted: input.hideCompleted ?? undefined,
     showOnlyAttempted: input.showOnlyAttempted ?? undefined,
     showOnlyCompleted: input.showOnlyCompleted ?? undefined,
+    // An explicit 0 means "no minimum" (the same idiom as the community
+    // minRating above), so collapse it rather than emitting `>= 0`.
+    minUserRating: input.minUserRating || undefined,
+    onlyRatedByMe: input.onlyRatedByMe ?? undefined,
     onlyDrafts: input.onlyDrafts ?? undefined,
     projectsOnly: input.projectsOnly ?? undefined,
     boulders: input.boulders ?? undefined,

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -862,6 +862,33 @@ export function ClimbFilterSheet({
                     />
                   ))}
                 </View>
+
+                {/* My rating — the stars you gave, at the angle you're browsing.
+                    The star row keeps climbs you never rated; the switch drops them. */}
+                <View style={styles.subsectionGap} />
+                <Text variant="footnote" style={styles.subsectionLabel}>
+                  {t('mobile.filter.myRating')}
+                </Text>
+                <Text variant="footnote" style={styles.subsectionDescription}>
+                  {t('mobile.filter.myRatingDescription')}
+                </Text>
+                <View style={styles.ratingRow}>
+                  <Chip
+                    label={t('mobile.filter.anyRating')}
+                    selected={localFilters.minUserRating == null}
+                    onPress={() => setFiltersPatch({ minUserRating: undefined })}
+                  />
+                  <StarRating
+                    value={localFilters.minUserRating}
+                    onChange={(value) => setFiltersPatch({ minUserRating: value })}
+                    clearValue={undefined}
+                  />
+                </View>
+                <SwitchRow
+                  label={t('mobile.filter.onlyRatedByMe')}
+                  value={!!localFilters.onlyRatedByMe}
+                  onValueChange={(value) => setFiltersPatch({ onlyRatedByMe: value || undefined })}
+                />
               </View>
             ) : null}
 

--- a/packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx
@@ -749,6 +749,32 @@ describe('ClimbFilterSheet flat sections', () => {
     expect(queryByTestId('segment-drafts')).toBeNull();
   });
 
+  // Personal rating filters (#2645) live inside the auth-gated Your progress
+  // section, so they must disappear with it when signed out.
+  it('renders the My rating controls inside the auth-gated progress section', () => {
+    const { getByText, getByTestId } = renderFilterSheet();
+    expect(getByText('mobile.filter.myRating')).not.toBeNull();
+    expect(getByTestId('switch-mobile.filter.onlyRatedByMe')).not.toBeNull();
+  });
+
+  it('hides the My rating controls when signed out', () => {
+    authMock.isAuthenticated = false;
+    const { queryByText, queryByTestId } = renderFilterSheet();
+    expect(queryByText('mobile.filter.myRating')).toBeNull();
+    expect(queryByTestId('switch-mobile.filter.onlyRatedByMe')).toBeNull();
+  });
+
+  it('applies onlyRatedByMe when the rated-by-me switch is turned on', () => {
+    const onApply = vi.fn();
+    const { getByTestId, getByText } = renderFilterSheet({ onApply });
+
+    fireEvent.click(getByTestId('switch-mobile.filter.onlyRatedByMe'));
+    fireEvent.click(getByText('mobile.filter.showCount12'));
+
+    const applied = onApply.mock.calls.at(-1)?.[0] as ClimbFilters;
+    expect(applied.onlyRatedByMe).toBe(true);
+  });
+
   it('selecting the "Unrepeated" popularity bucket sets status to projects', () => {
     const onApply = vi.fn();
     const { getByLabelText, getByText } = renderFilterSheet({ onApply });

--- a/packages/mobile/src/db/queries/__tests__/search-climbs-local.test.ts
+++ b/packages/mobile/src/db/queries/__tests__/search-climbs-local.test.ts
@@ -137,11 +137,22 @@ async function insertGrade(db: TestSqliteDb, fixture: GradeFixture): Promise<voi
 
 async function insertTick(
   db: TestSqliteDb,
-  opts: { uuid: string; climbUuid: string; boardType?: string; angle?: number; status: string },
+  opts: {
+    uuid: string;
+    climbUuid: string;
+    boardType?: string;
+    angle?: number;
+    status: string;
+    // Star rating and when it was given — the personal-rating filter reads both
+    // (latest rating wins).
+    quality?: number | null;
+    climbedAt?: string;
+  },
 ): Promise<void> {
+  const timestamp = opts.climbedAt ?? '2026-02-01T00:00:00Z';
   await db.runAsync(
-    `INSERT INTO boardsesh_ticks (uuid, user_id, board_type, climb_uuid, angle, is_mirror, status, attempt_count, is_benchmark, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, 0, ?, 1, 0, ?, ?)`,
+    `INSERT INTO boardsesh_ticks (uuid, user_id, board_type, climb_uuid, angle, is_mirror, status, attempt_count, quality, is_benchmark, climbed_at, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, 0, ?, 1, ?, 0, ?, ?, ?)`,
     [
       opts.uuid,
       'me',
@@ -149,8 +160,10 @@ async function insertTick(
       opts.climbUuid,
       opts.angle ?? 40,
       opts.status,
-      '2026-02-01T00:00:00Z',
-      '2026-02-01T00:00:00Z',
+      opts.quality ?? null,
+      timestamp,
+      timestamp,
+      timestamp,
     ],
   );
 }
@@ -270,6 +283,75 @@ describe('searchClimbsLocal', () => {
     const sent = withCounts.climbs.find((c) => c.uuid === 'sent');
     expect(sent?.userAscents).toBe(1);
     expect(sent?.userAttempts).toBe(0);
+  });
+
+  // Same three-case matrix the server test asserts (packages/backend
+  // src/__tests__/climb-queries.test.ts), so an offline search returns the same
+  // rows as an online one.
+  describe('personal rating filters (#2645)', () => {
+    beforeEach(async () => {
+      for (const uuid of ['rated5', 'rated2', 'reratedUp', 'reratedDown', 'sentUnrated', 'untouched', 'otherAngle']) {
+        await insertClimb(db, { uuid });
+        await insertStat(db, { climbUuid: uuid, ascensionistCount: 3 });
+      }
+      await insertTick(db, { uuid: 'r5', climbUuid: 'rated5', status: 'send', quality: 5 });
+      await insertTick(db, { uuid: 'r2', climbUuid: 'rated2', status: 'send', quality: 2 });
+      // Re-rated in both directions: the later climbed_at is the opinion that counts.
+      await insertTick(db, {
+        uuid: 'up-old',
+        climbUuid: 'reratedUp',
+        status: 'send',
+        quality: 2,
+        climbedAt: '2026-01-01T00:00:00Z',
+      });
+      await insertTick(db, {
+        uuid: 'up-new',
+        climbUuid: 'reratedUp',
+        status: 'send',
+        quality: 5,
+        climbedAt: '2026-03-01T00:00:00Z',
+      });
+      await insertTick(db, {
+        uuid: 'down-old',
+        climbUuid: 'reratedDown',
+        status: 'send',
+        quality: 5,
+        climbedAt: '2026-01-01T00:00:00Z',
+      });
+      await insertTick(db, {
+        uuid: 'down-new',
+        climbUuid: 'reratedDown',
+        status: 'send',
+        quality: 2,
+        climbedAt: '2026-03-01T00:00:00Z',
+      });
+      await insertTick(db, { uuid: 'unrated', climbUuid: 'sentUnrated', status: 'send', quality: null });
+      await insertTick(db, { uuid: 'other', climbUuid: 'otherAngle', status: 'send', quality: 5, angle: 20 });
+    });
+
+    it('minUserRating keeps unrated climbs and drops only the ones rated below it', async () => {
+      const result = await searchClimbsLocal(db, makeInput({ minUserRating: 4, pageSize: 50 }));
+
+      expect(uuids(result).sort()).toEqual(['otherAngle', 'rated5', 'reratedUp', 'sentUnrated', 'untouched']);
+      expect(await countClimbsLocal(db, makeInput({ minUserRating: 4 }))).toBe(5);
+    });
+
+    it('onlyRatedByMe keeps every climb rated at this angle, whatever the stars', async () => {
+      const result = await searchClimbsLocal(db, makeInput({ onlyRatedByMe: true, pageSize: 50 }));
+
+      expect(uuids(result).sort()).toEqual(['rated2', 'rated5', 'reratedDown', 'reratedUp']);
+    });
+
+    it('both together drop the unrated climbs too', async () => {
+      const result = await searchClimbsLocal(db, makeInput({ minUserRating: 4, onlyRatedByMe: true, pageSize: 50 }));
+
+      expect(uuids(result).sort()).toEqual(['rated5', 'reratedUp']);
+      expect(await countClimbsLocal(db, makeInput({ minUserRating: 4, onlyRatedByMe: true }))).toBe(2);
+    });
+
+    it('stays offline-expressible so the search does not fall back to the network', () => {
+      expect(isOfflineSearchSupported(makeInput({ minUserRating: 4, onlyRatedByMe: true }))).toBe(true);
+    });
   });
 
   it('maps difficulty label, stars, and is_no_match from local columns', async () => {

--- a/packages/mobile/src/db/queries/search-climbs-local.ts
+++ b/packages/mobile/src/db/queries/search-climbs-local.ts
@@ -125,7 +125,8 @@ function parseHoldsFilter(holdsFilter: unknown): HoldFilters {
 export function isOfflineSearchSupported(input: ClimbSearchInput): boolean {
   // projectsOnly, boulders/routes, benchmarks, name, setter, grade range, min
   // ascents/rating, present-hold, tall/wide (via the synced compatible_size_ids,
-  // see buildJoinAndWhere), and personal-progress filters are all supported.
+  // see buildJoinAndWhere), and personal progress/rating filters are all
+  // supported (synced ticks carry quality + climbed_at).
   // These need tables we don't sync (or the drafts owner path), so fall back:
   if (input.onlyDrafts) return false;
   if (input.onlyWithBetaVideos) return false;
@@ -298,6 +299,31 @@ function buildJoinAndWhere(input: ClimbSearchInput): JoinAndWhere {
   if (input.hideCompleted) push(ticksExists(true, `t.status IN ${COMPLETED_STATUSES}`), boardType, angle);
   if (input.showOnlyAttempted) push(ticksExists(false, "t.status = 'attempt'"), boardType, angle);
   if (input.showOnlyCompleted) push(ticksExists(false, `t.status IN ${COMPLETED_STATUSES}`), boardType, angle);
+
+  // Personal rating, mirroring create-climb-filters.ts case for case so an
+  // offline search returns the same rows as an online one. The local ticks
+  // table has no bigserial id, so the latest-rating tie-break falls back to
+  // updated_at where the server uses id — only reachable when two ratings of
+  // one climb share a climbed_at.
+  if (input.onlyRatedByMe) push(ticksExists(false, 't.quality IS NOT NULL'), boardType, angle);
+  if (input.minUserRating) {
+    push(
+      `NOT EXISTS (SELECT 1 FROM boardsesh_ticks rating_below
+        WHERE rating_below.climb_uuid = c.uuid AND rating_below.board_type = ? AND rating_below.angle = ?
+        AND rating_below.quality IS NOT NULL AND rating_below.quality < ?
+        AND NOT EXISTS (SELECT 1 FROM boardsesh_ticks rating_newer
+          WHERE rating_newer.climb_uuid = rating_below.climb_uuid
+          AND rating_newer.board_type = rating_below.board_type
+          AND rating_newer.angle = rating_below.angle
+          AND rating_newer.quality IS NOT NULL
+          AND (rating_newer.climbed_at > rating_below.climbed_at
+            OR (rating_newer.climbed_at = rating_below.climbed_at
+              AND rating_newer.updated_at > rating_below.updated_at))))`,
+      boardType,
+      angle,
+      input.minUserRating,
+    );
+  }
 
   return { joinSql, whereSql: conditions.join(' AND '), joinBinds, whereBinds };
 }

--- a/packages/mobile/src/lib/__tests__/climb-filter-types.test.ts
+++ b/packages/mobile/src/lib/__tests__/climb-filter-types.test.ts
@@ -42,4 +42,18 @@ describe('statusForAuth', () => {
     const filters: ClimbFilters = { ...DEFAULT_FILTERS, showOnlyCompleted: true };
     expect(statusForAuth(filters, true)).toBe(filters);
   });
+
+  // The personal rating filters live in the same auth-gated section (#2645), so
+  // signed out they'd filter the list with no visible control to clear them.
+  it('clears the personal rating filters when signed out', () => {
+    const filters: ClimbFilters = { ...DEFAULT_FILTERS, minUserRating: 4, onlyRatedByMe: true };
+    const result = statusForAuth(filters, false);
+    expect(result.minUserRating).toBeUndefined();
+    expect(result.onlyRatedByMe).toBeUndefined();
+  });
+
+  it('leaves the personal rating filters alone when signed in (same reference)', () => {
+    const filters: ClimbFilters = { ...DEFAULT_FILTERS, minUserRating: 4 };
+    expect(statusForAuth(filters, true)).toBe(filters);
+  });
 });

--- a/packages/mobile/src/lib/__tests__/filter-summary.test.ts
+++ b/packages/mobile/src/lib/__tests__/filter-summary.test.ts
@@ -30,6 +30,8 @@ const mockT = ((key: string, options?: Record<string, unknown>) => {
   if (key === 'mobile.search.gradeMax') return `≤${text(options?.grade)}`;
   if (key === 'mobile.search.ascents') return `${text(options?.count)}+ 🧗`;
   if (key === 'mobile.search.rating') return `${text(options?.count)}+ ⭐`;
+  if (key === 'mobile.search.myRating') return `My ${text(options?.count)}+ ⭐`;
+  if (key === 'mobile.filter.ratedByMeShort') return 'Rated by me';
   if (key === 'mobile.search.more') return `+${text(options?.count)} more`;
   if (key === 'mobile.search.setterName') return `By ${text(options?.setter)}`;
   if (key === 'mobile.search.settersCount') return `${text(options?.count)} setters`;
@@ -116,6 +118,25 @@ describe('getFilterSummary', () => {
   it('shows the setter count when multiple setters are selected', () => {
     const filters: ClimbFilters = { ...DEFAULT_FILTERS, setter: ['marco', 'jules'] };
     expect(getFilterSummary(filters, '', mockGrades, mockT)).toBe('2 setters');
+  });
+
+  // The summary is the recent-filter pill's label (climbs/index.tsx), so a
+  // rating-only search must not save under the generic "Filters" fallback, and
+  // "my 4 stars" has to read differently from the community "4+ stars".
+  it('names the personal star minimum, distinctly from the community rating', () => {
+    const filters: ClimbFilters = { ...DEFAULT_FILTERS, minUserRating: 4 };
+    expect(getFilterSummary(filters, '', mockGrades, mockT)).toBe('My 4+ ⭐');
+    expect(getFilterSummary({ ...DEFAULT_FILTERS, minRating: 4 }, '', mockGrades, mockT)).toBe('4+ ⭐');
+  });
+
+  it('names the rated-by-me switch', () => {
+    const filters: ClimbFilters = { ...DEFAULT_FILTERS, onlyRatedByMe: true };
+    expect(getFilterSummary(filters, '', mockGrades, mockT)).toBe('Rated by me');
+  });
+
+  it('shows both personal rating levers together', () => {
+    const filters: ClimbFilters = { ...DEFAULT_FILTERS, minUserRating: 4, onlyRatedByMe: true };
+    expect(getFilterSummary(filters, '', mockGrades, mockT)).toBe('My 4+ ⭐ · Rated by me');
   });
 });
 

--- a/packages/mobile/src/lib/__tests__/filter-tokens.test.ts
+++ b/packages/mobile/src/lib/__tests__/filter-tokens.test.ts
@@ -21,6 +21,8 @@ const mockT = ((key: string, options?: Record<string, unknown>) => {
   if (key === 'mobile.search.gradeMax') return `≤${text(options?.grade)}`;
   if (key === 'mobile.search.ascents') return `${text(options?.count)}+ 🧗`;
   if (key === 'mobile.search.rating') return `${text(options?.count)}+ ⭐`;
+  if (key === 'mobile.search.myRating') return `My ${text(options?.count)}+ ⭐`;
+  if (key === 'mobile.filter.ratedByMeShort') return 'Rated by me';
   if (key === 'mobile.search.setterName') return `By ${text(options?.setter)}`;
   if (key === 'mobile.search.settersCount') return `${text(options?.count)} setters`;
   if (key === 'search.summary.routesOnly') return 'Routes only';
@@ -158,6 +160,20 @@ describe('getActiveFilterTokens', () => {
     expect(status?.label).toBe('Unrepeated');
     status?.clear();
     expect(patchFilters).toHaveBeenCalledWith({ status: 'any', minAscents: undefined });
+  });
+
+  it('gives each personal rating lever its own clearable token', () => {
+    const { tokens, patchFilters } = build({ ...DEFAULT_FILTERS, minUserRating: 4, onlyRatedByMe: true });
+
+    const myRating = tokens.find((token) => token.key === 'minUserRating');
+    expect(myRating?.label).toBe('My 4+ ⭐');
+    myRating?.clear();
+    expect(patchFilters).toHaveBeenCalledWith({ minUserRating: undefined });
+
+    const ratedByMe = tokens.find((token) => token.key === 'onlyRatedByMe');
+    expect(ratedByMe?.label).toBe('Rated by me');
+    ratedByMe?.clear();
+    expect(patchFilters).toHaveBeenCalledWith({ onlyRatedByMe: undefined });
   });
 
   it('orders grade first, then refinements in summary order', () => {

--- a/packages/mobile/src/lib/__tests__/recent-filter-store.test.ts
+++ b/packages/mobile/src/lib/__tests__/recent-filter-store.test.ts
@@ -121,6 +121,8 @@ describe('getRecentFilters sanitizer', () => {
           status: 'any',
           hideAttempted: true,
           showOnlyCompleted: true,
+          minUserRating: 4,
+          onlyRatedByMe: true,
           minGrade: 10,
         },
         searchText: '',
@@ -130,6 +132,10 @@ describe('getRecentFilters sanitizer', () => {
     const result = await getRecentFilters({ isAuthenticated: false });
     expect(result[0]?.filters).not.toHaveProperty('hideAttempted');
     expect(result[0]?.filters).not.toHaveProperty('showOnlyCompleted');
+    // The personal rating filters are auth-gated too — a replayed pill would
+    // otherwise render as active while the backend ignores it.
+    expect(result[0]?.filters).not.toHaveProperty('minUserRating');
+    expect(result[0]?.filters).not.toHaveProperty('onlyRatedByMe');
     expect(result[0]?.filters.minGrade).toBe(10);
   });
 

--- a/packages/mobile/src/lib/climb-filter-types.ts
+++ b/packages/mobile/src/lib/climb-filter-types.ts
@@ -11,19 +11,25 @@ export type { SortOption };
 
 /**
  * Sanitizes the whole auth-gated "Your progress" section for a signed-out user.
- * That section — the `drafts` status and the personal progress lens (the four
- * per-user tick flags) — is hidden when signed out, so a value left over from a
- * prior signed-in session would filter the results with no visible control to
- * change it. Coerce `drafts`→`any` (the option is also gated out of the status
- * picker) and clear the tick flags. Pure, so it can run inside a `useState`
- * initializer and an effect with no ordering hazards, and returns the same
- * reference when there's nothing to change.
+ * That section — the `drafts` status, the personal progress lens (the four
+ * per-user tick flags) and the personal rating filters — is hidden when signed
+ * out, so a value left over from a prior signed-in session would filter the
+ * results with no visible control to change it. Coerce `drafts`→`any` (the
+ * option is also gated out of the status picker) and clear the tick flags and
+ * personal ratings. Pure, so it can run inside a `useState` initializer and an
+ * effect with no ordering hazards, and returns the same reference when there's
+ * nothing to change.
  */
 export function statusForAuth(filters: ClimbFilters, isAuthenticated: boolean): ClimbFilters {
   if (isAuthenticated) return filters;
   const needsStatusReset = filters.status === 'drafts';
   const needsProgressReset =
-    filters.hideAttempted || filters.hideCompleted || filters.showOnlyAttempted || filters.showOnlyCompleted;
+    filters.hideAttempted ||
+    filters.hideCompleted ||
+    filters.showOnlyAttempted ||
+    filters.showOnlyCompleted ||
+    filters.minUserRating != null ||
+    filters.onlyRatedByMe;
   if (!needsStatusReset && !needsProgressReset) return filters;
   return {
     ...filters,
@@ -32,5 +38,7 @@ export function statusForAuth(filters: ClimbFilters, isAuthenticated: boolean): 
     hideCompleted: undefined,
     showOnlyAttempted: undefined,
     showOnlyCompleted: undefined,
+    minUserRating: undefined,
+    onlyRatedByMe: undefined,
   };
 }

--- a/packages/mobile/src/lib/filter-labels.ts
+++ b/packages/mobile/src/lib/filter-labels.ts
@@ -49,6 +49,10 @@ export function buildFilterLabels(t: TFunction<'climbs'>): ClimbFilterLabels {
     gradeMax: (grade) => t('mobile.search.gradeMax', { grade }),
     ascents: (count) => t('mobile.search.ascents', { count }),
     rating: (count) => t('mobile.search.rating', { count }),
+    // The user's own stars. Prefixed ("My 4+ ⭐") so a receipt row carrying both
+    // rating filters can't be read as two community thresholds.
+    myRating: (count) => t('mobile.search.myRating', { count }),
+    onlyRatedByMe: () => t('mobile.filter.ratedByMeShort'),
     more: (count) => t('mobile.search.more', { count }),
     // i18n-keep mobile.search.settersCount
     setters: (count) => t('mobile.search.settersCount', { count }),

--- a/packages/mobile/src/lib/filter-summary.ts
+++ b/packages/mobile/src/lib/filter-summary.ts
@@ -39,6 +39,11 @@ export function getFilterSummary(
       hideCompleted: filters.hideCompleted,
       showOnlyAttempted: filters.showOnlyAttempted,
       showOnlyCompleted: filters.showOnlyCompleted,
+      // Personal rating (#2645). Without these a rating-only search saves its
+      // recent pill under the generic "Filters" title, and two different star
+      // minimums become indistinguishable pills.
+      minUserRating: filters.minUserRating,
+      onlyRatedByMe: filters.onlyRatedByMe,
     },
     grades ?? [],
     labels,

--- a/packages/mobile/src/lib/filter-tokens.ts
+++ b/packages/mobile/src/lib/filter-tokens.ts
@@ -122,6 +122,24 @@ export function getActiveFilterTokens({
     });
   }
 
+  // Personal rating (auth-gated). Both levers get their own token so either can
+  // be cleared without losing the other.
+  if (filters.minUserRating != null) {
+    tokens.push({
+      key: 'minUserRating',
+      label: labels.myRating(filters.minUserRating),
+      clear: () => patchFilters({ minUserRating: undefined }),
+    });
+  }
+
+  if (filters.onlyRatedByMe) {
+    tokens.push({
+      key: 'onlyRatedByMe',
+      label: labels.onlyRatedByMe(),
+      clear: () => patchFilters({ onlyRatedByMe: undefined }),
+    });
+  }
+
   if (filters.setter != null && filters.setter.length > 0) {
     tokens.push({
       key: 'setter',

--- a/packages/mobile/src/lib/recent-filter-store.ts
+++ b/packages/mobile/src/lib/recent-filter-store.ts
@@ -26,6 +26,8 @@ export const AUTH_GATED_FIELDS = [
   'hideCompleted',
   'showOnlyAttempted',
   'showOnlyCompleted',
+  'minUserRating',
+  'onlyRatedByMe',
 ] as const satisfies ReadonlyArray<keyof ClimbFilters>;
 
 function isValidEntry(entry: unknown): entry is RecentFilter {

--- a/packages/shared-schema/src/__tests__/user-specific-search-params.test.ts
+++ b/packages/shared-schema/src/__tests__/user-specific-search-params.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { USER_SPECIFIC_SEARCH_PARAMS } from '../types/climb';
+
+// USER_SPECIFIC_SEARCH_PARAMS drives two things at once in the search resolver
+// (packages/backend/src/graphql/resolvers/climbs/queries.ts): whether a userId
+// is resolved at all, and whether the result may be written to the shared Redis
+// entry. A filter missing from this list silently no-ops AND leaks a
+// personalized result into everyone else's cache, with no type error to catch
+// it — hence the explicit list assertion.
+describe('USER_SPECIFIC_SEARCH_PARAMS', () => {
+  it('lists every auth-gated search filter', () => {
+    expect([...USER_SPECIFIC_SEARCH_PARAMS].sort()).toEqual(
+      [
+        'hideAttempted',
+        'hideCompleted',
+        'showOnlyAttempted',
+        'showOnlyCompleted',
+        'minUserRating',
+        'onlyRatedByMe',
+        'onlyDrafts',
+      ].sort(),
+    );
+  });
+
+  it('includes the personal rating filters (#2645)', () => {
+    expect(USER_SPECIFIC_SEARCH_PARAMS).toContain('minUserRating');
+    expect(USER_SPECIFIC_SEARCH_PARAMS).toContain('onlyRatedByMe');
+  });
+});

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -195,6 +195,10 @@ input ClimbSearchInput {
   showOnlyAttempted: Boolean
   "Only show climbs the user has completed (requires auth)"
   showOnlyCompleted: Boolean
+  "Hide climbs whose latest rating from the user, at this angle, is below this many stars. Climbs the user never rated stay visible unless onlyRatedByMe is also set. 0 means no minimum. (requires auth)"
+  minUserRating: Int
+  "Only show climbs the user has rated at this angle (requires auth)"
+  onlyRatedByMe: Boolean
   "Show only the user's draft climbs (requires auth)"
   onlyDrafts: Boolean
   "Show only unclimbed projects (climbs with 0 ascents)"

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -1097,12 +1097,16 @@ export type ClimbSearchInput = {
   minGrade?: InputMaybe<Scalars['Int']['input']>;
   /** Minimum quality rating */
   minRating?: InputMaybe<Scalars['Float']['input']>;
+  /** Hide climbs whose latest rating from the user, at this angle, is below this many stars. Climbs the user never rated stay visible unless onlyRatedByMe is also set. 0 means no minimum. (requires auth) */
+  minUserRating?: InputMaybe<Scalars['Int']['input']>;
   /** Filter by climb name (partial match) */
   name?: InputMaybe<Scalars['String']['input']>;
   /** Only show benchmark climbs */
   onlyBenchmarks?: InputMaybe<Scalars['Boolean']['input']>;
   /** Show only the user's draft climbs (requires auth) */
   onlyDrafts?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Only show climbs the user has rated at this angle (requires auth) */
+  onlyRatedByMe?: InputMaybe<Scalars['Boolean']['input']>;
   /** Only show tall/steep climbs */
   onlyTallClimbs?: InputMaybe<Scalars['Boolean']['input']>;
   /** Only show Kilter Homewall climbs that use the 10x10 side expansion */

--- a/packages/shared-schema/src/schema/climb.ts
+++ b/packages/shared-schema/src/schema/climb.ts
@@ -191,6 +191,10 @@ export const climbTypeDefs = /* GraphQL */ `
     showOnlyAttempted: Boolean
     "Only show climbs the user has completed (requires auth)"
     showOnlyCompleted: Boolean
+    "Hide climbs whose latest rating from the user, at this angle, is below this many stars. Climbs the user never rated stay visible unless onlyRatedByMe is also set. 0 means no minimum. (requires auth)"
+    minUserRating: Int
+    "Only show climbs the user has rated at this angle (requires auth)"
+    onlyRatedByMe: Boolean
     "Show only the user's draft climbs (requires auth)"
     onlyDrafts: Boolean
     "Show only unclimbed projects (climbs with 0 ascents)"

--- a/packages/shared-schema/src/types/climb.ts
+++ b/packages/shared-schema/src/types/climb.ts
@@ -151,6 +151,11 @@ export type ClimbSearchInput = {
   hideCompleted?: boolean;
   showOnlyAttempted?: boolean;
   showOnlyCompleted?: boolean;
+  // Personal rating filters, read from the user's own ticks at the browsed
+  // angle. `minUserRating` keeps unrated climbs visible (0 = no minimum);
+  // `onlyRatedByMe` drops them.
+  minUserRating?: number;
+  onlyRatedByMe?: boolean;
   onlyDrafts?: boolean;
   projectsOnly?: boolean;
   // Climb-type toggles. Both undefined / both true → no frames_count filter.
@@ -175,6 +180,8 @@ export const USER_SPECIFIC_SEARCH_PARAMS = [
   'hideCompleted',
   'showOnlyAttempted',
   'showOnlyCompleted',
+  'minUserRating',
+  'onlyRatedByMe',
   'onlyDrafts',
 ] as const satisfies ReadonlyArray<keyof ClimbSearchInput>;
 

--- a/packages/shared/climb-filters/src/__tests__/filter-state.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/filter-state.test.ts
@@ -301,3 +301,27 @@ describe('applyStatusChange', () => {
     expect(input.minAscents).toBe(2);
   });
 });
+
+describe('personal rating filters (#2645)', () => {
+  it('counts a star minimum and the rated-by-me switch as active filters', () => {
+    expect(hasActiveClimbFilters({ ...DEFAULT_CLIMB_FILTER_STATE, minUserRating: 4 })).toBe(true);
+    expect(hasActiveClimbFilters({ ...DEFAULT_CLIMB_FILTER_STATE, onlyRatedByMe: true })).toBe(true);
+  });
+
+  it('forwards both to the search input', () => {
+    const state: ClimbFilterState = { ...DEFAULT_CLIMB_FILTER_STATE, minUserRating: 4, onlyRatedByMe: true };
+    const input = toClimbSearchInput(state, board, pagination);
+
+    expect(input.minUserRating).toBe(4);
+    expect(input.onlyRatedByMe).toBe(true);
+  });
+
+  it('omits both when unset, so an unfiltered search stays anonymous and cacheable', () => {
+    const input = toClimbSearchInput(DEFAULT_CLIMB_FILTER_STATE, board, pagination);
+
+    expect(input.minUserRating).toBeUndefined();
+    expect(input.onlyRatedByMe).toBeUndefined();
+    expect('minUserRating' in input).toBe(false);
+    expect('onlyRatedByMe' in input).toBe(false);
+  });
+});

--- a/packages/shared/climb-filters/src/active-filter-count.ts
+++ b/packages/shared/climb-filters/src/active-filter-count.ts
@@ -21,6 +21,10 @@ export function countActiveFiltersBeyondGrade(filters: ClimbFilterState, boardFi
   // The four tick flags are one conceptual axis (the "Your progress" selector),
   // so they contribute at most one — "Not tried" sets two flags but is one choice.
   if (isProgressFilterActive(filters)) count += 1;
+  // Personal rating: the star minimum and the "only climbs I've rated" switch
+  // are independent levers, each clearable on its own from the receipt row.
+  if (filters.minUserRating != null) count += 1;
+  if (filters.onlyRatedByMe) count += 1;
   // Climb-type defaults to boulders-only; "active" = routes on or boulders off.
   if ((filters.boulders ?? true) !== true || (filters.routes ?? false) !== false) count += 1;
   if (

--- a/packages/shared/climb-filters/src/filter-state.ts
+++ b/packages/shared/climb-filters/src/filter-state.ts
@@ -63,6 +63,11 @@ export type ClimbFilterState = {
   hideCompleted?: boolean;
   showOnlyAttempted?: boolean;
   showOnlyCompleted?: boolean;
+  // The user's own star rating, read from their ticks at the browsed angle.
+  // `minUserRating` (1-5) keeps climbs they never rated; `onlyRatedByMe` drops
+  // those. Both are auth-gated backend-side, like the four tick flags above.
+  minUserRating?: number;
+  onlyRatedByMe?: boolean;
 };
 
 export const DEFAULT_CLIMB_FILTER_STATE: ClimbFilterState = {
@@ -94,6 +99,8 @@ export function hasActiveClimbFilters(state: ClimbFilterState): boolean {
   if (state.hideCompleted) return true;
   if (state.showOnlyAttempted) return true;
   if (state.showOnlyCompleted) return true;
+  if (state.minUserRating != null) return true;
+  if (state.onlyRatedByMe) return true;
   // Default is boulders-only, so "active" means routes turned on or boulders off.
   if ((state.boulders ?? true) !== true) return true;
   if ((state.routes ?? false) !== false) return true;
@@ -192,6 +199,8 @@ export function toClimbSearchInput(
   if (state.hideCompleted) input.hideCompleted = true;
   if (state.showOnlyAttempted) input.showOnlyAttempted = true;
   if (state.showOnlyCompleted) input.showOnlyCompleted = true;
+  if (state.minUserRating != null) input.minUserRating = state.minUserRating;
+  if (state.onlyRatedByMe) input.onlyRatedByMe = true;
 
   // Climb-type filter. Both-on ("All") and both-off mean "no preference" for
   // the frames_count constraint, but they must NOT be handled the same way:

--- a/packages/shared/climb-filters/src/filter-summary.ts
+++ b/packages/shared/climb-filters/src/filter-summary.ts
@@ -25,6 +25,10 @@ export type FilterSummaryLabels = {
   // part (e.g. "Projects") instead of one part per flag. Callers on the old
   // four-switch model omit this and keep the per-flag parts above.
   progress?: (value: Exclude<ProgressFilter, 'all'>) => string;
+  // The user's own rating (auth-gated). Optional like the fields above — only
+  // callers that expose the personal-rating controls supply these.
+  myRating?: (count: number) => string;
+  onlyRatedByMe?: () => string;
 };
 
 export type BaseFilters = {
@@ -45,6 +49,8 @@ export type BaseFilters = {
   hideCompleted?: boolean;
   showOnlyAttempted?: boolean;
   showOnlyCompleted?: boolean;
+  minUserRating?: number;
+  onlyRatedByMe?: boolean;
 };
 
 // Web suppresses minAscents >= 2 when the "Established" status chip is active
@@ -89,6 +95,14 @@ export function getBaseFilterParts(
 
   if (filters.minRating != null) {
     parts.push(labels.rating(filters.minRating));
+  }
+
+  if (filters.minUserRating != null && labels.myRating) {
+    parts.push(labels.myRating(filters.minUserRating));
+  }
+
+  if (filters.onlyRatedByMe && labels.onlyRatedByMe) {
+    parts.push(labels.onlyRatedByMe());
   }
 
   if (filters.setter != null && filters.setter.length > 0 && labels.setters) {

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -1094,12 +1094,16 @@ export type ClimbSearchInput = {
   minGrade?: InputMaybe<Scalars['Int']['input']>;
   /** Minimum quality rating */
   minRating?: InputMaybe<Scalars['Float']['input']>;
+  /** Hide climbs whose latest rating from the user, at this angle, is below this many stars. Climbs the user never rated stay visible unless onlyRatedByMe is also set. 0 means no minimum. (requires auth) */
+  minUserRating?: InputMaybe<Scalars['Int']['input']>;
   /** Filter by climb name (partial match) */
   name?: InputMaybe<Scalars['String']['input']>;
   /** Only show benchmark climbs */
   onlyBenchmarks?: InputMaybe<Scalars['Boolean']['input']>;
   /** Show only the user's draft climbs (requires auth) */
   onlyDrafts?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Only show climbs the user has rated at this angle (requires auth) */
+  onlyRatedByMe?: InputMaybe<Scalars['Boolean']['input']>;
   /** Only show tall/steep climbs */
   onlyTallClimbs?: InputMaybe<Scalars['Boolean']['input']>;
   /** Only show Kilter Homewall climbs that use the 10x10 side expansion */

--- a/packages/shared/graphql/src/operations/climb-search.ts
+++ b/packages/shared/graphql/src/operations/climb-search.ts
@@ -152,6 +152,8 @@ export type ClimbSearchInputVariables = {
     hideCompleted?: boolean;
     showOnlyAttempted?: boolean;
     showOnlyCompleted?: boolean;
+    minUserRating?: number;
+    onlyRatedByMe?: boolean;
     onlyDrafts?: boolean;
     projectsOnly?: boolean;
     boulders?: boolean;

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -683,6 +683,10 @@
       "anyAscents": "Beliebig",
       "minRating": "Min. Bewertung",
       "anyRating": "Beliebig",
+      "myRating": "Meine Bewertung",
+      "myRatingDescription": "Sterne, die du in diesem Winkel vergeben hast",
+      "onlyRatedByMe": "Nur Boulder, die ich bewertet habe",
+      "ratedByMeShort": "Von mir bewertet",
       "apply": "Filter anwenden",
       "reset": "Zurücksetzen",
       "section": {
@@ -764,6 +768,7 @@
       "gradeMax": "≤{{grade}}",
       "ascents": "{{count}}+ 🧗",
       "rating": "{{count}}+ ⭐",
+      "myRating": "Meine {{count}}+ ⭐",
       "more": "+{{count}} weitere",
       "setterName": "Von {{setter}}",
       "settersCount_one": "{{count}} Routenbauer*in",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -683,6 +683,10 @@
       "anyAscents": "Any",
       "minRating": "Min rating",
       "anyRating": "Any",
+      "myRating": "My rating",
+      "myRatingDescription": "Stars you gave at this angle",
+      "onlyRatedByMe": "Only climbs I've rated",
+      "ratedByMeShort": "Rated by me",
       "apply": "Apply filters",
       "reset": "Reset",
       "section": {
@@ -764,6 +768,7 @@
       "gradeMax": "≤{{grade}}",
       "ascents": "{{count}}+ 🧗",
       "rating": "{{count}}+ ⭐",
+      "myRating": "My {{count}}+ ⭐",
       "more": "+{{count}} more",
       "setterName": "By {{setter}}",
       "settersCount_one": "{{count}} setter",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -683,6 +683,10 @@
       "anyAscents": "Todos",
       "minRating": "Mín valoración",
       "anyRating": "Todos",
+      "myRating": "Mi valoración",
+      "myRatingDescription": "Las estrellas que diste en este ángulo",
+      "onlyRatedByMe": "Solo los bloques que valoré",
+      "ratedByMeShort": "Valorados por mí",
       "apply": "Aplicar filtros",
       "reset": "Restablecer",
       "section": {
@@ -764,6 +768,7 @@
       "gradeMax": "≤{{grade}}",
       "ascents": "{{count}}+ 🧗",
       "rating": "{{count}}+ ⭐",
+      "myRating": "Mis {{count}}+ ⭐",
       "more": "+{{count}} más",
       "setterName": "Por {{setter}}",
       "settersCount_one": "{{count}} equipador",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -683,6 +683,10 @@
       "anyAscents": "Tous",
       "minRating": "Min note",
       "anyRating": "Tous",
+      "myRating": "Ma note",
+      "myRatingDescription": "Les étoiles que tu as données à cet angle",
+      "onlyRatedByMe": "Seulement les blocs que j'ai notés",
+      "ratedByMeShort": "Notés par moi",
       "apply": "Appliquer les filtres",
       "reset": "Réinitialiser",
       "section": {
@@ -764,6 +768,7 @@
       "gradeMax": "≤{{grade}}",
       "ascents": "{{count}}+ 🧗",
       "rating": "{{count}}+ ⭐",
+      "myRating": "Mes {{count}}+ ⭐",
       "more": "+{{count}} de plus",
       "setterName": "Par {{setter}}",
       "settersCount_one": "{{count}} ouvreur",

--- a/packages/web/app/__tests__/middleware.test.ts
+++ b/packages/web/app/__tests__/middleware.test.ts
@@ -112,6 +112,12 @@ describe('getListPageCacheTTL', () => {
       ['showOnlyCompleted', '1'],
       ['onlyDrafts', 'true'],
       ['onlyDrafts', '1'],
+      ['onlyRatedByMe', 'true'],
+      ['onlyRatedByMe', '1'],
+      // Numeric param — a flag-only 'true'/'1' test reads this as absent and
+      // would let personalized HTML share the anonymous CDN entry for 24h.
+      ['minUserRating', '4'],
+      ['minUserRating', '1'],
     ])('skips cache for %s=%s (legacy format)', (param, value) => {
       expect(getListPageCacheTTL(LEGACY_LIST, sp({ [param]: value }))).toBeNull();
     });
@@ -139,7 +145,20 @@ describe('getListPageCacheTTL', () => {
       ['showOnlyCompleted', '0'],
       ['onlyDrafts', 'false'],
       ['onlyDrafts', '0'],
+      ['onlyRatedByMe', 'false'],
+      ['minUserRating', '0'],
+      ['minUserRating', ''],
     ])('caches for %s=%s', (param, value) => {
+      expect(getListPageCacheTTL(LEGACY_LIST, sp({ [param]: value }))).toBe(TTL_24H);
+    });
+
+    // Per-type parsing, not "any non-empty value is user-specific": a crawler
+    // appending junk must not turn every list page into a CDN miss.
+    it.each([
+      ['onlyDrafts', 'x'],
+      ['hideAttempted', 'yes'],
+      ['minUserRating', 'abc'],
+    ])('caches for junk value %s=%s instead of bypassing the CDN', (param, value) => {
       expect(getListPageCacheTTL(LEGACY_LIST, sp({ [param]: value }))).toBe(TTL_24H);
     });
   });

--- a/packages/web/app/lib/list-page-cache.ts
+++ b/packages/web/app/lib/list-page-cache.ts
@@ -21,14 +21,24 @@ export function hasUserSpecificFilters(searchParams: SearchRequestPagination): b
   return USER_SPECIFIC_SEARCH_PARAMS.some((param) => !!searchParams[param]);
 }
 
+// User-specific params carrying a number rather than a flag. A flag test
+// (`'true' | '1'`) would read `?minUserRating=4` as absent and let personalized
+// HTML share the anonymous CDN entry.
+const NUMERIC_USER_SPECIFIC_PARAMS: ReadonlySet<string> = new Set(['minUserRating']);
+
 /**
  * True when the query string carries a user-specific filter that would make the
  * server render personalized HTML. Such a request must never share a CDN cache
  * entry with the anonymous version, so it is not cached.
+ *
+ * Parsed per type on purpose: treating any non-empty value as user-specific
+ * would turn `?onlyDrafts=x` from a crawler into a CDN bypass on every list page.
  */
 function hasUserSpecificQueryParams(searchParams: URLSearchParams): boolean {
   return USER_SPECIFIC_SEARCH_PARAMS.some((param) => {
     const value = searchParams.get(param);
+    if (value == null) return false;
+    if (NUMERIC_USER_SPECIFIC_PARAMS.has(param)) return Number(value) > 0;
     return value === 'true' || value === '1';
   });
 }

--- a/packages/web/app/lib/types.ts
+++ b/packages/web/app/lib/types.ts
@@ -142,6 +142,11 @@ export type SearchRequest = {
   hideCompleted: boolean;
   showOnlyAttempted: boolean;
   showOnlyCompleted: boolean;
+  // Personal rating filters. Optional and never parsed out of the URL — the
+  // controls are mobile-only (see #3122) — but present so the shared
+  // USER_SPECIFIC_SEARCH_PARAMS list stays assignable to this shape.
+  minUserRating?: number;
+  onlyRatedByMe?: boolean;
   onlyDrafts: boolean;
   projectsOnly: boolean;
   // Climb-type filter (defaults: boulders=true, routes=false). Both true → no


### PR DESCRIPTION
## Summary

Revives the per-user quality filter from the stale PR #2053, reimplemented on current `main`. Two new auth-gated search filters, wired end to end (GraphQL schema → Zod → SQL → shared filter state → mobile UI → offline SQLite):

- **`minUserRating`** — hide climbs whose *latest* rating from me, at the angle I'm browsing, is below N stars. Climbs I never rated stay visible.
- **`onlyRatedByMe`** — keep only climbs I've rated at this angle.

Together they reproduce the three cases the issue spells out: min 4 + switch off → unrated **and** my 4+; switch on → only my 4+; min 0 + switch on → anything I rated.

Closes #2645

### Deviations from the issue's original design

- **No `user_climb_qualities` / `user_climb_grades` projection tables, no tick-write sync, no backfill migration.** `boardsesh_ticks.quality` is already written by every tick writer (native `saveTick`, Aurora pulls, MoonBoard import), the offline SQLite mirror already syncs `quality` + `climbed_at` + `updated_at`, and both `create-climb-filters.ts` and `smart-playlists.ts` already read per-user quality straight off ticks. A projection would add a whole drift class (the issue's own `climbed_at` staleness guard exists only because of it) and would have to be mirrored into the offline schema too. Reading ticks directly is correct the instant a rating is edited or deleted.
- **Mobile-only UI.** The web climbing surface is deprecated (#3122), so the web search form is untouched beyond the two type/cache-correctness edits TypeScript and the CDN force.
- **The "Progress → Logbook" rename is skipped**, for the same reason (it was a web search-form rename).
- **Ratings are scoped to the browsed angle**, matching every sibling personal filter and matching the community `quality_average` this mirrors, which is itself stored per angle. A climb you rated 5 at 40° reads as unrated at 25°.

### Why the SQL looks like that

The obvious form — a scalar `(SELECT quality … ORDER BY climbed_at DESC LIMIT 1)` correlated subquery — cannot be unnested by Postgres, so it emits a SubPlan that runs once per **candidate climb**. Measured on the dev DB (kilter layout 1, angle 40, 220,056 candidates, a user with 529 rated ticks): list page 0 went from 498 ms to 1084 ms and the count from 1000 ms to 2724 ms.

Both filters are written as `EXISTS` / `NOT EXISTS` instead, which the planner unnests into semi/anti joins driven from `boardsesh_ticks` — the same reason the four sibling progress filters are fast. `minUserRating` is the anti-join "exclude climbs holding a rating below N that no newer rating supersedes", which preserves latest-wins exactly. Measured: list 567 ms, count 381 ms — at or below the unfiltered baseline.

### Cache correctness

Both params join `USER_SPECIFIC_SEARCH_PARAMS`, which drives **both** the resolver's `userId` resolution and `_isCacheable`. Without that the filter silently no-ops *and* a personalized result lands in the shared Redis entry. On the CDN side, `hasUserSpecificQueryParams` only recognised `'true'`/`'1'`, so a numeric `?minUserRating=4` read as absent; it now parses per type (flags stay `'true'`/`'1'`, numeric params check `Number(value) > 0`) rather than treating any non-empty value as user-specific, which would have handed crawlers a CDN bypass via `?onlyDrafts=x`.

## Release Notes

- Filter the climb list by the stars you gave: set a minimum, or show only the climbs you've rated
- Works offline on a downloaded board, and re-rating a climb updates what the filter shows

## Test plan

- `vp run typecheck` — green
- `vp test run --project backend --reporter=agent climb-queries` — 40 passed. New block seeds a user, two re-rated climbs (2→5 and 5→2), an unrated tick, a rating at a different angle and another user's rating, then asserts the three-case matrix, that `countClimbs` agrees with the list, and that the filter is a no-op without a `userId`.
- `vp run test:mobile` — 5273 passed. Adds the same three-case matrix against the offline SQLite path, the sheet's auth gating, the receipt-row chips, `statusForAuth`, and the recent-pill stripping.
- `vp test run --project climb-filters --project shared-schema` — 325 passed (filter-state forwarding + the `USER_SPECIFIC_SEARCH_PARAMS` guard).
- `vp test run --project web --reporter=agent middleware` — 140 passed (numeric param skips the CDN; junk values still cache).
- `vp check` — no new errors; one warning class I hit matched the file's existing pattern and was rewritten away. The 28 errors / ~298 warnings the repo reports are identical on a clean `main` checkout.
- `vp run check:i18n`, `vp run check:i18n:orphans`, `vp run check:mobile-bundle` — all OK.
- Full `vp run test:web` has 6-9 failing files that vary run to run (logbook, session-creation, gym-entity, error-boundary) — none touch this change; flaky/pre-existing.
- Not run: simulator/screenshot checks (macOS only). No device pass on the new sheet controls yet.
