### PR TITLE
fix(web): unbreak the production build's type check

### DIFF
--- a/packages/web/app/lib/__tests__/board-slug-utils.test.ts
+++ b/packages/web/app/lib/__tests__/board-slug-utils.test.ts
@@ -37,6 +37,7 @@ const publicBoard: ResolvedBoard = {
   description: null,
   locationName: null,
   isPublic: true,
+  isUnlisted: false,
   isOwned: true,
   ownerId: 'owner-1',
   angle: 40,


### PR DESCRIPTION
## Summary

Production Deploy on `main` is failing its type check ([run 31650050831](https://github.com/boardsesh/boardsesh/actions/runs/31650050831/job/94292257280)):

```
app/lib/__tests__/board-slug-utils.test.ts(29,7): error TS2741:
Property 'isUnlisted' is missing in type '{ ... }' but required in type 'ResolvedBoard'.
Failed to type check.
```

Two changes crossed on `main`: #4167 made `isUnlisted` a required field on `ResolvedBoard`, while the `board-slug-utils` test fixture was written against the shape before that. Per-PR CI didn't catch it because neither branch contained both halves; the Vercel build type-checks the whole package, tests included, so it dies there.

This adds `isUnlisted: false` to the `publicBoard` fixture. `privateBoard` spreads it, so both cases are covered.

Also visible in that log, and **not** fixed here: the Sentry step fails with `Invalid token (http status: 401)` when creating the release and uploading source maps. It doesn't fail the build — `runAfterProductionCompile` completes anyway — but it means production releases are shipping without source maps. The `SENTRY_AUTH_TOKEN` in the Vercel project needs rotating.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- Fixture now satisfies the `ResolvedBoard` type that `resolveBoardBySlug` returns; the single reported `tsc` error is the one this addresses.
- CI typecheck + web tests on this PR are the gate.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EUqCCian7wDJJ7Kt86cwtP)_