### PR TITLE
fix(sync): a pocketed phone pauses a board download instead of killing it (1/2)

### DIFF
--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -485,7 +485,8 @@ pre-import empty result set.
   restores the static caption, and stops passing `onProgress` into `File.downloadFileAsync` at the
   source (`use-snapshot-source.ts`) — that callback makes expo take a different **native** download
   implementation, so the flag has to restore the original call exactly, not just hide the UI. It drops
-  the progress **option** and nothing else: the wrapper still forwards `releaseArtifact` and
+  the download **options** (`onProgress`, and with it `signal` — pre-existing and deliberate, since the
+  restored call must be byte-identical) but never a capability: the wrapper still forwards `releaseArtifact` and
   `downloadGradesArtifact`, because omitting `releaseArtifact` made the engine fall back to
   `deleteArtifact` and throw away a completed-but-unimported artifact at the end of every cycle —
   silently opting this cohort out of retention (#4310) and out of the backgrounding fix below.

--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -484,7 +484,43 @@ pre-import empty result set.
   in `feature-flags-provider.tsx`, because the frozen spinner is the bug). Off does two things:
   restores the static caption, and stops passing `onProgress` into `File.downloadFileAsync` at the
   source (`use-snapshot-source.ts`) — that callback makes expo take a different **native** download
