### PR TITLE
feat(mobile): stamp connectivity on every analytics event

### DIFF
--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -851,6 +851,45 @@ On logout or account switch:
 4. Reset `syncEnabledBoards` and the `offlineBoardsV1` snapshots (board names must not survive into the next account on a shared device).
 5. On new login, sync pull client fetches the new user's data (small, seconds).
 
+## Usage telemetry
+
+Offline mode's whole value proposition is "you can still climb when the signal
+can't". Until issue #4317 nothing in the telemetry could tell an offline-served
+read apart from an online one, so that claim was unfalsifiable. This section is
+the source of truth for the signals that fix it. They are mobile-only today (the
+engine is shared, so a future web offline consumer would emit the same things).
+
+### The `connectivity` super property
+
+`packages/mobile/src/lib/analytics-connectivity.ts` registers a PostHog super
+property `connectivity: 'online' | 'offline'` at analytics startup and again on
+every real network transition. PostHog stamps super properties onto events at
+**capture** time, so every event the app sends — `$screen`, `Tick Logged`, the
+offline download events — becomes segmentable by connectivity, retroactively and
+for free.
+
+Three things are worth knowing before trusting a number derived from it:
+
+- **Offline-captured events do arrive.** The RN SDK persists its queue to disk
+  (`persistence: 'file'` is the default), and `@posthog/core`'s flush only
+  dequeues a batch when the failure was **not** a `PostHogFetchNetworkError` — a
+  network failure leaves the batch in the queue. So events captured in airplane
+  mode survive an app kill and flush on reconnect, still carrying the
+  `connectivity: 'offline'` they were captured with. The queue is capped at 1000
+  events with the oldest dropped, which is the reason the read signal below is a
+  rollup rather than one event per read.
+- **It is best-known connectivity, not ground truth.** It mirrors React Query's
+  `onlineManager`, which the app seeds from NetInfo asynchronously and which
+  defaults to online (`query-provider.tsx`), and which tracks `isConnected`, not
+  `isInternetReachable`. A genuinely-offline cold start can stamp its first
+  events `online`, and a captive portal or a dead gym-wifi upstream reads
+  `online` throughout. Both errors under-count offline usage, so any number built
+  on this is a floor.
+- **It is re-registered after `analytics.reset()`.** PostHog's reset clears every
+  super property and the client singleton is cached, so a sign-out would
+  otherwise drop `connectivity` for the rest of the launch — the same trap
+  `environment` and `$raw_user_agent` already document in `posthog-client.ts`.
+
 ## Performance targets
 
 | Metric                   | Target                | Notes                                     |

--- a/packages/mobile/src/components/analytics/AnalyticsProvider.tsx
+++ b/packages/mobile/src/components/analytics/AnalyticsProvider.tsx
@@ -2,6 +2,7 @@ import { useEffect, type ReactNode } from 'react';
 import { StyleSheet } from 'react-native';
 import { PostHogProvider } from 'posthog-react-native';
 import { getAnalyticsClient, setSessionRecordingEnabled } from '../../lib/analytics';
+import { startConnectivityTracking } from '../../lib/analytics-connectivity';
 import { loadSessionRecordingEnabled } from '../../lib/session-recording-preference';
 
 // PostHogProvider renders a touch-capturing View around its subtree; without
@@ -30,6 +31,12 @@ export function AnalyticsProvider({ children }: { children: ReactNode }) {
         // A failed preference read leaves recording off (the safe default).
       });
   }, []);
