### PR TITLE
feat(sync): instrument the board-download funnel

### DIFF
--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -534,6 +534,53 @@ pre-import empty result set.
     still burns an attempt (see the matrix above). The real exception is attached as the wrapper's `cause`,
     which is what lets the shared classifier recognise them at all (issue #4238).
 
+## Download funnel events
+
+Five PostHog events (`@boardsesh/analytics`'s `SHARED_EVENTS`) make board downloads measurable
+end-to-end (issue #4316). Before them the feature had exactly one — `Offline Board Download
+Completed` — so abandonment was structurally unmeasurable and failures went only to Sentry.
+
+| Event                              | When                                                   | Key props                                                                          |
+| ---------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| `Offline Board Download Started`   | first time any cycle starts pulling a scope, once ever | `scopeKey`, `pathIntent`, `artifactBytes`, `trigger`, `offlineEngineEnabled`        |
+| `Offline Board Download Completed`  | both board tables reached the tail, once ever          | `scopeKey`, `method`, `durationMs`, `bytes?`, `rowCount?`, `downloadMs?`, `importMs?` |
+| `Offline Board Download Failed`     | a bootstrap stage threw                                | `scopeKey`, `stage`, `attempt`, `expected`, `errorMessage`                          |
+| `Offline Board Download Cancelled`  | the board was switched off mid-download                | `scopeKey`, `source`, `stage?`, `fraction?`, `bytesDone?`                           |
+| `Offline Board Toggled`             | the offline switch was flipped, either way             | `scopeKey`, `enabled`, `source`                                                     |
+| `Offline Download All Tapped`       | the "download all my boards" switch was TAPPED         | `boardCount`                                                                        |
+
+**The once-ever contract.** Started and Completed are each guarded by a durable `sync_meta`
+marker — `scope-started:<scopeKey>` and `scope-complete:<scopeKey>` — so the funnel query is
+simply Started → Completed, with no first-occurrence de-duplication needed. Both markers sit
+**outside** the `checkpoint:` prefix, so signing out leaves them alone (matching the board rows,
+which survive as a shared cache), and both are cleared by `scope-teardown.ts` in the same
+transaction as the rows, so removing and re-adding a board starts a fresh funnel.
+
+Getting this wrong breaks the metric in both directions, which is why the marker exists at all: a
+paged crawl writes a board-table checkpoint on its **first page**, and `runBootstrapPhase` treats
+any existing checkpoint as ineligible — so a per-cycle Started gated on "no checkpoint yet" would
+emit **no Started at all** for the multi-cycle crawls that are the most likely to be abandoned,
+while a retrying snapshot would emit **several**.
+
+> **If a future change wipes board data on logout** (issue #3621), it must clear both markers in the
+> same transaction as the rows. Otherwise the next sign-in emits Completed with no Started.
+
+**Reading the props.** `pathIntent` on Started is an INTENT from cheap local facts, not an outcome —
+a snapshot-eligible scope can still fall back to the paged crawl after the manifest resolves. Split
+by resolved path using Completed's `method`. `bytes`/`rowCount`/`downloadMs`/`importMs` are absent
+(not zero) when the completing delta pull lands in a **later cycle** than the import — the
+dropped-connection tail — which biases those four toward the healthy population; `durationMs`,
+`method`, and the funnel ratio itself are unaffected.
+
+**Trigger vocabulary.** `trigger` separates deliberate taps from automatic re-enables, which is what
+#4318's discovery nudges are measured against: `toggle` and `download-all` are taps;
+`auto-download-all` (the More screen's mount effect acting on the persisted setting) and
+`adopt-auto` (a discovered board adopted because `autoOfflineBoards` is on) are not; plus
+`adopt-confirmed`, `retry`, and `unknown`. It is persisted per scope
+(`settings/offline-boards.ts`'s `rememberDownloadTrigger`), not held in memory, because the case
+that matters most is a board enabled with no signal whose download runs on a later launch — an
+in-memory map loses exactly that one. `unknown` is an explicit, expected value.
+
 ## Ops runbook
 
 ### Manual export

--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -540,14 +540,14 @@ Five PostHog events (`@boardsesh/analytics`'s `SHARED_EVENTS`) make board downlo
 end-to-end (issue #4316). Before them the feature had exactly one — `Offline Board Download
 Completed` — so abandonment was structurally unmeasurable and failures went only to Sentry.
 
-| Event                              | When                                                   | Key props                                                                          |
-| ---------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------- |
-| `Offline Board Download Started`   | first time any cycle starts pulling a scope, once ever | `scopeKey`, `pathIntent`, `artifactBytes`, `trigger`, `offlineEngineEnabled`        |
-| `Offline Board Download Completed`  | both board tables reached the tail, once ever          | `scopeKey`, `method`, `durationMs`, `bytes?`, `rowCount?`, `downloadMs?`, `importMs?` |
-| `Offline Board Download Failed`     | a bootstrap stage threw                                | `scopeKey`, `stage`, `attempt`, `expected`, `errorMessage`                          |
-| `Offline Board Download Cancelled`  | the board was switched off mid-download                | `scopeKey`, `source`, `stage?`, `fraction?`, `bytesDone?`                           |
-| `Offline Board Toggled`             | the offline switch was flipped, either way             | `scopeKey`, `enabled`, `source`                                                     |
-| `Offline Download All Tapped`       | the "download all my boards" switch was TAPPED         | `boardCount`                                                                        |
+| Event                              | When                                                   | Key props                                                                             |
+| ---------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| `Offline Board Download Started`   | first time any cycle starts pulling a scope, once ever | `scopeKey`, `pathIntent`, `artifactBytes`, `trigger`, `offlineEngineEnabled`          |
+| `Offline Board Download Completed` | both board tables reached the tail, once ever          | `scopeKey`, `method`, `durationMs`, `bytes?`, `rowCount?`, `downloadMs?`, `importMs?` |
+| `Offline Board Download Failed`    | a bootstrap stage threw                                | `scopeKey`, `stage`, `attempt`, `expected`, `errorMessage`                            |
+| `Offline Board Download Cancelled` | the board was switched off mid-download                | `scopeKey`, `source`, `stage?`, `fraction?`, `bytesDone?`                             |
+| `Offline Board Toggled`            | the offline switch was flipped, either way             | `scopeKey`, `enabled`, `source`                                                       |
+| `Offline Download All Tapped`      | the "download all my boards" switch was TAPPED         | `boardCount`                                                                          |
 
 **The once-ever contract.** Started and Completed are each guarded by a durable `sync_meta`
 marker — `scope-started:<scopeKey>` and `scope-complete:<scopeKey>` — so the funnel query is
@@ -561,6 +561,12 @@ paged crawl writes a board-table checkpoint on its **first page**, and `runBoots
 any existing checkpoint as ineligible — so a per-cycle Started gated on "no checkpoint yet" would
 emit **no Started at all** for the multi-cycle crawls that are the most likely to be abandoned,
 while a retrying snapshot would emit **several**.
+
+A scope that is **already complete** the first time this code sees it — every board on a device that
+upgrades into the funnel build — gets its `scope-started:` marker written but emits **no** Started.
+It can never emit Completed again either (that marker is already set), so announcing it would post
+one unmatched Started per already-downloaded board on the first cycle after release: a phantom
+abandonment spike in exactly the window the baseline is read from.
 
 > **If a future change wipes board data on logout** (issue #3621), it must clear both markers in the
 > same transaction as the rows. Otherwise the next sign-in emits Completed with no Started.

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -124,7 +124,14 @@ export default function MoreScreen() {
   useEffect(() => {
     if (!offlineEnabled || !autoOfflineBoards || myBoards.length === 0) return;
     const missing = missingOfflineBoards();
-    if (missing.length === 0) return;
+    if (missing.length === 0) {
+      // A tap with nothing left to enable is fully handled here. Leaving the
+      // flag armed would let the next automatic re-enable on this screen (a
+      // board followed minutes later, say) inherit a `download-all` attribution
+      // for a tap that had already been spent.
+      downloadAllTapPendingRef.current = false;
+      return;
+    }
     const fromTap = downloadAllTapPendingRef.current;
     downloadAllTapPendingRef.current = false;
     enableBoardsOffline(missing, {

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -15,7 +15,15 @@ import { useAuth } from '../../../src/providers/auth-provider';
 import { useProfile, useMyBoards } from '../../../src/lib/graphql/hooks';
 import { useBoardDownloads } from '../../../src/offline/use-board-downloads';
 import { isOfflineEngineEnabled } from '../../../src/lib/offline-engine';
-import { useSetting, setSetting, getSetting, offlineBoardKeyForBoard } from '../../../src/settings';
+import {
+  useSetting,
+  setSetting,
+  getSetting,
+  offlineBoardKeyForBoard,
+  rememberDownloadAllTap,
+  takeDownloadAllTap,
+  forgetDownloadAllTap,
+} from '../../../src/settings';
 import { useConfirm } from '../../../src/providers/dialog-provider';
 import { useIsOffline } from '../../../src/hooks/use-is-offline';
 import { RECLAIMABLE_VISIBLE_BYTES } from '../../../src/db/storage-usage';
@@ -120,7 +128,12 @@ export default function MoreScreen() {
   // (issue #4316). Without the handoff every enable here would look automatic —
   // the effect is also what runs on a plain app launch with the setting already
   // on, and #4318's discovery work is measured against the deliberate half.
-  const downloadAllTapPendingRef = useRef(false);
+  //
+  // The handoff is PERSISTED, not a ref. The tap can land before `useMyBoards`
+  // resolves, and this effect bails while the list is empty, so a ref would drop
+  // the attribution whenever the climber leaves the screen (or the app) in that
+  // window — and the enable that eventually ran would be filed as automatic,
+  // which is the one thing the split must not get wrong.
   useEffect(() => {
     if (!offlineEnabled || !autoOfflineBoards || myBoards.length === 0) return;
     const missing = missingOfflineBoards();
@@ -129,11 +142,10 @@ export default function MoreScreen() {
       // flag armed would let the next automatic re-enable on this screen (a
       // board followed minutes later, say) inherit a `download-all` attribution
       // for a tap that had already been spent.
-      downloadAllTapPendingRef.current = false;
+      forgetDownloadAllTap();
       return;
     }
-    const fromTap = downloadAllTapPendingRef.current;
-    downloadAllTapPendingRef.current = false;
+    const fromTap = takeDownloadAllTap();
     enableBoardsOffline(missing, {
       trigger: fromTap ? 'download-all' : 'auto-download-all',
       source: 'more',
@@ -565,7 +577,7 @@ export default function MoreScreen() {
               // per board. The effect above is a mount-time reaction to the
               // persisted setting, so firing a "…Tapped" event from it would
               // assert a tap that never happened.
-              downloadAllTapPendingRef.current = true;
+              rememberDownloadAllTap();
               track(SHARED_EVENTS.OfflineDownloadAllTapped, {
                 boardCount: missing.length,
                 offlineEngineEnabled: isOfflineEngineEnabled(),
@@ -573,6 +585,10 @@ export default function MoreScreen() {
               if (missing.length > 0) {
                 showToast(t('mobile.more.offline.downloadingAll', { count: missing.length }), 'info');
               }
+            } else {
+              // Switched back off before the list ever resolved: the tap is spent,
+              // and leaving it armed would attribute a later automatic enable to it.
+              forgetDownloadAllTap();
             }
           },
         },

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -14,6 +14,7 @@ import { openExternalUrl } from '../../../src/lib/open-url';
 import { useAuth } from '../../../src/providers/auth-provider';
 import { useProfile, useMyBoards } from '../../../src/lib/graphql/hooks';
 import { useBoardDownloads } from '../../../src/offline/use-board-downloads';
+import { isOfflineEngineEnabled } from '../../../src/lib/offline-engine';
 import { useSetting, setSetting, getSetting, offlineBoardKeyForBoard } from '../../../src/settings';
 import { useConfirm } from '../../../src/providers/dialog-provider';
 import { useIsOffline } from '../../../src/hooks/use-is-offline';
@@ -115,10 +116,21 @@ export default function MoreScreen() {
   // resolves, so flipping the toggle before the list loaded still downloads
   // everything. Only enables boards not already opted in, so once they're all in
   // it's a no-op — no repeated sync kicks.
+  // A deliberate tap on the switch below hands this effect its attribution
+  // (issue #4316). Without the handoff every enable here would look automatic —
+  // the effect is also what runs on a plain app launch with the setting already
+  // on, and #4318's discovery work is measured against the deliberate half.
+  const downloadAllTapPendingRef = useRef(false);
   useEffect(() => {
     if (!offlineEnabled || !autoOfflineBoards || myBoards.length === 0) return;
     const missing = missingOfflineBoards();
-    if (missing.length > 0) enableBoardsOffline(missing);
+    if (missing.length === 0) return;
+    const fromTap = downloadAllTapPendingRef.current;
+    downloadAllTapPendingRef.current = false;
+    enableBoardsOffline(missing, {
+      trigger: fromTap ? 'download-all' : 'auto-download-all',
+      source: 'more',
+    });
   }, [offlineEnabled, autoOfflineBoards, myBoards, missingOfflineBoards, enableBoardsOffline]);
 
   // Offline sync-issues surface. Poll the dead-letter count only while online (the
@@ -542,6 +554,15 @@ export default function MoreScreen() {
             setSetting('autoOfflineBoards', next);
             if (next) {
               const missing = missingOfflineBoards();
+              // Fired HERE, on the real tap, and once per tap rather than once
+              // per board. The effect above is a mount-time reaction to the
+              // persisted setting, so firing a "…Tapped" event from it would
+              // assert a tap that never happened.
+              downloadAllTapPendingRef.current = true;
+              track(SHARED_EVENTS.OfflineDownloadAllTapped, {
+                boardCount: missing.length,
+                offlineEngineEnabled: isOfflineEngineEnabled(),
+              });
               if (missing.length > 0) {
                 showToast(t('mobile.more.offline.downloadingAll', { count: missing.length }), 'info');
               }

--- a/packages/mobile/app/boards/manage.tsx
+++ b/packages/mobile/app/boards/manage.tsx
@@ -253,6 +253,12 @@ export default function ManageBoards() {
           currentTable: syncStatusRef.current.progress?.currentTable ?? null,
           phase: syncStatusRef.current.progress?.phase ?? null,
           snapshot: syncStatusRef.current.progress?.snapshot,
+          // With the progress kill switch off the frames still exist but carry no
+          // bytes, so a Cancelled event built from them would report a fake
+          // stage-and-zero. The abandonment itself is still counted — the
+          // Toggled(enabled:false) above always fires — just without the detail
+          // the progress feature is what supplies.
+          progressEnabled: downloadProgressEnabled,
         });
         // Disabling just drops the setting entry; the cached rows + checkpoint stay
         // so re-enabling resumes instantly, so no confirm is needed.
@@ -329,7 +335,7 @@ export default function ManageBoards() {
       // latest syncEnabledBoards setting).
       enableBoardsOffline(board, { trigger: 'toggle', source: 'manage' });
     },
-    [confirm, t, i18n.language, db, enableBoardsOffline],
+    [confirm, t, i18n.language, db, enableBoardsOffline, downloadProgressEnabled],
   );
 
   // See boards/index.tsx: a hard 401 clears tokens without flipping

--- a/packages/mobile/app/boards/manage.tsx
+++ b/packages/mobile/app/boards/manage.tsx
@@ -33,10 +33,14 @@ import { useRememberDownloadedBoards } from '../../src/offline/use-remember-down
 import { useSnapshotManifest } from '../../src/offline/use-snapshot-manifest';
 import { useSnapshotSource } from '../../src/offline/use-snapshot-source';
 import { formatBytes } from '../../src/lib/format-bytes';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { track } from '../../src/lib/analytics';
+import { isOfflineEngineEnabled } from '../../src/lib/offline-engine';
 import {
   getSetting,
   useSetting,
   setOfflineBoardEnabled,
+  forgetDownloadTrigger,
   forgetOfflineBoard,
   forgetOfflineBoardScope,
   useOfflineBoards,
@@ -135,6 +139,11 @@ export default function ManageBoards() {
   snapshotManifestRef.current = snapshotManifest;
   const db = useSQLiteContext();
   const syncStatus = useSyncStatus();
+  // Mirrored for the toggle-off handler, which only reads it at tap time: keeping
+  // the live status out of that callback's deps means a progress frame can't churn
+  // its identity and re-render every memoised row.
+  const syncStatusRef = useRef(syncStatus);
+  syncStatusRef.current = syncStatus;
   // This must be the same gate the sync bridge uses. A previous app version can
   // leave bootstrap markers in SQLite, but they are meaningless while this build
   // is intentionally running the ordinary paged downloader.
@@ -235,12 +244,41 @@ export default function ManageBoards() {
       const key = offlineBoardKeyForBoard(board);
       const alreadyEnabled = getSetting('syncEnabledBoards').includes(key);
       if (alreadyEnabled) {
+        // Was this download still in flight? Read BEFORE the setting write, so the
+        // cancel event carries how far it had got (issue #4316) — this is the
+        // abandonment the funnel exists to size, caught at the moment it happens.
+        const liveProgress = boardDownloadProgress({
+          scopeKey: key,
+          isSyncing: syncStatusRef.current.isSyncing,
+          currentTable: syncStatusRef.current.progress?.currentTable ?? null,
+          phase: syncStatusRef.current.progress?.phase ?? null,
+          snapshot: syncStatusRef.current.progress?.snapshot,
+        });
         // Disabling just drops the setting entry; the cached rows + checkpoint stay
         // so re-enabling resumes instantly, so no confirm is needed.
         setOfflineBoardEnabled(scope, false);
         // Drop the offline picker's snapshots for this scope too, so it stops
         // offering a board the user just opted out of.
         forgetOfflineBoardScope(scope);
+        // …and its pending download attribution, so a later re-enable is attributed
+        // to the tap that actually caused it rather than to this abandoned one.
+        forgetDownloadTrigger(key);
+        track(SHARED_EVENTS.OfflineBoardToggled, {
+          scopeKey: key,
+          enabled: false,
+          source: 'manage',
+          offlineEngineEnabled: isOfflineEngineEnabled(),
+        });
+        if (liveProgress) {
+          track(SHARED_EVENTS.OfflineBoardDownloadCancelled, {
+            scopeKey: key,
+            source: 'manage',
+            stage: liveProgress.stage,
+            fraction: liveProgress.fraction,
+            bytesDone: liveProgress.bytesDone,
+            offlineEngineEnabled: isOfflineEngineEnabled(),
+          });
+        }
         return;
       }
       // How big is this download? Only the snapshot path can answer honestly, and
@@ -289,7 +327,7 @@ export default function ManageBoards() {
       if (!confirmed) return;
       // Enable + kick a download now via the shared hook (single-flight, reads the
       // latest syncEnabledBoards setting).
-      enableBoardsOffline(board);
+      enableBoardsOffline(board, { trigger: 'toggle', source: 'manage' });
     },
     [confirm, t, i18n.language, db, enableBoardsOffline],
   );

--- a/packages/mobile/src/components/settings/StorageSettingsScreen.tsx
+++ b/packages/mobile/src/components/settings/StorageSettingsScreen.tsx
@@ -38,7 +38,10 @@ import { useConfirm } from '../../providers/dialog-provider';
 import { useToast } from '../../providers/toast-provider';
 import { useOfflineDownloadsEnabled } from '../../providers/feature-flags-provider';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
-import { useSetting } from '../../settings';
+import { useSetting, offlineBoardKey, forgetDownloadTrigger } from '../../settings';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { track } from '../../lib/analytics';
+import { isOfflineEngineEnabled } from '../../lib/offline-engine';
 import {
   measureDatabaseBytes,
   measureFreeDiskSpace,
@@ -161,7 +164,17 @@ export function StorageSettingsScreen() {
     async (scopes: OfflineBoardScope[]) => {
       try {
         for (const scope of scopes) {
+          const scopeKey = offlineBoardKey(scope);
           await removeOfflineBoard({ db, queryClient, scope });
+          // Removing storage IS turning the board off (issue #4316) — same
+          // funnel exit as the My Boards toggle, different surface.
+          forgetDownloadTrigger(scopeKey);
+          track(SHARED_EVENTS.OfflineBoardToggled, {
+            scopeKey,
+            enabled: false,
+            source: 'storage',
+            offlineEngineEnabled: isOfflineEngineEnabled(),
+          });
         }
         // Once, after every teardown — it rebuilds the whole file. Cosmetic by
         // design: a failure means the rows are gone but the file didn't shrink, so it

--- a/packages/mobile/src/hooks/__tests__/use-offline-mutations.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-offline-mutations.test.ts
@@ -13,6 +13,20 @@ import type { QueryClient } from '@tanstack/react-query';
 
 // useCallback → identity; useQueryClient → stub. Only the follow hooks use them.
 const invalidateQueries = vi.fn();
+// The adapter reads the persisted download-trigger attribution (issue #4316),
+// which pulls the settings store — and its native MMKV entry breaks the test
+// bundler's scan. Same in-memory stand-in as remove-offline-board.test.ts.
+const mockSettingsStorage = new Map<string, string>();
+vi.mock('react-native-mmkv', () => {
+  const createMockInstance = () => ({
+    getString: (key: string) => mockSettingsStorage.get(key),
+    set: (key: string, value: string) => void mockSettingsStorage.set(key, value),
+    remove: (key: string) => void mockSettingsStorage.delete(key),
+    clearAll: () => mockSettingsStorage.clear(),
+  });
+  return { createMMKV: vi.fn(() => createMockInstance()) };
+});
+
 vi.mock('react', () => ({
   useCallback: <T>(callback: T) => callback,
 }));

--- a/packages/mobile/src/lib/board-discovery/__tests__/use-adopt-found-board.test.tsx
+++ b/packages/mobile/src/lib/board-discovery/__tests__/use-adopt-found-board.test.tsx
@@ -106,7 +106,12 @@ describe('useAdoptFoundBoard', () => {
     const board = makeBoard();
     await result.current(board);
     expect(spies.confirm).toHaveBeenCalledTimes(1);
-    expect(spies.enableBoardsOffline).toHaveBeenCalledWith(board);
+    // 'adopt-confirmed', not 'adopt-auto': the split is what makes discovery
+    // work measurable against deliberate opt-ins (issue #4316).
+    expect(spies.enableBoardsOffline).toHaveBeenCalledWith(board, {
+      trigger: 'adopt-confirmed',
+      source: 'adopt',
+    });
   });
 
   it('does not download when the confirm is declined', async () => {
@@ -125,7 +130,8 @@ describe('useAdoptFoundBoard', () => {
     const board = makeBoard();
     await result.current(board);
     expect(spies.confirm).not.toHaveBeenCalled();
-    expect(spies.enableBoardsOffline).toHaveBeenCalledWith(board);
+    // The setting acting on its own — NOT a tap.
+    expect(spies.enableBoardsOffline).toHaveBeenCalledWith(board, { trigger: 'adopt-auto', source: 'adopt' });
   });
 
   it('never re-offers a board whose scope is already enabled for offline', async () => {

--- a/packages/mobile/src/lib/board-discovery/use-adopt-found-board.ts
+++ b/packages/mobile/src/lib/board-discovery/use-adopt-found-board.ts
@@ -50,7 +50,10 @@ export function useAdoptFoundBoard() {
       }
 
       if (decision.offline === 'auto') {
-        enableBoardsOffline(board);
+        // The `autoOfflineBoards` setting acting on its own — NOT a tap. Kept
+        // distinct from the confirmed branch below so discovery work (#4318) is
+        // measured against deliberate opt-ins only.
+        enableBoardsOffline(board, { trigger: 'adopt-auto', source: 'adopt' });
         return;
       }
       if (decision.offline === 'ask') {
@@ -60,7 +63,7 @@ export function useAdoptFoundBoard() {
           confirmLabel: t('mobile.offline.enableConfirm'),
           cancelLabel: t('mobile.manage.cancel'),
         });
-        if (confirmed) enableBoardsOffline(board);
+        if (confirmed) enableBoardsOffline(board, { trigger: 'adopt-confirmed', source: 'adopt' });
       }
     },
     // followBoard.mutate is stable; depending on the whole `followBoard` object

--- a/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
+++ b/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
@@ -6,6 +6,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const onlineManagerIsOnline = vi.fn(() => true);
+// The adapter reads the persisted download-trigger attribution (issue #4316),
+// which pulls the settings store — and its native MMKV entry breaks the test
+// bundler's scan. Same in-memory stand-in as remove-offline-board.test.ts.
+const mockSettingsStorage = new Map<string, string>();
+vi.mock('react-native-mmkv', () => {
+  const createMockInstance = () => ({
+    getString: (key: string) => mockSettingsStorage.get(key),
+    set: (key: string, value: string) => void mockSettingsStorage.set(key, value),
+    remove: (key: string) => void mockSettingsStorage.delete(key),
+    clearAll: () => mockSettingsStorage.clear(),
+  });
+  return { createMMKV: vi.fn(() => createMockInstance()) };
+});
+
 vi.mock('@tanstack/react-query', () => ({
   onlineManager: { isOnline: () => onlineManagerIsOnline() },
 }));
@@ -56,6 +70,7 @@ const trackMock = vi.fn();
 vi.mock('../../lib/analytics', () => ({ track: (...args: unknown[]) => trackMock(...args) }));
 
 import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { rememberDownloadTrigger } from '../../settings';
 import {
   drainMutationQueue,
   startSyncScheduler,
@@ -85,6 +100,8 @@ beforeEach(() => {
   appStateListener = null;
   netInfoListener = null;
   onlineManagerIsOnline.mockReturnValue(true);
+  // The trigger store is persisted, so it survives between tests unless cleared.
+  mockSettingsStorage.clear();
 });
 
 describe('drainMutationQueue binding', () => {
@@ -454,6 +471,7 @@ describe('snapshot-bootstrap bindings', () => {
       scopeKey: 'kilter:1:5',
       method: 'snapshot',
       durationMs: 1234,
+      offlineEngineEnabled: false,
     });
   });
 
@@ -473,7 +491,10 @@ describe('snapshot-bootstrap bindings', () => {
     options.onScopeDownloadComplete?.(info);
 
     expect(onScopeDownloadComplete).toHaveBeenCalledWith(info);
-    expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineBoardDownloadCompleted, info);
+    expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineBoardDownloadCompleted, {
+      ...info,
+      offlineEngineEnabled: false,
+    });
   });
 
   it('captures a PostHog event — not a Sentry error — when the coverage guard forces a resync', () => {
@@ -532,6 +553,129 @@ describe('snapshot-bootstrap bindings', () => {
     expect(trackMock).toHaveBeenCalledTimes(3);
   });
 
+  it('fires the funnel Started event with the persisted trigger, then prunes it', () => {
+    rememberDownloadTrigger('kilter:1:5', 'download-all');
+    startSyncScheduler(
+      db,
+      queryClient,
+      graphqlFetch,
+      () => [],
+      async () => {},
+    );
+    const options = startSyncSchedulerCore.mock.calls[0][6] as SchedulerOptions;
+
+    options.onScopeDownloadStart?.({ scopeKey: 'kilter:1:5', pathIntent: 'snapshot', artifactBytes: 103_000_000 });
+
+    expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineBoardDownloadStarted, {
+      scopeKey: 'kilter:1:5',
+      pathIntent: 'snapshot',
+      artifactBytes: 103_000_000,
+      trigger: 'download-all',
+      offlineEngineEnabled: false,
+    });
+
+    // Consumed: a second Started for the same scope (which the engine's durable
+    // marker should prevent anyway) can't re-use a stale attribution.
+    trackMock.mockClear();
+    options.onScopeDownloadStart?.({ scopeKey: 'kilter:1:5', pathIntent: 'paged', artifactBytes: null });
+    expect(trackMock).toHaveBeenCalledWith(
+      SHARED_EVENTS.OfflineBoardDownloadStarted,
+      expect.objectContaining({ trigger: 'unknown' }),
+    );
+  });
+
+  it('reports trigger "unknown" for a scope enabled by a build that predates the attribution', () => {
+    startSyncScheduler(
+      db,
+      queryClient,
+      graphqlFetch,
+      () => [],
+      async () => {},
+    );
+    const options = startSyncSchedulerCore.mock.calls[0][6] as SchedulerOptions;
+
+    options.onScopeDownloadStart?.({ scopeKey: 'tension:2:10', pathIntent: 'paged', artifactBytes: null });
+
+    expect(trackMock).toHaveBeenCalledWith(
+      SHARED_EVENTS.OfflineBoardDownloadStarted,
+      expect.objectContaining({ trigger: 'unknown', artifactBytes: null }),
+    );
+  });
+
+  it('sends a bootstrap failure to BOTH the funnel and Sentry, keeping the expected-offline downgrade', () => {
+    // Sentry alone can't answer "what fraction of downloads fail, and where" —
+    // it groups by exception shape and deliberately downgrades transport
+    // failures. Same call site, so the two can never disagree.
+    startSyncScheduler(
+      db,
+      queryClient,
+      graphqlFetch,
+      () => [],
+      async () => {},
+    );
+    const options = startSyncSchedulerCore.mock.calls[0][6] as SchedulerOptions;
+
+    options.onSnapshotBootstrapError?.({
+      scopeKey: 'kilter:1:5',
+      stage: 'download',
+      attempt: 2,
+      cause: new Error('The request timed out.'),
+      expected: true,
+    });
+
+    expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineBoardDownloadFailed, {
+      scopeKey: 'kilter:1:5',
+      stage: 'download',
+      attempt: 2,
+      expected: true,
+      errorMessage: 'The request timed out.',
+      offlineEngineEnabled: false,
+    });
+    expect(reportHandledError).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ level: 'warning' }));
+  });
+
+  it('carries the payload props on Completed, and omits them when the import ran in an earlier cycle', () => {
+    startSyncScheduler(
+      db,
+      queryClient,
+      graphqlFetch,
+      () => [],
+      async () => {},
+    );
+    const options = startSyncSchedulerCore.mock.calls[0][6] as SchedulerOptions;
+
+    options.onScopeDownloadComplete?.({
+      scopeKey: 'kilter:1:5',
+      method: 'snapshot',
+      durationMs: 1000,
+      bytes: 103_000_000,
+      rowCount: 40_000,
+      downloadMs: 800,
+      importMs: 150,
+    });
+    expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineBoardDownloadCompleted, {
+      scopeKey: 'kilter:1:5',
+      method: 'snapshot',
+      durationMs: 1000,
+      bytes: 103_000_000,
+      rowCount: 40_000,
+      downloadMs: 800,
+      importMs: 150,
+      offlineEngineEnabled: false,
+    });
+
+    // A cross-cycle completion: absent, never zero — a 0 would read as a real
+    // measurement of a download that took no time.
+    trackMock.mockClear();
+    options.onScopeDownloadComplete?.({ scopeKey: 'kilter:1:6', method: 'snapshot', durationMs: 2000 });
+    expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineBoardDownloadCompleted, {
+      scopeKey: 'kilter:1:6',
+      method: 'snapshot',
+      durationMs: 2000,
+      offlineEngineEnabled: false,
+    });
+  });
+
   it('pullSync binds the snapshot-bootstrap telemetry defaults but lets caller options win', async () => {
     const customBootstrapError = vi.fn();
     await pullSync(db, queryClient, graphqlFetch, { onSnapshotBootstrapError: customBootstrapError });
@@ -552,7 +696,15 @@ describe('snapshot-bootstrap bindings', () => {
       scopeKey: 'kilter:1:5',
       method: 'paged',
       durationMs: 500,
+      offlineEngineEnabled: false,
     });
+
+    // The Started reporter is bound by default too.
+    options.onScopeDownloadStart?.({ scopeKey: 'kilter:1:5', pathIntent: 'paged', artifactBytes: null });
+    expect(trackMock).toHaveBeenCalledWith(
+      SHARED_EVENTS.OfflineBoardDownloadStarted,
+      expect.objectContaining({ scopeKey: 'kilter:1:5', pathIntent: 'paged' }),
+    );
   });
 });
 

--- a/packages/mobile/src/offline/__tests__/use-board-downloads.test.tsx
+++ b/packages/mobile/src/offline/__tests__/use-board-downloads.test.tsx
@@ -87,4 +87,24 @@ describe('useBoardDownloads', () => {
     expect(getSyncStatusSnapshot().bootstrapMetadataRevision).toBe(2);
     expect(getSyncStatusSnapshot().scopeCompletionRevision).toBe(2);
   });
+
+  it('enables and announces once per SCOPE when two boards share one', () => {
+    // Two gyms with the same wall are one offline scope and one download, so a
+    // per-board Toggled would count two enables against the downloader's single
+    // Started. Download-all is where this lands: its "missing" filter runs
+    // against the pre-batch enabled set, so both siblings come through.
+    const boards = [makeBoard('garage', 'kilter', 1, 10), makeBoard('gym', 'kilter', 1, 10)];
+    const { result } = renderHook(() => useBoardDownloads());
+
+    result.current.enableBoardsOffline(boards, { trigger: 'download-all', source: 'more' });
+
+    expect(spies.setOfflineBoardEnabled).toHaveBeenCalledTimes(1);
+    expect(spies.rememberDownloadTrigger).toHaveBeenCalledTimes(1);
+    expect(spies.rememberDownloadTrigger).toHaveBeenCalledWith('kilter:1:10', 'download-all');
+    expect(spies.track).toHaveBeenCalledTimes(1);
+    // Both board cards are still remembered — that list is per-board, and the
+    // offline picker needs a row for each.
+    expect(spies.rememberOfflineBoards).toHaveBeenCalledWith(boards);
+    expect(spies.triggerSync).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/mobile/src/offline/__tests__/use-board-downloads.test.tsx
+++ b/packages/mobile/src/offline/__tests__/use-board-downloads.test.tsx
@@ -14,7 +14,9 @@ const spies = vi.hoisted(() => ({
   drainMutationQueue: vi.fn(),
   graphqlRequest: vi.fn(),
   rememberOfflineBoards: vi.fn(),
+  rememberDownloadTrigger: vi.fn(),
   setOfflineBoardEnabled: vi.fn(),
+  track: vi.fn(),
   triggerSync: vi.fn(),
 }));
 
@@ -30,10 +32,14 @@ vi.mock('../../lib/graphql/client', () => ({
 }));
 vi.mock('../../settings', () => ({
   getSetting: () => ['kilter:1:10', 'tension:2:11'],
+  offlineBoardKeyForBoard: (board: UserBoard) => `${board.boardType}:${board.layoutId}:${board.sizeId}`,
   offlineBoardScopeForBoard: (board: UserBoard) => `${board.boardType}:${board.layoutId}:${board.sizeId}`,
   rememberOfflineBoards: spies.rememberOfflineBoards,
+  rememberDownloadTrigger: spies.rememberDownloadTrigger,
   setOfflineBoardEnabled: spies.setOfflineBoardEnabled,
 }));
+vi.mock('../../lib/analytics', () => ({ track: spies.track }));
+vi.mock('../../lib/offline-engine', () => ({ isOfflineEngineEnabled: () => true }));
 
 import {
   __resetSyncStatusForTests,

--- a/packages/mobile/src/offline/offline-sync-adapter.ts
+++ b/packages/mobile/src/offline/offline-sync-adapter.ts
@@ -36,6 +36,7 @@ import {
   type CoverageEvaluatedReporter,
   type CoverageResetReporter,
   type ScopeDownloadCompleteReporter,
+  type ScopeDownloadStartReporter,
   type SchedulerTriggers,
   type SchemaDriftReporter,
   type SnapshotBootstrapErrorReporter,
@@ -45,6 +46,8 @@ import {
 } from '@boardsesh/offline-sync';
 import { SHARED_EVENTS, sanitizeErrorForAnalytics } from '@boardsesh/analytics';
 import { reportHandledError } from '../lib/error-reporting';
+import { isOfflineEngineEnabled } from '../lib/offline-engine';
+import { takeDownloadTrigger } from '../settings';
 import { track } from '../lib/analytics';
 
 // Exported so non-drain reporters can record the one dimension that decides
@@ -144,6 +147,19 @@ const reportSnapshotBootstrapError: SnapshotBootstrapErrorReporter = ({
   cause,
   expected,
 }) => {
+  // The funnel's Failed leg (issue #4316). Sentry alone could never answer "what
+  // fraction of downloads fail, and at which stage" — it groups by exception
+  // shape, not by scope, and expected transport failures are deliberately
+  // downgraded there. Same call site, so the two can never disagree about
+  // whether a failure happened.
+  track(SHARED_EVENTS.OfflineBoardDownloadFailed, {
+    scopeKey,
+    stage,
+    attempt,
+    expected,
+    errorMessage: cause instanceof Error ? cause.message : String(cause),
+    offlineEngineEnabled: isOfflineEngineEnabled(),
+  });
   reportHandledError(
     new Error(`Snapshot bootstrap failed for ${scopeKey} at stage "${stage}" (attempt ${attempt})`, { cause }),
     {
@@ -164,8 +180,48 @@ const reportSnapshotBootstrapError: SnapshotBootstrapErrorReporter = ({
 // Fired once per board scope's initial download so the snapshot-bootstrap
 // warm-up can be compared against the plain paged crawl in the field (which
 // path actually got used, and how long it took).
-const reportScopeDownloadComplete: ScopeDownloadCompleteReporter = ({ scopeKey, method, durationMs }) => {
-  track(SHARED_EVENTS.OfflineBoardDownloadCompleted, { scopeKey, method, durationMs });
+const reportScopeDownloadComplete: ScopeDownloadCompleteReporter = ({
+  scopeKey,
+  method,
+  durationMs,
+  bytes,
+  rowCount,
+  downloadMs,
+  importMs,
+}) => {
+  track(SHARED_EVENTS.OfflineBoardDownloadCompleted, {
+    scopeKey,
+    method,
+    durationMs,
+    // Spread rather than set: the engine omits these when the completing delta
+    // pull landed in a later cycle than the import, and an omitted prop is the
+    // honest answer where a 0 would look like a real measurement.
+    ...(bytes === undefined ? {} : { bytes }),
+    ...(rowCount === undefined ? {} : { rowCount }),
+    ...(downloadMs === undefined ? {} : { downloadMs }),
+    ...(importMs === undefined ? {} : { importMs }),
+    // Stamped so the funnel stays readable once #4312 bakes the flag on: the
+    // engine gate, not the raw flag value.
+    offlineEngineEnabled: isOfflineEngineEnabled(),
+  });
+};
+
+// The funnel's missing anchor (issue #4316): without it, abandonment is
+// structurally unmeasurable — a download that is never finished emits nothing at
+// all. The engine guarantees this fires once ever per scope (durable
+// `scope-started:` marker), matching Completed, so the ratio is real.
+const reportScopeDownloadStart: ScopeDownloadStartReporter = ({ scopeKey, pathIntent, artifactBytes }) => {
+  track(SHARED_EVENTS.OfflineBoardDownloadStarted, {
+    scopeKey,
+    pathIntent,
+    artifactBytes,
+    // Consumed here, which both attributes the event and prunes the store. The
+    // attribution is persisted rather than in-memory precisely because the
+    // interesting case is a board enabled while offline whose download runs on a
+    // later launch — an in-memory map loses exactly that one.
+    trigger: takeDownloadTrigger(scopeKey),
+    offlineEngineEnabled: isOfflineEngineEnabled(),
+  });
 };
 
 function combinedScopeDownloadCompleteReporter(
@@ -304,6 +360,7 @@ export function startSyncScheduler(
     onSnapshotBootstrapError: reportSnapshotBootstrapError,
     onBootstrapMetadataChanged: options?.onBootstrapMetadataChanged,
     onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete),
+    onScopeDownloadStart: reportScopeDownloadStart,
     onCoverageReset: reportCoverageReset,
     onCoverageEvaluated: reportCoverageEvaluated,
   });
@@ -326,6 +383,7 @@ export function triggerSync(
     onSnapshotBootstrapError: reportSnapshotBootstrapError,
     onBootstrapMetadataChanged: options?.onBootstrapMetadataChanged,
     onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete),
+    onScopeDownloadStart: reportScopeDownloadStart,
     onCoverageReset: reportCoverageReset,
     onCoverageEvaluated: reportCoverageEvaluated,
   });
@@ -343,6 +401,7 @@ export function pullSync(
     onSchemaDrift: options?.onSchemaDrift ?? reportSchemaDrift,
     onSnapshotBootstrapError: options?.onSnapshotBootstrapError ?? reportSnapshotBootstrapError,
     onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete),
+    onScopeDownloadStart: options?.onScopeDownloadStart ?? reportScopeDownloadStart,
     onCoverageReset: options?.onCoverageReset ?? reportCoverageReset,
     onCoverageEvaluated: options?.onCoverageEvaluated ?? reportCoverageEvaluated,
     // Caller-provided error/drift/coverage reporters keep their existing

--- a/packages/mobile/src/offline/use-board-downloads.ts
+++ b/packages/mobile/src/offline/use-board-downloads.ts
@@ -3,11 +3,25 @@ import { useSQLiteContext } from 'expo-sqlite';
 import { useQueryClient } from '@tanstack/react-query';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import type { GraphQLFetch } from '@boardsesh/offline-sync';
-import { getSetting, setOfflineBoardEnabled, offlineBoardScopeForBoard, rememberOfflineBoards } from '../settings';
+import {
+  getSetting,
+  setOfflineBoardEnabled,
+  offlineBoardKeyForBoard,
+  offlineBoardScopeForBoard,
+  rememberDownloadTrigger,
+  rememberOfflineBoards,
+  type OfflineDownloadTrigger,
+} from '../settings';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { track } from '../lib/analytics';
+import { isOfflineEngineEnabled } from '../lib/offline-engine';
 import { getHttpClient } from '../lib/graphql/client';
 import { notifyBootstrapMetadataChanged, notifyScopeDownloadComplete, setSyncProgress } from '../sync';
 import { triggerSync, drainMutationQueue } from './offline-sync-adapter';
 import { useSnapshotSource } from './use-snapshot-source';
+
+/** Which surface flipped the switch, for the Toggled event (issue #4316). */
+export type ToggleSource = 'manage' | 'storage' | 'more' | 'adopt';
 
 /**
  * Enable one or more boards for offline and kick a single sync so their catalogs
@@ -35,11 +49,23 @@ export function useBoardDownloads() {
   );
 
   const enableBoardsOffline = useCallback(
-    (boards: UserBoard | UserBoard[]) => {
+    (boards: UserBoard | UserBoard[], options?: { trigger?: OfflineDownloadTrigger; source?: ToggleSource }) => {
       const list = Array.isArray(boards) ? boards : [boards];
       if (list.length === 0) return;
+      const trigger = options?.trigger ?? 'unknown';
+      const source = options?.source ?? 'manage';
       for (const board of list) {
+        const scopeKey = offlineBoardKeyForBoard(board);
         setOfflineBoardEnabled(offlineBoardScopeForBoard(board), true);
+        // Persisted, then consumed when the download actually starts — which can
+        // be a later app launch entirely if the board was enabled with no signal.
+        rememberDownloadTrigger(scopeKey, trigger);
+        track(SHARED_EVENTS.OfflineBoardToggled, {
+          scopeKey,
+          enabled: true,
+          source,
+          offlineEngineEnabled: isOfflineEngineEnabled(),
+        });
       }
       // Snapshot the board identities while we hold them. This is the single funnel
       // for every offline enable (the My Boards toggle, adopt-found-board, the

--- a/packages/mobile/src/offline/use-board-downloads.ts
+++ b/packages/mobile/src/offline/use-board-downloads.ts
@@ -54,8 +54,19 @@ export function useBoardDownloads() {
       if (list.length === 0) return;
       const trigger = options?.trigger ?? 'unknown';
       const source = options?.source ?? 'manage';
+      // Two boards can share one offline scope — the key is board type + layout +
+      // size, so a climber who follows two gyms with the same wall gets one entry
+      // in `syncEnabledBoards` and ONE download for both. The enable work is
+      // per-scope for that reason: emitting a Toggled per board would count two
+      // enables against the single Started the downloader emits, and the
+      // download-all path is exactly where the duplicates arrive (its "missing"
+      // filter runs against the pre-batch enabled set, so siblings all pass).
+      // Every board card is still remembered below — that list is per-board.
+      const seenScopeKeys = new Set<string>();
       for (const board of list) {
         const scopeKey = offlineBoardKeyForBoard(board);
+        if (seenScopeKeys.has(scopeKey)) continue;
+        seenScopeKeys.add(scopeKey);
         setOfflineBoardEnabled(offlineBoardScopeForBoard(board), true);
         // Persisted, then consumed when the download actually starts — which can
         // be a later app launch entirely if the board was enabled with no signal.

--- a/packages/mobile/src/settings/__tests__/download-triggers.test.ts
+++ b/packages/mobile/src/settings/__tests__/download-triggers.test.ts
@@ -17,7 +17,14 @@ vi.mock('react-native-mmkv', () => {
   return { createMMKV: vi.fn(() => createMockInstance()) };
 });
 
-import { rememberDownloadTrigger, takeDownloadTrigger, forgetDownloadTrigger } from '../offline-boards';
+import {
+  rememberDownloadTrigger,
+  takeDownloadTrigger,
+  forgetDownloadTrigger,
+  rememberDownloadAllTap,
+  takeDownloadAllTap,
+  forgetDownloadAllTap,
+} from '../offline-boards';
 
 beforeEach(() => {
   mockStorage.clear();
@@ -69,5 +76,34 @@ describe('download-trigger attribution', () => {
     forgetDownloadTrigger('kilter:1:5');
 
     expect(takeDownloadTrigger('kilter:1:5')).toBe('unknown');
+  });
+});
+
+describe('download-all tap attribution', () => {
+  it('survives the window between the tap and My Boards resolving', () => {
+    // The tap persists; the effect that consumes it only runs once the board
+    // list lands, which can be a later mount or a later app launch entirely.
+    rememberDownloadAllTap();
+
+    expect(takeDownloadAllTap()).toBe(true);
+  });
+
+  it('spends the tap exactly once, so a later automatic enable stays automatic', () => {
+    rememberDownloadAllTap();
+
+    expect(takeDownloadAllTap()).toBe(true);
+    expect(takeDownloadAllTap()).toBe(false);
+  });
+
+  it('reports no tap when nothing armed it', () => {
+    expect(takeDownloadAllTap()).toBe(false);
+  });
+
+  it('disarms without consuming when the switch goes back off', () => {
+    rememberDownloadAllTap();
+
+    forgetDownloadAllTap();
+
+    expect(takeDownloadAllTap()).toBe(false);
   });
 });

--- a/packages/mobile/src/settings/__tests__/download-triggers.test.ts
+++ b/packages/mobile/src/settings/__tests__/download-triggers.test.ts
@@ -1,0 +1,73 @@
+// Download-trigger attribution (issue #4316). The whole reason this is a
+// persisted store rather than an in-memory map: a board enabled with no signal
+// downloads on a LATER app launch, and that slow tail is exactly the population
+// the funnel is for. An in-memory map would report `unknown` for all of it.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mockStorage = new Map<string, string>();
+
+vi.mock('react-native-mmkv', () => {
+  const createMockInstance = () => ({
+    getString: (key: string) => mockStorage.get(key),
+    set: (key: string, value: string) => void mockStorage.set(key, value),
+    remove: (key: string) => void mockStorage.delete(key),
+    clearAll: () => mockStorage.clear(),
+  });
+  return { createMMKV: vi.fn(() => createMockInstance()) };
+});
+
+import { rememberDownloadTrigger, takeDownloadTrigger, forgetDownloadTrigger } from '../offline-boards';
+
+beforeEach(() => {
+  mockStorage.clear();
+});
+
+describe('download-trigger attribution', () => {
+  it('round-trips a trigger and prunes it on read', () => {
+    rememberDownloadTrigger('kilter:1:5', 'download-all');
+
+    expect(takeDownloadTrigger('kilter:1:5')).toBe('download-all');
+    // Consuming is what keeps the store bounded: one entry lives from the enable
+    // until the download actually starts.
+    expect(takeDownloadTrigger('kilter:1:5')).toBe('unknown');
+  });
+
+  it('keeps scopes independent', () => {
+    rememberDownloadTrigger('kilter:1:5', 'toggle');
+    rememberDownloadTrigger('tension:2:10', 'adopt-auto');
+
+    expect(takeDownloadTrigger('tension:2:10')).toBe('adopt-auto');
+    expect(takeDownloadTrigger('kilter:1:5')).toBe('toggle');
+  });
+
+  it('reports unknown for a scope that was never attributed', () => {
+    // A board enabled by a build that predates this store. An explicit, expected
+    // value — not an accident.
+    expect(takeDownloadTrigger('kilter:1:5')).toBe('unknown');
+  });
+
+  it('lets the most recent intent win', () => {
+    // Toggled off and back on: the second choice was just as deliberate.
+    rememberDownloadTrigger('kilter:1:5', 'auto-download-all');
+    rememberDownloadTrigger('kilter:1:5', 'toggle');
+
+    expect(takeDownloadTrigger('kilter:1:5')).toBe('toggle');
+  });
+
+  it('degrades an unrecognised stored value to unknown rather than emitting it', () => {
+    // A value written by a NEWER build, read after a downgrade. PostHog event
+    // names are permanent; a stray trigger value would split the funnel.
+    rememberDownloadTrigger('kilter:1:5', 'from-the-future' as never);
+
+    expect(takeDownloadTrigger('kilter:1:5')).toBe('unknown');
+  });
+
+  it('forgets a pending attribution when the board is removed before it downloaded', () => {
+    rememberDownloadTrigger('kilter:1:5', 'toggle');
+
+    forgetDownloadTrigger('kilter:1:5');
+
+    expect(takeDownloadTrigger('kilter:1:5')).toBe('unknown');
+  });
+});

--- a/packages/mobile/src/settings/defaults.ts
+++ b/packages/mobile/src/settings/defaults.ts
@@ -4,6 +4,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   defaultBoardUuid: null,
   syncEnabledBoards: [],
   offlineBoardsV1: [],
+  offlineDownloadTriggers: {},
   autoOfflineBoards: false,
   autoConnectBle: true,
   autoDisconnectBle: false,

--- a/packages/mobile/src/settings/defaults.ts
+++ b/packages/mobile/src/settings/defaults.ts
@@ -5,6 +5,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   syncEnabledBoards: [],
   offlineBoardsV1: [],
   offlineDownloadTriggers: {},
+  offlineDownloadAllTapPending: false,
   autoOfflineBoards: false,
   autoConnectBle: true,
   autoDisconnectBle: false,

--- a/packages/mobile/src/settings/index.ts
+++ b/packages/mobile/src/settings/index.ts
@@ -21,5 +21,8 @@ export {
   rememberDownloadTrigger,
   takeDownloadTrigger,
   forgetDownloadTrigger,
+  rememberDownloadAllTap,
+  takeDownloadAllTap,
+  forgetDownloadAllTap,
   type OfflineDownloadTrigger,
 } from './offline-boards';

--- a/packages/mobile/src/settings/index.ts
+++ b/packages/mobile/src/settings/index.ts
@@ -18,4 +18,8 @@ export {
   forgetOfflineBoardScope,
   pruneOfflineBoards,
   clearOfflineBoards,
+  rememberDownloadTrigger,
+  takeDownloadTrigger,
+  forgetDownloadTrigger,
+  type OfflineDownloadTrigger,
 } from './offline-boards';

--- a/packages/mobile/src/settings/offline-boards.ts
+++ b/packages/mobile/src/settings/offline-boards.ts
@@ -209,3 +209,36 @@ export function forgetDownloadTrigger(scopeKey: string): void {
   const { [scopeKey]: _removed, ...rest } = current;
   setSetting(TRIGGER_SETTING_KEY, rest);
 }
+
+const DOWNLOAD_ALL_TAP_SETTING_KEY = 'offlineDownloadAllTapPending';
+
+/**
+ * Arm the "download all my boards" attribution. The tap flips a persisted
+ * setting, but the enable it causes runs from a mount effect once `myBoards`
+ * resolves — which can be a different mount, or a different app launch, if the
+ * list is still in flight when the climber leaves the screen. Held in the same
+ * store as the per-scope triggers for the same reason: an in-memory ref loses
+ * exactly the case the split exists to measure, and every enable that ran
+ * without it would be filed as automatic.
+ */
+export function rememberDownloadAllTap(): void {
+  if (getSetting(DOWNLOAD_ALL_TAP_SETTING_KEY) === true) return;
+  setSetting(DOWNLOAD_ALL_TAP_SETTING_KEY, true);
+}
+
+/**
+ * Read and CLEAR the pending download-all tap. One tap attributes one batch:
+ * leaving it armed would let the next automatic enable on that screen inherit a
+ * tap that had already been spent.
+ */
+export function takeDownloadAllTap(): boolean {
+  if (getSetting(DOWNLOAD_ALL_TAP_SETTING_KEY) !== true) return false;
+  setSetting(DOWNLOAD_ALL_TAP_SETTING_KEY, false);
+  return true;
+}
+
+/** Disarm without consuming — the climber turned the switch back off. */
+export function forgetDownloadAllTap(): void {
+  if (getSetting(DOWNLOAD_ALL_TAP_SETTING_KEY) !== true) return;
+  setSetting(DOWNLOAD_ALL_TAP_SETTING_KEY, false);
+}

--- a/packages/mobile/src/settings/offline-boards.ts
+++ b/packages/mobile/src/settings/offline-boards.ts
@@ -126,3 +126,86 @@ export function clearOfflineBoards(): void {
   if (Array.isArray(stored) && stored.length === 0) return;
   setSetting(SETTING_KEY, []);
 }
+
+// --- Download-trigger attribution (issue #4316) --------------------------------
+
+const TRIGGER_SETTING_KEY = 'offlineDownloadTriggers';
+
+/**
+ * Why a board's download was started. The split that matters is DELIBERATE vs
+ * AUTOMATIC — #4318's discovery nudges are measured against the deliberate taps,
+ * and lumping a settings-driven re-enable in with a real tap under a name that
+ * asserts a tap happened would make that measurement meaningless.
+ *
+ * - `toggle` — the My Boards per-row switch. A tap.
+ * - `download-all` — the "download all my boards" switch in More. A tap.
+ * - `auto-download-all` — the mount effect acting on the persisted
+ *   `autoOfflineBoards` setting. NOT a tap.
+ * - `adopt-auto` — a discovered board adopted because `autoOfflineBoards` is on.
+ *   NOT a tap.
+ * - `adopt-confirmed` — a discovered board the climber confirmed in the dialog.
+ * - `retry` — a manual re-run of a failed download.
+ * - `unknown` — no attribution recorded: a scope enabled by a build that predates
+ *   this, or one whose entry was already consumed. An explicit, expected value.
+ */
+export type OfflineDownloadTrigger =
+  | 'toggle'
+  | 'download-all'
+  | 'auto-download-all'
+  | 'adopt-auto'
+  | 'adopt-confirmed'
+  | 'retry'
+  | 'unknown';
+
+const KNOWN_TRIGGERS: readonly OfflineDownloadTrigger[] = [
+  'toggle',
+  'download-all',
+  'auto-download-all',
+  'adopt-auto',
+  'adopt-confirmed',
+  'retry',
+  'unknown',
+];
+
+function readTriggers(): Record<string, string> {
+  const stored = getSetting(TRIGGER_SETTING_KEY);
+  // A value written by a build with a different shape reads as empty rather than
+  // poisoning the event with garbage.
+  return stored !== null && typeof stored === 'object' && !Array.isArray(stored) ? stored : {};
+}
+
+/**
+ * Record why `scopeKey`'s download is starting. Overwrites any earlier
+ * un-consumed entry: the most recent intent is the truthful one (a climber who
+ * toggles a board off and back on chose it deliberately the second time too).
+ */
+export function rememberDownloadTrigger(scopeKey: string, trigger: OfflineDownloadTrigger): void {
+  const current = readTriggers();
+  if (current[scopeKey] === trigger) return;
+  setSetting(TRIGGER_SETTING_KEY, { ...current, [scopeKey]: trigger });
+}
+
+/**
+ * Read and PRUNE `scopeKey`'s trigger. Consuming it is what keeps the store
+ * bounded — one entry lives from the enable until the download actually starts,
+ * which is the whole span the attribution is for.
+ *
+ * Returns `'unknown'` when there is no entry, or when the stored string isn't a
+ * trigger this build knows (a value written by a newer build after a downgrade).
+ */
+export function takeDownloadTrigger(scopeKey: string): OfflineDownloadTrigger {
+  const current = readTriggers();
+  const stored = current[scopeKey];
+  if (stored === undefined) return 'unknown';
+  const { [scopeKey]: _consumed, ...rest } = current;
+  setSetting(TRIGGER_SETTING_KEY, rest);
+  return KNOWN_TRIGGERS.includes(stored as OfflineDownloadTrigger) ? (stored as OfflineDownloadTrigger) : 'unknown';
+}
+
+/** Drop `scopeKey`'s pending attribution — the board was removed before it downloaded. */
+export function forgetDownloadTrigger(scopeKey: string): void {
+  const current = readTriggers();
+  if (!(scopeKey in current)) return;
+  const { [scopeKey]: _removed, ...rest } = current;
+  setSetting(TRIGGER_SETTING_KEY, rest);
+}

--- a/packages/mobile/src/settings/types.ts
+++ b/packages/mobile/src/settings/types.ts
@@ -11,6 +11,15 @@ export type AppSettings = {
    * stale cards are ignored rather than misread.
    */
   offlineBoardsV1: UserBoard[];
+  /**
+   * Why each in-flight download was started, keyed by scope key (issue #4316).
+   * Persisted rather than held in memory because the case that matters most is
+   * exactly the one an in-memory map loses: a board enabled while offline, whose
+   * download runs on a later launch. Consumed and pruned when the Started event
+   * fires, and dropped with the scope on teardown, so it stays a handful of
+   * short-lived entries.
+   */
+  offlineDownloadTriggers: Record<string, string>;
   /** Keep every board the user follows/uses available offline by default. */
   autoOfflineBoards: boolean;
   autoConnectBle: boolean;

--- a/packages/mobile/src/settings/types.ts
+++ b/packages/mobile/src/settings/types.ts
@@ -20,6 +20,14 @@ export type AppSettings = {
    * short-lived entries.
    */
   offlineDownloadTriggers: Record<string, string>;
+  /**
+   * A "download all my boards" tap waiting for My Boards to resolve (issue
+   * #4316). Same reason as the map above: the enable it causes runs from a mount
+   * effect, so a ref would lose the attribution whenever the screen unmounts or
+   * the app restarts before the list lands, and the batch would be filed as
+   * automatic. Cleared the moment it is consumed.
+   */
+  offlineDownloadAllTapPending: boolean;
   /** Keep every board the user follows/uses available offline by default. */
   autoOfflineBoards: boolean;
   autoConnectBle: boolean;

--- a/packages/mobile/test/react-native-mmkv-stub.ts
+++ b/packages/mobile/test/react-native-mmkv-stub.ts
@@ -1,0 +1,37 @@
+// Vitest stub for `react-native-mmkv`.
+//
+// The real package's react-native Flow entry throws a `SyntaxError: Unexpected
+// token 'typeof'` under vitest's node env. The settings store binds an MMKV
+// instance at module load, so ANY suite that transitively reaches
+// `src/settings` — which is most of them, now that the offline adapter reads
+// persisted download-trigger attribution — would fail to load before a single
+// test ran.
+//
+// In-memory and per-process, so a suite that writes settings sees its own
+// writes. Suites that need to reset between tests (or assert on the raw stored
+// bytes) register their own `vi.mock('react-native-mmkv', ...)`, which takes
+// precedence over this alias. Wired via the `react-native-mmkv` alias in
+// packages/mobile/vite.config.ts.
+
+const store = new Map<string, string>();
+
+function createMMKVInstance() {
+  return {
+    getString(key: string): string | undefined {
+      return store.get(key);
+    },
+    set(key: string, value: string): void {
+      store.set(key, value);
+    },
+    remove(key: string): void {
+      store.delete(key);
+    },
+    clearAll(): void {
+      store.clear();
+    },
+  };
+}
+
+export function createMMKV(): ReturnType<typeof createMMKVInstance> {
+  return createMMKVInstance();
+}

--- a/packages/mobile/vite.config.ts
+++ b/packages/mobile/vite.config.ts
@@ -71,6 +71,15 @@ export default defineConfig({
         find: '@react-native-community/netinfo',
         replacement: fileURLToPath(new URL('./test/netinfo-stub.ts', import.meta.url)),
       },
+      // react-native-mmkv's react-native Flow entry throws a SyntaxError under
+      // vitest's node env, and the settings store binds an instance at module
+      // load — so any suite that transitively reaches `src/settings` would fail
+      // to load. Suites that need to reset the store between tests register
+      // their own vi.mock, which takes precedence.
+      {
+        find: 'react-native-mmkv',
+        replacement: fileURLToPath(new URL('./test/react-native-mmkv-stub.ts', import.meta.url)),
+      },
       // @sentry/react-native's real entry pulls in react-native's Promise.js,
       // which imports `promise/setimmediate/es6-extensions` (no extension) and
       // fails to resolve under vitest's node ESM env — breaking every suite that

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -365,8 +365,11 @@ export const SHARED_EVENTS = {
   OfflineBoardDownloadFailed: 'Offline Board Download Failed',
   // The climber turned a board OFF while its first download was still in flight
   // — the abandonment the funnel exists to size, caught at the moment it
-  // happens. Props: { scopeKey, source: 'manage' | 'storage', stage?, fraction?,
-  // bytesDone?, elapsedMs?, offlineEngineEnabled }.
+  // happens. Props: { scopeKey, source: 'manage', stage, fraction, bytesDone,
+  // offlineEngineEnabled }. It needs a live progress frame naming the scope, so
+  // today only the My Boards toggle mid-snapshot fires it: a paged crawl
+  // publishes no such frame, and removing a board from Storage reports its exit
+  // as `Offline Board Toggled { enabled: false, source: 'storage' }` instead.
   OfflineBoardDownloadCancelled: 'Offline Board Download Cancelled',
   // A board's offline switch was flipped, either way. Props: { scopeKey,
   // enabled: boolean, source: 'manage' | 'storage' | 'more' | 'adopt',

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -323,13 +323,62 @@ export const SHARED_EVENTS = {
   IntegrationDisconnected: 'Integration Disconnected',
   IntegrationAutoSyncToggled: 'Integration Auto Sync Toggled',
   SessionExportedToIntegration: 'Session Exported to Integration',
-  // Offline sync — fired once per board scope when its INITIAL download
-  // completes (offline-sync's onScopeDownloadComplete, both tables reached the
-  // tail), so the snapshot-bootstrap warm-up (Phase 3/4) can be compared
-  // against the plain paged crawl in the field. Props: { scopeKey,
-  // method: 'snapshot' | 'paged', durationMs }. Mobile-only today (the engine
-  // is shared, so a future web offline consumer would fire this too).
+  // Offline sync — the board-download funnel (issue #4316). Started and
+  // Completed are each fired ONCE EVER per board scope, guarded by durable
+  // `scope-started:` / `scope-complete:` markers in sync_meta, so
+  // Started → Completed is a real completion ratio rather than a count of
+  // retries. Both markers survive sign-out (matching the board rows, which stay
+  // as a shared cache) and are cleared by scope teardown, so removing and
+  // re-adding a board starts a fresh funnel.
+  //
+  // Fired the first time any cycle starts pulling a scope. Props: { scopeKey,
+  // pathIntent: 'snapshot' | 'paged', artifactBytes: number | null, trigger,
+  // offlineEngineEnabled }.
+  //
+  // `pathIntent` is an INTENT read from cheap local facts at that moment, not an
+  // outcome — a snapshot-eligible scope can still fall back to the paged crawl
+  // after the manifest resolves. Split funnels by Completed's `method` for the
+  // resolved path.
+  //
+  // `trigger` distinguishes DELIBERATE taps from AUTOMATIC re-enables, which is
+  // the whole point for discovery work: 'toggle' | 'download-all' (the My Boards
+  // / More tap) vs 'auto-download-all' | 'adopt-auto' (a setting acting on its
+  // own), plus 'adopt-confirmed' | 'retry' | 'unknown'. 'unknown' is an explicit,
+  // expected value — the trigger is persisted per scope, but a scope enabled by
+  // a build that predates this event has none.
+  OfflineBoardDownloadStarted: 'Offline Board Download Started',
+  // Fired once per board scope when its INITIAL download completes (both tables
+  // reached the tail), so the snapshot-bootstrap warm-up can be compared against
+  // the plain paged crawl in the field. Props: { scopeKey,
+  // method: 'snapshot' | 'paged', durationMs, bytes?, rowCount?, downloadMs?,
+  // importMs?, offlineEngineEnabled }. The four optional props are ABSENT rather
+  // than faked when the completing delta pull lands in a later cycle than the
+  // import, which biases them toward the healthy population; durationMs and the
+  // funnel ratio are unaffected. Mobile-only today (the engine is shared, so a
+  // future web offline consumer would fire this too).
   OfflineBoardDownloadCompleted: 'Offline Board Download Completed',
+  // A bootstrap stage failed. Props: { scopeKey, stage: 'manifest' | 'download'
+  // | 'import', attempt, expected, errorMessage, offlineEngineEnabled }.
+  // `expected: true` is a transport/reachability failure — a phone in a tunnel,
+  // not a defect — and is the normal case, not an alarm. These previously went
+  // only to Sentry, where they could not be joined to the funnel.
+  OfflineBoardDownloadFailed: 'Offline Board Download Failed',
+  // The climber turned a board OFF while its first download was still in flight
+  // — the abandonment the funnel exists to size, caught at the moment it
+  // happens. Props: { scopeKey, source: 'manage' | 'storage', stage?, fraction?,
+  // bytesDone?, elapsedMs?, offlineEngineEnabled }.
+  OfflineBoardDownloadCancelled: 'Offline Board Download Cancelled',
+  // A board's offline switch was flipped, either way. Props: { scopeKey,
+  // enabled: boolean, source: 'manage' | 'storage' | 'more' | 'adopt',
+  // offlineEngineEnabled }. The enable half is the entry point #4318's discovery
+  // nudges are measured against.
+  OfflineBoardToggled: 'Offline Board Toggled',
+  // The "Download all my boards" switch was TAPPED (once per tap, not once per
+  // board). Props: { boardCount, offlineEngineEnabled }. Deliberately not fired
+  // by the mount effect that re-enables boards from the persisted setting — that
+  // is an automatic re-enable and shows up as `trigger: 'auto-download-all'` on
+  // Started instead.
+  OfflineDownloadAllTapped: 'Offline Download All Tapped',
   // Offline sync — the device went longer than the tombstone retention window
   // without completing a deletions pull, so its local USER data was rebuilt
   // from scratch (issue #3474). Expected behaviour rather than an error: the

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -75,6 +75,8 @@ export type {
   BootstrapMetadataChangedReporter,
   ScopeDownloadCompleteInfo,
   ScopeDownloadCompleteReporter,
+  ScopeDownloadStartInfo,
+  ScopeDownloadStartReporter,
   CoverageResetInfo,
   CoverageResetReporter,
   CoverageEvaluatedInfo,

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
@@ -9,6 +9,8 @@ vi.mock('../checkpoints', () => ({
   ),
   markScopeDownloadComplete: vi.fn().mockResolvedValue(undefined),
   isScopeDownloadComplete: vi.fn().mockResolvedValue(false),
+  markScopeDownloadStarted: vi.fn().mockResolvedValue(undefined),
+  isScopeDownloadStarted: vi.fn().mockResolvedValue(false),
   rewindDeletionsCheckpoint: vi.fn().mockResolvedValue(undefined),
   compareCheckpoints: vi.fn().mockReturnValue(0),
   DELETIONS_CHECKPOINT_KEY: 'checkpoint:deletions',

--- a/packages/shared/offline-sync/src/sync/__tests__/scope-teardown.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/scope-teardown.test.ts
@@ -227,6 +227,10 @@ describe('removeBoardScopeData — markers', () => {
       '1',
     ]);
     await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      `scope-started:${scopeKey}`,
+      '1',
+    ]);
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
       `bootstrap-attempts:${scopeKey}`,
       '2',
     ]);
@@ -307,6 +311,9 @@ describe('removeBoardScopeData — markers', () => {
         'checkpoint:board_climb_stats:kilter:1:5',
         'checkpoint:board_climb_grades:kilter:1:5',
         'scope-complete:kilter:1:5',
+        // Its Started twin: leaving this behind would drop a re-added board out
+        // of the download funnel forever (issue #4316).
+        'scope-started:kilter:1:5',
         'bootstrap-attempts:kilter:1:5',
         'bootstrap-attempts-healed:kilter:1:5',
         'bootstrap-done:kilter:1:5',

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -2747,6 +2747,36 @@ describe('pullSync onScopeDownloadStart', () => {
     expect(typeof info.importMs).toBe('number');
   });
 
+  it('stays SILENT for a board that already finished downloading before the marker existed', async () => {
+    // The upgrade case, and the one that would wreck the first weeks of funnel
+    // data: every board already downloaded on the device has a `scope-complete:`
+    // marker and no `scope-started:` one. It cannot emit Completed again (that
+    // event is once-ever too), so an unguarded Started here would show up as one
+    // phantom abandoned download per board, on every upgrading device at once.
+    const seed = vi.fn();
+    const { fetch } = makeGraphqlFetch();
+    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], onScopeDownloadStart: seed });
+    expect(seed).toHaveBeenCalledTimes(1);
+    // Roll the device back to the pre-#4316 state: complete, never "started".
+    await db.runAsync('DELETE FROM sync_meta WHERE key = ?', ['scope-started:kilter:1:5']);
+
+    const onScopeDownloadStart = vi.fn();
+    const onScopeDownloadComplete = vi.fn();
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      onScopeDownloadStart,
+      onScopeDownloadComplete,
+    });
+
+    expect(onScopeDownloadStart).not.toHaveBeenCalled();
+    expect(onScopeDownloadComplete).not.toHaveBeenCalled();
+    // The marker is still written, so the scope is settled rather than
+    // re-evaluated on every future cycle.
+    expect(
+      await db.getFirstAsync('SELECT key FROM sync_meta WHERE key = ?', ['scope-started:kilter:1:5']),
+    ).not.toBeNull();
+  });
+
   it('omits the payload props on a paged completion, rather than reporting zeroes', async () => {
     // The engine has nothing honest to say about work it did not do.
     const onScopeDownloadComplete = vi.fn();

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -33,6 +33,7 @@ import {
   MAX_TRANSPORT_DOWNLOAD_FAILURES,
 } from '../bootstrap-retry';
 import { getCheckpoint, setCheckpoint, DELETIONS_CHECKPOINT_KEY } from '../checkpoints';
+import { removeBoardScopeData } from '../scope-teardown';
 import { runMigrations, LATEST_SCHEMA_VERSION } from '../../db/migrations';
 import { ensureMutationQueueTable } from '../../mutation-queue/schema';
 import { setSigningOut, setBackgrounded, __resetDrainerStateForTests } from '../../mutation-queue/drainer';
@@ -2599,5 +2600,165 @@ describe('pullSync bootstrap progress frames', () => {
     const frameCountAfterSync = collector.frames.length;
     lateEmit!();
     expect(collector.frames).toHaveLength(frameCountAfterSync);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// download-funnel Started anchor (issue #4316)
+// ---------------------------------------------------------------------------
+
+describe('pullSync onScopeDownloadStart', () => {
+  it('fires once with pathIntent snapshot and the artifact size for a fresh snapshot scope', async () => {
+    const filePath = join(workDir, 'started-snapshot.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const entry = makeEntry({ bytes: 103_000_000 });
+    const source = makeSnapshotSource({ manifest: makeManifest([entry]), fileForEntry: () => filePath });
+    const onScopeDownloadStart = vi.fn();
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onScopeDownloadStart,
+    });
+
+    expect(onScopeDownloadStart).toHaveBeenCalledTimes(1);
+    expect(onScopeDownloadStart).toHaveBeenCalledWith({
+      scopeKey: 'kilter:1:5',
+      pathIntent: 'snapshot',
+      // On Started specifically, because an ABANDONED download never emits
+      // Completed — without this the size of the downloads people give up on
+      // would be unknowable.
+      artifactBytes: 103_000_000,
+    });
+  });
+
+  it('fires once with pathIntent paged for a build with no snapshot source', async () => {
+    const onScopeDownloadStart = vi.fn();
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], onScopeDownloadStart });
+
+    expect(onScopeDownloadStart).toHaveBeenCalledTimes(1);
+    expect(onScopeDownloadStart).toHaveBeenCalledWith({
+      scopeKey: 'kilter:1:5',
+      pathIntent: 'paged',
+      artifactBytes: null,
+    });
+  });
+
+  it('DOES fire for a scope that already has a board checkpoint — the resumed multi-cycle crawl', async () => {
+    // This is the population the funnel most needs and the naive design dropped:
+    // a paged crawl writes a checkpoint on its FIRST page, and runBootstrapPhase
+    // treats any checkpoint as ineligible and skips the scope entirely.
+    await setCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5', { updatedAt: '2026-01-01T00:00:00Z', syncSeq: '5' });
+    const source = makeSnapshotSource({
+      manifest: makeManifest([makeEntry()]),
+      fileForEntry: () => join(workDir, 'never.db'),
+    });
+    const onScopeDownloadStart = vi.fn();
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onScopeDownloadStart,
+    });
+
+    expect(onScopeDownloadStart).toHaveBeenCalledTimes(1);
+    expect(onScopeDownloadStart.mock.calls[0][0].pathIntent).toBe('paged');
+  });
+
+  it('does NOT fire a second time on the next cycle, nor after a failed bootstrap retries', async () => {
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), downloadThrows: true });
+    const onScopeDownloadStart = vi.fn();
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onScopeDownloadStart,
+    });
+    expect(onScopeDownloadStart).toHaveBeenCalledTimes(1);
+
+    // A retry cycle: the download fails again and the scope is attempted afresh.
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onScopeDownloadStart,
+    });
+    expect(onScopeDownloadStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires again after scope teardown clears the marker, so a re-added board re-enters the funnel', async () => {
+    const onScopeDownloadStart = vi.fn();
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], onScopeDownloadStart });
+    expect(onScopeDownloadStart).toHaveBeenCalledTimes(1);
+
+    await removeBoardScopeData({
+      db,
+      scope: { boardType: 'kilter', layoutId: 1, sizeId: 5 },
+      scopeKey: 'kilter:1:5',
+      retainedScopes: [],
+    });
+
+    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], onScopeDownloadStart });
+    expect(onScopeDownloadStart).toHaveBeenCalledTimes(2);
+  });
+
+  it('carries bytes/rowCount/downloadMs/importMs on Completed when the import ran this cycle', async () => {
+    const filePath = join(workDir, 'complete-props.db');
+    buildArtifact({
+      filePath,
+      climbs: [
+        { uuid: 'c1', compatibleSizeIds: [5] },
+        { uuid: 'c2', compatibleSizeIds: [5] },
+      ],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const source = makeSnapshotSource({
+      manifest: makeManifest([makeEntry({ bytes: 103_000_000 })]),
+      fileForEntry: () => filePath,
+    });
+    const onScopeDownloadComplete = vi.fn();
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onScopeDownloadComplete,
+    });
+
+    const info = onScopeDownloadComplete.mock.calls[0][0];
+    expect(info.method).toBe('snapshot');
+    expect(info.bytes).toBe(103_000_000);
+    expect(info.rowCount).toBe(3); // two climbs + one stats row
+    expect(typeof info.downloadMs).toBe('number');
+    expect(typeof info.importMs).toBe('number');
+  });
+
+  it('omits the payload props on a paged completion, rather than reporting zeroes', async () => {
+    // The engine has nothing honest to say about work it did not do.
+    const onScopeDownloadComplete = vi.fn();
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], onScopeDownloadComplete });
+
+    const info = onScopeDownloadComplete.mock.calls[0][0];
+    expect(info.method).toBe('paged');
+    expect(info.bytes).toBeUndefined();
+    expect(info.rowCount).toBeUndefined();
+    expect(info.downloadMs).toBeUndefined();
+    expect(info.importMs).toBeUndefined();
   });
 });

--- a/packages/shared/offline-sync/src/sync/checkpoints.ts
+++ b/packages/shared/offline-sync/src/sync/checkpoints.ts
@@ -105,6 +105,42 @@ export async function isScopeDownloadComplete(db: SqlExecutor, scopeKey: string)
 }
 
 /**
+ * The Started half of the download funnel (issue #4316) — the exact mirror of
+ * SCOPE_COMPLETE_PREFIX above, and durable for the same reason.
+ *
+ * Without a marker, Started is neither an upper nor a lower bound on the
+ * completion rate, and it fails in BOTH directions. A paged crawl that spans
+ * cycles writes a board-table checkpoint on its first page, and
+ * `runBootstrapPhase` treats any existing checkpoint as ineligible — so the
+ * slow, most-likely-abandoned population would emit Completed with no Started at
+ * all. Meanwhile a snapshot scope that fails and retries would emit one Started
+ * per cycle. The marker makes it once-ever per scope per download lifecycle,
+ * matching what `wasScopeComplete` already gives Completed, so Started →
+ * Completed is a real ratio.
+ *
+ * Same lifecycle rules as the completion marker, for the same reasons: NOT under
+ * the `checkpoint:` prefix, so the sign-out wipe leaves it alone (matching the
+ * board rows, which survive as a shared cache), and package-internal so
+ * scope-teardown can clear it in the same transaction as those rows — removing
+ * and re-adding a board must start a fresh funnel.
+ */
+export const SCOPE_STARTED_PREFIX = 'scope-started:';
+
+export async function markScopeDownloadStarted(db: SqlExecutor, scopeKey: string): Promise<void> {
+  await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+    `${SCOPE_STARTED_PREFIX}${scopeKey}`,
+    '1',
+  ]);
+}
+
+export async function isScopeDownloadStarted(db: SqlExecutor, scopeKey: string): Promise<boolean> {
+  const row = await db.getFirstAsync<{ key: string }>('SELECT key FROM sync_meta WHERE key = ?', [
+    `${SCOPE_STARTED_PREFIX}${scopeKey}`,
+  ]);
+  return row !== null;
+}
+
+/**
  * The encoded board scope keys ("boardType:layoutId:sizeId") whose initial
  * download completed — both reference tables pulled to the tail. Used by the
  * My Boards UI as the per-scope "available offline" signal (a completed

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -1585,6 +1585,15 @@ export async function pullSync(
   const emitScopeDownloadStartOnce = async (info: ScopeDownloadStartInfo): Promise<void> => {
     if (await isScopeDownloadStarted(db, info.scopeKey)) return;
     await markScopeDownloadStarted(db, info.scopeKey);
+    // BACKFILL, NOT A START. A scope whose download already completed — every
+    // board on a device that upgrades into this build — is not starting one now,
+    // and it can never emit Completed again either (that event is guarded by the
+    // `scope-complete:` marker it already carries). Emitting here would give the
+    // funnel one unmatched Started per already-downloaded board on the first
+    // cycle after release: a phantom abandonment spike, in exactly the window
+    // the baseline is read from. Write the marker (so this is still once-ever)
+    // and stay silent.
+    if (await isScopeDownloadComplete(db, info.scopeKey)) return;
     options?.onScopeDownloadStart?.(info);
   };
   // Per-scope payload size and stage timings, recorded by the bootstrap phase and

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -7,6 +7,8 @@ import {
   getCheckpointKey,
   markScopeDownloadComplete,
   isScopeDownloadComplete,
+  markScopeDownloadStarted,
+  isScopeDownloadStarted,
   DELETIONS_CHECKPOINT_KEY,
 } from './checkpoints';
 import { markUserDataComplete } from './local-user-owner';
@@ -123,8 +125,49 @@ export type ScopeDownloadCompleteInfo = {
   durationMs: number;
   /** The snapshot import landed on a scope that had already crawled some rows. */
   bootstrapHealed?: boolean;
+  /**
+   * Wire size of the artifact this scope imported, and the rows it actually
+   * wrote (issue #4316) — what a slow download has to be normalised against
+   * before "Kilter is slow" means anything.
+   *
+   * All four are ABSENT rather than faked when the completing delta pull lands
+   * in a LATER cycle than the import (the dropped-connection tail), because this
+   * run has no record of work it did not do. That biases these props toward the
+   * healthy population; `durationMs`, `method`, and the Started→Completed ratio
+   * itself are unaffected.
+   */
+  bytes?: number;
+  rowCount?: number;
+  downloadMs?: number;
+  importMs?: number;
 };
 export type ScopeDownloadCompleteReporter = (info: ScopeDownloadCompleteInfo) => void;
+
+/**
+ * Fired ONCE EVER per board scope, the first time any cycle starts pulling it —
+ * the missing anchor that makes abandonment measurable (issue #4316). Guarded by
+ * a durable `scope-started:` marker, the mirror of the `scope-complete:` one, so
+ * a retrying snapshot cannot emit twice and a multi-cycle paged crawl cannot be
+ * skipped. Both markers are cleared by scope teardown, so removing and re-adding
+ * a board starts a fresh funnel.
+ *
+ * `pathIntent` is an INTENT decided from cheap local facts at emission time, not
+ * an outcome: a scope that looks snapshot-eligible can still fall back to the
+ * paged crawl after the manifest resolves. Funnel splits by resolved path must
+ * use Completed's `method`; reading `pathIntent` as ground truth would overstate
+ * the snapshot population.
+ *
+ * `artifactBytes` is the wire size of the artifact about to be downloaded, and
+ * is null on the paged path (a crawl has no byte total at all). It is on Started
+ * precisely because an ABANDONED download never emits Completed — without it,
+ * the size of the downloads people give up on is unknowable.
+ */
+export type ScopeDownloadStartInfo = {
+  scopeKey: string;
+  pathIntent: 'snapshot' | 'paged';
+  artifactBytes: number | null;
+};
+export type ScopeDownloadStartReporter = (info: ScopeDownloadStartInfo) => void;
 
 /**
  * Fired after one bootstrap scope reaches a coherent persisted decision (or is
@@ -246,6 +289,7 @@ export type SyncOptions = {
   onBootstrapMetadataChanged?: BootstrapMetadataChangedReporter;
   /** Telemetry for comparing the snapshot vs paged download paths. See ScopeDownloadCompleteInfo. */
   onScopeDownloadComplete?: ScopeDownloadCompleteReporter;
+  onScopeDownloadStart?: ScopeDownloadStartReporter;
   /** Telemetry for a forced deletions-coverage resync. See CoverageResetInfo. */
   onCoverageReset?: CoverageResetReporter;
   /**
@@ -802,11 +846,27 @@ async function runBootstrapPhase(params: {
   /** The epoch pullSync captured at CYCLE start — see `cycleAborted` there. */
   cycleEpoch: number;
   stampScopeStart: (scopeKey: string) => void;
+  /** Once-ever Started emitter, shared with the board-data loop (issue #4316). */
+  emitScopeDownloadStartOnce: (info: ScopeDownloadStartInfo) => Promise<void>;
+  /** Per-scope download/import timings + payload size, read back by the Completed event. */
+  bootstrapTimings: Map<string, { bytes: number; downloadMs?: number; importMs?: number; rowCount?: number }>;
   options: SyncOptions | undefined;
   now: () => number;
   random: () => number;
 }): Promise<{ skipPagedPull: Set<string> }> {
-  const { db, queryClient, source, scopes, cycleEpoch, stampScopeStart, options, now, random } = params;
+  const {
+    db,
+    queryClient,
+    source,
+    scopes,
+    cycleEpoch,
+    stampScopeStart,
+    emitScopeDownloadStartOnce,
+    bootstrapTimings,
+    options,
+    now,
+    random,
+  } = params;
   const onProgress = options?.onProgress;
   const onSchemaDrift = options?.onSchemaDrift;
   const onSnapshotBootstrapError = options?.onSnapshotBootstrapError;
@@ -1063,6 +1123,21 @@ async function runBootstrapPhase(params: {
           });
         }
 
+        // Started (issue #4316), the snapshot half. Emitted HERE — below every
+        // `continue` that means this scope does no snapshot work this cycle, and
+        // once the entry proved usable — so it can carry the artifact's wire
+        // size, which is the one thing an ABANDONED download never gets to
+        // report (it emits no Completed at all). The durable marker makes the
+        // board-data loop's emission below a no-op for this scope; every path
+        // that `continue`s above (including the metered heal defer) reaches that
+        // one instead and is correctly attributed to the paged crawl.
+        await emitScopeDownloadStartOnce({
+          scopeKey: scope.scopeKey,
+          pathIntent: 'snapshot',
+          artifactBytes: entry.bytes,
+        });
+        if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) break;
+
         const layoutKey = `${scope.boardType}:${scope.layoutId}`;
         // The failure cause is cached alongside the result so a second size of the
         // same layout (which reuses this entry instead of re-downloading) still
