### PR TITLE
fix(backend): retire the gym listing a stray-board attach empties

### DIFF
--- a/packages/backend/src/__tests__/gym-stray-boards.test.ts
+++ b/packages/backend/src/__tests__/gym-stray-boards.test.ts
@@ -117,10 +117,71 @@ const insertGymMember = (gymId: number, userId: string, role: string) =>
     VALUES (${gymId}, ${userId}, ${role}, now())
   `);
 
+const insertGymClaim = (gymId: number, claimantUserId: string, status: string) =>
+  db.execute(sql`
+    INSERT INTO gym_claims (gym_id, claimant_user_id, method, status, created_at, updated_at)
+    VALUES (${gymId}, ${claimantUserId}, 'admin', ${status}, now(), now())
+  `);
+
+const insertGymKiosk = (gymId: number, slug: string) =>
+  db.execute(sql`
+    INSERT INTO gym_kiosks (uuid, gym_id, slug, name, created_at, updated_at)
+    VALUES (${uuidv4()}, ${gymId}, ${slug}, ${'Kiosk ' + slug}, now(), now())
+  `);
+
+const insertGymSourceAlias = (gymId: number, sourceKey: string) =>
+  db.execute(sql`
+    INSERT INTO location_sync_gym_sources (source_key, gym_id, created_at, updated_at)
+    VALUES (${sourceKey}, ${gymId}, now(), now())
+  `);
+
 const boardGymId = async (boardUuid: string): Promise<number | null> => {
   const result = await db.execute(sql`SELECT gym_id FROM user_boards WHERE uuid = ${boardUuid}`);
   const row = Array.from(result as Iterable<{ gym_id: number | null }>)[0];
   return row?.gym_id != null ? Number(row.gym_id) : null;
+};
+
+const boardSyncFrozen = async (boardUuid: string): Promise<boolean> => {
+  const result = await db.execute(sql`SELECT sync_frozen_at FROM user_boards WHERE uuid = ${boardUuid}`);
+  const row = Array.from(result as Iterable<{ sync_frozen_at: Date | null }>)[0];
+  return row?.sync_frozen_at != null;
+};
+
+type GymRetireState = { deletedAt: Date | null; isPublic: boolean; mergedIntoGymId: number | null };
+
+const gymRetireState = async (gymId: number): Promise<GymRetireState> => {
+  const result = await db.execute(sql`
+    SELECT deleted_at, is_public, merged_into_gym_id FROM gyms WHERE id = ${gymId}
+  `);
+  const row = Array.from(
+    result as Iterable<{ deleted_at: Date | null; is_public: boolean; merged_into_gym_id: number | null }>,
+  )[0];
+  return {
+    deletedAt: row.deleted_at,
+    isPublic: row.is_public,
+    mergedIntoGymId: row.merged_into_gym_id != null ? Number(row.merged_into_gym_id) : null,
+  };
+};
+
+const sourceAliasGymId = async (sourceKey: string): Promise<number | null> => {
+  const result = await db.execute(sql`SELECT gym_id FROM location_sync_gym_sources WHERE source_key = ${sourceKey}`);
+  const row = Array.from(result as Iterable<{ gym_id: number | null }>)[0];
+  return row?.gym_id != null ? Number(row.gym_id) : null;
+};
+
+const mergeAuditRows = async (duplicateGymId: number) => {
+  const result = await db.execute(sql`
+    SELECT canonical_gym_id, duplicate_gym_id, action, performed_by
+      FROM gym_merge_audit
+     WHERE duplicate_gym_id = ${duplicateGymId}
+  `);
+  return Array.from(
+    result as Iterable<{
+      canonical_gym_id: number | null;
+      action: string;
+      performed_by: string | null;
+    }>,
+  );
 };
 
 const strayBoardsForGym = (gymUuid: string, ctx: ConnectionContext) =>
@@ -379,5 +440,249 @@ describe('attachBoardToGym', () => {
 
     await expect(attachBoardToGym({ gymUuid: target.uuid, boardUuid: board.uuid }, authCtx(OTHER))).rejects.toThrow();
     expect(await boardGymId(board.uuid)).toBeNull();
+  });
+
+  it('freezes the attached board so the next location sync cannot re-point it', async () => {
+    const target = await seedTargetGym();
+    const board = await insertBoard({
+      ownerId: SYSTEM_OWNER,
+      name: 'Synced Kilter',
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+    });
+
+    await attachBoardToGym({ gymUuid: target.uuid, boardUuid: board.uuid }, authCtx(OWNER));
+
+    expect(await boardSyncFrozen(board.uuid)).toBe(true);
+  });
+});
+
+// ============================================
+// #4188: the listing an attach empties
+// ============================================
+
+describe('attachBoardToGym — retiring the emptied source listing', () => {
+  /** A SYSTEM listing at the same spot as the target gym, holding `boardCount` synced boards. */
+  const seedSyncedListing = async (boardCount: number, name = 'Boulder Base (synced)') => {
+    const listing = await insertGym({
+      ownerId: SYSTEM_OWNER,
+      name,
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+    });
+    const boards = [];
+    for (let index = 0; index < boardCount; index++) {
+      boards.push(
+        await insertBoard({
+          ownerId: SYSTEM_OWNER,
+          name: `${name} wall ${index + 1}`,
+          gymId: listing.id,
+          latitude: LAT_60M,
+          longitude: BASE.longitude,
+        }),
+      );
+    }
+    return { listing, boards };
+  };
+
+  it('folds the emptied listing into the target gym instead of leaving it live and empty', async () => {
+    const target = await seedTargetGym();
+    const { listing, boards } = await seedSyncedListing(1);
+
+    await attachBoardToGym({ gymUuid: target.uuid, boardUuid: boards[0].uuid }, authCtx(OWNER));
+
+    const state = await gymRetireState(listing.id);
+    expect(state.deletedAt).not.toBeNull();
+    expect(state.isPublic).toBe(false);
+    expect(state.mergedIntoGymId).toBe(target.id);
+  });
+
+  it('writes a merge-audit row naming the attaching user so an admin can reverse it', async () => {
+    const target = await seedTargetGym();
+    const { listing, boards } = await seedSyncedListing(1);
+
+    await attachBoardToGym({ gymUuid: target.uuid, boardUuid: boards[0].uuid }, authCtx(OWNER));
+
+    const auditRows = await mergeAuditRows(listing.id);
+    expect(auditRows.length).toBe(1);
+    expect(auditRows[0].action).toBe('merged');
+    expect(Number(auditRows[0].canonical_gym_id)).toBe(target.id);
+    expect(auditRows[0].performed_by).toBe(OWNER);
+  });
+
+  it("moves the listing's location-sync alias to the target so the sync can't re-mint it", async () => {
+    const target = await seedTargetGym();
+    const { listing, boards } = await seedSyncedListing(1);
+    await insertGymSourceAlias(listing.id, 'kilter:gym-4188');
+
+    await attachBoardToGym({ gymUuid: target.uuid, boardUuid: boards[0].uuid }, authCtx(OWNER));
+
+    expect(await sourceAliasGymId('kilter:gym-4188')).toBe(target.id);
+  });
+
+  it('leaves the source listing live when it still has another board', async () => {
+    const target = await seedTargetGym();
+    const { listing, boards } = await seedSyncedListing(2);
+
+    await attachBoardToGym({ gymUuid: target.uuid, boardUuid: boards[0].uuid }, authCtx(OWNER));
+
+    const state = await gymRetireState(listing.id);
+    expect(state.deletedAt).toBeNull();
+    expect(state.isPublic).toBe(true);
+    expect(state.mergedIntoGymId).toBeNull();
+    expect(await mergeAuditRows(listing.id)).toEqual([]);
+  });
+
+  it('does not retire a listing with a pending claim', async () => {
+    const target = await seedTargetGym();
+    const { listing, boards } = await seedSyncedListing(1);
+    await insertGymClaim(listing.id, OTHER, 'pending');
+
+    await attachBoardToGym({ gymUuid: target.uuid, boardUuid: boards[0].uuid }, authCtx(OWNER));
+
+    expect((await gymRetireState(listing.id)).deletedAt).toBeNull();
+    expect(await boardGymId(boards[0].uuid)).toBe(target.id);
+  });
+
+  it('does not retire a listing with an approved claim', async () => {
+    const target = await seedTargetGym();
+    const { listing, boards } = await seedSyncedListing(1);
+    await insertGymClaim(listing.id, OTHER, 'approved');
+
+    await attachBoardToGym({ gymUuid: target.uuid, boardUuid: boards[0].uuid }, authCtx(OWNER));
+
+    expect((await gymRetireState(listing.id)).deletedAt).toBeNull();
+  });
+
+  it('does not retire a listing that has staff on it', async () => {
+    const target = await seedTargetGym();
+    const { listing, boards } = await seedSyncedListing(1);
+    await insertGymMember(listing.id, OTHER, 'editor');
+
+    await attachBoardToGym({ gymUuid: target.uuid, boardUuid: boards[0].uuid }, authCtx(OWNER));
+
+    expect((await gymRetireState(listing.id)).deletedAt).toBeNull();
+  });
+
+  it('does not retire a listing with a live kiosk', async () => {
+    const target = await seedTargetGym();
+    const { listing, boards } = await seedSyncedListing(1);
+    await insertGymKiosk(listing.id, 'front-desk');
+
+    await attachBoardToGym({ gymUuid: target.uuid, boardUuid: boards[0].uuid }, authCtx(OWNER));
+
+    expect((await gymRetireState(listing.id)).deletedAt).toBeNull();
+  });
+
+  it('leaves an already-merged twin listing untouched — it is not a second merge', async () => {
+    const target = await seedTargetGym();
+    const twin = await insertGym({
+      ownerId: OTHER,
+      name: 'Someone Else Gym',
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+      mergedIntoGymId: target.id,
+    });
+    const board = await insertBoard({ ownerId: OTHER, name: 'Leftover Wall', gymId: twin.id });
+
+    await attachBoardToGym({ gymUuid: target.uuid, boardUuid: board.uuid }, authCtx(OWNER));
+
+    const state = await gymRetireState(twin.id);
+    expect(state.deletedAt).toBeNull();
+    expect(state.mergedIntoGymId).toBe(target.id); // the pre-existing pointer, not a fresh fold
+    expect(await mergeAuditRows(twin.id)).toEqual([]);
+  });
+
+  it('retires nothing when the target gym is itself a synced listing', async () => {
+    // An editor member can manage a SYSTEM gym, but folding one synced listing
+    // into another is not this feature's job.
+    const syncedTarget = await insertGym({
+      ownerId: SYSTEM_OWNER,
+      name: 'Synced Target',
+      latitude: BASE.latitude,
+      longitude: BASE.longitude,
+    });
+    await insertGymMember(syncedTarget.id, OWNER, 'editor');
+    const { listing, boards } = await seedSyncedListing(1);
+
+    await attachBoardToGym({ gymUuid: syncedTarget.uuid, boardUuid: boards[0].uuid }, authCtx(OWNER));
+
+    expect(await boardGymId(boards[0].uuid)).toBe(syncedTarget.id);
+    expect((await gymRetireState(listing.id)).deletedAt).toBeNull();
+    expect(await mergeAuditRows(listing.id)).toEqual([]);
+  });
+
+  it('retires nothing when the attached board was unlinked', async () => {
+    const target = await seedTargetGym();
+    const board = await insertBoard({
+      ownerId: SYSTEM_OWNER,
+      name: 'Loose Wall',
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+    });
+
+    const ok = await attachBoardToGym({ gymUuid: target.uuid, boardUuid: board.uuid }, authCtx(OWNER));
+
+    expect(ok).toBe(true);
+    expect(await boardGymId(board.uuid)).toBe(target.id);
+    expect((await gymRetireState(target.id)).deletedAt).toBeNull();
+  });
+});
+
+describe('strayBoardsForGym — isLastBoardAtCurrentGym', () => {
+  it('flags the sole board on a listing, and not a board that has company', async () => {
+    const target = await seedTargetGym();
+    const soleListing = await insertGym({
+      ownerId: SYSTEM_OWNER,
+      name: 'One Wall Spot',
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+    });
+    const soleBoard = await insertBoard({
+      ownerId: SYSTEM_OWNER,
+      name: 'Only Wall',
+      gymId: soleListing.id,
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+    });
+    const busyListing = await insertGym({
+      ownerId: SYSTEM_OWNER,
+      name: 'Two Wall Spot',
+      latitude: LAT_120M,
+      longitude: BASE.longitude,
+    });
+    const busyBoard = await insertBoard({
+      ownerId: SYSTEM_OWNER,
+      name: 'First Of Two',
+      gymId: busyListing.id,
+      latitude: LAT_120M,
+      longitude: BASE.longitude,
+    });
+    await insertBoard({
+      ownerId: SYSTEM_OWNER,
+      name: 'Second Of Two',
+      gymId: busyListing.id,
+      latitude: LAT_120M,
+      longitude: BASE.longitude,
+    });
+
+    const results = await strayBoardsForGym(target.uuid, authCtx(OWNER));
+
+    expect(results.find((candidate) => candidate.uuid === soleBoard.uuid)?.isLastBoardAtCurrentGym).toBe(true);
+    expect(results.find((candidate) => candidate.uuid === busyBoard.uuid)?.isLastBoardAtCurrentGym).toBe(false);
+  });
+
+  it('never flags an unlinked board', async () => {
+    const target = await seedTargetGym();
+    const loose = await insertBoard({
+      ownerId: SYSTEM_OWNER,
+      name: 'Loose Wall',
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+    });
+
+    const results = await strayBoardsForGym(target.uuid, authCtx(OWNER));
+
+    expect(results.find((candidate) => candidate.uuid === loose.uuid)?.isLastBoardAtCurrentGym).toBe(false);
   });
 });

--- a/packages/backend/src/__tests__/gym-stray-boards.test.ts
+++ b/packages/backend/src/__tests__/gym-stray-boards.test.ts
@@ -685,4 +685,55 @@ describe('strayBoardsForGym — isLastBoardAtCurrentGym', () => {
 
     expect(results.find((candidate) => candidate.uuid === loose.uuid)?.isLastBoardAtCurrentGym).toBe(false);
   });
+
+  it('never flags a leftover board on an already-merged twin listing', async () => {
+    // The flag promises that attaching folds the listing away. A twin is already
+    // folded, so retireEmptiedSourceGym refuses it — flagging it here would put
+    // a merge confirm in front of a merge that never happens.
+    const target = await seedTargetGym();
+    const twin = await insertGym({
+      ownerId: SYSTEM_OWNER,
+      name: 'Already Folded',
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+      mergedIntoGymId: target.id,
+    });
+    const leftover = await insertBoard({
+      ownerId: SYSTEM_OWNER,
+      name: 'Leftover Wall',
+      gymId: twin.id,
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+    });
+
+    const results = await strayBoardsForGym(target.uuid, authCtx(OWNER));
+
+    const candidate = results.find((stray) => stray.uuid === leftover.uuid);
+    expect(candidate?.reason).toBe('MERGED_TWIN');
+    expect(candidate?.isLastBoardAtCurrentGym).toBe(false);
+  });
+
+  it('never flags a board sitting on a listing a real person owns', async () => {
+    // Only a SYSTEM listing is ever folded, so a user-owned listing must not
+    // carry the promise either.
+    const target = await seedTargetGym();
+    const ownedListing = await insertGym({
+      ownerId: OTHER,
+      name: 'Someone Elses Listing',
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+      mergedIntoGymId: target.id,
+    });
+    const board = await insertBoard({
+      ownerId: OWNER,
+      name: 'My Wall On Their Listing',
+      gymId: ownedListing.id,
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+    });
+
+    const results = await strayBoardsForGym(target.uuid, authCtx(OWNER));
+
+    expect(results.find((stray) => stray.uuid === board.uuid)?.isLastBoardAtCurrentGym).toBe(false);
+  });
 });

--- a/packages/backend/src/graphql/resolvers/social/gym-stray-boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-stray-boards.ts
@@ -1,9 +1,16 @@
-import { and, eq, inArray, isNull, ne, or, sql, type SQL } from 'drizzle-orm';
+import { and, eq, inArray, isNull, ne, or, sql, type SQL, type SQLWrapper } from 'drizzle-orm';
 import { GraphQLError } from 'graphql';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
-import { distanceMeters } from '@boardsesh/db/queries';
+import {
+  computeClusterSignature,
+  distanceMeters,
+  mergeGymsIntoCanonical,
+  type CanonicalGymCandidate,
+} from '@boardsesh/db/queries';
+import { executeRows } from '@boardsesh/db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { db } from '../../../db/client';
+import { logger } from '../../../utils/logger';
 import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
 import { AttachBoardToGymInputSchema, DetachBoardFromGymInputSchema, UUIDSchema } from '../../../validation/schemas';
 import { SYSTEM_BOARD_OWNER_ID } from '../board-presence/shared';
@@ -44,6 +51,12 @@ type StrayBoardCandidate = {
   currentGymName: string | null;
   distanceMeters: number | null;
   reason: StrayBoardReason;
+  /**
+   * True when this is the only live board left on its current listing, so
+   * attaching it empties that listing (and retires it — see
+   * {@link retireEmptiedSourceGym}). Always false for an unlinked board.
+   */
+  isLastBoardAtCurrentGym: boolean;
 };
 
 export type StrayBoardResult = Omit<StrayBoardCandidate, 'boardId' | 'currentGymId'>;
@@ -194,6 +207,7 @@ export async function findStrayBoardCandidates(gym: GymRow, viewerUserId: string
       currentGymName: row.currentGymName ?? null,
       distanceMeters: distanceFromGym(gym, row),
       reason: 'MERGED_TWIN' as const,
+      isLastBoardAtCurrentGym: false,
     }))
     .sort((first, second) => first.name.localeCompare(second.name));
 
@@ -215,11 +229,218 @@ export async function findStrayBoardCandidates(gym: GymRow, viewerUserId: string
       currentGymName: row.currentGymName ?? null,
       distanceMeters: distance,
       reason: 'NEARBY',
+      isLastBoardAtCurrentGym: false,
     });
   }
   nearbyCandidates.sort((first, second) => (first.distanceMeters ?? 0) - (second.distanceMeters ?? 0));
 
-  return [...twinCandidates, ...nearbyCandidates].slice(0, STRAY_BOARD_LIMIT);
+  const candidates = [...twinCandidates, ...nearbyCandidates].slice(0, STRAY_BOARD_LIMIT);
+  await markLastBoardAtCurrentGym(candidates);
+  return candidates;
+}
+
+/**
+ * Fills in `isLastBoardAtCurrentGym` for every candidate that sits on a listing,
+ * with ONE grouped count over the distinct listings involved (never a query per
+ * row). Mutates in place — the candidates are freshly built above.
+ */
+async function markLastBoardAtCurrentGym(candidates: StrayBoardCandidate[]): Promise<void> {
+  const listingIds = [
+    ...new Set(
+      candidates
+        .map((candidate) => candidate.currentGymId)
+        .filter((gymId): gymId is number => typeof gymId === 'number'),
+    ),
+  ];
+  if (listingIds.length === 0) return;
+
+  const counts = await db
+    .select({ gymId: dbSchema.userBoards.gymId, boardCount: sql<number>`count(*)::int` })
+    .from(dbSchema.userBoards)
+    .where(and(inArray(dbSchema.userBoards.gymId, listingIds), isNull(dbSchema.userBoards.deletedAt)))
+    .groupBy(dbSchema.userBoards.gymId);
+
+  const boardCountByGymId = new Map(counts.map((row) => [Number(row.gymId), Number(row.boardCount)]));
+  for (const candidate of candidates) {
+    if (candidate.currentGymId == null) continue;
+    candidate.isLastBoardAtCurrentGym = boardCountByGymId.get(candidate.currentGymId) === 1;
+  }
+}
+
+// ============================================
+// Retiring the listing an attach emptied
+// ============================================
+//
+// Taking the last board off an auto-synced listing used to leave that listing
+// live and public with nothing on it, so it kept turning up in gym search as a
+// plausible-looking duplicate of the gym the board just moved to (#4188).
+//
+// Rather than delete anything, the emptied listing is FOLDED into the gym that
+// took its board, through the same primitive the admin duplicates queue uses:
+// `merged_into_gym_id` + soft-delete, so old uuids/slugs still resolve to the
+// survivor, and a `gym_merge_audit` row records what moved. Folding also moves
+// the listing's `location_sync_gym_sources` alias to the survivor, which is what
+// stops the next location-sync run re-minting the same empty listing.
+
+/** Every gym column the merge primitive needs, plus the gates that decide whether we may fold at all. */
+type RetireGateRow = CanonicalGymCandidate & {
+  ownerId: string | null;
+  /** Claims in a state that means a human is (or has been) staking a title to this listing. */
+  openClaimCount: number;
+  liveKioskCount: number;
+};
+
+type TransactionDb = { execute(query: SQLWrapper | string): PromiseLike<unknown> };
+
+/**
+ * Locks the given gym rows (ascending id — the fixed order that keeps two
+ * concurrent folds from deadlocking) and returns the ones that are live,
+ * un-merged and have coordinates, keyed by id. A gym missing from the result is
+ * one we must not fold.
+ */
+async function loadRetireGateRows(tx: TransactionDb, gymIds: number[]): Promise<Map<number, RetireGateRow>> {
+  const rows = await executeRows<RetireGateRow>(
+    tx,
+    sql`
+    WITH locked_gym AS (
+      SELECT g.id, g.uuid, g.name, g.address, g.contact_email, g.contact_phone,
+             g.description, g.image_url, g.latitude, g.longitude, g.created_at, g.owner_id
+        FROM gyms g
+       WHERE g.id IN (${sql.join(
+         gymIds.map((gymId) => sql`${gymId}`),
+         sql`, `,
+       )})
+         AND g.deleted_at IS NULL
+         AND g.merged_into_gym_id IS NULL
+         AND g.latitude IS NOT NULL
+         AND g.longitude IS NOT NULL
+       ORDER BY g.id
+         FOR UPDATE
+    )
+    SELECT
+      g.id AS "id",
+      g.uuid AS "uuid",
+      g.name AS "name",
+      g.address AS "address",
+      g.contact_email AS "contactEmail",
+      g.contact_phone AS "contactPhone",
+      g.description AS "description",
+      g.image_url AS "imageUrl",
+      g.latitude AS "latitude",
+      g.longitude AS "longitude",
+      g.created_at AS "createdAt",
+      g.owner_id AS "ownerId",
+      COALESCE(board_counts.count, 0)::int AS "boardCount",
+      COALESCE(member_counts.count, 0)::int AS "memberCount",
+      COALESCE(follower_counts.count, 0)::int AS "followerCount",
+      COALESCE(comment_counts.count, 0)::int AS "commentCount",
+      (
+        SELECT count(*)::int FROM gym_claims
+         WHERE gym_id = g.id AND status IN ('pending', 'approved')
+      ) AS "openClaimCount",
+      (
+        SELECT count(*)::int FROM gym_kiosks
+         WHERE gym_id = g.id AND deleted_at IS NULL
+      ) AS "liveKioskCount"
+    FROM locked_gym g
+    LEFT JOIN (
+      SELECT gym_id, count(*) AS count FROM user_boards WHERE deleted_at IS NULL GROUP BY gym_id
+    ) board_counts ON board_counts.gym_id = g.id
+    LEFT JOIN (
+      SELECT gym_id, count(*) AS count FROM gym_members GROUP BY gym_id
+    ) member_counts ON member_counts.gym_id = g.id
+    LEFT JOIN (
+      SELECT gym_id, count(*) AS count FROM gym_follows GROUP BY gym_id
+    ) follower_counts ON follower_counts.gym_id = g.id
+    LEFT JOIN (
+      SELECT entity_id, count(*) AS count FROM comments
+      WHERE entity_type = 'gym' AND deleted_at IS NULL GROUP BY entity_id
+    ) comment_counts ON comment_counts.entity_id = g.uuid
+  `,
+  );
+  return new Map(rows.map((row) => [Number(row.id), { ...row, id: Number(row.id) }]));
+}
+
+function toMergeCandidate(row: RetireGateRow): CanonicalGymCandidate {
+  const { ownerId: _ownerId, openClaimCount: _openClaimCount, liveKioskCount: _liveKioskCount, ...candidate } = row;
+  return candidate;
+}
+
+/**
+ * Folds `sourceGymId` into `targetGym` when the attach that just ran left it
+ * with no boards at all.
+ *
+ * Deliberately narrow: only an auto-synced (SYSTEM-owned) listing that nobody
+ * has claimed, staffed or hung a kiosk on can be folded, and only into a gym a
+ * real person owns. Anything else is left exactly as it was — a gym editor must
+ * never be able to make someone else's listing disappear. Every refusal is a
+ * debug log and a plain `return`: the board move has already committed, so a
+ * skipped fold is a no-op, not an error.
+ */
+async function retireEmptiedSourceGym(sourceGymId: number, targetGym: GymRow, actorUserId: string): Promise<void> {
+  if (targetGym.ownerId === SYSTEM_BOARD_OWNER_ID) {
+    logger.debug('stray attach: not retiring the source listing, the target gym is itself a synced listing', {
+      sourceGymId,
+      targetGymId: targetGym.id,
+    });
+    return;
+  }
+
+  await db.transaction(async (tx) => {
+    const gateRows = await loadRetireGateRows(tx, [sourceGymId, targetGym.id]);
+    const source = gateRows.get(sourceGymId);
+    const target = gateRows.get(targetGym.id);
+
+    if (!source || !target) {
+      logger.debug('stray attach: not retiring the source listing, a gym is merged, deleted or lacks coordinates', {
+        sourceGymId,
+        targetGymId: targetGym.id,
+        sourceEligible: Boolean(source),
+        targetEligible: Boolean(target),
+      });
+      return;
+    }
+    if (source.ownerId !== SYSTEM_BOARD_OWNER_ID || target.ownerId === SYSTEM_BOARD_OWNER_ID) {
+      logger.debug('stray attach: not retiring the source listing, ownership does not allow it', {
+        sourceGymId,
+        targetGymId: targetGym.id,
+      });
+      return;
+    }
+    if (source.boardCount > 0 || source.memberCount > 0 || source.openClaimCount > 0 || source.liveKioskCount > 0) {
+      logger.debug('stray attach: not retiring the source listing, it is still in use', {
+        sourceGymId,
+        boardCount: source.boardCount,
+        memberCount: source.memberCount,
+        openClaimCount: source.openClaimCount,
+        liveKioskCount: source.liveKioskCount,
+      });
+      return;
+    }
+
+    const mergeResult = await mergeGymsIntoCanonical(tx, toMergeCandidate(target), [toMergeCandidate(source)]);
+
+    // Belt and braces: a retired listing must never be refreshed back to life by
+    // the location sync, even if its alias is somehow re-pointed at it later.
+    await tx.execute(sql`UPDATE gyms SET sync_frozen_at = NOW() WHERE id = ${sourceGymId}`);
+
+    await tx.insert(dbSchema.gymMergeAudit).values({
+      action: 'merged',
+      canonicalGymId: target.id,
+      duplicateGymId: source.id,
+      clusterSignature: computeClusterSignature([target.id, source.id]),
+      movedCounts: mergeResult.counts,
+      movedRows: mergeResult.movedRows,
+      warnings: mergeResult.warnings,
+      performedBy: actorUserId,
+    });
+
+    logger.info('stray attach emptied a synced listing; folded it into the target gym', {
+      sourceGymId,
+      targetGymId: target.id,
+      performedBy: actorUserId,
+    });
+  });
 }
 
 // ============================================
@@ -274,7 +495,17 @@ export const socialGymStrayBoardMutations = {
     // the bound param's type against the bigint column.
     const updated = await db
       .update(dbSchema.userBoards)
-      .set({ gymId: gym.id })
+      .set({
+        gymId: gym.id,
+        // A deliberate human link. Without the freeze the next location-sync run
+        // re-points the board straight back to the synced listing it came from
+        // (upsert.ts's board upsert is guarded only by
+        // `setWhere: isNull(userBoards.syncFrozenAt)`), silently undoing the
+        // attach and re-populating the listing we are about to retire. Mirrors
+        // updateBoard.
+        syncFrozenAt: new Date(),
+        updatedAt: new Date(),
+      })
       .where(
         and(
           eq(dbSchema.userBoards.id, target.boardId),
@@ -287,6 +518,22 @@ export const socialGymStrayBoardMutations = {
       throw new GraphQLError('This board changed before it could be attached. Refresh and try again.', {
         extensions: { code: 'CONFLICT' },
       });
+    }
+
+    // The board has moved and that write is committed. If it was the last board
+    // on a synced listing, fold that now-empty listing into this gym so it stops
+    // showing up in search as a board-less twin (#4188). A failure here must not
+    // turn a successful attach into a GraphQL error.
+    if (target.currentGymId != null && target.currentGymId !== gym.id) {
+      try {
+        await retireEmptiedSourceGym(target.currentGymId, gym, userId);
+      } catch (error) {
+        logger.error('failed to retire the listing a stray attach emptied', {
+          sourceGymId: target.currentGymId,
+          targetGymId: gym.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
     return true;
   },

--- a/packages/backend/src/graphql/resolvers/social/gym-stray-boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-stray-boards.ts
@@ -52,9 +52,10 @@ type StrayBoardCandidate = {
   distanceMeters: number | null;
   reason: StrayBoardReason;
   /**
-   * True when this is the only live board left on its current listing, so
-   * attaching it empties that listing (and retires it — see
-   * {@link retireEmptiedSourceGym}). Always false for an unlinked board.
+   * True when attaching this board empties the auto-synced listing it sits on,
+   * which {@link retireEmptiedSourceGym} then folds into the target gym. False
+   * for an unlinked board, and for a listing that never folds — see
+   * {@link markLastBoardAtCurrentGym}.
    */
   isLastBoardAtCurrentGym: boolean;
 };
@@ -243,6 +244,16 @@ export async function findStrayBoardCandidates(gym: GymRow, viewerUserId: string
  * Fills in `isLastBoardAtCurrentGym` for every candidate that sits on a listing,
  * with ONE grouped count over the distinct listings involved (never a query per
  * row). Mutates in place — the candidates are freshly built above.
+ *
+ * The flag is a promise that attaching this board folds its listing away, so it
+ * is only ever set for a listing {@link retireEmptiedSourceGym} would actually
+ * fold: live, not already merged, and SYSTEM-owned. Without those gates every
+ * MERGED_TWIN leftover would be flagged (a twin is already merged, and one
+ * leftover board is the usual shape), putting a merge confirm in front of a
+ * merge that never runs. The fold's other refusals — a claim, a member or a
+ * kiosk on the listing — are deliberately NOT mirrored here: any of them can
+ * appear between this read and the tap, and a warning about a fold that then
+ * gets refused is cheaper than silence about one that runs.
  */
 async function markLastBoardAtCurrentGym(candidates: StrayBoardCandidate[]): Promise<void> {
   const listingIds = [
@@ -257,7 +268,16 @@ async function markLastBoardAtCurrentGym(candidates: StrayBoardCandidate[]): Pro
   const counts = await db
     .select({ gymId: dbSchema.userBoards.gymId, boardCount: sql<number>`count(*)::int` })
     .from(dbSchema.userBoards)
-    .where(and(inArray(dbSchema.userBoards.gymId, listingIds), isNull(dbSchema.userBoards.deletedAt)))
+    .innerJoin(dbSchema.gyms, eq(dbSchema.userBoards.gymId, dbSchema.gyms.id))
+    .where(
+      and(
+        inArray(dbSchema.userBoards.gymId, listingIds),
+        isNull(dbSchema.userBoards.deletedAt),
+        isNull(dbSchema.gyms.deletedAt),
+        isNull(dbSchema.gyms.mergedIntoGymId),
+        eq(dbSchema.gyms.ownerId, SYSTEM_BOARD_OWNER_ID),
+      ),
+    )
     .groupBy(dbSchema.userBoards.gymId);
 
   const boardCountByGymId = new Map(counts.map((row) => [Number(row.gymId), Number(row.boardCount)]));
@@ -330,10 +350,20 @@ async function loadRetireGateRows(tx: TransactionDb, gymIds: number[]): Promise<
       g.longitude AS "longitude",
       g.created_at AS "createdAt",
       g.owner_id AS "ownerId",
-      COALESCE(board_counts.count, 0)::int AS "boardCount",
-      COALESCE(member_counts.count, 0)::int AS "memberCount",
-      COALESCE(follower_counts.count, 0)::int AS "followerCount",
-      COALESCE(comment_counts.count, 0)::int AS "commentCount",
+      -- Per-gym scalar subqueries rather than grouped joins: at most two gyms are
+      -- locked here, so these are index lookups, where a GROUP BY gym_id subquery
+      -- would aggregate the whole of user_boards/gym_follows/comments on every
+      -- attach — while holding the row locks above.
+      (
+        SELECT count(*)::int FROM user_boards
+         WHERE gym_id = g.id AND deleted_at IS NULL
+      ) AS "boardCount",
+      (SELECT count(*)::int FROM gym_members WHERE gym_id = g.id) AS "memberCount",
+      (SELECT count(*)::int FROM gym_follows WHERE gym_id = g.id) AS "followerCount",
+      (
+        SELECT count(*)::int FROM comments
+         WHERE entity_type = 'gym' AND entity_id = g.uuid AND deleted_at IS NULL
+      ) AS "commentCount",
       (
         SELECT count(*)::int FROM gym_claims
          WHERE gym_id = g.id AND status IN ('pending', 'approved')
@@ -343,19 +373,6 @@ async function loadRetireGateRows(tx: TransactionDb, gymIds: number[]): Promise<
          WHERE gym_id = g.id AND deleted_at IS NULL
       ) AS "liveKioskCount"
     FROM locked_gym g
-    LEFT JOIN (
-      SELECT gym_id, count(*) AS count FROM user_boards WHERE deleted_at IS NULL GROUP BY gym_id
-    ) board_counts ON board_counts.gym_id = g.id
-    LEFT JOIN (
-      SELECT gym_id, count(*) AS count FROM gym_members GROUP BY gym_id
-    ) member_counts ON member_counts.gym_id = g.id
-    LEFT JOIN (
-      SELECT gym_id, count(*) AS count FROM gym_follows GROUP BY gym_id
-    ) follower_counts ON follower_counts.gym_id = g.id
-    LEFT JOIN (
-      SELECT entity_id, count(*) AS count FROM comments
-      WHERE entity_type = 'gym' AND deleted_at IS NULL GROUP BY entity_id
-    ) comment_counts ON comment_counts.entity_id = g.uuid
   `,
   );
   return new Map(rows.map((row) => [Number(row.id), { ...row, id: Number(row.id) }]));

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -2877,6 +2877,8 @@ type StrayBoard {
   distanceMeters: Float
   "Why this board is a candidate for this gym."
   reason: StrayBoardReason!
+  "True when this is the only board left on its current listing — attaching it retires that listing into this gym. Always false for an unlinked board."
+  isLastBoardAtCurrentGym: Boolean!
 }
 
 """

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -2877,7 +2877,7 @@ type StrayBoard {
   distanceMeters: Float
   "Why this board is a candidate for this gym."
   reason: StrayBoardReason!
-  "True when this is the only board left on its current listing — attaching it retires that listing into this gym. Always false for an unlinked board."
+  "True when attaching this board empties the auto-synced listing it sits on, which then folds into this gym. False for an unlinked board, and for a listing that never folds (already merged, or owned by a person)."
   isLastBoardAtCurrentGym: Boolean!
 }
 

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -7105,6 +7105,8 @@ export type StrayBoard = {
   currentGymUuid?: Maybe<Scalars['ID']['output']>;
   /** Metres from this gym's location to the board; null when either lacks coordinates. */
   distanceMeters?: Maybe<Scalars['Float']['output']>;
+  /** True when this is the only board left on its current listing — attaching it retires that listing into this gym. Always false for an unlinked board. */
+  isLastBoardAtCurrentGym: Scalars['Boolean']['output'];
   /** The board's display name. */
   name: Scalars['String']['output'];
   /** Why this board is a candidate for this gym. */
@@ -12596,6 +12598,7 @@ export type StrayBoardResolvers<
   currentGymName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   currentGymUuid?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   distanceMeters?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  isLastBoardAtCurrentGym?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   reason?: Resolver<ResolversTypes['StrayBoardReason'], ParentType, ContextType>;
   uuid?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -7105,7 +7105,7 @@ export type StrayBoard = {
   currentGymUuid?: Maybe<Scalars['ID']['output']>;
   /** Metres from this gym's location to the board; null when either lacks coordinates. */
   distanceMeters?: Maybe<Scalars['Float']['output']>;
-  /** True when this is the only board left on its current listing — attaching it retires that listing into this gym. Always false for an unlinked board. */
+  /** True when attaching this board empties the auto-synced listing it sits on, which then folds into this gym. False for an unlinked board, and for a listing that never folds (already merged, or owned by a person). */
   isLastBoardAtCurrentGym: Scalars['Boolean']['output'];
   /** The board's display name. */
   name: Scalars['String']['output'];

--- a/packages/shared-schema/src/schema/gyms.ts
+++ b/packages/shared-schema/src/schema/gyms.ts
@@ -177,7 +177,7 @@ export const gymsTypeDefs = /* GraphQL */ `
     distanceMeters: Float
     "Why this board is a candidate for this gym."
     reason: StrayBoardReason!
-    "True when this is the only board left on its current listing — attaching it retires that listing into this gym. Always false for an unlinked board."
+    "True when attaching this board empties the auto-synced listing it sits on, which then folds into this gym. False for an unlinked board, and for a listing that never folds (already merged, or owned by a person)."
     isLastBoardAtCurrentGym: Boolean!
   }
 

--- a/packages/shared-schema/src/schema/gyms.ts
+++ b/packages/shared-schema/src/schema/gyms.ts
@@ -177,6 +177,8 @@ export const gymsTypeDefs = /* GraphQL */ `
     distanceMeters: Float
     "Why this board is a candidate for this gym."
     reason: StrayBoardReason!
+    "True when this is the only board left on its current listing — attaching it retires that listing into this gym. Always false for an unlinked board."
+    isLastBoardAtCurrentGym: Boolean!
   }
 
   """

