### PR TITLE
fix(mobile): refresh downloaded-board state and add the offline nudge policy (1/4)

### DIFF
--- a/.claude/skills/discord-feedback-triage/SKILL.md
+++ b/.claude/skills/discord-feedback-triage/SKILL.md
@@ -25,17 +25,17 @@ The invoking prompt gives you the bundle path and the decisions path. Each bundl
 
 One decision per message. Every message in the bundle gets exactly one.
 
-| Verdict | When | Result |
-|---|---|---|
-| `bug` | A concrete thing that is broken — has a symptom, and ideally a surface or device | Issue, labelled `bug` |
-| `feature` | A specific missing capability | Issue, labelled `enhancement` |
-| `question` | Asking how something works, or for support | Reaction only |
-| `noise` | Chatter, praise, off-topic, or too vague to act on | Reaction only |
-| `duplicate` | Already tracked, or repeats another message in this same bundle | Reaction + reply linking the existing issue |
+| Verdict     | When                                                                             | Result                                      |
+| ----------- | -------------------------------------------------------------------------------- | ------------------------------------------- |
+| `bug`       | A concrete thing that is broken — has a symptom, and ideally a surface or device | Issue, labelled `bug`                       |
+| `feature`   | A specific missing capability                                                    | Issue, labelled `enhancement`               |
+| `question`  | Asking how something works, or for support                                       | Reaction only                               |
+| `noise`     | Chatter, praise, off-topic, or too vague to act on                               | Reaction only                               |
+| `duplicate` | Already tracked, or repeats another message in this same bundle                  | Reaction + reply linking the existing issue |
 
 **Default to `noise` when uncertain.** A tracker full of unactionable issues is worse than missing one report — the reporter is still in Discord and will say it again.
 
-The line: *"the app is slow"* is `noise`. *"the board list takes 30s on my Pixel 8"* is a `bug`. *"would be nice if it did more"* is `noise`. *"let me sort the queue by grade"* is a `feature`.
+The line: _"the app is slow"_ is `noise`. _"the board list takes 30s on my Pixel 8"_ is a `bug`. _"would be nice if it did more"_ is `noise`. _"let me sort the queue by grade"_ is a `feature`.
 
 Weigh `threadContext` — the back-and-forth after a message usually contains the repro steps and the device, and often reveals the original report was user error.
 

--- a/docs/discord-feedback-pipeline.md
+++ b/docs/discord-feedback-pipeline.md
@@ -16,11 +16,11 @@ Bugs and feature requests become issues. Questions, praise, and chatter get the 
 
 Three separate **jobs**, not three steps in one:
 
-| Job | Environment | Permissions | Holds |
-|---|---|---|---|
-| `collect` | `discord-feedback` | `contents: read` | Discord token |
-| `triage` | **none** | `contents/issues: read` | Claude token only |
-| `apply` | `discord-feedback` | `contents/issues: write` | Discord token |
+| Job       | Environment        | Permissions              | Holds             |
+| --------- | ------------------ | ------------------------ | ----------------- |
+| `collect` | `discord-feedback` | `contents: read`         | Discord token     |
+| `triage`  | **none**           | `contents/issues: read`  | Claude token only |
+| `apply`   | `discord-feedback` | `contents/issues: write` | Discord token     |
 
 **The privilege separation is the security model.** The triage job reads text typed by anyone who can click a public invite, so it is the one that must be assumed compromised. It has no Discord token, no repo write, no issue write, and — because it declares no `environment:` — no ability to name a single environment secret. A prompt injection that fully captures that agent still cannot reach GitHub or Discord. Its only output is a JSON file.
 
@@ -34,14 +34,14 @@ The file→react→reply ordering lives in tested TypeScript rather than in the 
 
 **The bundle is digest-pinned across the triage job.** Cross-validating decisions against the bundle only helps if the bundle itself is trustworthy. The `collect` job records its sha256 as a job output — a different job from the one the agent runs in, so the agent has no way to write it — and `apply` refuses to file anything if the bundle no longer matches.
 
-| File | Role |
-|---|---|
-| `scripts/discord-feedback-scan.ts` | All Discord/GitHub I/O, retries, secrets, CLI |
-| `scripts/lib/discord-feedback.ts` | Pure: snowflakes, emoji matching, triggers, noise, redaction shaping |
-| `scripts/lib/discord-feedback-issue.ts` | Pure: marker, decision validation, issue body, replies |
-| `.claude/skills/discord-feedback-triage/` | The classifier prompt + output schema |
-| `.github/workflows/discord-feedback-issues.yml` | The scheduled job |
-| `scripts/tsconfig.json` | Typechecks these files — repo-root `scripts/` had no CI typecheck before |
+| File                                            | Role                                                                     |
+| ----------------------------------------------- | ------------------------------------------------------------------------ |
+| `scripts/discord-feedback-scan.ts`              | All Discord/GitHub I/O, retries, secrets, CLI                            |
+| `scripts/lib/discord-feedback.ts`               | Pure: snowflakes, emoji matching, triggers, noise, redaction shaping     |
+| `scripts/lib/discord-feedback-issue.ts`         | Pure: marker, decision validation, issue body, replies                   |
+| `.claude/skills/discord-feedback-triage/`       | The classifier prompt + output schema                                    |
+| `.github/workflows/discord-feedback-issues.yml` | The scheduled job                                                        |
+| `scripts/tsconfig.json`                         | Typechecks these files — repo-root `scripts/` had no CI typecheck before |
 
 Root `scripts/` was never typechecked, so a broken type here would only have surfaced when the scheduled workflow failed at runtime. `vp run typecheck:scripts` now covers this pipeline and runs as part of the `typecheck` aggregate; widen its `include` as other scripts are made type-clean.
 
@@ -66,24 +66,24 @@ Channel and guild ids need Developer Mode on (Discord → Settings → Advanced)
 
 Everything for this pipeline lives in a dedicated **`discord-feedback` environment** (repo → Settings → Environments), **not** in `Production`. Keep it that way — and keep it **reviewer-free**, or scheduled runs hang forever waiting for an approval nobody is watching for.
 
