### PR TITLE
fix(mobile): serve dark MoonBoard art in PlaylistBoardBackdrop

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
@@ -214,6 +214,7 @@ vi.mock('../../../../src/providers/theme-provider', () => ({
     brandColors: { primary: '#6D28D9' },
     features: { filtersInTopChrome: false, summaryExcludesGradeFilter: false },
   }),
+  useAppColorScheme: () => 'light',
 }));
 
 vi.mock('../../../../src/theme/variants', () => ({
@@ -439,6 +440,7 @@ describe('ClimbList board-art pre-warm (#3191 regression guard)', () => {
         layoutId: 1,
         sizeId: 10,
         setIds: [1],
+        colorScheme: 'light',
       }),
     );
 

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -46,7 +46,7 @@ import { FilterTokenRow } from '../../../src/components/search/FilterTokenRow';
 import { GradeRangeRail } from '../../../src/components/grade';
 import { applyPopularityBucket } from '../../../src/lib/filter-chip-menus';
 import { useDrawerHost } from '../../../src/providers/drawer-host-provider';
-import { useTheme } from '../../../src/providers/theme-provider';
+import { useTheme, useAppColorScheme } from '../../../src/providers/theme-provider';
 import { selectByVariant } from '../../../src/theme/variants';
 import { useActiveClimbUuid, useQueueActions } from '../../../src/providers/queue-provider';
 import { ClimbSearchProvider, useClimbSearch, type GradeBound } from '../../../src/providers/climb-search-provider';
@@ -188,6 +188,7 @@ function ClimbListInner() {
     setRevealTipVisible(false);
   }, [openBoardSheet]);
   const { systemColors, variant, brandColors, features } = useTheme();
+  const colorScheme = useAppColorScheme();
   // The ⋮ quick-actions button is a user setting that defaults on (More → Display
   // lets climbers turn it off).
   const { enabled: quickActionsButtonEnabled } = useClimbQuickActionsButton();
@@ -576,12 +577,13 @@ function ClimbListInner() {
         layoutId: activeBoard.layoutId,
         sizeId: activeBoard.sizeId,
         setIds: parsedSetIds,
+        colorScheme,
       });
     });
     return () => {
       task.cancel();
     };
-  }, [activeBoard]);
+  }, [activeBoard, colorScheme]);
 
   const searchInput = useMemo(
     () =>

--- a/packages/mobile/src/components/playlist/PlaylistBoardBackdrop.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistBoardBackdrop.tsx
@@ -3,6 +3,7 @@ import { StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
 import { getBoardConfigForPlaylist } from '../../lib/playlists/board-details-for-playlist';
 import { tryGetBackgroundPathsSync, ensureBackgroundsCached } from '../../lib/background-image-cache';
+import { useAppColorScheme } from '../../providers/theme-provider';
 
 type PlaylistBoardBackdropProps = {
   boardType: string;
@@ -20,11 +21,17 @@ type PlaylistBoardBackdropProps = {
  */
 function PlaylistBoardBackdropImpl({ boardType, layoutId }: PlaylistBoardBackdropProps) {
   const config = useMemo(() => getBoardConfigForPlaylist(boardType, layoutId), [boardType, layoutId]);
+  const colorScheme = useAppColorScheme();
 
   // This backdrop is blurred + dimmed to 35% opacity, so the 416px thumb
   // variant is plenty — and it keeps expo-image from resampling a ~1080px
-  // source on the main thread.
-  const backdropConfig = useMemo(() => (config ? { ...config, variant: 'thumb' as const } : null), [config]);
+  // source on the main thread. colorScheme picks up the MoonBoard `.dark.webp`
+  // siblings (issue #3885 / PR #3961) so the tile doesn't show the light art's
+  // near-black lettering and hold sheets behind the dark-mode colour tint.
+  const backdropConfig = useMemo(
+    () => (config ? { ...config, variant: 'thumb' as const, colorScheme } : null),
+    [config, colorScheme],
+  );
 
   // Sync fast-path so production builds paint the backdrop on the first frame.
   const [path, setPath] = useState<string | null>(() => {

--- a/packages/mobile/src/components/playlist/__tests__/playlist-board-backdrop.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-board-backdrop.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+const ctrl = vi.hoisted(() => ({
+  colorScheme: 'light' as 'light' | 'dark',
+  tryGetBackgroundPathsSync: vi.fn(),
+  ensureBackgroundsCached: vi.fn(),
+}));
+
+vi.mock('react-native', () => ({
+  StyleSheet: {
+    create: (styles: Record<string, unknown>) => styles,
+    absoluteFill: {},
+  },
+}));
+
+vi.mock('expo-image', () => ({
+  Image: ({ source }: { source: { uri: string } }) => createElement('img', { src: source.uri }),
+}));
+
+vi.mock('../../../lib/playlists/board-details-for-playlist', () => ({
+  getBoardConfigForPlaylist: () => ({
+    boardName: 'moonboard',
+    layoutId: 8,
+    sizeId: 23,
+    setIds: [51],
+  }),
+}));
+
+vi.mock('../../../lib/background-image-cache', () => ({
+  tryGetBackgroundPathsSync: ctrl.tryGetBackgroundPathsSync,
+  ensureBackgroundsCached: ctrl.ensureBackgroundsCached,
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useAppColorScheme: () => ctrl.colorScheme,
+}));
+
+import { PlaylistBoardBackdrop } from '../PlaylistBoardBackdrop';
+
+describe('PlaylistBoardBackdrop', () => {
+  it('resolves the dark MoonBoard art when the app is in dark mode', () => {
+    ctrl.colorScheme = 'dark';
+    ctrl.tryGetBackgroundPathsSync.mockReturnValue({ paths: ['/bundled/moonboard.dark.webp'], missingCount: 0 });
+    ctrl.ensureBackgroundsCached.mockClear();
+
+    const { container } = render(
+      createElement(PlaylistBoardBackdrop, { boardType: 'moonboard', layoutId: 8 }) as ReactNode,
+    );
+
+    expect(ctrl.tryGetBackgroundPathsSync).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: 'thumb', colorScheme: 'dark' }),
+    );
+    expect(container.querySelector('img')?.getAttribute('src')).toBe('/bundled/moonboard.dark.webp');
+  });
+
+  it('resolves the light MoonBoard art when the app is in light mode', () => {
+    ctrl.colorScheme = 'light';
+    ctrl.tryGetBackgroundPathsSync.mockReturnValue({ paths: ['/bundled/moonboard.webp'], missingCount: 0 });
+    ctrl.ensureBackgroundsCached.mockClear();
+
+    const { container } = render(
+      createElement(PlaylistBoardBackdrop, { boardType: 'moonboard', layoutId: 8 }) as ReactNode,
+    );
+
+    expect(ctrl.tryGetBackgroundPathsSync).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: 'thumb', colorScheme: 'light' }),
+    );
+    expect(container.querySelector('img')?.getAttribute('src')).toBe('/bundled/moonboard.webp');
+  });
+});

--- a/packages/mobile/src/lib/__tests__/background-image-cache.test.ts
+++ b/packages/mobile/src/lib/__tests__/background-image-cache.test.ts
@@ -403,8 +403,10 @@ describe('dark-mode art variants', () => {
       missingCount: 0,
     });
     // Omitting the param must behave exactly like passing 'light' — this is what
-    // keeps the callers that never pass it (PlaylistBoardBackdrop, the climbs-tab
-    // prefetch, the Live Activity thumbnail builder) rendering as they do today.
+    // keeps the one remaining caller that never passes it (the Live Activity
+    // thumbnail builder; PlaylistBoardBackdrop and the climbs-tab prefetch now
+    // thread the live app colour scheme through, see #3962) rendering as it
+    // does today.
     expect(explicitLight).toEqual(omitted);
   });
 

