### PR TITLE
fix(sync): close every silent exit from the snapshot bootstrap phase

### DIFF
--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -573,7 +573,7 @@ Completed` — so abandonment was structurally unmeasurable and failures went on
 | ---------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------- |
 | `Offline Board Download Started`   | first time any cycle starts pulling a scope, once ever | `scopeKey`, `pathIntent`, `artifactBytes`, `trigger`, `offlineEngineEnabled`          |
 | `Offline Board Download Completed` | both board tables reached the tail, once ever          | `scopeKey`, `method`, `durationMs`, `bytes?`, `rowCount?`, `downloadMs?`, `importMs?` |
-| `Offline Board Download Failed`    | a bootstrap stage threw                                | `scopeKey`, `stage`, `attempt`, `expected`, `errorMessage`                            |
+| `Offline Board Download Failed`    | a bootstrap attempt ended without succeeding           | `scopeKey`, `stage`, `attempt`, `expected`, `reason`, `aborted`, `errorMessage`       |
 | `Offline Board Download Cancelled` | the board was switched off mid-download                | `scopeKey`, `source`, `stage?`, `fraction?`, `bytesDone?`                             |
 | `Offline Board Toggled`            | the offline switch was flipped, either way             | `scopeKey`, `enabled`, `source`                                                       |
 | `Offline Download All Tapped`      | the "download all my boards" switch was TAPPED         | `boardCount`                                                                          |
@@ -599,6 +599,42 @@ abandonment spike in exactly the window the baseline is read from.
 
 > **If a future change wipes board data on logout** (issue #3621), it must clear both markers in the
 > same transaction as the rows. Otherwise the next sign-in emits Completed with no Started.
+
+**The terminal-event invariant: every Started has exactly one terminal event.** A snapshot bootstrap
+attempt ends in `Offline Board Download Completed` (its scope finished) or `Offline Board Download
+Failed` (everything else, teardowns included) — never in silence. Field reports kept arriving that
+looked impossible: a Started carrying a 103 MB `artifactBytes`, then nothing at all — no Completed,
+no Failed, no Sentry event — and the cycle moving on to the next board two minutes later.
+
+`runBootstrapPhase` has a dozen ways out (`break`, `continue`, a `throw` from any of the ~15 awaited
+SQLite writes that sit **outside** the import's own `try`, a consumer callback like `onProgress`
+raising back into the loop), and reporting them one site at a time only ever covers the sites
+somebody remembered. So the invariant is structural: the phase arms
+`createDownloadFunnelGuard` (`packages/shared/offline-sync/src/sync/download-funnel-guard.ts`) at the
+Started emission and closes it from a `finally`. An attempt that reaches that `finally` with no
+terminal event recorded emits one:
+
+| Exit                                         | `reason`                          | `aborted` | Sentry |
+| -------------------------------------------- | --------------------------------- | --------- | ------ |
+| sign-out / wipe epoch bump / board removal   | `aborted-wipe`                    | `true`    | no     |
+| app backgrounded                             | `aborted-background`              | `true`    | no     |
+| an exception unwinding the phase             | classified (`database-locked`, …) | `false`   | yes    |
+| anything else — a bail-out nobody registered | `unknown-exit`                    | `false`   | yes    |
+
+Two rules keep it honest. **No double-emit**: every explicit report settles the guard through the
+shared wrapper in `runBootstrapPhase`, and a successful import settles it too — its terminal event is
+the Completed the board-data loop fires once the delta pull reaches every table's tail, which on
+Kilter is usually cycles later. **No burn**: every guard-emitted report carries `attempt: 0`; the
+guard is a bystander and never spends the scope's retry budget.
+
+`unknown-exit` should sit at **zero**. Anything else means an exit path exists that the phase cannot
+explain, and it is the one abort-shaped outcome that still goes to Sentry (`source: offline-sync`,
+`kind: snapshot-bootstrap`, `reason: unknown-exit`) for exactly that reason.
+
+**The invariant is scoped to the snapshot bootstrap.** A paged crawl is multi-cycle by design — an
+interrupted one has not failed, it is simply not finished — so the board-data loop does not report
+per-cycle aborts, and a paged Started legitimately stays open until its Completed lands. Abandonment
+on that path is measured as a Started with no Completed after N days, not as a Failed.
 
 **Reading the props.** `pathIntent` on Started is an INTENT from cheap local facts, not an outcome —
 a snapshot-eligible scope can still fall back to the paged crawl after the manifest resolves. Split

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -331,6 +331,18 @@ export const SHARED_EVENTS = {
   // as a shared cache) and are cleared by scope teardown, so removing and
   // re-adding a board starts a fresh funnel.
   //
+  // THE INVARIANT: every Started has exactly one terminal event — Completed when
+  // the scope finishes, Failed for everything else, teardowns included. It is
+  // enforced structurally rather than site by site: the snapshot bootstrap phase
+  // arms a guard at the Started emission and closes it from a `finally`
+  // (`offline-sync/src/sync/download-funnel-guard.ts`), so an exit nobody
+  // registered — a new `break`, a SQLite lock thrown outside the import's own
+  // catch — still reports, as `reason: 'unknown-exit'`. A Started followed by
+  // silence is therefore a bug in the guard, not a shape to design queries
+  // around. The paged crawl is the one carve-out: it spans cycles by design, so
+  // its Started stays open until Completed and abandonment there is measured as
+  // "no Completed after N days".
+  //
   // Fired the first time any cycle starts pulling a scope. Props: { scopeKey,
   // pathIntent: 'snapshot' | 'paged', artifactBytes: number | null, trigger,
   // offlineEngineEnabled }.
@@ -376,7 +388,15 @@ export const SHARED_EVENTS = {
   // `reason` is a closed, low-cardinality bucket — 'aborted-wipe' |
   // 'aborted-background' | 'database-locked' | 'schema-stale' |
   // 'watermark-regression' | 'permanent-miss' | 'artifact-invalid' | 'network' |
-  // 'unknown' — for grouping. The verbatim text stays on `errorMessage`.
+  // 'unknown' | 'unknown-exit' — for grouping. The verbatim text stays on
+  // `errorMessage`.
+  //
+  // 'unknown-exit' should sit at ZERO: it means the bootstrap phase ended an
+  // attempt in a way it cannot explain — no teardown, no error anyone caught —
+  // and the guard's `finally` closed the funnel on its behalf. Alone among the
+  // abort-shaped outcomes it goes to Sentry, because it says the code has a hole
+  // rather than the phone went in a pocket. `attempt: 0` on any guard-emitted
+  // report: it never spends the scope's retry budget.
   OfflineBoardDownloadFailed: 'Offline Board Download Failed',
   // The climber turned a board OFF while its first download was still in flight
   // — the abandonment the funnel exists to size, caught at the moment it

--- a/packages/shared/offline-sync/src/sync/__tests__/download-funnel-guard.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/download-funnel-guard.test.ts
@@ -1,0 +1,177 @@
+// One test per class of exit from the bootstrap phase, asserting the funnel
+// invariant directly: an armed attempt emits EXACTLY ONE terminal event, and an
+// attempt that already reported emits none (issue #4316).
+//
+// The engine-level counterparts (a real pullSync against real SQLite) live in
+// snapshot-bootstrap.test.ts under "pullSync bootstrap funnel invariant"; these
+// pin the classification and the double-emit rules without a database.
+
+import { describe, expect, it, vi } from 'vitest';
+import { createDownloadFunnelGuard } from '../download-funnel-guard';
+import { SnapshotWipedError } from '../snapshot-bootstrap';
+
+function makeGuard(
+  teardown: () => ReturnType<Parameters<typeof createDownloadFunnelGuard>[0]['teardownReason']> = () => null,
+) {
+  const report = vi.fn();
+  return { report, guard: createDownloadFunnelGuard({ report, teardownReason: teardown }) };
+}
+
+describe('download funnel guard', () => {
+  it('reports an unregistered exit as unknown-exit, at full severity', () => {
+    // The case the guard exists for: a `break` nobody wired to a report. Simulated
+    // by arming and closing with nothing in between, which is exactly what the
+    // phase does when a future branch bails without reporting.
+    const { report, guard } = makeGuard();
+    guard.arm('kilter:1:5', 'download');
+    guard.close();
+
+    expect(report).toHaveBeenCalledTimes(1);
+    expect(report).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopeKey: 'kilter:1:5',
+        stage: 'download',
+        reason: 'unknown-exit',
+        // Not an abort and not expected: this is the one bucket that must reach
+        // Sentry, because it means the phase has a hole in it.
+        aborted: false,
+        expected: false,
+        attempt: 0,
+      }),
+    );
+    // A cause with a message, not null — the funnel's errorMessage names the stage.
+    const [{ cause }] = report.mock.calls[0] as [{ cause: unknown }];
+    expect(cause).toBeInstanceOf(Error);
+    expect((cause as Error).message).toContain('download');
+  });
+
+  it('carries the stage the attempt actually reached', () => {
+    const { report, guard } = makeGuard();
+    guard.arm('kilter:1:5', 'download');
+    guard.enterStage('import');
+    guard.close();
+
+    expect(report).toHaveBeenCalledWith(expect.objectContaining({ stage: 'import', reason: 'unknown-exit' }));
+  });
+
+  it('attributes an unexplained exit during a teardown to the teardown, not to a defect', () => {
+    // A pocketed phone is not a hole in the code. Same shape #4314's hand-written
+    // sites emit, which keeps it out of Sentry.
+    const { report, guard } = makeGuard(() => 'aborted-background');
+    guard.arm('kilter:1:5', 'download');
+    guard.close();
+
+    expect(report).toHaveBeenCalledTimes(1);
+    expect(report).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'aborted-background', aborted: true, expected: true, attempt: 0 }),
+    );
+  });
+
+  it('stays silent when a report site already closed the funnel', () => {
+    // The no-double-emit rule. Every explicit report in the phase settles the
+    // guard through the shared wrapper, so the finally must add nothing.
+    const { report, guard } = makeGuard();
+    guard.arm('kilter:1:5', 'download');
+    guard.settle('kilter:1:5');
+    guard.close();
+
+    expect(report).not.toHaveBeenCalled();
+  });
+
+  it('stays silent when the import succeeded', () => {
+    // A successful import owes the funnel a Completed from the board-data loop,
+    // not a Failed from here — and that Completed can land cycles later.
+    const { report, guard } = makeGuard();
+    guard.arm('kilter:1:5', 'import');
+    guard.settle('kilter:1:5');
+    guard.close();
+
+    expect(report).not.toHaveBeenCalled();
+  });
+
+  it('ignores a settle for a different scope', () => {
+    // The retrofit grades path reports for scopes this attempt never armed.
+    const { report, guard } = makeGuard();
+    guard.arm('kilter:1:5', 'download');
+    guard.settle('tension:2:8');
+    guard.close();
+
+    expect(report).toHaveBeenCalledTimes(1);
+    expect(report).toHaveBeenCalledWith(expect.objectContaining({ scopeKey: 'kilter:1:5', reason: 'unknown-exit' }));
+  });
+
+  it('classifies an exception unwinding the phase and reports it once', () => {
+    // The leading candidate for the silent device: a SQLite lock on one of the
+    // writes that sit outside the import's own catch.
+    const { report, guard } = makeGuard();
+    guard.arm('kilter:1:5', 'download');
+    guard.settleUncaught(new Error('Error code 5: database is locked'));
+    guard.close();
+
+    expect(report).toHaveBeenCalledTimes(1);
+    expect(report).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'database-locked', aborted: false, expected: false, attempt: 0 }),
+    );
+  });
+
+  it('marks a network exception expected so it lands as a warning, not an error', () => {
+    const { report, guard } = makeGuard();
+    guard.arm('kilter:1:5', 'download');
+    guard.settleUncaught(new TypeError('Network request failed'));
+    guard.close();
+
+    expect(report).toHaveBeenCalledTimes(1);
+    expect(report).toHaveBeenCalledWith(expect.objectContaining({ reason: 'network', aborted: false, expected: true }));
+  });
+
+  it('reports an exception thrown during a teardown as an abort', () => {
+    const { report, guard } = makeGuard(() => 'aborted-wipe');
+    guard.arm('kilter:1:5', 'import');
+    guard.settleUncaught(new Error('Error code 5: database is locked'));
+    guard.close();
+
+    expect(report).toHaveBeenCalledTimes(1);
+    expect(report).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'aborted-wipe', aborted: true, expected: true, attempt: 0 }),
+    );
+  });
+
+  it('reports a SnapshotWipedError as an abort even after the flags cleared', () => {
+    // The error IS the proof the cycle was torn down; the live flags may have
+    // moved on by the time it unwinds.
+    const { report, guard } = makeGuard(() => null);
+    guard.arm('kilter:1:5', 'import');
+    guard.settleUncaught(new SnapshotWipedError());
+    guard.close();
+
+    expect(report).toHaveBeenCalledWith(expect.objectContaining({ reason: 'aborted-wipe', aborted: true }));
+  });
+
+  it('says nothing at all for a scope that never reached Started', () => {
+    // Every `continue` above the Started emission — an ineligible scope, a
+    // cooldown, a layout the export does not carry — must stay silent.
+    const { report, guard } = makeGuard();
+    guard.close();
+    guard.settle('kilter:1:5');
+    guard.settleUncaught(new Error('boom'));
+
+    expect(report).not.toHaveBeenCalled();
+  });
+
+  it('does not carry an attempt over to the next scope', () => {
+    const { report, guard } = makeGuard();
+    guard.arm('kilter:1:5', 'download');
+    guard.close();
+    report.mockClear();
+    // Second iteration: this scope never armed, so its close is a no-op.
+    guard.close();
+
+    expect(report).not.toHaveBeenCalled();
+  });
+
+  it('survives a headless caller with no reporter', () => {
+    const guard = createDownloadFunnelGuard({ report: undefined, teardownReason: () => null });
+    guard.arm('kilter:1:5', 'download');
+    expect(() => guard.close()).not.toThrow();
+  });
+});

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -29,6 +29,7 @@ import {
 } from '../snapshot-bootstrap';
 import {
   getBootstrapAttempts,
+  readBootstrapRetryState,
   restoreBootstrapRetryBudget,
   EMPTY_BOOTSTRAP_RETRY_STATE,
   MAX_BOOTSTRAP_ATTEMPTS,
@@ -4079,6 +4080,174 @@ describe('pullSync bootstrap teardown reporting', () => {
       onSnapshotBootstrapError,
     });
 
+    expect(onSnapshotBootstrapError).not.toHaveBeenCalled();
+    expect(await countRows('board_climbs')).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The funnel's terminal-event invariant (issue #4316)
+//
+// EVERY `Offline Board Download Started` gets exactly one terminal event. #4314
+// wired the three teardown bail-outs by hand and a device still went silent —
+// six Starteds carrying a 103 MB artifactBytes, no Completed, no Failed, no
+// Sentry. Per-site reporting only ever covers the sites somebody remembered, so
+// the phase now arms a guard at the Started emission and closes it from a
+// `finally`. These pin the two exit classes that were still silent afterwards,
+// plus the no-double-emit rule. The guard's own exit matrix — including the
+// unregistered `break` that can no longer be written by construction — is
+// covered in download-funnel-guard.test.ts.
+// ---------------------------------------------------------------------------
+
+describe('pullSync bootstrap funnel invariant', () => {
+  function buildScopeArtifact(filePath: string): void {
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+  }
+
+  it('reports an exception thrown outside the import try instead of unwinding in silence', async () => {
+    // Everything between the Started emission and `bootstrapScopeFromSnapshot`
+    // sits outside any catch: the retry-state writes, the paged-fallback markers,
+    // and the two consumer callbacks. A SQLITE_BUSY on any of them used to end
+    // the phase with no terminal event at all. The progress sink stands in for
+    // that whole region here because it is the one seam a test can throw from.
+    const filePath = join(workDir, 'locked-after-download.db');
+    buildScopeArtifact(filePath);
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const onSnapshotBootstrapError = vi.fn();
+    const lockError = new Error("Calling the 'execAsync' function has failed", {
+      cause: new Error('Error code 5: database is locked'),
+    });
+
+    await expect(
+      pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+        enabledBoards: ['kilter:1:5'],
+        snapshotSource: source,
+        onSnapshotBootstrapError,
+        onProgress: (progress) => {
+          if (progress.snapshot?.stage === 'import') throw lockError;
+        },
+      }),
+    ).rejects.toBe(lockError);
+
+    expect(onSnapshotBootstrapError).toHaveBeenCalledTimes(1);
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopeKey: 'kilter:1:5',
+        stage: 'import',
+        // Classified off the real cause, so the Sentry issue lands under
+        // reason:database-locked instead of a blank unknown.
+        reason: 'database-locked',
+        aborted: false,
+        expected: false,
+        // A bystander never spends the scope's retry budget.
+        attempt: 0,
+      }),
+    );
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
+  });
+
+  it('does not burn an attempt when a backgrounded phone returns before the abort is handled', async () => {
+    // The race a review flagged on #4345: the teardown flags are LIVE, so a phone
+    // that woke between our own AbortController firing and the throw being
+    // handled read as "no teardown" — and the download we cancelled ourselves was
+    // settled as a real transport failure, burning an attempt and scheduling a
+    // cooldown. A pocketed phone is not a failure (#4326's taxonomy), so the
+    // reason is now latched at the moment we abort.
+    const filePath = join(workDir, 'backgrounded-then-foregrounded.db');
+    buildScopeArtifact(filePath);
+    const source: SnapshotSource = {
+      fetchManifest: async () => makeManifest([makeEntry()]),
+      downloadArtifact: async (_entry, options) => {
+        // Backgrounding notifies the teardown listeners synchronously, which is
+        // what aborts the transfer.
+        setBackgrounded(true);
+        expect(options?.signal?.aborted).toBe(true);
+        // ...and the climber pulls the phone back out before the rejection is
+        // handled, so every live flag reads clean at the check below.
+        setBackgrounded(false);
+        throw new Error('Aborted');
+      },
+      deleteArtifact: vi.fn(async () => {}),
+    };
+    const onSnapshotBootstrapError = vi.fn();
+    const onBootstrapRetryScheduled = vi.fn();
+
+    try {
+      await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+        enabledBoards: ['kilter:1:5'],
+        snapshotSource: source,
+        onSnapshotBootstrapError,
+        onBootstrapRetryScheduled,
+      });
+    } finally {
+      setBackgrounded(false);
+    }
+
+    expect(onSnapshotBootstrapError).toHaveBeenCalledTimes(1);
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopeKey: 'kilter:1:5',
+        stage: 'download',
+        reason: 'aborted-background',
+        aborted: true,
+        attempt: 0,
+      }),
+    );
+    // Nothing was spent and no cooldown was scheduled: the same scope simply runs
+    // again on the next foreground.
+    expect(onBootstrapRetryScheduled).not.toHaveBeenCalled();
+    expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
+    const { state } = await readBootstrapRetryState(db, 'kilter:1:5', { now: BASE_NOW, random: () => 0 }, false);
+    expect(state.transportFailures).toBe(0);
+    expect(state.structuralFailures).toBe(0);
+  });
+
+  it('emits exactly one terminal event for a download that genuinely failed', async () => {
+    // The no-double-emit rule at the engine level: the settled failure reports,
+    // and the guard's finally must add nothing on top of it.
+    const source = makeSnapshotSource({
+      manifest: makeManifest([makeEntry()]),
+      downloadError: new Error('Network request failed'),
+    });
+    const onSnapshotBootstrapError = vi.fn();
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onSnapshotBootstrapError,
+    });
+
+    expect(onSnapshotBootstrapError).toHaveBeenCalledTimes(1);
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(
+      expect.objectContaining({ stage: 'download', reason: 'network', aborted: false }),
+    );
+  });
+
+  it('adds nothing to a successful import, whose terminal event is the later Completed', async () => {
+    // The one settlement the guard cannot read off a report: a scope that
+    // imported owes the funnel a Completed from the board-data loop — on Kilter
+    // usually cycles later, once the grades crawl finishes — so a Failed here
+    // would be a second terminal event for the same Started.
+    const filePath = join(workDir, 'clean-funnel.db');
+    buildScopeArtifact(filePath);
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const onSnapshotBootstrapError = vi.fn();
+    const onScopeDownloadStart = vi.fn();
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onSnapshotBootstrapError,
+      onScopeDownloadStart,
+    });
+
+    expect(onScopeDownloadStart).toHaveBeenCalledTimes(1);
     expect(onSnapshotBootstrapError).not.toHaveBeenCalled();
     expect(await countRows('board_climbs')).toBe(1);
   });

--- a/packages/shared/offline-sync/src/sync/bootstrap-failure-reason.ts
+++ b/packages/shared/offline-sync/src/sync/bootstrap-failure-reason.ts
@@ -38,7 +38,16 @@ export type SnapshotBootstrapFailureReason =
   /** Offline, or the connection dropped. The normal state of a phone on a plane. */
   | 'network'
   /** Nothing above matched — the bucket that should stay near zero. */
-  | 'unknown';
+  | 'unknown'
+  /**
+   * The bootstrap phase left a scope with no terminal event, and nothing explains
+   * it: no teardown, and no error anyone caught (issue #4316). Never returned by
+   * the classifier below — only `download-funnel-guard.ts` sets it, from its
+   * `finally`, when a `break` / `continue` / `return` nobody registered ends an
+   * attempt. It is the one reason that means "the code has a hole", which is why
+   * it is the one abort-shaped exit that still goes to Sentry.
+   */
+  | 'unknown-exit';
 
 /** Substrings of the errors `verifySnapshotMeta` and the integrity check raise. */
 const ARTIFACT_INVALID_MARKERS = [

--- a/packages/shared/offline-sync/src/sync/download-funnel-guard.ts
+++ b/packages/shared/offline-sync/src/sync/download-funnel-guard.ts
@@ -1,0 +1,153 @@
+// The download funnel's terminal-event invariant (issue #4316).
+//
+// INVARIANT: every `Offline Board Download Started` is followed by exactly one
+// terminal event for that attempt — `Offline Board Download Completed` when the
+// scope finishes, `Offline Board Download Failed` otherwise.
+//
+// #4314 closed three specific bail-outs by hand (a sign-out, a wipe epoch bump,
+// the app backgrounding), and a device still went silent: Started fired with an
+// `artifactBytes` of 103 MB and no Completed, no Failed, and no Sentry event
+// ever followed. Per-site reporting can only ever cover the sites somebody
+// remembered, and `runBootstrapPhase` has a dozen ways out — `break`, `continue`,
+// a `throw` from any of the ~15 awaited SQLite writes that sit OUTSIDE the
+// import's try/catch, or a consumer callback (`onProgress`,
+// `onBootstrapMetadataChanged`) throwing back into the loop.
+//
+// So the guard is structural instead. The phase arms it at the Started emission
+// point and closes it from a `finally`; anything that reaches that `finally`
+// without a recorded terminal event is reported as one. A future `break` added
+// by someone who never reads this file is covered on the day it is written.
+//
+// WHAT COUNTS AS SETTLED
+//  - any `onSnapshotBootstrapError` report for the armed scope (the Failed leg,
+//    wired centrally so no report site has to remember to mark itself), and
+//  - a successful import, which hands the funnel to the board-data loop's
+//    Completed event.
+//
+// SEVERITY. Known teardowns keep #4314's convention: `aborted: true`,
+// `expected: true`, and therefore OUT of Sentry — a pocketed phone is not a
+// defect. Only a genuinely unexplained exit (`reason: 'unknown-exit'`) reports
+// as a real failure, which is what puts it in Sentry under the existing
+// `source: offline-sync` / `kind: snapshot-bootstrap` tags.
+//
+// NO BURN, EVER. Every report the guard emits carries `attempt: 0`: it is a
+// bystander that never touched the retry ladder, and claiming an attempt the
+// scope still has would strand a board on the paged crawl for a lock it can
+// retry in two minutes.
+
+import { classifySnapshotBootstrapFailure, type SnapshotBootstrapFailureReason } from './bootstrap-failure-reason';
+import { isNetworkError } from '../mutation-queue/error-classification';
+import type { SnapshotBootstrapErrorReport } from './snapshot-bootstrap';
+
+export type BootstrapStage = SnapshotBootstrapErrorReport['stage'];
+
+export type DownloadFunnelGuardOptions = {
+  /**
+   * The Failed leg. Undefined for headless callers (web, most tests) — the
+   * bookkeeping still runs, it just has nowhere to report, exactly like every
+   * explicit site in the phase.
+   */
+  report: ((report: SnapshotBootstrapErrorReport) => void) | undefined;
+  /**
+   * Why the cycle is being torn down AT THIS INSTANT, or null. Read at close
+   * time rather than latched, so an unexplained exit during a sign-out is
+   * attributed to the sign-out instead of being filed as a defect.
+   */
+  teardownReason: () => SnapshotBootstrapFailureReason | null;
+};
+
+export type DownloadFunnelGuard = {
+  /**
+   * The scope reached the Started emission point: from here to `close()` it owes
+   * the funnel a terminal event.
+   */
+  arm(scopeKey: string, stage: BootstrapStage): void;
+  /** How far this attempt got. Carried on whatever terminal event ends up firing. */
+  enterStage(stage: BootstrapStage): void;
+  /** A terminal event was recorded for `scopeKey` — the guard stays quiet. */
+  settle(scopeKey: string): void;
+  /** An exception is unwinding the phase. Reports it, classified, then stays quiet. */
+  settleUncaught(error: unknown): void;
+  /** Un-bypassable close-out. Call from a `finally`. */
+  close(): void;
+};
+
+export function createDownloadFunnelGuard(options: DownloadFunnelGuardOptions): DownloadFunnelGuard {
+  let attempt: { scopeKey: string; stage: BootstrapStage; settled: boolean } | null = null;
+
+  const emit = (report: {
+    reason: SnapshotBootstrapFailureReason;
+    cause: unknown;
+    aborted: boolean;
+    expected: boolean;
+  }): void => {
+    if (!attempt) return;
+    attempt.settled = true;
+    options.report?.({
+      scopeKey: attempt.scopeKey,
+      stage: attempt.stage,
+      // See NO BURN, EVER above. Zero is this field's established meaning for
+      // "nothing was spent", not a placeholder.
+      attempt: 0,
+      cause: report.cause,
+      reason: report.reason,
+      aborted: report.aborted,
+      expected: report.expected,
+    });
+  };
+
+  return {
+    arm(scopeKey, stage) {
+      attempt = { scopeKey, stage, settled: false };
+    },
+    enterStage(stage) {
+      if (attempt) attempt.stage = stage;
+    },
+    settle(scopeKey) {
+      // Scope-checked: a report for a DIFFERENT scope (the retrofit grades path
+      // runs for scopes this attempt never armed) must not close this one.
+      if (attempt?.scopeKey === scopeKey) attempt.settled = true;
+    },
+    settleUncaught(error) {
+      if (!attempt || attempt.settled) return;
+      const classified = classifySnapshotBootstrapFailure(error);
+      // A SnapshotWipedError classifies itself; anything else is only an abort if
+      // the cycle is being torn down right now.
+      const abortReason = classified === 'aborted-wipe' ? classified : options.teardownReason();
+      if (abortReason) {
+        emit({ reason: abortReason, cause: error, aborted: true, expected: true });
+        return;
+      }
+      // The case the field report behind this guard is made of: a SQLite lock on
+      // one of the writes that sit outside the import's own catch. Reported at
+      // full severity — it is a defect, and Sentry is where it gets diagnosed.
+      emit({ reason: classified, cause: error, aborted: false, expected: isNetworkError(error) });
+    },
+    close() {
+      const closing = attempt;
+      if (!closing) return;
+      if (closing.settled) {
+        attempt = null;
+        return;
+      }
+      const teardown = options.teardownReason();
+      if (teardown) {
+        // A known bail-out that forgot to report. Same shape #4314's hand-written
+        // sites emit, so the two can never disagree.
+        emit({ reason: teardown, cause: null, aborted: true, expected: true });
+        attempt = null;
+        return;
+      }
+      // Nothing explains this exit. A synthetic cause rather than null so the
+      // funnel's `errorMessage` and the Sentry issue both name the stage instead
+      // of reading "null".
+      emit({
+        reason: 'unknown-exit',
+        cause: new Error(`snapshot bootstrap left stage "${closing.stage}" with no terminal event`),
+        aborted: false,
+        expected: false,
+      });
+      attempt = null;
+    },
+  };
+}

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -35,6 +35,7 @@ import {
   type SnapshotBootstrapErrorReporter,
 } from './snapshot-bootstrap';
 import { classifySnapshotBootstrapFailure, type SnapshotBootstrapFailureReason } from './bootstrap-failure-reason';
+import { createDownloadFunnelGuard } from './download-funnel-guard';
 import {
   classifyBootstrapFailure,
   clearBootstrapPagedFallback,
@@ -960,19 +961,7 @@ async function runBootstrapPhase(params: {
   } = params;
   const onProgress = options?.onProgress;
   const onSchemaDrift = options?.onSchemaDrift;
-  // Wrapped ONCE here rather than at each of the eight report sites: every one of
-  // them already builds a payload with the cause in hand, so deriving `reason` and
-  // defaulting `aborted` centrally keeps them untouched and makes it impossible for
-  // a future arm to forget either field (issue #4314).
   const rawSnapshotBootstrapError = options?.onSnapshotBootstrapError;
-  const onSnapshotBootstrapError = rawSnapshotBootstrapError
-    ? (report: BootstrapErrorInput): void =>
-        rawSnapshotBootstrapError({
-          ...report,
-          reason: report.reason ?? classifySnapshotBootstrapFailure(report.cause),
-          aborted: report.aborted ?? false,
-        })
-    : undefined;
 
   /**
    * Why the phase is being torn down, or null when it is not. Read at each of the
@@ -984,6 +973,32 @@ async function runBootstrapPhase(params: {
     if (isBackgrounded()) return 'aborted-background';
     return null;
   };
+
+  // The terminal-event invariant, enforced structurally rather than site by site
+  // (issue #4316). Armed at the Started emission below and closed from the
+  // per-scope `finally`, so an exit nobody registered — a future `break`, a
+  // `throw` from any of the awaited SQLite writes that sit outside the import's
+  // own catch, a consumer callback blowing up — still closes the funnel. See
+  // download-funnel-guard.ts for what counts as settled and why only a genuinely
+  // unexplained exit reaches Sentry.
+  const funnelGuard = createDownloadFunnelGuard({ report: rawSnapshotBootstrapError, teardownReason });
+
+  // Wrapped ONCE here rather than at each of the eight report sites: every one of
+  // them already builds a payload with the cause in hand, so deriving `reason` and
+  // defaulting `aborted` centrally keeps them untouched and makes it impossible for
+  // a future arm to forget either field (issue #4314). The guard is settled from
+  // the same place for the same reason: a report site cannot forget to mark itself
+  // terminal if marking itself is not something it does.
+  const onSnapshotBootstrapError = rawSnapshotBootstrapError
+    ? (report: BootstrapErrorInput): void => {
+        funnelGuard.settle(report.scopeKey);
+        rawSnapshotBootstrapError({
+          ...report,
+          reason: report.reason ?? classifySnapshotBootstrapFailure(report.cause),
+          aborted: report.aborted ?? false,
+        });
+      }
+    : undefined;
 
   /** Close the funnel for a scope whose work this cycle was cut short. */
   const reportBootstrapAbort = (
@@ -1024,7 +1039,14 @@ async function runBootstrapPhase(params: {
   // Absent = not yet attempted; `file: null` = download failed (with its cause).
   const downloadByLayout = new Map<
     string,
-    { file: SnapshotArtifactHandle | null; cause: unknown; permanentMiss: boolean; downloadMs: number }
+    {
+      file: SnapshotArtifactHandle | null;
+      cause: unknown;
+      permanentMiss: boolean;
+      downloadMs: number;
+      /** Set when THIS phase cancelled the transfer, so a cleared flag can't relabel it a failure. */
+      abortedReason: SnapshotBootstrapFailureReason | null;
+    }
   >();
   // filePath → whether any scope managed to import it. An artifact the phase
   // never consumed (backgrounded cycle, wipe, aborted transfer) is handed back
@@ -1403,6 +1425,13 @@ async function runBootstrapPhase(params: {
         // board-data loop's emission below a no-op for this scope; every path
         // that `continue`s above (including the metered heal defer) reaches that
         // one instead and is correctly attributed to the paged crawl.
+        //
+        // The guard is armed BEFORE the emission, not after: the emitter writes
+        // the durable `scope-started:` marker, and a SQLite lock thrown between
+        // that write and the event is the one window where a Started could be
+        // owed a terminal event that no later cycle would ever emit (the marker
+        // makes the emission once-ever).
+        funnelGuard.arm(scope.scopeKey, 'download');
         await emitScopeDownloadStartOnce({
           scopeKey: scope.scopeKey,
           pathIntent: 'snapshot',
@@ -1422,7 +1451,13 @@ async function runBootstrapPhase(params: {
         // reports the real error, not null.
         let cachedDownload = downloadByLayout.get(layoutKey);
         if (!cachedDownload) {
-          cachedDownload = { file: null, cause: null, permanentMiss: false, downloadMs: 0 };
+          cachedDownload = {
+            file: null,
+            cause: null,
+            permanentMiss: false,
+            downloadMs: 0,
+            abortedReason: null,
+          };
           // The transfer runs for minutes on a 100 MB artifact. Cancelling it
           // when the cycle is torn down (sign-out, purge, backgrounding) stops
           // the native session from carrying on over a metered connection long
@@ -1434,8 +1469,20 @@ async function runBootstrapPhase(params: {
           // case where cancelling matters most. The progress callback stays a
           // pure reporter.
           const abortController = new AbortController();
+          // LATCHED, unlike `isBackgrounded()` itself. The teardown flags are
+          // live: a phone that woke, aborted a 100 MB transfer, and came back to
+          // the foreground before the throw was handled read as "no teardown" at
+          // the check below — and the download we cancelled ourselves was then
+          // settled as a real transport failure, burning a bootstrap attempt and
+          // scheduling a cooldown for a pocketed phone (review note on #4345).
+          // Latching the reason at the moment we abort is what makes that race
+          // unwinnable.
+          let selfAbortedReason: SnapshotBootstrapFailureReason | null = null;
           const abortIfTornDown = (): void => {
-            if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) abortController.abort();
+            const reason = teardownReason();
+            if (!reason) return;
+            selfAbortedReason ??= reason;
+            abortController.abort();
           };
           const unsubscribeTeardown = onTeardown(abortIfTornDown);
           // Covers a teardown that landed between the guard check above and the
@@ -1483,6 +1530,10 @@ async function runBootstrapPhase(params: {
           } finally {
             unsubscribeTeardown();
           }
+          // Only when the transfer actually died. A download that finished
+          // despite a teardown landing late is still importable, and calling it
+          // an abort here would throw away bytes that are already on disk.
+          if (!cachedDownload.file) cachedDownload.abortedReason = selfAbortedReason;
           cachedDownload.downloadMs = Date.now() - downloadStartedAt;
           downloadByLayout.set(layoutKey, cachedDownload);
           // Registered even on the reuse path: the phase still owns the file for
@@ -1507,7 +1558,12 @@ async function runBootstrapPhase(params: {
         // 100 MB Kilter transfer aborted by a board removal elsewhere in the app
         // landed here and returned nothing, so the funnel showed a Started with no
         // terminal event and the climber saw the download silently restart.
-        const downloadTeardown = teardownReason();
+        //
+        // `abortedReason` is the latched half: WE cancelled this transfer, so it
+        // is an abort even if the flag that caused it has since cleared. Without
+        // it a phone that unlocked at the wrong moment charged itself a transport
+        // failure (and a 2-minute cooldown) for its own cancellation.
+        const downloadTeardown = teardownReason() ?? cachedDownload.abortedReason;
         if (downloadTeardown) {
           reportBootstrapAbort(scope.scopeKey, 'download', downloadTeardown, cachedDownload.cause);
           break;
@@ -1571,6 +1627,9 @@ async function runBootstrapPhase(params: {
 
         // Stage 3 of 3. Indeterminate by construction: the import is one
         // exclusive SQLite transaction with no safe place to emit from inside it.
+        // The guard moves first so anything thrown from here on — including the
+        // progress consumer on the next line — is attributed to the import.
+        funnelGuard.enterStage('import');
         emitSnapshotFrame(
           progressThrottle.flush({
             scopeKey: scope.scopeKey,
@@ -1618,6 +1677,12 @@ async function runBootstrapPhase(params: {
           // reports false for exactly the runs the flag exists to filter out.
           await markBootstrapDone(db, scope.scopeKey, { healed: hasBoardCheckpoint });
           metadataSettled = true;
+          // The one settlement the guard cannot infer from a report: the scope's
+          // terminal event is the Completed the board-data loop fires once the
+          // delta pull reaches every table's tail — possibly cycles from now, on
+          // Kilter usually after the grades crawl. Nothing failed, so nothing
+          // should be reported.
+          funnelGuard.settle(scope.scopeKey);
           // Bust the board-table query caches now: if the snapshot fully satisfies
           // the scope, the delta pull returns zero documents and syncTable's
           // arrivals-only invalidation never fires — an active search/detail query
@@ -1722,7 +1787,21 @@ async function runBootstrapPhase(params: {
             skipPagedPull.add(scope.scopeKey);
           }
         }
+      } catch (error) {
+        // Everything between the Started emission and the import's own try sits
+        // OUTSIDE any catch: ~15 awaited SQLite writes (the retry-state writes,
+        // the paged-fallback markers, `clearTransportFailures` right after a
+        // 100 MB transfer lands) plus two consumer callbacks. A single
+        // SQLITE_BUSY on any of them unwound the whole phase in silence — the
+        // leading candidate for the device that emitted six Starteds and nothing
+        // else. Reported, classified, then rethrown: the control flow is
+        // unchanged, only the silence is gone.
+        funnelGuard.settleUncaught(error);
+        throw error;
       } finally {
+        // Un-bypassable: a `break` or `continue` a future change adds below the
+        // Started emission closes the funnel here whether or not it remembers to.
+        funnelGuard.close();
         if (metadataSettled) onBootstrapMetadataChanged?.({ scopeKey: scope.scopeKey });
       }
     }


### PR DESCRIPTION
Refs #4316 #4310

## The hole

A production device emits `Offline Board Download Started` with a 103 MB `artifactBytes` — manifest fine, network verified fast from Safari on the same phone — and then **nothing**. No Completed, no Failed, no Sentry event. The cycle moves on to the next scope two or three minutes later.

#4357 wired the three known teardown bail-outs (sign-out, wipe-epoch bump, backgrounding) into the funnel by hand, and the silence survived it. That is the lesson: per-site reporting only ever covers the sites somebody remembered, and `runBootstrapPhase` has a dozen ways out. Eight of them are `break`/`continue` arms below the Started emission — all covered. The ninth class was never covered at all: **an exception**. Everything between the Started emission and `bootstrapScopeFromSnapshot`'s own `try` sits outside any catch — ~15 awaited SQLite writes (the retry-state writes, the paged-fallback markers, `clearTransportFailures` on the line right after a 100 MB transfer lands) plus two consumer callbacks (`onProgress`, `onBootstrapMetadataChanged`). One `SQLITE_BUSY` on any of them unwound the whole phase in silence.

## The invariant, made structural

**Every Started has exactly one terminal event.** New `packages/shared/offline-sync/src/sync/download-funnel-guard.ts`: the phase arms a guard at the Started emission point and closes it from the per-scope `finally`. An attempt that reaches that `finally` with no terminal event recorded emits one.

| Guard sees | `reason` | `aborted` | Sentry |
| --- | --- | --- | --- |
| a live teardown (sign-out / wipe / purge) | `aborted-wipe` | `true` | no |
| a live teardown (backgrounded) | `aborted-background` | `true` | no |
| an exception unwinding the phase | classified — `database-locked`, `network`, `artifact-invalid`, … | `false` | yes |
| nothing that explains the exit | `unknown-exit` (new) | `false` | yes |

Known aborts stay out of Sentry per #4357's convention — a pocketed phone is not a defect. `unknown-exit` does not: it means the phase has a hole, and it should sit at zero forever.

Two rules keep it un-bypassable and non-duplicating:

- **Sites cannot forget to mark themselves**, because marking is not something they do. Every explicit report already flows through one wrapper in `runBootstrapPhase` (added by #4357 to fill in `reason`/`aborted`); that wrapper settles the guard. The one manual settle is the success path, whose terminal event is the Completed the board-data loop fires once the delta pull reaches every table's tail — on Kilter, usually cycles later.
- **Nothing burns.** Every guard-emitted report carries `attempt: 0`. It is a bystander; claiming an attempt the scope still has would strand a board on the 400-round-trip paged crawl over a lock it can retry in two minutes.

## Audited exit sites

Everything reachable in `runBootstrapPhase` and its `bootstrapScopeFromSnapshot` / `downloadArtifact` call paths. Line numbers are post-change.

| # | Site (`pull-client.ts`) | Exit | Before | Now |
| --- | --- | --- | --- | --- |
| 1 | :1187 top-of-loop teardown | `break` | silent | silent — **above** Started, nothing owed |
| 2 | :1271 retrofit-grades manifest teardown | `break` | silent | silent — above Started |
| 3 | :1279 scope not eligible (cooldown, complete, terminal) | `continue` | silent | silent — above Started |
| 4 | :1301 post-manifest teardown | `break` | silent | silent — above Started |
| 5 | :1320 re-arm found the same `builtAt` | `continue` | silent | silent — above Started |
| 6 | :1339 manifest absent | `continue` | silent | silent — above Started |
| 7 | :1354 manifest fetch failed | `continue` | Failed (settled) | unchanged |
| 8 | :1363 layout not in the manifest | `continue` | silent | silent — above Started |
| 9 | :1368 entry unusable (schema pre-check) | `continue` | silent | silent — above Started |
| 10 | :1394 metered-link heal defer | `continue` | silent | silent — above Started |
| — | **:1434–1435 `Offline Board Download Started` — guard armed** | | | |
| 11 | :1445 teardown between Started and the first byte | `break` | Failed `aborted-*` (#4357) | unchanged |
| 12 | :1569 teardown after the transfer | `break` | Failed `aborted-*` (#4357) | unchanged, **plus** the latched self-abort (below) |
| 13 | :1600 permanent miss at the download stage | `continue` | Failed (settled, burns) | unchanged |
| 14 | :1613 download failed | `continue` | Failed (settled, burns) | unchanged |
| 15 | :1709 wipe / teardown mid-import | `break` | Failed `aborted-*` (#4357) | unchanged |
| 16 | :1731 `SnapshotSchemaStaleError` | `continue` | Failed, no burn | unchanged |
| 17 | :1767 reused artifact's one free round | `continue` | Failed, no burn | unchanged |
| 18 | :1785 counted structural import failure | fall through | Failed (settled, burns) | unchanged |
| 19 | :1678–1685 import succeeded | fall through | silent (correct) | settles the guard; Completed still comes from the board-data loop |
| 20 | **:1799 any exception below Started** — SQLite write, `onProgress`, `onBootstrapMetadataChanged` | `throw` (escapes the phase and `pullSync`) | **silent** | **Failed, classified** (`database-locked` / `network` / …), `attempt: 0`, Sentry unless it is a teardown; rethrown, so control flow is unchanged |
| 21 | **:1804 anything else** — a `break`/`continue` a future change adds | `finally` | **silent** | **Failed `unknown-exit`**, Sentry |
| 22 | :1125–1126 `importGradesForScope` bails | `return` | silent | silent — runs after a settled success (or for an unarmed retrofit scope); grades failures are free and report on their own stages |
| 23 | outer `finally` :1830 artifact release | — | swallowed by `.catch(() => {})` | unchanged — cleanup, after the funnel closed |

## Backgrounding must not burn an attempt

A review flagged this race on #4345 and it was real. The teardown flags are **live**, not latched: a phone that woke between our own `AbortController` firing and the rejection being handled read as "no teardown" at site 12, fell through to site 14, and settled the download **we cancelled ourselves** as a genuine transport failure — one attempt burned and a 2-minute cooldown scheduled, for a pocketed phone. Against #4326's taxonomy that is plainly wrong: a teardown spends nothing.

The abort reason is now latched at the moment we abort, and consulted only when the transfer actually died (a download that finished despite a late teardown is still importable, and calling it an abort would throw away bytes already on disk). Pinned by a test that fails on `main`.

## Tests

`packages/shared/offline-sync/src/sync/__tests__/download-funnel-guard.test.ts` — one per exit class: the unregistered `break` (`unknown-exit`, full severity, synthetic cause naming the stage), the teardown-attributed close, the classified uncaught exception, the network downgrade, `SnapshotWipedError` after the flags cleared, no-double-emit from a settled report, no-double-emit after a successful import, a settle for a different scope, a scope that never reached Started, and no attempt leaking to the next scope.

`snapshot-bootstrap.test.ts` (real SQLite, real `pullSync`) — "pullSync bootstrap funnel invariant": an exception thrown outside the import `try` reports `database-locked` at `attempt: 0` and burns nothing; the background-then-foreground race reports `aborted-background` with no burn and no cooldown; a genuine download failure emits exactly one terminal event; a clean bootstrap emits none. Both regression tests were confirmed red against the pre-change code.

- `vp run typecheck` (full)
- `vp test run --reporter=agent --project offline-sync` — 606 pass
- `vp run test:mobile` — 5890 pass
- `vp run check:mobile-bundle` — OK

## What this does not cover

The **paged** crawl. Its Started legitimately stays open across cycles — an interrupted crawl has not failed, it is simply not finished — so the board-data loop still returns silently on a teardown and abandonment there is measured as "a Started with no Completed after N days". That boundary is now written down in `docs/board-snapshots.md` rather than left implicit. If Marco's device turns out to have imported its artifact and then never finished the grades crawl, that is the surface to instrument next, and it is a different event shape.

## Release Notes

- [x] No release note needed (internal / technical change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT6VP1sWqk6bY9mUgyeS2U
