### PR TITLE
fix(mobile): [native-train] avoid main-thread UIImage(named:) miss in expo-image

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -908,6 +908,7 @@
     "@expo/ui@57.0.8": "patches/@expo%2Fui@57.0.8.patch",
     "expo-dev-launcher@57.0.10": "patches/expo-dev-launcher@57.0.10.patch",
     "@expo/fingerprint@0.20.6": "patches/@expo%2Ffingerprint@0.20.6.patch",
+    "expo-image@57.0.1": "patches/expo-image@57.0.1.patch",
     "react-native-screens@4.26.2": "patches/react-native-screens@4.26.2.patch",
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@expo/fingerprint@0.20.6": "patches/@expo%2Ffingerprint@0.20.6.patch",
     "@expo/ui@57.0.8": "patches/@expo%2Fui@57.0.8.patch",
     "expo-dev-launcher@57.0.10": "patches/expo-dev-launcher@57.0.10.patch",
-    "react-native-screens@4.26.2": "patches/react-native-screens@4.26.2.patch"
+    "react-native-screens@4.26.2": "patches/react-native-screens@4.26.2.patch",
+    "expo-image@57.0.1": "patches/expo-image@57.0.1.patch"
   }
 }

--- a/patches/expo-image@57.0.1.patch
+++ b/patches/expo-image@57.0.1.patch
@@ -1,37 +1,21 @@
 diff --git a/ios/ImageView.swift b/ios/ImageView.swift
-index cccedd7adf7328b18bb61333c3fe2473c79e72cd..986ac82e9b89e227aa34d516358092fafd4bf130 100644
+index cccedd7adf7328b18bb61333c3fe2473c79e72cd..cb69b1b60b491d3da3df1202509e136041cfc739 100644
 --- a/ios/ImageView.swift
 +++ b/ios/ImageView.swift
