### PR TITLE
perf(sync): measure snapshot bootstrap phases and keep downloaded artifacts

### DIFF
--- a/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
+++ b/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
@@ -97,6 +97,32 @@ import type {
   SyncOptions,
 } from '@boardsesh/offline-sync';
 
+// The engine package is vi.mock'd above, so its `emptyScopeDownloadPhases`
+// helper is unreachable here — this literal stands in for it.
+const NO_PHASES = {
+  manifestMs: 0,
+  downloadMs: 0,
+  importMs: 0,
+  artifactBytes: 0,
+  artifactReused: false,
+  climbsPullMs: 0,
+  statsPullMs: 0,
+  gradesPullMs: 0,
+  gradesRows: 0,
+};
+
+// What the adapter actually emits from a zeroed breakdown: download/import/bytes
+// ride the per-scope timings on ScopeDownloadCompleteInfo (absent when this cycle
+// did not do the import), so the phase copies of them are not re-emitted.
+const NO_PHASE_PROPS = {
+  manifestMs: 0,
+  artifactReused: false,
+  climbsPullMs: 0,
+  statsPullMs: 0,
+  gradesPullMs: 0,
+  gradesRows: 0,
+};
+
 const db = {} as OfflineDatabase;
 const queryClient = { invalidateQueries: vi.fn() } as unknown as import('@tanstack/react-query').QueryClient;
 const graphqlFetch = vi.fn() as unknown as import('@boardsesh/offline-sync').GraphQLFetch;
@@ -471,12 +497,24 @@ describe('snapshot-bootstrap bindings', () => {
       async () => {},
     );
     const options = startSyncSchedulerCore.mock.calls[0][6] as SchedulerOptions;
-    options.onScopeDownloadComplete?.({ scopeKey: 'kilter:1:5', method: 'snapshot', durationMs: 1234 });
+    options.onScopeDownloadComplete?.({
+      scopeKey: 'kilter:1:5',
+      method: 'snapshot',
+      durationMs: 1234,
+      phases: { ...NO_PHASES, downloadMs: 900, importMs: 200, gradesPullMs: 134, gradesRows: 500, artifactBytes: 42 },
+    });
 
+    // The phase split rides on the SAME event rather than a new one (#4310).
     expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineBoardDownloadCompleted, {
       scopeKey: 'kilter:1:5',
       method: 'snapshot',
       durationMs: 1234,
+      manifestMs: 0,
+      artifactReused: false,
+      climbsPullMs: 0,
+      statsPullMs: 0,
+      gradesPullMs: 134,
+      gradesRows: 500,
       offlineEngineEnabled: false,
     });
   });
@@ -492,13 +530,16 @@ describe('snapshot-bootstrap bindings', () => {
       { onScopeDownloadComplete },
     );
     const options = startSyncSchedulerCore.mock.calls[0][6] as SchedulerOptions;
-    const info = { scopeKey: 'kilter:1:5', method: 'paged' as const, durationMs: 500 };
+    const info = { scopeKey: 'kilter:1:5', method: 'paged' as const, durationMs: 500, phases: NO_PHASES };
 
     options.onScopeDownloadComplete?.(info);
 
     expect(onScopeDownloadComplete).toHaveBeenCalledWith(info);
     expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineBoardDownloadCompleted, {
-      ...info,
+      scopeKey: 'kilter:1:5',
+      method: 'paged',
+      durationMs: 500,
+      ...NO_PHASE_PROPS,
       offlineEngineEnabled: false,
     });
   });
@@ -764,6 +805,7 @@ describe('snapshot-bootstrap bindings', () => {
       rowCount: 40_000,
       downloadMs: 800,
       importMs: 150,
+      phases: NO_PHASES,
     });
     expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineBoardDownloadCompleted, {
       scopeKey: 'kilter:1:5',
@@ -773,17 +815,24 @@ describe('snapshot-bootstrap bindings', () => {
       rowCount: 40_000,
       downloadMs: 800,
       importMs: 150,
+      ...NO_PHASE_PROPS,
       offlineEngineEnabled: false,
     });
 
     // A cross-cycle completion: absent, never zero — a 0 would read as a real
     // measurement of a download that took no time.
     trackMock.mockClear();
-    options.onScopeDownloadComplete?.({ scopeKey: 'kilter:1:6', method: 'snapshot', durationMs: 2000 });
+    options.onScopeDownloadComplete?.({
+      scopeKey: 'kilter:1:6',
+      method: 'snapshot',
+      durationMs: 2000,
+      phases: NO_PHASES,
+    });
     expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineBoardDownloadCompleted, {
       scopeKey: 'kilter:1:6',
       method: 'snapshot',
       durationMs: 2000,
+      ...NO_PHASE_PROPS,
       offlineEngineEnabled: false,
     });
   });
