### PR TITLE
fix(sync): survive a locked WAL checkpoint, report stalled downloads

### DIFF
--- a/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
+++ b/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
@@ -464,12 +464,14 @@ describe('snapshot-bootstrap bindings', () => {
       attempt: 1,
       cause: null,
       expected: false,
+      reason: 'unknown',
+      aborted: false,
     });
 
     expect(reportHandledError).toHaveBeenCalledWith(
       expect.objectContaining({ message: expect.stringContaining('kilter:1:5') }),
       expect.objectContaining({
-        tags: { source: 'offline-sync', kind: 'snapshot-bootstrap' },
+        tags: { source: 'offline-sync', kind: 'snapshot-bootstrap', stage: 'download', reason: 'unknown' },
         extra: expect.objectContaining({ scopeKey: 'kilter:1:5', stage: 'download', attempt: 1 }),
       }),
     );
@@ -497,6 +499,8 @@ describe('snapshot-bootstrap bindings', () => {
       attempt: 0,
       cause,
       expected: true,
+      reason: 'network',
+      aborted: false,
     });
 
     const [reported, context] = reportHandledError.mock.calls[0] as [
@@ -505,7 +509,13 @@ describe('snapshot-bootstrap bindings', () => {
     ];
     expect(reported.cause).toBe(cause);
     expect(context.level).toBe('warning');
-    expect(context.tags).toEqual({ source: 'offline-sync', kind: 'snapshot-bootstrap', expected_offline: true });
+    expect(context.tags).toEqual({
+      source: 'offline-sync',
+      kind: 'snapshot-bootstrap',
+      stage: 'manifest',
+      reason: 'network',
+      expected_offline: true,
+    });
     expect(context.extra).toEqual(
       expect.objectContaining({
         scopeKey: 'kilter:1:5',
@@ -847,6 +857,8 @@ describe('snapshot-bootstrap bindings', () => {
       attempt: 2,
       cause: new Error('The request timed out.'),
       expected: true,
+      reason: 'network',
+      aborted: false,
     });
 
     expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineBoardDownloadFailed, {
@@ -854,10 +866,86 @@ describe('snapshot-bootstrap bindings', () => {
       stage: 'download',
       attempt: 2,
       expected: true,
+      reason: 'network',
+      aborted: false,
       errorMessage: 'The request timed out.',
       offlineEngineEnabled: false,
     });
     expect(reportHandledError).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ level: 'warning' }));
+  });
+
+  it('keeps a torn-down download in the funnel and out of Sentry', () => {
+    // A board removal, a sign-out, or a pocketed phone. These used to emit
+    // NOTHING, leaving a Started with no terminal event (issue #4314) — so the
+    // funnel gets them, tagged `aborted: true` for the rate query to exclude.
+    // Sentry does not: there are as many of these as there are lock screens, and
+    // they would bury the artifact and database failures worth reading.
+    startSyncScheduler(
+      db,
+      queryClient,
+      graphqlFetch,
+      () => [],
+      async () => {},
+    );
+    const options = startSyncSchedulerCore.mock.calls[0][6] as SchedulerOptions;
+
+    options.onSnapshotBootstrapError?.({
+      scopeKey: 'kilter:1:5',
+      stage: 'download',
+      attempt: 0,
+      cause: null,
+      expected: true,
+      reason: 'aborted-wipe',
+      aborted: true,
+    });
+
+    expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineBoardDownloadFailed, {
+      scopeKey: 'kilter:1:5',
+      stage: 'download',
+      attempt: 0,
+      expected: true,
+      reason: 'aborted-wipe',
+      aborted: true,
+      errorMessage: 'null',
+      offlineEngineEnabled: false,
+    });
+    expect(reportHandledError).not.toHaveBeenCalled();
+  });
+
+  it('tags a real failure with its stage and reason so Sentry can group on them', () => {
+    // Tags, not extras: Sentry only searches and groups on tags, and chasing
+    // BOARDSESH-D7 through `extra.stage` is what made "which phase is this?"
+    // unanswerable from the issue page.
+    startSyncScheduler(
+      db,
+      queryClient,
+      graphqlFetch,
+      () => [],
+      async () => {},
+    );
+    const options = startSyncSchedulerCore.mock.calls[0][6] as SchedulerOptions;
+
+    options.onSnapshotBootstrapError?.({
+      scopeKey: 'kilter:1:5',
+      stage: 'import',
+      attempt: 1,
+      cause: new Error('Error code 6: database table is locked'),
+      expected: false,
+      reason: 'database-locked',
+      aborted: false,
+    });
+
+    expect(trackMock).toHaveBeenCalledWith(
+      SHARED_EVENTS.OfflineBoardDownloadFailed,
+      expect.objectContaining({ reason: 'database-locked', aborted: false }),
+    );
+    const context = reportHandledError.mock.calls[0][1] as { tags: Record<string, unknown> };
+    expect(context.tags).toEqual({
+      source: 'offline-sync',
+      kind: 'snapshot-bootstrap',
+      stage: 'import',
+      reason: 'database-locked',
+    });
   });
 
   it('carries the payload props on Completed, and omits them when the import ran in an earlier cycle', () => {
@@ -921,6 +1009,8 @@ describe('snapshot-bootstrap bindings', () => {
       attempt: 1,
       cause: null,
       expected: false,
+      reason: 'unknown',
+      aborted: false,
     });
     expect(customBootstrapError).toHaveBeenCalled();
     expect(reportHandledError).not.toHaveBeenCalled();

--- a/packages/mobile/src/offline/offline-sync-adapter.ts
+++ b/packages/mobile/src/offline/offline-sync-adapter.ts
@@ -148,30 +148,52 @@ const reportSnapshotBootstrapError: SnapshotBootstrapErrorReporter = ({
   attempt,
   cause,
   expected,
+  reason,
+  aborted,
 }) => {
   // The funnel's Failed leg (issue #4316). Sentry alone could never answer "what
   // fraction of downloads fail, and at which stage" — it groups by exception
   // shape, not by scope, and expected transport failures are deliberately
   // downgraded there. Same call site, so the two can never disagree about
   // whether a failure happened.
+  //
+  // `aborted` rides along so a failure-RATE query can exclude the teardowns (a
+  // pocketed phone, a board removed elsewhere in the app) that are now reported
+  // here for funnel completeness rather than because anything broke.
   track(SHARED_EVENTS.OfflineBoardDownloadFailed, {
     scopeKey,
     stage,
     attempt,
     expected,
+    reason,
+    aborted,
     errorMessage: cause instanceof Error ? cause.message : String(cause),
     offlineEngineEnabled: isOfflineEngineEnabled(),
   });
+  // A teardown is not a defect and there are as many of them as there are lock
+  // screens, so it stops at the funnel. Sending them would bury the artifact and
+  // database failures this issue exists to surface.
+  if (aborted) return;
   reportHandledError(
     new Error(`Snapshot bootstrap failed for ${scopeKey} at stage "${stage}" (attempt ${attempt})`, { cause }),
     {
       ...(expected ? { level: 'warning' as const } : {}),
-      tags: { source: 'offline-sync', kind: 'snapshot-bootstrap', ...(expected ? { expected_offline: true } : {}) },
+      // `stage` and `reason` are TAGS, not just extras: Sentry can only search and
+      // group on tags, and chasing BOARDSESH-D7 through `extra.stage` is exactly
+      // what made "which phase is this?" unanswerable from the issue page.
+      tags: {
+        source: 'offline-sync',
+        kind: 'snapshot-bootstrap',
+        stage,
+        reason,
+        ...(expected ? { expected_offline: true } : {}),
+      },
       extra: {
         scopeKey,
         stage,
         attempt,
         expected,
+        reason,
         cause: cause instanceof Error ? cause.message : cause,
         causeName: cause instanceof Error ? cause.name : null,
       },

--- a/packages/mobile/src/offline/remove-offline-board.ts
+++ b/packages/mobile/src/offline/remove-offline-board.ts
@@ -121,7 +121,15 @@ export async function compactOfflineDatabase(db: OfflineDatabase): Promise<boole
     // (the data is gone, the number may not have moved), so it's reported the same way.
     const truncated = await vacuumDatabase(db);
     if (!truncated) {
+      // A warning, not an error: the VACUUM landed and the rows are gone — a
+      // reader simply held the WAL open, which on a connection the whole app
+      // shares is routine and self-corrects at the next checkpoint. It used to
+      // arrive as an `error`-level SQLITE_LOCKED exception from inside
+      // vacuumDatabase instead (Sentry BOARDSESH-D7), which read as a broken
+      // database when nothing was broken. Still reported: a PERSISTENT failure
+      // means users cannot actually reclaim space.
       reportHandledError(new Error('wal_checkpoint(TRUNCATE) was busy after VACUUM; -wal not truncated'), {
+        level: 'warning',
         tags: { source: 'offline-sync', kind: 'vacuum' },
       });
     }

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -357,11 +357,26 @@ export const SHARED_EVENTS = {
   // funnel ratio are unaffected. Mobile-only today (the engine is shared, so a
   // future web offline consumer would fire this too).
   OfflineBoardDownloadCompleted: 'Offline Board Download Completed',
-  // A bootstrap stage failed. Props: { scopeKey, stage: 'manifest' | 'download'
-  // | 'import', attempt, expected, errorMessage, offlineEngineEnabled }.
+  // A bootstrap stage failed, or was cut short. Props: { scopeKey, stage:
+  // 'manifest' | 'download' | 'import' | 'grades-download' | 'grades-import',
+  // attempt, expected, reason, aborted, errorMessage, offlineEngineEnabled }.
   // `expected: true` is a transport/reachability failure — a phone in a tunnel,
   // not a defect — and is the normal case, not an alarm. These previously went
   // only to Sentry, where they could not be joined to the funnel.
+  //
+  // READ `aborted` BEFORE COMPUTING A FAILURE RATE (issue #4314). `aborted: true`
+  // means the cycle was TORN DOWN — the app backgrounded, or a sign-out/board
+  // removal bumped the wipe epoch — not that anything broke; the same scope
+  // resumes next cycle and can still emit Completed. Those teardowns are reported
+  // so every Started has a terminal event (they used to emit nothing at all,
+  // which made an interrupted 100 MB download structurally invisible), and they
+  // are deliberately kept out of Sentry. A failure rate is
+  // `Failed where aborted = false` over Started.
+  //
+  // `reason` is a closed, low-cardinality bucket — 'aborted-wipe' |
+  // 'aborted-background' | 'database-locked' | 'schema-stale' |
+  // 'watermark-regression' | 'permanent-miss' | 'artifact-invalid' | 'network' |
+  // 'unknown' — for grouping. The verbatim text stays on `errorMessage`.
   OfflineBoardDownloadFailed: 'Offline Board Download Failed',
   // The climber turned a board OFF while its first download was still in flight
   // — the abandonment the funnel exists to size, caught at the moment it

--- a/packages/shared/offline-sync/src/db/__tests__/vacuum.test.ts
+++ b/packages/shared/offline-sync/src/db/__tests__/vacuum.test.ts
@@ -7,6 +7,8 @@ import { mkdtempSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { vacuumDatabase, measureReclaimableBytes } from '../vacuum';
+import { classifySqliteLockError } from '../lock-errors';
+import type { OfflineDatabase } from '../../database';
 import { runMigrations } from '../migrations';
 import { ensureMutationQueueTable } from '../../mutation-queue/schema';
 import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
@@ -80,3 +82,94 @@ describe('vacuumDatabase', () => {
     ).rejects.toThrow();
   });
 });
+
+// --- Contended WAL truncation (Sentry BOARDSESH-D7) ------------------------------
+//
+// The offline database is ONE connection shared by the sync engine and every
+// `useSQLiteContext()` screen, so a compaction routinely runs while another
+// statement on that same handle is mid-flight. SQLite refuses the truncation
+// outright in that case — `sqlite3BtreeCheckpoint()` returns SQLITE_LOCKED when the
+// connection's b-tree already has an open transaction — and it arrives as a THROW,
+// not as the `busy = 1` row the original implementation was written against.
+describe('vacuumDatabase under lock contention', () => {
+  // The regression pin, against REAL SQLite rather than a hand-written message: if a
+  // future SQLite or driver stops reporting this as a lock, the shared classifier
+  // stops recognising it and the throw escapes to the user again.
+  it('is what SQLite really does when the same connection holds a read transaction', async () => {
+    await insertClimbs(20);
+
+    await db.execAsync('BEGIN');
+    await db.getFirstAsync('SELECT COUNT(*) AS n FROM board_climbs');
+    let thrown: unknown = null;
+    try {
+      await db.getFirstAsync('PRAGMA wal_checkpoint(TRUNCATE)');
+    } catch (error) {
+      thrown = error;
+    }
+    await db.execAsync('ROLLBACK');
+
+    expect(thrown, 'a checkpoint under an open read transaction must fail').not.toBeNull();
+    expect((thrown as Error).message).toContain('database table is locked');
+    // Code 6 (SQLITE_LOCKED), not 5 (SQLITE_BUSY): a conflict INSIDE one connection,
+    // which no busy_timeout can wait out. node:sqlite exposes it as a field and
+    // leaves the message bare; expo-sqlite prints it into the message instead
+    // ("Error code 6: database table is locked"), which is the shape the classifier
+    // test covers. Both must read as contention.
+    expect((thrown as { errcode?: number }).errcode).toBe(6);
+    expect(classifySqliteLockError(thrown).locked).toBe(true);
+  });
+
+  it('resolves false instead of throwing when the truncation stays locked', async () => {
+    const locked = lockedCheckpointDatabase({ failures: Number.POSITIVE_INFINITY });
+
+    await expect(vacuumDatabase(locked.db, { checkpointAttempts: 2, sleep: locked.sleep })).resolves.toBe(false);
+    expect(locked.checkpointCalls(), 'every attempt should have been spent').toBe(2);
+  });
+
+  // The retry is the whole reason the user's storage figure moves: the blocker is a
+  // list row or a search query that finishes in milliseconds.
+  it('retries and succeeds once the reader lets go', async () => {
+    const locked = lockedCheckpointDatabase({ failures: 1 });
+
+    await expect(vacuumDatabase(locked.db, { checkpointAttempts: 3, sleep: locked.sleep })).resolves.toBe(true);
+    expect(locked.checkpointCalls()).toBe(2);
+  });
+
+  // A broken database must never be laundered into "the file just didn't shrink".
+  it('still throws when the failure is not lock contention', async () => {
+    const broken = lockedCheckpointDatabase({
+      failures: Number.POSITIVE_INFINITY,
+      error: new Error('Error code 11: database disk image is malformed'),
+    });
+
+    await expect(vacuumDatabase(broken.db, { checkpointAttempts: 3, sleep: broken.sleep })).rejects.toThrow(
+      'malformed',
+    );
+  });
+});
+
+/**
+ * A database double whose VACUUM always succeeds and whose `wal_checkpoint` fails
+ * the first `failures` times. Only the checkpoint behaviour is under test, and a
+ * real file cannot be made to hold a contending cursor and run a VACUUM in the same
+ * call — the test above pins the error SHAPE against real SQLite, this one pins what
+ * the retry loop does with it.
+ */
+function lockedCheckpointDatabase(config: { failures: number; error?: Error }): {
+  db: OfflineDatabase;
+  sleep: (ms: number) => Promise<void>;
+  checkpointCalls: () => number;
+} {
+  const failure = config.error ?? new Error('Error code 6: database table is locked');
+  let checkpointCalls = 0;
+  const db = {
+    execAsync: async (): Promise<void> => {},
+    getFirstAsync: async <Row>(source: string): Promise<Row | null> => {
+      if (!source.includes('wal_checkpoint')) return null;
+      checkpointCalls += 1;
+      if (checkpointCalls <= config.failures) throw failure;
+      return { busy: 0 } as Row;
+    },
+  } as unknown as OfflineDatabase;
+  return { db, sleep: async (): Promise<void> => {}, checkpointCalls: () => checkpointCalls };
+}

--- a/packages/shared/offline-sync/src/db/vacuum.ts
+++ b/packages/shared/offline-sync/src/db/vacuum.ts
@@ -22,6 +22,71 @@
 // forever, and INCREMENTAL still needs an explicit `PRAGMA incremental_vacuum(N)`.
 
 import type { OfflineDatabase } from '../database';
+import { classifySqliteLockError } from './lock-errors';
+
+/**
+ * Tries at the post-VACUUM WAL truncation before settling for "the file may not
+ * have shrunk". The blocker is a live reader that finishes in milliseconds — a
+ * board row re-reading `downloadedScopeKeys`, a search query, the sync engine's
+ * own next statement — so a couple of short waits usually turn a `false` into a
+ * `true` and the user's storage figure actually moves.
+ */
+const CHECKPOINT_ATTEMPTS = 3;
+
+/** Base gap between truncation tries; multiplied by the attempt number. */
+const CHECKPOINT_RETRY_DELAY_MS = 120;
+
+const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Test seams for the truncation retry loop; every field is optional. */
+export type VacuumOptions = {
+  /** How many times to try `wal_checkpoint(TRUNCATE)`. Default CHECKPOINT_ATTEMPTS. */
+  checkpointAttempts?: number;
+  /** Injected sleep so a test does not pay the real backoff. */
+  sleep?: (ms: number) => Promise<void>;
+};
+
+/**
+ * Hand the WAL back to the filesystem after a VACUUM, reporting whether it
+ * actually happened.
+ *
+ * SQLite says "I could not truncate" in TWO different shapes, and only one of
+ * them used to be handled:
+ *
+ *  - `busy = 1` in the returned row — ANOTHER connection held a read lock.
+ *  - a THROW carrying SQLITE_LOCKED (6) / SQLITE_BUSY (5) — most often because
+ *    THIS connection has an open transaction. `sqlite3BtreeCheckpoint()` returns
+ *    SQLITE_LOCKED outright when `pBt->inTransaction != TRANS_NONE`, and on the
+ *    app's main connection that is true for as long as any other statement is in
+ *    flight on the same handle. The offline database has exactly that shape: the
+ *    engine, every `useSQLiteContext()` screen, and this call all share one
+ *    connection, so removing a board while My Boards re-reads its rows raced
+ *    straight into it (Sentry BOARDSESH-D7, "Error code 6: database table is
+ *    locked", reported against `finalizeAsync` because expo-sqlite's
+ *    `getFirstAsync` re-throws the same code from its `finally`).
+ *
+ * Both mean the same thing to the user — the rows are gone, the file may not
+ * have shrunk — so both now resolve `false` instead of one of them escaping as
+ * an exception. Anything that is NOT lock contention still throws: a genuinely
+ * broken database must not be reported as a cosmetic miss.
+ */
+async function truncateWal(db: OfflineDatabase, options: VacuumOptions | undefined): Promise<boolean> {
+  const attempts = Math.max(1, options?.checkpointAttempts ?? CHECKPOINT_ATTEMPTS);
+  const sleep = options?.sleep ?? wait;
+
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      // The pragma returns (busy, log, checkpointed). A non-WAL database returns
+      // no row at all; nothing was blocked, so that is a success.
+      const checkpoint = await db.getFirstAsync<{ busy: number }>('PRAGMA wal_checkpoint(TRUNCATE)');
+      if ((checkpoint?.busy ?? 0) === 0) return true;
+    } catch (error) {
+      if (!classifySqliteLockError(error).locked) throw error;
+    }
+    if (attempt >= attempts) return false;
+    await sleep(CHECKPOINT_RETRY_DELAY_MS * attempt);
+  }
+}
 
 /**
  * Bytes SQLite would hand back to the filesystem if `vacuumDatabase` ran now — the
@@ -57,19 +122,15 @@ export async function measureReclaimableBytes(db: OfflineDatabase): Promise<numb
  * (SQLITE_FULL, SQLITE_BUSY, app killed) still leaves a valid database with the rows
  * deleted and the space merely still on the freelist.
  */
-export async function vacuumDatabase(db: OfflineDatabase): Promise<boolean> {
+export async function vacuumDatabase(db: OfflineDatabase, options?: VacuumOptions): Promise<boolean> {
   await db.execAsync('VACUUM');
   // In WAL mode VACUUM writes the whole rebuilt database through the WAL, leaving a
   // -wal file at roughly the database's size — which would eat the reclaimed bytes
   // straight back, since the user's storage figure counts the sidecars. TRUNCATE (not
   // PASSIVE/FULL) is the checkpoint mode that actually shrinks the -wal file.
   //
-  // The pragma returns (busy, log, checkpointed) and does NOT throw when it can't
-  // finish: `busy = 1` means a reader held it off, the -wal stayed large, and the
-  // user's storage figure won't have improved despite a clean VACUUM. Silent, so
-  // report it rather than claiming success. Not fatal either way — the rows are gone
-  // and the next checkpoint truncates.
-  const checkpoint = await db.getFirstAsync<{ busy: number }>('PRAGMA wal_checkpoint(TRUNCATE)');
-  // A non-WAL database returns no row; nothing was blocked, so that's a success.
-  return (checkpoint?.busy ?? 0) === 0;
+  // Blocked truncation is reported, never thrown — the rows are gone either way and
+  // the next checkpoint truncates. See truncateWal for the two shapes SQLite uses to
+  // say "blocked" and why only reporting one of them was a bug.
+  return truncateWal(db, options);
 }

--- a/packages/shared/offline-sync/src/db/vacuum.ts
+++ b/packages/shared/offline-sync/src/db/vacuum.ts
@@ -100,8 +100,10 @@ export async function measureReclaimableBytes(db: OfflineDatabase): Promise<numb
 
 /**
  * Rebuild the database file, returning freelist pages to the filesystem. Resolves
- * false when the rebuild landed but the WAL truncation was blocked (see below) — the
- * data is still gone, the file just may not have shrunk as far as it should.
+ * false when the rebuild landed but the WAL truncation was blocked (see
+ * `truncateWal`) — the data is still gone, the file just may not have shrunk as far
+ * as it should. It never throws for lock contention; only a genuinely broken
+ * database escapes.
  *
  * MUST NOT run inside a transaction — SQLite rejects it outright, and note that
  * `withExclusiveTransactionAsync` opens a deferred BEGIN before its task body runs,

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -117,9 +117,12 @@ export type {
   SnapshotDownloadOptions,
   SnapshotDownloadProgress,
   SnapshotBootstrapResult,
+  SnapshotBootstrapErrorReport,
   SnapshotBootstrapErrorReporter,
   BootstrapScopeMetadata,
 } from './sync/snapshot-bootstrap';
+export { classifySnapshotBootstrapFailure } from './sync/bootstrap-failure-reason';
+export type { SnapshotBootstrapFailureReason } from './sync/bootstrap-failure-reason';
 
 // --- Bootstrap retry budgets + cooldowns (issue #4313) ---------------------------
 // The failure taxonomy that decides whether a snapshot failure is worth another

--- a/packages/shared/offline-sync/src/sync/__tests__/bootstrap-failure-reason.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/bootstrap-failure-reason.test.ts
@@ -1,0 +1,77 @@
+// The download funnel's "why", pinned bucket by bucket.
+//
+// Every case here is a shape the bootstrap phase really produces, so a rename of an
+// error class or a reworded message shows up as a failing test rather than as a
+// silent slide of live traffic into `unknown`.
+
+import { describe, it, expect } from 'vitest';
+import { classifySnapshotBootstrapFailure } from '../bootstrap-failure-reason';
+import {
+  SnapshotWipedError,
+  SnapshotSchemaStaleError,
+  SnapshotPermanentMissError,
+  SnapshotWatermarkRegressionError,
+} from '../snapshot-bootstrap';
+
+describe('classifySnapshotBootstrapFailure', () => {
+  it('names the engine error classes', () => {
+    expect(classifySnapshotBootstrapFailure(new SnapshotWipedError())).toBe('aborted-wipe');
+    expect(classifySnapshotBootstrapFailure(new SnapshotSchemaStaleError(3))).toBe('schema-stale');
+    expect(classifySnapshotBootstrapFailure(new SnapshotPermanentMissError('still gzipped'))).toBe('permanent-miss');
+    expect(
+      classifySnapshotBootstrapFailure(
+        new SnapshotWatermarkRegressionError(
+          'board_climbs',
+          { updatedAt: '2026-01-01T00:00:00.000Z', syncSeq: '1' },
+          { updatedAt: '2026-06-01T00:00:00.000Z', syncSeq: '9' },
+        ),
+      ),
+    ).toBe('watermark-regression');
+  });
+
+  // The bucket this issue exists to make visible. Both codes count: 5 is another
+  // connection, 6 is this one, and a climber cannot tell them apart.
+  it('buckets SQLite lock contention, including the code-6 shape from BOARDSESH-D7', () => {
+    expect(
+      classifySnapshotBootstrapFailure(
+        new Error(
+          "Calling the 'finalizeAsync' function has failed → Caused by: SQLiteErrorException: Error code 6: database table is locked",
+        ),
+      ),
+    ).toBe('database-locked');
+    expect(classifySnapshotBootstrapFailure(new Error('Error code 5: database is locked'))).toBe('database-locked');
+  });
+
+  // Walks the cause chain, because expo-sqlite wraps the driver error.
+  it('finds a lock through a wrapped cause', () => {
+    const wrapped = new Error("Calling the 'runAsync' function has failed", {
+      cause: new Error('Error code 6: database table is locked'),
+    });
+
+    expect(classifySnapshotBootstrapFailure(wrapped)).toBe('database-locked');
+  });
+
+  it('buckets the artifact-verification failures', () => {
+    const cases = [
+      'snapshot bootstrap: quick_check failed: page 3 is never used',
+      'snapshot bootstrap: snapshot_meta missing row for board_climb_stats',
+      'snapshot bootstrap: format_version 2 != 3 for board_climbs',
+      'snapshot bootstrap: board_climbs row_count 900 != actual 12 (truncated artifact?)',
+      'snapshot bootstrap: no shared board_climbs columns',
+    ];
+
+    for (const message of cases) {
+      expect(classifySnapshotBootstrapFailure(new Error(message)), message).toBe('artifact-invalid');
+    }
+  });
+
+  it('buckets a dropped connection as network', () => {
+    expect(classifySnapshotBootstrapFailure(new TypeError('Network request failed'))).toBe('network');
+  });
+
+  it('falls back to unknown rather than guessing', () => {
+    expect(classifySnapshotBootstrapFailure(new Error('something else entirely'))).toBe('unknown');
+    expect(classifySnapshotBootstrapFailure(null)).toBe('unknown');
+    expect(classifySnapshotBootstrapFailure(undefined)).toBe('unknown');
+  });
+});

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -3861,3 +3861,225 @@ describe('pullSync grades bootstrap', () => {
     expect(gradesDownloads).toEqual([]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Teardown reporting (issue #4314)
+//
+// Every one of these used to `break` in SILENCE: `Offline Board Download
+// Started` fired, the cycle was torn down by a sign-out / a `beginLocalPurge`
+// from removing any board / the app backgrounding, and no terminal event ever
+// followed. The funnel could not tell an abandoned 100 MB transfer from a
+// download that is still running. They report through the same
+// `onSnapshotBootstrapError` seam now, marked `aborted: true` so a failure RATE
+// can exclude them — nothing broke, and no retry budget was spent.
+// ---------------------------------------------------------------------------
+
+describe('pullSync bootstrap teardown reporting', () => {
+  /** A valid artifact, so only the teardown under test can end the phase. */
+  function buildScopeArtifact(filePath: string): void {
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+  }
+
+  it('reports a board removal that lands while the artifact is downloading', async () => {
+    const filePath = join(workDir, 'purged-mid-download.db');
+    buildScopeArtifact(filePath);
+    const source: SnapshotSource = {
+      fetchManifest: async () => makeManifest([makeEntry()]),
+      downloadArtifact: async () => {
+        // Removing ANY board bumps the wipe epoch — the field report behind
+        // #4314, where a Kilter transfer died to a Tension removal.
+        beginLocalPurge();
+        return { filePath };
+      },
+      deleteArtifact: vi.fn(async () => {}),
+    };
+    const onSnapshotBootstrapError = vi.fn();
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onSnapshotBootstrapError,
+    });
+
+    expect(onSnapshotBootstrapError).toHaveBeenCalledTimes(1);
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopeKey: 'kilter:1:5',
+        stage: 'download',
+        attempt: 0,
+        aborted: true,
+        reason: 'aborted-wipe',
+        expected: true,
+      }),
+    );
+    // Torn down, not failed: no rows, no budget spent, so the same scope simply
+    // runs again on the next cycle.
+    expect(await countRows('board_climbs')).toBe(0);
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
+  });
+
+  it('reports the app backgrounding during the artifact download as its own reason', async () => {
+    const filePath = join(workDir, 'backgrounded-mid-download.db');
+    buildScopeArtifact(filePath);
+    const source: SnapshotSource = {
+      fetchManifest: async () => makeManifest([makeEntry()]),
+      downloadArtifact: async () => {
+        setBackgrounded(true);
+        return { filePath };
+      },
+      deleteArtifact: vi.fn(async () => {}),
+    };
+    const onSnapshotBootstrapError = vi.fn();
+    const { fetch } = makeGraphqlFetch();
+
+    try {
+      await pullSync(db, noopQueryClient(), fetch, {
+        enabledBoards: ['kilter:1:5'],
+        snapshotSource: source,
+        onSnapshotBootstrapError,
+      });
+    } finally {
+      setBackgrounded(false);
+    }
+
+    expect(onSnapshotBootstrapError).toHaveBeenCalledTimes(1);
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(
+      expect.objectContaining({ stage: 'download', aborted: true, reason: 'aborted-background' }),
+    );
+    expect(await countRows('board_climbs')).toBe(0);
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
+  });
+
+  it('closes the tightest window of all: a teardown between Started and the transfer', async () => {
+    const filePath = join(workDir, 'purged-at-start.db');
+    buildScopeArtifact(filePath);
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const onSnapshotBootstrapError = vi.fn();
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      // Fired on the line directly above the bail, so this is a teardown landing
+      // in the gap between Started and the first byte.
+      onScopeDownloadStart: () => beginLocalPurge(),
+      onSnapshotBootstrapError,
+    });
+
+    expect(source.downloadArtifact).not.toHaveBeenCalled();
+    expect(onSnapshotBootstrapError).toHaveBeenCalledTimes(1);
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(
+      expect.objectContaining({ stage: 'download', attempt: 0, aborted: true, reason: 'aborted-wipe' }),
+    );
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
+  });
+
+  it('reports a SnapshotWipedError from the import as an abort, not a failure', async () => {
+    const filePath = join(workDir, 'wiped-mid-import.db');
+    buildScopeArtifact(filePath);
+    // Bump the epoch the moment the stats INSERT runs — inside the exclusive
+    // transaction, after bootstrapScopeFromSnapshot captured its start epoch, so
+    // the post-import guard raises SnapshotWipedError and rolls everything back.
+    // Prototype spy: the import runs on the transaction's own adapter instance.
+    const adapterPrototype = Object.getPrototypeOf(db) as { runAsync: typeof db.runAsync };
+    const realRunAsync = adapterPrototype.runAsync;
+    let purged = false;
+    vi.spyOn(adapterPrototype, 'runAsync').mockImplementation(async function (
+      this: unknown,
+      source: string,
+      ...rest: unknown[]
+    ) {
+      if (!purged && source.includes('INSERT OR REPLACE INTO main.board_climb_stats')) {
+        purged = true;
+        beginLocalPurge();
+      }
+      return realRunAsync.call(this, source, ...(rest as never[]));
+    } as typeof db.runAsync);
+
+    const snapshotSource = makeSnapshotSource({
+      manifest: makeManifest([makeEntry()]),
+      fileForEntry: () => filePath,
+    });
+    const onSnapshotBootstrapError = vi.fn();
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource,
+      onSnapshotBootstrapError,
+    });
+
+    expect(onSnapshotBootstrapError).toHaveBeenCalledTimes(1);
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopeKey: 'kilter:1:5',
+        stage: 'import',
+        attempt: 0,
+        aborted: true,
+        reason: 'aborted-wipe',
+        expected: true,
+      }),
+    );
+    // The transaction rolled back and the budget is untouched.
+    expect(await countRows('board_climbs')).toBe(0);
+    expect(await getCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5')).toBeNull();
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
+  });
+
+  it('still charges a GENUINE import failure, reported as a non-abort with a real reason', async () => {
+    // The behaviour the abort reporting must not have changed: a freshly
+    // downloaded artifact whose meta disagrees with its contents is broken, not
+    // torn down, and it burns a structural attempt exactly as it always did.
+    const filePath = join(workDir, 'truncated-artifact.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+      climbsRowCountOverride: 999, // claims 999 rows, artifact holds 1
+    });
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const onSnapshotBootstrapError = vi.fn();
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onSnapshotBootstrapError,
+    });
+
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopeKey: 'kilter:1:5',
+        stage: 'import',
+        attempt: 1,
+        aborted: false,
+        reason: 'artifact-invalid',
+        expected: false,
+      }),
+    );
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(1);
+  });
+
+  it('says nothing at all about a bootstrap that worked', async () => {
+    const filePath = join(workDir, 'clean-bootstrap.db');
+    buildScopeArtifact(filePath);
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const onSnapshotBootstrapError = vi.fn();
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onSnapshotBootstrapError,
+    });
+
+    expect(onSnapshotBootstrapError).not.toHaveBeenCalled();
+    expect(await countRows('board_climbs')).toBe(1);
+  });
+});

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -39,7 +39,12 @@ import { getCheckpoint, setCheckpoint, markScopeDownloadComplete, DELETIONS_CHEC
 import { removeBoardScopeData } from '../scope-teardown';
 import { runMigrations, LATEST_SCHEMA_VERSION, MIGRATIONS } from '../../db/migrations';
 import { ensureMutationQueueTable } from '../../mutation-queue/schema';
-import { setSigningOut, setBackgrounded, __resetDrainerStateForTests } from '../../mutation-queue/drainer';
+import {
+  setSigningOut,
+  setBackgrounded,
+  beginLocalPurge,
+  __resetDrainerStateForTests,
+} from '../../mutation-queue/drainer';
 import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
 import { SCHEMA_STATEMENTS } from '../../db/schema';
 import type { OfflineBoardScope } from '../../offline-board-key';
@@ -1392,6 +1397,10 @@ describe('pullSync bootstrap: transport failures never spend the structural budg
       attempt: 0,
       cause,
       expected: true,
+      // A real failure, not a teardown — the engine fills both fields in for every
+      // report site (issue #4314).
+      reason: 'network',
+      aborted: false,
     });
     // Nothing was persisted, so there is no settled decision to re-read.
     expect(onBootstrapMetadataChanged).not.toHaveBeenCalled();

