### PR TITLE
feat(mobile): offer to download your board after a session (2/4)

### DIFF
--- a/packages/mobile/app/(tabs)/record/__tests__/summary-error-state.test.tsx
+++ b/packages/mobile/app/(tabs)/record/__tests__/summary-error-state.test.tsx
@@ -37,6 +37,10 @@ vi.mock('expo-router', () => ({
 vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ bottom: 0 }) }));
 vi.mock('../../../../src/lib/graphql/hooks', () => ({ useSessionSummary: () => hook.result }));
 vi.mock('../../../../src/lib/graphql/use-active-board', () => ({ useActiveBoard: () => ({ data: null }) }));
+// Has its own render suite (src/components/offline/__tests__).
+vi.mock('../../../../src/components/offline/PostSessionOfflineNudge', () => ({
+  PostSessionOfflineNudge: () => null,
+}));
 // Stub the integration summary actions so the real integrations lib (which
 // pulls in the native health-workouts/reanimated modules) isn't loaded in the
 // node test env.
@@ -56,6 +60,10 @@ vi.mock('../../../../src/lib/store-review', () => ({
   SESSION_STORE_REVIEW_CANDIDATE_PARAM: '1',
   STORE_REVIEW_PROMPT_DELAY_MS: 1000,
   isSessionStoreReviewEligible: (summary: { totalSends: number }) => summary.totalSends >= 3,
+  // The screen resolves the FULL decision now (cooldown + per-session dedup +
+  // StoreReview.hasAction()), not the bare eligibility predicate — see
+  // usePostSessionPrompt.
+  shouldRequestSessionStoreReview: async (summary: { totalSends: number }) => summary.totalSends >= 3,
   maybeRequestSessionStoreReview: storeReview.maybeRequestSessionStoreReview,
 }));
 