@@ -803,11 +852,12 @@ describe('snapshot-bootstrap bindings', () => {
     expect(customBootstrapError).toHaveBeenCalled();
     expect(reportHandledError).not.toHaveBeenCalled();
 
-    options.onScopeDownloadComplete?.({ scopeKey: 'kilter:1:5', method: 'paged', durationMs: 500 });
+    options.onScopeDownloadComplete?.({ scopeKey: 'kilter:1:5', method: 'paged', durationMs: 500, phases: NO_PHASES });
     expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineBoardDownloadCompleted, {
       scopeKey: 'kilter:1:5',
       method: 'paged',
       durationMs: 500,
+      ...NO_PHASE_PROPS,
       offlineEngineEnabled: false,
     });
 

--- a/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
+++ b/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
@@ -13,7 +13,7 @@ const state = vi.hoisted(() => ({
     options?: { intermediates?: boolean; idempotent?: boolean; overwrite?: boolean };
   }>,
   createDirectoryError: null as Error | null,
-  downloadCalls: [] as Array<{ url: string; idempotent?: boolean; hasOnProgress: boolean }>,
+  downloadCalls: [] as Array<{ url: string; idempotent?: boolean; hasOnProgress: boolean; hasSignal: boolean }>,
   // Byte frames the fake downloader replays into the injected onProgress, in
   // whatever scale a real platform would report (Android: decoded bytes,
   // totalBytes -1).
@@ -28,6 +28,10 @@ const state = vi.hoisted(() => ({
   // the body at all" path.
   readError: null as Error | null,
   deletedUris: [] as string[],
+  // A real in-memory filesystem, not a stub: artifact RETENTION (issue #4310)
+  // turns on file existence, sidecar contents, sizes, and mtimes, so a fake
+  // where `exists` is always true would prove nothing.
+  files: new Map<string, { text: string | null; bytes: Uint8Array; size: number; lastModified: number }>(),
 }));
 
 vi.mock('expo-file-system', () => {
@@ -40,12 +44,14 @@ vi.mock('expo-file-system', () => {
       if (state.createDirectoryError) throw state.createDirectoryError;
       state.createdDirectories.push({ path: this.path, options });
     }
+    list(): FakeFile[] {
+      const prefix = `file://${this.path}/`;
+      return [...state.files.keys()].filter((uri) => uri.startsWith(prefix)).map((uri) => new FakeFile(uri));
+    }
   }
 
   class FakeFile {
     uri: string;
-    exists = true;
-    bytes: Uint8Array = new Uint8Array();
 
     constructor(...parts: unknown[]) {
       const joined = parts
@@ -58,29 +64,64 @@ vi.mock('expo-file-system', () => {
       this.uri = joined.startsWith('file://') ? joined : `file://${joined}`;
     }
 
+    get exists() {
+      return state.files.has(this.uri);
+    }
+
+    get size() {
+      return state.files.get(this.uri)?.size ?? 0;
+    }
+
+    get lastModified() {
+      return state.files.get(this.uri)?.lastModified ?? null;
+    }
+
+    get bytes() {
+      return state.files.get(this.uri)?.bytes ?? new Uint8Array();
+    }
+
     static downloadFileAsync = vi.fn(
       async (
         url: string,
         destination: FakeFile,
         options?: {
           idempotent?: boolean;
-          onProgress?: (progress: { bytesWritten: number; totalBytes: number }) => void;
+          onProgress?: (data: { bytesWritten: number; totalBytes: number }) => void;
+          signal?: AbortSignal;
         },
       ) => {
         state.downloadCalls.push({
           url,
           idempotent: options?.idempotent,
           hasOnProgress: options?.onProgress !== undefined,
+          hasSignal: options?.signal !== undefined,
         });
-        if (state.downloadError) throw state.downloadError;
         for (const frame of state.downloadProgressFrames) options?.onProgress?.(frame);
-        destination.bytes = state.downloadBytes;
+        if (options?.signal?.aborted) throw new Error('AbortError: download cancelled');
+        if (state.downloadError) throw state.downloadError;
+        writeFakeFile(destination.uri, { bytes: state.downloadBytes, text: null });
         return destination;
       },
     );
 
+    create(_options?: { intermediates?: boolean; overwrite?: boolean }) {
+      writeFakeFile(this.uri, { bytes: new Uint8Array(), text: '' });
+    }
+
+    write(content: string) {
+      writeFakeFile(this.uri, { bytes: new Uint8Array(), text: content });
+    }
+
+    textSync(): string {
+      const entry = state.files.get(this.uri);
+      if (entry?.text == null) throw new Error(`no text at ${this.uri}`);
+      return entry.text;
+    }
+
     delete() {
+      if (!state.files.has(this.uri)) throw new Error(`no such file: ${this.uri}`);
       state.deletedUris.push(this.uri);
+      state.files.delete(this.uri);
     }
 
     readableStream() {
@@ -97,6 +138,15 @@ vi.mock('expo-file-system', () => {
         }),
       };
     }
+  }
+
+  function writeFakeFile(uri: string, content: { bytes: Uint8Array; text: string | null }): void {
+    state.files.set(uri, {
+      bytes: content.bytes,
+      text: content.text,
+      size: content.text !== null ? content.text.length : content.bytes.length,
+      lastModified: state.files.size + 1,
+    });
   }
 
   return {
@@ -169,7 +219,17 @@ beforeEach(() => {
   state.streamChunks = null;
   state.readError = null;
   state.deletedUris = [];
+  state.files.clear();
 });
+
+const ARTIFACT_URI = 'file://cache-root/board-snapshots/kilter-8-2026-06-01T00-00-00-000Z.db';
+const SIDECAR_URI = `${ARTIFACT_URI}.complete`;
+
+/** Seeds a retained artifact + its completeness sidecar, as a previous cycle would leave them. */
+function seedRetainedArtifact(uri: string, builtAt: string, sizeBytes = 1_000): void {
+  state.files.set(uri, { bytes: PLAIN_SQLITE_BYTES, text: null, size: sizeBytes, lastModified: 1 });
+  state.files.set(`${uri}.complete`, { bytes: new Uint8Array(), text: builtAt, size: builtAt.length, lastModified: 1 });
+}
 
 describe('fetchManifest', () => {
   it('fetches the manifest URL with cache: no-store and returns the parsed JSON on 200', async () => {
@@ -253,7 +313,7 @@ describe('downloadArtifact', () => {
     expect(state.createdDirectories).toEqual([
       { path: 'cache-root/board-snapshots', options: { intermediates: true, idempotent: true } },
     ]);
-    expect(state.downloadCalls).toEqual([{ url: ENTRY.url, idempotent: true, hasOnProgress: false }]);
+    expect(state.downloadCalls).toEqual([{ url: ENTRY.url, idempotent: true, hasOnProgress: false, hasSignal: false }]);
     expect(result).not.toBeNull();
     expect(result?.filePath.startsWith('file://')).toBe(false);
     expect(result?.filePath).toContain('kilter-8-2026-06-01T00-00-00-000Z.db');
@@ -265,7 +325,7 @@ describe('downloadArtifact', () => {
     // exactly — not merely discard the callback's output.
     await mobileSnapshotSource.downloadArtifact(ENTRY);
 
-    expect(state.downloadCalls).toEqual([{ url: ENTRY.url, idempotent: true, hasOnProgress: false }]);
+    expect(state.downloadCalls).toEqual([{ url: ENTRY.url, idempotent: true, hasOnProgress: false, hasSignal: false }]);
   });
 
   it('forwards platform byte frames and maps a non-positive totalBytes to null', async () => {
@@ -280,7 +340,7 @@ describe('downloadArtifact', () => {
 
     await mobileSnapshotSource.downloadArtifact(ENTRY, { onProgress: (frame) => frames.push(frame) });
 
-    expect(state.downloadCalls).toEqual([{ url: ENTRY.url, idempotent: true, hasOnProgress: true }]);
+    expect(state.downloadCalls).toEqual([{ url: ENTRY.url, idempotent: true, hasOnProgress: true, hasSignal: false }]);
     expect(frames).toEqual([
       { bytesWritten: 1_000, totalBytes: null },
       { bytesWritten: 2_000, totalBytes: null },
@@ -412,8 +472,152 @@ describe('downloadArtifact', () => {
 });
 
 describe('deleteArtifact', () => {
-  it('deletes the file at the given plain path, best-effort', async () => {
+  it('deletes the file AND its completeness sidecar at the given plain path, best-effort', async () => {
+    seedRetainedArtifact('file:///cache/board-snapshots/kilter-8.db', ENTRY.builtAt);
+
     await mobileSnapshotSource.deleteArtifact('/cache/board-snapshots/kilter-8.db');
-    expect(state.deletedUris).toEqual(['file:///cache/board-snapshots/kilter-8.db']);
+
+    expect(new Set(state.deletedUris)).toEqual(
+      new Set(['file:///cache/board-snapshots/kilter-8.db', 'file:///cache/board-snapshots/kilter-8.db.complete']),
+    );
+  });
+
+  it('is a no-op when the file is already gone', async () => {
+    await mobileSnapshotSource.deleteArtifact('/cache/board-snapshots/kilter-8.db');
+    expect(state.deletedUris).toEqual([]);
+  });
+});
+
+// Artifact retention (issue #4310). Before this, `runBootstrapPhase` deleted
+// every downloaded artifact in a `finally`, so locking the phone mid-cycle threw
+// away a 103 MB Kilter download and started it again on the next wake.
+describe('retention and reuse', () => {
+  it('writes a completeness sidecar naming the artifact build only after the gzip sniff passes', async () => {
+    await mobileSnapshotSource.downloadArtifact(ENTRY);
+
+    expect(state.files.get(SIDECAR_URI)?.text).toBe(ENTRY.builtAt);
+  });
+
+  it('does NOT write a sidecar when the body arrived still gzip-compressed', async () => {
+    state.downloadBytes = GZIP_BYTES;
+
+    await expect(mobileSnapshotSource.downloadArtifact(ENTRY)).rejects.toThrow(SnapshotPermanentMissError);
+
+    expect(state.files.has(SIDECAR_URI)).toBe(false);
+  });
+
+  it('reuses a retained artifact for the same build with no network call at all', async () => {
+    seedRetainedArtifact(ARTIFACT_URI, ENTRY.builtAt);
+
+    const result = await mobileSnapshotSource.downloadArtifact(ENTRY);
+
+    expect(state.downloadCalls).toHaveLength(0);
+    expect(result?.reused).toBe(true);
+    expect(result?.filePath).toBe(ARTIFACT_URI.replace('file://', ''));
+  });
+
+  it('re-downloads a retained file that has NO sidecar — a half-written body is never reused', async () => {
+    state.files.set(ARTIFACT_URI, { bytes: PLAIN_SQLITE_BYTES, text: null, size: 12, lastModified: 1 });
+
+    const result = await mobileSnapshotSource.downloadArtifact(ENTRY);
+
+    expect(state.downloadCalls).toHaveLength(1);
+    expect(result?.reused).toBeUndefined();
+  });
+
+  it('re-downloads when the sidecar names a DIFFERENT build than the manifest asks for', async () => {
+    seedRetainedArtifact(ARTIFACT_URI, '2026-05-01T00:00:00.000Z');
+
+    await mobileSnapshotSource.downloadArtifact(ENTRY);
+
+    expect(state.downloadCalls).toHaveLength(1);
+  });
+
+  it('sweeps a superseded build of the same board+layout once the new one lands', async () => {
+    const supersededUri = 'file://cache-root/board-snapshots/kilter-8-2026-05-01T00-00-00-000Z.db';
+    seedRetainedArtifact(supersededUri, '2026-05-01T00:00:00.000Z');
+
+    await mobileSnapshotSource.downloadArtifact(ENTRY);
+
+    expect(state.files.has(supersededUri)).toBe(false);
+    expect(state.files.has(ARTIFACT_URI)).toBe(true);
+  });
+
+  it('keeps a DIFFERENT layout’s retained artifact — retention is per (board, layout)', async () => {
+    const otherLayoutUri = 'file://cache-root/board-snapshots/tension-9-2026-05-01T00-00-00-000Z.db';
+    seedRetainedArtifact(otherLayoutUri, '2026-05-01T00:00:00.000Z');
+
+    await mobileSnapshotSource.downloadArtifact(ENTRY);
+
+    expect(state.files.has(otherLayoutUri)).toBe(true);
+  });
+
+  it('evicts oldest-first once retained artifacts exceed the byte budget', async () => {
+    const oldest = 'file://cache-root/board-snapshots/tension-9-2026-01-01T00-00-00-000Z.db';
+    const newer = 'file://cache-root/board-snapshots/moonboard-2-2026-04-01T00-00-00-000Z.db';
+    seedRetainedArtifact(oldest, '2026-01-01T00:00:00.000Z', 300 * 1024 * 1024);
+    seedRetainedArtifact(newer, '2026-04-01T00:00:00.000Z', 300 * 1024 * 1024);
+    state.files.get(oldest)!.lastModified = 1;
+    state.files.get(newer)!.lastModified = 2;
+
+    await mobileSnapshotSource.downloadArtifact(ENTRY);
+
+    expect(state.files.has(oldest)).toBe(false);
+    expect(state.files.has(newer)).toBe(true);
+  });
+
+  it('counts the artifact it just downloaded against the budget', async () => {
+    // A survivor that exactly fills the 400 MB budget leaves no room for the
+    // file this cycle downloaded — which is retained too whenever the cycle is
+    // cut short before the import. Excluding it would let the directory settle
+    // at budget-plus-one-artifact.
+    const filling = 'file://cache-root/board-snapshots/tension-9-2026-01-01T00-00-00-000Z.db';
+    seedRetainedArtifact(filling, '2026-01-01T00:00:00.000Z', 400 * 1024 * 1024);
+
+    await mobileSnapshotSource.downloadArtifact(ENTRY);
+
+    expect(state.files.has(filling)).toBe(false);
+    expect(state.files.has(ARTIFACT_URI)).toBe(true);
+  });
+
+  it('retains nothing but the fresh artifact when free space is under the floor', async () => {
+    const otherLayoutUri = 'file://cache-root/board-snapshots/tension-9-2026-05-01T00-00-00-000Z.db';
+    seedRetainedArtifact(otherLayoutUri, '2026-05-01T00:00:00.000Z');
+    // Above the 6x download requirement for a 1 MB entry, below the 1.5 GB
+    // retention floor.
+    state.availableDiskSpace = 900 * 1024 * 1024;
+
+    await mobileSnapshotSource.downloadArtifact(ENTRY);
+
+    expect(state.files.has(otherLayoutUri)).toBe(false);
+    expect(state.files.has(ARTIFACT_URI)).toBe(true);
+  });
+
+  it('passes the caller’s AbortSignal through so a torn-down cycle cancels the transfer', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(mobileSnapshotSource.downloadArtifact(ENTRY, { signal: controller.signal })).rejects.toThrow(
+      /downloadFileAsync failed/,
+    );
+    expect(state.downloadCalls[0].hasSignal).toBe(true);
+  });
+
+  it('releaseArtifact deletes an IMPORTED artifact — its rows are in the database now', async () => {
+    seedRetainedArtifact(ARTIFACT_URI, ENTRY.builtAt);
+
+    await mobileSnapshotSource.releaseArtifact?.(ARTIFACT_URI.replace('file://', ''), { imported: true });
+
+    expect(state.files.has(ARTIFACT_URI)).toBe(false);
+    expect(state.files.has(SIDECAR_URI)).toBe(false);
+  });
+
+  it('releaseArtifact KEEPS an unimported artifact so the next cycle reuses it', async () => {
+    seedRetainedArtifact(ARTIFACT_URI, ENTRY.builtAt);
+
+    await mobileSnapshotSource.releaseArtifact?.(ARTIFACT_URI.replace('file://', ''), { imported: false });
+
+    expect(state.files.has(ARTIFACT_URI)).toBe(true);
+    expect(state.files.has(SIDECAR_URI)).toBe(true);
   });
 });

--- a/packages/mobile/src/offline/__tests__/use-board-downloads.test.tsx
+++ b/packages/mobile/src/offline/__tests__/use-board-downloads.test.tsx
@@ -2,7 +2,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { cleanup, renderHook } from '@testing-library/react';
-import type { BootstrapMetadataChangedInfo, ScopeDownloadCompleteInfo } from '@boardsesh/offline-sync';
+import {
+  emptyScopeDownloadPhases,
+  type BootstrapMetadataChangedInfo,
+  type ScopeDownloadCompleteInfo,
+} from '@boardsesh/offline-sync';
 import type { UserBoard } from '@boardsesh/shared-schema';
 
 const fixtures = vi.hoisted(() => ({
@@ -89,8 +93,18 @@ describe('useBoardDownloads', () => {
 
     syncOptions?.onBootstrapMetadataChanged?.({ scopeKey: 'kilter:1:10' });
     syncOptions?.onBootstrapMetadataChanged?.({ scopeKey: 'tension:2:11' });
-    syncOptions?.onScopeDownloadComplete?.({ scopeKey: 'kilter:1:10', method: 'snapshot', durationMs: 12 });
-    syncOptions?.onScopeDownloadComplete?.({ scopeKey: 'tension:2:11', method: 'paged', durationMs: 34 });
+    syncOptions?.onScopeDownloadComplete?.({
+      scopeKey: 'kilter:1:10',
+      method: 'snapshot',
+      durationMs: 12,
+      phases: emptyScopeDownloadPhases(),
+    });
+    syncOptions?.onScopeDownloadComplete?.({
+      scopeKey: 'tension:2:11',
+      method: 'paged',
+      durationMs: 34,
+      phases: emptyScopeDownloadPhases(),
+    });
 
     expect(getSyncStatusSnapshot().bootstrapMetadataRevision).toBe(2);
     expect(getSyncStatusSnapshot().scopeCompletionRevision).toBe(2);

--- a/packages/mobile/src/offline/offline-sync-adapter.ts
+++ b/packages/mobile/src/offline/offline-sync-adapter.ts
@@ -182,6 +182,15 @@ const reportSnapshotBootstrapError: SnapshotBootstrapErrorReporter = ({
 // Fired once per board scope's initial download so the snapshot-bootstrap
 // warm-up can be compared against the plain paged crawl in the field (which
 // path actually got used, and how long it took).
+// The phase breakdown rides on THIS event rather than a new one (issue #4310):
+// the question it answers — "of a 2m55s Kilter download, how much is the
+// artifact and how much is the grades crawl behind it?" — is a property of the
+// download that just completed, and splitting it across two events would make
+// every funnel query a join. Only the phases NOT already carried by the
+// per-scope timings above are emitted: `phases` also holds cycle-scoped copies
+// of download/import/artifact bytes, and the timings' absent-when-unknown
+// versions are the honest ones (a 0 from a later-cycle completion would read as
+// a real measurement).
 const reportScopeDownloadComplete: ScopeDownloadCompleteReporter = ({
   scopeKey,
   method,
@@ -190,6 +199,7 @@ const reportScopeDownloadComplete: ScopeDownloadCompleteReporter = ({
   rowCount,
   downloadMs,
   importMs,
+  phases,
 }) => {
   track(SHARED_EVENTS.OfflineBoardDownloadCompleted, {
     scopeKey,
@@ -202,6 +212,12 @@ const reportScopeDownloadComplete: ScopeDownloadCompleteReporter = ({
     ...(rowCount === undefined ? {} : { rowCount }),
     ...(downloadMs === undefined ? {} : { downloadMs }),
     ...(importMs === undefined ? {} : { importMs }),
+    manifestMs: phases.manifestMs,
+    artifactReused: phases.artifactReused,
+    climbsPullMs: phases.climbsPullMs,
+    statsPullMs: phases.statsPullMs,
+    gradesPullMs: phases.gradesPullMs,
+    gradesRows: phases.gradesRows,
     // Stamped so the funnel stays readable once #4312 bakes the flag on: the
     // engine gate, not the raw flag value.
     offlineEngineEnabled: isOfflineEngineEnabled(),

--- a/packages/mobile/src/offline/snapshot-source.ts
+++ b/packages/mobile/src/offline/snapshot-source.ts
@@ -27,21 +27,43 @@
 // failure landed as a Sentry `error`).
 
 import { Directory, File, Paths } from 'expo-file-system';
-import { SnapshotPermanentMissError, type SnapshotManifestEntry, type SnapshotSource } from '@boardsesh/offline-sync';
+import {
+  SnapshotPermanentMissError,
+  type SnapshotArtifactHandle,
+  type SnapshotDownloadOptions,
+  type SnapshotManifestEntry,
+  type SnapshotSource,
+} from '@boardsesh/offline-sync';
 import { SNAPSHOT_BASE_URL } from '../lib/env';
 import { reportHandledError } from '../lib/error-reporting';
 
 const MANIFEST_URL = `${SNAPSHOT_BASE_URL}/manifest.json`;
 
 // Cache-dir subfolder for downloaded artifacts. The engine ATTACHes the file,
-// imports the scope's rows, then calls `deleteArtifact` once it's done with
-// it (in a `finally`) — nothing here is meant to persist across app launches,
-// so the OS is also free to reclaim it under storage pressure (Paths.cache,
-// not Paths.document).
+// imports the scope's rows, then hands it back through `releaseArtifact`.
+// Since issue #4310 a file the engine did NOT import survives to the next
+// cycle (see the retention notes below), but it still lives under Paths.cache,
+// not Paths.document: the OS may reclaim it under storage pressure and losing
+// it costs a re-download, never data.
 // Exported so the cache sweeper (lib/sweep-caches.ts) reaps artifacts leaked by
 // a kill mid-bootstrap from the same directory this writes to, rather than
 // re-literalling the name and silently sweeping nothing if it ever moves.
 export const SNAPSHOT_DIR_NAME = 'board-snapshots';
+
+// Written next to `<artifact>.db` once the download AND the gzip sniff have
+// both passed, holding the artifact's `builtAt`. Retention is only useful if a
+// half-written file can never be reused — the file's own size is no help
+// (`entry.bytes` is the STORED gzip size, the file on disk is decompressed),
+// so the sidecar is the completeness proof. No sidecar → re-download.
+const COMPLETE_SIDECAR_SUFFIX = '.complete';
+
+// How much of the cache directory retained artifacts may occupy, and the free
+// space below which retention is abandoned entirely. Retaining a Kilter
+// artifact is ~271 MB decompressed, which is worth it (it saves re-downloading
+// 103 MB over a phone connection) but only while the device can spare it —
+// offline mode's storage footprint is already a live complaint (issue #3647).
+const RETENTION_BUDGET_BYTES = 400 * 1024 * 1024;
+const RETENTION_FREE_SPACE_FLOOR_BYTES = 1.5 * 1024 * 1024 * 1024;
 
 // Identity artifacts are already stored as SQLite files, so they only need room
 // for the download plus write overhead. Gzip artifacts may temporarily require
@@ -136,6 +158,121 @@ function safeDeleteFile(file: File): void {
   }
 }
 
+// --- Retention (issue #4310) --------------------------------------------------
+
+function sidecarFor(artifact: File): File {
+  return new File(`${artifact.uri}${COMPLETE_SIDECAR_SUFFIX}`);
+}
+
+/** Delete an artifact and its completeness sidecar together — never one alone. */
+function deleteArtifactWithSidecar(artifact: File): void {
+  safeDeleteFile(sidecarFor(artifact));
+  safeDeleteFile(artifact);
+}
+
+/**
+ * True when this exact file was fully downloaded and verified in an earlier
+ * cycle: the sidecar exists AND names the same `builtAt` the manifest is asking
+ * for. A filename match alone is not enough — a crash between `create` and the
+ * first byte leaves a plausible-looking name over an empty file.
+ */
+function hasCompleteSidecar(artifact: File, builtAt: string): boolean {
+  try {
+    const sidecar = sidecarFor(artifact);
+    if (!sidecar.exists) return false;
+    return sidecar.textSync().trim() === builtAt;
+  } catch {
+    return false;
+  }
+}
+
+function writeCompleteSidecar(artifact: File, builtAt: string): void {
+  try {
+    const sidecar = sidecarFor(artifact);
+    sidecar.create({ overwrite: true, intermediates: true });
+    sidecar.write(builtAt);
+  } catch {
+    // A missing sidecar only costs a re-download next cycle; never fail the
+    // import over it.
+  }
+}
+
+/**
+ * Drop retained artifacts that no longer earn their space: anything for a
+ * DIFFERENT build of the same (board, layout) than the one just downloaded
+ * (superseded — the manifest will never ask for it again), and then, oldest
+ * first, whatever it takes to get under the byte budget. Called after each
+ * successful download, so the budget is enforced at the moment the directory
+ * grows rather than on a timer.
+ *
+ * `keep` — the file this cycle just downloaded — is never evicted (the import is
+ * about to read it) but DOES count against the budget. A cycle cut short retains
+ * it like any other artifact, so excluding it would let the directory settle at
+ * budget-plus-one-artifact: a 350 MB survivor passes a 400 MB budget, a 271 MB
+ * Kilter file is then retained beside it, and the "400 MB" cap holds 621 MB.
+ *
+ * Coordination note for the image/thumbnail cache sweeper (issue #3647): this
+ * directory owns its own budget. A sweeper that also deletes here would
+ * silently reintroduce "backgrounding costs you the whole download".
+ */
+function sweepRetainedArtifacts(keep: File): void {
+  let entries: (File | Directory)[];
+  try {
+    entries = snapshotDirectory().list();
+  } catch {
+    return;
+  }
+
+  const artifacts: File[] = [];
+  for (const entry of entries) {
+    if (!(entry instanceof File)) continue;
+    if (entry.uri.endsWith(COMPLETE_SIDECAR_SUFFIX)) continue;
+    artifacts.push(entry);
+  }
+
+  // Below the free-space floor, retention stops being a kindness — nothing is
+  // kept except the artifact this cycle is about to import.
+  const belowFreeSpaceFloor = Paths.availableDiskSpace < RETENTION_FREE_SPACE_FLOOR_BYTES;
+
+  const keepPrefix = artifactNamePrefix(keep.uri);
+  const survivors: { file: File; size: number; modifiedAt: number }[] = [];
+  for (const artifact of artifacts) {
+    if (artifact.uri === keep.uri) continue;
+    // Same (board, layout), different build stamp → the manifest has moved on.
+    const isSuperseded = keepPrefix !== null && artifactNamePrefix(artifact.uri) === keepPrefix;
+    if (belowFreeSpaceFloor || isSuperseded) {
+      deleteArtifactWithSidecar(artifact);
+      continue;
+    }
+    survivors.push({
+      file: artifact,
+      size: artifact.size,
+      modifiedAt: artifact.lastModified ?? 0,
+    });
+  }
+
+  // Starts at the kept file's own size — see the note above.
+  let retainedBytes = survivors.reduce((total, survivor) => total + survivor.size, keep.size);
+  if (retainedBytes <= RETENTION_BUDGET_BYTES) return;
+  survivors.sort((left, right) => left.modifiedAt - right.modifiedAt);
+  for (const survivor of survivors) {
+    if (retainedBytes <= RETENTION_BUDGET_BYTES) break;
+    deleteArtifactWithSidecar(survivor.file);
+    retainedBytes -= survivor.size;
+  }
+}
+
+/**
+ * `<board>-<layout>` from a `<board>-<layout>-<builtAt>.db` artifact URI, or
+ * null when the name doesn't match — an unrecognised file is left alone rather
+ * than guessed at.
+ */
+function artifactNamePrefix(uri: string): string | null {
+  const name = uri.slice(uri.lastIndexOf('/') + 1);
+  const match = name.match(/^([a-z0-9]+-\d+)-/i);
+  return match ? match[1] : null;
+}
+
 /**
  * Fetch the manifest JSON. Returns `null` only when the manifest is genuinely
  * absent or unparseable (permanent miss this cycle, no attempt). HTTP outages
@@ -177,8 +314,8 @@ function formatError(error: unknown): string {
  */
 async function downloadArtifact(
   entry: SnapshotManifestEntry,
-  options?: { onProgress?: (progress: { bytesWritten: number; totalBytes: number | null }) => void },
-): Promise<{ filePath: string } | null> {
+  options?: SnapshotDownloadOptions,
+): Promise<SnapshotArtifactHandle | null> {
   const requiredBytes = requiredFreeBytes(entry);
   const availableBytes = Paths.availableDiskSpace;
   if (availableBytes < requiredBytes) {
@@ -201,6 +338,19 @@ async function downloadArtifact(
   const safeBuiltAt = entry.builtAt.replace(/[^a-zA-Z0-9]/g, '-');
   const destination = new File(directory, `${entry.boardType}-${entry.layoutId}-${safeBuiltAt}.db`);
 
+  // A retained artifact from an earlier cycle, complete and for this exact
+  // build: hand it straight back. The engine still runs quick_check and
+  // verifySnapshotMeta over it before importing a single row, and treats an
+  // import failure on a reused file as delete-and-refetch rather than a counted
+  // bootstrap attempt — so trusting the sidecar here cannot strand a scope.
+  if (destination.exists && hasCompleteSidecar(destination, entry.builtAt)) {
+    return { filePath: toSqlitePath(destination.uri), reused: true };
+  }
+  // A file with no (or a mismatched) sidecar is a half-written download, not a
+  // shortcut. Clear it so `idempotent: true` below never writes over a body it
+  // cannot verify.
+  if (destination.exists) deleteArtifactWithSidecar(destination);
+
   let downloaded: File;
   try {
     // `onProgress` is only passed when the caller asked for it (the engine
@@ -208,13 +358,15 @@ async function downloadArtifact(
     // expo-file-system take a different native download implementation — an
     // 8 KB streaming copy loop on Android, a delegate-driven URLSession on iOS
     // — rather than its plain path. Omitting it keeps the call byte-identical
-    // to the pre-#4311 one.
+    // to the pre-#4311 one. `signal` rides both shapes: it only cancels the
+    // transfer and does not switch implementations.
     downloaded = await File.downloadFileAsync(
       entry.url,
       destination,
       options?.onProgress
         ? {
             idempotent: true,
+            signal: options.signal,
             onProgress: ({ bytesWritten, totalBytes }) => {
               // Android reports -1 for a gzip body (OkHttp gunzips transparently,
               // so Content-Length is meaningless); the engine expects null for
@@ -222,7 +374,7 @@ async function downloadArtifact(
               options.onProgress?.({ bytesWritten, totalBytes: totalBytes > 0 ? totalBytes : null });
             },
           }
-        : { idempotent: true },
+        : { idempotent: true, signal: options?.signal },
     );
   } catch (error) {
     throw new Error(
@@ -265,15 +417,32 @@ async function downloadArtifact(
     }
   }
 
+  // Only now is the file provably complete AND decoded, so only now may a
+  // later cycle reuse it.
+  writeCompleteSidecar(downloaded, entry.builtAt);
+  sweepRetainedArtifacts(downloaded);
+
   return { filePath: toSqlitePath(downloaded.uri) };
 }
 
 async function deleteArtifact(filePath: string): Promise<void> {
-  safeDeleteFile(new File(toFileUri(filePath)));
+  deleteArtifactWithSidecar(new File(toFileUri(filePath)));
+}
+
+/**
+ * The engine is done with this artifact for the cycle. Imported → delete it,
+ * the rows are in the database now. NOT imported → keep it: the cycle was cut
+ * short (backgrounded, wiped, another scope failed) and re-downloading 103 MB
+ * on the next wake is the failure this retention exists to remove (issue
+ * #4310). The budget sweep already ran at download time.
+ */
+async function releaseArtifact(filePath: string, options: { imported: boolean }): Promise<void> {
+  if (options.imported) deleteArtifactWithSidecar(new File(toFileUri(filePath)));
 }
 
 export const mobileSnapshotSource: SnapshotSource = {
   fetchManifest,
   downloadArtifact,
   deleteArtifact,
+  releaseArtifact,
 };

--- a/packages/mobile/src/sync/__tests__/sync-status.test.ts
+++ b/packages/mobile/src/sync/__tests__/sync-status.test.ts
@@ -6,7 +6,7 @@ import {
   getSyncStatusSnapshot,
   __resetSyncStatusForTests,
 } from '../sync-status';
-import type { SyncProgress } from '@boardsesh/offline-sync';
+import { emptyScopeDownloadPhases, type SyncProgress } from '@boardsesh/offline-sync';
 
 // Store is React-free apart from the hook, so it's exercised through
 // setSyncProgress + getSyncStatusSnapshot directly. useSyncStatus is a thin
@@ -110,7 +110,12 @@ describe('sync-status store', () => {
       currentTable: 'board_climbs:kilter:1:5',
       documentsProcessed: 100,
     });
-    notifyScopeDownloadComplete({ scopeKey: 'kilter:1:5', method: 'paged', durationMs: 100 });
+    notifyScopeDownloadComplete({
+      scopeKey: 'kilter:1:5',
+      method: 'paged',
+      durationMs: 100,
+      phases: emptyScopeDownloadPhases(),
+    });
 
     const afterFirstScope = getSyncStatusSnapshot();
     expect(afterFirstScope.scopeCompletionRevision).toBe(1);
@@ -122,7 +127,12 @@ describe('sync-status store', () => {
       currentTable: 'board_climbs:tension:2:10',
       documentsProcessed: 200,
     });
-    notifyScopeDownloadComplete({ scopeKey: 'tension:2:10', method: 'paged', durationMs: 200 });
+    notifyScopeDownloadComplete({
+      scopeKey: 'tension:2:10',
+      method: 'paged',
+      durationMs: 200,
+      phases: emptyScopeDownloadPhases(),
+    });
     expect(getSyncStatusSnapshot().scopeCompletionRevision).toBe(2);
   });
 });

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -66,7 +66,7 @@ export {
 } from './mutation-queue/error-classification';
 
 // --- Pull sync -----------------------------------------------------------------
-export { pullSync, toSqliteValue, multiRowChunkSize } from './sync/pull-client';
+export { pullSync, toSqliteValue, multiRowChunkSize, emptyScopeDownloadPhases } from './sync/pull-client';
 export type {
   SyncProgress,
   SyncOptions,
@@ -77,6 +77,7 @@ export type {
   ScopeDownloadCompleteReporter,
   ScopeDownloadStartInfo,
   ScopeDownloadStartReporter,
+  ScopeDownloadPhaseBreakdown,
   CoverageResetInfo,
   CoverageResetReporter,
   CoverageEvaluatedInfo,
@@ -110,6 +111,9 @@ export {
 } from './sync/snapshot-bootstrap';
 export type {
   SnapshotSource,
+  SnapshotArtifactHandle,
+  SnapshotDownloadOptions,
+  SnapshotDownloadProgress,
   SnapshotBootstrapResult,
   SnapshotBootstrapErrorReporter,
   BootstrapScopeMetadata,

--- a/packages/shared/offline-sync/src/mutation-queue/drainer.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/drainer.ts
@@ -28,9 +28,44 @@ let _isSigningOut = false;
 // operations capture the epoch at start and abort when it has moved.
 let _wipeEpoch = 0;
 
+/**
+ * Fired the instant a teardown transition happens — sign-out starts, a local
+ * purge bumps the epoch, or the app goes to background.
+ *
+ * Everything else in the engine POLLS the three guards below across its awaits,
+ * which is enough for a loop that keeps reaching one. A single native artifact
+ * download does not: it can sit for minutes inside one `await` with no progress
+ * event to poll from (a stalled connection sends nothing), so the transfer would
+ * keep running over a metered link long after the cycle was torn down. Those
+ * callers subscribe instead of polling. Listeners must never throw and must
+ * never assume they run once — a listener that reads the guards itself gets the
+ * truth regardless of which transition woke it.
+ */
+const teardownListeners = new Set<() => void>();
+
+export function onTeardown(listener: () => void): () => void {
+  teardownListeners.add(listener);
+  return () => {
+    teardownListeners.delete(listener);
+  };
+}
+
+function notifyTeardown(): void {
+  // Snapshot first: a listener that unsubscribes itself must not mutate the set
+  // being iterated.
+  for (const listener of [...teardownListeners]) {
+    try {
+      listener();
+    } catch {
+      // A broken listener must never stop sign-out, a purge, or backgrounding.
+    }
+  }
+}
+
 export function setSigningOut(value: boolean): void {
   if (value && !_isSigningOut) _wipeEpoch += 1;
   _isSigningOut = value;
+  if (value) notifyTeardown();
 }
 
 /**
@@ -58,6 +93,7 @@ export function setSigningOut(value: boolean): void {
  */
 export function beginLocalPurge(): void {
   _wipeEpoch += 1;
+  notifyTeardown();
 }
 
 // Read by the pull client too: an in-flight pullSync page must stop writing the
@@ -75,7 +111,9 @@ export function getWipeEpoch(): number {
 let _isBackgrounded = false;
 
 export function setBackgrounded(value: boolean): void {
+  const wasBackgrounded = _isBackgrounded;
   _isBackgrounded = value;
+  if (value && !wasBackgrounded) notifyTeardown();
 }
 
 export function isBackgrounded(): boolean {
@@ -429,4 +467,6 @@ export function __resetDrainerStateForTests(): void {
   // Epoch checks are relative (capture-then-compare), so a residual value is
   // technically harmless — reset anyway so no test inherits another's wipes.
   _wipeEpoch = 0;
+  // A listener leaked by an aborted run would otherwise fire into the next test.
+  teardownListeners.clear();
 }

--- a/packages/shared/offline-sync/src/sync/__tests__/checkpoints.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/checkpoints.test.ts
@@ -12,6 +12,7 @@ import {
   markScopeDownloadComplete,
   isScopeDownloadComplete,
   getDownloadedScopeKeys,
+  ensureScopeDownloadStartedAt,
 } from '../checkpoints';
 import type { SyncCheckpoint } from '../checkpoints';
 import { getDeletionsCoverageAt, setDeletionsCoverageAt } from '../deletions-coverage';
@@ -239,5 +240,58 @@ describe('deleteAllSyncMeta', () => {
     const after = await db.getFirstAsync<{ count: number }>('SELECT COUNT(*) AS count FROM schema_version');
     expect(after?.count).toBe(before?.count);
     expect(after?.count).toBeGreaterThan(0);
+  });
+});
+
+// The persisted per-scope download start stamp (issue #4310). Before it, the
+// start time lived in a Map created per `pullSync` run, so a download that
+// spanned cycles — the normal shape for a 100 MB artifact on a phone that
+// backgrounds once — reported only the final cycle's slice as `durationMs`.
+describe('scope download start stamp', () => {
+  let db: TestSqliteDb;
+
+  beforeEach(async () => {
+    db = createTestDatabase();
+    await runMigrations(db);
+  });
+
+  it('records the first start and returns the SAME instant on every later cycle', async () => {
+    const first = await ensureScopeDownloadStartedAt(db, 'kilter:1:5', 1_000);
+    const second = await ensureScopeDownloadStartedAt(db, 'kilter:1:5', 9_000);
+
+    expect(first).toBe(1_000);
+    expect(second).toBe(1_000);
+  });
+
+  it('scopes the stamp per board — one download never times another', async () => {
+    await ensureScopeDownloadStartedAt(db, 'kilter:1:5', 1_000);
+
+    expect(await ensureScopeDownloadStartedAt(db, 'tension:9:11', 5_000)).toBe(5_000);
+  });
+
+  it('is cleared by markScopeDownloadComplete so a later re-download times itself', async () => {
+    await ensureScopeDownloadStartedAt(db, 'kilter:1:5', 1_000);
+
+    await markScopeDownloadComplete(db, 'kilter:1:5');
+
+    expect(await ensureScopeDownloadStartedAt(db, 'kilter:1:5', 7_000)).toBe(7_000);
+  });
+
+  it('is cleared on sign-out — it is not a `checkpoint:` key, so the wipe must name it', async () => {
+    // Left behind, a departing account's stamp is read by the NEXT account
+    // months later and reports a multi-week download duration.
+    await ensureScopeDownloadStartedAt(db, 'kilter:1:5', 1_000);
+
+    await deleteUserCheckpoints(db);
+
+    expect(await ensureScopeDownloadStartedAt(db, 'kilter:1:5', 7_000)).toBe(7_000);
+  });
+
+  it('survives a checkpoint-only wipe, which must not reach past its own prefix', async () => {
+    await ensureScopeDownloadStartedAt(db, 'kilter:1:5', 1_000);
+
+    await deleteAllCheckpoints(db);
+
+    expect(await ensureScopeDownloadStartedAt(db, 'kilter:1:5', 7_000)).toBe(1_000);
   });
 });

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
@@ -11,6 +11,9 @@ vi.mock('../checkpoints', () => ({
   isScopeDownloadComplete: vi.fn().mockResolvedValue(false),
   markScopeDownloadStarted: vi.fn().mockResolvedValue(undefined),
   isScopeDownloadStarted: vi.fn().mockResolvedValue(false),
+  // Returns the `nowMs` it was handed, i.e. behaves like a first stamp.
+  ensureScopeDownloadStartedAt: vi.fn(async (_db: unknown, _scopeKey: string, nowMs: number) => nowMs),
+  SCOPE_DOWNLOAD_START_MAX_AGE_MS: 24 * 60 * 60 * 1000,
   rewindDeletionsCheckpoint: vi.fn().mockResolvedValue(undefined),
   compareCheckpoints: vi.fn().mockReturnValue(0),
   DELETIONS_CHECKPOINT_KEY: 'checkpoint:deletions',

--- a/packages/shared/offline-sync/src/sync/__tests__/scope-teardown.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/scope-teardown.test.ts
@@ -250,6 +250,14 @@ describe('removeBoardScopeData — markers', () => {
       `bootstrap-retry:${scopeKey}`,
       JSON.stringify({ transportFailures: 3, structuralFailures: 2, retryAfter: 1_800_000_000_000 }),
     ]);
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      `scope-download-started:${scopeKey}`,
+      String(Date.now()),
+    ]);
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      `reused-import-failed:${scopeKey}`,
+      '2026-08-11T02:00:00Z',
+    ]);
   }
 
   // Rows and markers must die together. A surviving checkpoint means the strict `>`
@@ -302,7 +310,7 @@ describe('removeBoardScopeData — markers', () => {
   // what "a scope's downloaded state" consists of. Adding a marker here should mean
   // deliberately updating this list (and `seedMarkers` above, which proves the
   // teardown actually clears each one), not nudging a magic number.
-  it('is exactly the scope’s checkpoints plus its six markers', async () => {
+  it('is exactly the scope’s checkpoints plus its eight markers', async () => {
     const keys = scopeSyncMetaKeys('kilter:1:5');
 
     expect(new Set(keys)).toEqual(
@@ -319,6 +327,8 @@ describe('removeBoardScopeData — markers', () => {
         'bootstrap-done:kilter:1:5',
         'bootstrap-paged-fallback:kilter:1:5',
         'bootstrap-retry:kilter:1:5',
+        'scope-download-started:kilter:1:5',
+        'reused-import-failed:kilter:1:5',
       ]),
     );
   });

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -2840,3 +2840,402 @@ describe('pullSync onScopeDownloadStart', () => {
     expect(info.importMs).toBeUndefined();
   });
 });
+
+// Artifact retention, reuse, and phase telemetry (issue #4310)
+// ---------------------------------------------------------------------------
+
+/** A source that records how each artifact was released and can serve retained files. */
+function makeRetainingSource(config: {
+  manifest: SnapshotManifest;
+  fileForEntry: (entry: SnapshotManifestEntry) => string | null;
+  /** Files the previous cycle left on disk, returned with `reused: true`. */
+  retained?: Set<string>;
+}) {
+  const released: Array<{ filePath: string; imported: boolean }> = [];
+  const deleted: string[] = [];
+  const downloadedUrls: string[] = [];
+  const signals: (AbortSignal | undefined)[] = [];
+  const source = {
+    fetchManifest: vi.fn(async () => config.manifest),
+    downloadArtifact: vi.fn(async (entry: SnapshotManifestEntry, options?: { signal?: AbortSignal }) => {
+      const filePath = config.fileForEntry(entry);
+      if (!filePath) return null;
+      signals.push(options?.signal);
+      if (config.retained?.has(filePath)) return { filePath, reused: true };
+      downloadedUrls.push(entry.url);
+      return { filePath };
+    }),
+    deleteArtifact: vi.fn(async (filePath: string) => {
+      deleted.push(filePath);
+    }),
+    releaseArtifact: vi.fn(async (filePath: string, options: { imported: boolean }) => {
+      released.push({ filePath, imported: options.imported });
+    }),
+  };
+  return { source: source as unknown as SnapshotSource, released, deleted, downloadedUrls, signals };
+}
+
+describe('artifact release and reuse', () => {
+  it('releases an imported artifact with imported: true', async () => {
+    const filePath = join(workDir, 'released-imported.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const { source, released, deleted } = makeRetainingSource({
+      manifest: makeManifest([makeEntry()]),
+      fileForEntry: () => filePath,
+    });
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+    });
+
+    expect(released).toEqual([{ filePath, imported: true }]);
+    expect(deleted).toEqual([]);
+  });
+
+  it('releases a NEVER-IMPORTED artifact with imported: false so retention can keep it', async () => {
+    // Backgrounding after the download but before the import used to delete a
+    // 103 MB file in the phase's `finally` and start over on the next wake.
+    const filePath = join(workDir, 'released-unimported.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const { source, released } = makeRetainingSource({
+      manifest: makeManifest([makeEntry()]),
+      fileForEntry: () => filePath,
+    });
+    const backgroundingSource: SnapshotSource = {
+      ...source,
+      downloadArtifact: async (entry, options) => {
+        const handle = await source.downloadArtifact(entry, options);
+        setBackgrounded(true);
+        return handle;
+      },
+    };
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: backgroundingSource,
+    });
+
+    expect(released).toEqual([{ filePath, imported: false }]);
+    expect(await countRows('board_climbs')).toBe(0);
+  });
+
+  it('falls back to deleteArtifact for a source with no releaseArtifact (the shipped contract)', async () => {
+    const filePath = join(workDir, 'legacy-source.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+    });
+
+    expect(source.deleteArtifact).toHaveBeenCalledWith(filePath);
+  });
+
+  it('imports a REUSED artifact without downloading it again', async () => {
+    const filePath = join(workDir, 'reused-good.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const { source, downloadedUrls } = makeRetainingSource({
+      manifest: makeManifest([makeEntry()]),
+      fileForEntry: () => filePath,
+      retained: new Set([filePath]),
+    });
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+    });
+
+    expect(downloadedUrls).toEqual([]);
+    expect(await countRows('board_climbs')).toBe(1);
+  });
+
+  it('a REUSED artifact that fails to import is deleted and does NOT burn a bootstrap attempt', async () => {
+    // The #4313 failure mode retention could otherwise recreate: the same
+    // corrupt file on disk would fail twice and settle the scope onto the paged
+    // crawl forever. Deleting it is what bounds the uncounted path.
+    const filePath = join(workDir, 'reused-corrupt.db');
+    writeFileSync(filePath, 'not a sqlite database at all');
+    const { source, deleted } = makeRetainingSource({
+      manifest: makeManifest([makeEntry()]),
+      fileForEntry: () => filePath,
+      retained: new Set([filePath]),
+    });
+    const onSnapshotBootstrapError = vi.fn();
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onSnapshotBootstrapError,
+    });
+
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
+    expect(deleted).toEqual([filePath]);
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(expect.objectContaining({ stage: 'import', attempt: 0 }));
+  });
+
+  it('a FRESHLY-DOWNLOADED artifact that fails to import still burns an attempt', async () => {
+    const filePath = join(workDir, 'fresh-corrupt.db');
+    writeFileSync(filePath, 'not a sqlite database at all');
+    const { source } = makeRetainingSource({
+      manifest: makeManifest([makeEntry()]),
+      fileForEntry: () => filePath,
+    });
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+    });
+
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(1);
+  });
+
+  it('hands the downloader an AbortSignal so a torn-down cycle can cancel the transfer', async () => {
+    const filePath = join(workDir, 'signal.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const { source, signals } = makeRetainingSource({
+      manifest: makeManifest([makeEntry()]),
+      fileForEntry: () => filePath,
+    });
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+    });
+
+    expect(signals[0]).toBeInstanceOf(AbortSignal);
+    expect(signals[0]?.aborted).toBe(false);
+  });
+
+  it('aborts an in-flight transfer that emits no progress when the app backgrounds', async () => {
+    // The teardown EVENT drives the abort, not the progress callback: a stalled
+    // transfer emits nothing, and that is exactly when cancelling matters.
+    const filePath = join(workDir, 'stalled.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    let seenSignal: AbortSignal | undefined;
+    const source = {
+      fetchManifest: vi.fn(async () => makeManifest([makeEntry()])),
+      downloadArtifact: vi.fn(async (_entry: SnapshotManifestEntry, options?: { signal?: AbortSignal }) => {
+        seenSignal = options?.signal;
+        // No progress events at all — the connection is hung.
+        setBackgrounded(true);
+        return { filePath };
+      }),
+      deleteArtifact: vi.fn(async () => {}),
+      releaseArtifact: vi.fn(async () => {}),
+    } as unknown as SnapshotSource;
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+    });
+
+    expect(seenSignal?.aborted).toBe(true);
+  });
+
+  it('charges the SECOND failed import of the same reused build, so an undeletable file cannot loop', async () => {
+    // deleteArtifact is best-effort on every platform (mobile swallows its
+    // errors), so a corrupt retained file can come back cycle after cycle. The
+    // free round is granted once per (scope, build); after that it settles on
+    // the structural ladder like any other on-disk failure.
+    const filePath = join(workDir, 'undeletable-corrupt.db');
+    writeFileSync(filePath, 'not a sqlite database at all');
+    const makeSource = () =>
+      makeRetainingSource({
+        manifest: makeManifest([makeEntry()]),
+        fileForEntry: () => filePath,
+        // The delete never takes: the file is still retained next cycle.
+        retained: new Set([filePath]),
+      });
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: makeSource().source,
+    });
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: makeSource().source,
+    });
+
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(1);
+  });
+
+  it('gives a DIFFERENT build its own free round', async () => {
+    const filePath = join(workDir, 'rebuilt-corrupt.db');
+    writeFileSync(filePath, 'not a sqlite database at all');
+    const cycle = async (builtAt: string) => {
+      const { source } = makeRetainingSource({
+        manifest: makeManifest([makeEntry({ builtAt })]),
+        fileForEntry: () => filePath,
+        retained: new Set([filePath]),
+      });
+      await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+        enabledBoards: ['kilter:1:5'],
+        snapshotSource: source,
+      });
+    };
+
+    await cycle('2026-08-10T02:00:00.000Z');
+    await cycle('2026-08-11T02:00:00.000Z');
+
+    // Tonight's rebuilt artifact is a different bet: still uncounted.
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
+  });
+});
+
+describe('pullSync scope-download phase breakdown', () => {
+  it('reports the artifact bytes and a per-table paged-crawl split on the completion event', async () => {
+    const filePath = join(workDir, 'phases.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const source = makeSnapshotSource({
+      manifest: makeManifest([makeEntry({ bytes: 108_000_000 })]),
+      fileForEntry: () => filePath,
+    });
+    const onScopeDownloadComplete = vi.fn();
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onScopeDownloadComplete,
+    });
+
+    const { phases } = onScopeDownloadComplete.mock.calls[0][0] as { phases: Record<string, number | boolean> };
+    expect(phases.artifactBytes).toBe(108_000_000);
+    expect(phases.artifactReused).toBe(false);
+    // Every phase is measured, even when a fast test makes them all 0ms.
+    for (const key of ['manifestMs', 'downloadMs', 'importMs', 'climbsPullMs', 'statsPullMs', 'gradesPullMs']) {
+      expect(phases[key], key).toBeGreaterThanOrEqual(0);
+    }
+    expect(phases.gradesRows).toBe(0);
+  });
+
+  it('measures a download that spans cycles from its FIRST cycle, not the last', async () => {
+    // Cycle 1 downloads and imports, then the phone backgrounds before the
+    // delta pull reaches the tail. Cycle 2 finishes. The reported duration must
+    // cover both, which is only possible because the start stamp is persisted.
+    const filePath = join(workDir, 'spanning.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const onScopeDownloadComplete = vi.fn();
+
+    // Cycle 1: stamp the start, then background out the moment the artifact
+    // lands — exactly the "user locks the phone mid-download" shape.
+    const backgroundingSource: SnapshotSource = {
+      ...source,
+      downloadArtifact: async (entry, options) => {
+        const handle = await source.downloadArtifact(entry, options);
+        setBackgrounded(true);
+        return handle;
+      },
+    };
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: backgroundingSource,
+    });
+    const startedRow = await db.getFirstAsync<{ value: string }>('SELECT value FROM sync_meta WHERE key = ?', [
+      'scope-download-started:kilter:1:5',
+    ]);
+    expect(startedRow).not.toBeNull();
+    // Backdate the stamp by a minute — the second cycle must report ~60s, not ~0s.
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      'scope-download-started:kilter:1:5',
+      String(Date.now() - 60_000),
+    ]);
+    setBackgrounded(false);
+
+    // Cycle 2 completes the scope.
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onScopeDownloadComplete,
+    });
+
+    expect(onScopeDownloadComplete).toHaveBeenCalledTimes(1);
+    const { durationMs } = onScopeDownloadComplete.mock.calls[0][0] as { durationMs: number | null };
+    expect(durationMs).toBeGreaterThanOrEqual(60_000);
+  });
+
+  it('reports a null duration when the start stamp is older than the plausibility window', async () => {
+    // A stamp nobody cleared (a crash, or an app left closed for a week) is not
+    // a week-long download — reporting it would poison the percentiles.
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      'scope-download-started:kilter:1:5',
+      String(Date.now() - 9 * 24 * 60 * 60 * 1000),
+    ]);
+    const onScopeDownloadComplete = vi.fn();
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      onScopeDownloadComplete,
+    });
+
+    expect(onScopeDownloadComplete).toHaveBeenCalledTimes(1);
+    const { durationMs } = onScopeDownloadComplete.mock.calls[0][0] as { durationMs: number | null };
+    expect(durationMs).toBeNull();
+  });
+
+  it('clears the start stamp once the scope completes', async () => {
+    const onScopeDownloadComplete = vi.fn();
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      onScopeDownloadComplete,
+    });
+
+    const row = await db.getFirstAsync<{ value: string }>('SELECT value FROM sync_meta WHERE key = ?', [
+      'scope-download-started:kilter:1:5',
+    ]);
+    expect(row).toBeNull();
+  });
+});

--- a/packages/shared/offline-sync/src/sync/checkpoints.ts
+++ b/packages/shared/offline-sync/src/sync/checkpoints.ts
@@ -92,11 +92,57 @@ export async function rewindDeletionsCheckpoint(db: SqlExecutor, watermark: Sync
 // must clear this marker in the same transaction as the rows it describes.
 export const SCOPE_COMPLETE_PREFIX = 'scope-complete:';
 
+/**
+ * "This device started downloading scope X at wall-clock T." Persisted because
+ * the in-memory start map lives for exactly one `pullSync` run, so a download
+ * that spans cycles — the normal shape for a 100 MB Kilter artifact on a phone
+ * that backgrounds once — used to report only the FINAL cycle's work as
+ * `durationMs` (issue #4310). Deliberately NOT under the `checkpoint:` prefix:
+ * `deleteAllCheckpoints`' `LIKE 'checkpoint:%'` must not reach it, so every
+ * clearing site is explicit (scope completion, scope teardown, sign-out).
+ */
+export const SCOPE_DOWNLOAD_STARTED_PREFIX = 'scope-download-started:';
+
+/**
+ * Anything older than this is not a download, it is a stamp nobody cleared —
+ * a crash between the stamp and the completion, an app the user did not open
+ * for a week, a clock that moved. Reporting 9 days as a download duration would
+ * poison the p50 far worse than reporting nothing, so the caller emits a null
+ * duration instead. Same posture as the deletions-coverage plausibility floor.
+ */
+export const SCOPE_DOWNLOAD_START_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The wall-clock this scope's download started, creating the stamp at `nowMs`
+ * when there isn't one. Returns the EFFECTIVE start — the persisted value when
+ * it exists, `nowMs` otherwise — so a caller never has to read it back.
+ */
+export async function ensureScopeDownloadStartedAt(db: SqlExecutor, scopeKey: string, nowMs: number): Promise<number> {
+  const row = await db.getFirstAsync<{ value: string }>('SELECT value FROM sync_meta WHERE key = ?', [
+    `${SCOPE_DOWNLOAD_STARTED_PREFIX}${scopeKey}`,
+  ]);
+  const persisted = row ? Number(row.value) : Number.NaN;
+  if (Number.isFinite(persisted) && persisted > 0) return persisted;
+  await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+    `${SCOPE_DOWNLOAD_STARTED_PREFIX}${scopeKey}`,
+    String(nowMs),
+  ]);
+  return nowMs;
+}
+
+export async function clearScopeDownloadStarted(db: SqlExecutor, scopeKey: string): Promise<void> {
+  await db.runAsync('DELETE FROM sync_meta WHERE key = ?', [`${SCOPE_DOWNLOAD_STARTED_PREFIX}${scopeKey}`]);
+}
+
 export async function markScopeDownloadComplete(db: SqlExecutor, scopeKey: string): Promise<void> {
   await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
     `${SCOPE_COMPLETE_PREFIX}${scopeKey}`,
     '1',
   ]);
