### PR TITLE
perf(ci): cut the PR critical path from ~433s to ~230s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,21 +56,36 @@ jobs:
       # Defaults false off PRs (the OTA bot legitimately rewrites it on push).
       changelogData: ${{ github.event_name == 'pull_request' && steps.filter.outputs.changelogData || 'false' }}
       dbMigrations: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.dbMigrations }}
-      # True if any downstream job's gate would fire. setup gates on this so
-      # docs-only / firmware-only PRs skip the bun-install + build:db pass
-      # nothing downstream would consume. Must mirror the union of every
-      # downstream `if:` — sharedDeps/sharedSchema in particular cover
-      # non-JS files (SQL migrations under packages/db, .graphql under
-      # shared-schema) that wouldn't trigger anyJs but still need setup so
-      # test-backend / mobile-bundle / codegen-drift can run.
+      # True if any downstream job's gate would fire. This used to gate the
+      # `setup` job (bun install + build:db + a `built-packages` artifact every
+      # heavy job downloaded); that job was deleted because @boardsesh/db and
+      # @boardsesh/shared-schema resolve through `src/*.ts` in their exports
+      # maps — nothing in the repo ever consumed those dist dirs — and it cost
+      # ~69s of serialized latency in front of every gated job. The output is
+      # kept (no consumer today) because it is the one place that records the
+      # union of every downstream gate, and scripts/__tests__/
+      # ci-location-sync-workflow.test.ts asserts on its terms; keep it in sync
+      # with the job `if:`s below so a future job can gate on it again.
       runAny: ${{ github.event_name != 'pull_request' || steps.filter.outputs.anyJs == 'true' || steps.filter.outputs.web == 'true' || steps.filter.outputs.i18nCatalogs == 'true' || steps.filter.outputs.sharedSchema == 'true' || steps.filter.outputs.sharedDeps == 'true' || steps.filter.outputs.backend == 'true' || steps.filter.outputs.mobile == 'true' || steps.filter.outputs.ocr == 'true' || steps.filter.outputs.locationSync == 'true' || steps.filter.outputs.rootCi == 'true' }}
       # NOTE: deployConfig, storeMetadata, and mobileLocales are deliberately
       # NOT part of runAny — the deploy-config and listing-guards jobs below
-      # need [changes] only (no bun-install/build:db setup pass), so a PR
-      # touching only their files doesn't pay for a `setup` run nothing else
-      # would consume.
+      # gate on their own filters, so a PR touching only their files runs
+      # nothing else.
     steps:
-      - uses: actions/checkout@v6
+      # No actions/checkout here on purpose: on `pull_request` dorny/paths-filter
+      # reads the changed-file list from the REST API (no working tree needed),
+      # and on `push` the filter step is skipped outright and every output above
+      # hardcodes `true`. The checkout was 8-58s at the very head of the run.
+      #
+      # The one thing the API costs us is a ceiling: `GET /pulls/{n}/files` tops
+      # out at 3000 files, and a truncated list would evaluate a filter to
+      # `false` and silently skip a job that should have run — the failure mode
+      # this whole `changes` job exists to avoid. Fail closed instead, and say
+      # what to do about it. (Needs `pull-requests: read`, subsumed by the
+      # workflow-level `pull-requests: write`.)
+      - name: Guard against paths-filter API truncation
+        if: github.event_name == 'pull_request' && github.event.pull_request.changed_files > 2900
+        run: echo "::error::PR exceeds the paths-filter API window; re-add actions/checkout to the changes job" && exit 1
       - id: filter
         if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@v3
@@ -175,34 +190,16 @@ jobs:
               # invokes, so editing it has to run the job that depends on it.
               - 'packages/db/package.json'
 
-  setup:
-    needs: [changes]
-    if: needs.changes.outputs.runAny == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
-      - uses: voidzero-dev/setup-vp@v1
-        with:
-          node-version: 'lts'
-          cache: true
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-      - name: Build shared packages
-        run: vp run build:db
-      - name: Upload built packages
-        uses: actions/upload-artifact@v4
-        with:
-          name: built-packages
-          path: |
-            packages/shared-schema/dist
-            packages/db/dist
-          retention-days: 1
-
   lint:
-    needs: [changes, setup]
-    if: needs.changes.outputs.anyJs == 'true' || needs.changes.outputs.rootCi == 'true'
+    needs: [changes]
+    # Gate is the UNION of lint's own scope and the mobile-bundle scope, because
+    # the nine `check:mobile-*` guards live here now (they used to sit in front
+    # of Metro in mobile-bundle, costing ~24s on the critical path). mobile /
+    # sharedDeps cover paths that anyJs never matches — patches/**,
+    # packages/board-renderer/wasm/pkg/**, scripts/mobile-*.sh — so dropping
+    # either term would silently stop running the patch and fingerprint guards
+    # on exactly the PR shape they exist for. Only ever widen this.
+    if: needs.changes.outputs.anyJs == 'true' || needs.changes.outputs.rootCi == 'true' || needs.changes.outputs.mobile == 'true' || needs.changes.outputs.sharedDeps == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -222,12 +219,71 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Install Expo web lint dependencies
-        if: needs.changes.outputs.mobile == 'true'
+        # Widened alongside the job gate above: lint now also runs for
+        # sharedDeps-only changes, and the expo-web runtime has to be present
+        # whenever we lint mobile sources.
+        if: needs.changes.outputs.mobile == 'true' || needs.changes.outputs.sharedDeps == 'true'
         run: vp run mobile:web-runtime:install
-      - name: Download built packages
-        uses: actions/download-artifact@v4
-        with:
-          name: built-packages
+      # The nine `check:mobile-*` guards below used to run in mobile-bundle, in
+      # front of Metro — ~24s of the critical path (18s of it the fingerprint
+      # check) spent on checks that need nothing Metro produces. They live in
+      # this cheap job now. Fail-fast is preserved: lint still goes red inside a
+      # minute and PR runs cancel-in-progress. The only property given up is
+      # that a failing guard no longer short-circuits Metro's work.
+      - name: Check mobile board art stays bundled
+        run: vp run check:mobile-board-art-network
+      # Catches iOS bundle-phase dep-resolution breaks (e.g. a transitive-only
+      # @sentry/cli unresolvable from packages/mobile under Bun's isolated
+      # linker) here on Linux, instead of in the macOS TestFlight archive on
+      # push-to-main.
+      - name: Check native build-phase deps resolve
+        run: vp run check:mobile-native-deps
+      # Every @expo/* and expo-* dep must be exact-pinned: they ship a JS+native
+      # pair, and a `~`/`^` range lets the JS float ahead of a shipped binary's
+      # native layer. With the OTA fingerprint pinned via an override, that
+      # drifted JS still lands on the old binary — the ModalBottomSheetView
+      # .partialExpand "No handler registered" crash from a `~56.0.18` @expo/ui.
+      - name: Check Expo deps are exact-pinned
+        run: vp run check:mobile-expo-deps-pinned
+      # Deterministic, read-only dep-health check: compares our declared pins
+      # against packages/mobile/node_modules/expo/bundledNativeModules.json for
+      # the SDK release we actually have installed, and flags installed-version
+      # drift from those pins (the caret-drift class behind the 2.0.0 launch
+      # crash). It never consults the network or Expo's remote versions API, so
+      # it only changes outcome when WE change something (bump expo, edit a
+      # pin, lockfile drift) — not when Expo ships an unrelated patch release.
+      # Intentional deviations live in expo.install.exclude.
+      - name: Mobile dep-health check
+        run: vp run check:mobile-deps
+      # A Bun patch is keyed by an exact version, so an Expo/RN bump can silently
+      # drop it: install only warns, and typecheck + the Metro bundle stay green
+      # while a native-only behavior (e.g. the iOS 26 tab-bar minimize tracking
+      # the climbs FlashList) regresses all the way into TestFlight. Assert the
+      # patched source is actually present on this cheap Linux runner.
+      - name: Check native patches are applied
+        run: vp run check:mobile-patches
+      # The resolver can return a valid fingerprint even when a source is silently
+      # absent/null. Assert the four autolinking configs, every discovered native
+      # module dir, the fingerprint config, and root patch bodies all contribute.
+      - name: Check mobile fingerprint inputs are complete
+        run: vp run check:mobile-fingerprint-inputs
+      # Cheap source guard: no raw theme-variant magic-string compares regrew in
+      # mobile components (they must route through the variant primitives/tokens —
+      # see packages/mobile/src/theme/variants/README.md).
+      - name: Check mobile variant usage
+        run: vp run check:mobile-variants
+      # @expo/ui swift-ui / jetpack-compose imports must stay in their platform
+      # file (*.ios.tsx / *.android.tsx) — a misplaced one crashes the other
+      # platform at runtime. The .oxlintrc rule isn't enforced by `vp check`, so
+      # this grep guard is the real backstop. See docs/expo-ui-components.md.
+      - name: Check mobile @expo/ui platform imports
+        run: vp run check:mobile-platform-imports
+      # The offline-sync engine's drain/scheduler/pull entry points must be
+      # imported via src/offline/offline-sync-adapter (binds the connectivity
+      # probe + platform triggers). The .oxlintrc rule isn't enforced by
+      # `vp check`, so this grep guard is the real backstop.
+      - name: Check offline-sync adapter boundary
+        run: vp run check:mobile-offline-sync-imports
       - name: Lint changed files (PR)
         if: github.event_name == 'pull_request'
         env:
