### PR TITLE
fix(mobile): render Grasshopper climbs on Expo web

### DIFF
--- a/packages/mobile/modules/board-renderer/src/index.web.ts
+++ b/packages/mobile/modules/board-renderer/src/index.web.ts
@@ -16,15 +16,19 @@
  *   - `renderHoldsOverlay(configJson, cacheKey)` — resolves to an image URL.
  *   - `MARKER_RENDERER_UNAVAILABLE_MESSAGE` — for contract parity.
  *
- * Marker overrides (custom hold shapes, brush thickness, shape size) are NOT
- * supported by the committed WASM artifact: it is the overlay-only core
- * (8-field RenderConfig, no `stroke_width_multiplier` / `shape_size_multiplier`
- * / per-hold `shape`). serde silently ignores those extra fields, so a marker
- * config would render as plain circles — the exact silent-wrong-output failure
- * the native shim guards against for old binaries. We therefore mirror the
- * shim: detect a marker config and throw MARKER_RENDERER_UNAVAILABLE_MESSAGE so
- * the hook adds the signature to its unsupported set and falls back to default
- * rendering, instead of showing wrong markers.
+ * Two marker overrides — shape size and per-hold `shape` — are NOT supported by
+ * the committed WASM artifact: it is the overlay-only core (8-field
+ * RenderConfig, no `shape_size_multiplier` and no per-hold `shape`). serde
+ * silently ignores those extra fields, so such a config would render as plain
+ * default-sized circles — the exact silent-wrong-output failure the native shim
+ * guards against for old binaries. We therefore mirror the shim: detect those
+ * two and throw MARKER_RENDERER_UNAVAILABLE_MESSAGE so the hook records the
+ * signature as unsupported and falls back to default rendering, instead of
+ * showing wrong markers.
+ *
+ * `stroke_width_multiplier` is deliberately NOT part of that guard — see
+ * configRequiresModernRenderer below. It degrades to the renderer's built-in
+ * default thickness rather than being refused.
  */
 
 import {
@@ -119,7 +123,7 @@ function isNonDefaultMultiplier(value: unknown): boolean {
 }
 
 // Mirrors index.ts's configRequiresModernRenderer: a config needs the
-// marker-aware renderer when it sets a non-default brush/size multiplier or any
+// marker-aware renderer when it sets a non-default shape-size multiplier or any
 // non-circle hold shape. The committed WASM core cannot honour those.
 function configRequiresModernRenderer(configJson: string): boolean {
   let parsedConfig: unknown;
@@ -129,7 +133,16 @@ function configRequiresModernRenderer(configJson: string): boolean {
     return false;
   }
   if (!isRecord(parsedConfig)) return false;
-  if (isNonDefaultMultiplier(parsedConfig.stroke_width_multiplier)) return true;
+  // stroke_width_multiplier is deliberately NOT a gate here, matching native
+  // (index.ts) — see issue #2202 and #4240. The committed WASM's RenderConfig
+  // has 8 fields and no `deny_unknown_fields` on the struct (see
+  // packages/board-renderer/core/src/types.rs), so serde ignores the
+  // unrecognised key and the overlay renders at the built-in default
+  // thickness — never a parse failure, never wrong geometry. Gating on it
+  // would instead throw MARKER_RENDERER_UNAVAILABLE_MESSAGE unconditionally
+  // for Grasshopper, whose board-level stroke default is 1.35 with zero user
+  // overrides (packages/board-constants/src/hold-states.ts), leaving the
+  // overlay permanently blank on Expo web. Slightly thin beats invisible.
   if (isNonDefaultMultiplier(parsedConfig.shape_size_multiplier)) return true;
 
   const holdStateMap = parsedConfig.hold_state_map;
@@ -346,6 +359,7 @@ export async function renderHoldsOverlay(configJson: string, cacheKey: string): 
 }
 
 type WebRendererTestApi = {
+  configRequiresModernRenderer: typeof configRequiresModernRenderer;
   decodeRenderOutput: typeof decodeRenderOutput;
   rememberObjectUrl: typeof rememberObjectUrl;
   releaseAllObjectUrls: typeof releaseAllObjectUrls;
@@ -362,6 +376,7 @@ type WebRendererTestApi = {
 export const _webRendererForTests: WebRendererTestApi = (
   __DEV__
     ? {
+        configRequiresModernRenderer,
         decodeRenderOutput,
         rememberObjectUrl,
         releaseAllObjectUrls,

--- a/packages/mobile/public/wasm/README.md
+++ b/packages/mobile/public/wasm/README.md
@@ -32,7 +32,11 @@ the pkg and verifies the checksums match.
 ## Phase 0 note
 
 This committed artifact is the **overlay-only** core (8-field `RenderConfig`, no
-`stroke_width_multiplier` / `shape_size_multiplier` / per-hold `shape`). Marker
-overrides therefore fall back to default rendering on web — see the guard in
-`index.web.ts`. Rebuilding the pkg from the current Rust core (which supports
-markers) and re-syncing will lift that limitation.
+`stroke_width_multiplier` / `shape_size_multiplier` / per-hold `shape`). Two of
+those — `shape_size_multiplier` and per-hold `shape` — would render silently
+wrong geometry, so `index.web.ts` refuses them and the overlay falls back to
+default rendering. `stroke_width_multiplier` is **not** refused: the struct has
+no `deny_unknown_fields`, so serde drops the key and the overlay draws at the
+built-in default thickness (issue #4240 — refusing it left Grasshopper, whose
+board default is 1.35, permanently blank). Rebuilding the pkg from the current
+Rust core (which supports markers) and re-syncing will lift both limitations.

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
@@ -92,6 +92,8 @@ const {
   _inflightRendersForTests,
   _resetWarmupForTests,
   _setNativeModuleForTests,
+  _unsupportedRenderSignaturesForTests,
+  _MARKER_RENDERER_UNAVAILABLE_MESSAGE_FOR_TESTS,
 } = await import('../use-native-climb-render');
 
 const BASE = {
@@ -499,5 +501,55 @@ describe('useNativeClimbRender in-flight race', () => {
     ]);
     expect(JSON.stringify(reportErrorMock.mock.calls)).not.toContain(overlayUri);
     expect(JSON.stringify(reportErrorMock.mock.calls)).not.toContain(cacheKey);
+  });
+});
+
+// Issue #4240: a renderer that cannot honour a config's marker overrides is a
+// designed capability fallback, not a defect. Before this, the throw was
+// reported to Sentry once per climb — and because Grasshopper's board-level
+// stroke default leaves the render signature at DEFAULT_HOLD_COLOR_SIGNATURE,
+// the "record the signature and stop retrying" throttle never engaged (29
+// events in 60 seconds from one browser session).
+describe('capability-fallback render rejections', () => {
+  const rejectingNativeModule = {
+    boardRendererNative: {},
+    renderHoldsOverlay: vi.fn<(configJson: string, cacheKey: string) => Promise<string>>(),
+  };
+
+  beforeEach(() => {
+    existingOverlayUris.clear();
+    _resetWarmupForTests();
+    _renderedOverlaysForTests.clear();
+    _inflightRendersForTests.clear();
+    _unsupportedRenderSignaturesForTests.clear();
+    reportErrorMock.mockClear();
+    rejectingNativeModule.renderHoldsOverlay.mockReset();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    _setNativeModuleForTests(rejectingNativeModule as unknown as Parameters<typeof _setNativeModuleForTests>[0]);
+  });
+
+  it('does not report the marker-unavailable fallback, and never poisons the default signature', async () => {
+    rejectingNativeModule.renderHoldsOverlay.mockRejectedValue(
+      new Error(_MARKER_RENDERER_UNAVAILABLE_MESSAGE_FOR_TESTS),
+    );
+
+    renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_SLOW }));
+
+    await waitFor(() => expect(rejectingNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(console.warn).toHaveBeenCalled());
+
+    expect(reportErrorMock).not.toHaveBeenCalled();
+    // The default signature is consulted for every render on every board —
+    // adding it here would blank the overlay app-wide.
+    expect(_unsupportedRenderSignaturesForTests.size).toBe(0);
+  });
+
+  it('still reports an unrelated render failure', async () => {
+    rejectingNativeModule.renderHoldsOverlay.mockRejectedValue(new Error('disk full'));
+
+    renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_SLOW }));
+
+    await waitFor(() => expect(reportErrorMock).toHaveBeenCalledTimes(1));
+    expect((reportErrorMock.mock.calls[0][0] as Error).message).toBe('disk full');
   });
 });

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -358,6 +358,8 @@ export const _renderedOverlaysForTests = renderedOverlays;
 export const _cacheRenderedOverlayForTests = cacheRenderedOverlay;
 export const _getRenderedOverlayForTests = getRenderedOverlay;
 export const _invalidateRenderedOverlayForTests = invalidateRenderedOverlay;
