### PR TITLE
fix(mobile): normalize WebSocket errors before they reach Sentry

### DIFF
--- a/packages/mobile/src/lib/__tests__/sentry.test.ts
+++ b/packages/mobile/src/lib/__tests__/sentry.test.ts
@@ -28,6 +28,7 @@ import {
   captureToSentry,
   flushSentry,
   isExpoUiSheetNoHandlerRejection,
+  normalizeCapturedValueForSentry,
   setOtaChannelTag,
   setOtaSentryTags,
   wrapWithSentry,
@@ -292,6 +293,73 @@ describe('applyOtaTagsToScope', () => {
     const explicit = makeScope();
     applyOtaTagsToScope(explicit, { isEmbeddedLaunch: false });
     expect(explicit.setTag).toHaveBeenCalledWith('ota_is_embedded', 'false');
+  });
+});
+
+// normalizeCapturedValueForSentry runs purely (no SDK), so it's directly
+// testable regardless of enablement — it guards the #4241 fix: a raw
+// WebSocket Event/CloseEvent must never reach Sentry.captureException as an
+// opaque object that renders as `<unknown>` / `Event` / `anonymous`.
+describe('normalizeCapturedValueForSentry', () => {
+  it('passes a real Error through unchanged with no extra', () => {
+    const original = new Error('socket boom');
+    const result = normalizeCapturedValueForSentry(original);
+    expect(result.error).toBe(original);
+    expect(result.extra).toBeUndefined();
+  });
+
+  it('rewraps a CloseEvent-shaped object, surfaces code/reason/wasClean/readyState, and strips the query string from the target URL', () => {
+    const result = normalizeCapturedValueForSentry({
+      type: 'close',
+      code: 1001,
+      reason: 'Stream end encountered',
+      wasClean: false,
+      target: { readyState: 3, url: 'wss://api.example.com/graphql?token=SECRET' },
+    });
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error.message).toContain('close');
+    expect(result.error.message).toContain('1001');
+    expect(result.extra).toEqual({
+      type: 'close',
+      code: 1001,
+      reason: 'Stream end encountered',
+      wasClean: false,
+      readyState: 3,
+      url: 'wss://api.example.com/graphql',
+    });
+  });
+
+  it('rewraps a bare Event with no code/reason into just a type extra', () => {
+    const result = normalizeCapturedValueForSentry({ type: 'error' });
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error.message).toContain('error');
+    expect(result.extra).toEqual({ type: 'error' });
+  });
+
+  it('falls back to String(value) for a non-object, non-Error value', () => {
+    const stringResult = normalizeCapturedValueForSentry('connection reset');
+    expect(stringResult.error).toBeInstanceOf(Error);
+    expect(stringResult.error.message).toBe('connection reset');
+    expect(stringResult.extra).toBeUndefined();
+
+    const numberResult = normalizeCapturedValueForSentry(42);
+    expect(numberResult.error.message).toBe('42');
+  });
+
+  it('falls back to String(value) for a plain object with no `type` field', () => {
+    const result = normalizeCapturedValueForSentry({ status: 500 });
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error.message).toBe('[object Object]');
+    expect(result.extra).toBeUndefined();
+  });
+
+  it('drops a malformed target URL instead of throwing', () => {
+    const result = normalizeCapturedValueForSentry({
+      type: 'close',
+      code: 1006,
+      target: { readyState: 3, url: 'not a url' },
+    });
+    expect(result.extra).toEqual({ type: 'close', code: 1006, readyState: 3 });
   });
 });
 

