### PR TITLE
fix(sync): make circuit playlist sync idempotent under unique_playlist_climb

### DIFF
--- a/packages/aurora-sync/src/sync/json-import.test.ts
+++ b/packages/aurora-sync/src/sync/json-import.test.ts
@@ -11,6 +11,7 @@ import {
   isExportAscentActuallyAttempt,
   publishedClimbKey,
   readExportBool,
+  resolveCircuitClimbUuids,
   type AuroraExportAscent,
 } from './json-import';
 
@@ -360,5 +361,45 @@ describe('generateJsonImportCircuitAuroraId (#3526 / #3541)', () => {
     expect(generateJsonImportCircuitAuroraId('user-a', 'kilter', CIRCUIT, CREATED_AT)).toMatch(
       /^json-import-circuit-[0-9a-f]{32}$/,
     );
+  });
+});
+
+/**
+ * #4023: `unique_playlist_climb` is (playlist_id, climb_uuid). The JSON import
+ * resolves a circuit's climbs by NAME, so two entries collapsing onto one uuid
+ * used to produce duplicate insert rows, a raw 23505, and a rolled-back circuit
+ * that the climber only ever saw as a bumped `failed` count.
+ */
+describe('resolveCircuitClimbUuids (#4023)', () => {
+  const nameToUuid = new Map([
+    ['Crimp Ladder', 'uuid-a'],
+    ['Crimp Ladder ', 'uuid-a'],
+    ['Sloper Hell', 'uuid-b'],
+  ]);
+
+  it('collapses a climb listed twice under the same name to one row', () => {
+    expect(resolveCircuitClimbUuids(['Crimp Ladder', 'Sloper Hell', 'Crimp Ladder'], nameToUuid)).toEqual([
+      'uuid-a',
+      'uuid-b',
+    ]);
+  });
+
+  it('collapses two different names that resolve to the same uuid', () => {
+    expect(resolveCircuitClimbUuids(['Crimp Ladder', 'Crimp Ladder '], nameToUuid)).toEqual(['uuid-a']);
+  });
+
+  it('keeps the first occurrence, so circuit order survives the dedupe', () => {
+    expect(resolveCircuitClimbUuids(['Sloper Hell', 'Crimp Ladder', 'Sloper Hell'], nameToUuid)).toEqual([
+      'uuid-b',
+      'uuid-a',
+    ]);
+  });
+
+  it('drops names that resolve to nothing without disturbing the rest', () => {
+    expect(resolveCircuitClimbUuids(['Unknown Climb', 'Sloper Hell'], nameToUuid)).toEqual(['uuid-b']);
+  });
+
+  it('returns an empty list when nothing resolves, so the caller skips the delete', () => {
+    expect(resolveCircuitClimbUuids(['Unknown Climb'], nameToUuid)).toEqual([]);
   });
 });

--- a/packages/aurora-sync/src/sync/json-import.ts
+++ b/packages/aurora-sync/src/sync/json-import.ts
@@ -262,6 +262,30 @@ export function generateJsonImportCircuitAuroraId(
   return `json-import-circuit-${hash}`;
 }
 
