### PR TITLE
feat(backend): publish per-layout board_climb_grades snapshot artifacts

### DIFF
--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -108,6 +108,13 @@ avoid dropping data on a broken read:
   decompressed on disk (see Rollout plan). No explicit `cacheControl` is passed to `uploadToS3`, so
   artifacts get the storage layer's default: `public, max-age=31536000, immutable`. Content-addressed by
   build timestamp — safe to cache forever, a new build gets a new key.
+- Grades artifacts: `<keyPrefix>/<boardType>/<layoutId>/<builtAt>-grades.db`, same `Content-Type`, always
+  gzip, and **published only in the `v1-gzip` pass** (issue #4310). Same content-addressed immutability as
+  the whole-layout artifact. Referenced from the layout's manifest entry through the optional `grades`
+  block, never as its own `entries` element — `findSnapshotEntry` first-matches on `(boardType, layoutId)`,
+  so a sibling entry could be imported by an older client as if it carried the whole layout, stamping
+  checkpoints past rows it never imported. Layouts with no grade rows (every MoonBoard layout: MoonBoard is
+  deliberately outside `CROWD_MEAN_BOARDS`, see `docs/boardsesh-grade.md`) publish nothing.
 - Manifest: `<keyPrefix>/manifest.json`, `Content-Type: application/json`,
   `Cache-Control: public, max-age=300`. Mutable and cheap to refetch, written last so it's the only object
   in the whole scheme that changes in place. Each prefix has its own manifest.
@@ -122,7 +129,8 @@ Artifacts superseded by a newer build for the same `(boardType, layoutId)` are d
 
 An object is eligible for deletion when it's under the prefix the run targets (`board-snapshots/v1/` for
 the identity pass, `board-snapshots/v1-gzip/` for the gzip pass) and NOT referenced by the manifest
-just written, **and** its `lastModified` is older than a **14-day grace window**
+just written — where "referenced" includes every surviving entry's `grades.key`, which is not in `entries`
+and would otherwise be swept out from under live clients — **and** its `lastModified` is older than a **14-day grace window**
 (`PRUNE_GRACE_MS`). The grace window exists because the manifest is CDN-cached for up to 5 minutes and a
 client may hold a fetched manifest (with a now-superseded artifact URL) far longer than that before it
 actually starts the download. Pruning is defensive by design: any failure (per-object or the whole scan) is
@@ -130,8 +138,12 @@ logged and swallowed, never fails the run.
 
 ## Artifact format
 
-Each `.db` file carries exactly two data tables — `board_climbs` and `board_climb_stats` — plus
-`snapshot_meta`:
+The whole-layout `.db` file carries exactly two data tables — `board_climbs` and `board_climb_stats` —
+plus `snapshot_meta`. That has not changed since the first release and must not: every shipped binary
+verifies the file against its own two-table list and throws `snapshot_meta missing row for <table>` on a
+mismatch, which is a **counted** import failure. Two of those settle the scope onto the paged crawl, so
+widening this file's meta would break the fleet for the whole 14-day prune-grace window. Boardsesh grades
+ride in a separate file for exactly that reason (see "Grades artifact" below).
 
 ```sql
 CREATE TABLE snapshot_meta (
@@ -185,6 +197,28 @@ ignores the key. Every entry published before the field existed omits it, and th
 entries through untouched, so a reader must handle `undefined`. It only starts appearing on the first
 export run after the field ships: the nightly runs at 07:15 UTC, or dispatch
 `.github/workflows/export-board-snapshots.yml` manually to fill it in sooner.
+
+### Grades artifact (issue #4310)
+
+`board_climb_grades` is a per-board table the scope-completion gate waits on, but the whole-layout artifact
+never carried it — so every Kilter and Tension download paid hundreds of serial authenticated GraphQL
+pages for grades after the artifact had already landed. The natural experiment: `moonboard:2` (20.0 MB,
+93,939 climbs, **zero** grade rows) has a p50 of 14.5s, while `tension:9` (17.1 MB, 72,051 climbs, ~79k
+grade rows) takes 1m27s. Same bytes, same import shape, ~6x the duration.
+
+The fix is a second, standalone artifact per layout:
+
+- Contents: the `board_climb_grades` DDL from the shared MIGRATIONS, that layout's grade rows, and a
+  **one-row** `snapshot_meta`.
+- Scope: the same correlated `EXISTS` over `board_climbs` that `syncClimbGrades` uses, plus the stability
+  window — cursored on **`computed_at`**, not `updated_at`. Grades have no `updated_at` column. The cursor
+  column is declared once in `TABLE_CONFIGS[...].cursorColumn` (`@boardsesh/offline-sync`) and read from
+  there by both the export and the client, so the two cannot disagree about which column a watermark
+  covers.
+- Consistency: written inside the **same** `REPEATABLE READ` transaction as the whole-layout artifact, so
+  the grade rows and the climbs they hang off come from one database snapshot.
+- Kill switch: publish a manifest with no `grades` anywhere (or roll back to the identity `v1` prefix,
+  which never carries grades) and every client reverts to today's crawl with no deploy.
 
 ## Client bootstrap flow
 
@@ -426,6 +460,10 @@ manifest) and the export re-bases entry URLs onto it. Keep it consistent with
 - **Fastest, no deploy**: flip the `offline-snapshot-bootstrap-v2` PostHog flag off. Every client falls back
   to the paged crawl for newly-enabled boards; nothing already bootstrapped is affected (it's already past
   the eligibility check).
+- **Grades only** (issue #4310): the grades import runs only when the manifest entry carries a `grades`
+  block, so publishing a manifest without one — or rolling the fleet back to the identity `board-snapshots/v1`
+  prefix, which never publishes grades — reverts every client to the paged grades crawl with no deploy. It
+  is a slower download, not a broken one.
 - **Nuclear, affects every client regardless of flag state after cache expiry**: delete the
   `board-snapshots/v1-gzip/manifest.json` object from the bucket — that's the prefix the fleet reads;
   deleting `board-snapshots/v1/manifest.json` stops nothing. The manifest is cached for up to 5 minutes

--- a/packages/backend/src/__tests__/snapshot-export-golden.test.ts
+++ b/packages/backend/src/__tests__/snapshot-export-golden.test.ts
@@ -45,6 +45,7 @@ const BUILT_AT = '2026-06-01T00:00:00.000Z';
 
 const CLIMB_COLUMNS = TABLE_CONFIGS.board_climbs.localColumns;
 const STATS_COLUMNS = TABLE_CONFIGS.board_climb_stats.localColumns;
+const GRADES_COLUMNS = TABLE_CONFIGS.board_climb_grades.localColumns;
 
 function ctx(): ConnectionContext {
   return {
@@ -75,6 +76,9 @@ async function graphqlFetch<T>(query: string, variables?: Record<string, unknown
   // 'syncClimbs' (capital S after 'syncClimb'), so ordering is unambiguous.
   if (query.includes('syncClimbStats')) {
     return { syncClimbStats: await syncQueries.syncClimbStats(undefined, resolverArgs, ctx()) } as T;
+  }
+  if (query.includes('syncClimbGrades')) {
+    return { syncClimbGrades: await syncQueries.syncClimbGrades(undefined, resolverArgs, ctx()) } as T;
   }
   if (query.includes('syncClimbs')) {
     return { syncClimbs: await syncQueries.syncClimbs(undefined, resolverArgs, ctx()) } as T;
@@ -138,6 +142,57 @@ async function insertStat(values: {
   `);
 }
 
