### PR TITLE
perf(sync): import Boardsesh grades from the snapshot instead of crawling them

### DIFF
--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -220,6 +220,31 @@ The fix is a second, standalone artifact per layout:
 - Kill switch: publish a manifest with no `grades` anywhere (or roll back to the identity `v1` prefix,
   which never carries grades) and every client reverts to today's crawl with no deploy.
 
+Client side (`bootstrapScopeGradesFromSnapshot`), the grades file is imported in its **own** exclusive
+transaction immediately after the climbs/stats one, not merged into it. Merging would close a crash window
+but lengthen a single `BEGIN EXCLUSIVE` hold on a database the app is also reading (issue #4314); splitting
+keeps each hold short, and the worst case is exactly today's behaviour — no grades checkpoint gets stamped
+and the scope crawls grades as it always did. There is no reconcile step: `board_climb_grades` has no
+delete trigger at all, so `INSERT OR REPLACE` is the whole import, and `rewindDeletionsCheckpoint` stays
+`min(climbs, stats)`.
+
+Two entry points, both free to fail:
+
+1. Straight after a successful whole-layout import.
+2. **Retro-fit** — a scope whose climb catalog is already COMPLETE (`bootstrap-done:<scope>`: the
+   whole-layout artifact landed, or `scope-complete:<scope>`: the paged crawl reached every table's tail)
+   but whose `checkpoint:board_climb_grades:<scope>` is ABSENT. An absent grades checkpoint proves no grade
+   page was ever consumed (`syncTable` checkpoints per page), so importing and stamping at the artifact's
+   watermark cannot skip a row the crawl already had. This is what rescues every scope downloaded before
+   grades artifacts existed. The completeness gate is load-bearing: the import filters the artifact's grades
+   through `main.board_climbs`, so over a half-crawled catalog it would stamp the grades cursor past every
+   grade row whose climb has not been fetched yet, and the strict `>` delta never revisits those.
+
+Grades failures use their own budget (`grades-bootstrap-attempts:<scope>`, cap 2) and never touch
+`bootstrap-attempts` — losing the grades fast path must never cost a scope its snapshot fast path. A
+download that returns `null` counts against that budget exactly as a throw does; otherwise a source that
+signals failure by returning `null` would re-fetch the artifact every cycle forever.
+
 ## Client bootstrap flow
 
 Implemented in `snapshot-bootstrap.ts` (the ATTACH/import/verify mechanics) and orchestrated from

--- a/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
+++ b/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
@@ -621,3 +621,64 @@ describe('retention and reuse', () => {
     expect(state.files.has(SIDECAR_URI)).toBe(true);
   });
 });
+
+// The layout's separate Boardsesh-grades artifact (issue #4310). Small next to
+// the ~100 MB climbs file, but it removes hundreds of serial authenticated
+// GraphQL pages from every Kilter and Tension download.
+describe('downloadGradesArtifact', () => {
+  const GRADES_ARTIFACT = {
+    key: 'board-snapshots/v1-gzip/kilter/8/2026-06-01T00-00-00-000Z-grades.db',
+    url: 'https://example.test/artifacts/kilter-8-grades.db',
+    bytes: 2_000_000,
+    contentEncoding: 'gzip' as const,
+    builtAt: '2026-06-01T00:00:00.000Z',
+    schemaVersion: 1,
+    tables: {
+      board_climb_grades: { watermarkUpdatedAt: '2026-05-01T00:00:00Z', watermarkSyncSeq: '10', rowCount: 900 },
+    },
+  };
+
+  it('downloads to a key-derived filename and returns a plain filesystem path', async () => {
+    const result = await mobileSnapshotSource.downloadGradesArtifact?.(GRADES_ARTIFACT);
+
+    expect(state.downloadCalls).toEqual([
+      { url: GRADES_ARTIFACT.url, idempotent: true, hasOnProgress: false, hasSignal: false },
+    ]);
+    expect(result?.filePath.startsWith('file://')).toBe(false);
+    // Key-derived: the manifest's grades block carries no board/layout pair,
+    // and the key is already content-addressed by build stamp.
+    expect(result?.filePath).toContain('board-snapshots-v1-gzip-kilter-8');
+    // No completeness sidecar: a grades file is never retained across cycles
+    // (the engine deletes it in its finally), so nothing may mark it reusable.
+    expect([...state.files.keys()].some((uri) => uri.endsWith('.complete'))).toBe(false);
+  });
+
+  it('applies the same free-space guard as the whole-layout artifact', async () => {
+    state.availableDiskSpace = GRADES_ARTIFACT.bytes * 2; // under the 6x gzip multiple
+
+    await expect(mobileSnapshotSource.downloadGradesArtifact?.(GRADES_ARTIFACT)).rejects.toThrow(
+      /insufficient disk space/,
+    );
+    expect(state.downloadCalls).toHaveLength(0);
+  });
+
+  it('permanently misses (and deletes) a body that arrived still gzip-compressed', async () => {
+    state.downloadBytes = GZIP_BYTES;
+
+    await expect(mobileSnapshotSource.downloadGradesArtifact?.(GRADES_ARTIFACT)).rejects.toThrow(
+      SnapshotPermanentMissError,
+    );
+    expect(state.deletedUris).toHaveLength(1);
+  });
+
+  it('keeps the underlying download exception as `cause` for the transport classifier', async () => {
+    const downloadError = Object.assign(new Error('The request timed out.'), {
+      name: 'UnableToDownloadException',
+    });
+    state.downloadError = downloadError;
+
+    const rejection = await mobileSnapshotSource.downloadGradesArtifact?.(GRADES_ARTIFACT).catch((error) => error);
+
+    expect((rejection as Error).cause).toBe(downloadError);
+  });
+});

--- a/packages/mobile/src/offline/snapshot-source.ts
+++ b/packages/mobile/src/offline/snapshot-source.ts
@@ -31,6 +31,7 @@ import {
   SnapshotPermanentMissError,
   type SnapshotArtifactHandle,
   type SnapshotDownloadOptions,
+  type SnapshotGradesArtifact,
   type SnapshotManifestEntry,
   type SnapshotSource,
 } from '@boardsesh/offline-sync';
@@ -88,6 +89,11 @@ const EXACT_FREE_SPACE_SLACK_BYTES = 32 * 1024 * 1024;
  * can both be on disk at once, so it is the sum plus slack — and a coarse
  * multiplier otherwise.
  */
