### PR TITLE
feat(mobile): manage-gym shortcut after an auto-approved claim

### DIFF
--- a/packages/mobile/app/gyms/__tests__/edit.test.tsx
+++ b/packages/mobile/app/gyms/__tests__/edit.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { Gym } from '@boardsesh/shared-schema';
+
+type Children = { children?: ReactNode };
+type ButtonProps = { title: string; onPress: () => void };
+
+// Mutable per-test gym driving the mocked `useGym`, so a test can flip
+// `canClaim` the way an approved-claim refetch does.
+const state = vi.hoisted(() => ({
+  gym: {} as Gym,
+}));
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  View: ({ children }: Children) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('expo-router', () => ({
+  Stack: { Screen: () => null },
+  useRouter: () => ({ back: vi.fn(), push: vi.fn() }),
+  useLocalSearchParams: () => ({ gymUuid: 'gym-uuid-1' }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../../src/lib/graphql/hooks', () => ({
+  useGym: () => ({ data: state.gym, isLoading: false }),
+  useUpdateGym: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock('../../../src/providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('../../../src/providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { background: '#fff', label: '#000', secondaryLabel: '#666' },
+    brandColors: { primary: '#6D28D9' },
+  }),
+}));
+vi.mock('../../../src/hooks/use-stack-screen-options', () => ({ useStackScreenOptions: () => ({}) }));
+vi.mock('../../../src/lib/haptics', () => ({ hapticSelection: vi.fn() }));
+vi.mock('../../../src/theme/tokens', () => ({ spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 6: 24 } }));
+vi.mock('../../../src/theme/ios-colors', () => ({ iosSystemColors: { systemGray: '#8e8e93' } }));
+
+vi.mock('../../../src/components/Text', () => ({
+  Text: ({ children }: Children) => createElement('span', null, children),
+}));
+vi.mock('../../../src/components/Icon', () => ({ Icon: () => createElement('i') }));
+vi.mock('../../../src/components/Button', () => ({
+  Button: ({ title, onPress }: ButtonProps) => createElement('button', { onClick: onPress, type: 'button' }, title),
+}));
+vi.mock('../../../src/components/ActivityIndicator', () => ({ ActivityIndicator: () => createElement('div') }));
+vi.mock('../../../src/components/gym-directory/GymForm', () => ({
+  GymForm: ({ extraSections }: { extraSections?: ReactNode }) => createElement('div', null, extraSections),
+}));
+vi.mock('../../../src/components/gym-directory/GymWriteAccessSection', () => ({
+  GymWriteAccessSection: () => createElement('div'),
+}));
+// Stub the sheet down to a marker: this test only cares whether it stays mounted.
+vi.mock('../../../src/components/gym-directory/ClaimGymSheet', () => ({
+  ClaimGymSheet: () => createElement('div', { 'data-testid': 'claim-sheet' }),
+}));
+
+import EditGym from '../edit';
+
+function makeGym(overrides: Partial<Gym>): Gym {
+  return {
+    uuid: 'gym-uuid-1',
+    slug: null,
+    name: 'Bonsist',
+    canEdit: true,
+    canClaim: true,
+    canGrantAccess: false,
+    isPublic: true,
+    ...overrides,
+  } as unknown as Gym;
+}
+
+describe('EditGym — claim sheet lifetime', () => {
+  beforeEach(() => {
+    state.gym = makeGym({});
+  });
+
+  it('keeps the claim sheet mounted after an approved claim flips canClaim false', () => {
+    const view = render(<EditGym />);
+    expect(screen.getByTestId('claim-sheet')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('mobile.gymClaim.claimAction'));
+
+    // The approved claim invalidates the gym query; the refetch comes back with
+    // the claimant as owner, so `canClaim` is now false.
+    state.gym = makeGym({ canClaim: false });
+    view.rerender(<EditGym />);
+
+    // The sheet is still up showing the confirmation + "Set up your gym" CTA.
+    expect(screen.getByTestId('claim-sheet')).toBeTruthy();
+    // The claim entry point itself is correctly gone.
+    expect(screen.queryByText('mobile.gymClaim.claimAction')).toBeNull();
+  });
+
+  it('does not mount the claim sheet for a gym the viewer cannot claim', () => {
+    state.gym = makeGym({ canClaim: false });
+
+    render(<EditGym />);
+
+    expect(screen.queryByTestId('claim-sheet')).toBeNull();
+  });
+});