@@ -296,7 +352,7 @@ jobs:
           fi
 
   typecheck:
-    needs: [changes, setup]
+    needs: [changes]
     if: needs.changes.outputs.anyJs == 'true' || needs.changes.outputs.rootCi == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -309,10 +365,6 @@ jobs:
           cache: true
       - name: Install dependencies
         run: bun install --frozen-lockfile
-      - name: Download built packages
-        uses: actions/download-artifact@v4
-        with:
-          name: built-packages
       # `vp run typecheck` walks the dependsOn graph defined in root
       # vite.config.ts and uses vp's task cache — unchanged packages skip via
       # cache hits, so this is fast on small PRs even though it expresses the
@@ -340,11 +392,16 @@ jobs:
           POSTGRES_DB: postgres
         ports:
           - 5432:5432
+        # Docker runs its FIRST health probe only after --health-interval
+        # elapses, so a coarse interval is pure idle: Postgres logs "ready to
+        # accept connections" within ~0.1s of container start. Finer grid, same
+        # total tolerance (5s x 10 = 50s -> 2s x 25 = 50s). Do not shorten the
+        # window itself — that trades latency for flakiness on a slow start.
         options: >-
           --health-cmd "pg_isready -U postgres"
-          --health-interval 5s
+          --health-interval 2s
           --health-timeout 5s
-          --health-retries 10
+          --health-retries 25
     steps:
       - uses: actions/checkout@v6
         with:
@@ -371,7 +428,7 @@ jobs:
         run: vp run test:db:migration-journal
 
   codegen-drift:
-    needs: [changes, setup]
+    needs: [changes]
     # codegen.ts pulls GraphQL documents from packages/web/app/**/*.{ts,tsx}
     # in addition to the schema + shared/graphql, so a web-only PR that edits
     # a gql tag can drift the generated client. Include `web` in the gate.
@@ -387,10 +444,6 @@ jobs:
           cache: true
       - name: Install dependencies
         run: bun install --frozen-lockfile
-      - name: Download built packages
-        uses: actions/download-artifact@v4
-        with:
-          name: built-packages
       - name: Regenerate GraphQL types
         run: vp run codegen
       - name: Verify committed output matches
@@ -404,7 +457,7 @@ jobs:
           fi
 
   i18n:
-    needs: [changes, setup]
+    needs: [changes]
     if: needs.changes.outputs.web == 'true' || needs.changes.outputs.i18nCatalogs == 'true' || needs.changes.outputs.rootCi == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -417,10 +470,6 @@ jobs:
           cache: true
       - name: Install dependencies
         run: bun install --frozen-lockfile
-      - name: Download built packages
-        uses: actions/download-artifact@v4
-        with:
-          name: built-packages
       - name: Check hardcoded user-facing strings
         run: vp run check:i18n
       - name: Check orphaned i18n keys
@@ -477,12 +526,23 @@ jobs:
         run: vp test run --project scripts scripts/store-metadata-limits.test.ts scripts/mobile-locales-parity.test.ts
 
   test-default:
-    needs: [changes, setup]
+    needs: [changes]
     # i18nCatalogs: a catalog-only PR (pure JSON) must still run the
     # catalog-completeness parity test, which lives in this job.
     if: needs.changes.outputs.anyJs == 'true' || needs.changes.outputs.rootCi == 'true' || needs.changes.outputs.i18nCatalogs == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      # Same idiom as test-backend below. fail-fast stays false so a failure in
