### PR TITLE
fix(mobile): show an offline state instead of an empty list on network-only screens

### DIFF
--- a/packages/mobile/app/(tabs)/discover/index.tsx
+++ b/packages/mobile/app/(tabs)/discover/index.tsx
@@ -17,6 +17,8 @@ import type { DiscoverablePlaylist, Playlist, SmartPlaylistType } from '@boardse
 import { Text } from '../../../src/components/Text';
 import { Icon } from '../../../src/components/Icon';
 import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
+import { OfflineState } from '../../../src/components/OfflineState';
+import { useIsOffline } from '../../../src/hooks/use-is-offline';
 import { Button } from '../../../src/components/Button';
 import { SectionHeader } from '../../../src/components/SectionHeader';
 import { HorizontalScrollSection } from '../../../src/components/HorizontalScrollSection';
@@ -418,6 +420,14 @@ export default function DiscoverLibrary() {
     communityItems.length === 0 &&
     !userLoading;
 
+  // Every section here is network-only, and under `networkMode: 'offlineFirst'`
+  // an offline fetch pauses rather than failing — so `showLoadError` never fires
+  // and the hub renders "No playlists yet" to someone who has plenty.
+  const isOffline = useIsOffline();
+  const hasAnyDiscoverContent =
+    hasVisiblePinnedItems || userPlaylists.length > 0 || forYouSmartCards.length > 0 || communityItems.length > 0;
+  const showOfflineState = isOffline && !hasAnyDiscoverContent && !showSignInPrompt && !showLoadError;
+
   const handleRetryLoad = useCallback(() => {
     if (userError) refetchUser();
     if (smartCountsError) void refetchSmartCounts();
@@ -598,8 +608,11 @@ export default function DiscoverLibrary() {
           </View>
         ) : null}
 
+        {showOfflineState ? <OfflineState reason="offline" onRetry={handleRetryLoad} /> : null}
+
         {/* Empty state: signed in, nothing anywhere, nothing loading, no error. */}
-        {isAuthenticated &&
+        {!showOfflineState &&
+        isAuthenticated &&
         !userLoading &&
         !smartCountsLoading &&
         !communityLoading &&
@@ -624,7 +637,8 @@ export default function DiscoverLibrary() {
         ) : null}
 
         {/* Initial spinner before any section has resolved. */}
-        {(authLoading || tokenLoading) &&
+        {!showOfflineState &&
+        (authLoading || tokenLoading) &&
         !hasVisiblePinnedItems &&
         userPlaylists.length === 0 &&
         forYouSmartCards.length === 0 &&

--- a/packages/mobile/app/(tabs)/home/index.tsx
+++ b/packages/mobile/app/(tabs)/home/index.tsx
@@ -30,6 +30,8 @@ import { useTheme } from '../../../src/providers/theme-provider';
 import { useToast } from '../../../src/providers/toast-provider';
 import { useDrawerHost } from '../../../src/providers/drawer-host-provider';
 import { useBottomChromeMetrics } from '../../../src/hooks/use-bottom-chrome-metrics';
+import { useOfflineQueryState } from '../../../src/hooks/use-offline-query-state';
+import { OfflineState } from '../../../src/components/OfflineState';
 import { dedupeSessionsById } from '../../../src/lib/feed-time-buckets';
 import { deriveFeedScopeInput, type FeedMode } from '../../../src/lib/feed/feed-scope';
 import { buildVoteSummaryMap, voteSummaryKey, type VoteSummary } from '../../../src/lib/feed/vote-summary-map';
@@ -127,6 +129,10 @@ export default function HomeTab() {
     scopeReady && betaReady && betaExpanded,
   );
   const feed = useSessionGroupedFeed(feedInput, isAuthenticated && scopeReady);
+  // The feed is network-only and `networkMode: 'offlineFirst'` pauses an offline
+  // fetch instead of failing it, so neither `isLoading` nor `isError` ever
+  // resolves — the skeleton list would sit there for good.
+  const feedOffline = useOfflineQueryState(feed);
 
   const sessions = useMemo(
     () => dedupeSessionsById(feed.data?.pages.flatMap((page) => page.sessionGroupedFeed.sessions) ?? []),
@@ -414,7 +420,9 @@ export default function HomeTab() {
           />
         }
         ListEmptyComponent={
-          feed.isLoading || !scopeReady ? (
+          feedOffline.isBlocked && feedOffline.reason ? (
+            <OfflineState reason={feedOffline.reason} onRetry={handleRefresh} />
+          ) : feed.isLoading || !scopeReady ? (
             <ActivitySkeletonList skeletonKeys={INITIAL_FEED_SKELETON_KEYS} />
           ) : feed.isError ? (
             <View style={styles.feedState}>

--- a/packages/mobile/app/gyms/mine.tsx
+++ b/packages/mobile/app/gyms/mine.tsx
@@ -17,6 +17,8 @@ import { Icon } from '../../src/components/Icon';
 import { Button } from '../../src/components/Button';
 import { PressableSurface } from '../../src/components/PressableSurface';
 import { ActivityIndicator } from '../../src/components/ActivityIndicator';
+import { OfflineState } from '../../src/components/OfflineState';
+import { useOfflineQueryState } from '../../src/hooks/use-offline-query-state';
 import { MyGymRow } from '../../src/components/gym-directory/MyGymRow';
 import { iosSystemColors } from '../../src/theme/ios-colors';
 import { spacing, borderRadius } from '../../src/theme/tokens';
@@ -40,7 +42,11 @@ export default function MyGymsScreen() {
 
   const { data: profile } = useProfile();
   const currentUserId = profile?.id;
-  const { data: connection, isLoading, isError, refetch } = useMyGyms({ enabled: !!currentUserId });
+  const myGymsQuery = useMyGyms({ enabled: !!currentUserId });
+  const { data: connection, isLoading, isError, refetch } = myGymsQuery;
+  // Offline the fetch pauses rather than failing, so `isLoading` stays true and
+  // neither the error nor the empty branch below is ever reached.
+  const offline = useOfflineQueryState(myGymsQuery);
 
   const gyms = connection?.gyms ?? [];
 
@@ -104,6 +110,15 @@ export default function MyGymsScreen() {
     hapticSelection();
     router.push('/gyms');
   }, [router]);
+
+  if (offline.isBlocked && offline.reason) {
+    return (
+      <View style={[styles.centered, { backgroundColor: systemColors.background }]}>
+        {header}
+        <OfflineState reason={offline.reason} onRetry={() => void refetch()} />
+      </View>
+    );
+  }
 
   if (isLoading) {
     return (

--- a/packages/mobile/app/users/connections.tsx
+++ b/packages/mobile/app/users/connections.tsx
@@ -7,6 +7,8 @@ import type { PublicUserProfile } from '@boardsesh/shared-schema';
 import { Text } from '../../src/components/Text';
 import { Icon } from '../../src/components/Icon';
 import { ActivityIndicator } from '../../src/components/ActivityIndicator';
+import { OfflineState } from '../../src/components/OfflineState';
+import { useOfflineQueryState } from '../../src/hooks/use-offline-query-state';
 import {
   ClimberSearchErrorState,
   ClimberSearchPersonRow,
@@ -79,13 +81,17 @@ export default function ConnectionsScreen() {
     [currentUserId, handleToggleFollow, toggleFollow.isPending, toggleFollow.variables?.userId],
   );
 
-  const showSpinner = activeQuery.isPending && people.length === 0;
-  const showError = activeQuery.isError && people.length === 0;
+  // Followers/following are network-only. An offline fetch pauses instead of
+  // failing, so `isPending` never clears and neither branch below fires.
+  const offline = useOfflineQueryState(activeQuery);
+  const showOffline = offline.isBlocked && people.length === 0;
+  const showSpinner = !showOffline && activeQuery.isPending && people.length === 0;
+  const showError = !showOffline && activeQuery.isError && people.length === 0;
 
   return (
     <View style={[styles.flex, { backgroundColor: systemColors.background }]}>
       <FlashList
-        data={showSpinner || showError ? EMPTY_PEOPLE : people}
+        data={showSpinner || showError || showOffline ? EMPTY_PEOPLE : people}
         renderItem={renderItem}
         keyExtractor={(person) => person.id}
         contentInsetAdjustmentBehavior="automatic"
@@ -93,7 +99,9 @@ export default function ConnectionsScreen() {
         onEndReached={handleEndReached}
         onEndReachedThreshold={0.5}
         ListEmptyComponent={
-          showSpinner ? (
+          showOffline && offline.reason ? (
+            <OfflineState reason={offline.reason} onRetry={() => void activeQuery.refetch()} />
+          ) : showSpinner ? (
             <View style={styles.stateBlock}>
               <ActivityIndicator size="large" />
             </View>

--- a/packages/mobile/app/users/search.tsx
+++ b/packages/mobile/app/users/search.tsx
@@ -7,6 +7,8 @@ import { useTranslation } from 'react-i18next';
 import type { PublicUserProfile } from '@boardsesh/shared-schema';
 import { Text } from '../../src/components/Text';
 import { ActivityIndicator } from '../../src/components/ActivityIndicator';
+import { OfflineState } from '../../src/components/OfflineState';
+import { useOfflineQueryState } from '../../src/hooks/use-offline-query-state';
 import {
   ClimberSearchEmptyState,
   ClimberSearchErrorState,
@@ -83,9 +85,14 @@ export default function ClimberSearchScreen() {
   );
 
   const showHint = trimmedSearchQuery.length < 2;
-  const showInitialSpinner = !showHint && (searchIsDebouncing || (search.isPending && people.length === 0));
-  const showError = !showHint && !searchIsDebouncing && search.isError && people.length === 0;
-  const visiblePeople = showInitialSpinner || showHint || showError ? EMPTY_PEOPLE : people;
+  // Climber search is network-only. Offline the fetch pauses instead of failing,
+  // so without this it would sit on the loading state for good.
+  const offline = useOfflineQueryState(search);
+  const showOffline = !showHint && !searchIsDebouncing && offline.isBlocked && people.length === 0;
+  const showInitialSpinner =
+    !showOffline && !showHint && (searchIsDebouncing || (search.isPending && people.length === 0));
+  const showError = !showOffline && !showHint && !searchIsDebouncing && search.isError && people.length === 0;
+  const visiblePeople = showInitialSpinner || showHint || showError || showOffline ? EMPTY_PEOPLE : people;
 
   return (
     <View style={[styles.flex, { backgroundColor: systemColors.background, paddingTop: insets.top }]}>
@@ -120,7 +127,9 @@ export default function ClimberSearchScreen() {
         onEndReached={handleEndReached}
         onEndReachedThreshold={0.5}
         ListEmptyComponent={
-          showInitialSpinner ? (
+          showOffline && offline.reason ? (
+            <OfflineState reason={offline.reason} onRetry={() => void search.refetch()} />
+          ) : showInitialSpinner ? (
             <ClimberSearchLoadingState />
           ) : showError ? (
             <ClimberSearchErrorState onRetry={() => void search.refetch()} />

--- a/packages/mobile/src/components/OfflineState.tsx
+++ b/packages/mobile/src/components/OfflineState.tsx
@@ -1,0 +1,68 @@
+import { memo } from 'react';
+import { StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Icon } from './Icon';
+import { Text } from './Text';
+import { Button } from './Button';
+import { useTheme } from '../providers/theme-provider';
+import { spacing } from '../theme/tokens';
+import type { OfflineQueryReason } from '../hooks/use-offline-query-state';
+
+type OfflineStateProps = {
+  /**
+   * `'offline'` says the device has no signal; `'error'` says the request
+   * reached the network and failed. Pass `useOfflineQueryState(...).reason`.
+   */
+  reason: OfflineQueryReason;
+  /** Retry handler — usually the query's `refetch`. Omit to hide the button. */
+  onRetry?: () => void;
+  style?: StyleProp<ViewStyle>;
+};
+
+/**
+ * The placard a network-only screen shows instead of a spinner that never
+ * resolves or an empty list that claims the climber has nothing. Paired with
+ * `useOfflineQueryState`: when it reports `isBlocked`, render this.
+ *
+ * Deliberately says what still works offline rather than only what does not —
+ * downloaded boards keep browsing, searching and logging, and people who hit
+ * this screen with no signal need to know that.
+ */
+function OfflineStateComponent({ reason, onRetry, style }: OfflineStateProps) {
+  const { t } = useTranslation('common');
+  const { systemColors } = useTheme();
+
+  const isOffline = reason === 'offline';
+
+  return (
+    <View style={[styles.root, style]}>
+      <Icon name={isOffline ? 'offline.unavailable' : 'warning'} size={44} color={systemColors.tertiaryLabel} />
+      <Text variant="headline" color={systemColors.label} style={styles.title}>
+        {t(isOffline ? 'mobile.offlineState.title' : 'mobile.offlineState.errorTitle')}
+      </Text>
+      <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.body}>
+        {t(isOffline ? 'mobile.offlineState.body' : 'mobile.offlineState.errorBody')}
+      </Text>
+      {onRetry ? (
+        <View style={styles.cta}>
+          <Button title={t('mobile.offlineState.retry')} variant="tonal" onPress={onRetry} />
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+export const OfflineState = memo(OfflineStateComponent);
+
+const styles = StyleSheet.create({
+  root: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing[2],
+    paddingVertical: spacing[10],
+    paddingHorizontal: spacing[8],
+  },
+  title: { textAlign: 'center', marginTop: spacing[2] },
+  body: { textAlign: 'center', maxWidth: 420 },
+  cta: { marginTop: spacing[3] },
+});

--- a/packages/mobile/src/components/you/LogbookTab.tsx
+++ b/packages/mobile/src/components/you/LogbookTab.tsx
@@ -37,6 +37,8 @@ import { LogbookFacetRail } from './LogbookFacetRail';
 import type { LogbookFacetKey } from './LogbookChipRow.logic';
 import { useLogbookSearch, countActiveLogbookFilters } from './use-logbook-search';
 import { useUserAscentsFeed, useUserGroupedAscentsFeed, useGrades } from '../../lib/graphql/hooks';
+import { useOfflineQueryState } from '../../hooks/use-offline-query-state';
+import { OfflineState } from '../OfflineState';
 import type { Grade } from '@boardsesh/shared-schema';
 import { openClimbInPlayDrawer } from '../../lib/open-climb-in-play-drawer';
 import { tickToClimb } from '../../lib/tick-to-climb';
@@ -234,6 +236,10 @@ export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true }: Logbo
   // Control-surface alias (status flags, pagination); data is read per-mode in
   // the rows memo below where the types differ.
   const feed = groupedMode ? groupedFeed : flatFeed;
+  // An offline fetch pauses rather than erroring under `networkMode:
+  // 'offlineFirst'`, so it lands in neither the isError nor the loaded branch
+  // below — without this it spins forever.
+  const offline = useOfflineQueryState(feed);
 
   // Day dividers render only on a date-ordered feed (the Latest preset or a
   // custom date sort) — keyed off the EFFECTIVE feedInput, so the flag-off
@@ -639,7 +645,11 @@ export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true }: Logbo
         )}
       </View>
 
-      {feed.isPending ? (
+      {offline.isBlocked && offline.reason ? (
+        <View style={styles.centered}>
+          <OfflineState reason={offline.reason} onRetry={handleRetry} />
+        </View>
+      ) : feed.isPending ? (
         <View style={styles.centered}>
           <ActivityIndicator size="large" />
         </View>

--- a/packages/mobile/src/components/you/ProgressTab.tsx
+++ b/packages/mobile/src/components/you/ProgressTab.tsx
@@ -7,6 +7,7 @@ import { Icon } from '../Icon';
 import { Card } from '../Card';
 import { SectionHeader } from '../SectionHeader';
 import { ActivityIndicator } from '../ActivityIndicator';
+import { OfflineState } from '../OfflineState';
 import { ProfileBetaShelf } from './ProfileBetaShelf';
 import { StatsSummaryCard } from './StatsSummaryCard';
 import { StackedBarChart, GroupedBarChart, TotalAreaChart, type ChartLegendItem } from './YouCharts';
@@ -81,6 +82,16 @@ export const ProgressTab = memo(function ProgressTab({ data, topInset, userId }:
       })),
     [data.aggregatedFlashRedpointBars, colorScheme],
   );
+
+  // Offline (or a hard fetch failure) with nothing cached: say so rather than
+  // spin forever on a paused query or chart an empty climber.
+  if (data.offline.isBlocked && data.offline.reason) {
+    return (
+      <View style={[styles.centered, { paddingTop: topInset }]}>
+        <OfflineState reason={data.offline.reason} onRetry={data.refetch} />
+      </View>
+    );
+  }
 
   if (data.loading) {
     return (

--- a/packages/mobile/src/components/you/SessionsTab.tsx
+++ b/packages/mobile/src/components/you/SessionsTab.tsx
@@ -10,6 +10,7 @@ import { Icon } from '../Icon';
 import { Button } from '../Button';
 import { Card } from '../Card';
 import { ActivityIndicator } from '../ActivityIndicator';
+import { OfflineState } from '../OfflineState';
 import { SessionFeedCard } from './SessionFeedCard';
 import { SessionsFeedHeader } from './SessionsFeedHeader';
 import { FeedSectionLabel } from './FeedSectionLabel';
@@ -19,6 +20,7 @@ import { useSessionGroupedFeed, useBulkVoteSummaries } from '../../lib/graphql/h
 import { navigateToSessionFeedItem } from '../../lib/session-feed-navigation';
 import { openClimbInPlayDrawer } from '../../lib/open-climb-in-play-drawer';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
+import { useOfflineQueryState } from '../../hooks/use-offline-query-state';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
@@ -98,6 +100,9 @@ export function SessionsTab({ userId, topInset = 0 }: SessionsTabProps) {
   const [commentTarget, setCommentTarget] = useState<CommentTarget | null>(null);
 
   const feed = useSessionGroupedFeed({ userId }, !!userId);
+  // `networkMode: 'offlineFirst'` pauses an offline fetch instead of failing it,
+  // so `feed.isPending` below would hold the skeleton up for good.
+  const offline = useOfflineQueryState(feed);
   // De-dupe across pages: the OFFSET-paginated feed can return the same session
   // on two adjacent pages when its rank shifts mid-refetch, which would
   // otherwise produce duplicate FlashList keys (keyExtractor returns sessionId).
@@ -215,6 +220,14 @@ export function SessionsTab({ userId, topInset = 0 }: SessionsTabProps) {
     return (
       <View style={[styles.centered, { paddingTop: topInset }]}>
         <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  if (offline.isBlocked && offline.reason) {
+    return (
+      <View style={[styles.centered, { paddingTop: topInset }]}>
+        <OfflineState reason={offline.reason} onRetry={() => void feed.refetch()} />
       </View>
     );
   }

--- a/packages/mobile/src/components/you/SocialTab.tsx
+++ b/packages/mobile/src/components/you/SocialTab.tsx
@@ -13,6 +13,8 @@ import type { PublicUserProfile } from '@boardsesh/shared-schema';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { ActivityIndicator } from '../ActivityIndicator';
+import { OfflineState } from '../OfflineState';
+import { useOfflineQueryState } from '../../hooks/use-offline-query-state';
 import { SegmentedControl } from '../SegmentedControl';
 import {
   ClimberSearchEmptyState,
@@ -89,8 +91,15 @@ export function SocialTab({ userId, onScroll, topInset = 0, registerScrollToTop 
   const showSearchHint = mode === 'search' && trimmedSearchQuery.length < 2;
   const canRefetchActiveQuery = mode !== 'search' || canUseSearchQuery;
   const isSearchDebouncing = mode === 'search' && searchIsDebouncing;
-  const showInitialSpinner = isSearchDebouncing || (!showSearchHint && activeQuery.isPending && people.length === 0);
-  const showError = !showSearchHint && !isSearchDebouncing && activeQuery.isError && people.length === 0;
+  // An offline fetch pauses instead of erroring (`networkMode: 'offlineFirst'`),
+  // so it satisfies neither branch below and the spinner never clears. `offline`
+  // outranks both.
+  const offlineState = useOfflineQueryState(activeQuery);
+  const showOffline = !showSearchHint && !isSearchDebouncing && offlineState.isBlocked && people.length === 0;
+  const showInitialSpinner =
+    !showOffline && (isSearchDebouncing || (!showSearchHint && activeQuery.isPending && people.length === 0));
+  const showError =
+    !showOffline && !showSearchHint && !isSearchDebouncing && activeQuery.isError && people.length === 0;
   const isRefreshing = publicProfile.isRefetching || (canRefetchActiveQuery && activeQuery.isRefetching);
 
   const segmentOptions = useMemo(
@@ -189,7 +198,7 @@ export function SocialTab({ userId, onScroll, topInset = 0, registerScrollToTop 
     <View style={styles.flex}>
       <FlashList
         ref={listRef}
-        data={showInitialSpinner || showSearchHint || showError ? EMPTY_PEOPLE : people}
+        data={showInitialSpinner || showSearchHint || showError || showOffline ? EMPTY_PEOPLE : people}
         renderItem={renderItem}
         keyExtractor={(person) => person.id}
         onScroll={onScroll}
@@ -204,7 +213,9 @@ export function SocialTab({ userId, onScroll, topInset = 0, registerScrollToTop 
           <RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} tintColor={brandColors.primary} />
         }
         ListEmptyComponent={
-          showInitialSpinner ? (
+          showOffline && offlineState.reason ? (
+            <OfflineState reason={offlineState.reason} onRetry={handleRefresh} />
+          ) : showInitialSpinner ? (
             <View style={styles.stateBlock}>
               <ActivityIndicator size="large" />
             </View>

--- a/packages/mobile/src/components/you/__tests__/logbook-tab-analytics.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-tab-analytics.test.tsx
@@ -111,7 +111,11 @@ vi.mock('../../../providers/dialog-provider', () => ({ useConfirm: () => vi.fn(a
 // not silently change code path if a provider default ever moves.
 vi.mock('../../../providers/feature-flags-provider', () => ({ useFeatureFlag: () => undefined }));
 vi.mock('../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
-vi.mock('@tanstack/react-query', () => ({ useQueryClient: () => ({ setQueriesData: vi.fn() }) }));
+// onlineManager is what `useIsOffline` (via useOfflineQueryState) reads.
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ setQueriesData: vi.fn() }),
+  onlineManager: { isOnline: () => true, subscribe: () => () => {} },
+}));
 
 import { LogbookTab } from '../LogbookTab';
 import { toGroupedFeed } from './helpers/grouped-feed-factory';

--- a/packages/mobile/src/components/you/__tests__/logbook-tab-chips.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-tab-chips.test.tsx
@@ -159,7 +159,11 @@ vi.mock('../../../providers/drawer-host-provider', () => ({
 vi.mock('@boardsesh/board-react', () => ({ useDeleteTick: () => ({ mutate: vi.fn(), isPending: false }) }));
 vi.mock('../../../providers/dialog-provider', () => ({ useConfirm: () => vi.fn(async () => false) }));
 vi.mock('../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
-vi.mock('@tanstack/react-query', () => ({ useQueryClient: () => ({ setQueriesData: vi.fn() }) }));
+// onlineManager is what `useIsOffline` (via useOfflineQueryState) reads.
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ setQueriesData: vi.fn() }),
+  onlineManager: { isOnline: () => true, subscribe: () => () => {} },
+}));
 vi.mock('../../../providers/feature-flags-provider', () => ({
   useFeatureFlag: (key: string) => (key === 'logbook-filters' ? flagState.logbookFilters : undefined),
 }));

--- a/packages/mobile/src/components/you/__tests__/logbook-tab-error.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-tab-error.test.tsx
@@ -78,7 +78,11 @@ vi.mock('../../../providers/drawer-host-provider', () => ({ useDrawerHost: () =>
 vi.mock('@boardsesh/board-react', () => ({ useDeleteTick: () => ({ mutate: vi.fn(), isPending: false }) }));
 vi.mock('../../../providers/dialog-provider', () => ({ useConfirm: () => vi.fn(async () => false) }));
 vi.mock('../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
-vi.mock('@tanstack/react-query', () => ({ useQueryClient: () => ({ setQueriesData: vi.fn() }) }));
+// onlineManager is what `useIsOffline` (via useOfflineQueryState) reads.
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ setQueriesData: vi.fn() }),
+  onlineManager: { isOnline: () => true, subscribe: () => () => {} },
+}));
 
 import { LogbookTab } from '../LogbookTab';
 import { toGroupedFeed } from './helpers/grouped-feed-factory';

--- a/packages/mobile/src/components/you/__tests__/logbook-tab-toolbar.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-tab-toolbar.test.tsx
@@ -129,7 +129,11 @@ vi.mock('../../../providers/drawer-host-provider', () => ({
 vi.mock('@boardsesh/board-react', () => ({ useDeleteTick: () => ({ mutate: vi.fn(), isPending: false }) }));
 vi.mock('../../../providers/dialog-provider', () => ({ useConfirm: () => vi.fn(async () => false) }));
 vi.mock('../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
-vi.mock('@tanstack/react-query', () => ({ useQueryClient: () => ({ setQueriesData: vi.fn() }) }));
+// onlineManager is what `useIsOffline` (via useOfflineQueryState) reads.
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ setQueriesData: vi.fn() }),
+  onlineManager: { isOnline: () => true, subscribe: () => () => {} },
+}));
 vi.mock('../../../providers/feature-flags-provider', () => ({
   useFeatureFlag: (key: string) => (key === 'logbook-filters' ? flagState.logbookFilters : undefined),
 }));

--- a/packages/mobile/src/hooks/__tests__/use-offline-query-state.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-offline-query-state.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { deriveOfflineQueryState, type OfflineQueryInput } from '../use-offline-query-state';
+
+const pausedPending: OfflineQueryInput = { status: 'pending', fetchStatus: 'paused' };
+const fetchingPending: OfflineQueryInput = { status: 'pending', fetchStatus: 'fetching' };
+const idleError: OfflineQueryInput = { status: 'error', fetchStatus: 'idle' };
+const loadedEmptyList: OfflineQueryInput = { status: 'success', fetchStatus: 'idle', data: [] };
+const loadedRows: OfflineQueryInput = { status: 'success', fetchStatus: 'idle', data: [{ id: 'a' }] };
+
+describe('deriveOfflineQueryState', () => {
+  it('reports a paused query as blocked-offline — the permanent-spinner case', () => {
+    // networkMode: 'offlineFirst' leaves status 'pending' forever, which every
+    // screen reads as "still loading". fetchStatus is the honest signal.
+    expect(deriveOfflineQueryState([pausedPending], true)).toEqual({
+      isOffline: true,
+      isBlocked: true,
+      reason: 'offline',
+    });
+  });
+
+  it('trusts a paused query over a stale onlineManager read', () => {
+    expect(deriveOfflineQueryState([pausedPending], false).reason).toBe('offline');
+  });
+
+  it('does not claim "no signal" for a query that failed while online', () => {
+    expect(deriveOfflineQueryState([idleError], false)).toEqual({
+      isOffline: false,
+      isBlocked: true,
+      reason: 'error',
+    });
+  });
+
+  it('treats an error while offline as offline, not as a server failure', () => {
+    expect(deriveOfflineQueryState([idleError], true).reason).toBe('offline');
+  });
+
+  it('is not blocked while a fetch is genuinely in flight', () => {
+    expect(deriveOfflineQueryState([fetchingPending], false)).toEqual({
+      isOffline: false,
+      isBlocked: false,
+      reason: null,
+    });
+  });
+
+  it('is not blocked once a query has resolved, even to an empty list', () => {
+    // An honestly-empty answer is the screen's own empty state, not ours.
+    expect(deriveOfflineQueryState([loadedEmptyList], true).isBlocked).toBe(false);
+  });
+
+  it('renders the data it has rather than a placard when one of several queries succeeded', () => {
+    expect(deriveOfflineQueryState([pausedPending, loadedRows], true).isBlocked).toBe(false);
+  });
+
+  it('blocks when every query in the set is stalled', () => {
+    expect(deriveOfflineQueryState([pausedPending, idleError], true).isBlocked).toBe(true);
+  });
+
+  it('is not blocked with no queries at all', () => {
+    expect(deriveOfflineQueryState([], true)).toEqual({ isOffline: true, isBlocked: false, reason: null });
+  });
+
+  it('carries isOffline through even when nothing is blocked', () => {
+    expect(deriveOfflineQueryState([loadedRows], true).isOffline).toBe(true);
+  });
+});

--- a/packages/mobile/src/hooks/use-offline-query-state.ts
+++ b/packages/mobile/src/hooks/use-offline-query-state.ts
@@ -1,0 +1,74 @@
+import { useIsOffline } from './use-is-offline';
+
+/**
+ * The subset of a React Query result this module reads. Kept structural (rather
+ * than importing `UseQueryResult`) so `useInfiniteQuery` results, `useQueries`
+ * entries and hand-rolled snapshots all fit, and so the pure reducer below is
+ * testable without a QueryClient.
+ */
+export type OfflineQueryInput = {
+  status: 'pending' | 'error' | 'success';
+  fetchStatus: 'fetching' | 'paused' | 'idle';
+  data?: unknown;
+};
+
+export type OfflineQueryReason = 'offline' | 'error';
+
+export type OfflineQueryState = {
+  /** The device reports no connection. */
+  isOffline: boolean;
+  /**
+   * These queries cannot produce data right now AND have none to fall back on,
+   * so the screen has nothing honest to render. Show `OfflineState`.
+   */
+  isBlocked: boolean;
+  /** Why it is blocked, or `null` when it is not. */
+  reason: OfflineQueryReason | null;
+};
+
+/**
+ * Why this exists: `query-provider.tsx` sets `networkMode: 'offlineFirst'`, so a
+ * network-only query with no signal fires once, fails, and then **pauses**. Its
+ * `status` stays `'pending'` forever, which every screen in the app reads as
+ * "still loading". The result is a permanent spinner, or — on screens that
+ * render an empty list while pending — a lying "you have no playlists yet".
+ *
+ * `fetchStatus === 'paused'` is the honest signal: React Query knows it cannot
+ * even try. An `error` status with the device offline means the same thing (the
+ * request lost the race with a connectivity change). An `error` while genuinely
+ * online is a different failure and must not claim "no signal".
+ *
+ * Any query that already carries data wins over all of that: stale rows beat an
+ * offline placard, so a partially-loaded screen stays rendered.
+ */
+export function deriveOfflineQueryState(queries: readonly OfflineQueryInput[], isOffline: boolean): OfflineQueryState {
+  const hasAnyData = queries.some((query) => query.data !== undefined && query.data !== null);
+  const anyPaused = queries.some((query) => query.fetchStatus === 'paused');
+  const anyErrored = queries.some((query) => query.status === 'error');
+
+  const isBlocked = !hasAnyData && (anyPaused || anyErrored);
+  if (!isBlocked) return { isOffline, isBlocked: false, reason: null };
+
+  // A paused query is React Query's own "the network is down" verdict, which is
+  // more reliable than a stale onlineManager read, so it outranks `isOffline`.
+  const reason: OfflineQueryReason = anyPaused || isOffline ? 'offline' : 'error';
+  return { isOffline, isBlocked: true, reason };
+}
+
+/**
+ * Reactive `{ isOffline, isBlocked, reason }` for one query or a set of them.
+ * Pass every query the screen needs before it can render anything meaningful;
+ * if any of them has data the screen is not blocked.
+ *
+ * Deliberately not memoized: the reducer is three array scans over a handful of
+ * entries, and React Query hands back a fresh result object each render anyway,
+ * so a `useMemo` here would need a hand-rolled dependency fingerprint to buy
+ * anything at all.
+ */
+export function useOfflineQueryState(queries: OfflineQueryInput | readonly OfflineQueryInput[]): OfflineQueryState {
+  const isOffline = useIsOffline();
+  const list: readonly OfflineQueryInput[] = Array.isArray(queries)
+    ? (queries as readonly OfflineQueryInput[])
+    : [queries as OfflineQueryInput];
+  return deriveOfflineQueryState(list, isOffline);
+}

--- a/packages/mobile/src/lib/graphql/hooks/use-you-profile-data.ts
+++ b/packages/mobile/src/lib/graphql/hooks/use-you-profile-data.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import { deriveProfileViewModel, type UnifiedTimeframeType } from '@boardsesh/profile-stats';
 import { useGradeFormat } from '../../../hooks/use-grade-format';
+import { useOfflineQueryState } from '../../../hooks/use-offline-query-state';
 import { useAllBoardsTicks, useUserProfileStats, useUserClimbPercentile } from './use-you-data';
 
 /**
@@ -51,10 +52,15 @@ export function useYouProfileData(userId: string | undefined) {
     void percentileQuery.refetch();
   }, [allBoardsTicksQuery, profileStatsQuery, percentileQuery]);
 
+  // With `networkMode: 'offlineFirst'`, an offline fetch pauses instead of
+  // failing, so `isPending` stays true forever and `loading` below would spin
+  // for good. This is what the Progress tab renders instead.
+  const offline = useOfflineQueryState([allBoardsTicksQuery, profileStatsQuery]);
+
   // `!userId` (the brief post-login window before useProfile resolves) counts
   // as loading so the Progress tab shows a spinner instead of flashing the
   // empty state, then the charts.
-  const loading = !userId || allBoardsTicksQuery.isPending || profileStatsQuery.isPending;
+  const loading = !offline.isBlocked && (!userId || allBoardsTicksQuery.isPending || profileStatsQuery.isPending);
 
   const refreshing = allBoardsTicksQuery.isRefetching || profileStatsQuery.isRefetching || percentileQuery.isRefetching;
 
@@ -62,6 +68,7 @@ export function useYouProfileData(userId: string | undefined) {
 
   return {
     loading,
+    offline,
     refreshing,
     refetch,
     percentile: percentileQuery.data ?? null,

--- a/packages/shared/i18n/locales/de/common.json
+++ b/packages/shared/i18n/locales/de/common.json
@@ -333,6 +333,13 @@
       "manualHint": "Die Preview-Liste ließ sich nicht laden. Gib einen Channel-Namen ein (etwa pr-1234), um manuell zu wechseln.",
       "manualPlaceholder": "Channel-Name",
       "manualInputA11y": "Channel-Name zum Wechseln"
+    },
+    "offlineState": {
+      "title": "Kein Empfang",
+      "body": "Dafür brauchst du Empfang. Heruntergeladene Boards kannst du weiter durchstöbern, durchsuchen und offline eintragen.",
+      "errorTitle": "Konnte nicht geladen werden",
+      "errorBody": "Das ist nicht durchgekommen. Versuch es noch mal.",
+      "retry": "Erneut versuchen"
     }
   },
   "lightControl": {

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -333,6 +333,13 @@
       "manualHint": "Couldn't load the preview list. Enter a channel name (like pr-1234) to switch manually.",
       "manualPlaceholder": "channel name",
       "manualInputA11y": "Channel name to switch to"
+    },
+    "offlineState": {
+      "title": "No signal",
+      "body": "This one needs a connection. Boards you've downloaded still browse, search and log offline.",
+      "errorTitle": "Couldn't load this",
+      "errorBody": "That didn't come through. Give it another go.",
+      "retry": "Try again"
     }
   },
   "lightControl": {

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -550,6 +550,13 @@
       "manualHint": "No se pudo cargar la lista de versiones de prueba. Introduce un nombre de canal (como pr-1234) para cambiar manualmente.",
       "manualPlaceholder": "nombre del canal",
       "manualInputA11y": "Nombre del canal al que cambiar"
+    },
+    "offlineState": {
+      "title": "Sin conexión",
+      "body": "Esto necesita conexión. Los plafones que has descargado se siguen explorando, buscando y registrando sin conexión.",
+      "errorTitle": "No hemos podido cargarlo",
+      "errorBody": "No ha llegado. Vuelve a intentarlo.",
+      "retry": "Reintentar"
     }
   },
   "lightControl": {

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -333,6 +333,13 @@
       "manualHint": "Impossible de charger la liste des préversions. Saisissez un nom de canal (comme pr-1234) pour changer manuellement.",
       "manualPlaceholder": "nom du canal",
       "manualInputA11y": "Nom du canal vers lequel basculer"
+    },
+    "offlineState": {
+      "title": "Pas de réseau",
+      "body": "Il faut du réseau pour ça. Les boards que tu as téléchargées se parcourent, se cherchent et s'enregistrent toujours hors ligne.",
+      "errorTitle": "Impossible de charger ça",
+      "errorBody": "Ça n'est pas passé. Réessaie.",
+      "retry": "Réessayer"
     }
   },
   "lightControl": {


### PR DESCRIPTION
Stacked on #4348 (the decision doc). Review this commit only.

`query-provider.tsx` sets `networkMode: 'offlineFirst'`. A network-only query with no signal therefore fires once, fails, and then **pauses** — `status` stays `'pending'` forever while `fetchStatus` goes `'paused'`. Every screen in the app reads `isPending` as "still loading", so the result is one of two lies:

- a spinner that never resolves (You → Progress, You → Sessions, You → Logbook, Home feed, My Gyms), or
- an empty state claiming the climber has nothing (Discover's "No playlists yet", climber search, followers/following).

Neither says the one true thing: there is no signal, and downloaded boards still work.

## Changes

- **`useOfflineQueryState`** (`src/hooks/use-offline-query-state.ts`) — reads `fetchStatus === 'paused'` as React Query's own "the network is down" verdict, which is more reliable than a possibly-stale `onlineManager` read, so it outranks `isOffline`. An `error` while offline means the same thing; an `error` while genuinely online is a different failure and must **not** claim "no signal". Any query that already carries data outranks all of it — stale rows beat a placard, so a partly-loaded screen stays rendered. The reducer is a pure function taking `(queries, isOffline)`, so it is testable without a QueryClient.
- **`OfflineState`** (`src/components/OfflineState.tsx`) — icon, copy, optional retry. The copy deliberately says what still works ("Boards you've downloaded still browse, search and log offline") rather than only what does not.
- **Surface sweep**: `ProgressTab`, `LogbookTab`, `SessionsTab`, `SocialTab`, `app/(tabs)/discover`, `app/(tabs)/home`, `app/gyms/mine`, `app/users/search`, `app/users/connections`. Each one keeps its existing empty and error branches; the offline branch is inserted ahead of them and the existing conditions are gated on `!showOffline` so the two cannot both fire.
- `useYouProfileData` exposes `offline` and no longer reports `loading` while blocked — that hook's `loading` is exactly the flag that was pinning the Progress tab's spinner.
- New i18n keys `common:mobile.offlineState.*` in all four locales (es "plafón", fr "Pas de réseau", de du-form).
- The four logbook-tab test files mocked `@tanstack/react-query` with only `useQueryClient`; they now also stub `onlineManager`, which is what `useIsOffline` reads.

Discover and Home take a slightly different shape from the rest: Discover's sections come from `@boardsesh/playlists-react` hooks that expose `isLoading`/`hasError` rather than a raw query result, so it gates on device connectivity plus "nothing loaded anywhere" instead of per-query `fetchStatus`.

## Release Notes

Screens that need a connection now say so instead of showing an endless spinner or an empty list. Your progress, sessions, logbook, playlists, gyms and the activity feed all tell you when there's no signal — and remind you that boards you've downloaded still browse, search and log fine.

## Test plan

- `vp run test:mobile` — 623 files / 5,505 tests pass.
- New `use-offline-query-state.test.ts` (10 cases): paused → blocked-offline; a paused query outranks a stale online read; an error while online is `'error'`, never `'offline'`; a query still fetching is not blocked; a resolved-but-empty query is the screen's own empty state, not ours; one succeeded query in a set keeps the screen rendered.
- `vp test run --reporter=agent packages/shared/i18n` — 90 tests, catalog parity across all four locales.
- `vp run typecheck:mobile`, `vp check`.
- `vp run check:mobile-bundle` — Android bundle OK.

JS/TS only, no dependency change, no fingerprint movement — rides OTA.

Refs #4002

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT6VP1sWqk6bY9mUgyeS2U
