### PR TITLE
fix(mobile): gate offline writes on a ready schema and stop retrying a closed sqlite handle

### DIFF
--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -792,6 +792,61 @@ async function saveTick(db: SQLiteDatabase, tickData: TickInput) {
 }
 ```
 
+## Startup lock model
+
+SQLite allows exactly one writer per database file. Everything below shares one
+`boardsesh.db`, so who holds that write lock at launch — and for how long — decides
+whether offline storage comes up at all.
+
+**Who holds it**
+
+| Writer                                                    | Connection                                                  | Lock window                                                                                                                                    |
+| --------------------------------------------------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Startup DDL (`ensureMutationQueueTable`, `runMigrations`) | the app's main connection                                   | milliseconds on a warm install; the full migration set on an upgrade                                                                           |
+| Snapshot import (`bootstrapScopeFromSnapshot`)            | its own native connection (`withExclusiveTransactionAsync`) | one `BEGIN EXCLUSIVE` covering `reconcileScope` + `importScope` ONLY — the artifact is already downloaded to disk before the transaction opens |
+| Paged crawl (`pull-client`)                               | its own native connection                                   | one short exclusive transaction per page, with a 5s `busy_timeout`, so a contender can win in the gaps                                         |
+| `VACUUM` / teardown deletes                               | the main connection                                         | 5-20s on a 200-400MB file                                                                                                                      |
+
+`OfflineBoardDownloadCompleted.durationMs` is **not** a lock-hold measurement. It is
+stamped when the cycle first touches a scope and covers the manifest fetch and the
+artifact download as well as the import — mostly network. Sizing a retry window off
+it overstates the real contention by an order of magnitude. The measurement that
+does describe the lock is `Offline SQLite Init Recovered`'s `elapsedMs`: how long a
+launch that lost the lock took to win it back.
+
+**Why the launch gate opens before the schema is ready**
+
+`SQLiteProvider` renders nothing until its `onInit` promise resolves, so blocking
+`initializeDatabase` until a retry wins would be a black screen for the length of the
+chain. It therefore resolves after the FIRST attempt whatever that attempt did, and
+the retries continue detached. A contended launch consequently renders the whole app
+against a connection with no tables.
+
+**The readiness contract**
+
+- Non-React callers use `getDatabaseHandle()`, which stays `null` until migrations
+  have run. They already null-check and fall back to the network.
+- Callers that take the database from `useSQLiteContext()` bypass that gate — the
+  provider hands out its connection regardless. Anything that **writes** through such
+  a handle (the sync scheduler in `OfflineSyncBridge`, the download kick in
+  `useBoardDownloads`) MUST gate on `useOfflineSchemaReady()` (`src/db/schema-ready.ts`).
+- Read-only surfaces deliberately do NOT gate. They wrap their reads in a React Query
+  `queryFn`, so a missing table lands in `isError` and renders the existing empty
+  state; gating would strand them in a permanent spinner whenever init genuinely
+  fails. They fold readiness into the `queryKey` instead, so a late flip refetches.
+- Readiness can arrive late (a retry wins seconds in) and can go back to false
+  (sign-out clears the handle), so it is a live store, not a one-shot flag. Anything
+  that clears the database must do so through `setDatabaseHandle(null)` rather than
+  poking the store, which is what keeps the two from disagreeing.
+
+**Remounts**
+
+`SQLiteProvider`'s effect teardown calls `db.closeAsync()`, so a remount mid-chain
+closes the connection the chain captured and opens a new one. The retry chain is
+single-flight for the process but retargets onto the latest connection on every
+attempt; a failure against a superseded handle is a lifecycle artefact and is
+deliberately not reported to error tracking.
+
 ## What stays the same
 
 | Component             | Status                                                                                                        |

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -15,6 +15,7 @@ import { useAuth } from '../../../src/providers/auth-provider';
 import { useProfile, useMyBoards } from '../../../src/lib/graphql/hooks';
 import { useBoardDownloads } from '../../../src/offline/use-board-downloads';
 import { isOfflineEngineEnabled } from '../../../src/lib/offline-engine';
+import { useOfflineSchemaReady } from '../../../src/db/use-offline-schema-ready';
 import {
   useSetting,
   setSetting,
@@ -157,10 +158,16 @@ export default function MoreScreen() {
   // problem). A dead-lettered write is one the server rejected or that failed past
   // its retry budget while reachable: worth surfacing with a retry (never a discard).
   const db = useSQLiteContext();
+  // Handed out as soon as the launch gate opens — after the first init attempt,
+  // whatever it did — so on a contended launch it has no tables yet. Both reads
+  // below fold readiness into their KEY rather than gating on it: a failed read
+  // renders the existing empty state (the right answer), and a late flip refetches,
+  // whereas gating would spin forever whenever init genuinely fails.
+  const schemaReady = useOfflineSchemaReady();
   const queryClient = useQueryClient();
   const isOffline = useIsOffline();
   const { data: deadLetterCount = 0, refetch: refetchDeadLetters } = useQuery({
-    queryKey: ['deadLetters', 'count'],
+    queryKey: ['deadLetters', 'count', schemaReady],
     queryFn: () => getDeadLetterCount(db),
     enabled: !isOffline,
     // Dead letters are sticky (they don't resolve without a user Retry), so a slow
@@ -176,7 +183,7 @@ export default function MoreScreen() {
   // shared cache). One cheap indexed read, same cost shape as the dead-letter count.
   // Shares the ['downloadedScopeKeys'] cache entry with My Boards, so this warms it.
   const { data: downloadedScopeKeys } = useQuery({
-    queryKey: ['downloadedScopeKeys'],
+    queryKey: ['downloadedScopeKeys', schemaReady],
     queryFn: () => getDownloadedScopeKeys(db),
   });
   // ...AND when a removal deleted its rows but the compaction never landed, so the

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -28,6 +28,7 @@ import { useBottomChromeMetrics } from '../../src/hooks/use-bottom-chrome-metric
 import { useIsOffline } from '../../src/hooks/use-is-offline';
 import { useOfflineBoards } from '../../src/settings';
 import { useRememberDownloadedBoards } from '../../src/offline/use-remember-downloaded-boards';
+import { useOfflineSchemaReady } from '../../src/db/use-offline-schema-ready';
 import { resolveBoardReturnTo } from '../../src/lib/boards/board-return-to';
 import { setBoardRevealTipPending } from '../../src/lib/onboarding/onboarding-storage';
 import { track } from '../../src/lib/analytics';
@@ -82,8 +83,14 @@ export default function BoardSelection() {
   const db = useSQLiteContext();
   // Ungated by the offline-downloads flag: this reads rows already on disk, and a
   // flag flipped off must not strand a device that has downloads.
+  //
+  // Schema readiness is a KEY member, not an `enabled` gate. On a contended launch
+  // this connection has no tables yet, and the read lands in `isError` — the empty
+  // state, which is already the right answer. Gating instead would spin forever
+  // whenever init genuinely fails; keying makes a late readiness flip refetch.
+  const schemaReady = useOfflineSchemaReady();
   const { data: downloadedScopeKeys } = useQuery({
-    queryKey: ['downloadedScopeKeys'],
+    queryKey: ['downloadedScopeKeys', schemaReady],
     queryFn: () => getDownloadedScopeKeys(db),
   });
   const offlineCards = useOfflineBoards();

--- a/packages/mobile/app/boards/manage.tsx
+++ b/packages/mobile/app/boards/manage.tsx
@@ -32,6 +32,7 @@ import { useBoardDownloads } from '../../src/offline/use-board-downloads';
 import { useRememberDownloadedBoards } from '../../src/offline/use-remember-downloaded-boards';
 import { useSnapshotManifest } from '../../src/offline/use-snapshot-manifest';
 import { useSnapshotSource } from '../../src/offline/use-snapshot-source';
+import { useOfflineSchemaReady } from '../../src/db/use-offline-schema-ready';
 import { formatBytes } from '../../src/lib/format-bytes';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { track } from '../../src/lib/analytics';
@@ -138,6 +139,9 @@ export default function ManageBoards() {
   const snapshotManifestRef = useRef(snapshotManifest);
   snapshotManifestRef.current = snapshotManifest;
   const db = useSQLiteContext();
+  // This connection is handed out as soon as the launch gate opens — after the first
+  // init attempt, whatever it did — so on a contended launch it has no tables yet.
+  const schemaReady = useOfflineSchemaReady();
   const syncStatus = useSyncStatus();
   // Mirrored for the toggle-off handler, which only reads it at tap time: keeping
   // the live status out of that callback's deps means a progress frame can't churn
@@ -189,8 +193,12 @@ export default function ManageBoards() {
   // Ungated by the flag: the offline fallback below needs it too, and a device that
   // still holds downloads after a kill-switch rollback must not be stranded. One
   // cheap indexed read, shared with the Storage screen's cache entry.
+  //
+  // Readiness is a KEY member, not an `enabled` gate: a read against the unmigrated
+  // connection fails into "nothing downloaded", which is the right answer, and a
+  // late flip refetches. Gating would spin forever whenever init genuinely fails.
   const { data: downloadedScopeKeys, refetch: refetchDownloaded } = useQuery({
-    queryKey: ['downloadedScopeKeys'],
+    queryKey: ['downloadedScopeKeys', schemaReady],
     queryFn: () => getDownloadedScopeKeys(db),
   });
   const downloadedSet = useMemo(() => new Set(downloadedScopeKeys ?? []), [downloadedScopeKeys]);

--- a/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
+++ b/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
@@ -130,9 +130,11 @@ vi.mock('@react-native-async-storage/async-storage', () => {
   };
 });
 
+import { act } from 'react';
 import { OfflineSyncBridge, OfflineEngineFlagSync } from '../offline-sync-bridge';
 import { FeatureFlagsProvider, type FeatureFlags } from '../../providers/feature-flags-provider';
 import { isOfflineEngineEnabled, __resetOfflineEngineForTests } from '../../lib/offline-engine';
+import { setSchemaReady, __resetSchemaReadyForTests } from '../../db/schema-ready';
 
 function Harness({ flags, queryClient }: { flags: FeatureFlags; queryClient: QueryClient }) {
   return (
@@ -190,10 +192,14 @@ beforeEach(() => {
   clearUserDataMock.mockClear();
   beginLocalPurgeMock.mockClear();
   snapshotBaseUrlConfigured.value = true;
+  // Every case below except the readiness-gating describe assumes the ordinary
+  // uncontended launch, where the schema is stamped before the first render.
+  setSchemaReady(true);
 });
 
 afterEach(() => {
   __resetOfflineEngineForTests();
+  __resetSchemaReadyForTests();
 });
 
 // The bridge owns the "whose rows are these?" stamp, which is the only defence
@@ -421,6 +427,59 @@ describe('OfflineSyncBridge — outbox backlog gauge', () => {
     await waitFor(() => expect(getPendingCountMock).toHaveBeenCalled());
 
     expect(reportOutboxBacklogOnceMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for a stamped schema before reading the outbox', async () => {
+    // Same hazard as the sync effect: on a contended launch pending_mutations
+    // does not exist yet, and a gauge that throws there reports no backlog at
+    // all rather than the backlog it could not read.
+    setSchemaReady(false);
+    render(<Harness flags={FLAG_ON} queryClient={makeQueryClient()} />);
+    await waitFor(() => expect(setupNotificationHandlersMock).toHaveBeenCalledTimes(1));
+    expect(reportOutboxBacklogOnceMock).not.toHaveBeenCalled();
+
+    act(() => setSchemaReady(true));
+
+    await waitFor(() => expect(reportOutboxBacklogOnceMock).toHaveBeenCalledTimes(1));
+  });
+});
+
+// The launch gate opens after the FIRST init attempt whatever it did, so on a
+// contended launch SQLiteProvider renders this bridge against a connection whose
+// migrations never ran — no board_climb_grades, no characteristics column. Both
+// branches of the sync effect WRITE, so both have to wait.
+describe('OfflineSyncBridge — schema readiness gating', () => {
+  it('does not start the scheduler against a database whose migrations have not run', async () => {
+    setSchemaReady(false);
+    render(<Harness flags={FLAG_ON} queryClient={makeQueryClient()} />);
+
+    // Notifications are readiness-independent, so waiting on them proves the effects
+    // have flushed rather than merely not run yet.
+    await waitFor(() => expect(setupNotificationHandlersMock).toHaveBeenCalledTimes(1));
+    expect(startSyncSchedulerMock).not.toHaveBeenCalled();
+  });
+
+  it('starts the scheduler exactly once when readiness lands late', async () => {
+    setSchemaReady(false);
+    render(<Harness flags={FLAG_ON} queryClient={makeQueryClient()} />);
+    await waitFor(() => expect(setupNotificationHandlersMock).toHaveBeenCalledTimes(1));
+
+    // A retry won seconds after launch.
+    act(() => setSchemaReady(true));
+
+    await waitFor(() => expect(startSyncSchedulerMock).toHaveBeenCalledTimes(1));
+  });
+
+  it('holds the flag-off leftover drain until the schema is stamped', async () => {
+    setSchemaReady(false);
+    getPendingCountMock.mockResolvedValue(3);
+    render(<Harness flags={FLAG_OFF} queryClient={makeQueryClient()} />);
+    await waitFor(() => expect(setupNotificationHandlersMock).toHaveBeenCalledTimes(1));
+    expect(getPendingCountMock).not.toHaveBeenCalled();
+
+    act(() => setSchemaReady(true));
+
+    await waitFor(() => expect(drainMutationQueueMock).toHaveBeenCalledTimes(1));
   });
 });
 

--- a/packages/mobile/src/components/offline-sync-bridge.tsx
+++ b/packages/mobile/src/components/offline-sync-bridge.tsx
@@ -22,6 +22,7 @@ import { useSnapshotSource } from '../offline/use-snapshot-source';
 import { useStoredUserId } from '../hooks/use-current-user-id';
 import { clearUserData } from '../db/connection';
 import { reportError } from '../lib/error-reporting';
+import { useOfflineSchemaReady } from '../db/use-offline-schema-ready';
 
 /**
  * Publishes the offline-engine flag decision to the module-level store that
@@ -62,6 +63,10 @@ export function OfflineSyncBridge() {
   const { isAuthenticated } = useAuth();
   const offlineEnabled = useOfflineDownloadsEnabled();
   const snapshotSource = useSnapshotSource();
+  // `useSQLiteContext()` hands out a connection as soon as the launch gate opens,
+  // which is after the FIRST init attempt whatever it did — so on a contended launch
+  // this db has no tables yet. See src/db/schema-ready.ts.
+  const schemaReady = useOfflineSchemaReady();
 
   // getHttpClient() already carries auth + endpoint; binding .request keeps the
   // GraphQLFetch shape the scheduler and drainer expect.
@@ -77,9 +82,15 @@ export function OfflineSyncBridge() {
   // path that skips cleanup entirely. Re-run the wipe, report it, and only then
   // claim the device for this account. Until the stamp matches, every
   // user-scoped local read declines and falls through to the network.
+  //
+  // Waits for a stamped schema like every other db effect here: the stamp is a
+  // write, and on a contended launch there is no sync_meta table to write it
+  // into. Nothing reads local user data before the stamp lands either — those
+  // reads go through getDatabaseHandle(), which stays null until the same
+  // moment.
   const { userId: localUserId } = useStoredUserId(isAuthenticated);
   useEffect(() => {
-    if (!isAuthenticated || !localUserId) return;
+    if (!isAuthenticated || !localUserId || !schemaReady) return;
     let cancelled = false;
     void (async () => {
       try {
@@ -112,7 +123,7 @@ export function OfflineSyncBridge() {
     return () => {
       cancelled = true;
     };
-  }, [db, isAuthenticated, localUserId]);
+  }, [db, isAuthenticated, localUserId, schemaReady]);
 
   // Unconditional (unlike the scheduler effect below): the offline-sync
   // engine's backgrounding guard must cover ad-hoc drainMutationQueue() calls
@@ -140,16 +151,24 @@ export function OfflineSyncBridge() {
   // letters) are exactly as stranded as a flag-on user's, and the bridge
   // already drains their leftovers. reportOutboxBacklogOnce self-guards against
   // this effect re-running on an auth or flag flip, and swallows its own errors.
+  // Gated on the schema like every other db effect: pending_mutations does not
+  // exist yet on a contended launch, and a gauge that throws there would report
+  // no backlog rather than the backlog it could not read.
   useEffect(() => {
-    if (!isAuthenticated) return;
+    if (!isAuthenticated || !schemaReady) return;
     void reportOutboxBacklogOnce(db);
-  }, [db, isAuthenticated]);
+  }, [db, isAuthenticated, schemaReady]);
 
   // Push-then-pull sync loop (foreground + reconnect triggers). Returns its own
   // teardown, so React calls it on unmount / dependency change — including the
   // isAuthenticated flip on sign-out, which stops the scheduler.
   useEffect(() => {
     if (!isAuthenticated) return undefined;
+    // Both branches below WRITE to the database — the scheduler pulls catalog rows
+    // and the leftover drain flushes queued mutations — so both wait for a stamped
+    // schema. Readiness usually lands before the first commit; when a contended
+    // launch makes it late, this effect re-runs on the flip and starts then.
+    if (!schemaReady) return undefined;
     if (offlineEnabled) {
       try {
         const stop = startSyncScheduler(
@@ -197,7 +216,7 @@ export function OfflineSyncBridge() {
     return () => {
       cancelled = true;
     };
-  }, [db, queryClient, graphqlFetch, offlineEnabled, snapshotSource, isAuthenticated]);
+  }, [db, queryClient, graphqlFetch, offlineEnabled, snapshotSource, isAuthenticated, schemaReady]);
 
   // Deep-link routing for tapped push notifications. Deliberately independent
   // of the offline flag — notifications ship inert for everyone today.

--- a/packages/mobile/src/components/settings/StorageSettingsScreen.tsx
+++ b/packages/mobile/src/components/settings/StorageSettingsScreen.tsx
@@ -51,6 +51,7 @@ import {
 import { measureCachedImageBytes, clearCachedImages, type CachedImageMeasurement } from '../../lib/sweep-caches';
 import { removeOfflineBoard, compactOfflineDatabase } from '../../offline/remove-offline-board';
 import { formatStorageSize } from '../../lib/format-storage-size';
+import { useOfflineSchemaReady } from '../../db/use-offline-schema-ready';
 import { reportError } from '../../lib/error-reporting';
 import { hapticLight } from '../../lib/haptics';
 import { iosSystemColors } from '../../theme/ios-colors';
@@ -77,6 +78,11 @@ export function StorageSettingsScreen() {
   const confirm = useConfirm();
   const { showToast } = useToast();
   const db = useSQLiteContext();
+  // Live as soon as the launch gate opens — after the first init attempt, whatever
+  // it did — so on a contended launch this connection has no tables yet. Folded into
+  // the query KEY below rather than gating the query: a failed measurement renders
+  // the existing error state with its Retry, and a late readiness flip re-measures.
+  const schemaReady = useOfflineSchemaReady();
   const queryClient = useQueryClient();
   const bottomChrome = useBottomChromeMetrics();
   const offlineEnabled = useOfflineDownloadsEnabled();
@@ -93,7 +99,7 @@ export function StorageSettingsScreen() {
     isRefetching,
     refetch,
   } = useQuery<StorageMeasurement>({
-    queryKey: ['offlineStorage'],
+    queryKey: ['offlineStorage', schemaReady],
     // Not a poll: this walks 200k+ rows per scope in the worst case.
     refetchOnWindowFocus: false,
     queryFn: async () => {

--- a/packages/mobile/src/db/__tests__/connection.test.ts
+++ b/packages/mobile/src/db/__tests__/connection.test.ts
@@ -198,11 +198,20 @@ describe('initializeDatabase lock contention (#4104)', () => {
   let dbDir: string;
   let realDb: TestSqliteDb;
 
+  const LOCK_ERROR_MESSAGE = "Calling the 'execAsync' function has failed → Error code 5: database is locked";
+  // What expo-sqlite throws once SQLiteProvider's teardown has closed the handle the
+  // chain captured. Not a lock error, so it classifies as permanent.
+  const CLOSED_HANDLE_MESSAGE = 'Access to closed resource';
+
   // Stands in for the contended connection: the mutation-queue DDL — the first write
   // initializeDatabase issues — fails with the real Sentry message until `unlock()`.
-  function createContendedDatabase(options: { error?: Error; onFailure?: () => void } = {}) {
-    const failure =
-      options.error ?? new Error("Calling the 'execAsync' function has failed → Error code 5: database is locked");
+  // `error` may be a function to vary the throw per failure (attempt N is contended,
+  // attempt N+1 is a closed handle).
+  function createContendedDatabase(
+    options: { error?: Error | ((failureCount: number) => Error); onFailure?: (failureCount: number) => void } = {},
+  ) {
+    const { error = new Error(LOCK_ERROR_MESSAGE) } = options;
+    const failureFor = (failureCount: number) => (typeof error === 'function' ? error(failureCount) : error);
     let locked = true;
     let failures = 0;
 
@@ -212,8 +221,8 @@ describe('initializeDatabase lock contention (#4104)', () => {
           failures += 1;
           // Lets a test land a remount WHILE this attempt is in flight, which is the
           // only way the chain's target can be superseded.
-          options.onFailure?.();
-          throw failure;
+          options.onFailure?.(failures);
+          throw failureFor(failures);
         }
         await realDb.execAsync(source);
       },
@@ -313,11 +322,10 @@ describe('initializeDatabase lock contention (#4104)', () => {
     vi.useFakeTimers();
     const healthy = createContendedDatabase();
     healthy.unlock();
-    // What expo-sqlite throws once SQLiteProvider's teardown has closed the handle
-    // the chain captured. It is NOT a lock error, so without the supersede check the
-    // chain would stop dead on attempt 1 and file it under kind:'sqlite-init'.
+    // Without the supersede check the chain would stop dead on attempt 1 and file the
+    // closed-handle throw under kind:'sqlite-init'.
     const closed = createContendedDatabase({
-      error: new Error('Access to closed resource'),
+      error: new Error(CLOSED_HANDLE_MESSAGE),
       onFailure: () => {
         void initializeDatabase(healthy.db);
       },
@@ -334,6 +342,39 @@ describe('initializeDatabase lock contention (#4104)', () => {
     // artefact must not arm the recovery event either, or its ~retry-delay
     // elapsedMs would feed the distribution that sizes the retry window (#4325).
     expect(trackMock).not.toHaveBeenCalled();
+  });
+
+  it('does not spend the final attempt on a connection the remount had already closed', async () => {
+    vi.useFakeTimers();
+    const healthy = createContendedDatabase();
+    healthy.unlock();
+
+    // Attempts 1-4 are genuine contention; the remount lands DURING attempt 5, so the
+    // last attempt fails against a handle SQLiteProvider had already closed. That
+    // failure tested nothing, so it must not be the one that exhausts the budget:
+    // the remount already holds the resolved launch promise, so a chain that gives up
+    // here leaves the replacement handle uninitialized for the whole session.
+    const contended = createContendedDatabase({
+      error: (failureCount) => new Error(failureCount === 5 ? CLOSED_HANDLE_MESSAGE : LOCK_ERROR_MESSAGE),
+      onFailure: (failureCount) => {
+        if (failureCount === 5) {
+          void initializeDatabase(healthy.db);
+        }
+      },
+    });
+
+    await initializeDatabase(contended.db);
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(contended.failures()).toBe(5);
+    expect(getDatabaseHandle()).toBe(healthy.db);
+    expect(isSchemaReady()).toBe(true);
+    expect(reportErrorMock).not.toHaveBeenCalled();
+    // The refunded attempt retries immediately — the replacement connection is fresh,
+    // so there is no lock to wait out — and the lock narrative survives it: the
+    // recovery still names the contention from attempt 4, not the closed handle.
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(trackMock.mock.calls[0][1]).toMatchObject({ attempts: 6, phase: 'queue-table', sqliteCode: 5 });
   });
 
   it('reports a recovered init exactly once, with the contention it survived', async () => {

--- a/packages/mobile/src/db/__tests__/connection.test.ts
+++ b/packages/mobile/src/db/__tests__/connection.test.ts
@@ -330,6 +330,10 @@ describe('initializeDatabase lock contention (#4104)', () => {
 
     expect(getDatabaseHandle()).toBe(healthy.db);
     expect(reportErrorMock).not.toHaveBeenCalled();
+    // Working around a remount is not recovering from a lock: the closed-handle
+    // artefact must not arm the recovery event either, or its ~retry-delay
+    // elapsedMs would feed the distribution that sizes the retry window (#4325).
+    expect(trackMock).not.toHaveBeenCalled();
   });
 
   it('reports a recovered init exactly once, with the contention it survived', async () => {

--- a/packages/mobile/src/db/__tests__/connection.test.ts
+++ b/packages/mobile/src/db/__tests__/connection.test.ts
@@ -14,7 +14,11 @@ import { fileURLToPath } from 'node:url';
 const reportErrorMock = vi.hoisted(() => vi.fn());
 vi.mock('../../lib/error-reporting', () => ({ reportError: reportErrorMock }));
 
+const trackMock = vi.hoisted(() => vi.fn());
+vi.mock('../../lib/analytics', () => ({ track: trackMock }));
+
 import type { SQLiteDatabase } from 'expo-sqlite';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
 import {
   clearUserData,
   getDatabaseHandle,
@@ -22,6 +26,7 @@ import {
   INIT_RETRY_DELAYS_MS,
   setDatabaseHandle,
 } from '../connection';
+import { isSchemaReady } from '../schema-ready';
 import { resetDatabaseInitializationForTests } from '../testing';
 import {
   runMigrations,
@@ -137,6 +142,7 @@ describe('initializeDatabase connection PRAGMAs', () => {
     resetDatabaseInitializationForTests();
     setDatabaseHandle(null);
     reportErrorMock.mockClear();
+    trackMock.mockClear();
     dbDir = mkdtempSync(join(tmpdir(), 'bs-conn-'));
     dbPath = join(dbDir, 'boardsesh.db');
     fileDb = createTestDatabase(dbPath) as unknown as TestSqliteDb & SQLiteDatabase;
@@ -180,12 +186,21 @@ describe('initializeDatabase lock contention (#4104)', () => {
   // and nothing else, and it keeps tracking if the backoff is ever retuned.
   const FIRST_RETRY_DELAY_MS = INIT_RETRY_DELAYS_MS[0];
 
+  // The failure report awaits a best-effort `PRAGMA journal_mode` read-back, so it
+  // lands a microtask or two after the launch gate the test awaited. Wait for the
+  // report itself rather than guessing a tick count.
+  function settledReport(): Promise<void> {
+    return vi.waitFor(() => {
+      expect(reportErrorMock).toHaveBeenCalled();
+    });
+  }
+
   let dbDir: string;
   let realDb: TestSqliteDb;
 
   // Stands in for the contended connection: the mutation-queue DDL — the first write
   // initializeDatabase issues — fails with the real Sentry message until `unlock()`.
-  function createContendedDatabase(options: { error?: Error } = {}) {
+  function createContendedDatabase(options: { error?: Error; onFailure?: () => void } = {}) {
     const failure =
       options.error ?? new Error("Calling the 'execAsync' function has failed → Error code 5: database is locked");
     let locked = true;
@@ -195,6 +210,9 @@ describe('initializeDatabase lock contention (#4104)', () => {
       execAsync: async (source: string): Promise<void> => {
         if (locked && /pending_mutations/i.test(source)) {
           failures += 1;
+          // Lets a test land a remount WHILE this attempt is in flight, which is the
+          // only way the chain's target can be superseded.
+          options.onFailure?.();
           throw failure;
         }
         await realDb.execAsync(source);
@@ -219,6 +237,7 @@ describe('initializeDatabase lock contention (#4104)', () => {
     resetDatabaseInitializationForTests();
     setDatabaseHandle(null);
     reportErrorMock.mockClear();
+    trackMock.mockClear();
     dbDir = mkdtempSync(join(tmpdir(), 'bs-lock-'));
     realDb = createTestDatabase(join(dbDir, 'boardsesh.db'));
   });
@@ -262,7 +281,7 @@ describe('initializeDatabase lock contention (#4104)', () => {
     expect(reportErrorMock).not.toHaveBeenCalled();
   });
 
-  it('shares one lifecycle across a remount mid-retry rather than starting a second chain', async () => {
+  it('shares one lifecycle across a remount mid-retry, retargeted onto the new connection', async () => {
     vi.useFakeTimers();
     const first = createContendedDatabase();
     const second = createContendedDatabase();
@@ -277,12 +296,126 @@ describe('initializeDatabase lock contention (#4104)', () => {
     const remount = initializeDatabase(second.db);
     expect(remount).toBe(initial);
 
-    first.unlock();
+    // ...but the one chain must follow the LIVE connection. SQLiteProvider's effect
+    // teardown closed `first.db` on that remount, so every remaining attempt against
+    // it would throw "closed resource" — not a lock error, so classified permanent
+    // and reported to Sentry as a sqlite-init failure that never happened.
+    second.unlock();
     await vi.advanceTimersByTimeAsync(FIRST_RETRY_DELAY_MS);
 
-    expect(getDatabaseHandle()).toBe(first.db);
-    // The second database was never touched.
-    expect(second.failures()).toBe(0);
+    expect(getDatabaseHandle()).toBe(second.db);
+    // The dead connection was touched once, by the attempt that predates the remount.
+    expect(first.failures()).toBe(1);
+    expect(reportErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('does not report a failure against a connection the remount had already closed', async () => {
+    vi.useFakeTimers();
+    const healthy = createContendedDatabase();
+    healthy.unlock();
+    // What expo-sqlite throws once SQLiteProvider's teardown has closed the handle
+    // the chain captured. It is NOT a lock error, so without the supersede check the
+    // chain would stop dead on attempt 1 and file it under kind:'sqlite-init'.
+    const closed = createContendedDatabase({
+      error: new Error('Access to closed resource'),
+      onFailure: () => {
+        void initializeDatabase(healthy.db);
+      },
+    });
+
+    await initializeDatabase(closed.db);
+    expect(reportErrorMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(FIRST_RETRY_DELAY_MS);
+
+    expect(getDatabaseHandle()).toBe(healthy.db);
+    expect(reportErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('reports a recovered init exactly once, with the contention it survived', async () => {
+    vi.useFakeTimers();
+    const contended = createContendedDatabase();
+
+    await initializeDatabase(contended.db);
+    contended.unlock();
+    await vi.advanceTimersByTimeAsync(FIRST_RETRY_DELAY_MS);
+
+    expect(getDatabaseHandle()).toBe(contended.db);
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    const [eventName, properties] = trackMock.mock.calls[0];
+    expect(eventName).toBe(SHARED_EVENTS.OfflineSqliteInitRecovered);
+    expect(properties).toMatchObject({ attempts: 2, phase: 'queue-table', sqliteCode: 5 });
+    expect(typeof (properties as { elapsedMs: unknown }).elapsedMs).toBe('number');
+    // A recovery is not a failure — it must not also land in the Sentry aggregate.
+    expect(reportErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet on a clean launch — no recovery event when attempt 1 wins', async () => {
+    const healthy = createContendedDatabase();
+    healthy.unlock();
+
+    await initializeDatabase(healthy.db);
+
+    expect(getDatabaseHandle()).toBe(healthy.db);
+    expect(trackMock).not.toHaveBeenCalled();
+  });
+
+  it('publishes schema readiness only once the migrations have actually run', async () => {
+    vi.useFakeTimers();
+    const contended = createContendedDatabase();
+
+    await initializeDatabase(contended.db);
+    // The launch gate is open and every screen is rendering against this connection,
+    // but it has no tables yet — the whole point of the readiness store.
+    expect(isSchemaReady()).toBe(false);
+
+    contended.unlock();
+    await vi.advanceTimersByTimeAsync(FIRST_RETRY_DELAY_MS);
+
+    expect(isSchemaReady()).toBe(true);
+  });
+
+  it('tags the failure report with the SQLite result code and the journal mode', async () => {
+    vi.useFakeTimers();
+    const contended = createContendedDatabase();
+
+    await initializeDatabase(contended.db);
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    const [, context] = reportErrorMock.mock.calls[0];
+    expect(context.tags).toMatchObject({ sqlite_code: 5, journal_mode: 'wal' });
+    expect(context.extra).toMatchObject({ attempts: 5, retryable: true });
+    expect(typeof context.extra.elapsedMs).toBe('number');
+  });
+
+  it('falls back to an explicit sentinel when the journal-mode read itself fails', async () => {
+    // The report runs against a database that is contended by definition, so the
+    // read-back can fail too. 'unavailable' keeps "stuck in rollback journal"
+    // distinguishable from "we could not tell", instead of the tag vanishing.
+    const contended = createContendedDatabase({ error: new Error('Error code 10: disk I/O error') });
+    const unreadable = {
+      ...(contended.db as unknown as Record<string, unknown>),
+      getFirstAsync: () => Promise.reject(new Error('Error code 10: disk I/O error')),
+    } as unknown as SQLiteDatabase;
+
+    await initializeDatabase(unreadable);
+    await settledReport();
+
+    const [, context] = reportErrorMock.mock.calls[0];
+    expect(context.tags).toMatchObject({ journal_mode: 'unavailable' });
+  });
+
+  it('reports a disk-I/O failure on the first attempt, carrying its result code', async () => {
+    const failing = createContendedDatabase({ error: new Error('Error code 10: disk I/O error') });
+
+    await initializeDatabase(failing.db);
+    await settledReport();
+
+    expect(failing.failures()).toBe(1);
+    expect(reportErrorMock).toHaveBeenCalledTimes(1);
+    const [, context] = reportErrorMock.mock.calls[0];
+    expect(context.tags).toMatchObject({ sqlite_code: 10 });
+    expect(context.extra).toMatchObject({ attempts: 1, retryable: false });
   });
 
   it('gives up after the bounded attempt window and reports once, tagged with the phase', async () => {
@@ -307,6 +440,7 @@ describe('initializeDatabase lock contention (#4104)', () => {
     const contended = createContendedDatabase({ error: new Error('disk I/O error') });
 
     await initializeDatabase(contended.db);
+    await settledReport();
 
     expect(contended.failures()).toBe(1);
     expect(reportErrorMock).toHaveBeenCalledTimes(1);

--- a/packages/mobile/src/db/__tests__/use-offline-schema-ready.web.test.ts
+++ b/packages/mobile/src/db/__tests__/use-offline-schema-ready.web.test.ts
@@ -1,0 +1,21 @@
+// The browser app has no offline SQLite: metro.config.js aliases `expo-sqlite` to
+// src/web-shims/sqlite.tsx and database-provider.web.tsx never calls
+// initializeDatabase, so nothing publishes a handle and the native readiness store
+// would read false forever. Every gate built on it would then be permanently off,
+// turning surfaces that render safe empty states today into dead ones.
+//
+// This fork is invisible to the native bundle and to `vp run typecheck:mobile`'s
+// default resolution, so only `check:mobile-web-bundle` would catch it going wrong.
+// Importing it explicitly here is the guard.
+
+import { describe, expect, it } from 'vitest';
+import { useOfflineSchemaReady } from '../use-offline-schema-ready.web';
+
+describe('useOfflineSchemaReady (Expo web fork)', () => {
+  it('reports ready unconditionally, with no store to subscribe to', () => {
+    // Callable outside a render because it holds no hooks — that is the point: it
+    // must not reach for the native store, which web never populates.
+    expect(useOfflineSchemaReady()).toBe(true);
+    expect(useOfflineSchemaReady()).toBe(true);
+  });
+});

--- a/packages/mobile/src/db/connection.ts
+++ b/packages/mobile/src/db/connection.ts
@@ -11,9 +11,13 @@ import {
   runMigrations,
   deleteUserCheckpoints,
   applyBusyTimeout,
+  classifySqliteLockError,
   configureMainConnection,
 } from '@boardsesh/offline-sync';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { reportError } from '../lib/error-reporting';
+import { track } from '../lib/analytics';
+import { setSchemaReady } from './schema-ready';
 
 export const DATABASE_NAME = 'boardsesh.db';
 
@@ -37,6 +41,11 @@ let databaseHandle: SQLiteDatabase | null = null;
 
 export function setDatabaseHandle(db: SQLiteDatabase | null): void {
   databaseHandle = db;
+  // The handle is only ever published once migrations have run, so it doubles as
+  // the schema-readiness signal for the `useSQLiteContext()` consumers that can't
+  // see this handle at all. Driving the store from here — rather than letting
+  // callers poke it — keeps the two from ever disagreeing.
+  setSchemaReady(db !== null);
 }
 
 export function getDatabaseHandle(): SQLiteDatabase | null {
@@ -72,26 +81,68 @@ export const INIT_RETRY_DELAYS_MS = [500, 2_000, 5_000, 10_000];
 let activeInitialization: Promise<void> | null = null;
 
 /**
+ * The most recent database `SQLiteProvider` handed us, which is not necessarily the
+ * one the in-flight chain started with.
+ *
+ * `SQLiteProvider`'s effect teardown calls `db.closeAsync()` (expo-sqlite
+ * `build/hooks.js`), so a remount mid-chain CLOSES the connection the chain captured
+ * and opens a new one. The single-flight guard above means the remount just gets the
+ * existing promise back — so without this, every remaining retry hammers a closed
+ * handle, throws "database is closed" (not a lock error, therefore classified
+ * non-retryable), and reports a lifecycle artefact to Sentry under
+ * `kind: 'sqlite-init'` — polluting the exact aggregate #4314 reads to decide
+ * whether the lock problem is fixed. Each attempt reads this instead, so one chain
+ * follows the LIVE connection.
+ */
+let latestDatabase: SQLiteDatabase | null = null;
+
+/**
+ * At most one recovery event per process. A launch can only recover once, but the
+ * chain can restart after an exhausted window (`activeInitialization` is cleared),
+ * and one launch must not emit two.
+ */
+let hasReportedRecovery = false;
+
+/**
  * Which step of the setup sequence failed. Tagged on the Sentry report so the next
  * triage can tell a refused WAL switch from a locked migration — #4104 could not,
  * because all three steps shared a single catch.
  */
 type InitPhase = 'wal' | 'queue-table' | 'migrations';
 
-type InitOutcome = { status: 'ready' } | { status: 'failed'; phase: InitPhase; error: unknown; retryable: boolean };
+type InitOutcome =
+  | { status: 'ready' }
+  | { status: 'failed'; phase: InitPhase; error: unknown; retryable: boolean; sqliteCode: number | null };
 
-/**
- * A lock contention (SQLITE_BUSY code 5 / SQLITE_LOCKED code 6) — transient by
- * definition, so worth retrying. Anything else (a full disk, a corrupt file, missing
- * permissions) would fail identically forever, so it is reported at once instead.
- */
-function isDatabaseLockedError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return /database (?:table )?is locked/i.test(message);
-}
+// Retryability comes from `classifySqliteLockError` (@boardsesh/offline-sync,
+// db/lock-errors.ts): a lock contention (SQLITE_BUSY 5 / SQLITE_LOCKED 6) is
+// transient by definition and worth another attempt, while anything else — a full
+// disk, a corrupt file, missing permissions — would fail identically forever and is
+// reported at once. The matching lives there rather than here because the message
+// shapes differ per platform and are only knowable from telemetry, so they need a
+// test pinning the literal strings Sentry carries.
 
 function delay(durationMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, durationMs));
+}
+
+/**
+ * Best-effort read of the file's journal mode for the failure report.
+ *
+ * Tagged because one untested hypothesis for a device that fails at launch forever
+ * is that it never made it out of rollback-journal mode (the WAL switch is
+ * one-shot, and `configureMainConnection` steps over a refused one). By definition
+ * this runs against a contended database, so the read can fail too — the explicit
+ * `'unavailable'` sentinel keeps "stuck in rollback journal" distinguishable from
+ * "we couldn't tell", instead of the tag silently vanishing.
+ */
+async function readJournalMode(db: SQLiteDatabase): Promise<string> {
+  try {
+    const row = await db.getFirstAsync<{ journal_mode: string }>('PRAGMA journal_mode');
+    return row?.journal_mode ?? 'unavailable';
+  } catch {
+    return 'unavailable';
+  }
 }
 
 /**
@@ -118,6 +169,9 @@ function delay(durationMs: number): Promise<void> {
  * layout, size) scope.
  */
 export function initializeDatabase(db: SQLiteDatabase): Promise<void> {
+  // Recorded on EVERY call, including the remount that only gets the shared promise
+  // back, so the in-flight chain can retarget onto the live connection.
+  latestDatabase = db;
   activeInitialization ??= beginInitialization(db);
   return activeInitialization;
 }
@@ -143,7 +197,8 @@ async function attemptInitialization(db: SQLiteDatabase): Promise<InitOutcome> {
     setDatabaseHandle(db);
     return { status: 'ready' };
   } catch (error) {
-    return { status: 'failed', phase, error, retryable: isDatabaseLockedError(error) };
+    const { locked, code } = classifySqliteLockError(error);
+    return { status: 'failed', phase, error, retryable: locked, sqliteCode: code };
   }
 }
 
@@ -162,10 +217,18 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
   });
 
   void (async () => {
-    const deadline = Date.now() + MAX_INIT_WINDOW_MS;
+    const startedAt = Date.now();
+    const deadline = startedAt + MAX_INIT_WINDOW_MS;
+    // What the last failed attempt tripped over, so a recovery can say which step
+    // was contended rather than just "it took three goes".
+    let lastFailure: { phase: InitPhase; sqliteCode: number | null } | null = null;
 
     for (let attempt = 1; attempt <= MAX_INIT_ATTEMPTS; attempt += 1) {
-      const outcome = await attemptInitialization(db);
+      // The live connection, which a remount may have swapped since the chain
+      // started — see `latestDatabase`. Falls back to the captured one only if the
+      // handle was cleared outright.
+      const target = latestDatabase ?? db;
+      const outcome = await attemptInitialization(target);
 
       // Unblock the provider once, whatever the first attempt did.
       if (attempt === 1) {
@@ -173,12 +236,28 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
       }
 
       if (outcome.status === 'ready') {
+        if (attempt > 1) {
+          reportInitRecovered({
+            attempts: attempt,
+            elapsedMs: Date.now() - startedAt,
+            phase: lastFailure?.phase ?? null,
+            sqliteCode: lastFailure?.sqliteCode ?? null,
+          });
+        }
         return;
       }
 
+      lastFailure = { phase: outcome.phase, sqliteCode: outcome.sqliteCode };
+
+      // A remount landed WHILE this attempt was in flight, so the connection it just
+      // failed against is the one `SQLiteProvider` closed on teardown. That failure
+      // says nothing about the lock, and reporting it would pollute the sqlite-init
+      // aggregate with a lifecycle artefact — carry on against the new handle instead.
+      const superseded = latestDatabase !== null && latestDatabase !== target;
+
       const retryDelayMs = INIT_RETRY_DELAYS_MS[attempt - 1];
       const outOfRoad =
-        !outcome.retryable ||
+        (!outcome.retryable && !superseded) ||
         attempt === MAX_INIT_ATTEMPTS ||
         retryDelayMs === undefined ||
         Date.now() + retryDelayMs >= deadline;
@@ -191,15 +270,27 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
             outcome.error,
           );
         }
-        // In production a silent null handle just switches every offline feature off
-        // with no trace — report it so a spike is diagnosable from telemetry. Only the
-        // final attempt reports, so a retried-and-recovered launch stays quiet.
-        reportError(outcome.error, {
-          tags: { source: 'offline-sync', kind: 'sqlite-init', phase: outcome.phase },
-          extra: { attempts: attempt, retryable: outcome.retryable },
-        });
-        // Let a genuinely new mount try again rather than staying dead for the process.
+        // Let a genuinely new mount try again rather than staying dead for the
+        // process. Cleared BEFORE the report, because the journal-mode read-back
+        // below awaits — a mount landing in that window must start a fresh chain
+        // rather than be handed this dead one.
         activeInitialization = null;
+        if (!superseded) {
+          // In production a silent null handle just switches every offline feature off
+          // with no trace — report it so a spike is diagnosable from telemetry. Only the
+          // final attempt reports, so a retried-and-recovered launch stays quiet (it
+          // fires the recovery event above instead).
+          reportError(outcome.error, {
+            tags: {
+              source: 'offline-sync',
+              kind: 'sqlite-init',
+              phase: outcome.phase,
+              sqlite_code: outcome.sqliteCode,
+              journal_mode: await readJournalMode(target),
+            },
+            extra: { attempts: attempt, retryable: outcome.retryable, elapsedMs: Date.now() - startedAt },
+          });
+        }
         return;
       }
 
@@ -208,6 +299,29 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
   })();
 
   return launchGate;
+}
+
+/**
+ * Report that offline storage came up on a retry, at most once per process.
+ *
+ * Without this the lane is write-only: Sentry hears about a launch that ran out of
+ * retries and nothing at all about one that contended and recovered, so after an OTA
+ * "fixed" and "still contending, just retrying its way out" look identical. The
+ * `elapsedMs` distribution is also the only measurement of how long the offline
+ * writers actually hold the file — the retry window is sized on a guess today.
+ *
+ * Firing this ~1s into launch is safe: the PostHog client is constructed eagerly at
+ * module import with a synchronously-resolved bootstrap distinct id.
+ */
+function reportInitRecovered(properties: {
+  attempts: number;
+  elapsedMs: number;
+  phase: InitPhase | null;
+  sqliteCode: number | null;
+}): void {
+  if (hasReportedRecovery) return;
+  hasReportedRecovery = true;
+  track(SHARED_EVENTS.OfflineSqliteInitRecovered, properties);
 }
 
 /**
@@ -220,6 +334,8 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
  */
 export function resetDatabaseInitializationForTests(): void {
   activeInitialization = null;
+  latestDatabase = null;
+  hasReportedRecovery = false;
 }
 
 /**

--- a/packages/mobile/src/db/connection.ts
+++ b/packages/mobile/src/db/connection.ts
@@ -236,24 +236,35 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
       }
 
       if (outcome.status === 'ready') {
-        if (attempt > 1) {
+        // Only a chain that survived a GENUINE lock failure recovered from
+        // contention. A chain whose only failure was against a superseded (closed)
+        // handle worked around a remount, not a lock — firing the event for it
+        // would claim contention that never happened and feed a bogus ~retry-delay
+        // `elapsedMs` into the distribution that sizes the retry window (#4325).
+        if (attempt > 1 && lastFailure !== null) {
           reportInitRecovered({
             attempts: attempt,
             elapsedMs: Date.now() - startedAt,
-            phase: lastFailure?.phase ?? null,
-            sqliteCode: lastFailure?.sqliteCode ?? null,
+            phase: lastFailure.phase,
+            sqliteCode: lastFailure.sqliteCode,
           });
         }
         return;
       }
-
-      lastFailure = { phase: outcome.phase, sqliteCode: outcome.sqliteCode };
 
       // A remount landed WHILE this attempt was in flight, so the connection it just
       // failed against is the one `SQLiteProvider` closed on teardown. That failure
       // says nothing about the lock, and reporting it would pollute the sqlite-init
       // aggregate with a lifecycle artefact — carry on against the new handle instead.
       const superseded = latestDatabase !== null && latestDatabase !== target;
+
+      // Lock-classified failures always count toward the recovery narrative — the
+      // lock was real even if the handle was superseded a moment later. A non-lock
+      // throw against a superseded handle is the closed-connection artefact above
+      // and must not arm the recovery event.
+      if (outcome.retryable || !superseded) {
+        lastFailure = { phase: outcome.phase, sqliteCode: outcome.sqliteCode };
+      }
 
       const retryDelayMs = INIT_RETRY_DELAYS_MS[attempt - 1];
       const outOfRoad =
@@ -316,7 +327,7 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
 function reportInitRecovered(properties: {
   attempts: number;
   elapsedMs: number;
-  phase: InitPhase | null;
+  phase: InitPhase;
   sqliteCode: number | null;
 }): void {
   if (hasReportedRecovery) return;

--- a/packages/mobile/src/db/connection.ts
+++ b/packages/mobile/src/db/connection.ts
@@ -66,6 +66,13 @@ export function getDatabaseHandle(): SQLiteDatabase | null {
  */
 const MAX_INIT_ATTEMPTS = 5;
 const MAX_INIT_WINDOW_MS = 30_000;
+/**
+ * How many times a superseded attempt may be refunded (see the restart branch in
+ * `beginInitialization`). Each refund needs its own remount — the retry immediately
+ * retargets onto the connection that superseded it — so this only exists to stop a
+ * pathological remount loop from keeping one chain alive forever.
+ */
+const MAX_SUPERSEDED_RESTARTS = 3;
 // Exported so the retry tests advance their fake clock by the real gap rather than
 // mirroring these numbers in a literal that silently drifts from them.
 export const INIT_RETRY_DELAYS_MS = [500, 2_000, 5_000, 10_000];
@@ -223,15 +230,24 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
     // was contended rather than just "it took three goes".
     let lastFailure: { phase: InitPhase; sqliteCode: number | null } | null = null;
 
-    for (let attempt = 1; attempt <= MAX_INIT_ATTEMPTS; attempt += 1) {
+    // Attempts made, for the telemetry narrative ("it took three goes").
+    let attempts = 0;
+    // Attempts that actually reached the live connection, which is what the backoff
+    // and the give-up ceiling are budgeting for. A superseded attempt is refunded —
+    // see the restart branch below.
+    let budgetSpent = 0;
+    let supersededRestarts = 0;
+
+    while (budgetSpent < MAX_INIT_ATTEMPTS) {
       // The live connection, which a remount may have swapped since the chain
       // started — see `latestDatabase`. Falls back to the captured one only if the
       // handle was cleared outright.
       const target = latestDatabase ?? db;
       const outcome = await attemptInitialization(target);
+      attempts += 1;
 
       // Unblock the provider once, whatever the first attempt did.
-      if (attempt === 1) {
+      if (attempts === 1) {
         releaseLaunch();
       }
 
@@ -241,9 +257,11 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
         // handle worked around a remount, not a lock — firing the event for it
         // would claim contention that never happened and feed a bogus ~retry-delay
         // `elapsedMs` into the distribution that sizes the retry window (#4325).
-        if (attempt > 1 && lastFailure !== null) {
+        // `lastFailure` is only ever set by an earlier iteration, so it doubles as
+        // the "this was not a first-attempt win" check.
+        if (lastFailure !== null) {
           reportInitRecovered({
-            attempts: attempt,
+            attempts,
             elapsedMs: Date.now() - startedAt,
             phase: lastFailure.phase,
             sqliteCode: lastFailure.sqliteCode,
@@ -266,17 +284,30 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
         lastFailure = { phase: outcome.phase, sqliteCode: outcome.sqliteCode };
       }
 
-      const retryDelayMs = INIT_RETRY_DELAYS_MS[attempt - 1];
+      // A non-lock failure against a superseded handle never touched the live file, so
+      // it spends no budget and takes no backoff — the replacement connection is fresh,
+      // there is nothing to wait out. Without the refund a remount landing during the
+      // LAST attempt hit the attempt ceiling and ended the chain with the
+      // replacement never initialized, and nothing left to call in: that remount had
+      // already been handed the resolved launch promise, so schema readiness stayed
+      // false for the rest of the session.
+      if (superseded && !outcome.retryable && supersededRestarts < MAX_SUPERSEDED_RESTARTS) {
+        supersededRestarts += 1;
+        continue;
+      }
+
+      budgetSpent += 1;
+      const retryDelayMs = INIT_RETRY_DELAYS_MS[budgetSpent - 1];
       const outOfRoad =
         (!outcome.retryable && !superseded) ||
-        attempt === MAX_INIT_ATTEMPTS ||
+        budgetSpent === MAX_INIT_ATTEMPTS ||
         retryDelayMs === undefined ||
         Date.now() + retryDelayMs >= deadline;
 
       if (outOfRoad) {
         if (__DEV__) {
           console.warn(
-            `[SQLite] initializeDatabase failed in phase "${outcome.phase}" after ${attempt} attempt(s); ` +
+            `[SQLite] initializeDatabase failed in phase "${outcome.phase}" after ${attempts} attempt(s); ` +
               'offline storage disabled this session:',
             outcome.error,
           );
@@ -299,7 +330,7 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
               sqlite_code: outcome.sqliteCode,
               journal_mode: await readJournalMode(target),
             },
-            extra: { attempts: attempt, retryable: outcome.retryable, elapsedMs: Date.now() - startedAt },
+            extra: { attempts, retryable: outcome.retryable, elapsedMs: Date.now() - startedAt },
           });
         }
         return;

--- a/packages/mobile/src/db/index.ts
+++ b/packages/mobile/src/db/index.ts
@@ -1,3 +1,6 @@
 // On-device DDL + migrations live in @boardsesh/offline-sync (the client half of
 // docs/sync-table-manifest.md); this barrel keeps the expo-sqlite lifecycle only.
 export { DATABASE_NAME, initializeDatabase, setDatabaseHandle, getDatabaseHandle, clearUserData } from './connection';
+// Schema readiness for the consumers that take their db from `useSQLiteContext()`
+// and so can't use the null-gated handle above — see ./schema-ready.
+export { isSchemaReady, subscribeSchemaReady } from './schema-ready';

--- a/packages/mobile/src/db/schema-ready.ts
+++ b/packages/mobile/src/db/schema-ready.ts
@@ -1,0 +1,55 @@
+// Whether the offline SQLite schema is actually in place, as a module-level
+// subscribable store. React-free on purpose (the hook lives in
+// ./use-offline-schema-ready), mirroring src/sync/sync-status.ts.
+//
+// WHY THIS EXISTS
+//
+// `initializeDatabase` releases the launch gate after its FIRST attempt whatever
+// that attempt did (connection.ts) — blocking would leave `SQLiteProvider`
+// rendering nothing, i.e. a black screen, for the length of the retry chain. So on
+// a contended launch the provider hands every child a `useSQLiteContext()` handle
+// for a database whose migrations have not run: no `board_climb_grades`, no
+// `characteristics` column.
+//
+// Consumers that go through `getDatabaseHandle()` are safe — it stays null until
+// the schema is stamped, and they all null-check. Consumers that take the db from
+// `useSQLiteContext()` bypass that gate entirely, and the two that WRITE
+// (`OfflineSyncBridge`'s scheduler, `useBoardDownloads`' triggerSync) would start
+// a sync and a snapshot import against a half-set-up file. This store is the
+// signal they gate on.
+//
+// Readiness can arrive LATE (a retry wins seconds after launch) and can go back to
+// false (sign-out clears the handle), so it is a live store rather than a one-shot
+// flag.
+
+let schemaReady = false;
+const listeners = new Set<() => void>();
+
+/**
+ * Publish schema readiness. Only the database lifecycle may call this — it is
+ * driven from `setDatabaseHandle`, so the store can never disagree with the handle
+ * every non-React consumer already null-checks.
+ */
+export function setSchemaReady(ready: boolean): void {
+  if (schemaReady === ready) return;
+  schemaReady = ready;
+  for (const listener of listeners) listener();
+}
+
+/** Current readiness without subscribing (tests, imperative callers). */
+export function isSchemaReady(): boolean {
+  return schemaReady;
+}
+
+/** Subscribe to readiness changes. Returns the unsubscribe function. */
+export function subscribeSchemaReady(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Test-only: drop back to the not-ready state between cases. */
+export function __resetSchemaReadyForTests(): void {
+  setSchemaReady(false);
+}

--- a/packages/mobile/src/db/use-offline-schema-ready.ts
+++ b/packages/mobile/src/db/use-offline-schema-ready.ts
@@ -1,0 +1,21 @@
+import { useSyncExternalStore } from 'react';
+import { isSchemaReady, subscribeSchemaReady } from './schema-ready';
+
+/**
+ * Whether the offline SQLite schema is in place, as a live subscription.
+ *
+ * Every consumer that takes its database from `useSQLiteContext()` — rather than
+ * the already-null-gated `getDatabaseHandle()` — must consult this before WRITING:
+ * the launch gate opens after the first init attempt regardless of outcome, so on
+ * a contended launch the provider hands out a handle whose migrations never ran.
+ * See ./schema-ready for the full contract.
+ *
+ * Read-only surfaces do NOT gate on it. They wrap their reads in a React Query
+ * `queryFn`, so a missing table lands in `isError` and renders the existing empty
+ * state; gating them would strand them in a permanent spinner whenever init
+ * genuinely fails. They fold readiness into their `queryKey` instead, so a late
+ * flip refetches.
+ */
+export function useOfflineSchemaReady(): boolean {
+  return useSyncExternalStore(subscribeSchemaReady, isSchemaReady, () => false);
+}

--- a/packages/mobile/src/db/use-offline-schema-ready.web.ts
+++ b/packages/mobile/src/db/use-offline-schema-ready.web.ts
@@ -1,0 +1,19 @@
+/**
+ * Expo-web fork: readiness is always true in the browser.
+ *
+ * The browser app has no offline SQLite at all. `metro.config.js` aliases
+ * `expo-sqlite` to `src/web-shims/sqlite.tsx` (a fake connection whose queries
+ * resolve to `[]` and whose writes are no-ops), and `database-provider.web.tsx`
+ * renders its children without ever calling `initializeDatabase`. Nothing on web
+ * publishes a handle, so the native store would report "not ready" forever and
+ * every gate built on it would be permanently off — turning surfaces that render
+ * safe empty states today into dead ones.
+ *
+ * Returning a constant keeps web behaviour byte-for-byte what it is now: the
+ * gates pass, the fake database answers, the screens render as before. Wiring
+ * real offline storage for the browser (wa-sqlite / OPFS) is a separate job; when
+ * it lands, this fork becomes a real subscription instead.
+ */
+export function useOfflineSchemaReady(): boolean {
+  return true;
+}

--- a/packages/mobile/src/offline/__tests__/use-board-downloads.test.tsx
+++ b/packages/mobile/src/offline/__tests__/use-board-downloads.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
 import { cleanup, renderHook } from '@testing-library/react';
 import type { BootstrapMetadataChangedInfo, ScopeDownloadCompleteInfo } from '@boardsesh/offline-sync';
 import type { UserBoard } from '@boardsesh/shared-schema';
@@ -47,6 +48,7 @@ import {
   notifyBootstrapMetadataChanged,
   notifyScopeDownloadComplete,
 } from '../../sync';
+import { setSchemaReady, __resetSchemaReadyForTests } from '../../db/schema-ready';
 import { useBoardDownloads } from '../use-board-downloads';
 
 const makeBoard = (uuid: string, boardType: 'kilter' | 'tension', layoutId: number, sizeId: number): UserBoard =>
@@ -55,9 +57,15 @@ const makeBoard = (uuid: string, boardType: 'kilter' | 'tension', layoutId: numb
 beforeEach(() => {
   vi.clearAllMocks();
   __resetSyncStatusForTests();
+  // The ordinary launch: init won on its first attempt, so the schema is stamped
+  // before any screen renders. The contended launch has its own case below.
+  setSchemaReady(true);
 });
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  __resetSchemaReadyForTests();
+});
 
 describe('useBoardDownloads', () => {
   it('advances bootstrap and completion revisions for every scope in one ad-hoc multi-board sync', () => {
@@ -106,5 +114,42 @@ describe('useBoardDownloads', () => {
     // offline picker needs a row for each.
     expect(spies.rememberOfflineBoards).toHaveBeenCalledWith(boards);
     expect(spies.triggerSync).toHaveBeenCalledTimes(1);
+  });
+
+  // On a contended launch SQLiteProvider hands out a connection whose migrations
+  // never ran, so a download kicked then would import a snapshot into a file with
+  // no tables. The tap is held rather than dropped: a "Download" that visibly does
+  // nothing is worse than one that starts a moment later, and the discovery nudges
+  // aim people straight at this button.
+  it('holds a download kicked before the schema is ready, then fires it once readiness lands', () => {
+    setSchemaReady(false);
+    const board = makeBoard('garage', 'kilter', 1, 10);
+    const { result } = renderHook(() => useBoardDownloads());
+
+    result.current.enableBoardsOffline(board);
+
+    // The preference writes are pure settings state and must still land now — the
+    // board reads as "offline" in the UI immediately.
+    expect(spies.setOfflineBoardEnabled).toHaveBeenCalledTimes(1);
+    expect(spies.rememberOfflineBoards).toHaveBeenCalledWith([board]);
+    expect(spies.triggerSync).not.toHaveBeenCalled();
+
+    act(() => setSchemaReady(true));
+
+    expect(spies.triggerSync).toHaveBeenCalledTimes(1);
+    // Re-read at flush time, never replayed from the captured tap: someone who turns
+    // a board on and off again while the schema is unready gets a cycle that finds
+    // nothing to do, not the download they cancelled.
+    const enabledBoardsReader = spies.triggerSync.mock.calls[0]?.[3] as () => string[];
+    expect(enabledBoardsReader()).toEqual(['kilter:1:10', 'tension:2:11']);
+  });
+
+  it('does not kick a download on a readiness flip nobody asked for', () => {
+    setSchemaReady(false);
+    renderHook(() => useBoardDownloads());
+
+    act(() => setSchemaReady(true));
+
+    expect(spies.triggerSync).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/offline/use-board-downloads.ts
+++ b/packages/mobile/src/offline/use-board-downloads.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useSQLiteContext } from 'expo-sqlite';
 import { useQueryClient } from '@tanstack/react-query';
 import type { UserBoard } from '@boardsesh/shared-schema';
@@ -19,6 +19,7 @@ import { getHttpClient } from '../lib/graphql/client';
 import { notifyBootstrapMetadataChanged, notifyScopeDownloadComplete, setSyncProgress } from '../sync';
 import { triggerSync, drainMutationQueue } from './offline-sync-adapter';
 import { useSnapshotSource } from './use-snapshot-source';
+import { useOfflineSchemaReady } from '../db/use-offline-schema-ready';
 
 /** Which surface flipped the switch, for the Toggled event (issue #4316). */
 export type ToggleSource = 'manage' | 'storage' | 'more' | 'adopt';
@@ -41,12 +42,36 @@ export function useBoardDownloads() {
   const db = useSQLiteContext();
   const queryClient = useQueryClient();
   const snapshotSource = useSnapshotSource();
+  // The db from `useSQLiteContext()` is handed out as soon as the launch gate opens,
+  // which is after the FIRST init attempt whatever it did — so on a contended launch
+  // it has no tables yet and a snapshot import would land in a half-set-up file.
+  const schemaReady = useOfflineSchemaReady();
 
   const graphqlFetch = useMemo<GraphQLFetch>(() => (query, variables) => getHttpClient().request(query, variables), []);
   const drainQueue = useCallback(
     () => drainMutationQueue(db, queryClient, graphqlFetch),
     [db, queryClient, graphqlFetch],
   );
+
+  const startDownloadCycle = useCallback(() => {
+    // Reads `syncEnabledBoards` at call time, never a captured list — so a deferred
+    // kick downloads what is enabled NOW, not what was enabled when the user tapped.
+    // Someone who turns a board on and off again while the schema is unready gets
+    // one cycle that finds nothing to do rather than a download they cancelled.
+    triggerSync(db, queryClient, graphqlFetch, () => getSetting('syncEnabledBoards'), drainQueue, {
+      onProgress: setSyncProgress,
+      onBootstrapMetadataChanged: notifyBootstrapMetadataChanged,
+      onScopeDownloadComplete: notifyScopeDownloadComplete,
+      snapshotSource,
+    });
+  }, [db, queryClient, graphqlFetch, drainQueue, snapshotSource]);
+
+  // A tap that arrives before the schema is stamped is HELD, not dropped: the
+  // settings writes below are pure preference state and land immediately, and this
+  // flag replays the download kick once readiness flips. Dropping it would leave a
+  // "Download" tap doing visibly nothing, which is what discovery nudges send people
+  // straight into.
+  const downloadKickPendingRef = useRef(false);
 
   const enableBoardsOffline = useCallback(
     (boards: UserBoard | UserBoard[], options?: { trigger?: OfflineDownloadTrigger; source?: ToggleSource }) => {
@@ -84,15 +109,20 @@ export function useBoardDownloads() {
       // any caller having to remember to persist them. A scope key alone can't name
       // a board — see settings/offline-boards.ts.
       rememberOfflineBoards(list);
-      triggerSync(db, queryClient, graphqlFetch, () => getSetting('syncEnabledBoards'), drainQueue, {
-        onProgress: setSyncProgress,
-        onBootstrapMetadataChanged: notifyBootstrapMetadataChanged,
-        onScopeDownloadComplete: notifyScopeDownloadComplete,
-        snapshotSource,
-      });
+      if (!schemaReady) {
+        downloadKickPendingRef.current = true;
+        return;
+      }
+      startDownloadCycle();
     },
-    [db, queryClient, graphqlFetch, drainQueue, snapshotSource],
+    [schemaReady, startDownloadCycle],
   );
+
+  useEffect(() => {
+    if (!schemaReady || !downloadKickPendingRef.current) return;
+    downloadKickPendingRef.current = false;
+    startDownloadCycle();
+  }, [schemaReady, startDownloadCycle]);
 
   return { enableBoardsOffline };
 }

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -429,6 +429,16 @@ export const SHARED_EVENTS = {
   // 'reset' | 'probe_failed' }. Deduped once-per-launch-per-verdict in the
   // mobile binding, because the engine evaluates on every foreground.
   OfflineSyncCoverageEvaluated: 'Offline Sync Coverage Evaluated',
+  // Offline sync — the local SQLite setup lost the write lock at launch and a
+  // later retry won, so offline storage came up after all. Fired at most once
+  // per process, only when attempt 1 failed (a clean launch stays silent).
+  // Props: { attempts, phase: 'wal' | 'queue-table' | 'migrations', elapsedMs,
+  // sqliteCode }. Until this existed the lane was write-only: Sentry heard about
+  // a launch that ran out of retries and nothing at all about one that recovered,
+  // so "we fixed it" and "it still contends, it just retries its way out" looked
+  // identical. `elapsedMs` is the contention-duration measurement — its
+  // distribution is what sizes the retry window, which today is a guess.
+  OfflineSqliteInitRecovered: 'Offline SQLite Init Recovered',
 } as const;
 
 export type SharedEventKey = keyof typeof SHARED_EVENTS;

--- a/packages/shared/offline-sync/src/db/__tests__/lock-errors.test.ts
+++ b/packages/shared/offline-sync/src/db/__tests__/lock-errors.test.ts
@@ -1,5 +1,11 @@
+// Pins both entry points against the LITERAL strings Sentry carries for
+// `source:offline-sync kind:sqlite-init` / `kind:tick-local-write`. Every case
+// here was copied from a real event, because the whole point of the module is
+// that these shapes differ per platform and cannot be guessed from the
+// expo-sqlite type definitions.
+
 import { describe, it, expect } from 'vitest';
-import { isDatabaseLockedError } from '../lock-errors';
+import { classifySqliteLockError, isDatabaseLockedError } from '../lock-errors';
 
 // The Android driver emits a raw U+0005 where the result-code digit belongs
 // (BOARDSESH-6V, all 18 events). Built here rather than pasted so no editor,
@@ -51,5 +57,98 @@ describe('isDatabaseLockedError', () => {
     'some string',
   ])('does not match %p', (value) => {
     expect(isDatabaseLockedError(value)).toBe(false);
+  });
+});
+
+describe('classifySqliteLockError', () => {
+  it('reads the iOS 2.2.2 single-line cause chain as retryable contention', () => {
+    const result = classifySqliteLockError(
+      new Error("Calling the 'prepareAsync' function has failed → Caused by: Error code 5: database is locked"),
+    );
+
+    expect(result).toEqual({ locked: true, code: 5 });
+  });
+
+  it('reads the iOS 2.3.x multi-line SQLiteErrorException chain as retryable contention', () => {
+    const result = classifySqliteLockError(
+      new Error(
+        "FunctionCallException: Calling the 'prepareAsync' function has failed (at ExpoModulesCore/AsyncFunctionDefinition.swift:123)\n" +
+          '→ Caused by: SQLiteErrorException: Error code 5: database is locked (at ExpoSQLite/SQLiteModule.swift:382)',
+      ),
+    );
+
+    expect(result).toEqual({ locked: true, code: 5 });
+  });
+
+  it('reads the Android shape, where the numeric code is omitted entirely', () => {
+    // This is the case a code-only classifier would silently stop retrying: Android
+    // prints "Error code : database is locked" with nothing between the words.
+    const result = classifySqliteLockError(
+      new Error(
+        "Call to function 'NativeDatabase.prepareAsync' has been rejected.\n→ Caused by: Error code : database is locked",
+      ),
+    );
+
+    expect(result).toEqual({ locked: true, code: null });
+  });
+
+  it('reads the Android shape that prints the digit as a raw control byte', () => {
+    const result = classifySqliteLockError(
+      new Error(
+        `Calling the 'prepareAsync' function has failed → Caused by: Error code ${ANDROID_CODE_BYTE}: database is locked`,
+      ),
+    );
+
+    expect(result).toEqual({ locked: true, code: null });
+  });
+
+  it('agrees with isDatabaseLockedError on a wrapped cause chain', () => {
+    // No code in the outer message, so the verdict comes from the shared
+    // predicate, which walks the cause chain the reporting side already trusts.
+    const wrapped = new Error("Calling the 'execAsync' function has failed", {
+      cause: new Error('database is locked'),
+    });
+
+    expect(classifySqliteLockError(wrapped)).toEqual({ locked: true, code: null });
+    expect(isDatabaseLockedError(wrapped)).toBe(true);
+  });
+
+  it('treats "database table is locked" (SQLITE_LOCKED) as retryable', () => {
+    const result = classifySqliteLockError(new Error('Error code 6: database table is locked'));
+
+    expect(result).toEqual({ locked: true, code: 6 });
+  });
+
+  it('unpacks an extended busy code so a recovery-phase collision still retries', () => {
+    // 261 = SQLITE_BUSY_RECOVERY (5 | 1<<8). Comparing the raw code against 5 would
+    // report a plainly transient failure as permanent.
+    const result = classifySqliteLockError(new Error('Error code 261: database is locked'));
+
+    expect(result).toEqual({ locked: true, code: 261 });
+  });
+
+  it('does NOT retry a disk-I/O failure (code 10)', () => {
+    // BOARDSESH-BN. A full or failing disk fails identically forever — burning the
+    // retry window on it only delays the report.
+    const result = classifySqliteLockError(new Error('Error code 10: disk I/O error'));
+
+    expect(result).toEqual({ locked: false, code: 10 });
+  });
+
+  it('lets a numeric code beat lock-sounding prose', () => {
+    const result = classifySqliteLockError(
+      new Error('Error code 11: database disk image is malformed while database is locked'),
+    );
+
+    expect(result).toEqual({ locked: false, code: 11 });
+  });
+
+  it('classifies an ordinary non-SQLite error as not retryable', () => {
+    expect(classifySqliteLockError(new Error('Network request failed'))).toEqual({ locked: false, code: null });
+  });
+
+  it('handles a thrown non-Error value without throwing', () => {
+    expect(classifySqliteLockError('database is locked')).toEqual({ locked: true, code: null });
+    expect(classifySqliteLockError(undefined)).toEqual({ locked: false, code: null });
   });
 });

--- a/packages/shared/offline-sync/src/db/lock-errors.ts
+++ b/packages/shared/offline-sync/src/db/lock-errors.ts
@@ -6,6 +6,12 @@
 // broken database (disk full, corruption). Keeping one implementation here
 // stops the two workstreams from drifting apart on which strings count.
 //
+// Two entry points share that matcher:
+//   - `isDatabaseLockedError` — the yes/no question reporting asks.
+//   - `classifySqliteLockError` — the same verdict plus the numeric result
+//     code, which the mobile sqlite-init retry loop tags its failure and
+//     recovery events with.
+//
 // Matching rules, in order of trust:
 //   1. `database is locked` / `SQLITE_BUSY` — the primary, stable signal.
 //   2. The numeric result code, and only as a SECONDARY signal, because the
@@ -18,7 +24,15 @@
 //
 // Walks the `.cause` chain to the same depth error-classification.ts uses —
 // expo-sqlite wraps the driver error ("Calling the 'execAsync' function has
-// failed" → cause: the real one).
+// failed" → cause: the real one). Both platforms ALSO concatenate the cause
+// into the outer `message` (iOS `Exception.swift`, Android `CodedException.kt`),
+// so the message test carries the shapes that arrive with no structured cause:
+//   iOS 2.2.2  "Calling the 'prepareAsync' function has failed → Caused by:
+//               Error code 5: database is locked"
+//   iOS 2.3.x  "FunctionCallException: ...\n→ Caused by: SQLiteErrorException:
+//               Error code 5: database is locked"
+//   Android    "Call to function 'NativeDatabase.prepareAsync' has been rejected.\n
+//               → Caused by: Error code : database is locked"   ← NO numeric code
 
 const MAX_CAUSE_DEPTH = 3;
 
@@ -74,4 +88,53 @@ function isLockedAtDepth(error: unknown, depth: number): boolean {
  */
 export function isDatabaseLockedError(error: unknown): boolean {
   return isLockedAtDepth(error, 0);
+}
+
+/** SQLITE_BUSY — another connection holds the lock this statement needs. */
+const SQLITE_BUSY = 5;
+/** SQLITE_LOCKED — a lock conflict inside the same database connection. */
+const SQLITE_LOCKED = 6;
+
+/** Result of reading a thrown value as a SQLite lock failure. */
+export type SqliteLockClassification = {
+  /** True when another writer/reader held the file and a retry could win. */
+  locked: boolean;
+  /**
+   * The SQLite result code as reported, or null when the message carried none
+   * (the Android shape above). Kept RAW rather than reduced to its primary code so
+   * telemetry can still tell an extended code (e.g. 261 SQLITE_BUSY_RECOVERY) from
+   * a plain 5.
+   */
+  code: number | null;
+};
+
+const RESULT_CODE_PATTERN = /Error code (\d+)/;
+
+/**
+ * Read a thrown value as a SQLite lock failure, for callers that also report
+ * which result code came back.
+ *
+ * A numeric result code wins when present: it is unambiguous, and it keeps a
+ * message that merely mentions locking (a wrapped disk-I/O error whose prose
+ * happens to include the phrase) from being retried forever. SQLite's extended
+ * result codes pack the primary code in the low byte, so the comparison masks it —
+ * 261 (SQLITE_BUSY_RECOVERY) and 517 (SQLITE_BUSY_SNAPSHOT) are both retryable
+ * contention, and treating them as unknown would report a transient failure.
+ *
+ * With no code to read — the Android shape, which prints the digit as a raw
+ * control byte or omits it entirely — the verdict comes from
+ * `isDatabaseLockedError`, so the two entry points can never disagree about
+ * which strings count as contention.
+ */
+export function classifySqliteLockError(error: unknown): SqliteLockClassification {
+  const message = error instanceof Error ? error.message : String(error);
+  const codeMatch = RESULT_CODE_PATTERN.exec(message);
+
+  if (codeMatch) {
+    const code = Number.parseInt(codeMatch[1], 10);
+    const primaryCode = code & 0xff;
+    return { locked: primaryCode === SQLITE_BUSY || primaryCode === SQLITE_LOCKED, code };
+  }
+
+  return { locked: isDatabaseLockedError(error), code: null };
 }

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -215,10 +215,12 @@ export { SCHEMA_STATEMENTS } from './db/schema';
 export { runMigrations, MIGRATIONS, LATEST_SCHEMA_VERSION } from './db/migrations';
 export type { Migration } from './db/migrations';
 export { OFFLINE_DB_BUSY_TIMEOUT_MS, applyBusyTimeout, configureMainConnection } from './db/pragmas';
-// Shared with the sqlite-lock workstream (#4314): one predicate for "was this
-// write-lock contention?", so reporting and any future retry/defer logic can
-// never disagree about which failures count.
-export { isDatabaseLockedError } from './db/lock-errors';
+// One predicate for "was this write-lock contention?", so reporting (#4329) and
+// the sqlite-init retry loop (#4314) can never disagree about which failures
+// count. `classifySqliteLockError` is the same verdict plus the SQLite result
+// code, for callers that tag telemetry with it.
+export { isDatabaseLockedError, classifySqliteLockError } from './db/lock-errors';
+export type { SqliteLockClassification } from './db/lock-errors';
 
 // --- Offline board scope keys ----------------------------------------------------
 export {


### PR DESCRIPTION
Two things, both from digging into #4314.

## The issue's premise does not hold

#4314 says "database is locked" events are **still arriving after #3858/#4104**. They are not — every one of them predates the #4104 fix reaching devices.

#4121 (merged `733c4ac6d`, 2026-08-10 20:35 UTC) added a `phase` tag to the only reporter that emits `kind: 'sqlite-init'`. Before it, that call was `reportError(error, { tags: { source: 'offline-sync', kind: 'sqlite-init' } })` — no `phase`, no `extra` (`git show fcbe86b6b^:packages/mobile/src/db/connection.ts:78`).

The Sentry aggregate for `source:offline-sync kind:sqlite-init` over 90d, grouped by `tags[phase]` + `release`: **16 buckets, 83 events, every single one with `phase: ""`**. Zero phase-tagged events exist, so none of them came from post-#4121 code. Independently corroborated by the release dates — the 2.3.1 bump (`97bfd8029`) was authored 2026-08-04 10:21 UTC, six days before #4121 merged, so the 2.3.1 store binary shipped the pre-retry JS and the production OTA has not finished turning the fleet over. Events are still landing (latest 2026-08-12 04:07, release 2.2.2+3) and they are still all empty-phase.

The statement that failed in 2.3.1 is identifiable and is exactly what #4121 fixed: the shipped `configureMainConnection` ran `PRAGMA journal_mode = WAL` through `getFirstAsync` (a `prepareAsync`) as its **first** statement, with `busy_timeout` still 0, and let it throw into `initializeDatabase`'s single catch. That matches the signature in Sentry — `prepareAsync` → `SQLiteErrorException` code 5, ~0.4s after `app_start_time`.

Two of the four issues cited in #4314 are also mis-attributed: **BOARDSESH-A9** (49 events / 34 users, the biggest number in the issue) is `source:react-query kind:query`, not sqlite-init — it belongs to the read-vs-write family WAL already addressed, last event 2026-08-04. **BOARDSESH-CF** is a polluted group whose most recent event is `GoogleMapsView.setCameraPosition` / `CancellationException`; only its `kind:sqlite-init` events belong here.

That is all posted on #4314. This PR is the hardening that reading the code turned up along the way — three defects that are real regardless of what the post-OTA re-measure shows.

## What is actually broken

**1. Consumers write against a schema that has not been created.** `initializeDatabase` releases the launch gate after its first attempt whatever that attempt did (`connection.ts:167-173`) — blocking would leave `SQLiteProvider` rendering nothing for the length of the retry chain, i.e. a black screen. `SQLiteProvider` then renders children. Six consumers take the db from `useSQLiteContext()` and so bypass the `getDatabaseHandle()` null-gate every other consumer honours. The two that **write** are the bug: `OfflineSyncBridge` starts `startSyncScheduler`, and `useBoardDownloads` kicks `triggerSync`, against a database with no `board_climb_grades` and no `characteristics` column. That is a data-shape bug, not just a lock bug.

**2. The retry chain hammers a closed connection.** `SQLiteProvider`'s effect teardown calls `db.closeAsync()` (expo-sqlite `build/hooks.js:91-93`), so a remount mid-chain closes the handle the chain captured. The single-flight guard hands the remount the same promise, and every remaining attempt runs against the dead connection. A closed-connection throw is not "database is locked", so it is classified permanent and reported under `kind: 'sqlite-init'` — polluting the exact aggregate #4314's close criterion reads.

**3. There is no recovery signal.** The report fires only when retries are exhausted, so a launch that contended and recovered is silent. After the OTA we cannot distinguish "fixed" from "still contending, retried its way out" — which is precisely what #4314 asks.

## Changes

- **`@boardsesh/offline-sync/db/lock-errors.ts`** — `classifySqliteLockError(error) => { locked, code }`, extracted from the private free-text regex in `connection.ts`. Parses `Error code (\d+)` when present (masking the low byte so extended busy codes like 261 still retry) and falls back to the message otherwise. Unit-tested against the literal strings Sentry carries: the iOS 2.2.2 and 2.3.x cause chains, the Android shape where the numeric code is **absent** ("Error code : database is locked"), and the code-10 disk-I/O negative that must not be retryable.
- **Schema-readiness store** (`src/db/schema-ready.ts`), React-free, mirroring `sync/sync-status.ts`, driven from `setDatabaseHandle` so it can never disagree with the handle. `useOfflineSchemaReady()` sits over it via `useSyncExternalStore`.
- **The two write paths gate on it.** `OfflineSyncBridge` waits before starting the scheduler *and* before the flag-off leftover drain; the effect re-runs on the flip, so late readiness starts it then.
- **`useBoardDownloads` queues rather than drops.** The preference writes (`setOfflineBoardEnabled`, `rememberOfflineBoards`) land immediately, and the download kick is held and fired on the readiness flip — re-reading `syncEnabledBoards` at flush time, so someone who enables and disables a board while the schema is unready does not get the download they cancelled. Silently dropping the tap would be worse than today, and #4318's discovery nudges aim people straight at that button.
- **The four read-only surfaces are NOT gated.** They fold readiness into the `queryKey` instead (`boards/index.tsx`, `boards/manage.tsx`, `profile/more.tsx`, `StorageSettingsScreen.tsx`). Each wraps its db access in a React Query `queryFn`, so a missing table lands in `isError` and the existing empty state renders. Gating with `enabled` would strand them in a permanent spinner whenever init genuinely fails; keying makes a late flip refetch. Prefix-based invalidations (`['downloadedScopeKeys']`, `['offlineStorage']`) still match.
- **Expo web fork** `use-offline-schema-ready.web.ts` returns a constant `true`. `metro.config.js:92` aliases `expo-sqlite` to `src/web-shims/sqlite.tsx` and `database-provider.web.tsx` never calls `initializeDatabase`, so nothing on web publishes a handle and a live store would read false forever — every gate permanently off. This keeps browser behaviour byte-for-byte what it is today.
- **Retry chain retargeting.** A module-level `latestDatabase` is updated on every `initializeDatabase` call, including the remount that only gets the shared promise back; each attempt reads it. A failure against a superseded handle is not counted as permanent and is **not** reported — it is a lifecycle artefact, not a lock.
- **Telemetry.** `Offline SQLite Init Recovered` (`{ attempts, phase, elapsedMs, sqliteCode }`, capped at one per process) when a retry wins. On failure, `sqlite_code` and `journal_mode` tags — the latter read back best-effort with an explicit `'unavailable'` sentinel, so "stuck in rollback journal" stays distinguishable from "the read failed too" — plus `extra: { attempts, retryable, elapsedMs }`.
- **`docs/offline-sync-plan.md`** gains a "Startup lock model" section: who holds the write lock and for how long, why the launch gate opens before the schema is ready, the readiness contract every `useSQLiteContext()` consumer must honour, and an explicit note that `OfflineBoardDownloadCompleted.durationMs` is **not** a lock-hold measurement.

### One test assertion is intentionally flipped

`connection.test.ts`'s remount case used to assert `getDatabaseHandle()).toBe(first.db)` and `second.failures() === 0` — i.e. the chain keeps working the connection from before the remount. That assertion encoded the stale-handle bug. It now asserts the chain retargets: a win publishes `second.db`, and `first.db` is touched exactly once, by the attempt that predates the remount. The receipt is expo-sqlite `build/hooks.js:91-93`, whose effect cleanup closes the database on every `[databaseName, directory, options, onInit]` change.

### Deliberately not in this PR

A longer retry window. The previous plan wanted 15 minutes, justified by "the import holds `BEGIN EXCLUSIVE` for p50 2m55s". That p50 is `OfflineBoardDownloadCompleted.durationMs`, computed at `pull-client.ts:1219` across manifest fetch + artifact **download** + import — mostly network. `bootstrapScopeFromSnapshot` receives an already-downloaded `filePath`, and its exclusive transaction covers `reconcileScope` + `importScope` only. The real lock-hold time is currently unmeasured; `elapsedMs` above is what measures it. Follow-up issue filed to size the window from that data.

This is pure TS/JS — no new dependencies, no Expo plugin, no `app.config.ts` native field, no `patches/`. The `.web.ts` fork is resolved only by the Metro web target, exactly as `database-provider.web.tsx` already is. The runtimeVersion fingerprint is unchanged, which matters here: the fix has to reach the 2.3.1 store binaries over the production OTA channel, which a native-train PR could not do.

## Release Notes

Tapping "Download" on a board right after opening the app used to do nothing at all if the app was still finishing its local setup — the download quietly never started. Now the tap is held and the download begins the moment storage is ready. Offline data also stops being written against a half-built database on a busy launch, so a board you downloaded shows up as downloaded instead of vanishing.

## Test plan

Local, all foreground:

- `vp run typecheck:mobile` — pass
- `vp run typecheck:shared` — pass
- `vp run test:mobile` — 622 files, 5493 tests, all pass
- `vp test run --project offline-sync` — 22 files, 348 tests, all pass
- `vp test run --project analytics` — 4 files, 23 tests, all pass
- `vp check` — clean for every file this PR touches (two unrelated files, `.claude/skills/discord-feedback-triage/SKILL.md` and `docs/discord-feedback-pipeline.md`, have pre-existing formatting drift on `main` and were left alone)
- `vp run check:mobile-bundle` — Android bundle OK, from a sibling worktree outside `.claude/worktrees`
- `vp run check:mobile-web-bundle` — export complete with the required shell and WASM assets (mandatory here, this PR adds a platform fork)

New tests:

- `lock-errors.test.ts` — the iOS 2.2.2 and 2.3.x cause chains, the code-less Android shape, extended code 261, the code-10 negative, a code beating lock-sounding prose, and a thrown non-Error value.
- `connection.test.ts` — retargeting after remount; no report for a superseded handle; one recovery event with the right `attempts`/`phase`/`sqliteCode` and no `reportError`; no event on a clean launch; readiness published only after migrations; `sqlite_code` + `journal_mode` on the failure report; the `'unavailable'` sentinel when the pragma read itself throws; code-10 reported on attempt 1 with no retry.
- `offline-sync-bridge.test.tsx` — the scheduler does not start while readiness is false and starts exactly once when it flips; the flag-off leftover drain is held the same way.
- `use-board-downloads.test.tsx` — a tap before readiness writes the preferences but holds the sync, then fires once on the flip reading the setting at flush time; a readiness flip with no pending tap kicks nothing.
- `use-offline-schema-ready.web.test.ts` — the web fork returns true unconditionally, so a refactor cannot silently disable the browser surfaces.

Device QA not yet run — `.boardsesh/qa-notes.md` in the worktree covers the contended launch, the queued-intent path, the Android activity-recreate remount, the clean-launch regression check, and the Expo web pass.

Refs #4314

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT6VP1sWqk6bY9mUgyeS2U