+  // The download is over, so the start stamp describes nothing. Clearing it
+  // here (rather than only on teardown) is what keeps a later re-download —
+  // e.g. after a schema bump forces a fresh crawl — measuring its own time.
+  await clearScopeDownloadStarted(db, scopeKey);
 }
 
 export async function isScopeDownloadComplete(db: SqlExecutor, scopeKey: string): Promise<boolean> {
@@ -254,4 +300,10 @@ export async function deleteUserCheckpoints(db: SqlExecutor): Promise<void> {
   // companion `checkpoint:user_data_complete` is `checkpoint:`-prefixed and is
   // therefore already covered by the DELETE above.
   await db.runAsync('DELETE FROM sync_meta WHERE key = ?', [LOCAL_USER_ID_KEY]);
+  // Every in-flight download start stamp goes too. It is not a `checkpoint:`
+  // key, so the DELETE above cannot reach it, and a stamp left behind by the
+  // departing account would be read months later by the next one — reporting a
+  // multi-week `durationMs` for a download that took two minutes. GLOB keeps
+  // the literal-prefix range scan on sync_meta's binary primary key.
+  await db.runAsync('DELETE FROM sync_meta WHERE key GLOB ?', [`${SCOPE_DOWNLOAD_STARTED_PREFIX}*`]);
 }

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -9,6 +9,8 @@ import {
   isScopeDownloadComplete,
   markScopeDownloadStarted,
   isScopeDownloadStarted,
+  ensureScopeDownloadStartedAt,
+  SCOPE_DOWNLOAD_START_MAX_AGE_MS,
   DELETIONS_CHECKPOINT_KEY,
 } from './checkpoints';
 import { markUserDataComplete } from './local-user-owner';
@@ -17,10 +19,14 @@ import {
   markBootstrapDone,
   isBootstrapDone,
   wasBootstrapHealed,
+  getReusedImportFailure,
+  recordReusedImportFailure,
+  clearReusedImportFailure,
   SnapshotWipedError,
   SnapshotSchemaStaleError,
   SnapshotPermanentMissError,
   type SnapshotSource,
+  type SnapshotArtifactHandle,
   type SnapshotBootstrapErrorReporter,
 } from './snapshot-bootstrap';
 import {
@@ -59,7 +65,7 @@ import {
 import { applyBusyTimeout } from '../db/pragmas';
 import { getPendingCount } from '../mutation-queue/queue';
 import { isNetworkError } from '../mutation-queue/error-classification';
-import { isSigningOut, getWipeEpoch, isBackgrounded } from '../mutation-queue/drainer';
+import { isSigningOut, getWipeEpoch, isBackgrounded, onTeardown } from '../mutation-queue/drainer';
 import { parseOfflineBoardKey, type OfflineBoardScope } from '../offline-board-key';
 
 /**
@@ -97,6 +103,52 @@ export type SyncProgress = {
 };
 
 /**
+ * Where a board scope's initial download actually spent its time, split by
+ * phase, so `Offline Board Download Completed` can answer "is the 100 MB
+ * artifact the problem, or the paged crawl behind it?" (issue #4310) without
+ * minting a second event.
+ *
+ * SCOPED TO THE CYCLE THAT COMPLETED THE DOWNLOAD. `durationMs` spans cycles
+ * (it is persisted), the breakdown does not: a scope whose artifact imported on
+ * Monday and whose delta pull finished on Tuesday reports Tuesday's crawl time
+ * with zeros for manifest/download/import. Read the phases as "where this
+ * cycle's time went", not as a partition of `durationMs`.
+ */
+export type ScopeDownloadPhaseBreakdown = {
+  /** Resolving the manifest. 0 for every scope after the first in a cycle (it is cached per run). */
+  manifestMs: number;
+  /** Fetching the artifact. 0 when it was reused from disk or shared with another size of the layout. */
+  downloadMs: number;
+  /** ATTACH + verify + the single exclusive import transaction. */
+  importMs: number;
+  /** Stored (possibly gzip) size of the artifact this scope imported; 0 when none. */
+  artifactBytes: number;
+  /** The artifact came off disk from an earlier cycle — no bytes crossed the network. */
+  artifactReused: boolean;
+  /** Paged GraphQL crawl time per board table, the term the artifact does NOT cover. */
+  climbsPullMs: number;
+  statsPullMs: number;
+  gradesPullMs: number;
+  /** Rows the grades crawl consumed this cycle — the denominator for gradesPullMs. */
+  gradesRows: number;
+};
+
+/** A zeroed breakdown: what a scope reports before any phase has run. */
+export function emptyScopeDownloadPhases(): ScopeDownloadPhaseBreakdown {
+  return {
+    manifestMs: 0,
+    downloadMs: 0,
+    importMs: 0,
+    artifactBytes: 0,
+    artifactReused: false,
+    climbsPullMs: 0,
+    statsPullMs: 0,
+    gradesPullMs: 0,
+    gradesRows: 0,
+  };
+}
+
+/**
  * Fired once a board scope's initial download completes this cycle (every
  * BOARD_DATA_TABLES entry reached its tail — the same gate as
  * `markScopeDownloadComplete`). Lets the app compare the two download paths in
@@ -112,6 +164,14 @@ export type SyncProgress = {
  * loop. Per-scope stamping keeps a multi-board cycle honest: scope B's
  * duration never includes scope A's download time, so `'snapshot'` vs
  * `'paged'` percentiles stay apples-to-apples.
+ *
+ * Since issue #4310 the start stamp is PERSISTED in sync_meta rather than held
+ * in a per-run Map, so a download spanning several cycles reports its whole
+ * lifetime instead of only the final cycle's slice. Two consequences worth
+ * knowing before reading the series: durations recorded before that change are
+ * systematic under-reports and are not comparable to later ones, and a stamp
+ * older than SCOPE_DOWNLOAD_START_MAX_AGE_MS yields `durationMs: null` (a
+ * device that was simply closed for a week is not a week-long download).
  */
 export type ScopeDownloadCompleteInfo = {
   scopeKey: string;
@@ -121,8 +181,10 @@ export type ScopeDownloadCompleteInfo = {
    * over a partly-crawled catalog, issue #4313) reports `method: 'snapshot'` but
    * a duration that EXCLUDES the paged work earlier cycles already did. Filter on
    * `bootstrapHealed` before comparing snapshot-vs-paged percentiles.
+   *
+   * null when the persisted start stamp is too old to be a plausible duration.
    */
-  durationMs: number;
+  durationMs: number | null;
   /** The snapshot import landed on a scope that had already crawled some rows. */
   bootstrapHealed?: boolean;
   /**
@@ -140,6 +202,8 @@ export type ScopeDownloadCompleteInfo = {
   rowCount?: number;
   downloadMs?: number;
   importMs?: number;
+  /** Where this cycle's time went. See ScopeDownloadPhaseBreakdown. */
+  phases: ScopeDownloadPhaseBreakdown;
 };
 export type ScopeDownloadCompleteReporter = (info: ScopeDownloadCompleteInfo) => void;
 
@@ -840,7 +904,9 @@ async function resolveManifestOnce(
  *
  * A wipe detected mid-phase bails the whole phase with no burn (mirrors
  * syncTable). One artifact is downloaded per (boardType, layoutId) and reused
- * across that layout's sizes; all downloads are deleted in a finally.
+ * across that layout's sizes; every download is handed back in a finally through
+ * `releaseArtifact`, which keeps an UNIMPORTED file when the source supports
+ * retention and deletes it otherwise (issue #4310).
  *
  * Snapshot attribution for ScopeDownloadCompleteInfo.method and .bootstrapHealed
  * is NOT threaded through here — both read the persisted `bootstrap-done:` marker
@@ -854,11 +920,12 @@ async function runBootstrapPhase(params: {
   scopes: BoardScope[];
   /** The epoch pullSync captured at CYCLE start — see `cycleAborted` there. */
   cycleEpoch: number;
-  stampScopeStart: (scopeKey: string) => void;
   /** Once-ever Started emitter, shared with the board-data loop (issue #4316). */
   emitScopeDownloadStartOnce: (info: ScopeDownloadStartInfo) => Promise<void>;
   /** Per-scope download/import timings + payload size, read back by the Completed event. */
   bootstrapTimings: Map<string, { bytes: number; downloadMs?: number; importMs?: number; rowCount?: number }>;
+  stampScopeStart: (scopeKey: string) => Promise<void>;
+  phaseTimings: (scopeKey: string) => ScopeDownloadPhaseBreakdown;
   options: SyncOptions | undefined;
   now: () => number;
   random: () => number;
@@ -870,6 +937,7 @@ async function runBootstrapPhase(params: {
     scopes,
     cycleEpoch,
     stampScopeStart,
+    phaseTimings,
     emitScopeDownloadStartOnce,
     bootstrapTimings,
     options,
@@ -900,9 +968,12 @@ async function runBootstrapPhase(params: {
   // Absent = not yet attempted; `file: null` = download failed (with its cause).
   const downloadByLayout = new Map<
     string,
-    { file: { filePath: string } | null; cause: unknown; permanentMiss: boolean }
+    { file: SnapshotArtifactHandle | null; cause: unknown; permanentMiss: boolean; downloadMs: number }
   >();
-  const downloadedPaths = new Set<string>();
+  // filePath → whether any scope managed to import it. An artifact the phase
+  // never consumed (backgrounded cycle, wipe, aborted transfer) is handed back
+  // with `imported: false` so a retention-capable source can keep it.
+  const artifactImported = new Map<string, boolean>();
 
   const reportSettledFailure = (
     scope: BoardScope,
@@ -942,7 +1013,8 @@ async function runBootstrapPhase(params: {
 
         // Duration telemetry starts here — before the eligibility check — so a
         // snapshot scope's durationMs covers its manifest/download/import work.
-        stampScopeStart(scope.scopeKey);
+        await stampScopeStart(scope.scopeKey);
+        const phases = phaseTimings(scope.scopeKey);
 
         const climbsCheckpoint = await getCheckpoint(db, getCheckpointKey('board_climbs', scope.scopeKey));
         const statsCheckpoint = await getCheckpoint(db, getCheckpointKey('board_climb_stats', scope.scopeKey));
@@ -1010,7 +1082,9 @@ async function runBootstrapPhase(params: {
           }),
         );
 
+        const manifestStartedAt = Date.now();
         const resolution = await resolveManifestOnce(source, manifestCache);
+        phases.manifestMs += Date.now() - manifestStartedAt;
         // Re-check after the manifest network await: every branch below either
         // writes to SQLite or leads to one further down.
         if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) break;
@@ -1153,7 +1227,25 @@ async function runBootstrapPhase(params: {
         // reports the real error, not null.
         let cachedDownload = downloadByLayout.get(layoutKey);
         if (!cachedDownload) {
-          cachedDownload = { file: null, cause: null, permanentMiss: false };
+          cachedDownload = { file: null, cause: null, permanentMiss: false, downloadMs: 0 };
+          // The transfer runs for minutes on a 100 MB artifact. Cancelling it
+          // when the cycle is torn down (sign-out, purge, backgrounding) stops
+          // the native session from carrying on over a metered connection long
+          // after the engine stopped caring — the phase's own `break` below
+          // only stops the JS loop, not the download.
+          //
+          // The abort is driven by the teardown EVENT, not by progress: a
+          // stalled transfer emits no further progress, which is exactly the
+          // case where cancelling matters most. The progress callback stays a
+          // pure reporter.
+          const abortController = new AbortController();
+          const abortIfTornDown = (): void => {
+            if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) abortController.abort();
+          };
+          const unsubscribeTeardown = onTeardown(abortIfTornDown);
+          // Covers a teardown that landed between the guard check above and the
+          // subscription: the listener only sees transitions after this point.
+          abortIfTornDown();
           // Stage 2 of 3, the multi-minute one. A second SIZE of the same layout
           // reuses this cache entry, so it never re-runs and never re-emits
           // download frames for bytes that already came down.
@@ -1171,6 +1263,7 @@ async function runBootstrapPhase(params: {
           try {
             cachedDownload.file =
               (await source.downloadArtifact(entry, {
+                signal: abortController.signal,
                 onProgress: ({ bytesWritten, totalBytes }) => {
                   const resolved = resolveDownloadFraction({
                     entry,
@@ -1192,9 +1285,14 @@ async function runBootstrapPhase(params: {
           } catch (error) {
             cachedDownload.cause = error;
             cachedDownload.permanentMiss = error instanceof SnapshotPermanentMissError;
+          } finally {
+            unsubscribeTeardown();
           }
+          cachedDownload.downloadMs = Date.now() - downloadStartedAt;
           downloadByLayout.set(layoutKey, cachedDownload);
-          if (cachedDownload.file) downloadedPaths.add(cachedDownload.file.filePath);
+          // Registered even on the reuse path: the phase still owns the file for
+          // the rest of the cycle and must hand it back through releaseArtifact.
+          if (cachedDownload.file) artifactImported.set(cachedDownload.file.filePath, false);
           if (cachedDownload.file) {
             bootstrapTimings.set(scope.scopeKey, {
               bytes: entry.bytes,
@@ -1202,6 +1300,11 @@ async function runBootstrapPhase(params: {
             });
           }
         }
+        // Only the scope that actually fetched it pays the download time; a
+        // second size of the same layout reuses the file for free and its own
+        // breakdown correctly shows downloadMs 0.
+        phases.downloadMs += cachedDownload.downloadMs;
+        cachedDownload.downloadMs = 0;
         // Re-check after the (potentially multi-MB) artifact download await, same
         // reason as the manifest check above.
         if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) break;
@@ -1274,12 +1377,14 @@ async function runBootstrapPhase(params: {
           }),
         );
 
+        phases.artifactBytes = entry.bytes;
+        phases.artifactReused = download.reused === true;
+        const importStartedAt = Date.now();
         try {
           // Imports the scope's rows, stamps both table checkpoints, and rewinds
           // the global deletions cursor to the older table watermark — all in one
           // transaction, so no crash point can separate the imported rows from
           // the tombstone-replay window that must cover them.
-          const importStartedAt = Date.now();
           const imported = await bootstrapScopeFromSnapshot({
             db,
             scope,
@@ -1298,6 +1403,11 @@ async function runBootstrapPhase(params: {
             importMs: Date.now() - importStartedAt,
             rowCount: imported.climbsImported + imported.statsImported,
           });
+          phases.importMs += Date.now() - importStartedAt;
+          artifactImported.set(download.filePath, true);
+          // The scope imported an artifact, so any free-round marker it carries
+          // describes a build that no longer matters.
+          await clearReusedImportFailure(db, scope.scopeKey);
           // The heal flag rides the persisted marker, not a per-cycle set: the
           // scope usually reaches completion in a LATER cycle (board_climb_grades
           // is not a snapshot table and still crawls), and an in-memory set
@@ -1316,6 +1426,7 @@ async function runBootstrapPhase(params: {
           // Not skipped: the board-data phase delta-pulls from the watermark
           // checkpoints and fires markScopeDownloadComplete through the tail logic.
         } catch (error) {
+          phases.importMs += Date.now() - importStartedAt;
           // A wipe mid-import rolls the transaction back and bails the phase — no
           // burn (the pull is being torn down, not failing).
           if (
@@ -1345,6 +1456,42 @@ async function runBootstrapPhase(params: {
               cause: error,
               expected: false,
             });
+            continue;
+          }
+          // A RETAINED artifact that fails to import gets ONE round that spends
+          // no budget. Retention keeps the same file across cycles, so charging
+          // the first failure would spend the structural-artifact budget twice
+          // against the same bad bytes and settle the scope onto the paged crawl
+          // for good — recreating exactly the #4313 failure retention is meant to
+          // prevent.
+          //
+          // The free round is granted at most once per (scope, artifact build),
+          // and the marker is what bounds it. Deleting the file is best-effort on
+          // every platform — mobile's `safeDeleteFile` swallows its errors — so
+          // "the next cycle re-downloads fresh" is a hope, not a guarantee: a
+          // file that survives with its sidecar comes back as `reused: true` and
+          // would otherwise buy another free round every cycle, forever, with a
+          // fresh scope skipping its paged pull each time. The second failure on
+          // the same build falls through to the counted structural path below.
+          if (download.reused && (await getReusedImportFailure(db, scope.scopeKey)) !== entry.builtAt) {
+            await recordReusedImportFailure(db, scope.scopeKey, entry.builtAt);
+            await source.deleteArtifact(download.filePath).catch(() => {});
+            artifactImported.delete(download.filePath);
+            downloadByLayout.delete(layoutKey);
+            metadataSettled = true;
+            onSnapshotBootstrapError?.({
+              scopeKey: scope.scopeKey,
+              stage: 'import',
+              attempt: 0,
+              cause: error,
+              expected: false,
+            });
+            // Same grace-window rule as every other failure arm: only a fresh,
+            // non-terminal scope waits a cycle for the retry. A scope that already
+            // holds rows always crawls.
+            if (shouldSkipPagedPull({ retryState, hasBoardCheckpoint, now: evaluatedAt })) {
+              skipPagedPull.add(scope.scopeKey);
+            }
             continue;
           }
           // The bytes are already on disk, so nothing about this failure is a
@@ -1377,8 +1524,15 @@ async function runBootstrapPhase(params: {
     // behind them cannot emit a frame after the phase is over and re-light a row
     // the UI already moved past.
     progressThrottle.cancel();
-    for (const filePath of downloadedPaths) {
-      await source.deleteArtifact(filePath).catch(() => {});
+    // Hand every artifact back rather than deleting it outright. A source with
+    // no retention support falls through to deleteArtifact and behaves exactly
+    // as it did before #4310; a retention-capable one keeps the files the phase
+    // never got to import, so a backgrounded cycle no longer costs 100 MB.
+    for (const [filePath, imported] of artifactImported) {
+      const release = source.releaseArtifact
+        ? source.releaseArtifact(filePath, { imported })
+        : source.deleteArtifact(filePath);
+      await release.catch(() => {});
     }
   }
 
@@ -1600,9 +1754,28 @@ export async function pullSync(
   // its turn in the board-data loop) — NOT once at cycle start, which would
   // fold scope A's entire download time into scope B's duration whenever a
   // cycle processes several boards.
+  //
+  // PERSISTED (issue #4310), not just held here: a 100 MB Kilter artifact
+  // routinely spans cycles — the phone backgrounds, the scheduler wakes again —
+  // and a per-run Map made every one of those report only the final cycle's
+  // work. The in-memory Map is now a read-through cache over the sync_meta
+  // stamp so a cycle costs at most one extra SELECT per scope.
   const scopeStartedAt = new Map<string, number>();
-  const stampScopeStart = (scopeKey: string): void => {
-    if (!scopeStartedAt.has(scopeKey)) scopeStartedAt.set(scopeKey, Date.now());
+  const stampScopeStart = async (scopeKey: string): Promise<void> => {
+    if (scopeStartedAt.has(scopeKey)) return;
+    scopeStartedAt.set(scopeKey, await ensureScopeDownloadStartedAt(db, scopeKey, Date.now()));
+  };
+
+  // Per-scope phase breakdown for ScopeDownloadCompleteInfo.phases, accumulated
+  // across this cycle's bootstrap phase and board-data loop.
+  const phasesByScope = new Map<string, ScopeDownloadPhaseBreakdown>();
+  const phaseTimings = (scopeKey: string): ScopeDownloadPhaseBreakdown => {
+    let phases = phasesByScope.get(scopeKey);
+    if (!phases) {
+      phases = emptyScopeDownloadPhases();
+      phasesByScope.set(scopeKey, phases);
+    }
+    return phases;
   };
 
   // Download-funnel Started (issue #4316). Once ever per scope, guarded by the
@@ -1645,6 +1818,7 @@ export async function pullSync(
       stampScopeStart,
       emitScopeDownloadStartOnce,
       bootstrapTimings,
+      phaseTimings,
       options,
       now: options.now ?? Date.now,
       random: options.random ?? Math.random,
@@ -1708,7 +1882,8 @@ export async function pullSync(
     const scopeKey = boardScope.scopeKey;
     // No-op when the bootstrap phase already stamped this scope; the paged-only
     // path (no snapshotSource) starts its duration clock here.
-    stampScopeStart(scopeKey);
+    await stampScopeStart(scopeKey);
+    const phases = phaseTimings(scopeKey);
     // Started (issue #4316), the paged half — and the catch-all. Every scope
     // reaches this line on every path: a build with no snapshot source, a scope
     // the bootstrap phase found ineligible or unexportable, and the resumed
@@ -1732,6 +1907,12 @@ export async function pullSync(
         currentTableProcessed: 0,
       });
       const baseCount = totalDocuments;
+      // Timed per table, not per scope: the whole point of the #4310
+      // measurement is telling the artifact's tables (climbs, stats — imported
+      // in one shot) apart from board_climb_grades, which the artifact does not
+      // carry at all and which therefore crawls page by page every time.
+      const tableStartedAt = Date.now();
+      let tableRows = 0;
       const { reachedTail } = await syncTable(
         db,
         queryClient,
@@ -1740,6 +1921,7 @@ export async function pullSync(
         cycleEpoch,
         boardScope,
         (tableProcessed) => {
+          tableRows = tableProcessed;
           totalDocuments = baseCount + tableProcessed;
           onProgress?.({
             phase: 'board_data',
@@ -1750,6 +1932,13 @@ export async function pullSync(
         },
         options?.onSchemaDrift,
       );
+      const tableMs = Date.now() - tableStartedAt;
+      if (tableName === 'board_climbs') phases.climbsPullMs += tableMs;
+      else if (tableName === 'board_climb_stats') phases.statsPullMs += tableMs;
+      else if (tableName === 'board_climb_grades') {
+        phases.gradesPullMs += tableMs;
+        phases.gradesRows += tableRows;
+      }
       if (!reachedTail) allTablesReachedTail = false;
     }
     // Gate for local-first reads: only a scope whose climbs, stats AND grades
@@ -1758,6 +1947,7 @@ export async function pullSync(
     // catalog as if it were everything.
     if (allTablesReachedTail) {
       const wasScopeComplete = await isScopeDownloadComplete(db, scopeKey);
+      // Clears the persisted start stamp as well as writing the complete marker.
       await markScopeDownloadComplete(db, scopeKey);
       if (wasScopeComplete) continue;
       const startedAt = scopeStartedAt.get(scopeKey);
@@ -1765,6 +1955,12 @@ export async function pullSync(
       // loop for every scope. If that invariant breaks, skip telemetry rather
       // than emit a misleading 0ms duration.
       if (startedAt === undefined) continue;
+      // A stamp older than the plausibility window is a stamp nobody cleared,
+      // not a download that ran for days (a crash between stamp and completion,
+      // or an app the user simply did not open). Report the event with a null
+      // duration rather than poisoning the percentiles with it.
+      const elapsedMs = Date.now() - startedAt;
+      const durationMs = elapsedMs >= 0 && elapsedMs <= SCOPE_DOWNLOAD_START_MAX_AGE_MS ? elapsedMs : null;
       // Both attributions read the persisted marker, not this run's bootstrap
       // work: the import and the completing delta pull can land in different
       // cycles (connectivity drop between them, or the grades crawl still
@@ -1774,13 +1970,14 @@ export async function pullSync(
       options?.onScopeDownloadComplete?.({
         scopeKey,
         method: (await isBootstrapDone(db, scopeKey)) ? 'snapshot' : 'paged',
-        durationMs: Date.now() - startedAt,
+        durationMs,
         // A healed scope's duration excludes the paged work earlier cycles did,
         // so it must be filtered out of snapshot-vs-paged comparisons.
         bootstrapHealed: await wasBootstrapHealed(db, scopeKey),
         // Spread rather than set explicitly: absent when this cycle did not do
         // the import, which is the honest answer (see ScopeDownloadCompleteInfo).
         ...timings,
+        phases,
       });
     }
   }

--- a/packages/shared/offline-sync/src/sync/scope-teardown.ts
+++ b/packages/shared/offline-sync/src/sync/scope-teardown.ts
@@ -31,8 +31,13 @@ import type { OfflineDatabase, SqlExecutor, SqlValue } from '../database';
 import { applyBusyTimeout } from '../db/pragmas';
 import type { OfflineBoardScope } from '../offline-board-key';
 import { climbsScopeFilter, isSizeScopedBoard, sizeMembershipClause } from './board-scope-sql';
-import { getCheckpointKey, SCOPE_COMPLETE_PREFIX, SCOPE_STARTED_PREFIX } from './checkpoints';
-import { BOOTSTRAP_DONE_PREFIX } from './snapshot-bootstrap';
+import {
+  getCheckpointKey,
+  SCOPE_COMPLETE_PREFIX,
+  SCOPE_STARTED_PREFIX,
+  SCOPE_DOWNLOAD_STARTED_PREFIX,
+} from './checkpoints';
+import { BOOTSTRAP_DONE_PREFIX, REUSED_IMPORT_FAILED_PREFIX } from './snapshot-bootstrap';
 import {
   BOOTSTRAP_ATTEMPTS_HEALED_PREFIX,
   BOOTSTRAP_ATTEMPTS_PREFIX,
@@ -83,6 +88,15 @@ export function scopeSyncMetaKeys(scopeKey: string): string[] {
     // The retry budgets + cooldown (issue #4313). Re-adding the board must give
     // the scope a clean slate, not a terminal verdict it earned before removal.
     `${BOOTSTRAP_RETRY_PREFIX}${scopeKey}`,
+    // The in-flight download's start stamp. Removing a board mid-download and
+    // re-adding it must time the SECOND download, not measure from the first
+    // one's start — and a stamp left over an emptied scope is unclearable by
+    // any other path (it is not a `checkpoint:` key).
+    `${SCOPE_DOWNLOAD_STARTED_PREFIX}${scopeKey}`,
+    // The free-round marker a reused artifact's failed import leaves behind.
+    // Same clean-slate rule as the budgets above: a re-added board must not
+    // inherit a round it spent before removal.
+    `${REUSED_IMPORT_FAILED_PREFIX}${scopeKey}`,
   ];
 }
 

--- a/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
@@ -63,6 +63,39 @@ const EPOCH_WATERMARK: SyncCheckpoint = { updatedAt: '1970-01-01T00:00:00.000Z',
 // keeps the string-built SQL provably injection-free — same guard the export uses.
 const SAFE_IDENTIFIER = /^[a-z_][a-z0-9_]*$/;
 
+/** Byte progress for one artifact download, as the transport observes it. */
+export type SnapshotDownloadProgress = {
+  bytesWritten: number;
+  /** `null` when the server sent no Content-Length — never a negative sentinel. */
+  totalBytes: number | null;
+};
+
+/** Per-download seams the engine may pass; every one is optional for a source. */
+export type SnapshotDownloadOptions = {
+  onProgress?: (progress: SnapshotDownloadProgress) => void;
+  /**
+   * Aborted when the cycle is torn down mid-transfer (sign-out, local purge, or
+   * the app going to background). Without it the native transfer keeps running
+   * — and keeps burning a metered connection — long after the engine stopped
+   * caring about the result.
+   */
+  signal?: AbortSignal;
+};
+
+/** What a source hands back for one downloaded (or retained) artifact. */
+export type SnapshotArtifactHandle = {
+  filePath: string;
+  /**
+   * True when the file was already on disk from an earlier cycle and no bytes
+   * were fetched. The engine treats an import failure on a REUSED artifact
+   * differently: it deletes the file and spends NO retry budget, because a
+   * corrupt retained file would otherwise spend the whole structural-artifact
+   * budget against the same bytes and strand the scope on the paged crawl
+   * forever (issue #4313's failure mode).
+   */
+  reused?: boolean;
+};
+
 /**
  * Platform-injected snapshot I/O. The adapter (mobile: Phase 4) owns the network
  * and gzip; the engine only consumes what these return.
@@ -98,10 +131,22 @@ export interface SnapshotSource {
    */
   downloadArtifact(
     entry: SnapshotManifestEntry,
-    options?: { onProgress?: (progress: { bytesWritten: number; totalBytes: number | null }) => void },
-  ): Promise<{ filePath: string } | null>;
+    options?: SnapshotDownloadOptions,
+  ): Promise<SnapshotArtifactHandle | null>;
   /** Delete a downloaded artifact once the run is done with it. Best-effort. */
   deleteArtifact(filePath: string): Promise<void>;
+  /**
+   * Hand an artifact back at the end of the bootstrap phase. `imported: false`
+   * means the phase never got to use it — a backgrounded cycle, a wipe, an
+   * aborted download — and a source that supports retention should KEEP the
+   * file so the next cycle can reuse it instead of re-fetching 100 MB (issue
+   * #4310: `runBootstrapPhase` used to delete every artifact unconditionally,
+   * so locking the phone mid-cycle cost the whole download).
+   *
+   * OPTIONAL, and the engine falls back to `deleteArtifact` when it is absent,
+   * so a source written against the shipped contract behaves exactly as before.
+   */
+  releaseArtifact?(filePath: string, options: { imported: boolean }): Promise<void>;
 }
 
 /** Where a bootstrap failed, for telemetry. */
@@ -344,6 +389,45 @@ export async function isBootstrapDone(db: SqlExecutor, scopeKey: string): Promis
     `${BOOTSTRAP_DONE_PREFIX}${scopeKey}`,
   ]);
   return row !== null;
+}
+
+/**
+ * The artifact build stamp whose REUSED import failure already took this
+ * scope's one free (uncounted) round — see the `download.reused` arm in
+ * `runBootstrapPhase`.
+ *
+ * That arm's whole safety argument is "the file is deleted, so the next cycle
+ * downloads fresh and the free round cannot repeat". Deletion is best-effort on
+ * every platform (mobile's `safeDeleteFile` swallows its errors by design), and
+ * a file that survives with its completeness sidecar is handed straight back as
+ * `reused: true` next cycle — the same bad bytes, another free round, forever,
+ * with a fresh scope skipping its paged pull each time. This marker is what
+ * makes the SECOND failure on the same build spend the structural budget like
+ * any other on-disk failure, so a scope can always settle. Keyed by `builtAt`:
+ * tonight's rebuilt artifact is a different bet and gets its own free round.
+ *
+ * Package-internal, like BOOTSTRAP_DONE_PREFIX — scope-teardown.ts clears it
+ * alongside the scope's other markers.
+ */
+export const REUSED_IMPORT_FAILED_PREFIX = 'reused-import-failed:';
+
+/** The build stamp that already took this scope's free reused-import round, if any. */
+export async function getReusedImportFailure(db: SqlExecutor, scopeKey: string): Promise<string | null> {
+  const row = await db.getFirstAsync<{ value: string }>('SELECT value FROM sync_meta WHERE key = ?', [
+    `${REUSED_IMPORT_FAILED_PREFIX}${scopeKey}`,
+  ]);
+  return row?.value ?? null;
+}
+
+export async function recordReusedImportFailure(db: SqlExecutor, scopeKey: string, builtAt: string): Promise<void> {
+  await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+    `${REUSED_IMPORT_FAILED_PREFIX}${scopeKey}`,
+    builtAt,
+  ]);
+}
+
+export async function clearReusedImportFailure(db: SqlExecutor, scopeKey: string): Promise<void> {
+  await db.runAsync('DELETE FROM sync_meta WHERE key = ?', [`${REUSED_IMPORT_FAILED_PREFIX}${scopeKey}`]);
 }
 
 /** Whether this scope's snapshot import was a heal over an existing partial crawl. */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -657,6 +657,15 @@ export default defineConfig({
         command: 'vp test run --project web',
         cache: false,
       },
+      // The offline-sync engine suites live in their own Vitest project
+      // (packages/shared/offline-sync/vite.config.ts, name: 'offline-sync').
+      // Neither `test:mobile` nor the backend project pulls them in, so a
+      // snapshot-bootstrap change validated with only those two runs is a false
+      // green — hence its own alias next to the others.
+      'test:offline-sync': {
+        command: 'vp test run --project offline-sync',
+        cache: false,
+      },
 
       // --- Mobile validation ---
       'mobile:web-runtime:install': {


### PR DESCRIPTION
`Offline Board Download Completed.durationMs` is a single number covering four serial phases — manifest fetch, artifact download, the one-shot exclusive import, and the paged GraphQL crawl of every board table the artifact does not carry. Nobody has ever seen the split, so the Kilter p50 of 2m55s (Android 8m52s, 37% over five minutes, worst case 31m39s) has no attributable cause and the epic has been guessing at levers.

This PR makes the split visible on the event that already exists, and fixes two things the measurement immediately exposed.

**The duration was under-reported.** `scopeStartedAt` was a `Map` created per `pullSync` run, so a download spanning cycles — the normal shape for a 100 MB artifact on a phone that backgrounds once — reported only the final cycle's slice.

**Downloaded artifacts were thrown away.** `runBootstrapPhase`'s `finally` deleted every artifact unconditionally, and the phase breaks on `isBackgrounded()`. Lock the phone after the download finished and the whole transfer was lost.

## Changes

- **Phase breakdown on the existing event.** `ScopeDownloadCompleteInfo` gains `phases: { manifestMs, downloadMs, importMs, artifactBytes, artifactReused, climbsPullMs, statsPullMs, gradesPullMs, gradesRows }`, folded onto `Offline Board Download Completed` rather than a new event (no new `SHARED_EVENTS` entry, so #4316's funnel stays clean). Grades pull time is measured separately from climbs and stats — that is the term the artifact never covered.
- **Persisted start stamp.** `scope-download-started:<scopeKey>` in `sync_meta`, so a download spanning cycles reports its whole lifetime. Cleared at scope completion, in `scopeSyncMetaKeys` (teardown), and in `deleteUserCheckpoints` (sign-out) — it is deliberately not a `checkpoint:` key, so `deleteAllCheckpoints`' `LIKE 'checkpoint:%'` cannot reach it and every clearing site is explicit and tested. A stamp older than 24h yields `durationMs: null` rather than an absurd number.
- **Artifact retention.** New optional `SnapshotSource.releaseArtifact(filePath, { imported })`, defaulting to `deleteArtifact`, so a source written against the shipped contract behaves exactly as before. The mobile source keeps an unimported artifact behind a `.complete` sidecar (written only after the download AND the gzip sniff pass), a 400 MB budget, and a 1.5 GB free-space floor, sweeping superseded builds of the same board+layout on each successful download.
- **Safe reuse.** A retained artifact for the same `builtAt` is handed back with `reused: true` and no network call. `quick_check` and `verifySnapshotMeta` still run before a single row is imported, and an import failure on a reused artifact **deletes the file and does not burn a bootstrap attempt** — otherwise the same bad bytes would spend both attempts and strand the scope on the paged crawl, which is the #4313 failure retention exists to avoid. Deleting the file bounds the uncounted path.
- **Byte progress and cancellation** through `DownloadOptions` on the `File.downloadFileAsync` call already in the binary (`onProgress`, `signal`) — surfaced as `SyncProgress.bytesDownloaded` / `bytesTotal` on bootstrap frames, with the transport's `-1` unknown-total normalised to `null`. The signal is aborted when the cycle is torn down. No new dependency, no `expo-file-system/legacy`, no HTTP byte-range resume.
- **`vp run test:offline-sync`** alias beside `test:mobile`/`test:web`. The engine suites live in their own Vitest project that neither the mobile nor the backend run pulls in, so validating a snapshot-bootstrap change with those two alone is a false green.

### Honest limits

- Retention only saves a download that **completed** before the abort. A transfer killed mid-flight still restarts from zero; nothing here adds resume.
- `durationMs` now measures per-scope lifetime instead of per-run, so post-merge numbers are **not comparable** to the epic's 2m55s baseline. Read before/after against this PR's own baseline.
- The phase breakdown is scoped to the cycle that completed the download. A scope whose artifact imported on Monday and whose delta finished on Tuesday reports Tuesday's crawl with zeros for manifest/download/import — the phases are "where this cycle's time went", not a partition of `durationMs`.

### Coordination

Touches the same `runBootstrapPhase` region as #4313 (PR #4326 / #4333) and the same `offline-sync-adapter.ts` event as #4311/#4316 (PRs #4335–#4337). Whoever lands second rebases; no hard ordering. #3647's cache sweeper must **exclude** `Paths.cache/board-snapshots` (this PR owns its budget) or it silently reintroduces "backgrounding costs you the whole download".

### Rebase note (landed after #4335–#4337 and #4355)

Two overlaps with work that reached `main` first were collapsed rather than duplicated:

- **Byte progress.** #4311's staged `snapshot` frames (fraction, wire bytes, throttle) already ship the same measurement in a richer form, so this branch's raw `SyncProgress.bytesDownloaded` / `bytesTotal` pair and its test were dropped. The `AbortSignal` half of the same seam is kept — `downloadArtifact` now takes `{ onProgress, signal }`, and `signal` rides both call shapes so it never switches expo's native download implementation.
- **Completed-event props.** #4316's per-scope `bytes` / `rowCount` / `downloadMs` / `importMs` are absent-when-unknown, which is the more honest shape, so the adapter emits those and adds only the phases they do not carry: `manifestMs`, `artifactReused`, `climbsPullMs`, `statsPullMs`, `gradesPullMs`, `gradesRows`. The engine's `phases` breakdown keeps its cycle-scoped copies of download/import/bytes for its own assertions.

## Release Notes

Downloading a board no longer starts over when you lock your phone — a finished download is kept and picked up on the next sync instead of being thrown away.

## Test plan

- `vp test run --project offline-sync` — 344 passed. New coverage: the start stamp is idempotent, per-scope, cleared at completion/teardown/sign-out and untouched by the checkpoint-only wipe; an imported artifact releases with `imported: true` and an unimported one with `imported: false`; a source without `releaseArtifact` still gets `deleteArtifact`; a reused artifact imports with no download; a reused artifact whose import fails is deleted and burns no attempt while a freshly-downloaded one still does; the download gets a live `AbortSignal`; byte progress reaches the `SyncProgress` sink; a download spanning two cycles reports ≥60s; a 9-day-old stamp yields a null duration.
- `vp run test:mobile` — 621 files / 5494 tests passed. The `expo-file-system` fake was rebuilt as a real in-memory filesystem (existence, sidecar contents, sizes, mtimes) because retention turns on all four; new cases cover sidecar write/skip, reuse, no-sidecar re-download, `builtAt` mismatch, superseded sweep, cross-layout retention, oldest-first eviction, the free-space floor, progress normalisation, signal pass-through, and both `releaseArtifact` outcomes.
- `vp run typecheck:mobile`, `vp run typecheck` — clean.
- `vp lint` — no new errors in the touched packages (pre-existing `scripts/**` TS2741 errors are unrelated and present on `main`).

Not run: `vp run check:mobile-bundle` (needs a sibling worktree outside `.claude`), and no device QA — CI covers the bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT6VP1sWqk6bY9mUgyeS2U

