### PR TITLE
fix(mobile): stop the overlay render error storm on a full device (2/2)

### DIFF
--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-disk-full.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-disk-full.test.tsx
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+//
+// The full-disk render storm (issue #3647).
+//
+// Field shape being fixed: one iPhone with no free space produced ~50
+// `UnexpectedException: You can't save the file "v5_….png" because the volume
+// "User" is out of space` events in 50 minutes, spread across THREE Sentry issue
+// groups (BOARDSESH-C6/C7/C8) plus a fourth from a second device. Two separate
+// causes, so two separate fixes asserted here:
+//
+//  1. No once-guard on the reporter, and `getOrStartInflightRender` clears the
+//     settled promise — so every recycled FlashList row re-rendered and
+//     re-reported.
+//  2. Sentry groups on the message, and the raw message interpolates the
+//     FILENAME. So even one event per row would still have minted a new issue
+//     group per cache key. A guard alone was never enough.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+vi.mock('../../providers/theme-provider', () => ({ useAppColorScheme: () => 'light' }));
+
+class MockFile {
+  constructor(private readonly uri: string) {}
+  get exists(): boolean {
+    return false;
+  }
+  get name(): string {
+    return this.uri;
+  }
+}
+
+vi.mock('expo-file-system', () => ({
+  Directory: vi.fn(() => ({ exists: false, list: () => [] })),
+  File: MockFile,
+  Paths: { cache: { uri: 'file:///cache/' } },
+}));
+
+vi.mock('../../lib/board-details', () => ({
+  getBoardRenderData: vi.fn(() => ({
+    boardWidth: 1000,
+    boardHeight: 1200,
+    holdsData: [{ id: 1, mirroredHoldId: null, cx: 100, cy: 200, r: 20 }],
+  })),
+}));
+
+vi.mock('../../lib/background-image-cache', () => ({
+  tryGetBackgroundPathsSync: vi.fn(() => ({ paths: ['file:///bg.png'], missingCount: 0 })),
+  ensureBackgroundsCached: vi.fn(async () => ({ paths: ['file:///bg.png'], missingCount: 0 })),
+}));
+
+const reportErrorMock = vi.hoisted(() => vi.fn());
+vi.mock('../../lib/error-reporting', () => ({ reportError: reportErrorMock }));
+
+const sweepBoardArtCache = vi.hoisted(() =>
+  vi.fn(() => Promise.resolve({ beforeBytes: 0, freedBytes: 0, filesDeleted: 0 })),
+);
+vi.mock('../../lib/sweep-caches', () => ({ sweepBoardArtCache }));
+
+vi.mock('../../lib/hold-color-overrides', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../lib/hold-color-overrides')>();
+  const stableOverrides = {
+    overrides: {},
+    shapes: {},
+    brushThickness: original.DEFAULT_HOLD_BRUSH_THICKNESS,
+    shapeSize: original.DEFAULT_HOLD_SHAPE_SIZE,
+    renderSignature: original.DEFAULT_HOLD_COLOR_SIGNATURE,
+  };
+  return { ...original, useHoldColorOverrides: () => stableOverrides };
+});
+
+// Every render rejects the way a full volume does, with the FILENAME in the
+// message — which is what fragmented the Sentry groups.
+const renderOutcome = vi.hoisted(() => ({ mode: 'disk-full' as 'disk-full' | 'other' }));
+const fakeNativeModule = {
+  boardRendererNative: {},
+  renderHoldsOverlay: vi.fn((_configJson: string, cacheKey: string) =>
+    Promise.reject(
+      new Error(
+        renderOutcome.mode === 'disk-full'
+          ? `The operation couldn’t be completed. You can’t save the file “${cacheKey}.png” because the volume “User” is out of space.`
+          : `render failed for ${cacheKey}: unknown native error`,
+      ),
+    ),
+  ),
+};
+
+const {
+  useNativeClimbRender,
+  classifyRenderFailure,
+  _inflightRendersForTests,
+  _resetWarmupForTests,
+  _setNativeModuleForTests,
+} = await import('../use-native-climb-render');
+
+const BASE = { boardName: 'kilter' as const, layoutId: 1, sizeId: 10, setIds: '26,27', filledStyle: false };
+
+/** One recycled FlashList row: a distinct climb, hence a distinct cache key. */
+function renderRow(index: number) {
+  return renderHook(() => useNativeClimbRender({ ...BASE, frames: `p${1000 + index}r12` }));
+}
+
+beforeEach(() => {
+  renderOutcome.mode = 'disk-full';
+  _resetWarmupForTests();
+  _inflightRendersForTests.clear();
+  fakeNativeModule.renderHoldsOverlay.mockClear();
+  sweepBoardArtCache.mockClear();
+  reportErrorMock.mockClear();
+  _setNativeModuleForTests(fakeNativeModule as unknown as Parameters<typeof _setNativeModuleForTests>[0]);
+});
+
+describe('classifyRenderFailure', () => {
+  it('recognises the out-of-space wording each platform uses', () => {
+    expect(classifyRenderFailure('the volume “User” is out of space')).toBe('disk_full');
+    expect(classifyRenderFailure('write failed: ENOSPC (No space left on device)')).toBe('disk_full');
+    expect(classifyRenderFailure('java.io.IOException: No space left on device')).toBe('disk_full');
+    expect(classifyRenderFailure('unknown native error')).toBe('render_failed');
+  });
+});
+
+describe('out-of-space render storm', () => {
+  it('reports once across many failing rows, not once per row', async () => {
+    for (let index = 0; index < 20; index += 1) renderRow(index);
+    await waitFor(() => expect(reportErrorMock).toHaveBeenCalled());
+    // Give every rejection a chance to land before asserting the count.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(reportErrorMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('carries a stable message so the per-filename Sentry groups collapse into one', async () => {
+    renderRow(0);
+    await waitFor(() => expect(reportErrorMock).toHaveBeenCalled());
+    const [reported, options] = reportErrorMock.mock.calls[0] as [Error, Record<string, unknown>];
+    expect(reported.message).toBe('Board overlay render failed: disk_full');
+    // The filename is still readable — just not part of the fingerprint.
+    expect(reported.message).not.toContain('.png');
+    const extra = options.extra as Record<string, unknown>;
+    expect(String(extra.renderErrorMessage)).toContain('out of space');
+    expect(reported.cause).toBeInstanceOf(Error);
+  });
+
+  it('downgrades a full device from an error to a warning', async () => {
+    renderRow(0);
+    await waitFor(() => expect(reportErrorMock).toHaveBeenCalled());
+    const [, options] = reportErrorMock.mock.calls[0] as [Error, Record<string, unknown>];
+    expect(options.level).toBe('warning');
+    expect(options.tags).toMatchObject({ renderFailure: 'disk_full', expected_disk_full: 'true' });
+  });
+
+  it('still pages at error level for a failure that is not the disk', async () => {
+    renderOutcome.mode = 'other';
+    renderRow(0);
+    await waitFor(() => expect(reportErrorMock).toHaveBeenCalled());
+    const [reported, options] = reportErrorMock.mock.calls[0] as [Error, Record<string, unknown>];
+    expect(reported.message).toBe('Board overlay render failed: render_failed');
+    expect(options.level).toBe('error');
+  });
+
+  it('stops calling the native renderer once it has latched, and kicks one sweep', async () => {
+    renderRow(0);
+    await waitFor(() => expect(sweepBoardArtCache).toHaveBeenCalledWith({ trigger: 'disk-pressure' }));
+    const callsBeforeBackoff = fakeNativeModule.renderHoldsOverlay.mock.calls.length;
+
+    for (let index = 1; index < 20; index += 1) renderRow(index);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Every row after the latch skipped the bridge entirely.
+    expect(fakeNativeModule.renderHoldsOverlay.mock.calls.length).toBe(callsBeforeBackoff);
+    expect(sweepBoardArtCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the wall photo on screen while backed off', async () => {
+    const { result } = renderRow(0);
+    await waitFor(() => expect(sweepBoardArtCache).toHaveBeenCalled());
+    const backedOff = renderRow(1);
+    // Overlay is null, backgrounds still resolve — the existing missing-layer
+    // contract, not a blank screen.
+    expect(backedOff.result.current.overlayUri).toBeNull();
+    expect(backedOff.result.current.backgroundPaths).toEqual(['file:///bg.png']);
+    expect(result.current.backgroundPaths).toEqual(['file:///bg.png']);
+  });
+});

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-disk-full.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-disk-full.test.tsx
@@ -16,7 +16,7 @@
 //     group per cache key. A guard alone was never enough.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 
 vi.mock('../../providers/theme-provider', () => ({ useAppColorScheme: () => 'light' }));
 
@@ -30,10 +30,18 @@ class MockFile {
   }
 }
 
