### PR TITLE
test(mobile): harden the react-native-screens patch guard against a re-keyed bump

### DIFF
--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -103,7 +103,8 @@ in a higher window, not native sheets.
 
 **How a dismiss "settles."** The coordinator needs to know when a dismiss animation has
 really finished before it starts the next transition. On **iOS** that's the accurate native
-signal: our `@expo/ui` patch (`patches/@expo%2Fui@57.0.3.patch`) forwards SwiftUI's
+signal: our `@expo/ui` patch (`patches/@expo%2Fui@57.0.8.patch` — the version is baked into the
+filename, so it moves on every bump) forwards SwiftUI's
 post-animation `.sheet(onDismiss:)` out of the community wrapper as `onFullyDismissed`, which
 `useManagedSheet` routes into `coordinator.notifyFullyDismissed`. So a surface that renders the
 raw `BottomSheetModal`/`BottomSheet` must pass `onFullyDismissed={managed.onFullyDismissed}` (the
@@ -358,6 +359,46 @@ bottom tab (e.g. `/wall`, the "On the Wall" tab — `app/(tabs)/wall/`):
 - Add a `SidebarDestination` in `IpadSidebar.tsx`; `tabsActiveSegment` (route-segments.ts) already
   highlights it. Suppress any ambient duplicate of the same content (e.g. the wall column) while
   the destination is the focused segment.
+
+## Bumping `react-native-screens` (the bottom-accessory patch)
+
+`patches/react-native-screens@4.26.2.patch` carries the iOS 26 bottom-accessory fix: UIKit lays
+an accessory in for free when it's set during the tab controller's initial setup, but not when
+it's attached after the tab bar has appeared — which is exactly our case, since the accessory
+only mounts once a current climb exists. The patch nudges a layout pass on that attach.
+
+**The nudge must never run synchronously.** `applyBottomAccessoryVisibility` is called from
+`updateContainer`, inside a React Native mounting transaction. The first version of the patch
+called `-layoutIfNeeded` right there, and that layout got pulled into a feedback loop between a
+presenting/dismissing `UISheetPresentationController` and the tab bar's minimize machinery
+(our layout → `-[UITabBar layoutSubviews]` → `_minimizeBehavior` → a sheet alongside-animation
+property set → `_sheetLayoutInfoLayout` → tab bar again). On iOS 27 that trips an AnimationKit
+assertion over a stack overflow: 6 users, 27 crashes, one session looping 13 times (Sentry
+BOARDSESH-9K, fixed in #4198 / 2.3.1). The shipped shape hops out of the transaction with one
+coalesced `dispatch_async`, and hands the work to the transition coordinator's completion block
+if a transition is in flight.
+
+Bun keys patches by exact version, so a bump means re-keying. The runbook:
+
+1. `bun patch react-native-screens` against the new version, re-apply the hunks, and check that
+   upstream still hasn't added its own relayout to `applyBottomAccessoryVisibility` (4.27.0 has
+   none — the patch is still required).
+2. Re-key `patchedDependencies` in the root `package.json`, rename the file under `patches/`,
+   and **delete the old file** — Bun ignores unreferenced patches without a word.
+3. Update `patchedKey` on both `react-native-screens` rules in `scripts/mobile-patches-check.ts`,
+   and the `overrides` pin in the root `package.json`.
+4. `vp run check:mobile-patches`.
+
+That check is the backstop, and it asserts shape, not just symbols: the deferral sentinels
+(`rnscreens_layoutBottomAccessoryOutsideTransition`, `_rnscreens_bottomAccessoryRelayoutScheduled`,
+`animateAlongsideTransition`) plus a negative assertion that no synchronous layout sits inside
+`applyBottomAccessoryVisibility`. A re-keyed patch that kept the entry-point symbol but restored
+the crashing line would otherwise pass green. If it reports it can't locate the anchor method,
+upstream reshaped it — re-verify the patch by hand and update the rule. Don't delete the
+assertion to get green.
+
+A `react-native-screens` bump is a native-fingerprint change: it goes through a `[native-train]`
+draft, not straight to `main` (see `docs/mobile-ota-updates.md`).
 
 ## See also
 

--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -373,8 +373,8 @@ called `-layoutIfNeeded` right there, and that layout got pulled into a feedback
 presenting/dismissing `UISheetPresentationController` and the tab bar's minimize machinery
 (our layout → `-[UITabBar layoutSubviews]` → `_minimizeBehavior` → a sheet alongside-animation
 property set → `_sheetLayoutInfoLayout` → tab bar again). On iOS 27 that trips an AnimationKit
-assertion over a stack overflow: 6 users, 27 crashes, one session looping 13 times (Sentry
-BOARDSESH-9K, fixed in #4198 / 2.3.1). The shipped shape hops out of the transaction with one
+assertion (`Missing animationAndComposerGetter`): 42 events across 6 users, every one of them on
+iOS 27.0 and on a pre-fix release (Sentry BOARDSESH-9K, fixed in #4198 / 2.3.1). The shipped shape hops out of the transaction with one
 coalesced `dispatch_async`, and hands the work to the transition coordinator's completion block
 if a transition is in flight.
 

--- a/scripts/__tests__/mobile-patches-check.test.ts
+++ b/scripts/__tests__/mobile-patches-check.test.ts
@@ -342,6 +342,40 @@ describe('extractObjCMethodBody', () => {
     expect(extractObjCMethodBody(source, 'applyBottomAccessoryVisibility')).not.toContain('layoutIfNeeded');
   });
 
+  // RNSTabsHostComponentView.mm already carries two `@interface (…)` class
+  // extensions. If upstream ever forward-declares the anchor in one of them, a
+  // first-match slicer would read the @implementation ivar block instead of the
+  // method body, and the negative assertion would silently pass on crashing code.
+  it('skips a forward declaration and finds the real definition', () => {
+    const source = `
+@interface RNSTabsHostComponentView ()
+- (void)applyBottomAccessoryVisibility API_AVAILABLE(ios(26.0));
+@end
+
+@implementation RNSTabsHostComponentView {
+  BOOL _rnscreens_bottomAccessoryRelayoutScheduled;
+}
+
+- (void)applyBottomAccessoryVisibility API_AVAILABLE(ios(26.0))
+{
+  [_controller.view layoutIfNeeded];
+}
+@end
+`;
+
+    expect(extractObjCMethodBody(source, 'applyBottomAccessoryVisibility')).toContain('layoutIfNeeded');
+  });
+
+  it('returns null when only a forward declaration exists, so the check fails loudly', () => {
+    const source = `
+@interface RNSTabsHostComponentView ()
+- (void)applyBottomAccessoryVisibility;
+@end
+`;
+
+    expect(extractObjCMethodBody(source, 'applyBottomAccessoryVisibility')).toBeNull();
+  });
+
   it('handles class methods and nested braces', () => {
     const source = `
 + (void)load

--- a/scripts/__tests__/mobile-patches-check.test.ts
+++ b/scripts/__tests__/mobile-patches-check.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { checkPatchesApplied, versionFromKey, type PatchCheckEnv, type PatchRule } from '../mobile-patches-check';
+import {
+  RULES as REAL_RULES,
+  UNGUARDED_PATCHES,
+  checkPatchInventory,
+  checkPatchesApplied,
+  extractObjCMethodBody,
+  versionFromKey,
+  type PatchCheckEnv,
+  type PatchRule,
+} from '../mobile-patches-check';
 
 const PKG = 'react-native-screens';
 const FILE = 'ios/helpers/scroll-view/RNSScrollViewFinder.mm';
@@ -219,5 +228,283 @@ describe('versionFromKey', () => {
 
   it('returns empty string when no version segment is present', () => {
     expect(versionFromKey('react-native-screens')).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The RNSTabsHostComponentView guard (BOARDSESH-9K).
+//
+// The crashing version of this patch and the fixed one BOTH define
+// `rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance`. What separates
+// them is where the layout happens, so the guard has to assert the deferral
+// machinery and the absence of a synchronous layout in the mounting-transaction
+// path — not just the presence of a symbol.
+// ---------------------------------------------------------------------------
+
+const TABS_FILE = 'ios/tabs/host/RNSTabsHostComponentView.mm';
+const TABS_KEY = 'react-native-screens@4.26.2';
+const TABS_RULES: PatchRule[] = [
+  {
+    package: PKG,
+    file: TABS_FILE,
+    sentinels: [
+      'rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance',
+      'rnscreens_layoutBottomAccessoryOutsideTransition',
+      '_rnscreens_bottomAccessoryRelayoutScheduled',
+      'animateAlongsideTransition',
+    ],
+    patchedKey: TABS_KEY,
+    forbiddenInMethod: [
+      {
+        method: 'applyBottomAccessoryVisibility',
+        substrings: ['layoutIfNeeded', 'layoutBelowIfNeeded'],
+        why: 'synchronous layout inside the RN mounting transaction — BOARDSESH-9K',
+      },
+    ],
+  },
+];
+
+/** The shipped (2.3.1) shape: attach-only nudge, layout deferred off-transaction. */
+const TABS_FIXED_SOURCE = `
+- (void)applyBottomAccessoryVisibility API_AVAILABLE(ios(26.0))
+{
+  if (_bottomAccessoryWrapperView != nil) {
+    [_controller setBottomAccessory:accessory animated:YES];
+    [self rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance];
+  }
+}
+
+// The original version of this method called -layoutIfNeeded right there, and
+// that synchronous layout got pulled into a UIKit feedback loop.
+- (void)rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance
+{
+  if (_rnscreens_bottomAccessoryRelayoutScheduled) {
+    return;
+  }
+  _rnscreens_bottomAccessoryRelayoutScheduled = YES;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [weakSelf rnscreens_layoutBottomAccessoryOutsideTransition];
+  });
+}
+
+- (void)rnscreens_layoutBottomAccessoryOutsideTransition
+{
+  if (transitionCoordinator != nil) {
+    BOOL registered = [transitionCoordinator animateAlongsideTransition:nil completion:^(id context) {
+      [weakSelf rnscreens_layoutBottomAccessoryOutsideTransition];
+    }];
+    if (registered) {
+      return;
+    }
+  }
+  _rnscreens_bottomAccessoryRelayoutScheduled = NO;
+  [controllerView setNeedsLayout];
+  [controllerView layoutIfNeeded];
+}
+`;
+
+/** A re-keyed patch that kept the symbols but restored the crashing layout. */
+const TABS_REGRESSED_SOURCE = TABS_FIXED_SOURCE.replace(
+  '[self rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance];',
+  '[self rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance];\n    [_controller.view layoutIfNeeded];',
+);
+
+const tabsEnv = (source: string) =>
+  makeEnv({
+    patchedDependencies: { [TABS_KEY]: `patches/${TABS_KEY}.patch` },
+    versions: { [PKG]: '4.26.2' },
+    files: { [`${PKG}::${TABS_FILE}`]: source },
+  });
+
+describe('extractObjCMethodBody', () => {
+  it('extracts a body and stops at the closing brace, not the next declaration', () => {
+    const body = extractObjCMethodBody(TABS_FIXED_SOURCE, 'applyBottomAccessoryVisibility');
+
+    expect(body).toContain('rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance');
+    expect(body).not.toContain('dispatch_async');
+    expect(body).not.toContain('layoutIfNeeded');
+  });
+
+  it('returns null when the method is absent', () => {
+    expect(extractObjCMethodBody(TABS_FIXED_SOURCE, 'someUpstreamRenamedMethod')).toBeNull();
+  });
+
+  it('ignores prose in comments — the patch documents the crashing call by name', () => {
+    const source = `
+- (void)applyBottomAccessoryVisibility
+{
+  // The old version called -layoutIfNeeded here. Never do that again.
+  /* layoutIfNeeded */
+  [self nudge];
+}
+`;
+
+    expect(extractObjCMethodBody(source, 'applyBottomAccessoryVisibility')).not.toContain('layoutIfNeeded');
+  });
+
+  it('handles class methods and nested braces', () => {
+    const source = `
++ (void)load
+{
+  if (yes) {
+    [self doThing];
+  }
+}
+- (void)next
+{
+  [self other];
+}
+`;
+    const body = extractObjCMethodBody(source, 'load');
+
+    expect(body).toContain('doThing');
+    expect(body).not.toContain('other');
+  });
+});
+
+describe('checkPatchesApplied forbiddenInMethod', () => {
+  it('passes on the shipped shape — layoutIfNeeded lives only in the deferred helper', () => {
+    const result = checkPatchesApplied(TABS_RULES, tabsEnv(TABS_FIXED_SOURCE));
+
+    expect(result.errors).toEqual([]);
+  });
+
+  it('fails when a synchronous layout is back inside applyBottomAccessoryVisibility', () => {
+    const result = checkPatchesApplied(TABS_RULES, tabsEnv(TABS_REGRESSED_SOURCE));
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('applyBottomAccessoryVisibility');
+    expect(result.errors[0]).toContain('layoutIfNeeded');
+    expect(result.errors[0]).toContain('BOARDSESH-9K');
+  });
+
+  it('fails loudly when the anchor method cannot be found (upstream moved it)', () => {
+    const renamed = TABS_FIXED_SOURCE.replaceAll('applyBottomAccessoryVisibility', 'updateBottomAccessoryVisibility');
+
+    const result = checkPatchesApplied(TABS_RULES, tabsEnv(renamed));
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('cannot locate');
+    expect(result.errors[0]).toContain('re-verify');
+  });
+
+  it.each([
+    'rnscreens_layoutBottomAccessoryOutsideTransition',
+    '_rnscreens_bottomAccessoryRelayoutScheduled',
+    'animateAlongsideTransition',
+  ])('reports a missing deferral sentinel: %s', (sentinel) => {
+    const withoutSentinel = TABS_FIXED_SOURCE.replaceAll(sentinel, 'someOtherThing');
+
+    const result = checkPatchesApplied(TABS_RULES, tabsEnv(withoutSentinel));
+
+    expect(result.errors.join('\n')).toContain(sentinel);
+  });
+});
+
+describe('checkPatchInventory', () => {
+  const base = {
+    patchedDependencies: { [TABS_KEY]: `patches/${TABS_KEY}.patch` },
+    patchFilenames: [`${TABS_KEY}.patch`],
+    guardedKeys: [TABS_KEY],
+    allowUnguarded: {},
+  };
+
+  it('passes when every key has a file, a file has a key, and every key is guarded', () => {
+    expect(checkPatchInventory(base)).toEqual([]);
+  });
+
+  it('fails when a key points at a patch file that is not there', () => {
+    const errors = checkPatchInventory({ ...base, patchFilenames: [] });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('not in patches/');
+  });
+
+  it('fails on an orphaned patch file left behind by a re-key', () => {
+    const errors = checkPatchInventory({
+      ...base,
+      patchFilenames: [`${TABS_KEY}.patch`, 'react-native-screens@4.25.2.patch'],
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('orphaned');
+    expect(errors[0]).toContain('4.25.2');
+  });
+
+  it('fails when a newly patched package has no rule and no allowlist entry', () => {
+    const errors = checkPatchInventory({
+      ...base,
+      patchedDependencies: {
+        ...base.patchedDependencies,
+        'some-native-mod@1.0.0': 'patches/some-native-mod@1.0.0.patch',
+      },
+      patchFilenames: [...base.patchFilenames, 'some-native-mod@1.0.0.patch'],
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('patched but unguarded');
+  });
+
+  it('passes an unguarded package once it is allowlisted with a reason', () => {
+    const errors = checkPatchInventory({
+      ...base,
+      patchedDependencies: {
+        ...base.patchedDependencies,
+        'some-native-mod@1.0.0': 'patches/some-native-mod@1.0.0.patch',
+      },
+      patchFilenames: [...base.patchFilenames, 'some-native-mod@1.0.0.patch'],
+      allowUnguarded: { 'some-native-mod@1.0.0': 'unreachable from packages/mobile' },
+    });
+
+    expect(errors).toEqual([]);
+  });
+
+  it('resolves the URL-encoded scoped patch filename against the directory listing', () => {
+    const errors = checkPatchInventory({
+      patchedDependencies: { '@expo/ui@57.0.8': 'patches/@expo%2Fui@57.0.8.patch' },
+      patchFilenames: ['@expo%2Fui@57.0.8.patch'],
+      guardedKeys: ['@expo/ui@57.0.8'],
+      allowUnguarded: {},
+    });
+
+    expect(errors).toEqual([]);
+  });
+});
+
+// This is the assertion that fires if a future react-native-screens bump
+// quietly narrows the guard back to the single symbol it started with.
+describe('the shipped RULES', () => {
+  const tabsHostRule = REAL_RULES.find(
+    (rule) => rule.package === 'react-native-screens' && rule.file === 'ios/tabs/host/RNSTabsHostComponentView.mm',
+  );
+
+  it('still guards the tabs host', () => {
+    expect(tabsHostRule).toBeDefined();
+  });
+
+  it('asserts the deferral machinery, not just the entry-point symbol', () => {
+    expect(tabsHostRule?.sentinels).toEqual(
+      expect.arrayContaining([
+        'rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance',
+        'rnscreens_layoutBottomAccessoryOutsideTransition',
+        '_rnscreens_bottomAccessoryRelayoutScheduled',
+        'animateAlongsideTransition',
+      ]),
+    );
+  });
+
+  it('forbids a synchronous layout inside applyBottomAccessoryVisibility', () => {
+    const forbidden = tabsHostRule?.forbiddenInMethod?.find(
+      (entry) => entry.method === 'applyBottomAccessoryVisibility',
+    );
+
+    expect(forbidden?.substrings).toEqual(expect.arrayContaining(['layoutIfNeeded']));
+    expect(forbidden?.why).toContain('BOARDSESH-9K');
+  });
+
+  it('keeps a written reason for every deliberately unguarded patch', () => {
+    for (const [key, reason] of Object.entries(UNGUARDED_PATCHES)) {
+      expect(reason.length, `${key} needs a reason`).toBeGreaterThan(20);
+    }
   });
 });

--- a/scripts/mobile-patches-check.ts
+++ b/scripts/mobile-patches-check.ts
@@ -207,23 +207,37 @@ function stripObjCComments(source: string): string {
  * (or a following method) is never included. This is a slicer, not a parser:
  * an upstream reformat that breaks the anchor is meant to fail the check loudly
  * so a human re-verifies the patch.
+ *
+ * A forward declaration — the same signature terminated by `;` inside a class
+ * extension, which `RNSTabsHostComponentView.mm` already has two of — is
+ * skipped rather than matched. Matching one would slice from the *next* `{` in
+ * the file (the `@implementation` ivar block) and quietly scan the wrong text,
+ * which for a negative assertion means a silent pass. That is the exact failure
+ * this guard exists to prevent, so it must not be possible inside the guard.
  */
 export function extractObjCMethodBody(source: string, methodName: string): string | null {
   const stripped = stripObjCComments(source);
-  const declaration = new RegExp(String.raw`^[-+]\s*\([^)]*\)\s*${methodName}\b`, 'm').exec(stripped);
-  if (declaration === null) return null;
+  const escaped = methodName.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+  const declarations = new RegExp(String.raw`^[-+]\s*\([^)]*\)\s*${escaped}\b`, 'gm');
 
-  const openBrace = stripped.indexOf('{', declaration.index);
-  if (openBrace === -1) return null;
-
-  let depth = 0;
-  for (let index = openBrace; index < stripped.length; index += 1) {
-    const character = stripped[index];
-    if (character === '{') depth += 1;
-    else if (character === '}') {
-      depth -= 1;
-      if (depth === 0) return stripped.slice(openBrace + 1, index);
+  let declaration = declarations.exec(stripped);
+  while (declaration !== null) {
+    const openBrace = stripped.indexOf('{', declaration.index);
+    // Everything between the signature and its body is attributes/whitespace. A
+    // `;` in there means this match was a forward declaration, not a definition.
+    if (openBrace !== -1 && !stripped.slice(declaration.index, openBrace).includes(';')) {
+      let depth = 0;
+      for (let index = openBrace; index < stripped.length; index += 1) {
+        const character = stripped[index];
+        if (character === '{') depth += 1;
+        else if (character === '}') {
+          depth -= 1;
+          if (depth === 0) return stripped.slice(openBrace + 1, index);
+        }
+      }
+      return null;
     }
+    declaration = declarations.exec(stripped);
   }
   return null;
 }

--- a/scripts/mobile-patches-check.ts
+++ b/scripts/mobile-patches-check.ts
@@ -39,9 +39,25 @@
  */
 
 import { createRequire } from 'node:module';
-import { readFileSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve, dirname, basename } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+
+/**
+ * A substring that must NOT appear inside one specific Objective-C method body.
+ *
+ * Sentinels prove a patch's symbols survived. This proves its SHAPE survived: a
+ * re-keyed patch can keep every sentinel name and still restore the exact line
+ * that caused the crash the patch was written for.
+ */
+export interface ForbiddenInMethod {
+  /** Method to anchor on, e.g. `applyBottomAccessoryVisibility`. */
+  method: string;
+  /** Substrings that must not appear in that method's body (comments stripped). */
+  substrings: readonly string[];
+  /** Why they're forbidden — printed verbatim in the failure message. */
+  why: string;
+}
 
 export interface PatchRule {
   /** The patched package — must be a direct dependency of packages/mobile. */
@@ -52,6 +68,8 @@ export interface PatchRule {
   sentinels: readonly string[];
   /** The exact `patchedDependencies` key expected in the root package.json. */
   patchedKey: string;
+  /** Optional negative assertions scoped to a single method body. */
+  forbiddenInMethod?: readonly ForbiddenInMethod[];
 }
 
 /**
@@ -61,10 +79,10 @@ export interface PatchRule {
  * caught by `typecheck:mobile`, so it doesn't need one.
  *
  * Every rule's package must be a DIRECT dependency of packages/mobile, because
- * {@link createNodeEnv} resolves from packages/mobile/package.json. That is why
- * there is no expo-dev-launcher rule: under Bun's isolated linker it is only
- * reachable through expo-dev-client, so its 10s -> 120s iOS request-timeout
- * patch stays unguarded. Guarding it needs resolution via its parent first.
+ * {@link createNodeEnv} resolves from packages/mobile/package.json. A patched
+ * package that cannot be guarded for that reason must be listed in
+ * {@link UNGUARDED_PATCHES} — {@link checkPatchInventory} fails on any patched
+ * package that has neither a rule nor an allowlist entry.
  */
 export const RULES: readonly PatchRule[] = [
   {
@@ -90,11 +108,35 @@ export const RULES: readonly PatchRule[] = [
     ],
     patchedKey: 'react-native-screens@4.26.2',
   },
+  // The bottom-accessory attach nudge. The FIRST sentinel alone is not enough:
+  // the crashing pre-#4198 version of this patch also defined
+  // `rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance`, it just laid
+  // out synchronously inside the RN mounting transaction. A patch re-keyed for
+  // a react-native-screens bump could reintroduce exactly that and still pass a
+  // one-sentinel check, silently regressing BOARDSESH-9K. So the deferral
+  // machinery itself is asserted: the coalescing ivar, the out-of-transition
+  // helper, and the transition-coordinator hand-off — plus a negative assertion
+  // that no synchronous layout crept back into the mounting-transaction path.
   {
     package: 'react-native-screens',
     file: 'ios/tabs/host/RNSTabsHostComponentView.mm',
-    sentinels: ['rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance'],
+    sentinels: [
+      'rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance',
+      'rnscreens_layoutBottomAccessoryOutsideTransition',
+      '_rnscreens_bottomAccessoryRelayoutScheduled',
+      'animateAlongsideTransition',
+    ],
     patchedKey: 'react-native-screens@4.26.2',
+    forbiddenInMethod: [
+      {
+        method: 'applyBottomAccessoryVisibility',
+        substrings: ['layoutIfNeeded', 'layoutBelowIfNeeded'],
+        why:
+          'synchronous layout inside the RN mounting transaction re-enters UITabBar/_minimizeBehavior under a ' +
+          'UISheetPresentationController animation — BOARDSESH-9K. Lay out from ' +
+          'rnscreens_layoutBottomAccessoryOutsideTransition instead.',
+      },
+    ],
   },
   // The Android sheet guard is the one hunk NOTHING else can see: it only
   // swallows a native AsyncFunction rejection at runtime on store binaries
@@ -117,6 +159,128 @@ export const RULES: readonly PatchRule[] = [
     patchedKey: '@expo/ui@57.0.8',
   },
 ];
+
+/**
+ * `patchedDependencies` keys that deliberately have NO rule in {@link RULES},
+ * each with the reason. {@link checkPatchInventory} fails on any patched
+ * package that is in neither list, so adding a patch forces a decision instead
+ * of quietly landing unguarded.
+ */
+export const UNGUARDED_PATCHES: Readonly<Record<string, string>> = {
+  'expo-dev-launcher@57.0.10':
+    "raises the iOS dev-launcher request timeout from 10s to 120s. Under Bun's isolated linker the package is " +
+    'only reachable through expo-dev-client, so createNodeEnv cannot resolve it from packages/mobile. It is also ' +
+    'dev-client-only — it never ships in a store binary.',
+};
+
+/**
+ * Strip `//` line comments and block comments from Objective-C++ source.
+ *
+ * The RNSTabsHostComponentView patch documents the crash in prose that quotes
+ * `-layoutIfNeeded`, so a negative assertion has to read code only.
+ */
+function stripObjCComments(source: string): string {
+  let out = '';
+  let index = 0;
+  while (index < source.length) {
+    const two = source.slice(index, index + 2);
+    if (two === '//') {
+      const end = source.indexOf('\n', index);
+      index = end === -1 ? source.length : end;
+    } else if (two === '/*') {
+      const end = source.indexOf('*/', index + 2);
+      index = end === -1 ? source.length : end + 2;
+    } else {
+      out += source[index];
+      index += 1;
+    }
+  }
+  return out;
+}
+
+/**
+ * Return the body of Objective-C method `methodName`, comments stripped, or
+ * `null` when the method can't be found.
+ *
+ * Anchors on the `- (…)methodName` / `+ (…)methodName` declaration and then
+ * balances braces from the first `{`, so trailing prose after the closing brace
+ * (or a following method) is never included. This is a slicer, not a parser:
+ * an upstream reformat that breaks the anchor is meant to fail the check loudly
+ * so a human re-verifies the patch.
+ */
+export function extractObjCMethodBody(source: string, methodName: string): string | null {
+  const stripped = stripObjCComments(source);
+  const declaration = new RegExp(String.raw`^[-+]\s*\([^)]*\)\s*${methodName}\b`, 'm').exec(stripped);
+  if (declaration === null) return null;
+
+  const openBrace = stripped.indexOf('{', declaration.index);
+  if (openBrace === -1) return null;
+
+  let depth = 0;
+  for (let index = openBrace; index < stripped.length; index += 1) {
+    const character = stripped[index];
+    if (character === '{') depth += 1;
+    else if (character === '}') {
+      depth -= 1;
+      if (depth === 0) return stripped.slice(openBrace + 1, index);
+    }
+  }
+  return null;
+}
+
+export interface PatchInventoryInput {
+  /** The root package.json `patchedDependencies` map (key -> `patches/<file>`). */
+  patchedDependencies: Record<string, string>;
+  /** Filenames present in patches/ (basenames, not paths). */
+  patchFilenames: readonly string[];
+  /** `patchedKey` of every entry in {@link RULES}. */
+  guardedKeys: readonly string[];
+  /** Keys deliberately left unguarded, mapped to the reason. */
+  allowUnguarded: Readonly<Record<string, string>>;
+}
+
+/**
+ * Cross-check `patchedDependencies` against the patches/ directory and RULES.
+ *
+ * Catches the three things Bun and the per-rule check both stay silent about:
+ * a key pointing at a file that isn't there, a patch file left orphaned by a
+ * re-key (Bun never mentions unreferenced files), and a newly patched package
+ * that nobody guarded.
+ */
+export function checkPatchInventory(input: PatchInventoryInput): string[] {
+  const errors: string[] = [];
+  const present = new Set(input.patchFilenames);
+  const referenced = new Set<string>();
+  const guarded = new Set(input.guardedKeys);
+
+  for (const [patchedKey, patchPath] of Object.entries(input.patchedDependencies)) {
+    const filename = basename(patchPath);
+    referenced.add(filename);
+    if (!present.has(filename)) {
+      errors.push(
+        `${patchedKey}: "patchedDependencies" points at ${patchPath}, but that file is not in patches/. ` +
+          `Bun cannot apply a patch it can't read — restore the file or drop the key.`,
+      );
+    }
+    if (!guarded.has(patchedKey) && !Object.prototype.hasOwnProperty.call(input.allowUnguarded, patchedKey)) {
+      errors.push(
+        `${patchedKey}: patched but unguarded — add a rule to RULES in scripts/mobile-patches-check.ts so a ` +
+          `dropped patch fails CI, or add the key to UNGUARDED_PATCHES with the reason it can't be guarded.`,
+      );
+    }
+  }
+
+  for (const filename of input.patchFilenames) {
+    if (!referenced.has(filename)) {
+      errors.push(
+        `patches/${filename}: orphaned — no "patchedDependencies" key references it, so Bun ignores it entirely. ` +
+          `This is what a re-key leaves behind; delete the stale file or wire it up.`,
+      );
+    }
+  }
+
+  return errors;
+}
 
 /**
  * I/O abstracted so {@link checkPatchesApplied} can be unit-tested without a
@@ -201,6 +365,27 @@ export function checkPatchesApplied(rules: readonly PatchRule[], env: PatchCheck
           `regenerate it with \`bun patch ${rule.package}\`.`,
       );
     }
+
+    // (4) Shape assertions: a symbol can survive a re-keyed patch while the
+    //     dangerous line it replaced comes back with it.
+    for (const forbidden of rule.forbiddenInMethod ?? []) {
+      const body = extractObjCMethodBody(source, forbidden.method);
+      if (body === null) {
+        errors.push(
+          `${rule.package}: cannot locate -[${forbidden.method}] in ${rule.file}, so its safety assertion could not ` +
+            `run. Upstream moved or reshaped the anchor — re-verify patches/${rule.patchedKey}.patch by hand and ` +
+            `update the rule in scripts/mobile-patches-check.ts. Do not delete the assertion to get green.`,
+        );
+        continue;
+      }
+      const found = forbidden.substrings.filter((substring) => body.includes(substring));
+      if (found.length > 0) {
+        errors.push(
+          `${rule.package}: ${rule.file} has ${found.map((s) => `"${s}"`).join(', ')} inside -[${forbidden.method}], ` +
+            `which the patch exists to remove — ${forbidden.why}`,
+        );
+      }
+    }
   }
 
   return { checked, errors };
@@ -239,16 +424,33 @@ export function main(): number {
     return 1;
   }
 
-  const env = createNodeEnv(mobilePackageJson, patchedDependencies);
-  const { checked, errors } = checkPatchesApplied(RULES, env);
-
-  if (errors.length > 0) {
-    console.error('[mobile-patches] FAILED — native patch(es) not applied:');
-    for (const error of errors) console.error(`  ✗ ${error}`);
+  let patchFilenames: string[];
+  try {
+    patchFilenames = readdirSync(resolve(repoRoot, 'patches')).filter((name) => name.endsWith('.patch'));
+  } catch (error) {
+    console.error(`[mobile-patches] FAILED — cannot read patches/: ${(error as Error).message}`);
     return 1;
   }
 
-  console.log(`[mobile-patches] OK — ${checked} native patch(es) applied.`);
+  const env = createNodeEnv(mobilePackageJson, patchedDependencies);
+  const { checked, errors } = checkPatchesApplied(RULES, env);
+  const inventoryErrors = checkPatchInventory({
+    patchedDependencies,
+    patchFilenames,
+    guardedKeys: RULES.map((rule) => rule.patchedKey),
+    allowUnguarded: UNGUARDED_PATCHES,
+  });
+  const allErrors = [...errors, ...inventoryErrors];
+
+  if (allErrors.length > 0) {
+    console.error('[mobile-patches] FAILED — native patch(es) not applied:');
+    for (const error of allErrors) console.error(`  ✗ ${error}`);
+    return 1;
+  }
+
+  console.log(
+    `[mobile-patches] OK — ${checked} native patch(es) applied, ${patchFilenames.length} patch file(s) accounted for.`,
+  );
   return 0;
 }
 


### PR DESCRIPTION
## Summary

Closes #4237. Follow-up to #4198, which fixed Sentry **BOARDSESH-9K** (`Fatal Exception: NSInternalInconsistencyException` inside `RNSTabsHostComponentView`) in 2.3.1.

The crash itself is quiet: BOARDSESH-9K is `resolved`, 42 events / 6 users, last seen 2026-08-05, and **every** event is on a pre-fix release (2.2.2+3, 2.3.0+5, 2.3.0+12). Zero events on 2.3.1. The only sibling issue in that component is BOARDSESH-BJ — a single 2s app-hang in `reactAddControllerToClosestParent:`, unrelated to the accessory relayout.

Most of the CI guard the issue asks for already landed with #4198: `scripts/mobile-patches-check.ts` exists, runs as `check:mobile-patches` in the `mobile-bundle` job, `patches/**` is in the `mobile` paths-filter, and the root `package.json` + `bun.lock` are in `rootCi`. `scripts/mobile-ci-env-parity.test.ts` already asserts all of that. So "the check runs on the bump PR" is done and this PR does not touch CI config.

**What was not guarded** is what the check actually asserts. The `RNSTabsHostComponentView.mm` rule carried exactly one sentinel: `rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance` — the name of the method that crashed. The pre-#4198 version of the patch defined that same method; it just called `-layoutIfNeeded` synchronously inside `applyBottomAccessoryVisibility`, i.e. inside the RN mounting transaction, which re-entered `-[UITabBar layoutSubviews]` → `_minimizeBehavior` → a sheet alongside-animation set → `_sheetLayoutInfoLayout` → the tab bar again. A patch re-keyed for a `react-native-screens` bump could reintroduce exactly that line, keep every symbol, and pass CI green — silently regressing BOARDSESH-9K right as iOS 27 goes GA.

So the guard now asserts the crash-safety *shape*:

- **Four sentinels instead of one** on the tabs-host rule — the coalescing ivar (`_rnscreens_bottomAccessoryRelayoutScheduled`), the out-of-transition helper (`rnscreens_layoutBottomAccessoryOutsideTransition`), and the coordinator hand-off (`animateAlongsideTransition`), not just the entry point.
- **A scoped negative assertion** (`forbiddenInMethod`): no `layoutIfNeeded` / `layoutBelowIfNeeded` inside `applyBottomAccessoryVisibility`. `extractObjCMethodBody` anchors on the declaration, balances braces, and strips comments first — the shipped patch documents the crashing call by name in prose right below the method, so a naive substring scan would false-positive. If the anchor method can't be found the check **fails loudly** rather than skipping: upstream reshaping it is exactly when a human should re-verify the patch by hand.
- **A patch inventory pass** (`checkPatchInventory`) for the three things Bun stays silent about: a `patchedDependencies` key pointing at a file that isn't in `patches/`, a patch file **orphaned** by a re-key (Bun ignores unreferenced files without a word), and a patched package with no rule at all. The last one is escapable only via a new `UNGUARDED_PATCHES` allowlist that requires a written reason — which is where `expo-dev-launcher@57.0.10`'s existing "only reachable through expo-dev-client under Bun's isolated linker" carve-out now lives, promoted from a code comment to an assertion.
- **Docs**: `docs/mobile-sheets-vs-routes.md` had a stale `@expo/ui` patch path (`57.0.3`, two bumps behind — proof that patch paths rot), plus a new "Bumping react-native-screens" runbook: why the nudge must never lay out synchronously, the re-key steps *including deleting the orphaned file*, and what the check reports when the anchor moves.

No app code, no native code, no fingerprint change, no migration, no i18n, no new deps, no CI-config change. Bumping `react-native-screens` to 4.27.0 stays out of scope — that's a native-fingerprint change for a `[native-train]` draft. This PR only makes that bump fail loudly if it drops or weakens the patch.

**Still open on the issue:** re-checking BOARDSESH-9K on real iOS 27 GA volume (~Sept 2026). This PR cannot prove the fix holds on hardware; it only stops the fix from silently disappearing.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run check:mobile-patches` — passes against the installed `react-native-screens@4.26.2`; success line now reads `OK — 6 native patch(es) applied, 4 patch file(s) accounted for.`
- `vp test run --project scripts --reporter=agent` — 52 files / 737 tests pass; `mobile-patches-check.test.ts` is 36 tests (19 new). Covers `extractObjCMethodBody` (nested braces, class methods, comment prose, absent method, forward declarations), the regressed-vs-shipped pair, the missing-anchor error, each new deferral sentinel, and all four `checkPatchInventory` cases including the URL-encoded scoped filename.
- `vp check` on the touched files (what the pre-commit hook runs) — clean. A repo-wide `vp check` in this worktree reports pre-existing findings across ~100 untouched files; the CI `lint` job is green.
- A shape test over the **real** exported `RULES` asserts the tabs-host rule keeps the deferral sentinels and the `applyBottomAccessoryVisibility` entry, so a future bump can't quietly narrow the guard back.
- **Live negative proof (three runs against the installed `node_modules` copy, each restored after):**
  1. stripped the patch's `rnscreens_` symbols → `patch NOT applied` naming the missing sentinels;
  2. injected `[_controller.view layoutIfNeeded];` into `applyBottomAccessoryVisibility` → failed with the BOARDSESH-9K message;
  3. injected a **forward declaration** of `applyBottomAccessoryVisibility` into one of the file's `@interface ()` class extensions *plus* the crashing line → still fails (see below).
- Not run: `vp run typecheck` in full. It kicks off a `next build` that collides with other agents' concurrent builds on this machine, and no `typecheck:*` task covers root `scripts/` — `vp check` lints it and the `scripts` Vitest project executes it.

## Review follow-up (adversarial QA pass)

One real soundness hole found and fixed in `755961f2`:

`extractObjCMethodBody` anchored on the **first** `- (…)methodName` match in the file. `RNSTabsHostComponentView.mm` already carries two `@interface RNSTabsHostComponentView ()` class extensions, so if a future bump forward-declares the anchor in one of them, the slicer matched the *declaration*, took the next `{` — the `@implementation` ivar block — and scanned that instead of the method body. The negative assertion would then pass green on a patch that had restored the crashing synchronous layout: exactly the silent regression this guard exists to catch. Reproduced against the installed 4.26.2 (the check passed with the crashing line present), fixed by skipping matches whose signature ends in `;` before any body (and escaping the method name before it enters a `RegExp`), and re-verified live — the same injection now fails with the BOARDSESH-9K message. Two tests cover it.

Also aligned the doc's Sentry figures with the issue (42 events / 6 users, all iOS 27.0 on pre-fix releases) instead of unsourced crash/loop counts.

Noted, not acted on — both from the `claude-review` bot, both inert for the current rules and fail-loud rather than fail-silent: `stripObjCComments` would strip a `//` inside an Objective-C string literal (no string literals in any guarded method today), and the `\([^)]*\)` return-type pattern can't match a return type containing nested parens (every guarded method returns `void`; a miss surfaces as the loud `cannot locate` error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Msvwztpyh4KYh7iDkHWaxQ

