### PR TITLE
fix(web): require a global admin role for the /admin subtree

### DIFF
--- a/packages/backend/src/graphql/resolvers/social/__tests__/roles.test.ts
+++ b/packages/backend/src/graphql/resolvers/social/__tests__/roles.test.ts
@@ -59,6 +59,17 @@ describe('communityRoles auth gate', () => {
     ).rejects.toThrow('Admin role required for this operation');
   });
 
+  it('rejects a board-scoped admin caller', async () => {
+    // `requireAdmin(ctx)` is called with no board type, so only a globally
+    // scoped admin row passes. This is the contract the web /admin gate mirrors
+    // in packages/web/app/lib/admin/admin-scope.ts — a kilter-scoped admin now
+    // gets an explanation instead of a page whose every action fails.
+    dbState.queue = [[{ role: 'admin', boardType: 'kilter' }]];
+    await expect(
+      socialRoleQueries.communityRoles(null, {}, makeCtx({ isAuthenticated: true, userId: 'kilter-admin' })),
+    ).rejects.toThrow('Admin role required for this operation');
+  });
+
   it('returns the enriched role assignments for an admin caller', async () => {
     dbState.queue = [
       [{ role: 'admin', boardType: null }], // requireAdmin: caller is a global admin

--- a/packages/shared/i18n/locales/de/admin.json
+++ b/packages/shared/i18n/locales/de/admin.json
@@ -12,7 +12,8 @@
   "title": "Admin-Panel",
   "auth": {
     "signInRequired": "Melde dich an, um ins Admin-Panel zu kommen.",
-    "noAccess": "Du hast keinen Admin-Zugang."
+    "noAccess": "Du hast keinen Admin-Zugang.",
+    "boardScopedNoAccess": "Dein Admin-Zugang gilt nur für ein Board. Diese Tools brauchen Admin-Zugang für die ganze Seite."
   },
   "tabs": {
     "roles": "Rollen",

--- a/packages/shared/i18n/locales/en-US/admin.json
+++ b/packages/shared/i18n/locales/en-US/admin.json
@@ -12,7 +12,8 @@
   "title": "Admin Panel",
   "auth": {
     "signInRequired": "Please sign in to access the admin panel.",
-    "noAccess": "You do not have admin access."
+    "noAccess": "You do not have admin access.",
+    "boardScopedNoAccess": "Your admin role only covers one board. These tools need site-wide admin access."
   },
   "tabs": {
     "roles": "Roles",

--- a/packages/shared/i18n/locales/es/admin.json
+++ b/packages/shared/i18n/locales/es/admin.json
@@ -12,7 +12,8 @@
   "title": "Panel de admin",
   "auth": {
     "signInRequired": "Inicia sesión para acceder al panel de admin.",
-    "noAccess": "No tienes acceso de admin."
+    "noAccess": "No tienes acceso de admin.",
+    "boardScopedNoAccess": "Tu rol de admin solo cubre un plafón. Estas herramientas necesitan acceso de admin en todo el sitio."
   },
   "tabs": {
     "roles": "Roles",

--- a/packages/shared/i18n/locales/fr/admin.json
+++ b/packages/shared/i18n/locales/fr/admin.json
@@ -12,7 +12,8 @@
   "title": "Panneau d'administration",
   "auth": {
     "signInRequired": "Connectez-vous pour accéder au panneau d'administration.",
-    "noAccess": "Vous n'avez pas les droits d'administration."
+    "noAccess": "Vous n'avez pas les droits d'administration.",
+    "boardScopedNoAccess": "Vos droits d'administration ne couvrent qu'une seule board. Ces outils demandent un accès admin sur tout le site."
   },
   "tabs": {
     "roles": "Rôles",

--- a/packages/web/app/admin/feedback/page.tsx
+++ b/packages/web/app/admin/feedback/page.tsx
@@ -36,7 +36,7 @@ export default async function AdminFeedbackPage() {
     return (
       <I18nProvider locale={locale} namespaces={['common', 'admin']}>
         <Container maxWidth="md" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
-          <Alert severity="error">{t('auth.noAccess')}</Alert>
+          <Alert severity="error">{t(access.boardScopedOnly ? 'auth.boardScopedNoAccess' : 'auth.noAccess')}</Alert>
         </Container>
       </I18nProvider>
     );

--- a/packages/web/app/admin/gym-claims/page.tsx
+++ b/packages/web/app/admin/gym-claims/page.tsx
@@ -42,7 +42,7 @@ export default async function AdminGymClaimsPage() {
           maxWidth="md"
           sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)', pb: 'var(--bottom-bar-height)' }}
         >
-          <Alert severity="error">{t('auth.noAccess')}</Alert>
+          <Alert severity="error">{t(access.boardScopedOnly ? 'auth.boardScopedNoAccess' : 'auth.noAccess')}</Alert>
         </Container>
       </I18nProvider>
     );

--- a/packages/web/app/admin/gym-duplicates/page.tsx
+++ b/packages/web/app/admin/gym-duplicates/page.tsx
@@ -36,7 +36,7 @@ export default async function AdminGymDuplicatesPage() {
     return (
       <I18nProvider locale={locale} namespaces={['common', 'admin']}>
         <Container maxWidth="md" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
-          <Alert severity="error">{t('auth.noAccess')}</Alert>
+          <Alert severity="error">{t(access.boardScopedOnly ? 'auth.boardScopedNoAccess' : 'auth.noAccess')}</Alert>
         </Container>
       </I18nProvider>
     );

--- a/packages/web/app/admin/page.tsx
+++ b/packages/web/app/admin/page.tsx
@@ -18,13 +18,14 @@ import RoleManagement from '@/app/components/admin/role-management';
 import CommunitySettingsPanel from '@/app/components/admin/community-settings-panel';
 import GymSettingsPanel from '@/app/components/admin/gym-settings-panel';
 import LocaleLink from '@/app/components/i18n/locale-link';
+import { rolesGrantGlobalAdmin, rolesGrantScopedAdmin } from '@/app/lib/admin/admin-scope';
 
 export default function AdminPage() {
   const { t } = useTranslation('admin');
   const { token } = useWsAuthToken();
   const [tab, setTab] = useState(0);
   const [isAdmin, setIsAdmin] = useState(false);
-  const [isGlobalAdmin, setIsGlobalAdmin] = useState(false);
+  const [boardScopedOnly, setBoardScopedOnly] = useState(false);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -36,16 +37,17 @@ export default function AdminPage() {
       try {
         const client = createGraphQLHttpClient(token);
         const result = await client.request<{ myRoles: CommunityRoleAssignment[] }>(GET_MY_ROLES);
-        setIsAdmin(result.myRoles.some((role) => role.role === 'admin'));
-        // Gym settings are global config, and the backend gates them with
-        // `requireAdmin(ctx)` / `hasAdmin(userId)` — no board type — which a
-        // board-scoped admin fails. Without this narrower check they'd see the
-        // tab, read the toggle as off whatever its real value, and hit an
-        // authorization error on every change.
-        setIsGlobalAdmin(result.myRoles.some((role) => role.role === 'admin' && role.boardType == null));
+        // Every resolver these pages call — role grants, community settings,
+        // gym settings — gates with `requireAdmin(ctx)` / `hasAdmin(userId)`
+        // and no board type, which a board-scoped admin fails. Without the
+        // narrower check they'd see a hub whose every action errors (and a
+        // gym-settings toggle that reads "off" whatever its real value is).
+        const globalAdmin = rolesGrantGlobalAdmin(result.myRoles);
+        setIsAdmin(globalAdmin);
+        setBoardScopedOnly(!globalAdmin && rolesGrantScopedAdmin(result.myRoles));
       } catch {
         setIsAdmin(false);
-        setIsGlobalAdmin(false);
+        setBoardScopedOnly(false);
       } finally {
         setLoading(false);
       }
@@ -66,7 +68,7 @@ export default function AdminPage() {
   if (!isAdmin) {
     return (
       <Container maxWidth="md" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
-        <Alert severity="error">{t('auth.noAccess')}</Alert>
+        <Alert severity="error">{t(boardScopedOnly ? 'auth.boardScopedNoAccess' : 'auth.noAccess')}</Alert>
       </Container>
     );
   }
@@ -110,13 +112,13 @@ export default function AdminPage() {
         <Tabs value={tab} onChange={(_, v) => setTab(v)}>
           <Tab label={t('tabs.roles')} sx={{ textTransform: 'none' }} />
           <Tab label={t('tabs.settings')} sx={{ textTransform: 'none' }} />
-          {isGlobalAdmin && <Tab label={t('tabs.gyms')} sx={{ textTransform: 'none' }} />}
+          <Tab label={t('tabs.gyms')} sx={{ textTransform: 'none' }} />
         </Tabs>
       </Box>
 
       {tab === 0 && <RoleManagement />}
       {tab === 1 && <CommunitySettingsPanel />}
-      {tab === 2 && isGlobalAdmin && <GymSettingsPanel />}
+      {tab === 2 && <GymSettingsPanel />}
     </Container>
   );
 }

--- a/packages/web/app/admin/retention/page.tsx
+++ b/packages/web/app/admin/retention/page.tsx
@@ -280,7 +280,7 @@ export default async function AdminRetentionPage() {
     return (
       <I18nProvider locale={locale} namespaces={['common', 'admin']}>
         <Container maxWidth="md" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
-          <Alert severity="error">{t('auth.noAccess')}</Alert>
+          <Alert severity="error">{t(access.boardScopedOnly ? 'auth.boardScopedNoAccess' : 'auth.noAccess')}</Alert>
         </Container>
       </I18nProvider>
     );

--- a/packages/web/app/lib/admin/__tests__/admin-scope.test.ts
+++ b/packages/web/app/lib/admin/__tests__/admin-scope.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { rolesGrantGlobalAdmin, rolesGrantScopedAdmin, type AdminRoleScope } from '../admin-scope';
+
+describe('admin scope predicates', () => {
+  it('grants global admin for an unscoped admin row', () => {
+    const roles: AdminRoleScope[] = [{ role: 'admin', boardType: null }];
+    expect(rolesGrantGlobalAdmin(roles)).toBe(true);
+    expect(rolesGrantScopedAdmin(roles)).toBe(false);
+  });
+
+  it('denies global admin for a board-scoped admin row', () => {
+    const roles: AdminRoleScope[] = [{ role: 'admin', boardType: 'kilter' }];
+    expect(rolesGrantGlobalAdmin(roles)).toBe(false);
+    expect(rolesGrantScopedAdmin(roles)).toBe(true);
+  });
+
+  it('grants global admin when both a scoped and a global row are held', () => {
+    const roles: AdminRoleScope[] = [
+      { role: 'admin', boardType: 'kilter' },
+      { role: 'admin', boardType: null },
+    ];
+    expect(rolesGrantGlobalAdmin(roles)).toBe(true);
+  });
+
+  it('ignores non-admin roles even when they are global', () => {
+    const roles: AdminRoleScope[] = [
+      { role: 'community_leader', boardType: null },
+      { role: 'tester', boardType: null },
+    ];
+    expect(rolesGrantGlobalAdmin(roles)).toBe(false);
+    expect(rolesGrantScopedAdmin(roles)).toBe(false);
+  });
+
+  it('treats a missing boardType the same as a null one', () => {
+    const roles: AdminRoleScope[] = [{ role: 'admin' }];
+    expect(rolesGrantGlobalAdmin(roles)).toBe(true);
+    expect(rolesGrantScopedAdmin(roles)).toBe(false);
+  });
+
+  it('denies both for an empty role list', () => {
+    expect(rolesGrantGlobalAdmin([])).toBe(false);
+    expect(rolesGrantScopedAdmin([])).toBe(false);
+  });
+});

--- a/packages/web/app/lib/admin/__tests__/check-admin.test.ts
+++ b/packages/web/app/lib/admin/__tests__/check-admin.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, vi } from 'vite-plus/test';
+
+vi.mock('server-only', () => ({}));
+
+const mockGetServerSession = vi.fn();
+vi.mock('next-auth/next', () => ({
+  getServerSession: (...args: unknown[]) => mockGetServerSession(...args),
+}));
+
+vi.mock('@/app/lib/auth/auth-options', () => ({ authOptions: {} }));
+
+vi.mock('@/app/lib/db/schema', () => ({
+  communityRoles: {
+    id: 'community_roles.id',
+    userId: 'community_roles.user_id',
+    role: 'community_roles.role',
+    boardType: 'community_roles.board_type',
+  },
+}));
+
+// The `where` result is awaited directly, but it also answers `.limit()` so a
+// regression back to the `.limit(1)` query fails on the assertion below rather
+// than on a missing method.
+let queuedRows: Array<{ role: string; boardType: string | null }> = [];
+const mockLimit = vi.fn((count: number) => Promise.resolve(queuedRows.slice(0, count)));
+const mockWhere = vi.fn(() => Object.assign(Promise.resolve(queuedRows), { limit: mockLimit }));
+const mockFrom = vi.fn(() => ({ where: mockWhere }));
+const mockSelect = vi.fn(() => ({ from: mockFrom }));
+
+vi.mock('@/app/lib/db/db', () => ({
+  getDb: () => ({ select: mockSelect }),
+}));
+
+const { checkAdmin } = await import('../check-admin');
+
+describe('checkAdmin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue({ user: { id: 'user-1' } });
+    queuedRows = [];
+  });
+
+  it('reports unauthenticated when there is no session user', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    expect(await checkAdmin()).toEqual({ authenticated: false });
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it('denies a board-scoped admin and flags the scope (issue #4232)', async () => {
+    // The pre-fix query matched any `role = 'admin'` row with `.limit(1)`, so a
+    // kilter-scoped admin came back `isAdmin: true` and got a page whose every
+    // action failed against `requireAdmin(ctx)`.
+    queuedRows = [{ role: 'admin', boardType: 'kilter' }];
+
+    expect(await checkAdmin()).toEqual({
+      authenticated: true,
+      userId: 'user-1',
+      isAdmin: false,
+      boardScopedOnly: true,
+    });
+  });
+
+  it('grants a globally scoped admin', async () => {
+    queuedRows = [{ role: 'admin', boardType: null }];
+
+    expect(await checkAdmin()).toEqual({
+      authenticated: true,
+      userId: 'user-1',
+      isAdmin: true,
+      boardScopedOnly: false,
+    });
+  });
+
+  it('grants a user holding both a scoped and a global admin row', async () => {
+    // The dropped `.limit(1)` matters here: whichever row the database returned
+    // first used to decide the answer.
+    queuedRows = [
+      { role: 'admin', boardType: 'kilter' },
+      { role: 'admin', boardType: null },
+    ];
+
+    const access = await checkAdmin();
+    expect(access).toEqual({ authenticated: true, userId: 'user-1', isAdmin: true, boardScopedOnly: false });
+  });
+
+  it('denies a signed-in user with no admin rows without the scoped copy', async () => {
+    queuedRows = [];
+
+    expect(await checkAdmin()).toEqual({
+      authenticated: true,
+      userId: 'user-1',
+      isAdmin: false,
+      boardScopedOnly: false,
+    });
+  });
+
+  it('selects role and board type for every admin row, unlimited', async () => {
+    await checkAdmin();
+
+    expect(mockSelect).toHaveBeenCalledWith({
+      role: 'community_roles.role',
+      boardType: 'community_roles.board_type',
+    });
+    expect(mockWhere).toHaveBeenCalledTimes(1);
+    // A `.limit(1)` here would hide a second admin row from the scope check.
+    expect(mockLimit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/lib/admin/admin-scope.ts
+++ b/packages/web/app/lib/admin/admin-scope.ts
@@ -1,0 +1,26 @@
+/**
+ * Role-scope predicates for the /admin subtree.
+ *
+ * A `community_roles` row with a null `board_type` is a global assignment; a
+ * non-null one only covers that board type. Every resolver behind /admin —
+ * `communityRoles`, `grantRole`, `revokeRole`, `setCommunitySettings`,
+ * `pendingGymClaims`, `reviewGymClaim`, `duplicateGymClusters`, `mergeGyms`,
+ * `adminAppFeedback`, `updateAppFeedbackStatus` — calls `requireAdmin(ctx)` /
+ * `requireAdminOrLeader(ctx)` with no board type, and those only accept a
+ * globally-scoped admin. So "global admin" is the bar for these pages: a
+ * board-scoped admin who gets in only sees a page whose every action fails.
+ *
+ * Deliberately free of `server-only` so both the server pages and the client
+ * hub can share one predicate.
+ */
+export type AdminRoleScope = { role: string; boardType?: string | null };
+
+/** Does this user hold an `admin` role that applies to every board type? */
+export function rolesGrantGlobalAdmin(roles: AdminRoleScope[]): boolean {
+  return roles.some((entry) => entry.role === 'admin' && entry.boardType == null);
+}
+
+/** Does this user hold an `admin` role limited to a single board type? */
+export function rolesGrantScopedAdmin(roles: AdminRoleScope[]): boolean {
+  return roles.some((entry) => entry.role === 'admin' && entry.boardType != null);
+}

--- a/packages/web/app/lib/admin/check-admin.ts
+++ b/packages/web/app/lib/admin/check-admin.ts
@@ -4,19 +4,30 @@ import { eq, and } from 'drizzle-orm';
 import { authOptions } from '@/app/lib/auth/auth-options';
 import { getDb } from '@/app/lib/db/db';
 import { communityRoles } from '@/app/lib/db/schema';
+import { rolesGrantGlobalAdmin, rolesGrantScopedAdmin } from './admin-scope';
 
-export type AdminCheck = { authenticated: false } | { authenticated: true; userId: string; isAdmin: boolean };
+export type AdminCheck =
+  | { authenticated: false }
+  | { authenticated: true; userId: string; isAdmin: boolean; boardScopedOnly: boolean };
 
 export async function checkAdmin(): Promise<AdminCheck> {
   const session = await getServerSession(authOptions);
   const userId = session?.user?.id;
   if (!userId) return { authenticated: false };
 
-  const rows = await getDb()
-    .select({ id: communityRoles.id })
+  // Every admin row, not just the first: a board-scoped row and a global row
+  // are both `role = 'admin'`, and only the scope tells them apart.
+  const adminRoles = await getDb()
+    .select({ role: communityRoles.role, boardType: communityRoles.boardType })
     .from(communityRoles)
-    .where(and(eq(communityRoles.userId, userId), eq(communityRoles.role, 'admin')))
-    .limit(1);
+    .where(and(eq(communityRoles.userId, userId), eq(communityRoles.role, 'admin')));
 
-  return { authenticated: true, userId, isAdmin: rows.length > 0 };
+  const isAdmin = rolesGrantGlobalAdmin(adminRoles);
+
+  return {
+    authenticated: true,
+    userId,
+    isAdmin,
+    boardScopedOnly: !isAdmin && rolesGrantScopedAdmin(adminRoles),
+  };
 }


### PR DESCRIPTION
## Summary

`checkAdmin()` matched any `community_roles` row with `role = 'admin'` and never looked at `board_type`. Every resolver behind `/admin` calls `requireAdmin(ctx)` / `requireAdminOrLeader(ctx)` with no board type, and those only accept a globally-scoped admin. So an admin scoped to a single board type (say `kilter`) got fully-rendered admin pages where every button came back with "Admin role required for this operation", and no explanation why.

This makes the web gate mean what the backend already enforces: global admin.

- New `packages/web/app/lib/admin/admin-scope.ts` holds the two predicates (`rolesGrantGlobalAdmin`, `rolesGrantScopedAdmin`) so the server pages and the client hub share one definition. No `server-only` import, so it is unit-testable.
- `checkAdmin()` now selects `role` + `boardType` for all admin rows (dropping `.limit(1)`, since a scoped row and a global row are both `role = 'admin'`) and returns `boardScopedOnly` alongside `isAdmin`.
- `/admin`, `/admin/retention`, `/admin/gym-claims`, `/admin/feedback` and `/admin/gym-duplicates` show a new denial message when the caller is a board-scoped admin instead of a dead page. Plain non-admins keep the existing copy.
- The `/admin` hub's duplicated `isGlobalAdmin` state from #4230 is gone — the page-level `isAdmin` now means the same thing, so the Gyms tab gate collapses into it.
- Backend behaviour is unchanged (it was already correct); it gets a regression test pinning that `requireAdmin(ctx)` rejects a board-scoped admin, which is the contract the web gate mirrors.

**This tightens access on purpose.** A board-scoped admin loses `/admin` entirely. Nothing that used to work stops working — every action on those pages already failed server-side — but the pages themselves are no longer reachable, by design.

New i18n key `auth.boardScopedNoAccess` added to all four locales (en-US, es, fr, de), following the Spanish/French/German glossaries.

Closes #4232

## Release Notes

- Admin access scoped to a single board no longer opens the site-wide admin tools; those pages now say plainly that they need full admin access instead of loading a page where nothing works.

## Test plan

- `vp run typecheck:web`, `vp run typecheck:backend` — pass.
- `vp run test:web` — pass, including the new `packages/web/app/lib/admin/__tests__/admin-scope.test.ts` (global admin, board-scoped admin, both rows held, non-admin global roles, missing `boardType`, empty list) and `check-admin.test.ts`, added in adversarial review: it mocks the session and the roles query so the board-scoped case asserts `isAdmin: false` / `boardScopedOnly: true` on `checkAdmin()` itself, and pins that the query reads every admin row instead of `.limit(1)`. Reverting `check-admin.ts` to its pre-fix body turns those five cases red on the assertions, not on a missing mock.
- `vp test run --project backend social/__tests__/roles` — 5 pass, including the new board-scoped-admin rejection case. The full backend suite had 2 files failing (`integration.test.ts` and one other) from the known shared-port collision — `ss -ltnp` shows 8082 and 8084 held by another worktree's dev server — not from this change.
- `vp run check:i18n` and `vp run check:i18n:orphans` — clean.
- `vp check` reports pre-existing lint errors across ~90 untouched files (aurora-sync, db, mobile, backend tests); none in the files this PR touches, and the pre-commit hook passed on the staged set.
- Manual QA not run (no dev server started in this pass). Flows to exercise are written up in `.boardsesh/qa-notes.md`: grant a test user `admin` scoped to Kilter, confirm all five admin URLs show the new copy in every locale, and re-verify a global admin still gets all three hub tabs including Gyms plus working grant/revoke and gym-setting toggles.

