### PR TITLE
fix(shared): carry a frame count on party playback so peers detect reader skew

### DIFF
--- a/packages/backend/src/__tests__/playback-state-validation.test.ts
+++ b/packages/backend/src/__tests__/playback-state-validation.test.ts
@@ -39,6 +39,10 @@ describe('PlaybackStateInputSchema', () => {
   it.each([
     ['negative frame index', { frameIndex: -1 }],
     ['fractional frame index', { frameIndex: 0.5 }],
+    ['zero frame count', { frameCount: 0 }],
+    ['negative frame count', { frameCount: -3 }],
+    ['fractional frame count', { frameCount: 4.5 }],
+    ['frame count above GraphQL Int maximum', { frameCount: GRAPHQL_INT_MAX + 1 }],
     ['frame index above GraphQL Int maximum', { frameIndex: GRAPHQL_INT_MAX + 1 }],
     ['speed below the control minimum', { speed: 0.49 }],
     ['speed above the control maximum', { speed: 10.01 }],
@@ -61,6 +65,8 @@ describe('PlaybackStateInputSchema', () => {
     ['negative infinite speed', { speed: -Infinity }],
     ['NaN pace', { paceMs: Number.NaN }],
     ['infinite pace', { paceMs: Infinity }],
+    ['NaN frame count', { frameCount: Number.NaN }],
+    ['infinite frame count', { frameCount: Infinity }],
   ])('rejects %s', (_description, overrides) => {
     expect(PlaybackStateInputSchema.safeParse(playbackStateWith(overrides)).success).toBe(false);
   });
@@ -72,6 +78,7 @@ describe('PlaybackStateInputSchema', () => {
     ['string playing state', { isPlaying: 'true' }],
     ['numeric climb identifier', { climbUuid: 1 }],
     ['numeric client identifier', { clientId: 1 }],
+    ['string frame count', { frameCount: '4' }],
   ])('does not coerce a %s', (_description, overrides) => {
     expect(PlaybackStateInputSchema.safeParse(playbackStateWith(overrides)).success).toBe(false);
   });
@@ -89,5 +96,20 @@ describe('PlaybackStateInputSchema', () => {
   it('accepts an omitted or null client identifier for connection-id fallback', () => {
     expect(PlaybackStateInputSchema.safeParse(validPlaybackState).success).toBe(true);
     expect(PlaybackStateInputSchema.safeParse(playbackStateWith({ clientId: null })).success).toBe(true);
+  });
+
+  // Issue #3989: peers compare the publisher's frame count against their own to
+  // spot a frames-reader disagreement. Clients older than the field publish
+  // without it, so the field has to stay optional and nullable forever.
+  it('accepts an omitted or null frame count from clients that predate the field', () => {
+    expect(PlaybackStateInputSchema.parse(validPlaybackState).frameCount).toBeUndefined();
+    expect(PlaybackStateInputSchema.parse(playbackStateWith({ frameCount: null })).frameCount).toBeNull();
+  });
+
+  it('accepts a frame count from 1 up to the GraphQL Int maximum', () => {
+    expect(PlaybackStateInputSchema.parse(playbackStateWith({ frameCount: 1 })).frameCount).toBe(1);
+    expect(PlaybackStateInputSchema.parse(playbackStateWith({ frameCount: GRAPHQL_INT_MAX })).frameCount).toBe(
+      GRAPHQL_INT_MAX,
+    );
   });
 });

--- a/packages/backend/src/__tests__/publish-playback-state.test.ts
+++ b/packages/backend/src/__tests__/publish-playback-state.test.ts
@@ -62,6 +62,7 @@ const climbUuid = '11111111-1111-1111-1111-111111111111';
 const validPlaybackInput = {
   climbUuid,
   frameIndex: 3,
+  frameCount: 21,
   isPlaying: true,
   speed: 1.5,
   paceMs: 250,
@@ -90,6 +91,7 @@ describe('publishPlaybackState mutation', () => {
         __typename: string;
         climbUuid: string;
         frameIndex: number;
+        frameCount: number | null;
         isPlaying: boolean;
         speed: number;
         paceMs: number;
@@ -103,6 +105,7 @@ describe('publishPlaybackState mutation', () => {
     expect(event.__typename).toBe('PlaybackStateChanged');
     expect(event.climbUuid).toBe(climbUuid);
     expect(event.frameIndex).toBe(3);
+    expect(event.frameCount).toBe(21);
     expect(event.isPlaying).toBe(true);
     expect(event.speed).toBe(1.5);
     expect(event.paceMs).toBe(250);
@@ -130,6 +133,28 @@ describe('publishPlaybackState mutation', () => {
     );
     const event = pubsubMock.publishQueueEvent.mock.calls[0]?.[1] as { clientId: string | null };
     expect(event.clientId).toBeNull();
+  });
+
+  // Issue #3989: receivers use frameCount to notice they read this climb's
+  // frames differently to the publisher. Clients older than the field omit it,
+  // and those must still broadcast — as null, so receivers fall back to the
+  // legacy clamp rather than treating "no count" as a mismatch.
+  it('emits a null frameCount when the publisher predates the field', async () => {
+    await queueMutations.publishPlaybackState(
+      undefined,
+      {
+        input: {
+          climbUuid,
+          frameIndex: 1,
+          isPlaying: true,
+          speed: 1,
+          paceMs: 300,
+        },
+      },
+      makeCtx(),
+    );
+    const event = pubsubMock.publishQueueEvent.mock.calls[0]?.[1] as { frameCount: number | null };
+    expect(event.frameCount).toBeNull();
   });
 
   it('prefers the publisher-supplied clientId over the connection id', async () => {

--- a/packages/backend/src/graphql/resolvers/queue/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/queue/mutations.ts
@@ -533,6 +533,10 @@ export const queueMutations = {
       sequence: currentState.sequence,
       climbUuid: validatedInput.climbUuid,
       frameIndex: validatedInput.frameIndex,
+      // Forwarded verbatim so receivers can compare it to their own frame list.
+      // Null for publishers that predate the field — receivers fall back to the
+      // legacy clamp when they have nothing to compare against.
+      frameCount: validatedInput.frameCount ?? null,
       isPlaying: validatedInput.isPlaying,
       speed: validatedInput.speed,
       paceMs: validatedInput.paceMs,

--- a/packages/backend/src/validation/schemas/playback.ts
+++ b/packages/backend/src/validation/schemas/playback.ts
@@ -19,6 +19,18 @@ export const PlaybackStateInputSchema = z.object({
     .int('Frame index must be an integer')
     .min(0, 'Frame index cannot be negative')
     .max(GRAPHQL_INT_MAX, 'Frame index is too large'),
+  // How many frames the publisher's reader produced. Optional and nullable so
+  // clients that predate the field keep publishing successfully. A broadcast
+  // only happens for a climb with frames, so 1 is the floor — a 0 would mean
+  // the publisher had nothing to play and should not have broadcast at all.
+  frameCount: z
+    .number()
+    .finite('Frame count must be finite')
+    .int('Frame count must be an integer')
+    .min(1, 'Frame count must be at least 1')
+    .max(GRAPHQL_INT_MAX, 'Frame count is too large')
+    .nullable()
+    .optional(),
   isPlaying: z.boolean(),
   speed: z
     .number()

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -969,6 +969,7 @@ export function PlayDrawer({
                           isPlaying={playback.isPlaying}
                           speed={playback.speed}
                           paceMs={playback.paceMs}
+                          peerFrameMismatch={playback.peerFrameMismatch}
                           onPlay={playback.play}
                           onPause={playback.pause}
                           onSeek={playback.seek}

--- a/packages/mobile/src/components/play-drawer/PlaybackControls.tsx
+++ b/packages/mobile/src/components/play-drawer/PlaybackControls.tsx
@@ -52,6 +52,11 @@ type PlaybackControlsProps = {
   speed: number;
   /** Native per-frame pace (ms) — glides the progress cue at the playback cadence. */
   paceMs: number;
+  /**
+   * A party peer is counting this route's frames differently, so their
+   * playback isn't being followed. Renders a one-line passive notice.
+   */
+  peerFrameMismatch?: boolean;
   onPlay: () => void;
   onPause: () => void;
   onSeek: (index: number) => void;
@@ -305,6 +310,7 @@ export function PlaybackControls({
   isPlaying,
   speed,
   paceMs,
+  peerFrameMismatch = false,
   onPlay,
   onPause,
   onSeek,
@@ -444,6 +450,12 @@ export function PlaybackControls({
         </View>
       </View>
 
+      {peerFrameMismatch && (
+        <Text variant="caption1" color={systemColors.secondaryLabel} style={styles.mismatchNotice}>
+          {t('playView.peerFrameMismatch')}
+        </Text>
+      )}
+
       {showSpeed && (
         <Animated.View entering={FadeIn.duration(timing.fast)} exiting={FadeOut.duration(timing.instant)}>
           <SpeedSlider value={speed} onChange={onSpeedChange} onLiveChange={setLiveSpeed} />
@@ -515,6 +527,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing[3],
     paddingVertical: spacing[1],
     borderRadius: borderRadius.full,
+  },
+  mismatchNotice: {
+    textAlign: 'center',
   },
   speedPillText: {
     fontVariant: ['tabular-nums'],

--- a/packages/mobile/src/components/play-drawer/__tests__/use-mobile-playback.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-mobile-playback.test.ts
@@ -9,15 +9,17 @@ import type { BoardName, Climb, PlaybackStateChangedEvent } from '@boardsesh/sha
 // latest-wins GATT-safe drain, the climb-change reset, and party-sync wiring.
 
 type EngineInput = {
-  externalState?: { clientId: string | null } | null;
+  externalState?: { clientId: string | null; frameCount?: number | null } | null;
   onLocalStateChange?: (state: {
     frameIndex: number;
+    frameCount: number;
     isPlaying: boolean;
     speed: number;
     paceMs: number;
     anchorTimestamp: number;
     clientId: string | null;
   }) => void;
+  onPeerFrameMismatch?: (mismatch: { peerFrameCount: number; localFrameCount: number }) => void;
 };
 
 type SendCall = { frame: string; mirrored?: boolean; resolve: (value: boolean) => void };
@@ -33,6 +35,7 @@ const mocks = vi.hoisted(() => ({
     currentFrameString: '',
     isPlaying: false,
     speed: 1,
+    peerFrameMismatch: false,
     play: vi.fn(),
     pause: vi.fn(),
     seek: vi.fn(),
@@ -46,6 +49,7 @@ const mocks = vi.hoisted(() => ({
   // clear the externally-synced state.
   subscribeToPlaybackEvents: null as unknown as (listener: (event: PlaybackStateChangedEvent) => void) => () => void,
   queueValue: null as unknown as { subscribeToPlaybackEvents: unknown; publishPlaybackState: unknown },
+  track: vi.fn(),
   bluetooth: {
     isConnected: true,
     sendFramesToBoard: vi.fn() as ReturnType<typeof vi.fn>,
@@ -78,6 +82,10 @@ vi.mock('../../../providers/queue-provider', () => ({
 
 vi.mock('../../../providers/bluetooth-provider', () => ({
   useOptionalBluetoothContext: () => mocks.bluetooth,
+}));
+
+vi.mock('../../../lib/analytics', () => ({
+  track: mocks.track,
 }));
 
 import { useMobilePlayback } from '../use-mobile-playback';
@@ -115,6 +123,7 @@ beforeEach(() => {
   mocks.playback.currentFrameString = '';
   mocks.playback.isPlaying = false;
   mocks.playback.speed = 1;
+  mocks.playback.peerFrameMismatch = false;
   mocks.lastEngineInput.current = null;
   mocks.playbackEventListeners.clear();
   mocks.bluetooth.isConnected = true;
@@ -271,6 +280,7 @@ describe('useMobilePlayback — party-sync', () => {
     act(() => {
       mocks.lastEngineInput.current?.onLocalStateChange?.({
         frameIndex: 1,
+        frameCount: 3,
         isPlaying: true,
         speed: 2,
         paceMs: 500,
@@ -283,5 +293,56 @@ describe('useMobilePlayback — party-sync', () => {
     const published = mocks.publishPlaybackState.mock.calls[0][0];
     expect(published).toMatchObject({ climbUuid: 'c1', frameIndex: 1, isPlaying: true, speed: 2, paceMs: 500 });
     expect(typeof published.clientId).toBe('string');
+  });
+
+  // Issue #3989: the broadcast carries how many frames OUR reader produced, so a
+  // peer on a different frames reader can tell its index means something else
+  // rather than clamping it into range and freezing on the last frame.
+  it('publishes the frame count the engine reports', () => {
+    renderPlayback(climbWith('c1'));
+
+    act(() => {
+      mocks.lastEngineInput.current?.onLocalStateChange?.({
+        frameIndex: 4,
+        frameCount: 21,
+        isPlaying: true,
+        speed: 1,
+        paceMs: 500,
+        anchorTimestamp: 1700,
+        clientId: 'self',
+      });
+    });
+
+    expect(mocks.publishPlaybackState.mock.calls[0][0]).toMatchObject({ frameCount: 21 });
+  });
+
+  it('passes a peer frame count through to the engine, and null when absent', () => {
+    const { rerender } = renderPlayback(climbWith('c1'));
+
+    emitPlayback(playbackEvent({ climbUuid: 'c1', frameCount: 21 }));
+    expect(mocks.lastEngineInput.current?.externalState?.frameCount).toBe(21);
+
+    // A publisher older than the field sends nothing; the engine must see null
+    // rather than a stale count from the previous event.
+    act(() => {
+      rerender({ climb: climbWith('c1') });
+    });
+    emitPlayback(playbackEvent({ climbUuid: 'c1', frameCount: undefined }));
+    expect(mocks.lastEngineInput.current?.externalState?.frameCount).toBeNull();
+  });
+
+  it('reports a peer frame-count disagreement to analytics', () => {
+    renderPlayback(climbWith('c1'));
+
+    act(() => {
+      mocks.lastEngineInput.current?.onPeerFrameMismatch?.({ peerFrameCount: 21, localFrameCount: 11 });
+    });
+
+    expect(mocks.track).toHaveBeenCalledTimes(1);
+    expect(mocks.track).toHaveBeenLastCalledWith('Playback Peer Frame Mismatch', {
+      peerFrameCount: 21,
+      localFrameCount: 11,
+      boardName: KILTER,
+    });
   });
 });

--- a/packages/mobile/src/components/play-drawer/use-mobile-playback.ts
+++ b/packages/mobile/src/components/play-drawer/use-mobile-playback.ts
@@ -1,6 +1,14 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
-import { useClimbFrames, usePlaybackEngine, type ExternalPlaybackState } from '@boardsesh/playback-react';
+import {
+  useClimbFrames,
+  usePlaybackEngine,
+  type ExternalPlaybackState,
+  type LocalPlaybackState,
+  type PeerFrameMismatch,
+} from '@boardsesh/playback-react';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { track } from '../../lib/analytics';
 import { useQueueActions } from '../../providers/queue-provider';
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
 
@@ -32,6 +40,12 @@ export type UseMobilePlaybackOutput = {
   speed: number;
   /** Native per-frame pace (ms) — lets the UI glide a progress cue at the playback cadence. */
   paceMs: number;
+  /**
+   * True while a party peer is counting this climb's frames differently to us
+   * (they're on a build with a different frames reader). We stop following
+   * their playback rather than jumping to a frame that doesn't line up.
+   */
+  peerFrameMismatch: boolean;
   play: () => void;
   pause: () => void;
   seek: (frameIndex: number) => void;
@@ -74,6 +88,9 @@ export function useMobilePlayback({
       if (event.climbUuid !== climbUuid) return;
       setExternalPlayback({
         frameIndex: event.frameIndex,
+        // Null from peers that predate the field — the engine falls back to its
+        // legacy clamp when there's nothing to compare against.
+        frameCount: event.frameCount ?? null,
         isPlaying: event.isPlaying,
         speed: event.speed,
         paceMs: event.paceMs,
@@ -85,11 +102,14 @@ export function useMobilePlayback({
   }, [climbUuid, subscribeToPlaybackEvents]);
 
   const handleLocalStateChange = useCallback(
-    (next: ExternalPlaybackState) => {
+    (next: LocalPlaybackState) => {
       if (!climbUuid) return;
       void publishPlaybackState({
         climbUuid,
         frameIndex: next.frameIndex,
+        // Lets peers notice we read this climb's frames differently instead of
+        // clamping our index into their range (issue #3989).
+        frameCount: next.frameCount,
         isPlaying: next.isPlaying,
         speed: next.speed,
         paceMs: next.paceMs,
@@ -99,6 +119,19 @@ export function useMobilePlayback({
     [climbUuid, publishPlaybackState, playbackClientId],
   );
 
+  // Telemetry seam for the frame-count disagreement. Fires once per stretch of
+  // mismatched peer events, so a stale peer scrubbing a slider can't flood it.
+  const handlePeerFrameMismatch = useCallback(
+    ({ peerFrameCount, localFrameCount }: PeerFrameMismatch) => {
+      track(SHARED_EVENTS.PlaybackPeerFrameMismatch, {
+        peerFrameCount,
+        localFrameCount,
+        boardName,
+      });
+    },
+    [boardName],
+  );
+
   const playback = usePlaybackEngine({
     frames,
     frameStrings,
@@ -106,6 +139,7 @@ export function useMobilePlayback({
     clientId: playbackClientId,
     externalState: externalPlayback,
     onLocalStateChange: handleLocalStateChange,
+    onPeerFrameMismatch: handlePeerFrameMismatch,
   });
 
   // --- Latest-wins BLE frame writer ---
@@ -189,6 +223,7 @@ export function useMobilePlayback({
       isPlaying: playback.isPlaying,
       speed: playback.speed,
       paceMs,
+      peerFrameMismatch: playback.peerFrameMismatch,
       play,
       pause: playback.pause,
       seek: playback.seek,

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -1332,6 +1332,7 @@ export const QUEUE_UPDATES_SUBSCRIPTION = `
         sequence
         climbUuid
         frameIndex
+        frameCount
         isPlaying
         speed
         paceMs

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -7039,6 +7039,18 @@ input PlaybackStateInput {
   climbUuid: ID!
   "Frame index that became current at `anchorTimestamp`."
   frameIndex: Int!
+  """
+  Number of frames the publisher's frames reader produced for this climb.
+  Receivers compare it against their own frame list and stop following the
+  peer on a mismatch instead of clamping `frameIndex` into range — a clamp
+  turns a skew into a board stuck on its last frame. Null from clients that
+  predate this field.
+
+  Forward protection only: a peer that doesn't send the field can't be
+  checked, so this does nothing for frames-reader changes that already
+  shipped. It starts protecting from the next one.
+  """
+  frameCount: Int
   "Whether the engine is auto-advancing."
   isPlaying: Boolean!
   "Playback multiplier (1.0 = native pace)."
@@ -7066,6 +7078,12 @@ type PlaybackStateChanged {
   climbUuid: ID!
   "Frame index that was current at `anchorTimestamp`"
   frameIndex: Int!
+  """
+  Number of frames the publisher's frames reader produced. Receivers compare
+  it against their own frame list and stop following on a mismatch rather
+  than clamping. Null from publishers that predate the field.
+  """
+  frameCount: Int
   "Whether the engine is auto-advancing"
   isPlaying: Boolean!
   "Playback multiplier (1.0 = native pace)"

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -4312,6 +4312,12 @@ export type PlaybackStateChanged = {
   clientId?: Maybe<Scalars['ID']['output']>;
   /** UUID of the climb whose playback changed */
   climbUuid: Scalars['ID']['output'];
+  /**
+   * Number of frames the publisher's frames reader produced. Receivers compare
+   * it against their own frame list and stop following on a mismatch rather
+   * than clamping. Null from publishers that predate the field.
+   */
+  frameCount?: Maybe<Scalars['Int']['output']>;
   /** Frame index that was current at `anchorTimestamp` */
   frameIndex: Scalars['Int']['output'];
   /** Whether the engine is auto-advancing */
@@ -4338,6 +4344,18 @@ export type PlaybackStateInput = {
   clientId?: InputMaybe<Scalars['ID']['input']>;
   /** Climb the playback applies to. Peers ignore the event if it's for a different climb than they're showing. */
   climbUuid: Scalars['ID']['input'];
+  /**
+   * Number of frames the publisher's frames reader produced for this climb.
+   * Receivers compare it against their own frame list and stop following the
+   * peer on a mismatch instead of clamping `frameIndex` into range — a clamp
+   * turns a skew into a board stuck on its last frame. Null from clients that
+   * predate this field.
+   *
+   * Forward protection only: a peer that doesn't send the field can't be
+   * checked, so this does nothing for frames-reader changes that already
+   * shipped. It starts protecting from the next one.
+   */
+  frameCount?: InputMaybe<Scalars['Int']['input']>;
   /** Frame index that became current at `anchorTimestamp`. */
   frameIndex: Scalars['Int']['input'];
   /** Whether the engine is auto-advancing. */
@@ -11029,6 +11047,7 @@ export type PlaybackStateChangedResolvers<
   anchorTimestamp?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   clientId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   climbUuid?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  frameCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   frameIndex?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   isPlaying?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   paceMs?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;

--- a/packages/shared-schema/src/schema/events.ts
+++ b/packages/shared-schema/src/schema/events.ts
@@ -324,6 +324,18 @@ export const eventsTypeDefs = /* GraphQL */ `
     climbUuid: ID!
     "Frame index that became current at \`anchorTimestamp\`."
     frameIndex: Int!
+    """
+    Number of frames the publisher's frames reader produced for this climb.
+    Receivers compare it against their own frame list and stop following the
+    peer on a mismatch instead of clamping \`frameIndex\` into range — a clamp
+    turns a skew into a board stuck on its last frame. Null from clients that
+    predate this field.
+
+    Forward protection only: a peer that doesn't send the field can't be
+    checked, so this does nothing for frames-reader changes that already
+    shipped. It starts protecting from the next one.
+    """
+    frameCount: Int
     "Whether the engine is auto-advancing."
     isPlaying: Boolean!
     "Playback multiplier (1.0 = native pace)."
@@ -351,6 +363,12 @@ export const eventsTypeDefs = /* GraphQL */ `
     climbUuid: ID!
     "Frame index that was current at \`anchorTimestamp\`"
     frameIndex: Int!
+    """
+    Number of frames the publisher's frames reader produced. Receivers compare
+    it against their own frame list and stop following on a mismatch rather
+    than clamping. Null from publishers that predate the field.
+    """
+    frameCount: Int
     "Whether the engine is auto-advancing"
     isPlaying: Boolean!
     "Playback multiplier (1.0 = native pace)"

--- a/packages/shared-schema/src/types/events.ts
+++ b/packages/shared-schema/src/types/events.ts
@@ -27,6 +27,13 @@ export type PlaybackStateChangedEvent = {
   sequence: number;
   climbUuid: string;
   frameIndex: number;
+  /**
+   * Frames the publisher's reader produced for this climb. Optional: publishers
+   * that predate the field omit it, and legacy payloads must keep typechecking.
+   * Receivers stop following the peer when it disagrees with their own frame
+   * count rather than clamping the index into range.
+   */
+  frameCount?: number | null;
   isPlaying: boolean;
   speed: number;
   paceMs: number;

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -58,6 +58,14 @@ export const SHARED_EVENTS = {
   // title text.
   SessionRenamed: 'Session Renamed',
   AngleChanged: 'Angle Changed',
+  // A party peer broadcast a playback frame count that disagrees with ours, so
+  // the two clients read the same climb's frames differently and we stopped
+  // following them instead of clamping onto a wrong frame (issue #3989).
+  // Props: { peerFrameCount, localFrameCount, boardName } — counts only. Fires
+  // once per stretch of disagreement, not per broadcast. Expected to stay
+  // silent until the frames reader next changes shape; any volume at all means
+  // a mixed-fleet rollout is skewing playback in the field.
+  PlaybackPeerFrameMismatch: 'Playback Peer Frame Mismatch',
   // Queue sync-gate telemetry (createQueueSyncGate in @boardsesh/queue-runtime)
   // — observability for the sequence-gap / stale-event / hash-drift guards so
   // a resync loop or a dropped duplicate shows up in the field instead of only

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -4309,6 +4309,12 @@ export type PlaybackStateChanged = {
   clientId?: Maybe<Scalars['ID']['output']>;
   /** UUID of the climb whose playback changed */
   climbUuid: Scalars['ID']['output'];
+  /**
+   * Number of frames the publisher's frames reader produced. Receivers compare
+   * it against their own frame list and stop following on a mismatch rather
+   * than clamping. Null from publishers that predate the field.
+   */
+  frameCount?: Maybe<Scalars['Int']['output']>;
   /** Frame index that was current at `anchorTimestamp` */
   frameIndex: Scalars['Int']['output'];
   /** Whether the engine is auto-advancing */
@@ -4335,6 +4341,18 @@ export type PlaybackStateInput = {
   clientId?: InputMaybe<Scalars['ID']['input']>;
   /** Climb the playback applies to. Peers ignore the event if it's for a different climb than they're showing. */
   climbUuid: Scalars['ID']['input'];
+  /**
+   * Number of frames the publisher's frames reader produced for this climb.
+   * Receivers compare it against their own frame list and stop following the
+   * peer on a mismatch instead of clamping `frameIndex` into range — a clamp
+   * turns a skew into a board stuck on its last frame. Null from clients that
+   * predate this field.
+   *
+   * Forward protection only: a peer that doesn't send the field can't be
+   * checked, so this does nothing for frames-reader changes that already
+   * shipped. It starts protecting from the next one.
+   */
+  frameCount?: InputMaybe<Scalars['Int']['input']>;
   /** Frame index that became current at `anchorTimestamp`. */
   frameIndex: Scalars['Int']['input'];
   /** Whether the engine is auto-advancing. */

--- a/packages/shared/graphql/src/operations/queue-session.ts
+++ b/packages/shared/graphql/src/operations/queue-session.ts
@@ -487,6 +487,7 @@ export const EVENTS_REPLAY = `
           sequence
           climbUuid
           frameIndex
+          frameCount
           isPlaying
           speed
           paceMs
@@ -562,6 +563,7 @@ export const QUEUE_UPDATES = `
         sequence
         climbUuid
         frameIndex
+        frameCount
         isPlaying
         speed
         paceMs

--- a/packages/shared/i18n/locales/de/session.json
+++ b/packages/shared/i18n/locales/de/session.json
@@ -613,6 +613,7 @@
     "pause": "Pause",
     "replay": "Nochmal",
     "speed": "Wiedergabegeschwindigkeit",
+    "peerFrameMismatch": "Wiedergabe läuft eigenständig. Jemand in der Session nutzt eine andere App-Version, die die Bilder dieser Route anders liest.",
     "audienceCount_one": "{{count}} weitere Person schaut zu",
     "audienceCount_other": "{{count}} weitere Personen schauen zu",
     "yourAscents_one": "Deine Begehung ({{count}})",

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -613,6 +613,7 @@
     "pause": "Pause",
     "replay": "Replay",
     "speed": "Playback speed",
+    "peerFrameMismatch": "Playing on your own. Someone in the session is on a different app version that reads this route's frames differently.",
     "audienceCount_one": "{{count}} other watching",
     "audienceCount_other": "{{count}} others watching",
     "yourAscents_one": "Your Ascent ({{count}})",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -613,6 +613,7 @@
     "pause": "Pausar",
     "replay": "Repetir",
     "speed": "Velocidad de reproducción",
+    "peerFrameMismatch": "Reproduciendo por tu cuenta. Alguien de la sesión usa otra versión de la app que lee los fotogramas de esta vía de otra forma.",
     "audienceCount_one": "{{count}} más mirando",
     "audienceCount_other": "{{count}} más mirando",
     "yourAscents_one": "Tu ascenso ({{count}})",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -613,6 +613,7 @@
     "pause": "Pause",
     "replay": "Rejouer",
     "speed": "Vitesse de lecture",
+    "peerFrameMismatch": "Lecture en solo. Quelqu'un dans la session utilise une autre version de l'app qui lit les images de cette voie différemment.",
     "audienceCount_one": "{{count}} autre en train de regarder",
     "audienceCount_other": "{{count}} autres en train de regarder",
     "yourAscents_one": "Ton ascension ({{count}})",

--- a/packages/shared/playback-react/src/__tests__/use-playback-engine.test.ts
+++ b/packages/shared/playback-react/src/__tests__/use-playback-engine.test.ts
@@ -298,3 +298,214 @@ describe('usePlaybackEngine', () => {
     expect(result.current.isPlaying).toBe(false);
   });
 });
+
+// Issue #3989: the broadcast used to carry a bare frameIndex, so a peer running
+// a different frames reader (mid-rollout: web deploys instantly, mobile arrives
+// by OTA over days) sent indexes into a sequence we don't have. The old
+// behaviour clamped that index into our range, which made `reachedEnd` trivially
+// true and parked the board on its last frame for the rest of the climb.
+describe('usePlaybackEngine peer frame-count disagreement', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function peerState(overrides: Partial<ExternalPlaybackState> = {}): ExternalPlaybackState {
+    return {
+      frameIndex: 0,
+      isPlaying: false,
+      speed: 1,
+      paceMs: 200,
+      anchorTimestamp: Date.now(),
+      clientId: 'peer',
+      ...overrides,
+    };
+  }
+
+  it('ignores a peer whose frame count is larger than ours instead of clamping and stopping', () => {
+    const { frames, frameStrings } = decode(TENSION_FRAMES);
+    const onPeerFrameMismatch = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ externalState }: { externalState: ExternalPlaybackState | null }) =>
+        usePlaybackEngine({
+          frames,
+          frameStrings,
+          paceMs: 200,
+          clientId: 'self',
+          externalState,
+          onPeerFrameMismatch,
+        }),
+      { initialProps: { externalState: null as ExternalPlaybackState | null } },
+    );
+
+    // Local playback is under way at frame 1.
+    act(() => {
+      result.current.play();
+    });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current.frameIndex).toBe(1);
+
+    // A peer on a newer reader broadcasts an index from a 21-frame sequence.
+    rerender({
+      externalState: peerState({ frameIndex: 15, isPlaying: true, frameCount: 21 }),
+    });
+
+    // Not clamped to the last frame, not stopped, not reset to 0 — we keep
+    // playing our own sequence and simply stop following the peer.
+    expect(result.current.frameIndex).toBe(1);
+    expect(result.current.isPlaying).toBe(true);
+    expect(result.current.peerFrameMismatch).toBe(true);
+    expect(onPeerFrameMismatch).toHaveBeenCalledTimes(1);
+    expect(onPeerFrameMismatch).toHaveBeenLastCalledWith({ peerFrameCount: 21, localFrameCount: 4 });
+  });
+
+  it('ignores a peer whose frame count is smaller than ours', () => {
+    const { frames, frameStrings } = decode(TENSION_FRAMES);
+    const { result, rerender } = renderHook(
+      ({ externalState }: { externalState: ExternalPlaybackState | null }) =>
+        usePlaybackEngine({ frames, frameStrings, paceMs: 200, clientId: 'self', externalState }),
+      { initialProps: { externalState: null as ExternalPlaybackState | null } },
+    );
+    act(() => {
+      result.current.seek(3);
+    });
+    rerender({ externalState: peerState({ frameIndex: 0, isPlaying: true, frameCount: 2 }) });
+    expect(result.current.frameIndex).toBe(3);
+    expect(result.current.isPlaying).toBe(false);
+    expect(result.current.peerFrameMismatch).toBe(true);
+  });
+
+  it('fires the mismatch callback once per stretch of disagreement, not per event', () => {
+    const { frames, frameStrings } = decode(TENSION_FRAMES);
+    const onPeerFrameMismatch = vi.fn();
+    const { rerender } = renderHook(
+      ({ externalState }: { externalState: ExternalPlaybackState | null }) =>
+        usePlaybackEngine({
+          frames,
+          frameStrings,
+          paceMs: 200,
+          clientId: 'self',
+          externalState,
+          onPeerFrameMismatch,
+        }),
+      { initialProps: { externalState: null as ExternalPlaybackState | null } },
+    );
+    // A peer scrubbing a slider republishes constantly; only the first one
+    // should reach the telemetry seam.
+    for (const frameIndex of [4, 5, 6]) {
+      rerender({ externalState: peerState({ frameIndex, frameCount: 9 }) });
+    }
+    expect(onPeerFrameMismatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('converges normally when the peer reports the same frame count', () => {
+    const { frames, frameStrings } = decode(TENSION_FRAMES);
+    const onPeerFrameMismatch = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ externalState }: { externalState: ExternalPlaybackState | null }) =>
+        usePlaybackEngine({
+          frames,
+          frameStrings,
+          paceMs: 200,
+          clientId: 'self',
+          externalState,
+          onPeerFrameMismatch,
+        }),
+      { initialProps: { externalState: null as ExternalPlaybackState | null } },
+    );
+    rerender({
+      externalState: peerState({ frameIndex: 2, speed: 2, frameCount: frameStrings.length }),
+    });
+    expect(result.current.frameIndex).toBe(2);
+    expect(result.current.speed).toBe(2);
+    expect(result.current.peerFrameMismatch).toBe(false);
+    expect(onPeerFrameMismatch).not.toHaveBeenCalled();
+  });
+
+  it('keeps the legacy clamp for peers that send no frame count', () => {
+    const { frames, frameStrings } = decode(TENSION_FRAMES);
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const { result } = renderHook(() =>
+      usePlaybackEngine({
+        frames,
+        frameStrings,
+        paceMs: 200,
+        clientId: 'self',
+        externalState: peerState({ frameIndex: 99, isPlaying: true, anchorTimestamp: now }),
+      }),
+    );
+    // Unchanged pre-#3989 behaviour: an out-of-range index from a client that
+    // predates the field clamps to the last frame and stops.
+    expect(result.current.frameIndex).toBe(frameStrings.length - 1);
+    expect(result.current.isPlaying).toBe(false);
+    expect(result.current.peerFrameMismatch).toBe(false);
+  });
+
+  it('clears the mismatch once a peer agrees again, and on climb change', () => {
+    const { frames, frameStrings } = decode(TENSION_FRAMES);
+    const other = decode('p100r1,p200r2');
+    const { result, rerender } = renderHook(
+      ({ externalState, climb }: { externalState: ExternalPlaybackState | null; climb: ReturnType<typeof decode> }) =>
+        usePlaybackEngine({
+          frames: climb.frames,
+          frameStrings: climb.frameStrings,
+          paceMs: 200,
+          clientId: 'self',
+          externalState,
+        }),
+      { initialProps: { externalState: null as ExternalPlaybackState | null, climb: { frames, frameStrings } } },
+    );
+    rerender({ externalState: peerState({ frameCount: 12 }), climb: { frames, frameStrings } });
+    expect(result.current.peerFrameMismatch).toBe(true);
+
+    // Peer updated (or a different peer takes over) and now agrees.
+    rerender({
+      externalState: peerState({ frameIndex: 1, frameCount: frameStrings.length }),
+      climb: { frames, frameStrings },
+    });
+    expect(result.current.peerFrameMismatch).toBe(false);
+    expect(result.current.frameIndex).toBe(1);
+
+    // Back to a disagreement, then swap the climb underneath. Hosts drop the
+    // peer state on climb change (both use-mobile-playback and
+    // use-drawer-playback do), and the flag is per-climb, so it clears.
+    rerender({ externalState: peerState({ frameCount: 12 }), climb: { frames, frameStrings } });
+    expect(result.current.peerFrameMismatch).toBe(true);
+    rerender({ externalState: null, climb: other });
+    expect(result.current.peerFrameMismatch).toBe(false);
+  });
+
+  it('stamps our own frame count on every emitted state', () => {
+    const { frames, frameStrings } = decode(TENSION_FRAMES);
+    const onLocalStateChange = vi.fn();
+    const { result } = renderHook(() =>
+      usePlaybackEngine({ frames, frameStrings, paceMs: 200, clientId: 'self', onLocalStateChange }),
+    );
+    act(() => {
+      result.current.play();
+    });
+    expect(onLocalStateChange).toHaveBeenLastCalledWith(expect.objectContaining({ frameCount: frameStrings.length }));
+    act(() => {
+      result.current.setSpeed(2);
+    });
+    expect(onLocalStateChange).toHaveBeenLastCalledWith(expect.objectContaining({ frameCount: frameStrings.length }));
+  });
+
+  it('emits nothing for a frameless climb, so frameCount is never 0', () => {
+    const onLocalStateChange = vi.fn();
+    const { result } = renderHook(() =>
+      usePlaybackEngine({ frames: [], frameStrings: [], paceMs: 200, clientId: 'self', onLocalStateChange }),
+    );
+    // setSpeed is the one control not gated on isAnimatable.
+    act(() => {
+      result.current.setSpeed(2);
+    });
+    expect(onLocalStateChange).not.toHaveBeenCalled();
+    expect(result.current.speed).toBe(2);
+  });
+});

--- a/packages/shared/playback-react/src/__tests__/use-playback-engine.test.ts
+++ b/packages/shared/playback-react/src/__tests__/use-playback-engine.test.ts
@@ -480,6 +480,22 @@ describe('usePlaybackEngine peer frame-count disagreement', () => {
     expect(result.current.peerFrameMismatch).toBe(false);
   });
 
+  it('clears the mismatch when the host drops the peer state', () => {
+    const { frames, frameStrings } = decode(TENSION_FRAMES);
+    const { result, rerender } = renderHook(
+      ({ externalState }: { externalState: ExternalPlaybackState | null }) =>
+        usePlaybackEngine({ frames, frameStrings, paceMs: 200, clientId: 'self', externalState }),
+      { initialProps: { externalState: null as ExternalPlaybackState | null } },
+    );
+    rerender({ externalState: peerState({ frameCount: 12 }) });
+    expect(result.current.peerFrameMismatch).toBe(true);
+
+    // The mismatched peer left the session, so the host clears its state. The
+    // notice must not outlive the peer it describes.
+    rerender({ externalState: null });
+    expect(result.current.peerFrameMismatch).toBe(false);
+  });
+
   it('stamps our own frame count on every emitted state', () => {
     const { frames, frameStrings } = decode(TENSION_FRAMES);
     const onLocalStateChange = vi.fn();

--- a/packages/shared/playback-react/src/use-playback-engine.ts
+++ b/packages/shared/playback-react/src/use-playback-engine.ts
@@ -231,7 +231,12 @@ export function usePlaybackEngine({
   // out-of-range values would otherwise poison local state and get re-broadcast
   // on the next user action.
   useEffect(() => {
-    if (!externalState) return;
+    // Host dropped the peer state (climb change, session left). Nothing left to
+    // disagree with, so the notice shouldn't outlive it.
+    if (!externalState) {
+      updatePeerFrameMismatch(false);
+      return;
+    }
     if (externalState.clientId && externalState.clientId === clientId) return;
     if (frameStrings.length === 0) return;
     // Frame-count check first, before anything is clamped. A peer whose reader

--- a/packages/shared/playback-react/src/use-playback-engine.ts
+++ b/packages/shared/playback-react/src/use-playback-engine.ts
@@ -13,11 +13,43 @@ export type PlaybackSnapshot = {
   anchorTimestamp: number;
 };
 
+/**
+ * Peer state arriving over the wire. `frameCount` is optional and nullable
+ * because publishers older than the field omit it entirely — see
+ * `LocalPlaybackState` for the outbound shape, where it is always present.
+ */
 export type ExternalPlaybackState = PlaybackSnapshot & {
   /** Native per-frame pace from the climb metadata. */
   paceMs: number;
   /** Identifier of the client that produced this state. Used for echo suppression. */
   clientId: string | null;
+  /**
+   * Frames the publishing peer's reader produced. When it disagrees with our
+   * own frame list the two sides are counting frames differently and the
+   * event is ignored rather than clamped into range. Absent from peers that
+   * predate the field — those keep the legacy clamp.
+   */
+  frameCount?: number | null;
+};
+
+/**
+ * State the local engine emits for broadcast. Distinct from
+ * `ExternalPlaybackState` purely so `frameCount` can be required here (we
+ * always know our own frame count) while staying optional on the inbound side.
+ */
+export type LocalPlaybackState = PlaybackSnapshot & {
+  paceMs: number;
+  clientId: string | null;
+  /** Frames our reader produced for this climb. Always ≥ 1 — the engine never emits for a frameless climb. */
+  frameCount: number;
+};
+
+/** Details handed to `onPeerFrameMismatch` when a peer's frame count disagrees. */
+export type PeerFrameMismatch = {
+  /** Frames the peer reported. */
+  peerFrameCount: number;
+  /** Frames our own reader produced. */
+  localFrameCount: number;
 };
 
 type UsePlaybackEngineInput = {
@@ -32,7 +64,13 @@ type UsePlaybackEngineInput = {
    */
   externalState?: ExternalPlaybackState | null;
   /** Fires whenever the local engine produces a new state worth broadcasting. */
-  onLocalStateChange?: (state: ExternalPlaybackState) => void;
+  onLocalStateChange?: (state: LocalPlaybackState) => void;
+  /**
+   * Fires on the transition into a frame-count disagreement with a peer
+   * (once per stretch of mismatched events, not per event). Telemetry seam —
+   * the host wires it to its analytics transport.
+   */
+  onPeerFrameMismatch?: (mismatch: PeerFrameMismatch) => void;
 };
 
 export type UsePlaybackEngineOutput = {
@@ -45,6 +83,13 @@ export type UsePlaybackEngineOutput = {
   currentFrameString: string;
   /** Whether the engine has more than one frame (i.e. controls should render). */
   isAnimatable: boolean;
+  /**
+   * True while a peer is broadcasting a frame count that disagrees with ours,
+   * meaning the two clients read this climb's frames differently. Local
+   * playback keeps running on its own; the peer is simply not followed.
+   * Clears on climb change and as soon as a peer's count agrees again.
+   */
+  peerFrameMismatch: boolean;
   play: () => void;
   pause: () => void;
   seek: (frameIndex: number) => void;
@@ -69,12 +114,14 @@ export function usePlaybackEngine({
   clientId,
   externalState,
   onLocalStateChange,
+  onPeerFrameMismatch,
 }: UsePlaybackEngineInput): UsePlaybackEngineOutput {
   const isAnimatable = frameStrings.length > 1;
 
   const [frameIndex, setFrameIndex] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
   const [speed, setSpeedState] = useState(1);
+  const [peerFrameMismatch, setPeerFrameMismatch] = useState(false);
 
   // Refs so the timer callback doesn't capture stale state.
   const frameIndexRef = useRef(frameIndex);
@@ -82,11 +129,17 @@ export function usePlaybackEngine({
   const speedRef = useRef(speed);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const onLocalStateChangeRef = useRef(onLocalStateChange);
+  const onPeerFrameMismatchRef = useRef(onPeerFrameMismatch);
+  // Mirrors `peerFrameMismatch` so the convergence effect only writes state on
+  // a real transition. A stale peer scrubbing a slider republishes constantly;
+  // without this every one of those events would queue a render.
+  const peerFrameMismatchRef = useRef(peerFrameMismatch);
 
   frameIndexRef.current = frameIndex;
   isPlayingRef.current = isPlaying;
   speedRef.current = speed;
   onLocalStateChangeRef.current = onLocalStateChange;
+  onPeerFrameMismatchRef.current = onPeerFrameMismatch;
 
   const clearTimer = () => {
     if (timerRef.current !== null) {
@@ -95,16 +148,29 @@ export function usePlaybackEngine({
     }
   };
 
-  // Reset to frame 0 + paused whenever the underlying climb changes.
+  const updatePeerFrameMismatch = useCallback((next: boolean) => {
+    if (peerFrameMismatchRef.current === next) return;
+    peerFrameMismatchRef.current = next;
+    setPeerFrameMismatch(next);
+  }, []);
+
+  // Reset to frame 0 + paused whenever the underlying climb changes. A frame
+  // disagreement is per-climb (it comes out of how each side read THIS climb's
+  // frames), so it clears here too.
   const framesKey = frameStrings.join('|');
   useEffect(() => {
     clearTimer();
     setFrameIndex(0);
     setIsPlaying(false);
-  }, [framesKey]);
+    updatePeerFrameMismatch(false);
+  }, [framesKey, updatePeerFrameMismatch]);
 
   const emitLocalState = useCallback(
     (nextIndex: number, nextIsPlaying: boolean, nextSpeed: number) => {
+      // A frameless climb has nothing to play and nothing meaningful to
+      // broadcast — `setSpeed` is the one control that isn't gated on
+      // `isAnimatable`, so without this it would publish frameCount: 0.
+      if (frameStrings.length === 0) return;
       onLocalStateChangeRef.current?.({
         frameIndex: nextIndex,
         isPlaying: nextIsPlaying,
@@ -112,9 +178,10 @@ export function usePlaybackEngine({
         anchorTimestamp: Date.now(),
         paceMs,
         clientId,
+        frameCount: frameStrings.length,
       });
     },
-    [clientId, paceMs],
+    [clientId, paceMs, frameStrings.length],
   );
 
   // Timer driver: a single effect owns the timer for the whole engine life.
@@ -167,6 +234,27 @@ export function usePlaybackEngine({
     if (!externalState) return;
     if (externalState.clientId && externalState.clientId === clientId) return;
     if (frameStrings.length === 0) return;
+    // Frame-count check first, before anything is clamped. A peer whose reader
+    // produced a different number of frames is indexing a different sequence:
+    // its index N is not our frame N, and clamping it into our range would
+    // silently park us on the last frame and stop playback (issue #3989).
+    // Stop following instead and let the host say so. Peers that don't send a
+    // count (older than the field) keep the legacy clamp — there is nothing to
+    // compare against and same-version sessions must not regress.
+    const peerFrameCount = externalState.frameCount;
+    if (typeof peerFrameCount === 'number' && Number.isInteger(peerFrameCount) && peerFrameCount > 0) {
+      if (peerFrameCount !== frameStrings.length) {
+        if (!peerFrameMismatchRef.current) {
+          onPeerFrameMismatchRef.current?.({
+            peerFrameCount,
+            localFrameCount: frameStrings.length,
+          });
+        }
+        updatePeerFrameMismatch(true);
+        return;
+      }
+      updatePeerFrameMismatch(false);
+    }
     const safeSpeed = Number.isFinite(externalState.speed) ? Math.max(0.1, externalState.speed) : 1;
     const safePaceMs = Number.isFinite(externalState.paceMs)
       ? Math.max(MIN_PACE_MS, externalState.paceMs)
@@ -185,7 +273,7 @@ export function usePlaybackEngine({
     setFrameIndex(projected);
     setIsPlaying(externalState.isPlaying && !reachedEnd);
     setSpeedState(safeSpeed);
-  }, [externalState, clientId, frameStrings.length]);
+  }, [externalState, clientId, frameStrings.length, updatePeerFrameMismatch]);
 
   const play = useCallback(() => {
     if (!isAnimatable) return;
@@ -247,11 +335,24 @@ export function usePlaybackEngine({
       currentLitUpHoldsMap,
       currentFrameString,
       isAnimatable,
+      peerFrameMismatch,
       play,
       pause,
       seek,
       setSpeed,
     }),
-    [frameIndex, isPlaying, speed, currentLitUpHoldsMap, currentFrameString, isAnimatable, play, pause, seek, setSpeed],
+    [
+      frameIndex,
+      isPlaying,
+      speed,
+      currentLitUpHoldsMap,
+      currentFrameString,
+      isAnimatable,
+      peerFrameMismatch,
+      play,
+      pause,
+      seek,
+      setSpeed,
+    ],
   );
 }

--- a/packages/shared/queue-react/src/create-queue-mutations.ts
+++ b/packages/shared/queue-react/src/create-queue-mutations.ts
@@ -44,6 +44,13 @@ import {
 export type PublishPlaybackStateInput = {
   climbUuid: string;
   frameIndex: number;
+  /**
+   * Frames our reader produced for this climb. Peers compare it against their
+   * own list and stop following us when the two disagree instead of clamping
+   * our index into their range (issue #3989). Required here — a publisher
+   * always knows its own frame count.
+   */
+  frameCount: number;
   isPlaying: boolean;
   speed: number;
   paceMs: number;

--- a/packages/web/app/components/persistent-session/types.ts
+++ b/packages/web/app/components/persistent-session/types.ts
@@ -117,6 +117,12 @@ export type PersistentSessionActionsType = {
   publishPlaybackState: (input: {
     climbUuid: string;
     frameIndex: number;
+    /**
+     * Frames our reader produced for this climb. Peers stop following us when
+     * it disagrees with their own count rather than clamping our index into
+     * their range (issue #3989).
+     */
+    frameCount: number;
     isPlaying: boolean;
     speed: number;
     paceMs: number;

--- a/packages/web/app/components/play-view/use-drawer-playback.ts
+++ b/packages/web/app/components/play-view/use-drawer-playback.ts
@@ -7,7 +7,9 @@ import {
   usePlaybackEngine,
   type ExternalPlaybackState,
   type LocalPlaybackState,
+  type PeerFrameMismatch,
 } from '@boardsesh/playback-react/use-playback-engine';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { usePersistentSessionActions } from '../persistent-session';
 import { useBluetoothContext } from '../board-bluetooth-control/bluetooth-context';
 import { renderBoard } from '@/app/lib/board-render-worker/worker-manager';
@@ -110,6 +112,21 @@ export function useDrawerPlayback({
     [activeClimbUuid, publishPlaybackState, playbackClientId],
   );
 
+  // Telemetry only — the drawer shows no notice for this (the web climbing
+  // surface is frozen, #3122). Without it the event would be mobile-only and
+  // under-count how often a mixed fleet actually skews playback.
+  const handlePeerFrameMismatch = useCallback(
+    ({ peerFrameCount, localFrameCount }: PeerFrameMismatch) => {
+      track(SHARED_EVENTS.PlaybackPeerFrameMismatch, {
+        peerFrameCount,
+        localFrameCount,
+        boardName: boardDetails.board_name,
+        climbUuid: activeClimbUuid,
+      });
+    },
+    [boardDetails.board_name, activeClimbUuid],
+  );
+
   const playback = usePlaybackEngine({
     frames: climbFrames.frames,
     frameStrings: climbFrames.frameStrings,
@@ -117,6 +134,7 @@ export function useDrawerPlayback({
     clientId: playbackClientId,
     externalState: externalPlayback,
     onLocalStateChange: handleLocalPlaybackChange,
+    onPeerFrameMismatch: handlePeerFrameMismatch,
   });
 
   // Latest-wins BLE serialization: Web Bluetooth on Android can't cancel an

--- a/packages/web/app/components/play-view/use-drawer-playback.ts
+++ b/packages/web/app/components/play-view/use-drawer-playback.ts
@@ -3,7 +3,11 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import type { Climb, BoardDetails } from '@/app/lib/types';
 import { useClimbFrames } from '../board-renderer/util';
-import { usePlaybackEngine, type ExternalPlaybackState } from '@boardsesh/playback-react/use-playback-engine';
+import {
+  usePlaybackEngine,
+  type ExternalPlaybackState,
+  type LocalPlaybackState,
+} from '@boardsesh/playback-react/use-playback-engine';
 import { usePersistentSessionActions } from '../persistent-session';
 import { useBluetoothContext } from '../board-bluetooth-control/bluetooth-context';
 import { renderBoard } from '@/app/lib/board-render-worker/worker-manager';
@@ -72,6 +76,9 @@ export function useDrawerPlayback({
       if (event.climbUuid !== activeClimbUuid) return;
       setExternalPlayback({
         frameIndex: event.frameIndex,
+        // Null from peers that predate the field — the engine falls back to
+        // its legacy clamp when there's no count to compare against.
+        frameCount: event.frameCount ?? null,
         isPlaying: event.isPlaying,
         speed: event.speed,
         paceMs: event.paceMs,
@@ -83,11 +90,14 @@ export function useDrawerPlayback({
   }, [activeClimbUuid, subscribeToQueueEvents]);
 
   const handleLocalPlaybackChange = useCallback(
-    (state: ExternalPlaybackState) => {
+    (state: LocalPlaybackState) => {
       if (!activeClimbUuid) return;
       void publishPlaybackState({
         climbUuid: activeClimbUuid,
         frameIndex: state.frameIndex,
+        // Lets peers detect that we read this climb's frames differently
+        // instead of clamping our index into their range (issue #3989).
+        frameCount: state.frameCount,
         isPlaying: state.isPlaying,
         speed: state.speed,
         paceMs: state.paceMs,


### PR DESCRIPTION
Fixes #3989.

## The gap

`publishPlaybackState` broadcast a bare `frameIndex`. Nothing on the wire told a
receiver how many frames the publisher's reader produced, so it could not tell
that the two sides are indexing different sequences.

That only matters when the frames reader changes — but it changes, and web
deploys instantly while mobile arrives by OTA over days. During such a window
the receiver clamped the incoming index into its own range
(`use-playback-engine.ts`), which made `reachedEnd` trivially true and called
`setIsPlaying(false)`. A skew turned into a board stuck on its last frame for
the rest of the climb.

## What this does

- `PlaybackStateInput` and `PlaybackStateChanged` gain a **nullable** `frameCount`
  (nullable forever: clients older than the field neither send it nor select it).
- The shared engine stamps `frameCount: frameStrings.length` on every emission.
  No new broadcasts — it rides the existing user-action emissions (play / pause /
  seek / setSpeed), so the `RATE_LIMIT_PLAYBACK` budget is untouched.
- On receipt, **before** any clamping: if the peer's count is a positive integer
  and differs from ours, the event is ignored outright. Local playback keeps
  running at its own position, and `peerFrameMismatch` goes true.
- Mobile surfaces that as a one-line passive notice under the transport controls.
  Both platforms fire `Playback Peer Frame Mismatch` once per stretch of
  disagreement (not per broadcast — a peer scrubbing a slider republishes
  constantly). Web gets the telemetry and the stop-following protection but no
  notice: that surface is frozen (#3122), and a mobile-only event would
  under-count how often a mixed fleet really skews playback.
- The flag clears whenever the host drops the peer state (climb change today),
  so the notice can't outlive the state that produced it. Note the honest limit:
  neither host nulls peer state on a peer *leaving* the session, so a departed
  mismatched peer's notice still lingers until the next climb change. Fixing that
  properly needs a departure signal or a staleness timeout — out of scope here.
- A peer that sends **no** count keeps today's clamp exactly. Same-version
  sessions behave identically to before.
- Zero-frame guard: `setSpeed` was the one control not gated on `isAnimatable`,
  so a frameless climb could have published `frameCount: 0`. The engine now emits
  nothing at all when there are no frames.

Type split, so one type isn't trying to be two things: outbound
`LocalPlaybackState` has a required `frameCount`; inbound `ExternalPlaybackState`
keeps it optional/nullable.

## This is forward protection only

It does **not** detect or heal the #3986 skew already in flight. A pre-frameCount
peer neither sends the field nor understands it, and the legacy null path
deliberately preserves today's clamp. Detection only fires between two peers that
are both on this fix or later, i.e. from the *next* frames-reader change onward.
Practically, the mobile notice should essentially never appear until then — any
volume on `Playback Peer Frame Mismatch` means a rollout is skewing playback in
the field. Same caveat is written into the schema docstring.

## Deploy-order caveat (please read before merging)

A new client whose `QUEUE_UPDATES` subscription selects `frameCount` against a
backend that hasn't deployed it yet fails **whole-document** GraphQL validation:
every party-session subscribe errors and the client retries. That's the #2128 /
#2381 failure mode, documented in `operations-schema-validation.test.ts` — but
transient here, self-healing the moment Railway finishes deploying.

Railway (backend) and Vercel (web) both deploy off the same merge concurrently,
so a single-PR merge cannot guarantee backend-first. **This PR accepts that
minutes-long window.** The alternative, if you'd rather not: split into two
merges — schema + backend + validation first, then the client fragments
(`packages/shared/graphql/src/operations/queue-session.ts`,
`packages/mobile/src/lib/graphql/operations.ts`) once the backend is live. Say the
word and I'll split it. Don't publish a mobile OTA before the backend is out
either way.

## Validation

- `vp run typecheck:web|mobile|backend|shared` — all pass.
- `vp test run --project playback-react` — 21 passed (8 new, covering: peer count
  larger than ours, smaller than ours, matching converges as before, absent count
  keeps the legacy clamp, flag clears on a matching event and on climb change,
  callback fires once per stretch, emissions carry our own count, frameless climb
  emits nothing).
- `vp test run --project backend src/__tests__/playback-state-validation.test.ts
  src/__tests__/publish-playback-state.test.ts` — 55 passed (frameCount optional +
  nullable, rejects 0 / negative / fractional / NaN / Infinity / > Int max /
  string; the published event carries it through and is null when omitted).
- `vp test run --project backend src/__tests__/operations-schema-validation.test.ts`
  — 226 passed (the shared↔mobile fragment parity gate; both shared fragments and
  the mobile one were updated by hand).
- `vp run test:mobile` — 617 files / 5427 tests passed.
- `vp test run --project web playback persistent-session` — 123 passed.
- `vp test run --project i18n` — 90 passed (4-locale parity for the new key);
  `check:i18n` and `check:i18n:orphans` clean.
- `vp run check:mobile-bundle` — OK.
- `vp check` — only two pre-existing formatting failures, both in files this
  branch doesn't touch (`.claude/skills/discord-feedback-triage/SKILL.md`,
  `docs/discord-feedback-pipeline.md`).
- Backend runs intermittently hit `deadlock detected` on the setup `TRUNCATE`.
  That's parallel worktrees sharing `boardsesh_backend_test_w<N>` on :5433, not
  this change — every affected file passes on a re-run with the DB uncontended.

Generated GraphQL came from `vp run codegen`, not by hand.

CI was green after a re-run of one unrelated flake (`auth-provider.test.tsx >
lets a rejected reconnect refresh run the normal signed-out cleanup`, which
passes locally in a full `vp run test:mobile`).

Addressed from the automated review: web now reports the mismatch to analytics,
and the flag clears when the peer state is dropped. The reviewer's third point
(a peer *disconnecting* mid-mismatch) is only partly covered — see the note
above.

## Release Notes

- [x] No release note needed

## Open questions for @marcodejongh

- Deploy sequencing: is a minutes-long party-mode outage window acceptable when this merges (new web selecting `frameCount` against the not-yet-deployed backend fails the whole `QUEUE_UPDATES` subscription until Railway catches up — the #2128 failure mode, but transient)? Or do you want two PRs: schema+backend merged and deployed first, client fragments second?
- Is the mobile mismatch notice worth its i18n + play-drawer surface cost given it will essentially never fire until the NEXT frames-reader change (both peers must already be on post-fix builds for detection to trigger)? The issue says "stop following and say so", so it's included — confirm you want the UI, or whether silent stop-following plus the PostHog breadcrumb is enough for v1. Dropping the notice is a small revert: the `peerFrameMismatch` prop on `PlaybackControls` plus the four catalog keys.