-@@ -871,5 +871,32 @@ func localAssetName(from url: URL?) -> String? {
-   if path.hasPrefix("/") {
-     path.removeFirst()
-   }
+@@ -868,4 +868,16 @@ func localAssetName(from url: URL?) -> String? {
+   // Use `relativePath` so we recover the original input ("my_image") instead of
+   // the absolute path it resolves to against the file:// base
+   var path = url.relativePath
 +
-+  // A genuine filesystem URL — `file:///private/var/.../board.png`, or a
-+  // `file://host/...` — can never resolve via `UIImage(named:)`: that API only
-+  // looks in asset catalogs and bundle resources, so handing it a real path is
-+  // a guaranteed miss that still pays for `_UIImageCollectImagePathsForPath`'s
-+  // synchronous main-thread bundle-directory enumeration on every `reload`
-+  // (boardsesh/boardsesh#3928). Reject those here so `reload(force:)` falls
-+  // through to SDWebImage's disk loader instead, which handles `file://` URLs
-+  // correctly off the main thread.
-+  //
-+  // ExpoModulesCore also wraps scheme-less JS asset names with
-+  // `URL(fileURLWithPath:)`. Relative names retain the current directory as
-+  // their base URL, including supported namespaced catalog names such as
-+  // "Images/MyIcon"; keep those eligible for `UIImage(named:)`. Explicit file
-+  // URIs and absolute file paths have no base URL, so a remaining `/` after
-+  // stripping the leading slash identifies the real multi-component paths we
-+  // need to bypass. (A root-level `file:///image.png` is intentionally left
-+  // unchanged because Foundation loses the original JS spelling there.)
-+  if url.scheme == "file" {
-+    if let host = url.host, !host.isEmpty {
-+      return nil
-+    }
-+    if url.baseURL == nil && path.contains("/") {
-+      return nil
-+    }
++  // ExpoModulesCore represents scheme-less xcasset names with relative file
++  // URLs. Keep those (including "Images/MyIcon"), but skip absolute file URLs
++  // and file URLs with hosts: neither can resolve through UIImage(named:), and
++  // probing them triggers synchronous bundle scans (boardsesh/boardsesh#3928).
++  // This check must run before the leading slash is removed so root-level file
++  // URLs such as `file:///app_icon` cannot masquerade as an asset name.
++  let hasFileHost = url.scheme == "file" && !(url.host?.isEmpty ?? true)
++  let hasAbsoluteFilePath = url.scheme == "file" && path.hasPrefix("/")
++  if hasFileHost || hasAbsoluteFilePath {
++    return nil
 +  }
-+
-   return path.isEmpty ? nil : path
- }
+   if path.hasPrefix("/") {

--- a/patches/expo-image@57.0.1.patch
+++ b/patches/expo-image@57.0.1.patch
@@ -1,8 +1,8 @@
 diff --git a/ios/ImageView.swift b/ios/ImageView.swift
-index cccedd7adf7328b18bb61333c3fe2473c79e72cd..ebbb17024da36fd5c07d6f98ef064234cd3f5a0a 100644
+index cccedd7adf7328b18bb61333c3fe2473c79e72cd..986ac82e9b89e227aa34d516358092fafd4bf130 100644
 --- a/ios/ImageView.swift
 +++ b/ios/ImageView.swift
-@@ -871,5 +871,25 @@ func localAssetName(from url: URL?) -> String? {
+@@ -871,5 +871,32 @@ func localAssetName(from url: URL?) -> String? {
    if path.hasPrefix("/") {
      path.removeFirst()
    }
@@ -14,14 +14,21 @@ index cccedd7adf7328b18bb61333c3fe2473c79e72cd..ebbb17024da36fd5c07d6f98ef064234
 +  // synchronous main-thread bundle-directory enumeration on every `reload`
 +  // (boardsesh/boardsesh#3928). Reject those here so `reload(force:)` falls
 +  // through to SDWebImage's disk loader instead, which handles `file://` URLs
-+  // correctly off the main thread. A scheme-less local asset name like
-+  // "my_image" has exactly one path component (no `/` once the leading slash
-+  // is stripped) and is left untouched.
++  // correctly off the main thread.
++  //
++  // ExpoModulesCore also wraps scheme-less JS asset names with
++  // `URL(fileURLWithPath:)`. Relative names retain the current directory as
++  // their base URL, including supported namespaced catalog names such as
++  // "Images/MyIcon"; keep those eligible for `UIImage(named:)`. Explicit file
++  // URIs and absolute file paths have no base URL, so a remaining `/` after
++  // stripping the leading slash identifies the real multi-component paths we
++  // need to bypass. (A root-level `file:///image.png` is intentionally left
++  // unchanged because Foundation loses the original JS spelling there.)
 +  if url.scheme == "file" {
 +    if let host = url.host, !host.isEmpty {
 +      return nil
 +    }
-+    if path.contains("/") {
++    if url.baseURL == nil && path.contains("/") {
 +      return nil
 +    }
 +  }

--- a/patches/expo-image@57.0.1.patch
+++ b/patches/expo-image@57.0.1.patch
@@ -1,0 +1,30 @@
+diff --git a/ios/ImageView.swift b/ios/ImageView.swift
+index cccedd7adf7328b18bb61333c3fe2473c79e72cd..ebbb17024da36fd5c07d6f98ef064234cd3f5a0a 100644
+--- a/ios/ImageView.swift
++++ b/ios/ImageView.swift
+@@ -871,5 +871,25 @@ func localAssetName(from url: URL?) -> String? {
+   if path.hasPrefix("/") {
+     path.removeFirst()
+   }
++
++  // A genuine filesystem URL — `file:///private/var/.../board.png`, or a
++  // `file://host/...` — can never resolve via `UIImage(named:)`: that API only
++  // looks in asset catalogs and bundle resources, so handing it a real path is
++  // a guaranteed miss that still pays for `_UIImageCollectImagePathsForPath`'s
++  // synchronous main-thread bundle-directory enumeration on every `reload`
++  // (boardsesh/boardsesh#3928). Reject those here so `reload(force:)` falls
++  // through to SDWebImage's disk loader instead, which handles `file://` URLs
++  // correctly off the main thread. A scheme-less local asset name like
++  // "my_image" has exactly one path component (no `/` once the leading slash
++  // is stripped) and is left untouched.
++  if url.scheme == "file" {
++    if let host = url.host, !host.isEmpty {
++      return nil
++    }
++    if path.contains("/") {
++      return nil
++    }
++  }
++
+   return path.isEmpty ? nil : path
+ }

--- a/scripts/__tests__/mobile-patches-check.test.ts
+++ b/scripts/__tests__/mobile-patches-check.test.ts
@@ -146,6 +146,42 @@ const SCOPED_PATCH_PATH = 'patches/@expo%2Fui@57.0.8.patch';
 const SCOPED_RULES: PatchRule[] = [
   { package: SCOPED_PKG, file: SCOPED_FILE, sentinels: ['swallowMissingNativeHandler'], patchedKey: SCOPED_KEY },
 ];
+
+type ExpoImageUrlShape = {
+  scheme: string | null;
+  host: string | null;
+  relativePath: string;
+};
+
+// Portable model of the Foundation URL properties consumed by the Swift
+// patch. These cases mirror Expo's relative xcasset URL representation and the
+// absolute/hosted filesystem URLs that must bypass UIImage(named:).
+function modelPatchedLocalAssetName({ scheme, host, relativePath }: ExpoImageUrlShape): string | null {
+  if (scheme !== null && scheme !== 'file') return null;
+
+  const hasFileHost = scheme === 'file' && host !== null && host.length > 0;
+  const hasAbsoluteFilePath = scheme === 'file' && relativePath.startsWith('/');
+  if (hasFileHost || hasAbsoluteFilePath) return null;
+
+  const assetName = relativePath.startsWith('/') ? relativePath.slice(1) : relativePath;
+  return assetName.length > 0 ? assetName : null;
+}
+
+function expoImageGuardRunsBeforeSlashStripping(source: string): boolean {
+  const functionIndex = source.indexOf('func localAssetName(from url: URL?)');
+  const hostGuardIndex = source.indexOf('let hasFileHost', functionIndex);
+  const absolutePathGuardIndex = source.indexOf('let hasAbsoluteFilePath', functionIndex);
+  const combinedGuardIndex = source.indexOf('if hasFileHost || hasAbsoluteFilePath', functionIndex);
+  const stripLeadingSlashIndex = source.indexOf('if path.hasPrefix("/")', functionIndex);
+
+  return (
+    functionIndex >= 0 &&
+    hostGuardIndex > functionIndex &&
+    absolutePathGuardIndex > hostGuardIndex &&
+    combinedGuardIndex > absolutePathGuardIndex &&
+    stripLeadingSlashIndex > combinedGuardIndex
+  );
+}
 const SCOPED_PATCHED_SOURCE = `
 function swallowMissingNativeHandler(error: unknown): void { /* ... */ }
 sheetRef.current?.expand()?.catch(swallowMissingNativeHandler);
@@ -286,6 +322,92 @@ const close = hideSwallowingMissingNativeHandler;
     expect(result.errors[0]).not.toContain('hideSwallowingMissingNativeHandler();');
     expect(result.errors[0]).not.toContain('const close = hideSwallowingMissingNativeHandler;');
   });
+});
+
+describe('the shipped expo-image local-asset guard', () => {
+  const imageViewSource = readFileSync(
+    resolve(import.meta.dirname, '../../packages/mobile/node_modules/expo-image/ios/ImageView.swift'),
+    'utf8',
+  );
+
+  it('rejects filesystem URLs before stripping the leading slash', () => {
+    expect(expoImageGuardRunsBeforeSlashStripping(imageViewSource)).toBe(true);
+    expect(imageViewSource).not.toContain('url.baseURL == nil');
+    expect(imageViewSource).not.toContain('path.contains("/")');
+  });
+
+  it('goes red if the leading-slash normalization moves ahead of the filesystem guard', () => {
+    const guardBlock = `  let hasFileHost = url.scheme == "file" && !(url.host?.isEmpty ?? true)
+  let hasAbsoluteFilePath = url.scheme == "file" && path.hasPrefix("/")
+  if hasFileHost || hasAbsoluteFilePath {
+    return nil
+  }
+`;
+    const slashNormalizationBlock = `  if path.hasPrefix("/") {
+    path.removeFirst()
+  }
+`;
+    const reorderedSource = imageViewSource.replace(
+      `${guardBlock}${slashNormalizationBlock}`,
+      `${slashNormalizationBlock}${guardBlock}`,
+    );
+
+    expect(reorderedSource).not.toBe(imageViewSource);
+    expect(expoImageGuardRunsBeforeSlashStripping(reorderedSource)).toBe(false);
+  });
+
+  it.each([
+    {
+      name: 'keeps relative URL(fileURLWithPath:) asset names',
+      url: { scheme: 'file', host: null, relativePath: 'app_icon' },
+      expected: 'app_icon',
+    },
+    {
+      name: 'keeps nested xcasset URL(fileURLWithPath:) names',
+      url: { scheme: 'file', host: null, relativePath: 'Images/MyIcon' },
+      expected: 'Images/MyIcon',
+    },
+    {
+      name: 'keeps a scheme-less /app_icon name',
+      url: { scheme: null, host: null, relativePath: '/app_icon' },
+      expected: 'app_icon',
+    },
+    {
+      name: 'rejects file:///private paths',
+      url: { scheme: 'file', host: '', relativePath: '/private/var/mobile/board.png' },
+      expected: null,
+    },
+    {
+      name: 'rejects root-level file:///app_icon URLs',
+      url: { scheme: 'file', host: '', relativePath: '/app_icon' },
+      expected: null,
+    },
+    {
+      name: 'rejects absolute URL(fileURLWithPath:) values',
+      url: { scheme: 'file', host: null, relativePath: '/app_icon' },
+      expected: null,
+    },
+    {
+      name: 'rejects file://host paths',
+      url: { scheme: 'file', host: 'board-cache', relativePath: '/board.png' },
+      expected: null,
+    },
+    {
+      name: 'rejects non-file schemes',
+      url: { scheme: 'https', host: 'example.com', relativePath: '/app_icon' },
+      expected: null,
+    },
+    {
+      name: 'rejects an empty asset name',
+      url: { scheme: null, host: null, relativePath: '' },
+      expected: null,
+    },
+  ] satisfies readonly { name: string; url: ExpoImageUrlShape; expected: string | null }[])(
+    '$name',
+    ({ url, expected }) => {
+      expect(modelPatchedLocalAssetName(url)).toBe(expected);
+    },
+  );
 });
 
 describe('checkPatchesApplied across several packages', () => {
@@ -652,32 +774,38 @@ describe('the shipped RULES', () => {
     expect(pinnedVersion, 'expo-image must stay a direct packages/mobile dependency').toBeDefined();
     expect(versionFromKey(expoImageRule?.patchedKey ?? '')).toBe(pinnedVersion);
     expect(expoImageRule?.sentinels).toEqual(
-      expect.arrayContaining(['boardsesh/boardsesh#3928', 'url.baseURL == nil && path.contains("/")', 'Images/MyIcon']),
+      expect.arrayContaining([
+        'boardsesh/boardsesh#3928',
+        'let hasFileHost = url.scheme == "file" && !(url.host?.isEmpty ?? true)',
+        'let hasAbsoluteFilePath = url.scheme == "file" && path.hasPrefix("/")',
+        'if hasFileHost || hasAbsoluteFilePath',
+        'Images/MyIcon',
+      ]),
     );
   });
 
-  it('rejects the slash-only guard that breaks namespaced asset-catalog names', () => {
+  it('rejects the old post-normalization guard that leaks root-level file URLs', () => {
     const expoImageRule = REAL_RULES.find((rule) => rule.package === 'expo-image');
     if (!expoImageRule) throw new Error('no expo-image rule registered');
 
-    const slashOnlyGuardSource = `
+    const postNormalizationGuardSource = `
 // boardsesh/boardsesh#3928
 // Namespaced asset name: Images/MyIcon
 if url.scheme == "file" {
   if let host = url.host, !host.isEmpty { return nil }
-  if path.contains("/") { return nil }
+  if url.baseURL == nil && path.contains("/") { return nil }
 }
 `;
     const env = makeEnv({
       patchedDependencies: { [expoImageRule.patchedKey]: 'patches/expo-image@57.0.1.patch' },
       versions: { [expoImageRule.package]: versionFromKey(expoImageRule.patchedKey) },
-      files: { [`${expoImageRule.package}::${expoImageRule.file}`]: slashOnlyGuardSource },
+      files: { [`${expoImageRule.package}::${expoImageRule.file}`]: postNormalizationGuardSource },
     });
 
     const result = checkPatchesApplied([expoImageRule], env);
 
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]).toContain('patch NOT applied');
-    expect(result.errors[0]).toContain('url.baseURL == nil && path.contains');
+    expect(result.errors[0]).toContain('hasAbsoluteFilePath');
   });
 });

