### PR TITLE
feat(sync): report the deletions-coverage verdict on every sync cycle

### DIFF
--- a/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
+++ b/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
@@ -74,13 +74,6 @@ vi.mock('../../offline/outbox-telemetry', () => ({
   reportOutboxBacklogOnce: reportOutboxBacklogOnceMock,
 }));
 
-// The gauge itself is unit-tested in offline/__tests__/outbox-telemetry.test.ts;
-// what matters here is WHERE the bridge calls it from — both flag branches, once.
-const reportOutboxBacklogOnceMock = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => {}));
-vi.mock('../../offline/outbox-telemetry', () => ({
-  reportOutboxBacklogOnce: reportOutboxBacklogOnceMock,
-}));
-
 // Stub the settings barrel so the static import graph never pulls
 // react-native-mmkv (its react-native Flow entry breaks Rolldown's scan).
 vi.mock('../../settings', () => ({

--- a/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
+++ b/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
@@ -74,6 +74,13 @@ vi.mock('../../offline/outbox-telemetry', () => ({
   reportOutboxBacklogOnce: reportOutboxBacklogOnceMock,
 }));
 
+// The gauge itself is unit-tested in offline/__tests__/outbox-telemetry.test.ts;
+// what matters here is WHERE the bridge calls it from — both flag branches, once.
+const reportOutboxBacklogOnceMock = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => {}));
+vi.mock('../../offline/outbox-telemetry', () => ({
+  reportOutboxBacklogOnce: reportOutboxBacklogOnceMock,
+}));
+
 // Stub the settings barrel so the static import graph never pulls
 // react-native-mmkv (its react-native Flow entry breaks Rolldown's scan).
 vi.mock('../../settings', () => ({

--- a/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
+++ b/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
@@ -63,6 +63,7 @@ import {
   pullSync,
   startBackgroundTracking,
   subscribeMutationDelivery,
+  __resetCoverageVerdictDedupeForTests,
 } from '../offline-sync-adapter';
 import type {
   OfflineDatabase,
@@ -495,6 +496,40 @@ describe('snapshot-bootstrap bindings', () => {
       pendingMutations: 3,
     });
     expect(reportHandledError).not.toHaveBeenCalled();
+  });
+
+  // Issue #4315. The engine reports the verdict on EVERY cycle so the seam stays
+  // deterministic; the dedupe lives here because enforceDeletionsCoverage runs
+  // at the top of every pullSync and the scheduler wakes on foreground and
+  // reconnect with no interval — a device stuck on `unknown` would otherwise
+  // emit forever, and those are exactly the devices worth counting once.
+  it('reports the coverage verdict to analytics, deduped per verdict for the launch', () => {
+    __resetCoverageVerdictDedupeForTests();
+    startSyncScheduler(
+      db,
+      queryClient,
+      graphqlFetch,
+      () => [],
+      async () => {},
+    );
+    const options = startSyncSchedulerCore.mock.calls[0][6] as SchedulerOptions;
+
+    options.onCoverageEvaluated?.({ verdict: 'unknown', markerAgeDays: null, outcome: 'evaluated' });
+    options.onCoverageEvaluated?.({ verdict: 'unknown', markerAgeDays: null, outcome: 'evaluated' });
+
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineSyncCoverageEvaluated, {
+      verdict: 'unknown',
+      markerAgeDays: null,
+      outcome: 'evaluated',
+    });
+    // Never Sentry: an evaluation is not a failure, even when it is `stale`.
+    expect(reportHandledError).not.toHaveBeenCalled();
+
+    // A changed verdict is new information and reports again.
+    options.onCoverageEvaluated?.({ verdict: 'stale', markerAgeDays: 100, outcome: 'evaluated' });
+    options.onCoverageEvaluated?.({ verdict: 'stale', markerAgeDays: 100, outcome: 'reset' });
+    expect(trackMock).toHaveBeenCalledTimes(3);
   });
 
   it('pullSync binds the snapshot-bootstrap telemetry defaults but lets caller options win', async () => {

--- a/packages/mobile/src/offline/offline-sync-adapter.ts
+++ b/packages/mobile/src/offline/offline-sync-adapter.ts
@@ -33,6 +33,7 @@ import {
   type GraphQLFetch,
   type OfflineDatabase,
   type BootstrapMetadataChangedReporter,
+  type CoverageEvaluatedReporter,
   type CoverageResetReporter,
   type ScopeDownloadCompleteReporter,
   type SchedulerTriggers,
@@ -186,6 +187,30 @@ const reportCoverageReset: CoverageResetReporter = ({ markerAgeDays, rowsCleared
   track(SHARED_EVENTS.OfflineSyncCoverageResetForced, { markerAgeDays, rowsCleared, pendingMutations });
 };
 
+// The reset above only fires on the rare wipe. This one reports the verdict for
+// every evaluation, including `unknown` — the devices that have never completed
+// a deletions pull, which the reset event can never see (issue #4315).
+//
+// The dedupe lives HERE rather than in the engine on purpose: the engine seam
+// fires on every pullSync so it stays deterministic and testable, but
+// enforceDeletionsCoverage runs at the top of every cycle and the scheduler has
+// no interval — it wakes on foreground and on reconnect. Un-deduped, a device
+// stuck on `unknown` would emit indefinitely, and those are precisely the
+// devices we care about. Keyed on the verdict so a fresh→stale transition still
+// reports; once per launch otherwise.
+const reportedCoverageVerdicts = new Set<string>();
+
+const reportCoverageEvaluated: CoverageEvaluatedReporter = ({ verdict, markerAgeDays, outcome }) => {
+  const dedupeKey = `${verdict}:${outcome}`;
+  if (reportedCoverageVerdicts.has(dedupeKey)) return;
+  reportedCoverageVerdicts.add(dedupeKey);
+  track(SHARED_EVENTS.OfflineSyncCoverageEvaluated, { verdict, markerAgeDays, outcome });
+};
+
+export function __resetCoverageVerdictDedupeForTests(): void {
+  reportedCoverageVerdicts.clear();
+}
+
 // A failed cycle is routine for offline users (the reconnect trigger retries),
 // so production neither spams the console nor reports expected network errors
 // as handled exceptions.
@@ -280,6 +305,7 @@ export function startSyncScheduler(
     onBootstrapMetadataChanged: options?.onBootstrapMetadataChanged,
     onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete),
     onCoverageReset: reportCoverageReset,
+    onCoverageEvaluated: reportCoverageEvaluated,
   });
 }
 
@@ -301,6 +327,7 @@ export function triggerSync(
     onBootstrapMetadataChanged: options?.onBootstrapMetadataChanged,
     onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete),
     onCoverageReset: reportCoverageReset,
+    onCoverageEvaluated: reportCoverageEvaluated,
   });
 }
 
