### PR TITLE
fix(mobile): stop churning playlist context and over-counting playlist climbs

### DIFF
--- a/packages/backend/src/__tests__/add-climb-to-playlist-race.test.ts
+++ b/packages/backend/src/__tests__/add-climb-to-playlist-race.test.ts
@@ -38,7 +38,7 @@ async function playlistClimbRows(climbUuid: string): Promise<{ id: string; posit
   return Array.from(result as Iterable<{ id: string; position: number }>);
 }
 
-describe('addClimbToPlaylist — real DB (#3993)', () => {
+describe('playlist climb add/remove — real DB (#3993, #4014)', () => {
   // Playlist tables aren't in setup.ts's per-file reset list, so own the reset.
   // RESTART IDENTITY frees id=1 for a stable, trivially-referenced playlist.
   beforeEach(async () => {
@@ -140,5 +140,84 @@ describe('addClimbToPlaylist — real DB (#3993)', () => {
 
     const rows = await playlistClimbRows('climb-existing');
     expect(rows).toHaveLength(1);
+  });
+
+  // #4014: mobile's picker can't tell an add from a re-add (it writes its
+  // optimistic membership before calling the mutation), so it bumped the cached
+  // climbCount on every tap. The resolver reports which branch it took.
+  describe('wasAlreadyInPlaylist', () => {
+    it('is false on the inserting add and true on a duplicate add of the same climb', async () => {
+      const firstAdd = (await playlistMutations.addClimbToPlaylist(
+        null,
+        { input: { playlistId: PLAYLIST_UUID, climbUuid: 'climb-dup', angle: 40 } },
+        makeCtx(),
+      )) as { wasAlreadyInPlaylist: boolean };
+      expect(firstAdd.wasAlreadyInPlaylist).toBe(false);
+
+      const secondAdd = (await playlistMutations.addClimbToPlaylist(
+        null,
+        { input: { playlistId: PLAYLIST_UUID, climbUuid: 'climb-dup', angle: 40 } },
+        makeCtx(),
+      )) as { wasAlreadyInPlaylist: boolean };
+      expect(secondAdd.wasAlreadyInPlaylist).toBe(true);
+
+      expect(await playlistClimbRows('climb-dup')).toHaveLength(1);
+    });
+
+    it('marks exactly one of two concurrent adds as the inserter', async () => {
+      const results = (await Promise.all([
+        playlistMutations.addClimbToPlaylist(
+          null,
+          { input: { playlistId: PLAYLIST_UUID, climbUuid: 'climb-concurrent', angle: 40 } },
+          makeCtx(),
+        ),
+        playlistMutations.addClimbToPlaylist(
+          null,
+          { input: { playlistId: PLAYLIST_UUID, climbUuid: 'climb-concurrent', angle: 40 } },
+          makeCtx(),
+        ),
+      ])) as { wasAlreadyInPlaylist: boolean }[];
+
+      expect(results.map((result) => result.wasAlreadyInPlaylist).sort()).toEqual([false, true]);
+    });
+  });
+
+  describe('removeClimbFromPlaylist', () => {
+    it('returns true when a row was deleted and false when the climb was not in the playlist', async () => {
+      await playlistMutations.addClimbToPlaylist(
+        null,
+        { input: { playlistId: PLAYLIST_UUID, climbUuid: 'climb-removable', angle: 40 } },
+        makeCtx(),
+      );
+
+      await expect(
+        playlistMutations.removeClimbFromPlaylist(
+          null,
+          { input: { playlistId: PLAYLIST_UUID, climbUuid: 'climb-removable' } },
+          makeCtx(),
+        ),
+      ).resolves.toBe(true);
+      expect(await playlistClimbRows('climb-removable')).toHaveLength(0);
+
+      // Removing it again is still a success, but nothing was deleted — the
+      // client must not decrement its cached count for this one.
+      await expect(
+        playlistMutations.removeClimbFromPlaylist(
+          null,
+          { input: { playlistId: PLAYLIST_UUID, climbUuid: 'climb-removable' } },
+          makeCtx(),
+        ),
+      ).resolves.toBe(false);
+    });
+
+    it('returns false for a climb that was never in the playlist', async () => {
+      await expect(
+        playlistMutations.removeClimbFromPlaylist(
+          null,
+          { input: { playlistId: PLAYLIST_UUID, climbUuid: 'climb-never-added' } },
+          makeCtx(),
+        ),
+      ).resolves.toBe(false);
+    });
   });
 });

--- a/packages/backend/src/graphql/resolvers/playlists/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/mutations.ts
@@ -319,8 +319,14 @@ export const playlistMutations = {
     // attempts share one transaction so the position assignment and the
     // insert stay atomic; the second attempt only runs in the rare
     // vanished-row window.
+    // The insert-vs-conflict branch is the only place that knows whether this
+    // call actually added the climb, so it rides back to the caller as
+    // `wasAlreadyInPlaylist`. Mobile's picker can't tell on its own — it writes
+    // its optimistic membership before invoking the mutation — and without this
+    // it bumps the cached climbCount on every tap, inflating the count when a
+    // climb that was already in the playlist is "added" again (#4014).
     const maxInsertAttempts = 2;
-    const playlistClimb = await db.transaction(
+    const { playlistClimb, wasAlreadyInPlaylist } = await db.transaction(
       async (tx) => {
         for (let attempt = 0; attempt < maxInsertAttempts; attempt += 1) {
           const maxPosition = await tx
@@ -352,7 +358,7 @@ export const playlistMutations = {
               .set({ updatedAt: now, lastAccessedAt: now })
               .where(eq(dbSchema.playlists.id, playlistId));
 
-            return insertedClimb;
+            return { playlistClimb: insertedClimb, wasAlreadyInPlaylist: false };
           }
 
           // Conflict hit: a concurrent insert won the race. Re-select the
@@ -370,7 +376,7 @@ export const playlistMutations = {
             .limit(1);
 
           if (existingClimb) {
-            return existingClimb;
+            return { playlistClimb: existingClimb, wasAlreadyInPlaylist: true };
           }
         }
 
@@ -386,6 +392,7 @@ export const playlistMutations = {
       angle: playlistClimb.angle,
       position: playlistClimb.position,
       addedAt: playlistClimb.addedAt.toISOString(),
+      wasAlreadyInPlaylist,
     };
   },
 
@@ -427,19 +434,31 @@ export const playlistMutations = {
     // Note: Position gaps are acceptable after deletion. The position field is only used
     // for ordering (ORDER BY position), so gaps don't affect functionality. Reordering
     // positions after each deletion would be expensive for large playlists.
-    await db
+    //
+    // `.returning()` so the boolean means "a row was actually deleted" rather
+    // than the constant `true` it used to be. Removing a climb that isn't in
+    // the playlist stays a successful no-op (no error), but the caller can now
+    // tell the two apart — mobile skips its optimistic climbCount decrement on
+    // a no-op remove (#4014).
+    const deletedRows = await db
       .delete(dbSchema.playlistClimbs)
       .where(
         and(
           eq(dbSchema.playlistClimbs.playlistId, playlistId),
           eq(dbSchema.playlistClimbs.climbUuid, validatedInput.climbUuid),
         ),
-      );
+      )
+      .returning({ id: dbSchema.playlistClimbs.id });
 
-    // Update playlist updatedAt
-    await db.update(dbSchema.playlists).set({ updatedAt: new Date() }).where(eq(dbSchema.playlists.id, playlistId));
+    const removed = deletedRows.length > 0;
 
-    return true;
+    // Update playlist updatedAt — only when the playlist's contents actually
+    // changed, so a no-op remove doesn't bump it.
+    if (removed) {
+      await db.update(dbSchema.playlists).set({ updatedAt: new Date() }).where(eq(dbSchema.playlists.id, playlistId));
+    }
+
+    return removed;
   },
 
   /**

--- a/packages/mobile/src/lib/graphql/hooks/__tests__/use-mobile-climb-actions-data.test.tsx
+++ b/packages/mobile/src/lib/graphql/hooks/__tests__/use-mobile-climb-actions-data.test.tsx
@@ -266,7 +266,7 @@ describe('useMobileClimbActionsData', () => {
   describe('addToPlaylist + removeFromPlaylist', () => {
     it('addToPlaylist forwards { playlistId, climbUuid, angle } to ADD_CLIMB_TO_PLAYLIST', async () => {
       requestMock.mockResolvedValueOnce({ allUserPlaylists: { playlists: [] } });
-      requestMock.mockResolvedValueOnce({ addClimbToPlaylist: {} });
+      requestMock.mockResolvedValueOnce({ addClimbToPlaylist: { wasAlreadyInPlaylist: false } });
 
       const { Wrapper } = makeWrapper();
       const { result } = renderHook(() => useMobileClimbActionsData(), { wrapper: Wrapper });
@@ -297,7 +297,7 @@ describe('useMobileClimbActionsData', () => {
       requestMock.mockResolvedValueOnce({
         allUserPlaylists: { playlists: [mkPlaylist('p-1', 'Hard sends')] },
       });
-      requestMock.mockResolvedValueOnce({ addClimbToPlaylist: {} });
+      requestMock.mockResolvedValueOnce({ addClimbToPlaylist: { wasAlreadyInPlaylist: false } });
 
       const { queryClient, Wrapper } = makeWrapper();
       const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
@@ -351,6 +351,83 @@ describe('useMobileClimbActionsData', () => {
       });
 
       expect(queryClient.getQueryData<Playlist[]>(['userPlaylists'])?.[0].climbCount).toBe(0);
+    });
+
+    // #4014: the picker sends an add whenever its (possibly stale) membership
+    // cache says "not a member", so re-adding a climb the playlist already
+    // holds is a normal tap, not an error. The server reports the no-op and the
+    // cached count must stay put.
+    it('leaves climbCount alone when the server reports the climb was already in the playlist', async () => {
+      requestMock.mockResolvedValueOnce({
+        allUserPlaylists: { playlists: [{ ...mkPlaylist('p-1', 'Hard sends'), climbCount: 4 }] },
+      });
+      requestMock.mockResolvedValueOnce({ addClimbToPlaylist: { wasAlreadyInPlaylist: true } });
+
+      const { queryClient, Wrapper } = makeWrapper();
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+      const { result } = renderHook(() => useMobileClimbActionsData(), { wrapper: Wrapper });
+      await waitFor(() => expect(result.current.playlistsProviderProps.playlists.length).toBe(1));
+
+      await act(async () => {
+        await result.current.playlistsProviderProps.addToPlaylist('p-1', 'climb-x', 50);
+      });
+
+      expect(queryClient.getQueryData<Playlist[]>(['userPlaylists'])?.[0].climbCount).toBe(4);
+      // The detail caches still refresh — the climb list may have been changed
+      // by whoever inserted the row.
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['playlistClimbs', 'p-1'] });
+    });
+
+    it('leaves climbCount alone when removeFromPlaylist deleted nothing', async () => {
+      requestMock.mockResolvedValueOnce({
+        allUserPlaylists: { playlists: [{ ...mkPlaylist('p-1', 'Hard sends'), climbCount: 3 }] },
+      });
+      requestMock.mockResolvedValueOnce({ removeClimbFromPlaylist: false });
+
+      const { queryClient, Wrapper } = makeWrapper();
+      const { result } = renderHook(() => useMobileClimbActionsData(), { wrapper: Wrapper });
+      await waitFor(() => expect(result.current.playlistsProviderProps.playlists.length).toBe(1));
+
+      await act(async () => {
+        await result.current.playlistsProviderProps.removeFromPlaylist('p-1', 'climb-x');
+      });
+
+      expect(queryClient.getQueryData<Playlist[]>(['userPlaylists'])?.[0].climbCount).toBe(3);
+    });
+
+    // A server that predates `wasAlreadyInPlaylist` (or a bundle whose
+    // selection set omits it) returns undefined; keep the pre-#4014 +1.
+    it('still bumps climbCount when the response omits wasAlreadyInPlaylist', async () => {
+      requestMock.mockResolvedValueOnce({
+        allUserPlaylists: { playlists: [{ ...mkPlaylist('p-1', 'Hard sends'), climbCount: 1 }] },
+      });
+      requestMock.mockResolvedValueOnce({ addClimbToPlaylist: {} });
+
+      const { queryClient, Wrapper } = makeWrapper();
+      const { result } = renderHook(() => useMobileClimbActionsData(), { wrapper: Wrapper });
+      await waitFor(() => expect(result.current.playlistsProviderProps.playlists.length).toBe(1));
+
+      await act(async () => {
+        await result.current.playlistsProviderProps.addToPlaylist('p-1', 'climb-x', 50);
+      });
+
+      expect(queryClient.getQueryData<Playlist[]>(['userPlaylists'])?.[0].climbCount).toBe(2);
+    });
+  });
+
+  // #4014: the hook used to hand PlaylistsProvider a freshly allocated empty Map
+  // every render, busting the provider's `getPlaylistsForClimb` memo (and the
+  // context value built on it) on every parent render. Real memberships come
+  // from `playlistMembershipStore` / the picker's per-climb query instead.
+  describe('playlistsProviderProps stability', () => {
+    it('does not pass a playlistMemberships map', async () => {
+      requestMock.mockResolvedValue({ allUserPlaylists: { playlists: [] } });
+
+      const { Wrapper } = makeWrapper();
+      const { result } = renderHook(() => useMobileClimbActionsData(), { wrapper: Wrapper });
+      await waitFor(() => expect(requestMock).toHaveBeenCalledWith(GET_ALL_USER_PLAYLISTS, expect.anything()));
+
+      expect('playlistMemberships' in result.current.playlistsProviderProps).toBe(false);
     });
   });
 

--- a/packages/mobile/src/lib/graphql/hooks/use-mobile-climb-actions-data.ts
+++ b/packages/mobile/src/lib/graphql/hooks/use-mobile-climb-actions-data.ts
@@ -32,6 +32,7 @@ import {
   type Playlist,
   type GetAllUserPlaylistsQueryResponse,
   type AddClimbToPlaylistMutationResponse,
+  type RemoveClimbFromPlaylistMutationResponse,
   type CreatePlaylistMutationResponse,
 } from '@boardsesh/graphql/operations/playlists';
 import { getHttpClient } from '../client';
@@ -93,7 +94,6 @@ type MobileClimbActionsData = {
   };
   playlistsProviderProps: {
     playlists: Playlist[];
-    playlistMemberships: Map<string, Set<string>>;
     addToPlaylist: (playlistId: string, climbUuid: string, angle: number) => Promise<void>;
     removeFromPlaylist: (playlistId: string, climbUuid: string) => Promise<void>;
     createPlaylist: (
@@ -181,21 +181,35 @@ export function useMobileClimbActionsData(): MobileClimbActionsData {
         input: { playlistId: vars.playlistId, climbUuid: vars.climbUuid, angle: vars.angle },
       });
     },
-    onSuccess: (_response, vars) => {
+    // Gate the +1 on server truth. The picker decides "add vs remove" from a
+    // membership cache that is empty or stale until its per-climb query lands,
+    // so tapping a row for a climb the playlist already holds sends an add —
+    // which the backend idempotently no-ops. Bumping unconditionally inflated
+    // the cached count on every such tap (#4014). A pre-`wasAlreadyInPlaylist`
+    // server (or a response that omits the field) yields undefined, which keeps
+    // the old +1 behaviour.
+    onSuccess: (response, vars) => {
       invalidatePlaylistDetail(mutationDepsRef.current.queryClient, vars.playlistId);
-      bumpPlaylistClimbCount(mutationDepsRef.current.queryClient, vars.playlistId, 1);
+      if (response.addClimbToPlaylist.wasAlreadyInPlaylist !== true) {
+        bumpPlaylistClimbCount(mutationDepsRef.current.queryClient, vars.playlistId, 1);
+      }
     },
   });
 
   const removePlaylistMutation = useMutation({
     mutationFn: async (vars: { playlistId: string; climbUuid: string }) => {
-      return getHttpClient().request(REMOVE_CLIMB_FROM_PLAYLIST, {
+      return getHttpClient().request<RemoveClimbFromPlaylistMutationResponse>(REMOVE_CLIMB_FROM_PLAYLIST, {
         input: { playlistId: vars.playlistId, climbUuid: vars.climbUuid },
       });
     },
-    onSuccess: (_response, vars) => {
+    // Mirror of the add gating: the resolver now returns false when nothing was
+    // deleted (the climb wasn't in the playlist), so a no-op remove no longer
+    // decrements the cached count.
+    onSuccess: (response, vars) => {
       invalidatePlaylistDetail(mutationDepsRef.current.queryClient, vars.playlistId);
-      bumpPlaylistClimbCount(mutationDepsRef.current.queryClient, vars.playlistId, -1);
+      if (response.removeClimbFromPlaylist === true) {
+        bumpPlaylistClimbCount(mutationDepsRef.current.queryClient, vars.playlistId, -1);
+      }
     },
   });
 
@@ -297,9 +311,15 @@ export function useMobileClimbActionsData(): MobileClimbActionsData {
       isLoading: isAuthLoading,
       isAuthenticated,
     },
+    // `playlistMemberships` is deliberately not passed: PlaylistsProvider's prop
+    // is optional and falls back to a module-level empty Map, which keeps its
+    // `getPlaylistsForClimb` memo (and the context value hanging off it)
+    // referentially stable. Handing it a fresh Map per render busted both memos
+    // and re-rendered every consumer on every parent render (#4014). Real
+    // per-climb memberships come from `playlistMembershipStore` plus
+    // InlinePlaylistPicker's `playlistsForClimb` query, not from this hook.
     playlistsProviderProps: {
       playlists,
-      playlistMemberships: new Map<string, Set<string>>(),
       addToPlaylist,
       removeFromPlaylist,
       createPlaylist,

--- a/packages/mobile/src/providers/__tests__/playlists-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/playlists-provider.test.tsx
@@ -153,6 +153,26 @@ describe('PlaylistsProvider', () => {
     expect(createPlaylist).toHaveBeenCalledWith('Projects', 'Moon projects', '#ff00ff', 'star', boardContext);
   });
 
+  // #4014: the data hook used to pass a freshly built empty Map on every render,
+  // which busted `getPlaylistsForClimb`'s memo and, through it, the whole context
+  // value — re-rendering every consumer on every parent render. With the prop
+  // omitted it falls back to a module-level constant and stays stable.
+  it('keeps the context value stable across re-renders when playlistMemberships is omitted', () => {
+    const playlists = [mkPlaylist('p-1', 'Hard sends')];
+    const addToPlaylist = vi.fn(async (_playlistId: string, _climbUuid: string, _angle: number) => undefined);
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <PlaylistsProvider playlists={playlists} addToPlaylist={addToPlaylist}>
+        {children}
+      </PlaylistsProvider>
+    );
+    const { result, rerender } = renderHook(() => usePlaylistsContext(), { wrapper });
+    const first = result.current;
+    rerender();
+    rerender();
+    expect(result.current).toBe(first);
+    expect(result.current.getPlaylistsForClimb).toBe(first.getPlaylistsForClimb);
+  });
+
   it('usePlaylistsContext throws when called outside a provider', () => {
     expect(() => renderHook(() => usePlaylistsContext())).toThrow(/must be used within a PlaylistsProvider/);
   });

--- a/packages/mobile/src/providers/playlists-provider.tsx
+++ b/packages/mobile/src/providers/playlists-provider.tsx
@@ -57,6 +57,15 @@ const notWired = (method: string) => async (): Promise<never> => {
   throw new Error(message);
 };
 
+// Built once at module scope rather than inline in the default parameters below:
+// a default expression re-evaluates on every render, so inline `notWired(...)`
+// calls handed the memoized callbacks a fresh identity each time and rebuilt the
+// whole context value on every parent render (#4014).
+const NOT_WIRED_ADD_TO_PLAYLIST = notWired('addToPlaylist');
+const NOT_WIRED_REMOVE_FROM_PLAYLIST = notWired('removeFromPlaylist');
+const NOT_WIRED_CREATE_PLAYLIST = notWired('createPlaylist');
+const NOT_WIRED_REFRESH_PLAYLISTS = notWired('refreshPlaylists');
+
 type PlaylistsProviderProps = {
   playlists?: Playlist[];
   playlistMemberships?: Map<string, Set<string>>;
@@ -78,9 +87,9 @@ type PlaylistsProviderProps = {
 export function PlaylistsProvider({
   playlists = EMPTY_PLAYLISTS,
   playlistMemberships = EMPTY_MEMBERSHIPS,
-  addToPlaylist = notWired('addToPlaylist'),
-  removeFromPlaylist = notWired('removeFromPlaylist'),
-  createPlaylist = notWired('createPlaylist'),
+  addToPlaylist = NOT_WIRED_ADD_TO_PLAYLIST,
+  removeFromPlaylist = NOT_WIRED_REMOVE_FROM_PLAYLIST,
+  createPlaylist = NOT_WIRED_CREATE_PLAYLIST,
   // Default `true` (not `false`) so a consumer reading `isLoading` to gate a
   // spinner doesn't mistake "data hook not wired yet" for "user has no
   // playlists". The combination of `playlists=[]` + `isLoading=true` is the
@@ -89,7 +98,7 @@ export function PlaylistsProvider({
   // unwired baseline" rather than masquerading as real data.
   isLoading = true,
   isAuthenticated = false,
-  refreshPlaylists = notWired('refreshPlaylists'),
+  refreshPlaylists = NOT_WIRED_REFRESH_PLAYLISTS,
   children,
 }: PlaylistsProviderProps) {
   const getPlaylistsForClimb = useMemo(

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -1864,6 +1864,13 @@ type PlaylistClimb {
   position: Int!
   "When added (ISO 8601)"
   addedAt: String!
+  """
+  Populated only by addClimbToPlaylist: true when the climb was already in the
+  playlist and the add was an idempotent no-op, false when this call inserted
+  the row. Null everywhere else (list/detail reads never set it). Clients read
+  it to skip the optimistic climb-count bump on a duplicate add.
+  """
+  wasAlreadyInPlaylist: Boolean
 }
 
 """

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -4402,6 +4402,13 @@ export type PlaylistClimb = {
   playlistId: Scalars['ID']['output'];
   /** Position in playlist */
   position: Scalars['Int']['output'];
+  /**
+   * Populated only by addClimbToPlaylist: true when the climb was already in the
+   * playlist and the add was an idempotent no-op, false when this call inserted
+   * the row. Null everywhere else (list/detail reads never set it). Clients read
+   * it to skip the optimistic climb-count bump on a duplicate add.
+   */
+  wasAlreadyInPlaylist?: Maybe<Scalars['Boolean']['output']>;
 };
 
 /** Result of fetching playlist climbs. */
@@ -11071,6 +11078,7 @@ export type PlaylistClimbResolvers<
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   playlistId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   position?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  wasAlreadyInPlaylist?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 

--- a/packages/shared-schema/src/schema/playlists.ts
+++ b/packages/shared-schema/src/schema/playlists.ts
@@ -69,6 +69,13 @@ export const playlistsTypeDefs = /* GraphQL */ `
     position: Int!
     "When added (ISO 8601)"
     addedAt: String!
+    """
+    Populated only by addClimbToPlaylist: true when the climb was already in the
+    playlist and the add was an idempotent no-op, false when this call inserted
+    the row. Null everywhere else (list/detail reads never set it). Clients read
+    it to skip the optimistic climb-count bump on a duplicate add.
+    """
+    wasAlreadyInPlaylist: Boolean
   }
 
   """

--- a/packages/shared/graphql/src/generated/gql.ts
+++ b/packages/shared/graphql/src/generated/gql.ts
@@ -74,7 +74,7 @@ type Documents = {
   '\n  \n  mutation CreatePlaylist($input: CreatePlaylistInput!) {\n    createPlaylist(input: $input) {\n      ...PlaylistFields\n    }\n  }\n': typeof types.CreatePlaylistDocument;
   '\n  \n  mutation UpdatePlaylist($input: UpdatePlaylistInput!) {\n    updatePlaylist(input: $input) {\n      ...PlaylistFields\n    }\n  }\n': typeof types.UpdatePlaylistDocument;
   '\n  mutation DeletePlaylist($playlistId: ID!) {\n    deletePlaylist(playlistId: $playlistId)\n  }\n': typeof types.DeletePlaylistDocument;
-  '\n  mutation AddClimbToPlaylist($input: AddClimbToPlaylistInput!) {\n    addClimbToPlaylist(input: $input) {\n      id\n      playlistId\n      climbUuid\n      angle\n      position\n      addedAt\n    }\n  }\n': typeof types.AddClimbToPlaylistDocument;
+  '\n  mutation AddClimbToPlaylist($input: AddClimbToPlaylistInput!) {\n    addClimbToPlaylist(input: $input) {\n      id\n      playlistId\n      climbUuid\n      angle\n      position\n      addedAt\n      wasAlreadyInPlaylist\n    }\n  }\n': typeof types.AddClimbToPlaylistDocument;
   '\n  mutation RemoveClimbFromPlaylist($input: RemoveClimbFromPlaylistInput!) {\n    removeClimbFromPlaylist(input: $input)\n  }\n': typeof types.RemoveClimbFromPlaylistDocument;
   '\n  mutation ReorderPlaylistClimb($input: ReorderPlaylistClimbInput!) {\n    reorderPlaylistClimb(input: $input)\n  }\n': typeof types.ReorderPlaylistClimbDocument;
   '\n  query GetPlaylistClimbs($input: GetPlaylistClimbsInput!) {\n    playlistClimbs(input: $input) {\n      climbs {\n        uuid\n        layoutId\n        boardType\n        setter_username\n        name\n        description\n        frames\n        framesCount\n        framesPace\n        angle\n        ascensionist_count\n        difficulty\n        quality_average\n        stars\n        difficulty_error\n        benchmark_difficulty\n        boardseshDifficulty\n        boardseshConfidence\n      }\n      totalCount\n      hasMore\n    }\n  }\n': typeof types.GetPlaylistClimbsDocument;
@@ -255,7 +255,7 @@ const documents: Documents = {
     types.UpdatePlaylistDocument,
   '\n  mutation DeletePlaylist($playlistId: ID!) {\n    deletePlaylist(playlistId: $playlistId)\n  }\n':
     types.DeletePlaylistDocument,
-  '\n  mutation AddClimbToPlaylist($input: AddClimbToPlaylistInput!) {\n    addClimbToPlaylist(input: $input) {\n      id\n      playlistId\n      climbUuid\n      angle\n      position\n      addedAt\n    }\n  }\n':
+  '\n  mutation AddClimbToPlaylist($input: AddClimbToPlaylistInput!) {\n    addClimbToPlaylist(input: $input) {\n      id\n      playlistId\n      climbUuid\n      angle\n      position\n      addedAt\n      wasAlreadyInPlaylist\n    }\n  }\n':
     types.AddClimbToPlaylistDocument,
   '\n  mutation RemoveClimbFromPlaylist($input: RemoveClimbFromPlaylistInput!) {\n    removeClimbFromPlaylist(input: $input)\n  }\n':
     types.RemoveClimbFromPlaylistDocument,
@@ -751,8 +751,8 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: '\n  mutation AddClimbToPlaylist($input: AddClimbToPlaylistInput!) {\n    addClimbToPlaylist(input: $input) {\n      id\n      playlistId\n      climbUuid\n      angle\n      position\n      addedAt\n    }\n  }\n',
-): (typeof documents)['\n  mutation AddClimbToPlaylist($input: AddClimbToPlaylistInput!) {\n    addClimbToPlaylist(input: $input) {\n      id\n      playlistId\n      climbUuid\n      angle\n      position\n      addedAt\n    }\n  }\n'];
+  source: '\n  mutation AddClimbToPlaylist($input: AddClimbToPlaylistInput!) {\n    addClimbToPlaylist(input: $input) {\n      id\n      playlistId\n      climbUuid\n      angle\n      position\n      addedAt\n      wasAlreadyInPlaylist\n    }\n  }\n',
+): (typeof documents)['\n  mutation AddClimbToPlaylist($input: AddClimbToPlaylistInput!) {\n    addClimbToPlaylist(input: $input) {\n      id\n      playlistId\n      climbUuid\n      angle\n      position\n      addedAt\n      wasAlreadyInPlaylist\n    }\n  }\n'];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -4399,6 +4399,13 @@ export type PlaylistClimb = {
   playlistId: Scalars['ID']['output'];
   /** Position in playlist */
   position: Scalars['Int']['output'];
+  /**
+   * Populated only by addClimbToPlaylist: true when the climb was already in the
+   * playlist and the add was an idempotent no-op, false when this call inserted
+   * the row. Null everywhere else (list/detail reads never set it). Clients read
+   * it to skip the optimistic climb-count bump on a duplicate add.
+   */
+  wasAlreadyInPlaylist?: Maybe<Scalars['Boolean']['output']>;
 };
 
 /** Result of fetching playlist climbs. */
@@ -9062,6 +9069,7 @@ export type AddClimbToPlaylistMutation = {
     angle?: number | null;
     position: number;
     addedAt: string;
+    wasAlreadyInPlaylist?: boolean | null;
   };
 };
 
@@ -13678,6 +13686,7 @@ export const AddClimbToPlaylistDocument = {
                 { kind: 'Field', name: { kind: 'Name', value: 'angle' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'position' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'addedAt' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'wasAlreadyInPlaylist' } },
               ],
             },
           },

--- a/packages/shared/graphql/src/operations/playlists.ts
+++ b/packages/shared/graphql/src/operations/playlists.ts
@@ -135,6 +135,7 @@ export const ADD_CLIMB_TO_PLAYLIST = gql`
       angle
       position
       addedAt
+      wasAlreadyInPlaylist
     }
   }
 `;
@@ -374,6 +375,9 @@ export type AddClimbToPlaylistMutationResponse = {
     angle: number;
     position: number;
     addedAt: string;
+    // True when the climb was already in the playlist and the add was an
+    // idempotent no-op. Null/undefined against a server that predates the field.
+    wasAlreadyInPlaylist: boolean | null;
   };
 };
 


### PR DESCRIPTION
Closes #4014

Two defects in mobile's playlist wiring, both found by the review that produced #4010.

## 1. A fresh membership Map every render

`useMobileClimbActionsData` returned `playlistMemberships: new Map()` in its provider props. `PlaylistsProvider` memoises `getPlaylistsForClimb` on that Map and builds the context value on that getter, so a new Map on every render of `ClimbActionsDataWrapper` (mounted near the root in `app/_layout.tsx`, re-rendered on every auth / active-board / query tick) busted both memos and re-rendered every `usePlaylistsContext` consumer.

The Map was dead data. Nothing on mobile reads `getPlaylistsForClimb` outside the provider's own test — real per-climb memberships come from `playlistMembershipStore` and `InlinePlaylistPicker`'s `playlistsForClimb` query. The provider prop is optional and falls back to a module-level empty Map, so the fix is to stop passing it.

While in there: the provider's `notWired(...)` defaults were inline default-parameter expressions, which re-evaluate every render and gave the tracked-mutation `useCallback`s a new dependency each time — the same churn by a different route. Hoisted to module constants.

Net effect: the context value is now referentially stable across unrelated parent renders (asserted in a new provider test).

## 2. Unconditional climb-count bumps

`addToPlaylist`/`removeFromPlaylist` bumped the cached `['userPlaylists']` `climbCount` by +1/-1 on every successful call. The backend add is idempotent (`onConflictDoNothing` + re-select) and remove returned a constant `true`, so a no-op counted as a real change.

That is not a rare path: `InlinePlaylistPicker` decides add-vs-remove from a membership cache that is empty or stale until its per-climb query resolves (the store seeds are opt-in behind the playlist-tags setting). Tapping a row for a climb the playlist already holds sends an add, the server no-ops, and the picker's count subtitle grew by one anyway.

Web gates its delta on a real membership transition in `onMutate`, but mobile can't copy that — the picker writes its optimistic membership to the cache *before* invoking the mutation, so any hook-side check sees post-optimistic state. So the server reports the truth instead:

- `PlaylistClimb.wasAlreadyInPlaylist: Boolean` (nullable, additive). Populated only by `addClimbToPlaylist`: `false` on the fresh-insert branch, `true` on the conflict re-select branch. Null everywhere else.
- `removeClimbFromPlaylist` now uses `.returning()` and returns whether a row was actually deleted instead of a constant `true`. Removing a climb that isn't there is still a success, just a reported no-op (and no longer bumps the playlist's `updatedAt`).
- Mobile gates `+1` on `wasAlreadyInPlaylist !== true` and `-1` on `removeClimbFromPlaylist === true`.

### OTA / compatibility

The schema change is purely additive and the new field is nullable, so bundles already in the store (which don't select it) keep working. `wasAlreadyInPlaylist === undefined` falls back to the old unconditional `+1`, covered by a test. No caller branches on the remove boolean today: web ignores it, the mobile detail screen only catches throws, and `@boardsesh/offline-sync`'s `processMutation` awaits the request without inspecting `data`. Generated types come from `vp run codegen`, not hand edits. No native deps touched — JS/TS + backend only.

## Validation

- `vp run typecheck` — pass (exit 0, full monorepo)
- `vp run typecheck:mobile`, `:backend`, `:shared` — pass
- `vp run test:mobile` — pass (exit 0, full mobile project)
- `vp test run --project mobile` on the two touched files — 39 passed, including the new cases: duplicate add leaves `climbCount` alone, remove-returning-false leaves it alone, response omitting the field still bumps, hook no longer exposes `playlistMemberships`, and the provider's context value is identical across re-renders
- `vp check` — only pre-existing formatting failures in `.claude/skills/discord-feedback-triage/SKILL.md` and `docs/discord-feedback-pipeline.md`, both untouched by this branch and already in that state on `main`
- Backend tests could not be run locally: four other worktrees were running `vp test run --project backend` against the same shared worker DBs on :5433, which truncated the seeded `users` row out from under `beforeEach` and then deadlocked worker-DB init. The new assertions live in `packages/backend/src/__tests__/add-climb-to-playlist-race.test.ts` (first add → `false`, duplicate add → `true` with one row, exactly one of two concurrent adds is the inserter, remove of a present climb → `true`, remove of an absent climb → `false`) and run in CI.

## Open questions for @marcodejongh

- `removeClimbFromPlaylist` no longer bumps the playlist's `updatedAt` when nothing was deleted. That looks right (contents didn't change), but it does change what a "touch to refresh sort order" caller would get. Say the word if you'd rather keep the unconditional bump.
- The `favorites: new Set()` sibling allocation is left alone — it carries a justifying comment and the issue scoped it out.

## Release Notes

- [x] No release note needed
