### PR TITLE
feat(mobile): turn the no-signal dead ends into a one-tap download (3/4)

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
@@ -268,6 +268,9 @@ vi.mock('../../../../src/lib/graphql/client', () => ({ getHttpClient: () => ({ r
 // registered document from `operations`, so loading the real module would make
 // this test's partial operations mock load-bearing for future registrations.
 vi.mock('../../../../src/lib/graphql/offline-request', () => ({ offlineAwareRequest: vi.fn() }));
+// Has its own render suite (src/components/offline/__tests__).
+vi.mock('../../../../src/components/offline/OfflineCatalogCta', () => ({ OfflineCatalogCta: () => null }));
+vi.mock('../../../../src/offline/use-downloaded-scope-keys', () => ({ useDownloadedScopeKeys: () => ({ data: [] }) }));
 
 vi.mock('../../../../src/lib/playlists/use-playlist-activation', () => ({
   usePlaylistActivation: () => ({

--- a/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
@@ -22,9 +22,10 @@ const mocks = vi.hoisted(() => ({
     boardFilters: {} as Record<string, unknown>,
     name: '',
   },
-  // Offline empty-state fixtures: connectivity, and what the active board's
-  // catalog looks like on this device.
+  // Offline empty-state fixtures: connectivity, whether the search itself
+  // failed, and what the active board's catalog looks like on this device.
   isOffline: false,
+  searchFailed: false,
   offlineCatalog: null as 'missing' | 'queued' | null,
   activateClimb: vi.fn(),
   dismissKeyboard: vi.fn(),
@@ -258,6 +259,7 @@ vi.mock('../../../../src/lib/graphql/hooks/use-infinite-search-climbs', () => ({
   useInfiniteSearchClimbs: () => ({
     data: { pages: [{ climbs: mocks.searchClimbs, hasMore: false }] },
     isLoading: false,
+    isError: mocks.searchFailed,
     isFetchingNextPage: false,
     isRefetching: false,
     fetchNextPage: vi.fn(),
@@ -366,6 +368,7 @@ beforeEach(() => {
   mocks.searchClimbs = [mocks.climb, mocks.secondClimb];
   mocks.searchState = { filters: {}, boardFilters: {}, name: '' };
   mocks.isOffline = false;
+  mocks.searchFailed = false;
   mocks.offlineCatalog = null;
 });
 
@@ -405,6 +408,33 @@ describe('ClimbList offline catalog empty states', () => {
     expect(await findByText('mobile.emptyState.noClimbs.title')).toBeTruthy();
     expect(queryByText('mobile.emptyState.offlineNoCatalog.title')).toBeNull();
     expect(queryByText('mobile.emptyState.offlineCatalogQueued.title')).toBeNull();
+  });
+
+  // The lying connection: captive portal or dead-upstream gym wifi, where
+  // NetInfo says online and the search fails for real. The boards picker has
+  // always counted that as no connection (isLocalOnly); this screen used to fall
+  // through to the generic "no climbs", which reads as a broken search.
+  it('offers the download when the connection lies and the search fails', async () => {
+    mocks.isOffline = false;
+    mocks.searchFailed = true;
+    mocks.offlineCatalog = 'missing';
+
+    const { findByText } = render(<ClimbList />);
+
+    expect(await findByText('mobile.emptyState.offlineNoCatalog.title')).toBeTruthy();
+  });
+
+  // A search that failed but returned rows from a previous page is not an empty
+  // state at all, and a working search that finds nothing is still "no climbs".
+  it('keeps the generic empty state when the search simply found nothing', async () => {
+    mocks.isOffline = false;
+    mocks.searchFailed = false;
+    mocks.offlineCatalog = 'missing';
+
+    const { findByText, queryByText } = render(<ClimbList />);
+
+    expect(await findByText('mobile.emptyState.noClimbs.title')).toBeTruthy();
+    expect(queryByText('mobile.emptyState.offlineNoCatalog.title')).toBeNull();
   });
 });
 

--- a/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
@@ -22,6 +22,10 @@ const mocks = vi.hoisted(() => ({
     boardFilters: {} as Record<string, unknown>,
     name: '',
   },
+  // Offline empty-state fixtures: connectivity, and what the active board's
+  // catalog looks like on this device.
+  isOffline: false,
+  offlineCatalog: null as 'missing' | 'queued' | null,
   activateClimb: vi.fn(),
   dismissKeyboard: vi.fn(),
   getLastSearch: vi.fn(),
@@ -271,6 +275,12 @@ vi.mock('../../../../src/lib/graphql/offline-request', () => ({ offlineAwareRequ
 // Has its own render suite (src/components/offline/__tests__).
 vi.mock('../../../../src/components/offline/OfflineCatalogCta', () => ({ OfflineCatalogCta: () => null }));
 vi.mock('../../../../src/offline/use-downloaded-scope-keys', () => ({ useDownloadedScopeKeys: () => ({ data: [] }) }));
+// Mocked rather than driven through settings: the real hook reads MMKV, which
+// this suite deliberately keeps out of the screen's module graph.
+vi.mock('../../../../src/offline/use-offline-catalog-state', () => ({
+  useOfflineCatalogState: () => mocks.offlineCatalog,
+}));
+vi.mock('../../../../src/hooks/use-is-offline', () => ({ useIsOffline: () => mocks.isOffline }));
 
 vi.mock('../../../../src/lib/playlists/use-playlist-activation', () => ({
   usePlaylistActivation: () => ({
@@ -355,6 +365,47 @@ beforeEach(() => {
   mocks.imagePrefetch.mockClear();
   mocks.searchClimbs = [mocks.climb, mocks.secondClimb];
   mocks.searchState = { filters: {}, boardFilters: {}, name: '' };
+  mocks.isOffline = false;
+  mocks.offlineCatalog = null;
+});
+
+// The dead end this branch exists to remove, and the one it nearly reintroduced:
+// arming the download flips the scope out of 'off', which takes the CTA away —
+// so a branch keyed on "is it downloaded?" would keep telling the user their
+// board isn't on their phone, with nothing left to tap.
+describe('ClimbList offline catalog empty states', () => {
+  beforeEach(() => {
+    mocks.searchClimbs = [];
+    mocks.isOffline = true;
+  });
+
+  it('offers the download when nothing has been asked for', async () => {
+    mocks.offlineCatalog = 'missing';
+
+    const { findByText, queryByText } = render(<ClimbList />);
+
+    expect(await findByText('mobile.emptyState.offlineNoCatalog.title')).toBeTruthy();
+    expect(queryByText('mobile.emptyState.offlineCatalogQueued.title')).toBeNull();
+  });
+
+  it('says the download is queued once the board has been armed', async () => {
+    mocks.offlineCatalog = 'queued';
+
+    const { findByText, queryByText } = render(<ClimbList />);
+
+    expect(await findByText('mobile.emptyState.offlineCatalogQueued.title')).toBeTruthy();
+    expect(queryByText('mobile.emptyState.offlineNoCatalog.title')).toBeNull();
+  });
+
+  it('leaves the generic empty state alone once the catalog is here', async () => {
+    mocks.offlineCatalog = null;
+
+    const { findByText, queryByText } = render(<ClimbList />);
+
+    expect(await findByText('mobile.emptyState.noClimbs.title')).toBeTruthy();
+    expect(queryByText('mobile.emptyState.offlineNoCatalog.title')).toBeNull();
+    expect(queryByText('mobile.emptyState.offlineCatalogQueued.title')).toBeNull();
+  });
 });
 
 describe('ClimbList keyboard handling', () => {

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -64,8 +64,7 @@ import { useInfiniteSearchClimbs } from '../../../src/lib/graphql/hooks/use-infi
 import { offlineAwareRequest } from '../../../src/lib/graphql/offline-request';
 import { isOfflineSearchSupported } from '../../../src/db/queries/search-climbs-local';
 import { useIsOffline } from '../../../src/hooks/use-is-offline';
-import { offlineBoardKeyForBoard } from '@boardsesh/offline-sync';
-import { useDownloadedScopeKeys } from '../../../src/offline/use-downloaded-scope-keys';
+import { useOfflineCatalogState } from '../../../src/offline/use-offline-catalog-state';
 import { OfflineCatalogCta } from '../../../src/components/offline/OfflineCatalogCta';
 import { SEARCH_CLIMBS, type SearchClimbsQueryResponse } from '../../../src/lib/graphql/operations';
 import { usePlaylistActivation } from '../../../src/lib/playlists/use-playlist-activation';
@@ -453,10 +452,8 @@ function ClimbListInner() {
 
   // Reactive connectivity, for the offline-only empty state below.
   const isOffline = useIsOffline();
-  // One cheap indexed read, shared with My Boards / the boards picker via the
-  // ['downloadedScopeKeys'] cache entry — not a useSyncStatus() subscription,
-  // which republishes on every progress frame and would churn this list.
-  const { data: downloadedScopeKeys } = useDownloadedScopeKeys();
+  // 'missing' (offer the download) vs 'queued' (already asked for) vs null.
+  const offlineCatalog = useOfflineCatalogState(activeBoard);
 
   const { data: gradesData } = useGrades(boardName);
   const gradesRef = useRef(gradesData);
@@ -1377,13 +1374,12 @@ function ClimbListInner() {
   // filter IS answerable on-device, there is just no catalog here to answer it
   // against. Deliberately checked AFTER offlineFilterUnavailable so that branch
   // keeps its clear-filters CTA untouched.
-  const activeBoardScopeKey = activeBoard ? offlineBoardKeyForBoard(activeBoard) : null;
-  const offlineCatalogMissing =
-    isEmpty &&
-    isOffline &&
-    isOfflineSearchSupported(searchInput) &&
-    activeBoardScopeKey !== null &&
-    !(downloadedScopeKeys ?? []).includes(activeBoardScopeKey);
+  const offlineNoCatalog = isEmpty && isOffline && isOfflineSearchSupported(searchInput) && offlineCatalog !== null;
+  // Two states, not one: once the download is armed the CTA hides itself, so
+  // repeating "this board isn't on your phone" would drop the user back into
+  // the dead end they just tapped their way out of.
+  const offlineCatalogMissing = offlineNoCatalog && offlineCatalog === 'missing';
+  const offlineCatalogQueued = offlineNoCatalog && offlineCatalog === 'queued';
 
   return (
     <View testID="climbs-screen" style={[styles.container, { backgroundColor: systemColors.background }]}>
@@ -1437,6 +1433,16 @@ function ClimbListInner() {
                 {t('mobile.emptyState.offlineNoCatalog.subtitle')}
               </Text>
               <OfflineCatalogCta board={activeBoard} style={styles.emptyCta} />
+            </View>
+          ) : offlineCatalogQueued ? (
+            <View style={styles.emptyContainer}>
+              <Icon name="offline.download" size={48} color={iosSystemColors.systemGray4} />
+              <Text variant="headline" style={styles.emptyTitle}>
+                {t('mobile.emptyState.offlineCatalogQueued.title')}
+              </Text>
+              <Text variant="subheadline" style={styles.emptySubtitle}>
+                {t('mobile.emptyState.offlineCatalogQueued.subtitle', { name: activeBoard?.name ?? '' })}
+              </Text>
             </View>
           ) : isEmpty ? (
             <View style={styles.emptyContainer}>

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -64,6 +64,9 @@ import { useInfiniteSearchClimbs } from '../../../src/lib/graphql/hooks/use-infi
 import { offlineAwareRequest } from '../../../src/lib/graphql/offline-request';
 import { isOfflineSearchSupported } from '../../../src/db/queries/search-climbs-local';
 import { useIsOffline } from '../../../src/hooks/use-is-offline';
+import { offlineBoardKeyForBoard } from '@boardsesh/offline-sync';
+import { useDownloadedScopeKeys } from '../../../src/offline/use-downloaded-scope-keys';
+import { OfflineCatalogCta } from '../../../src/components/offline/OfflineCatalogCta';
 import { SEARCH_CLIMBS, type SearchClimbsQueryResponse } from '../../../src/lib/graphql/operations';
 import { usePlaylistActivation } from '../../../src/lib/playlists/use-playlist-activation';
 import { toQueueClimb, toQueueClimbs } from '../../../src/lib/climb-types';
@@ -450,6 +453,10 @@ function ClimbListInner() {
 
   // Reactive connectivity, for the offline-only empty state below.
   const isOffline = useIsOffline();
+  // One cheap indexed read, shared with My Boards / the boards picker via the
+  // ['downloadedScopeKeys'] cache entry — not a useSyncStatus() subscription,
+  // which republishes on every progress frame and would churn this list.
+  const { data: downloadedScopeKeys } = useDownloadedScopeKeys();
 
   const { data: gradesData } = useGrades(boardName);
   const gradesRef = useRef(gradesData);
@@ -1366,6 +1373,17 @@ function ClimbListInner() {
   // the generic "no climbs". Tall/wide are offline-expressible, so they don't
   // trip this.
   const offlineFilterUnavailable = isEmpty && isOffline && !isOfflineSearchSupported(searchInput);
+  // The other offline empty state, and the one that had no branch of its own: the
+  // filter IS answerable on-device, there is just no catalog here to answer it
+  // against. Deliberately checked AFTER offlineFilterUnavailable so that branch
+  // keeps its clear-filters CTA untouched.
+  const activeBoardScopeKey = activeBoard ? offlineBoardKeyForBoard(activeBoard) : null;
+  const offlineCatalogMissing =
+    isEmpty &&
+    isOffline &&
+    isOfflineSearchSupported(searchInput) &&
+    activeBoardScopeKey !== null &&
+    !(downloadedScopeKeys ?? []).includes(activeBoardScopeKey);
 
   return (
     <View testID="climbs-screen" style={[styles.container, { backgroundColor: systemColors.background }]}>
@@ -1408,6 +1426,17 @@ function ClimbListInner() {
                 onPress={handleClearNonGradeFilters}
                 style={styles.emptyCta}
               />
+            </View>
+          ) : offlineCatalogMissing ? (
+            <View style={styles.emptyContainer}>
+              <Icon name="offline.download" size={48} color={iosSystemColors.systemGray4} />
+              <Text variant="headline" style={styles.emptyTitle}>
+                {t('mobile.emptyState.offlineNoCatalog.title')}
+              </Text>
+              <Text variant="subheadline" style={styles.emptySubtitle}>
+                {t('mobile.emptyState.offlineNoCatalog.subtitle')}
+              </Text>
+              <OfflineCatalogCta board={activeBoard} style={styles.emptyCta} />
             </View>
           ) : isEmpty ? (
             <View style={styles.emptyContainer}>

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -606,6 +606,7 @@ function ClimbListInner() {
   const {
     data: searchPages,
     isLoading: isClimbsLoading,
+    isError: isClimbsError,
     isFetchingNextPage,
     isRefetching,
     fetchNextPage,
@@ -1365,16 +1366,24 @@ function ClimbListInner() {
   }
 
   const isEmpty = visibleClimbs.length === 0 && !isClimbsLoading;
-  // Offline with a filter we can't answer on-device (drafts, beta, zones, hold
-  // state) — the search returns an empty result, so tell the user why instead of
-  // the generic "no climbs". Tall/wide are offline-expressible, so they don't
-  // trip this.
-  const offlineFilterUnavailable = isEmpty && isOffline && !isOfflineSearchSupported(searchInput);
+  // A failed search counts as no connection, the same test the boards picker
+  // makes (`isLocalOnly`, app/boards/index.tsx): on a captive portal or gym wifi
+  // with a dead upstream `useIsOffline()` reads ONLINE, and offlineAwareRequest
+  // rethrows once it finds nothing local to serve the search with — the exact
+  // scenario these states exist for. Judging it by connectivity alone left that
+  // user on the generic "no climbs" with no way out.
+  const noUsableConnection = isOffline || isClimbsError;
+  // No connection, with a filter we can't answer on-device (drafts, beta, zones,
+  // hold state) — the search returns an empty result, so tell the user why
+  // instead of the generic "no climbs". Tall/wide are offline-expressible, so
+  // they don't trip this.
+  const offlineFilterUnavailable = isEmpty && noUsableConnection && !isOfflineSearchSupported(searchInput);
   // The other offline empty state, and the one that had no branch of its own: the
   // filter IS answerable on-device, there is just no catalog here to answer it
   // against. Deliberately checked AFTER offlineFilterUnavailable so that branch
   // keeps its clear-filters CTA untouched.
-  const offlineNoCatalog = isEmpty && isOffline && isOfflineSearchSupported(searchInput) && offlineCatalog !== null;
+  const offlineNoCatalog =
+    isEmpty && noUsableConnection && isOfflineSearchSupported(searchInput) && offlineCatalog !== null;
   // Two states, not one: once the download is armed the CTA hides itself, so
   // repeating "this board isn't on your phone" would drop the user back into
   // the dead end they just tapped their way out of.

--- a/packages/mobile/app/boards/__tests__/index-offline.test.tsx
+++ b/packages/mobile/app/boards/__tests__/index-offline.test.tsx
@@ -136,6 +136,14 @@ vi.mock('../../../src/hooks/use-bottom-chrome-metrics', () => ({
 }));
 vi.mock('../../../src/hooks/use-is-offline', () => ({ useIsOffline: () => state.isOffline }));
 vi.mock('../../../src/settings', () => ({ useOfflineBoards: () => state.offlineCards }));
+// Has its own render suite (src/components/offline/__tests__); the screen only
+// needs to know it renders in the empty state.
+vi.mock('../../../src/components/offline/OfflineCatalogCta', () => ({
+  OfflineCatalogCta: () => null,
+}));
+vi.mock('../../../src/offline/use-downloaded-scope-keys', () => ({
+  useDownloadedScopeKeys: () => ({ data: state.downloadedScopeKeys }),
+}));
 vi.mock('../../../src/offline/use-remember-downloaded-boards', () => ({
   useRememberDownloadedBoards: (boards: unknown) => rememberDownloadedBoardsMock(boards),
 }));

--- a/packages/mobile/app/boards/__tests__/index-offline.test.tsx
+++ b/packages/mobile/app/boards/__tests__/index-offline.test.tsx
@@ -28,6 +28,9 @@ const state = vi.hoisted(() => ({
   isOffline: false,
   offlineCards: [] as unknown[],
   downloadedScopeKeys: [] as string[],
+  // What the active board's catalog looks like on this device: the offline
+  // empty state reads differently for "never asked for" vs "already queued".
+  offlineCatalog: null as 'missing' | 'queued' | null,
   activeBoard: undefined as unknown,
   myBoards: {
     data: undefined as { boards: unknown[] } | undefined,
@@ -66,7 +69,7 @@ vi.mock('expo-router', () => ({
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => {
+    t: (key: string, options?: { name?: string }) => {
       const map: Record<string, string> = {
         'mobile.emptyTitle': 'No boards yet',
         'mobile.emptySubtitle': 'Search for a board to get started',
@@ -77,6 +80,7 @@ vi.mock('react-i18next', () => ({
           "Can't reach your boards right now — here are the ones you've downloaded.",
         'mobile.offline.pickerEmptyTitle': 'Nothing downloaded yet',
         'mobile.offline.pickerEmptyBody': 'Boards you make available offline show up here.',
+        'mobile.offline.pickerQueuedNotice': "{{name}} is queued — it downloads the moment you're back online.",
         'mobile.discovery.yourBoardsTitle': 'Your boards',
         'mobile.discovery.popularTitle': 'Popular',
         'mobile.discovery.create': 'Create a board',
@@ -85,7 +89,8 @@ vi.mock('react-i18next', () => ({
         'mobile.discovery.findGym': 'Find a gym',
         'mobile.boardSwitchError': 'Could not switch board',
       };
-      return map[key] ?? key;
+      const template = map[key] ?? key;
+      return options?.name === undefined ? template : template.replace('{{name}}', options.name);
     },
   }),
 }));
@@ -139,10 +144,16 @@ vi.mock('../../../src/settings', () => ({ useOfflineBoards: () => state.offlineC
 // Has its own render suite (src/components/offline/__tests__); the screen only
 // needs to know it renders in the empty state.
 vi.mock('../../../src/components/offline/OfflineCatalogCta', () => ({
-  OfflineCatalogCta: () => null,
+  OfflineCatalogCta: ({ board }: { board: unknown }) =>
+    board ? createElement('div', { 'data-testid': 'offline-catalog-cta' }) : null,
 }));
 vi.mock('../../../src/offline/use-downloaded-scope-keys', () => ({
   useDownloadedScopeKeys: () => ({ data: state.downloadedScopeKeys }),
+}));
+// The real hook reads MMKV through settings, which this suite mocks down to
+// useOfflineBoards; drive the derived state directly instead.
+vi.mock('../../../src/offline/use-offline-catalog-state', () => ({
+  useOfflineCatalogState: () => state.offlineCatalog,
 }));
 vi.mock('../../../src/offline/use-remember-downloaded-boards', () => ({
   useRememberDownloadedBoards: (boards: unknown) => rememberDownloadedBoardsMock(boards),
@@ -194,6 +205,7 @@ beforeEach(() => {
   state.isOffline = false;
   state.offlineCards = [];
   state.downloadedScopeKeys = [];
+  state.offlineCatalog = null;
   state.activeBoard = undefined;
   state.myBoards = { data: undefined, isLoading: false, isError: false, isRefetching: false };
   state.popular = { configs: [] };
@@ -241,6 +253,37 @@ describe('board picker with no usable network list', () => {
     expect(screen.queryByText('No boards yet')).toBeNull();
     expect(screen.queryByRole('button', { name: 'Create a board' })).toBeNull();
     expect(screen.queryByText('Try again')).toBeNull();
+  });
+
+  // Tapping the CTA arms the scope, which takes the CTA away. Falling silent
+  // there leaves the user looking at the same un-downloaded board with nothing
+  // to tap and no sign anything happened, so the queued line takes its place.
+  it('acknowledges the queued download once the board has been armed', () => {
+    state.isOffline = true;
+    state.activeBoard = downloadedBoard;
+    state.offlineCards = [downloadedBoard];
+    state.offlineCatalog = 'queued';
+
+    render(createElement(BoardSelection));
+
+    expect(screen.getByText("Marco garage is queued — it downloads the moment you're back online.")).toBeTruthy();
+    expect(screen.queryByTestId('offline-catalog-cta')).toBeNull();
+  });
+
+  // `offlineBoardRows` always offers the active board, so the empty state only
+  // renders when there is no board to suggest — the CTA anchored inside it
+  // could never appear. It belongs beside the carousel the un-downloaded board
+  // is actually showing in.
+  it('offers the download beside the carousel, not only in the empty state', () => {
+    state.isOffline = true;
+    state.activeBoard = downloadedBoard;
+    state.offlineCards = [downloadedBoard];
+    state.offlineCatalog = 'missing';
+
+    render(createElement(BoardSelection));
+
+    expect(screen.getByTestId('carousel')).toBeTruthy();
+    expect(screen.getByTestId('offline-catalog-cta')).toBeTruthy();
   });
 
   it('falls back to downloaded boards when the connection lies (online, every request fails)', async () => {

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -26,6 +26,7 @@ import { useIsOffline } from '../../src/hooks/use-is-offline';
 import { useOfflineBoards } from '../../src/settings';
 import { useRememberDownloadedBoards } from '../../src/offline/use-remember-downloaded-boards';
 import { useDownloadedScopeKeys } from '../../src/offline/use-downloaded-scope-keys';
+import { useOfflineCatalogState } from '../../src/offline/use-offline-catalog-state';
 import { OfflineCatalogCta } from '../../src/components/offline/OfflineCatalogCta';
 import { resolveBoardReturnTo } from '../../src/lib/boards/board-return-to';
 import { setBoardRevealTipPending } from '../../src/lib/onboarding/onboarding-storage';
@@ -79,6 +80,9 @@ export default function BoardSelection() {
   // device has actually downloaded.
   const isOffline = useIsOffline();
   const { data: downloadedScopeKeys } = useDownloadedScopeKeys();
+  // Whether the active board's catalog is missing, or merely queued after an
+  // arm — the offline empty state below reads differently in each case.
+  const offlineCatalog = useOfflineCatalogState(activeBoard);
   const offlineCards = useOfflineBoards();
   // `isError && nothing cached` is the lying-connection case: captive portal or gym
   // wifi with a dead upstream, where onlineManager says online, the request fails for
@@ -329,10 +333,6 @@ export default function BoardSelection() {
             <Text variant="subheadline" style={styles.emptySubtitle}>
               {t('mobile.offline.pickerEmptyBody')}
             </Text>
-            {/* Arm-only, and it renders itself away unless the active board is
-                genuinely un-downloaded. This is the surface that used to be a
-                pure dead end. */}
-            <OfflineCatalogCta board={activeBoard} style={styles.emptyCta} />
             {/* Only the lying-connection case gets a retry — offline it would just
                 pause, and the user already knows they have no signal. */}
             {isError ? (
@@ -345,6 +345,21 @@ export default function BoardSelection() {
               />
             ) : null}
           </View>
+        )}
+        {/* Outside the empty state, because `offlineBoardRows` always offers the
+            active board: the empty state only happens when there is NO board to
+            suggest, so a CTA anchored inside it could never render. Here it sits
+            under the carousel the un-downloaded board is showing in.
+
+            Arm-only, and it takes itself away the moment the scope leaves 'off'
+            — which is why the queued line has to replace it rather than let the
+            screen fall silent on a board the user just asked for. */}
+        {offlineCatalog === 'queued' ? (
+          <Text variant="subheadline" style={styles.offlineNotice}>
+            {t('mobile.offline.pickerQueuedNotice', { name: activeBoard?.name ?? '' })}
+          </Text>
+        ) : (
+          <OfflineCatalogCta board={activeBoard} style={styles.emptyCta} />
         )}
       </ScrollView>
     );

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -26,6 +26,7 @@ import { useIsOffline } from '../../src/hooks/use-is-offline';
 import { useOfflineBoards } from '../../src/settings';
 import { useRememberDownloadedBoards } from '../../src/offline/use-remember-downloaded-boards';
 import { useDownloadedScopeKeys } from '../../src/offline/use-downloaded-scope-keys';
+import { OfflineCatalogCta } from '../../src/components/offline/OfflineCatalogCta';
 import { resolveBoardReturnTo } from '../../src/lib/boards/board-return-to';
 import { setBoardRevealTipPending } from '../../src/lib/onboarding/onboarding-storage';
 import { track } from '../../src/lib/analytics';
@@ -328,6 +329,10 @@ export default function BoardSelection() {
             <Text variant="subheadline" style={styles.emptySubtitle}>
               {t('mobile.offline.pickerEmptyBody')}
             </Text>
+            {/* Arm-only, and it renders itself away unless the active board is
+                genuinely un-downloaded. This is the surface that used to be a
+                pure dead end. */}
+            <OfflineCatalogCta board={activeBoard} style={styles.emptyCta} />
             {/* Only the lying-connection case gets a retry — offline it would just
                 pause, and the user already knows they have no signal. */}
             {isError ? (

--- a/packages/mobile/src/components/board-discovery/__tests__/board-offline-state.test.ts
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-offline-state.test.ts
@@ -4,6 +4,7 @@ import {
   boardDownloadProgress,
   boardDownloadState,
   boardIsBootstrapping,
+  offlineCatalogState,
 } from '../board-offline-state';
 import type { SnapshotBootstrapProgress } from '@boardsesh/offline-sync';
 
@@ -328,5 +329,47 @@ describe('boardDownloadProgress', () => {
         snapshot: { ...downloadingFrame, fraction: null, wireBytesDone: null },
       }),
     ).toEqual({ stage: 'download', fraction: null, bytesDone: null, bytesTotal: 103_000_000 });
+  });
+});
+
+// The catalog screens' half of the same derivation. It has to agree with the
+// download CTA's gate, which hides the moment the scope leaves 'off': a screen
+// asking "is it downloaded?" instead would keep the offer-the-download copy
+// with the offer already gone.
+describe('offlineCatalogState', () => {
+  const catalogBase = {
+    scopeKey: 'kilter:1:5',
+    enabledScopeKeys: [] as string[],
+    downloadedScopeKeys: [] as string[],
+  };
+
+  it('offers the download when the scope was never asked for', () => {
+    expect(offlineCatalogState(catalogBase)).toBe('missing');
+  });
+
+  it('reports queued once the scope is armed but has not landed', () => {
+    expect(offlineCatalogState({ ...catalogBase, enabledScopeKeys: ['kilter:1:5'] })).toBe('queued');
+  });
+
+  it('says nothing once this scope has actually downloaded', () => {
+    expect(
+      offlineCatalogState({
+        ...catalogBase,
+        enabledScopeKeys: ['kilter:1:5'],
+        downloadedScopeKeys: ['kilter:1:5'],
+      }),
+    ).toBeNull();
+  });
+
+  it('ignores a sibling scope', () => {
+    expect(offlineCatalogState({ ...catalogBase, enabledScopeKeys: ['kilter:1:50'] })).toBe('missing');
+  });
+
+  it('says nothing when there is no active board', () => {
+    expect(offlineCatalogState({ ...catalogBase, scopeKey: null })).toBeNull();
+  });
+
+  it('treats a still-loading downloaded-scope query as not downloaded', () => {
+    expect(offlineCatalogState({ ...catalogBase, downloadedScopeKeys: undefined })).toBe('missing');
   });
 });

--- a/packages/mobile/src/components/board-discovery/board-offline-state.ts
+++ b/packages/mobile/src/components/board-discovery/board-offline-state.ts
@@ -78,6 +78,49 @@ export function boardDownloadState(input: BoardDownloadStateInput): BoardDownloa
 }
 
 /**
+ * Which offline empty state a catalog screen should show for the active board.
+ *
+ * `null` means there is no offline story to tell — the catalog is here, or
+ * there is no board to talk about — and the screen falls through to whatever
+ * empty state it would have shown anyway.
+ */
+export type OfflineCatalogState =
+  /** Nothing on the phone and nothing asked for: offer the download. */
+  | 'missing'
+  /** The user already asked; it lands on the next reconnect. */
+  | 'queued'
+  | null;
+
+export type OfflineCatalogStateInput = {
+  /** The active board's scope key, or `null` when there is no active board. */
+  scopeKey: string | null;
+  /** `getSetting('syncEnabledBoards')`. */
+  enabledScopeKeys: readonly string[];
+  /** `useDownloadedScopeKeys()`, still loading as `undefined`. */
+  downloadedScopeKeys: readonly string[] | undefined;
+};
+
+/**
+ * Derived from `boardDownloadState` with the same "no live sync frame" inputs
+ * the nudge gate uses, and that agreement is the point: the download CTA hides
+ * itself the moment the scope leaves `'off'`, so a screen that kept asking
+ * "is it downloaded?" would show the offer-the-download copy with the offer
+ * already gone — the dead end the CTA was added to remove, one tap later.
+ */
+export function offlineCatalogState(input: OfflineCatalogStateInput): OfflineCatalogState {
+  if (input.scopeKey === null) return null;
+  const state = boardDownloadState({
+    scopeKey: input.scopeKey,
+    enabled: input.enabledScopeKeys.includes(input.scopeKey),
+    downloaded: (input.downloadedScopeKeys ?? []).includes(input.scopeKey),
+    isSyncing: false,
+    currentTable: null,
+  });
+  if (state === 'downloaded') return null;
+  return state === 'off' ? 'missing' : 'queued';
+}
+
+/**
  * Whether THIS row's `'downloading'` state is the snapshot-bootstrap warm-up
  * rather than the paged crawl. The bootstrap phase carries no per-row climb
  * count (unlike the paged crawl's `currentTableProcessed`), so the UI needs a

--- a/packages/mobile/src/components/offline/OfflineCatalogCta.tsx
+++ b/packages/mobile/src/components/offline/OfflineCatalogCta.tsx
@@ -36,7 +36,11 @@ export function OfflineCatalogCta({ board, style }: OfflineCatalogCtaProps) {
 
   const handleArm = useCallback(() => {
     if (!board) return;
-    nudge.accept();
+    // 'armed', unconditionally, because that is all this button ever does.
+    // Deriving it from connectivity would file an arm as a started download on
+    // captive-portal wifi, where `useIsOffline()` reads online and nothing
+    // downloads — the exact case this surface was written for.
+    nudge.accept('armed');
     armWithoutConfirm(board);
     // Say what actually happens. Nothing downloads yet, and a toast that implied
     // otherwise is the most likely source of "it said it downloaded and it

--- a/packages/mobile/src/components/offline/OfflineCatalogCta.tsx
+++ b/packages/mobile/src/components/offline/OfflineCatalogCta.tsx
@@ -1,0 +1,59 @@
+// "You have no signal and this board isn't on your phone." The two screens that
+// detect that state — the boards picker and the climbs list — used to end there.
+//
+// An affordance, not a prompt: it lives inside a screen the user chose to look
+// at, in place of a dead end, so it carries no cooldown and no lifetime cap.
+// Capping it would mean the empty state reverts to the dead end this set out to
+// fix, possibly the day after an unrelated post-session prompt.
+//
+// ARM-ONLY. It never calls triggerSync. onlineManager.isOnline() is TRUE on
+// captive-portal wifi — the exact case the boards picker's `isError && no
+// cached boards` branch detects — so a cycle kicked from here would run, fail,
+// and spend one of the two MAX_BOOTSTRAP_ATTEMPTS per tap, pinning the scope to
+// the multi-minute paged crawl after two (#4313). The scheduler's own
+// connectivity trigger pulls the board the moment the device reconnects.
+
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { StyleProp, ViewStyle } from 'react-native';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { useOfflineNudge } from '../../lib/offline-nudges/use-offline-nudge';
+import { useConfirmBoardDownload } from '../../offline/use-confirm-board-download';
+import { useToast } from '../../providers/toast-provider';
+import { OfflineNudgeCard } from './OfflineNudgeCard';
+
+type OfflineCatalogCtaProps = {
+  /** The board whose catalog is missing. Usually the active board. */
+  board: UserBoard | null | undefined;
+  style?: StyleProp<ViewStyle>;
+};
+
+export function OfflineCatalogCta({ board, style }: OfflineCatalogCtaProps) {
+  const { t } = useTranslation('boards');
+  const { showToast } = useToast();
+  const { armWithoutConfirm } = useConfirmBoardDownload();
+  const nudge = useOfflineNudge({ surface: 'no_catalog', board });
+
+  const handleArm = useCallback(() => {
+    if (!board) return;
+    nudge.accept();
+    armWithoutConfirm(board);
+    // Say what actually happens. Nothing downloads yet, and a toast that implied
+    // otherwise is the most likely source of "it said it downloaded and it
+    // didn't" feedback.
+    showToast(t('mobile.offline.nudge.noCatalog.armedToast', { name: board.name }), 'success');
+  }, [board, nudge, armWithoutConfirm, showToast, t]);
+
+  if (!nudge.visible || !board) return null;
+
+  return (
+    <OfflineNudgeCard
+      testID="offline-catalog-cta"
+      title={t('mobile.offline.nudge.noCatalog.title')}
+      body={t('mobile.offline.nudge.noCatalog.body', { name: board.name })}
+      primaryLabel={t('mobile.offline.nudge.noCatalog.cta')}
+      onPrimary={handleArm}
+      style={style}
+    />
+  );
+}

--- a/packages/mobile/src/components/offline/__tests__/OfflineCatalogCta.test.tsx
+++ b/packages/mobile/src/components/offline/__tests__/OfflineCatalogCta.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+const state = vi.hoisted(() => ({
+  enabledBoards: [] as string[],
+  downloadedScopeKeys: [] as string[],
+  autoOfflineBoards: false,
+  offlineEngineEnabled: true,
+  nudgesEnabled: true,
+  // This surface exists for the no-signal case, so offline is the default here.
+  isOffline: true,
+}));
+
+const spies = vi.hoisted(() => ({
+  armWithoutConfirm: vi.fn(),
+  confirmAndDownload: vi.fn(async () => true),
+  showToast: vi.fn(),
+  track: vi.fn(),
+  saveNudgeState: vi.fn(async () => undefined),
+}));
+
+vi.mock('react-native', () => ({
+  View: ({ children, testID }: { children?: ReactNode; testID?: string }) =>
+    createElement('div', { 'data-testid': testID }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: () => createElement('span', { 'data-icon': 'true' }) }));
+vi.mock('../../Button', () => ({
+  Button: ({ title, onPress }: { title: string; onPress: () => void }) =>
+    createElement('button', { onClick: onPress }, title),
+}));
+vi.mock('../../../theme/tokens', () => ({ spacing: new Proxy({}, { get: () => 4 }), borderRadius: { lg: 12 } }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { secondaryBackground: '#eee', separator: '#ccc', secondaryLabel: '#888' },
+    brandColors: { primary: '#6D28D9' },
+  }),
+}));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: spies.showToast }) }));
+vi.mock('../../../offline/use-confirm-board-download', () => ({
+  useConfirmBoardDownload: () => ({
+    confirmAndDownload: spies.confirmAndDownload,
+    armWithoutConfirm: spies.armWithoutConfirm,
+  }),
+}));
+vi.mock('../../../offline/use-downloaded-scope-keys', () => ({
+  useDownloadedScopeKeys: () => ({ data: state.downloadedScopeKeys }),
+}));
+vi.mock('../../../providers/feature-flags-provider', () => ({
+  useOfflineDownloadsEnabled: () => state.offlineEngineEnabled,
+  useOfflineNudgesEnabled: () => state.nudgesEnabled,
+}));
+vi.mock('../../../hooks/use-is-offline', () => ({ useIsOffline: () => state.isOffline }));
+vi.mock('../../../settings', () => ({
+  offlineBoardKeyForBoard: (board: UserBoard) => `${board.boardType}:${board.layoutId}:${board.sizeId}`,
+  useSetting: (key: string) => [key === 'syncEnabledBoards' ? state.enabledBoards : state.autoOfflineBoards, vi.fn()],
+}));
+vi.mock('../../../lib/analytics', () => ({ track: spies.track }));
+vi.mock('../../../lib/offline-nudges/nudge-storage', async () => {
+  const policy = await import('../../../lib/offline-nudges/nudge-policy');
+  return { loadNudgeState: async () => policy.emptyNudgeState(), saveNudgeState: spies.saveNudgeState };
+});
+
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { OfflineCatalogCta } from '../OfflineCatalogCta';
+
+const board = { uuid: 'garage', name: 'Gym wall', boardType: 'tension', layoutId: 8, sizeId: 25 } as UserBoard;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.enabledBoards = [];
+  state.downloadedScopeKeys = [];
+  state.autoOfflineBoards = false;
+  state.offlineEngineEnabled = true;
+  state.nudgesEnabled = true;
+  state.isOffline = true;
+});
+afterEach(() => cleanup());
+
+async function renderCta(boardProp: UserBoard | null = board) {
+  render(createElement(OfflineCatalogCta, { board: boardProp }));
+  await screen.findByTestId('offline-catalog-cta').catch(() => null);
+}
+
+describe('OfflineCatalogCta', () => {
+  it('offers the download in place of the dead-end empty state', async () => {
+    await renderCta();
+    expect(screen.getByTestId('offline-catalog-cta')).toBeTruthy();
+  });
+
+  // The whole point of the arm-only design: a cycle kicked from here would burn
+  // a bootstrap attempt per tap on captive-portal wifi (#4313).
+  it('arms the board without starting a download, and says so', async () => {
+    await renderCta();
+    fireEvent.click(screen.getByText('mobile.offline.nudge.noCatalog.cta'));
+
+    expect(spies.armWithoutConfirm).toHaveBeenCalledWith(board);
+    expect(spies.confirmAndDownload).not.toHaveBeenCalled();
+    expect(spies.showToast).toHaveBeenCalledWith('mobile.offline.nudge.noCatalog.armedToast', 'success');
+  });
+
+  it('reports the accept as arm-only so the funnel does not look broken', async () => {
+    await renderCta();
+    fireEvent.click(screen.getByText('mobile.offline.nudge.noCatalog.cta'));
+
+    expect(spies.track).toHaveBeenCalledWith(
+      SHARED_EVENTS.OfflineNudgeAccepted,
+      expect.objectContaining({ surface: 'no_catalog', scopeKey: 'tension:8:25', armedOnly: true }),
+    );
+  });
+
+  // No cooldown, no lifetime cap: an affordance that hides itself is the dead
+  // end this replaced. Only "already armed / downloaded" takes it away.
+  it('has no dismiss affordance at all', async () => {
+    await renderCta();
+    expect(screen.queryByText('mobile.offline.nudge.notNow')).toBeNull();
+    expect(screen.queryByText('mobile.offline.nudge.never')).toBeNull();
+  });
+
+  it.each([
+    ['the scope is already armed', () => (state.enabledBoards = ['tension:8:25'])],
+    ['the offline engine is off', () => (state.offlineEngineEnabled = false)],
+    ['the nudge flag is off', () => (state.nudgesEnabled = false)],
+    ['there is no board', () => undefined],
+  ])('renders nothing when %s', async (label, mutate) => {
+    mutate();
+    await renderCta(label === 'there is no board' ? null : board);
+    expect(screen.queryByTestId('offline-catalog-cta')).toBeNull();
+  });
+
+  it('keeps firing the impression across repeat visits rather than capping itself', async () => {
+    await renderCta();
+    cleanup();
+    await renderCta();
+    await waitFor(() =>
+      expect(spies.track.mock.calls.filter(([event]) => event === SHARED_EVENTS.OfflineNudgeShown)).toHaveLength(2),
+    );
+  });
+});

--- a/packages/mobile/src/components/offline/__tests__/OfflineCatalogCta.test.tsx
+++ b/packages/mobile/src/components/offline/__tests__/OfflineCatalogCta.test.tsx
@@ -116,6 +116,22 @@ describe('OfflineCatalogCta', () => {
     );
   });
 
+  // The case `armedOnly` was invented for, and the one a connectivity probe gets
+  // wrong: the boards picker reaches this CTA on captive-portal wifi, where
+  // `useIsOffline()` reads ONLINE. Nothing downloads there either, so filing the
+  // accept as a started download promises a completion that never arrives.
+  it('still reports arm-only when the connection lies about being online', async () => {
+    state.isOffline = false;
+    await renderCta();
+    fireEvent.click(screen.getByText('mobile.offline.nudge.noCatalog.cta'));
+
+    expect(spies.armWithoutConfirm).toHaveBeenCalledWith(board);
+    expect(spies.track).toHaveBeenCalledWith(
+      SHARED_EVENTS.OfflineNudgeAccepted,
+      expect.objectContaining({ surface: 'no_catalog', armedOnly: true }),
+    );
+  });
+
   // No cooldown, no lifetime cap: an affordance that hides itself is the dead
   // end this replaced. Only "already armed / downloaded" takes it away.
   it('has no dismiss affordance at all', async () => {

--- a/packages/mobile/src/offline/__tests__/use-offline-catalog-state.test.tsx
+++ b/packages/mobile/src/offline/__tests__/use-offline-catalog-state.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+// The catalog states are promises the SCREEN makes, so they have to answer to
+// the same flags the download offer does — see the hook's own doc.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, renderHook } from '@testing-library/react';
+import type { OfflineBoardLike } from '@boardsesh/offline-sync';
+
+const state = vi.hoisted(() => ({
+  enabledScopeKeys: [] as string[],
+  downloadedScopeKeys: [] as string[],
+  offlineEngineEnabled: true,
+  nudgesEnabled: true,
+}));
+
+vi.mock('@boardsesh/offline-sync', () => ({
+  offlineBoardKeyForBoard: (board: OfflineBoardLike) => `${board.boardType}:${board.layoutId}:${board.sizeId}`,
+}));
+vi.mock('../../providers/feature-flags-provider', () => ({
+  useOfflineDownloadsEnabled: () => state.offlineEngineEnabled,
+  useOfflineNudgesEnabled: () => state.nudgesEnabled,
+}));
+vi.mock('../../settings', () => ({
+  useSetting: () => [state.enabledScopeKeys, vi.fn()],
+}));
+vi.mock('../use-downloaded-scope-keys', () => ({
+  useDownloadedScopeKeys: () => ({ data: state.downloadedScopeKeys }),
+}));
+
+import { useOfflineCatalogState } from '../use-offline-catalog-state';
+
+const board = { boardType: 'kilter', layoutId: 1, sizeId: 10 } as OfflineBoardLike;
+
+beforeEach(() => {
+  state.enabledScopeKeys = [];
+  state.downloadedScopeKeys = [];
+  state.offlineEngineEnabled = true;
+  state.nudgesEnabled = true;
+});
+afterEach(() => cleanup());
+
+describe('useOfflineCatalogState', () => {
+  it('offers the download when nothing is downloaded or asked for', () => {
+    const { result } = renderHook(() => useOfflineCatalogState(board));
+    expect(result.current).toBe('missing');
+  });
+
+  it('reports the wait once the board is armed', () => {
+    state.enabledScopeKeys = ['kilter:1:10'];
+    const { result } = renderHook(() => useOfflineCatalogState(board));
+    expect(result.current).toBe('queued');
+  });
+
+  it('says nothing once the catalog is on the device', () => {
+    state.enabledScopeKeys = ['kilter:1:10'];
+    state.downloadedScopeKeys = ['kilter:1:10'];
+    const { result } = renderHook(() => useOfflineCatalogState(board));
+    expect(result.current).toBeNull();
+  });
+
+  // The kill switch stops the scheduler, the listeners and the pull, so a scope
+  // left enabled in settings from before the flip is not "landing on the next
+  // reconnect" — nothing is running to land it.
+  it.each([
+    ['missing', [] as string[]],
+    ['queued', ['kilter:1:10']],
+  ])('says nothing about a %s catalog when the offline engine is off', (_label, enabled) => {
+    state.enabledScopeKeys = enabled;
+    state.offlineEngineEnabled = false;
+    const { result } = renderHook(() => useOfflineCatalogState(board));
+    expect(result.current).toBeNull();
+  });
+
+  // 'missing' exists to host the download offer, and the offer reads this flag
+  // too: selecting it anyway leaves the screen naming the problem with nothing
+  // to tap, a worse dead end than the generic empty state.
+  it('drops the missing state when the nudge surface is off', () => {
+    state.nudgesEnabled = false;
+    const { result } = renderHook(() => useOfflineCatalogState(board));
+    expect(result.current).toBeNull();
+  });
+
+  // The armed board still gets its wait: that came from My Boards, not from a
+  // nudge, and the download really is coming.
+  it('keeps the queued state when the nudge surface is off', () => {
+    state.enabledScopeKeys = ['kilter:1:10'];
+    state.nudgesEnabled = false;
+    const { result } = renderHook(() => useOfflineCatalogState(board));
+    expect(result.current).toBe('queued');
+  });
+});

--- a/packages/mobile/src/offline/use-offline-catalog-state.ts
+++ b/packages/mobile/src/offline/use-offline-catalog-state.ts
@@ -11,6 +11,7 @@ import { useMemo } from 'react';
 import type { OfflineBoardLike } from '@boardsesh/offline-sync';
 import { offlineBoardKeyForBoard } from '@boardsesh/offline-sync';
 import { offlineCatalogState, type OfflineCatalogState } from '../components/board-discovery/board-offline-state';
+import { useOfflineDownloadsEnabled, useOfflineNudgesEnabled } from '../providers/feature-flags-provider';
 import { useSetting } from '../settings';
 import { useDownloadedScopeKeys } from './use-downloaded-scope-keys';
 
@@ -18,16 +19,33 @@ import { useDownloadedScopeKeys } from './use-downloaded-scope-keys';
  * `'missing'` — nothing downloaded and nothing asked for: offer the download.
  * `'queued'` — the user already asked; it lands on the next reconnect.
  * `null` — the catalog is here, or there is no board, so say nothing about it.
+ *
+ * Both flags are read HERE and not only inside the CTA, because each state is a
+ * promise the screen makes on its own:
+ *
+ *   Kill switch off — `OfflineSyncBridge` starts no scheduler, no listeners and
+ *   no pull, so a scope left enabled in settings from before the flip is never
+ *   downloading. "It lands on the next reconnect" would simply be false.
+ *
+ *   Nudges off — `'missing'` exists to host the download offer, and the offer
+ *   checks the same flag. Selecting it anyway leaves the screen telling the
+ *   user their board isn't on their phone with nothing to do about it, which is
+ *   a worse dead end than the generic empty state it replaced. `'queued'`
+ *   survives: that board was armed from My Boards, and the wait is real.
  */
 export function useOfflineCatalogState(board: OfflineBoardLike | null | undefined): OfflineCatalogState {
+  const offlineEngineEnabled = useOfflineDownloadsEnabled();
+  const nudgesEnabled = useOfflineNudgesEnabled();
   const [enabledScopeKeys] = useSetting('syncEnabledBoards');
   // One cheap indexed read, shared with My Boards / the boards picker via the
   // ['downloadedScopeKeys'] cache entry — not a useSyncStatus() subscription,
   // which republishes on every progress frame and would churn these lists.
   const { data: downloadedScopeKeys } = useDownloadedScopeKeys();
   const scopeKey = board ? offlineBoardKeyForBoard(board) : null;
-  return useMemo(
-    () => offlineCatalogState({ scopeKey, enabledScopeKeys, downloadedScopeKeys }),
-    [scopeKey, enabledScopeKeys, downloadedScopeKeys],
-  );
+  return useMemo(() => {
+    if (!offlineEngineEnabled) return null;
+    const state = offlineCatalogState({ scopeKey, enabledScopeKeys, downloadedScopeKeys });
+    if (state === 'missing' && !nudgesEnabled) return null;
+    return state;
+  }, [scopeKey, enabledScopeKeys, downloadedScopeKeys, offlineEngineEnabled, nudgesEnabled]);
 }

--- a/packages/mobile/src/offline/use-offline-catalog-state.ts
+++ b/packages/mobile/src/offline/use-offline-catalog-state.ts
@@ -1,0 +1,33 @@
+// Which offline empty state the catalog screens (Climbs, the boards picker)
+// should show for a given board.
+//
+// One hook rather than two hand-rolled predicates because the two screens have
+// to agree with each other AND with the download CTA's own gate: the CTA takes
+// itself away the moment the scope leaves `'off'`, so a screen still asking
+// "is it downloaded?" would keep the offer-the-download copy after the offer
+// had gone — the dead end again, one tap later.
+
+import { useMemo } from 'react';
+import type { OfflineBoardLike } from '@boardsesh/offline-sync';
+import { offlineBoardKeyForBoard } from '@boardsesh/offline-sync';
+import { offlineCatalogState, type OfflineCatalogState } from '../components/board-discovery/board-offline-state';
+import { useSetting } from '../settings';
+import { useDownloadedScopeKeys } from './use-downloaded-scope-keys';
+
+/**
+ * `'missing'` — nothing downloaded and nothing asked for: offer the download.
+ * `'queued'` — the user already asked; it lands on the next reconnect.
+ * `null` — the catalog is here, or there is no board, so say nothing about it.
+ */
+export function useOfflineCatalogState(board: OfflineBoardLike | null | undefined): OfflineCatalogState {
+  const [enabledScopeKeys] = useSetting('syncEnabledBoards');
+  // One cheap indexed read, shared with My Boards / the boards picker via the
+  // ['downloadedScopeKeys'] cache entry — not a useSyncStatus() subscription,
+  // which republishes on every progress frame and would churn these lists.
+  const { data: downloadedScopeKeys } = useDownloadedScopeKeys();
+  const scopeKey = board ? offlineBoardKeyForBoard(board) : null;
+  return useMemo(
+    () => offlineCatalogState({ scopeKey, enabledScopeKeys, downloadedScopeKeys }),
+    [scopeKey, enabledScopeKeys, downloadedScopeKeys],
+  );
+}

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -522,9 +522,11 @@ export const SHARED_EVENTS = {
   // { surface: 'post_session' | 'no_catalog' | 'whats_new' | 'board_card',
   //   boardType, layoutId, scopeKey, downloadedBoardCount }.
   OfflineNudgeShown: 'Offline Nudge Shown',
-  // Plus { armedOnly }: true when accepting could only ARM the scope (the device
-  // was offline, so the pull waits for the scheduler's reconnect trigger). Without
-  // it the funnel reads as accepts that never download.
+  // Plus { armedOnly }: true when the accept could only ARM the scope, so the pull
+  // waits for the scheduler's reconnect trigger. Reported by the surface from what
+  // it actually did, never from a connectivity probe — `useIsOffline()` reads
+  // ONLINE on captive-portal wifi, where the arm-only CTA still downloads nothing.
+  // Without it the funnel reads as accepts that never download.
   OfflineNudgeAccepted: 'Offline Nudge Accepted',
   // Plus { dismissKind: 'once' | 'forever' }.
   OfflineNudgeDismissed: 'Offline Nudge Dismissed',

--- a/packages/shared/i18n/locales/de/boards.json
+++ b/packages/shared/i18n/locales/de/boards.json
@@ -318,6 +318,7 @@
       "retryFastDownloadMessage": "Lädt die Boulder dieses Boards am Stück statt über Tausende kleiner Anfragen.",
       "retryFastDownloadMessageWithSize": "Etwa {{size}}, am Stück geladen statt über Tausende kleiner Anfragen.",
       "retryFastDownloadConfirm": "Nochmal versuchen",
+      "pickerQueuedNotice": "{{name}} steht in der Warteschlange und lädt, sobald du wieder online bist.",
       "nudge": {
         "notNow": "Jetzt nicht",
         "never": "Nicht mehr anzeigen",

--- a/packages/shared/i18n/locales/de/boards.json
+++ b/packages/shared/i18n/locales/de/boards.json
@@ -326,6 +326,12 @@
           "body": "Lade den ganzen Katalog einmal herunter, dann ist jeder Boulder da, wenn das Hallen-WLAN streikt: suchen, filtern, Begehungen eintragen, alles.",
           "cta": "Dieses Board herunterladen",
           "allBoardsCta": "Alle meine Boards heruntergeladen halten"
+        },
+        "noCatalog": {
+          "title": "Kein Netz, kein Katalog",
+          "body": "{{name}} ist noch nicht auf deinem Handy, hier unten gibt es also nichts zu durchsuchen.",
+          "cta": "Holen, sobald ich Netz habe",
+          "armedToast": "{{name}} steht in der Warteschlange und lädt, sobald du wieder online bist."
         }
       }
     },

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -633,6 +633,10 @@
         "title": "Dieser Filter braucht Empfang",
         "subtitle": "Entwürfe, Beta, Zonen und Griff-Filter funktionieren nur online. Setz ihn zurück, um weiter in deinem heruntergeladenen Board zu stöbern.",
         "cta": "Filter zurücksetzen"
+      },
+      "offlineNoCatalog": {
+        "title": "Offline ist hier nichts",
+        "subtitle": "Die Boulder dieses Boards sind nicht auf deinem Handy, ohne Verbindung gibt es also nichts zu durchsuchen."
       }
     },
     "detail": {

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -637,6 +637,10 @@
       "offlineNoCatalog": {
         "title": "Offline ist hier nichts",
         "subtitle": "Die Boulder dieses Boards sind nicht auf deinem Handy, ohne Verbindung gibt es also nichts zu durchsuchen."
+      },
+      "offlineCatalogQueued": {
+        "title": "Steht in der Warteschlange",
+        "subtitle": "{{name}} lädt, sobald du wieder online bist, danach tauchen die Boulder in der Suche auf."
       }
     },
     "detail": {

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -326,6 +326,12 @@
           "body": "Download the whole catalog once and every climb is there next time the gym wifi isn't — browsing, filtering, logging sends, all of it.",
           "cta": "Download this board",
           "allBoardsCta": "Keep all my boards downloaded"
+        },
+        "noCatalog": {
+          "title": "No signal, no catalog",
+          "body": "{{name}} isn't on your phone yet, so there's nothing to search down here.",
+          "cta": "Grab it when I have signal",
+          "armedToast": "{{name}} is queued — it downloads the moment you're back online."
         }
       }
     },

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -318,6 +318,7 @@
       "retryFastDownloadMessage": "Downloads this board's climbs in one go instead of thousands of small requests.",
       "retryFastDownloadMessageWithSize": "About {{size}}, downloaded in one go instead of thousands of small requests.",
       "retryFastDownloadConfirm": "Try again",
+      "pickerQueuedNotice": "{{name}} is queued — it downloads the moment you're back online.",
       "nudge": {
         "notNow": "Not now",
         "never": "Don't show again",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -633,6 +633,10 @@
         "title": "This filter needs a signal",
         "subtitle": "Drafts, beta, zones, and hold filters only work online. Clear it to keep browsing your downloaded board.",
         "cta": "Clear filter"
+      },
+      "offlineNoCatalog": {
+        "title": "Nothing here offline",
+        "subtitle": "This board's climbs aren't on your phone, so there's nothing to search without a connection."
       }
     },
     "detail": {

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -637,6 +637,10 @@
       "offlineNoCatalog": {
         "title": "Nothing here offline",
         "subtitle": "This board's climbs aren't on your phone, so there's nothing to search without a connection."
+      },
+      "offlineCatalogQueued": {
+        "title": "Queued for download",
+        "subtitle": "{{name}} downloads the moment you're back online, and these climbs turn up in search."
       }
     },
     "detail": {

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -318,6 +318,7 @@
       "retryFastDownloadMessage": "Descarga los bloques de este plafón de una vez en lugar de con miles de peticiones pequeñas.",
       "retryFastDownloadMessageWithSize": "Unos {{size}}, descargados de una vez en lugar de con miles de peticiones pequeñas.",
       "retryFastDownloadConfirm": "Reintentar",
+      "pickerQueuedNotice": "{{name}} está en cola: se descarga en cuanto vuelvas a tener conexión.",
       "nudge": {
         "notNow": "Ahora no",
         "never": "No volver a mostrar",

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -326,6 +326,12 @@
           "body": "Descarga el catálogo completo una vez y tendrás todos los bloques la próxima vez que falle el wifi del rocódromo: buscar, filtrar y registrar encadenes, todo.",
           "cta": "Descargar este plafón",
           "allBoardsCta": "Mantener descargados todos mis plafones"
+        },
+        "noCatalog": {
+          "title": "Sin cobertura y sin catálogo",
+          "body": "Todavía no tienes {{name}} en el móvil, así que aquí abajo no hay nada que buscar.",
+          "cta": "Descargarlo cuando tenga cobertura",
+          "armedToast": "{{name}} está en cola: se descarga en cuanto vuelvas a tener conexión."
         }
       }
     },

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -633,6 +633,10 @@
         "title": "Este filtro necesita conexión",
         "subtitle": "Los borradores, las betas, las zonas y los filtros de presas solo funcionan con conexión. Bórralo para seguir explorando tu plafón descargado.",
         "cta": "Borrar filtro"
+      },
+      "offlineNoCatalog": {
+        "title": "Aquí no hay nada sin conexión",
+        "subtitle": "Los bloques de este plafón no están en tu móvil, así que no hay nada que buscar sin conexión."
       }
     },
     "detail": {

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -637,6 +637,10 @@
       "offlineNoCatalog": {
         "title": "Aquí no hay nada sin conexión",
         "subtitle": "Los bloques de este plafón no están en tu móvil, así que no hay nada que buscar sin conexión."
+      },
+      "offlineCatalogQueued": {
+        "title": "En cola para descargar",
+        "subtitle": "{{name}} se descarga en cuanto vuelvas a tener conexión y sus bloques aparecerán en la búsqueda."
       }
     },
     "detail": {

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -326,6 +326,12 @@
           "body": "Télécharge tout le catalogue une fois et chaque bloc est là quand le wifi de la salle lâche : recherche, filtres, croix dans le carnet, tout.",
           "cta": "Télécharger cette board",
           "allBoardsCta": "Garder toutes mes boards téléchargées"
+        },
+        "noCatalog": {
+          "title": "Pas de réseau, pas de catalogue",
+          "body": "{{name}} n'est pas encore sur ton téléphone, donc il n'y a rien à chercher ici.",
+          "cta": "La récupérer dès que j’ai du réseau",
+          "armedToast": "{{name}} est en file d’attente : le téléchargement démarre dès que tu es reconnecté."
         }
       }
     },

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -318,6 +318,7 @@
       "retryFastDownloadMessage": "Télécharge les blocs de cette board en une fois au lieu de milliers de petites requêtes.",
       "retryFastDownloadMessageWithSize": "Environ {{size}}, téléchargés en une fois au lieu de milliers de petites requêtes.",
       "retryFastDownloadConfirm": "Réessayer",
+      "pickerQueuedNotice": "{{name}} est en file d’attente : le téléchargement démarre dès que tu es reconnecté.",
       "nudge": {
         "notNow": "Pas maintenant",
         "never": "Ne plus afficher",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -633,6 +633,10 @@
         "title": "Ce filtre nécessite une connexion",
         "subtitle": "Les brouillons, les betas, les zones et les filtres de prises ne fonctionnent qu'en ligne. Efface-le pour continuer à parcourir hors ligne.",
         "cta": "Effacer le filtre"
+      },
+      "offlineNoCatalog": {
+        "title": "Rien ici hors connexion",
+        "subtitle": "Les blocs de cette board ne sont pas sur ton téléphone, il n'y a donc rien à chercher sans connexion."
       }
     },
     "detail": {

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -637,6 +637,10 @@
       "offlineNoCatalog": {
         "title": "Rien ici hors connexion",
         "subtitle": "Les blocs de cette board ne sont pas sur ton téléphone, il n'y a donc rien à chercher sans connexion."
+      },
+      "offlineCatalogQueued": {
+        "title": "En file d’attente",
+        "subtitle": "{{name}} se télécharge dès que tu es reconnecté, et ses blocs apparaîtront dans la recherche."
       }
     },
     "detail": {


### PR DESCRIPTION
**HOLD: merges only after Tier 1 (#4310-#4313).** This one in particular: see "Why #4313 gates this" below.

Stacked on #4342 (`feat/4318-post-session-nudge`).

Two screens already detect "you're offline and this board isn't on your phone", and both ended there.

- The boards picker's `isLocalOnly` empty state says *"Nothing downloaded yet — boards you make available offline show up here. Grab one while you have signal."* and then offers nothing to tap.
- The climbs list falls through to the generic `isEmpty` branch, which renders as a broken search rather than a missing catalog.

Both now offer to queue the board.

**Arm-only, and that's the design.** The CTA marks the scope and stops; the scheduler's own `subscribeConnectivity` trigger pulls it on reconnect. Kicking a cycle here would be worse than doing nothing: `onlineManager.isOnline()` is TRUE on captive-portal wifi — exactly the case `isLocalOnly = isOffline || (isError && myBoards.length === 0)` catches — so `triggerSync`'s guard wouldn't short-circuit, the cycle would run, every request would fail, and each tap would spend one of the two `MAX_BOOTSTRAP_ATTEMPTS`. Two taps and the scope is pinned to the paged crawl forever.

The toast says the download starts on reconnect, and `Offline Nudge Accepted` carries `armedOnly: true` — without it #4316's funnel would show accepts with no downloads and look broken. That flag is reported by the surface from what it did (`armed` / `download` / `handoff`), **not** from `useIsOffline()`: the probe reads online on captive-portal wifi, which is the one path where getting it wrong matters most.

**Armed is a third empty state.** The CTA hides itself the moment the scope leaves `'off'` — that is what stops it re-prompting for the board it just armed — so both screens need a state for `'pending'` too. Without one they render "this board isn't on your phone" with nothing left to tap: the dead end again, one tap later. `offlineCatalogState()` (via the `useOfflineCatalogState` hook) is the single derivation both screens read, built from the same inputs as the nudge gate so the two cannot drift: `'missing'` offers the download, `'queued'` says it lands on the next reconnect, `null` falls through to the ordinary empty state.

**On the boards picker the CTA sits beside the carousel, not inside the empty state.** `offlineBoardRows` always offers the active board as a row, so "Nothing downloaded yet" only renders when there is no board to suggest — a CTA anchored inside it could never appear.

**The climbs anchor is a new branch, not the existing one.** `offlineFilterUnavailable` means "the catalog IS downloaded, this filter just isn't answerable on-device (drafts, beta, zones, hold state)" and already owns a clear-filters CTA. It is untouched. The new `offlineCatalogMissing` / `offlineCatalogQueued` branches sit after it and cover the opposite state: filter answerable, catalog absent or on its way.

No cooldown, no lifetime cap. An empty state that hides its own way out is the dead end this replaced — "Not now" only clears it for the current visit.

## Changes

- `OfflineCatalogCta` — arm-only card, no dismiss-forever, no caps. Accepts report `armed`.
- Rendered on the boards picker's `isLocalOnly` branch beside the offline carousel, replaced by a queued line once the scope is armed (the empty state keeps its retry button on the lying-connection sub-case).
- New `offlineCatalogMissing` / `offlineCatalogQueued` branches on the climbs list, between `offlineFilterUnavailable` and the generic `isEmpty`.
- `offlineCatalogState()` in `board-offline-state.ts` + the `useOfflineCatalogState` hook — one derivation, shared by both screens and aligned with the nudge gate.
- `mobile.offline.nudge.noCatalog.*`, `mobile.offline.pickerQueuedNotice` (boards) and `mobile.emptyState.offlineNoCatalog.*`, `mobile.emptyState.offlineCatalogQueued.*` (climbs) across all four locales.

**RN perf:** neither screen mounts `useSyncStatus()`. The climbs list reads `useDownloadedScopeKeys()` — one indexed SQLite read sharing the existing cache entry, invalidated per completed scope by PR #4341 — and the nudge hook lives inside the CTA subtree only. No per-frame state churn on a virtualised screen (`docs/react-native-performance.md`).

## Release Notes

When you're out of signal and the board you're on isn't downloaded, the empty screen now offers to grab it — it starts the moment you're back online.

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — all green (628 files at the time of writing)
- `vp test run --project i18n` — 90 pass
- `vp run check:mobile-bundle`, `vp run check:mobile-web-bundle` — OK
- `vp run check:i18n:orphans` — OK

New: `OfflineCatalogCta.test.tsx` — arms without calling `confirmAndDownload`, reports `armedOnly: true` (including on a connection that lies about being online), has no dismiss affordance at all, keeps firing its impression across repeat visits rather than capping itself, and hides on every gate. `board-offline-state.test.ts` covers the `missing` / `queued` / `null` table; both screen suites assert the queued copy replaces the offer rather than falling back to the dead end.

The two screen suites gained mocks for the new component (it has its own render suite) and for `useDownloadedScopeKeys`.

Not yet exercised on device. The manual pass worth doing before this goes ready, with the flag forced on: airplane mode on My Boards with nothing downloaded → tap the CTA → the scope shows "Waiting to download" and `.boardsesh/mobile-metro.log` shows **no** sync cycle; tap twice more and confirm bootstrap attempts stay at 0; re-enable wifi and confirm the reconnect trigger pulls it. Then the captive-portal case (wifi with a dead upstream) for the same behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT6VP1sWqk6bY9mUgyeS2U