+async function insertGrade(values: {
+  climbUuid: string;
+  angle: number;
+  localGrade?: number | null;
+  universalGrade?: number | null;
+  gradeLow?: number | null;
+  gradeHigh?: number | null;
+  confidence?: string | null;
+  ascensionistCount?: number | null;
+  computedAt: string;
+}): Promise<void> {
+  // confidence / ascensionist_count / model_version / coeff_version are NOT NULL
+  // in board_climb_grades (packages/db/src/schema/app/climb-grades.ts).
+  await db.execute(sql`
+    INSERT INTO board_climb_grades
+      (board_type, climb_uuid, angle, local_grade, universal_grade, grade_low, grade_high,
+       confidence, ascensionist_count, model_version, coeff_version, computed_at)
+    VALUES
+      (${BOARD_TYPE}, ${values.climbUuid}, ${values.angle}, ${values.localGrade ?? null},
+       ${values.universalGrade ?? null}, ${values.gradeLow ?? null}, ${values.gradeHigh ?? null},
+       ${values.confidence ?? 'low'}, ${values.ascensionistCount ?? 0}, 'test-model', 'test-coeff',
+       ${values.computedAt}::timestamp)
+  `);
+}
+
+function readArtifactTableNames(filePath: string): string[] {
+  const artifactDb = new DatabaseSync(filePath);
+  try {
+    return (
+      artifactDb.prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name").all() as {
+        name: string;
+      }[]
+    ).map((row) => row.name);
+  } finally {
+    artifactDb.close();
+  }
+}
+
+function readArtifactMetaTableNames(filePath: string): string[] {
+  const artifactDb = new DatabaseSync(filePath);
+  try {
+    return (
+      artifactDb.prepare('SELECT table_name FROM snapshot_meta ORDER BY table_name').all() as {
+        table_name: string;
+      }[]
+    ).map((row) => row.table_name);
+  } finally {
+    artifactDb.close();
+  }
+}
+
 function readArtifactRows(filePath: string, table: string, columns: readonly string[]): Record<string, unknown>[] {
   const artifactDb = new DatabaseSync(filePath);
   try {
@@ -166,7 +221,7 @@ let workDir: string;
 
 beforeEach(async () => {
   workDir = mkdtempSync(join(tmpdir(), 'snapshot-golden-'));
-  await db.execute(sql`TRUNCATE TABLE board_climbs, board_climb_stats RESTART IDENTITY CASCADE`);
+  await db.execute(sql`TRUNCATE TABLE board_climbs, board_climb_stats, board_climb_grades RESTART IDENTITY CASCADE`);
 });
 
 afterEach(() => {
@@ -370,5 +425,219 @@ describe('board-snapshot export ↔ live pull parity', () => {
     expect(climbMeta.row_count).toBe(2);
     expect(climbMeta.watermark_sync_seq).toBe(String(stableWatermarkRow.sync_seq));
     expect(Number(climbMeta.watermark_sync_seq)).toBeLessThan(Number(recentRow.sync_seq));
+  });
+});
+
+// The SEPARATE per-layout grades artifact (issue #4310). Boardsesh grades are
+// the one per-board table the whole-layout artifact never carried, so every
+// Kilter/Tension download paid hundreds of serial authenticated GraphQL pages
+// for them — which is why a MoonBoard layout of the same byte size finishes
+// roughly six times faster.
+describe('board_climb_grades snapshot artifact', () => {
+  it('produces byte-identical grade rows via the export core and the real syncClimbGrades pull', async () => {
+    await insertClimb({ uuid: 'c1', compatibleSizeIds: [5], updatedAt: '2026-05-01T00:00:00Z' });
+    await insertClimb({ uuid: 'c2', compatibleSizeIds: [5, 7], updatedAt: '2026-05-01T00:00:00Z' });
+    await insertGrade({
+      climbUuid: 'c1',
+      angle: 40,
+      localGrade: 21.5,
+      universalGrade: 19.25,
+      gradeLow: 20,
+      gradeHigh: 23,
+      confidence: 'high',
+      ascensionistCount: 1234,
+      computedAt: '2026-05-01T00:00:00Z',
+    });
+    await insertGrade({
+      climbUuid: 'c1',
+      angle: 50,
+      localGrade: null,
+      universalGrade: null,
+      confidence: 'low',
+      ascensionistCount: 0,
+      computedAt: '2026-05-01T00:00:01.5Z', // fractional seconds
+    });
+    await insertGrade({ climbUuid: 'c2', angle: 40, localGrade: 15, computedAt: '2026-05-02T09:30:00Z' });
+
+    const filePath = join(workDir, 'artifact.db');
+    const gradesFilePath = join(workDir, 'artifact-grades.db');
+    await exportLayoutSnapshot({
+      sqlClient: createPool(),
+      boardType: BOARD_TYPE,
+      layoutId: LAYOUT_ID,
+      filePath,
+      gradesFilePath,
+      builtAt: BUILT_AT,
+      stabilityWindowSeconds: 0,
+    });
+    const artifactGrades = readArtifactRows(gradesFilePath, 'board_climb_grades', GRADES_COLUMNS);
+
+    const clientDb = createTestDatabase();
+    await runMigrations(clientDb);
+    await pullSync(clientDb, noopQueryClient(), graphqlFetch, { enabledBoards: [SCOPE_KEY] });
+    const pulledGrades = await clientDb.getAllAsync<Record<string, unknown>>(
+      `SELECT ${GRADES_COLUMNS.join(', ')} FROM board_climb_grades ORDER BY climb_uuid, angle`,
+    );
+
+    expect(artifactGrades).toEqual(pulledGrades);
+    expect(artifactGrades).toHaveLength(3);
+  });
+
+  it('leaves the WHOLE-LAYOUT artifact untouched — same tables, same two snapshot_meta rows', async () => {
+    // Every already-shipped binary verifies the whole-layout artifact against
+    // its own two-table list and throws "snapshot_meta missing row for <table>"
+    // on a mismatch. That failure is COUNTED, and two of them settle the scope
+    // onto the paged crawl — so growing this file's meta would break the fleet.
+    await insertClimb({ uuid: 'c1', compatibleSizeIds: [5], updatedAt: '2026-05-01T00:00:00Z' });
+    await insertGrade({ climbUuid: 'c1', angle: 40, localGrade: 20, computedAt: '2026-05-01T00:00:00Z' });
+
+    const filePath = join(workDir, 'artifact.db');
+    await exportLayoutSnapshot({
+      sqlClient: createPool(),
+      boardType: BOARD_TYPE,
+      layoutId: LAYOUT_ID,
+      filePath,
+      gradesFilePath: join(workDir, 'artifact-grades.db'),
+      builtAt: BUILT_AT,
+      stabilityWindowSeconds: 0,
+    });
+
+    expect(readArtifactMetaTableNames(filePath)).toEqual(['board_climb_stats', 'board_climbs']);
+    expect(readArtifactTableNames(filePath)).not.toContain('board_climb_grades');
+  });
+
+  it('carries ONLY board_climb_grades and its own one-row snapshot_meta', async () => {
+    await insertClimb({ uuid: 'c1', compatibleSizeIds: [5], updatedAt: '2026-05-01T00:00:00Z' });
+    await insertGrade({ climbUuid: 'c1', angle: 40, localGrade: 20, computedAt: '2026-05-01T00:00:00Z' });
+
+    const gradesFilePath = join(workDir, 'artifact-grades.db');
+    await exportLayoutSnapshot({
+      sqlClient: createPool(),
+      boardType: BOARD_TYPE,
+      layoutId: LAYOUT_ID,
+      filePath: join(workDir, 'artifact.db'),
+      gradesFilePath,
+      builtAt: BUILT_AT,
+      stabilityWindowSeconds: 0,
+    });
+
+    const tables = readArtifactTableNames(gradesFilePath);
+    expect(tables).toContain('board_climb_grades');
+    expect(tables).not.toContain('board_climbs');
+    expect(tables).not.toContain('board_climb_stats');
+    expect(readArtifactMetaTableNames(gradesFilePath)).toEqual(['board_climb_grades']);
+  });
+
+  it('cursors the grades watermark on computed_at, not updated_at (the column grades do not have)', async () => {
+    await insertClimb({ uuid: 'c1', compatibleSizeIds: [5], updatedAt: '2026-05-01T00:00:00Z' });
+    await insertGrade({ climbUuid: 'c1', angle: 40, localGrade: 20, computedAt: '2026-05-01T00:00:00Z' });
+    await insertGrade({ climbUuid: 'c1', angle: 50, localGrade: 22, computedAt: '2026-05-04T00:00:00Z' });
+
+    const gradesFilePath = join(workDir, 'artifact-grades.db');
+    const result = await exportLayoutSnapshot({
+      sqlClient: createPool(),
+      boardType: BOARD_TYPE,
+      layoutId: LAYOUT_ID,
+      filePath: join(workDir, 'artifact.db'),
+      gradesFilePath,
+      builtAt: BUILT_AT,
+      stabilityWindowSeconds: 0,
+    });
+
+    const latest = (
+      await db.execute(sql`
+        SELECT computed_at, sync_seq FROM board_climb_grades
+        WHERE board_type = ${BOARD_TYPE}
+        ORDER BY computed_at DESC, sync_seq DESC LIMIT 1
+      `)
+    )[0] as { computed_at: unknown; sync_seq: unknown };
+
+    const meta = readArtifactMeta(gradesFilePath, 'board_climb_grades')!;
+    expect(meta.row_count).toBe(2);
+    expect(meta.watermark_updated_at).toBe(toIso(latest.computed_at));
+    expect(meta.watermark_sync_seq).toBe(String(latest.sync_seq));
+    expect(result.grades?.tables.board_climb_grades.rowCount).toBe(2);
+  });
+
+  it('excludes a grade inside the stability window from the artifact AND its watermark', async () => {
+    await insertClimb({ uuid: 'c1', compatibleSizeIds: [5], updatedAt: '2026-05-01T00:00:00Z' });
+    await insertGrade({ climbUuid: 'c1', angle: 40, localGrade: 20, computedAt: '2026-05-01T00:00:00Z' });
+    await db.execute(sql`
+      INSERT INTO board_climb_grades
+        (board_type, climb_uuid, angle, local_grade, confidence, model_version, coeff_version, computed_at)
+      VALUES (${BOARD_TYPE}, 'c1', 50, 22, 'low', 'test-model', 'test-coeff', now())
+    `);
+
+    const gradesFilePath = join(workDir, 'artifact-grades.db');
+    await exportLayoutSnapshot({
+      sqlClient: createPool(),
+      boardType: BOARD_TYPE,
+      layoutId: LAYOUT_ID,
+      filePath: join(workDir, 'artifact.db'),
+      gradesFilePath,
+      builtAt: BUILT_AT,
+      stabilityWindowSeconds: 30,
+    });
+
+    const angles = readArtifactRows(gradesFilePath, 'board_climb_grades', ['angle']).map((row) => row.angle);
+    expect(angles).toEqual([40]);
+    const meta = readArtifactMeta(gradesFilePath, 'board_climb_grades')!;
+    expect(meta.row_count).toBe(1);
+  });
+
+  it('scopes grades to the layout’s climbs — a grade for another layout never lands', async () => {
+    await insertClimb({ uuid: 'c1', compatibleSizeIds: [5], updatedAt: '2026-05-01T00:00:00Z' });
+    await db.execute(sql`
+      INSERT INTO board_climbs (uuid, board_type, layout_id, compatible_size_ids, updated_at)
+      VALUES ('other-layout', ${BOARD_TYPE}, 99, '{5}'::int[], '2026-05-01T00:00:00Z'::timestamp)
+    `);
+    await insertGrade({ climbUuid: 'c1', angle: 40, localGrade: 20, computedAt: '2026-05-01T00:00:00Z' });
+    await insertGrade({ climbUuid: 'other-layout', angle: 40, localGrade: 20, computedAt: '2026-05-01T00:00:00Z' });
+
+    const gradesFilePath = join(workDir, 'artifact-grades.db');
+    await exportLayoutSnapshot({
+      sqlClient: createPool(),
+      boardType: BOARD_TYPE,
+      layoutId: LAYOUT_ID,
+      filePath: join(workDir, 'artifact.db'),
+      gradesFilePath,
+      builtAt: BUILT_AT,
+      stabilityWindowSeconds: 0,
+    });
+
+    const uuids = readArtifactRows(gradesFilePath, 'board_climb_grades', ['climb_uuid']).map((row) => row.climb_uuid);
+    expect(uuids).toEqual(['c1']);
+  });
+
+  it('publishes NO grades result for a layout with zero grade rows (every MoonBoard layout)', async () => {
+    await insertClimb({ uuid: 'c1', compatibleSizeIds: [5], updatedAt: '2026-05-01T00:00:00Z' });
+
+    const result = await exportLayoutSnapshot({
+      sqlClient: createPool(),
+      boardType: BOARD_TYPE,
+      layoutId: LAYOUT_ID,
+      filePath: join(workDir, 'artifact.db'),
+      gradesFilePath: join(workDir, 'artifact-grades.db'),
+      builtAt: BUILT_AT,
+      stabilityWindowSeconds: 0,
+    });
+
+    expect(result.grades).toBeUndefined();
+  });
+
+  it('omits grades entirely when no gradesFilePath is requested (the identity rollback pass)', async () => {
+    await insertClimb({ uuid: 'c1', compatibleSizeIds: [5], updatedAt: '2026-05-01T00:00:00Z' });
+    await insertGrade({ climbUuid: 'c1', angle: 40, localGrade: 20, computedAt: '2026-05-01T00:00:00Z' });
+
+    const result = await exportLayoutSnapshot({
+      sqlClient: createPool(),
+      boardType: BOARD_TYPE,
+      layoutId: LAYOUT_ID,
+      filePath: join(workDir, 'artifact.db'),
+      builtAt: BUILT_AT,
+      stabilityWindowSeconds: 0,
+    });
+
+    expect(result.grades).toBeUndefined();
   });
 });

--- a/packages/backend/src/__tests__/snapshot-export-run.test.ts
+++ b/packages/backend/src/__tests__/snapshot-export-run.test.ts
@@ -91,8 +91,19 @@ beforeEach(async () => {
   vi.mocked(getFromS3Strict).mockResolvedValue(null);
   vi.mocked(listS3Objects).mockResolvedValue([]);
   vi.mocked(deleteFromS3).mockResolvedValue(undefined);
-  await db.execute(sql`TRUNCATE TABLE board_climbs, board_climb_stats RESTART IDENTITY CASCADE`);
+  await db.execute(sql`TRUNCATE TABLE board_climbs, board_climb_stats, board_climb_grades RESTART IDENTITY CASCADE`);
 });
+
+/** Seeds one Boardsesh grade row for a climb (the NOT NULL columns are required). */
+async function seedGrade(boardType: string, climbUuid: string, angle: number): Promise<void> {
+  await db.execute(sql`
+    INSERT INTO board_climb_grades
+      (board_type, climb_uuid, angle, local_grade, universal_grade, confidence,
+       ascensionist_count, model_version, coeff_version, computed_at)
+    VALUES (${boardType}, ${climbUuid}, ${angle}, 20, 19, 'high', 100, 'test-model', 'test-coeff',
+            '2026-05-01T00:00:00Z'::timestamp)
+  `);
+}
 
 describe('mergeManifestEntries', () => {
   const kilterOld = manifestEntryFixture('kilter', 1, 'board-snapshots/v1/kilter/1/old.db');
@@ -451,5 +462,118 @@ describe('runExport — gzip + key-prefix (dual-publish transition)', () => {
     expect(manifest.entries[0].key.startsWith(`${GZIP_PREFIX}/kilter/1/`)).toBe(true);
     // A filtered run never prunes.
     expect(listS3Objects).not.toHaveBeenCalled();
+  });
+});
+
+// The separate per-layout grades artifact (issue #4310). It rides under the same
+// key prefix as the whole-layout artifact but is referenced through the entry's
+// optional `grades` block, never as its own `entries` element.
+describe('runExport — board_climb_grades artifacts', () => {
+  const GZIP_PREFIX = 'board-snapshots/v1-gzip';
+  const GZIP_MANIFEST_KEY = `${GZIP_PREFIX}/manifest.json`;
+
+  function gzipManifest(): SnapshotManifest {
+    const manifestCalls = vi.mocked(uploadToS3).mock.calls.filter(([, key]) => key === GZIP_MANIFEST_KEY);
+    expect(manifestCalls.length).toBeGreaterThan(0);
+    return JSON.parse((manifestCalls[manifestCalls.length - 1][0] as Buffer).toString('utf8')) as SnapshotManifest;
+  }
+
+  it('publishes a grades artifact and references it from the entry, not from `entries`', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+    await seedGrade('kilter', 'k1-a', 40);
+
+    await runExport(['--gzip', '--key-prefix', GZIP_PREFIX]);
+
+    const manifest = gzipManifest();
+    // One entry per (board, layout) — the grades file must never become a
+    // sibling entry, because findSnapshotEntry first-matches on that pair.
+    expect(manifest.entries).toHaveLength(1);
+    const entry = manifest.entries[0];
+    expect(entry.grades).toBeDefined();
+    expect(entry.grades?.key).toBe(`${entry.key.replace(/\.db$/, '')}-grades.db`);
+    expect(entry.grades?.contentEncoding).toBe('gzip');
+    expect(entry.grades?.tables.board_climb_grades.rowCount).toBe(1);
+    // The whole-layout entry's own fields are untouched.
+    expect(Object.keys(entry.tables).sort()).toEqual(['board_climb_stats', 'board_climbs']);
+    expect(manifest.formatVersion).toBe(1);
+
+    const gradesUpload = vi.mocked(uploadToS3).mock.calls.find(([, key]) => String(key).endsWith('-grades.db'))!;
+    expect(gradesUpload[3]).toEqual({ contentEncoding: 'gzip' });
+    expect((gradesUpload[0] as Buffer)[0]).toBe(0x1f); // gzip magic
+  });
+
+  it('omits `grades` for a layout with no grade rows (every MoonBoard layout)', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+
+    await runExport(['--gzip', '--key-prefix', GZIP_PREFIX]);
+
+    expect(gzipManifest().entries[0].grades).toBeUndefined();
+    expect(vi.mocked(uploadToS3).mock.calls.some(([, key]) => String(key).endsWith('-grades.db'))).toBe(false);
+  });
+
+  it('publishes NO grades artifact on the identity rollback pass — that prefix is the kill switch', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+    await seedGrade('kilter', 'k1-a', 40);
+
+    await runExport([]);
+
+    expect(uploadedManifest().entries[0].grades).toBeUndefined();
+    expect(vi.mocked(uploadToS3).mock.calls.some(([, key]) => String(key).endsWith('-grades.db'))).toBe(false);
+  });
+
+  it('never prunes a grades artifact the manifest just published', async () => {
+    // Grades keys are not in `entries`, so a prune that only walks entry.key
+    // would delete live grades files out from under every client holding the
+    // current manifest.
+    await seedClimb('kilter', 1, 'k1-a');
+    await seedGrade('kilter', 'k1-a', 40);
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    vi.mocked(listS3Objects).mockImplementation(async () =>
+      vi
+        .mocked(uploadToS3)
+        .mock.calls.filter(([, key]) => !String(key).endsWith('/manifest.json'))
+        .map(([, key]) => ({ key: String(key), size: 10, lastModified: thirtyDaysAgo })),
+    );
+
+    await runExport(['--gzip', '--key-prefix', GZIP_PREFIX]);
+
+    expect(deleteFromS3).not.toHaveBeenCalled();
+  });
+
+  it('prunes a SUPERSEDED grades artifact once it leaves the grace window', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+    await seedGrade('kilter', 'k1-a', 40);
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    vi.mocked(listS3Objects).mockResolvedValue([
+      { key: `${GZIP_PREFIX}/kilter/1/ancient-grades.db`, size: 10, lastModified: thirtyDaysAgo },
+    ]);
+
+    await runExport(['--gzip', '--key-prefix', GZIP_PREFIX]);
+
+    expect(deleteFromS3).toHaveBeenCalledWith(`${GZIP_PREFIX}/kilter/1/ancient-grades.db`);
+  });
+
+  it('a filtered run preserves another board’s previously-published grades block', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+    const previousTension: SnapshotManifestEntry = {
+      ...manifestEntryFixture('tension', 9, `${GZIP_PREFIX}/tension/9/old.db`),
+      grades: {
+        key: `${GZIP_PREFIX}/tension/9/old-grades.db`,
+        url: `https://cdn.example/${GZIP_PREFIX}/tension/9/old-grades.db`,
+        bytes: 42,
+        contentEncoding: 'gzip',
+        builtAt: '2026-06-01T00:00:00.000Z',
+        schemaVersion: 3,
+        tables: {
+          board_climb_grades: { watermarkUpdatedAt: '2026-05-01T00:00:00Z', watermarkSyncSeq: '9', rowCount: 4 },
+        },
+      },
+    };
+    serveExistingManifest(manifestFixture([previousTension]));
+
+    await runExport(['--gzip', '--key-prefix', GZIP_PREFIX, '--board', 'kilter']);
+
+    const tensionEntry = gzipManifest().entries.find((entry) => entry.boardType === 'tension')!;
+    expect(tensionEntry.grades?.key).toBe(`${GZIP_PREFIX}/tension/9/old-grades.db`);
   });
 });

