### PR TITLE
fix(backend): consolidate normalizeSetIds into @boardsesh/board-config's normaliseSetIds

### DIFF
--- a/packages/backend/src/__tests__/board-catalog-validation.test.ts
+++ b/packages/backend/src/__tests__/board-catalog-validation.test.ts
@@ -4,12 +4,12 @@ import { GraphQLError } from 'graphql';
 import { v4 as uuidv4 } from 'uuid';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
-import { MOONBOARD_LAYOUTS, MOONBOARD_SETS, MOONBOARD_SIZE } from '@boardsesh/board-config';
+import { MOONBOARD_LAYOUTS, MOONBOARD_SETS, MOONBOARD_SIZE, normaliseSetIds } from '@boardsesh/board-config';
 import { db } from '../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { assertKnownBoardConfig } from '../graphql/resolvers/board-presence/board-catalog';
 import { boardPresenceMutations } from '../graphql/resolvers/board-presence/mutations';
-import { normalizeSetIds, SYSTEM_BOARD_OWNER_ID } from '../graphql/resolvers/board-presence/shared';
+import { SYSTEM_BOARD_OWNER_ID } from '../graphql/resolvers/board-presence/shared';
 import { socialBoardMutations } from '../graphql/resolvers/social/boards';
 import { BoardPresenceConfigInputSchema, CreateBoardInputSchema, UpdateBoardInputSchema } from '../validation/schemas';
 import { seedAuroraCatalogFixtures } from './helpers/board-catalog-fixture';