@@ -317,6 +344,7 @@ export function pullSync(
     onSnapshotBootstrapError: options?.onSnapshotBootstrapError ?? reportSnapshotBootstrapError,
     onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete),
     onCoverageReset: options?.onCoverageReset ?? reportCoverageReset,
+    onCoverageEvaluated: options?.onCoverageEvaluated ?? reportCoverageEvaluated,
     // Caller-provided error/drift/coverage reporters keep their existing
     // override semantics; scope completion is the one callback deliberately
     // composed because both telemetry and per-scope UI invalidation are required.

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -368,6 +368,15 @@ export const SHARED_EVENTS = {
   // two, and `isLockError` says whether it was write-lock contention (#4314)
   // rather than a broken database. Props: { isLockError, wasOffline, error }.
   OfflineTickLocalWriteFailed: 'Offline Tick Local Write Failed',
+  // Offline sync — the deletions-coverage verdict for one sync cycle, reported
+  // whatever it is. The reset event above only fires on the rare wipe, and a
+  // device that has never completed a deletions pull stays `unknown` forever
+  // and emits nothing — so the reset-only view samples exactly the devices that
+  // are not at risk. Props: { verdict: 'unknown' | 'future' | 'fresh' |
+  // 'stale', markerAgeDays (null for unknown/future), outcome: 'evaluated' |
+  // 'reset' | 'probe_failed' }. Deduped once-per-launch-per-verdict in the
+  // mobile binding, because the engine evaluates on every foreground.
+  OfflineSyncCoverageEvaluated: 'Offline Sync Coverage Evaluated',
 } as const;
 
 export type SharedEventKey = keyof typeof SHARED_EVENTS;

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -77,6 +77,8 @@ export type {
   ScopeDownloadCompleteReporter,
   CoverageResetInfo,
   CoverageResetReporter,
+  CoverageEvaluatedInfo,
+  CoverageEvaluatedReporter,
 } from './sync/pull-client';
 
 // --- Tombstone retention (issue #3474) --------------------------------------

