### PR TITLE
fix(fastlane): guard screenshots lane on editable App Store version

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -71,14 +71,15 @@ def asc_api_key
 end
 
 # True when App Store Connect has a version deliver can edit (Prepare for
-# Submission / a rejected state), false when there is none, so the `metadata` lane
-# can skip instead of letting deliver retry "Cannot find edit app store version"
-# for ~20 minutes. Requires the Spaceship token to already be set (asc_api_key sets
-# it by default). On ANY uncertainty — app not found, credentials/API error — it
-# returns true so deliver still runs; this never suppresses a legitimate push, it
-# only avoids the pointless retry loop when we're certain there's nothing to edit.
-# Mirrors deliver's own lookup (App#get_edit_app_store_version, which returns nil
-# when no version is editable).
+# Submission / a rejected state), false when there is none, so the `metadata` and
+# `screenshots` lanes can skip instead of letting deliver retry "Cannot find edit
+# app store version" for ~20 minutes. Requires the Spaceship token to already be
+# set (asc_api_key / app_store_connect_api_key set it by default). On ANY
+# uncertainty — app not found, credentials/API error — it returns true so deliver
+# still runs; this never suppresses a legitimate push, it only avoids the
+# pointless retry loop when we're certain there's nothing to edit. Mirrors
+# deliver's own lookup (App#get_edit_app_store_version, which returns nil when no
+# version is editable).
 def editable_app_store_version_present?
   require "spaceship"
   app = Spaceship::ConnectAPI::App.find(APP_IDENTIFIER)
@@ -98,6 +99,15 @@ def emit_ci_output(value)
   github_output = ENV["GITHUB_OUTPUT"]
   return if github_output.nil? || github_output.empty?
   File.open(github_output, "a") { |file| file.puts("value=#{value}") }
+end
+
+# Append a line to the job's step summary (rendered on the Actions run page), so
+# a clean skip is visible without opening the logs — a green job that uploaded
+# nothing otherwise reads as a normal success. No-op when run locally.
+def emit_step_summary(message)
+  github_step_summary = ENV["GITHUB_STEP_SUMMARY"]
+  return if github_step_summary.nil? || github_step_summary.empty?
+  File.open(github_step_summary, "a") { |file| file.puts(message) }
 end
 
 def pngs_for_locale(locale)
@@ -264,6 +274,18 @@ platform :ios do
         in_house: false
       )
 
+      # Same pre-flight as the `metadata` lane (see its comment above `upload_to_app_store`
+      # there): deliver (sync_screenshots: true) can only attach screenshots to the
+      # *editable* App Store version, and between releases there's often nothing editable.
+      # Without this guard the upload grinds through deliver's ~20-minute "Cannot find edit
+      # app store version" backoff ladder AFTER the ~30-minute capture matrix has already run
+      # — wasted either way, but at least this saves the finalize step itself.
+      unless editable_app_store_version_present?
+        UI.important("No editable App Store version in 'Prepare for Submission' — nothing for deliver to attach screenshots to. Skipping the upload; re-run once a version is editable.")
+        emit_step_summary("**Skipped:** no editable App Store version — no iOS screenshots uploaded.")
+        next
+      end
+
       with_upload_retries do
         upload_to_app_store(
           api_key: api_key,
@@ -302,6 +324,7 @@ platform :ios do
     # next run once a version is editable (and it's pushed again at release time).
     unless editable_app_store_version_present?
       UI.important("No editable App Store version in 'Prepare for Submission' — nothing for deliver to edit. Skipping the listing-text upload; it will be pushed once a version is editable.")
+      emit_step_summary("**Skipped:** no editable App Store version — no iOS listing text uploaded.")
       next
     end
 


### PR DESCRIPTION
## What

Fixes #4172. The iOS `screenshots` lane in `fastlane/Fastfile` had no editable-App-Store-version pre-flight, unlike its sibling `metadata` lane. Between releases — live version "Ready for Distribution", nothing in "Prepare for Submission" — a screenshot upload would grind through deliver's ~20-minute "Cannot find edit app store version" backoff ladder and fail `ios-finalize`, after the ~30-minute capture matrix had already run.

Two changes, mirroring the issue's two-part ask:

1. **Guard the `screenshots` lane.** Added the same `editable_app_store_version_present?` pre-flight the `metadata` lane already has, placed *after* the `app_store_connect_api_key(...)` call so the Spaceship token is set (the helper's documented precondition) and *inside* the `begin`/`ensure` block so `next`-ing out of the guard still triggers the staged-tmpdir cleanup.
2. **Make a skip visible at the job level.** Added `emit_step_summary`, which appends a line to `GITHUB_STEP_SUMMARY` (no-op when unset, mirroring the existing `emit_ci_output` pattern). Called from both skip paths — the new `screenshots` guard and the existing `metadata` guard — so a run that uploaded nothing shows a **Skipped** line on the Actions run summary instead of reading as an ordinary green success.

Also updated the doc comment on `editable_app_store_version_present?` to note both lanes now depend on it.

## What this does NOT do

- Doesn't move the check earlier than `ios-finalize`, so it still only saves the finalize step — not the ~30-minute capture fan-out. The issue explicitly accepts this ("the expensive work is wasted either way"); a workflow-level pre-check in the setup job is a possible follow-up, not attempted here.
- Doesn't touch the Android lanes (`screenshots`/`metadata`/`images`) — `supply` has no editable-version concept, and the existing `google_play_track_version_codes` pinning already handles Play's equivalent failure mode.

## Validation

This is a Ruby-only change to `fastlane/Fastfile`. No `vp` task type-checks or lints Ruby, and there's no Ruby test suite in this repo, so validation was:

- `vp check` — passes (the two formatting warnings it reports are pre-existing, in unrelated files this PR doesn't touch).
- `ruby -c fastlane/Fastfile` — syntax OK (run in a `ruby:3.4-slim` container, matching the `ruby-version: '3.4'` pin the workflows use).
- `cd fastlane && bundle install && bundle exec fastlane lanes` — succeeds and lists both `ios screenshots` and `ios metadata` lanes with their descriptions, proving the Fastfile DSL (including the new guard and helper) evaluates cleanly end-to-end.
- `vp run typecheck` doesn't apply (no TypeScript touched); skipped per this being a Ruby-only change.

No CI workflow exercises `fastlane/Fastfile` on pull requests — `mobile-store-metadata.yml` only triggers on push to `main` with `fastlane/Fastfile` in its paths filter, so **merging this PR will itself trigger a live metadata run** (idempotent sync of the committed listing text; expected, not a regression). Behavioral confirmation of the new skip path needs either a manual `mobile-screenshots-ios.yml` dispatch with `upload=true` during a no-editable-version window, or waiting for the next real between-releases window — noted here rather than attempted, since forcing that ASC state isn't something this PR can do from CI.

## Release Notes

- [x] No release note needed (fastlane/CI tooling only, not shipped to users)