--- a/packages/mobile/src/lib/background-image-cache.ts
+++ b/packages/mobile/src/lib/background-image-cache.ts
@@ -209,8 +209,12 @@ type BackgroundParams = {
   /**
    * Colour scheme the art will be composited into. Defaults to `light`, which
    * resolves exactly what every caller resolved before dark variants existed —
-   * so the callers that don't pass it (PlaylistBoardBackdrop, the climbs-tab
-   * prefetch, the Live Activity thumbnail builder) keep their current output.
+   * so the one remaining caller that doesn't pass it (the Live Activity
+   * thumbnail builder, out of scope per issue #3962: Android composites
+   * natively with no ColorFilter and iOS uses a server-rendered thumbnail,
+   * so neither is reachable by this parameter) keeps its current output.
+   * PlaylistBoardBackdrop and the climbs-tab prefetch now thread the live
+   * app colour scheme through (see #3962).
    */
   colorScheme?: BackgroundColorScheme;
 };


### PR DESCRIPTION
## Summary

Closes #3962

`PlaylistBoardBackdrop` and the climbs-tab background prefetch resolved bundled
board art via `background-image-cache` without passing `colorScheme`, so both
silently took the `light` default even in dark mode. For MoonBoard playlists
this meant the near-black coordinate lettering and hold-sheet art (added by
#3961's dark-mode variants) rendered behind the dark-mode colour tint instead
of the readable `.dark.webp` sibling.

- `PlaylistBoardBackdrop.tsx` now reads `useAppColorScheme()` (the dedicated
  `ColorSchemeContext`, same pattern as `use-native-climb-render.ts`) and
  folds it into the `backdropConfig` memo, so the backdrop re-resolves on a
  live theme switch.
- `app/(tabs)/climbs/index.tsx`'s background prewarm effect now threads the
  same `colorScheme` through `ensureBackgroundsCached`, so the dark siblings
  are actually warmed before the play drawer requests them.
- The Live Activity thumbnail builder is intentionally **untouched** — per
  the issue, Android composites `backgroundPaths` natively in
  `BoardSessionService.kt` with no `ColorFilter`, and iOS uses a
  server-rendered thumbnail. Neither is reachable by this JS parameter, so it
  keeps defaulting to `light`. Updated the stale doc comments in
  `background-image-cache.ts` and its test to reflect that it's now the only
  remaining caller relying on the default.

## Visual evidence

Before/after screenshots could not be captured on this Linux host —
`vp run mobile:screenshot` / `check:mobile-simulator` are macOS-only and the
local Android emulator is unbootable here. The `mobile-screenshots-android.yml`
CI workflow does capture a playlist-library and playlist-detail shot in dark
mode (its `app-store` Maestro flow defaults to `theme: dark`), but neither
`app-store.yaml`/`app-store-android.yaml` targets a MoonBoard playlist
specifically, so an A/B dispatch of that workflow would not reliably surface
this bug either. @marcodejongh, please do a device pass (or a macOS
`vp run mobile:screenshot`) on a dark-mode playlists screen with a MoonBoard
playlist before merging. This PR should **not** be auto-merged without that
visual sign-off.

## Validation

- `vp run typecheck:mobile` — pass
- `vp run test:mobile` — pass (new `PlaylistBoardBackdrop` test covers dark
  vs light `colorScheme` resolution; existing `background-image-cache` test
  suite unchanged in behavior, comment-only update)
- `vp run check:mobile-bundle` — pass (run from this sibling worktree,
  outside `.claude/worktrees`)
- `vp check` — pass

## Release Notes

- Fixed dark-mode MoonBoard playlist tiles showing the light-mode board art
  (near-black coordinate lettering) instead of the readable dark variant.