--- a/packages/mobile/app/gyms/edit.tsx
+++ b/packages/mobile/app/gyms/edit.tsx
@@ -160,10 +160,20 @@ function EditGymForm({ gym }: { gym: Gym }) {
     [submitting, gym.uuid, updateGym, showToast, t, router],
   );
 
+  // An approved claim invalidates the `gym` query, so `canClaim` flips false a
+  // refetch later — while the sheet is still up showing the confirmation and its
+  // "Set up your gym" hand-off. Keep the sheet mounted from the moment it opens
+  // until it fully dismisses, or that refetch unmounts the confirmation out from
+  // under the user.
+  const [claimSheetOpen, setClaimSheetOpen] = useState(false);
+
   const presentClaim = useCallback(() => {
     hapticSelection();
+    setClaimSheetOpen(true);
     claimSheetRef.current?.present();
   }, []);
+
+  const onClaimSheetClosed = useCallback(() => setClaimSheetOpen(false), []);
 
   const extraSections = (
     <>
@@ -197,7 +207,9 @@ function EditGymForm({ gym }: { gym: Gym }) {
         submitLabel={t('mobile.gymEdit.save')}
         extraSections={extraSections}
       />
-      {gym.canClaim ? <ClaimGymSheet sheetRef={claimSheetRef} gym={gym} /> : null}
+      {gym.canClaim || claimSheetOpen ? (
+        <ClaimGymSheet sheetRef={claimSheetRef} gym={gym} onClosed={onClaimSheetClosed} />
+      ) : null}
     </>
   );
 }

--- a/packages/mobile/app/gyms/mine.tsx
+++ b/packages/mobile/app/gyms/mine.tsx
@@ -11,6 +11,7 @@ import { useSetting } from '../../src/settings';
 import { hapticSelection } from '../../src/lib/haptics';
 import { openValidatedUrl } from '../../src/lib/open-external-link';
 import { WEB_BASE_URL } from '../../src/lib/env';
+import { buildGymManageUrl } from '../../src/lib/gym-manage-url';
 import { Text } from '../../src/components/Text';
 import { Icon } from '../../src/components/Icon';
 import { Button } from '../../src/components/Button';
@@ -19,15 +20,6 @@ import { ActivityIndicator } from '../../src/components/ActivityIndicator';
 import { MyGymRow } from '../../src/components/gym-directory/MyGymRow';
 import { iosSystemColors } from '../../src/theme/ios-colors';
 import { spacing, borderRadius } from '../../src/theme/tokens';