@@ -1074,6 +1149,7 @@ async function runBootstrapPhase(params: {
           // reuses this cache entry, so it never re-runs and never re-emits
           // download frames for bytes that already came down.
           let fractionAnchor: DownloadFractionAnchor = createDownloadFractionAnchor();
+          const downloadStartedAt = Date.now();
           emitSnapshotFrame(
             progressThrottle.flush({
               scopeKey: scope.scopeKey,
@@ -1110,6 +1186,12 @@ async function runBootstrapPhase(params: {
           }
           downloadByLayout.set(layoutKey, cachedDownload);
           if (cachedDownload.file) downloadedPaths.add(cachedDownload.file.filePath);
+          if (cachedDownload.file) {
+            bootstrapTimings.set(scope.scopeKey, {
+              bytes: entry.bytes,
+              downloadMs: Date.now() - downloadStartedAt,
+            });
+          }
         }
         // Re-check after the (potentially multi-MB) artifact download await, same
         // reason as the manifest check above.
@@ -1170,7 +1252,8 @@ async function runBootstrapPhase(params: {
           // the global deletions cursor to the older table watermark — all in one
           // transaction, so no crash point can separate the imported rows from
           // the tombstone-replay window that must cover them.
-          await bootstrapScopeFromSnapshot({
+          const importStartedAt = Date.now();
+          const imported = await bootstrapScopeFromSnapshot({
             db,
             scope,
             scopeKey: scope.scopeKey,
@@ -1181,6 +1264,12 @@ async function runBootstrapPhase(params: {
             existingCheckpoints: hasBoardCheckpoint
               ? { board_climbs: climbsCheckpoint ?? undefined, board_climb_stats: statsCheckpoint ?? undefined }
               : undefined,
+          });
+          const timings = bootstrapTimings.get(scope.scopeKey) ?? { bytes: entry.bytes };
+          bootstrapTimings.set(scope.scopeKey, {
+            ...timings,
+            importMs: Date.now() - importStartedAt,
+            rowCount: imported.climbsImported + imported.statsImported,
           });
           // The heal flag rides the persisted marker, not a per-cycle set: the
           // scope usually reaches completion in a LATER cycle (board_climb_grades
@@ -1489,6 +1578,23 @@ export async function pullSync(
     if (!scopeStartedAt.has(scopeKey)) scopeStartedAt.set(scopeKey, Date.now());
   };
 
+  // Download-funnel Started (issue #4316). Once ever per scope, guarded by the
+  // durable `scope-started:` marker rather than by anything cycle-local, so a
+  // snapshot that fails and retries emits one event and a paged crawl that spans
+  // cycles is not skipped. Both are how the naive in-cycle version broke.
+  const emitScopeDownloadStartOnce = async (info: ScopeDownloadStartInfo): Promise<void> => {
+    if (await isScopeDownloadStarted(db, info.scopeKey)) return;
+    await markScopeDownloadStarted(db, info.scopeKey);
+    options?.onScopeDownloadStart?.(info);
+  };
+  // Per-scope payload size and stage timings, recorded by the bootstrap phase and
+  // read back by Completed below. Run-local on purpose: a cycle that did not do
+  // the import has nothing honest to report (see ScopeDownloadCompleteInfo).
+  const bootstrapTimings = new Map<
+    string,
+    { bytes: number; downloadMs?: number; importMs?: number; rowCount?: number }
+  >();
+
   // Phase 0: snapshot bootstrap (BEFORE deletions). Only when an adapter injected
   // snapshot I/O; otherwise this is a pure paged pull, byte-identical to before.
   let skipBootstrapPagedPull: Set<string> = new Set();
@@ -1501,6 +1607,8 @@ export async function pullSync(
       scopes: boardScopes,
       cycleEpoch,
       stampScopeStart,
+      emitScopeDownloadStartOnce,
+      bootstrapTimings,
       options,
       now: options.now ?? Date.now,
       random: options.random ?? Math.random,
@@ -1565,6 +1673,14 @@ export async function pullSync(
     // No-op when the bootstrap phase already stamped this scope; the paged-only
     // path (no snapshotSource) starts its duration clock here.
     stampScopeStart(scopeKey);
+    // Started (issue #4316), the paged half — and the catch-all. Every scope
+    // reaches this line on every path: a build with no snapshot source, a scope
+    // the bootstrap phase found ineligible or unexportable, and the resumed
+    // multi-cycle crawl the checkpoint gate above skips. A scope the bootstrap
+    // phase already announced is a no-op here thanks to the durable marker, so
+    // it keeps its 'snapshot' intent and its artifact size.
+    await emitScopeDownloadStartOnce({ scopeKey, pathIntent: 'paged', artifactBytes: null });
+    if (cycleAborted()) return;
     // A scope whose bootstrap failed this cycle (with attempts still left) skips
     // its paged pull: a first-page checkpoint would permanently disqualify the
     // snapshot path, so the next cycle retries the snapshot instead.
@@ -1618,6 +1734,7 @@ export async function pullSync(
       // cycles (connectivity drop between them, or the grades crawl still
       // running), and this event fires exactly once per scope — misreporting
       // that one event would permanently skew the rollout comparison.
+      const timings = bootstrapTimings.get(scopeKey);
       options?.onScopeDownloadComplete?.({
         scopeKey,
         method: (await isBootstrapDone(db, scopeKey)) ? 'snapshot' : 'paged',
@@ -1625,6 +1742,9 @@ export async function pullSync(
         // A healed scope's duration excludes the paged work earlier cycles did,
         // so it must be filtered out of snapshot-vs-paged comparisons.
         bootstrapHealed: await wasBootstrapHealed(db, scopeKey),
+        // Spread rather than set explicitly: absent when this cycle did not do
+        // the import, which is the honest answer (see ScopeDownloadCompleteInfo).
+        ...timings,
       });
     }
   }

--- a/packages/shared/offline-sync/src/sync/scope-teardown.ts
+++ b/packages/shared/offline-sync/src/sync/scope-teardown.ts
@@ -4,8 +4,8 @@
 //
 // Two invariants carry this whole module, and both are data-loss bugs when broken:
 //
-// 1. ROWS AND THEIR MARKERS DIE TOGETHER. A scope's downloaded state lives in seven
-//    kinds of sync_meta rows (see scopeSyncMetaKeys). If rows are deleted but a
+// 1. ROWS AND THEIR MARKERS DIE TOGETHER. A scope's downloaded state lives in a
+//    handful of sync_meta row kinds (see scopeSyncMetaKeys). If rows are deleted but a
 //    checkpoint survives, the next pull resumes from that cursor and — because the
 //    delta pull is a strict `>` keyset — NEVER revisits the deleted rows. The board
 //    comes back permanently incomplete, and a surviving `scope-complete:` marker
@@ -31,7 +31,7 @@ import type { OfflineDatabase, SqlExecutor, SqlValue } from '../database';
 import { applyBusyTimeout } from '../db/pragmas';
 import type { OfflineBoardScope } from '../offline-board-key';
 import { climbsScopeFilter, isSizeScopedBoard, sizeMembershipClause } from './board-scope-sql';
-import { getCheckpointKey, SCOPE_COMPLETE_PREFIX } from './checkpoints';
+import { getCheckpointKey, SCOPE_COMPLETE_PREFIX, SCOPE_STARTED_PREFIX } from './checkpoints';
 import { BOOTSTRAP_DONE_PREFIX } from './snapshot-bootstrap';
 import {
   BOOTSTRAP_ATTEMPTS_HEALED_PREFIX,
@@ -69,6 +69,10 @@ export function scopeSyncMetaKeys(scopeKey: string): string[] {
   return [
     ...BOARD_DATA_TABLES.map((tableName) => getCheckpointKey(tableName, scopeKey)),
     `${SCOPE_COMPLETE_PREFIX}${scopeKey}`,
+    // Its Started twin (issue #4316). Both must die with the rows: leaving the
+    // Started marker behind would silently drop a re-added board out of the
+    // funnel forever — its next download would emit Completed with no Started.
+    `${SCOPE_STARTED_PREFIX}${scopeKey}`,
     `${BOOTSTRAP_ATTEMPTS_PREFIX}${scopeKey}`,
     // Belongs with the attempts row it bounds: re-adding the board must give the
     // scope a clean counter AND a fresh heal budget, not one that was spent

--- a/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
@@ -127,6 +127,15 @@ export type SnapshotBootstrapErrorReporter = (report: {
 export type SnapshotBootstrapResult = {
   climbsWatermark: SyncCheckpoint;
   statsWatermark: SyncCheckpoint;
+  /**
+   * Rows this scope actually imported out of the layout artifact (issue #4316).
+   * Both are INSERT OR REPLACE `changes` counts, so a re-import of the same
+   * scope reports the same numbers rather than zero — they measure the work
+   * done, not the net row growth. Reported on the download-funnel's Completed
+   * event so a slow download can be normalised against payload size.
+   */
+  climbsImported: number;
+  statsImported: number;
 };
 
 /**
@@ -515,7 +524,7 @@ async function importScope(
   txn: SqlExecutor,
   scope: OfflineBoardScope,
   onSchemaDrift: SchemaDriftReporter | undefined,
-): Promise<void> {
+): Promise<{ climbsImported: number; statsImported: number }> {
   const climbColumns = await sharedColumns(txn, 'board_climbs', onSchemaDrift);
   const statsColumns = await sharedColumns(txn, 'board_climb_stats', onSchemaDrift);
   assertSafeColumns(climbColumns);
@@ -525,7 +534,7 @@ async function importScope(
 
   const climbScope = climbsScopeFilter(scope);
   const climbList = climbColumns.join(', ');
-  await txn.runAsync(
+  const climbsResult = await txn.runAsync(
     `INSERT OR REPLACE INTO main.board_climbs (${climbList})
      SELECT ${climbList} FROM ${SNAPSHOT_ALIAS}.board_climbs WHERE ${climbScope.sql}`,
     climbScope.params,
@@ -541,7 +550,7 @@ async function importScope(
     : '';
   const statsParams: (string | number)[] = [scope.boardType, scope.boardType, scope.layoutId];
   if (sizeScoped) statsParams.push(scope.sizeId);
-  await txn.runAsync(
+  const statsResult = await txn.runAsync(
     `INSERT OR REPLACE INTO main.board_climb_stats (${statsList})
      SELECT ${statsList} FROM ${SNAPSHOT_ALIAS}.board_climb_stats s
      WHERE s.board_type = ?
@@ -551,6 +560,8 @@ async function importScope(
        )`,
     statsParams,
   );
+
+  return { climbsImported: climbsResult.changes, statsImported: statsResult.changes };
 }
 
 // --- Verification -------------------------------------------------------------
@@ -689,6 +700,7 @@ export async function bootstrapScopeFromSnapshot(params: {
   const startEpoch = getWipeEpoch();
 
   let watermarks: Record<SnapshotTableName, SyncCheckpoint> | null = null;
+  let imported = { climbsImported: 0, statsImported: 0 };
   try {
     await db.withExclusiveTransactionAsync(async (txn) => {
       // Close the wrapper's (empty, deferred) transaction so ATTACH is legal,
@@ -734,7 +746,7 @@ export async function bootstrapScopeFromSnapshot(params: {
       }
 
       await reconcileScope(txn, scope, watermarks);
-      await importScope(txn, scope, onSchemaDrift);
+      imported = await importScope(txn, scope, onSchemaDrift);
 
       // Re-check after the (awaited) imports: abort before committing any rows or
       // checkpoints if a wipe landed while they ran.
@@ -765,5 +777,9 @@ export async function bootstrapScopeFromSnapshot(params: {
   // Unreachable null: the transaction either set watermarks or threw.
   if (!watermarks) throw new Error('snapshot bootstrap: transaction completed without watermarks');
   const finalWatermarks: Record<SnapshotTableName, SyncCheckpoint> = watermarks;
-  return { climbsWatermark: finalWatermarks.board_climbs, statsWatermark: finalWatermarks.board_climb_stats };
+  return {
+    climbsWatermark: finalWatermarks.board_climbs,
+    statsWatermark: finalWatermarks.board_climb_stats,
+    ...imported,
+  };
 }

--- a/packages/shared/offline-sync/src/sync/sync-scheduler.ts
+++ b/packages/shared/offline-sync/src/sync/sync-scheduler.ts
@@ -5,6 +5,7 @@ import {
   type SchemaDriftReporter,
   type BootstrapMetadataChangedReporter,
   type ScopeDownloadCompleteReporter,
+  type ScopeDownloadStartReporter,
   type CoverageResetReporter,
   type CoverageEvaluatedReporter,
   type BootstrapRetryScheduledReporter,
@@ -73,6 +74,7 @@ export type SchedulerOptions = {
   onBootstrapMetadataChanged?: BootstrapMetadataChangedReporter;
   /** Threaded through to pullSync's SyncOptions — see ScopeDownloadCompleteInfo. */
   onScopeDownloadComplete?: ScopeDownloadCompleteReporter;
+  onScopeDownloadStart?: ScopeDownloadStartReporter;
   /** Threaded through to pullSync's SyncOptions — see CoverageResetInfo. */
   onCoverageReset?: CoverageResetReporter;
   /** Threaded through to pullSync's SyncOptions — see CoverageEvaluatedInfo. */
@@ -126,6 +128,7 @@ async function runSync(
       onSnapshotBootstrapError: options?.onSnapshotBootstrapError,
       onBootstrapMetadataChanged: options?.onBootstrapMetadataChanged,
       onScopeDownloadComplete: options?.onScopeDownloadComplete,
+      onScopeDownloadStart: options?.onScopeDownloadStart,
       onCoverageReset: options?.onCoverageReset,
       onCoverageEvaluated: options?.onCoverageEvaluated,
       onBootstrapRetryScheduled: options?.onBootstrapRetryScheduled,


### PR DESCRIPTION
Third of three stacked PRs for the offline download work. **Base: `feat/4311-download-progress`** (PR2, now #4355 — #4336 was auto-closed when #4335 merged and its base branch was deleted).

## Why

Offline board downloads shipped with **exactly one** analytics event: `Offline Board Download Completed`, carrying `{ scopeKey, method, durationMs }`.

With no start anchor, abandonment is structurally unmeasurable — a download the climber gives up on emits nothing at all, so the one number everyone wants (what fraction of downloads finish?) has no denominator. Failures go only to Sentry, which groups by exception shape rather than by scope and deliberately downgrades transport errors. Toggling a board on or off emits nothing, and neither does the "download all my boards" switch. And completion carries no size, so Kilter's p50 2m55s can't be normalised against payload.

## Changes

Five new `SHARED_EVENTS` entries — Started, Failed, Cancelled, Toggled, Download-All-Tapped — plus `bytes` / `rowCount` / `downloadMs` / `importMs` on Completed.

### The once-ever contract

Started and Completed are each guarded by a **durable** `sync_meta` marker. `scope-started:` mirrors the existing `scope-complete:` line for line: package-internal, outside the `checkpoint:` prefix (so sign-out leaves it alone, matching the board rows that survive as a shared cache), and cleared by `scope-teardown.ts` in the same transaction as those rows, so re-adding a board starts a fresh funnel.

So the funnel query is just Started → Completed, with no first-occurrence de-duplication.

This is the part a naive per-cycle Started gets wrong, **in both directions**:

- A paged crawl writes a board-table checkpoint on its **first page**, and `runBootstrapPhase` treats any existing checkpoint as ineligible and skips the scope. A Started gated on "no checkpoint yet" would emit **nothing at all** for multi-cycle crawls — precisely the slow population most likely to be abandoned.
- A snapshot scope that fails and retries would emit **one Started per cycle**.

Emission sits at two places: just before the artifact download (so it can carry the artifact's wire size), and at the top of the board-data loop, which every scope reaches on every path — paged-only builds, bootstrap-ineligible scopes, resumed crawls. The marker makes the second a no-op after the first.

### Trigger attribution, and why the split matters

`trigger` separates deliberate taps from automatic re-enables, because that's what #4318's discovery nudges will be measured against — and lumping the two together under a name that asserts a tap happened would make that measurement meaningless.

`Offline Download All Tapped` fires from the real `onValueChange` in More, **once per tap** (not once per board), using the `missingOfflineBoards().length` that handler already computes for its toast. It is deliberately **not** fired by the mount effect that re-enables boards from the persisted `autoOfflineBoards` setting — that effect also runs on a plain app launch with the setting already on; those boards report `trigger: 'auto-download-all'` instead. Adopt splits the same way: `adopt-auto` (the setting acting alone) vs `adopt-confirmed`.

Full vocabulary: `toggle` | `download-all` | `auto-download-all` | `adopt-auto` | `adopt-confirmed` | `retry` | `unknown`. These names are permanent once shipped, so the auto-vs-deliberate line had to be right on day one.

The attribution is **persisted per scope**, not held in an in-memory map, because the case that matters most is a board enabled with no signal whose download runs on a later launch — an in-memory map loses exactly that one, and never prunes. It's consumed (and pruned) when Started fires, and dropped when the board is removed. Absent reads as `'unknown'`, an explicit documented value rather than an accident.

### Honest absence over faked zeroes

`bytes` / `rowCount` / `downloadMs` / `importMs` live in a run-local map, so they are **absent** — never zeroed — when the completing delta pull lands in a later cycle than the import (the dropped-connection tail). That biases those four toward the healthy population, which is documented; `durationMs`, `method`, and the funnel ratio itself are unaffected. `artifactBytes` rides on **Started** specifically because an abandoned download never reaches Completed, so without it the size of the downloads people give up on would be unknowable.

`pathIntent` on Started is an INTENT from cheap local facts, not an outcome — a snapshot-eligible scope can still fall back to the paged crawl after the manifest resolves. Split by resolved path using Completed's `method`; the doc comment says so, and so does `docs/board-snapshots.md`.

### Also

- `Offline Board Download Failed` is fired from the **same call site** as the existing Sentry report, so the two can never disagree about whether a failure happened. The `expected` transport downgrade in Sentry is untouched.
- `Offline Board Download Cancelled` fires when a board is switched off while its first download is in flight, reading the live progress frame *before* the setting write so it can carry stage/fraction/bytes.
- Every event carries `offlineEngineEnabled` from `isOfflineEngineEnabled()` rather than the raw flag, so the funnel stays readable once #4312 bakes the flag on.
- A vitest stub for `react-native-mmkv`: its react-native Flow entry throws `SyntaxError: Unexpected token 'typeof'` under vitest's node env, and the settings store binds an instance at module load — so any suite transitively reaching `src/settings` (now including the offline adapter) would die before a single test ran. Same alias pattern as the existing netinfo / posthog / paper stubs.

## Note for #3621 (delete offline data on logout)

The `scope-started:` and `scope-complete:` markers deliberately **survive sign-out**, matching the board rows. If #3621 starts deleting those rows on logout, it must clear both markers in the same transaction — otherwise the next sign-in emits Completed with no Started. Called out in `docs/board-snapshots.md`'s new "Download funnel events" section, which also lists every event, its props, the marker semantics, and how to read `pathIntent` vs `method`.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project offline-sync --reporter=agent` — 375 passed. New cases: Started fires once with `pathIntent: 'snapshot'` + the artifact size for a fresh snapshot scope; once with `'paged'` for a build with no snapshot source; **does** fire for a scope that already has a board checkpoint (the resumed multi-cycle crawl the naive design dropped); does **not** fire a second time on the next cycle or after a failed bootstrap retries; fires again after scope teardown clears the marker. Completed carries `bytes`/`rowCount`/`downloadMs`/`importMs` same-cycle and omits them on a paged completion. `scope-teardown.test.ts` now pins the marker in its exact-key specification.
- `vp test run --project analytics --reporter=agent` — 23 passed.
- `vp run test:mobile` — 622 files / 5504 passed. New cases in `offline-sync-adapter.test.ts` (Started consumes and prunes the persisted trigger, reports `'unknown'` when absent, Failed reaches both the funnel and Sentry with the `expected` downgrade intact, Completed's optional props present and absent), `download-triggers.test.ts` (round-trip + prune, per-scope independence, most-recent-intent-wins, an unrecognised stored value degrades to `'unknown'` rather than splitting the funnel), `use-adopt-found-board.test.tsx` (`adopt-auto` vs `adopt-confirmed` are distinguishable).
- `vp run typecheck` — clean. `vp run check:mobile-bundle` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT6VP1sWqk6bY9mUgyeS2U


