### PR TITLE
fix(web): stamp environment=production on PostHog super properties

### DIFF
--- a/packages/web/app/lib/__tests__/analytics.test.ts
+++ b/packages/web/app/lib/__tests__/analytics.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
     capture: vi.fn(),
     flush: vi.fn(async () => {}),
     identify: vi.fn(),
+    register: vi.fn().mockResolvedValue(undefined),
     reset: vi.fn(),
     setPersonProperties: vi.fn(),
   },
@@ -76,6 +77,55 @@ describe('analytics wrapper', () => {
       }),
     );
     expect(mocks.posthog.capture).toHaveBeenCalledWith('Climb Opened', { kept: 'yes', count: 2 });
+  });
+
+  // #3945: web PostHog events carried no `environment` property, so a
+  // dashboard filter of `environment = 'production'` silently dropped 100% of
+  // web volume. Registering it as a super property at client construction
+  // (mirroring mobile's registerAppEnvironment) fixes that.
+  it('registers the environment super property on first PostHog client init', async () => {
+    const { track } = await import('../analytics');
+
+    track('Climb Opened');
+
+    expect(mocks.posthog.register).toHaveBeenCalledWith({ environment: 'production' });
+  });
+
+  it('never registers an environment super property on a preview hostname', async () => {
+    setWindowLocation('https://boardsesh-preview.vercel.app/b/kilter');
+    const { track } = await import('../analytics');
+
+    track('Preview Event');
+
+    expect(mocks.PostHog).not.toHaveBeenCalled();
+    expect(mocks.posthog.register).not.toHaveBeenCalled();
+  });
+
+  it('re-registers the environment super property after reset()', async () => {
+    const { reset, track } = await import('../analytics');
+
+    // Constructs the client (and registers environment once).
+    track('Climb Opened');
+    expect(mocks.posthog.register).toHaveBeenCalledTimes(1);
+
+    expect(reset()).toBe(true);
+
+    expect(mocks.posthog.reset).toHaveBeenCalledTimes(1);
+    expect(mocks.posthog.register).toHaveBeenCalledTimes(2);
+    expect(mocks.posthog.register).toHaveBeenNthCalledWith(2, { environment: 'production' });
+  });
+
+  it('does not throw or block capture when register() rejects', async () => {
+    mocks.posthog.register.mockRejectedValueOnce(new Error('storage unavailable'));
+    const { track } = await import('../analytics');
+
+    expect(() => track('Climb Opened')).not.toThrow();
+    // The rejection is asynchronous; flush microtasks so the swallowed
+    // rejection is observed before the test ends.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.posthog.capture).toHaveBeenCalledWith('Climb Opened', undefined);
   });
 
   it('fails loud once when the PostHog key is missing on a production host', async () => {

--- a/packages/web/app/lib/__tests__/analytics.test.ts
+++ b/packages/web/app/lib/__tests__/analytics.test.ts
@@ -128,6 +128,19 @@ describe('analytics wrapper', () => {
     expect(mocks.posthog.capture).toHaveBeenCalledWith('Climb Opened', undefined);
   });
 
+  it('does not throw or block capture when register() throws synchronously', async () => {
+    // register() is `async` in @posthog/core 1.46.1 so it can only reject
+    // today, but analytics init must survive an SDK that makes it sync.
+    mocks.posthog.register.mockImplementationOnce(() => {
+      throw new Error('storage unavailable');
+    });
+    const { track } = await import('../analytics');
+
+    expect(() => track('Climb Opened')).not.toThrow();
+
+    expect(mocks.posthog.capture).toHaveBeenCalledWith('Climb Opened', undefined);
+  });
+
   it('fails loud once when the PostHog key is missing on a production host', async () => {
     vi.stubEnv('NEXT_PUBLIC_POSTHOG_KEY', '');
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/packages/web/app/lib/analytics.ts
+++ b/packages/web/app/lib/analytics.ts
@@ -83,7 +83,33 @@ function getPosthog(): PostHog | null {
     persistence: 'localStorage',
   });
 
+  registerWebEnvironment(posthogClient);
+
   return posthogClient;
+}
+
+// Registers `environment: 'production'` as a persistent super property on every
+// event, mirroring mobile's registerAppEnvironment() in
+// packages/mobile/src/lib/posthog-client.ts. Without this, web PostHog events
+// carried no `environment` tag at all, so a dashboard filter of
+// `environment = 'production'` silently dropped 100% of web volume while still
+// counting mobile and backend correctly (#3945).
+//
+// Hardcoded to 'production' rather than resolved dynamically: getPosthog() is
+// gated by isProductionHost() a few lines above, and posthogClient is only ever
+// constructed when that gate passes, so 'production' is correct by
+// construction. If that gate is ever relaxed (e.g. preview deploys get their
+// own PostHog key), this must become dynamic like mobile's
+// resolveAppEnvironment().
+//
+// register() IS in posthog-js-lite's public typings (inherited from
+// @posthog/core's PostHogCoreStateless) — no structural cast needed here,
+// unlike registerSessionSuperProperties() below. Best-effort: a failure must
+// never block analytics init, matching mobile's contract.
+function registerWebEnvironment(client: PostHog): void {
+  void client.register({ environment: 'production' }).catch((error: unknown) => {
+    if (shouldDebugAnalytics) console.warn('[analytics] failed to register environment super property', error);
+  });
 }
 
 type PosthogProperties = Record<string, string | number | boolean | null>;
@@ -227,8 +253,24 @@ export function alias(newId: string): boolean {
   return core.alias(newId);
 }
 
+// PostHog's reset() clears the distinct id AND every registered super
+// property, but getPosthog() caches the singleton, so the registration done at
+// construction never runs again. Re-register `environment` straight after so a
+// party-profile reset (party-profile-context.tsx) doesn't silently drop the tag
+// for the rest of the page session — mirrors mobile's reset() in
+// packages/mobile/src/lib/analytics.ts.
+//
+// Only re-registers when core.reset() actually forwarded to a real client
+// (didReset === true): calling getPosthog() unconditionally would construct a
+// client on the admin-page skip path, where core.reset() short-circuits before
+// ever calling getPosthog() itself.
 export function reset(): boolean {
-  return core.reset();
+  const didReset = core.reset();
+  if (didReset) {
+    const posthog = getPosthog();
+    if (posthog) registerWebEnvironment(posthog);
+  }
+  return didReset;
 }
 
 type PosthogSuperPropertyClient = {

--- a/packages/web/app/lib/analytics.ts
+++ b/packages/web/app/lib/analytics.ts
@@ -104,12 +104,25 @@ function getPosthog(): PostHog | null {
 //
 // register() IS in posthog-js-lite's public typings (inherited from
 // @posthog/core's PostHogCoreStateless) — no structural cast needed here,
-// unlike registerSessionSuperProperties() below. Best-effort: a failure must
-// never block analytics init, matching mobile's contract.
+// unlike registerSessionSuperProperties() below.
+//
+// Best-effort, exactly like mobile's registerAppEnvironment: a failure here
+// must never block analytics init, so a rejection AND a synchronous throw are
+// both swallowed. register() is declared `async` in @posthog/core 1.46.1, so
+// today it can only reject — the Promise.resolve() + try/catch keeps that from
+// being a silent version coupling if a future SDK makes it sync.
 function registerWebEnvironment(client: PostHog): void {
-  void client.register({ environment: 'production' }).catch((error: unknown) => {
-    if (shouldDebugAnalytics) console.warn('[analytics] failed to register environment super property', error);
-  });
+  try {
+    void Promise.resolve(client.register({ environment: 'production' })).catch((error: unknown) => {
+      warnEnvironmentRegistrationFailed(error);
+    });
+  } catch (error) {
+    warnEnvironmentRegistrationFailed(error);
+  }
+}
+
+function warnEnvironmentRegistrationFailed(error: unknown): void {
+  if (shouldDebugAnalytics) console.warn('[analytics] failed to register environment super property', error);
 }
 
 type PosthogProperties = Record<string, string | number | boolean | null>;


### PR DESCRIPTION
## Summary

Closes #3945.

Web's PostHog client never registered an `environment` super property, unlike mobile (`registerAppEnvironment()`) and backend (per-event `properties.environment`). Verified live in the issue against project 412845: `js`-lib events were **100% `(none)`** for `environment` over the last 30 days (102,331 events).

Once a dashboard filters on `environment = 'production'` — the natural way to exclude preview/localhost noise now that backend and mobile are tagged — that filter silently drops **all** web volume (~7.5% of events). The dashboards keep rendering; the numbers just quietly get smaller.

## What changed

Option 1 from the issue (register `environment` as a super property on web, matching mobile), per the issue author's stated preference over standardising queries on `environment != 'preview'`.

- `getPosthog()` calls `registerWebEnvironment(posthogClient)` right after constructing the client, registering `{ environment: 'production' }` via `client.register(...)` — the same persistent-super-property call mobile uses.
- The value is hardcoded rather than read from an env var, deliberately. `getPosthog()` is already gated by `isProductionHost()` (exact-match against `boardsesh.com` / `www.boardsesh.com`), and `posthogClient` is only ever constructed when that gate passes, so `'production'` is correct by construction. No new build-time env var is introduced — the May 2026 blackout where CI's `vercel build` never received `NEXT_PUBLIC_POSTHOG_KEY` is exactly the failure mode this avoids re-creating. Preview deploys (`<pr>.preview.boardsesh.com`) never construct a client at all, so they can't be mislabelled as production; they emit nothing, same as before. A comment marks the spot to switch to a dynamic resolve if that gate is ever relaxed.
- `reset()` re-registers `environment` after `core.reset()`. PostHog's `reset()` clears every registered super property, but `getPosthog()` caches the singleton, so without a re-register a party-profile reset (`party-profile-context.tsx`) would silently drop the tag for the rest of the page session. Only re-registers when `core.reset()` actually forwarded to a real client, so the admin-page skip path doesn't construct a client that wouldn't otherwise exist.
- Registration is best-effort: both a rejected promise and a synchronous throw are swallowed, so a storage failure can never take down analytics init (and with it every `track()` call on the page). `register()` is declared `async` in `@posthog/core` 1.46.1, so today it can only reject — the sync guard keeps that from being an invisible version coupling, and matches mobile's `registerAppEnvironment`, which has always caught both.

No changes needed in `packages/web/app/lib/analytics.server.ts` (Vercel only, no PostHog client) or `production-hosts.ts` (the hostname gate is already the exact-match fix from #3895, not the substring flaw from #3814).

Ordering is safe: `@posthog/core` routes `register()`, `reset()` and `capture()` through the same `wrap()` init queue, so the registration always lands ahead of the first captured event even before the SDK finishes initialising.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:web` — passes (confirms `register()` is in `posthog-js-lite`'s public typings, inherited from `@posthog/core`'s `PostHogCoreStateless` as `Promise<void>`, so no structural cast is needed).
- `vp check` — clean on both touched files; format passes across all 4828 files. The 4 remaining lint errors are pre-existing on `main` in `packages/db/scripts/dedupe-gym-locations-args.test.ts` and untouched here.
- `vp test run --project web app/lib/__tests__/analytics.test.ts` — 20/20 pass, including the 5 new cases:
  - registers `{ environment: 'production' }` on first PostHog client init
  - never registers on a preview hostname (the client isn't constructed at all)
  - re-registers after `reset()`
  - a rejected `register()` promise neither throws nor blocks a subsequent `capture()`
  - a synchronously throwing `register()` neither throws nor blocks a subsequent `capture()`

## Caveat for dashboard owners

This can't fix history: web events captured before this deploys still show `environment = (none)`. A filter of `environment = 'production'` keeps undercounting web until the query's date range moves past the deploy date. No event backfill is planned or in scope here.
