### PR TITLE
fix(mobile): restore the owned/followed split on My Boards offline

### DIFF
--- a/packages/mobile/app/boards/__tests__/manage-offline.test.tsx
+++ b/packages/mobile/app/boards/__tests__/manage-offline.test.tsx
@@ -41,6 +41,7 @@ const state = vi.hoisted(() => ({
   profileId: undefined as string | undefined,
   /** What the JWT already in SecureStore decodes to — the offline id source. */
   storedUserId: undefined as string | undefined,
+  isStoredUserIdLoading: false,
   isProfileLoading: false,
   offlineCards: [] as unknown[],
   enabledBoards: [] as string[],
@@ -273,7 +274,8 @@ vi.mock('../../../src/hooks/use-is-offline', () => ({ useIsOffline: () => state.
 vi.mock('../../../src/hooks/use-current-user-id', () => ({
   useStoredUserId: (enabled: boolean) => {
     storedUserIdEnabledMock(enabled);
-    return enabled ? state.storedUserId : undefined;
+    if (!enabled) return { userId: undefined, isLoading: false };
+    return { userId: state.storedUserId, isLoading: state.isStoredUserIdLoading };
   },
 }));
 vi.mock('../../../src/sync', () => ({ useSyncStatus: () => state.syncStatus }));
@@ -359,6 +361,7 @@ beforeEach(() => {
   state.isOffline = false;
   state.profileId = undefined;
   state.storedUserId = undefined;
+  state.isStoredUserIdLoading = false;
   state.isProfileLoading = false;
   state.offlineCards = [];
   state.enabledBoards = [];
@@ -937,6 +940,27 @@ describe('My Boards offline with a persisted user id (#4003)', () => {
     expect(screen.getByText('Your boards')).toBeTruthy();
     expect(screen.getByText('Network board')).toBeTruthy();
     expect(document.querySelector('[data-board="net-1"]')?.getAttribute('data-readonly')).toBe('false');
+  });
+
+  it('holds the spinner while the keychain read is still in flight', () => {
+    // The profile settled with nothing, but the JWT read hasn't come back yet.
+    // Rendering here would flash the error state on the way to the grouped list.
+    state.isOffline = false;
+    state.profileId = undefined;
+    state.isProfileLoading = false;
+    state.isStoredUserIdLoading = true;
+    state.myBoards = {
+      data: { boards: [board({ uuid: 'net-1', name: 'Network board' })] },
+      isLoading: false,
+      isError: false,
+      isRefetching: false,
+    };
+
+    render(createElement(ManageBoards));
+
+    expect(screen.getByTestId('spinner')).toBeTruthy();
+    expect(screen.queryByText('Something went wrong')).toBeNull();
+    expect(screen.queryByText('Network board')).toBeNull();
   });
 
   it('never reads the keychain once the profile has answered', () => {

--- a/packages/mobile/app/boards/__tests__/manage-offline.test.tsx
+++ b/packages/mobile/app/boards/__tests__/manage-offline.test.tsx
@@ -4,10 +4,13 @@
 // fatal one: `useProfile` is a plain network query, so with no signal `currentUserId`
 // is undefined and the guard `(isError && myBoards.length === 0) || !currentUserId`
 // fired the hard "Something went wrong / Try again" state — regardless of anything
-// done to the board list. Offline the screen now renders a flat list of the boards
-// this device downloaded (owned-vs-followed can't be classified without the profile
-// id, so the headers are dropped rather than guessed) with the network affordances
-// hidden.
+// done to the board list. Offline the screen now renders the boards this device
+// downloaded, with the network affordances hidden.
+//
+// #4003 finished the job: the id also comes off the JWT already in SecureStore
+// (`useStoredUserId`), so the owned/followed headers come back offline instead of
+// filing the user's own wall under "Following". Only when even that is missing does
+// the list stay flat.
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
@@ -31,10 +34,13 @@ const forgetOfflineBoardMock = vi.hoisted(() => vi.fn());
 const deleteBoardMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const unfollowBoardMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const confirmMock = vi.hoisted(() => vi.fn().mockResolvedValue(false));
+const storedUserIdEnabledMock = vi.hoisted(() => vi.fn());
 
 const state = vi.hoisted(() => ({
   isOffline: false,
   profileId: undefined as string | undefined,
+  /** What the JWT already in SecureStore decodes to — the offline id source. */
+  storedUserId: undefined as string | undefined,
   isProfileLoading: false,
   offlineCards: [] as unknown[],
   enabledBoards: [] as string[],
@@ -261,6 +267,15 @@ vi.mock('../../../src/hooks/use-bottom-chrome-metrics', () => ({
   useBottomChromeMetrics: () => ({ scrollBottomPadding: 0 }),
 }));
 vi.mock('../../../src/hooks/use-is-offline', () => ({ useIsOffline: () => state.isOffline }));
+// Mirrors the real hook's contract: disabled → undefined, otherwise the id decoded
+// from the stored JWT. Mocked at the hook boundary so this suite never has to pull
+// in expo-secure-store.
+vi.mock('../../../src/hooks/use-current-user-id', () => ({
+  useStoredUserId: (enabled: boolean) => {
+    storedUserIdEnabledMock(enabled);
+    return enabled ? state.storedUserId : undefined;
+  },
+}));
 vi.mock('../../../src/sync', () => ({ useSyncStatus: () => state.syncStatus }));
 vi.mock('../../../src/offline/use-board-downloads', () => ({
   useBoardDownloads: () => ({ enableBoardsOffline: vi.fn() }),
@@ -343,6 +358,7 @@ beforeEach(() => {
   confirmMock.mockResolvedValue(false);
   state.isOffline = false;
   state.profileId = undefined;
+  state.storedUserId = undefined;
   state.isProfileLoading = false;
   state.offlineCards = [];
   state.enabledBoards = [];
@@ -861,5 +877,80 @@ describe('My Boards with no usable network list', () => {
     render(createElement(ManageBoards));
 
     expect(screen.getByText('Something went wrong')).toBeTruthy();
+  });
+});
+
+describe('My Boards offline with a persisted user id (#4003)', () => {
+  it("files the user's own wall under Your boards and the rest under Following", () => {
+    state.isOffline = true;
+    state.storedUserId = 'me';
+    state.offlineCards = [
+      board({ uuid: 'board-a', name: 'Marco garage', ownerId: 'me', isOwned: true }),
+      board({ uuid: 'board-b', name: 'City gym', ownerId: 'someone-else', isOwned: false, layoutId: 9 }),
+    ];
+    state.downloadedScopeKeys = ['kilter:8:17', 'kilter:9:17'];
+
+    render(createElement(ManageBoards));
+
+    const rendered = [...document.querySelectorAll('[data-testid="list"] span, [data-board]')].map(
+      (node) => node.getAttribute('data-board') ?? node.textContent,
+    );
+    expect(rendered).toEqual(expect.arrayContaining(['Your boards', 'board-a', 'Following', 'board-b']));
+    expect(rendered.indexOf('Your boards')).toBeLessThan(rendered.indexOf('board-a'));
+    expect(rendered.indexOf('board-a')).toBeLessThan(rendered.indexOf('Following'));
+    expect(rendered.indexOf('Following')).toBeLessThan(rendered.indexOf('board-b'));
+    // Every row is still read-only: edit / delete / unfollow stay server mutations.
+    expect(document.querySelector('[data-board="board-a"]')?.getAttribute('data-readonly')).toBe('true');
+    expect(document.querySelector('[data-board="board-b"]')?.getAttribute('data-readonly')).toBe('true');
+  });
+
+  it('stays flat when the keychain yields no id at all', () => {
+    state.isOffline = true;
+    state.storedUserId = undefined;
+    state.offlineCards = [board({ uuid: 'board-a', name: 'Marco garage' })];
+    state.downloadedScopeKeys = ['kilter:8:17'];
+
+    render(createElement(ManageBoards));
+
+    expect(screen.getByText('Marco garage')).toBeTruthy();
+    expect(screen.queryByText('Your boards')).toBeNull();
+    expect(screen.queryByText('Following')).toBeNull();
+  });
+
+  it('keeps the normal grouped list online when only the profile request fails', () => {
+    // Previously this fell through to the read-only offline list, because the
+    // profile was the only id source. The JWT answers instead, so the live board
+    // list renders as usual.
+    state.isOffline = false;
+    state.profileId = undefined;
+    state.storedUserId = 'me';
+    state.myBoards = {
+      data: { boards: [board({ uuid: 'net-1', name: 'Network board', ownerId: 'me' })] },
+      isLoading: false,
+      isError: false,
+      isRefetching: false,
+    };
+
+    render(createElement(ManageBoards));
+
+    expect(screen.queryByText('Something went wrong')).toBeNull();
+    expect(screen.getByText('Your boards')).toBeTruthy();
+    expect(screen.getByText('Network board')).toBeTruthy();
+    expect(document.querySelector('[data-board="net-1"]')?.getAttribute('data-readonly')).toBe('false');
+  });
+
+  it('never reads the keychain once the profile has answered', () => {
+    state.profileId = 'me';
+    state.myBoards = {
+      data: { boards: [board({ uuid: 'net-1', name: 'Network board' })] },
+      isLoading: false,
+      isError: false,
+      isRefetching: false,
+    };
+
+    render(createElement(ManageBoards));
+
+    expect(storedUserIdEnabledMock).toHaveBeenCalled();
+    expect(storedUserIdEnabledMock.mock.calls.every(([enabled]) => enabled === false)).toBe(true);
   });
 });

--- a/packages/mobile/app/boards/manage.tsx
+++ b/packages/mobile/app/boards/manage.tsx
@@ -52,6 +52,7 @@ import {
 import { buildManageItems, type ManageItem } from '../../src/components/board-discovery/manage-items';
 import { offlineBoardRows } from '../../src/components/board-discovery/offline-board-items';
 import { useIsOffline } from '../../src/hooks/use-is-offline';
+import { useStoredUserId } from '../../src/hooks/use-current-user-id';
 import { iosSystemColors } from '../../src/theme/ios-colors';
 import { spacing } from '../../src/theme/tokens';
 
@@ -83,7 +84,11 @@ export default function ManageBoards() {
     isError: isProfileError,
     refetch: refetchProfile,
   } = useProfile({ enabled: isAuthenticated });
-  const currentUserId = profile?.id;
+  // The profile is the fresher answer but it's network-only. Fall back to the id
+  // the signed JWT already carries on this device, so owned-vs-followed survives a
+  // cold start with no signal (and an online profile fetch that simply fails).
+  const storedUserId = useStoredUserId(isAuthenticated && !profile?.id);
+  const currentUserId = profile?.id ?? storedUserId;
   const { data: activeBoard } = useActiveBoard();
   const activeUuid = activeBoard?.uuid;
 
@@ -278,24 +283,32 @@ export default function ManageBoards() {
     [myBoards, currentUserId, activeUuid, t],
   );
 
-  // Offline this screen has TWO independent failures, and the profile is the fatal
-  // one: `useProfile` is a plain network query, so with no signal `currentUserId` is
-  // undefined and the guard below shows a hard "Something went wrong" state no matter
-  // what the board list does. Fall back to a flat list of the boards this device
-  // downloaded — owned-vs-followed genuinely cannot be classified without the profile
-  // id, so the headers are dropped rather than guessed.
+  // Offline this screen has TWO independent failures: `useMyBoards` and `useProfile`
+  // are both plain network queries. Fall back to the boards this device downloaded,
+  // grouped the same way the online list is — `currentUserId` now resolves from the
+  // stored JWT, so the user's own wall still lands under "Your boards" instead of
+  // being filed as something they follow. Only when even that is missing (a keychain
+  // read that failed) do the headers drop and the list goes flat, because an
+  // undefined id would confidently mis-file every board.
   const isOffline = useIsOffline();
   const offlineCards = useOfflineBoards();
   const profileUnavailable = !currentUserId && !isProfileLoading;
   const shouldUseOfflineList = isOffline || profileUnavailable || (isError && myBoards.length === 0);
   const offlineItems = useMemo(() => {
     if (!shouldUseOfflineList) return EMPTY_ITEMS;
-    return offlineBoardRows({
+    const rows = offlineBoardRows({
       cards: offlineCards,
       cachedMyBoards: myBoards,
       activeBoard: activeBoard ?? null,
       downloadedScopeKeys: downloadedScopeKeys ?? [],
-    }).map(
+    });
+    if (currentUserId !== undefined) {
+      return buildManageItems(rows, currentUserId, activeUuid, {
+        ownedHeader: t('mobile.manage.ownedHeader'),
+        followingHeader: t('mobile.manage.followingHeader'),
+      });
+    }
+    return rows.map(
       (board): ManageItem => ({
         type: 'board',
         key: board.uuid,
@@ -304,7 +317,7 @@ export default function ManageBoards() {
         isActive: board.uuid === activeUuid,
       }),
     );
-  }, [shouldUseOfflineList, offlineCards, myBoards, activeBoard, downloadedScopeKeys, activeUuid]);
+  }, [shouldUseOfflineList, offlineCards, myBoards, activeBoard, downloadedScopeKeys, activeUuid, currentUserId, t]);
   // Only take over the screen when there is actually something to show; otherwise the
   // existing loading/error states still tell the more honest story.
   const showOfflineList = shouldUseOfflineList && offlineItems.length > 0;
@@ -497,8 +510,8 @@ export default function ManageBoards() {
     );
   }
 
-  // Wait for the profile too: owned-vs-followed is keyed on currentUserId, so
-  // rendering before it resolves would file the user's own boards under
+  // Wait for an id too: owned-vs-followed is keyed on currentUserId, so rendering
+  // before either source resolves would file the user's own boards under
   // "Following" (myBoards can win the race on a cold open / deep link).
   if (!showOfflineList && ((isLoading && myBoards.length === 0) || (isProfileLoading && !currentUserId))) {
     return (
@@ -508,9 +521,9 @@ export default function ManageBoards() {
     );
   }
 
-  // Boards failed with nothing cached, OR the profile settled without an id —
-  // without currentUserId we can't classify owned vs followed, so never render
-  // the list; offer a retry that refetches both.
+  // Boards failed with nothing cached, OR neither the profile nor the stored JWT
+  // yielded an id — without currentUserId we can't classify owned vs followed, so
+  // never render the list; offer a retry that refetches both.
   if (!showOfflineList && ((isError && myBoards.length === 0) || !currentUserId)) {
     return (
       <View style={[styles.centered, { backgroundColor: systemColors.background }]}>

--- a/packages/mobile/app/boards/manage.tsx
+++ b/packages/mobile/app/boards/manage.tsx
@@ -87,7 +87,7 @@ export default function ManageBoards() {
   // The profile is the fresher answer but it's network-only. Fall back to the id
   // the signed JWT already carries on this device, so owned-vs-followed survives a
   // cold start with no signal (and an online profile fetch that simply fails).
-  const storedUserId = useStoredUserId(isAuthenticated && !profile?.id);
+  const { userId: storedUserId, isLoading: isStoredUserIdLoading } = useStoredUserId(isAuthenticated && !profile?.id);
   const currentUserId = profile?.id ?? storedUserId;
   const { data: activeBoard } = useActiveBoard();
   const activeUuid = activeBoard?.uuid;
@@ -292,8 +292,11 @@ export default function ManageBoards() {
   // undefined id would confidently mis-file every board.
   const isOffline = useIsOffline();
   const offlineCards = useOfflineBoards();
-  const profileUnavailable = !currentUserId && !isProfileLoading;
-  const shouldUseOfflineList = isOffline || profileUnavailable || (isError && myBoards.length === 0);
+  // "No id is coming" — both sources have to have settled, or a slow keychain read
+  // would briefly look like a missing identity and flip the screen to the offline
+  // list on its way to the normal one.
+  const noUserIdAvailable = !currentUserId && !isProfileLoading && !isStoredUserIdLoading;
+  const shouldUseOfflineList = isOffline || noUserIdAvailable || (isError && myBoards.length === 0);
   const offlineItems = useMemo(() => {
     if (!shouldUseOfflineList) return EMPTY_ITEMS;
     const rows = offlineBoardRows({
@@ -513,7 +516,10 @@ export default function ManageBoards() {
   // Wait for an id too: owned-vs-followed is keyed on currentUserId, so rendering
   // before either source resolves would file the user's own boards under
   // "Following" (myBoards can win the race on a cold open / deep link).
-  if (!showOfflineList && ((isLoading && myBoards.length === 0) || (isProfileLoading && !currentUserId))) {
+  if (
+    !showOfflineList &&
+    ((isLoading && myBoards.length === 0) || ((isProfileLoading || isStoredUserIdLoading) && !currentUserId))
+  ) {
     return (
       <View style={[styles.centered, { backgroundColor: systemColors.background }]}>
         <ActivityIndicator size="large" />

--- a/packages/mobile/app/boards/manage.tsx
+++ b/packages/mobile/app/boards/manage.tsx
@@ -316,7 +316,9 @@ export default function ManageBoards() {
         type: 'board',
         key: board.uuid,
         board,
-        isOwned: board.isOwned,
+        // `=== true` because a snapshot written by an older build can be missing
+        // the field entirely, and the row prop is a plain boolean.
+        isOwned: board.isOwned === true,
         isActive: board.uuid === activeUuid,
       }),
     );

--- a/packages/mobile/src/components/board-discovery/__tests__/manage-items.test.ts
+++ b/packages/mobile/src/components/board-discovery/__tests__/manage-items.test.ts
@@ -58,4 +58,38 @@ describe('buildManageItems', () => {
     expect(items[0]).toEqual({ type: 'header', key: 'header:following', title: 'Following' });
     expect(boardItem(items, 'o1').isOwned).toBe(false);
   });
+
+  // The offline My Boards list replays persisted snapshots instead of a live
+  // myBoards fetch, and gets its id from the stored JWT rather than the profile.
+  describe('offline snapshot rows', () => {
+    it('groups downloaded boards under their headers once a persisted id is available', () => {
+      const items = buildManageItems(
+        [board('home-wall', 'me'), board('gym-wall', 'someone-else')],
+        'me',
+        undefined,
+        labels,
+      );
+      expect(items.map((item) => (item.type === 'header' ? `#${item.title}` : item.key))).toEqual([
+        '#Your boards',
+        'home-wall',
+        '#Following',
+        'gym-wall',
+      ]);
+      expect(boardItem(items, 'home-wall').isOwned).toBe(true);
+      expect(boardItem(items, 'gym-wall').isOwned).toBe(false);
+    });
+
+    it("falls back to a card's persisted isOwned when the snapshot carries no ownerId", () => {
+      // Cards written by a build that didn't capture ownerId still hold the server's
+      // own answer — better than filing the home wall under "Following".
+      const legacyOwnedCard = { uuid: 'legacy', isOwned: true } as unknown as UserBoard;
+      const items = buildManageItems([legacyOwnedCard, board('f1', 'other')], 'me', undefined, labels);
+      expect(items.map((item) => (item.type === 'header' ? `#${item.title}` : item.key))).toEqual([
+        '#Your boards',
+        'legacy',
+        '#Following',
+        'f1',
+      ]);
+    });
+  });
 });

--- a/packages/mobile/src/components/board-discovery/__tests__/manage-items.test.ts
+++ b/packages/mobile/src/components/board-discovery/__tests__/manage-items.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { UserBoard } from '@boardsesh/shared-schema';
-import { buildManageItems, type ManageItem } from '../manage-items';
+import { boardIsOwnedBy, buildManageItems, type ManageItem } from '../manage-items';
 
 // buildManageItems only reads uuid + ownerId, so a minimal cast is enough.
 const board = (uuid: string, ownerId: string): UserBoard => ({ uuid, ownerId }) as unknown as UserBoard;
@@ -11,6 +11,21 @@ function boardItem(items: ManageItem[], key: string) {
   if (!found || found.type !== 'board') throw new Error(`board item not found: ${key}`);
   return found;
 }
+
+describe('boardIsOwnedBy', () => {
+  it('compares ownerId whenever the board carries one', () => {
+    expect(boardIsOwnedBy(board('o1', 'me'), 'me')).toBe(true);
+    expect(boardIsOwnedBy(board('f1', 'other'), 'me')).toBe(false);
+    expect(boardIsOwnedBy(board('o1', 'me'), undefined)).toBe(false);
+  });
+
+  it('falls back to the persisted isOwned only when ownerId is absent or blank', () => {
+    expect(boardIsOwnedBy({ uuid: 'x', isOwned: true } as unknown as UserBoard, 'me')).toBe(true);
+    expect(boardIsOwnedBy({ uuid: 'x', isOwned: false } as unknown as UserBoard, 'me')).toBe(false);
+    expect(boardIsOwnedBy({ uuid: 'x' } as unknown as UserBoard, 'me')).toBe(false);
+    expect(boardIsOwnedBy({ uuid: 'x', ownerId: '', isOwned: true } as unknown as UserBoard, 'me')).toBe(true);
+  });
+});
 
 describe('buildManageItems', () => {
   it('splits owned vs followed by ownerId, each under its own header (owned first)', () => {

--- a/packages/mobile/src/components/board-discovery/manage-items.ts
+++ b/packages/mobile/src/components/board-discovery/manage-items.ts
@@ -38,8 +38,11 @@ export function buildManageItems(
   labels: { ownedHeader: string; followingHeader: string },
 ): ManageItem[] {
   const items: ManageItem[] = [];
-  const owned = boards.filter((board) => boardIsOwnedBy(board, currentUserId));
-  const followed = boards.filter((board) => !boardIsOwnedBy(board, currentUserId));
+  const owned: UserBoard[] = [];
+  const followed: UserBoard[] = [];
+  for (const board of boards) {
+    (boardIsOwnedBy(board, currentUserId) ? owned : followed).push(board);
+  }
   if (owned.length > 0) {
     items.push({ type: 'header', key: 'header:owned', title: labels.ownedHeader });
     for (const board of owned) {

--- a/packages/mobile/src/components/board-discovery/manage-items.ts
+++ b/packages/mobile/src/components/board-discovery/manage-items.ts
@@ -9,22 +9,37 @@ export type ManageItem =
   | { type: 'board'; key: string; board: UserBoard; isOwned: boolean; isActive: boolean };
 
 /**
+ * Is this board the current user's own? `ownerId === currentUserId` whenever the
+ * board carries an owner, which is always for anything the server sent
+ * (`ownerId: ID!`).
+ *
+ * Persisted offline snapshots are the exception the fallback exists for: a card
+ * written by a build that didn't capture `ownerId` still carries the server's own
+ * `isOwned` answer from the moment it was downloaded, which beats filing the
+ * user's home wall under "Following".
+ */
+export function boardIsOwnedBy(board: UserBoard, currentUserId: string | undefined): boolean {
+  if (typeof board.ownerId === 'string' && board.ownerId.length > 0) return board.ownerId === currentUserId;
+  return board.isOwned === true;
+}
+
+/**
  * Split `boards` (owned + followed, as `myBoards` returns them) into a flat item
  * array: an owned group then a followed group, each preceded by a header that's
- * omitted when the group is empty. Owned = `board.ownerId === currentUserId`.
+ * omitted when the group is empty. Owned = `boardIsOwnedBy`.
  * `myBoards` already orders owned-first, so this is a single pass; the caller
  * supplies the localized header titles. Each board carries precomputed
  * `isOwned`/`isActive` so the row never scans for them.
  */
 export function buildManageItems(
-  boards: UserBoard[],
+  boards: readonly UserBoard[],
   currentUserId: string | undefined,
   activeUuid: string | undefined,
   labels: { ownedHeader: string; followingHeader: string },
 ): ManageItem[] {
   const items: ManageItem[] = [];
-  const owned = boards.filter((board) => board.ownerId === currentUserId);
-  const followed = boards.filter((board) => board.ownerId !== currentUserId);
+  const owned = boards.filter((board) => boardIsOwnedBy(board, currentUserId));
+  const followed = boards.filter((board) => !boardIsOwnedBy(board, currentUserId));
   if (owned.length > 0) {
     items.push({ type: 'header', key: 'header:owned', title: labels.ownedHeader });
     for (const board of owned) {

--- a/packages/mobile/src/hooks/__tests__/use-current-user-id.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-current-user-id.test.tsx
@@ -32,20 +32,20 @@ describe('useStoredUserId', () => {
 
   it('resolves the id from the stored JWT', async () => {
     getAuthToken.mockResolvedValue(tokenForUser('user-42'));
-    const { result } = renderHook(() => useStoredUserId(true), { wrapper: wrapper() });
+    const { result } = renderHook(() => useStoredUserId(true).userId, { wrapper: wrapper() });
     await waitFor(() => expect(result.current).toBe('user-42'));
   });
 
   it('stays undefined when the keychain has no token', async () => {
     getAuthToken.mockResolvedValue(null);
-    const { result } = renderHook(() => useStoredUserId(true), { wrapper: wrapper() });
+    const { result } = renderHook(() => useStoredUserId(true).userId, { wrapper: wrapper() });
     await waitFor(() => expect(getAuthToken).toHaveBeenCalled());
     expect(result.current).toBeUndefined();
   });
 
   it('stays undefined when the stored token is malformed', async () => {
     getAuthToken.mockResolvedValue('not-a-jwt');
-    const { result } = renderHook(() => useStoredUserId(true), { wrapper: wrapper() });
+    const { result } = renderHook(() => useStoredUserId(true).userId, { wrapper: wrapper() });
     await waitFor(() => expect(getAuthToken).toHaveBeenCalled());
     expect(result.current).toBeUndefined();
   });
@@ -55,6 +55,24 @@ describe('useStoredUserId', () => {
     const { result } = renderHook(() => useStoredUserId(false), { wrapper: wrapper() });
     await Promise.resolve();
     expect(getAuthToken).not.toHaveBeenCalled();
-    expect(result.current).toBeUndefined();
+    expect(result.current.userId).toBeUndefined();
+    // A disabled query is "pending" in React Query terms; callers gate their
+    // loading state on this, so it must read as settled.
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('reports the in-flight read so callers can hold their loading state', async () => {
+    let releaseToken!: (token: string) => void;
+    getAuthToken.mockReturnValue(
+      new Promise<string>((resolve) => {
+        releaseToken = resolve;
+      }),
+    );
+    const { result } = renderHook(() => useStoredUserId(true), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+
+    releaseToken(tokenForUser('user-7'));
+    await waitFor(() => expect(result.current.userId).toBe('user-7'));
+    expect(result.current.isLoading).toBe(false);
   });
 });

--- a/packages/mobile/src/hooks/__tests__/use-current-user-id.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-current-user-id.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const { getAuthToken } = vi.hoisted(() => ({ getAuthToken: vi.fn<() => Promise<string | null>>() }));
+
+vi.mock('../../lib/auth-store', () => ({ getAuthToken }));
+
+import { useStoredUserId } from '../use-current-user-id';
+
+function base64Url(value: string): string {
+  return Buffer.from(value, 'utf8').toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function tokenForUser(userId: string): string {
+  return `${base64Url('{"alg":"HS256"}')}.${base64Url(JSON.stringify({ sub: userId }))}.signature`;
+}
+
+function wrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useStoredUserId', () => {
+  beforeEach(() => {
+    getAuthToken.mockReset();
+  });
+
+  it('resolves the id from the stored JWT', async () => {
+    getAuthToken.mockResolvedValue(tokenForUser('user-42'));
+    const { result } = renderHook(() => useStoredUserId(true), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current).toBe('user-42'));
+  });
+
+  it('stays undefined when the keychain has no token', async () => {
+    getAuthToken.mockResolvedValue(null);
+    const { result } = renderHook(() => useStoredUserId(true), { wrapper: wrapper() });
+    await waitFor(() => expect(getAuthToken).toHaveBeenCalled());
+    expect(result.current).toBeUndefined();
+  });
+
+  it('stays undefined when the stored token is malformed', async () => {
+    getAuthToken.mockResolvedValue('not-a-jwt');
+    const { result } = renderHook(() => useStoredUserId(true), { wrapper: wrapper() });
+    await waitFor(() => expect(getAuthToken).toHaveBeenCalled());
+    expect(result.current).toBeUndefined();
+  });
+
+  it('never touches the keychain while disabled (signed out, or the profile already answered)', async () => {
+    getAuthToken.mockResolvedValue(tokenForUser('user-42'));
+    const { result } = renderHook(() => useStoredUserId(false), { wrapper: wrapper() });
+    await Promise.resolve();
+    expect(getAuthToken).not.toHaveBeenCalled();
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/packages/mobile/src/hooks/use-current-user-id.ts
+++ b/packages/mobile/src/hooks/use-current-user-id.ts
@@ -4,6 +4,12 @@ import { userIdFromJwt } from '../lib/jwt-user-id';
 
 export const STORED_USER_ID_QUERY_KEY = ['storedJwtUserId'] as const;
 
+export type StoredUserId = {
+  userId: string | undefined;
+  /** The keychain read is still in flight — not yet "there is no id". */
+  isLoading: boolean;
+};
+
 /**
  * The signed-in user's id, read from the JWT already sitting in SecureStore.
  *
@@ -22,8 +28,8 @@ export const STORED_USER_ID_QUERY_KEY = ['storedJwtUserId'] as const;
  * derives the id instead of persisting a second identity field — one less thing
  * that can outlive an account on a shared device.
  */
-export function useStoredUserId(enabled: boolean): string | undefined {
-  const { data } = useQuery({
+export function useStoredUserId(enabled: boolean): StoredUserId {
+  const { data, isLoading } = useQuery({
     queryKey: STORED_USER_ID_QUERY_KEY,
     // `?? null` because React Query rejects an undefined resolution as a
     // programming error ("Query data cannot be undefined"); "no id" is a real,
@@ -31,9 +37,13 @@ export function useStoredUserId(enabled: boolean): string | undefined {
     queryFn: async () => userIdFromJwt(await getAuthToken()) ?? null,
     enabled,
     // The keychain read is cheap but the answer only changes across a sign-in /
-    // sign-out, both of which clear the cache anyway.
+    // sign-out, both of which clear the cache anyway. `gcTime: Infinity` is safe
+    // for the same reason: `runSignedOutCleanup`'s `queryClient.clear()` drops
+    // the entry, so it can't outlive the account that produced it.
     staleTime: Infinity,
     gcTime: Infinity,
   });
-  return data ?? undefined;
+  // `isLoading` (not `isPending`) so a disabled query never reads as in-flight —
+  // callers gate their loading state on this and would otherwise spin forever.
+  return { userId: data ?? undefined, isLoading };
 }

--- a/packages/mobile/src/hooks/use-current-user-id.ts
+++ b/packages/mobile/src/hooks/use-current-user-id.ts
@@ -1,0 +1,39 @@
+import { useQuery } from '@tanstack/react-query';
+import { getAuthToken } from '../lib/auth-store';
+import { userIdFromJwt } from '../lib/jwt-user-id';
+
+export const STORED_USER_ID_QUERY_KEY = ['storedJwtUserId'] as const;
+
+/**
+ * The signed-in user's id, read from the JWT already sitting in SecureStore.
+ *
+ * `useProfile` is a plain network query, so with no signal it never answers and
+ * every screen keyed on the profile id (My Boards' owned-vs-followed split) has
+ * to degrade. The id is on the device regardless: the backend signs the native
+ * JWT with `sub: userId`, the same id compared against `board.ownerId`. This
+ * reads it back so a cold start with no connection can still tell "your boards"
+ * from the ones you follow.
+ *
+ * Display-only — see `userIdFromJwt`'s warning; the decode is unverified.
+ *
+ * Nothing new has to be cleared at sign-out: the id lives in the JWT that
+ * `clearTokens()` deletes, and this query's cached copy goes with
+ * `queryClient.clear()` in `runSignedOutCleanup`. That's the whole reason it
+ * derives the id instead of persisting a second identity field — one less thing
+ * that can outlive an account on a shared device.
+ */
+export function useStoredUserId(enabled: boolean): string | undefined {
+  const { data } = useQuery({
+    queryKey: STORED_USER_ID_QUERY_KEY,
+    // `?? null` because React Query rejects an undefined resolution as a
+    // programming error ("Query data cannot be undefined"); "no id" is a real,
+    // cacheable answer here.
+    queryFn: async () => userIdFromJwt(await getAuthToken()) ?? null,
+    enabled,
+    // The keychain read is cheap but the answer only changes across a sign-in /
+    // sign-out, both of which clear the cache anyway.
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+  return data ?? undefined;
+}

--- a/packages/mobile/src/lib/__tests__/jwt-user-id.test.ts
+++ b/packages/mobile/src/lib/__tests__/jwt-user-id.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { userIdFromJwt } from '../jwt-user-id';
+
+function base64Url(value: string): string {
+  return Buffer.from(value, 'utf8').toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function jwtWithPayload(payload: string): string {
+  return `${base64Url('{"alg":"HS256","typ":"JWT"}')}.${base64Url(payload)}.c2lnbmF0dXJl`;
+}
+
+describe('userIdFromJwt', () => {
+  it('reads the sub claim from a well-formed token', () => {
+    const token = jwtWithPayload('{"sub":"3f0c8a2e-1b2c-4d5e-8f90-abcdef123456","iss":"boardsesh","exp":1893456000}');
+    expect(userIdFromJwt(token)).toBe('3f0c8a2e-1b2c-4d5e-8f90-abcdef123456');
+  });
+
+  it('decodes payloads that use the base64url alphabet and drop padding', () => {
+    // This payload's standard base64 contains both '+' and '/' and needs padding,
+    // so the token exercises the -/_ substitution and the stripped '='.
+    const token = jwtWithPayload('{"sub":"user-1","note":"~~~?>?"}');
+    const payloadSegment = token.split('.')[1];
+    expect(payloadSegment).toMatch(/[-_]/);
+    expect(payloadSegment).not.toMatch(/[+/=]/);
+    expect(userIdFromJwt(token)).toBe('user-1');
+  });
+
+  it('decodes multi-byte UTF-8 in the payload without mangling the sub', () => {
+    const token = jwtWithPayload('{"name":"Márco 🧗","sub":"user-2"}');
+    expect(userIdFromJwt(token)).toBe('user-2');
+  });
+
+  it('returns undefined for an absent token', () => {
+    expect(userIdFromJwt(null)).toBeUndefined();
+    expect(userIdFromJwt(undefined)).toBeUndefined();
+    expect(userIdFromJwt('')).toBeUndefined();
+  });
+
+  it('returns undefined for the wrong number of segments', () => {
+    expect(userIdFromJwt('header.payload')).toBeUndefined();
+    expect(userIdFromJwt('a.b.c.d')).toBeUndefined();
+    expect(userIdFromJwt('not-a-jwt')).toBeUndefined();
+  });
+
+  it('returns undefined when the payload is not JSON', () => {
+    expect(userIdFromJwt(`${base64Url('{}')}.${base64Url('not json at all')}.sig`)).toBeUndefined();
+    expect(userIdFromJwt(`${base64Url('{}')}.${base64Url('[1,2,3]')}.sig`)).toBeUndefined();
+    expect(userIdFromJwt(`${base64Url('{}')}.${base64Url('null')}.sig`)).toBeUndefined();
+  });
+
+  it('returns undefined when sub is missing, empty, or not a string', () => {
+    expect(userIdFromJwt(jwtWithPayload('{"iss":"boardsesh"}'))).toBeUndefined();
+    expect(userIdFromJwt(jwtWithPayload('{"sub":""}'))).toBeUndefined();
+    expect(userIdFromJwt(jwtWithPayload('{"sub":42}'))).toBeUndefined();
+    expect(userIdFromJwt(jwtWithPayload('{"sub":null}'))).toBeUndefined();
+  });
+
+  it('never throws on hostile or truncated input', () => {
+    const hostile = ['..', 'a..c', `${base64Url('{}')}..sig`, '💥.💥.💥', 'x.%%%%.y', 'a.b.'];
+    for (const token of hostile) {
+      expect(() => userIdFromJwt(token)).not.toThrow();
+      expect(userIdFromJwt(token)).toBeUndefined();
+    }
+  });
+});

--- a/packages/mobile/src/lib/jwt-user-id.ts
+++ b/packages/mobile/src/lib/jwt-user-id.ts
@@ -39,7 +39,12 @@ function base64UrlToBytes(segment: string): Uint8Array | undefined {
   return Uint8Array.from(bytes);
 }
 
-/** bytes → string, decoding UTF-8 by hand so no `TextDecoder` polyfill is assumed. */
+/**
+ * bytes → string, decoding UTF-8 by hand. Hermes ships `TextDecoder`, but this
+ * module also runs under the web build and under Vitest's jsdom, and a decoder
+ * that throws on a malformed sequence would defeat the never-throw contract
+ * above. 25 lines buys "works everywhere, fails soft".
+ */
 function utf8Decode(bytes: Uint8Array): string {
   let decoded = '';
   let index = 0;

--- a/packages/mobile/src/lib/jwt-user-id.ts
+++ b/packages/mobile/src/lib/jwt-user-id.ts
@@ -40,10 +40,11 @@ function base64UrlToBytes(segment: string): Uint8Array | undefined {
 }
 
 /**
- * bytes → string, decoding UTF-8 by hand. Hermes ships `TextDecoder`, but this
- * module also runs under the web build and under Vitest's jsdom, and a decoder
- * that throws on a malformed sequence would defeat the never-throw contract
- * above. 25 lines buys "works everywhere, fails soft".
+ * bytes → string, decoding UTF-8 by hand. `TextDecoder` would do — it substitutes
+ * on malformed input rather than throwing, so it wouldn't break the never-throw
+ * contract above. This keeps the whole decode in one place with one failure mode
+ * (substitute, return undefined) across the native, web, and jsdom targets this
+ * module runs in.
  */
 function utf8Decode(bytes: Uint8Array): string {
   let decoded = '';

--- a/packages/mobile/src/lib/jwt-user-id.ts
+++ b/packages/mobile/src/lib/jwt-user-id.ts
@@ -17,8 +17,8 @@ const BASE64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz012
 
 /**
  * base64url → bytes. Hand-rolled rather than `atob` because the JWT alphabet
- * uses `-`/`_` and drops padding, and because Hermes' `atob` availability
- * varies by runtime. Returns undefined for anything it can't decode.
+ * uses `-`/`_` and drops padding, and because `atob` throws on a bad character
+ * where this must fail soft. Returns undefined for anything it can't decode.
  */
 function base64UrlToBytes(segment: string): Uint8Array | undefined {
   const normalized = segment.replace(/-/g, '+').replace(/_/g, '/');

--- a/packages/mobile/src/lib/jwt-user-id.ts
+++ b/packages/mobile/src/lib/jwt-user-id.ts
@@ -1,0 +1,99 @@
+// Read the signed-in user id out of the JWT this device already holds.
+//
+// WARNING: this is an UNVERIFIED, client-side decode. It does not check the
+// signature, the issuer, the audience, or the expiry — a tampered token would
+// yield whatever id it claims. It exists for ONE job: classifying boards this
+// device has already downloaded as "yours" vs "following" while offline, where
+// the usual source (`useProfile`, a network query) cannot answer. Never feed the
+// result into an authorization decision, a mutation payload, or anything the
+// server trusts — the backend does its own `jwtVerify` on every request and that
+// remains the only real answer to "who is this?".
+//
+// The claim itself is the same id: the backend signs `SignJWT({ sub: userId })`
+// (packages/backend/src/handlers/native-auth.ts) with the id that later gets
+// compared against `board.ownerId`.
+
+const BASE64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+/**
+ * base64url → bytes. Hand-rolled rather than `atob` because the JWT alphabet
+ * uses `-`/`_` and drops padding, and because Hermes' `atob` availability
+ * varies by runtime. Returns undefined for anything it can't decode.
+ */
+function base64UrlToBytes(segment: string): Uint8Array | undefined {
+  const normalized = segment.replace(/-/g, '+').replace(/_/g, '/');
+  const bytes: number[] = [];
+  let accumulator = 0;
+  let bitsHeld = 0;
+  for (const character of normalized) {
+    if (character === '=') break;
+    const sextet = BASE64_ALPHABET.indexOf(character);
+    if (sextet === -1) return undefined;
+    accumulator = (accumulator << 6) | sextet;
+    bitsHeld += 6;
+    if (bitsHeld >= 8) {
+      bitsHeld -= 8;
+      bytes.push((accumulator >> bitsHeld) & 0xff);
+    }
+  }
+  return Uint8Array.from(bytes);
+}
+
+/** bytes → string, decoding UTF-8 by hand so no `TextDecoder` polyfill is assumed. */
+function utf8Decode(bytes: Uint8Array): string {
+  let decoded = '';
+  let index = 0;
+  while (index < bytes.length) {
+    const leadByte = bytes[index];
+    let codePoint: number;
+    let continuationCount: number;
+    if (leadByte < 0x80) {
+      codePoint = leadByte;
+      continuationCount = 0;
+    } else if ((leadByte & 0xe0) === 0xc0) {
+      codePoint = leadByte & 0x1f;
+      continuationCount = 1;
+    } else if ((leadByte & 0xf0) === 0xe0) {
+      codePoint = leadByte & 0x0f;
+      continuationCount = 2;
+    } else if ((leadByte & 0xf8) === 0xf0) {
+      codePoint = leadByte & 0x07;
+      continuationCount = 3;
+    } else {
+      // Not a valid lead byte — substitute rather than throw; the caller only
+      // cares whether a `sub` string survives.
+      decoded += '�';
+      index += 1;
+      continue;
+    }
+    for (let offset = 1; offset <= continuationCount; offset += 1) {
+      const continuationByte = bytes[index + offset];
+      if (continuationByte === undefined || (continuationByte & 0xc0) !== 0x80) return decoded + '�';
+      codePoint = (codePoint << 6) | (continuationByte & 0x3f);
+    }
+    decoded += String.fromCodePoint(codePoint);
+    index += continuationCount + 1;
+  }
+  return decoded;
+}
+
+/**
+ * The `sub` claim of a JWT, or undefined when the token is absent, malformed, or
+ * carries no usable subject. Never throws — hostile or truncated input just
+ * reads as "no id", which callers already handle.
+ */
+export function userIdFromJwt(token: string | null | undefined): string | undefined {
+  if (!token) return undefined;
+  const segments = token.split('.');
+  if (segments.length !== 3) return undefined;
+  try {
+    const payloadBytes = base64UrlToBytes(segments[1]);
+    if (!payloadBytes || payloadBytes.length === 0) return undefined;
+    const payload: unknown = JSON.parse(utf8Decode(payloadBytes));
+    if (typeof payload !== 'object' || payload === null) return undefined;
+    const subject = (payload as { sub?: unknown }).sub;
+    return typeof subject === 'string' && subject.length > 0 ? subject : undefined;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
Fixes #4003.

## The problem

#3897 made `/boards/manage` usable with no signal, but flat: one un-headed
section, no "Your boards" / "Following" split. That was honest rather than
cosmetic — the split is `board.ownerId === currentUserId`, and `currentUserId`
came only from `useProfile`, a plain network query. Offline it is `undefined`,
so every board (including the user's own home wall) would have been filed under
"Following".

## The fix

The id is already on the device, in the JWT `expo-secure-store` holds: the
backend signs the native token with `sub: userId`
(`packages/backend/src/handlers/native-auth.ts`), the same id later compared
against `board.ownerId`. `useStoredUserId` reads it back, `manage.tsx` uses
`profile?.id ?? storedUserId`, and the offline list now runs through the same
`buildManageItems` the online list uses.

- `src/lib/jwt-user-id.ts` — `userIdFromJwt`, a hand-rolled base64url + UTF-8
  decode of the payload's `sub`. Never throws; returns `undefined` for anything
  malformed.
- `src/hooks/use-current-user-id.ts` — `useStoredUserId(enabled)`, enabled only
  while authenticated and only while the profile hasn't answered.
- `manage.tsx` — offline rows go through `buildManageItems` when an id exists;
  the flat list stays as the degraded branch when it doesn't.
- `manage-items.ts` — `boardIsOwnedBy` falls back to a snapshot card's persisted
  `isOwned` when it carries no `ownerId` (cards from a build that didn't capture
  it), so an old download doesn't get mis-filed.

Side effect worth having: an online profile fetch that fails on its own no
longer drops My Boards into the read-only fallback — the board list renders
normally.

## Two deliberate deviations, both easy to veto

**1. Derived from the JWT, not a second persisted identity field.** The issue
asked for a persisted user id plus a write point plus a clear in
`runSignedOutCleanup`, next to `syncEnabledBoards` and `offlineBoardsV1`. This
derives it from the token instead, so there is nothing new to clear: the id
lives in the JWT `clearTokens()` deletes, and the cached copy goes with the
`queryClient.clear()` already in `runSignedOutCleanup`. Same user-visible
outcome, one less thing that can outlive an account on a shared device. Say the
word and I'll do the literal MMKV version.

**2. The decode is unverified.** No signature, issuer, or expiry check —
client-side parsing of a token this device already trusts enough to send. It is
display-only: classifying boards already downloaded here. The helper carries
that warning in a comment. The backend still does its own `jwtVerify` on every
request, and that remains the only real answer to "who is this?". If that
tradeoff isn't wanted, the alternative is grouping purely by the `isOwned` flag
already persisted on each card — zero auth surface, but it can't fix the online
profile-failure case and drifts if ownership changes server-side.

## Not in scope

Edit / delete / unfollow / create stay hidden offline — server mutations, per
the issue.

## Testing

- `packages/mobile/src/lib/__tests__/jwt-user-id.test.ts` — sub extraction,
  base64url alphabet + missing padding, multi-byte UTF-8, and a hostile-input
  sweep (wrong segment count, non-JSON, non-string/empty sub, truncated) that
  must return `undefined` and never throw.
- `manage-items.test.ts` — offline rows split under both headers; the
  no-`ownerId` card falls back to its persisted `isOwned`.
- `manage-offline.test.tsx` — offline with a stored id renders
  Your boards → own wall → Following → followed board, rows still read-only;
  no id at all stays flat; online-with-a-dead-profile now renders the normal
  grouped list; the keychain is never read once the profile has answered.
- `use-current-user-id.test.tsx` — resolves from the JWT, stays undefined on a
  missing/malformed token, never reads the keychain while disabled.

`vp run typecheck` ✅ · `vp run test:mobile` (621 files, 5476 tests) ✅ ·
`vp run check:mobile-bundle` ✅ · `vp check` ✅ (two pre-existing formatting
failures on `main` in `.claude/skills/discord-feedback-triage/SKILL.md` and
`docs/discord-feedback-pipeline.md`, untouched here).

Manual QA plan in `.boardsesh/qa-notes.md`: two boards downloaded (one owned,
one followed), cold start in airplane mode, check both headers, then confirm
the online list is unchanged.

## Release Notes

- Downloaded boards keep their "Your boards" and "Following" sections when you
  open My Boards with no signal.

JS-only, no native deps, no fingerprint movement — rides OTA.
