### PR TITLE
fix(sync): scope purge epochs per board so one removal stops one download

### DIFF
--- a/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
+++ b/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
@@ -60,12 +60,12 @@ const getPendingCountMock = vi.fn(async (..._args: unknown[]) => 0);
 const assertLocalUserDataOwnerMock = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => 'ok'));
 const stampLocalUserIdMock = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => {}));
 const clearUserDataMock = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => {}));
-const beginLocalPurgeMock = vi.hoisted(() => vi.fn());
+const beginGlobalPurgeMock = vi.hoisted(() => vi.fn());
 vi.mock('@boardsesh/offline-sync', () => ({
   getPendingCount: (...args: unknown[]) => getPendingCountMock(...args),
   assertLocalUserDataOwner: (...args: unknown[]) => assertLocalUserDataOwnerMock(...args),
   stampLocalUserId: (...args: unknown[]) => stampLocalUserIdMock(...args),
-  beginLocalPurge: (...args: unknown[]) => beginLocalPurgeMock(...args),
+  beginGlobalPurge: (...args: unknown[]) => beginGlobalPurgeMock(...args),
 }));
 
 // db/connection statically reaches expo-sqlite + the error reporter; the bridge
@@ -218,7 +218,7 @@ beforeEach(() => {
   assertLocalUserDataOwnerMock.mockResolvedValue('ok');
   stampLocalUserIdMock.mockClear();
   clearUserDataMock.mockClear();
-  beginLocalPurgeMock.mockClear();
+  beginGlobalPurgeMock.mockClear();
   snapshotBaseUrlConfigured.value = true;
   // Every case below except the readiness-gating describe assumes the ordinary
   // uncontended launch, where the schema is stamped before the first render.
@@ -249,12 +249,15 @@ describe('OfflineSyncBridge — local user-data owner stamp', () => {
     await waitFor(() => expect(clearUserDataMock).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(stampLocalUserIdMock).toHaveBeenCalledTimes(1));
     expect(stampLocalUserIdMock.mock.calls[0][1]).toBe('user-1');
-    // The epoch bump must land BEFORE the wipe: a pull page already on the wire
-    // when clearUserData ran would otherwise land afterwards and resurrect rows
-    // with a checkpoint past them — a gap `user_data_complete` would then
-    // falsely vouch for.
-    expect(beginLocalPurgeMock).toHaveBeenCalledTimes(1);
-    expect(beginLocalPurgeMock.mock.invocationCallOrder[0]).toBeLessThan(clearUserDataMock.mock.invocationCallOrder[0]);
+    // The GLOBAL epoch bump must land BEFORE the wipe: a pull page already on the
+    // wire when clearUserData ran would otherwise land afterwards and resurrect
+    // rows with a checkpoint past them — a gap `user_data_complete` would then
+    // falsely vouch for. Global rather than scoped because clearUserData DELETEs
+    // every user table, which no board namespace bounds (issue #4370).
+    expect(beginGlobalPurgeMock).toHaveBeenCalledTimes(1);
+    expect(beginGlobalPurgeMock.mock.invocationCallOrder[0]).toBeLessThan(
+      clearUserDataMock.mock.invocationCallOrder[0],
+    );
   });
 
   it('leaves a matching stamp alone', async () => {

--- a/packages/mobile/src/components/offline-sync-bridge.tsx
+++ b/packages/mobile/src/components/offline-sync-bridge.tsx
@@ -5,7 +5,7 @@ import { router } from 'expo-router';
 import { notifyBootstrapMetadataChanged, notifyScopeDownloadComplete, setSyncProgress } from '../sync';
 import {
   assertLocalUserDataOwner,
-  beginLocalPurge,
+  beginGlobalPurge,
   getPendingCount,
   stampLocalUserId,
   type GraphQLFetch,
@@ -140,7 +140,7 @@ export function OfflineSyncBridge() {
             tags: { source: 'offline-sync', op: 'owner-stamp-mismatch' },
           });
           // Same hazard every other wipe path guards against (sign-out uses
-          // setSigningOut, board removal uses beginLocalPurge): the scheduler
+          // setSigningOut, a board removal uses beginScopePurge): the scheduler
           // effect below may already have a pull cycle mid-table, and a page
           // that was on the wire when clearUserData ran would land AFTER the
           // wipe — resurrecting rows with a checkpoint past them, which the
@@ -148,7 +148,10 @@ export function OfflineSyncBridge() {
           // then vouch for. Bumping the epoch makes syncTable's post-await
           // re-check discard that page; the next cycle restarts from the
           // now-empty checkpoints.
-          beginLocalPurge();
+          // GLOBAL, unlike a board removal: clearUserData DELETEs every user
+          // table plus deleteUserCheckpoints, so there is nothing scope-shaped to
+          // narrow it to.
+          beginGlobalPurge();
           await clearUserData(db);
           if (cancelled) return;
         }

--- a/packages/mobile/src/components/settings/StorageSettingsScreen.tsx
+++ b/packages/mobile/src/components/settings/StorageSettingsScreen.tsx
@@ -185,8 +185,13 @@ export function StorageSettingsScreen() {
         // Once, after every teardown — it rebuilds the whole file. Cosmetic by
         // design: a failure means the rows are gone but the file didn't shrink, so it
         // must never read as "the removal failed".
-        const compacted = await compactOfflineDatabase(db);
-        if (!compacted) showToast(t('mobile.more.storage.compactFailed'), 'error');
+        //
+        // Deferred while a pull is in flight: VACUUM's exclusive lock would fail a
+        // concurrent import (issue #4370), and a board removal must not cost the
+        // boards it deliberately spared. 'deferred' is silent — the reclaimable
+        // banner below offers the manual Compact.
+        const compacted = await compactOfflineDatabase(db, { deferWhileSyncing: true });
+        if (compacted === 'not-truncated') showToast(t('mobile.more.storage.compactFailed'), 'error');
         await refetch();
         return true;
       } catch (error) {
@@ -250,8 +255,11 @@ export function StorageSettingsScreen() {
     hapticLight();
     setIsCompacting(true);
     try {
-      const compacted = await compactOfflineDatabase(db);
-      if (!compacted) showToast(t('mobile.more.storage.compactFailed'), 'error');
+      // Deliberate and blocking, so it aborts in-flight cycles rather than
+      // deferring: they resume from their checkpoints next foreground with no
+      // burned bootstrap attempt.
+      const compacted = await compactOfflineDatabase(db, { deferWhileSyncing: false });
+      if (compacted === 'not-truncated') showToast(t('mobile.more.storage.compactFailed'), 'error');
       await refetch();
     } finally {
       setIsCompacting(false);

--- a/packages/mobile/src/offline/__tests__/remove-offline-board.test.ts
+++ b/packages/mobile/src/offline/__tests__/remove-offline-board.test.ts
@@ -30,7 +30,10 @@ const removeBoardScopeData = vi.fn(async () => ({
   gradesDeleted: 0,
   removedAnyRows: true,
 }));
-const beginLocalPurge = vi.fn();
+const releasePurge = vi.fn();
+const beginScopePurge = vi.fn((_namespace: string) => releasePurge);
+const beginGlobalPurge = vi.fn();
+const isSyncInFlight = vi.fn(() => false);
 const vacuumDatabase = vi.fn(async () => true);
 
 vi.mock('@boardsesh/offline-sync', async (importOriginal) => {
@@ -38,7 +41,9 @@ vi.mock('@boardsesh/offline-sync', async (importOriginal) => {
   return {
     ...actual,
     removeBoardScopeData: (...args: unknown[]) => removeBoardScopeData(...(args as [])),
-    beginLocalPurge: () => beginLocalPurge(),
+    beginScopePurge: (namespace: string) => beginScopePurge(namespace),
+    beginGlobalPurge: () => beginGlobalPurge(),
+    isSyncInFlight: () => isSyncInFlight(),
     vacuumDatabase: () => vacuumDatabase(),
   };
 });
@@ -72,6 +77,11 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockStorage.clear();
   resetAllSettings();
+  // clearAllMocks drops the factory implementations above, so restore the two
+  // whose RETURN value the code under test depends on.
+  beginScopePurge.mockImplementation(() => releasePurge);
+  isSyncInFlight.mockImplementation(() => false);
+  vacuumDatabase.mockImplementation(async () => true);
 });
 
 describe('removeOfflineBoard', () => {
@@ -94,11 +104,16 @@ describe('removeOfflineBoard', () => {
   });
 
   // Without this an in-flight pull's page lands after the delete and resurrects rows,
-  // stamping a checkpoint past them that the strict `>` delta never revisits.
-  it('aborts in-flight pulls before deleting', async () => {
+  // stamping a checkpoint past them that the strict `>` delta never revisits. The
+  // namespace is the LAYOUT, not the scope key: that is exactly the DELETE predicate
+  // and exactly the artifact cache key (issue #4370).
+  it("aborts this layout's in-flight pull before deleting, and only this layout's", async () => {
     setSetting('syncEnabledBoards', ['kilter:1:7']);
     const callOrder: string[] = [];
-    beginLocalPurge.mockImplementationOnce(() => callOrder.push('purge'));
+    beginScopePurge.mockImplementationOnce((namespace: string) => {
+      callOrder.push(`purge:${namespace}`);
+      return releasePurge;
+    });
     removeBoardScopeData.mockImplementationOnce(async () => {
       callOrder.push('delete');
       return { climbsDeleted: 1, statsDeleted: 0, gradesDeleted: 0, removedAnyRows: true };
@@ -106,7 +121,31 @@ describe('removeOfflineBoard', () => {
 
     await removeOfflineBoard({ db, queryClient, scope: KILTER_12X14 });
 
-    expect(callOrder).toEqual(['purge', 'delete']);
+    expect(callOrder).toEqual(['purge:kilter:1', 'delete']);
+  });
+
+  // The latch covers the seconds the delete transaction holds; leaving it set would
+  // block this layout's downloads for the rest of the app session.
+  it('releases the purge latch after the delete resolves', async () => {
+    setSetting('syncEnabledBoards', ['kilter:1:7']);
+    const callOrder: string[] = [];
+    releasePurge.mockImplementation(() => callOrder.push('release'));
+    removeBoardScopeData.mockImplementationOnce(async () => {
+      callOrder.push('delete');
+      return { climbsDeleted: 1, statsDeleted: 0, gradesDeleted: 0, removedAnyRows: true };
+    });
+
+    await removeOfflineBoard({ db, queryClient, scope: KILTER_12X14 });
+
+    expect(callOrder).toEqual(['delete', 'release']);
+  });
+
+  it('releases the purge latch when the delete throws, and still propagates', async () => {
+    setSetting('syncEnabledBoards', ['kilter:1:7']);
+    removeBoardScopeData.mockRejectedValueOnce(new Error('disk went away'));
+
+    await expect(removeOfflineBoard({ db, queryClient, scope: KILTER_12X14 })).rejects.toThrow('disk went away');
+    expect(releasePurge).toHaveBeenCalledTimes(1);
   });
 
   it('retains every other enabled scope, and never the one being removed', async () => {
@@ -181,21 +220,55 @@ describe('removeOfflineBoard cached art', () => {
 describe('compactOfflineDatabase', () => {
   // The teardown already committed, so a failed VACUUM means "the data is gone but
   // the file didn't shrink" — reportable, never an error that implies data loss.
-  it('reports false instead of throwing when the vacuum fails', async () => {
+  it("reports 'not-truncated' instead of throwing when the vacuum fails", async () => {
     vacuumDatabase.mockRejectedValueOnce(new Error('SQLITE_FULL'));
 
-    await expect(compactOfflineDatabase(db)).resolves.toBe(false);
+    await expect(compactOfflineDatabase(db, { deferWhileSyncing: false })).resolves.toBe('not-truncated');
   });
 
   // The rebuild landed but a reader blocked the WAL truncation, so the -wal stayed
   // large and the user's number won't have moved. Silent otherwise — pragma, not throw.
-  it('reports false when the WAL truncation was blocked', async () => {
+  it("reports 'not-truncated' when the WAL truncation was blocked", async () => {
     vacuumDatabase.mockResolvedValueOnce(false);
 
-    await expect(compactOfflineDatabase(db)).resolves.toBe(false);
+    await expect(compactOfflineDatabase(db, { deferWhileSyncing: false })).resolves.toBe('not-truncated');
   });
 
-  it('reports true on success', async () => {
-    await expect(compactOfflineDatabase(db)).resolves.toBe(true);
+  it("reports 'truncated' on success", async () => {
+    await expect(compactOfflineDatabase(db, { deferWhileSyncing: false })).resolves.toBe('truncated');
+  });
+
+  // VACUUM's exclusive lock would fail a concurrent snapshot import with
+  // SQLITE_BUSY, which the retry ladder charges as a structural failure — two of
+  // those strand a board on the paged crawl (issue #4370). The post-removal
+  // compaction defers instead; the manual Compact button does not.
+  it("returns 'deferred' without touching the database while a pull is in flight", async () => {
+    isSyncInFlight.mockReturnValue(true);
+
+    await expect(compactOfflineDatabase(db, { deferWhileSyncing: true })).resolves.toBe('deferred');
+    expect(vacuumDatabase).not.toHaveBeenCalled();
+    expect(beginGlobalPurge).not.toHaveBeenCalled();
+  });
+
+  it('compacts anyway when nothing is syncing', async () => {
+    isSyncInFlight.mockReturnValue(false);
+
+    await expect(compactOfflineDatabase(db, { deferWhileSyncing: true })).resolves.toBe('truncated');
+    expect(vacuumDatabase).toHaveBeenCalledTimes(1);
+  });
+
+  // db/vacuum.ts has always required this: the rebuild holds an exclusive lock for
+  // 5-20s, so in-flight cycles must bail BEFORE it starts, not meet it.
+  it('bumps the global epoch before vacuuming when it does not defer', async () => {
+    isSyncInFlight.mockReturnValue(true);
+    const callOrder: string[] = [];
+    beginGlobalPurge.mockImplementationOnce(() => callOrder.push('global-purge'));
+    vacuumDatabase.mockImplementationOnce(async () => {
+      callOrder.push('vacuum');
+      return true;
+    });
+
+    await expect(compactOfflineDatabase(db, { deferWhileSyncing: false })).resolves.toBe('truncated');
+    expect(callOrder).toEqual(['global-purge', 'vacuum']);
   });
 });

--- a/packages/mobile/src/offline/remove-offline-board.ts
+++ b/packages/mobile/src/offline/remove-offline-board.ts
@@ -6,7 +6,10 @@
 
 import type { QueryClient } from '@tanstack/react-query';
 import {
-  beginLocalPurge,
+  beginScopePurge,
+  beginGlobalPurge,
+  isSyncInFlight,
+  purgeNamespaceKey,
   removeBoardScopeData,
   offlineBoardKey,
   parseOfflineBoardKey,
@@ -60,8 +63,13 @@ function invalidateBoardReaders(queryClient: QueryClient): void {
  *    and no scope-complete marker — i.e. a brand-new board — and re-download the whole
  *    catalog on cellular without asking. The user taps Remove, watches the number hit
  *    zero, and watches it climb straight back.
- * 2. `beginLocalPurge()` aborts any in-flight pull, so a page already on the wire
- *    can't land after the delete and resurrect rows with a checkpoint past them.
+ * 2. `beginScopePurge(namespace)` aborts THIS layout's in-flight pull, so a page
+ *    already on the wire can't land after the delete and resurrect rows with a
+ *    checkpoint past them. Its release is called from a `finally` — the latch, not
+ *    just the epoch bump, is what covers the seconds the delete transaction holds.
+ *    It deliberately does NOT abort other boards' downloads, the mutation drain,
+ *    the user-data pull or the deletions pull: none of them writes a row this
+ *    delete can touch (issue #4370).
  * 3. The retained set is read AFTER step 1, so it's exactly "every scope that must
  *    survive" — this scope has already dropped out of it.
  *
@@ -81,13 +89,20 @@ export async function removeOfflineBoard(params: {
   // The offline picker's snapshots for this scope go with the data. Left behind,
   // they'd offer a board whose climbs have just been deleted.
   forgetOfflineBoardScope(scope);
-  beginLocalPurge();
+  const releasePurge = beginScopePurge(purgeNamespaceKey(scope));
 
   const retainedScopes = getSetting('syncEnabledBoards')
     .map(parseOfflineBoardKey)
     .filter((parsed): parsed is OfflineBoardScope => parsed !== null);
 
-  const result = await removeBoardScopeData({ db, scope, scopeKey: offlineBoardKey(scope), retainedScopes });
+  let result: ScopeTeardownResult;
+  try {
+    result = await removeBoardScopeData({ db, scope, scopeKey: offlineBoardKey(scope), retainedScopes });
+  } finally {
+    // Unconditional: a latch left set would block this layout's downloads for the
+    // rest of the app session.
+    releasePurge();
+  }
 
   // The rendered PNGs for this board are cache, not data, so they are swept
   // AFTER the rows are gone and never allowed to change the teardown result —
@@ -104,6 +119,9 @@ export async function removeOfflineBoard(params: {
   return result;
 }
 
+/** What a compaction attempt actually did. `deferred` never touched the database. */
+export type CompactionOutcome = 'truncated' | 'not-truncated' | 'deferred';
+
 /**
  * Hand the freed pages back to the filesystem.
  *
@@ -113,8 +131,29 @@ export async function removeOfflineBoard(params: {
  * failure means users can't actually reclaim space) but never worth surfacing as an
  * error that implies the removal didn't work. Runs once after all teardowns, not per
  * scope: it rebuilds the entire file each time.
+ *
+ * VACUUM takes an exclusive lock for 5-20s on a 200-400MB database, and a snapshot
+ * import that meets it raises SQLITE_BUSY — which the bootstrap retry ladder charges
+ * as a structural failure, two of which strand a board on the paged crawl. Before
+ * #4370 a removal's global epoch bump guaranteed every in-flight import had already
+ * bailed for free before this ran; now that a removal spares the other boards, the
+ * two calling surfaces need different answers:
+ *
+ *  - `deferWhileSyncing: true` (the automatic post-removal compaction) returns
+ *    'deferred' without touching the database while a cycle is in flight. The
+ *    storage figure not moving is exactly what the reclaimable banner and the manual
+ *    Compact button already exist for.
+ *  - `deferWhileSyncing: false` (the deliberate, spinner-backed Compact button) bumps
+ *    the GLOBAL epoch first, so in-flight cycles abort cleanly — no burned attempt,
+ *    resumed from checkpoints next cycle — which is what db/vacuum.ts has always
+ *    required.
  */
-export async function compactOfflineDatabase(db: OfflineDatabase): Promise<boolean> {
+export async function compactOfflineDatabase(
+  db: OfflineDatabase,
+  options: { deferWhileSyncing: boolean },
+): Promise<CompactionOutcome> {
+  if (options.deferWhileSyncing && isSyncInFlight()) return 'deferred';
+  beginGlobalPurge();
   try {
     // False = the rebuild landed but a reader blocked the WAL truncation, so the file
     // may not have shrunk as far as it should. Same user-facing story as a throw
@@ -133,9 +172,9 @@ export async function compactOfflineDatabase(db: OfflineDatabase): Promise<boole
         tags: { source: 'offline-sync', kind: 'vacuum' },
       });
     }
-    return truncated;
+    return truncated ? 'truncated' : 'not-truncated';
   } catch (error) {
     reportHandledError(error, { tags: { source: 'offline-sync', kind: 'vacuum' } });
-    return false;
+    return 'not-truncated';
   }
 }

--- a/packages/shared/offline-sync/src/db/vacuum.ts
+++ b/packages/shared/offline-sync/src/db/vacuum.ts
@@ -110,8 +110,17 @@ export async function measureReclaimableBytes(db: OfflineDatabase): Promise<numb
  * so this belongs on the main connection, never inside that wrapper (the same trap
  * snapshot-bootstrap.ts's CONNECTION INVARIANT comment describes for ATTACH).
  *
- * MUST NOT run concurrently with a sync cycle — callers bump the wipe epoch
- * (beginLocalPurge) first so in-flight pulls bail.
+ * MUST NOT run concurrently with a sync cycle. A snapshot import that meets this
+ * exclusive lock raises SQLITE_BUSY past the 5s busy_timeout, which
+ * bootstrap-retry classifies as a structural failure — two of those and the scope
+ * is stranded on the paged crawl for a lock we took ourselves. Callers get this
+ * right in one of two ways (see compactOfflineDatabase in
+ * packages/mobile/src/offline/remove-offline-board.ts):
+ *  - DEFER while `isSyncInFlight()`, for the automatic post-removal compaction,
+ *    which must not abort the downloads a board removal deliberately spared; or
+ *  - bump the GLOBAL epoch (`beginGlobalPurge`) first, for the deliberate,
+ *    spinner-backed manual Compact, so in-flight pulls bail cleanly (no burned
+ *    attempt, resumed from checkpoints next cycle).
  *
  * Costs, for callers deciding how to present this: it builds a complete new file
  * before swapping, so peak disk is roughly original + final (SQLite documents up to

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -44,7 +44,10 @@ export {
   setSigningOut,
   isSigningOut,
   getWipeEpoch,
-  beginLocalPurge,
+  capturePurgeToken,
+  hasPurgeLanded,
+  beginScopePurge,
+  beginGlobalPurge,
   setBackgrounded,
   isBackgrounded,
   // Subscribed by the mobile downloader so a transfer can record that the app
@@ -53,6 +56,7 @@ export {
   onTeardown,
 } from './mutation-queue/drainer';
 export type {
+  PurgeToken,
   DrainOptions,
   MutationDeliveryEvent,
   MutationStatusListenerFailure,
@@ -151,7 +155,7 @@ export type {
   BootstrapRetryRead,
   BootstrapEligibility,
 } from './sync/bootstrap-retry';
-export { startSyncScheduler, triggerSync } from './sync/sync-scheduler';
+export { startSyncScheduler, triggerSync, isSyncInFlight } from './sync/sync-scheduler';
 export type { SyncProgressSink, SchedulerTriggers, SchedulerOptions, DrainQueue } from './sync/sync-scheduler';
 export {
   getCheckpoint,
@@ -272,5 +276,7 @@ export {
   offlineBoardKeyForBoard,
   offlineBoardScopeForBoard,
   parseOfflineBoardKey,
+  purgeNamespaceKey,
+  purgeNamespaceForScopeKey,
 } from './offline-board-key';
 export type { OfflineBoardScope, OfflineBoardLike } from './offline-board-key';

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/purge-epoch.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/purge-epoch.test.ts
@@ -1,0 +1,171 @@
+// The per-namespace purge registry (issue #4370).
+//
+// Before this, removing ANY board bumped one global epoch, so every other
+// scope's in-flight download, the mutation-queue drain, the user-data pull and
+// the deletions pull all aborted with it. These tests pin the split: a scope
+// purge is invisible to everything outside its namespace, and every global path
+// (sign-out, owner-stamp wipe, manual compaction) still stops everything.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  capturePurgeToken,
+  hasPurgeLanded,
+  beginScopePurge,
+  beginGlobalPurge,
+  getWipeEpoch,
+  setSigningOut,
+  onTeardown,
+  __resetDrainerStateForTests,
+} from '../drainer';
+import { purgeNamespaceKey, purgeNamespaceForScopeKey } from '../../offline-board-key';
+
+const KILTER = 'kilter:1';
+const TENSION = 'tension:2';
+
+beforeEach(() => {
+  __resetDrainerStateForTests();
+});
+
+describe('beginScopePurge', () => {
+  // The whole point: the drainer, the user-data pull and the deletions pull all
+  // compare the GLOBAL epoch, and none of them writes a row a board teardown can
+  // delete. Moving it for a board removal is what cost them a cycle each.
+  it('leaves the global epoch untouched', () => {
+    const before = getWipeEpoch();
+    beginScopePurge(KILTER)();
+    expect(getWipeEpoch()).toBe(before);
+  });
+
+  it('purges only its own namespace', () => {
+    const token = capturePurgeToken();
+    beginScopePurge(KILTER)();
+
+    expect(hasPurgeLanded(token, KILTER)).toBe(true);
+    expect(hasPurgeLanded(token, TENSION)).toBe(false);
+    // No namespace = global-only work (the outbox, the user tables, the
+    // deletions cursor), which a board removal must never abort.
+    expect(hasPurgeLanded(token)).toBe(false);
+  });
+
+  // The capture-once contract: a token captured AFTER a purge is already
+  // baselined past it, which is what lets the next cycle proceed normally.
+  it('reads not-purged for a namespace purged BEFORE the capture', () => {
+    beginScopePurge(KILTER)();
+    const token = capturePurgeToken();
+
+    expect(hasPurgeLanded(token, KILTER)).toBe(false);
+  });
+
+  // Totality of the `?? 0` fallback: a namespace nobody has ever purged needs no
+  // registration, so there is no "did you remember to add this scope" footgun.
+  it('reads not-purged for a namespace nobody has ever purged', () => {
+    beginScopePurge(KILTER)();
+    const token = capturePurgeToken();
+
+    expect(hasPurgeLanded(token, 'moonboard:9')).toBe(false);
+  });
+
+  it('fires teardown listeners exactly once per purge', () => {
+    const listener = vi.fn();
+    const unsubscribe = onTeardown(listener);
+
+    beginScopePurge(KILTER)();
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    beginScopePurge(KILTER)();
+    expect(listener).toHaveBeenCalledTimes(2);
+    unsubscribe();
+  });
+});
+
+describe('the purge latch', () => {
+  // removeBoardScopeData holds an exclusive transaction for seconds on a 40k-climb
+  // layout. The epoch bump alone leaves a check made INSIDE that window reading
+  // "no purge" whenever it captured its token after the bump — and that is exactly
+  // the window a `scope-complete:` marker write must not be dispatched into.
+  it('reads purged for a token captured AFTER the epoch bump, until released', () => {
+    const release = beginScopePurge(KILTER);
+    const midPurgeToken = capturePurgeToken();
+
+    expect(hasPurgeLanded(midPurgeToken, KILTER)).toBe(true);
+    expect(hasPurgeLanded(midPurgeToken, TENSION)).toBe(false);
+
+    release();
+    expect(hasPurgeLanded(midPurgeToken, KILTER)).toBe(false);
+  });
+
+  // Remove-all iterates the sizes of a layout, so two purges of one namespace can
+  // overlap. A non-refcounted latch would let the first release unlatch the second.
+  it('stays latched while a second purge of the same namespace is running', () => {
+    const releaseFirst = beginScopePurge(KILTER);
+    const releaseSecond = beginScopePurge(KILTER);
+    const token = capturePurgeToken();
+
+    releaseFirst();
+    expect(hasPurgeLanded(token, KILTER)).toBe(true);
+
+    releaseSecond();
+    expect(hasPurgeLanded(token, KILTER)).toBe(false);
+  });
+
+  it('is idempotent, so a double release cannot unlatch a concurrent purge', () => {
+    const releaseFirst = beginScopePurge(KILTER);
+    const releaseSecond = beginScopePurge(KILTER);
+    const token = capturePurgeToken();
+
+    releaseFirst();
+    releaseFirst();
+    expect(hasPurgeLanded(token, KILTER)).toBe(true);
+
+    releaseSecond();
+    expect(hasPurgeLanded(token, KILTER)).toBe(false);
+  });
+});
+
+describe('global purges', () => {
+  it('beginGlobalPurge stops every namespace and every global operation', () => {
+    const token = capturePurgeToken();
+    beginGlobalPurge();
+
+    expect(hasPurgeLanded(token)).toBe(true);
+    expect(hasPurgeLanded(token, KILTER)).toBe(true);
+    expect(hasPurgeLanded(token, TENSION)).toBe(true);
+  });
+
+  it('setSigningOut(true) stops every namespace and every global operation', () => {
+    const token = capturePurgeToken();
+    setSigningOut(true);
+
+    expect(hasPurgeLanded(token)).toBe(true);
+    expect(hasPurgeLanded(token, KILTER)).toBe(true);
+    setSigningOut(false);
+  });
+});
+
+describe('__resetDrainerStateForTests', () => {
+  it('clears both the epoch map and the in-flight latches', () => {
+    beginScopePurge(KILTER); // deliberately never released
+    __resetDrainerStateForTests();
+
+    const token = capturePurgeToken();
+    expect(hasPurgeLanded(token, KILTER)).toBe(false);
+    // A residual epoch would make a fresh token in the next test read purged the
+    // moment that namespace was touched again.
+    beginScopePurge(TENSION)();
+    expect(hasPurgeLanded(token, KILTER)).toBe(false);
+  });
+});
+
+describe('purge namespace keys', () => {
+  it('is the layout, not the scope', () => {
+    expect(purgeNamespaceKey({ boardType: 'kilter', layoutId: 1 })).toBe('kilter:1');
+    expect(purgeNamespaceForScopeKey('kilter:1:5')).toBe('kilter:1');
+  });
+
+  // A key we cannot parse must be treated as global-only, never laundered as a
+  // scope purge — we cannot prove which namespace it belongs to.
+  it('is undefined for a malformed scope key', () => {
+    expect(purgeNamespaceForScopeKey('kilter')).toBeUndefined();
+    expect(purgeNamespaceForScopeKey('kilter:one:5')).toBeUndefined();
+  });
+});

--- a/packages/shared/offline-sync/src/mutation-queue/drainer.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/drainer.ts
@@ -20,13 +20,76 @@ let _isDraining = false;
 // itself performs runs BEFORE the flag is set, so it isn't blocked.
 let _isSigningOut = false;
 
-// Monotonic wipe generation. The boolean above is true only for the
+// Monotonic GLOBAL wipe generation. The boolean above is true only for the
 // milliseconds clearUserData takes, so an async operation whose network await
 // was in flight during that window sees `false` on both sides of it and would
 // happily write the old user's data back after the wipe (or, in a drain, post
 // the old user's queued writes under the NEXT user's token). Long-running
 // operations capture the epoch at start and abort when it has moved.
-let _wipeEpoch = 0;
+//
+// GLOBAL means "nothing local survives this": sign-out, the owner-stamp
+// mismatch wipe, and the manual database compaction. Removing ONE board's
+// catalog bumps a per-namespace epoch instead (see beginScopePurge) so it stops
+// only the work it can actually invalidate (issue #4370).
+let _globalWipeEpoch = 0;
+
+/**
+ * Per-namespace purge generation, keyed by `purgeNamespaceKey(scope)` —
+ * `boardType:layoutId`, exactly removeBoardScopeData's DELETE predicate. A
+ * namespace absent from the map has never been purged this app session.
+ */
+const _purgeEpochs = new Map<string, number>();
+
+/**
+ * Namespaces whose delete transaction is running RIGHT NOW, refcounted so two
+ * removals of the same layout (Remove-all iterating two sizes) cannot unlatch
+ * each other. removeBoardScopeData holds an exclusive transaction for seconds
+ * on a 40k-climb layout; the epoch alone only tells a check "a purge happened",
+ * while this tells it "a purge is in progress", which is what keeps a marker
+ * write from being dispatched INTO the delete window.
+ */
+const _purgesInFlight = new Map<string, number>();
+
+/**
+ * What a long-running operation captures once, at its start, to detect a purge
+ * that landed while it was awaiting.
+ */
+export type PurgeToken = {
+  readonly global: number;
+  /** A COPY of every namespace epoch known at capture time. */
+  readonly namespaces: ReadonlyMap<string, number>;
+};
+
+/**
+ * Capture once, at the start of a long-running operation; never re-capture
+ * mid-flight. Re-capturing would re-baseline against a purge that has already
+ * landed and let the operation carry on writing rows that are being deleted.
+ *
+ * Takes no argument list and copies the whole map deliberately, which makes
+ * `hasPurgeLanded` total: a namespace never purged reads `0 !== 0`, one purged
+ * before capture reads `n !== n`, one purged after capture reads `n !== n+1`.
+ * There is no "did you remember to register this namespace" footgun. The map
+ * holds at most one entry per layout the user removed this app session.
+ */
+export function capturePurgeToken(): PurgeToken {
+  return { global: _globalWipeEpoch, namespaces: new Map(_purgeEpochs) };
+}
+
+/**
+ * Has a purge that could touch `namespace` landed since the token was captured?
+ *
+ * Omit `namespace` for work no board purge can invalidate — the user tables, the
+ * mutation outbox, the global deletions cursor — and only the global epoch
+ * counts. A board-scoped caller that forgets the argument degrades to
+ * global-only (i.e. it does not abort), so derive the namespace in ONE place per
+ * call path rather than at every check site.
+ */
+export function hasPurgeLanded(token: PurgeToken, namespace?: string): boolean {
+  if (token.global !== _globalWipeEpoch) return true;
+  if (namespace === undefined) return false;
+  if (_purgesInFlight.has(namespace)) return true;
+  return (token.namespaces.get(namespace) ?? 0) !== (_purgeEpochs.get(namespace) ?? 0);
+}
 
 /**
  * Fired the instant a teardown transition happens — sign-out starts, a local
@@ -63,36 +126,70 @@ function notifyTeardown(): void {
 }
 
 export function setSigningOut(value: boolean): void {
-  if (value && !_isSigningOut) _wipeEpoch += 1;
+  if (value && !_isSigningOut) _globalWipeEpoch += 1;
   _isSigningOut = value;
   if (value) notifyTeardown();
 }
 
 /**
- * Bump the wipe epoch WITHOUT asserting sign-out.
+ * Purge ONE board namespace — removing a downloaded catalog (issues #3617,
+ * #4370).
  *
- * A local purge — removing one board scope's downloaded catalog (issue #3617) — has
- * the same hazard sign-out does: a pull page already on the wire lands after the
- * delete and resurrects part of the catalog, complete with a checkpoint past it,
- * which the strict `>` delta pull then never revisits. Every long-running pull path
- * already re-checks getWipeEpoch() across its awaits (syncTable checks at each page
- * top AND again right after the fetch await, before upsertDocuments — that second
- * check is the one that discards the in-flight page), so bumping the epoch reuses
- * those guards verbatim rather than inventing a second mechanism for one hazard.
+ * The hazard is the one sign-out has: a pull page already on the wire lands
+ * after the delete and resurrects part of the catalog, complete with a
+ * checkpoint past it, which the strict `>` delta pull then never revisits. Every
+ * long-running pull path re-checks across its awaits (syncTable checks at each
+ * page top AND again right after the fetch await, before upsertDocuments — that
+ * second check is the one that discards the in-flight page), so bumping an epoch
+ * reuses those guards rather than inventing a second mechanism.
  *
- * Deliberately not setSigningOut(true): that also flips _isSigningOut, which halts
- * drainMutationQueue (the user's unsynced ticks have nothing to do with a board
- * catalog) and would need a paired setSigningOut(false) that races a real concurrent
- * sign-out and clears ITS flag.
+ * The epoch is PER NAMESPACE because removeBoardScopeData's blast radius is:
+ * `board_type = ? AND layout_id = ?` and nothing else. Bumping a global counter
+ * for it aborted every other board's download, the mutation-queue drain, the
+ * user-data pull and the deletions pull — a Remove tap cost the whole engine a
+ * cycle (#4370).
  *
- * There is no endLocalPurge: the epoch is monotonic, so there's no flag to unset,
- * nothing to leak, and no cleanup that a throw could skip. In-flight cycles captured
- * the old value and bail; the next cycle captures the new one and proceeds normally.
- * It does abort other scopes' pulls too — they resume from intact checkpoints on the
- * next trigger, so the cost is one cycle.
+ * Deliberately not setSigningOut(true): that also flips _isSigningOut, which
+ * halts drainMutationQueue (the user's unsynced ticks have nothing to do with a
+ * board catalog) and would need a paired setSigningOut(false) that races a real
+ * concurrent sign-out and clears ITS flag.
+ *
+ * Returns the latch release. Call it from a `finally`, never conditionally: the
+ * epoch bump alone leaves a window where a check made INSIDE the seconds-long
+ * delete transaction reads "no purge" unless the bump happened to precede it,
+ * and that is exactly the window a `scope-complete:` marker write must not be
+ * dispatched into. The release is idempotent, so a double call cannot unlatch a
+ * second concurrent purge of the same namespace.
  */
-export function beginLocalPurge(): void {
-  _wipeEpoch += 1;
+export function beginScopePurge(namespace: string): () => void {
+  _purgeEpochs.set(namespace, (_purgeEpochs.get(namespace) ?? 0) + 1);
+  _purgesInFlight.set(namespace, (_purgesInFlight.get(namespace) ?? 0) + 1);
+  notifyTeardown();
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    const inFlight = _purgesInFlight.get(namespace) ?? 0;
+    if (inFlight <= 1) _purgesInFlight.delete(namespace);
+    else _purgesInFlight.set(namespace, inFlight - 1);
+  };
+}
+
+/**
+ * Bump the GLOBAL epoch: a wipe that is not scoped to one board, so every
+ * in-flight operation must bail whatever it is working on. Three callers — the
+ * owner-stamp mismatch wipe, and the manual database compaction (VACUUM takes an
+ * exclusive lock for 5-20s, which a concurrent import would meet as SQLITE_BUSY
+ * and charge itself a structural failure for). Sign-out goes through
+ * setSigningOut, which bumps this too.
+ *
+ * There is no endGlobalPurge: the epoch is monotonic, so there's no flag to
+ * unset, nothing to leak, and no cleanup a throw could skip. In-flight cycles
+ * captured the old value and bail; the next cycle captures the new one.
+ */
+export function beginGlobalPurge(): void {
+  _globalWipeEpoch += 1;
   notifyTeardown();
 }
 
@@ -103,8 +200,9 @@ export function isSigningOut(): boolean {
   return _isSigningOut;
 }
 
+/** The GLOBAL epoch only — a board purge never moves it. See beginGlobalPurge. */
 export function getWipeEpoch(): number {
-  return _wipeEpoch;
+  return _globalWipeEpoch;
 }
 
 // Backgrounding guard (Sentry BOARDSESH-AN), same shape as the sign-out guard above.
@@ -307,11 +405,11 @@ export async function drainMutationQueue(
   // being replayed belong to the signing-out user, and graphqlFetch resolves
   // the CURRENT token per request — a drain tail that outlives the account
   // switch would post the old user's writes into the new user's account.
-  const startEpoch = _wipeEpoch;
+  const startEpoch = _globalWipeEpoch;
 
   try {
     while (true) {
-      if (_isSigningOut || _wipeEpoch !== startEpoch || _isBackgrounded) break;
+      if (_isSigningOut || _globalWipeEpoch !== startEpoch || _isBackgrounded) break;
       const batch = await peekPending(db, 10);
       if (batch.length === 0) break;
 
@@ -319,7 +417,7 @@ export async function drainMutationQueue(
       let networkStop = false;
 
       for (const mutation of batch) {
-        if (_isSigningOut || _wipeEpoch !== startEpoch || _isBackgrounded) {
+        if (_isSigningOut || _globalWipeEpoch !== startEpoch || _isBackgrounded) {
           networkStop = true; // reuse the "end cycle now" path
           break;
         }
@@ -330,7 +428,7 @@ export async function drainMutationQueue(
           // reached the server, but the local bookkeeping write must not — leave
           // the row pending (idempotency_key makes a resend on the next drain
           // safe) rather than dispatch a SQLite call right as iOS suspends.
-          if (_isSigningOut || _wipeEpoch !== startEpoch || _isBackgrounded) {
+          if (_isSigningOut || _globalWipeEpoch !== startEpoch || _isBackgrounded) {
             networkStop = true; // reuse the "end cycle now" path
             break;
           }
@@ -367,7 +465,7 @@ export async function drainMutationQueue(
 
           // Same re-check as the success path above, before the retry/dead-letter
           // bookkeeping writes below.
-          if (_isSigningOut || _wipeEpoch !== startEpoch || _isBackgrounded) {
+          if (_isSigningOut || _globalWipeEpoch !== startEpoch || _isBackgrounded) {
             networkStop = true;
             break;
           }
@@ -438,12 +536,12 @@ export async function drainMutationQueue(
         if (retryAttempts >= maxCycleAttempts) break;
         // Lifecycle/connectivity may change after the failed request but before
         // backoff starts. Avoid sleeping when this cycle can no longer retry.
-        if (_isSigningOut || _wipeEpoch !== startEpoch || _isBackgrounded || !options.isOnline()) break;
+        if (_isSigningOut || _globalWipeEpoch !== startEpoch || _isBackgrounded || !options.isOnline()) break;
         await sleep(backoffDelay(retryAttempts, baseDelayMs, maxDelayMs));
         retryAttempts += 1;
         // The app may sign out, background, or lose connectivity during the
         // sleep. Re-check before touching SQLite or sending the mutation again.
-        if (_isSigningOut || _wipeEpoch !== startEpoch || _isBackgrounded || !options.isOnline()) break;
+        if (_isSigningOut || _globalWipeEpoch !== startEpoch || _isBackgrounded || !options.isOnline()) break;
         continue;
       }
 
@@ -466,7 +564,10 @@ export function __resetDrainerStateForTests(): void {
   _isBackgrounded = false;
   // Epoch checks are relative (capture-then-compare), so a residual value is
   // technically harmless — reset anyway so no test inherits another's wipes.
-  _wipeEpoch = 0;
+  _globalWipeEpoch = 0;
+  _purgeEpochs.clear();
+  // A leaked latch would block that namespace's work for every later test.
+  _purgesInFlight.clear();
   // A listener leaked by an aborted run would otherwise fire into the next test.
   teardownListeners.clear();
 }

--- a/packages/shared/offline-sync/src/mutation-queue/drainer.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/drainer.ts
@@ -178,11 +178,11 @@ export function beginScopePurge(namespace: string): () => void {
 
 /**
  * Bump the GLOBAL epoch: a wipe that is not scoped to one board, so every
- * in-flight operation must bail whatever it is working on. Three callers — the
- * owner-stamp mismatch wipe, and the manual database compaction (VACUUM takes an
- * exclusive lock for 5-20s, which a concurrent import would meet as SQLITE_BUSY
- * and charge itself a structural failure for). Sign-out goes through
- * setSigningOut, which bumps this too.
+ * in-flight operation must bail whatever it is working on. Two callers — the
+ * owner-stamp mismatch wipe, and compactOfflineDatabase before a VACUUM (an
+ * exclusive lock held for 5-20s, which a concurrent import would meet as
+ * SQLITE_BUSY and charge itself a structural failure for). Sign-out bumps the
+ * same epoch through setSigningOut rather than calling this.
  *
  * There is no endGlobalPurge: the epoch is monotonic, so there's no flag to
  * unset, nothing to leak, and no cleanup a throw could skip. In-flight cycles

--- a/packages/shared/offline-sync/src/offline-board-key.ts
+++ b/packages/shared/offline-sync/src/offline-board-key.ts
@@ -50,3 +50,36 @@ export function parseOfflineBoardKey(key: string): OfflineBoardScope | null {
   if (!boardType || !Number.isInteger(layoutId) || !Number.isInteger(sizeId)) return null;
   return { boardType, layoutId, sizeId };
 }
+
+/**
+ * The purge namespace a board scope belongs to (issue #4370): `boardType:layoutId`.
+ *
+ * Two independent reasons this is the layout and not the full scope key:
+ *
+ *  - It is exactly the blast radius of `removeBoardScopeData`'s DELETEs —
+ *    `board_type = ? AND layout_id = ?`, plus an optional retained-sizes
+ *    negation. A purge provably cannot touch a row or a marker belonging to a
+ *    different namespace, without the correctness argument depending on the
+ *    compatible_size_ids retention clause holding for every future column.
+ *  - `runBootstrapPhase` already caches BOTH snapshot artifacts under this exact
+ *    string, because one artifact serves every size of a layout. A finer
+ *    namespace would be finer than the one native transfer a purge must cancel.
+ *
+ * Cost of the coarser key: removing Kilter 12x12 while Kilter 8x12 (same layout)
+ * is downloading aborts the sibling for one cycle, which resumes from intact
+ * checkpoints on the next trigger.
+ */
+export function purgeNamespaceKey(scope: Pick<OfflineBoardScope, 'boardType' | 'layoutId'>): string {
+  return `${scope.boardType}:${scope.layoutId}`;
+}
+
+/**
+ * The namespace for a stored scope key, or `undefined` when the key is
+ * malformed. Callers must then treat the work as global-only — a key we cannot
+ * parse must never be laundered as a scope purge, because we cannot prove which
+ * namespace it is in.
+ */
+export function purgeNamespaceForScopeKey(scopeKey: string): string | undefined {
+  const parsed = parseOfflineBoardKey(scopeKey);
+  return parsed ? purgeNamespaceKey(parsed) : undefined;
+}

--- a/packages/shared/offline-sync/src/sync/__tests__/download-funnel-guard.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/download-funnel-guard.test.ts
@@ -10,11 +10,10 @@ import { describe, expect, it, vi } from 'vitest';
 import { createDownloadFunnelGuard } from '../download-funnel-guard';
 import { SnapshotWipedError } from '../snapshot-bootstrap';
 
-function makeGuard(
-  teardown: () => ReturnType<Parameters<typeof createDownloadFunnelGuard>[0]['teardownReason']> = () => null,
-) {
+function makeGuard(teardown: Parameters<typeof createDownloadFunnelGuard>[0]['teardownReason'] = () => null) {
   const report = vi.fn();
-  return { report, guard: createDownloadFunnelGuard({ report, teardownReason: teardown }) };
+  const teardownReason = vi.fn(teardown);
+  return { report, teardownReason, guard: createDownloadFunnelGuard({ report, teardownReason }) };
 }
 
 describe('download funnel guard', () => {
@@ -173,5 +172,62 @@ describe('download funnel guard', () => {
     const guard = createDownloadFunnelGuard({ report: undefined, teardownReason: () => null });
     guard.arm('kilter:1:5', 'download');
     expect(() => guard.close()).not.toThrow();
+  });
+});
+
+// A board purge is per namespace now (issue #4370), so the guard has to ask about
+// THE ARMED SCOPE rather than about the cycle as a whole.
+describe('download funnel guard — scoped teardown', () => {
+  it('asks about the armed scope, not about the cycle', () => {
+    const { guard, teardownReason } = makeGuard(() => null);
+    guard.arm('kilter:1:5', 'download');
+    guard.close();
+
+    expect(teardownReason).toHaveBeenCalledWith('kilter:1:5');
+  });
+
+  it('passes the armed scope on the uncaught path too', () => {
+    const { guard, teardownReason } = makeGuard(() => null);
+    guard.arm('tension:2:8', 'import');
+    guard.settleUncaught(new Error('SQLITE_BUSY'));
+
+    expect(teardownReason).toHaveBeenCalledWith('tension:2:8');
+  });
+
+  // The truth improvement: an unexplained exit that merely COINCIDES with another
+  // board's removal used to be laundered as an expected `aborted-wipe` and kept out
+  // of Sentry. Only a teardown that could touch the armed scope launders it now.
+  it('still reports unknown-exit when a DIFFERENT scope is the one being torn down', () => {
+    const { report, guard } = makeGuard((scopeKey) => (scopeKey === 'tension:2:8' ? 'aborted-wipe' : null));
+    guard.arm('kilter:1:5', 'download');
+    guard.close();
+
+    expect(report).toHaveBeenCalledWith(
+      expect.objectContaining({ scopeKey: 'kilter:1:5', reason: 'unknown-exit', aborted: false, expected: false }),
+    );
+  });
+
+  it('launders the exit when the armed scope IS the one being torn down', () => {
+    const { report, guard } = makeGuard((scopeKey) => (scopeKey === 'kilter:1:5' ? 'aborted-wipe' : null));
+    guard.arm('kilter:1:5', 'download');
+    guard.close();
+
+    expect(report).toHaveBeenCalledWith(
+      expect.objectContaining({ scopeKey: 'kilter:1:5', reason: 'aborted-wipe', aborted: true, expected: true }),
+    );
+  });
+});
+
+// A SnapshotWipedError classifies itself regardless of scope — it is proof the
+// transaction rolled back, not a guess about why.
+describe('download funnel guard — wiped error keeps its own classification', () => {
+  it('reports aborted-wipe even when no teardown is live for the armed scope', () => {
+    const { report, guard } = makeGuard(() => null);
+    guard.arm('kilter:1:5', 'import');
+    guard.settleUncaught(new SnapshotWipedError());
+
+    expect(report).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'aborted-wipe', aborted: true, expected: true }),
+    );
   });
 });

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client.integration.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client.integration.test.ts
@@ -28,7 +28,12 @@ const onSchemaDrift = vi.fn();
 
 import { pullSync } from '../pull-client';
 import { enqueue } from '../../mutation-queue/queue';
-import { setBackgrounded, beginLocalPurge, __resetDrainerStateForTests } from '../../mutation-queue/drainer';
+import {
+  setBackgrounded,
+  beginGlobalPurge,
+  beginScopePurge,
+  __resetDrainerStateForTests,
+} from '../../mutation-queue/drainer';
 import { processMutation, type GraphQLFetch } from '../../mutation-queue/handlers';
 import { runMigrations } from '../../db/migrations';
 import { ensureMutationQueueTable } from '../../mutation-queue/schema';
@@ -940,19 +945,19 @@ describe('sync layer — real-DDL integration', () => {
       expect(onCoverageReset).not.toHaveBeenCalled();
     });
 
-    it('wipes NOTHING when a local purge lands while the probe is on the wire', async () => {
-      // removeBoardScopeData (Storage → Remove board) calls beginLocalPurge(),
-      // which bumps the wipe epoch to abort the whole cycle. The probe is a real
-      // network round-trip, so that purge can land mid-flight — and a wipe
-      // dispatched after it would clear user data with no rebuild behind it,
-      // because every phase below bails at its first cycleAborted().
+    it('wipes NOTHING when a GLOBAL purge lands while the probe is on the wire', async () => {
+      // The owner-stamp wipe (and sign-out) bump the global epoch to abort the
+      // whole cycle. The probe is a real network round-trip, so that wipe can land
+      // mid-flight — and a reset dispatched after it would clear user data with no
+      // rebuild behind it, because every phase below bails at its first
+      // cycleAborted().
       await seedStaleDevice();
       const staleAt = Date.now() - 100 * DAY_MS;
       await setCoverage(staleAt);
       const onCoverageReset = vi.fn();
       const { fetch } = makeCoverageFetch([{ uuid: 'fresh-tick', status: 'send' }]);
       const purgingFetch = (async (query: string, variables?: Record<string, unknown>) => {
-        if (variables?.limit === 1) beginLocalPurge();
+        if (variables?.limit === 1) beginGlobalPurge();
         return fetch(query, variables);
       }) as unknown as GraphQLFetch;
 
@@ -963,6 +968,25 @@ describe('sync layer — real-DDL integration', () => {
       expect(await readCheckpoint(db, 'checkpoint:deletions')).not.toBeNull();
       expect(await readCoverage()).toBe(staleAt);
       expect(onCoverageReset).not.toHaveBeenCalled();
+    });
+
+    // The behaviour change (issue #4370): a BOARD purge no longer aborts this
+    // cycle, so the rebuild does happen and the reset must run. A stale-coverage
+    // device used to skip its reset because somebody removed a board.
+    it('still resets when a BOARD purge lands while the probe is on the wire', async () => {
+      await seedStaleDevice();
+      await setCoverage(Date.now() - 100 * DAY_MS);
+      const onCoverageReset = vi.fn();
+      const { fetch } = makeCoverageFetch([{ uuid: 'fresh-tick', status: 'send' }]);
+      const purgingFetch = (async (query: string, variables?: Record<string, unknown>) => {
+        if (variables?.limit === 1) beginScopePurge('kilter:1')();
+        return fetch(query, variables);
+      }) as unknown as GraphQLFetch;
+
+      await pullSync(db, queryClient, purgingFetch, { onCoverageReset });
+
+      expect(onCoverageReset).toHaveBeenCalledTimes(1);
+      expect(await readCoverage()).toBeGreaterThan(Date.now() - 60_000);
     });
 
     it('does not wipe again on the next cycle (no probe, no second reset)', async () => {

--- a/packages/shared/offline-sync/src/sync/__tests__/scope-teardown.integration.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/scope-teardown.integration.test.ts
@@ -8,16 +8,29 @@
 // sync_meta row, because the delta pull is a strict `>` keyset and never looks back.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { QueryInvalidator } from '../../database';
+import type { OfflineDatabase, QueryInvalidator, SqlValue } from '../../database';
 import { pullSync } from '../pull-client';
 import { removeBoardScopeData } from '../scope-teardown';
-import { getCheckpoint, setCheckpoint, markScopeDownloadComplete } from '../checkpoints';
+import {
+  getCheckpoint,
+  setCheckpoint,
+  markScopeDownloadComplete,
+  isScopeDownloadComplete,
+  isScopeDownloadStarted,
+} from '../checkpoints';
+import { isUserDataComplete } from '../local-user-owner';
+import { getDeletionsCoverageAt } from '../deletions-coverage';
 import { getBootstrapAttempts } from '../bootstrap-retry';
 import { runMigrations } from '../../db/migrations';
 import { ensureMutationQueueTable } from '../../mutation-queue/schema';
-import { beginLocalPurge, __resetDrainerStateForTests } from '../../mutation-queue/drainer';
+import {
+  beginScopePurge,
+  beginGlobalPurge,
+  setSigningOut,
+  __resetDrainerStateForTests,
+} from '../../mutation-queue/drainer';
 import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
-import { TABLE_CONFIGS } from '../table-config';
+import { TABLE_CONFIGS, USER_DATA_TABLES } from '../table-config';
 import type { OfflineBoardScope } from '../../offline-board-key';
 
 const SCOPE: OfflineBoardScope = { boardType: 'kilter', layoutId: 1, sizeId: 5 };
@@ -180,13 +193,316 @@ describe('re-downloading a removed board', () => {
   });
 });
 
-describe('beginLocalPurge', () => {
-  // The bug this guards: a purge must abort the WHOLE cycle, not just the table that
-  // happens to be mid-flight. pullSync iterates `enabledBoards` as captured BEFORE the
-  // cycle began, so the scope being removed is still in that list. If each table
-  // re-baselined its own epoch, every table after the aborted one would sail through
-  // and re-download the scope whose rows removeBoardScopeData is deleting right now —
-  // the user taps Remove and the catalog comes back.
+const TENSION_SCOPE_KEY = 'tension:2:8';
+
+const TENSION_CLIMB_DOC = {
+  uuid: 'tension-climb-1',
+  board_type: 'tension',
+  layout_id: 2,
+  name: 'Tension catalog climb',
+  is_draft: false,
+  is_listed: true,
+  compatible_size_ids: [8],
+  updated_at: '2026-05-01T00:00:00Z',
+  sync_seq: '10',
+};
+
+// The LAST board table in BOARD_DATA_TABLES, so its checkpoint write is the final
+// await before the scope-complete block.
+const GRADE_DOC = {
+  board_type: 'kilter',
+  climb_uuid: 'climb-1',
+  angle: 40,
+  local_grade: '7A',
+  universal_grade: 20,
+  grade_low: 19,
+  grade_high: 21,
+  confidence: 0.9,
+  ascensionist_count: 12,
+  computed_at: '2026-05-01T00:00:00Z',
+  sync_seq: '10',
+};
+
+// The LAST user table in USER_DATA_TABLES, same reason for markUserDataComplete.
+const PLAYLIST_FOLLOW_DOC = {
+  playlist_uuid: 'playlist-1',
+  follower_id: 1,
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+  sync_seq: '10',
+};
+
+const TICK_DOC = {
+  uuid: 'tick-1',
+  user_id: 1,
+  board_type: 'kilter',
+  climb_uuid: 'climb-1',
+  angle: 40,
+  is_mirror: false,
+  status: 'sent',
+  attempt_count: 1,
+  quality: 3,
+  difficulty: 20,
+  is_benchmark: false,
+  comment: '',
+  climbed_at: '2026-05-01T00:00:00Z',
+  session_id: null,
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+  sync_seq: '10',
+};
+
+/** One page per table+scope, so every pull reaches its checkpoint write. */
+function documentsFor(tableName: string, scopeKey: string | null): Record<string, unknown>[] {
+  if (tableName === 'board_climbs' && scopeKey === SCOPE_KEY) return [CLIMB_DOC];
+  if (tableName === 'board_climbs' && scopeKey === TENSION_SCOPE_KEY) return [TENSION_CLIMB_DOC];
+  if (tableName === 'board_climb_grades' && scopeKey === SCOPE_KEY) return [GRADE_DOC];
+  if (tableName === 'boardsesh_ticks') return [TICK_DOC];
+  if (tableName === 'playlist_follows') return [PLAYLIST_FOLLOW_DOC];
+  return [];
+}
+
+/**
+ * Fire `onWrite` right AFTER a sync_meta write for `key` commits. That is the
+ * exact window the two new guards exist for: a purge landing there has already
+ * cleared syncTable's post-await guard, so nothing else stands between it and
+ * the marker write.
+ */
+function firstBoundParam(params: readonly SqlValue[]): SqlValue | undefined {
+  // Both of runAsync/getFirstAsync's overloads are used across the engine: one
+  // passes a params ARRAY, the other spreads them. Normalise so a spy can match
+  // on the first bound value either way.
+  const first: unknown = params[0];
+  return Array.isArray(first) ? (first as SqlValue[])[0] : (first as SqlValue | undefined);
+}
+
+function afterSyncMetaWrite(key: string, onWrite: () => void): () => void {
+  const originalRun: OfflineDatabase['runAsync'] = db.runAsync.bind(db);
+  const spy = vi.spyOn(db, 'runAsync').mockImplementation(async (source: string, ...params: SqlValue[]) => {
+    const result = await originalRun(source, ...params);
+    if (firstBoundParam(params) === key) onWrite();
+    return result;
+  });
+  return () => spy.mockRestore();
+}
+
+/** Which board scope a per-board query was asked for, as a scope key. */
+function scopeKeyOf(variables: Record<string, unknown> | undefined): string | null {
+  const boardType = variables?.boardType;
+  if (typeof boardType !== 'string') return null;
+  return `${boardType}:${Number(variables?.layoutId)}:${Number(variables?.sizeId)}`;
+}
+
+/**
+ * A fetch that serves TWO board scopes on different layouts plus one user tick,
+ * and calls `onFetch` for every table+scope pair BEFORE it resolves — so a test
+ * can fire a purge from precisely the await it wants to race.
+ */
+function makeMultiScopeFetch(onFetch: (info: { tableName: string; scopeKey: string | null }) => void): {
+  fetch: GraphqlFetchMock;
+  fetched: { tableName: string; scopeKey: string | null }[];
+} {
+  const fetched: { tableName: string; scopeKey: string | null }[] = [];
+  const fetchMock = vi.fn(async (query: string, variables?: Record<string, unknown>) => {
+    if (query.includes('syncDeletions')) {
+      const call = { tableName: 'deletions', scopeKey: null };
+      fetched.push(call);
+      onFetch(call);
+      return { syncDeletions: { deletions: [], cursor: null, hasMore: false } };
+    }
+    for (const [tableName, config] of Object.entries(TABLE_CONFIGS)) {
+      if (!query.includes(config.queryName)) continue;
+      const scopeKey = scopeKeyOf(variables);
+      const call = { tableName, scopeKey };
+      fetched.push(call);
+      onFetch(call);
+      const documents = documentsFor(tableName, scopeKey);
+      return {
+        [config.queryName]: {
+          documents,
+          cursor: documents.length > 0 ? { updatedAt: '2026-05-01T00:00:00Z', syncSeq: '10' } : null,
+          hasMore: false,
+        },
+      };
+    }
+    throw new Error(`Unexpected query: ${query}`);
+  });
+  return { fetch: fetchMock as unknown as GraphqlFetchMock, fetched };
+}
+
+const BOTH_SCOPES = [SCOPE_KEY, TENSION_SCOPE_KEY];
+
+async function climbCountFor(boardType: string): Promise<number> {
+  const row = await db.getFirstAsync<{ n: number }>('SELECT COUNT(*) AS n FROM board_climbs WHERE board_type = ?', [
+    boardType,
+  ]);
+  return row?.n ?? 0;
+}
+
+describe('scope purges', () => {
+  // THE HEADLINE (issue #4370). Removing one board used to bump one global epoch,
+  // so every OTHER board's in-flight download died with it. Now a purge stops only
+  // the namespace it can actually delete rows in.
+  it("lets an unrelated scope's download finish while another board is being removed", async () => {
+    const { fetch } = makeMultiScopeFetch(({ tableName, scopeKey }) => {
+      // A removal of the tension board fires while kilter's climbs page is on the wire.
+      if (tableName === 'board_climbs' && scopeKey === SCOPE_KEY) beginScopePurge('tension:2')();
+    });
+
+    await pullSync(db, queryClient, fetch, { enabledBoards: BOTH_SCOPES });
+
+    expect(await climbCountFor('kilter')).toBe(1);
+    expect(await getCheckpoint(db, `checkpoint:board_climbs:${SCOPE_KEY}`)).not.toBeNull();
+    expect(await isScopeDownloadComplete(db, SCOPE_KEY)).toBe(true);
+
+    // The removed scope pulled nothing and holds no state that could outlive its rows.
+    expect(await climbCountFor('tension')).toBe(0);
+    expect(await getCheckpoint(db, `checkpoint:board_climbs:${TENSION_SCOPE_KEY}`)).toBeNull();
+    expect(await isScopeDownloadComplete(db, TENSION_SCOPE_KEY)).toBe(false);
+  });
+
+  // The resurrection window, for the scope actually being removed: a page already on
+  // the wire when the delete runs must NOT land afterwards.
+  it("discards the purged scope's in-flight page while the other scope completes", async () => {
+    const { fetch } = makeMultiScopeFetch(({ tableName, scopeKey }) => {
+      if (tableName === 'board_climbs' && scopeKey === SCOPE_KEY) beginScopePurge('kilter:1')();
+    });
+
+    await pullSync(db, queryClient, fetch, { enabledBoards: BOTH_SCOPES });
+
+    expect(await climbCountFor('kilter')).toBe(0);
+    expect(await getCheckpoint(db, `checkpoint:board_climbs:${SCOPE_KEY}`)).toBeNull();
+    expect(await isScopeDownloadComplete(db, SCOPE_KEY)).toBe(false);
+    expect(await isScopeDownloadStarted(db, SCOPE_KEY)).toBe(true);
+
+    expect(await climbCountFor('tension')).toBe(1);
+    expect(await isScopeDownloadComplete(db, TENSION_SCOPE_KEY)).toBe(true);
+  });
+
+  // The deliberate over-abort of the layout-keyed namespace: two SIZES of one layout
+  // share climb rows AND one artifact, so removing one stops the sibling for a cycle.
+  // Its checkpoints survive, so it resumes on the next trigger.
+  it('aborts a sibling SIZE of the purged layout, without losing its checkpoints', async () => {
+    const siblingKey = 'kilter:1:10';
+    await setCheckpoint(db, `checkpoint:board_climbs:${siblingKey}`, {
+      updatedAt: '2026-04-01T00:00:00Z',
+      syncSeq: '5',
+    });
+
+    const { fetch } = makeMultiScopeFetch(({ tableName, scopeKey }) => {
+      if (tableName === 'board_climbs' && scopeKey === siblingKey) beginScopePurge('kilter:1')();
+    });
+
+    await pullSync(db, queryClient, fetch, { enabledBoards: [siblingKey, TENSION_SCOPE_KEY] });
+
+    expect(await getCheckpoint(db, `checkpoint:board_climbs:${siblingKey}`)).toEqual({
+      updatedAt: '2026-04-01T00:00:00Z',
+      syncSeq: '5',
+    });
+    expect(await isScopeDownloadComplete(db, siblingKey)).toBe(false);
+    expect(await isScopeDownloadComplete(db, TENSION_SCOPE_KEY)).toBe(true);
+  });
+
+  // FAILS BEFORE #4370: the removal's global epoch bump aborted the user-data pull
+  // too, even though removeBoardScopeData never touches a user table.
+  it('lets the user-data phase finish through a board purge', async () => {
+    const { fetch } = makeMultiScopeFetch(({ tableName }) => {
+      if (tableName === 'boardsesh_ticks') beginScopePurge('kilter:1')();
+    });
+
+    await pullSync(db, queryClient, fetch, { enabledBoards: BOTH_SCOPES });
+
+    const ticks = await db.getFirstAsync<{ n: number }>('SELECT COUNT(*) AS n FROM boardsesh_ticks');
+    expect(ticks?.n).toBe(1);
+    expect(await getCheckpoint(db, 'checkpoint:boardsesh_ticks')).not.toBeNull();
+    expect(await isUserDataComplete(db)).toBe(true);
+  });
+
+  // Same claim for the deletions phase and its coverage marker: the tombstone stream
+  // is user-wide, and a board removal cannot invalidate a single row of it.
+  it('lets the deletions phase finish and stamp coverage through a board purge', async () => {
+    const { fetch } = makeMultiScopeFetch(({ tableName }) => {
+      if (tableName === 'deletions') beginScopePurge('kilter:1')();
+    });
+
+    await pullSync(db, queryClient, fetch, { enabledBoards: BOTH_SCOPES });
+
+    expect(await getDeletionsCoverageAt(db)).not.toBeNull();
+  });
+
+  // The CRITICAL race the loop-top `allTablesReachedTail = false` provably cannot
+  // cover: it only runs on a loop-top break, which never executes after the FINAL
+  // table. Every table reaches its tail cleanly and the purge lands from the LAST
+  // one's resolution — i.e. after the final page's post-await guard has passed. A
+  // `scope-complete:` marker written here would outlive its rows, which
+  // scope-teardown.ts calls unrecoverable short of a reinstall.
+  it('never writes scope-complete after a purge that landed during the last table', async () => {
+    const completed: string[] = [];
+    const { fetch } = makeMultiScopeFetch(() => {});
+    // Fires once the FINAL board table's checkpoint has committed: every table
+    // reached its tail cleanly, so the loop-top break never runs and
+    // `allTablesReachedTail` is still true when control reaches the block.
+    const restore = afterSyncMetaWrite(`checkpoint:board_climb_grades:${SCOPE_KEY}`, () =>
+      beginScopePurge('kilter:1')(),
+    );
+
+    await pullSync(db, queryClient, fetch, {
+      enabledBoards: [SCOPE_KEY],
+      onScopeDownloadComplete: (info) => completed.push(info.scopeKey),
+    });
+    restore();
+
+    expect(await isScopeDownloadComplete(db, SCOPE_KEY)).toBe(false);
+    expect(completed).not.toContain(SCOPE_KEY);
+  });
+
+  // The second half of the same fix: the purge lands between the
+  // `isScopeDownloadComplete` READ and the `markScopeDownloadComplete` WRITE.
+  it('never writes scope-complete after a purge that landed on the completion read', async () => {
+    const { fetch } = makeMultiScopeFetch(() => {});
+    const originalGetFirst: OfflineDatabase['getFirstAsync'] = db.getFirstAsync.bind(db);
+    // The completion block's own read. `emitScopeDownloadStartOnce` reads the same
+    // key earlier in the cycle (its backfill guard), so only the SECOND read sits
+    // in the one-statement window between the decision and the write.
+    let scopeCompleteReads = 0;
+    const getFirstSpy = vi
+      .spyOn(db, 'getFirstAsync')
+      .mockImplementation(async (source: string, ...params: SqlValue[]) => {
+        const result = await originalGetFirst(source, ...params);
+        if (firstBoundParam(params) === `scope-complete:${SCOPE_KEY}`) {
+          scopeCompleteReads += 1;
+          if (scopeCompleteReads === 2) beginScopePurge('kilter:1')();
+        }
+        return result;
+      });
+
+    await pullSync(db, queryClient, fetch, { enabledBoards: [SCOPE_KEY] });
+    getFirstSpy.mockRestore();
+
+    expect(scopeCompleteReads).toBeGreaterThanOrEqual(2);
+    expect(await isScopeDownloadComplete(db, SCOPE_KEY)).toBe(false);
+  });
+
+  // The GLOBAL analogue at markUserDataComplete: a wipe landing during the last user
+  // table's final awaits must not stamp `user_data_complete` over data being cleared.
+  it('never stamps user_data_complete after a global purge landed during the last user table', async () => {
+    // Pins the assumption the hook below rests on: if the table order ever changes,
+    // fail here rather than silently stop testing the race.
+    expect(USER_DATA_TABLES[USER_DATA_TABLES.length - 1]).toBe('playlist_follows');
+    const { fetch } = makeMultiScopeFetch(() => {});
+    const restore = afterSyncMetaWrite('checkpoint:playlist_follows', () => beginGlobalPurge());
+
+    await pullSync(db, queryClient, fetch, { enabledBoards: [SCOPE_KEY] });
+    restore();
+
+    expect(await isUserDataComplete(db)).toBe(false);
+  });
+});
+
+describe('global purges', () => {
+  // The bug the original global epoch existed for, unchanged: pullSync iterates
+  // `enabledBoards` as captured BEFORE the cycle began, so a wipe must abort the
+  // WHOLE cycle rather than let later tables re-baseline and sail through.
   it('stops the whole cycle, not just the table that was mid-flight', async () => {
     const purgeAfter = 'boardsesh_ticks';
     const queriedTables: string[] = [];
@@ -198,8 +514,8 @@ describe('beginLocalPurge', () => {
       for (const [tableName, config] of Object.entries(TABLE_CONFIGS)) {
         if (!query.includes(config.queryName)) continue;
         queriedTables.push(tableName);
-        // A removal fires while this early user table is on the wire.
-        if (tableName === purgeAfter) beginLocalPurge();
+        // The owner-stamp wipe fires while this early user table is on the wire.
+        if (tableName === purgeAfter) beginGlobalPurge();
         if (tableName === 'board_climbs') {
           return {
             syncClimbs: {
@@ -216,14 +532,14 @@ describe('beginLocalPurge', () => {
 
     await pullSync(db, queryClient, graphqlFetch as unknown as GraphqlFetchMock, { enabledBoards: [SCOPE_KEY] });
 
-    // Nothing may be pulled after the purge — above all not the board tables, which
-    // is where the removed scope's catalog would come back from.
+    // Nothing may be pulled after the wipe — above all not the board tables, which
+    // is where a removed scope's catalog would come back from.
     expect(queriedTables).toEqual([purgeAfter]);
     expect(await climbCount()).toBe(0);
     expect(await getCheckpoint(db, `checkpoint:board_climbs:${SCOPE_KEY}`)).toBeNull();
   });
 
-  // The resurrection window: a page already on the wire when the delete runs would
+  // The resurrection window: a page already on the wire when the wipe runs would
   // otherwise land afterwards, restoring rows AND stamping a checkpoint past them.
   it('makes an in-flight pull discard the page it was fetching', async () => {
     const graphqlFetch = vi.fn(async (query: string) => {
@@ -231,8 +547,8 @@ describe('beginLocalPurge', () => {
         return { syncDeletions: { deletions: [], cursor: null, hasMore: false } };
       }
       if (query.includes('syncClimbs')) {
-        // A purge starts while this page is in flight.
-        beginLocalPurge();
+        // A wipe starts while this page is in flight.
+        beginGlobalPurge();
         return {
           syncClimbs: {
             documents: [CLIMB_DOC],
@@ -253,5 +569,30 @@ describe('beginLocalPurge', () => {
 
     expect(await climbCount()).toBe(0);
     expect(await getCheckpoint(db, `checkpoint:board_climbs:${SCOPE_KEY}`)).toBeNull();
+  });
+
+  it('stops every scope on sign-out, not just the one mid-flight', async () => {
+    const { fetch } = makeMultiScopeFetch(({ tableName, scopeKey }) => {
+      if (tableName === 'board_climbs' && scopeKey === SCOPE_KEY) setSigningOut(true);
+    });
+
+    await pullSync(db, queryClient, fetch, { enabledBoards: BOTH_SCOPES });
+    setSigningOut(false);
+
+    expect(await climbCountFor('kilter')).toBe(0);
+    expect(await climbCountFor('tension')).toBe(0);
+    expect(await isScopeDownloadComplete(db, TENSION_SCOPE_KEY)).toBe(false);
+  });
+
+  it('stops every scope on a global wipe, not just the one mid-flight', async () => {
+    const { fetch } = makeMultiScopeFetch(({ tableName, scopeKey }) => {
+      if (tableName === 'board_climbs' && scopeKey === SCOPE_KEY) beginGlobalPurge();
+    });
+
+    await pullSync(db, queryClient, fetch, { enabledBoards: BOTH_SCOPES });
+
+    expect(await climbCountFor('kilter')).toBe(0);
+    expect(await climbCountFor('tension')).toBe(0);
+    expect(await isScopeDownloadComplete(db, TENSION_SCOPE_KEY)).toBe(false);
   });
 });

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -49,7 +49,8 @@ import { ensureMutationQueueTable } from '../../mutation-queue/schema';
 import {
   setSigningOut,
   setBackgrounded,
-  beginLocalPurge,
+  beginGlobalPurge,
+  beginScopePurge,
   __resetDrainerStateForTests,
 } from '../../mutation-queue/drainer';
 import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
@@ -3149,7 +3150,7 @@ describe('artifact release and reuse', () => {
       fetchManifest: vi.fn(async () => makeManifest([makeEntry()])),
       downloadArtifact: vi.fn(async (_entry: SnapshotManifestEntry, options?: { signal?: AbortSignal }) => {
         seenSignal = options?.signal;
-        beginLocalPurge();
+        beginGlobalPurge();
         return { filePath };
       }),
       deleteArtifact: vi.fn(async () => {}),
@@ -4455,8 +4456,8 @@ describe('pullSync grades bootstrap', () => {
 // Teardown reporting (issue #4314)
 //
 // Every one of these used to `break` in SILENCE: `Offline Board Download
-// Started` fired, the cycle was torn down by a sign-out / a `beginLocalPurge`
-// from removing any board / the app backgrounding, and no terminal event ever
+// Started` fired, the cycle was torn down by a sign-out / a global wipe / a purge
+// of this board's own namespace / the app backgrounding, and no terminal event ever
 // followed. The funnel could not tell an abandoned 100 MB transfer from a
 // download that is still running. They report through the same
 // `onSnapshotBootstrapError` seam now, marked `aborted: true` so a failure RATE
@@ -4475,15 +4476,16 @@ describe('pullSync bootstrap teardown reporting', () => {
     });
   }
 
-  it('reports a board removal that lands while the artifact is downloading', async () => {
+  it("reports a removal of this board's own layout that lands while the artifact is downloading", async () => {
     const filePath = join(workDir, 'purged-mid-download.db');
     buildScopeArtifact(filePath);
     const source: SnapshotSource = {
       fetchManifest: async () => makeManifest([makeEntry()]),
       downloadArtifact: async () => {
-        // Removing ANY board bumps the wipe epoch — the field report behind
-        // #4314, where a Kilter transfer died to a Tension removal.
-        beginLocalPurge();
+        // The scope being downloaded is the one being removed, so this transfer
+        // SHOULD die. A removal of a different layout must not (issue #4370) —
+        // see the scoped-purge suite below.
+        beginScopePurge('kilter:1')();
         return { filePath };
       },
       deleteArtifact: vi.fn(async () => {}),
@@ -4558,7 +4560,7 @@ describe('pullSync bootstrap teardown reporting', () => {
       snapshotSource: source,
       // Fired on the line directly above the bail, so this is a teardown landing
       // in the gap between Started and the first byte.
-      onScopeDownloadStart: () => beginLocalPurge(),
+      onScopeDownloadStart: () => beginScopePurge('kilter:1')(),
       onSnapshotBootstrapError,
     });
 
@@ -4587,7 +4589,7 @@ describe('pullSync bootstrap teardown reporting', () => {
     ) {
       if (!purged && source.includes('INSERT OR REPLACE INTO main.board_climb_stats')) {
         purged = true;
-        beginLocalPurge();
+        beginScopePurge('kilter:1')();
       }
       return realRunAsync.call(this, source, ...(rest as never[]));
     } as typeof db.runAsync);
@@ -4838,5 +4840,286 @@ describe('pullSync bootstrap funnel invariant', () => {
     expect(onScopeDownloadStart).toHaveBeenCalledTimes(1);
     expect(onSnapshotBootstrapError).not.toHaveBeenCalled();
     expect(await countRows('board_climbs')).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-board purge scoping (issue #4370)
+//
+// Removing one board used to bump ONE global epoch, so a Tension removal killed
+// a 100 MB Kilter transfer mid-flight and the climber watched it restart from
+// zero on the next foreground. The epoch is now per `boardType:layoutId` — the
+// exact predicate removeBoardScopeData deletes on, and the exact key both
+// snapshot artifacts are already cached under.
+// ---------------------------------------------------------------------------
+
+describe('pullSync bootstrap purge scoping', () => {
+  const KILTER_KEY = 'kilter:1:5';
+  const TENSION_KEY = 'tension:2:8';
+
+  function buildTwoLayoutArtifacts(): { kilterFile: string; tensionFile: string; manifest: SnapshotManifest } {
+    const kilterFile = join(workDir, 'scoped-kilter.db');
+    const tensionFile = join(workDir, 'scoped-tension.db');
+    buildArtifact({
+      filePath: kilterFile,
+      climbs: [{ uuid: 'kilter-c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'kilter-c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    buildArtifact({
+      filePath: tensionFile,
+      climbs: [{ uuid: 'tension-c1', boardType: 'tension', layoutId: 2, compatibleSizeIds: [8] }],
+      stats: [{ climbUuid: 'tension-c1', boardType: 'tension', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const manifest = makeManifest([
+      makeEntry(),
+      makeEntry({
+        boardType: 'tension',
+        layoutId: 2,
+        key: 'board-snapshots/v1/tension/2/2026-06-01.db',
+        url: 'https://example.test/tension-2.db',
+      }),
+    ]);
+    return { kilterFile, tensionFile, manifest };
+  }
+
+  /** A source serving both layouts, with a hook that fires per downloaded layout. */
+  function makeTwoLayoutSource(
+    files: { kilterFile: string; tensionFile: string; manifest: SnapshotManifest },
+    onDownload: (boardType: string) => void,
+  ): SnapshotSource {
+    return {
+      fetchManifest: async () => files.manifest,
+      downloadArtifact: async (entry: SnapshotManifestEntry) => {
+        onDownload(entry.boardType);
+        return { filePath: entry.boardType === 'tension' ? files.tensionFile : files.kilterFile };
+      },
+      deleteArtifact: vi.fn(async () => {}),
+    } as unknown as SnapshotSource;
+  }
+
+  // THE WIN. Before this, the Kilter transfer died to the Tension removal.
+  it("imports the untouched layout while another layout's board is removed mid-download", async () => {
+    const files = buildTwoLayoutArtifacts();
+    const source = makeTwoLayoutSource(files, (boardType) => {
+      if (boardType === 'kilter') beginScopePurge('tension:2')();
+    });
+    const onSnapshotBootstrapError = vi.fn();
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: [KILTER_KEY, TENSION_KEY],
+      snapshotSource: source,
+      onSnapshotBootstrapError,
+    });
+
+    // Kilter imported, which is the whole point: before #4370 this row count was 0.
+    expect(await countRows('board_climbs')).toBe(1);
+    expect(await getCheckpoint(db, `checkpoint:board_climbs:${KILTER_KEY}`)).not.toBeNull();
+
+    // Tension is processed AFTER kilter, so its purge lands before it ever arms
+    // the funnel: it bails at the phase's loop top having emitted no Started, so
+    // it is owed no terminal event and nothing at all is reported. (A scope
+    // already armed when its own layout is purged DOES report — see the next
+    // test.) Its budget is untouched either way.
+    expect(onSnapshotBootstrapError).not.toHaveBeenCalled();
+    expect(await getCheckpoint(db, `checkpoint:board_climbs:${TENSION_KEY}`)).toBeNull();
+    expect(await getBootstrapAttempts(db, TENSION_KEY)).toBe(0);
+  });
+
+  // The other half: the removed layout's own transfer must still die.
+  it("aborts the removed layout's own download and still imports the other", async () => {
+    const files = buildTwoLayoutArtifacts();
+    const source = makeTwoLayoutSource(files, (boardType) => {
+      if (boardType === 'kilter') beginScopePurge('kilter:1')();
+    });
+    const onSnapshotBootstrapError = vi.fn();
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: [KILTER_KEY, TENSION_KEY],
+      snapshotSource: source,
+      onSnapshotBootstrapError,
+    });
+
+    expect(await getCheckpoint(db, `checkpoint:board_climbs:${KILTER_KEY}`)).toBeNull();
+    expect(await getBootstrapAttempts(db, KILTER_KEY)).toBe(0);
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(
+      expect.objectContaining({ scopeKey: KILTER_KEY, stage: 'download', aborted: true, reason: 'aborted-wipe' }),
+    );
+    // Tension was never touched by the purge, so it imported.
+    expect(await getCheckpoint(db, `checkpoint:board_climbs:${TENSION_KEY}`)).not.toBeNull();
+  });
+
+  // Pins the scoping of the two guards inside the import transaction: a purge of
+  // a DIFFERENT namespace must not raise SnapshotWipedError and roll this back.
+  it("does not roll back an import when a different layout's board is purged", async () => {
+    const filePath = join(workDir, 'other-layout-purged-mid-import.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const adapterPrototype = Object.getPrototypeOf(db) as { runAsync: typeof db.runAsync };
+    const realRunAsync = adapterPrototype.runAsync;
+    let purged = false;
+    vi.spyOn(adapterPrototype, 'runAsync').mockImplementation(async function (
+      this: unknown,
+      sql: string,
+      ...rest: unknown[]
+    ) {
+      if (!purged && sql.includes('INSERT OR REPLACE INTO main.board_climb_stats')) {
+        purged = true;
+        beginScopePurge('tension:2')();
+      }
+      return realRunAsync.call(this, sql, ...(rest as never[]));
+    } as typeof db.runAsync);
+
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const onSnapshotBootstrapError = vi.fn();
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: [KILTER_KEY],
+      snapshotSource: source,
+      onSnapshotBootstrapError,
+    });
+
+    expect(purged).toBe(true);
+    expect(await countRows('board_climbs')).toBe(1);
+    expect(await getCheckpoint(db, `checkpoint:board_climbs:${KILTER_KEY}`)).not.toBeNull();
+    expect(onSnapshotBootstrapError).not.toHaveBeenCalled();
+  });
+
+  // The grades artifact rides the same namespace key, so a sibling layout's
+  // removal must not stop it either — and it must not burn a grades attempt.
+  it("imports grades through another layout's purge without burning an attempt", async () => {
+    const climbsFile = join(workDir, 'grades-scoped-climbs.db');
+    const gradesFile = join(workDir, 'grades-scoped-grades.db');
+    buildArtifact({
+      filePath: climbsFile,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    buildGradesArtifact({
+      filePath: gradesFile,
+      grades: [{ climbUuid: 'c1', angle: 40 }],
+      watermark: { updatedAt: '2026-05-01T00:00:00Z', syncSeq: '10' },
+    });
+    const { source } = makeGradesSource({
+      manifest: makeManifest([makeEntry({ grades: gradesArtifactBlock() })]),
+      climbsFile,
+      gradesFile,
+    });
+    const originalDownloadGrades = source.downloadGradesArtifact?.bind(source);
+    source.downloadGradesArtifact = async (artifact) => {
+      beginScopePurge('tension:2')();
+      return originalDownloadGrades ? originalDownloadGrades(artifact) : null;
+    };
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: [KILTER_KEY],
+      snapshotSource: source,
+    });
+
+    expect(await getCheckpoint(db, `checkpoint:board_climb_grades:${KILTER_KEY}`)).not.toBeNull();
+    expect(await getGradesBootstrapAttempts(db, KILTER_KEY)).toBe(0);
+  });
+
+  // Term-count regression guard for the whole rewrite: every guard is
+  // `isSigningOut() || <purge> || isBackgrounded()`, and only the middle term
+  // changed. Dropping isBackgrounded() in front of the grades import would
+  // reopen the BOARDSESH-AN class of bug.
+  it('still bails the grades import when the app backgrounds and nothing was purged', async () => {
+    const climbsFile = join(workDir, 'grades-bg-climbs.db');
+    const gradesFile = join(workDir, 'grades-bg-grades.db');
+    buildArtifact({
+      filePath: climbsFile,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    buildGradesArtifact({
+      filePath: gradesFile,
+      grades: [{ climbUuid: 'c1', angle: 40 }],
+      watermark: { updatedAt: '2026-05-01T00:00:00Z', syncSeq: '10' },
+    });
+    const { source } = makeGradesSource({
+      manifest: makeManifest([makeEntry({ grades: gradesArtifactBlock() })]),
+      climbsFile,
+      gradesFile,
+    });
+    const originalDownloadGrades = source.downloadGradesArtifact?.bind(source);
+    source.downloadGradesArtifact = async (artifact) => {
+      const result = originalDownloadGrades ? await originalDownloadGrades(artifact) : null;
+      setBackgrounded(true);
+      return result;
+    };
+
+    try {
+      await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+        enabledBoards: [KILTER_KEY],
+        snapshotSource: source,
+      });
+    } finally {
+      setBackgrounded(false);
+    }
+
+    expect(await getCheckpoint(db, `checkpoint:board_climb_grades:${KILTER_KEY}`)).toBeNull();
+    expect(await getGradesBootstrapAttempts(db, KILTER_KEY)).toBe(0);
+  });
+
+  // THE FUNNEL INVARIANT under `break` → `continue`: every Started still gets
+  // exactly one terminal event. The per-scope `finally` closes the guard once per
+  // scope now instead of once per cycle, which is what preserves it.
+  it('emits exactly one terminal event per Started across a mid-flight scope purge', async () => {
+    const files = buildTwoLayoutArtifacts();
+    const source = makeTwoLayoutSource(files, (boardType) => {
+      if (boardType === 'kilter') beginScopePurge('tension:2')();
+    });
+    const started: string[] = [];
+    const terminals: string[] = [];
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: [KILTER_KEY, TENSION_KEY],
+      snapshotSource: source,
+      onScopeDownloadStart: (info) => started.push(info.scopeKey),
+      onSnapshotBootstrapError: (report) => terminals.push(report.scopeKey),
+      onScopeDownloadComplete: (info) => terminals.push(info.scopeKey),
+    });
+
+    // The purged scope never announced a Started, so it is owed nothing; the
+    // surviving one announced exactly one and got exactly one terminal.
+    expect(started).toEqual([KILTER_KEY]);
+    for (const scopeKey of started) {
+      expect(terminals.filter((key) => key === scopeKey)).toHaveLength(1);
+    }
+    expect(terminals).not.toContain(TENSION_KEY);
+  });
+
+  it('emits exactly one terminal event per Started across a mid-flight GLOBAL purge', async () => {
+    const files = buildTwoLayoutArtifacts();
+    const source = makeTwoLayoutSource(files, (boardType) => {
+      if (boardType === 'kilter') beginGlobalPurge();
+    });
+    const started: string[] = [];
+    const terminals: string[] = [];
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: [KILTER_KEY, TENSION_KEY],
+      snapshotSource: source,
+      onScopeDownloadStart: (info) => started.push(info.scopeKey),
+      onSnapshotBootstrapError: (report) => terminals.push(report.scopeKey),
+      onScopeDownloadComplete: (info) => terminals.push(info.scopeKey),
+    });
+
+    for (const scopeKey of started) {
+      expect(terminals.filter((key) => key === scopeKey)).toHaveLength(1);
+    }
   });
 });

--- a/packages/shared/offline-sync/src/sync/download-funnel-guard.ts
+++ b/packages/shared/offline-sync/src/sync/download-funnel-guard.ts
@@ -49,11 +49,16 @@ export type DownloadFunnelGuardOptions = {
    */
   report: ((report: SnapshotBootstrapErrorReport) => void) | undefined;
   /**
-   * Why the cycle is being torn down AT THIS INSTANT, or null. Read at close
-   * time rather than latched, so an unexplained exit during a sign-out is
-   * attributed to the sign-out instead of being filed as a defect.
+   * Why the armed scope's work is being torn down AT THIS INSTANT, or null. Read
+   * at close time rather than latched, so an unexplained exit during a sign-out
+   * is attributed to the sign-out instead of being filed as a defect.
+   *
+   * Takes the scope key because a board purge is per namespace (issue #4370): an
+   * unexplained exit that merely coincides with ANOTHER board's removal must
+   * still report `unknown-exit` and reach Sentry, rather than being laundered as
+   * an expected abort.
    */
-  teardownReason: () => SnapshotBootstrapFailureReason | null;
+  teardownReason: (scopeKey: string) => SnapshotBootstrapFailureReason | null;
 };
 
 export type DownloadFunnelGuard = {
@@ -113,7 +118,7 @@ export function createDownloadFunnelGuard(options: DownloadFunnelGuardOptions): 
       const classified = classifySnapshotBootstrapFailure(error);
       // A SnapshotWipedError classifies itself; anything else is only an abort if
       // the cycle is being torn down right now.
-      const abortReason = classified === 'aborted-wipe' ? classified : options.teardownReason();
+      const abortReason = classified === 'aborted-wipe' ? classified : options.teardownReason(attempt.scopeKey);
       if (abortReason) {
         emit({ reason: abortReason, cause: error, aborted: true, expected: true });
         return;
@@ -130,7 +135,7 @@ export function createDownloadFunnelGuard(options: DownloadFunnelGuardOptions): 
         attempt = null;
         return;
       }
-      const teardown = options.teardownReason();
+      const teardown = options.teardownReason(closing.scopeKey);
       if (teardown) {
         // A known bail-out that forgot to report. Same shape #4314's hand-written
         // sites emit, so the two can never disagree.

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -73,8 +73,20 @@ import {
 import { applyBusyTimeout } from '../db/pragmas';
 import { getPendingCount } from '../mutation-queue/queue';
 import { isNetworkError } from '../mutation-queue/error-classification';
-import { isSigningOut, getWipeEpoch, isBackgrounded, onTeardown } from '../mutation-queue/drainer';
-import { parseOfflineBoardKey, type OfflineBoardScope } from '../offline-board-key';
+import {
+  isSigningOut,
+  isBackgrounded,
+  onTeardown,
+  capturePurgeToken,
+  hasPurgeLanded,
+  type PurgeToken,
+} from '../mutation-queue/drainer';
+import {
+  parseOfflineBoardKey,
+  purgeNamespaceKey,
+  purgeNamespaceForScopeKey,
+  type OfflineBoardScope,
+} from '../offline-board-key';
 
 /**
  * Telemetry hook for schema drift: a sync document carried a column the local
@@ -611,14 +623,21 @@ async function syncTable(
   queryClient: QueryInvalidator,
   graphqlFetch: <T>(query: string, variables?: Record<string, unknown>) => Promise<T>,
   tableName: string,
-  /** The epoch pullSync captured at CYCLE start — see `cycleAborted` there. */
-  cycleEpoch: number,
+  /** The purge token pullSync captured at CYCLE start — see `cycleAborted` there. */
+  purgeToken: PurgeToken,
   boardScope?: BoardScope,
   onProgress?: (documentsProcessed: number) => void,
   onSchemaDrift?: SchemaDriftReporter,
 ): Promise<{ reachedTail: boolean; rowsProcessed: number; resumedFromCheckpoint: boolean }> {
   const config = TABLE_CONFIGS[tableName];
   if (!config) throw new Error(`No sync config for table: ${tableName}`);
+
+  // Derived ONCE here rather than at each guard, and from `boardScope` rather
+  // than from a caller argument, so there is exactly one place a board-scoped
+  // call could forget it (a forgotten namespace degrades to global-only, i.e.
+  // no abort). `undefined` for a user table is the correct answer, not an
+  // omission: a board purge can never invalidate boardsesh_ticks.
+  const purgeKey = boardScope ? purgeNamespaceKey(boardScope) : undefined;
 
   const checkpointKey = getCheckpointKey(tableName, boardScope?.scopeKey);
   const checkpoint = await getCheckpoint(db, checkpointKey);
@@ -642,16 +661,16 @@ async function syncTable(
   // epoch is monotonic, so comparing it catches a wipe that started AND
   // finished while we were awaiting the network.
   //
-  // The epoch compared against is the CYCLE's, passed in — never one captured
+  // The token compared against is the CYCLE's, passed in — never one captured
   // here. Capturing locally would make each table re-baseline against the
-  // post-wipe value and carry on, so a purge would only ever abort whichever
+  // post-purge value and carry on, so a purge would only ever abort whichever
   // table happened to be mid-flight (see `cycleAborted` in pullSync).
 
   let hasMore = true;
   while (hasMore) {
     // Sign-out is wiping local data: stop before this page writes the old
     // user's rows back (mirrors the drainer's guard).
-    if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded())
+    if (isSigningOut() || hasPurgeLanded(purgeToken, purgeKey) || isBackgrounded())
       return { reachedTail: false, rowsProcessed: totalProcessed, resumedFromCheckpoint };
     const variables: Record<string, unknown> = { cursor, limit: PAGE_LIMIT };
     if (config.isPerBoard && boardScope) {
@@ -663,9 +682,10 @@ async function syncTable(
     const response = await graphqlFetch<Record<string, SyncResult>>(query, variables);
     const result = response[config.queryName];
 
-    // Re-check after the await: the wipe may have started (or fully completed)
-    // while this page was on the wire.
-    if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded())
+    // Re-check after the await: the wipe (or this scope's purge) may have
+    // started AND fully completed while this page was on the wire. This is the
+    // check that discards an in-flight page.
+    if (isSigningOut() || hasPurgeLanded(purgeToken, purgeKey) || isBackgrounded())
       return { reachedTail: false, rowsProcessed: totalProcessed, resumedFromCheckpoint };
 
     // An empty page would not advance the cursor; if the backend ever returns
@@ -701,8 +721,8 @@ async function processDeletions(
   db: OfflineDatabase,
   queryClient: QueryInvalidator,
   graphqlFetch: <T>(query: string, variables?: Record<string, unknown>) => Promise<T>,
-  /** The epoch pullSync captured at CYCLE start — see `cycleAborted` there. */
-  cycleEpoch: number,
+  /** The purge token pullSync captured at CYCLE start — see `cycleAborted` there. */
+  purgeToken: PurgeToken,
   onProgress?: (documentsProcessed: number) => void,
 ): Promise<{ reachedTail: boolean }> {
   const checkpointKey = DELETIONS_CHECKPOINT_KEY;
@@ -715,20 +735,23 @@ async function processDeletions(
   const invalidatedKeys = new Set<string>();
 
   // See syncTable: catch a wipe that ran while a page was on the wire, and why the
-  // epoch is the cycle's rather than one captured here.
+  // token is the cycle's rather than one captured here.
+  //
+  // GLOBAL, no namespace: the tombstone stream and its cursor are user-wide, and
+  // removeBoardScopeData touches neither. A board removal must not stop this.
 
   let hasMore = true;
   while (hasMore) {
     // Sign-out is wiping local data: stop before this page writes the old
     // user's rows back (mirrors the drainer's guard).
-    if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) return { reachedTail: false };
+    if (isSigningOut() || hasPurgeLanded(purgeToken) || isBackgrounded()) return { reachedTail: false };
     const response = await graphqlFetch<{ syncDeletions: SyncDeletionsResult }>(SYNC_DELETIONS_QUERY, {
       cursor,
       limit: PAGE_LIMIT,
     });
     const result = response.syncDeletions;
 
-    if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) return { reachedTail: false };
+    if (isSigningOut() || hasPurgeLanded(purgeToken) || isBackgrounded()) return { reachedTail: false };
 
     // Empty page can't advance the cursor; break to avoid an infinite loop if
     // the backend returns deletions:[] with hasMore:true (I2).
@@ -981,8 +1004,8 @@ async function runBootstrapPhase(params: {
   queryClient: QueryInvalidator;
   source: SnapshotSource;
   scopes: BoardScope[];
-  /** The epoch pullSync captured at CYCLE start — see `cycleAborted` there. */
-  cycleEpoch: number;
+  /** The purge token pullSync captured at CYCLE start — see `cycleAborted` there. */
+  purgeToken: PurgeToken;
   /** Once-ever Started emitter, shared with the board-data loop (issue #4316). */
   emitScopeDownloadStartOnce: (info: ScopeDownloadStartInfo) => Promise<void>;
   /** Per-scope download/import timings + payload size, read back by the Completed event. */
@@ -998,7 +1021,7 @@ async function runBootstrapPhase(params: {
     queryClient,
     source,
     scopes,
-    cycleEpoch,
+    purgeToken,
     stampScopeStart,
     phaseTimings,
     emitScopeDownloadStartOnce,
@@ -1012,13 +1035,31 @@ async function runBootstrapPhase(params: {
   const rawSnapshotBootstrapError = options?.onSnapshotBootstrapError;
 
   /**
-   * Why the phase is being torn down, or null when it is not. Read at each of the
-   * bail-out points below, which used to `break`/`return` in silence — the reason
-   * `Offline Board Download Started` could be followed by nothing at all.
+   * `kind: 'cycle'` — nothing in this cycle may continue (break).
+   * `kind: 'scope'`  — only THIS scope's namespace was purged (continue), so
+   * every other board keeps its download (issue #4370).
    */
-  const teardownReason = (): SnapshotBootstrapFailureReason | null => {
-    if (isSigningOut() || getWipeEpoch() !== cycleEpoch) return 'aborted-wipe';
-    if (isBackgrounded()) return 'aborted-background';
+  type TeardownVerdict = { reason: SnapshotBootstrapFailureReason; kind: 'cycle' | 'scope' };
+
+  /**
+   * Why the phase — or just this scope — is being torn down, or null when it is
+   * not. Read at each of the bail-out points below, which used to
+   * `break`/`return` in silence: the reason `Offline Board Download Started`
+   * could be followed by nothing at all.
+   *
+   * The ordering is load-bearing and unchanged: sign-out/global wipe first,
+   * backgrounding second, scope purge last. That is what keeps a backgrounded
+   * phone reporting `aborted-background` rather than `aborted-wipe`. An
+   * unparseable scopeKey yields global-only checks — a malformed key is never
+   * laundered as a scope purge, because we cannot prove which namespace it is in.
+   */
+  const teardownVerdict = (scopeKey: string): TeardownVerdict | null => {
+    if (isSigningOut() || hasPurgeLanded(purgeToken)) return { reason: 'aborted-wipe', kind: 'cycle' };
+    if (isBackgrounded()) return { reason: 'aborted-background', kind: 'cycle' };
+    const namespace = purgeNamespaceForScopeKey(scopeKey);
+    if (namespace !== undefined && hasPurgeLanded(purgeToken, namespace)) {
+      return { reason: 'aborted-wipe', kind: 'scope' };
+    }
     return null;
   };
 
@@ -1029,7 +1070,13 @@ async function runBootstrapPhase(params: {
   // own catch, a consumer callback blowing up — still closes the funnel. See
   // download-funnel-guard.ts for what counts as settled and why only a genuinely
   // unexplained exit reaches Sentry.
-  const funnelGuard = createDownloadFunnelGuard({ report: rawSnapshotBootstrapError, teardownReason });
+  const funnelGuard = createDownloadFunnelGuard({
+    report: rawSnapshotBootstrapError,
+    // Scope-aware: an unexplained exit that merely COINCIDES with another
+    // board's removal is no longer laundered as `aborted-wipe`, so it still
+    // reaches Sentry as `unknown-exit` (issue #4370).
+    teardownReason: (scopeKey) => teardownVerdict(scopeKey)?.reason ?? null,
+  });
 
   // Wrapped ONCE here rather than at each of the eight report sites: every one of
   // them already builds a payload with the cause in hand, so deriving `reason` and
@@ -1145,7 +1192,9 @@ async function runBootstrapPhase(params: {
     if (!isSnapshotEntryUsable(gradesArtifact)) return;
     if ((await getGradesBootstrapAttempts(db, scope.scopeKey)) >= MAX_GRADES_BOOTSTRAP_ATTEMPTS) return;
 
-    const layoutKey = `${scope.boardType}:${scope.layoutId}`;
+    // One artifact serves every size of a layout, which is exactly why the purge
+    // namespace is keyed the same way — the two must never drift.
+    const layoutKey = purgeNamespaceKey(scope);
     let gradesDownload = gradesDownloadByLayout.get(layoutKey);
     if (gradesDownload === undefined) {
       let downloadCause: unknown = null;
@@ -1167,9 +1216,12 @@ async function runBootstrapPhase(params: {
         // artifact ever gets on a pocketed phone, and three screen locks left a
         // Kilter board crawling grades over GraphQL for the life of the install
         // (issue #4390).
-        const gradesTeardown = teardownReason();
+        // Scope-aware (issue #4370): another board's removal never charges this
+        // layout a grades attempt, and never masks a real grades failure as an
+        // abort either.
+        const gradesTeardown = teardownVerdict(scope.scopeKey);
         if (gradesTeardown) {
-          reportBootstrapAbort(scope.scopeKey, 'grades-download', gradesTeardown, downloadCause);
+          reportBootstrapAbort(scope.scopeKey, 'grades-download', gradesTeardown.reason, downloadCause);
           gradesDownloadByLayout.set(layoutKey, null);
           return;
         }
@@ -1186,7 +1238,7 @@ async function runBootstrapPhase(params: {
       if (gradesDownload) gradesArtifactPaths.add(gradesDownload.filePath);
     }
     if (!gradesDownload) return;
-    if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) return;
+    if (isSigningOut() || hasPurgeLanded(purgeToken, purgeNamespaceKey(scope)) || isBackgrounded()) return;
 
     try {
       const { rowsImported } = await bootstrapScopeGradesFromSnapshot({
@@ -1209,7 +1261,8 @@ async function runBootstrapPhase(params: {
       }
     } catch (error) {
       // A wipe rolls the transaction back; no checkpoint, nothing to count.
-      if (error instanceof SnapshotWipedError || isSigningOut() || getWipeEpoch() !== cycleEpoch) return;
+      if (error instanceof SnapshotWipedError || isSigningOut() || hasPurgeLanded(purgeToken, purgeNamespaceKey(scope)))
+        return;
       const attempt = await recordGradesBootstrapAttempt(db, scope.scopeKey);
       onSnapshotBootstrapError?.({
         scopeKey: scope.scopeKey,
@@ -1255,7 +1308,11 @@ async function runBootstrapPhase(params: {
     for (const scope of scopes) {
       let metadataSettled = false;
       try {
-        if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) break;
+        const loopTopVerdict = teardownVerdict(scope.scopeKey);
+        if (loopTopVerdict) {
+          if (loopTopVerdict.kind === 'cycle') break;
+          continue;
+        }
 
         // Duration telemetry starts here — before the eligibility check — so a
         // snapshot scope's durationMs covers its manifest/download/import work.
@@ -1339,7 +1396,11 @@ async function runBootstrapPhase(params: {
             const gradesCheckpoint = await getCheckpoint(db, getCheckpointKey('board_climb_grades', scope.scopeKey));
             if (!gradesCheckpoint) {
               const retrofitResolution = await resolveManifestOnce(source, manifestCache);
-              if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) break;
+              const retrofitVerdict = teardownVerdict(scope.scopeKey);
+              if (retrofitVerdict) {
+                if (retrofitVerdict.kind === 'cycle') break;
+                continue;
+              }
               const retrofitEntry =
                 retrofitResolution.status === 'ok'
                   ? findSnapshotEntry(retrofitResolution.manifest, scope.boardType, scope.layoutId)
@@ -1369,7 +1430,11 @@ async function runBootstrapPhase(params: {
         phases.manifestMs += Date.now() - manifestStartedAt;
         // Re-check after the manifest network await: every branch below either
         // writes to SQLite or leads to one further down.
-        if (isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded()) break;
+        const manifestVerdict = teardownVerdict(scope.scopeKey);
+        if (manifestVerdict) {
+          if (manifestVerdict.kind === 'cycle') break;
+          continue;
+        }
 
         // Shared with the pre-download size estimate (snapshot-estimate.ts) so the
         // UI can never quote a number for an artifact this phase would skip.
@@ -1510,13 +1575,17 @@ async function runBootstrapPhase(params: {
         });
         // Started fired on the line above, so a silent bail here is the tightest
         // possible dangling-Started window. Close it too (issue #4314).
-        const preDownloadTeardown = teardownReason();
-        if (preDownloadTeardown) {
-          reportBootstrapAbort(scope.scopeKey, 'download', preDownloadTeardown, null);
-          break;
+        const preDownloadVerdict = teardownVerdict(scope.scopeKey);
+        if (preDownloadVerdict) {
+          reportBootstrapAbort(scope.scopeKey, 'download', preDownloadVerdict.reason, null);
+          if (preDownloadVerdict.kind === 'cycle') break;
+          continue;
         }
 
-        const layoutKey = `${scope.boardType}:${scope.layoutId}`;
+        // Same key as the purge namespace, and the reason it is the namespace:
+        // one artifact serves every size of a layout, so one purge maps 1:1 onto
+        // the one native transfer that must die.
+        const layoutKey = purgeNamespaceKey(scope);
         // The failure cause is cached alongside the result so a second size of the
         // same layout (which reuses this entry instead of re-downloading) still
         // reports the real error, not null.
@@ -1566,15 +1635,18 @@ async function runBootstrapPhase(params: {
           // Android transfer would launder every later wifi drop, HTTP 500 or
           // disk error into a free, cooldown-free 100 MB retry loop.
           let suspensionWindowOpen = false;
+          // SCOPE-AWARE, and the single biggest user-visible win of #4370: a
+          // purge of a DIFFERENT layout returns null here, so the multi-minute
+          // transfer this board is in the middle of is not cancelled.
           const onTeardownNotice = (): void => {
-            const reason = teardownReason();
-            if (!reason) return;
-            if (reason === 'aborted-background') {
+            const verdict = teardownVerdict(scope.scopeKey);
+            if (!verdict) return;
+            if (verdict.reason === 'aborted-background') {
               transfer.backgroundedDuringTransfer = true;
               suspensionWindowOpen = true;
               return;
             }
-            selfAbortedReason ??= reason;
+            selfAbortedReason ??= verdict.reason;
             abortController.abort();
           };
           const unsubscribeTeardown = onTeardown(onTeardownNotice);
@@ -1603,7 +1675,7 @@ async function runBootstrapPhase(params: {
                   // A byte arrived while nothing is tearing us down: this
                   // transfer demonstrably survived the pocket, so a later
                   // failure is not the suspension's doing (issue #4390).
-                  if (suspensionWindowOpen && !teardownReason()) suspensionWindowOpen = false;
+                  if (suspensionWindowOpen && !teardownVerdict(scope.scopeKey)) suspensionWindowOpen = false;
                   const resolved = resolveDownloadFraction({
                     entry,
                     bytesWritten,
@@ -1673,8 +1745,15 @@ async function runBootstrapPhase(params: {
         // is an abort even if the flag that caused it has since cleared. Without
         // it a phone that unlocked at the wrong moment charged itself a transport
         // failure (and a 2-minute cooldown) for its own cancellation.
-        const downloadTeardown = teardownReason() ?? cachedDownload.abortedReason;
-        if (downloadTeardown) {
+        //
+        // A LATCHED self-abort whose flag has since cleared is treated as
+        // `kind: 'cycle'` deliberately — conservative, and it cannot emit a
+        // second terminal event for the same Started.
+        const downloadVerdict =
+          teardownVerdict(scope.scopeKey) ??
+          (cachedDownload.abortedReason ? { reason: cachedDownload.abortedReason, kind: 'cycle' as const } : null);
+        if (downloadVerdict) {
+          const downloadTeardown = downloadVerdict.reason;
           // A transfer that FINISHED is never a pause — the file is on disk, the
           // source's sidecar is written, and the next foreground cycle reuses it
           // for free (issue #4310). Only a dead transfer costs anything.
@@ -1729,7 +1808,10 @@ async function runBootstrapPhase(params: {
           } else {
             reportBootstrapAbort(scope.scopeKey, 'download', downloadTeardown, cachedDownload.cause);
           }
-          break;
+          // A purge of ONLY this scope's namespace stops this board and leaves
+          // every other download in the cycle running (issue #4370).
+          if (downloadVerdict.kind === 'cycle') break;
+          continue;
         }
         const download = cachedDownload.file;
         if (!download) {
@@ -1866,10 +1948,19 @@ async function runBootstrapPhase(params: {
           // A wipe mid-import rolls the transaction back and bails the phase — no
           // burn (the pull is being torn down, not failing). Reported all the
           // same, so the scope's Started is not left dangling (issue #4314).
-          const importTeardown = error instanceof SnapshotWipedError ? 'aborted-wipe' : teardownReason();
-          if (importTeardown) {
-            reportBootstrapAbort(scope.scopeKey, 'import', importTeardown, error);
-            break;
+          //
+          // A SnapshotWipedError carries no kind, so derive it: the epoch is
+          // monotonic, so a scope-purge-raised one still reads `kind: 'scope'`
+          // at catch time. The `?? cycle` arm is the unreachable-conservative
+          // default that matches the pre-#4370 `break`.
+          const importVerdict =
+            error instanceof SnapshotWipedError
+              ? (teardownVerdict(scope.scopeKey) ?? { reason: 'aborted-wipe' as const, kind: 'cycle' as const })
+              : teardownVerdict(scope.scopeKey);
+          if (importVerdict) {
+            reportBootstrapAbort(scope.scopeKey, 'import', importVerdict.reason, error);
+            if (importVerdict.kind === 'cycle') break;
+            continue;
           }
           if (error instanceof SnapshotSchemaStaleError) {
             // Permanent miss for this run, no burn: the artifact predates this
@@ -2028,17 +2119,17 @@ async function runBootstrapPhase(params: {
  * expired-token device can't wipe itself either. A throw propagates to the
  * scheduler's catch, which retries on the next trigger with local data intact.
  *
- * `beginLocalPurge()` is deliberately NOT called: it bumps the wipe epoch, which
- * would abort the very cycle that is supposed to rebuild. It isn't needed here —
- * the scheduler single-flights pullSync, so no other pull page is on the wire,
- * and the drainer writes only to pending_mutations, which this reset never
- * touches.
+ * `beginGlobalPurge()` is deliberately NOT called: it bumps the global wipe
+ * epoch, which would abort the very cycle that is supposed to rebuild. It isn't
+ * needed here — the scheduler single-flights pullSync, so no other pull page is
+ * on the wire, and the drainer writes only to pending_mutations, which this
+ * reset never touches.
  */
 async function enforceDeletionsCoverage(
   db: OfflineDatabase,
   queryClient: QueryInvalidator,
   graphqlFetch: <T>(query: string, variables?: Record<string, unknown>) => Promise<T>,
-  cycleEpoch: number,
+  purgeToken: PurgeToken,
   options?: SyncOptions,
 ): Promise<void> {
   // Sign-out is (or is about to be) wiping local user data on its own terms;
@@ -2099,12 +2190,16 @@ async function enforceDeletionsCoverage(
   }
 
   // Re-check the teardown flags after the network await — the probe may have
-  // been in flight across a sign-out or a backgrounding, and neither wants a
-  // multi-table DELETE dispatched at it. The epoch check catches the third
-  // teardown: a board removal (or any beginLocalPurge) that landed while the
-  // probe was on the wire is about to abort this cycle at its first
-  // cycleAborted(), so a wipe here would clear user data with no rebuild behind it.
-  if (isSigningOut() || isBackgrounded() || getWipeEpoch() !== cycleEpoch) return;
+  // been in flight across a sign-out, a global wipe, or a backgrounding, and
+  // none of them wants a multi-table DELETE dispatched at it.
+  //
+  // GLOBAL only (issue #4370). This used to compare a global epoch that a board
+  // removal moved too, with the reasoning "a board removal is about to abort
+  // this cycle at its first cycleAborted(), so a wipe here would clear user data
+  // with no rebuild behind it". A board purge no longer aborts the cycle, so the
+  // rebuild does happen — and a stale-coverage device stops skipping its reset
+  // because somebody removed a board.
+  if (isSigningOut() || isBackgrounded() || hasPurgeLanded(purgeToken)) return;
 
   const pendingMutations = await getPendingCount(db);
   // The STAMP is read fresh — it claims coverage as of the wipe itself, which is
@@ -2154,38 +2249,47 @@ export async function pullSync(
   if (!isOnline()) return;
 
   // Captured ONCE for the whole cycle and threaded into every phase, so a wipe or a
-  // local purge aborts the entire pull rather than just whichever table is mid-flight.
+  // purge aborts exactly the work it can invalidate rather than just whichever table
+  // is mid-flight. The token carries the global epoch AND a copy of every
+  // per-namespace purge epoch, so one capture answers for every scope this cycle
+  // will touch (issue #4370).
   //
-  // This matters because `enabledBoards` is a snapshot taken before the cycle began.
-  // Removing a board (see removeBoardScopeData) drops it from that setting and bumps
-  // the epoch — but this cycle is still iterating the STALE list. If each table
-  // re-baselined its own epoch, every table after the one that aborted would capture
-  // the post-bump value, sail through its guard, and happily re-download the scope
-  // whose rows are being deleted right now, writing checkpoints past them. The user
-  // taps Remove and the catalog comes back.
+  // Capturing once matters because `enabledBoards` is a snapshot taken before the
+  // cycle began. Removing a board (see removeBoardScopeData) drops it from that
+  // setting and bumps that namespace's epoch — but this cycle is still iterating the
+  // STALE list. If each table re-baselined its own token, every table after the one
+  // that aborted would capture the post-bump value, sail through its guard, and
+  // happily re-download the scope whose rows are being deleted right now, writing
+  // checkpoints past them. The user taps Remove and the catalog comes back.
   //
   // Sign-out never hit this because `isSigningOut()` is a persistent flag that stays
   // true for every subsequent table; the epoch alone is not a substitute for it.
   //
   // Captured immediately after the entry guard and BEFORE the coverage phase's
   // awaits: that phase can spend a network probe plus a multi-table wipe, and a
-  // purge landing inside that window must read as "not my epoch" rather than be
+  // purge landing inside that window must read as "not my token" rather than be
   // adopted as this cycle's own baseline.
-  const cycleEpoch = getWipeEpoch();
+  const purgeToken = capturePurgeToken();
+  // GLOBAL: sign-out, a global wipe, backgrounding, or connectivity loss. A board
+  // purge is deliberately absent — it cannot invalidate the user tables, the
+  // deletions cursor, or another board's rows, so it ends that scope's work
+  // (`scopePurged` below) and nothing else.
+  //
   // Unlike the other two checks, isBackgrounded() and isOnline() are live, not latched —
   // a background dip (or a connectivity blip) that clears before the next check runs
   // won't abort a cycle it can no longer affect. Connectivity is checked between phases
   // rather than inside the bootstrap phase deliberately: an artifact that finished
   // downloading must still get imported, and re-downloading 272 MB because NetInfo
   // flapped during the import would be the worse failure.
-  const cycleAborted = (): boolean =>
-    isSigningOut() || getWipeEpoch() !== cycleEpoch || isBackgrounded() || !isOnline();
+  const cycleAborted = (): boolean => isSigningOut() || hasPurgeLanded(purgeToken) || isBackgrounded() || !isOnline();
+  /** Was THIS scope's namespace purged since the cycle started? Then skip it, only it. */
+  const scopePurged = (scope: BoardScope): boolean => hasPurgeLanded(purgeToken, purgeNamespaceKey(scope));
 
   // Phase -1: deletions-coverage guard (issue #3474). Runs BEFORE the bootstrap
   // phase, so the reset and the rebuild that follows belong to the same cycle.
   // See deletions-coverage.ts for the invariant and for exactly what the reset
   // does (and does not) clear.
-  await enforceDeletionsCoverage(db, queryClient, graphqlFetch, cycleEpoch, options);
+  await enforceDeletionsCoverage(db, queryClient, graphqlFetch, purgeToken, options);
   // The phase can spend a probe and a multi-table wipe; the bootstrap phase below
   // starts downloading before the deletions phase's own cycleAborted(), so check
   // here rather than let a teardown that landed during it kick off a download.
@@ -2269,7 +2373,7 @@ export async function pullSync(
       queryClient,
       source: options.snapshotSource,
       scopes: boardScopes,
-      cycleEpoch,
+      purgeToken,
       stampScopeStart,
       emitScopeDownloadStartOnce,
       bootstrapTimings,
@@ -2289,7 +2393,7 @@ export async function pullSync(
   // never fetch it again.
   if (cycleAborted()) return;
   onProgress?.({ phase: 'deletions', currentTable: null, documentsProcessed: 0 });
-  const deletionsResult = await processDeletions(db, queryClient, graphqlFetch, cycleEpoch, (deletionsProcessed) => {
+  const deletionsResult = await processDeletions(db, queryClient, graphqlFetch, purgeToken, (deletionsProcessed) => {
     totalDocuments = deletionsProcessed;
     onProgress?.({ phase: 'deletions', currentTable: null, documentsProcessed: totalDocuments });
   });
@@ -2308,7 +2412,7 @@ export async function pullSync(
       queryClient,
       graphqlFetch,
       tableName,
-      cycleEpoch,
+      purgeToken,
       undefined,
       (tableProcessed) => {
         totalDocuments = baseCount + tableProcessed;
@@ -2324,20 +2428,32 @@ export async function pullSync(
   // from a fraction of the rows reads as "you never climbed that". Mirrors
   // markScopeDownloadComplete for board scopes. Cleared on sign-out for free:
   // the key is `checkpoint:`-prefixed, so deleteUserCheckpoints takes it.
+  //
+  // Guarded, symmetric to the scope-complete block below: the last user table's
+  // in-page check is one await back, so a global wipe landing in that window
+  // would otherwise stamp `user_data_complete` over data that is being deleted.
+  if (cycleAborted()) return;
   if (allUserTablesReachedTail) await markUserDataComplete(db);
 
   // Each enabled board is a "boardType:layoutId:sizeId" scope key (already parsed
   // into boardScopes). currentTable carries the full scope key so a per-board UI
   // can match itself.
   for (const boardScope of boardScopes) {
-    // boardScopes is the pre-cycle snapshot of the enabled set. Once a purge has
-    // fired, every remaining entry is suspect — the scope being deleted right now is
-    // still in this list — so stop the cycle rather than pulling any of them.
+    // boardScopes is the pre-cycle snapshot of the enabled set. A GLOBAL teardown
+    // makes every remaining entry suspect, so it stops the cycle. A per-namespace
+    // purge only invalidates its own scope — the one being deleted right now,
+    // which is still in this stale list — so it skips that scope and lets every
+    // other board finish (issue #4370).
     if (cycleAborted()) return;
+    if (scopePurged(boardScope)) continue;
     const scopeKey = boardScope.scopeKey;
     // No-op when the bootstrap phase already stamped this scope; the paged-only
     // path (no snapshotSource) starts its duration clock here.
     await stampScopeStart(scopeKey);
+    // `scope-download-started:` is a sync_meta write the teardown deletes and no
+    // other path can clear, so a purge landing across that await must not leave
+    // one behind for rows that are gone.
+    if (scopePurged(boardScope)) continue;
     const phases = phaseTimings(scopeKey);
     // Started (issue #4316), the paged half — and the catch-all. Every scope
     // reaches this line on every path: a build with no snapshot source, a scope
@@ -2347,6 +2463,7 @@ export async function pullSync(
     // it keeps its 'snapshot' intent and its artifact size.
     await emitScopeDownloadStartOnce({ scopeKey, pathIntent: 'paged', artifactBytes: null });
     if (cycleAborted()) return;
+    if (scopePurged(boardScope)) continue;
     // A scope whose bootstrap failed this cycle (with attempts still left) skips
     // its paged pull: a first-page checkpoint would permanently disqualify the
     // snapshot path, so the next cycle retries the snapshot instead.
@@ -2354,6 +2471,14 @@ export async function pullSync(
     let allTablesReachedTail = true;
     for (const tableName of BOARD_DATA_TABLES) {
       if (cycleAborted()) return;
+      if (scopePurged(boardScope)) {
+        // Not `continue` on the OUTER loop's terms: clearing the flag is what
+        // stops the completion block below from being reached through this
+        // loop's normal exit. It was never sufficient on its own — see the
+        // guards there.
+        allTablesReachedTail = false;
+        break;
+      }
       const tableLabel = `${tableName}:${scopeKey}`;
       onProgress?.({
         phase: 'board_data',
@@ -2372,7 +2497,7 @@ export async function pullSync(
         queryClient,
         graphqlFetch,
         tableName,
-        cycleEpoch,
+        purgeToken,
         boardScope,
         (tableProcessed) => {
           totalDocuments = baseCount + tableProcessed;
@@ -2408,8 +2533,23 @@ export async function pullSync(
     // (every BOARD_DATA_TABLES entry) have all pulled to the tail may serve
     // searches — a first-page checkpoint would otherwise serve a sliver of the
     // catalog as if it were everything.
+    //
+    // `scope-complete:` is the marker scope-teardown.ts's invariant #1 calls
+    // unrecoverable when it outlives its rows, and this block is the ONLY place
+    // that writes it. The last table's in-page guard (syncTable) is three awaits
+    // back — an upsert, a checkpoint write, and the read below — and
+    // removeBoardScopeData holds an exclusive transaction for seconds, so a purge
+    // landing in that window would queue this write BEHIND the delete. The
+    // table-loop's `allTablesReachedTail = false` never runs after the FINAL
+    // table, so it cannot cover this.
+    if (cycleAborted()) return;
+    if (scopePurged(boardScope)) continue;
     if (allTablesReachedTail) {
       const wasScopeComplete = await isScopeDownloadComplete(db, scopeKey);
+      // Checked again after the read, so the window between the decision and the
+      // write is one statement rather than one await.
+      if (cycleAborted()) return;
+      if (scopePurged(boardScope)) continue;
       // Clears the persisted start stamp as well as writing the complete marker.
       await markScopeDownloadComplete(db, scopeKey);
       if (wasScopeComplete) continue;

--- a/packages/shared/offline-sync/src/sync/scope-teardown.ts
+++ b/packages/shared/offline-sync/src/sync/scope-teardown.ts
@@ -22,10 +22,18 @@
 //    of a layout via compatible_size_ids, so removing "Kilter 12x12" must not gut a
 //    still-downloaded "Kilter 8x12". See orphanClimbsPredicate.
 //
-// The caller is responsible for aborting in-flight pulls before calling this
-// (beginLocalPurge in mutation-queue/drainer.ts) — a page already on the wire would
+// The caller is responsible for aborting this scope's in-flight pull before calling
+// this: `beginScopePurge(purgeNamespaceKey(scope))` in mutation-queue/drainer.ts,
+// with its release called from a `finally`. A page already on the wire would
 // otherwise land after the delete and resurrect part of the catalog, complete with
 // a checkpoint past it.
+//
+// The RELEASE is what covers the delete window, not just the epoch bump: this
+// transaction runs for seconds on a 40k-climb layout, and while it is latched every
+// check for that namespace reads "purged", so no page and no marker write can be
+// dispatched into it. Only THIS namespace is aborted — every other board's download,
+// the mutation drain, the user-data pull and the deletions pull keep running (issue
+// #4370).
 
 import type { OfflineDatabase, SqlExecutor, SqlValue } from '../database';
 import { applyBusyTimeout } from '../db/pragmas';

--- a/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
@@ -19,7 +19,7 @@
 // rows are harmless because reads are scoped.
 
 import type { OfflineDatabase, SqlExecutor } from '../database';
-import type { OfflineBoardScope } from '../offline-board-key';
+import { purgeNamespaceKey, type OfflineBoardScope } from '../offline-board-key';
 import type { SnapshotGradesArtifact, SnapshotManifestEntry, SnapshotTableName } from './snapshot-manifest';
 import { SNAPSHOT_MANIFEST_FORMAT_VERSION } from './snapshot-manifest';
 import { climbsScopeFilter, isSizeScopedBoard } from './board-scope-sql';
@@ -32,7 +32,7 @@ import {
   setCheckpoint,
   type SyncCheckpoint,
 } from './checkpoints';
-import { getWipeEpoch, isSigningOut } from '../mutation-queue/drainer';
+import { capturePurgeToken, hasPurgeLanded, isSigningOut } from '../mutation-queue/drainer';
 import { LATEST_SCHEMA_VERSION } from '../db/migrations';
 import { applyBusyTimeout } from '../db/pragmas';
 import {
@@ -209,7 +209,7 @@ export type SnapshotBootstrapErrorReport = {
   reason: SnapshotBootstrapFailureReason;
   /**
    * True when the phase BAILED rather than failed: a sign-out, a board removal
-   * (any `beginLocalPurge`), or the app backgrounding. Nothing is broken and no
+   * (any purge of its namespace), or the app backgrounding. Nothing is broken and no
    * retry budget was spent — the same scope resumes on the next cycle.
    *
    * These used to emit NOTHING at all, which is why a download that stopped was
@@ -890,9 +890,16 @@ export async function bootstrapScopeFromSnapshot(params: {
   // (or starts AND finishes) across ANY await below — including the ATTACH,
   // quick_check, and snapshot_meta reads — would otherwise resurrect the
   // artifact's rows into a wiped DB and write checkpoints past the next
-  // account's data. Capture the monotonic epoch before the FIRST await so even
-  // a wipe cycle that completes during the integrity checks is caught.
-  const startEpoch = getWipeEpoch();
+  // account's data. Capture the token before the FIRST await so even a wipe
+  // cycle that completes during the integrity checks is caught.
+  //
+  // SCOPED (issue #4370): this transaction writes only rows filtered through
+  // climbsScopeFilter(scope), this scope's two checkpoints, and a deletions
+  // rewind that moves the global cursor BACKWARDS (replaying more tombstones is
+  // always safe under any purge). Only a purge covering this scope's layout can
+  // invalidate any of it.
+  const startToken = capturePurgeToken();
+  const purgeKey = purgeNamespaceKey(scope);
 
   let watermarks: Record<SnapshotTableName, SyncCheckpoint> | null = null;
   let imported = { climbsImported: 0, statsImported: 0 };
@@ -929,7 +936,7 @@ export async function bootstrapScopeFromSnapshot(params: {
           }
         }
 
-        if (isSigningOut() || getWipeEpoch() !== startEpoch) throw new SnapshotWipedError();
+        if (isSigningOut() || hasPurgeLanded(startToken, purgeKey)) throw new SnapshotWipedError();
 
         // The import can take seconds on a big layout; don't let a concurrent
         // write on the app's main connection fail it with SQLITE_BUSY.
@@ -945,7 +952,7 @@ export async function bootstrapScopeFromSnapshot(params: {
 
       // Re-check after the (awaited) imports: abort before committing any rows or
       // checkpoints if a wipe landed while they ran.
-      if (isSigningOut() || getWipeEpoch() !== startEpoch) throw new SnapshotWipedError();
+      if (isSigningOut() || hasPurgeLanded(startToken, purgeKey)) throw new SnapshotWipedError();
 
       await setCheckpoint(txn, getCheckpointKey('board_climbs', scopeKey), watermarks.board_climbs);
       await setCheckpoint(txn, getCheckpointKey('board_climb_stats', scopeKey), watermarks.board_climb_stats);
@@ -1048,7 +1055,11 @@ export async function bootstrapScopeGradesFromSnapshot(params: {
   onSchemaDrift?: SchemaDriftReporter;
 }): Promise<{ gradesWatermark: SyncCheckpoint; rowsImported: number }> {
   const { db, scope, scopeKey, filePath, onSchemaDrift } = params;
-  const startEpoch = getWipeEpoch();
+  // Same scoping argument as bootstrapScopeFromSnapshot: the INSERT is filtered
+  // through gradesScopeFilter(scope) and the only checkpoint stamped is this
+  // scope's grades cursor.
+  const startToken = capturePurgeToken();
+  const purgeKey = purgeNamespaceKey(scope);
 
   let watermark: SyncCheckpoint | null = null;
   let rowsImported = 0;
@@ -1070,7 +1081,7 @@ export async function bootstrapScopeGradesFromSnapshot(params: {
         // change invisible to every pre-change artifact still on the CDN.
         await verifySnapshotMeta(txn, GRADES_ALIAS, GRADES_SNAPSHOT_TABLES);
 
-        if (isSigningOut() || getWipeEpoch() !== startEpoch) throw new SnapshotWipedError();
+        if (isSigningOut() || hasPurgeLanded(startToken, purgeKey)) throw new SnapshotWipedError();
 
         await applyBusyTimeout(txn);
         await txn.execAsync('BEGIN EXCLUSIVE');
@@ -1118,7 +1129,7 @@ export async function bootstrapScopeGradesFromSnapshot(params: {
         ? { updatedAt: String(watermarkRow.cursor_at), syncSeq: String(watermarkRow.sync_seq) }
         : EPOCH_WATERMARK;
 
-      if (isSigningOut() || getWipeEpoch() !== startEpoch) throw new SnapshotWipedError();
+      if (isSigningOut() || hasPurgeLanded(startToken, purgeKey)) throw new SnapshotWipedError();
 
       await setCheckpoint(txn, getCheckpointKey(GRADES_TABLE, scopeKey), watermark);
     });

--- a/packages/shared/offline-sync/src/sync/sync-scheduler.ts
+++ b/packages/shared/offline-sync/src/sync/sync-scheduler.ts
@@ -93,6 +93,18 @@ export type SchedulerOptions = {
 let isSyncing = false;
 let pendingTrigger = false;
 
+/**
+ * Is a drain+pull cycle running right now? The scheduler's single-flight latch,
+ * exposed so a caller can decide whether an exclusive-lock operation is safe to
+ * start. `compactOfflineDatabase` is the one consumer: VACUUM holds an exclusive
+ * lock for 5-20s on a 200-400MB database, which a concurrent snapshot import
+ * would meet as SQLITE_BUSY and charge itself a structural failure for (issue
+ * #4370).
+ */
+export function isSyncInFlight(): boolean {
+  return isSyncing;
+}
+
 export function __resetSyncSchedulerStateForTests(): void {
   isSyncing = false;
   pendingTrigger = false;


### PR DESCRIPTION
## Summary

Closes #4370. Part of the offline-mode epic #4319.

`beginLocalPurge()` bumped **one global epoch** that every long-running offline-sync operation compared against. Removing any board from Storage therefore aborted every *other* board's in-flight download, plus the mutation-queue drain, the user-data pull and the deletions pull. A climber clearing out a wall they were done with lost every download that was running.

The epoch splits in two:

- **`beginGlobalPurge()`** — sign-out, the owner-stamp mismatch wipe, the manual Compact button. Still stops everything.
- **`beginScopePurge(namespace)`** — one board removal, keyed on `boardType:layoutId`.

`boardType:layoutId` is the namespace for two independent reasons. It is exactly `removeBoardScopeData`'s DELETE predicate (`board_type = ? AND layout_id = ?` plus an optional retained-sizes negation), so it is provably a superset of what a purge can touch without the argument depending on the `compatible_size_ids` retention clause holding for every future column. And `runBootstrapPhase` already caches both snapshot artifacts under that identical string, because one artifact serves every size of a layout — so a finer namespace would be finer than the native transfer it is trying to cancel. Both ad-hoc `` `${scope.boardType}:${scope.layoutId}` `` template literals are replaced with `purgeNamespaceKey(scope)` so the two keys cannot drift.

Long-running work captures a `PurgeToken` **once** at cycle start (`capturePurgeToken()` copies the global epoch plus the whole namespace map) and asks `hasPurgeLanded(token, namespace?)` across its awaits. Capturing once is load-bearing: `enabledBoards` is a snapshot taken before the cycle began, so the scope being removed right now is still in the list the cycle is iterating — if each table re-baselined, every table after the aborted one would sail through and re-download the scope whose rows are being deleted.

`beginScopePurge` also returns a **latch release**, called from a `finally` in `removeOfflineBoard`. `removeBoardScopeData` holds an exclusive transaction for seconds on a 40k-climb layout; while it is latched, every check for that namespace reads "purged", so no page and no marker write can be dispatched into the delete window.

### The data-integrity hole this also closes

The block that writes `scope-complete:` ran after the board-table loop with **no teardown check at all** — the loop-top `allTablesReachedTail = false` only executes on a loop-top break, which never runs after the *final* table. So a purge landing during the last table's final awaits (the upsert, the checkpoint write, the `isScopeDownloadComplete` read) could queue the marker write *behind* the delete and commit after it. `scope-teardown.ts` calls rows-gone-markers-alive "unrecoverable short of a reinstall": the board reads "Available offline" and search returns nothing. It would also emit a spurious `Offline Board Download Completed` for the removed scope, and on re-add the surviving marker makes `emitScopeDownloadStartOnce`'s backfill guard suppress the new Started — a Completed with no Started.

Guarded immediately before the block and again between the read and the write, plus the symmetric global-only gap at `markUserDataComplete`. Two tests fail against `main` on both.

### VACUUM: a hazard the fix itself creates

Today the removal's global bump guarantees every in-flight import has already thrown a free `SnapshotWipedError` before `compactOfflineDatabase` runs, so contention is impossible by construction. Once a removal spares the other boards, an import that meets VACUUM's 5-20s exclusive lock raises SQLITE_BUSY past the 5s busy timeout — and `bootstrap-retry.ts` classifies *every* import-stage failure as `structural-artifact`. Two of those and the scope is stranded on the paged crawl, the #4313 failure mode, self-inflicted.

Two surfaces, two answers. The automatic post-removal compaction **defers** while a pull is in flight (returns `'deferred'`, silent; the existing reclaimable banner offers the manual retry). The deliberate, spinner-backed Compact button bumps the global epoch first, exactly as `db/vacuum.ts` has always required — an abort there is `aborted: true, expected: true, attempt: 0` and resumes from checkpoints next cycle.

### Behaviour changes nobody asked for but everybody wants

- The **mutation-queue drain** is no longer aborted by a board removal. `beginLocalPurge`'s own doc block already wished for this ("the user's unsynced ticks have nothing to do with a board catalog").
- The **deletions-coverage reset** is no longer cancelled by a board removal landing while its probe is on the wire. A stale-coverage device used to skip its reset because somebody removed a board.
- `download-funnel-guard`'s `teardownReason` now takes the armed `scopeKey`. An unexplained exit that merely coincides with *another* board's removal is no longer laundered as `aborted-wipe` — it still reaches Sentry as `unknown-exit`. Expect a small, real rise in that reason; it is a truth improvement.

### Correction to the issue's narrative

#4370 says "toggling any board off aborts the in-flight download of every other scope". There are only two non-test callers of the purge: `remove-offline-board.ts` and `offline-sync-bridge.tsx`. The **My Boards toggle-off does not purge** — it drops the setting entry only. So the reported "8 toggles in 45s" ran through Storage → Remove (or remove/re-add cycles), not the My Boards switch. The fix is unchanged; the telemetry read below distinguishes them by `Offline Board Toggled {source}`.

## Release Notes

- Clearing one board out of storage no longer stops your other boards downloading — remove a wall you're done with and the rest keep coming down.

## Decisions for Marco

Three plan decisions were flagged for your audit. All were taken on delegated authority; each is reversible.

1. **VACUUM split (the product call).** Post-removal compaction now *defers* while a pull is in flight, so your storage figure may not drop all the way immediately — the existing "reclaim space" banner appears and the manual Compact button finishes the job. Tapping Compact yourself *does* pause in-flight downloads for a cycle (they resume from checkpoints, nothing is lost, no retry budget burned). The alternative — bumping globally in the automatic path — would re-create #4370 once per Remove tap. Doing nothing is **not** the status quo: it strands boards on the paged crawl.
2. **Paged-crawl funnel gap: follow-up issue, not this PR.** Removing a board mid-*paged* download leaves an `Offline Board Download Started` with no terminal event. That gap is pre-existing and sits on the exact same line before and after this change (today's `return` and the new `continue` both exit after Started), so this PR does not widen it. Closing it needs a durable "download abandoned" emitter in `removeOfflineBoard` that de-dups against `runBootstrapPhase`'s own abort report — its own design, and folding it in would make a data-integrity PR also a telemetry-semantics PR. Filed as a follow-up in the #4319 orbit.
3. **No new `SnapshotBootstrapFailureReason`.** Kept the `aborted-wipe` union as-is rather than adding a value to tell "my own board was removed" from "a sibling size" from "sign-out". Reason values are permanent analytics vocabulary and existing PostHog filters enumerate them; adding one would fragment the historical series exactly where the before/after comparison is read. Both `Offline Board Download Failed` and `Offline Board Toggled` already carry `scopeKey`, so a session-level join answers the same question.

## Test plan

No events added, renamed or removed; no `SHARED_EVENTS` entry touched; no new i18n strings (`'deferred'` is silent and reuses no toast); JS/TS only, so the runtimeVersion fingerprint is unchanged and this ships as a normal OTA.

**Automated** (all run in the worktree, foreground):

- `vp run typecheck:mobile` — Done in 4.80s, clean.
- `vp run test:mobile` — 645 files, **5895 tests passed**.
- `vp test run --project offline-sync` — 30 files, **642 tests passed**.
- `vp run check:mobile-bundle` — `android bundle: OK`.
- `vp check` — clean on every file this PR touches (the two `docs/design/web-reposition/*.html` formatting hits are pre-existing drift on `main`, untouched here).

**Every new test was verified to fail without the change**, not just to pass with it:

- Temporarily making `beginScopePurge` bump the global epoch (the pre-#4370 behaviour) fails 5 scoping tests: the unrelated scope's download, the purged scope's own discard, the sibling-size case, the user-data phase, and the deletions phase.
- Temporarily removing the three new guards fails exactly the three race tests (`scope-complete` after the last table, `scope-complete` between read and write, `user_data_complete` after a global purge).

New/extended coverage: a new `purge-epoch.test.ts` for the registry and the refcounted latch (13 tests); the headline two-scope races and the completion-marker races in `scope-teardown.integration.test.ts`; two-layout snapshot-bootstrap scoping including the funnel invariant under `break` → `continue` and an `isBackgrounded()` term-count regression guard; scoped `teardownReason` in `download-funnel-guard.test.ts`; the coverage-reset test split into a global half (still cancels) and a board half (now resets); and the mobile `beginScopePurge`/latch-release/compaction-outcome tests.

**Device QA still owed** (a test double proves the JS decision, not that the native transfer for the untouched board keeps running). Run on iOS and Android:

1. Two boards on different layouts downloading; remove one from Storage. The other's progress keeps advancing within 5s and completes. Before the fix it dies silently and restarts on the next foreground.
2. Remove a board while *its own* artifact is mid-transfer — the transfer must still stop within a second or two. This is the half that must not regress.
3. The completion-marker race, worth 3-5 repeats: let a board reach the end of its paged crawl (progress caption on `board_climb_grades`, page counter near the tail) then remove it in the last few seconds. It must stay gone after a force-quit; no `Offline Board Download Completed` for that scopeKey; re-adding emits a fresh Started.
4. Two *sizes* of one layout, both mid-download, remove one: the sibling stops this cycle then resumes next foreground with no lost checkpoint progress. Deliberate over-abort — do not assert a byte-level artifact resume (that is #4390).
5. Toggle storm: 3+ boards downloading, 8 remove/re-add cycles in ~45s. No board other than the one removed loses progress.
6. Sign out mid-download — everything stops, database shrinks, nothing resumes.
7. Owner-stamp wipe (two accounts) — in-flight pulls stop, user B's data rebuilds.
8. Background 30s mid-download — funnel reports `aborted-background`, not `aborted-wipe`. This proves `teardownVerdict`'s ordering survived.
9. Remove-all while another board downloads — the survivor's download lives; the storage figure may not drop all the way and the Compact button appears. No "couldn't reclaim space" toast for the deferred case.
10. Tap Compact mid-download — spinner completes, figure drops, download resumes next foreground; PostHog shows `aborted: true, expected: true, attempt: 0`. `Offline Board Download Retry Scheduled` with rising `structuralFailures` means the global bump is missing and VACUUM raced the import.

**How success is read from fleet data** (two weeks post-OTA): on `Offline Board Download Failed` filtered to `reason = 'aborted-wipe'`, session-join each `scopeKey` against the same session's `Offline Board Toggled {enabled: false}`. Before, a large share name a scopeKey that was never toggled off — the #4370 signature. After, that share should be ~0, with only the removed scope, a same-layout sibling, sign-out sessions, and manual-Compact sessions surviving. Guardrails: zero `Offline Board Download Completed` for a scope removed earlier in the same session; flat `structuralFailures` (a rise concentrated in Remove/Compact sessions means the VACUUM wiring is wrong); `Offline Outbox Backlog` trending flat-to-down.