--- a/scripts/__tests__/mobile-patches-check.test.ts
+++ b/scripts/__tests__/mobile-patches-check.test.ts
@@ -651,6 +651,33 @@ describe('the shipped RULES', () => {
 
     expect(pinnedVersion, 'expo-image must stay a direct packages/mobile dependency').toBeDefined();
     expect(versionFromKey(expoImageRule?.patchedKey ?? '')).toBe(pinnedVersion);
-    expect(expoImageRule?.sentinels).toEqual(expect.arrayContaining(['boardsesh/boardsesh#3928']));
+    expect(expoImageRule?.sentinels).toEqual(
+      expect.arrayContaining(['boardsesh/boardsesh#3928', 'url.baseURL == nil && path.contains("/")', 'Images/MyIcon']),
+    );
+  });
+
+  it('rejects the slash-only guard that breaks namespaced asset-catalog names', () => {
+    const expoImageRule = REAL_RULES.find((rule) => rule.package === 'expo-image');
+    if (!expoImageRule) throw new Error('no expo-image rule registered');
+
+    const slashOnlyGuardSource = `
+// boardsesh/boardsesh#3928
+// Namespaced asset name: Images/MyIcon
+if url.scheme == "file" {
+  if let host = url.host, !host.isEmpty { return nil }
+  if path.contains("/") { return nil }
+}
+`;
+    const env = makeEnv({
+      patchedDependencies: { [expoImageRule.patchedKey]: 'patches/expo-image@57.0.1.patch' },
+      versions: { [expoImageRule.package]: versionFromKey(expoImageRule.patchedKey) },
+      files: { [`${expoImageRule.package}::${expoImageRule.file}`]: slashOnlyGuardSource },
+    });
+
+    const result = checkPatchesApplied([expoImageRule], env);
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('patch NOT applied');
+    expect(result.errors[0]).toContain('url.baseURL == nil && path.contains');
   });
 });

