### PR TITLE
fix(backend): guard the playlist recommendation fan-out against DSM exhaustion

### DIFF
--- a/packages/backend/src/__tests__/playlist-serial-plan.test.ts
+++ b/packages/backend/src/__tests__/playlist-serial-plan.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Regression net for the playlist recommendation fan-out and the Postgres DSM
+ * guard (#4235, Sentry BOARDSESH-AK).
+ *
+ * A library-page load fired up to nine concurrent aggregates over
+ * `board_climbs` x `board_climb_stats` — the counts CTE, board-target
+ * resolution, and one count per recommendation type — none of them guarded. A
+ * burst of those parallel hash joins exhausts Postgres's dynamic shared memory
+ * on our small /dev/shm and the request fails with pgCode 53100.
+ *
+ * The fix is two-part and both parts need pinning: every entry point issues
+ * `SET LOCAL max_parallel_workers_per_gather = 0` before its first SELECT, and
+ * the whole fan-out shares ONE transaction (one connection, one guard) instead
+ * of opening one per query. The executor parameter is what threads the handle
+ * down, so the "passing an executor opens nothing new" cases matter as much as
+ * the guard ones — re-wrapping an open transaction in `withSerialPlan` would
+ * open a savepoint.
+ *
+ * These live in the backend suite because `packages/db` runs on node's test
+ * runner and is not wired into CI, same reasoning as serial-plan-guard.test.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import type { BoardTarget, SerialPlanDb } from '@boardsesh/db/queries';
+import { resolveRecommendationBoardTarget } from '../graphql/resolvers/playlists/helpers/recommendation-board-target';
+import {
+  selectRecommendationClimbRefs,
+  countRecommendationClimbRefs,
+} from '../graphql/resolvers/playlists/helpers/recommendation-refs';
+import { playlistQueries } from '../graphql/resolvers/playlists/queries';
+
+const GUARD_PATTERN = /SET LOCAL max_parallel_workers_per_gather\s*=\s*0/i;
+
+const { fakeDb, fakeTx, state } = vi.hoisted(() => {
+  const state = {
+    /** Rendered SQL of every statement, in order. Assigned a real renderer below. */
+    render: (_statement: unknown): string => '',
+    executed: [] as string[],
+    /** Which handle each execute ran on: 'db' (top-level) or 'tx' (transaction). */
+    executeHandles: [] as string[],
+    transactions: 0,
+    rowsFor: (_renderedSql: string): unknown[] => [],
+    selectQueue: [] as unknown[][],
+    selectHandles: [] as string[],
+  };
+
+  const makeSelectBuilder = (handle: string) => {
+    const builder: Record<string, unknown> = {};
+    for (const method of ['from', 'innerJoin', 'leftJoin', 'where', 'groupBy', 'having', 'orderBy', 'limit', 'as']) {
+      builder[method] = () => builder;
+    }
+    // Deliberate: drizzle's query builder is awaitable, so the fake has to be a
+    // real thenable for `await tx.select()...` to resolve like a genuine query.
+    // oxlint-disable-next-line no-thenable
+    builder.then = (
+      onFulfilled?: ((value: unknown) => unknown) | null,
+      onRejected?: ((reason: unknown) => unknown) | null,
+    ) => {
+      state.selectHandles.push(handle);
+      return Promise.resolve(state.selectQueue.shift() ?? []).then(onFulfilled, onRejected);
+    };
+    return builder;
+  };
+
+  const makeExecute = (handle: string) => (statement: unknown) => {
+    const rendered = state.render(statement);
+    state.executed.push(rendered);
+    state.executeHandles.push(handle);
+    if (GUARD_PATTERN.test(rendered)) return Promise.resolve([]);
+    return Promise.resolve(state.rowsFor(rendered));
+  };
+
+  const fakeTx = {
+    execute: makeExecute('tx'),
+    select: () => makeSelectBuilder('tx'),
+    selectDistinct: () => makeSelectBuilder('tx'),
+  };
+
+  const fakeDb = {
+    execute: makeExecute('db'),
+    select: () => makeSelectBuilder('db'),
+    selectDistinct: () => makeSelectBuilder('db'),
+    transaction: (callback: (transactionDb: typeof fakeTx) => unknown) => {
+      state.transactions += 1;
+      return callback(fakeTx);
+    },
+  };
+
+  return { fakeDb, fakeTx, state };
+});
+
+vi.mock('../db/client', () => ({ db: fakeDb, dbRead: fakeDb }));
+
+const dialect = new PgDialect();
+state.render = (statement: unknown) => dialect.sqlToQuery(statement as SQL).sql;
+
+const KILTER_TARGET: BoardTarget = { boardType: 'kilter', layoutId: 8, sizeId: 25, angle: 40, setIds: null };
+
+/** A registered Kilter board, in the row shape resolveRegisteredTarget selects. */
+const REGISTERED_BOARD_ROW = { boardType: 'kilter', layoutId: 8, sizeId: 25, setIds: null, angle: 40 };
+
+function guardCount(): number {
+  return state.executed.filter((statement) => GUARD_PATTERN.test(statement)).length;
+}
+
+function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext {
+  return {
+    connectionId: 'conn-1',
+    isAuthenticated: true,
+    userId: 'user-123',
+    sessionId: null,
+    boardPath: null,
+    controllerId: null,
+    controllerApiKey: null,
+    ...overrides,
+  } as ConnectionContext;
+}
+
+beforeEach(() => {
+  state.executed.length = 0;
+  state.executeHandles.length = 0;
+  state.selectHandles.length = 0;
+  state.selectQueue.length = 0;
+  state.transactions = 0;
+  state.rowsFor = () => [];
+});
+
+describe('countRecommendationClimbRefs', () => {
+  it('opens one guarded transaction and runs the count inside it', async () => {
+    state.rowsFor = () => [{ count: 12 }];
+
+    const count = await countRecommendationClimbRefs('RECOMMENDED_CROWD_FAVORITES', KILTER_TARGET, 'user-123');
+
+    expect(count).toBe(12);
+    expect(state.transactions).toBe(1);
+    expect(state.executed[0]).toMatch(GUARD_PATTERN);
+    expect(state.executed).toHaveLength(2);
+    // Nothing ran on the top-level handle: SET LOCAL only covers its own transaction.
+    expect(state.executeHandles).toEqual(['tx', 'tx']);
+  });
+
+  it('runs on a supplied executor without opening a transaction or re-issuing the guard', async () => {
+    state.rowsFor = () => [{ count: 4 }];
+
+    const count = await countRecommendationClimbRefs(
+      'RECOMMENDED_CROWD_FAVORITES',
+      KILTER_TARGET,
+      'user-123',
+      fakeTx as unknown as SerialPlanDb,
+    );
+
+    expect(count).toBe(4);
+    expect(state.transactions).toBe(0);
+    expect(guardCount()).toBe(0);
+    expect(state.executed).toHaveLength(1);
+  });
+});
+
+describe('selectRecommendationClimbRefs', () => {
+  it('covers the AT_LEVEL grade-band query and the ranked page with one guard', async () => {
+    // The newest BOARDSESH-AK event failed inside buildRecommendationRefsSql,
+    // reached through this path — the grade band runs first, so both have to
+    // sit inside the same guarded transaction.
+    state.rowsFor = (renderedSql) =>
+      /max_difficulty/.test(renderedSql)
+        ? [{ board_type: 'kilter', max_difficulty: 20 }]
+        : [{ climb_uuid: 'climb-1', board_type: 'kilter' }];
+
+    const refs = await selectRecommendationClimbRefs('RECOMMENDED_AT_LEVEL', KILTER_TARGET, 'user-123', 0, 20);
+
+    expect(refs).toEqual([{ climbUuid: 'climb-1', boardType: 'kilter' }]);
+    expect(state.transactions).toBe(1);
+    expect(guardCount()).toBe(1);
+    expect(state.executed[0]).toMatch(GUARD_PATTERN);
+    expect(state.executed[1]).toMatch(/max_difficulty/);
+    expect(state.executeHandles.every((handle) => handle === 'tx')).toBe(true);
+  });
+
+  it('runs on a supplied executor without opening a transaction or re-issuing the guard', async () => {
+    state.rowsFor = () => [{ climb_uuid: 'climb-1', board_type: 'kilter' }];
+
+    const refs = await selectRecommendationClimbRefs(
+      'RECOMMENDED_CROWD_FAVORITES',
+      KILTER_TARGET,
+      'user-123',
+      0,
+      20,
+      fakeTx as unknown as SerialPlanDb,
+    );
+
+    expect(refs).toHaveLength(1);
+    expect(state.transactions).toBe(0);
+    expect(guardCount()).toBe(0);
+  });
+});
+
+describe('resolveRecommendationBoardTarget', () => {
+  it('guards the inferred-target path and keeps the angle/layout pair in one transaction', async () => {
+    // No registered board, so it infers from ticks — the boardsesh_ticks x
+    // board_climbs join for the dominant layout is the expensive one here.
+    state.rowsFor = (renderedSql) => {
+      if (/SELECT board_type FROM boardsesh_ticks/i.test(renderedSql)) return [{ board_type: 'kilter' }];
+      if (/SELECT angle FROM boardsesh_ticks/i.test(renderedSql)) return [{ angle: 45 }];
+      if (/layout_id/i.test(renderedSql)) return [{ layout_id: 8 }];
+      return [];
+    };
+
+    const target = await resolveRecommendationBoardTarget('user-123');
+
+    expect(target).toMatchObject({ boardType: 'kilter', layoutId: 8, angle: 45 });
+    expect(state.transactions).toBe(1);
+    expect(guardCount()).toBe(1);
+    expect(state.executed[0]).toMatch(GUARD_PATTERN);
+    // Guard + board type + angle + layout, all on the transaction handle.
+    expect(state.executed).toHaveLength(4);
+    expect(state.executeHandles.every((handle) => handle === 'tx')).toBe(true);
+    expect(state.selectHandles).toEqual(['tx']); // the registered-board lookup
+  });
+
+  it('runs on a supplied executor without opening a transaction or re-issuing the guard', async () => {
+    state.selectQueue.push([REGISTERED_BOARD_ROW]);
+
+    const target = await resolveRecommendationBoardTarget('user-123', undefined, fakeTx as unknown as SerialPlanDb);
+
+    expect(target).toMatchObject({ boardType: 'kilter', sizeId: 25 });
+    expect(state.transactions).toBe(0);
+    expect(guardCount()).toBe(0);
+  });
+});
+
+describe('mySmartPlaylistCounts', () => {
+  it('runs the counts CTE, board resolution and every recommendation count in one guarded transaction', async () => {
+    state.selectQueue.push([REGISTERED_BOARD_ROW]);
+    state.rowsFor = (renderedSql) => {
+      if (/WITH base/i.test(renderedSql)) return [{ type: 'FIVE_STARS', count: 7 }];
+      if (/max_difficulty/.test(renderedSql)) return [{ board_type: 'kilter', max_difficulty: 20 }];
+      return [{ count: 3 }];
+    };
+
+    const counts = await playlistQueries.mySmartPlaylistCounts(null, undefined, makeCtx());
+
+    expect(counts).toContainEqual({ type: 'FIVE_STARS', count: 7 });
+    expect(counts.filter((entry) => entry.type.startsWith('RECOMMENDED_'))).toHaveLength(4);
+
+    // One transaction and one guard for the whole fan-out — the point of the
+    // fix. Before it, this was up to nine unguarded concurrent queries.
+    expect(state.transactions).toBe(1);
+    expect(guardCount()).toBe(1);
+    expect(state.executed[0]).toMatch(GUARD_PATTERN);
+    expect(state.executed[1]).toMatch(/WITH base/i);
+    expect(state.executeHandles.every((handle) => handle === 'tx')).toBe(true);
+    expect(state.selectHandles.every((handle) => handle === 'tx')).toBe(true);
+  });
+});
+
+describe('smartPlaylist on a recommendation type', () => {
+  it('resolves the target, the page and the total in one guarded transaction', async () => {
+    state.selectQueue.push([REGISTERED_BOARD_ROW]); // registered-board lookup (tx)
+    state.selectQueue.push([]); // fetchUserMeta (top-level db, after the tx)
+    state.rowsFor = (renderedSql) =>
+      /SELECT COUNT\(\*\)/i.test(renderedSql) ? [{ count: 9 }] : [{ climb_uuid: 'climb-1', board_type: 'kilter' }];
+
+    const result = await playlistQueries.smartPlaylist(
+      null,
+      { input: { type: 'RECOMMENDED_CROWD_FAVORITES', userId: 'user-123', page: 0, pageSize: 20 } },
+      makeCtx(),
+    );
+
+    expect(result.totalCount).toBe(9);
+    expect(state.transactions).toBe(1);
+    expect(guardCount()).toBe(1);
+    expect(state.executed[0]).toMatch(GUARD_PATTERN);
+    // Guard + ranked page + count. fetchUserMeta and the hydrator stay outside
+    // the transaction on purpose (PK / IN-list lookups), so the connection is
+    // held for the catalog queries only.
+    expect(state.executed).toHaveLength(3);
+    // Registered-board lookup inside the transaction; fetchUserMeta and the
+    // hydrator after it, on the top-level handle.
+    expect(state.selectHandles).toEqual(['tx', 'db', 'db']);
+  });
+
+  it('still short-circuits for a non-owner without opening a transaction', async () => {
+    const result = await playlistQueries.smartPlaylist(
+      null,
+      { input: { type: 'RECOMMENDED_CROWD_FAVORITES', userId: 'user-123' } },
+      makeCtx({ userId: 'someone-else' }),
+    );
+
+    expect(result.totalCount).toBe(0);
+    expect(state.transactions).toBe(0);
+    expect(state.executed).toHaveLength(0);
+    expect(state.selectHandles).toHaveLength(0);
+  });
+});

--- a/packages/backend/src/__tests__/recompute-climb-stats.test.ts
+++ b/packages/backend/src/__tests__/recompute-climb-stats.test.ts
@@ -25,6 +25,14 @@ vi.mock('../db/client', () => ({
 
 import { recomputeClimbStats } from '../graphql/resolvers/ticks/recompute-climb-stats';
 
+/**
+ * The DSM guard `recomputeClimbStats` sets as the first statement of its
+ * transaction (#4235, Sentry BOARDSESH-B6). The aggregate below hash-joins
+ * `boardsesh_ticks` against `board_climb_stats`, the plan shape that exhausts
+ * Postgres's dynamic shared memory on our small /dev/shm.
+ */
+const GUARD_PATTERN = /SET LOCAL max_parallel_workers_per_gather\s*=\s*0/i;
+
 describe('recomputeClimbStats', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -50,11 +58,15 @@ describe('recomputeClimbStats', () => {
 
     await recomputeClimbStats('kilter', 'CLIMB-1', 40);
 
-    // Seed + aggregate. Asserted before indexing so a mock that never invoked
-    // the transaction callback fails as "0 statements" rather than as an
-    // undefined-index error inside sqlText.
-    expect(executed).toHaveLength(2);
-    const seedSql = sqlText(executed[0]);
+    // Guard + seed + aggregate. Asserted before indexing so a mock that never
+    // invoked the transaction callback fails as "0 statements" rather than as
+    // an undefined-index error inside sqlText.
+    expect(executed).toHaveLength(3);
+    // The guard has to come FIRST: `SET LOCAL` only covers statements that run
+    // after it in the same transaction, so a seed or aggregate ahead of it
+    // would still plan a parallel hash join (#4235).
+    expect(sqlText(executed[0])).toMatch(GUARD_PATTERN);
+    const seedSql = sqlText(executed[1]);
     expect(seedSql).toContain('INSERT INTO board_climb_stats');
     expect(seedSql).toMatch(/SELECT[\s\S]*FROM board_climbs bc/);
     expect(seedSql).toMatch(/WHERE bc\.uuid =/);
@@ -65,12 +77,12 @@ describe('recomputeClimbStats', () => {
     expect(seedSql).toContain('quality_normalized');
   });
 
-  it('runs the seed + recompute SQL inside a single transaction', async () => {
-    let executeCount = 0;
+  it('runs the guard, seed and recompute SQL inside one transaction', async () => {
+    const executed: unknown[] = [];
     mockDb.transaction.mockImplementation(async (callback: (tx: unknown) => Promise<void>) => {
       const tx = {
-        execute: vi.fn(async () => {
-          executeCount += 1;
+        execute: vi.fn(async (query: unknown) => {
+          executed.push(query);
           return [];
         }),
       };
@@ -79,9 +91,14 @@ describe('recomputeClimbStats', () => {
 
     await recomputeClimbStats('kilter', 'CLIMB-1', 40);
 
+    // One transaction, and only one — the guard rides the transaction this
+    // path already opens rather than nesting a savepoint through
+    // `withSerialPlan` just to run a `SET LOCAL` (#4235).
     expect(mockDb.transaction).toHaveBeenCalledTimes(1);
-    // Seed + the aggregate recompute.
-    expect(executeCount).toBe(2);
+    // The DSM guard, the seed, then the aggregate recompute.
+    expect(executed).toHaveLength(3);
+    expect(sqlText(executed[0])).toMatch(GUARD_PATTERN);
+    expect(executed.filter((statement) => GUARD_PATTERN.test(sqlText(statement)))).toHaveLength(1);
   });
 
   // FRAGILE TEST WARNING — read before changing:

--- a/packages/backend/src/__tests__/smart-playlists.test.ts
+++ b/packages/backend/src/__tests__/smart-playlists.test.ts
@@ -522,9 +522,35 @@ describe('smartPlaylist resolver', () => {
 
     expect(result.climbs).toHaveLength(20);
     expect(result.hasMore).toBe(false);
-    expect(selectRefsMock).toHaveBeenCalledWith('RECOMMENDED_CROWD_FAVORITES', expect.anything(), 'user-123', 25, 20);
+    // Trailing expect.anything() is the executor the resolver threads down (#4235).
+    expect(selectRefsMock).toHaveBeenCalledWith(
+      'RECOMMENDED_CROWD_FAVORITES',
+      expect.anything(),
+      'user-123',
+      25,
+      20,
+      expect.anything(),
+    );
   });
 });
+
+/**
+ * Queue the counts-CTE result.
+ *
+ * `mySmartPlaylistCounts` runs inside `withSerialPlan` (#4235). `mockDb` has no
+ * `transaction`, so the helper takes its execute-only fallback and the FIRST
+ * `execute` is the `SET LOCAL max_parallel_workers_per_gather = 0` guard — the
+ * CTE result has to be queued behind it or the guard eats it.
+ */
+function queueCountsRows(rows: unknown) {
+  mockDb.execute.mockResolvedValueOnce([]); // SET LOCAL guard
+  mockDb.execute.mockResolvedValueOnce(rows);
+}
+
+/** The SQL the resolver actually ran, i.e. the call after the guard. */
+function countsSqlArg() {
+  return mockDb.execute.mock.calls[1][0] as { queryChunks?: unknown[] } | undefined;
+}
 
 describe('mySmartPlaylistCounts resolver', () => {
   beforeEach(() => {
@@ -541,10 +567,9 @@ describe('mySmartPlaylistCounts resolver', () => {
   it('returns one entry per smart-playlist type from a single CTE roundtrip', async () => {
     const ctx = makeCtx();
 
-    // Single db.execute call returns three rows. Order returned from the
-    // resolver is fixed (FIVE_STARS, MOST_REPEATED, PROJECTS) regardless of
-    // SQL row order.
-    mockDb.execute.mockResolvedValueOnce([
+    // One CTE roundtrip returns three rows. Order returned from the resolver is
+    // fixed (FIVE_STARS, MOST_REPEATED, PROJECTS) regardless of SQL row order.
+    queueCountsRows([
       { type: 'PROJECTS', count: 5 },
       { type: 'FIVE_STARS', count: 7 },
       { type: 'MOST_REPEATED', count: 3 },
@@ -557,13 +582,14 @@ describe('mySmartPlaylistCounts resolver', () => {
       { type: 'PROJECTS', count: 5 },
       { type: 'LIKED_CLIMBS', count: 0 },
     ]);
-    expect(mockDb.execute).toHaveBeenCalledTimes(1);
+    // The guard plus the CTE — still one roundtrip for all four counts.
+    expect(mockDb.execute).toHaveBeenCalledTimes(2);
   });
 
   it('handles the {rows: ...} shape some postgres clients return', async () => {
     const ctx = makeCtx();
 
-    mockDb.execute.mockResolvedValueOnce({
+    queueCountsRows({
       rows: [
         { type: 'FIVE_STARS', count: 1 },
         { type: 'MOST_REPEATED', count: 2 },
@@ -583,7 +609,7 @@ describe('mySmartPlaylistCounts resolver', () => {
   it('returns 0 for any type missing from the CTE result', async () => {
     const ctx = makeCtx();
 
-    mockDb.execute.mockResolvedValueOnce([{ type: 'FIVE_STARS', count: 9 }]);
+    queueCountsRows([{ type: 'FIVE_STARS', count: 9 }]);
 
     const result = await playlistQueries.mySmartPlaylistCounts(null, undefined, ctx);
     expect(result).toEqual([
@@ -597,7 +623,7 @@ describe('mySmartPlaylistCounts resolver', () => {
   it('surfaces a non-zero LIKED_CLIMBS count from the CTE', async () => {
     const ctx = makeCtx();
 
-    mockDb.execute.mockResolvedValueOnce([
+    queueCountsRows([
       { type: 'FIVE_STARS', count: 7 },
       { type: 'MOST_REPEATED', count: 3 },
       { type: 'PROJECTS', count: 5 },
@@ -614,13 +640,12 @@ describe('mySmartPlaylistCounts resolver', () => {
     // the CTE is what enforces this, so this test asserts on the SQL string
     // rather than on db result rows.
     const ctx = makeCtx();
-    mockDb.execute.mockResolvedValueOnce([]);
+    queueCountsRows([]);
 
     await playlistQueries.mySmartPlaylistCounts(null, undefined, ctx);
 
-    expect(mockDb.execute).toHaveBeenCalledTimes(1);
-    const sqlArg = mockDb.execute.mock.calls[0][0] as { queryChunks?: unknown[] } | undefined;
-    const rendered = (sqlArg?.queryChunks ?? [])
+    expect(mockDb.execute).toHaveBeenCalledTimes(2);
+    const rendered = (countsSqlArg()?.queryChunks ?? [])
       .map((chunk) => (typeof chunk === 'string' ? chunk : ((chunk as { value?: string }).value ?? '')))
       .join(' ');
 
@@ -634,7 +659,7 @@ describe('mySmartPlaylistCounts resolver', () => {
 
   it('appends RECOMMENDED_* counts when a board resolves', async () => {
     const ctx = makeCtx();
-    mockDb.execute.mockResolvedValueOnce([{ type: 'FIVE_STARS', count: 1 }]);
+    queueCountsRows([{ type: 'FIVE_STARS', count: 1 }]);
     resolveTargetMock.mockResolvedValueOnce({ boardType: 'kilter', layoutId: 8, sizeId: 25, angle: 40, setIds: null });
     countRefsMock.mockResolvedValue(7);
 
@@ -648,7 +673,7 @@ describe('mySmartPlaylistCounts resolver', () => {
 
   it('omits RECOMMENDED_* counts when no board resolves', async () => {
     const ctx = makeCtx();
-    mockDb.execute.mockResolvedValueOnce([{ type: 'FIVE_STARS', count: 1 }]);
+    queueCountsRows([{ type: 'FIVE_STARS', count: 1 }]);
     resolveTargetMock.mockResolvedValueOnce(null);
 
     const result = await playlistQueries.mySmartPlaylistCounts(null, undefined, ctx);

--- a/packages/backend/src/graphql/resolvers/playlists/helpers/recommendation-board-target.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/helpers/recommendation-board-target.ts
@@ -6,7 +6,7 @@ import {
   getSetsForLayoutAndSize,
 } from '@boardsesh/board-constants/product-sizes';
 import type { BoardName } from '@boardsesh/shared-schema';
-import { rowsOf, type BoardTarget } from '@boardsesh/db/queries';
+import { rowsOf, withSerialPlan, type BoardTarget, type SerialPlanDb } from '@boardsesh/db/queries';
 import { db } from '../../../../db/client';
 
 /** Recommendations target Kilter & Tension boards (MoonBoard is single-size;
@@ -32,8 +32,8 @@ function sizeRank(boardType: string, sizeId: number): number {
 }
 
 /** The user's biggest registered Kilter/Tension board, or null. Precise. */
-async function resolveRegisteredTarget(userId: string): Promise<BoardTarget | null> {
-  const boards = await db
+async function resolveRegisteredTarget(userId: string, executor: SerialPlanDb): Promise<BoardTarget | null> {
+  const boards = await executor
     .select({
       boardType: dbSchema.userBoards.boardType,
       layoutId: dbSchema.userBoards.layoutId,
@@ -73,11 +73,11 @@ async function resolveRegisteredTarget(userId: string): Promise<BoardTarget | nu
  * their send history, the dominant layout of the climbs they've ticked, and that
  * layout's canonical default size/sets. Approximate — registered boards win.
  */
-async function resolveInferredTarget(userId: string): Promise<BoardTarget | null> {
+async function resolveInferredTarget(userId: string, executor: SerialPlanDb): Promise<BoardTarget | null> {
   // Deterministic tie-breakers (board_type / angle / layout_id ASC) so identical
   // activity always resolves to the same inferred board across requests.
   const boardRows = rowsOf<{ board_type: string }>(
-    await db.execute(sql`
+    await executor.execute(sql`
       SELECT board_type FROM boardsesh_ticks
       WHERE user_id = ${userId} AND status IN ('flash', 'send') AND board_type IN ('kilter', 'tension')
       GROUP BY board_type ORDER BY COUNT(*) DESC, board_type ASC LIMIT 1
@@ -88,12 +88,12 @@ async function resolveInferredTarget(userId: string): Promise<BoardTarget | null
 
   // Angle and dominant layout are independent given the board type — run together.
   const [angleRows, layoutRows] = await Promise.all([
-    db.execute(sql`
+    executor.execute(sql`
       SELECT angle FROM boardsesh_ticks
       WHERE user_id = ${userId} AND status IN ('flash', 'send') AND board_type = ${boardType}
       GROUP BY angle ORDER BY COUNT(*) DESC, angle ASC LIMIT 1
     `),
-    db.execute(sql`
+    executor.execute(sql`
       SELECT bc.layout_id FROM boardsesh_ticks t
       JOIN board_climbs bc ON bc.board_type = t.board_type AND bc.uuid = t.climb_uuid
       WHERE t.user_id = ${userId} AND t.board_type = ${boardType}
@@ -113,8 +113,12 @@ async function resolveInferredTarget(userId: string): Promise<BoardTarget | null
 
 /** A specific board the user owns (uuid), validated against ownership. Null if
  * it isn't theirs, is deleted, or isn't a recommendable board type. */
-async function resolveOwnedBoardByUuid(userId: string, boardUuid: string): Promise<BoardTarget | null> {
-  const [board] = await db
+async function resolveOwnedBoardByUuid(
+  userId: string,
+  boardUuid: string,
+  executor: SerialPlanDb,
+): Promise<BoardTarget | null> {
+  const [board] = await executor
     .select({
       boardType: dbSchema.userBoards.boardType,
       layoutId: dbSchema.userBoards.layoutId,
@@ -162,16 +166,30 @@ export type BoardTargetOverride = {
 export async function resolveRecommendationBoardTarget(
   userId: string,
   override?: BoardTargetOverride,
+  /**
+   * An already-guarded transaction to run on. Callers that resolve a target and
+   * then immediately count or rank recommendations pass their handle down so the
+   * whole fan-out shares one connection with per-gather parallelism off (#4235).
+   * Omit it and this opens its own guarded transaction.
+   */
+  executor?: SerialPlanDb,
 ): Promise<BoardTarget | null> {
-  const base =
-    (override?.boardUuid ? await resolveOwnedBoardByUuid(userId, override.boardUuid) : null) ??
-    (await resolveRegisteredTarget(userId)) ??
-    (await resolveInferredTarget(userId));
-  if (!base) return null;
+  const resolve = async (tx: SerialPlanDb): Promise<BoardTarget | null> => {
+    const base =
+      (override?.boardUuid ? await resolveOwnedBoardByUuid(userId, override.boardUuid, tx) : null) ??
+      (await resolveRegisteredTarget(userId, tx)) ??
+      (await resolveInferredTarget(userId, tx));
+    if (!base) return null;
 
-  return {
-    ...base,
-    sizeId: override?.sizeId ?? base.sizeId,
-    angle: override?.angle ?? base.angle,
+    return {
+      ...base,
+      sizeId: override?.sizeId ?? base.sizeId,
+      angle: override?.angle ?? base.angle,
+    };
   };
+
+  // The inferred-target path joins boardsesh_ticks against board_climbs for the
+  // dominant layout — the hash join that exhausts /dev/shm (#4235). Never hand an
+  // open transaction to withSerialPlan: it would open a savepoint just to set a GUC.
+  return executor ? resolve(executor) : withSerialPlan(db, resolve);
 }

--- a/packages/backend/src/graphql/resolvers/playlists/helpers/recommendation-refs.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/helpers/recommendation-refs.ts
@@ -6,9 +6,11 @@ import {
   buildUserSendGradesByBoardSql,
   computeUserMaxVGrade,
   rowsOf,
+  withSerialPlan,
   type BoardTarget,
   type RecommendationType,
   type RecommendationQueryParams,
+  type SerialPlanDb,
 } from '@boardsesh/db/queries';
 import type { BoardName } from '@boardsesh/shared-schema';
 import { db } from '../../../../db/client';
@@ -21,9 +23,12 @@ const GRADES_BELOW = 3;
 const GRADES_ABOVE = 1;
 
 /** The user's [max-3, max+1] V-band as target-board difficulty ids, or null. */
-async function resolveGradeBand(userId: string): Promise<{ minDifficultyId: number; maxDifficultyId: number } | null> {
+async function resolveGradeBand(
+  userId: string,
+  executor: SerialPlanDb,
+): Promise<{ minDifficultyId: number; maxDifficultyId: number } | null> {
   const rows = rowsOf<{ board_type: string; max_difficulty: number | null }>(
-    await db.execute(buildUserSendGradesByBoardSql(userId)),
+    await executor.execute(buildUserSendGradesByBoardSql(userId)),
   );
   const maxV = computeUserMaxVGrade(rows);
   if (maxV === null) return null;
@@ -40,13 +45,14 @@ async function buildParams(
   type: RecommendationType,
   target: BoardTarget,
   excludeUserId: string | null,
+  executor: SerialPlanDb,
 ): Promise<RecommendationQueryParams | null> {
   const tiers = getSizeFullnessTiers(target.boardType as BoardName, target.sizeId);
 
   let gradeBand: { minDifficultyId: number; maxDifficultyId: number } | null = null;
   if (type === 'RECOMMENDED_AT_LEVEL') {
     if (!excludeUserId) return null; // no user => no level to target
-    gradeBand = await resolveGradeBand(excludeUserId);
+    gradeBand = await resolveGradeBand(excludeUserId, executor);
     if (!gradeBand) return null;
   }
 
@@ -61,28 +67,48 @@ async function buildParams(
   };
 }
 
+/**
+ * Run `body` with per-gather parallelism disabled (#4235).
+ *
+ * The recommendation SQL hash-joins `board_climbs` against `board_climb_stats`,
+ * `board_setter_stats` and `board_climb_send_stats` — the plan shape that
+ * exhausts Postgres's dynamic shared memory on our small /dev/shm (pgCode 53100,
+ * Sentry BOARDSESH-AK). When the caller already owns a guarded transaction it
+ * passes its handle in and we run on that; re-wrapping it would open a savepoint
+ * and re-issue the GUC for nothing.
+ */
+function onGuardedExecutor<T>(executor: SerialPlanDb | undefined, body: (tx: SerialPlanDb) => Promise<T>): Promise<T> {
+  return executor ? body(executor) : withSerialPlan(db, body);
+}
+
 export async function selectRecommendationClimbRefs(
   type: RecommendationType,
   target: BoardTarget,
   excludeUserId: string | null,
   page: number,
   pageSize: number,
+  executor?: SerialPlanDb,
 ): Promise<ClimbRef[]> {
-  const params = await buildParams(type, target, excludeUserId);
-  if (!params) return [];
-  const rows = rowsOf<{ climb_uuid: string; board_type: string }>(
-    await db.execute(buildRecommendationRefsSql(params, page, pageSize)),
-  );
-  return rows.map((row) => ({ climbUuid: row.climb_uuid, boardType: row.board_type }));
+  return onGuardedExecutor(executor, async (tx) => {
+    const params = await buildParams(type, target, excludeUserId, tx);
+    if (!params) return [];
+    const rows = rowsOf<{ climb_uuid: string; board_type: string }>(
+      await tx.execute(buildRecommendationRefsSql(params, page, pageSize)),
+    );
+    return rows.map((row) => ({ climbUuid: row.climb_uuid, boardType: row.board_type }));
+  });
 }
 
 export async function countRecommendationClimbRefs(
   type: RecommendationType,
   target: BoardTarget,
   excludeUserId: string | null,
+  executor?: SerialPlanDb,
 ): Promise<number> {
-  const params = await buildParams(type, target, excludeUserId);
-  if (!params) return 0;
-  const rows = rowsOf<{ count: number }>(await db.execute(buildRecommendationCountSql(params)));
-  return Number(rows[0]?.count ?? 0);
+  return onGuardedExecutor(executor, async (tx) => {
+    const params = await buildParams(type, target, excludeUserId, tx);
+    if (!params) return 0;
+    const rows = rowsOf<{ count: number }>(await tx.execute(buildRecommendationCountSql(params)));
+    return Number(rows[0]?.count ?? 0);
+  });
 }

--- a/packages/backend/src/graphql/resolvers/playlists/queries/smart-playlists.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/smart-playlists.ts
@@ -1,6 +1,11 @@
 import { eq, and, desc, sql, inArray, max, type SQL } from 'drizzle-orm';
 import { type ConnectionContext, type Climb } from '@boardsesh/shared-schema';
-import { isRecommendationType, RECOMMENDATION_TYPES, type RecommendationType } from '@boardsesh/db/queries';
+import {
+  isRecommendationType,
+  RECOMMENDATION_TYPES,
+  withSerialPlan,
+  type RecommendationType,
+} from '@boardsesh/db/queries';
 import { db } from '../../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { applyRateLimit, requireAuthenticated, validateInput } from '../../shared/helpers';
@@ -287,21 +292,36 @@ export const smartPlaylist = async (
     if (!ctx.userId || ctx.userId !== input.userId) {
       return { meta: emptyMeta, climbs: [], totalCount: 0, hasMore: false };
     }
-    const target = await resolveRecommendationBoardTarget(input.userId, {
-      boardUuid: input.boardUuid,
-      sizeId: input.sizeId,
-      angle: input.angle,
-    });
-    if (!target) {
-      return { meta: emptyMeta, climbs: [], totalCount: 0, hasMore: false };
-    }
     const maxRecPage = Math.floor(MAX_RECOMMENDATION_OFFSET / pageSize);
     const recPage = Math.min(page, maxRecPage);
+    // Pin the narrowed type in a const: TypeScript drops the isRecommendationType
+    // narrowing of `input.type` inside the callback below.
+    const recommendationType = input.type;
+
+    // Board resolution, the ranked page and the total all hash-join
+    // board_climbs against board_climb_stats. Run them on one connection with
+    // per-gather parallelism off so a burst of these can't exhaust Postgres's
+    // dynamic shared memory (#4235, Sentry BOARDSESH-AK). fetchUserMeta and the
+    // hydrator stay outside — they're PK/IN-list lookups, and keeping them out
+    // shortens how long this holds a pooled connection.
+    const recommendation = await withSerialPlan(db, async (tx) => {
+      const target = await resolveRecommendationBoardTarget(
+        input.userId,
+        { boardUuid: input.boardUuid, sizeId: input.sizeId, angle: input.angle },
+        tx,
+      );
+      if (!target) return null;
+      const [pageRefs, totalCount] = await Promise.all([
+        selectRecommendationClimbRefs(recommendationType, target, input.userId, recPage, pageSize, tx),
+        countRecommendationClimbRefs(recommendationType, target, input.userId, tx),
+      ]);
+      return { target, pageRefs, totalCount };
+    });
+    if (!recommendation) {
+      return { meta: emptyMeta, climbs: [], totalCount: 0, hasMore: false };
+    }
+    const { target, pageRefs, totalCount } = recommendation;
     const owner = await fetchUserMeta(input.userId);
-    const [pageRefs, totalCount] = await Promise.all([
-      selectRecommendationClimbRefs(input.type, target, input.userId, recPage, pageSize),
-      countRecommendationClimbRefs(input.type, target, input.userId),
-    ]);
     // Hydrate at the board's angle, not the most-ascended angle.
     const angleOverrides = new Map<string, number>(
       pageRefs.map((ref) => [`${ref.boardType}:${ref.climbUuid}`, target.angle]),
@@ -367,88 +387,97 @@ export const mySmartPlaylistCounts = async (
   requireAuthenticated(ctx);
   const userId = ctx.userId!;
 
-  const result = await db.execute<{ type: SmartPlaylistType; count: number }>(sql`
-    WITH base AS (
-      SELECT climb_uuid, board_type, quality, attempt_count, status
-      FROM ${dbSchema.boardseshTicks}
-      WHERE user_id = ${userId}
-    ),
-    sent AS (
-      SELECT DISTINCT climb_uuid, board_type
-      FROM base
-      WHERE status IN ('flash', 'send')
-    ),
-    five_stars AS (
-      SELECT COUNT(DISTINCT (board_type, climb_uuid))::int AS count
-      FROM base
-      WHERE quality = 5
-    ),
-    most_repeated AS (
-      SELECT COUNT(*)::int AS count
-      FROM (
-        SELECT climb_uuid, board_type
+  // One transaction for the whole library-card fan-out: the counts CTE, board
+  // resolution and all four recommendation counts. Serially on one connection
+  // with per-gather parallelism off, instead of up to nine concurrent parallel
+  // hash joins that exhaust Postgres's dynamic shared memory (#4235, Sentry
+  // BOARDSESH-AK).
+  return withSerialPlan(db, async (tx) => {
+    const result = await tx.execute<{ type: SmartPlaylistType; count: number }>(sql`
+      WITH base AS (
+        SELECT climb_uuid, board_type, quality, attempt_count, status
+        FROM ${dbSchema.boardseshTicks}
+        WHERE user_id = ${userId}
+      ),
+      sent AS (
+        SELECT DISTINCT climb_uuid, board_type
         FROM base
-        GROUP BY climb_uuid, board_type
-        HAVING SUM(attempt_count) > 1
-      ) r
-    ),
-    projects AS (
-      -- Match sent on (climb_uuid, board_type) so a Kilter send doesn't
-      -- exclude a Tension climb sharing the same UUID; mirrors the
-      -- per-page paged-query semantics in selectSmartClimbRefs.
-      SELECT COUNT(DISTINCT (board_type, climb_uuid))::int AS count
-      FROM base
-      WHERE NOT EXISTS (
-        SELECT 1 FROM sent
-        WHERE sent.climb_uuid = base.climb_uuid
-          AND sent.board_type = base.board_type
+        WHERE status IN ('flash', 'send')
+      ),
+      five_stars AS (
+        SELECT COUNT(DISTINCT (board_type, climb_uuid))::int AS count
+        FROM base
+        WHERE quality = 5
+      ),
+      most_repeated AS (
+        SELECT COUNT(*)::int AS count
+        FROM (
+          SELECT climb_uuid, board_type
+          FROM base
+          GROUP BY climb_uuid, board_type
+          HAVING SUM(attempt_count) > 1
+        ) r
+      ),
+      projects AS (
+        -- Match sent on (climb_uuid, board_type) so a Kilter send doesn't
+        -- exclude a Tension climb sharing the same UUID; mirrors the
+        -- per-page paged-query semantics in selectSmartClimbRefs.
+        SELECT COUNT(DISTINCT (board_type, climb_uuid))::int AS count
+        FROM base
+        WHERE NOT EXISTS (
+          SELECT 1 FROM sent
+          WHERE sent.climb_uuid = base.climb_uuid
+            AND sent.board_type = base.board_type
+        )
+      ),
+      liked_climbs AS (
+        SELECT COUNT(DISTINCT (board_name, climb_uuid))::int AS count
+        FROM ${dbSchema.userFavorites}
+        WHERE user_id = ${userId}
       )
-    ),
-    liked_climbs AS (
-      SELECT COUNT(DISTINCT (board_name, climb_uuid))::int AS count
-      FROM ${dbSchema.userFavorites}
-      WHERE user_id = ${userId}
-    )
-    SELECT 'FIVE_STARS'::text AS type, count FROM five_stars
-    UNION ALL
-    SELECT 'MOST_REPEATED'::text, count FROM most_repeated
-    UNION ALL
-    SELECT 'PROJECTS'::text, count FROM projects
-    UNION ALL
-    SELECT 'LIKED_CLIMBS'::text, count FROM liked_climbs
-  `);
+      SELECT 'FIVE_STARS'::text AS type, count FROM five_stars
+      UNION ALL
+      SELECT 'MOST_REPEATED'::text, count FROM most_repeated
+      UNION ALL
+      SELECT 'PROJECTS'::text, count FROM projects
+      UNION ALL
+      SELECT 'LIKED_CLIMBS'::text, count FROM liked_climbs
+    `);
 
-  // db.execute returns either an iterable of rows directly or `{ rows }`
-  // depending on the underlying postgres client; normalise here.
-  const rows = (Array.isArray(result) ? result : (result as { rows?: unknown[] }).rows) as
-    | Array<{ type: SmartPlaylistType; count: number }>
-    | undefined;
-  if (!rows) return [];
+    // db.execute returns either an iterable of rows directly or `{ rows }`
+    // depending on the underlying postgres client; normalise here.
+    const rows = (Array.isArray(result) ? result : (result as { rows?: unknown[] }).rows) as
+      | Array<{ type: SmartPlaylistType; count: number }>
+      | undefined;
+    if (!rows) return [];
 
-  const byType = new Map<SmartPlaylistType, number>();
-  for (const row of rows) {
-    byType.set(row.type, Number(row.count ?? 0));
-  }
+    const byType = new Map<SmartPlaylistType, number>();
+    for (const row of rows) {
+      byType.set(row.type, Number(row.count ?? 0));
+    }
 
-  const counts: Array<{ type: SmartPlaylistType; count: number }> = [
-    { type: 'FIVE_STARS', count: byType.get('FIVE_STARS') ?? 0 },
-    { type: 'MOST_REPEATED', count: byType.get('MOST_REPEATED') ?? 0 },
-    { type: 'PROJECTS', count: byType.get('PROJECTS') ?? 0 },
-    { type: 'LIKED_CLIMBS', count: byType.get('LIKED_CLIMBS') ?? 0 },
-  ];
+    const counts: Array<{ type: SmartPlaylistType; count: number }> = [
+      { type: 'FIVE_STARS', count: byType.get('FIVE_STARS') ?? 0 },
+      { type: 'MOST_REPEATED', count: byType.get('MOST_REPEATED') ?? 0 },
+      { type: 'PROJECTS', count: byType.get('PROJECTS') ?? 0 },
+      { type: 'LIKED_CLIMBS', count: byType.get('LIKED_CLIMBS') ?? 0 },
+    ];
 
-  // Recommendation cards: scoped to the user's resolved board. Counted in
-  // parallel; all zero (cards hidden) when no board can be determined.
-  const target = await resolveRecommendationBoardTarget(userId);
-  if (target) {
-    const recCounts = await Promise.all(
-      RECOMMENDATION_TYPES.map(async (type) => ({
-        type,
-        count: await countRecommendationClimbRefs(type, target, userId),
-      })),
-    );
-    counts.push(...recCounts);
-  }
+    // Recommendation cards: scoped to the user's resolved board. All zero
+    // (cards hidden) when no board can be determined. The transaction handle
+    // goes down so the four counts share this connection and its guard rather
+    // than opening four more.
+    const target = await resolveRecommendationBoardTarget(userId, undefined, tx);
+    if (target) {
+      const recCounts = await Promise.all(
+        RECOMMENDATION_TYPES.map(async (type) => ({
+          type,
+          count: await countRecommendationClimbRefs(type, target, userId, tx),
+        })),
+      );
+      counts.push(...recCounts);
+    }
 
-  return counts;
+    return counts;
+  });
 };

--- a/packages/db/src/queries/climb-stats/recompute.ts
+++ b/packages/db/src/queries/climb-stats/recompute.ts
@@ -1,6 +1,7 @@
 import { sql } from 'drizzle-orm';
 import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
 import { rowsOf } from '../util/rows';
+import { setSerialPlan } from '../util/serial-plan';
 import { blendedQualityAverageSql } from './quality-blend';
 
 // Any drizzle-orm PgDatabase (postgres-js client, the script client, the
@@ -144,6 +145,14 @@ export async function recomputeClimbStats(
   });
 
   await db.transaction(async (tx) => {
+    // The aggregate UPDATE below hash-joins boardsesh_ticks against
+    // board_climb_stats, which is exactly the plan shape that exhausts
+    // Postgres's dynamic shared memory on our small /dev/shm (pgCode 53100 —
+    // Sentry BOARDSESH-B6, issue #4235). Set the GUC on the transaction we
+    // already own; `withSerialPlan` here would open a savepoint just to run one
+    // SET LOCAL.
+    await setSerialPlan(tx);
+
     // Defensive seed: set upstream/boardsesh counts to 0 explicitly so the
     // recompute and any later upstream sync both see a sensible baseline.
     //

--- a/packages/db/src/queries/util/serial-plan.ts
+++ b/packages/db/src/queries/util/serial-plan.ts
@@ -1,4 +1,4 @@
-import { sql } from 'drizzle-orm';
+import { sql, type SQL } from 'drizzle-orm';
 import type { DbInstance } from '../../client/postgres';
 
 /**
@@ -13,8 +13,33 @@ export type SerialPlanDb = DbInstance | TransactionDb;
 type SerialPlanTransaction = DbInstance['transaction'];
 type SerialPlanExecute = (query: unknown) => Promise<unknown>;
 
+/**
+ * Anything that can run a statement. Structural on purpose rather than
+ * `SerialPlanDb`, so a caller holding a transaction handle from a differently
+ * parameterised drizzle client (the generic `PgDatabase` in
+ * `climb-stats/recompute.ts`, for one) can pass it without a cast.
+ */
+type SerialPlanStatementRunner = { execute: (query: SQL) => Promise<unknown> };
+
 /** The statement every guarded query runs before its SELECT. Exported for tests. */
 export const SERIAL_PLAN_STATEMENT = 'SET LOCAL max_parallel_workers_per_gather = 0';
+
+/**
+ * Disable per-gather parallelism on an ALREADY-OPEN transaction.
+ *
+ * `SET LOCAL` lasts until the end of the enclosing transaction, so this is for
+ * callers that own one already:
+ * `db.transaction(async (tx) => { await setSerialPlan(tx); ... })`. Handing it a
+ * top-level client instead emits the statement outside a transaction, where
+ * Postgres discards it with a warning.
+ *
+ * Reach for `withSerialPlan` when you don't have a transaction yet. Never pass an
+ * open transaction handle to `withSerialPlan` — drizzle's `tx` exposes
+ * `.transaction`, so it would open a savepoint just to set a GUC.
+ */
+export async function setSerialPlan(db: SerialPlanStatementRunner): Promise<void> {
+  await db.execute(sql`SET LOCAL max_parallel_workers_per_gather = 0`);
+}
 
 function getTransaction(db: SerialPlanDb): SerialPlanTransaction | null {
   const candidate = db as SerialPlanDb & { transaction?: unknown };
@@ -56,7 +81,7 @@ export async function withSerialPlan<T>(db: SerialPlanDb, query: (tx: SerialPlan
   const transaction = getTransaction(db);
   if (transaction) {
     return transaction(async (transactionDb) => {
-      await transactionDb.execute(sql`SET LOCAL max_parallel_workers_per_gather = 0`);
+      await setSerialPlan(transactionDb);
       return query(transactionDb);
     });
   }


### PR DESCRIPTION
## Summary

Closes #4235.

A library-page load fired up to nine concurrent aggregates over `board_climbs` ⋈
`board_climb_stats` — the smart-playlist counts CTE, board-target resolution, and
one count per recommendation type — each on its own pooled connection, none of
them guarded. Every one of those plans is a parallel hash join, and a burst of
them exhausts Postgres's dynamic shared memory on our small `/dev/shm`. The
request dies with pgCode 53100, `could not resize shared memory segment`.

This is round three of the same fix. #4124 added the `withSerialPlan` helper and
guarded search, setter stats, the trending and session feeds, and
`userProfileStats`; it also added the `graphqlPath` tag and truncated
`failedQuery` context to `mask-error.ts`, which is exactly what named the two
paths left standing here.

**Sentry issues:** `BOARDSESH-AK` (656 events / 198 users, last seen
2026-08-10T16:50:52Z, `unresolved`) on `mySmartPlaylistCounts` and
`smartPlaylist`, and `BOARDSESH-B6` on `syncClimbStats` → `recomputeClimbStats`.

### What changed

- **`packages/db/src/queries/util/serial-plan.ts`** — new `setSerialPlan(db)` for
  callers that already own a transaction and only need the `SET LOCAL`.
  `withSerialPlan`'s transaction branch now calls it, so the statement has one
  definition. Handing an open `tx` to `withSerialPlan` would open a savepoint just
  to set a GUC; this is the escape hatch that avoids it.
- **`recommendation-refs.ts` / `recommendation-board-target.ts`** — every helper
  takes an executor. Called without one, `selectRecommendationClimbRefs`,
  `countRecommendationClimbRefs` and `resolveRecommendationBoardTarget` each open
  their own guarded transaction; called with one, they run on that handle and
  issue no guard of their own. This matters for the `RECOMMENDED_AT_LEVEL` path,
  where the grade-band query and the ranked page have to share one transaction.
- **`mySmartPlaylistCounts`** — the whole body after `requireAuthenticated` runs
  inside one `withSerialPlan`. Nine connections become one.
- **`smartPlaylist`** on a `RECOMMENDED_*` type — target resolution, ranked page
  and total share one guarded transaction. `fetchUserMeta` and the climb hydrator
  stay outside it: they're PK / IN-list lookups, and keeping them out shortens how
  long the pooled connection is held.
- **`recomputeClimbStats`** — `setSerialPlan(tx)` as the first statement of the
  transaction it already opens, before the defensive seed INSERT.
  `recomputeClimbStatsBulk` deliberately gets nothing: it doesn't open a
  transaction (it runs on the caller's handle), and `SET LOCAL` outside one is
  discarded with a warning.

### Trade-off, deliberately taken

The library card row goes from up to nine concurrent queries to nine sequential
ones on one connection — the same trade #4124 took for `userProfileStats`. The
counts are cached client-side for 5 minutes (`useSmartPlaylistCounts`), so this is
one fetch per library visit, not per render.

`SET LOCAL max_parallel_workers_per_gather = 0` changes the plan, never the rows.
If any count comes back different, the bug is in the executor threading, not the
GUC.

### Not fixed here

The pgCode **53300** (`too_many_connections`) events on `allUserPlaylists`,
`discoverPlaylists`, `profile` and `integrations` are pool saturation downstream
of this same fan-out. Collapsing nine connections to one should take pressure off
them, but nothing here targets them directly — re-check Sentry a few days after
deploy rather than assuming, and don't raise the pool cap blind.

Also left alone, on purpose: the 8-way enrichment fan-out in `session-feed.ts:403`
(genuinely the largest remaining one, but eight helpers to thread and zero Sentry
events), `gym-insights.ts:95`, and any change to the recommendation ranking SQL or
its indexes. This PR stays a pure plan-shape guard so its result-neutrality is
obvious.

## Release Notes

- Your playlist cards load their counts again instead of failing under load.

## Test plan

- `vp run typecheck` — pass (backend + db scoped runs also pass).
- `vp test run --project backend --reporter=agent playlist` — 18 files, 134 tests,
  all pass. That covers the updated `smart-playlists.test.ts`, the existing
  `serial-plan-guard.test.ts`, and the new `playlist-serial-plan.test.ts`.
- `vp check` — pass.
- New `packages/backend/src/__tests__/playlist-serial-plan.test.ts` renders the
  real SQL through drizzle's `PgDialect` against a fake db that records which
  handle every statement ran on. It pins, for each entry point: the guard is
  issued before the first SELECT, the whole fan-out opens exactly **one**
  transaction (not one per query), and passing an explicit executor opens no
  nested transaction and re-issues no guard. It also pins that `smartPlaylist`
  still short-circuits for a non-owner without touching the database.
- `smart-playlists.test.ts`'s behavioural assertions are unchanged — only the call
  arity and the extra leading `SET LOCAL` execute shifted, which is the point: the
  guard is result-neutral.
- `recompute-climb-stats.test.ts` — the two statement-shape cases counted the
  transaction's statements, so `setSerialPlan(tx)` shifted them by one and CI's
  `test-backend` job went red on the first push. Fixed in review rather than by
  bumping the numbers: both now assert the guard is the FIRST statement, that it
  is issued exactly once, and that the path still opens exactly one transaction.
  That is also the regression net the `BOARDSESH-B6` half shipped without.
  `vp test run --project backend --reporter=agent recompute` — 2 files, 45 tests,
  pass, including the real-Postgres provenance matrix.
- Not run locally: the backend integration suite. Ports 8082/8084 were held by
  other worktrees' dev servers on this machine, which fails the whole file for
  environmental reasons. CI runs it clean — and, as above, a `playlist`-scoped
  local run is not enough on its own: guard-count assertions live outside that
  filter.
- Manual QA steps in `.boardsesh/qa-notes.md`.

