### PR TITLE
fix(repo): add watchdog to dev-db discovery to stop silent exit-0

### DIFF
--- a/scripts/__tests__/dev-db-discover-watchdog.test.ts
+++ b/scripts/__tests__/dev-db-discover-watchdog.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { DiscoveryTimeoutError, raceAgainstWatchdog } from '../dev-db-discover';
+
+// Regression coverage for https://github.com/boardsesh/boardsesh/issues/3874:
+// `dev-db-discover.ts` could exit 0 mid-`await` before `discoverDatabase()`
+// ever resolved, because nothing kept Bun's event loop alive while a
+// postgres.js `client.end()` promise sat unsettled on a half-open socket.
+// `raceAgainstWatchdog` fixes that by racing discovery against a real
+// (non-unref'd) timer so a stuck probe surfaces as a loud, typed timeout
+// instead of a silent premature exit.
+
+describe('raceAgainstWatchdog', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects with a DiscoveryTimeoutError when the operation never settles', async () => {
+    const neverSettles = new Promise<never>(() => undefined);
+
+    await expect(raceAgainstWatchdog(neverSettles, 20)).rejects.toBeInstanceOf(DiscoveryTimeoutError);
+    await expect(raceAgainstWatchdog(neverSettles, 20)).rejects.toThrow('Discovery timed out after 20ms');
+  });
+
+  it('resolves pass-through and clears the watchdog timer when the operation settles first', async () => {
+    const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout');
+
+    await expect(raceAgainstWatchdog(Promise.resolve('selection'), 5_000)).resolves.toBe('selection');
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+  });
+
+  it('propagates a genuine rejection from the operation instead of masking it as a timeout', async () => {
+    const operationError = new Error('boom');
+
+    await expect(raceAgainstWatchdog(Promise.reject(operationError), 5_000)).rejects.toBe(operationError);
+  });
+});
+
+describe('dev-db-discover.ts module import', () => {
+  it('does not execute main() (no process.exit side effects) on import', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((): never => {
+      throw new Error('process.exit should not be called on import');
+    });
+
+    // Fresh import so any previously-cached module evaluation from another
+    // test file can't hide a regression here.
+    await vi.importActual('../dev-db-discover');
+
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('dev-db-discover.ts source invariants', () => {
+  const source = readFileSync(join(__dirname, '..', 'dev-db-discover.ts'), 'utf8');
+
+  it('guards the main() invocation with import.meta.main so importing the module has no side effects', () => {
+    expect(source).toMatch(/if\s*\(\s*import\.meta\.main\s*\)\s*\{\s*\n\s*main\(\)/);
+  });
+
+  it('bounds every postgres.js client.end() call with an explicit force-close timeout', () => {
+    const endCallLines = source
+      .split('\n')
+      .filter((line) => !line.trim().startsWith('//'))
+      .filter((line) => line.includes('client.end('));
+    expect(endCallLines.length).toBeGreaterThan(0);
+    for (const line of endCallLines) {
+      expect(line).toMatch(/timeout:\s*\d+/);
+    }
+  });
+});

--- a/scripts/dev-db-discover.ts
+++ b/scripts/dev-db-discover.ts
@@ -21,6 +21,18 @@ const postgresProbeTimeoutMs = 2500;
 const redisProbeTimeoutMs = 800;
 const tailscaleStatusTimeoutMs = 1500;
 const maxTailscaleCandidates = 32;
+// Per-candidate ceiling covering the Postgres shape probe, the Redis port
+// probe, and connection teardown, so a single wedged candidate can never
+// stall the Promise.all in discoverDatabase().
+const probeCandidateBudgetMs = postgresProbeTimeoutMs + redisProbeTimeoutMs + 1_000;
+// See https://github.com/boardsesh/boardsesh/issues/3874: postgres.js
+// `client.end()` can leave a promise unsettled after its socket handle is
+// destroyed on a half-open connection. With no live timer/handle left, Bun
+// (and Node) treat the event loop as drained and exit 0 mid-`await` instead
+// of hanging or throwing. This watchdog keeps a real timer alive around
+// discovery so that scenario surfaces as a loud, actionable timeout instead
+// of a silent premature exit.
+const discoveryWatchdogTimeoutMs = 30_000;
 
 type CandidateSource = 'local-standalone' | 'tailscale' | 'env';
 
@@ -126,6 +138,31 @@ async function withTimeout<T>(operation: Promise<T>, timeoutMs: number): Promise
   }
 }
 
+export class DiscoveryTimeoutError extends Error {}
+
+/**
+ * Races `operation` against a real (non-unref'd) timer. The live timer
+ * handle is the point: it is what keeps the runtime's event loop from
+ * deciding "nothing left to do" and exiting 0 while `operation` is stuck
+ * unsettled (see the module-level comment on `discoveryWatchdogTimeoutMs`).
+ * The timer is always cleared once either side settles.
+ */
+export async function raceAgainstWatchdog<T>(operation: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  const watchdog = new Promise<never>((_, reject) => {
+    timeoutHandle = setTimeout(
+      () => reject(new DiscoveryTimeoutError(`Discovery timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+  });
+
+  try {
+    return await Promise.race([operation, watchdog]);
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+  }
+}
+
 async function isBoardseshDevDatabase(client: postgres.Sql): Promise<boolean> {
   const shapeRows = await client<BoardseshShapeRow[]>`
     SELECT
@@ -149,6 +186,13 @@ async function isBoardseshDevDatabase(client: postgres.Sql): Promise<boolean> {
 }
 
 async function probeDatabaseCandidate(candidate: DatabaseCandidate): Promise<DatabaseSelection | null> {
+  // Bound the entire probe (including connection teardown) so one wedged
+  // candidate can never stall the Promise.all in discoverDatabase() -- see
+  // the module-level comment on probeCandidateBudgetMs.
+  return withTimeout(probeDatabaseCandidateUnbounded(candidate), probeCandidateBudgetMs).catch(() => null);
+}
+
+async function probeDatabaseCandidateUnbounded(candidate: DatabaseCandidate): Promise<DatabaseSelection | null> {
   const connectionString = buildPostgresUrl(candidate.host);
   const client = postgres(connectionString, {
     max: 1,
@@ -171,7 +215,9 @@ async function probeDatabaseCandidate(candidate: DatabaseCandidate): Promise<Dat
   } catch {
     return null;
   } finally {
-    await client.end().catch(() => undefined);
+    // Force-close after 1s instead of waiting indefinitely for in-flight
+    // queries to settle on a half-open/filtered socket (issue #3874).
+    await client.end({ timeout: 1 }).catch(() => undefined);
   }
 }
 
@@ -333,7 +379,9 @@ async function runPendingMigrations(connectionString: string): Promise<void> {
       }
     }
   } finally {
-    await client.end().catch(() => undefined);
+    // Bound teardown for the same reason as probeDatabaseCandidateUnbounded
+    // above -- see the module-level comment on discoveryWatchdogTimeoutMs.
+    await client.end({ timeout: 5 }).catch(() => undefined);
   }
 }
 
@@ -365,7 +413,20 @@ function clearGeneratedEnv(): void {
 }
 
 async function main(): Promise<void> {
-  const selection = await discoverDatabase();
+  let selection: DatabaseSelection | null;
+  try {
+    // Watchdog covers discovery only -- migrations can legitimately take
+    // minutes and must not be raced against this timer.
+    selection = await raceAgainstWatchdog(discoverDatabase(), discoveryWatchdogTimeoutMs);
+  } catch (error) {
+    if (!(error instanceof DiscoveryTimeoutError)) throw error;
+    clearGeneratedEnv();
+    console.error(
+      `[dev-db] ${error.message}; falling back to Docker. See https://github.com/boardsesh/boardsesh/issues/3874.`,
+    );
+    process.exit(2);
+  }
+
   if (!selection) {
     clearGeneratedEnv();
     console.info('[dev-db] No local or Tailscale Boardsesh dev database found.');
@@ -389,7 +450,12 @@ async function main(): Promise<void> {
   console.info('  Test user: test@boardsesh.com / test');
 }
 
-main().catch((error: unknown) => {
-  console.error('[dev-db] Failed to discover or prepare a dev database:', error);
-  process.exit(1);
-});
+// Guarded so importing this module (e.g. from Vitest) never runs main() or
+// triggers its process.exit() side effects; `bun scripts/dev-db-discover.ts`
+// still executes it because import.meta.main is true for the entry script.
+if (import.meta.main) {
+  main().catch((error: unknown) => {
+    console.error('[dev-db] Failed to discover or prepare a dev database:', error);
+    process.exit(1);
+  });
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "//": "Typechecks the repo-root scripts, which were previously never validated by CI — `vp run typecheck` only covered packages/*. Wired in via the `typecheck:scripts` task. Scoped to the Discord feedback pipeline for now; widen `include` as other scripts are made type-clean.",
+  "//": "Typechecks the repo-root scripts, which were previously never validated by CI — `vp run typecheck` only covered packages/*. Wired in via the `typecheck:scripts` task. Scoped to the Discord feedback pipeline and the dev-db discovery watchdog for now; widen `include` as other scripts are made type-clean.",
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
@@ -16,6 +16,8 @@
     "discord-feedback-scan.ts",
     "lib/discord-feedback.ts",
     "lib/discord-feedback-issue.ts",
-    "__tests__/discord-feedback-scan.test.ts"
+    "__tests__/discord-feedback-scan.test.ts",
+    "dev-db-discover.ts",
+    "__tests__/dev-db-discover-watchdog.test.ts"
   ]
 }


### PR DESCRIPTION
## Summary

`scripts/dev-db-discover.ts` could exit `0` before `discoverDatabase()` ever resolved. `postgres.js`'s `client.end()` can leave a promise unsettled after its socket handle is destroyed on a half-open/filtered connection; with no live timer or handle left, Bun (and Node) treat the event loop as drained and exit `0` mid-`await` instead of hanging or throwing. Because `scripts/dev-db-up.sh` trusts a bare exit code `0` as "discovery succeeded", this silently skipped the Docker fallback with zero diagnostic output — `vp run db:up` would just no-op.

This PR only touches the discovery script itself (`scripts/dev-db-discover.ts`), per the coordinator split with the sibling `dev-db-up.sh` ledger fix (#3978/#3979).

## Changes

- **Watchdog**: `main()` now races `discoverDatabase()` against a real (non-unref'd) 30s timer via a new exported `raceAgainstWatchdog()` helper. If discovery stalls, it now surfaces a loud `DiscoveryTimeoutError` and exits with code `2` — the existing "nothing found" contract — instead of exiting `0` with no output. The watchdog covers discovery only; migrations can legitimately take minutes and are never raced against it.
- **Hardened probing**: `probeDatabaseCandidate()` is now wrapped in a per-candidate timeout budget (probe + Redis check + 1s), so a single wedged Tailscale-peer candidate can't stall the `Promise.all` across up to 32 parallel probes.
- **Bounded teardown**: every `client.end()` call now force-closes after a short timeout (`{ timeout: 1 }` for probes, `{ timeout: 5 }` after migrations) instead of waiting indefinitely for in-flight queries to settle on a half-open socket — the proximate cause of the hang.
- **Testability**: the `main()` invocation is now guarded with `if (import.meta.main)`, so importing the module (e.g. from Vitest) has no `process.exit()` side effects, while `bun scripts/dev-db-discover.ts` still runs it directly (verified manually — see below).
- Widened `scripts/tsconfig.json` to typecheck `dev-db-discover.ts`, which had never been covered by any typecheck before.

## Root cause detail

Matches the issue's instrumented repro exactly: `[debug] main() entered` printed, ~3-4s of real probe activity happened, then the process exited `0` before the line after `await discoverDatabase()` ever printed and before either `process.exit()` branch in `main()` ran. The watchdog doesn't root-cause the Bun/postgres.js internals (not fully diagnosed — flagged as such in the issue), but makes the failure mode loud and fail-safe: a stuck probe now reliably produces `exit 2` and a `[dev-db] Discovery timed out ...` message that `dev-db-up.sh` can act on, instead of a silent `exit 0`.

## Testing

- `vp check` — pre-commit hook (`vp check --fix`) passed; only pre-existing, unrelated formatting issues remain in two doc files I did not touch.
- `vp run typecheck` — green.
- `vp run typecheck:scripts` — green (newly covers `dev-db-discover.ts`).
- `vp test run --project scripts --reporter=agent` (scoped to the new test file) — 6/6 passing:
  - watchdog rejects with `DiscoveryTimeoutError` when the operation never settles
  - watchdog resolves pass-through and clears its timer when the operation settles first
  - watchdog propagates a genuine rejection instead of masking it as a timeout
  - importing the module does not execute `main()` / call `process.exit()`
  - source invariant: `main()` is guarded by `import.meta.main`
  - source invariant: every `client.end()` call has an explicit force-close timeout
- Manual smoke tests (Bun, real local Postgres/Redis):
  - `bun scripts/dev-db-discover.ts` → happy path still works end-to-end (found local DB, "No pending migrations", wrote `.boardsesh/dev-db.env`, exit 0).
  - A standalone script driving `raceAgainstWatchdog()` against a never-resolving promise and a 200ms budget → confirmed it rejects with `DiscoveryTimeoutError: Discovery timed out after 200ms` under the real Bun runtime.

## Deviations from plan

The approved plan's step 3 (marker/freshness check in `dev-db-up.sh`) is explicitly out of scope per the coordinator note — that file belongs to the #3978 agent. This PR is discovery-script-only.

Fixes #3874

🤖 Generated with [Claude Code](https://claude.com/claude-code)
