### PR TITLE
fix(mobile): stop offline launches from disqualifying the fast board download

### DIFF
--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -172,36 +172,57 @@ layout artifact but intentionally outside the enabled size.
 Implemented in `snapshot-bootstrap.ts` (the ATTACH/import/verify mechanics) and orchestrated from
 `pull-client.ts`'s `runBootstrapPhase`, which runs **before** the deletions phase of every sync cycle.
 
+**Connectivity gate**: `pullSync` returns immediately when the injected `isOnline()` probe says the device
+is offline, mirroring `drainMutationQueue`'s entry guard. The probe defaults to `() => true`, so only the
+mobile adapter (React Query's `onlineManager`, wired to NetInfo) actually gates anything; web is unchanged.
+Without it, every offline launch ran the whole bootstrap phase and emitted one Sentry event per
+enabled-but-undownloaded scope (issue #4238). The scheduler's offline→online edge re-runs the skipped cycle.
+
 **Eligibility**: a board scope (`boardType:layoutId:sizeId`) is only considered when it has **no
 checkpoint on either snapshot-backed table, `board_climbs` or `board_climb_stats`** (i.e. genuinely
 fresh for the snapshot) and its bootstrap attempt count is under `MAX_BOOTSTRAP_ATTEMPTS` (2). The
 ordinary paged sync still downloads `board_climb_grades` before the scope is reported complete. One
 artifact download is shared across every size of the same `(boardType, layoutId)` within a cycle.
 
+The cap is evaluated **after** the manifest resolves, which is what makes the **one-shot heal** possible: a
+scope that already spent both attempts, still has no board checkpoint, and turns out to have a usable
+manifest entry waiting gets its `bootstrap-attempts:` row deleted and takes the snapshot path again —
+exactly once per scope, recorded in `bootstrap-attempts-healed:`. A device that burned both attempts in a
+tunnel therefore recovers on its first online launch, while a genuinely broken artifact costs two more
+attempts and then settles into the paged crawl for good. The cost is that an over-cap scope consults the
+manifest each cycle; `resolveManifestOnce` caches it per `pullSync` run, so that only adds a request on
+cycles where _every_ scope is over the cap.
+
 A scope torn down from **More → Storage** becomes eligible again: `removeBoardScopeData`
 (`sync/scope-teardown.ts`) clears all three board-data checkpoints **and** its `bootstrap-attempts:` /
-`bootstrap-done:` / `bootstrap-paged-fallback:` markers in the same transaction as the rows, so a re-download takes the snapshot fast
+`bootstrap-attempts-healed:` / `bootstrap-done:` / `bootstrap-paged-fallback:` markers in the same
+transaction as the rows, so a re-download takes the snapshot fast
 path rather than a paged crawl — and `onScopeDownloadComplete` attributes it honestly instead of
-reporting a stale `method: 'snapshot'` for a run that actually paged. All three marker prefixes are exported
+reporting a stale `method: 'snapshot'` for a run that actually paged. All four marker prefixes are exported
 from `snapshot-bootstrap.ts` for that teardown alone; they stay package-internal (not re-exported from
-`index.ts`).
+`index.ts`). Only the first three are read back by the My Boards metadata query — the heal marker has no UI,
+so `BOOTSTRAP_METADATA_PATTERNS` deliberately stays at six patterns.
 
 Failure/attempt matrix, copied from the `runBootstrapPhase` doc comment (the source of truth — keep this in
 sync if the code comment changes):
 
-| Condition                                                         | Attempt burned? | Result this cycle                                                                       |
-| ----------------------------------------------------------------- | --------------- | --------------------------------------------------------------------------------------- |
-| checkpoint exists on either board table                           | —               | not eligible → normal paged pull                                                        |
-| attempts ≥ `MAX_BOOTSTRAP_ATTEMPTS`                               | —               | gave up → normal paged pull                                                             |
-| manifest `absent` (404/missing or invalid JSON/shape)             | **no**          | permanent miss → normal paged pull                                                      |
-| manifest `error` (HTTP non-2xx except 404, network/transport)     | **yes**         | skip paged pull this cycle (retry next cycle)                                           |
-| manifest `ok` but no entry for `(boardType, layoutId)`            | **no**          | permanent miss (not exported yet) → normal paged pull                                   |
-| download fails or returns `null`                                  | **yes**         | skip paged pull this cycle                                                              |
-| download throws `SnapshotPermanentMissError`                      | **no**          | permanent miss → normal paged pull                                                      |
-| import throws — corrupt/short artifact, row-count/format mismatch | **yes**         | skip paged pull this cycle                                                              |
-| import throws `SnapshotSchemaStaleError`                          | **no**          | permanent miss this run → normal paged pull                                             |
-| a sign-out wipe is detected mid-phase                             | **no**          | whole phase bails, mirrors `syncTable`'s wipe guard                                     |
-| success                                                           | —               | marked done; deletions rewound; paged pull runs as a small delta from scoped watermarks |
+| Condition                                                          | Attempt burned? | Result this cycle                                                                       |
+| ------------------------------------------------------------------ | --------------- | --------------------------------------------------------------------------------------- |
+| checkpoint exists on either board table                            | —               | not eligible → normal paged pull                                                        |
+| `isOnline()` reports offline                                       | —               | whole cycle skipped before the phase starts; retried on reconnect                       |
+| attempts ≥ `MAX_BOOTSTRAP_ATTEMPTS`, heal available + usable entry | —               | counter reset once → snapshot path runs                                                 |
+| attempts ≥ `MAX_BOOTSTRAP_ATTEMPTS`, otherwise                     | —               | gave up → normal paged pull                                                             |
+| manifest `absent` (404/missing or invalid JSON/shape)              | **no**          | permanent miss → normal paged pull                                                      |
+| manifest `error`, transport-shaped (offline/DNS/TLS/timeout)       | **no**          | skip paged pull this cycle; reported as `expected`                                      |
+| manifest `error`, anything else (HTTP non-2xx except 404, …)       | **yes**         | skip paged pull this cycle (retry next cycle)                                           |
+| manifest `ok` but no entry for `(boardType, layoutId)`             | **no**          | permanent miss (not exported yet) → normal paged pull                                   |
+| download fails transport-shaped                                    | **no**          | skip paged pull this cycle; reported as `expected`                                      |
+| download fails otherwise or returns `null`                         | **yes**         | skip paged pull this cycle                                                              |
+| download throws `SnapshotPermanentMissError`                       | **no**          | permanent miss → normal paged pull                                                      |
+| import throws — corrupt/short artifact, row-count/format mismatch  | **yes**         | skip paged pull this cycle                                                              |
+| import throws `SnapshotSchemaStaleError`                           | **no**          | permanent miss this run → normal paged pull                                             |
+| a sign-out wipe is detected mid-phase                              | **no**          | whole phase bails, mirrors `syncTable`'s wipe guard                                     |
+| success                                                            | —               | marked done; deletions rewound; paged pull runs as a small delta from scoped watermarks |
 
 "Skip paged pull this cycle" matters because a scope whose bootstrap failed but still has attempts left
 must **not** run its ordinary paged pull this cycle either — a first-page checkpoint from that pull would
@@ -321,8 +342,12 @@ pre-import empty result set.
     `'snapshot'` scope's duration includes its manifest/download/import time, not just the trailing delta
     pull — an apples-to-apples comparison against a full paged crawl).
   - Sentry handled errors, `tags: { source: 'offline-sync', kind: 'snapshot-bootstrap' }`, for every
-    counted bootstrap failure (manifest/download/import stage, with `scopeKey`/`stage`/`attempt`/`cause` in
-    `extra`) and for the gzip-sniff failure above.
+    bootstrap failure (manifest/download/import stage, with
+    `scopeKey`/`stage`/`attempt`/`expected`/`cause`/`causeName` in `extra`) and for the gzip-sniff failure
+    above. Transport-shaped failures carry `expected: true`, report at `level: warning`, and are additionally
+    tagged `expected_offline` — they are a phone with no signal, not a defect, and they burn no attempt. The
+    real exception is attached as the wrapper's `cause`, which is what lets the shared classifier recognise
+    them at all (issue #4238).
 
 ## Ops runbook
 

--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -216,8 +216,7 @@ sync if the code comment changes):
 | manifest `error`, transport-shaped (offline/DNS/TLS/timeout)       | **no**          | skip paged pull this cycle; reported as `expected`                                      |
 | manifest `error`, anything else (HTTP non-2xx except 404, …)       | **yes**         | skip paged pull this cycle (retry next cycle)                                           |
 | manifest `ok` but no entry for `(boardType, layoutId)`             | **no**          | permanent miss (not exported yet) → normal paged pull                                   |
-| download fails transport-shaped                                    | **no**          | skip paged pull this cycle; reported as `expected`                                      |
-| download fails otherwise or returns `null`                         | **yes**         | skip paged pull this cycle                                                              |
+| download fails or returns `null` (transport-shaped or not)         | **yes**         | skip paged pull this cycle; transport-shaped ones still report as `expected`            |
 | download throws `SnapshotPermanentMissError`                       | **no**          | permanent miss → normal paged pull                                                      |
 | import throws — corrupt/short artifact, row-count/format mismatch  | **yes**         | skip paged pull this cycle                                                              |
 | import throws `SnapshotSchemaStaleError`                           | **no**          | permanent miss this run → normal paged pull                                             |
@@ -345,9 +344,10 @@ pre-import empty result set.
     bootstrap failure (manifest/download/import stage, with
     `scopeKey`/`stage`/`attempt`/`expected`/`cause`/`causeName` in `extra`) and for the gzip-sniff failure
     above. Transport-shaped failures carry `expected: true`, report at `level: warning`, and are additionally
-    tagged `expected_offline` — they are a phone with no signal, not a defect, and they burn no attempt. The
-    real exception is attached as the wrapper's `cause`, which is what lets the shared classifier recognise
-    them at all (issue #4238).
+    tagged `expected_offline` — they are a phone with no signal, not a defect. `expected` is a severity signal
+    only: at the manifest stage it also skips the attempt counter, but a transport-shaped download failure
+    still burns an attempt (see the matrix above). The real exception is attached as the wrapper's `cause`,
+    which is what lets the shared classifier recognise them at all (issue #4238).
 
 ## Ops runbook
 

--- a/packages/mobile/src/lib/__tests__/error-reporting.test.ts
+++ b/packages/mobile/src/lib/__tests__/error-reporting.test.ts
@@ -189,6 +189,33 @@ describe('reportHandledError', () => {
     });
   });
 