--- a/packages/shared/offline-sync/src/sync/bootstrap-failure-reason.ts
+++ b/packages/shared/offline-sync/src/sync/bootstrap-failure-reason.ts
@@ -1,0 +1,74 @@
+// One low-cardinality answer to "why did this board's fast download not finish?".
+//
+// The download funnel (issue #4316) could say THAT a scope failed and at which
+// stage, but not why — so a board that never finished looked identical whether the
+// artifact was corrupt, the phone went in a pocket, or SQLite refused the write.
+// Diagnosing Sentry BOARDSESH-D7 took an hour of cross-referencing PostHog against
+// Sentry for exactly that reason, and the answer ("a lock, on a path nobody
+// suspected") was a single string the funnel could have carried all along.
+//
+// Deliberately a CLOSED union of coarse buckets, not a message passthrough: this
+// rides on an analytics property, and error messages carry file paths, row counts
+// and byte offsets — unbounded cardinality that would make the funnel unqueryable.
+// The verbatim message still travels on the same event's `errorMessage`.
+//
+// Matched on `error.name` rather than `instanceof`, so this module stays free of a
+// dependency on snapshot-bootstrap.ts (which imports the reporter type from here).
+// The names are set explicitly in each class's constructor and are equally reliable
+// across a `.cause` chain the platform rebuilt.
+
+import { isNetworkError } from '../mutation-queue/error-classification';
+import { classifySqliteLockError } from '../db/lock-errors';
+
+export type SnapshotBootstrapFailureReason =
+  /** A sign-out, or a local purge (removing ANY board), tore the cycle down. */
+  | 'aborted-wipe'
+  /** The app went to the background mid-cycle. Resumes on the next foreground. */
+  | 'aborted-background'
+  /** SQLITE_BUSY / SQLITE_LOCKED — contention, not a broken database. */
+  | 'database-locked'
+  /** The artifact predates this client's schema; tonight's export rebuilds it. */
+  | 'schema-stale'
+  /** The artifact's scoped watermark sits behind what this scope already crawled. */
+  | 'watermark-regression'
+  /** The source declared the artifact unusable on this device. */
+  | 'permanent-miss'
+  /** `quick_check` failed, `snapshot_meta` was missing/mismatched, or the row count did not add up. */
+  | 'artifact-invalid'
+  /** Offline, or the connection dropped. The normal state of a phone on a plane. */
+  | 'network'
+  /** Nothing above matched — the bucket that should stay near zero. */
+  | 'unknown';
+
+/** Substrings of the errors `verifySnapshotMeta` and the integrity check raise. */
+const ARTIFACT_INVALID_MARKERS = [
+  'quick_check failed',
+  'snapshot_meta missing row',
+  'format_version',
+  'truncated artifact',
+  'no shared',
+];
+
+/**
+ * Bucket a bootstrap failure's cause.
+ *
+ * Order matters. The named error classes are checked first because they are exact;
+ * the lock test comes before the message tests because a lock failure surfacing
+ * through `finalizeAsync` carries no shape of its own; `network` comes last of the
+ * positive tests because its matcher is the broadest.
+ */
+export function classifySnapshotBootstrapFailure(cause: unknown): SnapshotBootstrapFailureReason {
+  const name = cause instanceof Error ? cause.name : null;
+  if (name === 'SnapshotWipedError') return 'aborted-wipe';
+  if (name === 'SnapshotSchemaStaleError') return 'schema-stale';
+  if (name === 'SnapshotWatermarkRegressionError') return 'watermark-regression';
+  if (name === 'SnapshotPermanentMissError') return 'permanent-miss';
+
+  if (classifySqliteLockError(cause).locked) return 'database-locked';
+
+  const message = cause instanceof Error ? cause.message : typeof cause === 'string' ? cause : '';
+  if (ARTIFACT_INVALID_MARKERS.some((marker) => message.includes(marker))) return 'artifact-invalid';
+
+  if (isNetworkError(cause)) return 'network';
+  return 'unknown';
+}

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -31,8 +31,18 @@ import {
   SnapshotPermanentMissError,
   type SnapshotSource,
   type SnapshotArtifactHandle,
+  type SnapshotBootstrapErrorReport,
   type SnapshotBootstrapErrorReporter,
 } from './snapshot-bootstrap';
