### PR TITLE
feat(mobile): show which boards are on your phone and spotlight offline in what's new (4/4)

### DIFF
--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -1163,7 +1163,7 @@ Supporting tiles, in the order they answer questions about it:
 
 4.4% of monthly actives had downloaded a board when the epic was opened, and 82%
 of those stopped at one. The engine was not the problem — nothing in the app ever
-*suggested* a download. Before this, offline was reachable from exactly two
+_suggested_ a download. Before this, offline was reachable from exactly two
 places: the per-row toggle on My Boards and a switch buried in More.
 
 ### Four surfaces, two kinds
@@ -1175,20 +1175,20 @@ anyway, so they carry the full frequency machinery: a per-surface cooldown, a
 lifetime cap, a cross-surface cooldown so two prompts can't stack, and a quiet
 period after any acceptance.
 
-| Surface        | Where                              | Caps                                          |
-| -------------- | ---------------------------------- | --------------------------------------------- |
-| `post_session` | `app/(tabs)/record/summary.tsx`    | 14d cooldown, max 3 lifetime, 72h global, 30d after accept |
+| Surface        | Where                           | Caps                                                       |
+| -------------- | ------------------------------- | ---------------------------------------------------------- |
+| `post_session` | `app/(tabs)/record/summary.tsx` | 14d cooldown, max 3 lifetime, 72h global, 30d after accept |
 
 **Affordances don't.** They live inside a screen the user chose to open, usually
 in place of a dead end. Capping them would mean the empty state this set out to
 fix reverts to a dead end — possibly the day after an unrelated prompt. They are
 bounded by eligibility and dismiss-forever only.
 
-| Surface       | Where                                                        |
-| ------------- | ------------------------------------------------------------ |
-| `no_catalog`  | boards-picker `isLocalOnly` empty state + a new climbs branch |
-| `board_card`  | download glyph on the Your Boards carousel                   |
-| `whats_new`   | curated card pinned above the generated changelog timeline    |
+| Surface      | Where                                                         |
+| ------------ | ------------------------------------------------------------- |
+| `no_catalog` | boards-picker `isLocalOnly` empty state + a new climbs branch |
+| `board_card` | download glyph on the Your Boards carousel                    |
+| `whats_new`  | curated card pinned above the generated changelog timeline    |
 
 ### Arming is not downloading
 

--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -1158,3 +1158,92 @@ Supporting tiles, in the order they answer questions about it:
 2. Deploy to Postgres. Pre-warmed DB is NOT rebuilt yet (simulates weekly lag).
 3. Launch the app. Verify on-device migration adds the new column.
 4. Sync pull returns rows with the new column. Verify they INSERT correctly.
