### PR TITLE
fix(backend): retry Postgres connect blips and add a database health endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ Read relevant `docs/` before working on the matching area; update docs when the 
 - `docs/live-activity-push-testing.md` — APNs Live Activity push testing
 - `docs/db-migrations.md` — migration numbering, `when`-not-number apply order, the collision/renumber bot, and when it hands work back
 - `docs/logging.md` — backend structured logger (winston)
+- `docs/db-connectivity.md` — Postgres connect retries (what is retried and why it can't double-execute a write), the retry budgets, and the `/health` vs `/health/db` split
 - `docs/og-climb.md` — backend-served climb OG share cards (`GET /og/climb`: caches, env vars, timings)
 - `docs/mobile-sheets-vs-routes.md` — mobile: which surface to use (bottom sheet vs route), with the decision tree + the hard rules (incl. why `fullScreenModal` breaks the iOS 26 native tab bar)
 

--- a/docs/db-connectivity.md
+++ b/docs/db-connectivity.md
@@ -7,12 +7,12 @@ retry, and where to point a monitor.
 
 postgres.js attaches the first query of a fresh connection to the connect
 attempt itself (`handler()` → `connect(closed.shift(), query)`,
-`postgres/src/index.js:336`). When that connect fails — Railway internal DNS
+`postgres/src/index.js:337`). When that connect fails — Railway internal DNS
 hiccup, refused TCP connect during a Postgres restart — the query is rejected
 outright. One blip, one user-visible 500, even though the statement never
-reached the server. postgres.js's own `backoff()` only paces _reconnecting an
-already-dropped_ connection; it never re-runs the query that triggered the
-connect.
+reached the server. postgres.js's own `backoff()` only _paces_ the next connect
+attempt (see "postgres.js paces its own connects" below); it never re-runs the
+query that the failed connect rejected.
 
 ## What is retried
 
@@ -29,7 +29,7 @@ single statement when it fails with one of:
 
 postgres.js starts `connectTimer` at `connection.js:343` and cancels it at
 `connection.js:552`, inside the ReadyForQuery handler — _before_
-`execute(initial)` at `connection.js:568`. DNS and TCP errors come from the
+`execute(initial)` at `connection.js:567`. DNS and TCP errors come from the
 socket before a single protocol byte is written. So an error carrying one of
 those codes proves the server never saw the statement: re-running it cannot
 double-execute a write. The safety argument is structural, not a judgement call
@@ -66,16 +66,44 @@ reconnecting after a blip does not hit the database in lockstep.
 The budget is what stops the retry from amplifying a real outage. `connect_timeout`
 is 30s, so a `CONNECT_TIMEOUT` has already blown the 10s budget by the time it
 surfaces: it is rethrown immediately instead of doubling the user's wait and
-holding a second pool slot. Fast failures — DNS `EAI_AGAIN`, `ECONNREFUSED`
-during a restart — land well inside the budget and do get retried. In other
-words this shrinks blips; it does not survive outages. The 2026-08-10 burst
-(Sentry BOARDSESH-D8, 03:11–03:54Z) would still have produced errors.
+holding a second pool slot. During a blip — a DNS `EAI_AGAIN`, an `ECONNREFUSED`
+while Postgres restarts — the attempts are milliseconds apart and the retry does
+its job. In other words this shrinks blips; it does not survive outages. The
+2026-08-10 burst (Sentry BOARDSESH-D8, 03:11–03:54Z) would still have produced
+errors.
+
+### postgres.js paces its own connects, and that is what the budget bounds
+
+`ECONNREFUSED` is only cheap for the first few failures. postgres.js gates every
+connect on a pool-wide backoff of its own: `options.shared.retries` increments on
+each errored close (`connection.js:455`), `backoff(retries)` is
+`(0.5 + rand/2) * min(3^retries/100, 20)` seconds (`index.js:511`), and
+`connection.connect()` waits that long before it even opens a socket
+(`connection.js:113-116` → `reconnect()` at `:362`). The counter is shared across
+the pool and only resets on a successful connect (`connection.js:568`).
+
+Measured against a dead port with **stock postgres.js and no wrapper at all**,
+nine sequential connects take 7, 2, 17, 43, 131, 637, 1305, 2540, 14204 ms. Deep
+into an outage a single connect already costs seconds today.
+
+What the retry changes is that one statement spends up to `DB_CONNECT_ATTEMPTS`
+connects instead of one, so that counter ramps roughly three times faster and one
+request can span two attempts of a ramping delay. The wall-clock budget is the
+bound: it is checked after each attempt returns, so once a single attempt costs
+more than `DB_CONNECT_RETRY_BUDGET_MS` the loop stops there. It cannot preempt an
+attempt already in flight, so worst case a request absorbs about two attempts
+instead of one. If an incident ever shows that trade going the wrong way, lower
+`DB_CONNECT_RETRY_BUDGET_MS` (or set `DB_CONNECT_ATTEMPTS=1` to turn the retry
+off) rather than reaching into postgres.js's backoff.
+
+The connect-retry tests pin their pools to `backoff: () => 0` so they measure this
+wrapper's loop rather than that ramp.
 
 ## Where the retry is wired
 
 `createDb()` / `createReadDb()` hand drizzle a retry-wrapped view of the pool
 (`withConnectRetry`). drizzle issues every statement through `client.unsafe()`
-(`drizzle-orm/postgres-js/session.js:103,106,33`), so all drizzle traffic is
+(`drizzle-orm/postgres-js/session.js:33,43,65,103,106`), so all drizzle traffic is
 covered — backend resolvers, the Next.js app, scripts.
 
 Not covered:
@@ -109,7 +137,7 @@ Not covered:
 The probe (`packages/backend/src/services/db-health.ts`) runs `select 1` with a
 5s result cache, single-flight dedupe, and a 2s deadline. When the deadline
 wins it calls `query.cancel()`: postgres.js queues a query with no timeout of
-its own (`postgres/src/index.js:340`), so walking away would leave a zombie
+its own (`postgres/src/index.js:341`), so walking away would leave a zombie
 `select 1` that fires whenever the pool recovers, and probes would pile up
 through an outage.
 

--- a/docs/db-connectivity.md
+++ b/docs/db-connectivity.md
@@ -1,0 +1,127 @@
+# Database connectivity: connect retries and health probes
+
+How Boardsesh survives a Postgres connect blip, what it deliberately does not
+retry, and where to point a monitor.
+
+## The failure this fixes
+
+postgres.js attaches the first query of a fresh connection to the connect
+attempt itself (`handler()` → `connect(closed.shift(), query)`,
+`postgres/src/index.js:336`). When that connect fails — Railway internal DNS
+hiccup, refused TCP connect during a Postgres restart — the query is rejected
+outright. One blip, one user-visible 500, even though the statement never
+reached the server. postgres.js's own `backoff()` only paces _reconnecting an
+already-dropped_ connection; it never re-runs the query that triggered the
+connect.
+
+## What is retried
+
+`withDbConnectRetry` (`packages/db/src/client/connect-retry.ts`) retries a
+single statement when it fails with one of:
+
+| code                                     | what it means                           |
+| ---------------------------------------- | --------------------------------------- |
+| `CONNECT_TIMEOUT`                        | postgres.js's own connect timer fired   |
+| `ECONNREFUSED`                           | nothing listening (Postgres restarting) |
+| `EAI_AGAIN` / `EAI_NODATA` / `ENOTFOUND` | DNS did not resolve the host            |
+
+### Why that is write-safe
+
+postgres.js starts `connectTimer` at `connection.js:343` and cancels it at
+`connection.js:552`, inside the ReadyForQuery handler — _before_
+`execute(initial)` at `connection.js:568`. DNS and TCP errors come from the
+socket before a single protocol byte is written. So an error carrying one of
+those codes proves the server never saw the statement: re-running it cannot
+double-execute a write. The safety argument is structural, not a judgement call
+about which statements "look idempotent".
+
+### What is NOT retried, and why
+
+- **`CONNECTION_CLOSED`** — postgres.js emits it both for a socket that died
+  while connecting and for one that died with a query in flight. The error
+  object does not distinguish them, so retrying could re-run a write.
+- **`read ETIMEDOUT`** (Sentry BOARDSESH-9X) — a `TLSWrap.onStreamRead` failure,
+  i.e. an in-flight query dying mid-read. Same ambiguity, and it is a separate
+  problem: it predates and outlives the connect bursts.
+- **Transactions.** drizzle runs a transaction body against the scoped client
+  postgres.js hands its callback, which never passes through the retry wrapper.
+  A transaction that loses its connection fails as a whole; it never replays
+  half its statements.
+- **Multi-statement callbacks.** `withDbConnectRetry` takes a single statement.
+  Wrapping a sequence would re-run the earlier statements when a later one
+  fails to connect.
+
+## Budgets
+
+Defaults, both overridable by env:
+
+| knob                         | default | meaning                                                      |
+| ---------------------------- | ------- | ------------------------------------------------------------ |
+| `DB_CONNECT_ATTEMPTS`        | 3       | total attempts including the first                           |
+| `DB_CONNECT_RETRY_BUDGET_MS` | 10000   | wall-clock budget, checked before scheduling another attempt |
+
+Backoff is 150ms then 300ms (capped at 600ms) with ±50% jitter, so a fleet
+reconnecting after a blip does not hit the database in lockstep.
+
+The budget is what stops the retry from amplifying a real outage. `connect_timeout`
+is 30s, so a `CONNECT_TIMEOUT` has already blown the 10s budget by the time it
+surfaces: it is rethrown immediately instead of doubling the user's wait and
+holding a second pool slot. Fast failures — DNS `EAI_AGAIN`, `ECONNREFUSED`
+during a restart — land well inside the budget and do get retried. In other
+words this shrinks blips; it does not survive outages. The 2026-08-10 burst
+(Sentry BOARDSESH-D8, 03:11–03:54Z) would still have produced errors.
+
+## Where the retry is wired
+
+`createDb()` / `createReadDb()` hand drizzle a retry-wrapped view of the pool
+(`withConnectRetry`). drizzle issues every statement through `client.unsafe()`
+(`drizzle-orm/postgres-js/session.js:103,106,33`), so all drizzle traffic is
+covered — backend resolvers, the Next.js app, scripts.
+
+Not covered:
+
+- **The raw pool** from `createPool()` / `createReadPool()`. Tagged templates
+  also build fragments and helpers whose return value is not an awaitable
+  query, and cursors consume incrementally, so neither is the re-runnable single
+  statement the wrapper is safe for. Raw callers that want the retry wrap one
+  statement in `withDbConnectRetry`.
+- **`packages/aurora-sync` and `packages/kilter-sync`**, whose runners build
+  their own `postgres()` pools directly (`sync-runner.ts` in each) rather than
+  going through `@boardsesh/db/client`. They are background jobs that already
+  retry at the job level; routing them through the shared builder is a separate
+  change (it would also add `ssl: 'require'`, which their local runs do not
+  currently use).
+
+## Health endpoints
+
+- **`GET /health`** — status code is governed by Redis alone. It reports
+  Postgres as data (`database.reachable`, `database.latencyMs`,
+  `database.connectRetries`) but never fails on it. This endpoint is polled by
+  `wait-on http-get://localhost:8080/health` in
+  `.github/workflows/e2e-tests.yml` (lines 336 and 584), by the dev orchestrator
+  (`scripts/dev-orchestrator.ts:424`) and by the branch-deploy compose
+  healthcheck (`docs/branch-deploys.md:442`). Gating it on Postgres would strand
+  all three on a blip, and party sessions over WebSocket keep working without
+  the database.
+- **`GET /health/db`** — 503 when Postgres does not answer. This is the
+  alertable endpoint.
+
+The probe (`packages/backend/src/services/db-health.ts`) runs `select 1` with a
+5s result cache, single-flight dedupe, and a 2s deadline. When the deadline
+wins it calls `query.cancel()`: postgres.js queues a query with no timeout of
+its own (`postgres/src/index.js:340`), so walking away would leave a zombie
+`select 1` that fires whenever the pool recovers, and probes would pile up
+through an outage.
+
+## Runbook
+
+- Retries are logged at `warn`: `[db] connect retry 1/3 after EAI_AGAIN …`. Warn,
+  not error, so `SentryWinstonTransport` (`utils/sentry-transport.ts:80`, built
+  with `level: 'error'`) does not double-report alongside the
+  `Sentry.captureException` that `graphql/mask-error.ts` already does for the
+  failures that outlive the retry.
+- Sustained retries with no errors = the fix is working and the network is
+  flaky. Retries _plus_ errors = an outage; check `/health/db`.
+- **Alerting is dashboard configuration, not repo code.** Create a Sentry cron /
+  uptime monitor against `https://<backend>/health/db` and alert on a non-200.
+  Boardsesh's Sentry access from CI is read-only, so this has to be done by hand.

