### PR TITLE
fix(backend): enable MoonBoard setter stats

### DIFF
--- a/packages/backend/src/__tests__/setter-stats-moonboard.test.ts
+++ b/packages/backend/src/__tests__/setter-stats-moonboard.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { climbQueries } from '../graphql/resolvers/climbs/queries';
+
+// Seeds use raw `sql` rather than `db.insert(...)` because the integration test
+// DB is built from a minimal hand-maintained DDL (schema-sql.ts), not the full
+// Drizzle schema — the query builder emits every default-bearing column (e.g.
+// quality_normalized) which that DDL omits, so a builder insert fails. Naming
+// only the columns the test DDL declares is the genuine raw-SQL exception.
+
+// Integration test (real DB) for #4008: getSetterStats size-scoped every board
+// with an unguarded `size_id = ANY(compatible_size_ids)`, which MoonBoard
+// climbs never populate (single fixed size), so `1 = ANY(NULL)` dropped every
+// MoonBoard row. Both callers (backend resolver, web REST route) additionally
+// short-circuited `boardName === 'moonboard'` to `[]`. This test locks in both
+// fixes: the resolver no longer short-circuits, and the predicate is gated by
+// isSizeScopedBoard rather than deleted outright (so size filtering still
+// works for Aurora boards like Kilter).
+
+function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext {
+  return {
+    connectionId: 'conn-setter-stats',
+    isAuthenticated: false,
+    userId: null,
+    sessionId: null,
+    boardPath: null,
+    controllerId: null,
+    controllerApiKey: null,
+    ...overrides,
+  } as ConnectionContext;
+}
+
+async function seedClimb(boardType: string, uuid: string, name: string, setter: string, sizeIdsSql: string) {
+  await db.execute(sql`
+    INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, description, frames, is_listed, compatible_size_ids)
+    VALUES (${uuid}, ${boardType}, 1, ${setter}, ${name}, '', 'p1r1', true, ${sql.raw(sizeIdsSql)})
+  `);
+}
+
+async function seedStats(boardType: string, uuid: string, angle: number, displayDifficulty: number, ascents: number) {
+  await db.execute(sql`
+    INSERT INTO board_climb_stats (board_type, climb_uuid, angle, display_difficulty, difficulty_average, quality_average, ascensionist_count, benchmark_difficulty)
+    VALUES (${boardType}, ${uuid}, ${angle}, ${displayDifficulty}, ${displayDifficulty}, 3.0, ${ascents}, 0)
+  `);
+}
+
+describe('setterStats — size filter skips MoonBoard, still applies to Aurora boards (real DB)', () => {
+  beforeAll(async () => {
+    // MoonBoard climbs: compatible_size_ids stays NULL, as in production —
+    // populate-denormalized-columns skips the size-edges step for moonboard.
+    await seedClimb('moonboard', 'moon-setter-climb-1', 'Moon one', 'moon-setter', 'NULL');
+    await seedStats('moonboard', 'moon-setter-climb-1', 40, 20, 50);
+    await seedClimb('moonboard', 'moon-setter-climb-2', 'Moon two', 'moon-setter', 'NULL');
+    await seedStats('moonboard', 'moon-setter-climb-2', 40, 22, 30);
+
+    // Kilter climbs: one compatible with size 10, one only with size 99 — the
+    // size filter must still apply to size-scoped boards.
+    await seedClimb(
+      'kilter',
+      'kilter-sized-setter-climb',
+      'Fits size 10',
+      'kilter-sized-setter',
+      'ARRAY[10]::integer[]',
+    );
+    await seedStats('kilter', 'kilter-sized-setter-climb', 40, 18, 100);
+    await seedClimb(
+      'kilter',
+      'kilter-other-size-setter-climb',
+      'Fits size 99 only',
+      'kilter-other-size-setter',
+      'ARRAY[99]::integer[]',
+    );
+    await seedStats('kilter', 'kilter-other-size-setter-climb', 40, 19, 80);
+  });
+
+  afterAll(async () => {
+    await db.execute(sql`
+      DELETE FROM board_climb_stats WHERE climb_uuid IN (
+        'moon-setter-climb-1', 'moon-setter-climb-2', 'kilter-sized-setter-climb', 'kilter-other-size-setter-climb'
+      )
+    `);
+    await db.execute(sql`
+      DELETE FROM board_climbs WHERE uuid IN (
+        'moon-setter-climb-1', 'moon-setter-climb-2', 'kilter-sized-setter-climb', 'kilter-other-size-setter-climb'
+      )
+    `);
+  });
+
+  it('returns MoonBoard setters with correct counts for the fixed board size, sizeId 1', async () => {
+    const result = await climbQueries.setterStats(
+      null,
+      { input: { boardName: 'moonboard', layoutId: 1, sizeId: 1, setIds: '1', angle: 40 } },
+      makeCtx(),
+    );
+
+    expect(result).toEqual([{ setterUsername: 'moon-setter', climbCount: 2 }]);
+  });
+
+  it('still size-filters Kilter, excluding a setter whose only climb fits a different size', async () => {
+    const result = await climbQueries.setterStats(
+      null,
+      { input: { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1', angle: 40 } },
+      makeCtx(),
+    );
+
+    expect(result).toEqual([{ setterUsername: 'kilter-sized-setter', climbCount: 1 }]);
+  });
+
+  it('filters MoonBoard setters by a search substring', async () => {
+    const result = await climbQueries.setterStats(
+      null,
+      { input: { boardName: 'moonboard', layoutId: 1, sizeId: 1, setIds: '1', angle: 40, search: 'moon' } },
+      makeCtx(),
+    );
+
+    expect(result).toEqual([{ setterUsername: 'moon-setter', climbCount: 2 }]);
+
+    const noMatch = await climbQueries.setterStats(
+      null,
+      { input: { boardName: 'moonboard', layoutId: 1, sizeId: 1, setIds: '1', angle: 40, search: 'nobody-sets-this' } },
+      makeCtx(),
+    );
+
+    expect(noMatch).toEqual([]);
+  });
+});

--- a/packages/backend/src/graphql/resolvers/climbs/queries.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/queries.ts
@@ -220,7 +220,6 @@ export const climbQueries = {
 
   /**
    * Get setter usernames with climb counts for autocomplete in the search drawer.
-   * MoonBoard has no setter data — returns an empty list to match the REST behaviour.
    */
   setterStats: async (
     _: unknown,
@@ -232,12 +231,6 @@ export const climbQueries = {
 
     if (!isValidBoardName(validated.boardName)) {
       throw new Error(`Invalid board name: ${validated.boardName}. Must be one of: ${SUPPORTED_BOARDS.join(', ')}`);
-    }
-
-    // MoonBoard doesn't have database tables for setter stats — return empty results
-    // to match the legacy REST endpoint.
-    if (validated.boardName === 'moonboard') {
-      return [];
     }
 
     // Parse setIds from comma-separated string (same pattern as searchClimbs)

--- a/packages/db/src/queries/climbs/setter-stats.ts
+++ b/packages/db/src/queries/climbs/setter-stats.ts
@@ -1,3 +1,4 @@
+import { isSizeScopedBoard } from '@boardsesh/board-config';
 import { and, eq, ilike, sql } from 'drizzle-orm';
 import type { DbInstance } from '../../client/postgres';
 import { boardClimbs, boardClimbStats } from '../../schema/index';
@@ -25,6 +26,17 @@ export type SetterStat = {
  *
  * Capped at 50 rows ordered by descending climb count for UI performance.
  *
+ * Size-scoped boards (everything but MoonBoard) are filtered to climbs whose
+ * `compatible_size_ids` contains the requested size, using array containment
+ * (`@>`) so Postgres can use the `board_climbs_compatible_size_ids_idx` GIN
+ * index. MoonBoard has a single fixed product size and never populates
+ * `compatible_size_ids`, so the size predicate is skipped entirely for it —
+ * `size_id = ANY(NULL)` evaluates to NULL and would otherwise drop every
+ * MoonBoard row. This is deliberately board-type-gated rather than
+ * NULL-tolerant: Kilter draft climbs can also have a NULL
+ * `compatible_size_ids` (see the "Draft climbs may have NULL
+ * compatible_size_ids" comments in search-climbs.ts) and must stay excluded.
+ *
  * Runs under `withSerialPlan`: this hash-joins the two biggest catalog tables
  * over a whole layout and aggregates them, which the planner is happy to run as
  * a parallel hash join. It fires from the same search drawer as `searchClimbs`
@@ -41,7 +53,9 @@ export const getSetterStats = async (
     eq(boardClimbs.boardType, params.board_name),
     eq(boardClimbs.layoutId, params.layout_id),
     eq(boardClimbStats.angle, params.angle),
-    sql`${params.size_id} = ANY(${boardClimbs.compatibleSizeIds})`,
+    ...(isSizeScopedBoard(params.board_name)
+      ? [sql`${boardClimbs.compatibleSizeIds} @> ARRAY[${params.size_id}]::int[]`]
+      : []),
     sql`${boardClimbs.setterUsername} IS NOT NULL`,
     sql`${boardClimbs.setterUsername} != ''`,
   ];

--- a/packages/web/app/api/v1/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/setters/route.ts
+++ b/packages/web/app/api/v1/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/setters/route.ts
@@ -13,11 +13,6 @@ export async function GET(
   try {
     const parsedParams = await parseBoardRouteParamsWithSlugs(params);
 
-    // MoonBoard doesn't have database tables for setter stats - return empty results
-    if (parsedParams.board_name === 'moonboard') {
-      return NextResponse.json([]);
-    }
-
     // Extract search query parameter
     const url = new URL(req.url);
     const searchQuery = url.searchParams.get('search') || undefined;


### PR DESCRIPTION
## Summary

Closes #4008.

MoonBoard setter search/autocomplete was returning empty everywhere (web and mobile), for two stacked reasons:

1. `getSetterStats` (`packages/db/src/queries/climbs/setter-stats.ts`) applied an unguarded size predicate — `size_id = ANY(compatible_size_ids)`. MoonBoard climbs never populate `compatible_size_ids` (single fixed product size; `populate-denormalized-columns` skips the size-edges step for MoonBoard), so `1 = ANY(NULL)` evaluates to `NULL` and drops every MoonBoard row.
2. Both callers additionally short-circuited `boardName === 'moonboard'` to `[]`, with a comment claiming MoonBoard has no setter data — no longer true, since the importers populate `setter_username` (`import-moonboard-problems.ts`) and `board_climb_stats`.

Per the maintainer decision on the issue thread (2026-07-31): enable MoonBoard setter stats in both callers.

## Changes

- `packages/db/src/queries/climbs/setter-stats.ts` — gate the size predicate with `isSizeScopedBoard` instead of applying it unconditionally, and rewrite it as `compatibleSizeIds @> ARRAY[size_id]::int[]` (array containment) to match the shape used in `create-climb-filters.ts` and use the existing `board_climbs_compatible_size_ids_idx` GIN index. Kilter/Tension draft climbs, which can also have a NULL `compatible_size_ids`, stay excluded — this is board-type-gated, not NULL-tolerant.
- `packages/backend/src/graphql/resolvers/climbs/queries.ts` — remove the `boardName === 'moonboard' → []` short-circuit in the `setterStats` resolver and its stale docstring line.
- `packages/web/app/api/v1/.../setters/route.ts` — remove the matching short-circuit in the REST route.
- No mobile changes needed: the mobile GraphQL hook has no client-side MoonBoard gate, so it picks this up automatically.
- New integration test `packages/backend/src/__tests__/setter-stats-moonboard.test.ts` (real DB), modeled on `playlist-climbs-moonboard-size-filter.test.ts`: seeds MoonBoard climbs with NULL `compatible_size_ids` plus Kilter climbs at two different sizes, and asserts (a) MoonBoard setter stats return real setters/counts, (b) Kilter size filtering still excludes a setter whose only climb is a different size, (c) MoonBoard setter search substring filtering works.

## Validation

- `vp check` — no lint errors; two pre-existing unrelated formatting warnings (`.claude/skills/discord-feedback-triage/SKILL.md`, `docs/discord-feedback-pipeline.md`) not touched by this change.
- `vp run typecheck` — clean.
- `vp test run --project backend --reporter=agent -- src/__tests__/setter-stats-moonboard.test.ts src/__tests__/playlist-climbs-moonboard-size-filter.test.ts` — see CI for final result; the shared test-infra machine was under very heavy concurrent load from other worktrees during local validation, see PR checks for the authoritative run.

## Release Notes

- MoonBoard setter search now shows setters and counts, matching Kilter/Tension.

## Assumptions for Marco

- Followed the issue's recommended `@>` (array containment) predicate style rather than a guarded `= ANY`, to match `create-climb-filters.ts` and use the existing GIN index — flagged in the plan as a deliberate choice since the merged `#4010` fix in `setter-follows.ts` kept a guarded `= ANY` instead.
