### PR TITLE
fix(sync): keep an offline tick when the local write loses the lock

### DIFF
--- a/packages/mobile/app/(tabs)/profile/_layout.tsx
+++ b/packages/mobile/app/(tabs)/profile/_layout.tsx
@@ -32,6 +32,8 @@ export default function ProfileLayout() {
         <Stack.Screen name="dev-servers" options={{ title: t('mobile.more.metroServersTitle') }} />
         {/* i18n-ignore-next-line — tester-only screen */}
         <Stack.Screen name="feature-flags" options={{ title: 'Feature Flags' }} />
+        {/* i18n-ignore-next-line — tester-only screen */}
+        <Stack.Screen name="dev-offline-writes" options={{ title: 'Offline Writes' }} />
         <Stack.Screen name="delete-account" options={{ title: tSettings('deleteAccount.title') }} />
       </Stack>
     </BoardArtVisibilityProvider>

--- a/packages/mobile/app/(tabs)/profile/dev-offline-writes.tsx
+++ b/packages/mobile/app/(tabs)/profile/dev-offline-writes.tsx
@@ -1,0 +1,5 @@
+import { DevOfflineWritesScreen } from '../../../src/components/settings/DevOfflineWritesScreen';
+
+export default function DevOfflineWritesRoute() {
+  return <DevOfflineWritesScreen />;
+}

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -228,10 +228,15 @@ export default function MoreScreen() {
   // wherever the dev section is allowed — for testers and in dev.
   const showFeatureFlags = __DEV__ || Boolean(profile?.isTester);
 
+  // The offline-write harness (hold a real SQLite write lock, inject fault
+  // shapes, inspect the outbox). Same audience as the flag overrides.
+  const showOfflineWrites = __DEV__ || Boolean(profile?.isTester);
+
   // Don't render an empty "Development" section header when no tool applies.
   // (The OTA channel switcher moved to an everyone-facing "Try a preview" entry
   // on the changelog screen, so it's no longer listed here.)
-  const showDevSection = (__DEV__ || Boolean(profile?.isTester)) && (showDevServerSwitcher || showFeatureFlags);
+  const showDevSection =
+    (__DEV__ || Boolean(profile?.isTester)) && (showDevServerSwitcher || showFeatureFlags || showOfflineWrites);
 
   // 'System' follows the device language; the rest are the supported locales,
   // labelled in their own script (English / Español / Français) from
@@ -724,6 +729,18 @@ export default function MoreScreen() {
         subtitle: 'Force feature flags on or off',
         icon: 'featureFlags',
         onPress: navAction(() => router.push('/(tabs)/profile/feature-flags')),
+      });
+    }
+    if (showOfflineWrites) {
+      devRows.push({
+        kind: 'nav',
+        key: 'offlineWrites',
+        // i18n-ignore-next-line — tester-only dev tooling
+        label: 'Offline Writes',
+        // i18n-ignore-next-line
+        subtitle: 'Hold the SQLite write lock, inject faults, inspect the outbox',
+        icon: 'featureFlags',
+        onPress: navAction(() => router.push('/(tabs)/profile/dev-offline-writes')),
       });
     }
     sections.push({ key: 'development', title: t('mobile.more.development'), rows: devRows });

--- a/packages/mobile/src/components/play-drawer/__tests__/use-quick-tick-form.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-quick-tick-form.test.tsx
@@ -73,6 +73,9 @@ vi.mock('../../../providers/rogue-timer-provider', () => ({
   useOptionalRogueTimer: () => null,
 }));
 vi.mock('../../../hooks/use-local-ticks', () => ({ useLocalPendingTicks: () => ({ data: 0 }) }));
+// Connectivity drives which save-failure message the form shows (issue #4315).
+const connectivityState = vi.hoisted(() => ({ isOffline: false }));
+vi.mock('../../../hooks/use-is-offline', () => ({ useIsOffline: () => connectivityState.isOffline }));
 vi.mock('../../../lib/analytics', () => ({ track: vi.fn() }));
 vi.mock('../../../lib/haptics', () => ({ hapticSuccess: vi.fn(), hapticError: vi.fn() }));
 
@@ -191,6 +194,7 @@ beforeEach(() => {
   saveMock.state.failure = null;
   toastMock.showToast.mockClear();
   gradesState.current = [];
+  connectivityState.isOffline = false;
   vi.mocked(track).mockClear();
 });
 
@@ -416,6 +420,33 @@ describe('useQuickTickForm save errors', () => {
     fireEvent.click(getByTestId('save'));
 
     expect(container.querySelector('[data-testid="last-error"]')?.textContent).toBe('mobile.logAscent.errorMessage');
+  });
+
+  // Issue #4315. A save that fails offline has already exhausted the local write,
+  // the retry ladder and the outbox degrade. The network error's own message is a
+  // technical, English-only string, so say what happened in the climber's language.
+  it('shows the localized offline message when the save fails while offline', () => {
+    boardState.current = null;
+    connectivityState.isOffline = true;
+    saveMock.state.failure = new Error('Network request failed');
+    const { container, getByTestId } = renderForm();
+
+    fireEvent.click(getByTestId('save'));
+
+    expect(container.querySelector('[data-testid="last-error"]')?.textContent).toBe(
+      'mobile.logAscent.offlineErrorMessage',
+    );
+  });
+
+  it('still surfaces the error own message when online, where it is worth reading', () => {
+    boardState.current = null;
+    connectivityState.isOffline = false;
+    saveMock.state.failure = new Error('Climb not found');
+    const { container, getByTestId } = renderForm();
+
+    fireEvent.click(getByTestId('save'));
+
+    expect(container.querySelector('[data-testid="last-error"]')?.textContent).toBe('Climb not found');
   });
 });
 

--- a/packages/mobile/src/components/play-drawer/use-quick-tick-form.ts
+++ b/packages/mobile/src/components/play-drawer/use-quick-tick-form.ts
@@ -31,6 +31,7 @@ import { useToast } from '../../providers/toast-provider';
 import { useOptionalRogueTimer } from '../../providers/rogue-timer-provider';
 import { useBoardPresenceControls } from '../../providers/board-presence-provider';
 import { useLocalPendingTicks } from '../../hooks/use-local-ticks';
+import { useIsOffline } from '../../hooks/use-is-offline';
 import { track } from '../../lib/analytics';
 import { hapticSuccess, hapticError } from '../../lib/haptics';
 