--- a/packages/backend/src/__tests__/db-connect-retry.test.ts
+++ b/packages/backend/src/__tests__/db-connect-retry.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, afterEach } from 'vite-plus/test';
 import net from 'node:net';
 import postgres from 'postgres';
+import { sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/postgres-js';
 import {
   backoffDelayMs,
   connectErrorCode,
@@ -130,6 +132,33 @@ describe('withDbConnectRetry', () => {
     expect(calls).toBe(1);
   });
 
+  it('stops retrying a fast code once postgres.js has slowed the attempts down', async () => {
+    // ECONNREFUSED is only cheap for the first few failures of an outage:
+    // postgres.js paces its own connect attempts with a pool-wide backoff that
+    // ramps to a 20s cap (index.js:511, connection.js:455), so deep into an
+    // outage one attempt costs seconds. The budget is the only thing bounding
+    // how much of that a single user request absorbs, so pin it for the
+    // allowlisted code the docs describe as "fast", not just CONNECT_TIMEOUT.
+    let calls = 0;
+    let clock = 0;
+    const failure = connectError('ECONNREFUSED');
+
+    await expect(
+      withDbConnectRetry(
+        () => {
+          calls += 1;
+          clock += 6_000;
+          return Promise.reject(failure);
+        },
+        { attempts: 3, budgetMs: 10_000, sleep: noSleep, now: () => clock },
+      ),
+    ).rejects.toBe(failure);
+
+    // One retry (6s elapsed, inside the budget), then the second attempt puts
+    // elapsed at 12s and the loop stops instead of running to `attempts`.
+    expect(calls).toBe(2);
+  });
+
   it('keeps a misbehaving observer from breaking the retry', async () => {
     setDbConnectObserver(() => {
       throw new Error('observer blew up');
@@ -245,30 +274,58 @@ describe('withConnectRetry (pool wrapper)', () => {
   });
 });
 
+async function reserveDeadPort(): Promise<number> {
+  const probe = net.createServer();
+  const port = await new Promise<number>((resolve, reject) => {
+    probe.once('error', reject);
+    probe.listen(0, '127.0.0.1', () => {
+      const address = probe.address();
+      resolve(typeof address === 'object' && address ? address.port : 0);
+    });
+  });
+  await new Promise<void>((resolve) => probe.close(() => resolve()));
+  return port;
+}
+
+function deadPool(port: number, max: number) {
+  return postgres(`postgresql://boardsesh:boardsesh@127.0.0.1:${port}/boardsesh`, {
+    max,
+    connect_timeout: 2,
+    idle_timeout: 1,
+    prepare: false,
+    onnotice: () => {},
+    // postgres.js paces its OWN connect attempts with a pool-wide backoff
+    // (`options.shared.retries` at connection.js:455, `backoff()` at
+    // index.js:511), which ramps to a 20s cap after ~8 failed connects and only
+    // resets on a success. Measured on a dead port with stock postgres.js and
+    // no wrapper at all, nine sequential connects take 7, 2, 17, 43, 131, 637,
+    // 1305, 2540, 14204 ms. Pinning it to 0 keeps these tests measuring OUR
+    // retry loop instead of that ramp. The production consequence is real and
+    // documented in docs/db-connectivity.md — it is what the wall-clock budget
+    // exists to bound, and it is why an ECONNREFUSED is only "fast" for the
+    // first few failures of an outage.
+    backoff: () => 0,
+  });
+}
+
+// Fast, deterministic backoff: these tests are about the retry loop driving a
+// real postgres.js pool, not about the jitter envelope (covered above).
+const FAST_BACKOFF = { baseDelayMs: 5, maxDelayMs: 10 } as const;
+
 describe('pool recovery after repeated connect failures', () => {
   // The regression this whole PR is fenced against: a retry that leaves
-  // postgres.js's connection bookkeeping wedged. After `max` consecutive
-  // connect failures, the next query must still reject promptly (not hang), and
-  // the pool must still be willing to open a socket afterwards.
-  it('keeps rejecting promptly and still reconnects once the port comes back', async () => {
-    const probe = net.createServer();
-    const port = await new Promise<number>((resolve, reject) => {
-      probe.once('error', reject);
-      probe.listen(0, '127.0.0.1', () => {
-        const address = probe.address();
-        resolve(typeof address === 'object' && address ? address.port : 0);
-      });
-    });
-    await new Promise<void>((resolve) => probe.close(() => resolve()));
+  // postgres.js's connection bookkeeping wedged. The refuted `options.socket`
+  // design stranded connections in the `connecting` queue, so after `max`
+  // failures every query hung forever. This drives the retry loop — attempts
+  // greater than 1, so the wrapper really re-enters the pool — against a real
+  // pool on a dead port, then proves the pool still opens a socket afterwards.
+  it('retries through a real pool, keeps rejecting promptly, and still reconnects', async () => {
+    const port = await reserveDeadPort();
+    const pool = deadPool(port, 2);
+    const events: DbConnectRetryEvent[] = [];
+    setDbConnectObserver((event) => events.push(event));
 
-    const pool = postgres(`postgresql://boardsesh:boardsesh@127.0.0.1:${port}/boardsesh`, {
-      max: 2,
-      connect_timeout: 2,
-      idle_timeout: 1,
-      prepare: false,
-      onnotice: () => {},
-    });
-    const retrying = withConnectRetry(pool, { attempts: 1 });
+    const retrying = withConnectRetry(pool, { attempts: 3, ...FAST_BACKOFF });
     const accepted: net.Socket[] = [];
     let connectionsSeen = 0;
     // Accepts the TCP connection and then says nothing, so postgres.js reaches
@@ -282,26 +339,66 @@ describe('pool recovery after repeated connect failures', () => {
     });
 
     try {
-      // max + 1 statements against a dead port: every one rejects, none hangs.
+      // max + 1 statements against a dead port: every one exhausts its attempts,
+      // rejects, and none hangs.
       for (let index = 0; index < 3; index += 1) {
         const startedAt = Date.now();
         await expect(retrying.unsafe('select 1')).rejects.toMatchObject({ code: 'ECONNREFUSED' });
-        expect(Date.now() - startedAt).toBeLessThan(4_000);
+        expect(Date.now() - startedAt).toBeLessThan(2_000);
       }
+
+      // Non-vacuous: 3 statements x (3 attempts - 1) retries, all against the
+      // real pool. A wrapper that silently stopped retrying would report none.
+      expect(events).toHaveLength(6);
+      expect(events.every((event) => event.code === 'ECONNREFUSED')).toBe(true);
+      expect(events.map((event) => event.attempt)).toEqual([1, 2, 1, 2, 1, 2]);
 
       await new Promise<void>((resolve, reject) => {
         revived.once('error', reject);
         revived.listen(port, '127.0.0.1', () => resolve());
       });
 
-      // The statement still fails, but the pool proves it is not wedged: it
-      // opened a socket again instead of queueing the query forever.
-      await expect(retrying.unsafe('select 1')).rejects.toMatchObject({ code: 'CONNECT_TIMEOUT' });
+      // 9 failed connects later the pool is not wedged: it opens a socket
+      // again instead of queueing the query forever. attempts:1 here so the
+      // assertion costs one connect_timeout, not three.
+      const once = withConnectRetry(pool, { attempts: 1 });
+      await expect(once.unsafe('select 1')).rejects.toMatchObject({ code: 'CONNECT_TIMEOUT' });
       expect(connectionsSeen).toBeGreaterThan(0);
     } finally {
       await pool.end({ timeout: 1 });
       for (const socket of accepted) socket.destroy();
       await new Promise<void>((resolve) => revived.close(() => resolve()));
+    }
+  }, 20_000);
+});
+
+describe('drizzle traffic through the wrapped pool', () => {
+  // The PR's coverage claim is "drizzle issues every statement through
+  // unsafe(), so all drizzle traffic is retried". Read off drizzle's source it
+  // is an assertion about a vendored file; here it is exercised end to end, so
+  // a drizzle upgrade that adds another statement path fails this test.
+  it('retries a drizzle statement and leaves transaction bodies alone', async () => {
+    const port = await reserveDeadPort();
+    const pool = deadPool(port, 1);
+    const events: DbConnectRetryEvent[] = [];
+    setDbConnectObserver((event) => events.push(event));
+
+    const db = drizzle(withConnectRetry(pool, { attempts: 3, ...FAST_BACKOFF }));
+
+    try {
+      await expect(db.execute(sql`select 1`)).rejects.toThrow();
+      expect(events).toHaveLength(2);
+      expect(events.every((event) => event.code === 'ECONNREFUSED')).toBe(true);
+
+      // A transaction must fail as a whole rather than replay half its
+      // statements: postgres.js runs `begin` and the whole body against the
+      // scoped client it builds internally (index.js:242, 252), which never
+      // passes through the wrapper. Zero retries proves it.
+      events.length = 0;
+      await expect(db.transaction(async (tx) => tx.execute(sql`select 1`))).rejects.toThrow();
+      expect(events).toEqual([]);
+    } finally {
+      await pool.end({ timeout: 1 });
     }
   }, 20_000);
 });

--- a/packages/backend/src/__tests__/db-connect-retry.test.ts
+++ b/packages/backend/src/__tests__/db-connect-retry.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it, afterEach } from 'vite-plus/test';
+import net from 'node:net';
+import postgres from 'postgres';
+import {
+  backoffDelayMs,
+  connectErrorCode,
+  isRetryableConnectError,
+  setDbConnectObserver,
+  withConnectRetry,
+  withDbConnectRetry,
+} from '@boardsesh/db/client';
+import type { DbConnectRetryEvent, PoolInstance } from '@boardsesh/db/client';
+
+function connectError(code: string): Error & { code: string } {
+  return Object.assign(new Error(`write ${code} db.internal:5432`), { code });
+}
+
+const noSleep = () => Promise.resolve();
+
+afterEach(() => {
+  setDbConnectObserver(null);
+});
+
+describe('connectErrorCode', () => {
+  it('accepts only the pre-dispatch connect codes', () => {
+    for (const code of ['CONNECT_TIMEOUT', 'ECONNREFUSED', 'EAI_AGAIN', 'EAI_NODATA', 'ENOTFOUND']) {
+      expect(connectErrorCode(connectError(code))).toBe(code);
+      expect(isRetryableConnectError(connectError(code))).toBe(true);
+    }
+  });
+
+  it('rejects codes that are ambiguous about whether the statement was dispatched', () => {
+    for (const code of ['CONNECTION_CLOSED', 'ETIMEDOUT', 'ECONNRESET', '57014', '23505']) {
+      expect(connectErrorCode(connectError(code))).toBeNull();
+      expect(isRetryableConnectError(connectError(code))).toBe(false);
+    }
+    expect(isRetryableConnectError(new Error('boom'))).toBe(false);
+    expect(isRetryableConnectError(null)).toBe(false);
+    expect(isRetryableConnectError('ECONNREFUSED')).toBe(false);
+  });
+});
+
+describe('withDbConnectRetry', () => {
+  it('runs once when the statement succeeds', async () => {
+    let calls = 0;
+    const result = await withDbConnectRetry(
+      () => {
+        calls += 1;
+        return Promise.resolve('rows');
+      },
+      { sleep: noSleep },
+    );
+
+    expect(result).toBe('rows');
+    expect(calls).toBe(1);
+  });
+
+  it('retries a connect failure and reports every retry to the observer', async () => {
+    const events: DbConnectRetryEvent[] = [];
+    setDbConnectObserver((event) => events.push(event));
+
+    let calls = 0;
+    const result = await withDbConnectRetry(
+      () => {
+        calls += 1;
+        return calls < 3 ? Promise.reject(connectError('EAI_AGAIN')) : Promise.resolve('rows');
+      },
+      { attempts: 3, sleep: noSleep },
+    );
+
+    expect(result).toBe('rows');
+    expect(calls).toBe(3);
+    expect(events.map((event) => event.attempt)).toEqual([1, 2]);
+    expect(events.every((event) => event.code === 'EAI_AGAIN' && event.maxAttempts === 3)).toBe(true);
+  });
+
+  it('rethrows the last error unchanged once attempts are exhausted', async () => {
+    const failure = connectError('ECONNREFUSED');
+    let calls = 0;
+
+    await expect(
+      withDbConnectRetry(
+        () => {
+          calls += 1;
+          return Promise.reject(failure);
+        },
+        { attempts: 3, sleep: noSleep },
+      ),
+    ).rejects.toBe(failure);
+
+    expect(calls).toBe(3);
+  });
+
+  it('never retries an error that could have reached the server', async () => {
+    let calls = 0;
+    const failure = connectError('CONNECTION_CLOSED');
+
+    await expect(
+      withDbConnectRetry(
+        () => {
+          calls += 1;
+          return Promise.reject(failure);
+        },
+        { attempts: 5, sleep: noSleep },
+      ),
+    ).rejects.toBe(failure);
+
+    expect(calls).toBe(1);
+  });
+
+  it('gives up immediately when the first attempt already burned the wall-clock budget', async () => {
+    // A CONNECT_TIMEOUT costs the full connect_timeout (30s). Retrying it would
+    // double the user's wait and hold a second pool slot, so the budget gate
+    // must stop the loop even though the code is on the allowlist.
+    let calls = 0;
+    let clock = 0;
+    const failure = connectError('CONNECT_TIMEOUT');
+
+    await expect(
+      withDbConnectRetry(
+        () => {
+          calls += 1;
+          clock += 30_000;
+          return Promise.reject(failure);
+        },
+        { attempts: 3, budgetMs: 10_000, sleep: noSleep, now: () => clock },
+      ),
+    ).rejects.toBe(failure);
+
+    expect(calls).toBe(1);
+  });
+
+  it('keeps a misbehaving observer from breaking the retry', async () => {
+    setDbConnectObserver(() => {
+      throw new Error('observer blew up');
+    });
+
+    let calls = 0;
+    const result = await withDbConnectRetry(
+      () => {
+        calls += 1;
+        return calls < 2 ? Promise.reject(connectError('ENOTFOUND')) : Promise.resolve('rows');
+      },
+      { attempts: 2, sleep: noSleep },
+    );
+
+    expect(result).toBe('rows');
+  });
+});
+
+describe('backoffDelayMs', () => {
+  it('grows, stays inside the +/-50% jitter envelope, and never exceeds the cap', () => {
+    for (const random of [0, 0.5, 0.999]) {
+      expect(backoffDelayMs(1, 150, 600, () => random)).toBeGreaterThanOrEqual(75);
+      expect(backoffDelayMs(1, 150, 600, () => random)).toBeLessThanOrEqual(225);
+      expect(backoffDelayMs(2, 150, 600, () => random)).toBeLessThanOrEqual(450);
+      // attempt 5 would be 2400ms unjittered; the cap holds it at 600 * 1.5.
+      expect(backoffDelayMs(5, 150, 600, () => random)).toBeLessThanOrEqual(900);
+    }
+  });
+});
+
+type FakeQuery = PromiseLike<unknown> & { values: () => FakeQuery };
+
+function fakeClient(run: (mode: 'rows' | 'values') => Promise<unknown>) {
+  let unsafeCalls = 0;
+  const client = {
+    unsafe(query: string, params?: unknown[]) {
+      unsafeCalls += 1;
+      void query;
+      void params;
+      let mode: 'rows' | 'values' = 'rows';
+      const fake: FakeQuery = {
+        values() {
+          mode = 'values';
+          return fake;
+        },
+        then(onFulfilled, onRejected) {
+          return run(mode).then(onFulfilled, onRejected);
+        },
+      };
+      return fake;
+    },
+    get unsafeCalls() {
+      return unsafeCalls;
+    },
+    options: { parsers: {} as Record<string, unknown> },
+    begin: (fn: unknown) => fn,
+  };
+  return client;
+}
+
+describe('withConnectRetry (pool wrapper)', () => {
+  it('retries a connect failure for a single statement issued through unsafe()', async () => {
+    let attempts = 0;
+    const client = fakeClient(() => {
+      attempts += 1;
+      return attempts < 3 ? Promise.reject(connectError('ECONNREFUSED')) : Promise.resolve([{ ok: 1 }]);
+    });
+
+    const wrapped = withConnectRetry(client as unknown as PoolInstance, { attempts: 3, sleep: noSleep });
+    await expect(wrapped.unsafe('select 1')).resolves.toEqual([{ ok: 1 }]);
+    expect(attempts).toBe(3);
+    // Every attempt builds a fresh postgres.js query — a rejected one can never
+    // be re-awaited.
+    expect(client.unsafeCalls).toBe(3);
+  });
+
+  it('preserves .values() across retries', async () => {
+    const modes: string[] = [];
+    let attempts = 0;
+    const client = fakeClient((mode) => {
+      modes.push(mode);
+      attempts += 1;
+      return attempts < 2 ? Promise.reject(connectError('EAI_AGAIN')) : Promise.resolve([[1]]);
+    });
+
+    const wrapped = withConnectRetry(client as unknown as PoolInstance, { attempts: 2, sleep: noSleep });
+    await expect(wrapped.unsafe('select 1').values()).resolves.toEqual([[1]]);
+    expect(modes).toEqual(['values', 'values']);
+  });
+
+  it('does not retry statements that may already have reached the server', async () => {
+    let attempts = 0;
+    const failure = connectError('CONNECTION_CLOSED');
+    const client = fakeClient(() => {
+      attempts += 1;
+      return Promise.reject(failure);
+    });
+
+    const wrapped = withConnectRetry(client as unknown as PoolInstance, { attempts: 3, sleep: noSleep });
+    await expect(wrapped.unsafe('insert into ticks values (1)')).rejects.toBe(failure);
+    expect(attempts).toBe(1);
+  });
+
+  it('passes non-statement members straight through so drizzle can install its parsers', () => {
+    const client = fakeClient(() => Promise.resolve([]));
+    const wrapped = withConnectRetry(client as unknown as PoolInstance, { sleep: noSleep });
+
+    // drizzle mutates client.options.parsers when it constructs — that has to
+    // land on the real pool, not on a copy.
+    (wrapped.options.parsers as Record<string, unknown>)['1184'] = 'transparent';
+    expect(client.options.parsers['1184']).toBe('transparent');
+    expect(typeof wrapped.begin).toBe('function');
+  });
+});
+
+describe('pool recovery after repeated connect failures', () => {
+  // The regression this whole PR is fenced against: a retry that leaves
+  // postgres.js's connection bookkeeping wedged. After `max` consecutive
+  // connect failures, the next query must still reject promptly (not hang), and
+  // the pool must still be willing to open a socket afterwards.
+  it('keeps rejecting promptly and still reconnects once the port comes back', async () => {
+    const probe = net.createServer();
+    const port = await new Promise<number>((resolve, reject) => {
+      probe.once('error', reject);
+      probe.listen(0, '127.0.0.1', () => {
+        const address = probe.address();
+        resolve(typeof address === 'object' && address ? address.port : 0);
+      });
+    });
+    await new Promise<void>((resolve) => probe.close(() => resolve()));
+
+    const pool = postgres(`postgresql://boardsesh:boardsesh@127.0.0.1:${port}/boardsesh`, {
+      max: 2,
+      connect_timeout: 2,
+      idle_timeout: 1,
+      prepare: false,
+      onnotice: () => {},
+    });
+    const retrying = withConnectRetry(pool, { attempts: 1 });
+    const accepted: net.Socket[] = [];
+    let connectionsSeen = 0;
+    // Accepts the TCP connection and then says nothing, so postgres.js reaches
+    // its own connect timeout and rejects. A listener that hung up instead
+    // would leave the query attached to the connection, and postgres.js
+    // answers that with an unbounded reconnect loop (connection.js:449).
+    const revived = net.createServer((socket) => {
+      connectionsSeen += 1;
+      accepted.push(socket);
+      socket.on('error', () => {});
+    });
+
+    try {
+      // max + 1 statements against a dead port: every one rejects, none hangs.
+      for (let index = 0; index < 3; index += 1) {
+        const startedAt = Date.now();
+        await expect(retrying.unsafe('select 1')).rejects.toMatchObject({ code: 'ECONNREFUSED' });
+        expect(Date.now() - startedAt).toBeLessThan(4_000);
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        revived.once('error', reject);
+        revived.listen(port, '127.0.0.1', () => resolve());
+      });
+
+      // The statement still fails, but the pool proves it is not wedged: it
+      // opened a socket again instead of queueing the query forever.
+      await expect(retrying.unsafe('select 1')).rejects.toMatchObject({ code: 'CONNECT_TIMEOUT' });
+      expect(connectionsSeen).toBeGreaterThan(0);
+    } finally {
+      await pool.end({ timeout: 1 });
+      for (const socket of accepted) socket.destroy();
+      await new Promise<void>((resolve) => revived.close(() => resolve()));
+    }
+  }, 20_000);
+});

--- a/packages/backend/src/__tests__/db-health.test.ts
+++ b/packages/backend/src/__tests__/db-health.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it, beforeEach, vi } from 'vite-plus/test';
+import type { IncomingMessage, ServerResponse } from 'http';
+
+const pubsubMock = vi.hoisted(() => ({
+  isRedisRequired: vi.fn(() => false),
+  isRedisConnected: vi.fn(() => true),
+}));
+
+vi.mock('../pubsub/index', () => ({ pubsub: pubsubMock }));
+
+import { handleDatabaseHealthCheck, handleHealthCheck } from '../handlers/health';
+import { getDbConnectRetryStats, probeDatabase, recordDbConnectRetry, resetDbHealthState } from '../services/db-health';
+
+type FakeQuery = {
+  settle: (value: unknown) => void;
+  fail: (error: unknown) => void;
+  cancelled: boolean;
+  promise: Promise<unknown>;
+};
+
+function fakePool() {
+  const queries: FakeQuery[] = [];
+  const pool = {
+    unsafe(_statement: string) {
+      let settle: (value: unknown) => void = () => {};
+      let fail: (error: unknown) => void = () => {};
+      const promise = new Promise<unknown>((resolve, reject) => {
+        settle = resolve;
+        fail = reject;
+      });
+      const record: FakeQuery = { settle, fail, cancelled: false, promise };
+      queries.push(record);
+      return {
+        then: (onFulfilled: unknown, onRejected: unknown) =>
+          promise.then(onFulfilled as (value: unknown) => unknown, onRejected as (reason: unknown) => unknown),
+        cancel: () => {
+          record.cancelled = true;
+          record.fail(Object.assign(new Error('canceling statement due to user request'), { code: '57014' }));
+        },
+      };
+    },
+    queries,
+  };
+  return pool;
+}
+
+function fakeResponse() {
+  const state = { statusCode: 0, body: '' };
+  const res = {
+    setHeader: () => {},
+    writeHead: (statusCode: number) => {
+      state.statusCode = statusCode;
+      return res;
+    },
+    end: (chunk?: string) => {
+      state.body = chunk ?? '';
+      return res;
+    },
+    headersSent: false,
+  };
+  return { res: res as unknown as ServerResponse, state };
+}
+
+const fakeRequest = { method: 'GET', headers: {} } as unknown as IncomingMessage;
+
+beforeEach(() => {
+  resetDbHealthState();
+  pubsubMock.isRedisRequired.mockReturnValue(false);
+  pubsubMock.isRedisConnected.mockReturnValue(true);
+});
+
+describe('probeDatabase', () => {
+  it('reports the round trip when Postgres answers', async () => {
+    const pool = fakePool();
+    let clock = 1_000;
+    const pending = probeDatabase({ getPool: () => pool as never, now: () => clock });
+
+    clock = 1_012;
+    pool.queries[0]!.settle([{ '?column?': 1 }]);
+
+    await expect(pending).resolves.toMatchObject({ reachable: true, latencyMs: 12, error: null });
+  });
+
+  it('caches within the TTL and re-probes after it', async () => {
+    const pool = fakePool();
+    let clock = 0;
+
+    const first = probeDatabase({ getPool: () => pool as never, now: () => clock, ttlMs: 5_000 });
+    pool.queries[0]!.settle([]);
+    await first;
+
+    clock = 4_000;
+    await probeDatabase({ getPool: () => pool as never, now: () => clock, ttlMs: 5_000 });
+    expect(pool.queries).toHaveLength(1);
+
+    clock = 6_000;
+    const third = probeDatabase({ getPool: () => pool as never, now: () => clock, ttlMs: 5_000 });
+    expect(pool.queries).toHaveLength(2);
+    pool.queries[1]!.settle([]);
+    await third;
+  });
+
+  it('de-duplicates concurrent callers into a single query', async () => {
+    const pool = fakePool();
+    const first = probeDatabase({ getPool: () => pool as never });
+    const second = probeDatabase({ getPool: () => pool as never });
+
+    expect(pool.queries).toHaveLength(1);
+    pool.queries[0]!.settle([]);
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    expect(firstResult).toBe(secondResult);
+  });
+
+  it('gives up on the deadline and cancels the abandoned query', async () => {
+    vi.useFakeTimers();
+    try {
+      const pool = fakePool();
+      const pending = probeDatabase({ getPool: () => pool as never, deadlineMs: 2_000 });
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      const health = await pending;
+
+      expect(health).toMatchObject({ reachable: false, latencyMs: null });
+      expect(health.error).toContain('2000ms');
+      // Without cancel() the `select 1` sits in postgres.js's queue forever and
+      // fires whenever the pool recovers.
+      expect(pool.queries[0]!.cancelled).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reports only the error code, never the statement', async () => {
+    const pool = fakePool();
+    const pending = probeDatabase({ getPool: () => pool as never });
+    pool.queries[0]!.fail(
+      Object.assign(new Error('write CONNECT_TIMEOUT postgis.railway.internal:5432'), {
+        code: 'CONNECT_TIMEOUT',
+        query: 'select 1',
+      }),
+    );
+
+    await expect(pending).resolves.toMatchObject({ reachable: false, error: 'CONNECT_TIMEOUT' });
+  });
+
+  it('reports unreachable when the pool itself cannot be built', async () => {
+    await expect(
+      probeDatabase({
+        getPool: () => {
+          throw Object.assign(new Error('DATABASE_URL is required'), { code: 'ENOTFOUND' });
+        },
+      }),
+    ).resolves.toMatchObject({ reachable: false, error: 'ENOTFOUND' });
+  });
+});
+
+describe('connect retry counters', () => {
+  it('counts retries and remembers the last code', () => {
+    expect(getDbConnectRetryStats()).toEqual({ count: 0, lastRetryAt: null, lastCode: null });
+
+    recordDbConnectRetry({ attempt: 1, maxAttempts: 3, delayMs: 150, elapsedMs: 5, code: 'EAI_AGAIN' }, () => 42);
+
+    expect(getDbConnectRetryStats()).toEqual({ count: 1, lastRetryAt: 42, lastCode: 'EAI_AGAIN' });
+  });
+});
+
+describe('GET /health', () => {
+  it('stays 200 with database.reachable false when Postgres is down', async () => {
+    const pool = fakePool();
+    const probe = probeDatabase({ getPool: () => pool as never });
+    pool.queries[0]!.fail(Object.assign(new Error('down'), { code: 'ECONNREFUSED' }));
+    await probe;
+
+    const { res, state } = fakeResponse();
+    await handleHealthCheck(fakeRequest, res);
+
+    // Regression guard: /health is polled by the e2e workflow, the dev
+    // orchestrator and the branch-deploy compose healthcheck. Gating it on
+    // Postgres would strand all three on a blip.
+    expect(state.statusCode).toBe(200);
+    const payload = JSON.parse(state.body);
+    expect(payload.status).toBe('healthy');
+    expect(payload.database.reachable).toBe(false);
+    expect(payload.database.error).toBe('ECONNREFUSED');
+  });
+
+  it('still returns 503 when Redis is required and disconnected', async () => {
+    const pool = fakePool();
+    const probe = probeDatabase({ getPool: () => pool as never });
+    pool.queries[0]!.settle([]);
+    await probe;
+
+    pubsubMock.isRedisRequired.mockReturnValue(true);
+    pubsubMock.isRedisConnected.mockReturnValue(false);
+
+    const { res, state } = fakeResponse();
+    await handleHealthCheck(fakeRequest, res);
+
+    expect(state.statusCode).toBe(503);
+    expect(JSON.parse(state.body).database.reachable).toBe(true);
+  });
+});
+
+describe('GET /health/db', () => {
+  it('returns 200 when Postgres answers and 503 when it does not', async () => {
+    const reachablePool = fakePool();
+    const reachableProbe = probeDatabase({ getPool: () => reachablePool as never });
+    reachablePool.queries[0]!.settle([]);
+    await reachableProbe;
+
+    const healthy = fakeResponse();
+    await handleDatabaseHealthCheck(fakeRequest, healthy.res);
+    expect(healthy.state.statusCode).toBe(200);
+    expect(JSON.parse(healthy.state.body).status).toBe('healthy');
+
+    resetDbHealthState();
+    const deadPool = fakePool();
+    const deadProbe = probeDatabase({ getPool: () => deadPool as never });
+    deadPool.queries[0]!.fail(Object.assign(new Error('down'), { code: 'EAI_AGAIN' }));
+    await deadProbe;
+
+    const unhealthy = fakeResponse();
+    await handleDatabaseHealthCheck(fakeRequest, unhealthy.res);
+    expect(unhealthy.state.statusCode).toBe(503);
+    expect(JSON.parse(unhealthy.state.body).database.error).toBe('EAI_AGAIN');
+  });
+});

--- a/packages/backend/src/handlers/health.ts
+++ b/packages/backend/src/handlers/health.ts
@@ -1,16 +1,37 @@
 import type { IncomingMessage, ServerResponse } from 'http';
 import { applyCorsHeaders } from './cors';
 import { pubsub } from '../pubsub/index';
+import { getDbConnectRetryStats, probeDatabase } from '../services/db-health';
 
 /**
  * Health check endpoint handler
  * GET /health
+ *
+ * The status code stays governed by Redis alone, and reports Postgres as data
+ * rather than gating on it. /health is what the e2e workflow polls with
+ * `wait-on http-get://localhost:8080/health` (.github/workflows/e2e-tests.yml
+ * lines 336 and 584), what the dev orchestrator waits on
+ * (scripts/dev-orchestrator.ts:424), and what the branch-deploy compose
+ * healthcheck hits (docs/branch-deploys.md:442). Failing it during a Postgres
+ * blip would strand all three, and party sessions over WebSocket keep working
+ * without the database. Alert on /health/db instead.
  */
 export async function handleHealthCheck(req: IncomingMessage, res: ServerResponse): Promise<void> {
   if (!applyCorsHeaders(req, res)) return;
 
   const redisRequired = pubsub.isRedisRequired();
   const redisConnected = pubsub.isRedisConnected();
+  const database = await probeDatabase();
+  const retries = getDbConnectRetryStats();
+
+  const databasePayload = {
+    reachable: database.reachable,
+    latencyMs: database.latencyMs,
+    checkedAt: database.checkedAt,
+    error: database.error,
+    connectRetries: retries.count,
+    lastConnectRetryAt: retries.lastRetryAt,
+  };
 
   // If Redis is required but not connected, report unhealthy
   if (redisRequired && !redisConnected) {
@@ -20,6 +41,7 @@ export async function handleHealthCheck(req: IncomingMessage, res: ServerRespons
         status: 'unhealthy',
         timestamp: Date.now(),
         redis: { required: true, connected: false },
+        database: databasePayload,
       }),
     );
     return;
@@ -31,6 +53,39 @@ export async function handleHealthCheck(req: IncomingMessage, res: ServerRespons
       status: 'healthy',
       timestamp: Date.now(),
       redis: { required: redisRequired, connected: redisConnected },
+      database: databasePayload,
+    }),
+  );
+}
+
+/**
+ * Database health endpoint
+ * GET /health/db
+ *
+ * 503 when Postgres does not answer. Deliberately not the Railway
+ * `healthcheckPath` — this is the endpoint to point an external monitor or a
+ * Sentry cron at, so a database outage pages someone instead of restarting a
+ * backend that cannot fix it.
+ */
+export async function handleDatabaseHealthCheck(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if (!applyCorsHeaders(req, res)) return;
+
+  const database = await probeDatabase();
+  const retries = getDbConnectRetryStats();
+
+  res.writeHead(database.reachable ? 200 : 503, { 'Content-Type': 'application/json' });
+  res.end(
+    JSON.stringify({
+      status: database.reachable ? 'healthy' : 'unhealthy',
+      timestamp: Date.now(),
+      database: {
+        reachable: database.reachable,
+        latencyMs: database.latencyMs,
+        checkedAt: database.checkedAt,
+        error: database.error,
+        connectRetries: retries.count,
+        lastConnectRetryAt: retries.lastRetryAt,
+      },
     }),
   );
 }

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -7,7 +7,8 @@ import { roomManager } from './services/room-manager';
 import { redisClientManager } from './redis/client';
 import { eventBroker, NotificationWorker } from './events/index';
 import { initCors, applyCorsHeaders } from './handlers/cors';
-import { handleHealthCheck } from './handlers/health';
+import { handleDatabaseHealthCheck, handleHealthCheck } from './handlers/health';
+import { recordDbConnectRetry } from './services/db-health';
 import { handleSessionJoin } from './handlers/join';
 import { handleAvatarUpload } from './handlers/avatars';
 import { handleGymLogoUpload } from './handlers/gym-logos';
@@ -66,6 +67,7 @@ import { getBoardSeqFloor, resolveBoardHolder } from './graphql/resolvers/board-
 import { registerBoardQueuePreviewHook } from './services/board-queue-preview';
 import { logger, setInstanceIdProvider } from './utils/logger';
 import { isClientAbortError } from './utils/http-errors';
+import { setDbConnectObserver } from '@boardsesh/db/client';
 import type { QueueEvent } from '@boardsesh/shared-schema';
 
 /**
@@ -96,6 +98,19 @@ async function dispatchLiveActivityForSession(sessionId: string): Promise<void> 
 }
 
 export async function startServer(): Promise<ServerResources> {
+  // Surface database connect retries. `warn`, not `error`: SentryWinstonTransport
+  // is constructed with `level: 'error'` (utils/sentry-transport.ts:80), so a
+  // warn stays log-only and cannot double-report alongside the
+  // Sentry.captureException that graphql/mask-error.ts already does for the
+  // failures that outlive the retry.
+  setDbConnectObserver((event) => {
+    recordDbConnectRetry(event);
+    logger.warn(
+      `[db] connect retry ${event.attempt}/${event.maxAttempts} after ${event.code} ` +
+        `(elapsed ${event.elapsedMs}ms, next attempt in ${event.delayMs}ms)`,
+    );
+  });
+
   // Initialize PubSub (connects to Redis if configured)
   // This must happen before we start accepting connections
   await pubsub.initialize();
@@ -321,6 +336,13 @@ export async function startServer(): Promise<ServerResources> {
       // Health check endpoint
       if (pathname === '/health' && req.method === 'GET') {
         await handleHealthCheck(req, res);
+        return;
+      }
+
+      // Database health — 503 when Postgres does not answer. Point monitors
+      // here, not at /health (see handlers/health.ts for why).
+      if (pathname === '/health/db' && req.method === 'GET') {
+        await handleDatabaseHealthCheck(req, res);
         return;
       }
 
@@ -624,6 +646,7 @@ export async function startServer(): Promise<ServerResources> {
     logger.info(`  GraphQL HTTP: ${httpScheme}://0.0.0.0:${PORT}/graphql`);
     logger.info(`  GraphQL WS: ${wsScheme}://0.0.0.0:${PORT}/graphql`);
     logger.info(`  Health check: ${httpScheme}://0.0.0.0:${PORT}/health`);
+    logger.info(`  Database health: ${httpScheme}://0.0.0.0:${PORT}/health/db`);
     logger.info(`  Join session: ${httpScheme}://0.0.0.0:${PORT}/join/:sessionId`);
     logger.info(`  Avatar upload: ${httpScheme}://0.0.0.0:${PORT}/api/avatars`);
     logger.info(`  Avatar files: ${httpScheme}://0.0.0.0:${PORT}/static/avatars/`);

--- a/packages/backend/src/services/db-health.ts
+++ b/packages/backend/src/services/db-health.ts
@@ -114,7 +114,7 @@ async function runProbe(options: ProbeOptions): Promise<DatabaseHealth> {
 
     if (outcome === 'timeout') {
       // postgres.js queues a query with no timeout of its own
-      // (postgres/src/index.js:340). Walking away from the promise would leave
+      // (postgres/src/index.js:341). Walking away from the promise would leave
       // a zombie `select 1` in the queue that fires whenever the pool
       // recovers, so probes would pile up through an outage. cancel() takes it
       // back out of the queue (index.js:350-360).

--- a/packages/backend/src/services/db-health.ts
+++ b/packages/backend/src/services/db-health.ts
@@ -1,0 +1,160 @@
+import { createPool } from '@boardsesh/db/client';
+import type { DbConnectRetryEvent, PoolInstance } from '@boardsesh/db/client';
+
+export type DatabaseHealth = {
+  reachable: boolean;
+  /** Round-trip time of the `select 1`, or null when it never came back. */
+  latencyMs: number | null;
+  checkedAt: number;
+  /** Error code (or a short message) — never the SQL or the connection string. */
+  error: string | null;
+};
+
+export type DbConnectRetryStats = {
+  count: number;
+  lastRetryAt: number | null;
+  lastCode: string | null;
+};
+
+/**
+ * Result cache. /health is polled by the Railway healthcheck, the Docker
+ * HEALTHCHECK and any external monitor; without a TTL each of those would put
+ * another `select 1` on the pool, and during an outage the probes would occupy
+ * pool slots and then all fire at once on recovery.
+ */
+const PROBE_TTL_MS = 5_000;
+/** Hard ceiling on how long /health can wait behind a dead pool. */
+const PROBE_DEADLINE_MS = 2_000;
+
+type ProbeOptions = {
+  ttlMs?: number;
+  deadlineMs?: number;
+  now?: () => number;
+  getPool?: () => PoolInstance;
+};
+
+let cachedHealth: DatabaseHealth | null = null;
+let inFlightProbe: Promise<DatabaseHealth> | null = null;
+
+let retryStats: DbConnectRetryStats = { count: 0, lastRetryAt: null, lastCode: null };
+
+export function recordDbConnectRetry(event: DbConnectRetryEvent, now: () => number = Date.now): void {
+  retryStats = { count: retryStats.count + 1, lastRetryAt: now(), lastCode: event.code };
+}
+
+export function getDbConnectRetryStats(): DbConnectRetryStats {
+  return retryStats;
+}
+
+/** Test seam — drops the cached probe result and the retry counters. */
+export function resetDbHealthState(): void {
+  cachedHealth = null;
+  inFlightProbe = null;
+  retryStats = { count: 0, lastRetryAt: null, lastCode: null };
+}
+
+/**
+ * Reports whether Postgres answers a `select 1`. Cached for `PROBE_TTL_MS` and
+ * de-duplicated across concurrent callers, so a burst of health checks costs at
+ * most one query.
+ */
+export function probeDatabase(options: ProbeOptions = {}): Promise<DatabaseHealth> {
+  const now = options.now ?? Date.now;
+  const ttlMs = options.ttlMs ?? PROBE_TTL_MS;
+
+  if (cachedHealth && now() - cachedHealth.checkedAt < ttlMs) {
+    return Promise.resolve(cachedHealth);
+  }
+  if (inFlightProbe) {
+    return inFlightProbe;
+  }
+
+  const pending = runProbe(options)
+    .then((health) => {
+      cachedHealth = health;
+      return health;
+    })
+    .finally(() => {
+      if (inFlightProbe === pending) {
+        inFlightProbe = null;
+      }
+    });
+  inFlightProbe = pending;
+  return pending;
+}
+
+async function runProbe(options: ProbeOptions): Promise<DatabaseHealth> {
+  const now = options.now ?? Date.now;
+  const deadlineMs = options.deadlineMs ?? PROBE_DEADLINE_MS;
+  const startedAt = now();
+
+  let query: ReturnType<PoolInstance['unsafe']>;
+  try {
+    const pool = (options.getPool ?? createPool)();
+    query = pool.unsafe('select 1');
+  } catch (error) {
+    return { reachable: false, latencyMs: null, checkedAt: now(), error: describeError(error) };
+  }
+
+  // Handle the rejection inside the race, so cancelling the query below can
+  // never surface as an unhandled rejection.
+  const settled = query.then(
+    () => ({ ok: true as const }),
+    (error: unknown) => ({ ok: false as const, error }),
+  );
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<'timeout'>((resolve) => {
+    timer = setTimeout(() => resolve('timeout'), deadlineMs);
+    timer.unref?.();
+  });
+
+  try {
+    const outcome = await Promise.race([settled, deadline]);
+
+    if (outcome === 'timeout') {
+      // postgres.js queues a query with no timeout of its own
+      // (postgres/src/index.js:340). Walking away from the promise would leave
+      // a zombie `select 1` in the queue that fires whenever the pool
+      // recovers, so probes would pile up through an outage. cancel() takes it
+      // back out of the queue (index.js:350-360).
+      cancelQuietly(query);
+      return {
+        reachable: false,
+        latencyMs: null,
+        checkedAt: now(),
+        error: `probe exceeded ${deadlineMs}ms`,
+      };
+    }
+
+    if (!outcome.ok) {
+      return { reachable: false, latencyMs: null, checkedAt: now(), error: describeError(outcome.error) };
+    }
+
+    return { reachable: true, latencyMs: now() - startedAt, checkedAt: now(), error: null };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function cancelQuietly(query: ReturnType<PoolInstance['unsafe']>): void {
+  try {
+    // Typed `void`, but postgres.js actually hands back a promise when the
+    // query already reached the server, so swallow its rejection too.
+    const cancelled: unknown = query.cancel();
+    if (cancelled && typeof (cancelled as PromiseLike<unknown>).then === 'function') {
+      void Promise.resolve(cancelled).catch(() => {});
+    }
+  } catch {
+    // Cancelling is best effort; a failure here must not fail the probe.
+  }
+}
+
+function describeError(error: unknown): string {
+  if (error && typeof error === 'object') {
+    const { code, message } = error as { code?: unknown; message?: unknown };
+    if (typeof code === 'string' && code.length > 0) return code;
+    if (typeof message === 'string' && message.length > 0) return message.slice(0, 200);
+  }
+  return 'unknown error';
+}

--- a/packages/db/src/client/connect-retry.ts
+++ b/packages/db/src/client/connect-retry.ts
@@ -1,0 +1,262 @@
+import type postgres from 'postgres';
+
+/**
+ * Bounded retry for Postgres *connect* failures.
+ *
+ * postgres.js attaches the first query of a fresh connection to the connect
+ * attempt itself (`handler()` -> `connect(closed.shift(), query)`,
+ * postgres/src/index.js:336). If that connect fails, the query is rejected
+ * outright, so a single DNS blip or refused TCP connect turns into one
+ * user-visible 500 even though the statement never reached the server.
+ *
+ * WRITE SAFETY. We retry only the error codes that are structurally impossible
+ * once a statement has been dispatched. postgres.js starts `connectTimer` at
+ * connection.js:343 and cancels it at connection.js:552, inside the
+ * ReadyForQuery handler, *before* `execute(initial)` at connection.js:568. DNS
+ * and TCP errors (ECONNREFUSED / EAI_AGAIN / EAI_NODATA / ENOTFOUND) come from
+ * the socket before any protocol byte is written. So an error carrying one of
+ * these codes proves the server never saw the statement, and re-running it
+ * cannot double-execute a write.
+ *
+ * Everything else is rethrown unchanged — in particular CONNECTION_CLOSED and
+ * `read ETIMEDOUT`, which postgres.js emits both for a socket that died while
+ * connecting and for one that died with a query in flight. Those are
+ * indistinguishable at the error object, so retrying them could re-run a write.
+ */
+const RETRYABLE_CONNECT_ERROR_CODES: ReadonlySet<string> = new Set([
+  'CONNECT_TIMEOUT',
+  'ECONNREFUSED',
+  'EAI_AGAIN',
+  'EAI_NODATA',
+  'ENOTFOUND',
+]);
+
+const DEFAULT_ATTEMPTS = 3;
+const DEFAULT_BASE_DELAY_MS = 150;
+const DEFAULT_MAX_DELAY_MS = 600;
+/**
+ * Wall-clock budget for the whole retry loop, checked *before* scheduling
+ * another attempt. This is what stops the retry from amplifying a real outage:
+ * `connect_timeout` is 30s, so a CONNECT_TIMEOUT already burned 30s and blew
+ * the budget — it is rethrown immediately instead of doubling the user's wait
+ * and holding a second pool slot. Fast failures (DNS EAI_AGAIN, ECONNREFUSED
+ * during a Postgres restart) land well inside the budget and do get retried.
+ */
+const DEFAULT_BUDGET_MS = 10_000;
+
+export type DbConnectRetryEvent = {
+  /** 1-based index of the attempt that just failed. */
+  attempt: number;
+  maxAttempts: number;
+  /** Delay before the next attempt, after jitter. */
+  delayMs: number;
+  /** Milliseconds since the first attempt started. */
+  elapsedMs: number;
+  code: string;
+};
+
+export type DbConnectObserver = (event: DbConnectRetryEvent) => void;
+
+/**
+ * `packages/db` has no logger and no Sentry dependency, so the observer is how
+ * a host process (the backend) gets structured visibility into retries without
+ * this package reaching for `console.*`.
+ */
+let connectObserver: DbConnectObserver | null = null;
+
+export function setDbConnectObserver(observer: DbConnectObserver | null): void {
+  connectObserver = observer;
+}
+
+export type DbConnectRetryOptions = {
+  /** Total attempts including the first. Defaults to `DB_CONNECT_ATTEMPTS` or 3. */
+  attempts?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  /** Defaults to `DB_CONNECT_RETRY_BUDGET_MS` or 10000. */
+  budgetMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+  random?: () => number;
+  now?: () => number;
+};
+
+function readEnvInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+export function connectErrorCode(error: unknown): string | null {
+  if (!error || typeof error !== 'object') return null;
+  const { code } = error as { code?: unknown };
+  if (typeof code !== 'string') return null;
+  return RETRYABLE_CONNECT_ERROR_CODES.has(code) ? code : null;
+}
+
+export function isRetryableConnectError(error: unknown): boolean {
+  return connectErrorCode(error) !== null;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    // Never hold a process open just to pace a retry.
+    timer.unref?.();
+  });
+}
+
+export function backoffDelayMs(attempt: number, baseDelayMs: number, maxDelayMs: number, random: () => number): number {
+  const target = Math.min(maxDelayMs, baseDelayMs * 2 ** (attempt - 1));
+  // Full ±50% jitter so a fleet of instances reconnecting after a blip does not
+  // hit the database in lockstep.
+  return Math.round(target * (0.5 + random()));
+}
+
+/**
+ * Runs `execute` and retries it while it fails with a pre-dispatch connect
+ * error. `execute` MUST be a single statement (or an otherwise re-runnable
+ * unit) — never a multi-statement sequence or a transaction body, because a
+ * later statement failing to connect would re-run the earlier ones.
+ */
+export async function withDbConnectRetry<T>(
+  execute: () => PromiseLike<T>,
+  options: DbConnectRetryOptions = {},
+): Promise<T> {
+  const maxAttempts = Math.max(1, options.attempts ?? readEnvInt('DB_CONNECT_ATTEMPTS', DEFAULT_ATTEMPTS));
+  const budgetMs = options.budgetMs ?? readEnvInt('DB_CONNECT_RETRY_BUDGET_MS', DEFAULT_BUDGET_MS);
+  const baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+  const maxDelayMs = options.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep ?? defaultSleep;
+  const random = options.random ?? Math.random;
+
+  const startedAt = now();
+  let attempt = 1;
+
+  for (;;) {
+    try {
+      return await execute();
+    } catch (error) {
+      const code = connectErrorCode(error);
+      const elapsedMs = now() - startedAt;
+      if (code === null || attempt >= maxAttempts || elapsedMs >= budgetMs) {
+        // Rethrow untouched: on a genuine outage the caller sees exactly the
+        // error it sees today, just a little later.
+        throw error;
+      }
+
+      const delayMs = backoffDelayMs(attempt, baseDelayMs, maxDelayMs, random);
+      notifyObserver({ attempt, maxAttempts, delayMs, elapsedMs, code });
+      await sleep(delayMs);
+      attempt += 1;
+    }
+  }
+}
+
+function notifyObserver(event: DbConnectRetryEvent): void {
+  if (!connectObserver) return;
+  try {
+    connectObserver(event);
+  } catch {
+    // Observability must never turn a recoverable blip into a hard failure.
+  }
+}
+
+type Pool = ReturnType<typeof postgres>;
+type UnsafeArgs = Parameters<Pool['unsafe']>;
+type UnsafeQuery = ReturnType<Pool['unsafe']>;
+
+type LazyQuery = {
+  values(): unknown;
+  raw(): unknown;
+  then(onFulfilled?: unknown, onRejected?: unknown): Promise<unknown>;
+  catch(onRejected?: unknown): Promise<unknown>;
+  finally(onFinally?: unknown): Promise<unknown>;
+};
+
+type Settle = ((value: unknown) => unknown) | null | undefined;
+
+/**
+ * Builds a lazy stand-in for a postgres.js query that re-creates the query on
+ * every retry. postgres.js only dispatches a query when it is awaited
+ * (`Query.handle()` runs from `then`/`catch`/`finally`/`execute`), so building
+ * one per attempt costs nothing and a rejected query is never re-awaited.
+ */
+function createRetryingUnsafe(client: Pool, options?: DbConnectRetryOptions) {
+  return (...args: UnsafeArgs): UnsafeQuery => {
+    let mode: 'rows' | 'values' | 'raw' = 'rows';
+    let materialized: UnsafeQuery | undefined;
+
+    const build = (): PromiseLike<unknown> => {
+      const query = client.unsafe(...args);
+      if (mode === 'values') return query.values();
+      if (mode === 'raw') return query.raw();
+      return query;
+    };
+
+    const run = (): Promise<unknown> => withDbConnectRetry(build, options);
+
+    const lazy: LazyQuery = {
+      values() {
+        mode = 'values';
+        return proxy;
+      },
+      raw() {
+        mode = 'raw';
+        return proxy;
+      },
+      then(onFulfilled?: unknown, onRejected?: unknown) {
+        return run().then(onFulfilled as Settle, onRejected as Settle);
+      },
+      catch(onRejected?: unknown) {
+        return run().catch(onRejected as Settle);
+      },
+      finally(onFinally?: unknown) {
+        return run().finally(onFinally as (() => void) | null | undefined);
+      },
+    };
+
+    const proxy = new Proxy(lazy, {
+      get(target, property, receiver) {
+        if (property in target) {
+          return Reflect.get(target, property, receiver);
+        }
+        // Anything outside the awaited surface (cursor, stream, describe,
+        // forEach, …) gets the stock postgres.js query with no retry: those
+        // shapes dispatch and consume incrementally, so re-running them is not
+        // the single-statement unit this wrapper is safe for.
+        materialized ??= client.unsafe(...args);
+        const value = Reflect.get(materialized as object, property);
+        return typeof value === 'function' ? value.bind(materialized) : value;
+      },
+    }) as unknown as UnsafeQuery;
+
+    return proxy;
+  };
+}
+
+/**
+ * Wraps a postgres.js pool so that every *single statement* issued through
+ * `unsafe()` retries pre-dispatch connect failures. `unsafe()` is the only path
+ * drizzle uses for statements (drizzle-orm/postgres-js/session.js:103,106,33),
+ * so wrapping it covers all drizzle traffic.
+ *
+ * Deliberately NOT wrapped:
+ * - the tagged-template call itself, because `sql(...)` also builds fragments
+ *   and helpers whose return value is not an awaitable query;
+ * - `begin()` / `savepoint()`, because drizzle runs transaction bodies against
+ *   the scoped client postgres.js hands the callback. A transaction that loses
+ *   its connection must fail as a whole, never replay half its statements.
+ */
+export function withConnectRetry<T extends Pool>(client: T, options?: DbConnectRetryOptions): T {
+  const retryingUnsafe = createRetryingUnsafe(client, options);
+
+  return new Proxy(client, {
+    get(target, property, receiver) {
+      if (property === 'unsafe') return retryingUnsafe;
+      const value = Reflect.get(target, property, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  }) as T;
+}

--- a/packages/db/src/client/connect-retry.ts
+++ b/packages/db/src/client/connect-retry.ts
@@ -5,14 +5,14 @@ import type postgres from 'postgres';
  *
  * postgres.js attaches the first query of a fresh connection to the connect
  * attempt itself (`handler()` -> `connect(closed.shift(), query)`,
- * postgres/src/index.js:336). If that connect fails, the query is rejected
+ * postgres/src/index.js:337). If that connect fails, the query is rejected
  * outright, so a single DNS blip or refused TCP connect turns into one
  * user-visible 500 even though the statement never reached the server.
  *
  * WRITE SAFETY. We retry only the error codes that are structurally impossible
  * once a statement has been dispatched. postgres.js starts `connectTimer` at
  * connection.js:343 and cancels it at connection.js:552, inside the
- * ReadyForQuery handler, *before* `execute(initial)` at connection.js:568. DNS
+ * ReadyForQuery handler, *before* `execute(initial)` at connection.js:567. DNS
  * and TCP errors (ECONNREFUSED / EAI_AGAIN / EAI_NODATA / ENOTFOUND) come from
  * the socket before any protocol byte is written. So an error carrying one of
  * these codes proves the server never saw the statement, and re-running it
@@ -39,8 +39,19 @@ const DEFAULT_MAX_DELAY_MS = 600;
  * another attempt. This is what stops the retry from amplifying a real outage:
  * `connect_timeout` is 30s, so a CONNECT_TIMEOUT already burned 30s and blew
  * the budget — it is rethrown immediately instead of doubling the user's wait
- * and holding a second pool slot. Fast failures (DNS EAI_AGAIN, ECONNREFUSED
- * during a Postgres restart) land well inside the budget and do get retried.
+ * and holding a second pool slot. During a blip the DNS/TCP codes fail in
+ * milliseconds and the retry does its job.
+ *
+ * The budget also bounds a second, less obvious cost. postgres.js paces its own
+ * connect attempts with a pool-wide backoff: `options.shared.retries` increments
+ * on every errored close (connection.js:455) and `connection.connect()` waits
+ * `backoff(retries)` seconds — capped at 20 — before opening a socket
+ * (connection.js:113-116 -> reconnect() at :362), resetting only on a success
+ * (connection.js:568). So deep into an outage even an ECONNREFUSED costs
+ * seconds, and issuing three connects per statement ramps that counter faster.
+ * The budget check after each attempt is what keeps a single request from
+ * absorbing more than roughly two of those. Details and measurements:
+ * docs/db-connectivity.md.
  */
 const DEFAULT_BUDGET_MS = 10_000;
 
@@ -239,7 +250,7 @@ function createRetryingUnsafe(client: Pool, options?: DbConnectRetryOptions) {
 /**
  * Wraps a postgres.js pool so that every *single statement* issued through
  * `unsafe()` retries pre-dispatch connect failures. `unsafe()` is the only path
- * drizzle uses for statements (drizzle-orm/postgres-js/session.js:103,106,33),
+ * drizzle uses for statements (drizzle-orm/postgres-js/session.js:33,43,65,103,106),
  * so wrapping it covers all drizzle traffic.
  *
  * Deliberately NOT wrapped:

--- a/packages/db/src/client/index.ts
+++ b/packages/db/src/client/index.ts
@@ -15,3 +15,12 @@ export {
 export type { DbInstance, PoolInstance } from './postgres';
 export { getConnectionConfig, isLocalDevelopment } from './config';
 export type { ConnectionConfig } from './config';
+export {
+  withDbConnectRetry,
+  withConnectRetry,
+  setDbConnectObserver,
+  isRetryableConnectError,
+  connectErrorCode,
+  backoffDelayMs,
+} from './connect-retry';
+export type { DbConnectRetryEvent, DbConnectObserver, DbConnectRetryOptions } from './connect-retry';

--- a/packages/db/src/client/postgres.ts
+++ b/packages/db/src/client/postgres.ts
@@ -2,6 +2,7 @@ import { drizzle } from 'drizzle-orm/postgres-js';
 import type { Logger, SQLWrapper } from 'drizzle-orm';
 import postgres from 'postgres';
 import { getConnectionConfig, isLocalDevelopment } from './config';
+import { withConnectRetry } from './connect-retry';
 import * as schema from '../schema/index';
 import * as relations from '../relations/index';
 
@@ -81,7 +82,13 @@ export function createDb() {
   if (!cache.db) {
     const { connectionString } = getConnectionConfig();
     cache.client = postgres(connectionString, buildPoolOptions(connectionString));
-    cache.db = drizzle(cache.client, { schema: fullSchema, logger: sqlLogger });
+    // drizzle gets a retry-wrapped view of the pool: every statement it issues
+    // goes through `unsafe()`, and a statement that dies before it was
+    // dispatched (DNS/TCP connect failure) is retried instead of surfacing as a
+    // 500. See connect-retry.ts for why that is write-safe. drizzle mutates
+    // `client.options.parsers` on construction; the proxy forwards `options` to
+    // the real pool object, so the parser GUARANTEE below still holds.
+    cache.db = drizzle(withConnectRetry(cache.client), { schema: fullSchema, logger: sqlLogger });
   }
   return cache.db;
 }
@@ -94,6 +101,11 @@ export function createDb() {
  * Dates. Consumers that stream raw rows and expect resolver-shaped values (e.g.
  * the board-snapshot export) rely on this — never return a pool from here
  * without constructing drizzle over it first.
+ *
+ * This is the raw pool, without the connect-retry wrapper drizzle gets: tagged
+ * templates and cursors compose in ways a re-runnable single statement does
+ * not. Raw callers that want the retry can wrap one statement in
+ * `withDbConnectRetry`.
  */
 export function createPool() {
   if (!cache.client) {
@@ -116,7 +128,7 @@ export async function closePool(): Promise<void> {
 function ensureReadConnection(readReplicaUrl: string) {
   if (!cache.readClient || !cache.readDb) {
     cache.readClient = postgres(readReplicaUrl, buildPoolOptions(readReplicaUrl));
-    cache.readDb = drizzle(cache.readClient, { schema: fullSchema, logger: sqlLogger });
+    cache.readDb = drizzle(withConnectRetry(cache.readClient), { schema: fullSchema, logger: sqlLogger });
   }
   return { readClient: cache.readClient, readDb: cache.readDb };
 }


### PR DESCRIPTION
## Summary

Closes #4234.

A single Postgres connect blip turns into a user-visible 500 today. postgres.js
attaches the first query of a fresh connection to the connect attempt itself
(`handler()` → `connect(closed.shift(), query)`, `postgres/src/index.js:337`),
so when DNS hiccups or the TCP connect is refused, that query is rejected
outright — even though the statement never reached the server. postgres.js's own
`backoff()` only *paces* the next connect attempt; it never re-runs the query the
failed connect rejected.

Two halves:

**1. A bounded, write-safe connect retry** (`packages/db/src/client/connect-retry.ts`).
`withDbConnectRetry` retries a single statement on the pre-dispatch codes only:
`CONNECT_TIMEOUT`, `ECONNREFUSED`, `EAI_AGAIN`, `EAI_NODATA`, `ENOTFOUND`.
postgres.js starts `connectTimer` at `connection.js:343` and cancels it at
`connection.js:552`, inside ReadyForQuery, *before* `execute(initial)` at
`connection.js:567` — so those codes prove the server never saw the statement,
and re-running it cannot double-execute a write. The safety argument is
structural, not a guess about which statements look idempotent.

Everything else is rethrown unchanged: `CONNECTION_CLOSED` and `read ETIMEDOUT`
are emitted both for a socket that died while connecting and for one that died
with a query in flight, and the error object does not distinguish them.

drizzle gets a retry-wrapped view of the pool (it issues every statement through
`client.unsafe()`). The raw pool from `createPool()`, tagged templates, cursors
and transaction bodies keep stock behaviour — none of those is the re-runnable
single statement the retry is safe for, and a transaction that loses its
connection must fail as a whole rather than replay half its statements.

Defaults: 3 attempts, 150→600ms backoff with ±50% jitter, and a 10s wall-clock
budget checked *before* scheduling another attempt (`DB_CONNECT_ATTEMPTS`,
`DB_CONNECT_RETRY_BUDGET_MS`). The budget is what keeps the retry from
amplifying an outage: `connect_timeout` is 30s, so a `CONNECT_TIMEOUT` has
already blown the budget and is rethrown immediately instead of doubling the
user's wait and holding a second pool slot. During a blip the DNS/TCP codes fail
in milliseconds and the retry does its job.

**2. A real database health probe.** `GET /health` now carries a `database`
block (`reachable`, `latencyMs`, `connectRetries`) but its status code stays
governed by Redis alone, and `GET /health/db` is a new endpoint that returns 503
when Postgres does not answer. `/health` is what
`wait-on http-get://localhost:8080/health` polls in
`.github/workflows/e2e-tests.yml` (lines 336 and 584), what the dev orchestrator
waits on (`scripts/dev-orchestrator.ts:424`) and what the branch-deploy compose
healthcheck hits (`docs/branch-deploys.md:442`) — gating it on Postgres would
strand all three on a blip, and party sessions over WebSocket keep working
without the database. `/health/db` is the alertable one.

The probe runs `select 1` with a 5s result cache, single-flight dedupe and a 2s
deadline, and calls `query.cancel()` when the deadline wins: postgres.js queues
a query with no timeout of its own (`index.js:341`), so an abandoned probe would
sit in the queue and fire on recovery, with probes piling up through an outage.

Retries are logged at `warn` — `SentryWinstonTransport` is built with
`level: 'error'` (`utils/sentry-transport.ts:80`), so this stays log-only and
cannot double-report alongside the `Sentry.captureException` that
`graphql/mask-error.ts` already does for the failures that outlive the retry.

Docs: `docs/db-connectivity.md`.

### What this costs during a real outage

`ECONNREFUSED` is only cheap for the first few failures. postgres.js gates every
connect on a pool-wide backoff of its own: `options.shared.retries` increments on
each errored close (`connection.js:455`), `backoff(retries)` is
`(0.5 + rand/2) * min(3^retries/100, 20)` seconds (`index.js:511`), and
`connection.connect()` waits that long before it even opens a socket
(`connection.js:113-116` → `reconnect()` at `:362`). It resets only on a
successful connect.

Measured against a dead port with **stock postgres.js and no wrapper at all**,
nine sequential connects take 7, 2, 17, 43, 131, 637, 1305, 2540, 14204 ms — so
deep into an outage a single connect already costs seconds today.

What this PR changes is that one statement spends up to `DB_CONNECT_ATTEMPTS`
connects instead of one, so that counter ramps roughly 3× faster and one request
can span two attempts of a ramping delay. The wall-clock budget is the bound: it
is checked after each attempt returns, so once one attempt costs more than
`DB_CONNECT_RETRY_BUDGET_MS` the loop stops there. It cannot preempt an attempt
already in flight, so worst case a request absorbs about two attempts instead of
one. `DB_CONNECT_ATTEMPTS=1` turns the retry off without a deploy.

### Sentry issues

- **BOARDSESH-A0** `getaddrinfo EAI_AGAIN postgis.railway.internal` — the DNS
  blips this actually retries.
- **BOARDSESH-D8** `write CONNECT_TIMEOUT postgis.railway.internal:5432` — the
  headline burst, and **not** retried in practice: `connect_timeout` is 30s, so
  the first attempt has already blown the 10s budget. It is on the allowlist for
  correctness, not for effect. Expect it to keep firing.
- **BOARDSESH-9X** (`read ETIMEDOUT`) and **BOARDSESH-D9**
  (`CONNECTION_CLOSED`) are deliberately **not** touched — both are ambiguous
  about whether the statement reached the server. Expect them to keep firing.

### Honest scope

This shrinks blips; it does not survive outages. The 08-10 burst ran
03:11–03:54Z (~43 min), and a bounded ~1s retry would not have covered it. What
this PR buys is: fast DNS/TCP failures stop reaching users, and `/health/db`
plus the retry counters make the next event visible instead of inferred.

The design changed after review: an earlier plan put the retry in postgres.js's
`options.socket` factory. That was refuted with a repro — a rejecting factory
strands connections in the `connecting` queue forever (`connection.js:129-138`
never fires `'close'`, so `onclose` never runs `move(c, closed)`), and after
`max` failures every query hangs permanently, even once Postgres recovers. The
regression test in this PR fences exactly that: after `max` consecutive connect
failures the next query still rejects promptly, and the pool still opens a
socket afterwards.

### Not covered

`packages/aurora-sync` and `packages/kilter-sync` build their own `postgres()`
pools directly in their `sync-runner.ts` rather than going through
`@boardsesh/db/client`, so the retry does not reach them. They are background
jobs that retry at the job level; routing them through the shared builder would
also add `ssl: 'require'`, which their local runs do not currently use — that is
a separate change.

The Sentry alert rule (issue item 2) is dashboard configuration, not repo code.
`/health/db` is the code-side half; the runbook step is in
`docs/db-connectivity.md`.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check` — no new findings (the repo-wide run exits 1 on pre-existing
  warnings, identically on `origin/main`).
- `vp run typecheck:db` and `vp run typecheck:backend` — clean (backend
  tsconfig includes `src/**/*`, so the new tests typecheck too).
- `vp test run --project backend --reporter=agent db-connect-retry db-health` —
  26 passed; `db-connect-retry` run 3× for flake, stable.
- Real-database coverage of the proxy: `aurora-twin-dedup`, `climb-queries`,
  `climb-mutations`, `setter-follows` pass against the worker Postgres. Between
  them they exercise `db.execute`, relational queries and `db.transaction`
  through the wrapped pool.
- `vp run test:db` — 3 pre-existing failures (`createClimbFilters: zone modes`,
  `createClimbFilters: MoonBoard hold search`), identical on a clean tree at the
  same base commit; unrelated to this change.
- Not run: the full backend suite. Ports 8082/8084 are held by other processes
  on this machine, which makes `integration.test.ts` fail with `socket hang up`
  regardless of the diff. CI runs it clean.
- Not run: manual dev-server smoke. `.boardsesh/qa-notes.md` has the flows
  (stop/start the dev Postgres, check `/health` stays 200 with
  `database.reachable:false`, `/health/db` returns 503, and both recover without
  a backend restart).

### Adversarial QA pass (post-implementation)

- The pool-recovery regression test wrapped the pool with `attempts: 1`, making
  `withConnectRetry` a pass-through — it proved the wrapper does not wedge
  postgres.js but never entered the retry loop. Raised to 3 attempts with an
  observer assertion, plus a new end-to-end drizzle test so the "every statement
  goes through `unsafe()`" coverage claim is exercised rather than read off a
  vendored file, and so a transaction proves it does *not* retry.
- That change surfaced postgres.js's own pool-wide connect backoff (documented
  above and in `docs/db-connectivity.md`). The PR previously claimed
  `ECONNREFUSED` failures "land well inside the budget"; that holds for a blip,
  not through an outage. Claim corrected and the budget guarantee pinned with a
  test on `ECONNREFUSED`, not just `CONNECT_TIMEOUT`.
- Verified against the vendored `drizzle-orm@0.45.2` postgres-js session that
  `client.unsafe()` really is the only statement path (lines 33, 43, 65, 103,
  106) and that `begin()`/`savepoint()` hand the callback a scoped client built
  inside postgres.js (`index.js:242,252`), which never passes through the
  wrapper.
- Corrected four off-by-one source citations (`index.js:336→337`,
  `index.js:340→341`, `connection.js:568→567`, the drizzle `unsafe()` line list).
- Verified `/health` keeps its Redis-only status code and that
  `drizzle(...)` still mutates the real pool's `options.parsers` through the
  proxy.
