### PR TITLE
feat(mobile): measure offline-served reads and define the north-star

### DIFF
--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -975,8 +975,9 @@ lane it took. Four terminal outcomes are worth measuring:
 | Offline, board downloaded         | `Offline Read Served`      | `offline_local`        |
 | Network threw, board downloaded   | `Offline Read Served`      | `network_error_local`  |
 | Online, flag on, board downloaded | `Offline Read Served`      | `online_local`         |
-| Offline, nothing local to serve   | `Offline Read Unavailable` | `board_not_downloaded` |
+| Offline, board not downloaded     | `Offline Read Unavailable` | `board_not_downloaded` |
 | Offline, filter not expressible   | `Offline Read Unavailable` | `filter_unsupported`   |
+| Offline, no database handle       | `Offline Read Unavailable` | `local_db_unavailable` |
 
 `network_error_local` is real offline value that `onlineManager` mislabels as
 online (captive portal, dead gym-wifi upstream, cold-start seed race), so it
@@ -996,8 +997,10 @@ only when the count crosses a rung of `[1, 10, 100]`:
 - A suppressed read costs one integer compare, one `Map` lookup and one
   increment. No I/O, no persistence, no battery.
 - Worst case for a pathological user is 3 lanes x 2 boards x 3 rungs = 18
-  events/day; typical is one or two. A `maxEmitsPerProcess` backstop (60) stops
-  any future call site turning it into a firehose.
+  events/day; typical is one or two. A `maxEmitsPerDay` backstop (60) stops any
+  future call site turning it into a firehose. Per day, not per process: a phone
+  can keep the process resident for weeks, and a lifetime cap would eventually
+  mute the north-star for the heaviest offline users.
 - Rung 1 fires on the _first_ qualifying read, so the north-star can never be
   lost to an app kill. The deeper rungs only add depth.
 - `readCount` is therefore the **rung**, never a raw counter, and the absence of
@@ -1018,12 +1021,16 @@ only when the count crosses a rung of `[1, 10, 100]`:
 
 Supporting tiles, in the order they answer questions about it:
 
-1. **Depth** — weekly median of the maximum `readCount` per user, same lane
-   filter. Distinguishes "opened the app once with no signal" from "climbed a
-   whole session off the local database".
+1. **Depth** — weekly unique users who crossed the 10-read rung (`readCount > 9`),
+   same lane filter. Distinguishes "opened the app once with no signal" from
+   "climbed a whole session off the local database". A rung count, not a median
+   of per-user maxima: `readCount` only ever takes the ladder values, so a median
+   over it would read as precision the rollup does not have.
 2. **The gap** — weekly unique users on `Offline Read Unavailable`, broken down
    by `reason`. `board_not_downloaded` is the audience #4318's nudges exist to
