### PR TITLE
fix(backend): degrade board and gym location writes gracefully without PostGIS

### DIFF
--- a/packages/backend/src/__tests__/location-geography-degradation.test.ts
+++ b/packages/backend/src/__tests__/location-geography-degradation.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeEach } from 'vite-plus/test';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vite-plus/test';
 import { sql } from 'drizzle-orm';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { db } from '../db/client';
+import { logger } from '../utils/logger';
 import { socialBoardMutations } from '../graphql/resolvers/social/boards';
 import { socialGymMutations } from '../graphql/resolvers/social/gyms';
 import { resetAllRateLimits } from '../utils/rate-limiter';
@@ -13,15 +14,16 @@ import { resetAllRateLimits } from '../utils/rate-limiter';
  * DB is a plain `postgres` image and `schema-sql.ts` declares `user_boards` and
  * `gyms` with latitude/longitude but no `location` column — it IS the
  * no-PostGIS deployment #4218 reports. If PostGIS is ever added to the test
- * image, every case here passes vacuously and this file must be rewritten to
- * drop the column (or stub the write) explicitly.
+ * image, every case here would pass vacuously — so the first case below asserts
+ * the premise and fails loudly instead of going quietly green.
  *
  * On main, updateBoard/updateGym/createGym issued unguarded
  * `UPDATE ... SET location = ST_MakePoint(...)` statements, so saving an edit
  * with coordinates threw (42704 `type "geography" does not exist` here, 42703
  * undefined-column where the type exists but the column doesn't) after the row
  * had already been updated: the user saw a failure for a save that had landed.
- * Six of the seven cases below fail against main.
+ * Every case below except the premise probe and `createBoard` (already guarded)
+ * fails against main.
  */
 
 const OWNER = 'geo-degrade-owner';
@@ -72,6 +74,18 @@ async function storedCoordinates(table: 'user_boards' | 'gyms', uuid: string): P
   };
 }
 