+
+  // Stamp `connectivity` on every event and keep it current for the launch.
+  // Declared BEFORE the `!client` early return so the hook order stays stable
+  // when analytics is disabled; startConnectivityTracking is itself a no-op
+  // against a null client, so running it either way costs nothing.
+  useEffect(() => startConnectivityTracking(), []);
 
   if (!client) return <>{children}</>;
   return (

--- a/packages/mobile/src/lib/__tests__/analytics-connectivity.test.ts
+++ b/packages/mobile/src/lib/__tests__/analytics-connectivity.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { onlineManager } from '@tanstack/react-query';
+
+const posthogClientMocks = vi.hoisted(() => ({ getPostHogClient: vi.fn() }));
+
+vi.mock('../posthog-client', () => ({ getPostHogClient: posthogClientMocks.getPostHogClient }));
+
+import {
+  CONNECTIVITY_SUPER_PROPERTY,
+  currentConnectivityState,
+  registerConnectivitySuperProperty,
+  startConnectivityTracking,
+} from '../analytics-connectivity';
+
+// Issue #4317: without this property nothing in the app's telemetry says whether
+// the network was usable when an event was captured, so "did anyone use the app
+// away from signal?" — the whole premise of offline mode — is unanswerable.
+describe('analytics connectivity super property', () => {
+  let register: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    register = vi.fn();
+    posthogClientMocks.getPostHogClient.mockReturnValue({ register });
+    onlineManager.setOnline(true);
+  });
+
+  afterEach(() => {
+    onlineManager.setOnline(true);
+  });
+
+  it('reads the current state from onlineManager', () => {
+    expect(currentConnectivityState()).toBe('online');
+    onlineManager.setOnline(false);
+    expect(currentConnectivityState()).toBe('offline');
+  });
+
+  it('registers the resolved client singleton when no client is passed', () => {
+    onlineManager.setOnline(false);
+    registerConnectivitySuperProperty();
+    expect(register).toHaveBeenCalledWith({ [CONNECTIVITY_SUPER_PROPERTY]: 'offline' });
+  });
+
+  it('registers on the passed client without resolving the singleton', () => {
+    const explicitRegister = vi.fn();
+    registerConnectivitySuperProperty({ register: explicitRegister });
+    expect(explicitRegister).toHaveBeenCalledWith({ [CONNECTIVITY_SUPER_PROPERTY]: 'online' });
+    expect(posthogClientMocks.getPostHogClient).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when analytics is disabled (null client)', () => {
+    posthogClientMocks.getPostHogClient.mockReturnValue(null);
+    expect(() => registerConnectivitySuperProperty()).not.toThrow();
+    expect(register).not.toHaveBeenCalled();
+  });
+
+  it('swallows a throwing register so it can never break the caller', () => {
+    register.mockImplementation(() => {
+      throw new Error('register exploded');
+    });
+    expect(() => registerConnectivitySuperProperty()).not.toThrow();
+  });
+
+  it('swallows a rejecting register promise', async () => {
+    register.mockReturnValue(Promise.reject(new Error('register rejected')));
+    expect(() => registerConnectivitySuperProperty()).not.toThrow();
+    await Promise.resolve();
+  });
+
+  it('registers immediately on start', () => {
+    const stop = startConnectivityTracking();
+    expect(register).toHaveBeenCalledExactlyOnceWith({ [CONNECTIVITY_SUPER_PROPERTY]: 'online' });
+    stop();
+  });
+
+  it('re-registers on an online → offline transition', () => {
+    const stop = startConnectivityTracking();
+    register.mockClear();
+
+    onlineManager.setOnline(false);
+
+    expect(register).toHaveBeenCalledExactlyOnceWith({ [CONNECTIVITY_SUPER_PROPERTY]: 'offline' });
+    stop();
+  });
+
+  // NetInfo's change stream is chatty and onlineManager notifies on every
+  // setOnline call, including same-value ones. Each register() is a persisted
+  // write, so a repeat must not cost one.
+  it('does not re-register when the state has not changed', () => {
+    const stop = startConnectivityTracking();
+    register.mockClear();
+
+    onlineManager.setOnline(true);
+    onlineManager.setOnline(true);
+
+    expect(register).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it('stops re-registering once unsubscribed', () => {
+    const stop = startConnectivityTracking();
+    register.mockClear();
+    stop();
+
+    onlineManager.setOnline(false);
+
+    expect(register).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/__tests__/analytics-reset.test.ts
+++ b/packages/mobile/src/lib/__tests__/analytics-reset.test.ts
@@ -46,6 +46,19 @@ describe('analytics reset', () => {
     expect(posthogClientMocks.registerAppSuperProperties).toHaveBeenCalledWith(fakeClient);
   });
 
+  // #4317: `connectivity` is registered once at startup and then only on a
+  // network transition, so a sign-out that dropped it would leave every
+  // remaining event of the launch unattributable to online or offline.
+  it('re-registers connectivity after resetting the client', async () => {
+    const fakeClient = { register: vi.fn() };
+    posthogClientMocks.getPostHogClient.mockReturnValue(fakeClient);
+    const { reset } = await import('../analytics');
+
+    expect(reset()).toBe(true);
+
+    expect(fakeClient.register).toHaveBeenCalledWith({ connectivity: 'online' });
+  });
+
   it('does not re-register when analytics is disabled (no client)', async () => {
     posthogClientMocks.getPostHogClient.mockReturnValue(null);
     const { reset } = await import('../analytics');

--- a/packages/mobile/src/lib/analytics-connectivity.ts
+++ b/packages/mobile/src/lib/analytics-connectivity.ts
@@ -1,0 +1,67 @@
+import { onlineManager } from '@tanstack/react-query';
+import type { PostHog } from 'posthog-react-native';
+import { getPostHogClient } from './posthog-client';
+
+// The `connectivity` super property: 'online' | 'offline', stamped onto every
+// event this client sends until it is re-registered. It exists because nothing
+// in the app's telemetry said whether the network was usable at capture time —
+// so "does anyone actually use Boardsesh away from signal?" (the whole point of
+// offline mode, issue #4317) was unanswerable from any existing event.
+//
+// PostHog resolves super properties at CAPTURE time, not at flush time, and the
+// RN SDK persists its queue to disk ('file' persistence) and deliberately does
+// NOT dequeue a batch that failed with a network error (@posthog/core's
+// `_flushRoute` only persists the dequeue when the failure is not a
+// PostHogFetchNetworkError). So events captured while offline survive an app
+// kill, flush on reconnect, and still carry `connectivity: 'offline'` — which is
+// what makes this property worth registering rather than derivable server-side.
+//
+// Best-known connectivity, NOT ground truth: it mirrors React Query's
+// `onlineManager`, which the app seeds from NetInfo asynchronously and which
+// defaults to online (query-provider.tsx), and which tracks `isConnected` rather
+// than `isInternetReachable`. A genuinely-offline cold start can therefore stamp
+// its first events 'online', and a captive portal / dead gym-wifi upstream reads
+// 'online' throughout. Both errors point the same way — they under-count offline
+// usage — so a number derived from this property is a floor, never an inflation.
+export type ConnectivityState = 'online' | 'offline';
+
+export const CONNECTIVITY_SUPER_PROPERTY = 'connectivity';
+
+export function currentConnectivityState(): ConnectivityState {
+  return onlineManager.isOnline() ? 'online' : 'offline';
+}
+
+// Registers the current connectivity as a super property. Pass the client when
+// the caller already holds one (analytics.reset() does), otherwise it resolves
+// the singleton. Best-effort like registerMobileUserAgent / registerAppEnvironment
+// in posthog-client.ts: a failure here must never break the calling path, and it
+// is a silent no-op when analytics is disabled (dev / no key → null client).
+export function registerConnectivitySuperProperty(client?: Pick<PostHog, 'register'> | null): void {
+  const target = client ?? getPostHogClient();
+  if (!target) return;
+  try {
+    void Promise.resolve(target.register({ [CONNECTIVITY_SUPER_PROPERTY]: currentConnectivityState() })).catch(
+      (error: unknown) => {
+        if (__DEV__) console.warn('[analytics] failed to register connectivity super property', error);
+      },
+    );
+  } catch (error) {
+    if (__DEV__) console.warn('[analytics] failed to register connectivity super property', error);
+  }
+}
+
+// Registers connectivity now and keeps it current for the rest of the launch.
+// Re-registers only on an actual online↔offline transition — `onlineManager`
+// notifies its subscribers on every setOnline call, including same-value ones
+// from NetInfo's chatty change stream, and each register() is a persisted write.
+// Returns the unsubscribe so the caller can tear the subscription down.
+export function startConnectivityTracking(): () => void {
+  let registeredState = currentConnectivityState();
+  registerConnectivitySuperProperty();
+  return onlineManager.subscribe(() => {
+    const nextState = currentConnectivityState();
+    if (nextState === registeredState) return;
+    registeredState = nextState;
+    registerConnectivitySuperProperty();
+  });
+}

--- a/packages/mobile/src/lib/analytics.ts
+++ b/packages/mobile/src/lib/analytics.ts
@@ -1,6 +1,7 @@
 import type { PostHog } from 'posthog-react-native';
 import { createAnalytics } from '@boardsesh/analytics';
 import { getPostHogClient, registerAppSuperProperties } from './posthog-client';
+import { registerConnectivitySuperProperty } from './analytics-connectivity';
 
 // `sendEvent: false` suppresses the SDK's `$feature_flag_called` capture. Verified
 // in @posthog/core 1.46.1 (shared by posthog-react-native and posthog-js-lite):
@@ -145,10 +146,18 @@ export const { track, identify, setPersonProperties, alias } = analytics;
 // reads as production again, reopening #3814) and `$raw_user_agent` (without it,
 // PostHog bot-filters the events). Person-scoped properties are meant to be
 // cleared and are deliberately not restored.
+//
+// `connectivity` goes back on for the same reason: it is registered once at
+// startup and then only on a network transition, so a sign-out that dropped it
+// would leave every remaining event of the launch unattributed to online or
+// offline unless the user happened to change networks (issue #4317).
 export function reset(): boolean {
   const didReset = analytics.reset();
   const client = getClient();
-  if (client) registerAppSuperProperties(client);
+  if (client) {
+    registerAppSuperProperties(client);
+    registerConnectivitySuperProperty(client);
+  }
   return didReset;
 }
 


### PR DESCRIPTION
Part 1 of two for #4317. The 2026-08-11 PostHog audit found no mobile event carries a connectivity state, a served-from-local marker, or any cache-hit signal — so the best available proxy for "does anyone use a downloaded board offline?" was app retention (63.3% of downloaders reopened on a later day), which measures something else entirely.

This PR fixes the cheap half: every event the app sends now carries whether the network was usable when it was captured.

`connectivity: 'online' | 'offline'` is registered as a PostHog super property from React Query's `onlineManager` at analytics startup, and re-registered on each real online↔offline transition. Same-value NetInfo churn is ignored, so a flaky network costs no extra persisted writes — the steady-state cost is one small write per actual transition.

Two details that make this worth doing as a super property rather than a per-event prop:

- **PostHog resolves super properties at capture time**, so `$screen`, `Tick Logged`, and the download-funnel events from #4316 all become segmentable by connectivity retroactively, with no work at any call site.
- **Offline-captured events really do arrive later.** Verified in the SDK source rather than assumed: `posthog-react-native` defaults to `persistence: 'file'`, and `@posthog/core`'s flush only persists the dequeue when the failure is **not** a `PostHogFetchNetworkError` — so a batch that fails offline stays in the on-disk queue, survives an app kill, and flushes on reconnect still carrying the `connectivity: 'offline'` it was captured with.

It is also re-registered inside `analytics.reset()`. PostHog's reset clears every super property and `getPostHogClient()` caches the singleton, so without that a sign-out silently drops connectivity for the rest of the launch — the exact trap `environment` (#3814) and `$raw_user_agent` already document there.

Known limitation, documented rather than papered over: this is best-known connectivity, not ground truth. `onlineManager` seeds from NetInfo asynchronously and defaults to online, and it tracks `isConnected`, not `isInternetReachable` — so a genuinely-offline cold start can stamp its first events `online`, and a captive portal reads `online` throughout. Both errors under-count offline usage, so any number built on this property is a floor, never an inflation.

## Changes

- `packages/mobile/src/lib/analytics-connectivity.ts` (new) — `currentConnectivityState()`, `registerConnectivitySuperProperty()`, `startConnectivityTracking()`. Best-effort and non-throwing, matching `registerMobileUserAgent` / `registerAppEnvironment`; a no-op when analytics is disabled (dev / no key).
- `packages/mobile/src/lib/analytics.ts` — `reset()` re-registers connectivity alongside the build-level super properties.
- `packages/mobile/src/components/analytics/AnalyticsProvider.tsx` — starts/stops the subscription in an effect, declared before the `!client` early return so hook order stays stable when analytics is off.
- `docs/offline-sync-plan.md` — new `## Usage telemetry` section covering what the property means, the buffer-and-flush behaviour, and the `onlineManager` caveat.
- Tests: new `analytics-connectivity.test.ts` (registers on start, re-registers only on a real transition, unsubscribes cleanly, swallows a throwing/rejecting `register`), plus a case in `analytics-reset.test.ts` for the post-reset re-registration.

No new dependencies, no native config — `@tanstack/react-query` and `posthog-react-native` are already in the native graph. Ships over OTA on the existing production channel.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — 622 files / 5491 tests passed.
- `vp run check:mobile-bundle` — android bundle OK.
- `vp check` — clean for every file this PR touches (two pre-existing formatting misses on `main`, in `.claude/skills/discord-feedback-triage/SKILL.md` and `docs/discord-feedback-pipeline.md`, are untouched here).

Not verifiable on a dev build: `isAnalyticsEnabled = !!apiKey && !__DEV__`, so Metro only exercises the debug console hook and never sends. End-to-end confirmation (go offline, browse, kill the app, reconnect, check the events land with `connectivity: 'offline'` and their original timestamps) needs the `pr-<number>` OTA preview channel against a TestFlight/store binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT6VP1sWqk6bY9mUgyeS2U