+      # one shard still reports the other's failures — a cancelled sibling costs
+      # a round trip (and `cancelled` is neither success nor skipped, so
+      # ci-status still fails either way).
+      fail-fast: false
+      # 3 shards on main (the whole ~1380-spec run, job mean 558s), 2 on PRs
+      # (where `--changed` already trims the spec set and a third runner is
+      # mostly harness overhead).
+      matrix:
+        include: ${{ fromJSON(github.event_name != 'pull_request' && '[{"shard":1,"total":3},{"shard":2,"total":3},{"shard":3,"total":3}]' || '[{"shard":1,"total":2},{"shard":2,"total":2}]') }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -499,10 +559,6 @@ jobs:
           cache: true
       - name: Install dependencies
         run: bun install --frozen-lockfile
-      - name: Download built packages
-        uses: actions/download-artifact@v4
-        with:
-          name: built-packages
       # Run every project EXCEPT the two with dedicated infra-bearing jobs
       # (`backend`: postgres+redis; `moonboard-ocr`: canvas libs) as an explicit
       # POSITIVE `--project` list. Negation (`--project '!backend'`) does NOT
@@ -513,7 +569,14 @@ jobs:
       # project absent from a positive list is never loaded. The list is derived
       # from root vite.config.ts's `test.projects` (see the script) so new
       # packages are picked up automatically and can't be silently skipped.
-      - name: Run tests
+      #
+      # No `passWithNoTests` flag anywhere, deliberately: on a PR `--changed` is
+      # set, which already implies it inside Vitest and also suppresses Vitest's
+      # `shard.count > specs.length` throw, so a one-file diff can't red the
+      # build; on push the run selects ~1380 specs, far above 3. Passing the
+      # flag would instead turn "this shard collected nothing" into a silent
+      # green.
+      - name: Run tests (shard ${{ matrix.shard }}/${{ matrix.total }})
         env:
           BASE_REF: ${{ github.base_ref }}
           EVENT_NAME: ${{ github.event_name }}
@@ -526,23 +589,29 @@ jobs:
           echo "test-default projects: $PROJECTS"
           if [ "$EVENT_NAME" = "pull_request" ]; then
             vp test run --changed "origin/$BASE_REF" $PROJECTS \
+              --shard=${{ matrix.shard }}/${{ matrix.total }} \
               --reporter=verbose --reporter=github-actions \
-              --reporter=junit --outputFile.junit=./test-results/junit-default.xml
+              --reporter=junit --outputFile.junit=./test-results/junit-default-${{ matrix.shard }}.xml
           else
             vp test run $PROJECTS \
+              --shard=${{ matrix.shard }}/${{ matrix.total }} \
               --reporter=verbose --reporter=github-actions \
-              --reporter=junit --outputFile.junit=./test-results/junit-default.xml
+              --reporter=junit --outputFile.junit=./test-results/junit-default-${{ matrix.shard }}.xml
           fi
+      # Shard-scoped artifact name AND file name: test-report downloads
+      # `test-results-*` with merge-multiple, which flattens every artifact into
+      # one directory — same-named files would clobber each other and the report
+      # would silently lose a shard's worth of results.
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-default
-          path: test-results/junit-default.xml
+          name: test-results-default-${{ matrix.shard }}
+          path: test-results/junit-default-${{ matrix.shard }}.xml
           retention-days: 7
 
   test-backend:
-    needs: [changes, setup]
+    needs: [changes]
     # Gated on `sharedDeps` (packages/shared/**) as well as `backend`: the backend
     # test project drives the queue-client integration suite against the real
     # @boardsesh/queue* packages, so a change to those must run it. See the
@@ -567,20 +636,25 @@ jobs:
           POSTGRES_DB: boardsesh_backend_test
         ports:
           - 5433:5432
+        # Finer probe grid, identical tolerance window (10s x 5 = 50s ->
+        # 2s x 25 = 50s). Docker's first probe fires only after one interval
+        # elapses, so the coarse grid was ~13s of idle in `Initialize
+        # containers` while the server was already accepting connections.
         options: >-
           --health-cmd "pg_isready -U postgres"
-          --health-interval 10s
+          --health-interval 2s
           --health-timeout 5s
-          --health-retries 5
+          --health-retries 25
       redis:
         image: redis:7-alpine
         ports:
           - 6380:6379
+        # Same rescale: 10s x 5 = 50s -> 2s x 25 = 50s.
         options: >-
           --health-cmd "redis-cli ping"
-          --health-interval 10s
+          --health-interval 2s
           --health-timeout 5s
-          --health-retries 5
+          --health-retries 25
     steps:
       - uses: actions/checkout@v6
         with:
@@ -612,10 +686,6 @@ jobs:
           cache: true
       - name: Install dependencies
         run: bun install --frozen-lockfile
-      - name: Download built packages
-        uses: actions/download-artifact@v4
-        with:
-          name: built-packages
       - name: Run backend tests (shard ${{ matrix.shard }}/${{ matrix.total }})
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5433/boardsesh_backend_test
@@ -644,7 +714,7 @@ jobs:
           retention-days: 7
 
   test-ocr:
-    needs: [changes, setup]
+    needs: [changes]
     # Include sharedDeps so OCR tests rerun when a shared package they
     # depend on changes (e.g. shared-schema, board-constants). Mirrors how
     # test-backend and mobile-bundle already gate on sharedDeps.
@@ -660,10 +730,16 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: git fetch --depth=50 origin "$BASE_REF":"refs/remotes/origin/$BASE_REF"
-      - name: Install canvas system libs
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+      # No apt-get for canvas's build deps (~22s): canvas@3.2.3 installs through
+      # `prebuild-install -r napi`, and the napi prebuild vendors every graphics
+      # library inside the package — ldd on the installed canvas.node resolves
+      # libcairo, libpango, librsvg, libjpeg, libgif, libfreetype, libharfbuzz,
+      # libpixman and libfontconfig to its own build/Release via RUNPATH $ORIGIN;
+      # only libc/libm/libstdc++/libgcc come from the runner. The node-gyp
+      # compile fallback is never reached here. If a future bump ever loses the
+      # prebuild, parser.canvas.test.ts imports canvas at module scope with no
+      # skipIf guard, so this job fails loudly at import time rather than
+      # quietly dropping a spec file.
       - uses: oven-sh/setup-bun@v2
       - uses: voidzero-dev/setup-vp@v1
         with:
@@ -671,10 +747,6 @@ jobs:
           cache: true
       - name: Install dependencies
         run: bun install --frozen-lockfile
-      - name: Download built packages
-        uses: actions/download-artifact@v4
-        with:
-          name: built-packages
       - name: Run OCR tests
         env:
           BASE_REF: ${{ github.base_ref }}
@@ -699,7 +771,7 @@ jobs:
           retention-days: 7
 
   test-location-sync-integration:
-    needs: [changes, setup]
+    needs: [changes]
     if: needs.changes.outputs.locationSync == 'true' || needs.changes.outputs.sharedDeps == 'true' || needs.changes.outputs.sharedSchema == 'true' || needs.changes.outputs.rootCi == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -715,11 +787,14 @@ jobs:
           POSTGRES_DB: main
         ports:
           - 5432:5432
+        # Finer probe grid, identical tolerance window (10s x 10 = 100s ->
+        # 2s x 50 = 100s). The window stays generous on purpose: this is the
+        # large pre-seeded dev-db image, which is the slowest container we boot.
         options: >-
           --health-cmd "pg_isready -U postgres"
-          --health-interval 10s
+          --health-interval 2s
           --health-timeout 5s
-          --health-retries 10
+          --health-retries 50
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
@@ -729,10 +804,6 @@ jobs:
           cache: true
       - name: Install dependencies
         run: bun install --frozen-lockfile
-      - name: Download built packages
-        uses: actions/download-artifact@v4
-        with:
-          name: built-packages
       - name: Apply the full migration journal
         env:
           DATABASE_URL: postgres://postgres:password@localhost:5432/main
@@ -756,7 +827,7 @@ jobs:
           retention-days: 7
 
   mobile-bundle:
-    needs: [changes, setup]
+    needs: [changes]
     if: needs.changes.outputs.mobile == 'true' || needs.changes.outputs.sharedDeps == 'true' || needs.changes.outputs.rootCi == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -769,69 +840,86 @@ jobs:
           cache: true
       - name: Install dependencies
         run: bun install --frozen-lockfile
-      - name: Check mobile board art stays bundled
-        run: vp run check:mobile-board-art-network
-      # Catches iOS bundle-phase dep-resolution breaks (e.g. a transitive-only
-      # @sentry/cli unresolvable from packages/mobile under Bun's isolated
-      # linker) here on Linux, instead of in the macOS TestFlight archive on
-      # push-to-main. Runs before the heavier Metro bundle so it fails fast.
-      - name: Check native build-phase deps resolve
-        run: vp run check:mobile-native-deps
-      # Every @expo/* and expo-* dep must be exact-pinned: they ship a JS+native
-      # pair, and a `~`/`^` range lets the JS float ahead of a shipped binary's
-      # native layer. With the OTA fingerprint pinned via an override, that
-      # drifted JS still lands on the old binary — the ModalBottomSheetView
-      # .partialExpand "No handler registered" crash from a `~56.0.18` @expo/ui.
-      - name: Check Expo deps are exact-pinned
-        run: vp run check:mobile-expo-deps-pinned
-      # Deterministic, read-only dep-health check: compares our declared pins
-      # against packages/mobile/node_modules/expo/bundledNativeModules.json for
-      # the SDK release we actually have installed, and flags installed-version
-      # drift from those pins (the caret-drift class behind the 2.0.0 launch
-      # crash). It never consults the network or Expo's remote versions API, so
-      # it only changes outcome when WE change something (bump expo, edit a
-      # pin, lockfile drift) — not when Expo ships an unrelated patch release.
-      # Intentional deviations live in expo.install.exclude. Cheap, so it runs
-      # before the heavier Metro bundle.
-      - name: Mobile dep-health check
-        run: vp run check:mobile-deps
-      # A Bun patch is keyed by an exact version, so an Expo/RN bump can silently
-      # drop it: install only warns, and typecheck + the Metro bundle stay green
-      # while a native-only behavior (e.g. the iOS 26 tab-bar minimize tracking
-      # the climbs FlashList) regresses all the way into TestFlight. Assert the
-      # patched source is actually present on this cheap Linux runner.
-      - name: Check native patches are applied
-        run: vp run check:mobile-patches
-      # The resolver can return a valid fingerprint even when a source is silently
-      # absent/null. Assert the four autolinking configs, every discovered native
-      # module dir, the fingerprint config, and root patch bodies all contribute.
-      - name: Check mobile fingerprint inputs are complete
-        run: vp run check:mobile-fingerprint-inputs
-      # Cheap source guard: no raw theme-variant magic-string compares regrew in
-      # mobile components (they must route through the variant primitives/tokens —
-      # see packages/mobile/src/theme/variants/README.md).
-      - name: Check mobile variant usage
-        run: vp run check:mobile-variants
-      # @expo/ui swift-ui / jetpack-compose imports must stay in their platform
-      # file (*.ios.tsx / *.android.tsx) — a misplaced one crashes the other
-      # platform at runtime. The .oxlintrc rule isn't enforced by `vp check`, so
-      # this grep guard is the real backstop. See docs/expo-ui-components.md.
-      - name: Check mobile @expo/ui platform imports
-        run: vp run check:mobile-platform-imports
-      # The offline-sync engine's drain/scheduler/pull entry points must be
-      # imported via src/offline/offline-sync-adapter (binds the connectivity
-      # probe + platform triggers). The .oxlintrc rule isn't enforced by
-      # `vp check`, so this grep guard is the real backstop.
-      - name: Check offline-sync adapter boundary
-        run: vp run check:mobile-offline-sync-imports
-      - name: Download built packages
-        uses: actions/download-artifact@v4
+      # The nine cheap `check:mobile-*` guards that used to sit here now run in
+      # the `lint` job, whose gate was widened to this job's union so none of
+      # them lost coverage. See the block above `Check mobile board art stays
+      # bundled` in `lint`.
+      #
+      # Metro's transform cache. @expo/metro-config hard-codes the store to
+      # os.tmpdir()/metro-cache, so TMPDIR is the only supported way to move it
+      # — hence a cache dir under runner.temp plus TMPDIR on the bundle step.
+      # It must NOT live inside the workspace: packages/mobile/metro.config.js
+      # sets watchFolders to the monorepo root, so an in-repo cache directory
+      # gets crawled by the file watcher. Measured on identical hardware with
+      # only TMPDIR differing: 178s cold vs 90s warm (649 vs 104 CPU-seconds),
+      # i.e. ~84% of the babel transform output is reusable, and each reused
+      # entry is still validated by Metro's own content hash.
+      #
+      # The key hashes what decides HOW a module is transformed, not the modules
+      # themselves — Metro content-hashes every source file on its own, so a
+      # source edit is a per-file miss, never a stale hit. metro.config.js pulls
+      # in the two sibling .cjs helpers, so they're keyed too. There is no
+      # project babel config today (babel-preset-expo comes in through
+      # @expo/metro-config); packages/mobile/babel.config.js stays in the list
+      # so the day someone adds one it is keyed from the first run instead of
+      # silently reusing transforms built under the old preset chain.
+      - name: Prepare the Metro transform cache directory
+        run: mkdir -p ${{ runner.temp }}/metro-native
+      - name: Restore Metro's native transform cache
+        uses: actions/cache/restore@v4
         with:
-          name: built-packages
+          path: ${{ runner.temp }}/metro-native
+          # Deliberately NO cross-lockfile restore-key: any dependency bump must
+          # fall back to a fully cold Metro rather than reuse transforms built
+          # against different sources.
+          key: metro-native-${{ runner.os }}-${{ hashFiles('bun.lock', 'packages/mobile/metro.config.js', 'packages/mobile/metro-web-runtime-resolution.cjs', 'packages/mobile/expo-web-response-headers.cjs', 'packages/mobile/babel.config.js', 'packages/mobile/app.config.ts', 'patches/**') }}-${{ github.sha }}
+          restore-keys: |
+            metro-native-${{ runner.os }}-${{ hashFiles('bun.lock', 'packages/mobile/metro.config.js', 'packages/mobile/metro-web-runtime-resolution.cjs', 'packages/mobile/expo-web-response-headers.cjs', 'packages/mobile/babel.config.js', 'packages/mobile/app.config.ts', 'patches/**') }}-
       - name: Metro bundle check
+        env:
+          TMPDIR: ${{ runner.temp }}/metro-native
         run: vp run check:mobile-bundle
+      - name: Save Metro's native transform cache
+        uses: actions/cache/save@v4
+        # Only main writes the cache. PRs restore from the default-branch
+        # lineage but never upload, so a PR can't poison the shared entry and
+        # PR runs don't spend ~10s uploading 62 MB each. mobile-bundle runs on
+        # every push to main, so the lineage stays fresh on its own.
+        if: github.ref == 'refs/heads/main'
+        with:
+          path: ${{ runner.temp }}/metro-native
+          key: metro-native-${{ runner.os }}-${{ hashFiles('bun.lock', 'packages/mobile/metro.config.js', 'packages/mobile/metro-web-runtime-resolution.cjs', 'packages/mobile/expo-web-response-headers.cjs', 'packages/mobile/babel.config.js', 'packages/mobile/app.config.ts', 'patches/**') }}-${{ github.sha }}
+      # Same treatment for the Expo web export, in its own store so the two
+      # bundle checks can't invalidate each other's entries.
+      # BOARDSESH_EXPORT_KEEP_METRO_CACHE is honoured by
+      # scripts/build-expo-web-export.sh: without it the export passes --clear,
+      # which rm -rf's all 256 shards of the store (and would delete whatever we
+      # just restored). scripts/mobile-web-bundle-check.sh already sets it on
+      # its own call, so this is belt-and-braces: it keeps the reason the cache
+      # steps exist next to the cache steps. Those two are the ONLY places it
+      # may be set — Dockerfile.web and production-deploy.yml must keep --clear
+      # plus their BOARDSESH_EXPORT_EXPECT_URLS assertion, because they bake
+      # EXPO_PUBLIC_* values into a bundle somebody serves.
+      - name: Prepare the Expo web Metro cache directory
+        run: mkdir -p ${{ runner.temp }}/metro-web
+      - name: Restore Metro's Expo-web transform cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ runner.temp }}/metro-web
+          key: metro-web-${{ runner.os }}-${{ hashFiles('bun.lock', 'packages/mobile/metro.config.js', 'packages/mobile/metro-web-runtime-resolution.cjs', 'packages/mobile/expo-web-response-headers.cjs', 'packages/mobile/babel.config.js', 'packages/mobile/app.config.ts', 'patches/**') }}-${{ github.sha }}
+          restore-keys: |
+            metro-web-${{ runner.os }}-${{ hashFiles('bun.lock', 'packages/mobile/metro.config.js', 'packages/mobile/metro-web-runtime-resolution.cjs', 'packages/mobile/expo-web-response-headers.cjs', 'packages/mobile/babel.config.js', 'packages/mobile/app.config.ts', 'patches/**') }}-
       - name: Expo web bundle check
+        env:
+          TMPDIR: ${{ runner.temp }}/metro-web
+          BOARDSESH_EXPORT_KEEP_METRO_CACHE: '1'
         run: vp run check:mobile-web-bundle
+      - name: Save Metro's Expo-web transform cache
+        uses: actions/cache/save@v4
+        if: github.ref == 'refs/heads/main'
+        with:
+          path: ${{ runner.temp }}/metro-web
+          key: metro-web-${{ runner.os }}-${{ hashFiles('bun.lock', 'packages/mobile/metro.config.js', 'packages/mobile/metro-web-runtime-resolution.cjs', 'packages/mobile/expo-web-response-headers.cjs', 'packages/mobile/babel.config.js', 'packages/mobile/app.config.ts', 'patches/**') }}-${{ github.sha }}
 
   commit-lint:
     needs: [changes]
@@ -973,7 +1061,6 @@ jobs:
   ci-status:
     needs:
       - changes
-      - setup
       - lint
       - typecheck
       - db-migrations

--- a/scripts/__tests__/typecheck-graph-contract.test.ts
+++ b/scripts/__tests__/typecheck-graph-contract.test.ts
@@ -1,0 +1,89 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// The root `typecheck` aggregate deliberately depends on `build:X` instead of
+// `typecheck:X` for eight packages: both run tsc over the same tsconfig, so
+// listing both compiled each package twice (51 CPU-seconds of duplicate work
+// per CI run). Emit-mode tsc reports a superset of `--noEmit` diagnostics, so
+// nothing is lost — WHILE the premise holds.
+//
+// The premise is invisible from vite.config.ts, and its failure is silent: if
+// one of these packages switches `build` to a bundler, or gains a
+// tsconfig.build.json that excludes tests, the aggregate stops type-checking it
+// and nothing goes red. Coverage just evaporates. A comment cannot fail, so
+// this test is the guard.
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+/**
+ * Packages whose `typecheck:X` was replaced by `build:X` in the aggregate, as
+ * [vp task suffix, package dir]. The task suffix does NOT track the directory
+ * name (`build:shared` builds packages/shared-schema, `build:aurora` builds
+ * packages/aurora-sync), so both are spelled out rather than derived.
+ */
+const BUILD_COVERS_TYPECHECK = [
+  ['shared', 'packages/shared-schema'],
+  ['db', 'packages/db'],
+  ['backend', 'packages/backend'],
+  ['aurora', 'packages/aurora-sync'],
+  ['kilter', 'packages/kilter-sync'],
+  ['location-sync', 'packages/location-sync'],
+  ['moonboard-sync', 'packages/moonboard-sync'],
+  ['sync-runtime', 'packages/sync-runtime'],
+] as const;
+
+function readJson(path: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(resolve(REPO_ROOT, path), 'utf8'));
+}
+
+describe('typecheck aggregate: build:X may only stand in for typecheck:X while both run the same tsc', () => {
+  it.each(BUILD_COVERS_TYPECHECK)('%s builds with plain tsc, not a bundler', (_name, packageDir) => {
+    const scripts = readJson(`${packageDir}/package.json`).scripts as Record<string, string> | undefined;
+    const build = scripts?.build ?? '';
+
+    // `tsc` (optionally with flags) and nothing else. A bundler emits JS without
+    // ever type-checking, which is exactly the silent-coverage-loss case.
+    expect(build, `${packageDir} build script must be tsc for the typecheck aggregate to cover it`).toMatch(
+      /^tsc(\s|$)/,
+    );
+    for (const bundler of ['tsup', 'esbuild', 'bun build', 'rollup', 'swc', 'babel']) {
+      expect(
+        build,
+        `${packageDir} build switched to ${bundler} — restore typecheck:${_name} in vite.config.ts`,
+      ).not.toContain(bundler);
+    }
+  });
+
+  it.each(BUILD_COVERS_TYPECHECK)('%s has no tsconfig.build.json narrowing what build sees', (_name, packageDir) => {
+    // A separate build tsconfig is the other way the premise breaks: build would
+    // compile a narrower file set (typically src minus tests) than typecheck did.
+    let exists = true;
+    try {
+      readFileSync(resolve(REPO_ROOT, `${packageDir}/tsconfig.build.json`), 'utf8');
+    } catch {
+      exists = false;
+    }
+    expect(exists, `${packageDir} gained a tsconfig.build.json — restore typecheck:${_name} in vite.config.ts`).toBe(
+      false,
+    );
+  });
+
+  it('keeps every one of those build:X entries in the typecheck aggregate', () => {
+    const config = readFileSync(resolve(REPO_ROOT, 'vite.config.ts'), 'utf8');
+    const aggregate = config.match(/^ {6}typecheck: \{\n[\s\S]*?^ {6}\},$/m)?.[0];
+    expect(aggregate, 'vite.config.ts must define a `typecheck` aggregate task').toBeTruthy();
+
+    // Spelled out rather than left to arrive transitively, so an unrelated edit
+    // to someone else's dependsOn cannot quietly drop one out of the graph.
+    // Either spelling is acceptable: `build:X` is today's dedup, `typecheck:X`
+    // is the correct restoration if a package ever breaks the tsc premise above.
+    for (const [task, packageDir] of BUILD_COVERS_TYPECHECK) {
+      expect(aggregate, `${packageDir} must reach the typecheck aggregate`).toMatch(
+        new RegExp(`'(build|typecheck):${task}'`),
+      );
+    }
+  });
+});

