### PR TITLE
fix(backend): gate saveTick's boardUuid rung on a full board config match

### DIFF
--- a/packages/backend/src/__tests__/save-tick-board-uuid-config-gate.test.ts
+++ b/packages/backend/src/__tests__/save-tick-board-uuid-config-gate.test.ts
@@ -123,6 +123,10 @@ describe('saveTick boardUuid config gate', () => {
   });
 
   afterAll(async () => {
+    // Belt and braces: afterEach already clears these, but a run killed between
+    // tests would otherwise strand boards in the shared worker DB.
+    await db.execute(sql`DELETE FROM boardsesh_ticks WHERE user_id = ${USER_ID}`);
+    await db.execute(sql`DELETE FROM user_boards WHERE owner_id IN (${USER_ID}, ${OTHER_USER_ID})`);
     await db.execute(sql`DELETE FROM board_climbs WHERE uuid = ${CLIMB_UUID}`);
     await db.execute(sql`DELETE FROM users WHERE id IN (${USER_ID}, ${OTHER_USER_ID})`);
   });

--- a/packages/backend/src/__tests__/save-tick-board-uuid-config-gate.test.ts
+++ b/packages/backend/src/__tests__/save-tick-board-uuid-config-gate.test.ts
@@ -70,6 +70,7 @@ function tickInput(overrides: Record<string, unknown> = {}) {
 
 async function insertBoard(opts: {
   ownerId?: string;
+  boardType?: string;
   setIds?: string;
   layoutId?: number;
   sizeId?: number;
@@ -79,7 +80,7 @@ async function insertBoard(opts: {
   const result = await db.execute(sql`
     INSERT INTO user_boards
       (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, is_public, created_at, updated_at)
-    VALUES (${uuid}, ${uuid}, ${opts.ownerId ?? USER_ID}, ${CONFIG.boardType}, ${opts.layoutId ?? CONFIG.layoutId},
+    VALUES (${uuid}, ${uuid}, ${opts.ownerId ?? USER_ID}, ${opts.boardType ?? CONFIG.boardType}, ${opts.layoutId ?? CONFIG.layoutId},
             ${opts.sizeId ?? CONFIG.sizeId}, ${opts.setIds ?? CONFIG.setIds}, ${opts.name}, true, now(), now())
     RETURNING id
   `);
@@ -168,6 +169,15 @@ describe('saveTick boardUuid config gate', () => {
     const otherSetsBoard = await insertBoard({ ownerId: OTHER_USER_ID, setIds: '3,4', name: 'Other sets' });
 
     expect(await saveTick({ boardUuid: otherSetsBoard.uuid })).toBeNull();
+  });
+
+  it('records the tick unassociated when the named board is a different board type', async () => {
+    // Layout, size and sets all line up — only the board type differs. Layout
+    // ids aren't unique across board types, so without this leg a Tension board
+    // could collect Kilter ticks.
+    const otherTypeBoard = await insertBoard({ ownerId: OTHER_USER_ID, boardType: 'tension', name: 'Tension wall' });
+
+    expect(await saveTick({ boardUuid: otherTypeBoard.uuid })).toBeNull();
   });
 
   it('attributes when stored and sent hold sets differ only in order', async () => {

--- a/packages/backend/src/__tests__/save-tick-board-uuid-config-gate.test.ts
+++ b/packages/backend/src/__tests__/save-tick-board-uuid-config-gate.test.ts
@@ -1,0 +1,194 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import { v4 as uuidv4 } from 'uuid';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { setupWorkerDatabase } from './worker-db';
+
+// Side effects saveTick fires after the insert. None of them are under test and
+// they'd otherwise pull in Redis / the social event bus.
+vi.mock('../events', () => ({ publishSocialEvent: vi.fn(async () => undefined) }));
+vi.mock('../graphql/resolvers/ticks/debounced-climb-stats-publisher', () => ({
+  queueClimbStatsRecompute: vi.fn(),
+}));
+vi.mock('../graphql/resolvers/sessions/debounced-stats-publisher', () => ({
+  publishDebouncedSessionStats: vi.fn(),
+}));
+vi.mock('../graphql/resolvers/board-presence/stats', () => ({ queueBoardStatsPublish: vi.fn() }));
+vi.mock('../services/analytics/posthog', () => ({ captureBackendEvent: vi.fn(() => true) }));
+
+import { db } from '../db/client';
+import { tickMutations } from '../graphql/resolvers/ticks/mutations';
+
+/**
+ * Real-DB coverage for the `boardUuid` rung of saveTick's board resolution
+ * (#4219).
+ *
+ * A named-board route (`/b/<slug>/...`) sends the board's uuid, and the rung
+ * deliberately isn't ownership-gated — ticking a gym's seeded wall you don't own
+ * is the whole point. It used to accept the uuid on its own, so any
+ * authenticated caller who knew (or guessed) a uuid could stamp ticks onto that
+ * board's stats and leaderboards. The rung now requires the same FULL config
+ * match (type + layout + size + set) as the presence and session rungs; a
+ * mismatch records the tick unassociated, matching the rung's existing
+ * stale-uuid behaviour, and never falls through to the climber's own board.
+ */
+
+const USER_ID = 'uuid-gate-user';
+const OTHER_USER_ID = 'uuid-gate-gym-owner';
+const PREFIX = 'UUID-GATE-';
+const CLIMB_UUID = `${PREFIX}CLIMB`;
+
+const CONFIG = { boardType: 'kilter', layoutId: 8, sizeId: 25, setIds: '1,2' };
+
+function authCtx(userId = USER_ID): ConnectionContext {
+  return {
+    connectionId: `conn-${Math.random().toString(36).slice(2)}`,
+    isAuthenticated: true,
+    userId,
+  } as ConnectionContext;
+}
+
+function tickInput(overrides: Record<string, unknown> = {}) {
+  return {
+    boardType: CONFIG.boardType,
+    climbUuid: CLIMB_UUID,
+    angle: 40,
+    isMirror: false,
+    status: 'send',
+    attemptCount: 1,
+    quality: null,
+    difficulty: 17,
+    isBenchmark: false,
+    comment: '',
+    climbedAt: new Date().toISOString(),
+    layoutId: CONFIG.layoutId,
+    sizeId: CONFIG.sizeId,
+    setIds: CONFIG.setIds,
+    ...overrides,
+  };
+}
+
+async function insertBoard(opts: {
+  ownerId?: string;
+  setIds?: string;
+  layoutId?: number;
+  sizeId?: number;
+  name: string;
+}): Promise<{ id: number; uuid: string }> {
+  const uuid = uuidv4();
+  const result = await db.execute(sql`
+    INSERT INTO user_boards
+      (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, is_public, created_at, updated_at)
+    VALUES (${uuid}, ${uuid}, ${opts.ownerId ?? USER_ID}, ${CONFIG.boardType}, ${opts.layoutId ?? CONFIG.layoutId},
+            ${opts.sizeId ?? CONFIG.sizeId}, ${opts.setIds ?? CONFIG.setIds}, ${opts.name}, true, now(), now())
+    RETURNING id
+  `);
+  return { id: Number(Array.from(result as Iterable<{ id: number }>)[0].id), uuid };
+}
+
+/** The board_id the tick actually landed on. */
+async function tickBoardId(tickUuid: string): Promise<number | null> {
+  const result = await db.execute(sql`SELECT board_id FROM boardsesh_ticks WHERE uuid = ${tickUuid}`);
+  const row = Array.from(result as Iterable<{ board_id: number | null }>)[0];
+  return row.board_id == null ? null : Number(row.board_id);
+}
+
+async function saveTick(overrides: Record<string, unknown> = {}, userId = USER_ID) {
+  const uuid = uuidv4();
+  await tickMutations.saveTick(undefined, { input: { uuid, ...tickInput(overrides) } }, authCtx(userId));
+  return tickBoardId(uuid);
+}
+
+describe('saveTick boardUuid config gate', () => {
+  beforeAll(async () => {
+    await setupWorkerDatabase();
+  });
+
+  // Re-seeded per test, not once in beforeAll: sibling suites TRUNCATE these
+  // same shared tables in their own beforeEach, and this file's tests can
+  // interleave with theirs within a worker's shared DB.
+  beforeEach(async () => {
+    for (const id of [USER_ID, OTHER_USER_ID]) {
+      await db.execute(sql`
+        INSERT INTO users (id, email, name, created_at, updated_at)
+        VALUES (${id}, ${`${id}@test.com`}, ${`User ${id}`}, now(), now())
+        ON CONFLICT (id) DO NOTHING
+      `);
+    }
+    await db.execute(sql`
+      INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, description, frames, is_listed)
+      VALUES (${CLIMB_UUID}, ${CONFIG.boardType}, ${CONFIG.layoutId}, 'setter', 'Test Climb', '', 'p1r1', true)
+      ON CONFLICT (uuid) DO NOTHING
+    `);
+  });
+
+  afterAll(async () => {
+    await db.execute(sql`DELETE FROM board_climbs WHERE uuid = ${CLIMB_UUID}`);
+    await db.execute(sql`DELETE FROM users WHERE id IN (${USER_ID}, ${OTHER_USER_ID})`);
+  });
+
+  afterEach(async () => {
+    await db.execute(sql`DELETE FROM boardsesh_ticks WHERE user_id = ${USER_ID}`);
+    await db.execute(sql`DELETE FROM user_boards WHERE owner_id IN (${USER_ID}, ${OTHER_USER_ID})`);
+  });
+
+  it("attributes a tick to a gym's board the climber doesn't own when the config matches", async () => {
+    // The flow the rung exists for: climbing at a gym on a seeded board owned by
+    // someone else, logged from that board's named route.
+    const gymBoard = await insertBoard({ ownerId: OTHER_USER_ID, name: 'Gym wall' });
+
+    expect(await saveTick({ boardUuid: gymBoard.uuid })).toBe(gymBoard.id);
+  });
+
+  it('records the tick unassociated when the named board runs a different layout', async () => {
+    // The pollution vector: a uuid for a board the climber was never on. The
+    // tick is still saved, just not counted towards that board — and explicitly
+    // NOT re-homed onto the climber's own matching wall either, or a rejected
+    // uuid would quietly become a config-lookup tick.
+    const otherLayoutBoard = await insertBoard({ ownerId: OTHER_USER_ID, layoutId: 1, name: 'Other layout' });
+    const ownBoard = await insertBoard({ name: 'Home wall' });
+
+    const boardId = await saveTick({ boardUuid: otherLayoutBoard.uuid });
+    expect(boardId).toBeNull();
+    expect(boardId).not.toBe(otherLayoutBoard.id);
+    expect(boardId).not.toBe(ownBoard.id);
+  });
+
+  it('records the tick unassociated when the named board runs a different size', async () => {
+    const otherSizeBoard = await insertBoard({ ownerId: OTHER_USER_ID, sizeId: 27, name: 'Other size' });
+
+    expect(await saveTick({ boardUuid: otherSizeBoard.uuid })).toBeNull();
+  });
+
+  it('records the tick unassociated when the named board runs different hold sets', async () => {
+    const otherSetsBoard = await insertBoard({ ownerId: OTHER_USER_ID, setIds: '3,4', name: 'Other sets' });
+
+    expect(await saveTick({ boardUuid: otherSetsBoard.uuid })).toBeNull();
+  });
+
+  it('attributes when stored and sent hold sets differ only in order', async () => {
+    // Same normalisation the presence and session rungs use — '2,1' and '1,2'
+    // are one wall, not two.
+    const gymBoard = await insertBoard({ ownerId: OTHER_USER_ID, setIds: '2,1', name: 'Gym wall' });
+
+    expect(await saveTick({ boardUuid: gymBoard.uuid, setIds: '1,2' })).toBe(gymBoard.id);
+  });
+
+  it('records the tick unassociated when the input carries a boardUuid but no configuration', async () => {
+    // Deliberate strictness: without a layout/size/set there is nothing to check,
+    // so omitting the config can't be a way around the gate.
+    const gymBoard = await insertBoard({ ownerId: OTHER_USER_ID, name: 'Gym wall' });
+
+    expect(
+      await saveTick({ boardUuid: gymBoard.uuid, layoutId: undefined, sizeId: undefined, setIds: undefined }),
+    ).toBeNull();
+  });
+
+  it('records the tick unassociated when the boardUuid is unknown', async () => {
+    // Deleted board or a stale client uuid: the tick is kept, not rejected
+    // (#2386's trade-off), and doesn't fall back to config resolution.
+    await insertBoard({ name: 'Home wall' });
+
+    expect(await saveTick({ boardUuid: uuidv4() })).toBeNull();
+  });
+});

--- a/packages/backend/src/graphql/resolvers/board-presence/shared.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/shared.ts
@@ -289,6 +289,46 @@ export function normalizeSetIds(setIds: string | null | undefined): string {
     .join(',');
 }
 
+/**
+ * The board configuration a tick names: the board type it was logged against
+ * plus the layout/size/set triple from the route it was logged from. The three
+ * config fields are optional on the wire (`SaveTickInputSchema`), so a caller
+ * can omit them entirely.
+ */
+export interface TickBoardConfigTarget {
+  boardType: string;
+  layoutId?: number | null;
+  sizeId?: number | null;
+  setIds?: string | null;
+}
+
+/**
+ * Does a board's stored configuration match the one a tick names?
+ *
+ * Every board-resolution rung in `saveTick` accepts a candidate board only when
+ * its FULL config (type + layout + size + set) matches the tick's — otherwise a
+ * stale id/uuid stamps the tick onto the wrong wall and corrupts that board's
+ * stats and leaderboards. Set ids are compared normalized so order/format
+ * differences don't reject a real match.
+ *
+ * A tick that carries no layout/size/set matches nothing: without a config
+ * there is nothing to check, and accepting it would reopen the bypass this gate
+ * exists to close.
+ */
+export function boardConfigMatchesTick(
+  board: Pick<ActivePresenceBoard, 'boardType' | 'layoutId' | 'sizeId' | 'setIds'> | null | undefined,
+  target: TickBoardConfigTarget,
+): boolean {
+  if (!board) return false;
+  if (target.layoutId == null || target.sizeId == null || !target.setIds) return false;
+  return (
+    board.boardType === target.boardType &&
+    board.layoutId === target.layoutId &&
+    board.sizeId === target.sizeId &&
+    normalizeSetIds(board.setIds) === normalizeSetIds(target.setIds)
+  );
+}
+
 export async function requireActiveBoardById(boardId: number): Promise<ActivePresenceBoard> {
   assertValidBoardId(boardId);
   const board = await findActiveBoardById(boardId);

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -768,8 +768,15 @@ export const tickMutations = {
       if (board && boardConfigMatchesTick(board, validatedInput)) {
         boardId = board.id;
       } else if (board) {
+        // Two different reasons to land here, and they mean different things in
+        // production triage: a client that sends no config at all is a client
+        // to go fix, a real mismatch is a stale uuid or a pollution attempt.
+        const hasConfig =
+          validatedInput.layoutId != null && validatedInput.sizeId != null && Boolean(validatedInput.setIds);
         logger.warn(
-          `[saveTick] Ignoring tick boardUuid ${validatedInput.boardUuid} — config mismatch for ${validatedInput.boardType}/${validatedInput.layoutId}/${validatedInput.sizeId}/${validatedInput.setIds}`,
+          hasConfig
+            ? `[saveTick] Ignoring tick boardUuid ${validatedInput.boardUuid} — config mismatch for ${validatedInput.boardType}/${validatedInput.layoutId}/${validatedInput.sizeId}/${validatedInput.setIds}`
+            : `[saveTick] Ignoring tick boardUuid ${validatedInput.boardUuid} — input carries no layout/size/set to match against`,
         );
       }
     } else if (validatedInput.boardId != null) {

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -15,7 +15,7 @@ import {
   readTimestampFractionalSeconds,
 } from '../../../validation/schemas';
 import { resolveBoardFromPath } from '../social/boards';
-import { findActiveBoardById, normalizeSetIds } from '../board-presence/shared';
+import { boardConfigMatchesTick, findActiveBoardById } from '../board-presence/shared';
 import { queueBoardStatsPublish } from '../board-presence/stats';
 import { publishSocialEvent } from '../../../events';
 import { publishDebouncedSessionStats } from '../sessions/debounced-stats-publisher';
@@ -729,9 +729,12 @@ export const tickMutations = {
     // Resolve the tick's board_id. Four rungs, most specific first:
     //  1. boardUuid — a named-board route (`/b/<slug>/...`); attaches to that
     //     exact board entity even when the climber doesn't own it (e.g. a
-    //     seeded gym board owned by the system user). Best-effort: a deleted or
-    //     stale uuid records the tick unassociated rather than rejecting it, and
-    //     does NOT fall back to config resolution.
+    //     seeded gym board owned by the system user). Config-gated exactly like
+    //     rungs 2 and 3, so knowing a uuid isn't enough to stamp a tick onto
+    //     another board's stats (#4219). Best-effort: a deleted uuid, a stale
+    //     uuid, a config mismatch, or an input carrying no layout/size/set all
+    //     record the tick unassociated rather than rejecting it, and none of
+    //     them fall back to config resolution.
     //  2. boardId — the board-presence connected wall (resolveBoardForSerial),
     //     flag-gated. On a stale/mismatched id we warn and fall back to the
     //     config lookup rather than surfacing a raw FK/type mismatch.
@@ -760,23 +763,22 @@ export const tickMutations = {
       // Board may have been deleted or the client sent a stale UUID — just
       // record the tick without a board association rather than rejecting it.
       // board_id is nullable (onDelete: 'set null') so this is always valid.
-      if (board) {
+      // Same for a config mismatch: knowing a board's uuid must not be enough
+      // to add a tick to a wall the climber wasn't on (#4219).
+      if (board && boardConfigMatchesTick(board, validatedInput)) {
         boardId = board.id;
+      } else if (board) {
+        logger.warn(
+          `[saveTick] Ignoring tick boardUuid ${validatedInput.boardUuid} — config mismatch for ${validatedInput.boardType}/${validatedInput.layoutId}/${validatedInput.sizeId}/${validatedInput.setIds}`,
+        );
       }
     } else if (validatedInput.boardId != null) {
       const explicitBoard = await findActiveBoardById(validatedInput.boardId);
       // Accept the explicit wall board only when its FULL config matches the
       // tick's target (type + layout + size + set). A stale presence boardId
       // from a different layout/size/set would otherwise stamp this tick onto
-      // the wrong wall and corrupt that board's presence stats. Set ids are
-      // compared normalized so order/format differences don't reject a match.
-      const configMatches =
-        explicitBoard != null &&
-        explicitBoard.boardType === validatedInput.boardType &&
-        explicitBoard.layoutId === validatedInput.layoutId &&
-        explicitBoard.sizeId === validatedInput.sizeId &&
-        normalizeSetIds(explicitBoard.setIds) === normalizeSetIds(validatedInput.setIds);
-      if (configMatches) {
+      // the wrong wall and corrupt that board's presence stats.
+      if (explicitBoard && boardConfigMatchesTick(explicitBoard, validatedInput)) {
         boardId = explicitBoard.id;
       } else {
         logger.warn(
@@ -800,13 +802,7 @@ export const tickMutations = {
       const sessionBoard = await findActiveBoardById(sessionBoardId);
       // Same full-config gate as rung 2: a session left open on another wall
       // must not stamp this tick onto it.
-      const configMatches =
-        sessionBoard != null &&
-        sessionBoard.boardType === validatedInput.boardType &&
-        sessionBoard.layoutId === validatedInput.layoutId &&
-        sessionBoard.sizeId === validatedInput.sizeId &&
-        normalizeSetIds(sessionBoard.setIds) === normalizeSetIds(validatedInput.setIds);
-      if (configMatches) {
+      if (sessionBoard && boardConfigMatchesTick(sessionBoard, validatedInput)) {
         boardId = sessionBoard.id;
       }
     }


### PR DESCRIPTION
## Summary

`saveTick` resolves a tick's board through four rungs. The `boardUuid` rung — the one a named-board route (`/b/<slug>/<angle>/...`) uses — selected the board by uuid and took its id without checking anything else, even though it was already selecting the board's config columns. Any authenticated caller who knew a board uuid could stamp ticks onto that board's stats and leaderboards regardless of what configuration the tick itself named.

The two newer rungs (presence board, session board) already required a full config match — board type + layout + size + hold sets — before attributing. This applies the same gate to the `boardUuid` rung and pulls the three copies of the comparison into one helper.

Behaviour on a mismatch follows the rung's existing best-effort contract: the tick is still saved, just with `board_id` NULL, and it deliberately does **not** fall through to the config lookup — a supplied-but-rejected uuid must stay unassociated rather than quietly landing on the climber's own same-config board. A `[saveTick] Ignoring tick boardUuid …` warning makes any real client hitting this visible in backend logs after deploy.

An input carrying a `boardUuid` but no `layoutId`/`sizeId`/`setIds` is also left unassociated — otherwise omitting the config would be a way around the gate.

### Changes

- `packages/backend/src/graphql/resolvers/board-presence/shared.ts` — new `boardConfigMatchesTick(board, target)` next to `normalizeSetIds`.
- `packages/backend/src/graphql/resolvers/ticks/mutations.ts` — rung 1 gated on it; rungs 2 and 3 refactored onto it (behaviour-preserving); four-rung doc comment updated.
- `packages/backend/src/__tests__/save-tick-board-uuid-config-gate.test.ts` — 8 real-DB cases.

### Client audit (why this doesn't break the legitimate flow)

`boardUuid` is only ever injected by the shared `BoardProvider`, and only the web named-board route sets it. Both web tick call sites (`logascent-form.tsx`, `use-tick-save.ts`) always send `layoutId`/`sizeId`/`setIds` from the same board's route params, so the gate passes for the gym-board flow the rung exists for. Mobile never sends `boardUuid`. Offline replay sends the stored variables verbatim, so config survives replay.

### Not in scope

- Ownership/visibility gating of the rung — would break ticking an unlisted or party-host board you don't own, and needs a product decision.
- Checking that the tick's climb belongs to the resolved board's layout — applies to all four rungs, deserves its own issue.
- Backfilling existing `boardsesh_ticks` rows attributed through the ungated rung.

## Release Notes

Board leaderboards now only count ticks actually logged on that board's setup — a tick whose layout, size, or hold sets don't match the board it names is kept in your logbook but left off that board's stats.

- [ ] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:backend` — pass
- `vp test run --project backend --reporter=agent save-tick-board-uuid-config-gate legacy-tick-board-attribution board-presence` — pass, 96/96 (a first attempt can time out in the shared-worker-DB setup hook; clean on re-run)
- Reverted the rung-1 gate locally and re-ran the new suite: 5 of its 8 cases fail without the fix, so it is a real regression guard rather than a happy-path sweep.
- `vp check` — pass
- The full `vp test run --project backend` sweep did not complete locally: ports 8082/8084, which `integration.test.ts` and the resolver suite hard-bind, are held by two other worktrees' long-running Expo dev servers on this machine. CI runs it on a clean box.

New cases: matching config attributes to a gym board you don't own; differing layout / size / hold sets each record the tick unassociated and specifically not on the climber's own matching board; a board of a different type with an identical layout/size/set records unassociated; `2,1` vs `1,2` still attributes; boardUuid with no config records unassociated; unknown uuid records unassociated.

QA notes: `.boardsesh/qa-notes.md`.

Closes #4219