+/**
+ * Resolve an export circuit's climb NAMES to climb uuids, dropping unresolved
+ * names and collapsing repeats.
+ *
+ * The dedupe is load-bearing, not tidiness: `unique_playlist_climb` is
+ * (playlist_id, climb_uuid), so a circuit that lists the same climb twice — or
+ * two distinct names that resolve to one uuid — produced duplicate rows and a
+ * raw 23505 that rolled the whole circuit's transaction back. The climber saw a
+ * bumped `failed` count and a silently missing circuit. Same index exposure the
+ * user-sync circuits branch fixes in #4023; extracted so it is testable without
+ * a database.
+ */
+export function resolveCircuitClimbUuids(climbNames: string[], nameToUuid: Map<string, string>): string[] {
+  const resolved: string[] = [];
+  const seen = new Set<string>();
+  for (const name of climbNames) {
+    const uuid = nameToUuid.get(name);
+    if (uuid == null || seen.has(uuid)) continue;
+    seen.add(uuid);
+    resolved.push(uuid);
+  }
+  return resolved;
+}
+
 export type JsonImportTickRow = typeof boardseshTicks.$inferInsert;
 
 /**
@@ -1622,9 +1646,7 @@ export async function importJsonExportData(
   // so one failure doesn't roll back others or abort the tick transaction)
   for (let ci = 0; ci < data.circuits.length; ci++) {
     const circuit = data.circuits[ci];
-    const resolvedClimbs = circuit.climbs
-      .map((name) => nameToUuid.get(name))
-      .filter((uuid): uuid is string => uuid != null);
+    const resolvedClimbs = resolveCircuitClimbUuids(circuit.climbs, nameToUuid);
 
     // The key is user-scoped (see generateJsonImportCircuitAuroraId), so two
     // importers can no longer collide on the global `playlists_aurora_id_idx`.
@@ -1727,7 +1749,14 @@ export async function importJsonExportData(
           }));
 
           for (let i = 0; i < climbValues.length; i += BATCH_SIZE) {
-            await tx.insert(playlistClimbs).values(climbValues.slice(i, i + BATCH_SIZE));
+            // Belt to the dedupe's braces: a re-import racing a concurrent
+            // addClimbToPlaylist can still land a row between the delete and
+            // this insert, and DO NOTHING keeps that one instead of aborting
+            // the circuit. #4023.
+            await tx
+              .insert(playlistClimbs)
+              .values(climbValues.slice(i, i + BATCH_SIZE))
+              .onConflictDoNothing({ target: [playlistClimbs.playlistId, playlistClimbs.climbUuid] });
           }
         }
 

--- a/packages/aurora-sync/src/sync/user-sync.test.ts
+++ b/packages/aurora-sync/src/sync/user-sync.test.ts
@@ -56,10 +56,15 @@ function createDbShim(
                 Promise.resolve(returningQueue[returningIdx++] ?? [{ id: BigInt(1) }]);
               return Object.assign(Promise.resolve(), { returning });
             },
-            onConflictDoNothing: () => Promise.resolve(),
+            onConflictDoNothing: (conflictArgs: unknown) => {
+              calls.push({ kind: 'conflict', table, args: [conflictArgs] });
+              return Promise.resolve();
+            },
           };
-          // playlist_climbs inserts are awaited straight off .values(), with no
-          // conflict clause — so the chain object has to be thenable too.
+          // Both the playlists upsert (.onConflictDoUpdate) and the
+          // playlist_climbs batch insert (.onConflictDoNothing) chain off
+          // .values() directly, so the chain object has to be thenable too —
+          // some callers await .values(...) with no conflict clause at all.
           return Object.assign(Promise.resolve(), chain);
         },
       };
@@ -294,6 +299,116 @@ describe('upsertTableData circuits — foreign-owner guard (#3526)', () => {
     expect(rendered.sql).toContain('"playlist_ownership"."user_id" <>');
     expect(rendered.params).toContain('owner');
     expect(rendered.params).toContain('user-b');
+  });
+});
+
+/**
+ * #4023: `unique_playlist_climb` is (playlist_id, climb_uuid) only — it
+ * doesn't know about angle — so a bare per-row insert throws a raw 23505
+ * whenever a circuit repeats a climb (e.g. the same climb at two angles) or a
+ * concurrent addClimbToPlaylist lands between the delete and the inserts.
+ * kilter-sync's applyCircuits already does diff + chunked batch insert +
+ * onConflictDoNothing for the same table; this mirrors that pattern.
+ */
+describe('upsertTableData circuits — playlist_climbs idempotency (#4023)', () => {
+  it('dedupes a repeated climb_uuid within one circuit, keeping the first occurrence', async () => {
+    const { db, calls } = createDbShim({
+      selectResults: [[{ upstreamId: 'circuit-1', ownerUserId: 'user-1' }]],
+      returningRows: [[{ id: BigInt(7) }]],
+    });
+
+    await upsertTableData(
+      db as unknown as ShimDb,
+      'tension',
+      'circuits',
+      144574,
+      'user-1',
+      [
+        circuit('circuit-1', 'Mine', [
+          { climb_uuid: 'climb-A', angle: 40, position: 0 },
+          { climb_uuid: 'climb-A', angle: 55, position: 1 },
+          { climb_uuid: 'climb-B', angle: 40, position: 2 },
+        ] as never),
+      ],
+      () => {},
+    );
+
+    const climbInsert = calls.find((call) => call.kind === 'insert' && call.table === playlistClimbs);
+    const rows = climbInsert?.args[0] as Array<{ climbUuid: string; angle: number | null; position: number }>;
+    expect(rows).toHaveLength(2);
+    // First occurrence (angle 40, position 0) wins over the angle-55 duplicate.
+    expect(rows).toEqual([
+      { playlistId: BigInt(7), climbUuid: 'climb-A', angle: 40, position: 0 },
+      { playlistId: BigInt(7), climbUuid: 'climb-B', angle: 40, position: 2 },
+    ]);
+  });
+
+  it('carries onConflictDoNothing targeting (playlist_id, climb_uuid) on the playlist_climbs insert', async () => {
+    const { db, calls } = createDbShim({
+      selectResults: [[{ upstreamId: 'circuit-1', ownerUserId: 'user-1' }]],
+      returningRows: [[{ id: BigInt(7) }]],
+    });
+
+    await upsertTableData(
+      db as unknown as ShimDb,
+      'tension',
+      'circuits',
+      144574,
+      'user-1',
+      [circuit('circuit-1', 'Mine', [{ climb_uuid: 'climb-A' }])],
+      () => {},
+    );
+
+    const conflictClause = calls.find((call) => call.kind === 'conflict' && call.table === playlistClimbs)?.args[0] as
+      | { target?: unknown[] }
+      | undefined;
+    expect(conflictClause?.target).toEqual([playlistClimbs.playlistId, playlistClimbs.climbUuid]);
+  });
+
+  it('deletes playlist_climbs before inserting the new rows', async () => {
+    const { db, calls } = createDbShim({
+      selectResults: [[{ upstreamId: 'circuit-1', ownerUserId: 'user-1' }]],
+      returningRows: [[{ id: BigInt(7) }]],
+    });
+
+    await upsertTableData(
+      db as unknown as ShimDb,
+      'tension',
+      'circuits',
+      144574,
+      'user-1',
+      [circuit('circuit-1', 'Mine', [{ climb_uuid: 'climb-A' }])],
+      () => {},
+    );
+
+    const deleteIdx = calls.findIndex((call) => call.kind === 'delete' && call.table === playlistClimbs);
+    const insertIdx = calls.findIndex((call) => call.kind === 'insert' && call.table === playlistClimbs);
+    expect(deleteIdx).toBeGreaterThanOrEqual(0);
+    expect(insertIdx).toBeGreaterThan(deleteIdx);
+  });
+
+  it('skips non-string climb entries and issues no insert when nothing survives', async () => {
+    const { db, insertsInto } = createDbShim({
+      selectResults: [[{ upstreamId: 'circuit-1', ownerUserId: 'user-1' }]],
+      returningRows: [[{ id: BigInt(7) }]],
+    });
+
+    await upsertTableData(
+      db as unknown as ShimDb,
+      'tension',
+      'circuits',
+      144574,
+      'user-1',
+      [
+        circuit('circuit-1', 'Mine', [
+          { climb_uuid: 42 as unknown as string },
+          { climb_uuid: null as unknown as string },
+        ]),
+      ],
+      () => {},
+    );
+
+    expect(insertsInto(playlistClimbs)).toHaveLength(0);
   });
 });
 

