### PR TITLE
fix(backend): key anonymous HTTP rate limits on a trusted client IP

### DIFF
--- a/packages/backend/src/__tests__/http-client-ip-context.test.ts
+++ b/packages/backend/src/__tests__/http-client-ip-context.test.ts
@@ -1,0 +1,225 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createServer, type IncomingMessage, type Server } from 'node:http';
+
+/**
+ * Cover for issue #4034: anonymous HTTP requests must key their rate-limit
+ * bucket on a trusted hop, not on the client-authored first `x-forwarded-for`
+ * entry (which let a scripted caller mint a fresh bucket per request, or pin a
+ * victim's IP to exhaust theirs).
+ *
+ * Normalization itself is owned by websocket-client-ip.test.ts; this file
+ * covers the HTTP context builder and the `req` plumbing behind `yoga.handle`.
+ */
+
+const { resolverCalls } = vi.hoisted(() => ({
+  resolverCalls: [] as { forwardedFor?: string; cloudflareIp?: string; remoteAddress?: string; resolved?: string }[],
+}));
+
+function headerText(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value.join(',') : value;
+}
+
+// Wrap rather than replace: the real resolver keeps running (so the assertions
+// below are about genuine behaviour), and every call is recorded with the Node
+// request it actually saw. That recording is what makes the end-to-end case
+// fail if the `req` plumbing in yoga.ts is deleted — a spy on yoga.ts's own
+// `buildHttpConnectionContext` export could not, because `createYogaInstance`
+// captures the same-module reference.
+vi.mock('../websocket/client-ip', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../websocket/client-ip')>();
+  return {
+    ...actual,
+    resolveWebSocketClientIp: (req?: IncomingMessage) => {
+      const resolved = actual.resolveWebSocketClientIp(req);
+      resolverCalls.push({
+        forwardedFor: headerText(req?.headers['x-forwarded-for']),
+        cloudflareIp: headerText(req?.headers['cf-connecting-ip']),
+        remoteAddress: req?.socket?.remoteAddress,
+        resolved,
+      });
+      return resolved;
+    },
+  };
+});
+
+vi.mock('../middleware/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../middleware/auth')>();
+  return {
+    ...actual,
+    validateToken: async (token: string) =>
+      token === 'valid-token' ? { userId: 'user-1', isAuthenticated: true } : null,
+  };
+});
+
+import { buildHttpConnectionContext, createYogaInstance } from '../graphql/yoga';
+
+/** Minimal stand-in for the Node request Yoga hands the context factory. */
+function nodeRequest(options: { headers?: Record<string, string>; remoteAddress?: string }): IncomingMessage {
+  return {
+    headers: options.headers ?? {},
+    socket: { remoteAddress: options.remoteAddress },
+  } as unknown as IncomingMessage;
+}
+
+function fetchRequest(headers: Record<string, string> = {}): Request {
+  return new Request('http://localhost/graphql', { method: 'POST', headers });
+}
+
+describe('buildHttpConnectionContext client IP', () => {
+  beforeEach(() => {
+    resolverCalls.length = 0;
+  });
+
+  it('ignores a client-authored first forwarded hop and keys on the last one', async () => {
+    const context = await buildHttpConnectionContext({
+      request: fetchRequest(),
+      req: nodeRequest({ headers: { 'x-forwarded-for': '6.6.6.6, 203.0.113.9' }, remoteAddress: '10.0.0.5' }),
+    });
+
+    expect(context.clientIp).toBe('203.0.113.9');
+  });
+
+  it('prefers cf-connecting-ip over the forwarded chain', async () => {
+    const context = await buildHttpConnectionContext({
+      request: fetchRequest(),
+      req: nodeRequest({
+        headers: { 'cf-connecting-ip': '203.0.113.7', 'x-forwarded-for': '6.6.6.6, 198.51.100.4' },
+        remoteAddress: '10.0.0.5',
+      }),
+    });
+
+    expect(context.clientIp).toBe('203.0.113.7');
+  });
+
+  it('falls through to the socket peer when the forwarded chain is junk', async () => {
+    const context = await buildHttpConnectionContext({
+      request: fetchRequest(),
+      req: nodeRequest({ headers: { 'x-forwarded-for': 'not-an-ip' }, remoteAddress: '198.51.100.44' }),
+    });
+
+    expect(context.clientIp).toBe('198.51.100.44');
+  });
+
+  it('keys a direct-to-origin caller on the socket peer instead of a per-request bucket', async () => {
+    // Pre-fix this request resolved to undefined and fell through to the
+    // `http-<uuid>` connectionId branch of applyRateLimit — a fresh bucket per
+    // request, i.e. no limit at all.
+    const first = await buildHttpConnectionContext({
+      request: fetchRequest(),
+      req: nodeRequest({ remoteAddress: '198.51.100.44' }),
+    });
+    const second = await buildHttpConnectionContext({
+      request: fetchRequest(),
+      req: nodeRequest({ remoteAddress: '198.51.100.44' }),
+    });
+
+    expect(first.connectionId).not.toBe(second.connectionId);
+    expect(first.clientIp).toBe('198.51.100.44');
+    expect(second.clientIp).toBe(first.clientIp);
+  });
+
+  it('ignores x-real-ip entirely', async () => {
+    const context = await buildHttpConnectionContext({
+      request: fetchRequest({ 'x-real-ip': '6.6.6.6' }),
+      req: nodeRequest({ headers: { 'x-real-ip': '6.6.6.6' }, remoteAddress: '198.51.100.44' }),
+    });
+
+    expect(context.clientIp).toBe('198.51.100.44');
+  });
+
+  it('groups an IPv6 client on its /64 prefix', async () => {
+    const context = await buildHttpConnectionContext({
+      request: fetchRequest(),
+      req: nodeRequest({ headers: { 'cf-connecting-ip': '2001:db8:1:2:3:4:5:6' } }),
+    });
+
+    expect(context.clientIp).toBe('2001:db8:1:2::/64');
+  });
+
+  it('leaves clientIp undefined when there is no Node request (yoga.fetch path)', async () => {
+    const context = await buildHttpConnectionContext({ request: fetchRequest() });
+
+    expect(context.clientIp).toBeUndefined();
+    expect(context.isAuthenticated).toBe(false);
+  });
+
+  it('carries the derived clientIp on authenticated contexts too', async () => {
+    const req = nodeRequest({ headers: { 'x-forwarded-for': '6.6.6.6, 203.0.113.9' } });
+
+    const authenticated = await buildHttpConnectionContext({
+      request: fetchRequest({ authorization: 'Bearer valid-token' }),
+      req,
+    });
+    const anonymous = await buildHttpConnectionContext({ request: fetchRequest(), req });
+
+    expect(authenticated.isAuthenticated).toBe(true);
+    expect(authenticated.userId).toBe('user-1');
+    expect(authenticated.clientIp).toBe('203.0.113.9');
+    expect(anonymous.isAuthenticated).toBe(false);
+    expect(anonymous.userId).toBeUndefined();
+    expect(anonymous.clientIp).toBe('203.0.113.9');
+  });
+});
+
+describe('Yoga HTTP request wiring', () => {
+  let httpServer: Server;
+  let graphqlUrl: string;
+
+  beforeAll(async () => {
+    const yoga = createYogaInstance();
+    httpServer = createServer((req, res) => {
+      void yoga.handle(req, res);
+    });
+    const port = await new Promise<number>((resolve, reject) => {
+      httpServer.once('error', reject);
+      httpServer.listen(0, '127.0.0.1', () => {
+        const address = httpServer.address();
+        if (!address || typeof address === 'string') {
+          reject(new Error('Test server did not expose a TCP port'));
+          return;
+        }
+        resolve(address.port);
+      });
+    });
+    graphqlUrl = `http://127.0.0.1:${port}/graphql`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => httpServer.close((error) => (error ? reject(error) : resolve())));
+  });
+
+  beforeEach(() => {
+    resolverCalls.length = 0;
+  });
+
+  async function query(headers: Record<string, string>): Promise<void> {
+    const response = await fetch(graphqlUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ query: '{ __typename }' }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ data: { __typename: 'Query' } });
+  }
+
+  it('hands the real Node request, forged proxy headers and all, to the IP resolver', async () => {
+    await query({ 'x-forwarded-for': '6.6.6.6, 203.0.113.9', 'x-real-ip': '6.6.6.6' });
+
+    const call = resolverCalls.at(-1);
+    expect(call).toBeDefined();
+    // A missing `req` (deleted plumbing) shows up here as an undefined chain and
+    // an undefined resolution, not as a silently-passing unit test.
+    expect(call?.forwardedFor).toBe('6.6.6.6, 203.0.113.9');
+    expect(call?.resolved).toBe('203.0.113.9');
+  });
+
+  it('resolves the loopback socket peer when a real request sends no proxy headers', async () => {
+    await query({});
+
+    const call = resolverCalls.at(-1);
+    expect(call?.forwardedFor).toBeUndefined();
+    expect(call?.remoteAddress).toBeDefined();
+    expect(call?.resolved).toBe('127.0.0.1');
+  });
+});

