### PR TITLE
fix(backend): clear orphaned climb stats on account deletion

### DIFF
--- a/packages/backend/src/__tests__/delete-account.test.ts
+++ b/packages/backend/src/__tests__/delete-account.test.ts
@@ -57,12 +57,32 @@ function makeAnonCtx(): ConnectionContext {
 /**
  * Set up the transaction mock so it records all calls on the tx object.
  * Returns the txCalls array for assertions.
+ *
+ * `draftClimbs` seeds what the initial `tx.select(...).from(boardClimbs)...`
+ * lookup returns — the (uuid, boardType) pairs deleteAccount uses to clean up
+ * dependent rows before deleting the drafts themselves. Defaults to none, so
+ * existing tests that don't care about this keep their original call counts.
  */
-function setupTransactionMock(options?: { failOnUserDelete?: boolean }) {
+function setupTransactionMock(options?: {
+  failOnUserDelete?: boolean;
+  draftClimbs?: Array<{ uuid: string; boardType: string }>;
+}) {
   txCalls.length = 0;
 
   mockDb.transaction.mockImplementation(async (callback: (tx: unknown) => Promise<void>) => {
     const tx = {
+      select: vi.fn().mockImplementation((columns: unknown) => {
+        const call = { method: 'select', columns, args: [] as unknown[] };
+        return {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockImplementation((...args: unknown[]) => {
+              call.args = args;
+              txCalls.push(call);
+              return Promise.resolve(options?.draftClimbs ?? []);
+            }),
+          }),
+        };
+      }),
       delete: vi.fn().mockImplementation((table: unknown) => {
         const call = { method: 'delete', table, args: [] as unknown[] };
         return {
@@ -159,14 +179,52 @@ describe('deleteAccount mutation', () => {
     ).rejects.toThrow('DB error');
   });
 
-  it('should execute operations in correct order: drafts, setter name, user', async () => {
+  it('should execute operations in correct order: select drafts, delete drafts, setter name, user', async () => {
     await userMutations.deleteAccount({}, { input: { removeSetterName: true } }, makeAuthCtx());
 
-    // Order: delete drafts, update setter name, delete user
-    expect(txCalls).toHaveLength(3);
-    expect(txCalls[0].method).toBe('delete'); // draft climbs
-    expect(txCalls[1].method).toBe('update'); // setter name
-    expect(txCalls[2].method).toBe('delete'); // user row
+    // Order: select this user's draft climbs, delete drafts, update setter name, delete user
+    expect(txCalls).toHaveLength(4);
+    expect(txCalls[0].method).toBe('select'); // this user's draft climbs
+    expect(txCalls[1].method).toBe('delete'); // draft climbs
+    expect(txCalls[2].method).toBe('update'); // setter name
+    expect(txCalls[3].method).toBe('delete'); // user row
+  });
+
+  it('cleans up board_climb_stats/history/beta_links for a draft climb before deleting the drafts', async () => {
+    setupTransactionMock({ draftClimbs: [{ uuid: 'draft-1', boardType: 'kilter' }] });
+
+    await userMutations.deleteAccount({}, { input: { removeSetterName: false } }, makeAuthCtx());
+
+    // select drafts, delete stats, delete history, delete beta links, delete drafts, delete user.
+    // The dependent-row cleanup (3 deletes) must land between the select and the drafts delete.
+    expect(txCalls.map((call) => call.method)).toEqual(['select', 'delete', 'delete', 'delete', 'delete', 'delete']);
+    const deleteCalls = txCalls.filter((call) => call.method === 'delete');
+    expect(deleteCalls).toHaveLength(5);
+  });
+
+  it('groups dependent-row cleanup by board type when drafts span multiple boards', async () => {
+    setupTransactionMock({
+      draftClimbs: [
+        { uuid: 'draft-1', boardType: 'kilter' },
+        { uuid: 'draft-2', boardType: 'tension' },
+      ],
+    });
+
+    await userMutations.deleteAccount({}, { input: { removeSetterName: false } }, makeAuthCtx());
+
+    // 3 dependent-row deletes per board type (2 boards) + the drafts delete + the user delete.
+    const deleteCalls = txCalls.filter((call) => call.method === 'delete');
+    expect(deleteCalls).toHaveLength(2 * 3 + 2);
+  });
+
+  it('skips dependent-row cleanup when the user has no draft climbs', async () => {
+    setupTransactionMock({ draftClimbs: [] });
+
+    await userMutations.deleteAccount({}, { input: { removeSetterName: false } }, makeAuthCtx());
+
+    // Only the (empty) drafts delete + the user delete — no dependent-row deletes fire.
+    const deleteCalls = txCalls.filter((call) => call.method === 'delete');
+    expect(deleteCalls).toHaveLength(2);
   });
 });
 

--- a/packages/backend/src/graphql/resolvers/climbs/__tests__/climb-cleanup.test.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/__tests__/climb-cleanup.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vite-plus/test';
+import { deleteClimbDependentRows, groupClimbUuidsByBoardType } from '../climb-cleanup';
+
+function makeMockTx() {
+  const deleteCalls: Array<{ table: unknown; args: unknown[] }> = [];
+  const tx = {
+    delete: vi.fn().mockImplementation((table: unknown) => {
+      const call = { table, args: [] as unknown[] };
+      deleteCalls.push(call);
+      return {
+        where: vi.fn().mockImplementation((...args: unknown[]) => {
+          call.args = args;
+          return Promise.resolve(undefined);
+        }),
+      };
+    }),
+  };
+  return { tx, deleteCalls };
+}
+
+describe('deleteClimbDependentRows', () => {
+  it('deletes board_climb_stats, board_climb_stats_history, and board_beta_links for the given climbs', async () => {
+    const { tx, deleteCalls } = makeMockTx();
+
+    await deleteClimbDependentRows(tx as never, 'kilter', ['climb-1', 'climb-2']);
+
+    expect(deleteCalls).toHaveLength(3);
+    // Each delete's WHERE predicate must have been built (not skipped) — a
+    // condition arg was passed through for every call.
+    for (const call of deleteCalls) {
+      expect(call.args).toHaveLength(1);
+    }
+  });
+
+  it('is a no-op when given no climb uuids', async () => {
+    const { tx, deleteCalls } = makeMockTx();
+
+    await deleteClimbDependentRows(tx as never, 'kilter', []);
+
+    expect(tx.delete).not.toHaveBeenCalled();
+    expect(deleteCalls).toHaveLength(0);
+  });
+});
+
+describe('groupClimbUuidsByBoardType', () => {
+  it('groups uuids under their board type, preserving per-group order', () => {
+    const grouped = groupClimbUuidsByBoardType([
+      { boardType: 'kilter', uuid: 'a' },
+      { boardType: 'tension', uuid: 'b' },
+      { boardType: 'kilter', uuid: 'c' },
+    ]);
+
+    expect(Array.from(grouped.entries())).toEqual([
+      ['kilter', ['a', 'c']],
+      ['tension', ['b']],
+    ]);
+  });
+
+  it('returns an empty map for an empty input', () => {
+    const grouped = groupClimbUuidsByBoardType([]);
+
+    expect(grouped.size).toBe(0);
+  });
+});

--- a/packages/backend/src/graphql/resolvers/climbs/climb-cleanup.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/climb-cleanup.ts
@@ -1,0 +1,72 @@
+import { and, eq, inArray } from 'drizzle-orm';
+import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
+import * as dbSchema from '@boardsesh/db/schema';
+
+// Any drizzle-orm PgDatabase (the backend's `db` singleton, or the
+// `tx` a `db.transaction(...)` callback receives) satisfies this — the
+// callers here always pass a transaction so the deletes are atomic with
+// whatever else the caller is doing (e.g. deleting the climb row itself).
+type DrizzleTx = PgDatabase<PgQueryResultHKT, Record<string, unknown>>;
+
+/**
+ * Delete the rows that hang off a set of climbs without an FK back to
+ * `board_climbs` — `board_climb_stats`, `board_climb_stats_history`, and
+ * `board_beta_links`. There is no `ON DELETE CASCADE` here on purpose:
+ * stats legitimately arrive before their climb during upstream sync (see
+ * the schema note at `packages/db/src/schema/boards/unified.ts` near the
+ * `boardClimbStats` table), so every site that deletes a `board_climbs`
+ * row is responsible for clearing these itself or it strands an orphan
+ * (issue #3943).
+ *
+ * Callers MUST run this before deleting the `board_climbs` row(s) it
+ * targets, in the same transaction. `board_climb_holds` needs no such
+ * call — it has a real FK cascade (`board_climb_holds_climb_fk`).
+ */
+export async function deleteClimbDependentRows(
+  tx: DrizzleTx,
+  boardType: string,
+  climbUuids: readonly string[],
+): Promise<void> {
+  if (climbUuids.length === 0) return;
+
+  await tx
+    .delete(dbSchema.boardClimbStats)
+    .where(
+      and(eq(dbSchema.boardClimbStats.boardType, boardType), inArray(dbSchema.boardClimbStats.climbUuid, climbUuids)),
+    );
+
+  await tx
+    .delete(dbSchema.boardClimbStatsHistory)
+    .where(
+      and(
+        eq(dbSchema.boardClimbStatsHistory.boardType, boardType),
+        inArray(dbSchema.boardClimbStatsHistory.climbUuid, climbUuids),
+      ),
+    );
+
+  await tx
+    .delete(dbSchema.boardBetaLinks)
+    .where(
+      and(eq(dbSchema.boardBetaLinks.boardType, boardType), inArray(dbSchema.boardBetaLinks.climbUuid, climbUuids)),
+    );
+}
+
+/**
+ * Group (boardType, climbUuid) pairs by boardType, for callers that need
+ * to clean up dependent rows for climbs spanning more than one board
+ * (e.g. account deletion, where a user's drafts can live on any board).
+ */
+export function groupClimbUuidsByBoardType(
+  climbs: readonly { boardType: string; uuid: string }[],
+): Map<string, string[]> {
+  const byBoardType = new Map<string, string[]>();
+  for (const climb of climbs) {
+    const existing = byBoardType.get(climb.boardType);
+    if (existing) {
+      existing.push(climb.uuid);
+    } else {
+      byBoardType.set(climb.boardType, [climb.uuid]);
+    }
+  }
+  return byBoardType;
+}

--- a/packages/backend/src/graphql/resolvers/climbs/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/mutations.ts
@@ -20,6 +20,7 @@ import { publishSocialEvent } from '../../../events';
 import { notifyClimbRevalidated } from '../../../lib/web-revalidate';
 import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
 import { requireAdminOrLeader } from '../social/roles';
+import { deleteClimbDependentRows } from './climb-cleanup';
 import {
   buildMoonBoardClimbHoldRows,
   buildMoonBoardDuplicateError,
@@ -741,32 +742,9 @@ export const climbMutations = {
         throw new Error('Published climbs cannot be deleted here');
       }
 
-      await tx
-        .delete(dbSchema.boardClimbStats)
-        .where(
-          and(
-            eq(dbSchema.boardClimbStats.boardType, validatedBoardType),
-            eq(dbSchema.boardClimbStats.climbUuid, validatedUuid),
-          ),
-        );
-
-      await tx
-        .delete(dbSchema.boardClimbStatsHistory)
-        .where(
-          and(
-            eq(dbSchema.boardClimbStatsHistory.boardType, validatedBoardType),
-            eq(dbSchema.boardClimbStatsHistory.climbUuid, validatedUuid),
-          ),
-        );
-
-      await tx
-        .delete(dbSchema.boardBetaLinks)
-        .where(
-          and(
-            eq(dbSchema.boardBetaLinks.boardType, validatedBoardType),
-            eq(dbSchema.boardBetaLinks.climbUuid, validatedUuid),
-          ),
-        );
+      // Clear the rows that have no FK back to board_climbs before deleting
+      // the climb itself, or they strand as orphans (issue #3943).
+      await deleteClimbDependentRows(tx, validatedBoardType, [validatedUuid]);
 
       const deletedRows = await tx
         .delete(dbSchema.boardClimbs)

--- a/packages/backend/src/graphql/resolvers/users/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/users/mutations.ts
@@ -28,6 +28,7 @@ import {
   type AuroraCredentialStatus as RestAuroraCredentialStatus,
 } from '../../../services/aurora-credentials';
 import type { AuroraBoardName } from '@boardsesh/shared-schema';
+import { deleteClimbDependentRows, groupClimbUuidsByBoardType } from '../climbs/climb-cleanup';
 
 function mapAuroraCredentialStatus(credential: RestAuroraCredentialStatus): AuroraCredentialStatus {
   return {
@@ -206,6 +207,25 @@ export const userMutations = {
     const userId = ctx.userId!;
 
     await db.transaction(async (tx) => {
+      // Find this user's draft climbs first — the dependent-row cleanup below
+      // needs the (boardType, uuid) pairs, and it must run before the drafts
+      // themselves are deleted or the rows it targets would already be gone.
+      const draftClimbs = await tx
+        .select({ uuid: dbSchema.boardClimbs.uuid, boardType: dbSchema.boardClimbs.boardType })
+        .from(dbSchema.boardClimbs)
+        .where(and(eq(dbSchema.boardClimbs.userId, userId), eq(dbSchema.boardClimbs.isDraft, true)));
+
+      // board_climb_stats/_history/board_beta_links have no FK back to
+      // board_climbs (stats can legitimately arrive before their climb during
+      // upstream sync), so deleting a draft here without also clearing these
+      // strands an orphan row (issue #3943). Only the user's OWN drafts are
+      // touched — published climbs survive account deletion with userId set
+      // to null, and their stats must remain untouched.
+      const draftsByBoardType = groupClimbUuidsByBoardType(draftClimbs);
+      for (const [draftBoardType, uuids] of draftsByBoardType) {
+        await deleteClimbDependentRows(tx, draftBoardType, uuids);
+      }
+
       // Delete draft climbs created by this user
       await tx
         .delete(dbSchema.boardClimbs)


### PR DESCRIPTION
Closes #3943

## What

`board_climb_stats`, `board_climb_stats_history`, and `board_beta_links` have
no FK back to `board_climbs` on purpose — stats legitimately arrive before
their climb during upstream sync (see the schema note at
`packages/db/src/schema/boards/unified.ts` near `boardClimbStats`). So every
site that deletes a `board_climbs` row is responsible for clearing these
itself, or it strands an orphan.

The issue names three such delete paths. Two are already fixed on `main`:

- **`deleteDraftClimb`** (`packages/backend/src/graphql/resolvers/climbs/mutations.ts`)
  has deleted `boardClimbStats`/`boardClimbStatsHistory`/`boardBetaLinks` in
  the same transaction since commit `193b63457` (2026-05-09, "Add draft climb
  deletion"). The issue's claim about this path was already stale by the time
  it was filed.
- **`clear-aurora-board.ts`** was fixed by #3880 (merged 2026-07-25) — it
  now deletes stats/history for all non-owned climbs before the upstream
  `boardClimbs` delete, guarded by a row-count invariant.

The third path, **`deleteAccount`**, was still live: it deletes a user's
draft climbs (`userId` + `isDraft = true`) without cleaning up their stats,
history, or beta-link rows. A user who ticks their own draft gets a stats
row seeded by the tick recompute (`saveClimb` skips the seed for drafts, but
the recompute doesn't) — deleting the account then strands that row forever.

## Fix

- Extracted the cleanup `deleteDraftClimb` already did into a shared helper,
  `deleteClimbDependentRows(tx, boardType, climbUuids)` in
  `packages/backend/src/graphql/resolvers/climbs/climb-cleanup.ts`, and a
  `groupClimbUuidsByBoardType` helper for callers whose climbs span more than
  one board.
- `deleteDraftClimb` now calls the shared helper instead of inlining the same
  three deletes (no behavior change — same predicates, same transaction).
- `deleteAccount` now selects the user's draft climbs (`uuid`, `boardType`)
  *before* deleting them, groups them by board type, and runs the same
  cleanup for each group — all inside the existing transaction, and before
  the `boardClimbs` draft delete.
- Published climbs are untouched: `deleteAccount` only ever selects/deletes
  rows where `isDraft = true` and `userId = <this user>`; published climbs
  keep their stats and have `userId` set to `null` by the existing cascade.
- No suppression of sync tombstones — these are real deletions and offline
  clients should drop their copies, matching `deleteDraftClimb`'s existing
  behavior. (Only `clear-aurora-board` suppresses, because it re-inserts in
  the same transaction.)
- No schema change, no migration — the no-FK design is intentional (see
  above), so this stays app-level cleanup.

## Out of scope

Per the issue body: cleaning up the ~77 existing orphaned `board_climb_stats`
rows in prod is a separate, human-signed-off migration, not this PR.

## Validation

- `vp check` — clean on all files this PR touches (two unrelated
  pre-existing formatting issues in `docs/discord-feedback-pipeline.md` and
  `.claude/skills/discord-feedback-triage/SKILL.md` are untouched by this PR).
- `vp run typecheck` (backend) — clean.
- `vp test run --project backend --reporter=agent` — full backend suite,
  including:
  - Extended `delete-account.test.ts`: asserts the dependent-row cleanup
    (`select` drafts → 3 deletes per board type → delete drafts → delete
    user) runs in order inside the transaction, groups by board type when
    drafts span multiple boards, and is skipped entirely when there are no
    drafts. Existing assertions (auth, `removeSetterName`, rollback-on-error)
    still pass unchanged.
  - New `climb-cleanup.test.ts`: unit tests for `deleteClimbDependentRows`
    (deletes all three tables, no-ops on an empty uuid list) and
    `groupClimbUuidsByBoardType`.

## Open questions for @marcodejongh

- Scope: this PR closes only the `deleteAccount` path. The other two paths
  the issue names were already fixed by prior commits/PRs (cited above) —
  flagging in case you were expecting a three-path fix in one PR.