--- a/scripts/__tests__/mobile-patches-check.test.ts
+++ b/scripts/__tests__/mobile-patches-check.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   RULES as REAL_RULES,
@@ -630,5 +632,25 @@ describe('the shipped RULES', () => {
     for (const [key, reason] of Object.entries(UNGUARDED_PATCHES)) {
       expect(reason.length, `${key} needs a reason`).toBeGreaterThan(20);
     }
+  });
+
+  // Guards against the #3928 fix silently dropping on the next expo-image
+  // bump: `patchedDependencies` is keyed by an EXACT version, so a bump that
+  // forgets to re-key the patch installs expo-image UNPATCHED and this rule
+  // would keep asserting against a key nothing resolves to. Pinning it to
+  // packages/mobile/package.json's declared version turns that drift into a
+  // failing test instead of a silent no-op.
+  it('keeps the expo-image local-asset patch keyed to the pinned mobile version', () => {
+    const expoImageRule = REAL_RULES.find((rule) => rule.package === 'expo-image');
+    expect(expoImageRule).toBeDefined();
+
+    const mobilePackageJson = JSON.parse(
+      readFileSync(resolve(import.meta.dirname, '../../packages/mobile/package.json'), 'utf8'),
+    ) as { dependencies?: Record<string, string> };
+    const pinnedVersion = mobilePackageJson.dependencies?.['expo-image'];
+
+    expect(pinnedVersion, 'expo-image must stay a direct packages/mobile dependency').toBeDefined();
+    expect(versionFromKey(expoImageRule?.patchedKey ?? '')).toBe(pinnedVersion);
+    expect(expoImageRule?.sentinels).toEqual(expect.arrayContaining(['boardsesh/boardsesh#3928']));
   });
 });