+
+## Discovery nudges (issue #4318)
+
+4.4% of monthly actives had downloaded a board when the epic was opened, and 82%
+of those stopped at one. The engine was not the problem — nothing in the app ever
+*suggested* a download. Before this, offline was reachable from exactly two
+places: the per-row toggle on My Boards and a switch buried in More.
+
+### Four surfaces, two kinds
+
+The split matters more than the count.
+
+**Prompts interrupt.** The user asked for something else and the app spoke
+anyway, so they carry the full frequency machinery: a per-surface cooldown, a
+lifetime cap, a cross-surface cooldown so two prompts can't stack, and a quiet
+period after any acceptance.
+
+| Surface        | Where                              | Caps                                          |
+| -------------- | ---------------------------------- | --------------------------------------------- |
+| `post_session` | `app/(tabs)/record/summary.tsx`    | 14d cooldown, max 3 lifetime, 72h global, 30d after accept |
+
+**Affordances don't.** They live inside a screen the user chose to open, usually
+in place of a dead end. Capping them would mean the empty state this set out to
+fix reverts to a dead end — possibly the day after an unrelated prompt. They are
+bounded by eligibility and dismiss-forever only.
+
+| Surface       | Where                                                        |
+| ------------- | ------------------------------------------------------------ |
+| `no_catalog`  | boards-picker `isLocalOnly` empty state + a new climbs branch |
+| `board_card`  | download glyph on the Your Boards carousel                   |
+| `whats_new`   | curated card pinned above the generated changelog timeline    |
+
+### Arming is not downloading
+
+`useBoardDownloads` exposes two actions, and the difference is a bug fix, not a
+convenience:
+
+- `enableBoardsOffline` — enable + `triggerSync`. Only from surfaces that are
+  genuinely online.
+- `armBoardsOffline` — enable, **no cycle**. From every surface that can fire
+  offline.
+
+`onlineManager.isOnline()` is TRUE on captive-portal wifi, so `triggerSync`'s own
+guard does not short-circuit there: the cycle runs, every request fails, and
+`recordRetryableBootstrapFailure` spends one of the two `MAX_BOOTSTRAP_ATTEMPTS`.
+Two taps of an offline CTA and that scope is pinned to the multi-minute paged
+crawl (#4313). Nothing is lost by waiting — the scheduler's `subscribeConnectivity`
+trigger runs a cycle the moment the device reconnects, reading the latest
+`syncEnabledBoards`.
+
+The user-visible consequence: an accepted offline nudge is a promise, not a
+download. The copy and the toast say so, and `Offline Nudge Accepted` carries
+`armedOnly: true` — without it the funnel reads as accepts that never downloaded.
+
+### Eligibility
+
+`shouldShowNudge` (pure, `src/lib/offline-nudges/nudge-policy.ts`) gates on
+`boardDownloadState() !== 'off'`, i.e. on `syncEnabledBoards` — **not** on
+"absent from `downloadedScopeKeys`". An offline arm leaves the scope `'pending'`,
+which satisfies the naive gate, so the nudge would re-prompt for the board it
+just armed. `autoOfflineBoards` suppresses everything (that user downloads
+everything already), and screenshot mode suppresses everything so App Store
+captures never sprout nudge cards.
+
+### Events
+
+`Offline Nudge Shown / Accepted / Dismissed`, split by `surface`, with
+`{ boardType, layoutId, scopeKey, downloadedBoardCount }` plus `armedOnly` on
+accept and `dismissKind` on dismiss. State lives in one AsyncStorage key,
+`offlineNudgeStateV1`.
+
+### Flag ramp
+
+`offline-discovery-nudges`, ANDed with `offline-board-downloads`. Ramp from 0%.
+Before going past 25%, check `Offline Nudge Accepted` against the completed /
+failed split per board type — nudging someone into a download that takes minutes
+is a worse first impression than not nudging at all.
+
+**Bake it at 100%, do not leave it flagged.** Once the accept-to-complete rate
+holds for two weeks at 100%, delete the flag definition and the
+`useOfflineNudgesEnabled` gate in the same PR. `offline-board-downloads` sat
+resolved-on for months while the changelog still called it a tester feature
+(#4312); this one gets an owner and a date instead.
+
+### Hand-off to #3621 (sign-out wipe)
+
+`offlineNudgeStateV1` must be added to the logout wipe. A stale key across
+accounts on a shared device silently suppresses every nudge for the next user.
+`__resetNudgeStateCacheForTests` in `nudge-storage.ts` is the in-memory half.

--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -1229,6 +1229,13 @@ captures never sprout nudge cards.
 accept and `dismissKind` on dismiss. State lives in one AsyncStorage key,
 `offlineNudgeStateV1`.
 
+`board_card` is the exception: the glyph emits `Accepted` only. A card scrolling
+past in a carousel is not a suggestion the way a prompt is, so there is no
+impression event to divide by — read that surface as accepts joined to
+`Offline Board Download Completed`, not as a conversion rate. It is also the one
+surface not behind `offline-discovery-nudges`: it is a status badge on a screen
+the user opened, gated by the offline kill switch alone.
+
 ### Flag ramp
 
 `offline-discovery-nudges`, ANDed with `offline-board-downloads`. Ramp from 0%.

--- a/packages/mobile/app/boards/__tests__/index-offline.test.tsx
+++ b/packages/mobile/app/boards/__tests__/index-offline.test.tsx
@@ -136,7 +136,8 @@ vi.mock('../../../src/lib/haptics', () => ({ hapticSelection: vi.fn() }));
 vi.mock('../../../src/lib/onboarding/onboarding-storage', () => ({
   setBoardRevealTipPending: vi.fn().mockResolvedValue(undefined),
 }));
-vi.mock('../../../src/lib/analytics', () => ({ track: vi.fn() }));
+const trackMock = vi.hoisted(() => vi.fn());
+vi.mock('../../../src/lib/analytics', () => ({ track: trackMock }));
 vi.mock('../../../src/hooks/use-bottom-chrome-metrics', () => ({
   useBottomChromeMetrics: () => ({ scrollBottomPadding: 0 }),
 }));
@@ -153,8 +154,9 @@ vi.mock('../../../src/components/offline/OfflineCatalogCta', () => ({
   OfflineCatalogCta: ({ board }: { board: unknown }) =>
     board ? createElement('div', { 'data-testid': 'offline-catalog-cta' }) : null,
 }));
+const confirmAndDownloadMock = vi.hoisted(() => vi.fn(async () => true));
 vi.mock('../../../src/offline/use-confirm-board-download', () => ({
-  useConfirmBoardDownload: () => ({ confirmAndDownload: vi.fn(), armWithoutConfirm: vi.fn() }),
+  useConfirmBoardDownload: () => ({ confirmAndDownload: confirmAndDownloadMock, armWithoutConfirm: vi.fn() }),
 }));
 vi.mock('../../../src/providers/feature-flags-provider', () => ({ useOfflineDownloadsEnabled: () => true }));
 vi.mock('../../../src/offline/use-downloaded-scope-keys', () => ({
@@ -189,12 +191,31 @@ vi.mock('../../../src/components/ActivityIndicator', () => ({
   ActivityIndicator: () => createElement('div', { 'data-testid': 'spinner' }),
 }));
 vi.mock('../../../src/components/board-discovery/BoardCarousel', () => ({
-  BoardCarousel: ({ items, onSelect }: { items: CarouselItem[]; onSelect: (item: CarouselItem) => void }) =>
+  BoardCarousel: ({
+    items,
+    onSelect,
+    onDownload,
+  }: {
+    items: CarouselItem[];
+    onSelect: (item: CarouselItem) => void;
+    onDownload?: (item: CarouselItem) => void;
+  }) =>
     createElement(
       'div',
       { 'data-testid': 'carousel' },
       items.map((item) =>
-        createElement('button', { key: item.key, type: 'button', onClick: () => onSelect(item) }, item.title),
+        createElement('span', { key: item.key }, [
+          createElement('button', { key: 'select', type: 'button', onClick: () => onSelect(item) }, item.title),
+          // Only the Your Boards carousel is handed one; the download glyph is
+          // what fires the board-card accept event.
+          onDownload
+            ? createElement(
+                'button',
+                { key: 'download', type: 'button', onClick: () => onDownload(item) },
+                `download ${item.title}`,
+              )
+            : null,
+        ]),
       ),
     ),
 }));
@@ -344,6 +365,45 @@ describe('board picker with no usable network list', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Network board' }));
 
     await waitFor(() => expect(adoptFoundBoardMock).toHaveBeenCalledTimes(1));
+  });
+
+  // The board-card glyph is the widest-reach discovery surface in #4318, and it
+  // is the one that joins to the download funnel through this event alone (it
+  // has no impression event by design).
+  it('reports a board-card download once the size dialog is confirmed', async () => {
+    state.myBoards = {
+      data: { boards: [board({ uuid: 'net-1', name: 'Network board' })] },
+      isLoading: false,
+      isError: false,
+      isRefetching: false,
+    };
+
+    render(createElement(BoardSelection));
+    fireEvent.click(screen.getByRole('button', { name: 'download Network board' }));
+
+    await waitFor(() => expect(confirmAndDownloadMock).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(trackMock).toHaveBeenCalledWith(
+        'Offline Nudge Accepted',
+        expect.objectContaining({ surface: 'board_card', scopeKey: 'kilter:8:17', armedOnly: false }),
+      ),
+    );
+  });
+
+  it('reports nothing when the board-card size dialog is cancelled', async () => {
+    confirmAndDownloadMock.mockResolvedValueOnce(false);
+    state.myBoards = {
+      data: { boards: [board({ uuid: 'net-1', name: 'Network board' })] },
+      isLoading: false,
+      isError: false,
+      isRefetching: false,
+    };
+
+    render(createElement(BoardSelection));
+    fireEvent.click(screen.getByRole('button', { name: 'download Network board' }));
+
+    await waitFor(() => expect(confirmAndDownloadMock).toHaveBeenCalledTimes(1));
+    expect(trackMock).not.toHaveBeenCalledWith('Offline Nudge Accepted', expect.anything());
   });
 
   it('leaves the online screen untouched', () => {

--- a/packages/mobile/app/boards/__tests__/index-offline.test.tsx
+++ b/packages/mobile/app/boards/__tests__/index-offline.test.tsx
@@ -28,6 +28,7 @@ const state = vi.hoisted(() => ({
   isOffline: false,
   offlineCards: [] as unknown[],
   downloadedScopeKeys: [] as string[],
+  enabledScopeKeys: [] as string[],
   // What the active board's catalog looks like on this device: the offline
   // empty state reads differently for "never asked for" vs "already queued".
   offlineCatalog: null as 'missing' | 'queued' | null,
@@ -140,13 +141,22 @@ vi.mock('../../../src/hooks/use-bottom-chrome-metrics', () => ({
   useBottomChromeMetrics: () => ({ scrollBottomPadding: 0 }),
 }));
 vi.mock('../../../src/hooks/use-is-offline', () => ({ useIsOffline: () => state.isOffline }));
-vi.mock('../../../src/settings', () => ({ useOfflineBoards: () => state.offlineCards }));
+vi.mock('../../../src/settings', () => ({
+  useOfflineBoards: () => state.offlineCards,
+  useSetting: () => [state.enabledScopeKeys, vi.fn()],
+  offlineBoardKeyForBoard: (board: { boardType: string; layoutId: number; sizeId: number }) =>
+    `${board.boardType}:${board.layoutId}:${board.sizeId}`,
+}));
 // Has its own render suite (src/components/offline/__tests__); the screen only
 // needs to know it renders in the empty state.
 vi.mock('../../../src/components/offline/OfflineCatalogCta', () => ({
   OfflineCatalogCta: ({ board }: { board: unknown }) =>
     board ? createElement('div', { 'data-testid': 'offline-catalog-cta' }) : null,
 }));
+vi.mock('../../../src/offline/use-confirm-board-download', () => ({
+  useConfirmBoardDownload: () => ({ confirmAndDownload: vi.fn(), armWithoutConfirm: vi.fn() }),
+}));
+vi.mock('../../../src/providers/feature-flags-provider', () => ({ useOfflineDownloadsEnabled: () => true }));
 vi.mock('../../../src/offline/use-downloaded-scope-keys', () => ({
   useDownloadedScopeKeys: () => ({ data: state.downloadedScopeKeys }),
 }));

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -23,10 +23,13 @@ import { offlineBoardRows } from '../../src/components/board-discovery/offline-b
 import type { DiscoveryBoardItem } from '../../src/components/board-discovery/BoardDiscoveryCard';
 import { useBottomChromeMetrics } from '../../src/hooks/use-bottom-chrome-metrics';
 import { useIsOffline } from '../../src/hooks/use-is-offline';
-import { useOfflineBoards } from '../../src/settings';
+import { offlineBoardKeyForBoard, useOfflineBoards, useSetting } from '../../src/settings';
 import { useRememberDownloadedBoards } from '../../src/offline/use-remember-downloaded-boards';
 import { useDownloadedScopeKeys } from '../../src/offline/use-downloaded-scope-keys';
+import { useConfirmBoardDownload } from '../../src/offline/use-confirm-board-download';
 import { useOfflineCatalogState } from '../../src/offline/use-offline-catalog-state';
+import { useOfflineDownloadsEnabled } from '../../src/providers/feature-flags-provider';
+import { boardDownloadState, type BoardDownloadState } from '../../src/components/board-discovery/board-offline-state';
 import { OfflineCatalogCta } from '../../src/components/offline/OfflineCatalogCta';
 import { resolveBoardReturnTo } from '../../src/lib/boards/board-return-to';
 import { setBoardRevealTipPending } from '../../src/lib/onboarding/onboarding-storage';
@@ -80,6 +83,8 @@ export default function BoardSelection() {
   // device has actually downloaded.
   const isOffline = useIsOffline();
   const { data: downloadedScopeKeys } = useDownloadedScopeKeys();
+  const offlineDownloadsEnabled = useOfflineDownloadsEnabled();
+  const { confirmAndDownload } = useConfirmBoardDownload();
   // Whether the active board's catalog is missing, or merely queued after an
   // arm — the offline empty state below reads differently in each case.
   const offlineCatalog = useOfflineCatalogState(activeBoard);
@@ -160,12 +165,28 @@ export default function BoardSelection() {
     [setActiveBoard, adoptFoundBoard, router, boardReturnTo, showToast, t, fromOnboarding, isLocalOnly],
   );
 
+  // Only the user's OWN boards carry a download state. Derived from the setting
+  // + the downloaded checkpoints, not from useSyncStatus(): the card only needs
+  // "on my phone / on the way / not yet", and subscribing to the live progress
+  // frame would re-render three carousels on every tick.
+  const enabledScopeKeys = useSetting('syncEnabledBoards')[0];
+  const boardOfflineState = useCallback(
+    (board: UserBoard): BoardDownloadState =>
+      boardDownloadState({
+        scopeKey: offlineBoardKeyForBoard(board),
+        enabled: enabledScopeKeys.includes(offlineBoardKeyForBoard(board)),
+        downloaded: (downloadedScopeKeys ?? []).includes(offlineBoardKeyForBoard(board)),
+        isSyncing: false,
+        currentTable: null,
+      }),
+    [enabledScopeKeys, downloadedScopeKeys],
+  );
   const myBoardItems = useMemo(
     () =>
       myBoards
-        .map((board) => userBoardToItem(board, activeBoard?.uuid))
+        .map((board) => userBoardToItem(board, activeBoard?.uuid, boardOfflineState(board)))
         .filter((item): item is DiscoveryBoardItem => item !== null),
-    [myBoards, activeBoard?.uuid],
+    [myBoards, activeBoard?.uuid, boardOfflineState],
   );
   const nearbyItems = useMemo(
     () =>
@@ -214,10 +235,29 @@ export default function BoardSelection() {
         <BoardCarousel items={nearbyItems} onSelect={onSelectMyBoard} />
       </Section>
     ) : null;
+  // Tap-to-download, scoped to boards the user owns or follows. Gated on the
+  // engine's kill switch so the glyph never renders in the Expo browser app
+  // (offline-downloads-enabled.web.ts hard-returns false) or with offline off.
+  const onDownloadMyBoard = useCallback(
+    (item: DiscoveryBoardItem) => {
+      const board = myBoards.find((candidate) => candidate.uuid === item.key);
+      if (board) void confirmAndDownload(board);
+    },
+    [myBoards, confirmAndDownload],
+  );
+  const downloadLabelFor = useCallback(
+    (item: DiscoveryBoardItem) => t('mobile.offline.makeAvailableAria', { name: item.title }),
+    [t],
+  );
   const myBoardsSection =
     myBoardItems.length > 0 ? (
       <Section title={t('mobile.discovery.yourBoardsTitle')}>
-        <BoardCarousel items={myBoardItems} onSelect={onSelectMyBoard} />
+        <BoardCarousel
+          items={myBoardItems}
+          onSelect={onSelectMyBoard}
+          onDownload={offlineDownloadsEnabled ? onDownloadMyBoard : undefined}
+          downloadLabelFor={downloadLabelFor}
+        />
       </Section>
     ) : null;
 

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -31,6 +31,7 @@ import { useOfflineCatalogState } from '../../src/offline/use-offline-catalog-st
 import { useOfflineDownloadsEnabled } from '../../src/providers/feature-flags-provider';
 import { boardDownloadState, type BoardDownloadState } from '../../src/components/board-discovery/board-offline-state';
 import { OfflineCatalogCta } from '../../src/components/offline/OfflineCatalogCta';
+import { trackNudgeAccepted } from '../../src/lib/offline-nudges/nudge-analytics';
 import { resolveBoardReturnTo } from '../../src/lib/boards/board-return-to';
 import { setBoardRevealTipPending } from '../../src/lib/onboarding/onboarding-storage';
 import { track } from '../../src/lib/analytics';
@@ -241,9 +242,27 @@ export default function BoardSelection() {
   const onDownloadMyBoard = useCallback(
     (item: DiscoveryBoardItem) => {
       const board = myBoards.find((candidate) => candidate.uuid === item.key);
-      if (board) void confirmAndDownload(board);
+      if (!board) return;
+      void confirmAndDownload(board).then((confirmed) => {
+        if (!confirmed) return;
+        // This surface deliberately has no impression event — a card scrolling
+        // past in a carousel is not a suggestion the way a prompt is — so the
+        // accept is what joins the glyph to the download funnel. Without it the
+        // widest-reach discovery surface ships blind, which is the failure
+        // epic #4319 exists to fix. Never arm-only: the glyph is online-only.
+        trackNudgeAccepted(
+          {
+            surface: 'board_card',
+            boardType: board.boardType,
+            layoutId: board.layoutId,
+            scopeKey: offlineBoardKeyForBoard(board),
+            downloadedBoardCount: (downloadedScopeKeys ?? []).length,
+          },
+          false,
+        );
+      });
     },
-    [myBoards, confirmAndDownload],
+    [myBoards, confirmAndDownload, downloadedScopeKeys],
   );
   const downloadLabelFor = useCallback(
     (item: DiscoveryBoardItem) => t('mobile.offline.makeAvailableAria', { name: item.title }),

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -258,7 +258,7 @@ export default function BoardSelection() {
             scopeKey: offlineBoardKeyForBoard(board),
             downloadedBoardCount: (downloadedScopeKeys ?? []).length,
           },
-          false,
+          'download',
         );
       });
     },

--- a/packages/mobile/app/changelog.tsx
+++ b/packages/mobile/app/changelog.tsx
@@ -9,6 +9,7 @@ import { Button } from '../src/components/Button';
 import { Icon } from '../src/components/Icon';
 import { PressableSurface } from '../src/components/PressableSurface';
 import { Text } from '../src/components/Text';
+import { OfflineSpotlightCard } from '../src/components/offline/OfflineSpotlightCard';
 import { useBottomChromeMetrics } from '../src/hooks/use-bottom-chrome-metrics';
 import { useStackScreenOptions } from '../src/hooks/use-stack-screen-options';
 import {
@@ -307,6 +308,10 @@ export default function ChangelogScreen() {
                 <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.intro}>
                   {t('mobile.changelog.intro')}
                 </Text>
+                {/* Pinned above the generated timeline — see OfflineSpotlightCard
+                    for why it isn't a changelog entry. Renders itself away once
+                    the user has a board offline. */}
+                <OfflineSpotlightCard style={styles.spotlight} />
                 <View style={styles.headerMeta}>
                   <CurrentBuildChip />
                   <CheckForUpdatesButton />
@@ -329,6 +334,9 @@ const Separator = memo(function Separator() {
 const styles = StyleSheet.create({
   flex: {
     flex: 1,
+  },
+  spotlight: {
+    marginBottom: spacing[4],
   },
   listHeader: {
     gap: spacing[3],

--- a/packages/mobile/app/user-drawer.tsx
+++ b/packages/mobile/app/user-drawer.tsx
@@ -18,6 +18,7 @@ import { latestEntryDate } from '../src/lib/changelog';
 import { getLastSeenChangelogDate, hasUnseenChangelog } from '../src/lib/changelog-seen';
 import { hasUnseenOfflineSpotlight } from '../src/lib/offline-nudges/spotlight-unseen';
 import { useOfflineDownloadsEnabled, useOfflineNudgesEnabled } from '../src/providers/feature-flags-provider';
+import { useActiveBoard } from '../src/lib/graphql/use-active-board';
 
 const DRAWER_MAX_WIDTH = 320;
 const DRAWER_SCREEN_FRACTION = 0.86;
@@ -57,10 +58,13 @@ export default function UserDrawerScreen() {
   // ONLY when that card can actually render. Both flags gate the card itself, so
   // without this the pill would light for every user with nothing downloaded
   // while the nudge flag sits at 0%, and opening What's New would never clear it
-  // (the card never renders, so its "shown" marker is never written).
+  // (the card never renders, so its "shown" marker is never written). The active
+  // board is the same kind of precondition: the card names a board, so someone
+  // who has never picked one would carry the pill forever.
   const offlineEngineEnabled = useOfflineDownloadsEnabled();
   const offlineNudgesEnabled = useOfflineNudgesEnabled();
-  const spotlightReachable = offlineEngineEnabled && offlineNudgesEnabled;
+  const { data: activeBoard } = useActiveBoard();
+  const spotlightReachable = offlineEngineEnabled && offlineNudgesEnabled && !!activeBoard;
   const [changelogUnseen, setChangelogUnseen] = useState(false);
   useEffect(() => {
     let active = true;

--- a/packages/mobile/app/user-drawer.tsx
+++ b/packages/mobile/app/user-drawer.tsx
@@ -16,6 +16,7 @@ import { ListRow } from '../src/components/ListRow';
 import { useUserDrawer } from '../src/components/user-drawer/UserDrawerProvider';
 import { latestEntryDate } from '../src/lib/changelog';
 import { getLastSeenChangelogDate, hasUnseenChangelog } from '../src/lib/changelog-seen';
+import { hasUnseenOfflineSpotlight } from '../src/lib/offline-nudges/spotlight-unseen';
 
 const DRAWER_MAX_WIDTH = 320;
 const DRAWER_SCREEN_FRACTION = 0.86;
@@ -50,11 +51,13 @@ export default function UserDrawerScreen() {
   // the "New" pill on the What's New row. The drawer is a fresh route push every
   // time it opens, so a one-shot mount read is enough; opening the changelog clears
   // the marker and the next drawer open re-reads it.
+  // ...OR'd with the curated offline spotlight pinned inside that screen, which
+  // is otherwise unreachable for anyone whose changelog is already read.
   const [changelogUnseen, setChangelogUnseen] = useState(false);
   useEffect(() => {
     let active = true;
-    void getLastSeenChangelogDate().then((lastSeen) => {
-      if (active) setChangelogUnseen(hasUnseenChangelog(latestEntryDate, lastSeen));
+    void Promise.all([getLastSeenChangelogDate(), hasUnseenOfflineSpotlight()]).then(([lastSeen, spotlightUnseen]) => {
+      if (active) setChangelogUnseen(hasUnseenChangelog(latestEntryDate, lastSeen) || spotlightUnseen);
     });
     return () => {
       active = false;

--- a/packages/mobile/app/user-drawer.tsx
+++ b/packages/mobile/app/user-drawer.tsx
@@ -17,6 +17,7 @@ import { useUserDrawer } from '../src/components/user-drawer/UserDrawerProvider'
 import { latestEntryDate } from '../src/lib/changelog';
 import { getLastSeenChangelogDate, hasUnseenChangelog } from '../src/lib/changelog-seen';
 import { hasUnseenOfflineSpotlight } from '../src/lib/offline-nudges/spotlight-unseen';
+import { useOfflineDownloadsEnabled, useOfflineNudgesEnabled } from '../src/providers/feature-flags-provider';
 
 const DRAWER_MAX_WIDTH = 320;
 const DRAWER_SCREEN_FRACTION = 0.86;
@@ -52,17 +53,27 @@ export default function UserDrawerScreen() {
   // time it opens, so a one-shot mount read is enough; opening the changelog clears
   // the marker and the next drawer open re-reads it.
   // ...OR'd with the curated offline spotlight pinned inside that screen, which
-  // is otherwise unreachable for anyone whose changelog is already read.
+  // is otherwise unreachable for anyone whose changelog is already read — but
+  // ONLY when that card can actually render. Both flags gate the card itself, so
+  // without this the pill would light for every user with nothing downloaded
+  // while the nudge flag sits at 0%, and opening What's New would never clear it
+  // (the card never renders, so its "shown" marker is never written).
+  const offlineEngineEnabled = useOfflineDownloadsEnabled();
+  const offlineNudgesEnabled = useOfflineNudgesEnabled();
+  const spotlightReachable = offlineEngineEnabled && offlineNudgesEnabled;
   const [changelogUnseen, setChangelogUnseen] = useState(false);
   useEffect(() => {
     let active = true;
-    void Promise.all([getLastSeenChangelogDate(), hasUnseenOfflineSpotlight()]).then(([lastSeen, spotlightUnseen]) => {
+    void Promise.all([
+      getLastSeenChangelogDate(),
+      spotlightReachable ? hasUnseenOfflineSpotlight() : Promise.resolve(false),
+    ]).then(([lastSeen, spotlightUnseen]) => {
       if (active) setChangelogUnseen(hasUnseenChangelog(latestEntryDate, lastSeen) || spotlightUnseen);
     });
     return () => {
       active = false;
     };
-  }, []);
+  }, [spotlightReachable]);
 
   const {
     navigateToBoards,

--- a/packages/mobile/src/components/board-discovery/BoardCarousel.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardCarousel.tsx
@@ -11,6 +11,10 @@ const SNAP_INTERVAL = DISCOVERY_CARD_WIDTH + CARD_GAP;
 type BoardCarouselProps = {
   items: DiscoveryBoardItem[];
   onSelect: (item: DiscoveryBoardItem) => void;
+  /** See BoardDiscoveryCard — only the user's own boards carousel passes one. */
+  onDownload?: (item: DiscoveryBoardItem) => void;
+  /** Per-item accessibility label for the download glyph. Memoize it. */
+  downloadLabelFor?: (item: DiscoveryBoardItem) => string;
   contentStyle?: ViewStyle;
 };
 
@@ -20,10 +24,17 @@ type BoardCarouselProps = {
  * board scroller. Built on FlashList so long sections (popular/nearby) stay
  * cheap to render.
  */
-export function BoardCarousel({ items, onSelect, contentStyle }: BoardCarouselProps) {
+export function BoardCarousel({ items, onSelect, onDownload, downloadLabelFor, contentStyle }: BoardCarouselProps) {
   const renderItem = useCallback(
-    ({ item }: { item: DiscoveryBoardItem }) => <BoardDiscoveryCard item={item} onPress={onSelect} />,
-    [onSelect],
+    ({ item }: { item: DiscoveryBoardItem }) => (
+      <BoardDiscoveryCard
+        item={item}
+        onPress={onSelect}
+        onDownload={onDownload}
+        downloadLabel={downloadLabelFor?.(item)}
+      />
+    ),
+    [onSelect, onDownload, downloadLabelFor],
   );
 
   return (

--- a/packages/mobile/src/components/board-discovery/BoardDiscoveryCard.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardDiscoveryCard.tsx
@@ -11,6 +11,7 @@ import { useTheme } from '../../providers/theme-provider';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { BoardImageNative } from '../BoardImageNative';
+import type { BoardDownloadState } from './board-offline-state';
 
 /** The minimal board shape the card renders. UserBoard, PopularBoardConfig, and
  *  BLE-resolved boards all map onto this so one card serves every section. */
@@ -28,6 +29,11 @@ export type DiscoveryBoardItem = {
   distanceMeters?: number | null;
   /** When true, marks this as the currently-active board. */
   isActive?: boolean;
+  /**
+   * Offline download state for this board's scope. Absent on cards that cannot
+   * be downloaded as a board (popular configs — see `popularConfigToItem`).
+   */
+  offlineState?: BoardDownloadState;
 };
 
 export const DISCOVERY_CARD_WIDTH = 168;
@@ -43,9 +49,18 @@ const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 type BoardDiscoveryCardProps = {
   item: DiscoveryBoardItem;
   onPress: (item: DiscoveryBoardItem) => void;
+  /**
+   * Offer a one-tap download for an un-downloaded board. Passed only by the
+   * carousel that renders boards the user owns or follows; Nearby (other
+   * people's boards), Popular (no uuid) and the offline rows (already on the
+   * device, and there is no connection) never get one.
+   */
+  onDownload?: (item: DiscoveryBoardItem) => void;
+  /** Accessibility label for the download glyph. */
+  downloadLabel?: string;
 };
 
-export function BoardDiscoveryCard({ item, onPress }: BoardDiscoveryCardProps) {
+export function BoardDiscoveryCard({ item, onPress, onDownload, downloadLabel }: BoardDiscoveryCardProps) {
   const { systemColors, brandColors } = useTheme();
   const scale = useSharedValue(1);
 
@@ -110,6 +125,34 @@ export function BoardDiscoveryCard({ item, onPress }: BoardDiscoveryCardProps) {
           </View>
         ) : null}
 
+        {/* At-a-glance "is this board on my phone". A downloaded or in-flight
+            board is a status badge with no press target; only 'off' is
+            actionable, and only where the host passed a handler. */}
+        {item.offlineState === 'downloaded' ? (
+          <View style={styles.offlineBadge}>
+            <Icon name="offline.downloaded" size={15} color={brandColors.primary} />
+          </View>
+        ) : item.offlineState === 'downloading' || item.offlineState === 'pending' ? (
+          <View style={styles.offlineBadge}>
+            <Icon name="offline.pending" size={15} color={systemColors.secondaryLabel} />
+          </View>
+        ) : item.offlineState === 'off' && onDownload ? (
+          <Pressable
+            onPress={() => {
+              hapticLight();
+              onDownload(item);
+            }}
+            accessibilityRole="button"
+            accessibilityLabel={downloadLabel}
+            style={styles.offlineBadge}
+            // The glyph is a 26pt target inside a 168pt card, so widen the touch
+            // area rather than the visual.
+            hitSlop={8}
+          >
+            <Icon name="offline.download" size={15} color={brandColors.primary} />
+          </Pressable>
+        ) : null}
+
         {item.distanceMeters != null ? (
           <View style={styles.distanceBadge}>
             <Icon name="location" size={11} color={overlays.onScrim} />
@@ -158,6 +201,21 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: spacing[2],
     right: spacing[2],
+    width: 26,
+    height: 26,
+    borderRadius: borderRadius.full,
+    backgroundColor: iosSystemColors.white,
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...Platform.select({
+      ios: { shadowColor: '#000', shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.15, shadowRadius: 2 },
+      android: { elevation: 2 },
+    }),
+  },
+  offlineBadge: {
+    position: 'absolute',
+    top: spacing[2],
+    left: spacing[2],
     width: 26,
     height: 26,
     borderRadius: borderRadius.full,

--- a/packages/mobile/src/components/board-discovery/__tests__/board-discovery-card.test.tsx
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-discovery-card.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { render, cleanup } from '@testing-library/react';
+import { render, cleanup, fireEvent } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import type { DiscoveryBoardItem } from '../BoardDiscoveryCard';
 
@@ -11,7 +11,15 @@ const boardImageProps = vi.hoisted(() => ({ last: null as Record<string, unknown
 
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
-  Pressable: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({
+    children,
+    onPress,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityLabel?: string;
+  }) => createElement('div', { onClick: onPress, 'aria-label': accessibilityLabel, role: 'button' }, children),
   Platform: { select: (spec: Record<string, unknown>) => spec.ios },
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
 }));
@@ -47,7 +55,9 @@ vi.mock('../../../providers/theme-provider', () => ({
 vi.mock('../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
 }));
-vi.mock('../../Icon', () => ({ Icon: () => createElement('span', { 'data-icon': 'true' }) }));
+vi.mock('../../Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }),
+}));
 
 // A non-null render keeps the card on the BoardImageNative branch.
 vi.mock('../../../lib/board-details', () => ({
@@ -85,5 +95,60 @@ describe('BoardDiscoveryCard', () => {
     // The discovery card cell is 168px; requesting renderWidth forces the
     // thumb-variant background + small overlay instead of a full-res decode.
     expect(boardImageProps.last?.renderWidth).toBe(400);
+  });
+
+  // The badge answers "is this board on my phone" without leaving the picker.
+  it.each([
+    ['downloaded', 'offline.downloaded'],
+    ['downloading', 'offline.pending'],
+    ['pending', 'offline.pending'],
+  ] as const)('shows a status badge for a %s board', (offlineState, icon) => {
+    const { container } = render(
+      createElement(BoardDiscoveryCard, { item: { ...item, offlineState }, onPress: vi.fn() }),
+    );
+    expect(container.querySelector(`[data-icon="${icon}"]`)).not.toBeNull();
+  });
+
+  it('has no press target on a board that is already downloading', () => {
+    const onDownload = vi.fn();
+    const { container } = render(
+      createElement(BoardDiscoveryCard, {
+        item: { ...item, offlineState: 'downloading' },
+        onPress: vi.fn(),
+        onDownload,
+      }),
+    );
+    fireEvent.click(container.querySelector('[data-icon="offline.pending"]')!.parentElement!);
+    expect(onDownload).not.toHaveBeenCalled();
+  });
+
+  it('offers a tappable download glyph only where the host wired one', () => {
+    const onDownload = vi.fn();
+    const downloadItem = { ...item, offlineState: 'off' as const };
+
+    const withoutHandler = render(createElement(BoardDiscoveryCard, { item: downloadItem, onPress: vi.fn() }));
+    expect(withoutHandler.container.querySelector('[data-icon="offline.download"]')).toBeNull();
+    cleanup();
+
+    const { container } = render(
+      createElement(BoardDiscoveryCard, {
+        item: downloadItem,
+        onPress: vi.fn(),
+        onDownload,
+        downloadLabel: 'Make Tension 8x10 available offline',
+      }),
+    );
+    const glyph = container.querySelector('[data-icon="offline.download"]')!.parentElement!;
+    expect(glyph.getAttribute('aria-label')).toBe('Make Tension 8x10 available offline');
+    fireEvent.click(glyph);
+    expect(onDownload).toHaveBeenCalledWith(downloadItem);
+  });
+
+  // A popular config has no uuid, so rememberOfflineBoards drops it: its data
+  // would download but the board could never appear in the offline picker.
+  it('renders no offline affordance at all without an offlineState', () => {
+    const { container } = render(createElement(BoardDiscoveryCard, { item, onPress: vi.fn(), onDownload: vi.fn() }));
+    expect(container.querySelector('[data-icon="offline.download"]')).toBeNull();
+    expect(container.querySelector('[data-icon="offline.downloaded"]')).toBeNull();
   });
 });

--- a/packages/mobile/src/components/board-discovery/__tests__/board-items.test.ts
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-items.test.ts
@@ -119,3 +119,33 @@ describe('findOwnedBoardForConfig', () => {
     expect(findOwnedBoardForConfig([], { boardType: 'kilter', layoutId: 1, sizeId: 2, setIds: '3,4' })).toBeUndefined();
   });
 });
+
+describe('offline state on discovery items', () => {
+  it('carries the download state a caller supplies for an owned board', () => {
+    const board = {
+      uuid: 'garage',
+      name: "Marco's garage",
+      boardType: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '1,2',
+    } as UserBoard;
+    expect(userBoardToItem(board, null, 'downloaded')?.offlineState).toBe('downloaded');
+    expect(userBoardToItem(board, null)?.offlineState).toBeUndefined();
+  });
+
+  // A popular config has no uuid, so rememberOfflineBoards filters it out
+  // (settings/offline-boards.ts): its data would download but the board could
+  // never appear in the offline picker. It must never carry a download state.
+  it('never gives a popular config a download state', () => {
+    const item = popularConfigToItem({
+      boardType: 'tension',
+      layoutId: 9,
+      sizeId: 8,
+      setIds: [1, 2],
+      displayName: 'Tension 8x10',
+    } as unknown as PopularBoardConfig);
+    expect(item?.offlineState).toBeUndefined();
+    expect(item?.key.startsWith('popular:')).toBe(true);
+  });
+});

--- a/packages/mobile/src/components/board-discovery/board-items.ts
+++ b/packages/mobile/src/components/board-discovery/board-items.ts
@@ -5,8 +5,19 @@
 import type { BoardName, UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
 import { toBoardName, normaliseSetIds } from '@boardsesh/board-config';
 import type { DiscoveryBoardItem } from './BoardDiscoveryCard';
+import type { BoardDownloadState } from './board-offline-state';
 
-export function userBoardToItem(board: UserBoard, activeUuid?: string | null): DiscoveryBoardItem | null {
+export function userBoardToItem(
+  board: UserBoard,
+  activeUuid?: string | null,
+  /**
+   * Whether this board's catalog is on the device. Only owned/followed boards
+   * get one — a popular config has no `uuid`, so `rememberOfflineBoards` drops
+   * it (see settings/offline-boards.ts) and it could never appear in the offline
+   * picker even though its data would download.
+   */
+  offlineState?: BoardDownloadState,
+): DiscoveryBoardItem | null {
   const boardName = toBoardName(board.boardType);
   if (boardName === null) return null;
   return {
@@ -19,6 +30,7 @@ export function userBoardToItem(board: UserBoard, activeUuid?: string | null): D
     subtitle: board.sizeName ?? board.boardType,
     distanceMeters: board.distanceMeters ?? undefined,
     isActive: activeUuid != null && board.uuid === activeUuid,
+    offlineState,
   };
 }
 

--- a/packages/mobile/src/components/offline/OfflineSpotlightCard.tsx
+++ b/packages/mobile/src/components/offline/OfflineSpotlightCard.tsx
@@ -1,0 +1,54 @@
+// A curated, translated spotlight pinned above the generated What's New
+// timeline.
+//
+// It is pinned rather than written into the timeline because
+// `changelog.generated.json` is regenerated from merged PR release notes by
+// scripts/generate-changelog.ts — anything edited into it is overwritten on the
+// next build, and its entries are English-only. One of them still describes
+// offline downloads as testers-only, which stopped being true when the flag hit
+// 100%.
+//
+// An affordance: no cooldown, no lifetime cap. It takes itself away once the
+// user has any board armed or downloaded, or when they dismiss it.
+
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useRouter } from 'expo-router';
+import type { StyleProp, ViewStyle } from 'react-native';
+import { useActiveBoard } from '../../lib/graphql/use-active-board';
+import { useOfflineNudge } from '../../lib/offline-nudges/use-offline-nudge';
+import { OfflineNudgeCard } from './OfflineNudgeCard';
+
+type OfflineSpotlightCardProps = {
+  style?: StyleProp<ViewStyle>;
+};
+
+export function OfflineSpotlightCard({ style }: OfflineSpotlightCardProps) {
+  const { t } = useTranslation('boards');
+  const router = useRouter();
+  const { data: activeBoard } = useActiveBoard();
+  const nudge = useOfflineNudge({ surface: 'whats_new', board: activeBoard });
+
+  // Send them to My Boards rather than downloading from under them: this is a
+  // "here's a feature you may not know about" card, not a confirmation, and the
+  // per-board toggle there is where the size quote lives.
+  const handleOpen = useCallback(() => {
+    nudge.accept();
+    router.push('/boards/manage');
+  }, [nudge, router]);
+
+  if (!nudge.visible) return null;
+
+  return (
+    <OfflineNudgeCard
+      testID="offline-spotlight-card"
+      title={t('mobile.offline.nudge.spotlight.title')}
+      body={t('mobile.offline.nudge.spotlight.body')}
+      primaryLabel={t('mobile.offline.nudge.spotlight.cta')}
+      onPrimary={handleOpen}
+      neverLabel={t('mobile.offline.nudge.never')}
+      onNever={() => nudge.dismiss('forever')}
+      style={style}
+    />
+  );
+}

--- a/packages/mobile/src/components/offline/OfflineSpotlightCard.tsx
+++ b/packages/mobile/src/components/offline/OfflineSpotlightCard.tsx
@@ -33,7 +33,10 @@ export function OfflineSpotlightCard({ style }: OfflineSpotlightCardProps) {
   // "here's a feature you may not know about" card, not a confirmation, and the
   // per-board toggle there is where the size quote lives.
   const handleOpen = useCallback(() => {
-    nudge.accept();
+    // A handoff, not an arm: nothing is queued here, the user is sent to the
+    // screen where the size quote and the real download live. The drop-off that
+    // leaves behind is a real one, so it counts as an ordinary accept.
+    nudge.accept('handoff');
     router.push('/boards/manage');
   }, [nudge, router]);
 

--- a/packages/mobile/src/components/offline/__tests__/OfflineSpotlightCard.test.tsx
+++ b/packages/mobile/src/components/offline/__tests__/OfflineSpotlightCard.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen, fireEvent } from '@testing-library/react';
+import { cleanup, render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import type { UserBoard } from '@boardsesh/shared-schema';
 
@@ -13,7 +13,13 @@ const state = vi.hoisted(() => ({
   nudgesEnabled: true,
 }));
 
-const spies = vi.hoisted(() => ({ push: vi.fn(), track: vi.fn(), saveNudgeState: vi.fn(async () => undefined) }));
+const spies = vi.hoisted(() => ({
+  push: vi.fn(),
+  track: vi.fn(),
+  // Typed loosely on purpose: the pill assertion below reads the saved state
+  // back out of the call args, so the parameter has to exist in the signature.
+  saveNudgeState: vi.fn(async (_next: unknown) => undefined),
+}));
 
 vi.mock('react-native', () => ({
   View: ({ children, testID }: { children?: ReactNode; testID?: string }) =>
@@ -57,6 +63,7 @@ vi.mock('../../../lib/offline-nudges/nudge-storage', async () => {
 });
 
 import { SHARED_EVENTS } from '@boardsesh/analytics';
+import type { OfflineNudgeState } from '../../../lib/offline-nudges/nudge-policy';
 import { OfflineSpotlightCard } from '../OfflineSpotlightCard';
 
 const board = { uuid: 'garage', name: 'Gym wall', boardType: 'kilter', layoutId: 1, sizeId: 10 } as UserBoard;
@@ -98,6 +105,20 @@ describe('OfflineSpotlightCard', () => {
       SHARED_EVENTS.OfflineNudgeAccepted,
       expect.objectContaining({ surface: 'whats_new' }),
     );
+  });
+
+  // The handoff is a drop-off risk: someone can open My Boards and back out
+  // without downloading anything. The spotlight must stay "seen" all the same,
+  // or hasUnseenOfflineSpotlight lights the What's New "New" pill again for a
+  // card the user already opened and accepted.
+  it('keeps the spotlight marked as seen after the handoff', async () => {
+    await renderSpotlight();
+    await waitFor(() => expect(spies.saveNudgeState).toHaveBeenCalled());
+    fireEvent.click(screen.getByText('mobile.offline.nudge.spotlight.cta'));
+
+    await waitFor(() => expect(spies.saveNudgeState).toHaveBeenCalledTimes(2));
+    const saved = spies.saveNudgeState.mock.calls[1][0] as OfflineNudgeState;
+    expect(saved.surfaces.whats_new.shownCount).toBe(1);
   });
 
   it('persists a dismissal as forever, with no "not now" half-measure', async () => {

--- a/packages/mobile/src/components/offline/__tests__/OfflineSpotlightCard.test.tsx
+++ b/packages/mobile/src/components/offline/__tests__/OfflineSpotlightCard.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+const state = vi.hoisted(() => ({
+  activeBoard: null as UserBoard | null,
+  enabledBoards: [] as string[],
+  downloadedScopeKeys: [] as string[],
+  autoOfflineBoards: false,
+  offlineEngineEnabled: true,
+  nudgesEnabled: true,
+}));
+
+const spies = vi.hoisted(() => ({ push: vi.fn(), track: vi.fn(), saveNudgeState: vi.fn(async () => undefined) }));
+
+vi.mock('react-native', () => ({
+  View: ({ children, testID }: { children?: ReactNode; testID?: string }) =>
+    createElement('div', { 'data-testid': testID }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: () => createElement('span', { 'data-icon': 'true' }) }));
+vi.mock('../../Button', () => ({
+  Button: ({ title, onPress }: { title: string; onPress: () => void }) =>
+    createElement('button', { onClick: onPress }, title),
+}));
+vi.mock('../../../theme/tokens', () => ({ spacing: new Proxy({}, { get: () => 4 }), borderRadius: { lg: 12 } }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { secondaryBackground: '#eee', separator: '#ccc', secondaryLabel: '#888' },
+    brandColors: { primary: '#6D28D9' },
+  }),
+}));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('expo-router', () => ({ useRouter: () => ({ push: spies.push }) }));
+vi.mock('../../../lib/graphql/use-active-board', () => ({ useActiveBoard: () => ({ data: state.activeBoard }) }));
+vi.mock('../../../offline/use-downloaded-scope-keys', () => ({
+  useDownloadedScopeKeys: () => ({ data: state.downloadedScopeKeys }),
+}));
+vi.mock('../../../providers/feature-flags-provider', () => ({
+  useOfflineDownloadsEnabled: () => state.offlineEngineEnabled,
+  useOfflineNudgesEnabled: () => state.nudgesEnabled,
+}));
+vi.mock('../../../hooks/use-is-offline', () => ({ useIsOffline: () => false }));
+vi.mock('../../../settings', () => ({
+  offlineBoardKeyForBoard: (board: UserBoard) => `${board.boardType}:${board.layoutId}:${board.sizeId}`,
+  useSetting: (key: string) => [key === 'syncEnabledBoards' ? state.enabledBoards : state.autoOfflineBoards, vi.fn()],
+}));
+vi.mock('../../../lib/analytics', () => ({ track: spies.track }));
+vi.mock('../../../lib/offline-nudges/nudge-storage', async () => {
+  const policy = await import('../../../lib/offline-nudges/nudge-policy');
+  return { loadNudgeState: async () => policy.emptyNudgeState(), saveNudgeState: spies.saveNudgeState };
+});
+
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { OfflineSpotlightCard } from '../OfflineSpotlightCard';
+
+const board = { uuid: 'garage', name: 'Gym wall', boardType: 'kilter', layoutId: 1, sizeId: 10 } as UserBoard;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.activeBoard = board;
+  state.enabledBoards = [];
+  state.downloadedScopeKeys = [];
+  state.autoOfflineBoards = false;
+  state.offlineEngineEnabled = true;
+  state.nudgesEnabled = true;
+});
+afterEach(() => cleanup());
+
+async function renderSpotlight() {
+  render(createElement(OfflineSpotlightCard, {}));
+  await screen.findByTestId('offline-spotlight-card').catch(() => null);
+}
+
+describe('OfflineSpotlightCard', () => {
+  it('introduces offline downloads to someone who has none', async () => {
+    await renderSpotlight();
+    expect(screen.getByTestId('offline-spotlight-card')).toBeTruthy();
+  });
+
+  it('takes itself away once a board is already offline', async () => {
+    state.enabledBoards = ['kilter:1:10'];
+    await renderSpotlight();
+    expect(screen.queryByTestId('offline-spotlight-card')).toBeNull();
+  });
+
+  // It's an introduction, not a confirmation — the size quote lives on My Boards.
+  it('sends the user to My Boards rather than downloading under them', async () => {
+    await renderSpotlight();
+    fireEvent.click(screen.getByText('mobile.offline.nudge.spotlight.cta'));
+    expect(spies.push).toHaveBeenCalledWith('/boards/manage');
+    expect(spies.track).toHaveBeenCalledWith(
+      SHARED_EVENTS.OfflineNudgeAccepted,
+      expect.objectContaining({ surface: 'whats_new' }),
+    );
+  });
+
+  it('persists a dismissal as forever, with no "not now" half-measure', async () => {
+    await renderSpotlight();
+    expect(screen.queryByText('mobile.offline.nudge.notNow')).toBeNull();
+    fireEvent.click(screen.getByText('mobile.offline.nudge.never'));
+    expect(spies.track).toHaveBeenCalledWith(
+      SHARED_EVENTS.OfflineNudgeDismissed,
+      expect.objectContaining({ surface: 'whats_new', dismissKind: 'forever' }),
+    );
+    expect(screen.queryByTestId('offline-spotlight-card')).toBeNull();
+  });
+});

--- a/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
@@ -99,6 +99,11 @@ vi.mock('../../../providers/feature-flags-provider', () => ({
   useOfflineDownloadsEnabled: () => true,
   useOfflineNudgesEnabled: () => true,
 }));
+// AsyncStorage-backed; the spotlight names a board, so the pill asks whether
+// there is one.
+vi.mock('../../../lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: { uuid: 'board-1' } }),
+}));
 vi.mock('../../../lib/graphql/hooks', () => ({
   useProfile: () => ({ data: { id: 'user-1', displayName: 'Alex', email: 'alex@example.com', avatarUrl: null } }),
 }));

--- a/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
@@ -93,6 +93,12 @@ vi.mock('../../../lib/changelog-seen', () => changelogSeen);
 vi.mock('../../../lib/offline-nudges/spotlight-unseen', () => ({
   hasUnseenOfflineSpotlight: async () => false,
 }));
+// Pulls PostHog into the graph; the pill only asks it whether the spotlight
+// could render at all.
+vi.mock('../../../providers/feature-flags-provider', () => ({
+  useOfflineDownloadsEnabled: () => true,
+  useOfflineNudgesEnabled: () => true,
+}));
 vi.mock('../../../lib/graphql/hooks', () => ({
   useProfile: () => ({ data: { id: 'user-1', displayName: 'Alex', email: 'alex@example.com', avatarUrl: null } }),
 }));

--- a/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
@@ -89,6 +89,10 @@ const changelogSeen = vi.hoisted(() => ({
 }));
 vi.mock('../../../lib/changelog', () => ({ latestEntryDate: '2026-01-01T00:00:00.000Z' }));
 vi.mock('../../../lib/changelog-seen', () => changelogSeen);
+// Reads MMKV-backed settings; the pill's spotlight half has its own suite.
+vi.mock('../../../lib/offline-nudges/spotlight-unseen', () => ({
+  hasUnseenOfflineSpotlight: async () => false,
+}));
 vi.mock('../../../lib/graphql/hooks', () => ({
   useProfile: () => ({ data: { id: 'user-1', displayName: 'Alex', email: 'alex@example.com', avatarUrl: null } }),
 }));

--- a/packages/mobile/src/lib/offline-nudges/__tests__/spotlight-unseen.test.ts
+++ b/packages/mobile/src/lib/offline-nudges/__tests__/spotlight-unseen.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({ enabledBoards: [] as string[], autoOfflineBoards: false }));
+const spies = vi.hoisted(() => ({ loadNudgeState: vi.fn() }));
+
+vi.mock('../../../settings', () => ({
+  getSetting: (key: string) => (key === 'syncEnabledBoards' ? state.enabledBoards : state.autoOfflineBoards),
+}));
+vi.mock('../nudge-storage', () => ({ loadNudgeState: spies.loadNudgeState }));
+
+import { emptyNudgeState, withNudgeDismissed, withNudgeShown } from '../nudge-policy';
+import { hasUnseenOfflineSpotlight } from '../spotlight-unseen';
+
+const originalScreenshotMode = process.env.EXPO_PUBLIC_SCREENSHOT_MODE;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.enabledBoards = [];
+  state.autoOfflineBoards = false;
+  spies.loadNudgeState.mockResolvedValue(emptyNudgeState());
+});
+afterEach(() => {
+  if (originalScreenshotMode === undefined) delete process.env.EXPO_PUBLIC_SCREENSHOT_MODE;
+  else process.env.EXPO_PUBLIC_SCREENSHOT_MODE = originalScreenshotMode;
+});
+
+describe('hasUnseenOfflineSpotlight', () => {
+  // Without this the spotlight is unreachable: it lives inside What's New, and
+  // someone with no unseen changelog entries has no reason to open that screen.
+  it('earns the pill for a user with nothing downloaded', async () => {
+    await expect(hasUnseenOfflineSpotlight()).resolves.toBe(true);
+  });
+
+  it('stays quiet once the user already has a board offline', async () => {
+    state.enabledBoards = ['kilter:1:10'];
+    await expect(hasUnseenOfflineSpotlight()).resolves.toBe(false);
+  });
+
+  it('stays quiet for someone auto-downloading every board', async () => {
+    state.autoOfflineBoards = true;
+    await expect(hasUnseenOfflineSpotlight()).resolves.toBe(false);
+  });
+
+  it('stays quiet after the spotlight has been seen or dismissed', async () => {
+    spies.loadNudgeState.mockResolvedValue(withNudgeShown(emptyNudgeState(), 'whats_new', 1));
+    await expect(hasUnseenOfflineSpotlight()).resolves.toBe(false);
+
+    spies.loadNudgeState.mockResolvedValue(withNudgeDismissed(emptyNudgeState(), 'whats_new', 'forever', 1));
+    await expect(hasUnseenOfflineSpotlight()).resolves.toBe(false);
+  });
+
+  it('never lights the pill in a screenshot run', async () => {
+    process.env.EXPO_PUBLIC_SCREENSHOT_MODE = '1';
+    await expect(hasUnseenOfflineSpotlight()).resolves.toBe(false);
+  });
+});

--- a/packages/mobile/src/lib/offline-nudges/spotlight-unseen.ts
+++ b/packages/mobile/src/lib/offline-nudges/spotlight-unseen.ts
@@ -1,0 +1,25 @@
+// Whether the What's New row deserves its "New" pill because of the offline
+// spotlight, independently of whether the generated changelog has new entries.
+//
+// Without this the spotlight is unreachable: it lives inside the changelog
+// screen, and a user with no unseen changelog entries has no reason to open it.
+
+import { getSetting } from '../../settings';
+import { loadNudgeState } from './nudge-storage';
+
+/**
+ * True when the offline spotlight would render if the user opened What's New:
+ * they have never dismissed it and have no board offline yet.
+ *
+ * Screenshot mode reports false, matching `hasUnseenChangelog` — a captured
+ * store screen must never show the pill.
+ */
+export async function hasUnseenOfflineSpotlight(): Promise<boolean> {
+  if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1') return false;
+  // Already downloading something: the spotlight has nothing to tell them.
+  if (getSetting('syncEnabledBoards').length > 0) return false;
+  if (getSetting('autoOfflineBoards')) return false;
+  const state = await loadNudgeState();
+  const spotlight = state.surfaces.whats_new;
+  return !spotlight.dismissedForever && spotlight.shownCount === 0;
+}

--- a/packages/shared/i18n/locales/de/boards.json
+++ b/packages/shared/i18n/locales/de/boards.json
@@ -333,6 +333,11 @@
           "body": "{{name}} ist noch nicht auf deinem Handy, hier unten gibt es also nichts zu durchsuchen.",
           "cta": "Holen, sobald ich Netz habe",
           "armedToast": "{{name}} steht in der Warteschlange und lädt, sobald du wieder online bist."
+        },
+        "spotlight": {
+          "title": "Klettere, wo kein WLAN hinkommt",
+          "body": "Lade ein Board einmal herunter und der ganze Katalog liegt auf deinem Handy: Suche, Filter und Begehungen eintragen funktionieren auch im Kellerraum ohne Empfang.",
+          "cta": "Board zum Herunterladen wählen"
         }
       }
     },

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -333,6 +333,11 @@
           "body": "{{name}} isn't on your phone yet, so there's nothing to search down here.",
           "cta": "Grab it when I have signal",
           "armedToast": "{{name}} is queued — it downloads the moment you're back online."
+        },
+        "spotlight": {
+          "title": "Climb where the wifi does not reach",
+          "body": "Download a board once and its whole catalog lives on your phone — search, filters and logging sends all work in a basement gym with no bars.",
+          "cta": "Pick a board to download"
         }
       }
     },

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -333,6 +333,11 @@
           "body": "Todavía no tienes {{name}} en el móvil, así que aquí abajo no hay nada que buscar.",
           "cta": "Descargarlo cuando tenga cobertura",
           "armedToast": "{{name}} está en cola: se descarga en cuanto vuelvas a tener conexión."
+        },
+        "spotlight": {
+          "title": "Escala donde no llega el wifi",
+          "body": "Descarga un plafón una vez y todo su catálogo queda en tu móvil: la búsqueda, los filtros y registrar encadenes funcionan en un sótano sin cobertura.",
+          "cta": "Elegir un plafón para descargar"
         }
       }
     },

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -333,6 +333,11 @@
           "body": "{{name}} n'est pas encore sur ton téléphone, donc il n'y a rien à chercher ici.",
           "cta": "La récupérer dès que j’ai du réseau",
           "armedToast": "{{name}} est en file d’attente : le téléchargement démarre dès que tu es reconnecté."
+        },
+        "spotlight": {
+          "title": "Grimpe là où le wifi ne va pas",
+          "body": "Télécharge une board une fois et tout son catalogue reste sur ton téléphone : recherche, filtres et croix dans le carnet marchent dans une salle en sous-sol sans réseau.",
+          "cta": "Choisir une board à télécharger"
         }
       }
     },


### PR DESCRIPTION
**HOLD: merges only after Tier 1 (#4310-#4313).** Nudging people into today's download would burn the one first impression they get.

Stacked on #4343 (`feat/4318-no-signal-download-cta`). Closes #4318.

The last two surfaces, both affordances rather than prompts.

**Board cards say whether the catalog is on the phone.** A check badge when it's downloaded, a cloud when it's queued or downloading, a tappable download glyph when it isn't. Scoped on purpose:

- **Your Boards only.** Nearby is other people's walls, and a Popular entry is a config with no `uuid` — `rememberOfflineBoards` filters those out (`settings/offline-boards.ts`), so downloading one would pull the data but leave a board that could never appear in the offline picker. The state lives on the item mapping (`userBoardToItem`), and `popularConfigToItem` never sets it.
- **Gated on the offline kill switch**, so the glyph never renders dead in the Expo browser app (`offline-downloads-enabled.web.ts` hard-returns false) or with offline off.
- **Downloaded and downloading are status, not buttons** — no press target.

This is the surface that makes PR #4341's freshness fix visible: complete a download while sitting on the boards picker and the badge flips without leaving the screen.

**What's New gets a curated offline spotlight.** Pinned above the generated timeline rather than written into it: `changelog.generated.json` is rebuilt from merged PR release notes by `scripts/generate-changelog.ts`, is English-only, and one of its entries still describes offline downloads as a tester feature. The card is translated, dismissible, and takes itself away once the user has any board offline. Its unseen state is OR'd into the drawer's "New" pill — without that, anyone whose changelog is already read has no reason to open the screen the card lives on. `hasUnseenOfflineSpotlight` keeps `hasUnseenChangelog`'s screenshot-mode suppression.

Also adds the "Discovery nudges" section to `docs/offline-sync-plan.md`: the four surfaces, prompts vs affordances, why arming isn't downloading, the event shape, the flag ramp, and an explicit bake-at-100% plan so this doesn't repeat #4312.

## Changes

- `DiscoveryBoardItem.offlineState`, populated only by `userBoardToItem`.
- `BoardCarousel` takes optional `onDownload` + `downloadLabelFor`; wired only on the Your Boards carousel.
- Badge / glyph branches in `BoardDiscoveryCard`.
- `OfflineSpotlightCard` in the changelog list header; `hasUnseenOfflineSpotlight` OR'd into the drawer pill.
- `mobile.offline.nudge.spotlight.*` across all four locales.
- `docs/offline-sync-plan.md`.

## Release Notes

Your board cards now show at a glance which ones are on your phone, and tapping the download icon grabs one right there.

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 628 files / 5552 tests pass
- `vp test run --project i18n` (90), `--project analytics` (23) — pass
- `vp run check:mobile-bundle` — OK
- `vp run check:mobile-web-bundle` — OK (this stack touches `boards/index.tsx`, `climbs/index.tsx`, `changelog.tsx`, `user-drawer.tsx`, all in the web graph)
- `vp run check:i18n:orphans` — OK

New coverage: badge branches per state, the glyph appearing only where a handler was wired and carrying the right accessibility label, no press target while downloading, a popular config never carrying an `offlineState`; `OfflineSpotlightCard.tsx` (hides once a board is offline, routes to My Boards rather than downloading under the user, dismiss is forever-only); `spotlight-unseen.test.ts` including the screenshot-mode guard.

Not yet exercised on device. Worth checking before ready: complete a download while on the boards picker and watch the badge flip; confirm the glyph is absent on Nearby and Popular; confirm `EXPO_PUBLIC_SCREENSHOT_MODE=1` renders no nudge cards anywhere.

## Follow-ups

Hand-off to #3621: `offlineNudgeStateV1` must join the sign-out wipe. A stale key across accounts on a shared device silently suppresses every nudge for the next user. Written into the docs section too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT6VP1sWqk6bY9mUgyeS2U