--- a/packages/backend/src/scripts/export-board-snapshots.ts
+++ b/packages/backend/src/scripts/export-board-snapshots.ts
@@ -43,6 +43,8 @@ import {
   SNAPSHOT_MANIFEST_FORMAT_VERSION,
   type SnapshotManifest,
   type SnapshotManifestEntry,
+  type SnapshotGradesArtifact,
+  type SnapshotGradesTableName,
   type SnapshotTableName,
 } from '@boardsesh/offline-sync';
 import { createPool, closePool } from '@boardsesh/db/client';
@@ -105,6 +107,28 @@ const EPOCH_WATERMARK_SYNC_SEQ = '0';
 
 const SNAPSHOT_TABLES: readonly SnapshotTableName[] = ['board_climbs', 'board_climb_stats'];
 
+// The SEPARATE per-layout grades artifact's single table (issue #4310). It is
+// not folded into SNAPSHOT_TABLES on purpose: the client verifies a whole-layout
+// artifact's `snapshot_meta` against its OWN two-table list and throws
+// "snapshot_meta missing row for <table>" on a mismatch, so growing the
+// whole-layout file's meta would make an updated client reject every artifact
+// published before this change — as a COUNTED import failure, twice, which
+// settles the scope onto the paged crawl. Separate file, separate meta, no
+// interaction.
+const GRADES_SNAPSHOT_TABLES: readonly SnapshotGradesTableName[] = ['board_climb_grades'];
+
+// Every snapshot table's keyset cursor column, read from the SHARED table config
+// so the export, the sync resolvers, and the client import can never disagree
+// about which column a watermark covers. `board_climb_grades` is the one that
+// is not `updated_at`.
+function cursorColumnFor(tableName: SnapshotTableName | SnapshotGradesTableName): string {
+  const cursorColumn = TABLE_CONFIGS[tableName]?.cursorColumn;
+  if (!cursorColumn || !SAFE_IDENTIFIER.test(cursorColumn)) {
+    throw new Error(`No safe cursor column configured for snapshot table ${tableName}`);
+  }
+  return cursorColumn;
+}
+
 const SNAPSHOT_META_DDL = `
 CREATE TABLE IF NOT EXISTS snapshot_meta (
   table_name TEXT PRIMARY KEY,
@@ -139,6 +163,18 @@ export type LayoutSnapshotResult = {
   builtAt: string;
   schemaVersion: number;
   tables: Record<SnapshotTableName, SnapshotTableExportResult>;
+  /**
+   * The layout's grades artifact, when one was requested AND the layout has
+   * grade rows. Absent for every MoonBoard layout (MoonBoard is outside
+   * CROWD_MEAN_BOARDS, so `board_climb_grades` is empty for it by design) and
+   * for any run that did not ask for one.
+   */
+  grades?: LayoutGradesSnapshotResult;
+};
+
+export type LayoutGradesSnapshotResult = {
+  filePath: string;
+  tables: Record<SnapshotGradesTableName, SnapshotTableExportResult>;
 };
 
 export type LayoutPair = { boardType: string; layoutId: number };
@@ -153,9 +189,11 @@ export type LayoutPair = { boardType: string; layoutId: number };
  * client (e.g. the v2 `characteristics` ALTER) flows into the snapshot with no
  * duplicated DDL here.
  */
-export function boardSnapshotDdlStatements(): string[] {
+export function boardSnapshotDdlStatements(
+  tables: readonly (SnapshotTableName | SnapshotGradesTableName)[] = SNAPSHOT_TABLES,
+): string[] {
   const referencesSnapshotTable = (statement: string): boolean =>
-    SNAPSHOT_TABLES.some((table) => new RegExp(`\\b${table}\\b`).test(statement));
+    tables.some((table) => new RegExp(`\\b${table}\\b`).test(statement));
 
   const statements: string[] = [];
   for (const migration of [...MIGRATIONS].sort((left, right) => left.version - right.version)) {
@@ -202,6 +240,17 @@ const STATS_WHERE = `board_type = $1
     )
     AND updated_at < now() - make_interval(secs => $3)`;
 
+// Grades have no layout_id, so they are scoped to the layout's climbs through
+// the SAME correlated EXISTS the syncClimbGrades resolver uses — import wider
+// than the resolver's scope and rows are merely redundant, narrower and a row
+// inside the stamped watermark is lost forever.
+const GRADES_WHERE = `board_type = $1
+    AND EXISTS (
+      SELECT 1 FROM board_climbs bc
+      WHERE bc.uuid = board_climb_grades.climb_uuid AND bc.board_type = $1 AND bc.layout_id = $2
+    )
+    AND computed_at < now() - make_interval(secs => $3)`;
+
 /**
  * Stream one table's scoped rows from Postgres through the shared row shaping into
  * the SQLite artifact, batched into multi-row INSERTs. Returns the number of rows
@@ -211,7 +260,7 @@ const STATS_WHERE = `board_type = $1
 async function streamTableIntoSqlite(
   tx: TransactionSql,
   sqliteDb: DatabaseSync,
-  tableName: SnapshotTableName,
+  tableName: SnapshotTableName | SnapshotGradesTableName,
   columns: readonly string[],
   whereClause: string,
   params: (string | number)[],
@@ -264,34 +313,70 @@ async function streamTableIntoSqlite(
  */
 async function tableWatermark(
   tx: TransactionSql,
-  tableName: SnapshotTableName,
+  tableName: SnapshotTableName | SnapshotGradesTableName,
   whereClause: string,
   params: (string | number)[],
 ): Promise<{ watermarkUpdatedAt: string; watermarkSyncSeq: string }> {
+  const cursorColumn = cursorColumnFor(tableName);
   const rows = await tx.unsafe(
-    `SELECT updated_at, sync_seq
+    `SELECT ${cursorColumn} AS cursor_at, sync_seq
      FROM ${tableName}
      WHERE ${whereClause}
-     ORDER BY updated_at DESC, sync_seq DESC
+     ORDER BY ${cursorColumn} DESC, sync_seq DESC
      LIMIT 1`,
     params,
   );
-  const watermarkRow = rows[0] as unknown as { updated_at: unknown; sync_seq: unknown } | undefined;
+  const watermarkRow = rows[0] as unknown as { cursor_at: unknown; sync_seq: unknown } | undefined;
   if (!watermarkRow) {
     return { watermarkUpdatedAt: EPOCH_WATERMARK_UPDATED_AT, watermarkSyncSeq: EPOCH_WATERMARK_SYNC_SEQ };
   }
   return {
-    watermarkUpdatedAt: toIso(watermarkRow.updated_at),
+    watermarkUpdatedAt: toIso(watermarkRow.cursor_at),
     watermarkSyncSeq: String(watermarkRow.sync_seq),
   };
 }
 
 // --- Layout snapshot build ----------------------------------------------------
 
+/** Writes one `snapshot_meta` row per table into an artifact. */
+function writeSnapshotMeta(
+  sqliteDb: DatabaseSync,
+  builtAt: string,
+  tables: Record<string, SnapshotTableExportResult>,
+): void {
+  const insertMeta = sqliteDb.prepare(
+    `INSERT OR REPLACE INTO snapshot_meta
+      (table_name, watermark_updated_at, watermark_sync_seq, row_count, built_at, schema_version, format_version)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  );
+  for (const [tableName, tableResult] of Object.entries(tables)) {
+    insertMeta.run(
+      tableName,
+      tableResult.watermarkUpdatedAt,
+      tableResult.watermarkSyncSeq,
+      tableResult.rowCount,
+      builtAt,
+      LATEST_SCHEMA_VERSION,
+      SNAPSHOT_MANIFEST_FORMAT_VERSION,
+    );
+  }
+}
+
 /**
- * Build ONE (boardType, layoutId) SQLite snapshot at `filePath`. Both tables and
- * every watermark are read inside a single REPEATABLE READ transaction so climbs,
- * stats, and their watermarks come from one consistent database snapshot.
+ * Build ONE (boardType, layoutId) SQLite snapshot at `filePath`, and — when
+ * `gradesFilePath` is given and the layout has grade rows — a SECOND, separate
+ * artifact carrying only `board_climb_grades`.
+ *
+ * Every table and every watermark is read inside a SINGLE REPEATABLE READ
+ * transaction, so the whole-layout artifact, the grades artifact, and all four
+ * watermarks come from one consistent database snapshot. That matters for the
+ * grades file specifically: its rows are scoped by an EXISTS over
+ * `board_climbs`, so a climb committed between the two reads would otherwise
+ * make the grade rows and the climbs they hang off disagree.
+ *
+ * The whole-layout artifact is BYTE-FOR-BYTE what it was before grades existed
+ * — same DDL, same two tables, same two `snapshot_meta` rows — because every
+ * shipped binary verifies it against a two-table list.
  */
 export async function exportLayoutSnapshot(params: {
   sqlClient: Sql;
@@ -299,22 +384,31 @@ export async function exportLayoutSnapshot(params: {
   layoutId: number;
   filePath: string;
   builtAt: string;
+  /** Where to write the layout's grades artifact. Omit to skip grades entirely. */
+  gradesFilePath?: string;
   stabilityWindowSeconds?: number;
   streamBatchSize?: number;
 }): Promise<LayoutSnapshotResult> {
-  const { sqlClient, boardType, layoutId, filePath, builtAt } = params;
+  const { sqlClient, boardType, layoutId, filePath, builtAt, gradesFilePath } = params;
   const stabilityWindowSeconds = params.stabilityWindowSeconds ?? DEFAULT_STABILITY_WINDOW_SECONDS;
   const streamBatchSize = params.streamBatchSize ?? 5000;
   const scopeParams: (string | number)[] = [boardType, layoutId, stabilityWindowSeconds];
 
   const sqliteDb = new DatabaseSync(filePath);
+  const gradesDb = gradesFilePath ? new DatabaseSync(gradesFilePath) : null;
   try {
     for (const statement of boardSnapshotDdlStatements()) {
       sqliteDb.exec(statement);
     }
+    if (gradesDb) {
+      for (const statement of boardSnapshotDdlStatements(GRADES_SNAPSHOT_TABLES)) {
+        gradesDb.exec(statement);
+      }
+    }
 
     sqliteDb.exec('BEGIN');
-    const tables = await sqlClient.begin(async (tx) => {
+    gradesDb?.exec('BEGIN');
+    const streamed = await sqlClient.begin(async (tx) => {
       await tx.unsafe('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ');
 
       const climbColumns = TABLE_CONFIGS.board_climbs.localColumns;
@@ -342,30 +436,46 @@ export async function exportLayoutSnapshot(params: {
       );
       const statsWatermark = await tableWatermark(tx, 'board_climb_stats', STATS_WHERE, scopeParams);
 
-      return {
+      const tables = {
         board_climbs: { rowCount: climbRowCount, ...climbWatermark },
         board_climb_stats: { rowCount: statsRowCount, ...statsWatermark },
       } satisfies Record<SnapshotTableName, SnapshotTableExportResult>;
+
+      if (!gradesDb) return { tables, gradesTables: null };
+
+      const gradesRowCount = await streamTableIntoSqlite(
+        tx,
+        gradesDb,
+        'board_climb_grades',
+        TABLE_CONFIGS.board_climb_grades.localColumns,
+        GRADES_WHERE,
+        scopeParams,
+        streamBatchSize,
+      );
+      const gradesWatermark = await tableWatermark(tx, 'board_climb_grades', GRADES_WHERE, scopeParams);
+
+      return {
+        tables,
+        gradesTables: {
+          board_climb_grades: { rowCount: gradesRowCount, ...gradesWatermark },
+        } satisfies Record<SnapshotGradesTableName, SnapshotTableExportResult>,
+      };
     });
 
-    const insertMeta = sqliteDb.prepare(
-      `INSERT OR REPLACE INTO snapshot_meta
-        (table_name, watermark_updated_at, watermark_sync_seq, row_count, built_at, schema_version, format_version)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
-    );
-    for (const tableName of SNAPSHOT_TABLES) {
-      const tableResult = tables[tableName];
-      insertMeta.run(
-        tableName,
-        tableResult.watermarkUpdatedAt,
-        tableResult.watermarkSyncSeq,
-        tableResult.rowCount,
-        builtAt,
-        LATEST_SCHEMA_VERSION,
-        SNAPSHOT_MANIFEST_FORMAT_VERSION,
-      );
-    }
+    writeSnapshotMeta(sqliteDb, builtAt, streamed.tables);
     sqliteDb.exec('COMMIT');
+
+    let grades: LayoutGradesSnapshotResult | undefined;
+    if (gradesDb && streamed.gradesTables) {
+      writeSnapshotMeta(gradesDb, builtAt, streamed.gradesTables);
+      gradesDb.exec('COMMIT');
+      // A layout with no grade rows publishes nothing at all — every MoonBoard
+      // layout lands here, because MoonBoard is deliberately outside
+      // CROWD_MEAN_BOARDS (docs/boardsesh-grade.md).
+      if (streamed.gradesTables.board_climb_grades.rowCount > 0) {
+        grades = { filePath: gradesFilePath as string, tables: streamed.gradesTables };
+      }
+    }
 
     return {
       boardType,
@@ -373,17 +483,21 @@ export async function exportLayoutSnapshot(params: {
       filePath,
       builtAt,
       schemaVersion: LATEST_SCHEMA_VERSION,
-      tables,
+      tables: streamed.tables,
+      ...(grades ? { grades } : {}),
     };
   } catch (error) {
-    try {
-      sqliteDb.exec('ROLLBACK');
-    } catch {
-      // No open transaction to roll back — ignore.
+    for (const database of [sqliteDb, gradesDb]) {
+      try {
+        database?.exec('ROLLBACK');
+      } catch {
+        // No open transaction to roll back — ignore.
+      }
     }
     throw error;
   } finally {
     sqliteDb.close();
+    gradesDb?.close();
   }
 }
 
@@ -465,7 +579,20 @@ function buildManifestEntry(
     uncompressedBytes: number;
     contentEncoding: 'gzip' | 'identity';
   },
+  gradesUpload?: { url: string; key: string; bytes: number; contentEncoding: 'gzip' | 'identity' },
 ): SnapshotManifestEntry {
+  const grades: SnapshotGradesArtifact | undefined =
+    gradesUpload && result.grades
+      ? {
+          key: gradesUpload.key,
+          url: gradesUpload.url,
+          bytes: gradesUpload.bytes,
+          contentEncoding: gradesUpload.contentEncoding,
+          builtAt: result.builtAt,
+          schemaVersion: result.schemaVersion,
+          tables: { board_climb_grades: result.grades.tables.board_climb_grades },
+        }
+      : undefined;
   return {
     boardType: result.boardType,
     layoutId: result.layoutId,
@@ -480,6 +607,10 @@ function buildManifestEntry(
       board_climbs: result.tables.board_climbs,
       board_climb_stats: result.tables.board_climb_stats,
     },
+    // Omitted entirely rather than set to undefined: the manifest is serialized
+    // to JSON, and an explicit `"grades": undefined` key is not a thing — but
+    // keeping the shape clean makes the golden test's byte comparison honest.
+    ...(grades ? { grades } : {}),
   };
 }
 
@@ -585,6 +716,12 @@ async function fetchPreviousManifest(options: {
 async function pruneStaleArtifacts(manifest: SnapshotManifest, nowMs: number, keyPrefix: string): Promise<void> {
   try {
     const referencedKeys = new Set<string>(manifest.entries.map((entry) => entry.key));
+    // Grades artifacts live under the same prefix but are NOT in `entries`, so
+    // without this the 14-day grace window would start deleting live grades
+    // files out from under every client holding the current manifest.
+    for (const entry of manifest.entries) {
+      if (entry.grades) referencedKeys.add(entry.grades.key);
+    }
     referencedKeys.add(manifestKeyForPrefix(keyPrefix));
     const cutoffMs = nowMs - PRUNE_GRACE_MS;
 
@@ -676,6 +813,7 @@ export async function runExport(argv: string[]): Promise<void> {
     for (const pair of pairs) {
       const startedAt = Date.now();
       const filePath = join(workDir, `${pair.boardType}-${pair.layoutId}.db`);
+      const gradesFilePath = join(workDir, `${pair.boardType}-${pair.layoutId}-grades.db`);
       try {
         const result = await exportLayoutSnapshot({
           sqlClient,
@@ -683,6 +821,13 @@ export async function runExport(argv: string[]): Promise<void> {
           layoutId: pair.layoutId,
           filePath,
           builtAt,
+          // GZIP PASS ONLY. The nightly runs twice — once at the identity `v1`
+          // prefix kept as a rollback target, once at `v1-gzip` where the fleet
+          // actually points. Publishing grades only in the gzip pass means a
+          // rollback to `v1` is exactly today's behaviour (whole file + grades
+          // crawl) with no deploy, which is the kill switch for the whole
+          // grades path.
+          ...(options.gzip ? { gradesFilePath } : {}),
         });
 
         const rawBuffer = readFileSync(filePath);
@@ -699,28 +844,51 @@ export async function runExport(argv: string[]): Promise<void> {
         const keyStamp = builtAt.replace(/[:.]/g, '-');
         const key = `${keyPrefix}/${pair.boardType}/${pair.layoutId}/${keyStamp}.db`;
 
+        // The grades artifact is a sibling object under the same prefix, never
+        // a second `entries` element — findSnapshotEntry first-matches on
+        // (boardType, layoutId), so an old client could otherwise pick it up as
+        // if it were the whole layout and stamp checkpoints past rows it never
+        // imported.
+        const gradesKey = `${keyPrefix}/${pair.boardType}/${pair.layoutId}/${keyStamp}-grades.db`;
+        const gradesRawBuffer = result.grades ? readFileSync(result.grades.filePath) : null;
+        const gradesUploadBody = gradesRawBuffer ? gzipSync(gradesRawBuffer) : null;
+
         if (options.dryRun) {
           logger.info('[export-snapshots] built (dry-run, not uploaded)', {
             boardType: pair.boardType,
             layoutId: pair.layoutId,
             climbs: result.tables.board_climbs.rowCount,
             stats: result.tables.board_climb_stats.rowCount,
+            grades: result.grades?.tables.board_climb_grades.rowCount ?? 0,
             rawBytes: rawBuffer.length,
             uploadBytes: uploadBody.length,
+            gradesUploadBytes: gradesUploadBody?.length ?? 0,
             contentEncoding,
             durationMs: Date.now() - startedAt,
           });
+          // publicUrlForKey may fall back to getPublicUrl, which instantiates
+          // the S3 client — so only call it when S3 is configured. A dry-run
+          // must work with no AWS credentials at all.
+          const canBuildPublicUrl = isS3Configured() || snapshotPublicBaseUrl() !== '';
           newEntries.push(
-            buildManifestEntry(result, {
-              // publicUrlForKey may fall back to getPublicUrl, which instantiates
-              // the S3 client — so only call it when S3 is configured. A dry-run
-              // must work with no AWS credentials at all.
-              url: isS3Configured() || snapshotPublicBaseUrl() ? publicUrlForKey(key) : `dry-run:${key}`,
-              key,
-              bytes: uploadBody.length,
-              uncompressedBytes: rawBuffer.length,
-              contentEncoding,
-            }),
+            buildManifestEntry(
+              result,
+              {
+                url: canBuildPublicUrl ? publicUrlForKey(key) : `dry-run:${key}`,
+                key,
+                bytes: uploadBody.length,
+                uncompressedBytes: rawBuffer.length,
+                contentEncoding,
+              },
+              gradesUploadBody
+                ? {
+                    url: canBuildPublicUrl ? publicUrlForKey(gradesKey) : `dry-run:${gradesKey}`,
+                    key: gradesKey,
+                    bytes: gradesUploadBody.length,
+                    contentEncoding: 'gzip' as const,
+                  }
+                : undefined,
+            ),
           );
         } else {
           const uploaded = await uploadToS3(
@@ -729,24 +897,44 @@ export async function runExport(argv: string[]): Promise<void> {
             ARTIFACT_CONTENT_TYPE,
             options.gzip ? { contentEncoding: 'gzip' } : undefined,
           );
+          // Uploaded BEFORE the manifest that references it, like the
+          // whole-layout artifact — the manifest is always written last, so a
+          // reader never sees a key that is not on S3 yet.
+          const uploadedGrades = gradesUploadBody
+            ? await uploadToS3(gradesUploadBody, gradesKey, ARTIFACT_CONTENT_TYPE, { contentEncoding: 'gzip' })
+            : null;
           logger.info('[export-snapshots] uploaded', {
             boardType: pair.boardType,
             layoutId: pair.layoutId,
             climbs: result.tables.board_climbs.rowCount,
             stats: result.tables.board_climb_stats.rowCount,
+            grades: result.grades?.tables.board_climb_grades.rowCount ?? 0,
             uploadBytes: uploadBody.length,
+            gradesUploadBytes: gradesUploadBody?.length ?? 0,
             contentEncoding,
             key: uploaded.key,
+            gradesKey: uploadedGrades?.key ?? null,
             durationMs: Date.now() - startedAt,
           });
           newEntries.push(
-            buildManifestEntry(result, {
-              url: publicUrlForKey(uploaded.key),
-              key: uploaded.key,
-              bytes: uploadBody.length,
-              uncompressedBytes: rawBuffer.length,
-              contentEncoding,
-            }),
+            buildManifestEntry(
+              result,
+              {
+                url: publicUrlForKey(uploaded.key),
+                key: uploaded.key,
+                bytes: uploadBody.length,
+                uncompressedBytes: rawBuffer.length,
+                contentEncoding,
+              },
+              uploadedGrades && gradesUploadBody
+                ? {
+                    url: publicUrlForKey(uploadedGrades.key),
+                    key: uploadedGrades.key,
+                    bytes: gradesUploadBody.length,
+                    contentEncoding: 'gzip' as const,
+                  }
+                : undefined,
+            ),
           );
         }
       } catch (error) {
@@ -763,6 +951,7 @@ export async function runExport(argv: string[]): Promise<void> {
         });
       } finally {
         rmSync(filePath, { force: true });
+        rmSync(gradesFilePath, { force: true });
       }
     }
 

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -144,6 +144,8 @@ export type {
   SnapshotManifestEntry,
   SnapshotTableStats,
   SnapshotTableName,
+  SnapshotGradesArtifact,
+  SnapshotGradesTableName,
 } from './sync/snapshot-manifest';
 
 // --- Pre-download size estimate (issue #3616) ------------------------------------

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-manifest.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-manifest.test.ts
@@ -140,3 +140,113 @@ describe('parseSnapshotManifest', () => {
     expect(parseSnapshotManifest(withEntry({ contentEncoding: 'br' as unknown as 'gzip' }))).toBeNull();
   });
 });
+
+// Backward-compat gate for the additive `grades` block (issue #4310). The
+// validator below is a FROZEN COPY of the predicate that shipped before grades
+// existed, checked in rather than imported, so it keeps testing the old
+// behaviour even as the real one evolves. If a manifest carrying grades ever
+// stops parsing under it, every already-installed binary loses the snapshot
+// fast path the moment the export publishes.
+function parseWithShippedV1Validator(value: unknown): unknown | null {
+  const isRecord = (candidate: unknown): candidate is Record<string, unknown> =>
+    typeof candidate === 'object' && candidate !== null && !Array.isArray(candidate);
+  const isInteger = (candidate: unknown): boolean => typeof candidate === 'number' && Number.isInteger(candidate);
+  const isDecimalString = (candidate: unknown): boolean => typeof candidate === 'string' && /^\d+$/.test(candidate);
+  const isIso = (candidate: unknown): boolean =>
+    typeof candidate === 'string' &&
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?Z$/.test(candidate) &&
+    Number.isFinite(Date.parse(candidate));
+  const isTableStats = (candidate: unknown): boolean =>
+    isRecord(candidate) &&
+    isIso(candidate.watermarkUpdatedAt) &&
+    isDecimalString(candidate.watermarkSyncSeq) &&
+    isInteger(candidate.rowCount);
+  const isEntry = (candidate: unknown): boolean => {
+    if (!isRecord(candidate)) return false;
+    if (
+      typeof candidate.boardType !== 'string' ||
+      !isInteger(candidate.layoutId) ||
+      typeof candidate.key !== 'string' ||
+      typeof candidate.url !== 'string' ||
+      !isInteger(candidate.bytes) ||
+      (candidate.contentEncoding !== 'gzip' && candidate.contentEncoding !== 'identity') ||
+      !isIso(candidate.builtAt) ||
+      !isInteger(candidate.schemaVersion)
+    ) {
+      return false;
+    }
+    const tables = candidate.tables;
+    if (!isRecord(tables)) return false;
+    return ['board_climbs', 'board_climb_stats'].every((tableName) => isTableStats(tables[tableName]));
+  };
+
+  if (!isRecord(value)) return null;
+  if (value.formatVersion !== 1) return null;
+  if (!isIso(value.generatedAt)) return null;
+  if (!Array.isArray(value.entries)) return null;
+  if (!value.entries.every(isEntry)) return null;
+  return value;
+}
+
+function validGradesArtifact() {
+  return {
+    key: 'board-snapshots/v1-gzip/kilter/8/2026-06-01T00-00-00-000Z-grades.db',
+    url: 'https://cdn.example/board-snapshots/v1-gzip/kilter/8/2026-06-01T00-00-00-000Z-grades.db',
+    bytes: 2048,
+    contentEncoding: 'gzip' as const,
+    builtAt: '2026-06-01T00:00:00.000Z',
+    schemaVersion: 3,
+    tables: {
+      board_climb_grades: { watermarkUpdatedAt: '2026-05-30T08:00:00Z', watermarkSyncSeq: '777', rowCount: 5000 },
+    },
+  };
+}
+
+describe('parseSnapshotManifest — the optional grades artifact', () => {
+  it('accepts an entry with no grades block at all (MoonBoard, or the export rolled back)', () => {
+    expect(parseSnapshotManifest(validManifest())).not.toBeNull();
+  });
+
+  it('accepts and preserves a well-formed grades block', () => {
+    const manifest = withEntry({ grades: validGradesArtifact() });
+
+    const parsed = parseSnapshotManifest(JSON.parse(JSON.stringify(manifest)) as unknown);
+
+    expect(parsed?.entries[0].grades?.tables.board_climb_grades.rowCount).toBe(5000);
+  });
+
+  it('REJECTS a malformed grades block rather than trusting half of it', () => {
+    // A truncated grades block that still parsed would be trusted far enough to
+    // stamp a grades checkpoint over rows that never arrived.
+    for (const broken of [
+      { ...validGradesArtifact(), bytes: 1.5 },
+      { ...validGradesArtifact(), key: 42 },
+      { ...validGradesArtifact(), contentEncoding: 'br' },
+      { ...validGradesArtifact(), builtAt: 'not-a-timestamp' },
+      { ...validGradesArtifact(), tables: {} },
+      { ...validGradesArtifact(), tables: { board_climb_grades: { rowCount: 1 } } },
+      'not an object',
+    ]) {
+      expect(parseSnapshotManifest(withEntry({ grades: broken as never })), JSON.stringify(broken)).toBeNull();
+    }
+  });
+
+  it('parses under the FROZEN shipped v1 validator — no installed binary can choke on it', () => {
+    const manifest = JSON.parse(JSON.stringify(withEntry({ grades: validGradesArtifact() }))) as unknown;
+
+    expect(parseWithShippedV1Validator(manifest)).not.toBeNull();
+  });
+
+  it('keeps the grades artifact OUT of `entries` — a sibling entry would be picked as the whole layout', () => {
+    // findSnapshotEntry first-matches on (boardType, layoutId), so a grades
+    // artifact promoted to its own entry could be imported by an older client
+    // as if it carried the layout's climbs, stamping checkpoints past rows it
+    // never imported. Permanent loss, so pin the shape.
+    const manifest = parseSnapshotManifest(
+      JSON.parse(JSON.stringify(withEntry({ grades: validGradesArtifact() }))) as unknown,
+    );
+
+    expect(manifest?.entries).toHaveLength(1);
+    expect(manifest?.entries[0].tables).not.toHaveProperty('board_climb_grades');
+  });
+});

--- a/packages/shared/offline-sync/src/sync/snapshot-manifest.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-manifest.ts
@@ -11,8 +11,25 @@
 // change so an old client rejects a manifest it can't parse rather than acting
 // on partial data.
 
-/** The two reference-data tables a snapshot carries. */
+/** The two reference-data tables the whole-layout snapshot carries. */
 export type SnapshotTableName = 'board_climbs' | 'board_climb_stats';
+
+/**
+ * The table the SEPARATE per-layout grades artifact carries.
+ *
+ * Boardsesh grades live in their own file rather than in the whole-layout
+ * artifact for two reasons (issue #4310). First, every shipped binary already
+ * downloads and verifies the whole-layout artifact against a two-table
+ * `snapshot_meta`, and widening that file's meta would make an updated client
+ * reject every pre-change artifact still inside the 14-day prune grace as a
+ * COUNTED import failure — two of those and the scope falls to the paged crawl.
+ * Second, grades are the term the whole-layout artifact never covered: they are
+ * a per-board table the scope-completion gate waits on, so every Kilter and
+ * Tension download pays hundreds of serial authenticated GraphQL pages for
+ * them, which is why boards with grades are ~6x slower than a MoonBoard layout
+ * of the same size.
+ */
+export type SnapshotGradesTableName = 'board_climb_grades';
 
 /** Artifact-level per-table watermark + row count. */
 export type SnapshotTableStats = {
@@ -24,6 +41,31 @@ export type SnapshotTableStats = {
   // lose precision in a JS number.
   watermarkSyncSeq: string;
   rowCount: number;
+};
+
+/**
+ * A layout's Boardsesh-grades artifact: a standalone SQLite file with the
+ * `board_climb_grades` DDL, that layout's grade rows, and its own one-row
+ * `snapshot_meta`. Optional per entry — layouts with no grade rows (every
+ * MoonBoard layout: MoonBoard is deliberately outside CROWD_MEAN_BOARDS,
+ * see docs/boardsesh-grade.md) publish none, and a manifest with no `grades`
+ * anywhere is the kill switch that reverts the fleet to the crawl.
+ *
+ * Deliberately NOT its own element of `entries`: `findSnapshotEntry` first-
+ * matches on (boardType, layoutId), so a sibling entry could be picked by an
+ * older client and imported as if it were the whole layout — stamping
+ * checkpoints past rows it never imported.
+ */
+export type SnapshotGradesArtifact = {
+  // S3 object key, e.g. `board-snapshots/v1-gzip/kilter/1/<iso>-grades.db`.
+  key: string;
+  url: string;
+  // Stored object size in bytes (gzip, like the whole-layout entry's `bytes`).
+  bytes: number;
+  contentEncoding: 'gzip' | 'identity';
+  builtAt: string;
+  schemaVersion: number;
+  tables: Record<SnapshotGradesTableName, SnapshotTableStats>;
 };
 
 export type SnapshotManifestEntry = {
@@ -60,6 +102,11 @@ export type SnapshotManifestEntry = {
   // up (or refuse it) before serving reads from it.
   schemaVersion: number;
   tables: Record<SnapshotTableName, SnapshotTableStats>;
+  // The layout's separate grades artifact, when it has grade rows. ADDITIVE:
+  // `formatVersion` stays 1 because the shipped validator only rejects
+  // missing/mistyped KNOWN fields, so a binary that predates this field parses
+  // the manifest unchanged and takes today's path.
+  grades?: SnapshotGradesArtifact;
 };
 
 export type SnapshotManifest = {
@@ -72,6 +119,7 @@ export type SnapshotManifest = {
 export const SNAPSHOT_MANIFEST_FORMAT_VERSION = 1 as const;
 
 const SNAPSHOT_TABLE_NAMES: readonly SnapshotTableName[] = ['board_climbs', 'board_climb_stats'];
+const SNAPSHOT_GRADES_TABLE_NAMES: readonly SnapshotGradesTableName[] = ['board_climb_grades'];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -105,6 +153,27 @@ function isTableStats(value: unknown): value is SnapshotTableStats {
   );
 }
 
+// Validated only WHEN PRESENT: absent `grades` is the normal, supported state
+// (a MoonBoard layout, a rolled-back export, the kill switch). A MALFORMED one
+// is rejected, because a half-written grades block would otherwise be trusted
+// far enough to stamp a grades checkpoint over rows that never arrived.
+function isGradesArtifact(value: unknown): value is SnapshotGradesArtifact {
+  if (!isRecord(value)) return false;
+  if (
+    typeof value.key !== 'string' ||
+    typeof value.url !== 'string' ||
+    !isInteger(value.bytes) ||
+    (value.contentEncoding !== 'gzip' && value.contentEncoding !== 'identity') ||
+    !isIsoUtcTimestamp(value.builtAt) ||
+    !isInteger(value.schemaVersion)
+  ) {
+    return false;
+  }
+  const tables = value.tables;
+  if (!isRecord(tables)) return false;
+  return SNAPSHOT_GRADES_TABLE_NAMES.every((tableName) => isTableStats(tables[tableName]));
+}
+
 function isManifestEntry(value: unknown): value is SnapshotManifestEntry {
   if (!isRecord(value)) return false;
   if (
@@ -127,6 +196,7 @@ function isManifestEntry(value: unknown): value is SnapshotManifestEntry {
   if (value.uncompressedBytes !== undefined && (!isInteger(value.uncompressedBytes) || value.uncompressedBytes < 0)) {
     return false;
   }
+  if (value.grades !== undefined && !isGradesArtifact(value.grades)) return false;
   const tables = value.tables;
   if (!isRecord(tables)) return false;
   return SNAPSHOT_TABLE_NAMES.every((tableName) => isTableStats(tables[tableName]));

--- a/packages/shared/offline-sync/src/sync/table-config.ts
+++ b/packages/shared/offline-sync/src/sync/table-config.ts
@@ -13,13 +13,31 @@ export type TableSyncConfig = {
   invalidateKeys: InvalidateKeys;
   primaryKeyColumns: string[];
   localColumns: readonly string[];
+  /**
+   * The timestamp half of this table's `(timestamp, sync_seq)` keyset cursor —
+   * whatever the resolver passes as `updatedAtColumn` in
+   * packages/backend/src/graphql/resolvers/sync/queries.ts. Almost every table
+   * cursors on `updated_at`; `board_climb_grades` cursors on `computed_at`
+   * because grades are bulk-recomputed reference data, not user writes.
+   *
+   * Declared HERE rather than duplicated in the nightly export job and the
+   * snapshot import so the two can never disagree about which column a
+   * watermark covers. Disagreement is a data-loss bug in one direction: a
+   * watermark read off the wrong column can cover rows the artifact never
+   * carried, and the strict `>` delta pull never revisits them.
+   */
+  cursorColumn: string;
 };
 
 type TableSyncDefinition = Omit<TableSyncConfig, 'invalidateKeys'>;
 
+/** The cursor column all but one sync table uses. */
+const UPDATED_AT_CURSOR = 'updated_at';
+
 const TABLE_SYNC_DEFINITIONS: Record<string, TableSyncDefinition> = {
   boardsesh_ticks: {
     queryName: 'syncTicks',
+    cursorColumn: UPDATED_AT_CURSOR,
     operationKey: 'SYNC_TICKS',
     isPerBoard: false,
     primaryKeyColumns: ['uuid'],
@@ -44,6 +62,7 @@ const TABLE_SYNC_DEFINITIONS: Record<string, TableSyncDefinition> = {
   },
   playlists: {
     queryName: 'syncPlaylists',
+    cursorColumn: UPDATED_AT_CURSOR,
     operationKey: 'SYNC_PLAYLISTS',
     isPerBoard: false,
     primaryKeyColumns: ['uuid'],
@@ -63,6 +82,7 @@ const TABLE_SYNC_DEFINITIONS: Record<string, TableSyncDefinition> = {
   },
   playlist_climbs: {
     queryName: 'syncPlaylistClimbs',
+    cursorColumn: UPDATED_AT_CURSOR,
     operationKey: 'SYNC_PLAYLIST_CLIMBS',
     isPerBoard: false,
     primaryKeyColumns: ['playlist_uuid', 'climb_uuid'],
@@ -70,6 +90,7 @@ const TABLE_SYNC_DEFINITIONS: Record<string, TableSyncDefinition> = {
   },
   user_favorites: {
     queryName: 'syncFavorites',
+    cursorColumn: UPDATED_AT_CURSOR,
     operationKey: 'SYNC_FAVORITES',
     isPerBoard: false,
     primaryKeyColumns: ['board_name', 'climb_uuid', 'angle'],
@@ -77,6 +98,7 @@ const TABLE_SYNC_DEFINITIONS: Record<string, TableSyncDefinition> = {
   },
   user_follows: {
     queryName: 'syncUserFollows',
+    cursorColumn: UPDATED_AT_CURSOR,
     operationKey: 'SYNC_USER_FOLLOWS',
     isPerBoard: false,
     primaryKeyColumns: ['following_id'],
@@ -84,6 +106,7 @@ const TABLE_SYNC_DEFINITIONS: Record<string, TableSyncDefinition> = {
   },
   setter_follows: {
     queryName: 'syncSetterFollows',
+    cursorColumn: UPDATED_AT_CURSOR,
     operationKey: 'SYNC_SETTER_FOLLOWS',
     isPerBoard: false,
     primaryKeyColumns: ['setter_username'],
@@ -91,6 +114,7 @@ const TABLE_SYNC_DEFINITIONS: Record<string, TableSyncDefinition> = {
   },
   playlist_follows: {
     queryName: 'syncPlaylistFollows',
+    cursorColumn: UPDATED_AT_CURSOR,
     operationKey: 'SYNC_PLAYLIST_FOLLOWS',
     isPerBoard: false,
     primaryKeyColumns: ['playlist_uuid'],
@@ -98,6 +122,7 @@ const TABLE_SYNC_DEFINITIONS: Record<string, TableSyncDefinition> = {
   },
   board_climbs: {
     queryName: 'syncClimbs',
+    cursorColumn: UPDATED_AT_CURSOR,
     operationKey: 'SYNC_CLIMBS',
     isPerBoard: true,
     primaryKeyColumns: ['uuid'],
@@ -133,6 +158,7 @@ const TABLE_SYNC_DEFINITIONS: Record<string, TableSyncDefinition> = {
   },
   board_climb_stats: {
     queryName: 'syncClimbStats',
+    cursorColumn: UPDATED_AT_CURSOR,
     operationKey: 'SYNC_CLIMB_STATS',
     isPerBoard: true,
     primaryKeyColumns: ['board_type', 'climb_uuid', 'angle'],
@@ -153,6 +179,10 @@ const TABLE_SYNC_DEFINITIONS: Record<string, TableSyncDefinition> = {
   },
   board_climb_grades: {
     queryName: 'syncClimbGrades',
+    // The one table that does NOT cursor on updated_at — it has no such column.
+    // Matches `updatedAtColumn: sql`board_climb_grades.computed_at`` in the
+    // syncClimbGrades resolver.
+    cursorColumn: 'computed_at',
     // operationKey is a label only — the pull client builds the query from
     // queryName (buildSyncQuery), so no separate registered SYNC_CLIMB_GRADES
     // document is needed, exactly like SYNC_CLIMB_STATS.


### PR DESCRIPTION
Boardsesh grades are the one per-board table the snapshot never carried, and the scope-completion gate waits on **every** per-board table — so after a Kilter or Tension artifact lands, the scope still pages hundreds of serial authenticated GraphQL requests for `board_climb_grades` before it can serve an offline search, each re-running a correlated `EXISTS` against 375k climbs.

The live manifest holds the natural experiment. `board_climb_grades` is populated only for `CROWD_MEAN_BOARDS`, which deliberately excludes MoonBoard (`packages/db/src/queries/grade-model/constants.ts`, `docs/boardsesh-grade.md`):

| entry | artifact | climbs | grade rows | p50 |
|---|---|---|---|---|
| `moonboard:2` | 20.0 MB | 93,939 | **0** | **14.5s** |
| `tension:9` | 17.1 MB | 72,051 | ~79k | **1m27s** |

Same bytes, same import shape, roughly six times the duration. The only structural difference is the grades crawl.

This PR is the **export side only**. Nothing reads `grades` yet — that is the stacked follow-up.

## Changes

- **A second, standalone artifact per layout** at `<prefix>/<board>/<layout>/<builtAt>-grades.db`: the `board_climb_grades` DDL from the shared MIGRATIONS, that layout's grade rows, and its own **one-row** `snapshot_meta`. Scoped by the same correlated `EXISTS` over `board_climbs` that the `syncClimbGrades` resolver uses, plus the stability window.
- **One transaction.** Both files are written inside the same `REPEATABLE READ` transaction as the whole-layout artifact, so the grade rows and the climbs they hang off come from one database snapshot and their watermarks are mutually consistent.
- **The whole-layout artifact is untouched** — same DDL, same two tables, same two `snapshot_meta` rows, pinned by a test. Every shipped binary verifies that file against its own two-table list and a mismatch is a **counted** import failure; two of those settle a scope onto the paged crawl, so widening its meta would break the fleet for the entire 14-day prune grace.
- **Additive manifest.** Optional `grades` block on the layout's existing entry, `formatVersion` still `1`, validated only when present (and rejected when malformed — a half-parsed grades block would be trusted far enough to stamp a checkpoint over rows that never arrived). Grades artifacts are deliberately **not** elements of `entries`: `findSnapshotEntry` first-matches on `(boardType, layoutId)`, so a sibling entry could be imported by an older client as if it were the whole layout.
- **Per-table cursor column.** `TABLE_CONFIGS[...].cursorColumn` now declares the timestamp half of each table's keyset cursor once. Grades cursor on `computed_at` — they have no `updated_at` column — and the export reads the column from the shared config so it, the resolvers, and the client import cannot disagree about which column a watermark covers.
- **Prune safety.** `pruneStaleArtifacts`' referenced-key set now includes every surviving entry's `grades.key`. Without it the 14-day grace window would start deleting live grades files out from under clients holding the current manifest.
- **Gzip pass only.** The nightly runs twice — the identity `v1` prefix kept as a rollback target, and `v1-gzip` where the fleet actually points. Publishing grades only in the gzip pass makes a rollback to `v1` exactly today's behaviour with no deploy, which is the kill switch for the whole path.
- `docs/board-snapshots.md` updated: storage layout, prune, artifact format, a new "Grades artifact" section, and the kill switch.

### Deviation from the plan

The plan's dead-index trim (`idx_stats_lookup`, an exact duplicate of the stats `PRIMARY KEY`, plus `idx_stats_difficulty`) is **not included**. It was gated on two proofs — a `--dry-run` byte delta against the dev DB and an old-engine import test — and it is the only PR-2 change a shipped binary can feel. Filed as a follow-up rather than landed unmeasured.

### Post-merge reconciliation

Rebased onto `main` after #4335 (`uncompressedBytes` in the manifest entry + export) landed — both features are kept: entries carry `uncompressedBytes` **and** the optional `grades` block. A further reconciliation with #4345 is expected on the client side of this stack: #4345 replaces the `downloadedPaths` set that #4347 registers the grades file in with its `artifactImported` / `releaseArtifact` seam, and grades filenames do not match snapshot-source's `artifactNamePrefix` regex, so its supersede sweep will not recognise them. Nothing in this backend-only PR changes as a result.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project backend packages/backend/src/__tests__/snapshot-export-golden.test.ts` — 11 passed. New: exported grade rows are byte-identical to what a real `syncClimbGrades` pull writes through the real client upsert path; the whole-layout artifact still has exactly `board_climbs` + `board_climb_stats` and two meta rows and no grades table; the grades file carries only its own table and one meta row; the watermark cursors on `computed_at`; a grade inside the stability window is excluded from both the rows and the watermark; a grade for another layout never lands; a layout with no grade rows publishes nothing; omitting `gradesFilePath` skips grades entirely.
- `vp test run --project backend packages/backend/src/__tests__/snapshot-export-run.test.ts` — 30 passed. New: a gzip run publishes the grades object and references it from the entry (still one entry per board+layout, `formatVersion` 1); a layout with no grades omits the block and uploads nothing; the identity pass publishes no grades at all; the prune never deletes a just-published grades key; a superseded grades key **is** pruned past the grace window; a filtered run preserves another board's previously-published grades block.
- `vp test run --project offline-sync` — 344 passed, including a **frozen copy of the shipped v1 manifest validator** checked in as a fixture that must keep accepting a grades-carrying manifest, plus malformed-grades rejection and the "grades stay out of `entries`" shape guard.
- `vp run typecheck` (all packages), `vp lint` — clean in the touched packages.

Only the two changed backend files were run, per the shared-worker-DB rule; CI covers the rest of the backend suite. No nightly export has been dispatched yet — that is the gate for the stacked client PR leaving draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT6VP1sWqk6bY9mUgyeS2U


