### PR TITLE
ci: guard and document the app.boardsesh.com deploy hold

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -957,6 +957,12 @@ jobs:
           WEB_RESULT: ${{ needs.deploy-web.result }}
           BACKEND_RESULT: ${{ needs.deploy-production-backend.result }}
           APP_WEB_RESULT: ${{ needs.deploy-app-web.result }}
+          # A held deploy is a skip, which would otherwise print as "unchanged" —
+          # the exact invisibility notify-app-web-held exists to prevent. True
+          # only when the hold is set AND this push would have deployed the
+          # subdomain; with the variable unset this renders "false" and the
+          # message is byte-identical to before.
+          APP_WEB_HELD: ${{ vars.APP_WEB_DEPLOY_HOLD != '' && needs.detect-changes.outputs.app_changed == 'true' }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           COMMIT_SHA: ${{ github.sha }}
           BEFORE_SHA: ${{ github.event.before }}
@@ -973,6 +979,7 @@ jobs:
           if [ "$BACKEND_RESULT" = "success" ]; then BACKEND_LINE="deployed"; fi
           APP_WEB_LINE="unchanged"
           if [ "$APP_WEB_RESULT" = "success" ]; then APP_WEB_LINE="deployed"; fi
+          if [ "$APP_WEB_HELD" = "true" ]; then APP_WEB_LINE="held (APP_WEB_DEPLOY_HOLD set)"; fi
 
           # Pull PR numbers from merge-commit subjects in BEFORE..SHA. Skip the
           # section entirely if BEFORE is missing/zero (workflow_dispatch, first

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -958,11 +958,22 @@ jobs:
           BACKEND_RESULT: ${{ needs.deploy-production-backend.result }}
           APP_WEB_RESULT: ${{ needs.deploy-app-web.result }}
           # A held deploy is a skip, which would otherwise print as "unchanged" —
-          # the exact invisibility notify-app-web-held exists to prevent. True
-          # only when the hold is set AND this push would have deployed the
-          # subdomain; with the variable unset this renders "false" and the
-          # message is byte-identical to before.
-          APP_WEB_HELD: ${{ vars.APP_WEB_DEPLOY_HOLD != '' && needs.detect-changes.outputs.app_changed == 'true' }}
+          # the exact invisibility notify-app-web-held exists to prevent.
+          #
+          # Read off what deploy-app-web actually did, NOT by re-reading
+          # vars.APP_WEB_DEPLOY_HOLD here. This job declares
+          # `environment: Production`, so a step-level `vars.` lookup resolves
+          # Production environment variables as well as repository ones, while
+          # the gate on deploy-app-web is a job-level `if:` that only ever sees
+          # repository variables. Re-reading would print "held" for a deploy that
+          # actually shipped whenever an operator scoped the variable to the
+          # environment — the worst-direction lie to hand an incident responder.
+          # The hold is the only reason deploy-app-web skips while app_changed is
+          # 'true'; a cancellation short-circuits this job via its own
+          # `!contains(needs.*.result, 'cancelled')`. With no hold set the
+          # expression renders "false" and the message is byte-identical to
+          # before.
+          APP_WEB_HELD: ${{ needs.deploy-app-web.result == 'skipped' && needs.detect-changes.outputs.app_changed == 'true' }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           COMMIT_SHA: ${{ github.sha }}
           BEFORE_SHA: ${{ github.event.before }}
@@ -977,9 +988,15 @@ jobs:
           if [ "$WEB_RESULT" = "success" ]; then WEB_LINE="deployed"; fi
           BACKEND_LINE="unchanged"
           if [ "$BACKEND_RESULT" = "success" ]; then BACKEND_LINE="deployed"; fi
+          # elif, not a second `if`: an override would let "held" win over a
+          # deploy that demonstrably shipped, which is the inversion this line
+          # exists to prevent.
           APP_WEB_LINE="unchanged"
-          if [ "$APP_WEB_RESULT" = "success" ]; then APP_WEB_LINE="deployed"; fi
-          if [ "$APP_WEB_HELD" = "true" ]; then APP_WEB_LINE="held (APP_WEB_DEPLOY_HOLD set)"; fi
+          if [ "$APP_WEB_RESULT" = "success" ]; then
+            APP_WEB_LINE="deployed"
+          elif [ "$APP_WEB_HELD" = "true" ]; then
+            APP_WEB_LINE="held (APP_WEB_DEPLOY_HOLD set)"
+          fi
 
           # Pull PR numbers from merge-commit subjects in BEFORE..SHA. Skip the
           # section entirely if BEFORE is missing/zero (workflow_dispatch, first

--- a/deploy/app-subdomain/README.md
+++ b/deploy/app-subdomain/README.md
@@ -3,9 +3,9 @@
 `_redirects` and `_headers` are copied into the standalone Expo web export at
 deploy time and shipped to the `boardsesh-app` Cloudflare Pages project. They
 are the only deployed files here; the rest of the directory is this README plus
-the CI tests that guard them — and the deploy job that ships them
-(`__tests__/`, `vite.config.ts`). They are **not**
-part of the export itself — the export recipe
+the CI tests that guard both these files and the deploy job that ships them
+(`__tests__/`, `tsconfig.json`, `vite.config.ts`). They are **not** part of the
+export itself — the export recipe
 (`scripts/build-expo-web-export.sh --subdomain`) emits a `baseUrl /` static SPA;
 this directory adds the host-level SPA fallback and caching rules Pages needs.
 
@@ -66,8 +66,11 @@ export script, `Dockerfile.web`, or the deploy workflow.
 config files: it asserts the `APP_WEB_DEPLOY_HOLD` freeze on `deploy-app-web`,
 the Discord ping that makes a held run visible, and that the export's
 `EXPO_PUBLIC_*` stay at workflow level. It lives here because the `deploy-config`
-job already runs this project unfiltered on any `production-deploy.yml` change,
-which is the only CI gate that fires for a workflow-only diff. See
+job already runs this project unfiltered on any `production-deploy.yml` change —
+the only gate that selects a test suite for a workflow-only diff, since Vitest's
+`--changed` can never relate an fs read to a diff of the file being read. (Other
+gates do fire on such a diff — `service-deploy-inputs.yml` lists the workflow in
+its paths filter — they just run no tests over it.) See
 `docs/expo-web-deployment.md`.
 
 ## Why `EXPO_PUBLIC_WEB_URL` is www, not app

--- a/deploy/app-subdomain/README.md
+++ b/deploy/app-subdomain/README.md
@@ -3,7 +3,8 @@
 `_redirects` and `_headers` are copied into the standalone Expo web export at
 deploy time and shipped to the `boardsesh-app` Cloudflare Pages project. They
 are the only deployed files here; the rest of the directory is this README plus
-the CI tests that guard them (`__tests__/`, `vite.config.ts`). They are **not**
+the CI tests that guard them — and the deploy job that ships them
+(`__tests__/`, `vite.config.ts`). They are **not**
 part of the export itself — the export recipe
 (`scripts/build-expo-web-export.sh --subdomain`) emits a `baseUrl /` static SPA;
 this directory adds the host-level SPA fallback and caching rules Pages needs.
@@ -60,6 +61,14 @@ above, the `noindex` tag, forever-caching on content-hashed assets only, and the
 `200` SPA rewrite for deep links. The `deploy-config` job in
 `.github/workflows/ci.yml` runs it on every PR touching this directory, the
 export script, `Dockerfile.web`, or the deploy workflow.
+
+`__tests__/production-deploy-hold.test.ts` guards the deploy job rather than the
+config files: it asserts the `APP_WEB_DEPLOY_HOLD` freeze on `deploy-app-web`,
+the Discord ping that makes a held run visible, and that the export's
+`EXPO_PUBLIC_*` stay at workflow level. It lives here because the `deploy-config`
+job already runs this project unfiltered on any `production-deploy.yml` change,
+which is the only CI gate that fires for a workflow-only diff. See
+`docs/expo-web-deployment.md`.
 
 ## Why `EXPO_PUBLIC_WEB_URL` is www, not app
 

--- a/deploy/app-subdomain/__tests__/production-deploy-hold.test.ts
+++ b/deploy/app-subdomain/__tests__/production-deploy-hold.test.ts
@@ -47,6 +47,21 @@ function jobCondition(jobId: string): string | undefined {
   return jobBlock(jobId).match(/^ {4}if: (.+)$/m)?.[1];
 }
 
+/**
+ * The shell body of a job's `run: |` step, with the surrounding YAML (the job's
+ * own `if:`, its `env:` keys) stripped off. Assertions about what an operator
+ * reads on Discord must run against this, not the whole job block: the block
+ * quotes `APP_WEB_DEPLOY_HOLD` in the gate condition and the webhook name in
+ * `env:`, so a whole-block `toContain` for either passes even after the message
+ * and the POST are deleted.
+ */
+function jobRunScript(jobId: string): string {
+  const block = jobBlock(jobId);
+  const marker = block.indexOf('run: |');
+  if (marker === -1) throw new Error(`production-deploy.yml's \`${jobId}:\` job has no \`run: |\` step`);
+  return block.slice(marker + 'run: |'.length);
+}
+
 describe('production-deploy.yml: the app.boardsesh.com deploy hold', () => {
   it('skips deploy-app-web while APP_WEB_DEPLOY_HOLD is set', () => {
     const condition = jobCondition('deploy-app-web');
@@ -71,10 +86,16 @@ describe('production-deploy.yml: the app.boardsesh.com deploy hold', () => {
   it('announces every held run on Discord', () => {
     // A skipped job is only grey in the run summary, so without the ping a
     // forgotten hold strands the browser app on an old bundle unnoticed.
-    const notifyJob = jobBlock('notify-app-web-held');
     expect(jobCondition('notify-app-web-held')).toContain(HOLD_SET);
-    expect(notifyJob).toContain('DISCORD_DEPLOY_WEBHOOK');
-    expect(notifyJob, 'the message must name the variable to clear').toContain('APP_WEB_DEPLOY_HOLD');
+    expect(jobBlock('notify-app-web-held'), 'the job must wire in the webhook secret').toContain(
+      'DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}',
+    );
+
+    const notifyScript = jobRunScript('notify-app-web-held');
+    expect(notifyScript, 'and the step must actually POST to it').toMatch(/curl[^\n]*"\$DISCORD_DEPLOY_WEBHOOK"/);
+    expect(notifyScript, 'the posted message must tell the operator which variable to clear').toContain(
+      'Clear the `APP_WEB_DEPLOY_HOLD` repo variable',
+    );
   });
 
   it('pairs the gate and the ping on one condition, so neither can drift', () => {
@@ -85,10 +106,26 @@ describe('production-deploy.yml: the app.boardsesh.com deploy hold', () => {
   });
 
   it('reports a hold in the success notification instead of "unchanged"', () => {
-    const successJob = jobBlock('notify-success');
-    expect(successJob, 'notify-success must read the hold').toContain('APP_WEB_HELD:');
-    expect(successJob, 'and print it rather than claiming the subdomain was unchanged').toContain(
-      'held (APP_WEB_DEPLOY_HOLD set)',
+    const heldEnv = jobBlock('notify-success').match(/^ +APP_WEB_HELD: (.+)$/m)?.[1];
+    expect(heldEnv, 'notify-success must compute a held flag for the subdomain line').toBeTruthy();
+
+    // Read off the observed outcome, never by re-reading the variable here.
+    // notify-success declares `environment: Production`, so a step-level `vars.`
+    // lookup resolves environment-scoped variables that the job-level gate on
+    // deploy-app-web never sees — a hold scoped to the environment would then
+    // print "held" for a deploy that actually shipped.
+    expect(heldEnv, 'derive the hold from what deploy-app-web did').toContain(
+      "needs.deploy-app-web.result == 'skipped'",
+    );
+    expect(heldEnv, 'and only claim a hold when this push would have deployed the subdomain').toContain(APP_CHANGED);
+    expect(heldEnv, 'a step in an `environment:` job must not re-read the repo variable').not.toContain(
+      'vars.APP_WEB_DEPLOY_HOLD',
+    );
+
+    // An `if`/`elif` chain, not two independent `if`s: an unconditional override
+    // after the success branch prints "held" for a deploy that shipped.
+    expect(jobRunScript('notify-success'), 'a successful deploy must win over the held line').toMatch(
+      /if \[ "\$APP_WEB_RESULT" = "success" \]; then\s+APP_WEB_LINE="deployed"\s+elif \[ "\$APP_WEB_HELD" = "true" \]; then\s+APP_WEB_LINE="held \(APP_WEB_DEPLOY_HOLD set\)"/,
     );
   });
 

--- a/deploy/app-subdomain/__tests__/production-deploy-hold.test.ts
+++ b/deploy/app-subdomain/__tests__/production-deploy-hold.test.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Guards the APP_WEB_DEPLOY_HOLD freeze on `deploy-app-web` in
+// .github/workflows/production-deploy.yml — the job that ships this directory's
+// Cloudflare Pages config (see ../README.md, docs/expo-web-deployment.md).
+//
+// deploy-web and deploy-production-backend read `check-rollback` and stage
+// instead of promoting while a Vercel Instant Rollback is pinned. Pages exposes
+// no equivalent signal, so a dashboard rollback of app.boardsesh.com is
+// protected by this repo variable alone. Losing the gate fails silently and at
+// the worst moment: the next merge touching packages/mobile re-ships the build
+// the rollback was mitigating.
+//
+// It lives in this project, not scripts/, because it reads the workflow via fs.
+// The `deploy-config` job in ci.yml runs this project UNFILTERED whenever
+// production-deploy.yml changes; Vitest's `--changed` module-graph selection can
+// never relate an fs read to a diff of the file it reads.
+
+const WORKFLOW_PATH = resolve(import.meta.dirname, '..', '..', '..', '.github', 'workflows', 'production-deploy.yml');
+const workflow = readFileSync(WORKFLOW_PATH, 'utf8');
+
+const HOLD_CLEAR = "vars.APP_WEB_DEPLOY_HOLD == ''";
+const HOLD_SET = "vars.APP_WEB_DEPLOY_HOLD != ''";
+const APP_CHANGED = "needs.detect-changes.outputs.app_changed == 'true'";
+
+/**
+ * The YAML body of a top-level job. Job keys sit at 2-space indent and their
+ * bodies at 4+, so the block ends at the first line that is neither blank nor
+ * 4-space indented — the next job key, or the comment introducing it.
+ */
+function jobBlock(jobId: string): string {
+  const lines = workflow.split('\n');
+  const start = lines.findIndex((line) => line.trimEnd() === `  ${jobId}:`);
+  if (start === -1) throw new Error(`production-deploy.yml has no \`${jobId}:\` job`);
+  const body: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim() !== '' && !line.startsWith('    ')) break;
+    body.push(line);
+  }
+  return body.join('\n');
+}
+
+/** The single-line job-level `if:` expression, or undefined. */
+function jobCondition(jobId: string): string | undefined {
+  return jobBlock(jobId).match(/^ {4}if: (.+)$/m)?.[1];
+}
+
+describe('production-deploy.yml: the app.boardsesh.com deploy hold', () => {
+  it('skips deploy-app-web while APP_WEB_DEPLOY_HOLD is set', () => {
+    const condition = jobCondition('deploy-app-web');
+    expect(condition, 'deploy-app-web must carry a single-line job-level `if:`').toBeTruthy();
+    expect(condition, 'the hold must gate the deploy').toContain(HOLD_CLEAR);
+    expect(condition, 'and it must still only run when the app actually changed').toContain(APP_CHANGED);
+  });
+
+  it('gates the whole job, so no post-deploy check probes a deploy it withheld', () => {
+    // The wrangler upload, the curl smoke and the Playwright boot check all live
+    // in deploy-app-web. A step-level guard would leave the two checks asserting
+    // against app.boardsesh.com for a build this run deliberately did not ship.
+    const deployJob = jobBlock('deploy-app-web');
+    expect(deployJob).toContain('--project-name=boardsesh-app');
+    expect(deployJob).toContain('pages deploy');
+    expect(
+      (workflow.match(/pages deploy/g) ?? []).length,
+      'exactly one Cloudflare Pages publish, and it must sit inside the gated job',
+    ).toBe(1);
+  });
+
+  it('announces every held run on Discord', () => {
+    // A skipped job is only grey in the run summary, so without the ping a
+    // forgotten hold strands the browser app on an old bundle unnoticed.
+    const notifyJob = jobBlock('notify-app-web-held');
+    expect(jobCondition('notify-app-web-held')).toContain(HOLD_SET);
+    expect(notifyJob).toContain('DISCORD_DEPLOY_WEBHOOK');
+    expect(notifyJob, 'the message must name the variable to clear').toContain('APP_WEB_DEPLOY_HOLD');
+  });
+
+  it('pairs the gate and the ping on one condition, so neither can drift', () => {
+    // The two `if:`s differ in exactly one operator: every run the hold skips is
+    // a run the ping announces. Editing one alone opens a silent hole (held and
+    // unannounced) or double-fires (deployed and announced as held).
+    expect(jobCondition('deploy-app-web')?.replace(HOLD_CLEAR, HOLD_SET)).toBe(jobCondition('notify-app-web-held'));
+  });
+
+  it('reports a hold in the success notification instead of "unchanged"', () => {
+    const successJob = jobBlock('notify-success');
+    expect(successJob, 'notify-success must read the hold').toContain('APP_WEB_HELD:');
+    expect(successJob, 'and print it rather than claiming the subdomain was unchanged').toContain(
+      'held (APP_WEB_DEPLOY_HOLD set)',
+    );
+  });
+
+  it('keeps the export env at workflow level, where mobile-ci-env-parity can see it', () => {
+    // scripts/mobile-ci-env-parity.test.ts matches `^  KEY:` only, so moving
+    // these into deploy-app-web blinds the test guarding them without failing
+    // anything. That test is fs-read too, and `--changed` never selects it for a
+    // workflow-only diff — this assertion runs in the deploy-config job, which
+    // does fire on one.
+    expect(jobBlock('deploy-app-web'), 'EXPO_PUBLIC_* must not be re-declared inside the job').not.toMatch(
+      /^\s*EXPO_PUBLIC_[A-Z_]+:/m,
+    );
+    for (const key of ['EXPO_PUBLIC_SENTRY_DSN', 'EXPO_PUBLIC_POSTHOG_KEY', 'EXPO_PUBLIC_SENTRY_ENVIRONMENT']) {
+      expect(workflow, `${key} must stay at workflow level (2-space indent)`).toMatch(new RegExp(`^ {2}${key}:`, 'm'));
+    }
+  });
+});

--- a/deploy/app-subdomain/tsconfig.json
+++ b/deploy/app-subdomain/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "//": "Not wired into `vp run typecheck` (this directory isn't a bun workspace package — no package.json) and not read by the `deploy-app-subdomain` vitest project either. It exists solely so oxlint's type-aware lint (lint.options.typeCheck in the root vite.config.ts) can resolve `node:fs`/`node:path`/`import.meta.dirname` when it type-checks a file here by explicit path, which is what the `vp staged` pre-commit hook does. Without this, TS2591 (\"Cannot find name 'node:fs'\") fires on every file in __tests__/ that reads the config files or the workflow from disk. The vitest run remains the actual correctness oracle for this directory — see README.md.",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["__tests__/**/*.ts"]
+}

--- a/docs/expo-web-deployment.md
+++ b/docs/expo-web-deployment.md
@@ -158,6 +158,47 @@ variable instead:
 - `notify-failure` fires on `failure`/`cancelled` only, so a held (skipped) job
   raises no false alarm.
 
+#### Holding and releasing
+
+Anyone with **admin** or **maintain** on the repo can set it: GitHub →
+Settings → Secrets and variables → Actions → **Variables** → _Repository
+variables_, or from the CLI:
+
+```
+gh variable set APP_WEB_DEPLOY_HOLD --body "2026-08-12 incident: Pages pinned to <deployment>"
+gh variable list                       # confirm it is set
+gh variable delete APP_WEB_DEPLOY_HOLD # release
+```
+
+Three things to get right:
+
+- **Repository variable, not an environment variable.** The gate is the
+  job-level `if:` on `deploy-app-web`, which GitHub evaluates before the job's
+  `environment: Production` is resolved — a variable scoped to that environment
+  is not reliably visible there, and a hold that silently does nothing is worse
+  than no hold at all.
+- **Not a secret.** Only its presence is read, never its value, so spend the body
+  on the incident reference: it is what the next person sees in Settings.
+- **Clear it before the next intended deploy.** The hold is not time-boxed and
+  nothing queues behind it. Every qualifying merge while it is set skips the
+  subdomain and pings Discord, and those commits stay unshipped until it is
+  cleared.
+
+Releasing does not redeploy by itself. After `gh variable delete`, either wait
+for the next qualifying merge or ship current `main` immediately with
+`gh workflow run production-deploy.yml` — a manual dispatch marks web, backend
+and app as changed (see `detect-changes`), so it rebuilds and republishes the
+subdomain.
+
+The hold covers `app.boardsesh.com` only. `deploy-web` (Vercel) and
+`deploy-production-backend` (Railway) still deploy while it is set; their own
+guard is `check-rollback`.
+
+`deploy/app-subdomain/__tests__/production-deploy-hold.test.ts` asserts the gate,
+its Discord counterpart, and that the export's `EXPO_PUBLIC_*` stay at workflow
+level. The `deploy-config` job in `.github/workflows/ci.yml` runs it on every PR
+touching `production-deploy.yml`.
+
 ### Infra follow-ups (not provisioned here)
 
 These are DNS / hosting operations outside this repo's build:

--- a/docs/expo-web-deployment.md
+++ b/docs/expo-web-deployment.md
@@ -177,27 +177,45 @@ Three things to get right:
   `environment: Production` is resolved — a variable scoped to that environment
   is not reliably visible there, and a hold that silently does nothing is worse
   than no hold at all.
-- **Not a secret.** Only its presence is read, never its value, so spend the body
-  on the incident reference: it is what the next person sees in Settings.
+- **Not a secret, but never empty.** The gate reads
+  `vars.APP_WEB_DEPLOY_HOLD == ''`, so what holds the deploy is a **non-empty
+  value**, not the variable merely existing — set it with an empty body (the
+  `gh variable set` prompt accepts one) and you get a hold that does nothing at
+  all. Always pass `--body`, and spend it on the incident reference: it is what
+  the next person sees in Settings. The value is only ever compared against the
+  empty string, never used as a credential, so it needs no secret handling.
 - **Clear it before the next intended deploy.** The hold is not time-boxed and
   nothing queues behind it. Every qualifying merge while it is set skips the
   subdomain and pings Discord, and those commits stay unshipped until it is
   cleared.
 
-Releasing does not redeploy by itself. After `gh variable delete`, either wait
-for the next qualifying merge or ship current `main` immediately with
-`gh workflow run production-deploy.yml` — a manual dispatch marks web, backend
-and app as changed (see `detect-changes`), so it rebuilds and republishes the
-subdomain.
+Releasing does not redeploy by itself. After `gh variable delete`, in order of
+blast radius:
+
+1. **Re-run the held run** — Actions → the run that was held → _Re-run all jobs_.
+   This is what the held-run Discord ping tells you to do. `detect-changes` and
+   every job `if:` re-evaluate on a re-run, so it ships exactly what that push
+   qualified for: after a mobile-only merge, the subdomain and nothing else.
+2. **Wait for the next qualifying merge**, if nothing is urgent.
+3. **`gh workflow run production-deploy.yml`** to ship current `main` now. Mind
+   the blast radius: a manual dispatch marks web, backend _and_ app as changed
+   (see `detect-changes`), so it redeploys Vercel and Railway as well, not just
+   the subdomain.
 
 The hold covers `app.boardsesh.com` only. `deploy-web` (Vercel) and
 `deploy-production-backend` (Railway) still deploy while it is set; their own
 guard is `check-rollback`.
 
+`notify-success` reports a held subdomain as `held (APP_WEB_DEPLOY_HOLD set)`
+instead of `unchanged`. It derives that from `deploy-app-web` skipping, not by
+re-reading the variable: that job declares `environment: Production`, where a
+step-level `vars.` lookup would also resolve environment-scoped variables the
+job-level gate cannot see, and print "held" for a deploy that actually shipped.
+
 `deploy/app-subdomain/__tests__/production-deploy-hold.test.ts` asserts the gate,
-its Discord counterpart, and that the export's `EXPO_PUBLIC_*` stay at workflow
-level. The `deploy-config` job in `.github/workflows/ci.yml` runs it on every PR
-touching `production-deploy.yml`.
+its Discord counterpart, that held line, and that the export's `EXPO_PUBLIC_*`
+stay at workflow level. The `deploy-config` job in `.github/workflows/ci.yml`
+runs it on every PR touching `production-deploy.yml`.
 
 ### Infra follow-ups (not provisioned here)
 


### PR DESCRIPTION
## Summary

The `APP_WEB_DEPLOY_HOLD` gate on `deploy-app-web` already shipped on `main` — commit `d87b4bda7` (inside PR #4065 / W-01, merged 2026-07-31) added the job-level `if:` gate, the `notify-app-web-held` Discord job, and a runbook section in `docs/expo-web-deployment.md`. This PR does not re-implement the gate. It ships the three things that were genuinely missing:

1. **A regression test** — `deploy/app-subdomain/__tests__/production-deploy-hold.test.ts`. Nothing in the repo asserted the gate exists, and its failure mode is silent: delete `&& vars.APP_WEB_DEPLOY_HOLD == ''` and every held run re-ships the build a rollback was mitigating, with a green CI. Six assertions: (1) `deploy-app-web`'s `if:` carries both the hold-clear condition and the `app_changed` guard; (2) the gate is job-level — the single `pages deploy` call in the whole workflow lives inside that job, so a step-level "fix" that still runs the post-deploy curl smoke and Playwright boot check against a withheld deploy would fail; (3) `notify-app-web-held` carries the hold-set condition, wires in `secrets.DISCORD_DEPLOY_WEBHOOK`, and its **`run:` body** both POSTs to that webhook via `curl` and names the variable to clear — asserted against the shell body, not the whole job block, so the gate condition and the `env:` key cannot satisfy it vacuously; (4) the two conditions are exact complements, so neither can drift without the other catching it; (5) `notify-success` derives its held flag from `needs.deploy-app-web.result == 'skipped'` (never by re-reading `vars.`) and prints it through an `if`/`elif` chain where a real deploy wins; (6) the export's `EXPO_PUBLIC_*` stay at 2-space workflow-level indent, which is what `scripts/mobile-ci-env-parity.test.ts`'s `^  KEY:` extractor requires. The test lives in `deploy/app-subdomain/__tests__/` rather than `scripts/` because the `deploy-config` job in `ci.yml` runs `vp test run --project deploy-app-subdomain` **unfiltered** whenever `production-deploy.yml` changes — `scripts/*` tests only run under `--changed`, whose module-graph selection can never relate an fs-read of a workflow file to a diff of that file.

2. **The notify-success accuracy fix** — a held run currently prints `app.boardsesh.com: unchanged`, which is false and exactly the invisibility the hold's Discord ping exists to prevent. Adds an `APP_WEB_HELD` flag and a `held (APP_WEB_DEPLOY_HOLD set)` line.

   The flag reads off **what `deploy-app-web` actually did** — `needs.deploy-app-web.result == 'skipped' && needs.detect-changes.outputs.app_changed == 'true'` — rather than re-reading `vars.APP_WEB_DEPLOY_HOLD` in the step. `notify-success` declares `environment: Production`, so a step-level `vars.` lookup there resolves Production _environment_ variables as well as repository ones, while the gate is a job-level `if:` that only ever sees repository variables. Re-reading would print "held" for a deploy that actually shipped whenever an operator scoped the variable to the environment — the exact operator error the new runbook warns about, and the worst-direction lie to hand an incident responder. The hold is the only reason `deploy-app-web` skips while `app_changed` is `'true'`; a cancellation short-circuits this job via its own `!contains(needs.*.result, 'cancelled')`.

   The two branches are an `if`/`elif`, not an override, so a successful deploy always wins over the held line. With no hold set the expression renders `false`, no new branch is taken, and the printed message is byte-identical to before.

3. **The docs runbook extension** — `docs/expo-web-deployment.md`'s existing "Freezing the subdomain deploy" section covered set/clear semantics and the Discord ping but not the who/where the issue asked for: that it must be a **repository** variable (not environment-scoped — the gate is a job-level `if:`, evaluated before `environment: Production` resolves), that its **value must be non-empty** (the gate is `== ''`, so `gh variable set` with an empty body is a hold that does nothing at all), the `gh variable set/list/delete` commands, and that it must be cleared before the next intended deploy. The release path is ordered by blast radius: **re-run the held run** first — what the Discord ping itself tells you to do, and `detect-changes` plus every job `if:` re-evaluate, so a mobile-only push re-runs to ship the subdomain and nothing else — then wait for the next qualifying merge, then `gh workflow run production-deploy.yml`, with an explicit note that a manual dispatch marks web, backend _and_ app changed and therefore redeploys Vercel and Railway too.

4. **README edit** — `deploy/app-subdomain/README.md` now enumerates the directory's contents accurately (including the new `tsconfig.json`) and documents the new test file's purpose and why it lives here. The "why here" claim is narrowed to what is true: `deploy-config` is the only gate that _selects a test suite_ for a workflow-only diff, not the only gate that fires at all — `service-deploy-inputs.yml` lists `production-deploy.yml` in its paths filter and runs on such a diff too, it just runs no tests over it.

**Deviation from the plan (not requested by the plan, required by the pre-commit hook):** also adds `deploy/app-subdomain/tsconfig.json`. The new test reads files via `node:fs`/`node:path`/`import.meta.dirname`, the same pattern the pre-existing (already-merged) `cloudflare-config.ts` uses. Without a local `tsconfig.json`, oxlint's type-aware lint (`lint.options.typeCheck` in the root `vite.config.ts`) can't resolve those when it type-checks a file here by **explicit path** — which is exactly what the `vp staged` pre-commit hook does (confirmed the same pre-existing `cloudflare-config.ts` fails the identical way under `vp check <path>` today, unrelated to this PR). Modeled on `scripts/tsconfig.json`'s existing pattern. It is **not** wired into `vp run typecheck` (this directory has no `package.json`, so it isn't a bun workspace package the aggregate task iterates) and is not read by the `deploy-app-subdomain` vitest project — it exists solely to give the pre-commit hook's per-file lint a project context. Full unscoped `vp check` never touched this directory before or after (confirmed) so this doesn't change what CI's `deploy-config` job checks either — the vitest run stays the correctness oracle, as the plan says.

The Cloudflare Pages API check (comparing `latest_deployment.id` against `canonical_deployment.id` to detect a pinned rollback automatically) is explicitly out of scope per the issue — the field name is inferred from the Vercel analogue and unverified, and no live Cloudflare call is possible from this environment.

Part of #4358
Closes #4360

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

Rebased onto `origin/main` at `d9a4a4ad7`, then:

- `vp run typecheck` — green. (The `board-slug-utils.test.ts` failure reported on the first revision was a `main` regression, fixed upstream by `d9a4a4ad7` and picked up by the rebase.)
- `vp test run --project deploy-app-subdomain --reporter=agent` — 3 files, 13 tests passed (7 pre-existing + 6 new).
- `vp test run --reporter=agent --project web` — 485 files, 5944 tests passed. (The 4 failures on the first revision were the same `main` regression; green after the rebase.)
- `vp test run --reporter=agent scripts/mobile-ci-env-parity.test.ts` — 34 passed. It is the other fs-reader of this workflow.
- `vp run check:service-deploy-inputs` — passed. It is the other gate that fires on a `production-deploy.yml` diff.
- `vp check` over the four changed paths — 9 files correctly formatted, no warnings, lint errors, or type errors. Two unrelated pre-existing formatting issues remain in `docs/design/web-reposition/*.html`, untouched by this diff, dating to commit `19268ee78`; reproduced on a checkout carrying none of this PR's changes. CI's PR lint step is scoped to changed `*.ts|tsx|js|mjs|cjs` files (`ci.yml:231-253`), so `.html` is out of scope in both directions.

**Mutation proof** — each mutation applied alone to `production-deploy.yml`, the suite re-run, then the file restored. All six fail a test; none was committed:

| Mutation                                                                       | Result                                                                 |
| ------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
| Drop `&& vars.APP_WEB_DEPLOY_HOLD == ''` from `deploy-app-web`'s `if:`          | 2 failed (`skips deploy-app-web…`, `pairs the gate and the ping…`)      |
| Strip every mention of `APP_WEB_DEPLOY_HOLD` from the held-run Discord `printf` | 1 failed (`announces every held run on Discord`)                        |
| Replace the `curl` POST in `notify-app-web-held` with `cat`                     | 1 failed (`announces every held run on Discord`)                        |
| Drop `&& …app_changed == 'true'` from `APP_WEB_HELD`                            | 1 failed (`reports a hold in the success notification…`)                |
| Revert `APP_WEB_HELD` to re-reading `vars.APP_WEB_DEPLOY_HOLD != ''`            | 1 failed (`reports a hold in the success notification…`)                |
| Turn the `elif` back into an unconditional override `if`                        | 1 failed (`reports a hold in the success notification…`)                |

Mutations 2, 3, 4 and 6 all passed silently on the first revision — adversarial QA proved the message and webhook assertions read the whole job block, which already contains both strings via the gate condition and the `env:` key. They are load-bearing now.

**Shell truth table** for the rewritten `notify-success` branch, executed directly:

| `APP_WEB_RESULT` | `APP_WEB_HELD` | printed                          |
| ---------------- | -------------- | -------------------------------- |
| `success`        | `true`         | `deployed`                       |
| `success`        | `false`        | `deployed`                       |
| `skipped`        | `true`         | `held (APP_WEB_DEPLOY_HOLD set)` |
| `skipped`        | `false`        | `unchanged`                      |
| (empty)          | `true`         | `held (APP_WEB_DEPLOY_HOLD set)` |
| (empty)          | `false`        | `unchanged`                      |

`success` never prints `held` — the inversion QA reproduced against the first revision is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6Ur37Pg6Ro9kyFxUr8r97
