### PR TITLE
fix(backend): stabilise playlist listing pagination and escape LIKE filters

### DIFF
--- a/packages/backend/src/__tests__/playlist-pagination-stability.test.ts
+++ b/packages/backend/src/__tests__/playlist-pagination-stability.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { playlistQueries } from '../graphql/resolvers/playlists/queries';
+
+// Integration test (real DB) for #4011: offset-paginated playlist listing
+// queries (discoverPlaylists, searchPlaylists, allUserPlaylists) previously
+// ordered only by columns that tie in the common case (nightly recommendation
+// batch upserts share createdAt; most playlists share a climb count), so rows
+// could repeat or vanish across pages. Fixed by appending playlists.id as a
+// final deterministic tiebreak. Also covers the discoverPlaylists name filter
+// and playlistCreators searchQuery LIKE-escaping fix (search.ts already
+// escaped; discover.ts did not).
+
+const OWNER_ID = 'user-123'; // seeded by setup.ts
+const CREATOR_PERCENT_ID = 'user-creator-percent';
+const CREATOR_X_ID = 'user-creator-x';
+const TIED_TIMESTAMP = '2026-08-01T00:00:00Z';
+
+function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext {
+  return {
+    connectionId: 'conn-1',
+    isAuthenticated: true,
+    userId: OWNER_ID,
+    sessionId: null,
+    boardPath: null,
+    controllerId: null,
+    controllerApiKey: null,
+    ...overrides,
+  } as ConnectionContext;
+}
+
+/** Seed `count` public playlists that all tie on createdAt/updatedAt and climb count. */
+async function seedTiedPublicPlaylists(count: number, namePrefix: string): Promise<string[]> {
+  const uuids: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const uuid = `${namePrefix}-${i}`;
+    uuids.push(uuid);
+    const result = await db.execute(sql`
+      INSERT INTO playlists (uuid, board_type, layout_id, name, is_public, created_at, updated_at)
+      VALUES (${uuid}, 'kilter', 1, ${`${namePrefix} ${i}`}, true, ${TIED_TIMESTAMP}, ${TIED_TIMESTAMP})
+      RETURNING id
+    `);
+    const playlistId = (result as unknown as { id: number | bigint }[])[0].id;
+    await db.execute(sql`
+      INSERT INTO playlist_ownership (playlist_id, user_id, role)
+      VALUES (${playlistId}, ${OWNER_ID}, 'owner')
+    `);
+    await db.execute(sql`
+      INSERT INTO playlist_climbs (playlist_id, climb_uuid, angle, position)
+      VALUES (${playlistId}, 'climb-shared', 40, 0)
+    `);
+  }
+  return uuids;
+}
+
+describe('playlist listing pagination stability — real DB (#4011)', () => {
+  beforeEach(async () => {
+    await db.execute(sql`TRUNCATE TABLE playlist_climbs, playlist_ownership, playlists RESTART IDENTITY CASCADE`);
+    await db.execute(sql`
+      INSERT INTO users (id, email, name, created_at, updated_at)
+      VALUES
+        (${CREATOR_PERCENT_ID}, 'creator-percent@test.com', 'Bob%Percent', now(), now()),
+        (${CREATOR_X_ID}, 'creator-x@test.com', 'BobXPercent', now(), now())
+      ON CONFLICT (id) DO NOTHING
+    `);
+  });
+
+  afterAll(async () => {
+    await db.execute(sql`TRUNCATE TABLE playlist_climbs, playlist_ownership, playlists RESTART IDENTITY CASCADE`);
+    // Deliberately not deleting the fixture creator users here: this table is
+    // shared across test files in the worker DB (see setup.ts's TABLES_TO_RESET),
+    // and a targeted DELETE racing another file's TRUNCATE ... CASCADE on `users`
+    // deadlocks. Mirror setup.ts's user-123 pattern instead — leave these rows
+    // in place; the ON CONFLICT DO NOTHING insert above makes reseeding idempotent.
+  });
+
+  describe('discoverPlaylists', () => {
+    it('pages a fully-tied set (same createdAt/updatedAt/climbCount) with no repeats or gaps', async () => {
+      const seededUuids = await seedTiedPublicPlaylists(6, 'discover-tied');
+      const ctx = makeCtx({ isAuthenticated: false, userId: undefined });
+
+      const seenUuids: string[] = [];
+      for (let page = 0; page < 3; page++) {
+        const result = await playlistQueries.discoverPlaylists(
+          null,
+          { input: { pageSize: 2, page, sortBy: 'recent' } },
+          ctx,
+        );
+        const rows = result.playlists as { uuid: string }[];
+        expect(rows.length).toBe(2);
+        seenUuids.push(...rows.map((row) => row.uuid));
+        expect(result.hasMore).toBe(page < 2);
+      }
+
+      expect(new Set(seenUuids).size).toBe(6);
+      expect(seenUuids.sort()).toEqual([...seededUuids].sort());
+    });
+
+    it('pages a tied set under sortBy popular with no repeats or gaps', async () => {
+      const seededUuids = await seedTiedPublicPlaylists(6, 'discover-popular-tied');
+      const ctx = makeCtx({ isAuthenticated: false, userId: undefined });
+
+      const seenUuids: string[] = [];
+      for (let page = 0; page < 3; page++) {
+        const result = await playlistQueries.discoverPlaylists(
+          null,
+          { input: { pageSize: 2, page, sortBy: 'popular' } },
+          ctx,
+        );
+        const rows = result.playlists as { uuid: string }[];
+        seenUuids.push(...rows.map((row) => row.uuid));
+      }
+
+      expect(new Set(seenUuids).size).toBe(6);
+      expect(seenUuids.sort()).toEqual([...seededUuids].sort());
+    });
+
+    it('treats % in the name filter as a literal character, not a wildcard', async () => {
+      const percentUuid = 'discover-literal-percent';
+      const otherUuid = 'discover-literal-other';
+      for (const [uuid, name] of [
+        [percentUuid, 'a%b'],
+        [otherUuid, 'axyzb'],
+      ] as const) {
+        const result = await db.execute(sql`
+          INSERT INTO playlists (uuid, board_type, layout_id, name, is_public, created_at, updated_at)
+          VALUES (${uuid}, 'kilter', 1, ${name}, true, ${TIED_TIMESTAMP}, ${TIED_TIMESTAMP})
+          RETURNING id
+        `);
+        const playlistId = (result as unknown as { id: number | bigint }[])[0].id;
+        await db.execute(sql`
+          INSERT INTO playlist_ownership (playlist_id, user_id, role) VALUES (${playlistId}, ${OWNER_ID}, 'owner')
+        `);
+        await db.execute(sql`
+          INSERT INTO playlist_climbs (playlist_id, climb_uuid, angle, position)
+          VALUES (${playlistId}, 'climb-shared', 40, 0)
+        `);
+      }
+
+      const ctx = makeCtx({ isAuthenticated: false, userId: undefined });
+      const result = await playlistQueries.discoverPlaylists(null, { input: { name: 'a%b' } }, ctx);
+      const rows = result.playlists as { uuid: string }[];
+
+      expect(rows.map((row) => row.uuid)).toEqual([percentUuid]);
+    });
+
+    it('treats _ in the name filter as a literal character, not a single-char wildcard', async () => {
+      const underscoreUuid = 'discover-literal-underscore';
+      const otherUuid = 'discover-literal-underscore-other';
+      for (const [uuid, name] of [
+        [underscoreUuid, 'c_d'],
+        [otherUuid, 'ced'],
+      ] as const) {
+        const result = await db.execute(sql`
+          INSERT INTO playlists (uuid, board_type, layout_id, name, is_public, created_at, updated_at)
+          VALUES (${uuid}, 'kilter', 1, ${name}, true, ${TIED_TIMESTAMP}, ${TIED_TIMESTAMP})
+          RETURNING id
+        `);
+        const playlistId = (result as unknown as { id: number | bigint }[])[0].id;
+        await db.execute(sql`
+          INSERT INTO playlist_ownership (playlist_id, user_id, role) VALUES (${playlistId}, ${OWNER_ID}, 'owner')
+        `);
+        await db.execute(sql`
+          INSERT INTO playlist_climbs (playlist_id, climb_uuid, angle, position)
+          VALUES (${playlistId}, 'climb-shared', 40, 0)
+        `);
+      }
+
+      const ctx = makeCtx({ isAuthenticated: false, userId: undefined });
+      const result = await playlistQueries.discoverPlaylists(null, { input: { name: 'c_d' } }, ctx);
+      const rows = result.playlists as { uuid: string }[];
+
+      expect(rows.map((row) => row.uuid)).toEqual([underscoreUuid]);
+    });
+  });
+
+  describe('playlistCreators', () => {
+    it('treats % in searchQuery as a literal character, not a wildcard', async () => {
+      for (const [uuid, ownerId] of [
+        ['creator-search-percent', CREATOR_PERCENT_ID],
+        ['creator-search-x', CREATOR_X_ID],
+      ] as const) {
+        const result = await db.execute(sql`
+          INSERT INTO playlists (uuid, board_type, layout_id, name, is_public, created_at, updated_at)
+          VALUES (${uuid}, 'kilter', 1, ${uuid}, true, ${TIED_TIMESTAMP}, ${TIED_TIMESTAMP})
+          RETURNING id
+        `);
+        const playlistId = (result as unknown as { id: number | bigint }[])[0].id;
+        await db.execute(sql`
+          INSERT INTO playlist_ownership (playlist_id, user_id, role) VALUES (${playlistId}, ${ownerId}, 'owner')
+        `);
+        await db.execute(sql`
+          INSERT INTO playlist_climbs (playlist_id, climb_uuid, angle, position)
+          VALUES (${playlistId}, 'climb-shared', 40, 0)
+        `);
+      }
+
+      const ctx = makeCtx({ isAuthenticated: false, userId: undefined });
+      const results = (await playlistQueries.playlistCreators(
+        null,
+        { input: { boardType: 'kilter', layoutId: 1, searchQuery: 'Bob%Percent' } },
+        ctx,
+      )) as { userId: string }[];
+
+      expect(results.map((row) => row.userId)).toEqual([CREATOR_PERCENT_ID]);
+    });
+  });
+
+  describe('searchPlaylists', () => {
+    it('pages a fully-tied set (same createdAt/climbCount) with no repeats or gaps', async () => {
+      const seededUuids = await seedTiedPublicPlaylists(6, 'search-tied');
+      const ctx = makeCtx({ isAuthenticated: false, userId: undefined });
+
+      const seenUuids: string[] = [];
+      for (let offset = 0; offset < 6; offset += 2) {
+        const result = await playlistQueries.searchPlaylists(
+          null,
+          { input: { query: 'search-tied', limit: 2, offset } },
+          ctx,
+        );
+        const rows = result.playlists as { uuid: string }[];
+        expect(rows.length).toBe(2);
+        seenUuids.push(...rows.map((row) => row.uuid));
+      }
+
+      expect(new Set(seenUuids).size).toBe(6);
+      expect(seenUuids.sort()).toEqual([...seededUuids].sort());
+    });
+
+    it('treats % in the query as a literal character, not a wildcard', async () => {
+      const percentUuid = 'search-literal-percent';
+      const otherUuid = 'search-literal-other';
+      for (const [uuid, name] of [
+        [percentUuid, 'search-a%b'],
+        [otherUuid, 'search-axyzb'],
+      ] as const) {
+        const result = await db.execute(sql`
+          INSERT INTO playlists (uuid, board_type, layout_id, name, is_public, created_at, updated_at)
+          VALUES (${uuid}, 'kilter', 1, ${name}, true, ${TIED_TIMESTAMP}, ${TIED_TIMESTAMP})
+          RETURNING id
+        `);
+        const playlistId = (result as unknown as { id: number | bigint }[])[0].id;
+        await db.execute(sql`
+          INSERT INTO playlist_ownership (playlist_id, user_id, role) VALUES (${playlistId}, ${OWNER_ID}, 'owner')
+        `);
+        await db.execute(sql`
+          INSERT INTO playlist_climbs (playlist_id, climb_uuid, angle, position)
+          VALUES (${playlistId}, 'climb-shared', 40, 0)
+        `);
+      }
+
+      const ctx = makeCtx({ isAuthenticated: false, userId: undefined });
+      const result = await playlistQueries.searchPlaylists(null, { input: { query: 'search-a%b' } }, ctx);
+      const rows = result.playlists as { uuid: string }[];
+
+      expect(rows.map((row) => row.uuid)).toEqual([percentUuid]);
+    });
+  });
+
+  describe('allUserPlaylists', () => {
+    it('pages a fully-tied set (same lastAccessedAt/updatedAt) with no repeats or gaps', async () => {
+      const seededUuids = await seedTiedPublicPlaylists(6, 'library-tied');
+      const ctx = makeCtx();
+
+      const seenUuids: string[] = [];
+      for (let page = 0; page < 3; page++) {
+        const result = await playlistQueries.allUserPlaylists(null, { input: { pageSize: 2, page } }, ctx);
+        const rows = result.playlists as { uuid: string }[];
+        expect(rows.length).toBe(2);
+        seenUuids.push(...rows.map((row) => row.uuid));
+        expect(result.hasMore).toBe(page < 2);
+      }
+
+      expect(new Set(seenUuids).size).toBe(6);
+      expect(seenUuids.sort()).toEqual([...seededUuids].sort());
+    });
+  });
+});

