### PR TITLE
fix(backend): reorder playlist climbs in the index space clients render

### DIFF
--- a/packages/backend/src/__tests__/playlist-climbs-uuid-join-invariant.test.ts
+++ b/packages/backend/src/__tests__/playlist-climbs-uuid-join-invariant.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { getTableConfig } from 'drizzle-orm/pg-core';
+import * as dbSchema from '@boardsesh/db/schema';
+
+// #4012 asked whether the all-boards playlistClimbs join — `board_climbs.uuid =
+// playlist_climbs.climb_uuid`, with no board_type predicate — can fan one
+// playlist row into several page rows and break the `pageSize + 1` paging, and
+// whether `playlist_climbs` should therefore start persisting `board_type`.
+//
+// It cannot, because `board_climbs.uuid` is the table's primary key: a uuid
+// names at most one climb across every board, so the uuid-only join is already
+// both unique and index-backed. That makes the extra column redundant today —
+// but the argument rests entirely on the shape of the key. Should `board_climbs`
+// ever move to a composite `(board_type, uuid)` primary key, the uuid-only joins
+// in `resolvers/playlists/queries/playlist-climbs.ts` (and the resolvable-ref
+// lookup in `reorderPlaylistClimb`) stop being safe — this test is what fails
+// loudly at that moment, instead of the paging quietly going wrong.
+describe('board_climbs uuid is a global primary key', () => {
+  const tableConfig = getTableConfig(dbSchema.boardClimbs);
+
+  it('declares uuid as a single-column primary key', () => {
+    const uuidColumn = tableConfig.columns.find((column) => column.name === 'uuid');
+    expect(uuidColumn).toBeDefined();
+    expect(uuidColumn?.primary).toBe(true);
+  });
+
+  it('has no composite primary key that would scope uuid to a board', () => {
+    expect(tableConfig.primaryKeys).toEqual([]);
+    const otherPrimaryColumns = tableConfig.columns.filter((column) => column.primary && column.name !== 'uuid');
+    expect(otherPrimaryColumns).toEqual([]);
+  });
+});