-   convert; `filter_unsupported` is #4002's.
+   convert; `filter_unsupported` is #4002's. `local_db_unavailable` is neither —
+   it means the database handle was missing (init retrying or wedged, #4313 /
+   #4314), so those users may already have the board downloaded.
 3. **Conversion** — `Offline Board Download Completed` → `Offline Read Served`
    (offline lanes) over 30 days: of the people who downloaded a board, how many
    ever used it away from signal.

--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -958,6 +958,79 @@ Three things are worth knowing before trusting a number derived from it:
   otherwise drop `connectivity` for the rest of the launch — the same trap
   `environment` and `$raw_user_agent` already document in `posthog-client.ts`.
 
+### The offline-read signal
+
+`connectivity` says whether the network was usable. It cannot say whether the
+local database actually answered anything — "offline and browsing my downloaded
+Kilter catalog" and "offline staring at an empty screen" look identical through
+it, and that distinction _is_ the value proposition. So the interceptor emits a
+second, narrower signal.
+
+Every offline-served read funnels through `offlineAwareRequest()` in
+`packages/mobile/src/lib/graphql/offline-request.ts`, which already knows which
+lane it took. Four terminal outcomes are worth measuring:
+
+| Outcome                           | Event                      | Lane / reason          |
+| --------------------------------- | -------------------------- | ---------------------- |
+| Offline, board downloaded         | `Offline Read Served`      | `offline_local`        |
+| Network threw, board downloaded   | `Offline Read Served`      | `network_error_local`  |
+| Online, flag on, board downloaded | `Offline Read Served`      | `online_local`         |
+| Offline, nothing local to serve   | `Offline Read Unavailable` | `board_not_downloaded` |
+| Offline, filter not expressible   | `Offline Read Unavailable` | `filter_unsupported`   |
+
+`network_error_local` is real offline value that `onlineManager` mislabels as
+online (captive portal, dead gym-wifi upstream, cold-start seed race), so it
+counts toward the north-star. `online_local` is the flag-on latency
+optimization — it proves the local path is exercised but it is **not** offline
+usage, and it is excluded from the north-star. Expect it to dominate the
+breakdown once #4312 bakes the engine flag on.
+
+**These events are rolled up, not per-read.** Search and its count fire on every
+keystroke, so a per-read event would be thousands per session — and PostHog's
+offline queue holds 1000 events and drops the _oldest_ when full, so a chatty
+read event captured offline would evict the ticks and screens sharing that
+queue. `createOfflineUsageSignal` (`@boardsesh/offline-sync`, pure TS with `emit`
+and `now` injected) counts reads per `(UTC epoch-day, lane, board)` and emits
+only when the count crosses a rung of `[1, 10, 100]`:
+
+- A suppressed read costs one integer compare, one `Map` lookup and one
+  increment. No I/O, no persistence, no battery.
+- Worst case for a pathological user is 3 lanes x 2 boards x 3 rungs = 18
+  events/day; typical is one or two. A `maxEmitsPerProcess` backstop (60) stops
+  any future call site turning it into a firehose.
+- Rung 1 fires on the _first_ qualifying read, so the north-star can never be
+  lost to an app kill. The deeper rungs only add depth.
+- `readCount` is therefore the **rung**, never a raw counter, and the absence of
+  a follow-up event means "fewer than the next rung", not "no more reads".
+- `surface` (`search` / `climb_detail` / `grade`) is a descriptive prop of the
+  read that crossed the rung, **not** part of the key — keying on it would
+  roughly triple the volume for a breakdown nobody has asked for yet.
+- The counter is in-memory and not persisted. A relaunch re-arms the day, which
+  can double-count a user; harmless for a unique-users metric. It is **not**
+  harmless across an account switch, so `resetOfflineUsageSignal()` runs on both
+  sign-out paths in `auth-provider.tsx` — without it the next user's first
+  offline day silently never fires.
+
+### North-star
+
+> **Weekly unique users who fire `Offline Read Served` with
+> `lane in ('offline_local', 'network_error_local')`.**
+
+Supporting tiles, in the order they answer questions about it:
+
+1. **Depth** — weekly median of the maximum `readCount` per user, same lane
+   filter. Distinguishes "opened the app once with no signal" from "climbed a
+   whole session off the local database".
+2. **The gap** — weekly unique users on `Offline Read Unavailable`, broken down
+   by `reason`. `board_not_downloaded` is the audience #4318's nudges exist to
+   convert; `filter_unsupported` is #4002's.
+3. **Conversion** — `Offline Board Download Completed` → `Offline Read Served`
+   (offline lanes) over 30 days: of the people who downloaded a board, how many
+   ever used it away from signal.
+4. **Any activity offline** — weekly unique users on any event with
+   `connectivity == 'offline'`. The loosest possible read of "did anyone use the
+   app with no network", and the sanity check on the three above.
+
 ## Performance targets
 
 | Metric                   | Target                | Notes                                     |

--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -970,14 +970,14 @@ Every offline-served read funnels through `offlineAwareRequest()` in
 `packages/mobile/src/lib/graphql/offline-request.ts`, which already knows which
 lane it took. Four terminal outcomes are worth measuring:
 
-| Outcome                           | Event                      | Lane / reason          |
-| --------------------------------- | -------------------------- | ---------------------- |
-| Offline, board downloaded         | `Offline Read Served`      | `offline_local`        |
-| Network threw, board downloaded   | `Offline Read Served`      | `network_error_local`  |
-| Online, flag on, board downloaded | `Offline Read Served`      | `online_local`         |
-| Offline, board not downloaded     | `Offline Read Unavailable` | `board_not_downloaded` |
-| Offline, filter not expressible   | `Offline Read Unavailable` | `filter_unsupported`   |
-| Offline, no database handle       | `Offline Read Unavailable` | `local_db_unavailable` |
+| Outcome                                    | Event                      | Lane / reason          |
+| ------------------------------------------ | -------------------------- | ---------------------- |
+| Offline, board downloaded, row found       | `Offline Read Served`      | `offline_local`        |
+| Network threw, board downloaded, row found | `Offline Read Served`      | `network_error_local`  |
+| Online, flag on, board downloaded          | `Offline Read Served`      | `online_local`         |
+| Offline, board not downloaded              | `Offline Read Unavailable` | `board_not_downloaded` |
+| Offline, board downloaded, filter gap      | `Offline Read Unavailable` | `filter_unsupported`   |
+| Offline, no database handle                | `Offline Read Unavailable` | `local_db_unavailable` |
 
 `network_error_local` is real offline value that `onlineManager` mislabels as
 online (captive portal, dead gym-wifi upstream, cold-start seed race), so it
@@ -985,6 +985,22 @@ counts toward the north-star. `online_local` is the flag-on latency
 optimization — it proves the local path is exercised but it is **not** offline
 usage, and it is excluded from the north-star. Expect it to dominate the
 breakdown once #4312 bakes the engine flag on.
+
+Two labelling rules keep those buckets honest, and both are cases where the
+obvious code books the wrong thing:
+
+- **A local miss is never a served read.** Climb detail and the single-grade read
+  treat a null row as a miss (`isLocalMiss`) and retry over the network while
+  online. Offline there is no retry, so the null is returned as-is — and the
+  caller gets exactly the nothing the empty fallback would have given, so it
+  counts in no served lane. It gets no `Offline Read Unavailable` either: for the
+  grade reads a null row is indistinguishable from a genuinely ungraded climb
+  (MoonBoard, too few ascents), so counting it would put a number we can't verify
+  on the gap tile.
+- **A missing download outranks the filter gap.** An unsupported filter run
+  against a board that was never downloaded is reported as
+  `board_not_downloaded`. Teaching SQLite every filter (#4002) would still serve
+  that read nothing; only a download (#4318) would.
 
 **These events are rolled up, not per-read.** Search and its count fire on every
 keystroke, so a per-read event would be thousands per session — and PostHog's

--- a/packages/mobile/src/lib/graphql/__tests__/offline-request.test.ts
+++ b/packages/mobile/src/lib/graphql/__tests__/offline-request.test.ts
@@ -694,6 +694,39 @@ describe('offlineAwareRequest — offline-usage signal lanes (#4317)', () => {
     expect(recordOfflineRead).not.toHaveBeenCalled();
   });
 
+  // Database init retries for up to 30s and can stay wedged for the whole launch
+  // (#4313 / #4314). Reporting that as `board_not_downloaded` would put users who
+  // DID download a board into the audience #4318 nudges to download one.
+  it('records local_db_unavailable, not board_not_downloaded, when there is no database handle', async () => {
+    setOnline(false);
+    getDatabaseHandle.mockReturnValue(null);
+
+    await offlineAwareRequest<SearchClimbsQueryResponse>(SEARCH_CLIMBS, { input: searchInput });
+
+    expect(recordOfflineReadUnavailable).toHaveBeenCalledExactlyOnceWith({
+      reason: 'local_db_unavailable',
+      surface: 'search',
+      boardName: 'kilter',
+    });
+  });
+
+  // The rescue read is what makes this lane "served"; if it throws, the caller
+  // gets the network error and no data, so booking a served read would inflate
+  // the north-star with reads nobody received.
+  it('does not record network_error_local when the local rescue read itself throws', async () => {
+    setOfflineEngineEnabled(false);
+    setOnline(true);
+    isBoardDownloadedLocally.mockResolvedValue(true);
+    request.mockRejectedValue(new Error('Network request failed'));
+    searchClimbsLocal.mockRejectedValue(new Error('database is locked'));
+
+    await expect(offlineAwareRequest<SearchClimbsQueryResponse>(SEARCH_CLIMBS, { input: searchInput })).rejects.toThrow(
+      'database is locked',
+    );
+
+    expect(recordOfflineRead).not.toHaveBeenCalled();
+  });
+
   it('does not record anything for an unregistered document', async () => {
     setOnline(false);
 

--- a/packages/mobile/src/lib/graphql/__tests__/offline-request.test.ts
+++ b/packages/mobile/src/lib/graphql/__tests__/offline-request.test.ts
@@ -679,6 +679,40 @@ describe('offlineAwareRequest — offline-usage signal lanes (#4317)', () => {
     });
   });
 
+  // Both gaps at once. Fixing #4002's filter coverage would still serve this
+  // user nothing — they have no downloaded board to filter — so the read belongs
+  // to #4318's conversion pool, not #4002's.
+  it('prefers board_not_downloaded over filter_unsupported when the board was never downloaded', async () => {
+    setOnline(false);
+    isOfflineSearchSupported.mockReturnValue(false);
+    isBoardDownloadedLocally.mockResolvedValue(false);
+
+    await offlineAwareRequest<SearchClimbsQueryResponse>(SEARCH_CLIMBS, { input: searchInput });
+
+    expect(recordOfflineReadUnavailable).toHaveBeenCalledExactlyOnceWith({
+      reason: 'board_not_downloaded',
+      surface: 'search',
+      boardName: 'kilter',
+    });
+  });
+
+  // The supported-filter branch already ran (and failed) the download probe
+  // inside canServeSearchLocal, so labelling that read must not pay for a
+  // second SQLite round trip on every keystroke.
+  it('does not re-probe the download when the filter was expressible', async () => {
+    setOnline(false);
+    isBoardDownloadedLocally.mockResolvedValue(false);
+
+    await offlineAwareRequest<SearchClimbsQueryResponse>(SEARCH_CLIMBS, { input: searchInput });
+
+    expect(isBoardDownloadedLocally).toHaveBeenCalledOnce();
+    expect(recordOfflineReadUnavailable).toHaveBeenCalledExactlyOnceWith({
+      reason: 'board_not_downloaded',
+      surface: 'search',
+      boardName: 'kilter',
+    });
+  });
+
   // The local read happened, but it MISSED and the network answered instead —
   // counting it as served would inflate the north-star with reads the local DB
   // could not actually satisfy.
@@ -691,6 +725,38 @@ describe('offlineAwareRequest — offline-usage signal lanes (#4317)', () => {
     const result = await offlineAwareRequest<GetClimbQueryResponse>(GET_CLIMB, climbVars);
 
     expect(result.climb?.uuid).toBe('net-detail');
+    expect(recordOfflineRead).not.toHaveBeenCalled();
+  });
+
+  // Offline, the miss can't be retried, so it is returned as-is — and what the
+  // caller gets is `{ climb: null }`, the same nothing the empty fallback gives.
+  // Counting that as offline_local would put "offline staring at an empty
+  // screen" into the north-star, the one distinction this signal exists to make.
+  it('does not record a served read for a local miss returned as-is while offline', async () => {
+    setOnline(false);
+    isBoardDownloadedLocally.mockResolvedValue(true);
+    getClimbLocal.mockResolvedValue(null);
+
+    const result = await offlineAwareRequest<GetClimbQueryResponse>(GET_CLIMB, climbVars);
+
+    expect(result).toEqual({ climb: null });
+    expect(recordOfflineRead).not.toHaveBeenCalled();
+    // No `unavailable` counterpart either: a null grade row is indistinguishable
+    // from a genuinely ungraded climb, so the gap tile would be inventing a
+    // number. Silence beats a wrong one.
+    expect(recordOfflineReadUnavailable).not.toHaveBeenCalled();
+  });
+
+  it('does not record network_error_local when the rescue read itself misses', async () => {
+    setOfflineEngineEnabled(false); // straight passthrough, so the catch block is the only local read
+    setOnline(true);
+    isBoardDownloadedLocally.mockResolvedValue(true);
+    getClimbLocal.mockResolvedValue(null);
+    request.mockRejectedValue(new Error('Network request failed'));
+
+    const result = await offlineAwareRequest<GetClimbQueryResponse>(GET_CLIMB, climbVars);
+
+    expect(result).toEqual({ climb: null });
     expect(recordOfflineRead).not.toHaveBeenCalled();
   });
 

--- a/packages/mobile/src/lib/graphql/__tests__/offline-request.test.ts
+++ b/packages/mobile/src/lib/graphql/__tests__/offline-request.test.ts
@@ -23,6 +23,8 @@ const {
   getBoardseshGradeLocal,
   getBoardseshGradesForAnglesLocal,
   request,
+  recordOfflineRead,
+  recordOfflineReadUnavailable,
 } = vi.hoisted(() => ({
   getDatabaseHandle: vi.fn(),
   isBoardDownloadedLocally: vi.fn(),
@@ -34,6 +36,8 @@ const {
   getBoardseshGradeLocal: vi.fn(),
   getBoardseshGradesForAnglesLocal: vi.fn(),
   request: vi.fn(),
+  recordOfflineRead: vi.fn(),
+  recordOfflineReadUnavailable: vi.fn(),
 }));
 
 vi.mock('../../../db', () => ({ getDatabaseHandle }));
@@ -52,6 +56,12 @@ vi.mock('../../../db/queries/get-boardsesh-grade-local', () => ({
   getBoardseshGradesForAnglesLocal,
 }));
 vi.mock('../client', () => ({ getHttpClient: () => ({ request }) }));
+// The rollup gate itself is covered in @boardsesh/offline-sync; here we assert
+// the interceptor hands it the right LANE for each terminal outcome (#4317).
+vi.mock('../../../offline/offline-usage-signal', () => ({
+  recordOfflineRead,
+  recordOfflineReadUnavailable,
+}));
 
 const fakeDb = { tag: 'db' };
 
@@ -591,5 +601,129 @@ describe('offlineAwareRequest — offline-engine flag OFF', () => {
     const result = await offlineAwareRequest<GetClimbQueryResponse>(GET_CLIMB, climbVars);
     expect(result).toEqual({ climb: null });
     expect(request).not.toHaveBeenCalled();
+  });
+});
+
+describe('offlineAwareRequest — offline-usage signal lanes (#4317)', () => {
+  // Four terminal outcomes are worth measuring, and each one has to reach the
+  // rollup gate with the right lane or the north-star counts the wrong thing.
+
+  it('records offline_local when a downloaded board is served while offline', async () => {
+    setOnline(false);
+    isBoardDownloadedLocally.mockResolvedValue(true);
+
+    await offlineAwareRequest<SearchClimbsQueryResponse>(SEARCH_CLIMBS, { input: searchInput });
+
+    expect(recordOfflineRead).toHaveBeenCalledExactlyOnceWith({
+      lane: 'offline_local',
+      surface: 'search',
+      boardName: 'kilter',
+    });
+    expect(recordOfflineReadUnavailable).not.toHaveBeenCalled();
+  });
+
+  it('records online_local when the flag-on latency short-circuit serves local while online', async () => {
+    setOfflineEngineEnabled(true);
+    setOnline(true);
+    isBoardDownloadedLocally.mockResolvedValue(true);
+
+    await offlineAwareRequest<GetClimbQueryResponse>(GET_CLIMB, climbVars);
+
+    expect(recordOfflineRead).toHaveBeenCalledExactlyOnceWith({
+      lane: 'online_local',
+      surface: 'climb_detail',
+      boardName: 'kilter',
+    });
+  });
+
+  it('records network_error_local when a dead network is rescued by the downloaded board', async () => {
+    setOfflineEngineEnabled(false); // straight passthrough, so the network is the only lane
+    setOnline(true);
+    isBoardDownloadedLocally.mockResolvedValue(true);
+    request.mockRejectedValue(new Error('Network request failed'));
+
+    await offlineAwareRequest<SearchClimbsQueryResponse>(SEARCH_CLIMBS, { input: searchInput });
+
+    expect(recordOfflineRead).toHaveBeenCalledExactlyOnceWith({
+      lane: 'network_error_local',
+      surface: 'search',
+      boardName: 'kilter',
+    });
+  });
+
+  it('records board_not_downloaded when offline with nothing local', async () => {
+    setOnline(false);
+    isBoardDownloadedLocally.mockResolvedValue(false);
+
+    await offlineAwareRequest<SearchClimbsQueryResponse>(SEARCH_CLIMBS, { input: searchInput });
+
+    expect(recordOfflineReadUnavailable).toHaveBeenCalledExactlyOnceWith({
+      reason: 'board_not_downloaded',
+      surface: 'search',
+      boardName: 'kilter',
+    });
+    expect(recordOfflineRead).not.toHaveBeenCalled();
+  });
+
+  it('records filter_unsupported when the board IS downloaded but the filter needs a table we do not sync', async () => {
+    setOnline(false);
+    isOfflineSearchSupported.mockReturnValue(false);
+    isBoardDownloadedLocally.mockResolvedValue(true);
+
+    await offlineAwareRequest<SearchClimbsQueryResponse>(SEARCH_CLIMBS, { input: searchInput });
+
+    expect(recordOfflineReadUnavailable).toHaveBeenCalledExactlyOnceWith({
+      reason: 'filter_unsupported',
+      surface: 'search',
+      boardName: 'kilter',
+    });
+  });
+
+  // The local read happened, but it MISSED and the network answered instead —
+  // counting it as served would inflate the north-star with reads the local DB
+  // could not actually satisfy.
+  it('does not record a served read when a local miss is answered by the network', async () => {
+    setOfflineEngineEnabled(true);
+    setOnline(true);
+    isBoardDownloadedLocally.mockResolvedValue(true);
+    getClimbLocal.mockResolvedValue(null);
+
+    const result = await offlineAwareRequest<GetClimbQueryResponse>(GET_CLIMB, climbVars);
+
+    expect(result.climb?.uuid).toBe('net-detail');
+    expect(recordOfflineRead).not.toHaveBeenCalled();
+  });
+
+  it('does not record anything for an unregistered document', async () => {
+    setOnline(false);
+
+    await offlineAwareRequest('query Unregistered { x }');
+
+    expect(recordOfflineRead).not.toHaveBeenCalled();
+    expect(recordOfflineReadUnavailable).not.toHaveBeenCalled();
+  });
+
+  // A registered document called without variables degrades to the fallback;
+  // every accessor destructures the variables, so the signal has to sit this out
+  // rather than throw on a read path.
+  it('does not record an unavailable read when a registered document is called without variables', async () => {
+    setOnline(false);
+
+    await offlineAwareRequest<SearchClimbsQueryResponse>(SEARCH_CLIMBS);
+
+    expect(recordOfflineReadUnavailable).not.toHaveBeenCalled();
+  });
+
+  it('reports the board the read was scoped to, not a hardcoded one', async () => {
+    setOnline(false);
+    isBoardTypeDownloadedLocally.mockResolvedValue(true);
+
+    await offlineAwareRequest<BoardseshGradeResponse>(BOARDSESH_GRADE, { ...gradeVars, boardName: 'tension' });
+
+    expect(recordOfflineRead).toHaveBeenCalledExactlyOnceWith({
+      lane: 'offline_local',
+      surface: 'grade',
+      boardName: 'tension',
+    });
   });
 });

--- a/packages/mobile/src/lib/graphql/offline-request.ts
+++ b/packages/mobile/src/lib/graphql/offline-request.ts
@@ -8,6 +8,8 @@ import { getClimbLocal } from '../../db/queries/get-climb-local';
 import { getBoardseshGradeLocal, getBoardseshGradesForAnglesLocal } from '../../db/queries/get-boardsesh-grade-local';
 import { isBoardDownloadedLocally, isBoardTypeDownloadedLocally } from '../../db/queries/board-download-status';
 import { getHttpClient } from './client';
+import type { OfflineReadSurface, OfflineUnavailableReason } from '@boardsesh/offline-sync';
+import { recordOfflineRead, recordOfflineReadUnavailable } from '../../offline/offline-usage-signal';
 import {
   BOARDSESH_GRADE,
   BOARDSESH_GRADES_FOR_ANGLES,
@@ -51,6 +53,15 @@ function scopeOf(input: { boardName: string; layoutId: number; sizeId: number })
 
 type OfflineOperation<TVariables, TResponse> = {
   document: string;
+  // Offline-usage rollup (#4317): which read this is, and which board it is
+  // scoped to. The gate keys on (day, lane, board) and carries `surface` as a
+  // descriptive prop of the read that crossed a rung.
+  surface: OfflineReadSurface;
+  boardNameOf: (variables: TVariables) => string;
+  // Why an offline read came back empty, when the answer isn't simply "the
+  // board isn't downloaded". Only computed when the rollup gate has already
+  // decided to emit, so it costs nothing on the suppressed path.
+  unavailableReason?: (variables: TVariables) => OfflineUnavailableReason;
   canServeLocal: (db: SQLiteDatabase, variables: TVariables) => Promise<boolean>;
   // Returns the RAW GraphQL response shape (as if the server had answered).
   resolveLocal: (db: SQLiteDatabase, variables: TVariables) => Promise<TResponse>;
@@ -78,8 +89,20 @@ async function canServeSearchLocal(db: SQLiteDatabase, { input }: SearchClimbsQu
   return isOfflineSearchSupported(input) && (await isBoardDownloadedLocally(db, scopeOf(input)));
 }
 
+// A search can come back empty offline for two very different reasons, and the
+// difference decides who can be converted: a missing download is #4318's
+// audience, an unsupported filter is #4002's.
+function searchUnavailableReason({ input }: SearchClimbsQueryVariables): OfflineUnavailableReason {
+  return isOfflineSearchSupported(input) ? 'board_not_downloaded' : 'filter_unsupported';
+}
+
+const searchBoardName = ({ input }: SearchClimbsQueryVariables) => input.boardName;
+
 registerOfflineOperation<SearchClimbsQueryVariables, SearchClimbsQueryResponse>({
   document: SEARCH_CLIMBS,
+  surface: 'search',
+  boardNameOf: searchBoardName,
+  unavailableReason: searchUnavailableReason,
   canServeLocal: canServeSearchLocal,
   resolveLocal: async (db, { input }) => ({ searchClimbs: await searchClimbsLocal(db, input) }),
   offlineFallback: () => ({ searchClimbs: { climbs: [], hasMore: false } }),
@@ -87,6 +110,9 @@ registerOfflineOperation<SearchClimbsQueryVariables, SearchClimbsQueryResponse>(
 
 registerOfflineOperation<SearchClimbsQueryVariables, SearchClimbsCountQueryResponse>({
   document: SEARCH_CLIMBS_COUNT,
+  surface: 'search',
+  boardNameOf: searchBoardName,
+  unavailableReason: searchUnavailableReason,
   canServeLocal: canServeSearchLocal,
   resolveLocal: async (db, { input }) => ({ searchClimbs: { totalCount: await countClimbsLocal(db, input) } }),
   offlineFallback: () => ({ searchClimbs: { totalCount: 0 } }),
@@ -94,6 +120,8 @@ registerOfflineOperation<SearchClimbsQueryVariables, SearchClimbsCountQueryRespo
 
 registerOfflineOperation<GetClimbQueryVariables, GetClimbQueryResponse>({
   document: GET_CLIMB,
+  surface: 'climb_detail',
+  boardNameOf: (variables) => variables.boardName,
   // Detail has no filters — local whenever the exact scope is downloaded.
   canServeLocal: (db, variables) => isBoardDownloadedLocally(db, scopeOf(variables)),
   resolveLocal: async (db, variables) => ({
@@ -117,6 +145,8 @@ registerOfflineOperation<GetClimbQueryVariables, GetClimbQueryResponse>({
 // exactly like an empty search — no needless network retry.
 registerOfflineOperation<BoardseshGradeVariables, BoardseshGradeResponse>({
   document: BOARDSESH_GRADE,
+  surface: 'grade',
+  boardNameOf: ({ boardName }) => boardName,
   canServeLocal: (db, { boardName }) => isBoardTypeDownloadedLocally(db, boardName),
   resolveLocal: async (db, { boardName, climbUuid, angle }) => ({
     boardseshGrade: await getBoardseshGradeLocal(db, { boardName, climbUuid, angle }),
@@ -146,6 +176,8 @@ registerOfflineOperation<BoardseshGradeVariables, BoardseshGradeResponse>({
 // offline-request.test.ts's "does not retry an empty local list" case.
 registerOfflineOperation<BoardseshGradesForAnglesVariables, BoardseshGradesForAnglesResponse>({
   document: BOARDSESH_GRADES_FOR_ANGLES,
+  surface: 'grade',
+  boardNameOf: ({ boardName }) => boardName,
   canServeLocal: (db, { boardName }) => isBoardTypeDownloadedLocally(db, boardName),
   resolveLocal: async (db, { boardName, climbUuid }) => ({
     boardseshGradesForAngles: await getBoardseshGradesForAnglesLocal(db, { boardName, climbUuid }),
@@ -206,8 +238,29 @@ export async function offlineAwareRequest<TResponse>(document: string, variables
         // may simply not have synced yet. Offline, the miss stands (it has the
         // same shape as offlineFallback).
         const retryOverNetwork = operation.isLocalMiss?.(localResponse) === true && isOnline;
-        if (!retryOverNetwork) return localResponse;
+        if (!retryOverNetwork) {
+          // Recorded on the RETURN path only, so the online miss-retry that
+          // continues to the network below is never counted as served (#4317).
+          recordOfflineRead({
+            lane: isOnline ? 'online_local' : 'offline_local',
+            surface: operation.surface,
+            boardName: operation.boardNameOf(variables as never),
+          });
+          return localResponse;
+        }
       } else if (!isOnline) {
+        // Offline with nothing local to serve — the surface gets an empty
+        // result. `variables` can legitimately be undefined here (a registered
+        // document called without them degrades to the fallback), and every
+        // accessor below destructures it, so skip the signal in that case
+        // rather than throw on a read path.
+        if (variables !== undefined) {
+          recordOfflineReadUnavailable({
+            reason: operation.unavailableReason?.(variables as never) ?? 'board_not_downloaded',
+            surface: operation.surface,
+            boardName: operation.boardNameOf(variables as never),
+          });
+        }
         return operation.offlineFallback() as TResponse;
       }
     }
@@ -226,6 +279,14 @@ export async function offlineAwareRequest<TResponse>(document: string, variables
       // them; otherwise (flag off, or db not resolved above) probe now.
       const db = localDb ?? getDatabaseHandle();
       if (db && (localServiceable || (await operation.canServeLocal(db, variables as never)))) {
+        // Real offline value that `onlineManager` called online — counted as its
+        // own lane so the north-star doesn't lose captive-portal / dead-upstream
+        // sessions (#4317).
+        recordOfflineRead({
+          lane: 'network_error_local',
+          surface: operation.surface,
+          boardName: operation.boardNameOf(variables as never),
+        });
         return (await operation.resolveLocal(db, variables as never)) as TResponse;
       }
     }

--- a/packages/mobile/src/lib/graphql/offline-request.ts
+++ b/packages/mobile/src/lib/graphql/offline-request.ts
@@ -59,9 +59,11 @@ type OfflineOperation<TVariables, TResponse> = {
   surface: OfflineReadSurface;
   boardNameOf: (variables: TVariables) => string;
   // Why an offline read came back empty, when the answer isn't simply "the
-  // board isn't downloaded". Only computed when the rollup gate has already
-  // decided to emit, so it costs nothing on the suppressed path.
-  unavailableReason?: (variables: TVariables) => OfflineUnavailableReason;
+  // board isn't downloaded". Runs on every unavailable read (the rollup gate
+  // keys on the reason, so it can't be deferred until the gate decides to
+  // emit) — keep it to what `canServeLocal` already established, and only pay
+  // for an extra probe on the branch that genuinely needs one.
+  unavailableReason?: (db: SQLiteDatabase, variables: TVariables) => Promise<OfflineUnavailableReason>;
   canServeLocal: (db: SQLiteDatabase, variables: TVariables) => Promise<boolean>;
   // Returns the RAW GraphQL response shape (as if the server had answered).
   resolveLocal: (db: SQLiteDatabase, variables: TVariables) => Promise<TResponse>;
@@ -92,8 +94,20 @@ async function canServeSearchLocal(db: SQLiteDatabase, { input }: SearchClimbsQu
 // A search can come back empty offline for two very different reasons, and the
 // difference decides who can be converted: a missing download is #4318's
 // audience, an unsupported filter is #4002's.
-function searchUnavailableReason({ input }: SearchClimbsQueryVariables): OfflineUnavailableReason {
-  return isOfflineSearchSupported(input) ? 'board_not_downloaded' : 'filter_unsupported';
+//
+// The missing download OUTRANKS the filter gap when both are true. Teaching
+// SQLite every filter would not serve a board that was never downloaded, so
+// attributing those reads to `filter_unsupported` would credit #4002 with an
+// audience it can't convert and hide it from #4318's. `canServeSearchLocal`
+// short-circuits on the filter before probing the download, so the probe is
+// only owed on the unsupported branch — when the filter IS expressible, the
+// download probe already ran (and returned false) on the way here.
+async function searchUnavailableReason(
+  db: SQLiteDatabase,
+  { input }: SearchClimbsQueryVariables,
+): Promise<OfflineUnavailableReason> {
+  if (isOfflineSearchSupported(input)) return 'board_not_downloaded';
+  return (await isBoardDownloadedLocally(db, scopeOf(input))) ? 'filter_unsupported' : 'board_not_downloaded';
 }
 
 const searchBoardName = ({ input }: SearchClimbsQueryVariables) => input.boardName;
@@ -237,15 +251,25 @@ export async function offlineAwareRequest<TResponse>(document: string, variables
         // A known-key miss falls through to the network while online — the row
         // may simply not have synced yet. Offline, the miss stands (it has the
         // same shape as offlineFallback).
-        const retryOverNetwork = operation.isLocalMiss?.(localResponse) === true && isOnline;
-        if (!retryOverNetwork) {
+        const localMiss = operation.isLocalMiss?.(localResponse) === true;
+        if (!(localMiss && isOnline)) {
           // Recorded on the RETURN path only, so the online miss-retry that
-          // continues to the network below is never counted as served (#4317).
-          recordOfflineRead({
-            lane: isOnline ? 'online_local' : 'offline_local',
-            surface: operation.surface,
-            boardName: operation.boardNameOf(variables as never),
-          });
+          // continues to the network below is never counted as served (#4317) —
+          // and NOT for a miss we return as-is. A null climb or grade is the
+          // empty fallback reached by another route: the caller gets nothing,
+          // so booking it as served would put "offline staring at an empty
+          // screen" into the north-star. There is no `unavailable` counterpart
+          // either, deliberately: for the grade ops a null row is
+          // indistinguishable from a genuinely ungraded climb (see the
+          // BOARDSESH_GRADES_FOR_ANGLES note above), so counting it would
+          // invent a gap number we can't verify.
+          if (!localMiss) {
+            recordOfflineRead({
+              lane: isOnline ? 'online_local' : 'offline_local',
+              surface: operation.surface,
+              boardName: operation.boardNameOf(variables as never),
+            });
+          }
           return localResponse;
         }
       } else if (!isOnline) {
@@ -262,7 +286,7 @@ export async function offlineAwareRequest<TResponse>(document: string, variables
           // people who already have one.
           recordOfflineReadUnavailable({
             reason: localDb
-              ? (operation.unavailableReason?.(variables as never) ?? 'board_not_downloaded')
+              ? ((await operation.unavailableReason?.(localDb, variables as never)) ?? 'board_not_downloaded')
               : 'local_db_unavailable',
             surface: operation.surface,
             boardName: operation.boardNameOf(variables as never),
@@ -291,12 +315,17 @@ export async function offlineAwareRequest<TResponse>(document: string, variables
         // own lane so the north-star doesn't lose captive-portal / dead-upstream
         // sessions (#4317). Recorded only once the local read actually resolved,
         // so a throwing resolveLocal (which propagates instead of answering)
-        // can't book a served read the user never got.
-        recordOfflineRead({
-          lane: 'network_error_local',
-          surface: operation.surface,
-          boardName: operation.boardNameOf(variables as never),
-        });
+        // can't book a served read the user never got — and only when it
+        // resolved to something: a rescue that misses hands the caller the same
+        // nothing the network error would have, exactly like the miss on the
+        // local-first path above.
+        if (operation.isLocalMiss?.(rescued) !== true) {
+          recordOfflineRead({
+            lane: 'network_error_local',
+            surface: operation.surface,
+            boardName: operation.boardNameOf(variables as never),
+          });
+        }
         return rescued;
       }
     }

--- a/packages/mobile/src/lib/graphql/offline-request.ts
+++ b/packages/mobile/src/lib/graphql/offline-request.ts
@@ -255,8 +255,15 @@ export async function offlineAwareRequest<TResponse>(document: string, variables
         // accessor below destructures it, so skip the signal in that case
         // rather than throw on a read path.
         if (variables !== undefined) {
+          // A missing db handle is its OWN reason. Initialization retries for up
+          // to 30s and can stay wedged for the whole launch (#4313 / #4314), and
+          // the board may well BE downloaded — reporting that as
+          // `board_not_downloaded` would aim #4318's "download a board" nudge at
+          // people who already have one.
           recordOfflineReadUnavailable({
-            reason: operation.unavailableReason?.(variables as never) ?? 'board_not_downloaded',
+            reason: localDb
+              ? (operation.unavailableReason?.(variables as never) ?? 'board_not_downloaded')
+              : 'local_db_unavailable',
             surface: operation.surface,
             boardName: operation.boardNameOf(variables as never),
           });
@@ -279,15 +286,18 @@ export async function offlineAwareRequest<TResponse>(document: string, variables
       // them; otherwise (flag off, or db not resolved above) probe now.
       const db = localDb ?? getDatabaseHandle();
       if (db && (localServiceable || (await operation.canServeLocal(db, variables as never)))) {
+        const rescued = (await operation.resolveLocal(db, variables as never)) as TResponse;
         // Real offline value that `onlineManager` called online — counted as its
         // own lane so the north-star doesn't lose captive-portal / dead-upstream
-        // sessions (#4317).
+        // sessions (#4317). Recorded only once the local read actually resolved,
+        // so a throwing resolveLocal (which propagates instead of answering)
+        // can't book a served read the user never got.
         recordOfflineRead({
           lane: 'network_error_local',
           surface: operation.surface,
           boardName: operation.boardNameOf(variables as never),
         });
-        return (await operation.resolveLocal(db, variables as never)) as TResponse;
+        return rescued;
       }
     }
     throw networkError;

--- a/packages/mobile/src/offline/__tests__/offline-usage-signal.test.ts
+++ b/packages/mobile/src/offline/__tests__/offline-usage-signal.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+
+const analyticsMocks = vi.hoisted(() => ({ track: vi.fn() }));
+
+vi.mock('../../lib/analytics', () => ({ track: analyticsMocks.track }));
+
+import { recordOfflineRead, recordOfflineReadUnavailable, resetOfflineUsageSignal } from '../offline-usage-signal';
+
+// The binding between the shared rollup gate and PostHog (#4317). The gate is
+// tested in @boardsesh/offline-sync; what matters here is that an emission maps
+// to the right SHARED_EVENTS name with the right props, since a renamed prop
+// silently breaks the north-star insight rather than failing anything.
+describe('mobile offline-usage signal binding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetOfflineUsageSignal();
+  });
+
+  it('maps a served read to Offline Read Served with its lane, surface, board and rung', () => {
+    recordOfflineRead({ lane: 'offline_local', surface: 'search', boardName: 'kilter' });
+
+    expect(analyticsMocks.track).toHaveBeenCalledExactlyOnceWith(SHARED_EVENTS.OfflineReadServed, {
+      lane: 'offline_local',
+      surface: 'search',
+      boardName: 'kilter',
+      readCount: 1,
+    });
+  });
+
+  it('maps an unavailable read to Offline Read Unavailable with its reason', () => {
+    recordOfflineReadUnavailable({ reason: 'filter_unsupported', surface: 'search', boardName: 'tension' });
+
+    expect(analyticsMocks.track).toHaveBeenCalledExactlyOnceWith(SHARED_EVENTS.OfflineReadUnavailable, {
+      reason: 'filter_unsupported',
+      surface: 'search',
+      boardName: 'tension',
+      readCount: 1,
+    });
+  });
+
+  it('rolls up repeat reads rather than tracking one event per read', () => {
+    for (let read = 0; read < 9; read += 1) {
+      recordOfflineRead({ lane: 'offline_local', surface: 'search', boardName: 'kilter' });
+    }
+
+    expect(analyticsMocks.track).toHaveBeenCalledOnce();
+  });
+
+  it('re-arms the rollup after a sign-out reset', () => {
+    recordOfflineRead({ lane: 'offline_local', surface: 'search', boardName: 'kilter' });
+    recordOfflineRead({ lane: 'offline_local', surface: 'search', boardName: 'kilter' });
+    resetOfflineUsageSignal();
+    recordOfflineRead({ lane: 'offline_local', surface: 'search', boardName: 'kilter' });
+
+    expect(analyticsMocks.track).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/mobile/src/offline/offline-usage-signal.ts
+++ b/packages/mobile/src/offline/offline-usage-signal.ts
@@ -1,0 +1,60 @@
+import {
+  createOfflineUsageSignal,
+  type OfflineReadLane,
+  type OfflineReadSurface,
+  type OfflineUnavailableReason,
+  type OfflineUsageEmission,
+} from '@boardsesh/offline-sync';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { track } from '../lib/analytics';
+
+// Binds the shared offline-usage rollup gate to PostHog (issue #4317). Same
+// shape as the other injected-telemetry bindings in this directory — the shared
+// package emits a plain object and the app decides what that means, so
+// @boardsesh/offline-sync never imports an analytics client.
+//
+// Import direction is one-way: this module imports `track`, and nothing in
+// src/lib/analytics may import this module back.
+function emitOfflineUsage(emission: OfflineUsageEmission): void {
+  if (emission.kind === 'served') {
+    track(SHARED_EVENTS.OfflineReadServed, {
+      lane: emission.lane,
+      surface: emission.surface,
+      boardName: emission.boardName,
+      readCount: emission.readCount,
+    });
+    return;
+  }
+  track(SHARED_EVENTS.OfflineReadUnavailable, {
+    reason: emission.reason,
+    surface: emission.surface,
+    boardName: emission.boardName,
+    readCount: emission.readCount,
+  });
+}
+
+const offlineUsageSignal = createOfflineUsageSignal({ emit: emitOfflineUsage });
+
+export function recordOfflineRead(read: {
+  lane: OfflineReadLane;
+  surface: OfflineReadSurface;
+  boardName: string;
+}): void {
+  offlineUsageSignal.recordRead(read);
+}
+
+export function recordOfflineReadUnavailable(miss: {
+  reason: OfflineUnavailableReason;
+  surface: OfflineReadSurface;
+  boardName: string;
+}): void {
+  offlineUsageSignal.recordUnavailable(miss);
+}
+
+// Sign-out boundary. The gate's suppression map is in-memory and unkeyed by
+// user, so without this a same-day account switch inherits the previous user's
+// counters and the new user's first offline day never fires — silent
+// under-counting of exactly the metric this exists to produce.
+export function resetOfflineUsageSignal(): void {
+  offlineUsageSignal.reset();
+}

--- a/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
@@ -279,6 +279,14 @@ vi.mock('@boardsesh/offline-sync', () => ({
 vi.mock('../../offline/offline-sync-adapter', () => ({
   drainMutationQueue: (...args: unknown[]) => drainMutationQueueMock(...args),
 }));
+// The offline-usage rollup's suppression map is in-memory and not keyed by user,
+// so the sign-out paths reset it (#4317) — otherwise a same-day account switch
+// inherits the previous user's counters and the new user's first offline day
+// silently never fires.
+const resetOfflineUsageSignalMock = vi.hoisted(() => vi.fn());
+vi.mock('../../offline/offline-usage-signal', () => ({
+  resetOfflineUsageSignal: () => resetOfflineUsageSignalMock(),
+}));
 
 const stopTokenManagementMock = vi.fn(async () => {});
 vi.mock('../../notifications', () => ({
@@ -402,6 +410,9 @@ describe('AuthProvider.signOut', () => {
     // queryClient is the durable check.
     expect(queryClient.getQueryData(['userPlaylists'])).toBeUndefined();
     expect(queryClient.getQueryData(['betaLinks', 'kilter', 'climb-x'])).toBeUndefined();
+    // Same auth boundary, same reason: the next user must not inherit the
+    // previous one's offline-read rollup counters (#4317).
+    expect(resetOfflineUsageSignalMock).toHaveBeenCalled();
   });
 
   it('runs the auth-side cleanup before clearing the cache', async () => {

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -22,6 +22,7 @@ import {
 } from '../lib/auth';
 import { SCREENSHOT_USER_EMAIL, SCREENSHOT_USER_PASSWORD } from '../lib/screenshot-mode';
 import { reset as resetAnalytics, track } from '../lib/analytics';
+import { resetOfflineUsageSignal } from '../offline/offline-usage-signal';
 import { reportError, reportHandledError } from '../lib/error-reporting';
 import { setOnForcedSignOut } from '../lib/auth-interceptor';
 import { getHttpClient, resetHttpClient } from '../lib/graphql/client';
@@ -162,6 +163,11 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
     const authState = authStateRef.current;
     if (authState.isLoading || authState.isAuthenticated) {
       resetAnalytics();
+      // The offline-usage rollup's suppression map is in-memory and not keyed by
+      // user, so a same-day account switch would otherwise inherit the previous
+      // user's counters and the new user's first offline day would never fire
+      // (#4317).
+      resetOfflineUsageSignal();
     }
   }, []);
 
@@ -246,6 +252,7 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
       const localDb = getDatabaseHandle();
       if (localDb) await reportOutboxDiscardedOnSignOut(localDb);
       resetAnalytics();
+      resetOfflineUsageSignal();
       const stopTokenCleanup = stopTokenManagement(async () => {});
       if (Platform.OS === 'web') await waitForCleanupPhase(stopTokenCleanup);
       else await stopTokenCleanup;

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -457,6 +457,12 @@ export const SHARED_EVENTS = {
   // (a lying connection — real offline value), or the online flag-on latency
   // short-circuit (NOT offline usage; excluded from the north-star). `surface`
   // is the read that crossed the rung, not an exhaustive list of what was used.
+  //
+  // A read that found NOTHING locally is not served, in any lane: climb detail
+  // and the single-grade read can come back null from a downloaded board (the
+  // row hasn't synced), and offline there's no network to retry against, so the
+  // caller gets the same nothing the empty fallback gives. Counting it would put
+  // "offline staring at an empty screen" into the north-star.
   OfflineReadServed: 'Offline Read Served',
   // Offline sync — the counterpart: the device was offline and there was nothing
   // local to serve, so the surface got an empty result. The conversion pool that
@@ -467,7 +473,10 @@ export const SHARED_EVENTS = {
   //   boardName, readCount }. `local_db_unavailable` means there was no database
   // handle to ask at all (init still retrying, or wedged — #4313 / #4314). The
   // board may well BE downloaded in that case, so it is deliberately NOT part of
-  // #4318's nudge audience.
+  // #4318's nudge audience. `filter_unsupported` means the board IS downloaded
+  // and only the filter blocked the read — when both are missing the reason is
+  // `board_not_downloaded`, since fixing filters would still serve that read
+  // nothing.
   OfflineReadUnavailable: 'Offline Read Unavailable',
 } as const;
 

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -439,6 +439,32 @@ export const SHARED_EVENTS = {
   // identical. `elapsedMs` is the contention-duration measurement — its
   // distribution is what sizes the retry window, which today is a guess.
   OfflineSqliteInitRecovered: 'Offline SQLite Init Recovered',
+  // Offline sync — someone read climb data from the on-device database. THE
+  // north-star signal for offline mode (issue #4317): weekly unique users firing
+  // this with `lane in ('offline_local', 'network_error_local')`.
+  //
+  // ROLLED UP, NOT PER-READ. Search fires on every keystroke, so a per-read
+  // event would be thousands per session and would evict other events from
+  // PostHog's 1000-slot offline queue. The gate (createOfflineUsageSignal in
+  // @boardsesh/offline-sync) counts reads per (UTC day, lane, board) and emits
+  // only when the count crosses 1, 10 or 100. So `readCount` is the RUNG that
+  // was crossed — 1 / 10 / 100 — never a raw per-read counter, and the absence
+  // of a follow-up event means "fewer than the next rung", not "no more reads".
+  //
+  // Props: { lane: 'offline_local' | 'network_error_local' | 'online_local',
+  //   surface: 'search' | 'climb_detail' | 'grade', boardName, readCount }.
+  // `lane` is the source: served while offline, served after the network threw
+  // (a lying connection — real offline value), or the online flag-on latency
+  // short-circuit (NOT offline usage; excluded from the north-star). `surface`
+  // is the read that crossed the rung, not an exhaustive list of what was used.
+  OfflineReadServed: 'Offline Read Served',
+  // Offline sync — the counterpart: the device was offline and there was nothing
+  // local to serve, so the surface got an empty result. The conversion pool that
+  // #4318 (discovery nudges) and #4002 (unsupported filters) exist to shrink.
+  // Same rollup contract and same readCount semantics as Offline Read Served.
+  // Props: { reason: 'board_not_downloaded' | 'filter_unsupported',
+  //   surface: 'search' | 'climb_detail' | 'grade', boardName, readCount }.
+  OfflineReadUnavailable: 'Offline Read Unavailable',
 } as const;
 
 export type SharedEventKey = keyof typeof SHARED_EVENTS;

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -462,8 +462,12 @@ export const SHARED_EVENTS = {
   // local to serve, so the surface got an empty result. The conversion pool that
   // #4318 (discovery nudges) and #4002 (unsupported filters) exist to shrink.
   // Same rollup contract and same readCount semantics as Offline Read Served.
-  // Props: { reason: 'board_not_downloaded' | 'filter_unsupported',
-  //   surface: 'search' | 'climb_detail' | 'grade', boardName, readCount }.
+  // Props: { reason: 'board_not_downloaded' | 'filter_unsupported' |
+  //   'local_db_unavailable', surface: 'search' | 'climb_detail' | 'grade',
+  //   boardName, readCount }. `local_db_unavailable` means there was no database
+  // handle to ask at all (init still retrying, or wedged — #4313 / #4314). The
+  // board may well BE downloaded in that case, so it is deliberately NOT part of
+  // #4318's nudge audience.
   OfflineReadUnavailable: 'Offline Read Unavailable',
 } as const;
 

--- a/packages/shared/offline-sync/src/__tests__/offline-usage-signal.test.ts
+++ b/packages/shared/offline-sync/src/__tests__/offline-usage-signal.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createOfflineUsageSignal, type OfflineUsageEmission } from '../telemetry/offline-usage-signal';
+
+// The rollup gate behind the offline north-star (#4317). Search fires per
+// keystroke, so this has to suppress the overwhelming majority of reads while
+// still guaranteeing the FIRST qualifying read of a day emits — the headline
+// metric is weekly unique users, and a user who only ever reads once must count.
+
+const DAY_MS = 86_400_000;
+
+function createHarness(options?: { ladder?: readonly number[]; maxEmitsPerProcess?: number; startAt?: number }) {
+  const emissions: OfflineUsageEmission[] = [];
+  let clock = options?.startAt ?? DAY_MS * 20_000;
+  const signal = createOfflineUsageSignal({
+    emit: (emission) => emissions.push(emission),
+    now: () => clock,
+    ladder: options?.ladder,
+    maxEmitsPerProcess: options?.maxEmitsPerProcess,
+  });
+  return {
+    emissions,
+    signal,
+    advance(ms: number) {
+      clock += ms;
+    },
+  };
+}
+
+const kilterSearch = { lane: 'offline_local', surface: 'search', boardName: 'kilter' } as const;
+
+describe('createOfflineUsageSignal', () => {
+  it('emits on the first read of a day with readCount 1', () => {
+    const { signal, emissions } = createHarness();
+
+    signal.recordRead(kilterSearch);
+
+    expect(emissions).toEqual([
+      { kind: 'served', lane: 'offline_local', surface: 'search', boardName: 'kilter', readCount: 1 },
+    ]);
+  });
+
+  it('suppresses every read between ladder rungs', () => {
+    const { signal, emissions } = createHarness();
+
+    for (let read = 0; read < 9; read += 1) signal.recordRead(kilterSearch);
+
+    expect(emissions).toHaveLength(1);
+    expect(emissions[0]?.readCount).toBe(1);
+  });
+
+  it('emits again at the 10th and 100th read', () => {
+    const { signal, emissions } = createHarness();
+
+    for (let read = 0; read < 100; read += 1) signal.recordRead(kilterSearch);
+
+    expect(emissions.map((emission) => emission.readCount)).toEqual([1, 10, 100]);
+  });
+
+  it('counts each lane independently', () => {
+    const { signal, emissions } = createHarness();
+
+    signal.recordRead(kilterSearch);
+    signal.recordRead({ ...kilterSearch, lane: 'network_error_local' });
+    signal.recordRead({ ...kilterSearch, lane: 'online_local' });
+
+    expect(emissions.map((emission) => emission.kind === 'served' && emission.lane)).toEqual([
+      'offline_local',
+      'network_error_local',
+      'online_local',
+    ]);
+  });
+
+  it('counts each board independently', () => {
+    const { signal, emissions } = createHarness();
+
+    signal.recordRead(kilterSearch);
+    signal.recordRead({ ...kilterSearch, boardName: 'tension' });
+
+    expect(emissions).toHaveLength(2);
+    expect(emissions.map((emission) => emission.boardName)).toEqual(['kilter', 'tension']);
+  });
+
+  // `surface` is descriptive, not part of the key — including it would roughly
+  // triple the volume for a breakdown nobody has asked for yet.
+  it('does not key on surface, and reports the surface that crossed the rung', () => {
+    const { signal, emissions } = createHarness();
+
+    signal.recordRead(kilterSearch);
+    signal.recordRead({ ...kilterSearch, surface: 'climb_detail' });
+
+    expect(emissions).toHaveLength(1);
+    expect(emissions[0]?.surface).toBe('search');
+  });
+
+  it('re-arms when the UTC epoch day rolls over', () => {
+    const harness = createHarness();
+
+    harness.signal.recordRead(kilterSearch);
+    harness.signal.recordRead(kilterSearch);
+    harness.advance(DAY_MS);
+    harness.signal.recordRead(kilterSearch);
+
+    expect(harness.emissions.map((emission) => emission.readCount)).toEqual([1, 1]);
+  });
+
+  it('does not re-arm within the same day', () => {
+    const harness = createHarness();
+
+    harness.signal.recordRead(kilterSearch);
+    harness.advance(DAY_MS / 2);
+    harness.signal.recordRead(kilterSearch);
+
+    expect(harness.emissions).toHaveLength(1);
+  });
+
+  // Without this, a same-day account switch inherits the previous user's
+  // counters and the new user's first offline day silently never fires.
+  it('re-arms after reset()', () => {
+    const { signal, emissions } = createHarness();
+
+    signal.recordRead(kilterSearch);
+    signal.recordRead(kilterSearch);
+    signal.reset();
+    signal.recordRead(kilterSearch);
+
+    expect(emissions.map((emission) => emission.readCount)).toEqual([1, 1]);
+  });
+
+  it('records unavailable reads on their own keys, split by reason', () => {
+    const { signal, emissions } = createHarness();
+
+    signal.recordUnavailable({ reason: 'board_not_downloaded', surface: 'search', boardName: 'kilter' });
+    signal.recordUnavailable({ reason: 'board_not_downloaded', surface: 'search', boardName: 'kilter' });
+    signal.recordUnavailable({ reason: 'filter_unsupported', surface: 'search', boardName: 'kilter' });
+
+    expect(emissions).toEqual([
+      { kind: 'unavailable', reason: 'board_not_downloaded', surface: 'search', boardName: 'kilter', readCount: 1 },
+      { kind: 'unavailable', reason: 'filter_unsupported', surface: 'search', boardName: 'kilter', readCount: 1 },
+    ]);
+  });
+
+  it('does not let a served read and an unavailable read share a counter', () => {
+    const { signal, emissions } = createHarness();
+
+    signal.recordRead(kilterSearch);
+    signal.recordUnavailable({ reason: 'board_not_downloaded', surface: 'search', boardName: 'kilter' });
+
+    expect(emissions.map((emission) => emission.kind)).toEqual(['served', 'unavailable']);
+  });
+
+  // Backstop against a future call site turning this into a firehose.
+  it('stops emitting once maxEmitsPerProcess is reached, until reset()', () => {
+    const { signal, emissions } = createHarness({ ladder: [1], maxEmitsPerProcess: 2 });
+
+    signal.recordRead({ ...kilterSearch, boardName: 'kilter' });
+    signal.recordRead({ ...kilterSearch, boardName: 'tension' });
+    signal.recordRead({ ...kilterSearch, boardName: 'moonboard' });
+
+    expect(emissions).toHaveLength(2);
+
+    signal.reset();
+    signal.recordRead({ ...kilterSearch, boardName: 'moonboard' });
+
+    expect(emissions).toHaveLength(3);
+  });
+
+  // The gate is called from a read path — a broken emit binding must never
+  // surface as a failed climb search.
+  it('swallows a throwing emit', () => {
+    const signal = createOfflineUsageSignal({
+      emit: vi.fn(() => {
+        throw new Error('analytics exploded');
+      }),
+    });
+
+    expect(() => signal.recordRead(kilterSearch)).not.toThrow();
+  });
+});

--- a/packages/shared/offline-sync/src/__tests__/offline-usage-signal.test.ts
+++ b/packages/shared/offline-sync/src/__tests__/offline-usage-signal.test.ts
@@ -8,14 +8,14 @@ import { createOfflineUsageSignal, type OfflineUsageEmission } from '../telemetr
 
 const DAY_MS = 86_400_000;
 
-function createHarness(options?: { ladder?: readonly number[]; maxEmitsPerProcess?: number; startAt?: number }) {
+function createHarness(options?: { ladder?: readonly number[]; maxEmitsPerDay?: number; startAt?: number }) {
   const emissions: OfflineUsageEmission[] = [];
   let clock = options?.startAt ?? DAY_MS * 20_000;
   const signal = createOfflineUsageSignal({
     emit: (emission) => emissions.push(emission),
     now: () => clock,
     ladder: options?.ladder,
-    maxEmitsPerProcess: options?.maxEmitsPerProcess,
+    maxEmitsPerDay: options?.maxEmitsPerDay,
   });
   return {
     emissions,
@@ -149,8 +149,8 @@ describe('createOfflineUsageSignal', () => {
   });
 
   // Backstop against a future call site turning this into a firehose.
-  it('stops emitting once maxEmitsPerProcess is reached, until reset()', () => {
-    const { signal, emissions } = createHarness({ ladder: [1], maxEmitsPerProcess: 2 });
+  it('stops emitting once maxEmitsPerDay is reached, until reset()', () => {
+    const { signal, emissions } = createHarness({ ladder: [1], maxEmitsPerDay: 2 });
 
     signal.recordRead({ ...kilterSearch, boardName: 'kilter' });
     signal.recordRead({ ...kilterSearch, boardName: 'tension' });
@@ -162,6 +162,22 @@ describe('createOfflineUsageSignal', () => {
     signal.recordRead({ ...kilterSearch, boardName: 'moonboard' });
 
     expect(emissions).toHaveLength(3);
+  });
+
+  // A phone can keep this process resident for weeks. A lifetime cap would
+  // eventually mute the north-star for the heaviest offline users — the exact
+  // silent under-count this signal exists to eliminate — so the cap is per day.
+  it('lifts the emission cap when the day rolls over', () => {
+    const harness = createHarness({ ladder: [1], maxEmitsPerDay: 1 });
+
+    harness.signal.recordRead(kilterSearch);
+    harness.signal.recordRead({ ...kilterSearch, boardName: 'tension' });
+    expect(harness.emissions).toHaveLength(1);
+
+    harness.advance(DAY_MS);
+    harness.signal.recordRead(kilterSearch);
+
+    expect(harness.emissions).toHaveLength(2);
   });
 
   // The gate is called from a read path — a broken emit binding must never

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -222,6 +222,21 @@ export { OFFLINE_DB_BUSY_TIMEOUT_MS, applyBusyTimeout, configureMainConnection }
 export { isDatabaseLockedError, classifySqliteLockError } from './db/lock-errors';
 export type { SqliteLockClassification } from './db/lock-errors';
 
+// --- Offline-usage telemetry (issue #4317) ---------------------------------------
+// The rollup gate that turns "this read was served from the local DB" into a
+// low-volume, chartable signal. `emit` is injected so the package keeps zero
+// runtime deps and never imports an analytics client — mobile binds it in
+// packages/mobile/src/offline/offline-usage-signal.ts.
+export { createOfflineUsageSignal } from './telemetry/offline-usage-signal';
+export type {
+  OfflineReadLane,
+  OfflineReadSurface,
+  OfflineUnavailableReason,
+  OfflineUsageEmission,
+  OfflineUsageSignal,
+  OfflineUsageSignalOptions,
+} from './telemetry/offline-usage-signal';
+
 // --- Offline board scope keys ----------------------------------------------------
 export {
   offlineBoardKey,

--- a/packages/shared/offline-sync/src/telemetry/offline-usage-signal.ts
+++ b/packages/shared/offline-sync/src/telemetry/offline-usage-signal.ts
@@ -49,7 +49,11 @@ export type OfflineReadSurface = 'search' | 'climb_detail' | 'grade';
 //   board_not_downloaded — nothing local for this board scope. The audience #4318 exists to convert.
 //   filter_unsupported   — the board IS downloaded but the filter needs a table we don't sync
 //                          (hold state, zone, tall/wide, beta, drafts) — the #4002 gap.
-export type OfflineUnavailableReason = 'board_not_downloaded' | 'filter_unsupported';
+//   local_db_unavailable — there was no database handle to ask at all (init still retrying, or
+//                          wedged — #4313 / #4314). Kept separate on purpose: the board may well
+//                          BE downloaded, so folding this into board_not_downloaded would aim
+//                          #4318's "download a board" nudge at people who already have one.
+export type OfflineUnavailableReason = 'board_not_downloaded' | 'filter_unsupported' | 'local_db_unavailable';
 
 export type OfflineUsageEmission =
   | { kind: 'served'; lane: OfflineReadLane; surface: OfflineReadSurface; boardName: string; readCount: number }
@@ -70,9 +74,13 @@ export type OfflineUsageSignalOptions = {
   // north-star is guaranteed on the first read.
   ladder?: readonly number[];
   // Hard backstop against any future call site turning this into a firehose:
-  // once this many emissions have fired in this process, the gate goes quiet
-  // until reset().
-  maxEmitsPerProcess?: number;
+  // once this many emissions have fired on the current UTC day, the gate goes
+  // quiet until the day rolls over (or reset() runs). Per-DAY rather than
+  // per-process on purpose — a phone can keep this process resident for weeks,
+  // and a lifetime cap would eventually mute the north-star for exactly the
+  // heaviest offline users, which is the silent under-count this signal exists
+  // to eliminate.
+  maxEmitsPerDay?: number;
 };
 
 export type OfflineUsageSignal = {
@@ -87,7 +95,7 @@ export type OfflineUsageSignal = {
 
 const MILLISECONDS_PER_DAY = 86_400_000;
 const DEFAULT_LADDER: readonly number[] = [1, 10, 100];
-const DEFAULT_MAX_EMITS_PER_PROCESS = 60;
+const DEFAULT_MAX_EMITS_PER_DAY = 60;
 
 // UTC epoch-day as a plain integer — no Intl, no Date object, no allocation, so
 // it is cheap enough to run on every suppressed read.
@@ -99,11 +107,11 @@ export function createOfflineUsageSignal({
   emit,
   now = Date.now,
   ladder = DEFAULT_LADDER,
-  maxEmitsPerProcess = DEFAULT_MAX_EMITS_PER_PROCESS,
+  maxEmitsPerDay = DEFAULT_MAX_EMITS_PER_DAY,
 }: OfflineUsageSignalOptions): OfflineUsageSignal {
   const countsByKey = new Map<string, number>();
   let currentEpochDay = epochDay(now());
-  let emitsThisProcess = 0;
+  let emitsToday = 0;
 
   // Returns the new count when it crossed a ladder rung, otherwise null.
   function countAndCheckRung(key: string): number | null {
@@ -111,12 +119,13 @@ export function createOfflineUsageSignal({
     if (day !== currentEpochDay) {
       currentEpochDay = day;
       countsByKey.clear();
+      emitsToday = 0;
     }
     const count = (countsByKey.get(key) ?? 0) + 1;
     countsByKey.set(key, count);
     if (!ladder.includes(count)) return null;
-    if (emitsThisProcess >= maxEmitsPerProcess) return null;
-    emitsThisProcess += 1;
+    if (emitsToday >= maxEmitsPerDay) return null;
+    emitsToday += 1;
     return count;
   }
 
@@ -143,7 +152,7 @@ export function createOfflineUsageSignal({
     reset() {
       countsByKey.clear();
       currentEpochDay = epochDay(now());
-      emitsThisProcess = 0;
+      emitsToday = 0;
     },
   };
 }

--- a/packages/shared/offline-sync/src/telemetry/offline-usage-signal.ts
+++ b/packages/shared/offline-sync/src/telemetry/offline-usage-signal.ts
@@ -1,0 +1,149 @@
+// Offline-usage rollup gate (issue #4317).
+//
+// The problem: every offline-served read funnels through ONE interceptor, and
+// that interceptor sees five registered documents — search, search count, climb
+// detail, and two grade reads. Search and its count fire on every keystroke, so
+// a per-read event would be thousands of events per user per session. PostHog's
+// offline queue holds 1000 events and drops the OLDEST when full, so a chatty
+// read event captured offline would evict the very events (ticks, screens) it
+// shares the queue with. Per-read is not an option; the signal has to be a
+// rollup.
+//
+// The gate: an in-memory counter keyed by (UTC epoch-day, lane, board) that
+// emits only when the count crosses a rung of a ladder — first read of the day,
+// then 10, then 100. Per SUPPRESSED read the whole cost is one integer compare,
+// one Map lookup and one increment: no I/O, no persistence, no Date formatting,
+// no battery. A pathological user tops out around 3 lanes x 2 boards x 3 rungs
+// = 18 events/day; the typical user emits one or two.
+//
+// Rung 1 fires on the very first qualifying read, so the north-star (weekly
+// users with >=1 offline-served read) can never be lost to an app kill — the
+// deeper rungs only add depth, they never gate the headline metric.
+//
+// The counter is deliberately NOT persisted. A process restart re-arms the day,
+// which can double-count a user across relaunches; that is harmless for a
+// unique-users metric and buys us zero storage dependencies. It also means the
+// consumer MUST call reset() on sign-out, or a same-day account switch inherits
+// the previous user's suppression map and the new user's first offline day
+// silently never fires.
+//
+// Pure TS with `emit` and `now` injected, like every other seam in this package
+// — it never imports an analytics client, so a future web offline consumer can
+// bind the same gate to its own telemetry.
+
+// Which local-read lane the interceptor took.
+//   offline_local       — device reported offline, served from the downloaded board. The value prop.
+//   network_error_local — the request reached the network and threw, and the downloaded board
+//                         rescued it. Real offline value that `onlineManager` mislabels as online
+//                         (captive portal, dead gym-wifi upstream, cold-start seed race).
+//   online_local        — device reported online and the engine flag short-circuited to local.
+//                         A latency optimization, NOT offline usage — excluded from the north-star.
+export type OfflineReadLane = 'offline_local' | 'network_error_local' | 'online_local';
+
+// The read that crossed the rung. Descriptive only — it is NOT part of the
+// dedupe key, so this is "the surface that happened to trip the counter", not an
+// exhaustive list of surfaces the user browsed.
+export type OfflineReadSurface = 'search' | 'climb_detail' | 'grade';
+
+// Why an offline read came back empty.
+//   board_not_downloaded — nothing local for this board scope. The audience #4318 exists to convert.
+//   filter_unsupported   — the board IS downloaded but the filter needs a table we don't sync
+//                          (hold state, zone, tall/wide, beta, drafts) — the #4002 gap.
+export type OfflineUnavailableReason = 'board_not_downloaded' | 'filter_unsupported';
+
+export type OfflineUsageEmission =
+  | { kind: 'served'; lane: OfflineReadLane; surface: OfflineReadSurface; boardName: string; readCount: number }
+  | {
+      kind: 'unavailable';
+      reason: OfflineUnavailableReason;
+      surface: OfflineReadSurface;
+      boardName: string;
+      readCount: number;
+    };
+
+export type OfflineUsageSignalOptions = {
+  // Bound by the app to its analytics client. Must not throw — the gate calls it
+  // from a read path — but the gate swallows anything it does anyway.
+  emit: (emission: OfflineUsageEmission) => void;
+  now?: () => number;
+  // Counts at which an emission fires. Ascending, first entry should be 1 so the
+  // north-star is guaranteed on the first read.
+  ladder?: readonly number[];
+  // Hard backstop against any future call site turning this into a firehose:
+  // once this many emissions have fired in this process, the gate goes quiet
+  // until reset().
+  maxEmitsPerProcess?: number;
+};
+
+export type OfflineUsageSignal = {
+  recordRead: (read: { lane: OfflineReadLane; surface: OfflineReadSurface; boardName: string }) => void;
+  recordUnavailable: (miss: {
+    reason: OfflineUnavailableReason;
+    surface: OfflineReadSurface;
+    boardName: string;
+  }) => void;
+  reset: () => void;
+};
+
+const MILLISECONDS_PER_DAY = 86_400_000;
+const DEFAULT_LADDER: readonly number[] = [1, 10, 100];
+const DEFAULT_MAX_EMITS_PER_PROCESS = 60;
+
+// UTC epoch-day as a plain integer — no Intl, no Date object, no allocation, so
+// it is cheap enough to run on every suppressed read.
+function epochDay(timestamp: number): number {
+  return Math.floor(timestamp / MILLISECONDS_PER_DAY);
+}
+
+export function createOfflineUsageSignal({
+  emit,
+  now = Date.now,
+  ladder = DEFAULT_LADDER,
+  maxEmitsPerProcess = DEFAULT_MAX_EMITS_PER_PROCESS,
+}: OfflineUsageSignalOptions): OfflineUsageSignal {
+  const countsByKey = new Map<string, number>();
+  let currentEpochDay = epochDay(now());
+  let emitsThisProcess = 0;
+
+  // Returns the new count when it crossed a ladder rung, otherwise null.
+  function countAndCheckRung(key: string): number | null {
+    const day = epochDay(now());
+    if (day !== currentEpochDay) {
+      currentEpochDay = day;
+      countsByKey.clear();
+    }
+    const count = (countsByKey.get(key) ?? 0) + 1;
+    countsByKey.set(key, count);
+    if (!ladder.includes(count)) return null;
+    if (emitsThisProcess >= maxEmitsPerProcess) return null;
+    emitsThisProcess += 1;
+    return count;
+  }
+
+  // The gate owns the try/catch so no call site on a read path has to.
+  function safeEmit(emission: OfflineUsageEmission): void {
+    try {
+      emit(emission);
+    } catch {
+      // Telemetry must never break a read.
+    }
+  }
+
+  return {
+    recordRead({ lane, surface, boardName }) {
+      const readCount = countAndCheckRung(`served|${lane}|${boardName}`);
+      if (readCount === null) return;
+      safeEmit({ kind: 'served', lane, surface, boardName, readCount });
+    },
+    recordUnavailable({ reason, surface, boardName }) {
+      const readCount = countAndCheckRung(`unavailable|${reason}|${boardName}`);
+      if (readCount === null) return;
+      safeEmit({ kind: 'unavailable', reason, surface, boardName, readCount });
+    },
+    reset() {
+      countsByKey.clear();
+      currentEpochDay = epochDay(now());
+      emitsThisProcess = 0;
+    },
+  };
+}


### PR DESCRIPTION
Part 2 of two for #4317, stacked on #4322. **Base is `feat/4317-connectivity-super-property`** — review the diff against that branch, not `main`.

#4322 made every event say whether the network was usable. That still can't tell "offline and browsing my downloaded Kilter catalog" apart from "offline staring at an empty screen", and that distinction _is_ the value proposition the 2026-08-11 audit found unmeasured. This PR closes it and writes down the number the epic is trying to move.

Every offline-served read funnels through one function — `offlineAwareRequest()` in `packages/mobile/src/lib/graphql/offline-request.ts` — which already knows the lane it took. Four terminal outcomes are worth measuring:

| Outcome                           | Event                      | Lane / reason          |
| --------------------------------- | -------------------------- | ---------------------- |
| Offline, board downloaded         | `Offline Read Served`      | `offline_local`        |
| Network threw, board downloaded   | `Offline Read Served`      | `network_error_local`  |
| Online, flag on, board downloaded | `Offline Read Served`      | `online_local`         |
| Offline, nothing local            | `Offline Read Unavailable` | `board_not_downloaded` |
| Offline, filter not expressible   | `Offline Read Unavailable` | `filter_unsupported`   |

`network_error_local` counts toward the north-star: that is real offline value `onlineManager` mislabels as online (captive portal, dead gym-wifi upstream, cold-start seed race — the case `offline-request.ts` already documents). `online_local` is the flag-on latency short-circuit and is **excluded** — it proves the local path is exercised, nothing more, and it will dominate any unfiltered breakdown once #4312 bakes the flag on.

### Why this is a rollup, not a property on existing events

Search and its count fire on every keystroke. A per-read event is thousands per user per session, and PostHog's offline queue holds 1000 events and drops the **oldest** — so a chatty read event captured offline would evict the ticks and screens sharing that queue. That rules out the issue's option 1 as written.

So `createOfflineUsageSignal` (pure TS in `@boardsesh/offline-sync`, `emit` and `now` injected) counts reads per `(UTC epoch-day, lane, board)` and emits only when the count crosses `1`, `10` or `100`:

- A suppressed read costs one integer compare, one `Map` lookup and one increment. No I/O, no persistence, no battery.
- Worst case for a pathological user is 3 lanes × 2 boards × 3 rungs = 18 events/day; typical is one or two. A `maxEmitsPerProcess` backstop (60) stops any future call site turning it into a firehose.
- Rung 1 fires on the _first_ qualifying read, so the north-star can never be lost to an app kill. This is why the "one summary event at app background" option was rejected — for a north-star, losing the whole signal on a hard kill is the one failure mode you can't accept.
- `readCount` is therefore the **rung**, never a raw counter. The event comment and the doc both say so, because reading it as a per-read count would silently produce a wrong number rather than an error.

Two placement details worth a look in review, both of them silent-undercount bugs if they're wrong:

- The served signal sits on the **return path only**, so the online miss-retry that continues to the network is never counted as served. There's a test for it.
- The gate's map is in-memory and not keyed by user, so `resetOfflineUsageSignal()` runs on both sign-out paths in `auth-provider.tsx`. Without it a same-day account switch inherits the previous user's counters and the new user's first offline day never fires.

## Changes

- `packages/shared/offline-sync/src/telemetry/offline-usage-signal.ts` (new) — the rollup gate, exported from the package index. Zero runtime deps; it never imports an analytics client.
- `packages/shared/analytics/src/events.ts` — `OfflineReadServed` + `OfflineReadUnavailable`, with the rollup contract spelled out in the doc comment.
- `packages/mobile/src/offline/offline-usage-signal.ts` (new) — binds `emit` to `track()`, mirroring the existing `offline-sync-adapter.ts` pattern.
- `packages/mobile/src/lib/graphql/offline-request.ts` — a `surface` + `boardNameOf` per registration, and the four outcomes instrumented.
- `packages/mobile/src/providers/auth-provider.tsx` — reset on both sign-out paths.
- `docs/offline-sync-plan.md` — the event contract, the lane table, why not per-query, and the north-star written out verbatim.
- Tests: 13 cases on the gate (rungs, per-lane/per-board keys, epoch-day rollover, reset, the backstop, a throwing `emit`), one interceptor case per lane plus the miss-retry and no-variables edges, the emit→`SHARED_EVENTS` mapping, and the sign-out reset in `auth-provider.test.tsx`.

No new dependencies, no native config, no migration, no i18n keys. Ships over OTA.

## The dashboard

Built, not just described — [**Offline Mode** (dashboard 1987476)](https://us.posthog.com/project/412845/dashboard/1987476):

1. [North-Star] Weekly users with an offline-served read — offline lanes only, broken down by board.
2. [Depth] Weekly users who crossed 10+ offline reads in a day.
3. [Gap] Weekly users who went offline with nothing to read — broken down by `reason`.
4. [Conversion] Board downloaded → first offline-served read, 30-day window.
5. [Connectivity] Weekly users active with no network — from #4322's super property.

**Tiles 1–4 read empty until this ships to production binaries over OTA.** That is expected, not a broken query. Worth sanity-checking the prop names on the dashboard before it starts accumulating — a rename after the fact loses the history.

One deviation from the plan: tile 2 is "users who crossed the 10-read rung" rather than "median of max readCount per user". The rollup makes per-user max a HogQL exercise for a number the rung already answers, and a rung count is the honest shape of the data.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile`, `vp run typecheck:offline-sync`, `vp run typecheck:analytics` — all clean.
- `vp test run --project offline-sync --reporter=agent` — 22 files / 352 tests passed.
- `vp test run --project analytics --reporter=agent` — 4 files / 23 tests passed.
- `vp run test:mobile` — 623 files / 5504 tests passed.
- `vp run check:mobile-bundle` — android bundle OK.
- `vp check` — clean for every file this PR touches (the two pre-existing misses on `main`, `.claude/skills/discord-feedback-triage/SKILL.md` and `docs/discord-feedback-pipeline.md`, are untouched here).

Not verifiable on a dev build: `isAnalyticsEnabled = !!apiKey && !__DEV__`, so Metro only logs through the debug hook and never sends. Before this leaves draft it wants one pass on a `pr-<number>` OTA preview against a TestFlight binary: with Kilter downloaded, go into airplane mode, run a few searches and open a climb, kill the app, reconnect — expect exactly one `Offline Read Served { lane: 'offline_local' }` per lane/board for the day (not one per search), landing in PostHog with its original timestamp. Then remove the download and repeat for one `Offline Read Unavailable`.

Closes #4317

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT6VP1sWqk6bY9mUgyeS2U