-
-// Kiosk/TV management is web-only by design; the mobile row hands off to the
-// browser console at /gym/{slug|uuid}/manage. The web route resolves either a
-// slug or a uuid, so a slugless legacy gym still reaches setup via its uuid.
-// `WEB_BASE_URL` respects the EXPO_PUBLIC_WEB_URL override, so it points at
-// whatever web build we're testing.
-function buildManageUrl(slugOrUuid: string): string {
-  return `${WEB_BASE_URL}/gym/${encodeURIComponent(slugOrUuid)}/manage`;
-}
 
 /**
  * "My gyms" — the owner's home for the gyms they run, reached from the More tab.
@@ -93,7 +85,7 @@ export default function MyGymsScreen() {
       hapticSelection();
       // openURL (never canOpenURL — false for https on Android 11+ package
       // visibility); a genuine failure rejects and we toast.
-      const opened = await openValidatedUrl(buildManageUrl(slugOrUuid), (url) => url.startsWith(WEB_BASE_URL));
+      const opened = await openValidatedUrl(buildGymManageUrl(slugOrUuid), (url) => url.startsWith(WEB_BASE_URL));
       if (!opened) showToast(t('mobile.myGyms.manageError'), 'error');
     },
     [kioskHintSeen, setKioskHintSeen, showToast, t],

--- a/packages/mobile/src/components/gym-directory/ClaimGymSheet.tsx
+++ b/packages/mobile/src/components/gym-directory/ClaimGymSheet.tsx
@@ -13,6 +13,9 @@ import { useTheme } from '../../providers/theme-provider';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useRequestGymClaim } from '../../lib/graphql/hooks';
 import { extractGraphqlMessage } from '../../lib/graphql/extract-error-message';
+import { openValidatedUrl } from '../../lib/open-external-link';
+import { WEB_BASE_URL } from '../../lib/env';
+import { buildGymManageUrl } from '../../lib/gym-manage-url';
 import type { ManagedSheetHandle } from '../../providers/sheet-presentation-provider';
 
 type ClaimMode = 'domain' | 'admin';
@@ -32,9 +35,11 @@ type ClaimGymSheetProps = {
  * or lands straight away (`approved`) when an admin has turned on auto-approval
  * and the gym is an unclaimed listing.
  * A domain mismatch rejects with a GraphQL error surfaced inline. Feedback stays
- * INSIDE the sheet — toasts render behind a native modal sheet — and the emailed
+ * INSIDE the sheet — toasts render behind a native modal sheet. The emailed
  * link is opened in the browser and handled by the backend, so the app does
- * nothing further after confirming.
+ * nothing further after confirming an `email_sent`/`admin_review` claim. An
+ * `approved` claim instead offers a "Manage gym" hand-off to the web setup
+ * console, mirroring MyGymsScreen's kiosk hand-off and the web claim dialog.
  */
 export function ClaimGymSheet({ sheetRef, gym, onClosed }: ClaimGymSheetProps) {
   const { t } = useTranslation('boards');
@@ -52,6 +57,9 @@ export function ClaimGymSheet({ sheetRef, gym, onClosed }: ClaimGymSheetProps) {
   const [message, setMessage] = useState('');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [confirmation, setConfirmation] = useState<{ status: string; email?: string | null } | null>(null);
+  // Separate from `errorMessage` (pre-submission form validation) so resetting
+  // one never accidentally clears feedback that belongs to the other.
+  const [manageError, setManageError] = useState<string | null>(null);
 
   const resetState = useCallback(() => {
     setMode(canUseDomain ? 'domain' : 'admin');
@@ -59,6 +67,7 @@ export function ClaimGymSheet({ sheetRef, gym, onClosed }: ClaimGymSheetProps) {
     setMessage('');
     setErrorMessage(null);
     setConfirmation(null);
+    setManageError(null);
     requestClaim.reset();
   }, [canUseDomain, requestClaim]);
 
@@ -89,6 +98,22 @@ export function ClaimGymSheet({ sheetRef, gym, onClosed }: ClaimGymSheetProps) {
     setErrorMessage(null);
     setMode(next);
   }, []);
+
+  // Same web hand-off pattern as MyGymsScreen's manageKiosks: kiosk/setup
+  // management is web-only by design. `gym.uuid` is always present, so a
+  // slugless gym still reaches setup via its uuid.
+  const openManageGym = useCallback(async () => {
+    setManageError(null);
+    const slugOrUuid = gym.slug ?? gym.uuid;
+    const opened = await openValidatedUrl(buildGymManageUrl(slugOrUuid), (url) => url.startsWith(WEB_BASE_URL));
+    if (opened) {
+      dismiss();
+    } else {
+      // Inline, not a toast -- toasts render behind this native modal sheet
+      // (see the sheet-level doc comment above).
+      setManageError(t('mobile.gymClaim.approved.manageError'));
+    }
+  }, [gym.slug, gym.uuid, dismiss, t]);
 
   return (
     <ModalSheet
@@ -124,7 +149,25 @@ export function ClaimGymSheet({ sheetRef, gym, onClosed }: ClaimGymSheetProps) {
                 ? t('mobile.gymClaim.approved.sent', { gym: gym.name })
                 : t('mobile.gymClaim.admin.sent')}
           </Text>
-          <Button title={t('mobile.gymClaim.done')} onPress={dismiss} variant="filled" size="large" />
+          {confirmation.status === 'approved' ? (
+            <Button
+              title={t('mobile.gymClaim.approved.manageCta')}
+              onPress={() => void openManageGym()}
+              variant="filled"
+              size="large"
+            />
+          ) : null}
+          {manageError ? (
+            <Text variant="footnote" color={brandColors.error} style={styles.errorText}>
+              {manageError}
+            </Text>
+          ) : null}
+          <Button
+            title={t('mobile.gymClaim.done')}
+            onPress={dismiss}
+            variant={confirmation.status === 'approved' ? 'text' : 'filled'}
+            size="large"
+          />
         </View>
       ) : mode === 'domain' && canUseDomain && domain ? (
         <>

--- a/packages/mobile/src/components/gym-directory/__tests__/claim-gym-sheet.test.tsx
+++ b/packages/mobile/src/components/gym-directory/__tests__/claim-gym-sheet.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { createElement, type ReactNode, type RefObject } from 'react';
 import type { Gym } from '@boardsesh/shared-schema';
@@ -61,18 +61,29 @@ vi.mock('../../../lib/graphql/extract-error-message', () => ({
   extractGraphqlMessage: (error: unknown) => (error as Error)?.message ?? null,
 }));
 
+const openUrl = vi.hoisted(() => ({ openValidatedUrl: vi.fn().mockResolvedValue(true) }));
+vi.mock('../../../lib/open-external-link', () => openUrl);
+vi.mock('../../../lib/env', () => ({ WEB_BASE_URL: 'https://www.boardsesh.com' }));
+
 import { ClaimGymSheet } from '../ClaimGymSheet';
 
 // No website, so the sheet opens in admin-review mode — the only path that can
 // come back `approved`.
-const gym = { uuid: 'gym-uuid-1', name: 'Bonsist', website: null } as unknown as Gym;
-const sheetRef = { current: { dismiss: vi.fn() } } as unknown as RefObject<ManagedSheetHandle | null>;
+const gym = { uuid: 'gym-uuid-1', slug: null, name: 'Bonsist', website: null } as unknown as Gym;
+const dismissMock = vi.fn();
+const sheetRef = { current: { dismiss: dismissMock } } as unknown as RefObject<ManagedSheetHandle | null>;
 
 const renderSheet = () => render(<ClaimGymSheet sheetRef={sheetRef} gym={gym} />);
 
 const submit = () => fireEvent.click(screen.getByText('mobile.gymClaim.admin.submit'));
 
 describe('ClaimGymSheet — claim outcome', () => {
+  beforeEach(() => {
+    dismissMock.mockClear();
+    openUrl.openValidatedUrl.mockClear();
+    openUrl.openValidatedUrl.mockResolvedValue(true);
+  });
+
   it('confirms ownership when the claim is auto-approved', async () => {
     mockMutateAsync.mockResolvedValueOnce({ status: 'approved', email: null });
 
@@ -93,5 +104,45 @@ describe('ClaimGymSheet — claim outcome', () => {
     // to wait for a review that had already happened.
     await waitFor(() => expect(screen.getByText('mobile.gymClaim.admin.sent')).toBeTruthy());
     expect(screen.queryByText('mobile.gymClaim.approved.sent')).toBeNull();
+  });
+
+  it('offers a manage-gym hand-off on an approved claim and dismisses the sheet on success', async () => {
+    mockMutateAsync.mockResolvedValueOnce({ status: 'approved', email: null });
+
+    renderSheet();
+    submit();
+    await waitFor(() => expect(screen.getByText('mobile.gymClaim.approved.sent')).toBeTruthy());
+
+    fireEvent.click(screen.getByText('mobile.gymClaim.approved.manageCta'));
+
+    expect(openUrl.openValidatedUrl).toHaveBeenCalledWith(
+      'https://www.boardsesh.com/gym/gym-uuid-1/manage',
+      expect.any(Function),
+    );
+    await waitFor(() => expect(dismissMock).toHaveBeenCalled());
+  });
+
+  it('shows an inline error and keeps the sheet open when the hand-off fails to open', async () => {
+    openUrl.openValidatedUrl.mockResolvedValue(false);
+    mockMutateAsync.mockResolvedValueOnce({ status: 'approved', email: null });
+
+    renderSheet();
+    submit();
+    await waitFor(() => expect(screen.getByText('mobile.gymClaim.approved.sent')).toBeTruthy());
+
+    fireEvent.click(screen.getByText('mobile.gymClaim.approved.manageCta'));
+
+    await waitFor(() => expect(screen.getByText('mobile.gymClaim.approved.manageError')).toBeTruthy());
+    expect(dismissMock).not.toHaveBeenCalled();
+  });
+
+  it('does not offer the manage-gym hand-off on a review-queued claim', async () => {
+    mockMutateAsync.mockResolvedValueOnce({ status: 'admin_review', email: null });
+
+    renderSheet();
+    submit();
+    await waitFor(() => expect(screen.getByText('mobile.gymClaim.admin.sent')).toBeTruthy());
+
+    expect(screen.queryByText('mobile.gymClaim.approved.manageCta')).toBeNull();
   });
 });

--- a/packages/mobile/src/components/gym-directory/__tests__/claim-gym-sheet.test.tsx
+++ b/packages/mobile/src/components/gym-directory/__tests__/claim-gym-sheet.test.tsx
@@ -73,7 +73,8 @@ const gym = { uuid: 'gym-uuid-1', slug: null, name: 'Bonsist', website: null } a
 const dismissMock = vi.fn();
 const sheetRef = { current: { dismiss: dismissMock } } as unknown as RefObject<ManagedSheetHandle | null>;
 
-const renderSheet = () => render(<ClaimGymSheet sheetRef={sheetRef} gym={gym} />);
+const renderSheet = (overrides?: Partial<Gym>) =>
+  render(<ClaimGymSheet sheetRef={sheetRef} gym={{ ...gym, ...overrides } as Gym} />);
 
 const submit = () => fireEvent.click(screen.getByText('mobile.gymClaim.admin.submit'));
 
@@ -120,6 +121,21 @@ describe('ClaimGymSheet — claim outcome', () => {
       expect.any(Function),
     );
     await waitFor(() => expect(dismissMock).toHaveBeenCalled());
+  });
+
+  it('prefers the gym slug over the uuid in the hand-off URL', async () => {
+    mockMutateAsync.mockResolvedValueOnce({ status: 'approved', email: null });
+
+    renderSheet({ slug: 'bonsist-amsterdam' });
+    submit();
+    await waitFor(() => expect(screen.getByText('mobile.gymClaim.approved.sent')).toBeTruthy());
+
+    fireEvent.click(screen.getByText('mobile.gymClaim.approved.manageCta'));
+
+    expect(openUrl.openValidatedUrl).toHaveBeenCalledWith(
+      'https://www.boardsesh.com/gym/bonsist-amsterdam/manage',
+      expect.any(Function),
+    );
   });
 
   it('shows an inline error and keeps the sheet open when the hand-off fails to open', async () => {

--- a/packages/mobile/src/lib/gym-manage-url.ts
+++ b/packages/mobile/src/lib/gym-manage-url.ts
@@ -1,0 +1,10 @@
+import { WEB_BASE_URL } from './env';
+
+// Kiosk/TV management (and general gym setup) is web-only by design; mobile
+// hands off to the browser console at /gym/{slug|uuid}/manage. The web route
+// resolves either a slug or a uuid, so a slugless legacy gym still reaches
+// setup via its uuid. `WEB_BASE_URL` respects the EXPO_PUBLIC_WEB_URL
+// override, so it points at whatever web build we're testing.
+export function buildGymManageUrl(slugOrUuid: string): string {
+  return `${WEB_BASE_URL}/gym/${encodeURIComponent(slugOrUuid)}/manage`;
+}

--- a/packages/shared/i18n/locales/de/boards.json
+++ b/packages/shared/i18n/locales/de/boards.json
@@ -281,7 +281,9 @@
         "sent": "Wir haben unser Team benachrichtigt. Wir melden uns bald."
       },
       "approved": {
-        "sent": "{{gym}} gehört jetzt dir."
+        "sent": "{{gym}} gehört jetzt dir.",
+        "manageCta": "Halle einrichten",
+        "manageError": "Die Halle-Einrichtung ließ sich nicht öffnen. Probier es im Browser."
       }
     },
     "offline": {

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -281,7 +281,9 @@
         "sent": "We've emailed our team. They'll be in touch soon."
       },
       "approved": {
-        "sent": "{{gym}} is yours to manage."
+        "sent": "{{gym}} is yours to manage.",
+        "manageCta": "Set up your gym",
+        "manageError": "Couldn't open gym setup. Try it in a browser."
       }
     },
     "offline": {

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -281,7 +281,9 @@
         "sent": "Hemos avisado a nuestro equipo. Se pondrán en contacto pronto."
       },
       "approved": {
-        "sent": "{{gym}} ya es tuyo."
+        "sent": "{{gym}} ya es tuyo.",
+        "manageCta": "Configura tu gimnasio",
+        "manageError": "No se pudo abrir la configuración del gimnasio. Ábrela en un navegador."
       }
     },
     "offline": {

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -281,7 +281,9 @@
         "sent": "Nous avons prévenu notre équipe. Elle te contactera bientôt."
       },
       "approved": {
-        "sent": "{{gym}} est à toi."
+        "sent": "{{gym}} est à toi.",
+        "manageCta": "Configurer votre salle",
+        "manageError": "Impossible d'ouvrir la configuration de la salle. Ouvre-la dans un navigateur."
       }
     },
     "offline": {

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -282,7 +282,7 @@
       },
       "approved": {
         "sent": "{{gym}} est à toi.",
-        "manageCta": "Configurer votre salle",
+        "manageCta": "Configurer ta salle",
         "manageError": "Impossible d'ouvrir la configuration de la salle. Ouvre-la dans un navigateur."
       }
     },