@@ -152,6 +153,15 @@ export function useQuickTickForm({
   const boardActions = useOptionalBoardActions();
   const boardLogbook = useOptionalBoardLogbook();
   const { data: localPendingTicks = 0 } = useLocalPendingTicks(climbUuid, boardName);
+  // Read through a ref so the save handler's identity doesn't change on every
+  // connectivity flip (the file's existing stable-identity idiom). A save that
+  // fails while offline has already exhausted the local write, the retry ladder
+  // and the outbox degrade — the network error's own message is a technical,
+  // English-only string, so say what happened in the climber's language instead.
+  // Online, the error's own message is worth reading and stays.
+  const isOffline = useIsOffline();
+  const isOfflineRef = useRef(isOffline);
+  isOfflineRef.current = isOffline;
   useEffect(() => {
     if (!boardActions) return;
     void boardActions.getLogbook([climbUuid]);
@@ -334,8 +344,11 @@ export function useQuickTickForm({
           onError: (error: unknown) => {
             hapticError();
             track(SHARED_EVENTS.QuickTickFailed, { climbUuid, layoutId: layoutId ?? null });
-            const message =
-              error instanceof Error && error.message ? error.message : tClimbs('mobile.logAscent.errorMessage');
+            const message = isOfflineRef.current
+              ? tClimbs('mobile.logAscent.offlineErrorMessage')
+              : error instanceof Error && error.message
+                ? error.message
+                : tClimbs('mobile.logAscent.errorMessage');
             setLastError(message);
           },
         },

--- a/packages/mobile/src/components/settings/DevOfflineWritesScreen.tsx
+++ b/packages/mobile/src/components/settings/DevOfflineWritesScreen.tsx
@@ -1,0 +1,183 @@
+// Tester/dev-only harness for the offline local-write path (issue #4315).
+//
+// The failure this screen exists to reproduce cannot be produced by ordinary
+// use: every measured board import fits inside the shipped 5s `busy_timeout`, so
+// "log a tick during a download" just yields a fast save. Two tools here, plus
+// the read that proves the outcome:
+//
+//   1. Hold write lock — a SECOND connection sits on a real write lock. Any hold
+//      longer than the timeout makes the app's next write throw the GENUINE
+//      platform lock error, which is the only way to check on a device that
+//      `isDatabaseLockedError` still matches what Android and iOS emit.
+//   2. Fault mode — deterministic error shapes for the branches a real lock
+//      cannot schedule (a fixed number of failures, a non-lock error, and the
+//      commit-then-throw case behind the tick INSERT's OR IGNORE).
+//   3. Outbox inspector — the newest `pending_mutations` rows. The More tab's
+//      "Sync issues" section only renders online and only lists dead letters, so
+//      nothing else in the app can show a degraded tick's queued row.
+//
+// All copy is hardcoded English with `i18n-ignore`, matching the other dev
+// screens (FeatureFlagsScreen, DevServerSwitcherScreen).
+
+import { useCallback, useState } from 'react';
+import { View, ScrollView, StyleSheet, ActivityIndicator } from 'react-native';
+import { Redirect } from 'expo-router';
+import { Text } from '../Text';
+import { SectionHeader } from '../SectionHeader';
+import { ListRow } from '../ListRow';
+import { Button } from '../Button';
+import { useTheme } from '../../providers/theme-provider';
+import { useProfile } from '../../lib/graphql/hooks';
+import { getDatabaseHandle } from '../../db';
+import { holdWriteLock } from '../../offline/dev/lock-holder';
+import { setWriteFault, type WriteFaultMode } from '../../offline/dev/write-fault-injection';
+import { usePendingMutations } from '../../offline/dev/use-pending-mutations';
+
+const HOLD_DURATIONS_MS = [3000, 7000, 15000];
+
+const FAULT_MODES: { mode: WriteFaultMode; label: string }[] = [
+  // i18n-ignore-next-line — tester-only screen
+  { mode: 'off', label: 'Off' },
+  { mode: 'ios-lock', label: 'iOS lock' },
+  { mode: 'android-lock', label: 'Android lock (control byte)' },
+  { mode: 'android-lock-no-code', label: 'Android lock (no code)' },
+  { mode: 'disk-full', label: 'Disk full (not retryable)' },
+  { mode: 'commit-then-throw', label: 'Commit, then throw' },
+];
+
+const FAIL_ATTEMPT_CHOICES = [1, 99];
+
+export function DevOfflineWritesScreen() {
+  const { systemColors, spacing } = useTheme();
+  const { data: profile, isLoading: profileLoading } = useProfile();
+  const database = getDatabaseHandle();
+  const pendingMutations = usePendingMutations(database);
+
+  const [holdStatus, setHoldStatus] = useState<string | null>(null);
+  const [faultMode, setFaultMode] = useState<WriteFaultMode>('off');
+  const [failAttempts, setFailAttempts] = useState(1);
+
+  const handleHold = useCallback((durationMs: number) => {
+    // i18n-ignore-next-line — tester-only screen
+    setHoldStatus(`Holding the write lock for ${durationMs / 1000}s — log a tick NOW.`);
+    holdWriteLock(durationMs)
+      // i18n-ignore-next-line
+      .then(() => setHoldStatus('Lock released.'))
+      .catch((error: unknown) => {
+        // i18n-ignore-next-line
+        setHoldStatus(`Hold failed: ${error instanceof Error ? error.message : String(error)}`);
+      });
+  }, []);
+
+  const applyFault = useCallback((mode: WriteFaultMode, attempts: number) => {
+    setFaultMode(mode);
+    setFailAttempts(attempts);
+    setWriteFault(mode, attempts);
+  }, []);
+
+  // Same route guard as FeatureFlagsScreen: hiding the More-tab row is not a
+  // guard, since a deep link reaches this route directly — and this screen can
+  // hold a real write lock on the user's database.
+  if (!__DEV__) {
+    if (profileLoading) {
+      return (
+        <View style={[styles.loading, { backgroundColor: systemColors.groupedBackground }]}>
+          <ActivityIndicator />
+        </View>
+      );
+    }
+    if (!profile?.isTester) {
+      return <Redirect href="/(tabs)/profile/more" />;
+    }
+  }
+
+  return (
+    <ScrollView
+      style={{ backgroundColor: systemColors.groupedBackground }}
+      contentContainerStyle={{ padding: spacing[4], gap: spacing[4] }}
+    >
+      {/* i18n-ignore-next-line — tester-only screen */}
+      <SectionHeader title="Hold the write lock" />
+      <Text variant="footnote" color={systemColors.secondaryLabel}>
+        {/* i18n-ignore-next-line */}
+        Opens a second connection and sits on a real write lock. Start a hold, then log an ascent: a hold shorter than
+        the 9s budget should still save normally; a longer one should degrade to an outbox-only row.
+      </Text>
+      <View style={[styles.buttonRow, { gap: spacing[2] }]}>
+        {HOLD_DURATIONS_MS.map((durationMs) => (
+          <Button
+            key={durationMs}
+            // i18n-ignore-next-line
+            title={`${durationMs / 1000}s`}
+            variant="tonal"
+            size="small"
+            onPress={() => handleHold(durationMs)}
+          />
+        ))}
+      </View>
+      {holdStatus !== null && (
+        <Text variant="footnote" color={systemColors.label}>
+          {holdStatus}
+        </Text>
+      )}
+
+      {/* i18n-ignore-next-line — tester-only screen */}
+      <SectionHeader title="Inject a write fault" />
+      <Text variant="footnote" color={systemColors.secondaryLabel}>
+        {/* i18n-ignore-next-line */}
+        Deterministic error shapes for the branches a real lock cannot schedule. Fail 1 attempt to see the retry
+        recover; fail 99 to see the ladder exhaust and the tick degrade.
+      </Text>
+      <View style={[styles.buttonRow, { gap: spacing[2] }]}>
+        {FAIL_ATTEMPT_CHOICES.map((attempts) => (
+          <Button
+            key={attempts}
+            // i18n-ignore-next-line
+            title={`Fail ${attempts}`}
+            variant={failAttempts === attempts ? 'filled' : 'outlined'}
+            size="small"
+            onPress={() => applyFault(faultMode, attempts)}
+          />
+        ))}
+      </View>
+      {FAULT_MODES.map((option) => (
+        <ListRow
+          key={option.mode}
+          title={option.label}
+          // i18n-ignore-next-line
+          subtitle={faultMode === option.mode ? 'Armed' : undefined}
+          onPress={() => applyFault(option.mode, failAttempts)}
+        />
+      ))}
+
+      {/* i18n-ignore-next-line — tester-only screen */}
+      <SectionHeader title="Outbox (newest 50)" />
+      <Button
+        // i18n-ignore-next-line
+        title="Refresh"
+        variant="outlined"
+        size="small"
+        onPress={() => void pendingMutations.refetch()}
+      />
+      {pendingMutations.data?.length === 0 && (
+        <Text variant="footnote" color={systemColors.secondaryLabel}>
+          {/* i18n-ignore-next-line */}
+          Nothing queued.
+        </Text>
+      )}
+      {pendingMutations.data?.map((row) => (
+        <ListRow
+          key={row.id}
+          title={`${row.table_name} · ${row.operation} · ${row.status}`}
+          subtitle={`${row.idempotency_key} · retries ${row.retry_count} · ${row.created_at}`}
+          haptic={false}
+        />
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  loading: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  buttonRow: { flexDirection: 'row', flexWrap: 'wrap' },
+});

--- a/packages/mobile/src/hooks/__tests__/use-offline-mutations.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-offline-mutations.test.ts
@@ -51,10 +51,15 @@ vi.mock('../../offline/outbox-telemetry', () => ({
   reportEnqueueSuppressed: reportEnqueueSuppressedMock,
 }));
 
+// The retry ladder emits one analytics event per contended write; the event's
+// own shape is covered in offline/__tests__/local-write-telemetry.test.ts.
+vi.mock('../../lib/analytics', () => ({ track: vi.fn() }));
+
 import {
   writeTickLocal,
   addFavoriteLocal,
   removeFavoriteLocal,
+  enqueueTickOutboxOnly,
   favoriteAddKey,
   favoriteRemoveKey,
   useOfflineFollowUser,
@@ -87,6 +92,32 @@ function makeTickInput(overrides: Partial<SaveTickInput> = {}): SaveTickInput {
     ...overrides,
   };
 }
+
+// node:sqlite serializes, so genuine SQLITE_BUSY is unreachable in this suite.
+// Wrapping the handle so the first N transactions throw the real driver message
+// is what lets the ladder's behaviour be asserted against the REAL DDL: the
+// recovering attempt still runs the actual SQL.
+function withFailingTransactions(base: TestSqliteDb, failures: number, message: string): TestSqliteDb {
+  let remaining = failures;
+  return new Proxy(base, {
+    get(target, property) {
+      if (property === 'withExclusiveTransactionAsync') {
+        return async (task: (txn: unknown) => Promise<void>) => {
+          if (remaining > 0) {
+            remaining -= 1;
+            throw new Error(message);
+          }
+          return target.withExclusiveTransactionAsync(task as never);
+        };
+      }
+      const value = Reflect.get(target, property) as unknown;
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+}
+
+const LOCK_MESSAGE = 'Error code 5: database is locked';
+const DISK_MESSAGE = 'database or disk is full';
 
 let db: TestSqliteDb;
 
@@ -136,6 +167,173 @@ describe('writeTickLocal', () => {
 
     const tick = await db.getFirstAsync<Row>('SELECT session_id FROM boardsesh_ticks WHERE uuid = ?', ['tick-uuid-2']);
     expect(tick?.session_id).toBeNull();
+  });
+
+  // Issue #4315. The transaction is atomic, so losing the lock used to roll back
+  // the tick row AND the outbox row — the send vanished. One retry is what makes
+  // an ordinary contended save land.
+  it('recovers a lock-contended write on the retry and lands exactly one tick and one queue row', async () => {
+    await writeTickLocal(withFailingTransactions(db, 1, LOCK_MESSAGE), makeTickInput(), 'tick-retry-1');
+
+    const ticks = await db.getAllAsync<Row>('SELECT * FROM boardsesh_ticks WHERE uuid = ?', ['tick-retry-1']);
+    expect(ticks).toHaveLength(1);
+    const queued = await db.getAllAsync<Row>('SELECT * FROM pending_mutations WHERE idempotency_key = ?', [
+      'tick-retry-1',
+    ]);
+    expect(queued).toHaveLength(1);
+  });
+
+  // A SQLITE_BUSY can surface at COMMIT, so a retry can follow an attempt that
+  // actually landed. The tick INSERT is OR IGNORE precisely so that re-run is a
+  // no-op rather than a UNIQUE violation.
+  it('is idempotent when the same uuid is written twice (commit-then-throw safety)', async () => {
+    const input = makeTickInput();
+    await writeTickLocal(db, input, 'tick-twice');
+    await writeTickLocal(db, input, 'tick-twice');
+
+    const ticks = await db.getAllAsync<Row>('SELECT * FROM boardsesh_ticks WHERE uuid = ?', ['tick-twice']);
+    expect(ticks).toHaveLength(1);
+    const queued = await db.getAllAsync<Row>('SELECT * FROM pending_mutations WHERE idempotency_key = ?', [
+      'tick-twice',
+    ]);
+    expect(queued).toHaveLength(1);
+  });
+
+  it('rethrows a non-lock error without a second attempt', async () => {
+    const flaky = withFailingTransactions(db, 1, DISK_MESSAGE);
+
+    await expect(writeTickLocal(flaky, makeTickInput(), 'tick-disk')).rejects.toThrow(DISK_MESSAGE);
+
+    const ticks = await db.getAllAsync<Row>('SELECT * FROM boardsesh_ticks');
+    expect(ticks).toHaveLength(0);
+  });
+
+  // The adapter stamps input.uuid before the first write so the queued replay and
+  // any network fall-through name the same server row. If the payload ever lost
+  // it, the fall-through would log a second send.
+  it('carries a caller-stamped input.uuid into the enqueued payload, matching the key', async () => {
+    const input = makeTickInput({ uuid: 'tick-stamped' });
+
+    await writeTickLocal(db, input, 'tick-stamped');
+
+    const queued = await db.getFirstAsync<Row>('SELECT * FROM pending_mutations WHERE idempotency_key = ?', [
+      'tick-stamped',
+    ]);
+    const payload = JSON.parse(queued?.payload as string) as Record<string, unknown>;
+    expect(payload.uuid).toBe('tick-stamped');
+    expect(payload.uuid).toBe(queued?.idempotency_key);
+  });
+});
+
+// Issue #4315. The tick can survive on its outbox row alone: the drainer replays
+// a queued mutation from its payload, so the local boardsesh_ticks row only ever
+// served LOCAL reads (the "waiting to sync" badge, the offline logbook).
+describe('enqueueTickOutboxOnly', () => {
+  it('writes the queue row and NO tick row, with the payload the full write would have queued', async () => {
+    const input = makeTickInput({ uuid: 'degraded-1', sessionId: 'session-7' });
+
+    await enqueueTickOutboxOnly(db, input, 'degraded-1', 5000);
+
+    const ticks = await db.getAllAsync<Row>('SELECT * FROM boardsesh_ticks');
+    expect(ticks).toHaveLength(0);
+
+    const queued = await db.getAllAsync<Row>('SELECT * FROM pending_mutations');
+    expect(queued).toHaveLength(1);
+    expect(queued[0].table_name).toBe('boardsesh_ticks');
+    expect(queued[0].operation).toBe('create');
+    expect(queued[0].idempotency_key).toBe('degraded-1');
+    expect(JSON.parse(queued[0].payload as string)).toEqual(input);
+  });
+
+  it('is a no-throw no-op when the key is already queued', async () => {
+    const input = makeTickInput({ uuid: 'degraded-2' });
+    await enqueueTickOutboxOnly(db, input, 'degraded-2', 5000);
+
+    await expect(enqueueTickOutboxOnly(db, input, 'degraded-2', 5000)).resolves.toBeUndefined();
+
+    const queued = await db.getAllAsync<Row>('SELECT * FROM pending_mutations');
+    expect(queued).toHaveLength(1);
+  });
+
+  it('retries once on a lock error', async () => {
+    const flaky = withFailingTransactions(db, 1, LOCK_MESSAGE);
+
+    await enqueueTickOutboxOnly(flaky, makeTickInput({ uuid: 'degraded-3' }), 'degraded-3', 5000);
+
+    const queued = await db.getAllAsync<Row>('SELECT * FROM pending_mutations');
+    expect(queued).toHaveLength(1);
+  });
+});
+
+// The ladder is a class fix, not a tick fix: favorites and follows lost writes
+// the same way and reported nothing at all. They keep today's reject-and-revert
+// behaviour on a hard failure — only the retry (and the new event) are new.
+describe('retry ladder across every local write', () => {
+  const favorite = { boardName: 'kilter', climbUuid: 'climb-9', angle: 40 };
+
+  it('addFavoriteLocal recovers and lands the same state as an uncontended run', async () => {
+    await addFavoriteLocal(withFailingTransactions(db, 1, LOCK_MESSAGE), favorite);
+
+    const rows = await db.getAllAsync<Row>('SELECT * FROM user_favorites');
+    expect(rows).toHaveLength(1);
+    const queued = await db.getAllAsync<Row>('SELECT * FROM pending_mutations');
+    expect(queued).toHaveLength(1);
+    expect(queued[0].idempotency_key).toBe(favoriteAddKey(favorite));
+  });
+
+  it('removeFavoriteLocal recovers', async () => {
+    await db.runAsync(
+      "INSERT INTO user_favorites (board_name, climb_uuid, angle, created_at, updated_at) VALUES ('kilter', 'climb-9', 40, 'now', 'now')",
+    );
+
+    await removeFavoriteLocal(withFailingTransactions(db, 1, LOCK_MESSAGE), favorite);
+
+    expect(await db.getAllAsync<Row>('SELECT * FROM user_favorites')).toHaveLength(0);
+    const queued = await db.getAllAsync<Row>('SELECT * FROM pending_mutations');
+    expect(queued).toHaveLength(1);
+    expect(queued[0].idempotency_key).toBe(favoriteRemoveKey(favorite));
+  });
+
+  it('the follow hooks recover', async () => {
+    const followUser = useOfflineFollowUser(withFailingTransactions(db, 1, LOCK_MESSAGE), parkedGraphqlFetch);
+
+    await followUser('user-42');
+
+    expect(await db.getAllAsync<Row>('SELECT * FROM user_follows')).toHaveLength(1);
+    const queued = await db.getAllAsync<Row>('SELECT * FROM pending_mutations');
+    expect(queued).toHaveLength(1);
+    expect(queued[0].idempotency_key).toBe('add:user_follows:user-42');
+  });
+
+  it('the unfollow hook recovers', async () => {
+    await db.runAsync(
+      "INSERT INTO user_follows (following_id, created_at, updated_at) VALUES ('user-42', 'now', 'now')",
+    );
+    const unfollowUser = useOfflineUnfollowUser(withFailingTransactions(db, 1, LOCK_MESSAGE), parkedGraphqlFetch);
+
+    await unfollowUser('user-42');
+
+    expect(await db.getAllAsync<Row>('SELECT * FROM user_follows')).toHaveLength(0);
+    const queued = await db.getAllAsync<Row>('SELECT * FROM pending_mutations');
+    expect(queued).toHaveLength(1);
+    expect(queued[0].idempotency_key).toBe('del:user_follows:user-42');
+  });
+
+  it('rethrows a non-lock favorite failure untouched (favorites are NOT degraded)', async () => {
+    await expect(addFavoriteLocal(withFailingTransactions(db, 1, DISK_MESSAGE), favorite)).rejects.toThrow(
+      DISK_MESSAGE,
+    );
+    expect(await db.getAllAsync<Row>('SELECT * FROM user_favorites')).toHaveLength(0);
+  });
+
+  // A retried write re-runs `enqueue`, which can now see a row a previous attempt
+  // committed. That is only safe because reportEnqueueSuppressed early-returns
+  // unless the existing row is a dead letter — pinned here rather than left as an
+  // accident of the reporter's filter.
+  it('never reports a suppressed enqueue just because the write was retried', async () => {
+    await addFavoriteLocal(withFailingTransactions(db, 1, LOCK_MESSAGE), favorite);
+
+    expect(reportEnqueueSuppressedMock).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/mobile/src/hooks/use-offline-mutations.ts
+++ b/packages/mobile/src/hooks/use-offline-mutations.ts
@@ -4,12 +4,19 @@ import {
   applyBusyTimeout,
   enqueue,
   getLocalUserId,
+  runLocalWriteWithRetry,
+  OFFLINE_DB_BUSY_TIMEOUT_MS,
+  OFFLINE_DB_RETRY_BUSY_TIMEOUT_MS,
+  OFFLINE_DB_FALLBACK_BUSY_TIMEOUT_MS,
   type EnqueueResult,
   type GraphQLFetch,
   type OfflineDatabase,
+  type SqlExecutor,
 } from '@boardsesh/offline-sync';
 import { drainMutationQueue } from '../offline/offline-sync-adapter';
 import { reportEnqueueSuppressed } from '../offline/outbox-telemetry';
+import { localWriteRetryOptions } from '../offline/local-write-telemetry';
+import { takeInjectedWriteFault } from '../offline/dev/write-fault-injection';
 import type { SaveTickMutationVariables } from '../lib/graphql/operations';
 
 export type SaveTickInput = SaveTickMutationVariables['input'];
@@ -32,51 +39,141 @@ function scheduleDrain(
   });
 }
 
-export async function writeTickLocal(db: OfflineDatabase, input: SaveTickInput, tickUuid: string): Promise<void> {
+/**
+ * Run one local write through the shared retry ladder (issue #4315).
+ *
+ * Every write in this file is a single `withExclusiveTransactionAsync` task, so
+ * losing the single-writer lock rolls back both the data row and the outbox row
+ * it would have queued — the whole write vanishes and, for a tick, the send is
+ * gone. Attempt 1 keeps the shipped 5s `busy_timeout`; a retry gets the shorter
+ * one, because a first-attempt failure already means a five-second holder.
+ *
+ * Every statement inside `task` MUST be safe to re-run: a `SQLITE_BUSY` can
+ * surface at COMMIT, so a retry can follow an attempt that actually landed.
+ */
+function runLocalWrite(
+  db: OfflineDatabase,
+  tableName: string,
+  operation: 'create' | 'delete',
+  task: (txn: SqlExecutor) => Promise<void>,
+  budgetMs?: number,
+): Promise<void> {
+  return runLocalWriteWithRetry(
+    async (attempt) => {
+      if (__DEV__) {
+        const injectedFault = takeInjectedWriteFault('before-task');
+        if (injectedFault) throw injectedFault;
+      }
+      await db.withExclusiveTransactionAsync(async (txn) => {
+        // Own connection, busy_timeout defaults to 0 — wait for a held write lock
+        // instead of failing this offline write instantly (BOARDSESH-AB/AX).
+        await applyBusyTimeout(txn, attempt === 1 ? OFFLINE_DB_BUSY_TIMEOUT_MS : OFFLINE_DB_RETRY_BUSY_TIMEOUT_MS);
+        await task(txn);
+      });
+      if (__DEV__) {
+        const injectedFault = takeInjectedWriteFault('after-commit');
+        if (injectedFault) throw injectedFault;
+      }
+    },
+    {
+      ...localWriteRetryOptions(tableName, operation),
+      ...(budgetMs === undefined ? {} : { budgetMs }),
+    },
+  );
+}
+
+export async function writeTickLocal(
+  db: OfflineDatabase,
+  input: SaveTickInput,
+  tickUuid: string,
+  budgetMs?: number,
+): Promise<void> {
   const now = new Date().toISOString();
   const climbedAt = input.climbedAt ?? now;
   const sessionId = input.sessionId ?? null;
 
-  await db.withExclusiveTransactionAsync(async (txn) => {
-    // Own connection, busy_timeout defaults to 0 — wait for a held write lock
-    // instead of failing this offline write instantly (BOARDSESH-AB/AX).
-    await applyBusyTimeout(txn);
-    // Stamp the owner so a local reader's `(user_id = ? OR user_id IS NULL)`
-    // predicate can tell this tick from a previous account's leftovers. Rows
-    // written before this existed stay NULL, which the `IS NULL` arm covers —
-    // that arm cannot be dropped until every such row has synced back down.
-    const ownerUserId = await getLocalUserId(txn);
-    await txn.runAsync(
-      `INSERT INTO boardsesh_ticks (uuid, user_id, board_type, climb_uuid, angle, status,
+  await runLocalWrite(
+    db,
+    'boardsesh_ticks',
+    'create',
+    async (txn) => {
+      // Stamp the owner so a local reader's `(user_id = ? OR user_id IS NULL)`
+      // predicate can tell this tick from a previous account's leftovers. Rows
+      // written before this existed stay NULL, which the `IS NULL` arm covers —
+      // that arm cannot be dropped until every such row has synced back down.
+      const ownerUserId = await getLocalUserId(txn);
+      // OR IGNORE so a retried attempt is a no-op against a row the previous
+      // attempt already committed: a `SQLITE_BUSY` can surface at COMMIT, which
+      // makes "the transaction landed and still threw" a real shape. `uuid` is
+      // the PRIMARY KEY, and every other statement here is already idempotent.
+      await txn.runAsync(
+        `INSERT OR IGNORE INTO boardsesh_ticks (uuid, user_id, board_type, climb_uuid, angle, status,
        attempt_count, quality, difficulty, comment, climbed_at, session_id, is_mirror, is_benchmark,
        created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      [
-        tickUuid,
-        ownerUserId,
-        input.boardType,
-        input.climbUuid,
-        input.angle,
-        input.status,
-        input.attemptCount,
-        input.quality ?? null,
-        input.difficulty ?? null,
-        input.comment,
-        climbedAt,
-        sessionId,
-        input.isMirror ? 1 : 0,
-        input.isBenchmark ? 1 : 0,
-        now,
-        now,
-      ],
-    );
+        [
+          tickUuid,
+          ownerUserId,
+          input.boardType,
+          input.climbUuid,
+          input.angle,
+          input.status,
+          input.attemptCount,
+          input.quality ?? null,
+          input.difficulty ?? null,
+          input.comment,
+          climbedAt,
+          sessionId,
+          input.isMirror ? 1 : 0,
+          input.isBenchmark ? 1 : 0,
+          now,
+          now,
+        ],
+      );
 
-    // No suppressed-enqueue check here, and that is a property of the key, not
-    // an oversight: every tick gets a fresh uuid, so this INSERT OR IGNORE can
-    // never collide with an existing row. A future tick key derived from
-    // climb+angle would inherit the favorites blind spot below — re-check then.
-    await enqueue(txn, 'boardsesh_ticks', 'create', input, tickUuid);
-  });
+      // No suppressed-enqueue check here, and that is a property of the key, not
+      // an oversight: every tick gets a fresh uuid, so this INSERT OR IGNORE can
+      // never collide with an existing row. A future tick key derived from
+      // climb+angle would inherit the favorites blind spot below — re-check then.
+      await enqueue(txn, 'boardsesh_ticks', 'create', input, tickUuid);
+    },
+    budgetMs,
+  );
+}
+
+/**
+ * Last-chance tick write: the outbox row ONLY, no `boardsesh_ticks` row (issue
+ * #4315).
+ *
+ * Called when `writeTickLocal` has already lost the lock. A queued mutation is
+ * self-contained — the drainer replays it from the payload alone — so an
+ * outbox-only row is enough for the send to reach the server. It is also a
+ * strictly smaller target than the full write: one `INSERT OR IGNORE`, no owner
+ * read, at a later instant with its own (shorter) `busy_timeout`.
+ *
+ * No owner stamp is needed: the server derives ownership from the authenticated
+ * call. What the user gives up is documented at the call site — no local tick
+ * row means no "waiting to sync" badge, and the tick is missing from the local
+ * logbook if the app is killed before it drains.
+ *
+ * The payload and key are byte-identical to what `writeTickLocal` would have
+ * queued, so the drain path is unchanged.
+ */
+export async function enqueueTickOutboxOnly(
+  db: OfflineDatabase,
+  input: SaveTickInput,
+  tickUuid: string,
+  budgetMs: number,
+): Promise<void> {
+  await runLocalWriteWithRetry(
+    async () => {
+      await db.withExclusiveTransactionAsync(async (txn) => {
+        await applyBusyTimeout(txn, OFFLINE_DB_FALLBACK_BUSY_TIMEOUT_MS);
+        await enqueue(txn, 'boardsesh_ticks', 'create', input, tickUuid);
+      });
+    },
+    { ...localWriteRetryOptions('boardsesh_ticks', 'create'), maxAttempts: 2, budgetMs },
+  );
 }
 
 export function favoriteAddKey(input: FavoriteInput): string {
@@ -95,8 +192,7 @@ export async function addFavoriteLocal(db: OfflineDatabase, input: FavoriteInput
   // inside a callback.
   const enqueueOutcome = newEnqueueOutcome();
 
-  await db.withExclusiveTransactionAsync(async (txn) => {
-    await applyBusyTimeout(txn);
+  await runLocalWrite(db, 'user_favorites', 'create', async (txn) => {
     // Same owner stamp as writeTickLocal — user_favorites has a user_id column
     // the dual-write never filled.
     const ownerUserId = await getLocalUserId(txn);
@@ -109,6 +205,10 @@ export async function addFavoriteLocal(db: OfflineDatabase, input: FavoriteInput
     await txn.runAsync(`DELETE FROM pending_mutations WHERE idempotency_key = ? AND status = 'pending'`, [
       favoriteRemoveKey(input),
     ]);
+    // A retry re-runs this and reassigns the holder — last attempt wins, which
+    // is the outcome that matters. Re-running `enqueue` against a row a previous
+    // attempt committed reports `pending`, and reportEnqueueSuppressed only
+    // fires on `dead_letter`, so a retry can never fake a suppressed-enqueue.
     enqueueOutcome.result = await enqueue(txn, 'user_favorites', 'create', input, favoriteAddKey(input));
   });
 
@@ -135,8 +235,7 @@ function reportSuppressedEnqueue(tableName: string, operation: 'create' | 'delet
 export async function removeFavoriteLocal(db: OfflineDatabase, input: FavoriteInput): Promise<void> {
   const enqueueOutcome = newEnqueueOutcome();
 
-  await db.withExclusiveTransactionAsync(async (txn) => {
-    await applyBusyTimeout(txn);
+  await runLocalWrite(db, 'user_favorites', 'delete', async (txn) => {
     await txn.runAsync(`DELETE FROM user_favorites WHERE board_name = ? AND climb_uuid = ? AND angle = ?`, [
       input.boardName,
       input.climbUuid,
@@ -167,8 +266,7 @@ export function useOfflineFollowUser(db: OfflineDatabase, graphqlFetch: GraphQLF
       const idempotencyKey = `add:user_follows:${followingId}`;
       const enqueueOutcome = newEnqueueOutcome();
 
-      await db.withExclusiveTransactionAsync(async (txn) => {
-        await applyBusyTimeout(txn);
+      await runLocalWrite(db, 'user_follows', 'create', async (txn) => {
         await txn.runAsync(
           `INSERT OR IGNORE INTO user_follows (following_id, created_at, updated_at)
            VALUES (?, ?, ?)`,
@@ -204,8 +302,7 @@ export function useOfflineUnfollowUser(db: OfflineDatabase, graphqlFetch: GraphQ
       const idempotencyKey = `del:user_follows:${followingId}`;
       const enqueueOutcome = newEnqueueOutcome();
 
-      await db.withExclusiveTransactionAsync(async (txn) => {
-        await applyBusyTimeout(txn);
+      await runLocalWrite(db, 'user_follows', 'delete', async (txn) => {
         await txn.runAsync(`DELETE FROM user_follows WHERE following_id = ?`, [followingId]);
 
         // Cancel a not-yet-drained follow, but ALWAYS enqueue the unfollow —

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -807,6 +807,13 @@ export const SAVE_TICK = gql`
 
 export type SaveTickMutationVariables = {
   input: {
+    /**
+     * Client-generated tick id. The offline adapter stamps it before the local
+     * write so the SQLite row, the queued replay and any network fall-through
+     * all name the same server row — `saveTick` returns the existing tick for a
+     * repeat uuid instead of logging a second send.
+     */
+    uuid?: string;
     boardType: string;
     climbUuid: string;
     angle: number;

--- a/packages/mobile/src/offline/__tests__/local-write-telemetry.test.ts
+++ b/packages/mobile/src/offline/__tests__/local-write-telemetry.test.ts
@@ -1,0 +1,108 @@
+// The favorites/follows blind spot closes here (issue #4315): before this event,
+// a favorite whose local write lost the lock rejected with no Sentry report and
+// no analytics at all. These assertions pin what the one event says.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const trackMock = vi.hoisted(() => vi.fn());
+vi.mock('../../lib/analytics', () => ({ track: trackMock }));
+
+const isOnlineMock = vi.hoisted(() => vi.fn(() => true));
+vi.mock('../offline-sync-adapter', () => ({ isOnline: isOnlineMock }));
+
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { localWriteRetryOptions } from '../local-write-telemetry';
+
+const LOCK_ERROR = new Error('Error code 5: database is locked');
+const DISK_ERROR = new Error('database or disk is full');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isOnlineMock.mockReturnValue(true);
+});
+
+describe('localWriteRetryOptions', () => {
+  it('reports a recovered write with its table, operation and timings', () => {
+    localWriteRetryOptions('boardsesh_ticks', 'create').onSettled?.({
+      attempts: 2,
+      error: LOCK_ERROR,
+      recovered: true,
+      elapsedMs: 5150,
+    });
+
+    expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineLocalWriteAttemptFailed, {
+      tableName: 'boardsesh_ticks',
+      operation: 'create',
+      attempts: 2,
+      elapsedMs: 5150,
+      outcome: 'recovered',
+      isLockError: true,
+      wasOffline: false,
+    });
+  });
+
+  it('reports an exhausted lock failure', () => {
+    localWriteRetryOptions('user_favorites', 'delete').onSettled?.({
+      attempts: 2,
+      error: LOCK_ERROR,
+      recovered: false,
+      elapsedMs: 6700,
+    });
+
+    expect(trackMock).toHaveBeenCalledWith(
+      SHARED_EVENTS.OfflineLocalWriteAttemptFailed,
+      expect.objectContaining({
+        tableName: 'user_favorites',
+        operation: 'delete',
+        outcome: 'exhausted',
+        isLockError: true,
+      }),
+    );
+  });
+
+  // attempts: 1 + exhausted is how a non-retryable error reads in the funnel.
+  it('marks a non-lock error as such and shows it was never retried', () => {
+    localWriteRetryOptions('user_follows', 'create').onSettled?.({
+      attempts: 1,
+      error: DISK_ERROR,
+      recovered: false,
+      elapsedMs: 12,
+    });
+
+    expect(trackMock).toHaveBeenCalledWith(
+      SHARED_EVENTS.OfflineLocalWriteAttemptFailed,
+      expect.objectContaining({ attempts: 1, isLockError: false, outcome: 'exhausted' }),
+    );
+  });
+
+  it('follows the connectivity reading for wasOffline', () => {
+    isOnlineMock.mockReturnValue(false);
+
+    localWriteRetryOptions('boardsesh_ticks', 'create').onSettled?.({
+      attempts: 2,
+      error: LOCK_ERROR,
+      recovered: false,
+      elapsedMs: 8800,
+    });
+
+    expect(trackMock).toHaveBeenCalledWith(
+      SHARED_EVENTS.OfflineLocalWriteAttemptFailed,
+      expect.objectContaining({ wasOffline: true }),
+    );
+  });
+
+  it('swallows a throwing analytics client so a saved write stays saved', () => {
+    trackMock.mockImplementation(() => {
+      throw new Error('posthog exploded');
+    });
+
+    expect(() =>
+      localWriteRetryOptions('boardsesh_ticks', 'create').onSettled?.({
+        attempts: 2,
+        error: LOCK_ERROR,
+        recovered: true,
+        elapsedMs: 1,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/mobile/src/offline/dev/__tests__/write-fault-injection.test.ts
+++ b/packages/mobile/src/offline/dev/__tests__/write-fault-injection.test.ts
@@ -1,0 +1,60 @@
+// The fault injector is only useful if its synthetic errors are classified the
+// same way the real platform ones are — otherwise a device QA run "proves" a
+// retry path the real error would never reach. That is what this pins.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { isDatabaseLockedError } from '@boardsesh/offline-sync';
+import { setWriteFault, getWriteFault, takeInjectedWriteFault } from '../write-fault-injection';
+
+beforeEach(() => {
+  setWriteFault('off', 0);
+});
+
+describe('write fault injection', () => {
+  it.each(['ios-lock', 'android-lock', 'android-lock-no-code', 'commit-then-throw'] as const)(
+    '%s produces an error the shared lock predicate recognises',
+    (mode) => {
+      setWriteFault(mode, 1);
+      const phase = mode === 'commit-then-throw' ? 'after-commit' : 'before-task';
+
+      const fault = takeInjectedWriteFault(phase);
+
+      expect(fault).toBeInstanceOf(Error);
+      expect(isDatabaseLockedError(fault)).toBe(true);
+    },
+  );
+
+  it('disk-full is NOT lock contention, so the ladder must not retry it', () => {
+    setWriteFault('disk-full', 1);
+
+    const fault = takeInjectedWriteFault('before-task');
+
+    expect(fault).toBeInstanceOf(Error);
+    expect(isDatabaseLockedError(fault)).toBe(false);
+  });
+
+  it('fires exactly failAttempts times and then disarms itself', () => {
+    setWriteFault('ios-lock', 1);
+
+    expect(takeInjectedWriteFault('before-task')).toBeInstanceOf(Error);
+    expect(takeInjectedWriteFault('before-task')).toBeNull();
+    expect(getWriteFault()).toEqual({ mode: 'off', remaining: 0 });
+  });
+
+  it('clears immediately when switched off mid-run', () => {
+    setWriteFault('ios-lock', 99);
+    setWriteFault('off', 0);
+
+    expect(takeInjectedWriteFault('before-task')).toBeNull();
+  });
+
+  it('only commit-then-throw fires after the transaction commits', () => {
+    setWriteFault('commit-then-throw', 1);
+    expect(takeInjectedWriteFault('before-task')).toBeNull();
+    expect(takeInjectedWriteFault('after-commit')).toBeInstanceOf(Error);
+
+    setWriteFault('ios-lock', 1);
+    expect(takeInjectedWriteFault('after-commit')).toBeNull();
+    expect(takeInjectedWriteFault('before-task')).toBeInstanceOf(Error);
+  });
+});

--- a/packages/mobile/src/offline/dev/lock-holder.ts
+++ b/packages/mobile/src/offline/dev/lock-holder.ts
@@ -1,0 +1,56 @@
+// Dev-only write-lock holder for the offline database (issue #4315).
+//
+// Opens a SECOND connection to `boardsesh.db` and sits on a real write lock for
+// N milliseconds. Any hold longer than the app's `busy_timeout` makes every
+// other connection's write throw the GENUINE platform lock error — which is the
+// only way to prove on a device that `isDatabaseLockedError` still matches what
+// Android and iOS actually emit (Android prints a raw U+0005 control byte where
+// the result-code digit belongs; iOS prints `Error code 5:`). The fault injector
+// next door emits the strings we BELIEVE those platforms produce, so it cannot
+// substitute for this check.
+//
+// Reachable only from the tester/dev-gated "Offline writes" screen. Nothing here
+// runs at import time.
+
+import { openDatabaseAsync } from 'expo-sqlite';
+import { DATABASE_NAME } from '../../db';
+
+/** Key of the throwaway row the hold writes; never read by anything else. */
+const LOCK_HOLDER_META_KEY = 'dev:lock-holder';
+
+let holdingUntil = 0;
+
+export function isHoldingWriteLock(): boolean {
+  return Date.now() < holdingUntil;
+}
+
+/**
+ * Hold a real write lock on the offline database for `durationMs`.
+ *
+ * `busy_timeout = 0` on the holding connection so it never itself waits, then a
+ * throwaway write against `sync_meta` — a real write lock, not the deferred
+ * `BEGIN` that `withExclusiveTransactionAsync` opens, which takes no lock until
+ * its first statement. The row is deleted before the transaction commits, so the
+ * database is byte-identical afterwards.
+ *
+ * Resolves when the lock is released. Rejects only if the connection itself
+ * fails; the caller shows the message.
+ */
+export async function holdWriteLock(durationMs: number): Promise<void> {
+  const connection = await openDatabaseAsync(DATABASE_NAME);
+  holdingUntil = Date.now() + durationMs;
+  try {
+    await connection.withExclusiveTransactionAsync(async (txn) => {
+      await txn.execAsync('PRAGMA busy_timeout = 0');
+      await txn.runAsync(`INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)`, [
+        LOCK_HOLDER_META_KEY,
+        new Date().toISOString(),
+      ]);
+      await new Promise<void>((resolve) => setTimeout(resolve, durationMs));
+      await txn.runAsync(`DELETE FROM sync_meta WHERE key = ?`, [LOCK_HOLDER_META_KEY]);
+    });
+  } finally {
+    holdingUntil = 0;
+    await connection.closeAsync();
+  }
+}

--- a/packages/mobile/src/offline/dev/use-pending-mutations.ts
+++ b/packages/mobile/src/offline/dev/use-pending-mutations.ts
@@ -1,0 +1,37 @@
+// Dev-only outbox inspector (issue #4315).
+//
+// The More tab's "Sync issues" section only renders when `!isOffline &&
+// deadLetterCount > 0`, and it lists dead letters — so nothing in the app shows
+// a PENDING row, which is exactly what the tick degrade produces and exactly
+// what QA has to see, offline, to know the send survived. This is the read
+// behind that list.
+
+import { useQuery } from '@tanstack/react-query';
+import type { OfflineDatabase } from '@boardsesh/offline-sync';
+
+export type PendingMutationRow = {
+  id: number;
+  table_name: string;
+  operation: string;
+  idempotency_key: string;
+  status: string;
+  retry_count: number;
+  created_at: string;
+};
+
+/** Newest 50 outbox rows, whatever their status. Refetched on focus by the caller. */
+export function usePendingMutations(db: OfflineDatabase | null) {
+  return useQuery({
+    queryKey: ['dev', 'pendingMutations'],
+    enabled: db !== null,
+    queryFn: async (): Promise<PendingMutationRow[]> => {
+      if (!db) return [];
+      return db.getAllAsync<PendingMutationRow>(
+        `SELECT id, table_name, operation, idempotency_key, status, retry_count, created_at
+         FROM pending_mutations ORDER BY id DESC LIMIT 50`,
+        [],
+      );
+    },
+    staleTime: 0,
+  });
+}

--- a/packages/mobile/src/offline/dev/write-fault-injection.ts
+++ b/packages/mobile/src/offline/dev/write-fault-injection.ts
@@ -1,0 +1,89 @@
+// Dev-only fault injection for local SQLite writes (issue #4315).
+//
+// The retry ladder and the tick degrade branch cannot be reached by ordinary
+// use: measured import windows all fit inside the shipped 5s `busy_timeout`, so
+// "log a tick during a board download" just produces a normal fast save. The
+// sibling `lock-holder.ts` produces REAL contention, which is the only way to
+// prove the platform's genuine lock string is matched; this module covers the
+// shapes a real lock cannot schedule precisely — a specific number of failures,
+// a non-lock error, and the commit-then-throw case that motivates the
+// `INSERT OR IGNORE` on the tick insert.
+//
+// Consumed only from inside `if (__DEV__)` in `runLocalWrite`, so Metro's
+// minifier drops the branch in release; nothing here runs at import time.
+//
+// The lock strings are copied from the shapes `@boardsesh/offline-sync`'s
+// lock-errors.ts documents from real Sentry events, including the raw U+0005
+// byte Android emits where the result-code digit belongs. Built with
+// fromCharCode for the same reason lock-errors.ts does: no raw control byte in
+// source.
+
+export type WriteFaultMode =
+  | 'off'
+  | 'ios-lock'
+  | 'android-lock'
+  | 'android-lock-no-code'
+  | 'disk-full'
+  | 'commit-then-throw';
+
+export type WriteFaultPhase = 'before-task' | 'after-commit';
+
+const BUSY_CONTROL_BYTE = String.fromCharCode(5);
+
+const IOS_LOCK_MESSAGE =
+  "FunctionCallException: Calling the 'prepareAsync' function has failed\n→ Caused by: SQLiteErrorException: Error code 5: database is locked";
+const ANDROID_LOCK_MESSAGE =
+  "Call to function 'NativeDatabase.prepareAsync' has been rejected.\n→ Caused by: Error code " +
+  BUSY_CONTROL_BYTE +
+  ': database is locked';
+const ANDROID_LOCK_NO_CODE_MESSAGE =
+  "Call to function 'NativeDatabase.prepareAsync' has been rejected.\n→ Caused by: Error code : database is locked";
+const DISK_FULL_MESSAGE =
+  "FunctionCallException: Calling the 'runAsync' function has failed\n→ Caused by: SQLiteErrorException: Error code 13: database or disk is full";
+
+const FAULT_MESSAGES: Record<Exclude<WriteFaultMode, 'off'>, string> = {
+  'ios-lock': IOS_LOCK_MESSAGE,
+  'android-lock': ANDROID_LOCK_MESSAGE,
+  'android-lock-no-code': ANDROID_LOCK_NO_CODE_MESSAGE,
+  'disk-full': DISK_FULL_MESSAGE,
+  // The lock shape matters here too: a commit-then-throw only retries when the
+  // ladder classifies it as contention, which is the case being reproduced.
+  'commit-then-throw': IOS_LOCK_MESSAGE,
+};
+
+type WriteFaultState = { mode: WriteFaultMode; remaining: number };
+
+const state: WriteFaultState = { mode: 'off', remaining: 0 };
+
+/**
+ * Arm the injector. `failAttempts` is how many write attempts should fail
+ * before it disarms itself — 1 exercises "the retry recovers", a large number
+ * exercises "the ladder is exhausted and the caller degrades".
+ */
+export function setWriteFault(mode: WriteFaultMode, failAttempts: number): void {
+  state.mode = mode;
+  state.remaining = mode === 'off' ? 0 : Math.max(0, failAttempts);
+}
+
+export function getWriteFault(): WriteFaultState {
+  return { mode: state.mode, remaining: state.remaining };
+}
+
+/**
+ * Take one injected fault for this phase, or null.
+ *
+ * `commit-then-throw` fires only AFTER the transaction resolved — the exact
+ * shape a `SQLITE_BUSY` at COMMIT produces, and the only way to exercise the
+ * tick insert's idempotency on a device. Every other mode fires before the
+ * transaction opens.
+ */
+export function takeInjectedWriteFault(phase: WriteFaultPhase): Error | null {
+  const armedMode = state.mode;
+  if (armedMode === 'off' || state.remaining <= 0) return null;
+  const firesAfterCommit = armedMode === 'commit-then-throw';
+  if (firesAfterCommit !== (phase === 'after-commit')) return null;
+
+  state.remaining -= 1;
+  if (state.remaining <= 0) state.mode = 'off';
+  return new Error(FAULT_MESSAGES[armedMode]);
+}

--- a/packages/mobile/src/offline/local-write-telemetry.ts
+++ b/packages/mobile/src/offline/local-write-telemetry.ts
@@ -1,0 +1,49 @@
+// Telemetry for the local-write retry ladder (issue #4315).
+//
+// A contended local SQLite write is invisible today unless it is a tick: the
+// tick path reports to Sentry, but a favorite or follow whose transaction throws
+// just rejects, the heart reverts, and nobody learns. This binds the shared
+// ladder's `onSettled` seam to one PostHog event so every table's contention
+// shows up in the same chart.
+//
+// Silent on a clean write — `onSettled` only fires when the first attempt threw
+// — so the event's raw count is the contention rate, not the write rate.
+
+import {
+  isDatabaseLockedError,
+  type LocalWriteRetryOptions,
+  type LocalWriteRetryOutcome,
+} from '@boardsesh/offline-sync';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { track } from '../lib/analytics';
+import { isOnline } from './offline-sync-adapter';
+
+/**
+ * Retry options carrying the `onSettled` reporter for one write.
+ *
+ * Never throws: a failed report must not turn a saved write into a lost one
+ * (the shared ladder also guards this, so the try/catch here is belt and braces
+ * for the property reads, mirroring `reportEnqueueSuppressed`).
+ */
+export function localWriteRetryOptions(
+  tableName: string,
+  operation: 'create' | 'delete',
+): Pick<LocalWriteRetryOptions, 'onSettled'> {
+  return {
+    onSettled: ({ attempts, error, recovered, elapsedMs }: LocalWriteRetryOutcome) => {
+      try {
+        track(SHARED_EVENTS.OfflineLocalWriteAttemptFailed, {
+          tableName,
+          operation,
+          attempts,
+          elapsedMs,
+          outcome: recovered ? 'recovered' : 'exhausted',
+          isLockError: isDatabaseLockedError(error),
+          wasOffline: !isOnline(),
+        });
+      } catch (reportError) {
+        if (__DEV__) console.warn('[LocalWriteTelemetry] attempt-failed report failed:', reportError);
+      }
+    },
+  };
+}

--- a/packages/mobile/src/providers/__tests__/board-adapter.test.tsx
+++ b/packages/mobile/src/providers/__tests__/board-adapter.test.tsx
@@ -84,8 +84,9 @@ const trackMock = vi.hoisted(() => vi.fn());
 vi.mock('../../lib/analytics', () => ({ track: trackMock }));
 
 const isOnlineMock = vi.hoisted(() => vi.fn(() => true));
+const drainMutationQueueMock = vi.hoisted(() => vi.fn(async () => {}));
 vi.mock('../../offline/offline-sync-adapter', () => ({
-  drainMutationQueue: vi.fn(async () => {}),
+  drainMutationQueue: drainMutationQueueMock,
   subscribeMutationDelivery: vi.fn(() => () => {}),
   isOnline: isOnlineMock,
 }));
@@ -236,9 +237,23 @@ describe('BoardAdapterWrapper tick degrade + telemetry', () => {
     // No local tick row exists, so the badge query's JOIN returns 0 either way —
     // invalidating it would be a no-op that reads as intent.
     expect(queryClient.invalidateQueries).not.toHaveBeenCalled();
+    // The queued row should not wait for the next app-driven drain trigger.
+    expect(drainMutationQueueMock).toHaveBeenCalledTimes(1);
   });
 
   it('falls through to the network when the degrade also fails', async () => {
+    writeTickLocalMock.mockRejectedValue(new Error('database is locked'));
+    enqueueTickOutboxOnlyMock.mockRejectedValue(new Error('still locked'));
+    isOnlineMock.mockReturnValue(false);
+
+    const { savedTick } = await saveTick();
+
+    expect(savedTick).toBeNull();
+    // Nothing was queued, so there is nothing to drain.
+    expect(drainMutationQueueMock).not.toHaveBeenCalled();
+  });
+
+  it('reports fell_through when the degrade also fails', async () => {
     writeTickLocalMock.mockRejectedValue(new Error('database is locked'));
     enqueueTickOutboxOnlyMock.mockRejectedValue(new Error('still locked'));
     isOnlineMock.mockReturnValue(false);

--- a/packages/mobile/src/providers/__tests__/board-adapter.test.tsx
+++ b/packages/mobile/src/providers/__tests__/board-adapter.test.tsx
@@ -91,8 +91,10 @@ vi.mock('../../offline/offline-sync-adapter', () => ({
 }));
 
 const writeTickLocalMock = vi.hoisted(() => vi.fn(async () => {}));
+const enqueueTickOutboxOnlyMock = vi.hoisted(() => vi.fn(async () => {}));
 vi.mock('../../hooks/use-offline-mutations', () => ({
   writeTickLocal: writeTickLocalMock,
+  enqueueTickOutboxOnly: enqueueTickOutboxOnlyMock,
 }));
 
 import { SHARED_EVENTS } from '@boardsesh/analytics';
@@ -104,6 +106,7 @@ beforeEach(() => {
   capturedAdapter = undefined;
   isOnlineMock.mockReturnValue(true);
   writeTickLocalMock.mockResolvedValue(undefined);
+  enqueueTickOutboxOnlyMock.mockResolvedValue(undefined);
 });
 
 describe('BoardAdapterWrapper offline gating', () => {
@@ -158,25 +161,112 @@ describe('BoardAdapterWrapper offline gating', () => {
   });
 });
 
-// Issue #4315. When the local write throws, saveTickOffline returns null and
-// useSaveTick falls through to a direct network save. Online that still lands;
-// OFFLINE the network save fails and the tick is gone. Nothing in the old
-// report distinguished those two, so the Sentry count could not tell us how
-// many ticks were actually lost.
-describe('BoardAdapterWrapper tick-local-write telemetry', () => {
-  async function saveTickWithLocalWriteError(error: unknown) {
-    offlineEnabled = true;
-    writeTickLocalMock.mockRejectedValue(error);
-    render(<BoardAdapterWrapper>{null}</BoardAdapterWrapper>);
-    const queryClient = { invalidateQueries: vi.fn() };
-    return capturedAdapter?.saveTickOffline?.(
-      { input: { climbUuid: 'climb-1', angle: 40 } } as never,
-      { queryClient, executeHttp: vi.fn() } as never,
-    );
+// Issue #4315. A local write that throws used to drop the send outright:
+// saveTickOffline returned null, useSaveTick fell through to a direct network
+// save, and offline that save failed. Now the catch tries the outbox row alone,
+// so the send still reaches the server on the next drain — and every exit emits
+// exactly one event saying which of the two happened.
+describe('BoardAdapterWrapper tick degrade + telemetry', () => {
+  function makeVariables() {
+    return { input: { climbUuid: 'climb-1', angle: 40 } } as unknown as Parameters<
+      NonNullable<BoardAdapter['saveTickOffline']>
+    >[0];
   }
 
-  it('keeps returning null so the network fall-through is unchanged', async () => {
-    await expect(saveTickWithLocalWriteError(new Error('disk I/O error'))).resolves.toBeNull();
+  async function saveTick(variables = makeVariables(), queryClient = { invalidateQueries: vi.fn() }) {
+    offlineEnabled = true;
+    render(<BoardAdapterWrapper>{null}</BoardAdapterWrapper>);
+    const savedTick = await capturedAdapter?.saveTickOffline?.(variables, {
+      queryClient,
+      executeHttp: vi.fn(),
+    } as never);
+    return { savedTick, queryClient };
+  }
+
+  // The contract that stops one send being delivered twice: the local write, the
+  // queued replay and useSaveTick's network fall-through all carry this uuid, and
+  // the server's saveTick returns the existing row for a repeat.
+  it('stamps input.uuid with the generated tick uuid before the write, on the success path', async () => {
+    const variables = makeVariables();
+
+    const { savedTick } = await saveTick(variables);
+
+    expect(variables.input.uuid).toBe('uuid-fixed');
+    expect(savedTick?.uuid).toBe('uuid-fixed');
+    // Stamped BEFORE the write, not after it.
+    expect(writeTickLocalMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ uuid: 'uuid-fixed' }),
+      'uuid-fixed',
+      expect.any(Number),
+    );
+  });
+
+  it('stamps input.uuid on the failure path too, so the fall-through cannot double-deliver', async () => {
+    writeTickLocalMock.mockRejectedValue(new Error('disk I/O error'));
+    enqueueTickOutboxOnlyMock.mockRejectedValue(new Error('disk I/O error'));
+    const variables = makeVariables();
+
+    await saveTick(variables);
+
+    expect(variables.input.uuid).toBe('uuid-fixed');
+  });
+
+  it('degrades to an outbox-only row and reports the tick as queued', async () => {
+    writeTickLocalMock.mockRejectedValue(new Error('database is locked'));
+    isOnlineMock.mockReturnValue(false);
+
+    const { savedTick, queryClient } = await saveTick();
+
+    expect(enqueueTickOutboxOnlyMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ uuid: 'uuid-fixed' }),
+      'uuid-fixed',
+      expect.any(Number),
+    );
+    // Same saved-tick shape as a clean offline save: useSaveTick treats it as
+    // `delivery: 'queued'` and the delivery subscription keys on the same uuid.
+    expect(savedTick).toMatchObject({ uuid: 'uuid-fixed', climbUuid: 'climb-1', angle: 40 });
+    expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineTickLocalWriteFailed, {
+      isLockError: true,
+      wasOffline: true,
+      error: expect.any(String),
+      outcome: 'queued',
+    });
+    // No local tick row exists, so the badge query's JOIN returns 0 either way —
+    // invalidating it would be a no-op that reads as intent.
+    expect(queryClient.invalidateQueries).not.toHaveBeenCalled();
+  });
+
+  it('falls through to the network when the degrade also fails', async () => {
+    writeTickLocalMock.mockRejectedValue(new Error('database is locked'));
+    enqueueTickOutboxOnlyMock.mockRejectedValue(new Error('still locked'));
+    isOnlineMock.mockReturnValue(false);
+
+    const { savedTick } = await saveTick();
+
+    expect(savedTick).toBeNull();
+    expect(trackMock).toHaveBeenCalledWith(
+      SHARED_EVENTS.OfflineTickLocalWriteFailed,
+      expect.objectContaining({ outcome: 'fell_through' }),
+    );
+  });
+
+  // The terminal-event invariant: one failed local write, one event, whichever
+  // exit it takes. Anything else makes the loss rate unreadable.
+  it.each([
+    ['the degrade succeeds', undefined],
+    ['the degrade fails', new Error('still locked')],
+  ])('emits exactly one Offline Tick Local Write Failed when %s', async (_label, fallbackError) => {
+    writeTickLocalMock.mockRejectedValue(new Error('database is locked'));
+    if (fallbackError) enqueueTickOutboxOnlyMock.mockRejectedValue(fallbackError);
+
+    await saveTick();
+
+    const tickFailureEvents = trackMock.mock.calls.filter(
+      ([eventName]) => eventName === SHARED_EVENTS.OfflineTickLocalWriteFailed,
+    );
+    expect(tickFailureEvents).toHaveLength(1);
   });
 
   it.each([
@@ -186,10 +276,13 @@ describe('BoardAdapterWrapper tick-local-write telemetry', () => {
     ['a non-lock error while online', new Error('disk I/O error'), true, false, false],
   ])('tags %s', async (_label, error, online, expectedWasOffline, expectedIsLockError) => {
     isOnlineMock.mockReturnValue(online);
+    writeTickLocalMock.mockRejectedValue(error);
 
-    await saveTickWithLocalWriteError(error);
+    await saveTick();
 
     expect(reportHandledErrorMock).toHaveBeenCalledWith(
+      // The ORIGINAL error object by identity — the ladder rethrows without
+      // wrapping, so the existing 90-day Sentry aggregate does not fork.
       error,
       expect.objectContaining({
         tags: {
@@ -198,6 +291,7 @@ describe('BoardAdapterWrapper tick-local-write telemetry', () => {
           kind: 'tick-local-write',
           was_offline: expectedWasOffline,
           is_lock_error: expectedIsLockError,
+          outcome: 'queued',
         },
       }),
     );
@@ -205,19 +299,15 @@ describe('BoardAdapterWrapper tick-local-write telemetry', () => {
       isLockError: expectedIsLockError,
       wasOffline: expectedWasOffline,
       error: expect.any(String),
+      outcome: 'queued',
     });
   });
 
   it('emits nothing when the local write succeeds', async () => {
-    offlineEnabled = true;
-    render(<BoardAdapterWrapper>{null}</BoardAdapterWrapper>);
-
-    await capturedAdapter?.saveTickOffline?.(
-      { input: { climbUuid: 'climb-1', angle: 40 } } as never,
-      { queryClient: { invalidateQueries: vi.fn() }, executeHttp: vi.fn() } as never,
-    );
+    await saveTick();
 
     expect(reportHandledErrorMock).not.toHaveBeenCalled();
     expect(trackMock).not.toHaveBeenCalled();
+    expect(enqueueTickOutboxOnlyMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/providers/board-adapter.tsx
+++ b/packages/mobile/src/providers/board-adapter.tsx
@@ -13,6 +13,8 @@ import {
   CLIMB_STATS_UPDATED_SUBSCRIPTION,
   type ClimbStatsForClimbsResponse,
   type ClimbStatsUpdatedSubscriptionResponse,
+  type SaveTickMutationResponse,
+  type SaveTickMutationVariables,
 } from '@boardsesh/graphql/operations';
 import { useAuth } from './auth-provider';
 import { useOfflineDownloadsEnabled } from './feature-flags-provider';
@@ -24,10 +26,33 @@ import { captureAuthCredentialGeneration, isAuthCredentialGenerationCurrent } fr
 import { reportHandledError } from '../lib/error-reporting';
 import { getWsClient } from '../lib/graphql/ws-client';
 import { drainMutationQueue, isOnline, subscribeMutationDelivery } from '../offline/offline-sync-adapter';
-import { writeTickLocal } from '../hooks/use-offline-mutations';
-import { isDatabaseLockedError } from '@boardsesh/offline-sync';
+import { enqueueTickOutboxOnly, writeTickLocal } from '../hooks/use-offline-mutations';
+import { isDatabaseLockedError, OFFLINE_LOCAL_WRITE_BUDGET_MS } from '@boardsesh/offline-sync';
 import { SHARED_EVENTS, sanitizeErrorForAnalytics } from '@boardsesh/analytics';
 import { track } from '../lib/analytics';
+
+/**
+ * The saved-tick shape useSaveTick writes into its logbook cache. Identical on
+ * the normal offline save and on the degraded (outbox-only) one — the tick is
+ * queued either way, so the in-session UI must not be able to tell them apart.
+ */
+function toSavedTickShape(
+  input: SaveTickMutationVariables['input'],
+  tickUuid: string,
+): SaveTickMutationResponse['saveTick'] {
+  return {
+    uuid: tickUuid,
+    climbUuid: input.climbUuid,
+    angle: input.angle,
+    isMirror: input.isMirror,
+    status: input.status,
+    attemptCount: input.attemptCount,
+    quality: input.quality ?? null,
+    difficulty: input.difficulty ?? null,
+    comment: input.comment,
+    climbedAt: input.climbedAt,
+  };
+}
 
 export function BoardAdapterWrapper({ children }: { children: ReactNode }) {
   const { isAuthenticated, isLoading } = useAuth();
@@ -134,39 +159,91 @@ export function BoardAdapterWrapper({ children }: { children: ReactNode }) {
             if (!db) return null;
 
             const tickUuid = randomUUID();
+            // Stamp the id EVERY delivery path will carry, before the first
+            // write. The server's saveTick dedupes on SaveTickInput.uuid and
+            // returns the existing row for a repeat, so the local write, the
+            // queued replay and useSaveTick's network fall-through all resolve
+            // to one tick. Without it, a transaction that committed its outbox
+            // row and still threw (a SQLITE_BUSY surfacing at COMMIT) would
+            // queue the send AND post a second, differently-identified one.
+            variables.input.uuid = tickUuid;
+            // One deadline for both ladders, so the retry and the fallback
+            // together can never block the log-ascent sheet past the budget.
+            const deadline = Date.now() + OFFLINE_LOCAL_WRITE_BUDGET_MS;
             try {
-              await writeTickLocal(db, variables.input, tickUuid);
+              await writeTickLocal(db, variables.input, tickUuid, OFFLINE_LOCAL_WRITE_BUDGET_MS);
             } catch (error) {
-              // A broken local DB (disk full, corruption) must not block the tick:
-              // returning null falls through to the direct network save in
-              // useSaveTick. Offline, that network attempt fails visibly — same
-              // outcome as today — but online the send still lands.
+              // The retry ladder is spent. Try the strictly smaller write: the
+              // outbox row alone. A queued mutation replays from its payload, so
+              // that row is enough for the send to reach the server — the local
+              // `boardsesh_ticks` row only serves LOCAL reads.
               //
-              // The two dimensions on the report are what the Sentry trend alone
-              // could never answer. `wasOffline` splits "fell through and landed"
-              // from "fell through and the tick is gone" — the only version of
-              // this failure that actually loses data. `isLockError` says whether
-              // it was write-lock contention (the snapshot import holding a long
-              // EXCLUSIVE, #4314) or a genuinely broken database, which need
-              // completely different fixes. The `kind` tag is unchanged on
-              // purpose so the existing 90-day trend stays comparable.
+              // What the user gives up when this branch wins: no local tick row,
+              // so (a) the "waiting to sync" badge does not light on that climb,
+              // and (b) if the app is killed while still offline, the tick is
+              // missing from the local logbook until the drain lands it and the
+              // pull brings the server row back down. Both are strictly better
+              // than losing the send, and both self-heal.
               const wasOffline = !isOnline();
               const isLockError = isDatabaseLockedError(error);
+              let queued = false;
+              let fallbackError: unknown = null;
+              try {
+                await enqueueTickOutboxOnly(db, variables.input, tickUuid, Math.max(0, deadline - Date.now()));
+                queued = true;
+              } catch (caught) {
+                fallbackError = caught;
+                if (__DEV__) {
+                  console.warn('[BoardAdapter] outbox-only tick fallback failed:', caught);
+                }
+              }
+
+              // `wasOffline` splits "fell through and landed" from "fell through
+              // and the tick is gone" — the only version that actually loses
+              // data. `isLockError` says whether it was write-lock contention
+              // (#4314) or a genuinely broken database, which need completely
+              // different fixes. The reported error object and the `kind` tag are
+              // the ORIGINAL ones on purpose, so the existing 90-day Sentry trend
+              // stays comparable and does not fork on this change.
               reportHandledError(error, {
                 tags: {
                   source: 'offline-sync',
                   kind: 'tick-local-write',
                   was_offline: wasOffline,
                   is_lock_error: isLockError,
+                  outcome: queued ? 'queued' : 'fell_through',
                 },
-                extra: { errorMessage: error instanceof Error ? error.message : String(error) },
+                extra: {
+                  errorMessage: error instanceof Error ? error.message : String(error),
+                  fallbackErrorMessage:
+                    fallbackError === null
+                      ? null
+                      : fallbackError instanceof Error
+                        ? fallbackError.message
+                        : String(fallbackError),
+                },
               });
+              // Exactly one per failed local write, on both exits.
               track(SHARED_EVENTS.OfflineTickLocalWriteFailed, {
                 isLockError,
                 wasOffline,
                 error: sanitizeErrorForAnalytics(error),
+                outcome: queued ? 'queued' : 'fell_through',
               });
-              return null;
+
+              // Nothing queued: fall through to the direct network save, which
+              // now carries the stamped uuid so it cannot double-deliver.
+              if (!queued) return null;
+
+              // Deliberately NO invalidateQueries(['localTicks', …]) here: with no
+              // local tick row the badge query's JOIN returns 0 either way, so it
+              // would be a no-op that reads as intent.
+              void drainMutationQueue(db, queryClient, executeHttp).catch((drainError: unknown) => {
+                if (__DEV__) {
+                  console.warn('[BoardAdapter] degraded tick queue drain failed:', drainError);
+                }
+              });
+              return toSavedTickShape(variables.input, tickUuid);
             }
             // Wake the "waiting to sync" badge immediately: its query caches with
             // staleTime Infinity and the drainer (its usual invalidator) no-ops
@@ -178,18 +255,7 @@ export function BoardAdapterWrapper({ children }: { children: ReactNode }) {
               }
             });
 
-            return {
-              uuid: tickUuid,
-              climbUuid: variables.input.climbUuid,
-              angle: variables.input.angle,
-              isMirror: variables.input.isMirror,
-              status: variables.input.status,
-              attemptCount: variables.input.attemptCount,
-              quality: variables.input.quality ?? null,
-              difficulty: variables.input.difficulty ?? null,
-              comment: variables.input.comment,
-              climbedAt: variables.input.climbedAt,
-            };
+            return toSavedTickShape(variables.input, tickUuid);
           },
       // Mobile has no IndexedDB tick-draft store, so onTickSaved is omitted.
       showError: (reason) => showErrorRef.current?.(reason),

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -449,11 +449,29 @@ export const SHARED_EVENTS = {
   // so neither a drain nor a dead-letter event can ever report it. Props:
   // { tableName, operation, existingStatus }.
   OfflineMutationEnqueueSuppressed: 'Offline Mutation Enqueue Suppressed',
-  // Offline sync — the local SQLite write behind an offline tick threw, so the
-  // tick fell through to a direct network save. Online that still lands;
-  // offline it is a lost tick. `wasOffline` is the dimension that splits those
-  // two, and `isLockError` says whether it was write-lock contention (#4314)
-  // rather than a broken database. Props: { isLockError, wasOffline, error }.
+  // Offline sync — the FIRST attempt of a local SQLite write (tick, favorite,
+  // follow) threw, so the retry ladder ran. Silent on a clean write, so its raw
+  // count is the contention rate. `outcome: 'recovered'` means a later attempt
+  // landed and the user lost nothing; 'exhausted' means the ladder gave up and
+  // the caller saw the throw. `attempts: 1` + 'exhausted' means the error was not
+  // lock contention (disk full, corruption) and was therefore never retried.
+  // `elapsedMs` is the contention-duration measurement — its distribution is what
+  // should size the ladder, which today rests on an estimate. This is the ONLY
+  // signal for a lost favorite/follow; those paths have no Sentry report at all.
+  // Props: { tableName, operation, attempts, outcome: 'recovered' | 'exhausted',
+  // isLockError, wasOffline, elapsedMs }.
+  OfflineLocalWriteAttemptFailed: 'Offline Local Write Attempt Failed',
+  // Offline sync — the local SQLite write behind an offline tick threw. `outcome`
+  // says what happened next: 'queued' means the outbox-only fallback still saved
+  // the tick and it will sync; 'fell_through' means it did not, and the direct
+  // network save is the last chance (fine online, a lost tick offline).
+  // `wasOffline` is the dimension that splits those two, and `isLockError` says
+  // whether it was write-lock contention (#4314) rather than a broken database.
+  // Exactly one per failed local write, on every exit path. A failed write also
+  // emits one `Offline Local Write Attempt Failed` — two layers of one story (the
+  // write ladder and the degrade), not a double count. A RECOVERED write emits
+  // only that one, never this. Props: { isLockError, wasOffline, error,
+  // outcome: 'queued' | 'fell_through' }.
   OfflineTickLocalWriteFailed: 'Offline Tick Local Write Failed',
   // Offline sync — the deletions-coverage verdict for one sync cycle, reported
   // whatever it is. The reset event above only fires on the rare wipe, and a

--- a/packages/shared/board-react/src/__tests__/use-save-tick.test.tsx
+++ b/packages/shared/board-react/src/__tests__/use-save-tick.test.tsx
@@ -155,6 +155,50 @@ describe('useSaveTick (shared)', () => {
     expect(cache?.[0].uuid).toBe('local-1');
   });
 
+  // Issue #4315. The offline adapter may stamp `variables.input.uuid` with the id
+  // it queued under, and useSaveTick sends the SAME object on the fall-through —
+  // so a write that queued the tick and still threw cannot deliver it twice.
+  it('sends the adapter-stamped uuid on the network fall-through', async () => {
+    const executeHttp = vi.fn().mockResolvedValue({ saveTick: savedTick({ uuid: 'stamped-1' }) });
+    const saveTickOffline = vi.fn().mockImplementation(async (variables: { input: { uuid?: string } }) => {
+      variables.input.uuid = 'stamped-1';
+      return null;
+    });
+    const { wrapper, queryClient } = createWrapper({
+      executeHttp: executeHttp as unknown as ExecuteHttp,
+      saveTickOffline,
+    });
+    queryClient.setQueryData(accumulatedLogbookQueryKey('kilter'), []);
+
+    const { result } = renderHook(() => useSaveTick('kilter'), { wrapper });
+    await act(async () => {
+      result.current.mutate(tickOptions());
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(executeHttp).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ input: expect.objectContaining({ uuid: 'stamped-1' }) }),
+    );
+  });
+
+  // Web omits saveTickOffline entirely, so nothing stamps a uuid and the server
+  // mints one exactly as before.
+  it('sends no uuid when the adapter has no offline save path', async () => {
+    const executeHttp = vi.fn().mockResolvedValue({ saveTick: savedTick() });
+    const { wrapper, queryClient } = createWrapper({ executeHttp: executeHttp as unknown as ExecuteHttp });
+    queryClient.setQueryData(accumulatedLogbookQueryKey('kilter'), []);
+
+    const { result } = renderHook(() => useSaveTick('kilter'), { wrapper });
+    await act(async () => {
+      result.current.mutate(tickOptions());
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [, sentVariables] = executeHttp.mock.calls[0] as [string, { input: Record<string, unknown> }];
+    expect(sentVariables.input.uuid).toBeUndefined();
+  });
+
   it('schedules the exact post-ack repair when an eager drain wins the queued-token race', async () => {
     const scheduledTasks: Array<() => void> = [];
     const saveTickOffline = vi.fn().mockImplementation(async () => {

--- a/packages/shared/board-react/src/adapter.tsx
+++ b/packages/shared/board-react/src/adapter.tsx
@@ -73,6 +73,14 @@ export type BoardAdapter = {
    * Optional platform-local save path. Mobile uses this to commit a tick to
    * SQLite and enqueue the GraphQL replay before falling back to network-only
    * behavior when no local database is available. Web omits it.
+   *
+   * The adapter MAY stamp `variables.input.uuid` with the id it queued the tick
+   * under, and mobile does. `useSaveTick` sends that SAME `variables` object on
+   * the fall-through, and the server's `saveTick` dedupes on
+   * `SaveTickInput.uuid` — so the local write, the outbox replay and the network
+   * fall-through all resolve to one server row. Without the stamp, a write that
+   * committed its outbox row and still threw (a `SQLITE_BUSY` surfacing at
+   * COMMIT) would deliver the same send twice with no way to merge them.
    */
   saveTickOffline?: (
     variables: SaveTickMutationVariables,

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -648,6 +648,7 @@
     },
     "logAscent": {
       "errorMessage": "Deine Begehung konnte nicht gespeichert werden. Versuch es nochmal.",
+      "offlineErrorMessage": "Deine Begehung konnte offline nicht gespeichert werden. Der Speicher deines Handys war belegt – versuch es gleich nochmal.",
       "savedToast": "Eintrag gespeichert"
     },
     "tick": {

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -648,6 +648,7 @@
     },
     "logAscent": {
       "errorMessage": "Could not save your ascent. Please try again.",
+      "offlineErrorMessage": "Couldn't save this ascent while you're offline. Your phone's storage was busy — try again in a moment.",
       "savedToast": "Tick saved"
     },
     "tick": {

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -648,6 +648,7 @@
     },
     "logAscent": {
       "errorMessage": "No se pudo guardar tu ascenso. Inténtalo de nuevo.",
+      "offlineErrorMessage": "No se pudo guardar tu ascenso sin conexión. El almacenamiento del teléfono estaba ocupado; inténtalo de nuevo en un momento.",
       "savedToast": "Encadene guardado"
     },
     "tick": {

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -648,6 +648,7 @@
     },
     "logAscent": {
       "errorMessage": "Impossible de sauvegarder votre ascension. Veuillez réessayer.",
+      "offlineErrorMessage": "Impossible d'enregistrer votre ascension hors ligne. Le stockage du téléphone était occupé, réessayez dans un instant.",
       "savedToast": "Tick enregistré"
     },
     "tick": {

--- a/packages/shared/offline-sync/src/db/__tests__/pragmas.test.ts
+++ b/packages/shared/offline-sync/src/db/__tests__/pragmas.test.ts
@@ -10,6 +10,8 @@ import { join } from 'node:path';
 import {
   OFFLINE_DB_BUSY_TIMEOUT_MS,
   OFFLINE_DB_WAL_SWITCH_TIMEOUT_MS,
+  OFFLINE_DB_RETRY_BUSY_TIMEOUT_MS,
+  OFFLINE_DB_FALLBACK_BUSY_TIMEOUT_MS,
   applyBusyTimeout,
   configureMainConnection,
 } from '../pragmas';
@@ -38,6 +40,24 @@ describe('applyBusyTimeout', () => {
 
     const after = await db.getFirstAsync<{ timeout: number }>('PRAGMA busy_timeout');
     expect(after?.timeout).toBe(OFFLINE_DB_BUSY_TIMEOUT_MS);
+  });
+
+  // The retry ladder shortens the wait on later attempts (issue #4315): attempt 1
+  // already sat out the full five seconds, so a second full wait buys little.
+  it('honours an explicit timeout for a retry attempt', async () => {
+    await applyBusyTimeout(db, OFFLINE_DB_RETRY_BUSY_TIMEOUT_MS);
+
+    const after = await db.getFirstAsync<{ timeout: number }>('PRAGMA busy_timeout');
+    expect(after?.timeout).toBe(OFFLINE_DB_RETRY_BUSY_TIMEOUT_MS);
+    expect(OFFLINE_DB_RETRY_BUSY_TIMEOUT_MS).toBeLessThan(OFFLINE_DB_BUSY_TIMEOUT_MS);
+  });
+
+  it('honours the shorter fallback timeout for the last-chance write', async () => {
+    await applyBusyTimeout(db, OFFLINE_DB_FALLBACK_BUSY_TIMEOUT_MS);
+
+    const after = await db.getFirstAsync<{ timeout: number }>('PRAGMA busy_timeout');
+    expect(after?.timeout).toBe(OFFLINE_DB_FALLBACK_BUSY_TIMEOUT_MS);
+    expect(OFFLINE_DB_FALLBACK_BUSY_TIMEOUT_MS).toBeLessThan(OFFLINE_DB_RETRY_BUSY_TIMEOUT_MS);
   });
 });
 

--- a/packages/shared/offline-sync/src/db/__tests__/write-retry.test.ts
+++ b/packages/shared/offline-sync/src/db/__tests__/write-retry.test.ts
@@ -1,0 +1,164 @@
+// The retry ladder's contract (issue #4315). Every assertion here is something
+// a caller depends on: the silence on a clean write (the event's count is the
+// contention rate), the identity-preserving rethrow (Sentry grouping), and the
+// budget gating retries but never attempt 1.
+//
+// Clock and sleep are injected, so no fake timers and no real waiting.
+
+import { describe, it, expect, vi } from 'vitest';
+import { runLocalWriteWithRetry, OFFLINE_LOCAL_WRITE_BUDGET_MS } from '../write-retry';
+
+const LOCK_ERROR = () => new Error('Error code 5: database is locked');
+const DISK_ERROR = () => new Error('database or disk is full');
+
+/** A clock that advances by `stepMs` on every read, so elapsed time is exact. */
+function steppingClock(stepMs: number) {
+  let value = 0;
+  return () => {
+    const current = value;
+    value += stepMs;
+    return current;
+  };
+}
+
+describe('runLocalWriteWithRetry', () => {
+  it('returns the write value and reports nothing when the first attempt succeeds', async () => {
+    const onSettled = vi.fn();
+    const write = vi.fn().mockResolvedValue('saved');
+
+    await expect(runLocalWriteWithRetry(write, { onSettled })).resolves.toBe('saved');
+
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(onSettled).not.toHaveBeenCalled();
+  });
+
+  it('passes the 1-based attempt number to the write', async () => {
+    const attempts: number[] = [];
+    await runLocalWriteWithRetry(
+      async (attempt) => {
+        attempts.push(attempt);
+        if (attempt === 1) throw LOCK_ERROR();
+      },
+      { sleep: async () => {} },
+    );
+
+    expect(attempts).toEqual([1, 2]);
+  });
+
+  it('retries a lock error and reports a recovery', async () => {
+    const onSettled = vi.fn();
+    const write = vi.fn().mockRejectedValueOnce(LOCK_ERROR()).mockResolvedValue('second');
+
+    await expect(runLocalWriteWithRetry(write, { onSettled, sleep: async () => {} })).resolves.toBe('second');
+
+    expect(write).toHaveBeenCalledTimes(2);
+    expect(onSettled).toHaveBeenCalledTimes(1);
+    expect(onSettled.mock.calls[0][0]).toMatchObject({ attempts: 2, recovered: true });
+  });
+
+  it('does not retry a non-lock error', async () => {
+    const onSettled = vi.fn();
+    const write = vi.fn().mockRejectedValue(DISK_ERROR());
+
+    await expect(runLocalWriteWithRetry(write, { onSettled, sleep: async () => {} })).rejects.toThrow(
+      'database or disk is full',
+    );
+
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(onSettled.mock.calls[0][0]).toMatchObject({ attempts: 1, recovered: false });
+  });
+
+  it('rethrows after exhausting maxAttempts and reports the exhaustion', async () => {
+    const onSettled = vi.fn();
+    const write = vi.fn().mockRejectedValue(LOCK_ERROR());
+
+    await expect(runLocalWriteWithRetry(write, { onSettled, sleep: async () => {} })).rejects.toThrow(
+      'database is locked',
+    );
+
+    expect(write).toHaveBeenCalledTimes(2);
+    expect(onSettled.mock.calls[0][0]).toMatchObject({ attempts: 2, recovered: false });
+  });
+
+  it('rethrows the SAME error object, so Sentry grouping and lock classification are unchanged', async () => {
+    const thrown = DISK_ERROR();
+    const caught = await runLocalWriteWithRetry(async () => {
+      throw thrown;
+    }).catch((error: unknown) => error);
+
+    expect(caught).toBe(thrown);
+  });
+
+  it('sleeps the retry delay between attempts', async () => {
+    const sleep = vi.fn(async () => {});
+    const write = vi.fn().mockRejectedValueOnce(LOCK_ERROR()).mockResolvedValue(null);
+
+    await runLocalWriteWithRetry(write, { retryDelayMs: 150, sleep });
+
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(150);
+  });
+
+  it('still runs attempt 1 with a zero budget, and does not retry', async () => {
+    const write = vi.fn().mockRejectedValue(LOCK_ERROR());
+    const sleep = vi.fn(async () => {});
+
+    await expect(runLocalWriteWithRetry(write, { budgetMs: 0, sleep })).rejects.toThrow('database is locked');
+
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('stops on the budget rather than on maxAttempts once the clock has run out', async () => {
+    // 5s per clock read: the first budget check sits at 5s (a retry still fits),
+    // the second at 10s (it does not) — so four allowed attempts yield two.
+    const write = vi.fn().mockRejectedValue(LOCK_ERROR());
+    const sleep = vi.fn(async () => {});
+
+    await expect(runLocalWriteWithRetry(write, { maxAttempts: 4, now: steppingClock(5000), sleep })).rejects.toThrow(
+      'database is locked',
+    );
+
+    expect(write).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports elapsedMs from the injected clock', async () => {
+    const onSettled = vi.fn();
+    const write = vi.fn().mockRejectedValueOnce(LOCK_ERROR()).mockResolvedValue(null);
+
+    await runLocalWriteWithRetry(write, { onSettled, now: steppingClock(100), sleep: async () => {} });
+
+    // Reads: start=0, budget check=100, settle=200.
+    expect(onSettled.mock.calls[0][0].elapsedMs).toBe(200);
+  });
+
+  it('does not let a throwing onSettled change the outcome', async () => {
+    const onSettled = vi.fn(() => {
+      throw new Error('analytics exploded');
+    });
+
+    await expect(
+      runLocalWriteWithRetry(vi.fn().mockRejectedValueOnce(LOCK_ERROR()).mockResolvedValue('ok'), {
+        onSettled,
+        sleep: async () => {},
+      }),
+    ).resolves.toBe('ok');
+
+    await expect(
+      runLocalWriteWithRetry(vi.fn().mockRejectedValue(DISK_ERROR()), { onSettled, sleep: async () => {} }),
+    ).rejects.toThrow('database or disk is full');
+  });
+
+  it('honours a custom shouldRetry over the lock-error default', async () => {
+    const write = vi.fn().mockRejectedValueOnce(DISK_ERROR()).mockResolvedValue('retried anyway');
+
+    await expect(runLocalWriteWithRetry(write, { shouldRetry: () => true, sleep: async () => {} })).resolves.toBe(
+      'retried anyway',
+    );
+    expect(write).toHaveBeenCalledTimes(2);
+  });
+
+  it('caps the default budget at nine seconds', () => {
+    expect(OFFLINE_LOCAL_WRITE_BUDGET_MS).toBe(9000);
+  });
+});

--- a/packages/shared/offline-sync/src/db/pragmas.ts
+++ b/packages/shared/offline-sync/src/db/pragmas.ts
@@ -46,12 +46,33 @@ export const OFFLINE_DB_BUSY_TIMEOUT_MS = 5000;
 export const OFFLINE_DB_WAL_SWITCH_TIMEOUT_MS = 250;
 
 /**
+ * The `busy_timeout` for a RETRY of a local write whose first attempt already
+ * waited out the full five seconds. Shorter on purpose: measured import windows
+ * (`Offline Board Download Completed.importMs`, p50 806ms / max 3.2s over 60
+ * days) all fit inside attempt 1, so a second full wait buys almost nothing —
+ * this attempt asks "did the lock clear in the retry gap?" and gets out of the
+ * log-ascent sheet's way if it did not.
+ */
+export const OFFLINE_DB_RETRY_BUSY_TIMEOUT_MS = 1500;
+
+/**
+ * The `busy_timeout` for the last-chance fallback write, run after the main
+ * write has already lost the lock twice (mobile's outbox-only tick degrade).
+ * One second: the user is blocked on it, it is the smallest write on the path,
+ * and the whole ladder still has to land inside OFFLINE_LOCAL_WRITE_BUDGET_MS.
+ */
+export const OFFLINE_DB_FALLBACK_BUSY_TIMEOUT_MS = 1000;
+
+/**
  * Set `busy_timeout` on a connection. Call as the first statement of every
  * `withExclusiveTransactionAsync` task — the task runs on its own native
  * connection, which starts at `busy_timeout = 0`.
+ *
+ * `timeoutMs` exists for the retry ladder, which shortens the wait on later
+ * attempts (see the two constants above). Everything else takes the default.
  */
-export async function applyBusyTimeout(db: SqlExecutor): Promise<void> {
-  await db.execAsync(`PRAGMA busy_timeout = ${OFFLINE_DB_BUSY_TIMEOUT_MS}`);
+export async function applyBusyTimeout(db: SqlExecutor, timeoutMs = OFFLINE_DB_BUSY_TIMEOUT_MS): Promise<void> {
+  await db.execAsync(`PRAGMA busy_timeout = ${timeoutMs}`);
 }
 
 /**

--- a/packages/shared/offline-sync/src/db/write-retry.ts
+++ b/packages/shared/offline-sync/src/db/write-retry.ts
@@ -1,0 +1,147 @@
+// Retry ladder for a local SQLite write that lost the single-writer lock.
+//
+// Every offline write in the engine is one `withExclusiveTransactionAsync` task
+// on its own connection. The transaction is atomic, so a `SQLITE_BUSY` anywhere
+// inside it rolls back BOTH the data row and the outbox row it would have
+// queued — the whole write vanishes. Today the caller sees the throw and, for a
+// tick, drops the send. One extra attempt turns most of those into ordinary
+// saves.
+//
+// SIZING, from measurement rather than assertion:
+//   - Attempt 1 keeps the shipped 5s `busy_timeout` (OFFLINE_DB_BUSY_TIMEOUT_MS),
+//     so a first-attempt failure already means a real holder sat on the file for
+//     five seconds.
+//   - Attempt 2 gets a shortened 1.5s timeout after a 150ms gap. Measured
+//     `Offline Board Download Completed.importMs` over 60 days is p50 806ms,
+//     p90 2.3s, max 3.2s — every observed import fits inside attempt 1's window,
+//     so a second FULL 5s wait buys almost nothing. Attempt 2 is a "did the lock
+//     clear in the gap" probe.
+//   - A caller may then run a smaller fallback write (mobile's outbox-only tick
+//     degrade) on the remaining budget.
+// Worst case 5000 + 150 + 1500 + 1000 + 150 + 1000 = 8.8s, under the hard
+// OFFLINE_LOCAL_WRITE_BUDGET_MS wall-clock cap, so no composition of per-attempt
+// timeouts can overrun it.
+//
+// The case this deliberately does NOT try to outlast: VACUUM holds an exclusive
+// lock for the whole rebuild, order 5-20s on a 200-400MB database (see
+// db/vacuum.ts), and it is reachable from the UI (remove a downloaded board).
+// Waiting that out would freeze the log-ascent sheet for twenty seconds. That
+// case exits as a localized error instead, and `onSettled`'s `elapsedMs` is what
+// will finally measure how long these locks really are.
+
+import { isDatabaseLockedError } from './lock-errors';
+
+/**
+ * Hard wall-clock cap on everything a single user-visible local write may spend
+ * fighting for the lock, retries and any caller-run fallback included. Checked
+ * against the clock before each retry, so the budget is a real ceiling rather
+ * than the sum of some timeouts.
+ */
+export const OFFLINE_LOCAL_WRITE_BUDGET_MS = 9000;
+
+/** What the ladder did, reported once per write whose first attempt threw. */
+export type LocalWriteRetryOutcome = {
+  /** How many attempts ran, 1-based. `1` means the error was not retryable. */
+  attempts: number;
+  /** The LAST error seen. On a recovered write this is attempt 1's error. */
+  error: unknown;
+  /** True when a later attempt succeeded and the caller lost nothing. */
+  recovered: boolean;
+  /** Wall-clock time from the first attempt to the settle, per the injected clock. */
+  elapsedMs: number;
+};
+
+export type LocalWriteRetryOptions = {
+  /** Total attempts including the first. Default 2. */
+  maxAttempts?: number;
+  /** Pause between attempts, giving the holder a chance to commit. Default 150ms. */
+  retryDelayMs?: number;
+  /** Wall-clock ceiling for the whole ladder. Default OFFLINE_LOCAL_WRITE_BUDGET_MS. */
+  budgetMs?: number;
+  /** Which errors are worth another attempt. Default: SQLite lock contention. */
+  shouldRetry?: (error: unknown) => boolean;
+  /** Clock seam, so tests need no fake timers. Default Date.now. */
+  now?: () => number;
+  /** Sleep seam, same reason. Default a real setTimeout. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Telemetry hook. Fires at most once, only when attempt 1 threw. */
+  onSettled?: (outcome: LocalWriteRetryOutcome) => void;
+};
+
+const DEFAULT_MAX_ATTEMPTS = 2;
+const DEFAULT_RETRY_DELAY_MS = 150;
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Run a local SQLite write, retrying it while the failure looks like lock
+ * contention and the budget still allows another try.
+ *
+ * Contract, relied on by callers:
+ *  - Attempt 1 succeeding is silent: `onSettled` is NOT called. Its raw count is
+ *    therefore the contention rate, not the write rate.
+ *  - `write` receives the 1-based attempt number so the caller can shorten that
+ *    attempt's `busy_timeout`.
+ *  - A terminal failure rethrows the ORIGINAL error object BY IDENTITY, never a
+ *    wrapper. Load-bearing: mobile hands that same object to Sentry under
+ *    `kind: 'tick-local-write'`, and a wrapper would both fork that aggregate and
+ *    add a `.cause` level for `isDatabaseLockedError`'s bounded walk to spend.
+ *  - The budget gates RETRIES only. Attempt 1 always runs, even with
+ *    `budgetMs: 0` — performing the write is the whole point.
+ *  - `onSettled` runs inside try/catch: a throwing telemetry callback must never
+ *    change the write's outcome (same discipline as the drainer's
+ *    `onMutationStatusError`).
+ *
+ * The write MUST be safe to re-run. A `SQLITE_BUSY` can surface at COMMIT, so a
+ * retried attempt may follow one that actually landed — every statement inside
+ * must be idempotent (`INSERT OR IGNORE`, `DELETE`, an upsert).
+ */
+export async function runLocalWriteWithRetry<T>(
+  write: (attempt: number) => Promise<T>,
+  options: LocalWriteRetryOptions = {},
+): Promise<T> {
+  const {
+    maxAttempts = DEFAULT_MAX_ATTEMPTS,
+    retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+    budgetMs = OFFLINE_LOCAL_WRITE_BUDGET_MS,
+    shouldRetry = isDatabaseLockedError,
+    now = Date.now,
+    sleep = defaultSleep,
+    onSettled,
+  } = options;
+
+  const startedAt = now();
+  let attempt = 0;
+  let lastError: unknown = null;
+
+  const settle = (recovered: boolean) => {
+    // Only when the ladder actually ran — a clean first attempt reports nothing.
+    if (attempt <= 1 && recovered) return;
+    if (!onSettled) return;
+    try {
+      onSettled({ attempts: attempt, error: lastError, recovered, elapsedMs: now() - startedAt });
+    } catch {
+      // A broken telemetry sink must not turn a saved write into a lost one.
+    }
+  };
+
+  for (;;) {
+    attempt += 1;
+    try {
+      const result = await write(attempt);
+      settle(true);
+      return result;
+    } catch (error) {
+      lastError = error;
+      const hasAttemptsLeft = attempt < maxAttempts;
+      const fitsInBudget = now() - startedAt + retryDelayMs < budgetMs;
+      if (!hasAttemptsLeft || !fitsInBudget || !shouldRetry(error)) {
+        settle(false);
+        throw error;
+      }
+      await sleep(retryDelayMs);
+    }
+  }
+}

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -224,7 +224,21 @@ export { vacuumDatabase, measureReclaimableBytes } from './db/vacuum';
 export { SCHEMA_STATEMENTS } from './db/schema';
 export { runMigrations, MIGRATIONS, LATEST_SCHEMA_VERSION } from './db/migrations';
 export type { Migration } from './db/migrations';
-export { OFFLINE_DB_BUSY_TIMEOUT_MS, applyBusyTimeout, configureMainConnection } from './db/pragmas';
+export {
+  OFFLINE_DB_BUSY_TIMEOUT_MS,
+  OFFLINE_DB_RETRY_BUSY_TIMEOUT_MS,
+  OFFLINE_DB_FALLBACK_BUSY_TIMEOUT_MS,
+  applyBusyTimeout,
+  configureMainConnection,
+} from './db/pragmas';
+
+// --- Local write retry (issue #4315) ---------------------------------------------
+// One ladder for every local SQLite write that can lose the single-writer lock.
+// Silent when the first attempt succeeds, so `onSettled` fires only on a
+// contended write; a terminal failure rethrows the ORIGINAL error object, which
+// keeps Sentry grouping and lock classification unchanged.
+export { runLocalWriteWithRetry, OFFLINE_LOCAL_WRITE_BUDGET_MS } from './db/write-retry';
+export type { LocalWriteRetryOptions, LocalWriteRetryOutcome } from './db/write-retry';
 // One predicate for "was this write-lock contention?", so reporting (#4329) and
 // the sqlite-init retry loop (#4314) can never disagree about which failures
 // count. `classifySqliteLockError` is the same verdict plus the SQLite result


### PR DESCRIPTION
## Summary

Refs #4315 (offline-mode epic #4319).

An offline tick whose local SQLite write threw was dropped outright: `saveTickOffline` returned null, `useSaveTick` fell through to a direct network save, and offline that save failed too. Every `kind: tick-local-write` failure in Sentry over 90 days is a `database is locked`.

Three layers, all JS/TS — no new deps, no config-plugin or `package.json` native change, so the fingerprint is unmoved and this rides OTA to the shipped binary.

**1. A shared retry ladder (fixes the class).** New `runLocalWriteWithRetry` in `@boardsesh/offline-sync` wraps all five local writes — `writeTickLocal`, `addFavoriteLocal`, `removeFavoriteLocal`, `useOfflineFollowUser`, `useOfflineUnfollowUser`. Attempt 1 keeps the shipped 5s `busy_timeout`; a retry gets 1.5s after a 150ms gap. Worst case ~8.8s, under a hard 9s wall-clock budget checked before each retry, so no composition of timeouts can overrun it. A terminal failure rethrows the **original error object by identity** — load-bearing, since the board adapter hands that same object to Sentry under `kind: 'tick-local-write'` and a wrapper would fork the 90-day aggregate.

Sizing came from measurement, not assertion. `Offline Board Download Completed.importMs` over 60 days is p50 806ms / p90 2.3s / max 3.2s, so every observed import already fits inside attempt 1 and a second full 5s wait buys almost nothing. The 5-20s figure in the codebase belongs to **VACUUM** (`vacuum.ts:119`), which the ladder deliberately does not try to outlast — that case exits with an honest error rather than freezing the sheet for twenty seconds.

**2. Ticks degrade to the outbox row alone.** When the ladder is spent, `enqueueTickOutboxOnly` writes just the `pending_mutations` row. A queued mutation replays from its payload, so the local `boardsesh_ticks` row only ever served LOCAL reads — the outbox row is enough for the send to reach the server. Cost, documented in code: no "waiting to sync" badge on that climb, and the tick is missing from the local logbook if the app is killed while still offline. Both self-heal once it drains and the pull returns the server row.

**3. Honest last-resort copy.** When the degrade also fails offline, the sheet showed the raw network error — an English technical string for every locale. New `mobile.logAscent.offlineErrorMessage` in all four catalogs, used only when `useIsOffline()` is true (online, the error's own message is still worth reading).

### No double delivery

`variables.input.uuid` is stamped with the tick uuid **before the first write**. The server's `saveTick` dedupes on `SaveTickInput.uuid` and returns the existing row for a repeat, so the local write, the queued replay and `useSaveTick`'s network fall-through all resolve to one server row. Without it, a transaction that committed its outbox row and still threw — a `SQLITE_BUSY` surfacing at COMMIT, the exact premise behind the retry — would queue the send *and* post a second, differently-identified one. For the same reason the tick INSERT becomes `INSERT OR IGNORE` (`uuid` is the PRIMARY KEY), which makes the whole write safe to re-run.

### Dev harness (tester/dev-gated)

Without it, the central risk ships unverified: measured import windows all fit inside the current 5s `busy_timeout`, so the obvious QA recipe ("log a tick during a download") produces an ordinary fast save. More → Development → **Offline Writes** adds

- a lock holder that opens a second connection and sits on a real write lock, the only way to make a device throw the genuine platform lock string (and thus prove the Android control-byte matcher still works),
- a fault injector for the shapes a real lock cannot schedule — the iOS / Android-control-byte / Android-no-code lock strings, disk-full, and commit-then-throw — read only inside `if (__DEV__)`,
- an outbox inspector, since the More tab's Sync-issues section only renders `!isOffline && deadLetterCount > 0` and lists dead letters, never pending rows.

### Telemetry

- **New permanent name** `Offline Local Write Attempt Failed`. Fires only when a local write's FIRST attempt threw, so its raw count is the contention rate. Props `{ tableName, operation, attempts, outcome: 'recovered' | 'exhausted', isLockError, wasOffline, elapsedMs }`. This is the first and only signal for a lost favorite/follow — that path has no Sentry report at all today. `elapsedMs` is what should resize the ladder, replacing today's estimate.
- **Extended** `Offline Tick Local Write Failed` (name unchanged) with `outcome: 'queued' | 'fell_through'`. Still exactly one per failed local write, on every exit path, pinned by a test. A recovered write emits only the new event; a failed one emits both — two layers of one story, not a double count.
- **Sentry** keeps `kind: 'tick-local-write'` and the original error object, gaining an `outcome` tag and a `fallbackErrorMessage` extra. Grouping is stacktrace/message based, so the aggregate should not fork — worth a check after the first release.

### Notes

- `useOfflineFollowUser` / `useOfflineUnfollowUser` are wrapped for one uniform seam but **no app code calls them today** (grep across `packages/mobile` + `packages/shared` finds only their module and their test), so expect `tableName: 'user_follows'` to read zero. Deleting them is a separate call.
- Favorites now hold a promise up to ~6.7s longer in the contended case. Checked both consumers (`use-climb-actions.ts:130`, `PlayDrawer.tsx:337`): neither reads `isPending`; the heart is driven by the optimistic `setQueryData`. Nothing sits behind a disabled control or a spinner that could hang.

## Release Notes

- Log a send while your phone's storage is tied up — mid board download, or right after you clear a board out — and it no longer disappears. Boardsesh retries the save, queues it for the next sync if the storage is still busy, and if it truly can't stash it offline it tells you plainly, in your own language, instead of swallowing the send.

## Decisions for Marco

Every plan decision flagged `needsMarco`, with the default that shipped.

**1. Does the outbox-only degrade cover favorites and follows too, or ticks only?** → **Ticks only.** Favorites and follows get the retry ladder plus the new telemetry, but keep today's behaviour on a hard failure (the mutation rejects, the heart reverts). A send logged at the wall is irreplaceable; a favorite is one tap to redo and its optimistic UI already shows it did not stick. Degrading a favorite is also messier — the local row IS the read model, so an outbox-only favorite would render as un-favorited until the pull returns it, which reads as a bug. The new event closes the favorites blind spot so the next call comes from data.

**2. How long may the log-ascent save block before we give up on the local write?** → **A hard 9s wall-clock budget** (5s + 150ms + 1.5s on the main write, then up to two 1s outbox-only attempts; worst case ~8.8s). Sized from `importMs` (p50 806ms, max 3.2s over 60 days), not from the misattributed 5-20s VACUUM figure. If snappier is preferred, `maxAttempts: 1` degrades immediately — a one-line options change.

**3. New analytics event name — permanent once shipped.** → **`Offline Local Write Attempt Failed`.** One event covering all local writes, fired only when the first attempt threw. Chosen over `…Retried`, which baked in a wart: it would fire on non-retryable errors that were never retried. It sits beside the shipped `Offline SQLite Init Recovered`, which uses the same only-when-attempt-1-failed rule.

**4. Ship the dev-only contention harness in this PR?** → **Yes**, behind the existing `__DEV__ || profile?.isTester` Development-section gate. Without it the workstream's central risk — does the degrade actually save the tick, on both platforms — ships unverified. All JS-only, no native surface, reusable by the rest of the epic.

## Test plan

Validation, all run in this worktree:

- `vp check` — clean for every file this PR touches. (Two pre-existing formatting drifts in `docs/design/web-reposition/*.html` on `main` are untouched here.)
- `vp run typecheck:offline-sync` — Done in 1.19s
- `vp run typecheck:shared` — Done
- `vp run typecheck:mobile` — Done in 12.73s
- `vp run test:offline-sync` — 30 files, 621 tests passed
- `vp run test:mobile` — 647 files, 5923 tests passed
- `vp test run --project i18n` — 90 passed (four-locale parity)
- `vp test run --project analytics` — 23 passed
- `vp test run --project board-react` — 108 passed
- `vp run check:mobile-bundle` — android bundle: OK
- `vp run check:i18n:orphans` — OK, 4558 keys all referenced

New/extended suites: `write-retry.test.ts` (ladder contract incl. identity-preserving rethrow, budget-gates-retries-not-attempt-1, throwing `onSettled`), `pragmas.test.ts` (the two new timeouts), `use-offline-mutations.test.ts` against the real DDL (retry recovery for all five writes, `INSERT OR IGNORE` idempotency, stamped-uuid payload, `enqueueTickOutboxOnly` shape, no false suppressed-enqueue on a retry), `board-adapter.test.tsx` (the stamp on both paths, degrade → `queued`, degrade failure → `fell_through`, exactly-one-event invariant, Sentry identity assert), `use-save-tick.test.tsx` (fall-through carries the stamped uuid; web still sends none), `use-quick-tick-form.test.tsx` (localized offline message; online still shows the error's own), `local-write-telemetry.test.ts`, `write-fault-injection.test.ts`.

**Device QA is still owed** and cannot be done off-device: the unit suites run against `node:sqlite`, which serializes and cannot produce genuine `SQLITE_BUSY`, and the lock-error message shape differs per platform (Android emits a raw U+0005 control byte where the result-code digit belongs). The full list is in the plan; the load-bearing steps, on **both** an iPhone and an Android handset:

- **A. Retry wins.** Hold the lock 7s, log an ascent → saves normally, badge appears, one outbox row.
- **B. Degrade.** Airplane mode, hold the lock 15s, log an ascent → resolves as saved, no badge, **exactly one** outbox row. Go online and count the ticks — a second copy is the double-delivery bug this revision fixes. Repeat with a force-kill before going online.
- **C. Fault modes.** `failAttempts: 1` → `outcome: 'recovered'`; `failAttempts: 99` → `exhausted` + `queued`; `disk-full` → `attempts: 1`, `isLockError: false`; `commit-then-throw` → exactly one tick row and one outbox row.
- **E. Android blocker check.** With a REAL held lock (not the injector), confirm the emitted event carries `isLockError: true`. If Android reports `false`, the platform's message shape has drifted and the ladder is not retrying at all there — a blocker, not a nit.
- **G. Copy.** Flag off + airplane mode → the sheet shows the new localized message; repeat in es, fr and de and check it fits the error row without truncation.