@@ -52,7 +52,7 @@ function anonCtx(): ConnectionContext {
 }
 
 function presenceSlug(boardType: string, layoutId: number, sizeId: number, setIds: string): string {
-  const normalizedSetIds = normalizeSetIds(setIds);
+  const normalizedSetIds = normaliseSetIds(setIds);
   const digest = createHash('sha256')
     .update(`${boardType}:${layoutId}:${sizeId}:${normalizedSetIds}`)
     .digest('hex')

--- a/packages/backend/src/__tests__/save-tick-board-uuid-config-gate.test.ts
+++ b/packages/backend/src/__tests__/save-tick-board-uuid-config-gate.test.ts
@@ -188,6 +188,18 @@ describe('saveTick boardUuid config gate', () => {
     expect(await saveTick({ boardUuid: gymBoard.uuid, setIds: '1,2' })).toBe(gymBoard.id);
   });
 
+  it('records the tick unassociated instead of falsely matching when the sent hold sets carry a non-numeric token', async () => {
+    // SaveTickInputSchema.setIds isn't NumericCsvSchema-restricted (#4217), so a
+    // client could in theory send a malformed token here. The set-id comparison
+    // (@boardsesh/board-config's normaliseSetIds) keeps non-numeric tokens
+    // verbatim rather than silently dropping them, so '1,2,abc' never collapses
+    // to '1,2' and can't be coincidentally attributed to a real board that
+    // happens to run sets 1 and 2.
+    const gymBoard = await insertBoard({ ownerId: OTHER_USER_ID, setIds: '1,2', name: 'Gym wall' });
+
+    expect(await saveTick({ boardUuid: gymBoard.uuid, setIds: '1,2,abc' })).toBeNull();
+  });
+
   it('records the tick unassociated when the input carries a boardUuid but no configuration', async () => {
     // Deliberate strictness: without a layout/size/set there is nothing to check,
     // so omitting the config can't be a way around the gate.

--- a/packages/backend/src/graphql/resolvers/board-presence/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/mutations.ts
@@ -7,6 +7,7 @@ import type {
   ResolvedBoard,
   BoardPresenceClimb,
 } from '@boardsesh/shared-schema';
+import { normaliseSetIds } from '@boardsesh/board-config';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
@@ -35,7 +36,6 @@ import {
   findReachableActiveBoardByUuid,
   isDuplicateBoardSerialError,
   lastSentAtByBoardIds,
-  normalizeSetIds,
   rememberBoardForSerial,
   requireActiveBoardById,
   resolveSharedBoardForConfig,
@@ -181,7 +181,7 @@ async function bindOrCreateOwnBoardForSerial(
         boardType: config.boardType,
         layoutId: config.layoutId,
         sizeId: config.sizeId,
-        setIds: normalizeSetIds(config.setIds),
+        setIds: normaliseSetIds(config.setIds),
         name,
         serialNumber: serial,
       })

--- a/packages/backend/src/graphql/resolvers/board-presence/shared.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/shared.ts
@@ -3,6 +3,7 @@ import { and, asc, eq, inArray, isNotNull, isNull, or, sql } from 'drizzle-orm';
 import { createHash } from 'crypto';
 import { v4 as uuidv4 } from 'uuid';
 import type { BoardConnectionHolder, ResolvedBoard } from '@boardsesh/shared-schema';
+import { normaliseSetIds } from '@boardsesh/board-config';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { pubsub } from '../../../pubsub/index';
@@ -271,25 +272,6 @@ export async function findReachableActiveBoardByUuid(
 }
 
 /**
- * Canonical set-id string for equality checks: numeric tokens only, deduped,
- * numerically sorted. Lets us compare a tick's target set against a board's
- * stored set without caring about order or formatting.
- */
-export function normalizeSetIds(setIds: string | null | undefined): string {
-  if (!setIds) return '';
-  return [
-    ...new Set(
-      setIds
-        .split(',')
-        .map((token) => token.trim())
-        .filter((token) => /^\d+$/.test(token)),
-    ),
-  ]
-    .sort((first, second) => Number(first) - Number(second))
-    .join(',');
-}
-
-/**
  * The board configuration a tick names: the board type it was logged against
  * plus the layout/size/set triple from the route it was logged from. The three
  * config fields are optional on the wire (`SaveTickInputSchema`), so a caller
@@ -325,7 +307,7 @@ export function boardConfigMatchesTick(
     board.boardType === target.boardType &&
     board.layoutId === target.layoutId &&
     board.sizeId === target.sizeId &&
-    normalizeSetIds(board.setIds) === normalizeSetIds(target.setIds)
+    normaliseSetIds(board.setIds) === normaliseSetIds(target.setIds)
   );
 }
 
@@ -483,7 +465,7 @@ export async function findOwnActiveBoardByConfig(
   setIds: string,
   preferredSerial?: string,
 ): Promise<ActivePresenceBoard | undefined> {
-  const normalizedSetIds = normalizeSetIds(setIds);
+  const normalizedSetIds = normaliseSetIds(setIds);
   const [board] = await db
     .select({
       id: dbSchema.userBoards.id,
@@ -631,7 +613,7 @@ export async function resolveSharedBoardForConfig(
   // creates the feed the first time a config is seen; anon then joins it.
   allowCreate = true,
 ): Promise<ResolvedBoard> {
-  const normalizedSetIds = normalizeSetIds(setIds);
+  const normalizedSetIds = normaliseSetIds(setIds);
   const slug = boardConfigPresenceSlug(boardType, layoutId, sizeId, normalizedSetIds);
 
   const [existing] = await db

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -25,12 +25,7 @@ import { resolveAutoGymForBoard } from './gym-matching';
 import { findBlockingDuplicate, type BoardLocation } from './board-duplicates';
 import { assertBoardCapNotReached } from './board-limits';
 import { getUserCommunityRoles, hasAdminOrLeader, rolesGrantAdminOrLeader } from './roles';
-import {
-  SYSTEM_BOARD_OWNER_ID,
-  isRowAnonReadable,
-  normalizeSetIds,
-  requireAnonReadableBoard,
-} from '../board-presence/shared';
+import { SYSTEM_BOARD_OWNER_ID, isRowAnonReadable, requireAnonReadableBoard } from '../board-presence/shared';
 import { assertKnownBoardConfig } from '../board-presence/board-catalog';
 import { publishBoardQueuePreviewTombstoneForBoard } from '../../../services/board-queue-preview';
 import { logger } from '../../../utils/logger';
@@ -231,8 +226,8 @@ export async function resolveBoardFromPath(
     // cap is a safety net against a pathological account.
     .limit(100);
 
-  const targetSetIds = normalizeSetIds(setIds);
-  return candidates.find((candidate) => normalizeSetIds(candidate.setIds) === targetSetIds)?.id ?? null;
+  const targetSetIds = normaliseSetIds(setIds);
+  return candidates.find((candidate) => normaliseSetIds(candidate.setIds) === targetSetIds)?.id ?? null;
 }
 
 /**

--- a/packages/shared/board-config/src/__tests__/set-ids.test.ts
+++ b/packages/shared/board-config/src/__tests__/set-ids.test.ts
@@ -45,4 +45,15 @@ describe('normaliseSetIds', () => {
   it('returns an empty string for an empty input', () => {
     expect(normaliseSetIds('')).toBe('');
   });
+
+  it('keeps a non-numeric token verbatim, unlike parseSetIds which drops it', () => {
+    // No real board's stored setIds ever contains a non-digit token (DB writes
+    // and NumericCsvSchema-validated config both stay digit-CSV), so keeping the
+    // token here means malformed input can never coincidentally normalise to
+    // match a real board — it just fails to match anything, which is the safe
+    // outcome. Backend consumers rely on exactly this: see
+    // packages/backend/src/__tests__/save-tick-board-uuid-config-gate.test.ts.
+    expect(normaliseSetIds('1,2,abc')).toBe('1,2,abc');
+    expect(parseSetIds('1,2,abc')).toEqual([1, 2]);
+  });
 });

--- a/packages/shared/board-config/src/__tests__/set-ids.test.ts
+++ b/packages/shared/board-config/src/__tests__/set-ids.test.ts
@@ -46,14 +46,23 @@ describe('normaliseSetIds', () => {
     expect(normaliseSetIds('')).toBe('');
   });
 
-  it('keeps a non-numeric token verbatim, unlike parseSetIds which drops it', () => {
+  it('keeps a non-numeric token, unlike parseSetIds which drops it', () => {
     // No real board's stored setIds ever contains a non-digit token (DB writes
     // and NumericCsvSchema-validated config both stay digit-CSV), so keeping the
     // token here means malformed input can never coincidentally normalise to
-    // match a real board — it just fails to match anything, which is the safe
-    // outcome. Backend consumers rely on exactly this: see
+    // match a real board's digit-only value — it just fails to match anything,
+    // which is the safe outcome. Backend consumers rely on exactly this: see
     // packages/backend/src/__tests__/save-tick-board-uuid-config-gate.test.ts.
-    expect(normaliseSetIds('1,2,abc')).toBe('1,2,abc');
+    //
+    // Asserted as a token set, not an exact string: the sort comparator's
+    // behaviour on a NaN comparison ('abc' vs a number) is a V8 implementation
+    // detail (stable-sort-on-NaN), not a documented contract, so pinning an
+    // exact output order here would make the test fragile across runtimes.
+    // The safety property under test — never collapsing to '1,2' — doesn't
+    // depend on where 'abc' lands.
+    const result = normaliseSetIds('1,2,abc');
+    expect(new Set(result.split(','))).toEqual(new Set(['1', '2', 'abc']));
+    expect(result).not.toBe('1,2');
     expect(parseSetIds('1,2,abc')).toEqual([1, 2]);
   });
 });


### PR DESCRIPTION
## Summary

`packages/backend/src/graphql/resolvers/social/boards.ts` imported two set-id
normalisation helpers that do the same job: `normalizeSetIds` (defined in
`board-presence/shared.ts`, used by the tick-resolution rungs) and
`normaliseSetIds` (from `@boardsesh/board-config`, used by the duplicate
guards) — two spellings one letter apart.

This PR deletes the backend-local `normalizeSetIds` and repoints every caller
at the shared package's `normaliseSetIds`:

- `board-presence/shared.ts` — deleted the duplicate helper; its three
  internal call sites (`boardConfigMatchesTick`, `findOwnActiveBoardByConfig`,
  `resolveSharedBoardForConfig`) now import and call
  `@boardsesh/board-config`'s `normaliseSetIds`.
- `board-presence/mutations.ts` — same swap at the board-create call site.
- `social/boards.ts` — same swap in `resolveBoardFromPath`; this file already
  imported `normaliseSetIds` for its duplicate guards, so it no longer imports
  two spellings of the same helper.
- `board-catalog-validation.test.ts` — updated to import `normaliseSetIds`
  from `@boardsesh/board-config`.

For every currently-persisted board, all inputs into these call sites are
either DB-stored (digit-CSV, `NOT NULL`) or `NumericCsvSchema`-validated, so
the two helpers produced byte-identical output — this is a
behaviour-preserving refactor for existing data.

One documented hardening, not a regression: `ticks/mutations.ts`'s
`SaveTickInputSchema.setIds` is only `z.string().min(1).optional()`, not
`NumericCsvSchema`-restricted, so a client could in theory send a non-digit
token in a tick's `setIds`. The old `normalizeSetIds` silently dropped
non-digit tokens, which could in theory make a malformed token coincidentally
normalise to match a real board's stored set string. `normaliseSetIds` keeps
non-digit tokens verbatim, so a malformed token can never coincidentally
collapse into a match — it just fails to match, which is the safe outcome.
Covered by a new regression test.

Closes #4217

### Adjacent PRs (rebase-conflict risk only, not blockers)

- #4263 ("gate saveTick's boardUuid rung on a full board config match") —
  already merged into `main`. Its `boardConfigMatchesTick` helper called the
  old `normalizeSetIds` internally; this PR repoints it at `normaliseSetIds`.
- #3422 ("consolidate duplicate serial-number boards...") — still open, edits
  the same three backend files (`board-presence/mutations.ts`,
  `board-presence/shared.ts`, `social/boards.ts`). Real rebase risk if it
  lands first; it does not touch the `normalizeSetIds` definition itself.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck` — whole repo, confirms the deleted export isn't
  referenced anywhere.
- `vp test run --project backend --reporter=agent` — includes the new
  `save-tick-board-uuid-config-gate.test.ts` case (a tick with a non-numeric
  token in `setIds` never falsely attributes to a real board).
- `vp test run --project board-config --reporter=agent` — includes the new
  `set-ids.test.ts` case pinning `normaliseSetIds`'s non-numeric-token
  retention.
- `vp check` — format + lint.