-  implementation, so the flag has to restore the original call exactly, not just hide the UI.
+  implementation, so the flag has to restore the original call exactly, not just hide the UI. It drops
+  the progress **option** and nothing else: the wrapper still forwards `releaseArtifact` and
+  `downloadGradesArtifact`, because omitting `releaseArtifact` made the engine fall back to
+  `deleteArtifact` and throw away a completed-but-unimported artifact at the end of every cycle —
+  silently opting this cohort out of retention (#4310) and out of the backgrounding fix below.
+
+- **Backgrounding: a pocketed phone pauses a download, it does not kill it (issue #4390)**. The rule
+  `runBootstrapPhase` encodes is **start new work only in the foreground; never kill work already in
+  flight**. A wipe / sign-out / board removal still aborts the transfer the instant it lands — the rows
+  the artifact is for are being deleted, so its bytes are worthless — but a backgrounding does not. On
+  Android the process stays alive, so simply not cancelling is the whole fix there.
+
+  Whether a dead transfer counts as a free **pause** or a real transport failure is a deliberately
+  narrow test, and both halves matter:
+  - the **suspension window** must still be open. It opens when the app backgrounds mid-transfer and
+    **closes on the first byte delivered in the foreground** — after that the transfer demonstrably
+    survived the pocket, so a later failure belongs to the network or the device. Without the closing
+    rule, one screen lock during a nine-minute Android transfer would launder every subsequent wifi
+    drop, HTTP 500 or disk error into a free, cooldown-free 100 MB retry loop.
+  - the cause must be **network-shaped** (`isNetworkError`), which is what a suspension kill produces
+    (`NSURLErrorNetworkConnectionLost`, a timeout, a `SocketException`) and what a disk-full or an
+    HTTP 500 is not.
+
+  Free pauses are **bounded at three per scope** (`MAX_FREE_BACKGROUND_PAUSES`, persisted as
+  `BootstrapRetryState.backgroundPauses`). The fourth is charged to the **transport** budget on its
+  ladder, so the worst case terminates at 3 free + 3 transport restarts, after which the board still
+  arrives via the paged crawl and "Try the fast download again" is the consented escape. Any completed
+  download resets the counter (`clearTransportFailures`) — landed bytes prove the device can finish one.
+  The bound also closes a hole that predates this work: a self-aborted background transfer used to be
+  free with no bound at all. An older bundle rolled back onto the new row reads the missing key as 0 and
+  simply loses the bound, which is the pre-#4390 behaviour, not a corruption.
+
+  A transfer that **finishes** while backgrounded is never a pause. The file is on disk with its
+  `.complete` sidecar, the phase hands it back through `releaseArtifact({ imported: false })`, and the
+  next foreground cycle returns it as `reused: true` with zero bytes re-fetched. The grades stage
+  follows the same rule: `importGradesForScope` checks the teardown reason before spending one of the
+  three attempts that artifact ever gets.
 
 - **Download fallback status**: My Boards keeps the normal per-row download state (`pending`,
   `downloading`, or `downloaded`) and separately derives a `BoardDownloadNotice` from the persisted

--- a/packages/mobile/src/offline/__tests__/use-snapshot-source.test.tsx
+++ b/packages/mobile/src/offline/__tests__/use-snapshot-source.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+//
+// The gate that hands the engine snapshot I/O, and the `offline-download-progress`
+// kill switch's wrapper. The wrapper is the interesting half: it only ever meant
+// to drop the `onProgress` OPTION, and dropping a capability along with it
+// silently opted this cohort out of artifact retention (issue #4390).
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cleanup, renderHook } from '@testing-library/react';
+import type { SnapshotSource } from '@boardsesh/offline-sync';
+
+const flags = vi.hoisted(() => ({
+  offlineDownloadsEnabled: true,
+  snapshotBootstrapEnabled: true,
+  downloadProgressEnabled: true,
+}));
+
+const sourceSpies = vi.hoisted(() => ({
+  fetchManifest: vi.fn(async () => null),
+  downloadArtifact: vi.fn(async () => null),
+  downloadGradesArtifact: vi.fn(async () => null),
+  deleteArtifact: vi.fn(async () => {}),
+  releaseArtifact: vi.fn(async () => {}),
+}));
+
+vi.mock('../../lib/env', () => ({ isSnapshotBaseUrlConfigured: () => true }));
+vi.mock('../../providers/feature-flags-provider', () => ({
+  useOfflineDownloadsEnabled: () => flags.offlineDownloadsEnabled,
+  useSnapshotBootstrapEnabled: () => flags.snapshotBootstrapEnabled,
+  useOfflineDownloadProgressEnabled: () => flags.downloadProgressEnabled,
+}));
+vi.mock('../snapshot-source', () => ({ mobileSnapshotSource: sourceSpies }));
+
+import { useSnapshotSource } from '../use-snapshot-source';
+
+function renderSource(): SnapshotSource | undefined {
+  return renderHook(() => useSnapshotSource()).result.current;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  flags.offlineDownloadsEnabled = true;
+  flags.snapshotBootstrapEnabled = true;
+  flags.downloadProgressEnabled = true;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('useSnapshotSource', () => {
+  it('hands out the full source when every gate is on', () => {
+    expect(renderSource()).toBe(sourceSpies);
+  });
+
+  it('withholds snapshot I/O when the snapshot-bootstrap flag is off', () => {
+    flags.snapshotBootstrapEnabled = false;
+    expect(renderSource()).toBeUndefined();
+  });
+
+  it('withholds snapshot I/O when the offline kill switch is off', () => {
+    flags.offlineDownloadsEnabled = false;
+    expect(renderSource()).toBeUndefined();
+  });
+
+  describe('with download progress off', () => {
+    beforeEach(() => {
+      flags.downloadProgressEnabled = false;
+    });
+
+    it('drops the onProgress option from downloadArtifact', async () => {
+      const source = renderSource();
+      await source?.downloadArtifact({ url: 'https://example.test/a.db' } as never, {
+        onProgress: () => {},
+        signal: new AbortController().signal,
+      });
+
+      expect(sourceSpies.downloadArtifact).toHaveBeenCalledTimes(1);
+      expect(sourceSpies.downloadArtifact).toHaveBeenCalledWith({ url: 'https://example.test/a.db' });
+    });
+
+    it('still forwards releaseArtifact, so a background-completed artifact is RETAINED', async () => {
+      // Without this the engine falls back to deleteArtifact and throws away the
+      // ~100 MB a pocketed phone just finished downloading (issues #4310/#4390),
+      // aimed squarely at the users who turned this switch off because their
+      // downloads are slow.
+      const source = renderSource();
+      expect(source?.releaseArtifact).toBeTypeOf('function');
+
+      await source?.releaseArtifact?.('/cache/kilter-1.db', { imported: false });
+
+      expect(sourceSpies.releaseArtifact).toHaveBeenCalledWith('/cache/kilter-1.db', { imported: false });
+    });
+
+    it('still forwards downloadGradesArtifact', async () => {
+      const source = renderSource();
+      expect(source?.downloadGradesArtifact).toBeTypeOf('function');
+
+      await source?.downloadGradesArtifact?.({ key: 'grades-1' } as never);
+
+      expect(sourceSpies.downloadGradesArtifact).toHaveBeenCalledWith({ key: 'grades-1' });
+    });
+  });
+});

--- a/packages/mobile/src/offline/use-snapshot-source.ts
+++ b/packages/mobile/src/offline/use-snapshot-source.ts
@@ -24,8 +24,10 @@ import { mobileSnapshotSource } from './snapshot-source';
  * to stay, or the row sits on "Downloading 0 MB of 103 MB" for the whole
  * download with the switch supposedly off.
  *
- * The ONLY thing this wrapper drops is the `onProgress` OPTION — never a
- * capability. It used to omit `releaseArtifact` and `downloadGradesArtifact`
+ * This wrapper drops the download OPTIONS — `onProgress`, and with it `signal`,
+ * which is pre-existing and deliberate (the first paragraph: the restored call
+ * must be byte-identical) — never a CAPABILITY. It used to omit
+ * `releaseArtifact` and `downloadGradesArtifact`
  * too, which silently opted this cohort out of artifact retention (#4310): the
  * engine falls back to `deleteArtifact`, so a download that completed while the
  * phone was in a pocket was deleted at the end of the cycle and re-fetched from

--- a/packages/mobile/src/offline/use-snapshot-source.ts
+++ b/packages/mobile/src/offline/use-snapshot-source.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import type { SnapshotManifestEntry, SnapshotSource } from '@boardsesh/offline-sync';
+import type { SnapshotGradesArtifact, SnapshotManifestEntry, SnapshotSource } from '@boardsesh/offline-sync';
 import { isSnapshotBaseUrlConfigured } from '../lib/env';
 import {
   useOfflineDownloadProgressEnabled,
@@ -23,12 +23,27 @@ import { mobileSnapshotSource } from './snapshot-source';
  * any of them — see `snapshotFrame` in `app/boards/manage.tsx`. Both reads have
  * to stay, or the row sits on "Downloading 0 MB of 103 MB" for the whole
  * download with the switch supposedly off.
+ *
+ * The ONLY thing this wrapper drops is the `onProgress` OPTION — never a
+ * capability. It used to omit `releaseArtifact` and `downloadGradesArtifact`
+ * too, which silently opted this cohort out of artifact retention (#4310): the
+ * engine falls back to `deleteArtifact`, so a download that completed while the
+ * phone was in a pocket was deleted at the end of the cycle and re-fetched from
+ * byte 0 on the next wake — exactly the failure #4390 exists to remove, aimed at
+ * exactly the users who turned the switch off because their downloads are slow.
  */
 function withoutDownloadProgress(source: SnapshotSource): SnapshotSource {
+  const { downloadGradesArtifact, releaseArtifact } = source;
   return {
     fetchManifest: () => source.fetchManifest(),
     downloadArtifact: (entry: SnapshotManifestEntry) => source.downloadArtifact(entry),
     deleteArtifact: (filePath: string) => source.deleteArtifact(filePath),
+    ...(downloadGradesArtifact
+      ? { downloadGradesArtifact: (artifact: SnapshotGradesArtifact) => downloadGradesArtifact(artifact) }
+      : {}),
+    ...(releaseArtifact
+      ? { releaseArtifact: (filePath: string, options: { imported: boolean }) => releaseArtifact(filePath, options) }
+      : {}),
   };
 }
 

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -47,6 +47,10 @@ export {
   beginLocalPurge,
   setBackgrounded,
   isBackgrounded,
+  // Subscribed by the mobile downloader so a transfer can record that the app
+  // was suspended while it ran without opening a second AppState listener
+  // (issue #4390).
+  onTeardown,
 } from './mutation-queue/drainer';
 export type {
   DrainOptions,

--- a/packages/shared/offline-sync/src/sync/__tests__/bootstrap-retry.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/bootstrap-retry.test.ts
@@ -11,6 +11,7 @@ import {
   BOOTSTRAP_RETRY_GRACE_WINDOW_MS,
   EMPTY_BOOTSTRAP_RETRY_STATE,
   MAX_BOOTSTRAP_ATTEMPTS,
+  MAX_FREE_BACKGROUND_PAUSES,
   MAX_STRUCTURAL_REARMS,
   MAX_TRANSPORT_DOWNLOAD_FAILURES,
   canRearmOnNewArtifact,
@@ -23,6 +24,7 @@ import {
   nextRetryState,
   readBootstrapRetryState,
   rearmForNewArtifact,
+  recordBackgroundPause,
   restoreBootstrapRetryBudget,
   shouldSkipPagedPull,
   spendUserRequest,
@@ -140,6 +142,49 @@ describe('budgets', () => {
     for (let failure = 0; failure < MAX_BOOTSTRAP_ATTEMPTS; failure += 1)
       current = burn(current, 'structural-artifact');
     expect(isTerminal(current)).toBe(true);
+  });
+});
+
+describe('recordBackgroundPause', () => {
+  const pause = (from: BootstrapRetryState) =>
+    recordBackgroundPause({ state: from, builtAt: null, now: NOW, random: noJitter });
+
+  it('costs nothing for the first MAX_FREE_BACKGROUND_PAUSES — a pocketed phone is not a fault', () => {
+    let current = state();
+    for (let count = 1; count <= MAX_FREE_BACKGROUND_PAUSES; count += 1) {
+      const result = pause(current);
+      expect(result.charged).toBe(false);
+      expect(result.state.backgroundPauses).toBe(count);
+      expect(result.state.transportFailures).toBe(0);
+      expect(result.state.retryAfter).toBeNull();
+      expect(result.state.hasPriorSnapshotFailure).toBe(false);
+      current = result.state;
+    }
+  });
+
+  it('charges the next one to the transport budget on its ladder', () => {
+    let current = state();
+    for (let count = 0; count < MAX_FREE_BACKGROUND_PAUSES; count += 1) current = pause(current).state;
+
+    const charged = pause(current);
+
+    expect(charged.charged).toBe(true);
+    expect(charged.state.transportFailures).toBe(1);
+    expect(charged.state.lastFailureKind).toBe('transport');
+    expect(charged.state.retryAfter).toBe(NOW + 2 * MINUTE);
+    // Reset as it charges, so the pattern terminates at 3 free + 3 transport
+    // rather than charging every pause from here on.
+    expect(charged.state.backgroundPauses).toBe(0);
+  });
+
+  it('is cleared by a completed download — landed bytes prove the device can finish', () => {
+    const paused = pause(pause(state()).state).state;
+    expect(clearTransportFailures(paused).backgroundPauses).toBe(0);
+  });
+
+  it('is cleared by the user tapping "Try the fast download again"', () => {
+    const paused = pause(pause(state()).state).state;
+    expect(clearRetryStateForUserRequest(paused).backgroundPauses).toBe(0);
   });
 });
 
@@ -506,6 +551,7 @@ describe('bootstrap-retry persistence', () => {
       'kilter:1:5',
       state({
         transportFailures: 2,
+        backgroundPauses: 2,
         structuralFailures: 1,
         structuralRearms: 1,
         lastFailureKind: 'structural-artifact',
@@ -522,6 +568,24 @@ describe('bootstrap-retry persistence', () => {
     );
     expect(migratedFromLegacy).toBe(false);
     expect(reread).toEqual(written);
+  });
+
+  it('defaults a missing backgroundPauses to 0, so a rolled-back bundle only loses the bound', async () => {
+    // The shape an older bundle writes: no `backgroundPauses` key at all. Zero
+    // is the pre-#4390 behaviour (unbounded free pauses), not a corruption.
+    await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+      'bootstrap-retry:kilter:1:5',
+      JSON.stringify({ transportFailures: 1, structuralFailures: 0, hasPriorSnapshotFailure: true }),
+    ]);
+    const { state: recovered, migratedFromLegacy } = await readBootstrapRetryState(
+      db,
+      'kilter:1:5',
+      { now: NOW, random: noJitter },
+      false,
+    );
+    expect(migratedFromLegacy).toBe(false);
+    expect(recovered.backgroundPauses).toBe(0);
+    expect(recovered.transportFailures).toBe(1);
   });
 
   it('treats a corrupt retry row as an un-migrated scope rather than crashing the cycle', async () => {

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -33,6 +33,7 @@ import {
   restoreBootstrapRetryBudget,
   EMPTY_BOOTSTRAP_RETRY_STATE,
   MAX_BOOTSTRAP_ATTEMPTS,
+  MAX_FREE_BACKGROUND_PAUSES,
   MAX_STRUCTURAL_REARMS,
   MAX_TRANSPORT_DOWNLOAD_FAILURES,
 } from '../bootstrap-retry';
@@ -3051,9 +3052,12 @@ describe('artifact release and reuse', () => {
     expect(signals[0]?.aborted).toBe(false);
   });
 
-  it('aborts an in-flight transfer that emits no progress when the app backgrounds', async () => {
-    // The teardown EVENT drives the abort, not the progress callback: a stalled
-    // transfer emits nothing, and that is exactly when cancelling matters.
+  it('does NOT abort an in-flight transfer when the app backgrounds', async () => {
+    // Issue #4390, and the inverse of what this file used to pin. Start new work
+    // only in the foreground; never kill work already in flight. Cancelling on a
+    // screen lock threw away up to 103 MB and restarted from byte 0 on the next
+    // wake — the phone can keep the transfer alive, the engine cannot get the
+    // bytes back.
     const filePath = join(workDir, 'stalled.db');
     buildArtifact({
       filePath,
@@ -3075,12 +3079,306 @@ describe('artifact release and reuse', () => {
       releaseArtifact: vi.fn(async () => {}),
     } as unknown as SnapshotSource;
 
+    try {
+      await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+        enabledBoards: ['kilter:1:5'],
+        snapshotSource: source,
+      });
+    } finally {
+      setBackgrounded(false);
+    }
+
+    expect(seenSignal?.aborted).toBe(false);
+  });
+
+  it('aborts an in-flight transfer when a wipe starts', async () => {
+    // The other half of the same rule: the rows this artifact is for are being
+    // deleted, so its bytes are worthless and the native session must stop now.
+    const filePath = join(workDir, 'wiped-mid-transfer.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    let seenSignal: AbortSignal | undefined;
+    const source = {
+      fetchManifest: vi.fn(async () => makeManifest([makeEntry()])),
+      downloadArtifact: vi.fn(async (_entry: SnapshotManifestEntry, options?: { signal?: AbortSignal }) => {
+        seenSignal = options?.signal;
+        beginLocalPurge();
+        return { filePath };
+      }),
+      deleteArtifact: vi.fn(async () => {}),
+      releaseArtifact: vi.fn(async () => {}),
+    } as unknown as SnapshotSource;
+
     await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
       enabledBoards: ['kilter:1:5'],
       snapshotSource: source,
     });
 
     expect(seenSignal?.aborted).toBe(true);
+  });
+
+  it('a download that completes while backgrounded is retained and reused next cycle', async () => {
+    const filePath = join(workDir, 'completed-while-backgrounded.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const retained = new Set<string>();
+    const firstCycle = makeRetainingSource({
+      manifest: makeManifest([makeEntry()]),
+      fileForEntry: () => filePath,
+      retained,
+    });
+    const backgroundingSource = {
+      ...firstCycle.source,
+      downloadArtifact: vi.fn(async () => {
+        setBackgrounded(true);
+        return { filePath };
+      }),
+    } as unknown as SnapshotSource;
+
+    try {
+      await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+        enabledBoards: ['kilter:1:5'],
+        snapshotSource: backgroundingSource,
+      });
+    } finally {
+      setBackgrounded(false);
+    }
+
+    // Handed back unimported, so a retention-capable source keeps the bytes.
+    expect(firstCycle.released).toEqual([{ filePath, imported: false }]);
+    expect(await countRows('board_climbs')).toBe(0);
+
+    // Next foreground cycle: the same file comes back as reused, no re-fetch.
+    retained.add(filePath);
+    const secondCycle = makeRetainingSource({
+      manifest: makeManifest([makeEntry()]),
+      fileForEntry: () => filePath,
+      retained,
+    });
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: secondCycle.source,
+    });
+
+    expect(secondCycle.downloadedUrls).toEqual([]);
+    expect(await countRows('board_climbs')).toBe(1);
+  });
+
+  it('a transfer that fails while suspended does not burn a transport attempt', async () => {
+    const source = {
+      fetchManifest: vi.fn(async () => makeManifest([makeEntry()])),
+      downloadArtifact: vi.fn(async () => {
+        setBackgrounded(true);
+        // The shape iOS produces when it suspends the app mid-transfer.
+        throw new Error('The network connection was lost.');
+      }),
+      deleteArtifact: vi.fn(async () => {}),
+      releaseArtifact: vi.fn(async () => {}),
+    } as unknown as SnapshotSource;
+    const onSnapshotBootstrapError = vi.fn();
+    const onBootstrapRetryScheduled = vi.fn();
+
+    try {
+      await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+        enabledBoards: ['kilter:1:5'],
+        snapshotSource: source,
+        onSnapshotBootstrapError,
+        onBootstrapRetryScheduled,
+      });
+    } finally {
+      setBackgrounded(false);
+    }
+
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(
+      expect.objectContaining({ stage: 'download', aborted: true, reason: 'aborted-background', attempt: 0 }),
+    );
+    expect(onBootstrapRetryScheduled).not.toHaveBeenCalled();
+    const { state } = await readBootstrapRetryState(db, 'kilter:1:5', { now: BASE_NOW, random: () => 0 }, false);
+    expect(state.transportFailures).toBe(0);
+    expect(state.retryAfter).toBeNull();
+    expect(state.backgroundPauses).toBe(1);
+  });
+
+  it('a backgrounded blip, a foreground recovery, then a real network failure still burns a transport attempt', async () => {
+    // The masked-failure case the suspension window exists to prevent: one
+    // pocketed moment during a nine-minute transfer must not launder every later
+    // wifi drop into a free, cooldown-free 100 MB retry loop.
+    const source = {
+      fetchManifest: vi.fn(async () => makeManifest([makeEntry()])),
+      downloadArtifact: vi.fn(
+        async (
+          _entry: SnapshotManifestEntry,
+          options?: { onProgress?: (progress: { bytesWritten: number; totalBytes: number | null }) => void },
+        ) => {
+          setBackgrounded(true);
+          // Back in the foreground, and a byte lands: the transfer demonstrably
+          // survived, so the suspension window closes.
+          setBackgrounded(false);
+          options?.onProgress?.({ bytesWritten: 4096, totalBytes: null });
+          throw new Error('The network connection was lost.');
+        },
+      ),
+      deleteArtifact: vi.fn(async () => {}),
+      releaseArtifact: vi.fn(async () => {}),
+    } as unknown as SnapshotSource;
+    const onSnapshotBootstrapError = vi.fn();
+    const onBootstrapRetryScheduled = vi.fn();
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onSnapshotBootstrapError,
+      onBootstrapRetryScheduled,
+    });
+
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(
+      expect.objectContaining({ stage: 'download', aborted: false, reason: 'network', attempt: 1 }),
+    );
+    expect(onBootstrapRetryScheduled).toHaveBeenCalledWith(
+      expect.objectContaining({ stage: 'download', failureKind: 'transport', transportFailures: 1 }),
+    );
+    const { state } = await readBootstrapRetryState(db, 'kilter:1:5', { now: BASE_NOW, random: () => 0 }, false);
+    expect(state.transportFailures).toBe(1);
+    expect(state.backgroundPauses).toBe(0);
+  });
+
+  it('a non-network failure that arrives after a foreground byte still burns, even though the app backgrounded', async () => {
+    // A disk-full is not a suspension kill. Once a byte has arrived in the
+    // foreground the window is shut, so `isNetworkError` never even gets asked —
+    // this settles on the structural-device ladder like any other on-device fault.
+    const source = {
+      fetchManifest: vi.fn(async () => makeManifest([makeEntry()])),
+      downloadArtifact: vi.fn(
+        async (
+          _entry: SnapshotManifestEntry,
+          options?: { onProgress?: (progress: { bytesWritten: number; totalBytes: number | null }) => void },
+        ) => {
+          setBackgrounded(true);
+          setBackgrounded(false);
+          options?.onProgress?.({ bytesWritten: 4096, totalBytes: null });
+          throw new Error('snapshot download: insufficient disk space for kilter:1');
+        },
+      ),
+      deleteArtifact: vi.fn(async () => {}),
+      releaseArtifact: vi.fn(async () => {}),
+    } as unknown as SnapshotSource;
+    const onSnapshotBootstrapError = vi.fn();
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onSnapshotBootstrapError,
+    });
+
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(
+      expect.objectContaining({ stage: 'download', aborted: false, attempt: 1 }),
+    );
+    const { state } = await readBootstrapRetryState(db, 'kilter:1:5', { now: BASE_NOW, random: () => 0 }, false);
+    expect(state.structuralFailures).toBe(1);
+    expect(state.backgroundPauses).toBe(0);
+  });
+
+  it('charges the FOURTH consecutive background pause to the transport budget', async () => {
+    const onSnapshotBootstrapError = vi.fn();
+    const onBootstrapRetryScheduled = vi.fn();
+    const runSuspendedCycle = async () => {
+      const source = {
+        fetchManifest: vi.fn(async () => makeManifest([makeEntry()])),
+        downloadArtifact: vi.fn(async () => {
+          setBackgrounded(true);
+          throw new Error('The network connection was lost.');
+        }),
+        deleteArtifact: vi.fn(async () => {}),
+        releaseArtifact: vi.fn(async () => {}),
+      } as unknown as SnapshotSource;
+      try {
+        await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+          enabledBoards: ['kilter:1:5'],
+          snapshotSource: source,
+          onSnapshotBootstrapError,
+          onBootstrapRetryScheduled,
+        });
+      } finally {
+        setBackgrounded(false);
+      }
+    };
+
+    for (let pause = 0; pause < MAX_FREE_BACKGROUND_PAUSES; pause += 1) await runSuspendedCycle();
+
+    const afterFreePauses = await readBootstrapRetryState(db, 'kilter:1:5', { now: BASE_NOW, random: () => 0 }, false);
+    expect(afterFreePauses.state.backgroundPauses).toBe(MAX_FREE_BACKGROUND_PAUSES);
+    expect(afterFreePauses.state.transportFailures).toBe(0);
+    expect(onBootstrapRetryScheduled).not.toHaveBeenCalled();
+    expect(onSnapshotBootstrapError).toHaveBeenCalledTimes(MAX_FREE_BACKGROUND_PAUSES);
+
+    await runSuspendedCycle();
+
+    const afterCharge = await readBootstrapRetryState(db, 'kilter:1:5', { now: BASE_NOW, random: () => 0 }, false);
+    expect(afterCharge.state.backgroundPauses).toBe(0);
+    expect(afterCharge.state.transportFailures).toBe(1);
+    expect(afterCharge.state.retryAfter).not.toBeNull();
+    // Still an abort — the phone went in a pocket, that IS what happened — but
+    // the attempt number now tells the truth about the budget.
+    expect(onSnapshotBootstrapError).toHaveBeenLastCalledWith(
+      expect.objectContaining({ stage: 'download', aborted: true, reason: 'aborted-background', attempt: 1 }),
+    );
+    expect(onBootstrapRetryScheduled).toHaveBeenCalledTimes(1);
+    expect(onBootstrapRetryScheduled).toHaveBeenCalledWith(
+      expect.objectContaining({ failureKind: 'transport', transportFailures: 1, terminal: false }),
+    );
+  });
+
+  it('a completed download resets the free-pause counter', async () => {
+    const filePath = join(workDir, 'pause-then-complete.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const suspendedSource = {
+      fetchManifest: vi.fn(async () => makeManifest([makeEntry()])),
+      downloadArtifact: vi.fn(async () => {
+        setBackgrounded(true);
+        throw new Error('The network connection was lost.');
+      }),
+      deleteArtifact: vi.fn(async () => {}),
+      releaseArtifact: vi.fn(async () => {}),
+    } as unknown as SnapshotSource;
+
+    try {
+      await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+        enabledBoards: ['kilter:1:5'],
+        snapshotSource: suspendedSource,
+      });
+    } finally {
+      setBackgrounded(false);
+    }
+    const afterPause = await readBootstrapRetryState(db, 'kilter:1:5', { now: BASE_NOW, random: () => 0 }, false);
+    expect(afterPause.state.backgroundPauses).toBe(1);
+
+    const { source } = makeRetainingSource({
+      manifest: makeManifest([makeEntry()]),
+      fileForEntry: () => filePath,
+    });
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+    });
+
+    const afterSuccess = await readBootstrapRetryState(db, 'kilter:1:5', { now: BASE_NOW, random: () => 0 }, false);
+    expect(afterSuccess.state.backgroundPauses).toBe(0);
   });
 
   it('charges the SECOND failed import of the same reused build, so an undeletable file cannot loop', async () => {
@@ -3818,6 +4116,45 @@ describe('pullSync grades bootstrap', () => {
     );
     // The whole-layout budget is untouched, as ever.
     expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
+  });
+
+  it('a grades download that fails during a teardown does not burn a grades attempt', async () => {
+    // The grades artifact only ever gets three tries, and a pocketed phone was
+    // spending them: three screen locks left a Kilter board crawling grades over
+    // GraphQL for the life of the install (issue #4390).
+    const climbsPath = join(workDir, 'grades-teardown-climbs.db');
+    buildArtifact({
+      filePath: climbsPath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const source = {
+      fetchManifest: vi.fn(async () => makeManifest([makeEntry({ grades: gradesArtifactBlock() })])),
+      downloadArtifact: vi.fn(async () => ({ filePath: climbsPath })),
+      downloadGradesArtifact: vi.fn(async () => {
+        setBackgrounded(true);
+        throw new Error('The network connection was lost.');
+      }),
+      deleteArtifact: vi.fn(async () => {}),
+    } as unknown as SnapshotSource;
+    const onSnapshotBootstrapError = vi.fn();
+
+    try {
+      await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+        enabledBoards: ['kilter:1:5'],
+        snapshotSource: source,
+        onSnapshotBootstrapError,
+      });
+    } finally {
+      setBackgrounded(false);
+    }
+
+    expect(await getGradesBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(
+      expect.objectContaining({ stage: 'grades-download', attempt: 0, aborted: true, reason: 'aborted-background' }),
+    );
   });
 
   it('stops trying grades once its own attempt budget is spent', async () => {

--- a/packages/shared/offline-sync/src/sync/bootstrap-retry.ts
+++ b/packages/shared/offline-sync/src/sync/bootstrap-retry.ts
@@ -15,7 +15,10 @@
 //                       touches the structural budget. 3 consecutive failures,
 //                       reset to 0 by any successful download. (The MANIFEST
 //                       stage stays entirely free — a few KB of JSON, and it is
-//                       where an offline launch dies. Issue #4238.)
+//                       where an offline launch dies. Issue #4238.) A transfer
+//                       the OS killed by suspending us is free for its first
+//                       three tries and charged here after that — see
+//                       `recordBackgroundPause` (issue #4390).
 //   structural-artifact the bytes are on disk and provably bad (quick_check,
 //                       snapshot_meta mismatch, import throw). Tonight's export
 //                       might fix it, so a NEW `builtAt` may re-arm the budget —
@@ -79,6 +82,19 @@ export const MAX_BOOTSTRAP_ATTEMPTS = 2;
  */
 export const MAX_TRANSPORT_DOWNLOAD_FAILURES = 3;
 
+/**
+ * Consecutive download-stage backgrounding pauses a scope gets for free before
+ * the transport ladder takes over (issue #4390).
+ *
+ * A pocketed phone is not a broken device, so a transfer the OS suspended must
+ * not burn an attempt or schedule a cooldown. Four in a row with zero bytes
+ * retained is a different thing: it is a device that cannot finish a ~100 MB
+ * unresumable GET, and leaving it uncharged would re-fetch the whole artifact on
+ * every foreground, forever, straight past the 3-strikes ladder that exists to
+ * stop exactly that.
+ */
+export const MAX_FREE_BACKGROUND_PAUSES = 3;
+
 /** Lifetime re-arms of the structural budget on a newly built artifact. */
 export const MAX_STRUCTURAL_REARMS = 1;
 
@@ -111,6 +127,13 @@ export type BootstrapFailureKind = 'transport' | 'structural-artifact' | 'struct
 export type BootstrapRetryState = {
   /** Consecutive download-stage transport failures; any success resets it to 0. */
   readonly transportFailures: number;
+  /**
+   * Consecutive download-stage backgrounding pauses since the last completed
+   * download. Free up to `MAX_FREE_BACKGROUND_PAUSES`, then charged as
+   * `transport` on its ladder; `clearTransportFailures` resets it, because a
+   * download that finished proves the device can finish one.
+   */
+  readonly backgroundPauses: number;
   /** Structural failures spent from the current (possibly re-armed) budget. */
   readonly structuralFailures: number;
   /** Structural budgets granted by a newly built artifact, lifetime. */
@@ -146,6 +169,7 @@ export type BootstrapRetryState = {
 
 export const EMPTY_BOOTSTRAP_RETRY_STATE: BootstrapRetryState = {
   transportFailures: 0,
+  backgroundPauses: 0,
   structuralFailures: 0,
   structuralRearms: 0,
   lastFailureKind: null,
@@ -260,10 +284,48 @@ export function rearmForNewArtifact(state: BootstrapRetryState, builtAt: string)
   };
 }
 
-/** A successful download clears the consecutive-transport counter and its cooldown. */
+/**
+ * Fold one download-stage backgrounding pause into the scope's retry state.
+ *
+ * The first `MAX_FREE_BACKGROUND_PAUSES` cost nothing at all — no attempt, no
+ * cooldown, no budget — and only advance the counter. The next one is charged to
+ * the TRANSPORT budget on its ladder, which is precisely what that budget is
+ * for: bounding total spend on a device where the unresumable GET never
+ * completes. The counter resets as it charges, so the pattern that terminates is
+ * 3 free + 3 transport, after which the scope settles onto the paged crawl and
+ * "Try the fast download again" is the consented escape.
+ */
+export function recordBackgroundPause(input: {
+  state: BootstrapRetryState;
+  /** `builtAt` of the artifact the pause happened against, when known. */
+  builtAt: string | null;
+  now: number;
+  random: () => number;
+}): { state: BootstrapRetryState; charged: boolean } {
+  const backgroundPauses = input.state.backgroundPauses + 1;
+  if (backgroundPauses <= MAX_FREE_BACKGROUND_PAUSES) {
+    return { state: { ...input.state, backgroundPauses }, charged: false };
+  }
+  return {
+    state: nextRetryState({
+      state: { ...input.state, backgroundPauses: 0 },
+      failureKind: 'transport',
+      builtAt: input.builtAt,
+      now: input.now,
+      random: input.random,
+    }),
+    charged: true,
+  };
+}
+
+/**
+ * A successful download clears the consecutive-transport counter and its
+ * cooldown — and the free-pause counter with them: bytes that landed are proof
+ * this device can finish a transfer, whatever happened on the way there.
+ */
 export function clearTransportFailures(state: BootstrapRetryState): BootstrapRetryState {
-  if (state.transportFailures === 0 && state.retryAfter === null) return state;
-  return { ...state, transportFailures: 0, retryAfter: null };
+  if (state.transportFailures === 0 && state.backgroundPauses === 0 && state.retryAfter === null) return state;
+  return { ...state, transportFailures: 0, backgroundPauses: 0, retryAfter: null };
 }
 
 /**
@@ -424,6 +486,10 @@ export function parseBootstrapRetryState(raw: string): BootstrapRetryState | nul
   const lastFailureKind = parsed.lastFailureKind;
   return {
     transportFailures: readNumber(parsed.transportFailures, 0),
+    // Absent on every row written before #4390, and on any row an older bundle
+    // rewrote after a rollback: 0 is exactly the pre-#4390 behaviour (unbounded
+    // free pauses), not a corruption.
+    backgroundPauses: readNumber(parsed.backgroundPauses, 0),
     structuralFailures: readNumber(parsed.structuralFailures, 0),
     structuralRearms: readNumber(parsed.structuralRearms, 0),
     lastFailureKind:

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -47,6 +47,7 @@ import {
   nextRetryState,
   readBootstrapRetryState,
   rearmForNewArtifact,
+  recordBackgroundPause,
   shouldSkipPagedPull,
   spendUserRequest,
   writeBootstrapRetryState,
@@ -1036,18 +1037,22 @@ async function runBootstrapPhase(params: {
       snapshot: frame,
     });
   };
+  type LayoutDownloadRecord = {
+    file: SnapshotArtifactHandle | null;
+    cause: unknown;
+    permanentMiss: boolean;
+    downloadMs: number;
+    /** Set when THIS phase cancelled the transfer, so a cleared flag can't relabel it a failure. */
+    abortedReason: SnapshotBootstrapFailureReason | null;
+    /**
+     * Telemetry only (issue #4390): the app went to the background at some
+     * point during this transfer. Deliberately NOT part of the pause/failure
+     * decision — see `suspensionWindowOpen` below for the narrow test that is.
+     */
+    backgroundedDuringTransfer: boolean;
+  };
   // Absent = not yet attempted; `file: null` = download failed (with its cause).
-  const downloadByLayout = new Map<
-    string,
-    {
-      file: SnapshotArtifactHandle | null;
-      cause: unknown;
-      permanentMiss: boolean;
-      downloadMs: number;
-      /** Set when THIS phase cancelled the transfer, so a cleared flag can't relabel it a failure. */
-      abortedReason: SnapshotBootstrapFailureReason | null;
-    }
-  >();
+  const downloadByLayout = new Map<string, LayoutDownloadRecord>();
   // filePath → whether any scope managed to import it. An artifact the phase
   // never consumed (backgrounded cycle, wipe, aborted transfer) is handed back
   // with `imported: false` so a retention-capable source can keep it.
@@ -1110,6 +1115,17 @@ async function runBootstrapPhase(params: {
       // re-fetch the artifact on every cycle for the life of the install,
       // straight past MAX_GRADES_BOOTSTRAP_ATTEMPTS.
       if (!gradesDownload) {
+        // A cycle that is being torn down did not fail — it was interrupted.
+        // Charging a grades attempt here spent one of the three tries this
+        // artifact ever gets on a pocketed phone, and three screen locks left a
+        // Kilter board crawling grades over GraphQL for the life of the install
+        // (issue #4390).
+        const gradesTeardown = teardownReason();
+        if (gradesTeardown) {
+          reportBootstrapAbort(scope.scopeKey, 'grades-download', gradesTeardown, downloadCause);
+          gradesDownloadByLayout.set(layoutKey, null);
+          return;
+        }
         const attempt = await recordGradesBootstrapAttempt(db, scope.scopeKey);
         onSnapshotBootstrapError?.({
           scopeKey: scope.scopeKey,
@@ -1451,23 +1467,33 @@ async function runBootstrapPhase(params: {
         // reports the real error, not null.
         let cachedDownload = downloadByLayout.get(layoutKey);
         if (!cachedDownload) {
-          cachedDownload = {
+          // A const alias, not the `let` above: the teardown listener below
+          // closes over it, and TypeScript widens a reassignable binding back to
+          // `| undefined` inside a callback.
+          const transfer: LayoutDownloadRecord = {
             file: null,
             cause: null,
             permanentMiss: false,
             downloadMs: 0,
             abortedReason: null,
+            backgroundedDuringTransfer: false,
           };
-          // The transfer runs for minutes on a 100 MB artifact. Cancelling it
-          // when the cycle is torn down (sign-out, purge, backgrounding) stops
-          // the native session from carrying on over a metered connection long
-          // after the engine stopped caring — the phase's own `break` below
-          // only stops the JS loop, not the download.
+          cachedDownload = transfer;
+          // The rule this encodes (issue #4390): START new work only in the
+          // foreground, NEVER kill work already in flight.
           //
-          // The abort is driven by the teardown EVENT, not by progress: a
+          // A wipe / sign-out / board removal still cancels immediately — the
+          // rows the artifact is for are being deleted, so its bytes are
+          // worthless and a native session must not keep pulling ~100 MB for
+          // them. A BACKGROUNDING does not: on iOS with a background URLSession
+          // the transfer keeps running while the process is suspended, and on
+          // Android the process simply stays alive. Cancelling here is what made
+          // a 103 MB Kilter artifact restart from byte 0 on every screen lock.
+          //
+          // The decision is driven by the teardown EVENT, not by progress: a
           // stalled transfer emits no further progress, which is exactly the
           // case where cancelling matters most. The progress callback stays a
-          // pure reporter.
+          // pure reporter apart from closing the suspension window below.
           const abortController = new AbortController();
           // LATCHED, unlike `isBackgrounded()` itself. The teardown flags are
           // live: a phone that woke, aborted a 100 MB transfer, and came back to
@@ -1478,16 +1504,28 @@ async function runBootstrapPhase(params: {
           // Latching the reason at the moment we abort is what makes that race
           // unwinnable.
           let selfAbortedReason: SnapshotBootstrapFailureReason | null = null;
-          const abortIfTornDown = (): void => {
+          // Open while an OS suspension might still be what kills this transfer.
+          // CLOSED by the first byte delivered in the foreground: after that a
+          // failure belongs to the network or the device, not to the pocket.
+          // Without that closing rule, one screen lock during a nine-minute
+          // Android transfer would launder every later wifi drop, HTTP 500 or
+          // disk error into a free, cooldown-free 100 MB retry loop.
+          let suspensionWindowOpen = false;
+          const onTeardownNotice = (): void => {
             const reason = teardownReason();
             if (!reason) return;
+            if (reason === 'aborted-background') {
+              transfer.backgroundedDuringTransfer = true;
+              suspensionWindowOpen = true;
+              return;
+            }
             selfAbortedReason ??= reason;
             abortController.abort();
           };
-          const unsubscribeTeardown = onTeardown(abortIfTornDown);
+          const unsubscribeTeardown = onTeardown(onTeardownNotice);
           // Covers a teardown that landed between the guard check above and the
           // subscription: the listener only sees transitions after this point.
-          abortIfTornDown();
+          onTeardownNotice();
           // Stage 2 of 3, the multi-minute one. A second SIZE of the same layout
           // reuses this cache entry, so it never re-runs and never re-emits
           // download frames for bytes that already came down.
@@ -1507,6 +1545,10 @@ async function runBootstrapPhase(params: {
               (await source.downloadArtifact(entry, {
                 signal: abortController.signal,
                 onProgress: ({ bytesWritten, totalBytes }) => {
+                  // A byte arrived while nothing is tearing us down: this
+                  // transfer demonstrably survived the pocket, so a later
+                  // failure is not the suspension's doing (issue #4390).
+                  if (suspensionWindowOpen && !teardownReason()) suspensionWindowOpen = false;
                   const resolved = resolveDownloadFraction({
                     entry,
                     bytesWritten,
@@ -1533,7 +1575,20 @@ async function runBootstrapPhase(params: {
           // Only when the transfer actually died. A download that finished
           // despite a teardown landing late is still importable, and calling it
           // an abort here would throw away bytes that are already on disk.
-          if (!cachedDownload.file) cachedDownload.abortedReason = selfAbortedReason;
+          //
+          // Two ways a dead transfer counts as a pause rather than a failure:
+          // we cancelled it ourselves (a wipe — latched, so a cleared flag
+          // cannot relabel it), or the OS suspension plausibly killed it. The
+          // second test is deliberately narrow: the suspension window must still
+          // be open (no byte since the app backgrounded) AND the cause must be
+          // network-shaped, which is what a suspension kill produces
+          // ("The network connection was lost", a timeout, a SocketException)
+          // and what a disk-full, an HTTP 500 or a programmer error is not.
+          if (!cachedDownload.file) {
+            cachedDownload.abortedReason =
+              selfAbortedReason ??
+              (suspensionWindowOpen && isNetworkError(cachedDownload.cause) ? 'aborted-background' : null);
+          }
           cachedDownload.downloadMs = Date.now() - downloadStartedAt;
           downloadByLayout.set(layoutKey, cachedDownload);
           // Registered even on the reuse path: the phase still owns the file for
@@ -1565,7 +1620,60 @@ async function runBootstrapPhase(params: {
         // failure (and a 2-minute cooldown) for its own cancellation.
         const downloadTeardown = teardownReason() ?? cachedDownload.abortedReason;
         if (downloadTeardown) {
-          reportBootstrapAbort(scope.scopeKey, 'download', downloadTeardown, cachedDownload.cause);
+          // A transfer that FINISHED is never a pause — the file is on disk, the
+          // source's sidecar is written, and the next foreground cycle reuses it
+          // for free (issue #4310). Only a dead transfer costs anything.
+          //
+          // The free path is bounded (issue #4390). Before this, a self-aborted
+          // background transfer was free with no bound at all: a device that can
+          // never finish the unresumable GET re-fetched ~100 MB on every
+          // foreground, forever. Three per scope stay free; the fourth is
+          // charged to the TRANSPORT budget on its ladder, so the pattern
+          // terminates at 3 free + 3 transport and the board still arrives via
+          // the paged crawl.
+          if (downloadTeardown === 'aborted-background' && !cachedDownload.file) {
+            const pause = recordBackgroundPause({
+              state: retryState,
+              builtAt: entry.builtAt,
+              now: evaluatedAt,
+              random,
+            });
+            retryState = await writeBootstrapRetryState(db, scope.scopeKey, pause.state);
+            metadataSettled = true;
+            if (pause.charged) {
+              // Still `aborted: true` — the climber's phone went in a pocket,
+              // that is what happened — but `attempt` tells the truth about the
+              // budget, exactly as reportSettledFailure spells it, and the retry
+              // ladder now applies.
+              onSnapshotBootstrapError?.({
+                scopeKey: scope.scopeKey,
+                stage: 'download',
+                attempt: retryState.transportFailures,
+                cause: cachedDownload.cause,
+                expected: true,
+                aborted: true,
+                reason: 'aborted-background',
+              });
+              options?.onBootstrapRetryScheduled?.({
+                scopeKey: scope.scopeKey,
+                boardType: scope.boardType,
+                stage: 'download',
+                failureKind: 'transport',
+                retryAfterMs:
+                  isTerminal(retryState) || retryState.retryAfter === null
+                    ? 0
+                    : Math.max(0, retryState.retryAfter - evaluatedAt),
+                transportFailures: retryState.transportFailures,
+                structuralFailures: retryState.structuralFailures,
+                terminal: isTerminal(retryState),
+              });
+              if (isTerminal(retryState)) await markBootstrapPagedFallback(db, scope.scopeKey);
+            } else {
+              reportBootstrapAbort(scope.scopeKey, 'download', downloadTeardown, cachedDownload.cause);
+            }
+          } else {
+            reportBootstrapAbort(scope.scopeKey, 'download', downloadTeardown, cachedDownload.cause);
+          }
           break;
         }
         const download = cachedDownload.file;


### PR DESCRIPTION
## Summary

Refs #4390. First of a 2-PR stack; PR 2 (`feat/offline-download-transport-strategies`) adds the transport strategy seam and per-transfer telemetry on top of this.

`runBootstrapPhase` used to abort an in-flight artifact transfer on **any** teardown, so a locked screen threw away up to 103 MB and the next foreground restarted at byte 0. The rule the code now encodes is **start new work only in the foreground, never kill work already in flight**:

- A wipe / sign-out / board removal still aborts the transfer immediately — the rows the artifact is for are being deleted, so its bytes are worthless and a native session must not keep pulling ~100 MB for them.
- A **backgrounding** does not. On Android the process stays alive, so simply not cancelling is the whole fix and it lands at merge with no flag. On iOS the shipped `downloadFileAsync` path is a foreground session that will usually still die on suspension — this PR stops iOS being *punished* for that; PR 2's flag rollout is what makes an iOS transfer actually continue.

### When a dead transfer is a free pause

Deliberately narrow, because "the app backgrounded at some point during this transfer" is far broader than "the OS suspension is what killed it" — on a nine-minute Android transfer the user pockets the phone almost every time.

- The **suspension window** must still be open. It opens when the app backgrounds mid-transfer and **closes on the first byte delivered in the foreground**: after that the transfer demonstrably survived the pocket, so a later failure belongs to the network or the device.
- The cause must be **network-shaped** (`isNetworkError`) — what a suspension kill produces (`NSURLErrorNetworkConnectionLost`, a timeout, a `SocketException`), and what a disk-full or an HTTP 500 is not.

`backgroundedDuringTransfer` is still latched for the whole transfer, but it is now telemetry only (PR 2 reads it) and has no say in classification.

### The free path is bounded

New `BootstrapRetryState.backgroundPauses` + `MAX_FREE_BACKGROUND_PAUSES = 3` and a pure `recordBackgroundPause()`. Pauses 1–3 are free exactly as today (attempt 0, no cooldown, no budget); the 4th is charged to the **transport** budget on its ladder, reported as `aborted: true` with a real attempt number plus an `Offline Snapshot Retry Scheduled` event. Any completed download clears it via `clearTransportFailures` — landed bytes prove the device can finish one.

This also closes a hole that predates this work: main already treats a self-aborted background transfer as free with *no bound at all*, so widening the free path without bounding it would have made a latent 100 MB-per-foreground loop load-bearing. 3 free + 3 transport terminates at 6 restarts, after which the board still arrives via the paged crawl.

### Two smaller fixes that are load-bearing for the above

- `importGradesForScope` checks `teardownReason()` before `recordGradesBootstrapAttempt` — three screen locks used to spend all three tries the grades artifact ever gets, leaving a Kilter board crawling grades over GraphQL for the life of the install.
- `withoutDownloadProgress` (the `offline-download-progress` kill switch) now forwards `releaseArtifact` and `downloadGradesArtifact`. It only ever meant to drop the `onProgress` **option**; dropping `releaseArtifact` made the engine fall back to `deleteArtifact` and delete exactly the background-completed file this PR exists to keep — aimed at the cohort most likely to have flipped the switch because their downloads are slow.

`onTeardown` is exported from the package index for PR 2's downloader.

## Decisions for Marco

Plan decisions flagged `needsMarco`, landing on the chosen default:

- **Should a download keep running while backgrounded on a metered/cellular link — including a wifi→cellular handover mid-transfer?** → **Yes, continue on any link.** The download was either confirmed by the climber on a size-disclosing dialog moments earlier, or it is an automatic heal, which `METERED_HEAL_DEFERRAL_MS` already defers 6 h on a metered link before it ever starts. Aborting is precisely what makes a 103 MB transfer unable to finish, and aborted bytes are pure waste (a partial has no sidecar and is deleted). The case genuinely worth a sign-off is the **handover**: consent was given on wifi and the remaining ~80 MB may land on cellular. The alternative — snapshot `isOnUnmeteredNetwork()` at transfer start and keep aborting on cellular — is a one-line change.

(The other two `needsMarco` decisions — the unresolved-flag transport default and the new `Offline Artifact Transfer` event — belong to PR 2 and are listed there.)

## Release Notes

- Lock your phone mid-download and the board keeps downloading. Before, the transfer was thrown away the moment the app went in your pocket and started again from zero next time you opened it — on a slow connection the big Kilter board could never finish.

## Test plan

Local, all foreground, all green:

- `vp run typecheck:mobile` — pass
- `vp run typecheck:shared` — pass
- `vp test run --project offline-sync --reporter=agent` — 29 files, 619 tests passed
- `vp run test:mobile` — 646 files, 5896 tests passed
- `vp run check:mobile-bundle` — `android bundle: OK`
- `vp check` on every changed file — 0 errors

New/changed engine coverage in `snapshot-bootstrap.test.ts`:

- **Rewritten** (behaviour deliberately inverted): "aborts an in-flight transfer that emits no progress when the app backgrounds" → **"does NOT abort an in-flight transfer when the app backgrounds"**, plus a new "aborts an in-flight transfer when a wipe starts".
- "a transfer that fails while suspended does not burn a transport attempt" — `{ aborted: true, reason: 'aborted-background', attempt: 0 }`, `transportFailures` 0, `retryAfter` null.
- "a backgrounded blip, a foreground recovery, then a real network failure still burns a transport attempt" — the masked-failure case: `{ aborted: false, reason: 'network', attempt: 1 }` plus a scheduled transport cooldown.
- "a non-network failure that arrives after a foreground byte still burns, even though the app backgrounded".
- "charges the FOURTH consecutive background pause to the transport budget" — pauses 1–3 leave `transportFailures` 0 with no retry scheduled; the 4th reports `attempt: 1`, `transportFailures: 1`, a transport-ladder `retryAfter` and one `Offline Snapshot Retry Scheduled`.
- "a completed download resets the free-pause counter".
- "a download that completes while backgrounded is retained and reused next cycle" — `releaseArtifact({ imported: false })`, then a second cycle imports with no second `downloadArtifact` call.
- "a grades download that fails during a teardown does not burn a grades attempt".

`bootstrap-retry.test.ts`: the `recordBackgroundPause` matrix (free ×3 → charged, counter reset on charge, cleared by `clearTransportFailures` and by `clearRetryStateForUserRequest`), and a persistence case pinning that a row with no `backgroundPauses` key reads as 0 so an OTA rollback only loses the bound.

New `packages/mobile/src/offline/__tests__/use-snapshot-source.test.tsx`: with `offline-download-progress` off, the source still exposes `releaseArtifact` and `downloadGradesArtifact` and still omits `onProgress` from `downloadArtifact`.

**Not provable in CI — needs a real phone** (full script in the plan's device-QA section, and PR 2 carries the flag-dependent half):

1. Android, no flag: start the Kilter download, lock the screen 3 minutes, unlock → the transfer continues and completes.
2. Android with `offline-download-progress` = Off: a download that completes while backgrounded is still reused next cycle rather than deleted.
3. Android, airplane mode mid-download **in the foreground** → `Failed{aborted:false, reason:'network', attempt:1}` and a cooldown. This must NOT be swallowed as a pause.
4. Android: lock 30 s, unlock, wait for the bar to visibly advance, *then* airplane mode → still `{aborted:false, reason:'network'}`. If this comes back as an abort, the suspension window is not closing.
5. iOS with the shipped path: lock the screen four times in a row → the first three are `{aborted:true, attempt:0}` with no retry scheduled, the fourth is `{aborted:true, attempt:1}` plus one `Offline Snapshot Retry Scheduled` with a ~2-minute cooldown.