+/** Free space on the cache volume, as the platform reports it. */
+const diskState = vi.hoisted(() => ({ freeBytes: null as number | null }));
+
 vi.mock('expo-file-system', () => ({
   Directory: vi.fn(() => ({ exists: false, list: () => [] })),
   File: MockFile,
-  Paths: { cache: { uri: 'file:///cache/' } },
+  Paths: {
+    cache: { uri: 'file:///cache/' },
+    get availableDiskSpace(): number | null {
+      return diskState.freeBytes;
+    },
+  },
 }));
 
 vi.mock('../../lib/board-details', () => ({
@@ -71,17 +79,24 @@ vi.mock('../../lib/hold-color-overrides', async (importOriginal) => {
 
 // Every render rejects the way a full volume does, with the FILENAME in the
 // message — which is what fragmented the Sentry groups.
-const renderOutcome = vi.hoisted(() => ({ mode: 'disk-full' as 'disk-full' | 'other' }));
+const renderOutcome = vi.hoisted(() => ({ mode: 'disk-full' as 'disk-full' | 'localized-disk-full' | 'other' }));
+
+/** What Foundation hands back for the same failure, by device language. */
+function failureMessage(mode: (typeof renderOutcome)['mode'], cacheKey: string): string {
+  if (mode === 'disk-full') {
+    return `The operation couldn’t be completed. You can’t save the file “${cacheKey}.png” because the volume “User” is out of space.`;
+  }
+  if (mode === 'localized-disk-full') {
+    // Same NSCocoaErrorDomain 640, on a phone set to Spanish.
+    return `No se puede guardar el archivo “${cacheKey}.png” porque el volumen “User” no tiene suficiente espacio.`;
+  }
+  return `render failed for ${cacheKey}: unknown native error`;
+}
+
 const fakeNativeModule = {
   boardRendererNative: {},
   renderHoldsOverlay: vi.fn((_configJson: string, cacheKey: string) =>
-    Promise.reject(
-      new Error(
-        renderOutcome.mode === 'disk-full'
-          ? `The operation couldn’t be completed. You can’t save the file “${cacheKey}.png” because the volume “User” is out of space.`
-          : `render failed for ${cacheKey}: unknown native error`,
-      ),
-    ),
+    Promise.reject(new Error(failureMessage(renderOutcome.mode, cacheKey))),
   ),
 };
 
@@ -102,6 +117,8 @@ function renderRow(index: number) {
 
 beforeEach(() => {
   renderOutcome.mode = 'disk-full';
+  // Default: a platform that won't say, so the message match stands alone.
+  diskState.freeBytes = null;
   _resetWarmupForTests();
   _inflightRendersForTests.clear();
   fakeNativeModule.renderHoldsOverlay.mockClear();
@@ -116,6 +133,19 @@ describe('classifyRenderFailure', () => {
     expect(classifyRenderFailure('write failed: ENOSPC (No space left on device)')).toBe('disk_full');
     expect(classifyRenderFailure('java.io.IOException: No space left on device')).toBe('disk_full');
     expect(classifyRenderFailure('unknown native error')).toBe('render_failed');
+  });
+
+  // `NSError.localizedDescription` is translated, so the wording above only
+  // exists on an English phone. Free space answers the same question in a way no
+  // locale can change.
+  it('recognises a full disk the OS described in another language', () => {
+    const spanish = 'No se puede guardar el archivo porque el volumen no tiene suficiente espacio.';
+    expect(classifyRenderFailure(spanish)).toBe('render_failed');
+    expect(classifyRenderFailure(spanish, 4 * 1024 * 1024)).toBe('disk_full');
+  });
+
+  it('does not blame the disk for a genuine render bug on a phone with room to spare', () => {
+    expect(classifyRenderFailure('unknown native error', 8 * 1024 * 1024 * 1024)).toBe('render_failed');
   });
 });
 
@@ -179,5 +209,71 @@ describe('out-of-space render storm', () => {
     expect(backedOff.result.current.overlayUri).toBeNull();
     expect(backedOff.result.current.backgroundPaths).toEqual(['file:///bg.png']);
     expect(result.current.backgroundPaths).toEqual(['file:///bg.png']);
+  });
+
+  // The same storm, on a phone that isn't set to English: without the free-space
+  // check nothing backs off and nothing sweeps, because the OS phrased "out of
+  // space" in Spanish.
+  it('backs off and sweeps when the OS reports the full disk in another language', async () => {
+    renderOutcome.mode = 'localized-disk-full';
+    diskState.freeBytes = 3 * 1024 * 1024;
+    renderRow(0);
+    await waitFor(() => expect(sweepBoardArtCache).toHaveBeenCalledWith({ trigger: 'disk-pressure' }));
+    const [reported, options] = reportErrorMock.mock.calls[0] as [Error, Record<string, unknown>];
+    expect(reported.message).toBe('Board overlay render failed: disk_full');
+    expect(options.level).toBe('warning');
+  });
+
+  // A play view the user is looking at never re-runs the render effect on its
+  // own, so without a re-trigger it stays without art for the life of the mount
+  // even after the sweep freed the space.
+  it('comes back once the back-off lifts instead of staying blank for the whole mount', async () => {
+    vi.useFakeTimers();
+    try {
+      renderRow(0);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(sweepBoardArtCache).toHaveBeenCalledWith({ trigger: 'disk-pressure' });
+
+      const stationary = renderRow(1);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      const callsWhileLatched = fakeNativeModule.renderHoldsOverlay.mock.calls.length;
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_001);
+      });
+      expect(fakeNativeModule.renderHoldsOverlay.mock.calls.length).toBeGreaterThan(callsWhileLatched);
+      // Still the missing-layer contract while it retries, never a blank screen.
+      expect(stationary.result.current.backgroundPaths).toEqual(['file:///bg.png']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('gives up after a bounded number of retries rather than retrying forever', async () => {
+    vi.useFakeTimers();
+    try {
+      renderRow(0);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      renderRow(1);
+
+      const attempts: number[] = [];
+      for (let round = 0; round < 6; round += 1) {
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(60_001);
+        });
+        attempts.push(fakeNativeModule.renderHoldsOverlay.mock.calls.length);
+      }
+      // Every retry fails and re-latches, so the count stops moving once the
+      // per-mount budget is spent.
+      expect(attempts.at(-1)).toBe(attempts.at(-2));
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
@@ -545,11 +545,18 @@ describe('capability-fallback render rejections', () => {
   });
 
   it('still reports an unrelated render failure', async () => {
-    rejectingNativeModule.renderHoldsOverlay.mockRejectedValue(new Error('disk full'));
+    rejectingNativeModule.renderHoldsOverlay.mockRejectedValue(new Error('some native failure'));
 
     renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES_SLOW }));
 
     await waitFor(() => expect(reportErrorMock).toHaveBeenCalledTimes(1));
-    expect((reportErrorMock.mock.calls[0][0] as Error).message).toBe('disk full');
+    // Reported through a stable synthetic message with the original as `cause`
+    // (issue #3647): Sentry groups on the message, and the native errors
+    // interpolate the cache filename, so reporting the raw error minted a new
+    // issue group per climb. The original text still rides along in `extra`.
+    const [reported, options] = reportErrorMock.mock.calls[0] as [Error, Record<string, unknown>];
+    expect(reported.message).toBe('Board overlay render failed: render_failed');
+    expect((reported.cause as Error).message).toBe('some native failure');
+    expect((options.extra as Record<string, unknown>).renderErrorMessage).toBe('some native failure');
   });
 });

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -13,6 +13,7 @@ import {
 import { useAppColorScheme } from '../providers/theme-provider';
 import { reportError } from '../lib/error-reporting';
 import { sweepBoardArtCache } from '../lib/sweep-caches';
+import { measureFreeCacheSpaceBytes } from '../lib/cache-dir-io';
 import {
   cacheRenderedOverlay,
   getRenderedOverlay,
@@ -210,8 +211,33 @@ type RenderFailureKind = 'disk_full' | 'render_failed';
 /** iOS's NSFileManager wording, plus the POSIX shapes Android surfaces. */
 const DISK_FULL_PATTERN = /out of space|ENOSPC|No space left/i;
 
-export function classifyRenderFailure(message: string): RenderFailureKind {
-  return DISK_FULL_PATTERN.test(message) ? 'disk_full' : 'render_failed';
+/**
+ * Below this much free space, a failed write is the disk — whatever language the
+ * OS said so in.
+ *
+ * A board overlay PNG is a few hundred KB, so 32 MB is far more headroom than one
+ * write needs: this is not "would this render have fit", it is "this phone is out
+ * of room", the same condition the English wording describes. The margin covers
+ * the gap between our probe and the write, and iOS's habit of refusing writes
+ * before the volume literally hits zero.
+ */
+const DISK_FULL_FREE_SPACE_BYTES = 32 * 1024 * 1024;
+
+/**
+ * @param freeDiskBytes free space on the cache volume, or null when unavailable.
+ *
+ * The message match is the fast path, but `NSError.localizedDescription` is
+ * TRANSLATED: on a Spanish, French or German phone a full volume reads "no hay
+ * espacio suficiente" / "n'a plus d'espace" / "nicht genügend Speicherplatz" and
+ * matches none of the English wording. Misclassifying that as `render_failed`
+ * costs exactly the storm this whole path exists to stop — no back-off, no sweep,
+ * every recycled row re-encoding a PNG it cannot write. Free space is the same
+ * question asked in a way no locale can change the answer to.
+ */
+export function classifyRenderFailure(message: string, freeDiskBytes: number | null = null): RenderFailureKind {
+  if (DISK_FULL_PATTERN.test(message)) return 'disk_full';
+  if (freeDiskBytes !== null && freeDiskBytes < DISK_FULL_FREE_SPACE_BYTES) return 'disk_full';
+  return 'render_failed';
 }
 
 const reportedRenderFailures = new Set<RenderFailureKind>();
@@ -269,6 +295,24 @@ let diskPressureUntilMs = 0;
 function isDiskPressureLatched(nowMs = Date.now()): boolean {
   return nowMs < diskPressureUntilMs;
 }
+
+/** How long until the current back-off lifts. Zero when nothing is latched. */
+function diskPressureRemainingMs(nowMs = Date.now()): number {
+  return Math.max(0, diskPressureUntilMs - nowMs);
+}
+
+/**
+ * How many times one mounted surface will come back after a back-off lifts.
+ *
+ * The back-off exists so a full device stops re-encoding PNGs it cannot write —
+ * but a play view the user is staring at has no prop change to bring it back, so
+ * without a re-trigger its overlay stays missing for the life of the mount even
+ * after the sweep freed 200 MB. Bounded rather than unlimited because the retry
+ * costs a full render on a device that may still be full: three attempts covers
+ * the sweep landing and a user deleting photos in the next couple of minutes,
+ * and then this surface gives up until it is remounted or its props change.
+ */
+const DISK_PRESSURE_MAX_RETRIES = 3;
 
 function latchDiskPressure(): void {
   diskPressureUntilMs = Date.now() + DISK_PRESSURE_BACKOFF_MS;
@@ -808,6 +852,9 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
   latestCacheKeyRef.current = currentCacheKey;
   const nativeRenderRef = useRef(nativeRender);
   nativeRenderRef.current = nativeRender;
+  // Per-mount budget for coming back after a full-disk back-off lifts. Not keyed
+  // on the cache key: a recycled row that lands on a new climb re-renders anyway.
+  const diskPressureRetriesRef = useRef(0);
   const retryBudgetRef = useRef({ key: currentCacheKey, used: 0 });
   if (retryBudgetRef.current.key !== currentCacheKey) {
     retryBudgetRef.current = { key: currentCacheKey, used: 0 };
@@ -943,7 +990,19 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     // Backed off after a full-disk failure: the write cannot succeed, and every
     // recycled row retrying it is what turned one out-of-space device into 50
     // Sentry events in 50 minutes. Overlay stays null; backgrounds still show.
-    if (isDiskPressureLatched()) return;
+    if (isDiskPressureLatched()) {
+      // Come back once when the latch lifts. A list scrolls and remounts rows,
+      // so it recovers on its own; a stationary play view never re-runs this
+      // effect, and would sit with no overlay for the rest of the mount even
+      // though the sweep this back-off kicked off may have freed the space.
+      if (diskPressureRetriesRef.current >= DISK_PRESSURE_MAX_RETRIES) return;
+      diskPressureRetriesRef.current += 1;
+      // +1ms so the latch has certainly expired by the time the effect re-runs.
+      const retryTimer = setTimeout(() => {
+        if (mountedRef.current) setRecoveryRequest((request) => request + 1);
+      }, diskPressureRemainingMs() + 1);
+      return () => clearTimeout(retryTimer);
+    }
 
     const renderPromise = getOrStartInflightRender(currentCacheKey, () => {
       const configJson = JSON.stringify({
@@ -988,7 +1047,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
         // whenever the signature stays default (issue #4240: 29 Sentry events
         // in 60s from one session).
         if (isCapabilityFallback) return;
-        const kind = classifyRenderFailure(message);
+        const kind = classifyRenderFailure(message, measureFreeCacheSpaceBytes());
         if (kind === 'disk_full') latchDiskPressure();
         reportRenderFailureOnce({
           kind,

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -12,6 +12,7 @@ import {
 } from '../lib/background-image-cache';
 import { useAppColorScheme } from '../providers/theme-provider';
 import { reportError } from '../lib/error-reporting';
+import { sweepBoardArtCache } from '../lib/sweep-caches';
 import {
   cacheRenderedOverlay,
   getRenderedOverlay,
@@ -198,6 +199,94 @@ function reportOverlayLoadOnce(kind: OverlayLoadTelemetryKind, boardName: BoardN
 }
 
 /**
+ * Why a render failed, at a cardinality Sentry can group on.
+ *
+ * `disk_full` is the device being out of space, which is a user condition rather
+ * than a defect in this code: the write cannot succeed, and every recycled
+ * FlashList row tries again.
+ */
+type RenderFailureKind = 'disk_full' | 'render_failed';
+
+/** iOS's NSFileManager wording, plus the POSIX shapes Android surfaces. */
+const DISK_FULL_PATTERN = /out of space|ENOSPC|No space left/i;
+
+export function classifyRenderFailure(message: string): RenderFailureKind {
+  return DISK_FULL_PATTERN.test(message) ? 'disk_full' : 'render_failed';
+}
+
+const reportedRenderFailures = new Set<RenderFailureKind>();
+
+/**
+ * One Sentry event per failure class per JS lifetime, carrying a STABLE message.
+ *
+ * Both halves are load-bearing. Without the once-guard, a full device produced
+ * one `level: error` event per recycled row — 50 events in 50 minutes from a
+ * single device (BOARDSESH-C6/C7/C8), because `getOrStartInflightRender` clears
+ * the settled promise so every recycle re-renders and re-reports. And without
+ * the stable synthetic message, the guard alone would not have been enough:
+ * Sentry groups on the message, and the raw error interpolates the FILENAME
+ * ("You can't save the file \"v5_….png\"…"), so each distinct cache key minted a
+ * NEW issue group. That is why one device produced three of them. The original
+ * error rides along as `cause`, and the filename lands in `extra` where it is
+ * still readable but no longer part of the fingerprint.
+ */
+function reportRenderFailureOnce(params: {
+  kind: RenderFailureKind;
+  error: unknown;
+  message: string;
+  boardName: BoardName;
+  extra: Record<string, unknown>;
+}): void {
+  const { kind, error, message, boardName, extra } = params;
+  if (reportedRenderFailures.has(kind)) return;
+  reportedRenderFailures.add(kind);
+  const isDiskFull = kind === 'disk_full';
+  reportError(new Error(`Board overlay render failed: ${kind}`, { cause: error }), {
+    // A device with no free space is expected behaviour we back off from, not a
+    // bug to page on.
+    level: isDiskFull ? 'warning' : 'error',
+    tags: {
+      feature: 'mobile_board_renderer',
+      boardName,
+      renderFailure: kind,
+      ...(isDiskFull ? { expected_disk_full: 'true' } : {}),
+    },
+    extra: { ...extra, renderErrorMessage: message },
+  });
+}
+
+/**
+ * How long the render path stays quiet after the device reports a full disk.
+ *
+ * The overlay stays null and the wall photo still shows — the existing
+ * missing-layer contract — so the cost of backing off is a plain board rather
+ * than a blank screen. The cost of NOT backing off is a phone with no free space
+ * burning battery re-encoding PNGs it cannot write.
+ */
+const DISK_PRESSURE_BACKOFF_MS = 60_000;
+let diskPressureUntilMs = 0;
+
+function isDiskPressureLatched(nowMs = Date.now()): boolean {
+  return nowMs < diskPressureUntilMs;
+}
+
+function latchDiskPressure(): void {
+  diskPressureUntilMs = Date.now() + DISK_PRESSURE_BACKOFF_MS;
+  // Free what we can while we are backed off. The sweeper's own per-trigger rate
+  // limit keeps this to one sweep even if several rows fail at once.
+  void sweepBoardArtCache({ trigger: 'disk-pressure' }).catch(() => {
+    // Best-effort: a sweep that fails on a full disk changes nothing about the
+    // back-off, which is the part that stops the storm.
+  });
+}
+
+/** Test-only handles for the failure-reporting guards. */
+export function _resetRenderFailureStateForTests(): void {
+  reportedRenderFailures.clear();
+  diskPressureUntilMs = 0;
+}
+
+/**
  * One-time eager scan of the native module's PNG cache directory. The
  * Swift/Kotlin modules write to {cache}/board-thumbnails/<cacheKey>.png;
  * we list it once at JS startup and populate `renderedOverlays` so prior
@@ -266,6 +355,7 @@ export function _resetWarmupForTests(): void {
   warmupRun = false;
   _resetOverlayIndexForTests();
   reportedOverlayLoadTelemetry.clear();
+  _resetRenderFailureStateForTests();
 }
 
 /** Test-only handle to invoke the warm-up explicitly (it normally runs lazily on first render). */
@@ -850,6 +940,10 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       holdRenderSignature,
     );
     if (!boardConfig) return;
+    // Backed off after a full-disk failure: the write cannot succeed, and every
+    // recycled row retrying it is what turned one out-of-space device into 50
+    // Sentry events in 50 minutes. Overlay stays null; backgrounds still show.
+    if (isDiskPressureLatched()) return;
 
     const renderPromise = getOrStartInflightRender(currentCacheKey, () => {
       const configJson = JSON.stringify({
@@ -894,11 +988,13 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
         // whenever the signature stays default (issue #4240: 29 Sentry events
         // in 60s from one session).
         if (isCapabilityFallback) return;
-        reportError(error, {
-          tags: {
-            feature: 'mobile_board_renderer',
-            boardName,
-          },
+        const kind = classifyRenderFailure(message);
+        if (kind === 'disk_full') latchDiskPressure();
+        reportRenderFailureOnce({
+          kind,
+          error,
+          message,
+          boardName,
           extra: {
             layoutId,
             sizeId,

--- a/packages/mobile/src/lib/cache-dir-io.ts
+++ b/packages/mobile/src/lib/cache-dir-io.ts
@@ -132,6 +132,23 @@ export function deleteCacheDirEntries(dirName: string, names: readonly string[])
   return deleted;
 }
 
+/**
+ * Free bytes on the volume the cache lives on, or null when the platform won't say.
+ *
+ * A `statfs`, not a walk — cheap enough to ask on a failed write. It exists so
+ * "is this device full?" has an answer that does not depend on the language the
+ * OS phrased its error in: `NSError.localizedDescription` is translated, so
+ * matching English wording alone misses a full disk on every non-English phone.
+ */
+export function measureFreeCacheSpaceBytes(): number | null {
+  try {
+    const availableBytes = Paths.availableDiskSpace;
+    return typeof availableBytes === 'number' && Number.isFinite(availableBytes) ? availableBytes : null;
+  } catch {
+    return null;
+  }
+}
+
 /** The expo-image disk-cache directory on this device, or null when none of the known names exist. */
 export function resolveImageCacheDirName(): string | null {
   for (const candidate of IMAGE_CACHE_DIR_CANDIDATES) {

--- a/packages/mobile/src/lib/cache-dir-io.web.ts
+++ b/packages/mobile/src/lib/cache-dir-io.web.ts
@@ -19,6 +19,10 @@ export function deleteCacheDirEntries(): string[] {
   return [];
 }
 
+export function measureFreeCacheSpaceBytes(): number | null {
+  return null;
+}
+
 export function resolveImageCacheDirName(): string | null {
   return null;
 }


### PR DESCRIPTION
Stacked on #4338. Last of the #3647 cache work: the thing a full device does to Sentry, and to the battery.

## The evidence

`search_issues(org=boardsesh, "out of space", 90d)` returns four live groups, all the same exception:

| Issue | Events |
| --- | --- |
| BOARDSESH-C6 | 23 |
| BOARDSESH-C7 | 16 |
| BOARDSESH-C8 | 11 |
| BOARDSESH-CZ | 1 (a second device, `tension_10_6`, four days old) |

All `UnexpectedException: You can't save the file "v5_….png" because the volume "User" is out of space`, from `ExpoModulesCore/AsyncFunctionDefinition.swift:126` — i.e. the `renderHoldsOverlay` AsyncFunction rejecting. C6/C7/C8 are one device: **50 events in 50 minutes.**

This is a different path from #4240's capability-fallback storm, which is already guarded at the `MARKER_RENDERER_UNAVAILABLE_MESSAGE` check and never reaches `reportError`.

**Two independent causes, and fixing only one wouldn't have worked:**

1. The reporter had no once-guard, and `getOrStartInflightRender` clears the settled promise — so every recycled FlashList row re-renders and re-reports.
2. **Sentry groups on the message, and the message interpolates the FILENAME.** So even one event per row would still have minted a new issue group per cache key. That is why one device produced three groups, and it is why a once-guard alone was not the fix.

## Changes

- `classifyRenderFailure(message)` → `'disk_full' | 'render_failed'`, matching the wording each platform uses (`out of space`, `ENOSPC`, `No space left`).
- `reportRenderFailureOnce` — one event per class per JS lifetime, reported through a **stable synthetic message** (`Board overlay render failed: disk_full`) with the original error as `cause` and its text in `extra.renderErrorMessage`. The filename stays readable; it just stops being part of the fingerprint.
- Out-of-space reports at `level: 'warning'` with an `expected_disk_full` tag. A device with no free space is a user condition we back off from, not a bug to page on. Anything else still reports at `error`.
- **A 60-second disk-pressure latch.** The first out-of-space failure skips the native bridge for a minute and kicks exactly one `sweepBoardArtCache({ trigger: 'disk-pressure' })`. Zero cost on the normal path — no `availableDiskSpace` read per render, just an integer comparison. The overlay stays null and the wall photo still shows: the existing missing-layer contract, not a blank screen.

## Sentry note

This deliberately changes grouping. C6/C7/C8 and CZ will stop receiving events and a single new group will appear. That is the fix working, **not** the storm having stopped on its own — worth saying out loud before someone reads the quiet as a resolution. Happy to resolve the four old groups with a pointer at the new one if you'd rather they didn't just go silent.

Also parked, not smuggled in: `retryOnceAfterRecreatingCacheDir` (`BoardRendererModule.swift`) retries an out-of-space write that `BoardRendererErrorClassificationTests.swift` already classifies as non-retryable, doubling the failed writes per row. That is a native-fingerprint change, so it belongs in a `[native-train]` follow-up alongside making the once-per-launch prune gate periodic.

No native-fingerprint inputs touched here: no new dependencies, no plugin, no `app.config.ts`, nothing under `modules/`, `ios/`, `android/`, or `patches/`.

## Release Notes

A phone that's out of space no longer burns battery re-drawing board art it can't save — Boardsesh backs off, frees what it can, and keeps the wall photo on screen.

## Test plan

All foreground, all via `vp`:

- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — **628 files, 5556 tests, all passing.**
- New `use-native-climb-render-disk-full.test.tsx` (7 tests), driving the real hook through a native module that rejects the way a full volume does, filename and all: 20 failing rows produce **one** report, not 20; that report's message is stable and filename-free with the original as `cause`; out-of-space lands at `warning` with the tag while an unrelated failure still lands at `error`; after the latch every subsequent row skips the bridge entirely and exactly one sweep was kicked; and `backgroundPaths` still resolves while backed off.
- Updated the existing "still reports an unrelated render failure" case in `use-native-climb-render-race.test.tsx` — it asserted the raw error was reported, which is precisely the behaviour this PR changes; it now pins the synthetic message plus the `cause` and `extra` round-trip.
- `vp run check:mobile-bundle` — Android bundle OK.
- `vp check` — clean for every file this PR touches.

Manual QA (in `.boardsesh/qa-notes.md`): fill a simulator's disk and scroll a climb list — expect one Sentry warning in one group, not 50 events across three, and a board that still renders its wall photo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT6VP1sWqk6bY9mUgyeS2U
