### PR TITLE
fix(mobile): bound and measure the image caches in Manage Storage

### DIFF
--- a/packages/mobile/src/components/settings/StorageSettingsScreen.tsx
+++ b/packages/mobile/src/components/settings/StorageSettingsScreen.tsx
@@ -45,6 +45,7 @@ import {
   isStorageScreenEmpty,
   RECLAIMABLE_VISIBLE_BYTES,
 } from '../../db/storage-usage';
+import { measureCachedImageBytes, clearCachedImages, type CachedImageMeasurement } from '../../lib/sweep-caches';
 import { removeOfflineBoard, compactOfflineDatabase } from '../../offline/remove-offline-board';
 import { formatStorageSize } from '../../lib/format-storage-size';
 import { reportError } from '../../lib/error-reporting';
@@ -56,8 +57,16 @@ type StorageMeasurement = {
   totalBytes: number;
   freeBytes: number | null;
   reclaimableBytes: number;
+  /** Null where there is no cache directory to measure at all — the browser build. */
+  cachedImages: CachedImageMeasurement | null;
   boards: { scopeKey: string; scope: OfflineBoardScope; climbCount: number; estimatedBytes: number }[];
 };
+
+/** Everything the Clear button reclaims, for the empty-state check and the button label. */
+function totalCachedImageBytes(cachedImages: CachedImageMeasurement | null): number {
+  if (!cachedImages) return 0;
+  return cachedImages.artBytes + (cachedImages.photoBytes ?? 0) + cachedImages.leftoverSnapshotBytes;
+}
 
 export function StorageSettingsScreen() {
   const { t } = useTranslation('common');
@@ -72,6 +81,7 @@ export function StorageSettingsScreen() {
   const [removingScopeKey, setRemovingScopeKey] = useState<string | null>(null);
   const [isRemovingAll, setIsRemovingAll] = useState(false);
   const [isCompacting, setIsCompacting] = useState(false);
+  const [isClearingCache, setIsClearingCache] = useState(false);
 
   const {
     data: measurement,
@@ -97,6 +107,9 @@ export function StorageSettingsScreen() {
         totalBytes: measureDatabaseBytes(),
         freeBytes: measureFreeDiskSpace(),
         reclaimableBytes: await measureReclaimableBytes(db),
+        // Memoized for a minute behind cache-size-meter, so the focus refetch
+        // above doesn't re-walk a few thousand PNGs every time you tab back.
+        cachedImages: await measureCachedImageBytes(),
         // A scope with no rows left is nothing to manage — don't offer a Remove that
         // would free nothing.
         boards: usage.filter((entry) => entry.climbCount > 0),
@@ -226,7 +239,42 @@ export function StorageSettingsScreen() {
     }
   }, [db, showToast, t, refetch]);
 
-  const isBusy = removingScopeKey !== null || isRemovingAll || isCompacting;
+  const cachedImages = measurement?.cachedImages ?? null;
+  const cachedImageBytes = totalCachedImageBytes(cachedImages);
+
+  const handleClearCachedImages = useCallback(async () => {
+    hapticLight();
+    const confirmed = await confirm({
+      title: t('mobile.more.storage.clearCachedImagesTitle'),
+      message: t('mobile.more.storage.clearCachedImagesMessage', { size: formatStorageSize(cachedImageBytes) }),
+      confirmLabel: t('mobile.more.storage.clearCachedImagesConfirm'),
+      cancelLabel: t('mobile.more.storage.cancel'),
+      destructive: true,
+    });
+    if (!confirmed) return;
+    setIsClearingCache(true);
+    try {
+      const result = await clearCachedImages();
+      // expo-image resolves FALSE rather than throwing when it declines to clear
+      // its disk cache (Android with no current activity), so the board art is
+      // gone but the photos are not. Saying "done" there would be a lie the next
+      // measurement immediately contradicts.
+      showToast(
+        result.photoCacheCleared
+          ? t('mobile.more.storage.clearCachedImagesDone')
+          : t('mobile.more.storage.clearCachedImagesPartial'),
+        result.photoCacheCleared ? 'success' : 'warning',
+      );
+    } catch (error) {
+      reportError(error, { tags: { source: 'offline-sync', kind: 'cache-clear' } });
+      showToast(t('mobile.more.storage.clearCachedImagesError'), 'error');
+    } finally {
+      setIsClearingCache(false);
+      await refetch();
+    }
+  }, [confirm, t, cachedImageBytes, showToast, refetch]);
+
+  const isBusy = removingScopeKey !== null || isRemovingAll || isCompacting || isClearingCache;
 
   // Also spin while re-measuring over an empty cached result: a board downloaded
   // while this screen was unmounted would otherwise flash "Nothing downloaded yet"
@@ -264,7 +312,13 @@ export function StorageSettingsScreen() {
   // reserved space, fall through to the full screen instead — that's the case where
   // a compaction failed after the last board was removed, and a bare empty state
   // would hide the total, the free-space figure, and the only way to retry.
-  if (isStorageScreenEmpty({ boardCount: rows.length, reclaimableBytes: measurement.reclaimableBytes })) {
+  if (
+    isStorageScreenEmpty({
+      boardCount: rows.length,
+      reclaimableBytes: measurement.reclaimableBytes,
+      cachedImageBytes,
+    })
+  ) {
     return (
       <View style={[styles.centered, { backgroundColor: systemColors.background }]}>
         <Icon name="boards" size={48} color={systemColors.tertiaryLabel} />
@@ -341,6 +395,43 @@ export function StorageSettingsScreen() {
               />
             </View>
           </Card>
+        </>
+      ) : null}
+
+      {/* Board art and photos. Hidden entirely on the browser build, where there is
+          no cache directory to measure and the Cache API bounds overlays by count.
+          The Photos row is omitted (never rendered as 0 B) when expo-image's cache
+          directory isn't one we recognise — the button still works. */}
+      {cachedImages ? (
+        <>
+          <SectionHeader title={t('mobile.more.storage.cachedImagesHeader')} />
+          <Card style={styles.card}>
+            <ListRow
+              title={t('mobile.more.storage.cachedImagesArtLabel')}
+              haptic={false}
+              showSeparator={cachedImages.photoBytes !== null}
+              trailing={<Text variant="body">{formatStorageSize(cachedImages.artBytes)}</Text>}
+            />
+            {cachedImages.photoBytes !== null ? (
+              <ListRow
+                title={t('mobile.more.storage.cachedImagesPhotosLabel')}
+                haptic={false}
+                showSeparator={false}
+                trailing={<Text variant="body">{formatStorageSize(cachedImages.photoBytes)}</Text>}
+              />
+            ) : null}
+          </Card>
+          <Text variant="caption1" style={[styles.note, { color: systemColors.tertiaryLabel }]}>
+            {t('mobile.more.storage.cachedImagesNote')}
+          </Text>
+          <Button
+            title={t('mobile.more.storage.clearCachedImages')}
+            variant="outlined"
+            loading={isClearingCache}
+            disabled={removingScopeKey !== null || isRemovingAll || isCompacting}
+            onPress={() => void handleClearCachedImages()}
+            style={styles.clearCache}
+          />
         </>
       ) : null}
 
@@ -427,6 +518,11 @@ const styles = StyleSheet.create({
   },
   removeAll: {
     marginTop: spacing[4],
+    marginHorizontal: spacing[4],
+  },
+  clearCache: {
+    marginTop: spacing[3],
+    marginBottom: spacing[2],
     marginHorizontal: spacing[4],
   },
   reserved: {

--- a/packages/mobile/src/db/__tests__/storage-usage.test.ts
+++ b/packages/mobile/src/db/__tests__/storage-usage.test.ts
@@ -5,7 +5,7 @@
 // screen with no way to reclaim the space it exists to reclaim.
 
 import { describe, it, expect } from 'vitest';
-import { isStorageScreenEmpty, RECLAIMABLE_VISIBLE_BYTES } from '../storage-usage';
+import { isStorageScreenEmpty, CACHED_IMAGES_VISIBLE_BYTES, RECLAIMABLE_VISIBLE_BYTES } from '../storage-usage';
 
 describe('isStorageScreenEmpty', () => {
   it('is empty with no boards and nothing reserved', () => {
@@ -21,6 +21,22 @@ describe('isStorageScreenEmpty', () => {
 
   it('is never empty while a board is downloaded', () => {
     expect(isStorageScreenEmpty({ boardCount: 1, reclaimableBytes: 0 })).toBe(false);
+  });
+
+  // Issue #3647: hundreds of megabytes of cached board art can accumulate on a
+  // device that never downloaded a board. A bare empty state would hide both the
+  // number and the only button that clears it.
+  it('is NOT empty when nothing is downloaded but the caches are holding real space', () => {
+    expect(isStorageScreenEmpty({ boardCount: 0, reclaimableBytes: 0, cachedImageBytes: 180_000_000 })).toBe(false);
+  });
+
+  it('ignores a handful of thumbnails the same way it ignores freelist churn', () => {
+    expect(
+      isStorageScreenEmpty({ boardCount: 0, reclaimableBytes: 0, cachedImageBytes: CACHED_IMAGES_VISIBLE_BYTES - 1 }),
+    ).toBe(true);
+    expect(
+      isStorageScreenEmpty({ boardCount: 0, reclaimableBytes: 0, cachedImageBytes: CACHED_IMAGES_VISIBLE_BYTES }),
+    ).toBe(false);
   });
 
   // SQLite's freelist is basically never empty after ordinary sync churn, so a

--- a/packages/mobile/src/db/storage-usage.ts
+++ b/packages/mobile/src/db/storage-usage.ts
@@ -19,6 +19,17 @@ import { DATABASE_NAME } from './connection';
 export const RECLAIMABLE_VISIBLE_BYTES = 5_000_000;
 
 /**
+ * How much cached board art / photos is worth keeping the screen open for.
+ *
+ * Same reasoning as RECLAIMABLE_VISIBLE_BYTES, applied to the caches: a couple of
+ * megabytes of thumbnails is noise, but tens or hundreds of megabytes is the
+ * gap between this screen's number and the OS storage screen's — and it would be
+ * invisible behind a bare "Nothing downloaded yet" that also hides the only
+ * button that clears it.
+ */
+export const CACHED_IMAGES_VISIBLE_BYTES = 5_000_000;
+
+/**
  * Whether the Storage screen has genuinely nothing to show or do.
  *
  * Deliberately NOT just "no boards downloaded". Removing the last board and then
@@ -26,9 +37,20 @@ export const RECLAIMABLE_VISIBLE_BYTES = 5_000_000;
  * the rows are gone, the user's storage figure hasn't moved, and a bare empty state
  * would hide the total, the free-space figure, and the only button that can finish the
  * job — on the one screen whose entire purpose is reclaiming that space.
+ *
+ * Cached board art and photos count for the same reason (issue #3647): you can
+ * hold a few hundred megabytes of overlay PNGs having never downloaded a board.
  */
-export function isStorageScreenEmpty(params: { boardCount: number; reclaimableBytes: number }): boolean {
-  return params.boardCount === 0 && params.reclaimableBytes < RECLAIMABLE_VISIBLE_BYTES;
+export function isStorageScreenEmpty(params: {
+  boardCount: number;
+  reclaimableBytes: number;
+  cachedImageBytes?: number;
+}): boolean {
+  return (
+    params.boardCount === 0 &&
+    params.reclaimableBytes < RECLAIMABLE_VISIBLE_BYTES &&
+    (params.cachedImageBytes ?? 0) < CACHED_IMAGES_VISIBLE_BYTES
+  );
 }
 
 /**

--- a/packages/mobile/src/hooks/__tests__/use-image-cache-memory-management.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-image-cache-memory-management.test.ts
@@ -51,6 +51,7 @@ const deviceLayout = vi.hoisted(() => ({ isPad: true }));
 vi.mock('../use-device-layout', () => ({ useDeviceLayout: () => ({ isPad: deviceLayout.isPad }) }));
 
 import {
+  IMAGE_DISK_CACHE_MAX_BYTES,
   IMAGE_MEMORY_CACHE_MAX_BYTES,
   useImageCacheMemoryManagement,
   useIpadTabSwitchImageCacheSweep,
@@ -68,7 +69,10 @@ describe('image memory cache ceiling', () => {
     // Pins the wiring, not the arithmetic: it must be maxMemoryCost (the in-memory
     // bitmap budget), not maxDiskSize — capping the disk cache instead would evict
     // the very PNGs a re-decode reads back and would not bound memory at all.
-    expect(configureCache).toHaveBeenCalledWith({ maxMemoryCost: IMAGE_MEMORY_CACHE_MAX_BYTES });
+    expect(configureCache).toHaveBeenCalledWith({
+      maxMemoryCost: IMAGE_MEMORY_CACHE_MAX_BYTES,
+      maxDiskSize: IMAGE_DISK_CACHE_MAX_BYTES,
+    });
   });
 
   it('applies the cap once, not on every render', () => {
@@ -97,6 +101,15 @@ describe('image memory cache ceiling', () => {
     const fullResOverlayBytes = 8 * 1024 * 1024;
     expect(IMAGE_MEMORY_CACHE_MAX_BYTES).toBeGreaterThan(8 * fullResOverlayBytes);
     expect(IMAGE_MEMORY_CACHE_MAX_BYTES).toBeLessThan(512 * 1024 * 1024);
+  });
+
+  // The disk ceiling is the one that was genuinely missing (#3647): expo-image
+  // defaults maxDiskSize to 0, i.e. no limit at all. Any positive number fixes
+  // the defect; this guards the two ways to get it wrong — a value so small the
+  // cache thrashes and re-downloads over cellular, or one so large it never bites.
+  it('bounds the on-disk photo cache at something a phone can actually feel', () => {
+    expect(IMAGE_DISK_CACHE_MAX_BYTES).toBeGreaterThan(50 * 1024 * 1024);
+    expect(IMAGE_DISK_CACHE_MAX_BYTES).toBeLessThan(512 * 1024 * 1024);
   });
 });
 

--- a/packages/mobile/src/hooks/use-image-cache-memory-management.ts
+++ b/packages/mobile/src/hooks/use-image-cache-memory-management.ts
@@ -20,6 +20,28 @@ import { tabsActiveSegment } from '../lib/route-segments';
  */
 export const IMAGE_MEMORY_CACHE_MAX_BYTES = 256 * 1024 * 1024;
 
+/**
+ * Ceiling for expo-image's ON-DISK cache, in bytes (issue #3647).
+ *
+ * `ImageCacheConfig.maxDiskSize` "defaults to 0, which means there is no cache
+ * size limit" and nothing ever set it, so until now every `memory-disk` surface
+ * — LayeredClimbImage, PlaylistBoardBackdrop, feed and beta cards — wrote into a
+ * cache bounded only by SDWebImage's 7-day age default. That is the genuinely
+ * unbounded cache on this device: `{cache}/board-thumbnails` has had a 200 MB cap
+ * in the native renderer all along.
+ *
+ * 150 MB is several thousand list thumbnails and a few hundred full-width photos
+ * — far past a session's working set, so the cap bites on accumulation rather
+ * than on use, and what it evicts re-downloads only if you scroll back to it.
+ *
+ * Two caveats worth knowing before reading this as an instantaneous cap:
+ * `ImageCacheConfig` is `@platform ios` (Android runs on Glide, which bounds its
+ * own disk cache by its device-derived policy), and SDWebImage enforces the
+ * ceiling during its background/terminate cleanup rather than continuously — so
+ * the bound is real but lagging.
+ */
+export const IMAGE_DISK_CACHE_MAX_BYTES = 150 * 1024 * 1024;
+
 // Bound and reclaim expo-image's in-memory decoded-bitmap cache.
 //
 // The ceiling is the load-bearing part. SDWebImage ships `maxMemoryCost = 0`
@@ -48,7 +70,10 @@ export function useImageCacheMemoryManagement(): void {
   // (docs/react-native-performance.md §7); web has no native cache to configure.
   useEffect(() => {
     if (Platform.OS !== 'ios') return;
-    Image.configureCache({ maxMemoryCost: IMAGE_MEMORY_CACHE_MAX_BYTES });
+    Image.configureCache({
+      maxMemoryCost: IMAGE_MEMORY_CACHE_MAX_BYTES,
+      maxDiskSize: IMAGE_DISK_CACHE_MAX_BYTES,
+    });
   }, []);
 
   useEffect(() => {

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -13,6 +13,14 @@ import {
 import { useAppColorScheme } from '../providers/theme-provider';
 import { reportError } from '../lib/error-reporting';
 import {
+  cacheRenderedOverlay,
+  getRenderedOverlay,
+  invalidateRenderedOverlay,
+  _renderedOverlaysForTests,
+  _resetOverlayIndexForTests,
+  type RenderedOverlayEntry,
+} from '../lib/overlay-index';
+import {
   DEFAULT_HOLD_COLOR_SIGNATURE,
   DEFAULT_HOLD_BRUSH_THICKNESS,
   DEFAULT_HOLD_MARKER_SHAPE,
@@ -127,10 +135,7 @@ type NativeClimbRenderResult = {
  * huge list scrolled before any render completes) leaving stale entries
  * if components unmount mid-render.
  */
-export type RenderedOverlayEntry = {
-  uri: string;
-  generation: number;
-};
+export type { RenderedOverlayEntry } from '../lib/overlay-index';
 
 type NativeRenderState = {
   key: string;
@@ -163,56 +168,11 @@ const unsupportedRenderSignatures = new Set<string>();
 
 const BOARD_CONFIG_CACHE_MAX = 20;
 
-/**
- * Synchronous lookup of already-rendered overlay PNGs keyed by cache key.
- * Populated when (a) any successful render completes, and (b) on first
- * module import we scan the on-disk cache directory to surface PNGs from
- * prior app sessions.
- *
- * This is the mechanism that makes drawer-open instant after the list
- * has scrolled past a climb: the hook's useState initial value reads
- * from this map, so a cache hit displays the overlay on the very first
- * render with no useEffect-driven update.
- */
-const renderedOverlays = new Map<string, RenderedOverlayEntry>();
-const RENDERED_OVERLAYS_MAX = 200;
-let nextOverlayGeneration = 1;
-
-/**
- * The only insertion path for the synchronous overlay cache. A generation is
- * minted even when native rewrites the same URI, which lets mounted consumers
- * distinguish the replacement from the missing file they just failed to load.
- */
-function cacheRenderedOverlay(cacheKey: string, uri: string): RenderedOverlayEntry {
-  const entry = { uri, generation: nextOverlayGeneration };
-  nextOverlayGeneration += 1;
-
-  // Delete first so replacing an entry also promotes it to most-recently used.
-  renderedOverlays.delete(cacheKey);
-  if (renderedOverlays.size >= RENDERED_OVERLAYS_MAX) {
-    const oldestKey = renderedOverlays.keys().next().value;
-    if (oldestKey !== undefined) renderedOverlays.delete(oldestKey);
-  }
-  renderedOverlays.set(cacheKey, entry);
-  return entry;
-}
-
-function getRenderedOverlay(cacheKey: string): RenderedOverlayEntry | undefined {
-  const entry = renderedOverlays.get(cacheKey);
-  if (!entry) return undefined;
-  // Map iteration order is the LRU order. Reads promote without changing the
-  // immutable entry identity used by exact failure guards.
-  renderedOverlays.delete(cacheKey);
-  renderedOverlays.set(cacheKey, entry);
-  return entry;
-}
-
-function invalidateRenderedOverlay(cacheKey: string, expected: RenderedOverlayEntry): boolean {
-  const current = renderedOverlays.get(cacheKey);
-  if (!current || current.uri !== expected.uri || current.generation !== expected.generation) return false;
-  renderedOverlays.delete(cacheKey);
-  return true;
-}
+// The synchronous overlay index (the `renderedOverlays` map, its insertion /
+// read / invalidation helpers, and the access clock the disk sweeper protects
+// live keys with) lives in ../lib/overlay-index. It was extracted so the sweeper
+// can forget keys whose PNG it just deleted without importing this hook — see
+// that module for why the cycle mattered.
 
 type OverlayLoadTelemetryKind =
   | 'cache_entry_missing'
@@ -304,8 +264,7 @@ onOverlayCacheHydrated(() => {
 /** Test-only handle for re-running the warm-up against a fresh mock list. */
 export function _resetWarmupForTests(): void {
   warmupRun = false;
-  renderedOverlays.clear();
-  nextOverlayGeneration = 1;
+  _resetOverlayIndexForTests();
   reportedOverlayLoadTelemetry.clear();
 }
 
@@ -354,7 +313,8 @@ export function getOrStartInflightRender(
 
 /** Test-only handles. Not part of the public API. */
 export const _inflightRendersForTests = inflightRenders;
-export const _renderedOverlaysForTests = renderedOverlays;
+// Re-exported from ../lib/overlay-index so the existing suites keep their imports.
+export { _renderedOverlaysForTests };
 export const _cacheRenderedOverlayForTests = cacheRenderedOverlay;
 export const _getRenderedOverlayForTests = getRenderedOverlay;
 export const _invalidateRenderedOverlayForTests = invalidateRenderedOverlay;

--- a/packages/mobile/src/lib/__tests__/cache-dir-io.test.ts
+++ b/packages/mobile/src/lib/__tests__/cache-dir-io.test.ts
@@ -1,0 +1,104 @@
+// The one filesystem seam of the cache sweep.
+//
+// Two things matter here and neither is obvious from the API: a missing
+// directory must not throw (`Directory.list()` does), and the walk must hand the
+// JS thread back periodically — `Directory.size` looks like the cheap way to do
+// this but is a synchronous full recursive walk on both platforms, so it can
+// never yield.
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+// Imported by path, not by package name: the `expo-file-system` alias in
+// vite.config.ts points at this same file, so this is the same module instance
+// cache-dir-io sees — but `tsc` resolves the package name to the real types,
+// which know nothing about the seeding helpers.
+import { Directory, __resetFileSystem, __seedFileSystem } from '../../../test/expo-file-system-stub';
+import { deleteCacheDirEntries, resolveImageCacheDirName, walkCacheDir } from '../cache-dir-io';
+
+afterEach(() => {
+  __resetFileSystem();
+  vi.restoreAllMocks();
+});
+
+describe('walkCacheDir', () => {
+  it('reports a missing directory as null rather than zero bytes', async () => {
+    expect(await walkCacheDir('board-thumbnails')).toBeNull();
+  });
+
+  it('returns per-entry size and mtime alongside the total in one pass', async () => {
+    __seedFileSystem({
+      'cache/board-thumbnails': {
+        'a.png': { size: 100, lastModified: 1_000 },
+        'b.png': { size: 250, lastModified: 2_000 },
+      },
+    });
+    const walk = await walkCacheDir('board-thumbnails');
+    expect(walk?.totalBytes).toBe(350);
+    expect(walk?.entries).toEqual([
+      { name: 'a.png', sizeBytes: 100, modifiedAtMs: 1_000 },
+      { name: 'b.png', sizeBytes: 250, modifiedAtMs: 2_000 },
+    ]);
+  });
+
+  // `list()` returns `(Directory | File)[]`, and reading `.size` off a Directory
+  // is the recursive walk we are avoiding.
+  it('skips subdirectories by default and never reads their size', async () => {
+    __seedFileSystem({
+      'cache/board-thumbnails': { 'a.png': { size: 100, lastModified: 1_000 } },
+      'cache/board-thumbnails/nested': { 'b.png': { size: 999, lastModified: 1_000 } },
+    });
+    const directorySize = vi.spyOn(Directory.prototype, 'list');
+    const walk = await walkCacheDir('board-thumbnails');
+    expect(walk?.totalBytes).toBe(100);
+    expect(walk?.entries.map((entry) => entry.name)).toEqual(['a.png']);
+    // One list call: the nested directory was skipped, not descended into.
+    expect(directorySize).toHaveBeenCalledTimes(1);
+  });
+
+  it('descends when asked — SDWebImage keeps its files one level down', async () => {
+    __seedFileSystem({
+      'cache/com.hackemist.SDImageCache': {},
+      'cache/com.hackemist.SDImageCache/default': {
+        'photo-a': { size: 1_000, lastModified: 1 },
+        'photo-b': { size: 2_500, lastModified: 1 },
+      },
+    });
+    const walk = await walkCacheDir('com.hackemist.SDImageCache', { recursive: true });
+    expect(walk?.totalBytes).toBe(3_500);
+  });
+
+  it('yields the JS thread once per chunk instead of blocking on the whole directory', async () => {
+    const files: Record<string, { size: number; lastModified: number }> = {};
+    for (let index = 0; index < 6; index += 1) files[`entry-${index}.png`] = { size: 1, lastModified: index };
+    __seedFileSystem({ 'cache/board-thumbnails': files });
+
+    const scheduled = vi.spyOn(globalThis, 'setTimeout');
+    await walkCacheDir('board-thumbnails', { chunkSize: 2 });
+    expect(scheduled).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('deleteCacheDirEntries', () => {
+  it('deletes what it can and keeps going past a name that is already gone', () => {
+    __seedFileSystem({
+      'cache/board-thumbnails': { 'a.png': { size: 1 }, 'c.png': { size: 1 } },
+    });
+    expect(deleteCacheDirEntries('board-thumbnails', ['a.png', 'b-vanished.png', 'c.png'])).toBe(2);
+    expect(new Directory('cache/board-thumbnails').list()).toHaveLength(0);
+  });
+});
+
+describe('resolveImageCacheDirName', () => {
+  it('is null when neither known cache directory is on this device', () => {
+    expect(resolveImageCacheDirName()).toBeNull();
+  });
+
+  it('finds SDWebImage on iOS', () => {
+    __seedFileSystem({ 'cache/com.hackemist.SDImageCache': {} });
+    expect(resolveImageCacheDirName()).toBe('com.hackemist.SDImageCache');
+  });
+
+  it('finds Glide on Android', () => {
+    __seedFileSystem({ 'cache/image_manager_disk_cache': {} });
+    expect(resolveImageCacheDirName()).toBe('image_manager_disk_cache');
+  });
+});

--- a/packages/mobile/src/lib/__tests__/cache-sweep-plan.test.ts
+++ b/packages/mobile/src/lib/__tests__/cache-sweep-plan.test.ts
@@ -1,0 +1,217 @@
+// The cache-deletion rules, tested without a filesystem.
+//
+// The regression this file exists for: the JS sweeper walks the SAME directory
+// the native BoardRenderer modules write into. If it deletes a file the native
+// side considers in-flight, the render on the bridge fails with ENOENT and the
+// user gets exactly the Sentry storm this issue is also trying to stop. So
+// "never touches a foreign file" is asserted on every path, not just eviction.
+
+import { describe, it, expect } from 'vitest';
+import {
+  classifyOverlayEntry,
+  measureOverlayCacheBytes,
+  planLruEviction,
+  planOverlayCacheClear,
+  planStaleArtifactSweep,
+  overlayNameMatchesScope,
+  cacheKeyForOverlayName,
+  MANAGED_TEMP_MIN_AGE_MS,
+  OVERLAY_CACHE_TARGET_BYTES,
+  type CacheDirEntry,
+} from '../cache-sweep-plan';
+
+const NOW = 1_800_000_000_000;
+
+function entry(name: string, sizeBytes: number, ageMs: number | null = 0): CacheDirEntry {
+  return { name, sizeBytes, modifiedAtMs: ageMs === null ? null : NOW - ageMs };
+}
+
+describe('classifyOverlayEntry', () => {
+  it('treats finished overlay PNGs as ours to evict', () => {
+    expect(classifyOverlayEntry('v5_f_w400_kilter_1_7_1,20_ab12cd34.png')).toBe('cache-entry');
+  });
+
+  it('recognises the Android atomic-write temp by BOTH its prefix and suffix', () => {
+    expect(classifyOverlayEntry('.bsov-1234.tmp')).toBe('managed-temp');
+    // Prefix without the suffix, and suffix without the prefix, are not ours.
+    expect(classifyOverlayEntry('.bsov-1234.png')).toBe('foreign');
+    expect(classifyOverlayEntry('scratch.tmp')).toBe('foreign');
+  });
+
+  // iOS stages `pngData.write(to:options:.atomic)` as a hidden dot-file in this
+  // same directory, and its own pruner skips hidden files. Deleting one is a
+  // guaranteed failure for a render already on the bridge.
+  it('never claims a hidden file it did not create', () => {
+    expect(classifyOverlayEntry('.dat.nosync0f1e.abc')).toBe('foreign');
+    expect(classifyOverlayEntry('.DS_Store')).toBe('foreign');
+    expect(classifyOverlayEntry('.hidden.png')).toBe('foreign');
+  });
+
+  it('leaves anything else alone', () => {
+    expect(classifyOverlayEntry('subdirectory')).toBe('foreign');
+    expect(classifyOverlayEntry('notes.txt')).toBe('foreign');
+  });
+});
+
+describe('measureOverlayCacheBytes', () => {
+  it('counts only finished PNGs', () => {
+    const entries = [entry('a.png', 100), entry('.bsov-1.tmp', 5_000), entry('.DS_Store', 7)];
+    expect(measureOverlayCacheBytes(entries)).toBe(100);
+  });
+});
+
+describe('planLruEviction', () => {
+  it('plans nothing while under target', () => {
+    const plan = planLruEviction({ entries: [entry('a.png', 10)], targetBytes: 100, nowMs: NOW });
+    expect(plan.evictNames).toEqual([]);
+    expect(plan.beforeBytes).toBe(10);
+    expect(plan.afterBytes).toBe(10);
+  });
+
+  it('evicts oldest-modified first and stops as soon as it is under target', () => {
+    const plan = planLruEviction({
+      entries: [entry('newest.png', 40, 1_000), entry('oldest.png', 40, 90_000), entry('middle.png', 40, 50_000)],
+      targetBytes: 80,
+      nowMs: NOW,
+    });
+    expect(plan.evictNames).toEqual(['oldest.png']);
+    expect(plan.afterBytes).toBe(80);
+  });
+
+  it('evicts an undateable entry first — it is the one we know least about', () => {
+    const plan = planLruEviction({
+      entries: [entry('dated.png', 40, 90_000), entry('undated.png', 40, null)],
+      targetBytes: 40,
+      nowMs: NOW,
+    });
+    expect(plan.evictNames).toEqual(['undated.png']);
+  });
+
+  // The whole point of the access clock: mtime says this file is ancient, but a
+  // mounted surface read it eight seconds ago and is displaying it right now.
+  it('never evicts a protected key, even when it is the oldest', () => {
+    const plan = planLruEviction({
+      entries: [entry('ancient.png', 60, 900_000), entry('recent.png', 60, 1_000)],
+      targetBytes: 60,
+      protectedNames: new Set(['ancient']),
+      nowMs: NOW,
+    });
+    expect(plan.evictNames).toEqual(['recent.png']);
+  });
+
+  it('never puts a foreign file in an eviction plan', () => {
+    const plan = planLruEviction({
+      entries: [entry('.dat.nosync0f1e.abc', 10_000, 900_000), entry('a.png', 100, 900_000)],
+      targetBytes: 0,
+      nowMs: NOW,
+    });
+    expect(plan.evictNames).toEqual(['a.png']);
+    expect(plan.staleTempNames).toEqual([]);
+  });
+
+  it('sweeps a managed temp only once it is certainly dead', () => {
+    const fresh = planLruEviction({
+      entries: [entry('.bsov-1.tmp', 5_000, 1_000)],
+      targetBytes: OVERLAY_CACHE_TARGET_BYTES,
+      nowMs: NOW,
+    });
+    expect(fresh.staleTempNames).toEqual([]);
+
+    const orphaned = planLruEviction({
+      entries: [entry('.bsov-1.tmp', 5_000, MANAGED_TEMP_MIN_AGE_MS + 1)],
+      targetBytes: OVERLAY_CACHE_TARGET_BYTES,
+      nowMs: NOW,
+    });
+    expect(orphaned.staleTempNames).toEqual(['.bsov-1.tmp']);
+    // ...and it never counted toward the budget in the first place.
+    expect(orphaned.beforeBytes).toBe(0);
+  });
+
+  it('evicts a single file bigger than the whole target', () => {
+    const plan = planLruEviction({ entries: [entry('huge.png', 500)], targetBytes: 100, nowMs: NOW });
+    expect(plan.evictNames).toEqual(['huge.png']);
+    expect(plan.afterBytes).toBe(0);
+  });
+});
+
+describe('planOverlayCacheClear', () => {
+  it('clears every finished PNG and every dead temp, and nothing else', () => {
+    const plan = planOverlayCacheClear({
+      entries: [
+        entry('a.png', 100, 10),
+        entry('b.png', 200, 10),
+        entry('.bsov-old.tmp', 9, MANAGED_TEMP_MIN_AGE_MS + 1),
+        entry('.bsov-live.tmp', 9, 10),
+        entry('.dat.nosync0f1e.abc', 9, 10),
+      ],
+      nowMs: NOW,
+    });
+    expect(plan.deleteNames.sort()).toEqual(['.bsov-old.tmp', 'a.png', 'b.png']);
+    expect(plan.freedBytes).toBe(300);
+  });
+});
+
+describe('planStaleArtifactSweep', () => {
+  it('reaps leaked artifacts and leaves recent ones for a retry', () => {
+    const plan = planStaleArtifactSweep({
+      entries: [entry('kilter-1.db', 271_000_000, 48 * 60 * 60 * 1000), entry('tension-2.db', 40_000_000, 60_000)],
+      nowMs: NOW,
+      maxAgeMs: 24 * 60 * 60 * 1000,
+    });
+    expect(plan.deleteNames).toEqual(['kilter-1.db']);
+    expect(plan.freedBytes).toBe(271_000_000);
+  });
+
+  it('leaves an undateable artifact alone rather than guessing it is dead', () => {
+    const plan = planStaleArtifactSweep({
+      entries: [entry('kilter-1.db', 271_000_000, null)],
+      nowMs: NOW,
+      maxAgeMs: 0,
+    });
+    expect(plan.deleteNames).toEqual([]);
+  });
+});
+
+describe('overlayNameMatchesScope', () => {
+  const name = 'v5_f_w400_kilter_1_7_1,20_ab12cd34.png';
+
+  it('matches the scope that rendered it', () => {
+    expect(overlayNameMatchesScope(name, { boardType: 'kilter', layoutId: 1, sizeId: 7 })).toBe(true);
+  });
+
+  // The delimiter regression: without the trailing underscore, layout 1 also
+  // matches layout 12 and size 7 also matches size 70 — a board removal would
+  // silently take a neighbouring board's art with it.
+  it('does not match a longer layout or size id that starts with the same digits', () => {
+    expect(
+      overlayNameMatchesScope('v5_f_w400_kilter_12_7_1,20_ab12cd34.png', {
+        boardType: 'kilter',
+        layoutId: 1,
+        sizeId: 7,
+      }),
+    ).toBe(false);
+    expect(
+      overlayNameMatchesScope('v5_f_w400_kilter_1_70_1,20_ab12cd34.png', {
+        boardType: 'kilter',
+        layoutId: 1,
+        sizeId: 7,
+      }),
+    ).toBe(false);
+  });
+
+  it('does not match another board type', () => {
+    expect(overlayNameMatchesScope(name, { boardType: 'tension', layoutId: 1, sizeId: 7 })).toBe(false);
+  });
+
+  it('never matches a file that is not ours', () => {
+    expect(overlayNameMatchesScope('.bsov-kilter_1_7_.tmp', { boardType: 'kilter', layoutId: 1, sizeId: 7 })).toBe(
+      false,
+    );
+  });
+});
+
+describe('cacheKeyForOverlayName', () => {
+  it('strips the .png so the name maps back onto the in-memory index key', () => {
+    expect(cacheKeyForOverlayName('v5_f_w400_kilter_1_7_1,20_ab12cd34.png')).toBe('v5_f_w400_kilter_1_7_1,20_ab12cd34');
+  });
+});

--- a/packages/mobile/src/lib/__tests__/overlay-index.test.ts
+++ b/packages/mobile/src/lib/__tests__/overlay-index.test.ts
@@ -1,0 +1,113 @@
+// The in-memory overlay index, and the two things the disk sweeper needs from it.
+//
+// The design this replaced protected "the tail of the map" from eviction, which
+// looked like an LRU and wasn't: the launch warm-up inserts a couple of hundred
+// prior-session PNGs in directory-listing order, so the tail after launch is an
+// arbitrary sample of the disk rather than anything on screen. The regression
+// test for that is `getRecentlyUsedCacheKeys` returning only what was READ.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  cacheRenderedOverlay,
+  getRenderedOverlay,
+  invalidateRenderedOverlay,
+  getRecentlyUsedCacheKeys,
+  forgetOverlays,
+  clearOverlayIndex,
+  onOverlayWriteThreshold,
+  _renderedOverlaysForTests,
+  _resetOverlayIndexForTests,
+} from '../overlay-index';
+
+beforeEach(() => {
+  _resetOverlayIndexForTests();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  _resetOverlayIndexForTests();
+});
+
+describe('getRecentlyUsedCacheKeys', () => {
+  it('returns what a surface READ, not the tail of the insertion order', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    // The warm-up shape: 150 prior-session PNGs inserted in directory order.
+    for (let index = 0; index < 150; index += 1) cacheRenderedOverlay(`warm-${index}`, `file:///warm-${index}.png`);
+
+    // Five minutes of browsing later, three of them are actually on screen.
+    vi.setSystemTime(5 * 60 * 1000);
+    getRenderedOverlay('warm-3');
+    getRenderedOverlay('warm-77');
+    getRenderedOverlay('warm-149');
+
+    const recent = getRecentlyUsedCacheKeys(120_000);
+    expect([...recent].sort()).toEqual(['warm-149', 'warm-3', 'warm-77']);
+  });
+
+  it('lets a key that has not been read since the window fall out of protection', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    cacheRenderedOverlay('stale', 'file:///stale.png');
+    vi.setSystemTime(200_000);
+    cacheRenderedOverlay('fresh', 'file:///fresh.png');
+    expect([...getRecentlyUsedCacheKeys(120_000)]).toEqual(['fresh']);
+  });
+
+  it('does not keep protecting a key whose entry is gone', () => {
+    cacheRenderedOverlay('gone', 'file:///gone.png');
+    forgetOverlays(['gone']);
+    expect(getRecentlyUsedCacheKeys(120_000).size).toBe(0);
+  });
+});
+
+describe('forgetOverlays', () => {
+  it('removes exactly the named keys', () => {
+    cacheRenderedOverlay('a', 'file:///a.png');
+    cacheRenderedOverlay('b', 'file:///b.png');
+    expect(forgetOverlays(['a', 'never-existed'])).toBe(1);
+    expect(_renderedOverlaysForTests.has('a')).toBe(false);
+    expect(_renderedOverlaysForTests.has('b')).toBe(true);
+  });
+});
+
+describe('index bookkeeping', () => {
+  it('mints a new generation even when the URI is unchanged', () => {
+    const first = cacheRenderedOverlay('a', 'file:///a.png');
+    const second = cacheRenderedOverlay('a', 'file:///a.png');
+    expect(second.generation).toBeGreaterThan(first.generation);
+    // A stale handle must not be able to invalidate the replacement.
+    expect(invalidateRenderedOverlay('a', first)).toBe(false);
+    expect(invalidateRenderedOverlay('a', second)).toBe(true);
+  });
+
+  it('clears wholesale', () => {
+    cacheRenderedOverlay('a', 'file:///a.png');
+    clearOverlayIndex();
+    expect(_renderedOverlaysForTests.size).toBe(0);
+    expect(getRecentlyUsedCacheKeys(120_000).size).toBe(0);
+  });
+});
+
+describe('write odometer', () => {
+  it('notifies once per threshold and starts counting again', () => {
+    const listener = vi.fn();
+    const unsubscribe = onOverlayWriteThreshold(4, listener);
+    for (let index = 0; index < 3; index += 1) cacheRenderedOverlay(`k-${index}`, `file:///k-${index}.png`);
+    expect(listener).not.toHaveBeenCalled();
+
+    cacheRenderedOverlay('k-3', 'file:///k-3.png');
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    for (let index = 4; index < 8; index += 1) cacheRenderedOverlay(`k-${index}`, `file:///k-${index}.png`);
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    for (let index = 8; index < 20; index += 1) cacheRenderedOverlay(`k-${index}`, `file:///k-${index}.png`);
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('costs nothing when nobody is listening', () => {
+    expect(() => cacheRenderedOverlay('a', 'file:///a.png')).not.toThrow();
+  });
+});

--- a/packages/mobile/src/lib/__tests__/sweep-caches.test.ts
+++ b/packages/mobile/src/lib/__tests__/sweep-caches.test.ts
@@ -1,0 +1,152 @@
+// Measuring and clearing the caches, against a seeded filesystem.
+//
+// The load-bearing assertions: the Photos row is ABSENT rather than zero when we
+// can't find expo-image's cache directory (the issue's design note is explicit
+// that a fake number is worse than no number), Clear never deletes a file that
+// isn't ours, and a `clearDiskCache()` that resolves FALSE — which is what
+// Android does with no current activity — is reported as partial, not success.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+// Imported by path — see cache-dir-io.test.ts for why.
+import { __resetFileSystem, __seedFileSystem } from '../../../test/expo-file-system-stub';
+
+// The stub aliased in for expo-image is a bare render component with no statics,
+// so the disk-cache call has to be mocked here.
+const clearDiskCache = vi.hoisted(() => vi.fn<() => Promise<boolean>>());
+vi.mock('expo-image', () => ({ Image: { clearDiskCache } }));
+
+import { clearCachedImages, measureCachedImageBytes, sweepSnapshotLeftovers } from '../sweep-caches';
+import { invalidateCacheMeasurement } from '../cache-size-meter';
+import { cacheRenderedOverlay, _renderedOverlaysForTests, _resetOverlayIndexForTests } from '../overlay-index';
+
+const NOW = 1_800_000_000_000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+  invalidateCacheMeasurement();
+  _resetOverlayIndexForTests();
+  clearDiskCache.mockReset();
+  clearDiskCache.mockResolvedValue(true);
+});
+
+afterEach(() => {
+  __resetFileSystem();
+  invalidateCacheMeasurement();
+  _resetOverlayIndexForTests();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('measureCachedImageBytes', () => {
+  it('counts finished board art only, and omits Photos when the directory is unknown', async () => {
+    __seedFileSystem({
+      'cache/board-thumbnails': {
+        'a.png': { size: 60_000, lastModified: NOW },
+        '.bsov-live.tmp': { size: 40_000, lastModified: NOW },
+        '.dat.nosync0f1e.abc': { size: 10_000, lastModified: NOW },
+      },
+    });
+    const measurement = await measureCachedImageBytes();
+    expect(measurement?.artBytes).toBe(60_000);
+    // Null, never 0: the row is omitted rather than fabricated.
+    expect(measurement?.photoBytes).toBeNull();
+    expect(measurement?.leftoverSnapshotBytes).toBe(0);
+  });
+
+  it('measures expo-image and leaked snapshot artifacts when they are there', async () => {
+    __seedFileSystem({
+      'cache/board-thumbnails': { 'a.png': { size: 1_000, lastModified: NOW } },
+      'cache/com.hackemist.SDImageCache': {},
+      'cache/com.hackemist.SDImageCache/default': { photo: { size: 5_000, lastModified: NOW } },
+      'cache/board-snapshots': { 'kilter-1.db': { size: 271_000_000, lastModified: NOW - 2 * DAY_MS } },
+    });
+    const measurement = await measureCachedImageBytes();
+    expect(measurement).toEqual({ artBytes: 1_000, photoBytes: 5_000, leftoverSnapshotBytes: 271_000_000 });
+  });
+
+  it('reuses a measurement rather than re-walking on every focus', async () => {
+    __seedFileSystem({ 'cache/board-thumbnails': { 'a.png': { size: 1_000, lastModified: NOW } } });
+    await measureCachedImageBytes();
+    // The disk moved on, but within the memo window the screen keeps the number
+    // it already has — that is the point, one walk per minute, not per focus.
+    __seedFileSystem({ 'cache/board-thumbnails': { 'a.png': { size: 9_999_999, lastModified: NOW } } });
+    expect((await measureCachedImageBytes())?.artBytes).toBe(1_000);
+
+    vi.setSystemTime(NOW + 61_000);
+    expect((await measureCachedImageBytes())?.artBytes).toBe(9_999_999);
+  });
+});
+
+describe('sweepSnapshotLeftovers', () => {
+  it('reaps an artifact leaked by a kill and leaves a recent one for the retry', async () => {
+    __seedFileSystem({
+      'cache/board-snapshots': {
+        'leaked.db': { size: 271_000_000, lastModified: NOW - 2 * DAY_MS },
+        'in-flight.db': { size: 40_000_000, lastModified: NOW - 30_000 },
+      },
+    });
+    expect(await sweepSnapshotLeftovers()).toBe(271_000_000);
+    const measurement = await measureCachedImageBytes();
+    expect(measurement?.leftoverSnapshotBytes).toBe(40_000_000);
+  });
+
+  it('does nothing when the directory was never created', async () => {
+    expect(await sweepSnapshotLeftovers()).toBe(0);
+  });
+});
+
+describe('clearCachedImages', () => {
+  it('deletes every overlay PNG and dead temp, and nothing that is not ours', async () => {
+    __seedFileSystem({
+      'cache/board-thumbnails': {
+        'v5_f_w400_kilter_1_7_1,20_aa.png': { size: 60_000, lastModified: NOW },
+        'v5_f_w400_kilter_1_7_1,20_bb.png': { size: 60_000, lastModified: NOW },
+        '.bsov-dead.tmp': { size: 9, lastModified: NOW - 2 * 60 * 60 * 1000 },
+        '.bsov-live.tmp': { size: 9, lastModified: NOW },
+        '.dat.nosync0f1e.abc': { size: 9, lastModified: NOW },
+      },
+    });
+    const result = await clearCachedImages();
+    expect(result.filesDeleted).toBe(3);
+    expect(result.freedBytes).toBe(120_000);
+    expect(result.photoCacheCleared).toBe(true);
+
+    // The in-flight temp and the foreign staging file survived — deleting either
+    // is how a sweeper manufactures the render-failure storm.
+    const measurement = await measureCachedImageBytes();
+    expect(measurement?.artBytes).toBe(0);
+  });
+
+  it('drops the cleared keys from the in-memory index so nothing serves a dead URI', async () => {
+    __seedFileSystem({
+      'cache/board-thumbnails': { 'live.png': { size: 100, lastModified: NOW } },
+    });
+    cacheRenderedOverlay('live', 'file:///cache/board-thumbnails/live.png');
+    await clearCachedImages();
+    expect(_renderedOverlaysForTests.size).toBe(0);
+  });
+
+  // Android's Image.clearDiskCache resolves false — a no-op — when the module has
+  // no current activity. Reporting that as success is a lie the very next
+  // measurement contradicts.
+  it('reports partial rather than success when expo-image declines', async () => {
+    clearDiskCache.mockResolvedValue(false);
+    const result = await clearCachedImages();
+    expect(result.photoCacheCleared).toBe(false);
+  });
+
+  it('reports partial rather than throwing when expo-image rejects', async () => {
+    clearDiskCache.mockRejectedValue(new Error('no activity'));
+    await expect(clearCachedImages()).resolves.toMatchObject({ photoCacheCleared: false });
+  });
+
+  it('leaves a snapshot download that could still be in flight alone', async () => {
+    __seedFileSystem({
+      'cache/board-snapshots': { 'downloading.db': { size: 271_000_000, lastModified: NOW - 30_000 } },
+    });
+    const result = await clearCachedImages();
+    expect(result.freedBytes).toBe(0);
+  });
+});

--- a/packages/mobile/src/lib/__tests__/sweep-caches.test.ts
+++ b/packages/mobile/src/lib/__tests__/sweep-caches.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 // Imported by path — see cache-dir-io.test.ts for why.
-import { __resetFileSystem, __seedFileSystem } from '../../../test/expo-file-system-stub';
+import { Directory, __resetFileSystem, __seedFileSystem } from '../../../test/expo-file-system-stub';
 
 // The stub aliased in for expo-image is a bare render component with no statics,
 // so the disk-cache call has to be mocked here.
@@ -66,6 +66,32 @@ describe('measureCachedImageBytes', () => {
     expect(measurement).toEqual({ artBytes: 1_000, photoBytes: 5_000, leftoverSnapshotBytes: 271_000_000 });
   });
 
+  // This runs inside the same ['offlineStorage'] query as the database total, the
+  // board list and the Remove buttons, so a throwing walk must degrade to "no
+  // section", never to the error state on the one screen about reclaiming space.
+  it('omits the section rather than failing the whole Manage Storage query', async () => {
+    __seedFileSystem({ 'cache/board-thumbnails': { 'a.png': { size: 1_000, lastModified: NOW } } });
+    vi.spyOn(Directory.prototype, 'list').mockImplementation(() => {
+      throw new Error('EACCES');
+    });
+    await expect(measureCachedImageBytes()).resolves.toBeNull();
+  });
+
+  it('still reports board art when only the photo directory is unreadable', async () => {
+    __seedFileSystem({
+      'cache/board-thumbnails': { 'a.png': { size: 1_000, lastModified: NOW } },
+      'cache/image_manager_disk_cache': {},
+    });
+    const listDirectory = Directory.prototype.list;
+    vi.spyOn(Directory.prototype, 'list').mockImplementation(function (this: Directory) {
+      if (this.path.includes('image_manager_disk_cache')) throw new Error('EACCES');
+      return listDirectory.call(this);
+    });
+    const measurement = await measureCachedImageBytes();
+    expect(measurement?.artBytes).toBe(1_000);
+    expect(measurement?.photoBytes).toBeNull();
+  });
+
   it('reuses a measurement rather than re-walking on every focus', async () => {
     __seedFileSystem({ 'cache/board-thumbnails': { 'a.png': { size: 1_000, lastModified: NOW } } });
     await measureCachedImageBytes();
@@ -114,7 +140,16 @@ describe('clearCachedImages', () => {
     expect(result.photoCacheCleared).toBe(true);
 
     // The in-flight temp and the foreign staging file survived — deleting either
-    // is how a sweeper manufactures the render-failure storm.
+    // is how a sweeper manufactures the render-failure storm. Assert the files
+    // themselves, not just the byte total: artBytes counts PNGs only, so it
+    // would read 0 whether or not the temps were collateral damage.
+    expect(
+      new Directory('cache/board-thumbnails')
+        .list()
+        .map((entry) => entry.name)
+        .sort(),
+    ).toEqual(['.bsov-live.tmp', '.dat.nosync0f1e.abc']);
+
     const measurement = await measureCachedImageBytes();
     expect(measurement?.artBytes).toBe(0);
   });

--- a/packages/mobile/src/lib/cache-dir-io.ts
+++ b/packages/mobile/src/lib/cache-dir-io.ts
@@ -1,0 +1,138 @@
+// The only filesystem seam the cache sweeper has (issue #3647).
+//
+// Everything that decides WHAT to delete is pure and lives in
+// `cache-sweep-plan.ts`; everything that touches `expo-file-system` lives here,
+// behind a `.web.ts` twin, so no other module in the sweep has to care that
+// expo-file-system has no browser build.
+//
+// Deliberately absent: `Directory.size`. It reads like a cheap stat but it is a
+// full recursive walk on both platforms — iOS `FileSystemDirectory.swift`
+// (`subpathsOfDirectory` + `attributesOfItem` per subpath), Android
+// `FileSystemDirectory.kt` (`walkTopDown().filter { isFile }.map { length }.sum()`)
+// — implemented as a synchronous JSI getter, so it cannot yield. On a directory
+// with thousands of PNGs that blocks the JS thread outright. The chunked walk
+// below is the same work with a macrotask between every chunk, and it returns
+// the per-entry data an eviction plan needs from the SAME pass, so measuring and
+// sweeping never walk twice.
+
+import { Directory, File, Paths } from 'expo-file-system';
+import type { CacheDirEntry } from './cache-sweep-plan';
+
+export type CacheDirWalk = {
+  entries: CacheDirEntry[];
+  totalBytes: number;
+};
+
+const DEFAULT_CHUNK_SIZE = 100;
+
+/**
+ * expo-image's default on-disk cache directories, by the underlying library.
+ *
+ * These are the upstream defaults, not something we configure, so they are a
+ * best guess that a dependency bump could invalidate. Getting it wrong is
+ * degraded, not dishonest: `measureCachedImageBytes` reports null and the UI
+ * omits the row rather than printing a fabricated `0 B`. To confirm or correct
+ * one on a device, load an image and read
+ * `new File(await Image.getCachePathAsync(uri)).parentDirectory` — the fix is a
+ * one-line change here that rides an OTA.
+ */
+const IMAGE_CACHE_DIR_CANDIDATES = [
+  // iOS: SDWebImage's `SDImageCache` default namespace. Its PNGs live one level
+  // down in `default/`, which is why the probe walk is recursive.
+  'com.hackemist.SDImageCache',
+  // Android: Glide's `InternalCacheDiskCacheFactory` default directory.
+  'image_manager_disk_cache',
+];
+
+/** Hand the JS thread back to the runtime between chunks. */
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
+async function walkDirectory(
+  directory: Directory,
+  chunkSize: number,
+  recursive: boolean,
+  collected: CacheDirEntry[],
+  counter: { seen: number },
+): Promise<number> {
+  // `list()` throws when the directory is absent, so the existence check is not
+  // an optimisation — it is the contract (see `listOverlayCacheEntries`).
+  if (!directory.exists) return 0;
+  let totalBytes = 0;
+  for (const item of directory.list()) {
+    if (item instanceof Directory) {
+      if (recursive) totalBytes += await walkDirectory(item, chunkSize, recursive, collected, counter);
+      continue;
+    }
+    // `size` is 0 and `lastModified` null for anything unreadable, which is the
+    // right answer for a plan: nothing to reclaim, nothing datable to evict on.
+    collected.push({ name: item.name, sizeBytes: item.size, modifiedAtMs: item.lastModified });
+    totalBytes += item.size;
+    counter.seen += 1;
+    if (counter.seen % chunkSize === 0) await yieldToEventLoop();
+  }
+  return totalBytes;
+}
+
+/**
+ * Walk one directory under `Paths.cache`, yielding to the runtime every
+ * `chunkSize` files.
+ *
+ * Returns null when the directory does not exist — a clean install, or an OS
+ * that already reclaimed it. Callers must treat that as "nothing here", never
+ * as "zero bytes measured".
+ */
+export async function walkCacheDir(
+  dirName: string,
+  options?: { chunkSize?: number; recursive?: boolean },
+): Promise<CacheDirWalk | null> {
+  const directory = new Directory(Paths.cache, dirName);
+  if (!directory.exists) return null;
+  const entries: CacheDirEntry[] = [];
+  const totalBytes = await walkDirectory(
+    directory,
+    options?.chunkSize ?? DEFAULT_CHUNK_SIZE,
+    options?.recursive ?? false,
+    entries,
+    { seen: 0 },
+  );
+  return { entries, totalBytes };
+}
+
+/**
+ * Delete named entries from a cache directory, best-effort.
+ *
+ * Per-entry try/catch because the interesting failure is a race — the OS
+ * reclaimed the file, or the native pruner got there first — and a sweep that
+ * rejects on the first of those frees nothing at all.
+ */
+export function deleteCacheDirEntries(dirName: string, names: readonly string[]): number {
+  const directory = new Directory(Paths.cache, dirName);
+  let deleted = 0;
+  for (const name of names) {
+    try {
+      const file = new File(directory, name);
+      if (!file.exists) continue;
+      file.delete();
+      deleted += 1;
+    } catch {
+      // Ignore: see above.
+    }
+  }
+  return deleted;
+}
+
+/** The expo-image disk-cache directory on this device, or null when none of the known names exist. */
+export function resolveImageCacheDirName(): string | null {
+  for (const candidate of IMAGE_CACHE_DIR_CANDIDATES) {
+    try {
+      if (new Directory(Paths.cache, candidate).exists) return candidate;
+    } catch {
+      // A candidate we can't even stat is not the one.
+    }
+  }
+  return null;
+}

--- a/packages/mobile/src/lib/cache-dir-io.web.ts
+++ b/packages/mobile/src/lib/cache-dir-io.web.ts
@@ -1,0 +1,24 @@
+// Browser twin of cache-dir-io.ts. There is no `Paths.cache` in a browser: the
+// overlay store on web is the Cache API, already bounded by entry count
+// (modules/board-renderer/src/overlay-cache-store.web.ts), and photos are held
+// by the browser's own HTTP cache. Nothing here to measure, nothing to sweep —
+// so every caller sees the same "directory absent" answer a clean install gives.
+
+import type { CacheDirEntry } from './cache-sweep-plan';
+
+export type CacheDirWalk = {
+  entries: CacheDirEntry[];
+  totalBytes: number;
+};
+
+export async function walkCacheDir(): Promise<CacheDirWalk | null> {
+  return null;
+}
+
+export function deleteCacheDirEntries(): number {
+  return 0;
+}
+
+export function resolveImageCacheDirName(): string | null {
+  return null;
+}

--- a/packages/mobile/src/lib/cache-size-meter.ts
+++ b/packages/mobile/src/lib/cache-size-meter.ts
@@ -1,0 +1,56 @@
+// A short memo in front of the cache-directory walk (issue #3647).
+//
+// Measuring a cache directory is a full walk — there is no cheap stat (see
+// cache-dir-io.ts). Manage Storage re-measures on every focus, and the sweeper
+// wants the same number, so without a memo the two of them race two thousand-file
+// walks past each other every time you tab back to the screen.
+//
+// A minute is long enough that focus churn costs one walk, and short enough that
+// the figure on screen is never meaningfully behind the disk. Anything that
+// mutates a directory invalidates it explicitly, so a Clear or a sweep shows its
+// result immediately rather than after a TTL.
+
+const MEASUREMENT_TTL_MS = 60_000;
+
+type Measurement = { bytes: number | null; measuredAtMs: number };
+
+const measurements = new Map<string, Measurement>();
+
+/** Read a fresh-enough measurement, or null when one needs taking. */
+export function readCachedMeasurement(dirName: string, nowMs = Date.now()): number | null | undefined {
+  const measurement = measurements.get(dirName);
+  if (!measurement) return undefined;
+  if (nowMs - measurement.measuredAtMs >= MEASUREMENT_TTL_MS) return undefined;
+  return measurement.bytes;
+}
+
+/** Record a measurement someone already took — a sweep's walk counts as one. */
+export function recordCacheMeasurement(dirName: string, bytes: number | null, nowMs = Date.now()): void {
+  measurements.set(dirName, { bytes, measuredAtMs: nowMs });
+}
+
+/** Drop one directory's memo, or all of them. Call after anything that deletes. */
+export function invalidateCacheMeasurement(dirName?: string): void {
+  if (dirName === undefined) measurements.clear();
+  else measurements.delete(dirName);
+}
+
+/**
+ * Measure a directory, reusing a recent measurement when there is one.
+ *
+ * `measure` returns null for "directory absent", which is memoized too: probing
+ * a directory that isn't there is still a syscall, and on a device where
+ * expo-image's cache name doesn't match our allowlist that probe would otherwise
+ * repeat on every screen focus forever.
+ */
+export async function measureCacheDirBytes(
+  dirName: string,
+  measure: () => Promise<number | null>,
+  nowMs = Date.now(),
+): Promise<number | null> {
+  const cached = readCachedMeasurement(dirName, nowMs);
+  if (cached !== undefined) return cached;
+  const bytes = await measure();
+  recordCacheMeasurement(dirName, bytes, Date.now());
+  return bytes;
+}

--- a/packages/mobile/src/lib/cache-sweep-plan.ts
+++ b/packages/mobile/src/lib/cache-sweep-plan.ts
@@ -1,0 +1,238 @@
+// Pure planning for the on-disk caches this app owns (issue #3647).
+//
+// Zero imports on purpose: every rule here is a decision about *which files are
+// ours to delete*, and that decision has to be testable without a filesystem,
+// a native module, or a React tree. The I/O that feeds it lives in
+// `cache-dir-io.ts`; the orchestration lives in `sweep-caches.ts`.
+//
+// The board-art rules below MIRROR the native pruner's contract. If you change
+// one, change the other:
+//   - packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/
+//     boardrenderer/CachePruner.kt  (`.png`-only accounting + eviction, temp sweep)
+//   - .../boardrenderer/AtomicFileWrite.kt  (`TEMP_PREFIX` / `TEMP_SUFFIX`)
+//   - packages/mobile/modules/board-renderer/ios/BoardRendererModule.swift
+//     (`cacheCapBytes`, and the `.skipsHiddenFiles` that keeps its own
+//     `write(to:options:.atomic)` staging file out of the sweep)
+//
+// Two pruners walking the same directory with different ideas of what is safe
+// to delete is how you manufacture a "file vanished mid-write" storm, which is
+// the exact Sentry noise this issue is trying to remove.
+
+/** One directory entry, reduced to what a plan can be built from. */
+export type CacheDirEntry = {
+  name: string;
+  sizeBytes: number;
+  /** Milliseconds since the epoch, or null when the platform wouldn't say. */
+  modifiedAtMs: number | null;
+};
+
+/**
+ * What a name in `{cache}/board-thumbnails` is, from the sweeper's point of view.
+ *
+ * - `cache-entry` — a finished overlay PNG. The only class that counts toward the
+ *   size budget and the only class eviction may delete.
+ * - `managed-temp` — an in-flight (or orphaned) atomic write from the Android
+ *   module. Ours, but deletable only once it is old enough to be certainly dead.
+ * - `foreign` — everything else, including EVERY other dot-prefixed name. iOS
+ *   stages its atomic write as a hidden dot-file in this same directory and its
+ *   own pruner deliberately skips hidden files; deleting one mid-write is a
+ *   guaranteed ENOENT for a render already on the bridge.
+ */
+export type OverlayEntryKind = 'cache-entry' | 'managed-temp' | 'foreign';
+
+/** Mirrors `AtomicFileWrite.TEMP_PREFIX`. */
+const MANAGED_TEMP_PREFIX = '.bsov-';
+/** Mirrors `AtomicFileWrite.TEMP_SUFFIX`. */
+const MANAGED_TEMP_SUFFIX = '.tmp';
+/** Mirrors `CachePruner.CACHE_ENTRY_SUFFIX`. */
+const CACHE_ENTRY_SUFFIX = '.png';
+
+/**
+ * The size ceiling for the rendered board-art cache, mirroring the native
+ * modules' own cap (`BoardRendererModule.swift`'s `cacheCapBytes`, and the
+ * `maxBytes` Android passes to `CachePruner`). Deliberately the same number:
+ * the JS sweeper exists to enforce it *during* a session, not to disagree
+ * with it.
+ */
+export const OVERLAY_CACHE_TARGET_BYTES = 200 * 1024 * 1024;
+
+/**
+ * How old a managed temp file must be before a mid-session sweep will delete it.
+ *
+ * The native pruner deletes them unconditionally, which is safe there because it
+ * runs once at module start, before any render is in flight. A JS sweep can fire
+ * while a write is happening, and no single PNG encode takes an hour — so age is
+ * the cheap way to tell "orphaned by a kill" from "being written right now".
+ */
+export const MANAGED_TEMP_MIN_AGE_MS = 60 * 60 * 1000;
+
+/**
+ * How long a downloaded snapshot artifact may sit in `{cache}/board-snapshots`
+ * before it is treated as leaked.
+ *
+ * The engine deletes its artifact in a `finally`, so anything still here was
+ * orphaned by a kill mid-bootstrap — and a Kilter artifact is ~271 MB. A day is
+ * deliberately generous: a resumable/partial download (#4310) or a retryable
+ * bootstrap (#4313) must never be reaped out from under a retry that is still
+ * plausibly coming.
+ */
+export const SNAPSHOT_LEFTOVER_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * How old a snapshot artifact must be before the explicit Clear button will
+ * reap it.
+ *
+ * Not zero: the whole point of Clear is to hand back the biggest thing in the
+ * cache directory, but deleting the file a bootstrap is downloading right now
+ * breaks that download. Five minutes clears the observed Kilter download (p50
+ * ~3 minutes) with room to spare, so anything older is certainly abandoned.
+ */
+export const SNAPSHOT_CLEAR_MIN_AGE_MS = 5 * 60 * 1000;
+
+/**
+ * Overlay writes between foreground sweeps.
+ *
+ * The launch and background sweeps miss the failure mode this issue names — a
+ * long-lived foreground session, the same shape as the ~3.7-day iPad uptime in
+ * #3803. Counting writes rather than minutes makes the trigger track growth: 400
+ * writes is roughly 25 MB at the issue's ~60 KB/climb average, so a session that
+ * is browsing hard gets swept often and an idle one never pays anything.
+ */
+export const OVERLAY_WRITES_PER_SWEEP = 400;
+
+/** Classify one directory entry name. See `OverlayEntryKind`. */
+export function classifyOverlayEntry(name: string): OverlayEntryKind {
+  if (name.startsWith(MANAGED_TEMP_PREFIX) && name.endsWith(MANAGED_TEMP_SUFFIX)) return 'managed-temp';
+  // Hidden files are never ours, whatever they end in — iOS's atomic staging
+  // file can carry any suffix and its own pruner skips it.
+  if (name.startsWith('.')) return 'foreign';
+  if (name.endsWith(CACHE_ENTRY_SUFFIX)) return 'cache-entry';
+  return 'foreign';
+}
+
+/** Bytes held by finished overlay PNGs. Temps and foreign files are not our budget. */
+export function measureOverlayCacheBytes(entries: readonly CacheDirEntry[]): number {
+  let total = 0;
+  for (const entry of entries) {
+    if (classifyOverlayEntry(entry.name) === 'cache-entry') total += entry.sizeBytes;
+  }
+  return total;
+}
+
+/** A null mtime sorts oldest, so an entry the platform can't date is evicted first. */
+function modifiedAtOrEpoch(entry: CacheDirEntry): number {
+  return entry.modifiedAtMs ?? 0;
+}
+
+export type OverlayEvictionPlan = {
+  /** Finished PNGs to delete, oldest first. */
+  evictNames: string[];
+  /** Orphaned atomic-write temps old enough to be certainly dead. */
+  staleTempNames: string[];
+  beforeBytes: number;
+  afterBytes: number;
+};
+
+/**
+ * Least-recently-modified eviction down to `targetBytes`.
+ *
+ * mtime is the LRU proxy both native modules already maintain — they bump it on
+ * a cache hit — so JS does not need its own access database on disk. What JS
+ * adds is `protectedNames`: the keys a live surface read in the last couple of
+ * minutes, which no amount of mtime can tell you about a file written days ago
+ * and displayed right now.
+ */
+export function planLruEviction(params: {
+  entries: readonly CacheDirEntry[];
+  targetBytes: number;
+  protectedNames?: ReadonlySet<string>;
+  nowMs: number;
+  managedTempMinAgeMs?: number;
+}): OverlayEvictionPlan {
+  const { entries, targetBytes, nowMs } = params;
+  const protectedNames = params.protectedNames ?? new Set<string>();
+  const managedTempMinAgeMs = params.managedTempMinAgeMs ?? MANAGED_TEMP_MIN_AGE_MS;
+
+  const cacheEntries: CacheDirEntry[] = [];
+  const staleTempNames: string[] = [];
+  for (const entry of entries) {
+    const kind = classifyOverlayEntry(entry.name);
+    if (kind === 'cache-entry') {
+      cacheEntries.push(entry);
+    } else if (kind === 'managed-temp' && nowMs - modifiedAtOrEpoch(entry) >= managedTempMinAgeMs) {
+      staleTempNames.push(entry.name);
+    }
+  }
+
+  const beforeBytes = cacheEntries.reduce((sum, entry) => sum + entry.sizeBytes, 0);
+  if (beforeBytes <= targetBytes) {
+    return { evictNames: [], staleTempNames, beforeBytes, afterBytes: beforeBytes };
+  }
+
+  const oldestFirst = [...cacheEntries].sort((left, right) => modifiedAtOrEpoch(left) - modifiedAtOrEpoch(right));
+  const evictNames: string[] = [];
+  let remainingBytes = beforeBytes;
+  for (const entry of oldestFirst) {
+    if (remainingBytes <= targetBytes) break;
+    // A name a surface just read is worth more than the bytes it holds: deleting
+    // it blanks live art and costs a re-render plus a Sentry warning.
+    if (protectedNames.has(cacheKeyForOverlayName(entry.name))) continue;
+    evictNames.push(entry.name);
+    remainingBytes -= entry.sizeBytes;
+  }
+  return { evictNames, staleTempNames, beforeBytes, afterBytes: remainingBytes };
+}
+
+/** Everything the Clear button deletes: every finished PNG, plus certainly-dead temps. */
+export function planOverlayCacheClear(params: {
+  entries: readonly CacheDirEntry[];
+  nowMs: number;
+  managedTempMinAgeMs?: number;
+}): { deleteNames: string[]; freedBytes: number } {
+  const plan = planLruEviction({ ...params, targetBytes: -1 });
+  return {
+    deleteNames: [...plan.evictNames, ...plan.staleTempNames],
+    freedBytes: plan.beforeBytes - plan.afterBytes,
+  };
+}
+
+/** Leaked download artifacts: anything older than `maxAgeMs`. Undateable entries are left alone. */
+export function planStaleArtifactSweep(params: {
+  entries: readonly CacheDirEntry[];
+  nowMs: number;
+  maxAgeMs: number;
+}): { deleteNames: string[]; freedBytes: number } {
+  const deleteNames: string[] = [];
+  let freedBytes = 0;
+  for (const entry of params.entries) {
+    // Null mtime means "the platform wouldn't say"; for a 271 MB artifact that a
+    // retry may still want, guessing "old" is the wrong way to be wrong.
+    if (entry.modifiedAtMs === null) continue;
+    if (params.nowMs - entry.modifiedAtMs < params.maxAgeMs) continue;
+    deleteNames.push(entry.name);
+    freedBytes += entry.sizeBytes;
+  }
+  return { deleteNames, freedBytes };
+}
+
+/** The cache key a PNG name encodes (i.e. the name without its `.png`). */
+export function cacheKeyForOverlayName(name: string): string {
+  return name.endsWith(CACHE_ENTRY_SUFFIX) ? name.slice(0, -CACHE_ENTRY_SUFFIX.length) : name;
+}
+
+/**
+ * Whether an overlay PNG belongs to one downloaded board scope.
+ *
+ * `buildCacheKey` (use-native-climb-render.ts) lays the identity out as
+ * `v{version}_{style}_w{width}_{boardName}_{layoutId}_{sizeId}_{setIds}_{hash}`,
+ * so the scope is an underscore-delimited run inside the name. The delimiters on
+ * BOTH sides are load-bearing: without the trailing one, layout 1 also matches
+ * layout 12, and size 7 also matches size 70.
+ */
+export function overlayNameMatchesScope(
+  name: string,
+  scope: { boardType: string; layoutId: number; sizeId: number },
+): boolean {
+  if (classifyOverlayEntry(name) !== 'cache-entry') return false;
+  return name.includes(`_${scope.boardType}_${scope.layoutId}_${scope.sizeId}_`);
+}

--- a/packages/mobile/src/lib/overlay-index.ts
+++ b/packages/mobile/src/lib/overlay-index.ts
@@ -1,0 +1,174 @@
+// The synchronous index of already-rendered overlay PNGs (issue #3647).
+//
+// Extracted out of use-native-climb-render.ts so the disk sweeper can drop keys
+// it just deleted WITHOUT the sweeper importing the render hook (and with it
+// React, expo-image, and the whole board-config graph). The hook imports this;
+// the sweeper imports this; neither imports the other, so the module graph stays
+// acyclic under Metro's CJS interop, where a cycle binds `undefined` rather than
+// failing loudly.
+//
+// Behaviour is unchanged from the map that used to live in the hook, plus two
+// additions the sweeper needs: an access clock and a write odometer.
+
+export type RenderedOverlayEntry = {
+  uri: string;
+  generation: number;
+};
+
+/**
+ * Synchronous lookup of already-rendered overlay PNGs keyed by cache key.
+ * Populated when (a) any successful render completes, and (b) on first module
+ * import when the hook scans the on-disk cache directory to surface PNGs from
+ * prior app sessions.
+ *
+ * This is the mechanism that makes drawer-open instant after the list has
+ * scrolled past a climb: the hook's useState initial value reads from this map,
+ * so a cache hit displays the overlay on the very first render with no
+ * useEffect-driven update.
+ */
+const renderedOverlays = new Map<string, RenderedOverlayEntry>();
+
+/**
+ * When JS last READ each key — not when the file was written.
+ *
+ * Kept beside the index rather than inside the entry so `RenderedOverlayEntry`
+ * stays the immutable identity the hook's exact-match failure guards compare by
+ * value.
+ */
+const lastUsedAtMs = new Map<string, number>();
+
+export const RENDERED_OVERLAYS_MAX = 200;
+let nextOverlayGeneration = 1;
+
+let overlayWritesSinceSweep = 0;
+let writeThresholdListener: (() => void) | null = null;
+let writeThreshold = 0;
+
+function dropKey(cacheKey: string): boolean {
+  lastUsedAtMs.delete(cacheKey);
+  return renderedOverlays.delete(cacheKey);
+}
+
+/**
+ * The only insertion path for the synchronous overlay cache. A generation is
+ * minted even when native rewrites the same URI, which lets mounted consumers
+ * distinguish the replacement from the missing file they just failed to load.
+ */
+export function cacheRenderedOverlay(cacheKey: string, uri: string): RenderedOverlayEntry {
+  const entry = { uri, generation: nextOverlayGeneration };
+  nextOverlayGeneration += 1;
+
+  // Delete first so replacing an entry also promotes it to most-recently used.
+  renderedOverlays.delete(cacheKey);
+  if (renderedOverlays.size >= RENDERED_OVERLAYS_MAX) {
+    const oldestKey = renderedOverlays.keys().next().value;
+    if (oldestKey !== undefined) dropKey(oldestKey);
+  }
+  renderedOverlays.set(cacheKey, entry);
+  lastUsedAtMs.set(cacheKey, Date.now());
+
+  noteOverlayWrite();
+  return entry;
+}
+
+export function getRenderedOverlay(cacheKey: string): RenderedOverlayEntry | undefined {
+  const entry = renderedOverlays.get(cacheKey);
+  if (!entry) return undefined;
+  // Map iteration order is the LRU order. Reads promote without changing the
+  // immutable entry identity used by exact failure guards.
+  renderedOverlays.delete(cacheKey);
+  renderedOverlays.set(cacheKey, entry);
+  lastUsedAtMs.set(cacheKey, Date.now());
+  return entry;
+}
+
+export function invalidateRenderedOverlay(cacheKey: string, expected: RenderedOverlayEntry): boolean {
+  const current = renderedOverlays.get(cacheKey);
+  if (!current || current.uri !== expected.uri || current.generation !== expected.generation) return false;
+  return dropKey(cacheKey);
+}
+
+/**
+ * The cache keys a live surface actually READ recently.
+ *
+ * Not the tail of the map — the warm-up inserts a couple of hundred prior-session
+ * PNGs in directory-listing order, so map order after launch is an arbitrary
+ * sample of the disk, not the working set. What a sweep must not delete is what
+ * something on screen is displaying, and the only honest record of that is when
+ * JS last looked a key up. Warm-up insertions are stamped at insert time and
+ * fall out of the window within `withinMs`, which is correct: an overlay nothing
+ * has read is not on screen.
+ */
+export function getRecentlyUsedCacheKeys(withinMs: number, nowMs = Date.now()): Set<string> {
+  const recent = new Set<string>();
+  for (const [cacheKey, usedAt] of lastUsedAtMs) {
+    // A timestamp whose entry is gone (an evicted key, or a test reaching into
+    // the map directly) is bookkeeping, not a protection — drop it here so the
+    // clock can't outgrow the index it describes.
+    if (!renderedOverlays.has(cacheKey)) {
+      lastUsedAtMs.delete(cacheKey);
+      continue;
+    }
+    if (nowMs - usedAt <= withinMs) recent.add(cacheKey);
+  }
+  return recent;
+}
+
+/** Drop keys whose PNG has just been deleted, so nothing hands out a dead URI. */
+export function forgetOverlays(cacheKeys: Iterable<string>): number {
+  let forgotten = 0;
+  for (const cacheKey of cacheKeys) {
+    if (dropKey(cacheKey)) forgotten += 1;
+  }
+  return forgotten;
+}
+
+export function clearOverlayIndex(): void {
+  renderedOverlays.clear();
+  lastUsedAtMs.clear();
+}
+
+/**
+ * Fire a listener every `threshold` overlay writes.
+ *
+ * The sweep triggers that come for free — launch, and the transition to
+ * background — both miss the failure mode this issue is about: a session that
+ * stays in the foreground for days (#3803's ~3.7-day iPad) never backgrounds and
+ * never relaunches, so nothing ever enforces the cap while it grows. Counting
+ * writes tracks growth directly and costs one integer increment per render.
+ */
+export function onOverlayWriteThreshold(threshold: number, listener: () => void): () => void {
+  writeThreshold = threshold;
+  writeThresholdListener = listener;
+  overlayWritesSinceSweep = 0;
+  return () => {
+    if (writeThresholdListener === listener) {
+      writeThresholdListener = null;
+      writeThreshold = 0;
+    }
+  };
+}
+
+/** Reset the odometer — a sweep just ran, from whatever trigger. */
+export function resetOverlayWriteOdometer(): void {
+  overlayWritesSinceSweep = 0;
+}
+
+function noteOverlayWrite(): void {
+  if (writeThresholdListener === null || writeThreshold <= 0) return;
+  overlayWritesSinceSweep += 1;
+  if (overlayWritesSinceSweep < writeThreshold) return;
+  overlayWritesSinceSweep = 0;
+  writeThresholdListener();
+}
+
+/** Test-only handles. Not part of the public API. */
+export function _resetOverlayIndexForTests(): void {
+  clearOverlayIndex();
+  nextOverlayGeneration = 1;
+  overlayWritesSinceSweep = 0;
+  writeThresholdListener = null;
+  writeThreshold = 0;
+}
+
+export const _renderedOverlaysForTests = renderedOverlays;

--- a/packages/mobile/src/lib/sweep-caches.ts
+++ b/packages/mobile/src/lib/sweep-caches.ts
@@ -84,12 +84,27 @@ async function measureSnapshotLeftoverBytes(): Promise<number> {
  * works, so the action survives even when the measurement doesn't.
  */
 export async function measureCachedImageBytes(): Promise<CachedImageMeasurement | null> {
-  const [artBytes, photoBytes, leftoverSnapshotBytes] = await Promise.all([
-    measureOverlayBytes(),
-    measurePhotoBytes(),
-    measureSnapshotLeftoverBytes(),
-  ]);
-  return { artBytes, photoBytes, leftoverSnapshotBytes };
+  try {
+    const [artBytes, photoBytes, leftoverSnapshotBytes] = await Promise.all([
+      measureOverlayBytes(),
+      // A directory we can name but not read is the same answer as one we
+      // couldn't name: omit the row, keep the button.
+      measurePhotoBytes().catch(() => null),
+      measureSnapshotLeftoverBytes(),
+    ]);
+    return { artBytes, photoBytes, leftoverSnapshotBytes };
+  } catch {
+    // This runs inside Manage Storage's single `['offlineStorage']` query, beside
+    // the database total, the free-space figure, the board list and the Remove
+    // buttons. A walk that throws — `list()` on an unreadable directory, a
+    // permission failure on an Android volume — would take all of that down with
+    // it and render the error state on the one screen whose purpose is
+    // reclaiming space. Omitting the section is the same degraded-not-dishonest
+    // answer the Photos row already gives, and the same posture as
+    // `measureFreeDiskSpace` (storage-usage.ts), which returns null rather than
+    // a fabricated zero.
+    return null;
+  }
 }
 
 /**

--- a/packages/mobile/src/lib/sweep-caches.ts
+++ b/packages/mobile/src/lib/sweep-caches.ts
@@ -1,0 +1,165 @@
+// Measuring and reclaiming the on-disk caches this app owns (issue #3647).
+//
+// Three of them, and they are not equally broken:
+//
+// 1. expo-image's disk cache. On iOS `ImageCacheConfig.maxDiskSize` defaults to
+//    0 — "no cache size limit" — and nothing ever set it, so every
+//    `cachePolicy="memory-disk"` surface wrote into an unbounded cache bounded
+//    only by SDWebImage's 7-day age default. The ceiling now lives in
+//    use-image-cache-memory-management.ts; this module measures it and clears it
+//    on request. Android runs on Glide, which bounds its own disk cache.
+// 2. `{cache}/board-thumbnails/*.png`. Already capped at 200 MB by the native
+//    modules — but the cap is enforced once per cold launch, so a long-lived
+//    foreground session grows past it unchecked.
+// 3. `{cache}/board-snapshots/*.db`. The engine deletes its artifact in a
+//    `finally`, so a kill mid-bootstrap leaks the whole thing (a Kilter artifact
+//    is ~271 MB) until the OS reclaims it. Nothing swept it.
+//
+// All three live under `Paths.cache`, which the OS may reclaim on its own at any
+// moment — the copy in Manage Storage says so, because a number that drops to
+// zero without the user doing anything is the same "the app disagrees with the
+// OS" problem this issue is about.
+
+import { Image } from 'expo-image';
+import { deleteCacheDirEntries, resolveImageCacheDirName, walkCacheDir } from './cache-dir-io';
+import { invalidateCacheMeasurement, measureCacheDirBytes, recordCacheMeasurement } from './cache-size-meter';
+import {
+  measureOverlayCacheBytes,
+  planOverlayCacheClear,
+  planStaleArtifactSweep,
+  SNAPSHOT_CLEAR_MIN_AGE_MS,
+  SNAPSHOT_LEFTOVER_MAX_AGE_MS,
+  cacheKeyForOverlayName,
+} from './cache-sweep-plan';
+import { clearOverlayIndex, forgetOverlays } from './overlay-index';
+import { SNAPSHOT_DIR_NAME } from '../offline/snapshot-source';
+
+/** Must match the directory the native BoardRenderer modules write PNGs into. */
+export const OVERLAY_CACHE_DIR_NAME = 'board-thumbnails';
+
+export type CachedImageMeasurement = {
+  /** Rendered board art: `{cache}/board-thumbnails`. */
+  artBytes: number;
+  /** expo-image's disk cache, or null when its directory couldn't be located on this device. */
+  photoBytes: number | null;
+  /** Downloaded snapshot artifacts orphaned by a kill mid-bootstrap. */
+  leftoverSnapshotBytes: number;
+};
+
+async function measureOverlayBytes(): Promise<number> {
+  const bytes = await measureCacheDirBytes(OVERLAY_CACHE_DIR_NAME, async () => {
+    const walk = await walkCacheDir(OVERLAY_CACHE_DIR_NAME);
+    // Only finished PNGs count — in-flight temps and anything foreign are not
+    // space the user can reclaim by tapping our button.
+    return walk === null ? null : measureOverlayCacheBytes(walk.entries);
+  });
+  return bytes ?? 0;
+}
+
+async function measurePhotoBytes(): Promise<number | null> {
+  const dirName = resolveImageCacheDirName();
+  if (dirName === null) return null;
+  return measureCacheDirBytes(dirName, async () => {
+    // Recursive: SDWebImage keeps its files one level down in `default/`.
+    const walk = await walkCacheDir(dirName, { recursive: true });
+    return walk === null ? null : walk.totalBytes;
+  });
+}
+
+async function measureSnapshotLeftoverBytes(): Promise<number> {
+  const bytes = await measureCacheDirBytes(SNAPSHOT_DIR_NAME, async () => {
+    const walk = await walkCacheDir(SNAPSHOT_DIR_NAME);
+    return walk === null ? null : walk.totalBytes;
+  });
+  return bytes ?? 0;
+}
+
+/**
+ * What the caches occupy right now, for Manage Storage.
+ *
+ * `photoBytes` is null rather than 0 when expo-image's cache directory isn't one
+ * of the names we know: the screen omits the row entirely in that case. An
+ * honest-looking `0 B` over a cache that plainly holds photos is exactly the
+ * fake number the issue's design note warns against — the Clear button still
+ * works, so the action survives even when the measurement doesn't.
+ */
+export async function measureCachedImageBytes(): Promise<CachedImageMeasurement | null> {
+  const [artBytes, photoBytes, leftoverSnapshotBytes] = await Promise.all([
+    measureOverlayBytes(),
+    measurePhotoBytes(),
+    measureSnapshotLeftoverBytes(),
+  ]);
+  return { artBytes, photoBytes, leftoverSnapshotBytes };
+}
+
+/**
+ * Reap downloaded snapshot artifacts orphaned by a kill mid-bootstrap.
+ *
+ * Age-based rather than "anything from a previous launch" on purpose: a resumable
+ * partial download (#4310) and a retryable bootstrap (#4313) both have a claim on
+ * a recent artifact, and a leaked `.db` is currently the only durable evidence an
+ * interrupted bootstrap leaves behind.
+ */
+export async function sweepSnapshotLeftovers(options?: { maxAgeMs?: number }): Promise<number> {
+  const walk = await walkCacheDir(SNAPSHOT_DIR_NAME);
+  if (walk === null || walk.entries.length === 0) return 0;
+  const plan = planStaleArtifactSweep({
+    entries: walk.entries,
+    nowMs: Date.now(),
+    maxAgeMs: options?.maxAgeMs ?? SNAPSHOT_LEFTOVER_MAX_AGE_MS,
+  });
+  if (plan.deleteNames.length === 0) {
+    recordCacheMeasurement(SNAPSHOT_DIR_NAME, walk.totalBytes);
+    return 0;
+  }
+  deleteCacheDirEntries(SNAPSHOT_DIR_NAME, plan.deleteNames);
+  invalidateCacheMeasurement(SNAPSHOT_DIR_NAME);
+  return plan.freedBytes;
+}
+
+export type ClearCachedImagesResult = {
+  freedBytes: number;
+  filesDeleted: number;
+  /** False when expo-image declined to clear its disk cache — see below. */
+  photoCacheCleared: boolean;
+};
+
+/**
+ * The Clear button: drop every rendered overlay PNG, every certainly-dead temp,
+ * every leaked snapshot artifact, and expo-image's disk cache.
+ *
+ * Never deletes the directories themselves and never touches a foreign or
+ * in-flight file — the native modules are writing into the same directory, and a
+ * file that vanishes mid-write surfaces as a rejected `renderHoldsOverlay`, i.e.
+ * the very Sentry storm this issue also exists to stop.
+ */
+export async function clearCachedImages(): Promise<ClearCachedImagesResult> {
+  let freedBytes = 0;
+  let filesDeleted = 0;
+
+  const walk = await walkCacheDir(OVERLAY_CACHE_DIR_NAME);
+  if (walk !== null) {
+    const plan = planOverlayCacheClear({ entries: walk.entries, nowMs: Date.now() });
+    filesDeleted += deleteCacheDirEntries(OVERLAY_CACHE_DIR_NAME, plan.deleteNames);
+    freedBytes += plan.freedBytes;
+    forgetOverlays(plan.deleteNames.map(cacheKeyForOverlayName));
+  }
+  // Belt and braces: anything the walk missed (a race with a render that landed
+  // between list and delete) must not stay in the index handing out dead URIs.
+  clearOverlayIndex();
+
+  freedBytes += await sweepSnapshotLeftovers({ maxAgeMs: SNAPSHOT_CLEAR_MIN_AGE_MS });
+
+  // Android's `clearDiskCache` resolves FALSE — a no-op — when the module has no
+  // current activity, which is why this is only ever wired to a button press and
+  // never to a background trigger. A false must not read as success.
+  let photoCacheCleared = false;
+  try {
+    photoCacheCleared = await Image.clearDiskCache();
+  } catch {
+    photoCacheCleared = false;
+  }
+
+  invalidateCacheMeasurement();
+  return { freedBytes, filesDeleted, photoCacheCleared };
+}

--- a/packages/mobile/src/lib/sweep-caches.web.ts
+++ b/packages/mobile/src/lib/sweep-caches.web.ts
@@ -1,0 +1,26 @@
+// Browser twin of sweep-caches.ts.
+//
+// None of the three caches exist here. Rendered overlays live in the Cache API,
+// already bounded by entry count (modules/board-renderer/src/overlay-cache-store.web.ts);
+// photos are the browser's own HTTP cache, which we neither measure nor evict;
+// and the snapshot bootstrap never writes a file. `measureCachedImageBytes`
+// returns null so Manage Storage omits the whole Cached-images section rather
+// than rendering a live Clear button over a fabricated `0 B`.
+
+import type { CachedImageMeasurement, ClearCachedImagesResult } from './sweep-caches';
+
+export type { CachedImageMeasurement, ClearCachedImagesResult } from './sweep-caches';
+
+export const OVERLAY_CACHE_DIR_NAME = 'board-thumbnails';
+
+export async function measureCachedImageBytes(): Promise<CachedImageMeasurement | null> {
+  return null;
+}
+
+export async function sweepSnapshotLeftovers(): Promise<number> {
+  return 0;
+}
+
+export async function clearCachedImages(): Promise<ClearCachedImagesResult> {
+  return { freedBytes: 0, filesDeleted: 0, photoCacheCleared: false };
+}

--- a/packages/mobile/src/offline/snapshot-source.ts
+++ b/packages/mobile/src/offline/snapshot-source.ts
@@ -38,7 +38,10 @@ const MANIFEST_URL = `${SNAPSHOT_BASE_URL}/manifest.json`;
 // it (in a `finally`) — nothing here is meant to persist across app launches,
 // so the OS is also free to reclaim it under storage pressure (Paths.cache,
 // not Paths.document).
-const SNAPSHOT_DIR_NAME = 'board-snapshots';
+// Exported so the cache sweeper (lib/sweep-caches.ts) reaps artifacts leaked by
+// a kill mid-bootstrap from the same directory this writes to, rather than
+// re-literalling the name and silently sweeping nothing if it ever moves.
+export const SNAPSHOT_DIR_NAME = 'board-snapshots';
 
 // Identity artifacts are already stored as SQLite files, so they only need room
 // for the download plus write overhead. Gzip artifacts may temporarily require

--- a/packages/mobile/test/expo-file-system-stub.ts
+++ b/packages/mobile/test/expo-file-system-stub.ts
@@ -6,44 +6,144 @@
 // throw `SyntaxError: Unexpected token 'typeof'` in Vitest's module worker
 // before the TypeScript plugin can strip the type annotations.
 //
-// No test in this repo exercises the real file-system; this stub only needs to
-// satisfy static imports so Vitest's module graph resolves cleanly.
-// Suites that assert file-system behaviour can register their own `vi.mock`
-// which takes precedence over this alias.
+// Most suites only need this to satisfy static imports so Vitest's module graph
+// resolves cleanly, so THE UNSEEDED DEFAULTS ARE UNCHANGED: every directory
+// reports `exists === false` and `list()` returns []. Suites that assert
+// file-system behaviour either register their own `vi.mock` (which takes
+// precedence over this alias) or opt in with `__seedFileSystem` below and reset
+// in `afterEach`.
 //
 // Wired via the `expo-file-system` alias in packages/mobile/vite.config.ts.
 
+/** One seeded file: size in bytes, last-modified in ms since the epoch. */
+export type SeededFile = { size?: number; lastModified?: number | null };
+
+/** Seeded tree: directory path -> file name -> file. Directories are the keys. */
+export type SeededFileSystem = Record<string, Record<string, SeededFile>>;
+
+const seed: { tree: SeededFileSystem; availableDiskSpace: number | null } = {
+  tree: {},
+  availableDiskSpace: null,
+};
+
+/**
+ * Opt in to a seeded filesystem for one suite. Always pair with
+ * `__resetFileSystem()` — an unreset seed leaks into every other suite sharing
+ * the worker, which is exactly why the unseeded defaults stay empty.
+ */
+export function __seedFileSystem(tree: SeededFileSystem, options?: { availableDiskSpace?: number | null }): void {
+  seed.tree = tree;
+  if (options && 'availableDiskSpace' in options) seed.availableDiskSpace = options.availableDiskSpace ?? null;
+}
+
+export function __resetFileSystem(): void {
+  seed.tree = {};
+  seed.availableDiskSpace = null;
+}
+
+function joinPath(parts: unknown[]): string {
+  return parts
+    .map((part) => (typeof part === 'string' ? part : ((part as { path?: string })?.path ?? '')))
+    .filter((part) => part.length > 0)
+    .join('/');
+}
+
+function parentPathOf(path: string): string {
+  return path.split('/').slice(0, -1).join('/');
+}
+
+function nameOf(path: string): string {
+  return path.split('/').pop() ?? '';
+}
+
 export class Directory {
-  constructor(..._args: unknown[]) {}
+  readonly path: string;
+
+  constructor(...args: unknown[]) {
+    this.path = joinPath(args);
+  }
+
+  get name(): string {
+    return nameOf(this.path);
+  }
+
   get exists(): boolean {
-    return false;
+    return Object.prototype.hasOwnProperty.call(seed.tree, this.path);
   }
-  list(): unknown[] {
-    return [];
+
+  list(): (Directory | File)[] {
+    const entries = seed.tree[this.path];
+    if (!entries) return [];
+    const children: (Directory | File)[] = Object.keys(entries).map((name) => new File(this, name));
+    // Seeded directories one level below this one surface as Directory instances,
+    // mirroring the real `(Directory | File)[]` return type.
+    for (const path of Object.keys(seed.tree)) {
+      if (path === this.path) continue;
+      if (!path.startsWith(`${this.path}/`)) continue;
+      if (path.slice(this.path.length + 1).includes('/')) continue;
+      children.push(new Directory(path));
+    }
+    return children;
   }
-  delete(): void {}
+
+  delete(): void {
+    delete seed.tree[this.path];
+  }
 }
 
 export class File {
-  constructor(..._args: unknown[]) {}
+  readonly path: string;
+
+  constructor(...args: unknown[]) {
+    this.path = joinPath(args);
+  }
+
+  private get record(): SeededFile | undefined {
+    return seed.tree[parentPathOf(this.path)]?.[this.name];
+  }
+
+  get name(): string {
+    return nameOf(this.path);
+  }
+
   get exists(): boolean {
-    return false;
+    return this.record !== undefined;
   }
+
   get uri(): string {
-    return '';
+    return this.path;
   }
-  delete(): void {}
+
+  get size(): number {
+    return this.record?.size ?? 0;
+  }
+
+  get lastModified(): number | null {
+    return this.record?.lastModified ?? null;
+  }
+
+  get modificationTime(): number | null {
+    return this.lastModified;
+  }
+
+  delete(): void {
+    const entries = seed.tree[parentPathOf(this.path)];
+    if (entries) delete entries[this.name];
+  }
 }
 
 export const Paths = {
   get cache(): Directory {
-    return new Directory();
+    return new Directory('cache');
   },
   get document(): Directory {
-    return new Directory();
+    return new Directory('document');
   },
   get bundle(): Directory {
-    return new Directory();
+    return new Directory('bundle');
+  },
+  get availableDiskSpace(): number | null {
+    return seed.availableDiskSpace;
   },
 };
 

--- a/packages/shared/i18n/locales/de/common.json
+++ b/packages/shared/i18n/locales/de/common.json
@@ -119,7 +119,18 @@
         "emptySubtitle": "Mach ein Board offline verfügbar, dann taucht es hier auf.",
         "errorTitle": "Deine Downloads ließen sich nicht messen",
         "errorSubtitle": "Beim Lesen dessen, was auf diesem Handy liegt, kam etwas dazwischen.",
-        "errorRetry": "Nochmal versuchen"
+        "errorRetry": "Nochmal versuchen",
+        "cachedImagesHeader": "Bilder im Cache",
+        "cachedImagesArtLabel": "Board-Grafik",
+        "cachedImagesPhotosLabel": "Fotos",
+        "cachedImagesNote": "Die Board-Grafik wird beim Stöbern neu gezeichnet und die Fotos kommen zurück, sobald du online bist — Leeren kostet dich also einen Moment, nicht deine Daten. Dein Handy kann den Cache auch von selbst leeren, wenn der Platz knapp wird.",
+        "clearCachedImages": "Bilder im Cache leeren",
+        "clearCachedImagesTitle": "Bilder im Cache leeren?",
+        "clearCachedImagesMessage": "Gibt etwa {{size}} frei. Die Board-Grafik wird beim Stöbern neu gezeichnet und die Fotos kommen zurück, sobald du online bist — deine Begehungen, Playlists und heruntergeladenen Boards bleiben.",
+        "clearCachedImagesConfirm": "Leeren",
+        "clearCachedImagesDone": "Bilder im Cache geleert.",
+        "clearCachedImagesPartial": "Die Board-Grafik ist weg, die Fotos sind geblieben. Öffne die App und versuch es nochmal.",
+        "clearCachedImagesError": "Die Bilder im Cache ließen sich nicht leeren. Versuch es nochmal."
       },
       "appearance": {
         "title": "Darstellung",

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -119,7 +119,18 @@
         "emptySubtitle": "Make a board available offline and it'll show up here.",
         "errorTitle": "Couldn't measure your downloads",
         "errorSubtitle": "Something got in the way of reading what's on this phone.",
-        "errorRetry": "Try again"
+        "errorRetry": "Try again",
+        "cachedImagesHeader": "Cached images",
+        "cachedImagesArtLabel": "Board art",
+        "cachedImagesPhotosLabel": "Photos",
+        "cachedImagesNote": "Board art redraws as you browse and photos come back when you're online, so clearing this costs you a moment, not your data. Your phone can also clear it on its own when space runs low.",
+        "clearCachedImages": "Clear cached images",
+        "clearCachedImagesTitle": "Clear cached images?",
+        "clearCachedImagesMessage": "Frees about {{size}}. Board art redraws as you browse and photos come back when you're online — your sends, playlists and downloaded boards stay put.",
+        "clearCachedImagesConfirm": "Clear",
+        "clearCachedImagesDone": "Cleared the cached images.",
+        "clearCachedImagesPartial": "Cleared the board art, but the photos stayed put. Open the app and try again.",
+        "clearCachedImagesError": "Couldn't clear the cached images. Try again."
       },
       "appearance": {
         "title": "Appearance",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -336,7 +336,18 @@
         "emptySubtitle": "Haz que un plafón esté disponible sin conexión y aparecerá aquí.",
         "errorTitle": "No se pudo medir tus descargas",
         "errorSubtitle": "Algo impidió leer lo que hay en este teléfono.",
-        "errorRetry": "Inténtalo de nuevo"
+        "errorRetry": "Inténtalo de nuevo",
+        "cachedImagesHeader": "Imágenes en caché",
+        "cachedImagesArtLabel": "Dibujo del plafón",
+        "cachedImagesPhotosLabel": "Fotos",
+        "cachedImagesNote": "El dibujo del plafón se vuelve a generar mientras navegas y las fotos vuelven cuando tengas conexión, así que borrar esto te cuesta un momento, no tus datos. Tu teléfono también puede borrarlo por su cuenta cuando falte espacio.",
+        "clearCachedImages": "Borrar imágenes en caché",
+        "clearCachedImagesTitle": "¿Borrar las imágenes en caché?",
+        "clearCachedImagesMessage": "Libera unos {{size}}. El dibujo del plafón se vuelve a generar mientras navegas y las fotos vuelven cuando tengas conexión: tus ascensos, listas y plafones descargados se quedan como están.",
+        "clearCachedImagesConfirm": "Borrar",
+        "clearCachedImagesDone": "Imágenes en caché borradas.",
+        "clearCachedImagesPartial": "Se borró el dibujo del plafón, pero las fotos siguen ahí. Abre la app e inténtalo de nuevo.",
+        "clearCachedImagesError": "No se pudieron borrar las imágenes en caché. Inténtalo de nuevo."
       },
       "appearance": {
         "title": "Apariencia",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -119,7 +119,18 @@
         "emptySubtitle": "Rends une board disponible hors ligne et elle apparaîtra ici.",
         "errorTitle": "Impossible de mesurer tes téléchargements",
         "errorSubtitle": "Quelque chose a empêché de lire ce qui se trouve sur ce téléphone.",
-        "errorRetry": "Réessayer"
+        "errorRetry": "Réessayer",
+        "cachedImagesHeader": "Images en cache",
+        "cachedImagesArtLabel": "Dessin de la board",
+        "cachedImagesPhotosLabel": "Photos",
+        "cachedImagesNote": "Le dessin de la board se refait au fil de ta navigation et les photos reviennent dès que tu es en ligne : vider ça te coûte un instant, pas tes données. Ton téléphone peut aussi le vider tout seul quand la place manque.",
+        "clearCachedImages": "Vider les images en cache",
+        "clearCachedImagesTitle": "Vider les images en cache ?",
+        "clearCachedImagesMessage": "Libère environ {{size}}. Le dessin de la board se refait au fil de ta navigation et les photos reviennent dès que tu es en ligne : tes croix, tes playlists et tes boards téléchargées restent en place.",
+        "clearCachedImagesConfirm": "Vider",
+        "clearCachedImagesDone": "Images en cache vidées.",
+        "clearCachedImagesPartial": "Le dessin de la board a été vidé, mais les photos sont restées. Ouvre l'app et réessaie.",
+        "clearCachedImagesError": "Impossible de vider les images en cache. Réessaie."
       },
       "appearance": {
         "title": "Apparence",


### PR DESCRIPTION
Split out of #3647, which named three caches that nothing ever sweeps. Re-verifying them at `origin/main` inverted the priority the issue assumed, so this PR fixes the one that is genuinely unbounded and makes all three visible; the LRU sweeper for board art follows in a stacked PR.

**What the code actually says:**

- **expo-image's iOS disk cache is the unbounded one.** `ImageCacheConfig.maxDiskSize` — *"Defaults to 0, which means there is no cache size limit"* (`expo-image/src/Image.types.ts`) — was never set. `use-image-cache-memory-management.ts` passed only `maxMemoryCost`, and `Image.clearDiskCache()` had zero call sites repo-wide. Every `cachePolicy="memory-disk"` surface (LayeredClimbImage, PlaylistBoardBackdrop, feed and beta cards) wrote into it forever, bounded only by SDWebImage's 7-day age default. Android runs on Glide, which bounds its own disk cache.
- **`{cache}/board-thumbnails` was already capped at 200 MB** by the native renderer (`BoardRendererModule.swift`'s `cacheCapBytes`, `CachePruner.kt`) — but the cap is enforced once per cold launch, so a long-lived foreground session outgrows it. That is the next PR.
- **`{cache}/board-snapshots/*.db` leftovers.** The engine deletes its artifact in a `finally`, so a kill mid-bootstrap leaks the whole thing (a Kilter artifact is ~271 MB) until the OS reclaims it. Nothing swept that directory.
- **Manage Storage under-reported all three.** `storage-usage.ts` stats only `Documents/SQLite/boardsesh.db{,-wal,-shm}`, so the one screen whose purpose is reclaiming space disagreed with the OS storage screen by up to hundreds of megabytes — and offered no way to act on the difference.

The issue's design note set the bar: *"Either measure the dir directly, or present it as a plain 'Clear cached images' action with no number rather than an honest-looking-but-fake one."* Both halves are honoured — the directory is measured where it can be found, and the Photos row is **omitted entirely** (never `0 B`) when it can't, with the Clear button still working.

## Changes

- `lib/cache-sweep-plan.ts` — pure, zero imports. `classifyOverlayEntry` mirrors the native contract exactly: `*.png` only for size accounting and eviction (`CachePruner.kt`), `.bsov-*.tmp` only for temp sweeping (`AtomicFileWrite.kt`), and **every other dot-prefixed name is foreign and never deleted** — which is what protects the hidden staging file iOS's own `write(to:options:.atomic)` creates in the same directory and its pruner skips via `.skipsHiddenFiles`. Two pruners disagreeing about what's safe to delete is how you manufacture a file-vanished-mid-write storm. Plus `planLruEviction`, `planOverlayCacheClear`, `planStaleArtifactSweep`, `overlayNameMatchesScope`, and the constants.
- `lib/cache-dir-io.ts` (+ `.web.ts`) — the only `expo-file-system` importer. Chunked walk that yields a macrotask every 100 files, gates on `Directory.exists` (`list()` throws when absent), skips `Directory` entries, and returns per-entry size/mtime **and** the total from one pass. **`Directory.size` is deliberately never called**: it reads like a cheap stat but is a synchronous full recursive walk on both platforms (`FileSystemDirectory.swift`, `FileSystemDirectory.kt`), so it cannot yield and would block JS on every measurement.
- `lib/cache-size-meter.ts` — 60-second memo per directory with explicit invalidation, so the Manage Storage focus refetch walks at most once a minute rather than on every focus.
- `lib/overlay-index.ts` — extracts the `renderedOverlays` map out of `use-native-climb-render.ts` so the sweeper can forget keys whose PNG it deleted without importing the render hook (that cycle binds `undefined` under Metro's CJS interop). Adds the access clock and the write odometer the stacked PR uses. The `_*ForTests` handles are re-exported, so existing suites are untouched.
- `lib/sweep-caches.ts` (+ `.web.ts`) — `measureCachedImageBytes`, `sweepSnapshotLeftovers`, `clearCachedImages`.
- `use-image-cache-memory-management.ts` — `maxDiskSize: 150 MB` alongside the existing memory ceiling, iOS-only, with the caveats recorded in the comment (`ImageCacheConfig` is `@platform ios`; SDWebImage enforces on background/terminate, so the bound is real but lagging).
- Manage Storage — a measured "Cached images" section with a Board art row, a Photos row rendered only when the directory resolved, and a destructive-confirm Clear. `isStorageScreenEmpty` now counts cached images above a 5 MB floor, so the empty state can't hide the only button that reclaims that space.
- `test/expo-file-system-stub.ts` — extended **additively**: unseeded defaults are byte-for-byte the old behaviour (`exists === false`, `list() === []`), with an opt-in `__seedFileSystem`.

Two things worth flagging for review:

- **The image-cache directory allowlist** (`com.hackemist.SDImageCache`, `image_manager_disk_cache`) is the one thing unit tests can't prove. Wrong on a device means the Photos row is absent — degraded, not dishonest — and the fix is a one-line JS change that rides an OTA. QA step 1 verifies it with `Image.getCachePathAsync`.
- **`Paths.cache` is reclaimable by the OS at any moment**, so this number can drop to zero on its own. The copy says so, otherwise it becomes a second flavour of the number-disagrees-with-the-OS problem this issue is about.

No native-fingerprint inputs touched: no new dependencies (`expo-file-system` and `expo-image` are already direct mobile deps), no plugin, no `app.config.ts`, nothing under `modules/`, `ios/`, `android/`, or `patches/`. The obvious fix — moving the native once-per-launch prune gate to a periodic check — is a native change that could never reach store binaries over OTA, which is why the same 200 MB mtime-LRU is enforced from JS against the same directory using the same file-classification rules.

## Release Notes

Manage Storage now shows what the board art and photos on your phone actually take up, with a Clear cached images button for when you need the space back. Boardsesh also stops letting downloaded photos pile up without a ceiling, and cleans up board downloads that got interrupted halfway.

## Test plan

All foreground, all via `vp`:

- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — **625 files, 5530 tests, all passing** (the overlay-index extraction touches the hottest hook in the app, so the whole suite is the gate, not just the new files).
- New suites: `cache-sweep-plan.test.ts`, `cache-dir-io.test.ts`, `overlay-index.test.ts`, `sweep-caches.test.ts` — 53 tests. Covers the foreign-file regression on every deletion path, oldest-first eviction with a protected key, the managed-temp age gate, the underscore-delimiter scope match (layout 1 vs 12, size 7 vs 70), the missing-directory-is-null contract, the chunked yield, and `clearDiskCache()` resolving **false** (Android with no current activity) reporting partial rather than success.
- `@boardsesh/i18n` `catalog-completeness.test.ts` — 90 tests, four locales at parity.
- `vp run check:mobile-bundle` — Android bundle OK.
- `vp check` — clean for every file this PR touches.

Manual QA notes are in `.boardsesh/qa-notes.md` (untracked): the device check that matters is confirming the expo-image cache directory on both platforms via `Image.getCachePathAsync` → `parentDirectory`, and triggering a Clear mid-scroll on Android to confirm no `FileNotFoundException` storm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT6VP1sWqk6bY9mUgyeS2U