--- a/scripts/mobile-patches-check.ts
+++ b/scripts/mobile-patches-check.ts
@@ -185,13 +185,20 @@ export const RULES: readonly PatchRule[] = [
   // main-thread bundle-directory enumeration on every reload (#3928). The
   // patch rejects `file://` URLs that resolve to an absolute filesystem path
   // (or carry a host) so `reload` falls straight through to SDWebImage's disk
-  // loader instead. Silently dropping this patch on the next expo-image bump
-  // wouldn't fail typecheck or the bundle — board art would just resume the
-  // per-reload main-thread stall.
+  // loader instead. It must preserve ExpoModulesCore's relative file URLs for
+  // asset-catalog names such as `Images/MyIcon`, which retain a base URL.
+  // Silently dropping this patch on the next expo-image bump wouldn't fail
+  // typecheck or the bundle — board art would just resume the per-reload
+  // main-thread stall.
   {
     package: 'expo-image',
     file: 'ios/ImageView.swift',
-    sentinels: ['boardsesh/boardsesh#3928', 'host, !host.isEmpty', 'path.contains("/")'],
+    sentinels: [
+      'boardsesh/boardsesh#3928',
+      'host, !host.isEmpty',
+      'url.baseURL == nil && path.contains("/")',
+      'Images/MyIcon',
+    ],
     patchedKey: 'expo-image@57.0.1',
   },
 ];