### PR DESCRIPTION
## Summary

`ClaimGymSheet`'s `approved` confirmation branch (when a gym claim is
auto-approved and the claimant becomes owner immediately) only showed a
"Done" button — nothing routed the new owner to the gym's setup screen. Web
already handles this with a "Set up your gym" CTA in `claim-gym-dialog.tsx`.

Adds the same primary "Set up your gym" hand-off to mobile, reusing the
exact web-hand-off pattern `MyGymsScreen` already uses for kiosk/TV
management (`Linking.openURL` to `/gym/{slug|uuid}/manage`, validated
against `WEB_BASE_URL`). The URL builder that pattern used
(`buildManageUrl` in `mine.tsx`) is now a small shared helper
(`src/lib/gym-manage-url.ts`) so both call sites stay in sync.

"Done" remains as the secondary (text-variant) dismiss action, matching the
web dialog's CTA-then-close visual hierarchy. A failed hand-off shows an
inline error and leaves the sheet open to retry — not a toast, since this
sheet's own doc comment establishes that toasts render behind native modal
sheets (the same convention `SessionTitleSheet`, `SessionEditSheet`, and
`InlinePlaylistPicker` already follow).

Closes #4231

## Review pass (adversarial QA)

- The gym-edit screen mounted the sheet behind `gym.canClaim`. An approved
  claim invalidates the `gym` query, so `canClaim` flipped false a refetch
  later and unmounted the sheet mid-confirmation — taking the new "Set up
  your gym" button with it. The sheet now stays mounted from the moment it
  opens until it fully dismisses (`packages/mobile/app/gyms/edit.tsx`, new
  `app/gyms/__tests__/edit.test.tsx`).
