### PR TITLE
fix(backend): use validateInput's parsed result in searchClimbs

### DIFF
--- a/packages/backend/src/__tests__/climb-search-validation.test.ts
+++ b/packages/backend/src/__tests__/climb-search-validation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vite-plus/test';
 import { MAX_SEARCH_PAGE, mapSearchInputToParams } from '@boardsesh/db/queries';
+import { typeDefs } from '@boardsesh/shared-schema';
 import { ClimbSearchInputSchema } from '../validation/schemas';
 
 const base = {
@@ -100,5 +101,31 @@ describe('ClimbSearchInputSchema boulders/routes have no default (#3975)', () =>
     };
     expect(hasNoClimbTypeConstraint(omitted)).toBe(true);
     expect(hasNoClimbTypeConstraint(explicit)).toBe(true);
+  });
+});
+
+describe('ClimbSearchInputSchema covers every ClimbSearchInput SDL field (#3975)', () => {
+  it('has one Zod key per GraphQL input field, so parsing strips nothing the resolver needs', () => {
+    // searchClimbs now feeds `validateInput`'s PARSED result downstream, and
+    // Zod objects strip keys they don't declare. Before #3975 the resolver
+    // read the raw GraphQL input, so a field added to the SDL but forgotten
+    // in this schema still reached mapSearchInputToParams; now it would be
+    // silently dropped and the filter would just stop working. This test is
+    // the tripwire for that: add the field here whenever the SDL grows one.
+    const sdl = typeDefs.join('\n');
+    const inputBlock = /input ClimbSearchInput\s*\{([\s\S]*?)\n\s*\}/.exec(sdl);
+    expect(inputBlock).not.toBeNull();
+
+    const sdlFields = (inputBlock?.[1] ?? '')
+      .split('\n')
+      // Drop SDL doc-comment lines ("..." / """...""") and blanks.
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !line.startsWith('"') && !line.startsWith('#'))
+      .map((line) => line.split(':')[0].trim())
+      .sort();
+    const zodFields = Object.keys(ClimbSearchInputSchema.shape).sort();
+
+    expect(sdlFields.length).toBeGreaterThan(0);
+    expect(zodFields).toEqual(sdlFields);
   });
 });

--- a/packages/backend/src/__tests__/climb-search-validation.test.ts
+++ b/packages/backend/src/__tests__/climb-search-validation.test.ts
@@ -77,16 +77,28 @@ describe('ClimbSearchInputSchema boulders/routes have no default (#3975)', () =>
     expect(result.routes).toBeUndefined();
   });
 
-  it('produces identical search params whether boulders/routes are omitted or explicitly true/true', () => {
+  it('resolves to the same "no climb-type constraint" outcome whether boulders/routes are omitted or explicitly true/true', () => {
     // This is the no-behavior-change proof for removing the dead .default(true)/
     // .default(false): now that searchClimbs uses validateInput's parsed return
     // (see queries.ts), a live default here would have flipped omitted callers
-    // to boulders-only. Confirm omission and explicit true/true stay equivalent
-    // (both mean "no frames_count constraint"), mirroring #3976's repro.
+    // to boulders-only. omitted and explicit true/true are NOT byte-identical
+    // ClimbSearchParams (boulders/routes are `undefined` vs `true`), but
+    // create-climb-filters.ts's `wantsBoulders = !!searchParams.boulders` /
+    // `wantsRoutes = !!searchParams.routes` coerce both `undefined` and the
+    // both-true case to the same "no frames_count constraint" branch — that's
+    // the equivalence #3976's repro (and filter-state.ts's comment) rely on.
     const omitted = mapSearchInputToParams(ClimbSearchInputSchema.parse(base));
     const explicit = mapSearchInputToParams(ClimbSearchInputSchema.parse({ ...base, boulders: true, routes: true }));
     expect(omitted.boulders).toBeUndefined();
     expect(omitted.routes).toBeUndefined();
-    expect(explicit).toEqual(omitted);
+
+    const hasNoClimbTypeConstraint = (params: { boulders?: boolean | null; routes?: boolean | null }) => {
+      const wantsBoulders = !!params.boulders;
+      const wantsRoutes = !!params.routes;
+      // Mirrors create-climb-filters.ts: constrained only when exactly one is set.
+      return !((wantsBoulders && !wantsRoutes) || (wantsRoutes && !wantsBoulders));
+    };
+    expect(hasNoClimbTypeConstraint(omitted)).toBe(true);
+    expect(hasNoClimbTypeConstraint(explicit)).toBe(true);
   });
 });