--- a/scripts/mobile-patches-check.ts
+++ b/scripts/mobile-patches-check.ts
@@ -177,6 +177,23 @@ export const RULES: readonly PatchRule[] = [
     sentinels: ['onFullyDismissedRef', 'handleNativeDismiss'],
     patchedKey: '@expo/ui@57.0.8',
   },
+  // `localAssetName` accepted `file://` URLs alongside genuinely scheme-less
+  // JS asset names, so every board-art `file://` source (LayeredClimbImage's
+  // bundled photos, the Rust renderer's holds-overlay PNGs) was routed through
+  // `UIImage(named: <absolute path>)` on `reload(force:)` — a guaranteed miss
+  // that still pays for `_UIImageCollectImagePathsForPath`'s synchronous
+  // main-thread bundle-directory enumeration on every reload (#3928). The
+  // patch rejects `file://` URLs that resolve to an absolute filesystem path
+  // (or carry a host) so `reload` falls straight through to SDWebImage's disk
+  // loader instead. Silently dropping this patch on the next expo-image bump
+  // wouldn't fail typecheck or the bundle — board art would just resume the
+  // per-reload main-thread stall.
+  {
+    package: 'expo-image',
+    file: 'ios/ImageView.swift',
+    sentinels: ['boardsesh/boardsesh#3928', 'host, !host.isEmpty', 'path.contains("/")'],
+    patchedKey: 'expo-image@57.0.1',
+  },
 ];
 
 /**

--- a/scripts/mobile-patches-check.ts
+++ b/scripts/mobile-patches-check.ts
@@ -177,26 +177,20 @@ export const RULES: readonly PatchRule[] = [
     sentinels: ['onFullyDismissedRef', 'handleNativeDismiss'],
     patchedKey: '@expo/ui@57.0.8',
   },
-  // `localAssetName` accepted `file://` URLs alongside genuinely scheme-less
-  // JS asset names, so every board-art `file://` source (LayeredClimbImage's
-  // bundled photos, the Rust renderer's holds-overlay PNGs) was routed through
-  // `UIImage(named: <absolute path>)` on `reload(force:)` — a guaranteed miss
-  // that still pays for `_UIImageCollectImagePathsForPath`'s synchronous
-  // main-thread bundle-directory enumeration on every reload (#3928). The
-  // patch rejects `file://` URLs that resolve to an absolute filesystem path
-  // (or carry a host) so `reload` falls straight through to SDWebImage's disk
-  // loader instead. It must preserve ExpoModulesCore's relative file URLs for
-  // asset-catalog names such as `Images/MyIcon`, which retain a base URL.
-  // Silently dropping this patch on the next expo-image bump wouldn't fail
-  // typecheck or the bundle — board art would just resume the per-reload
-  // main-thread stall.
+  // ExpoModulesCore uses relative file URLs for xcasset names, so
+  // `localAssetName` must keep those while rejecting absolute/hosted file URLs
+  // before the leading slash is stripped and `UIImage(named:)` synchronously
+  // enumerates the bundle for a guaranteed board-art miss (#3928). Silently
+  // dropping this patch on the next expo-image bump wouldn't fail typecheck or
+  // the bundle — board art would just resume the per-reload main-thread stall.
   {
     package: 'expo-image',
     file: 'ios/ImageView.swift',
     sentinels: [
       'boardsesh/boardsesh#3928',
-      'host, !host.isEmpty',
-      'url.baseURL == nil && path.contains("/")',
+      'let hasFileHost = url.scheme == "file" && !(url.host?.isEmpty ?? true)',
+      'let hasAbsoluteFilePath = url.scheme == "file" && path.hasPrefix("/")',
+      'if hasFileHost || hasAbsoluteFilePath',
       'Images/MyIcon',
     ],
     patchedKey: 'expo-image@57.0.1',


### PR DESCRIPTION
## Native release train

This PR patches `expo-image`'s iOS native source (`ios/ImageView.swift`) and adds a `patchedDependencies` entry, which changes the Expo native fingerprint. It targets `release/next-ota`, stacked after the merged #4120 repair. A new store build has to ship and be adopted before an OTA from this branch can reach users.

Fixes #3928. Refs #3803 and #3944.

## The bug

`ImageView.reload(force:)` asks `localAssetName(from:)` whether a source can be loaded synchronously through `UIImage(named:)` before falling through to SDWebImage.

ExpoModulesCore represents scheme-less asset names with relative `file:` URLs, so upstream intentionally accepts the `file` scheme. That also admitted genuine filesystem URLs used by board photos and generated holds overlays. Every reload therefore tried `UIImage(named: <filesystem path>)`, a guaranteed miss that can synchronously enumerate bundle paths on the main thread before SDWebImage loads the same file correctly.

## The fix

`patches/expo-image@57.0.1.patch` now classifies filesystem URLs before removing a leading slash:

```swift
let hasFileHost = url.scheme == "file" && !(url.host?.isEmpty ?? true)
let hasAbsoluteFilePath = url.scheme == "file" && path.hasPrefix("/")
if hasFileHost || hasAbsoluteFilePath {
  return nil
}
if path.hasPrefix("/") {
  path.removeFirst()
}
```

This preserves Expo's supported asset-name forms:

- relative `URL(fileURLWithPath: "app_icon")`
- nested xcasset names such as `URL(fileURLWithPath: "Images/MyIcon")`
- a genuinely scheme-less `/app_icon`, which normalizes to `app_icon`

It rejects every absolute `file:` URL before normalization, including `file:///app_icon`, `file:///private/...`, and `URL(fileURLWithPath: "/app_icon")`, plus hosted `file://host/...` URLs. Rejected sources still use SDWebImage's disk loader; the visual result is unchanged.

The installed patched Swift source hashes to `cb69b1b60b491d3da3df1202509e136041cfc739`, which is recorded in the patch header.

## Guard against the patch silently dropping

Bun keys `patchedDependencies` by exact package version. A future `expo-image` bump can otherwise install an unpatched copy while typecheck and Metro remain green.

The shipped patch rule now pins the exact host, absolute-path, and combined-guard expressions. Regression coverage also:

- verifies the guard runs before leading-slash normalization
- mutates that ordering and proves the check goes red
- rejects the former post-normalization guard
- models relative, nested, scheme-less, absolute root, absolute nested, hosted, remote, and empty URL shapes
- pins the patch key to the direct `expo-image` dependency version

## Validation

Run from the native-train repair worktree on Linux:

| step | result |
| --- | --- |
| `vp install` | pass; patch applies cleanly |
| `vp run check:mobile-patches` | pass — 7 native patch rules applied, 5 patch files accounted for |
| `vp test run --project scripts --reporter=agent scripts/__tests__/mobile-patches-check.test.ts` | pass — 53 tests on the cumulative #4420 → #4120 → #4301 head |
| `vp run typecheck:mobile` | pass |
| `vp run test:mobile` | pass — 619 files, 5,458 tests |
| `vp run check:mobile-bundle` | pass — iOS and Android |
| `vp check scripts/mobile-patches-check.ts scripts/__tests__/mobile-patches-check.test.ts` | pass |
| pre-commit hook | pass, no `--no-verify` |
| independent QA | PASS with no P0–P2 findings; exact stacked head `c787b2649` is patch-identical to the reviewed repair |

Swift cannot be compiled on this Linux host. Native-train macOS CI and device/simulator QA should confirm the board-art surfaces still render unchanged.

## Release Notes

- iOS: Board photos and hold overlays load without an extra pause.