--- a/packages/mobile/src/lib/graphql/__tests__/ws-client.test.ts
+++ b/packages/mobile/src/lib/graphql/__tests__/ws-client.test.ts
@@ -391,7 +391,18 @@ describe('native GraphQL WebSocket transport', () => {
     it('swallows a dispose rejection without producing an unhandled rejection', async () => {
       getWsClient();
       const rawCloseEventLike = { type: 'close', code: 1001, reason: 'Stream end encountered', wasClean: false };
-      disposeSpy.mockRejectedValueOnce(rawCloseEventLike);
+      // Deliberately NOT `disposeSpy.mockRejectedValueOnce(...)`: vitest attaches
+      // its own settled-result handlers to whatever a `vi.fn()` returns, which
+      // marks the promise handled and makes an unhandled-rejection assertion
+      // vacuous — it passes even against the pre-fix `void wsClient.dispose()`.
+      // A plain rejecting function leaves the promise genuinely unhandled unless
+      // disposeWsClient() attaches a handler itself.
+      let plainDisposeCalls = 0;
+      const clientUnderTest = singletonClient as unknown as { dispose: () => Promise<void> };
+      clientUnderTest.dispose = () => {
+        plainDisposeCalls += 1;
+        return Promise.reject(rawCloseEventLike);
+      };
 
       const unhandledRejections: unknown[] = [];
       const onUnhandledRejection = (reason: unknown): void => {
@@ -400,14 +411,16 @@ describe('native GraphQL WebSocket transport', () => {
       process.on('unhandledRejection', onUnhandledRejection);
       try {
         disposeWsClient();
-        await vi.waitFor(() => expect(disposeSpy).toHaveBeenCalledTimes(1));
-        // Let the microtask queue flush so any unhandled rejection would have
-        // surfaced by now.
-        await new Promise((resolve) => setTimeout(resolve, 0));
+        await vi.waitFor(() => expect(plainDisposeCalls).toBe(1));
+        // Node emits 'unhandledRejection' a turn after the microtask queue
+        // drains, so flush past a macrotask before asserting.
+        await new Promise((resolve) => setTimeout(resolve, 50));
       } finally {
         process.off('unhandledRejection', onUnhandledRejection);
+        clientUnderTest.dispose = disposeSpy;
       }
 
+      expect(plainDisposeCalls).toBe(1);
       expect(unhandledRejections).toEqual([]);
     });
 

--- a/packages/mobile/src/lib/graphql/__tests__/ws-client.test.ts
+++ b/packages/mobile/src/lib/graphql/__tests__/ws-client.test.ts
@@ -381,4 +381,53 @@ describe('native GraphQL WebSocket transport', () => {
     expect(getAuthTokenMock).toHaveBeenCalledTimes(1);
     await rawClient.dispose();
   });
+
+  // #4241: dispose() rejects with the raw closing Event/CloseEvent, not an
+  // Error — `void wsClient.dispose()` with no rejection handler let that
+  // escape as an unhandled rejection, which Hermes forwarded to Sentry as an
+  // opaque object. disposeWsClient() must fire-and-forget through a try/catch
+  // so the rejection never reaches the process.
+  describe('disposeWsClient (rejection safety)', () => {
+    it('swallows a dispose rejection without producing an unhandled rejection', async () => {
+      getWsClient();
+      const rawCloseEventLike = { type: 'close', code: 1001, reason: 'Stream end encountered', wasClean: false };
+      disposeSpy.mockRejectedValueOnce(rawCloseEventLike);
+
+      const unhandledRejections: unknown[] = [];
+      const onUnhandledRejection = (reason: unknown): void => {
+        unhandledRejections.push(reason);
+      };
+      process.on('unhandledRejection', onUnhandledRejection);
+      try {
+        disposeWsClient();
+        await vi.waitFor(() => expect(disposeSpy).toHaveBeenCalledTimes(1));
+        // Let the microtask queue flush so any unhandled rejection would have
+        // surfaced by now.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      } finally {
+        process.off('unhandledRejection', onUnhandledRejection);
+      }
+
+      expect(unhandledRejections).toEqual([]);
+    });
+
+    it('is idempotent — a second immediate call does not dispose again', () => {
+      getWsClient();
+      disposeWsClient();
+      expect(disposeSpy).toHaveBeenCalledTimes(1);
+
+      disposeWsClient();
+      expect(disposeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('nulls the singleton synchronously, so getWsClient() after dispose starts a fresh client lifecycle', () => {
+      getWsClient();
+      disposeWsClient();
+      expect(disposeSpy).toHaveBeenCalledTimes(1);
+
+      getWsClient();
+      disposeWsClient();
+      expect(disposeSpy).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/packages/mobile/src/lib/graphql/ws-client-core.ts
+++ b/packages/mobile/src/lib/graphql/ws-client-core.ts
@@ -215,8 +215,17 @@ export function createWsClientModule(deps: WsClientDeps): WsClientModule {
 
   function disposeWsClient(): void {
     if (!wsClient) return;
-    void wsClient.dispose();
+    const client = wsClient;
     wsClient = null;
+    void (async () => {
+      try {
+        await client.dispose();
+      } catch {
+        // Suppress: dispose errors are non-fatal. The socket is being torn down
+        // and these rejections carry no actionable information (graphql-ws
+        // rejects with the raw closing Event/CloseEvent, not an Error).
+      }
+    })();
   }
 
   return { getWsClient, disposeWsClient };

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -145,16 +145,97 @@ export function applyErrorContextToScope(scope: SentryScopeLike, context?: Error
   }
 }
 
+/** Result of normalizing a captured value into something Sentry can render usefully. */
+export type NormalizedCapturedError = {
+  error: Error;
+  extra?: Record<string, unknown>;
+};
+
+// Structural shape of a browser Event/CloseEvent/ErrorEvent — every field is
+// `unknown` on purpose since we only trust it after checking its runtime type.
+type EventLike = {
+  type?: unknown;
+  code?: unknown;
+  reason?: unknown;
+  wasClean?: unknown;
+  target?: unknown;
+};
+
+/**
+ * Strip a WebSocket URL down to protocol+host+pathname so a captured auth
+ * token or session id in the query string (or userinfo) never reaches
+ * Sentry. Returns undefined for anything that isn't a parseable URL string.
+ */
+function sanitizeSocketUrl(url: unknown): string | undefined {
+  if (typeof url !== 'string' || !url) return undefined;
+  try {
+    const parsed = new URL(url);
+    return `${parsed.protocol}//${parsed.host}${parsed.pathname}`;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Normalizes a value on its way to `Sentry.captureException`. graphql-ws's
+ * `dispose()` and raw `wsClient.subscribe` error sinks reject/forward the
+ * browser's native `Event`/`CloseEvent` objects (not `Error` instances) on a
+ * WebSocket failure — Sentry renders those as `<unknown>` / `Event` /
+ * `anonymous`, discarding the close code and reason that would actually
+ * explain the failure (#4241).
+ *
+ * Duck-types on a `type` field rather than `instanceof Event`/`CloseEvent`:
+ * RN/Hermes' DOM-event polyfills aren't reliable across native vs. Expo-web,
+ * so structural detection is the only check that holds in both. A match is
+ * rewrapped as a proper `Error` (message carries the event type and close
+ * code, when present) with the code/reason/wasClean/readyState/sanitized
+ * socket URL surfaced as `extra` so triage isn't blind. Anything already an
+ * `Error` passes through unchanged; anything else (string, number, plain
+ * object with no `type`) falls back to `new Error(String(value))` so no
+ * value is ever handed to Sentry raw.
+ */
+export function normalizeCapturedValueForSentry(value: unknown): NormalizedCapturedError {
+  if (value instanceof Error) return { error: value };
+  if (typeof value === 'object' && value !== null && 'type' in value) {
+    const eventLike = value as EventLike;
+    const type = typeof eventLike.type === 'string' ? eventLike.type : 'unknown';
+    const code = typeof eventLike.code === 'number' ? eventLike.code : undefined;
+    const extra: Record<string, unknown> = { type };
+    if (code !== undefined) extra.code = code;
+    if (typeof eventLike.reason === 'string' && eventLike.reason) extra.reason = eventLike.reason;
+    if (typeof eventLike.wasClean === 'boolean') extra.wasClean = eventLike.wasClean;
+    if (typeof eventLike.target === 'object' && eventLike.target !== null) {
+      const target = eventLike.target as { readyState?: unknown; url?: unknown };
+      if (typeof target.readyState === 'number') extra.readyState = target.readyState;
+      const sanitizedUrl = sanitizeSocketUrl(target.url);
+      if (sanitizedUrl) extra.url = sanitizedUrl;
+    }
+    return {
+      error: new Error(`WebSocket ${type}${code !== undefined ? ` (code ${code})` : ''}`),
+      extra,
+    };
+  }
+  return { error: new Error(String(value)) };
+}
+
 /**
  * Report an error to Sentry if it is active. No-op otherwise. The optional
  * context (level/tags/extra) is mapped onto a Sentry scope so callers can attach
  * triage data — e.g. a `source` tag and HTTP status on a failed session start.
+ * The captured value is normalized first (see normalizeCapturedValueForSentry)
+ * so a raw WebSocket Event/CloseEvent never reaches Sentry as an opaque object.
  */
 export function captureToSentry(error: unknown, context?: ErrorReportContext): void {
   if (!isSentryEnabled) return;
+  const { error: normalizedError, extra } = normalizeCapturedValueForSentry(error);
   Sentry.withScope((scope) => {
     applyErrorContextToScope(scope, context);
-    Sentry.captureException(error);
+    if (extra) {
+      for (const [key, value] of Object.entries(extra)) {
+        scope.setExtra(key, value);
+      }
+    }
+    Sentry.captureException(normalizedError);
   });
 }
 

--- a/packages/mobile/src/providers/__tests__/queue-provider-regrade.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-regrade.test.tsx
@@ -66,7 +66,10 @@ vi.mock('react-native', () => ({
   AppState: { addEventListener: vi.fn(() => ({ remove: vi.fn() })) },
 }));
 vi.mock('expo-crypto', () => ({ randomUUID: () => 'test-correlation-id' }));
-vi.mock('@boardsesh/graphql-client', () => ({ execute: graph.execute }));
+vi.mock('@boardsesh/graphql-client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/graphql-client')>()),
+  execute: graph.execute,
+}));
 vi.mock('@boardsesh/queue-react', () => ({ useQueueMutations: () => queueMutations }));
 vi.mock('@boardsesh/play-view', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@boardsesh/play-view')>()),

--- a/packages/mobile/src/providers/__tests__/queue-provider-resolve-climbs.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-resolve-climbs.test.tsx
@@ -66,7 +66,10 @@ vi.mock('react-native', () => ({
   AppState: { addEventListener: vi.fn(() => ({ remove: vi.fn() })) },
 }));
 vi.mock('expo-crypto', () => ({ randomUUID: () => 'test-correlation-id' }));
-vi.mock('@boardsesh/graphql-client', () => ({ execute: graph.execute }));
+vi.mock('@boardsesh/graphql-client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/graphql-client')>()),
+  execute: graph.execute,
+}));
 vi.mock('@boardsesh/queue-react', () => ({ useQueueMutations: () => queueMutations }));
 vi.mock('@boardsesh/play-view', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@boardsesh/play-view')>()),

--- a/packages/mobile/src/providers/queue/use-session-realtime.ts
+++ b/packages/mobile/src/providers/queue/use-session-realtime.ts
@@ -17,7 +17,7 @@ import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { parseBoardPath, parseNamedBoardPath } from '@boardsesh/board-config';
 import type { PlaybackStateChangedEvent, SessionUser, UserBoard } from '@boardsesh/shared-schema';
 import { emitWallConfirm } from '@boardsesh/play-view';
-import { GraphQLOperationError, isNotSessionMemberError } from '@boardsesh/graphql-client';
+import { GraphQLOperationError, isNotSessionMemberError, subscribe } from '@boardsesh/graphql-client';
 import { getWsClient } from '../../lib/graphql/ws-client';
 import { AUTH_REFRESH_RETRY_CLOSE_CODE } from '../../lib/graphql/ws-close-codes';
 import {
@@ -450,13 +450,14 @@ export function useSessionRealtime({
       if (disposed || currentStartToken !== subscriptionStartToken || sessionIdRef.current !== sessionId) return;
       joinRetryCount = 0;
 
-      queueUpdatesCleanup = wsClient.subscribe<{ queueUpdates: QueueUpdateEvent }>(
+      queueUpdatesCleanup = subscribe<{ queueUpdates: QueueUpdateEvent }>(
+        wsClient,
         {
           query: QUEUE_UPDATES_SUBSCRIPTION,
           variables: { sessionId },
         },
         {
-          next: ({ data }) => {
+          next: (data) => {
             if (!data?.queueUpdates) return;
             const event = data.queueUpdates;
             // PlaybackStateChanged is a first-class wire variant but carries no
@@ -637,13 +638,14 @@ export function useSessionRealtime({
       // angle is session-shared: when a peer changes it we update our own active
       // board's angle (which cascades to the climb list, play drawer, and the
       // re-grade effect). We don't switch the whole board — only the angle.
-      sessionUpdatesCleanup = wsClient.subscribe<{ sessionUpdates: SessionUpdateEvent }>(
+      sessionUpdatesCleanup = subscribe<{ sessionUpdates: SessionUpdateEvent }>(
+        wsClient,
         {
           query: SESSION_UPDATES_SUBSCRIPTION,
           variables: { sessionId },
         },
         {
-          next: ({ data }) => {
+          next: (data) => {
             const event = data?.sessionUpdates;
             if (!event) return;
             if (sessionIdRef.current !== sessionId) return;


### PR DESCRIPTION
## Summary

WebSocket failures on mobile were reaching Sentry as bare browser `Event`/`CloseEvent` objects instead of `Error` instances, so Sentry rendered them as `<unknown>` / `Event` / `anonymous` — hiding the close code and reason that would explain the real failure (28 events / 28 users over 14 days: BOARDSESH-8W, BOARDSESH-A3, BOARDSESH-BR).

Three fixes, matching the issue's own analysis:

1. **`packages/mobile/src/lib/graphql/ws-client-core.ts`** — `disposeWsClient()` used `void wsClient.dispose()` with no rejection handler. graphql-ws's `dispose()` rejects with the raw closing `Event`/`CloseEvent` on a failed socket, which became an unhandled promise rejection that Hermes forwarded straight to `Sentry.captureException`. Now the singleton is nulled synchronously and `dispose()` is awaited inside a fire-and-forget async IIFE wrapped in try/catch (mirroring `create-client.ts`'s existing wrapper), so the rejection is swallowed instead of escaping. Fixes the dominant source (26 of 28 events, `mechanism: onunhandledrejection`) — this single fix in the shared `createWsClientModule` covers every `disposeWsClient()` call site.
2. **`packages/mobile/src/providers/queue/use-session-realtime.ts`** — the `queueUpdates` and `sessionUpdates` subscriptions called `wsClient.subscribe(...)` directly, bypassing the shared, normalizing `subscribe()` helper (`@boardsesh/graphql-client`) that coerces a raw DOM error event into a proper `Error` (or `GraphQLOperationError` for server-sent GraphQL errors) before it reaches a sink's `error` callback. `sessionUpdates`'s error handler forwards straight to `reportHandledError` → Sentry, so it leaked the raw object (2 of 28 events, `mechanism: generic`). Converted both subscriptions to the shared wrapper — `queueUpdates` too, for consistency, even though its error handler currently only shows a toast.
3. **`packages/mobile/src/lib/sentry.ts`** — added a backstop: `normalizeCapturedValueForSentry`, wired into `captureToSentry`. Any non-`Error` value handed to Sentry (including a raw Event/CloseEvent that somehow still slips past 1+2, or any other future call site) is rewrapped as a real `Error` with a descriptive message ("WebSocket close (code 1001)"), and its `type`/`code`/`reason`/`wasClean`/`readyState`/socket URL are attached as Sentry `extra` fields. The socket URL is stripped down to protocol+host+pathname before being attached, so an auth token in the query string never reaches Sentry.

Closes #4241.

## Release Notes

- [x] No release note needed (internal / technical change)

Purely a crash-reporting/observability fix — no user-visible behavior change. The subscription callback bodies (`next`/`error`/`complete`) are unchanged; only the transport wrapper they're routed through changed.

## Test plan

- `vp run typecheck:mobile` — passes.
- `vp check` (lint + format) on all touched files — passes.
- `vp test run --project mobile --reporter=agent` scoped to the touched suites:
  - `packages/mobile/src/lib/graphql/__tests__/ws-client.test.ts` — new `disposeWsClient (rejection safety)` block: a rejected `dispose()` (rejecting with a raw CloseEvent-shaped object) never produces an `unhandledRejection`; double-dispose stays idempotent; the singleton is nulled so a subsequent `getWsClient()` starts a fresh lifecycle. **Mutation-verified**: reverting `ws-client-core.ts` to `void wsClient.dispose()` fails this test with the raw `{ type: 'close', code: 1001, ... }` object as the rejection reason.
- **Fixed a vacuous test** (caught in QA review of this PR, commit 2 of 2). The rejection-safety test originally drove the rejection through `disposeSpy.mockRejectedValueOnce(...)`. Vitest attaches its own settled-result handlers to whatever a `vi.fn()` returns, which marks that promise handled — so Node never emitted `unhandledRejection` and the test passed identically against the pre-fix code. Probed both paths in this suite: a `vi.fn` rejection produced 0 `unhandledRejection` events, a plain `Promise.reject` produced 1. The test now installs a plain (non-spy) rejecting `dispose` for that case, so the only automated guard on the dominant leak source (26 of 28 Sentry events) actually asserts something.
  - `packages/mobile/src/lib/__tests__/sentry.test.ts` — new `normalizeCapturedValueForSentry` block: a real `Error` passes through unchanged; a CloseEvent-shaped object is rewrapped into an `Error` whose message carries the type/code, with `extra` carrying type/code/reason/wasClean/readyState and a query-string-stripped URL; a bare `{ type: 'error' }` produces just a `type` extra; non-object/non-Error values fall back to `new Error(String(value))`; a malformed target URL is dropped rather than throwing.
- Not independently re-tested: the shared `subscribe()` coercion mechanism that `use-session-realtime.ts` now routes through already has its own test suite (`packages/shared/graphql-client/src/__tests__/subscribe.test.ts`, unmodified here) proving raw DOM error events are coerced into `Error`/`GraphQLOperationError`.

### Deviation from the plan

The plan's `filesTouched` listed a new `packages/mobile/src/providers/queue/__tests__/use-session-realtime.test.ts` "if it doesn't already exist." It doesn't. `use-session-realtime.ts` is a 940-line hook with no existing test harness or scaffolding (`renderHook` setup, reducer/coordinator/board-config mocks, etc.), and the actual behavior change there is a mechanical swap of `wsClient.subscribe(...)` for the already-tested `subscribe(wsClient, ...)` wrapper — same `next`/`error`/`complete` callback bodies. Building a from-scratch hook-level test harness for this file is a substantially larger, separately-scoped effort with real risk of a mock setup that doesn't reflect production wiring. Given the coercion behavior itself is already covered by `subscribe.test.ts`, I left this as a documented gap rather than rushing a low-confidence test. Happy to follow up with a dedicated PR if a reviewer wants hook-level coverage.