--- a/packages/backend/src/__tests__/climb-search-validation.test.ts
+++ b/packages/backend/src/__tests__/climb-search-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { MAX_SEARCH_PAGE } from '@boardsesh/db/queries';
+import { MAX_SEARCH_PAGE, mapSearchInputToParams } from '@boardsesh/db/queries';
 import { ClimbSearchInputSchema } from '../validation/schemas';
 
 const base = {
@@ -67,5 +67,26 @@ describe('ClimbSearchInputSchema personal rating filters (#2645)', () => {
 
   it('leaves both filters optional', () => {
     expect(ClimbSearchInputSchema.safeParse(base).success).toBe(true);
+  });
+});
+
+describe('ClimbSearchInputSchema boulders/routes have no default (#3975)', () => {
+  it('leaves omitted boulders/routes undefined after parsing, not defaulted to boulders-only', () => {
+    const result = ClimbSearchInputSchema.parse(base);
+    expect(result.boulders).toBeUndefined();
+    expect(result.routes).toBeUndefined();
+  });
+
+  it('produces identical search params whether boulders/routes are omitted or explicitly true/true', () => {
+    // This is the no-behavior-change proof for removing the dead .default(true)/
+    // .default(false): now that searchClimbs uses validateInput's parsed return
+    // (see queries.ts), a live default here would have flipped omitted callers
+    // to boulders-only. Confirm omission and explicit true/true stay equivalent
+    // (both mean "no frames_count constraint"), mirroring #3976's repro.
+    const omitted = mapSearchInputToParams(ClimbSearchInputSchema.parse(base));
+    const explicit = mapSearchInputToParams(ClimbSearchInputSchema.parse({ ...base, boulders: true, routes: true }));
+    expect(omitted.boulders).toBeUndefined();
+    expect(omitted.routes).toBeUndefined();
+    expect(explicit).toEqual(omitted);
   });
 });

--- a/packages/backend/src/__tests__/wall-confirm-and-board-serial.test.ts
+++ b/packages/backend/src/__tests__/wall-confirm-and-board-serial.test.ts
@@ -20,6 +20,8 @@
  *  setSessionBoardSerial
  *  - Persists the serial via the room manager and publishes
  *    `SessionBoardSerialChanged` when the value changes.
+ *  - Normalizes the serial (trim + uppercase, via BoardSerialSchema's
+ *    validateInput return) before writing/broadcasting — see #3975.
  *  - Idempotent: when the stored serial already equals the incoming value,
  *    no event fires (avoids redundant subscriber work on reconnect storms).
  *  - Rejects non-members via the shared membership check.
@@ -358,6 +360,26 @@ describe('setSessionBoardSerial mutation', () => {
     );
     expect(roomManagerMock.setSessionBoardSerialAndReturnPrevious).not.toHaveBeenCalled();
     expect(pubsubMock.publishSessionEvent).not.toHaveBeenCalled();
+  });
+
+  it('normalizes the serial (trim + uppercase) before writing and broadcasting (#3975)', async () => {
+    // BoardSerialSchema's `.transform(normalizeSerial)` only takes effect on
+    // the parsed return; a lowercase/whitespace-padded serial must still
+    // reach roomManager and the broadcast event in its normalized form, the
+    // same way resolveBoardForSerial (board-presence/mutations.ts) already
+    // normalizes before comparing/storing. Regression guard for the
+    // discarded-validateInput-return bug fixed alongside #3975.
+    roomManagerMock.setSessionBoardSerialAndReturnPrevious.mockResolvedValueOnce(null);
+    roomManagerMock.getSessionBoardSerial.mockResolvedValueOnce(validSerial);
+    const ctx = makeCtx();
+
+    await sessionMutations.setSessionBoardSerial(undefined, { serial: '  kb-ab12-cd34  ' }, ctx);
+
+    expect(roomManagerMock.setSessionBoardSerialAndReturnPrevious).toHaveBeenCalledWith('session-1', validSerial);
+    expect(pubsubMock.publishSessionEvent).toHaveBeenCalledWith('session-1', {
+      __typename: 'SessionBoardSerialChanged',
+      lastConnectedBoardSerial: validSerial,
+    });
   });
 
   it('throws when ctx.participantId is missing and does not mutate state or publish', async () => {

--- a/packages/backend/src/graphql/resolvers/climbs/queries.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/queries.ts
@@ -149,43 +149,43 @@ export const climbQueries = {
     // request per page, so the limit sits well above any interactive cadence while
     // capping abuse (deep-OFFSET pages, holdsFilter floods) on an anonymous endpoint.
     await applyRateLimit(ctx, 120, 'search-climbs');
-    validateInput(ClimbSearchInputSchema, input, 'input');
+    const parsedInput = validateInput(ClimbSearchInputSchema, input, 'input');
 
     // Validate board name
-    if (!isValidBoardName(input.boardName)) {
-      throw new Error(`Invalid board name: ${input.boardName}. Must be one of: ${SUPPORTED_BOARDS.join(', ')}`);
+    if (!isValidBoardName(parsedInput.boardName)) {
+      throw new Error(`Invalid board name: ${parsedInput.boardName}. Must be one of: ${SUPPORTED_BOARDS.join(', ')}`);
     }
 
     // Parse setIds from comma-separated string
-    const setIds = input.setIds
+    const setIds = parsedInput.setIds
       .split(',')
       .map((id) => parseInt(id.trim(), 10))
       .filter((id) => !isNaN(id));
 
     // Build route parameters
     const params: ParsedBoardRouteParameters = {
-      board_name: input.boardName,
-      layout_id: input.layoutId,
-      size_id: input.sizeId,
+      board_name: parsedInput.boardName,
+      layout_id: parsedInput.layoutId,
+      size_id: parsedInput.sizeId,
       set_ids: setIds,
-      angle: input.angle,
+      angle: parsedInput.angle,
     };
 
     // Build search parameters via the shared mapper — same falsy-collapse
     // rules as the web SSR path. Don't inline the field-by-field copy here.
-    const searchParams: ClimbSearchParams = mapSearchInputToParams(input);
+    const searchParams: ClimbSearchParams = mapSearchInputToParams(parsedInput);
 
     if (DEBUG) {
       logger.info(
         '[searchClimbs] onlyDrafts:',
-        input.onlyDrafts,
+        parsedInput.onlyDrafts,
         'userId:',
         ctx.isAuthenticated ? ctx.userId : 'not authenticated',
       );
     }
 
     // Drafts require authentication — return empty results if not signed in
-    if (input.onlyDrafts && !ctx.isAuthenticated) {
+    if (parsedInput.onlyDrafts && !ctx.isAuthenticated) {
       return {
         params,
         searchParams,
@@ -202,7 +202,7 @@ export const climbQueries = {
     const hasUserSpecificFilters = USER_SPECIFIC_SEARCH_PARAMS.some(
       (param) => !!searchParams[param as keyof typeof searchParams],
     );
-    const isCacheableBoard = input.boardName !== 'moonboard';
+    const isCacheableBoard = parsedInput.boardName !== 'moonboard';
 
     // Only resolve userId when user-specific filters are active — otherwise the query
     // results are identical to anonymous and can be served from Redis cache.

--- a/packages/backend/src/graphql/resolvers/sessions/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/mutations.ts
@@ -577,7 +577,13 @@ export const sessionMutations = {
     // Session identity from the WebSocket context (WS-implicit pattern); no
     // sessionId argument.
     const sessionId = requireSession(ctx);
-    validateInput(BoardSerialSchema, serial, 'serial');
+    // Capture the parsed/normalized value (BoardSerialSchema trims +
+    // uppercases via normalizeSerial) — resolveBoardForSerial and the other
+    // BoardSerialSchema call sites in board-presence/mutations.ts already do
+    // this, so discarding it here (as before #3975) would let this one path
+    // store/broadcast a differently-cased serial than every other caller,
+    // breaking string-equality comparisons against it downstream.
+    const validSerial = validateInput(BoardSerialSchema, serial, 'serial');
     await requireSessionMember(ctx, sessionId);
 
     // Hard-error when ctx.participantId is missing — same reasoning as
@@ -590,11 +596,11 @@ export const sessionMutations = {
     }
     const participantId = ctx.participantId;
 
-    const previousSerial = await roomManager.setSessionBoardSerialAndReturnPrevious(sessionId, serial);
-    if (previousSerial !== serial) {
+    const previousSerial = await roomManager.setSessionBoardSerialAndReturnPrevious(sessionId, validSerial);
+    if (previousSerial !== validSerial) {
       pubsub.publishSessionEvent(sessionId, {
         __typename: 'SessionBoardSerialChanged',
-        lastConnectedBoardSerial: serial,
+        lastConnectedBoardSerial: validSerial,
       });
     }
 

--- a/packages/backend/src/validation/__tests__/validate-input-return-usage.test.ts
+++ b/packages/backend/src/validation/__tests__/validate-input-return-usage.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Regression guard for #3975: `validateInput(SomeSchema, raw, 'field')` is
+// only safe to call as a bare statement (discarding the parsed return) when
+// `SomeSchema` has no `.default(...)`/`.transform(...)` in its chain — those
+// only take effect on the PARSED result, never on the raw input the resolver
+// keeps reading afterwards. `ClimbSearchInputSchema`'s `boulders`/`routes`
+// defaults were exactly this: dead code because searchClimbs discarded the
+// parsed value (see packages/backend/src/graphql/resolvers/climbs/queries.ts
+// and packages/backend/src/validation/schemas/climbs.ts). This test statically
+// scans every resolver file for statement-form validateInput calls and fails
+// if the referenced schema has a live default/transform, so a future schema
+// change can't silently go dormant the same way.
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+// packages/backend/src/validation/__tests__ -> packages/backend/src
+const backendSrcDir = join(currentDir, '..', '..');
+const resolversDir = join(backendSrcDir, 'graphql', 'resolvers');
+const schemasDir = join(backendSrcDir, 'validation', 'schemas');
+
+function listTsFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) return listTsFiles(fullPath);
+    if (entry.isFile() && entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) return [fullPath];
+    return [];
+  });
+}
+
+/** Strip `//` and `/* *\/` comments so prose mentioning `.default(`/`.transform(`
+ * (e.g. explaining this very footgun) can't trip the scan. */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+}
+
+type DiscardedCall = { file: string; line: number; schemaName: string };
+
+/** Find statement-form `validateInput(SchemaName, ...)` calls: the trimmed
+ * line starts with `validateInput(`, i.e. the return isn't assigned/awaited
+ * into a variable. Every current discarded call site in this codebase fits
+ * this single-line shape (verified against `grep -rn validateInput(` at
+ * authoring time); a call written across multiple lines with the schema name
+ * on a later line would be missed, so keep discarded calls single-line. */
+function findDiscardedValidateInputCalls(filePath: string): DiscardedCall[] {
+  const source = stripComments(readFileSync(filePath, 'utf8'));
+  const lines = source.split('\n');
+  const calls: DiscardedCall[] = [];
+  const statementFormRegex = /^validateInput\(\s*([A-Za-z_][A-Za-z0-9_]*)/;
+  lines.forEach((line, index) => {
+    const match = statementFormRegex.exec(line.trim());
+    if (match) {
+      calls.push({ file: filePath, line: index + 1, schemaName: match[1] });
+    }
+  });
+  return calls;
+}
+
+/** Slice out one `export const <Name> = ...` schema definition from a schema
+ * file's source, from its declaration up to (but not including) the next
+ * top-level `export const/function` — a good-enough approximation of "this
+ * schema's chain" for detecting `.default(`/`.transform(` without a real
+ * parser. */
+function extractSchemaBody(source: string, schemaName: string): string | undefined {
+  const declRegex = new RegExp(`export const ${schemaName}\\b`);
+  const declMatch = declRegex.exec(source);
+  if (!declMatch) return undefined;
+  const startIndex = declMatch.index;
+  const nextExportRegex = /\n(?=export (const|function) )/g;
+  nextExportRegex.lastIndex = startIndex + declMatch[0].length;
+  const nextMatch = nextExportRegex.exec(source);
+  const endIndex = nextMatch ? nextMatch.index : source.length;
+  return source.slice(startIndex, endIndex);
+}
+
+function schemaHasLiveDefaultOrTransform(schemaName: string, schemaFiles: { path: string; source: string }[]): boolean {
+  for (const { source } of schemaFiles) {
+    const body = extractSchemaBody(stripComments(source), schemaName);
+    if (body === undefined) continue;
+    return /\.default\(|\.transform\(/.test(body);
+  }
+  // Schema not found in validation/schemas (e.g. imported from elsewhere,
+  // or a plain z.ZodSchema built inline) — nothing to flag here.
+  return false;
+}
+
+describe('validateInput discarded-return usage', () => {
+  it('never discards the return of a schema with a live .default()/.transform()', () => {
+    const resolverFiles = listTsFiles(resolversDir);
+    const schemaFiles = listTsFiles(schemasDir)
+      .filter((path) => statSync(path).isFile())
+      .map((path) => ({ path, source: readFileSync(path, 'utf8') }));
+
+    const offenders: DiscardedCall[] = [];
+    for (const file of resolverFiles) {
+      for (const call of findDiscardedValidateInputCalls(file)) {
+        if (schemaHasLiveDefaultOrTransform(call.schemaName, schemaFiles)) {
+          offenders.push(call);
+        }
+      }
+    }
+
+    if (offenders.length > 0) {
+      const details = offenders
+        .map((offender) => `  ${offender.file}:${offender.line} — validateInput(${offender.schemaName}, ...)`)
+        .join('\n');
+      throw new Error(
+        `Found ${offenders.length} statement-form validateInput() call(s) whose schema has a ` +
+          `.default()/.transform() that will never apply because the parsed return is discarded ` +
+          `(see #3975):\n${details}\n\nEither capture the return (const parsed = validateInput(...)) ` +
+          `and use it, or remove the default/transform if it's not meant to apply.`,
+      );
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('sanity check: the scan actually finds discarded statement-form calls today', () => {
+    // Guards against the scan itself silently matching nothing (e.g. a path
+    // typo) and the first test passing for the wrong reason.
+    const resolverFiles = listTsFiles(resolversDir);
+    const totalDiscarded = resolverFiles.flatMap((file) => findDiscardedValidateInputCalls(file));
+    expect(totalDiscarded.length).toBeGreaterThan(50);
+  });
+});

--- a/packages/backend/src/validation/__tests__/validate-input-return-usage.test.ts
+++ b/packages/backend/src/validation/__tests__/validate-input-return-usage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -38,23 +38,26 @@ function stripComments(source: string): string {
 
 type DiscardedCall = { file: string; line: number; schemaName: string };
 
-/** Find statement-form `validateInput(SchemaName, ...)` calls: the trimmed
- * line starts with `validateInput(`, i.e. the return isn't assigned/awaited
- * into a variable. Every current discarded call site in this codebase fits
- * this single-line shape (verified against `grep -rn validateInput(` at
- * authoring time); a call written across multiple lines with the schema name
- * on a later line would be missed, so keep discarded calls single-line. */
+/** Find statement-form `validateInput(SchemaName, ...)` calls: the statement
+ * begins with `validateInput(`, i.e. the return isn't assigned/awaited into a
+ * variable. Matched against the whole file rather than line-by-line so a call
+ * wrapped across lines (schema name on the next line, as the formatter does
+ * for long argument lists) is still caught. */
 function findDiscardedValidateInputCalls(filePath: string): DiscardedCall[] {
   const source = stripComments(readFileSync(filePath, 'utf8'));
-  const lines = source.split('\n');
   const calls: DiscardedCall[] = [];
-  const statementFormRegex = /^validateInput\(\s*([A-Za-z_][A-Za-z0-9_]*)/;
-  lines.forEach((line, index) => {
-    const match = statementFormRegex.exec(line.trim());
-    if (match) {
-      calls.push({ file: filePath, line: index + 1, schemaName: match[1] });
-    }
-  });
+  const statementFormRegex = /(?:^|\n)[ \t]*validateInput\(\s*([A-Za-z_][A-Za-z0-9_]*)/g;
+  let match = statementFormRegex.exec(source);
+  while (match !== null) {
+    // Line number of the `validateInput(` token itself.
+    const tokenIndex = source.indexOf('validateInput(', match.index);
+    calls.push({
+      file: filePath,
+      line: source.slice(0, tokenIndex).split('\n').length,
+      schemaName: match[1],
+    });
+    match = statementFormRegex.exec(source);
+  }
   return calls;
 }
 
@@ -89,9 +92,7 @@ function schemaHasLiveDefaultOrTransform(schemaName: string, schemaFiles: { path
 describe('validateInput discarded-return usage', () => {
   it('never discards the return of a schema with a live .default()/.transform()', () => {
     const resolverFiles = listTsFiles(resolversDir);
-    const schemaFiles = listTsFiles(schemasDir)
-      .filter((path) => statSync(path).isFile())
-      .map((path) => ({ path, source: readFileSync(path, 'utf8') }));
+    const schemaFiles = listTsFiles(schemasDir).map((path) => ({ path, source: readFileSync(path, 'utf8') }));
 
     const offenders: DiscardedCall[] = [];
     for (const file of resolverFiles) {
@@ -119,9 +120,12 @@ describe('validateInput discarded-return usage', () => {
 
   it('sanity check: the scan actually finds discarded statement-form calls today', () => {
     // Guards against the scan itself silently matching nothing (e.g. a path
-    // typo) and the first test passing for the wrong reason.
+    // typo) and the first test passing for the wrong reason. Deliberately a
+    // low floor rather than today's exact count — resolvers legitimately come
+    // and go, and this assertion only needs to prove the scanner sees code.
     const resolverFiles = listTsFiles(resolversDir);
+    expect(resolverFiles.length).toBeGreaterThan(0);
     const totalDiscarded = resolverFiles.flatMap((file) => findDiscardedValidateInputCalls(file));
-    expect(totalDiscarded.length).toBeGreaterThan(50);
+    expect(totalDiscarded.length).toBeGreaterThan(5);
   });
 });

--- a/packages/backend/src/validation/__tests__/validate-input-return-usage.test.ts
+++ b/packages/backend/src/validation/__tests__/validate-input-return-usage.test.ts
@@ -5,15 +5,16 @@ import { fileURLToPath } from 'node:url';
 
 // Regression guard for #3975: `validateInput(SomeSchema, raw, 'field')` is
 // only safe to call as a bare statement (discarding the parsed return) when
-// `SomeSchema` has no `.default(...)`/`.transform(...)` in its chain — those
-// only take effect on the PARSED result, never on the raw input the resolver
-// keeps reading afterwards. `ClimbSearchInputSchema`'s `boulders`/`routes`
-// defaults were exactly this: dead code because searchClimbs discarded the
-// parsed value (see packages/backend/src/graphql/resolvers/climbs/queries.ts
-// and packages/backend/src/validation/schemas/climbs.ts). This test statically
+// `SomeSchema` has no output-mutating operator in its chain (see
+// OUTPUT_MUTATING_OPS below) — those only take effect on the PARSED result,
+// never on the raw input the resolver keeps reading afterwards.
+// `ClimbSearchInputSchema`'s `boulders`/`routes` defaults were exactly this:
+// dead code because searchClimbs discarded the parsed value (see
+// packages/backend/src/graphql/resolvers/climbs/queries.ts and
+// packages/backend/src/validation/schemas/climbs.ts). This test statically
 // scans every resolver file for statement-form validateInput calls and fails
-// if the referenced schema has a live default/transform, so a future schema
-// change can't silently go dormant the same way.
+// if the referenced schema has a live one, so a future schema change can't
+// silently go dormant the same way.
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 // packages/backend/src/validation/__tests__ -> packages/backend/src
@@ -94,9 +95,18 @@ function collectSchemaBodies(schemaFiles: { path: string; source: string }[]): M
   return bodies;
 }
 
-/** True when the schema — or any schema it composes, transitively — carries a
- * `.default()`/`.transform()`. Composition matters: `ClimbQueueItemSchema` has
- * no default of its own but embeds `ClimbInputSchema`, whose null-coalescing
+/** Zod operators whose whole effect lands on the PARSED value, so they are
+ * dead when the caller keeps reading the raw input. `.default()` and
+ * `.transform()` are the two this guard was written for; `.trim()`,
+ * `.catch()` and `z.coerce.*` belong here for the same reason — they rewrite
+ * the output and leave the input untouched. None of them has a discarded
+ * call site today, so listing them costs nothing and closes the gap before
+ * someone reaches for `z.string().trim()` on a discarded schema. */
+const OUTPUT_MUTATING_OPS = /\.default\(|\.transform\(|\.trim\(|\.catch\(|z\.coerce\b/;
+
+/** True when the schema — or any schema it composes, transitively — carries an
+ * output-mutating op. Composition matters: `ClimbQueueItemSchema` has no
+ * default of its own but embeds `ClimbInputSchema`, whose null-coalescing
  * `.transform()`s are just as dead when the parsed return is thrown away. */
 function schemaHasLiveDefaultOrTransform(
   schemaName: string,
@@ -109,7 +119,7 @@ function schemaHasLiveDefaultOrTransform(
   // Schema not found in validation/schemas (e.g. imported from elsewhere,
   // or a plain z.ZodSchema built inline) — nothing to flag here.
   if (body === undefined) return false;
-  if (/\.default\(|\.transform\(/.test(body)) return true;
+  if (OUTPUT_MUTATING_OPS.test(body)) return true;
   for (const match of body.matchAll(/\b([A-Za-z_][A-Za-z0-9_]*)\b/g)) {
     const referenced = match[1];
     if (referenced === schemaName || !bodies.has(referenced)) continue;
@@ -128,9 +138,14 @@ function schemaHasLiveDefaultOrTransform(
  * store/broadcast the RAW item, so those coercions never apply — peers and
  * Redis keep the nulls. Capturing the parsed value here would change what
  * every party-mode client receives for a queue item, which needs its own
- * change with its own QA, not a drive-by in the #3975 fix.
+ * change with its own QA, not a drive-by in the #3975 fix. Tracked in #4601 —
+ * the entry comes out when that lands.
  *
  * Entries are `<resolver path relative to graphql/resolvers>::<SchemaName>`.
+ * One key covers every call site for that schema in that file (there are
+ * three for `ClimbQueueItemSchema`), so clean them up together: fixing a
+ * subset still satisfies the ratchet below.
+ *
  * Shrink this list; never grow it.
  */
 const KNOWN_DISCARDED_ALLOWLIST = new Set(['queue/mutations.ts::ClimbQueueItemSchema']);
@@ -140,7 +155,7 @@ function allowlistKey(call: DiscardedCall): string {
 }
 
 describe('validateInput discarded-return usage', () => {
-  it('never discards the return of a schema with a live .default()/.transform()', () => {
+  it('never discards the return of a schema with a live output-mutating op', () => {
     const resolverFiles = listTsFiles(resolversDir);
     const schemaBodies = collectSchemaBodies(
       listTsFiles(schemasDir).map((path) => ({ path, source: readFileSync(path, 'utf8') })),
@@ -169,10 +184,11 @@ describe('validateInput discarded-return usage', () => {
         .map((offender) => `  ${offender.file}:${offender.line} — validateInput(${offender.schemaName}, ...)`)
         .join('\n');
       throw new Error(
-        `Found ${offenders.length} statement-form validateInput() call(s) whose schema has a ` +
-          `.default()/.transform() that will never apply because the parsed return is discarded ` +
-          `(see #3975):\n${details}\n\nEither capture the return (const parsed = validateInput(...)) ` +
-          `and use it, or remove the default/transform if it's not meant to apply.`,
+        `Found ${offenders.length} statement-form validateInput() call(s) whose schema carries a ` +
+          `.default()/.transform()/.trim()/.catch()/z.coerce that will never apply because the ` +
+          `parsed return is discarded (see #3975):\n${details}\n\nEither capture the return ` +
+          `(const parsed = validateInput(...)) and use it, or drop the operator if it's not ` +
+          `meant to apply.`,
       );
     }
 

--- a/packages/backend/src/validation/__tests__/validate-input-return-usage.test.ts
+++ b/packages/backend/src/validation/__tests__/validate-input-return-usage.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vite-plus/test';
 import { readdirSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 // Regression guard for #3975: `validateInput(SomeSchema, raw, 'field')` is
@@ -78,30 +78,91 @@ function extractSchemaBody(source: string, schemaName: string): string | undefin
   return source.slice(startIndex, endIndex);
 }
 
-function schemaHasLiveDefaultOrTransform(schemaName: string, schemaFiles: { path: string; source: string }[]): boolean {
+/** Collect every `export const <Name>` in the schema files, so a schema body
+ * can be checked for references to OTHER schemas and followed into them. */
+function collectSchemaBodies(schemaFiles: { path: string; source: string }[]): Map<string, string> {
+  const bodies = new Map<string, string>();
   for (const { source } of schemaFiles) {
-    const body = extractSchemaBody(stripComments(source), schemaName);
-    if (body === undefined) continue;
-    return /\.default\(|\.transform\(/.test(body);
+    const stripped = stripComments(source);
+    for (const match of stripped.matchAll(/export const ([A-Za-z_][A-Za-z0-9_]*)\b/g)) {
+      const name = match[1];
+      if (bodies.has(name)) continue;
+      const body = extractSchemaBody(stripped, name);
+      if (body !== undefined) bodies.set(name, body);
+    }
   }
+  return bodies;
+}
+
+/** True when the schema — or any schema it composes, transitively — carries a
+ * `.default()`/`.transform()`. Composition matters: `ClimbQueueItemSchema` has
+ * no default of its own but embeds `ClimbInputSchema`, whose null-coalescing
+ * `.transform()`s are just as dead when the parsed return is thrown away. */
+function schemaHasLiveDefaultOrTransform(
+  schemaName: string,
+  bodies: Map<string, string>,
+  seen: Set<string> = new Set(),
+): boolean {
+  if (seen.has(schemaName)) return false;
+  seen.add(schemaName);
+  const body = bodies.get(schemaName);
   // Schema not found in validation/schemas (e.g. imported from elsewhere,
   // or a plain z.ZodSchema built inline) — nothing to flag here.
+  if (body === undefined) return false;
+  if (/\.default\(|\.transform\(/.test(body)) return true;
+  for (const match of body.matchAll(/\b([A-Za-z_][A-Za-z0-9_]*)\b/g)) {
+    const referenced = match[1];
+    if (referenced === schemaName || !bodies.has(referenced)) continue;
+    if (schemaHasLiveDefaultOrTransform(referenced, bodies, seen)) return true;
+  }
   return false;
+}
+
+/**
+ * Pre-existing discarded-return call sites, kept out of the failure list so
+ * this guard can land as a ratchet rather than forcing an unrelated
+ * behaviour change in the same PR.
+ *
+ * `ClimbQueueItemSchema` embeds `ClimbInputSchema`, whose nullish fields
+ * `.transform()` null into `''`/`0`. The queue mutations validate and then
+ * store/broadcast the RAW item, so those coercions never apply — peers and
+ * Redis keep the nulls. Capturing the parsed value here would change what
+ * every party-mode client receives for a queue item, which needs its own
+ * change with its own QA, not a drive-by in the #3975 fix.
+ *
+ * Entries are `<resolver path relative to graphql/resolvers>::<SchemaName>`.
+ * Shrink this list; never grow it.
+ */
+const KNOWN_DISCARDED_ALLOWLIST = new Set(['queue/mutations.ts::ClimbQueueItemSchema']);
+
+function allowlistKey(call: DiscardedCall): string {
+  return `${relative(resolversDir, call.file).split(sep).join('/')}::${call.schemaName}`;
 }
 
 describe('validateInput discarded-return usage', () => {
   it('never discards the return of a schema with a live .default()/.transform()', () => {
     const resolverFiles = listTsFiles(resolversDir);
-    const schemaFiles = listTsFiles(schemasDir).map((path) => ({ path, source: readFileSync(path, 'utf8') }));
+    const schemaBodies = collectSchemaBodies(
+      listTsFiles(schemasDir).map((path) => ({ path, source: readFileSync(path, 'utf8') })),
+    );
 
     const offenders: DiscardedCall[] = [];
+    const matchedAllowlistKeys = new Set<string>();
     for (const file of resolverFiles) {
       for (const call of findDiscardedValidateInputCalls(file)) {
-        if (schemaHasLiveDefaultOrTransform(call.schemaName, schemaFiles)) {
-          offenders.push(call);
+        if (!schemaHasLiveDefaultOrTransform(call.schemaName, schemaBodies)) continue;
+        const key = allowlistKey(call);
+        if (KNOWN_DISCARDED_ALLOWLIST.has(key)) {
+          matchedAllowlistKeys.add(key);
+          continue;
         }
+        offenders.push(call);
       }
     }
+
+    // The allowlist is a ratchet: once a call site is cleaned up (or deleted),
+    // its entry has to go too, or it silently starts covering something new.
+    expect([...KNOWN_DISCARDED_ALLOWLIST].filter((key) => !matchedAllowlistKeys.has(key))).toEqual([]);
 
     if (offenders.length > 0) {
       const details = offenders

--- a/packages/backend/src/validation/schemas/climbs.ts
+++ b/packages/backend/src/validation/schemas/climbs.ts
@@ -206,22 +206,19 @@ export const ClimbSearchInputSchema = z.object({
   onlyRatedByMe: z.boolean().optional(),
   onlyDrafts: z.boolean().optional(),
   projectsOnly: z.boolean().optional(),
-  // Intended to default to boulders-only so non-web GraphQL callers (mobile,
-  // scripts) get the same shape as the web UI when the field is omitted. This
-  // default is currently DEAD CODE: searchClimbs (see
-  // packages/backend/src/graphql/resolvers/climbs/queries.ts) calls
-  // validateInput(ClimbSearchInputSchema, input, 'input') only for its
-  // throw-on-invalid side effect and discards the parsed/defaulted return
-  // value, so every downstream consumer (mapSearchInputToParams) reads the
-  // raw, un-defaulted input — an omitted boulders/routes stays undefined, not
-  // true/false (see #2636). Do not "fix" this by wiring the parsed result
-  // into use without auditing every caller of @boardsesh/climb-filters'
-  // toClimbSearchInput first: its both-selected ("All") case now sends
-  // explicit boulders: true, routes: true (hardened by #2636) so it's safe,
-  // but its both-off case still relies on omission staying undefined, and
-  // reactivating this default would flip that to boulders-only.
-  boulders: z.boolean().optional().default(true),
-  routes: z.boolean().optional().default(false),
+  // No default here on purpose: omitted means "no climb-type constraint"
+  // (both boulders and routes match), not "boulders-only". searchClimbs (see
+  // packages/backend/src/graphql/resolvers/climbs/queries.ts) now uses the
+  // parsed/defaulted return of validateInput(ClimbSearchInputSchema, ...),
+  // so a `.default()` here would actually apply — a boulders-only default
+  // would silently narrow every caller that omits these fields, and
+  // @boardsesh/climb-filters' toClimbSearchInput relies on the both-off case
+  // staying undefined (hardened by #2636, which closed #3975's original
+  // symptom by always sending explicit values for the "All" case). If a
+  // future change wants a real default, audit every caller of
+  // toClimbSearchInput first, not just the web client.
+  boulders: z.boolean().optional(),
+  routes: z.boolean().optional(),
   zoneBox: z
     .object({
       edgeLeft: z.number().int(),

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -205,9 +205,9 @@ input ClimbSearchInput {
   onlyDrafts: Boolean
   "Show only unclimbed projects (climbs with 0 ascents)"
   projectsOnly: Boolean
-  "Include single-frame climbs (boulders). Default true. Set to false (paired with routes=true) to filter to routes only."
+  "Include single-frame climbs (boulders). Omitting both boulders and routes matches all climb types; set boulders=true with routes=false (or omit routes) to filter to boulders only."
   boulders: Boolean
-  "Include multi-frame climbs (routes). Default false. Set to true to include or filter to routes."
+  "Include multi-frame climbs (routes). Omitting both boulders and routes matches all climb types; set routes=true with boulders=false (or omit boulders) to filter to routes only."
   routes: Boolean
   "Restrict results using this drawn zone"
   zoneBox: ZoneBoxInput

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -1100,7 +1100,7 @@ export type ClimbSearchInput = {
   angle: Scalars['Int']['input'];
   /** Board type (e.g., 'kilter', 'tension') */
   boardName: Scalars['String']['input'];
-  /** Include single-frame climbs (boulders). Default true. Set to false (paired with routes=true) to filter to routes only. */
+  /** Include single-frame climbs (boulders). Omitting both boulders and routes matches all climb types; set boulders=true with routes=false (or omit routes) to filter to boulders only. */
   boulders?: InputMaybe<Scalars['Boolean']['input']>;
   /** Grade accuracy filter ('tight', 'moderate', 'loose') */
   gradeAccuracy?: InputMaybe<Scalars['String']['input']>;
@@ -1142,7 +1142,7 @@ export type ClimbSearchInput = {
   pageSize?: InputMaybe<Scalars['Int']['input']>;
   /** Show only unclimbed projects (climbs with 0 ascents) */
   projectsOnly?: InputMaybe<Scalars['Boolean']['input']>;
-  /** Include multi-frame climbs (routes). Default false. Set to true to include or filter to routes. */
+  /** Include multi-frame climbs (routes). Omitting both boulders and routes matches all climb types; set routes=true with boulders=false (or omit boulders) to filter to routes only. */
   routes?: InputMaybe<Scalars['Boolean']['input']>;
   /** Comma-separated set IDs */
   setIds: Scalars['String']['input'];

--- a/packages/shared-schema/src/schema/climb.ts
+++ b/packages/shared-schema/src/schema/climb.ts
@@ -201,9 +201,9 @@ export const climbTypeDefs = /* GraphQL */ `
     onlyDrafts: Boolean
     "Show only unclimbed projects (climbs with 0 ascents)"
     projectsOnly: Boolean
-    "Include single-frame climbs (boulders). Default true. Set to false (paired with routes=true) to filter to routes only."
+    "Include single-frame climbs (boulders). Omitting both boulders and routes matches all climb types; set boulders=true with routes=false (or omit routes) to filter to boulders only."
     boulders: Boolean
-    "Include multi-frame climbs (routes). Default false. Set to true to include or filter to routes."
+    "Include multi-frame climbs (routes). Omitting both boulders and routes matches all climb types; set routes=true with boulders=false (or omit boulders) to filter to routes only."
     routes: Boolean
     "Restrict results using this drawn zone"
     zoneBox: ZoneBoxInput

--- a/packages/shared/climb-filters/src/__tests__/climb-type-filter.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/climb-type-filter.test.ts
@@ -36,11 +36,12 @@ describe('climb-type (boulders/routes) filter', () => {
   });
 
   it('sends explicit boulders=true, routes=true when both are selected (no frames_count constraint)', () => {
-    // Regression guard for #2636: omission here is currently equivalent to
-    // explicit true/true (both parse to "no constraint" downstream), but
-    // omission relies on the backend's Zod default(true)/default(false) for
-    // these fields staying dead code (see filter-state.ts comment above the
-    // both-on branch). Sending explicit true/true removes that footgun.
+    // Regression guard for #2636: omission here is equivalent to explicit
+    // true/true (both parse to "no constraint" downstream) because the
+    // backend's ClimbSearchInputSchema has no `.default()` on these fields
+    // (see filter-state.ts comment above the both-on branch). Sending
+    // explicit true/true keeps that contract independent of the backend
+    // schema either way.
     const input = inputFor({ boulders: true, routes: true });
     expect(input.boulders).toBe(true);
     expect(input.routes).toBe(true);

--- a/packages/shared/climb-filters/src/filter-state.ts
+++ b/packages/shared/climb-filters/src/filter-state.ts
@@ -209,19 +209,15 @@ export function toClimbSearchInput(
   //   never-both-off toggle and mobile's boulders/routes/both selector never
   //   produce it — kept as-is, out of scope for this fix).
   // - Both-on ("All") sends explicit boulders: true, routes: true rather than
-  //   omitting both fields. Omission and explicit true/true are proven
-  //   behaviourally identical today (both parse to no frames_count
-  //   constraint), but only because the backend resolver's Zod
-  //   default(true)/default(false) for these fields is dead code —
-  //   searchClimbs's validateInput() call at
-  //   packages/backend/src/graphql/resolvers/climbs/queries.ts discards its
-  //   parsed/defaulted return value, so the default never actually applies.
-  //   If that discard is ever "cleaned up" to use the parsed result, an
-  //   omitted both/both would silently start defaulting to
-  //   boulders=true/routes=false (boulders-only) — reintroducing the exact
-  //   regression reported in issue #2636. Sending explicit true/true removes
-  //   that footgun regardless of what the backend resolver does with its
-  //   validation return. See create-climb-filters.ts for the SQL this maps to.
+  //   omitting both fields. Omission and explicit true/true are behaviourally
+  //   identical (both parse to no frames_count constraint): the backend's
+  //   ClimbSearchInputSchema has no `.default()` on these fields (#3975
+  //   removed the dead-code default that searchClimbs's discarded
+  //   validateInput() return used to make unreachable), and
+  //   mapSearchInputToParams passes `undefined` through unchanged. Sending
+  //   explicit true/true here is still the right call — it keeps this
+  //   contract independent of the backend schema's defaulting choices. See
+  //   create-climb-filters.ts for the SQL this maps to.
   const bouldersOn = state.boulders ?? true;
   const routesOn = state.routes ?? false;
   if (bouldersOn && routesOn) {

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -1097,7 +1097,7 @@ export type ClimbSearchInput = {
   angle: Scalars['Int']['input'];
   /** Board type (e.g., 'kilter', 'tension') */
   boardName: Scalars['String']['input'];
-  /** Include single-frame climbs (boulders). Default true. Set to false (paired with routes=true) to filter to routes only. */
+  /** Include single-frame climbs (boulders). Omitting both boulders and routes matches all climb types; set boulders=true with routes=false (or omit routes) to filter to boulders only. */
   boulders?: InputMaybe<Scalars['Boolean']['input']>;
   /** Grade accuracy filter ('tight', 'moderate', 'loose') */
   gradeAccuracy?: InputMaybe<Scalars['String']['input']>;
@@ -1139,7 +1139,7 @@ export type ClimbSearchInput = {
   pageSize?: InputMaybe<Scalars['Int']['input']>;
   /** Show only unclimbed projects (climbs with 0 ascents) */
   projectsOnly?: InputMaybe<Scalars['Boolean']['input']>;
-  /** Include multi-frame climbs (routes). Default false. Set to true to include or filter to routes. */
+  /** Include multi-frame climbs (routes). Omitting both boulders and routes matches all climb types; set routes=true with boulders=false (or omit boulders) to filter to routes only. */
   routes?: InputMaybe<Scalars['Boolean']['input']>;
   /** Comma-separated set IDs */
   setIds: Scalars['String']['input'];


### PR DESCRIPTION
## Summary

Fixes #3975. `searchClimbs` called `validateInput(ClimbSearchInputSchema, input, 'input')` purely for its throw-on-invalid side effect and discarded the parsed/defaulted return, so every downstream read (`mapSearchInputToParams(input)`, the board-name check, `setIds` parsing, etc.) used the raw GraphQL input instead. This made `ClimbSearchInputSchema`'s `boulders`/`routes` `.default()`s dead code since they were added.

**Note:** the user-facing symptom (climb-type "Both" not working) was already fixed client-side by #3976, which now always sends explicit `boulders`/`routes` values. This PR is the resolver-side hardening the issue asks for and does not change that behaviour.

### The `searchClimbs` fix

- `searchClimbs` now captures and uses `validateInput`'s parsed return (`parsedInput`) instead of re-reading the raw `input`.
- Removed the dead `.default(true)`/`.default(false)` from `ClimbSearchInputSchema.boulders`/`routes` in `packages/backend/src/validation/schemas/climbs.ts`. Now that the resolver actually uses the parsed value, those defaults would have gone live for the first time and silently narrowed every caller that omits both fields from "all climbs" to "boulders-only" — a real behaviour change for any client built before #3976. Kept `.optional()` so the schema's contract now matches what actually happens today: omitted = no climb-type constraint. `mapSearchInputToParams` already does `input.boulders ?? undefined` / `input.routes ?? undefined`, so an omitted field parses to `undefined` both before and after this change.
- Corrected the `boulders`/`routes` doc comments in the GraphQL SDL (`packages/shared-schema/src/schema/climb.ts`), which claimed "Default true"/"Default false" — never true — and regenerated `schema.graphql` / `types.ts` / `graphql.ts` from it.
- Updated the stale "this default is dead code" comments in `climbs.ts`, `packages/shared/climb-filters/src/filter-state.ts`, and the `climb-type-filter.test.ts` regression comment — they described the discard bug this PR fixes, so they were about to become wrong.
- Extended `packages/backend/src/__tests__/climb-search-validation.test.ts` with the no-behaviour-change proof: parsing with omitted `boulders`/`routes` leaves them `undefined` (not byte-identical `ClimbSearchParams` to the explicit `{boulders: true, routes: true}` case — that's `undefined` vs `true`), but `create-climb-filters.ts`'s `!!searchParams.boulders`/`!!searchParams.routes` coercion resolves both to the same "no `frames_count` constraint" branch.

I also diffed the full `ClimbSearchInputSchema` for other `.default()`/`.transform()` calls that would newly go live now that the return is used — there are none; `boulders`/`routes` were the only ones.

### The guard test — and a second live instance it found

Added `packages/backend/src/validation/__tests__/validate-input-return-usage.test.ts`: a static scan of every resolver file for statement-form (discarded-return) `validateInput(...)` calls, cross-referenced against each schema's `.default()`/`.transform()` usage. This is the lint-rule follow-up the issue asked for, implemented as a test since root `scripts/` isn't typechecked/linted the same way.

Running it against `origin/main` (before touching `searchClimbs`) turned up a **second, previously-unnoticed live instance** of the same bug: `setSessionBoardSerial` (`packages/backend/src/graphql/resolvers/sessions/mutations.ts`) calls `validateInput(BoardSerialSchema, serial, 'serial')` and discards the return. `BoardSerialSchema` has `.transform(normalizeSerial)` (trim + uppercase) — every other `BoardSerialSchema` call site (`board-presence/mutations.ts`, 3 places) captures and uses the parsed value, but this one stored/broadcast the raw, un-normalized serial via `roomManager.setSessionBoardSerialAndReturnPrevious` and the `SessionBoardSerialChanged` event. A client sending a differently-cased serial than another path normalized would fail string-equality comparisons against `lastConnectedBoardSerial` downstream. Fixed the same way as `searchClimbs`: capture `validSerial` and use it for the write, the idempotence comparison, and the broadcast. Added a regression test (`wall-confirm-and-board-serial.test.ts`) asserting a lowercase/padded serial normalizes before it's persisted/broadcast.

The issue's original 2026-07 audit concluded `ClimbSearchInputSchema` was the only live case at the time — this second instance was evidently introduced afterward, which is exactly the scenario the guard test exists to catch going forward.

### Follow-up hardening (adoption pass)

- Added an SDL↔Zod field-parity test for `ClimbSearchInput`. Feeding the parsed result downstream makes `ClimbSearchInputSchema` authoritative — Zod strips keys it doesn't declare, so a field added to the GraphQL input but forgotten in the schema would now be silently dropped rather than passed through as before. The test compares the SDL input block's field names against `ClimbSearchInputSchema.shape`, so that drift fails loudly instead of quietly turning a filter into a no-op. (Field sets are identical today: 35 fields on both sides.)
- The scanner now follows composed schemas (Codex review): a `.default()`/`.transform()` in a child schema counts, not just one on the referenced schema's own declaration. That surfaces the three `validateInput(ClimbQueueItemSchema, ...)` call sites in `queue/mutations.ts`, which reach `ClimbInputSchema`'s null-coalescing transforms. Those go on an explicit ratchet allowlist instead of being changed here — capturing the parsed item would alter what every party-mode peer receives for a queue item, which needs its own change and QA. A companion assertion fails when an allowlist entry stops matching, so the list can only shrink.
- Hardened the new scanner test per review: it now matches statement-form `validateInput(...)` calls across line breaks (the line-anchored regex would have missed a formatter-wrapped call), the redundant `statSync` filter is gone, and the sanity-check floor is a low bound instead of a near-exact count that resolver churn would break. Offender count is unchanged (68 discarded call sites scanned, 0 offenders).

### Adoption pass (2026-08-19)

Picked up stale, re-reviewed against current `main`, rebased (clean, 41 commits). Full review notes are in [this comment](https://github.com/boardsesh/boardsesh/pull/4298#issuecomment-5348797636). Two changes came out of it:

- **Filed #4601** for the `KNOWN_DISCARDED_ALLOWLIST` entry and referenced it from the allowlist comment. The deferred `queue/mutations.ts::ClimbQueueItemSchema` case was a real bug documented only in a code comment — now it has a tracking issue, and the comment says which one. Also noted there that the `<file>::<SchemaName>` key covers all three call sites at once, so they have to be fixed together.
- **Broadened the scanner's operator list** to `.trim()`, `.catch()` and `z.coerce` alongside `.default()`/`.transform()`. All five only ever rewrite the parsed output, so all five are equally dead on a discarded return. Verified this adds zero offenders today (68 discarded call sites scanned, still only the three allowlisted ones) — it closes the gap before someone reaches for `z.string().trim()` on a schema whose return nobody keeps.

The one behavioural change to be aware of when reading this: `setSessionBoardSerial` now stores and broadcasts the uppercased/trimmed serial. `bluetooth-provider.tsx:846` compares that echoed value against the serial it parses locally out of the BLE advertised name, so a case difference would cost a redundant mutation and a duplicate `Session Board Serial Set` event per connect. Aurora serials are digits in practice, so it's inert, and the server's own idempotence check still suppresses the redundant broadcast.

## Test plan

- [x] `vp check`
- [x] `vp run typecheck` (full backend build + typecheck, twice — once after the GraphQL schema regen, once after the `setSessionBoardSerial` fix)
- [x] `vp test run --project climb-filters --reporter=agent` — 11 files / 186 tests pass
- [x] `vp lint` on every changed file — no new warnings/errors (a few pre-existing `restrict-template-expressions` warnings on unrelated lines in `queries.ts`, unchanged by this PR)
- [x] `vp test run --project backend --reporter=agent` (via CI's `test-backend` job — local runs were blocked by shared per-worker test Postgres contention from ~10 concurrent agent worktrees). First CI run caught a real bug in my own new test's assertion (comparing `ClimbSearchParams` objects for equality instead of the downstream climb-type-constraint outcome — see the corrected wording above); fixed and re-pushed. 169 files / 2402 tests pass.

- [x] Adoption pass: rebased clean onto `main` (41 commits), `vp check` clean on the changed file, `vp run typecheck:backend` green, and the widened scanner re-run against the current tree — 68 discarded call sites, 0 offenders, allowlist entry still matching.

## Release Notes

- [x] No release note needed (backend-only correctness fix + test hardening; the `packages/shared`/`shared-schema` files touched are comment-only / generated-from-comment changes, no runtime behaviour change)



