### PR TITLE
fix(sync): stop reporting zero grade rows a later cycle never counted

### DIFF
--- a/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
+++ b/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
@@ -103,7 +103,9 @@ import type {
 } from '@boardsesh/offline-sync';
 
 // The engine package is vi.mock'd above, so its `emptyScopeDownloadPhases`
-// helper is unreachable here — this literal stands in for it.
+// helper is unreachable here — this literal stands in for it. Neither grade row
+// count appears, mirroring the real helper: the engine omits both rather than
+// reporting a count it cannot vouch for (issue #4393).
 const NO_PHASES = {
   manifestMs: 0,
   downloadMs: 0,
@@ -113,7 +115,6 @@ const NO_PHASES = {
   climbsPullMs: 0,
   statsPullMs: 0,
   gradesPullMs: 0,
-  gradesRows: 0,
 };
 
 // What the adapter actually emits from a zeroed breakdown: download/import/bytes
@@ -125,7 +126,6 @@ const NO_PHASE_PROPS = {
   climbsPullMs: 0,
   statsPullMs: 0,
   gradesPullMs: 0,
-  gradesRows: 0,
 };
 
 const db = {} as OfflineDatabase;
@@ -557,6 +557,79 @@ describe('snapshot-bootstrap bindings', () => {
       gradesRows: 500,
       offlineEngineEnabled: false,
     });
+  });
+
+  it('omits gradesRows when the engine could not count this cycle’s grade rows', () => {
+    startSyncScheduler(
+      db,
+      queryClient,
+      graphqlFetch,
+      () => [],
+      async () => {},
+    );
+    const options = startSyncSchedulerCore.mock.calls[0][6] as SchedulerOptions;
+    options.onScopeDownloadComplete?.({
+      scopeKey: 'kilter:1:5',
+      method: 'snapshot',
+      durationMs: 1234,
+      phases: { ...NO_PHASES, gradesPullMs: 134 },
+    });
+
+    const properties = trackMock.mock.calls[0][1] as Record<string, unknown>;
+    // Structural: an explicit `gradesRows: undefined` would read as a value in
+    // PostHog, so the key must not be on the object at all.
+    expect(Object.hasOwn(properties, 'gradesRows')).toBe(false);
+    expect(Object.hasOwn(properties, 'gradesArtifactRows')).toBe(false);
+    expect(properties.gradesPullMs).toBe(134);
+  });
+
+  it('forwards the grade rows the artifact imported', () => {
+    startSyncScheduler(
+      db,
+      queryClient,
+      graphqlFetch,
+      () => [],
+      async () => {},
+    );
+    const options = startSyncSchedulerCore.mock.calls[0][6] as SchedulerOptions;
+    options.onScopeDownloadComplete?.({
+      scopeKey: 'kilter:1:5',
+      method: 'snapshot',
+      durationMs: 1234,
+      phases: { ...NO_PHASES, gradesArtifactRows: 41232, gradesRows: 0 },
+    });
+
+    const properties = trackMock.mock.calls[0][1] as Record<string, unknown>;
+    expect(properties.gradesArtifactRows).toBe(41232);
+    // A real measurement here — the artifact left the crawl nothing to fetch.
+    expect(properties.gradesRows).toBe(0);
+  });
+
+  it('forwards the healed-bootstrap flag so snapshot-vs-paged percentiles can filter on it', () => {
+    startSyncScheduler(
+      db,
+      queryClient,
+      graphqlFetch,
+      () => [],
+      async () => {},
+    );
+    const options = startSyncSchedulerCore.mock.calls[0][6] as SchedulerOptions;
+    options.onScopeDownloadComplete?.({
+      scopeKey: 'kilter:1:5',
+      method: 'snapshot',
+      durationMs: 1234,
+      bootstrapHealed: true,
+      phases: NO_PHASES,
+    });
+    options.onScopeDownloadComplete?.({
+      scopeKey: 'kilter:1:6',
+      method: 'paged',
+      durationMs: 900,
+      phases: NO_PHASES,
+    });
+
+    expect((trackMock.mock.calls[0][1] as Record<string, unknown>).bootstrapHealed).toBe(true);
+    expect(Object.hasOwn(trackMock.mock.calls[1][1] as Record<string, unknown>, 'bootstrapHealed')).toBe(false);
   });
 
   it('composes per-scope UI invalidation with completion telemetry', () => {

--- a/packages/mobile/src/offline/offline-sync-adapter.ts
+++ b/packages/mobile/src/offline/offline-sync-adapter.ts
@@ -212,11 +212,20 @@ const reportSnapshotBootstrapError: SnapshotBootstrapErrorReporter = ({
 // per-scope timings above are emitted: `phases` also holds cycle-scoped copies
 // of download/import/artifact bytes, and the timings' absent-when-unknown
 // versions are the honest ones (a 0 from a later-cycle completion would read as
-// a real measurement).
+// a real measurement). The same rule now covers the two grade row counts
+// (issue #4393): the engine omits `gradesRows` when this cycle only picked up
+// the tail of a crawl an earlier cycle started, and omits `gradesArtifactRows`
+// when no grades artifact imported this cycle — a 0 for either would read as
+// "this board has no grades".
+// `bootstrapHealed` is emitted because the engine's own doc makes it the
+// required filter for snapshot-vs-paged percentile comparisons (a healed scope's
+// duration excludes the paged work earlier cycles did) — it was computed and
+// then silently dropped here, which made that comparison unanswerable.
 const reportScopeDownloadComplete: ScopeDownloadCompleteReporter = ({
   scopeKey,
   method,
   durationMs,
+  bootstrapHealed,
   bytes,
   rowCount,
   downloadMs,
@@ -230,6 +239,7 @@ const reportScopeDownloadComplete: ScopeDownloadCompleteReporter = ({
     // Spread rather than set: the engine omits these when the completing delta
     // pull landed in a later cycle than the import, and an omitted prop is the
     // honest answer where a 0 would look like a real measurement.
+    ...(bootstrapHealed === undefined ? {} : { bootstrapHealed }),
     ...(bytes === undefined ? {} : { bytes }),
     ...(rowCount === undefined ? {} : { rowCount }),
     ...(downloadMs === undefined ? {} : { downloadMs }),
@@ -239,7 +249,8 @@ const reportScopeDownloadComplete: ScopeDownloadCompleteReporter = ({
     climbsPullMs: phases.climbsPullMs,
     statsPullMs: phases.statsPullMs,
     gradesPullMs: phases.gradesPullMs,
-    gradesRows: phases.gradesRows,
+    ...(phases.gradesRows === undefined ? {} : { gradesRows: phases.gradesRows }),
+    ...(phases.gradesArtifactRows === undefined ? {} : { gradesArtifactRows: phases.gradesArtifactRows }),
     // Stamped so the funnel stays readable once #4312 bakes the flag on: the
     // engine gate, not the raw flag value.
     offlineEngineEnabled: isOfflineEngineEnabled(),

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -359,15 +359,34 @@ export const SHARED_EVENTS = {
   // expected value — the trigger is persisted per scope, but a scope enabled by
   // a build that predates this event has none.
   OfflineBoardDownloadStarted: 'Offline Board Download Started',
-  // Fired once per board scope when its INITIAL download completes (both tables
-  // reached the tail), so the snapshot-bootstrap warm-up can be compared against
-  // the plain paged crawl in the field. Props: { scopeKey,
+  // Fired once per board scope when its INITIAL download completes (every board
+  // table reached the tail), so the snapshot-bootstrap warm-up can be compared
+  // against the plain paged crawl in the field. Props: { scopeKey,
   // method: 'snapshot' | 'paged', durationMs, bytes?, rowCount?, downloadMs?,
-  // importMs?, offlineEngineEnabled }. The four optional props are ABSENT rather
-  // than faked when the completing delta pull lands in a later cycle than the
-  // import, which biases them toward the healthy population; durationMs and the
-  // funnel ratio are unaffected. Mobile-only today (the engine is shared, so a
-  // future web offline consumer would fire this too).
+  // importMs?, bootstrapHealed?, manifestMs, artifactReused, climbsPullMs,
+  // statsPullMs, gradesPullMs, gradesRows?, gradesArtifactRows?,
+  // offlineEngineEnabled }.
+  // Every optional prop is ABSENT rather than faked when this cycle cannot vouch
+  // for it — most often because the completing delta pull landed in a later cycle
+  // than the import. That biases those props toward the healthy population;
+  // durationMs and the funnel ratio are unaffected. Read a missing value as
+  // UNKNOWN, never as 0.
+  // Grade rows a completion landed this cycle = (gradesArtifactRows ?? 0) +
+  // (gradesRows ?? 0), meaningful only when at least one key is present.
+  // `gradesRows` counts the paged crawl and is present only when that crawl
+  // started from a cursor no earlier cycle advanced; `gradesArtifactRows` counts
+  // the grades artifact's own import and is what makes a truthful `gradesRows: 0`
+  // (the artifact left the crawl nothing to fetch) readable next to a board that
+  // genuinely has no grades. Events from before issue #4393 shipped carry a
+  // fabricated `gradesRows: 0`, so window those series from that merge date.
+  // Filter on `bootstrapHealed != true` before comparing snapshot-vs-paged
+  // durationMs percentiles: a healed scope (#4313) reports method 'snapshot' but
+  // a duration that excludes the paged work earlier cycles did.
+  // Deliberately NOT emitted: the breakdown's own `downloadMs`, `importMs` and
+  // `artifactBytes` — the per-scope timings above carry the honest,
+  // absent-when-unknown versions of the same numbers, so re-adding the phase
+  // copies would put a cycle-scoped 0 next to them. Mobile-only today (the engine
+  // is shared, so a future web offline consumer would fire this too).
   OfflineBoardDownloadCompleted: 'Offline Board Download Completed',
   // A bootstrap stage failed, or was cut short. Props: { scopeKey, stage:
   // 'manifest' | 'download' | 'import' | 'grades-download' | 'grades-import',

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -13,7 +13,12 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { QueryInvalidator } from '../../database';
-import { pullSync, type SyncProgress } from '../pull-client';
+import {
+  pullSync,
+  emptyScopeDownloadPhases,
+  type SyncProgress,
+  type ScopeDownloadPhaseBreakdown,
+} from '../pull-client';
 import type { SnapshotBootstrapProgress } from '../snapshot-progress';
 import {
   bootstrapScopeFromSnapshot,
@@ -252,15 +257,30 @@ function compareCursor(a: Cursor, b: Cursor): number {
  * tail page). Every other query is an empty page. Captures the cursor each board
  * query received so delta continuity can be asserted.
  */
-function makeGraphqlFetch(options?: { climbServerRows?: Array<{ doc: Record<string, unknown>; cursor: Cursor }> }) {
+function makeGraphqlFetch(options?: {
+  climbServerRows?: Array<{ doc: Record<string, unknown>; cursor: Cursor }>;
+  gradeServerRows?: Array<{ doc: Record<string, unknown>; cursor: Cursor }>;
+}) {
   const capturedClimbCursors: Array<Cursor | undefined> = [];
   const capturedStatsCursors: Array<Cursor | undefined> = [];
+  const capturedGradeCursors: Array<Cursor | undefined> = [];
   const emptyCursor: Cursor = { updatedAt: '1970-01-01T00:00:00.000Z', syncSeq: '0' };
 
   const fetch = vi.fn(async <T>(query: string, variables?: Record<string, unknown>): Promise<T> => {
     const cursor = variables?.cursor as Cursor | undefined;
     if (query.includes('syncDeletions')) {
       return { syncDeletions: { deletions: [], cursor: emptyCursor, hasMore: false } } as T;
+    }
+    if (query.includes('syncClimbGrades')) {
+      capturedGradeCursors.push(cursor);
+      const rows = (options?.gradeServerRows ?? []).filter((row) => !cursor || compareCursor(row.cursor, cursor) > 0);
+      if (rows.length === 0) {
+        return { syncClimbGrades: { documents: [], cursor: cursor ?? emptyCursor, hasMore: false } } as T;
+      }
+      const last = rows[rows.length - 1];
+      return {
+        syncClimbGrades: { documents: rows.map((row) => row.doc), cursor: last.cursor, hasMore: false },
+      } as T;
     }
     if (query.includes('syncClimbStats')) {
       capturedStatsCursors.push(cursor);
@@ -284,7 +304,29 @@ function makeGraphqlFetch(options?: { climbServerRows?: Array<{ doc: Record<stri
 
   // Keep the generic call signature pullSync expects AND the mock's `.mock`.
   const typedFetch = fetch as unknown as GraphqlFetchMock;
-  return { fetch: typedFetch, capturedClimbCursors, capturedStatsCursors };
+  return { fetch: typedFetch, capturedClimbCursors, capturedStatsCursors, capturedGradeCursors };
+}
+
+/**
+ * `count` grade rows the paged crawl can consume, all stamped after the grades
+ * artifact's watermark so they survive a cursor the artifact already advanced.
+ */
+function gradeServerRows(count: number): Array<{ doc: Record<string, unknown>; cursor: Cursor }> {
+  return Array.from({ length: count }, (_unused, index) => {
+    const syncSeq = String(100 + index);
+    const computedAt = '2026-06-01T00:00:00.000Z';
+    return {
+      doc: {
+        board_type: 'kilter',
+        climb_uuid: `crawled-grade-${index}`,
+        angle: 40,
+        local_grade: 20,
+        computed_at: computedAt,
+        sync_seq: Number(syncSeq),
+      },
+      cursor: { updatedAt: computedAt, syncSeq },
+    };
+  });
 }
 
 type GraphqlFetchMock = ReturnType<typeof vi.fn> &
@@ -3164,7 +3206,84 @@ describe('pullSync scope-download phase breakdown', () => {
     for (const key of ['manifestMs', 'downloadMs', 'importMs', 'climbsPullMs', 'statsPullMs', 'gradesPullMs']) {
       expect(phases[key], key).toBeGreaterThanOrEqual(0);
     }
+    // A fresh crawl with no grades checkpoint and genuinely zero rows: the 0 is a
+    // real measurement, so the key is PRESENT. No grades artifact rode along, so
+    // that key is absent rather than 0 (issue #4393).
     expect(phases.gradesRows).toBe(0);
+    expect(Object.hasOwn(phases, 'gradesRows')).toBe(true);
+    expect(Object.hasOwn(phases, 'gradesArtifactRows')).toBe(false);
+  });
+
+  it('counts the grade rows a same-cycle fresh crawl consumed', async () => {
+    const onScopeDownloadComplete = vi.fn();
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch({ gradeServerRows: gradeServerRows(3) }).fetch, {
+      enabledBoards: ['kilter:1:5'],
+      onScopeDownloadComplete,
+    });
+
+    const { phases } = onScopeDownloadComplete.mock.calls[0][0] as { phases: ScopeDownloadPhaseBreakdown };
+    expect(phases.gradesRows).toBe(3);
+    expect(Object.hasOwn(phases, 'gradesArtifactRows')).toBe(false);
+    expect(phases.gradesPullMs).toBeGreaterThanOrEqual(0);
+  });
+
+  // The #4393 regression anchor: a cycle that only picked up the tail of a crawl
+  // an EARLIER cycle started has no idea how many rows the board has, and the 0
+  // it used to report read as "this board has no grades" in the #4310 analysis.
+  it('omits gradesRows when an earlier cycle already crawled the grades', async () => {
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      'checkpoint:board_climb_grades:kilter:1:5',
+      JSON.stringify({ updatedAt: '2026-05-01T00:00:00.000Z', syncSeq: '10' }),
+    ]);
+    const onScopeDownloadComplete = vi.fn();
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      onScopeDownloadComplete,
+    });
+
+    const call = onScopeDownloadComplete.mock.calls[0][0] as {
+      method: string;
+      durationMs: number | null;
+      phases: ScopeDownloadPhaseBreakdown;
+    };
+    expect(call.phases.gradesRows).toBeUndefined();
+    // Structural, not just undefined: a re-introduced 0 must fail here.
+    expect(Object.hasOwn(call.phases, 'gradesRows')).toBe(false);
+    expect(Object.hasOwn(call.phases, 'gradesArtifactRows')).toBe(false);
+    // The timings are unaffected — they are real measurements of this cycle.
+    expect(typeof call.phases.gradesPullMs).toBe('number');
+    expect(typeof call.phases.manifestMs).toBe('number');
+    expect(call.method).toBe('paged');
+    expect(call.durationMs).not.toBeUndefined();
+  });
+
+  it('omits gradesRows when an earlier cycle’s crawl is only being finished', async () => {
+    // The partial-tail case: 2 rows this cycle, nothing distinguishing them from
+    // the tail of 40,000 an earlier cycle already pulled.
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      'checkpoint:board_climb_grades:kilter:1:5',
+      JSON.stringify({ updatedAt: '2026-05-01T00:00:00.000Z', syncSeq: '10' }),
+    ]);
+    const onScopeDownloadComplete = vi.fn();
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch({ gradeServerRows: gradeServerRows(2) }).fetch, {
+      enabledBoards: ['kilter:1:5'],
+      onScopeDownloadComplete,
+    });
+
+    const { phases } = onScopeDownloadComplete.mock.calls[0][0] as { phases: ScopeDownloadPhaseBreakdown };
+    expect(await countRows('board_climb_grades')).toBe(2);
+    expect(phases.gradesRows).toBeUndefined();
+    expect(Object.hasOwn(phases, 'gradesRows')).toBe(false);
+    expect(phases.gradesPullMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('emptyScopeDownloadPhases() reports no grade counts', () => {
+    const phases = emptyScopeDownloadPhases();
+    expect(Object.hasOwn(phases, 'gradesRows')).toBe(false);
+    expect(Object.hasOwn(phases, 'gradesArtifactRows')).toBe(false);
   });
 
   it('measures a download that spans cycles from its FIRST cycle, not the last', async () => {
@@ -3530,6 +3649,138 @@ describe('pullSync grades bootstrap', () => {
       updatedAt: '2026-05-02T00:00:00Z',
       syncSeq: '21',
     });
+  });
+
+  // The dominant snapshot path, and the shape that made the naive "a checkpoint
+  // existed ⇒ report nothing" rule unreadable: the artifact stamps the grades
+  // checkpoint mid-cycle, so the delta crawl behind it truthfully consumes 0
+  // rows. gradesArtifactRows is what says where the grades actually came from.
+  it('reports the artifact’s grade rows when the crawl behind it has nothing left to fetch', async () => {
+    const climbsPath = join(workDir, 'grades-rows-climbs.db');
+    buildArtifact({
+      filePath: climbsPath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const gradesPath = join(workDir, 'grades-rows-grades.db');
+    buildGradesArtifact({
+      filePath: gradesPath,
+      grades: [
+        { climbUuid: 'c1', angle: 40, computedAt: '2026-05-02T00:00:00Z', syncSeq: 21 },
+        { climbUuid: 'c1', angle: 45, computedAt: '2026-05-02T00:00:00Z', syncSeq: 21 },
+      ],
+      watermark: { updatedAt: '2026-05-02T00:00:00Z', syncSeq: '21' },
+    });
+    const { source } = makeGradesSource({
+      manifest: makeManifest([makeEntry({ grades: gradesArtifactBlock() })]),
+      climbsFile: climbsPath,
+      gradesFile: gradesPath,
+    });
+    const onScopeDownloadComplete = vi.fn();
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onScopeDownloadComplete,
+    });
+
+    const { phases } = onScopeDownloadComplete.mock.calls[0][0] as { phases: ScopeDownloadPhaseBreakdown };
+    expect(phases.gradesArtifactRows).toBe(2);
+    // A real measurement of the crawl, not a fabricated one — so it stays present.
+    expect(phases.gradesRows).toBe(0);
+    expect(Object.hasOwn(phases, 'gradesRows')).toBe(true);
+  });
+
+  it('still counts the crawl behind a same-cycle grades artifact', async () => {
+    const climbsPath = join(workDir, 'grades-delta-climbs.db');
+    buildArtifact({
+      filePath: climbsPath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const gradesPath = join(workDir, 'grades-delta-grades.db');
+    buildGradesArtifact({
+      filePath: gradesPath,
+      grades: [{ climbUuid: 'c1', computedAt: '2026-05-02T00:00:00Z', syncSeq: 21 }],
+      watermark: { updatedAt: '2026-05-02T00:00:00Z', syncSeq: '21' },
+    });
+    const { source } = makeGradesSource({
+      manifest: makeManifest([makeEntry({ grades: gradesArtifactBlock() })]),
+      climbsFile: climbsPath,
+      gradesFile: gradesPath,
+    });
+    const onScopeDownloadComplete = vi.fn();
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch({ gradeServerRows: gradeServerRows(4) }).fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onScopeDownloadComplete,
+    });
+
+    const { phases } = onScopeDownloadComplete.mock.calls[0][0] as { phases: ScopeDownloadPhaseBreakdown };
+    // The artifact's own mid-cycle checkpoint stamp must not read as an earlier cycle.
+    expect(phases.gradesRows).toBe(4);
+    expect(phases.gradesArtifactRows).toBe(1);
+  });
+
+  it('carries no grades row counts when the artifact imported in an earlier cycle', async () => {
+    const climbsPath = join(workDir, 'grades-spanning-climbs.db');
+    buildArtifact({
+      filePath: climbsPath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const gradesPath = join(workDir, 'grades-spanning-grades.db');
+    buildGradesArtifact({
+      filePath: gradesPath,
+      grades: [{ climbUuid: 'c1', computedAt: '2026-05-02T00:00:00Z', syncSeq: 21 }],
+      watermark: { updatedAt: '2026-05-02T00:00:00Z', syncSeq: '21' },
+    });
+    const { source, gradesDownloads } = makeGradesSource({
+      manifest: makeManifest([makeEntry({ grades: gradesArtifactBlock() })]),
+      climbsFile: climbsPath,
+      gradesFile: gradesPath,
+    });
+
+    // Cycle 1 imports both artifacts, then the phone backgrounds the moment the
+    // board-data loop starts crawling — the scope does not complete.
+    const backgroundingFetch = makeGraphqlFetch();
+    const cycleOneFetch = ((query: string, variables?: Record<string, unknown>) => {
+      if (query.includes('syncClimbs')) setBackgrounded(true);
+      return backgroundingFetch.fetch(query, variables);
+    }) as unknown as typeof backgroundingFetch.fetch;
+    const neverCompletes = vi.fn();
+    await pullSync(db, noopQueryClient(), cycleOneFetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onScopeDownloadComplete: neverCompletes,
+    });
+    expect(neverCompletes).not.toHaveBeenCalled();
+    expect(gradesDownloads).toEqual([gradesArtifactBlock().key]);
+    setBackgrounded(false);
+
+    // Cycle 2 finishes the crawl. Nothing it did wrote a grade row: the artifact
+    // landed yesterday and the crawl resumes from the cursor it stamped.
+    const onScopeDownloadComplete = vi.fn();
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onScopeDownloadComplete,
+    });
+
+    expect(onScopeDownloadComplete).toHaveBeenCalledTimes(1);
+    const { phases } = onScopeDownloadComplete.mock.calls[0][0] as { phases: ScopeDownloadPhaseBreakdown };
+    expect(gradesDownloads).toHaveLength(1);
+    expect(phases.gradesRows).toBeUndefined();
+    expect(phases.gradesArtifactRows).toBeUndefined();
+    expect(Object.hasOwn(phases, 'gradesRows')).toBe(false);
+    expect(Object.hasOwn(phases, 'gradesArtifactRows')).toBe(false);
   });
 
   // Retention (#4310) keeps an UNIMPORTED whole-layout artifact for the next

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -128,6 +128,11 @@ export type SyncProgress = {
  * Monday and whose delta pull finished on Tuesday reports Tuesday's crawl time
  * with zeros for manifest/download/import. Read the phases as "where this
  * cycle's time went", not as a partition of `durationMs`.
+ *
+ * The ROW COUNTS below are OPTIONAL rather than zeroed for exactly that reason
+ * (issue #4393): a timing this cycle did not spend really is 0ms of this cycle's
+ * time, but a row count this cycle cannot vouch for is not 0 rows — it is
+ * unknown, and a fabricated 0 reads as "this board has no grades".
  */
 export type ScopeDownloadPhaseBreakdown = {
   /** Resolving the manifest. 0 for every scope after the first in a cycle (it is cached per run). */
@@ -144,11 +149,46 @@ export type ScopeDownloadPhaseBreakdown = {
   climbsPullMs: number;
   statsPullMs: number;
   gradesPullMs: number;
-  /** Rows the grades crawl consumed this cycle — the denominator for gradesPullMs. */
-  gradesRows: number;
+  /**
+   * Rows the PAGED grades crawl consumed this cycle — the denominator for
+   * `gradesPullMs`. Present iff this cycle's crawl started from a cursor no
+   * EARLIER cycle advanced: either no grades checkpoint existed, or the only one
+   * that existed was stamped by this cycle's own grades artifact.
+   *
+   * ABSENT (never 0) when the crawl resumed from an earlier cycle's checkpoint.
+   * The rows those cycles wrote are not counted here, so any number would be a
+   * silent under-report — the same reason `downloadMs`/`importMs` go absent on
+   * a completion whose import landed in an earlier cycle.
+   *
+   * Known imprecision on a HEALED scope (#4313 — an artifact imported over a
+   * partly-crawled catalog): both arms can be true at once, so this counts only
+   * this cycle's crawl above the artifact watermark while earlier cycles' grade
+   * rows go unreported. `bootstrapHealed` is the filter for that population.
+   */
+  gradesRows?: number;
+  /**
+   * Rows this cycle's grades-artifact import wrote (`INSERT OR REPLACE`
+   * changes). Absent when no grades artifact imported this cycle: no
+   * `entry.grades` in the manifest, no `source.downloadGradesArtifact`, an
+   * unusable or attempt-exhausted artifact, or the import landed in an earlier
+   * cycle.
+   *
+   * This is what makes a `gradesRows: 0` readable. The artifact stamps the
+   * grades checkpoint mid-cycle, so the delta crawl behind it legitimately
+   * consumes 0 rows: `gradesRows: 0` next to `gradesArtifactRows: 41232` means
+   * the artifact did the work, while `gradesRows: 0` with no
+   * `gradesArtifactRows` means the scope genuinely has no grade rows. Grade rows
+   * landed this cycle = `(gradesArtifactRows ?? 0) + (gradesRows ?? 0)`,
+   * meaningful only when at least one of the two is present.
+   */
+  gradesArtifactRows?: number;
 };
 
-/** A zeroed breakdown: what a scope reports before any phase has run. */
+/**
+ * A zeroed breakdown: what a scope reports before any phase has run.
+ * `gradesRows` and `gradesArtifactRows` are deliberately ABSENT rather than 0 —
+ * see their docs.
+ */
 export function emptyScopeDownloadPhases(): ScopeDownloadPhaseBreakdown {
   return {
     manifestMs: 0,
@@ -159,7 +199,6 @@ export function emptyScopeDownloadPhases(): ScopeDownloadPhaseBreakdown {
     climbsPullMs: 0,
     statsPullMs: 0,
     gradesPullMs: 0,
-    gradesRows: 0,
   };
 }
 
@@ -576,12 +615,18 @@ async function syncTable(
   boardScope?: BoardScope,
   onProgress?: (documentsProcessed: number) => void,
   onSchemaDrift?: SchemaDriftReporter,
-): Promise<{ reachedTail: boolean }> {
+): Promise<{ reachedTail: boolean; rowsProcessed: number; resumedFromCheckpoint: boolean }> {
   const config = TABLE_CONFIGS[tableName];
   if (!config) throw new Error(`No sync config for table: ${tableName}`);
 
   const checkpointKey = getCheckpointKey(tableName, boardScope?.scopeKey);
   const checkpoint = await getCheckpoint(db, checkpointKey);
+  // Whether some earlier call already advanced this cursor, so the caller can
+  // tell "these are all the rows" from "these are the tail of a crawl someone
+  // else started" (issue #4393). Sound because `setCheckpoint` below only runs
+  // after a NON-EMPTY page: a table that genuinely never had rows never leaves
+  // a checkpoint behind.
+  const resumedFromCheckpoint = checkpoint !== null;
   const query = buildSyncQuery(config.queryName, config.isPerBoard);
 
   let cursor: SyncCursorInput | undefined = checkpoint
@@ -605,7 +650,8 @@ async function syncTable(
   while (hasMore) {
     // Sign-out is wiping local data: stop before this page writes the old
     // user's rows back (mirrors the drainer's guard).
-    if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) return { reachedTail: false };
+    if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded())
+      return { reachedTail: false, rowsProcessed: totalProcessed, resumedFromCheckpoint };
     const variables: Record<string, unknown> = { cursor, limit: PAGE_LIMIT };
     if (config.isPerBoard && boardScope) {
       variables.boardType = boardScope.boardType;
@@ -618,7 +664,8 @@ async function syncTable(
 
     // Re-check after the await: the wipe may have started (or fully completed)
     // while this page was on the wire.
-    if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) return { reachedTail: false };
+    if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded())
+      return { reachedTail: false, rowsProcessed: totalProcessed, resumedFromCheckpoint };
 
     // An empty page would not advance the cursor; if the backend ever returns
     // documents:[] with hasMore:true we'd spin forever. Stop here (I2).
@@ -646,7 +693,7 @@ async function syncTable(
 
   // Both loop exits here mean the server has nothing more for this cursor:
   // hasMore === false, or an empty page (the tail). Aborts return early above.
-  return { reachedTail: true };
+  return { reachedTail: true, rowsProcessed: totalProcessed, resumedFromCheckpoint };
 }
 
 async function processDeletions(
@@ -1126,13 +1173,21 @@ async function runBootstrapPhase(params: {
     if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) return;
 
     try {
-      await bootstrapScopeGradesFromSnapshot({
+      const { rowsImported } = await bootstrapScopeGradesFromSnapshot({
         db,
         scope,
         scopeKey: scope.scopeKey,
         filePath: gradesDownload.filePath,
         onSchemaDrift,
       });
+      // The artifact's own row count, reported alongside the paged crawl's
+      // (issue #4393): it is what tells a truthful `gradesRows: 0` — the crawl
+      // behind a fresh artifact has nothing left to fetch — apart from a board
+      // that has no grades at all. Accumulating rather than assigning because
+      // the two call sites (post-import and the retrofit path) are mutually
+      // exclusive per scope today, and `+=` stays correct if that changes.
+      const phases = phaseTimings(scope.scopeKey);
+      phases.gradesArtifactRows = (phases.gradesArtifactRows ?? 0) + rowsImported;
       for (const key of TABLE_CONFIGS.board_climb_grades.invalidateKeys) {
         queryClient.invalidateQueries({ queryKey: key });
       }
@@ -2204,8 +2259,7 @@ export async function pullSync(
       // in one shot) apart from board_climb_grades, which the artifact does not
       // carry at all and which therefore crawls page by page every time.
       const tableStartedAt = Date.now();
-      let tableRows = 0;
-      const { reachedTail } = await syncTable(
+      const { reachedTail, rowsProcessed, resumedFromCheckpoint } = await syncTable(
         db,
         queryClient,
         graphqlFetch,
@@ -2213,7 +2267,6 @@ export async function pullSync(
         cycleEpoch,
         boardScope,
         (tableProcessed) => {
-          tableRows = tableProcessed;
           totalDocuments = baseCount + tableProcessed;
           onProgress?.({
             phase: 'board_data',
@@ -2228,8 +2281,18 @@ export async function pullSync(
       if (tableName === 'board_climbs') phases.climbsPullMs += tableMs;
       else if (tableName === 'board_climb_stats') phases.statsPullMs += tableMs;
       else if (tableName === 'board_climb_grades') {
+        // gradesPullMs accumulates unconditionally — it is a real measurement of
+        // this cycle either way. The row count is absent-when-unknown (#4393): a
+        // crawl that resumed from an EARLIER cycle's checkpoint consumed only a
+        // tail, so no number here is the import, and the 0 this used to emit read
+        // as "this board has no grades" in the #4310 analysis. A checkpoint THIS
+        // cycle's own grades artifact stamped is not an earlier cycle: the crawl
+        // behind it really did consume these rows, and gradesArtifactRows (set by
+        // importGradesForScope) says where the rest went.
         phases.gradesPullMs += tableMs;
-        phases.gradesRows += tableRows;
+        if (!resumedFromCheckpoint || phases.gradesArtifactRows !== undefined) {
+          phases.gradesRows = (phases.gradesRows ?? 0) + rowsProcessed;
+        }
       }
       if (!reachedTail) allTablesReachedTail = false;
     }


### PR DESCRIPTION
## Summary

Refs #4393.

`Offline Board Download Completed` was reporting `gradesRows: 0` on completions where the number was not 0 but unknown. `ScopeDownloadPhaseBreakdown.gradesRows` was initialised to 0 and emitted unconditionally, so a scope whose grades crawl only picked up a tail an earlier cycle had already advanced reported a fabricated `gradesRows: 0` sitting next to correctly-absent `downloadMs`/`importMs` — indistinguishable from a board that genuinely has no grade rows. That is the number the #4310 read (snapshot vs paged download cost) has to divide `gradesPullMs` by.

Three changes, all in the completion event's grades story:

**1. `gradesRows` becomes absent-when-unknown.** It is present only when this cycle's crawl started from a cursor no earlier cycle advanced — either no grades checkpoint existed, or the only one that existed was stamped by this cycle's own grades artifact. `syncTable` now returns `{ reachedTail, rowsProcessed, resumedFromCheckpoint }`; the `resumedFromCheckpoint` signal is sound because `setCheckpoint` only runs after a NON-EMPTY page, so a table that genuinely never had rows never leaves a checkpoint behind. A partial count from a resumed crawl is suppressed too: nothing distinguishes "500 rows, the whole import" from "500 rows, the tail of 40,000", which is the same class of lie as the 0.

**2. A new `gradesArtifactRows` keeps the remaining honest 0 readable.** `bootstrapScopeGradesFromSnapshot` stamps the grades checkpoint mid-cycle, so on the dominant snapshot path the delta crawl behind the artifact legitimately consumes 0 rows. Suppressing that would blank the grade numbers for the whole snapshot population; emitting a bare `0` would be just as unreadable as the bug. So the artifact's own `rowsImported` (already returned by the import, previously discarded) is now reported. `gradesRows: 0` next to `gradesArtifactRows: 41232` means the artifact did the work; `gradesRows: 0` with neither an artifact nor an earlier checkpoint means the scope really has no grades.

**3. `bootstrapHealed` starts being emitted.** The engine has computed it since #4313 and its own doc names it the required filter for snapshot-vs-paged percentile comparisons (a healed scope's `durationMs` excludes the paged work earlier cycles did) — but `reportScopeDownloadComplete` destructured everything except that flag, so it never reached PostHog and the comparison is unanswerable in today's data. One conditional spread, plus a test.

`gradesPullMs` still accumulates unconditionally: it is a real measurement of this cycle either way. Rate queries just have to filter on `gradesRows is set`.

No `SHARED_EVENTS` entry is added, removed, or renamed. The funnel invariant from #4391 is untouched — no new exit path, no early return, only the property set on the existing terminal Completed event.

### Reading the new shape

- Grade rows a completion landed this cycle = `(gradesArtifactRows ?? 0) + (gradesRows ?? 0)`, meaningful only when at least one key is present. A missing value is **unknown**, never 0 — treating it as 0 reintroduces the bug on the read side.
- Events from before this merges carry the fabricated `gradesRows: 0`, so window the #4310 series from the merge date.
- The share of completions carrying `gradesRows` at all is the new health signal: it is the share of downloads that finished in the same cycle that did their grades work.

### Decisions for Marco

Three plan decisions were flagged `needsMarco`; the defaults below are what shipped.

1. **A grades crawl that resumes from an earlier cycle's checkpoint and consumes some rows: partial count, or absent?** → **Absent.** A partial count is the same lie as the 0. Cost: a multi-cycle download (backgrounded phone mid-crawl) reports no row denominator for `gradesPullMs` at all. The alternative — a durable cumulative counter in `sync_meta` — needs persisted state that scope teardown must clear and a persisted `gradesPullMs` to pair it with; that is a redesign, not a small fix.
2. **The artifact stamps the grades checkpoint mid-cycle, so the delta crawl behind it truthfully consumes 0 rows — fold the artifact rows into `gradesRows`, go absent on the whole snapshot path, or mint a new property?** → **Mint `gradesArtifactRows`.** Folding would silently redefine a shipped property and break its pairing with `gradesPullMs` (artifact rows cost ~0 crawl ms). Going absent on the snapshot path would leave a snapshot completion reporting no grade numbers whatsoever. Cost: one permanent property name.
3. **`bootstrapHealed`: emit here, or file a follow-up?** → **Emit here**, absent-when-unknown, with an adapter test. The #4310 read this work exists to unblock is exactly the comparison the engine says is invalid without this filter. Cost: a second permanent property name in a small PR.

Both new property names are permanent once shipped.

### Deviations from the plan

None affecting behaviour. Two notes: `vp check` fails on this branch only for two pre-existing unformatted files under `docs/design/web-reposition/` that are already unformatted on `main` and untouched here; `vp lint` reports 30 pre-existing errors, all in `packages/web` tests and `scripts/`, none in the files this PR touches.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

Six new engine tests and three new adapter tests pin every shape of the fix.

`packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts`

- updated `reports the artifact bytes and a per-table paged-crawl split…` — a fresh crawl with genuinely zero rows keeps `gradesRows: 0` **present** (`Object.hasOwn`), with no `gradesArtifactRows`
- `counts the grade rows a same-cycle fresh crawl consumed` — N crawled rows report N
- `omits gradesRows when an earlier cycle already crawled the grades` — the #4393 regression anchor; a hand-seeded `checkpoint:board_climb_grades:*` plus an empty page must not bring the 0 back (structural `Object.hasOwn` assertion, so an explicit `undefined` also fails)
- `omits gradesRows when an earlier cycle's crawl is only being finished` — the partial-tail case (2 rows land, no count reported)
- `reports the artifact's grade rows when the crawl behind it has nothing left to fetch` — the dominant snapshot path: `gradesArtifactRows: K`, `gradesRows: 0` present
- `still counts the crawl behind a same-cycle grades artifact` — the artifact's own mid-cycle stamp must not read as an earlier cycle
- `carries no grades row counts when the artifact imported in an earlier cycle` — cycle 1 imports and backgrounds, cycle 2 completes: both keys absent
- `emptyScopeDownloadPhases() reports no grade counts`

`packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts`

- `omits gradesRows when the engine could not count this cycle's grade rows`
- `forwards the grade rows the artifact imported`
- `forwards the healed-bootstrap flag so snapshot-vs-paged percentiles can filter on it`

Commands run in the worktree:

- `vp run typecheck:mobile` — Done in 17.88s, no errors
- `vp run typecheck:offline-sync` — Done in 1.42s, no errors
- `vp run typecheck:analytics` — Done in 479ms, no errors
- `vp run test:mobile` — 645 files / 5893 tests passed
- `vp test run --reporter=agent packages/shared/offline-sync/src` — 29 files / 613 tests passed
- `vp run check:mobile-bundle` — `android bundle: OK`
- `vp lint` — no new findings in the touched files

JS/TS only, no native deps or config touched, so this rides OTA with no `[native-train]` companion.

**Field verification is after merge, not before.** Nothing on-device can reproduce the later-cycle shape deterministically (the seeded checkpoint in the suite can). Once the OTA lands: a Kilter re-download backgrounded mid-grades-crawl should produce one Completed whose `gradesRows` and `gradesArtifactRows` keys are both **missing** from the event JSON; a snapshot-path re-download should carry `gradesArtifactRows` in the tens of thousands. The fleet check is *not* "zero `gradesRows: 0` events" — an artifact-supplied scope reports a truthful 0 — it is zero completions carrying `gradesRows: 0` with **no** `gradesArtifactRows` for a layout known to have grades.