--- a/packages/backend/src/graphql/resolvers/playlists/queries/discover.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/discover.ts
@@ -5,6 +5,7 @@ import * as dbSchema from '@boardsesh/db/schema';
 import { validateInput } from '../../shared/helpers';
 import { DiscoverPlaylistsInputSchema, GetPlaylistCreatorsInputSchema } from '../../../../validation/schemas';
 import { formatPublicPlaylist } from '../helpers/enrichment';
+import { escapeLikePattern } from '../../../../utils/like-pattern';
 
 /** Shared select fields for public playlist queries (discover + search). */
 const PUBLIC_PLAYLIST_SELECT = {
@@ -102,7 +103,7 @@ export const discoverPlaylists = async (
     conditions.push(or(eq(dbSchema.playlists.layoutId, input.layoutId), isNull(dbSchema.playlists.layoutId))!);
   }
   if (input.name) {
-    conditions.push(sql`LOWER(${dbSchema.playlists.name}) LIKE LOWER(${'%' + input.name + '%'})`);
+    conditions.push(sql`LOWER(${dbSchema.playlists.name}) LIKE LOWER(${'%' + escapeLikePattern(input.name) + '%'})`);
   }
   if (input.creatorIds && input.creatorIds.length > 0) {
     conditions.push(inArray(dbSchema.playlistOwnership.userId, input.creatorIds));
@@ -139,6 +140,7 @@ export const discoverPlaylists = async (
         ? desc(sql`count(DISTINCT ${dbSchema.playlistClimbs.id})`)
         : desc(dbSchema.playlists.createdAt),
       desc(dbSchema.playlists.updatedAt),
+      desc(dbSchema.playlists.id),
     )
     .limit(pageSize + 1)
     .offset(page * pageSize);
@@ -180,7 +182,7 @@ export const playlistCreators = async (
   ];
 
   if (input.searchQuery) {
-    conditions.push(sql`LOWER(${dbSchema.users.name}) LIKE LOWER(${'%' + input.searchQuery + '%'})`);
+    conditions.push(sql`LOWER(${dbSchema.users.name}) LIKE LOWER(${'%' + escapeLikePattern(input.searchQuery) + '%'})`);
   }
 
   const results = await db

--- a/packages/backend/src/graphql/resolvers/playlists/queries/search.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/search.ts
@@ -5,6 +5,7 @@ import { validateInput } from '../../shared/helpers';
 import { SearchPlaylistsInputSchema } from '../../../../validation/schemas';
 import { formatPublicPlaylist } from '../helpers/enrichment';
 import { PUBLIC_PLAYLIST_GROUP_BY, publicPlaylistBaseQuery, publicPlaylistCountQuery } from './discover';
+import { escapeLikePattern } from '../../../../utils/like-pattern';
 
 /**
  * Search public playlists globally by name.
@@ -23,7 +24,7 @@ export const searchPlaylists = async (
   const conditions = [eq(dbSchema.playlists.isPublic, true)];
 
   // Name filter (required, ILIKE partial match)
-  const escapedQuery = validatedInput.query.replace(/[%_\\]/g, '\\$&');
+  const escapedQuery = escapeLikePattern(validatedInput.query);
   conditions.push(sql`LOWER(${dbSchema.playlists.name}) LIKE LOWER(${'%' + escapedQuery + '%'})`);
 
   if (validatedInput.boardType) {
@@ -38,7 +39,11 @@ export const searchPlaylists = async (
   const results = await publicPlaylistBaseQuery()
     .where(whereClause)
     .groupBy(...PUBLIC_PLAYLIST_GROUP_BY)
-    .orderBy(desc(sql`count(DISTINCT ${dbSchema.playlistClimbs.id})`), desc(dbSchema.playlists.createdAt))
+    .orderBy(
+      desc(sql`count(DISTINCT ${dbSchema.playlistClimbs.id})`),
+      desc(dbSchema.playlists.createdAt),
+      desc(dbSchema.playlists.id),
+    )
     .limit(limit + 1)
     .offset(offset);
 

--- a/packages/backend/src/graphql/resolvers/playlists/queries/user-playlists.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/user-playlists.ts
@@ -80,7 +80,7 @@ export const userPlaylists = async (
         or(eq(dbSchema.playlists.layoutId, input.layoutId), isNull(dbSchema.playlists.layoutId)),
       ),
     )
-    .orderBy(PLAYLIST_ORDER);
+    .orderBy(PLAYLIST_ORDER, desc(dbSchema.playlists.id));
 
   return enrichOwnedPlaylists(userPlaylists, userId);
 };
@@ -139,7 +139,7 @@ export const allUserPlaylists = async (
       ),
     )
     .where(whereClause)
-    .orderBy(PLAYLIST_ORDER)
+    .orderBy(PLAYLIST_ORDER, desc(dbSchema.playlists.id))
     .limit(pageSize + 1)
     .offset(page * pageSize);
 


### PR DESCRIPTION
Closes #4011

## Problem

Two robustness gaps in the playlist listing resolvers, found during the playlist review that produced #4010:

1. **Unstable offset pagination.** `discoverPlaylists`, `searchPlaylists`, and `userPlaylists`/`allUserPlaylists` ordered by columns that tie in the common case — the nightly recommendation job batch-upserts many playlists with the same `createdAt`, and most playlists share a climb count — with no unique final sort key. Rows could repeat or vanish across pages whenever a tie split across a page boundary.
2. **Unescaped `LIKE` input in `discoverPlaylists`.** The `name` filter and `playlistCreators`' `searchQuery` built `LOWER(name) LIKE LOWER('%' + input + '%')` without escaping `%`/`_`/`\`. Not a SQL-injection risk (parameterised), but user-typed wildcards acted as wildcards, and a `%%%%…` query is a cheap seq-scan amplifier on an unindexed `LOWER(name) LIKE '%…%'`. `searchPlaylists` already escaped this inline with its own regex instead of the shared `escapeLikePattern` helper.

## Fix

- Appended `desc(playlists.id)` as the final `orderBy` key in `discoverPlaylists`, `searchPlaylists`, `userPlaylists`, and `allUserPlaylists`. `playlists.id` is the serial PK, so it's always unique and gives every page a deterministic boundary.
- Escaped `discoverPlaylists`' `name` filter and `playlistCreators`' `searchQuery` with the existing `escapeLikePattern` helper (`packages/backend/src/utils/like-pattern.ts`).
- Replaced `searchPlaylists`' inline escaping regex with the same shared helper (dedupe — it was already unit-tested via `beta-link-write-gate.test.ts`).

Left the `generatedRecommendation` cohort-key `LIKE` in `discoverPlaylists` (`packages/backend/src/graphql/resolvers/playlists/queries/discover.ts` around line 125) unescaped — its components (`boardType`, `layoutId`, `sizeId`, `angle`) are all zod-validated, not free-text user input, so there's nothing to escape there.

## Files changed

- `packages/backend/src/graphql/resolvers/playlists/queries/discover.ts`
- `packages/backend/src/graphql/resolvers/playlists/queries/search.ts`
- `packages/backend/src/graphql/resolvers/playlists/queries/user-playlists.ts`
- `packages/backend/src/__tests__/playlist-pagination-stability.test.ts` (new, real-DB integration test)

## Tests

New integration test file `playlist-pagination-stability.test.ts` (real worker DB, following the pattern in `playlist-reorder-integration.test.ts`):

- Seeds 6 public playlists that all tie on `createdAt`/`updatedAt`/climb count, pages `discoverPlaylists` (both `sortBy: 'recent'` and `sortBy: 'popular'`) with `pageSize: 2` across 3 pages, and asserts the union of pages is exactly the 6 seeded playlists with no repeats or gaps.
- Same tie-seeding + full-paging assertion for `searchPlaylists` and `allUserPlaylists`.
- Seeds playlists named `a%b` / `axyzb` and `c_d` / `ced` and asserts `discoverPlaylists({ name: 'a%b' })` / `{ name: 'c_d' }` match only the literal playlist, not the wildcard-expanded one.
- Same literal-match assertion for `playlistCreators`' `searchQuery` against two seeded creator names.

Ran (foreground):

- `vp run typecheck` — clean.
- `vp test run --project backend --reporter=agent packages/backend/src/__tests__/playlist-pagination-stability.test.ts` — 8/8 passed (took 3 attempts; the first two hit the documented shared-worker-DB contention flake — concurrent worktrees racing `boardsesh_backend_test_w1` via `TRUNCATE ... CASCADE`/DB creation, not caused by this change. Confirmed via `ps aux` that sibling worktrees were running `vp test run --project backend` at the same time).
- `vp check` — clean except two pre-existing formatting issues in `docs/discord-feedback-pipeline.md` and `.claude/skills/discord-feedback-triage/SKILL.md`, both untouched by this PR (confirmed via `git status`).
- Full `vp test run --project backend --reporter=agent` — kicked off; see CI for the definitive run given the local contention noted above.

## Deviations from plan

None. Implementation follows the approved plan exactly: `desc(playlists.id)` tiebreaker appended last in all four order-by call sites, `escapeLikePattern` reused (not reimplemented) in both `discover.ts` call sites and `search.ts`, integration-style real-DB tests over the mocked-db style already in `discover-playlists.test.ts`.

## Open questions for @marcodejongh

- Adding the `id` tiebreaker changes exact page boundaries for any client mid-pagination when a tie is broken differently than before (one-time reshuffle, not a correctness issue) — flagging per the plan's noted risk, no action needed unless you want a changelog note.
- The escaping fix means `%`/`_` typed into the discover name filter or creator search box now match literally instead of as wildcards, matching `searchPlaylists`' existing (and presumably intended) behaviour. If any client code relied on the old wildcard behaviour it would need updating, but I found no such usage.
