### PR TITLE
fix(backend): reject cross-board playlist adds

### DIFF
--- a/packages/backend/src/__tests__/add-climb-to-playlist-board-guard.test.ts
+++ b/packages/backend/src/__tests__/add-climb-to-playlist-board-guard.test.ts
@@ -1,0 +1,237 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { playlistMutations } from '../graphql/resolvers/playlists/mutations';
+
+// #4015: addClimbToPlaylist only checked ownership, not board/layout
+// compatibility, so a cross-board add would insert a playlist_climbs row
+// successfully — then the board-scoped membership refetch
+// (playlistsForClimb / playlistsForClimbs, which filter on
+// board_type = X AND (layout_id = Y OR layout_id IS NULL)) would silently
+// exclude it, making the UI checkmark vanish. #4268 fixed the mobile picker
+// to stop offering mismatched playlists as targets; this guard is the
+// server-side backstop that mirrors the membership query's exact rule.
+//
+// FIXTURE_RUN_ID keeps rows unique across parallel test workers sharing the
+// worker DB (see the "Backend tests: shared worker DBs" note) — no TRUNCATE
+// of shared tables, only scoped INSERT/DELETE by uuid prefix.
+
+// Short: climbUuid goes through ExternalUUIDSchema (max 50 chars), so keep
+// every generated climb uuid well under that ceiling.
+const FIXTURE_RUN_ID = crypto.randomUUID().slice(0, 8);
+const OWNER_ID = `bg4015-owner-${FIXTURE_RUN_ID}`;
+
+const KILTER_LAYOUT_8_PLAYLIST = `bg4015-kilter-l8-${FIXTURE_RUN_ID}`;
+const KILTER_NULL_LAYOUT_PLAYLIST = `bg4015-kilter-null-${FIXTURE_RUN_ID}`;
+
+const KILTER_L8_CLIMB = `bg4015-ck8-${FIXTURE_RUN_ID}`;
+const KILTER_L9_CLIMB = `bg4015-ck9-${FIXTURE_RUN_ID}`;
+const TENSION_L8_CLIMB = `bg4015-ct8-${FIXTURE_RUN_ID}`;
+const UNKNOWN_CLIMB = `bg4015-cunk-${FIXTURE_RUN_ID}`;
+
+const ALIAS_UUID = `bg4015-calias-${FIXTURE_RUN_ID}`;
+const ALIAS_CANONICAL_KILTER_L8 = KILTER_L8_CLIMB;
+
+function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext {
+  return {
+    connectionId: `bg4015-${FIXTURE_RUN_ID}`,
+    isAuthenticated: true,
+    userId: OWNER_ID,
+    sessionId: null,
+    boardPath: null,
+    controllerId: null,
+    controllerApiKey: null,
+    ...overrides,
+  } as ConnectionContext;
+}
+
+async function playlistIdByUuid(playlistUuid: string): Promise<number> {
+  const result = await db.execute(sql`SELECT id FROM playlists WHERE uuid = ${playlistUuid}`);
+  const rows = Array.from(result as Iterable<{ id: number }>);
+  return rows[0].id;
+}
+
+async function climbUuidsInPlaylist(playlistUuid: string): Promise<string[]> {
+  const playlistId = await playlistIdByUuid(playlistUuid);
+  const result = await db.execute(sql`
+    SELECT climb_uuid FROM playlist_climbs WHERE playlist_id = ${playlistId}
+  `);
+  return Array.from(result as Iterable<{ climb_uuid: string }>).map((row) => row.climb_uuid);
+}
+
+describe('addClimbToPlaylist — board-compatibility guard (#4015)', () => {
+  beforeAll(async () => {
+    await db.execute(sql`
+      INSERT INTO users (id, email, name)
+      VALUES (${OWNER_ID}, ${`${OWNER_ID}@test.invalid`}, 'Board guard owner')
+      ON CONFLICT (id) DO NOTHING
+    `);
+
+    await db.execute(sql`
+      INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, frames, is_listed)
+      VALUES
+        (${KILTER_L8_CLIMB}, 'kilter', 8, 'setter', 'Kilter layout 8 climb', 'p1', true),
+        (${KILTER_L9_CLIMB}, 'kilter', 9, 'setter', 'Kilter layout 9 climb', 'p1', true),
+        (${TENSION_L8_CLIMB}, 'tension', 8, 'setter', 'Tension layout 8 climb', 'p1', true)
+      ON CONFLICT (uuid) DO NOTHING
+    `);
+
+    // A non-canonical alias pointing at the Kilter layout-8 climb, on the
+    // same board — this is what board_climb_aliases dedup rows look like.
+    await db.execute(sql`
+      INSERT INTO board_climb_aliases (board_type, alias_uuid, canonical_uuid, source)
+      VALUES ('kilter', ${ALIAS_UUID}, ${ALIAS_CANONICAL_KILTER_L8}, 'kilter')
+      ON CONFLICT (board_type, alias_uuid) DO NOTHING
+    `);
+
+    await db.execute(sql`
+      INSERT INTO playlists (uuid, board_type, layout_id, name, is_public)
+      VALUES
+        (${KILTER_LAYOUT_8_PLAYLIST}, 'kilter', 8, 'Kilter layout 8 playlist', false),
+        (${KILTER_NULL_LAYOUT_PLAYLIST}, 'kilter', NULL, 'Kilter any-layout playlist', false)
+      ON CONFLICT (uuid) DO NOTHING
+    `);
+
+    await db.execute(sql`
+      INSERT INTO playlist_ownership (playlist_id, user_id, role)
+      SELECT id, ${OWNER_ID}, 'owner' FROM playlists
+      WHERE uuid IN (${KILTER_LAYOUT_8_PLAYLIST}, ${KILTER_NULL_LAYOUT_PLAYLIST})
+      ON CONFLICT (playlist_id, user_id) DO NOTHING
+    `);
+  });
+
+  afterAll(async () => {
+    await db.execute(
+      sql`DELETE FROM playlists WHERE uuid IN (${KILTER_LAYOUT_8_PLAYLIST}, ${KILTER_NULL_LAYOUT_PLAYLIST})`,
+    );
+    await db.execute(sql`DELETE FROM board_climb_aliases WHERE alias_uuid = ${ALIAS_UUID} AND board_type = 'kilter'`);
+    await db.execute(
+      sql`DELETE FROM board_climbs WHERE uuid IN (${KILTER_L8_CLIMB}, ${KILTER_L9_CLIMB}, ${TENSION_L8_CLIMB})`,
+    );
+    await db.execute(sql`DELETE FROM users WHERE id = ${OWNER_ID}`);
+  });
+
+  it('accepts a same-board, same-layout add', async () => {
+    const result = (await playlistMutations.addClimbToPlaylist(
+      null,
+      { input: { playlistId: KILTER_LAYOUT_8_PLAYLIST, climbUuid: KILTER_L8_CLIMB, angle: 40 } },
+      makeCtx(),
+    )) as { climbUuid: string };
+
+    expect(result.climbUuid).toBe(KILTER_L8_CLIMB);
+    expect(await climbUuidsInPlaylist(KILTER_LAYOUT_8_PLAYLIST)).toContain(KILTER_L8_CLIMB);
+  });
+
+  it('rejects a cross-board add (different boardType)', async () => {
+    await expect(
+      playlistMutations.addClimbToPlaylist(
+        null,
+        { input: { playlistId: KILTER_LAYOUT_8_PLAYLIST, climbUuid: TENSION_L8_CLIMB, angle: 40 } },
+        makeCtx(),
+      ),
+    ).rejects.toThrow('This playlist is for a different board');
+
+    expect(await climbUuidsInPlaylist(KILTER_LAYOUT_8_PLAYLIST)).not.toContain(TENSION_L8_CLIMB);
+  });
+
+  it('rejects a same-board layout mismatch when the playlist has a specific layoutId', async () => {
+    await expect(
+      playlistMutations.addClimbToPlaylist(
+        null,
+        { input: { playlistId: KILTER_LAYOUT_8_PLAYLIST, climbUuid: KILTER_L9_CLIMB, angle: 40 } },
+        makeCtx(),
+      ),
+    ).rejects.toThrow('This playlist is for a different board');
+
+    expect(await climbUuidsInPlaylist(KILTER_LAYOUT_8_PLAYLIST)).not.toContain(KILTER_L9_CLIMB);
+  });
+
+  it('accepts any layout of its own board when the playlist has a NULL layoutId', async () => {
+    const resultL8 = (await playlistMutations.addClimbToPlaylist(
+      null,
+      { input: { playlistId: KILTER_NULL_LAYOUT_PLAYLIST, climbUuid: KILTER_L8_CLIMB, angle: 40 } },
+      makeCtx(),
+    )) as { climbUuid: string };
+    const resultL9 = (await playlistMutations.addClimbToPlaylist(
+      null,
+      { input: { playlistId: KILTER_NULL_LAYOUT_PLAYLIST, climbUuid: KILTER_L9_CLIMB, angle: 40 } },
+      makeCtx(),
+    )) as { climbUuid: string };
+
+    expect(resultL8.climbUuid).toBe(KILTER_L8_CLIMB);
+    expect(resultL9.climbUuid).toBe(KILTER_L9_CLIMB);
+    const members = await climbUuidsInPlaylist(KILTER_NULL_LAYOUT_PLAYLIST);
+    expect(members).toContain(KILTER_L8_CLIMB);
+    expect(members).toContain(KILTER_L9_CLIMB);
+  });
+
+  it('rejects a different board even when the playlist has a NULL layoutId', async () => {
+    await expect(
+      playlistMutations.addClimbToPlaylist(
+        null,
+        { input: { playlistId: KILTER_NULL_LAYOUT_PLAYLIST, climbUuid: TENSION_L8_CLIMB, angle: 40 } },
+        makeCtx(),
+      ),
+    ).rejects.toThrow('This playlist is for a different board');
+
+    expect(await climbUuidsInPlaylist(KILTER_NULL_LAYOUT_PLAYLIST)).not.toContain(TENSION_L8_CLIMB);
+  });
+
+  it('fails open (allows the add) when the climb uuid has no board_climbs row and no alias', async () => {
+    const result = (await playlistMutations.addClimbToPlaylist(
+      null,
+      { input: { playlistId: KILTER_LAYOUT_8_PLAYLIST, climbUuid: UNKNOWN_CLIMB, angle: 40 } },
+      makeCtx(),
+    )) as { climbUuid: string };
+
+    expect(result.climbUuid).toBe(UNKNOWN_CLIMB);
+    expect(await climbUuidsInPlaylist(KILTER_LAYOUT_8_PLAYLIST)).toContain(UNKNOWN_CLIMB);
+  });
+
+  it('resolves an alias uuid to its canonical board and accepts a same-board add', async () => {
+    const result = (await playlistMutations.addClimbToPlaylist(
+      null,
+      { input: { playlistId: KILTER_LAYOUT_8_PLAYLIST, climbUuid: ALIAS_UUID, angle: 40 } },
+      makeCtx(),
+    )) as { climbUuid: string };
+
+    expect(result.climbUuid).toBe(ALIAS_UUID);
+    expect(await climbUuidsInPlaylist(KILTER_LAYOUT_8_PLAYLIST)).toContain(ALIAS_UUID);
+  });
+
+  it('resolves an alias uuid to its canonical board and rejects a cross-board add', async () => {
+    // ALIAS_UUID resolves to a Kilter layout-8 canonical climb; the
+    // null-layout playlist above is Kilter (would accept it), so exercise
+    // the reject path against a Kilter *layout-9* playlist instead — the
+    // canonical climb's board matches but its layout doesn't.
+    const specificLayoutPlaylist = `bg4015-kilter-l9-playlist-${FIXTURE_RUN_ID}`;
+    await db.execute(sql`
+      INSERT INTO playlists (uuid, board_type, layout_id, name, is_public)
+      VALUES (${specificLayoutPlaylist}, 'kilter', 9, 'Kilter layout 9 playlist', false)
+    `);
+    const [{ id: specificLayoutPlaylistId }] = Array.from(
+      (await db.execute(sql`SELECT id FROM playlists WHERE uuid = ${specificLayoutPlaylist}`)) as Iterable<{
+        id: number;
+      }>,
+    );
+    await db.execute(sql`
+      INSERT INTO playlist_ownership (playlist_id, user_id, role)
+      VALUES (${specificLayoutPlaylistId}, ${OWNER_ID}, 'owner')
+    `);
+
+    try {
+      await expect(
+        playlistMutations.addClimbToPlaylist(
+          null,
+          { input: { playlistId: specificLayoutPlaylist, climbUuid: ALIAS_UUID, angle: 40 } },
+          makeCtx(),
+        ),
+      ).rejects.toThrow('This playlist is for a different board');
+
+      expect(await climbUuidsInPlaylist(specificLayoutPlaylist)).not.toContain(ALIAS_UUID);
+    } finally {
+      await db.execute(sql`DELETE FROM playlists WHERE uuid = ${specificLayoutPlaylist}`);
+    }
+  });
+});