--- a/scripts/build-expo-web-export.sh
+++ b/scripts/build-expo-web-export.sh
@@ -21,6 +21,10 @@ set -euo pipefail
 # The output directory is wiped first. As a guard, the script refuses to wipe a
 # non-empty directory that isn't already an Expo web export (no `_expo/`), and
 # refuses any target at or above the repo root. See docs/expo-web-deployment.md.
+#
+# BOARDSESH_EXPORT_KEEP_METRO_CACHE=1 trades the `--clear` cache wipe for an
+# env-scoped transform store — throwaway validation only, never a shipped
+# artifact. See the block above the export invocation for the full reasoning.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
@@ -101,11 +105,96 @@ export TAILSCALE_HOSTS="${TAILSCALE_HOSTS-}"
 #
 # --clear: expo export reuses Metro's transform cache across EXPO_PUBLIC_* env
 # changes, silently shipping a stale bundle with old env values inlined
-# (verified 2026-07-18..20). Every consumer of this script is a
-# build-the-artifact-once path (Docker builder stage, CI deploy, bundle
-# check), so the cache buys nothing here and the staleness risk is real.
+# (verified 2026-07-18..20). It stays ON by default, for every caller that
+# produces an artifact somebody serves: Dockerfile.web's builder stage,
+# production-deploy.yml's standalone export, `vp run build:expo-web`, and
+# scripts/dev-expo-web-static.sh. Those bake real origins in, so a stale shard
+# ships; none of them sets the opt-out below.
+EXPORT_CLEAR_FLAG='--clear'
+
+# The one caller that gains nothing from the wipe is the CI bundle check
+# (scripts/mobile-web-bundle-check.sh): it bakes no EXPO_PUBLIC_*, sets no
+# BOARDSESH_EXPORT_EXPECT_URLS, and deletes its own output directory. It asserts
+# only that the web graph still resolves, transforms and serializes, and that
+# the shell + WASM assets land — yet it paid a fully cold Metro (~95s) on every
+# run, and would also have deleted any cache restored for it.
+#
+# The opt-out does not drop the 2026-07-18 guarantee, it re-buys it a different
+# way: the transform store moves into a directory named after a hash of every
+# env value this export bakes in. A changed value therefore cannot *reach* a
+# shard transformed under the old one — it lands in a different directory. Never
+# ship the flag gate without the hashed root; the flag alone is the stale-bundle
+# bug again.
+# A bare `-n` test would read BOARDSESH_EXPORT_KEEP_METRO_CACHE=0 as "on" — and
+# `=0` is the first spelling anyone reaches for to turn a speed-up OFF. For a
+# flag whose wrong answer is a reused cache, unsetting must not be the only way
+# to say no. Off-shaped values are off; anything else (1, true, yes) opts in.
+KEEP_METRO_CACHE=1
+case "${BOARDSESH_EXPORT_KEEP_METRO_CACHE:-}" in
+  '' | 0 | false | FALSE | no | NO) KEEP_METRO_CACHE=0 ;;
+esac
+
+if [[ "$KEEP_METRO_CACHE" == 1 && -n "${BOARDSESH_EXPORT_EXPECT_URLS:-}" ]]; then
+  # Interlock. BOARDSESH_EXPORT_EXPECT_URLS means this export is an artifact
+  # with real origins baked in — exactly the shape --clear was bought for. No
+  # caller sets both today; if one ever does, the wipe wins over the speed-up.
+  echo "[build-expo-web-export] BOARDSESH_EXPORT_EXPECT_URLS is set — ignoring BOARDSESH_EXPORT_KEEP_METRO_CACHE and keeping --clear" >&2
+elif [[ "$KEEP_METRO_CACHE" == 1 ]]; then
+  # macOS ships `shasum`, Linux and the alpine builder ship GNU `sha256sum`.
+  if command -v sha256sum >/dev/null 2>&1; then
+    hash_inlined_env() { sha256sum; }
+  elif command -v shasum >/dev/null 2>&1; then
+    hash_inlined_env() { shasum -a 256; }
+  else
+    hash_inlined_env() { return 1; }
+  fi
+
+  INLINED_ENV_HASH="$(
+    {
+      # BOARDSESH_WEB_BASE_URL is set on the export command line below rather
+      # than exported, so `env` cannot see it — feed the effective value in by
+      # hand. --subdomain flips it, and it decides every asset URL in
+      # index.html, which is exactly the kind of staleness --clear guarded.
+      printf 'BOARDSESH_WEB_BASE_URL=%s\n' "$WEB_BASE_URL"
+      # Deliberately broad. EXPO_PUBLIC_* are inlined into the JS by babel; the
+      # rest steer app.config.ts, whose resolved config is serialized into the
+      # bundle too. Over-inclusion costs at most a cache miss (slow); a missing
+      # name is the 2026-07-18 bug (wrong).
+      #
+      # The trailing `[^=]*=` is load-bearing twice over: those entries are name
+      # PREFIXES, so binding the `=` straight to the group (`^(EXPO_|...)=`)
+      # would only ever match a variable named exactly `EXPO_`, silently hashing
+      # nothing — and requiring a `NAME=` shape also skips the continuation
+      # lines of any multi-line value, which cannot be attributed to a name.
+      #
+      # KNOWN LIMIT, so nobody reads this as "every inlined value": the Expo CLI
+      # also loads packages/mobile/.env* from inside the node process, after
+      # this snapshot, so EXPO_PUBLIC_* set THERE are inlined without reaching
+      # the hash. That file is gitignored (a local-dev thing; CI has none), and
+      # the only caller that opts in throws its export away — but it is exactly
+      # why the opt-out must never move to a path that keeps its output.
+      env | grep -E '^(EXPO_|BOARDSESH_|EAS_BUILD|TAILSCALE_HOSTS|GOOGLE_MAPS_API_KEY)[^=]*=' || true
+    } | LC_ALL=C sort | hash_inlined_env | cut -c1-16
+  )" || INLINED_ENV_HASH=''
+
+  if [[ -z "$INLINED_ENV_HASH" ]]; then
+    # No sha256 tool means no scoped root, and an unscoped reused cache is the
+    # thing we refuse to ship. Slow is an acceptable failure here; stale is not.
+    echo "[build-expo-web-export] no sha256sum/shasum available — keeping --clear despite BOARDSESH_EXPORT_KEEP_METRO_CACHE" >&2
+  else
+    # @expo/metro-config hard-codes the transform store to
+    # os.tmpdir()/metro-cache, so TMPDIR is the only supported way to move it.
+    # (Do NOT reach for a cacheStores override in metro.config.js — that file is
+    # a native-fingerprint input and editing it invalidates every OTA binary.)
+    export TMPDIR="${TMPDIR:-/tmp}/metro-web-env-$INLINED_ENV_HASH"
+    mkdir -p "$TMPDIR"
+    EXPORT_CLEAR_FLAG=''
+    echo "[build-expo-web-export] reusing Metro's transform cache under $TMPDIR (inlined-env $INLINED_ENV_HASH)"
+  fi
+fi
+
 BOARDSESH_WEB=1 BOARDSESH_WEB_BASE_URL="$WEB_BASE_URL" EXPO_NO_WEB_SETUP=1 EXPO_NO_TELEMETRY=1 \
