### PR TITLE
fix(sync): bound bootstrap retries by failure kind, not one shared counter

### DIFF
--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -254,7 +254,12 @@ scope that already holds rows always crawls — a failed heal must not stall pro
 **The metered-network probe.** `SyncOptions.isOnUnmeteredNetwork` (default `() => true`, so web and every
 existing caller are unchanged) gates ONE decision: the automatic heal of a partly-crawled scope, which is a
 ~100 MB download the user did not ask for that day. On a metered link the heal defers 6 hours and burns
-nothing. A fresh bootstrap (they just confirmed the size) and a user-requested retry ignore it.
+nothing. A fresh bootstrap (they just confirmed the size) ignores it, and so does a user-requested retry:
+`restoreBootstrapRetryBudget` arms a `userRequested` flag on the persisted state, `runBootstrapPhase` skips
+the defer while it is set, and the flag is spent the instant the download starts (one tap, one artifact).
+That last part matters — a settled scope has always crawled, so it can only ever come back as a
+heal-over-partial, and without the flag "Try the fast download again" was a silent 6-hour deferral on
+cellular. A recovery on that path reports `trigger: 'user-request'`.
 
 **The watermark-regression guard.** `bootstrapScopeFromSnapshot` takes the scope's current board-table
 checkpoints on the heal path and throws `SnapshotWatermarkRegressionError` — before opening the exclusive
@@ -265,6 +270,12 @@ after any export/client filter drift), and a crawl that already ran past the art
 import would lower `checkpoint:board_climbs:<scope>` — destroying exactly the progress the heal exists to
 rescue — and rewind the single global deletions cursor with it. It is reported at full severity
 (`expected: false`) because it means the export's scope filter and the client's disagree.
+
+The refusal **burns the structural-artifact budget**, like any other import failure. That is not bookkeeping
+pedantry: the refusal is deterministic for a given artifact (local checkpoints only move forward), so a
+refusal that recorded nothing left the scope exactly as eligible as before and pulled the whole ~100 MB
+again on every single sync cycle, forever. Charged, it costs at most 2 downloads (6 h then 24 h apart) plus
+the one re-armed round a genuinely newer `builtAt` can grant.
 
 With `W ≥ C` enforced the coverage argument is simple: rows ≤ C are already local, the artifact supplies
 every scoped row ≤ W, `reconcileScope` removes local scoped rows ≤ W absent from the artifact, and the
@@ -278,9 +289,11 @@ would re-arm a fresh 2-attempt round plus another one-shot heal. Reads reconcile
 legacy counter moved past what we last mirrored (`mirroredAttempts`), an older bundle counted something
 real and the difference is folded back into `structuralFailures`. On first touch,
 `migrateLegacyBootstrapMarkers` derives a state from the legacy rows and grants one clean pass under the
-new taxonomy (the old counter conflated transport with structural, which is the bug), leaving the rows in
-place; a scope that already holds rows gets a `retryAfter` jittered across 2 hours so the fleet does not
-start downloading on the same post-OTA launch.
+new taxonomy (the old counter conflated transport with structural, which is the bug); a scope that already
+holds rows gets a `retryAfter` jittered across 2 hours so the fleet does not start downloading on the same
+post-OTA launch. The legacy rows are never deleted, but the first write after a migration does re-stamp
+`bootstrap-attempts:` down to the mirrored value — the clean pass has to be visible to a rolled-back bundle
+too, or it would re-read the pre-migration count and settle the scope all over again.
 
 A scope torn down from **More → Storage** becomes eligible again: `removeBoardScopeData`
 (`sync/scope-teardown.ts`) clears all three board-data checkpoints **and** its `bootstrap-attempts:` /
@@ -303,6 +316,7 @@ sync if the code comment changes):
 | terminal, last failure `structural-artifact`, re-arm left, new build | — (grants a round)        | budget restored once → snapshot path runs                                                 |
 | terminal, otherwise                                                  | —                         | settled → normal paged pull, manifest not fetched                                         |
 | heal-over-partial on a metered link                                  | **no** (defers 6 h)       | normal paged pull                                                                         |
+| the same, with `userRequested` armed by the retry action             | — (spends the tap)        | snapshot path runs now; recovery reports `trigger: 'user-request'`                        |
 | manifest `absent` (404/missing or invalid JSON/shape)                | **no**                    | permanent miss → normal paged pull                                                        |
 | manifest `error`, transport-shaped (offline/DNS/TLS/timeout)         | **no**, nothing persisted | skip paged pull this cycle; reported as `expected`                                        |
 | manifest `error`, anything else (HTTP non-2xx except 404, …)         | `structural-device`       | 6 h ladder; crawl runs (past the grace window)                                            |
@@ -312,7 +326,7 @@ sync if the code comment changes):
 | download throws `SnapshotPermanentMissError`                         | **no**                    | permanent miss → normal paged pull                                                        |
 | import throws — corrupt/short artifact, row-count/format mismatch    | `structural-artifact`     | 6 h ladder; a new `builtAt` may re-arm it once                                            |
 | import throws `SnapshotSchemaStaleError`                             | **no**                    | permanent miss this run → normal paged pull                                               |
-| import throws `SnapshotWatermarkRegressionError`                     | **no**                    | permanent miss, nothing written → normal paged pull; reported `expected: false`           |
+| import throws `SnapshotWatermarkRegressionError`                     | `structural-artifact`     | nothing written → normal paged pull; 6 h ladder; reported `expected: false`               |
 | a sign-out wipe is detected mid-phase                                | **no**                    | whole phase bails, mirrors `syncTable`'s wipe guard                                       |
 | success                                                              | transport counter reset   | marked done; deletions rewound; paged pull runs as a small delta from scoped watermarks   |
 
@@ -338,10 +352,13 @@ inside the artifact, then in **one exclusive transaction**:
 - Stamps both table checkpoints at the scoped imported-row watermarks.
 - **Rewinds the deletions checkpoint** to the older scoped table watermark timestamp with deletion cursor
   `syncSeq = '0'`, in the _same_ transaction as the import. Deletion cursors page over deletion-row ids, not
-  board table `sync_seq` values. Once a scope has board checkpoints it's never bootstrap-eligible again, so
-  a crash between the import commit and a separate rewind step would permanently strand any board-row
-  deletions that fell in `(watermark, deletions-head]` — they'd never replay against the freshly-imported
-  rows. Doing it in the same transaction closes that gap.
+  board table `sync_seq` values. A committed import stamps `bootstrap-done:`, which disqualifies the scope
+  from ever bootstrapping again, so a crash between the import commit and a separate rewind step would
+  permanently strand any board-row deletions that fell in `(watermark, deletions-head]` — they'd never
+  replay against the freshly-imported rows. Doing it in the same transaction closes that gap. Note the
+  rewind target is `min(scoped watermarks)`, the max `updated_at` of the artifact's rows FOR THIS SCOPE:
+  on a quiet layout that timestamp can be weeks old, so the replay window is bounded by the 80-day
+  tombstone retention, not by one nightly export window.
 
 **Wipe-epoch guard**: a sign-out wipe can start (or fully complete) across any of the `await`s above. The
 bootstrap captures the monotonic wipe epoch before its first `await` and re-checks it (and the
@@ -432,7 +449,11 @@ pre-import empty result set.
     per scope's first-download completion (climbs, stats, and grades all reached the tail), with method
     `snapshot` or `paged` and `durationMs` measured from the start of the sync cycle's work on that scope (so a
     `'snapshot'` scope's duration includes its manifest/download/import time, not just the trailing delta
-    pull — an apples-to-apples comparison against a full paged crawl).
+    pull — an apples-to-apples comparison against a full paged crawl). A HEALED scope carries
+    `bootstrapHealed: true` and must be filtered out of those percentiles: its duration excludes the paged
+    work earlier cycles already did. Both fields read the persisted `bootstrap-done:` row (its presence for
+    `method`, its value — `'heal'` vs `'1'` — for `bootstrapHealed`) rather than anything in-memory, because
+    completion routinely lands cycles after the import.
   - Sentry handled errors, `tags: { source: 'offline-sync', kind: 'snapshot-bootstrap' }`, for every
     bootstrap failure (manifest/download/import stage, with
     `scopeKey`/`stage`/`attempt`/`expected`/`cause`/`causeName` in `extra`) and for the gzip-sniff failure