--- a/packages/backend/src/__tests__/add-climb-to-playlist-board-guard.test.ts
+++ b/packages/backend/src/__tests__/add-climb-to-playlist-board-guard.test.ts
@@ -217,7 +217,7 @@ describe('addClimbToPlaylist — board-compatibility guard (#4015)', () => {
     expect(await climbUuidsInPlaylist(KILTER_LAYOUT_8_PLAYLIST)).toContain(ALIAS_UUID);
   });
 
-  it('resolves an alias uuid to its canonical board and rejects a cross-board add', async () => {
+  it('resolves an alias uuid to its canonical layout and rejects a layout mismatch', async () => {
     // ALIAS_UUID resolves to a Kilter layout-8 canonical climb; the
     // null-layout playlist above is Kilter (would accept it), so exercise
     // the reject path against a Kilter *layout-9* playlist instead — the

--- a/packages/backend/src/__tests__/add-climb-to-playlist-board-guard.test.ts
+++ b/packages/backend/src/__tests__/add-climb-to-playlist-board-guard.test.ts
@@ -33,6 +33,11 @@ const UNKNOWN_CLIMB = `bg4015-cunk-${FIXTURE_RUN_ID}`;
 const ALIAS_UUID = `bg4015-calias-${FIXTURE_RUN_ID}`;
 const ALIAS_CANONICAL_KILTER_L8 = KILTER_L8_CLIMB;
 
+// One alias uuid carrying a row under BOTH boards — the alias PK is
+// (board_type, alias_uuid), so this is representable and each row can point at
+// a different canonical climb.
+const AMBIGUOUS_ALIAS_UUID = `bg4015-camb-${FIXTURE_RUN_ID}`;
+
 function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext {
   return {
     connectionId: `bg4015-${FIXTURE_RUN_ID}`,
@@ -81,7 +86,10 @@ describe('addClimbToPlaylist — board-compatibility guard (#4015)', () => {
     // same board — this is what board_climb_aliases dedup rows look like.
     await db.execute(sql`
       INSERT INTO board_climb_aliases (board_type, alias_uuid, canonical_uuid, source)
-      VALUES ('kilter', ${ALIAS_UUID}, ${ALIAS_CANONICAL_KILTER_L8}, 'kilter')
+      VALUES
+        ('kilter', ${ALIAS_UUID}, ${ALIAS_CANONICAL_KILTER_L8}, 'kilter'),
+        ('kilter', ${AMBIGUOUS_ALIAS_UUID}, ${KILTER_L8_CLIMB}, 'kilter'),
+        ('tension', ${AMBIGUOUS_ALIAS_UUID}, ${TENSION_L8_CLIMB}, 'aurora')
       ON CONFLICT (board_type, alias_uuid) DO NOTHING
     `);
 
@@ -102,10 +110,13 @@ describe('addClimbToPlaylist — board-compatibility guard (#4015)', () => {
   });
 
   afterAll(async () => {
+    // playlist_climbs.playlist_id is declared `onDelete: 'cascade'`
+    // (packages/db/src/schema/app/playlists.ts), so dropping the playlists
+    // takes every membership row these tests added with them.
     await db.execute(
       sql`DELETE FROM playlists WHERE uuid IN (${KILTER_LAYOUT_8_PLAYLIST}, ${KILTER_NULL_LAYOUT_PLAYLIST})`,
     );
-    await db.execute(sql`DELETE FROM board_climb_aliases WHERE alias_uuid = ${ALIAS_UUID} AND board_type = 'kilter'`);
+    await db.execute(sql`DELETE FROM board_climb_aliases WHERE alias_uuid IN (${ALIAS_UUID}, ${AMBIGUOUS_ALIAS_UUID})`);
     await db.execute(
       sql`DELETE FROM board_climbs WHERE uuid IN (${KILTER_L8_CLIMB}, ${KILTER_L9_CLIMB}, ${TENSION_L8_CLIMB})`,
     );
@@ -124,13 +135,19 @@ describe('addClimbToPlaylist — board-compatibility guard (#4015)', () => {
   });
 
   it('rejects a cross-board add (different boardType)', async () => {
+    // The code matters as much as the message: clients branch on
+    // BAD_USER_INPUT to tell "you picked the wrong playlist" apart from a
+    // server failure they should retry.
     await expect(
       playlistMutations.addClimbToPlaylist(
         null,
         { input: { playlistId: KILTER_LAYOUT_8_PLAYLIST, climbUuid: TENSION_L8_CLIMB, angle: 40 } },
         makeCtx(),
       ),
-    ).rejects.toThrow('This playlist is for a different board');
+    ).rejects.toMatchObject({
+      message: 'This playlist is for a different board',
+      extensions: { code: 'BAD_USER_INPUT' },
+    });
 
     expect(await climbUuidsInPlaylist(KILTER_LAYOUT_8_PLAYLIST)).not.toContain(TENSION_L8_CLIMB);
   });
@@ -232,6 +249,49 @@ describe('addClimbToPlaylist — board-compatibility guard (#4015)', () => {
       expect(await climbUuidsInPlaylist(specificLayoutPlaylist)).not.toContain(ALIAS_UUID);
     } finally {
       await db.execute(sql`DELETE FROM playlists WHERE uuid = ${specificLayoutPlaylist}`);
+    }
+  });
+
+  // An alias uuid with a row under two boards resolves to two candidate
+  // scopes. The guard accepts when ANY of them fits, so the verdict can't flip
+  // with whichever row Postgres returns first — this test would be a coin flip
+  // against an unordered LIMIT 1 lookup.
+  it('accepts an alias uuid that resolves under two boards when one of them fits the playlist', async () => {
+    const result = (await playlistMutations.addClimbToPlaylist(
+      null,
+      { input: { playlistId: KILTER_LAYOUT_8_PLAYLIST, climbUuid: AMBIGUOUS_ALIAS_UUID, angle: 40 } },
+      makeCtx(),
+    )) as { climbUuid: string };
+
+    expect(result.climbUuid).toBe(AMBIGUOUS_ALIAS_UUID);
+    expect(await climbUuidsInPlaylist(KILTER_LAYOUT_8_PLAYLIST)).toContain(AMBIGUOUS_ALIAS_UUID);
+  });
+
+  it('rejects an alias uuid whose every resolved board disagrees with the playlist', async () => {
+    // Both of AMBIGUOUS_ALIAS_UUID's canonical climbs sit on layout 8, so a
+    // Kilter layout-9 playlist matches neither.
+    const layout9Playlist = `bg4015-amb-l9-${FIXTURE_RUN_ID}`;
+    await db.execute(sql`
+      INSERT INTO playlists (uuid, board_type, layout_id, name, is_public)
+      VALUES (${layout9Playlist}, 'kilter', 9, 'Kilter layout 9 playlist', false)
+    `);
+    await db.execute(sql`
+      INSERT INTO playlist_ownership (playlist_id, user_id, role)
+      SELECT id, ${OWNER_ID}, 'owner' FROM playlists WHERE uuid = ${layout9Playlist}
+    `);
+
+    try {
+      await expect(
+        playlistMutations.addClimbToPlaylist(
+          null,
+          { input: { playlistId: layout9Playlist, climbUuid: AMBIGUOUS_ALIAS_UUID, angle: 40 } },
+          makeCtx(),
+        ),
+      ).rejects.toThrow('This playlist is for a different board');
+
+      expect(await climbUuidsInPlaylist(layout9Playlist)).not.toContain(AMBIGUOUS_ALIAS_UUID);
+    } finally {
+      await db.execute(sql`DELETE FROM playlists WHERE uuid = ${layout9Playlist}`);
     }
   });
 });

--- a/packages/backend/src/graphql/resolvers/playlists/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/mutations.ts
@@ -16,6 +16,56 @@ import {
 import { getPlaylistFollowStats } from './queries';
 import { verifyPlaylistAccess } from './helpers/enrichment';
 import { computePlaylistReorderWrites } from './helpers/reorder';
+import { logger } from '../../../utils/logger';
+
+type ClimbBoardScope = { boardType: string; layoutId: number };
+
+// Resolves the board + layout a climb belongs to, following the same
+// alias-read convention as the rest of the codebase (see
+// packages/db/src/queries/aliases.ts and
+// docs' "Climb alias read-resolution" note): board_climb_aliases dedups
+// duplicate Kilter UUIDs onto a single canonical board_climbs row within the
+// same board, so a climbUuid that isn't itself a board_climbs row may still
+// be a non-canonical alias whose canonical row carries the real board/layout.
+//
+// Returns null when the uuid resolves to no board_climbs row even after
+// alias resolution — callers should fail OPEN on null (see
+// addClimbToPlaylist below) rather than reject: the catalog row can
+// legitimately lag behind create-climb / offline-sync writes, and hard
+// rejecting here would risk breaking those flows for the sake of a guard
+// that is defense-in-depth (the mobile picker, per #4268, no longer offers
+// mismatched playlists as add targets in the first place).
+async function resolveClimbBoardScope(climbUuid: string): Promise<ClimbBoardScope | null> {
+  const direct = await db
+    .select({ boardType: dbSchema.boardClimbs.boardType, layoutId: dbSchema.boardClimbs.layoutId })
+    .from(dbSchema.boardClimbs)
+    .where(eq(dbSchema.boardClimbs.uuid, climbUuid))
+    .limit(1);
+
+  if (direct.length > 0) return direct[0];
+
+  // Not a canonical row — check whether it's a non-canonical alias. The
+  // alias table's PK is (board_type, alias_uuid), but the board a duplicate
+  // UUID belongs to is exactly the board its canonical row lives on, so we
+  // can join straight from alias_uuid to the canonical board_climbs row
+  // without needing to know board_type up front.
+  const viaAlias = await db
+    .select({ boardType: dbSchema.boardClimbs.boardType, layoutId: dbSchema.boardClimbs.layoutId })
+    .from(dbSchema.boardClimbAliases)
+    .innerJoin(dbSchema.boardClimbs, eq(dbSchema.boardClimbs.uuid, dbSchema.boardClimbAliases.canonicalUuid))
+    .where(eq(dbSchema.boardClimbAliases.aliasUuid, climbUuid))
+    .limit(1);
+
+  if (viaAlias.length > 0) return viaAlias[0];
+
+  logger.warn(
+    'addClimbToPlaylist: climb uuid not found in board_climbs or board_climb_aliases; allowing add (fail-open)',
+    {
+      climbUuid,
+    },
+  );
+  return null;
+}
 
 function playlistResult(playlist: dbSchema.Playlist, climbCount: number): Record<string, unknown> {
   return {
@@ -279,7 +329,11 @@ export const playlistMutations = {
     // Check owner role. Editors/viewers retain private read access, but cannot
     // mutate playlist contents.
     const ownership = await db
-      .select({ id: dbSchema.playlists.id })
+      .select({
+        id: dbSchema.playlists.id,
+        boardType: dbSchema.playlists.boardType,
+        layoutId: dbSchema.playlists.layoutId,
+      })
       .from(dbSchema.playlistOwnership)
       .innerJoin(dbSchema.playlists, eq(dbSchema.playlists.id, dbSchema.playlistOwnership.playlistId))
       .where(
@@ -296,6 +350,24 @@ export const playlistMutations = {
     }
 
     const playlistId = ownership[0].id;
+
+    // Board-compatibility guard (#4015): reject adds where the climb's own
+    // board/layout doesn't match the playlist's. This mirrors the exact rule
+    // playlistsForClimb / playlistsForClimbs already use to scope membership
+    // (board_type match + layout_id match-or-null) — without it, an add could
+    // succeed here while the membership refetch silently excludes it,
+    // making the UI checkmark vanish. #4268 already stops the mobile picker
+    // from offering a mismatched playlist as a target; this is the
+    // server-side backstop for stale clients and the deprecated web picker
+    // (packages/web, no longer maintained per #3122, is still unfiltered).
+    const climbBoardScope = await resolveClimbBoardScope(validatedInput.climbUuid);
+    if (climbBoardScope) {
+      const boardMismatch = climbBoardScope.boardType !== ownership[0].boardType;
+      const layoutMismatch = ownership[0].layoutId !== null && climbBoardScope.layoutId !== ownership[0].layoutId;
+      if (boardMismatch || layoutMismatch) {
+        throw new Error('This playlist is for a different board');
+      }
+    }
 
     // Insert-or-noop + position assignment share one transaction: a plain
     // pre-check SELECT followed by a separate INSERT leaves a window where

--- a/packages/backend/src/graphql/resolvers/playlists/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/mutations.ts
@@ -1,4 +1,5 @@
 import { eq, and, asc, inArray, sql } from 'drizzle-orm';
+import { GraphQLError } from 'graphql';
 import { v4 as uuidv4 } from 'uuid';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
@@ -20,43 +21,50 @@ import { logger } from '../../../utils/logger';
 
 type ClimbBoardScope = { boardType: string; layoutId: number };
 
-// Resolves the board + layout a climb belongs to, following the same
-// alias-read convention as the rest of the codebase (see
-// packages/db/src/queries/aliases.ts and
-// docs' "Climb alias read-resolution" note): board_climb_aliases dedups
-// duplicate Kilter UUIDs onto a single canonical board_climbs row within the
-// same board, so a climbUuid that isn't itself a board_climbs row may still
-// be a non-canonical alias whose canonical row carries the real board/layout.
+// Resolves every board + layout a climb uuid can legitimately stand for,
+// following the same alias-read convention as the rest of the codebase (see
+// packages/db/src/queries/aliases.ts and docs' "Climb alias read-resolution"
+// note): board_climb_aliases dedups duplicate Kilter UUIDs onto a single
+// canonical board_climbs row, so a climbUuid that isn't itself a board_climbs
+// row may still be a non-canonical alias whose canonical row carries the real
+// board/layout.
 //
-// Returns null when the uuid resolves to no board_climbs row even after
-// alias resolution — callers should fail OPEN on null (see
-// addClimbToPlaylist below) rather than reject: the catalog row can
-// legitimately lag behind create-climb / offline-sync writes, and hard
-// rejecting here would risk breaking those flows for the sake of a guard
-// that is defense-in-depth (the mobile picker, per #4268, no longer offers
-// mismatched playlists as add targets in the first place).
-async function resolveClimbBoardScope(climbUuid: string): Promise<ClimbBoardScope | null> {
+// A LIST, not a single row, because the alias table's PK is
+// (board_type, alias_uuid): the same alias_uuid can in principle exist under
+// more than one board, pointing at different canonical climbs. Picking one of
+// those with an unordered LIMIT 1 would make the guard's verdict depend on
+// whichever row Postgres happened to return. Callers accept the add when ANY
+// resolved scope is compatible, so an ambiguous uuid can never be rejected on
+// a coin flip.
+//
+// Returns an empty list when the uuid resolves to no board_climbs row even
+// after alias resolution — callers fail OPEN on empty (see addClimbToPlaylist
+// below) rather than reject: the catalog row can legitimately lag behind
+// create-climb / offline-sync writes, and hard rejecting here would risk
+// breaking those flows for the sake of a guard that is defense-in-depth (the
+// mobile picker, per #4268, no longer offers mismatched playlists as add
+// targets in the first place).
+async function resolveClimbBoardScopes(climbUuid: string): Promise<ClimbBoardScope[]> {
   const direct = await db
     .select({ boardType: dbSchema.boardClimbs.boardType, layoutId: dbSchema.boardClimbs.layoutId })
     .from(dbSchema.boardClimbs)
     .where(eq(dbSchema.boardClimbs.uuid, climbUuid))
     .limit(1);
 
-  if (direct.length > 0) return direct[0];
+  if (direct.length > 0) return direct;
 
-  // Not a canonical row — check whether it's a non-canonical alias. The
-  // alias table's PK is (board_type, alias_uuid), but the board a duplicate
-  // UUID belongs to is exactly the board its canonical row lives on, so we
-  // can join straight from alias_uuid to the canonical board_climbs row
-  // without needing to know board_type up front.
+  // Not a canonical row — check whether it's a non-canonical alias. We don't
+  // know the board up front, so join straight from alias_uuid to the canonical
+  // board_climbs row and take the board/layout from there. Bounded by the
+  // number of boards a single alias_uuid can appear under (one row per board
+  // at most, by the alias PK), so no LIMIT is needed.
   const viaAlias = await db
     .select({ boardType: dbSchema.boardClimbs.boardType, layoutId: dbSchema.boardClimbs.layoutId })
     .from(dbSchema.boardClimbAliases)
     .innerJoin(dbSchema.boardClimbs, eq(dbSchema.boardClimbs.uuid, dbSchema.boardClimbAliases.canonicalUuid))
-    .where(eq(dbSchema.boardClimbAliases.aliasUuid, climbUuid))
-    .limit(1);
+    .where(eq(dbSchema.boardClimbAliases.aliasUuid, climbUuid));
 
-  if (viaAlias.length > 0) return viaAlias[0];
+  if (viaAlias.length > 0) return viaAlias;
 
   logger.warn(
     'addClimbToPlaylist: climb uuid not found in board_climbs or board_climb_aliases; allowing add (fail-open)',
@@ -64,7 +72,19 @@ async function resolveClimbBoardScope(climbUuid: string): Promise<ClimbBoardScop
       climbUuid,
     },
   );
-  return null;
+  return [];
+}
+
+// The playlist side of the same rule playlistsForClimb / playlistsForClimbs
+// use to scope membership: the boards must match, and a playlist pinned to one
+// layout only takes climbs from that layout (a null layoutId — how Aurora- and
+// Kilter-synced circuits arrive — takes any layout of its own board).
+function climbFitsPlaylistBoard(
+  climbScope: ClimbBoardScope,
+  playlistScope: { boardType: string; layoutId: number | null },
+): boolean {
+  if (climbScope.boardType !== playlistScope.boardType) return false;
+  return playlistScope.layoutId === null || climbScope.layoutId === playlistScope.layoutId;
 }
 
 function playlistResult(playlist: dbSchema.Playlist, climbCount: number): Record<string, unknown> {
@@ -355,18 +375,24 @@ export const playlistMutations = {
     // board/layout doesn't match the playlist's. This mirrors the exact rule
     // playlistsForClimb / playlistsForClimbs already use to scope membership
     // (board_type match + layout_id match-or-null) — without it, an add could
-    // succeed here while the membership refetch silently excludes it,
-    // making the UI checkmark vanish. #4268 already stops the mobile picker
-    // from offering a mismatched playlist as a target; this is the
-    // server-side backstop for stale clients and the deprecated web picker
-    // (packages/web, no longer maintained per #3122, is still unfiltered).
-    const climbBoardScope = await resolveClimbBoardScope(validatedInput.climbUuid);
-    if (climbBoardScope) {
-      const boardMismatch = climbBoardScope.boardType !== ownership[0].boardType;
-      const layoutMismatch = ownership[0].layoutId !== null && climbBoardScope.layoutId !== ownership[0].layoutId;
-      if (boardMismatch || layoutMismatch) {
-        throw new Error('This playlist is for a different board');
-      }
+    // succeed here while the membership refetch silently excludes it, making
+    // the UI checkmark vanish on the next fetch and leaving a row the climber
+    // can no longer untick. #4268 already stops the mobile picker from
+    // offering a mismatched playlist as a target; this is the server-side
+    // backstop for every client that predates it — OTA rollout takes days to
+    // reach the whole fleet, and offline queues can replay an add that was
+    // composed before the update landed.
+    const climbBoardScopes = await resolveClimbBoardScopes(validatedInput.climbUuid);
+    if (climbBoardScopes.length > 0 && !climbBoardScopes.some((scope) => climbFitsPlaylistBoard(scope, ownership[0]))) {
+      // A GraphQLError with a BAD_USER_INPUT code rather than a bare Error: the
+      // rejection is a client-input verdict the app can branch on, and it keeps
+      // the guard out of the "unexpected server failure" bucket. The message
+      // still reaches clients verbatim (mask-error.ts only sanitizes raw
+      // database errors), and the mobile picker turns any rejection into its
+      // own translated "couldn't add" line — the wire text is never shown.
+      throw new GraphQLError('This playlist is for a different board', {
+        extensions: { code: 'BAD_USER_INPUT' },
+      });
     }
 
     // Insert-or-noop + position assignment share one transaction: a plain


### PR DESCRIPTION
## Summary

Closes #4015.

`addClimbToPlaylist` only checked ownership — not whether the climb being added
belongs to the playlist's board and layout. A cross-board add (a Kilter climb
into a Tension playlist) inserted a `playlist_climbs` row and ticked the
checkmark optimistically, then the board-scoped membership refetch
(`playlistsForClimb` / `playlistsForClimbs`, which filter on
`board_type = X AND (layout_id = Y OR layout_id IS NULL)`) dropped it again.
The checkmark vanished, and tapping a second time couldn't remove the row —
the UI no longer believed the climb was in there.

#4268 fixed the client-visible half on mobile: `InlinePlaylistPicker` now only
offers playlists on the climb's own board, so an up-to-date app can't pick a
mismatched target. This PR is the server-side half — the same rule enforced in
`addClimbToPlaylist`, so a client that predates #4268 (OTA rollout takes days
to reach the fleet) or an offline queue replaying an add composed before the
update can't leave an unreachable row behind either.

## Release Notes

- Adding a climb to a playlist from another board now fails cleanly instead of
  leaving a ghost entry you can't tap off again.

## What changed

`packages/backend/src/graphql/resolvers/playlists/mutations.ts`:

- The existing ownership `SELECT` also returns the playlist's
  `boardType`/`layoutId` — no extra round trip.
- `resolveClimbBoardScopes(climbUuid)` looks up the climb's own
  `boardType`/`layoutId` in `board_climbs`, falling back to
  `board_climb_aliases` (canonical-uuid join) when the uuid isn't itself a
  canonical row — the alias-read pattern from
  `packages/db/src/queries/aliases.ts`. It returns *every* scope the uuid can
  resolve to: the alias PK is `(board_type, alias_uuid)`, so one alias uuid can
  carry a row under two boards, and an unordered `LIMIT 1` would have made the
  guard's verdict depend on Postgres row order.
- `climbFitsPlaylistBoard` holds the match rule, mirroring the membership query
  exactly: boards must match, and a playlist pinned to a layout only takes that
  layout (`layout_id IS NULL` — how Aurora- and Kilter-synced circuits arrive —
  takes any layout of its own board). The add is accepted when *any* resolved
  scope fits, so an ambiguous uuid is never rejected on a coin flip.
- Rejection is a `GraphQLError` with `extensions.code = 'BAD_USER_INPUT'`, so a
  client can tell "wrong playlist" apart from a server failure worth retrying,
  and the offline outbox keeps classifying it as non-retryable (dead-letter,
  not an endless replay). The mobile picker already reverts the optimistic
  checkmark and shows its own translated "couldn't add" line on any rejection,
  so nothing user-facing depends on the wire text.
- The guard runs *before* the insert-or-noop transaction, so it doesn't widen
  the transaction window the race-handling comments in this file bound.
- **Fails open** (allows the add, logs a `logger.warn`) when the uuid resolves
  to no `board_climbs` row even after alias resolution — see below.

Not touched: `playlistsForClimb` / `playlistsForClimbs` (already correct, and
now agree with both the mobile picker and this guard), the mobile picker
itself (#4268), and cross-board `playlist_climbs` rows already in the database
(a cleanup pass is data deletion and needs sign-off).

## Notes

- **Fail-open on an unknown climb uuid.** A uuid with no `board_climbs` row and
  no alias is allowed through with a warning: the catalog row can legitimately
  lag behind create-climb and offline-sync writes, and rejecting would break
  those flows for the sake of a defense-in-depth guard. The add still has to
  pass playlist ownership and the table's own constraints. Happy to flip this
  to fail-closed if you'd rather be strict.
- Mobile Discover can still show climbs from a board other than the active
  board config (#3996). The picker there is scoped to the *active* board, so an
  add for such a climb now surfaces a "couldn't add" error where it used to
  produce the ghost row. That is the honest outcome of the same bug; the real
  fix is #3996's board-aware feed.

## Test plan

`packages/backend/src/__tests__/add-climb-to-playlist-board-guard.test.ts`
(real Postgres, modeled on `add-climb-to-playlist-race.test.ts` /
`playlist-role-matrix.test.ts`):

- same-board, same-layout add succeeds
- cross-board add rejected, with `BAD_USER_INPUT` on the error
- same-board layout mismatch rejected when the playlist pins a `layoutId`
- `layoutId = NULL` playlist accepts any layout of its own board
- `layoutId = NULL` playlist still rejects a different board
- unknown climb uuid fails open — the add still succeeds
- alias uuid resolving to a canonical climb on the right board accepted
- alias uuid resolving to a canonical climb on the wrong board rejected
- alias uuid resolving under *two* boards accepted for the board that fits, and
  rejected when neither fits (the row-order case above)

Regression cover that must stay green: `add-climb-to-playlist-race.test.ts`
(the guard sits outside the `onConflictDoNothing` retry transaction) and
`playlist-role-matrix.test.ts` (ownership-check ordering unchanged).

Local validation: `vp run typecheck:backend` and `vp check` clean. Backend
Vitest is left to CI — this machine runs several worktrees against the same
Postgres worker DBs, so local backend runs report noise rather than signal.