@@ -205,6 +213,9 @@ describe('SessionSummaryScreen settled error/empty state', () => {
     render(<SessionSummaryScreen />);
     expect(storeReview.maybeRequestSessionStoreReview).not.toHaveBeenCalled();
 
+    // The review-vs-offline-nudge decision resolves asynchronously now, and only
+    // then does the delay timer get scheduled — flush the microtask first.
+    await act(async () => {});
     await act(async () => {
       vi.advanceTimersByTime(1000);
     });
@@ -231,6 +242,7 @@ describe('SessionSummaryScreen settled error/empty state', () => {
 
     const { rerender } = render(<SessionSummaryScreen />);
 
+    await act(async () => {});
     await act(async () => {
       vi.advanceTimersByTime(500);
     });

--- a/packages/mobile/app/(tabs)/record/summary.tsx
+++ b/packages/mobile/app/(tabs)/record/summary.tsx
@@ -27,12 +27,9 @@ import { SaveToAppleHealthButton } from '../../../src/components/integrations/Sa
 import { ShareToStravaButton } from '../../../src/components/integrations/ShareToStravaButton';
 import { springs, timing } from '../../../src/theme/animations';
 import { hapticSuccess } from '../../../src/lib/haptics';
-import {
-  SESSION_STORE_REVIEW_CANDIDATE_PARAM,
-  STORE_REVIEW_PROMPT_DELAY_MS,
-  isSessionStoreReviewEligible,
-  maybeRequestSessionStoreReview,
-} from '../../../src/lib/store-review';
+import { STORE_REVIEW_PROMPT_DELAY_MS, maybeRequestSessionStoreReview } from '../../../src/lib/store-review';
+import { usePostSessionPrompt } from '../../../src/lib/offline-nudges/use-post-session-prompt';
+import { PostSessionOfflineNudge } from '../../../src/components/offline/PostSessionOfflineNudge';
 import { spacing } from '../../../src/theme/tokens';
 
 type TFunc = (key: string, opts?: Record<string, unknown>) => string;
@@ -63,10 +60,15 @@ export default function SessionSummaryScreen() {
   const promptedSessionIdRef = useRef<string | null>(null);
   const reviewCandidateParam = Array.isArray(reviewCandidate) ? reviewCandidate[0] : reviewCandidate;
 
+  // One decision for the whole screen: the store review, the offline-download
+  // offer, or neither. Resolving it once is what keeps the offline prompt alive
+  // on the ≥3-send sessions where the review is merely on cooldown — see
+  // usePostSessionPrompt.
+  const postSessionPrompt = usePostSessionPrompt(summary, reviewCandidateParam);
+
   useEffect(() => {
     if (!summary) return undefined;
-    if (reviewCandidateParam !== SESSION_STORE_REVIEW_CANDIDATE_PARAM) return undefined;
-    if (!isSessionStoreReviewEligible(summary)) return undefined;
+    if (postSessionPrompt !== 'review') return undefined;
     if (promptedSessionIdRef.current === summary.sessionId) return undefined;
 
     const timer = setTimeout(() => {
@@ -75,7 +77,7 @@ export default function SessionSummaryScreen() {
     }, STORE_REVIEW_PROMPT_DELAY_MS);
 
     return () => clearTimeout(timer);
-  }, [summary, reviewCandidateParam]);
+  }, [summary, postSessionPrompt]);
 
   // Still loading: query hasn't settled yet (first fetch in flight or refetching
   // after a retry). isPending covers the disabled (no sessionId) case too.
@@ -108,7 +110,7 @@ export default function SessionSummaryScreen() {
     );
   }
 
-  return <SessionSummaryContent summary={summary} />;
+  return <SessionSummaryContent summary={summary} storeReviewWillPrompt={postSessionPrompt !== 'offline'} />;
 }
 
 /**
@@ -118,7 +120,13 @@ export default function SessionSummaryScreen() {
  * stat tiles, and the same grade chart — so the post-session payoff feels like
  * the rest of the app.
  */
-function SessionSummaryContent({ summary }: { summary: SessionSummary }) {
+function SessionSummaryContent({
+  summary,
+  storeReviewWillPrompt,
+}: {
+  summary: SessionSummary;
+  storeReviewWillPrompt: boolean;
+}) {
   const { t } = useTranslation('session');
   const { systemColors } = useTheme();
   const insets = useSafeAreaInsets();
@@ -239,6 +247,11 @@ function SessionSummaryContent({ summary }: { summary: SessionSummary }) {
           </Text>
         </Animated.View>
       </View>
+
+      {/* "You climbed here — keep it on your phone." Renders itself away unless
+          the board is un-downloaded, the flags are on, and the store review has
+          stood down. */}
+      <PostSessionOfflineNudge storeReviewWillPrompt={storeReviewWillPrompt} style={styles.offlineNudge} />
 
       {/* Hardest send — a real achievement card with a board thumbnail */}
       {hardest ? (
@@ -395,6 +408,9 @@ const styles = StyleSheet.create({
   },
   featuredValue: {
     fontWeight: '700',
+  },
+  offlineNudge: {
+    marginBottom: spacing[4],
   },
   hardestRow: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/offline/OfflineNudgeCard.tsx
+++ b/packages/mobile/src/components/offline/OfflineNudgeCard.tsx
@@ -1,0 +1,107 @@
+// The one card every offline-nudge surface renders. Purely presentational: the
+// host owns eligibility, persistence and analytics (see use-offline-nudge).
+//
+// No animation, so it is Reduce-Motion-safe by construction — same reasoning as
+// OnboardingTipBanner, and the post-session screen already has a hero animation
+// running when this appears.
+
+import { memo } from 'react';
+import { StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { Button } from '../Button';
+import { useTheme } from '../../providers/theme-provider';
+import { borderRadius, spacing } from '../../theme/tokens';
+
+export type OfflineNudgeCardProps = {
+  /** Already-translated. */
+  title: string;
+  body: string;
+  primaryLabel: string;
+  onPrimary: () => void;
+  /** Optional second offer, e.g. "keep all my boards downloaded". */
+  secondaryLabel?: string;
+  onSecondary?: () => void;
+  /** Omit both to render an affordance with no way to hide it. */
+  dismissLabel?: string;
+  onDismiss?: () => void;
+  neverLabel?: string;
+  onNever?: () => void;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+};
+
+function OfflineNudgeCardComponent({
+  title,
+  body,
+  primaryLabel,
+  onPrimary,
+  secondaryLabel,
+  onSecondary,
+  dismissLabel,
+  onDismiss,
+  neverLabel,
+  onNever,
+  style,
+  testID,
+}: OfflineNudgeCardProps) {
+  const { brandColors, systemColors } = useTheme();
+
+  return (
+    <View
+      testID={testID ?? 'offline-nudge-card'}
+      style={[
+        styles.card,
+        { backgroundColor: systemColors.secondaryBackground, borderColor: systemColors.separator },
+        style,
+      ]}
+    >
+      <View style={styles.header}>
+        <Icon name="offline.download" size={22} color={brandColors.primary} />
+        <Text variant="headline" style={styles.title}>
+          {title}
+        </Text>
+      </View>
+      <Text variant="subheadline" color={systemColors.secondaryLabel}>
+        {body}
+      </Text>
+      <Button title={primaryLabel} variant="filled" onPress={onPrimary} style={styles.primary} />
+      {secondaryLabel && onSecondary ? <Button title={secondaryLabel} variant="tonal" onPress={onSecondary} /> : null}
+      {(dismissLabel && onDismiss) || (neverLabel && onNever) ? (
+        <View style={styles.dismissRow}>
+          {dismissLabel && onDismiss ? (
+            <Button title={dismissLabel} variant="text" size="small" onPress={onDismiss} />
+          ) : null}
+          {neverLabel && onNever ? <Button title={neverLabel} variant="text" size="small" onPress={onNever} /> : null}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+export const OfflineNudgeCard = memo(OfflineNudgeCardComponent);
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: borderRadius.lg,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: spacing[4],
+    gap: spacing[2],
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  title: {
+    flexShrink: 1,
+  },
+  primary: {
+    marginTop: spacing[2],
+  },
+  dismissRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+});

--- a/packages/mobile/src/components/offline/PostSessionOfflineNudge.tsx
+++ b/packages/mobile/src/components/offline/PostSessionOfflineNudge.tsx
@@ -32,25 +32,36 @@ export function PostSessionOfflineNudge({ storeReviewWillPrompt, style }: PostSe
 
   const board = activeBoard ?? null;
 
+  // The size dialog inside confirmAndDownload is the consent gate, so nothing is
+  // recorded until it resolves true. Accepting on the tap would count a cancelled
+  // dialog as an accept: it inflates the funnel, and it starts the 30-day
+  // post-acceptance quiet period for someone who just said no.
   const handleDownload = useCallback(() => {
     if (!board) return;
-    nudge.accept();
-    void confirmAndDownload(board);
+    void confirmAndDownload(board).then((confirmed) => {
+      if (confirmed) nudge.accept();
+    });
   }, [board, nudge, confirmAndDownload]);
 
   // The 82%-stop-at-one lever, using the switch that already exists in More
   // rather than a second nudge surface: one setting write, and every board the
-  // user owns (now and later) downloads.
+  // user owns (now and later) downloads. Same gate, and here it matters most —
+  // writing the setting before the dialog resolves would leave someone who
+  // cancelled opted into downloading every board they own.
   const handleDownloadAll = useCallback(() => {
     if (!board) return;
-    nudge.accept();
-    setSetting('autoOfflineBoards', true);
-    void confirmAndDownload(board);
+    void confirmAndDownload(board).then((confirmed) => {
+      if (!confirmed) return;
+      nudge.accept();
+      setSetting('autoOfflineBoards', true);
+    });
   }, [board, nudge, confirmAndDownload]);
 
   if (!nudge.visible || !board) return null;
 
-  // Only worth offering "all my boards" to someone who has more than this one.
+  // Offered to someone who has downloaded nothing yet: the bulk switch is a fair
+  // ask on a first download, but a user already curating individual boards has
+  // made that choice by hand and shouldn't be talked out of it.
   const offerAllBoards = getSetting('syncEnabledBoards').length === 0;
 
   return (

--- a/packages/mobile/src/components/offline/PostSessionOfflineNudge.tsx
+++ b/packages/mobile/src/components/offline/PostSessionOfflineNudge.tsx
@@ -39,7 +39,7 @@ export function PostSessionOfflineNudge({ storeReviewWillPrompt, style }: PostSe
   const handleDownload = useCallback(() => {
     if (!board) return;
     void confirmAndDownload(board).then((confirmed) => {
-      if (confirmed) nudge.accept();
+      if (confirmed) nudge.accept('download');
     });
   }, [board, nudge, confirmAndDownload]);
 
@@ -52,7 +52,7 @@ export function PostSessionOfflineNudge({ storeReviewWillPrompt, style }: PostSe
     if (!board) return;
     void confirmAndDownload(board).then((confirmed) => {
       if (!confirmed) return;
-      nudge.accept();
+      nudge.accept('download');
       setSetting('autoOfflineBoards', true);
     });
   }, [board, nudge, confirmAndDownload]);

--- a/packages/mobile/src/components/offline/PostSessionOfflineNudge.tsx
+++ b/packages/mobile/src/components/offline/PostSessionOfflineNudge.tsx
@@ -9,13 +9,15 @@
 // That is why it uses confirmAndDownload (size quote + a real download) rather
 // than the arm-only path the offline surfaces need.
 
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { StyleProp, ViewStyle } from 'react-native';
 import { useActiveBoard } from '../../lib/graphql/use-active-board';
+import { useMyBoards } from '../../lib/graphql/hooks';
 import { useOfflineNudge } from '../../lib/offline-nudges/use-offline-nudge';
+import { useBoardDownloads } from '../../offline/use-board-downloads';
 import { useConfirmBoardDownload } from '../../offline/use-confirm-board-download';
-import { getSetting, setSetting } from '../../settings';
+import { getSetting, offlineBoardKeyForBoard, setSetting } from '../../settings';
 import { OfflineNudgeCard } from './OfflineNudgeCard';
 
 type PostSessionOfflineNudgeProps = {
@@ -28,9 +30,17 @@ export function PostSessionOfflineNudge({ storeReviewWillPrompt, style }: PostSe
   const { t } = useTranslation('boards');
   const { data: activeBoard } = useActiveBoard();
   const { confirmAndDownload } = useConfirmBoardDownload();
+  const { enableBoardsOffline } = useBoardDownloads();
   const nudge = useOfflineNudge({ surface: 'post_session', board: activeBoard, storeReviewWillPrompt });
 
   const board = activeBoard ?? null;
+
+  // Which boards "all my boards" actually means. Fetched only while the card is
+  // on screen — a nudge that stood down must not add a query to the summary
+  // screen — and it has the whole time the user spends reading the card to
+  // resolve before the tap.
+  const { data: myBoardsConnection } = useMyBoards(undefined, { enabled: nudge.visible });
+  const myBoards = useMemo(() => myBoardsConnection?.boards ?? [], [myBoardsConnection]);
 
   // The size dialog inside confirmAndDownload is the consent gate, so nothing is
   // recorded until it resolves true. Accepting on the tap would count a cancelled
@@ -44,18 +54,28 @@ export function PostSessionOfflineNudge({ storeReviewWillPrompt, style }: PostSe
   }, [board, nudge, confirmAndDownload]);
 
   // The 82%-stop-at-one lever, using the switch that already exists in More
-  // rather than a second nudge surface: one setting write, and every board the
-  // user owns (now and later) downloads. Same gate, and here it matters most —
-  // writing the setting before the dialog resolves would leave someone who
-  // cancelled opted into downloading every board they own.
+  // rather than a second nudge surface: the setting makes every board the user
+  // adds from now on download itself. Same gate as the single download, and here
+  // it matters most — writing the setting before the dialog resolves would leave
+  // someone who cancelled opted into downloading every board they own.
+  //
+  // The boards they ALREADY own are downloaded here, not left to the setting.
+  // The only code that expands `autoOfflineBoards` into downloads is an effect
+  // scoped to the More screen, so without this a user with three boards would
+  // get one — and the other two whenever they next happened to open Settings.
   const handleDownloadAll = useCallback(() => {
     if (!board) return;
     void confirmAndDownload(board).then((confirmed) => {
       if (!confirmed) return;
       nudge.accept('download');
       setSetting('autoOfflineBoards', true);
+      // Read the setting rather than close over it: confirmAndDownload has just
+      // enabled this board, and re-enabling it here would kick a second cycle.
+      const alreadyEnabled = new Set(getSetting('syncEnabledBoards'));
+      const missing = myBoards.filter((owned) => !alreadyEnabled.has(offlineBoardKeyForBoard(owned)));
+      if (missing.length > 0) enableBoardsOffline(missing);
     });
-  }, [board, nudge, confirmAndDownload]);
+  }, [board, nudge, confirmAndDownload, myBoards, enableBoardsOffline]);
 
   if (!nudge.visible || !board) return null;
 

--- a/packages/mobile/src/components/offline/PostSessionOfflineNudge.tsx
+++ b/packages/mobile/src/components/offline/PostSessionOfflineNudge.tsx
@@ -1,0 +1,72 @@
+// The post-session offer: you just climbed here, keep the catalog on your phone.
+//
+// The only INTERRUPTIVE nudge in the set — the user asked for a session recap,
+// not for this — so it is the only one that carries the cooldown / lifetime cap
+// machinery, and the only one that stands down for a store-review prompt.
+//
+// Online by construction: the summary is a plain network query whose screen
+// hard-errors when it fails, so this can only render with a working connection.
+// That is why it uses confirmAndDownload (size quote + a real download) rather
+// than the arm-only path the offline surfaces need.
+
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { StyleProp, ViewStyle } from 'react-native';
+import { useActiveBoard } from '../../lib/graphql/use-active-board';
+import { useOfflineNudge } from '../../lib/offline-nudges/use-offline-nudge';
+import { useConfirmBoardDownload } from '../../offline/use-confirm-board-download';
+import { getSetting, setSetting } from '../../settings';
+import { OfflineNudgeCard } from './OfflineNudgeCard';
+
+type PostSessionOfflineNudgeProps = {
+  /** True once the screen has decided the store review is NOT going to fire. */
+  storeReviewWillPrompt: boolean;
+  style?: StyleProp<ViewStyle>;
+};
+
+export function PostSessionOfflineNudge({ storeReviewWillPrompt, style }: PostSessionOfflineNudgeProps) {
+  const { t } = useTranslation('boards');
+  const { data: activeBoard } = useActiveBoard();
+  const { confirmAndDownload } = useConfirmBoardDownload();
+  const nudge = useOfflineNudge({ surface: 'post_session', board: activeBoard, storeReviewWillPrompt });
+
+  const board = activeBoard ?? null;
+
+  const handleDownload = useCallback(() => {
+    if (!board) return;
+    nudge.accept();
+    void confirmAndDownload(board);
+  }, [board, nudge, confirmAndDownload]);
+
+  // The 82%-stop-at-one lever, using the switch that already exists in More
+  // rather than a second nudge surface: one setting write, and every board the
+  // user owns (now and later) downloads.
+  const handleDownloadAll = useCallback(() => {
+    if (!board) return;
+    nudge.accept();
+    setSetting('autoOfflineBoards', true);
+    void confirmAndDownload(board);
+  }, [board, nudge, confirmAndDownload]);
+
+  if (!nudge.visible || !board) return null;
+
+  // Only worth offering "all my boards" to someone who has more than this one.
+  const offerAllBoards = getSetting('syncEnabledBoards').length === 0;
+
+  return (
+    <OfflineNudgeCard
+      testID="post-session-offline-nudge"
+      title={t('mobile.offline.nudge.postSession.title', { name: board.name })}
+      body={t('mobile.offline.nudge.postSession.body')}
+      primaryLabel={t('mobile.offline.nudge.postSession.cta')}
+      onPrimary={handleDownload}
+      secondaryLabel={offerAllBoards ? t('mobile.offline.nudge.postSession.allBoardsCta') : undefined}
+      onSecondary={offerAllBoards ? handleDownloadAll : undefined}
+      dismissLabel={t('mobile.offline.nudge.notNow')}
+      onDismiss={() => nudge.dismiss('once')}
+      neverLabel={t('mobile.offline.nudge.never')}
+      onNever={() => nudge.dismiss('forever')}
+      style={style}
+    />
+  );
+}

--- a/packages/mobile/src/components/offline/__tests__/PostSessionOfflineNudge.test.tsx
+++ b/packages/mobile/src/components/offline/__tests__/PostSessionOfflineNudge.test.tsx
@@ -164,6 +164,23 @@ describe('PostSessionOfflineNudge', () => {
     );
   });
 
+  // `armedOnly` reports the action taken, never a connectivity reading. The
+  // probe is a heuristic in both directions, so a confirmed download stays a
+  // download even on a device that reads offline — otherwise the funnel writes
+  // off a completion it should be counting.
+  it('reports a confirmed download as not arm-only even when the device reads offline', async () => {
+    state.isOffline = true;
+    await renderNudge();
+    fireEvent.click(screen.getByText('mobile.offline.nudge.postSession.cta'));
+
+    await waitFor(() =>
+      expect(spies.track).toHaveBeenCalledWith(
+        SHARED_EVENTS.OfflineNudgeAccepted,
+        expect.objectContaining({ surface: 'post_session', armedOnly: false }),
+      ),
+    );
+  });
+
   // The size dialog is the consent gate: counting a cancel as an accept would
   // inflate the funnel and start the 30-day quiet period on a "no".
   it('records nothing when the size dialog is cancelled', async () => {

--- a/packages/mobile/src/components/offline/__tests__/PostSessionOfflineNudge.test.tsx
+++ b/packages/mobile/src/components/offline/__tests__/PostSessionOfflineNudge.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+const state = vi.hoisted(() => ({
+  activeBoard: null as UserBoard | null,
+  enabledBoards: [] as string[],
+  downloadedScopeKeys: [] as string[],
+  autoOfflineBoards: false,
+  offlineEngineEnabled: true,
+  nudgesEnabled: true,
+  isOffline: false,
+  nudgeState: null as unknown,
+}));
+
+const spies = vi.hoisted(() => ({
+  confirmAndDownload: vi.fn(async () => true),
+  setSetting: vi.fn(),
+  track: vi.fn(),
+  saveNudgeState: vi.fn(async () => undefined),
+}));
+
+vi.mock('react-native', () => ({
+  View: ({ children, testID }: { children?: ReactNode; testID?: string }) =>
+    createElement('div', { 'data-testid': testID }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: () => createElement('span', { 'data-icon': 'true' }) }));
+vi.mock('../../Button', () => ({
+  Button: ({ title, onPress }: { title: string; onPress: () => void }) =>
+    createElement('button', { onClick: onPress }, title),
+}));
+vi.mock('../../../theme/tokens', () => ({
+  spacing: new Proxy({}, { get: () => 4 }),
+  borderRadius: { lg: 12 },
+}));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { secondaryBackground: '#eee', separator: '#ccc', secondaryLabel: '#888' },
+    brandColors: { primary: '#6D28D9' },
+  }),
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../../lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: state.activeBoard }),
+}));
+vi.mock('../../../offline/use-confirm-board-download', () => ({
+  useConfirmBoardDownload: () => ({ confirmAndDownload: spies.confirmAndDownload, armWithoutConfirm: vi.fn() }),
+}));
+vi.mock('../../../offline/use-downloaded-scope-keys', () => ({
+  useDownloadedScopeKeys: () => ({ data: state.downloadedScopeKeys }),
+}));
+vi.mock('../../../providers/feature-flags-provider', () => ({
+  useOfflineDownloadsEnabled: () => state.offlineEngineEnabled,
+  useOfflineNudgesEnabled: () => state.nudgesEnabled,
+}));
+vi.mock('../../../hooks/use-is-offline', () => ({ useIsOffline: () => state.isOffline }));
+vi.mock('../../../settings', () => ({
+  offlineBoardKeyForBoard: (board: UserBoard) => `${board.boardType}:${board.layoutId}:${board.sizeId}`,
+  useSetting: (key: string) => [key === 'syncEnabledBoards' ? state.enabledBoards : state.autoOfflineBoards, vi.fn()],
+  getSetting: (key: string) => (key === 'syncEnabledBoards' ? state.enabledBoards : state.autoOfflineBoards),
+  setSetting: spies.setSetting,
+}));
+vi.mock('../../../lib/analytics', () => ({ track: spies.track }));
+vi.mock('../../../lib/offline-nudges/nudge-storage', async () => {
+  const policy = await import('../../../lib/offline-nudges/nudge-policy');
+  return {
+    loadNudgeState: async () => state.nudgeState ?? policy.emptyNudgeState(),
+    saveNudgeState: spies.saveNudgeState,
+  };
+});
+
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { suppressedNudgeState } from '../../../lib/offline-nudges/nudge-policy';
+import { PostSessionOfflineNudge } from '../PostSessionOfflineNudge';
+
+const board = { uuid: 'garage', name: "Marco's garage", boardType: 'kilter', layoutId: 1, sizeId: 10 } as UserBoard;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.activeBoard = board;
+  state.enabledBoards = [];
+  state.downloadedScopeKeys = [];
+  state.autoOfflineBoards = false;
+  state.offlineEngineEnabled = true;
+  state.nudgesEnabled = true;
+  state.isOffline = false;
+  state.nudgeState = null;
+});
+afterEach(() => cleanup());
+
+async function renderNudge(storeReviewWillPrompt = false) {
+  const result = render(createElement(PostSessionOfflineNudge, { storeReviewWillPrompt }));
+  // The persisted nudge state loads asynchronously; nothing renders before it.
+  await screen.findByTestId('post-session-offline-nudge').catch(() => null);
+  return result;
+}
+
+describe('PostSessionOfflineNudge', () => {
+  it('offers the download for an un-downloaded active board', async () => {
+    await renderNudge();
+    expect(screen.getByTestId('post-session-offline-nudge')).toBeTruthy();
+    await waitFor(() =>
+      expect(spies.track).toHaveBeenCalledWith(
+        SHARED_EVENTS.OfflineNudgeShown,
+        expect.objectContaining({ surface: 'post_session', scopeKey: 'kilter:1:10', downloadedBoardCount: 0 }),
+      ),
+    );
+  });
+
+  it('fires the impression once across re-renders', async () => {
+    const { rerender } = await renderNudge();
+    rerender(createElement(PostSessionOfflineNudge, { storeReviewWillPrompt: false }));
+    rerender(createElement(PostSessionOfflineNudge, { storeReviewWillPrompt: false }));
+    await waitFor(() =>
+      expect(spies.track.mock.calls.filter(([event]) => event === SHARED_EVENTS.OfflineNudgeShown)).toHaveLength(1),
+    );
+  });
+
+  it('stands down when the store review is going to prompt', async () => {
+    await renderNudge(true);
+    expect(screen.queryByTestId('post-session-offline-nudge')).toBeNull();
+  });
+
+  // The regression the naive "suppress on isSessionStoreReviewEligible" design
+  // would have shipped: on a ≥3-send session with the review on cooldown, the
+  // offline prompt is exactly what should appear.
+  it('still shows when the review candidate resolved to no prompt', async () => {
+    await renderNudge(false);
+    expect(screen.getByTestId('post-session-offline-nudge')).toBeTruthy();
+  });
+
+  it.each([
+    ['already enabled', () => (state.enabledBoards = ['kilter:1:10'])],
+    ['auto-downloading every board', () => (state.autoOfflineBoards = true)],
+    ['the offline engine is off', () => (state.offlineEngineEnabled = false)],
+    ['the nudge flag is off', () => (state.nudgesEnabled = false)],
+    ['dismissed forever', () => (state.nudgeState = suppressedNudgeState())],
+    ['there is no active board', () => (state.activeBoard = null)],
+  ])('renders nothing when %s', async (_label, mutate) => {
+    mutate();
+    await renderNudge();
+    expect(screen.queryByTestId('post-session-offline-nudge')).toBeNull();
+  });
+
+  it('starts a real download on accept and reports it as not arm-only', async () => {
+    await renderNudge();
+    fireEvent.click(screen.getByText('mobile.offline.nudge.postSession.cta'));
+
+    expect(spies.confirmAndDownload).toHaveBeenCalledWith(board);
+    expect(spies.track).toHaveBeenCalledWith(
+      SHARED_EVENTS.OfflineNudgeAccepted,
+      expect.objectContaining({ surface: 'post_session', armedOnly: false }),
+    );
+  });
+
+  it('turns on auto-download from the secondary action', async () => {
+    await renderNudge();
+    fireEvent.click(screen.getByText('mobile.offline.nudge.postSession.allBoardsCta'));
+
+    expect(spies.setSetting).toHaveBeenCalledWith('autoOfflineBoards', true);
+    expect(spies.confirmAndDownload).toHaveBeenCalledWith(board);
+  });
+
+  it.each([
+    ['mobile.offline.nudge.notNow', 'once'],
+    ['mobile.offline.nudge.never', 'forever'],
+  ])('reports %s as dismissKind %s', async (label, dismissKind) => {
+    await renderNudge();
+    fireEvent.click(screen.getByText(label));
+
+    expect(spies.track).toHaveBeenCalledWith(
+      SHARED_EVENTS.OfflineNudgeDismissed,
+      expect.objectContaining({ surface: 'post_session', dismissKind }),
+    );
+    expect(screen.queryByTestId('post-session-offline-nudge')).toBeNull();
+  });
+});

--- a/packages/mobile/src/components/offline/__tests__/PostSessionOfflineNudge.test.tsx
+++ b/packages/mobile/src/components/offline/__tests__/PostSessionOfflineNudge.test.tsx
@@ -6,6 +6,7 @@ import type { UserBoard } from '@boardsesh/shared-schema';
 
 const state = vi.hoisted(() => ({
   activeBoard: null as UserBoard | null,
+  myBoards: [] as UserBoard[],
   enabledBoards: [] as string[],
   downloadedScopeKeys: [] as string[],
   autoOfflineBoards: false,
@@ -17,9 +18,12 @@ const state = vi.hoisted(() => ({
 
 const spies = vi.hoisted(() => ({
   confirmAndDownload: vi.fn(async () => true),
+  enableBoardsOffline: vi.fn(),
   setSetting: vi.fn(),
   track: vi.fn(),
-  saveNudgeState: vi.fn(async () => undefined),
+  // Typed loosely on purpose: the assertions below read the saved state back
+  // out of the call args, so the parameter has to exist in the spy's signature.
+  saveNudgeState: vi.fn(async (_next: unknown) => undefined),
 }));
 
 vi.mock('react-native', () => ({
@@ -52,8 +56,16 @@ vi.mock('react-i18next', () => ({
 vi.mock('../../../lib/graphql/use-active-board', () => ({
   useActiveBoard: () => ({ data: state.activeBoard }),
 }));
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useMyBoards: (_input: unknown, options?: { enabled?: boolean }) => ({
+    data: options?.enabled === false ? undefined : { boards: state.myBoards },
+  }),
+}));
 vi.mock('../../../offline/use-confirm-board-download', () => ({
   useConfirmBoardDownload: () => ({ confirmAndDownload: spies.confirmAndDownload, armWithoutConfirm: vi.fn() }),
+}));
+vi.mock('../../../offline/use-board-downloads', () => ({
+  useBoardDownloads: () => ({ enableBoardsOffline: spies.enableBoardsOffline, armBoardsOffline: vi.fn() }),
 }));
 vi.mock('../../../offline/use-downloaded-scope-keys', () => ({
   useDownloadedScopeKeys: () => ({ data: state.downloadedScopeKeys }),
@@ -65,6 +77,7 @@ vi.mock('../../../providers/feature-flags-provider', () => ({
 vi.mock('../../../hooks/use-is-offline', () => ({ useIsOffline: () => state.isOffline }));
 vi.mock('../../../settings', () => ({
   offlineBoardKeyForBoard: (board: UserBoard) => `${board.boardType}:${board.layoutId}:${board.sizeId}`,
+  offlineBoardScopeForBoard: (board: UserBoard) => board,
   useSetting: (key: string) => [key === 'syncEnabledBoards' ? state.enabledBoards : state.autoOfflineBoards, vi.fn()],
   getSetting: (key: string) => (key === 'syncEnabledBoards' ? state.enabledBoards : state.autoOfflineBoards),
   setSetting: spies.setSetting,
@@ -79,7 +92,7 @@ vi.mock('../../../lib/offline-nudges/nudge-storage', async () => {
 });
 
 import { SHARED_EVENTS } from '@boardsesh/analytics';
-import { suppressedNudgeState } from '../../../lib/offline-nudges/nudge-policy';
+import { suppressedNudgeState, type OfflineNudgeState } from '../../../lib/offline-nudges/nudge-policy';
 import { PostSessionOfflineNudge } from '../PostSessionOfflineNudge';
 
 const board = { uuid: 'garage', name: "Marco's garage", boardType: 'kilter', layoutId: 1, sizeId: 10 } as UserBoard;
@@ -87,6 +100,7 @@ const board = { uuid: 'garage', name: "Marco's garage", boardType: 'kilter', lay
 beforeEach(() => {
   vi.clearAllMocks();
   state.activeBoard = board;
+  state.myBoards = [board];
   state.enabledBoards = [];
   state.downloadedScopeKeys = [];
   state.autoOfflineBoards = false;
@@ -200,6 +214,36 @@ describe('PostSessionOfflineNudge', () => {
     await waitFor(() => expect(spies.setSetting).toHaveBeenCalledWith('autoOfflineBoards', true));
   });
 
+  // The setting alone only reaches the other boards when the More screen next
+  // mounts, so "download all my boards" used to download one.
+  it('downloads the boards the user already owns, not just the active one', async () => {
+    const otherBoard = { uuid: 'gym', name: 'The gym', boardType: 'tension', layoutId: 8, sizeId: 25 } as UserBoard;
+    state.myBoards = [board, otherBoard];
+    // confirmAndDownload has enabled the active board by the time we expand.
+    spies.confirmAndDownload.mockImplementationOnce(async () => {
+      state.enabledBoards = ['kilter:1:10'];
+      return true;
+    });
+    await renderNudge();
+    fireEvent.click(screen.getByText('mobile.offline.nudge.postSession.allBoardsCta'));
+
+    await waitFor(() => expect(spies.enableBoardsOffline).toHaveBeenCalledWith([otherBoard]));
+  });
+
+  // Re-enabling the board confirmAndDownload just enabled would kick a second
+  // sync cycle for a download already in flight.
+  it('leaves the board the dialog just started alone', async () => {
+    spies.confirmAndDownload.mockImplementationOnce(async () => {
+      state.enabledBoards = ['kilter:1:10'];
+      return true;
+    });
+    await renderNudge();
+    fireEvent.click(screen.getByText('mobile.offline.nudge.postSession.allBoardsCta'));
+
+    await waitFor(() => expect(spies.setSetting).toHaveBeenCalled());
+    expect(spies.enableBoardsOffline).not.toHaveBeenCalled();
+  });
+
   // Cancelling must not leave the user opted into downloading every board they
   // own — that is the opposite of what they just said.
   it('leaves auto-download alone when the size dialog is cancelled', async () => {
@@ -209,6 +253,32 @@ describe('PostSessionOfflineNudge', () => {
 
     await waitFor(() => expect(spies.confirmAndDownload).toHaveBeenCalled());
     expect(spies.setSetting).not.toHaveBeenCalled();
+  });
+
+  // The impression is a write too. Building accept/dismiss on the pre-impression
+  // state saved shownCount back to 0 and dropped lastPromptAtMs, so an accepted
+  // or dismissed prompt stopped counting against the three-show lifetime cap and
+  // stopped holding off the cross-surface cooldown.
+  it('keeps the impression it just recorded when the download is accepted', async () => {
+    await renderNudge();
+    await waitFor(() => expect(spies.saveNudgeState).toHaveBeenCalled());
+    fireEvent.click(screen.getByText('mobile.offline.nudge.postSession.cta'));
+
+    await waitFor(() => expect(spies.saveNudgeState).toHaveBeenCalledTimes(2));
+    const saved = spies.saveNudgeState.mock.calls[1][0] as OfflineNudgeState;
+    expect(saved.surfaces.post_session.shownCount).toBe(1);
+    expect(saved.lastPromptAtMs).not.toBeNull();
+    expect(saved.lastAcceptedAtMs).not.toBeNull();
+  });
+
+  it('keeps the impression it just recorded when the prompt is dismissed', async () => {
+    await renderNudge();
+    await waitFor(() => expect(spies.saveNudgeState).toHaveBeenCalled());
+    fireEvent.click(screen.getByText('mobile.offline.nudge.notNow'));
+
+    const saved = spies.saveNudgeState.mock.calls[1][0] as OfflineNudgeState;
+    expect(saved.surfaces.post_session.shownCount).toBe(1);
+    expect(saved.lastPromptAtMs).not.toBeNull();
   });
 
   it.each([

--- a/packages/mobile/src/components/offline/__tests__/PostSessionOfflineNudge.test.tsx
+++ b/packages/mobile/src/components/offline/__tests__/PostSessionOfflineNudge.test.tsx
@@ -156,18 +156,42 @@ describe('PostSessionOfflineNudge', () => {
     fireEvent.click(screen.getByText('mobile.offline.nudge.postSession.cta'));
 
     expect(spies.confirmAndDownload).toHaveBeenCalledWith(board);
-    expect(spies.track).toHaveBeenCalledWith(
-      SHARED_EVENTS.OfflineNudgeAccepted,
-      expect.objectContaining({ surface: 'post_session', armedOnly: false }),
+    await waitFor(() =>
+      expect(spies.track).toHaveBeenCalledWith(
+        SHARED_EVENTS.OfflineNudgeAccepted,
+        expect.objectContaining({ surface: 'post_session', armedOnly: false }),
+      ),
     );
+  });
+
+  // The size dialog is the consent gate: counting a cancel as an accept would
+  // inflate the funnel and start the 30-day quiet period on a "no".
+  it('records nothing when the size dialog is cancelled', async () => {
+    spies.confirmAndDownload.mockResolvedValueOnce(false);
+    await renderNudge();
+    fireEvent.click(screen.getByText('mobile.offline.nudge.postSession.cta'));
+
+    await waitFor(() => expect(spies.confirmAndDownload).toHaveBeenCalled());
+    expect(spies.track).not.toHaveBeenCalledWith(SHARED_EVENTS.OfflineNudgeAccepted, expect.anything());
   });
 
   it('turns on auto-download from the secondary action', async () => {
     await renderNudge();
     fireEvent.click(screen.getByText('mobile.offline.nudge.postSession.allBoardsCta'));
 
-    expect(spies.setSetting).toHaveBeenCalledWith('autoOfflineBoards', true);
     expect(spies.confirmAndDownload).toHaveBeenCalledWith(board);
+    await waitFor(() => expect(spies.setSetting).toHaveBeenCalledWith('autoOfflineBoards', true));
+  });
+
+  // Cancelling must not leave the user opted into downloading every board they
+  // own — that is the opposite of what they just said.
+  it('leaves auto-download alone when the size dialog is cancelled', async () => {
+    spies.confirmAndDownload.mockResolvedValueOnce(false);
+    await renderNudge();
+    fireEvent.click(screen.getByText('mobile.offline.nudge.postSession.allBoardsCta'));
+
+    await waitFor(() => expect(spies.confirmAndDownload).toHaveBeenCalled());
+    expect(spies.setSetting).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/packages/mobile/src/lib/offline-nudges/__tests__/use-post-session-prompt.test.ts
+++ b/packages/mobile/src/lib/offline-nudges/__tests__/use-post-session-prompt.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, renderHook, waitFor } from '@testing-library/react';
+
+const spies = vi.hoisted(() => ({ shouldRequestSessionStoreReview: vi.fn(async () => true) }));
+
+vi.mock('../../store-review', () => ({
+  SESSION_STORE_REVIEW_CANDIDATE_PARAM: '1',
+  shouldRequestSessionStoreReview: spies.shouldRequestSessionStoreReview,
+}));
+
+import { usePostSessionPrompt } from '../use-post-session-prompt';
+
+const summary = { sessionId: 'session-1', totalSends: 7 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  spies.shouldRequestSessionStoreReview.mockResolvedValue(true);
+});
+afterEach(() => cleanup());
+
+describe('usePostSessionPrompt', () => {
+  it('gives the review the screen when it is actually going to fire', async () => {
+    const { result } = renderHook(() => usePostSessionPrompt(summary, '1'));
+    await waitFor(() => expect(result.current).toBe('review'));
+  });
+
+  // The whole reason this hook exists: totalSends is 7, so the bare eligibility
+  // predicate is true, but the 90-day cooldown means no review appears — and the
+  // offline offer is exactly what should take that slot.
+  it('hands the screen to the offline offer when the review is on cooldown', async () => {
+    spies.shouldRequestSessionStoreReview.mockResolvedValue(false);
+    const { result } = renderHook(() => usePostSessionPrompt(summary, '1'));
+    await waitFor(() => expect(result.current).toBe('offline'));
+  });
+
+  it('never consults the review when the screen was not opened as a candidate', async () => {
+    const { result } = renderHook(() => usePostSessionPrompt(summary, undefined));
+    await waitFor(() => expect(result.current).toBe('offline'));
+    expect(spies.shouldRequestSessionStoreReview).not.toHaveBeenCalled();
+  });
+
+  it('resolves the review decision once, not on every render', async () => {
+    const { result, rerender } = renderHook(() => usePostSessionPrompt(summary, '1'));
+    await waitFor(() => expect(result.current).toBe('review'));
+    rerender();
+    rerender();
+    expect(spies.shouldRequestSessionStoreReview).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports no prompt without a summary', async () => {
+    const { result } = renderHook(() => usePostSessionPrompt(null, '1'));
+    await waitFor(() => expect(result.current).toBe('none'));
+  });
+});

--- a/packages/mobile/src/lib/offline-nudges/nudge-analytics.ts
+++ b/packages/mobile/src/lib/offline-nudges/nudge-analytics.ts
@@ -21,12 +21,27 @@ export function trackNudgeShown(context: NudgeEventContext): void {
 }
 
 /**
- * `armedOnly` is load-bearing, not decoration: offline the accept can only mark
- * the scope, so the download starts on the scheduler's next reconnect. Without
- * this the funnel reads as accepts that never produced a download.
+ * What the accept actually DID, as reported by the surface that ran it. Never
+ * derived from a connectivity probe: `useIsOffline()` reads ONLINE on
+ * captive-portal wifi, which is the exact case the arm-only CTA was written
+ * for, so a probe would file an arm as a started download.
  */
-export function trackNudgeAccepted(context: NudgeEventContext, armedOnly: boolean): void {
-  track(SHARED_EVENTS.OfflineNudgeAccepted, { ...context, armedOnly });
+export type NudgeAcceptAction =
+  /** The scope was marked only; the scheduler pulls it on the next reconnect. */
+  | 'armed'
+  /** A size dialog was confirmed and a real download started. */
+  | 'download'
+  /** The user was handed off to the screen where the download lives. */
+  | 'handoff';
+
+/**
+ * `armedOnly` is load-bearing, not decoration: an armed accept produces no
+ * download until the device reconnects, so without it the funnel reads as
+ * accepts that never downloaded. A handoff is NOT armed — a download can follow
+ * straight away — so the drop-off it leaves behind is real and worth counting.
+ */
+export function trackNudgeAccepted(context: NudgeEventContext, action: NudgeAcceptAction): void {
+  track(SHARED_EVENTS.OfflineNudgeAccepted, { ...context, armedOnly: action === 'armed' });
 }
 
 export function trackNudgeDismissed(context: NudgeEventContext, dismissKind: 'once' | 'forever'): void {

--- a/packages/mobile/src/lib/offline-nudges/use-offline-nudge.ts
+++ b/packages/mobile/src/lib/offline-nudges/use-offline-nudge.ts
@@ -60,11 +60,25 @@ export function useOfflineNudge({ surface, board, storeReviewWillPrompt }: UseOf
   // `null` until AsyncStorage answers. Nothing renders before that, so a nudge
   // can't flash on screen and then retract when the cap turns out to be spent.
   const [nudgeState, setNudgeState] = useState<OfflineNudgeState | null>(null);
+
+  // What is actually ON DISK, which after an impression is no longer what
+  // `nudgeState` holds. Two values because they answer different questions:
+  // `nudgeState` decides visibility and must NOT absorb the shown transition
+  // (an incremented shownCount / fresh lastShownAtMs fails the very cooldown
+  // checks that just passed, retracting the card mid-mount), while accept and
+  // dismiss are writes and have to build on the last write — otherwise they
+  // save a pre-impression state back over it, resetting shownCount and
+  // lastPromptAtMs. That reset is how an accepted spotlight got its "New" pill
+  // back, and how an accepted prompt stopped counting against the lifetime cap.
+  const persistedStateRef = useRef<OfflineNudgeState | null>(null);
+
   useEffect(() => {
     let cancelled = false;
     loadNudgeState()
       .then((loaded) => {
-        if (!cancelled) setNudgeState(loaded);
+        if (cancelled) return;
+        persistedStateRef.current = loaded;
+        setNudgeState(loaded);
       })
       // loadNudgeState resolves a read failure to the suppress-everything state,
       // so this only catches a genuinely unexpected throw. Stay silent either way.
@@ -72,6 +86,13 @@ export function useOfflineNudge({ surface, board, storeReviewWillPrompt }: UseOf
     return () => {
       cancelled = true;
     };
+  }, []);
+
+  // Persist a transition and remember it, so the next writer builds on it.
+  const persist = useCallback((next: OfflineNudgeState) => {
+    persistedStateRef.current = next;
+    void saveNudgeState(next);
+    return next;
   }, []);
 
   const scopeKey = board ? offlineBoardKeyForBoard(board) : null;
@@ -131,30 +152,40 @@ export function useOfflineNudge({ surface, board, storeReviewWillPrompt }: UseOf
     if (shownScopeKeyRef.current === eventContext.scopeKey) return;
     shownScopeKeyRef.current = eventContext.scopeKey;
     trackNudgeShown(eventContext);
-    void saveNudgeState(withNudgeShown(nudgeState, surface, Date.now()));
+    // Into the ref only: see persistedStateRef. `nudgeState` keeps driving
+    // visibility, so this can't retract the card it just counted.
+    persist(withNudgeShown(persistedStateRef.current ?? nudgeState, surface, Date.now()));
     // Deliberately not re-running on `nudgeState`: recording the show writes it
     // back, and depending on it would loop.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [visible, eventContext, surface]);
+  }, [visible, eventContext, surface, persist]);
 
   const accept = useCallback(
     (action: NudgeAcceptAction) => {
       if (eventContext) trackNudgeAccepted(eventContext, action);
-      void saveNudgeState(withNudgeAccepted(nudgeState ?? emptyNudgeState(), surface, Date.now()));
-      setNudgeState((previous) => withNudgeAccepted(previous ?? emptyNudgeState(), surface, Date.now()));
+      const next = persist(
+        withNudgeAccepted(persistedStateRef.current ?? nudgeState ?? emptyNudgeState(), surface, Date.now()),
+      );
+      setNudgeState(next);
     },
-    [eventContext, nudgeState, surface],
+    [eventContext, nudgeState, surface, persist],
   );
 
   const dismiss = useCallback(
     (dismissKind: 'once' | 'forever') => {
       if (eventContext) trackNudgeDismissed(eventContext, dismissKind);
-      const next = withNudgeDismissed(nudgeState ?? emptyNudgeState(), surface, dismissKind, Date.now());
-      void saveNudgeState(next);
+      const next = persist(
+        withNudgeDismissed(
+          persistedStateRef.current ?? nudgeState ?? emptyNudgeState(),
+          surface,
+          dismissKind,
+          Date.now(),
+        ),
+      );
       setNudgeState(next);
       setDismissedThisMount(true);
     },
-    [eventContext, nudgeState, surface],
+    [eventContext, nudgeState, surface, persist],
   );
 
   return { visible, accept, dismiss } satisfies OfflineNudgeController;

--- a/packages/mobile/src/lib/offline-nudges/use-offline-nudge.ts
+++ b/packages/mobile/src/lib/offline-nudges/use-offline-nudge.ts
@@ -13,7 +13,6 @@ import type { UserBoard } from '@boardsesh/shared-schema';
 import { boardDownloadState } from '../../components/board-discovery/board-offline-state';
 import { useOfflineDownloadsEnabled, useOfflineNudgesEnabled } from '../../providers/feature-flags-provider';
 import { useDownloadedScopeKeys } from '../../offline/use-downloaded-scope-keys';
-import { useIsOffline } from '../../hooks/use-is-offline';
 import { offlineBoardKeyForBoard, useSetting } from '../../settings';
 import {
   emptyNudgeState,
@@ -25,7 +24,7 @@ import {
 import type { NudgeSurface, OfflineNudgeState } from './nudge-policy';
 import { loadNudgeState, saveNudgeState } from './nudge-storage';
 import { trackNudgeAccepted, trackNudgeDismissed, trackNudgeShown } from './nudge-analytics';
-import type { NudgeEventContext } from './nudge-analytics';
+import type { NudgeAcceptAction, NudgeEventContext } from './nudge-analytics';
 
 export type UseOfflineNudgeInput = {
   surface: NudgeSurface;
@@ -42,16 +41,18 @@ export type UseOfflineNudgeInput = {
 export type OfflineNudgeController = {
   /** Render the nudge. False until the persisted state has loaded. */
   visible: boolean;
-  /** True when accepting can only arm the scope, not start the download. */
-  armedOnly: boolean;
-  accept: () => void;
+  /**
+   * Record the accept. The caller passes what it actually did, because only the
+   * caller knows: the hook can see connectivity, and connectivity is exactly
+   * what lies on captive-portal wifi.
+   */
+  accept: (action: NudgeAcceptAction) => void;
   dismiss: (dismissKind: 'once' | 'forever') => void;
 };
 
 export function useOfflineNudge({ surface, board, storeReviewWillPrompt }: UseOfflineNudgeInput) {
   const offlineEngineEnabled = useOfflineDownloadsEnabled();
   const nudgesEnabled = useOfflineNudgesEnabled();
-  const isOffline = useIsOffline();
   const [enabledBoards] = useSetting('syncEnabledBoards');
   const [autoOfflineBoards] = useSetting('autoOfflineBoards');
   const { data: downloadedScopeKeys } = useDownloadedScopeKeys();
@@ -136,11 +137,14 @@ export function useOfflineNudge({ surface, board, storeReviewWillPrompt }: UseOf
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible, eventContext, surface]);
 
-  const accept = useCallback(() => {
-    if (eventContext) trackNudgeAccepted(eventContext, isOffline);
-    void saveNudgeState(withNudgeAccepted(nudgeState ?? emptyNudgeState(), surface, Date.now()));
-    setNudgeState((previous) => withNudgeAccepted(previous ?? emptyNudgeState(), surface, Date.now()));
-  }, [eventContext, isOffline, nudgeState, surface]);
+  const accept = useCallback(
+    (action: NudgeAcceptAction) => {
+      if (eventContext) trackNudgeAccepted(eventContext, action);
+      void saveNudgeState(withNudgeAccepted(nudgeState ?? emptyNudgeState(), surface, Date.now()));
+      setNudgeState((previous) => withNudgeAccepted(previous ?? emptyNudgeState(), surface, Date.now()));
+    },
+    [eventContext, nudgeState, surface],
+  );
 
   const dismiss = useCallback(
     (dismissKind: 'once' | 'forever') => {
@@ -153,5 +157,5 @@ export function useOfflineNudge({ surface, board, storeReviewWillPrompt }: UseOf
     [eventContext, nudgeState, surface],
   );
 
-  return { visible, armedOnly: isOffline, accept, dismiss } satisfies OfflineNudgeController;
+  return { visible, accept, dismiss } satisfies OfflineNudgeController;
 }

--- a/packages/mobile/src/lib/offline-nudges/use-offline-nudge.ts
+++ b/packages/mobile/src/lib/offline-nudges/use-offline-nudge.ts
@@ -1,0 +1,157 @@
+// The one hook every offline-nudge surface mounts. It answers "may I show this,
+// for this board", fires the impression event exactly once, and hands back the
+// accept / dismiss actions already wired to persistence and analytics.
+//
+// Deliberately does NOT read `useSyncStatus()`. The only distinction the gate
+// needs is `'off'` vs everything else, and `boardDownloadState` returns `'off'`
+// exactly when the scope is absent from `syncEnabledBoards` — so the live sync
+// frame adds nothing but a re-render on every progress tick, on screens that are
+// virtualised lists (see docs/react-native-performance.md).
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { boardDownloadState } from '../../components/board-discovery/board-offline-state';
+import { useOfflineDownloadsEnabled, useOfflineNudgesEnabled } from '../../providers/feature-flags-provider';
+import { useDownloadedScopeKeys } from '../../offline/use-downloaded-scope-keys';
+import { useIsOffline } from '../../hooks/use-is-offline';
+import { offlineBoardKeyForBoard, useSetting } from '../../settings';
+import {
+  emptyNudgeState,
+  shouldShowNudge,
+  withNudgeAccepted,
+  withNudgeDismissed,
+  withNudgeShown,
+} from './nudge-policy';
+import type { NudgeSurface, OfflineNudgeState } from './nudge-policy';
+import { loadNudgeState, saveNudgeState } from './nudge-storage';
+import { trackNudgeAccepted, trackNudgeDismissed, trackNudgeShown } from './nudge-analytics';
+import type { NudgeEventContext } from './nudge-analytics';
+
+export type UseOfflineNudgeInput = {
+  surface: NudgeSurface;
+  /** The board to suggest. `null` (no active board) means nothing to suggest. */
+  board: UserBoard | null | undefined;
+  /**
+   * `post_session` only: a store-review prompt is going to appear on this
+   * screen, so stay out of its way. Must be the resolved decision, not the bare
+   * "≥3 sends" eligibility — see `usePostSessionPrompt`.
+   */
+  storeReviewWillPrompt?: boolean;
+};
+
+export type OfflineNudgeController = {
+  /** Render the nudge. False until the persisted state has loaded. */
+  visible: boolean;
+  /** True when accepting can only arm the scope, not start the download. */
+  armedOnly: boolean;
+  accept: () => void;
+  dismiss: (dismissKind: 'once' | 'forever') => void;
+};
+
+export function useOfflineNudge({ surface, board, storeReviewWillPrompt }: UseOfflineNudgeInput) {
+  const offlineEngineEnabled = useOfflineDownloadsEnabled();
+  const nudgesEnabled = useOfflineNudgesEnabled();
+  const isOffline = useIsOffline();
+  const [enabledBoards] = useSetting('syncEnabledBoards');
+  const [autoOfflineBoards] = useSetting('autoOfflineBoards');
+  const { data: downloadedScopeKeys } = useDownloadedScopeKeys();
+
+  // `null` until AsyncStorage answers. Nothing renders before that, so a nudge
+  // can't flash on screen and then retract when the cap turns out to be spent.
+  const [nudgeState, setNudgeState] = useState<OfflineNudgeState | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    loadNudgeState()
+      .then((loaded) => {
+        if (!cancelled) setNudgeState(loaded);
+      })
+      // loadNudgeState resolves a read failure to the suppress-everything state,
+      // so this only catches a genuinely unexpected throw. Stay silent either way.
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const scopeKey = board ? offlineBoardKeyForBoard(board) : null;
+  const offlineState = useMemo(
+    () =>
+      boardDownloadState({
+        scopeKey: scopeKey ?? '',
+        enabled: scopeKey !== null && enabledBoards.includes(scopeKey),
+        downloaded: scopeKey !== null && (downloadedScopeKeys ?? []).includes(scopeKey),
+        isSyncing: false,
+        currentTable: null,
+      }),
+    [scopeKey, enabledBoards, downloadedScopeKeys],
+  );
+
+  // "Not now" has to take the card off the screen even on the affordances, which
+  // carry no cooldown by design. That is a this-mount decision, not persisted
+  // state: come back to the screen and the empty state offers the download again
+  // rather than staying a dead end.
+  const [dismissedThisMount, setDismissedThisMount] = useState(false);
+
+  const visible =
+    board != null &&
+    scopeKey !== null &&
+    nudgeState !== null &&
+    !dismissedThisMount &&
+    shouldShowNudge({
+      surface,
+      state: nudgeState,
+      nowMs: Date.now(),
+      offlineEngineEnabled,
+      nudgesEnabled,
+      offlineState,
+      autoOfflineBoards: autoOfflineBoards === true,
+      storeReviewWillPrompt,
+    });
+
+  const eventContext = useMemo<NudgeEventContext | null>(
+    () =>
+      board && scopeKey
+        ? {
+            surface,
+            boardType: board.boardType,
+            layoutId: board.layoutId,
+            scopeKey,
+            downloadedBoardCount: (downloadedScopeKeys ?? []).length,
+          }
+        : null,
+    [surface, board, scopeKey, downloadedScopeKeys],
+  );
+
+  // One impression per scope per mount. Keyed on the scope so switching boards
+  // on a live screen still counts, but a re-render never double-counts.
+  const shownScopeKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!visible || !eventContext || nudgeState === null) return;
+    if (shownScopeKeyRef.current === eventContext.scopeKey) return;
+    shownScopeKeyRef.current = eventContext.scopeKey;
+    trackNudgeShown(eventContext);
+    void saveNudgeState(withNudgeShown(nudgeState, surface, Date.now()));
+    // Deliberately not re-running on `nudgeState`: recording the show writes it
+    // back, and depending on it would loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible, eventContext, surface]);
+
+  const accept = useCallback(() => {
+    if (eventContext) trackNudgeAccepted(eventContext, isOffline);
+    void saveNudgeState(withNudgeAccepted(nudgeState ?? emptyNudgeState(), surface, Date.now()));
+    setNudgeState((previous) => withNudgeAccepted(previous ?? emptyNudgeState(), surface, Date.now()));
+  }, [eventContext, isOffline, nudgeState, surface]);
+
+  const dismiss = useCallback(
+    (dismissKind: 'once' | 'forever') => {
+      if (eventContext) trackNudgeDismissed(eventContext, dismissKind);
+      const next = withNudgeDismissed(nudgeState ?? emptyNudgeState(), surface, dismissKind, Date.now());
+      void saveNudgeState(next);
+      setNudgeState(next);
+      setDismissedThisMount(true);
+    },
+    [eventContext, nudgeState, surface],
+  );
+
+  return { visible, armedOnly: isOffline, accept, dismiss } satisfies OfflineNudgeController;
+}

--- a/packages/mobile/src/lib/offline-nudges/use-post-session-prompt.ts
+++ b/packages/mobile/src/lib/offline-nudges/use-post-session-prompt.ts
@@ -1,0 +1,52 @@
+// One decision for the whole post-session screen: does the user get the App
+// Store review prompt, the offline-download prompt, or neither?
+//
+// Resolving `shouldRequestSessionStoreReview` ONCE and branching on the answer
+// is the point. Gating the offline prompt on `isSessionStoreReviewEligible`
+// instead would be wrong in the worst direction: that predicate is only
+// "totalSends >= 3", while an actual review prompt needs the 90-day cooldown,
+// the per-session dedup and `StoreReview.hasAction()` on top — so the offline
+// prompt would go quiet on every good session, which is its entire audience,
+// and fire mainly after weak ones.
+
+import { useEffect, useState } from 'react';
+import type { SessionSummary } from '@boardsesh/shared-schema';
+import { SESSION_STORE_REVIEW_CANDIDATE_PARAM, shouldRequestSessionStoreReview } from '../store-review';
+
+export type PostSessionPrompt = 'pending' | 'review' | 'offline' | 'none';
+
+/**
+ * `'pending'` until the review decision resolves, so neither prompt renders on
+ * a guess. `'offline'` means the review is not going to fire — whether the
+ * offline nudge itself is eligible is `useOfflineNudge`'s call.
+ */
+export function usePostSessionPrompt(
+  summary: Pick<SessionSummary, 'sessionId' | 'totalSends'> | null | undefined,
+  reviewCandidateParam: string | undefined,
+): PostSessionPrompt {
+  const [prompt, setPrompt] = useState<PostSessionPrompt>('pending');
+  const sessionId = summary?.sessionId ?? null;
+  const totalSends = summary?.totalSends ?? 0;
+
+  useEffect(() => {
+    if (sessionId === null) {
+      setPrompt('none');
+      return undefined;
+    }
+    // Not a review candidate at all (arrived from history rather than from
+    // ending a session): the offline prompt is unopposed.
+    if (reviewCandidateParam !== SESSION_STORE_REVIEW_CANDIDATE_PARAM) {
+      setPrompt('offline');
+      return undefined;
+    }
+    let cancelled = false;
+    void shouldRequestSessionStoreReview({ sessionId, totalSends }).then((willPrompt) => {
+      if (!cancelled) setPrompt(willPrompt ? 'review' : 'offline');
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, totalSends, reviewCandidateParam]);
+
+  return prompt;
+}

--- a/packages/shared/i18n/locales/de/boards.json
+++ b/packages/shared/i18n/locales/de/boards.json
@@ -317,7 +317,17 @@
       "retryFastDownloadTitle": "Schnellen Download nochmal versuchen?",
       "retryFastDownloadMessage": "Lädt die Boulder dieses Boards am Stück statt über Tausende kleiner Anfragen.",
       "retryFastDownloadMessageWithSize": "Etwa {{size}}, am Stück geladen statt über Tausende kleiner Anfragen.",
-      "retryFastDownloadConfirm": "Nochmal versuchen"
+      "retryFastDownloadConfirm": "Nochmal versuchen",
+      "nudge": {
+        "notNow": "Jetzt nicht",
+        "never": "Nicht mehr anzeigen",
+        "postSession": {
+          "title": "{{name}} aufs Handy holen",
+          "body": "Lade den ganzen Katalog einmal herunter, dann ist jeder Boulder da, wenn das Hallen-WLAN streikt: suchen, filtern, Begehungen eintragen, alles.",
+          "cta": "Dieses Board herunterladen",
+          "allBoardsCta": "Alle meine Boards heruntergeladen halten"
+        }
+      }
     },
     "gymPicker": {
       "title": "Wo steht dieses Board?",

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -317,7 +317,17 @@
       "retryFastDownloadTitle": "Try the fast download again?",
       "retryFastDownloadMessage": "Downloads this board's climbs in one go instead of thousands of small requests.",
       "retryFastDownloadMessageWithSize": "About {{size}}, downloaded in one go instead of thousands of small requests.",
-      "retryFastDownloadConfirm": "Try again"
+      "retryFastDownloadConfirm": "Try again",
+      "nudge": {
+        "notNow": "Not now",
+        "never": "Don't show again",
+        "postSession": {
+          "title": "Keep {{name}} on your phone",
+          "body": "Download the whole catalog once and every climb is there next time the gym wifi isn't — browsing, filtering, logging sends, all of it.",
+          "cta": "Download this board",
+          "allBoardsCta": "Keep all my boards downloaded"
+        }
+      }
     },
     "gymPicker": {
       "title": "Where is this board?",

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -317,7 +317,17 @@
       "retryFastDownloadTitle": "¿Reintentar la descarga rápida?",
       "retryFastDownloadMessage": "Descarga los bloques de este plafón de una vez en lugar de con miles de peticiones pequeñas.",
       "retryFastDownloadMessageWithSize": "Unos {{size}}, descargados de una vez en lugar de con miles de peticiones pequeñas.",
-      "retryFastDownloadConfirm": "Reintentar"
+      "retryFastDownloadConfirm": "Reintentar",
+      "nudge": {
+        "notNow": "Ahora no",
+        "never": "No volver a mostrar",
+        "postSession": {
+          "title": "Ten {{name}} en tu móvil",
+          "body": "Descarga el catálogo completo una vez y tendrás todos los bloques la próxima vez que falle el wifi del rocódromo: buscar, filtrar y registrar encadenes, todo.",
+          "cta": "Descargar este plafón",
+          "allBoardsCta": "Mantener descargados todos mis plafones"
+        }
+      }
     },
     "gymPicker": {
       "title": "¿Dónde está este plafón?",

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -317,7 +317,17 @@
       "retryFastDownloadTitle": "Réessayer le téléchargement rapide ?",
       "retryFastDownloadMessage": "Télécharge les blocs de cette board en une fois au lieu de milliers de petites requêtes.",
       "retryFastDownloadMessageWithSize": "Environ {{size}}, téléchargés en une fois au lieu de milliers de petites requêtes.",
-      "retryFastDownloadConfirm": "Réessayer"
+      "retryFastDownloadConfirm": "Réessayer",
+      "nudge": {
+        "notNow": "Pas maintenant",
+        "never": "Ne plus afficher",
+        "postSession": {
+          "title": "Garde {{name}} sur ton téléphone",
+          "body": "Télécharge tout le catalogue une fois et chaque bloc est là quand le wifi de la salle lâche : recherche, filtres, croix dans le carnet, tout.",
+          "cta": "Télécharger cette board",
+          "allBoardsCta": "Garder toutes mes boards téléchargées"
+        }
+      }
     },
     "gymPicker": {
       "title": "Où se trouve cette board ?",


### PR DESCRIPTION
**HOLD: merges only after Tier 1 (#4310-#4313).** Nudging people into today's download would burn the one first impression they get.

Stacked on 4341 (`feat/4318-offline-nudge-policy`).

You just finished a session at a board. If its catalog isn't on your phone yet, the recap now offers to grab it — and, for someone who owns more than one wall, offers to keep every board downloaded from then on. That second offer is the existing `autoOfflineBoards` switch from More, not a new prompt: 82% of the 371 people who have downloaded a board stopped at one, and this is the cheapest lever against that number.

**The store-review collision is resolved by hoisting, not by a second predicate.** `usePostSessionPrompt` resolves `shouldRequestSessionStoreReview` once and the screen branches on `'review' | 'offline' | 'none'`. The obvious alternative — suppress the offline offer whenever `isSessionStoreReviewEligible(summary)` — is wrong in the worst direction: that predicate is only `totalSends >= 3`, while an actual review prompt additionally needs the 90-day cooldown, the per-session dedup and `StoreReview.hasAction()`. Gating on it would silence the offline offer on every good session — its entire audience — and leave it firing mainly after weak ones. There's a test for exactly that case.

This is the only **interruptive** surface in the set, so it's the only one carrying the frequency machinery: 14-day cooldown, max 3 lifetime, 72h cross-surface cooldown, 30 days quiet after any acceptance. Screenshot mode suppresses it, so App Store captures stay clean.

Honest about reach: `summary.tsx` hard-errors when its network query fails, so at a dead-zone gym — the exact context this sells — the screen never renders and the nudge can't appear. Sessions are optional too. The affordances in PRs 3 and 4 carry the rest.

## Changes

- `OfflineNudgeCard` — presentational, memoized, no animation (Reduce-Motion-safe by construction).
- `useOfflineNudge` — one hook per surface: eligibility, one impression per scope, accept/dismiss wired to persistence and analytics. Reads settings + downloaded keys, deliberately **not** `useSyncStatus()`.
- `usePostSessionPrompt` + `PostSessionOfflineNudge`, rendered under the hero.
- `mobile.offline.nudge.postSession.*` across en-US / es / fr / de.

## Release Notes

Finish a session at a board you haven't downloaded yet and Boardsesh now offers to keep the whole catalog on your phone — one tap, and every climb is there next time the gym wifi isn't.

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 628 files / 5552 tests pass
- `vp test run --project i18n` — 90 pass (catalog parity across all four locales)
- `vp run check:mobile-bundle`, `vp run check:mobile-web-bundle` — OK
- `vp run check:i18n:orphans` — OK

New: `PostSessionOfflineNudge.test.tsx` (shows/hides across every gate, one impression across re-renders, the ≥3-sends-with-review-on-cooldown regression, accept reports `armedOnly: false` — including on a device that reads offline, since the flag now comes from the action taken rather than a connectivity probe — both dismiss kinds) and `use-post-session-prompt.test.ts` (resolves once, never consults the review off the candidate path).

`summary-error-state.test.tsx` needed two adjustments: the review decision is async now, so its fake-timer tests flush a microtask before advancing, and its `store-review` mock gains `shouldRequestSessionStoreReview`.

Not yet exercised on device — the flag is off by default (`undefined → false`), so this is inert until someone forces it on the tester Feature Flags screen.

Translations follow the glossaries: es uses *plafón*, fr uses *la board* and *la croix* (never « envoyer »), de is informal *du* with *das Board* and *Begehungen*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT6VP1sWqk6bY9mUgyeS2U

