### PR TITLE
fix(mobile): keep the board-art cache under its cap during long sessions (1/2)

### DIFF
--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -73,6 +73,7 @@ import { performOtaRecovery, type OtaRecoveryPhase } from '../src/lib/ota-recove
 import { loadRequiredFonts } from '../src/lib/required-fonts';
 import { loadSectionExpandState } from '../src/lib/section-expand-store';
 import { useImageCacheMemoryManagement } from '../src/hooks/use-image-cache-memory-management';
+import { useDiskCacheSweep } from '../src/hooks/use-disk-cache-sweep';
 import { AnalyticsProvider } from '../src/components/analytics/AnalyticsProvider';
 import { AnalyticsScreenTracker } from '../src/components/analytics/AnalyticsScreenTracker';
 import { ImageCacheTabSweeper } from '../src/components/ImageCacheTabSweeper';
@@ -429,6 +430,9 @@ function RootLayout() {
 
   // Flush decoded board-art bitmaps on background / memory warning (#3479).
   useImageCacheMemoryManagement();
+  // Keep the on-disk board-art cache under its cap DURING a session, not only on
+  // the cold launch the native pruner runs on (#3647).
+  useDiskCacheSweep();
 
   useEffect(() => {
     let cancelled = false;

--- a/packages/mobile/src/hooks/__tests__/use-disk-cache-sweep.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-disk-cache-sweep.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+//
+// When the disk sweep fires. The regression this file exists for is the
+// foreground leg: a launch + background pair reproduces the very blind spot the
+// issue names, because a session kept open for days never does either.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+const sweepBoardArtCache = vi.hoisted(() =>
+  vi.fn(() => Promise.resolve({ beforeBytes: 0, freedBytes: 0, filesDeleted: 0 })),
+);
+const sweepSnapshotLeftovers = vi.hoisted(() => vi.fn(() => Promise.resolve(0)));
+vi.mock('../../lib/sweep-caches', () => ({ sweepBoardArtCache, sweepSnapshotLeftovers }));
+
+// Capture the interaction callback so a test can decide whether the queue ever
+// drains — a starved queue is the case the fallback timer exists for.
+const interactions = vi.hoisted(() => {
+  const pending: (() => void)[] = [];
+  return {
+    pending,
+    runAfterInteractions: vi.fn((callback: () => void) => {
+      pending.push(callback);
+      return { cancel: vi.fn() };
+    }),
+    drain: () => {
+      for (const callback of pending.splice(0)) callback();
+    },
+  };
+});
+vi.mock('react-native', () => ({ InteractionManager: interactions }));
+
+const isBackgrounded = vi.hoisted(() => ({ value: false }));
+vi.mock('../../lib/app-visibility', () => ({ useIsAppBackgrounded: () => isBackgrounded.value }));
+
+const writeThresholdListener = vi.hoisted(() => ({ current: null as null | (() => void) }));
+vi.mock('../../lib/overlay-index', () => ({
+  onOverlayWriteThreshold: (_threshold: number, listener: () => void) => {
+    writeThresholdListener.current = listener;
+    return () => {
+      writeThresholdListener.current = null;
+    };
+  },
+}));
+
+import { useDiskCacheSweep } from '../use-disk-cache-sweep';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  sweepBoardArtCache.mockClear();
+  sweepSnapshotLeftovers.mockClear();
+  interactions.pending.length = 0;
+  interactions.runAfterInteractions.mockClear();
+  isBackgrounded.value = false;
+  writeThresholdListener.current = null;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useDiskCacheSweep', () => {
+  it('defers the launch sweep past the opening animation rather than blocking it', () => {
+    renderHook(() => useDiskCacheSweep());
+    expect(sweepBoardArtCache).not.toHaveBeenCalled();
+
+    act(() => interactions.drain());
+    expect(sweepBoardArtCache).toHaveBeenCalledWith({ trigger: 'launch' });
+    expect(sweepSnapshotLeftovers).toHaveBeenCalledTimes(1);
+  });
+
+  // `runAfterInteractions` can be starved indefinitely by a leaked handle, which
+  // would otherwise mean the sweep simply never runs on a busy launch.
+  it('still sweeps via the fallback timer when the interaction queue never drains', () => {
+    renderHook(() => useDiskCacheSweep());
+    act(() => {
+      vi.advanceTimersByTime(2_500);
+    });
+    expect(sweepBoardArtCache).toHaveBeenCalledWith({ trigger: 'launch' });
+  });
+
+  it('sweeps only once when both the queue and the fallback fire', () => {
+    renderHook(() => useDiskCacheSweep());
+    act(() => interactions.drain());
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+    expect(sweepBoardArtCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('sweeps on the transition to background, and not on the way back', () => {
+    const { rerender } = renderHook(() => useDiskCacheSweep());
+    act(() => interactions.drain());
+    sweepBoardArtCache.mockClear();
+
+    isBackgrounded.value = true;
+    rerender();
+    expect(sweepBoardArtCache).toHaveBeenCalledWith({ trigger: 'background' });
+
+    sweepBoardArtCache.mockClear();
+    isBackgrounded.value = false;
+    rerender();
+    expect(sweepBoardArtCache).not.toHaveBeenCalled();
+  });
+
+  // The leg that covers the actual failure mode: growth in a session that never
+  // backgrounds and never relaunches.
+  it('sweeps when the overlay write odometer crosses its threshold', () => {
+    renderHook(() => useDiskCacheSweep());
+    act(() => interactions.drain());
+    sweepBoardArtCache.mockClear();
+
+    act(() => writeThresholdListener.current?.());
+    expect(sweepBoardArtCache).toHaveBeenCalledWith({ trigger: 'write-threshold' });
+  });
+
+  it('unsubscribes the odometer on unmount', () => {
+    const { unmount } = renderHook(() => useDiskCacheSweep());
+    expect(writeThresholdListener.current).not.toBeNull();
+    unmount();
+    expect(writeThresholdListener.current).toBeNull();
+  });
+});

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render.test.ts
@@ -60,6 +60,8 @@ vi.mock('../../../modules/board-renderer/src/index', () => {
   throw new Error('Native module not available (simulated Expo Go)');
 });
 
+import { overlayNameMatchesScope } from '../../lib/cache-sweep-plan';
+
 const {
   buildCacheKey,
   buildBoardKey,
@@ -96,6 +98,18 @@ describe('buildCacheKey', () => {
     // style defaults to 's' (stroke-only / non-filled); width defaults to
     // 'full' (native board width, used by the play view).
     expect(key).toMatch(/^v\d+_s_wfull_kilter_1_10_24,25_[0-9a-f]{8}$/);
+  });
+
+  // The board-removal sweep (issue #3647) matches PNG names against an
+  // OfflineBoardScope's `boardType`, while the name itself carries `boardName`
+  // from here. They are the same string today; if that ever drifts, the sweep
+  // silently deletes nothing rather than failing loudly — so pin the identity
+  // against the real key builder rather than a hand-written filename.
+  it('produces a name the offline-scope sweep can match', () => {
+    const scope = { boardType: 'kilter', layoutId: 1, sizeId: 10 };
+    const name = `${buildCacheKey(scope.boardType, scope.layoutId, scope.sizeId, '24,25', 'p1r42', true, 400)}.png`;
+    expect(overlayNameMatchesScope(name, scope)).toBe(true);
+    expect(overlayNameMatchesScope(name, { ...scope, sizeId: 100 })).toBe(false);
   });
 
   it('defaults to the full-width token and switches to a numeric token when renderWidth is set', () => {

--- a/packages/mobile/src/hooks/use-disk-cache-sweep.ts
+++ b/packages/mobile/src/hooks/use-disk-cache-sweep.ts
@@ -1,0 +1,78 @@
+// When to sweep the on-disk board-art cache (issue #3647).
+//
+// The native modules already enforce a 200 MB cap, but behind a
+// once-per-module-lifetime gate — so it only ever runs on a cold launch. The
+// failure mode the issue names is the opposite of that: a session that stays in
+// the foreground and grows. This repo has already met that shape once, in
+// `useIpadTabSwitchImageCacheSweep`, written because "an iPad kept open for days
+// never backgrounds" (#3803, ~3.7 days uptime).
+//
+// So the trigger set is deliberately three-legged:
+//
+//   launch      — reclaims whatever the last session left, deferred past the
+//                 opening animation, WITH a fallback timer because
+//                 `runAfterInteractions` can be starved indefinitely (the same
+//                 reason use-deferred-after-interactions pairs the two).
+//   background  — the natural seam; costs the user nothing.
+//   writes      — the foreground leg the other two miss. The overlay index
+//                 counts writes and fires once per OVERLAY_WRITES_PER_SWEEP,
+//                 which tracks growth rather than the clock.
+//
+// Snapshot leftovers are swept once at launch only: they are orphaned by a kill,
+// so nothing new appears mid-session.
+
+import { useEffect, useRef } from 'react';
+import { InteractionManager } from 'react-native';
+import { useIsAppBackgrounded } from '../lib/app-visibility';
+import { OVERLAY_WRITES_PER_SWEEP } from '../lib/cache-sweep-plan';
+import { onOverlayWriteThreshold } from '../lib/overlay-index';
+import { sweepBoardArtCache, sweepSnapshotLeftovers, type CacheSweepTrigger } from '../lib/sweep-caches';
+import { reportHandledError } from '../lib/error-reporting';
+
+/** Matches use-deferred-after-interactions' fallback: a starved queue must not mean "never". */
+const LAUNCH_DEFER_FALLBACK_MS = 2_000;
+
+function runSweep(trigger: CacheSweepTrigger): void {
+  void sweepBoardArtCache({ trigger }).catch((error: unknown) => {
+    // A sweep is best-effort housekeeping. Worth knowing about if it fails
+    // persistently (the cap stops being enforced) but never worth a crash.
+    reportHandledError(error, { tags: { source: 'offline-sync', kind: 'cache-sweep' } });
+  });
+}
+
+export function useDiskCacheSweep(): void {
+  const isBackgrounded = useIsAppBackgrounded();
+  const hasSweptOnLaunch = useRef(false);
+
+  useEffect(() => {
+    if (hasSweptOnLaunch.current) return;
+    let settled = false;
+    const sweepOnce = () => {
+      if (settled) return;
+      settled = true;
+      hasSweptOnLaunch.current = true;
+      runSweep('launch');
+      void sweepSnapshotLeftovers().catch((error: unknown) => {
+        reportHandledError(error, { tags: { source: 'offline-sync', kind: 'snapshot-leftover-sweep' } });
+      });
+    };
+
+    const interaction = InteractionManager.runAfterInteractions(sweepOnce);
+    const fallback = setTimeout(sweepOnce, LAUNCH_DEFER_FALLBACK_MS);
+    return () => {
+      interaction.cancel();
+      clearTimeout(fallback);
+    };
+  }, []);
+
+  useEffect(() => {
+    // Gates on the flag VALUE, so returning to the foreground doesn't sweep again.
+    if (isBackgrounded) runSweep('background');
+  }, [isBackgrounded]);
+
+  useEffect(() => {
+    return onOverlayWriteThreshold(OVERLAY_WRITES_PER_SWEEP, () => {
+      runSweep('write-threshold');
+    });
+  }, []);
+}

--- a/packages/mobile/src/lib/__tests__/cache-dir-io.test.ts
+++ b/packages/mobile/src/lib/__tests__/cache-dir-io.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 // vite.config.ts points at this same file, so this is the same module instance
 // cache-dir-io sees — but `tsc` resolves the package name to the real types,
 // which know nothing about the seeding helpers.
-import { Directory, __resetFileSystem, __seedFileSystem } from '../../../test/expo-file-system-stub';
+import { Directory, File, __resetFileSystem, __seedFileSystem } from '../../../test/expo-file-system-stub';
 import { deleteCacheDirEntries, resolveImageCacheDirName, walkCacheDir } from '../cache-dir-io';
 
 afterEach(() => {
@@ -82,8 +82,20 @@ describe('deleteCacheDirEntries', () => {
     __seedFileSystem({
       'cache/board-thumbnails': { 'a.png': { size: 1 }, 'c.png': { size: 1 } },
     });
-    expect(deleteCacheDirEntries('board-thumbnails', ['a.png', 'b-vanished.png', 'c.png'])).toBe(2);
+    expect(deleteCacheDirEntries('board-thumbnails', ['a.png', 'b-vanished.png', 'c.png'])).toEqual(['a.png', 'c.png']);
     expect(new Directory('cache/board-thumbnails').list()).toHaveLength(0);
+  });
+
+  // The names rather than a count, because the callers turn this into freed
+  // BYTES: a file that survived the pass is still occupying its space.
+  it('leaves a file it could not delete out of the result', () => {
+    __seedFileSystem({
+      'cache/board-thumbnails': { 'a.png': { size: 1 }, 'locked.png': { size: 1 }, 'c.png': { size: 1 } },
+    });
+    vi.spyOn(File.prototype, 'delete').mockImplementation(function refuseOne(this: File) {
+      if (this.name === 'locked.png') throw new Error('EPERM: operation not permitted');
+    });
+    expect(deleteCacheDirEntries('board-thumbnails', ['a.png', 'locked.png', 'c.png'])).toEqual(['a.png', 'c.png']);
   });
 });
 

--- a/packages/mobile/src/lib/__tests__/sweep-board-art.test.ts
+++ b/packages/mobile/src/lib/__tests__/sweep-board-art.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 // Imported by path — see cache-dir-io.test.ts for why.
-import { __resetFileSystem, __seedFileSystem } from '../../../test/expo-file-system-stub';
+import { Directory, __resetFileSystem, __seedFileSystem } from '../../../test/expo-file-system-stub';
 
 const clearDiskCache = vi.hoisted(() => vi.fn<() => Promise<boolean>>(() => Promise.resolve(true)));
 vi.mock('expo-image', () => ({ Image: { clearDiskCache } }));
@@ -110,6 +110,15 @@ describe('sweepBoardArtCache', () => {
     // and are never in the plan.
     expect(result.filesDeleted).toBe(4);
     expect(result.beforeBytes).toBe(4 * MB);
+    // Assert the survivors themselves, not just the count: deleting either of
+    // these is how a JS sweeper manufactures the "file vanished mid-write"
+    // render storm that PR 3 exists to stop.
+    expect(
+      new Directory('cache/board-thumbnails')
+        .list()
+        .map((entry) => entry.name)
+        .sort(),
+    ).toEqual(['.bsov-live.tmp', '.dat.nosync0f1e.abc']);
   });
 
   it('reaps an orphaned temp once it is old enough to be certainly dead', async () => {

--- a/packages/mobile/src/lib/__tests__/sweep-board-art.test.ts
+++ b/packages/mobile/src/lib/__tests__/sweep-board-art.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 // Imported by path — see cache-dir-io.test.ts for why.
-import { Directory, __resetFileSystem, __seedFileSystem } from '../../../test/expo-file-system-stub';
+import { Directory, File, __resetFileSystem, __seedFileSystem } from '../../../test/expo-file-system-stub';
 
 const clearDiskCache = vi.hoisted(() => vi.fn<() => Promise<boolean>>(() => Promise.resolve(true)));
 vi.mock('expo-image', () => ({ Image: { clearDiskCache } }));
@@ -149,6 +149,31 @@ describe('sweepBoardArtCache', () => {
       beforeBytes: 10 * MB,
       freedBytes: 4 * MB,
       filesDeleted: 4,
+    });
+  });
+
+  // A sweep that couldn't delete everything it planned leaves the cache above
+  // its cap. Reporting the planned figure would put that fiction into
+  // `CachedImagesSwept` and into the number Manage Storage shows.
+  it('counts only the files it actually removed, not the ones it planned to', async () => {
+    seedOverlays(10);
+    vi.setSystemTime(NOW + 5 * 60 * 1000);
+    const reallyDelete = File.prototype.delete;
+    vi.spyOn(File.prototype, 'delete').mockImplementation(function refuseTwo(this: File) {
+      if (this.name === overlayName(0) || this.name === overlayName(1)) {
+        throw new Error('EPERM: operation not permitted');
+      }
+      reallyDelete.call(this);
+    });
+
+    const result = await sweepBoardArtCache({ trigger: 'background', targetBytes: 6 * MB });
+    expect(result.filesDeleted).toBe(2);
+    expect(result.freedBytes).toBe(2 * MB);
+    expect(track).toHaveBeenCalledWith('Cached Images Swept', {
+      trigger: 'background',
+      beforeBytes: 10 * MB,
+      freedBytes: 2 * MB,
+      filesDeleted: 2,
     });
   });
 

--- a/packages/mobile/src/lib/__tests__/sweep-board-art.test.ts
+++ b/packages/mobile/src/lib/__tests__/sweep-board-art.test.ts
@@ -1,0 +1,177 @@
+// The LRU sweep that keeps `{cache}/board-thumbnails` under the cap during a
+// session, rather than only on the cold launch the native pruner runs on.
+//
+// The two assertions that matter most: a foreign file is never in a plan (a
+// sweeper that deletes an in-flight write manufactures the render-failure storm
+// this issue also exists to stop), and eviction protects the keys a live surface
+// READ — not the tail of the in-memory map, which after warm-up is an arbitrary
+// sample of the disk.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+// Imported by path — see cache-dir-io.test.ts for why.
+import { __resetFileSystem, __seedFileSystem } from '../../../test/expo-file-system-stub';
+
+const clearDiskCache = vi.hoisted(() => vi.fn<() => Promise<boolean>>(() => Promise.resolve(true)));
+vi.mock('expo-image', () => ({ Image: { clearDiskCache } }));
+
+const track = vi.hoisted(() => vi.fn());
+vi.mock('../analytics', () => ({ track }));
+
+import { sweepBoardArtCache, sweepOverlaysForScope, _resetSweepRateLimitForTests } from '../sweep-caches';
+import { invalidateCacheMeasurement } from '../cache-size-meter';
+import {
+  cacheRenderedOverlay,
+  getRenderedOverlay,
+  _renderedOverlaysForTests,
+  _resetOverlayIndexForTests,
+} from '../overlay-index';
+
+const NOW = 1_800_000_000_000;
+const MB = 1024 * 1024;
+
+function overlayName(index: number): string {
+  return `v5_f_w400_kilter_1_7_1,20_${index.toString(16).padStart(8, '0')}.png`;
+}
+
+/** A directory of `count` 1 MB PNGs, oldest first. */
+function seedOverlays(count: number, extra: Record<string, { size: number; lastModified: number }> = {}): void {
+  const files: Record<string, { size: number; lastModified: number }> = { ...extra };
+  for (let index = 0; index < count; index += 1) {
+    files[overlayName(index)] = { size: MB, lastModified: NOW - (count - index) * 1_000 };
+  }
+  __seedFileSystem({ 'cache/board-thumbnails': files });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+  _resetSweepRateLimitForTests();
+  _resetOverlayIndexForTests();
+  invalidateCacheMeasurement();
+  track.mockReset();
+});
+
+afterEach(() => {
+  __resetFileSystem();
+  _resetSweepRateLimitForTests();
+  _resetOverlayIndexForTests();
+  invalidateCacheMeasurement();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('sweepBoardArtCache', () => {
+  it('does nothing, and reports nothing, while under the cap', async () => {
+    seedOverlays(4);
+    const result = await sweepBoardArtCache({ trigger: 'launch', targetBytes: 100 * MB });
+    expect(result).toEqual({ beforeBytes: 4 * MB, freedBytes: 0, filesDeleted: 0 });
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it('evicts oldest-first down to the target and forgets exactly those keys', async () => {
+    seedOverlays(10);
+    for (let index = 0; index < 10; index += 1) {
+      cacheRenderedOverlay(overlayName(index).replace('.png', ''), `file:///${overlayName(index)}`);
+    }
+    // Past the protection window: these were rendered a while ago and nothing has
+    // looked at them since, so none of them is on screen.
+    vi.setSystemTime(NOW + 5 * 60 * 1000);
+
+    const result = await sweepBoardArtCache({ trigger: 'background', targetBytes: 6 * MB });
+    expect(result.beforeBytes).toBe(10 * MB);
+    expect(result.freedBytes).toBe(4 * MB);
+    expect(result.filesDeleted).toBe(4);
+    // The four oldest are gone from the index; the survivors are untouched.
+    for (let index = 0; index < 4; index += 1) {
+      expect(_renderedOverlaysForTests.has(overlayName(index).replace('.png', ''))).toBe(false);
+    }
+    expect(_renderedOverlaysForTests.has(overlayName(9).replace('.png', ''))).toBe(true);
+  });
+
+  it('never deletes the art a surface just read, even though it is the oldest', async () => {
+    seedOverlays(6);
+    const oldestKey = overlayName(0).replace('.png', '');
+    cacheRenderedOverlay(oldestKey, `file:///${overlayName(0)}`);
+    // Long enough that mtime says "ancient" — then a mounted surface reads it.
+    vi.setSystemTime(NOW + 5 * 60 * 1000);
+    getRenderedOverlay(oldestKey);
+
+    await sweepBoardArtCache({ trigger: 'write-threshold', targetBytes: 4 * MB });
+    expect(_renderedOverlaysForTests.has(oldestKey)).toBe(true);
+  });
+
+  it('leaves an in-flight atomic write and a foreign staging file alone', async () => {
+    seedOverlays(4, {
+      '.bsov-live.tmp': { size: 30 * MB, lastModified: NOW },
+      '.dat.nosync0f1e.abc': { size: 30 * MB, lastModified: NOW - 999_999 },
+    });
+    const result = await sweepBoardArtCache({ trigger: 'launch', targetBytes: 0 });
+    // Only the four PNGs — the temps and hidden files were never in the budget
+    // and are never in the plan.
+    expect(result.filesDeleted).toBe(4);
+    expect(result.beforeBytes).toBe(4 * MB);
+  });
+
+  it('reaps an orphaned temp once it is old enough to be certainly dead', async () => {
+    seedOverlays(1, { '.bsov-orphan.tmp': { size: 5 * MB, lastModified: NOW - 2 * 60 * 60 * 1000 } });
+    const result = await sweepBoardArtCache({ trigger: 'launch', targetBytes: 100 * MB });
+    expect(result.filesDeleted).toBe(1);
+  });
+
+  it('rate-limits a trigger class so a chatty signal cannot re-walk the directory', async () => {
+    seedOverlays(10);
+    const first = await sweepBoardArtCache({ trigger: 'write-threshold', targetBytes: 6 * MB });
+    expect(first.filesDeleted).toBe(4);
+
+    seedOverlays(10);
+    const second = await sweepBoardArtCache({ trigger: 'write-threshold', targetBytes: 6 * MB });
+    expect(second.filesDeleted).toBe(0);
+
+    // A different class is its own budget, and the window eventually reopens.
+    const other = await sweepBoardArtCache({ trigger: 'background', targetBytes: 6 * MB });
+    expect(other.filesDeleted).toBe(4);
+  });
+
+  it('reports a sweep that actually freed something, with the trigger that caused it', async () => {
+    seedOverlays(10);
+    await sweepBoardArtCache({ trigger: 'background', targetBytes: 6 * MB });
+    expect(track).toHaveBeenCalledWith('Cached Images Swept', {
+      trigger: 'background',
+      beforeBytes: 10 * MB,
+      freedBytes: 4 * MB,
+      filesDeleted: 4,
+    });
+  });
+
+  it('does nothing when the cache directory was never created', async () => {
+    await expect(sweepBoardArtCache({ trigger: 'launch' })).resolves.toEqual({
+      beforeBytes: 0,
+      freedBytes: 0,
+      filesDeleted: 0,
+    });
+  });
+});
+
+describe('sweepOverlaysForScope', () => {
+  it('deletes only the removed board’s art', async () => {
+    __seedFileSystem({
+      'cache/board-thumbnails': {
+        'v5_f_w400_kilter_1_7_1,20_aa.png': { size: MB, lastModified: NOW },
+        'v5_s_wfull_kilter_1_7_1,20_bb.png': { size: MB, lastModified: NOW },
+        // A neighbouring size, and a different board entirely.
+        'v5_f_w400_kilter_1_70_1,20_cc.png': { size: MB, lastModified: NOW },
+        'v5_f_w400_tension_1_7_1,20_dd.png': { size: MB, lastModified: NOW },
+      },
+    });
+    const result = await sweepOverlaysForScope({ boardType: 'kilter', layoutId: 1, sizeId: 7 });
+    expect(result.filesDeleted).toBe(2);
+    expect(result.freedBytes).toBe(2 * MB);
+  });
+
+  it('is a no-op when that board rendered nothing', async () => {
+    __seedFileSystem({ 'cache/board-thumbnails': {} });
+    const result = await sweepOverlaysForScope({ boardType: 'kilter', layoutId: 1, sizeId: 7 });
+    expect(result.filesDeleted).toBe(0);
+    expect(track).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/cache-dir-io.ts
+++ b/packages/mobile/src/lib/cache-dir-io.ts
@@ -103,21 +103,28 @@ export async function walkCacheDir(
 }
 
 /**
- * Delete named entries from a cache directory, best-effort.
+ * Delete named entries from a cache directory, best-effort. Returns the names it
+ * actually removed.
  *
  * Per-entry try/catch because the interesting failure is a race — the OS
  * reclaimed the file, or the native pruner got there first — and a sweep that
  * rejects on the first of those frees nothing at all.
+ *
+ * The names rather than a count, because the callers report freed BYTES: a
+ * permission failure or an unreadable volume takes one file out of the plan
+ * without taking it out of a `beforeBytes - afterBytes` subtraction, so the
+ * sweep would claim space it never reclaimed. Only what came back from here is
+ * counted.
  */
-export function deleteCacheDirEntries(dirName: string, names: readonly string[]): number {
+export function deleteCacheDirEntries(dirName: string, names: readonly string[]): string[] {
   const directory = new Directory(Paths.cache, dirName);
-  let deleted = 0;
+  const deleted: string[] = [];
   for (const name of names) {
     try {
       const file = new File(directory, name);
       if (!file.exists) continue;
       file.delete();
-      deleted += 1;
+      deleted.push(name);
     } catch {
       // Ignore: see above.
     }

--- a/packages/mobile/src/lib/cache-dir-io.web.ts
+++ b/packages/mobile/src/lib/cache-dir-io.web.ts
@@ -15,8 +15,8 @@ export async function walkCacheDir(): Promise<CacheDirWalk | null> {
   return null;
 }
 
-export function deleteCacheDirEntries(): number {
-  return 0;
+export function deleteCacheDirEntries(): string[] {
+  return [];
 }
 
 export function resolveImageCacheDirName(): string | null {

--- a/packages/mobile/src/lib/cache-sweep-plan.ts
+++ b/packages/mobile/src/lib/cache-sweep-plan.ts
@@ -119,6 +119,31 @@ export function measureOverlayCacheBytes(entries: readonly CacheDirEntry[]): num
   return total;
 }
 
+/**
+ * Bytes a delete pass genuinely reclaimed.
+ *
+ * `deletedNames` is what the filesystem confirmed gone; `countableNames` is the
+ * subset of the plan whose bytes the caller is reporting on (for the overlay
+ * cache that is the finished PNGs, so a freed figure stays comparable with the
+ * `beforeBytes` measured the same way). Anything the delete pass planned but
+ * could not remove — a permission failure, an unreadable volume — is absent from
+ * `deletedNames` and therefore absent from this total, which is the whole point:
+ * a sweep that leaves the cache over its cap must not report the space as freed.
+ */
+export function measureFreedBytes(params: {
+  entries: readonly CacheDirEntry[];
+  deletedNames: readonly string[];
+  countableNames: readonly string[];
+}): number {
+  const countable = new Set(params.countableNames);
+  const sizeByName = new Map(params.entries.map((entry) => [entry.name, entry.sizeBytes]));
+  let freedBytes = 0;
+  for (const name of params.deletedNames) {
+    if (countable.has(name)) freedBytes += sizeByName.get(name) ?? 0;
+  }
+  return freedBytes;
+}
+
 /** A null mtime sorts oldest, so an entry the platform can't date is evicted first. */
 function modifiedAtOrEpoch(entry: CacheDirEntry): number {
   return entry.modifiedAtMs ?? 0;
@@ -188,10 +213,13 @@ export function planOverlayCacheClear(params: {
   entries: readonly CacheDirEntry[];
   nowMs: number;
   managedTempMinAgeMs?: number;
-}): { deleteNames: string[]; freedBytes: number } {
+}): { deleteNames: string[]; pngNames: string[]; freedBytes: number } {
   const plan = planLruEviction({ ...params, targetBytes: -1 });
   return {
     deleteNames: [...plan.evictNames, ...plan.staleTempNames],
+    // The PNGs alone, so the caller can report the bytes it actually removed
+    // against the same definition `beforeBytes` uses.
+    pngNames: plan.evictNames,
     freedBytes: plan.beforeBytes - plan.afterBytes,
   };
 }

--- a/packages/mobile/src/lib/sweep-caches.ts
+++ b/packages/mobile/src/lib/sweep-caches.ts
@@ -21,17 +21,28 @@
 // OS" problem this issue is about.
 
 import { Image } from 'expo-image';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import type { OfflineBoardScope } from '@boardsesh/offline-sync';
 import { deleteCacheDirEntries, resolveImageCacheDirName, walkCacheDir } from './cache-dir-io';
 import { invalidateCacheMeasurement, measureCacheDirBytes, recordCacheMeasurement } from './cache-size-meter';
 import {
   measureOverlayCacheBytes,
+  overlayNameMatchesScope,
+  planLruEviction,
   planOverlayCacheClear,
   planStaleArtifactSweep,
+  OVERLAY_CACHE_TARGET_BYTES,
   SNAPSHOT_CLEAR_MIN_AGE_MS,
   SNAPSHOT_LEFTOVER_MAX_AGE_MS,
   cacheKeyForOverlayName,
 } from './cache-sweep-plan';
-import { clearOverlayIndex, forgetOverlays } from './overlay-index';
+import {
+  clearOverlayIndex,
+  forgetOverlays,
+  getRecentlyUsedCacheKeys,
+  resetOverlayWriteOdometer,
+} from './overlay-index';
+import { track } from './analytics';
 import { SNAPSHOT_DIR_NAME } from '../offline/snapshot-source';
 
 /** Must match the directory the native BoardRenderer modules write PNGs into. */
@@ -177,4 +188,129 @@ export async function clearCachedImages(): Promise<ClearCachedImagesResult> {
 
   invalidateCacheMeasurement();
   return { freedBytes, filesDeleted, photoCacheCleared };
+}
+
+/** Where a sweep came from. Carried on the analytics event so the triggers can be compared. */
+export type CacheSweepTrigger =
+  | 'launch'
+  | 'background'
+  | 'write-threshold'
+  | 'board-removed'
+  | 'manual'
+  | 'disk-pressure';
+
+export type CacheSweepResult = {
+  beforeBytes: number;
+  freedBytes: number;
+  filesDeleted: number;
+};
+
+const EMPTY_SWEEP: CacheSweepResult = { beforeBytes: 0, freedBytes: 0, filesDeleted: 0 };
+
+/**
+ * How long a cache key stays protected from eviction after JS last read it.
+ *
+ * Long enough to cover a surface that is mounted but idle (a play drawer left
+ * open, a list the user stopped scrolling), short enough that the warm-up's
+ * couple of hundred prior-session insertions age out of the protected set within
+ * one browsing session.
+ */
+const RECENTLY_USED_WINDOW_MS = 120_000;
+
+/** Minimum gap between two sweeps of the same trigger class. */
+const SWEEP_RATE_LIMIT_MS = 5 * 60 * 1000;
+
+const lastSweptAtMsByTrigger = new Map<CacheSweepTrigger, number>();
+
+/**
+ * Bring `{cache}/board-thumbnails` back under the native modules' own 200 MB cap.
+ *
+ * The cap already exists — what was missing is anything enforcing it during a
+ * session. Both native modules prune behind a once-per-module-lifetime gate
+ * (`BoardRendererModule.swift`'s `lazy var pruneOnce`, `.kt`'s `@Volatile pruned`),
+ * so a foreground session that never relaunches grows unchecked. Fixing the gate
+ * is a native change that could not reach store binaries over OTA, so this runs
+ * the same mtime-LRU from JS against the same directory, with the same
+ * file-classification rules, plus the one thing mtime can't know: which keys a
+ * live surface read in the last two minutes.
+ */
+export async function sweepBoardArtCache(params: {
+  trigger: CacheSweepTrigger;
+  targetBytes?: number;
+  nowMs?: number;
+}): Promise<CacheSweepResult> {
+  const nowMs = params.nowMs ?? Date.now();
+  const lastSweptAtMs = lastSweptAtMsByTrigger.get(params.trigger);
+  if (lastSweptAtMs !== undefined && nowMs - lastSweptAtMs < SWEEP_RATE_LIMIT_MS) return EMPTY_SWEEP;
+  lastSweptAtMsByTrigger.set(params.trigger, nowMs);
+  // The odometer counts growth since the LAST sweep, whatever fired it.
+  resetOverlayWriteOdometer();
+
+  const walk = await walkCacheDir(OVERLAY_CACHE_DIR_NAME);
+  if (walk === null) return EMPTY_SWEEP;
+
+  const plan = planLruEviction({
+    entries: walk.entries,
+    targetBytes: params.targetBytes ?? OVERLAY_CACHE_TARGET_BYTES,
+    protectedNames: getRecentlyUsedCacheKeys(RECENTLY_USED_WINDOW_MS, nowMs),
+    nowMs,
+  });
+  const deleteNames = [...plan.evictNames, ...plan.staleTempNames];
+  if (deleteNames.length === 0) {
+    // The walk we just paid for is the measurement Manage Storage would take.
+    recordCacheMeasurement(OVERLAY_CACHE_DIR_NAME, plan.beforeBytes, nowMs);
+    return { beforeBytes: plan.beforeBytes, freedBytes: 0, filesDeleted: 0 };
+  }
+
+  const filesDeleted = deleteCacheDirEntries(OVERLAY_CACHE_DIR_NAME, deleteNames);
+  forgetOverlays(plan.evictNames.map(cacheKeyForOverlayName));
+  invalidateCacheMeasurement(OVERLAY_CACHE_DIR_NAME);
+
+  const result = { beforeBytes: plan.beforeBytes, freedBytes: plan.beforeBytes - plan.afterBytes, filesDeleted };
+  if (result.freedBytes > 0) {
+    track(SHARED_EVENTS.CachedImagesSwept, {
+      trigger: params.trigger,
+      beforeBytes: result.beforeBytes,
+      freedBytes: result.freedBytes,
+      filesDeleted: result.filesDeleted,
+    });
+  }
+  return result;
+}
+
+/**
+ * Drop the rendered art for one board scope, on removal.
+ *
+ * Best-effort by design: Remove is about reclaiming space, and art that survives
+ * a removal is exactly the leftover this screen exists to reap. Re-browsing that
+ * board online redraws every thumbnail locally in tens of milliseconds, no
+ * network — which is why this is worth doing even though it is not free.
+ */
+export async function sweepOverlaysForScope(scope: OfflineBoardScope): Promise<CacheSweepResult> {
+  const walk = await walkCacheDir(OVERLAY_CACHE_DIR_NAME);
+  if (walk === null) return EMPTY_SWEEP;
+
+  const matching = walk.entries.filter((entry) => overlayNameMatchesScope(entry.name, scope));
+  if (matching.length === 0) return EMPTY_SWEEP;
+
+  const freedBytes = matching.reduce((sum, entry) => sum + entry.sizeBytes, 0);
+  const names = matching.map((entry) => entry.name);
+  const filesDeleted = deleteCacheDirEntries(OVERLAY_CACHE_DIR_NAME, names);
+  forgetOverlays(names.map(cacheKeyForOverlayName));
+  invalidateCacheMeasurement(OVERLAY_CACHE_DIR_NAME);
+
+  if (freedBytes > 0) {
+    track(SHARED_EVENTS.CachedImagesSwept, {
+      trigger: 'board-removed',
+      beforeBytes: measureOverlayCacheBytes(walk.entries),
+      freedBytes,
+      filesDeleted,
+    });
+  }
+  return { beforeBytes: measureOverlayCacheBytes(walk.entries), freedBytes, filesDeleted };
+}
+
+/** Test-only: forget the per-trigger rate limit. */
+export function _resetSweepRateLimitForTests(): void {
+  lastSweptAtMsByTrigger.clear();
 }

--- a/packages/mobile/src/lib/sweep-caches.ts
+++ b/packages/mobile/src/lib/sweep-caches.ts
@@ -26,6 +26,7 @@ import type { OfflineBoardScope } from '@boardsesh/offline-sync';
 import { deleteCacheDirEntries, resolveImageCacheDirName, walkCacheDir } from './cache-dir-io';
 import { invalidateCacheMeasurement, measureCacheDirBytes, recordCacheMeasurement } from './cache-size-meter';
 import {
+  measureFreedBytes,
   measureOverlayCacheBytes,
   overlayNameMatchesScope,
   planLruEviction,
@@ -138,9 +139,9 @@ export async function sweepSnapshotLeftovers(options?: { maxAgeMs?: number }): P
     recordCacheMeasurement(SNAPSHOT_DIR_NAME, walk.totalBytes);
     return 0;
   }
-  deleteCacheDirEntries(SNAPSHOT_DIR_NAME, plan.deleteNames);
+  const deletedNames = deleteCacheDirEntries(SNAPSHOT_DIR_NAME, plan.deleteNames);
   invalidateCacheMeasurement(SNAPSHOT_DIR_NAME);
-  return plan.freedBytes;
+  return measureFreedBytes({ entries: walk.entries, deletedNames, countableNames: plan.deleteNames });
 }
 
 export type ClearCachedImagesResult = {
@@ -166,8 +167,12 @@ export async function clearCachedImages(): Promise<ClearCachedImagesResult> {
   const walk = await walkCacheDir(OVERLAY_CACHE_DIR_NAME);
   if (walk !== null) {
     const plan = planOverlayCacheClear({ entries: walk.entries, nowMs: Date.now() });
-    filesDeleted += deleteCacheDirEntries(OVERLAY_CACHE_DIR_NAME, plan.deleteNames);
-    freedBytes += plan.freedBytes;
+    const deletedNames = deleteCacheDirEntries(OVERLAY_CACHE_DIR_NAME, plan.deleteNames);
+    filesDeleted += deletedNames.length;
+    freedBytes += measureFreedBytes({ entries: walk.entries, deletedNames, countableNames: plan.pngNames });
+    // Forgetting a key whose file survived the delete is the safe direction: the
+    // index would otherwise keep handing out a URI for a file the next pass is
+    // still trying to remove, and a forgotten key costs one re-render.
     forgetOverlays(plan.deleteNames.map(cacheKeyForOverlayName));
   }
   // Belt and braces: anything the walk missed (a race with a render that landed
@@ -262,11 +267,18 @@ export async function sweepBoardArtCache(params: {
     return { beforeBytes: plan.beforeBytes, freedBytes: 0, filesDeleted: 0 };
   }
 
-  const filesDeleted = deleteCacheDirEntries(OVERLAY_CACHE_DIR_NAME, deleteNames);
+  const deletedNames = deleteCacheDirEntries(OVERLAY_CACHE_DIR_NAME, deleteNames);
   forgetOverlays(plan.evictNames.map(cacheKeyForOverlayName));
   invalidateCacheMeasurement(OVERLAY_CACHE_DIR_NAME);
 
-  const result = { beforeBytes: plan.beforeBytes, freedBytes: plan.beforeBytes - plan.afterBytes, filesDeleted };
+  // Not `beforeBytes - afterBytes`: that is what the plan WANTED to free. A file
+  // the delete pass couldn't remove leaves the cache above its cap, and saying
+  // otherwise here would put the fiction straight into `CachedImagesSwept`.
+  const result = {
+    beforeBytes: plan.beforeBytes,
+    freedBytes: measureFreedBytes({ entries: walk.entries, deletedNames, countableNames: plan.evictNames }),
+    filesDeleted: deletedNames.length,
+  };
   if (result.freedBytes > 0) {
     track(SHARED_EVENTS.CachedImagesSwept, {
       trigger: params.trigger,
@@ -293,21 +305,26 @@ export async function sweepOverlaysForScope(scope: OfflineBoardScope): Promise<C
   const matching = walk.entries.filter((entry) => overlayNameMatchesScope(entry.name, scope));
   if (matching.length === 0) return EMPTY_SWEEP;
 
-  const freedBytes = matching.reduce((sum, entry) => sum + entry.sizeBytes, 0);
   const names = matching.map((entry) => entry.name);
-  const filesDeleted = deleteCacheDirEntries(OVERLAY_CACHE_DIR_NAME, names);
+  const deletedNames = deleteCacheDirEntries(OVERLAY_CACHE_DIR_NAME, names);
   forgetOverlays(names.map(cacheKeyForOverlayName));
   invalidateCacheMeasurement(OVERLAY_CACHE_DIR_NAME);
+
+  // Only the files that are actually gone — art that survived the pass is still
+  // occupying the space the Remove screen just told the user it reclaimed.
+  const freedBytes = measureFreedBytes({ entries: walk.entries, deletedNames, countableNames: names });
+  const filesDeleted = deletedNames.length;
+  const beforeBytes = measureOverlayCacheBytes(walk.entries);
 
   if (freedBytes > 0) {
     track(SHARED_EVENTS.CachedImagesSwept, {
       trigger: 'board-removed',
-      beforeBytes: measureOverlayCacheBytes(walk.entries),
+      beforeBytes,
       freedBytes,
       filesDeleted,
     });
   }
-  return { beforeBytes: measureOverlayCacheBytes(walk.entries), freedBytes, filesDeleted };
+  return { beforeBytes, freedBytes, filesDeleted };
 }
 
 /** Test-only: forget the per-trigger rate limit. */

--- a/packages/mobile/src/lib/sweep-caches.web.ts
+++ b/packages/mobile/src/lib/sweep-caches.web.ts
@@ -7,9 +7,14 @@
 // returns null so Manage Storage omits the whole Cached-images section rather
 // than rendering a live Clear button over a fabricated `0 B`.
 
-import type { CachedImageMeasurement, ClearCachedImagesResult } from './sweep-caches';
+import type { CacheSweepResult, CachedImageMeasurement, ClearCachedImagesResult } from './sweep-caches';
 
-export type { CachedImageMeasurement, ClearCachedImagesResult } from './sweep-caches';
+export type {
+  CacheSweepResult,
+  CacheSweepTrigger,
+  CachedImageMeasurement,
+  ClearCachedImagesResult,
+} from './sweep-caches';
 
 export const OVERLAY_CACHE_DIR_NAME = 'board-thumbnails';
 
@@ -23,4 +28,12 @@ export async function sweepSnapshotLeftovers(): Promise<number> {
 
 export async function clearCachedImages(): Promise<ClearCachedImagesResult> {
   return { freedBytes: 0, filesDeleted: 0, photoCacheCleared: false };
+}
+
+export async function sweepBoardArtCache(): Promise<CacheSweepResult> {
+  return { beforeBytes: 0, freedBytes: 0, filesDeleted: 0 };
+}
+
+export async function sweepOverlaysForScope(): Promise<CacheSweepResult> {
+  return { beforeBytes: 0, freedBytes: 0, filesDeleted: 0 };
 }

--- a/packages/mobile/src/offline/__tests__/remove-offline-board.test.ts
+++ b/packages/mobile/src/offline/__tests__/remove-offline-board.test.ts
@@ -48,6 +48,11 @@ vi.mock('../../lib/error-reporting', () => ({
   reportError: vi.fn(),
 }));
 
+const sweepOverlaysForScope = vi.fn(async () => ({ beforeBytes: 0, freedBytes: 0, filesDeleted: 0 }));
+vi.mock('../../lib/sweep-caches', () => ({
+  sweepOverlaysForScope: (...args: unknown[]) => sweepOverlaysForScope(...(args as [])),
+}));
+
 import type { QueryClient } from '@tanstack/react-query';
 import { removeOfflineBoard, compactOfflineDatabase } from '../remove-offline-board';
 import { getSetting, setSetting, resetAllSettings } from '../../settings/hooks';
@@ -151,6 +156,25 @@ describe('removeOfflineBoard', () => {
     expect(invalidatedKeys).toContain(JSON.stringify(['climb']));
     expect(invalidatedKeys).toContain(JSON.stringify(['downloadedScopeKeys']));
     expect(invalidatedKeys).toContain(JSON.stringify(['offlineStorage']));
+  });
+});
+
+describe('removeOfflineBoard cached art', () => {
+  it("sweeps the removed scope's rendered art", async () => {
+    setSetting('syncEnabledBoards', ['kilter:1:7']);
+    await removeOfflineBoard({ db, queryClient, scope: KILTER_12X14 });
+    expect(sweepOverlaysForScope).toHaveBeenCalledWith(KILTER_12X14);
+  });
+
+  // Cache housekeeping must never be able to turn a successful teardown into a
+  // failure the user reads as "the removal didn't work" — same posture as
+  // compactOfflineDatabase.
+  it('still reports the teardown result when the art sweep throws', async () => {
+    sweepOverlaysForScope.mockRejectedValueOnce(new Error('cache dir vanished'));
+    setSetting('syncEnabledBoards', ['kilter:1:7']);
+    await expect(removeOfflineBoard({ db, queryClient, scope: KILTER_12X14 })).resolves.toMatchObject({
+      removedAnyRows: true,
+    });
   });
 });
 

--- a/packages/mobile/src/offline/remove-offline-board.ts
+++ b/packages/mobile/src/offline/remove-offline-board.ts
@@ -19,6 +19,7 @@ import {
 } from '@boardsesh/offline-sync';
 import { getSetting, setOfflineBoardEnabled, forgetOfflineBoardScope } from '../settings';
 import { reportHandledError } from '../lib/error-reporting';
+import { sweepOverlaysForScope } from '../lib/sweep-caches';
 
 /** The query keys that read board reference rows, derived from the tables we delete from. */
 function boardDataQueryKeys(): readonly (readonly unknown[])[] {
@@ -87,6 +88,18 @@ export async function removeOfflineBoard(params: {
     .filter((parsed): parsed is OfflineBoardScope => parsed !== null);
 
   const result = await removeBoardScopeData({ db, scope, scopeKey: offlineBoardKey(scope), retainedScopes });
+
+  // The rendered PNGs for this board are cache, not data, so they are swept
+  // AFTER the rows are gone and never allowed to change the teardown result —
+  // same posture as compactOfflineDatabase. Remove is a reclaim-space action and
+  // the art re-renders locally in tens of milliseconds, no network, so leaving it
+  // behind would just be the leftover this screen exists to reap.
+  try {
+    await sweepOverlaysForScope(scope);
+  } catch (error) {
+    reportHandledError(error, { tags: { source: 'offline-sync', kind: 'scope-overlay-sweep' } });
+  }
+
   invalidateBoardReaders(queryClient);
   return result;
 }

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -506,6 +506,15 @@ export const SHARED_EVENTS = {
   // `hadBoardCheckpoint` distinguishes a heal over a partly-crawled catalog
   // from a fresh board's first attempt.
   OfflineSnapshotPathRecovered: 'Offline Snapshot Path Recovered',
+  // Offline sync — a JS sweep of the rendered board-art cache freed disk space
+  // (issue #3647). Fired only when it actually freed something, so the rate is
+  // the signal for "does the 200 MB cap ever bite in the field", and
+  // `beforeBytes` is what the write-odometer trigger constant gets tuned from.
+  // Props: { trigger: 'launch' | 'background' | 'write-threshold' |
+  // 'board-removed' | 'manual' | 'disk-pressure', beforeBytes, freedBytes,
+  // filesDeleted }. Mobile-only: web's overlay store is the Cache API, already
+  // bounded by entry count.
+  CachedImagesSwept: 'Cached Images Swept',
 } as const;
 
 export type SharedEventKey = keyof typeof SHARED_EVENTS;


### PR DESCRIPTION
Stacked on #4334. Second of the #3647 cache work: PR 1 bounded and measured the caches, this one enforces the board-art cap while the app is running.

## Why

`{cache}/board-thumbnails` was never the unbounded cache the issue assumed — the native renderer already caps it at 200 MB. What was missing is anything enforcing that cap during a session:

- iOS: `BoardRendererModule.swift` prunes from a `lazy var pruneOnce`, i.e. once per module lifetime.
- Android: `BoardRendererModule.kt` gates on a `@Volatile pruned` flag via `ensurePruned()`, same story.

So a cold launch trims, and then the directory grows for as long as the app stays up. That is exactly the failure shape this repo has already met once: `useIpadTabSwitchImageCacheSweep` exists because "an iPad kept open for days never backgrounds" (#3803, ~3.7 days uptime). The obvious fix — making the native prune periodic — is a fingerprint-input change that could never reach store binaries over OTA, so the same policy runs from JS instead.

## Changes

- **`sweepBoardArtCache({ trigger })`** — one chunked walk, `planLruEviction` (oldest mtime first, from PR 1's pure planner), delete, forget the evicted keys, invalidate the size memo. mtime is the LRU proxy both natives already maintain (they bump it on a cache hit), so JS needs no access database on disk. Rate-limited to one sweep per five minutes per trigger class; a delete that throws never rejects the sweep.
- **Protection comes from the access clock, not map order.** `getRecentlyUsedCacheKeys(120s)` returns the keys JS genuinely *read*. The tempting alternative — protect the tail of `renderedOverlays` — looks like an LRU and isn't: the warm-up inserts a couple of hundred prior-session PNGs in directory-listing order, so post-launch map order is an arbitrary sample of the disk rather than the working set. An entry no surface has read is not on screen; one a surface read eight seconds ago is, however ancient its mtime.
- **`sweepOverlaysForScope(scope)`** wired into `remove-offline-board.ts` after the rows are gone. Best-effort, and structurally unable to change the returned `ScopeTeardownResult` — same posture as `compactOfflineDatabase`, because "the removal failed" must never be the story when only cache housekeeping did.
- **`useDiskCacheSweep`**, mounted beside `useImageCacheMemoryManagement()` in `_layout.tsx`. Three triggers: launch (via `runAfterInteractions` **with a fallback timer** — `use-deferred-after-interactions.ts` documents that a leaked interaction handle can starve that queue indefinitely, which would mean the sweep simply never runs on a busy launch), background, and the overlay write odometer. The odometer is the leg that matters: it counts growth rather than the clock, at one integer increment per render, and it fires in a session that never backgrounds and never relaunches.
- **`CachedImagesSwept`** appended to `SHARED_EVENTS`, fired only when a sweep actually freed bytes. It answers "does the cap ever bite in the field", and `beforeBytes` is what the 400-write odometer constant gets tuned from.

## Behaviour change worth naming

**Removing a downloaded board now deletes that board's rendered art.** Deliberate — Remove is a reclaim-space action, and the art re-renders locally from Rust in tens of milliseconds with no network — but browsing that board online right after a Remove redraws every thumbnail. Happy to drop that leg if you'd rather Remove stayed strictly about SQLite.

The write odometer is a proxy for bytes, not bytes: 400 writes is ~25 MB at the issue's ~60 KB/climb average, but a session of `wfull` renders (~120 KB) crosses the real cap sooner and a session of `w400` list thumbnails (~5–25 KB) later. Acceptable because the sweep is cheap when already under target, and it is one number to tune from the new event.

No native-fingerprint inputs touched: no new dependencies, no plugin, no `app.config.ts`, nothing under `modules/`, `ios/`, `android/`, or `patches/`.

## Release Notes

Board art no longer piles up during a long session — Boardsesh trims it as you browse instead of only at app start. Removing a downloaded board now clears the art it drew for that board, too.

## Test plan

All foreground, all via `vp`:

- `vp run typecheck:mobile`, `vp run typecheck:shared` — clean.
- `vp run test:mobile` — **627 files, 5549 tests, all passing.**
- `sweep-board-art.test.ts` (10 tests): oldest-first eviction stopping exactly at target; a key read five minutes after it was written surviving despite being the oldest; an in-flight `.bsov-*.tmp` and a foreign hidden staging file untouched even at `targetBytes: 0`; an hour-old orphaned temp reaped; the per-trigger rate limit; the event firing only on a sweep that freed something; scope removal deleting only that scope (size 7 not matching size 70).
- `use-disk-cache-sweep.test.ts` (6 tests): launch deferred past interactions; **the fallback firing when the queue never drains**; exactly one sweep when both fire; one per background transition and none on return; the odometer leg; unsubscribe on unmount.
- `remove-offline-board.test.ts`: the scope sweep is called, and a throwing sweep still returns the teardown result unchanged.
- `use-native-climb-render.test.ts`: pins `buildCacheKey`'s `boardName` against `OfflineBoardScope.boardType` through the real key builder, so a future divergence fails here instead of silently deleting nothing.
- `vp test run --reporter=agent packages/shared/analytics` — 23 passed.
- `vp run check:mobile-bundle` — Android bundle OK.
- `vp check` — clean for every file this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT6VP1sWqk6bY9mUgyeS2U

Closes #3647