+  it('follows the .cause chain of a synthetic wrapper to find the transport failure (#4238)', () => {
+    // The snapshot-bootstrap reporter wraps its own prose around the real error.
+    // The wrapper message matches nothing, so before the cause was attached this
+    // reached Sentry at level: error for every user who opened the app offline.
+    const wrapped = new Error('Snapshot bootstrap failed for kilter:1:10 at stage "manifest" (attempt 1)', {
+      cause: new TypeError('Network request failed'),
+    });
+    reportHandledError(wrapped, { tags: { source: 'offline-sync', kind: 'snapshot-bootstrap' } });
+    expect(mockedCaptureToSentry).toHaveBeenCalledWith(wrapped, {
+      level: 'warning',
+      tags: { source: 'offline-sync', kind: 'snapshot-bootstrap', network: true },
+    });
+  });
+
+  it('reaches a transport cause nested two wrappers deep (expo-file-system inside our own wrapper)', () => {
+    const wrapped = new Error('Snapshot bootstrap failed for kilter:1:10 at stage "download" (attempt 1)', {
+      cause: new Error('snapshot download: File.downloadFileAsync failed for kilter:1: The request timed out.', {
+        cause: Object.assign(new Error('The request timed out.'), { name: 'UnableToDownloadException' }),
+      }),
+    });
+    reportHandledError(wrapped, { tags: { source: 'offline-sync' } });
+    expect(mockedCaptureToSentry).toHaveBeenCalledWith(wrapped, {
+      level: 'warning',
+      tags: { source: 'offline-sync', network: true },
+    });
+  });
+
   it('forces warning for a network error even if the caller asked for a higher level', () => {
     const offline = new TypeError('Network request failed');
     reportHandledError(offline, { level: 'fatal', tags: { source: 'x' } });

--- a/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
+++ b/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
@@ -306,13 +306,62 @@ describe('snapshot-bootstrap bindings', () => {
       async () => {},
     );
     const options = startSyncSchedulerCore.mock.calls[0][6] as SchedulerOptions;
-    options.onSnapshotBootstrapError?.({ scopeKey: 'kilter:1:5', stage: 'download', attempt: 1, cause: null });
+    options.onSnapshotBootstrapError?.({
+      scopeKey: 'kilter:1:5',
+      stage: 'download',
+      attempt: 1,
+      cause: null,
+      expected: false,
+    });
 
     expect(reportHandledError).toHaveBeenCalledWith(
       expect.objectContaining({ message: expect.stringContaining('kilter:1:5') }),
       expect.objectContaining({
         tags: { source: 'offline-sync', kind: 'snapshot-bootstrap' },
         extra: expect.objectContaining({ scopeKey: 'kilter:1:5', stage: 'download', attempt: 1 }),
+      }),
+    );
+    // A counted failure keeps the caller's default severity — no level override.
+    const context = reportHandledError.mock.calls[0][1] as { level?: string };
+    expect(context.level).toBeUndefined();
+  });
+
+  it('attaches the real cause to the synthetic bootstrap error so the classifier can walk it', () => {
+    // The wrapper message ("Snapshot bootstrap failed for …") matches nothing in
+    // isNetworkError, so without `{ cause }` every offline user's failure landed
+    // at level: error with extra.cause: null (issue #4238).
+    const cause = new TypeError('Network request failed');
+    startSyncScheduler(
+      db,
+      queryClient,
+      graphqlFetch,
+      () => [],
+      async () => {},
+    );
+    const options = startSyncSchedulerCore.mock.calls[0][6] as SchedulerOptions;
+    options.onSnapshotBootstrapError?.({
+      scopeKey: 'kilter:1:5',
+      stage: 'manifest',
+      attempt: 0,
+      cause,
+      expected: true,
+    });
+
+    const [reported, context] = reportHandledError.mock.calls[0] as [
+      Error,
+      { level?: string; tags: Record<string, unknown>; extra: Record<string, unknown> },
+    ];
+    expect(reported.cause).toBe(cause);
+    expect(context.level).toBe('warning');
+    expect(context.tags).toEqual({ source: 'offline-sync', kind: 'snapshot-bootstrap', expected_offline: true });
+    expect(context.extra).toEqual(
+      expect.objectContaining({
+        scopeKey: 'kilter:1:5',
+        stage: 'manifest',
+        attempt: 0,
+        expected: true,
+        cause: 'Network request failed',
+        causeName: 'TypeError',
       }),
     );
   });
@@ -381,7 +430,13 @@ describe('snapshot-bootstrap bindings', () => {
     await pullSync(db, queryClient, graphqlFetch, { onSnapshotBootstrapError: customBootstrapError });
 
     const options = pullSyncCore.mock.calls[0][3] as SyncOptions;
-    options.onSnapshotBootstrapError?.({ scopeKey: 'kilter:1:5', stage: 'manifest', attempt: 1, cause: null });
+    options.onSnapshotBootstrapError?.({
+      scopeKey: 'kilter:1:5',
+      stage: 'manifest',
+      attempt: 1,
+      cause: null,
+      expected: false,
+    });
     expect(customBootstrapError).toHaveBeenCalled();
     expect(reportHandledError).not.toHaveBeenCalled();
 
@@ -391,6 +446,53 @@ describe('snapshot-bootstrap bindings', () => {
       method: 'paged',
       durationMs: 500,
     });
+  });
+});
+
+describe('connectivity probe on the pull path (issue #4238)', () => {
+  it('startSyncScheduler hands the scheduler the onlineManager-backed probe', () => {
+    startSyncScheduler(
+      db,
+      queryClient,
+      graphqlFetch,
+      () => [],
+      async () => {},
+    );
+
+    const options = startSyncSchedulerCore.mock.calls[0][6] as SchedulerOptions;
+    onlineManagerIsOnline.mockReturnValue(true);
+    expect(options.isOnline?.()).toBe(true);
+    onlineManagerIsOnline.mockReturnValue(false);
+    expect(options.isOnline?.()).toBe(false);
+  });
+
+  it('triggerSync hands the scheduler the same probe', () => {
+    triggerSync(
+      db,
+      queryClient,
+      graphqlFetch,
+      () => [],
+      async () => {},
+    );
+
+    const options = triggerSyncCore.mock.calls[0][5] as SchedulerOptions;
+    onlineManagerIsOnline.mockReturnValue(false);
+    expect(options.isOnline?.()).toBe(false);
+  });
+
+  it('pullSync defaults to the probe and lets a caller-supplied one win', async () => {
+    await pullSync(db, queryClient, graphqlFetch);
+    const defaulted = pullSyncCore.mock.calls[0][3] as SyncOptions;
+    onlineManagerIsOnline.mockReturnValue(false);
+    expect(defaulted.isOnline?.()).toBe(false);
+
+    vi.clearAllMocks();
+    const customProbe = vi.fn(() => true);
+    await pullSync(db, queryClient, graphqlFetch, { isOnline: customProbe });
+    const overridden = pullSyncCore.mock.calls[0][3] as SyncOptions;
+    expect(overridden.isOnline?.()).toBe(true);
+    expect(customProbe).toHaveBeenCalled();
+    expect(onlineManagerIsOnline).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
+++ b/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
@@ -20,6 +20,9 @@ const state = vi.hoisted(() => ({
   // instead of the whole file in one chunk — for the empty-first-chunk and
   // split-header edge cases the ReadableStream spec allows.
   streamChunks: null as Uint8Array[] | null,
+  // When set, the reader rejects instead of yielding bytes — the "can't verify
+  // the body at all" path.
+  readError: null as Error | null,
   deletedUris: [] as string[],
 }));
 
@@ -68,6 +71,7 @@ vi.mock('expo-file-system', () => {
       return {
         getReader: () => ({
           read: async () => {
+            if (state.readError) throw state.readError;
             if (index >= chunks.length) return { done: true, value: undefined };
             return { done: false, value: chunks[index++] };
           },
@@ -144,6 +148,7 @@ beforeEach(() => {
   state.downloadError = null;
   state.downloadBytes = PLAIN_SQLITE_BYTES;
   state.streamChunks = null;
+  state.readError = null;
   state.deletedUris = [];
 });
 
@@ -241,11 +246,44 @@ describe('downloadArtifact', () => {
     await expect(mobileSnapshotSource.downloadArtifact(ENTRY)).rejects.toThrow(/downloadFileAsync failed.*boom/);
   });
 
-  it('throws a descriptive error wrapping the underlying cause when the cache directory cannot be created', async () => {
-    state.createDirectoryError = new Error('disk is read-only');
+  it('keeps the original download exception as `cause` so the transport classifier can see it (issue #4238)', async () => {
+    // expo-file-system throws UnableToDownloadException("The request timed out.")
+    // for an offline user. Interpolating it into the message reads fine in
+    // Sentry's title but is invisible to isNetworkError, which walks `.cause`.
+    const downloadError = Object.assign(new Error('The request timed out.'), {
+      name: 'UnableToDownloadException',
+    });
+    state.downloadError = downloadError;
 
-    await expect(mobileSnapshotSource.downloadArtifact(ENTRY)).rejects.toThrow(/cache directory.*disk is read-only/);
+    const rejection = await mobileSnapshotSource.downloadArtifact(ENTRY).catch((error: unknown) => error);
+
+    expect(rejection).toBeInstanceOf(Error);
+    expect((rejection as Error).cause).toBe(downloadError);
+  });
+
+  it('throws a descriptive error wrapping the underlying cause when the cache directory cannot be created', async () => {
+    const createError = new Error('disk is read-only');
+    state.createDirectoryError = createError;
+
+    const rejection = await mobileSnapshotSource.downloadArtifact(ENTRY).catch((error: unknown) => error);
+
+    expect((rejection as Error).message).toMatch(/cache directory.*disk is read-only/);
+    expect((rejection as Error).cause).toBe(createError);
     expect(state.downloadCalls).toHaveLength(0);
+  });
+
+  it('throws (rather than returning null) and deletes the partial file when the gzip sniff cannot read the body', async () => {
+    // The last path that still returned a bare null, which is exactly the one
+    // Sentry reported as `cause: null` at stage "download" (issue #4238).
+    const readError = new Error('stream closed');
+    state.downloadBytes = GZIP_BYTES;
+    state.readError = readError;
+
+    const rejection = await mobileSnapshotSource.downloadArtifact(ENTRY).catch((error: unknown) => error);
+
+    expect((rejection as Error).message).toMatch(/could not verify artifact encoding/);
+    expect((rejection as Error).cause).toBe(readError);
+    expect(state.deletedUris).toHaveLength(1);
   });
 
   it('accepts a gzip-encoded entry whose downloaded bytes are already decompressed', async () => {

--- a/packages/mobile/src/offline/offline-sync-adapter.ts
+++ b/packages/mobile/src/offline/offline-sync-adapter.ts
@@ -10,7 +10,9 @@
 // triggerSync / pullSync from '@boardsesh/offline-sync' directly — always from
 // here. The package's isOnline default assumes online; only this adapter
 // guarantees the real probe is attached, so a direct import would silently
-// drain (and burn retry budget) while offline.
+// drain (and burn retry budget) while offline — and, since #4238, would also
+// run a whole pull cycle offline, reporting a snapshot-bootstrap failure per
+// enabled-but-undownloaded board on the way.
 
 import { AppState, type AppStateStatus } from 'react-native';
 import NetInfo from '@react-native-community/netinfo';
@@ -86,11 +88,35 @@ const reportSchemaDrift: SchemaDriftReporter = ({ tableName, column }) => {
 // it skips entirely without one); reportScopeDownloadComplete fires for EVERY
 // scope's first full download — paged crawls included — because the
 // snapshot-vs-paged rollout comparison needs both methods to emit the event.
-const reportSnapshotBootstrapError: SnapshotBootstrapErrorReporter = ({ scopeKey, stage, attempt, cause }) => {
-  reportHandledError(new Error(`Snapshot bootstrap failed for ${scopeKey} at stage "${stage}" (attempt ${attempt})`), {
-    tags: { source: 'offline-sync', kind: 'snapshot-bootstrap' },
-    extra: { scopeKey, stage, attempt, cause: cause instanceof Error ? cause.message : cause },
-  });
+// The `{ cause }` is load-bearing, not decoration: reportHandledError classifies
+// the error it is handed, and this synthetic wrapper matches nothing on its own,
+// so every offline user's bootstrap failure used to land in Sentry at `level:
+// error` with `extra.cause: null` (issue #4238). The shared classifier walks a
+// `.cause` chain three deep, so attaching the real cause is all it takes to get
+// the network downgrade — and `expected` (set by the engine for transport-shaped
+// failures) forces the warning even when the cause is an unrecognised shape.
+const reportSnapshotBootstrapError: SnapshotBootstrapErrorReporter = ({
+  scopeKey,
+  stage,
+  attempt,
+  cause,
+  expected,
+}) => {
+  reportHandledError(
+    new Error(`Snapshot bootstrap failed for ${scopeKey} at stage "${stage}" (attempt ${attempt})`, { cause }),
+    {
+      ...(expected ? { level: 'warning' as const } : {}),
+      tags: { source: 'offline-sync', kind: 'snapshot-bootstrap', ...(expected ? { expected_offline: true } : {}) },
+      extra: {
+        scopeKey,
+        stage,
+        attempt,
+        expected,
+        cause: cause instanceof Error ? cause.message : cause,
+        causeName: cause instanceof Error ? cause.name : null,
+      },
+    },
+  );
 };
 
 // Fired once per board scope's initial download so the snapshot-bootstrap
@@ -194,6 +220,7 @@ export function startSyncScheduler(
   options?: SyncRunOptions,
 ): () => void {
   return startSyncSchedulerCore(db, queryClient, graphqlFetch, getEnabledBoards, drainQueue, schedulerTriggers, {
+    isOnline,
     onProgress: options?.onProgress,
     onCycleError: warnCycleError,
     onSchemaDrift: reportSchemaDrift,
@@ -214,6 +241,7 @@ export function triggerSync(
   options?: SyncRunOptions,
 ): void {
   triggerSyncCore(db, queryClient, graphqlFetch, getEnabledBoards, drainQueue, {
+    isOnline,
     onProgress: options?.onProgress,
     onCycleError: warnCycleError,
     onSchemaDrift: reportSchemaDrift,
@@ -233,6 +261,7 @@ export function pullSync(
 ): Promise<void> {
   return pullSyncCore(db, queryClient, graphqlFetch, {
     ...options,
+    isOnline: options?.isOnline ?? isOnline,
     onSchemaDrift: options?.onSchemaDrift ?? reportSchemaDrift,
     onSnapshotBootstrapError: options?.onSnapshotBootstrapError ?? reportSnapshotBootstrapError,
     onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete),

--- a/packages/mobile/src/offline/snapshot-source.ts
+++ b/packages/mobile/src/offline/snapshot-source.ts
@@ -13,14 +13,17 @@
 //
 // The engine only consumes what this returns — it never fetches, downloads, or
 // gunzips anything itself (see snapshot-bootstrap.ts's `SnapshotSource`
-// contract). Every failure path here (disk space, directory creation, download
-// error, a stubborn gzip body) THROWS a descriptive Error, which the engine
-// counts as one bootstrap attempt and falls back to the ordinary paged crawl
-// (MAX_BOOTSTRAP_ATTEMPTS caps it at two tries before giving up on the
-// snapshot path for that scope) — see `runBootstrapPhase`'s `cachedDownload`
-// handling in pull-client.ts, which only captures a `cause` for Sentry when
-// this throws (issue #4106: these used to `return null` on real failures,
-// which is a legal contract but reported `cause: null` for everything).
+// contract). EVERY failure path here (disk space, directory creation, download
+// error, an unreadable body, a stubborn gzip body) THROWS a descriptive Error
+// carrying the underlying exception as its `cause`, and the engine reports that
+// chain — see `runBootstrapPhase`'s `cachedDownload` handling in pull-client.ts.
+// A transport-shaped cause burns NO bootstrap attempt; anything else counts,
+// and MAX_BOOTSTRAP_ATTEMPTS caps it at two tries before the scope settles into
+// the ordinary paged crawl (issue #4106: these used to `return null` on real
+// failures, which is a legal contract but reported `cause: null` for
+// everything; issue #4238: the causes that survived were only interpolated into
+// the message, so the classifier could not see them and every offline user's
+// failure landed as a Sentry `error`).
 
 import { Directory, File, Paths } from 'expo-file-system';
 import { SnapshotPermanentMissError, type SnapshotManifestEntry, type SnapshotSource } from '@boardsesh/offline-sync';
@@ -134,9 +137,14 @@ function formatError(error: unknown): string {
  * `catch`) stayed `null` for every one of these — so Sentry's
  * `reportSnapshotBootstrapError` reported `cause: null` for every real-world
  * download failure, with no way to tell a 404 from a timeout from a disk-full
- * device without reproducing it (issue #4106). Throwing instead of swallowing
- * keeps the exact same retry/attempt/fallback semantics — only the visibility
- * changes.
+ * device without reproducing it (issue #4106).
+ *
+ * Each wrapper keeps the underlying exception as its `cause` as well as in its
+ * message. The message alone reads fine in Sentry's title but is invisible to
+ * the shared transport classifier, which walks `.cause` — and that classifier is
+ * what decides whether expo-file-system's `UnableToDownloadException("The
+ * request timed out.")` is an offline user (a warning) or a real fault (an
+ * error). Issue #4238.
  */
 async function downloadArtifact(entry: SnapshotManifestEntry): Promise<{ filePath: string } | null> {
   const freeSpaceSafetyMultiplier =
@@ -154,7 +162,7 @@ async function downloadArtifact(entry: SnapshotManifestEntry): Promise<{ filePat
   try {
     directory.create({ intermediates: true, idempotent: true });
   } catch (error) {
-    throw new Error(`snapshot download: failed to create cache directory: ${formatError(error)}`);
+    throw new Error(`snapshot download: failed to create cache directory: ${formatError(error)}`, { cause: error });
   }
 
   // Content-addressed filename (boardType/layoutId/builtAt) so a retried
@@ -169,6 +177,7 @@ async function downloadArtifact(entry: SnapshotManifestEntry): Promise<{ filePat
   } catch (error) {
     throw new Error(
       `snapshot download: File.downloadFileAsync failed for ${entry.boardType}:${entry.layoutId}: ${formatError(error)}`,
+      { cause: error },
     );
   }
 
@@ -176,10 +185,15 @@ async function downloadArtifact(entry: SnapshotManifestEntry): Promise<{ filePat
     let stillCompressed: boolean;
     try {
       stillCompressed = await looksGzipCompressed(downloaded);
-    } catch {
-      // Can't verify the body — treat it as untrustworthy, same as a failed download.
+    } catch (error) {
+      // Can't verify the body — treat it as untrustworthy, same as a failed
+      // download. This was the last path that still `return null`ed, and it is
+      // the one that reported `cause: null` to Sentry (issue #4238).
       safeDeleteFile(downloaded);
-      return null;
+      throw new Error(
+        `snapshot download: could not verify artifact encoding for ${entry.boardType}:${entry.layoutId}: ${formatError(error)}`,
+        { cause: error },
+      );
     }
     if (stillCompressed) {
       safeDeleteFile(downloaded);

--- a/packages/mobile/src/offline/snapshot-source.ts
+++ b/packages/mobile/src/offline/snapshot-source.ts
@@ -17,8 +17,9 @@
 // error, an unreadable body, a stubborn gzip body) THROWS a descriptive Error
 // carrying the underlying exception as its `cause`, and the engine reports that
 // chain — see `runBootstrapPhase`'s `cachedDownload` handling in pull-client.ts.
-// A transport-shaped cause burns NO bootstrap attempt; anything else counts,
-// and MAX_BOOTSTRAP_ATTEMPTS caps it at two tries before the scope settles into
+// A transport-shaped cause is reported as a warning rather than an error; every
+// failure the engine sees from `downloadArtifact` still burns an attempt, and
+// MAX_BOOTSTRAP_ATTEMPTS caps it at two tries before the scope settles into
 // the ordinary paged crawl (issue #4106: these used to `return null` on real
 // failures, which is a legal contract but reported `cause: null` for
 // everything; issue #4238: the causes that survived were only interpolated into

--- a/packages/shared/offline-sync/src/sync/__tests__/scope-teardown.integration.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/scope-teardown.integration.test.ts
@@ -148,6 +148,12 @@ describe('re-downloading a removed board', () => {
       `bootstrap-paged-fallback:${SCOPE_KEY}`,
       '1',
     ]);
+    // The one-shot attempt heal was already spent before the user removed the
+    // board; re-adding it must hand back a fresh heal budget too (issue #4238).
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      `bootstrap-attempts-healed:${SCOPE_KEY}`,
+      '1',
+    ]);
 
     await removeBoardScopeData({ db, scope: SCOPE, scopeKey: SCOPE_KEY, retainedScopes: [] });
 
@@ -159,6 +165,9 @@ describe('re-downloading a removed board', () => {
     expect(await getCheckpoint(db, `checkpoint:board_climb_grades:${SCOPE_KEY}`)).toBeNull();
     expect(
       await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', [`bootstrap-paged-fallback:${SCOPE_KEY}`]),
+    ).toBeNull();
+    expect(
+      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', [`bootstrap-attempts-healed:${SCOPE_KEY}`]),
     ).toBeNull();
   });
 });

--- a/packages/shared/offline-sync/src/sync/__tests__/scope-teardown.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/scope-teardown.test.ts
@@ -231,6 +231,10 @@ describe('removeBoardScopeData — markers', () => {
       '2',
     ]);
     await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      `bootstrap-attempts-healed:${scopeKey}`,
+      '1',
+    ]);
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
       `bootstrap-done:${scopeKey}`,
       '1',
     ]);
@@ -290,7 +294,7 @@ describe('removeBoardScopeData — markers', () => {
   // what "a scope's downloaded state" consists of. Adding a marker here should mean
   // deliberately updating this list (and `seedMarkers` above, which proves the
   // teardown actually clears each one), not nudging a magic number.
-  it('is exactly the scope’s checkpoints plus its four markers', async () => {
+  it('is exactly the scope’s checkpoints plus its five markers', async () => {
     const keys = scopeSyncMetaKeys('kilter:1:5');
 
     expect(new Set(keys)).toEqual(
@@ -300,6 +304,7 @@ describe('removeBoardScopeData — markers', () => {
         'checkpoint:board_climb_grades:kilter:1:5',
         'scope-complete:kilter:1:5',
         'bootstrap-attempts:kilter:1:5',
+        'bootstrap-attempts-healed:kilter:1:5',
         'bootstrap-done:kilter:1:5',
         'bootstrap-paged-fallback:kilter:1:5',
       ]),

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -181,18 +181,24 @@ function makeManifest(entries: SnapshotManifestEntry[]): SnapshotManifest {
 function makeSnapshotSource(config: {
   manifest?: SnapshotManifest | null;
   manifestThrows?: boolean;
+  /** Thrown instead of the default non-transport `Error('network down')`. */
+  manifestError?: unknown;
   fileForEntry?: (entry: SnapshotManifestEntry) => string | null;
   downloadThrows?: boolean;
+  /** Thrown instead of the default non-transport `Error('download failed')`. */
+  downloadError?: unknown;
 }): SnapshotSource & {
   fetchManifest: ReturnType<typeof vi.fn>;
   downloadArtifact: ReturnType<typeof vi.fn>;
   deleteArtifact: ReturnType<typeof vi.fn>;
 } {
   const fetchManifest = vi.fn(async () => {
+    if (config.manifestError !== undefined) throw config.manifestError;
     if (config.manifestThrows) throw new Error('network down');
     return config.manifest ?? null;
   });
   const downloadArtifact = vi.fn(async (entry: SnapshotManifestEntry) => {
+    if (config.downloadError !== undefined) throw config.downloadError;
     if (config.downloadThrows) throw new Error('download failed');
     const filePath = config.fileForEntry?.(entry) ?? null;
     return filePath ? { filePath } : null;
@@ -1096,7 +1102,7 @@ describe('pullSync snapshot bootstrap', () => {
     expect(onSnapshotBootstrapError).toHaveBeenCalledWith(expect.objectContaining({ stage: 'download', attempt: 0 }));
   });
 
-  it('counts an attempt AND skips the paged pull when the manifest fetch fails (network)', async () => {
+  it('counts an attempt AND skips the paged pull when the manifest fetch fails for a non-transport reason', async () => {
     const source = makeSnapshotSource({ manifestThrows: true });
     const onSnapshotBootstrapError = vi.fn();
     const onBootstrapMetadataChanged = vi.fn();
@@ -1117,7 +1123,9 @@ describe('pullSync snapshot bootstrap', () => {
     ).toEqual({
       value: '1',
     });
-    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(expect.objectContaining({ stage: 'manifest', attempt: 1 }));
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(
+      expect.objectContaining({ stage: 'manifest', attempt: 1, expected: false }),
+    );
     expect(onBootstrapMetadataChanged).toHaveBeenCalledWith({ scopeKey: 'kilter:1:5' });
   });
 
@@ -1164,49 +1172,55 @@ describe('pullSync snapshot bootstrap', () => {
     );
   });
 
-  it('records two attempts on repeated corrupt artifacts, then the third run falls back to the paged crawl', async () => {
+  it('records two attempts on repeated corrupt artifacts, heals once, then settles into the paged crawl', async () => {
     const filePath = join(workDir, 'corrupt.db');
     writeFileSync(filePath, 'not a database');
     const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
     const onBootstrapMetadataChanged = vi.fn();
 
-    // Run 1: import fails → attempt 1, paged pull skipped.
-    const run1 = makeGraphqlFetch();
-    await pullSync(db, noopQueryClient(), run1.fetch, {
-      enabledBoards: ['kilter:1:5'],
-      snapshotSource: source,
-      onBootstrapMetadataChanged,
-    });
+    const runOnce = async () => {
+      const run = makeGraphqlFetch();
+      await pullSync(db, noopQueryClient(), run.fetch, {
+        enabledBoards: ['kilter:1:5'],
+        snapshotSource: source,
+        onBootstrapMetadataChanged,
+      });
+      return run;
+    };
+    const attemptsRow = () =>
+      db.getFirstAsync('SELECT value FROM sync_meta WHERE key = ?', ['bootstrap-attempts:kilter:1:5']);
+
+    // Runs 1 and 2: import fails → attempts 1 then 2, paged pull skipped both times.
+    const run1 = await runOnce();
     expect(run1.fetch.mock.calls.filter((a) => (a[0] as string).includes('syncClimbs'))).toHaveLength(0);
-    expect(
-      await db.getFirstAsync('SELECT value FROM sync_meta WHERE key = ?', ['bootstrap-attempts:kilter:1:5']),
-    ).toEqual({ value: '1' });
+    expect(await attemptsRow()).toEqual({ value: '1' });
 
-    // Run 2: import fails again → attempt 2, still skipped.
-    const run2 = makeGraphqlFetch();
-    await pullSync(db, noopQueryClient(), run2.fetch, {
-      enabledBoards: ['kilter:1:5'],
-      snapshotSource: source,
-      onBootstrapMetadataChanged,
-    });
+    const run2 = await runOnce();
     expect(run2.fetch.mock.calls.filter((a) => (a[0] as string).includes('syncClimbs'))).toHaveLength(0);
-    expect(
-      await db.getFirstAsync('SELECT value FROM sync_meta WHERE key = ?', ['bootstrap-attempts:kilter:1:5']),
-    ).toEqual({ value: '2' });
+    expect(await attemptsRow()).toEqual({ value: '2' });
 
-    // Run 3: attempts >= MAX → bootstrap not eligible → paged crawl runs from scratch.
-    const run3 = makeGraphqlFetch();
-    await pullSync(db, noopQueryClient(), run3.fetch, {
-      enabledBoards: ['kilter:1:5'],
-      snapshotSource: source,
-      onBootstrapMetadataChanged,
-    });
-    const run3ClimbsCalls = run3.fetch.mock.calls.filter((a) => (a[0] as string).includes('syncClimbs'));
-    expect(run3ClimbsCalls.length).toBeGreaterThan(0);
-    expect(run3.capturedClimbCursors[0]).toBeUndefined();
-    // downloadArtifact was NOT called on run 3 (bootstrap skipped entirely).
-    expect(source.downloadArtifact).toHaveBeenCalledTimes(2);
-    expect(onBootstrapMetadataChanged).toHaveBeenCalledTimes(3);
+    // Run 3: over the cap, but the manifest resolves with a usable entry, so the
+    // scope spends its ONE heal and tries the snapshot path again (issue #4238).
+    // The artifact is still corrupt, so it burns a fresh attempt 1.
+    const run3 = await runOnce();
+    expect(source.downloadArtifact).toHaveBeenCalledTimes(3);
+    expect(run3.fetch.mock.calls.filter((a) => (a[0] as string).includes('syncClimbs'))).toHaveLength(0);
+    expect(await attemptsRow()).toEqual({ value: '1' });
+    expect(
+      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-attempts-healed:kilter:1:5']),
+    ).not.toBeNull();
+
+    // Run 4: attempt 2 again.
+    await runOnce();
+    expect(await attemptsRow()).toEqual({ value: '2' });
+
+    // Run 5: over the cap AND the heal is spent → bootstrap gives up for good and
+    // the paged crawl runs from scratch. No sixth download.
+    const run5 = await runOnce();
+    expect(run5.fetch.mock.calls.filter((a) => (a[0] as string).includes('syncClimbs')).length).toBeGreaterThan(0);
+    expect(run5.capturedClimbCursors[0]).toBeUndefined();
+    expect(source.downloadArtifact).toHaveBeenCalledTimes(4);
+    expect(onBootstrapMetadataChanged).toHaveBeenCalledTimes(5);
   });
 
   it('Sentry BOARDSESH-AN: stops before the attempt-bookkeeping write when the app backgrounds during the manifest fetch', async () => {
@@ -1270,6 +1284,291 @@ describe('pullSync snapshot bootstrap', () => {
     } finally {
       setBackgrounded(false);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Offline hygiene (issue #4238): connectivity gate, transport failures don't
+// burn attempts, and an over-cap scope heals once.
+// ---------------------------------------------------------------------------
+
+describe('pullSync connectivity gate', () => {
+  it('does nothing at all when the injected probe says the device is offline', async () => {
+    const source = makeSnapshotSource({
+      manifest: makeManifest([makeEntry()]),
+      fileForEntry: () => join(workDir, 'x'),
+    });
+    const { fetch } = makeGraphqlFetch();
+    const onSnapshotBootstrapError = vi.fn();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      isOnline: () => false,
+      onSnapshotBootstrapError,
+    });
+
+    // No manifest fetch means no per-scope Sentry event for a user who simply
+    // opened the app on a plane — the whole point of the gate.
+    expect(source.fetchManifest).not.toHaveBeenCalled();
+    expect(source.downloadArtifact).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+    expect(onSnapshotBootstrapError).not.toHaveBeenCalled();
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
+  });
+
+  it('runs exactly as before when no probe is injected (web and every existing caller)', async () => {
+    const source = makeSnapshotSource({ manifest: null });
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+
+    expect(source.fetchManifest).toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalled();
+  });
+
+  it('stops the cycle before the board pulls when connectivity drops mid-run', async () => {
+    let online = true;
+    const { fetch, capturedClimbCursors } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      isOnline: () => online,
+      onProgress: (progress) => {
+        // Drop the connection the moment the deletions phase starts.
+        if (progress.phase === 'deletions') online = false;
+      },
+    });
+
+    expect(capturedClimbCursors).toHaveLength(0);
+    expect(await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['scope-complete:kilter:1:5'])).toBeNull();
+  });
+});
+
+describe('pullSync bootstrap: transport failures do not burn an attempt', () => {
+  it('reports a transport manifest failure as expected, keeps the counter at 0, and still skips the paged pull', async () => {
+    const cause = new TypeError('Network request failed');
+    const source = makeSnapshotSource({ manifestError: cause });
+    const onSnapshotBootstrapError = vi.fn();
+    const onBootstrapMetadataChanged = vi.fn();
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onSnapshotBootstrapError,
+      onBootstrapMetadataChanged,
+    });
+
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
+    // Still skipped: a first-page checkpoint would disqualify the snapshot path
+    // for good, which is exactly what we're protecting the scope from.
+    expect(fetch.mock.calls.filter((args) => (args[0] as string).includes('syncClimbs'))).toHaveLength(0);
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith({
+      scopeKey: 'kilter:1:5',
+      stage: 'manifest',
+      attempt: 0,
+      cause,
+      expected: true,
+    });
+    // Nothing was persisted, so there is no settled decision to re-read.
+    expect(onBootstrapMetadataChanged).not.toHaveBeenCalled();
+  });
+
+  it('survives two offline launches with the snapshot path intact', async () => {
+    const source = makeSnapshotSource({ manifestError: new TypeError('Network request failed') });
+
+    for (let launch = 0; launch < 2; launch += 1) {
+      const run = makeGraphqlFetch();
+      await pullSync(db, noopQueryClient(), run.fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+    }
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
+
+    // Third launch, back online: the scope is still eligible and bootstraps.
+    const filePath = join(workDir, 'after-offline.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c-in', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c-in', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const onlineSource = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const online = makeGraphqlFetch();
+    await pullSync(db, noopQueryClient(), online.fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: onlineSource,
+    });
+
+    expect(
+      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-done:kilter:1:5']),
+    ).not.toBeNull();
+  });
+
+  it('counts a NON-transport download failure but not a transport one', async () => {
+    const transportSource = makeSnapshotSource({
+      manifest: makeManifest([makeEntry()]),
+      downloadError: new Error('snapshot download: File.downloadFileAsync failed', {
+        cause: new TypeError('Network request failed'),
+      }),
+    });
+    const transportReports = vi.fn();
+    const transportRun = makeGraphqlFetch();
+    await pullSync(db, noopQueryClient(), transportRun.fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: transportSource,
+      onSnapshotBootstrapError: transportReports,
+    });
+
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
+    expect(transportReports).toHaveBeenCalledWith(
+      expect.objectContaining({ stage: 'download', attempt: 0, expected: true }),
+    );
+
+    // A disk-full device is a real failure the user can act on — that still counts.
+    const diskFullSource = makeSnapshotSource({
+      manifest: makeManifest([makeEntry()]),
+      downloadError: new Error('snapshot download: insufficient disk space for kilter:1'),
+    });
+    const diskReports = vi.fn();
+    const diskRun = makeGraphqlFetch();
+    await pullSync(db, noopQueryClient(), diskRun.fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: diskFullSource,
+      onSnapshotBootstrapError: diskReports,
+    });
+
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(1);
+    expect(diskReports).toHaveBeenCalledWith(
+      expect.objectContaining({ stage: 'download', attempt: 1, expected: false }),
+    );
+  });
+
+  it('still counts an import failure — a corrupt artifact is never an offline problem', async () => {
+    const filePath = join(workDir, 'corrupt-import.db');
+    writeFileSync(filePath, 'not a database');
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const onSnapshotBootstrapError = vi.fn();
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onSnapshotBootstrapError,
+    });
+
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(1);
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(
+      expect.objectContaining({ stage: 'import', attempt: 1, expected: false }),
+    );
+  });
+});
+
+describe('pullSync bootstrap: one-shot heal for an over-cap scope', () => {
+  async function seedExhaustedScope(): Promise<void> {
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      'bootstrap-attempts:kilter:1:5',
+      '2',
+    ]);
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      'bootstrap-paged-fallback:kilter:1:5',
+      '1',
+    ]);
+  }
+
+  it('clears the counter and takes the snapshot path when the manifest finally resolves online', async () => {
+    await seedExhaustedScope();
+    const filePath = join(workDir, 'heal.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c-in', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c-in', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+
+    const climbs = await db.getAllAsync<{ uuid: string }>('SELECT uuid FROM board_climbs ORDER BY uuid');
+    expect(climbs.map((row) => row.uuid)).toEqual(['c-in']);
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
+    expect(
+      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-attempts-healed:kilter:1:5']),
+    ).not.toBeNull();
+    expect(
+      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-done:kilter:1:5']),
+    ).not.toBeNull();
+  });
+
+  it('does not heal a second time — the marker is what bounds the re-download', async () => {
+    await seedExhaustedScope();
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      'bootstrap-attempts-healed:kilter:1:5',
+      '1',
+    ]);
+    const source = makeSnapshotSource({
+      manifest: makeManifest([makeEntry()]),
+      fileForEntry: () => join(workDir, 'never.db'),
+    });
+    const { fetch, capturedClimbCursors } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+
+    expect(source.downloadArtifact).not.toHaveBeenCalled();
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(2);
+    // The paged crawl runs this cycle, exactly as it did before the heal existed.
+    expect(capturedClimbCursors[0]).toBeUndefined();
+    expect(
+      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-paged-fallback:kilter:1:5']),
+    ).not.toBeNull();
+  });
+
+  it('does not heal while still offline: the manifest never resolves, so the paged crawl runs and the counter stands', async () => {
+    await seedExhaustedScope();
+    const source = makeSnapshotSource({ manifestError: new TypeError('Network request failed') });
+    const { fetch, capturedClimbCursors } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(2);
+    expect(
+      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-attempts-healed:kilter:1:5']),
+    ).toBeNull();
+    expect(capturedClimbCursors[0]).toBeUndefined();
+  });
+
+  it('does not heal a scope whose layout is not in the manifest', async () => {
+    await seedExhaustedScope();
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry({ layoutId: 99 })]) });
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+
+    expect(source.downloadArtifact).not.toHaveBeenCalled();
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(2);
+    expect(
+      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-attempts-healed:kilter:1:5']),
+    ).toBeNull();
+  });
+
+  it('does not heal a scope that already has a board checkpoint (nothing to bootstrap into)', async () => {
+    await seedExhaustedScope();
+    await setCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5', { updatedAt: '2026-01-01T00:00:00Z', syncSeq: '5' });
+    const source = makeSnapshotSource({
+      manifest: makeManifest([makeEntry()]),
+      fileForEntry: () => join(workDir, 'never.db'),
+    });
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+
+    expect(source.fetchManifest).not.toHaveBeenCalled();
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(2);
+    expect(
+      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-attempts-healed:kilter:1:5']),
+    ).toBeNull();
   });
 });
 

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -1548,6 +1548,36 @@ describe('pullSync bootstrap: one-shot heal for an over-cap scope', () => {
     ).not.toBeNull();
   });
 
+  it('drops the paged-fallback marker before the download so My Boards stops saying "slower download"', async () => {
+    await seedExhaustedScope();
+    const filePath = join(workDir, 'heal-marker.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c-in', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c-in', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    // A snapshot download can run for 18 minutes; the row must not claim the slow
+    // path for the whole of it once the scope is back on the fast one.
+    let fallbackDuringDownload: unknown = 'never read';
+    const source: SnapshotSource = {
+      fetchManifest: vi.fn(async () => makeManifest([makeEntry()])),
+      downloadArtifact: vi.fn(async () => {
+        fallbackDuringDownload = await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', [
+          'bootstrap-paged-fallback:kilter:1:5',
+        ]);
+        return { filePath };
+      }),
+      deleteArtifact: vi.fn(async () => {}),
+    };
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+
+    expect(fallbackDuringDownload).toBeNull();
+  });
+
   it('does not heal a second time — the marker is what bounds the re-download', async () => {
     await seedExhaustedScope();
     await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -1345,7 +1345,7 @@ describe('pullSync connectivity gate', () => {
   });
 });
 
-describe('pullSync bootstrap: transport failures do not burn an attempt', () => {
+describe('pullSync bootstrap: transport failures at the manifest stage do not burn an attempt', () => {
   it('reports a transport manifest failure as expected, keeps the counter at 0, and still skips the paged pull', async () => {
     const cause = new TypeError('Network request failed');
     const source = makeSnapshotSource({ manifestError: cause });
@@ -1405,7 +1405,12 @@ describe('pullSync bootstrap: transport failures do not burn an attempt', () => 
     ).not.toBeNull();
   });
 
-  it('counts a NON-transport download failure but not a transport one', async () => {
+  it('counts a download failure even when it is transport-shaped — only the severity differs', async () => {
+    // The manifest resolved over this same connection moments earlier, so the
+    // device is provably online. Exempting this from the cap would let an
+    // unresumable 272 MB GET that always times out restart on every foreground
+    // forever, and — because a download failure also skips the paged pull — the
+    // board would never get an offline catalog by any route.
     const transportSource = makeSnapshotSource({
       manifest: makeManifest([makeEntry()]),
       downloadError: new Error('snapshot download: File.downloadFileAsync failed', {
@@ -1420,12 +1425,14 @@ describe('pullSync bootstrap: transport failures do not burn an attempt', () => 
       onSnapshotBootstrapError: transportReports,
     });
 
-    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(1);
+    // Still reported as expected, so Sentry sees a warning rather than an error.
     expect(transportReports).toHaveBeenCalledWith(
-      expect.objectContaining({ stage: 'download', attempt: 0, expected: true }),
+      expect.objectContaining({ stage: 'download', attempt: 1, expected: true }),
     );
 
-    // A disk-full device is a real failure the user can act on — that still counts.
+    // A disk-full device is a real failure the user can act on — that counts too,
+    // and reports at full severity.
     const diskFullSource = makeSnapshotSource({
       manifest: makeManifest([makeEntry()]),
       downloadError: new Error('snapshot download: insufficient disk space for kilter:1'),
@@ -1438,10 +1445,49 @@ describe('pullSync bootstrap: transport failures do not burn an attempt', () => 
       onSnapshotBootstrapError: diskReports,
     });
 
-    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(1);
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(2);
     expect(diskReports).toHaveBeenCalledWith(
-      expect.objectContaining({ stage: 'download', attempt: 1, expected: false }),
+      expect.objectContaining({ stage: 'download', attempt: 2, expected: false }),
     );
+  });
+
+  it('settles a board whose huge artifact always times out onto the paged crawl instead of re-downloading forever', async () => {
+    // Regression guard for the download-stage cap exemption: an unresumable
+    // multi-hundred-MB GET that times out every cycle must not restart on every
+    // foreground. Two counted attempts (+ the one-shot heal's second round) and
+    // the scope takes the slow-but-working paged path.
+    const timeoutSource = makeSnapshotSource({
+      manifest: makeManifest([makeEntry()]),
+      downloadError: new Error('snapshot download: File.downloadFileAsync failed for kilter:1', {
+        // The exact shape the issue's Sentry sample carries on iOS.
+        cause: new Error('UnableToDownloadException: The request timed out.'),
+      }),
+    });
+
+    // Four launches: two burn the initial budget, the third heals it once, the
+    // fourth exhausts the healed budget.
+    for (let launch = 0; launch < 4; launch += 1) {
+      const run = makeGraphqlFetch();
+      await pullSync(db, noopQueryClient(), run.fetch, {
+        enabledBoards: ['kilter:1:5'],
+        snapshotSource: timeoutSource,
+      });
+    }
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(2);
+    expect(timeoutSource.downloadArtifact).toHaveBeenCalledTimes(4);
+
+    // Fifth launch: over the cap with the heal spent, so the artifact is not
+    // fetched again and the paged crawl finally runs for this scope.
+    const settled = makeGraphqlFetch();
+    await pullSync(db, noopQueryClient(), settled.fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: timeoutSource,
+    });
+    expect(timeoutSource.downloadArtifact).toHaveBeenCalledTimes(4);
+    expect(settled.capturedClimbCursors).toHaveLength(1);
+    expect(
+      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-paged-fallback:kilter:1:5']),
+    ).not.toBeNull();
   });
 
   it('still counts an import failure — a corrupt artifact is never an offline problem', async () => {

--- a/packages/shared/offline-sync/src/sync/__tests__/sync-scheduler.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/sync-scheduler.test.ts
@@ -118,6 +118,31 @@ describe('sync-scheduler', () => {
     );
   });
 
+  it('threads the connectivity probe into pullSync, and omits it when the caller has none (#4238)', async () => {
+    const drainQueue: DrainQueue = vi.fn().mockResolvedValue(undefined);
+    const isOnline = () => false;
+
+    triggerSync(mockDb, createMockQueryClient(), mockGraphqlFetch, getEnabledBoards, drainQueue, { isOnline });
+    await flush();
+
+    expect(mockPullSync).toHaveBeenCalledWith(
+      mockDb,
+      expect.anything(),
+      mockGraphqlFetch,
+      expect.objectContaining({ isOnline }),
+    );
+
+    // No probe supplied → pullSync gets `undefined` and keeps its assume-online
+    // default, so today's callers are unchanged.
+    vi.clearAllMocks();
+    __resetSyncSchedulerStateForTests();
+    triggerSync(mockDb, createMockQueryClient(), mockGraphqlFetch, getEnabledBoards, drainQueue);
+    await flush();
+
+    const options = mockPullSync.mock.calls[0][3] as { isOnline?: () => boolean };
+    expect(options.isOnline).toBeUndefined();
+  });
+
   it('single-flights concurrent triggers into one run plus one follow-up', async () => {
     const drainGate = deferred();
     const drainQueue: DrainQueue = vi.fn(() => drainGate.promise);

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -13,6 +13,9 @@ import {
   bootstrapScopeFromSnapshot,
   getBootstrapAttempts,
   recordBootstrapAttempt,
+  resetBootstrapAttempts,
+  hasHealedBootstrapAttempts,
+  markBootstrapAttemptsHealed,
   markBootstrapPagedFallback,
   clearBootstrapPagedFallback,
   markBootstrapDone,
@@ -34,6 +37,7 @@ import {
 } from './deletions-coverage';
 import { applyBusyTimeout } from '../db/pragmas';
 import { getPendingCount } from '../mutation-queue/queue';
+import { isNetworkError } from '../mutation-queue/error-classification';
 import { isSigningOut, getWipeEpoch, isBackgrounded } from '../mutation-queue/drainer';
 import { parseOfflineBoardKey, type OfflineBoardScope } from '../offline-board-key';
 
@@ -119,6 +123,17 @@ export type CoverageResetReporter = (info: CoverageResetInfo) => void;
 export type SyncOptions = {
   /** Encoded board scope keys ("boardType:layoutId:sizeId") to download offline. */
   enabledBoards?: string[];
+  /**
+   * Connectivity probe, mirroring `DrainOptions.isOnline` (drainer.ts). A pull
+   * that starts with no connection can only fail every request it makes, and
+   * the snapshot bootstrap phase would report each enabled-but-undownloaded
+   * scope's manifest failure as telemetry on the way (issue #4238).
+   *
+   * DEFAULTS TO `() => true`, so every existing caller — web included — behaves
+   * exactly as it did before this seam existed. Only the mobile adapter injects
+   * a real probe (React Query's onlineManager, wired to NetInfo).
+   */
+  isOnline?: () => boolean;
   onProgress?: (progress: SyncProgress) => void;
   onSchemaDrift?: SchemaDriftReporter;
   /**
@@ -517,6 +532,34 @@ async function recordRetryableBootstrapFailure(db: OfflineDatabase, scopeKey: st
   return attempt;
 }
 
+/**
+ * Settle one retryable manifest/download failure.
+ *
+ * A TRANSPORT-shaped cause (offline, DNS, TLS, timeout — `isNetworkError`, the
+ * same predicate the drainer uses to decide a mutation must not advance toward
+ * the dead-letter) burns NO attempt and writes nothing at all: the artifact is
+ * fine, the phone just isn't on a network, and counting it meant two launches in
+ * airplane mode permanently dropped a board to the paged crawl (issue #4238).
+ * The scope's paged pull is still skipped by the caller so no first-page
+ * checkpoint disqualifies the snapshot path.
+ *
+ * Anything else — a 500 from the CDN, a short artifact, a disk-full device — is
+ * a real failure and counts exactly as it always did.
+ *
+ * Returns the attempt number to report and whether the failure was expected
+ * (i.e. transport-shaped), which the mobile reporter uses to downgrade severity.
+ */
+async function settleRetryableBootstrapFailure(
+  db: OfflineDatabase,
+  scopeKey: string,
+  cause: unknown,
+): Promise<{ attempt: number; expected: boolean }> {
+  if (isNetworkError(cause)) {
+    return { attempt: await getBootstrapAttempts(db, scopeKey), expected: true };
+  }
+  return { attempt: await recordRetryableBootstrapFailure(db, scopeKey), expected: false };
+}
+
 async function resolveManifestOnce(
   source: SnapshotSource,
   cache: { value?: ManifestResolution },
@@ -549,18 +592,36 @@ async function resolveManifestOnce(
  *
  * Eligibility + failure matrix (per scope):
  *   - checkpoint exists on either board table → NOT eligible → normal paged pull.
- *   - attempts ≥ MAX → gave up → normal paged pull.
+ *   - attempts ≥ MAX → gave up → normal paged pull, EXCEPT for the one-shot heal
+ *     below.
  *   - manifest `absent` (missing/unparseable) → permanent miss, NO attempt →
  *     normal paged pull.
- *   - manifest `error` (network) → counted attempt → SKIP paged pull this cycle.
+ *   - manifest `error`, TRANSPORT-shaped (offline/DNS/TLS/timeout) → NO attempt,
+ *     nothing persisted → SKIP paged pull this cycle, reported as `expected`.
+ *   - manifest `error`, anything else (a 500 from the CDN, a parse blow-up) →
+ *     counted attempt → SKIP paged pull this cycle.
  *   - manifest `ok` but no entry for (boardType, layoutId) → permanent miss, NO
  *     attempt → normal paged pull (layout not exported yet).
- *   - download fails/returns null → counted attempt → SKIP paged pull this cycle.
+ *   - download fails transport-shaped → NO attempt → SKIP paged pull this cycle,
+ *     reported as `expected`.
+ *   - download fails/returns null otherwise → counted attempt → SKIP paged pull.
  *   - download throws SnapshotPermanentMissError → NO attempt → normal paged pull.
  *   - import throws (corrupt/short artifact, row-count/format mismatch) → counted
- *     attempt → SKIP paged pull this cycle.
+ *     attempt → SKIP paged pull this cycle. Import failures ALWAYS count: an
+ *     artifact that downloaded but won't import is a real defect, and the cap is
+ *     what stops the client re-downloading it forever.
  *   - success → mark done, rewind deletions to min(watermarks); paged pull runs
  *     normally, now a ~1-day delta from the scoped watermark checkpoints.
+ *
+ * ONE-SHOT HEAL (issue #4238): the attempt cap is evaluated AFTER the manifest
+ * resolves, so an over-cap scope that turns out to have a usable artifact
+ * waiting gets its counter cleared exactly once (`bootstrap-attempts-healed:`)
+ * and takes the snapshot path again. A device that spent both attempts offline
+ * therefore recovers on its first online launch, while a genuinely broken
+ * artifact costs two more attempts and then settles into the paged crawl for
+ * good. Cost: an over-cap scope consults the manifest each cycle — cached per
+ * pullSync run by `resolveManifestOnce`, so it adds a request only on cycles
+ * where EVERY scope is over the cap.
  * A wipe detected mid-phase bails the whole phase with no attempt (mirrors
  * syncTable). One artifact is downloaded per (boardType, layoutId) and reused
  * across that layout's sizes; all downloads are deleted in a finally.
@@ -612,11 +673,7 @@ async function runBootstrapPhase(
           metadataSettled = true;
           continue;
         }
-        if ((await getBootstrapAttempts(db, scope.scopeKey)) >= MAX_BOOTSTRAP_ATTEMPTS) {
-          await markBootstrapPagedFallback(db, scope.scopeKey);
-          metadataSettled = true;
-          continue;
-        }
+        const isOverAttemptCap = (await getBootstrapAttempts(db, scope.scopeKey)) >= MAX_BOOTSTRAP_ATTEMPTS;
 
         onProgress?.({ phase: 'bootstrap', currentTable: scope.scopeKey, documentsProcessed: 0 });
 
@@ -624,33 +681,59 @@ async function runBootstrapPhase(
         // Re-check after the manifest network await: every branch below either
         // writes to SQLite (recordBootstrapAttempt) or leads to one further down.
         if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) break;
+
+        // Shared with the pre-download size estimate (snapshot-estimate.ts) so the
+        // UI can never quote a number for an artifact this phase would skip.
+        const entry =
+          resolution.status === 'ok' ? findSnapshotEntry(resolution.manifest, scope.boardType, scope.layoutId) : null;
+        // Pre-check the manifest's schemaVersion so a schema-stale artifact is
+        // skipped BEFORE the multi-MB download; verifySnapshotMeta re-checks the
+        // authoritative value inside the file. Same permanent-miss semantics as
+        // SnapshotSchemaStaleError: no attempt, paged crawl runs this cycle, and
+        // tonight's export rebuilds at the new schema.
+        const isEntryUsable = entry !== null && isSnapshotEntryUsable(entry);
+
+        // The attempt cap is decided HERE, below the manifest resolution, so it
+        // can tell "we gave up because the artifact is broken" from "we gave up
+        // because the phone was in a tunnel twice". See the ONE-SHOT HEAL note
+        // in this function's doc comment.
+        if (isOverAttemptCap) {
+          const canHeal = isEntryUsable && !(await hasHealedBootstrapAttempts(db, scope.scopeKey));
+          if (!canHeal) {
+            await markBootstrapPagedFallback(db, scope.scopeKey);
+            metadataSettled = true;
+            continue;
+          }
+          await resetBootstrapAttempts(db, scope.scopeKey);
+          await markBootstrapAttemptsHealed(db, scope.scopeKey);
+        }
+
         if (resolution.status === 'absent') {
           await markBootstrapPagedFallback(db, scope.scopeKey);
           metadataSettled = true;
           continue; // permanent miss, no attempt
         }
         if (resolution.status === 'error') {
-          const attempt = await recordRetryableBootstrapFailure(db, scope.scopeKey);
-          metadataSettled = true;
-          onSnapshotBootstrapError?.({ scopeKey: scope.scopeKey, stage: 'manifest', attempt, cause: resolution.cause });
+          const { attempt, expected } = await settleRetryableBootstrapFailure(db, scope.scopeKey, resolution.cause);
+          // A transport failure persists nothing, so there is no settled decision
+          // for the UI to re-read — only a counted one changed sync_meta.
+          metadataSettled = !expected;
+          onSnapshotBootstrapError?.({
+            scopeKey: scope.scopeKey,
+            stage: 'manifest',
+            attempt,
+            cause: resolution.cause,
+            expected,
+          });
           skipPagedPull.add(scope.scopeKey);
           continue;
         }
-
-        // Shared with the pre-download size estimate (snapshot-estimate.ts) so the
-        // UI can never quote a number for an artifact this phase would skip.
-        const entry = findSnapshotEntry(resolution.manifest, scope.boardType, scope.layoutId);
         if (!entry) {
           await markBootstrapPagedFallback(db, scope.scopeKey);
           metadataSettled = true;
           continue; // layout not exported yet — permanent miss, no attempt
         }
-        // Pre-check the manifest's schemaVersion so a schema-stale artifact is
-        // skipped BEFORE the multi-MB download; verifySnapshotMeta re-checks the
-        // authoritative value inside the file. Same permanent-miss semantics as
-        // SnapshotSchemaStaleError: no attempt, paged crawl runs this cycle, and
-        // tonight's export rebuilds at the new schema.
-        if (!isSnapshotEntryUsable(entry)) {
+        if (!isEntryUsable) {
           await markBootstrapPagedFallback(db, scope.scopeKey);
           metadataSettled = true;
           continue;
@@ -685,16 +768,18 @@ async function runBootstrapPhase(
               stage: 'download',
               attempt: 0,
               cause: cachedDownload.cause,
+              expected: false,
             });
             continue;
           }
-          const attempt = await recordRetryableBootstrapFailure(db, scope.scopeKey);
-          metadataSettled = true;
+          const { attempt, expected } = await settleRetryableBootstrapFailure(db, scope.scopeKey, cachedDownload.cause);
+          metadataSettled = !expected;
           onSnapshotBootstrapError?.({
             scopeKey: scope.scopeKey,
             stage: 'download',
             attempt,
             cause: cachedDownload.cause,
+            expected,
           });
           skipPagedPull.add(scope.scopeKey);
           continue;
@@ -743,12 +828,26 @@ async function runBootstrapPhase(
             // artifact at the new schema for future fresh scopes.
             await markBootstrapPagedFallback(db, scope.scopeKey);
             metadataSettled = true;
-            onSnapshotBootstrapError?.({ scopeKey: scope.scopeKey, stage: 'import', attempt: 0, cause: error });
+            onSnapshotBootstrapError?.({
+              scopeKey: scope.scopeKey,
+              stage: 'import',
+              attempt: 0,
+              cause: error,
+              expected: false,
+            });
             continue;
           }
+          // Import failures always count, transport-shaped or not: the bytes are
+          // already on disk, so nothing about this failure is a network problem.
           const attempt = await recordRetryableBootstrapFailure(db, scope.scopeKey);
           metadataSettled = true;
-          onSnapshotBootstrapError?.({ scopeKey: scope.scopeKey, stage: 'import', attempt, cause: error });
+          onSnapshotBootstrapError?.({
+            scopeKey: scope.scopeKey,
+            stage: 'import',
+            attempt,
+            cause: error,
+            expected: false,
+          });
           skipPagedPull.add(scope.scopeKey);
         }
       } finally {
@@ -882,6 +981,14 @@ export async function pullSync(
   // when the app is already backgrounded.
   if (isBackgrounded()) return;
 
+  // Offline: every request this cycle would make is already lost, and the
+  // bootstrap phase would spend a Sentry event per enabled-but-undownloaded
+  // scope announcing it (issue #4238). Skip; the scheduler's offline→online
+  // edge and the next foreground both retrigger a cycle. Same posture as
+  // drainMutationQueue's `if (!options.isOnline()) return`.
+  const isOnline = options?.isOnline ?? (() => true);
+  if (!isOnline()) return;
+
   // Captured ONCE for the whole cycle and threaded into every phase, so a wipe or a
   // local purge aborts the entire pull rather than just whichever table is mid-flight.
   //
@@ -901,9 +1008,14 @@ export async function pullSync(
   // purge landing inside that window must read as "not my epoch" rather than be
   // adopted as this cycle's own baseline.
   const cycleEpoch = getWipeEpoch();
-  // Unlike the other two checks, isBackgrounded() is live, not latched — a background
-  // dip that clears before the next check runs won't abort a cycle it can no longer affect.
-  const cycleAborted = (): boolean => isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded();
+  // Unlike the other two checks, isBackgrounded() and isOnline() are live, not latched —
+  // a background dip (or a connectivity blip) that clears before the next check runs
+  // won't abort a cycle it can no longer affect. Connectivity is checked between phases
+  // rather than inside the bootstrap phase deliberately: an artifact that finished
+  // downloading must still get imported, and re-downloading 272 MB because NetInfo
+  // flapped during the import would be the worse failure.
+  const cycleAborted = (): boolean =>
+    isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded() || !isOnline();
 
   // Phase -1: deletions-coverage guard (issue #3474). Runs BEFORE the bootstrap
   // phase, so the reset and the rebuild that follows belong to the same cycle.

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -533,31 +533,49 @@ async function recordRetryableBootstrapFailure(db: OfflineDatabase, scopeKey: st
 }
 
 /**
- * Settle one retryable manifest/download failure.
+ * Settle one retryable manifest/download failure into the two INDEPENDENT
+ * decisions it drives: how loudly to report it (`expected`) and whether it burns
+ * an attempt.
  *
- * A TRANSPORT-shaped cause (offline, DNS, TLS, timeout — `isNetworkError`, the
- * same predicate the drainer uses to decide a mutation must not advance toward
- * the dead-letter) burns NO attempt and writes nothing at all: the artifact is
- * fine, the phone just isn't on a network, and counting it meant two launches in
- * airplane mode permanently dropped a board to the paged crawl (issue #4238).
- * The scope's paged pull is still skipped by the caller so no first-page
- * checkpoint disqualifies the snapshot path.
+ * `expected` is purely a severity signal — a TRANSPORT-shaped cause (offline,
+ * DNS, TLS, timeout; `isNetworkError`, the same predicate the drainer uses to
+ * decide a mutation must not advance toward the dead-letter) is routine on a
+ * phone and the mobile reporter downgrades it to a warning. It says nothing
+ * about the retry budget.
  *
- * Anything else — a 500 from the CDN, a short artifact, a disk-full device — is
- * a real failure and counts exactly as it always did.
+ * `exemptTransportFromCap` is the retry-budget decision, and it is TRUE for the
+ * manifest stage ONLY:
  *
- * Returns the attempt number to report and whether the failure was expected
- * (i.e. transport-shaped), which the mobile reporter uses to downgrade severity.
+ *  - MANIFEST: the request is a few KB of JSON and it is the stage an offline
+ *    launch dies at, which is exactly what made two launches in airplane mode
+ *    permanently drop a board to the paged crawl (issue #4238). Retrying it for
+ *    free costs nothing. The caller still skips the paged pull so no first-page
+ *    checkpoint disqualifies the snapshot path.
+ *  - DOWNLOAD: the manifest already resolved over the same connection seconds
+ *    earlier, so the device is provably online — a failure here is a slow or
+ *    flaky link, not a plane. Exempting it would let an unresumable 272 MB GET
+ *    that always times out (the download failure the issue's own Sentry sample
+ *    actually shows: `UnableToDownloadException: … The request timed out.`)
+ *    restart from byte 0 on every foreground FOREVER, burning cellular data and
+ *    — because the failure also skips the paged pull — leaving the board with no
+ *    offline catalog at all. Counting it means the scope settles into the paged
+ *    crawl after MAX_BOOTSTRAP_ATTEMPTS (plus the one-shot heal's second round),
+ *    which is a working board on the slow path.
+ *
+ * Anything non-transport — a 500 from the CDN, a short artifact, a disk-full
+ * device — counts at either stage, exactly as it always did.
  */
 async function settleRetryableBootstrapFailure(
   db: OfflineDatabase,
   scopeKey: string,
   cause: unknown,
+  { exemptTransportFromCap }: { exemptTransportFromCap: boolean },
 ): Promise<{ attempt: number; expected: boolean }> {
-  if (isNetworkError(cause)) {
-    return { attempt: await getBootstrapAttempts(db, scopeKey), expected: true };
+  const expected = isNetworkError(cause);
+  if (expected && exemptTransportFromCap) {
+    return { attempt: await getBootstrapAttempts(db, scopeKey), expected };
   }
-  return { attempt: await recordRetryableBootstrapFailure(db, scopeKey), expected: false };
+  return { attempt: await recordRetryableBootstrapFailure(db, scopeKey), expected };
 }
 
 async function resolveManifestOnce(
@@ -602,9 +620,11 @@ async function resolveManifestOnce(
  *     counted attempt → SKIP paged pull this cycle.
  *   - manifest `ok` but no entry for (boardType, layoutId) → permanent miss, NO
  *     attempt → normal paged pull (layout not exported yet).
- *   - download fails transport-shaped → NO attempt → SKIP paged pull this cycle,
- *     reported as `expected`.
- *   - download fails/returns null otherwise → counted attempt → SKIP paged pull.
+ *   - download fails/returns null → counted attempt → SKIP paged pull this cycle,
+ *     transport-shaped or not (only the severity differs — see
+ *     `settleRetryableBootstrapFailure` for why the cap exemption stops at the
+ *     manifest). Two of these settle the scope onto the paged crawl, which is
+ *     what stops an unresumable 272 MB GET restarting on every foreground.
  *   - download throws SnapshotPermanentMissError → NO attempt → normal paged pull.
  *   - import throws (corrupt/short artifact, row-count/format mismatch) → counted
  *     attempt → SKIP paged pull this cycle. Import failures ALWAYS count: an
@@ -714,9 +734,11 @@ async function runBootstrapPhase(
           continue; // permanent miss, no attempt
         }
         if (resolution.status === 'error') {
-          const { attempt, expected } = await settleRetryableBootstrapFailure(db, scope.scopeKey, resolution.cause);
-          // A transport failure persists nothing, so there is no settled decision
-          // for the UI to re-read — only a counted one changed sync_meta.
+          const { attempt, expected } = await settleRetryableBootstrapFailure(db, scope.scopeKey, resolution.cause, {
+            exemptTransportFromCap: true,
+          });
+          // A cap-exempt transport failure persists nothing, so there is no settled
+          // decision for the UI to re-read — only a counted one changed sync_meta.
           metadataSettled = !expected;
           onSnapshotBootstrapError?.({
             scopeKey: scope.scopeKey,
@@ -772,8 +794,18 @@ async function runBootstrapPhase(
             });
             continue;
           }
-          const { attempt, expected } = await settleRetryableBootstrapFailure(db, scope.scopeKey, cachedDownload.cause);
-          metadataSettled = !expected;
+          // NOT cap-exempt even when transport-shaped: the manifest resolved over
+          // this same connection moments ago, so the device is online and the
+          // artifact just won't come down. See settleRetryableBootstrapFailure.
+          const { attempt, expected } = await settleRetryableBootstrapFailure(
+            db,
+            scope.scopeKey,
+            cachedDownload.cause,
+            {
+              exemptTransportFromCap: false,
+            },
+          );
+          metadataSettled = true;
           onSnapshotBootstrapError?.({
             scopeKey: scope.scopeKey,
             stage: 'download',

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -726,6 +726,17 @@ async function runBootstrapPhase(
           }
           await resetBootstrapAttempts(db, scope.scopeKey);
           await markBootstrapAttemptsHealed(db, scope.scopeKey);
+          // The scope reached the cap, so it is carrying a paged-fallback marker
+          // that My Boards renders as "using the slower download". It is back on
+          // the snapshot path as of this line, and the download below can run for
+          // 18 minutes — leaving the marker up would tell the climber the wrong
+          // story for the whole of it. A later failure re-stamps it.
+          await clearBootstrapPagedFallback(db, scope.scopeKey);
+          // The scope reached the cap, so it is carrying a paged-fallback marker
+          // that My Boards renders as "using the slower download". It is back on
+          // the snapshot path as of this line, and the download below can run for
+          // 18 minutes — leaving the marker up would tell the climber the wrong
+          // story for the whole of it. A later failure re-stamps it.
         }
 
         if (resolution.status === 'absent') {

--- a/packages/shared/offline-sync/src/sync/scope-teardown.ts
+++ b/packages/shared/offline-sync/src/sync/scope-teardown.ts
@@ -33,6 +33,7 @@ import type { OfflineBoardScope } from '../offline-board-key';
 import { climbsScopeFilter, isSizeScopedBoard, sizeMembershipClause } from './board-scope-sql';
 import { getCheckpointKey, SCOPE_COMPLETE_PREFIX } from './checkpoints';
 import {
+  BOOTSTRAP_ATTEMPTS_HEALED_PREFIX,
   BOOTSTRAP_ATTEMPTS_PREFIX,
   BOOTSTRAP_DONE_PREFIX,
   BOOTSTRAP_PAGED_FALLBACK_PREFIX,
@@ -68,6 +69,10 @@ export function scopeSyncMetaKeys(scopeKey: string): string[] {
     ...BOARD_DATA_TABLES.map((tableName) => getCheckpointKey(tableName, scopeKey)),
     `${SCOPE_COMPLETE_PREFIX}${scopeKey}`,
     `${BOOTSTRAP_ATTEMPTS_PREFIX}${scopeKey}`,
+    // Belongs with the attempts row it bounds: re-adding the board must give the
+    // scope a clean counter AND a fresh heal budget, not one that was spent
+    // before the user removed it.
+    `${BOOTSTRAP_ATTEMPTS_HEALED_PREFIX}${scopeKey}`,
     `${BOOTSTRAP_DONE_PREFIX}${scopeKey}`,
     `${BOOTSTRAP_PAGED_FALLBACK_PREFIX}${scopeKey}`,
   ];

--- a/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
@@ -101,11 +101,16 @@ export type SnapshotBootstrapErrorReporter = (report: {
   /**
    * True when the failure is a transport/reachability one — the device was
    * offline or the connection dropped, which is the normal state of a phone on
-   * a plane, not a defect in the artifact or the client. These burn NO attempt
-   * (see `runBootstrapPhase`) and the mobile reporter downgrades them to a
-   * warning instead of an error (issue #4238). False for everything an engineer
-   * would actually want to look at: a corrupt artifact, a row-count mismatch, a
-   * schema-stale import, a permanent miss.
+   * a plane, not a defect in the artifact or the client. The mobile reporter
+   * downgrades these to a warning instead of an error (issue #4238). False for
+   * everything an engineer would actually want to look at: a corrupt artifact, a
+   * row-count mismatch, a schema-stale import, a permanent miss.
+   *
+   * SEVERITY ONLY. Whether the failure burns a bootstrap attempt is a separate,
+   * per-stage decision in `settleRetryableBootstrapFailure`: a transport-shaped
+   * MANIFEST failure is free, a transport-shaped DOWNLOAD failure still counts
+   * (the manifest already proved the device was online, and an unresumable
+   * 272 MB retry loop is worse than the paged crawl).
    */
   expected: boolean;
 }) => void;

--- a/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
@@ -51,6 +51,15 @@ export const MAX_BOOTSTRAP_ATTEMPTS = 2;
 export const BOOTSTRAP_ATTEMPTS_PREFIX = 'bootstrap-attempts:';
 export const BOOTSTRAP_DONE_PREFIX = 'bootstrap-done:';
 export const BOOTSTRAP_PAGED_FALLBACK_PREFIX = 'bootstrap-paged-fallback:';
+/**
+ * "This scope has already spent its one free counter reset." Written alongside
+ * `resetBootstrapAttempts` when `runBootstrapPhase` heals an over-cap scope that
+ * turns out to have a perfectly usable artifact waiting for it (issue #4238:
+ * two launches in airplane mode used to disqualify a board from the fast path
+ * forever). Bounding the heal to once per scope is what keeps a genuinely broken
+ * 272 MB artifact from being re-downloaded on every launch.
+ */
+export const BOOTSTRAP_ATTEMPTS_HEALED_PREFIX = 'bootstrap-attempts-healed:';
 const EPOCH_WATERMARK: SyncCheckpoint = { updatedAt: '1970-01-01T00:00:00.000Z', syncSeq: '0' };
 
 // Only snake_case identifiers may be spliced into the INSERT/SELECT column list.
@@ -89,6 +98,16 @@ export type SnapshotBootstrapErrorReporter = (report: {
   stage: 'manifest' | 'download' | 'import';
   attempt: number;
   cause: unknown;
+  /**
+   * True when the failure is a transport/reachability one — the device was
+   * offline or the connection dropped, which is the normal state of a phone on
+   * a plane, not a defect in the artifact or the client. These burn NO attempt
+   * (see `runBootstrapPhase`) and the mobile reporter downgrades them to a
+   * warning instead of an error (issue #4238). False for everything an engineer
+   * would actually want to look at: a corrupt artifact, a row-count mismatch, a
+   * schema-stale import, a permanent miss.
+   */
+  expected: boolean;
 }) => void;
 
 export type SnapshotBootstrapResult = {
@@ -251,6 +270,32 @@ export async function recordBootstrapAttempt(db: SqlExecutor, scopeKey: string):
     String(next),
   ]);
   return next;
+}
+
+/**
+ * Drop a scope's attempt counter entirely, making it bootstrap-eligible again.
+ * Only `runBootstrapPhase`'s one-shot heal calls this, and only once per scope
+ * (guarded by the healed marker below) — an unbounded reset would re-download a
+ * broken artifact on every launch.
+ */
+export async function resetBootstrapAttempts(db: SqlExecutor, scopeKey: string): Promise<void> {
+  await db.runAsync('DELETE FROM sync_meta WHERE key = ?', [`${BOOTSTRAP_ATTEMPTS_PREFIX}${scopeKey}`]);
+}
+
+/** True once this scope has spent its single attempt-counter heal. */
+export async function hasHealedBootstrapAttempts(db: SqlExecutor, scopeKey: string): Promise<boolean> {
+  const row = await db.getFirstAsync<{ key: string }>('SELECT key FROM sync_meta WHERE key = ?', [
+    `${BOOTSTRAP_ATTEMPTS_HEALED_PREFIX}${scopeKey}`,
+  ]);
+  return row !== null;
+}
+
+/** Record that this scope's one attempt-counter heal has been spent. */
+export async function markBootstrapAttemptsHealed(db: SqlExecutor, scopeKey: string): Promise<void> {
+  await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+    `${BOOTSTRAP_ATTEMPTS_HEALED_PREFIX}${scopeKey}`,
+    '1',
+  ]);
 }
 
 /** Persist that the latest bootstrap decision selected the ordinary paged crawl. */

--- a/packages/shared/offline-sync/src/sync/sync-scheduler.ts
+++ b/packages/shared/offline-sync/src/sync/sync-scheduler.ts
@@ -46,6 +46,14 @@ export type SchedulerTriggers = {
 export type SchedulerOptions = {
   onProgress?: SyncProgressSink;
   /**
+   * Threaded through to pullSync's SyncOptions. Omitted → pullSync assumes
+   * online, which is what every existing caller got. The offline→online edge
+   * detection below stays the retry mechanism: a cycle skipped because the
+   * probe said offline is re-run by `subscribeConnectivity` the moment the
+   * device reconnects.
+   */
+  isOnline?: () => boolean;
+  /**
    * Called when a sync cycle throws. A failed cycle is routine for offline
    * users (the reconnect trigger retries), so the mobile adapter passes a
    * dev-only console.warn — production neither spams the console nor reports
@@ -97,6 +105,7 @@ async function runSync(
     await drainQueue();
     await pullSync(db, queryClient, graphqlFetch, {
       enabledBoards: getEnabledBoards(),
+      isOnline: options?.isOnline,
       onProgress: options?.onProgress,
       onSchemaDrift: options?.onSchemaDrift,
       snapshotSource: options?.snapshotSource,


### PR DESCRIPTION
## Summary

Closes #4238.

Three connected defects in the offline snapshot bootstrap, all of which only bite users who open the app with no signal.

**1. `pullSync` had no connectivity gate.** The drainer has one (`drainer.ts:217`); the pull path only checked `isBackgrounded()`. `startSyncScheduler` fires on mount, on every foreground, and on every offline→online edge, so every offline launch ran the whole bootstrap phase and emitted one `level: error` Sentry event per enabled-but-undownloaded scope. `SyncOptions`/`SchedulerOptions` now take an injectable `isOnline`, defaulting to `() => true` — web and every existing caller are unchanged — and only the mobile adapter injects the real onlineManager/NetInfo probe. The probe is also folded into `cycleAborted()`, so a connection lost mid-cycle stops the run between phases. Deliberately **not** inside `runBootstrapPhase`: an artifact that finished downloading must still get imported, and re-downloading 272 MB because NetInfo flapped would be the worse failure.

**2. The severity downgrade was dead code.** `reportSnapshotBootstrapError` built a synthetic `new Error("Snapshot bootstrap failed for … ")` and only stringified the cause into `extra`, so `isNetworkError` matched nothing and the `level: 'warning'` + `tags.network` branch never ran. The wrapper now carries `{ cause }` (the shared classifier already walks a `.cause` chain three deep, so `error-reporting.ts` needed no change), plus `extra.causeName`. On the source side, the mkdir and `downloadFileAsync` wrappers keep the original exception as `cause` instead of only interpolating it, and the gzip-sniff catch now throws instead of `return null` — the last live path that reported `cause: null`.

**3. Two offline launches permanently disqualified a board.** `MAX_BOOTSTRAP_ATTEMPTS = 2`, persisted in `sync_meta`, and a transport failure counted exactly like a corrupt artifact. Two fixes:

- A transport-shaped **manifest** failure (classified with the same `isNetworkError` the drainer uses) now burns **no** attempt and persists nothing at all. That is the stage an offline launch dies at, and the request is a few KB of JSON, so retrying it for free costs nothing. The scope's paged pull is still skipped so no first-page checkpoint disqualifies the snapshot path. **Download** failures still count even when transport-shaped — the manifest resolved over the same connection seconds earlier, so the device is provably online, and exempting them would let an unresumable 272 MB GET that always times out (`UnableToDownloadException: … The request timed out.`, the download failure the issue's Sentry sample actually carries) restart from byte 0 on every foreground forever, with the board never getting an offline catalog by any route. Import failures count too — the bytes are already on disk, so that is never a network problem. `expected` on the reporter is therefore a **severity signal only**; the attempt-cap exemption is a separate per-stage decision.
- The cap is now evaluated **after** the manifest resolves, which lets an over-cap scope with a usable entry waiting clear its counter exactly once (`bootstrap-attempts-healed:`) and take the fast path again. A device that burned both attempts in a tunnel recovers on its first online launch; a genuinely broken artifact costs two more attempts and then settles into the paged crawl for good.

### Reviewer-facing choices

- **Transport failures report as `level: warning` + `tags.network` + `expected_offline`, not silence.** Dropping them entirely was the alternative; keeping them as warnings preserves the ability to watch the rate without drowning real bugs. Easy to flip to an early-return in the mobile reporter if you'd rather see nothing.
- **Cost of moving the cap check:** an over-cap scope now consults the manifest each cycle. `resolveManifestOnce` caches it per `pullSync` run, so that only adds a request on cycles where *every* enabled scope is over the cap.
- **Cost of the heal:** a device with a genuinely broken artifact gets two extra download attempts (up to 2 × 272 MB for `kilter:1`) before settling. Bounded by the marker; the alternative — resetting on every online launch — would be unbounded.
- **Where the heal can't reach:** a device that already burned both attempts *and* has since run a paged pull has a board checkpoint, which makes the scope permanently ineligible for bootstrap. The heal recovers the pre-checkpoint case (which is what `skipPagedPull` protects), not that one.
- `SnapshotBootstrapErrorReporter`'s report type gained a required `expected` field. The only implementer is the mobile adapter plus test doubles.

Not in scope (issue lists them under "separately worth sizing"): the 272 MB unresumable single-GET, the missing `AbortSignal`/`onProgress`, and surfacing the ~544 MB free-space requirement in the enable dialog. That is a download-strategy rewrite plus UI + i18n across four locales — its own PR.

**Sentry:** BOARDSESH-C2, BOARDSESH-C5, BOARDSESH-AE, BOARDSESH-AF, BOARDSESH-AA. Note that a lingering `cause: null` event after merge is not a regression until the production OTA has drained the fleet.

JS-only, no native fingerprint input, no migration, no i18n keys, no Bluetooth.

## Release Notes

- Open the app offline and your board downloads stay on the fast path — two launches without signal no longer drop a board to the slow catalog crawl.

## Test plan

- `vp run typecheck:mobile`, `vp run typecheck:shared` — clean.
- `vp test run --project offline-sync --reporter=agent` — 338 passed / 21 files. Coverage: the connectivity gate (offline probe does nothing, no probe behaves exactly as before, mid-cycle drop stops before the board pulls), transport vs non-transport manifest classification, "two offline launches then online still bootstraps", a transport-shaped download failure that still counts its attempt, the "always times out → settles onto the paged crawl instead of re-downloading forever" guard, the import-failure regression guard, and five heal cases (heals once, refuses a second time, refuses while offline, refuses an unexported layout, refuses a mid-crawl scope).
- `vp run test:mobile` — 5309 passed, 606 files.
- `vp check` on the touched paths — clean (the repo-wide run reports the same pre-existing `packages/db` warnings on `main`).
- Manual QA plan for the offline flows is in `.boardsesh/qa-notes.md` on the branch (gitignored): airplane-mode launch is silent, two offline launches then online still takes the snapshot path, remove/re-add gets a clean heal budget.