--- a/packages/backend/src/__tests__/playlist-reorder-integration.test.ts
+++ b/packages/backend/src/__tests__/playlist-reorder-integration.test.ts
@@ -55,16 +55,20 @@ describe('reorderPlaylistClimb — real DB (#3607)', () => {
     `);
     // The resolver reads which refs resolve to a catalogued climb (#4012), so the
     // catalog rows have to exist for these moves to run in visible-index space.
-    await db.execute(sql`TRUNCATE TABLE board_climbs CASCADE`);
+    // Seeded and cleaned by uuid rather than by truncating board_climbs: the
+    // worker database is shared with every other backend suite, and an
+    // AccessExclusiveLock on the catalog is both wider than this test needs and
+    // a deadlock magnet.
     await db.execute(sql`
       INSERT INTO board_climbs (uuid, board_type, layout_id, name)
       VALUES ('climb-a', 'kilter', 1, 'A'), ('climb-b', 'kilter', 1, 'B'), ('climb-c', 'kilter', 1, 'C')
+      ON CONFLICT (uuid) DO NOTHING
     `);
   });
 
   afterAll(async () => {
     await db.execute(sql`TRUNCATE TABLE playlist_climbs, playlist_ownership, playlists RESTART IDENTITY CASCADE`);
-    await db.execute(sql`TRUNCATE TABLE board_climbs CASCADE`);
+    await db.execute(sql`DELETE FROM board_climbs WHERE uuid IN ('climb-a', 'climb-b', 'climb-c')`);
   });
 
   it('persists a move to the front (the batched CASE update that threw 42804)', async () => {
@@ -135,16 +139,18 @@ describe('reorderPlaylistClimb with an orphaned ref — real DB (#4012)', () => 
       INSERT INTO playlist_climbs (playlist_id, climb_uuid, angle, position)
       VALUES (1, 'ghost-climb', 40, 0), (1, 'climb-a', 40, 1), (1, 'climb-b', 40, 2), (1, 'climb-c', 40, 3)
     `);
-    await db.execute(sql`TRUNCATE TABLE board_climbs CASCADE`);
     await db.execute(sql`
       INSERT INTO board_climbs (uuid, board_type, layout_id, name)
       VALUES ('climb-a', 'kilter', 1, 'A'), ('climb-b', 'kilter', 1, 'B'), ('climb-c', 'kilter', 1, 'C')
+      ON CONFLICT (uuid) DO NOTHING
     `);
+    // Whatever else the shared worker database holds, this uuid must not resolve.
+    await db.execute(sql`DELETE FROM board_climbs WHERE uuid = 'ghost-climb'`);
   });
 
   afterAll(async () => {
     await db.execute(sql`TRUNCATE TABLE playlist_climbs, playlist_ownership, playlists RESTART IDENTITY CASCADE`);
-    await db.execute(sql`TRUNCATE TABLE board_climbs CASCADE`);
+    await db.execute(sql`DELETE FROM board_climbs WHERE uuid IN ('climb-a', 'climb-b', 'climb-c')`);
   });
 
   it('honours the index the client rendered when dragging to the end', async () => {

--- a/packages/backend/src/__tests__/playlist-reorder-integration.test.ts
+++ b/packages/backend/src/__tests__/playlist-reorder-integration.test.ts
@@ -53,10 +53,18 @@ describe('reorderPlaylistClimb — real DB (#3607)', () => {
       INSERT INTO playlist_climbs (playlist_id, climb_uuid, angle, position)
       VALUES (1, 'climb-a', 40, 0), (1, 'climb-b', 40, 1), (1, 'climb-c', 40, 2)
     `);
+    // The resolver reads which refs resolve to a catalogued climb (#4012), so the
+    // catalog rows have to exist for these moves to run in visible-index space.
+    await db.execute(sql`TRUNCATE TABLE board_climbs CASCADE`);
+    await db.execute(sql`
+      INSERT INTO board_climbs (uuid, board_type, layout_id, name)
+      VALUES ('climb-a', 'kilter', 1, 'A'), ('climb-b', 'kilter', 1, 'B'), ('climb-c', 'kilter', 1, 'C')
+    `);
   });
 
   afterAll(async () => {
     await db.execute(sql`TRUNCATE TABLE playlist_climbs, playlist_ownership, playlists RESTART IDENTITY CASCADE`);
+    await db.execute(sql`TRUNCATE TABLE board_climbs CASCADE`);
   });
 
   it('persists a move to the front (the batched CASE update that threw 42804)', async () => {
@@ -102,5 +110,76 @@ describe('reorderPlaylistClimb — real DB (#3607)', () => {
     ).rejects.toThrow('do not have permission');
 
     expect(await orderedClimbs()).toEqual(['climb-a', 'climb-b', 'climb-c']);
+  });
+});
+
+// Integration test (real DB) for #4012: the playlistClimbs query inner-joins
+// board_climbs, so a playlist row whose climb_uuid has no catalog row never
+// reaches the client — but it still holds a position. The client therefore
+// numbers its drag targets over a shorter list than the resolver splices, and
+// one orphaned ref ahead of the target shifted every move below it by one.
+describe('reorderPlaylistClimb with an orphaned ref — real DB (#4012)', () => {
+  beforeEach(async () => {
+    await db.execute(sql`TRUNCATE TABLE playlist_climbs, playlist_ownership, playlists RESTART IDENTITY CASCADE`);
+    await db.execute(sql`
+      INSERT INTO playlists (id, uuid, board_type, layout_id, name, is_public)
+      VALUES (1, ${PLAYLIST_UUID}, 'kilter', 1, 'Reorder', true)
+    `);
+    await db.execute(sql`
+      INSERT INTO playlist_ownership (playlist_id, user_id)
+      VALUES (1, ${OWNER_ID})
+    `);
+    // 'ghost-climb' is deliberately absent from board_climbs: the user's list
+    // renders as [climb-a, climb-b, climb-c].
+    await db.execute(sql`
+      INSERT INTO playlist_climbs (playlist_id, climb_uuid, angle, position)
+      VALUES (1, 'ghost-climb', 40, 0), (1, 'climb-a', 40, 1), (1, 'climb-b', 40, 2), (1, 'climb-c', 40, 3)
+    `);
+    await db.execute(sql`TRUNCATE TABLE board_climbs CASCADE`);
+    await db.execute(sql`
+      INSERT INTO board_climbs (uuid, board_type, layout_id, name)
+      VALUES ('climb-a', 'kilter', 1, 'A'), ('climb-b', 'kilter', 1, 'B'), ('climb-c', 'kilter', 1, 'C')
+    `);
+  });
+
+  afterAll(async () => {
+    await db.execute(sql`TRUNCATE TABLE playlist_climbs, playlist_ownership, playlists RESTART IDENTITY CASCADE`);
+    await db.execute(sql`TRUNCATE TABLE board_climbs CASCADE`);
+  });
+
+  it('honours the index the client rendered when dragging to the end', async () => {
+    // Drag climb-a to the bottom of the visible list (index 2 of 3). Splicing at
+    // full index 2 would land it between climb-b and climb-c instead.
+    const result = await playlistMutations.reorderPlaylistClimb(
+      null,
+      { input: { playlistId: PLAYLIST_UUID, climbUuid: 'climb-a', newIndex: 2 } },
+      makeCtx(),
+    );
+
+    expect(result).toBe(true);
+    expect(await orderedClimbs()).toEqual(['ghost-climb', 'climb-b', 'climb-c', 'climb-a']);
+  });
+
+  it('leaves the orphaned ref at the top when dragging to the visible front', async () => {
+    const result = await playlistMutations.reorderPlaylistClimb(
+      null,
+      { input: { playlistId: PLAYLIST_UUID, climbUuid: 'climb-c', newIndex: 0 } },
+      makeCtx(),
+    );
+
+    expect(result).toBe(true);
+    expect(await orderedClimbs()).toEqual(['ghost-climb', 'climb-c', 'climb-a', 'climb-b']);
+  });
+
+  it('is a no-op when the climb already sits at that index on screen', async () => {
+    // climb-a is second overall but FIRST on screen.
+    const result = await playlistMutations.reorderPlaylistClimb(
+      null,
+      { input: { playlistId: PLAYLIST_UUID, climbUuid: 'climb-a', newIndex: 0 } },
+      makeCtx(),
+    );
+
+    expect(result).toBe(true);
+    expect(await orderedClimbs()).toEqual(['ghost-climb', 'climb-a', 'climb-b', 'climb-c']);
   });
 });

--- a/packages/backend/src/__tests__/playlist-reorder-math.test.ts
+++ b/packages/backend/src/__tests__/playlist-reorder-math.test.ts
@@ -80,3 +80,128 @@ describe('computePlaylistReorderWrites', () => {
     expect(() => computePlaylistReorderWrites(denseRows(), 'missing', 0)).toThrow('Climb not found in playlist');
   });
 });
+
+// #4012: the client computes `newIndex` against the list it renders, and that
+// list comes from an inner join to board_climbs — a playlist row whose climb no
+// longer resolves is invisible there but still holds a position in the full
+// list. `x`/`y` below are those invisible rows.
+describe('computePlaylistReorderWrites — visible-index translation', () => {
+  it('resolves the target index against the visible rows when an orphan sits ahead', () => {
+    // Full [X,A,B,C]; the user sees [A,B,C] and drags A to the end (visible 2).
+    // Full-list semantics would land A at full index 2 → visible [B,A,C].
+    const rows: ReorderRow<number>[] = [
+      { id: 9, climbUuid: 'x', position: 0 },
+      { id: 1, climbUuid: 'a', position: 1 },
+      { id: 2, climbUuid: 'b', position: 2 },
+      { id: 3, climbUuid: 'c', position: 3 },
+    ];
+    const writes = computePlaylistReorderWrites(rows, 'a', 2, new Set(['a', 'b', 'c']));
+    // → [X,B,C,A]: visible [B,C,A], exactly what the user dropped.
+    expect(writes).toEqual([
+      { id: 2, position: 1 },
+      { id: 3, position: 2 },
+      { id: 1, position: 3 },
+    ]);
+  });
+
+  it('leaves an orphan below the move untouched', () => {
+    // Full [A,B,C,X]; move C to the front. Nothing crosses X, so it keeps its
+    // position and stays out of the write set.
+    const rows: ReorderRow<number>[] = [
+      { id: 1, climbUuid: 'a', position: 0 },
+      { id: 2, climbUuid: 'b', position: 1 },
+      { id: 3, climbUuid: 'c', position: 2 },
+      { id: 9, climbUuid: 'x', position: 3 },
+    ];
+    const writes = computePlaylistReorderWrites(rows, 'c', 0, new Set(['a', 'b', 'c']));
+    expect(writes).toEqual([
+      { id: 3, position: 0 },
+      { id: 1, position: 1 },
+      { id: 2, position: 2 },
+    ]);
+  });
+
+  it('keeps a trailing orphan at the tail when moving to the visible end', () => {
+    // Full [A,B,X]; visible [A,B]. Move A to visible index 1 → [B,A,X].
+    const rows: ReorderRow<number>[] = [
+      { id: 1, climbUuid: 'a', position: 0 },
+      { id: 2, climbUuid: 'b', position: 1 },
+      { id: 9, climbUuid: 'x', position: 2 },
+    ];
+    const writes = computePlaylistReorderWrites(rows, 'a', 1, new Set(['a', 'b']));
+    expect(writes).toEqual([
+      { id: 2, position: 0 },
+      { id: 1, position: 1 },
+    ]);
+  });
+
+  it('clamps to the last VISIBLE index, not the last row', () => {
+    // Same list; an out-of-range index clamps to visible index 1, so A lands
+    // ahead of the orphan rather than after it.
+    const rows: ReorderRow<number>[] = [
+      { id: 1, climbUuid: 'a', position: 0 },
+      { id: 2, climbUuid: 'b', position: 1 },
+      { id: 9, climbUuid: 'x', position: 2 },
+    ];
+    expect(computePlaylistReorderWrites(rows, 'a', 99, new Set(['a', 'b']))).toEqual([
+      { id: 2, position: 0 },
+      { id: 1, position: 1 },
+    ]);
+  });
+
+  it('renumbers a gappy list with an orphan into dense visible order', () => {
+    const rows: ReorderRow<number>[] = [
+      { id: 9, climbUuid: 'x', position: 0 },
+      { id: 1, climbUuid: 'a', position: 5 },
+      { id: 2, climbUuid: 'b', position: 10 },
+      { id: 3, climbUuid: 'c', position: 20 },
+    ];
+    // Visible [A,B,C]; move C between A and B → full [X,A,C,B].
+    expect(computePlaylistReorderWrites(rows, 'c', 1, new Set(['a', 'b', 'c']))).toEqual([
+      { id: 1, position: 1 },
+      { id: 3, position: 2 },
+      { id: 2, position: 3 },
+    ]);
+  });
+
+  it('treats a move to the same visible index as a no-op, orphan and all', () => {
+    // A is already first on screen; there is no reason to hoist it past X.
+    const rows: ReorderRow<number>[] = [
+      { id: 9, climbUuid: 'x', position: 0 },
+      { id: 1, climbUuid: 'a', position: 1 },
+      { id: 2, climbUuid: 'b', position: 2 },
+    ];
+    expect(computePlaylistReorderWrites(rows, 'a', 0, new Set(['a', 'b']))).toEqual([]);
+  });
+
+  it('is a no-op when the moved row is the only visible one', () => {
+    const rows: ReorderRow<number>[] = [
+      { id: 9, climbUuid: 'x', position: 0 },
+      { id: 1, climbUuid: 'a', position: 1 },
+      { id: 8, climbUuid: 'y', position: 2 },
+    ];
+    expect(computePlaylistReorderWrites(rows, 'a', 2, new Set(['a']))).toEqual([]);
+  });
+
+  it('matches full-list behaviour when every row resolves', () => {
+    const allVisible = new Set(['a', 'b', 'c', 'd', 'e']);
+    for (const [climbUuid, newIndex] of [
+      ['e', 0],
+      ['d', 2],
+      ['a', 99],
+      ['a', 0],
+      ['c', 4],
+    ] as const) {
+      expect(computePlaylistReorderWrites(denseRows(), climbUuid, newIndex, allVisible)).toEqual(
+        computePlaylistReorderWrites(denseRows(), climbUuid, newIndex),
+      );
+    }
+  });
+
+  it('falls back to full-list semantics when the moved row itself is invisible', () => {
+    // Can't come from the UI (the row isn't rendered), so there is no visible
+    // index to honour — behave exactly as before.
+    const writes = computePlaylistReorderWrites(denseRows(), 'e', 0, new Set(['a', 'b', 'c', 'd']));
+    expect(writes).toEqual(computePlaylistReorderWrites(denseRows(), 'e', 0));
+  });
+});

--- a/packages/backend/src/__tests__/playlist-reorder.test.ts
+++ b/packages/backend/src/__tests__/playlist-reorder.test.ts
@@ -44,16 +44,19 @@ function createMockChain(resolveValue: unknown = []): Record<string, unknown> {
 type ClimbRow = { id: number; climbUuid: string; position: number };
 
 /**
- * Mock a transaction whose `tx.select(...).for('update')` yields `rows` and
+ * Mock a transaction whose selects yield, in order, the locked `playlist_climbs`
+ * rows and then the `board_climbs` rows that resolve them (every climb by
+ * default — pass `resolvableClimbUuids` to model orphaned refs, #4012), and
  * whose `tx.update(...).set(x)` records `x`. The resolver does at most two
  * updates: one batched `{ position: <CASE sql> }` for the shifted climbs, then
  * the parent playlist's `{ updatedAt }`.
  */
-function primeTransaction(rows: ClimbRow[]) {
+function primeTransaction(rows: ClimbRow[], resolvableClimbUuids: string[] = rows.map((row) => row.climbUuid)) {
   const setCalls: Array<Record<string, unknown>> = [];
-  const selectChain = createMockChain(rows);
+  const selectResults = [rows, resolvableClimbUuids.map((uuid) => ({ uuid }))];
+  let selectCall = 0;
   const tx = {
-    select: vi.fn(() => selectChain),
+    select: vi.fn(() => createMockChain(selectResults[selectCall++] ?? [])),
     update: vi.fn(() => {
       const chain: Record<string, unknown> = {};
       chain.set = vi.fn((arg: Record<string, unknown>) => {
@@ -66,7 +69,7 @@ function primeTransaction(rows: ClimbRow[]) {
     }),
   };
   mockDb.transaction.mockImplementationOnce(async (cb: (t: typeof tx) => Promise<unknown>) => cb(tx));
-  return { setCalls };
+  return { setCalls, tx };
 }
 
 /** How many of the captured updates rewrote climb positions (the batched CASE). */
@@ -108,6 +111,42 @@ describe('reorderPlaylistClimb mutation', () => {
     const result = await playlistMutations.reorderPlaylistClimb(
       null,
       { input: { playlistId: 'p-uuid', climbUuid: 'climb-a', newIndex: 0 } },
+      makeCtx(),
+    );
+
+    expect(result).toBe(true);
+    expect(positionUpdateCount(setCalls)).toBe(0);
+    expect('updatedAt' in setCalls[setCalls.length - 1]).toBe(true);
+  });
+
+  it('reads which refs resolve to a climb before splicing (#4012)', async () => {
+    mockDb.select.mockReturnValueOnce(createMockChain([{ id: 1 }]));
+    const { tx, setCalls } = primeTransaction(ROWS.map((row) => ({ ...row })));
+
+    await playlistMutations.reorderPlaylistClimb(
+      null,
+      { input: { playlistId: 'p-uuid', climbUuid: 'climb-c', newIndex: 0 } },
+      makeCtx(),
+    );
+
+    // Two selects inside the transaction: the locked playlist rows, then the
+    // board_climbs lookup that says which of them the client can actually see.
+    expect(tx.select).toHaveBeenCalledTimes(2);
+    expect(positionUpdateCount(setCalls)).toBe(1);
+  });
+
+  it('skips the position update when the move is a no-op in the rendered list (#4012)', async () => {
+    mockDb.select.mockReturnValueOnce(createMockChain([{ id: 1 }]));
+    // climb-a is an orphaned ref: the client renders [climb-b, climb-c], so
+    // "move climb-b to index 0" is already true on screen.
+    const { setCalls } = primeTransaction(
+      ROWS.map((row) => ({ ...row })),
+      ['climb-b', 'climb-c'],
+    );
+
+    const result = await playlistMutations.reorderPlaylistClimb(
+      null,
+      { input: { playlistId: 'p-uuid', climbUuid: 'climb-b', newIndex: 0 } },
       makeCtx(),
     );
 

--- a/packages/backend/src/__tests__/playlist-reorder.test.ts
+++ b/packages/backend/src/__tests__/playlist-reorder.test.ts
@@ -53,10 +53,14 @@ type ClimbRow = { id: number; climbUuid: string; position: number };
  */
 function primeTransaction(rows: ClimbRow[], resolvableClimbUuids: string[] = rows.map((row) => row.climbUuid)) {
   const setCalls: Array<Record<string, unknown>> = [];
-  const selectResults = [rows, resolvableClimbUuids.map((uuid) => ({ uuid }))];
-  let selectCall = 0;
   const tx = {
-    select: vi.fn(() => createMockChain(selectResults[selectCall++] ?? [])),
+    // Dispatch on the projection, not on call order: a third select added later
+    // throws here instead of quietly being served another query's rows.
+    select: vi.fn((projection: Record<string, unknown>) => {
+      if ('uuid' in projection) return createMockChain(resolvableClimbUuids.map((uuid) => ({ uuid })));
+      if ('climbUuid' in projection) return createMockChain(rows);
+      throw new Error(`Unexpected select in reorder transaction: ${Object.keys(projection).join(', ')}`);
+    }),
     update: vi.fn(() => {
       const chain: Record<string, unknown> = {};
       chain.set = vi.fn((arg: Record<string, unknown>) => {

--- a/packages/backend/src/graphql/resolvers/playlists/helpers/reorder.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/helpers/reorder.ts
@@ -15,6 +15,16 @@ export type ReorderWrite<Id> = {
  * Compute the position writes for moving `climbUuid` to `newIndex` within an
  * already-ordered list (`rows` must be sorted by current position).
  *
+ * `newIndex` is an index into the list the CLIENT renders, which is not always
+ * the full `playlist_climbs` list: the playlistClimbs query inner-joins
+ * `board_climbs`, so a row whose `climb_uuid` no longer resolves (catalog sync
+ * lag, a climb that left the catalog) is invisible to the user while still
+ * occupying a position here. `resolvableClimbUuids` names the rows the client
+ * can see; the target index is resolved against that sublist and translated
+ * back into the full list, so one invisible row no longer shifts every move
+ * below it by one (#4012). Omit it — or pass a set covering every row — and the
+ * whole list counts as visible, which is the plain full-list behaviour.
+ *
  * The result renumbers the list to a dense `0..n-1` but returns ONLY the rows
  * whose position actually changes — so the caller can persist them in a single
  * batched statement. Deriving the move from ranks (not raw position values)
@@ -26,23 +36,57 @@ export function computePlaylistReorderWrites<Id>(
   rows: ReadonlyArray<ReorderRow<Id>>,
   climbUuid: string,
   newIndex: number,
+  resolvableClimbUuids?: ReadonlySet<string>,
 ): ReorderWrite<Id>[] {
   const oldIndex = rows.findIndex((row) => row.climbUuid === climbUuid);
   if (oldIndex === -1) {
     throw new Error('Climb not found in playlist');
   }
 
+  const isVisible = (row: ReorderRow<Id>): boolean =>
+    resolvableClimbUuids === undefined || resolvableClimbUuids.has(row.climbUuid);
+  // The moved row itself has to be one the client renders for its index to mean
+  // anything in visible space. A move of an invisible row can't come from the UI
+  // — it isn't on screen — so fall back to full-list semantics instead of
+  // inventing a visible slot for it.
+  const inVisibleSpace = isVisible(rows[oldIndex]);
+  const visibleRows = inVisibleSpace ? rows.filter(isVisible) : rows;
+
   // Clamp the target into range; a true no-op move yields an empty write set —
   // short-circuit so a misbehaving client sending the current index can't make
   // us renumber (and rewrite) a gappy list for no reason.
-  const targetIndex = Math.min(Math.max(newIndex, 0), rows.length - 1);
-  if (targetIndex === oldIndex) {
+  const oldVisibleIndex = visibleRows.findIndex((row) => row.climbUuid === climbUuid);
+  const targetVisibleIndex = Math.min(Math.max(newIndex, 0), visibleRows.length - 1);
+  if (targetVisibleIndex === oldVisibleIndex) {
     return [];
   }
 
-  const reordered = [...rows];
-  const [moved] = reordered.splice(oldIndex, 1);
-  reordered.splice(targetIndex, 0, moved);
+  const remaining = rows.filter((_, index) => index !== oldIndex);
+  // Where each still-visible row sits in `remaining`, so a visible target index
+  // maps to an insertion point in the full list.
+  const visibleIndexesInRemaining: number[] = [];
+  for (let index = 0; index < remaining.length; index++) {
+    if (!inVisibleSpace || isVisible(remaining[index])) {
+      visibleIndexesInRemaining.push(index);
+    }
+  }
+
+  let insertAt: number;
+  if (targetVisibleIndex < visibleIndexesInRemaining.length) {
+    // Land immediately before the visible row currently holding the target
+    // index, so exactly `targetVisibleIndex` visible rows end up ahead.
+    insertAt = visibleIndexesInRemaining[targetVisibleIndex];
+  } else if (visibleIndexesInRemaining.length > 0) {
+    // Moving to the visible end: land just after the last visible row rather
+    // than after any trailing invisible rows — same visible result, fewer
+    // position writes, and the invisible rows stay put.
+    insertAt = visibleIndexesInRemaining[visibleIndexesInRemaining.length - 1] + 1;
+  } else {
+    insertAt = remaining.length;
+  }
+
+  const reordered = [...remaining];
+  reordered.splice(insertAt, 0, rows[oldIndex]);
 
   const writes: ReorderWrite<Id>[] = [];
   for (let index = 0; index < reordered.length; index++) {

--- a/packages/backend/src/graphql/resolvers/playlists/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/mutations.ts
@@ -474,6 +474,13 @@ export const playlistMutations = {
    * `newIndex` is read in the client's index space — the rendered list, which
    * excludes playlist rows whose climb_uuid doesn't resolve in board_climbs — and
    * translated back to the full list before splicing (#4012).
+   *
+   * That index space is specifically the ALL-BOARDS `playlistClimbs` list, the
+   * one the only editor renders: the mobile playlist screen deliberately omits
+   * `boardName` so off-board climbs stay listed (dimmed) instead of being
+   * filtered out. A future editor that reordered from a board-SCOPED list would
+   * be numbering against a shorter list again, and this input carries no board
+   * argument to infer that from — it would have to start sending one.
    */
   reorderPlaylistClimb: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext): Promise<boolean> => {
     requireAuthenticated(ctx);

--- a/packages/backend/src/graphql/resolvers/playlists/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/mutations.ts
@@ -13,6 +13,7 @@ import {
   FollowPlaylistInputSchema,
   PinPlaylistInputSchema,
 } from '../../../validation/schemas';
+import { UNIFIED_TABLES } from '../../../db/queries/util/table-select';
 import { getPlaylistFollowStats } from './queries';
 import { verifyPlaylistAccess } from './helpers/enrichment';
 import { computePlaylistReorderWrites } from './helpers/reorder';
@@ -469,6 +470,10 @@ export const playlistMutations = {
    * never has to send a stale oldIndex), splices it to the clamped target index,
    * then renumbers positions to a dense 0..n-1. Only rows whose position actually
    * changed are written.
+   *
+   * `newIndex` is read in the client's index space — the rendered list, which
+   * excludes playlist rows whose climb_uuid doesn't resolve in board_climbs — and
+   * translated back to the full list before splicing (#4012).
    */
   reorderPlaylistClimb: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext): Promise<boolean> => {
     requireAuthenticated(ctx);
@@ -512,9 +517,34 @@ export const playlistMutations = {
         .orderBy(asc(dbSchema.playlistClimbs.position), asc(dbSchema.playlistClimbs.addedAt))
         .for('update');
 
+      // `newIndex` is an index into the list the client RENDERS, and that list
+      // comes from the playlistClimbs query, which inner-joins board_climbs — a
+      // playlist row whose climb_uuid no longer resolves is dropped there while
+      // still holding a position here. Without translating index spaces, one such
+      // row ahead of the target silently shifts every move below it by one (#4012).
+      //
+      // Visibility is resolved with a second statement rather than a LEFT JOIN on
+      // the locked select above: Postgres rejects FOR UPDATE on the nullable side
+      // of an outer join. Playlists are small and board_climbs.uuid is the primary
+      // key, so this is an index scan over a handful of ids.
+      const rowClimbUuids = rows.map((row) => row.climbUuid);
+      const resolvableRows: Array<{ uuid: string }> =
+        rowClimbUuids.length === 0
+          ? []
+          : await tx
+              .select({ uuid: UNIFIED_TABLES.climbs.uuid })
+              .from(UNIFIED_TABLES.climbs)
+              .where(inArray(UNIFIED_TABLES.climbs.uuid, rowClimbUuids));
+      const resolvableClimbUuids = new Set(resolvableRows.map((row) => row.uuid));
+
       // Throws if the climb isn't in the playlist; returns only the rows whose
       // position actually shifts (dense 0..n-1 renumber).
-      const writes = computePlaylistReorderWrites(rows, validatedInput.climbUuid, validatedInput.newIndex);
+      const writes = computePlaylistReorderWrites(
+        rows,
+        validatedInput.climbUuid,
+        validatedInput.newIndex,
+        resolvableClimbUuids,
+      );
 
       // Persist every shifted row in ONE statement — a `CASE id WHEN … THEN …`
       // update — rather than a write per row. A move to the front of a 100-climb

--- a/packages/backend/src/graphql/resolvers/playlists/queries/playlist-climbs.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/playlist-climbs.ts
@@ -176,6 +176,17 @@ async function fetchSpecificBoardClimbs(
  * query uses (#4000), rather than a bare `playlist_climbs` row count. A stale
  * playlist row whose `climb_uuid` no longer resolves is excluded from both
  * results, so the count cannot exceed what paging through `climbs` can return.
+ * That exclusion is also why `reorderPlaylistClimb` translates the client's
+ * `newIndex` out of this (shorter) rendered list before splicing (#4012).
+ *
+ * The join keys on `uuid` alone, without a `board_type` predicate — unlike the
+ * specific-board path, which has a board to filter to. That is safe because
+ * `board_climbs.uuid` is the table's PRIMARY KEY, so a uuid names at most one
+ * climb across every board: the join cannot fan one playlist row into several
+ * page rows (which would break `pageSize + 1` paging), and it already rides the
+ * PK index. `playlist_climbs` therefore doesn't need to persist `board_type`
+ * (#4012). `playlist-climbs-uuid-join-invariant.test.ts` pins that key shape so
+ * a move to a composite `(board_type, uuid)` PK fails there rather than here.
  */
 async function fetchAllBoardsClimbs(
   playlistId: bigint,


### PR DESCRIPTION
Closes #4012

## The bug that was real

`playlistClimbs` inner-joins `board_climbs`, so a `playlist_climbs` row whose `climb_uuid` no longer resolves (catalog sync lag, a climb that left the catalog) never reaches the client — `hydrateClimbsByRefs` drops it too. The mobile playlist editor computes `newIndex` against that rendered list (`packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx`), while `reorderPlaylistClimb` spliced against the **full** `playlist_climbs` list.

One orphaned ref ahead of the target was enough to put every move below it one slot off, and the wrong order persisted. Concretely, with `[ghost, A, B, C]` in the table and `[A, B, C]` on screen, dragging A to the bottom sent `newIndex: 2` and produced `[ghost, B, A, C]` — A lands in the middle, and the user's next drag starts from a list that already disagrees with what they did.

Fixing it server-side also fixes the app versions already in the field: every shipped client has always numbered its drags over the rendered list, so no client change is needed or possible via OTA-skew.

## The fix

`computePlaylistReorderWrites` now takes the set of refs that resolve to a climb. It maps `newIndex` through the visible sublist, finds the insertion point in the full list that leaves exactly that many visible rows ahead of the moved row, then renumbers dense `0..n-1` and returns only changed rows — the contract callers already had.

- Omitting the set, or passing one that covers every row, reproduces the old behaviour byte for byte. A test asserts that equivalence across five different moves, and the existing math tests are unchanged.
- A move to the visible end lands just after the last visible row, not after trailing invisible ones — same result on screen, fewer position writes, orphans stay put.
- Moving a row that isn't visible can't come from the UI, so it falls back to full-list semantics rather than inventing a slot.
- The resolver reads visibility with a second statement inside the same transaction instead of turning the locked select into a `LEFT JOIN`: Postgres rejects `FOR UPDATE` on the nullable side of an outer join. Playlists are small and `board_climbs.uuid` is the primary key, so it's an index scan over a handful of ids.

The index space being honoured is the **all-boards** `playlistClimbs` list — the one the mobile playlist screen renders (it omits `boardName` on purpose so off-board climbs stay listed, dimmed). That assumption is now written at the resolver: a future editor that reordered from a board-scoped list would be numbering against a shorter list again, and the mutation input carries no board argument to infer that from.

## The two other complaints in the issue

**`totalCount` counting dropped refs** was already fixed on `main` by #4000: the count and the ref-rows query in `fetchAllBoardsClimbs` now share one inner join. Nothing to redo.

**Cross-board UUID collision** can't happen. `board_climbs.uuid` is the table's PRIMARY KEY (`packages/db/src/schema/boards/unified.ts`), so a uuid names at most one climb across every board — the uuid-only all-boards join cannot fan one playlist row into several page rows, and it already rides the PK index. **No `board_type` column was added to `playlist_climbs`**: it would be redundant against that key, and it would cost a migration plus a backfill plus new writers in `addClimbToPlaylist` and the Aurora circuit sync. Instead the invariant is written down where the join lives, and `playlist-climbs-uuid-join-invariant.test.ts` pins the key shape, so a future move to a composite `(board_type, uuid)` PK fails there loudly rather than corrupting paging quietly.

Orphaned `playlist_climbs` rows are left alone — they can be transient (catalog re-sync lag), and deleting user data isn't a call to make here.

## Validation

- `vp run typecheck:backend` — pass on the rebased branch.
- `vp check packages/backend/src/graphql/resolvers/playlists/mutations.ts` — clean.
- `vp test run --reporter=agent --project backend playlist-reorder` — 30 tests pass across the math, mocked-resolver, and real-DB files (run before the rebase; backend tests are left to CI here because the shared worker databases are contended locally).
- New coverage:
  - `playlist-reorder-math.test.ts` — orphan ahead of the target, orphan below it, move to the visible end with a trailing orphan, clamp to the last *visible* index, gappy positions plus an orphan, no-op in visible space, only-visible-row, parity with full-list behaviour, unresolvable-moved-row fallback.
  - `playlist-reorder-integration.test.ts` (real DB) — a playlist with a `ghost-climb` ref: drag to the end, drag to the front, and a no-op that is only a no-op on screen. The existing cases now seed `board_climbs` so they exercise the resolvable path rather than the fallback.
  - `playlist-climbs-uuid-join-invariant.test.ts` — `board_climbs.uuid` is a single-column primary key.

The new catalog seeds use `ON CONFLICT DO NOTHING` + `DELETE ... WHERE uuid IN (...)` rather than `TRUNCATE board_climbs CASCADE` (an AccessExclusiveLock on a table every backend suite shares), and the mocked transaction picks its result by select projection rather than call order.

Pre-existing flake spotted while validating, not fixed here: `playlist-reorder-integration.test.ts` and `playlist-climbs-total-count.test.ts` both `TRUNCATE ... playlists RESTART IDENTITY` in `beforeEach` and both build a playlist at `id = 1`. Whenever they land in the same worker database they knock each other over with "Playlist not found or access denied". Both do it on `main` today; worth a separate cleanup if it starts showing up in CI.

## Two calls made here, say the word to reverse either

1. **No `board_type` on `playlist_climbs`** — declined above on the grounds that the global PK already makes the join unique. It's a migration + backfill + two writers, so if you want the column anyway (denormalised provenance, cheaper composite index, survives a future PK change) it wants its own PR.
2. **Where a row lands when dragged to the bottom of a list with trailing orphans** — it goes after the last visible row, leaving the orphans below it. Visually identical either way; this way writes fewer rows.

## Release Notes

Dragging a climb in a playlist now drops it exactly where you let go, even when the playlist holds a climb the catalog has lost track of.

## Test plan

Backend-only change; covered by the unit, mocked-resolver, and real-DB tests listed above. Manual pass on mobile: open a playlist with an out-of-catalog ref, enter edit mode, drag a climb to the top / bottom / middle, leave edit mode (which refetches) and confirm the order matches what was dropped.