+export const _unsupportedRenderSignaturesForTests = unsupportedRenderSignatures;
+export const _MARKER_RENDERER_UNAVAILABLE_MESSAGE_FOR_TESTS = MARKER_RENDERER_UNAVAILABLE_MESSAGE;
 
 /**
  * Test-only: inject a fake native module. The real one loads via a literal
@@ -912,10 +914,14 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       })
       .catch((error: unknown) => {
         const message = error instanceof Error ? error.message : String(error);
-        if (
-          holdRenderSignature !== DEFAULT_HOLD_COLOR_SIGNATURE &&
-          message.includes(MARKER_RENDERER_UNAVAILABLE_MESSAGE)
-        ) {
+        // A renderer that cannot honour this config's marker overrides is a
+        // designed capability fallback (old native binary, or the overlay-only
+        // WASM core on web), not a defect: the overlay falls back to default
+        // rendering. Record the signature so we stop retrying it, but never
+        // record DEFAULT_HOLD_COLOR_SIGNATURE — that key is consulted for every
+        // render above, so poisoning it would blank the overlay on every board.
+        const isCapabilityFallback = message.includes(MARKER_RENDERER_UNAVAILABLE_MESSAGE);
+        if (isCapabilityFallback && holdRenderSignature !== DEFAULT_HOLD_COLOR_SIGNATURE) {
           unsupportedRenderSignatures.add(holdRenderSignature);
         }
         // Native render failed -- overlay stays null, backgrounds still show.
@@ -924,6 +930,10 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
         // overlay layer.
         // eslint-disable-next-line no-console
         console.warn(`[useNativeClimbRender] render failed for ${currentCacheKey}:`, message);
+        // Don't page on the capability fallback — it re-fires once per climb
+        // whenever the signature stays default (issue #4240: 29 Sentry events
+        // in 60s from one session).
+        if (isCapabilityFallback) return;
         reportError(error, {
           tags: {
             feature: 'mobile_board_renderer',

--- a/packages/mobile/src/lib/__tests__/board-renderer.web.test.ts
+++ b/packages/mobile/src/lib/__tests__/board-renderer.web.test.ts
@@ -57,10 +57,54 @@ describe('web board renderer', () => {
   it('rejects marker overrides that the committed WASM cannot render', async () => {
     await expect(
       renderHoldsOverlay(
-        JSON.stringify({ stroke_width_multiplier: 1.5, hold_state_map: {}, holds: [], frames: '' }),
-        'marker-key',
+        JSON.stringify({ shape_size_multiplier: 1.5, hold_state_map: {}, holds: [], frames: '' }),
+        'marker-size-key',
       ),
     ).rejects.toThrow(MARKER_RENDERER_UNAVAILABLE_MESSAGE);
+
+    await expect(
+      renderHoldsOverlay(
+        JSON.stringify({
+          hold_state_map: { 2: { color: '#4455FF', shape: 'triangle-up' } },
+          holds: [],
+          frames: '',
+        }),
+        'marker-shape-key',
+      ),
+    ).rejects.toThrow(MARKER_RENDERER_UNAVAILABLE_MESSAGE);
+  });
+
+  // Issue #4240: Grasshopper's board-level stroke default (1.35, with zero user
+  // overrides) used to trip the guard, leaving the overlay permanently blank on
+  // Expo web. Native never gated on it (#2202) — web must not either.
+  it('renders a board-default stroke multiplier instead of refusing it', () => {
+    expect(
+      _webRendererForTests.configRequiresModernRenderer(
+        JSON.stringify({
+          stroke_width_multiplier: 1.35,
+          shape_size_multiplier: 1,
+          hold_state_map: { 2: { color: '#4455FF' } },
+          holds: [],
+          frames: '',
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('still requires the modern renderer for shape size and non-circle hold shapes', () => {
+    expect(_webRendererForTests.configRequiresModernRenderer(JSON.stringify({ shape_size_multiplier: 1.5 }))).toBe(
+      true,
+    );
+    expect(
+      _webRendererForTests.configRequiresModernRenderer(
+        JSON.stringify({ hold_state_map: { 2: { color: '#4455FF', shape: 'square' } } }),
+      ),
+    ).toBe(true);
+    expect(
+      _webRendererForTests.configRequiresModernRenderer(
+        JSON.stringify({ hold_state_map: { 2: { color: '#4455FF', shape: 'circle' } } }),
+      ),
+    ).toBe(false);
   });
 
   it('revokes every owned object URL during cleanup', () => {

--- a/packages/mobile/src/lib/__tests__/overlay-cache.web.test.ts
+++ b/packages/mobile/src/lib/__tests__/overlay-cache.web.test.ts
@@ -281,7 +281,9 @@ describe('renderHoldsOverlay Cache-API integration', () => {
     installCaches();
     installFakeWorker();
     await expect(
-      renderHoldsOverlay(JSON.stringify({ stroke_width_multiplier: 1.5, hold_state_map: {} }), 'marker'),
+      // shape_size_multiplier, not stroke_width_multiplier — the latter is
+      // tolerated by the committed WASM and must render (issue #4240).
+      renderHoldsOverlay(JSON.stringify({ shape_size_multiplier: 1.5, hold_state_map: {} }), 'marker'),
     ).rejects.toThrow(MARKER_RENDERER_UNAVAILABLE_MESSAGE);
   });
 


### PR DESCRIPTION
## Summary

Grasshopper climbs never drew a holds overlay on the Expo browser app. The web
renderer fork refused any config carrying a non-default `stroke_width_multiplier`,
and Grasshopper sets a board-level default of `1.35` with zero user overrides
(`packages/board-constants/src/hold-states.ts`), so every Grasshopper climb threw
`MARKER_RENDERER_UNAVAILABLE_MESSAGE` and the overlay stayed blank.

Native deliberately does **not** gate on that field — see the comment in
`modules/board-renderer/src/index.ts` citing #2202. The committed `RenderConfig`
has 8 fields and no `deny_unknown_fields` (`packages/board-renderer/core/src/types.rs`),
so serde drops the unrecognised key and the overlay renders at the renderer's
built-in default thickness. Web now matches native.

`shape_size_multiplier` and per-hold non-circle `shape` stay gated: those two
really would produce silently-wrong geometry on this WASM artifact.

Second half of the fix: the hook no longer sends this capability fallback to
Sentry. When the render signature is the default one, the hook never records it
as unsupported — and must not, since that key gates every render on every board —
so `reportError` re-fired once per climb: **29 events in 60 seconds** from a single
browser session. It still logs a console warning, and unrelated render failures
still report.

Accepted trade-off, same one native made in #2202: Grasshopper outlines on Expo
web draw at 1.0 rather than 1.35, so they read slightly thin against that board's
busier photo. Slightly thin beats invisible. Regenerating the WASM artifact
(`vp run build:wasm` + `scripts/sync-mobile-board-renderer-wasm.sh`) retires the
whole guard and is filed as follow-up work, not done here.

Closes #4240
Fixes BOARDSESH-BT (Sentry)

### OTA fingerprint neutrality

`bunx expo-updates runtimeversion:resolve`, before and after the change:

| platform | before | after |
| --- | --- | --- |
| ios | `d5e0a9feb2f6b4b83b2c01fddcdb4ac66af86f1e` | `d5e0a9feb2f6b4b83b2c01fddcdb4ac66af86f1e` |
| android | `182a679e6174e2eadc3bb3b69816e7da532d2083` | `182a679e6174e2eadc3bb3b69816e7da532d2083` |

Unchanged on both. The edit lands in `modules/board-renderer/src/*.ts`; the only
fingerprint source under that module is the `modules/board-renderer/ios`
directory, which this PR does not touch. Store binaries stay OTA-compatible.

## Release Notes

- Grasshopper climbs now light up on the browser app instead of showing a blank board. Outlines draw at the standard thickness for now.

## Test plan

Foreground, in `wt-bb20-4240`:

- `vp run typecheck:mobile` — pass
- `vp test run --project mobile` (full mobile suite) — 5303 passed; the two
  pre-existing failures in `src/lib/i18n/__tests__/screenshot-locale.test.ts`
  reproduce on a clean checkout of this branch's base and are unrelated
- Targeted re-run after fixes: `board-renderer.web.test.ts`,
  `overlay-cache.web.test.ts`, `use-native-climb-render.test.ts`,
  `use-native-climb-render-race.test.tsx`, `board-renderer-shim.test.ts` — all pass
- `vp check` scoped to the five changed files — pass (repo-wide `vp check` exceeds
  a 10-minute budget on this machine and its diagnostics are in
  `packages/shared/offline-sync`, untouched here)
- `vp run check:mobile-web-bundle` — pass (Expo web export contains shell + WASM assets)
- `vp run check:mobile-bundle` — pass (ios + android Metro bundles)

Tests added/changed:

- `board-renderer.web.test.ts`: the exact Grasshopper config from the Sentry
  payload (`stroke_width_multiplier: 1.35`, everything else default) no longer
  requires the modern renderer; `shape_size_multiplier` and non-circle shapes
  still do, in both directions. The old "rejects marker overrides" case is
  repointed from stroke width to shape size and gains a hold-shape case.
- `overlay-cache.web.test.ts`: same repoint for its pre-cache throw assertion.
- `use-native-climb-render-race.test.tsx`: a `MARKER_RENDERER_UNAVAILABLE_MESSAGE`
  rejection does not call `reportError` and does not add the default signature to
  the unsupported set; an unrelated rejection (`disk full`) still reports.
- `board-renderer-shim.test.ts` unchanged — it pins native's #2202 behaviour and
  is the reference this aligns to. Still green.

Manual QA plan (not run — no dev server started): `.boardsesh/qa-notes.md`.
