### PR TITLE
fix(mobile): scope add-to-playlist picker to the climb's board

### DIFF
--- a/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
+++ b/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
@@ -28,7 +28,7 @@ import { usePlaylistsContext, type Playlist } from '../../providers/playlists-pr
 import { useTheme } from '../../providers/theme-provider';
 import { useToast } from '../../providers/toast-provider';
 import { reportHandledError } from '../../lib/error-reporting';
-import { sortPlaylistsByName } from '../../lib/sort-filter-playlists';
+import { filterPlaylistsByBoard, sortPlaylistsByName } from '../../lib/sort-filter-playlists';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { borderRadius, spacing } from '../../theme/tokens';
 import { PLAYLIST_COLORS, normalizePlaylistColor } from './playlist-colors';
@@ -206,7 +206,13 @@ export function InlinePlaylistPicker({
     [showToast],
   );
 
-  const sortedPlaylists = useMemo(() => sortPlaylistsByName(playlists), [playlists]);
+  // Scope the "add to playlist" list to the climb's own board+layout — the
+  // provider's `playlists` spans every board the user has playlists on, and
+  // adding a climb to a wrong-board playlist isn't guarded server-side (#4224).
+  const sortedPlaylists = useMemo(
+    () => sortPlaylistsByName(filterPlaylistsByBoard(playlists, boardName, layoutId)),
+    [playlists, boardName, layoutId],
+  );
 
   // Write a membership set to the cache and mirror it into the shared chip store
   // (so climb-list playlist chips reflect the change without a refetch).

--- a/packages/mobile/src/components/playlist/__tests__/InlinePlaylistPicker.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/InlinePlaylistPicker.test.tsx
@@ -241,6 +241,21 @@ describe('InlinePlaylistPicker', () => {
     expect(getByLabelText('banana').getAttribute('data-hint')).toBe('actions.playlist.toast.added');
   });
 
+  // #4224: the provider's `playlists` spans every board the user has
+  // playlists on; the picker (default props: boardName="kilter", layoutId=1)
+  // must only offer playlists for the climb's own board+layout.
+  it('never renders a playlist from a different board or layout as a row', () => {
+    playlistContext.playlists = [
+      makePlaylist('p-kilter', 'Kilter warmups'),
+      { ...basePlaylist, id: 'p-tension', uuid: 'p-tension', name: 'Tension crimps', boardType: 'tension' },
+      { ...basePlaylist, id: 'p-other-layout', uuid: 'p-other-layout', name: 'Other layout', layoutId: 2 },
+    ];
+    const { getByLabelText, queryByLabelText } = renderPicker();
+    expect(getByLabelText('Kilter warmups')).not.toBeNull();
+    expect(queryByLabelText('Tension crimps')).toBeNull();
+    expect(queryByLabelText('Other layout')).toBeNull();
+  });
+
   it('adds the climb when tapping a non-member row (optimistic + store sync)', async () => {
     playlistContext.playlists = [makePlaylist('p-1', 'Hard Crimps')];
     qstate.data = [];

--- a/packages/mobile/src/components/playlist/__tests__/InlinePlaylistPicker.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/InlinePlaylistPicker.test.tsx
@@ -256,6 +256,26 @@ describe('InlinePlaylistPicker', () => {
     expect(queryByLabelText('Other layout')).toBeNull();
   });
 
+  // A layout-less playlist (Aurora/Kilter-synced circuit) belongs to the whole
+  // board — the backend's own board-scoped queries match `layout_id IS NULL`,
+  // so the picker keeps offering it rather than hiding the climber's circuits.
+  it('still offers a layout-less playlist on the matching board', () => {
+    playlistContext.playlists = [
+      { ...basePlaylist, id: 'p-circuit', uuid: 'p-circuit', name: 'Aurora circuit', layoutId: null },
+      {
+        ...basePlaylist,
+        id: 'p-other-board-circuit',
+        uuid: 'p-other-board-circuit',
+        name: 'Tension circuit',
+        boardType: 'tension',
+        layoutId: null,
+      },
+    ];
+    const { getByLabelText, queryByLabelText } = renderPicker();
+    expect(getByLabelText('Aurora circuit')).not.toBeNull();
+    expect(queryByLabelText('Tension circuit')).toBeNull();
+  });
+
   it('adds the climb when tapping a non-member row (optimistic + store sync)', async () => {
     playlistContext.playlists = [makePlaylist('p-1', 'Hard Crimps')];
     qstate.data = [];

--- a/packages/mobile/src/lib/__tests__/sort-filter-playlists.test.ts
+++ b/packages/mobile/src/lib/__tests__/sort-filter-playlists.test.ts
@@ -79,8 +79,16 @@ describe('filterPlaylistsByBoard', () => {
     expect(filterPlaylistsByBoard(input, 'kilter', 9)).toEqual([]);
   });
 
-  it('drops playlists with a null layoutId (Aurora-synced circuits)', () => {
+  // Mirrors the backend rule (`layout_id = $layout OR layout_id IS NULL`) that
+  // userPlaylists/allUserPlaylists apply: a layout-less playlist belongs to the
+  // whole board, so it stays an add target on every layout of that board.
+  it('keeps playlists with a null layoutId (Aurora/Kilter-synced circuits)', () => {
     const input = [playlist('Aurora circuit', { boardType: 'kilter', layoutId: null })];
+    expect(names(filterPlaylistsByBoard(input, 'kilter', 9))).toEqual(['Aurora circuit']);
+  });
+
+  it('still drops a null-layout playlist belonging to another board', () => {
+    const input = [playlist('Tension circuit', { boardType: 'tension', layoutId: null })];
     expect(filterPlaylistsByBoard(input, 'kilter', 9)).toEqual([]);
   });
 

--- a/packages/mobile/src/lib/__tests__/sort-filter-playlists.test.ts
+++ b/packages/mobile/src/lib/__tests__/sort-filter-playlists.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import type { Playlist } from '@boardsesh/graphql/operations/playlists';
-import { sortAndFilterPlaylists, sortPlaylistsByName } from '../sort-filter-playlists';
+import { filterPlaylistsByBoard, sortAndFilterPlaylists, sortPlaylistsByName } from '../sort-filter-playlists';
 
 // A minimal Playlist factory — the helper only reads `name`, so the rest is
 // padding to satisfy the type.
-function playlist(name: string): Playlist {
+function playlist(name: string, overrides: Partial<Playlist> = {}): Playlist {
   return {
     id: name,
     uuid: name,
@@ -18,6 +18,7 @@ function playlist(name: string): Playlist {
     followerCount: 0,
     isFollowedByMe: false,
     isPinnedByMe: false,
+    ...overrides,
   } as Playlist;
 }
 
@@ -59,5 +60,33 @@ describe('sortAndFilterPlaylists', () => {
   it('returns an empty array when nothing matches', () => {
     const input = [playlist('Projects'), playlist('Warmups')];
     expect(sortAndFilterPlaylists(input, 'zzz')).toEqual([]);
+  });
+});
+
+describe('filterPlaylistsByBoard', () => {
+  it('keeps playlists matching both boardType and layoutId', () => {
+    const input = [playlist('Kilter 9', { boardType: 'kilter', layoutId: 9 })];
+    expect(names(filterPlaylistsByBoard(input, 'kilter', 9))).toEqual(['Kilter 9']);
+  });
+
+  it('drops playlists with a mismatched boardType', () => {
+    const input = [playlist('Tension climbs', { boardType: 'tension', layoutId: 9 })];
+    expect(filterPlaylistsByBoard(input, 'kilter', 9)).toEqual([]);
+  });
+
+  it('drops playlists with a mismatched layoutId', () => {
+    const input = [playlist('Other layout', { boardType: 'kilter', layoutId: 8 })];
+    expect(filterPlaylistsByBoard(input, 'kilter', 9)).toEqual([]);
+  });
+
+  it('drops playlists with a null layoutId (Aurora-synced circuits)', () => {
+    const input = [playlist('Aurora circuit', { boardType: 'kilter', layoutId: null })];
+    expect(filterPlaylistsByBoard(input, 'kilter', 9)).toEqual([]);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [playlist('a', { boardType: 'tension' }), playlist('b', { boardType: 'kilter', layoutId: 1 })];
+    filterPlaylistsByBoard(input, 'kilter', 1);
+    expect(names(input)).toEqual(['a', 'b']);
   });
 });

--- a/packages/mobile/src/lib/sort-filter-playlists.ts
+++ b/packages/mobile/src/lib/sort-filter-playlists.ts
@@ -9,15 +9,23 @@ export function sortPlaylistsByName(playlists: Playlist[]): Playlist[] {
 }
 
 /**
- * Keep only playlists that belong to the given board+layout. Mirrors the
- * board+layout equality rule `canAddClimbToBoard` uses (board-config's
- * board-compatibility.ts): both fields must match exactly. `layoutId` is
- * nullable on `Playlist` for Aurora-synced circuits, whose board identity is
- * unverifiable — a null `layoutId` never matches, so those circuits are
- * correctly excluded from add-target lists rather than shown for every board.
+ * Keep only playlists that belong to the given board+layout, using the same rule
+ * the backend already applies for board-scoped playlist lists —
+ * `boardType = $board AND (layout_id = $layout OR layout_id IS NULL)` in
+ * `userPlaylists` / `allUserPlaylists`
+ * (packages/backend/src/graphql/resolvers/playlists/queries/user-playlists.ts).
+ *
+ * `layoutId` is nullable on `Playlist` by design: a playlist is scoped to a
+ * board and only *optionally* to a layout (see packages/db schema), which is how
+ * Aurora- and Kilter-synced circuits arrive. Those are legitimate add targets on
+ * every layout of their board, and the Discover "My playlists" list already
+ * shows them — so a null `layoutId` matches here too, rather than silently
+ * dropping a climber's circuits from the add-to-playlist picker.
  */
 export function filterPlaylistsByBoard(playlists: Playlist[], boardName: string, layoutId: number): Playlist[] {
-  return playlists.filter((playlist) => playlist.boardType === boardName && playlist.layoutId === layoutId);
+  return playlists.filter(
+    (playlist) => playlist.boardType === boardName && (playlist.layoutId == null || playlist.layoutId === layoutId),
+  );
 }
 
 /**

--- a/packages/mobile/src/lib/sort-filter-playlists.ts
+++ b/packages/mobile/src/lib/sort-filter-playlists.ts
@@ -9,6 +9,18 @@ export function sortPlaylistsByName(playlists: Playlist[]): Playlist[] {
 }
 
 /**
+ * Keep only playlists that belong to the given board+layout. Mirrors the
+ * board+layout equality rule `canAddClimbToBoard` uses (board-config's
+ * board-compatibility.ts): both fields must match exactly. `layoutId` is
+ * nullable on `Playlist` for Aurora-synced circuits, whose board identity is
+ * unverifiable — a null `layoutId` never matches, so those circuits are
+ * correctly excluded from add-target lists rather than shown for every board.
+ */
+export function filterPlaylistsByBoard(playlists: Playlist[], boardName: string, layoutId: number): Playlist[] {
+  return playlists.filter((playlist) => playlist.boardType === boardName && playlist.layoutId === layoutId);
+}
+
+/**
  * Sort playlists alphabetically by name, then keep only those whose name
  * contains the (trimmed, case-insensitive) query.
  */


### PR DESCRIPTION
## Summary

Fixes the mobile "Add to playlist" picker (`InlinePlaylistPicker`, shared by
`AddToPlaylistSheet` and the `ClimbReactionMenu` long-press overlay) listing
every playlist the user owns across **all** boards, unfiltered — instead of
scoping to the climb's own board+layout the way Discover's "My playlists"
list already does.

Root cause: `InlinePlaylistPicker` rendered `sortPlaylistsByName(playlists)`
straight from `PlaylistsContext`, which fetches every playlist with no
board/layout filter, even though the component already receives
`boardName`/`layoutId` props (previously used only for the membership-query
cache key and to scope newly-created playlists).

Fix: a new pure helper, `filterPlaylistsByBoard(playlists, boardName,
layoutId)` in `packages/mobile/src/lib/sort-filter-playlists.ts`, filters the
list down to the climb's own board before sorting, using exactly the rule the
backend already applies to board-scoped playlist lists —
`board_type = $board AND (layout_id = $layout OR layout_id IS NULL)` in
`userPlaylists` / `allUserPlaylists`
(`packages/backend/src/graphql/resolvers/playlists/queries/user-playlists.ts`).

`layoutId` is nullable on a playlist by design: a playlist is scoped to a board
and only *optionally* to a layout, which is how Aurora- and Kilter-synced
circuits arrive. Those stay valid add targets on every layout of their own
board (and never on another board), so the picker now offers the same set
Discover's "My playlists" already does.

Both the `AddToPlaylistSheet` swipe/ellipsis path and the `ClimbReactionMenu`
long-press overlay route through the same `InlinePlaylistPicker`, so this one
change covers both surfaces.

Out of scope (see `.boardsesh/qa-notes.md` for the full reasoning):

- Web's identical unfiltered behavior — `packages/web`'s climbing UI is
  deprecated (issue #3122), no fixes land there.
- A backend guard rejecting `addClimbToPlaylist` for a board mismatch — the
  picker no longer offers the mismatched playlist as a target, which is
  sufficient for this bug; a backend guard is a separate, riskier change.

Closes #4224

## Release Notes

- Add to playlist now only shows playlists for the board you're climbing on

## Test plan

- `vp run typecheck:mobile` — pass
- `vp run test:mobile` — pass, including new unit tests for
  `filterPlaylistsByBoard` (match, boardType mismatch, layoutId mismatch,
  layout-less playlist kept on its own board, layout-less playlist dropped on
  another board) and `InlinePlaylistPicker` tests asserting a
  different-board/layout playlist never renders as a row while a layout-less
  playlist on the matching board still does
- `vp run check:mobile-bundle` — pass (android + ios bundles export OK)
- `vp check` on the touched files — 0 errors, 1 pre-existing warning in
  untouched code in `InlinePlaylistPicker.test.tsx` (verified present before
  this change too, unrelated to this diff)
- Manual QA plan written to `.boardsesh/qa-notes.md` (not run — no dev server
  started per workflow instructions): cross-board verification via both the
  `AddToPlaylistSheet` and `ClimbReactionMenu` paths, toggle/create still
  work, empty-state and layout-less-circuit behaviour