-  bunx expo export --platform web --output-dir "$OUTPUT_DIR" --clear
+  bunx expo export --platform web --output-dir "$OUTPUT_DIR" ${EXPORT_CLEAR_FLAG:+"$EXPORT_CLEAR_FLAG"}
 
 if [[ ! -f "$OUTPUT_DIR/index.html" ]]; then
   echo "[build-expo-web-export] missing index.html in $OUTPUT_DIR" >&2

--- a/scripts/mobile-ci-env-parity.test.ts
+++ b/scripts/mobile-ci-env-parity.test.ts
@@ -271,11 +271,38 @@ describe('mobile CI env parity (OTA fingerprint invariant)', () => {
     expect(mobileFilter, 'ci.yml must retain a mobile paths-filter mapping').toBeTruthy();
     expect(mobileFilter).toContain("- 'patches/**'");
 
-    const mobileBundleJob = ci.match(/^  mobile-bundle:\n[\s\S]*?(?=^  [a-z][a-z0-9-]*:\n|(?![\s\S]))/m)?.[0];
-    expect(mobileBundleJob, 'ci.yml must retain the mobile-bundle job').toBeTruthy();
-    expect(mobileBundleJob).toMatch(/if:.*needs\.changes\.outputs\.mobile == 'true'/);
-    expect(mobileBundleJob).toContain('run: vp run check:mobile-patches');
-    expect(mobileBundleJob).toContain('run: vp run check:mobile-fingerprint-inputs');
+    // Assert the PROPERTY (a patch-only PR reaches both sentinels), not the
+    // address. These guards used to live in mobile-bundle and now run in `lint`
+    // — they sat in front of Metro and cost ~24s on the critical path. Pinning
+    // the assertion to a job name meant a pure relocation reddened CI while the
+    // contract still held, so find whichever job hosts each guard and check
+    // THAT job is gated on the mobile filter.
+    const jobs = [...ci.matchAll(/^ {2}([a-z][a-z0-9-]*):\n([\s\S]*?)(?=^ {2}[a-z][a-z0-9-]*:\n|(?![\s\S]))/gm)];
+    expect(jobs.length, 'ci.yml must parse into jobs').toBeGreaterThan(0);
+
+    for (const guard of ['check:mobile-patches', 'check:mobile-fingerprint-inputs']) {
+      const hosts = jobs.filter(([, , body]) => body.includes(`run: vp run ${guard}`));
+      expect(hosts.length, `exactly one ci.yml job must run ${guard}`).toBe(1);
+
+      const [, hostName, hostBody] = hosts[0];
+      // The JOB-level gate only — four-space indent. Step-level `if:`s sit at
+      // eight spaces, and matching one of those instead makes this assertion
+      // inert: the lint job already has a step gated on `mobile`, so a loose
+      // /if:.*mobile/ passes even after the job gate drops the term.
+      const jobGate = hostBody.match(/^ {4}if: (.*)$/m)?.[1] ?? '';
+      // Whatever job hosts it must run on a patches-only PR. `mobile` is the
+      // only filter term that matches `patches/**`, so its absence would skip
+      // the guard on exactly the PR shape it exists for.
+      expect(jobGate, `the ${hostName} job runs ${guard}, so its job gate must include the mobile filter`).toContain(
+        "needs.changes.outputs.mobile == 'true'",
+      );
+
+      // ...and the guard's own step must not re-narrow what the job gate allows.
+      const guardStep =
+        hostBody.match(new RegExp(`^ {6}- name: [^\\n]*\\n(?: {8}[^\\n]*\\n)*? {8}run: vp run ${guard}$`, 'm'))?.[0] ??
+        '';
+      expect(guardStep, `the ${guard} step must not carry its own narrowing if:`).not.toMatch(/^ {8}if:/m);
+    }
   });
 
   it('forces the binary onto the gate fingerprint, and the OTA publish resolves fresh (never pinned)', () => {

--- a/scripts/mobile-web-bundle-check.sh
+++ b/scripts/mobile-web-bundle-check.sh
@@ -2,6 +2,10 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# CI points TMPDIR at a restored cache directory (see the Expo web bundle check
+# step in ci.yml), which does not exist yet on a cold cache — mktemp would fail
+# before the guard ever ran. Create it rather than trust the caller.
+mkdir -p "${TMPDIR:-/tmp}"
 OUTPUT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/boardsesh-mobile-web-export.XXXXXX")"
 SOURCE_GLUE="$ROOT_DIR/packages/board-renderer/wasm/pkg/board_renderer_wasm.js"
 SOURCE_WASM="$ROOT_DIR/packages/board-renderer/wasm/pkg/board_renderer_wasm_bg.wasm"
@@ -34,7 +38,19 @@ verify_synced_artifact "$SOURCE_WASM" "$PUBLIC_WASM" "WASM"
 
 # Single export recipe shared with the production build path (Dockerfile.web /
 # `vp run build:expo-web`); it also asserts the shell and WASM assets landed.
-bash "$ROOT_DIR/scripts/build-expo-web-export.sh" "$OUTPUT_DIR"
+#
+# This is the ONE caller that opts out of the export's `--clear` cache wipe. The
+# wipe exists because expo export reuses Metro's transform cache across
+# EXPO_PUBLIC_* changes and once shipped a bundle with stale origins inlined
+# (2026-07-18) — but this check bakes no EXPO_PUBLIC_*, asserts no baked URLs,
+# and throws the export away below. It only proves the web graph still resolves,
+# transforms and serializes, so a cold Metro was ~95s of CI spent on nothing.
+# In exchange the export script scopes its transform store by a hash of every
+# env value it inlines, so a change in baked env lands in a different cache
+# directory instead of hitting a stale shard. Do not set this anywhere an
+# artifact is kept.
+BOARDSESH_EXPORT_KEEP_METRO_CACHE=1 \
+  bash "$ROOT_DIR/scripts/build-expo-web-export.sh" "$OUTPUT_DIR"
 
 # The off-main-thread render worker is a static asset loaded by runtime URL, so
 # it must be copied into the export verbatim (Metro never bundles it).

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -601,13 +601,40 @@ export default defineConfig({
         command: 'bun run --filter=@boardsesh/sync-runtime typecheck',
         dependsOn: ['build:sync-runtime'],
       },
+      // The eight `build:*` entries in this list stand in for the `typecheck:*`
+      // tasks of the same packages (shared-schema, db, backend, aurora-sync,
+      // kilter-sync, location-sync, moonboard-sync, sync-runtime). Each of them
+      // runs plain `tsc` for `build` and `tsc --noEmit` for `typecheck` against
+      // the SAME tsconfig.json — same `include: ["src/**/*"]`, which covers
+      // their test files too — and every `typecheck:X` already dependsOn
+      // `build:X`. Listing both compiled each package twice back to back: 51
+      // CPU-seconds of literal duplicate work per CI run, with
+      // `typecheck:backend` the task that ended the non-web half of the job.
+      // No coverage is lost: emit-mode `tsc` reports a superset of `--noEmit`
+      // diagnostics over the same files (it adds declaration-emit errors).
+      //
+      // THE INVARIANT THIS BUYS INTO, which is invisible from this file: it
+      // holds only while those eight packages' `build` script stays plain `tsc`
+      // over the same tsconfig their `typecheck` script uses. The day one of
+      // them gains a `tsconfig.build.json` that excludes tests, or switches
+      // `build` to a bundler (tsup/esbuild/`bun build`), this aggregate
+      // silently stops type-checking it — nothing goes red, coverage just
+      // evaporates. Put that package's `typecheck:X` back in this list in the
+      // same commit. The `typecheck:X` task definitions above are deliberately
+      // kept so `vp run typecheck:backend` still works on its own locally.
+      //
+      // All eight `build:*` are named here even though build:aurora,
+      // build:kilter, build:location-sync and build:sync-runtime arrive
+      // transitively via build:backend today, and build:shared/build:db via
+      // build:web: spelling them out means an unrelated edit to someone else's
+      // dependsOn cannot quietly drop one of them out of the typecheck graph.
       typecheck: {
         command: 'true',
         dependsOn: [
           'typecheck:scripts',
-          'typecheck:shared',
-          'typecheck:db',
-          'typecheck:backend',
+          'build:shared',
+          'build:db',
+          'build:backend',
           'typecheck:web',
           'typecheck:ble-protocol',
           'typecheck:queue',
@@ -637,11 +664,11 @@ export default defineConfig({
           'typecheck:graphql',
           'typecheck:graphql-client',
           'typecheck:mobile',
-          'typecheck:kilter',
-          'typecheck:aurora',
-          'typecheck:location-sync',
-          'typecheck:moonboard-sync',
-          'typecheck:sync-runtime',
+          'build:kilter',
+          'build:aurora',
+          'build:location-sync',
+          'build:moonboard-sync',
+          'build:sync-runtime',
         ],
       },
       // Footgun-proof scoped test runs. `vp test --project <name> run` (the


### PR DESCRIPTION
## Summary

Cuts the PR critical path from a measured **433s to a projected ~230s**. Every number here comes from `gh run view` over the 21 most recent `ci.yml` runs plus real runner logs — not estimates.

A benchmarking pass measured each CI layer first. Two things it corrected before any code changed:

- **The pole is `mobile-bundle`, not `test-default`.** The 366s `test-default` mean mixes push runs (full 1380-file suite, 558s) with PR runs (`--changed`, 269s). Rebuilt from run-level offsets, `mobile-bundle` owns the PR critical path in 8 of 14 runs, `test-default` in 4, `typecheck` in 1, `test-backend` in 1.
- **`typecheck`'s "cache-driven affected" step reports `0/54 cache hit (0%)`** in 5 of 5 sampled runs. It was never cache-driven.

### What changed

| # | Change | CP saving |
|---|---|---|
| 1 | Delete the `setup` job + nine `Download built packages` steps | −69s |
| 2 | Persist Metro's transform cache | −62s |
| 3 | Move the nine `check:mobile-*` guards into `lint` | −22s |
| 4 | Stop `--clear`-ing Metro's cache in the Expo-web *check* | −34s |
| 5 | Drop `changes`'s checkout (fail-closed truncation guard) | −6s |
| 6 | Drop 8 duplicate `tsc --noEmit` tasks | −12s |
| 7 | Shard `test-default` 3x main / 2x PR | tail + main |
| 8 | Health intervals 10s→2s; delete test-ocr's apt install | runner-s |

**The `setup` job was distributing nothing.** It spent 58s of serialized latency uploading `packages/db/dist` + `packages/shared-schema/dist` so nine jobs could download them. Both packages declare `main`, `types` and every `exports` entry pointing at `./src/*.ts`; neither dist dir exists in a working checkout; the only references to those paths anywhere outside `node_modules` were the two upload lines themselves. Nine jobs now start at ~20s instead of ~93s. `vp run build:db` stays on the required path via `typecheck:db`.

**Metro's cache was thrown away every run.** `@expo/metro-config` hard-codes the store at `os.tmpdir()/metro-cache`. Measured on the exact CI command: **cold 178.4s / 649.6 CPU-s vs warm 89.6s / 104.0 CPU-s** — 84% of the CPU is babel output Metro already knows how to cache. `TMPDIR` now points at a cached dir under `runner.temp`, deliberately not inside the workspace (`metro.config.js` watches the monorepo root). The Expo-web check additionally passed `--clear`, which `rm -rf`s all 256 shards — measured **101.4s cold vs 6.9s warm** for the identical 4311-module export.

### Guarding the `--clear` removal

`--clear` was bought by a real incident (stale `EXPO_PUBLIC_*` / base-URL inlining reaching a shipped artifact). The deploy path keeps it. Only the *check* path — which sets none of that env and throws its output away — opts out, and the property that replaces the flag is a **cache root scoped by a hash of the inlined env**, so a baked-env change lands in a different directory instead of hitting a stale shard. Default with no env var set is today's behaviour: `--clear` on.

### A contract test that pinned an address instead of a property

`scripts/mobile-ci-env-parity.test.ts` asserted the patch and fingerprint guards live *in the `mobile-bundle` job, by name*. Relocating them reddened it while its semantic intent — a patches-only PR reaches both sentinels — still held. It now asserts the property: whichever job hosts a guard must carry the `mobile` filter in its **job-level** gate.

My first version of that fix was inert. A loose `/if:.*mobile/` matched a *step-level* `if:` inside `lint`, so it passed even with the job gate narrowed. Caught by mutation-testing, then fixed to read the 4-space-indent job gate specifically.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

**Test quality is the constraint, not the variable.** A benchmark agent built the invariants first: 45 vitest projects / 1630 spec files / 19275 tests, 20 jobs, 21 skip sites. Nothing here deletes, skips, retries, reselects or re-times a test.

The repo's specific gaming risks, all checked against the diff:
- **All 21 skip sites are environment-conditional**, and `ci-status` treats `skipped` as pass — so dropping a service container silently turns hard failures green. No service container was dropped; health-check *tolerance windows* are byte-identical (50s/50s/50s/100s before and after), only the polling frequency changed.
- **`INFRA_PROJECTS` is a subtraction set** — one added name deletes a whole project from CI while its own unit test stays green. `scripts/ci-test-default-projects.ts` is untouched; still emits 42 `--project=` flags.
- No `--passWithNoTests`, no changed `--changed` base, no lowered `fetch-depth`, no `isolate:false`, no `retry:`/`repeats:`/`bail:`, no new skip sites, no third `continue-on-error`.
- Every `if:` and path filter that moved got **wider**, never narrower. `lint`'s gate is now the union of its own and `mobile-bundle`'s.

Verified:
- `vp run typecheck` — exit 0; task graph 54 → 46 (the 8 duplicates)
- `vp check` (full repo) — exit 0
- 3 CI contract tests green, incl. the rewritten parity assertion
- **Mutation-tested the rewritten guard 3 ways** — narrowed job gate, deleted guard step, narrowed step gate. All three caught; the guard fails when it should.
- Job set diffed against `main`: only `setup` removed, no job added, `ci-status.needs` gaps identical to main (`large-files` / `test-report`, both pre-existing)

The real proof is this PR's own CI run — that's the measurement, and I'll compare it against the baseline once it lands.

## Deferred

Dropping `--changed` to run the full suite sharded 4–6 ways is a coverage **increase** (~3.4x more specs per PR, closing the `--changed` blind spot for fs-reading tests). Held back only because 4–6 concurrent shards land on a wave already running ~8 heavy jobs, near the 20-job concurrency ceiling. Worth its own PR.

Rejected as coverage trade-offs: jsdom → happy-dom (482 web specs lose CSSOM/Selection/form-validation fidelity that MUI+Emotion exercise) and moving 159 DOM-free specs to the node environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX6Gz2Ew9UduUhTP3W6dC7

---

## Measured result (run 31657115300)

**Critical path 433s → 349s, −84s (−19%)** — and this run had a **cold Metro cache**, so the two cache changes contributed nothing to it yet.

```
  END  START    DUR   JOB
 349s   346s     3s   ci-status
 344s    26s   318s   mobile-bundle          <- the pole, cold cache
 220s    75s   145s   test-location-sync-integration
 199s     5s   194s   typecheck
 100s     5s    95s   test-backend (1, 1)
  97s    19s    78s   test-default (2, 2)
  89s     6s    83s   lint  (+ the 9 relocated mobile guards)
  77s     7s    70s   test-default (1, 2)
  72s    13s    59s   test-ocr
   3s     0s     3s   changes
```

Heavy jobs now start at **5–19s instead of ~93s**. `changes` went 15s → 3s. `test-ocr` 84s → 59s with the apt install gone.

The cache saves are gated to `main`, so they populate on the first push after merge; a PR restores from the default branch's entry via the restore-key prefix. Expected once warm: `mobile-bundle` ~318s → ~140s, which hands the pole to `typecheck` at 199s for a **~215s** critical path.

Verified on the artifacts: the two shards partition cleanly (**0 overlap**), and `test-report` merged both.

## A coverage hole this PR demonstrated on itself

`test-default` ran exactly **one** spec file on this PR — `mobile-ci-env-parity.test.ts`, 34 tests — and only because I edited that file directly. `scripts/__tests__/ci-location-sync-workflow.test.ts` reads `ci.yml` through `readFileSync`, so `--changed`'s module graph never linked my ci.yml rewrite to it, and **it did not run**.

A PR that rewrites CI ran 34 tests. That is the pre-existing `--changed` blind spot for fs-reading tests, not something this PR introduced — but this PR is an unusually clean demonstration of it. All three CI contract tests were run locally and are green; the mutation testing described above was done by hand for the same reason.

This is the argument for the deferred full-suite-sharding change.