--- a/packages/backend/src/__tests__/http-client-ip-context.test.ts
+++ b/packages/backend/src/__tests__/http-client-ip-context.test.ts
@@ -91,6 +91,19 @@ describe('buildHttpConnectionContext client IP', () => {
     expect(context.clientIp).toBe('203.0.113.7');
   });
 
+  it('trusts a single-hop forwarded chain — the residual a direct-origin caller can still forge', async () => {
+    const context = await buildHttpConnectionContext({
+      request: fetchRequest(),
+      req: nodeRequest({ headers: { 'x-forwarded-for': '203.0.113.9' }, remoteAddress: '10.0.0.5' }),
+    });
+
+    // Behind Cloudflare a lone entry IS our edge's own observation, so trusting
+    // it is right. Reaching the Railway origin directly it is client-authored
+    // again — the documented residual this fix does not close, shared with
+    // og-climb.ts and the WebSocket path (#4034).
+    expect(context.clientIp).toBe('203.0.113.9');
+  });
+
   it('falls through to the socket peer when the forwarded chain is junk', async () => {
     const context = await buildHttpConnectionContext({
       request: fetchRequest(),

--- a/packages/backend/src/graphql/resolvers/shared/helpers.ts
+++ b/packages/backend/src/graphql/resolvers/shared/helpers.ts
@@ -436,9 +436,15 @@ export async function isSessionMember(ctx: ConnectionContext, sessionId: string)
  * 2. **Redis** (authenticated callers and anonymous WebSockets): Distributed
  *    enforcement across multiple backend instances. Authenticated callers key
  *    on userId; anonymous WebSockets key on the trusted-hop clientIp resolved
- *    during upgrade. Anonymous HTTP stays on Tier 1 because its separate proxy
- *    trust boundary is not equivalent yet. Uses an atomic Lua script (INCR +
- *    EXPIRE) so counts are consistent cluster-wide.
+ *    during upgrade. Uses an atomic Lua script (INCR + EXPIRE) so counts are
+ *    consistent cluster-wide.
+ *
+ *    Anonymous HTTP deliberately stays on Tier 1 only. Since issue #4034 both
+ *    transports resolve clientIp through the same trusted-hop resolver, so the
+ *    trust boundary no longer blocks it — extending Tier 2 to anonymous HTTP is
+ *    now a cost/benefit call (one Redis round-trip on every anonymous HTTP
+ *    request vs. limits that currently scale with instance count) and is left
+ *    open on #4034 rather than folded into that fix.
  *
  * Callers are checked by *both* tiers intentionally:
  * the in-memory check is a fast short-circuit that avoids a Redis

--- a/packages/backend/src/graphql/yoga.ts
+++ b/packages/backend/src/graphql/yoga.ts
@@ -2,9 +2,11 @@ import { createYoga } from 'graphql-yoga';
 import { v4 as uuidv4 } from 'uuid';
 import { GraphQLError } from 'graphql';
 import * as Sentry from '@sentry/node';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 import { schema } from './index';
 import { validateToken } from '../middleware/auth';
 import type { AuthResult } from '../middleware/auth';
+import { resolveWebSocketClientIp } from '../websocket/client-ip';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { maxDepthPlugin } from '@escape.tech/graphql-armor-max-depth';
 import { costLimitPlugin } from '@escape.tech/graphql-armor-cost-limit';
@@ -26,6 +28,61 @@ async function authenticateHttpBearer(authHeader: string | null): Promise<AuthRe
 }
 
 /**
+ * Node server context Yoga hands to the context factory.
+ *
+ * `server.ts` serves `/graphql` with `yoga.handle(req, res)`, so the Node
+ * request (and its TCP socket) is available on every real HTTP request. The
+ * `yoga.fetch` path — used by tests and by any non-Node adapter — supplies
+ * neither, hence both are optional.
+ */
+type NodeServerContext = { req?: IncomingMessage; res?: ServerResponse };
+
+/**
+ * Build the connection context for an HTTP GraphQL request.
+ *
+ * Exported so tests can drive the exact shape Yoga passes in. HTTP requests are
+ * stateless and are not tracked in the connections Map; only WebSocket
+ * connections are stored there (they have onDisconnect cleanup).
+ *
+ * The anonymous rate-limit identity comes from `resolveWebSocketClientIp`, the
+ * same trusted-hop resolver the WebSocket transport uses (issue #4034):
+ * `cf-connecting-ip` -> LAST `x-forwarded-for` hop -> `req.socket.remoteAddress`
+ * -> undefined. Two bypasses this closes, both live before it:
+ *
+ *  - the FIRST forwarded hop is client-authored (Cloudflare appends rather than
+ *    strips), so a scripted client could send `x-forwarded-for: <random>` per
+ *    request and mint a fresh `applyRateLimit` bucket every time — or pin a
+ *    victim's IP to exhaust theirs.
+ *  - a direct-to-origin client sending no proxy headers at all resolved to
+ *    `undefined` and fell through to the per-request `http-<uuid>` bucket, which
+ *    is no limit at all. The socket fallback keys it on the real peer.
+ *
+ * `x-real-ip` is deliberately no longer consulted: nothing in our chain sets it,
+ * so it was pure spoof surface.
+ *
+ * When no IP resolves (the `yoga.fetch` path) `clientIp` stays undefined and
+ * `applyRateLimit` falls back to the connectionId branch, exactly as before.
+ */
+export async function buildHttpConnectionContext({
+  request,
+  req,
+}: { request: Request } & NodeServerContext): Promise<ConnectionContext> {
+  const authHeader = request.headers.get('authorization');
+  const clientIp = resolveWebSocketClientIp(req);
+
+  const authResult = await authenticateHttpBearer(authHeader);
+
+  return {
+    connectionId: `http-${uuidv4()}`,
+    transport: 'http' as const,
+    sessionId: undefined,
+    userId: authResult?.userId,
+    isAuthenticated: authResult !== null,
+    clientIp,
+  };
+}
+
+/**
  * Create and configure the GraphQL Yoga instance
  *
  * Note: This Yoga instance is primarily used for HTTP GraphQL requests.
@@ -33,44 +90,16 @@ async function authenticateHttpBearer(authHeader: string | null): Promise<AuthRe
  * to maintain protocol compatibility with the frontend.
  */
 export function createYogaInstance() {
-  const yoga = createYoga({
+  const yoga = createYoga<NodeServerContext>({
     schema,
     graphqlEndpoint: '/graphql',
     // Depth/cost limiting for HTTP GraphQL requests.
     // WebSocket subscriptions are protected separately via onSubscribe in websocket/setup.ts
     plugins: [maxDepthPlugin({ n: 10 }), costLimitPlugin({ maxCost: 5000 })],
-    // Context function - extract auth from HTTP requests
-    // HTTP requests are stateless and don't need to be tracked in the connections Map.
-    // Only WebSocket connections are stored there (they have onDisconnect cleanup).
-    context: async ({ request }): Promise<ConnectionContext> => {
-      // Extract Authorization header
-      const authHeader = request.headers.get('authorization');
-
-      // Extract client IP for rate limiting anonymous HTTP requests
-      const clientIp =
-        request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || request.headers.get('x-real-ip') || undefined;
-
-      const authResult = await authenticateHttpBearer(authHeader);
-      if (authResult) {
-        return {
-          connectionId: `http-${uuidv4()}`,
-          transport: 'http' as const,
-          sessionId: undefined,
-          userId: authResult.userId,
-          isAuthenticated: true,
-          clientIp,
-        };
-      }
-
-      return {
-        connectionId: `http-${uuidv4()}`,
-        transport: 'http' as const,
-        sessionId: undefined,
-        userId: undefined,
-        isAuthenticated: false,
-        clientIp,
-      };
-    },
+    // Context function - extract auth and the trusted client IP from HTTP requests.
+    // `req` is the Node request `server.ts` hands to `yoga.handle`; it carries the
+    // TCP socket the client cannot forge.
+    context: ({ request, req }): Promise<ConnectionContext> => buildHttpConnectionContext({ request, req }),
     // Disable GraphiQL in production
     graphiql:
       process.env.NODE_ENV !== 'production'

--- a/packages/backend/src/websocket/client-ip.ts
+++ b/packages/backend/src/websocket/client-ip.ts
@@ -91,7 +91,10 @@ function headerValue(value: string | string[] | undefined): string | undefined {
 }
 
 /**
- * Resolve the client IP of a WebSocket upgrade request for rate-limit keying.
+ * Resolve the client IP of an incoming request for rate-limit keying. Named for
+ * the WebSocket upgrade it was written for; `packages/backend/src/graphql/yoga.ts`
+ * now calls it with the Node request behind `yoga.handle` so both transports
+ * share one trust boundary (issue #4034).
  *
  * Trusted-hop order — mirrors `packages/backend/src/handlers/og-climb.ts`:
  *   1. `cf-connecting-ip` — Cloudflare overwrites this header, and Cloudflare
@@ -105,10 +108,8 @@ function headerValue(value: string | string[] | undefined): string | undefined {
  * Why not the FIRST x-forwarded-for hop: it is attacker-controlled. A scripted
  * client can set `x-forwarded-for: <random>` on each upgrade and mint a fresh
  * bucket every time — exactly the bypass issue #2863 exists to close — and can
- * also pin a *victim's* IP to exhaust their bucket. This deliberately diverges
- * from `packages/backend/src/graphql/yoga.ts`, whose HTTP anonymous derivation
- * still trusts the first hop; that is the same defect on the HTTP transport and
- * is tracked separately.
+ * also pin a *victim's* IP to exhaust their bucket. HTTP had the same defect
+ * until issue #4034 pointed `yoga.ts` at this resolver.
  *
  * Residual: a client that reaches the Railway origin directly, bypassing
  * Cloudflare, can spoof `cf-connecting-ip` (same caveat as og-climb.ts).


### PR DESCRIPTION
Closes #4034

## What was wrong

`packages/backend/src/graphql/yoga.ts` derived the anonymous HTTP rate-limit identity as:

```ts
request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || request.headers.get('x-real-ip') || undefined
```

Both sources are client-authored. Cloudflare fronts the Railway origin and **appends** to `x-forwarded-for` rather than stripping it, so the first hop is whatever the client sent, and nothing in our chain sets `x-real-ip` at all. That value becomes the tier-1 bucket key `ip:<clientIp>:<operation>` in `applyRateLimit` (`resolvers/shared/helpers.ts`), which gave anonymous callers two bypasses:

1. **Header rotation.** Send `x-forwarded-for: <random>` per request and mint a fresh bucket every time — unlimited anonymous HTTP throughput. The mirror image also worked: pin a *victim's* IP to exhaust the bucket they share.
2. **No headers at all.** A direct-to-origin scripted client sending neither header resolved `clientIp` to `undefined` and fell through to the per-request `http-<uuid>` connectionId key — also a fresh bucket per request, i.e. no limit.

There was no `isIP` validation, no `::ffff:` unwrap and no IPv6 truncation either, so junk headers became permanent in-memory map keys and one routed /64 could mint 2^64 buckets.

This is the HTTP half of #2863. The WebSocket half landed in #4039, whose `resolveWebSocketClientIp` docblock explicitly named `yoga.ts` as "the same defect on the HTTP transport … tracked separately".

## The fix

Point the HTTP context at the resolver #4039 already shipped, rather than duplicating it: `cf-connecting-ip` → **last** `x-forwarded-for` hop → `req.socket.remoteAddress` → undefined, with `isIP` validation, `::ffff:` unwrapping and IPv6 /64 truncation.

That resolver needs the Node request, which only exists behind `yoga.handle(req, res)` (`server.ts`), so `createYoga` is now typed `createYoga<{ req?: IncomingMessage; res?: ServerResponse }>` and the context body moved into an exported `buildHttpConnectionContext({ request, req })`. Both are optional because the `yoga.fetch` path (tests, non-Node adapters) supplies neither — that path still yields `clientIp: undefined` and the connectionId branch, exactly as today.

`x-real-ip` is dropped entirely: nothing in our chain sets it, so it was pure spoof surface.

## Blast radius

- **Honest anonymous traffic is essentially unchanged.** A client that sends no `x-forwarded-for` of its own already had "first hop == its real IP", because our edge is the only thing appending to the chain. What changes is that the forged prefix no longer wins.
- **Direct-to-origin anonymous HTTP tightens.** Clients sending no proxy headers previously got a fresh `http-<uuid>` bucket per request (no effective tier-1 limit) and now key on `socket.remoteAddress`. This is a real behaviour change for that traffic class, and it is the point.
- **Anonymous clients behind their own forward proxy** (corporate egress) previously keyed on their inner/first-hop address and now key on the proxy egress IP, so they share a bucket per NAT. Same trade-off #4039 shipped for WebSockets.
- **IPv6 anonymous clients group per /64**, again matching #4039.
- **Authenticated requests are untouched** — they key on `userId` in both tiers.
- **Residual, deliberately not closed here:** a client that reaches the Railway origin directly, bypassing Cloudflare, can still forge `cf-connecting-ip`. Known and shared with `og-climb.ts` and the WebSocket path; see the open questions below.

No limit bumps were needed. Unlike WebSocket `reportBoardClimb` in #4039, anonymous HTTP operations were already effectively per-real-IP for honest traffic.

## Comment updates

- `websocket/client-ip.ts`: the `resolveWebSocketClientIp` docblock no longer says `yoga.ts` "still trusts the first hop … tracked separately", because it doesn't. **Only that docblock paragraph is touched** — `normalizeClientIp`'s body is left alone to stay out of #4162's way.
- `resolvers/shared/helpers.ts`: the tier-2 paragraph said anonymous HTTP stays on tier 1 "because its separate proxy trust boundary is not equivalent yet". This PR makes the boundaries equivalent, so that rationale would have been false the moment it merged. Rewritten to say the deferral is now a cost/benefit call, not a trust-boundary one, and left open on #4034 (first open question below). The tier-2 gate itself (`ctx.transport === 'ws'`) is unchanged in this PR.

## Validation

- `vp run typecheck:backend` — clean. This is what proves the `createYoga<NodeServerContext>` generic actually flows through `yoga.handle(req, res)`; no casts were needed.
- `vp test run --project backend --reporter=agent http-client-ip-context` — **10/10 pass** (new file).
- `vp test run --project backend --reporter=agent auth-transport websocket-client-ip apply-rate-limit` — **4 files, 55/55 pass**, unchanged (`auth-transport.test.ts` drives `yoga.fetch` with no Node `req`, which is exactly the "builder must tolerate a missing req" case).
- `vp check` — the pre-commit hook ran `vp check --fix` over all four changed files clean. A repo-wide `vp check` reports 2 pre-existing formatting files (`docs/discord-feedback-pipeline.md`, already reformatted on newer `main`; `.claude/skills/discord-feedback-triage/SKILL.md`) and 18 pre-existing lint errors, all under `scripts/` — none in `packages/backend`, none in files this PR touches.
- Local backend runs hit intermittent `deadlock detected` in the shared `boardsesh_backend_test_w<N>` database on :5433 — several worktrees on this box run backend tests against the same worker DBs. Reruns are green; nothing in this change touches the DB.

### New test file

`packages/backend/src/__tests__/http-client-ip-context.test.ts` covers the builder (last-hop wins over a forged first hop; `cf-connecting-ip` priority; junk chain falls through to the socket; `x-real-ip` ignored; IPv6 → /64; missing `req` → `undefined`; the direct-origin case that used to get a fresh uuid bucket; `clientIp` present on both authenticated and anonymous contexts) plus two end-to-end cases that drive a real `createServer(...yoga.handle(req, res))` over the network.

The wiring cases assert through a `vi.mock('../websocket/client-ip')` wrapper that records every call with the Node request it actually saw, mirroring how `websocket-client-ip-context.test.ts` wraps `createContext`. This is deliberate rather than incidental: a spy on `yoga.ts`'s own `buildHttpConnectionContext` export cannot intercept `createYogaInstance`'s same-module reference, so that variant would pass vacuously. As written, deleting the `req` plumbing from `yoga.ts` turns those cases red.

Normalization internals are **not** re-tested here — `websocket-client-ip.test.ts` owns them.

## Coordination

- **#4035** (per-IP cap on concurrent anonymous WS connections) imports from `client-ip.ts`. This PR does not rename or move any export and does not touch `websocket/setup.ts`.
- **#4162** (`fix/3096-public-api-rate-limit`) rewrites `normalizeClientIp`'s body to delegate to a new `@boardsesh/rate-limit` package and edits `websocket-client-ip.test.ts`. This PR's only `client-ip.ts` change is the `resolveWebSocketClientIp` docblock, a different hunk, so a textual conflict is unlikely — but a rebase may be needed if #4162 lands first.

## Open questions for @marcodejongh

- Now that HTTP's proxy trust boundary matches the WS one, should anonymous HTTP also join Tier-2 Redis enforcement (drop the `ctx.transport === 'ws'` gate at helpers.ts:490)? Today anon HTTP limits are per-instance only, so N backend instances give attackers N× the intended budget. Extending it adds one Redis round-trip per anon HTTP request.
- Should the HTTP context also set socketPeerIp (via `resolveWebSocketSocketPeerIp(req)`, nearly free since `req.socket` is in hand), so the direct-origin secondary ceiling that #4038 gave WS can later cover HTTP? Without it, a direct-to-origin HTTP client forging cf-connecting-ip still mints unlimited tier-1 buckets (and unbounded in-memory map growth from valid-looking forged IPs). Fine to defer, but wants a follow-up issue if so.
- Confirm the IPv6 /64 grouping and corporate-NAT bucket-sharing trade-off (same decision #4039 shipped for WS) is also acceptable for HTTP anon traffic at the default 60 req/min/operation — busy CGNAT egress points now share one bucket per operation.

## Release Notes

- [x] No release note needed