--- a/packages/shared-schema/src/types/gyms.ts
+++ b/packages/shared-schema/src/types/gyms.ts
@@ -107,8 +107,9 @@ export type StrayBoard = {
   distanceMeters?: number | null;
   reason: StrayBoardReason;
   /**
-   * True when this is the only board left on its current listing — attaching it
-   * retires that listing into this gym. Always false for an unlinked board.
+   * True when attaching this board empties the auto-synced listing it sits on,
+   * which then folds into this gym. False for an unlinked board, and for a
+   * listing that never folds (already merged, or owned by a person).
    */
   isLastBoardAtCurrentGym: boolean;
 };

--- a/packages/shared-schema/src/types/gyms.ts
+++ b/packages/shared-schema/src/types/gyms.ts
@@ -106,6 +106,11 @@ export type StrayBoard = {
   /** Metres from this gym's location to the board; null when either lacks coordinates. */
   distanceMeters?: number | null;
   reason: StrayBoardReason;
+  /**
+   * True when this is the only board left on its current listing — attaching it
+   * retires that listing into this gym. Always false for an unlinked board.
+   */
+  isLastBoardAtCurrentGym: boolean;
 };
 
 export type AttachBoardToGymInput = {

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -7102,7 +7102,7 @@ export type StrayBoard = {
   currentGymUuid?: Maybe<Scalars['ID']['output']>;
   /** Metres from this gym's location to the board; null when either lacks coordinates. */
   distanceMeters?: Maybe<Scalars['Float']['output']>;
-  /** True when this is the only board left on its current listing — attaching it retires that listing into this gym. Always false for an unlinked board. */
+  /** True when attaching this board empties the auto-synced listing it sits on, which then folds into this gym. False for an unlinked board, and for a listing that never folds (already merged, or owned by a person). */
   isLastBoardAtCurrentGym: Scalars['Boolean']['output'];
   /** The board's display name. */
   name: Scalars['String']['output'];

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -7102,6 +7102,8 @@ export type StrayBoard = {
   currentGymUuid?: Maybe<Scalars['ID']['output']>;
   /** Metres from this gym's location to the board; null when either lacks coordinates. */
   distanceMeters?: Maybe<Scalars['Float']['output']>;
+  /** True when this is the only board left on its current listing — attaching it retires that listing into this gym. Always false for an unlinked board. */
+  isLastBoardAtCurrentGym: Scalars['Boolean']['output'];
   /** The board's display name. */
   name: Scalars['String']['output'];
   /** Why this board is a candidate for this gym. */

--- a/packages/shared/graphql/src/operations/gyms.ts
+++ b/packages/shared/graphql/src/operations/gyms.ts
@@ -190,6 +190,7 @@ export const STRAY_BOARDS_FOR_GYM = gql`
       currentGymName
       distanceMeters
       reason
+      isLastBoardAtCurrentGym
     }
   }
 `;

--- a/packages/shared/i18n/locales/de/kiosk.json
+++ b/packages/shared/i18n/locales/de/kiosk.json
@@ -267,6 +267,10 @@
         "attach": "Zur Halle hinzufügen",
         "attached": "Board zu deiner Halle hinzugefügt.",
         "attachFailed": "Dieses Board ließ sich nicht hinzufügen.",
+        "lastBoardNote": "Letztes Board auf diesem Eintrag",
+        "lastBoardTitle": "Damit wird der andere Eintrag leer",
+        "lastBoardBody": "\"{{name}}\" hat kein weiteres Board. Häng dieses hier dran, dann geht der Eintrag in deiner Halle auf. Alte Links landen weiterhin hier, und er taucht nicht mehr als leeres Duplikat in der Suche auf.",
+        "lastBoardConfirm": "Hinzufügen und zusammenführen",
         "empty": "Gerade nichts Loses. Jedes Board in der Nähe deiner Halle steht schon in deinem Eintrag.",
         "loadError": "Konnte nicht nach herrenlosen Boards suchen.",
         "retry": "Nochmal versuchen"

--- a/packages/shared/i18n/locales/en-US/kiosk.json
+++ b/packages/shared/i18n/locales/en-US/kiosk.json
@@ -267,6 +267,10 @@
         "attach": "Add to gym",
         "attached": "Board added to your gym.",
         "attachFailed": "Couldn't add that board.",
+        "lastBoardNote": "Last board on that listing",
+        "lastBoardTitle": "This empties the other listing",
+        "lastBoardBody": "\"{{name}}\" has no other boards. Add this one and that listing folds into your gym — old links still land here, and it stops turning up in search as an empty duplicate.",
+        "lastBoardConfirm": "Add and merge",
         "empty": "Nothing loose right now. Every board near your gym is already on your listing.",
         "loadError": "Couldn't check for stray boards.",
         "retry": "Try again"

--- a/packages/shared/i18n/locales/es/kiosk.json
+++ b/packages/shared/i18n/locales/es/kiosk.json
@@ -267,6 +267,10 @@
         "attach": "Añadir al rocódromo",
         "attached": "Plafón añadido a tu rocódromo.",
         "attachFailed": "No se pudo añadir ese plafón.",
+        "lastBoardNote": "Último plafón de esa ficha",
+        "lastBoardTitle": "Esto deja vacía la otra ficha",
+        "lastBoardBody": "«{{name}}» no tiene más plafones. Añade este y esa ficha se fusiona con tu rocódromo: los enlaces antiguos siguen llegando aquí y deja de aparecer en las búsquedas como un duplicado vacío.",
+        "lastBoardConfirm": "Añadir y fusionar",
         "empty": "Nada suelto por ahora. Todos los plafones cerca de tu rocódromo ya están en tu ficha.",
         "loadError": "No se pudieron buscar plafones sueltos.",
         "retry": "Reintentar"

--- a/packages/shared/i18n/locales/fr/kiosk.json
+++ b/packages/shared/i18n/locales/fr/kiosk.json
@@ -267,6 +267,10 @@
         "attach": "Ajouter à la salle",
         "attached": "Board ajoutée à ta salle.",
         "attachFailed": "Impossible d'ajouter cette board.",
+        "lastBoardNote": "Dernière board de cette fiche",
+        "lastBoardTitle": "Ça vide l'autre fiche",
+        "lastBoardBody": "« {{name}} » n'a plus d'autre board. Ajoute celle-ci et cette fiche fusionne avec ta salle : les anciens liens arrivent toujours ici, et elle n'apparaît plus dans la recherche comme un doublon vide.",
+        "lastBoardConfirm": "Ajouter et fusionner",
         "empty": "Rien qui traîne pour l'instant. Toutes les boards près de ta salle sont déjà sur ta fiche.",
         "loadError": "Impossible de chercher les boards égarées.",
         "retry": "Réessayer"

--- a/packages/web/app/components/gym-entity/manage/__tests__/gym-boards-tab.test.tsx
+++ b/packages/web/app/components/gym-entity/manage/__tests__/gym-boards-tab.test.tsx
@@ -167,6 +167,7 @@ describe('GymBoardsTab — stray boards', () => {
       currentGymName: null,
       distanceMeters: 42,
       reason: 'NEARBY',
+      isLastBoardAtCurrentGym: false,
       ...overrides,
     };
   }
@@ -249,6 +250,95 @@ describe('GymBoardsTab — stray boards', () => {
 
     expect(await screen.findByText(/couldn't check for stray boards/i)).toBeTruthy();
     expect(screen.getByRole('button', { name: /try again/i })).toBeTruthy();
+  });
+
+  it('asks before attaching the last board on a listing, and only then fires the mutation', async () => {
+    stubRequests({
+      gymBoards: [],
+      myBoards: [],
+      strays: [
+        makeStray({
+          uuid: 'stray-last',
+          name: 'Lonely Kilter',
+          currentGymUuid: 'other-gym',
+          currentGymName: 'Auto Listing',
+          isLastBoardAtCurrentGym: true,
+        }),
+      ],
+    });
+    render(<GymBoardsTab gym={editableGym} onGymChange={vi.fn()} />);
+
+    await screen.findByText('Lonely Kilter');
+    expect(screen.getByText(/last board on that listing/i)).toBeTruthy();
+    mockExecute.mockResolvedValueOnce({ attachBoardToGym: true });
+
+    fireEvent.click(screen.getByRole('button', { name: /add to gym/i }));
+
+    // The confirm step must land before anything is written.
+    expect(await screen.findByText(/this empties the other listing/i)).toBeTruthy();
+    expect(screen.getByText(/"Auto Listing" has no other boards/i)).toBeTruthy();
+    expect(mockExecute).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /add and merge/i }));
+
+    await waitFor(() =>
+      expect(mockExecute).toHaveBeenCalledWith({
+        input: { gymUuid: GYM_UUID, boardUuid: 'stray-last' },
+      }),
+    );
+  });
+
+  it('leaves the board alone when the merge confirm is cancelled', async () => {
+    stubRequests({
+      gymBoards: [],
+      myBoards: [],
+      strays: [
+        makeStray({
+          uuid: 'stray-last',
+          name: 'Lonely Kilter',
+          currentGymUuid: 'other-gym',
+          currentGymName: 'Auto Listing',
+          isLastBoardAtCurrentGym: true,
+        }),
+      ],
+    });
+    render(<GymBoardsTab gym={editableGym} onGymChange={vi.fn()} />);
+
+    await screen.findByText('Lonely Kilter');
+    fireEvent.click(screen.getByRole('button', { name: /add to gym/i }));
+    await screen.findByText(/this empties the other listing/i);
+
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+    await waitFor(() => expect(screen.queryByText(/this empties the other listing/i)).toBeNull());
+    expect(mockExecute).not.toHaveBeenCalled();
+    expect(screen.getByText('Lonely Kilter')).toBeTruthy();
+  });
+
+  it('keeps the one-tap path for a board that is not the last on its listing', async () => {
+    stubRequests({
+      gymBoards: [],
+      myBoards: [],
+      strays: [
+        makeStray({
+          uuid: 'stray-nearby',
+          name: 'Nearby Tension',
+          currentGymUuid: 'other-gym',
+          currentGymName: 'Auto Listing',
+          isLastBoardAtCurrentGym: false,
+        }),
+      ],
+    });
+    render(<GymBoardsTab gym={editableGym} onGymChange={vi.fn()} />);
+
+    await screen.findByText('Nearby Tension');
+    expect(screen.queryByText(/last board on that listing/i)).toBeNull();
+    mockExecute.mockResolvedValueOnce({ attachBoardToGym: true });
+
+    fireEvent.click(screen.getByRole('button', { name: /add to gym/i }));
+
+    await waitFor(() => expect(mockExecute).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText(/this empties the other listing/i)).toBeNull();
   });
 
   it('does not render the strays section without gym edit access', async () => {

--- a/packages/web/app/components/gym-entity/manage/gym-boards-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/gym-boards-tab.tsx
@@ -43,6 +43,7 @@ import type { StrayBoard, UserBoard } from '@boardsesh/shared-schema';
 import { boardTypeLabel } from '@boardsesh/board-constants';
 import { themeTokens } from '@/app/theme/theme-config';
 import { canManageGymBoards, canUnlinkBoard, linkableBoards } from './gym-board-permissions';
+import ConfirmDialog from './confirm-dialog';
 import type { GymManageTabProps } from './tab-props';
 
 export function VisibilityChip({ board }: { board: Pick<UserBoard, 'isPublic' | 'isUnlisted'> }) {
@@ -363,6 +364,10 @@ type StrayBoardsSectionProps = {
  * this gym (within ~150 m, unlinked or on a synced listing) or left behind by a
  * merged listing. One tap re-points the board to this gym. Only mounted for
  * viewers with gym edit access — the resolver enforces the same gate.
+ *
+ * A board flagged `isLastBoardAtCurrentGym` is the exception to one-tap: taking
+ * it empties its listing, and the backend then folds that listing into this gym,
+ * so the consequence gets a confirm step instead of happening silently.
  */
 function StrayBoardsSection({ gymUuid, onAttached }: StrayBoardsSectionProps) {
   const { t } = useTranslation('kiosk');
@@ -370,6 +375,7 @@ function StrayBoardsSection({ gymUuid, onAttached }: StrayBoardsSectionProps) {
   const [strays, setStrays] = useState<StrayBoard[] | null>(null);
   const [loadError, setLoadError] = useState(false);
   const [attachingUuid, setAttachingUuid] = useState<string | null>(null);
+  const [mergeConfirmTarget, setMergeConfirmTarget] = useState<StrayBoard | null>(null);
 
   const attachMutation = useEntityMutation<AttachBoardToGymMutationResponse, AttachBoardToGymMutationVariables>(
     ATTACH_BOARD_TO_GYM,
@@ -413,6 +419,25 @@ function StrayBoardsSection({ gymUuid, onAttached }: StrayBoardsSectionProps) {
     },
     [attachMutation, gymUuid, onAttached],
   );
+
+  const handleAttachClick = useCallback(
+    (board: StrayBoard) => {
+      if (board.isLastBoardAtCurrentGym) {
+        setMergeConfirmTarget(board);
+        return;
+      }
+      void handleAttach(board);
+    },
+    [handleAttach],
+  );
+
+  const handleMergeConfirm = useCallback(() => {
+    const board = mergeConfirmTarget;
+    setMergeConfirmTarget(null);
+    if (board) {
+      void handleAttach(board);
+    }
+  }, [mergeConfirmTarget, handleAttach]);
 
   const reasonText = (board: StrayBoard): string => {
     if (board.reason === 'MERGED_TWIN') {
@@ -476,7 +501,7 @@ function StrayBoardsSection({ gymUuid, onAttached }: StrayBoardsSectionProps) {
                   variant="contained"
                   startIcon={<AddLinkOutlined />}
                   disabled={attachingUuid !== null}
-                  onClick={() => handleAttach(board)}
+                  onClick={() => handleAttachClick(board)}
                   sx={{ textTransform: 'none' }}
                 >
                   {attachingUuid === board.uuid ? (
@@ -488,7 +513,19 @@ function StrayBoardsSection({ gymUuid, onAttached }: StrayBoardsSectionProps) {
               }
             >
               <ListItemText
-                primary={board.name}
+                primary={
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+                    <Typography component="span">{board.name}</Typography>
+                    {board.isLastBoardAtCurrentGym && (
+                      <Chip
+                        size="small"
+                        color="warning"
+                        variant="outlined"
+                        label={t('manage.boards.strays.lastBoardNote')}
+                      />
+                    )}
+                  </Box>
+                }
                 secondary={
                   board.currentGymName
                     ? `${reasonText(board)} · ${t('manage.boards.strays.onListing', { name: board.currentGymName })}`
@@ -499,6 +536,17 @@ function StrayBoardsSection({ gymUuid, onAttached }: StrayBoardsSectionProps) {
           ))}
         </List>
       )}
+
+      <ConfirmDialog
+        open={mergeConfirmTarget !== null}
+        title={t('manage.boards.strays.lastBoardTitle')}
+        body={t('manage.boards.strays.lastBoardBody', { name: mergeConfirmTarget?.currentGymName ?? '' })}
+        confirmLabel={t('manage.boards.strays.lastBoardConfirm')}
+        cancelLabel={t('manage.boards.cancel')}
+        confirmColor="primary"
+        onConfirm={handleMergeConfirm}
+        onClose={() => setMergeConfirmTarget(null)}
+      />
     </Box>
   );
 }


### PR DESCRIPTION
## Summary

Taking the **last** board off an auto-synced gym listing left that listing live and public with nothing on it, so it kept coming back in gym search as a plausible-looking duplicate of the gym the board had just moved to — the exact duplicate problem #3843's attach flow was meant to solve. Closes #4188.

Three parts:

**The attach now sticks.** `attachBoardToGym` sets `sync_frozen_at` on the board it re-points. `packages/location-sync/src/upsert.ts` upserts catalog boards with `set: { gymId: excluded.gym_id }` guarded only by `setWhere: isNull(userBoards.syncFrozenAt)`, so without the freeze the next sync run put the board straight back on the synced listing and re-populated it. `updateBoard` and `updateGym` already do this on any human edit.

**The emptied listing gets folded, not deleted.** When an attach leaves its source listing with zero live boards, the listing is folded into the target gym through `mergeGymsIntoCanonical` — the same primitive the admin duplicates queue uses. Soft-delete plus `merged_into_gym_id`, so old uuids and slugs still resolve to the survivor; the listing's `location_sync_gym_sources` alias moves across, which is what stops the sync re-minting the same empty listing; and a `gym_merge_audit` row (`action: 'merged'`, `performed_by` = the attaching user) records exactly what moved so an admin can reverse it. No row is destroyed.

The fold is deliberately narrow. All of these must hold or it silently does nothing: source is SYSTEM-owned, live, un-merged, has zero live boards, no pending or approved claim, no members, no live kiosk, and has coordinates; target has coordinates and is **not** SYSTEM-owned. A refusal is a debug log and a plain return — the board move is already committed, so a skipped or failed fold never turns a successful attach into a GraphQL error.

**The Boards tab warns first.** `StrayBoard` gains `isLastBoardAtCurrentGym` (one grouped count over the listings in the result, not a query per row). A flagged stray shows a "Last board on that listing" chip and its **Add to gym** tap goes through a confirm dialog naming the listing; everything else keeps the one-tap path. New strings in en-US, es, fr and de.

On the issue's second question — "is it possible to steal a gym?" — the existing gates hold up. `strayBoardsForGym` and `attachBoardToGym` both require edit access on the **target**; NEARBY candidates only come off a SYSTEM listing or an unlinked board, and only for SYSTEM-owned or the viewer's own boards, with `hide_location` boards excluded; MERGED_TWIN candidates only exist after an admin merge; and approving a claim reassigns `gyms.owner_id` to the claimant, so a claimed gym's boards stop being strays. One gap remains and is **not** fixed here: a listing with a *pending* claim is still SYSTEM-owned, so a third party can still vacuum its boards mid-claim. This PR refuses to retire such a listing; excluding it from stray candidates entirely wants its own issue.

## Release Notes

- Moving the last board off an auto-generated gym listing now folds that listing into your gym instead of leaving an empty duplicate in gym search — old links still land on the right place.
- The Boards tab tells you when a board is the last one on its listing, and asks before it merges.

## Test plan

- `vp run codegen` — clean, generated files committed.
- `vp run typecheck` — green.
- `vp test run --project backend --reporter=agent gym-stray-boards` — 29/29 green. Eleven new cases: the fold (soft-delete + `is_public=false` + `merged_into_gym_id`), the audit row, the source-alias move, a non-last board leaving the listing live, each refusal gate (pending claim, approved claim, member, live kiosk, SYSTEM target, already-merged twin), the unlinked-board no-op, `sync_frozen_at` on the attached board, and `isLastBoardAtCurrentGym` true/false/unlinked.
  Caveat: this machine's backend worker DBs on :5433 are shared with parallel worktrees, and intermittent runs failed on `users` being truncated mid-test or a TRUNCATE deadlock — always during seeding, never an assertion. Pointing `DATABASE_URL` at a private database name gives a clean deterministic 29/29. `gym-duplicates.test.ts` (the other `mergeGymsIntoCanonical` caller) passes unchanged.
- `vp run test:web` — 5910/5910 across 480 files, including four new `gym-boards-tab` cases (chip renders, confirm gates the mutation, cancel writes nothing, non-flagged strays keep one tap).
- `vp run check:i18n` and `vp run check:i18n:orphans` — OK.
- `vp check` — no new diagnostics in any touched file.
- No migration, no mobile surface, no Bluetooth code.