--- a/packages/shared/offline-sync/src/sync/__tests__/deletions-coverage.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/deletions-coverage.test.ts
@@ -18,6 +18,7 @@ import {
 import {
   DELETIONS_COVERAGE_EPOCH_FLOOR_MS,
   DELETIONS_COVERAGE_MARGIN_DAYS,
+  DELETIONS_COVERAGE_MAX_AGE_MS,
   SYNC_DELETIONS_RETENTION_DAYS,
 } from '../retention';
 import { USER_DATA_TABLES, BOARD_DATA_TABLES } from '../table-config';
@@ -30,6 +31,15 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 const NOW = Date.parse('2026-07-01T12:00:00.000Z');
 
 describe('evaluateDeletionsCoverage', () => {
+  // Issue #4315: `Offline Sync Coverage Reset Forced` has never fired, and that
+  // is arithmetic, not breakage. The marker first shipped 2026-08-01 (#4048),
+  // and the guard needs one 80 days old, so nothing can fire before roughly
+  // 2026-10-20. Pinning the 80 here means a retention or margin edit that moves
+  // that date fails CI instead of quietly moving a dashboard's expectations.
+  it('pins the 80-day staleness threshold the reachability arithmetic depends on', () => {
+    expect(DELETIONS_COVERAGE_MAX_AGE_MS).toBe(80 * DAY_MS);
+  });
+
   it('reads an absent marker as unknown, never as stale', () => {
     // Rollout safety: the key is new, so every existing install hits this branch
     // once. If absence ever meant "stale", the OTA that ships this feature would

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client.integration.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client.integration.test.ts
@@ -34,6 +34,7 @@ import { runMigrations } from '../../db/migrations';
 import { ensureMutationQueueTable } from '../../mutation-queue/schema';
 import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
 import { getDeletionsCoverageAt } from '../deletions-coverage';
+import { DELETIONS_COVERAGE_EPOCH_FLOOR_MS } from '../retention';
 import { TABLE_CONFIGS } from '../table-config';
 
 // The non-null fields of the backend's `input SaveTickInput`
@@ -1110,16 +1111,41 @@ describe('sync layer — real-DDL integration', () => {
         });
       });
 
-      it('reports verdict future for a clock corrected backwards', async () => {
+      // The age is asserted exactly, not via objectContaining: the arithmetic
+      // does produce a value here (-10) and reporting it would put negative
+      // numbers into a property a dashboard averages. Same for the below-floor
+      // marker below, whose raw age is ~20,000 days.
+      it('reports verdict future with a null age for a clock corrected backwards', async () => {
         await seedStaleDevice();
         await setCoverage(Date.now() + 10 * DAY_MS);
         const onCoverageEvaluated = vi.fn();
 
         await pullSync(db, queryClient, makeCoverageFetch([]).fetch, { onCoverageEvaluated });
 
-        expect(onCoverageEvaluated).toHaveBeenCalledWith(
-          expect.objectContaining({ verdict: 'future', outcome: 'evaluated' }),
-        );
+        expect(onCoverageEvaluated).toHaveBeenCalledWith({
+          verdict: 'future',
+          markerAgeDays: null,
+          outcome: 'evaluated',
+        });
+      });
+
+      it('reports a below-epoch-floor marker as unknown with a null age', async () => {
+        await seedStaleDevice();
+        // A phone that booted to 1970 before NTP landed. evaluateDeletionsCoverage
+        // calls this `unknown` rather than 56-years-stale, and the reported age
+        // has to agree with that verdict.
+        await setCoverage(DELETIONS_COVERAGE_EPOCH_FLOOR_MS - DAY_MS);
+        const onCoverageEvaluated = vi.fn();
+        const onCoverageReset = vi.fn();
+
+        await pullSync(db, queryClient, makeCoverageFetch([]).fetch, { onCoverageEvaluated, onCoverageReset });
+
+        expect(onCoverageEvaluated).toHaveBeenCalledWith({
+          verdict: 'unknown',
+          markerAgeDays: null,
+          outcome: 'evaluated',
+        });
+        expect(onCoverageReset).not.toHaveBeenCalled();
       });
 
       it('reports evaluated then reset when the guard actually fires', async () => {

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client.integration.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client.integration.test.ts
@@ -1072,5 +1072,100 @@ describe('sync layer — real-DDL integration', () => {
 
       expect(await readCoverage()).toBe(freshAt);
     });
+
+    // Issue #4315. The reset event alone is a censored instrument: it can only
+    // ever fire for a device that already completed a deletions pull, and a
+    // device that never completes one (the at-risk population — see #4313) stays
+    // `unknown` forever and emits nothing. Reporting the verdict for every cycle
+    // is what turns "zero resets" into evidence.
+    describe('coverage verdict telemetry', () => {
+      it('reports verdict unknown with a null age when no marker exists', async () => {
+        await seedStaleDevice();
+        const onCoverageEvaluated = vi.fn();
+        const onCoverageReset = vi.fn();
+
+        await pullSync(db, queryClient, makeCoverageFetch([]).fetch, { onCoverageEvaluated, onCoverageReset });
+
+        expect(onCoverageEvaluated).toHaveBeenCalledWith({
+          verdict: 'unknown',
+          markerAgeDays: null,
+          outcome: 'evaluated',
+        });
+        // Still resets nothing — the verdict report is observation only.
+        expect(onCoverageReset).not.toHaveBeenCalled();
+        expect(await countRows('boardsesh_ticks')).toBe(1);
+      });
+
+      it('reports verdict fresh for a marker well inside the window', async () => {
+        await seedStaleDevice();
+        await setCoverage(Date.now() - 45 * DAY_MS);
+        const onCoverageEvaluated = vi.fn();
+
+        await pullSync(db, queryClient, makeCoverageFetch([]).fetch, { onCoverageEvaluated });
+
+        expect(onCoverageEvaluated).toHaveBeenCalledWith({
+          verdict: 'fresh',
+          markerAgeDays: 45,
+          outcome: 'evaluated',
+        });
+      });
+
+      it('reports verdict future for a clock corrected backwards', async () => {
+        await seedStaleDevice();
+        await setCoverage(Date.now() + 10 * DAY_MS);
+        const onCoverageEvaluated = vi.fn();
+
+        await pullSync(db, queryClient, makeCoverageFetch([]).fetch, { onCoverageEvaluated });
+
+        expect(onCoverageEvaluated).toHaveBeenCalledWith(
+          expect.objectContaining({ verdict: 'future', outcome: 'evaluated' }),
+        );
+      });
+
+      it('reports evaluated then reset when the guard actually fires', async () => {
+        await seedStaleDevice();
+        await setCoverage(Date.now() - 100 * DAY_MS);
+        const onCoverageEvaluated = vi.fn();
+        const onCoverageReset = vi.fn();
+
+        await pullSync(db, queryClient, makeCoverageFetch([{ uuid: 'fresh-tick', status: 'send' }]).fetch, {
+          onCoverageEvaluated,
+          onCoverageReset,
+        });
+
+        expect(onCoverageReset).toHaveBeenCalledTimes(1);
+        expect(onCoverageEvaluated.mock.calls.map(([info]) => info)).toEqual([
+          { verdict: 'stale', markerAgeDays: 100, outcome: 'evaluated' },
+          { verdict: 'stale', markerAgeDays: 100, outcome: 'reset' },
+        ]);
+      });
+
+      // The probe rejecting on a stale device is invisible today (it vanishes
+      // into the scheduler's dev-only console.warn). Reporting it must not
+      // change the throw: the throw is exactly what leaves local data intact.
+      it('reports probe_failed and still rethrows, leaving local rows untouched', async () => {
+        await seedStaleDevice();
+        const staleAt = Date.now() - 100 * DAY_MS;
+        await setCoverage(staleAt);
+        const onCoverageEvaluated = vi.fn();
+        const onCoverageReset = vi.fn();
+        const offlineFetch = vi.fn(async () => {
+          throw new Error('Network request failed');
+        }) as unknown as GraphQLFetch;
+
+        await expect(pullSync(db, queryClient, offlineFetch, { onCoverageEvaluated, onCoverageReset })).rejects.toThrow(
+          'Network request failed',
+        );
+
+        expect(onCoverageEvaluated.mock.calls.map(([info]) => info)).toEqual([
+          { verdict: 'stale', markerAgeDays: 100, outcome: 'evaluated' },
+          { verdict: 'stale', markerAgeDays: 100, outcome: 'probe_failed' },
+        ]);
+        expect(onCoverageReset).not.toHaveBeenCalled();
+        expect(await countRows('boardsesh_ticks')).toBe(1);
+        expect(await countRows('playlists')).toBe(1);
+        expect(await readCoverage()).toBe(staleAt);
+      });
+    });
   });
 });

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -121,6 +121,29 @@ export type CoverageResetInfo = {
 };
 export type CoverageResetReporter = (info: CoverageResetInfo) => void;
 
+/**
+ * Every deletions-coverage evaluation, not just the ones that force a reset.
+ *
+ * The reset event alone is a censored instrument. `enforceDeletionsCoverage`
+ * returns early on `coverageAt === null`, and the marker only exists after a
+ * COMPLETED deletions pull — so a device that can never finish one (the paged
+ * crawl stranded in #4313, say) stays `unknown` forever and emits nothing. The
+ * reset-only view therefore samples exactly the devices healthy enough not to
+ * be at risk. Reporting the verdict for every cycle makes `unknown` a
+ * first-class value and turns "zero resets" into evidence rather than a shrug.
+ *
+ * `markerAgeDays` is null for `unknown` (no marker) and `future` (a marker
+ * dated after now, i.e. a clock corrected backwards) — neither has a meaningful
+ * age. `outcome: 'probe_failed'` is the reachability probe rejecting on a stale
+ * device, which today vanishes into a dev-only console.warn.
+ */
+export type CoverageEvaluatedInfo = {
+  verdict: 'unknown' | 'future' | 'fresh' | 'stale';
+  markerAgeDays: number | null;
+  outcome: 'evaluated' | 'reset' | 'probe_failed';
+};
+export type CoverageEvaluatedReporter = (info: CoverageEvaluatedInfo) => void;
+
 export type SyncOptions = {
   /** Encoded board scope keys ("boardType:layoutId:sizeId") to download offline. */
   enabledBoards?: string[];
@@ -151,6 +174,12 @@ export type SyncOptions = {
   onScopeDownloadComplete?: ScopeDownloadCompleteReporter;
   /** Telemetry for a forced deletions-coverage resync. See CoverageResetInfo. */
   onCoverageReset?: CoverageResetReporter;
+  /**
+   * Telemetry for EVERY deletions-coverage evaluation. Fires once per pullSync
+   * cycle with no interval of its own — dedupe belongs in the platform binding,
+   * so the engine seam stays deterministic and testable.
+   */
+  onCoverageEvaluated?: CoverageEvaluatedReporter;
 };
 
 /** A per-board download target: the parsed scope plus its encoded key. */
@@ -968,16 +997,38 @@ async function enforceDeletionsCoverage(
   const coverageAt = await getDeletionsCoverageAt(db);
   const verdict = evaluateDeletionsCoverage(coverageAt, evaluatedAt);
 
+  // floor, not round, everywhere this age is reported: a 79.6-day marker must
+  // not read as 80 (the threshold value) when the decision was made on exact
+  // milliseconds. Null for the two verdicts with no meaningful age.
+  const markerAgeDays = coverageAt === null ? null : Math.floor((evaluatedAt - coverageAt) / 86_400_000);
+
+  // Reported BEFORE the early return below, so `unknown` and `future` are
+  // first-class values rather than silence. That is the whole point: the
+  // devices that never complete a deletions pull are the at-risk population,
+  // and a reset-only instrument can never see them.
+  options?.onCoverageEvaluated?.({ verdict, markerAgeDays, outcome: 'evaluated' });
+
   // Only 'stale' does anything. Keeping the explicit `coverageAt === null`
   // disjunct means an absent marker can never structurally reach the wipe below,
   // whatever the classifier is later taught to return — and it narrows
   // coverageAt to a number, so markerAgeDays needs no fallback for a case that
   // cannot happen.
-  if (coverageAt === null || verdict !== 'stale') return;
+  // (markerAgeDays is null exactly when coverageAt is; naming it in the guard
+  // narrows it to a number for the reset report below.)
+  if (coverageAt === null || markerAgeDays === null || verdict !== 'stale') return;
 
   // Reachability + auth probe. Its payload is irrelevant; only "did it resolve"
-  // matters, so it asks for a single row.
-  await graphqlFetch<{ syncDeletions: SyncDeletionsResult }>(SYNC_DELETIONS_QUERY, { cursor: undefined, limit: 1 });
+  // matters, so it asks for a single row. A rejection is reported and then
+  // RETHROWN unchanged: the throw is what leaves local data intact and defers
+  // to the next cycle, and swallowing it here would wipe a stale device's user
+  // data without a verified connection — the exact catastrophe the probe exists
+  // to prevent.
+  try {
+    await graphqlFetch<{ syncDeletions: SyncDeletionsResult }>(SYNC_DELETIONS_QUERY, { cursor: undefined, limit: 1 });
+  } catch (error) {
+    options?.onCoverageEvaluated?.({ verdict, markerAgeDays, outcome: 'probe_failed' });
+    throw error;
+  }
 
   // Re-check the teardown flags after the network await — the probe may have
   // been in flight across a sign-out or a backgrounding, and neither wants a
@@ -1008,10 +1059,11 @@ async function enforceDeletionsCoverage(
     queryClient.invalidateQueries({ queryKey: JSON.parse(serializedKey) as string[] });
   }
 
-  // floor, not round: a 79.6-day marker must not be reported as 80 (the
-  // threshold value) when the decision was made on exact milliseconds.
-  const markerAgeDays = Math.floor((evaluatedAt - coverageAt) / 86_400_000);
   options?.onCoverageReset?.({ markerAgeDays, rowsCleared, pendingMutations });
+  // Alongside the reset event, not instead of it: onCoverageReset stays the
+  // dedicated "a wipe happened" signal, while the verdict stream carries the
+  // denominator that makes its rate readable.
+  options?.onCoverageEvaluated?.({ verdict, markerAgeDays, outcome: 'reset' });
 }
 
 export async function pullSync(

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -132,10 +132,14 @@ export type CoverageResetReporter = (info: CoverageResetInfo) => void;
  * be at risk. Reporting the verdict for every cycle makes `unknown` a
  * first-class value and turns "zero resets" into evidence rather than a shrug.
  *
- * `markerAgeDays` is null for `unknown` (no marker) and `future` (a marker
- * dated after now, i.e. a clock corrected backwards) — neither has a meaningful
- * age. `outcome: 'probe_failed'` is the reachability probe rejecting on a stale
- * device, which today vanishes into a dev-only console.warn.
+ * `markerAgeDays` is a number only for `fresh` and `stale`. It is null for
+ * `unknown` (no marker at all, or one below the epoch floor — a phone that
+ * booted to 1970) and for `future` (a marker dated after now, i.e. a clock
+ * corrected backwards): the arithmetic still produces a value for those two,
+ * but it is ~20,000 days or a negative number, and either would poison an
+ * average over this property. `outcome: 'probe_failed'` is the reachability
+ * probe rejecting on a stale device, which today vanishes into a dev-only
+ * console.warn.
  */
 export type CoverageEvaluatedInfo = {
   verdict: 'unknown' | 'future' | 'fresh' | 'stale';
@@ -999,8 +1003,18 @@ async function enforceDeletionsCoverage(
 
   // floor, not round, everywhere this age is reported: a 79.6-day marker must
   // not read as 80 (the threshold value) when the decision was made on exact
-  // milliseconds. Null for the two verdicts with no meaningful age.
-  const markerAgeDays = coverageAt === null ? null : Math.floor((evaluatedAt - coverageAt) / 86_400_000);
+  // milliseconds.
+  //
+  // Null for the two verdicts whose age is not a coverage age. That is a data
+  // rule, not cosmetics: `future` is a marker dated after now (a clock
+  // corrected backwards) and would report a NEGATIVE age, and `unknown` covers
+  // both an absent marker AND one below DELETIONS_COVERAGE_EPOCH_FLOOR_MS (a
+  // phone that booted to 1970 before NTP landed), which would report ~20,000
+  // days. Either value poisons an average or a percentile over this property.
+  const markerAgeDays =
+    coverageAt === null || verdict === 'unknown' || verdict === 'future'
+      ? null
+      : Math.floor((evaluatedAt - coverageAt) / 86_400_000);
 
   // Reported BEFORE the early return below, so `unknown` and `future` are
   // first-class values rather than silence. That is the whole point: the
@@ -1013,8 +1027,8 @@ async function enforceDeletionsCoverage(
   // whatever the classifier is later taught to return — and it narrows
   // coverageAt to a number, so markerAgeDays needs no fallback for a case that
   // cannot happen.
-  // (markerAgeDays is null exactly when coverageAt is; naming it in the guard
-  // narrows it to a number for the reset report below.)
+  // (markerAgeDays is null for every verdict except `fresh` and `stale`;
+  // naming it in the guard narrows it to a number for the reset report below.)
   if (coverageAt === null || markerAgeDays === null || verdict !== 'stale') return;
 
   // Reachability + auth probe. Its payload is irrelevant; only "did it resolve"

--- a/packages/shared/offline-sync/src/sync/retention.ts
+++ b/packages/shared/offline-sync/src/sync/retention.ts
@@ -46,6 +46,23 @@ export const DELETIONS_COVERAGE_MARGIN_DAYS = 10;
  * tombstones it never saw may already be pruned and the only recovery is a
  * from-scratch user-data resync.
  *
+ * WHY `Offline Sync Coverage Reset Forced` has never fired once, and why that is
+ * arithmetic rather than breakage (issue #4315): the guard only acts on verdict
+ * `stale`, which needs a `deletions-coverage` marker older than this constant —
+ * 90 − 10 = 80 days. The marker is stamped in TWO places, both claiming coverage
+ * only for work that actually completed: after a completed deletions pull
+ * (pull-client.ts) and inside resetUserDataForLostCoverage
+ * (deletions-coverage.ts) as the post-wipe re-seed. It first shipped in
+ * cb4210c5c on 2026-08-01 (#4048), so no device can hold an 80-day-old marker
+ * before roughly 2026-10-20. Zero events is the predicted value, and
+ * deletions-coverage.test.ts pins the 80 so a retention or margin edit that
+ * moves that date fails CI rather than quietly moving a dashboard.
+ *
+ * `Offline Sync Coverage Evaluated` reports the verdict on EVERY cycle, which
+ * makes that prediction falsifiable — and its `unknown` bucket is the
+ * population the reset event structurally cannot see: devices that have never
+ * completed a deletions pull at all.
+ *
  * NOTE: the client's copy of these numbers only refreshes with the OTA bundle.
  * Lowering SYNC_DELETIONS_RETENTION_DAYS on the backend does NOT reach older
  * clients — they keep comparing against the value they shipped with, and the

--- a/packages/shared/offline-sync/src/sync/sync-scheduler.ts
+++ b/packages/shared/offline-sync/src/sync/sync-scheduler.ts
@@ -6,6 +6,7 @@ import {
   type BootstrapMetadataChangedReporter,
   type ScopeDownloadCompleteReporter,
   type CoverageResetReporter,
+  type CoverageEvaluatedReporter,
 } from './pull-client';
 import type { SnapshotSource, SnapshotBootstrapErrorReporter } from './snapshot-bootstrap';
 
@@ -72,6 +73,8 @@ export type SchedulerOptions = {
   onScopeDownloadComplete?: ScopeDownloadCompleteReporter;
   /** Threaded through to pullSync's SyncOptions — see CoverageResetInfo. */
   onCoverageReset?: CoverageResetReporter;
+  /** Threaded through to pullSync's SyncOptions — see CoverageEvaluatedInfo. */
+  onCoverageEvaluated?: CoverageEvaluatedReporter;
 };
 
 let isSyncing = false;
@@ -113,6 +116,7 @@ async function runSync(
       onBootstrapMetadataChanged: options?.onBootstrapMetadataChanged,
       onScopeDownloadComplete: options?.onScopeDownloadComplete,
       onCoverageReset: options?.onCoverageReset,
+      onCoverageEvaluated: options?.onCoverageEvaluated,
     });
   } catch (error) {
     options?.onCycleError?.(error);


### PR DESCRIPTION
Stacked on #4329 (base `feat/4315-offline-loss-telemetry`) for the `events.ts` / adapter overlap; rebases onto `main` the moment that merges.

`Offline Sync Coverage Reset Forced` has never fired once, which #4315 flags as a possible dead path. It is not: it is arithmetic. The guard only acts on verdict `stale`, which needs a `deletions-coverage` marker older than `DELETIONS_COVERAGE_MAX_AGE_MS` = (90 − 10) = 80 days. The marker first shipped in cb4210c5c on **2026-08-01** (#4048), so the earliest a device can hold an 80-day-old one is roughly **2026-10-20**. Zero is the predicted value. The path itself is live and tested end-to-end (the back-dated-marker integration test and the adapter→`track()` binding).

But the reset event alone is a **censored instrument**, and that part is a real gap. `enforceDeletionsCoverage` returns early on `coverageAt === null`, and the marker only exists after a *completed* deletions pull — so a device that can never finish one (a board stranded on the paged crawl, cf. #4313) stays `unknown` forever and emits nothing. The reset-only view therefore samples exactly the devices healthy enough not to be at risk.

Two smaller corrections while in here: the marker is stamped in **two** places, not one (after a completed deletions pull, and inside `resetUserDataForLostCoverage` as the post-wipe re-seed), and the reachability probe rejecting on a stale device is invisible today — it throws into the scheduler's catch and dies in a dev-only `console.warn`.

## Changes

- **`onCoverageEvaluated`** on `SyncOptions`, emitted immediately after `evaluateDeletionsCoverage` and **before** the `coverageAt === null || verdict !== 'stale'` early return, so `unknown` and `future` are first-class values rather than silence. Payload: `verdict`, `markerAgeDays` (null for `unknown`/`future`, floored otherwise), `outcome: 'evaluated' | 'reset' | 'probe_failed'`. Threaded through `sync-scheduler` exactly like `onCoverageReset`.
- The reachability probe is wrapped in try/catch that reports `probe_failed` and **rethrows unchanged**. The rethrow is the whole safety property: it is what leaves local data intact and defers to the next cycle. Swallowing it would let a stale device wipe user data without a verified connection — the precise catastrophe the probe exists to prevent. The existing "no reset on a rejecting probe" test stays green untouched, and the new one asserts the throw still propagates.
- On a successful reset, `outcome: 'reset'` is emitted **alongside** `onCoverageReset`, not instead of it: the reset event stays the dedicated "a wipe happened" signal, and the verdict stream carries the denominator that makes its rate readable.
- **`Offline Sync Coverage Evaluated`** in `SHARED_EVENTS`, bound in the mobile adapter on `startSyncScheduler` / `triggerSync` / `pullSync`. The dedupe lives in the **binding**, not the engine: the engine fires every cycle so the seam stays deterministic and testable, but `enforceDeletionsCoverage` runs at the top of every `pullSync` and the scheduler has no interval — it wakes on foreground and reconnect, so an un-deduped emit would repeat indefinitely on precisely the devices worth counting once. Keyed on the verdict, so a `fresh`→`stale` transition still reports.
- **`retention.ts` doc** records the reachability arithmetic (both stamp sites, the 80 days, the ~2026-10-20 floor), and `deletions-coverage.test.ts` pins `DELETIONS_COVERAGE_MAX_AGE_MS === 80 days` so a future retention or margin edit that moves that date fails CI rather than quietly moving a dashboard's expectations.

No behaviour change: the only new code paths are a report and a rethrow.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project offline-sync --reporter=agent` — 380 passed. New integration tests against real `node:sqlite`: **no marker at all** emits `verdict: 'unknown'`, `markerAgeDays: null` and still resets nothing (the case the reset-only view could never see, so the load-bearing one); a 45-day marker emits `fresh`; a future-dated marker emits `future`; the existing back-dated-marker test still emits `onCoverageReset` exactly once and now also emits `evaluated` then `reset` in that order; a stale marker whose probe rejects emits `probe_failed`, **still rethrows**, and leaves every local row and the marker untouched. Plus the pinned 80-day constant.
- `vp test run --project analytics --reporter=agent` — 23 passed.
- `vp run test:mobile` — 622 files / 5511 tests passed, including the adapter test asserting the verdict routes to `track` and never to Sentry, emits once for a repeated identical verdict, and again when the verdict changes.
- `vp run typecheck:mobile` — clean.
- `vp check` — clean for every file this PR touches.
- `vp run check:mobile-bundle` — android bundle OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT6VP1sWqk6bY9mUgyeS2U