--- a/packages/aurora-sync/src/sync/user-sync.test.ts
+++ b/packages/aurora-sync/src/sync/user-sync.test.ts
@@ -410,6 +410,54 @@ describe('upsertTableData circuits — playlist_climbs idempotency (#4023)', () 
 
     expect(insertsInto(playlistClimbs)).toHaveLength(0);
   });
+
+  it('logs the dropped rows, because a silent dedupe is indistinguishable from Aurora never repeating a climb', async () => {
+    const { db } = createDbShim({
+      selectResults: [[{ upstreamId: 'circuit-1', ownerUserId: 'user-1' }]],
+      returningRows: [[{ id: BigInt(7) }]],
+    });
+    const lines: string[] = [];
+
+    await upsertTableData(
+      db as unknown as ShimDb,
+      'tension',
+      'circuits',
+      144574,
+      'user-1',
+      [
+        circuit('circuit-1', 'Mine', [
+          { climb_uuid: 'climb-A', angle: 40, position: 0 },
+          { climb_uuid: 'climb-A', angle: 55, position: 1 },
+          { climb_uuid: 'climb-A', angle: 70, position: 2 },
+        ] as never),
+      ],
+      (line) => lines.push(line),
+    );
+
+    expect(lines.some((line) => line.includes('circuit-1') && line.includes('dropped 2 repeated climb_uuid'))).toBe(
+      true,
+    );
+  });
+
+  it('stays quiet when nothing was dropped', async () => {
+    const { db } = createDbShim({
+      selectResults: [[{ upstreamId: 'circuit-1', ownerUserId: 'user-1' }]],
+      returningRows: [[{ id: BigInt(7) }]],
+    });
+    const lines: string[] = [];
+
+    await upsertTableData(
+      db as unknown as ShimDb,
+      'tension',
+      'circuits',
+      144574,
+      'user-1',
+      [circuit('circuit-1', 'Mine', [{ climb_uuid: 'climb-A' }, { climb_uuid: 'climb-B' }])],
+      (line) => lines.push(line),
+    );
+
+    expect(lines.some((line) => line.includes('dropped'))).toBe(false);
+  });
 });
 
 describe('upsertTableData circuits — race-guard suppression + owner lookup SQL', () => {

--- a/packages/aurora-sync/src/sync/user-sync.ts
+++ b/packages/aurora-sync/src/sync/user-sync.ts
@@ -428,29 +428,47 @@ export async function upsertTableData(
               angle: number | null;
               position: number;
             }> = [];
+            let droppedDuplicateClimbs = 0;
             for (let i = 0; i < item.climbs.length; i++) {
               const climb = item.climbs[i];
               const climbUuid = climb.climb_uuid || climb.uuid || climb;
               const climbAngle = climb.angle ?? null;
               const climbPosition = climb.position ?? i;
 
-              if (typeof climbUuid === 'string' && !seenClimbUuids.has(climbUuid)) {
-                seenClimbUuids.add(climbUuid);
-                climbRows.push({
-                  playlistId: playlist.id,
-                  climbUuid,
-                  angle: climbAngle,
-                  position: climbPosition,
-                });
+              if (typeof climbUuid !== 'string') continue;
+              if (seenClimbUuids.has(climbUuid)) {
+                droppedDuplicateClimbs++;
+                continue;
               }
+              seenClimbUuids.add(climbUuid);
+              climbRows.push({
+                playlistId: playlist.id,
+                climbUuid,
+                angle: climbAngle,
+                position: climbPosition,
+              });
+            }
+
+            // Dropping a row is data loss the climber never asked for: the
+            // circuit they see in Aurora has an entry ours won't. Right trade
+            // against wedging their entire sync, but it has to be visible —
+            // without this line there is no way to tell "Aurora never repeats a
+            // climb" from "we have been quietly truncating circuits for
+            // months". If this fires in prod, widening the index to include
+            // angle is the real fix.
+            if (droppedDuplicateClimbs > 0) {
+              log(
+                `  Circuit ${item.uuid}: dropped ${droppedDuplicateClimbs} repeated climb_uuid row(s) — unique_playlist_climb is (playlist_id, climb_uuid) and ignores angle`,
+              );
             }
 
             if (climbRows.length > 0) {
               // Chunked batch insert with onConflictDoNothing: a concurrent
               // addClimbToPlaylist landing mid-transaction (both run under
               // READ COMMITTED) no-ops instead of aborting the whole sync
-              // batch with a raw 23505. Same pattern as kilter-sync's
-              // applyCircuits.
+              // batch with a raw 23505. Same shape as kilter-sync's
+              // applyCircuits, which leans on a bare onConflictDoNothing with
+              // no JS dedupe in front of it.
               await processBatches(climbRows, BATCH_SIZE, async (batch) => {
                 await db
                   .insert(playlistClimbs)

--- a/packages/aurora-sync/src/sync/user-sync.ts
+++ b/packages/aurora-sync/src/sync/user-sync.ts
@@ -415,20 +415,48 @@ export async function upsertTableData(
           if (item.climbs && Array.isArray(item.climbs)) {
             await db.delete(playlistClimbs).where(eq(playlistClimbs.playlistId, playlist.id));
 
+            // Build the full row set first and dedupe by climb_uuid before
+            // inserting: `unique_playlist_climb` is (playlist_id, climb_uuid)
+            // only — it doesn't know about angle — so an Aurora circuit that
+            // repeats the same climb at two angles collides on insert.
+            // First occurrence wins, matching what onConflictDoNothing below
+            // would keep anyway. #4023.
+            const seenClimbUuids = new Set<string>();
+            const climbRows: Array<{
+              playlistId: typeof playlist.id;
+              climbUuid: string;
+              angle: number | null;
+              position: number;
+            }> = [];
             for (let i = 0; i < item.climbs.length; i++) {
               const climb = item.climbs[i];
               const climbUuid = climb.climb_uuid || climb.uuid || climb;
               const climbAngle = climb.angle ?? null;
               const climbPosition = climb.position ?? i;
 
-              if (typeof climbUuid === 'string') {
-                await db.insert(playlistClimbs).values({
+              if (typeof climbUuid === 'string' && !seenClimbUuids.has(climbUuid)) {
+                seenClimbUuids.add(climbUuid);
+                climbRows.push({
                   playlistId: playlist.id,
-                  climbUuid: climbUuid,
+                  climbUuid,
                   angle: climbAngle,
                   position: climbPosition,
                 });
               }
+            }
+
+            if (climbRows.length > 0) {
+              // Chunked batch insert with onConflictDoNothing: a concurrent
+              // addClimbToPlaylist landing mid-transaction (both run under
+              // READ COMMITTED) no-ops instead of aborting the whole sync
+              // batch with a raw 23505. Same pattern as kilter-sync's
+              // applyCircuits.
+              await processBatches(climbRows, BATCH_SIZE, async (batch) => {
+                await db
+                  .insert(playlistClimbs)
+                  .values(batch)
+                  .onConflictDoNothing({ target: [playlistClimbs.playlistId, playlistClimbs.climbUuid] });
+              });
             }
           }
         }

--- a/packages/web/app/lib/data-sync/aurora/__tests__/user-sync-circuits.test.ts
+++ b/packages/web/app/lib/data-sync/aurora/__tests__/user-sync-circuits.test.ts
@@ -53,7 +53,10 @@ function createDbShim(opts: { owners?: Array<Record<string, unknown>>; returning
                 returning: () => Promise.resolve(opts.returning ?? [{ id: BigInt(1) }]),
               });
             },
-            onConflictDoNothing: () => Promise.resolve(),
+            onConflictDoNothing: (conflictArgs: unknown) => {
+              calls.push({ kind: 'conflict', table, args: [conflictArgs] });
+              return Promise.resolve();
+            },
           };
           return Object.assign(Promise.resolve(), chain);
         },
@@ -131,5 +134,66 @@ describe('web aurora proxy — circuits foreign-owner guard (#3526)', () => {
     expect(insertsInto(playlistOwnership)).toHaveLength(0);
     expect(insertsInto(playlistClimbs)).toHaveLength(0);
     expect(calls.filter((call) => call.kind === 'delete')).toHaveLength(0);
+  });
+});
+
+/**
+ * #4023: this legacy proxy route shares the same `unique_playlist_climb`
+ * (playlist_id, climb_uuid) index with the aurora-sync daemon, so it carries
+ * the identical dedupe + onConflictDoNothing fix.
+ */
+describe('web aurora proxy — playlist_climbs idempotency (#4023)', () => {
+  const circuitWithDupeClimb = {
+    ...circuit,
+    climbs: [
+      { climb_uuid: 'climb-A', angle: 40, position: 0 },
+      { climb_uuid: 'climb-A', angle: 55, position: 1 },
+      { climb_uuid: 'climb-B', angle: 40, position: 2 },
+    ],
+  };
+
+  it('dedupes a repeated climb_uuid within one circuit, keeping the first occurrence', async () => {
+    const { db, calls } = createDbShim({ owners: [{ upstreamId: 'circuit-1', ownerUserId: 'user-1' }] });
+
+    await upsertTableData(db as never, 'tension', 'circuits', 144574, 'user-1', [circuitWithDupeClimb] as never);
+
+    const climbInsert = calls.find((call) => call.kind === 'insert' && call.table === playlistClimbs);
+    const rows = climbInsert?.args[0] as Array<{ climbUuid: string; angle: number | null; position: number }>;
+    expect(rows).toHaveLength(2);
+    expect(rows).toEqual([
+      { playlistId: BigInt(1), climbUuid: 'climb-A', angle: 40, position: 0 },
+      { playlistId: BigInt(1), climbUuid: 'climb-B', angle: 40, position: 2 },
+    ]);
+  });
+
+  it('carries onConflictDoNothing targeting (playlist_id, climb_uuid) on the playlist_climbs insert', async () => {
+    const { db, calls } = createDbShim({ owners: [{ upstreamId: 'circuit-1', ownerUserId: 'user-1' }] });
+
+    await upsertTableData(db as never, 'tension', 'circuits', 144574, 'user-1', [circuit] as never);
+
+    const conflictClause = calls.find((call) => call.kind === 'conflict' && call.table === playlistClimbs)?.args[0] as
+      | { target?: unknown[] }
+      | undefined;
+    expect(conflictClause?.target).toEqual([playlistClimbs.playlistId, playlistClimbs.climbUuid]);
+  });
+
+  it('deletes playlist_climbs before inserting the new rows', async () => {
+    const { db, calls } = createDbShim({ owners: [{ upstreamId: 'circuit-1', ownerUserId: 'user-1' }] });
+
+    await upsertTableData(db as never, 'tension', 'circuits', 144574, 'user-1', [circuit] as never);
+
+    const deleteIdx = calls.findIndex((call) => call.kind === 'delete' && call.table === playlistClimbs);
+    const insertIdx = calls.findIndex((call) => call.kind === 'insert' && call.table === playlistClimbs);
+    expect(deleteIdx).toBeGreaterThanOrEqual(0);
+    expect(insertIdx).toBeGreaterThan(deleteIdx);
+  });
+
+  it('skips non-string climb entries and issues no insert when nothing survives', async () => {
+    const { db, insertsInto } = createDbShim({ owners: [{ upstreamId: 'circuit-1', ownerUserId: 'user-1' }] });
+    const circuitWithBadClimbs = { ...circuit, climbs: [{ climb_uuid: 42 }, { climb_uuid: null }] };
+
+    await upsertTableData(db as never, 'tension', 'circuits', 144574, 'user-1', [circuitWithBadClimbs] as never);
+
+    expect(insertsInto(playlistClimbs)).toHaveLength(0);
   });
 });

--- a/packages/web/app/lib/data-sync/aurora/user-sync.ts
+++ b/packages/web/app/lib/data-sync/aurora/user-sync.ts
@@ -337,7 +337,19 @@ export async function upsertTableData(
             // Delete existing climbs for this playlist to handle removals
             await db.delete(playlistClimbs).where(eq(playlistClimbs.playlistId, playlist.id));
 
-            // Insert new climbs
+            // Build the full row set first and dedupe by climb_uuid before
+            // inserting: `unique_playlist_climb` is (playlist_id, climb_uuid)
+            // only — it doesn't know about angle — so an Aurora circuit that
+            // repeats the same climb at two angles collides on insert.
+            // First occurrence wins, matching what onConflictDoNothing below
+            // would keep anyway. #4023.
+            const seenClimbUuids = new Set<string>();
+            const climbRows: Array<{
+              playlistId: typeof playlist.id;
+              climbUuid: string;
+              angle: number | null;
+              position: number;
+            }> = [];
             for (let i = 0; i < item.climbs.length; i++) {
               const climb = item.climbs[i];
               // Handle different possible structures of climb data
@@ -345,13 +357,29 @@ export async function upsertTableData(
               const climbAngle = climb.angle ?? null;
               const climbPosition = climb.position ?? i;
 
-              if (typeof climbUuid === 'string') {
-                await db.insert(playlistClimbs).values({
+              if (typeof climbUuid === 'string' && !seenClimbUuids.has(climbUuid)) {
+                seenClimbUuids.add(climbUuid);
+                climbRows.push({
                   playlistId: playlist.id,
-                  climbUuid: climbUuid,
+                  climbUuid,
                   angle: climbAngle,
                   position: climbPosition,
                 });
+              }
+            }
+
+            if (climbRows.length > 0) {
+              // Chunked insert with onConflictDoNothing: a concurrent
+              // addClimbToPlaylist landing mid-transaction (both run under
+              // READ COMMITTED) no-ops instead of aborting the whole sync
+              // batch with a raw 23505. Same pattern as kilter-sync's
+              // applyCircuits and the aurora-sync daemon's mirror of this fix.
+              const CLIMB_INSERT_CHUNK_SIZE = 500;
+              for (let i = 0; i < climbRows.length; i += CLIMB_INSERT_CHUNK_SIZE) {
+                await db
+                  .insert(playlistClimbs)
+                  .values(climbRows.slice(i, i + CLIMB_INSERT_CHUNK_SIZE))
+                  .onConflictDoNothing({ target: [playlistClimbs.playlistId, playlistClimbs.climbUuid] });
               }
             }
           }

--- a/packages/web/app/lib/data-sync/aurora/user-sync.ts
+++ b/packages/web/app/lib/data-sync/aurora/user-sync.ts
@@ -350,6 +350,7 @@ export async function upsertTableData(
               angle: number | null;
               position: number;
             }> = [];
+            let droppedDuplicateClimbs = 0;
             for (let i = 0; i < item.climbs.length; i++) {
               const climb = item.climbs[i];
               // Handle different possible structures of climb data
@@ -357,15 +358,26 @@ export async function upsertTableData(
               const climbAngle = climb.angle ?? null;
               const climbPosition = climb.position ?? i;
 
-              if (typeof climbUuid === 'string' && !seenClimbUuids.has(climbUuid)) {
-                seenClimbUuids.add(climbUuid);
-                climbRows.push({
-                  playlistId: playlist.id,
-                  climbUuid,
-                  angle: climbAngle,
-                  position: climbPosition,
-                });
+              if (typeof climbUuid !== 'string') continue;
+              if (seenClimbUuids.has(climbUuid)) {
+                droppedDuplicateClimbs++;
+                continue;
               }
+              seenClimbUuids.add(climbUuid);
+              climbRows.push({
+                playlistId: playlist.id,
+                climbUuid,
+                angle: climbAngle,
+                position: climbPosition,
+              });
+            }
+
+            // Data loss the climber never asked for, so say so out loud — see
+            // the same log line in the aurora-sync daemon for why.
+            if (droppedDuplicateClimbs > 0) {
+              console.warn(
+                `Circuit ${item.uuid}: dropped ${droppedDuplicateClimbs} repeated climb_uuid row(s) — unique_playlist_climb is (playlist_id, climb_uuid) and ignores angle`,
+              );
             }
 
             if (climbRows.length > 0) {


### PR DESCRIPTION
## Summary

Closes #4023

Three Aurora circuit → `playlist_climbs` writers rebuild a playlist by deleting its rows and then inserting, with no conflict handling against `unique_playlist_climb` on `(playlist_id, climb_uuid)` (`packages/db/src/schema/app/playlists.ts:92`):

- `packages/aurora-sync/src/sync/user-sync.ts` — the primary sync daemon
- `packages/web/app/lib/data-sync/aurora/user-sync.ts` — still live via `/api/v1/[board_name]/proxy/user-sync` and `/proxy/login`
- `packages/aurora-sync/src/sync/json-import.ts` — the Aurora JSON export importer (found during the adoption re-review, see below)

Two ways to hit a deterministic `23505`:

1. A circuit payload containing the same `climb_uuid` twice — e.g. the same climb at two angles, which the index cannot distinguish. Fails identically on every retry.
2. A concurrent `addClimbToPlaylist` committing between the delete and an insert. The delete only locks index entries for rows that already existed, so a *newly* added climb can slip in and collide.

**Correction to the issue text:** the delete and inserts already share a transaction, so rows are not left deleted on partial failure. The damage is different, and worse than "not urgent" suggests — see below.

### How bad case 1 actually is

`syncUserData` wraps **every table for one user** in a single `db.transaction` (`packages/aurora-sync/src/sync/user-sync.ts:596`), and `updateUserSyncs` is inside it (`:625`). A 23505 out of the circuits branch therefore rolls back that user's logbook, ascents and bids for the same batch, and `last_synchronized_at` never advances — so the next cycle re-fetches the byte-identical payload and throws again. One duplicated climb in one circuit stops that climber's entire Aurora sync, ticks included, permanently.

It does **not** spread: `syncNextUser` catches per credential (`packages/aurora-sync/src/runner/sync-runner.ts:224`) and `recordSyncFailure` (`:279`) always advances `last_sync_attempt_at`, so a wedged credential rotates to the back of the queue and the rest of the fleet keeps syncing. That is a real difference from the kilter dup-`log_uuid` incident (#3329), where one poison-pill user blocked everyone.

## Changes

**Both user-sync copies (circuits case):**

- Build the full row set first, resolving `climbUuid = climb.climb_uuid || climb.uuid || climb` exactly as before, keeping the `typeof climbUuid === 'string'` guard.
- Dedupe by `climbUuid`, first occurrence wins (what `onConflictDoNothing` would keep anyway).
- Batch-insert with `.onConflictDoNothing({ target: [playlistClimbs.playlistId, playlistClimbs.climbUuid] })`, so a concurrent `addClimbToPlaylist` no-ops instead of aborting the batch.
- **Log every dropped row.** Dedupe is silent data loss — the circuit in Aurora has an entry ours won't — and without a log line there is no way to tell "Aurora never repeats a climb" from "we have been truncating circuits for months". If this fires in prod, widening the index to `(playlist_id, climb_uuid, angle)` is the real fix and needs its own PR.
- `aurora-sync` chunks via the file's existing `processBatches` helper; the web copy uses a local 500-row constant (matching kilter-sync — `aurora-sync`'s file-level `BATCH_SIZE = 100` is the outlier).

**JSON import (`json-import.ts`):** same index, same exposure, missed by the original pass. `resolvedClimbs` was `circuit.climbs.map((name) => nameToUuid.get(name))` — resolved by climb *name*, so a circuit listing the same climb twice, or two names resolving to one uuid, produced duplicate rows. The per-circuit transaction rolled back and the climber saw only a bumped `failed` count and a missing circuit. Extracted `resolveCircuitClimbUuids()` (dedupes, drops unresolved names, preserves order) and added `onConflictDoNothing` to the batch insert.

Did not touch `packages/kilter-sync` or `packages/backend` playlist mutations (fixed in #4021). Note for later: kilter-sync's `applyCircuits` has no JS dedupe at all and leans entirely on a bare `onConflictDoNothing`, while its `resolveCanonicalClimbUuid` alias mapping can collapse two raw uuids onto one — it should be brought up to this standard, not the reverse.

## Tests

Shim-based, no real Postgres:

- `packages/aurora-sync/src/sync/user-sync.test.ts` — duplicate `climb_uuid` dedupes to one row (first occurrence's angle/position wins), the insert carries `onConflictDoNothing` on `(playlistId, climbUuid)`, delete precedes insert, non-string entries skipped, the drop is logged, and nothing is logged when nothing was dropped.
- `packages/web/app/lib/data-sync/aurora/__tests__/user-sync-circuits.test.ts` — the same four assertions for the web copy.
- `packages/aurora-sync/src/sync/json-import.test.ts` — `resolveCircuitClimbUuids` collapses a repeated name, collapses two names resolving to one uuid, keeps first-occurrence order, drops unresolved names, and returns empty so the caller skips the delete.

Reverting the source hunk in `aurora-sync/src/sync/user-sync.ts` and re-running turns 2 of the original 4 tests red, so they are not tautological. (The "delete precedes insert" test asserts pre-existing ordering and passes either way.)

## Validation

- `vp test run --project aurora-sync --reporter=agent` — 9 files, 228 tests passed.
- `vp test run --project web --reporter=agent user-sync-circuits` — 9/9 passed.
- `vp run typecheck` — clean (exit 0, all 46 tasks).
- `vp check` — 2 errors and 324 warnings repo-wide, none in any file this PR touches. Both errors are `TS2307: Cannot find module 'yaml'` in `scripts/`, unrelated and pre-existing (#4488).
- Pre-commit hook (`vp check --fix` + commit-lint) passed.
- Rebased onto `origin/main` (`a71db63b9`); the rebase was mechanical, no conflicts.

## Assumptions / open questions

- **Does Aurora actually send the same `climb_uuid` twice in one circuit?** Nobody has verified this against a live payload, here or in #4023. If it does, the dedupe is silently truncating real circuits and the index should grow an `angle` column — a migration plus a change to the #4021 `addClimbToPlaylist` resolver. The new log line exists to answer that question from prod.
- With `onConflictDoNothing`, a concurrent `addClimbToPlaylist` that wins the race keeps its own angle/position rather than the Aurora snapshot's for that one climb. Acceptable; the next cycle's delete reconciles it.
- These tests do not exercise a real 23505 against a live index. The real-DB proof of the pattern already exists in `packages/backend/src/__tests__/add-climb-to-playlist-race.test.ts` from #4021.

## Release Notes

- Your circuits keep syncing when a circuit lists the same climb twice — one repeat used to quietly stall every sync for that board account, ticks included.
- Importing an Aurora export no longer drops a circuit that names the same climb more than once.