+import { classifySnapshotBootstrapFailure, type SnapshotBootstrapFailureReason } from './bootstrap-failure-reason';
+
+/**
+ * What a report site inside the phase supplies. `reason` and `aborted` are filled
+ * in by the wrapper in `runBootstrapPhase`, so an arm that has nothing special to
+ * say about either simply leaves them out.
+ */
+type BootstrapErrorInput = Omit<SnapshotBootstrapErrorReport, 'reason' | 'aborted'> &
+  Partial<Pick<SnapshotBootstrapErrorReport, 'reason' | 'aborted'>>;
 import {
   classifyBootstrapFailure,
   clearBootstrapPagedFallback,
@@ -950,7 +960,43 @@ async function runBootstrapPhase(params: {
   } = params;
   const onProgress = options?.onProgress;
   const onSchemaDrift = options?.onSchemaDrift;
-  const onSnapshotBootstrapError = options?.onSnapshotBootstrapError;
+  // Wrapped ONCE here rather than at each of the eight report sites: every one of
+  // them already builds a payload with the cause in hand, so deriving `reason` and
+  // defaulting `aborted` centrally keeps them untouched and makes it impossible for
+  // a future arm to forget either field (issue #4314).
+  const rawSnapshotBootstrapError = options?.onSnapshotBootstrapError;
+  const onSnapshotBootstrapError = rawSnapshotBootstrapError
+    ? (report: BootstrapErrorInput): void =>
+        rawSnapshotBootstrapError({
+          ...report,
+          reason: report.reason ?? classifySnapshotBootstrapFailure(report.cause),
+          aborted: report.aborted ?? false,
+        })
+    : undefined;
+
+  /**
+   * Why the phase is being torn down, or null when it is not. Read at each of the
+   * bail-out points below, which used to `break`/`return` in silence — the reason
+   * `Offline Board Download Started` could be followed by nothing at all.
+   */
+  const teardownReason = (): SnapshotBootstrapFailureReason | null => {
+    if (isSigningOut() || getWipeEpoch() !== cycleEpoch) return 'aborted-wipe';
+    if (isBackgrounded()) return 'aborted-background';
+    return null;
+  };
+
+  /** Close the funnel for a scope whose work this cycle was cut short. */
+  const reportBootstrapAbort = (
+    scopeKey: string,
+    stage: BootstrapErrorInput['stage'],
+    reason: SnapshotBootstrapFailureReason,
+    cause: unknown,
+  ): void => {
+    // `expected: true` keeps the severity story consistent with transport
+    // failures; `aborted: true` is what a failure-rate query filters on.
+    onSnapshotBootstrapError?.({ scopeKey, stage, attempt: 0, cause, expected: true, aborted: true, reason });
+  };
+
   const onBootstrapMetadataChanged = options?.onBootstrapMetadataChanged;
   const isOnUnmeteredNetwork = options?.isOnUnmeteredNetwork ?? (() => true);
 
@@ -1356,7 +1402,13 @@ async function runBootstrapPhase(params: {
           pathIntent: 'snapshot',
           artifactBytes: entry.bytes,
         });
-        if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) break;
+        // Started fired on the line above, so a silent bail here is the tightest
+        // possible dangling-Started window. Close it too (issue #4314).
+        const preDownloadTeardown = teardownReason();
+        if (preDownloadTeardown) {
+          reportBootstrapAbort(scope.scopeKey, 'download', preDownloadTeardown, null);
+          break;
+        }
 
         const layoutKey = `${scope.boardType}:${scope.layoutId}`;
         // The failure cause is cached alongside the result so a second size of the
@@ -1444,7 +1496,16 @@ async function runBootstrapPhase(params: {
         cachedDownload.downloadMs = 0;
         // Re-check after the (potentially multi-MB) artifact download await, same
         // reason as the manifest check above.
-        if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) break;
+        //
+        // This is the bail that swallowed the field reports behind issue #4314: a
+        // 100 MB Kilter transfer aborted by a board removal elsewhere in the app
+        // landed here and returned nothing, so the funnel showed a Started with no
+        // terminal event and the climber saw the download silently restart.
+        const downloadTeardown = teardownReason();
+        if (downloadTeardown) {
+          reportBootstrapAbort(scope.scopeKey, 'download', downloadTeardown, cachedDownload.cause);
+          break;
+        }
         const download = cachedDownload.file;
         if (!download) {
           if (cachedDownload.permanentMiss) {
@@ -1569,14 +1630,13 @@ async function runBootstrapPhase(params: {
         } catch (error) {
           phases.importMs += Date.now() - importStartedAt;
           // A wipe mid-import rolls the transaction back and bails the phase — no
-          // burn (the pull is being torn down, not failing).
-          if (
-            error instanceof SnapshotWipedError ||
-            isSigningOut() ||
-            getWipeEpoch() !== cycleEpoch ||
-            isBackgrounded()
-          )
+          // burn (the pull is being torn down, not failing). Reported all the
+          // same, so the scope's Started is not left dangling (issue #4314).
+          const importTeardown = error instanceof SnapshotWipedError ? 'aborted-wipe' : teardownReason();
+          if (importTeardown) {
+            reportBootstrapAbort(scope.scopeKey, 'import', importTeardown, error);
             break;
+          }
           if (error instanceof SnapshotSchemaStaleError) {
             // Permanent miss for this run, no burn: the artifact predates this
             // client's schema and tonight's export rebuilds it at the new one, so

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -994,6 +994,12 @@ async function runBootstrapPhase(params: {
   ): void => {
     // `expected: true` keeps the severity story consistent with transport
     // failures; `aborted: true` is what a failure-rate query filters on.
+    //
+    // `attempt: 0` is the field's established meaning, NOT a placeholder: every
+    // report site spells "nothing was burned" as zero — `reportSettledFailure`
+    // sends `settled.persisted ? burned : 0`, and the schema-stale arm sends a
+    // literal 0 for the same reason. A teardown spends no retry budget, so any
+    // other number here would claim a scope had used up an attempt it still has.
     onSnapshotBootstrapError?.({ scopeKey, stage, attempt: 0, cause, expected: true, aborted: true, reason });
   };
 

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -35,14 +35,6 @@ import {
   type SnapshotBootstrapErrorReporter,
 } from './snapshot-bootstrap';
 import { classifySnapshotBootstrapFailure, type SnapshotBootstrapFailureReason } from './bootstrap-failure-reason';
-
-/**
- * What a report site inside the phase supplies. `reason` and `aborted` are filled
- * in by the wrapper in `runBootstrapPhase`, so an arm that has nothing special to
- * say about either simply leaves them out.
- */
-type BootstrapErrorInput = Omit<SnapshotBootstrapErrorReport, 'reason' | 'aborted'> &
-  Partial<Pick<SnapshotBootstrapErrorReport, 'reason' | 'aborted'>>;
 import {
   classifyBootstrapFailure,
   clearBootstrapPagedFallback,
@@ -88,6 +80,14 @@ import { parseOfflineBoardKey, type OfflineBoardScope } from '../offline-board-k
  * source: 'offline-sync', kind: 'schema-drift'); tests and headless callers omit it.
  */
 export type SchemaDriftReporter = (drift: { tableName: string; column: string }) => void;
+
+/**
+ * What a report site inside the bootstrap phase supplies. `reason` and `aborted`
+ * are filled in by the wrapper in `runBootstrapPhase`, so an arm with nothing
+ * special to say about either simply leaves them out.
+ */
+type BootstrapErrorInput = Omit<SnapshotBootstrapErrorReport, 'reason' | 'aborted'> &
+  Partial<Pick<SnapshotBootstrapErrorReport, 'reason' | 'aborted'>>;
 
 export type SyncProgress = {
   phase: 'bootstrap' | 'user_data' | 'board_data' | 'deletions' | 'idle';

--- a/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
@@ -45,6 +45,7 @@ import {
   type BootstrapRetryState,
 } from './bootstrap-retry';
 import type { SchemaDriftReporter } from './pull-client';
+import type { SnapshotBootstrapFailureReason } from './bootstrap-failure-reason';
 
 /**
  * The two reference tables a WHOLE-LAYOUT snapshot carries; import order is
@@ -195,11 +196,30 @@ export interface SnapshotSource {
 }
 
 /** Where a bootstrap failed, for telemetry. */
-export type SnapshotBootstrapErrorReporter = (report: {
+export type SnapshotBootstrapErrorReport = {
   scopeKey: string;
   stage: 'manifest' | 'download' | 'import' | 'grades-download' | 'grades-import';
   attempt: number;
   cause: unknown;
+  /**
+   * The coarse "why" (issue #4314). Always set — the engine fills it in from the
+   * cause when a call site does not name one — so the funnel's Failed leg can be
+   * grouped by reason instead of by unbounded error text.
+   */
+  reason: SnapshotBootstrapFailureReason;
+  /**
+   * True when the phase BAILED rather than failed: a sign-out, a board removal
+   * (any `beginLocalPurge`), or the app backgrounding. Nothing is broken and no
+   * retry budget was spent — the same scope resumes on the next cycle.
+   *
+   * These used to emit NOTHING at all, which is why a download that stopped was
+   * structurally invisible: `Offline Board Download Started` fired, the cycle was
+   * torn down, and no terminal event ever arrived (issue #4314). They are
+   * reported now so every Started has a terminal event, but they are NOT defects:
+   * a consumer computing a failure RATE must exclude them, and the mobile
+   * reporter deliberately keeps them out of Sentry.
+   */
+  aborted: boolean;
   /**
    * True when the failure is a transport/reachability one — the device was
    * offline or the connection dropped, which is the normal state of a phone on
@@ -215,7 +235,9 @@ export type SnapshotBootstrapErrorReporter = (report: {
    * 272 MB retry loop is worse than the paged crawl).
    */
   expected: boolean;
-}) => void;
+};
+
+export type SnapshotBootstrapErrorReporter = (report: SnapshotBootstrapErrorReport) => void;
 
 export type SnapshotBootstrapResult = {
   climbsWatermark: SyncCheckpoint;


### PR DESCRIPTION
Refs #4314 #4310

## The bug

Sentry [BOARDSESH-D7](https://boardsesh.sentry.io/issues/BOARDSESH-D7): `FunctionCallException: Calling the 'finalizeAsync' function has failed → Caused by: SQLiteErrorException: Error code 6: database table is locked`.

Two users, iOS, `2.3.1+2`. The Sentry tags say `source: offline-sync`, `kind: vacuum` — so despite the shape of the message this is **not** the snapshot-import path. It is `vacuumDatabase()`.

### Root cause

`packages/shared/offline-sync/src/db/vacuum.ts:72` ran `PRAGMA wal_checkpoint(TRUNCATE)` on the app's **main** SQLite connection — the one the sync engine, every `useSQLiteContext()` screen, and this call all share.

SQLite's `sqlite3BtreeCheckpoint()` returns **SQLITE_LOCKED (6)** outright when the *calling* connection already has an open b-tree transaction:

```c
if( pBt->inTransaction!=TRANS_NONE ){
  rc = SQLITE_LOCKED;
}else{
  rc = sqlite3PagerCheckpoint(...);
}
```

On a shared handle that is true for as long as any other statement is in flight. Removing a board runs `removeOfflineBoard` → `compactOfflineDatabase` → `vacuumDatabase` while My Boards is re-reading `downloadedScopeKeys`, and the checkpoint loses the race.

Code 6 is **not** code 5: it is a conflict *inside* one connection, so no `busy_timeout` can wait it out — which is why the #3858 / #4104 / #4324 busy-timeout and retry work never touched it.

Reproduced against real SQLite (now pinned as a test):

```
checkpoint, no open txn:    { busy: 0, log: 0, checkpointed: 0 }
checkpoint w/ open read txn: THREW -> database table is locked | errcode= 6
```

The stack says `finalizeAsync` because expo-sqlite's `getFirstAsync` wraps execution in `try { … } finally { await statement.finalizeAsync(); }`, and `sqlite3_finalize()` re-returns the error code of the statement's last failed evaluation — so the `finally` throws the *same* error and replaces the original. **Every** code-5/code-6 failure on any expo-sqlite prepared-statement call is reported as `finalizeAsync`; the frame names the cleanup, never the statement.

### The fix

`vacuumDatabase` already modelled a blocked truncation as `resolves false` — for the `busy = 1` row. SQLite says "blocked" in two shapes and only one was handled. The thrown SQLITE_LOCKED/SQLITE_BUSY shape now resolves `false` too, after a short bounded retry (the blocker is a list row that finishes in milliseconds, so a retry usually turns a `false` into a `true` and the storage figure actually moves). Anything that is **not** lock contention still throws — a malformed database must never be laundered into "the file just didn't shrink". The remove-board reporter drops to `warning`: the VACUUM landed, the rows are gone.

## The telemetry gap

PostHog for the affected device: six `Offline Board Download Started`, **zero** Completed, **zero** Failed.

The snapshot bootstrap phase bailed **silently** whenever the cycle was torn down — a sign-out, *any* board removal (`beginLocalPurge()`), or the app backgrounding. Started fired, the cycle was cut, and no terminal event ever arrived, so an interrupted 100 MB download was structurally invisible.

Those three bail-outs now report through the existing `onSnapshotBootstrapError` seam with `aborted: true` and a classified `reason`. They stay **out of Sentry** — a pocketed phone is not a defect — but they close the funnel, so every Started has a terminal event. Consumers computing a failure *rate* filter `aborted = false`; that is documented on the event.

Every failure report also gained `reason`, a closed low-cardinality union (`database-locked`, `artifact-invalid`, `schema-stale`, `watermark-regression`, `network`, …). `stage` and `reason` are now Sentry **tags**, not extras — chasing this issue through `extra.stage` is exactly what made "which phase is this?" unanswerable from the issue page.

## Not in this PR

Removing **any** board calls `beginLocalPurge()`, which bumps a **global** wipe epoch that every scope's cycle checks. Toggling one board off therefore aborts the in-flight download of every *other* board. That is what actually cost the affected device its six downloads — eight boards toggled in 45 seconds, each toggle killing the running 102 MB Kilter transfer. Scoping the purge per-board touches ~15 epoch checks and has real data-integrity implications (an in-flight page must not land after a delete), so it needs its own change. With `reason: 'aborted-wipe'` now on the funnel it is finally measurable.

## Testing

- `vp test run --reporter=agent --project offline-sync`
- `vp run test:mobile`
- `vp run typecheck:mobile`
- `vp run check:mobile-bundle`

New coverage: the real-SQLite error shape (regression pin — if SQLite or the driver stops reporting this as a lock, the classifier stops recognising it and the throw escapes again), the retry/return-false/rethrow logic, every `reason` bucket, the engine's abort reports, and the adapter's track-but-don't-Sentry behaviour.

## Release Notes

Removing a downloaded board could fail to hand its space back while the app was busy reading, and stop with a database error instead of just leaving the file a little larger. It now waits for the app to finish and reclaims the space properly.

Downloads that get interrupted — by locking your phone, or by removing another board mid-download — are now recorded instead of vanishing, so we can see how often a board download stops short and why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT6VP1sWqk6bY9mUgyeS2U