- French `manageCta` was copied from the web catalog, which addresses the
  reader as *vous*; the mobile `gymClaim` block is *tu* throughout
  ("{{gym}} est à toi.", "Ouvre-la dans un navigateur"). Now
  "Configurer ta salle".
- Added a test that the hand-off URL prefers the slug over the uuid.

## Release Notes

- Claim a gym that's auto-approved and you'll get a "Set up your gym"
  button straight from the confirmation screen — no more hunting for the
  setup page yourself.

## Test plan

- `vp run typecheck:mobile` — passes.
- `vp run test:mobile` — 616 files / 5392 tests pass, including 3 new tests
  in `claim-gym-sheet.test.tsx` (manage CTA opens the right URL and
  dismisses on success; failed open shows an inline error and keeps the
  sheet open; the CTA does not render on the non-`approved` confirmation
  branches).
- `vp run check:mobile-bundle` — OK.
- `vp run check:i18n` / `vp run check:i18n:orphans` — pass; new keys added
  to all four locale catalogs (en-US, es, fr, de) under
  `mobile.gymClaim.approved.{manageCta,manageError}`, matching the existing
  web `claimGym.approved.manageCta` copy per locale.
- `vp staged` (the pre-commit hook, run against every changed file) — clean.
- No dev server was started; this is a pure client-side navigation
  affordance using data the existing `requestGymClaim` mutation already
  returns. QA notes for a manual on-device pass are in `.boardsesh/qa-notes.md`
  (gitignored, not part of this diff).

