### PR TITLE
fix(mobile): read the signed-in id from the browser session

### DIFF
--- a/packages/mobile/src/hooks/__tests__/use-current-user-id.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-current-user-id.test.tsx
@@ -4,19 +4,15 @@ import type { ReactNode } from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-const { getAuthToken } = vi.hoisted(() => ({ getAuthToken: vi.fn<() => Promise<string | null>>() }));
+const { readLocalUserId } = vi.hoisted(() => ({
+  readLocalUserId: vi.fn<() => Promise<string | undefined>>(),
+}));
 
-vi.mock('../../lib/auth-store', () => ({ getAuthToken }));
+// The platform fork under this hook is covered by `local-user-id.test.ts` and
+// `local-user-id.web.test.ts`; here only the React Query wrapper is under test.
+vi.mock('../../lib/local-user-id', () => ({ readLocalUserId }));
 
 import { useStoredUserId } from '../use-current-user-id';
-
-function base64Url(value: string): string {
-  return Buffer.from(value, 'utf8').toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
-
-function tokenForUser(userId: string): string {
-  return `${base64Url('{"alg":"HS256"}')}.${base64Url(JSON.stringify({ sub: userId }))}.signature`;
-}
 
 function wrapper() {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -27,34 +23,34 @@ function wrapper() {
 
 describe('useStoredUserId', () => {
   beforeEach(() => {
-    getAuthToken.mockReset();
+    readLocalUserId.mockReset();
   });
 
-  it('resolves the id from the stored JWT', async () => {
-    getAuthToken.mockResolvedValue(tokenForUser('user-42'));
+  it('resolves the id the device can answer locally', async () => {
+    readLocalUserId.mockResolvedValue('user-42');
     const { result } = renderHook(() => useStoredUserId(true).userId, { wrapper: wrapper() });
     await waitFor(() => expect(result.current).toBe('user-42'));
   });
 
-  it('stays undefined when the keychain has no token', async () => {
-    getAuthToken.mockResolvedValue(null);
+  it('stays undefined when the device has no id to answer with', async () => {
+    readLocalUserId.mockResolvedValue(undefined);
     const { result } = renderHook(() => useStoredUserId(true).userId, { wrapper: wrapper() });
-    await waitFor(() => expect(getAuthToken).toHaveBeenCalled());
+    await waitFor(() => expect(readLocalUserId).toHaveBeenCalled());
     expect(result.current).toBeUndefined();
   });
 
-  it('stays undefined when the stored token is malformed', async () => {
-    getAuthToken.mockResolvedValue('not-a-jwt');
-    const { result } = renderHook(() => useStoredUserId(true).userId, { wrapper: wrapper() });
-    await waitFor(() => expect(getAuthToken).toHaveBeenCalled());
-    expect(result.current).toBeUndefined();
+  it('caches "no id" as a real answer instead of failing the query', async () => {
+    readLocalUserId.mockResolvedValue(undefined);
+    const { result } = renderHook(() => useStoredUserId(true), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.userId).toBeUndefined();
   });
 
-  it('never touches the keychain while disabled (signed out, or the profile already answered)', async () => {
-    getAuthToken.mockResolvedValue(tokenForUser('user-42'));
+  it('never reads while disabled (signed out, or the profile already answered)', async () => {
+    readLocalUserId.mockResolvedValue('user-42');
     const { result } = renderHook(() => useStoredUserId(false), { wrapper: wrapper() });
     await Promise.resolve();
-    expect(getAuthToken).not.toHaveBeenCalled();
+    expect(readLocalUserId).not.toHaveBeenCalled();
     expect(result.current.userId).toBeUndefined();
     // A disabled query is "pending" in React Query terms; callers gate their
     // loading state on this, so it must read as settled.
@@ -62,16 +58,16 @@ describe('useStoredUserId', () => {
   });
 
   it('reports the in-flight read so callers can hold their loading state', async () => {
-    let releaseToken!: (token: string) => void;
-    getAuthToken.mockReturnValue(
+    let releaseUserId!: (userId: string) => void;
+    readLocalUserId.mockReturnValue(
       new Promise<string>((resolve) => {
-        releaseToken = resolve;
+        releaseUserId = resolve;
       }),
     );
     const { result } = renderHook(() => useStoredUserId(true), { wrapper: wrapper() });
     await waitFor(() => expect(result.current.isLoading).toBe(true));
 
-    releaseToken(tokenForUser('user-7'));
+    releaseUserId('user-7');
     await waitFor(() => expect(result.current.userId).toBe('user-7'));
     expect(result.current.isLoading).toBe(false);
   });

--- a/packages/mobile/src/hooks/use-current-user-id.ts
+++ b/packages/mobile/src/hooks/use-current-user-id.ts
@@ -1,32 +1,41 @@
 import { useQuery } from '@tanstack/react-query';
-import { getAuthToken } from '../lib/auth-store';
-import { userIdFromJwt } from '../lib/jwt-user-id';
+import { readLocalUserId } from '../lib/local-user-id';
 
+/**
+ * Historical key name: on web the id no longer comes from a JWT (see below). It
+ * stays as-is because the string is internal to React Query, and renaming it
+ * would churn every consumer and mock for nothing.
+ */
 export const STORED_USER_ID_QUERY_KEY = ['storedJwtUserId'] as const;
 
 export type StoredUserId = {
   userId: string | undefined;
-  /** The keychain read is still in flight — not yet "there is no id". */
+  /** The local read is still in flight — not yet "there is no id". */
   isLoading: boolean;
 };
 
 /**
- * The signed-in user's id, read from the JWT already sitting in SecureStore.
+ * The signed-in user's id, from whatever this device can answer without the
+ * network — `readLocalUserId`, the platform-forked source.
  *
  * `useProfile` is a plain network query, so with no signal it never answers and
  * every screen keyed on the profile id (My Boards' owned-vs-followed split) has
- * to degrade. The id is on the device regardless: the backend signs the native
- * JWT with `sub: userId`, the same id compared against `board.ownerId`. This
- * reads it back so a cold start with no connection can still tell "your boards"
- * from the ones you follow.
+ * to degrade. The id is on the device regardless, it just lives somewhere
+ * different per platform: native decodes the `sub` claim of the JWT in
+ * SecureStore, web reads the identity the browser session already confirmed
+ * (its token is an encrypted JWE with nothing to decode — #4321). Either way
+ * it's the same id compared against `board.ownerId`, so a start with no
+ * connection can still tell "your boards" from the ones you follow.
  *
- * Display-only — see `userIdFromJwt`'s warning; the decode is unverified.
+ * Display-only — the native decode is unverified (see `userIdFromJwt`) and the
+ * web read reports what a past session confirmed, not what the server says now.
  *
- * Nothing new has to be cleared at sign-out: the id lives in the JWT that
- * `clearTokens()` deletes, and this query's cached copy goes with
- * `queryClient.clear()` in `runSignedOutCleanup`. That's the whole reason it
- * derives the id instead of persisting a second identity field — one less thing
- * that can outlive an account on a shared device.
+ * Nothing new has to be cleared at sign-out: on native the id lives in the JWT
+ * that `clearTokens()` deletes, on web in the module-level identity a sign-out
+ * resets, and this query's cached copy goes with `queryClient.clear()` in
+ * `runSignedOutCleanup`. That's the whole reason it derives the id instead of
+ * persisting a second identity field — one less thing that can outlive an
+ * account on a shared device.
  */
 export function useStoredUserId(enabled: boolean): StoredUserId {
   const { data, isLoading } = useQuery({
@@ -34,9 +43,9 @@ export function useStoredUserId(enabled: boolean): StoredUserId {
     // `?? null` because React Query rejects an undefined resolution as a
     // programming error ("Query data cannot be undefined"); "no id" is a real,
     // cacheable answer here.
-    queryFn: async () => userIdFromJwt(await getAuthToken()) ?? null,
+    queryFn: async () => (await readLocalUserId()) ?? null,
     enabled,
-    // The keychain read is cheap but the answer only changes across a sign-in /
+    // The local read is cheap but the answer only changes across a sign-in /
     // sign-out, both of which clear the cache anyway. `gcTime: Infinity` is safe
     // for the same reason: `runSignedOutCleanup`'s `queryClient.clear()` drops
     // the entry, so it can't outlive the account that produced it.

--- a/packages/mobile/src/lib/__tests__/local-user-id.test.ts
+++ b/packages/mobile/src/lib/__tests__/local-user-id.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { getAuthToken } = vi.hoisted(() => ({ getAuthToken: vi.fn<() => Promise<string | null>>() }));
+
+vi.mock('../auth-store', () => ({ getAuthToken }));
+
+import { readLocalUserId } from '../local-user-id';
+
+function base64Url(value: string): string {
+  return Buffer.from(value, 'utf8').toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function nativeJwt(userId: string): string {
+  return `${base64Url('{"alg":"HS256"}')}.${base64Url(JSON.stringify({ sub: userId }))}.signature`;
+}
+
+describe('readLocalUserId (native)', () => {
+  beforeEach(() => {
+    getAuthToken.mockReset();
+  });
+
+  it('reads the sub claim of the stored JWT', async () => {
+    getAuthToken.mockResolvedValue(nativeJwt('user-42'));
+    await expect(readLocalUserId()).resolves.toBe('user-42');
+  });
+
+  it('answers undefined when the keychain has no token', async () => {
+    getAuthToken.mockResolvedValue(null);
+    await expect(readLocalUserId()).resolves.toBeUndefined();
+  });
+
+  it('answers undefined for a malformed token', async () => {
+    getAuthToken.mockResolvedValue('not-a-jwt');
+    await expect(readLocalUserId()).resolves.toBeUndefined();
+  });
+
+  it('answers undefined for the 5-segment compact JWE the browser holds (#4321)', async () => {
+    // The exact shape `auth-store.web.ts` stores as `backendToken`: a compact
+    // JWE (header.encryptedKey.iv.ciphertext.tag), whose claims are encrypted.
+    // This is why the web fork exists — no decode can recover an id from it.
+    const compactJwe = [
+      base64Url('{"alg":"dir","enc":"A256GCM"}'),
+      '',
+      base64Url('initvector'),
+      base64Url('ciphertext-nobody-can-read'),
+      base64Url('authtag'),
+    ].join('.');
+    getAuthToken.mockResolvedValue(compactJwe);
+    await expect(readLocalUserId()).resolves.toBeUndefined();
+  });
+});

--- a/packages/mobile/src/lib/__tests__/local-user-id.web.test.ts
+++ b/packages/mobile/src/lib/__tests__/local-user-id.web.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+type WebAuthIdentity = { userId: string; authSessionId: string };
+
+const { captureConfirmedWebAuthIdentity, getAuthToken } = vi.hoisted(() => ({
+  captureConfirmedWebAuthIdentity: vi.fn<() => WebAuthIdentity | null>(),
+  getAuthToken: vi.fn<() => Promise<string | null>>(),
+}));
+
+// Mocked as a factory so the real module — BroadcastChannel, crypto, and its
+// module-level session state — never loads in this test.
+vi.mock('../auth-store.web', () => ({ captureConfirmedWebAuthIdentity, getAuthToken }));
+
+import { readLocalUserId } from '../local-user-id.web';
+
+describe('readLocalUserId (web)', () => {
+  beforeEach(() => {
+    captureConfirmedWebAuthIdentity.mockReset();
+    getAuthToken.mockReset();
+  });
+
+  it('reads the id off the identity the session confirmed', async () => {
+    captureConfirmedWebAuthIdentity.mockReturnValue({ userId: 'user-42', authSessionId: 'session-1' });
+    await expect(readLocalUserId()).resolves.toBe('user-42');
+  });
+
+  it('answers undefined while no identity is confirmed', async () => {
+    captureConfirmedWebAuthIdentity.mockReturnValue(null);
+    await expect(readLocalUserId()).resolves.toBeUndefined();
+  });
+
+  it('never consults the token, whose claims are encrypted (#4321)', async () => {
+    captureConfirmedWebAuthIdentity.mockReturnValue({ userId: 'user-7', authSessionId: 'session-2' });
+    getAuthToken.mockResolvedValue('header.encryptedkey.iv.ciphertext.tag');
+    await expect(readLocalUserId()).resolves.toBe('user-7');
+    expect(getAuthToken).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/local-user-id.ts
+++ b/packages/mobile/src/lib/local-user-id.ts
@@ -1,0 +1,19 @@
+import { getAuthToken } from './auth-store';
+import { userIdFromJwt } from './jwt-user-id';
+
+/**
+ * The signed-in user's id this device can answer WITHOUT the network — the id
+ * `board.ownerId` is compared against, so "your boards" can be told apart from
+ * the ones you follow when `useProfile` (a plain network query) has no answer.
+ *
+ * Display-only on both platforms: native decodes an unverified JWT (see
+ * `userIdFromJwt`), web reports the last identity its session confirmed. Never
+ * feed it into an authorization decision or a mutation payload.
+ */
+export type LocalUserIdReader = () => Promise<string | undefined>;
+
+/**
+ * Native: the backend signs `SignJWT({ sub: userId })`, so the id is already in
+ * the token SecureStore holds and no request has to be made for it.
+ */
+export const readLocalUserId: LocalUserIdReader = async () => userIdFromJwt(await getAuthToken());

--- a/packages/mobile/src/lib/local-user-id.web.ts
+++ b/packages/mobile/src/lib/local-user-id.web.ts
@@ -1,0 +1,19 @@
+import { captureConfirmedWebAuthIdentity } from './auth-store.web';
+import type { LocalUserIdReader } from './local-user-id';
+
+/**
+ * Browser sessions have no readable token id: `getAuthToken()` returns the
+ * backend's 5-segment compact JWE, whose claims are encrypted, so the native
+ * JWT decode reads it as "no id" and My Boards falls back to one flat list
+ * (#4321). The id is already in this tab — `/api/auth/session` confirmed it
+ * before the token was ever paired with it — so read it from there.
+ *
+ * Null until the first session synchronisation confirms an identity, which
+ * always happens before AuthProvider flips `isAuthenticated` (the only thing
+ * that enables the caller). Fails soft either way: no id means the old flat
+ * list, never a wrong id.
+ *
+ * `import type` above is the compile-time parity guard against the native
+ * sibling; it is fully erased, so no native module reaches the web bundle.
+ */
+export const readLocalUserId: LocalUserIdReader = async () => captureConfirmedWebAuthIdentity()?.userId;


### PR DESCRIPTION
## Summary

Refs #4321.

`useStoredUserId` is the fallback that lets My Boards split owned-vs-followed when `useProfile` (a plain network query) has no answer. It read the id by decoding the `sub` claim of whatever `getAuthToken()` returned. On native that's the backend-signed 3-segment JWT, so it works. On Expo web `auth-store.web.ts` hands back `backendToken` — the compact JWE minted by `/api/internal/ws-auth`, five segments with encrypted claims — and `userIdFromJwt` bails at its `segments.length !== 3` guard. The hook answered `undefined`, and `manage.tsx:102` fell through to one flat board list.

The fix forks only the id **source**, following the convention already used by the 19 other `*.web.ts` siblings in `packages/mobile/src/lib/`:

- **New `packages/mobile/src/lib/local-user-id.ts`** (native) — exports `type LocalUserIdReader = () => Promise<string | undefined>` and `readLocalUserId`, which keeps the existing `userIdFromJwt(await getAuthToken())` decode.
- **New `packages/mobile/src/lib/local-user-id.web.ts`** — reads `captureConfirmedWebAuthIdentity()?.userId`, the identity `/api/auth/session` confirmed for this tab before the token was ever paired with it. It's a pure getter returning a copy of `{ userId, authSessionId }`, `null` while unconfirmed — no consume-and-clear. `import type { LocalUserIdReader }` from the native sibling is the compile-time parity guard; `import type` is erased, so no native module reaches the web bundle.
- **`packages/mobile/src/hooks/use-current-user-id.ts`** — swaps the two imports for `readLocalUserId`. `useStoredUserId`, `StoredUserId`, `STORED_USER_ID_QUERY_KEY` and its `['storedJwtUserId']` key string, `enabled`, `staleTime`/`gcTime: Infinity` and the `isLoading`-not-`isPending` return are all unchanged; the docstring now describes both sources and notes the key name is historical.

No change to `jwt-user-id.ts`, `manage.tsx`, or `offline-sync-bridge.tsx`.

**Blast radius.** On native, nothing changes — native already got an id. On web, `manage.tsx:102` is the only reachable consumer: the hook's other caller, the local user-data owner stamp at `offline-sync-bridge.tsx:130`, never mounts in a browser, because the browser bundle resolves `offline-sync-bridge.web.tsx`, whose `OfflineSyncBridge` returns `null` and whose `OfflineEngineFlagSync` calls `setOfflineEngineEnabled(false)` + `registerOfflineEngineState('web-off')`. There is no browser offline engine, no browser SQLite user data, and no `pullSync` in a tab, so there is nothing to stamp, serve, or wipe.

**Fails soft.** No confirmed identity means `undefined`, which is exactly today's flat list — never a wrong id. AuthProvider confirms the session identity before it flips the `isAuthenticated` flag that gates the hook, so the unconfirmed window isn't reachable in practice.

No new dependency, no `app.config.ts` / `plugins/` / `modules/` change: JS/TS only, OTA-safe, no `[native-train]` companion.

### Considered and rejected

- **Forking the whole hook** — duplicates the React Query config and the `isLoading` contract across two files and two test files kept in lockstep, for one line of platform I/O.
- **Falling back to `resolveAuthSession()` when no identity is confirmed** — `synchronizeWebSession()` rotates `sessionGeneration` and can invalidate an in-flight credential generation elsewhere in the auth machinery. Too much blast radius for a list header, and the gap is unreachable (see above).
- **Exporting a getter from `user-storage-owner.web.ts`** — same id, but needs a new export on both forks (the native one a no-op stub) for no gain over the already-exported `captureConfirmedWebAuthIdentity`.

## Release Notes

- [x] No release note needed (internal / technical change)

<!--
Deliberate: with a healthy profile query the browser app already splits owned/followed,
so the fallback only engages while `useProfile` is in flight or errored, on the env-gated
Expo browser app behind Next at `/app`. There is no query persister on web yet (#4353),
so there is no offline cold-start story to promise either. A changelog line would describe
a win most users cannot observe.
-->

## Decisions for Marco

Plan decisions flagged `needsMarco` for this PR: **none**. Both PR B decisions were adjudicated as no-Marco-needed; recorded here so the choices are auditable:

1. **Keep `useStoredUserId` / `STORED_USER_ID_QUERY_KEY` / the `['storedJwtUserId']` key string, or rename now that web doesn't read a JWT?** → **Keep all three; only the docs change.** The key has no other reference in the repo and is internal to React Query, so a rename buys nothing while touching three consumers and their mocks. It would also collide with the cold-start persister work (#4353), which may start persisting the query cache.
2. **Should the web reader fall back to `resolveAuthSession()` when no identity has been confirmed yet?** → **No.** Read the confirmed identity only; `undefined` falls back to today's flat list. `synchronizeWebSession()` rotates `sessionGeneration` and can invalidate an in-flight credential generation elsewhere in the auth machinery — too much blast radius for a list header, and AuthProvider confirms the identity before flipping the `isAuthenticated` flag that enables the hook, so the gap isn't reachable.
3. **Does this warrant a user-facing release note?** → **No.** Reasoning in the comment under Release Notes above.

No analytics change: no `SHARED_EVENTS` entry added, removed, or renamed, and no event property touched.

## Test plan

Tests (all new/updated ones use `vi.hoisted` mock fns — mobile CI typechecks test files):

- **NEW `packages/mobile/src/lib/__tests__/local-user-id.test.ts`** (native, `vi.mock('../auth-store')`): resolves the `sub` of a 3-segment JWT; `undefined` for `null`; `undefined` for a malformed token; `undefined` for a **5-segment compact JWE** built as five base64url segments — the exact #4321 input, pinned where the fork is justified.
- **NEW `packages/mobile/src/lib/__tests__/local-user-id.web.test.ts`** (`// @vitest-environment jsdom`, `vi.mock('../auth-store.web')` as a hoisted factory so the real module's BroadcastChannel / crypto / module-level session state never loads): returns `userId` when an identity is confirmed; `undefined` when the getter returns `null`; and the token is never consulted when an identity is present.
- **UPDATED `packages/mobile/src/hooks/__tests__/use-current-user-id.test.tsx`** — mocks `'../../lib/local-user-id'` instead of `'../../lib/auth-store'`, keeping all five behaviours (resolves the id; undefined when the reader has none; "no id" caches as a real answer rather than failing the query; never reads while disabled and reports `isLoading: false`; reports the in-flight read via a deferred promise). The malformed-token case moved down to the native fork's own test.
- `packages/mobile/src/lib/__tests__/jwt-user-id.test.ts` and `packages/mobile/app/boards/__tests__/manage-offline.test.tsx` unchanged — the latter mocks `useStoredUserId` directly, so it already covers the owned/followed split given an id.

Commands run locally, all green:

- `vp run typecheck:mobile` → `@boardsesh/mobile typecheck $ tsc --noEmit` Done in 4.73 s
- `vp run test:mobile` → **Test Files 647 passed (647), Tests 5897 passed (5897)**
- `vp test run --reporter=agent` on the three touched files → **3 passed, 12 passed**
- `vp run check:mobile-bundle` → `[mobile-bundle] android bundle: OK`
- `vp run check:mobile-web-bundle` → `[mobile-web-bundle] Expo web export is complete and contains the required shell and WASM assets` (this PR adds a `.web.ts` fork, so the export check is the gate that the web bundle still builds)
- `vp check` → clean for every file this PR touches. It reports pre-existing formatting issues in `docs/design/web-reposition/{gyms-directory,homepage-marketing}.html`, both landed on `main` in `19268ee78` and untouched here.

Browser QA to run before this leaves draft (`vp run dev:mobile:web`, Expo browser app behind Next at `/app`, signed in):

1. Force the fallback deterministically with an **uncommitted** one-line local edit: in `packages/mobile/app/boards/manage.tsx:96`, change `useProfile({ enabled: isAuthenticated })` to `useProfile({ enabled: false })`. That leaves `useMyBoards` on the network so the board list still loads, while `useStoredUserId` becomes the only id source. Do **not** try to force it by blocking `/graphql` in DevTools — `useProfile` and `useMyBoards` share one transport (`getHttpClient().request`), so blocking it empties the board list and the split can't appear either way.
2. With the edit on `main`: flat list (reproduces #4321). With the edit on this branch: **Your boards** / **Following** headers. Revert the edit and confirm the profile-driven split groups the same boards under the same headers — proving the session id is the id `board.ownerId` is compared against.
3. Second account in a private window, same forced-fallback edit: the split reflects *that* account's ownership (no id leaking across tabs).
4. Sign out and back in as the same user: the split still renders, no error state.
5. Native regression pass on a dev client: My Boards still splits owned/followed and the app still comes up signed in.

Explicitly **not** a QA step: anything about local SQLite user data, the owner stamp, or offline reads in the browser — `offline-sync-bridge.web.tsx` returns `null` and registers `offline_engine_state = 'web-off'`.