-| Name | Where | Notes |
-|---|---|---|
-| `DISCORD_BOT_TOKEN` | `discord-feedback` secret | Bot token from the portal. The only secret this pipeline needs |
-| `CLAUDE_CODE_OAUTH_TOKEN` | repo secret | Already exists, shared with `claude.yml`. Used by the `triage` job, which declares no environment |
+| Name                      | Where                     | Notes                                                                                             |
+| ------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------- |
+| `DISCORD_BOT_TOKEN`       | `discord-feedback` secret | Bot token from the portal. The only secret this pipeline needs                                    |
+| `CLAUDE_CODE_OAUTH_TOKEN` | repo secret               | Already exists, shared with `claude.yml`. Used by the `triage` job, which declares no environment |
 
 `DISCORD_DEPLOY_WEBHOOK` stays in `Production` — different thing, used by the deploy workflows.
 
 Variables, all in the `discord-feedback` environment except the kill switch (non-secret so they're auditable in the run log):
 
-| Name | Where | Default / example |
-|---|---|---|
-| `DISCORD_FEEDBACK_ENABLED` | **repo level** | `true` — kill switch for the **hourly run**; manual dispatch works regardless |
-| `DISCORD_GUILD_ID` | `discord-feedback` | The Boardsesh guild id |
-| `DISCORD_FEEDBACK_CHANNEL_IDS` | `discord-feedback` | Comma-separated; the `#user-feedback` id |
-| `DISCORD_EXCLUDE_CHANNEL_IDS` | `discord-feedback` | Comma-separated; optional |
-| `DISCORD_TRIGGER_EMOJI` | `discord-feedback` | `🐛` (custom emoji: `name:id`) |
-| `DISCORD_PROCESSED_EMOJI` | `discord-feedback` | `✅` |
-| `DISCORD_TRIGGER_KEYWORDS` | `discord-feedback` | `bug,issue,file this,feature request` |
+| Name                           | Where              | Default / example                                                             |
+| ------------------------------ | ------------------ | ----------------------------------------------------------------------------- |
+| `DISCORD_FEEDBACK_ENABLED`     | **repo level**     | `true` — kill switch for the **hourly run**; manual dispatch works regardless |
+| `DISCORD_GUILD_ID`             | `discord-feedback` | The Boardsesh guild id                                                        |
+| `DISCORD_FEEDBACK_CHANNEL_IDS` | `discord-feedback` | Comma-separated; the `#user-feedback` id                                      |
+| `DISCORD_EXCLUDE_CHANNEL_IDS`  | `discord-feedback` | Comma-separated; optional                                                     |
+| `DISCORD_TRIGGER_EMOJI`        | `discord-feedback` | `🐛` (custom emoji: `name:id`)                                                |
+| `DISCORD_PROCESSED_EMOJI`      | `discord-feedback` | `✅`                                                                          |
+| `DISCORD_TRIGGER_KEYWORDS`     | `discord-feedback` | `bug,issue,file this,feature request`                                         |
 
 ### 4. Provenance label
 
@@ -110,13 +110,13 @@ Two independent guards:
 
 Per message the order is `findIssueByMarker → ensureLabels → createIssue → addReaction → postReply`.
 
-| Crash point | Next run sees | Outcome |
-|---|---|---|
-| before create | no reaction, no marker | re-triaged and filed; one wasted triage |
+| Crash point    | Next run sees             | Outcome                                                                      |
+| -------------- | ------------------------- | ---------------------------------------------------------------------------- |
+| before create  | no reaction, no marker    | re-triaged and filed; one wasted triage                                      |
 | create → react | no reaction, marker found | creation short-circuits; reacts + replies. **This is why the marker exists** |
-| react → reply | reaction present | skipped; the reply is never posted |
+| react → reply  | reaction present          | skipped; the reply is never posted                                           |
 
-That last row is a deliberate trade. Replying before reacting would turn a missing reply into a *duplicate* reply on every subsequent run, which is louder and worse.
+That last row is a deliberate trade. Replying before reacting would turn a missing reply into a _duplicate_ reply on every subsequent run, which is louder and worse.
 
 ## Privacy
 
@@ -158,16 +158,16 @@ vp run discord:feedback-scan -- --mode apply --bundle /tmp/bundle.json --decisio
 
 ## Troubleshooting
 
-| Symptom | Cause |
-|---|---|
-| Run fails with "MESSAGE CONTENT ... disabled" | The privileged intent is off in the Developer Portal |
-| Run fails with "every scan pass failed" | The bot isn't in the guild, or lacks View Channels / Read Message History. `403 Missing Access` on `/guilds/{id}/channels` means **not a member** — inviting it is a browser flow you have to complete, editing the `permissions=` number in the URL does nothing on its own |
-| Collect finds nothing on a busy server | Bot can't see the channels — check role and category overrides |
-| `Discord 403` for one channel | Normal for channels the bot isn't allowed in; it's logged and skipped |
-| `Discord 401` | Bad or rotated token. Fails fast on purpose — repeated 401s get the runner IP Cloudflare-banned |
-| Triage step green but "did not write ... decisions" | A tool the agent needed was denied. Read `claude-execution-output.json` in the run artifact and check `permission_denials_count`. Note Claude Code only consults path rules for `Read`/`Edit` — a `Write(<path>)` rule is accepted and silently never checked |
-| Issues filed but no ✅ | Crash between filing and reacting; the next run recovers via the marker |
-| Same issue filed twice | Should be impossible — check the marker is the body's first line and that search isn't lagging |
-| Nothing runs at all | `DISCORD_FEEDBACK_ENABLED` is not `true` |
+| Symptom                                             | Cause                                                                                                                                                                                                                                                                        |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Run fails with "MESSAGE CONTENT ... disabled"       | The privileged intent is off in the Developer Portal                                                                                                                                                                                                                         |
+| Run fails with "every scan pass failed"             | The bot isn't in the guild, or lacks View Channels / Read Message History. `403 Missing Access` on `/guilds/{id}/channels` means **not a member** — inviting it is a browser flow you have to complete, editing the `permissions=` number in the URL does nothing on its own |
+| Collect finds nothing on a busy server              | Bot can't see the channels — check role and category overrides                                                                                                                                                                                                               |
+| `Discord 403` for one channel                       | Normal for channels the bot isn't allowed in; it's logged and skipped                                                                                                                                                                                                        |
+| `Discord 401`                                       | Bad or rotated token. Fails fast on purpose — repeated 401s get the runner IP Cloudflare-banned                                                                                                                                                                              |
+| Triage step green but "did not write ... decisions" | A tool the agent needed was denied. Read `claude-execution-output.json` in the run artifact and check `permission_denials_count`. Note Claude Code only consults path rules for `Read`/`Edit` — a `Write(<path>)` rule is accepted and silently never checked                |
+| Issues filed but no ✅                              | Crash between filing and reacting; the next run recovers via the marker                                                                                                                                                                                                      |
+| Same issue filed twice                              | Should be impossible — check the marker is the body's first line and that search isn't lagging                                                                                                                                                                               |
+| Nothing runs at all                                 | `DISCORD_FEEDBACK_ENABLED` is not `true`                                                                                                                                                                                                                                     |
 
 **Rollback:** set `DISCORD_FEEDBACK_ENABLED=false`. Emergency: revoke the bot token. Filed issues stay, and the ✅ reactions remain an accurate record of what was processed, so re-enabling never re-files.

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -31,11 +31,19 @@ import {
   getDeadLetterCount,
   getDeadLetters,
   retryDeadLetter,
+<<<<<<< HEAD
   getDownloadedScopeKeys,
+||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
+  getPendingCount,
+  getDownloadedScopeKeys,
+=======
+  getPendingCount,
+>>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
   measureReclaimableBytes,
   type GraphQLFetch,
 } from '@boardsesh/offline-sync';
 import { drainMutationQueue } from '../../../src/offline/offline-sync-adapter';
+import { useDownloadedScopeKeys } from '../../../src/offline/use-downloaded-scope-keys';
 import { getHttpClient } from '../../../src/lib/graphql/client';
 import { hapticLight, hapticSelection } from '../../../src/lib/haptics';
 import { DevMetadataPanel } from '../../../src/components/DevMetadataPanel';
@@ -178,10 +186,19 @@ export default function MoreScreen() {
   // sign-out — which clears syncEnabledBoards but deliberately keeps the rows as the
   // shared cache). One cheap indexed read, same cost shape as the dead-letter count.
   // Shares the ['downloadedScopeKeys'] cache entry with My Boards, so this warms it.
+<<<<<<< HEAD
   const { data: downloadedScopeKeys } = useQuery({
     queryKey: ['downloadedScopeKeys', schemaReady],
     queryFn: () => getDownloadedScopeKeys(db),
   });
+||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
+  const { data: downloadedScopeKeys } = useQuery({
+    queryKey: ['downloadedScopeKeys'],
+    queryFn: () => getDownloadedScopeKeys(db),
+  });
+=======
+  const { data: downloadedScopeKeys } = useDownloadedScopeKeys();
+>>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
   // ...AND when a removal deleted its rows but the compaction never landed, so the
   // freelist is still holding real space. That state clears the scope-complete
   // markers (so downloadedScopeKeys is empty) and can coincide with the flag being

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -31,14 +31,6 @@ import {
   getDeadLetterCount,
   getDeadLetters,
   retryDeadLetter,
-<<<<<<< HEAD
-  getDownloadedScopeKeys,
-||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
-  getPendingCount,
-  getDownloadedScopeKeys,
-=======
-  getPendingCount,
->>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
   measureReclaimableBytes,
   type GraphQLFetch,
 } from '@boardsesh/offline-sync';
@@ -186,19 +178,7 @@ export default function MoreScreen() {
   // sign-out — which clears syncEnabledBoards but deliberately keeps the rows as the
   // shared cache). One cheap indexed read, same cost shape as the dead-letter count.
   // Shares the ['downloadedScopeKeys'] cache entry with My Boards, so this warms it.
-<<<<<<< HEAD
-  const { data: downloadedScopeKeys } = useQuery({
-    queryKey: ['downloadedScopeKeys', schemaReady],
-    queryFn: () => getDownloadedScopeKeys(db),
-  });
-||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
-  const { data: downloadedScopeKeys } = useQuery({
-    queryKey: ['downloadedScopeKeys'],
-    queryFn: () => getDownloadedScopeKeys(db),
-  });
-=======
   const { data: downloadedScopeKeys } = useDownloadedScopeKeys();
->>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
   // ...AND when a removal deleted its rows but the compaction never landed, so the
   // freelist is still holding real space. That state clears the scope-complete
   // markers (so downloadedScopeKeys is empty) and can coincide with the flag being

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -25,12 +25,7 @@ import { useBottomChromeMetrics } from '../../src/hooks/use-bottom-chrome-metric
 import { useIsOffline } from '../../src/hooks/use-is-offline';
 import { useOfflineBoards } from '../../src/settings';
 import { useRememberDownloadedBoards } from '../../src/offline/use-remember-downloaded-boards';
-<<<<<<< HEAD
-import { useOfflineSchemaReady } from '../../src/db/use-offline-schema-ready';
-||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
-=======
 import { useDownloadedScopeKeys } from '../../src/offline/use-downloaded-scope-keys';
->>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
 import { resolveBoardReturnTo } from '../../src/lib/boards/board-return-to';
 import { setBoardRevealTipPending } from '../../src/lib/onboarding/onboarding-storage';
 import { track } from '../../src/lib/analytics';
@@ -82,31 +77,7 @@ export default function BoardSelection() {
   // false claim whose only CTA also needs the network. Fall back to the boards this
   // device has actually downloaded.
   const isOffline = useIsOffline();
-<<<<<<< HEAD
-  const db = useSQLiteContext();
-  // Ungated by the offline-downloads flag: this reads rows already on disk, and a
-  // flag flipped off must not strand a device that has downloads.
-  //
-  // Schema readiness is a KEY member, not an `enabled` gate. On a contended launch
-  // this connection has no tables yet, and the read lands in `isError` — the empty
-  // state, which is already the right answer. Gating instead would spin forever
-  // whenever init genuinely fails; keying makes a late readiness flip refetch.
-  const schemaReady = useOfflineSchemaReady();
-  const { data: downloadedScopeKeys } = useQuery({
-    queryKey: ['downloadedScopeKeys', schemaReady],
-    queryFn: () => getDownloadedScopeKeys(db),
-  });
-||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
-  const db = useSQLiteContext();
-  // Ungated by the offline-downloads flag: this reads rows already on disk, and a
-  // flag flipped off must not strand a device that has downloads.
-  const { data: downloadedScopeKeys } = useQuery({
-    queryKey: ['downloadedScopeKeys'],
-    queryFn: () => getDownloadedScopeKeys(db),
-  });
-=======
   const { data: downloadedScopeKeys } = useDownloadedScopeKeys();
->>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
   const offlineCards = useOfflineBoards();
   // `isError && nothing cached` is the lying-connection case: captive portal or gym
   // wifi with a dead upstream, where onlineManager says online, the request fails for

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -2,11 +2,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { View, ScrollView, StyleSheet } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { useSQLiteContext } from 'expo-sqlite';
-import { useQuery } from '@tanstack/react-query';
 import type BottomSheet from '@expo/ui/community/bottom-sheet';
 import type { UserBoard } from '@boardsesh/shared-schema';
-import { getDownloadedScopeKeys } from '@boardsesh/offline-sync';
 import { useMyBoards, usePopularBoardConfigs, useNearbyBoards } from '../../src/lib/graphql/hooks';
 import { useActiveBoard, useSetActiveBoard } from '../../src/lib/graphql/use-active-board';
 import { useAdoptFoundBoard } from '../../src/lib/board-discovery/use-adopt-found-board';
@@ -28,7 +25,12 @@ import { useBottomChromeMetrics } from '../../src/hooks/use-bottom-chrome-metric
 import { useIsOffline } from '../../src/hooks/use-is-offline';
 import { useOfflineBoards } from '../../src/settings';
 import { useRememberDownloadedBoards } from '../../src/offline/use-remember-downloaded-boards';
+<<<<<<< HEAD
 import { useOfflineSchemaReady } from '../../src/db/use-offline-schema-ready';
+||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
+=======
+import { useDownloadedScopeKeys } from '../../src/offline/use-downloaded-scope-keys';
+>>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
 import { resolveBoardReturnTo } from '../../src/lib/boards/board-return-to';
 import { setBoardRevealTipPending } from '../../src/lib/onboarding/onboarding-storage';
 import { track } from '../../src/lib/analytics';
@@ -80,6 +82,7 @@ export default function BoardSelection() {
   // false claim whose only CTA also needs the network. Fall back to the boards this
   // device has actually downloaded.
   const isOffline = useIsOffline();
+<<<<<<< HEAD
   const db = useSQLiteContext();
   // Ungated by the offline-downloads flag: this reads rows already on disk, and a
   // flag flipped off must not strand a device that has downloads.
@@ -93,6 +96,17 @@ export default function BoardSelection() {
     queryKey: ['downloadedScopeKeys', schemaReady],
     queryFn: () => getDownloadedScopeKeys(db),
   });
+||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
+  const db = useSQLiteContext();
+  // Ungated by the offline-downloads flag: this reads rows already on disk, and a
+  // flag flipped off must not strand a device that has downloads.
+  const { data: downloadedScopeKeys } = useQuery({
+    queryKey: ['downloadedScopeKeys'],
+    queryFn: () => getDownloadedScopeKeys(db),
+  });
+=======
+  const { data: downloadedScopeKeys } = useDownloadedScopeKeys();
+>>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
   const offlineCards = useOfflineBoards();
   // `isError && nothing cached` is the lying-connection case: captive portal or gym
   // wifi with a dead upstream, where onlineManager says online, the request fails for

--- a/packages/mobile/app/boards/manage.tsx
+++ b/packages/mobile/app/boards/manage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import { Pressable, RefreshControl, StyleSheet, View } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import { useNavigation, useRouter } from 'expo-router';
@@ -18,25 +18,21 @@ import {
 } from '../../src/providers/feature-flags-provider';
 import { useBottomChromeMetrics } from '../../src/hooks/use-bottom-chrome-metrics';
 import { useSyncStatus } from '../../src/sync';
-import {
-  getDownloadedScopeKeys,
-  getCheckpoint,
-  getCheckpointKey,
-  readBootstrapRetryState,
-  isScopeDownloadComplete,
-  isBootstrapDone,
-  getBootstrapMetadataByScope,
-  estimateScopeDownload,
-} from '@boardsesh/offline-sync';
-import { useBoardDownloads } from '../../src/offline/use-board-downloads';
+import { getBootstrapMetadataByScope } from '@boardsesh/offline-sync';
+import { useConfirmBoardDownload } from '../../src/offline/use-confirm-board-download';
+import { useDownloadedScopeKeys } from '../../src/offline/use-downloaded-scope-keys';
 import { useRememberDownloadedBoards } from '../../src/offline/use-remember-downloaded-boards';
-import { useSnapshotManifest } from '../../src/offline/use-snapshot-manifest';
 import { useSnapshotSource } from '../../src/offline/use-snapshot-source';
+<<<<<<< HEAD
 import { useOfflineSchemaReady } from '../../src/db/use-offline-schema-ready';
 import { formatBytes } from '../../src/lib/format-bytes';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { track } from '../../src/lib/analytics';
 import { isOfflineEngineEnabled } from '../../src/lib/offline-engine';
+||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
+import { formatBytes } from '../../src/lib/format-bytes';
+=======
+>>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
 import {
   getSetting,
   useSetting,
@@ -76,7 +72,7 @@ const getItemType = (item: ManageItem) => item.type;
 export default function ManageBoards() {
   const router = useRouter();
   const navigation = useNavigation();
-  const { t, i18n } = useTranslation('boards');
+  const { t } = useTranslation('boards');
   const { isAuthenticated, refreshAuthState } = useAuth();
   const { systemColors, brandColors } = useTheme();
   const { showToast } = useToast();
@@ -128,7 +124,13 @@ export default function ManageBoards() {
   // previously-queued writes still flush (see OfflineSyncBridge). This screen
   // stays the only writer of syncEnabledBoards.
   const offlineDownloadsEnabled = useOfflineDownloadsEnabled();
+<<<<<<< HEAD
   const { enableBoardsOffline, retryFastDownload } = useBoardDownloads();
+||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
+  const { enableBoardsOffline } = useBoardDownloads();
+=======
+  const { confirmAndDownload } = useConfirmBoardDownload();
+>>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
   // Warmed here on mount so the download-size estimate is already in cache when a
   // row's toggle is tapped — the confirm dialog must never wait on a fetch.
   //
@@ -136,9 +138,6 @@ export default function ManageBoards() {
   // keeping it out of that handler's deps means a manifest refresh can't churn the
   // callback identity and re-render every memoised row. The ref also always reads
   // the freshest manifest, which is exactly what the tap wants.
-  const snapshotManifest = useSnapshotManifest();
-  const snapshotManifestRef = useRef(snapshotManifest);
-  snapshotManifestRef.current = snapshotManifest;
   const db = useSQLiteContext();
   // This connection is handed out as soon as the launch gate opens — after the first
   // init attempt, whatever it did — so on a contended launch it has no tables yet.
@@ -194,6 +193,7 @@ export default function ManageBoards() {
   // Ungated by the flag: the offline fallback below needs it too, and a device that
   // still holds downloads after a kill-switch rollback must not be stranded. One
   // cheap indexed read, shared with the Storage screen's cache entry.
+<<<<<<< HEAD
   //
   // Readiness is a KEY member, not an `enabled` gate: a read against the unmigrated
   // connection fails into "nothing downloaded", which is the right answer, and a
@@ -202,6 +202,14 @@ export default function ManageBoards() {
     queryKey: ['downloadedScopeKeys', schemaReady],
     queryFn: () => getDownloadedScopeKeys(db),
   });
+||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
+  const { data: downloadedScopeKeys, refetch: refetchDownloaded } = useQuery({
+    queryKey: ['downloadedScopeKeys'],
+    queryFn: () => getDownloadedScopeKeys(db),
+  });
+=======
+  const { data: downloadedScopeKeys, refetch: refetchDownloaded } = useDownloadedScopeKeys();
+>>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
   const downloadedSet = useMemo(() => new Set(downloadedScopeKeys ?? []), [downloadedScopeKeys]);
   useEffect(() => {
     if (offlineDownloadsEnabled && (!isSyncing || syncStatus.scopeCompletionRevision > 0)) void refetchDownloaded();
@@ -296,6 +304,7 @@ export default function ManageBoards() {
         }
         return;
       }
+<<<<<<< HEAD
       // How big is this download? Only the snapshot path can answer honestly, and
       // only for a scope that would actually bootstrap — a board toggled off and
       // back on keeps its rows + checkpoint and resumes as a small delta, so
@@ -343,7 +352,60 @@ export default function ManageBoards() {
       // Enable + kick a download now via the shared hook (single-flight, reads the
       // latest syncEnabledBoards setting).
       enableBoardsOffline(board, { trigger: 'toggle', source: 'manage' });
+||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
+      // How big is this download? Only the snapshot path can answer honestly, and
+      // only for a scope that would actually bootstrap — a board toggled off and
+      // back on keeps its rows + checkpoint and resumes as a small delta, so
+      // quoting the full artifact size there would be wrong. estimateScopeDownload
+      // owns those rules (shared with the engine's own eligibility check); anything
+      // it can't vouch for falls back to the sizeless copy.
+      //
+      // Concurrent, not sequential: these are three independent reads and the
+      // dialog opens behind them, so serialising them would show up as a stall on
+      // slow storage.
+      const now = Date.now();
+      const [climbsCheckpoint, statsCheckpoint, scopeComplete, bootstrapAlreadyDone] = await Promise.all([
+        getCheckpoint(db, getCheckpointKey('board_climbs', key)),
+        getCheckpoint(db, getCheckpointKey('board_climb_stats', key)),
+        isScopeDownloadComplete(db, key),
+        isBootstrapDone(db, key),
+      ]);
+      const hasBoardCheckpoint = !!climbsCheckpoint || !!statsCheckpoint;
+      const { state: retryState } = await readBootstrapRetryState(
+        db,
+        key,
+        { now, random: Math.random },
+        hasBoardCheckpoint,
+      );
+      const estimate = estimateScopeDownload({
+        manifest: snapshotManifestRef.current,
+        boardType: scope.boardType,
+        layoutId: scope.layoutId,
+        retryState,
+        hasBoardCheckpoint,
+        isScopeComplete: scopeComplete,
+        isBootstrapDone: bootstrapAlreadyDone,
+        now,
+      });
+      const confirmed = await confirm({
+        title: t('mobile.offline.enableTitle', { name: board.name }),
+        message:
+          estimate.kind === 'snapshot'
+            ? t('mobile.offline.enableMessageWithSize', { size: formatBytes(estimate.bytes, i18n.language) })
+            : t('mobile.offline.enableMessage'),
+        confirmLabel: t('mobile.offline.enableConfirm'),
+        cancelLabel: t('mobile.manage.cancel'),
+      });
+      if (!confirmed) return;
+      // Enable + kick a download now via the shared hook (single-flight, reads the
+      // latest syncEnabledBoards setting).
+      enableBoardsOffline(board);
+=======
+      // Size quote + confirm + enable, shared with the discovery-nudge surfaces.
+      await confirmAndDownload(board);
+>>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
     },
+<<<<<<< HEAD
     [confirm, t, i18n.language, db, enableBoardsOffline, downloadProgressEnabled],
   );
 
@@ -396,6 +458,11 @@ export default function ManageBoards() {
       await retryFastDownload(board);
     },
     [confirm, t, i18n.language, db, retryFastDownload],
+||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
+    [confirm, t, i18n.language, db, enableBoardsOffline],
+=======
+    [confirmAndDownload],
+>>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
   );
 
   // See boards/index.tsx: a hard 401 clears tokens without flipping

--- a/packages/mobile/app/boards/manage.tsx
+++ b/packages/mobile/app/boards/manage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Pressable, RefreshControl, StyleSheet, View } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import { useNavigation, useRouter } from 'expo-router';
@@ -18,21 +18,26 @@ import {
 } from '../../src/providers/feature-flags-provider';
 import { useBottomChromeMetrics } from '../../src/hooks/use-bottom-chrome-metrics';
 import { useSyncStatus } from '../../src/sync';
-import { getBootstrapMetadataByScope } from '@boardsesh/offline-sync';
+import {
+  getCheckpoint,
+  getCheckpointKey,
+  readBootstrapRetryState,
+  isScopeDownloadComplete,
+  isBootstrapDone,
+  getBootstrapMetadataByScope,
+  estimateScopeDownload,
+} from '@boardsesh/offline-sync';
+import { useBoardDownloads } from '../../src/offline/use-board-downloads';
+import { useSnapshotManifest } from '../../src/offline/use-snapshot-manifest';
 import { useConfirmBoardDownload } from '../../src/offline/use-confirm-board-download';
 import { useDownloadedScopeKeys } from '../../src/offline/use-downloaded-scope-keys';
 import { useRememberDownloadedBoards } from '../../src/offline/use-remember-downloaded-boards';
 import { useSnapshotSource } from '../../src/offline/use-snapshot-source';
-<<<<<<< HEAD
 import { useOfflineSchemaReady } from '../../src/db/use-offline-schema-ready';
 import { formatBytes } from '../../src/lib/format-bytes';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { track } from '../../src/lib/analytics';
 import { isOfflineEngineEnabled } from '../../src/lib/offline-engine';
-||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
-import { formatBytes } from '../../src/lib/format-bytes';
-=======
->>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
 import {
   getSetting,
   useSetting,
@@ -72,7 +77,7 @@ const getItemType = (item: ManageItem) => item.type;
 export default function ManageBoards() {
   const router = useRouter();
   const navigation = useNavigation();
-  const { t } = useTranslation('boards');
+  const { t, i18n } = useTranslation('boards');
   const { isAuthenticated, refreshAuthState } = useAuth();
   const { systemColors, brandColors } = useTheme();
   const { showToast } = useToast();
@@ -124,13 +129,8 @@ export default function ManageBoards() {
   // previously-queued writes still flush (see OfflineSyncBridge). This screen
   // stays the only writer of syncEnabledBoards.
   const offlineDownloadsEnabled = useOfflineDownloadsEnabled();
-<<<<<<< HEAD
-  const { enableBoardsOffline, retryFastDownload } = useBoardDownloads();
-||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
-  const { enableBoardsOffline } = useBoardDownloads();
-=======
+  const { retryFastDownload } = useBoardDownloads();
   const { confirmAndDownload } = useConfirmBoardDownload();
->>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
   // Warmed here on mount so the download-size estimate is already in cache when a
   // row's toggle is tapped — the confirm dialog must never wait on a fetch.
   //
@@ -138,6 +138,9 @@ export default function ManageBoards() {
   // keeping it out of that handler's deps means a manifest refresh can't churn the
   // callback identity and re-render every memoised row. The ref also always reads
   // the freshest manifest, which is exactly what the tap wants.
+  const snapshotManifest = useSnapshotManifest();
+  const snapshotManifestRef = useRef(snapshotManifest);
+  snapshotManifestRef.current = snapshotManifest;
   const db = useSQLiteContext();
   // This connection is handed out as soon as the launch gate opens — after the first
   // init attempt, whatever it did — so on a contended launch it has no tables yet.
@@ -193,23 +196,7 @@ export default function ManageBoards() {
   // Ungated by the flag: the offline fallback below needs it too, and a device that
   // still holds downloads after a kill-switch rollback must not be stranded. One
   // cheap indexed read, shared with the Storage screen's cache entry.
-<<<<<<< HEAD
-  //
-  // Readiness is a KEY member, not an `enabled` gate: a read against the unmigrated
-  // connection fails into "nothing downloaded", which is the right answer, and a
-  // late flip refetches. Gating would spin forever whenever init genuinely fails.
-  const { data: downloadedScopeKeys, refetch: refetchDownloaded } = useQuery({
-    queryKey: ['downloadedScopeKeys', schemaReady],
-    queryFn: () => getDownloadedScopeKeys(db),
-  });
-||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
-  const { data: downloadedScopeKeys, refetch: refetchDownloaded } = useQuery({
-    queryKey: ['downloadedScopeKeys'],
-    queryFn: () => getDownloadedScopeKeys(db),
-  });
-=======
   const { data: downloadedScopeKeys, refetch: refetchDownloaded } = useDownloadedScopeKeys();
->>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
   const downloadedSet = useMemo(() => new Set(downloadedScopeKeys ?? []), [downloadedScopeKeys]);
   useEffect(() => {
     if (offlineDownloadsEnabled && (!isSyncing || syncStatus.scopeCompletionRevision > 0)) void refetchDownloaded();
@@ -304,109 +291,10 @@ export default function ManageBoards() {
         }
         return;
       }
-<<<<<<< HEAD
-      // How big is this download? Only the snapshot path can answer honestly, and
-      // only for a scope that would actually bootstrap — a board toggled off and
-      // back on keeps its rows + checkpoint and resumes as a small delta, so
-      // quoting the full artifact size there would be wrong. estimateScopeDownload
-      // owns those rules (shared with the engine's own eligibility check); anything
-      // it can't vouch for falls back to the sizeless copy.
-      //
-      // Concurrent, not sequential: these are three independent reads and the
-      // dialog opens behind them, so serialising them would show up as a stall on
-      // slow storage.
-      const now = Date.now();
-      const [climbsCheckpoint, statsCheckpoint, scopeComplete, bootstrapAlreadyDone] = await Promise.all([
-        getCheckpoint(db, getCheckpointKey('board_climbs', key)),
-        getCheckpoint(db, getCheckpointKey('board_climb_stats', key)),
-        isScopeDownloadComplete(db, key),
-        isBootstrapDone(db, key),
-      ]);
-      const hasBoardCheckpoint = !!climbsCheckpoint || !!statsCheckpoint;
-      const { state: retryState } = await readBootstrapRetryState(
-        db,
-        key,
-        { now, random: Math.random },
-        hasBoardCheckpoint,
-      );
-      const estimate = estimateScopeDownload({
-        manifest: snapshotManifestRef.current,
-        boardType: scope.boardType,
-        layoutId: scope.layoutId,
-        retryState,
-        hasBoardCheckpoint,
-        isScopeComplete: scopeComplete,
-        isBootstrapDone: bootstrapAlreadyDone,
-        now,
-      });
-      const confirmed = await confirm({
-        title: t('mobile.offline.enableTitle', { name: board.name }),
-        message:
-          estimate.kind === 'snapshot'
-            ? t('mobile.offline.enableMessageWithSize', { size: formatBytes(estimate.bytes, i18n.language) })
-            : t('mobile.offline.enableMessage'),
-        confirmLabel: t('mobile.offline.enableConfirm'),
-        cancelLabel: t('mobile.manage.cancel'),
-      });
-      if (!confirmed) return;
-      // Enable + kick a download now via the shared hook (single-flight, reads the
-      // latest syncEnabledBoards setting).
-      enableBoardsOffline(board, { trigger: 'toggle', source: 'manage' });
-||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
-      // How big is this download? Only the snapshot path can answer honestly, and
-      // only for a scope that would actually bootstrap — a board toggled off and
-      // back on keeps its rows + checkpoint and resumes as a small delta, so
-      // quoting the full artifact size there would be wrong. estimateScopeDownload
-      // owns those rules (shared with the engine's own eligibility check); anything
-      // it can't vouch for falls back to the sizeless copy.
-      //
-      // Concurrent, not sequential: these are three independent reads and the
-      // dialog opens behind them, so serialising them would show up as a stall on
-      // slow storage.
-      const now = Date.now();
-      const [climbsCheckpoint, statsCheckpoint, scopeComplete, bootstrapAlreadyDone] = await Promise.all([
-        getCheckpoint(db, getCheckpointKey('board_climbs', key)),
-        getCheckpoint(db, getCheckpointKey('board_climb_stats', key)),
-        isScopeDownloadComplete(db, key),
-        isBootstrapDone(db, key),
-      ]);
-      const hasBoardCheckpoint = !!climbsCheckpoint || !!statsCheckpoint;
-      const { state: retryState } = await readBootstrapRetryState(
-        db,
-        key,
-        { now, random: Math.random },
-        hasBoardCheckpoint,
-      );
-      const estimate = estimateScopeDownload({
-        manifest: snapshotManifestRef.current,
-        boardType: scope.boardType,
-        layoutId: scope.layoutId,
-        retryState,
-        hasBoardCheckpoint,
-        isScopeComplete: scopeComplete,
-        isBootstrapDone: bootstrapAlreadyDone,
-        now,
-      });
-      const confirmed = await confirm({
-        title: t('mobile.offline.enableTitle', { name: board.name }),
-        message:
-          estimate.kind === 'snapshot'
-            ? t('mobile.offline.enableMessageWithSize', { size: formatBytes(estimate.bytes, i18n.language) })
-            : t('mobile.offline.enableMessage'),
-        confirmLabel: t('mobile.offline.enableConfirm'),
-        cancelLabel: t('mobile.manage.cancel'),
-      });
-      if (!confirmed) return;
-      // Enable + kick a download now via the shared hook (single-flight, reads the
-      // latest syncEnabledBoards setting).
-      enableBoardsOffline(board);
-=======
       // Size quote + confirm + enable, shared with the discovery-nudge surfaces.
-      await confirmAndDownload(board);
->>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
+      await confirmAndDownload(board, { trigger: 'toggle', source: 'manage' });
     },
-<<<<<<< HEAD
-    [confirm, t, i18n.language, db, enableBoardsOffline, downloadProgressEnabled],
+    [confirmAndDownload],
   );
 
   // The escape from a board that settled onto the slow crawl (issue #4313).
@@ -458,11 +346,6 @@ export default function ManageBoards() {
       await retryFastDownload(board);
     },
     [confirm, t, i18n.language, db, retryFastDownload],
-||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
-    [confirm, t, i18n.language, db, enableBoardsOffline],
-=======
-    [confirmAndDownload],
->>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
   );
 
   // See boards/index.tsx: a hard 401 clears tokens without flipping

--- a/packages/mobile/src/lib/offline-nudges/__tests__/nudge-policy.test.ts
+++ b/packages/mobile/src/lib/offline-nudges/__tests__/nudge-policy.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  GLOBAL_PROMPT_COOLDOWN_MS,
+  POST_ACCEPT_QUIET_MS,
+  POST_SESSION_COOLDOWN_MS,
+  POST_SESSION_MAX_SHOWS,
+  emptyNudgeState,
+  shouldShowNudge,
+  suppressedNudgeState,
+  withNudgeAccepted,
+  withNudgeDismissed,
+  withNudgeShown,
+  type NudgeDecisionInput,
+  type NudgeSurface,
+  type OfflineNudgeState,
+} from '../nudge-policy';
+
+const NOW = 1_800_000_000_000;
+
+function input(overrides: Partial<NudgeDecisionInput> = {}): NudgeDecisionInput {
+  return {
+    surface: 'post_session',
+    state: emptyNudgeState(),
+    nowMs: NOW,
+    offlineEngineEnabled: true,
+    nudgesEnabled: true,
+    offlineState: 'off',
+    autoOfflineBoards: false,
+    ...overrides,
+  };
+}
+
+const originalScreenshotMode = process.env.EXPO_PUBLIC_SCREENSHOT_MODE;
+afterEach(() => {
+  if (originalScreenshotMode === undefined) delete process.env.EXPO_PUBLIC_SCREENSHOT_MODE;
+  else process.env.EXPO_PUBLIC_SCREENSHOT_MODE = originalScreenshotMode;
+});
+
+describe('shouldShowNudge — eligibility', () => {
+  it('shows on a board that is not offline at all', () => {
+    expect(shouldShowNudge(input())).toBe(true);
+  });
+
+  // The self-retrigger regression: an offline accept leaves the scope 'pending',
+  // which is NOT in downloadedScopeKeys and has no sync in flight, so a naive
+  // gate would re-prompt for the board it just armed.
+  it.each(['pending', 'downloading', 'downloaded'] as const)('suppresses when the board is %s', (offlineState) => {
+    for (const surface of ['post_session', 'no_catalog', 'whats_new', 'board_card'] as NudgeSurface[]) {
+      expect(shouldShowNudge(input({ surface, offlineState }))).toBe(false);
+    }
+  });
+
+  it('suppresses every surface when the user auto-downloads all boards', () => {
+    for (const surface of ['post_session', 'no_catalog', 'whats_new', 'board_card'] as NudgeSurface[]) {
+      expect(shouldShowNudge(input({ surface, autoOfflineBoards: true }))).toBe(false);
+    }
+  });
+
+  it('suppresses every surface in screenshot mode', () => {
+    process.env.EXPO_PUBLIC_SCREENSHOT_MODE = '1';
+    for (const surface of ['post_session', 'no_catalog', 'whats_new', 'board_card'] as NudgeSurface[]) {
+      expect(shouldShowNudge(input({ surface }))).toBe(false);
+    }
+  });
+
+  it('suppresses when either flag is off', () => {
+    expect(shouldShowNudge(input({ offlineEngineEnabled: false }))).toBe(false);
+    expect(shouldShowNudge(input({ nudgesEnabled: false }))).toBe(false);
+  });
+
+  it('respects dismiss-forever per surface', () => {
+    const state = withNudgeDismissed(emptyNudgeState(), 'no_catalog', 'forever', NOW);
+    expect(shouldShowNudge(input({ surface: 'no_catalog', state }))).toBe(false);
+    expect(shouldShowNudge(input({ surface: 'whats_new', state }))).toBe(true);
+  });
+
+  it('suppresses everything from the storage-failure state', () => {
+    const state = suppressedNudgeState();
+    for (const surface of ['post_session', 'no_catalog', 'whats_new', 'board_card'] as NudgeSurface[]) {
+      expect(shouldShowNudge(input({ surface, state }))).toBe(false);
+    }
+  });
+});
+
+describe('shouldShowNudge — caps apply to the interruptive prompt only', () => {
+  it('holds the post-session prompt for its cooldown', () => {
+    const state = withNudgeShown(emptyNudgeState(), 'post_session', NOW);
+    expect(shouldShowNudge(input({ state, nowMs: NOW + POST_SESSION_COOLDOWN_MS - 1 }))).toBe(false);
+    // The global cooldown is shorter, so at the surface cooldown it is free again.
+    expect(shouldShowNudge(input({ state, nowMs: NOW + POST_SESSION_COOLDOWN_MS }))).toBe(true);
+  });
+
+  it('stops after the lifetime cap', () => {
+    let state = emptyNudgeState();
+    let nowMs = NOW;
+    for (let show = 0; show < POST_SESSION_MAX_SHOWS; show += 1) {
+      expect(shouldShowNudge(input({ state, nowMs }))).toBe(true);
+      state = withNudgeShown(state, 'post_session', nowMs);
+      nowMs += POST_SESSION_COOLDOWN_MS;
+    }
+    expect(shouldShowNudge(input({ state, nowMs }))).toBe(false);
+  });
+
+  it('applies the cross-surface cooldown between prompts', () => {
+    const state = { ...emptyNudgeState(), lastPromptAtMs: NOW };
+    expect(shouldShowNudge(input({ state, nowMs: NOW + GLOBAL_PROMPT_COOLDOWN_MS - 1 }))).toBe(false);
+    expect(shouldShowNudge(input({ state, nowMs: NOW + GLOBAL_PROMPT_COOLDOWN_MS }))).toBe(true);
+  });
+
+  it('goes quiet for a month after any acceptance', () => {
+    const state = withNudgeAccepted(emptyNudgeState(), 'no_catalog', NOW);
+    expect(shouldShowNudge(input({ state, nowMs: NOW + POST_ACCEPT_QUIET_MS - 1 }))).toBe(false);
+    expect(shouldShowNudge(input({ state, nowMs: NOW + POST_ACCEPT_QUIET_MS }))).toBe(true);
+  });
+
+  // The affordance regression the design review flagged: an empty state that
+  // reverts to a dead end because an unrelated prompt fired two days ago.
+  it.each(['no_catalog', 'whats_new', 'board_card'] as NudgeSurface[])(
+    'never cools down the %s affordance',
+    (surface) => {
+      let state: OfflineNudgeState = { ...emptyNudgeState(), lastPromptAtMs: NOW, lastAcceptedAtMs: NOW };
+      for (let show = 0; show < POST_SESSION_MAX_SHOWS + 3; show += 1) {
+        expect(shouldShowNudge(input({ surface, state, nowMs: NOW + show }))).toBe(true);
+        state = withNudgeShown(state, surface, NOW + show);
+      }
+      state = withNudgeDismissed(state, surface, 'once', NOW);
+      expect(shouldShowNudge(input({ surface, state, nowMs: NOW + 1 }))).toBe(true);
+    },
+  );
+
+  it('yields to a store-review prompt that is actually going to appear', () => {
+    expect(shouldShowNudge(input({ storeReviewWillPrompt: true }))).toBe(false);
+    // ...and NOT to the bare "≥3 sends" eligibility, which is on for the whole
+    // audience this prompt is written for.
+    expect(shouldShowNudge(input({ storeReviewWillPrompt: false }))).toBe(true);
+  });
+});
+
+describe('nudge state reducers', () => {
+  it('does not mutate the input state', () => {
+    const state = emptyNudgeState();
+    const snapshot = JSON.stringify(state);
+    withNudgeShown(state, 'post_session', NOW);
+    withNudgeAccepted(state, 'post_session', NOW);
+    withNudgeDismissed(state, 'post_session', 'forever', NOW);
+    expect(JSON.stringify(state)).toBe(snapshot);
+  });
+
+  it('counts shows and starts the cross-surface cooldown for prompts only', () => {
+    const prompted = withNudgeShown(emptyNudgeState(), 'post_session', NOW);
+    expect(prompted.surfaces.post_session.shownCount).toBe(1);
+    expect(prompted.lastPromptAtMs).toBe(NOW);
+
+    const affordance = withNudgeShown(emptyNudgeState(), 'board_card', NOW);
+    expect(affordance.surfaces.board_card.shownCount).toBe(1);
+    expect(affordance.lastPromptAtMs).toBeNull();
+  });
+});

--- a/packages/mobile/src/lib/offline-nudges/__tests__/nudge-storage.test.ts
+++ b/packages/mobile/src/lib/offline-nudges/__tests__/nudge-storage.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const spies = vi.hoisted(() => ({
+  getPreference: vi.fn(),
+  setPreference: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../preference-store', () => ({
+  getPreference: spies.getPreference,
+  setPreference: spies.setPreference,
+}));
+
+import { emptyNudgeState, withNudgeShown } from '../nudge-policy';
+import {
+  OFFLINE_NUDGE_STATE_KEY,
+  __resetNudgeStateCacheForTests,
+  loadNudgeState,
+  parseNudgeState,
+  saveNudgeState,
+} from '../nudge-storage';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetNudgeStateCacheForTests();
+});
+
+describe('nudge-storage', () => {
+  it('returns defaults when nothing is stored', async () => {
+    spies.getPreference.mockResolvedValue(null);
+    await expect(loadNudgeState()).resolves.toEqual(emptyNudgeState());
+  });
+
+  it('round-trips a written state', async () => {
+    const state = withNudgeShown(emptyNudgeState(), 'post_session', 1_700_000_000_000);
+    await saveNudgeState(state);
+    expect(spies.setPreference).toHaveBeenCalledWith(OFFLINE_NUDGE_STATE_KEY, state);
+    await expect(loadNudgeState()).resolves.toEqual(state);
+  });
+
+  // A rejection is not "no value stored" — iOS can deny the backing-file read
+  // before first unlock. Suppress this run, cache nothing, retry next time.
+  it('suppresses every surface when the read rejects, and retries afterwards', async () => {
+    spies.getPreference.mockRejectedValueOnce(new Error('locked'));
+    const suppressed = await loadNudgeState();
+    for (const surface of Object.values(suppressed.surfaces)) {
+      expect(surface.dismissedForever).toBe(true);
+    }
+
+    spies.getPreference.mockResolvedValueOnce(null);
+    await expect(loadNudgeState()).resolves.toEqual(emptyNudgeState());
+  });
+
+  it('degrades a corrupt or legacy payload to defaults', () => {
+    expect(parseNudgeState('not-an-object')).toEqual(emptyNudgeState());
+    expect(parseNudgeState({ surfaces: 42, lastPromptAtMs: 'soon' })).toEqual(emptyNudgeState());
+
+    const partial = parseNudgeState({
+      surfaces: { post_session: { shownCount: 2, dismissedForever: 'yes' }, ancient_surface: {} },
+      lastAcceptedAtMs: 5,
+    });
+    expect(partial.surfaces.post_session).toEqual({ lastShownAtMs: null, shownCount: 2, dismissedForever: false });
+    expect(partial.lastAcceptedAtMs).toBe(5);
+    expect(partial.surfaces.board_card).toEqual({ lastShownAtMs: null, shownCount: 0, dismissedForever: false });
+  });
+});

--- a/packages/mobile/src/lib/offline-nudges/nudge-analytics.ts
+++ b/packages/mobile/src/lib/offline-nudges/nudge-analytics.ts
@@ -1,0 +1,34 @@
+// Thin wrappers around the offline-nudge events so the surfaces stay free of
+// property-key bookkeeping. Every surface emits the same shape, separated by
+// `surface`, so the funnel (shown → accepted → Offline Board Download Completed)
+// can be split by where the suggestion appeared.
+
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { track } from '../analytics';
+import type { NudgeSurface } from './nudge-policy';
+
+export type NudgeEventContext = {
+  surface: NudgeSurface;
+  boardType: string;
+  layoutId: number;
+  scopeKey: string;
+  /** How many scopes this device already holds — 0 means a first download. */
+  downloadedBoardCount: number;
+};
+
+export function trackNudgeShown(context: NudgeEventContext): void {
+  track(SHARED_EVENTS.OfflineNudgeShown, { ...context });
+}
+
+/**
+ * `armedOnly` is load-bearing, not decoration: offline the accept can only mark
+ * the scope, so the download starts on the scheduler's next reconnect. Without
+ * this the funnel reads as accepts that never produced a download.
+ */
+export function trackNudgeAccepted(context: NudgeEventContext, armedOnly: boolean): void {
+  track(SHARED_EVENTS.OfflineNudgeAccepted, { ...context, armedOnly });
+}
+
+export function trackNudgeDismissed(context: NudgeEventContext, dismissKind: 'once' | 'forever'): void {
+  track(SHARED_EVENTS.OfflineNudgeDismissed, { ...context, dismissKind });
+}

--- a/packages/mobile/src/lib/offline-nudges/nudge-policy.ts
+++ b/packages/mobile/src/lib/offline-nudges/nudge-policy.ts
@@ -1,0 +1,181 @@
+// Whether the app may suggest taking a board offline, and where.
+//
+// Pure: no React, no AsyncStorage, no expo. Everything the decision needs is an
+// argument, so the whole table is unit-testable and one place answers "why did
+// (or didn't) this fire".
+//
+// Two kinds of surface, and the difference is the whole design:
+//
+//   Prompts (`post_session`) INTERRUPT. The user did not ask; the app spoke.
+//   They carry a cooldown, a lifetime cap, a cross-surface cooldown and a
+//   post-acceptance quiet period.
+//
+//   Affordances (`no_catalog`, `whats_new`, `board_card`) live inside a screen
+//   the user chose to look at, usually in place of a dead end. Capping them is
+//   a regression: an empty state that reverts to "nothing here" 72 hours after
+//   an unrelated prompt is worse than the empty state we set out to fix. They
+//   are bounded by eligibility and dismiss-forever alone.
+
+import type { BoardDownloadState } from '../../components/board-discovery/board-offline-state';
+
+export type NudgeSurface = 'post_session' | 'no_catalog' | 'whats_new' | 'board_card';
+
+export const NUDGE_SURFACES: readonly NudgeSurface[] = ['post_session', 'no_catalog', 'whats_new', 'board_card'];
+
+/** Surfaces that interrupt, and therefore carry frequency machinery. */
+const CAPPED_SURFACES: ReadonlySet<NudgeSurface> = new Set<NudgeSurface>(['post_session']);
+
+export const POST_SESSION_COOLDOWN_MS = 14 * 24 * 60 * 60 * 1000;
+export const POST_SESSION_MAX_SHOWS = 3;
+/** No two interruptive prompts inside three days, whatever their surface. */
+export const GLOBAL_PROMPT_COOLDOWN_MS = 72 * 60 * 60 * 1000;
+/** Someone who just accepted does not need asking again this month. */
+export const POST_ACCEPT_QUIET_MS = 30 * 24 * 60 * 60 * 1000;
+
+export type NudgeSurfaceState = {
+  lastShownAtMs: number | null;
+  shownCount: number;
+  dismissedForever: boolean;
+};
+
+export type OfflineNudgeState = {
+  surfaces: Record<NudgeSurface, NudgeSurfaceState>;
+  /** Most recent show of any CAPPED surface — drives the cross-surface cooldown. */
+  lastPromptAtMs: number | null;
+  /** Most recent accept of any surface. */
+  lastAcceptedAtMs: number | null;
+};
+
+function emptySurfaceState(): NudgeSurfaceState {
+  return { lastShownAtMs: null, shownCount: 0, dismissedForever: false };
+}
+
+export function emptyNudgeState(): OfflineNudgeState {
+  return {
+    surfaces: {
+      post_session: emptySurfaceState(),
+      no_catalog: emptySurfaceState(),
+      whats_new: emptySurfaceState(),
+      board_card: emptySurfaceState(),
+    },
+    lastPromptAtMs: null,
+    lastAcceptedAtMs: null,
+  };
+}
+
+/** A state in which nothing will ever be shown. Used when storage can't be read. */
+export function suppressedNudgeState(): OfflineNudgeState {
+  const state = emptyNudgeState();
+  for (const surface of NUDGE_SURFACES) {
+    state.surfaces[surface] = { ...emptySurfaceState(), dismissedForever: true };
+  }
+  return state;
+}
+
+export type NudgeDecisionInput = {
+  surface: NudgeSurface;
+  state: OfflineNudgeState;
+  nowMs: number;
+  /** `useOfflineDownloadsEnabled()` — the whole engine's kill switch. */
+  offlineEngineEnabled: boolean;
+  /** `useOfflineNudgesEnabled()` — this feature's own ramp flag. */
+  nudgesEnabled: boolean;
+  /**
+   * The candidate board's download state, from `boardDownloadState()`. Anything
+   * but `'off'` means the user already asked for this board — including
+   * `'pending'`, which is exactly what an offline arm produces, so gating on
+   * "not in downloadedScopeKeys" instead would re-prompt for a board the nudge
+   * itself just armed.
+   */
+  offlineState: BoardDownloadState;
+  /** `getSetting('autoOfflineBoards')` — this user downloads everything already. */
+  autoOfflineBoards: boolean;
+  /**
+   * `post_session` only: a store-review prompt is actually going to appear on
+   * this screen. Must be the resolved `shouldRequestSessionStoreReview` answer
+   * (cooldown + per-session dedup + `StoreReview.hasAction()`), never the bare
+   * `isSessionStoreReviewEligible` predicate — that one is just "≥3 sends", so
+   * using it would silence the nudge on every good session, its whole audience.
+   */
+  storeReviewWillPrompt?: boolean;
+};
+
+/**
+ * Screenshot runs must render the app, not our marketing. Every comparable
+ * surface does this (`hasUnseenChangelog`, `hasSeenTip`, `OnboardingGate`), and
+ * this flag is baked on for the App Store capture matrix.
+ */
+function isScreenshotMode(): boolean {
+  return process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1';
+}
+
+export function shouldShowNudge(input: NudgeDecisionInput): boolean {
+  if (isScreenshotMode()) return false;
+  if (!input.offlineEngineEnabled || !input.nudgesEnabled) return false;
+  // The board is already downloaded, downloading, or armed — there is nothing
+  // to suggest.
+  if (input.offlineState !== 'off') return false;
+  // This user opted into downloading every board they own; suggesting one is noise.
+  if (input.autoOfflineBoards) return false;
+
+  const surfaceState = input.state.surfaces[input.surface] ?? emptySurfaceState();
+  if (surfaceState.dismissedForever) return false;
+
+  if (!CAPPED_SURFACES.has(input.surface)) return true;
+
+  if (input.storeReviewWillPrompt) return false;
+  if (surfaceState.shownCount >= POST_SESSION_MAX_SHOWS) return false;
+  if (surfaceState.lastShownAtMs !== null && input.nowMs - surfaceState.lastShownAtMs < POST_SESSION_COOLDOWN_MS) {
+    return false;
+  }
+  if (input.state.lastPromptAtMs !== null && input.nowMs - input.state.lastPromptAtMs < GLOBAL_PROMPT_COOLDOWN_MS) {
+    return false;
+  }
+  if (input.state.lastAcceptedAtMs !== null && input.nowMs - input.state.lastAcceptedAtMs < POST_ACCEPT_QUIET_MS) {
+    return false;
+  }
+  return true;
+}
+
+function withSurface(
+  state: OfflineNudgeState,
+  surface: NudgeSurface,
+  update: (previous: NudgeSurfaceState) => NudgeSurfaceState,
+): OfflineNudgeState {
+  const previous = state.surfaces[surface] ?? emptySurfaceState();
+  return {
+    ...state,
+    surfaces: { ...state.surfaces, [surface]: update(previous) },
+  };
+}
+
+export function withNudgeShown(state: OfflineNudgeState, surface: NudgeSurface, nowMs: number): OfflineNudgeState {
+  const next = withSurface(state, surface, (previous) => ({
+    ...previous,
+    lastShownAtMs: nowMs,
+    shownCount: previous.shownCount + 1,
+  }));
+  // Only interruptive prompts start the cross-surface cooldown; an affordance
+  // the user scrolled past must not silence the next real prompt.
+  return CAPPED_SURFACES.has(surface) ? { ...next, lastPromptAtMs: nowMs } : next;
+}
+
+export function withNudgeAccepted(state: OfflineNudgeState, surface: NudgeSurface, nowMs: number): OfflineNudgeState {
+  return { ...withSurface(state, surface, (previous) => previous), lastAcceptedAtMs: nowMs };
+}
+
+export function withNudgeDismissed(
+  state: OfflineNudgeState,
+  surface: NudgeSurface,
+  dismissKind: 'once' | 'forever',
+  nowMs: number,
+): OfflineNudgeState {
+  return withSurface(state, surface, (previous) => ({
+    ...previous,
+    // A one-off dismissal is the cooldown doing its job, so record the moment
+    // rather than a flag: the surface returns after its own cooldown, and an
+    // uncapped affordance is unaffected by design.
+    lastShownAtMs: nowMs,
+    dismissedForever: dismissKind === 'forever' ? true : previous.dismissedForever,
+  }));
+}

--- a/packages/mobile/src/lib/offline-nudges/nudge-storage.ts
+++ b/packages/mobile/src/lib/offline-nudges/nudge-storage.ts
@@ -1,0 +1,82 @@
+// Persistence for the offline-nudge policy state (issue #4318).
+//
+// One AsyncStorage key holding the whole per-surface record, loaded once per
+// app run through a promise singleton. `preference-store.getPreference`
+// deliberately lets a storage REJECTION propagate (iOS can deny the backing-file
+// read before first unlock), so the singleton clears a rejected promise and the
+// next caller retries instead of caching a wrong answer.
+//
+// A read that fails resolves to `suppressedNudgeState()`: never nag on a flaky
+// store. Same direction `hasSeenTip` errs in.
+
+import { getPreference, setPreference } from '../preference-store';
+import { emptyNudgeState, suppressedNudgeState, NUDGE_SURFACES, type OfflineNudgeState } from './nudge-policy';
+
+export const OFFLINE_NUDGE_STATE_KEY = 'offlineNudgeStateV1';
+
+let loadPromise: Promise<OfflineNudgeState> | null = null;
+let cachedState: OfflineNudgeState | null = null;
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+/**
+ * Rebuild a full state from whatever is on disk, so a value written by an older
+ * build (or a corrupt one) degrades to defaults rather than throwing at a read
+ * site. Unknown surfaces are dropped; missing ones get defaults.
+ */
+export function parseNudgeState(stored: unknown): OfflineNudgeState {
+  const state = emptyNudgeState();
+  if (typeof stored !== 'object' || stored === null) return state;
+  const record = stored as Record<string, unknown>;
+
+  if (isFiniteNumber(record.lastPromptAtMs)) state.lastPromptAtMs = record.lastPromptAtMs;
+  if (isFiniteNumber(record.lastAcceptedAtMs)) state.lastAcceptedAtMs = record.lastAcceptedAtMs;
+
+  const surfaces = record.surfaces;
+  if (typeof surfaces !== 'object' || surfaces === null) return state;
+  const surfaceRecord = surfaces as Record<string, unknown>;
+  for (const surface of NUDGE_SURFACES) {
+    const raw = surfaceRecord[surface];
+    if (typeof raw !== 'object' || raw === null) continue;
+    const entry = raw as Record<string, unknown>;
+    state.surfaces[surface] = {
+      lastShownAtMs: isFiniteNumber(entry.lastShownAtMs) ? entry.lastShownAtMs : null,
+      shownCount: isFiniteNumber(entry.shownCount) ? entry.shownCount : 0,
+      dismissedForever: entry.dismissedForever === true,
+    };
+  }
+  return state;
+}
+
+export async function loadNudgeState(): Promise<OfflineNudgeState> {
+  if (cachedState) return cachedState;
+  if (!loadPromise) {
+    loadPromise = getPreference<unknown>(OFFLINE_NUDGE_STATE_KEY)
+      .then((stored) => {
+        const state = parseNudgeState(stored);
+        cachedState = state;
+        return state;
+      })
+      .catch(() => {
+        // Clear the rejected promise so a later read (post-unlock) can retry,
+        // and do NOT cache: this run stays silent, the next one may not.
+        loadPromise = null;
+        return suppressedNudgeState();
+      });
+  }
+  return loadPromise;
+}
+
+export async function saveNudgeState(state: OfflineNudgeState): Promise<void> {
+  cachedState = state;
+  loadPromise = Promise.resolve(state);
+  await setPreference(OFFLINE_NUDGE_STATE_KEY, state);
+}
+
+/** Test seam. Also the hook for #3621's sign-out wipe once it lands. */
+export function __resetNudgeStateCacheForTests(): void {
+  loadPromise = null;
+  cachedState = null;
+}

--- a/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
+++ b/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
@@ -36,7 +36,12 @@ vi.mock('react-native', () => ({
   },
 }));
 
-type NetInfoState = { isConnected: boolean | null; type?: string; details?: { isConnectionExpensive?: boolean } };
+type NetInfoState = {
+  isConnected: boolean | null;
+  isInternetReachable?: boolean | null;
+  type?: string;
+  details?: { isConnectionExpensive?: boolean };
+};
 type NetInfoListener = (state: NetInfoState) => void;
 let netInfoListener: NetInfoListener | null = null;
 const netInfoUnsubscribe = vi.fn();
@@ -342,6 +347,31 @@ describe('scheduler trigger bindings', () => {
 
     unsubscribe();
     expect(netInfoUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  // The lying connection: `isConnected` stays true across a captive portal, so
+  // without reachability the scheduler never sees an offline→online edge and a
+  // board armed there waits for a network change (issue #4318).
+  it('reports an unreachable connection as disconnected, so recovery is an edge', () => {
+    const { triggers } = startAndGetTriggers();
+    const callback = vi.fn();
+    triggers.subscribeConnectivity(callback);
+
+    netInfoListener?.({ isConnected: true, isInternetReachable: false });
+    netInfoListener?.({ isConnected: true, isInternetReachable: true });
+    expect(callback).toHaveBeenNthCalledWith(1, false);
+    expect(callback).toHaveBeenNthCalledWith(2, true);
+  });
+
+  // Not-probed-yet is not unreachable — inventing a disconnect there would fake
+  // an edge on every platform that answers the reachability probe late.
+  it('treats unknown reachability as connected', () => {
+    const { triggers } = startAndGetTriggers();
+    const callback = vi.fn();
+    triggers.subscribeConnectivity(callback);
+
+    netInfoListener?.({ isConnected: true, isInternetReachable: null });
+    expect(callback).toHaveBeenCalledWith(true);
   });
 
   it('binds schema-drift telemetry to Sentry with the offline-sync tags', () => {
@@ -682,7 +712,12 @@ describe('snapshot-bootstrap bindings', () => {
       name === 'startSyncScheduler' ? startSyncSchedulerCore.mock.calls[0][6] : triggerSyncCore.mock.calls[0][5]
     ) as SchedulerOptions;
 
-    options.onScopeDownloadComplete?.({ scopeKey: 'kilter:1:5', method: 'snapshot', durationMs: 10 });
+    options.onScopeDownloadComplete?.({
+      scopeKey: 'kilter:1:5',
+      method: 'snapshot',
+      durationMs: 10,
+      phases: NO_PHASES,
+    });
 
     expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['downloadedScopeKeys'] });
     expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['offlineStorage'] });

--- a/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
+++ b/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
@@ -650,6 +650,44 @@ describe('snapshot-bootstrap bindings', () => {
     stopTracking();
   });
 
+  // Until #4318 only remove-offline-board.ts ever invalidated these, so a board
+  // that finished downloading kept reading as "not downloaded" on every screen
+  // the user hadn't left — the badge and every download affordance with it.
+  it.each([
+    [
+      'startSyncScheduler',
+      () =>
+        startSyncScheduler(
+          db,
+          queryClient,
+          graphqlFetch,
+          () => [],
+          async () => {},
+        ),
+    ],
+    [
+      'triggerSync',
+      () =>
+        triggerSync(
+          db,
+          queryClient,
+          graphqlFetch,
+          () => [],
+          async () => {},
+        ),
+    ],
+  ])('refreshes the downloaded-scope caches from %s on scope completion', (name, run) => {
+    run();
+    const options = (
+      name === 'startSyncScheduler' ? startSyncSchedulerCore.mock.calls[0][6] : triggerSyncCore.mock.calls[0][5]
+    ) as SchedulerOptions;
+
+    options.onScopeDownloadComplete?.({ scopeKey: 'kilter:1:5', method: 'snapshot', durationMs: 10 });
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['downloadedScopeKeys'] });
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['offlineStorage'] });
+  });
+
   it('captures a PostHog event — not a Sentry error — when the coverage guard forces a resync', () => {
     // A forced deletions-coverage reset is expected behaviour whose FREQUENCY is
     // the signal (issue #3474), so it belongs with the operational events, not

--- a/packages/mobile/src/offline/__tests__/use-board-downloads.test.tsx
+++ b/packages/mobile/src/offline/__tests__/use-board-downloads.test.tsx
@@ -110,6 +110,7 @@ describe('useBoardDownloads', () => {
     expect(getSyncStatusSnapshot().scopeCompletionRevision).toBe(2);
   });
 
+<<<<<<< HEAD
   it('enables and announces once per SCOPE when two boards share one', () => {
     // Two gyms with the same wall are one offline scope and one download, so a
     // per-board Toggled would count two enables against the downloader's single
@@ -164,6 +165,33 @@ describe('useBoardDownloads', () => {
 
     act(() => setSchemaReady(true));
 
+||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
+=======
+  // This assertion is the guard, not a description: `onlineManager.isOnline()` is
+  // TRUE on captive-portal wifi, so a cycle kicked from an offline surface would
+  // run, fail, and spend one of the two MAX_BOOTSTRAP_ATTEMPTS per tap — pinning
+  // the scope to the paged crawl after two (#4313). The scheduler's own reconnect
+  // trigger pulls it instead.
+  it('arms a board without kicking a sync cycle', () => {
+    const board = makeBoard('garage', 'kilter', 1, 10);
+    const { result } = renderHook(() => useBoardDownloads());
+
+    result.current.armBoardsOffline(board);
+
+    expect(spies.setOfflineBoardEnabled).toHaveBeenCalledWith('kilter:1:10', true);
+    expect(spies.rememberOfflineBoards).toHaveBeenCalledWith([board]);
+    expect(spies.triggerSync).not.toHaveBeenCalled();
+  });
+
+  it('does nothing for an empty board list on either entry point', () => {
+    const { result } = renderHook(() => useBoardDownloads());
+
+    result.current.armBoardsOffline([]);
+    result.current.enableBoardsOffline([]);
+
+    expect(spies.setOfflineBoardEnabled).not.toHaveBeenCalled();
+    expect(spies.rememberOfflineBoards).not.toHaveBeenCalled();
+>>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
     expect(spies.triggerSync).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/offline/__tests__/use-board-downloads.test.tsx
+++ b/packages/mobile/src/offline/__tests__/use-board-downloads.test.tsx
@@ -110,7 +110,6 @@ describe('useBoardDownloads', () => {
     expect(getSyncStatusSnapshot().scopeCompletionRevision).toBe(2);
   });
 
-<<<<<<< HEAD
   it('enables and announces once per SCOPE when two boards share one', () => {
     // Two gyms with the same wall are one offline scope and one download, so a
     // per-board Toggled would count two enables against the downloader's single
@@ -165,8 +164,9 @@ describe('useBoardDownloads', () => {
 
     act(() => setSchemaReady(true));
 
-||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
-=======
+    expect(spies.triggerSync).not.toHaveBeenCalled();
+  });
+
   // This assertion is the guard, not a description: `onlineManager.isOnline()` is
   // TRUE on captive-portal wifi, so a cycle kicked from an offline surface would
   // run, fail, and spend one of the two MAX_BOOTSTRAP_ATTEMPTS per tap — pinning
@@ -191,7 +191,6 @@ describe('useBoardDownloads', () => {
 
     expect(spies.setOfflineBoardEnabled).not.toHaveBeenCalled();
     expect(spies.rememberOfflineBoards).not.toHaveBeenCalled();
->>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
     expect(spies.triggerSync).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/offline/offline-sync-adapter.ts
+++ b/packages/mobile/src/offline/offline-sync-adapter.ts
@@ -242,11 +242,31 @@ const reportScopeDownloadStart: ScopeDownloadStartReporter = ({ scopeKey, pathIn
   });
 };
 
+/**
+ * Query keys that answer "which board scopes are on this device". They are read
+ * by My Boards, the boards picker, More (the Storage row) and every download
+ * affordance, and until now only `remove-offline-board.ts` ever invalidated
+ * them — so a screen the user never left kept claiming a board was not
+ * downloaded long after it had finished (issue #4318).
+ *
+ * Invalidating from this callback rather than from a hook is deliberate:
+ * `useSyncStatus()` publishes a fresh object on every progress frame, so a
+ * subscribing hook would churn the hottest virtualised screens. This fires once
+ * per COMPLETED scope, so the cost is one SQLite read per completion.
+ */
+const DOWNLOAD_STATE_QUERY_KEYS: readonly (readonly string[])[] = [['downloadedScopeKeys'], ['offlineStorage']];
+
 function combinedScopeDownloadCompleteReporter(
   onScopeDownloadComplete: ScopeDownloadCompleteReporter | undefined,
+  queryClient?: QueryClient,
 ): ScopeDownloadCompleteReporter {
   return (info) => {
     reportScopeDownloadComplete(info);
+    if (queryClient) {
+      for (const queryKey of DOWNLOAD_STATE_QUERY_KEYS) {
+        void queryClient.invalidateQueries({ queryKey });
+      }
+    }
     onScopeDownloadComplete?.(info);
   };
 }
@@ -440,8 +460,14 @@ export function startSyncScheduler(
     snapshotSource: options?.snapshotSource,
     onSnapshotBootstrapError: reportSnapshotBootstrapError,
     onBootstrapMetadataChanged: options?.onBootstrapMetadataChanged,
+<<<<<<< HEAD
     onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete),
     onScopeDownloadStart: reportScopeDownloadStart,
+||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
+    onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete),
+=======
+    onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete, queryClient),
+>>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
     onCoverageReset: reportCoverageReset,
     onCoverageEvaluated: reportCoverageEvaluated,
     onBootstrapRetryScheduled: reportBootstrapRetryScheduled,
@@ -466,8 +492,14 @@ export function triggerSync(
     snapshotSource: options?.snapshotSource,
     onSnapshotBootstrapError: reportSnapshotBootstrapError,
     onBootstrapMetadataChanged: options?.onBootstrapMetadataChanged,
+<<<<<<< HEAD
     onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete),
     onScopeDownloadStart: reportScopeDownloadStart,
+||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
+    onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete),
+=======
+    onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete, queryClient),
+>>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
     onCoverageReset: reportCoverageReset,
     onCoverageEvaluated: reportCoverageEvaluated,
     onBootstrapRetryScheduled: reportBootstrapRetryScheduled,
@@ -487,8 +519,14 @@ export function pullSync(
     isOnline: options?.isOnline ?? isOnline,
     onSchemaDrift: options?.onSchemaDrift ?? reportSchemaDrift,
     onSnapshotBootstrapError: options?.onSnapshotBootstrapError ?? reportSnapshotBootstrapError,
+<<<<<<< HEAD
     onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete),
     onScopeDownloadStart: options?.onScopeDownloadStart ?? reportScopeDownloadStart,
+||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
+    onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete),
+=======
+    onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete, queryClient),
+>>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
     onCoverageReset: options?.onCoverageReset ?? reportCoverageReset,
     onCoverageEvaluated: options?.onCoverageEvaluated ?? reportCoverageEvaluated,
     onBootstrapRetryScheduled: options?.onBootstrapRetryScheduled ?? reportBootstrapRetryScheduled,

--- a/packages/mobile/src/offline/offline-sync-adapter.ts
+++ b/packages/mobile/src/offline/offline-sync-adapter.ts
@@ -395,7 +395,18 @@ const schedulerTriggers: SchedulerTriggers = {
   },
   subscribeConnectivity(callback) {
     return NetInfo.addEventListener((state) => {
-      callback(state.isConnected ?? false);
+      // Reachability, not just "a network is attached". `isConnected` is TRUE
+      // for the whole of a captive portal or gym wifi with a dead upstream —
+      // the exact connection `armBoardsOffline` exists for — so forwarding it
+      // alone gives the scheduler no offline→online edge when that link starts
+      // working again: an armed scope would sit pending until the user changed
+      // networks or backgrounded and reopened the app. NetInfo's reachability
+      // probe is what actually flips there, and that false→true edge is the
+      // retry.
+      //
+      // `null` is "not probed yet", never "unreachable" — treating it as a
+      // disconnect would invent an edge on every platform that answers late.
+      callback((state.isConnected ?? false) && state.isInternetReachable !== false);
     });
   },
 };
@@ -460,14 +471,8 @@ export function startSyncScheduler(
     snapshotSource: options?.snapshotSource,
     onSnapshotBootstrapError: reportSnapshotBootstrapError,
     onBootstrapMetadataChanged: options?.onBootstrapMetadataChanged,
-<<<<<<< HEAD
-    onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete),
-    onScopeDownloadStart: reportScopeDownloadStart,
-||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
-    onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete),
-=======
     onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete, queryClient),
->>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
+    onScopeDownloadStart: reportScopeDownloadStart,
     onCoverageReset: reportCoverageReset,
     onCoverageEvaluated: reportCoverageEvaluated,
     onBootstrapRetryScheduled: reportBootstrapRetryScheduled,
@@ -492,14 +497,8 @@ export function triggerSync(
     snapshotSource: options?.snapshotSource,
     onSnapshotBootstrapError: reportSnapshotBootstrapError,
     onBootstrapMetadataChanged: options?.onBootstrapMetadataChanged,
-<<<<<<< HEAD
-    onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete),
-    onScopeDownloadStart: reportScopeDownloadStart,
-||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
-    onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete),
-=======
     onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete, queryClient),
->>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
+    onScopeDownloadStart: reportScopeDownloadStart,
     onCoverageReset: reportCoverageReset,
     onCoverageEvaluated: reportCoverageEvaluated,
     onBootstrapRetryScheduled: reportBootstrapRetryScheduled,
@@ -519,14 +518,8 @@ export function pullSync(
     isOnline: options?.isOnline ?? isOnline,
     onSchemaDrift: options?.onSchemaDrift ?? reportSchemaDrift,
     onSnapshotBootstrapError: options?.onSnapshotBootstrapError ?? reportSnapshotBootstrapError,
-<<<<<<< HEAD
-    onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete),
-    onScopeDownloadStart: options?.onScopeDownloadStart ?? reportScopeDownloadStart,
-||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
-    onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete),
-=======
     onScopeDownloadComplete: combinedScopeDownloadCompleteReporter(options?.onScopeDownloadComplete, queryClient),
->>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
+    onScopeDownloadStart: options?.onScopeDownloadStart ?? reportScopeDownloadStart,
     onCoverageReset: options?.onCoverageReset ?? reportCoverageReset,
     onCoverageEvaluated: options?.onCoverageEvaluated ?? reportCoverageEvaluated,
     onBootstrapRetryScheduled: options?.onBootstrapRetryScheduled ?? reportBootstrapRetryScheduled,

--- a/packages/mobile/src/offline/use-board-downloads.ts
+++ b/packages/mobile/src/offline/use-board-downloads.ts
@@ -73,10 +73,15 @@ export function useBoardDownloads() {
   // straight into.
   const downloadKickPendingRef = useRef(false);
 
-  const enableBoardsOffline = useCallback(
-    (boards: UserBoard | UserBoard[], options?: { trigger?: OfflineDownloadTrigger; source?: ToggleSource }) => {
-      const list = Array.isArray(boards) ? boards : [boards];
-      if (list.length === 0) return;
+  // The enable half both entry points share: flip the per-scope setting, persist
+  // the attribution, emit Toggled, and snapshot the board identities while we
+  // hold them. This is the single funnel for every offline enable (the My Boards
+  // toggle, adopt-found-board, the "download all" settings toggle, the discovery
+  // nudges), so the offline picker gets its rows without any caller having to
+  // remember to persist them. A scope key alone can't name a board — see
+  // settings/offline-boards.ts.
+  const markBoardsEnabled = useCallback(
+    (list: UserBoard[], options?: { trigger?: OfflineDownloadTrigger; source?: ToggleSource }) => {
       const trigger = options?.trigger ?? 'unknown';
       const source = options?.source ?? 'manage';
       // Two boards can share one offline scope — the key is board type + layout +
@@ -94,7 +99,8 @@ export function useBoardDownloads() {
         seenScopeKeys.add(scopeKey);
         setOfflineBoardEnabled(offlineBoardScopeForBoard(board), true);
         // Persisted, then consumed when the download actually starts — which can
-        // be a later app launch entirely if the board was enabled with no signal.
+        // be a later app launch entirely if the board was enabled with no signal,
+        // which is exactly what the arm path below leaves behind.
         rememberDownloadTrigger(scopeKey, trigger);
         track(SHARED_EVENTS.OfflineBoardToggled, {
           scopeKey,
@@ -103,19 +109,23 @@ export function useBoardDownloads() {
           offlineEngineEnabled: isOfflineEngineEnabled(),
         });
       }
-      // Snapshot the board identities while we hold them. This is the single funnel
-      // for every offline enable (the My Boards toggle, adopt-found-board, the
-      // "download all" settings toggle), so the offline picker gets its rows without
-      // any caller having to remember to persist them. A scope key alone can't name
-      // a board — see settings/offline-boards.ts.
       rememberOfflineBoards(list);
+    },
+    [],
+  );
+
+  const enableBoardsOffline = useCallback(
+    (boards: UserBoard | UserBoard[], options?: { trigger?: OfflineDownloadTrigger; source?: ToggleSource }) => {
+      const list = Array.isArray(boards) ? boards : [boards];
+      if (list.length === 0) return;
+      markBoardsEnabled(list, options);
       if (!schemaReady) {
         downloadKickPendingRef.current = true;
         return;
       }
       startDownloadCycle();
     },
-    [schemaReady, startDownloadCycle],
+    [markBoardsEnabled, schemaReady, startDownloadCycle],
   );
 
   useEffect(() => {
@@ -140,5 +150,32 @@ export function useBoardDownloads() {
     [db, startDownloadCycle],
   );
 
-  return { enableBoardsOffline, retryFastDownload };
+  /**
+   * Mark boards for offline WITHOUT kicking a sync cycle.
+   *
+   * Deliberately no `triggerSync`. Every surface that can fire while the device
+   * has no usable connection — the offline board picker, the offline climbs
+   * empty state — reaches this instead of `enableBoardsOffline`, because
+   * `onlineManager.isOnline()` is TRUE on captive-portal / dead-upstream wifi, so
+   * `triggerSync`'s own guard would not short-circuit: the cycle would run,
+   * every request would fail, and `recordRetryableBootstrapFailure` would spend
+   * one of the two `MAX_BOOTSTRAP_ATTEMPTS` per tap. Two taps and the scope is
+   * pinned to the multi-minute paged crawl forever (issue #4313).
+   *
+   * Nothing is lost by waiting: the scheduler's own connectivity trigger
+   * (`subscribeConnectivity` in this adapter) runs a cycle the moment the device
+   * reconnects, and that cycle reads the latest `syncEnabledBoards`. The board
+   * sits in the documented `'pending'` state until then, which the My Boards row
+   * already renders as "Waiting to download".
+   */
+  const armBoardsOffline = useCallback(
+    (boards: UserBoard | UserBoard[]) => {
+      const list = Array.isArray(boards) ? boards : [boards];
+      if (list.length === 0) return;
+      markBoardsEnabled(list);
+    },
+    [markBoardsEnabled],
+  );
+
+  return { enableBoardsOffline, armBoardsOffline, retryFastDownload };
 }

--- a/packages/mobile/src/offline/use-board-downloads.ts
+++ b/packages/mobile/src/offline/use-board-downloads.ts
@@ -163,16 +163,21 @@ export function useBoardDownloads() {
    * pinned to the multi-minute paged crawl forever (issue #4313).
    *
    * Nothing is lost by waiting: the scheduler's own connectivity trigger
-   * (`subscribeConnectivity` in this adapter) runs a cycle the moment the device
-   * reconnects, and that cycle reads the latest `syncEnabledBoards`. The board
-   * sits in the documented `'pending'` state until then, which the My Boards row
-   * already renders as "Waiting to download".
+   * (`subscribeConnectivity` in the adapter) runs a cycle the moment the device
+   * reconnects, and that cycle reads the latest `syncEnabledBoards`. That
+   * trigger forwards NetInfo REACHABILITY rather than bare `isConnected`,
+   * precisely so the connection that produced this arm counts: on a captive
+   * portal `isConnected` never stops being true, so the reachability edge is the
+   * only signal that the upstream came back without the user changing networks
+   * or backgrounding the app. The board sits in the documented `'pending'` state
+   * until then, which the My Boards row already renders as "Waiting to
+   * download".
    */
   const armBoardsOffline = useCallback(
-    (boards: UserBoard | UserBoard[]) => {
+    (boards: UserBoard | UserBoard[], options?: { trigger?: OfflineDownloadTrigger; source?: ToggleSource }) => {
       const list = Array.isArray(boards) ? boards : [boards];
       if (list.length === 0) return;
-      markBoardsEnabled(list);
+      markBoardsEnabled(list, options);
     },
     [markBoardsEnabled],
   );

--- a/packages/mobile/src/offline/use-confirm-board-download.ts
+++ b/packages/mobile/src/offline/use-confirm-board-download.ts
@@ -1,0 +1,115 @@
+// The two ways a board becomes available offline, shared by every surface that
+// offers it (the My Boards toggle and the discovery nudges of issue #4318).
+//
+// Splitting them is the point. A download and an arm are different promises:
+//
+//   confirmAndDownload — the device is online. Quote the size, ask, then enable
+//     and kick a cycle. Byte-identical to what My Boards has always done, so a
+//     nudge-triggered download is the same download.
+//
+//   armWithoutConfirm — the device has no usable connection. Enable only, no
+//     cycle, no size dialog (no honest number exists before the manifest is
+//     reachable, and there is nothing to consent to yet — nothing downloads).
+//     See armBoardsOffline for why kicking a cycle here is actively harmful.
+
+import { useCallback, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useSQLiteContext } from 'expo-sqlite';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import {
+  estimateScopeDownload,
+  getCheckpoint,
+  getCheckpointKey,
+  isBootstrapDone,
+  isScopeDownloadComplete,
+  readBootstrapRetryState,
+} from '@boardsesh/offline-sync';
+import { offlineBoardKeyForBoard, offlineBoardScopeForBoard } from '../settings';
+import { useConfirm } from '../providers/dialog-provider';
+import { formatBytes } from '../lib/format-bytes';
+import { useBoardDownloads } from './use-board-downloads';
+import { useSnapshotManifest } from './use-snapshot-manifest';
+
+export function useConfirmBoardDownload() {
+  const { t, i18n } = useTranslation('boards');
+  const db = useSQLiteContext();
+  const confirm = useConfirm();
+  const { enableBoardsOffline, armBoardsOffline } = useBoardDownloads();
+  // A ref, not a dep: the manifest arrives asynchronously and must not rebuild
+  // the callback (My Boards passes it to every virtualised row).
+  const snapshotManifest = useSnapshotManifest();
+  const snapshotManifestRef = useRef(snapshotManifest);
+  snapshotManifestRef.current = snapshotManifest;
+
+  /**
+   * Quote the download size, ask, and start it. Resolves to whether the user
+   * confirmed.
+   */
+  const confirmAndDownload = useCallback(
+    async (board: UserBoard): Promise<boolean> => {
+      const scope = offlineBoardScopeForBoard(board);
+      const key = offlineBoardKeyForBoard(board);
+      // How big is this download? Only the snapshot path can answer honestly, and
+      // only for a scope that would actually bootstrap — a board toggled off and
+      // back on keeps its rows + checkpoint and resumes as a small delta, so
+      // quoting the full artifact size there would be wrong. estimateScopeDownload
+      // owns those rules (shared with the engine's own eligibility check); anything
+      // it can't vouch for falls back to the sizeless copy.
+      //
+      // Concurrent, not sequential: these are four independent reads and the
+      // dialog opens behind them, so serialising them would show up as a stall on
+      // slow storage. The retry state is read after them because it needs to know
+      // whether a board checkpoint exists (a snapshot failure over a partial crawl
+      // is budgeted differently from one over an empty scope).
+      const now = Date.now();
+      const [climbsCheckpoint, statsCheckpoint, scopeComplete, bootstrapAlreadyDone] = await Promise.all([
+        getCheckpoint(db, getCheckpointKey('board_climbs', key)),
+        getCheckpoint(db, getCheckpointKey('board_climb_stats', key)),
+        isScopeDownloadComplete(db, key),
+        isBootstrapDone(db, key),
+      ]);
+      const hasBoardCheckpoint = !!climbsCheckpoint || !!statsCheckpoint;
+      const { state: retryState } = await readBootstrapRetryState(
+        db,
+        key,
+        { now, random: Math.random },
+        hasBoardCheckpoint,
+      );
+      const estimate = estimateScopeDownload({
+        manifest: snapshotManifestRef.current,
+        boardType: scope.boardType,
+        layoutId: scope.layoutId,
+        retryState,
+        hasBoardCheckpoint,
+        isScopeComplete: scopeComplete,
+        isBootstrapDone: bootstrapAlreadyDone,
+        now,
+      });
+      const confirmed = await confirm({
+        title: t('mobile.offline.enableTitle', { name: board.name }),
+        message:
+          estimate.kind === 'snapshot'
+            ? t('mobile.offline.enableMessageWithSize', { size: formatBytes(estimate.bytes, i18n.language) })
+            : t('mobile.offline.enableMessage'),
+        confirmLabel: t('mobile.offline.enableConfirm'),
+        cancelLabel: t('mobile.manage.cancel'),
+      });
+      if (!confirmed) return false;
+      // Enable + kick a download now via the shared hook (single-flight, reads the
+      // latest syncEnabledBoards setting).
+      enableBoardsOffline(board);
+      return true;
+    },
+    [confirm, t, i18n.language, db, enableBoardsOffline],
+  );
+
+  /** Mark the board for offline; the scheduler pulls it on the next reconnect. */
+  const armWithoutConfirm = useCallback(
+    (board: UserBoard): void => {
+      armBoardsOffline(board);
+    },
+    [armBoardsOffline],
+  );
+
+  return { confirmAndDownload, armWithoutConfirm };
+}

--- a/packages/mobile/src/offline/use-confirm-board-download.ts
+++ b/packages/mobile/src/offline/use-confirm-board-download.ts
@@ -24,10 +24,10 @@ import {
   isScopeDownloadComplete,
   readBootstrapRetryState,
 } from '@boardsesh/offline-sync';
-import { offlineBoardKeyForBoard, offlineBoardScopeForBoard } from '../settings';
+import { offlineBoardKeyForBoard, offlineBoardScopeForBoard, type OfflineDownloadTrigger } from '../settings';
 import { useConfirm } from '../providers/dialog-provider';
 import { formatBytes } from '../lib/format-bytes';
-import { useBoardDownloads } from './use-board-downloads';
+import { useBoardDownloads, type ToggleSource } from './use-board-downloads';
 import { useSnapshotManifest } from './use-snapshot-manifest';
 
 export function useConfirmBoardDownload() {
@@ -44,9 +44,16 @@ export function useConfirmBoardDownload() {
   /**
    * Quote the download size, ask, and start it. Resolves to whether the user
    * confirmed.
+   *
+   * `options` is the funnel attribution (issue #4316) — which surface asked and
+   * what triggered it — forwarded to the enable so the eventual Started event
+   * says where the download came from. Every nudge surface passes its own.
    */
   const confirmAndDownload = useCallback(
-    async (board: UserBoard): Promise<boolean> => {
+    async (
+      board: UserBoard,
+      options?: { trigger?: OfflineDownloadTrigger; source?: ToggleSource },
+    ): Promise<boolean> => {
       const scope = offlineBoardScopeForBoard(board);
       const key = offlineBoardKeyForBoard(board);
       // How big is this download? Only the snapshot path can answer honestly, and
@@ -97,7 +104,7 @@ export function useConfirmBoardDownload() {
       if (!confirmed) return false;
       // Enable + kick a download now via the shared hook (single-flight, reads the
       // latest syncEnabledBoards setting).
-      enableBoardsOffline(board);
+      enableBoardsOffline(board, options);
       return true;
     },
     [confirm, t, i18n.language, db, enableBoardsOffline],
@@ -105,8 +112,8 @@ export function useConfirmBoardDownload() {
 
   /** Mark the board for offline; the scheduler pulls it on the next reconnect. */
   const armWithoutConfirm = useCallback(
-    (board: UserBoard): void => {
-      armBoardsOffline(board);
+    (board: UserBoard, options?: { trigger?: OfflineDownloadTrigger; source?: ToggleSource }): void => {
+      armBoardsOffline(board, options);
     },
     [armBoardsOffline],
   );

--- a/packages/mobile/src/offline/use-downloaded-scope-keys.ts
+++ b/packages/mobile/src/offline/use-downloaded-scope-keys.ts
@@ -1,0 +1,32 @@
+// The one reactive read of "which board scopes have actually landed on this
+// device". Three screens (My Boards, the boards picker, More) each had their own
+// inline copy of this query; they now share this hook so the query key, the
+// SQLite read and — crucially — the freshness contract live in one place.
+//
+// Freshness is NOT owned here. `offline-sync-adapter.ts` invalidates
+// `['downloadedScopeKeys']` from the engine's per-scope completion callback, so
+// a badge or an empty state flips on the screen the user is already looking at
+// without any consumer subscribing to `useSyncStatus()` (which republishes on
+// every progress frame and would churn the virtualised screens).
+
+import { useQuery } from '@tanstack/react-query';
+import { useSQLiteContext } from 'expo-sqlite';
+import { getDownloadedScopeKeys } from '@boardsesh/offline-sync';
+
+export const DOWNLOADED_SCOPE_KEYS_QUERY_KEY = ['downloadedScopeKeys'] as const;
+
+/**
+ * Scope keys (`boardType:layoutId:sizeId`) whose board data has a completed
+ * download checkpoint.
+ *
+ * Deliberately ungated by the offline-downloads flag: it reads rows already on
+ * disk, and a device that still holds downloads after a kill-switch rollback
+ * must not be stranded.
+ */
+export function useDownloadedScopeKeys() {
+  const db = useSQLiteContext();
+  return useQuery({
+    queryKey: DOWNLOADED_SCOPE_KEYS_QUERY_KEY,
+    queryFn: () => getDownloadedScopeKeys(db),
+  });
+}

--- a/packages/mobile/src/offline/use-downloaded-scope-keys.ts
+++ b/packages/mobile/src/offline/use-downloaded-scope-keys.ts
@@ -12,6 +12,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useSQLiteContext } from 'expo-sqlite';
 import { getDownloadedScopeKeys } from '@boardsesh/offline-sync';
+import { useOfflineSchemaReady } from '../db/use-offline-schema-ready';
 
 export const DOWNLOADED_SCOPE_KEYS_QUERY_KEY = ['downloadedScopeKeys'] as const;
 
@@ -25,8 +26,14 @@ export const DOWNLOADED_SCOPE_KEYS_QUERY_KEY = ['downloadedScopeKeys'] as const;
  */
 export function useDownloadedScopeKeys() {
   const db = useSQLiteContext();
+  // Schema readiness is a KEY member, not an `enabled` gate. On a contended launch
+  // this connection has no tables yet, and the read lands in `isError` — the empty
+  // state, which is already the right answer. Gating instead would spin forever
+  // whenever init genuinely fails; keying makes a late readiness flip refetch.
+  // The invalidations above target the prefix, so they still reach every variant.
+  const schemaReady = useOfflineSchemaReady();
   return useQuery({
-    queryKey: DOWNLOADED_SCOPE_KEYS_QUERY_KEY,
+    queryKey: [...DOWNLOADED_SCOPE_KEYS_QUERY_KEY, schemaReady],
     queryFn: () => getDownloadedScopeKeys(db),
   });
 }

--- a/packages/mobile/src/offline/use-snapshot-source.ts
+++ b/packages/mobile/src/offline/use-snapshot-source.ts
@@ -9,7 +9,6 @@ import {
 import { mobileSnapshotSource } from './snapshot-source';
 
 /**
-<<<<<<< HEAD
  * The kill-switch wrapper for download progress (issue #4311). Passing an
  * `onProgress` callback makes expo-file-system take a different NATIVE download
  * implementation — an 8 KB streaming copy loop on Android, a delegate-driven

--- a/packages/mobile/src/providers/feature-flags-provider.tsx
+++ b/packages/mobile/src/providers/feature-flags-provider.tsx
@@ -77,6 +77,12 @@ export const FEATURE_FLAG_DEFINITIONS = [
       'DEFAULT: ON — unlike every other flag here, absent/undefined means enabled. Real byte + percent progress on a downloading board instead of a static spinner. Off restores the old caption AND stops passing a progress callback to the native downloader, so it doubles as the kill switch if the progress-enabled download path ever proves slower.',
   },
   {
+    key: 'offline-discovery-nudges',
+    label: 'Offline discovery nudges',
+    description:
+      "Suggest taking a board offline: the post-session prompt, the no-signal empty states, the board-card download glyph and the What's New spotlight. Requires offline-board-downloads to also be on.",
+  },
+  {
     key: 'boardsesh-grade',
     label: 'Boardsesh grade',
     description:
@@ -181,6 +187,18 @@ export function useSnapshotBootstrapEnabled(): boolean {
  */
 export function useOfflineDownloadProgressEnabled(): boolean {
   return useFeatureFlag('offline-download-progress') !== false;
+}
+
+/**
+ * Gate for the offline discovery nudges (issue #4318). Missing/undefined reads
+ * as OFF so this ramps from zero — nudging users into a download before the
+ * download itself is fast burns the one first impression they get.
+ *
+ * Callers must AND this with `useOfflineDownloadsEnabled()`: a nudge for a
+ * feature the kill switch has disabled is a dead end.
+ */
+export function useOfflineNudgesEnabled(): boolean {
+  return useFeatureFlag('offline-discovery-nudges') === true;
 }
 
 /**

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -429,6 +429,7 @@ export const SHARED_EVENTS = {
   // 'reset' | 'probe_failed' }. Deduped once-per-launch-per-verdict in the
   // mobile binding, because the engine evaluates on every foreground.
   OfflineSyncCoverageEvaluated: 'Offline Sync Coverage Evaluated',
+<<<<<<< HEAD
   // Offline sync — the local SQLite setup lost the write lock at launch and a
   // later retry won, so offline storage came up after all. Fired at most once
   // per process, only when attempt 1 failed (a clean launch stays silent).
@@ -515,6 +516,22 @@ export const SHARED_EVENTS = {
   // filesDeleted }. Mobile-only: web's overlay store is the Cache API, already
   // bounded by entry count.
   CachedImagesSwept: 'Cached Images Swept',
+||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
+=======
+  // Offline discovery nudges (issue #4318) — the app suggesting a board download
+  // rather than waiting to be found. One event trio across every nudge surface,
+  // separated by `surface`, so the funnel reads shown → accepted → (#4316's
+  // download started / OfflineBoardDownloadCompleted above). Props on all three:
+  // { surface: 'post_session' | 'no_catalog' | 'whats_new' | 'board_card',
+  //   boardType, layoutId, scopeKey, downloadedBoardCount }.
+  OfflineNudgeShown: 'Offline Nudge Shown',
+  // Plus { armedOnly }: true when accepting could only ARM the scope (the device
+  // was offline, so the pull waits for the scheduler's reconnect trigger). Without
+  // it the funnel reads as accepts that never download.
+  OfflineNudgeAccepted: 'Offline Nudge Accepted',
+  // Plus { dismissKind: 'once' | 'forever' }.
+  OfflineNudgeDismissed: 'Offline Nudge Dismissed',
+>>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
 } as const;
 
 export type SharedEventKey = keyof typeof SHARED_EVENTS;

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -429,7 +429,6 @@ export const SHARED_EVENTS = {
   // 'reset' | 'probe_failed' }. Deduped once-per-launch-per-verdict in the
   // mobile binding, because the engine evaluates on every foreground.
   OfflineSyncCoverageEvaluated: 'Offline Sync Coverage Evaluated',
-<<<<<<< HEAD
   // Offline sync — the local SQLite setup lost the write lock at launch and a
   // later retry won, so offline storage came up after all. Fired at most once
   // per process, only when attempt 1 failed (a clean launch stays silent).
@@ -516,8 +515,6 @@ export const SHARED_EVENTS = {
   // filesDeleted }. Mobile-only: web's overlay store is the Cache API, already
   // bounded by entry count.
   CachedImagesSwept: 'Cached Images Swept',
-||||||| parent of 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
-=======
   // Offline discovery nudges (issue #4318) — the app suggesting a board download
   // rather than waiting to be found. One event trio across every nudge surface,
   // separated by `surface`, so the funnel reads shown → accepted → (#4316's
@@ -531,7 +528,6 @@ export const SHARED_EVENTS = {
   OfflineNudgeAccepted: 'Offline Nudge Accepted',
   // Plus { dismissKind: 'once' | 'forever' }.
   OfflineNudgeDismissed: 'Offline Nudge Dismissed',
->>>>>>> 10230768c (fix(mobile): refresh downloaded-board state on scope completion and add the offline nudge policy)
 } as const;
 
 export type SharedEventKey = keyof typeof SHARED_EVENTS;


### PR DESCRIPTION
**HOLD: merges only after Tier 1 (#4310-#4313).** Nudging people into today's download would burn the one first impression they get.

Groundwork for the offline discovery nudges (#4318), plus the freshness bug that would have made every one of them lie.

**The bug.** Nothing invalidated `['downloadedScopeKeys']` when a board finished downloading — only `remove-offline-board.ts` ever did, and only on removal. My Boards papered over it with a manual `useEffect` refetch keyed on `syncStatus`; the two other copies of the same query (`boards/index.tsx`, `(tabs)/profile/more.tsx`) had nothing. So a board that finished downloading kept reading as "not downloaded" on any screen the user hadn't left. Nothing renders that state today, which is why it hasn't been reported — but a badge or a download affordance built on it would have shipped visibly wrong.

The fix goes into the engine's per-scope completion callback in `offline-sync-adapter.ts`, which is the one place `triggerSync`, `startSyncScheduler` and `pullSync` all pass through. Deliberately *not* a hook subscribing to `useSyncStatus()`: that republishes a fresh object on every progress frame, and the consumers are virtualised screens. This fires once per completed scope, so the cost is one SQLite read per completion.

**Arming vs downloading.** `useBoardDownloads` gains `armBoardsOffline` — enable the scope, no sync cycle. `onlineManager.isOnline()` is TRUE on captive-portal wifi (that's what makes it a lying connection), so `triggerSync`'s guard doesn't short-circuit there: the cycle runs, every request fails, and `recordRetryableBootstrapFailure` spends one of the two `MAX_BOOTSTRAP_ATTEMPTS`. Two taps of an offline CTA and the scope is pinned to the multi-minute paged crawl (#4313). The scheduler's own `subscribeConnectivity` trigger pulls it on reconnect instead. The regression test asserts `triggerSync` is **not** called — that assertion is the guard, not a description.

## Changes

- `offline-sync-adapter.ts`: `combinedScopeDownloadCompleteReporter` is queryClient-aware and invalidates `['downloadedScopeKeys']` + `['offlineStorage']` per completed scope.
- New `useDownloadedScopeKeys()`; all three inline copies repointed at it.
- `armBoardsOffline()` alongside `enableBoardsOffline()`.
- `use-confirm-board-download.ts` extracts the size-quote + confirm + enable half of My Boards' `handleToggleOffline`, so a nudge-triggered download is byte-identical to a manual one. The disable branch stays on the screen.
- `SHARED_EVENTS.OfflineNudge{Shown,Accepted,Dismissed}`.
- `offline-discovery-nudges` feature flag (`undefined → false`) + `useOfflineNudgesEnabled()`.
- `src/lib/offline-nudges/`: pure policy, AsyncStorage-backed state, analytics wrappers.

## Release Notes

- [x] No release note needed (internal / technical change)

The freshness fix is real but not observable on any surface that ships today; the surfaces that make it visible are PRs 2-4 in this stack.

## Test plan

Foreground, from a worktree outside `.claude/worktrees`:

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 628 files / 5552 tests pass
- `vp test run --project i18n` (90), `--project analytics` (23) — pass
- `vp run check:mobile-bundle`, `vp run check:mobile-web-bundle` — OK
- `vp run check:i18n:orphans` — OK

New coverage: `nudge-policy.test.ts` (full decision table), `nudge-storage.test.ts` (read rejection → suppress-everything, corrupt payload → defaults), `use-board-downloads.test.tsx` (`armBoardsOffline` does NOT call `triggerSync`), `offline-sync-adapter.test.ts` (scope completion invalidates the caches from both the scheduler and the manual path).

Not yet exercised on device — nothing user-visible lands until PR 2.

## Merge-order notes

`events.ts`, `use-board-downloads.ts`, `offline-sync-adapter.ts` and `manage.tsx` are each touched by #4310/#4311/#4315/#4316/#4317 too. Land theirs first; conflicts here are textual and additive. #4316's `Offline Board Download Started` must **not** fire for `armBoardsOffline` — nothing downloads — which pairs with the `armedOnly` prop on `Offline Nudge Accepted`.

Hand-off to #3621: `offlineNudgeStateV1` needs adding to the sign-out wipe. A stale key across accounts on a shared device silently suppresses every nudge for the next user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT6VP1sWqk6bY9mUgyeS2U