+/** The coarse multiplier, for artifacts the manifest gives no decoded size for. */
+function gradesFreeSpaceMultiplier(contentEncoding: 'gzip' | 'identity'): number {
+  return contentEncoding === 'gzip' ? GZIP_FREE_SPACE_SAFETY_MULTIPLIER : IDENTITY_FREE_SPACE_SAFETY_MULTIPLIER;
+}
+
 function requiredFreeBytes(entry: SnapshotManifestEntry): number {
   if (typeof entry.uncompressedBytes === 'number' && entry.uncompressedBytes > 0) {
     return entry.uncompressedBytes + entry.bytes + EXACT_FREE_SPACE_SLACK_BYTES;
@@ -312,15 +318,38 @@ function formatError(error: unknown): string {
  * request timed out.")` is an offline user (a warning) or a real fault (an
  * error). Issue #4238.
  */
-async function downloadArtifact(
-  entry: SnapshotManifestEntry,
+/**
+ * The shared download body for BOTH artifact kinds: free-space check,
+ * content-addressed destination, download, and the gzip magic-byte sniff. The
+ * only differences between the whole-layout artifact and the separate grades
+ * artifact are the filename, the label in error messages, and retention — which
+ * only the whole-layout file gets (`retainAs`).
+ */
+async function downloadSnapshotFile(
+  artifact: {
+    label: string;
+    url: string;
+    requiredBytes: number;
+    contentEncoding: 'gzip' | 'identity';
+    fileName: string;
+    telemetryExtra: Record<string, unknown>;
+    /**
+     * Build stamp for the completeness sidecar. Present only for the
+     * whole-layout artifact: retention (#4310) is sized for its ~100 MB and its
+     * supersede sweep recognises a build by the `<board>-<layout>` filename
+     * prefix, which a grades file (named from its manifest key) does not carry.
+     * Without it this function writes no sidecar, reuses nothing, and runs no
+     * sweep — the engine deletes the file at the end of the cycle instead.
+     */
+    retainAs?: { builtAt: string };
+  },
   options?: SnapshotDownloadOptions,
 ): Promise<SnapshotArtifactHandle | null> {
-  const requiredBytes = requiredFreeBytes(entry);
+  const requiredBytes = artifact.requiredBytes;
   const availableBytes = Paths.availableDiskSpace;
   if (availableBytes < requiredBytes) {
     throw new Error(
-      `snapshot download: insufficient disk space for ${entry.boardType}:${entry.layoutId} ` +
+      `snapshot download: insufficient disk space for ${artifact.label} ` +
         `(need ~${requiredBytes} bytes, have ${availableBytes} bytes free)`,
     );
   }
@@ -332,18 +361,14 @@ async function downloadArtifact(
     throw new Error(`snapshot download: failed to create cache directory: ${formatError(error)}`, { cause: error });
   }
 
-  // Content-addressed filename (boardType/layoutId/builtAt) so a retried
-  // download for the same artifact overwrites cleanly (idempotent: true below)
-  // instead of accumulating orphaned files across bootstrap attempts.
-  const safeBuiltAt = entry.builtAt.replace(/[^a-zA-Z0-9]/g, '-');
-  const destination = new File(directory, `${entry.boardType}-${entry.layoutId}-${safeBuiltAt}.db`);
+  const destination = new File(directory, artifact.fileName);
 
   // A retained artifact from an earlier cycle, complete and for this exact
   // build: hand it straight back. The engine still runs quick_check and
   // verifySnapshotMeta over it before importing a single row, and treats an
   // import failure on a reused file as delete-and-refetch rather than a counted
   // bootstrap attempt — so trusting the sidecar here cannot strand a scope.
-  if (destination.exists && hasCompleteSidecar(destination, entry.builtAt)) {
+  if (artifact.retainAs && destination.exists && hasCompleteSidecar(destination, artifact.retainAs.builtAt)) {
     return { filePath: toSqlitePath(destination.uri), reused: true };
   }
   // A file with no (or a mismatched) sidecar is a half-written download, not a
@@ -361,7 +386,7 @@ async function downloadArtifact(
     // to the pre-#4311 one. `signal` rides both shapes: it only cancels the
     // transfer and does not switch implementations.
     downloaded = await File.downloadFileAsync(
-      entry.url,
+      artifact.url,
       destination,
       options?.onProgress
         ? {
@@ -377,13 +402,12 @@ async function downloadArtifact(
         : { idempotent: true, signal: options?.signal },
     );
   } catch (error) {
-    throw new Error(
-      `snapshot download: File.downloadFileAsync failed for ${entry.boardType}:${entry.layoutId}: ${formatError(error)}`,
-      { cause: error },
-    );
+    throw new Error(`snapshot download: File.downloadFileAsync failed for ${artifact.label}: ${formatError(error)}`, {
+      cause: error,
+    });
   }
 
-  if (entry.contentEncoding === 'gzip') {
+  if (artifact.contentEncoding === 'gzip') {
     let stillCompressed: boolean;
     try {
       stillCompressed = await looksGzipCompressed(downloaded);
@@ -393,7 +417,7 @@ async function downloadArtifact(
       // the one that reported `cause: null` to Sentry (issue #4238).
       safeDeleteFile(downloaded);
       throw new Error(
-        `snapshot download: could not verify artifact encoding for ${entry.boardType}:${entry.layoutId}: ${formatError(error)}`,
+        `snapshot download: could not verify artifact encoding for ${artifact.label}: ${formatError(error)}`,
         { cause: error },
       );
     }
@@ -410,7 +434,7 @@ async function downloadArtifact(
         new Error('snapshot artifact arrived still gzip-compressed (Content-Encoding was not auto-decoded)'),
         {
           tags: { source: 'offline-sync', kind: 'snapshot-bootstrap' },
-          extra: { boardType: entry.boardType, layoutId: entry.layoutId, url: entry.url },
+          extra: artifact.telemetryExtra,
         },
       );
       throw new SnapshotPermanentMissError('snapshot artifact arrived still gzip-compressed');
@@ -418,11 +442,60 @@ async function downloadArtifact(
   }
 
   // Only now is the file provably complete AND decoded, so only now may a
-  // later cycle reuse it.
-  writeCompleteSidecar(downloaded, entry.builtAt);
-  sweepRetainedArtifacts(downloaded);
+  // later cycle reuse it. Retained artifacts only: a grades file is deleted by
+  // the engine at the end of the cycle, so it neither claims a sidecar nor
+  // triggers a sweep.
+  if (artifact.retainAs) {
+    writeCompleteSidecar(downloaded, artifact.retainAs.builtAt);
+    sweepRetainedArtifacts(downloaded);
+  }
 
   return { filePath: toSqlitePath(downloaded.uri) };
+}
+
+async function downloadArtifact(
+  entry: SnapshotManifestEntry,
+  options?: SnapshotDownloadOptions,
+): Promise<SnapshotArtifactHandle | null> {
+  // Content-addressed filename (boardType/layoutId/builtAt) so a retried
+  // download for the same artifact overwrites cleanly (idempotent: true)
+  // instead of accumulating orphaned files across bootstrap attempts.
+  const safeBuiltAt = entry.builtAt.replace(/[^a-zA-Z0-9]/g, '-');
+  return downloadSnapshotFile(
+    {
+      label: `${entry.boardType}:${entry.layoutId}`,
+      url: entry.url,
+      requiredBytes: requiredFreeBytes(entry),
+      contentEncoding: entry.contentEncoding,
+      fileName: `${entry.boardType}-${entry.layoutId}-${safeBuiltAt}.db`,
+      telemetryExtra: { boardType: entry.boardType, layoutId: entry.layoutId, url: entry.url },
+      retainAs: { builtAt: entry.builtAt },
+    },
+    options,
+  );
+}
+
+/**
+ * The layout's separate Boardsesh-grades artifact (issue #4310). Small next to
+ * the climbs file — a few MB against ~100 — but it removes hundreds of serial
+ * authenticated GraphQL pages from every Kilter and Tension download.
+ *
+ * The filename is derived from the artifact KEY rather than from a board/layout
+ * pair, because the manifest's grades block does not carry them; the key is
+ * already content-addressed by build stamp, so it is unique per build.
+ */
+async function downloadGradesArtifact(artifact: SnapshotGradesArtifact): Promise<{ filePath: string } | null> {
+  const safeKey = artifact.key.replace(/[^a-zA-Z0-9]/g, '-');
+  return downloadSnapshotFile({
+    label: `grades ${artifact.key}`,
+    url: artifact.url,
+    // No `uncompressedBytes` in the manifest's grades block, so this is the
+    // coarse multiplier path — cheap either way at a few MB.
+    requiredBytes: artifact.bytes * gradesFreeSpaceMultiplier(artifact.contentEncoding),
+    contentEncoding: artifact.contentEncoding,
+    fileName: `${safeKey}.db`,
+    telemetryExtra: { gradesKey: artifact.key, url: artifact.url },
+  });
 }
 
 async function deleteArtifact(filePath: string): Promise<void> {
@@ -443,6 +516,7 @@ async function releaseArtifact(filePath: string, options: { imported: boolean })
 export const mobileSnapshotSource: SnapshotSource = {
   fetchManifest,
   downloadArtifact,
+  downloadGradesArtifact,
   deleteArtifact,
   releaseArtifact,
 };

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -101,9 +101,11 @@ export {
 } from './sync/retention';
 export {
   bootstrapScopeFromSnapshot,
+  bootstrapScopeGradesFromSnapshot,
   getBootstrapMetadataByScope,
   markBootstrapDone,
   isBootstrapDone,
+  MAX_GRADES_BOOTSTRAP_ATTEMPTS,
   SnapshotWipedError,
   SnapshotSchemaStaleError,
   SnapshotPermanentMissError,

--- a/packages/shared/offline-sync/src/sync/__tests__/scope-teardown.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/scope-teardown.test.ts
@@ -258,6 +258,10 @@ describe('removeBoardScopeData — markers', () => {
       `reused-import-failed:${scopeKey}`,
       '2026-08-11T02:00:00Z',
     ]);
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      `grades-bootstrap-attempts:${scopeKey}`,
+      '1',
+    ]);
   }
 
   // Rows and markers must die together. A surviving checkpoint means the strict `>`
@@ -310,7 +314,7 @@ describe('removeBoardScopeData — markers', () => {
   // what "a scope's downloaded state" consists of. Adding a marker here should mean
   // deliberately updating this list (and `seedMarkers` above, which proves the
   // teardown actually clears each one), not nudging a magic number.
-  it('is exactly the scope’s checkpoints plus its eight markers', async () => {
+  it('is exactly the scope’s checkpoints plus its nine markers', async () => {
     const keys = scopeSyncMetaKeys('kilter:1:5');
 
     expect(new Set(keys)).toEqual(
@@ -329,6 +333,7 @@ describe('removeBoardScopeData — markers', () => {
         'bootstrap-retry:kilter:1:5',
         'scope-download-started:kilter:1:5',
         'reused-import-failed:kilter:1:5',
+        'grades-bootstrap-attempts:kilter:1:5',
       ]),
     );
   });

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -17,6 +17,9 @@ import { pullSync, type SyncProgress } from '../pull-client';
 import type { SnapshotBootstrapProgress } from '../snapshot-progress';
 import {
   bootstrapScopeFromSnapshot,
+  bootstrapScopeGradesFromSnapshot,
+  getGradesBootstrapAttempts,
+  markBootstrapDone,
   getBootstrapMetadataByScope,
   BOOTSTRAP_METADATA_QUERY,
   BOOTSTRAP_METADATA_PATTERNS,
@@ -32,15 +35,15 @@ import {
   MAX_STRUCTURAL_REARMS,
   MAX_TRANSPORT_DOWNLOAD_FAILURES,
 } from '../bootstrap-retry';
-import { getCheckpoint, setCheckpoint, DELETIONS_CHECKPOINT_KEY } from '../checkpoints';
+import { getCheckpoint, setCheckpoint, markScopeDownloadComplete, DELETIONS_CHECKPOINT_KEY } from '../checkpoints';
 import { removeBoardScopeData } from '../scope-teardown';
-import { runMigrations, LATEST_SCHEMA_VERSION } from '../../db/migrations';
+import { runMigrations, LATEST_SCHEMA_VERSION, MIGRATIONS } from '../../db/migrations';
 import { ensureMutationQueueTable } from '../../mutation-queue/schema';
 import { setSigningOut, setBackgrounded, __resetDrainerStateForTests } from '../../mutation-queue/drainer';
 import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
 import { SCHEMA_STATEMENTS } from '../../db/schema';
 import type { OfflineBoardScope } from '../../offline-board-key';
-import type { SnapshotManifest, SnapshotManifestEntry } from '../snapshot-manifest';
+import type { SnapshotGradesArtifact, SnapshotManifest, SnapshotManifestEntry } from '../snapshot-manifest';
 
 const SNAPSHOT_META_DDL = `
 CREATE TABLE IF NOT EXISTS snapshot_meta (
@@ -3237,5 +3240,615 @@ describe('pullSync scope-download phase breakdown', () => {
       'scope-download-started:kilter:1:5',
     ]);
     expect(row).toBeNull();
+  });
+});
+
+// Boardsesh grades from the separate artifact (issue #4310)
+// ---------------------------------------------------------------------------
+
+const GRADES_META_DDL = SNAPSHOT_META_DDL;
+
+type GradeInput = {
+  climbUuid: string;
+  boardType?: string;
+  angle?: number;
+  localGrade?: number | null;
+  computedAt?: string;
+  syncSeq?: number;
+};
+
+/** Builds a standalone grades artifact: one data table, one snapshot_meta row. */
+function buildGradesArtifact(spec: {
+  filePath: string;
+  grades: GradeInput[];
+  watermark: Cursor;
+  rowCountOverride?: number;
+  schemaVersion?: number;
+}): void {
+  const artifactDb = new DatabaseSync(spec.filePath);
+  try {
+    // board_climb_grades arrives in a later MIGRATION, not in the v1
+    // SCHEMA_STATEMENTS — the same source the export's DDL builder reads.
+    for (const migration of [...MIGRATIONS].sort((left, right) => left.version - right.version)) {
+      for (const statement of migration.statements) {
+        if (statement.includes('board_climb_grades')) artifactDb.exec(statement);
+      }
+    }
+    artifactDb.exec(GRADES_META_DDL);
+    for (const grade of spec.grades) {
+      artifactDb
+        .prepare(
+          `INSERT OR REPLACE INTO board_climb_grades
+            (board_type, climb_uuid, angle, local_grade, computed_at, sync_seq)
+           VALUES (?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          grade.boardType ?? 'kilter',
+          grade.climbUuid,
+          grade.angle ?? 40,
+          grade.localGrade ?? 20,
+          grade.computedAt ?? spec.watermark.updatedAt,
+          grade.syncSeq ?? Number(spec.watermark.syncSeq),
+        );
+    }
+    artifactDb
+      .prepare(
+        `INSERT OR REPLACE INTO snapshot_meta
+          (table_name, watermark_updated_at, watermark_sync_seq, row_count, built_at, schema_version, format_version)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        'board_climb_grades',
+        spec.watermark.updatedAt,
+        spec.watermark.syncSeq,
+        spec.rowCountOverride ?? spec.grades.length,
+        '2026-06-01T00:00:00.000Z',
+        spec.schemaVersion ?? LATEST_SCHEMA_VERSION,
+        1,
+      );
+  } finally {
+    artifactDb.close();
+  }
+}
+
+function gradesArtifactBlock(overrides: Partial<SnapshotGradesArtifact> = {}): SnapshotGradesArtifact {
+  return {
+    key: 'board-snapshots/v1-gzip/kilter/1/2026-06-01-grades.db',
+    url: 'https://example.test/kilter-1-grades.db',
+    bytes: 2048,
+    contentEncoding: 'gzip',
+    builtAt: '2026-06-01T00:00:00.000Z',
+    schemaVersion: LATEST_SCHEMA_VERSION,
+    tables: { board_climb_grades: { watermarkUpdatedAt: '2026-05-01T00:00:00Z', watermarkSyncSeq: '10', rowCount: 1 } },
+    ...overrides,
+  };
+}
+
+/** A source that also serves the layout's grades artifact. */
+function makeGradesSource(config: {
+  manifest: SnapshotManifest;
+  climbsFile: string;
+  gradesFile?: string | null;
+  gradesDownloadThrows?: boolean;
+}) {
+  const gradesDownloads: string[] = [];
+  const source = {
+    fetchManifest: vi.fn(async () => config.manifest),
+    downloadArtifact: vi.fn(async () => ({ filePath: config.climbsFile })),
+    downloadGradesArtifact: vi.fn(async (artifact: SnapshotGradesArtifact) => {
+      gradesDownloads.push(artifact.key);
+      if (config.gradesDownloadThrows) throw new Error('grades download failed');
+      return config.gradesFile ? { filePath: config.gradesFile } : null;
+    }),
+    deleteArtifact: vi.fn(async () => {}),
+  };
+  return { source: source as unknown as SnapshotSource, gradesDownloads };
+}
+
+async function seedScopeClimb(uuid: string): Promise<void> {
+  await db.runAsync(
+    `INSERT OR REPLACE INTO board_climbs (uuid, board_type, layout_id, name, is_draft, is_listed, compatible_size_ids, updated_at, sync_seq)
+     VALUES (?, 'kilter', 1, ?, 0, 1, ?, '2026-05-01T00:00:00Z', 10)`,
+    [uuid, `name-${uuid}`, JSON.stringify([5])],
+  );
+}
+
+describe('bootstrapScopeGradesFromSnapshot', () => {
+  const SCOPE: OfflineBoardScope = { boardType: 'kilter', layoutId: 1, sizeId: 5 };
+
+  it('imports the scope’s grades and stamps the checkpoint at their computed_at watermark', async () => {
+    await seedScopeClimb('c1');
+    const gradesPath = join(workDir, 'grades.db');
+    buildGradesArtifact({
+      filePath: gradesPath,
+      grades: [
+        { climbUuid: 'c1', angle: 40, computedAt: '2026-05-01T00:00:00Z', syncSeq: 10 },
+        { climbUuid: 'c1', angle: 50, computedAt: '2026-05-03T00:00:00Z', syncSeq: 44 },
+      ],
+      watermark: { updatedAt: '2026-05-03T00:00:00Z', syncSeq: '44' },
+    });
+
+    const result = await bootstrapScopeGradesFromSnapshot({
+      db,
+      scope: SCOPE,
+      scopeKey: 'kilter:1:5',
+      filePath: gradesPath,
+    });
+
+    expect(result.rowsImported).toBe(2);
+    expect(await countRows('board_climb_grades')).toBe(2);
+    // Stamped on computed_at, the column grades actually cursor on.
+    expect(await getCheckpoint(db, 'checkpoint:board_climb_grades:kilter:1:5')).toEqual({
+      updatedAt: '2026-05-03T00:00:00Z',
+      syncSeq: '44',
+    });
+  });
+
+  it('drops grades whose climb is outside the scope, and never stamps past them', async () => {
+    await seedScopeClimb('in-scope');
+    const gradesPath = join(workDir, 'grades-scoped.db');
+    buildGradesArtifact({
+      filePath: gradesPath,
+      grades: [
+        { climbUuid: 'in-scope', computedAt: '2026-05-01T00:00:00Z', syncSeq: 10 },
+        // No matching board_climbs row → outside this scope.
+        { climbUuid: 'other-layout', computedAt: '2026-05-09T00:00:00Z', syncSeq: 99 },
+      ],
+      watermark: { updatedAt: '2026-05-09T00:00:00Z', syncSeq: '99' },
+    });
+
+    await bootstrapScopeGradesFromSnapshot({ db, scope: SCOPE, scopeKey: 'kilter:1:5', filePath: gradesPath });
+
+    const rows = await db.getAllAsync<{ climb_uuid: string }>('SELECT climb_uuid FROM board_climb_grades');
+    expect(rows.map((row) => row.climb_uuid)).toEqual(['in-scope']);
+    // The stamped cursor covers only what landed — the artifact's snapshot_meta
+    // watermark (which covers the excluded row) would have skipped it forever.
+    expect(await getCheckpoint(db, 'checkpoint:board_climb_grades:kilter:1:5')).toEqual({
+      updatedAt: '2026-05-01T00:00:00Z',
+      syncSeq: '10',
+    });
+  });
+
+  it('stamps from the ARTIFACT rows, never from newer rows a sibling scope already crawled into main', async () => {
+    // board_climb_grades is shared across scopes. A sibling scope of the same
+    // layout (say kilter:1:7, synced for months) has already crawled rows for
+    // shared climbs with cursors far NEWER than this artifact. Stamping this
+    // scope's checkpoint off main would land at the sibling's tail, silently
+    // skipping every grade row computed since the artifact was built for
+    // climbs exclusive to THIS scope — the strict `>` delta never revisits
+    // anything at-or-below the stamp.
+    await seedScopeClimb('shared-climb');
+    await db.runAsync(
+      `INSERT INTO board_climb_grades (board_type, climb_uuid, angle, local_grade, computed_at, sync_seq)
+       VALUES ('kilter', 'shared-climb', 45, 21, '2026-08-01T00:00:00Z', 900)`,
+    );
+    const gradesPath = join(workDir, 'grades-sibling.db');
+    buildGradesArtifact({
+      filePath: gradesPath,
+      grades: [{ climbUuid: 'shared-climb', angle: 40, computedAt: '2026-05-03T00:00:00Z', syncSeq: 44 }],
+      watermark: { updatedAt: '2026-05-03T00:00:00Z', syncSeq: '44' },
+    });
+
+    await bootstrapScopeGradesFromSnapshot({ db, scope: SCOPE, scopeKey: 'kilter:1:5', filePath: gradesPath });
+
+    // The sibling's newer row is untouched, and the stamp stops at the
+    // artifact's own scoped watermark so the delta still covers
+    // (artifact, sibling-tail] for this scope's exclusive climbs.
+    expect(await countRows('board_climb_grades')).toBe(2);
+    expect(await getCheckpoint(db, 'checkpoint:board_climb_grades:kilter:1:5')).toEqual({
+      updatedAt: '2026-05-03T00:00:00Z',
+      syncSeq: '44',
+    });
+  });
+
+  it('stamps NOTHING and imports nothing when the artifact is corrupt', async () => {
+    await seedScopeClimb('c1');
+    const gradesPath = join(workDir, 'grades-corrupt.db');
+    writeFileSync(gradesPath, 'definitely not sqlite');
+
+    await expect(
+      bootstrapScopeGradesFromSnapshot({ db, scope: SCOPE, scopeKey: 'kilter:1:5', filePath: gradesPath }),
+    ).rejects.toThrow();
+
+    expect(await getCheckpoint(db, 'checkpoint:board_climb_grades:kilter:1:5')).toBeNull();
+    expect(await countRows('board_climb_grades')).toBe(0);
+  });
+
+  it('refuses an artifact whose snapshot_meta row_count disagrees with its actual rows', async () => {
+    await seedScopeClimb('c1');
+    const gradesPath = join(workDir, 'grades-truncated.db');
+    buildGradesArtifact({
+      filePath: gradesPath,
+      grades: [{ climbUuid: 'c1' }],
+      watermark: { updatedAt: '2026-05-01T00:00:00Z', syncSeq: '10' },
+      rowCountOverride: 900,
+    });
+
+    await expect(
+      bootstrapScopeGradesFromSnapshot({ db, scope: SCOPE, scopeKey: 'kilter:1:5', filePath: gradesPath }),
+    ).rejects.toThrow(/row_count/);
+    expect(await getCheckpoint(db, 'checkpoint:board_climb_grades:kilter:1:5')).toBeNull();
+  });
+
+  it('leaves the deletions checkpoint alone — grades have no delete trigger to replay', async () => {
+    await seedScopeClimb('c1');
+    const deletionsCursor = { updatedAt: '2026-07-01T00:00:00Z', syncSeq: '500' };
+    await setCheckpoint(db, DELETIONS_CHECKPOINT_KEY, deletionsCursor);
+    const gradesPath = join(workDir, 'grades-deletions.db');
+    buildGradesArtifact({
+      filePath: gradesPath,
+      grades: [{ climbUuid: 'c1' }],
+      watermark: { updatedAt: '2026-05-01T00:00:00Z', syncSeq: '10' },
+    });
+
+    await bootstrapScopeGradesFromSnapshot({ db, scope: SCOPE, scopeKey: 'kilter:1:5', filePath: gradesPath });
+
+    expect(await getCheckpoint(db, DELETIONS_CHECKPOINT_KEY)).toEqual(deletionsCursor);
+  });
+});
+
+describe('pullSync grades bootstrap', () => {
+  it('imports grades right after the whole-layout import and skips the crawl', async () => {
+    const climbsPath = join(workDir, 'grades-flow-climbs.db');
+    buildArtifact({
+      filePath: climbsPath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const gradesPath = join(workDir, 'grades-flow-grades.db');
+    buildGradesArtifact({
+      filePath: gradesPath,
+      grades: [{ climbUuid: 'c1', computedAt: '2026-05-02T00:00:00Z', syncSeq: 21 }],
+      watermark: { updatedAt: '2026-05-02T00:00:00Z', syncSeq: '21' },
+    });
+    const { source, gradesDownloads } = makeGradesSource({
+      manifest: makeManifest([makeEntry({ grades: gradesArtifactBlock() })]),
+      climbsFile: climbsPath,
+      gradesFile: gradesPath,
+    });
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+    });
+
+    expect(gradesDownloads).toEqual([gradesArtifactBlock().key]);
+    expect(await countRows('board_climb_grades')).toBe(1);
+    expect(await getCheckpoint(db, 'checkpoint:board_climb_grades:kilter:1:5')).toEqual({
+      updatedAt: '2026-05-02T00:00:00Z',
+      syncSeq: '21',
+    });
+  });
+
+  // Retention (#4310) keeps an UNIMPORTED whole-layout artifact for the next
+  // cycle and recognises a superseded build by the `<board>-<layout>` prefix in
+  // its filename. A grades file, named from its manifest key, matches no prefix
+  // — so a retained one would never be swept and would sit in the cache
+  // directory forever. It is deleted outright instead, on every exit path.
+  it('deletes the grades artifact rather than handing it to releaseArtifact', async () => {
+    const climbsPath = join(workDir, 'grades-release-climbs.db');
+    buildArtifact({
+      filePath: climbsPath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const gradesPath = join(workDir, 'grades-release-grades.db');
+    buildGradesArtifact({
+      filePath: gradesPath,
+      grades: [{ climbUuid: 'c1', computedAt: '2026-05-02T00:00:00Z', syncSeq: 21 }],
+      watermark: { updatedAt: '2026-05-02T00:00:00Z', syncSeq: '21' },
+    });
+    const { source } = makeGradesSource({
+      manifest: makeManifest([makeEntry({ grades: gradesArtifactBlock() })]),
+      climbsFile: climbsPath,
+      gradesFile: gradesPath,
+    });
+    const releaseArtifact = vi.fn(async () => {});
+    (source as unknown as { releaseArtifact: typeof releaseArtifact }).releaseArtifact = releaseArtifact;
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+    });
+
+    expect(source.deleteArtifact).toHaveBeenCalledWith(gradesPath);
+    expect(releaseArtifact).not.toHaveBeenCalledWith(gradesPath, expect.anything());
+    // The whole-layout artifact still goes through the retention seam.
+    expect(releaseArtifact).toHaveBeenCalledWith(climbsPath, { imported: true });
+  });
+
+  // A failed grades import must not strand the file either: the same finally
+  // runs on every exit path.
+  it('deletes the grades artifact when its import failed', async () => {
+    const climbsPath = join(workDir, 'grades-failed-climbs.db');
+    buildArtifact({
+      filePath: climbsPath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    // Not a grades artifact at all — ATTACH finds no board_climb_grades table.
+    const notAGradesFile = join(workDir, 'grades-failed-grades.db');
+    buildArtifact({
+      filePath: notAGradesFile,
+      climbs: [],
+      stats: [],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const { source } = makeGradesSource({
+      manifest: makeManifest([makeEntry({ grades: gradesArtifactBlock() })]),
+      climbsFile: climbsPath,
+      gradesFile: notAGradesFile,
+    });
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+    });
+
+    expect(source.deleteArtifact).toHaveBeenCalledWith(notAGradesFile);
+    // Proof the import really failed rather than the assertion above passing
+    // over a healthy run: a successful import stamps this.
+    expect(await getCheckpoint(db, 'checkpoint:board_climb_grades:kilter:1:5')).toBeNull();
+  });
+
+  it('takes today’s path verbatim when the manifest entry has no grades block', async () => {
+    const climbsPath = join(workDir, 'no-grades-climbs.db');
+    buildArtifact({
+      filePath: climbsPath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const { source, gradesDownloads } = makeGradesSource({
+      manifest: makeManifest([makeEntry()]),
+      climbsFile: climbsPath,
+      gradesFile: null,
+    });
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+    });
+
+    expect(gradesDownloads).toEqual([]);
+    // The paged crawl still stamps its own (empty-page) grades checkpoint.
+    expect(await countRows('board_climb_grades')).toBe(0);
+  });
+
+  it('retro-fits a scope that was bootstrapped BEFORE grades artifacts existed', async () => {
+    // Whole-layout artifact already imported (the catalog is complete) and the
+    // grades checkpoint absent = no grade page was ever consumed, so importing
+    // from the artifact cannot skip anything.
+    await seedScopeClimb('c1');
+    await setCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5', CLIMBS_WATERMARK);
+    await setCheckpoint(db, 'checkpoint:board_climb_stats:kilter:1:5', STATS_WATERMARK);
+    await markBootstrapDone(db, 'kilter:1:5');
+    const gradesPath = join(workDir, 'retrofit-grades.db');
+    buildGradesArtifact({
+      filePath: gradesPath,
+      grades: [{ climbUuid: 'c1', computedAt: '2026-05-02T00:00:00Z', syncSeq: 21 }],
+      watermark: { updatedAt: '2026-05-02T00:00:00Z', syncSeq: '21' },
+    });
+    const { source, gradesDownloads } = makeGradesSource({
+      manifest: makeManifest([makeEntry({ grades: gradesArtifactBlock() })]),
+      climbsFile: join(workDir, 'never-downloaded.db'),
+      gradesFile: gradesPath,
+    });
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+    });
+
+    expect(gradesDownloads).toHaveLength(1);
+    expect(await countRows('board_climb_grades')).toBe(1);
+    // The whole-layout artifact is NOT re-downloaded — the scope is past that.
+    expect(source.downloadArtifact).not.toHaveBeenCalled();
+  });
+
+  it('retro-fits a scope whose PAGED crawl finished every table', async () => {
+    // scope-complete is the other proof of a whole catalog: the crawl reached
+    // every table's tail. (Its grades checkpoint is cleared below to model the
+    // pre-#4310 shape where grades were the term still missing.)
+    await seedScopeClimb('c1');
+    await setCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5', CLIMBS_WATERMARK);
+    await setCheckpoint(db, 'checkpoint:board_climb_stats:kilter:1:5', STATS_WATERMARK);
+    await markScopeDownloadComplete(db, 'kilter:1:5');
+    const gradesPath = join(workDir, 'retrofit-complete-grades.db');
+    buildGradesArtifact({
+      filePath: gradesPath,
+      grades: [{ climbUuid: 'c1', computedAt: '2026-05-02T00:00:00Z', syncSeq: 21 }],
+      watermark: { updatedAt: '2026-05-02T00:00:00Z', syncSeq: '21' },
+    });
+    const { source, gradesDownloads } = makeGradesSource({
+      manifest: makeManifest([makeEntry({ grades: gradesArtifactBlock() })]),
+      climbsFile: join(workDir, 'never-downloaded-complete.db'),
+      gradesFile: gradesPath,
+    });
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+    });
+
+    expect(gradesDownloads).toHaveLength(1);
+    expect(await countRows('board_climb_grades')).toBe(1);
+  });
+
+  it('does NOT retro-fit a scope whose climb catalog is only half crawled', async () => {
+    // Board checkpoints exist (syncTable stamps one per page) but neither
+    // bootstrap-done nor scope-complete does, so main.board_climbs is a
+    // fraction of the layout. Importing here would stamp the grades cursor at
+    // the watermark of the grades whose climbs happen to be local, and the
+    // strict `>` delta would never fetch the rest.
+    await seedScopeClimb('c1');
+    await setCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5', CLIMBS_WATERMARK);
+    await setCheckpoint(db, 'checkpoint:board_climb_stats:kilter:1:5', STATS_WATERMARK);
+    const gradesPath = join(workDir, 'retrofit-partial-grades.db');
+    buildGradesArtifact({
+      filePath: gradesPath,
+      grades: [{ climbUuid: 'c1', computedAt: '2026-05-02T00:00:00Z', syncSeq: 21 }],
+      watermark: { updatedAt: '2026-05-02T00:00:00Z', syncSeq: '21' },
+    });
+    const { source, gradesDownloads } = makeGradesSource({
+      manifest: makeManifest([makeEntry({ grades: gradesArtifactBlock() })]),
+      climbsFile: join(workDir, 'never-downloaded-partial.db'),
+      gradesFile: gradesPath,
+    });
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+    });
+
+    expect(gradesDownloads).toEqual([]);
+    // No artifact rows, and no artifact watermark stamped over the crawl.
+    expect(await countRows('board_climb_grades')).toBe(0);
+    expect(await getCheckpoint(db, 'checkpoint:board_climb_grades:kilter:1:5')).not.toEqual({
+      updatedAt: '2026-05-02T00:00:00Z',
+      syncSeq: '21',
+    });
+  });
+
+  it('does NOT retro-fit a scope that already has a grades checkpoint', async () => {
+    await seedScopeClimb('c1');
+    await setCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5', CLIMBS_WATERMARK);
+    await setCheckpoint(db, 'checkpoint:board_climb_stats:kilter:1:5', STATS_WATERMARK);
+    await markBootstrapDone(db, 'kilter:1:5');
+    await setCheckpoint(db, 'checkpoint:board_climb_grades:kilter:1:5', {
+      updatedAt: '2026-04-01T00:00:00Z',
+      syncSeq: '3',
+    });
+    const { source, gradesDownloads } = makeGradesSource({
+      manifest: makeManifest([makeEntry({ grades: gradesArtifactBlock() })]),
+      climbsFile: join(workDir, 'unused.db'),
+      gradesFile: join(workDir, 'unused-grades.db'),
+    });
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+    });
+
+    expect(gradesDownloads).toEqual([]);
+  });
+
+  it('a failed grades import never costs the scope its whole-layout bootstrap attempt', async () => {
+    const climbsPath = join(workDir, 'grades-fail-climbs.db');
+    buildArtifact({
+      filePath: climbsPath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const gradesPath = join(workDir, 'grades-fail-grades.db');
+    writeFileSync(gradesPath, 'not sqlite');
+    const { source } = makeGradesSource({
+      manifest: makeManifest([makeEntry({ grades: gradesArtifactBlock() })]),
+      climbsFile: climbsPath,
+      gradesFile: gradesPath,
+    });
+    const onSnapshotBootstrapError = vi.fn();
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onSnapshotBootstrapError,
+    });
+
+    // The climbs/stats import succeeded and stays intact.
+    expect(await countRows('board_climbs')).toBe(1);
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
+    expect(await getCheckpoint(db, 'checkpoint:board_climb_grades:kilter:1:5')).toBeNull();
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(expect.objectContaining({ stage: 'grades-import' }));
+    // Its own budget was spent instead.
+    const attempts = await db.getFirstAsync<{ value: string }>('SELECT value FROM sync_meta WHERE key = ?', [
+      'grades-bootstrap-attempts:kilter:1:5',
+    ]);
+    expect(attempts?.value).toBe('1');
+  });
+
+  it('counts a grades download that returns null, so it cannot re-fetch forever', async () => {
+    const climbsPath = join(workDir, 'grades-null-climbs.db');
+    buildArtifact({
+      filePath: climbsPath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const { source, gradesDownloads } = makeGradesSource({
+      manifest: makeManifest([makeEntry({ grades: gradesArtifactBlock() })]),
+      climbsFile: climbsPath,
+      // A source that signals "unusable this cycle" by returning null rather
+      // than throwing — the same thing a throw means under SnapshotSource.
+      gradesFile: null,
+    });
+    const onSnapshotBootstrapError = vi.fn();
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onSnapshotBootstrapError,
+    });
+
+    expect(gradesDownloads).toHaveLength(1);
+    expect(await getGradesBootstrapAttempts(db, 'kilter:1:5')).toBe(1);
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(
+      expect.objectContaining({ stage: 'grades-download', attempt: 1 }),
+    );
+    // The whole-layout budget is untouched, as ever.
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
+  });
+
+  it('stops trying grades once its own attempt budget is spent', async () => {
+    await seedScopeClimb('c1');
+    await setCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5', CLIMBS_WATERMARK);
+    await setCheckpoint(db, 'checkpoint:board_climb_stats:kilter:1:5', STATS_WATERMARK);
+    await markBootstrapDone(db, 'kilter:1:5');
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      'grades-bootstrap-attempts:kilter:1:5',
+      '2',
+    ]);
+    const { source, gradesDownloads } = makeGradesSource({
+      manifest: makeManifest([makeEntry({ grades: gradesArtifactBlock() })]),
+      climbsFile: join(workDir, 'unused.db'),
+      gradesFile: join(workDir, 'unused-grades.db'),
+    });
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+    });
+
+    expect(gradesDownloads).toEqual([]);
+  });
+
+  it('skips a grades artifact built at an older client schema', async () => {
+    await seedScopeClimb('c1');
+    await setCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5', CLIMBS_WATERMARK);
+    await setCheckpoint(db, 'checkpoint:board_climb_stats:kilter:1:5', STATS_WATERMARK);
+    await markBootstrapDone(db, 'kilter:1:5');
+    const { source, gradesDownloads } = makeGradesSource({
+      manifest: makeManifest([makeEntry({ grades: gradesArtifactBlock({ schemaVersion: 0 }) })]),
+      climbsFile: join(workDir, 'unused.db'),
+      gradesFile: join(workDir, 'unused-grades.db'),
+    });
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+    });
+
+    expect(gradesDownloads).toEqual([]);
   });
 });

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-estimate.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-estimate.test.ts
@@ -277,3 +277,46 @@ describe('estimateScopeDownload parity with the engine gate', () => {
     });
   }
 });
+
+describe('estimateScopeDownload — the separate grades artifact (issue #4310)', () => {
+  it('adds the grades artifact’s bytes to the quoted figure', () => {
+    const withGrades = manifest([
+      entry({
+        bytes: 100_000_000,
+        grades: {
+          key: 'board-snapshots/v1-gzip/kilter/1/2026-06-01-grades.db',
+          url: 'https://cdn.example/grades.db',
+          bytes: 3_000_000,
+          contentEncoding: 'gzip',
+          builtAt: '2026-06-01T00:00:00.000Z',
+          schemaVersion: LATEST_SCHEMA_VERSION,
+          tables: {
+            board_climb_grades: { watermarkUpdatedAt: '2026-05-01T00:00:00Z', watermarkSyncSeq: '1', rowCount: 900 },
+          },
+        },
+      }),
+    ]);
+
+    const estimate = eligible({ manifest: withGrades });
+
+    // The scope downloads BOTH files, so quoting only the climbs one would
+    // under-promise what the user is about to spend.
+    expect(estimate).toEqual({
+      kind: 'snapshot',
+      bytes: 103_000_000,
+      climbCount: 370497,
+      builtAt: '2026-07-15T02:31:02.103Z',
+    });
+  });
+
+  it('is unchanged when the entry has no grades block', () => {
+    const estimate = eligible({ manifest: manifest([entry({ bytes: 100_000_000 })]) });
+
+    expect(estimate).toEqual({
+      kind: 'snapshot',
+      bytes: 100_000_000,
+      climbCount: 370497,
+      builtAt: '2026-07-15T02:31:02.103Z',
+    });
+  });
+});

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -16,6 +16,10 @@ import {
 import { markUserDataComplete } from './local-user-owner';
 import {
   bootstrapScopeFromSnapshot,
+  bootstrapScopeGradesFromSnapshot,
+  getGradesBootstrapAttempts,
+  recordGradesBootstrapAttempt,
+  MAX_GRADES_BOOTSTRAP_ATTEMPTS,
   markBootstrapDone,
   isBootstrapDone,
   wasBootstrapHealed,
@@ -46,7 +50,7 @@ import {
   type BootstrapFailureKind,
   type BootstrapRetryState,
 } from './bootstrap-retry';
-import { parseSnapshotManifest, type SnapshotManifest } from './snapshot-manifest';
+import { parseSnapshotManifest, type SnapshotManifest, type SnapshotManifestEntry } from './snapshot-manifest';
 import { findSnapshotEntry, isSnapshotEntryUsable } from './snapshot-estimate';
 import {
   createDownloadFractionAnchor,
@@ -974,6 +978,103 @@ async function runBootstrapPhase(params: {
   // never consumed (backgrounded cycle, wipe, aborted transfer) is handed back
   // with `imported: false` so a retention-capable source can keep it.
   const artifactImported = new Map<string, boolean>();
+  // Grades artifacts are tracked apart from `artifactImported` because they are
+  // never retained: the retention seam above keeps an UNIMPORTED whole-layout
+  // file for the next cycle, and its supersede sweep recognises a build by the
+  // `<board>-<layout>` prefix in the filename — which a grades file, named from
+  // its manifest key, does not have. A retained one would therefore never be
+  // recognised as superseded and would sit in the cache directory forever, so
+  // these are deleted outright in the finally below. Re-fetching a few MB next
+  // cycle is the cheaper failure.
+  const gradesArtifactPaths = new Set<string>();
+  // Absent = not yet attempted for this layout; null = unavailable this cycle.
+  const gradesDownloadByLayout = new Map<string, { filePath: string } | null>();
+
+  /**
+   * Import the layout's Boardsesh grades from its separate artifact, replacing
+   * the paged crawl of `board_climb_grades` — the term the whole-layout
+   * artifact never covered, and the reason a Kilter/Tension download takes ~6x
+   * a MoonBoard layout of the same size (issue #4310).
+   *
+   * Called on two paths: straight after a successful whole-layout import, and
+   * — for a scope that was bootstrapped before this shipped, or crashed between
+   * the two transactions — whenever the grades checkpoint is ABSENT on a scope
+   * whose climb catalog is already COMPLETE (`bootstrap-done` or
+   * `scope-complete`). An absent grades checkpoint is proof no grade page was
+   * ever consumed (`syncTable` checkpoints per page), so importing and stamping
+   * at the artifact's watermark cannot skip a row the crawl already had; the
+   * completeness gate is what stops the stamp landing above grade rows whose
+   * climbs a half-finished crawl has not fetched yet.
+   *
+   * Every failure here is free: it never touches the whole-layout attempt
+   * counter, and the worst case is that the scope crawls grades exactly as it
+   * does today.
+   */
+  const importGradesForScope = async (scope: BoardScope, entry: SnapshotManifestEntry): Promise<void> => {
+    const gradesArtifact = entry.grades;
+    if (!gradesArtifact || !source.downloadGradesArtifact) return;
+    // A grades artifact built at an older client schema would NULL-fill columns
+    // this app added and then stamp the cursor past them — same permanent-miss
+    // rule the whole-layout artifact gets.
+    if (!isSnapshotEntryUsable(gradesArtifact)) return;
+    if ((await getGradesBootstrapAttempts(db, scope.scopeKey)) >= MAX_GRADES_BOOTSTRAP_ATTEMPTS) return;
+
+    const layoutKey = `${scope.boardType}:${scope.layoutId}`;
+    let gradesDownload = gradesDownloadByLayout.get(layoutKey);
+    if (gradesDownload === undefined) {
+      let downloadCause: unknown = null;
+      try {
+        gradesDownload = (await source.downloadGradesArtifact(gradesArtifact)) ?? null;
+      } catch (error) {
+        gradesDownload = null;
+        downloadCause = error;
+      }
+      // A NULL return counts exactly as a throw does. `SnapshotSource` lets a
+      // source signal "unusable this cycle" either way (see downloadArtifact's
+      // contract), and the whole-layout path settles a failure on both — so
+      // leaving the null arm uncounted here would let a null-returning source
+      // re-fetch the artifact on every cycle for the life of the install,
+      // straight past MAX_GRADES_BOOTSTRAP_ATTEMPTS.
+      if (!gradesDownload) {
+        const attempt = await recordGradesBootstrapAttempt(db, scope.scopeKey);
+        onSnapshotBootstrapError?.({
+          scopeKey: scope.scopeKey,
+          stage: 'grades-download',
+          attempt,
+          cause: downloadCause,
+          expected: isNetworkError(downloadCause),
+        });
+      }
+      gradesDownloadByLayout.set(layoutKey, gradesDownload);
+      if (gradesDownload) gradesArtifactPaths.add(gradesDownload.filePath);
+    }
+    if (!gradesDownload) return;
+    if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) return;
+
+    try {
+      await bootstrapScopeGradesFromSnapshot({
+        db,
+        scope,
+        scopeKey: scope.scopeKey,
+        filePath: gradesDownload.filePath,
+        onSchemaDrift,
+      });
+      for (const key of TABLE_CONFIGS.board_climb_grades.invalidateKeys) {
+        queryClient.invalidateQueries({ queryKey: key });
+      }
+    } catch (error) {
+      // A wipe rolls the transaction back; no checkpoint, nothing to count.
+      if (error instanceof SnapshotWipedError || isSigningOut() || getWipeEpoch() !== cycleEpoch) return;
+      const attempt = await recordGradesBootstrapAttempt(db, scope.scopeKey);
+      onSnapshotBootstrapError?.({
+        scopeKey: scope.scopeKey,
+        stage: 'grades-import',
+        attempt,
+        cause: error,
+        expected: false,
+      });
+    }
+  };
 
   const reportSettledFailure = (
     scope: BoardScope,
@@ -1064,6 +1165,42 @@ async function runBootstrapPhase(params: {
           metadataSettled = true;
           if (shouldSkipPagedPull({ retryState, hasBoardCheckpoint, now: evaluatedAt })) {
             skipPagedPull.add(scope.scopeKey);
+          }
+          // RETRO-FIT (issue #4310): a scope with a COMPLETE climb catalog but
+          // NO grades checkpoint has never consumed a single grade page
+          // (`syncTable` checkpoints per page), so it is still facing the full
+          // crawl — every scope bootstrapped before grades artifacts existed is
+          // in exactly this state. Import them from the artifact instead. Gated
+          // on the local checkpoint read, so once a scope has grades this costs
+          // nothing, and the manifest is only fetched for scopes that need it.
+          //
+          // COMPLETENESS IS THE GATE, not the mere presence of a board
+          // checkpoint. The import filters the artifact's grade rows through
+          // `main.board_climbs` and stamps the grades cursor at THAT subset's
+          // watermark, so running it over a half-crawled catalog would stamp
+          // past every grade row belonging to a climb the crawl has not fetched
+          // yet — and the strict `>` delta never revisits them. `bootstrap-done`
+          // (the artifact carried the whole layout, heal included) and
+          // `scope-complete` (the paged crawl reached every table's tail) are
+          // the two proofs of a whole catalog; a scope mid-crawl waits until it
+          // has one, at which point this branch picks it up.
+          //
+          // Deliberately NOT run for a scope with no board data at all: that one
+          // is either fresh (the eligible path below imports its grades right
+          // after the whole-layout artifact) or serving a snapshot cooldown the
+          // retry taxonomy imposed (#4313), and a cooldown means no artifact
+          // bytes for this scope this cycle — grades included.
+          if ((isAlreadyBootstrapped || isScopeComplete) && source.downloadGradesArtifact) {
+            const gradesCheckpoint = await getCheckpoint(db, getCheckpointKey('board_climb_grades', scope.scopeKey));
+            if (!gradesCheckpoint) {
+              const retrofitResolution = await resolveManifestOnce(source, manifestCache);
+              if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) break;
+              const retrofitEntry =
+                retrofitResolution.status === 'ok'
+                  ? findSnapshotEntry(retrofitResolution.manifest, scope.boardType, scope.layoutId)
+                  : null;
+              if (retrofitEntry) await importGradesForScope(scope, retrofitEntry);
+            }
           }
           continue;
         }
@@ -1423,6 +1560,10 @@ async function runBootstrapPhase(params: {
               queryClient.invalidateQueries({ queryKey: key });
             }
           }
+          // Grades ride a second, small artifact and a second short exclusive
+          // transaction, right after the climbs/stats one. See
+          // importGradesForScope — every failure here is free.
+          await importGradesForScope(scope, entry);
           // Not skipped: the board-data phase delta-pulls from the watermark
           // checkpoints and fires markScopeDownloadComplete through the tail logic.
         } catch (error) {
@@ -1533,6 +1674,12 @@ async function runBootstrapPhase(params: {
         ? source.releaseArtifact(filePath, { imported })
         : source.deleteArtifact(filePath);
       await release.catch(() => {});
+    }
+    // Deleted, never released: see gradesArtifactPaths. Deterministic on every
+    // exit path — imported, failed, or torn down — so a grades file can never
+    // outlive the cycle that fetched it.
+    for (const filePath of gradesArtifactPaths) {
+      await source.deleteArtifact(filePath).catch(() => {});
     }
   }
 

--- a/packages/shared/offline-sync/src/sync/scope-teardown.ts
+++ b/packages/shared/offline-sync/src/sync/scope-teardown.ts
@@ -37,7 +37,11 @@ import {
   SCOPE_STARTED_PREFIX,
   SCOPE_DOWNLOAD_STARTED_PREFIX,
 } from './checkpoints';
-import { BOOTSTRAP_DONE_PREFIX, REUSED_IMPORT_FAILED_PREFIX } from './snapshot-bootstrap';
+import {
+  BOOTSTRAP_DONE_PREFIX,
+  REUSED_IMPORT_FAILED_PREFIX,
+  GRADES_BOOTSTRAP_ATTEMPTS_PREFIX,
+} from './snapshot-bootstrap';
 import {
   BOOTSTRAP_ATTEMPTS_HEALED_PREFIX,
   BOOTSTRAP_ATTEMPTS_PREFIX,
@@ -97,6 +101,10 @@ export function scopeSyncMetaKeys(scopeKey: string): string[] {
     // Same clean-slate rule as the budgets above: a re-added board must not
     // inherit a round it spent before removal.
     `${REUSED_IMPORT_FAILED_PREFIX}${scopeKey}`,
+    // The grades import's own attempt budget. Re-adding a removed board must
+    // give it a clean counter, and a stale one over emptied tables would keep
+    // the scope on the grades crawl for no reason.
+    `${GRADES_BOOTSTRAP_ATTEMPTS_PREFIX}${scopeKey}`,
   ];
 }
 

--- a/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
@@ -20,9 +20,10 @@
 
 import type { OfflineDatabase, SqlExecutor } from '../database';
 import type { OfflineBoardScope } from '../offline-board-key';
-import type { SnapshotManifestEntry, SnapshotTableName } from './snapshot-manifest';
+import type { SnapshotGradesArtifact, SnapshotManifestEntry, SnapshotTableName } from './snapshot-manifest';
 import { SNAPSHOT_MANIFEST_FORMAT_VERSION } from './snapshot-manifest';
 import { climbsScopeFilter, isSizeScopedBoard } from './board-scope-sql';
+import { TABLE_CONFIGS } from './table-config';
 import {
   compareCheckpoints,
   getCheckpointKey,
@@ -45,11 +46,39 @@ import {
 } from './bootstrap-retry';
 import type { SchemaDriftReporter } from './pull-client';
 
-/** The two reference tables a snapshot carries; import order is climbs → stats. */
+/**
+ * The two reference tables a WHOLE-LAYOUT snapshot carries; import order is
+ * climbs → stats.
+ *
+ * Stays exactly two. `verifySnapshotMeta` iterates this list and throws
+ * `snapshot_meta missing row for <table>` on a miss, and an import failure is
+ * COUNTED — so widening it would make every newly-updated client reject every
+ * artifact published before the change (live for the 14-day prune grace, plus
+ * CDN-cached manifests), twice, and settle the scope onto the paged crawl.
+ * Boardsesh grades therefore arrive in their OWN file, verified against their
+ * own one-element list. See GRADES_SNAPSHOT_TABLES.
+ */
 const SNAPSHOT_TABLES = ['board_climbs', 'board_climb_stats'] as const;
+
+/** The single table the separate per-layout grades artifact carries. */
+const GRADES_SNAPSHOT_TABLES = ['board_climb_grades'] as const;
 
 /** The ATTACH alias for the artifact; the only ATTACH the DB lifecycle performs. */
 const SNAPSHOT_ALIAS = 'bs_snapshot';
+
+/** The ATTACH alias for the separate grades artifact (its own transaction, its own connection). */
+const GRADES_ALIAS = 'bs_grades';
+
+/**
+ * Two grades-import attempts, counted SEPARATELY from the whole-layout
+ * bootstrap's retry budgets (bootstrap-retry.ts). A grades import that fails
+ * must never cost the scope its snapshot fast path: the worst case here is
+ * exactly today's behaviour — the scope crawls `board_climb_grades` page by
+ * page — so it gets its own plain counter rather than spending the transport or
+ * structural budget the whole-layout artifact is bounded by.
+ */
+export const MAX_GRADES_BOOTSTRAP_ATTEMPTS = 2;
+export const GRADES_BOOTSTRAP_ATTEMPTS_PREFIX = 'grades-bootstrap-attempts:';
 
 // Package-internal (deliberately NOT re-exported from index.ts, same posture as
 // checkpoints.ts's DELETIONS_CHECKPOINT_KEY): scope-teardown.ts must clear this
@@ -133,6 +162,22 @@ export interface SnapshotSource {
     entry: SnapshotManifestEntry,
     options?: SnapshotDownloadOptions,
   ): Promise<SnapshotArtifactHandle | null>;
+  /**
+   * Download the layout's SEPARATE Boardsesh-grades artifact (issue #4310).
+   * Same failure contract as `downloadArtifact` — but NOT the same retention
+   * contract: a grades file is never handed to `releaseArtifact`. The engine
+   * deletes it through `deleteArtifact` at the end of every cycle, because
+   * retention is sized and keyed for the ~100 MB whole-layout file (its
+   * supersede sweep pairs a build with a `<board>-<layout>` filename prefix a
+   * grades name does not carry). Re-fetching a few MB is the cheaper failure.
+   *
+   * OPTIONAL: a source that does not implement it — or a manifest entry with no
+   * `grades` block — makes the engine take today's path verbatim, crawling
+   * `board_climb_grades` page by page. An updated engine against an old
+   * manifest and a new manifest against an old engine therefore both behave
+   * exactly as before.
+   */
+  downloadGradesArtifact?(artifact: SnapshotGradesArtifact): Promise<{ filePath: string } | null>;
   /** Delete a downloaded artifact once the run is done with it. Best-effort. */
   deleteArtifact(filePath: string): Promise<void>;
   /**
@@ -152,7 +197,7 @@ export interface SnapshotSource {
 /** Where a bootstrap failed, for telemetry. */
 export type SnapshotBootstrapErrorReporter = (report: {
   scopeKey: string;
-  stage: 'manifest' | 'download' | 'import';
+  stage: 'manifest' | 'download' | 'import' | 'grades-download' | 'grades-import';
   attempt: number;
   cause: unknown;
   /**
@@ -354,6 +399,23 @@ export async function getBootstrapMetadataByScope(
   return metadataByScope;
 }
 
+/** Counted grades-import failures for this scope (separate budget — see MAX_GRADES_BOOTSTRAP_ATTEMPTS). */
+export async function getGradesBootstrapAttempts(db: SqlExecutor, scopeKey: string): Promise<number> {
+  const row = await db.getFirstAsync<{ value: string }>('SELECT value FROM sync_meta WHERE key = ?', [
+    `${GRADES_BOOTSTRAP_ATTEMPTS_PREFIX}${scopeKey}`,
+  ]);
+  return row ? parseBootstrapAttempts(row.value) : 0;
+}
+
+export async function recordGradesBootstrapAttempt(db: SqlExecutor, scopeKey: string): Promise<number> {
+  const next = (await getGradesBootstrapAttempts(db, scopeKey)) + 1;
+  await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+    `${GRADES_BOOTSTRAP_ATTEMPTS_PREFIX}${scopeKey}`,
+    String(next),
+  ]);
+  return next;
+}
+
 /** The `bootstrap-done:` value that records a heal over a partly-crawled catalog. */
 const BOOTSTRAP_DONE_HEAL_VALUE = 'heal';
 
@@ -449,11 +511,7 @@ function assertSafeColumns(columns: readonly string[]): void {
 }
 
 /** Column names of a table for the given schema (`main` or the snapshot alias). */
-async function tableColumns(
-  db: SqlExecutor,
-  tableName: string,
-  schema: 'main' | typeof SNAPSHOT_ALIAS,
-): Promise<string[]> {
+async function tableColumns(db: SqlExecutor, tableName: string, schema: string): Promise<string[]> {
   const rows =
     schema === 'main'
       ? await db.getAllAsync<{ name: string }>('SELECT name FROM pragma_table_info(?)', [tableName])
@@ -472,9 +530,10 @@ async function sharedColumns(
   db: SqlExecutor,
   tableName: string,
   onSchemaDrift: SchemaDriftReporter | undefined,
+  alias: string = SNAPSHOT_ALIAS,
 ): Promise<string[]> {
   const mainColumns = await tableColumns(db, tableName, 'main');
-  const snapshotColumns = await tableColumns(db, tableName, SNAPSHOT_ALIAS);
+  const snapshotColumns = await tableColumns(db, tableName, alias);
   const mainSet = new Set(mainColumns);
   const snapshotSet = new Set(snapshotColumns);
   for (const column of snapshotColumns) {
@@ -716,11 +775,15 @@ export class SnapshotWatermarkRegressionError extends Error {
  * imported). Artifact-level watermarks are validation/export metadata; the
  * imported scope's checkpoints are computed from scoped artifact rows.
  */
-async function verifySnapshotMeta(db: SqlExecutor): Promise<void> {
-  for (const tableName of SNAPSHOT_TABLES) {
+async function verifySnapshotMeta(
+  db: SqlExecutor,
+  alias: string = SNAPSHOT_ALIAS,
+  tables: readonly string[] = SNAPSHOT_TABLES,
+): Promise<void> {
+  for (const tableName of tables) {
     const meta = await db.getFirstAsync<SnapshotMetaRow>(
       `SELECT table_name, watermark_updated_at, watermark_sync_seq, row_count, schema_version, format_version
-       FROM ${SNAPSHOT_ALIAS}.snapshot_meta WHERE table_name = ?`,
+       FROM ${alias}.snapshot_meta WHERE table_name = ?`,
       [tableName],
     );
     if (!meta) throw new Error(`snapshot bootstrap: snapshot_meta missing row for ${tableName}`);
@@ -734,7 +797,7 @@ async function verifySnapshotMeta(db: SqlExecutor): Promise<void> {
     if (meta.schema_version < LATEST_SCHEMA_VERSION) {
       throw new SnapshotSchemaStaleError(meta.schema_version);
     }
-    const actual = await db.getFirstAsync<{ n: number }>(`SELECT COUNT(*) AS n FROM ${SNAPSHOT_ALIAS}.${tableName}`);
+    const actual = await db.getFirstAsync<{ n: number }>(`SELECT COUNT(*) AS n FROM ${alias}.${tableName}`);
     const actualCount = actual?.n ?? 0;
     if (actualCount !== meta.row_count) {
       throw new Error(
@@ -874,4 +937,155 @@ export async function bootstrapScopeFromSnapshot(params: {
     statsWatermark: finalWatermarks.board_climb_stats,
     ...imported,
   };
+}
+
+// --- Grades bootstrap (issue #4310) -------------------------------------------
+
+const GRADES_TABLE = 'board_climb_grades';
+const GRADES_CURSOR_COLUMN = TABLE_CONFIGS[GRADES_TABLE].cursorColumn;
+
+/**
+ * The scope filter for `board_climb_grades`, evaluated against the layout's
+ * climbs. Grades carry no `layout_id`, so this is the same correlated EXISTS
+ * over `board_climbs` that `syncClimbGrades` uses (queries.ts) — and it MUST
+ * NOT be narrower: a grade row inside the stamped watermark that this import
+ * dropped is lost forever, because the strict `>` delta never revisits it.
+ *
+ * `climbsSchema` is `main` for both the import and the watermark (the climbs
+ * this scope just committed); the watermark additionally reads its ROWS from
+ * the attached artifact, not from main, so what gets stamped can only cover
+ * what this import actually selected — see the comment at the watermark query.
+ */
+function gradesScopeFilter(
+  scope: OfflineBoardScope,
+  gradesTableRef: string,
+  climbsSchema: string,
+): { sql: string; params: (string | number)[] } {
+  const sizeScoped = isSizeScopedBoard(scope.boardType);
+  const innerSize = sizeScoped
+    ? ' AND bc.compatible_size_ids IS NOT NULL AND EXISTS (SELECT 1 FROM json_each(bc.compatible_size_ids) WHERE value = ?)'
+    : '';
+  const params: (string | number)[] = [scope.boardType, scope.boardType, scope.layoutId];
+  if (sizeScoped) params.push(scope.sizeId);
+  return {
+    sql: `${gradesTableRef}.board_type = ?
+       AND EXISTS (
+         SELECT 1 FROM ${climbsSchema}.board_climbs bc
+         WHERE bc.uuid = ${gradesTableRef}.climb_uuid AND bc.board_type = ? AND bc.layout_id = ?${innerSize}
+       )`,
+    params,
+  };
+}
+
+/**
+ * Warm one scope's `board_climb_grades` rows from the layout's separate grades
+ * artifact, and stamp the grades resume checkpoint at the imported rows'
+ * watermark — replacing hundreds of serial authenticated GraphQL pages with one
+ * file and one transaction.
+ *
+ * DELIBERATELY ITS OWN EXCLUSIVE TRANSACTION, not merged into
+ * `bootstrapScopeFromSnapshot`'s. Merging would close a crash window but
+ * lengthen a single `BEGIN EXCLUSIVE` hold on a database the app is also
+ * reading (issue #4314). Splitting keeps each hold short, and the worst case is
+ * exactly today's behaviour: if this fails, or the app dies between the two
+ * transactions, no grades checkpoint is stamped and the scope crawls grades as
+ * it always did. No data is at risk either way, so the shorter lock wins.
+ *
+ * No reconcile: `board_climb_grades` has no delete trigger at all (see
+ * deletions-coverage.ts), so there is no tombstone stream to reconcile against
+ * and `INSERT OR REPLACE` is the whole import. `rewindDeletionsCheckpoint` is
+ * likewise untouched — it stays min(climbs, stats) on purpose.
+ *
+ * Same per-connection ATTACH invariant as `bootstrapScopeFromSnapshot`
+ * (BOARDSESH-AA): everything touching the alias runs inside the transaction
+ * task, on the transaction's own connection.
+ */
+export async function bootstrapScopeGradesFromSnapshot(params: {
+  db: OfflineDatabase;
+  scope: OfflineBoardScope;
+  scopeKey: string;
+  filePath: string;
+  onSchemaDrift?: SchemaDriftReporter;
+}): Promise<{ gradesWatermark: SyncCheckpoint; rowsImported: number }> {
+  const { db, scope, scopeKey, filePath, onSchemaDrift } = params;
+  const startEpoch = getWipeEpoch();
+
+  let watermark: SyncCheckpoint | null = null;
+  let rowsImported = 0;
+  try {
+    await db.withExclusiveTransactionAsync(async (txn) => {
+      await txn.execAsync('COMMIT');
+      try {
+        await txn.execAsync(`ATTACH DATABASE '${filePath.replace(/'/g, "''")}' AS ${GRADES_ALIAS}`);
+
+        const integrity = await txn.getAllAsync<{ quick_check: string }>(`PRAGMA ${GRADES_ALIAS}.quick_check`);
+        if (integrity.length !== 1 || integrity[0].quick_check !== 'ok') {
+          throw new Error(
+            `snapshot grades bootstrap: quick_check failed: ${integrity.map((row) => row.quick_check).join('; ')}`,
+          );
+        }
+
+        // Verified against the ONE-ELEMENT grades list. The client's
+        // whole-layout SNAPSHOT_TABLES is untouched, which is what keeps this
+        // change invisible to every pre-change artifact still on the CDN.
+        await verifySnapshotMeta(txn, GRADES_ALIAS, GRADES_SNAPSHOT_TABLES);
+
+        if (isSigningOut() || getWipeEpoch() !== startEpoch) throw new SnapshotWipedError();
+
+        await applyBusyTimeout(txn);
+        await txn.execAsync('BEGIN EXCLUSIVE');
+      } catch (preTransactionError) {
+        await txn.execAsync('BEGIN').catch(() => {});
+        throw preTransactionError;
+      }
+
+      const gradeColumns = await sharedColumns(txn, GRADES_TABLE, onSchemaDrift, GRADES_ALIAS);
+      assertSafeColumns(gradeColumns);
+      if (gradeColumns.length === 0) throw new Error('snapshot grades bootstrap: no shared board_climb_grades columns');
+      const columnList = gradeColumns.join(', ');
+
+      const importFilter = gradesScopeFilter(scope, 'g', 'main');
+      const inserted = await txn.runAsync(
+        `INSERT OR REPLACE INTO main.${GRADES_TABLE} (${columnList})
+         SELECT ${columnList} FROM ${GRADES_ALIAS}.${GRADES_TABLE} g
+         WHERE ${importFilter.sql}`,
+        importFilter.params,
+      );
+      rowsImported = inserted.changes;
+
+      // Stamp at the watermark of the rows the INSERT above actually selected:
+      // the ARTIFACT's rows, under the same scope filter (mirroring
+      // scopedWatermarks' artifact-side reads for climbs/stats). Two wrong
+      // alternatives, both a permanent silent gap because the strict `>` delta
+      // never revisits anything at-or-below the stamp:
+      //  - the artifact's snapshot_meta watermark could stamp past a row the
+      //    scope filter excluded (its climb outside this scope);
+      //  - main.board_climb_grades could stamp past rows this scope NEVER
+      //    received — the table is shared across scopes, so a sibling scope's
+      //    earlier crawl (e.g. kilter:1:7 synced for months when kilter:1:10 is
+      //    added) leaves rows for shared climbs with cursors far beyond this
+      //    artifact, and stamping there skips every grade row computed since
+      //    the artifact was built for climbs exclusive to THIS scope.
+      const watermarkRow = await txn.getFirstAsync<{ cursor_at: string; sync_seq: number | string }>(
+        `SELECT ${GRADES_CURSOR_COLUMN} AS cursor_at, sync_seq
+         FROM ${GRADES_ALIAS}.${GRADES_TABLE} g
+         WHERE ${importFilter.sql}
+         ORDER BY ${GRADES_CURSOR_COLUMN} DESC, sync_seq DESC
+         LIMIT 1`,
+        importFilter.params,
+      );
+      watermark = watermarkRow
+        ? { updatedAt: String(watermarkRow.cursor_at), syncSeq: String(watermarkRow.sync_seq) }
+        : EPOCH_WATERMARK;
+
+      if (isSigningOut() || getWipeEpoch() !== startEpoch) throw new SnapshotWipedError();
+
+      await setCheckpoint(txn, getCheckpointKey(GRADES_TABLE, scopeKey), watermark);
+    });
+  } finally {
+    await db.execAsync(`DETACH DATABASE ${GRADES_ALIAS}`).catch(() => {});
+  }
+
+  if (!watermark) throw new Error('snapshot grades bootstrap: transaction completed without a watermark');
+  return { gradesWatermark: watermark, rowsImported };
 }

--- a/packages/shared/offline-sync/src/sync/snapshot-estimate.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-estimate.ts
@@ -37,6 +37,10 @@ export type SnapshotDownloadEstimate =
    * Wire is deliberately the scale quoted here: it is the honest number for a
    * cellular-data prompt, and it is the same scale the download progress row
    * renders (issue #4311), so the dialog and the bar can never disagree.
+   *
+   * It includes the layout's separate Boardsesh-grades artifact when the
+   * manifest carries one (issue #4310): the scope downloads both, so quoting
+   * only the climbs file would under-promise what the user is about to spend.
    */
   | { kind: 'snapshot'; bytes: number; climbCount: number; builtAt: string }
   /** No trustworthy number — say nothing rather than guess. */
@@ -62,9 +66,11 @@ export function findSnapshotEntry(
  * schema OLDER than ours would NULL-fill the columns that migration added and
  * then stamp the resume cursor past those rows, which the strict `>` delta pull
  * would never backfill. Newer is fine — the import intersects columns.
- * Mirrors the pre-download gate in `runBootstrapPhase`.
+ * Mirrors the pre-download gate in `runBootstrapPhase`. Takes just the version
+ * field so the separate grades artifact — which carries its own
+ * `schemaVersion` — is held to the same rule.
  */
-export function isSnapshotEntryUsable(entry: SnapshotManifestEntry): boolean {
+export function isSnapshotEntryUsable(entry: Pick<SnapshotManifestEntry, 'schemaVersion'>): boolean {
   return entry.schemaVersion >= LATEST_SCHEMA_VERSION;
 }
 
@@ -113,7 +119,7 @@ export function estimateScopeDownload(input: {
 
   return {
     kind: 'snapshot',
-    bytes: entry.bytes,
+    bytes: entry.bytes + (entry.grades?.bytes ?? 0),
     climbCount: entry.tables.board_climbs.rowCount,
     builtAt: entry.builtAt,
   };


### PR DESCRIPTION
**Stacked on #4346** (base `feat/4310-grades-snapshot-artifacts`), which publishes the artifacts this PR consumes. Review the diff of the last commit only.

This is the payoff for #4310. `board_climb_grades` is a per-board table the scope-completion gate waits on, and the whole-layout artifact never carried it — so after a Kilter or Tension artifact lands, the scope still pages hundreds of serial authenticated GraphQL requests before it can serve an offline search, each re-running a correlated `EXISTS` against 375k climbs. `moonboard:2` (20.0 MB, 93,939 climbs, **zero** grade rows) finishes in 14.5s; `tension:9` (17.1 MB, 72,051 climbs, ~79k grade rows) takes 1m27s. Same bytes, same import shape.

The engine now downloads the layout's separate grades artifact and imports it directly, so the following grades pull is a one-page delta instead of a full crawl.

## Changes

- **`bootstrapScopeGradesFromSnapshot`** — its own `withExclusiveTransactionAsync`: COMMIT → ATTACH as `bs_grades` → `quick_check` → verify `snapshot_meta` against the **one-element** grades list → `applyBusyTimeout` → `BEGIN EXCLUSIVE` → scoped `INSERT OR REPLACE` → stamp `checkpoint:board_climb_grades:<scope>` → commit, DETACH in `finally`. Same per-connection ATTACH invariant as the whole-layout import (BOARDSESH-AA): everything touching the alias runs inside the transaction task.
- **Deliberately a second transaction, not a merged one.** Merging would close a crash window but lengthen a single `BEGIN EXCLUSIVE` hold on a database the app is also reading (#4314). Split, each hold stays short and the worst case is *exactly today's behaviour*: no grades checkpoint, and the scope crawls grades as it always did. No data is at risk either way, so the shorter lock wins.
- **No reconcile.** `board_climb_grades` has no delete trigger at all, so `INSERT OR REPLACE` is the whole import and `rewindDeletionsCheckpoint` stays `min(climbs, stats)`.
- **The scope filter is the one place a row can be lost**, so the import uses the same correlated `EXISTS` over `main.board_climbs` that `syncClimbGrades` uses, and the checkpoint is stamped at the watermark of the **artifact rows that same filter actually selected** — mirroring how `scopedWatermarks` reads climbs and stats off the artifact. Both alternatives open a permanent silent gap, since the strict `>` delta never revisits anything at or below the stamp: the artifact's own `snapshot_meta` watermark can sit past a row the scope filter excluded, and `main.board_climb_grades` is **shared across scopes** — a sibling scope crawled months ago (`kilter:1:7` when the user adds `kilter:1:10`) leaves rows with cursors far beyond this artifact, so stamping from `main` skips every grade row computed since the artifact was built for climbs exclusive to the new scope. Covered by two tests: an out-of-scope grade with a *later* cursor does not raise the stamp, and neither does a sibling scope's newer already-crawled row sitting in `main`.
- **Two entry points, both free to fail.** Straight after a successful whole-layout import, and — the retro-fit — for any scope whose board checkpoints exist while `checkpoint:board_climb_grades:<scope>` is **absent**. An absent grades checkpoint proves no grade page was ever consumed (`syncTable` checkpoints per page), so importing and stamping at the artifact's watermark cannot skip a row the crawl already had. That is what rescues every scope downloaded before grades artifacts existed, plus any that crashed between the two transactions. The local checkpoint read is the gate, so a scope that already has grades costs nothing and the manifest is only fetched for scopes that still need it.
- **Separate attempt budget.** `grades-bootstrap-attempts:<scope>` (cap 2), registered in `scopeSyncMetaKeys`. A grades failure never touches `bootstrap-attempts`: losing the grades fast path must not cost a scope its snapshot fast path. New telemetry stages `grades-download` / `grades-import`.
- **Client `SNAPSHOT_TABLES` stays exactly two.** The grades file is verified against its own one-element list, so no pre-change artifact still on the CDN (14-day prune grace plus cached manifests) can fail verification on an updated client as a counted failure.
- **Mobile `downloadGradesArtifact`** shares the whole-layout download body — free-space guard, content-addressed destination, gzip magic-byte sniff, `cause`-preserving errors — with a key-derived filename, since the manifest's grades block carries no board/layout pair.
- **`estimateScopeDownload`** quotes `entry.bytes + grades.bytes`; the stale "artifacts are identity-encoded so stored == wire" comment is corrected (the fleet has been on `v1-gzip` since the cutover).
- `docs/board-snapshots.md` documents the client flow, the two entry points, and the separate budget.

### Rollout

Gated on the presence of `entry.grades` (and the existing `offline-snapshot-bootstrap-v2` flag). Publishing a manifest without `grades` — or rolling back to the identity `v1` prefix, which never carries them — reverts the whole fleet to today's crawl with no deploy. It is a slower download, not a broken one.

**Held in draft** until #4346 has merged, a nightly export has actually published grades artifacts, and one real on-device Kilter `layout 1 / size 10` download is verified on both platforms — the same gate the gzip cutover used.

### Coordination

- Touches `pull-client.ts`'s `runBootstrapPhase` and `snapshot-bootstrap.ts`, same region as #4313 (PRs #4326/#4333) and #4311 (PRs #4335–#4337); whoever lands second rebases.
- This PR is **not** stacked on #4345 (the phase-telemetry PR), so it deliberately does not use its `SnapshotArtifactHandle` / progress types. Once both are on `main`, the grades download can take the same `onProgress`/`signal` options in a small follow-up.
- **Post-merge reconciliation with #4345 is expected.** #4345 replaces the `downloadedPaths` set this PR registers the grades file in with an `artifactImported` / `releaseArtifact` seam, and grades filenames do not match snapshot-source's `artifactNamePrefix` regex, so #4345's supersede sweep will not recognise them. Whichever of the two lands second reconciles: decide whether grades files get sidecar/retention treatment or stay delete-per-cycle, then re-run the offline-sync and mobile suites.
- Rebased onto `main` after #4335 (`uncompressedBytes`) landed; base branch #4346 rebased first, so this branch still stacks on it.

### Rebase note (landed after #4345's retention seam)

#4345 replaced the phase's per-cycle `downloadedPaths` delete with an
`artifactImported` map and a `releaseArtifact(filePath, { imported })` seam, so a
whole-layout artifact the cycle never got to import is KEPT for the next one.
The grades artifact deliberately does **not** join that seam:

- **Deleted, never released.** Grades files are tracked in their own
  `gradesArtifactPaths` set and deleted in the same `finally`, on every exit path
  — imported, failed, or torn down.
- **Why.** Retention is sized and keyed for the ~100 MB climbs file: its
  supersede sweep recognises a build by the `<board>-<layout>` prefix in the
  filename, and a grades file (named from its manifest key) matches no prefix, so
  a retained one would never be swept and would sit in the cache directory
  forever. Re-fetching a few MB next cycle is the cheaper failure.
- **Mobile side.** The shared download body now takes an optional
  `retainAs: { builtAt }`. Only `downloadArtifact` passes it, so only the
  whole-layout file gets the completeness sidecar, the reuse-on-next-cycle check,
  and the budget sweep. `downloadGradesArtifact` writes no sidecar and triggers
  no sweep.

Three regression tests cover it: the grades file reaches `deleteArtifact` (and
not `releaseArtifact`) on the happy path while the climbs file still releases with
`imported: true`, it is deleted after a failed grades import too, and on mobile a
grades download leaves no `.complete` sidecar behind.

## Release Notes

Kilter and Tension downloads finish much faster — Boardsesh grades now arrive with the catalog instead of being fetched a page at a time. Boards you already downloaded pick them up on the next sync too.

## Test plan

- `vp test run --project offline-sync` — 358 passed. New: grades import stamps at the `computed_at` watermark; an out-of-scope grade is dropped and the stamp stops short of it; a corrupt artifact imports nothing and stamps nothing; a `row_count` mismatch is refused; the deletions checkpoint is untouched; `pullSync` imports grades after the whole-layout import and downloads the right key; an entry with no `grades` block takes today's path verbatim; the retro-fit fires for a pre-existing scope **without** re-downloading the whole-layout artifact; it does **not** fire when a grades checkpoint exists; a failed grades import leaves `bootstrap-attempts` at 0 while spending its own budget; the budget cap stops further tries; a schema-stale grades artifact is skipped.
- `vp run test:mobile` — 621 files / 5484 tests passed, including new `downloadGradesArtifact` cases (key-derived filename, free-space guard, still-gzip permanent miss, `cause` preservation).
- `vp run typecheck` (all packages), `vp run typecheck:mobile`, `vp lint` — clean in the touched packages.

Not run: `vp run check:mobile-bundle` (needs a sibling worktree outside `.claude`) and the on-device gate above, which is the draft blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT6VP1sWqk6bY9mUgyeS2U


