### PR TITLE
fix(mobile): keep the throttled queue-add recovery alive after a full sync

### DIFF
--- a/packages/mobile/src/providers/__tests__/queue-provider-local-queue.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-local-queue.test.tsx
@@ -61,6 +61,11 @@ const queueMutations = vi.hoisted(() => ({
   confirmClimbOnWall: vi.fn(async () => {}),
   setSessionBoardSerial: vi.fn(async () => {}),
   setSessionBoardPath: vi.fn(async () => {}),
+  // Synchronous read of the shared factory's removal ledger (#4009). Nothing
+  // here removes a climb mid-recovery, so the honest default is "not dropped by
+  // the climber" — but the member has to exist or the provider's recovery path
+  // would call undefined.
+  wasUuidExplicitlyRemoved: vi.fn((_uuid: string) => false),
 }));
 
 // Capture the deps mobile passes into the shared useQueueMutations so the
@@ -232,6 +237,11 @@ describe('QueueProvider local solo queue', () => {
       mutation.mockReset();
       mutation.mockResolvedValue(undefined);
     }
+    // The blanket reset above hands every action a resolved promise, which for a
+    // SYNCHRONOUS boolean action is truthy — i.e. "the climber removed it"
+    // everywhere. Restore the real default.
+    queueMutations.wasUuidExplicitlyRemoved.mockReset();
+    queueMutations.wasUuidExplicitlyRemoved.mockReturnValue(false);
     sessionStore.getStoredSessionId.mockReset();
     sessionStore.getStoredSessionId.mockResolvedValue(null);
     sessionStore.setStoredSessionId.mockClear();

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -122,7 +122,9 @@ const partyProfile = vi.hoisted(() => ({
 
 const queueMutations = vi.hoisted(() => ({
   addQueueItem: vi.fn(async () => {}),
-  removeQueueItem: vi.fn(async () => {}),
+  // Typed arg so a test can model the shared factory's removal ledger, which
+  // records here before any session guard (#4009).
+  removeQueueItem: vi.fn(async (_uuid: string) => {}),
   reorderQueueItem: vi.fn(async () => {}),
   setCurrentClimb: vi.fn(async () => {}),
   mirrorCurrentClimb: vi.fn(async () => {}),
@@ -133,6 +135,13 @@ const queueMutations = vi.hoisted(() => ({
   reportWallDisconnect: vi.fn(async () => {}),
   setSessionBoardSerial: vi.fn(async () => {}),
   setSessionBoardPath: vi.fn(async () => {}),
+  // Read-only classification of a LOCAL absence, backed in production by the
+  // shared factory's removal ledger (#4009). These tests verify how the
+  // provider BRANCHES on the verdict; the ledger that produces it is covered in
+  // packages/shared/queue-react/src/__tests__/create-queue-mutations.test.ts.
+  // Default false = "the climber didn't drop it", so an absence reads as a
+  // wholesale server sync; tests that model a removal override it.
+  wasUuidExplicitlyRemoved: vi.fn((_uuid: string) => false),
 }));
 
 const wallConfirm = vi.hoisted(() => ({
@@ -473,6 +482,11 @@ describe('QueueProvider session update subscription', () => {
       mutation.mockReset();
       mutation.mockResolvedValue(undefined);
     }
+    // The blanket reset above hands every action a resolved promise. For a
+    // SYNCHRONOUS boolean action that is a truthy Promise, which would read as
+    // "the climber removed it" everywhere. Restore the real default.
+    queueMutations.wasUuidExplicitlyRemoved.mockReset();
+    queueMutations.wasUuidExplicitlyRemoved.mockReturnValue(false);
     wallConfirm.emitWallConfirm.mockClear();
     sessionStore.getStoredSessionId.mockReset();
     sessionStore.getStoredSessionId.mockResolvedValue('session-1');
@@ -1652,7 +1666,46 @@ describe('QueueProvider session update subscription', () => {
 describe('QueueProvider mutation-failure resync', () => {
   beforeEach(() => {
     toast.showToast.mockClear();
+    installRemovalLedger();
   });
+
+  // This harness swaps the shared mutations factory for hand-rolled mocks, so
+  // the removal ledger those actions maintain has to be modelled here: the real
+  // `removeQueueItem` records the uuid before any session guard, and
+  // `wasUuidExplicitlyRemoved` reads that ledger back (#4009). The ledger itself
+  // is covered against the real factory in
+  // packages/shared/queue-react/src/__tests__/create-queue-mutations.test.ts;
+  // what these tests pin is how the provider BRANCHES on its verdict. Absence
+  // with no ledger hit means a wholesale server sync, not climber intent.
+  function installRemovalLedger() {
+    const explicitlyRemoved = new Set<string>();
+    queueMutations.removeQueueItem.mockImplementation(async (uuid: string) => {
+      explicitlyRemoved.add(uuid);
+    });
+    queueMutations.wasUuidExplicitlyRemoved.mockImplementation((uuid: string) => explicitlyRemoved.has(uuid));
+  }
+
+  // A server FullSync — the event whose INITIAL_QUEUE_DATA mapping REPLACES the
+  // local queue wholesale, wiping any not-yet-synced optimistic slot (#4009).
+  function pushFullSync(items: ClimbQueueItem[], current: ClimbQueueItem | null, sequence: number) {
+    const sink = ws.getQueueUpdatesSink();
+    if (!sink) throw new Error('queueUpdates subscription was not opened');
+    const toWire = (item: ClimbQueueItem) => ({ uuid: item.uuid, climb: item.climb });
+    sink.next({
+      data: {
+        queueUpdates: {
+          __typename: 'FullSync',
+          sequence,
+          state: {
+            sequence,
+            stateHash: `hash-${sequence}`,
+            queue: items.map(toWire),
+            currentClimbQueueItem: current ? toWire(current) : null,
+          },
+        },
+      },
+    });
+  }
 
   // The harness routes both endSession and the queueState query through
   // http.request. Branch on the operation text so the resync query returns the
@@ -2072,6 +2125,9 @@ describe('QueueProvider mutation-failure resync', () => {
       expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.rateLimited', 'error');
     });
     // Recovering the slot now would resurrect a climb the user just deleted.
+    // Absence alone no longer decides that (#4009) — the removal ledger does,
+    // and the swipe above put this uuid in it.
+    expect(queueMutations.wasUuidExplicitlyRemoved).toHaveBeenCalledWith('local-current');
     expect(queueMutations.addQueueItem).not.toHaveBeenCalled();
     expect(queueStateCalls).toBe(0);
   });
@@ -2126,7 +2182,9 @@ describe('QueueProvider mutation-failure resync', () => {
     });
 
     // The add landed after the remove, so it put the climb back on every peer's
-    // queue. Undo it instead of leaving a climb nobody asked for.
+    // queue. Undo it instead of leaving a climb nobody asked for. The removal
+    // ledger is what licenses that undo (#4009) — the swipe above wrote this
+    // uuid into it, so absence here reads as intent rather than as a sync.
     await waitFor(() => {
       expect(queueMutations.removeQueueItem).toHaveBeenCalledTimes(2);
     });
@@ -2259,6 +2317,190 @@ describe('QueueProvider mutation-failure resync', () => {
       ([uuid]) => uuid,
     );
     expect(removedUuids).not.toContain('swap-current');
+  });
+
+  // The #4009 regression. The burst's HEAD activation is itself an add, so the
+  // server answers it with a FullSync — which INITIAL_QUEUE_DATA applies by
+  // REPLACING the queue, wiping the optimistic slot seconds before the throttled
+  // mutation rejects. A bare "gone locally -> skip" reads that as intent and the
+  // climb reaches nobody.
+  it('still re-sends the queue add when a wholesale server sync wiped the local slot (#4009)', async () => {
+    const snapshots: Snapshot[] = [];
+    const alreadyQueued = makeQueueItem('item-1', 'climb-1');
+    let queueStateCalls = 0;
+    routeHttpRequest(queueStateResponse([alreadyQueued], alreadyQueued), {
+      onQueueStateCall: () => (queueStateCalls += 1),
+    });
+    // Hold the mutation open so the sync below lands before it settles.
+    const inFlightSetCurrent = createDeferred<void>();
+    inFlightSetCurrent.promise.catch(() => {});
+    queueMutations.setCurrentClimb.mockReturnValueOnce(inFlightSetCurrent.promise);
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    act(() => {
+      snapshots.at(-1)?.setQueue([alreadyQueued], alreadyQueued);
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue).toHaveLength(1);
+    });
+    queueMutations.addQueueItem.mockClear();
+
+    act(() => {
+      snapshots.at(-1)?.setCurrentClimb(makeQueueItem('local-current', 'climb-local-current'));
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue).toHaveLength(2);
+    });
+
+    // The server's own answer to the burst head lands: a full snapshot that has
+    // never heard of the pending slot. Nobody removed anything.
+    act(() => {
+      pushFullSync([alreadyQueued], alreadyQueued, 1);
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['item-1']);
+    });
+
+    await act(async () => {
+      inFlightSetCurrent.reject(makeRateLimitedError());
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(queueMutations.addQueueItem).toHaveBeenCalledTimes(1);
+    });
+    const [recoveredItem, recoveredPosition] = queueMutations.addQueueItem.mock.calls[0] as unknown as [
+      ClimbQueueItem,
+      number | undefined,
+    ];
+    expect(recoveredItem.uuid).toBe('local-current');
+    // No local slot left to mirror, so no position is claimed — the server
+    // appends. Worse order than insert-after-current, far better than the climb
+    // existing nowhere.
+    expect(recoveredPosition).toBeUndefined();
+    // Recovering is not reconciling: no queue refetch, and the pacing hint still
+    // reaches the climber.
+    expect(queueStateCalls).toBe(0);
+    expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.rateLimited', 'error');
+  });
+
+  // The second-order half of #4009: the add DID land, and the only reason the
+  // slot is missing locally is the same wholesale sync. Undoing here deletes the
+  // picker's own pick off the whole crew's queue AND writes the uuid into the
+  // shared removal ledger, which then suppresses every later deferred add for it.
+  it('does not undo the re-sent queue add when a wholesale sync wiped the slot with no removal (#4009)', async () => {
+    const snapshots: Snapshot[] = [];
+    const alreadyQueued = makeQueueItem('sync-seed', 'climb-sync-seed');
+    let queueStateCalls = 0;
+    routeHttpRequest(queueStateResponse([alreadyQueued], alreadyQueued), {
+      onQueueStateCall: () => (queueStateCalls += 1),
+    });
+    queueMutations.setCurrentClimb.mockRejectedValueOnce(makeRateLimitedError());
+    // Hold the recovery add open — this is `execute`'s back-off window.
+    const inFlightAdd = createDeferred<void>();
+    queueMutations.addQueueItem.mockReturnValueOnce(inFlightAdd.promise);
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    act(() => {
+      snapshots.at(-1)?.setQueue([alreadyQueued], alreadyQueued);
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue).toHaveLength(1);
+    });
+    queueMutations.removeQueueItem.mockClear();
+
+    act(() => {
+      snapshots.at(-1)?.setCurrentClimb(makeQueueItem('sync-current', 'climb-sync-current'));
+    });
+    await waitFor(() => {
+      const addedUuids = (queueMutations.addQueueItem.mock.calls as unknown as Array<[ClimbQueueItem, number]>).map(
+        ([item]) => item?.uuid,
+      );
+      expect(addedUuids).toContain('sync-current');
+    });
+
+    // A peer's activation lands a FullSync while our add is still backing off.
+    act(() => {
+      pushFullSync([alreadyQueued], alreadyQueued, 1);
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['sync-seed']);
+    });
+
+    await act(async () => {
+      inFlightAdd.resolve();
+      await Promise.resolve();
+    });
+
+    const removedUuids = (queueMutations.removeQueueItem.mock.calls as unknown as Array<[string]>).map(
+      ([uuid]) => uuid,
+    );
+    expect(removedUuids).not.toContain('sync-current');
+    expect(queueStateCalls).toBe(0);
+  });
+
+  // The unpositioned re-send resolves the LIVE session, so without a captured
+  // room the recovery would append the old room's climb to the new crew's queue.
+  it('does not re-send the queue add into a session joined while the activation was backing off (#4009)', async () => {
+    const snapshots: Snapshot[] = [];
+    const seeded = makeQueueItem('flip-seed', 'climb-flip-seed');
+    const activated = makeQueueItem('flip-current', 'climb-flip-current');
+    routeHttpRequest(queueStateResponse([seeded], seeded));
+    const inFlightSetCurrent = createDeferred<void>();
+    inFlightSetCurrent.promise.catch(() => {});
+    queueMutations.setCurrentClimb.mockReturnValueOnce(inFlightSetCurrent.promise);
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    act(() => {
+      snapshots.at(-1)?.setQueue([seeded], seeded);
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue).toHaveLength(1);
+    });
+
+    act(() => {
+      snapshots.at(-1)?.setCurrentClimb(activated);
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue).toHaveLength(2);
+    });
+
+    // The climber walks to another board's room while the activation is still
+    // throttled. session-2 never saw this climb and must not receive it.
+    await act(async () => {
+      await snapshots.at(-1)?.joinSession('session-2', {
+        boardPath: '/kilter/1/10/1,2/40/list',
+        userBoard: activeBoard.stored,
+      });
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-2');
+    });
+
+    await act(async () => {
+      inFlightSetCurrent.reject(makeRateLimitedError());
+      await Promise.resolve();
+    });
+
+    const addedUuids = (queueMutations.addQueueItem.mock.calls as unknown as Array<[ClimbQueueItem, number]>).map(
+      ([item]) => item?.uuid,
+    );
+    expect(addedUuids).not.toContain('flip-current');
   });
 
   it('toasts "slow down" rather than the generic failure when reorderQueue is rate-limited', async () => {

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -121,7 +121,9 @@ const partyProfile = vi.hoisted(() => ({
 }));
 
 const queueMutations = vi.hoisted(() => ({
-  addQueueItem: vi.fn(async () => {}),
+  // Typed args so a test can model the shared factory's removal ledger, where an
+  // add retracts an earlier drop of the same uuid (#4009).
+  addQueueItem: vi.fn(async (_item: { uuid: string }, _position?: number) => {}),
   // Typed arg so a test can model the shared factory's removal ledger, which
   // records here before any session guard (#4009).
   removeQueueItem: vi.fn(async (_uuid: string) => {}),
@@ -1677,10 +1679,18 @@ describe('QueueProvider mutation-failure resync', () => {
   // packages/shared/queue-react/src/__tests__/create-queue-mutations.test.ts;
   // what these tests pin is how the provider BRANCHES on its verdict. Absence
   // with no ledger hit means a wholesale server sync, not climber intent.
+  // It tracks the climber's LATEST intent, so `addQueueItem` retracts an earlier
+  // drop just as the real factory does. A test that stubs `addQueueItem` with
+  // `mockReturnValueOnce` bypasses this, which is fine — none of them assert on
+  // the retraction, and the retraction itself is covered against the real
+  // factory in the file above.
   function installRemovalLedger() {
     const explicitlyRemoved = new Set<string>();
     queueMutations.removeQueueItem.mockImplementation(async (uuid: string) => {
       explicitlyRemoved.add(uuid);
+    });
+    queueMutations.addQueueItem.mockImplementation(async (queueItem: { uuid: string }) => {
+      explicitlyRemoved.delete(queueItem.uuid);
     });
     queueMutations.wasUuidExplicitlyRemoved.mockImplementation((uuid: string) => explicitlyRemoved.has(uuid));
   }
@@ -2950,6 +2960,11 @@ describe('QueueProvider always-live wall control', () => {
       mutation.mockReset();
       mutation.mockResolvedValue(undefined);
     }
+    // Same correction the other two harnesses make: the blanket loop above hands
+    // this SYNCHRONOUS boolean action a resolved Promise, which is truthy and so
+    // reads as "the climber removed it" for every uuid (#4009).
+    queueMutations.wasUuidExplicitlyRemoved.mockReset();
+    queueMutations.wasUuidExplicitlyRemoved.mockReturnValue(false);
     sessionStore.getStoredSessionId.mockReset();
     sessionStore.getStoredSessionId.mockResolvedValue('session-1');
     sessionStore.clearStoredSessionId.mockClear();

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -1081,8 +1081,15 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // `execute` gives it a fresh rate-limit back-off budget, the server's add is
   // idempotent by uuid, and it leaves the current pointer alone, so the climb
   // reaches the crew without the yank-back a resync would cause (#2763).
+  //
+  // Three outcomes, decided by whether the slot is still in the local queue and,
+  // when it isn't, by the shared removal ledger (#4009):
+  //   still queued           -> positioned ADD (peers see our order)
+  //   gone, climber removed  -> nothing (don't resurrect their discard)
+  //   gone, wholesale sync   -> unpositioned ADD (server appends; the crew still
+  //                             gets the climb instead of nobody getting it)
   const recoverThrottledQueueAdd = useCallback(
-    async (item: ClimbQueueItem) => {
+    async (item: ClimbQueueItem, activationSessionId: string | null) => {
       // Capture the session this slot belongs to. Every leg below runs after an
       // await, and the undo leg in particular can wake up in a DIFFERENT session
       // (the climber ended this one and joined another while the add was backing
@@ -1090,15 +1097,32 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       // Same discipline the coalescer applies to its own deferred sends.
       const recoverySessionId = sessionIdRef.current;
       if (!recoverySessionId) return;
+      // The activation was issued into a different room than the one we're in
+      // now: the throttled setCurrentClimb sat in back-off while the climber
+      // left and joined elsewhere. Re-sending here would append the OLD room's
+      // climb to the NEW crew's queue. `activationSessionId` is snapshotted by
+      // dispatchSetCurrent at issue time — the live ref is useless for this,
+      // because it is read fresh on entry and so always agrees with itself.
+      if (recoverySessionId !== activationSessionId) return;
       // Position the re-send where the optimistic insert actually landed
       // (insert-after-current, #2217) so peers see the same order we do. The
       // server clamps an out-of-range position to an append.
       const position = stateRef.current.queue.findIndex((queueItem) => queueItem.uuid === item.uuid);
-      // Already gone locally — removed, cleared, or replaced by a server sync
-      // while the throttled mutation was in flight. Don't resurrect it.
-      if (position === -1) return;
+      // Gone locally. Two reasons, and only one of them means "don't send"
+      // (#4009) — the same fork the shared coalescer's sendDeferredQueueAdd
+      // makes, read off the ledger it already keeps rather than re-derived here:
+      //   - the climber dropped it (a swipe-remove, a clear, a playlist replace)
+      //     → honour that; a bare ADD resurrects a climb they just discarded.
+      //   - a wholesale server sync replaced the queue → the activation that
+      //     started this burst was itself an add, so the server answered it with
+      //     a FullSync, and INITIAL_QUEUE_DATA applies that by REPLACING the
+      //     queue, wiping the not-yet-synced optimistic slot. Bailing here is
+      //     the bug: the climb reaches nobody. Send it WITHOUT a position — the
+      //     server appends, no worse than the pre-#3934 behaviour, and the crew
+      //     at least gets the climb.
+      if (position === -1 && mutations.wasUuidExplicitlyRemoved(item.uuid)) return;
       try {
-        await mutations.addQueueItem(item, position);
+        await mutations.addQueueItem(item, position === -1 ? undefined : position);
       } catch (error) {
         if (__DEV__) console.warn('[queue] throttled setCurrentClimb queue-add recovery failed', error);
         // The slot never reached the server even with its own retry budget, so
@@ -1117,6 +1141,13 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       // room, and its lack of this item says nothing about the old one.
       if (sessionIdRef.current !== recoverySessionId) return;
       if (stateRef.current.queue.some((queueItem) => queueItem.uuid === item.uuid)) return;
+      // Absence alone is not intent (#4009). A wholesale sync wipes the slot
+      // locally while the add lands server-side, and undoing on that reading
+      // both deletes a climb the picker did choose and writes its uuid into the
+      // shared removal ledger, which then suppresses any later legitimate
+      // deferred add for it. Only a ledger hit — a real remove / clear /
+      // wholesale replace by this climber — is a reason to compensate.
+      if (!mutations.wasUuidExplicitlyRemoved(item.uuid)) return;
       mutations.removeQueueItem(item.uuid).catch((error) => {
         if (__DEV__) console.warn('[queue] undoing a resurrected queue-add failed', error);
         void resyncQueueAfterMutationFailure();
@@ -1177,6 +1208,11 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       // of the previously-skipped slot can't re-broadcast an item we've moved off.
       pendingUnsyncedCurrentRef.current = null;
       coordinator.trackPendingMutation(correlationId);
+      // The room this activation is aimed at. A throttled setCurrentClimb can
+      // sit in back-off long enough for the climber to leave and join another
+      // session, so the recovery below needs the id from HERE — by the time it
+      // runs, the live ref may already point at the new room (#4009).
+      const activationSessionId = sessionIdRef.current;
       mutations.setCurrentClimb(item, shouldAddToQueue, correlationId).catch((error: unknown) => {
         // A throttled POINTER move is not a divergence: the rate-limit gate
         // throws before the resolver runs, so the server still holds the climb
@@ -1198,7 +1234,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
         // content change isn't stranded locally (solo no-ops — its queue is
         // authoritative and there's no server to fall behind).
         if (throttled && shouldAddToQueue) {
-          void recoverThrottledQueueAdd(item);
+          void recoverThrottledQueueAdd(item, activationSessionId);
         }
         // Solo (no server to reconcile) and the rate-limited party case both
         // land here: toast only, no resync.

--- a/packages/shared/queue-react/src/__tests__/create-queue-mutations.test.ts
+++ b/packages/shared/queue-react/src/__tests__/create-queue-mutations.test.ts
@@ -769,3 +769,96 @@ describe('wasUuidExplicitlyRemoved (#4009)', () => {
     expect(m.wasUuidExplicitlyRemoved('B')).toBe(false);
   });
 });
+
+// The ledger records the climber's LATEST intent, not "ever dropped". It lives
+// as long as the factory — which `useQueueMutations` memoises for the
+// QueueProvider's whole lifetime — so an append-only answer would keep saying
+// "dropped" for the rest of the app process and re-open #4009 for every climb
+// the climber had cleared earlier. Re-queueing a project you cleared is
+// ordinary, and mobile's clear-queue drops EVERY queued uuid in one burst.
+describe('removal ledger retraction (#4009)', () => {
+  it('forgets a removed uuid once addQueueItem puts it back', async () => {
+    const m = make();
+    await m.removeQueueItem('B');
+    expect(m.wasUuidExplicitlyRemoved('B')).toBe(true);
+    await m.addQueueItem(item('B'), 0);
+    expect(m.wasUuidExplicitlyRemoved('B')).toBe(false);
+  });
+
+  it('forgets a removed uuid once an activation carrying a queue-add re-picks it', async () => {
+    const m = make();
+    await m.removeQueueItem('B');
+    await m.setCurrentClimb(item('B'), true);
+    expect(m.wasUuidExplicitlyRemoved('B')).toBe(false);
+  });
+
+  // A pointer move is navigation, not "put this back in my queue" — it must not
+  // retract the drop, or stepping past a removed climb would re-arm its add.
+  it('keeps the drop when the re-activation carries no queue-add', async () => {
+    const m = make();
+    await m.removeQueueItem('B');
+    await m.setCurrentClimb(item('B'), false);
+    expect(m.wasUuidExplicitlyRemoved('B')).toBe(true);
+  });
+
+  it('forgets every uuid a setQueue payload contains', async () => {
+    const m = make();
+    await m.removeQueueItem('B');
+    await m.removeQueueItem('C');
+    await m.setQueue([item('B')]);
+    expect(m.wasUuidExplicitlyRemoved('B')).toBe(false);
+    // C is still dropped: the payload does not contain it.
+    expect(m.wasUuidExplicitlyRemoved('C')).toBe(true);
+  });
+
+  // The retraction runs before the discard diff, so a uuid that is both a stale
+  // add-candidate and absent from the payload still ends up recorded.
+  it('still records an add-candidate the same setQueue payload discarded', async () => {
+    const m = make();
+    await m.setCurrentClimb(item('B'), true);
+    await m.setQueue([item('X')]);
+    expect(m.wasUuidExplicitlyRemoved('B')).toBe(true);
+  });
+
+  // End to end through the coalescer, which is what the ledger exists for: the
+  // climb was cleared earlier in the app session, re-picked, and then wiped from
+  // the local queue by a wholesale server sync. The stale entry must not
+  // suppress the deferred add — that is #4009 all over again.
+  it('sends the deferred add for a climb dropped earlier and since re-picked', async () => {
+    const m = make({ onBestEffortError: () => {} });
+    // Earlier in the session the climber cleared this climb away.
+    await m.removeQueueItem('B');
+    expect(m.wasUuidExplicitlyRemoved('B')).toBe(true);
+    executeMock.mockReset();
+    executeMock.mockResolvedValue(undefined);
+
+    localQueue = [item('cur'), item('A'), item('B')];
+    let firstResolve: (() => void) | undefined;
+    let setCurrentCalls = 0;
+    executeMock.mockImplementation((_c, op) => {
+      if (op.query !== SET_CURRENT_CLIMB) return Promise.resolve();
+      setCurrentCalls += 1;
+      if (setCurrentCalls === 1)
+        return new Promise<void>((resolve) => {
+          firstResolve = () => resolve();
+        });
+      return new Promise<void>((_resolve, reject) =>
+        setTimeout(() => {
+          // The burst head's own FullSync replaces the queue and wipes the
+          // not-yet-synced optimistic slot for B.
+          localQueue = [item('cur'), item('A')];
+          reject(new Error('RATE_LIMITED'));
+        }, 0),
+      );
+    });
+
+    const pA = m.setCurrentClimb(item('A'), true);
+    const pB = m.setCurrentClimb(item('B'), true);
+    firstResolve?.();
+    await Promise.all([pA, pB]);
+    await flush();
+
+    expect(queriesFor(ADD_QUEUE_ITEM)).toHaveLength(1);
+    expect(queriesFor(ADD_QUEUE_ITEM)[0][1].variables).toEqual({ item: { uuid: 'B', climb: { uuid: 'c-B' } } });
+  });
+});

--- a/packages/shared/queue-react/src/__tests__/create-queue-mutations.test.ts
+++ b/packages/shared/queue-react/src/__tests__/create-queue-mutations.test.ts
@@ -712,3 +712,60 @@ describe('setQueue baseline sequence (#3933)', () => {
     expect(queriesFor(SET_QUEUE)).toHaveLength(0);
   });
 });
+
+// The ledger is also read from OUTSIDE the coalescer: mobile's caller-side
+// burst-head recovery (recoverThrottledQueueAdd) faces the same "is this
+// absence intent or a wholesale sync?" fork and must reach the same verdict
+// (#4009). These pin the read-only action rather than the send branches.
+describe('wasUuidExplicitlyRemoved (#4009)', () => {
+  it('is false for a uuid nothing ever touched', () => {
+    expect(make().wasUuidExplicitlyRemoved('never-seen')).toBe(false);
+  });
+
+  it('is true after removeQueueItem', async () => {
+    const m = make();
+    await m.removeQueueItem('B');
+    expect(m.wasUuidExplicitlyRemoved('B')).toBe(true);
+    expect(m.wasUuidExplicitlyRemoved('C')).toBe(false);
+  });
+
+  // The remove records BEFORE the session guards, so a no-op remove (mobile,
+  // solo) still counts as the climber saying "drop this" — the same reason
+  // sendDeferredQueueAdd trusts it.
+  it('is true after a removeQueueItem that no-opped for want of a session', async () => {
+    const ensureReady = vi.fn(async (captured: string | null) => captured);
+    const m = make({ getSessionId: () => null, ensureReady });
+    await m.removeQueueItem('B');
+    expect(executeMock).not.toHaveBeenCalled();
+    expect(m.wasUuidExplicitlyRemoved('B')).toBe(true);
+  });
+
+  // Web's Clear button and mobile's playlist "replace my queue" never call
+  // removeQueueItem — setQueue diffs the remembered add-candidates instead.
+  it('is true after a wholesale setQueue replace discarded a remembered add-candidate', async () => {
+    const m = make();
+    await m.setCurrentClimb(item('B'), true); // remembers B as an add-candidate
+    await m.setQueue([item('X')]); // B is not in the new queue -> discarded
+    expect(m.wasUuidExplicitlyRemoved('B')).toBe(true);
+    // X survived the replace, so it was never discarded.
+    expect(m.wasUuidExplicitlyRemoved('X')).toBe(false);
+  });
+
+  // Only an activation that carried a queue-add can ever produce a deferred
+  // ADD, so a pointer-only activation is not an add-candidate and a later
+  // replace must not read as discarding it.
+  it('is false for an activation that carried no queue-add when a replace follows', async () => {
+    const m = make();
+    await m.setCurrentClimb(item('B'), false);
+    await m.setQueue([]);
+    expect(m.wasUuidExplicitlyRemoved('B')).toBe(false);
+  });
+
+  it('does not mutate the ledger when read', async () => {
+    const m = make();
+    expect(m.wasUuidExplicitlyRemoved('B')).toBe(false);
+    await m.setCurrentClimb(item('B'), true);
+    await m.setQueue([item('B')]); // still queued -> not discarded
+    expect(m.wasUuidExplicitlyRemoved('B')).toBe(false);
+  });
+});

--- a/packages/shared/queue-react/src/create-queue-mutations.ts
+++ b/packages/shared/queue-react/src/create-queue-mutations.ts
@@ -174,6 +174,28 @@ export type QueueMutationsActions<TItem> = {
    */
   reorderQueueItem: (uuid: string, oldIndex: number, newIndex: number) => Promise<void>;
   setCurrentClimb: (item: TItem | null, shouldAddToQueue?: boolean, correlationId?: string) => Promise<void>;
+  /**
+   * Did the CLIMBER drop `uuid` — via a per-item `removeQueueItem`, or a
+   * wholesale `setQueue` replace that discarded a remembered add-candidate?
+   *
+   * Read-only, synchronous, side-effect free. It exists so a caller-side
+   * recovery can classify a LOCAL ABSENCE the same way `sendDeferredQueueAdd`
+   * does. An item that has left this client's queue left for one of two very
+   * different reasons:
+   *   - true  — the climber dropped it. Don't resurrect it; a bare ADD would put
+   *             a climb they just discarded back on the whole crew's queue.
+   *   - false — a wholesale server sync REPLACED the queue (INITIAL_QUEUE_DATA
+   *             from a FullSync) and wiped a not-yet-synced optimistic slot. The
+   *             absence says nothing about intent, so the add must still be sent.
+   * Mobile's `recoverThrottledQueueAdd` reads it for exactly that fork (#4009);
+   * reimplementing the heuristic there would have to duplicate the ledger this
+   * factory already keeps.
+   *
+   * Also false for an item a PEER removed mid-flight: that arrives as a server
+   * delta, indistinguishable at this layer from a wholesale sync, so it takes
+   * the send branch. Same deliberate gap `sendDeferredQueueAdd` documents.
+   */
+  wasUuidExplicitlyRemoved: (uuid: string) => boolean;
   mirrorCurrentClimb: (mirrored: boolean) => Promise<void>;
   /**
    * Broadcast a playback engine state change for a multi-frame climb so party
@@ -241,6 +263,10 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
   // removing the item mid-back-off arrives as a server delta, which is
   // indistinguishable here from a wholesale sync, so it takes the append branch.
   // Pre-existing on the superseded path, which appended unconditionally.
+  //
+  // Read back through the `wasUuidExplicitlyRemoved` action so callers running
+  // their OWN recovery against the same fork (mobile's recoverThrottledQueueAdd,
+  // #4009) consult this ledger instead of re-deriving the heuristic.
   //
   // Backed by an insertion-ordered Set rather than a small ring: mobile's
   // `clearQueue` fires one `removeQueueItem` per queued item in a single burst,
@@ -437,6 +463,8 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
       }
       await coalescer.enqueue({ item, shouldAddToQueue, correlationId });
     },
+
+    wasUuidExplicitlyRemoved: (uuid) => removedUuids.has(uuid),
 
     mirrorCurrentClimb: async (mirrored) => {
       const ready = await resolveCore({ allowCreate: false });

--- a/packages/shared/queue-react/src/create-queue-mutations.ts
+++ b/packages/shared/queue-react/src/create-queue-mutations.ts
@@ -175,8 +175,10 @@ export type QueueMutationsActions<TItem> = {
   reorderQueueItem: (uuid: string, oldIndex: number, newIndex: number) => Promise<void>;
   setCurrentClimb: (item: TItem | null, shouldAddToQueue?: boolean, correlationId?: string) => Promise<void>;
   /**
-   * Did the CLIMBER drop `uuid` — via a per-item `removeQueueItem`, or a
-   * wholesale `setQueue` replace that discarded a remembered add-candidate?
+   * Is the climber's LATEST intent for `uuid` "drop it" — set by a per-item
+   * `removeQueueItem` or by a wholesale `setQueue` replace that discarded a
+   * remembered add-candidate, and retracted by any later `addQueueItem`,
+   * queue-adding activation, or `setQueue` payload that contains it?
    *
    * Read-only, synchronous, side-effect free. It exists so a caller-side
    * recovery can classify a LOCAL ABSENCE the same way `sendDeferredQueueAdd`
@@ -194,6 +196,11 @@ export type QueueMutationsActions<TItem> = {
    * Also false for an item a PEER removed mid-flight: that arrives as a server
    * delta, indistinguishable at this layer from a wholesale sync, so it takes
    * the send branch. Same deliberate gap `sendDeferredQueueAdd` documents.
+   *
+   * Latest-intent rather than ever-dropped matters because the ledger outlives
+   * any one session: the factory is memoised for the QueueProvider's lifetime,
+   * so an append-only answer would suppress the recovery for every climb the
+   * climber cleared earlier in the app process.
    */
   wasUuidExplicitlyRemoved: (uuid: string) => boolean;
   mirrorCurrentClimb: (mirrored: boolean) => Promise<void>;
@@ -268,6 +275,16 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
   // their OWN recovery against the same fork (mobile's recoverThrottledQueueAdd,
   // #4009) consult this ledger instead of re-deriving the heuristic.
   //
+  // It records the climber's LATEST intent for a uuid, not "ever dropped": every
+  // path that puts the climb back — `addQueueItem`, an activation carrying a
+  // queue-add, or a `setQueue` payload that contains it — forgets the entry. An
+  // append-only ledger keeps answering "dropped" for the rest of the app process
+  // (`useQueueMutations` memoises the factory for the QueueProvider's whole
+  // lifetime, and nothing but the cap below ever deletes), so a climber who
+  // cleared their queue and later re-picked one of those climbs would hit the
+  // very #4009 bail this exists to prevent. Re-queueing a project you cleared is
+  // ordinary, and mobile's clear-queue puts EVERY queued uuid in here at once.
+  //
   // Backed by an insertion-ordered Set rather than a small ring: mobile's
   // `clearQueue` fires one `removeQueueItem` per queued item in a single burst,
   // so a 50-entry ring evicted its own earliest entries on any queue longer than
@@ -282,6 +299,14 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
       const oldest = removedUuids.values().next();
       if (!oldest.done) removedUuids.delete(oldest.value);
     }
+  }
+  // The climber put it back, so the earlier drop no longer describes what they
+  // want. Called from every add path BEFORE that path's own awaits, so a remove
+  // that races in afterwards still records and still wins — which is what keeps
+  // the #3934 undo leg alive (recovery's add forgets, the swipe during its
+  // back-off re-records, the undo check reads the swipe).
+  function forgetRemovedUuid(uuid: string): void {
+    removedUuids.delete(uuid);
   }
 
   // uuids of recent activations that carried a queue-add — the only uuids a
@@ -428,6 +453,9 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
 
   return {
     addQueueItem: async (item, position) => {
+      // Putting it back retracts any earlier drop, and before the session guards
+      // for the same reason `removeQueueItem` records before them.
+      forgetRemovedUuid(toQueueItemInput(item).uuid);
       const ready = await resolveCore({ allowCreate: true });
       if (!ready) return;
       await runMutation(ready.client, {
@@ -455,7 +483,15 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
     setCurrentClimb: async (item, shouldAddToQueue, correlationId) => {
       // Only an activation that carries a queue-add can ever produce a deferred
       // ADD, so only those uuids need tracking for the wholesale-replace diff.
-      if (item !== null && shouldAddToQueue) rememberAddCandidate(toQueueItemInput(item).uuid);
+      // Such an activation is also the climber asking for the climb back, so it
+      // retracts any earlier drop of the same uuid — otherwise a climb they
+      // cleared an hour ago is still "dropped" when this activation's own
+      // recovery asks (#4009).
+      if (item !== null && shouldAddToQueue) {
+        const activatedUuid = toQueueItemInput(item).uuid;
+        rememberAddCandidate(activatedUuid);
+        forgetRemovedUuid(activatedUuid);
+      }
       // Web throws upfront when disconnected (no ensureReady); mobile enqueues
       // and lets the coalescer's sendArgs resolve / create the session.
       if (!ensureReady && (!getClient() || !getSessionId())) {
@@ -509,6 +545,13 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
       // placeholder reads as discarded — harmless, since the ledger is
       // consulted only once the item has also left the local queue, and an
       // activation is always a resolved climb.)
+      // The mirror image of the same intent: a uuid the payload DOES contain is
+      // one the climber just asserted belongs in their queue, so it retracts any
+      // earlier drop (#4009). Runs first, so a uuid that is both a stale
+      // add-candidate and absent from the payload still ends up recorded.
+      for (const queueInput of queueInputs) {
+        forgetRemovedUuid(queueInput.uuid);
+      }
       if (addCandidateUuids.length > 0) {
         const nextUuids = new Set(queueInputs.map((queueInput) => queueInput.uuid));
         for (const candidate of addCandidateUuids) {


### PR DESCRIPTION
Closes #4009

## The bug

`recoverThrottledQueueAdd` (`packages/mobile/src/providers/queue-provider.tsx`) is the caller-side recovery #3934 added for the climb that *heads* a throttled burst — the one whose activation promise actually rejects. It bailed on a bare local-absence check:

```ts
const position = stateRef.current.queue.findIndex((queueItem) => queueItem.uuid === item.uuid);
if (position === -1) return;
```

#4005 already proved that "replaced by a server sync" is the dominant reason the slot is gone by then, not a rare one. A queue-adding activation makes `queue-navigation.ts` publish a `FullSync` with no `clientId`, `sync-coordinator.ts` maps it to `INITIAL_QUEUE_DATA`, and `reducer.ts` applies that by **replacing** `queue` wholesale — wiping the not-yet-synced optimistic slot seconds before the rate-limited mutation rejects. The recovery then dropped the add and the climb reached nobody.

Second-order, since #4005: the same absence drove the undo leg, so an add that *did* land got a compensating `removeQueueItem`. That deletes the picker's own pick off the crew's queue **and** writes the uuid into the shared removal ledger, which then suppresses every later legitimate deferred add for it.

## The fix

Split the two causes the way the shared coalescer's `sendDeferredQueueAdd` already does, by reading the ledger the factory keeps instead of re-deriving the heuristic in the provider (the shape the issue suggested):

| local state | verdict | action |
| --- | --- | --- |
| still queued | — | positioned `ADD_QUEUE_ITEM` (peers see our order) |
| gone, ledger hit | the climber dropped it | nothing — don't resurrect their discard |
| gone, no ledger hit | a wholesale sync wiped it | unpositioned `ADD_QUEUE_ITEM` (server appends) |

and gate the undo leg on a ledger hit rather than on bare absence.

- `packages/shared/queue-react/src/create-queue-mutations.ts` — new read-only `wasUuidExplicitlyRemoved(uuid)` action on `QueueMutationsActions`. Synchronous, side-effect free. The hook returns the factory object as-is, so it flows through to web and the backend headless test client with no wiring.
- `packages/mobile/src/providers/queue-provider.tsx` — the three-way recovery above, plus a session-flip bail (see below).

### Session-flip bail

The throttled `setCurrentClimb` can sit in back-off while the climber leaves and joins another room, and `addQueueItem` resolves the **live** session — so an unpositioned send would append the old room's climb to the new crew's queue. `dispatchSetCurrent` snapshots `sessionIdRef.current` at activation time and passes it to the recovery, which bails when the live session no longer matches. This also covers the `position >= 0` branch, which sent into the wrong room before this PR too, and the solo-to-party case (`null !== 'session-2'`).

### The ledger records latest intent, not "ever dropped" (second commit)

Adversarial re-review found the guard above was leaning on a ledger that only ever grew. Nothing deleted from `removedUuids` except the 2000-entry cap, and `useQueueMutations` memoises the factory on `[hasEnsureReady]`, which never toggles — so on mobile the Set lives for the whole app process.

That made the new guard read a verdict that could be hours old. Mobile's clear-queue fires one `removeQueueItem` per queued item, so a single **Clear queue** puts every queued uuid in the ledger permanently. Re-pick one of those climbs — ordinary, with a project — during a throttled burst, let the burst-head `FullSync` wipe the slot, and the recovery reads `true` and bails. The climb reaches nobody: #4009 again, silently conditioned on "was this uuid ever dropped in this process". The same staleness already reached `sendDeferredQueueAdd`, which has consulted the ledger since #4005.

So every path that puts the climb back now retracts the entry, each before its own awaits:

- `addQueueItem`
- `setCurrentClimb` carrying a queue-add (a pointer-only move does not — navigation is not "put this back")
- `setQueue`, for every uuid the payload contains

Ordering keeps the #3934 undo leg alive: the recovery's add forgets, the climber's swipe during its back-off re-records, and the undo check reads the swipe. It also closes the cross-user leak where user A's removal would suppress user B's pick after a sign-out on the same device.

The same commit restores the `false` default for `wasUuidExplicitlyRemoved` in the third test harness — `describe('QueueProvider always-live wall control')` ran the same blanket `mockReset(); mockResolvedValue(undefined)` loop as the other two, handing a synchronous boolean action a truthy Promise.

## Validation

- `vp test run --project queue-react --reporter=agent` — 3 files, 63 tests passed
- `vp run test:mobile` — 684 files, 6551 tests passed
- `vp run typecheck:mobile` / `typecheck:shared` / `typecheck:web` — clean
- `vp lint packages/shared/queue-react/src packages/mobile/src/providers` — 0 errors (warnings are all pre-existing `no-floating-promises` in `act()` callbacks)
- `vp fmt --check` on both trees — clean

The four load-bearing retraction tests were checked against a no-op `forgetRemovedUuid`: all four fail, the two control cases stay green.

### Tests

Factory (`packages/shared/queue-react/src/__tests__/create-queue-mutations.test.ts`), against the real `createQueueMutations`:

- `wasUuidExplicitlyRemoved` false for an untouched uuid; true after `removeQueueItem`, including the no-session no-op path; true after a wholesale `setQueue` replace discards a remembered add-candidate; false for a pointer-only activation; reading does not mutate
- retraction: forgotten after `addQueueItem`, after a queue-adding activation, and for every uuid a `setQueue` payload contains — but **not** after a pointer-only re-activation, and a uuid the same payload discarded is still recorded
- end to end through the coalescer: a climb dropped earlier and since re-picked still gets its deferred add when a wholesale sync wipes the local slot

Provider (`packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx`) — these pin how the provider **branches** on the verdict. Recovery is driven by rejecting the mocked `setCurrentClimb` with a real `GraphQLOperationError` carrying `code: 'RATE_LIMITED'`, and the wipe by a real `FullSync` pushed over the `queueUpdates` sink.

- the #4009 regression: throttled activation, `FullSync` wipes the slot → an unpositioned `ADD_QUEUE_ITEM` is still sent (`position` asserted `undefined`), no queue refetch, pacing toast intact
- add lands, then a `FullSync` wipes the slot with no removal → **no** `removeQueueItem` undo
- session joined while the activation was backing off → nothing sent into the new room
- the existing "climber removed it mid-flight → skip" and "climber removed it while the add was in flight → undo still fires" cases keep passing on the ledger rather than on bare absence (#3934 semantics preserved)

## Open questions for @marcodejongh

- **A peer removing the climb during the recovery's back-off is no longer undone.** The undo leg now needs a ledger hit, and a peer's removal arrives as a server delta with no entry. Sequence: our slot is still local, the recovery sends a positioned add, a peer deletes the climb mid-back-off, our add lands after it and puts the climb back, and nothing compensates. Pre-PR the bare-absence undo did fire here. The PR documents the resurrection tradeoff on the *send* side (matching #4005); this is the same tradeoff on the *undo* side. I think it is the right trade — undoing on bare absence is what deletes the picker's own pick and poisons the ledger, and that is both worse and far more common — but it is a real behaviour change. Closing it properly needs the reducer to distinguish a `QUEUE_ITEM_REMOVED` delta from an `INITIAL_QUEUE_DATA` replace and surface that to the recovery; happy to file it.
- **Deliberate change to the #3934 undo leg**: an add that landed server-side but is locally absent with no ledger hit is no longer undone — the climb survives on the crew's queue instead of being removed. Intended (it is the picker's pick), but it changes observable party behaviour.
- **API shape**: `wasUuidExplicitlyRemoved` widens `QueueMutationsActions`, which flows to web and the backend headless test client. Every implementer gets the object from the factory and nothing constructs the type by hand, so nothing breaks — but it is your interface.
- The unpositioned send appends rather than preserving insert-after-current, so peers may see the recovered climb at the queue tail. Same degradation #4005 chose, and only on the sync-wiped branch.

## Release Notes

A climb picked during a busy party session no longer goes missing for the rest of the crew when the app is pacing itself — including a climb you'd cleared off your queue earlier in the session and queued back up.
