### PR TITLE
feat(backend): publish the uncompressed artifact size in the snapshot manifest

### DIFF
--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -167,6 +167,25 @@ layout artifact but intentionally outside the enabled size.
   **permanent miss for that run, no bootstrap attempt burned** — the scope falls back to the always-correct
   paged crawl, and the next nightly export rebuilds the artifact at the new schema.
 
+### The two artifact sizes in a manifest entry
+
+A manifest entry carries the artifact's size twice, and the two diverge once `--gzip` ships:
+
+| Field               | What it is                                    | Who reads it                                                                                                                                                              |
+| ------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bytes`             | Stored object size — what comes down the wire | **Every user-facing number.** The My Boards confirm-dialog size quote (`estimateScopeDownload`) and the download progress row both use it, so the two can never disagree. |
+| `uncompressedBytes` | Decoded size — the SQLite file that hits disk | Internals only: the progress denominator on downloaders that write decoded bytes with no usable reported total, and the exact free-disk-space precheck. Never rendered.   |
+
+Under `--gzip` the decoded size runs several times `bytes` (Kilter layout 1: ~103 MB stored, ~271 MB
+decoded). Showing the decoded figure in the progress row would contradict the number the user just accepted
+in the confirm dialog, so it never reaches the UI.
+
+`uncompressedBytes` is **optional and additive** — no `format_version` bump, since an old client simply
+ignores the key. Every entry published before the field existed omits it, and the merge path carries those
+entries through untouched, so a reader must handle `undefined`. It only starts appearing on the first
+export run after the field ships: the nightly runs at 07:15 UTC, or dispatch
+`.github/workflows/export-board-snapshots.yml` manually to fill it in sooner.
+
 ## Client bootstrap flow
 
 Implemented in `snapshot-bootstrap.ts` (the ATTACH/import/verify mechanics) and orchestrated from

--- a/packages/backend/src/__tests__/snapshot-export-run.test.ts
+++ b/packages/backend/src/__tests__/snapshot-export-run.test.ts
@@ -381,6 +381,46 @@ describe('runExport — gzip + key-prefix (dual-publish transition)', () => {
     expect((body as Buffer)[1]).toBe(0x8b);
   });
 
+  it('--gzip publishes the pre-compression size in uncompressedBytes, distinct from the stored bytes', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+
+    await runExport(['--gzip', '--key-prefix', GZIP_PREFIX]);
+
+    const manifestCalls = vi.mocked(uploadToS3).mock.calls.filter(([, key]) => key === GZIP_MANIFEST_KEY);
+    const manifest = JSON.parse((manifestCalls[0][0] as Buffer).toString('utf8')) as SnapshotManifest;
+    const entry = manifest.entries[0];
+    const [gzippedBody] = artifactUploadCalls()[0];
+
+    // `bytes` is what S3 stores (and what the client downloads); uncompressedBytes
+    // is the SQLite file that lands on disk after gunzip — strictly larger here.
+    expect(entry.bytes).toBe((gzippedBody as Buffer).length);
+    expect(entry.uncompressedBytes).toBeGreaterThan(entry.bytes);
+  });
+
+  it('an identity run reports uncompressedBytes equal to bytes', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+
+    await runExport([]);
+
+    const entry = uploadedManifest().entries[0];
+    expect(entry.uncompressedBytes).toBe(entry.bytes);
+  });
+
+  it('a merged previous entry that predates uncompressedBytes rides through without it', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+    // The fixture deliberately omits uncompressedBytes — every entry published
+    // before this field existed looks like this, and the merge must not invent one.
+    const legacyEntry = manifestEntryFixture('tension', 9, 'board-snapshots/v1/tension/9/old.db');
+    expect(legacyEntry.uncompressedBytes).toBeUndefined();
+    serveExistingManifest(manifestFixture([legacyEntry]));
+
+    await runExport(['--board', 'kilter']);
+
+    const merged = uploadedManifest().entries.find((entry) => entry.boardType === 'tension')!;
+    expect(merged).toEqual(legacyEntry);
+    expect(merged.uncompressedBytes).toBeUndefined();
+  });
+
   it('rejects an unsafe --key-prefix before any upload', async () => {
     await seedClimb('kilter', 1, 'k1-a');
     await expect(runExport(['--key-prefix', '../evil'])).rejects.toThrow(/--key-prefix expects a safe key/);

--- a/packages/backend/src/scripts/export-board-snapshots.ts
+++ b/packages/backend/src/scripts/export-board-snapshots.ts
@@ -454,7 +454,17 @@ function parseLayoutFilter(raw: string | undefined): number {
 
 function buildManifestEntry(
   result: LayoutSnapshotResult,
-  upload: { url: string; key: string; bytes: number; contentEncoding: 'gzip' | 'identity' },
+  upload: {
+    url: string;
+    key: string;
+    bytes: number;
+    // Pre-compression size of the artifact: equal to `bytes` on an identity
+    // upload, several times larger under --gzip. Clients use it as the progress
+    // denominator on downloaders that write decoded bytes with no usable total,
+    // and for the exact free-disk-space precheck. Never shown to a user.
+    uncompressedBytes: number;
+    contentEncoding: 'gzip' | 'identity';
+  },
 ): SnapshotManifestEntry {
   return {
     boardType: result.boardType,
@@ -462,6 +472,7 @@ function buildManifestEntry(
     key: upload.key,
     url: upload.url,
     bytes: upload.bytes,
+    uncompressedBytes: upload.uncompressedBytes,
     contentEncoding: upload.contentEncoding,
     builtAt: result.builtAt,
     schemaVersion: result.schemaVersion,
@@ -707,6 +718,7 @@ export async function runExport(argv: string[]): Promise<void> {
               url: isS3Configured() || snapshotPublicBaseUrl() ? publicUrlForKey(key) : `dry-run:${key}`,
               key,
               bytes: uploadBody.length,
+              uncompressedBytes: rawBuffer.length,
               contentEncoding,
             }),
           );
@@ -732,6 +744,7 @@ export async function runExport(argv: string[]): Promise<void> {
               url: publicUrlForKey(uploaded.key),
               key: uploaded.key,
               bytes: uploadBody.length,
+              uncompressedBytes: rawBuffer.length,
               contentEncoding,
             }),
           );

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-manifest.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-manifest.test.ts
@@ -14,6 +14,7 @@ function validEntry(): SnapshotManifestEntry {
     key: 'board-snapshots/v1/kilter/8/2026-06-01T00-00-00-000Z.db',
     url: 'https://cdn.example/board-snapshots/v1/kilter/8/2026-06-01T00-00-00-000Z.db',
     bytes: 123456,
+    uncompressedBytes: 456789,
     contentEncoding: 'gzip',
     builtAt: '2026-06-01T00:00:00.000Z',
     schemaVersion: 3,
@@ -85,6 +86,25 @@ describe('parseSnapshotManifest', () => {
       },
     });
     expect(parseSnapshotManifest(fractionalRowCount)).toBeNull();
+  });
+
+  it('accepts an entry with no uncompressedBytes (every entry built before the field existed)', () => {
+    const entry = validEntry();
+    delete entry.uncompressedBytes;
+    const parsed = parseSnapshotManifest({
+      formatVersion: 1,
+      generatedAt: '2026-06-01T00:05:00.000Z',
+      entries: [entry],
+    });
+    expect(parsed?.entries[0].uncompressedBytes).toBeUndefined();
+  });
+
+  it('accepts a non-negative integer uncompressedBytes and rejects fractional / negative ones', () => {
+    expect(parseSnapshotManifest(withEntry({ uncompressedBytes: 271_000_000 }))).not.toBeNull();
+    expect(parseSnapshotManifest(withEntry({ uncompressedBytes: 0 }))).not.toBeNull();
+    expect(parseSnapshotManifest(withEntry({ uncompressedBytes: 1.5 }))).toBeNull();
+    expect(parseSnapshotManifest(withEntry({ uncompressedBytes: -1 }))).toBeNull();
+    expect(parseSnapshotManifest(withEntry({ uncompressedBytes: '271000000' as unknown as number }))).toBeNull();
   });
 
   it('rejects a numeric watermarkSyncSeq — the protocol carries seqs as decimal strings', () => {

--- a/packages/shared/offline-sync/src/sync/snapshot-manifest.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-manifest.ts
@@ -33,8 +33,18 @@ export type SnapshotManifestEntry = {
   key: string;
   // Public URL of the artifact.
   url: string;
-  // Stored object size in bytes.
+  // Stored object size in bytes — what comes down the wire, and the ONLY size
+  // ever shown to a user (the pre-download estimate and the download progress
+  // row both quote it, so the two can never disagree).
   bytes: number;
+  // The DECODED artifact size in bytes: the size of the SQLite file that lands
+  // on disk, which for a gzip-encoded entry is several times `bytes`. Absent on
+  // entries built before this field existed, so every reader must treat it as
+  // optional. Used internally only — as the progress denominator on platforms
+  // whose downloader reports decoded byte counts with no usable total (Android
+  // gunzips transparently and then reports Content-Length -1), and for the exact
+  // free-disk-space precheck. Never rendered.
+  uncompressedBytes?: number;
   // The S3 object's Content-Encoding — how the bytes are stored at rest, NOT
   // necessarily what a client receives: an HTTP stack that honours
   // Content-Encoding (browser/RN fetch) hands back decompressed bytes, while a
@@ -107,6 +117,14 @@ function isManifestEntry(value: unknown): value is SnapshotManifestEntry {
     !isIsoUtcTimestamp(value.builtAt) ||
     !isInteger(value.schemaVersion)
   ) {
+    return false;
+  }
+  // Optional and additive, so no formatVersion bump: an old client ignores the
+  // key, a new client reading an old manifest gets `undefined` and falls back.
+  // Present-but-corrupt is still a rejection — a fractional or negative decoded
+  // size would drive a nonsense progress denominator and a nonsense disk-space
+  // precheck.
+  if (value.uncompressedBytes !== undefined && (!isInteger(value.uncompressedBytes) || value.uncompressedBytes < 0)) {
     return false;
   }
   const tables = value.tables;


### PR DESCRIPTION
First of three stacked PRs for the offline download-progress + funnel work (#4311, #4316). This one is pure backend/schema plumbing with no client behaviour change.

## Why

The manifest carries the artifact's size exactly once, as `bytes` — the **stored** object size. Under `--gzip` (which the whole fleet reads today, `board-snapshots/v1-gzip`) that is ~103 MB for `kilter:1`, while the SQLite file that actually lands on disk is ~271 MB.

Any client that wants a progress denominator for a byte counter, or an honest free-disk-space precheck, currently has no way to know the decoded size. The export job already computes it — `rawBuffer.length`, logged as `rawBytes` and then thrown away.

## Changes

- Optional `uncompressedBytes` on `SnapshotManifestEntry`, populated from the pre-gzip buffer length at both export call sites (dry-run and upload).
- **No `formatVersion` bump.** The field is additive and optional: an old client ignores the key, a new client reading a pre-change manifest gets `undefined` and falls back. Present-but-corrupt (fractional, negative, non-numeric) still rejects the whole manifest, because a nonsense decoded size would drive a nonsense progress bar and a nonsense disk-space check.
- The merge path carries entries that lack the field through untouched, so a filtered run can't invent one for a board it didn't rebuild.
- `docs/board-snapshots.md` gains a short section on the two sizes and who reads which.

## The scale rule this establishes

`bytes` stays the **only** size a user ever sees. The enable-confirm dialog's quote (`estimateScopeDownload`) and — in PR2 — the download progress row both read it, so the two can never disagree. `uncompressedBytes` is internals-only: a progress denominator on platforms whose downloader counts decoded bytes, and the disk-space precheck. It never reaches the UI.

## Rollout note

The field only appears on entries built by an export run **after** this merges. The nightly runs at 07:15 UTC; dispatching `.github/workflows/export-board-snapshots.yml` manually fills it in sooner. Until then PR2's Android percentage degrades gracefully to an indeterminate byte counter (iOS is unaffected — it uses the platform's own reported total).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project backend --reporter=agent packages/backend/src/__tests__/snapshot-export-run.test.ts` — 27 passed. New cases: `--gzip` publishes `uncompressedBytes > bytes` and `bytes` equals the gzipped upload length; an identity run reports them equal; a merged previous-manifest entry that predates the field rides through with `uncompressedBytes` still `undefined`.
- `vp test run --project offline-sync --reporter=agent` — 341 passed. New cases in `snapshot-manifest.test.ts`: an entry with no `uncompressedBytes` parses; a non-negative integer parses; fractional / negative / string values reject the manifest.
- `vp run typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT6VP1sWqk6bY9mUgyeS2U

