### PR TITLE
feat(sync): surface offline outbox write losses in telemetry

### DIFF
--- a/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
+++ b/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
@@ -67,6 +67,13 @@ vi.mock('../../lib/error-reporting', () => ({
   reportError: vi.fn(),
 }));
 
+// The gauge itself is unit-tested in offline/__tests__/outbox-telemetry.test.ts;
+// what matters here is WHERE the bridge calls it from — both flag branches, once.
+const reportOutboxBacklogOnceMock = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => {}));
+vi.mock('../../offline/outbox-telemetry', () => ({
+  reportOutboxBacklogOnce: reportOutboxBacklogOnceMock,
+}));
+
 // Stub the settings barrel so the static import graph never pulls
 // react-native-mmkv (its react-native Flow entry breaks Rolldown's scan).
 vi.mock('../../settings', () => ({
@@ -377,6 +384,43 @@ describe('OfflineSyncBridge — mid-session flag flips', () => {
 
     await waitFor(() => expect(startSyncSchedulerMock).toHaveBeenCalledTimes(1));
     expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});
+
+// Issue #4315: a kill-switched user's queued writes are exactly as stranded as a
+// flag-on user's — and sign-out deletes them all — so the launch gauge has to
+// run on both sides of the flag, and never on a signed-out launch.
+describe('OfflineSyncBridge — outbox backlog gauge', () => {
+  it('reads the backlog once with the flag ON', async () => {
+    render(<Harness flags={FLAG_ON} queryClient={makeQueryClient()} />);
+
+    await waitFor(() => expect(reportOutboxBacklogOnceMock).toHaveBeenCalledTimes(1));
+    expect(reportOutboxBacklogOnceMock).toHaveBeenCalledWith(fakeDb);
+  });
+
+  it('reads the backlog with the flag OFF too', async () => {
+    render(<Harness flags={FLAG_OFF} queryClient={makeQueryClient()} />);
+
+    await waitFor(() => expect(reportOutboxBacklogOnceMock).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not read anything while signed out', async () => {
+    isAuthenticated = false;
+    render(<Harness flags={FLAG_ON} queryClient={makeQueryClient()} />);
+
+    await waitFor(() => expect(startBackgroundTrackingMock).toHaveBeenCalled());
+    expect(reportOutboxBacklogOnceMock).not.toHaveBeenCalled();
+  });
+
+  it('does not re-read when the flag flips mid-session', async () => {
+    const queryClient = makeQueryClient();
+    const { rerender } = render(<Harness flags={FLAG_ON} queryClient={queryClient} />);
+    await waitFor(() => expect(reportOutboxBacklogOnceMock).toHaveBeenCalledTimes(1));
+
+    rerender(<Harness flags={FLAG_OFF} queryClient={queryClient} />);
+    await waitFor(() => expect(getPendingCountMock).toHaveBeenCalled());
+
+    expect(reportOutboxBacklogOnceMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/mobile/src/components/offline-sync-bridge.tsx
+++ b/packages/mobile/src/components/offline-sync-bridge.tsx
@@ -11,6 +11,7 @@ import {
   type GraphQLFetch,
 } from '@boardsesh/offline-sync';
 import { startSyncScheduler, drainMutationQueue, startBackgroundTracking } from '../offline/offline-sync-adapter';
+import { reportOutboxBacklogOnce } from '../offline/outbox-telemetry';
 import { getSetting } from '../settings';
 import { setupNotificationHandlers } from '../notifications';
 import { getHttpClient } from '../lib/graphql/client';
@@ -133,6 +134,16 @@ export function OfflineSyncBridge() {
       void queryClient.invalidateQueries({ queryKey: ['climb'] });
     }
   }, [offlineEnabled, queryClient]);
+
+  // How much unsynced work this launch inherited. Deliberately OUTSIDE the
+  // offlineEnabled branch below: a kill-switched user's queued writes (and dead
+  // letters) are exactly as stranded as a flag-on user's, and the bridge
+  // already drains their leftovers. reportOutboxBacklogOnce self-guards against
+  // this effect re-running on an auth or flag flip, and swallows its own errors.
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    void reportOutboxBacklogOnce(db);
+  }, [db, isAuthenticated]);
 
   // Push-then-pull sync loop (foreground + reconnect triggers). Returns its own
   // teardown, so React calls it on unmount / dependency change — including the

--- a/packages/mobile/src/hooks/__tests__/use-offline-mutations.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-offline-mutations.test.ts
@@ -30,6 +30,13 @@ vi.mock('@react-native-community/netinfo', () => ({
   default: { addEventListener: () => () => {} },
 }));
 
+// The reporter itself is unit-tested in offline/__tests__/outbox-telemetry.test.ts;
+// here we prove the write primitives feed it the right enqueue outcome.
+const reportEnqueueSuppressedMock = vi.hoisted(() => vi.fn());
+vi.mock('../../offline/outbox-telemetry', () => ({
+  reportEnqueueSuppressed: reportEnqueueSuppressedMock,
+}));
+
 import {
   writeTickLocal,
   addFavoriteLocal,
@@ -71,6 +78,7 @@ let db: TestSqliteDb;
 
 beforeEach(async () => {
   invalidateQueries.mockClear();
+  reportEnqueueSuppressedMock.mockClear();
   __resetDrainerStateForTests();
   db = createTestDatabase();
   await runMigrations(db);
@@ -236,5 +244,70 @@ describe('useOfflineUnfollowUser', () => {
     const queued = await db.getAllAsync<Row>('SELECT * FROM pending_mutations WHERE operation = ?', ['delete']);
     expect(queued).toHaveLength(1);
     expect(queued[0].idempotency_key).toBe('del:user_follows:user-42');
+  });
+});
+
+// Issue #4315. `enqueue` is INSERT OR IGNORE against a UNIQUE idempotency key,
+// and the cancel DELETEs in these primitives match only status = 'pending'. So
+// once a favorite/follow key dead-letters it owns that key forever: every later
+// tap writes the local row, gets silently dropped at enqueue time, and produces
+// no queue row to drain and therefore no dead-letter event anywhere. Making the
+// swallow countable is the point; reviving the row is a separate behaviour
+// change with its own issue.
+describe('enqueue suppressed by a dead-lettered key', () => {
+  const favorite = { boardName: 'kilter', climbUuid: 'climb-9', angle: 40 };
+
+  async function deadLetterExistingRow(idempotencyKey: string) {
+    await db.runAsync("UPDATE pending_mutations SET status = 'dead_letter' WHERE idempotency_key = ?", [
+      idempotencyKey,
+    ]);
+  }
+
+  it('reports when a favorite add is swallowed by a dead-lettered row', async () => {
+    await addFavoriteLocal(db, favorite);
+    await deadLetterExistingRow(favoriteAddKey(favorite));
+    reportEnqueueSuppressedMock.mockClear();
+
+    await addFavoriteLocal(db, favorite);
+
+    expect(reportEnqueueSuppressedMock).toHaveBeenCalledWith('user_favorites', 'create', 'dead_letter');
+    // The local row still exists, so the UI shows a favorite that will never sync.
+    const rows = await db.getAllAsync<Row>('SELECT * FROM user_favorites');
+    expect(rows).toHaveLength(1);
+  });
+
+  it('reports when a favorite remove is swallowed', async () => {
+    await removeFavoriteLocal(db, favorite);
+    await deadLetterExistingRow(favoriteRemoveKey(favorite));
+    reportEnqueueSuppressedMock.mockClear();
+
+    await removeFavoriteLocal(db, favorite);
+
+    expect(reportEnqueueSuppressedMock).toHaveBeenCalledWith('user_favorites', 'delete', 'dead_letter');
+  });
+
+  it('reports when a follow is swallowed', async () => {
+    const followUser = useOfflineFollowUser(db, parkedGraphqlFetch);
+    await followUser('user-42');
+    await deadLetterExistingRow('add:user_follows:user-42');
+    reportEnqueueSuppressedMock.mockClear();
+
+    await followUser('user-42');
+
+    expect(reportEnqueueSuppressedMock).toHaveBeenCalledWith('user_follows', 'create', 'dead_letter');
+  });
+
+  it('reports a live pending duplicate as pending, not as a loss', async () => {
+    await addFavoriteLocal(db, favorite);
+    reportEnqueueSuppressedMock.mockClear();
+
+    await addFavoriteLocal(db, favorite);
+
+    expect(reportEnqueueSuppressedMock).toHaveBeenCalledWith('user_favorites', 'create', 'pending');
+  });
+
+  it('never fires on a fresh insert', async () => {
+    await addFavoriteLocal(db, favorite);
+    expect(reportEnqueueSuppressedMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/hooks/use-offline-mutations.ts
+++ b/packages/mobile/src/hooks/use-offline-mutations.ts
@@ -4,10 +4,12 @@ import {
   applyBusyTimeout,
   enqueue,
   getLocalUserId,
+  type EnqueueResult,
   type GraphQLFetch,
   type OfflineDatabase,
 } from '@boardsesh/offline-sync';
 import { drainMutationQueue } from '../offline/offline-sync-adapter';
+import { reportEnqueueSuppressed } from '../offline/outbox-telemetry';
 import type { SaveTickMutationVariables } from '../lib/graphql/operations';
 
 export type SaveTickInput = SaveTickMutationVariables['input'];
@@ -69,6 +71,10 @@ export async function writeTickLocal(db: OfflineDatabase, input: SaveTickInput, 
       ],
     );
 
+    // No suppressed-enqueue check here, and that is a property of the key, not
+    // an oversight: every tick gets a fresh uuid, so this INSERT OR IGNORE can
+    // never collide with an existing row. A future tick key derived from
+    // climb+angle would inherit the favorites blind spot below — re-check then.
     await enqueue(txn, 'boardsesh_ticks', 'create', input, tickUuid);
   });
 }
@@ -83,6 +89,11 @@ export function favoriteRemoveKey(input: FavoriteInput): string {
 
 export async function addFavoriteLocal(db: OfflineDatabase, input: FavoriteInput): Promise<void> {
   const now = new Date().toISOString();
+  // Captured inside the transaction, reported after it commits: the report
+  // reaches Sentry/PostHog, and neither belongs on a held write lock. A holder
+  // object rather than a `let` because TypeScript doesn't track assignments made
+  // inside a callback.
+  const enqueueOutcome = newEnqueueOutcome();
 
   await db.withExclusiveTransactionAsync(async (txn) => {
     await applyBusyTimeout(txn);
@@ -98,11 +109,32 @@ export async function addFavoriteLocal(db: OfflineDatabase, input: FavoriteInput
     await txn.runAsync(`DELETE FROM pending_mutations WHERE idempotency_key = ? AND status = 'pending'`, [
       favoriteRemoveKey(input),
     ]);
-    await enqueue(txn, 'user_favorites', 'create', input, favoriteAddKey(input));
+    enqueueOutcome.result = await enqueue(txn, 'user_favorites', 'create', input, favoriteAddKey(input));
   });
+
+  // The cancel DELETE above matches only `status = 'pending'`, so a
+  // dead-lettered add keeps owning this UNIQUE key forever and every later add
+  // for the same climb/angle is dropped right here — local row written, nothing
+  // queued, nothing to drain. Reviving that row is a behaviour change with its
+  // own issue; this makes the swallow countable.
+  reportSuppressedEnqueue('user_favorites', 'create', enqueueOutcome);
+}
+
+type EnqueueOutcome = { result: EnqueueResult | null };
+
+function newEnqueueOutcome(): EnqueueOutcome {
+  return { result: null };
+}
+
+function reportSuppressedEnqueue(tableName: string, operation: 'create' | 'delete', outcome: EnqueueOutcome): void {
+  const { result } = outcome;
+  if (result === null || result.inserted) return;
+  reportEnqueueSuppressed(tableName, operation, result.existingStatus);
 }
 
 export async function removeFavoriteLocal(db: OfflineDatabase, input: FavoriteInput): Promise<void> {
+  const enqueueOutcome = newEnqueueOutcome();
+
   await db.withExclusiveTransactionAsync(async (txn) => {
     await applyBusyTimeout(txn);
     await txn.runAsync(`DELETE FROM user_favorites WHERE board_name = ? AND climb_uuid = ? AND angle = ?`, [
@@ -120,8 +152,10 @@ export async function removeFavoriteLocal(db: OfflineDatabase, input: FavoriteIn
     await txn.runAsync(`DELETE FROM pending_mutations WHERE idempotency_key = ? AND status = 'pending'`, [
       favoriteAddKey(input),
     ]);
-    await enqueue(txn, 'user_favorites', 'delete', input, favoriteRemoveKey(input));
+    enqueueOutcome.result = await enqueue(txn, 'user_favorites', 'delete', input, favoriteRemoveKey(input));
   });
+
+  reportSuppressedEnqueue('user_favorites', 'delete', enqueueOutcome);
 }
 
 export function useOfflineFollowUser(db: OfflineDatabase, graphqlFetch: GraphQLFetch) {
@@ -131,6 +165,7 @@ export function useOfflineFollowUser(db: OfflineDatabase, graphqlFetch: GraphQLF
     async (followingId: string) => {
       const now = new Date().toISOString();
       const idempotencyKey = `add:user_follows:${followingId}`;
+      const enqueueOutcome = newEnqueueOutcome();
 
       await db.withExclusiveTransactionAsync(async (txn) => {
         await applyBusyTimeout(txn);
@@ -147,8 +182,10 @@ export function useOfflineFollowUser(db: OfflineDatabase, graphqlFetch: GraphQLF
         await txn.runAsync(`DELETE FROM pending_mutations WHERE idempotency_key = ? AND status = 'pending'`, [
           `del:user_follows:${followingId}`,
         ]);
-        await enqueue(txn, 'user_follows', 'create', { followingId }, idempotencyKey);
+        enqueueOutcome.result = await enqueue(txn, 'user_follows', 'create', { followingId }, idempotencyKey);
       });
+
+      reportSuppressedEnqueue('user_follows', 'create', enqueueOutcome);
 
       queryClient.invalidateQueries({ queryKey: ['followers'] });
       queryClient.invalidateQueries({ queryKey: ['following'] });
@@ -165,6 +202,7 @@ export function useOfflineUnfollowUser(db: OfflineDatabase, graphqlFetch: GraphQ
   return useCallback(
     async (followingId: string) => {
       const idempotencyKey = `del:user_follows:${followingId}`;
+      const enqueueOutcome = newEnqueueOutcome();
 
       await db.withExclusiveTransactionAsync(async (txn) => {
         await applyBusyTimeout(txn);
@@ -176,8 +214,10 @@ export function useOfflineUnfollowUser(db: OfflineDatabase, graphqlFetch: GraphQ
         await txn.runAsync(`DELETE FROM pending_mutations WHERE idempotency_key = ? AND status = 'pending'`, [
           `add:user_follows:${followingId}`,
         ]);
-        await enqueue(txn, 'user_follows', 'delete', { followingId }, idempotencyKey);
+        enqueueOutcome.result = await enqueue(txn, 'user_follows', 'delete', { followingId }, idempotencyKey);
       });
+
+      reportSuppressedEnqueue('user_follows', 'delete', enqueueOutcome);
 
       queryClient.invalidateQueries({ queryKey: ['followers'] });
       queryClient.invalidateQueries({ queryKey: ['following'] });

--- a/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
+++ b/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
@@ -67,6 +67,7 @@ import {
 import type {
   OfflineDatabase,
   DrainOptions,
+  MutationDeadLetterInfo,
   MutationDeliveryEvent,
   SchedulerTriggers,
   SchedulerOptions,
@@ -158,6 +159,77 @@ describe('drainMutationQueue binding', () => {
       unsubscribeThrowing();
       unsubscribeLater();
     }
+  });
+});
+
+// Issue #4315: before this binding a dead-lettered write — a user action that
+// will never reach the server — produced nothing in Sentry and nothing in
+// PostHog. The drainer never dead-letters for lack of a connection, so every
+// one of these is a real, permanent loss.
+describe('dead-letter binding', () => {
+  const deadLetterInfo = (overrides: Partial<MutationDeadLetterInfo> = {}): MutationDeadLetterInfo => ({
+    tableName: 'user_favorites',
+    operation: 'create',
+    idempotencyKey: 'add:user_favorites:kilter:climb-uuid:40',
+    reason: 'non_retryable',
+    retryCount: 2,
+    maxRetries: 10,
+    queuedForMs: 90_000,
+    status: 400,
+    errorMessage: 'Bad Request',
+    error: new Error('Bad Request'),
+    ...overrides,
+  });
+
+  it('reports to Sentry with the original error as cause and to analytics without the idempotency key', async () => {
+    await drainMutationQueue(db, queryClient, graphqlFetch);
+    const options = drainMutationQueueCore.mock.calls[0][3] as DrainOptions;
+    const info = deadLetterInfo();
+
+    options.onMutationDeadLettered?.(info);
+
+    expect(reportHandledError).toHaveBeenCalledTimes(1);
+    const [reportedError, context] = reportHandledError.mock.calls[0] as [Error, { tags: Record<string, unknown> }];
+    expect(reportedError.cause).toBe(info.error);
+    expect(context.tags).toEqual({ source: 'offline-sync', kind: 'mutation-dead-letter', reason: 'non_retryable' });
+
+    expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineMutationDeadLettered, {
+      tableName: 'user_favorites',
+      operation: 'create',
+      reason: 'non_retryable',
+      retryCount: 2,
+      status: 400,
+      queuedForMs: 90_000,
+      error: 'Bad Request',
+    });
+    const [, trackedProps] = trackMock.mock.calls[0] as [string, Record<string, unknown>];
+    expect(trackedProps).not.toHaveProperty('idempotencyKey');
+  });
+
+  it('runs telemetry even when the caller supplies its own handler', async () => {
+    const callerHandler = vi.fn();
+    await drainMutationQueue(db, queryClient, graphqlFetch, { onMutationDeadLettered: callerHandler });
+    const options = drainMutationQueueCore.mock.calls[0][3] as DrainOptions;
+    const info = deadLetterInfo({ reason: 'retries_exhausted' });
+
+    options.onMutationDeadLettered?.(info);
+
+    expect(callerHandler).toHaveBeenCalledWith(info);
+    expect(reportHandledError).toHaveBeenCalledTimes(1);
+    expect(trackMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('still reports when a caller-supplied handler throws', async () => {
+    await drainMutationQueue(db, queryClient, graphqlFetch, {
+      onMutationDeadLettered: () => {
+        throw new Error('caller exploded');
+      },
+    });
+    const options = drainMutationQueueCore.mock.calls[0][3] as DrainOptions;
+
+    expect(() => options.onMutationDeadLettered?.(deadLetterInfo())).toThrow('caller exploded');
+    expect(reportHandledError).toHaveBeenCalledTimes(1);
+    expect(trackMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/mobile/src/offline/__tests__/outbox-telemetry.test.ts
+++ b/packages/mobile/src/offline/__tests__/outbox-telemetry.test.ts
@@ -1,0 +1,129 @@
+// Issue #4315: the three offline-write losses the drainer's own telemetry can
+// never see — a backlog that predates the per-mutation events, sign-out
+// deleting the whole outbox, and an enqueue swallowed at INSERT time.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getOutboxSummaryMock = vi.hoisted(() => vi.fn());
+vi.mock('@boardsesh/offline-sync', async () => {
+  const actual = await vi.importActual<typeof import('@boardsesh/offline-sync')>('@boardsesh/offline-sync');
+  return { ...actual, getOutboxSummary: getOutboxSummaryMock };
+});
+
+const trackMock = vi.hoisted(() => vi.fn());
+vi.mock('../../lib/analytics', () => ({ track: trackMock }));
+
+const reportHandledErrorMock = vi.hoisted(() => vi.fn());
+vi.mock('../../lib/error-reporting', () => ({ reportHandledError: reportHandledErrorMock }));
+
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import type { SqlExecutor } from '@boardsesh/offline-sync';
+import {
+  reportOutboxBacklogOnce,
+  reportOutboxDiscardedOnSignOut,
+  reportEnqueueSuppressed,
+  __resetOutboxTelemetryForTests,
+} from '../outbox-telemetry';
+
+const db = {} as SqlExecutor;
+
+const emptyOutbox = { pendingCount: 0, deadLetterCount: 0, oldestPendingAt: null, oldestDeadLetterAt: null };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetOutboxTelemetryForTests();
+  getOutboxSummaryMock.mockResolvedValue(emptyOutbox);
+});
+
+describe('reportOutboxBacklogOnce', () => {
+  it('emits once with counts and ages when work is queued', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-12T00:00:00Z'));
+    getOutboxSummaryMock.mockResolvedValue({
+      pendingCount: 4,
+      deadLetterCount: 1,
+      oldestPendingAt: '2026-08-10 00:00:00',
+      oldestDeadLetterAt: '2026-08-02 00:00:00',
+    });
+
+    await reportOutboxBacklogOnce(db);
+
+    expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineOutboxBacklogDetected, {
+      pendingCount: 4,
+      deadLetterCount: 1,
+      oldestPendingAgeDays: 2,
+      oldestDeadLetterAgeDays: 10,
+    });
+    vi.useRealTimers();
+  });
+
+  it('stays silent on an empty outbox', async () => {
+    await reportOutboxBacklogOnce(db);
+    expect(trackMock).not.toHaveBeenCalled();
+  });
+
+  it('does not fire twice when the bridge effect re-runs', async () => {
+    getOutboxSummaryMock.mockResolvedValue({ ...emptyOutbox, deadLetterCount: 2 });
+
+    await reportOutboxBacklogOnce(db);
+    await reportOutboxBacklogOnce(db);
+
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(getOutboxSummaryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows a failed read rather than taking the sync bridge down', async () => {
+    getOutboxSummaryMock.mockRejectedValue(new Error('database is locked'));
+    await expect(reportOutboxBacklogOnce(db)).resolves.toBeUndefined();
+    expect(trackMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('reportOutboxDiscardedOnSignOut', () => {
+  it('reports what the sign-out wipe is about to delete', async () => {
+    getOutboxSummaryMock.mockResolvedValue({ ...emptyOutbox, pendingCount: 1, deadLetterCount: 3 });
+
+    await reportOutboxDiscardedOnSignOut(db);
+
+    expect(trackMock).toHaveBeenCalledWith(
+      SHARED_EVENTS.OfflineOutboxDiscardedOnSignOut,
+      expect.objectContaining({ pendingCount: 1, deadLetterCount: 3 }),
+    );
+  });
+
+  it('is not once-per-launch — every sign-out reports its own loss', async () => {
+    getOutboxSummaryMock.mockResolvedValue({ ...emptyOutbox, deadLetterCount: 1 });
+
+    await reportOutboxDiscardedOnSignOut(db);
+    await reportOutboxDiscardedOnSignOut(db);
+
+    expect(trackMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('never throws, so a wedged database cannot block sign-out', async () => {
+    getOutboxSummaryMock.mockRejectedValue(new Error('database is locked'));
+    await expect(reportOutboxDiscardedOnSignOut(db)).resolves.toBeUndefined();
+  });
+});
+
+describe('reportEnqueueSuppressed', () => {
+  it('reports a suppression against a dead-lettered row', () => {
+    reportEnqueueSuppressed('user_favorites', 'create', 'dead_letter');
+
+    expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineMutationEnqueueSuppressed, {
+      tableName: 'user_favorites',
+      operation: 'create',
+      existingStatus: 'dead_letter',
+    });
+    expect(reportHandledErrorMock).toHaveBeenCalledTimes(1);
+  });
+
+  // A duplicate against a live pending row is correct dedup (a double-tapped
+  // favorite while offline). Reporting it would bury the real signal.
+  it.each(['pending', null])('stays silent for existingStatus %p', (existingStatus) => {
+    reportEnqueueSuppressed('user_favorites', 'create', existingStatus);
+
+    expect(trackMock).not.toHaveBeenCalled();
+    expect(reportHandledErrorMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/offline/offline-sync-adapter.ts
+++ b/packages/mobile/src/offline/offline-sync-adapter.ts
@@ -26,6 +26,7 @@ import {
   pullSync as pullSyncCore,
   setBackgrounded,
   type DrainOptions,
+  type MutationDeadLetterReporter,
   type MutationDeliveryEvent,
   type MutationStatusListenerFailure,
   type DrainQueue,
@@ -41,11 +42,14 @@ import {
   type SyncOptions,
   type SyncProgressSink,
 } from '@boardsesh/offline-sync';
-import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { SHARED_EVENTS, sanitizeErrorForAnalytics } from '@boardsesh/analytics';
 import { reportHandledError } from '../lib/error-reporting';
 import { track } from '../lib/analytics';
 
-const isOnline = () => onlineManager.isOnline();
+// Exported so non-drain reporters can record the one dimension that decides
+// whether a failed local write actually lost data: a tick that falls through to
+// the network save is fine online and gone offline (see board-adapter).
+export const isOnline = () => onlineManager.isOnline();
 
 const mutationDeliveryListeners = new Set<(event: MutationDeliveryEvent) => void>();
 
@@ -74,6 +78,43 @@ function publishMutationDelivery(event: MutationDeliveryEvent): void {
     }
   }
 }
+
+// A queued write we will never deliver. Both channels are deliberate: Sentry
+// because a dead letter is a defect (the drainer never dead-letters for lack of
+// a connection, so this is always a real rejection or an exhausted retry
+// budget), and PostHog because only a rate across the fleet says whether it is
+// one broken account or a systemic loss. The `{ cause }` is load-bearing for the
+// same reason it is on reportSnapshotBootstrapError: reportHandledError
+// classifies what it is handed, and a synthetic wrapper with no cause matches
+// nothing (issue #4238).
+const reportMutationDeadLettered: MutationDeadLetterReporter = ({
+  tableName,
+  operation,
+  idempotencyKey,
+  reason,
+  retryCount,
+  maxRetries,
+  queuedForMs,
+  status,
+  errorMessage,
+  error,
+}) => {
+  reportHandledError(new Error(`Offline ${tableName} ${operation} dead-lettered (${reason})`, { cause: error }), {
+    tags: { source: 'offline-sync', kind: 'mutation-dead-letter', reason },
+    extra: { tableName, operation, idempotencyKey, reason, retryCount, maxRetries, status, queuedForMs, errorMessage },
+  });
+  // idempotencyKey stays out of the analytics props on purpose: it is a raw
+  // uuid for ticks and a per-climb key for favorites, i.e. unbounded cardinality.
+  track(SHARED_EVENTS.OfflineMutationDeadLettered, {
+    tableName,
+    operation,
+    reason,
+    retryCount,
+    status,
+    queuedForMs,
+    error: sanitizeErrorForAnalytics(error),
+  });
+};
 
 const reportSchemaDrift: SchemaDriftReporter = ({ tableName, column }) => {
   reportHandledError(new Error(`Sync document for ${tableName} contains unknown column: ${column}`), {
@@ -192,6 +233,16 @@ export function drainMutationQueue(
         options?.onMutationStatus?.(event);
       } finally {
         publishMutationDelivery(event);
+      }
+    },
+    // Composed, not defaulted (unlike the reporters above): telemetry for a
+    // permanently lost write must not be something a call site can opt out of
+    // by passing its own handler.
+    onMutationDeadLettered: (info) => {
+      try {
+        options?.onMutationDeadLettered?.(info);
+      } finally {
+        reportMutationDeadLettered(info);
       }
     },
   });

--- a/packages/mobile/src/offline/outbox-telemetry.ts
+++ b/packages/mobile/src/offline/outbox-telemetry.ts
@@ -1,0 +1,102 @@
+// Telemetry for offline writes that are lost somewhere other than the drain
+// loop. The drainer's own dead-letter seam (offline-sync-adapter) covers writes
+// the server permanently rejects; these three cover the losses it structurally
+// cannot see:
+//
+//   1. Backlog at launch — per-mutation events only count from the day they
+//      ship, so a queue that piled up earlier is invisible without a gauge.
+//   2. Sign-out — clearUserData DELETEs pending_mutations wholesale, dead
+//      letters included, with no drain attempt for them (the pre-sign-out drain
+//      gates on getPendingCount, which filters status = 'pending').
+//   3. Suppressed enqueue — `INSERT OR IGNORE` against a deterministic
+//      idempotency key silently drops a repeat favorite/follow whenever the
+//      existing row is already a dead letter. The drop happens at enqueue time,
+//      so no drain and no dead-letter event ever mentions it.
+
+import { getOutboxSummary, queueTimestampAgeDays, type OutboxSummary, type SqlExecutor } from '@boardsesh/offline-sync';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { track } from '../lib/analytics';
+import { reportHandledError } from '../lib/error-reporting';
+
+type OutboxGaugeProps = {
+  pendingCount: number;
+  deadLetterCount: number;
+  oldestPendingAgeDays: number | null;
+  oldestDeadLetterAgeDays: number | null;
+};
+
+function toGaugeProps(summary: OutboxSummary): OutboxGaugeProps {
+  return {
+    pendingCount: summary.pendingCount,
+    deadLetterCount: summary.deadLetterCount,
+    oldestPendingAgeDays: queueTimestampAgeDays(summary.oldestPendingAt),
+    oldestDeadLetterAgeDays: queueTimestampAgeDays(summary.oldestDeadLetterAt),
+  };
+}
+
+// Once per JS runtime, not once per effect: the bridge's sync effect re-runs on
+// a flag flip, an auth flip, or a snapshotSource change, and a gauge that fired
+// on each of those would read as several backlogs rather than one.
+let hasReportedOutboxBacklog = false;
+
+/**
+ * Report the outbox backlog this launch inherited, at most once per runtime and
+ * only when something is actually queued. Never throws: a failed read must not
+ * take the sync bridge down with it.
+ */
+export async function reportOutboxBacklogOnce(db: SqlExecutor): Promise<void> {
+  if (hasReportedOutboxBacklog) return;
+  hasReportedOutboxBacklog = true;
+  try {
+    const summary = await getOutboxSummary(db);
+    if (summary.pendingCount === 0 && summary.deadLetterCount === 0) return;
+    track(SHARED_EVENTS.OfflineOutboxBacklogDetected, toGaugeProps(summary));
+  } catch (error) {
+    if (__DEV__) console.warn('[OutboxTelemetry] backlog gauge failed:', error);
+  }
+}
+
+/**
+ * Report what sign-out is about to delete. MUST be awaited before
+ * resetAnalytics(), or the event lands on an anonymous distinct_id and can no
+ * longer be joined to the account that lost the writes. Never throws, so a
+ * wedged database can't block sign-out.
+ */
+export async function reportOutboxDiscardedOnSignOut(db: SqlExecutor): Promise<void> {
+  try {
+    const summary = await getOutboxSummary(db);
+    if (summary.pendingCount === 0 && summary.deadLetterCount === 0) return;
+    track(SHARED_EVENTS.OfflineOutboxDiscardedOnSignOut, toGaugeProps(summary));
+  } catch (error) {
+    if (__DEV__) console.warn('[OutboxTelemetry] sign-out discard gauge failed:', error);
+  }
+}
+
+/**
+ * Report a repeat write that `INSERT OR IGNORE` swallowed because a
+ * dead-lettered row already holds its idempotency key.
+ *
+ * Only the dead-letter case is reported. A suppression against a `pending` row
+ * is correct dedup — a double-tapped favorite while offline — and reporting it
+ * would bury the signal under the common case.
+ */
+export function reportEnqueueSuppressed(
+  tableName: string,
+  operation: 'create' | 'delete',
+  existingStatus: string | null,
+): void {
+  if (existingStatus !== 'dead_letter') return;
+  try {
+    reportHandledError(new Error(`Offline ${tableName} ${operation} suppressed by a dead-lettered queue row`), {
+      tags: { source: 'offline-sync', kind: 'mutation-enqueue-suppressed' },
+      extra: { tableName, operation, existingStatus },
+    });
+    track(SHARED_EVENTS.OfflineMutationEnqueueSuppressed, { tableName, operation, existingStatus });
+  } catch (error) {
+    if (__DEV__) console.warn('[OutboxTelemetry] suppressed-enqueue report failed:', error);
+  }
+}
+
+export function __resetOutboxTelemetryForTests(): void {
+  hasReportedOutboxBacklog = false;
+}

--- a/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
@@ -174,9 +174,18 @@ vi.mock('../../lib/error-reporting', () => ({
   reportHandledError: (...args: unknown[]) => reportHandledErrorMock(...args),
 }));
 
+const resetAnalyticsMock = vi.hoisted(() => vi.fn());
 vi.mock('../../lib/analytics', () => ({
-  reset: vi.fn(),
+  reset: resetAnalyticsMock,
   track: (...args: unknown[]) => trackMock(...args),
+}));
+
+// Sign-out is about to DELETE the whole outbox (dead letters included). The
+// gauge that measures it must run before resetAnalytics() or the event lands on
+// an anonymous distinct_id — see the ordering test near the bottom of this file.
+const reportOutboxDiscardedOnSignOutMock = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => {}));
+vi.mock('../../offline/outbox-telemetry', () => ({
+  reportOutboxDiscardedOnSignOut: reportOutboxDiscardedOnSignOutMock,
 }));
 
 vi.mock('../../lib/oauth-pending-store', () => ({
@@ -1009,6 +1018,44 @@ describe('AuthProvider.signOut mutation-queue drain gating', () => {
 
     expect(getPendingCountMock).not.toHaveBeenCalled();
     expect(drainMutationQueueMock).not.toHaveBeenCalled();
+  });
+
+  // Issue #4315. clearUserData DELETEs pending_mutations wholesale, and the
+  // best-effort drain above skips dead letters entirely (getPendingCount filters
+  // status = 'pending'), so this gauge is the only record that those writes
+  // existed. The ordering is the whole correctness of it: after
+  // resetAnalytics() the event carries an anonymous distinct_id and can never be
+  // joined back to the account that lost them.
+  it('measures the outbox before resetting analytics', async () => {
+    resetAnalyticsMock.mockClear();
+    reportOutboxDiscardedOnSignOutMock.mockClear();
+
+    await signOutWithQueueState(0);
+
+    expect(reportOutboxDiscardedOnSignOutMock).toHaveBeenCalledWith({ tag: 'db' });
+    expect(resetAnalyticsMock).toHaveBeenCalled();
+    const gaugeOrder = reportOutboxDiscardedOnSignOutMock.mock.invocationCallOrder[0];
+    const resetOrder = resetAnalyticsMock.mock.invocationCallOrder[0];
+    expect(gaugeOrder).toBeLessThan(resetOrder);
+  });
+
+  it('skips the gauge when there is no local database', async () => {
+    reportOutboxDiscardedOnSignOutMock.mockClear();
+    getDatabaseHandleMock.mockReturnValue(null);
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>{children}</AuthProvider>
+      </QueryClientProvider>
+    );
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+    await act(async () => {
+      await result.current.signOut();
+    });
+
+    expect(reportOutboxDiscardedOnSignOutMock).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/mobile/src/providers/__tests__/board-adapter.test.tsx
+++ b/packages/mobile/src/providers/__tests__/board-adapter.test.tsx
@@ -75,25 +75,35 @@ vi.mock('../../lib/graphql/ws-client', () => ({
   getWsClient: wsMocks.getClient,
 }));
 
+const reportHandledErrorMock = vi.hoisted(() => vi.fn());
 vi.mock('../../lib/error-reporting', () => ({
-  reportHandledError: vi.fn(),
+  reportHandledError: reportHandledErrorMock,
 }));
 
+const trackMock = vi.hoisted(() => vi.fn());
+vi.mock('../../lib/analytics', () => ({ track: trackMock }));
+
+const isOnlineMock = vi.hoisted(() => vi.fn(() => true));
 vi.mock('../../offline/offline-sync-adapter', () => ({
   drainMutationQueue: vi.fn(async () => {}),
   subscribeMutationDelivery: vi.fn(() => () => {}),
+  isOnline: isOnlineMock,
 }));
 
+const writeTickLocalMock = vi.hoisted(() => vi.fn(async () => {}));
 vi.mock('../../hooks/use-offline-mutations', () => ({
-  writeTickLocal: vi.fn(async () => {}),
+  writeTickLocal: writeTickLocalMock,
 }));
 
+import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { BoardAdapterWrapper } from '../board-adapter';
 
 beforeEach(() => {
   vi.clearAllMocks();
   offlineEnabled = false;
   capturedAdapter = undefined;
+  isOnlineMock.mockReturnValue(true);
+  writeTickLocalMock.mockResolvedValue(undefined);
 });
 
 describe('BoardAdapterWrapper offline gating', () => {
@@ -145,5 +155,69 @@ describe('BoardAdapterWrapper offline gating', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// Issue #4315. When the local write throws, saveTickOffline returns null and
+// useSaveTick falls through to a direct network save. Online that still lands;
+// OFFLINE the network save fails and the tick is gone. Nothing in the old
+// report distinguished those two, so the Sentry count could not tell us how
+// many ticks were actually lost.
+describe('BoardAdapterWrapper tick-local-write telemetry', () => {
+  async function saveTickWithLocalWriteError(error: unknown) {
+    offlineEnabled = true;
+    writeTickLocalMock.mockRejectedValue(error);
+    render(<BoardAdapterWrapper>{null}</BoardAdapterWrapper>);
+    const queryClient = { invalidateQueries: vi.fn() };
+    return capturedAdapter?.saveTickOffline?.(
+      { input: { climbUuid: 'climb-1', angle: 40 } } as never,
+      { queryClient, executeHttp: vi.fn() } as never,
+    );
+  }
+
+  it('keeps returning null so the network fall-through is unchanged', async () => {
+    await expect(saveTickWithLocalWriteError(new Error('disk I/O error'))).resolves.toBeNull();
+  });
+
+  it.each([
+    ['a lock error while offline', new Error('database is locked'), false, true, true],
+    ['a lock error while online', new Error('database is locked'), true, false, true],
+    ['a non-lock error while offline', new Error('disk I/O error'), false, true, false],
+    ['a non-lock error while online', new Error('disk I/O error'), true, false, false],
+  ])('tags %s', async (_label, error, online, expectedWasOffline, expectedIsLockError) => {
+    isOnlineMock.mockReturnValue(online);
+
+    await saveTickWithLocalWriteError(error);
+
+    expect(reportHandledErrorMock).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({
+        tags: {
+          source: 'offline-sync',
+          // Unchanged so the existing 90-day Sentry trend stays comparable.
+          kind: 'tick-local-write',
+          was_offline: expectedWasOffline,
+          is_lock_error: expectedIsLockError,
+        },
+      }),
+    );
+    expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineTickLocalWriteFailed, {
+      isLockError: expectedIsLockError,
+      wasOffline: expectedWasOffline,
+      error: expect.any(String),
+    });
+  });
+
+  it('emits nothing when the local write succeeds', async () => {
+    offlineEnabled = true;
+    render(<BoardAdapterWrapper>{null}</BoardAdapterWrapper>);
+
+    await capturedAdapter?.saveTickOffline?.(
+      { input: { climbUuid: 'climb-1', angle: 40 } } as never,
+      { queryClient: { invalidateQueries: vi.fn() }, executeHttp: vi.fn() } as never,
+    );
+
+    expect(reportHandledErrorMock).not.toHaveBeenCalled();
+    expect(trackMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -37,6 +37,7 @@ import { clearUserData, getDatabaseHandle } from '../db';
 import { setSetting, clearOfflineBoards } from '../settings';
 import { getPendingCount, setSigningOut } from '@boardsesh/offline-sync';
 import { drainMutationQueue } from '../offline/offline-sync-adapter';
+import { reportOutboxDiscardedOnSignOut } from '../offline/outbox-telemetry';
 import { stopTokenManagement } from '../notifications';
 import { consumeFreshOAuthPending } from '../lib/oauth-pending-store';
 import { consumeWebOAuthReturn } from '../lib/oauth-return';
@@ -234,6 +235,16 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
   const runSignedOutCleanup = useCallback(
     async (transitionEpoch: number, storageOwner?: UserStorageOwner | null): Promise<boolean> => {
       if (!isAuthTransitionCurrent(transitionEpoch)) return false;
+      // What the wipe below is about to delete. clearUserData DELETEs
+      // pending_mutations wholesale — dead letters included, and those never get
+      // a drain attempt (the pre-sign-out drain gates on getPendingCount, which
+      // filters status = 'pending'). This MUST stay ahead of resetAnalytics():
+      // afterwards the event would land on an anonymous distinct_id and could no
+      // longer be joined to the account that lost the writes. Sitting in
+      // runSignedOutCleanup rather than in the manual signOut covers all three
+      // paths — manual, forced 401, and proactive expiry.
+      const localDb = getDatabaseHandle();
+      if (localDb) await reportOutboxDiscardedOnSignOut(localDb);
       resetAnalytics();
       const stopTokenCleanup = stopTokenManagement(async () => {});
       if (Platform.OS === 'web') await waitForCleanupPhase(stopTokenCleanup);

--- a/packages/mobile/src/providers/board-adapter.tsx
+++ b/packages/mobile/src/providers/board-adapter.tsx
@@ -23,8 +23,11 @@ import { getHttpClient } from '../lib/graphql/client';
 import { captureAuthCredentialGeneration, isAuthCredentialGenerationCurrent } from '../lib/auth-store';
 import { reportHandledError } from '../lib/error-reporting';
 import { getWsClient } from '../lib/graphql/ws-client';
-import { drainMutationQueue, subscribeMutationDelivery } from '../offline/offline-sync-adapter';
+import { drainMutationQueue, isOnline, subscribeMutationDelivery } from '../offline/offline-sync-adapter';
 import { writeTickLocal } from '../hooks/use-offline-mutations';
+import { isDatabaseLockedError } from '@boardsesh/offline-sync';
+import { SHARED_EVENTS, sanitizeErrorForAnalytics } from '@boardsesh/analytics';
+import { track } from '../lib/analytics';
 
 export function BoardAdapterWrapper({ children }: { children: ReactNode }) {
   const { isAuthenticated, isLoading } = useAuth();
@@ -138,7 +141,31 @@ export function BoardAdapterWrapper({ children }: { children: ReactNode }) {
               // returning null falls through to the direct network save in
               // useSaveTick. Offline, that network attempt fails visibly — same
               // outcome as today — but online the send still lands.
-              reportHandledError(error, { tags: { source: 'offline-sync', kind: 'tick-local-write' } });
+              //
+              // The two dimensions on the report are what the Sentry trend alone
+              // could never answer. `wasOffline` splits "fell through and landed"
+              // from "fell through and the tick is gone" — the only version of
+              // this failure that actually loses data. `isLockError` says whether
+              // it was write-lock contention (the snapshot import holding a long
+              // EXCLUSIVE, #4314) or a genuinely broken database, which need
+              // completely different fixes. The `kind` tag is unchanged on
+              // purpose so the existing 90-day trend stays comparable.
+              const wasOffline = !isOnline();
+              const isLockError = isDatabaseLockedError(error);
+              reportHandledError(error, {
+                tags: {
+                  source: 'offline-sync',
+                  kind: 'tick-local-write',
+                  was_offline: wasOffline,
+                  is_lock_error: isLockError,
+                },
+                extra: { errorMessage: error instanceof Error ? error.message : String(error) },
+              });
+              track(SHARED_EVENTS.OfflineTickLocalWriteFailed, {
+                isLockError,
+                wasOffline,
+                error: sanitizeErrorForAnalytics(error),
+              });
               return null;
             }
             // Wake the "waiting to sync" badge immediately: its query caches with

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -337,6 +337,37 @@ export const SHARED_EVENTS = {
   // pendingMutations }. Downloaded board catalogs are deliberately untouched,
   // so this never implies a surprise re-download.
   OfflineSyncCoverageResetForced: 'Offline Sync Coverage Reset Forced',
+  // Offline sync — a queued write was given up on permanently. A dead letter is
+  // never a connectivity problem (a network error leaves the row pending
+  // without burning retry_count), so each one is a user action that will never
+  // reach the server. Props: { tableName, operation, reason:
+  // 'retries_exhausted' | 'non_retryable', retryCount, status, queuedForMs,
+  // error }. The idempotency key is deliberately NOT a prop — it is a raw uuid
+  // or a per-climb key, i.e. unbounded cardinality; it rides the Sentry event.
+  OfflineMutationDeadLettered: 'Offline Mutation Dead Lettered',
+  // Offline sync — how much unsynced work was already sitting in the outbox at
+  // launch. Per-mutation events only count from ship day, so without this every
+  // backlog that accumulated earlier is invisible. Fires at most once per app
+  // launch, and only when something is queued. Props: { pendingCount,
+  // deadLetterCount, oldestPendingAgeDays, oldestDeadLetterAgeDays }.
+  OfflineOutboxBacklogDetected: 'Offline Outbox Backlog Detected',
+  // Offline sync — sign-out deletes the whole outbox, dead letters included, so
+  // this is the size of what the user just lost. Emitted before the analytics
+  // reset so it lands on the signed-in identity. Props: { pendingCount,
+  // deadLetterCount, oldestPendingAgeDays, oldestDeadLetterAgeDays }.
+  OfflineOutboxDiscardedOnSignOut: 'Offline Outbox Discarded On Sign Out',
+  // Offline sync — an enqueue was swallowed by INSERT OR IGNORE because a
+  // dead-lettered row already owns that deterministic idempotency key
+  // (favorites, follows). The user's repeat action is dropped at enqueue time,
+  // so neither a drain nor a dead-letter event can ever report it. Props:
+  // { tableName, operation, existingStatus }.
+  OfflineMutationEnqueueSuppressed: 'Offline Mutation Enqueue Suppressed',
+  // Offline sync — the local SQLite write behind an offline tick threw, so the
+  // tick fell through to a direct network save. Online that still lands;
+  // offline it is a lost tick. `wasOffline` is the dimension that splits those
+  // two, and `isLockError` says whether it was write-lock contention (#4314)
+  // rather than a broken database. Props: { isLockError, wasOffline, error }.
+  OfflineTickLocalWriteFailed: 'Offline Tick Local Write Failed',
 } as const;
 
 export type SharedEventKey = keyof typeof SHARED_EVENTS;

--- a/packages/shared/offline-sync/src/db/__tests__/lock-errors.test.ts
+++ b/packages/shared/offline-sync/src/db/__tests__/lock-errors.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { isDatabaseLockedError } from '../lock-errors';
+
+// The Android driver emits a raw U+0005 where the result-code digit belongs
+// (BOARDSESH-6V, all 18 events). Built here rather than pasted so no editor,
+// formatter, or copy/paste can quietly drop the byte and turn this test green
+// against the wrong string.
+const ANDROID_CODE_BYTE = String.fromCharCode(5);
+
+describe('isDatabaseLockedError', () => {
+  it.each([
+    ["Calling the 'execAsync' function has failed", 'database is locked'],
+    ["Calling the 'finalizeAsync' function has failed", 'Error code 5: database is locked'],
+    ["Calling the 'prepareAsync' function has failed", `Error code ${ANDROID_CODE_BYTE}: database is locked`],
+  ])('matches the real Sentry shape %s', (message, causeMessage) => {
+    expect(isDatabaseLockedError(new Error(message, { cause: new Error(causeMessage) }))).toBe(true);
+  });
+
+  it('matches the iOS 2.3.1 exception shape', () => {
+    expect(isDatabaseLockedError(new Error('SQLiteErrorException: Error code 5: database is locked'))).toBe(true);
+  });
+
+  it('matches a bare SQLITE_BUSY code', () => {
+    expect(isDatabaseLockedError(Object.assign(new Error('write failed'), { code: 'SQLITE_BUSY' }))).toBe(true);
+  });
+
+  it('matches through a nested cause chain', () => {
+    const nested = new Error('outer', { cause: new Error('middle', { cause: new Error('database is locked') }) });
+    expect(isDatabaseLockedError(nested)).toBe(true);
+  });
+
+  it('stops at the cause depth limit instead of walking forever', () => {
+    const tooDeep = new Error('1', {
+      cause: new Error('2', { cause: new Error('3', { cause: new Error('4', { cause: 'database is locked' }) }) }),
+    });
+    expect(isDatabaseLockedError(tooDeep)).toBe(false);
+  });
+
+  it('survives a self-referential cause', () => {
+    const looping: { message: string; cause?: unknown } = { message: 'boom' };
+    looping.cause = looping;
+    expect(isDatabaseLockedError(looping)).toBe(false);
+  });
+
+  it.each([
+    new TypeError("Cannot read property 'foo' of undefined"),
+    new Error('database disk image is malformed'),
+    new Error('Error code 13: database or disk is full'),
+    null,
+    undefined,
+    'some string',
+  ])('does not match %p', (value) => {
+    expect(isDatabaseLockedError(value)).toBe(false);
+  });
+});

--- a/packages/shared/offline-sync/src/db/lock-errors.ts
+++ b/packages/shared/offline-sync/src/db/lock-errors.ts
@@ -1,0 +1,77 @@
+// "Is this SQLite write-lock contention?" — one predicate, shared.
+//
+// Every `kind: 'tick-local-write'` failure in Sentry over 90 days is a
+// `database is locked`, and #4314 needs the same test to decide whether a
+// failed local write is contention (worth deferring/retrying) or a genuinely
+// broken database (disk full, corruption). Keeping one implementation here
+// stops the two workstreams from drifting apart on which strings count.
+//
+// Matching rules, in order of trust:
+//   1. `database is locked` / `SQLITE_BUSY` — the primary, stable signal.
+//   2. The numeric result code, and only as a SECONDARY signal, because the
+//      real Android strings carry a raw control byte (U+0005) where the digit
+//      belongs — "Error code <U+0005>: database is locked" (BOARDSESH-6V, all
+//      18 events) — while iOS and newer builds carry a plain "Error code 5:".
+//      A matcher keyed on the literal text "Error code 5" misses every Android
+//      event; a matcher keyed only on the code would also swallow unrelated
+//      SQLITE_ result codes, so it never fires on its own.
+//
+// Walks the `.cause` chain to the same depth error-classification.ts uses —
+// expo-sqlite wraps the driver error ("Calling the 'execAsync' function has
+// failed" → cause: the real one).
+
+const MAX_CAUSE_DEPTH = 3;
+
+/** The stable, locale-independent identifiers for write-lock contention. */
+const LOCK_MARKERS = /database is locked|database table is locked|sqlite_busy|sqlite_locked/i;
+
+/**
+ * SQLite result code 5 (SQLITE_BUSY) as it appears in a driver message: either
+ * the literal digit or the raw U+0005 byte Android emits, followed by a colon.
+ *
+ * Built with fromCharCode rather than written as a literal so no raw control
+ * byte ever lands in this source file — one would make the file "binary" to
+ * grep and is trivially lost to a copy/paste or a formatter pass.
+ */
+const BUSY_CONTROL_BYTE = String.fromCharCode(5);
+const BUSY_RESULT_CODE = new RegExp(`error code\\s*(?:${BUSY_CONTROL_BYTE}|5)\\s*:`, 'i');
+
+function messageOf(error: unknown): string | null {
+  if (typeof error === 'string') return error;
+  if (error === null || typeof error !== 'object') return null;
+  const message = (error as { message?: unknown }).message;
+  return typeof message === 'string' ? message : null;
+}
+
+function isLockedAtDepth(error: unknown, depth: number): boolean {
+  if (error === null || error === undefined) return false;
+
+  const message = messageOf(error);
+  if (message !== null) {
+    if (LOCK_MARKERS.test(message)) return true;
+    // Secondary: the busy result code only counts when the message ALSO says
+    // something about a lock. On its own it would swallow unrelated errors that
+    // happen to carry an "Error code N:" prefix.
+    if (BUSY_RESULT_CODE.test(message) && /lock/i.test(message)) return true;
+  }
+
+  if (typeof error === 'object') {
+    const code = (error as { code?: unknown }).code;
+    if (typeof code === 'string' && LOCK_MARKERS.test(code)) return true;
+
+    if (depth < MAX_CAUSE_DEPTH) {
+      const cause = (error as { cause?: unknown }).cause;
+      if (cause !== undefined && cause !== error && isLockedAtDepth(cause, depth + 1)) return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * True when `error` (or anything up to three `.cause` links deep) is SQLite
+ * write-lock contention rather than a broken database.
+ */
+export function isDatabaseLockedError(error: unknown): boolean {
+  return isLockedAtDepth(error, 0);
+}

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -31,11 +31,13 @@ export {
   getPendingCount,
   getDeadLetterCount,
   getDeadLetters,
+  getOutboxSummary,
   retryDeadLetter,
   discardDeadLetter,
   clearAll,
 } from './mutation-queue/queue';
-export type { PendingMutation } from './mutation-queue/queue';
+export type { PendingMutation, EnqueueResult, OutboxSummary } from './mutation-queue/queue';
+export { parseQueueTimestamp, queueTimestampAgeDays } from './mutation-queue/queue-timestamps';
 export {
   drainMutationQueue,
   isDraining,
@@ -46,7 +48,13 @@ export {
   setBackgrounded,
   isBackgrounded,
 } from './mutation-queue/drainer';
-export type { DrainOptions, MutationDeliveryEvent, MutationStatusListenerFailure } from './mutation-queue/drainer';
+export type {
+  DrainOptions,
+  MutationDeliveryEvent,
+  MutationStatusListenerFailure,
+  MutationDeadLetterInfo,
+  MutationDeadLetterReporter,
+} from './mutation-queue/drainer';
 export { ensureMutationQueueTable, MUTATION_QUEUE_SCHEMA } from './mutation-queue/schema';
 export { processMutation } from './mutation-queue/handlers';
 export type { GraphQLFetch } from './mutation-queue/handlers';
@@ -159,6 +167,10 @@ export { SCHEMA_STATEMENTS } from './db/schema';
 export { runMigrations, MIGRATIONS, LATEST_SCHEMA_VERSION } from './db/migrations';
 export type { Migration } from './db/migrations';
 export { OFFLINE_DB_BUSY_TIMEOUT_MS, applyBusyTimeout, configureMainConnection } from './db/pragmas';
+// Shared with the sqlite-lock workstream (#4314): one predicate for "was this
+// write-lock contention?", so reporting and any future retry/defer logic can
+// never disagree about which failures count.
+export { isDatabaseLockedError } from './db/lock-errors';
 
 // --- Offline board scope keys ----------------------------------------------------
 export {

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer-empty-response.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer-empty-response.test.ts
@@ -5,7 +5,7 @@ import type { PendingMutation } from '../queue';
 vi.mock('../queue', () => ({
   peekPending: vi.fn(),
   markCompleted: vi.fn().mockResolvedValue(undefined),
-  recordFailure: vi.fn().mockResolvedValue(undefined),
+  recordFailure: vi.fn().mockResolvedValue({ status: 'pending', retryCount: 1 }),
   markDeadLetter: vi.fn().mockResolvedValue(undefined),
 }));
 

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer.test.ts
@@ -17,12 +17,13 @@ vi.mock('../error-classification', () => ({
   isGraphQLEmptyResponseError: vi.fn().mockReturnValue(false),
   isRetryable: vi.fn().mockReturnValue(false),
   isNetworkError: vi.fn().mockReturnValue(false),
+  getErrorStatus: vi.fn().mockReturnValue(null),
 }));
 
 import { drainMutationQueue, __resetDrainerStateForTests, setSigningOut, setBackgrounded } from '../drainer';
 import { peekPending, markCompleted, recordFailure, markDeadLetter } from '../queue';
 import { processMutation } from '../handlers';
-import { isGraphQLEmptyResponseError, isRetryable, isNetworkError } from '../error-classification';
+import { isGraphQLEmptyResponseError, isRetryable, isNetworkError, getErrorStatus } from '../error-classification';
 
 const mockPeekPending = peekPending as ReturnType<typeof vi.fn>;
 const mockMarkCompleted = markCompleted as ReturnType<typeof vi.fn>;
@@ -32,6 +33,7 @@ const mockProcessMutation = processMutation as ReturnType<typeof vi.fn>;
 const mockIsGraphQLEmptyResponseError = isGraphQLEmptyResponseError as ReturnType<typeof vi.fn>;
 const mockIsRetryable = isRetryable as ReturnType<typeof vi.fn>;
 const mockIsNetworkError = isNetworkError as ReturnType<typeof vi.fn>;
+const mockGetErrorStatus = getErrorStatus as ReturnType<typeof vi.fn>;
 
 // Always online unless a test opts out — matches the onlineManager default and
 // keeps every existing drain-behaviour test running as before.
@@ -73,7 +75,8 @@ describe('drainMutationQueue', () => {
     mockIsGraphQLEmptyResponseError.mockReturnValue(false);
     mockIsRetryable.mockReturnValue(false);
     mockIsNetworkError.mockReturnValue(false);
-    mockRecordFailure.mockResolvedValue('pending');
+    mockGetErrorStatus.mockReturnValue(null);
+    mockRecordFailure.mockResolvedValue({ status: 'pending', retryCount: 1 });
   });
 
   it('skips the drain entirely while offline', async () => {
@@ -178,7 +181,7 @@ describe('drainMutationQueue', () => {
     mockPeekPending.mockResolvedValueOnce([retryable]).mockResolvedValueOnce([nonRetryable]).mockResolvedValueOnce([]);
     mockProcessMutation.mockRejectedValueOnce(new Error('503')).mockRejectedValueOnce(new Error('invalid'));
     mockIsRetryable.mockReturnValueOnce(true).mockReturnValueOnce(false);
-    mockRecordFailure.mockResolvedValueOnce('dead_letter');
+    mockRecordFailure.mockResolvedValueOnce({ status: 'dead_letter', retryCount: 10 });
     const onMutationStatus = vi.fn();
 
     await drainMutationQueue(mockDb, createMockQueryClient(), mockGraphqlFetch, {
@@ -194,6 +197,118 @@ describe('drainMutationQueue', () => {
     expect(onMutationStatus).toHaveBeenCalledWith(
       expect.objectContaining({ idempotencyKey: 'invalid-tick', status: 'dead_letter' }),
     );
+  });
+
+  // Issue #4315: a dead letter is a permanently lost user write, and until this
+  // seam existed it produced no Sentry event and no analytics event anywhere.
+  describe('dead-letter telemetry', () => {
+    it('reports an exhausted retry budget with the bumped attempt count', async () => {
+      const mutation = makeMutation({ id: 1, idempotency_key: 'tick-uuid', max_retries: 5 });
+      mockPeekPending.mockResolvedValueOnce([mutation]).mockResolvedValueOnce([]);
+      mockProcessMutation.mockRejectedValueOnce(new Error('503 Service Unavailable'));
+      mockIsRetryable.mockReturnValue(true);
+      mockGetErrorStatus.mockReturnValue(503);
+      mockRecordFailure.mockResolvedValueOnce({ status: 'dead_letter', retryCount: 5 });
+      const onMutationDeadLettered = vi.fn();
+
+      await drainMutationQueue(mockDb, createMockQueryClient(), mockGraphqlFetch, {
+        ...ONLINE,
+        maxCycleAttempts: 1,
+        sleep: async () => {},
+        onMutationDeadLettered,
+      });
+
+      expect(onMutationDeadLettered).toHaveBeenCalledTimes(1);
+      expect(onMutationDeadLettered).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tableName: 'boardsesh_ticks',
+          operation: 'create',
+          idempotencyKey: 'tick-uuid',
+          reason: 'retries_exhausted',
+          retryCount: 5,
+          maxRetries: 5,
+          status: 503,
+          errorMessage: '503 Service Unavailable',
+        }),
+      );
+      // The original throw rides along so the platform reporter can attach it
+      // as `cause` — a synthetic wrapper with no cause classifies as nothing.
+      expect(onMutationDeadLettered.mock.calls[0]?.[0].error).toBeInstanceOf(Error);
+      expect(onMutationDeadLettered.mock.calls[0]?.[0].queuedForMs).toBeTypeOf('number');
+    });
+
+    it('reports a non-retryable rejection', async () => {
+      const mutation = makeMutation({ id: 2, idempotency_key: 'invalid-tick', retry_count: 1 });
+      mockPeekPending.mockResolvedValueOnce([mutation]).mockResolvedValueOnce([]);
+      mockProcessMutation.mockRejectedValueOnce(new Error('400 Bad Request'));
+      mockIsRetryable.mockReturnValue(false);
+      mockGetErrorStatus.mockReturnValue(400);
+      const onMutationDeadLettered = vi.fn();
+
+      await drainMutationQueue(mockDb, createMockQueryClient(), mockGraphqlFetch, {
+        ...ONLINE,
+        onMutationDeadLettered,
+      });
+
+      expect(onMutationDeadLettered).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'non_retryable', retryCount: 1, status: 400 }),
+      );
+    });
+
+    it('does not fire on an acknowledged write', async () => {
+      mockPeekPending.mockResolvedValueOnce([makeMutation({ id: 3 })]).mockResolvedValueOnce([]);
+      const onMutationDeadLettered = vi.fn();
+
+      await drainMutationQueue(mockDb, createMockQueryClient(), mockGraphqlFetch, {
+        ...ONLINE,
+        onMutationDeadLettered,
+      });
+
+      expect(onMutationDeadLettered).not.toHaveBeenCalled();
+    });
+
+    // The regression that would silently re-break the "an offline write never
+    // dead-letters for lack of a connection" contract: a network failure must
+    // leave the row pending, so there is nothing to report.
+    it('does not fire on a network error', async () => {
+      // No trailing empty peek queued: the network branch breaks the cycle
+      // immediately, so an unconsumed mockResolvedValueOnce would leak into the
+      // next test and silently drain nothing there.
+      mockPeekPending.mockResolvedValueOnce([makeMutation({ id: 4 })]);
+      mockProcessMutation.mockRejectedValueOnce(new Error('Network request failed'));
+      mockIsNetworkError.mockReturnValue(true);
+      const onMutationDeadLettered = vi.fn();
+
+      await drainMutationQueue(mockDb, createMockQueryClient(), mockGraphqlFetch, {
+        ...ONLINE,
+        onMutationDeadLettered,
+      });
+
+      expect(onMutationDeadLettered).not.toHaveBeenCalled();
+      expect(mockRecordFailure).not.toHaveBeenCalled();
+      expect(mockMarkDeadLetter).not.toHaveBeenCalled();
+    });
+
+    it('survives a throwing reporter without aborting the drain or skipping the write', async () => {
+      const failing = makeMutation({ id: 5, idempotency_key: 'invalid-tick' });
+      const healthy = makeMutation({ id: 6, idempotency_key: 'tick-ok' });
+      mockPeekPending.mockResolvedValueOnce([failing, healthy]).mockResolvedValueOnce([]);
+      mockProcessMutation.mockRejectedValueOnce(new Error('400')).mockResolvedValueOnce(undefined);
+      mockIsRetryable.mockReturnValue(false);
+      const onMutationDeadLettered = vi.fn(() => {
+        throw new Error('reporter exploded');
+      });
+
+      await expect(
+        drainMutationQueue(mockDb, createMockQueryClient(), mockGraphqlFetch, {
+          ...ONLINE,
+          onMutationDeadLettered,
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(mockMarkDeadLetter).toHaveBeenCalledWith(mockDb, 5, '400');
+      expect(mockMarkCompleted).toHaveBeenCalledWith(mockDb, 6);
+    });
   });
 
   it('stops processing on retryable error and increments retry', async () => {

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/queue-fifo.integration.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/queue-fifo.integration.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import type { OfflineDatabase } from '../../database';
 
-import { peekPending, recordFailure, type PendingMutation } from '../queue';
+import { enqueue, getOutboxSummary, markDeadLetter, peekPending, recordFailure, type PendingMutation } from '../queue';
 import { ensureMutationQueueTable } from '../schema';
 import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
 
@@ -62,6 +62,82 @@ describe('peekPending FIFO ordering', () => {
       'same-a',
       'same-b',
     ]);
+  });
+});
+
+// Issue #4315. Both of these are read by telemetry whose failure mode is
+// SILENCE — the outbox gauge swallows its own errors and the suppressed-enqueue
+// report only fires on `inserted: false` — so a wrong SQL string or a driver
+// that reports `changes` differently would look exactly like "nothing to
+// report" forever. The sibling queue.test.ts only proves the code against a
+// hand-written double that returns whatever the implementation expects; these
+// run the same calls through a real SQLite engine.
+describe('enqueue suppression against real SQLite', () => {
+  const key = 'add:user_favorites:kilter:climb-1:40';
+
+  it('reports a fresh insert', async () => {
+    await expect(enqueue(db, 'user_favorites', 'create', { climbUuid: 'climb-1' }, key)).resolves.toEqual({
+      inserted: true,
+      existingStatus: null,
+    });
+  });
+
+  // The load-bearing one: INSERT OR IGNORE must actually surface changes = 0 on
+  // the real driver, or the whole dead-letter-swallow instrument is dead code.
+  it('reports the existing row status when the UNIQUE key is already taken', async () => {
+    await enqueue(db, 'user_favorites', 'create', {}, key);
+
+    await expect(enqueue(db, 'user_favorites', 'create', {}, key)).resolves.toEqual({
+      inserted: false,
+      existingStatus: 'pending',
+    });
+
+    const rows = await db.getAllAsync<PendingMutation>('SELECT * FROM pending_mutations');
+    expect(rows).toHaveLength(1);
+  });
+
+  it('reports dead_letter once the row that owns the key has been given up on', async () => {
+    await enqueue(db, 'user_favorites', 'create', {}, key);
+    const row = await db.getFirstAsync<{ id: number }>('SELECT id FROM pending_mutations WHERE idempotency_key = ?', [
+      key,
+    ]);
+    await markDeadLetter(db, row!.id, '400 Bad Request');
+
+    await expect(enqueue(db, 'user_favorites', 'create', {}, key)).resolves.toEqual({
+      inserted: false,
+      existingStatus: 'dead_letter',
+    });
+  });
+});
+
+describe('getOutboxSummary against real SQLite', () => {
+  it('splits counts and oldest created_at per status', async () => {
+    await insertPending(db, 'pending-newer', '2026-08-02T10:00:00');
+    await insertPending(db, 'pending-older', '2026-08-01T10:00:00');
+    await insertPending(db, 'dead-older', '2026-07-20T08:30:00');
+    await insertPending(db, 'dead-newer', '2026-07-25T08:30:00');
+    for (const deadKey of ['dead-older', 'dead-newer']) {
+      const row = await db.getFirstAsync<{ id: number }>('SELECT id FROM pending_mutations WHERE idempotency_key = ?', [
+        deadKey,
+      ]);
+      await markDeadLetter(db, row!.id, 'gone');
+    }
+
+    await expect(getOutboxSummary(db)).resolves.toEqual({
+      pendingCount: 2,
+      deadLetterCount: 2,
+      oldestPendingAt: '2026-08-01T10:00:00',
+      oldestDeadLetterAt: '2026-07-20T08:30:00',
+    });
+  });
+
+  it('reads an empty outbox as zeros and nulls, not as an error', async () => {
+    await expect(getOutboxSummary(db)).resolves.toEqual({
+      pendingCount: 0,
+      deadLetterCount: 0,
+      oldestPendingAt: null,
+      oldestDeadLetterAt: null,
+    });
   });
 });
 

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/queue-fifo.integration.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/queue-fifo.integration.test.ts
@@ -79,7 +79,10 @@ describe('recordFailure atomic dead-letter', () => {
       "SELECT id FROM pending_mutations WHERE idempotency_key = 'k'",
     );
 
-    await expect(recordFailure(db, before!.id, 'transient 503')).resolves.toBe('pending');
+    await expect(recordFailure(db, before!.id, 'transient 503')).resolves.toEqual({
+      status: 'pending',
+      retryCount: 1,
+    });
 
     const row = await getRow(before!.id);
     expect(row?.retry_count).toBe(1);
@@ -99,7 +102,10 @@ describe('recordFailure atomic dead-letter', () => {
       "SELECT id FROM pending_mutations WHERE idempotency_key = 'k'",
     );
 
-    await expect(recordFailure(db, before!.id, 'still down')).resolves.toBe('dead_letter');
+    await expect(recordFailure(db, before!.id, 'still down')).resolves.toEqual({
+      status: 'dead_letter',
+      retryCount: 3,
+    });
 
     const row = await getRow(before!.id);
     expect(row?.retry_count).toBe(3);
@@ -123,8 +129,11 @@ describe('recordFailure atomic dead-letter', () => {
       "SELECT id FROM pending_mutations WHERE idempotency_key = 'healthy'",
     );
 
-    await expect(recordFailure(db, exhausted!.id, 'gone')).resolves.toBe('dead_letter');
-    await expect(recordFailure(db, healthy!.id, 'blip')).resolves.toBe('pending');
+    await expect(recordFailure(db, exhausted!.id, 'gone')).resolves.toEqual({
+      status: 'dead_letter',
+      retryCount: 5,
+    });
+    await expect(recordFailure(db, healthy!.id, 'blip')).resolves.toEqual({ status: 'pending', retryCount: 1 });
 
     const deadLettered = await db.getAllAsync<PendingMutation>(
       "SELECT * FROM pending_mutations WHERE status = 'dead_letter'",

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/queue-timestamps.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/queue-timestamps.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { parseQueueTimestamp, queueTimestampAgeDays } from '../queue-timestamps';
+
+describe('parseQueueTimestamp', () => {
+  // The exact epoch matters, not just "not null": SQLite's datetime('now')
+  // format has a SPACE separator and no zone, so a naive `Date.parse` is
+  // implementation-defined — V8 accepts it and Hermes does not. Asserting the
+  // number is what proves the normalisation, and that the value is read as UTC
+  // rather than the device's local time.
+  it('parses the SQLite datetime() shape as UTC', () => {
+    expect(parseQueueTimestamp('2026-08-12 10:00:00')).toBe(Date.UTC(2026, 7, 12, 10, 0, 0));
+  });
+
+  it('passes an already-ISO value through to the same epoch', () => {
+    expect(parseQueueTimestamp('2026-08-12T10:00:00Z')).toBe(Date.UTC(2026, 7, 12, 10, 0, 0));
+  });
+
+  it('respects an explicit offset instead of stamping Z on top of it', () => {
+    expect(parseQueueTimestamp('2026-08-12T12:00:00+02:00')).toBe(Date.UTC(2026, 7, 12, 10, 0, 0));
+  });
+
+  it.each([null, undefined, '', '   ', 'not a date'])('returns null for %p', (value) => {
+    expect(parseQueueTimestamp(value)).toBeNull();
+  });
+});
+
+describe('queueTimestampAgeDays', () => {
+  it('floors whole days since the timestamp', () => {
+    const now = Date.UTC(2026, 7, 12, 10, 0, 0);
+    expect(queueTimestampAgeDays('2026-08-09 10:00:01', now)).toBe(2);
+    expect(queueTimestampAgeDays('2026-08-09 10:00:00', now)).toBe(3);
+  });
+
+  it('returns null rather than 0 when the timestamp is unusable', () => {
+    expect(queueTimestampAgeDays(null)).toBeNull();
+  });
+});

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/queue.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/queue.test.ts
@@ -17,6 +17,7 @@ import {
   markDeadLetter,
   getPendingCount,
   getDeadLetterCount,
+  getOutboxSummary,
   retryDeadLetter,
   discardDeadLetter,
   clearAll,
@@ -66,11 +67,11 @@ describe('mutation queue', () => {
   });
 
   it.each(['pending', 'dead_letter'] as const)(
-    'recordFailure returns %s from one UPDATE RETURNING statement',
+    'recordFailure returns %s and the bumped retry count from one UPDATE RETURNING statement',
     async (status) => {
-      (db.getFirstAsync as ReturnType<typeof vi.fn>).mockResolvedValue({ status });
+      (db.getFirstAsync as ReturnType<typeof vi.fn>).mockResolvedValue({ status, retry_count: 3 });
 
-      await expect(recordFailure(db, 7, 'Connection timeout')).resolves.toBe(status);
+      await expect(recordFailure(db, 7, 'Connection timeout')).resolves.toEqual({ status, retryCount: 3 });
 
       expect(db.getFirstAsync).toHaveBeenCalledTimes(1);
       const [sql, params] = (db.getFirstAsync as ReturnType<typeof vi.fn>).mock.calls[0];
@@ -78,7 +79,7 @@ describe('mutation queue', () => {
       expect(sql).toMatch(/retry_count = retry_count \+ 1/);
       expect(sql).toMatch(/last_error = \?/);
       expect(sql).toMatch(/status = CASE WHEN retry_count \+ 1 >= max_retries THEN 'dead_letter' ELSE status END/);
-      expect(sql).toMatch(/RETURNING status$/);
+      expect(sql).toMatch(/RETURNING status, retry_count$/);
       expect(sql).not.toMatch(/\bSELECT\b/);
       expect(params).toEqual(['Connection timeout', 7]);
       expect(db.runAsync).not.toHaveBeenCalled();
@@ -88,10 +89,83 @@ describe('mutation queue', () => {
   it('recordFailure treats an already-missing row as pending without a second query', async () => {
     (db.getFirstAsync as ReturnType<typeof vi.fn>).mockResolvedValue(null);
 
-    await expect(recordFailure(db, 404, 'Already removed')).resolves.toBe('pending');
+    await expect(recordFailure(db, 404, 'Already removed')).resolves.toEqual({ status: 'pending', retryCount: 0 });
 
     expect(db.getFirstAsync).toHaveBeenCalledTimes(1);
     expect(db.runAsync).not.toHaveBeenCalled();
+  });
+
+  describe('enqueue result (issue #4315)', () => {
+    it('reports a fresh insert without spending a lookup', async () => {
+      (db.runAsync as ReturnType<typeof vi.fn>).mockResolvedValue({ changes: 1, lastInsertRowId: 9 });
+
+      await expect(enqueue(db, 'user_favorites', 'create', {}, 'add:user_favorites:kilter:abc:40')).resolves.toEqual({
+        inserted: true,
+        existingStatus: null,
+      });
+
+      expect(db.getFirstAsync).not.toHaveBeenCalled();
+    });
+
+    it('reports a suppression against a live pending row (legitimate dedup)', async () => {
+      (db.runAsync as ReturnType<typeof vi.fn>).mockResolvedValue({ changes: 0, lastInsertRowId: 0 });
+      (db.getFirstAsync as ReturnType<typeof vi.fn>).mockResolvedValue({ status: 'pending' });
+
+      await expect(enqueue(db, 'user_favorites', 'create', {}, 'add:user_favorites:kilter:abc:40')).resolves.toEqual({
+        inserted: false,
+        existingStatus: 'pending',
+      });
+    });
+
+    it('reports a suppression against a dead-lettered row — the silent-loss case', async () => {
+      (db.runAsync as ReturnType<typeof vi.fn>).mockResolvedValue({ changes: 0, lastInsertRowId: 0 });
+      (db.getFirstAsync as ReturnType<typeof vi.fn>).mockResolvedValue({ status: 'dead_letter' });
+
+      await expect(enqueue(db, 'user_favorites', 'create', {}, 'add:user_favorites:kilter:abc:40')).resolves.toEqual({
+        inserted: false,
+        existingStatus: 'dead_letter',
+      });
+
+      expect(db.getFirstAsync).toHaveBeenCalledWith('SELECT status FROM pending_mutations WHERE idempotency_key = ?', [
+        'add:user_favorites:kilter:abc:40',
+      ]);
+    });
+
+    it('degrades to "inserted" when the driver reports no changes count', async () => {
+      (db.runAsync as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+      await expect(enqueue(db, 'boardsesh_ticks', 'create', {}, 'uuid-1')).resolves.toEqual({
+        inserted: true,
+        existingStatus: null,
+      });
+    });
+  });
+
+  describe('getOutboxSummary', () => {
+    it('splits counts and oldest timestamps per status', async () => {
+      (db.getAllAsync as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { status: 'pending', count: 3, oldest_created_at: '2026-08-01 10:00:00' },
+        { status: 'dead_letter', count: 2, oldest_created_at: '2026-07-20 08:30:00' },
+      ]);
+
+      await expect(getOutboxSummary(db)).resolves.toEqual({
+        pendingCount: 3,
+        deadLetterCount: 2,
+        oldestPendingAt: '2026-08-01 10:00:00',
+        oldestDeadLetterAt: '2026-07-20 08:30:00',
+      });
+    });
+
+    it('returns zeros and nulls on an empty outbox', async () => {
+      (db.getAllAsync as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+      await expect(getOutboxSummary(db)).resolves.toEqual({
+        pendingCount: 0,
+        deadLetterCount: 0,
+        oldestPendingAt: null,
+        oldestDeadLetterAt: null,
+      });
+    });
   });
 
   it('markDeadLetter sets status to dead_letter with error', async () => {

--- a/packages/shared/offline-sync/src/mutation-queue/drainer.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/drainer.ts
@@ -2,8 +2,9 @@ import type { OfflineDatabase, QueryInvalidator } from '../database';
 import type { GraphQLFetch } from './handlers';
 import { processMutation } from './handlers';
 import { peekPending, markCompleted, recordFailure, markDeadLetter } from './queue';
-import { isGraphQLEmptyResponseError, isRetryable, isNetworkError } from './error-classification';
+import { isGraphQLEmptyResponseError, isRetryable, isNetworkError, getErrorStatus } from './error-classification';
 import { invalidateKeysForTable } from '../sync/invalidate-keys';
+import { parseQueueTimestamp } from './queue-timestamps';
 
 // Module-level singletons (drain flag, sign-out guard, wipe epoch): correct as
 // long as exactly one app runtime consumes this package per JS context — the
@@ -104,6 +105,38 @@ export type MutationStatusListenerFailure = {
   event: MutationDeliveryEvent;
 };
 
+/**
+ * A queued user write that will never reach the server. Deliberately NOT folded
+ * into MutationDeliveryEvent: that type is mirrored field-for-field by
+ * OfflineMutationDelivery in @boardsesh/board-react (see the note above it), so
+ * widening it forces a lockstep edit in a second package for data no UI
+ * consumer wants. A separate seam matches the engine's other telemetry hooks
+ * (onSchemaDrift, onCoverageReset, onScopeDownloadComplete).
+ *
+ * A dead letter is by construction NOT a connectivity problem — a network error
+ * takes the networkStop branch without burning retry_count — so every one of
+ * these is a permanent loss of something the user did.
+ */
+export type MutationDeadLetterInfo = {
+  tableName: string;
+  operation: string;
+  /** Raw entity uuid or a deterministic key; keep it out of analytics props. */
+  idempotencyKey: string;
+  /** `retries_exhausted` burned the whole budget; `non_retryable` was a 4xx. */
+  reason: 'retries_exhausted' | 'non_retryable';
+  retryCount: number;
+  maxRetries: number;
+  /** How long the write sat in the outbox before it was given up on. */
+  queuedForMs: number | null;
+  /** Resolved HTTP / GraphQL status, when the failure carried one. */
+  status: number | null;
+  errorMessage: string;
+  /** The original throw, so the platform reporter can attach it as `cause`. */
+  error: unknown;
+};
+
+export type MutationDeadLetterReporter = (info: MutationDeadLetterInfo) => void;
+
 export type DrainOptions = {
   /** Injectable sleep for deterministic tests. Defaults to setTimeout. */
   sleep?: (ms: number) => Promise<void>;
@@ -131,6 +164,13 @@ export type DrainOptions = {
   onMutationStatus?: (event: MutationDeliveryEvent) => void;
   /** Platform-owned telemetry for a throwing delivery callback. */
   onMutationStatusError?: (failure: MutationStatusListenerFailure) => void;
+  /**
+   * Telemetry seam for a permanently lost write. Fires once per row that
+   * reaches dead_letter, from BOTH the exhausted-retries and non-retryable
+   * branches. Failure-isolated like onMutationStatus: a throwing reporter can
+   * never abort a drain or prevent the dead-letter write committing.
+   */
+  onMutationDeadLettered?: MutationDeadLetterReporter;
 };
 
 function notifyMutationStatus(options: DrainOptions, event: MutationDeliveryEvent): void {
@@ -146,6 +186,16 @@ function notifyMutationStatus(options: DrainOptions, event: MutationDeliveryEven
     }
     if (!options.onMutationStatusError && process.env.NODE_ENV !== 'production') {
       console.warn('[MutationQueue] mutation-status listener failed:', error);
+    }
+  }
+}
+
+function notifyDeadLetter(options: DrainOptions, info: MutationDeadLetterInfo): void {
+  try {
+    options.onMutationDeadLettered?.(info);
+  } catch (reportingError) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('[MutationQueue] dead-letter reporter failed:', reportingError);
     }
   }
 }
@@ -183,6 +233,12 @@ function invalidateForTable(queryClient: QueryInvalidator, tableName: string): v
 function formatError(error: unknown): string {
   if (error instanceof Error) return error.message;
   return String(error);
+}
+
+/** How long a row sat in the outbox, or null when created_at won't parse. */
+function queuedForMs(createdAt: string): number | null {
+  const queuedAt = parseQueueTimestamp(createdAt);
+  return queuedAt === null ? null : Math.max(0, Date.now() - queuedAt);
 }
 
 export async function drainMutationQueue(
@@ -282,7 +338,7 @@ export async function drainMutationQueue(
             // One atomic UPDATE bumps the retry and, when the bumped count hits
             // max_retries, flips to dead_letter — no window where the row is
             // exhausted-but-still-pending.
-            const status = await recordFailure(db, mutation.id, errorMessage);
+            const { status, retryCount } = await recordFailure(db, mutation.id, errorMessage);
             // The row may have just flipped to dead_letter; refresh the pending
             // badges either way (an extra COUNT requery is harmless).
             invalidateForTable(queryClient, mutation.table_name);
@@ -292,6 +348,18 @@ export async function drainMutationQueue(
                 operation: mutation.operation,
                 idempotencyKey: mutation.idempotency_key,
                 status,
+              });
+              notifyDeadLetter(options, {
+                tableName: mutation.table_name,
+                operation: mutation.operation,
+                idempotencyKey: mutation.idempotency_key,
+                reason: 'retries_exhausted',
+                retryCount,
+                maxRetries: mutation.max_retries,
+                queuedForMs: queuedForMs(mutation.created_at),
+                status: getErrorStatus(error),
+                errorMessage,
+                error,
               });
             }
             retryableHit = true;
@@ -306,6 +374,18 @@ export async function drainMutationQueue(
               operation: mutation.operation,
               idempotencyKey: mutation.idempotency_key,
               status: 'dead_letter',
+            });
+            notifyDeadLetter(options, {
+              tableName: mutation.table_name,
+              operation: mutation.operation,
+              idempotencyKey: mutation.idempotency_key,
+              reason: 'non_retryable',
+              retryCount: mutation.retry_count,
+              maxRetries: mutation.max_retries,
+              queuedForMs: queuedForMs(mutation.created_at),
+              status: getErrorStatus(error),
+              errorMessage,
+              error,
             });
           }
         }

--- a/packages/shared/offline-sync/src/mutation-queue/queue-timestamps.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/queue-timestamps.ts
@@ -1,0 +1,37 @@
+// Parsing pending_mutations.created_at back into an epoch.
+//
+// The column defaults to SQLite `datetime('now')` (see mutation-queue/schema.ts),
+// which produces UTC in the form 'YYYY-MM-DD HH:MM:SS' — a SPACE separator and
+// no zone designator. That is NOT ISO-8601, so `Date.parse` on it is
+// implementation-defined: V8 accepts it (a Node-only test would pass), Hermes is
+// stricter, and the device would silently return null forever while the metric
+// read as "no data" instead of "bug". Normalising the separator and stamping the
+// zone is what makes the same string parse identically on both engines.
+
+/**
+ * Parse a `pending_mutations.created_at` value into epoch milliseconds.
+ * Returns null for anything unparseable — callers must treat a null age as
+ * "unknown", never as zero.
+ */
+export function parseQueueTimestamp(createdAt: string | null | undefined): number | null {
+  if (!createdAt) return null;
+  const trimmed = createdAt.trim();
+  if (trimmed.length === 0) return null;
+
+  // Already carries a zone (or an offset) — pass it through untouched.
+  const hasZone = /(?:z|[+-]\d{2}:?\d{2})$/i.test(trimmed);
+  const normalized = hasZone ? trimmed.replace(' ', 'T') : `${trimmed.replace(' ', 'T')}Z`;
+
+  const parsed = Date.parse(normalized);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/**
+ * Whole days between a queue timestamp and `now`, floored. Null when the
+ * timestamp can't be parsed, so a missing value never renders as "0 days old".
+ */
+export function queueTimestampAgeDays(createdAt: string | null | undefined, now: number = Date.now()): number | null {
+  const parsed = parseQueueTimestamp(createdAt);
+  if (parsed === null) return null;
+  return Math.floor((now - parsed) / 86_400_000);
+}

--- a/packages/shared/offline-sync/src/mutation-queue/queue.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/queue.ts
@@ -13,18 +13,45 @@ export type PendingMutation = {
   status: string;
 };
 
+/**
+ * What an enqueue actually did. `idempotency_key` is UNIQUE and the INSERT is
+ * `OR IGNORE`, so a duplicate key is dropped silently — which is correct dedup
+ * for a double-tapped favorite (`existingStatus: 'pending'`) but SILENT DATA
+ * LOSS once the existing row is a dead letter: every later add for that
+ * climb/angle is swallowed at enqueue time, so no drain runs and no
+ * dead-letter event can ever fire for it. Callers that use a deterministic key
+ * (favorites, follows) inspect this to report the second case.
+ */
+export type EnqueueResult = {
+  inserted: boolean;
+  /** Status of the row that won the UNIQUE key, when nothing was inserted. */
+  existingStatus: string | null;
+};
+
 export async function enqueue(
   db: SqlExecutor,
   tableName: string,
   operation: 'create' | 'update' | 'delete',
   payload: Record<string, unknown>,
   idempotencyKey: string,
-): Promise<void> {
-  await db.runAsync(
+): Promise<EnqueueResult> {
+  const result = await db.runAsync(
     `INSERT OR IGNORE INTO pending_mutations (table_name, operation, payload, idempotency_key)
      VALUES (?, ?, ?, ?)`,
     [tableName, operation, JSON.stringify(payload), idempotencyKey],
   );
+  // Anything other than an explicit `changes: 0` counts as inserted. A driver
+  // (or test double) that doesn't report `changes` degrades to losing the
+  // suppression signal rather than inventing a data-loss report for every write.
+  if (result?.changes !== 0) return { inserted: true, existingStatus: null };
+
+  // Only the suppressed path pays for the extra lookup: a single indexed hit on
+  // the UNIQUE column, inside the transaction the caller already opened.
+  const existing = await db.getFirstAsync<{ status: string }>(
+    'SELECT status FROM pending_mutations WHERE idempotency_key = ?',
+    [idempotencyKey],
+  );
+  return { inserted: false, existingStatus: existing?.status ?? null };
 }
 
 export async function peekPending(db: SqlExecutor, limit: number = 10): Promise<PendingMutation[]> {
@@ -42,6 +69,17 @@ export async function markCompleted(db: SqlExecutor, id: number): Promise<void> 
 }
 
 /**
+ * The post-UPDATE state of a failed push attempt. The bumped `retryCount` rides
+ * along because the drainer's dead-letter telemetry needs "how many attempts
+ * did this write burn before we gave up", and re-reading it after the UPDATE
+ * would be a second statement racing the same row.
+ */
+export type RecordFailureResult = {
+  status: 'pending' | 'dead_letter';
+  retryCount: number;
+};
+
+/**
  * Atomically records a failed push attempt: bumps retry_count, stores the error,
  * and flips status to dead_letter in the SAME statement once the bumped count
  * reaches max_retries. Folding the bump and the dead-letter transition into one
@@ -49,20 +87,23 @@ export async function markCompleted(db: SqlExecutor, id: number): Promise<void> 
  * exhausted but status still 'pending' (which the old two-write
  * incrementRetry + markDeadLetter pair could).
  */
-export async function recordFailure(db: SqlExecutor, id: number, error: string): Promise<'pending' | 'dead_letter'> {
-  const row = await db.getFirstAsync<{ status: string }>(
+export async function recordFailure(db: SqlExecutor, id: number, error: string): Promise<RecordFailureResult> {
+  const row = await db.getFirstAsync<{ status: string; retry_count: number }>(
     `UPDATE pending_mutations
      SET retry_count = retry_count + 1,
          last_error = ?,
          status = CASE WHEN retry_count + 1 >= max_retries THEN 'dead_letter' ELSE status END
      WHERE id = ?
-     RETURNING status`,
+     RETURNING status, retry_count`,
     [error, id],
   );
   // A missing row means another lifecycle action already completed/discarded
   // it. There is no durable dead letter to announce, so preserve the existing
   // conservative contract and report it as pending.
-  return row?.status === 'dead_letter' ? 'dead_letter' : 'pending';
+  return {
+    status: row?.status === 'dead_letter' ? 'dead_letter' : 'pending',
+    retryCount: row?.retry_count ?? 0,
+  };
 }
 
 /**
@@ -85,6 +126,49 @@ export async function getDeadLetterCount(db: SqlExecutor): Promise<number> {
     `SELECT COUNT(*) as count FROM pending_mutations WHERE status = 'dead_letter'`,
   );
   return row?.count ?? 0;
+}
+
+/**
+ * A whole-outbox gauge: how much unsynced work is sitting here, and how old the
+ * oldest of each kind is.
+ *
+ * Per-mutation telemetry only counts from the moment it ships, and sign-out
+ * DELETEs the entire outbox (mobile's USER_DATA_TABLES_TO_CLEAR includes
+ * pending_mutations), so a backlog that accumulated before either event is
+ * otherwise invisible forever. One grouped SELECT rather than four COUNT
+ * queries because the mobile callers read this on the launch path and inside
+ * sign-out.
+ */
+export type OutboxSummary = {
+  pendingCount: number;
+  deadLetterCount: number;
+  /** Raw SQLite `created_at`; parse with parseQueueTimestamp. */
+  oldestPendingAt: string | null;
+  oldestDeadLetterAt: string | null;
+};
+
+export async function getOutboxSummary(db: SqlExecutor): Promise<OutboxSummary> {
+  const rows = await db.getAllAsync<{ status: string; count: number; oldest_created_at: string | null }>(
+    `SELECT status, COUNT(*) as count, MIN(created_at) as oldest_created_at
+     FROM pending_mutations
+     GROUP BY status`,
+  );
+  const summary: OutboxSummary = {
+    pendingCount: 0,
+    deadLetterCount: 0,
+    oldestPendingAt: null,
+    oldestDeadLetterAt: null,
+  };
+  for (const row of rows) {
+    if (row.status === 'pending') {
+      summary.pendingCount = row.count;
+      summary.oldestPendingAt = row.oldest_created_at;
+    } else if (row.status === 'dead_letter') {
+      summary.deadLetterCount = row.count;
+      summary.oldestDeadLetterAt = row.oldest_created_at;
+    }
+  }
+  return summary;
 }
 
 export async function getDeadLetters(db: SqlExecutor): Promise<PendingMutation[]> {


### PR DESCRIPTION
Issue #4315 asks to make offline data loss visible. Three of the four losses below emit nothing at all today, and the fourth emits a Sentry count that can't tell a saved tick from a lost one.

**A dead-lettered write is invisible.** `recordFailure` flips a row to `dead_letter` in one atomic UPDATE (`mutation-queue/queue.ts`) and `markDeadLetter` force-flips non-retryables; both only reach `notifyMutationStatus`, whose sole consumer is mobile's optimistic-UI seam. `DrainOptions` had no telemetry hook at all. And a dead letter is never a connectivity problem — a network error takes the `networkStop` branch without burning `retry_count` — so every one of them is a permanent loss of something the user did, with no Sentry event and no PostHog event anywhere. The only surface is More → Sync issues, which the user has to happen to visit while online.

**Sign-out DELETEs the whole outbox, dead letters included.** `USER_DATA_TABLES_TO_CLEAR` lists `pending_mutations` and `clearUserData` deletes it. The best-effort pre-sign-out drain returns early when `getPendingCount === 0`, and that filters `status = 'pending'` — so a user whose only outstanding writes are dead letters gets no drain attempt and no record before the rows vanish. This also defeats a launch-time gauge on its own: the backlog is wiped before the next launch, which is why both gauges exist.

**A dead-lettered favorite/follow key swallows every retry.** `enqueue` is `INSERT OR IGNORE` against a UNIQUE `idempotency_key`, and favorite/follow keys are deterministic (`add:user_favorites:<board>:<climb>:<angle>`). The cancel DELETEs in `addFavoriteLocal`/`removeFavoriteLocal` match only `status = 'pending'`. So once a favorite add dead-letters, every later add for that climb/angle is dropped at enqueue time: local row present, no queue row, no drain, and therefore no dead-letter event could ever mention it. Ticks are immune (fresh uuid per tick); favorites and follows are not.

**A failed local tick write can't be read.** Sentry `kind:tick-local-write` over 90 days: 72 events, all `database is locked`, 71 on 2.2.x and exactly 1 on 2.3.1 (WAL + `busy_timeout` from #3887 did the work). But the report can't say whether the `return null` fall-through then landed over the network or dropped the tick — that turns entirely on whether the device was offline, which nothing recorded.

## Changes

**Engine (`@boardsesh/offline-sync`)**

- `onMutationDeadLettered` on `DrainOptions`, fired from both dead-letter branches with `reason: 'retries_exhausted' | 'non_retryable'`, the burned `retryCount`, `queuedForMs`, the resolved status, and the original error so the platform reporter can attach it as `cause`. Failure-isolated exactly like `notifyMutationStatus`. Deliberately a separate seam rather than widening `MutationDeliveryEvent`, which is mirrored field-for-field by `OfflineMutationDelivery` in `@boardsesh/board-react`.
- `recordFailure` returns `{ status, retryCount }` from the same `RETURNING`, so the attempt count needs no second read racing the row. Package-internal — the index never exported it.
- `enqueue` returns `{ inserted, existingStatus }`. Only the suppressed path pays for the extra `SELECT`, and a driver that doesn't report `changes` degrades to "inserted" rather than inventing a loss report.
- `getOutboxSummary` — one grouped `SELECT` for per-status counts and oldest `created_at`.
- `parseQueueTimestamp` — `created_at` is SQLite `datetime('now')`, i.e. `'YYYY-MM-DD HH:MM:SS'` with a space separator and no zone. That is not ISO-8601, so `Date.parse` is implementation-defined: V8 accepts it (a Node-only test passes) and Hermes is stricter, so the device would return null forever while the metric read as "no data".
- `isDatabaseLockedError` in `db/lock-errors.ts`, shared with #4314 so reporting and any future retry/defer logic can't disagree on which failures count. The busy result code is a secondary signal only, because the real Android strings carry a raw U+0005 where the digit belongs (BOARDSESH-6V, all 18 events) while iOS carries a plain `Error code 5:`.

**Analytics** — five `SHARED_EVENTS` entries, all `Offline <Noun> <PastTenseVerb>`: `Offline Mutation Dead Lettered`, `Offline Outbox Backlog Detected`, `Offline Outbox Discarded On Sign Out`, `Offline Mutation Enqueue Suppressed`, `Offline Tick Local Write Failed`.

**Mobile**

- Adapter binds the dead-letter seam to both Sentry (`kind: 'mutation-dead-letter'`, with the original error as `cause`) and PostHog. Composed rather than defaulted, so no call site can opt out of it by passing its own handler. The idempotency key rides the Sentry extra only — as an analytics prop it is unbounded cardinality.
- `offline/outbox-telemetry.ts` holds the three non-drain gauges. The launch backlog gauge runs from `OfflineSyncBridge` in **both** flag branches (the bridge already drains a kill-switched user's leftovers, and their dead letters are exactly as lost), self-guarded so an effect re-run can't double-fire. The sign-out gauge runs inside `runSignedOutCleanup` — covering manual, forced-401, and proactive-expiry sign-out — and **strictly before `resetAnalytics()`**, or the event lands on an anonymous distinct_id and can never be joined back to the account that lost the writes. There's an explicit call-order assertion for that.
- Suppressed-enqueue reporting on favorites and follows, and only when `existingStatus === 'dead_letter'`. A suppression against a `pending` row is correct dedup of a double tap and reporting it would bury the signal.
- The `tick-local-write` report keeps its `kind` tag verbatim so the 90-day trend stays comparable, and gains `was_offline` and `is_lock_error`. `return null` is unchanged.

**Not in scope.** No durability fix for the tick write path. The original plan's retry-ladder-plus-queue-only fallback was dropped: `writeTickLocal` already applies `busy_timeout = 5000` inside its transaction, so every failure surviving on 2.3.1 is by construction a lock held ≥5s — and the dominant holder is `snapshot-bootstrap.ts`'s `BEGIN EXCLUSIVE` across a whole scope import (p50 2m55s Kilter). A 3×150ms ladder can't outlast minutes, `enqueue` is itself a writer blocked by that same lock, and the local `boardsesh_ticks` row a queue-only fallback would skip is read by the offline search's ticked filters and per-climb counts, so the climb would render UNTICKED offline for days. The evidence is 1 event / 90 days on the shipping release, and the issue explicitly permits deferring. #4314 owns it and now has `isDatabaseLockedError` plus the two dimensions to size it.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project offline-sync --reporter=agent` — 374 passed. New: dead-letter seam fires with the right reason and attempt count from both branches, does NOT fire on an acknowledged write, and **does not fire on a network error** (the regression that would silently re-break "an offline write never dead-letters for lack of a connection"); a throwing reporter neither aborts the drain nor prevents the dead-letter write committing; `enqueue` returns all three outcomes; `getOutboxSummary` on populated and empty tables; `parseQueueTimestamp` asserts the exact parsed epoch, not just non-null; `isDatabaseLockedError` against the real Sentry shapes including the U+0005 Android variant (built via `fromCharCode` so no formatter can eat the byte).
- `vp test run --project analytics --reporter=agent` — 23 passed.
- `vp run test:mobile` — 622 files / 5510 tests passed.
- `vp run typecheck:mobile` — clean.
- `vp check` — clean for every file this PR touches (two unrelated docs files were already failing on `main`).
- `vp run check:mobile-bundle` — android bundle OK, run from a sibling worktree.

Not run: manual dev-client QA (forcing a dead letter, re-favoriting past it, relaunch, sign-out). `.boardsesh/qa-notes.md` in the worktree lists the flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT6VP1sWqk6bY9mUgyeS2U