+type GeographyWarning = { table: string; operation: string; code: string | undefined };
+
+// Reduce logger.warn calls to the geography-sync ones, dropping the message and
+// the raw driver text so the assertion reads as the contract, not the wording.
+function warnedGeographyFailures(warnSpy: { mock: { calls: unknown[][] } }): GeographyWarning[] {
+  return warnSpy.mock.calls.flatMap((call) => {
+    const meta = call[1] as { table?: string; operation?: string; code?: string } | undefined;
+    if (meta?.table == null || meta.operation == null) return [];
+    return [{ table: meta.table, operation: meta.operation, code: meta.code }];
+  });
+}
+
 beforeEach(async () => {
   resetAllRateLimits();
   await db.execute(sql`
@@ -82,7 +96,33 @@ beforeEach(async () => {
   await insertUser(OWNER);
 });
 
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe('location geography writes degrade without PostGIS', () => {
+  it('runs against a database that really has no location column', async () => {
+    const tablesWithColumn = async (columnName: string) => {
+      const rows = await db.execute(sql`
+        SELECT table_name FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name IN ('user_boards', 'gyms')
+          AND column_name = ${columnName}
+      `);
+      return Array.from(rows as Iterable<{ table_name: string }>)
+        .map((row) => row.table_name)
+        .sort();
+    };
+
+    // The latitude probe proves the query shape finds columns that DO exist, so
+    // the empty `location` result below is a real absence rather than a query
+    // that silently returns nothing.
+    expect(await tablesWithColumn('latitude')).toEqual(['gyms', 'user_boards']);
+    // If this ever fails, the test DB grew PostGIS and every case below is now
+    // vacuous — drop the column here (or stub the write) before trusting them.
+    expect(await tablesWithColumn('location')).toEqual([]);
+  });
+
   it('updateBoard saves new coordinates instead of failing on the missing column', async () => {
     const board = await createBoard({ name: 'Klimmuur MoonBoard' });
 
@@ -134,5 +174,35 @@ describe('location geography writes degrade without PostGIS', () => {
     const board = await createBoard({ name: 'Klimmuur MoonBoard', latitude: 47.0, longitude: 8.0 });
 
     expect(await storedCoordinates('user_boards', board.uuid)).toEqual({ latitude: 47.0, longitude: 8.0 });
+  });
+
+  // The cases above only prove the mutations stop throwing — they would also
+  // pass if the geography writes were deleted outright. These two pin the
+  // guard itself: the write is still attempted, and the failure is warned with
+  // the SQLSTATE this database really returns.
+  it('warns with the ST_MakePoint SQLSTATE instead of throwing', async () => {
+    const board = await createBoard({ name: 'Klimmuur MoonBoard' });
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+
+    await updateBoard({ boardUuid: board.uuid, latitude: 47.0, longitude: 8.0 });
+
+    expect(warnedGeographyFailures(warnSpy)).toContainEqual({
+      table: 'user_boards',
+      operation: 'updateBoard',
+      code: '42704', // type "geography" does not exist
+    });
+  });
+
+  it('warns with the missing-column SQLSTATE when clearing coordinates', async () => {
+    const gym = await createGym({ name: 'Boulder Space', latitude: 47.0, longitude: 8.0 });
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+
+    await updateGym({ gymUuid: gym.uuid, latitude: null, longitude: null });
+
+    expect(warnedGeographyFailures(warnSpy)).toContainEqual({
+      table: 'gyms',
+      operation: 'updateGym',
+      code: '42703', // column "location" does not exist
+    });
   });
 });

--- a/packages/backend/src/__tests__/location-geography-degradation.test.ts
+++ b/packages/backend/src/__tests__/location-geography-degradation.test.ts
@@ -21,7 +21,7 @@ import { resetAllRateLimits } from '../utils/rate-limiter';
  * with coordinates threw (42704 `type "geography" does not exist` here, 42703
  * undefined-column where the type exists but the column doesn't) after the row
  * had already been updated: the user saw a failure for a save that had landed.
- * Five of the six cases below fail against main.
+ * Six of the seven cases below fail against main.
  */
 
 const OWNER = 'geo-degrade-owner';
@@ -120,6 +120,14 @@ describe('location geography writes degrade without PostGIS', () => {
     await updateGym({ gymUuid: gym.uuid, latitude: 47.1, longitude: 8.1 });
 
     expect(await storedCoordinates('gyms', gym.uuid)).toEqual({ latitude: 47.1, longitude: 8.1 });
+  });
+
+  it('updateGym clears coordinates without failing', async () => {
+    const gym = await createGym({ name: 'Boulder Space', latitude: 47.0, longitude: 8.0 });
+
+    await updateGym({ gymUuid: gym.uuid, latitude: null, longitude: null });
+
+    expect(await storedCoordinates('gyms', gym.uuid)).toEqual({ latitude: null, longitude: null });
   });
 
   it('createBoard with coordinates still resolves after the refactor', async () => {

--- a/packages/backend/src/__tests__/location-geography-degradation.test.ts
+++ b/packages/backend/src/__tests__/location-geography-degradation.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { socialBoardMutations } from '../graphql/resolvers/social/boards';
+import { socialGymMutations } from '../graphql/resolvers/social/gyms';
+import { resetAllRateLimits } from '../utils/rate-limiter';
+
+/**
+ * Real-DB coverage for board/gym mutations on a database WITHOUT PostGIS.
+ *
+ * IMPORTANT: this file only tests anything because the per-worker backend test
+ * DB is a plain `postgres` image and `schema-sql.ts` declares `user_boards` and
+ * `gyms` with latitude/longitude but no `location` column — it IS the
+ * no-PostGIS deployment #4218 reports. If PostGIS is ever added to the test
+ * image, every case here passes vacuously and this file must be rewritten to
+ * drop the column (or stub the write) explicitly.
+ *
+ * On main, updateBoard/updateGym/createGym issued unguarded
+ * `UPDATE ... SET location = ST_MakePoint(...)` statements, so saving an edit
+ * with coordinates threw (42704 `type "geography" does not exist` here, 42703
+ * undefined-column where the type exists but the column doesn't) after the row
+ * had already been updated: the user saw a failure for a save that had landed.
+ * Five of the six cases below fail against main.
+ */
+
+const OWNER = 'geo-degrade-owner';
+
+const BOARD_CONFIG = { boardType: 'moonboard', layoutId: 3, sizeId: 1, setIds: '5,6,7' };
+
+let connectionCounter = 0;
+const authCtx = (userId: string): ConnectionContext =>
+  ({ connectionId: `conn-${userId}-${connectionCounter++}`, isAuthenticated: true, userId }) as ConnectionContext;
+
+const insertUser = (id: string) =>
+  db.execute(sql`
+    INSERT INTO "users" (id, email, name, created_at, updated_at)
+    VALUES (${id}, ${id + '@test.com'}, ${'User ' + id}, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `);
+
+type BoardRow = { uuid: string; name: string };
+type GymRow = { uuid: string; name: string };
+
+const createBoard = (input: Record<string, unknown>) =>
+  socialBoardMutations.createBoard(
+    null,
+    { input: { ...BOARD_CONFIG, name: 'A board', ...input } },
+    authCtx(OWNER),
+  ) as Promise<BoardRow>;
+
+const updateBoard = (input: Record<string, unknown>) =>
+  socialBoardMutations.updateBoard(null, { input }, authCtx(OWNER)) as Promise<BoardRow>;
+
+const createGym = (input: Record<string, unknown>) =>
+  socialGymMutations.createGym(null, { input: { name: 'A gym', ...input } }, authCtx(OWNER)) as Promise<GymRow>;
+
+const updateGym = (input: Record<string, unknown>) =>
+  socialGymMutations.updateGym(null, { input }, authCtx(OWNER)) as Promise<GymRow>;
+
+type Coordinates = { latitude: number | null; longitude: number | null };
+
+async function storedCoordinates(table: 'user_boards' | 'gyms', uuid: string): Promise<Coordinates> {
+  const result =
+    table === 'user_boards'
+      ? await db.execute(sql`SELECT latitude, longitude FROM user_boards WHERE uuid = ${uuid}`)
+      : await db.execute(sql`SELECT latitude, longitude FROM gyms WHERE uuid = ${uuid}`);
+  const row = Array.from(result as Iterable<Coordinates>)[0];
+  return {
+    latitude: row.latitude == null ? null : Number(row.latitude),
+    longitude: row.longitude == null ? null : Number(row.longitude),
+  };
+}
+
+beforeEach(async () => {
+  resetAllRateLimits();
+  await db.execute(sql`
+    TRUNCATE TABLE
+      "community_roles", "gym_members", "gym_follows", "location_sync_gym_sources", "user_boards", "gyms"
+    RESTART IDENTITY CASCADE
+  `);
+  await insertUser(OWNER);
+});
+
+describe('location geography writes degrade without PostGIS', () => {
+  it('updateBoard saves new coordinates instead of failing on the missing column', async () => {
+    const board = await createBoard({ name: 'Klimmuur MoonBoard' });
+
+    const updated = await updateBoard({ boardUuid: board.uuid, latitude: 47.0, longitude: 8.0 });
+
+    expect(updated.uuid).toBe(board.uuid);
+    expect(await storedCoordinates('user_boards', board.uuid)).toEqual({ latitude: 47.0, longitude: 8.0 });
+  });
+
+  it('updateBoard clears coordinates without failing', async () => {
+    const board = await createBoard({ name: 'Klimmuur MoonBoard', latitude: 47.0, longitude: 8.0 });
+
+    await updateBoard({ boardUuid: board.uuid, latitude: null, longitude: null });
+
+    expect(await storedCoordinates('user_boards', board.uuid)).toEqual({ latitude: null, longitude: null });
+  });
+
+  it('updateBoard changing only longitude keeps the stored latitude', async () => {
+    const board = await createBoard({ name: 'Klimmuur MoonBoard', latitude: 47.0, longitude: 8.0 });
+
+    await updateBoard({ boardUuid: board.uuid, longitude: 8.5 });
+
+    expect(await storedCoordinates('user_boards', board.uuid)).toEqual({ latitude: 47.0, longitude: 8.5 });
+  });
+
+  it('createGym with coordinates resolves', async () => {
+    const gym = await createGym({ name: 'Boulder Space', latitude: 47.0, longitude: 8.0 });
+
+    expect(await storedCoordinates('gyms', gym.uuid)).toEqual({ latitude: 47.0, longitude: 8.0 });
+  });
+
+  it('updateGym saves new coordinates instead of failing', async () => {
+    const gym = await createGym({ name: 'Boulder Space' });
+
+    await updateGym({ gymUuid: gym.uuid, latitude: 47.1, longitude: 8.1 });
+
+    expect(await storedCoordinates('gyms', gym.uuid)).toEqual({ latitude: 47.1, longitude: 8.1 });
+  });
+
+  it('createBoard with coordinates still resolves after the refactor', async () => {
+    const board = await createBoard({ name: 'Klimmuur MoonBoard', latitude: 47.0, longitude: 8.0 });
+
+    expect(await storedCoordinates('user_boards', board.uuid)).toEqual({ latitude: 47.0, longitude: 8.0 });
+  });
+});

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -24,6 +24,7 @@ import { generateUniqueGymSlug, requireBoardGymLinkAccess, userCanEditGym } from
 import { resolveAutoGymForBoard } from './gym-matching';
 import { findBlockingDuplicate, type BoardLocation } from './board-duplicates';
 import { assertBoardCapNotReached } from './board-limits';
+import { syncLocationGeography } from './location-geography';
 import { getUserCommunityRoles, hasAdminOrLeader, rolesGrantAdminOrLeader } from './roles';
 import {
   SYSTEM_BOARD_OWNER_ID,
@@ -1884,39 +1885,29 @@ export const socialBoardMutations = {
       }
     }
 
-    // Populate the PostGIS `location` columns. These are denormalizations used by
-    // proximity search, and they run AFTER the transaction, each guarded on its
-    // own. Inside the transaction a PostGIS failure (the column is absent in the
-    // backend test DB, and the extension can be missing anywhere) rolled the
-    // whole thing back and silently cost the user their gym; out here the worst
-    // case is a null `location` that a backfill can repair. The board id is
-    // logged so that backfill is a one-liner.
+    // Populate the PostGIS `location` columns. These run AFTER the transaction,
+    // each guarded on its own inside syncLocationGeography — see that helper for
+    // why a failure here must never fail the mutation.
     if (incomingLocation.latitude != null && incomingLocation.longitude != null) {
       const { latitude, longitude } = incomingLocation;
 
       if (mintedGymId != null) {
-        try {
-          await db.execute(
-            sql`UPDATE gyms SET location = ST_MakePoint(${longitude}, ${latitude})::geography WHERE id = ${mintedGymId}`,
-          );
-        } catch (error) {
-          logger.warn('createBoard: failed to set gym location geography; leaving it null', {
-            gymId: mintedGymId,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-      }
-
-      try {
-        await db.execute(
-          sql`UPDATE user_boards SET location = ST_MakePoint(${longitude}, ${latitude})::geography WHERE id = ${board.id}`,
-        );
-      } catch (error) {
-        logger.warn('createBoard: failed to set board location geography; leaving it null', {
-          boardId: board.id,
-          error: error instanceof Error ? error.message : String(error),
+        await syncLocationGeography({
+          table: 'gyms',
+          id: mintedGymId,
+          latitude,
+          longitude,
+          operation: 'createBoard',
         });
       }
+
+      await syncLocationGeography({
+        table: 'user_boards',
+        id: board.id,
+        latitude,
+        longitude,
+        operation: 'createBoard',
+      });
     }
 
     return enrichBoard(board, userId);
@@ -2136,17 +2127,15 @@ export const socialBoardMutations = {
       }
     }
 
-    // Update PostGIS location column
+    // Update PostGIS location column (guarded — see syncLocationGeography)
     if (validatedInput.latitude !== undefined || validatedInput.longitude !== undefined) {
-      const lat = validatedInput.latitude ?? updated.latitude;
-      const lon = validatedInput.longitude ?? updated.longitude;
-      if (lat != null && lon != null) {
-        await db.execute(
-          sql`UPDATE user_boards SET location = ST_MakePoint(${lon}, ${lat})::geography WHERE id = ${updated.id}`,
-        );
-      } else {
-        await db.execute(sql`UPDATE user_boards SET location = NULL WHERE id = ${updated.id}`);
-      }
+      await syncLocationGeography({
+        table: 'user_boards',
+        id: updated.id,
+        latitude: validatedInput.latitude ?? updated.latitude,
+        longitude: validatedInput.longitude ?? updated.longitude,
+        operation: 'updateBoard',
+      });
     }
 
     return enrichBoard(updated, userId);

--- a/packages/backend/src/graphql/resolvers/social/gyms.ts
+++ b/packages/backend/src/graphql/resolvers/social/gyms.ts
@@ -24,6 +24,7 @@ import {
 import { distanceMeters } from '@boardsesh/db/queries';
 import { logger } from '../../../utils/logger';
 import { PROXIMITY_MATCH_RADIUS_METERS } from './gym-matching';
+import { syncLocationGeography } from './location-geography';
 
 // ============================================
 // Helpers
@@ -959,11 +960,15 @@ export const socialGymMutations = {
       })
       .returning();
 
-    // Populate PostGIS location column if lat/lon provided
+    // Populate PostGIS location column if lat/lon provided (guarded — see syncLocationGeography)
     if (validatedInput.latitude != null && validatedInput.longitude != null) {
-      await db.execute(
-        sql`UPDATE gyms SET location = ST_MakePoint(${validatedInput.longitude}, ${validatedInput.latitude})::geography WHERE id = ${gym.id}`,
-      );
+      await syncLocationGeography({
+        table: 'gyms',
+        id: gym.id,
+        latitude: validatedInput.latitude,
+        longitude: validatedInput.longitude,
+        operation: 'createGym',
+      });
     }
 
     // Optionally link a board
@@ -1039,17 +1044,15 @@ export const socialGymMutations = {
 
     const [updated] = await db.update(dbSchema.gyms).set(updateValues).where(eq(dbSchema.gyms.id, gym.id)).returning();
 
-    // Update PostGIS location column
+    // Update PostGIS location column (guarded — see syncLocationGeography)
     if (validatedInput.latitude !== undefined || validatedInput.longitude !== undefined) {
-      const lat = validatedInput.latitude ?? updated.latitude;
-      const lon = validatedInput.longitude ?? updated.longitude;
-      if (lat != null && lon != null) {
-        await db.execute(
-          sql`UPDATE gyms SET location = ST_MakePoint(${lon}, ${lat})::geography WHERE id = ${updated.id}`,
-        );
-      } else {
-        await db.execute(sql`UPDATE gyms SET location = NULL WHERE id = ${updated.id}`);
-      }
+      await syncLocationGeography({
+        table: 'gyms',
+        id: updated.id,
+        latitude: validatedInput.latitude ?? updated.latitude,
+        longitude: validatedInput.longitude ?? updated.longitude,
+        operation: 'updateGym',
+      });
     }
 
     return enrichGym(updated, userId);

--- a/packages/backend/src/graphql/resolvers/social/location-geography.ts
+++ b/packages/backend/src/graphql/resolvers/social/location-geography.ts
@@ -1,0 +1,67 @@
+import { sql } from 'drizzle-orm';
+import { db } from '../../../db/client';
+import { logger } from '../../../utils/logger';
+import { getPostgresErrorCode } from '../../../utils/postgres-errors';
+
+export type LocationGeographyTable = 'user_boards' | 'gyms';
+
+type SyncLocationGeographyArgs = {
+  table: LocationGeographyTable;
+  id: number;
+  latitude: number | null;
+  longitude: number | null;
+  /** Resolver name, for log correlation. */
+  operation: string;
+};
+
+/**
+ * Populate (or clear) the PostGIS `location` column for a gym or board row.
+ *
+ * These columns are denormalizations used by proximity search. The write runs
+ * outside the caller's transaction and never throws: inside a transaction a
+ * PostGIS failure (the column is absent in the backend test DB, and the
+ * extension can be missing on any self-hosted deployment) rolled the whole
+ * thing back and silently cost the user their gym. Out here the worst case is
+ * a null `location` that a backfill can repair — the row id is logged so that
+ * backfill is a one-liner.
+ *
+ * On a migrated PostGIS database this write is a backstop anyway: migration
+ * 0127 installs `gyms_set_location` / `user_boards_set_location` BEFORE INSERT
+ * OR UPDATE OF latitude, longitude triggers that already derive the geography
+ * from the lat/lng columns, so failing this statement is never load-bearing.
+ */
+export async function syncLocationGeography({
+  table,
+  id,
+  latitude,
+  longitude,
+  operation,
+}: SyncLocationGeographyArgs): Promise<void> {
+  const hasCoordinates = latitude != null && longitude != null;
+
+  try {
+    // The table name is never interpolated — each branch is a hard-coded
+    // statement so no caller can steer the SQL.
+    if (table === 'gyms') {
+      await db.execute(
+        hasCoordinates
+          ? sql`UPDATE gyms SET location = ST_MakePoint(${longitude}, ${latitude})::geography WHERE id = ${id}`
+          : sql`UPDATE gyms SET location = NULL WHERE id = ${id}`,
+      );
+    } else {
+      await db.execute(
+        hasCoordinates
+          ? sql`UPDATE user_boards SET location = ST_MakePoint(${longitude}, ${latitude})::geography WHERE id = ${id}`
+          : sql`UPDATE user_boards SET location = NULL WHERE id = ${id}`,
+      );
+    }
+  } catch (error) {
+    logger.warn('Failed to sync location geography; leaving the column as-is', {
+      table,
+      id,
+      operation,
+      code: getPostgresErrorCode(error),
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}


### PR DESCRIPTION
## Summary

`updateBoard` wrote the PostGIS `location` column with two bare
`db.execute(sql\`UPDATE user_boards SET location = ...\`)` statements and no
error handling, while `createBoard` right above it wrapped its two equivalent
writes in try/catch and carried on. On a database without PostGIS the
`updateBoard` writes throw and the whole edit fails — after the row has already
been updated, so the user is told their save failed when it landed.

`createGym` and `updateGym` had the identical unguarded pattern, so this fixes
all of them rather than leaving a duplicate follow-up: all six write sites now
go through one `syncLocationGeography({ table, id, latitude, longitude,
operation })` helper that logs the SQLSTATE via `getPostgresErrorCode` and
returns, matching `createBoard`'s existing warn-and-continue behaviour. The
table name is never interpolated — each branch is a hard-coded `sql` statement.

Why swallowing is safe: migration 0127 installs `gyms_set_location` /
`user_boards_set_location` BEFORE INSERT OR UPDATE OF latitude, longitude
triggers, so on a migrated PostGIS database the geography is already derived
from the lat/lng columns and these manual writes are a backstop.

One judgement call worth a reviewer's eye, flagged rather than blocked on: this
keeps the manual writes as a guarded backstop. The cleaner end state is deleting
them outright and relying on the 0127 triggers, but that is a bet on trigger
presence in production that I could not verify from this checkout.

Closes #4218

## Release Notes

- Editing a board's or gym's location saves cleanly on self-hosted setups without PostGIS, instead of erroring out on a save that already went through.

## Test plan

- New `packages/backend/src/__tests__/location-geography-degradation.test.ts`.
  The per-worker backend test DB is plain postgres with no `location` column, so
  it *is* the no-PostGIS deployment — no mocking. Covers updateBoard with
  coordinates, updateBoard clearing coordinates, updateBoard changing only
  longitude, createGym with coordinates, updateGym with coordinates, updateGym
  clearing coordinates, and createBoard with coordinates (guarding the existing
  behaviour the refactor must not regress). 6 of the 7 fail against main (42704
  `type "geography" does not exist` on the ST_MakePoint cast, 42703 `column
  "location" does not exist` on the clear-to-NULL path); all 7 pass here.
- Review pass added three more cases to that file. The seven above only prove
  the mutations stop throwing — they would pass just as well if the geography
  writes were deleted outright, and would go vacuously green if the test image
  ever grew PostGIS. So: a premise probe that looks up `latitude` (a column that
  does exist) before asserting `location` does not, and two cases that spy on
  `logger.warn` to pin the guard itself — 42704 on the ST_MakePoint cast,
  42703 on the clear-to-NULL path. CI backend suite: 726 passed, 0 failed.
- `vp run typecheck:backend` — clean.
- `vp check` — no findings in the touched files.
- `vp test run --project backend --reporter=agent` scoped to the new file plus
  the neighbouring suites that exercise these paths
  (update-board-duplicate-guard, create-board-duplicate-guard,
  find-similar-gyms-and-auto-gym, gym-branding-and-boards,
  board-gym-edit-authorization, board-gym-self-link): 7 files, 128 tests passed.
- No migration, no GraphQL schema change, no i18n keys, no mobile/web files, no
  Bluetooth code.