--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -197,55 +197,129 @@ mobile adapter (React Query's `onlineManager`, wired to NetInfo) actually gates 
 Without it, every offline launch ran the whole bootstrap phase and emitted one Sentry event per
 enabled-but-undownloaded scope (issue #4238). The scheduler's offline→online edge re-runs the skipped cycle.
 
-**Eligibility**: a board scope (`boardType:layoutId:sizeId`) is only considered when it has **no
-checkpoint on either snapshot-backed table, `board_climbs` or `board_climb_stats`** (i.e. genuinely
-fresh for the snapshot) and its bootstrap attempt count is under `MAX_BOOTSTRAP_ATTEMPTS` (2). The
-ordinary paged sync still downloads `board_climb_grades` before the scope is reported complete. One
-artifact download is shared across every size of the same `(boardType, layoutId)` within a cycle.
+**Eligibility** (`evaluateBootstrapEligibility` in `sync/bootstrap-retry.ts`, called by BOTH
+`runBootstrapPhase` and `estimateScopeDownload` so the size the UI quotes can never disagree with what the
+engine does). A board scope (`boardType:layoutId:sizeId`) qualifies in one of two ways:
 
-The cap is evaluated **after** the manifest resolves, which is what makes the **one-shot heal** possible: a
-scope that already spent both attempts, still has no board checkpoint, and turns out to have a usable
-manifest entry waiting gets its `bootstrap-attempts:` row deleted and takes the snapshot path again —
-exactly once per scope, recorded in `bootstrap-attempts-healed:`. A device that burned both attempts in a
-tunnel therefore recovers on its first online launch, while a genuinely broken artifact costs two more
-attempts and then settles into the paged crawl for good. The cost is that an over-cap scope consults the
-manifest each cycle; `resolveManifestOnce` caches it per `pullSync` run, so that only adds a request on
-cycles where _every_ scope is over the cap.
+- **fresh** — no checkpoint on either snapshot-backed table (`board_climbs`, `board_climb_stats`).
+- **heal-over-partial** — it HAS checkpoints, has **not** reached `scope-complete:`, has not already
+  imported an artifact, and carries snapshot-path failures behind it. This is the un-strand for issue
+  #4313: a board that gave up on the snapshot and then crawled part of its catalog can jump the rest of
+  the climbs/stats crawl from an artifact.
+
+Both also require that neither retry budget is spent and that any scheduled cooldown has elapsed. A
+`scope-complete:` scope is never healed — it already serves the whole catalog locally, so ~100 MB buys it
+nothing. The ordinary paged sync still downloads `board_climb_grades` before a scope is reported complete
+(it is not in `SNAPSHOT_TABLES`), so a heal removes part of the slow path, not all of it. One artifact
+download is shared across every size of the same `(boardType, layoutId)` within a cycle.
+
+**Failure taxonomy and budgets** (issue #4313). Before this, `MAX_BOOTSTRAP_ATTEMPTS = 2` was doing two
+jobs: it was the retry policy (there is none — the artifact GET is unresumable and never retried) and the
+total-spend bound. Because a dropped connection at the DOWNLOAD stage burned the same counter as a corrupt
+artifact, two bad-reception launches condemned a board to the 400+-round-trip crawl for the life of the
+install. The two jobs are now separate: kind-specific budgets bound total spend, a cooldown ladder bounds
+frequency.
+
+| Kind                  | Raised by                                                                            | Budget                                | Cooldown ladder      | Re-armed by a new `builtAt`?                         |
+| --------------------- | ------------------------------------------------------------------------------------ | ------------------------------------- | -------------------- | ---------------------------------------------------- |
+| `transport`           | `isNetworkError(cause)` at the download stage (offline, DNS, TLS, timeout)           | `MAX_TRANSPORT_DOWNLOAD_FAILURES` = 3 | 2 min → 15 min → 2 h | no                                                   |
+| `structural-artifact` | anything raised inside the import (`quick_check`, `snapshot_meta` mismatch, throw)   | `MAX_BOOTSTRAP_ATTEMPTS` = 2          | 6 h → 24 h           | yes, `MAX_STRUCTURAL_REARMS` = 1 per scope, lifetime |
+| `structural-device`   | every other non-transport cause (disk space, cache dir, CDN non-2xx, unclassifiable) | `MAX_BOOTSTRAP_ATTEMPTS` = 2          | 6 h → 24 h           | **no**                                               |
+
+A successful download resets `transportFailures` to 0 and drops its cooldown. The manifest stage stays
+entirely free for transport failures (a few KB of JSON, and the stage an offline launch dies at — issue
+#4238); everything else is charged at either stage. The `structural-device` default is deliberately
+conservative: a plain `Error` from an adapter's downloader cannot be told apart from a disk-full or
+cache-dir fault, and the export is **nightly**, so a `builtAt` reset for a device-side fault would be
+2 × ~100 MB every day, forever.
+
+**Worst-case lifetime spend per scope: 7 artifact downloads** — 3 transport + 2 structural + 2 for the
+single re-armed structural round — each separated by at least one cooldown rung. A test in
+`snapshot-bootstrap.test.ts` drives 40 cycles against an injected clock and pins that count, so any future
+loosening shows up in a diff.
+
+When either budget is spent the scope is **terminal**: `bootstrap-paged-fallback:` is stamped and the
+manifest is not even fetched for it (cheaper than the pre-#4313 over-cap path, which consulted it every
+cycle). The one exception is a terminal scope whose last failure was `structural-artifact` and which has a
+re-arm left — that one still reads the manifest, because a differently built artifact is exactly what could
+fix it. Terminal is cleared by scope teardown or by the user tapping **Try the fast download again** in My
+Boards, which restores both budgets behind the same size-disclosing confirm dialog the enable toggle uses.
+
+**Cooldowns and skipping the paged crawl.** The skip is a grace window, not all-or-nothing: only a FRESH,
+non-terminal scope whose retry lands within 30 minutes waits for it, because a first-page checkpoint used
+to disqualify the snapshot path permanently and the crawl is 400+ serial round trips it is about to throw
+away. Past that window the crawl runs, so a board is never left empty waiting on a 2-hour cooldown, and a
+scope that already holds rows always crawls — a failed heal must not stall progress already being made.
+
+**The metered-network probe.** `SyncOptions.isOnUnmeteredNetwork` (default `() => true`, so web and every
+existing caller are unchanged) gates ONE decision: the automatic heal of a partly-crawled scope, which is a
+~100 MB download the user did not ask for that day. On a metered link the heal defers 6 hours and burns
+nothing. A fresh bootstrap (they just confirmed the size) and a user-requested retry ignore it.
+
+**The watermark-regression guard.** `bootstrapScopeFromSnapshot` takes the scope's current board-table
+checkpoints on the heal path and throws `SnapshotWatermarkRegressionError` — before opening the exclusive
+transaction, so nothing at all is written — when either table's artifact watermark compares older than the
+local checkpoint. That covers both hazards at once: an artifact whose scope filter matches no rows
+(`tableWatermark` returns the epoch, reachable for a size whose `compatible_size_ids` never matches or
+after any export/client filter drift), and a crawl that already ran past the artifact. Without it the
+import would lower `checkpoint:board_climbs:<scope>` — destroying exactly the progress the heal exists to
+rescue — and rewind the single global deletions cursor with it. It is reported at full severity
+(`expected: false`) because it means the export's scope filter and the client's disagree.
+
+With `W ≥ C` enforced the coverage argument is simple: rows ≤ C are already local, the artifact supplies
+every scoped row ≤ W, `reconcileScope` removes local scoped rows ≤ W absent from the artifact, and the
+checkpoint moves forward to W with the strict-`>` delta covering (W, head].
+
+**Rollback safety: the legacy dual-write.** `bootstrap-retry:<scopeKey>` (a JSON `BootstrapRetryState`) is
+the source of truth, but `writeBootstrapRetryState` also mirrors the legacy `bootstrap-attempts:` /
+`bootstrap-attempts-healed:` / `bootstrap-paged-fallback:` rows and **never deletes them**. Production
+channel rollback and `pr-<n>` preview channels are live paths here: an older bundle that read no legacy row
+would re-arm a fresh 2-attempt round plus another one-shot heal. Reads reconcile the other way too — if the
+legacy counter moved past what we last mirrored (`mirroredAttempts`), an older bundle counted something
+real and the difference is folded back into `structuralFailures`. On first touch,
+`migrateLegacyBootstrapMarkers` derives a state from the legacy rows and grants one clean pass under the
+new taxonomy (the old counter conflated transport with structural, which is the bug), leaving the rows in
+place; a scope that already holds rows gets a `retryAfter` jittered across 2 hours so the fleet does not
+start downloading on the same post-OTA launch.
 
 A scope torn down from **More → Storage** becomes eligible again: `removeBoardScopeData`
 (`sync/scope-teardown.ts`) clears all three board-data checkpoints **and** its `bootstrap-attempts:` /
-`bootstrap-attempts-healed:` / `bootstrap-done:` / `bootstrap-paged-fallback:` markers in the same
-transaction as the rows, so a re-download takes the snapshot fast
-path rather than a paged crawl — and `onScopeDownloadComplete` attributes it honestly instead of
-reporting a stale `method: 'snapshot'` for a run that actually paged. All four marker prefixes are exported
-from `snapshot-bootstrap.ts` for that teardown alone; they stay package-internal (not re-exported from
-`index.ts`). Only the first three are read back by the My Boards metadata query — the heal marker has no UI,
-so `BOOTSTRAP_METADATA_PATTERNS` deliberately stays at six patterns.
+`bootstrap-attempts-healed:` / `bootstrap-done:` / `bootstrap-paged-fallback:` / `bootstrap-retry:` markers
+in the same transaction as the rows, so a re-download takes the snapshot fast path rather than a paged
+crawl — and `onScopeDownloadComplete` attributes it honestly instead of reporting a stale
+`method: 'snapshot'` for a run that actually paged. The marker prefixes stay package-internal (not
+re-exported from `index.ts`). `BOOTSTRAP_METADATA_QUERY` is built from `BOOTSTRAP_METADATA_PATTERNS` rather
+than hand-written, and a test asserts the placeholder count matches, so adding a prefix cannot silently
+drop one; the heal marker is the only one with no UI and stays out of that list.
 
-Failure/attempt matrix, copied from the `runBootstrapPhase` doc comment (the source of truth — keep this in
+Per-stage outcomes, copied from the `runBootstrapPhase` doc comment (the source of truth — keep this in
 sync if the code comment changes):
 
-| Condition                                                          | Attempt burned? | Result this cycle                                                                       |
-| ------------------------------------------------------------------ | --------------- | --------------------------------------------------------------------------------------- |
-| checkpoint exists on either board table                            | —               | not eligible → normal paged pull                                                        |
-| `isOnline()` reports offline                                       | —               | whole cycle skipped before the phase starts; retried on reconnect                       |
-| attempts ≥ `MAX_BOOTSTRAP_ATTEMPTS`, heal available + usable entry | —               | counter reset once → snapshot path runs                                                 |
-| attempts ≥ `MAX_BOOTSTRAP_ATTEMPTS`, otherwise                     | —               | gave up → normal paged pull                                                             |
-| manifest `absent` (404/missing or invalid JSON/shape)              | **no**          | permanent miss → normal paged pull                                                      |
-| manifest `error`, transport-shaped (offline/DNS/TLS/timeout)       | **no**          | skip paged pull this cycle; reported as `expected`                                      |
-| manifest `error`, anything else (HTTP non-2xx except 404, …)       | **yes**         | skip paged pull this cycle (retry next cycle)                                           |
-| manifest `ok` but no entry for `(boardType, layoutId)`             | **no**          | permanent miss (not exported yet) → normal paged pull                                   |
-| download fails or returns `null` (transport-shaped or not)         | **yes**         | skip paged pull this cycle; transport-shaped ones still report as `expected`            |
-| download throws `SnapshotPermanentMissError`                       | **no**          | permanent miss → normal paged pull                                                      |
-| import throws — corrupt/short artifact, row-count/format mismatch  | **yes**         | skip paged pull this cycle                                                              |
-| import throws `SnapshotSchemaStaleError`                           | **no**          | permanent miss this run → normal paged pull                                             |
-| a sign-out wipe is detected mid-phase                              | **no**          | whole phase bails, mirrors `syncTable`'s wipe guard                                     |
-| success                                                            | —               | marked done; deletions rewound; paged pull runs as a small delta from scoped watermarks |
+| Condition                                                            | Budget burned             | Result this cycle                                                                         |
+| -------------------------------------------------------------------- | ------------------------- | ----------------------------------------------------------------------------------------- |
+| `scope-complete:` / `bootstrap-done:` / mid-crawl with no failures   | —                         | not eligible → normal paged pull                                                          |
+| `isOnline()` reports offline                                         | —                         | whole cycle skipped before the phase starts; retried on reconnect                         |
+| a scheduled retry has not elapsed                                    | —                         | not eligible this cycle; crawl runs unless the retry is inside the 30-minute grace window |
+| terminal, last failure `structural-artifact`, re-arm left, new build | — (grants a round)        | budget restored once → snapshot path runs                                                 |
+| terminal, otherwise                                                  | —                         | settled → normal paged pull, manifest not fetched                                         |
+| heal-over-partial on a metered link                                  | **no** (defers 6 h)       | normal paged pull                                                                         |
+| manifest `absent` (404/missing or invalid JSON/shape)                | **no**                    | permanent miss → normal paged pull                                                        |
+| manifest `error`, transport-shaped (offline/DNS/TLS/timeout)         | **no**, nothing persisted | skip paged pull this cycle; reported as `expected`                                        |
+| manifest `error`, anything else (HTTP non-2xx except 404, …)         | `structural-device`       | 6 h ladder; crawl runs (past the grace window)                                            |
+| manifest `ok` but no entry for `(boardType, layoutId)`               | **no**                    | permanent miss (not exported yet) → normal paged pull                                     |
+| download fails or returns `null`, transport-shaped                   | `transport`               | 2 min ladder; paged pull skipped while the retry is imminent                              |
+| download fails or returns `null`, anything else                      | `structural-device`       | 6 h ladder; crawl runs                                                                    |
+| download throws `SnapshotPermanentMissError`                         | **no**                    | permanent miss → normal paged pull                                                        |
+| import throws — corrupt/short artifact, row-count/format mismatch    | `structural-artifact`     | 6 h ladder; a new `builtAt` may re-arm it once                                            |
+| import throws `SnapshotSchemaStaleError`                             | **no**                    | permanent miss this run → normal paged pull                                               |
+| import throws `SnapshotWatermarkRegressionError`                     | **no**                    | permanent miss, nothing written → normal paged pull; reported `expected: false`           |
+| a sign-out wipe is detected mid-phase                                | **no**                    | whole phase bails, mirrors `syncTable`'s wipe guard                                       |
+| success                                                              | transport counter reset   | marked done; deletions rewound; paged pull runs as a small delta from scoped watermarks   |
 
-"Skip paged pull this cycle" matters because a scope whose bootstrap failed but still has attempts left
-must **not** run its ordinary paged pull this cycle either — a first-page checkpoint from that pull would
-permanently disqualify the scope from ever bootstrapping (the eligibility check requires no checkpoint at
-all), so the next cycle retries the snapshot path instead of falling through to a slow crawl by accident.
+Resumable / ranged artifact downloads are **not** in scope here — artifacts ship gzip-encoded and rely on
+the native stack to decode, so byte-offset resume needs a JS gunzipper (a native dependency, OTA-forbidden).
+That is issue #4310's; when it lands, the transport ladder's first rung should drop, because a resumed
+attempt is cheap.
 
 **Import mechanics** (`bootstrapScopeFromSnapshot`): `ATTACH`es the downloaded file as `bs_snapshot`, runs
 `PRAGMA quick_check` (rejects a truncated/corrupt file before touching any row), verifies `snapshot_meta`

--- a/packages/mobile/app/boards/__tests__/manage-offline.test.tsx
+++ b/packages/mobile/app/boards/__tests__/manage-offline.test.tsx
@@ -54,6 +54,8 @@ const state = vi.hoisted(() => ({
       isPagedFallback: boolean;
       hasBoardCheckpoint: boolean;
       isScopeComplete: boolean;
+      isTerminal?: boolean;
+      retryAfter?: number | null;
     }
   >(),
   bootstrapQueryAsync: false,
@@ -495,6 +497,8 @@ describe('My Boards with no usable network list', () => {
           isPagedFallback: false,
           hasBoardCheckpoint: true,
           isScopeComplete: false,
+          // Both snapshot budgets spent, so this board really is on the crawl.
+          isTerminal: true,
         },
       ],
     ]);

--- a/packages/mobile/app/boards/manage.tsx
+++ b/packages/mobile/app/boards/manage.tsx
@@ -19,7 +19,9 @@ import {
   getDownloadedScopeKeys,
   getCheckpoint,
   getCheckpointKey,
-  getBootstrapAttempts,
+  readBootstrapRetryState,
+  isScopeDownloadComplete,
+  isBootstrapDone,
   getBootstrapMetadataByScope,
   estimateScopeDownload,
 } from '@boardsesh/offline-sync';
@@ -237,17 +239,29 @@ export default function ManageBoards() {
       // Concurrent, not sequential: these are three independent reads and the
       // dialog opens behind them, so serialising them would show up as a stall on
       // slow storage.
-      const [climbsCheckpoint, statsCheckpoint, bootstrapAttempts] = await Promise.all([
+      const now = Date.now();
+      const [climbsCheckpoint, statsCheckpoint, scopeComplete, bootstrapAlreadyDone] = await Promise.all([
         getCheckpoint(db, getCheckpointKey('board_climbs', key)),
         getCheckpoint(db, getCheckpointKey('board_climb_stats', key)),
-        getBootstrapAttempts(db, key),
+        isScopeDownloadComplete(db, key),
+        isBootstrapDone(db, key),
       ]);
+      const hasBoardCheckpoint = !!climbsCheckpoint || !!statsCheckpoint;
+      const { state: retryState } = await readBootstrapRetryState(
+        db,
+        key,
+        { now, random: Math.random },
+        hasBoardCheckpoint,
+      );
       const estimate = estimateScopeDownload({
         manifest: snapshotManifestRef.current,
         boardType: scope.boardType,
         layoutId: scope.layoutId,
-        hasExistingCheckpoint: !!climbsCheckpoint || !!statsCheckpoint,
-        bootstrapAttempts,
+        retryState,
+        hasBoardCheckpoint,
+        isScopeComplete: scopeComplete,
+        isBootstrapDone: bootstrapAlreadyDone,
+        now,
       });
       const confirmed = await confirm({
         title: t('mobile.offline.enableTitle', { name: board.name }),
@@ -417,6 +431,8 @@ export default function ManageBoards() {
             downloaded: isDownloaded,
             snapshotSourceAvailable,
             bootstrapAttempts: bootstrapMetadata?.attempts ?? 0,
+            isTerminal: bootstrapMetadata?.isTerminal ?? false,
+            retryAfter: bootstrapMetadata?.retryAfter ?? null,
             isBootstrapDone: bootstrapMetadata?.isBootstrapDone ?? false,
             isPagedFallback: bootstrapMetadata?.isPagedFallback ?? false,
             hasBoardCheckpoint: bootstrapMetadata?.hasBoardCheckpoint ?? false,

--- a/packages/mobile/src/components/board-discovery/__tests__/board-offline-state.test.ts
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-offline-state.test.ts
@@ -159,6 +159,8 @@ describe('boardDownloadNotice', () => {
     downloaded: false,
     snapshotSourceAvailable: true,
     bootstrapAttempts: 0,
+    isTerminal: false,
+    retryAfter: null,
     isBootstrapDone: false,
     isPagedFallback: false,
     hasBoardCheckpoint: false,
@@ -171,17 +173,31 @@ describe('boardDownloadNotice', () => {
     expect(boardDownloadNotice({ ...noticeBase, bootstrapAttempts: 1 })).toBe('snapshot-retrying');
   });
 
-  it('shows a paged-fallback notice after bootstrap retries are exhausted', () => {
-    expect(boardDownloadNotice({ ...noticeBase, bootstrapAttempts: 2 })).toBe('paged-fallback');
+  it('keeps the retrying notice while a snapshot attempt is scheduled', () => {
+    // The crawl may be running underneath it, but the fast download WILL be
+    // tried again — the caption promises what actually happens (issue #4313).
+    expect(boardDownloadNotice({ ...noticeBase, bootstrapAttempts: 1, retryAfter: 1_800_000_000_000 })).toBe(
+      'snapshot-retrying',
+    );
+  });
+
+  it('shows a paged-fallback notice once both snapshot budgets are spent', () => {
+    expect(boardDownloadNotice({ ...noticeBase, bootstrapAttempts: 2, isTerminal: true })).toBe('paged-fallback');
+  });
+
+  it('does not condemn a board to the slow path just because it failed twice', () => {
+    // Pre-#4313 this was the cliff: two transport failures and the caption said
+    // "slower download" for the life of the install.
+    expect(boardDownloadNotice({ ...noticeBase, bootstrapAttempts: 2 })).toBe('snapshot-retrying');
   });
 
   it('uses the explicit paged outcome after a transient failure followed by a permanent miss', () => {
     expect(boardDownloadNotice({ ...noticeBase, bootstrapAttempts: 1, isPagedFallback: true })).toBe('paged-fallback');
   });
 
-  it('treats a restored checkpoint as paged fallback after restart', () => {
+  it('keeps a mid-crawl scope on the retrying caption — it can still be healed', () => {
     expect(boardDownloadNotice({ ...noticeBase, bootstrapAttempts: 1, hasBoardCheckpoint: true })).toBe(
-      'paged-fallback',
+      'snapshot-retrying',
     );
   });
 
@@ -194,15 +210,15 @@ describe('boardDownloadNotice', () => {
   });
 
   it('clears the notice once the scope has completed its download', () => {
-    expect(boardDownloadNotice({ ...noticeBase, bootstrapAttempts: 2, downloaded: true })).toBeNull();
+    expect(boardDownloadNotice({ ...noticeBase, isTerminal: true, downloaded: true })).toBeNull();
   });
 
   it('clears from the metadata batch as soon as the per-scope completion marker lands', () => {
-    expect(boardDownloadNotice({ ...noticeBase, bootstrapAttempts: 2, isScopeComplete: true })).toBeNull();
+    expect(boardDownloadNotice({ ...noticeBase, isTerminal: true, isScopeComplete: true })).toBeNull();
   });
 
   it('ignores stale bootstrap markers when snapshot I/O is unavailable', () => {
-    expect(boardDownloadNotice({ ...noticeBase, bootstrapAttempts: 2, snapshotSourceAvailable: false })).toBeNull();
+    expect(boardDownloadNotice({ ...noticeBase, isTerminal: true, snapshotSourceAvailable: false })).toBeNull();
   });
 
   it('restores the correct retry outcome when snapshot I/O is toggled back on before paging starts', () => {
@@ -211,11 +227,12 @@ describe('boardDownloadNotice', () => {
     expect(boardDownloadNotice({ ...persistedRetry, snapshotSourceAvailable: true })).toBe('snapshot-retrying');
   });
 
-  it('uses live paged progress when the snapshot flag returns before a checkpoint lands', () => {
+  it('reports the settled verdict while the crawl it fell back to is running', () => {
     expect(
       boardDownloadNotice({
         ...noticeBase,
-        bootstrapAttempts: 1,
+        bootstrapAttempts: 2,
+        isTerminal: true,
         isPagedDownloadActive: true,
       }),
     ).toBe('paged-fallback');
@@ -227,6 +244,7 @@ describe('boardDownloadNotice', () => {
         ...noticeBase,
         bootstrapAttempts: 1,
         isPagedFallback: true,
+        isTerminal: true,
         isBootstrapping: true,
       }),
     ).toBeNull();

--- a/packages/mobile/src/components/board-discovery/board-offline-state.ts
+++ b/packages/mobile/src/components/board-discovery/board-offline-state.ts
@@ -2,7 +2,7 @@
 // sync status. Kept renderer-free so the My Boards screen can compute one state
 // per row without each row subscribing to the sync store, and so it can be tested.
 
-import { MAX_BOOTSTRAP_ATTEMPTS, type SyncProgress } from '@boardsesh/offline-sync';
+import type { SyncProgress } from '@boardsesh/offline-sync';
 
 export type BoardDownloadState =
   | 'off' // not made available offline
@@ -90,8 +90,15 @@ export function boardIsBootstrapping(input: BoardDownloadStateInput): boolean {
 export type BoardDownloadNoticeInput = Pick<BoardDownloadStateInput, 'enabled' | 'downloaded'> & {
   /** Snapshot I/O is actually injected for this build and feature-flag state. */
   snapshotSourceAvailable: boolean;
-  /** Persisted count of transient snapshot-bootstrap failures for this scope. */
+  /** Persisted count of snapshot-bootstrap failures for this scope (any kind). */
   bootstrapAttempts: number;
+  /**
+   * Both snapshot retry budgets are spent (issue #4313): this board is on the
+   * slow crawl until the climber asks for another go or removes it.
+   */
+  isTerminal: boolean;
+  /** Epoch ms of the next scheduled snapshot attempt, or null when none is pending. */
+  retryAfter: number | null;
   /** Persisted once an artifact import succeeded for this scope. */
   isBootstrapDone: boolean;
   /** Persisted when the latest bootstrap decision selected the paged crawl. */
@@ -122,11 +129,11 @@ export function boardDownloadNotice(input: BoardDownloadNoticeInput): BoardDownl
     input.isBootstrapping
   )
     return null;
-  if (
-    input.isPagedFallback ||
-    input.bootstrapAttempts >= MAX_BOOTSTRAP_ATTEMPTS ||
-    ((input.hasBoardCheckpoint || input.isPagedDownloadActive) && input.bootstrapAttempts > 0)
-  )
-    return 'paged-fallback';
+  // A settled scope is the only permanent verdict now. A scheduled retry keeps
+  // the softer "we'll try the fast download again" caption even though the crawl
+  // is running underneath it, because that is exactly what will happen.
+  if (input.isTerminal) return 'paged-fallback';
+  if (input.retryAfter !== null) return 'snapshot-retrying';
+  if (input.isPagedFallback) return 'paged-fallback';
   return input.bootstrapAttempts > 0 ? 'snapshot-retrying' : null;
 }

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -79,6 +79,10 @@ export type {
   CoverageResetReporter,
   CoverageEvaluatedInfo,
   CoverageEvaluatedReporter,
+  BootstrapRetryScheduledInfo,
+  BootstrapRetryScheduledReporter,
+  BootstrapPathRecoveredInfo,
+  BootstrapPathRecoveredReporter,
 } from './sync/pull-client';
 
 // --- Tombstone retention (issue #3474) --------------------------------------
@@ -94,15 +98,13 @@ export {
 } from './sync/retention';
 export {
   bootstrapScopeFromSnapshot,
-  getBootstrapAttempts,
   getBootstrapMetadataByScope,
-  recordBootstrapAttempt,
   markBootstrapDone,
   isBootstrapDone,
-  MAX_BOOTSTRAP_ATTEMPTS,
   SnapshotWipedError,
   SnapshotSchemaStaleError,
   SnapshotPermanentMissError,
+  SnapshotWatermarkRegressionError,
 } from './sync/snapshot-bootstrap';
 export type {
   SnapshotSource,
@@ -110,6 +112,29 @@ export type {
   SnapshotBootstrapErrorReporter,
   BootstrapScopeMetadata,
 } from './sync/snapshot-bootstrap';
+
+// --- Bootstrap retry budgets + cooldowns (issue #4313) ---------------------------
+// The failure taxonomy that decides whether a snapshot failure is worth another
+// artifact download, and when. `restoreBootstrapRetryBudget` is the user-facing
+// escape from a settled scope ("Try the fast download again").
+export {
+  MAX_BOOTSTRAP_ATTEMPTS,
+  MAX_TRANSPORT_DOWNLOAD_FAILURES,
+  MAX_STRUCTURAL_REARMS,
+  EMPTY_BOOTSTRAP_RETRY_STATE,
+  classifyBootstrapFailure,
+  evaluateBootstrapEligibility,
+  isTerminal as isBootstrapRetryTerminal,
+  getBootstrapAttempts,
+  readBootstrapRetryState,
+  restoreBootstrapRetryBudget,
+} from './sync/bootstrap-retry';
+export type {
+  BootstrapFailureKind,
+  BootstrapRetryState,
+  BootstrapRetryRead,
+  BootstrapEligibility,
+} from './sync/bootstrap-retry';
 export { startSyncScheduler, triggerSync } from './sync/sync-scheduler';
 export type { SyncProgressSink, SchedulerTriggers, SchedulerOptions, DrainQueue } from './sync/sync-scheduler';
 export {

--- a/packages/shared/offline-sync/src/sync/__tests__/bootstrap-retry.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/bootstrap-retry.test.ts
@@ -1,0 +1,481 @@
+// The failure taxonomy, budgets and cooldown ladders that replaced "2 attempts
+// then paged forever" (issue #4313). Everything here is pure — the clock and the
+// jitter source are injected — plus the two SQLite helpers, which run against the
+// real client DDL so the legacy dual-write is exercised for real.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  BOOTSTRAP_RETRY_GRACE_WINDOW_MS,
+  EMPTY_BOOTSTRAP_RETRY_STATE,
+  MAX_BOOTSTRAP_ATTEMPTS,
+  MAX_STRUCTURAL_REARMS,
+  MAX_TRANSPORT_DOWNLOAD_FAILURES,
+  canRearmOnNewArtifact,
+  classifyBootstrapFailure,
+  clearRetryStateForUserRequest,
+  clearTransportFailures,
+  evaluateBootstrapEligibility,
+  isTerminal,
+  migrateLegacyBootstrapMarkers,
+  nextRetryState,
+  readBootstrapRetryState,
+  rearmForNewArtifact,
+  restoreBootstrapRetryBudget,
+  shouldSkipPagedPull,
+  writeBootstrapRetryState,
+  type BootstrapFailureKind,
+  type BootstrapRetryState,
+} from '../bootstrap-retry';
+import { runMigrations } from '../../db/migrations';
+import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
+
+const NOW = 1_800_000_000_000;
+const MINUTE = 60_000;
+const HOUR = 3_600_000;
+
+/** No jitter: every cooldown lands on its base rung, so assertions are exact. */
+const noJitter = () => 0;
+
+function state(patch: Partial<BootstrapRetryState> = {}): BootstrapRetryState {
+  return { ...EMPTY_BOOTSTRAP_RETRY_STATE, ...patch };
+}
+
+function burn(
+  from: BootstrapRetryState,
+  failureKind: BootstrapFailureKind,
+  options: { builtAt?: string | null; now?: number; random?: () => number } = {},
+): BootstrapRetryState {
+  return nextRetryState({
+    state: from,
+    failureKind,
+    builtAt: options.builtAt ?? null,
+    now: options.now ?? NOW,
+    random: options.random ?? noJitter,
+  });
+}
+
+describe('classifyBootstrapFailure', () => {
+  it('routes a dropped connection at the download stage to the transport budget', () => {
+    // The exact shape iOS raises for the case in issue #4313's Sentry sample.
+    const cause = new Error('snapshot download: File.downloadFileAsync failed', {
+      cause: new Error('UnableToDownloadException: The request timed out.'),
+    });
+    expect(classifyBootstrapFailure({ cause, stage: 'download' })).toBe('transport');
+    expect(classifyBootstrapFailure({ cause: new TypeError('Network request failed'), stage: 'manifest' })).toBe(
+      'transport',
+    );
+  });
+
+  it('attributes an import failure to the ARTIFACT — the bytes are on disk', () => {
+    expect(classifyBootstrapFailure({ cause: new Error('quick_check failed'), stage: 'import' })).toBe(
+      'structural-artifact',
+    );
+  });
+
+  it('attributes an unclassifiable download failure to the DEVICE, not the artifact', () => {
+    // Conservative on purpose: a plain Error from an adapter's downloader could
+    // be disk-full or a cache-dir fault, and a nightly rebuild must not re-arm
+    // the budget for either of those.
+    expect(classifyBootstrapFailure({ cause: new Error('insufficient disk space'), stage: 'download' })).toBe(
+      'structural-device',
+    );
+  });
+});
+
+describe('cooldown ladders', () => {
+  it('walks the transport ladder 2 min → 15 min → 2 h', () => {
+    let current = state();
+    current = burn(current, 'transport');
+    expect(current.retryAfter).toBe(NOW + 2 * MINUTE);
+    current = burn(current, 'transport');
+    expect(current.retryAfter).toBe(NOW + 15 * MINUTE);
+    current = burn(current, 'transport');
+    expect(current.retryAfter).toBe(NOW + 2 * HOUR);
+  });
+
+  it('walks the structural ladder 6 h → 24 h', () => {
+    let current = state();
+    current = burn(current, 'structural-device');
+    expect(current.retryAfter).toBe(NOW + 6 * HOUR);
+    current = burn(current, 'structural-device');
+    expect(current.retryAfter).toBe(NOW + 24 * HOUR);
+  });
+
+  it('jitters within [1x, 1.5x) so a fleet that failed together does not retry together', () => {
+    const atFloor = burn(state(), 'transport', { random: () => 0 });
+    const nearCeiling = burn(state(), 'transport', { random: () => 0.999999 });
+    expect(atFloor.retryAfter! - NOW).toBe(2 * MINUTE);
+    expect(nearCeiling.retryAfter! - NOW).toBeGreaterThan(2 * MINUTE);
+    expect(nearCeiling.retryAfter! - NOW).toBeLessThanOrEqual(3 * MINUTE);
+  });
+});
+
+describe('budgets', () => {
+  it('spends the transport budget without ever touching the structural one', () => {
+    let current = state();
+    for (let failure = 0; failure < MAX_TRANSPORT_DOWNLOAD_FAILURES; failure += 1) {
+      expect(isTerminal(current)).toBe(false);
+      current = burn(current, 'transport');
+    }
+    expect(current.structuralFailures).toBe(0);
+    expect(current.transportFailures).toBe(MAX_TRANSPORT_DOWNLOAD_FAILURES);
+    expect(isTerminal(current)).toBe(true);
+  });
+
+  it('resets the transport counter and its cooldown on a successful download', () => {
+    const afterTwo = burn(burn(state(), 'transport'), 'transport');
+    const recovered = clearTransportFailures(afterTwo);
+    expect(recovered.transportFailures).toBe(0);
+    expect(recovered.retryAfter).toBeNull();
+    // …and the ladder starts again at its first rung, not where it left off.
+    expect(burn(recovered, 'transport').retryAfter).toBe(NOW + 2 * MINUTE);
+  });
+
+  it('settles a scope after MAX_BOOTSTRAP_ATTEMPTS structural failures', () => {
+    let current = state();
+    for (let failure = 0; failure < MAX_BOOTSTRAP_ATTEMPTS; failure += 1)
+      current = burn(current, 'structural-artifact');
+    expect(isTerminal(current)).toBe(true);
+  });
+});
+
+describe('re-arming on a newly built artifact', () => {
+  const spendStructural = (kind: BootstrapFailureKind, builtAt: string): BootstrapRetryState => {
+    let current = state();
+    for (let failure = 0; failure < MAX_BOOTSTRAP_ATTEMPTS; failure += 1) current = burn(current, kind, { builtAt });
+    return current;
+  };
+
+  it('re-arms an ARTIFACT-attributable scope once, and only once', () => {
+    let current = spendStructural('structural-artifact', 'build-1');
+    expect(canRearmOnNewArtifact(current)).toBe(true);
+
+    current = rearmForNewArtifact(current, 'build-2');
+    expect(isTerminal(current)).toBe(false);
+    expect(current.retryAfter).toBeNull();
+    expect(current.structuralRearms).toBe(MAX_STRUCTURAL_REARMS);
+
+    for (let failure = 0; failure < MAX_BOOTSTRAP_ATTEMPTS; failure += 1) {
+      current = burn(current, 'structural-artifact', { builtAt: 'build-2' });
+    }
+    expect(isTerminal(current)).toBe(true);
+    // The export is nightly, so without this cap every launch would offer a
+    // "new" builtAt and the scope would download 2 x 103 MB per day forever.
+    expect(canRearmOnNewArtifact(current)).toBe(false);
+  });
+
+  it('never re-arms a DEVICE-attributable scope, however many nightly rebuilds land', () => {
+    const current = spendStructural('structural-device', 'build-1');
+    expect(isTerminal(current)).toBe(true);
+    expect(canRearmOnNewArtifact(current)).toBe(false);
+  });
+
+  it('never re-arms a scope whose transport budget is spent', () => {
+    let current = spendStructural('structural-artifact', 'build-1');
+    current = { ...current, transportFailures: MAX_TRANSPORT_DOWNLOAD_FAILURES };
+    expect(canRearmOnNewArtifact(current)).toBe(false);
+  });
+});
+
+describe('evaluateBootstrapEligibility', () => {
+  const evaluate = (patch: Partial<Parameters<typeof evaluateBootstrapEligibility>[0]> = {}) =>
+    evaluateBootstrapEligibility({
+      retryState: state(),
+      hasBoardCheckpoint: false,
+      isScopeComplete: false,
+      isBootstrapDone: false,
+      now: NOW,
+      ...patch,
+    });
+
+  it('admits a fresh scope', () => {
+    expect(evaluate()).toEqual({ eligible: true, kind: 'fresh' });
+  });
+
+  it('admits a mid-crawl scope that carries snapshot-path failures', () => {
+    expect(
+      evaluate({
+        hasBoardCheckpoint: true,
+        retryState: state({ transportFailures: 1, hasPriorSnapshotFailure: true }),
+      }),
+    ).toEqual({ eligible: true, kind: 'heal-over-partial' });
+  });
+
+  it('refuses a mid-crawl scope with no snapshot history — it is just a crawl in progress', () => {
+    expect(evaluate({ hasBoardCheckpoint: true })).toMatchObject({ eligible: false, reason: 'no-failure-evidence' });
+  });
+
+  it('never heals a scope that already serves the whole catalog offline', () => {
+    // It holds every row locally; 103 MB buys it nothing until its next teardown.
+    expect(
+      evaluate({
+        isScopeComplete: true,
+        hasBoardCheckpoint: true,
+        retryState: state({ structuralFailures: 1, hasPriorSnapshotFailure: true }),
+      }),
+    ).toMatchObject({ eligible: false, reason: 'scope-complete' });
+  });
+
+  it('never re-runs for a scope that already imported an artifact', () => {
+    expect(evaluate({ isBootstrapDone: true })).toMatchObject({ eligible: false, reason: 'bootstrap-done' });
+  });
+
+  it('holds a scope until its scheduled retry, then admits it', () => {
+    const cooling = state({ transportFailures: 1, hasPriorSnapshotFailure: true, retryAfter: NOW + 1 });
+    expect(evaluate({ retryState: cooling })).toMatchObject({ eligible: false, reason: 'cooling-down' });
+    expect(evaluate({ retryState: { ...cooling, retryAfter: NOW } })).toEqual({ eligible: true, kind: 'fresh' });
+  });
+
+  it('reports a terminal scope and whether tonight’s export could revive it', () => {
+    expect(evaluate({ retryState: state({ transportFailures: MAX_TRANSPORT_DOWNLOAD_FAILURES }) })).toMatchObject({
+      eligible: false,
+      reason: 'terminal',
+      canRearm: false,
+    });
+    expect(
+      evaluate({
+        retryState: state({ structuralFailures: MAX_BOOTSTRAP_ATTEMPTS, lastFailureKind: 'structural-artifact' }),
+      }),
+    ).toMatchObject({ eligible: false, reason: 'terminal', canRearm: true });
+  });
+});
+
+describe('shouldSkipPagedPull', () => {
+  const skip = (patch: Partial<Parameters<typeof shouldSkipPagedPull>[0]> = {}) =>
+    shouldSkipPagedPull({ retryState: state(), hasBoardCheckpoint: false, now: NOW, ...patch });
+
+  it('waits for an imminent retry on a fresh scope', () => {
+    expect(skip({ retryState: state({ retryAfter: NOW + 2 * MINUTE }) })).toBe(true);
+    expect(skip({ retryState: state({ retryAfter: NOW + BOOTSTRAP_RETRY_GRACE_WINDOW_MS }) })).toBe(true);
+  });
+
+  it('runs the crawl rather than leave a board empty for a 2-hour cooldown', () => {
+    expect(skip({ retryState: state({ retryAfter: NOW + 2 * HOUR }) })).toBe(false);
+  });
+
+  it('never stalls a scope that is already making crawl progress', () => {
+    expect(skip({ hasBoardCheckpoint: true, retryState: state({ retryAfter: NOW + MINUTE }) })).toBe(false);
+  });
+
+  it('never stalls a settled scope — the crawl is the only path it has left', () => {
+    expect(skip({ retryState: state({ transportFailures: MAX_TRANSPORT_DOWNLOAD_FAILURES }) })).toBe(false);
+  });
+});
+
+describe('legacy marker migration', () => {
+  it('grants a stranded scope one clean pass instead of inheriting the conflated counter', () => {
+    // The legacy counter mixed transport failures in with real defects — that IS
+    // the bug — so carrying its value forward would strand the same users again.
+    const migrated = migrateLegacyBootstrapMarkers({
+      legacyAttempts: MAX_BOOTSTRAP_ATTEMPTS,
+      legacyHealed: false,
+      hasBoardCheckpoint: false,
+      now: NOW,
+      random: noJitter,
+    });
+    expect(isTerminal(migrated)).toBe(false);
+    expect(migrated.structuralFailures).toBe(0);
+    expect(migrated.hasPriorSnapshotFailure).toBe(true);
+    expect(migrated.retryAfter).toBeNull();
+    // The old bundle's one-shot heal is pre-spent, so a rollback can't re-grant it.
+    expect(migrated.legacyHealSpent).toBe(true);
+    expect(migrated.mirroredAttempts).toBe(MAX_BOOTSTRAP_ATTEMPTS);
+  });
+
+  it('spreads the post-OTA wave for scopes that already hold rows', () => {
+    const early = migrateLegacyBootstrapMarkers({
+      legacyAttempts: 2,
+      legacyHealed: false,
+      hasBoardCheckpoint: true,
+      now: NOW,
+      random: () => 0,
+    });
+    const late = migrateLegacyBootstrapMarkers({
+      legacyAttempts: 2,
+      legacyHealed: false,
+      hasBoardCheckpoint: true,
+      now: NOW,
+      random: () => 0.9,
+    });
+    expect(early.retryAfter).toBe(NOW);
+    expect(late.retryAfter).toBeGreaterThan(NOW + HOUR);
+    expect(late.retryAfter).toBeLessThan(NOW + 2 * HOUR);
+  });
+
+  it('spends the re-arm budget for a scope that already used the old one-shot heal', () => {
+    const migrated = migrateLegacyBootstrapMarkers({
+      legacyAttempts: 2,
+      legacyHealed: true,
+      hasBoardCheckpoint: false,
+      now: NOW,
+      random: noJitter,
+    });
+    expect(migrated.structuralRearms).toBe(MAX_STRUCTURAL_REARMS);
+  });
+
+  it('leaves a never-failed scope completely untouched', () => {
+    expect(
+      migrateLegacyBootstrapMarkers({
+        legacyAttempts: 0,
+        legacyHealed: false,
+        hasBoardCheckpoint: true,
+        now: NOW,
+        random: noJitter,
+      }),
+    ).toEqual(EMPTY_BOOTSTRAP_RETRY_STATE);
+  });
+});
+
+describe('clearRetryStateForUserRequest', () => {
+  it('restores both budgets and the re-arm, keeping the rollback mirrors honest', () => {
+    const settled = state({
+      transportFailures: MAX_TRANSPORT_DOWNLOAD_FAILURES,
+      structuralFailures: MAX_BOOTSTRAP_ATTEMPTS,
+      structuralRearms: MAX_STRUCTURAL_REARMS,
+      retryAfter: NOW + 24 * HOUR,
+      mirroredAttempts: MAX_BOOTSTRAP_ATTEMPTS,
+      hasPriorSnapshotFailure: true,
+    });
+    const cleared = clearRetryStateForUserRequest(settled);
+    expect(isTerminal(cleared)).toBe(false);
+    expect(cleared.retryAfter).toBeNull();
+    expect(cleared.structuralRearms).toBe(0);
+    expect(cleared.legacyHealSpent).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Persistence + the legacy dual-write, against the real DDL
+// ---------------------------------------------------------------------------
+
+describe('bootstrap-retry persistence', () => {
+  let workDir: string;
+  let db: TestSqliteDb;
+
+  beforeEach(async () => {
+    workDir = mkdtempSync(join(tmpdir(), 'bootstrap-retry-'));
+    db = createTestDatabase(join(workDir, 'client.db'));
+    await runMigrations(db);
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  const readMeta = async (key: string): Promise<string | null> => {
+    const row = await db.getFirstAsync<{ value: string }>('SELECT value FROM sync_meta WHERE key = ?', [key]);
+    return row ? row.value : null;
+  };
+
+  it('mirrors the legacy rows on every write and never deletes them', async () => {
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      'bootstrap-attempts:kilter:1:5',
+      '2',
+    ]);
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      'bootstrap-attempts-healed:kilter:1:5',
+      '1',
+    ]);
+
+    const { state: migrated, migratedFromLegacy } = await readBootstrapRetryState(
+      db,
+      'kilter:1:5',
+      { now: NOW, random: noJitter },
+      false,
+    );
+    expect(migratedFromLegacy).toBe(true);
+    const written = await writeBootstrapRetryState(db, 'kilter:1:5', burn(migrated, 'structural-artifact'));
+
+    expect(await readMeta('bootstrap-retry:kilter:1:5')).not.toBeNull();
+    // One structural failure spent, not yet terminal, so the legacy view is 1.
+    expect(await readMeta('bootstrap-attempts:kilter:1:5')).toBe('1');
+    // A rolled-back bundle must not re-grant the one-shot heal it already spent.
+    expect(await readMeta('bootstrap-attempts-healed:kilter:1:5')).toBe('1');
+    expect(written.mirroredAttempts).toBe(1);
+  });
+
+  it('mirrors a terminal scope as the legacy cap so an old bundle also gives up', async () => {
+    let current = state();
+    for (let failure = 0; failure < MAX_BOOTSTRAP_ATTEMPTS; failure += 1) current = burn(current, 'structural-device');
+    await writeBootstrapRetryState(db, 'kilter:1:5', current);
+    expect(await readMeta('bootstrap-attempts:kilter:1:5')).toBe(String(MAX_BOOTSTRAP_ATTEMPTS));
+  });
+
+  it('folds back failures an older bundle counted while it was rolled back', async () => {
+    await writeBootstrapRetryState(db, 'kilter:1:5', state({ hasPriorSnapshotFailure: true }));
+    // A rolled-back bundle runs and bumps only the legacy counter it knows about.
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      'bootstrap-attempts:kilter:1:5',
+      '2',
+    ]);
+
+    const { state: reconciled } = await readBootstrapRetryState(
+      db,
+      'kilter:1:5',
+      { now: NOW, random: noJitter },
+      false,
+    );
+    expect(reconciled.structuralFailures).toBe(2);
+    expect(isTerminal(reconciled)).toBe(true);
+  });
+
+  it('round-trips a persisted state without laundering anything', async () => {
+    const written = await writeBootstrapRetryState(
+      db,
+      'kilter:1:5',
+      state({
+        transportFailures: 2,
+        structuralFailures: 1,
+        structuralRearms: 1,
+        lastFailureKind: 'structural-artifact',
+        failedBuiltAt: 'build-7',
+        retryAfter: NOW + HOUR,
+        hasPriorSnapshotFailure: true,
+      }),
+    );
+    const { state: reread, migratedFromLegacy } = await readBootstrapRetryState(
+      db,
+      'kilter:1:5',
+      { now: NOW, random: noJitter },
+      false,
+    );
+    expect(migratedFromLegacy).toBe(false);
+    expect(reread).toEqual(written);
+  });
+
+  it('treats a corrupt retry row as an un-migrated scope rather than crashing the cycle', async () => {
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      'bootstrap-retry:kilter:1:5',
+      'not json',
+    ]);
+    const { state: recovered, migratedFromLegacy } = await readBootstrapRetryState(
+      db,
+      'kilter:1:5',
+      { now: NOW, random: noJitter },
+      false,
+    );
+    expect(migratedFromLegacy).toBe(true);
+    expect(recovered).toEqual(EMPTY_BOOTSTRAP_RETRY_STATE);
+  });
+
+  it('restoreBootstrapRetryBudget revives a settled scope and drops its slow-path caption', async () => {
+    let current = state();
+    for (let failure = 0; failure < MAX_BOOTSTRAP_ATTEMPTS; failure += 1) current = burn(current, 'structural-device');
+    await writeBootstrapRetryState(db, 'kilter:1:5', current);
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      'bootstrap-paged-fallback:kilter:1:5',
+      '1',
+    ]);
+
+    const restored = await restoreBootstrapRetryBudget(db, 'kilter:1:5');
+
+    expect(isTerminal(restored)).toBe(false);
+    expect(await readMeta('bootstrap-paged-fallback:kilter:1:5')).toBeNull();
+    expect(await readMeta('bootstrap-attempts:kilter:1:5')).toBe('0');
+    const { state: reread } = await readBootstrapRetryState(db, 'kilter:1:5', { now: NOW, random: noJitter }, false);
+    expect(isTerminal(reread)).toBe(false);
+  });
+});

--- a/packages/shared/offline-sync/src/sync/__tests__/bootstrap-retry.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/bootstrap-retry.test.ts
@@ -25,6 +25,7 @@ import {
   rearmForNewArtifact,
   restoreBootstrapRetryBudget,
   shouldSkipPagedPull,
+  spendUserRequest,
   writeBootstrapRetryState,
   type BootstrapFailureKind,
   type BootstrapRetryState,
@@ -366,6 +367,17 @@ describe('clearRetryStateForUserRequest', () => {
       }),
     ).toEqual({ eligible: true, kind: 'heal-over-partial' });
   });
+
+  it('arms a one-shot user-request flag that survives one download and no more', () => {
+    // The flag is what lets the tap through the metered defer. Spending it as the
+    // download STARTS keeps a failure from leaving a standing licence to pull
+    // ~100 MB over cellular on every later cooldown.
+    const armed = clearRetryStateForUserRequest(state({ hasPriorSnapshotFailure: true }));
+    expect(armed.userRequested).toBe(true);
+    const spent = spendUserRequest(armed);
+    expect(spent.userRequested).toBe(false);
+    expect(spendUserRequest(spent)).toBe(spent);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -498,6 +510,9 @@ describe('bootstrap-retry persistence', () => {
     expect(await readMeta('bootstrap-attempts:kilter:1:5')).toBe('0');
     const { state: reread } = await readBootstrapRetryState(db, 'kilter:1:5', { now: NOW, random: noJitter }, true);
     expect(isTerminal(reread)).toBe(false);
+    // The consent survives the round trip: without it the next cycle defers the
+    // heal for 6 h on cellular and the tap does nothing at all.
+    expect(reread.userRequested).toBe(true);
     // …and the engine will actually run for it on the next cycle, which is the
     // only reason the row action exists.
     expect(

--- a/packages/shared/offline-sync/src/sync/__tests__/bootstrap-retry.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/bootstrap-retry.test.ts
@@ -345,6 +345,27 @@ describe('clearRetryStateForUserRequest', () => {
     expect(cleared.structuralRearms).toBe(0);
     expect(cleared.legacyHealSpent).toBe(true);
   });
+
+  it('makes the scope actually eligible again — a settled board has always crawled', () => {
+    // The regression this pins: dropping `hasPriorSnapshotFailure` alongside the
+    // budgets left a checkpointed scope on `no-failure-evidence`, so the whole
+    // "Try the fast download again" action was a silent no-op.
+    const settled = state({
+      structuralFailures: MAX_BOOTSTRAP_ATTEMPTS,
+      retryAfter: NOW + 24 * HOUR,
+      hasPriorSnapshotFailure: true,
+      lastFailureKind: 'structural-device',
+    });
+    expect(
+      evaluateBootstrapEligibility({
+        retryState: clearRetryStateForUserRequest(settled),
+        hasBoardCheckpoint: true,
+        isScopeComplete: false,
+        isBootstrapDone: false,
+        now: NOW,
+      }),
+    ).toEqual({ eligible: true, kind: 'heal-over-partial' });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -475,7 +496,18 @@ describe('bootstrap-retry persistence', () => {
     expect(isTerminal(restored)).toBe(false);
     expect(await readMeta('bootstrap-paged-fallback:kilter:1:5')).toBeNull();
     expect(await readMeta('bootstrap-attempts:kilter:1:5')).toBe('0');
-    const { state: reread } = await readBootstrapRetryState(db, 'kilter:1:5', { now: NOW, random: noJitter }, false);
+    const { state: reread } = await readBootstrapRetryState(db, 'kilter:1:5', { now: NOW, random: noJitter }, true);
     expect(isTerminal(reread)).toBe(false);
+    // …and the engine will actually run for it on the next cycle, which is the
+    // only reason the row action exists.
+    expect(
+      evaluateBootstrapEligibility({
+        retryState: reread,
+        hasBoardCheckpoint: true,
+        isScopeComplete: false,
+        isBootstrapDone: false,
+        now: NOW,
+      }).eligible,
+    ).toBe(true);
   });
 });

--- a/packages/shared/offline-sync/src/sync/__tests__/scope-teardown.integration.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/scope-teardown.integration.test.ts
@@ -12,7 +12,7 @@ import type { QueryInvalidator } from '../../database';
 import { pullSync } from '../pull-client';
 import { removeBoardScopeData } from '../scope-teardown';
 import { getCheckpoint, setCheckpoint, markScopeDownloadComplete } from '../checkpoints';
-import { getBootstrapAttempts } from '../snapshot-bootstrap';
+import { getBootstrapAttempts } from '../bootstrap-retry';
 import { runMigrations } from '../../db/migrations';
 import { ensureMutationQueueTable } from '../../mutation-queue/schema';
 import { beginLocalPurge, __resetDrainerStateForTests } from '../../mutation-queue/drainer';
@@ -154,6 +154,11 @@ describe('re-downloading a removed board', () => {
       `bootstrap-attempts-healed:${SCOPE_KEY}`,
       '1',
     ]);
+    // …as must the retry budgets and cooldown the scope settled into (#4313).
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      `bootstrap-retry:${SCOPE_KEY}`,
+      JSON.stringify({ transportFailures: 3, structuralFailures: 2, retryAfter: 1_800_000_000_000 }),
+    ]);
 
     await removeBoardScopeData({ db, scope: SCOPE, scopeKey: SCOPE_KEY, retainedScopes: [] });
 
@@ -165,6 +170,9 @@ describe('re-downloading a removed board', () => {
     expect(await getCheckpoint(db, `checkpoint:board_climb_grades:${SCOPE_KEY}`)).toBeNull();
     expect(
       await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', [`bootstrap-paged-fallback:${SCOPE_KEY}`]),
+    ).toBeNull();
+    expect(
+      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', [`bootstrap-retry:${SCOPE_KEY}`]),
     ).toBeNull();
     expect(
       await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', [`bootstrap-attempts-healed:${SCOPE_KEY}`]),

--- a/packages/shared/offline-sync/src/sync/__tests__/scope-teardown.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/scope-teardown.test.ts
@@ -242,6 +242,10 @@ describe('removeBoardScopeData — markers', () => {
       `bootstrap-paged-fallback:${scopeKey}`,
       '1',
     ]);
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      `bootstrap-retry:${scopeKey}`,
+      JSON.stringify({ transportFailures: 3, structuralFailures: 2, retryAfter: 1_800_000_000_000 }),
+    ]);
   }
 
   // Rows and markers must die together. A surviving checkpoint means the strict `>`
@@ -294,7 +298,7 @@ describe('removeBoardScopeData — markers', () => {
   // what "a scope's downloaded state" consists of. Adding a marker here should mean
   // deliberately updating this list (and `seedMarkers` above, which proves the
   // teardown actually clears each one), not nudging a magic number.
-  it('is exactly the scope’s checkpoints plus its five markers', async () => {
+  it('is exactly the scope’s checkpoints plus its six markers', async () => {
     const keys = scopeSyncMetaKeys('kilter:1:5');
 
     expect(new Set(keys)).toEqual(
@@ -307,6 +311,7 @@ describe('removeBoardScopeData — markers', () => {
         'bootstrap-attempts-healed:kilter:1:5',
         'bootstrap-done:kilter:1:5',
         'bootstrap-paged-fallback:kilter:1:5',
+        'bootstrap-retry:kilter:1:5',
       ]),
     );
   });

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -16,7 +16,6 @@ import type { QueryInvalidator } from '../../database';
 import { pullSync } from '../pull-client';
 import {
   bootstrapScopeFromSnapshot,
-  getBootstrapAttempts,
   getBootstrapMetadataByScope,
   BOOTSTRAP_METADATA_QUERY,
   BOOTSTRAP_METADATA_PATTERNS,
@@ -24,6 +23,12 @@ import {
   SnapshotSchemaStaleError,
   type SnapshotSource,
 } from '../snapshot-bootstrap';
+import {
+  getBootstrapAttempts,
+  MAX_BOOTSTRAP_ATTEMPTS,
+  MAX_STRUCTURAL_REARMS,
+  MAX_TRANSPORT_DOWNLOAD_FAILURES,
+} from '../bootstrap-retry';
 import { getCheckpoint, setCheckpoint, DELETIONS_CHECKPOINT_KEY } from '../checkpoints';
 import { runMigrations, LATEST_SCHEMA_VERSION } from '../../db/migrations';
 import { ensureMutationQueueTable } from '../../mutation-queue/schema';
@@ -273,6 +278,9 @@ type GraphqlFetchMock = ReturnType<typeof vi.fn> &
   (<T>(query: string, variables?: Record<string, unknown>) => Promise<T>);
 
 const SCOPE_KILTER_5: OfflineBoardScope = { boardType: 'kilter', layoutId: 1, sizeId: 5 };
+/** Fixed clock for the retry-ladder tests; the real one is injected via SyncOptions. */
+const BASE_NOW = 1_800_000_000_000;
+const HOUR_MS = 3_600_000;
 const CLIMBS_WATERMARK: Cursor = { updatedAt: '2026-05-02T00:00:00Z', syncSeq: '20' };
 const STATS_WATERMARK: Cursor = { updatedAt: '2026-05-02T00:00:00Z', syncSeq: '20' };
 
@@ -314,6 +322,22 @@ describe('getBootstrapMetadataByScope', () => {
       'bootstrap-paged-fallback:tension:2:10',
       '1',
     ]);
+    // A settled scope's retry row is what My Boards reads to tell "waiting to try
+    // again" from "this board is on the slow path for good".
+    await db.runAsync('INSERT INTO sync_meta (key, value) VALUES (?, ?)', [
+      'bootstrap-retry:tension:2:10',
+      JSON.stringify({
+        transportFailures: 0,
+        structuralFailures: MAX_BOOTSTRAP_ATTEMPTS,
+        structuralRearms: 0,
+        lastFailureKind: 'structural-device',
+        failedBuiltAt: null,
+        retryAfter: 1_800_000_000_000,
+        hasPriorSnapshotFailure: true,
+        mirroredAttempts: MAX_BOOTSTRAP_ATTEMPTS,
+        legacyHealSpent: true,
+      }),
+    ]);
     await db.runAsync('INSERT INTO sync_meta (key, value) VALUES (?, ?)', ['bootstrap-attempts:kilter:9:20', '1']);
     await db.runAsync('INSERT INTO sync_meta (key, value) VALUES (?, ?)', [
       'checkpoint:board_climb_stats:kilter:9:20',
@@ -335,6 +359,9 @@ describe('getBootstrapMetadataByScope', () => {
       isPagedFallback: false,
       hasBoardCheckpoint: true,
       isScopeComplete: true,
+      retryAfter: null,
+      structuralFailures: 0,
+      isTerminal: false,
     });
     expect(metadataByScope.get('tension:2:10')).toEqual({
       attempts: 2,
@@ -342,6 +369,9 @@ describe('getBootstrapMetadataByScope', () => {
       isPagedFallback: true,
       hasBoardCheckpoint: false,
       isScopeComplete: false,
+      retryAfter: 1_800_000_000_000,
+      structuralFailures: MAX_BOOTSTRAP_ATTEMPTS,
+      isTerminal: true,
     });
     expect(metadataByScope.get('kilter:9:20')).toEqual({
       attempts: 1,
@@ -349,9 +379,18 @@ describe('getBootstrapMetadataByScope', () => {
       isPagedFallback: false,
       hasBoardCheckpoint: true,
       isScopeComplete: false,
+      retryAfter: null,
+      structuralFailures: 0,
+      isTerminal: false,
     });
     expect(metadataByScope.get('missing:4:20')).toBeUndefined();
     expect(metadataByScope.has('moonboard:3:7')).toBe(false);
+  });
+
+  it('binds exactly one placeholder per metadata prefix', () => {
+    // The query is built FROM the pattern list, so this can only break if someone
+    // hand-writes the clauses again — which is how a prefix gets silently dropped.
+    expect((BOOTSTRAP_METADATA_QUERY.match(/\?/g) ?? []).length).toBe(BOOTSTRAP_METADATA_PATTERNS.length);
   });
 
   it('uses the sync_meta primary-key index for every metadata prefix', async () => {
@@ -1102,7 +1141,7 @@ describe('pullSync snapshot bootstrap', () => {
     expect(onSnapshotBootstrapError).toHaveBeenCalledWith(expect.objectContaining({ stage: 'download', attempt: 0 }));
   });
 
-  it('counts an attempt AND skips the paged pull when the manifest fetch fails for a non-transport reason', async () => {
+  it('burns a structural slot on a non-transport manifest failure and lets the crawl deliver the board meanwhile', async () => {
     const source = makeSnapshotSource({ manifestThrows: true });
     const onSnapshotBootstrapError = vi.fn();
     const onBootstrapMetadataChanged = vi.fn();
@@ -1115,9 +1154,11 @@ describe('pullSync snapshot bootstrap', () => {
       onBootstrapMetadataChanged,
     });
 
-    // Paged pull SKIPPED this cycle (a first-page checkpoint would disqualify bootstrap).
+    // The retry is 6 hours out, well past the grace window, so the crawl runs
+    // rather than leave the board empty until then (issue #4313). Its first-page
+    // checkpoint no longer disqualifies the snapshot path — heal-over-partial does.
     const climbsCalls = fetch.mock.calls.filter((args) => (args[0] as string).includes('syncClimbs'));
-    expect(climbsCalls).toHaveLength(0);
+    expect(climbsCalls.length).toBeGreaterThan(0);
     expect(
       await db.getFirstAsync('SELECT value FROM sync_meta WHERE key = ?', ['bootstrap-attempts:kilter:1:5']),
     ).toEqual({
@@ -1131,28 +1172,36 @@ describe('pullSync snapshot bootstrap', () => {
 
   it('persists paged fallback after a transient failure is followed by a permanent miss', async () => {
     const source = makeSnapshotSource({ manifestThrows: true });
-
-    const firstRun = makeGraphqlFetch();
-    await pullSync(db, noopQueryClient(), firstRun.fetch, {
-      enabledBoards: ['kilter:1:5'],
-      snapshotSource: source,
-    });
-    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(1);
-
-    // The next cycle can reach the source but no usable manifest exists. Abort
-    // the paged crawl at its first board request so the explicit decision is
-    // tested before a checkpoint or scope-complete marker can mask it.
-    source.fetchManifest.mockResolvedValue(null);
-    const secondRun = makeGraphqlFetch();
-    const failPagedFetch = (async <T>(query: string, variables?: Record<string, unknown>): Promise<T> => {
-      if (query.includes('syncClimbs')) throw new Error('stop after bootstrap outcome');
-      return secondRun.fetch<T>(query, variables);
-    }) as GraphqlFetchMock;
+    // Abort the paged crawl at its first board request on BOTH cycles, so the
+    // explicit bootstrap decision is what the assertions see rather than a
+    // checkpoint or scope-complete marker the (instant) fake crawl would write.
+    const stopAtPagedCrawl = (): GraphqlFetchMock => {
+      const run = makeGraphqlFetch();
+      return (async <T>(query: string, variables?: Record<string, unknown>): Promise<T> => {
+        if (query.includes('syncClimbs')) throw new Error('stop after bootstrap outcome');
+        return run.fetch<T>(query, variables);
+      }) as GraphqlFetchMock;
+    };
 
     await expect(
-      pullSync(db, noopQueryClient(), failPagedFetch, {
+      pullSync(db, noopQueryClient(), stopAtPagedCrawl(), {
         enabledBoards: ['kilter:1:5'],
         snapshotSource: source,
+        now: () => BASE_NOW,
+        random: () => 0,
+      }),
+    ).rejects.toThrow('stop after bootstrap outcome');
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(1);
+
+    // A day later — past the structural cooldown — the source is reachable but no
+    // usable manifest exists.
+    source.fetchManifest.mockResolvedValue(null);
+    await expect(
+      pullSync(db, noopQueryClient(), stopAtPagedCrawl(), {
+        enabledBoards: ['kilter:1:5'],
+        snapshotSource: source,
+        now: () => BASE_NOW + 25 * HOUR_MS,
+        random: () => 0,
       }),
     ).rejects.toThrow('stop after bootstrap outcome');
 
@@ -1166,61 +1215,13 @@ describe('pullSync snapshot bootstrap', () => {
             isPagedFallback: true,
             hasBoardCheckpoint: false,
             isScopeComplete: false,
+            retryAfter: expect.any(Number),
+            structuralFailures: 1,
+            isTerminal: false,
           },
         ],
       ]),
     );
-  });
-
-  it('records two attempts on repeated corrupt artifacts, heals once, then settles into the paged crawl', async () => {
-    const filePath = join(workDir, 'corrupt.db');
-    writeFileSync(filePath, 'not a database');
-    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
-    const onBootstrapMetadataChanged = vi.fn();
-
-    const runOnce = async () => {
-      const run = makeGraphqlFetch();
-      await pullSync(db, noopQueryClient(), run.fetch, {
-        enabledBoards: ['kilter:1:5'],
-        snapshotSource: source,
-        onBootstrapMetadataChanged,
-      });
-      return run;
-    };
-    const attemptsRow = () =>
-      db.getFirstAsync('SELECT value FROM sync_meta WHERE key = ?', ['bootstrap-attempts:kilter:1:5']);
-
-    // Runs 1 and 2: import fails → attempts 1 then 2, paged pull skipped both times.
-    const run1 = await runOnce();
-    expect(run1.fetch.mock.calls.filter((a) => (a[0] as string).includes('syncClimbs'))).toHaveLength(0);
-    expect(await attemptsRow()).toEqual({ value: '1' });
-
-    const run2 = await runOnce();
-    expect(run2.fetch.mock.calls.filter((a) => (a[0] as string).includes('syncClimbs'))).toHaveLength(0);
-    expect(await attemptsRow()).toEqual({ value: '2' });
-
-    // Run 3: over the cap, but the manifest resolves with a usable entry, so the
-    // scope spends its ONE heal and tries the snapshot path again (issue #4238).
-    // The artifact is still corrupt, so it burns a fresh attempt 1.
-    const run3 = await runOnce();
-    expect(source.downloadArtifact).toHaveBeenCalledTimes(3);
-    expect(run3.fetch.mock.calls.filter((a) => (a[0] as string).includes('syncClimbs'))).toHaveLength(0);
-    expect(await attemptsRow()).toEqual({ value: '1' });
-    expect(
-      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-attempts-healed:kilter:1:5']),
-    ).not.toBeNull();
-
-    // Run 4: attempt 2 again.
-    await runOnce();
-    expect(await attemptsRow()).toEqual({ value: '2' });
-
-    // Run 5: over the cap AND the heal is spent → bootstrap gives up for good and
-    // the paged crawl runs from scratch. No sixth download.
-    const run5 = await runOnce();
-    expect(run5.fetch.mock.calls.filter((a) => (a[0] as string).includes('syncClimbs')).length).toBeGreaterThan(0);
-    expect(run5.capturedClimbCursors[0]).toBeUndefined();
-    expect(source.downloadArtifact).toHaveBeenCalledTimes(4);
-    expect(onBootstrapMetadataChanged).toHaveBeenCalledTimes(5);
   });
 
   it('Sentry BOARDSESH-AN: stops before the attempt-bookkeeping write when the app backgrounds during the manifest fetch', async () => {
@@ -1345,8 +1346,8 @@ describe('pullSync connectivity gate', () => {
   });
 });
 
-describe('pullSync bootstrap: transport failures at the manifest stage do not burn an attempt', () => {
-  it('reports a transport manifest failure as expected, keeps the counter at 0, and still skips the paged pull', async () => {
+describe('pullSync bootstrap: transport failures never spend the structural budget', () => {
+  it('reports a transport manifest failure as expected, keeps the counters at 0, and still skips the paged pull', async () => {
     const cause = new TypeError('Network request failed');
     const source = makeSnapshotSource({ manifestError: cause });
     const onSnapshotBootstrapError = vi.fn();
@@ -1361,8 +1362,8 @@ describe('pullSync bootstrap: transport failures at the manifest stage do not bu
     });
 
     expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
-    // Still skipped: a first-page checkpoint would disqualify the snapshot path
-    // for good, which is exactly what we're protecting the scope from.
+    // Still skipped: a first-page checkpoint used to disqualify the snapshot path
+    // for good, and the manifest stage is where an offline launch dies.
     expect(fetch.mock.calls.filter((args) => (args[0] as string).includes('syncClimbs'))).toHaveLength(0);
     expect(onSnapshotBootstrapError).toHaveBeenCalledWith({
       scopeKey: 'kilter:1:5',
@@ -1405,57 +1406,77 @@ describe('pullSync bootstrap: transport failures at the manifest stage do not bu
     ).not.toBeNull();
   });
 
-  it('counts a download failure even when it is transport-shaped — only the severity differs', async () => {
-    // The manifest resolved over this same connection moments earlier, so the
-    // device is provably online. Exempting this from the cap would let an
-    // unresumable 272 MB GET that always times out restart on every foreground
-    // forever, and — because a download failure also skips the paged pull — the
-    // board would never get an offline catalog by any route.
+  it('charges a transport DOWNLOAD failure to the transport budget, leaving the structural one intact', async () => {
+    // The regression this whole issue is about: a dropped connection mid-artifact
+    // used to burn the same 2-slot counter a corrupt artifact does, so two
+    // bad-reception launches condemned the board to the 400+-round-trip crawl.
     const transportSource = makeSnapshotSource({
       manifest: makeManifest([makeEntry()]),
       downloadError: new Error('snapshot download: File.downloadFileAsync failed', {
         cause: new TypeError('Network request failed'),
       }),
     });
-    const transportReports = vi.fn();
-    const transportRun = makeGraphqlFetch();
-    await pullSync(db, noopQueryClient(), transportRun.fetch, {
-      enabledBoards: ['kilter:1:5'],
-      snapshotSource: transportSource,
-      onSnapshotBootstrapError: transportReports,
-    });
+    const reports = vi.fn();
+    const clock = { now: BASE_NOW };
+    const retries: unknown[] = [];
 
-    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(1);
+    for (let launch = 0; launch < 2; launch += 1) {
+      const run = makeGraphqlFetch();
+      await pullSync(db, noopQueryClient(), run.fetch, {
+        enabledBoards: ['kilter:1:5'],
+        snapshotSource: transportSource,
+        onSnapshotBootstrapError: reports,
+        onBootstrapRetryScheduled: (info) => retries.push(info),
+        now: () => clock.now,
+        random: () => 0,
+      });
+      clock.now += 3 * HOUR_MS;
+    }
+
+    // Two transport failures — the OLD cap — and the scope is still on the fast path.
+    expect(transportSource.downloadArtifact).toHaveBeenCalledTimes(2);
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
+    expect(
+      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-paged-fallback:kilter:1:5']),
+    ).toBeNull();
     // Still reported as expected, so Sentry sees a warning rather than an error.
-    expect(transportReports).toHaveBeenCalledWith(
-      expect.objectContaining({ stage: 'download', attempt: 1, expected: true }),
-    );
-
-    // A disk-full device is a real failure the user can act on — that counts too,
-    // and reports at full severity.
-    const diskFullSource = makeSnapshotSource({
-      manifest: makeManifest([makeEntry()]),
-      downloadError: new Error('snapshot download: insufficient disk space for kilter:1'),
-    });
-    const diskReports = vi.fn();
-    const diskRun = makeGraphqlFetch();
-    await pullSync(db, noopQueryClient(), diskRun.fetch, {
-      enabledBoards: ['kilter:1:5'],
-      snapshotSource: diskFullSource,
-      onSnapshotBootstrapError: diskReports,
-    });
-
-    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(2);
-    expect(diskReports).toHaveBeenCalledWith(
-      expect.objectContaining({ stage: 'download', attempt: 2, expected: false }),
-    );
+    expect(reports).toHaveBeenCalledWith(expect.objectContaining({ stage: 'download', expected: true }));
+    expect(retries).toEqual([
+      expect.objectContaining({
+        failureKind: 'transport',
+        transportFailures: 1,
+        structuralFailures: 0,
+        terminal: false,
+      }),
+      expect.objectContaining({ failureKind: 'transport', transportFailures: 2, terminal: false }),
+    ]);
   });
 
-  it('settles a board whose huge artifact always times out onto the paged crawl instead of re-downloading forever', async () => {
-    // Regression guard for the download-stage cap exemption: an unresumable
-    // multi-hundred-MB GET that times out every cycle must not restart on every
-    // foreground. Two counted attempts (+ the one-shot heal's second round) and
-    // the scope takes the slow-but-working paged path.
+  it('waits out the scheduled cooldown instead of re-downloading on every foreground', async () => {
+    const source = makeSnapshotSource({
+      manifest: makeManifest([makeEntry()]),
+      downloadError: new Error('boom', { cause: new TypeError('Network request failed') }),
+    });
+    const clock = { now: BASE_NOW };
+
+    for (let launch = 0; launch < 4; launch += 1) {
+      const run = makeGraphqlFetch();
+      await pullSync(db, noopQueryClient(), run.fetch, {
+        enabledBoards: ['kilter:1:5'],
+        snapshotSource: source,
+        now: () => clock.now,
+        random: () => 0,
+      });
+      // Four foregrounds inside the first 2-minute rung.
+      clock.now += 20_000;
+    }
+
+    expect(source.downloadArtifact).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops after the transport budget and lets the paged crawl deliver the board', async () => {
+    // Bounded spend, which is the half of the old cap worth keeping: a device on
+    // which the unresumable GET can never complete must not retry it forever.
     const timeoutSource = makeSnapshotSource({
       manifest: makeManifest([makeEntry()]),
       downloadError: new Error('snapshot download: File.downloadFileAsync failed for kilter:1', {
@@ -1463,28 +1484,86 @@ describe('pullSync bootstrap: transport failures at the manifest stage do not bu
         cause: new Error('UnableToDownloadException: The request timed out.'),
       }),
     });
+    const clock = { now: BASE_NOW };
+    let climbQueries = 0;
 
-    // Four launches: two burn the initial budget, the third heals it once, the
-    // fourth exhausts the healed budget.
-    for (let launch = 0; launch < 4; launch += 1) {
+    for (let launch = 0; launch < 40; launch += 1) {
       const run = makeGraphqlFetch();
       await pullSync(db, noopQueryClient(), run.fetch, {
         enabledBoards: ['kilter:1:5'],
         snapshotSource: timeoutSource,
+        now: () => clock.now,
+        random: () => 0,
       });
+      climbQueries += run.capturedClimbCursors.length;
+      clock.now += 25 * HOUR_MS;
     }
-    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(2);
-    expect(timeoutSource.downloadArtifact).toHaveBeenCalledTimes(4);
 
-    // Fifth launch: over the cap with the heal spent, so the artifact is not
-    // fetched again and the paged crawl finally runs for this scope.
-    const settled = makeGraphqlFetch();
-    await pullSync(db, noopQueryClient(), settled.fetch, {
-      enabledBoards: ['kilter:1:5'],
-      snapshotSource: timeoutSource,
+    expect(timeoutSource.downloadArtifact).toHaveBeenCalledTimes(MAX_TRANSPORT_DOWNLOAD_FAILURES);
+    expect(
+      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-paged-fallback:kilter:1:5']),
+    ).not.toBeNull();
+    // …and the board is not left empty while that plays out.
+    expect(climbQueries).toBeGreaterThan(0);
+    expect(
+      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['scope-complete:kilter:1:5']),
+    ).not.toBeNull();
+  });
+
+  it('spends only the structural budget for a device-side fault, and no nightly rebuild re-arms it', async () => {
+    // A disk-full device would otherwise download 2 x 103 MB every night, because
+    // `builtAt` differs on essentially every launch after the first day.
+    const diskFullSource = makeSnapshotSource({
+      manifest: makeManifest([makeEntry()]),
+      downloadError: new Error('snapshot download: insufficient disk space for kilter:1'),
     });
-    expect(timeoutSource.downloadArtifact).toHaveBeenCalledTimes(4);
-    expect(settled.capturedClimbCursors).toHaveLength(1);
+    const clock = { now: BASE_NOW };
+
+    for (let launch = 0; launch < 40; launch += 1) {
+      diskFullSource.fetchManifest.mockResolvedValue(
+        makeManifest([makeEntry({ builtAt: new Date(clock.now).toISOString() })]),
+      );
+      const run = makeGraphqlFetch();
+      await pullSync(db, noopQueryClient(), run.fetch, {
+        enabledBoards: ['kilter:1:5'],
+        snapshotSource: diskFullSource,
+        now: () => clock.now,
+        random: () => 0,
+      });
+      // The real Kilter crawl is 400+ serial round trips and does not finish in
+      // one cycle; the fake resolver reaches the tail instantly, so drop the
+      // completion marker to keep the scope in the state this test is about.
+      await db.runAsync('DELETE FROM sync_meta WHERE key = ?', ['scope-complete:kilter:1:5']);
+      clock.now += 25 * HOUR_MS;
+    }
+
+    expect(diskFullSource.downloadArtifact).toHaveBeenCalledTimes(MAX_BOOTSTRAP_ATTEMPTS);
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(MAX_BOOTSTRAP_ATTEMPTS);
+  });
+
+  it('gives a broken ARTIFACT exactly one extra round when a new build lands, then stops', async () => {
+    const filePath = join(workDir, 'corrupt-forever.db');
+    writeFileSync(filePath, 'not a database');
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const clock = { now: BASE_NOW };
+
+    for (let launch = 0; launch < 40; launch += 1) {
+      source.fetchManifest.mockResolvedValue(makeManifest([makeEntry({ builtAt: new Date(clock.now).toISOString() })]));
+      const run = makeGraphqlFetch();
+      await pullSync(db, noopQueryClient(), run.fetch, {
+        enabledBoards: ['kilter:1:5'],
+        snapshotSource: source,
+        now: () => clock.now,
+        random: () => 0,
+      });
+      // See above: keep the scope mid-crawl so the budget, not the crawl
+      // finishing, is what stops the downloads.
+      await db.runAsync('DELETE FROM sync_meta WHERE key = ?', ['scope-complete:kilter:1:5']);
+      clock.now += 25 * HOUR_MS;
+    }
+
+    // 2 structural slots + 2 more from the single lifetime re-arm.
+    expect(source.downloadArtifact).toHaveBeenCalledTimes(MAX_BOOTSTRAP_ATTEMPTS * (1 + MAX_STRUCTURAL_REARMS));
     expect(
       await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-paged-fallback:kilter:1:5']),
     ).not.toBeNull();
@@ -1510,8 +1589,9 @@ describe('pullSync bootstrap: transport failures at the manifest stage do not bu
   });
 });
 
-describe('pullSync bootstrap: one-shot heal for an over-cap scope', () => {
-  async function seedExhaustedScope(): Promise<void> {
+describe('pullSync bootstrap: healing a scope stranded mid-crawl', () => {
+  /** A board that gave up on the snapshot path and then crawled part of its catalog. */
+  async function seedStrandedMidCrawl(checkpoint = { updatedAt: '2026-04-01T00:00:00Z', syncSeq: '5' }): Promise<void> {
     await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
       'bootstrap-attempts:kilter:1:5',
       '2',
@@ -1520,11 +1600,227 @@ describe('pullSync bootstrap: one-shot heal for an over-cap scope', () => {
       'bootstrap-paged-fallback:kilter:1:5',
       '1',
     ]);
+    await setCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5', checkpoint);
   }
 
-  it('clears the counter and takes the snapshot path when the manifest finally resolves online', async () => {
-    await seedExhaustedScope();
+  function buildHealArtifact(filePath: string): void {
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c-in', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c-in', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+  }
+
+  it('imports the artifact over the partial catalog and moves both checkpoints FORWARD', async () => {
+    await seedStrandedMidCrawl();
     const filePath = join(workDir, 'heal.db');
+    buildHealArtifact(filePath);
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const { fetch } = makeGraphqlFetch();
+    const recovered = vi.fn();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onBootstrapPathRecovered: recovered,
+      now: () => BASE_NOW,
+      random: () => 0,
+    });
+
+    const climbs = await db.getAllAsync<{ uuid: string }>('SELECT uuid FROM board_climbs ORDER BY uuid');
+    expect(climbs.map((row) => row.uuid)).toEqual(['c-in']);
+    expect(await getCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5')).toEqual(CLIMBS_WATERMARK);
+    expect(
+      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-done:kilter:1:5']),
+    ).not.toBeNull();
+    expect(recovered).toHaveBeenCalledWith({
+      scopeKey: 'kilter:1:5',
+      boardType: 'kilter',
+      trigger: 'legacy-migration',
+      hadBoardCheckpoint: true,
+    });
+    // Rollback safety: the legacy rows an older bundle reads are still there.
+    expect(
+      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-attempts:kilter:1:5']),
+    ).not.toBeNull();
+    expect(
+      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-attempts-healed:kilter:1:5']),
+    ).not.toBeNull();
+  });
+
+  it('reports the healed scope so download-duration comparisons can exclude it', async () => {
+    await seedStrandedMidCrawl();
+    const filePath = join(workDir, 'heal-telemetry.db');
+    buildHealArtifact(filePath);
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const { fetch } = makeGraphqlFetch();
+    const onScopeDownloadComplete = vi.fn();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onScopeDownloadComplete,
+      now: () => BASE_NOW,
+      random: () => 0,
+    });
+
+    expect(onScopeDownloadComplete).toHaveBeenCalledWith(
+      expect.objectContaining({ scopeKey: 'kilter:1:5', method: 'snapshot', bootstrapHealed: true }),
+    );
+  });
+
+  it('never heals a scope that already serves the whole catalog offline', async () => {
+    await seedStrandedMidCrawl();
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      'scope-complete:kilter:1:5',
+      '1',
+    ]);
+    const source = makeSnapshotSource({
+      manifest: makeManifest([makeEntry()]),
+      fileForEntry: () => join(workDir, 'never.db'),
+    });
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      now: () => BASE_NOW,
+      random: () => 0,
+    });
+
+    expect(source.fetchManifest).not.toHaveBeenCalled();
+    expect(source.downloadArtifact).not.toHaveBeenCalled();
+  });
+
+  it('never heals a mid-crawl scope that has no snapshot failures behind it', async () => {
+    await setCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5', { updatedAt: '2026-04-01T00:00:00Z', syncSeq: '5' });
+    const source = makeSnapshotSource({
+      manifest: makeManifest([makeEntry()]),
+      fileForEntry: () => join(workDir, 'never.db'),
+    });
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      now: () => BASE_NOW,
+      random: () => 0,
+    });
+
+    expect(source.downloadArtifact).not.toHaveBeenCalled();
+    // …and its crawl is never stalled by a snapshot decision it isn't part of.
+    expect(
+      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['scope-complete:kilter:1:5']),
+    ).not.toBeNull();
+  });
+
+  it('defers the automatic heal on a metered link without burning anything', async () => {
+    await seedStrandedMidCrawl();
+    const filePath = join(workDir, 'metered.db');
+    buildHealArtifact(filePath);
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      isOnUnmeteredNetwork: () => false,
+      now: () => BASE_NOW,
+      random: () => 0,
+    });
+
+    expect(source.downloadArtifact).not.toHaveBeenCalled();
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
+
+    // The crawl ran while the heal was deferred (a deferred scope is never
+    // stalled), and the fake resolver reaches the tail instantly. Drop the
+    // completion marker so this stays the mid-crawl case the heal exists for.
+    await db.runAsync('DELETE FROM sync_meta WHERE key = ?', ['scope-complete:kilter:1:5']);
+
+    // Back on wifi (and past the deferral), the same scope heals.
+    const later = makeGraphqlFetch();
+    await pullSync(db, noopQueryClient(), later.fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      now: () => BASE_NOW + 7 * HOUR_MS,
+      random: () => 0,
+    });
+    expect(source.downloadArtifact).toHaveBeenCalledTimes(1);
+  });
+
+  it('a fresh scope ignores the metered probe — the user just confirmed the size', async () => {
+    const filePath = join(workDir, 'metered-fresh.db');
+    buildHealArtifact(filePath);
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      isOnUnmeteredNetwork: () => false,
+      now: () => BASE_NOW,
+      random: () => 0,
+    });
+
+    expect(source.downloadArtifact).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('pullSync bootstrap: the watermark-regression guard', () => {
+  async function seedStranded(checkpoint: Cursor): Promise<void> {
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      'bootstrap-attempts:kilter:1:5',
+      '2',
+    ]);
+    await setCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5', checkpoint);
+    await setCheckpoint(db, 'checkpoint:board_climb_stats:kilter:1:5', checkpoint);
+    await setCheckpoint(db, DELETIONS_CHECKPOINT_KEY, checkpoint);
+  }
+
+  it('refuses an artifact whose scope filter matches nothing, leaving every checkpoint byte-identical', async () => {
+    const localCheckpoint: Cursor = { updatedAt: '2026-04-01T00:00:00Z', syncSeq: '5' };
+    await seedStranded(localCheckpoint);
+    const filePath = join(workDir, 'empty-scope.db');
+    // Every climb is compatible with a size this scope does not have, so the
+    // scoped watermark computes as the EPOCH — which would otherwise stamp
+    // checkpoint:board_climbs back to 1970 and re-crawl 400+ pages from scratch.
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'other-size', compatibleSizeIds: [77] }],
+      stats: [{ climbUuid: 'other-size', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const onSnapshotBootstrapError = vi.fn();
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onSnapshotBootstrapError,
+      now: () => BASE_NOW,
+      random: () => 0,
+    });
+
+    expect(await getCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5')).toEqual(localCheckpoint);
+    expect(await getCheckpoint(db, 'checkpoint:board_climb_stats:kilter:1:5')).toEqual(localCheckpoint);
+    expect(await getCheckpoint(db, DELETIONS_CHECKPOINT_KEY)).toEqual(localCheckpoint);
+    expect(await countRows('board_climbs')).toBe(0);
+    // No budget burned — a scope-filter disagreement is not the device's fault…
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
+    // …but it IS something an engineer wants to see.
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(
+      expect.objectContaining({ stage: 'import', attempt: 0, expected: false }),
+    );
+  });
+
+  it('refuses an artifact the local crawl has already run past', async () => {
+    const aheadOfArtifact: Cursor = { updatedAt: '2026-09-01T00:00:00Z', syncSeq: '999' };
+    await seedStranded(aheadOfArtifact);
+    const filePath = join(workDir, 'behind-crawl.db');
     buildArtifact({
       filePath,
       climbs: [{ uuid: 'c-in', compatibleSizeIds: [5] }],
@@ -1535,116 +1831,39 @@ describe('pullSync bootstrap: one-shot heal for an over-cap scope', () => {
     const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
     const { fetch } = makeGraphqlFetch();
 
-    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      now: () => BASE_NOW,
+      random: () => 0,
+    });
 
-    const climbs = await db.getAllAsync<{ uuid: string }>('SELECT uuid FROM board_climbs ORDER BY uuid');
-    expect(climbs.map((row) => row.uuid)).toEqual(['c-in']);
-    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
-    expect(
-      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-attempts-healed:kilter:1:5']),
-    ).not.toBeNull();
-    expect(
-      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-done:kilter:1:5']),
-    ).not.toBeNull();
+    expect(await getCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5')).toEqual(aheadOfArtifact);
+    expect(await countRows('board_climbs')).toBe(0);
   });
 
-  it('drops the paged-fallback marker before the download so My Boards stops saying "slower download"', async () => {
-    await seedExhaustedScope();
-    const filePath = join(workDir, 'heal-marker.db');
+  it('still imports the same artifact into a FRESH scope', async () => {
+    const filePath = join(workDir, 'fresh-ok.db');
     buildArtifact({
       filePath,
-      climbs: [{ uuid: 'c-in', compatibleSizeIds: [5] }],
-      stats: [{ climbUuid: 'c-in', angle: 40 }],
+      climbs: [{ uuid: 'other-size', compatibleSizeIds: [77] }],
+      stats: [{ climbUuid: 'other-size', angle: 40 }],
       climbsWatermark: CLIMBS_WATERMARK,
       statsWatermark: STATS_WATERMARK,
     });
-    // A snapshot download can run for 18 minutes; the row must not claim the slow
-    // path for the whole of it once the scope is back on the fast one.
-    let fallbackDuringDownload: unknown = 'never read';
-    const source: SnapshotSource = {
-      fetchManifest: vi.fn(async () => makeManifest([makeEntry()])),
-      downloadArtifact: vi.fn(async () => {
-        fallbackDuringDownload = await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', [
-          'bootstrap-paged-fallback:kilter:1:5',
-        ]);
-        return { filePath };
-      }),
-      deleteArtifact: vi.fn(async () => {}),
-    };
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
     const { fetch } = makeGraphqlFetch();
 
-    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
-
-    expect(fallbackDuringDownload).toBeNull();
-  });
-
-  it('does not heal a second time — the marker is what bounds the re-download', async () => {
-    await seedExhaustedScope();
-    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
-      'bootstrap-attempts-healed:kilter:1:5',
-      '1',
-    ]);
-    const source = makeSnapshotSource({
-      manifest: makeManifest([makeEntry()]),
-      fileForEntry: () => join(workDir, 'never.db'),
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      now: () => BASE_NOW,
+      random: () => 0,
     });
-    const { fetch, capturedClimbCursors } = makeGraphqlFetch();
 
-    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
-
-    expect(source.downloadArtifact).not.toHaveBeenCalled();
-    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(2);
-    // The paged crawl runs this cycle, exactly as it did before the heal existed.
-    expect(capturedClimbCursors[0]).toBeUndefined();
     expect(
-      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-paged-fallback:kilter:1:5']),
+      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-done:kilter:1:5']),
     ).not.toBeNull();
-  });
-
-  it('does not heal while still offline: the manifest never resolves, so the paged crawl runs and the counter stands', async () => {
-    await seedExhaustedScope();
-    const source = makeSnapshotSource({ manifestError: new TypeError('Network request failed') });
-    const { fetch, capturedClimbCursors } = makeGraphqlFetch();
-
-    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
-
-    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(2);
-    expect(
-      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-attempts-healed:kilter:1:5']),
-    ).toBeNull();
-    expect(capturedClimbCursors[0]).toBeUndefined();
-  });
-
-  it('does not heal a scope whose layout is not in the manifest', async () => {
-    await seedExhaustedScope();
-    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry({ layoutId: 99 })]) });
-    const { fetch } = makeGraphqlFetch();
-
-    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
-
-    expect(source.downloadArtifact).not.toHaveBeenCalled();
-    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(2);
-    expect(
-      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-attempts-healed:kilter:1:5']),
-    ).toBeNull();
-  });
-
-  it('does not heal a scope that already has a board checkpoint (nothing to bootstrap into)', async () => {
-    await seedExhaustedScope();
-    await setCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5', { updatedAt: '2026-01-01T00:00:00Z', syncSeq: '5' });
-    const source = makeSnapshotSource({
-      manifest: makeManifest([makeEntry()]),
-      fileForEntry: () => join(workDir, 'never.db'),
-    });
-    const { fetch } = makeGraphqlFetch();
-
-    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
-
-    expect(source.fetchManifest).not.toHaveBeenCalled();
-    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(2);
-    expect(
-      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-attempts-healed:kilter:1:5']),
-    ).toBeNull();
   });
 });
 

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -25,6 +25,8 @@ import {
 } from '../snapshot-bootstrap';
 import {
   getBootstrapAttempts,
+  restoreBootstrapRetryBudget,
+  EMPTY_BOOTSTRAP_RETRY_STATE,
   MAX_BOOTSTRAP_ATTEMPTS,
   MAX_STRUCTURAL_REARMS,
   MAX_TRANSPORT_DOWNLOAD_FAILURES,
@@ -1671,6 +1673,47 @@ describe('pullSync bootstrap: healing a scope stranded mid-crawl', () => {
     );
   });
 
+  it('still reports the heal when the scope completes in a LATER cycle', async () => {
+    // The common shape: board_climb_grades is not a snapshot table, so a healed
+    // scope routinely reaches completion cycles after the import. An in-memory
+    // per-cycle set reported bootstrapHealed:false for exactly those runs —
+    // contaminating the comparison the field exists to protect.
+    await seedStrandedMidCrawl();
+    const filePath = join(workDir, 'heal-late-complete.db');
+    buildHealArtifact(filePath);
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const onScopeDownloadComplete = vi.fn();
+
+    const run1 = makeGraphqlFetch();
+    const failingStatsFetch = (async <T>(query: string, variables?: Record<string, unknown>): Promise<T> => {
+      if (query.includes('syncClimbStats')) throw new Error('network dropped mid-delta');
+      return run1.fetch<T>(query, variables);
+    }) as GraphqlFetchMock;
+    await expect(
+      pullSync(db, noopQueryClient(), failingStatsFetch, {
+        enabledBoards: ['kilter:1:5'],
+        snapshotSource: source,
+        onScopeDownloadComplete,
+        now: () => BASE_NOW,
+        random: () => 0,
+      }),
+    ).rejects.toThrow('network dropped mid-delta');
+    expect(onScopeDownloadComplete).not.toHaveBeenCalled();
+
+    const run2 = makeGraphqlFetch();
+    await pullSync(db, noopQueryClient(), run2.fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onScopeDownloadComplete,
+      now: () => BASE_NOW + HOUR_MS,
+      random: () => 0,
+    });
+
+    expect(onScopeDownloadComplete).toHaveBeenCalledWith(
+      expect.objectContaining({ scopeKey: 'kilter:1:5', method: 'snapshot', bootstrapHealed: true }),
+    );
+  });
+
   it('never heals a scope that already serves the whole catalog offline', async () => {
     await seedStrandedMidCrawl();
     await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
@@ -1809,12 +1852,62 @@ describe('pullSync bootstrap: the watermark-regression guard', () => {
     expect(await getCheckpoint(db, 'checkpoint:board_climb_stats:kilter:1:5')).toEqual(localCheckpoint);
     expect(await getCheckpoint(db, DELETIONS_CHECKPOINT_KEY)).toEqual(localCheckpoint);
     expect(await countRows('board_climbs')).toBe(0);
-    // No budget burned — a scope-filter disagreement is not the device's fault…
-    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
-    // …but it IS something an engineer wants to see.
+    // The refusal is RECORDED: it burns the structural budget like any other
+    // import failure, because the artifact on offer provably cannot serve this
+    // scope and only a rebuilt one can change that.
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(1);
+    // It is also something an engineer wants to see, at full severity.
     expect(onSnapshotBootstrapError).toHaveBeenCalledWith(
-      expect.objectContaining({ stage: 'import', attempt: 0, expected: false }),
+      expect.objectContaining({ stage: 'import', attempt: 1, expected: false }),
     );
+  });
+
+  it('does not re-download the artifact on every cycle after refusing it', async () => {
+    // The regression that shipped in the first cut of #4313: the refusal stamped
+    // a paged-fallback marker and continued, leaving the scope exactly as
+    // eligible as before, so every sync cycle pulled the whole ~100 MB again.
+    const aheadOfArtifact: Cursor = { updatedAt: '2026-09-01T00:00:00Z', syncSeq: '999' };
+    await seedStranded(aheadOfArtifact);
+    const filePath = join(workDir, 'refusal-loop.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c-in', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c-in', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+
+    for (let cycle = 0; cycle < 5; cycle += 1) {
+      const run = makeGraphqlFetch();
+      await pullSync(db, noopQueryClient(), run.fetch, {
+        enabledBoards: ['kilter:1:5'],
+        snapshotSource: source,
+        now: () => BASE_NOW + cycle * 60_000,
+        random: () => 0,
+      });
+      // The scope stays incomplete between cycles — board_climb_grades is still
+      // crawling, which is exactly the population the heal targets and the one
+      // that kept re-downloading. Completion would end the loop on its own.
+      await db.runAsync('DELETE FROM sync_meta WHERE key = ?', ['scope-complete:kilter:1:5']);
+    }
+    expect(source.downloadArtifact).toHaveBeenCalledTimes(1);
+
+    // Past the 6 h cooldown the scope spends its second and last structural
+    // attempt; the same artifact refuses again and it settles onto the crawl.
+    const afterCooldown = makeGraphqlFetch();
+    await pullSync(db, noopQueryClient(), afterCooldown.fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      now: () => BASE_NOW + 7 * HOUR_MS,
+      random: () => 0,
+    });
+
+    expect(source.downloadArtifact).toHaveBeenCalledTimes(2);
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(MAX_BOOTSTRAP_ATTEMPTS);
+    expect(
+      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-paged-fallback:kilter:1:5']),
+    ).not.toBeNull();
   });
 
   it('refuses an artifact the local crawl has already run past', async () => {
@@ -1864,6 +1957,139 @@ describe('pullSync bootstrap: the watermark-regression guard', () => {
     expect(
       await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['bootstrap-done:kilter:1:5']),
     ).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// "Try the fast download again" — the consented, size-disclosed retry
+// ---------------------------------------------------------------------------
+
+describe('pullSync bootstrap: a user-requested retry', () => {
+  /**
+   * A board that spent its budget and settled. It ALWAYS carries board
+   * checkpoints — a terminal scope is never in `skipPagedPull`, so it crawls
+   * while it is settled — which is why it can only ever come back as a
+   * heal-over-partial, the one kind the metered probe defers.
+   */
+  async function seedSettledScope(): Promise<void> {
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      'bootstrap-retry:kilter:1:5',
+      JSON.stringify({
+        ...EMPTY_BOOTSTRAP_RETRY_STATE,
+        structuralFailures: MAX_BOOTSTRAP_ATTEMPTS,
+        lastFailureKind: 'structural-device',
+        hasPriorSnapshotFailure: true,
+        mirroredAttempts: MAX_BOOTSTRAP_ATTEMPTS,
+      }),
+    ]);
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      'bootstrap-paged-fallback:kilter:1:5',
+      '1',
+    ]);
+    await setCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5', { updatedAt: '2026-04-01T00:00:00Z', syncSeq: '5' });
+  }
+
+  /**
+   * The fixture's paged crawl reaches its tail on every cycle, which would mark
+   * the scope complete and make it permanently bootstrap-ineligible. A real
+   * settled board is still crawling `board_climb_grades`, so it is not complete —
+   * drop the marker between cycles to keep the fixture honest.
+   */
+  async function keepScopeIncomplete(): Promise<void> {
+    await db.runAsync('DELETE FROM sync_meta WHERE key = ?', ['scope-complete:kilter:1:5']);
+  }
+
+  function buildRetryArtifact(filePath: string): void {
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c-in', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c-in', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+  }
+
+  it('downloads on a metered link — the climber just confirmed the size', async () => {
+    await seedSettledScope();
+    const filePath = join(workDir, 'user-retry-metered.db');
+    buildRetryArtifact(filePath);
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const recovered = vi.fn();
+
+    // Settled: the engine will not even read the manifest for it.
+    const before = makeGraphqlFetch();
+    await pullSync(db, noopQueryClient(), before.fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      isOnUnmeteredNetwork: () => false,
+      now: () => BASE_NOW,
+      random: () => 0,
+    });
+    expect(source.downloadArtifact).not.toHaveBeenCalled();
+    await keepScopeIncomplete();
+
+    await restoreBootstrapRetryBudget(db, 'kilter:1:5');
+
+    const after = makeGraphqlFetch();
+    await pullSync(db, noopQueryClient(), after.fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      isOnUnmeteredNetwork: () => false,
+      onBootstrapPathRecovered: recovered,
+      now: () => BASE_NOW + 60_000,
+      random: () => 0,
+    });
+
+    expect(source.downloadArtifact).toHaveBeenCalledTimes(1);
+    const climbs = await db.getAllAsync<{ uuid: string }>('SELECT uuid FROM board_climbs');
+    expect(climbs.map((row) => row.uuid)).toEqual(['c-in']);
+    expect(recovered).toHaveBeenCalledWith({
+      scopeKey: 'kilter:1:5',
+      boardType: 'kilter',
+      trigger: 'user-request',
+      hadBoardCheckpoint: true,
+    });
+  });
+
+  it('spends the request on one download, then defers on a metered link again', async () => {
+    await seedSettledScope();
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), downloadThrows: true });
+    await restoreBootstrapRetryBudget(db, 'kilter:1:5');
+
+    const consented = makeGraphqlFetch();
+    await pullSync(db, noopQueryClient(), consented.fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      isOnUnmeteredNetwork: () => false,
+      now: () => BASE_NOW,
+      random: () => 0,
+    });
+    expect(source.downloadArtifact).toHaveBeenCalledTimes(1);
+    await keepScopeIncomplete();
+
+    // Past the failure's 6 h cooldown, still on cellular: the tap is spent, so
+    // this is an ordinary automatic heal again and defers instead of pulling
+    // another ~100 MB the climber never asked for.
+    const stillMetered = makeGraphqlFetch();
+    await pullSync(db, noopQueryClient(), stillMetered.fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      isOnUnmeteredNetwork: () => false,
+      now: () => BASE_NOW + 7 * HOUR_MS,
+      random: () => 0,
+    });
+    expect(source.downloadArtifact).toHaveBeenCalledTimes(1);
+    await keepScopeIncomplete();
+
+    // On wifi, past the deferral, the automatic heal runs on its own.
+    const onWifi = makeGraphqlFetch();
+    await pullSync(db, noopQueryClient(), onWifi.fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      now: () => BASE_NOW + 14 * HOUR_MS,
+      random: () => 0,
+    });
+    expect(source.downloadArtifact).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-estimate.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-estimate.test.ts
@@ -2,9 +2,10 @@
 // quotes a number the download won't match, so most of this file is the `unknown`
 // branches: every case where the paged crawl runs instead of a snapshot import.
 //
-// The eligibility rules here mirror runBootstrapPhase's. `mirrors runBootstrapPhase`
-// below is the guard against the two drifting apart — that drift is the only way
-// this feature starts lying to users.
+// Eligibility is not restated here: `estimateScopeDownload` CALLS the engine's
+// own `evaluateBootstrapEligibility`, and the parity table at the bottom pins
+// that the two verdicts agree row for row — that drift is the only way this
+// feature starts lying to users.
 
 import { describe, it, expect } from 'vitest';
 import {
@@ -13,7 +14,13 @@ import {
   isSnapshotEntryUsable,
   type SnapshotDownloadEstimate,
 } from '../snapshot-estimate';
-import { MAX_BOOTSTRAP_ATTEMPTS } from '../snapshot-bootstrap';
+import {
+  evaluateBootstrapEligibility,
+  EMPTY_BOOTSTRAP_RETRY_STATE,
+  MAX_BOOTSTRAP_ATTEMPTS,
+  MAX_TRANSPORT_DOWNLOAD_FAILURES,
+  type BootstrapRetryState,
+} from '../bootstrap-retry';
 import { LATEST_SCHEMA_VERSION } from '../../db/migrations';
 import type { SnapshotManifest, SnapshotManifestEntry } from '../snapshot-manifest';
 
@@ -44,14 +51,23 @@ function manifest(entries: SnapshotManifestEntry[] = [entry()]): SnapshotManifes
   return { formatVersion: 1, generatedAt: '2026-07-15T02:33:29.916Z', entries };
 }
 
-/** A scope that would bootstrap: fresh on both board tables, no attempts burned. */
+const NOW = 1_800_000_000_000;
+
+function retryState(patch: Partial<BootstrapRetryState> = {}): BootstrapRetryState {
+  return { ...EMPTY_BOOTSTRAP_RETRY_STATE, ...patch };
+}
+
+/** A scope that would bootstrap: fresh on both board tables, nothing burned. */
 function eligible(patch: Partial<Parameters<typeof estimateScopeDownload>[0]> = {}) {
   return estimateScopeDownload({
     manifest: manifest(),
     boardType: 'kilter',
     layoutId: 1,
-    hasExistingCheckpoint: false,
-    bootstrapAttempts: 0,
+    retryState: retryState(),
+    hasBoardCheckpoint: false,
+    isScopeComplete: false,
+    isBootstrapDone: false,
+    now: NOW,
     ...patch,
   });
 }
@@ -105,16 +121,58 @@ describe('estimateScopeDownload', () => {
     expect(eligible({ manifest: null })).toEqual({ kind: 'unknown' });
   });
 
-  it('is unknown when the scope already has a checkpoint — a re-enable pulls a delta, not 270 MB', () => {
-    expect(eligible({ hasExistingCheckpoint: true })).toEqual({ kind: 'unknown' });
+  it('is unknown when the scope has a checkpoint and no snapshot failures — a re-enable pulls a delta, not 270 MB', () => {
+    expect(eligible({ hasBoardCheckpoint: true })).toEqual({ kind: 'unknown' });
+  });
+
+  it('quotes the artifact for a mid-crawl scope the engine would heal', () => {
+    // The heal-over-partial path (issue #4313): the scope holds a fraction of the
+    // catalog, never finished the crawl, and has snapshot failures behind it.
+    expect(
+      eligible({
+        hasBoardCheckpoint: true,
+        retryState: retryState({ structuralFailures: 1, hasPriorSnapshotFailure: true }),
+      }),
+    ).toMatchObject({ kind: 'snapshot' });
+  });
+
+  it('is unknown for a scope that already serves the whole catalog offline', () => {
+    expect(eligible({ isScopeComplete: true })).toEqual({ kind: 'unknown' });
   });
 
   it('is unknown once the engine has given up on the snapshot for this scope', () => {
-    expect(eligible({ bootstrapAttempts: MAX_BOOTSTRAP_ATTEMPTS })).toEqual({ kind: 'unknown' });
+    expect(eligible({ retryState: retryState({ structuralFailures: MAX_BOOTSTRAP_ATTEMPTS }) })).toEqual({
+      kind: 'unknown',
+    });
+    expect(eligible({ retryState: retryState({ transportFailures: MAX_TRANSPORT_DOWNLOAD_FAILURES }) })).toEqual({
+      kind: 'unknown',
+    });
   });
 
-  it('still quotes a size on the last remaining attempt', () => {
-    expect(eligible({ bootstrapAttempts: MAX_BOOTSTRAP_ATTEMPTS - 1 })).toMatchObject({ kind: 'snapshot' });
+  it('is unknown while the scope is waiting out a scheduled retry', () => {
+    expect(eligible({ retryState: retryState({ retryAfter: NOW + 60_000 }) })).toEqual({ kind: 'unknown' });
+  });
+
+  it('still quotes a size on the last remaining structural attempt', () => {
+    expect(eligible({ retryState: retryState({ structuralFailures: MAX_BOOTSTRAP_ATTEMPTS - 1 }) })).toMatchObject({
+      kind: 'snapshot',
+    });
+  });
+
+  it('quotes a size for a user-requested retry even though the scope is terminal', () => {
+    // The confirm dialog behind "Try the fast download again" restores the budget
+    // as its action, so the size it discloses must be the artifact's.
+    expect(
+      eligible({
+        retryState: retryState({ structuralFailures: MAX_BOOTSTRAP_ATTEMPTS }),
+        userRequested: true,
+      }),
+    ).toMatchObject({ kind: 'snapshot' });
+  });
+
+  it('refuses even a user-requested quote for a complete or already-warmed scope', () => {
+    expect(eligible({ isScopeComplete: true, userRequested: true })).toEqual({ kind: 'unknown' });
+    expect(eligible({ isBootstrapDone: true, userRequested: true })).toEqual({ kind: 'unknown' });
   });
 
   it('is unknown when the layout has not been exported yet', () => {
@@ -137,4 +195,85 @@ describe('estimateScopeDownload', () => {
     // into 'unknown' and silently dropping the size line.
     expect(eligible({ manifest: manifest([entry({ bytes: 0 })]) })).toMatchObject({ kind: 'snapshot', bytes: 0 });
   });
+});
+
+describe('estimateScopeDownload parity with the engine gate', () => {
+  // The mirror that used to be a promise in a comment. Every row asserts the
+  // estimate's snapshot/unknown verdict equals evaluateBootstrapEligibility's,
+  // so the UI can never quote a number for a download the engine would skip.
+  const rows: Array<{
+    name: string;
+    scopeState: Omit<Parameters<typeof evaluateBootstrapEligibility>[0], 'now'>;
+  }> = [
+    {
+      name: 'fresh',
+      scopeState: {
+        retryState: retryState(),
+        hasBoardCheckpoint: false,
+        isScopeComplete: false,
+        isBootstrapDone: false,
+      },
+    },
+    {
+      name: 'heal-over-partial',
+      scopeState: {
+        retryState: retryState({ transportFailures: 1, hasPriorSnapshotFailure: true }),
+        hasBoardCheckpoint: true,
+        isScopeComplete: false,
+        isBootstrapDone: false,
+      },
+    },
+    {
+      name: 'mid-crawl with no failure history',
+      scopeState: {
+        retryState: retryState(),
+        hasBoardCheckpoint: true,
+        isScopeComplete: false,
+        isBootstrapDone: false,
+      },
+    },
+    {
+      name: 'scope complete',
+      scopeState: { retryState: retryState(), hasBoardCheckpoint: true, isScopeComplete: true, isBootstrapDone: false },
+    },
+    {
+      name: 'already bootstrapped',
+      scopeState: { retryState: retryState(), hasBoardCheckpoint: true, isScopeComplete: false, isBootstrapDone: true },
+    },
+    {
+      name: 'terminal on transport',
+      scopeState: {
+        retryState: retryState({ transportFailures: MAX_TRANSPORT_DOWNLOAD_FAILURES, hasPriorSnapshotFailure: true }),
+        hasBoardCheckpoint: false,
+        isScopeComplete: false,
+        isBootstrapDone: false,
+      },
+    },
+    {
+      name: 'cooling down',
+      scopeState: {
+        retryState: retryState({ transportFailures: 1, hasPriorSnapshotFailure: true, retryAfter: NOW + 1 }),
+        hasBoardCheckpoint: false,
+        isScopeComplete: false,
+        isBootstrapDone: false,
+      },
+    },
+    {
+      name: 'cooldown just elapsed',
+      scopeState: {
+        retryState: retryState({ transportFailures: 1, hasPriorSnapshotFailure: true, retryAfter: NOW }),
+        hasBoardCheckpoint: false,
+        isScopeComplete: false,
+        isBootstrapDone: false,
+      },
+    },
+  ];
+
+  for (const row of rows) {
+    it(`agrees with the engine for: ${row.name}`, () => {
+      const verdict = evaluateBootstrapEligibility({ ...row.scopeState, now: NOW });
+      const estimate = eligible({ ...row.scopeState, now: NOW });
+      expect(estimate.kind === 'snapshot').toBe(verdict.eligible);
+    });
+  }
 });

--- a/packages/shared/offline-sync/src/sync/bootstrap-retry.ts
+++ b/packages/shared/offline-sync/src/sync/bootstrap-retry.ts
@@ -266,6 +266,13 @@ export function clearTransportFailures(state: BootstrapRetryState): BootstrapRet
 export function clearRetryStateForUserRequest(state: BootstrapRetryState): BootstrapRetryState {
   return {
     ...EMPTY_BOOTSTRAP_RETRY_STATE,
+    // The failure history is KEPT on purpose. A settled scope has always crawled
+    // (a terminal scope is never in `skipPagedPull`), so it carries board
+    // checkpoints — and `evaluateBootstrapEligibility` only lets a checkpointed
+    // scope back onto the artifact path as a `heal-over-partial`, which requires
+    // this evidence. Resetting it to false would make the whole "Try the fast
+    // download again" action a silent no-op: `no-failure-evidence`.
+    hasPriorSnapshotFailure: state.hasPriorSnapshotFailure,
     mirroredAttempts: state.mirroredAttempts,
     legacyHealSpent: true,
   };

--- a/packages/shared/offline-sync/src/sync/bootstrap-retry.ts
+++ b/packages/shared/offline-sync/src/sync/bootstrap-retry.ts
@@ -1,0 +1,540 @@
+// Snapshot-bootstrap retry accounting (issue #4313).
+//
+// The problem this replaces: `MAX_BOOTSTRAP_ATTEMPTS = 2` was doing two jobs at
+// once. It was the retry policy (there is none — the artifact GET is unresumable
+// and never retried) AND the total-spend bound (a ~103 MB download must not
+// restart on every foreground). Because a dropped connection at the DOWNLOAD
+// stage burned the same counter as a corrupt artifact, two flaky-network launches
+// condemned a board to the 400+-round-trip paged crawl for the life of the
+// install — 123 Sentry events across 75 users in 60 days.
+//
+// The split made here: every failure gets a KIND, each kind has its own lifetime
+// budget, and frequency is bounded separately by a persisted cooldown ladder.
+//
+//   transport           network/DNS/TLS/timeout at the download stage. Never
+//                       touches the structural budget. 3 consecutive failures,
+//                       reset to 0 by any successful download. (The MANIFEST
+//                       stage stays entirely free — a few KB of JSON, and it is
+//                       where an offline launch dies. Issue #4238.)
+//   structural-artifact the bytes are on disk and provably bad (quick_check,
+//                       snapshot_meta mismatch, import throw). Tonight's export
+//                       might fix it, so a NEW `builtAt` may re-arm the budget —
+//                       once per scope, ever.
+//   structural-device   everything else non-transport (disk full, cache dir,
+//                       CDN non-2xx, unclassifiable). Burns the structural
+//                       budget and NEVER re-arms on `builtAt`: the export is
+//                       nightly, so a `builtAt` reset for a device-side fault
+//                       would be 2 x 103 MB every day, forever.
+//
+// Worst-case lifetime artifact downloads per scope: 3 (transport) + 2
+// (structural) + 2 (the one re-armed structural round) = 7, each separated by at
+// least one cooldown rung. `snapshot-bootstrap.test.ts` pins that number so any
+// future loosening shows up in a diff.
+//
+// ROLLBACK SAFETY. `bootstrap-retry:<scopeKey>` is the source of truth, but every
+// write ALSO mirrors the legacy `bootstrap-attempts:` / `-healed:` /
+// `-paged-fallback:` rows, and they are never deleted. Production channel
+// rollback and `pr-<n>` preview channels are live paths here: an older bundle
+// that reads no legacy row would re-arm a fresh 2-attempt round plus another
+// one-shot heal. Reads reconcile in the other direction — if the legacy counter
+// moved past what we last mirrored, an older bundle counted something real and
+// those failures are folded back in.
+//
+// Pure except for the two SqlExecutor helpers at the bottom: no clock, no RNG,
+// no I/O inside the decision functions. `now` and `random` are always injected.
+
+import type { SqlExecutor } from '../database';
+import { isNetworkError } from '../mutation-queue/error-classification';
+
+// --- sync_meta keys -----------------------------------------------------------
+//
+// Package-internal (deliberately NOT re-exported from index.ts, same posture as
+// checkpoints.ts's DELETIONS_CHECKPOINT_KEY): scope-teardown.ts must clear these
+// alongside the rows they describe, so it needs the exact key spelling. They live
+// here rather than in snapshot-bootstrap.ts because the retry row and its legacy
+// mirrors are written together, by one function, and a cycle between the two
+// modules would leave `BOOTSTRAP_METADATA_PATTERNS` reading `undefined` at import
+// time.
+
+export const BOOTSTRAP_ATTEMPTS_PREFIX = 'bootstrap-attempts:';
+/** "This scope has already spent its one free counter reset" (legacy, #4238). */
+export const BOOTSTRAP_ATTEMPTS_HEALED_PREFIX = 'bootstrap-attempts-healed:';
+export const BOOTSTRAP_PAGED_FALLBACK_PREFIX = 'bootstrap-paged-fallback:';
+/** The retry row this module owns: one JSON `BootstrapRetryState` per scope. */
+export const BOOTSTRAP_RETRY_PREFIX = 'bootstrap-retry:';
+
+// --- Budgets and ladders ------------------------------------------------------
+
+/**
+ * Structural failures (artifact- or device-side) a scope may spend before it
+ * settles onto the paged crawl. Unchanged in value from the pre-#4313 cap, but
+ * narrowed in meaning: transport failures no longer touch it.
+ */
+export const MAX_BOOTSTRAP_ATTEMPTS = 2;
+
+/**
+ * Consecutive download-stage transport failures before a scope settles. Bounds
+ * total spend on a device where the unresumable GET can never complete — the
+ * cooldown alone only bounds frequency.
+ */
+export const MAX_TRANSPORT_DOWNLOAD_FAILURES = 3;
+
+/** Lifetime re-arms of the structural budget on a newly built artifact. */
+export const MAX_STRUCTURAL_REARMS = 1;
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 3_600_000;
+
+/** Cooldown after the 1st, 2nd, 3rd… consecutive transport failure. */
+const TRANSPORT_COOLDOWNS_MS = [2 * MINUTE_MS, 15 * MINUTE_MS, 2 * HOUR_MS] as const;
+/** Cooldown after the 1st, 2nd… structural failure. */
+const STRUCTURAL_COOLDOWNS_MS = [6 * HOUR_MS, 24 * HOUR_MS] as const;
+
+/**
+ * How close a scheduled retry must be before a FRESH scope skips its paged crawl
+ * to wait for it. Beyond this the crawl runs, so a board is never left empty
+ * waiting on a 2-hour cooldown — it just doesn't spend 400 round trips when an
+ * artifact is two minutes away.
+ */
+export const BOOTSTRAP_RETRY_GRACE_WINDOW_MS = 30 * MINUTE_MS;
+
+/** How long an automatic heal defers itself when the link is metered. */
+export const METERED_HEAL_DEFERRAL_MS = 6 * HOUR_MS;
+
+/** Spread the post-OTA migration wave for scopes that already hold rows. */
+const LEGACY_MIGRATION_SPREAD_MS = 2 * HOUR_MS;
+
+// --- State --------------------------------------------------------------------
+
+export type BootstrapFailureKind = 'transport' | 'structural-artifact' | 'structural-device';
+
+export type BootstrapRetryState = {
+  /** Consecutive download-stage transport failures; any success resets it to 0. */
+  readonly transportFailures: number;
+  /** Structural failures spent from the current (possibly re-armed) budget. */
+  readonly structuralFailures: number;
+  /** Structural budgets granted by a newly built artifact, lifetime. */
+  readonly structuralRearms: number;
+  readonly lastFailureKind: BootstrapFailureKind | null;
+  /** `builtAt` of the artifact the last structural failure was raised against. */
+  readonly failedBuiltAt: string | null;
+  /** Epoch ms before which this scope is not bootstrap-eligible. */
+  readonly retryAfter: number | null;
+  /**
+   * Whether this scope has ever failed on the snapshot path. Gates
+   * heal-over-partial: a scope with a checkpoint and no failure history is
+   * simply a mid-crawl board that never had a snapshot to begin with.
+   */
+  readonly hasPriorSnapshotFailure: boolean;
+  /**
+   * The value last written to the legacy `bootstrap-attempts:` row. A legacy
+   * counter ABOVE this means an older (rolled-back) bundle counted failures we
+   * never saw, and the difference is folded into `structuralFailures` on read.
+   */
+  readonly mirroredAttempts: number;
+  /** The legacy one-shot heal is pre-spent, so a rolled-back bundle can't re-grant it. */
+  readonly legacyHealSpent: boolean;
+};
+
+export const EMPTY_BOOTSTRAP_RETRY_STATE: BootstrapRetryState = {
+  transportFailures: 0,
+  structuralFailures: 0,
+  structuralRearms: 0,
+  lastFailureKind: null,
+  failedBuiltAt: null,
+  retryAfter: null,
+  hasPriorSnapshotFailure: false,
+  mirroredAttempts: 0,
+  legacyHealSpent: false,
+};
+
+// --- Pure decisions -----------------------------------------------------------
+
+/**
+ * Which budget a failure spends. Import-stage failures are always
+ * `structural-artifact`: the bytes are already on disk, so nothing about them is
+ * a network problem, and a rebuilt artifact is the one thing that could fix it.
+ * Anything else transport-shaped (`isNetworkError`, the same predicate the
+ * mutation drainer uses to keep a mutation off the dead-letter path) is
+ * `transport`; everything remaining is attributed to the device, which is the
+ * conservative default because a plain `Error` from an adapter's downloader
+ * cannot be told apart from a disk-full or cache-dir fault.
+ */
+export function classifyBootstrapFailure(input: {
+  cause: unknown;
+  stage: 'manifest' | 'download' | 'import';
+}): BootstrapFailureKind {
+  if (input.stage === 'import') return 'structural-artifact';
+  if (isNetworkError(input.cause)) return 'transport';
+  return 'structural-device';
+}
+
+/** Either budget exhausted: the scope has settled onto the paged crawl. */
+export function isTerminal(state: BootstrapRetryState): boolean {
+  return (
+    state.transportFailures >= MAX_TRANSPORT_DOWNLOAD_FAILURES || state.structuralFailures >= MAX_BOOTSTRAP_ATTEMPTS
+  );
+}
+
+/**
+ * Whether a newly built artifact could still re-arm this terminal scope. True
+ * only for a scope whose last failure was attributable to the ARTIFACT and which
+ * has a re-arm left — a device-side fault or a spent transport budget is not
+ * something tonight's export can fix.
+ */
+export function canRearmOnNewArtifact(state: BootstrapRetryState): boolean {
+  return (
+    state.lastFailureKind === 'structural-artifact' &&
+    state.structuralFailures >= MAX_BOOTSTRAP_ATTEMPTS &&
+    state.transportFailures < MAX_TRANSPORT_DOWNLOAD_FAILURES &&
+    state.structuralRearms < MAX_STRUCTURAL_REARMS
+  );
+}
+
+function jitter(baseMs: number, random: () => number): number {
+  // [1x, 1.5x) so a fleet that failed together does not retry together.
+  return Math.round(baseMs * (1 + random() * 0.5));
+}
+
+function cooldownFor(ladder: readonly number[], failureCount: number, random: () => number): number {
+  const rung = Math.min(Math.max(failureCount, 1), ladder.length) - 1;
+  return jitter(ladder[rung], random);
+}
+
+/**
+ * Fold one failure into the scope's retry state: burn the right budget, and
+ * schedule the next attempt on that budget's ladder. Never mutates its input.
+ */
+export function nextRetryState(input: {
+  state: BootstrapRetryState;
+  failureKind: BootstrapFailureKind;
+  /** `builtAt` of the artifact the failure was raised against, when known. */
+  builtAt: string | null;
+  now: number;
+  random: () => number;
+}): BootstrapRetryState {
+  const { state, failureKind, builtAt, now, random } = input;
+
+  if (failureKind === 'transport') {
+    const transportFailures = state.transportFailures + 1;
+    return {
+      ...state,
+      transportFailures,
+      lastFailureKind: 'transport',
+      hasPriorSnapshotFailure: true,
+      retryAfter: now + cooldownFor(TRANSPORT_COOLDOWNS_MS, transportFailures, random),
+    };
+  }
+
+  const structuralFailures = state.structuralFailures + 1;
+  return {
+    ...state,
+    structuralFailures,
+    lastFailureKind: failureKind,
+    failedBuiltAt: builtAt ?? state.failedBuiltAt,
+    hasPriorSnapshotFailure: true,
+    retryAfter: now + cooldownFor(STRUCTURAL_COOLDOWNS_MS, structuralFailures, random),
+  };
+}
+
+/**
+ * Grant a terminal, artifact-attributable scope one more structural round
+ * because a differently-built artifact is now on offer. Spends a lifetime re-arm.
+ */
+export function rearmForNewArtifact(state: BootstrapRetryState, builtAt: string): BootstrapRetryState {
+  return {
+    ...state,
+    structuralFailures: 0,
+    structuralRearms: state.structuralRearms + 1,
+    failedBuiltAt: builtAt,
+    retryAfter: null,
+  };
+}
+
+/** A successful download clears the consecutive-transport counter and its cooldown. */
+export function clearTransportFailures(state: BootstrapRetryState): BootstrapRetryState {
+  if (state.transportFailures === 0 && state.retryAfter === null) return state;
+  return { ...state, transportFailures: 0, retryAfter: null };
+}
+
+/**
+ * The user tapped "Try the fast download again". Restores both budgets and drops
+ * the cooldown, keeping only the rollback mirrors' bookkeeping. This is the one
+ * escape from a terminal scope short of removing and re-adding the board — and
+ * it is consented and size-disclosed, which the automatic paths are not.
+ */
+export function clearRetryStateForUserRequest(state: BootstrapRetryState): BootstrapRetryState {
+  return {
+    ...EMPTY_BOOTSTRAP_RETRY_STATE,
+    mirroredAttempts: state.mirroredAttempts,
+    legacyHealSpent: true,
+  };
+}
+
+/** Defer an automatic heal without spending anything (metered link). */
+export function deferHeal(state: BootstrapRetryState, now: number): BootstrapRetryState {
+  return { ...state, retryAfter: now + METERED_HEAL_DEFERRAL_MS };
+}
+
+export type BootstrapEligibility =
+  | { eligible: true; kind: 'fresh' | 'heal-over-partial' }
+  | {
+      eligible: false;
+      reason: 'scope-complete' | 'bootstrap-done' | 'terminal' | 'cooling-down' | 'no-failure-evidence';
+      /** Only a `terminal` scope can ever be revived by tonight's export. */
+      canRearm: boolean;
+    };
+
+/**
+ * The single authority on "would the snapshot bootstrap run for this scope right
+ * now". Called by `runBootstrapPhase` AND by `estimateScopeDownload`, so the size
+ * the UI quotes can never disagree with what the engine would do — the two used
+ * to be a comment promising they mirrored each other.
+ *
+ * `heal-over-partial` is the un-strand: a scope that holds a partly-crawled
+ * catalog, never finished it, and has snapshot-path failures behind it is allowed
+ * to import an artifact over the top. A `scope-complete:` scope is NOT — it
+ * already serves the whole catalog locally, so 103 MB buys it nothing.
+ */
+export function evaluateBootstrapEligibility(input: {
+  retryState: BootstrapRetryState;
+  hasBoardCheckpoint: boolean;
+  isScopeComplete: boolean;
+  isBootstrapDone: boolean;
+  now: number;
+}): BootstrapEligibility {
+  const { retryState, hasBoardCheckpoint, isScopeComplete, isBootstrapDone, now } = input;
+  if (isScopeComplete) return { eligible: false, reason: 'scope-complete', canRearm: false };
+  if (isBootstrapDone) return { eligible: false, reason: 'bootstrap-done', canRearm: false };
+  if (isTerminal(retryState)) {
+    return { eligible: false, reason: 'terminal', canRearm: canRearmOnNewArtifact(retryState) };
+  }
+  if (retryState.retryAfter !== null && now < retryState.retryAfter) {
+    return { eligible: false, reason: 'cooling-down', canRearm: false };
+  }
+  if (!hasBoardCheckpoint) return { eligible: true, kind: 'fresh' };
+  if (retryState.hasPriorSnapshotFailure) return { eligible: true, kind: 'heal-over-partial' };
+  return { eligible: false, reason: 'no-failure-evidence', canRearm: false };
+}
+
+/**
+ * Whether a scope whose bootstrap did not run this cycle should ALSO skip its
+ * paged crawl. Only a fresh scope with an imminent retry does: a first-page
+ * checkpoint would (pre-heal-over-partial) have disqualified the snapshot path,
+ * and the crawl is 400+ serial round trips it is about to throw away. A scope
+ * that already holds rows always crawls — a failed heal must never stall
+ * progress that was already being made.
+ */
+export function shouldSkipPagedPull(input: {
+  retryState: BootstrapRetryState;
+  hasBoardCheckpoint: boolean;
+  now: number;
+}): boolean {
+  const { retryState, hasBoardCheckpoint, now } = input;
+  if (hasBoardCheckpoint) return false;
+  if (isTerminal(retryState)) return false;
+  if (retryState.retryAfter === null) return true;
+  return retryState.retryAfter - now <= BOOTSTRAP_RETRY_GRACE_WINDOW_MS;
+}
+
+/**
+ * Derive a starting state from the legacy markers an installed app already has.
+ *
+ * The legacy counter CONFLATED transport failures with real defects — that is the
+ * bug — so its value is not carried into `structuralFailures`. A stranded scope
+ * gets exactly one clean pass under the new taxonomy (bounded at 3 transport + 2
+ * structural), which is what un-strands the mid-crawl population. The legacy rows
+ * themselves stay on disk untouched: `mirroredAttempts` records what they said, so
+ * a later read can tell "an older bundle bumped this" from "this is what we
+ * migrated".
+ *
+ * A scope that already holds rows gets a spread-out `retryAfter` so the whole
+ * fleet does not start a 103 MB download on the same post-OTA launch.
+ */
+export function migrateLegacyBootstrapMarkers(input: {
+  legacyAttempts: number;
+  legacyHealed: boolean;
+  hasBoardCheckpoint: boolean;
+  now: number;
+  random: () => number;
+}): BootstrapRetryState {
+  const { legacyAttempts, legacyHealed, hasBoardCheckpoint, now, random } = input;
+  const hadFailures = legacyAttempts > 0 || legacyHealed;
+  return {
+    ...EMPTY_BOOTSTRAP_RETRY_STATE,
+    structuralRearms: legacyHealed ? MAX_STRUCTURAL_REARMS : 0,
+    hasPriorSnapshotFailure: hadFailures,
+    retryAfter: hasBoardCheckpoint && hadFailures ? now + Math.floor(random() * LEGACY_MIGRATION_SPREAD_MS) : null,
+    mirroredAttempts: legacyAttempts,
+    legacyHealSpent: legacyHealed || legacyAttempts >= MAX_BOOTSTRAP_ATTEMPTS,
+  };
+}
+
+// --- Persistence --------------------------------------------------------------
+
+type PersistedRetryRow = Partial<Record<keyof BootstrapRetryState, unknown>>;
+
+function readNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+/** Parse one persisted `bootstrap-retry:` row; null when it is missing or corrupt. */
+export function parseBootstrapRetryState(raw: string): BootstrapRetryState | null {
+  let parsed: PersistedRetryRow;
+  try {
+    parsed = JSON.parse(raw) as PersistedRetryRow;
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const lastFailureKind = parsed.lastFailureKind;
+  return {
+    transportFailures: readNumber(parsed.transportFailures, 0),
+    structuralFailures: readNumber(parsed.structuralFailures, 0),
+    structuralRearms: readNumber(parsed.structuralRearms, 0),
+    lastFailureKind:
+      lastFailureKind === 'transport' ||
+      lastFailureKind === 'structural-artifact' ||
+      lastFailureKind === 'structural-device'
+        ? lastFailureKind
+        : null,
+    failedBuiltAt: typeof parsed.failedBuiltAt === 'string' ? parsed.failedBuiltAt : null,
+    retryAfter: typeof parsed.retryAfter === 'number' && Number.isFinite(parsed.retryAfter) ? parsed.retryAfter : null,
+    hasPriorSnapshotFailure: parsed.hasPriorSnapshotFailure === true,
+    mirroredAttempts: readNumber(parsed.mirroredAttempts, 0),
+    legacyHealSpent: parsed.legacyHealSpent === true,
+  };
+}
+
+function parseLegacyAttempts(value: string): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export type BootstrapRetryRead = {
+  state: BootstrapRetryState;
+  /** This scope had no retry row: the state above was derived from legacy markers. */
+  migratedFromLegacy: boolean;
+};
+
+/**
+ * Read a scope's retry state, deriving it from the legacy markers on first
+ * touch. One indexed `sync_meta` lookup for all four keys.
+ */
+export async function readBootstrapRetryState(
+  db: SqlExecutor,
+  scopeKey: string,
+  clock: { now: number; random: () => number },
+  hasBoardCheckpoint: boolean,
+): Promise<BootstrapRetryRead> {
+  const rows = await db.getAllAsync<{ key: string; value: string }>(
+    'SELECT key, value FROM sync_meta WHERE key IN (?, ?, ?)',
+    [
+      `${BOOTSTRAP_RETRY_PREFIX}${scopeKey}`,
+      `${BOOTSTRAP_ATTEMPTS_PREFIX}${scopeKey}`,
+      `${BOOTSTRAP_ATTEMPTS_HEALED_PREFIX}${scopeKey}`,
+    ],
+  );
+  let retryRow: string | null = null;
+  let legacyAttempts = 0;
+  let legacyHealed = false;
+  for (const row of rows) {
+    if (row.key.startsWith(BOOTSTRAP_RETRY_PREFIX)) retryRow = row.value;
+    else if (row.key.startsWith(BOOTSTRAP_ATTEMPTS_HEALED_PREFIX)) legacyHealed = true;
+    else if (row.key.startsWith(BOOTSTRAP_ATTEMPTS_PREFIX)) legacyAttempts = parseLegacyAttempts(row.value);
+  }
+
+  const persisted = retryRow === null ? null : parseBootstrapRetryState(retryRow);
+  if (!persisted) {
+    return {
+      state: migrateLegacyBootstrapMarkers({
+        legacyAttempts,
+        legacyHealed,
+        hasBoardCheckpoint,
+        now: clock.now,
+        random: clock.random,
+      }),
+      migratedFromLegacy: true,
+    };
+  }
+
+  // An older bundle ran in between and counted something real: fold the excess
+  // back in rather than letting a rollback launder failures away.
+  const unmirroredAttempts = Math.max(0, legacyAttempts - persisted.mirroredAttempts);
+  if (unmirroredAttempts === 0) return { state: persisted, migratedFromLegacy: false };
+  return {
+    state: {
+      ...persisted,
+      structuralFailures: persisted.structuralFailures + unmirroredAttempts,
+      hasPriorSnapshotFailure: true,
+      mirroredAttempts: legacyAttempts,
+    },
+    migratedFromLegacy: false,
+  };
+}
+
+/**
+ * Persist a retry state AND its legacy mirror, in that order. The mirror is what
+ * keeps an OTA rollback honest, so it lives in exactly one function — there is
+ * no second place that can forget it.
+ */
+export async function writeBootstrapRetryState(
+  db: SqlExecutor,
+  scopeKey: string,
+  state: BootstrapRetryState,
+): Promise<BootstrapRetryState> {
+  const terminal = isTerminal(state);
+  const legacyAttempts = terminal
+    ? MAX_BOOTSTRAP_ATTEMPTS
+    : Math.min(state.structuralFailures, MAX_BOOTSTRAP_ATTEMPTS - 1);
+  const mirrored: BootstrapRetryState = { ...state, mirroredAttempts: legacyAttempts };
+
+  await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+    `${BOOTSTRAP_RETRY_PREFIX}${scopeKey}`,
+    JSON.stringify(mirrored),
+  ]);
+  await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+    `${BOOTSTRAP_ATTEMPTS_PREFIX}${scopeKey}`,
+    String(legacyAttempts),
+  ]);
+  if (mirrored.legacyHealSpent) {
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      `${BOOTSTRAP_ATTEMPTS_HEALED_PREFIX}${scopeKey}`,
+      '1',
+    ]);
+  }
+  return mirrored;
+}
+
+/** Read a scope's legacy attempt counter (the rollback mirror, not the budget). */
+export async function getBootstrapAttempts(db: SqlExecutor, scopeKey: string): Promise<number> {
+  const row = await db.getFirstAsync<{ value: string }>('SELECT value FROM sync_meta WHERE key = ?', [
+    `${BOOTSTRAP_ATTEMPTS_PREFIX}${scopeKey}`,
+  ]);
+  return row ? parseLegacyAttempts(row.value) : 0;
+}
+
+/** Persist that the latest bootstrap decision selected the ordinary paged crawl. */
+export async function markBootstrapPagedFallback(db: SqlExecutor, scopeKey: string): Promise<void> {
+  await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+    `${BOOTSTRAP_PAGED_FALLBACK_PREFIX}${scopeKey}`,
+    '1',
+  ]);
+}
+
+/** A new eligible snapshot attempt supersedes a prior run's paged decision. */
+export async function clearBootstrapPagedFallback(db: SqlExecutor, scopeKey: string): Promise<void> {
+  await db.runAsync('DELETE FROM sync_meta WHERE key = ?', [`${BOOTSTRAP_PAGED_FALLBACK_PREFIX}${scopeKey}`]);
+}
+
+/**
+ * Restore both budgets for a scope the user explicitly asked to retry, and drop
+ * the paged-fallback caption so My Boards stops promising the slow path. Returns
+ * the state that was written.
+ */
+export async function restoreBootstrapRetryBudget(db: SqlExecutor, scopeKey: string): Promise<BootstrapRetryState> {
+  const { state } = await readBootstrapRetryState(db, scopeKey, { now: 0, random: () => 0 }, false);
+  const written = await writeBootstrapRetryState(db, scopeKey, clearRetryStateForUserRequest(state));
+  await clearBootstrapPagedFallback(db, scopeKey);
+  return written;
+}

--- a/packages/shared/offline-sync/src/sync/bootstrap-retry.ts
+++ b/packages/shared/offline-sync/src/sync/bootstrap-retry.ts
@@ -127,6 +127,14 @@ export type BootstrapRetryState = {
    */
   readonly hasPriorSnapshotFailure: boolean;
   /**
+   * The climber tapped "Try the fast download again" and has not been served
+   * yet. Worth one consented artifact download: it overrides the metered-link
+   * defer — they confirmed the size on that exact screen moments ago — and is
+   * spent the instant the download starts, so a failure does not hand the
+   * engine a standing licence to keep pulling ~100 MB over cellular.
+   */
+  readonly userRequested: boolean;
+  /**
    * The value last written to the legacy `bootstrap-attempts:` row. A legacy
    * counter ABOVE this means an older (rolled-back) bundle counted failures we
    * never saw, and the difference is folded into `structuralFailures` on read.
@@ -144,6 +152,7 @@ export const EMPTY_BOOTSTRAP_RETRY_STATE: BootstrapRetryState = {
   failedBuiltAt: null,
   retryAfter: null,
   hasPriorSnapshotFailure: false,
+  userRequested: false,
   mirroredAttempts: 0,
   legacyHealSpent: false,
 };
@@ -266,6 +275,10 @@ export function clearTransportFailures(state: BootstrapRetryState): BootstrapRet
 export function clearRetryStateForUserRequest(state: BootstrapRetryState): BootstrapRetryState {
   return {
     ...EMPTY_BOOTSTRAP_RETRY_STATE,
+    // The tap is the consent the automatic heal does not have, so it also
+    // overrides the metered-link defer — otherwise the climber confirms ~100 MB
+    // on a cellular link and the engine silently sits on it for 6 hours.
+    userRequested: true,
     // The failure history is KEPT on purpose. A settled scope has always crawled
     // (a terminal scope is never in `skipPagedPull`), so it carries board
     // checkpoints — and `evaluateBootstrapEligibility` only lets a checkpointed
@@ -281,6 +294,17 @@ export function clearRetryStateForUserRequest(state: BootstrapRetryState): Boots
 /** Defer an automatic heal without spending anything (metered link). */
 export function deferHeal(state: BootstrapRetryState, now: number): BootstrapRetryState {
   return { ...state, retryAfter: now + METERED_HEAL_DEFERRAL_MS };
+}
+
+/**
+ * Consume the user's retry the moment its download starts. Spending it here
+ * rather than on success is deliberate: one tap buys one artifact download, so a
+ * failure over cellular schedules an ordinary cooldown instead of leaving a
+ * standing metered-link override behind.
+ */
+export function spendUserRequest(state: BootstrapRetryState): BootstrapRetryState {
+  if (!state.userRequested) return state;
+  return { ...state, userRequested: false };
 }
 
 export type BootstrapEligibility =
@@ -351,8 +375,11 @@ export function shouldSkipPagedPull(input: {
  * bug — so its value is not carried into `structuralFailures`. A stranded scope
  * gets exactly one clean pass under the new taxonomy (bounded at 3 transport + 2
  * structural), which is what un-strands the mid-crawl population. The legacy rows
- * themselves stay on disk untouched: `mirroredAttempts` records what they said, so
- * a later read can tell "an older bundle bumped this" from "this is what we
+ * are never DELETED, but the first `writeBootstrapRetryState` after a migration
+ * re-stamps `bootstrap-attempts:` down to the mirrored value — the clean pass has
+ * to be visible to a rolled-back bundle too, or it would re-read the pre-migration
+ * count and settle the scope again. `mirroredAttempts` records what we wrote, so a
+ * later read can tell "an older bundle bumped this" from "this is what we
  * migrated".
  *
  * A scope that already holds rows gets a spread-out `retryAfter` so the whole
@@ -408,6 +435,7 @@ export function parseBootstrapRetryState(raw: string): BootstrapRetryState | nul
     failedBuiltAt: typeof parsed.failedBuiltAt === 'string' ? parsed.failedBuiltAt : null,
     retryAfter: typeof parsed.retryAfter === 'number' && Number.isFinite(parsed.retryAfter) ? parsed.retryAfter : null,
     hasPriorSnapshotFailure: parsed.hasPriorSnapshotFailure === true,
+    userRequested: parsed.userRequested === true,
     mirroredAttempts: readNumber(parsed.mirroredAttempts, 0),
     legacyHealSpent: parsed.legacyHealSpent === true,
   };
@@ -535,9 +563,10 @@ export async function clearBootstrapPagedFallback(db: SqlExecutor, scopeKey: str
 }
 
 /**
- * Restore both budgets for a scope the user explicitly asked to retry, and drop
- * the paged-fallback caption so My Boards stops promising the slow path. Returns
- * the state that was written.
+ * Restore both budgets for a scope the user explicitly asked to retry, drop the
+ * paged-fallback caption so My Boards stops promising the slow path, and arm the
+ * one-shot `userRequested` flag the bootstrap phase reads to override the
+ * metered-link defer. Returns the state that was written.
  */
 export async function restoreBootstrapRetryBudget(db: SqlExecutor, scopeKey: string): Promise<BootstrapRetryState> {
   const { state } = await readBootstrapRetryState(db, scopeKey, { now: 0, random: () => 0 }, false);

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -12,22 +12,31 @@ import {
 import { markUserDataComplete } from './local-user-owner';
 import {
   bootstrapScopeFromSnapshot,
-  getBootstrapAttempts,
-  recordBootstrapAttempt,
-  resetBootstrapAttempts,
-  hasHealedBootstrapAttempts,
-  markBootstrapAttemptsHealed,
-  markBootstrapPagedFallback,
-  clearBootstrapPagedFallback,
   markBootstrapDone,
   isBootstrapDone,
-  MAX_BOOTSTRAP_ATTEMPTS,
   SnapshotWipedError,
   SnapshotSchemaStaleError,
   SnapshotPermanentMissError,
+  SnapshotWatermarkRegressionError,
   type SnapshotSource,
   type SnapshotBootstrapErrorReporter,
 } from './snapshot-bootstrap';
+import {
+  classifyBootstrapFailure,
+  clearBootstrapPagedFallback,
+  clearTransportFailures,
+  deferHeal,
+  evaluateBootstrapEligibility,
+  isTerminal,
+  markBootstrapPagedFallback,
+  nextRetryState,
+  readBootstrapRetryState,
+  rearmForNewArtifact,
+  shouldSkipPagedPull,
+  writeBootstrapRetryState,
+  type BootstrapFailureKind,
+  type BootstrapRetryState,
+} from './bootstrap-retry';
 import { parseSnapshotManifest, type SnapshotManifest } from './snapshot-manifest';
 import { findSnapshotEntry, isSnapshotEntryUsable } from './snapshot-estimate';
 import {
@@ -86,7 +95,15 @@ export type SyncProgress = {
 export type ScopeDownloadCompleteInfo = {
   scopeKey: string;
   method: 'snapshot' | 'paged';
+  /**
+   * NOTE for path comparisons: a scope that was HEALED (an artifact imported
+   * over a partly-crawled catalog, issue #4313) reports `method: 'snapshot'` but
+   * a duration that EXCLUDES the paged work earlier cycles already did. Filter on
+   * `bootstrapHealed` before comparing snapshot-vs-paged percentiles.
+   */
   durationMs: number;
+  /** The snapshot import landed on a scope that had already crawled some rows. */
+  bootstrapHealed?: boolean;
 };
 export type ScopeDownloadCompleteReporter = (info: ScopeDownloadCompleteInfo) => void;
 
@@ -148,6 +165,40 @@ export type CoverageEvaluatedInfo = {
 };
 export type CoverageEvaluatedReporter = (info: CoverageEvaluatedInfo) => void;
 
+/**
+ * Fired when a bootstrap failure schedules the scope's next snapshot attempt
+ * (issue #4313). Operational, not an error — `onSnapshotBootstrapError` still
+ * carries the failure itself at its existing severity. `terminal` means both
+ * budgets are spent, so the scope has settled onto the paged crawl until the
+ * user asks for a retry or removes the board.
+ */
+export type BootstrapRetryScheduledInfo = {
+  scopeKey: string;
+  boardType: string;
+  stage: 'manifest' | 'download' | 'import';
+  failureKind: BootstrapFailureKind;
+  /** Milliseconds until the scheduled retry; 0 when the scope went terminal. */
+  retryAfterMs: number;
+  transportFailures: number;
+  structuralFailures: number;
+  terminal: boolean;
+};
+export type BootstrapRetryScheduledReporter = (info: BootstrapRetryScheduledInfo) => void;
+
+/**
+ * Fired when a scope that had previously failed the snapshot path gets back on
+ * it — the measurement that tells us whether #4313's recovery actually reaches
+ * stranded installs.
+ */
+export type BootstrapPathRecoveredInfo = {
+  scopeKey: string;
+  boardType: string;
+  trigger: 'cooldown' | 'new-artifact' | 'legacy-migration' | 'user-request';
+  /** True when this is a heal over a partly-crawled catalog, not a fresh scope. */
+  hadBoardCheckpoint: boolean;
+};
+export type BootstrapPathRecoveredReporter = (info: BootstrapPathRecoveredInfo) => void;
+
 export type SyncOptions = {
   /** Encoded board scope keys ("boardType:layoutId:sizeId") to download offline. */
   enabledBoards?: string[];
@@ -184,6 +235,27 @@ export type SyncOptions = {
    * so the engine seam stays deterministic and testable.
    */
   onCoverageEvaluated?: CoverageEvaluatedReporter;
+  /** Telemetry for a scheduled snapshot retry (issue #4313). */
+  onBootstrapRetryScheduled?: BootstrapRetryScheduledReporter;
+  /** Telemetry for a scope getting back onto the snapshot path (issue #4313). */
+  onBootstrapPathRecovered?: BootstrapPathRecoveredReporter;
+  /**
+   * Whether the device is on an unmetered link. Consulted for ONE decision: the
+   * automatic heal of a partly-crawled scope, which is a ~100 MB download the
+   * user did not ask for today. A fresh bootstrap (they just enabled the board,
+   * behind a size-disclosing confirm) and a user-requested retry both ignore it.
+   *
+   * DEFAULTS TO `() => true`, so web and every existing caller are unchanged.
+   */
+  isOnUnmeteredNetwork?: () => boolean;
+  /**
+   * Wall clock for the bootstrap retry ladder. Injected so the cooldown schedule
+   * is testable without fake timers fighting the SQLite test double.
+   * Defaults to `Date.now`.
+   */
+  now?: () => number;
+  /** Jitter source for the retry ladder. Defaults to `Math.random`. */
+  random?: () => number;
 };
 
 /** A per-board download target: the parsed scope plus its encoded key. */
@@ -553,9 +625,52 @@ type ManifestResolution =
   | { status: 'absent' }
   | { status: 'error'; cause: unknown };
 
-async function recordRetryableBootstrapFailure(db: OfflineDatabase, scopeKey: string): Promise<number> {
-  const attempt = await recordBootstrapAttempt(db, scopeKey);
-  if (attempt >= MAX_BOOTSTRAP_ATTEMPTS) {
+/**
+ * Settle one bootstrap failure: burn the budget its KIND spends, schedule the
+ * next attempt on that budget's ladder, and mirror the legacy markers.
+ *
+ * Two independent decisions come out of a failure, and #4313 is the story of
+ * them having been fused. `expected` is purely a SEVERITY signal — a
+ * transport-shaped cause (offline, DNS, TLS, timeout; `isNetworkError`, the same
+ * predicate the drainer uses to keep a mutation off the dead-letter path) is
+ * routine on a phone and the mobile reporter downgrades it to a warning. Which
+ * budget it spends is `classifyBootstrapFailure`'s call, and a transport failure
+ * now spends the transport budget instead of the structural one.
+ *
+ * The MANIFEST stage stays entirely free for transport failures (issue #4238):
+ * it is a few KB of JSON and the stage an offline launch dies at. Everything
+ * else — a 500 from the CDN, a short artifact, a disk-full device — is charged.
+ */
+async function settleBootstrapFailure(
+  db: OfflineDatabase,
+  scopeKey: string,
+  input: {
+    state: BootstrapRetryState;
+    cause: unknown;
+    stage: 'manifest' | 'download' | 'import';
+    builtAt: string | null;
+    now: number;
+    random: () => number;
+  },
+): Promise<{
+  state: BootstrapRetryState;
+  failureKind: BootstrapFailureKind;
+  expected: boolean;
+  cause: unknown;
+  /** False for the free manifest-transport case: nothing was written to sync_meta. */
+  persisted: boolean;
+}> {
+  const { state, cause, stage, builtAt, now, random } = input;
+  const failureKind = classifyBootstrapFailure({ cause, stage });
+  const expected = isNetworkError(cause);
+  if (stage === 'manifest' && failureKind === 'transport') {
+    // Cap-exempt and cooldown-exempt: nothing is persisted, so the scope is
+    // exactly as eligible on the next cycle as it was on this one.
+    return { state, failureKind, expected, cause, persisted: false };
+  }
+  const scheduled = nextRetryState({ state, failureKind, builtAt, now, random });
+  const written = await writeBootstrapRetryState(db, scopeKey, scheduled);
+  if (isTerminal(written)) {
     await markBootstrapPagedFallback(db, scopeKey);
   } else {
     // Preserve the prior fallback marker until the new attempt has a durable
@@ -563,53 +678,7 @@ async function recordRetryableBootstrapFailure(db: OfflineDatabase, scopeKey: st
     // transient decision that this run never finished making.
     await clearBootstrapPagedFallback(db, scopeKey);
   }
-  return attempt;
-}
-
-/**
- * Settle one retryable manifest/download failure into the two INDEPENDENT
- * decisions it drives: how loudly to report it (`expected`) and whether it burns
- * an attempt.
- *
- * `expected` is purely a severity signal — a TRANSPORT-shaped cause (offline,
- * DNS, TLS, timeout; `isNetworkError`, the same predicate the drainer uses to
- * decide a mutation must not advance toward the dead-letter) is routine on a
- * phone and the mobile reporter downgrades it to a warning. It says nothing
- * about the retry budget.
- *
- * `exemptTransportFromCap` is the retry-budget decision, and it is TRUE for the
- * manifest stage ONLY:
- *
- *  - MANIFEST: the request is a few KB of JSON and it is the stage an offline
- *    launch dies at, which is exactly what made two launches in airplane mode
- *    permanently drop a board to the paged crawl (issue #4238). Retrying it for
- *    free costs nothing. The caller still skips the paged pull so no first-page
- *    checkpoint disqualifies the snapshot path.
- *  - DOWNLOAD: the manifest already resolved over the same connection seconds
- *    earlier, so the device is provably online — a failure here is a slow or
- *    flaky link, not a plane. Exempting it would let an unresumable 272 MB GET
- *    that always times out (the download failure the issue's own Sentry sample
- *    actually shows: `UnableToDownloadException: … The request timed out.`)
- *    restart from byte 0 on every foreground FOREVER, burning cellular data and
- *    — because the failure also skips the paged pull — leaving the board with no
- *    offline catalog at all. Counting it means the scope settles into the paged
- *    crawl after MAX_BOOTSTRAP_ATTEMPTS (plus the one-shot heal's second round),
- *    which is a working board on the slow path.
- *
- * Anything non-transport — a 500 from the CDN, a short artifact, a disk-full
- * device — counts at either stage, exactly as it always did.
- */
-async function settleRetryableBootstrapFailure(
-  db: OfflineDatabase,
-  scopeKey: string,
-  cause: unknown,
-  { exemptTransportFromCap }: { exemptTransportFromCap: boolean },
-): Promise<{ attempt: number; expected: boolean }> {
-  const expected = isNetworkError(cause);
-  if (expected && exemptTransportFromCap) {
-    return { attempt: await getBootstrapAttempts(db, scopeKey), expected };
-  }
-  return { attempt: await recordRetryableBootstrapFailure(db, scopeKey), expected };
+  return { state: written, failureKind, expected, cause, persisted: true };
 }
 
 async function resolveManifestOnce(
@@ -634,71 +703,90 @@ async function resolveManifestOnce(
 }
 
 /**
- * Snapshot-bootstrap phase (runs BEFORE deletions). For each enabled scope that
- * is FRESH (no checkpoint on either board table) and still under the attempt cap,
- * warm it from a pre-built artifact instead of paging the whole catalog. Returns
- * the set of scope keys whose paged board-table pull must be SKIPPED this cycle —
- * a scope whose bootstrap failed (and still has attempts left): letting its paged
- * pull run would write a first-page checkpoint and permanently disqualify the
- * snapshot path, so it is skipped so the NEXT cycle retries the snapshot.
+ * Snapshot-bootstrap phase (runs BEFORE deletions). For each enabled scope the
+ * shared eligibility gate vouches for, warm it from a pre-built artifact instead
+ * of paging the whole catalog. Returns the scope keys whose paged board-table
+ * pull must be SKIPPED this cycle, plus the scopes an artifact was imported over
+ * a partly-crawled catalog for (see ScopeDownloadCompleteInfo.bootstrapHealed).
  *
- * Eligibility + failure matrix (per scope):
- *   - checkpoint exists on either board table → NOT eligible → normal paged pull.
- *   - attempts ≥ MAX → gave up → normal paged pull, EXCEPT for the one-shot heal
- *     below.
- *   - manifest `absent` (missing/unparseable) → permanent miss, NO attempt →
+ * ELIGIBILITY lives in `bootstrap-retry.ts`'s `evaluateBootstrapEligibility`,
+ * which `estimateScopeDownload` calls too so the size the UI quotes can never
+ * disagree with what this function does. Two kinds pass it:
+ *   - `fresh` — no checkpoint on either board table (the original rule).
+ *   - `heal-over-partial` — a scope that HAS checkpoints but never finished its
+ *     crawl and carries snapshot-path failures behind it. This is the un-strand
+ *     for issue #4313's victims: their board data is a fraction of the catalog
+ *     and the paged crawl that was going to finish it is 400+ serial round trips.
+ *     A `scope-complete:` scope is never healed — it already serves the whole
+ *     catalog locally, so an artifact buys it nothing.
+ *
+ * FAILURE ACCOUNTING is `classifyBootstrapFailure` + `nextRetryState` (same
+ * module). Per stage:
+ *   - manifest `absent` (missing/unparseable) → permanent miss, NO burn →
  *     normal paged pull.
- *   - manifest `error`, TRANSPORT-shaped (offline/DNS/TLS/timeout) → NO attempt,
- *     nothing persisted → SKIP paged pull this cycle, reported as `expected`.
- *   - manifest `error`, anything else (a 500 from the CDN, a parse blow-up) →
- *     counted attempt → SKIP paged pull this cycle.
+ *   - manifest `error`, TRANSPORT-shaped → NO burn, nothing persisted, no
+ *     cooldown → SKIP paged pull this cycle, reported as `expected` (#4238).
+ *   - manifest `error`, anything else → structural-device burn + cooldown.
  *   - manifest `ok` but no entry for (boardType, layoutId) → permanent miss, NO
- *     attempt → normal paged pull (layout not exported yet).
- *   - download fails/returns null → counted attempt → SKIP paged pull this cycle,
- *     transport-shaped or not (only the severity differs — see
- *     `settleRetryableBootstrapFailure` for why the cap exemption stops at the
- *     manifest). Two of these settle the scope onto the paged crawl, which is
- *     what stops an unresumable 272 MB GET restarting on every foreground.
- *   - download throws SnapshotPermanentMissError → NO attempt → normal paged pull.
- *   - import throws (corrupt/short artifact, row-count/format mismatch) → counted
- *     attempt → SKIP paged pull this cycle. Import failures ALWAYS count: an
- *     artifact that downloaded but won't import is a real defect, and the cap is
- *     what stops the client re-downloading it forever.
- *   - success → mark done, rewind deletions to min(watermarks); paged pull runs
- *     normally, now a ~1-day delta from the scoped watermark checkpoints.
+ *     burn → normal paged pull (layout not exported yet).
+ *   - download fails/returns null, TRANSPORT-shaped → transport burn + the
+ *     2 min → 15 min → 2 h ladder. THIS is what #4313 changed: it used to burn
+ *     the same 2-slot counter a corrupt artifact does, so two bad-reception
+ *     launches condemned the board to the crawl for the life of the install.
+ *   - download fails otherwise → structural-device burn (6 h → 24 h ladder), and
+ *     a device-side fault is never re-armed by a nightly rebuild.
+ *   - download throws SnapshotPermanentMissError → NO burn → normal paged pull.
+ *   - import throws → structural-artifact burn. The bytes are on disk and
+ *     provably bad, so tonight's export MIGHT fix it: a terminal scope of this
+ *     one kind consults the manifest again and a differently-built artifact
+ *     re-arms its budget exactly once per scope, ever.
+ *   - import throws SnapshotWatermarkRegressionError → permanent miss, NO burn.
+ *     The artifact's scoped watermark is behind what this scope already crawled;
+ *     importing would lower a checkpoint (and the global deletions cursor) below
+ *     local progress. Nothing was written — reported at full severity because it
+ *     means the export's scope filter and the client's disagree.
+ *   - success → mark done, rewind deletions to min(watermarks), clear the
+ *     consecutive-transport counter; the paged pull runs normally, now a ~1-day
+ *     delta from the scoped watermark checkpoints.
  *
- * ONE-SHOT HEAL (issue #4238): the attempt cap is evaluated AFTER the manifest
- * resolves, so an over-cap scope that turns out to have a usable artifact
- * waiting gets its counter cleared exactly once (`bootstrap-attempts-healed:`)
- * and takes the snapshot path again. A device that spent both attempts offline
- * therefore recovers on its first online launch, while a genuinely broken
- * artifact costs two more attempts and then settles into the paged crawl for
- * good. Cost: an over-cap scope consults the manifest each cycle — cached per
- * pullSync run by `resolveManifestOnce`, so it adds a request only on cycles
- * where EVERY scope is over the cap.
- * A wipe detected mid-phase bails the whole phase with no attempt (mirrors
+ * WORST-CASE LIFETIME SPEND per scope: 3 transport + 2 structural + 2 for the
+ * single re-armed structural round = 7 artifact downloads, each separated by at
+ * least one cooldown rung. A test pins that count.
+ *
+ * SKIPPING THE PAGED PULL is now a grace window, not all-or-nothing: only a
+ * FRESH, non-terminal scope whose retry is within 30 minutes waits for it. A
+ * scope that already holds rows always crawls, so a failed heal can never stall
+ * progress that was already being made.
+ *
+ * A wipe detected mid-phase bails the whole phase with no burn (mirrors
  * syncTable). One artifact is downloaded per (boardType, layoutId) and reused
  * across that layout's sizes; all downloads are deleted in a finally.
  *
- * Returns the skip-set (above). Snapshot attribution for
- * ScopeDownloadCompleteInfo.method is NOT threaded through here — it reads the
- * persisted `isBootstrapDone` marker instead, because the completing delta
- * pull can land cycles after the import (see ScopeDownloadCompleteInfo).
+ * Snapshot attribution for ScopeDownloadCompleteInfo.method is NOT threaded
+ * through here — it reads the persisted `isBootstrapDone` marker instead,
+ * because the completing delta pull can land cycles after the import.
  */
-async function runBootstrapPhase(
-  db: OfflineDatabase,
-  queryClient: QueryInvalidator,
-  source: SnapshotSource,
-  scopes: BoardScope[],
+async function runBootstrapPhase(params: {
+  db: OfflineDatabase;
+  queryClient: QueryInvalidator;
+  source: SnapshotSource;
+  scopes: BoardScope[];
   /** The epoch pullSync captured at CYCLE start — see `cycleAborted` there. */
-  cycleEpoch: number,
-  stampScopeStart: (scopeKey: string) => void,
-  onProgress: ((progress: SyncProgress) => void) | undefined,
-  onSchemaDrift: SchemaDriftReporter | undefined,
-  onSnapshotBootstrapError: SnapshotBootstrapErrorReporter | undefined,
-  onBootstrapMetadataChanged: BootstrapMetadataChangedReporter | undefined,
-): Promise<Set<string>> {
+  cycleEpoch: number;
+  stampScopeStart: (scopeKey: string) => void;
+  options: SyncOptions | undefined;
+  now: () => number;
+  random: () => number;
+}): Promise<{ skipPagedPull: Set<string>; healedScopes: Set<string> }> {
+  const { db, queryClient, source, scopes, cycleEpoch, stampScopeStart, options, now, random } = params;
+  const onProgress = options?.onProgress;
+  const onSchemaDrift = options?.onSchemaDrift;
+  const onSnapshotBootstrapError = options?.onSnapshotBootstrapError;
+  const onBootstrapMetadataChanged = options?.onBootstrapMetadataChanged;
+  const isOnUnmeteredNetwork = options?.isOnUnmeteredNetwork ?? (() => true);
+
   const skipPagedPull = new Set<string>();
+  const healedScopes = new Set<string>();
   const manifestCache: { value?: ManifestResolution } = {};
   // Absent = not yet attempted; `file: null` = download failed (with its cause).
   const downloadByLayout = new Map<
@@ -706,6 +794,36 @@ async function runBootstrapPhase(
     { file: { filePath: string } | null; cause: unknown; permanentMiss: boolean }
   >();
   const downloadedPaths = new Set<string>();
+
+  const reportSettledFailure = (
+    scope: BoardScope,
+    stage: 'manifest' | 'download' | 'import',
+    settled: Awaited<ReturnType<typeof settleBootstrapFailure>>,
+    evaluatedAt: number,
+  ): void => {
+    const burned =
+      settled.failureKind === 'transport' ? settled.state.transportFailures : settled.state.structuralFailures;
+    onSnapshotBootstrapError?.({
+      scopeKey: scope.scopeKey,
+      stage,
+      attempt: settled.persisted ? burned : 0,
+      cause: settled.cause,
+      expected: settled.expected,
+    });
+    if (!settled.persisted) return;
+    const terminal = isTerminal(settled.state);
+    options?.onBootstrapRetryScheduled?.({
+      scopeKey: scope.scopeKey,
+      boardType: scope.boardType,
+      stage,
+      failureKind: settled.failureKind,
+      retryAfterMs:
+        terminal || settled.state.retryAfter === null ? 0 : Math.max(0, settled.state.retryAfter - evaluatedAt),
+      transportFailures: settled.state.transportFailures,
+      structuralFailures: settled.state.structuralFailures,
+      terminal,
+    });
+  };
 
   try {
     for (const scope of scopes) {
@@ -717,23 +835,60 @@ async function runBootstrapPhase(
         // snapshot scope's durationMs covers its manifest/download/import work.
         stampScopeStart(scope.scopeKey);
 
-        // Eligibility: FRESH on BOTH board tables and under the attempt cap.
         const climbsCheckpoint = await getCheckpoint(db, getCheckpointKey('board_climbs', scope.scopeKey));
         const statsCheckpoint = await getCheckpoint(db, getCheckpointKey('board_climb_stats', scope.scopeKey));
-        if (climbsCheckpoint || statsCheckpoint) {
-          // Checkpoints can be written by an ad-hoc pull while the scheduled
-          // snapshot source is disabled. Refresh this scope even though this
-          // run did not mutate its bootstrap markers.
+        const hasBoardCheckpoint = climbsCheckpoint !== null || statsCheckpoint !== null;
+        const isScopeComplete = await isScopeDownloadComplete(db, scope.scopeKey);
+        const isAlreadyBootstrapped = await isBootstrapDone(db, scope.scopeKey);
+        // ONE clock reading for this scope's whole decision: the cooldown
+        // comparison, the ladder it schedules, and the reported retryAfterMs must
+        // all be made against the same instant or a slow download would report a
+        // delay it never waited.
+        const evaluatedAt = now();
+        const { state: migratedState, migratedFromLegacy } = await readBootstrapRetryState(
+          db,
+          scope.scopeKey,
+          { now: evaluatedAt, random },
+          hasBoardCheckpoint,
+        );
+        let retryState = migratedState;
+        // Persist the derived state on first touch so the spread-out post-OTA
+        // retryAfter is stable across launches instead of being re-rolled every
+        // cycle. The legacy rows are deliberately LEFT IN PLACE (rollback).
+        if (migratedFromLegacy && retryState.hasPriorSnapshotFailure) {
+          retryState = await writeBootstrapRetryState(db, scope.scopeKey, retryState);
           metadataSettled = true;
+        }
+
+        const verdict = evaluateBootstrapEligibility({
+          retryState,
+          hasBoardCheckpoint,
+          isScopeComplete,
+          isBootstrapDone: isAlreadyBootstrapped,
+          now: evaluatedAt,
+        });
+        // A terminal scope whose last failure was the ARTIFACT's fault is the one
+        // case worth spending a manifest request on: a differently-built artifact
+        // re-arms it. Everything else terminal skips the fetch entirely, which is
+        // cheaper than the pre-#4313 over-cap path that consulted it every cycle.
+        const isRearmCandidate = !verdict.eligible && verdict.reason === 'terminal' && verdict.canRearm;
+        if (!verdict.eligible && !isRearmCandidate) {
+          if (verdict.reason === 'terminal') await markBootstrapPagedFallback(db, scope.scopeKey);
+          // Set on BOTH not-eligible arms deliberately: the pre-#4313 bail did
+          // the same for a checkpointed scope so My Boards re-reads the row even
+          // though this run did not mutate its markers.
+          metadataSettled = true;
+          if (shouldSkipPagedPull({ retryState, hasBoardCheckpoint, now: evaluatedAt })) {
+            skipPagedPull.add(scope.scopeKey);
+          }
           continue;
         }
-        const isOverAttemptCap = (await getBootstrapAttempts(db, scope.scopeKey)) >= MAX_BOOTSTRAP_ATTEMPTS;
 
         onProgress?.({ phase: 'bootstrap', currentTable: scope.scopeKey, documentsProcessed: 0 });
 
         const resolution = await resolveManifestOnce(source, manifestCache);
         // Re-check after the manifest network await: every branch below either
-        // writes to SQLite (recordBootstrapAttempt) or leads to one further down.
+        // writes to SQLite or leads to one further down.
         if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) break;
 
         // Shared with the pre-download size estimate (snapshot-estimate.ts) so the
@@ -743,67 +898,92 @@ async function runBootstrapPhase(
         // Pre-check the manifest's schemaVersion so a schema-stale artifact is
         // skipped BEFORE the multi-MB download; verifySnapshotMeta re-checks the
         // authoritative value inside the file. Same permanent-miss semantics as
-        // SnapshotSchemaStaleError: no attempt, paged crawl runs this cycle, and
+        // SnapshotSchemaStaleError: no burn, paged crawl runs this cycle, and
         // tonight's export rebuilds at the new schema.
         const isEntryUsable = entry !== null && isSnapshotEntryUsable(entry);
 
-        // The attempt cap is decided HERE, below the manifest resolution, so it
-        // can tell "we gave up because the artifact is broken" from "we gave up
-        // because the phone was in a tunnel twice". See the ONE-SHOT HEAL note
-        // in this function's doc comment.
-        if (isOverAttemptCap) {
-          const canHeal = isEntryUsable && !(await hasHealedBootstrapAttempts(db, scope.scopeKey));
-          if (!canHeal) {
+        if (isRearmCandidate) {
+          // Only a genuinely DIFFERENT build is worth another round; the same
+          // artifact would fail the same way.
+          if (!isEntryUsable || entry.builtAt === retryState.failedBuiltAt) {
             await markBootstrapPagedFallback(db, scope.scopeKey);
             metadataSettled = true;
             continue;
           }
-          await resetBootstrapAttempts(db, scope.scopeKey);
-          await markBootstrapAttemptsHealed(db, scope.scopeKey);
-          // The scope reached the cap, so it is carrying a paged-fallback marker
-          // that My Boards renders as "using the slower download". It is back on
-          // the snapshot path as of this line, and the download below can run for
-          // 18 minutes — leaving the marker up would tell the climber the wrong
-          // story for the whole of it. A later failure re-stamps it.
+          retryState = await writeBootstrapRetryState(
+            db,
+            scope.scopeKey,
+            rearmForNewArtifact(retryState, entry.builtAt),
+          );
+          // The scope was carrying a paged-fallback marker that My Boards renders
+          // as "using the slower download". It is back on the snapshot path as of
+          // this line, and the download below can run for 18 minutes — leaving the
+          // marker up would tell the climber the wrong story for the whole of it.
+          // A later failure re-stamps it.
           await clearBootstrapPagedFallback(db, scope.scopeKey);
-          // The scope reached the cap, so it is carrying a paged-fallback marker
-          // that My Boards renders as "using the slower download". It is back on
-          // the snapshot path as of this line, and the download below can run for
-          // 18 minutes — leaving the marker up would tell the climber the wrong
-          // story for the whole of it. A later failure re-stamps it.
+          metadataSettled = true;
         }
 
         if (resolution.status === 'absent') {
           await markBootstrapPagedFallback(db, scope.scopeKey);
           metadataSettled = true;
-          continue; // permanent miss, no attempt
+          continue; // permanent miss, no burn
         }
         if (resolution.status === 'error') {
-          const { attempt, expected } = await settleRetryableBootstrapFailure(db, scope.scopeKey, resolution.cause, {
-            exemptTransportFromCap: true,
+          const settled = await settleBootstrapFailure(db, scope.scopeKey, {
+            state: retryState,
+            cause: resolution.cause,
+            stage: 'manifest',
+            builtAt: null,
+            now: evaluatedAt,
+            random,
           });
+          retryState = settled.state;
           // A cap-exempt transport failure persists nothing, so there is no settled
           // decision for the UI to re-read — only a counted one changed sync_meta.
-          metadataSettled = !expected;
-          onSnapshotBootstrapError?.({
-            scopeKey: scope.scopeKey,
-            stage: 'manifest',
-            attempt,
-            cause: resolution.cause,
-            expected,
-          });
-          skipPagedPull.add(scope.scopeKey);
+          metadataSettled = metadataSettled || settled.persisted;
+          reportSettledFailure(scope, 'manifest', settled, evaluatedAt);
+          if (shouldSkipPagedPull({ retryState, hasBoardCheckpoint, now: evaluatedAt })) {
+            skipPagedPull.add(scope.scopeKey);
+          }
           continue;
         }
         if (!entry) {
           await markBootstrapPagedFallback(db, scope.scopeKey);
           metadataSettled = true;
-          continue; // layout not exported yet — permanent miss, no attempt
+          continue; // layout not exported yet — permanent miss, no burn
         }
         if (!isEntryUsable) {
           await markBootstrapPagedFallback(db, scope.scopeKey);
           metadataSettled = true;
           continue;
+        }
+
+        // A re-arm makes a terminal scope eligible as of this cycle; its kind is
+        // whatever it would have been had the budget never run out.
+        const bootstrapKind = verdict.eligible
+          ? verdict.kind
+          : hasBoardCheckpoint
+            ? ('heal-over-partial' as const)
+            : ('fresh' as const);
+
+        // The automatic heal is the one path that downloads ~100 MB for a board
+        // the user enabled on some earlier day. Defer it on a metered link; a
+        // fresh bootstrap (confirmed behind a size-disclosing dialog moments ago)
+        // and a user-requested retry are consented and ignore the probe.
+        if (bootstrapKind === 'heal-over-partial' && !isOnUnmeteredNetwork()) {
+          retryState = await writeBootstrapRetryState(db, scope.scopeKey, deferHeal(retryState, evaluatedAt));
+          metadataSettled = true;
+          continue;
+        }
+
+        if (retryState.hasPriorSnapshotFailure) {
+          options?.onBootstrapPathRecovered?.({
+            scopeKey: scope.scopeKey,
+            boardType: scope.boardType,
+            trigger: isRearmCandidate ? 'new-artifact' : migratedFromLegacy ? 'legacy-migration' : 'cooldown',
+            hadBoardCheckpoint: hasBoardCheckpoint,
+          });
         }
 
         const layoutKey = `${scope.boardType}:${scope.layoutId}`;
@@ -839,27 +1019,29 @@ async function runBootstrapPhase(
             });
             continue;
           }
-          // NOT cap-exempt even when transport-shaped: the manifest resolved over
-          // this same connection moments ago, so the device is online and the
-          // artifact just won't come down. See settleRetryableBootstrapFailure.
-          const { attempt, expected } = await settleRetryableBootstrapFailure(
-            db,
-            scope.scopeKey,
-            cachedDownload.cause,
-            {
-              exemptTransportFromCap: false,
-            },
-          );
-          metadataSettled = true;
-          onSnapshotBootstrapError?.({
-            scopeKey: scope.scopeKey,
-            stage: 'download',
-            attempt,
+          const settled = await settleBootstrapFailure(db, scope.scopeKey, {
+            state: retryState,
             cause: cachedDownload.cause,
-            expected,
+            stage: 'download',
+            builtAt: entry.builtAt,
+            now: evaluatedAt,
+            random,
           });
-          skipPagedPull.add(scope.scopeKey);
+          retryState = settled.state;
+          metadataSettled = true;
+          reportSettledFailure(scope, 'download', settled, evaluatedAt);
+          if (shouldSkipPagedPull({ retryState, hasBoardCheckpoint, now: evaluatedAt })) {
+            skipPagedPull.add(scope.scopeKey);
+          }
           continue;
+        }
+
+        // The artifact came down: the link works, so the consecutive-transport
+        // counter (and any cooldown it scheduled) no longer describes anything.
+        const withTransportCleared = clearTransportFailures(retryState);
+        if (withTransportCleared !== retryState) {
+          retryState = await writeBootstrapRetryState(db, scope.scopeKey, withTransportCleared);
+          metadataSettled = true;
         }
 
         try {
@@ -873,8 +1055,14 @@ async function runBootstrapPhase(
             scopeKey: scope.scopeKey,
             filePath: download.filePath,
             onSchemaDrift,
+            // Arms the watermark-regression guard on the heal path: the artifact
+            // may not stamp a checkpoint BELOW what this scope already crawled.
+            existingCheckpoints: hasBoardCheckpoint
+              ? { board_climbs: climbsCheckpoint ?? undefined, board_climb_stats: statsCheckpoint ?? undefined }
+              : undefined,
           });
           await markBootstrapDone(db, scope.scopeKey);
+          if (hasBoardCheckpoint) healedScopes.add(scope.scopeKey);
           metadataSettled = true;
           // Bust the board-table query caches now: if the snapshot fully satisfies
           // the scope, the delta pull returns zero documents and syncTable's
@@ -889,7 +1077,7 @@ async function runBootstrapPhase(
           // checkpoints and fires markScopeDownloadComplete through the tail logic.
         } catch (error) {
           // A wipe mid-import rolls the transaction back and bails the phase — no
-          // attempt (the pull is being torn down, not failing).
+          // burn (the pull is being torn down, not failing).
           if (
             error instanceof SnapshotWipedError ||
             isSigningOut() ||
@@ -897,12 +1085,12 @@ async function runBootstrapPhase(
             isBackgrounded()
           )
             break;
-          if (error instanceof SnapshotSchemaStaleError) {
-            // The artifact predates this client's schema — importing it would
-            // NULL-fill newer columns and stamp the cursor past them forever.
-            // Permanent miss for this run: no attempt burned, and the scope's
-            // paged pull runs NOW (always correct); tonight's export rebuilds the
-            // artifact at the new schema for future fresh scopes.
+          if (error instanceof SnapshotSchemaStaleError || error instanceof SnapshotWatermarkRegressionError) {
+            // Permanent miss for this run, no burn. Schema-stale: the artifact
+            // predates this client's schema, and tonight's export rebuilds it.
+            // Watermark regression: the artifact would have lowered a checkpoint
+            // this scope already crawled past, and it wrote nothing at all.
+            // Either way the scope's paged pull runs NOW, which is always correct.
             await markBootstrapPagedFallback(db, scope.scopeKey);
             metadataSettled = true;
             onSnapshotBootstrapError?.({
@@ -914,18 +1102,23 @@ async function runBootstrapPhase(
             });
             continue;
           }
-          // Import failures always count, transport-shaped or not: the bytes are
-          // already on disk, so nothing about this failure is a network problem.
-          const attempt = await recordRetryableBootstrapFailure(db, scope.scopeKey);
-          metadataSettled = true;
-          onSnapshotBootstrapError?.({
-            scopeKey: scope.scopeKey,
-            stage: 'import',
-            attempt,
+          // The bytes are already on disk, so nothing about this failure is a
+          // network problem: it burns the structural budget, and a differently
+          // built artifact is the only thing that can re-arm it.
+          const settled = await settleBootstrapFailure(db, scope.scopeKey, {
+            state: retryState,
             cause: error,
-            expected: false,
+            stage: 'import',
+            builtAt: entry.builtAt,
+            now: evaluatedAt,
+            random,
           });
-          skipPagedPull.add(scope.scopeKey);
+          retryState = settled.state;
+          metadataSettled = true;
+          reportSettledFailure(scope, 'import', settled, evaluatedAt);
+          if (shouldSkipPagedPull({ retryState, hasBoardCheckpoint, now: evaluatedAt })) {
+            skipPagedPull.add(scope.scopeKey);
+          }
         }
       } finally {
         if (metadataSettled) onBootstrapMetadataChanged?.({ scopeKey: scope.scopeKey });
@@ -937,7 +1130,7 @@ async function runBootstrapPhase(
     }
   }
 
-  return skipPagedPull;
+  return { skipPagedPull, healedScopes };
 }
 
 /**
@@ -1163,20 +1356,22 @@ export async function pullSync(
   // Phase 0: snapshot bootstrap (BEFORE deletions). Only when an adapter injected
   // snapshot I/O; otherwise this is a pure paged pull, byte-identical to before.
   let skipBootstrapPagedPull: Set<string> = new Set();
+  let bootstrapHealedScopes: Set<string> = new Set();
   if (options?.snapshotSource && boardScopes.length > 0) {
     onProgress?.({ phase: 'bootstrap', currentTable: null, documentsProcessed: 0 });
-    skipBootstrapPagedPull = await runBootstrapPhase(
+    const bootstrapPhase = await runBootstrapPhase({
       db,
       queryClient,
-      options.snapshotSource,
-      boardScopes,
+      source: options.snapshotSource,
+      scopes: boardScopes,
       cycleEpoch,
       stampScopeStart,
-      onProgress,
-      options.onSchemaDrift,
-      options.onSnapshotBootstrapError,
-      options.onBootstrapMetadataChanged,
-    );
+      options,
+      now: options.now ?? Date.now,
+      random: options.random ?? Math.random,
+    });
+    skipBootstrapPagedPull = bootstrapPhase.skipPagedPull;
+    bootstrapHealedScopes = bootstrapPhase.healedScopes;
   }
 
   // Deletions FIRST, table pulls second. This ordering is what makes a
@@ -1293,6 +1488,9 @@ export async function pullSync(
         scopeKey,
         method: (await isBootstrapDone(db, scopeKey)) ? 'snapshot' : 'paged',
         durationMs: Date.now() - startedAt,
+        // A healed scope's duration excludes the paged work earlier cycles did,
+        // so it must be filtered out of snapshot-vs-paged comparisons.
+        bootstrapHealed: bootstrapHealedScopes.has(scopeKey),
       });
     }
   }

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -14,10 +14,10 @@ import {
   bootstrapScopeFromSnapshot,
   markBootstrapDone,
   isBootstrapDone,
+  wasBootstrapHealed,
   SnapshotWipedError,
   SnapshotSchemaStaleError,
   SnapshotPermanentMissError,
-  SnapshotWatermarkRegressionError,
   type SnapshotSource,
   type SnapshotBootstrapErrorReporter,
 } from './snapshot-bootstrap';
@@ -33,6 +33,7 @@ import {
   readBootstrapRetryState,
   rearmForNewArtifact,
   shouldSkipPagedPull,
+  spendUserRequest,
   writeBootstrapRetryState,
   type BootstrapFailureKind,
   type BootstrapRetryState,
@@ -706,8 +707,10 @@ async function resolveManifestOnce(
  * Snapshot-bootstrap phase (runs BEFORE deletions). For each enabled scope the
  * shared eligibility gate vouches for, warm it from a pre-built artifact instead
  * of paging the whole catalog. Returns the scope keys whose paged board-table
- * pull must be SKIPPED this cycle, plus the scopes an artifact was imported over
- * a partly-crawled catalog for (see ScopeDownloadCompleteInfo.bootstrapHealed).
+ * pull must be SKIPPED this cycle. Whether an import was a HEAL over a
+ * partly-crawled catalog is persisted on the `bootstrap-done:` marker instead of
+ * returned, because the scope's completion event usually fires cycles later (see
+ * ScopeDownloadCompleteInfo.bootstrapHealed).
  *
  * ELIGIBILITY lives in `bootstrap-retry.ts`'s `evaluateBootstrapEligibility`,
  * which `estimateScopeDownload` calls too so the size the UI quotes can never
@@ -740,11 +743,17 @@ async function resolveManifestOnce(
  *     provably bad, so tonight's export MIGHT fix it: a terminal scope of this
  *     one kind consults the manifest again and a differently-built artifact
  *     re-arms its budget exactly once per scope, ever.
- *   - import throws SnapshotWatermarkRegressionError → permanent miss, NO burn.
- *     The artifact's scoped watermark is behind what this scope already crawled;
- *     importing would lower a checkpoint (and the global deletions cursor) below
- *     local progress. Nothing was written — reported at full severity because it
- *     means the export's scope filter and the client's disagree.
+ *   - import throws SnapshotSchemaStaleError → permanent miss, NO burn: the next
+ *     cycle's manifest pre-check filters the rebuilt entry out before any bytes
+ *     move, so nothing can loop on it.
+ *   - import throws SnapshotWatermarkRegressionError → structural-artifact burn,
+ *     same as any other import failure. The artifact's scoped watermark is behind
+ *     what this scope already crawled; importing would lower a checkpoint (and the
+ *     global deletions cursor) below local progress, so nothing was written.
+ *     Charging it is what stops the loop: the refusal is deterministic for that
+ *     artifact, and before #4313's fix the scope stayed eligible and pulled the
+ *     whole ~100 MB again every cycle, forever. Reported at full severity because
+ *     it means the export's scope filter and the client's disagree.
  *   - success → mark done, rewind deletions to min(watermarks), clear the
  *     consecutive-transport counter; the paged pull runs normally, now a ~1-day
  *     delta from the scoped watermark checkpoints.
@@ -762,9 +771,10 @@ async function resolveManifestOnce(
  * syncTable). One artifact is downloaded per (boardType, layoutId) and reused
  * across that layout's sizes; all downloads are deleted in a finally.
  *
- * Snapshot attribution for ScopeDownloadCompleteInfo.method is NOT threaded
- * through here — it reads the persisted `isBootstrapDone` marker instead,
- * because the completing delta pull can land cycles after the import.
+ * Snapshot attribution for ScopeDownloadCompleteInfo.method and .bootstrapHealed
+ * is NOT threaded through here — both read the persisted `bootstrap-done:` marker
+ * (its presence, and whether its value records a heal), because the completing
+ * delta pull can land cycles after the import.
  */
 async function runBootstrapPhase(params: {
   db: OfflineDatabase;
@@ -777,7 +787,7 @@ async function runBootstrapPhase(params: {
   options: SyncOptions | undefined;
   now: () => number;
   random: () => number;
-}): Promise<{ skipPagedPull: Set<string>; healedScopes: Set<string> }> {
+}): Promise<{ skipPagedPull: Set<string> }> {
   const { db, queryClient, source, scopes, cycleEpoch, stampScopeStart, options, now, random } = params;
   const onProgress = options?.onProgress;
   const onSchemaDrift = options?.onSchemaDrift;
@@ -786,7 +796,6 @@ async function runBootstrapPhase(params: {
   const isOnUnmeteredNetwork = options?.isOnUnmeteredNetwork ?? (() => true);
 
   const skipPagedPull = new Set<string>();
-  const healedScopes = new Set<string>();
   const manifestCache: { value?: ManifestResolution } = {};
   // Absent = not yet attempted; `file: null` = download failed (with its cause).
   const downloadByLayout = new Map<
@@ -854,7 +863,10 @@ async function runBootstrapPhase(params: {
         let retryState = migratedState;
         // Persist the derived state on first touch so the spread-out post-OTA
         // retryAfter is stable across launches instead of being re-rolled every
-        // cycle. The legacy rows are deliberately LEFT IN PLACE (rollback).
+        // cycle. The legacy ROWS survive (a rolled-back bundle still finds them),
+        // but this write does re-stamp `bootstrap-attempts:` down to the mirrored
+        // value — the migration grants one clean pass, and the mirror has to say
+        // so or a rollback would re-read the pre-migration count.
         if (migratedFromLegacy && retryState.hasPriorSnapshotFailure) {
           retryState = await writeBootstrapRetryState(db, scope.scopeKey, retryState);
           metadataSettled = true;
@@ -967,21 +979,43 @@ async function runBootstrapPhase(params: {
             ? ('heal-over-partial' as const)
             : ('fresh' as const);
 
+        // The one path the climber DID ask for today: "Try the fast download
+        // again", behind the same size-disclosing confirm the enable toggle
+        // uses. It reads as consent for this one download, so it overrides the
+        // metered defer below — without it the tap is a silent no-op on
+        // cellular, because a settled scope always carries board checkpoints and
+        // therefore always heals rather than bootstrapping fresh.
+        const isUserRequested = retryState.userRequested;
+
         // The automatic heal is the one path that downloads ~100 MB for a board
         // the user enabled on some earlier day. Defer it on a metered link; a
         // fresh bootstrap (confirmed behind a size-disclosing dialog moments ago)
         // and a user-requested retry are consented and ignore the probe.
-        if (bootstrapKind === 'heal-over-partial' && !isOnUnmeteredNetwork()) {
+        if (bootstrapKind === 'heal-over-partial' && !isUserRequested && !isOnUnmeteredNetwork()) {
           retryState = await writeBootstrapRetryState(db, scope.scopeKey, deferHeal(retryState, evaluatedAt));
           metadataSettled = true;
           continue;
+        }
+
+        // Spend the request BEFORE the download: one tap buys one artifact, so a
+        // failure schedules an ordinary cooldown instead of leaving a standing
+        // metered-link override that keeps pulling ~100 MB over cellular.
+        if (isUserRequested) {
+          retryState = await writeBootstrapRetryState(db, scope.scopeKey, spendUserRequest(retryState));
+          metadataSettled = true;
         }
 
         if (retryState.hasPriorSnapshotFailure) {
           options?.onBootstrapPathRecovered?.({
             scopeKey: scope.scopeKey,
             boardType: scope.boardType,
-            trigger: isRearmCandidate ? 'new-artifact' : migratedFromLegacy ? 'legacy-migration' : 'cooldown',
+            trigger: isUserRequested
+              ? 'user-request'
+              : isRearmCandidate
+                ? 'new-artifact'
+                : migratedFromLegacy
+                  ? 'legacy-migration'
+                  : 'cooldown',
             hadBoardCheckpoint: hasBoardCheckpoint,
           });
         }
@@ -1061,8 +1095,11 @@ async function runBootstrapPhase(params: {
               ? { board_climbs: climbsCheckpoint ?? undefined, board_climb_stats: statsCheckpoint ?? undefined }
               : undefined,
           });
-          await markBootstrapDone(db, scope.scopeKey);
-          if (hasBoardCheckpoint) healedScopes.add(scope.scopeKey);
+          // The heal flag rides the persisted marker, not a per-cycle set: the
+          // scope usually reaches completion in a LATER cycle (board_climb_grades
+          // is not a snapshot table and still crawls), and an in-memory set
+          // reports false for exactly the runs the flag exists to filter out.
+          await markBootstrapDone(db, scope.scopeKey, { healed: hasBoardCheckpoint });
           metadataSettled = true;
           // Bust the board-table query caches now: if the snapshot fully satisfies
           // the scope, the delta pull returns zero documents and syncTable's
@@ -1085,12 +1122,17 @@ async function runBootstrapPhase(params: {
             isBackgrounded()
           )
             break;
-          if (error instanceof SnapshotSchemaStaleError || error instanceof SnapshotWatermarkRegressionError) {
-            // Permanent miss for this run, no burn. Schema-stale: the artifact
-            // predates this client's schema, and tonight's export rebuilds it.
-            // Watermark regression: the artifact would have lowered a checkpoint
-            // this scope already crawled past, and it wrote nothing at all.
-            // Either way the scope's paged pull runs NOW, which is always correct.
+          if (error instanceof SnapshotSchemaStaleError) {
+            // Permanent miss for this run, no burn: the artifact predates this
+            // client's schema and tonight's export rebuilds it at the new one, so
+            // the next cycle's cheap manifest pre-check (isSnapshotEntryUsable)
+            // filters it out before any bytes move. The scope's paged pull runs
+            // NOW, which is always correct.
+            //
+            // The watermark regression deliberately does NOT land here — it is a
+            // structural failure, charged below. Refusing without recording the
+            // refusal left the scope exactly as eligible as it was, so the same
+            // ~100 MB artifact came down again on every cycle, forever.
             await markBootstrapPagedFallback(db, scope.scopeKey);
             metadataSettled = true;
             onSnapshotBootstrapError?.({
@@ -1104,7 +1146,10 @@ async function runBootstrapPhase(params: {
           }
           // The bytes are already on disk, so nothing about this failure is a
           // network problem: it burns the structural budget, and a differently
-          // built artifact is the only thing that can re-arm it.
+          // built artifact is the only thing that can re-arm it. A watermark
+          // regression is charged here too — the artifact on offer provably
+          // cannot serve this scope, and only a rebuilt one (with a watermark
+          // past the local checkpoint, or a fixed scope filter) can change that.
           const settled = await settleBootstrapFailure(db, scope.scopeKey, {
             state: retryState,
             cause: error,
@@ -1130,7 +1175,7 @@ async function runBootstrapPhase(params: {
     }
   }
 
-  return { skipPagedPull, healedScopes };
+  return { skipPagedPull };
 }
 
 /**
@@ -1356,7 +1401,6 @@ export async function pullSync(
   // Phase 0: snapshot bootstrap (BEFORE deletions). Only when an adapter injected
   // snapshot I/O; otherwise this is a pure paged pull, byte-identical to before.
   let skipBootstrapPagedPull: Set<string> = new Set();
-  let bootstrapHealedScopes: Set<string> = new Set();
   if (options?.snapshotSource && boardScopes.length > 0) {
     onProgress?.({ phase: 'bootstrap', currentTable: null, documentsProcessed: 0 });
     const bootstrapPhase = await runBootstrapPhase({
@@ -1371,7 +1415,6 @@ export async function pullSync(
       random: options.random ?? Math.random,
     });
     skipBootstrapPagedPull = bootstrapPhase.skipPagedPull;
-    bootstrapHealedScopes = bootstrapPhase.healedScopes;
   }
 
   // Deletions FIRST, table pulls second. This ordering is what makes a
@@ -1479,18 +1522,18 @@ export async function pullSync(
       // loop for every scope. If that invariant breaks, skip telemetry rather
       // than emit a misleading 0ms duration.
       if (startedAt === undefined) continue;
-      // Attribution reads the persisted marker, not this run's bootstrap set:
-      // the import and the completing delta pull can land in different cycles
-      // (connectivity drop between them), and this event fires exactly once per
-      // scope — misreporting that one event as 'paged' would permanently
-      // undercount snapshot wins in the rollout comparison.
+      // Both attributions read the persisted marker, not this run's bootstrap
+      // work: the import and the completing delta pull can land in different
+      // cycles (connectivity drop between them, or the grades crawl still
+      // running), and this event fires exactly once per scope — misreporting
+      // that one event would permanently skew the rollout comparison.
       options?.onScopeDownloadComplete?.({
         scopeKey,
         method: (await isBootstrapDone(db, scopeKey)) ? 'snapshot' : 'paged',
         durationMs: Date.now() - startedAt,
         // A healed scope's duration excludes the paged work earlier cycles did,
         // so it must be filtered out of snapshot-vs-paged comparisons.
-        bootstrapHealed: bootstrapHealedScopes.has(scopeKey),
+        bootstrapHealed: await wasBootstrapHealed(db, scopeKey),
       });
     }
   }

--- a/packages/shared/offline-sync/src/sync/scope-teardown.ts
+++ b/packages/shared/offline-sync/src/sync/scope-teardown.ts
@@ -32,12 +32,13 @@ import { applyBusyTimeout } from '../db/pragmas';
 import type { OfflineBoardScope } from '../offline-board-key';
 import { climbsScopeFilter, isSizeScopedBoard, sizeMembershipClause } from './board-scope-sql';
 import { getCheckpointKey, SCOPE_COMPLETE_PREFIX } from './checkpoints';
+import { BOOTSTRAP_DONE_PREFIX } from './snapshot-bootstrap';
 import {
   BOOTSTRAP_ATTEMPTS_HEALED_PREFIX,
   BOOTSTRAP_ATTEMPTS_PREFIX,
-  BOOTSTRAP_DONE_PREFIX,
   BOOTSTRAP_PAGED_FALLBACK_PREFIX,
-} from './snapshot-bootstrap';
+  BOOTSTRAP_RETRY_PREFIX,
+} from './bootstrap-retry';
 import { BOARD_DATA_TABLES } from './table-config';
 
 /** One scope's measured footprint. `estimatedBytes` is an apportionment — see getScopeUsage. */
@@ -75,6 +76,9 @@ export function scopeSyncMetaKeys(scopeKey: string): string[] {
     `${BOOTSTRAP_ATTEMPTS_HEALED_PREFIX}${scopeKey}`,
     `${BOOTSTRAP_DONE_PREFIX}${scopeKey}`,
     `${BOOTSTRAP_PAGED_FALLBACK_PREFIX}${scopeKey}`,
+    // The retry budgets + cooldown (issue #4313). Re-adding the board must give
+    // the scope a clean slate, not a terminal verdict it earned before removal.
+    `${BOOTSTRAP_RETRY_PREFIX}${scopeKey}`,
   ];
 }
 

--- a/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
@@ -279,11 +279,29 @@ export async function getBootstrapMetadataByScope(
   return metadataByScope;
 }
 
-/** Permanent "this scope was warmed from a snapshot" marker (cheap, unambiguous). */
-export async function markBootstrapDone(db: SqlExecutor, scopeKey: string): Promise<void> {
+/** The `bootstrap-done:` value that records a heal over a partly-crawled catalog. */
+const BOOTSTRAP_DONE_HEAL_VALUE = 'heal';
+
+/**
+ * Permanent "this scope was warmed from a snapshot" marker (cheap, unambiguous).
+ *
+ * The VALUE carries whether the import landed on a scope that had already
+ * crawled rows (`healed`), because `ScopeDownloadCompleteInfo.bootstrapHealed`
+ * is read at scope completion — which is routinely a LATER cycle than the
+ * import, since `board_climb_grades` is not a snapshot table and still crawls to
+ * its tail. An in-memory per-cycle set would report `false` for exactly the
+ * population the field exists to filter out. Legacy rows hold `'1'`, which reads
+ * as done-and-not-healed — correct for every scope written before this marker
+ * carried a value.
+ */
+export async function markBootstrapDone(
+  db: SqlExecutor,
+  scopeKey: string,
+  options?: { healed: boolean },
+): Promise<void> {
   await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
     `${BOOTSTRAP_DONE_PREFIX}${scopeKey}`,
-    '1',
+    options?.healed ? BOOTSTRAP_DONE_HEAL_VALUE : '1',
   ]);
   // Write done first: if clearing the stale outcome fails, done still outranks
   // it in derivation. The reverse order has a crash window that mislabels a
@@ -296,6 +314,14 @@ export async function isBootstrapDone(db: SqlExecutor, scopeKey: string): Promis
     `${BOOTSTRAP_DONE_PREFIX}${scopeKey}`,
   ]);
   return row !== null;
+}
+
+/** Whether this scope's snapshot import was a heal over an existing partial crawl. */
+export async function wasBootstrapHealed(db: SqlExecutor, scopeKey: string): Promise<boolean> {
+  const row = await db.getFirstAsync<{ value: string }>('SELECT value FROM sync_meta WHERE key = ?', [
+    `${BOOTSTRAP_DONE_PREFIX}${scopeKey}`,
+  ]);
+  return row?.value === BOOTSTRAP_DONE_HEAL_VALUE;
 }
 
 // --- Column helpers -----------------------------------------------------------

--- a/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
@@ -34,6 +34,15 @@ import {
 import { getWipeEpoch, isSigningOut } from '../mutation-queue/drainer';
 import { LATEST_SCHEMA_VERSION } from '../db/migrations';
 import { applyBusyTimeout } from '../db/pragmas';
+import {
+  BOOTSTRAP_ATTEMPTS_PREFIX,
+  BOOTSTRAP_PAGED_FALLBACK_PREFIX,
+  BOOTSTRAP_RETRY_PREFIX,
+  clearBootstrapPagedFallback,
+  isTerminal,
+  parseBootstrapRetryState,
+  type BootstrapRetryState,
+} from './bootstrap-retry';
 import type { SchemaDriftReporter } from './pull-client';
 
 /** The two reference tables a snapshot carries; import order is climbs → stats. */
@@ -42,24 +51,11 @@ const SNAPSHOT_TABLES = ['board_climbs', 'board_climb_stats'] as const;
 /** The ATTACH alias for the artifact; the only ATTACH the DB lifecycle performs. */
 const SNAPSHOT_ALIAS = 'bs_snapshot';
 
-/** Two bootstrap attempts, then a scope falls through to the normal paged crawl. */
-export const MAX_BOOTSTRAP_ATTEMPTS = 2;
-
 // Package-internal (deliberately NOT re-exported from index.ts, same posture as
-// checkpoints.ts's DELETIONS_CHECKPOINT_KEY): scope-teardown.ts must clear these
-// alongside the rows they describe, so it needs the exact key spelling.
-export const BOOTSTRAP_ATTEMPTS_PREFIX = 'bootstrap-attempts:';
+// checkpoints.ts's DELETIONS_CHECKPOINT_KEY): scope-teardown.ts must clear this
+// alongside the rows it describes, so it needs the exact key spelling. The
+// retry-accounting keys live in bootstrap-retry.ts, which owns their writes.
 export const BOOTSTRAP_DONE_PREFIX = 'bootstrap-done:';
-export const BOOTSTRAP_PAGED_FALLBACK_PREFIX = 'bootstrap-paged-fallback:';
-/**
- * "This scope has already spent its one free counter reset." Written alongside
- * `resetBootstrapAttempts` when `runBootstrapPhase` heals an over-cap scope that
- * turns out to have a perfectly usable artifact waiting for it (issue #4238:
- * two launches in airplane mode used to disqualify a board from the fast path
- * forever). Bounding the heal to once per scope is what keeps a genuinely broken
- * 272 MB artifact from being re-downloaded on every launch.
- */
-export const BOOTSTRAP_ATTEMPTS_HEALED_PREFIX = 'bootstrap-attempts-healed:';
 const EPOCH_WATERMARK: SyncCheckpoint = { updatedAt: '1970-01-01T00:00:00.000Z', syncSeq: '0' };
 
 // Only snake_case identifiers may be spliced into the INSERT/SELECT column list.
@@ -149,16 +145,26 @@ export class SnapshotPermanentMissError extends Error {
 // describe, which survive as the shared cache) ---------------------------------
 
 export type BootstrapScopeMetadata = {
-  /** Counted transient bootstrap failures persisted for this scope. */
+  /**
+   * The legacy `bootstrap-attempts:` mirror. Kept for rollback compatibility and
+   * for callers that only want "has this scope failed before"; the budgets the
+   * engine actually enforces are `structuralFailures` / `isTerminal` below.
+   */
   readonly attempts: number;
   /** The scope has imported a snapshot, even if its delta pull has not finished yet. */
   readonly isBootstrapDone: boolean;
   /** The latest bootstrap decision for this scope selected the ordinary paged crawl. */
   readonly isPagedFallback: boolean;
-  /** Either board table has a checkpoint, so the scope is no longer bootstrap-eligible. */
+  /** Either board table has a checkpoint. */
   readonly hasBoardCheckpoint: boolean;
   /** The whole scope has reached the tail and can serve complete offline results. */
   readonly isScopeComplete: boolean;
+  /** Epoch ms of the next scheduled snapshot retry, or null when none is pending. */
+  readonly retryAfter: number | null;
+  /** Structural (artifact/device) failures spent from the current budget. */
+  readonly structuralFailures: number;
+  /** Both budgets are spent: only a user-requested retry or a teardown revives it. */
+  readonly isTerminal: boolean;
 };
 
 type MutableBootstrapScopeMetadata = {
@@ -168,37 +174,28 @@ type MutableBootstrapScopeMetadata = {
 const BOARD_CLIMBS_CHECKPOINT_PREFIX = 'checkpoint:board_climbs:';
 const BOARD_STATS_CHECKPOINT_PREFIX = 'checkpoint:board_climb_stats:';
 
-// GLOB's literal-prefix optimization uses sync_meta's binary primary-key index.
-// SQLite's default case-insensitive LIKE cannot use that index and scans every
-// metadata row, which is especially expensive after years of sync checkpoints.
-export const BOOTSTRAP_METADATA_QUERY = `SELECT key, value
-  FROM sync_meta
-  WHERE key GLOB ?
-     OR key GLOB ?
-     OR key GLOB ?
-     OR key GLOB ?
-     OR key GLOB ?
-     OR key GLOB ?`;
-
 export const BOOTSTRAP_METADATA_PATTERNS = [
   `${BOOTSTRAP_ATTEMPTS_PREFIX}*`,
   `${BOOTSTRAP_DONE_PREFIX}*`,
   `${BOOTSTRAP_PAGED_FALLBACK_PREFIX}*`,
+  `${BOOTSTRAP_RETRY_PREFIX}*`,
   `${BOARD_CLIMBS_CHECKPOINT_PREFIX}*`,
   `${BOARD_STATS_CHECKPOINT_PREFIX}*`,
   `${SCOPE_COMPLETE_PREFIX}*`,
 ] as const;
 
+// GLOB's literal-prefix optimization uses sync_meta's binary primary-key index.
+// SQLite's default case-insensitive LIKE cannot use that index and scans every
+// metadata row, which is especially expensive after years of sync checkpoints.
+// Built FROM the pattern list rather than hand-written, so adding a prefix can
+// never leave a dangling clause or drop one silently (a test pins the counts).
+export const BOOTSTRAP_METADATA_QUERY = `SELECT key, value
+  FROM sync_meta
+  WHERE ${BOOTSTRAP_METADATA_PATTERNS.map(() => 'key GLOB ?').join('\n     OR ')}`;
+
 function parseBootstrapAttempts(value: string): number {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : 0;
-}
-
-export async function getBootstrapAttempts(db: SqlExecutor, scopeKey: string): Promise<number> {
-  const row = await db.getFirstAsync<{ value: string }>('SELECT value FROM sync_meta WHERE key = ?', [
-    `${BOOTSTRAP_ATTEMPTS_PREFIX}${scopeKey}`,
-  ]);
-  return row ? parseBootstrapAttempts(row.value) : 0;
 }
 
 /**
@@ -231,6 +228,9 @@ export async function getBootstrapMetadataByScope(
     const fallbackScopeKey = row.key.startsWith(BOOTSTRAP_PAGED_FALLBACK_PREFIX)
       ? row.key.slice(BOOTSTRAP_PAGED_FALLBACK_PREFIX.length)
       : null;
+    const retryScopeKey = row.key.startsWith(BOOTSTRAP_RETRY_PREFIX)
+      ? row.key.slice(BOOTSTRAP_RETRY_PREFIX.length)
+      : null;
     const climbsCheckpointScopeKey = row.key.startsWith(BOARD_CLIMBS_CHECKPOINT_PREFIX)
       ? row.key.slice(BOARD_CLIMBS_CHECKPOINT_PREFIX.length)
       : null;
@@ -244,6 +244,7 @@ export async function getBootstrapMetadataByScope(
       attemptsScopeKey ??
       doneScopeKey ??
       fallbackScopeKey ??
+      retryScopeKey ??
       climbsCheckpointScopeKey ??
       statsCheckpointScopeKey ??
       completeScopeKey;
@@ -255,65 +256,27 @@ export async function getBootstrapMetadataByScope(
       isPagedFallback: false,
       hasBoardCheckpoint: false,
       isScopeComplete: false,
+      retryAfter: null,
+      structuralFailures: 0,
+      isTerminal: false,
     };
     if (attemptsScopeKey) existing.attempts = parseBootstrapAttempts(row.value);
     if (doneScopeKey) existing.isBootstrapDone = true;
     if (fallbackScopeKey) existing.isPagedFallback = true;
+    if (retryScopeKey) {
+      const retryState: BootstrapRetryState | null = parseBootstrapRetryState(row.value);
+      if (retryState) {
+        existing.retryAfter = retryState.retryAfter;
+        existing.structuralFailures = retryState.structuralFailures;
+        existing.isTerminal = isTerminal(retryState);
+      }
+    }
     if (climbsCheckpointScopeKey || statsCheckpointScopeKey) existing.hasBoardCheckpoint = true;
     if (completeScopeKey) existing.isScopeComplete = true;
     metadataByScope.set(scopeKey, existing);
   }
 
   return metadataByScope;
-}
-
-/** Increments the attempt counter for a scope and returns the new count. */
-export async function recordBootstrapAttempt(db: SqlExecutor, scopeKey: string): Promise<number> {
-  const next = (await getBootstrapAttempts(db, scopeKey)) + 1;
-  await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
-    `${BOOTSTRAP_ATTEMPTS_PREFIX}${scopeKey}`,
-    String(next),
-  ]);
-  return next;
-}
-
-/**
- * Drop a scope's attempt counter entirely, making it bootstrap-eligible again.
- * Only `runBootstrapPhase`'s one-shot heal calls this, and only once per scope
- * (guarded by the healed marker below) — an unbounded reset would re-download a
- * broken artifact on every launch.
- */
-export async function resetBootstrapAttempts(db: SqlExecutor, scopeKey: string): Promise<void> {
-  await db.runAsync('DELETE FROM sync_meta WHERE key = ?', [`${BOOTSTRAP_ATTEMPTS_PREFIX}${scopeKey}`]);
-}
-
-/** True once this scope has spent its single attempt-counter heal. */
-export async function hasHealedBootstrapAttempts(db: SqlExecutor, scopeKey: string): Promise<boolean> {
-  const row = await db.getFirstAsync<{ key: string }>('SELECT key FROM sync_meta WHERE key = ?', [
-    `${BOOTSTRAP_ATTEMPTS_HEALED_PREFIX}${scopeKey}`,
-  ]);
-  return row !== null;
-}
-
-/** Record that this scope's one attempt-counter heal has been spent. */
-export async function markBootstrapAttemptsHealed(db: SqlExecutor, scopeKey: string): Promise<void> {
-  await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
-    `${BOOTSTRAP_ATTEMPTS_HEALED_PREFIX}${scopeKey}`,
-    '1',
-  ]);
-}
-
-/** Persist that the latest bootstrap decision selected the ordinary paged crawl. */
-export async function markBootstrapPagedFallback(db: SqlExecutor, scopeKey: string): Promise<void> {
-  await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
-    `${BOOTSTRAP_PAGED_FALLBACK_PREFIX}${scopeKey}`,
-    '1',
-  ]);
-}
-
-/** A new eligible snapshot attempt supersedes a prior run's paged decision. */
-export async function clearBootstrapPagedFallback(db: SqlExecutor, scopeKey: string): Promise<void> {
-  await db.runAsync('DELETE FROM sync_meta WHERE key = ?', [`${BOOTSTRAP_PAGED_FALLBACK_PREFIX}${scopeKey}`]);
 }
 
 /** Permanent "this scope was warmed from a snapshot" marker (cheap, unambiguous). */
@@ -579,6 +542,31 @@ export class SnapshotSchemaStaleError extends Error {
 }
 
 /**
+ * Thrown when the artifact's scoped watermark sits BEHIND the checkpoint this
+ * scope has already crawled to. Importing anyway would lower
+ * `checkpoint:board_climbs:<scope>` — destroying exactly the crawl progress a
+ * heal-over-partial exists to rescue — and rewind the single global deletions
+ * cursor with it. Two reachable causes, both refused for the same reason:
+ *
+ *  - the artifact holds NO row matching this scope's filter, so `tableWatermark`
+ *    returns the epoch (a size whose `compatible_size_ids` never matches, or any
+ *    scope-filter drift between export and client), and
+ *  - the local crawl already ran past the artifact's watermark.
+ *
+ * Nothing is written on this path: no rows, no checkpoint, no deletions rewind.
+ * Reported at full severity — it means the export's scope filter and the
+ * client's disagree, which is a real signal, not a flaky network.
+ */
+export class SnapshotWatermarkRegressionError extends Error {
+  constructor(tableName: SnapshotTableName, artifact: SyncCheckpoint, local: SyncCheckpoint) {
+    super(
+      `snapshot bootstrap: ${tableName} artifact watermark ${artifact.updatedAt}/${artifact.syncSeq} is behind local checkpoint ${local.updatedAt}/${local.syncSeq}`,
+    );
+    this.name = 'SnapshotWatermarkRegressionError';
+  }
+}
+
+/**
  * Read + validate the artifact's `snapshot_meta`: every snapshot table present,
  * `format_version` matching this client, `schema_version` not older than this
  * client's schema, and each recorded `row_count` equal to the artifact's ACTUAL
@@ -643,8 +631,15 @@ export async function bootstrapScopeFromSnapshot(params: {
   scopeKey: string;
   filePath: string;
   onSchemaDrift?: SchemaDriftReporter;
+  /**
+   * The scope's CURRENT board-table checkpoints, when it already has any (the
+   * heal-over-partial path — the caller read them for its eligibility check).
+   * Supplying them arms the watermark-regression guard; omitting them is the
+   * fresh-scope case, where there is no progress to protect.
+   */
+  existingCheckpoints?: Partial<Record<SnapshotTableName, SyncCheckpoint>>;
 }): Promise<SnapshotBootstrapResult> {
-  const { db, scope, scopeKey, filePath, onSchemaDrift } = params;
+  const { db, scope, scopeKey, filePath, onSchemaDrift, existingCheckpoints } = params;
 
   // The whole import + checkpoint stamping is all-or-nothing. A wipe that runs
   // (or starts AND finishes) across ANY await below — including the ATTACH,
@@ -675,6 +670,18 @@ export async function bootstrapScopeFromSnapshot(params: {
 
         await verifySnapshotMeta(txn);
         watermarks = await scopedWatermarks(txn, scope);
+
+        // Refuse BEFORE the exclusive transaction opens, so a regression writes
+        // nothing at all — see SnapshotWatermarkRegressionError.
+        if (existingCheckpoints) {
+          for (const tableName of SNAPSHOT_TABLES) {
+            const localCheckpoint = existingCheckpoints[tableName];
+            if (!localCheckpoint) continue;
+            if (compareCheckpoints(watermarks[tableName], localCheckpoint) < 0) {
+              throw new SnapshotWatermarkRegressionError(tableName, watermarks[tableName], localCheckpoint);
+            }
+          }
+        }
 
         if (isSigningOut() || getWipeEpoch() !== startEpoch) throw new SnapshotWipedError();
 

--- a/packages/shared/offline-sync/src/sync/snapshot-estimate.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-estimate.ts
@@ -4,9 +4,11 @@
 // The manifest already carries every number this needs (`bytes` per artifact,
 // `rowCount` per table) — the hard part is knowing WHEN that number is the truth.
 // A scope only downloads an artifact if the snapshot bootstrap would actually run
-// for it, and `runBootstrapPhase` (pull-client.ts) is the authority on that. The
-// rules are duplicated nowhere: `findSnapshotEntry` is shared with the engine, and
-// the checkpoint/attempt gates below mirror its eligibility check one-for-one.
+// for it, so this CALLS the engine's own gate (`evaluateBootstrapEligibility`)
+// rather than re-stating it. It used to carry a copy of the checkpoint/attempt
+// rules with a comment promising they mirrored `runBootstrapPhase` one-for-one;
+// heal-over-partial (issue #4313) made both of those rules wrong at once, which
+// is why the mirror is now a literal shared call.
 //
 // Getting this wrong is worse than showing nothing. A board that was downloaded
 // once and toggled off keeps its rows + checkpoints on purpose (see
@@ -18,7 +20,7 @@
 // and cached it) and the scope's local checkpoint/attempt state.
 
 import type { SnapshotManifest, SnapshotManifestEntry } from './snapshot-manifest';
-import { MAX_BOOTSTRAP_ATTEMPTS } from './snapshot-bootstrap';
+import { evaluateBootstrapEligibility, type BootstrapRetryState } from './bootstrap-retry';
 import { LATEST_SCHEMA_VERSION } from '../db/migrations';
 
 export type SnapshotDownloadEstimate =
@@ -72,23 +74,35 @@ export function isSnapshotEntryUsable(entry: SnapshotManifestEntry): boolean {
  *
  * - `manifest` is null: not fetched yet, unreachable, unparseable, or the
  *   snapshot path is switched off entirely (flag/base URL) so nothing is downloaded.
- * - `hasExistingCheckpoint`: the scope already pulled rows, so it is permanently
- *   past bootstrap eligibility and resumes as a delta.
- * - attempts at the cap: the engine has given up on the snapshot for this scope.
+ * - the engine's gate says no: a scope that already serves the full catalog, one
+ *   that already imported an artifact, one mid-cooldown, one whose budgets are
+ *   spent, and a mid-crawl scope with no snapshot failures behind it all resume
+ *   as a delta or a crawl instead of downloading.
  * - no entry for the layout: not exported yet.
  * - schema-stale entry: rejected before the download (`isSnapshotEntryUsable`).
+ *
+ * `userRequested` is the "Try the fast download again" path: the user has asked
+ * for the artifact explicitly, so the size must be quoted from the entry even
+ * though the scope's persisted state is currently terminal — restoring the
+ * budget is the action the dialog is confirming.
  */
 export function estimateScopeDownload(input: {
   manifest: SnapshotManifest | null;
   boardType: string;
   layoutId: number;
-  hasExistingCheckpoint: boolean;
-  bootstrapAttempts: number;
+  retryState: BootstrapRetryState;
+  hasBoardCheckpoint: boolean;
+  isScopeComplete: boolean;
+  isBootstrapDone: boolean;
+  now: number;
+  userRequested?: boolean;
 }): SnapshotDownloadEstimate {
-  const { manifest, boardType, layoutId, hasExistingCheckpoint, bootstrapAttempts } = input;
+  const { manifest, boardType, layoutId, userRequested } = input;
   if (!manifest) return { kind: 'unknown' };
-  if (hasExistingCheckpoint) return { kind: 'unknown' };
-  if (bootstrapAttempts >= MAX_BOOTSTRAP_ATTEMPTS) return { kind: 'unknown' };
+  if (!userRequested && !evaluateBootstrapEligibility(input).eligible) return { kind: 'unknown' };
+  // Even a user-requested retry cannot download over a catalog that is already
+  // complete or already snapshot-warmed — the engine would refuse it too.
+  if (userRequested && (input.isScopeComplete || input.isBootstrapDone)) return { kind: 'unknown' };
 
   const entry = findSnapshotEntry(manifest, boardType, layoutId);
   if (!entry) return { kind: 'unknown' };

--- a/packages/shared/offline-sync/src/sync/sync-scheduler.ts
+++ b/packages/shared/offline-sync/src/sync/sync-scheduler.ts
@@ -7,6 +7,8 @@ import {
   type ScopeDownloadCompleteReporter,
   type CoverageResetReporter,
   type CoverageEvaluatedReporter,
+  type BootstrapRetryScheduledReporter,
+  type BootstrapPathRecoveredReporter,
 } from './pull-client';
 import type { SnapshotSource, SnapshotBootstrapErrorReporter } from './snapshot-bootstrap';
 
@@ -75,6 +77,15 @@ export type SchedulerOptions = {
   onCoverageReset?: CoverageResetReporter;
   /** Threaded through to pullSync's SyncOptions — see CoverageEvaluatedInfo. */
   onCoverageEvaluated?: CoverageEvaluatedReporter;
+  /** Threaded through to pullSync's SyncOptions — see BootstrapRetryScheduledInfo. */
+  onBootstrapRetryScheduled?: BootstrapRetryScheduledReporter;
+  /** Threaded through to pullSync's SyncOptions — see BootstrapPathRecoveredInfo. */
+  onBootstrapPathRecovered?: BootstrapPathRecoveredReporter;
+  /**
+   * Threaded through to pullSync's SyncOptions. Only the automatic heal of a
+   * partly-crawled scope consults it (issue #4313).
+   */
+  isOnUnmeteredNetwork?: () => boolean;
 };
 
 let isSyncing = false;
@@ -117,6 +128,9 @@ async function runSync(
       onScopeDownloadComplete: options?.onScopeDownloadComplete,
       onCoverageReset: options?.onCoverageReset,
       onCoverageEvaluated: options?.onCoverageEvaluated,
+      onBootstrapRetryScheduled: options?.onBootstrapRetryScheduled,
+      onBootstrapPathRecovered: options?.onBootstrapPathRecovered,
+      isOnUnmeteredNetwork: options?.isOnUnmeteredNetwork,
     });
   } catch (error) {
     options?.onCycleError?.(error);


### PR DESCRIPTION
## Why

`MAX_BOOTSTRAP_ATTEMPTS = 2` was doing two jobs at once, and #4313 is the story of them being fused.

It was the **retry policy** — there isn't one; the ~100 MB artifact GET is unresumable and never retried — and it was the **total-spend bound**, the thing stopping a device from restarting that GET on every foreground. Because a dropped connection at the *download* stage burned the same counter a corrupt artifact does (`settleRetryableBootstrapFailure(..., { exemptTransportFromCap: false })`), **two bad-reception launches condemned a board to the 400+-round-trip paged crawl for the life of the install**. Sentry over 60 days: 123 snapshot-bootstrap transport failures across 75 users, with `UnableToDownloadException: The request timed out` — which `isNetworkError` classifies as transport — as the headline cause.

Worse, the strand locked itself in. An over-cap scope was not added to `skipPagedPull`, so the same cycle's crawl wrote `checkpoint:board_climbs:<scope>`, and the first eligibility check (`if (climbsCheckpoint || statsCheckpoint) continue`) disqualified the scope from the snapshot path forever. The #4238 one-shot heal is spent once per scope and never comes back.

This splits the two jobs. Kind-specific budgets bound **total spend**; a persisted cooldown ladder bounds **frequency**. Both, always — an exemption without a budget would be the failure the old comment at `pull-client.ts:554-563` was guarding against.

## Changes

**New `packages/shared/offline-sync/src/sync/bootstrap-retry.ts`** — the whole decision surface, pure (clock and jitter injected), plus its persistence:

| Kind | Raised by | Budget | Cooldown | Re-armed by a new `builtAt`? |
| --- | --- | --- | --- | --- |
| `transport` | `isNetworkError(cause)` at the download stage | 3 consecutive, reset by any successful download | 2 min → 15 min → 2 h | no |
| `structural-artifact` | anything thrown inside the import | 2 | 6 h → 24 h | yes — **once per scope, lifetime** |
| `structural-device` | every other non-transport cause (disk, cache dir, CDN non-2xx, unclassifiable) | 2 | 6 h → 24 h | **no** |

The manifest stage stays entirely free for transport failures, exactly as #4238 shipped. `structural-device` is the conservative default because a plain `Error` from an adapter's downloader can't be told apart from a device fault — and the export is **nightly**, so a `builtAt` reset for a disk-full phone would be 2 × ~100 MB every day, forever.

**Worst-case lifetime spend per scope: 7 artifact downloads** (3 + 2 + 2), each behind at least one cooldown rung. A test drives 40 cycles against an injected clock and asserts the `downloadArtifact` call count, so loosening it shows up in a diff.

- **Heal-over-partial.** A scope that has checkpoints, never reached `scope-complete:`, and carries snapshot-path failures can now import an artifact over its partial catalog. A `scope-complete:` scope is never healed — it already serves the whole thing locally.
- **`SnapshotWatermarkRegressionError`.** `bootstrapScopeFromSnapshot` takes the scope's current checkpoints on the heal path and refuses — before the exclusive transaction opens, so **nothing at all is written** — when the artifact's scoped watermark is behind them. Covers both hazards at once: an artifact whose scope filter matches zero rows (`tableWatermark` returns the epoch) and a crawl that already ran past the artifact. Without it the import would lower `checkpoint:board_climbs` and rewind the single global deletions cursor with it. The refusal **spends the structural-artifact budget**, like any other import failure: it is deterministic for a given artifact (local checkpoints only move forward), so a refusal that recorded nothing left the scope as eligible as before and pulled the whole ~100 MB again every single cycle, forever. A five-cycle test pins the download count.
- **One eligibility function, two callers.** `evaluateBootstrapEligibility` is called by `runBootstrapPhase` *and* `estimateScopeDownload`. `snapshot-estimate.ts` used to carry a copy of the rules under a comment promising they mirrored the engine "one-for-one"; heal-over-partial made both copies wrong at once. A parity table in the tests pins them row for row.
- **Grace-window skip.** Only a fresh, non-terminal scope whose retry lands within 30 minutes waits for it. Past that the crawl runs, so a board is never left empty on a 2-hour cooldown — and a scope that already holds rows always crawls, so a failed heal can't stall progress.
- **Legacy dual-write, never delete.** `bootstrap-retry:<scopeKey>` is the source of truth, but every write mirrors `bootstrap-attempts:` / `-healed:` / `-paged-fallback:`, and reads fold back anything a rolled-back bundle counted (`mirroredAttempts`). Production channel rollback and `pr-<n>` previews are live paths here.
- **New seams**, all defaulted so web and every existing caller are byte-identical: `isOnUnmeteredNetwork` (gates the automatic heal only), `now`, `random`, `onBootstrapRetryScheduled`, `onBootstrapPathRecovered`, and `ScopeDownloadCompleteInfo.bootstrapHealed` so #4316 can keep healed scopes out of its snapshot-vs-paged duration comparison. A fresh bootstrap ignores the metered probe because the size dialog just closed; a user-requested retry ignores it because `restoreBootstrapRetryBudget` arms a `userRequested` flag on the persisted state that overrides the defer and is spent the instant the download starts — one tap, one artifact. `bootstrapHealed` reads the persisted `bootstrap-done:` value (`'heal'` vs `'1'`), not an in-memory set, because a healed scope usually reaches completion cycles after the import (`board_climb_grades` is still crawling) and an in-memory set would report `false` for exactly those runs.
- Both `MAX_BOOTSTRAP_ATTEMPTS` read-sites move in this PR (`snapshot-estimate.ts`, `board-offline-state.ts`) so no intermediate merge leaves the constant's meaning inconsistent. `bootstrap-retry:` joins `scopeSyncMetaKeys`. `BOOTSTRAP_METADATA_QUERY` is now built from `BOOTSTRAP_METADATA_PATTERNS` with a test pinning the placeholder count.

**Five existing tests encoded the old behaviour as deliberate, and they were right to.** The cap really was the only spend bound. They're rewritten to assert the same intent — a permanently-failing artifact must still stop, and the crawl must still deliver a board meanwhile — expressed as bounded lifetime download counts instead of a 2-attempt cliff.

## What this does not fix

`SNAPSHOT_TABLES` is climbs + stats only, so a healed scope still crawls `board_climb_grades` before it reports complete. This removes part of the slow path, not all of it. Resumable downloads are #4310's — artifacts ship gzip-encoded, so byte-offset resume needs a JS gunzipper (a native dep, OTA-forbidden). When that lands, the transport ladder's first rung should drop.

## Release Notes

A dropped connection while downloading a board no longer condemns it to the slow download path. Boards that got stuck partway through the slow crawl now finish on the fast one by themselves.

## Test plan

- `vp test run --project offline-sync --reporter=agent` — 458 passed, 25 files (rebased onto main's #4329/#4330 suites). New `bootstrap-retry.test.ts` covers the ladders, jitter bounds, both budgets, the artifact-only `builtAt` re-arm and its lifetime cap, the eligibility matrix, legacy migration + dual-write + read reconciliation, and `restoreBootstrapRetryBudget`. New blocks in `snapshot-bootstrap.test.ts` cover the 40-cycle bounded-spend counts per kind, heal-over-partial (including the `bootstrapHealed` report both in-cycle and one cycle late, and the metered deferral), four watermark-guard cases (including five cycles asserting one download, not five), and the user-requested retry end to end: budget restored → the artifact lands on cellular with `trigger: 'user-request'`, and the second cycle defers because the tap is spent.
- `vp run typecheck` — clean across the monorepo.
- `vp run test:mobile` — 5601 tests, all passing.
- `vp run typecheck:mobile` — clean.
- `vp run check:mobile-bundle` — android bundle OK.
- `vp check` — clean for every file this PR touches.

Device QA is in `.boardsesh/qa-notes.md` (untracked): airplane-mode enable, three mid-artifact drops, a hand-edited past `bootstrap-retry:` on a mid-crawl scope, a seeded behind-checkpoint artifact for the guard, and driving a scope terminal.

Refs #4313

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT6VP1sWqk6bY9mUgyeS2U

