### PR TITLE
feat(mobile): choose the board download transport by flag and measure every transfer (2/2)

### DIFF
--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -523,6 +523,84 @@ pre-import empty result set.
   follows the same rule: `importGradesForScope` checks the teardown reason before spending one of the
   three attempts that artifact ever gets.
 
+- **Download transport (issues #4394 / #4390)**. Which expo-file-system API moves the bytes is chosen by
+  `resolveSnapshotDownloadStrategy` (`packages/mobile/src/offline/download-strategy.ts`) from two PostHog
+  booleans plus `Platform.OS`:
+
+  | `offline-download-task-api` | `offline-download-background-session` | iOS                   | Android               |
+  | --------------------------- | ------------------------------------- | --------------------- | --------------------- |
+  | unset or `false`            | anything                              | `download-file-async` | `download-file-async` |
+  | `true`                      | unset or `true`                       | `task-background`     | `task-foreground`     |
+  | `true`                      | `false`                               | `task-foreground`     | `task-foreground`     |
+
+  **The unresolved default is today's shipped path on BOTH platforms, on purpose.** Production OTAs
+  auto-publish on every push to `main`, and a PostHog key that does not exist yet reads `undefined` on
+  every device — so an "undefined → background session" default would flip the whole iOS fleet the hour
+  it merged. The downside is not symmetric: a background `URLSession` runs out of `nsurlsessiond`, a
+  different process from the in-process default-config sessions the gzip cutover was validated against,
+  and if it does not transparently gunzip, `snapshot-source` raises `SnapshotPermanentMissError`, which
+  at the download stage burns the structural budget **and** marks the paged fallback — a durable settle
+  that flipping the flag back does not undo. Roll out by SETTING the flag (10% → 50% → 100%, watching
+  `sizeMismatch`, `reason: 'permanent-miss'` and `wireKbps`), never by merging.
+
+  The strategy lives in **module state**, set by an effect in `use-snapshot-source.ts`, because
+  `mobileSnapshotSource`'s object identity is a dependency of the scheduler effect in
+  `offline-sync-bridge.tsx` — a factory would restart the sync scheduler mid-download the moment a flag
+  resolved. It is latched at the start of each transfer so a flag resolving mid-download cannot mislabel
+  the measurement.
+
+  Both platforms are real arms, not relabels: Android ignores `sessionType` but a `DownloadTask` builds
+  its **own** `OkHttpClient` (60 s connect/read/write timeouts), and on iOS the task sessions use
+  `delegateQueue: .main` where the legacy `downloadFileAsync` store uses `nil` — which makes
+  `task-foreground` double as a main-thread-contention probe at zero native cost.
+
+- **Why continuation and not persisted pause/resume.** Measured against the live CDN object on
+  2026-08-13: `Content-Encoding: gzip` comes back **unconditionally** (even under
+  `Accept-Encoding: identity` — it is stored-object metadata, not negotiated), `Accept-Ranges: bytes`,
+  strong ETag, and `Range: bytes=0-15` returns `206` with `Content-Range: bytes 0-15/102416919` and a
+  body starting `1f 8b` — so **Range addresses ENCODED bytes**. Both platforms write **decoded** bytes to
+  disk. expo's Android resume computes its offset as the destination file's length
+  (`FileSystemDownloadTask.kt:92`) and sends `Range: bytes=<decoded>-` (line 112): provably wrong for
+  every gzip artifact we publish, off by 2.6× on kilter:1, with no JS-side fix. **Never enable Android
+  resume** until the artifacts are served identity-encoded or expo's offset moves to encoded byte space.
+  iOS `resumeData` validity over a `Content-Encoding` response cannot be established off-device and is
+  treated as unproven. Background-session continuation needs no byte-space reasoning at all.
+
+  Residual gap, stated honestly: if iOS **terminates** the app (force-quit or a memory-pressure kill),
+  expo's dispatcher has no delegate on relaunch and the finished temp file is dropped — that download is
+  lost and the next foreground restarts at 0. A merely _suspended_ app keeps its delegate and resolves
+  on resume, which is the common case.
+
+- **Exact decoded-size gate (#4394)**. Before the `.complete` sidecar is written, the finished file's
+  size is compared against `entry.uncompressedBytes` — exact, because the export writes
+  `rawBuffer.length`, the SQLite file's own byte length. A mismatch deletes the file, reports a handled
+  error, and throws `SnapshotArtifactTruncatedError` → funnel reason `artifact-truncated`, charged to the
+  **transport** budget (a short body is a cut-short response; `structural-device` would durably settle a
+  scope onto the paged crawl after two occurrences). It runs **after** the gzip sniff, so a
+  still-compressed body keeps reporting `permanent-miss`. Absent `uncompressedBytes` — every gzip grades
+  block and every pre-#4311 layout entry — the gate is skipped; an `identity` entry gates on
+  `entry.bytes`, which there IS the decoded size. A retained artifact's size is re-verified before its
+  sidecar is trusted, so a survivor the OS truncated is re-downloaded rather than ATTACHed.
+
+- **Superseded-partial sweep**: artifacts for an older `builtAt` of the same (board, layout) are deleted
+  at the **top** of `downloadSnapshotFile`, before the free-space precheck, as well as after a successful
+  download. A 271 MB stale partial used to sit in the cache until the next download succeeded — which it
+  might not, because that partial counted against the precheck the new download had to pass.
+
+- **Per-transfer telemetry**: every transfer that moved bytes emits `Offline Artifact Transfer` with
+  `strategy`, `wireBytes`, `wallMs`, `firstByteMs`, `wireKbps`, `backgroundedDuringTransfer` and friends
+  (full prop contract in `packages/shared/analytics/src/events.ts`). A reused artifact emits nothing, so
+  the denominator is always real network work. Read `wireKbps` only where
+  `backgroundedDuringTransfer = false`: a suspended transfer's `wallMs` includes wall-clock time nobody
+  was downloading.
+
+- **Not on `main`, ever** — these need a native fingerprint change and belong on a `[native-train]` draft:
+  the `URLSessionConfiguration` knobs behind #4394's Low Data Mode hypothesis
+  (`allowsConstrainedNetworkAccess`, `allowsExpensiveNetworkAccess`, `waitsForConnectivity`,
+  `networkServiceType`, `delegateQueue`), restoring background-session delegates on relaunch, and
+  surfacing `X-Tigris-*` response headers from a download task. All of them live in expo-file-system's
+  Swift, reachable only via a bun patch or an upstream PR.
+
 - **Download fallback status**: My Boards keeps the normal per-row download state (`pending`,
   `downloading`, or `downloaded`) and separately derives a `BoardDownloadNotice` from the persisted
   attempt, done, and explicit paged-fallback markers plus board checkpoints. The explicit outcome closes
@@ -751,6 +829,13 @@ manifest) and the export re-bases entry URLs onto it. Keep it consistent with
   block, so publishing a manifest without one — or rolling the fleet back to the identity `board-snapshots/v1`
   prefix, which never publishes grades — reverts every client to the paged grades crawl with no deploy. It
   is a slower download, not a broken one.
+- **Download transport** (issue #4394): `offline-download-task-api` off (or deleted — unset reads as off)
+  puts every device back on today's `File.downloadFileAsync`, and
+  `offline-download-background-session` off pins an iOS task to a foreground session without leaving the
+  DownloadTask arm. Both default OFF, so a merge changes nobody's transport; the rollback signal to watch
+  is a spike in the `snapshot artifact arrived still gzip-compressed` Sentry handled error or in
+  `reason: 'permanent-miss'`, because a background session runs out of `nsurlsessiond` rather than
+  in-process.
 - **Nuclear, affects every client regardless of flag state after cache expiry**: delete the
   `board-snapshots/v1-gzip/manifest.json` object from the bucket — that's the prefix the fleet reads;
   deleting `board-snapshots/v1/manifest.json` stops nothing. The manifest is cached for up to 5 minutes

--- a/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
+++ b/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
@@ -48,8 +48,10 @@ vi.mock('../../offline/offline-sync-adapter', () => ({
 // expo-file-system-backed implementation). vi.hoisted because vi.mock
 // factories are hoisted above regular top-level const declarations.
 const mobileSnapshotSourceStub = vi.hoisted(() => ({ tag: 'snapshot-source' }));
+const setSnapshotDownloadStrategyFromFlagsMock = vi.hoisted(() => vi.fn());
 vi.mock('../../offline/snapshot-source', () => ({
   mobileSnapshotSource: mobileSnapshotSourceStub,
+  setSnapshotDownloadStrategyFromFlags: (flags: unknown) => setSnapshotDownloadStrategyFromFlagsMock(flags),
 }));
 
 const getPendingCountMock = vi.fn(async (..._args: unknown[]) => 0);
@@ -315,6 +317,25 @@ describe('OfflineSyncBridge — flag ON', () => {
   it('passes the mobile snapshot source when offline-snapshot-bootstrap is also on', async () => {
     render(<Harness flags={FLAG_ON_WITH_SNAPSHOT} queryClient={makeQueryClient()} />);
     await waitFor(() => expect(startSyncSchedulerMock).toHaveBeenCalledTimes(1));
+    expect(getStartSyncSchedulerSnapshotSource()).toBe(mobileSnapshotSourceStub);
+  });
+
+  it('pushes the resolved transport flags into the source WITHOUT churning its identity', async () => {
+    // Issue #4394. The source's object identity is a dependency of the
+    // scheduler effect, so a flag resolving mid-download must not rebuild it —
+    // which is exactly why the strategy rides module state instead of the memo.
+    render(
+      <Harness
+        flags={{ ...FLAG_ON_WITH_SNAPSHOT, 'offline-download-task-api': true }}
+        queryClient={makeQueryClient()}
+      />,
+    );
+    await waitFor(() => expect(startSyncSchedulerMock).toHaveBeenCalledTimes(1));
+
+    expect(setSnapshotDownloadStrategyFromFlagsMock).toHaveBeenCalledWith({
+      taskApiFlag: true,
+      backgroundSessionFlag: undefined,
+    });
     expect(getStartSyncSchedulerSnapshotSource()).toBe(mobileSnapshotSourceStub);
   });
 

--- a/packages/mobile/src/lib/sweep-caches.ts
+++ b/packages/mobile/src/lib/sweep-caches.ts
@@ -44,7 +44,7 @@ import {
   resetOverlayWriteOdometer,
 } from './overlay-index';
 import { track } from './analytics';
-import { SNAPSHOT_DIR_NAME } from '../offline/snapshot-source';
+import { SNAPSHOT_DIR_NAME } from '../offline/snapshot-paths';
 
 /** Must match the directory the native BoardRenderer modules write PNGs into. */
 export const OVERLAY_CACHE_DIR_NAME = 'board-thumbnails';

--- a/packages/mobile/src/offline/__tests__/download-strategy.test.ts
+++ b/packages/mobile/src/offline/__tests__/download-strategy.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { resolveSnapshotDownloadStrategy } from '../download-strategy';
+
+const resolve = (
+  taskApiFlag: boolean | undefined,
+  backgroundSessionFlag: boolean | undefined,
+  platform: string,
+): string => resolveSnapshotDownloadStrategy({ taskApiFlag, backgroundSessionFlag, platform });
+
+describe('resolveSnapshotDownloadStrategy', () => {
+  it('resolves an UNSET task-api flag to the shipped path on both platforms, whatever the other flag says', () => {
+    // The corner that matters most: the flag key does not exist in PostHog on
+    // OTA day, so `undefined` is what every device reads. It must never reach a
+    // transport nobody has run on a real phone.
+    for (const backgroundSessionFlag of [undefined, true, false]) {
+      expect(resolve(undefined, backgroundSessionFlag, 'ios')).toBe('download-file-async');
+      expect(resolve(undefined, backgroundSessionFlag, 'android')).toBe('download-file-async');
+    }
+  });
+
+  it('resolves an explicitly-off task-api flag to the shipped path everywhere', () => {
+    for (const backgroundSessionFlag of [undefined, true, false]) {
+      expect(resolve(false, backgroundSessionFlag, 'ios')).toBe('download-file-async');
+      expect(resolve(false, backgroundSessionFlag, 'android')).toBe('download-file-async');
+    }
+  });
+
+  it('gives iOS a background URLSession when the task API is on and the session flag is not explicitly off', () => {
+    expect(resolve(true, undefined, 'ios')).toBe('task-background');
+    expect(resolve(true, true, 'ios')).toBe('task-background');
+  });
+
+  it('pins iOS to a foreground session when the background-session flag is explicitly off', () => {
+    expect(resolve(true, false, 'ios')).toBe('task-foreground');
+  });
+
+  it('never reports a background session on Android — the native side ignores sessionType', () => {
+    for (const backgroundSessionFlag of [undefined, true, false]) {
+      expect(resolve(true, backgroundSessionFlag, 'android')).toBe('task-foreground');
+    }
+  });
+
+  it('never yields task-background for an unknown platform string', () => {
+    for (const backgroundSessionFlag of [undefined, true, false]) {
+      expect(resolve(true, backgroundSessionFlag, 'web')).toBe('task-foreground');
+      expect(resolve(true, backgroundSessionFlag, 'windows')).toBe('task-foreground');
+    }
+  });
+});

--- a/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
+++ b/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
@@ -255,6 +255,7 @@ import {
   __resetSnapshotDownloadStrategyForTests,
 } from '../snapshot-source';
 import {
+  setBackgrounded,
   SnapshotArtifactTruncatedError,
   SnapshotPermanentMissError,
   type SnapshotManifestEntry,
@@ -743,6 +744,20 @@ describe('superseded-partial sweep', () => {
     expect(state.files.has(`${stalePartial}.complete`)).toBe(false);
   });
 
+  it('sweeps the stale build even when the free-space precheck then refuses — the ordering is the point', async () => {
+    // The fake's availableDiskSpace is static, so the precheck still refuses
+    // here — but the stale bytes are already gone, which on a real device is
+    // exactly what lets the retry pass. Sweep BEFORE precheck is the invariant.
+    const stalePartial = 'file://cache-root/board-snapshots/kilter-8-2026-05-01T00-00-00-000Z.db';
+    seedRetainedArtifact(stalePartial, '2026-05-01T00:00:00.000Z', 271_000_000);
+    state.availableDiskSpace = 1;
+
+    await expect(mobileSnapshotSource.downloadArtifact(ENTRY)).rejects.toThrow(/insufficient disk space/);
+
+    expect(state.files.has(stalePartial)).toBe(false);
+    expect(state.files.has(`${stalePartial}.complete`)).toBe(false);
+  });
+
   it('leaves a DIFFERENT layout alone — the sweep is per (board, layout)', async () => {
     const otherLayout = 'file://cache-root/board-snapshots/kilter-9-2026-05-01T00-00-00-000Z.db';
     seedRetainedArtifact(otherLayout, '2026-05-01T00:00:00.000Z');
@@ -796,6 +811,27 @@ describe('Offline Artifact Transfer telemetry', () => {
     });
     expect(typeof report.wallMs).toBe('number');
     expect(typeof report.firstByteMs).toBe('number');
+  });
+
+  it('latches backgroundedDuringTransfer through the real teardown wiring, per transfer not per process', async () => {
+    // The app pockets mid-transfer: the source's own onTeardown subscription
+    // (not a second AppState listener) must record it on THIS transfer's event —
+    // and the next transfer, run in the foreground, must not inherit the latch.
+    state.downloadProgressFrames = [{ bytesWritten: 1_000, totalBytes: -1 }];
+    try {
+      await mobileSnapshotSource.downloadArtifact(ENTRY, { onProgress: () => setBackgrounded(true) });
+    } finally {
+      setBackgrounded(false);
+    }
+
+    expect(reportArtifactTransfer).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: 'completed', backgroundedDuringTransfer: true }),
+    );
+
+    reportArtifactTransfer.mockClear();
+    await mobileSnapshotSource.downloadArtifact({ ...ENTRY, builtAt: '2026-06-02T00:00:00.000Z' });
+
+    expect(reportArtifactTransfer).toHaveBeenCalledWith(expect.objectContaining({ backgroundedDuringTransfer: false }));
   });
 
   it('omits firstByteMs when no progress callback ever fired', async () => {

--- a/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
+++ b/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
@@ -14,6 +14,19 @@ const state = vi.hoisted(() => ({
   }>,
   createDirectoryError: null as Error | null,
   downloadCalls: [] as Array<{ url: string; idempotent?: boolean; hasOnProgress: boolean; hasSignal: boolean }>,
+  // The DownloadTask arm (issue #4394): which sessionType each call asked for,
+  // how many native handles were released, and whether the task resolves the
+  // `null` expo returns for a PAUSED transfer (which we never request).
+  taskCalls: [] as Array<{
+    url: string;
+    sessionType?: 'background' | 'foreground';
+    hasOnProgress: boolean;
+    hasSignal: boolean;
+  }>,
+  taskReleases: 0,
+  taskResolvesNull: false,
+  /** Overrides the finished file's on-disk size, for the exact decoded-size gate. */
+  downloadedFileSize: null as number | null,
   // Byte frames the fake downloader replays into the injected onProgress, in
   // whatever scale a real platform would report (Android: decoded bytes,
   // totalBytes -1).
@@ -96,11 +109,38 @@ vi.mock('expo-file-system', () => {
           hasOnProgress: options?.onProgress !== undefined,
           hasSignal: options?.signal !== undefined,
         });
-        for (const frame of state.downloadProgressFrames) options?.onProgress?.(frame);
-        if (options?.signal?.aborted) throw new Error('AbortError: download cancelled');
-        if (state.downloadError) throw state.downloadError;
-        writeFakeFile(destination.uri, { bytes: state.downloadBytes, text: null });
-        return destination;
+        return runFakeTransfer(destination, options);
+      },
+    );
+
+    // The DownloadTask arm (issue #4394). Same byte-writing behaviour as
+    // downloadFileAsync so every existing assertion holds under either
+    // strategy; what differs is what the transport records.
+    static createDownloadTask = vi.fn(
+      (
+        url: string,
+        destination: FakeFile,
+        options?: {
+          sessionType?: 'background' | 'foreground';
+          onProgress?: (data: { bytesWritten: number; totalBytes: number }) => void;
+          signal?: AbortSignal;
+        },
+      ) => {
+        state.taskCalls.push({
+          url,
+          sessionType: options?.sessionType,
+          hasOnProgress: options?.onProgress !== undefined,
+          hasSignal: options?.signal !== undefined,
+        });
+        return {
+          downloadAsync: async () => {
+            const file = await runFakeTransfer(destination, options);
+            return state.taskResolvesNull ? null : file;
+          },
+          release: () => {
+            state.taskReleases += 1;
+          },
+        };
       },
     );
 
@@ -149,6 +189,28 @@ vi.mock('expo-file-system', () => {
     });
   }
 
+  /** The shared body of both transport fakes: frames, abort, error, then bytes. */
+  async function runFakeTransfer(
+    destination: FakeFile,
+    options?: {
+      onProgress?: (data: { bytesWritten: number; totalBytes: number }) => void;
+      signal?: AbortSignal;
+    },
+  ): Promise<FakeFile> {
+    for (const frame of state.downloadProgressFrames) options?.onProgress?.(frame);
+    if (options?.signal?.aborted) throw new Error('AbortError: download cancelled');
+    if (state.downloadError) throw state.downloadError;
+    writeFakeFile(destination.uri, { bytes: state.downloadBytes, text: null });
+    // The decoded on-disk size the exact-size gate reads. Decoupled from the
+    // sniffed bytes so a test can simulate a 269 MB artifact without allocating
+    // one — or a short body, which is the gate's whole point.
+    if (state.downloadedFileSize !== null) {
+      const entry = state.files.get(destination.uri);
+      if (entry) state.files.set(destination.uri, { ...entry, size: state.downloadedFileSize });
+    }
+    return destination;
+  }
+
   return {
     Directory: FakeDirectory,
     File: FakeFile,
@@ -167,13 +229,36 @@ vi.mock('../../lib/env', () => ({
   SNAPSHOT_BASE_URL: 'https://example.test/board-snapshots/v1',
 }));
 
+// The strategy resolver reads Platform.OS. RN's real entry is Flow source that
+// Rolldown's scan cannot parse, so it is stubbed here the way
+// offline-sync-adapter.test.ts does.
+vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }));
+
 const reportHandledError = vi.fn();
 vi.mock('../../lib/error-reporting', () => ({
   reportHandledError: (...args: unknown[]) => reportHandledError(...args),
 }));
 
-import { mobileSnapshotSource } from '../snapshot-source';
-import { SnapshotPermanentMissError, type SnapshotManifestEntry } from '@boardsesh/offline-sync';
+// Mocked wholesale: the real module reaches offline-sync-adapter for the cached
+// NetInfo verdict, which drags NetInfo and the whole scheduler into this graph.
+const reportArtifactTransfer = vi.fn();
+vi.mock('../artifact-transfer-telemetry', () => ({
+  reportArtifactTransfer: (...args: unknown[]) => reportArtifactTransfer(...args),
+}));
+
+// The FAKE File class the vi.mock above installs — imported so the strategy
+// tests can read the exact options object each transport was handed.
+import { File } from 'expo-file-system';
+import {
+  mobileSnapshotSource,
+  setSnapshotDownloadStrategyFromFlags,
+  __resetSnapshotDownloadStrategyForTests,
+} from '../snapshot-source';
+import {
+  SnapshotArtifactTruncatedError,
+  SnapshotPermanentMissError,
+  type SnapshotManifestEntry,
+} from '@boardsesh/offline-sync';
 
 const ENTRY: SnapshotManifestEntry = {
   boardType: 'kilter',
@@ -220,6 +305,11 @@ beforeEach(() => {
   state.readError = null;
   state.deletedUris = [];
   state.files.clear();
+  state.taskCalls = [];
+  state.taskReleases = 0;
+  state.taskResolvesNull = false;
+  state.downloadedFileSize = null;
+  __resetSnapshotDownloadStrategyForTests();
 });
 
 const ARTIFACT_URI = 'file://cache-root/board-snapshots/kilter-8-2026-06-01T00-00-00-000Z.db';
@@ -299,6 +389,8 @@ describe('downloadArtifact', () => {
 
   it('allows identity artifacts with the lower identity safety multiple', async () => {
     state.availableDiskSpace = ENTRY.bytes * 3;
+    // An identity entry's `bytes` IS the decoded size, so it also gates on it.
+    state.downloadedFileSize = ENTRY.bytes;
     const identityEntry: SnapshotManifestEntry = { ...ENTRY, contentEncoding: 'identity' };
 
     const result = await mobileSnapshotSource.downloadArtifact(identityEntry);
@@ -353,6 +445,7 @@ describe('downloadArtifact', () => {
     // figure is 3 MB decoded + 1 MB wire + 32 MB slack.
     const withDecodedSize: SnapshotManifestEntry = { ...ENTRY, uncompressedBytes: 3_000_000 };
     const exactRequirement = 3_000_000 + ENTRY.bytes + 32 * 1024 * 1024;
+    state.downloadedFileSize = 3_000_000;
 
     state.availableDiskSpace = exactRequirement - 1;
     await expect(mobileSnapshotSource.downloadArtifact(withDecodedSize)).rejects.toThrow(/insufficient disk space/);
@@ -372,7 +465,7 @@ describe('downloadArtifact', () => {
   it('throws a descriptive error wrapping the underlying cause when the download itself fails (issue #4106: this used to swallow to null)', async () => {
     state.downloadError = new Error('boom');
 
-    await expect(mobileSnapshotSource.downloadArtifact(ENTRY)).rejects.toThrow(/downloadFileAsync failed.*boom/);
+    await expect(mobileSnapshotSource.downloadArtifact(ENTRY)).rejects.toThrow(/transfer failed.*boom/);
   });
 
   it('keeps the original download exception as `cause` so the transport classifier can see it (issue #4238)', async () => {
@@ -462,12 +555,317 @@ describe('downloadArtifact', () => {
 
   it('skips the gzip-magic check entirely for an identity-encoded entry', async () => {
     state.downloadBytes = GZIP_BYTES; // would fail the check if it ran
+    state.downloadedFileSize = ENTRY.bytes;
     const identityEntry: SnapshotManifestEntry = { ...ENTRY, contentEncoding: 'identity' };
 
     const result = await mobileSnapshotSource.downloadArtifact(identityEntry);
 
     expect(result).not.toBeNull();
     expect(state.deletedUris).toHaveLength(0);
+  });
+});
+
+// Which expo API moves the bytes (issue #4394). The default is deliberately
+// today's shipped call on both platforms — the new transports roll out by
+// setting a PostHog flag after on-device QA, never by merging an OTA.
+describe('download transport strategies', () => {
+  const DECODED = { ...ENTRY, uncompressedBytes: 3_000_000 };
+
+  it('uses downloadFileAsync with EXACTLY the shipped options when the flags are unresolved', async () => {
+    await mobileSnapshotSource.downloadArtifact(ENTRY);
+
+    expect(state.taskCalls).toEqual([]);
+    const call = (File.downloadFileAsync as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[2]).toEqual({ idempotent: true, signal: undefined });
+  });
+
+  it('passes the four-key options object when the caller asked for progress', async () => {
+    await mobileSnapshotSource.downloadArtifact(ENTRY, { onProgress: () => {} });
+
+    const call = (File.downloadFileAsync as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(Object.keys(call[2] as object).sort()).toEqual(['idempotent', 'onProgress', 'signal']);
+    expect((call[2] as { idempotent: boolean }).idempotent).toBe(true);
+  });
+
+  it('stays on downloadFileAsync when the task-api flag is explicitly off', async () => {
+    setSnapshotDownloadStrategyFromFlags({ taskApiFlag: false, backgroundSessionFlag: true });
+
+    await mobileSnapshotSource.downloadArtifact(ENTRY);
+
+    expect(state.taskCalls).toEqual([]);
+    expect(state.downloadCalls).toHaveLength(1);
+  });
+
+  it('drives a background URLSession task on iOS when the task-api flag is on', async () => {
+    setSnapshotDownloadStrategyFromFlags({ taskApiFlag: true, backgroundSessionFlag: undefined });
+
+    await mobileSnapshotSource.downloadArtifact(ENTRY, { onProgress: () => {} });
+
+    expect(state.downloadCalls).toEqual([]);
+    expect(state.taskCalls).toEqual([
+      { url: ENTRY.url, sessionType: 'background', hasOnProgress: true, hasSignal: false },
+    ]);
+  });
+
+  it('pins the task to a foreground session when the background-session flag is off', async () => {
+    setSnapshotDownloadStrategyFromFlags({ taskApiFlag: true, backgroundSessionFlag: false });
+
+    await mobileSnapshotSource.downloadArtifact(ENTRY);
+
+    expect(state.taskCalls[0].sessionType).toBe('foreground');
+  });
+
+  it('releases the native task handle on the success AND the throw path', async () => {
+    setSnapshotDownloadStrategyFromFlags({ taskApiFlag: true, backgroundSessionFlag: undefined });
+
+    await mobileSnapshotSource.downloadArtifact(ENTRY);
+    expect(state.taskReleases).toBe(1);
+
+    // A different build, so the sidecar the first download wrote cannot short
+    // -circuit this one into the reuse path.
+    state.downloadError = new Error('boom');
+    await expect(
+      mobileSnapshotSource.downloadArtifact({ ...ENTRY, builtAt: '2026-06-02T00:00:00.000Z' }),
+    ).rejects.toThrow(/transfer failed/);
+    expect(state.taskReleases).toBe(2);
+  });
+
+  it('treats a task that resolves null as a failed transfer, not a silent success', async () => {
+    // expo resolves null only for a PAUSED transfer, which we never request.
+    setSnapshotDownloadStrategyFromFlags({ taskApiFlag: true, backgroundSessionFlag: undefined });
+    state.taskResolvesNull = true;
+
+    await expect(mobileSnapshotSource.downloadArtifact(ENTRY)).rejects.toThrow(/ended without a file/);
+  });
+
+  it('reports the strategy it actually used on the transfer event', async () => {
+    setSnapshotDownloadStrategyFromFlags({ taskApiFlag: true, backgroundSessionFlag: false });
+    state.downloadedFileSize = DECODED.uncompressedBytes;
+
+    await mobileSnapshotSource.downloadArtifact(DECODED);
+
+    expect(reportArtifactTransfer).toHaveBeenCalledWith(
+      expect.objectContaining({ strategy: 'task-foreground', outcome: 'completed' }),
+    );
+  });
+});
+
+// The exact decoded-size gate (issue #4394): the manifest's `uncompressedBytes`
+// is the SQLite file's own byte length, so a short body is provable — and it
+// must be provable BEFORE the completeness sidecar is written.
+describe('the exact decoded-size gate', () => {
+  const DECODED_BYTES = 3_000_000;
+  const WITH_DECODED_SIZE: SnapshotManifestEntry = { ...ENTRY, uncompressedBytes: DECODED_BYTES };
+
+  it('deletes a short body, writes no sidecar, and throws SnapshotArtifactTruncatedError', async () => {
+    state.downloadedFileSize = DECODED_BYTES - 1;
+
+    const rejection = await mobileSnapshotSource.downloadArtifact(WITH_DECODED_SIZE).catch((error: unknown) => error);
+
+    expect(rejection).toBeInstanceOf(SnapshotArtifactTruncatedError);
+    expect((rejection as Error).message).toMatch(/expected 3000000 bytes, got 2999999/);
+    expect(state.files.has(ARTIFACT_URI)).toBe(false);
+    expect(state.files.has(SIDECAR_URI)).toBe(false);
+    expect(reportHandledError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'snapshot artifact size mismatch' }),
+      expect.objectContaining({
+        extra: expect.objectContaining({ expectedDecodedBytes: DECODED_BYTES, bytesOnDisk: DECODED_BYTES - 1 }),
+      }),
+    );
+  });
+
+  it('writes the sidecar exactly as before when the size matches', async () => {
+    state.downloadedFileSize = DECODED_BYTES;
+
+    const result = await mobileSnapshotSource.downloadArtifact(WITH_DECODED_SIZE);
+
+    expect(result).toEqual({ filePath: ARTIFACT_URI.replace('file://', '') });
+    expect(state.files.get(SIDECAR_URI)?.text).toBe(ENTRY.builtAt);
+  });
+
+  it('skips the gate for an entry with no uncompressedBytes (grades artifact / pre-#4311 manifest)', async () => {
+    expect(ENTRY.uncompressedBytes).toBeUndefined();
+
+    await expect(mobileSnapshotSource.downloadArtifact(ENTRY)).resolves.not.toBeNull();
+  });
+
+  it('gates an identity-encoded entry on entry.bytes — there, bytes IS the decoded size', async () => {
+    const identityEntry: SnapshotManifestEntry = { ...ENTRY, contentEncoding: 'identity' };
+    state.downloadedFileSize = ENTRY.bytes - 10;
+
+    await expect(mobileSnapshotSource.downloadArtifact(identityEntry)).rejects.toBeInstanceOf(
+      SnapshotArtifactTruncatedError,
+    );
+  });
+
+  it('keeps the gzip sniff WINNING over the size gate for a still-compressed body', async () => {
+    // A still-compressed body is a permanent miss, not a short one: the two
+    // spend different budgets and mean different things.
+    state.downloadBytes = GZIP_BYTES;
+    state.downloadedFileSize = DECODED_BYTES - 1;
+
+    await expect(mobileSnapshotSource.downloadArtifact(WITH_DECODED_SIZE)).rejects.toBeInstanceOf(
+      SnapshotPermanentMissError,
+    );
+  });
+
+  it('re-downloads a RETAINED artifact whose file has since been truncated', async () => {
+    seedRetainedArtifact(ARTIFACT_URI, ENTRY.builtAt, DECODED_BYTES - 1);
+    state.downloadedFileSize = DECODED_BYTES;
+
+    const result = await mobileSnapshotSource.downloadArtifact(WITH_DECODED_SIZE);
+
+    expect(result?.reused).toBeUndefined();
+    expect(state.downloadCalls).toHaveLength(1);
+  });
+
+  it('still reuses a retained artifact whose size matches', async () => {
+    seedRetainedArtifact(ARTIFACT_URI, ENTRY.builtAt, DECODED_BYTES);
+
+    const result = await mobileSnapshotSource.downloadArtifact(WITH_DECODED_SIZE);
+
+    expect(result).toEqual({ filePath: ARTIFACT_URI.replace('file://', ''), reused: true });
+    expect(state.downloadCalls).toEqual([]);
+  });
+});
+
+describe('superseded-partial sweep', () => {
+  it('discards an older build BEFORE the free-space precheck that its bytes would fail', async () => {
+    // Today a 271 MB stale partial sits in the cache until the NEXT download
+    // succeeds — which it may not, because that partial counts against the
+    // precheck. Sweeping first frees the space the new download needs.
+    const stalePartial = 'file://cache-root/board-snapshots/kilter-8-2026-05-01T00-00-00-000Z.db';
+    seedRetainedArtifact(stalePartial, '2026-05-01T00:00:00.000Z', 271_000_000);
+
+    await expect(mobileSnapshotSource.downloadArtifact(ENTRY)).resolves.not.toBeNull();
+
+    expect(state.files.has(stalePartial)).toBe(false);
+    expect(state.files.has(`${stalePartial}.complete`)).toBe(false);
+  });
+
+  it('leaves a DIFFERENT layout alone — the sweep is per (board, layout)', async () => {
+    const otherLayout = 'file://cache-root/board-snapshots/kilter-9-2026-05-01T00-00-00-000Z.db';
+    seedRetainedArtifact(otherLayout, '2026-05-01T00:00:00.000Z');
+
+    await mobileSnapshotSource.downloadArtifact(ENTRY);
+
+    expect(state.files.has(otherLayout)).toBe(true);
+  });
+
+  it('never runs for a grades artifact, whose filename carries no board-layout prefix', async () => {
+    const layoutArtifact = 'file://cache-root/board-snapshots/kilter-8-2026-05-01T00-00-00-000Z.db';
+    seedRetainedArtifact(layoutArtifact, '2026-05-01T00:00:00.000Z');
+
+    await mobileSnapshotSource.downloadGradesArtifact?.({
+      key: 'board-snapshots/v1-gzip/kilter/8/2026-06-01-grades.db',
+      url: 'https://example.test/artifacts/kilter-8-grades.db',
+      bytes: 2_000_000,
+      contentEncoding: 'gzip',
+      builtAt: '2026-06-01T00:00:00.000Z',
+      schemaVersion: 1,
+      tables: {
+        board_climb_grades: { watermarkUpdatedAt: '2026-05-01T00:00:00Z', watermarkSyncSeq: '10', rowCount: 900 },
+      },
+    });
+
+    expect(state.files.has(layoutArtifact)).toBe(true);
+  });
+});
+
+describe('Offline Artifact Transfer telemetry', () => {
+  it('reports a completed layout transfer with its dimensions and no fabricated numbers', async () => {
+    state.downloadProgressFrames = [{ bytesWritten: 1_000, totalBytes: -1 }];
+    state.downloadedFileSize = 3_000_000;
+
+    await mobileSnapshotSource.downloadArtifact({ ...ENTRY, uncompressedBytes: 3_000_000 }, { onProgress: () => {} });
+
+    expect(reportArtifactTransfer).toHaveBeenCalledTimes(1);
+    const report = reportArtifactTransfer.mock.calls[0][0] as Record<string, unknown>;
+    expect(report).toMatchObject({
+      strategy: 'download-file-async',
+      artifact: 'layout',
+      boardType: 'kilter',
+      layoutId: 8,
+      outcome: 'completed',
+      wireBytes: ENTRY.bytes,
+      expectedDecodedBytes: 3_000_000,
+      bytesOnDisk: 3_000_000,
+      backgroundedDuringTransfer: false,
+      resumed: false,
+      sizeMismatch: false,
+    });
+    expect(typeof report.wallMs).toBe('number');
+    expect(typeof report.firstByteMs).toBe('number');
+  });
+
+  it('omits firstByteMs when no progress callback ever fired', async () => {
+    await mobileSnapshotSource.downloadArtifact(ENTRY);
+
+    const report = reportArtifactTransfer.mock.calls[0][0] as Record<string, unknown>;
+    expect('firstByteMs' in report).toBe(false);
+  });
+
+  it('reports a cancelled transfer as aborted, not failed', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(mobileSnapshotSource.downloadArtifact(ENTRY, { signal: controller.signal })).rejects.toThrow();
+
+    expect(reportArtifactTransfer).toHaveBeenCalledWith(expect.objectContaining({ outcome: 'aborted' }));
+  });
+
+  it('reports a failed transfer as failed', async () => {
+    state.downloadError = new Error('boom');
+
+    await expect(mobileSnapshotSource.downloadArtifact(ENTRY)).rejects.toThrow();
+
+    expect(reportArtifactTransfer).toHaveBeenCalledWith(expect.objectContaining({ outcome: 'failed' }));
+  });
+
+  it('reports sizeMismatch on a short body', async () => {
+    state.downloadedFileSize = 10;
+
+    await expect(mobileSnapshotSource.downloadArtifact({ ...ENTRY, uncompressedBytes: 3_000_000 })).rejects.toThrow();
+
+    expect(reportArtifactTransfer).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: 'failed', sizeMismatch: true, bytesOnDisk: 10 }),
+    );
+  });
+
+  it('emits NOTHING for a reused artifact — the denominator stays real network work', async () => {
+    seedRetainedArtifact(ARTIFACT_URI, ENTRY.builtAt);
+
+    await mobileSnapshotSource.downloadArtifact(ENTRY);
+
+    expect(reportArtifactTransfer).not.toHaveBeenCalled();
+  });
+
+  it('emits NOTHING when the disk-space precheck refuses before any bytes move', async () => {
+    state.availableDiskSpace = 1;
+
+    await expect(mobileSnapshotSource.downloadArtifact(ENTRY)).rejects.toThrow(/insufficient disk space/);
+
+    expect(reportArtifactTransfer).not.toHaveBeenCalled();
+  });
+
+  it('reports a grades transfer without board dimensions its manifest block does not carry', async () => {
+    await mobileSnapshotSource.downloadGradesArtifact?.({
+      key: 'board-snapshots/v1-gzip/kilter/8/2026-06-01-grades.db',
+      url: 'https://example.test/artifacts/kilter-8-grades.db',
+      bytes: 2_000_000,
+      contentEncoding: 'gzip',
+      builtAt: '2026-06-01T00:00:00.000Z',
+      schemaVersion: 1,
+      tables: {
+        board_climb_grades: { watermarkUpdatedAt: '2026-05-01T00:00:00Z', watermarkSyncSeq: '10', rowCount: 900 },
+      },
+    });
+
+    const report = reportArtifactTransfer.mock.calls[0][0] as Record<string, unknown>;
+    expect(report).toMatchObject({ artifact: 'grades', outcome: 'completed', wireBytes: 2_000_000 });
+    expect('boardType' in report).toBe(false);
+    expect('layoutId' in report).toBe(false);
+    expect('expectedDecodedBytes' in report).toBe(false);
   });
 });
 
@@ -598,7 +996,7 @@ describe('retention and reuse', () => {
     controller.abort();
 
     await expect(mobileSnapshotSource.downloadArtifact(ENTRY, { signal: controller.signal })).rejects.toThrow(
-      /downloadFileAsync failed/,
+      /transfer failed/,
     );
     expect(state.downloadCalls[0].hasSignal).toBe(true);
   });

--- a/packages/mobile/src/offline/__tests__/use-snapshot-source.test.tsx
+++ b/packages/mobile/src/offline/__tests__/use-snapshot-source.test.tsx
@@ -13,6 +13,7 @@ const flags = vi.hoisted(() => ({
   offlineDownloadsEnabled: true,
   snapshotBootstrapEnabled: true,
   downloadProgressEnabled: true,
+  raw: {} as Record<string, boolean | undefined>,
 }));
 
 const sourceSpies = vi.hoisted(() => ({
@@ -22,14 +23,19 @@ const sourceSpies = vi.hoisted(() => ({
   deleteArtifact: vi.fn(async () => {}),
   releaseArtifact: vi.fn(async () => {}),
 }));
+const setSnapshotDownloadStrategyFromFlags = vi.hoisted(() => vi.fn());
 
 vi.mock('../../lib/env', () => ({ isSnapshotBaseUrlConfigured: () => true }));
 vi.mock('../../providers/feature-flags-provider', () => ({
   useOfflineDownloadsEnabled: () => flags.offlineDownloadsEnabled,
   useSnapshotBootstrapEnabled: () => flags.snapshotBootstrapEnabled,
   useOfflineDownloadProgressEnabled: () => flags.downloadProgressEnabled,
+  useFeatureFlag: (key: string) => flags.raw[key],
 }));
-vi.mock('../snapshot-source', () => ({ mobileSnapshotSource: sourceSpies }));
+vi.mock('../snapshot-source', () => ({
+  mobileSnapshotSource: sourceSpies,
+  setSnapshotDownloadStrategyFromFlags: (value: unknown) => setSnapshotDownloadStrategyFromFlags(value),
+}));
 
 import { useSnapshotSource } from '../use-snapshot-source';
 
@@ -42,6 +48,7 @@ beforeEach(() => {
   flags.offlineDownloadsEnabled = true;
   flags.snapshotBootstrapEnabled = true;
   flags.downloadProgressEnabled = true;
+  flags.raw = {};
 });
 
 afterEach(() => {
@@ -61,6 +68,18 @@ describe('useSnapshotSource', () => {
   it('withholds snapshot I/O when the offline kill switch is off', () => {
     flags.offlineDownloadsEnabled = false;
     expect(renderSource()).toBeUndefined();
+  });
+
+  it('pushes the transport flags into module state WITHOUT rebuilding the source', () => {
+    // The source's identity is a dependency of the scheduler effect, so a
+    // transport flag resolving must not churn it (issue #4394).
+    flags.raw = { 'offline-download-task-api': true, 'offline-download-background-session': false };
+
+    expect(renderSource()).toBe(sourceSpies);
+    expect(setSnapshotDownloadStrategyFromFlags).toHaveBeenCalledWith({
+      taskApiFlag: true,
+      backgroundSessionFlag: false,
+    });
   });
 
   describe('with download progress off', () => {

--- a/packages/mobile/src/offline/artifact-transfer-telemetry.ts
+++ b/packages/mobile/src/offline/artifact-transfer-telemetry.ts
@@ -1,0 +1,75 @@
+// `Offline Artifact Transfer` — one event per artifact transfer that actually
+// moved bytes (issue #4394).
+//
+// The download funnel cannot answer "how fast is this device downloading?":
+// `Offline Board Download Completed` fires at SCOPE completion, omits
+// `downloadMs` whenever the delta pull lands in a later cycle, and carries no
+// transport dimension. A reused artifact emits nothing here, so the denominator
+// is always real network work.
+//
+// Every prop is ABSENT when unknown, never zero — a 0 kbit/s row and a row with
+// no measurement are different facts, and only one of them is a slow download.
+
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { track } from '../lib/analytics';
+import { isOfflineEngineEnabled } from '../lib/offline-engine';
+import { getLastKnownMetered } from './offline-sync-adapter';
+import type { SnapshotDownloadStrategy } from './download-strategy';
+
+export type ArtifactTransferOutcome = 'completed' | 'failed' | 'aborted';
+
+export type ArtifactTransferReport = {
+  strategy: SnapshotDownloadStrategy;
+  artifact: 'layout' | 'grades';
+  /** Layout artifacts only — a grades manifest block carries neither. */
+  boardType?: string;
+  layoutId?: number;
+  outcome: ArtifactTransferOutcome;
+  /** The stored object size: the scale the confirm dialog and the progress bar quote. */
+  wireBytes: number;
+  expectedDecodedBytes?: number;
+  bytesOnDisk?: number;
+  wallMs: number;
+  firstByteMs?: number;
+  backgroundedDuringTransfer: boolean;
+  /** Reserved for the resume follow-up; always false today. */
+  resumed: boolean;
+  /** Only ever set when `expectedDecodedBytes` was known and could be compared. */
+  sizeMismatch?: boolean;
+};
+
+/**
+ * Wire throughput in kbit/s, or undefined when it would not mean anything.
+ *
+ * WIRE scale deliberately: it is the number directly comparable to the
+ * ~15 Mbit/s Safari and ~1.3 Mbit/s in-app figures in #4394. Only computed for a
+ * completed transfer with a positive duration — a failed transfer moved an
+ * unknown number of bytes, and dividing by a zero-ish wall clock produces a
+ * headline figure nobody can reproduce.
+ */
+function wireKbps(report: ArtifactTransferReport): number | undefined {
+  if (report.outcome !== 'completed' || report.wallMs <= 0) return undefined;
+  return Math.round((report.wireBytes * 8) / report.wallMs);
+}
+
+export function reportArtifactTransfer(report: ArtifactTransferReport): void {
+  const metered = getLastKnownMetered();
+  track(SHARED_EVENTS.OfflineArtifactTransfer, {
+    strategy: report.strategy,
+    artifact: report.artifact,
+    ...(report.boardType !== undefined ? { boardType: report.boardType } : {}),
+    ...(report.layoutId !== undefined ? { layoutId: report.layoutId } : {}),
+    outcome: report.outcome,
+    wireBytes: report.wireBytes,
+    ...(report.expectedDecodedBytes !== undefined ? { expectedDecodedBytes: report.expectedDecodedBytes } : {}),
+    ...(report.bytesOnDisk !== undefined ? { bytesOnDisk: report.bytesOnDisk } : {}),
+    wallMs: report.wallMs,
+    ...(report.firstByteMs !== undefined ? { firstByteMs: report.firstByteMs } : {}),
+    ...(wireKbps(report) !== undefined ? { wireKbps: wireKbps(report) } : {}),
+    backgroundedDuringTransfer: report.backgroundedDuringTransfer,
+    resumed: report.resumed,
+    ...(report.sizeMismatch !== undefined ? { sizeMismatch: report.sizeMismatch } : {}),
+    ...(metered !== null ? { metered } : {}),
+    offlineEngineEnabled: isOfflineEngineEnabled(),
+  });
+}

--- a/packages/mobile/src/offline/download-strategy.ts
+++ b/packages/mobile/src/offline/download-strategy.ts
@@ -1,0 +1,50 @@
+// Which expo-file-system transport a board-artifact download rides (issue
+// #4394, issue #4390).
+//
+// Pure and dependency-free on purpose: `Platform.OS` is passed in, so the whole
+// matrix — including the corner where one flag is set and the other is not — is
+// pinned by a plain unit test with no React Native in the module graph.
+//
+// The three arms:
+//   download-file-async  today's shipped `File.downloadFileAsync`. iOS: a
+//                        foreground `URLSession` (`.default`, delegateQueue nil
+//                        on the legacy path). Android: a shared OkHttpClient.
+//   task-foreground      `File.createDownloadTask(..., sessionType: 'foreground')`.
+//                        On Android this is a genuinely different client (the
+//                        task builds its own OkHttpClient with 60 s timeouts),
+//                        not a relabel; on iOS it is a default-config session
+//                        with `delegateQueue: .main`, which doubles as a
+//                        main-thread-contention probe.
+//   task-background      iOS only: `URLSessionConfiguration.background`
+//                        (isDiscretionary false, sessionSendsLaunchEvents true),
+//                        so the transfer keeps running while the process is
+//                        suspended. The transport half of #4390 on iOS.
+
+export type SnapshotDownloadStrategy = 'download-file-async' | 'task-foreground' | 'task-background';
+
+export function resolveSnapshotDownloadStrategy(input: {
+  taskApiFlag: boolean | undefined;
+  backgroundSessionFlag: boolean | undefined;
+  /** `Platform.OS`. */
+  platform: string;
+}): SnapshotDownloadStrategy {
+  // UNRESOLVED reads as the SHIPPED path, on both platforms. Production OTAs
+  // auto-publish on every push to main, and a PostHog key that does not exist
+  // yet reads `undefined` on every device — so an "undefined → task-background"
+  // default would flip the whole iOS fleet the hour this merges, before any of
+  // the on-device QA that is the only way to prove the path.
+  //
+  // The downside is not symmetric. A background URLSession runs out of
+  // nsurlsessiond, a different process from the in-process default-config
+  // sessions the gzip cutover was validated against; if it does not transparently
+  // gunzip, snapshot-source raises SnapshotPermanentMissError, which at the
+  // download stage burns the structural budget AND marks the paged fallback — a
+  // durable settle that flipping the flag back does not undo.
+  //
+  // So: roll out by SETTING the flag, never by merging.
+  if (input.taskApiFlag !== true) return 'download-file-async';
+  // Android's native side ignores `sessionType` entirely, so reporting
+  // 'task-background' there would be a lie in the telemetry.
+  if (input.platform !== 'ios') return 'task-foreground';
+  return input.backgroundSessionFlag === false ? 'task-foreground' : 'task-background';
+}

--- a/packages/mobile/src/offline/offline-sync-adapter.ts
+++ b/packages/mobile/src/offline/offline-sync-adapter.ts
@@ -378,6 +378,16 @@ const isOnUnmeteredNetwork = async (): Promise<boolean> => {
   return !isConnectionMetered;
 };
 
+/**
+ * The cached verdict WITHOUT the probe — `null` until NetInfo has reported.
+ * Telemetry-only (issue #4394's `Offline Artifact Transfer`), which is why it
+ * never falls back to "unmetered" the way the gate above does: an absent prop is
+ * honest, a fabricated `false` is not.
+ */
+export function getLastKnownMetered(): boolean | null {
+  return isConnectionMetered;
+}
+
 /** Cold-launch state is per-process; tests re-arm it between cases. */
 export function __resetMeteredStateForTests(): void {
   isConnectionMetered = null;

--- a/packages/mobile/src/offline/snapshot-paths.ts
+++ b/packages/mobile/src/offline/snapshot-paths.ts
@@ -1,0 +1,17 @@
+// Where downloaded board artifacts live, as a constant with NO imports.
+//
+// A module of its own rather than a line in `snapshot-source.ts` because the
+// cache sweeper (`lib/sweep-caches.ts`) needs the directory name and nothing
+// else — and snapshot-source now statically imports `react-native` for
+// `Platform.OS`. Under RN 0.86 that entry is Flow source, which Rolldown's
+// collection-time scan cannot parse, so pulling it into the sweeper's graph
+// broke four unrelated suites (see the `react-native` note in
+// packages/mobile/vite.config.ts). Keep this file dependency-free.
+
+// Cache-dir subfolder for downloaded artifacts. The engine ATTACHes the file,
+// imports the scope's rows, then hands it back through `releaseArtifact`.
+// Since issue #4310 a file the engine did NOT import survives to the next
+// cycle, but it still lives under `Paths.cache`, not `Paths.document`: the OS
+// may reclaim it under storage pressure and losing it costs a re-download,
+// never data.
+export const SNAPSHOT_DIR_NAME = 'board-snapshots';

--- a/packages/mobile/src/offline/snapshot-source.ts
+++ b/packages/mobile/src/offline/snapshot-source.ts
@@ -26,8 +26,12 @@
 // the message, so the classifier could not see them and every offline user's
 // failure landed as a Sentry `error`).
 
+import { Platform } from 'react-native';
 import { Directory, File, Paths } from 'expo-file-system';
 import {
+  isBackgrounded,
+  onTeardown,
+  SnapshotArtifactTruncatedError,
   SnapshotPermanentMissError,
   type SnapshotArtifactHandle,
   type SnapshotDownloadOptions,
@@ -36,20 +40,47 @@ import {
   type SnapshotSource,
 } from '@boardsesh/offline-sync';
 import { SNAPSHOT_BASE_URL } from '../lib/env';
+import { SNAPSHOT_DIR_NAME } from './snapshot-paths';
 import { reportHandledError } from '../lib/error-reporting';
+import { resolveSnapshotDownloadStrategy, type SnapshotDownloadStrategy } from './download-strategy';
+import { reportArtifactTransfer, type ArtifactTransferOutcome } from './artifact-transfer-telemetry';
+
+// Which transport the next transfer rides (issue #4394). MODULE STATE rather
+// than a factory on purpose: `mobileSnapshotSource`'s object identity is a
+// dependency of the scheduler effect in offline-sync-bridge.tsx, so rebuilding
+// the source when a PostHog flag resolves would restart the whole sync scheduler
+// mid-download. Mirrors the `isConnectionMetered` pattern in
+// offline-sync-adapter.ts.
+let activeStrategy: SnapshotDownloadStrategy = resolveSnapshotDownloadStrategy({
+  taskApiFlag: undefined,
+  backgroundSessionFlag: undefined,
+  platform: Platform.OS,
+});
+
+/** Called from `useSnapshotSource`'s effect whenever either flag resolves or changes. */
+export function setSnapshotDownloadStrategyFromFlags(flags: {
+  taskApiFlag: boolean | undefined;
+  backgroundSessionFlag: boolean | undefined;
+}): void {
+  activeStrategy = resolveSnapshotDownloadStrategy({ ...flags, platform: Platform.OS });
+}
+
+export function __resetSnapshotDownloadStrategyForTests(): void {
+  activeStrategy = resolveSnapshotDownloadStrategy({
+    taskApiFlag: undefined,
+    backgroundSessionFlag: undefined,
+    platform: Platform.OS,
+  });
+}
 
 const MANIFEST_URL = `${SNAPSHOT_BASE_URL}/manifest.json`;
 
-// Cache-dir subfolder for downloaded artifacts. The engine ATTACHes the file,
-// imports the scope's rows, then hands it back through `releaseArtifact`.
-// Since issue #4310 a file the engine did NOT import survives to the next
-// cycle (see the retention notes below), but it still lives under Paths.cache,
-// not Paths.document: the OS may reclaim it under storage pressure and losing
-// it costs a re-download, never data.
-// Exported so the cache sweeper (lib/sweep-caches.ts) reaps artifacts leaked by
-// a kill mid-bootstrap from the same directory this writes to, rather than
-// re-literalling the name and silently sweeping nothing if it ever moves.
-export const SNAPSHOT_DIR_NAME = 'board-snapshots';
+// The directory name lives in `snapshot-paths.ts` — an import-free module — so
+// the cache sweeper can reap artifacts from the same directory this writes to
+// without dragging `react-native` (imported above for `Platform.OS`) into its
+// module graph. Re-exported here because this is where callers expect to find
+// it, and re-literalling the name would silently sweep nothing if it ever moved.
+export { SNAPSHOT_DIR_NAME } from './snapshot-paths';
 
 // Written next to `<artifact>.db` once the download AND the gzip sniff have
 // both passed, holding the artifact's `builtAt`. Retention is only useful if a
@@ -280,6 +311,82 @@ function artifactNamePrefix(uri: string): string | null {
 }
 
 /**
+ * Drop artifacts for a SUPERSEDED build of this (board, layout) BEFORE the
+ * download starts (issue #4390 asks for partials to be discarded by `builtAt`).
+ *
+ * `sweepRetainedArtifacts` already does this after a successful download, which
+ * is one download too late: a 271 MB partial from an older build sits in the
+ * cache until the NEXT download succeeds — and it may not, because that partial
+ * counts against the free-space precheck the new download has to pass. Sweeping
+ * first both discards the stale bytes and frees the space the new one needs.
+ *
+ * Whole-layout artifacts only: a grades file is named from its manifest key and
+ * carries no `<board>-<layout>` prefix, so it is never recognised here.
+ */
+function sweepSupersededArtifacts(keepFileName: string): void {
+  const keepPrefix = artifactNamePrefix(keepFileName);
+  if (keepPrefix === null) return;
+  let entries: (File | Directory)[];
+  try {
+    entries = snapshotDirectory().list();
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (!(entry instanceof File)) continue;
+    if (entry.uri.endsWith(COMPLETE_SIDECAR_SUFFIX)) continue;
+    const name = entry.uri.slice(entry.uri.lastIndexOf('/') + 1);
+    if (name === keepFileName) continue;
+    if (artifactNamePrefix(entry.uri) !== keepPrefix) continue;
+    deleteArtifactWithSidecar(entry);
+  }
+}
+
+/**
+ * The one place the two download APIs differ.
+ *
+ * `download-file-async` is byte-for-byte today's shipped call, including the
+ * exact options object shape the `offline-download-progress` kill switch
+ * restores. The task strategies pass `sessionType` EXPLICITLY on both arms
+ * rather than relying on expo's `.background` default, so the telemetry label
+ * and the native behaviour can never drift.
+ */
+async function runTransfer(args: {
+  strategy: SnapshotDownloadStrategy;
+  url: string;
+  destination: File;
+  onProgress?: (progress: { bytesWritten: number; totalBytes: number }) => void;
+  signal?: AbortSignal;
+}): Promise<File> {
+  if (args.strategy === 'download-file-async') {
+    return File.downloadFileAsync(
+      args.url,
+      args.destination,
+      args.onProgress
+        ? { idempotent: true, signal: args.signal, onProgress: args.onProgress }
+        : { idempotent: true, signal: args.signal },
+    );
+  }
+  const task = File.createDownloadTask(args.url, args.destination, {
+    sessionType: args.strategy === 'task-background' ? 'background' : 'foreground',
+    ...(args.signal ? { signal: args.signal } : {}),
+    ...(args.onProgress ? { onProgress: args.onProgress } : {}),
+  });
+  try {
+    const file = await task.downloadAsync();
+    // `downloadAsync` resolves null ONLY when `pause()` was called, which we
+    // never do. Treat it as a failed transfer rather than a silent success that
+    // would hand the engine a handle to a file nobody wrote.
+    if (!file) throw new Error('snapshot download: transfer ended without a file');
+    return file;
+  } finally {
+    // Only after the promise settles: `release()` frees the native shared
+    // object, and `sharedObjectDidRelease` cancels an in-flight call.
+    task.release();
+  }
+}
+
+/**
  * Fetch the manifest JSON. Returns `null` only when the manifest is genuinely
  * absent or unparseable (permanent miss this cycle, no attempt). HTTP outages
  * throw so the engine treats them as retryable manifest errors.
@@ -318,139 +425,258 @@ function formatError(error: unknown): string {
  * request timed out.")` is an offline user (a warning) or a real fault (an
  * error). Issue #4238.
  */
+/** Everything `downloadSnapshotFile` needs that differs between the two artifact kinds. */
+type SnapshotArtifactRequest = {
+  label: string;
+  url: string;
+  requiredBytes: number;
+  contentEncoding: 'gzip' | 'identity';
+  fileName: string;
+  telemetryExtra: Record<string, unknown>;
+  /** Telemetry dimension on `Offline Artifact Transfer`. */
+  kind: 'layout' | 'grades';
+  /** The stored object size — what the confirm dialog and the progress bar quote. */
+  wireBytes: number;
+  /**
+   * The exact byte length the finished file must have, when the manifest can
+   * say. Absent for a gzip artifact with no `uncompressedBytes` (every grades
+   * block, and pre-#4311 layout entries), where there is nothing to compare to.
+   */
+  expectedDecodedBytes?: number;
+  boardType?: string;
+  layoutId?: number;
+  /**
+   * Build stamp for the completeness sidecar. Present only for the
+   * whole-layout artifact: retention (#4310) is sized for its ~100 MB and its
+   * supersede sweep recognises a build by the `<board>-<layout>` filename
+   * prefix, which a grades file (named from its manifest key) does not carry.
+   * Without it this function writes no sidecar, reuses nothing, and runs no
+   * sweep — the engine deletes the file at the end of the cycle instead.
+   */
+  retainAs?: { builtAt: string };
+};
+
 /**
- * The shared download body for BOTH artifact kinds: free-space check,
- * content-addressed destination, download, and the gzip magic-byte sniff. The
- * only differences between the whole-layout artifact and the separate grades
- * artifact are the filename, the label in error messages, and retention — which
- * only the whole-layout file gets (`retainAs`).
+ * The shared download body for BOTH artifact kinds: superseded-partial sweep,
+ * free-space check, content-addressed destination, transfer, the gzip magic-byte
+ * sniff, and the exact decoded-size gate. The only differences between the
+ * whole-layout artifact and the separate grades artifact are the filename, the
+ * label in error messages, and retention — which only the whole-layout file gets
+ * (`retainAs`).
  */
 async function downloadSnapshotFile(
-  artifact: {
-    label: string;
-    url: string;
-    requiredBytes: number;
-    contentEncoding: 'gzip' | 'identity';
-    fileName: string;
-    telemetryExtra: Record<string, unknown>;
-    /**
-     * Build stamp for the completeness sidecar. Present only for the
-     * whole-layout artifact: retention (#4310) is sized for its ~100 MB and its
-     * supersede sweep recognises a build by the `<board>-<layout>` filename
-     * prefix, which a grades file (named from its manifest key) does not carry.
-     * Without it this function writes no sidecar, reuses nothing, and runs no
-     * sweep — the engine deletes the file at the end of the cycle instead.
-     */
-    retainAs?: { builtAt: string };
-  },
+  artifact: SnapshotArtifactRequest,
   options?: SnapshotDownloadOptions,
 ): Promise<SnapshotArtifactHandle | null> {
-  const requiredBytes = artifact.requiredBytes;
-  const availableBytes = Paths.availableDiskSpace;
-  if (availableBytes < requiredBytes) {
-    throw new Error(
-      `snapshot download: insufficient disk space for ${artifact.label} ` +
-        `(need ~${requiredBytes} bytes, have ${availableBytes} bytes free)`,
-    );
-  }
-
-  const directory = snapshotDirectory();
-  try {
-    directory.create({ intermediates: true, idempotent: true });
-  } catch (error) {
-    throw new Error(`snapshot download: failed to create cache directory: ${formatError(error)}`, { cause: error });
-  }
-
-  const destination = new File(directory, artifact.fileName);
-
-  // A retained artifact from an earlier cycle, complete and for this exact
-  // build: hand it straight back. The engine still runs quick_check and
-  // verifySnapshotMeta over it before importing a single row, and treats an
-  // import failure on a reused file as delete-and-refetch rather than a counted
-  // bootstrap attempt — so trusting the sidecar here cannot strand a scope.
-  if (artifact.retainAs && destination.exists && hasCompleteSidecar(destination, artifact.retainAs.builtAt)) {
-    return { filePath: toSqlitePath(destination.uri), reused: true };
-  }
-  // A file with no (or a mismatched) sidecar is a half-written download, not a
-  // shortcut. Clear it so `idempotent: true` below never writes over a body it
-  // cannot verify.
-  if (destination.exists) deleteArtifactWithSidecar(destination);
-
-  let downloaded: File;
-  try {
-    // `onProgress` is only passed when the caller asked for it (the engine
-    // omits it when the kill switch is off), because supplying it makes
-    // expo-file-system take a different native download implementation — an
-    // 8 KB streaming copy loop on Android, a delegate-driven URLSession on iOS
-    // — rather than its plain path. Omitting it keeps the call byte-identical
-    // to the pre-#4311 one. `signal` rides both shapes: it only cancels the
-    // transfer and does not switch implementations.
-    downloaded = await File.downloadFileAsync(
-      artifact.url,
-      destination,
-      options?.onProgress
-        ? {
-            idempotent: true,
-            signal: options.signal,
-            onProgress: ({ bytesWritten, totalBytes }) => {
-              // Android reports -1 for a gzip body (OkHttp gunzips transparently,
-              // so Content-Length is meaningless); the engine expects null for
-              // "no usable total" and resolves the denominator itself.
-              options.onProgress?.({ bytesWritten, totalBytes: totalBytes > 0 ? totalBytes : null });
-            },
-          }
-        : { idempotent: true, signal: options?.signal },
-    );
-  } catch (error) {
-    throw new Error(`snapshot download: File.downloadFileAsync failed for ${artifact.label}: ${formatError(error)}`, {
-      cause: error,
+  // Latched for this transfer, so a flag resolving mid-download cannot mislabel
+  // the measurement it produces.
+  const strategy = activeStrategy;
+  const startedAt = Date.now();
+  let firstByteMs: number | undefined;
+  let backgroundedDuringTransfer = isBackgrounded();
+  // The engine's own teardown subscription drives the pause/failure decision;
+  // this one only records the fact for telemetry, which is why it reads the
+  // guard rather than trusting the transition — and why there is no second
+  // react-native AppState listener anywhere in this file.
+  const unsubscribeTeardown = onTeardown(() => {
+    if (isBackgrounded()) backgroundedDuringTransfer = true;
+  });
+  const emitTransfer = (
+    outcome: ArtifactTransferOutcome,
+    extra?: { bytesOnDisk?: number; sizeMismatch?: boolean },
+  ): void => {
+    reportArtifactTransfer({
+      strategy,
+      artifact: artifact.kind,
+      ...(artifact.boardType !== undefined ? { boardType: artifact.boardType } : {}),
+      ...(artifact.layoutId !== undefined ? { layoutId: artifact.layoutId } : {}),
+      outcome,
+      wireBytes: artifact.wireBytes,
+      ...(artifact.expectedDecodedBytes !== undefined ? { expectedDecodedBytes: artifact.expectedDecodedBytes } : {}),
+      ...(extra?.bytesOnDisk !== undefined ? { bytesOnDisk: extra.bytesOnDisk } : {}),
+      wallMs: Date.now() - startedAt,
+      ...(firstByteMs !== undefined ? { firstByteMs } : {}),
+      backgroundedDuringTransfer,
+      resumed: false,
+      ...(extra?.sizeMismatch !== undefined ? { sizeMismatch: extra.sizeMismatch } : {}),
     });
-  }
+  };
 
-  if (artifact.contentEncoding === 'gzip') {
-    let stillCompressed: boolean;
-    try {
-      stillCompressed = await looksGzipCompressed(downloaded);
-    } catch (error) {
-      // Can't verify the body — treat it as untrustworthy, same as a failed
-      // download. This was the last path that still `return null`ed, and it is
-      // the one that reported `cause: null` to Sentry (issue #4238).
-      safeDeleteFile(downloaded);
+  try {
+    // Superseded partials FIRST (issue #4390 asks for stale partials to be
+    // discarded by `builtAt`), because they are counted by the free-space check
+    // on the very next line — a 271 MB leftover could otherwise fail the
+    // precheck for the download that would have replaced it.
+    if (artifact.retainAs) sweepSupersededArtifacts(artifact.fileName);
+
+    const requiredBytes = artifact.requiredBytes;
+    const availableBytes = Paths.availableDiskSpace;
+    if (availableBytes < requiredBytes) {
       throw new Error(
-        `snapshot download: could not verify artifact encoding for ${artifact.label}: ${formatError(error)}`,
-        { cause: error },
+        `snapshot download: insufficient disk space for ${artifact.label} ` +
+          `(need ~${requiredBytes} bytes, have ${availableBytes} bytes free)`,
       );
     }
-    if (stillCompressed) {
+
+    const directory = snapshotDirectory();
+    try {
+      directory.create({ intermediates: true, idempotent: true });
+    } catch (error) {
+      throw new Error(`snapshot download: failed to create cache directory: ${formatError(error)}`, { cause: error });
+    }
+
+    const destination = new File(directory, artifact.fileName);
+
+    // A retained artifact from an earlier cycle, complete and for this exact
+    // build: hand it straight back, no event (no bytes moved). The engine still
+    // runs quick_check and verifySnapshotMeta over it before importing a single
+    // row, and treats an import failure on a reused file as delete-and-refetch
+    // rather than a counted bootstrap attempt — so trusting the sidecar here
+    // cannot strand a scope. The size is re-checked all the same: a survivor the
+    // OS truncated under storage pressure carries a sidecar that now lies.
+    if (artifact.retainAs && destination.exists && hasCompleteSidecar(destination, artifact.retainAs.builtAt)) {
+      if (artifact.expectedDecodedBytes === undefined || destination.size === artifact.expectedDecodedBytes) {
+        return { filePath: toSqlitePath(destination.uri), reused: true };
+      }
+      deleteArtifactWithSidecar(destination);
+    }
+    // A file with no (or a mismatched) sidecar is a half-written download, not a
+    // shortcut. Clear it so `idempotent: true` below never writes over a body it
+    // cannot verify.
+    if (destination.exists) deleteArtifactWithSidecar(destination);
+
+    let downloaded: File;
+    try {
+      // `onProgress` is only passed when the caller asked for it (the engine
+      // omits it when the kill switch is off), because supplying it makes
+      // expo-file-system take a different native download implementation — an
+      // 8 KB streaming copy loop on Android, a delegate-driven URLSession on iOS
+      // — rather than its plain path. Omitting it keeps the call byte-identical
+      // to the pre-#4311 one. `signal` rides both shapes: it only cancels the
+      // transfer and does not switch implementations.
+      downloaded = await runTransfer({
+        strategy,
+        url: artifact.url,
+        destination,
+        signal: options?.signal,
+        ...(options?.onProgress
+          ? {
+              onProgress: ({ bytesWritten, totalBytes }: { bytesWritten: number; totalBytes: number }) => {
+                // Separates slow-to-start (DNS/TLS/CDN) from slow-throughput —
+                // three lines that answer the first half of #4394 without a
+                // second round trip to the CDN.
+                if (firstByteMs === undefined && bytesWritten > 0) firstByteMs = Date.now() - startedAt;
+                // Android reports -1 for a gzip body (OkHttp gunzips transparently,
+                // so Content-Length is meaningless); the engine expects null for
+                // "no usable total" and resolves the denominator itself.
+                options.onProgress?.({ bytesWritten, totalBytes: totalBytes > 0 ? totalBytes : null });
+              },
+            }
+          : {}),
+      });
+    } catch (error) {
+      emitTransfer(options?.signal?.aborted === true ? 'aborted' : 'failed');
+      throw new Error(`snapshot download: transfer failed for ${artifact.label}: ${formatError(error)}`, {
+        cause: error,
+      });
+    }
+
+    if (artifact.contentEncoding === 'gzip') {
+      let stillCompressed: boolean;
+      try {
+        stillCompressed = await looksGzipCompressed(downloaded);
+      } catch (error) {
+        // Can't verify the body — treat it as untrustworthy, same as a failed
+        // download. This was the last path that still `return null`ed, and it is
+        // the one that reported `cause: null` to Sentry (issue #4238).
+        safeDeleteFile(downloaded);
+        emitTransfer('failed');
+        throw new Error(
+          `snapshot download: could not verify artifact encoding for ${artifact.label}: ${formatError(error)}`,
+          { cause: error },
+        );
+      }
+      if (stillCompressed) {
+        safeDeleteFile(downloaded);
+        // Expected behaviour is that the native HTTP stack (NSURLSession /
+        // OkHttp) auto-decodes a gzip Content-Encoding while downloading — this
+        // path should be rare-to-never (validated on Android/OkHttp and iOS 26.5.2
+        // before the fleet was cut over to the gzip prefix). Report it as a handled
+        // error (not just a dev warning) so a real pattern shows up in Sentry —
+        // it's now the live download path, and a spike here is the cutover's
+        // rollback signal, including for the background-URLSession rollout (a
+        // background session runs out of nsurlsessiond, a different process from
+        // the in-process sessions the gzip cutover was validated against).
+        reportHandledError(
+          new Error('snapshot artifact arrived still gzip-compressed (Content-Encoding was not auto-decoded)'),
+          {
+            tags: { source: 'offline-sync', kind: 'snapshot-bootstrap' },
+            extra: { ...artifact.telemetryExtra, strategy },
+          },
+        );
+        emitTransfer('failed');
+        throw new SnapshotPermanentMissError('snapshot artifact arrived still gzip-compressed');
+      }
+    }
+
+    // The exact decoded-size gate (issue #4394). `uncompressedBytes` is the
+    // SQLite file's own byte length (the export writes `rawBuffer.length`), so
+    // this is unambiguous — and it is the one check that fires BEFORE the
+    // sidecar is written, so a short or mixed-byte-space body can never be
+    // retained, reused or ATTACHed. Deliberately AFTER the gzip sniff: a body
+    // that is still compressed must keep reporting `permanent-miss`.
+    const bytesOnDisk = downloaded.size;
+    if (artifact.expectedDecodedBytes !== undefined && bytesOnDisk !== artifact.expectedDecodedBytes) {
       safeDeleteFile(downloaded);
-      // Expected behaviour is that the native HTTP stack (NSURLSession /
-      // OkHttp) auto-decodes a gzip Content-Encoding while downloading — this
-      // path should be rare-to-never (validated on Android/OkHttp and iOS 26.5.2
-      // before the fleet was cut over to the gzip prefix). Report it as a handled
-      // error (not just a dev warning) so a real pattern shows up in Sentry —
-      // it's now the live download path, and a spike here is the cutover's
-      // rollback signal.
-      reportHandledError(
-        new Error('snapshot artifact arrived still gzip-compressed (Content-Encoding was not auto-decoded)'),
-        {
-          tags: { source: 'offline-sync', kind: 'snapshot-bootstrap' },
-          extra: artifact.telemetryExtra,
+      reportHandledError(new Error('snapshot artifact size mismatch'), {
+        tags: { source: 'offline-sync', kind: 'snapshot-bootstrap' },
+        extra: {
+          ...artifact.telemetryExtra,
+          strategy,
+          expectedDecodedBytes: artifact.expectedDecodedBytes,
+          bytesOnDisk,
         },
+      });
+      emitTransfer('failed', { bytesOnDisk, sizeMismatch: true });
+      throw new SnapshotArtifactTruncatedError(
+        `snapshot download: short body for ${artifact.label} ` +
+          `(expected ${artifact.expectedDecodedBytes} bytes, got ${bytesOnDisk})`,
       );
-      throw new SnapshotPermanentMissError('snapshot artifact arrived still gzip-compressed');
     }
-  }
 
-  // Only now is the file provably complete AND decoded, so only now may a
-  // later cycle reuse it. Retained artifacts only: a grades file is deleted by
-  // the engine at the end of the cycle, so it neither claims a sidecar nor
-  // triggers a sweep.
-  if (artifact.retainAs) {
-    writeCompleteSidecar(downloaded, artifact.retainAs.builtAt);
-    sweepRetainedArtifacts(downloaded);
-  }
+    // Only now is the file provably complete AND decoded, so only now may a
+    // later cycle reuse it. Retained artifacts only: a grades file is deleted by
+    // the engine at the end of the cycle, so it neither claims a sidecar nor
+    // triggers a sweep.
+    if (artifact.retainAs) {
+      writeCompleteSidecar(downloaded, artifact.retainAs.builtAt);
+      sweepRetainedArtifacts(downloaded);
+    }
 
-  return { filePath: toSqlitePath(downloaded.uri) };
+    emitTransfer('completed', {
+      bytesOnDisk,
+      ...(artifact.expectedDecodedBytes !== undefined ? { sizeMismatch: false } : {}),
+    });
+    return { filePath: toSqlitePath(downloaded.uri) };
+  } finally {
+    unsubscribeTeardown();
+  }
+}
+
+/**
+ * The exact byte length a finished artifact must have, or undefined when the
+ * manifest cannot say. An `identity` entry's `bytes` IS the decoded size (the
+ * `board-snapshots/v1/` rollback prefix); a gzip entry needs
+ * `uncompressedBytes`, which every live grades block and every pre-#4311 layout
+ * entry lacks.
+ */
+function expectedDecodedBytesFor(entry: {
+  bytes: number;
+  contentEncoding: 'gzip' | 'identity';
+  uncompressedBytes?: number;
+}): number | undefined {
+  if (typeof entry.uncompressedBytes === 'number' && entry.uncompressedBytes > 0) return entry.uncompressedBytes;
+  return entry.contentEncoding === 'identity' ? entry.bytes : undefined;
 }
 
 async function downloadArtifact(
@@ -469,6 +695,11 @@ async function downloadArtifact(
       contentEncoding: entry.contentEncoding,
       fileName: `${entry.boardType}-${entry.layoutId}-${safeBuiltAt}.db`,
       telemetryExtra: { boardType: entry.boardType, layoutId: entry.layoutId, url: entry.url },
+      kind: 'layout',
+      wireBytes: entry.bytes,
+      ...(expectedDecodedBytesFor(entry) !== undefined ? { expectedDecodedBytes: expectedDecodedBytesFor(entry) } : {}),
+      boardType: entry.boardType,
+      layoutId: entry.layoutId,
       retainAs: { builtAt: entry.builtAt },
     },
     options,
@@ -495,6 +726,15 @@ async function downloadGradesArtifact(artifact: SnapshotGradesArtifact): Promise
     contentEncoding: artifact.contentEncoding,
     fileName: `${safeKey}.db`,
     telemetryExtra: { gradesKey: artifact.key, url: artifact.url },
+    kind: 'grades',
+    wireBytes: artifact.bytes,
+    // A gzip grades block carries no `uncompressedBytes` (verified against the
+    // live manifest), so the size gate applies to layout artifacts by
+    // construction — and to an identity grades artifact, where `bytes` IS the
+    // decoded size.
+    ...(expectedDecodedBytesFor(artifact) !== undefined
+      ? { expectedDecodedBytes: expectedDecodedBytesFor(artifact) }
+      : {}),
   });
 }
 

--- a/packages/mobile/src/offline/use-snapshot-source.ts
+++ b/packages/mobile/src/offline/use-snapshot-source.ts
@@ -1,12 +1,13 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import type { SnapshotGradesArtifact, SnapshotManifestEntry, SnapshotSource } from '@boardsesh/offline-sync';
 import { isSnapshotBaseUrlConfigured } from '../lib/env';
 import {
+  useFeatureFlag,
   useOfflineDownloadProgressEnabled,
   useOfflineDownloadsEnabled,
   useSnapshotBootstrapEnabled,
 } from '../providers/feature-flags-provider';
-import { mobileSnapshotSource } from './snapshot-source';
+import { mobileSnapshotSource, setSnapshotDownloadStrategyFromFlags } from './snapshot-source';
 
 /**
  * The kill-switch wrapper for download progress (issue #4311). Passing an
@@ -69,6 +70,16 @@ export function useSnapshotSource(): SnapshotSource | undefined {
   const offlineDownloadsEnabled = useOfflineDownloadsEnabled();
   const snapshotBootstrapEnabled = useSnapshotBootstrapEnabled();
   const downloadProgressEnabled = useOfflineDownloadProgressEnabled();
+  // The transport choice (issue #4394) is pushed into module state rather than
+  // folded into the memo below on purpose: the source's object IDENTITY is a
+  // dependency of the scheduler effect in offline-sync-bridge.tsx, so rebuilding
+  // it when a PostHog flag resolves would restart the sync scheduler
+  // mid-download. Neither flag belongs in the memo deps.
+  const taskApiFlag = useFeatureFlag('offline-download-task-api');
+  const backgroundSessionFlag = useFeatureFlag('offline-download-background-session');
+  useEffect(() => {
+    setSnapshotDownloadStrategyFromFlags({ taskApiFlag, backgroundSessionFlag });
+  }, [taskApiFlag, backgroundSessionFlag]);
   return useMemo(() => {
     if (!offlineDownloadsEnabled || !snapshotBootstrapEnabled || !isSnapshotBaseUrlConfigured()) return undefined;
     return downloadProgressEnabled ? mobileSnapshotSource : withoutDownloadProgress(mobileSnapshotSource);

--- a/packages/mobile/src/providers/feature-flags-provider.tsx
+++ b/packages/mobile/src/providers/feature-flags-provider.tsx
@@ -77,6 +77,18 @@ export const FEATURE_FLAG_DEFINITIONS = [
       'DEFAULT: ON — unlike every other flag here, absent/undefined means enabled. Real byte + percent progress on a downloading board instead of a static spinner. Off restores the old caption AND stops passing a progress callback to the native downloader, so it doubles as the kill switch if the progress-enabled download path ever proves slower.',
   },
   {
+    key: 'offline-download-task-api',
+    label: 'Offline download: DownloadTask transport',
+    description:
+      "Download board artifacts through expo-file-system's DownloadTask instead of downloadFileAsync. DEFAULT OFF, including unset: the new transports are the #4394 speed experiment and roll out by SETTING this flag after on-device QA, never by shipping a build. On + iOS gives a background URLSession (the only way a transfer survives suspension) unless the background-session flag below is explicitly off. Android ignores the session type and gets a different OkHttp client.",
+  },
+  {
+    key: 'offline-download-background-session',
+    label: 'Offline download: background URLSession',
+    description:
+      'iOS only, and only when the DownloadTask transport is on: use a background URLSession so the transfer keeps running while the app is suspended. Off pins it to a foreground session.',
+  },
+  {
     key: 'offline-discovery-nudges',
     label: 'Offline discovery nudges',
     description:

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -387,9 +387,17 @@ export const SHARED_EVENTS = {
   //
   // `reason` is a closed, low-cardinality bucket — 'aborted-wipe' |
   // 'aborted-background' | 'database-locked' | 'schema-stale' |
-  // 'watermark-regression' | 'permanent-miss' | 'artifact-invalid' | 'network' |
-  // 'unknown' | 'unknown-exit' — for grouping. The verbatim text stays on
-  // `errorMessage`.
+  // 'watermark-regression' | 'permanent-miss' | 'artifact-invalid' |
+  // 'artifact-truncated' | 'network' | 'unknown' | 'unknown-exit' — for
+  // grouping. The verbatim text stays on `errorMessage`. Dashboards that
+  // ENUMERATE reasons need 'artifact-truncated' added (issue #4394's exact
+  // decoded-size gate); failure-rate queries (`aborted = false`) pick it up on
+  // their own.
+  //
+  // One pairing changed with #4390: `aborted: true` can now arrive alongside an
+  // `Offline Snapshot Retry Scheduled` with `failureKind: 'transport'` — the
+  // 4th-and-beyond charged background pause. Every prior pairing had
+  // `aborted: false`.
   //
   // 'unknown-exit' should sit at ZERO: it means the bootstrap phase ended an
   // attempt in a way it cannot explain — no teardown, no error anyone caught —
@@ -406,6 +414,48 @@ export const SHARED_EVENTS = {
   // publishes no such frame, and removing a board from Storage reports its exit
   // as `Offline Board Toggled { enabled: false, source: 'storage' }` instead.
   OfflineBoardDownloadCancelled: 'Offline Board Download Cancelled',
+  // One artifact transfer that actually moved bytes — the per-download
+  // throughput measurement the funnel could not give us (issue #4394). Completed
+  // fires at SCOPE completion, omits `downloadMs` whenever the delta pull lands
+  // in a later cycle, and carries no transport dimension, so a slow transfer was
+  // invisible unless the whole scope finished in one cycle. A REUSED artifact
+  // fires nothing, so the denominator is always real network work.
+  //
+  // Named for the transfer, not for the strategy experiment: event names are
+  // permanent and the experiment is not. The props carry the dimensions.
+  //
+  // Props, all absent-when-unknown and never 0-when-unknown:
+  //   strategy: 'download-file-async' | 'task-foreground' | 'task-background' —
+  //     latched at transfer start, so a flag resolving mid-transfer cannot
+  //     mislabel it.
+  //   artifact: 'layout' | 'grades'.
+  //   boardType, layoutId — layout artifacts only (bounded cardinality); absent
+  //     for grades, whose manifest block carries neither.
+  //   outcome: 'completed' | 'failed' | 'aborted' ('aborted' = we cancelled it).
+  //   wireBytes — the stored object size, the same scale the confirm dialog and
+  //     the progress bar quote.
+  //   expectedDecodedBytes — `entry.uncompressedBytes`; absent on grades
+  //     artifacts and pre-#4311 manifest entries.
+  //   bytesOnDisk — the finished file's size; absent when there is no file.
+  //   wallMs — start of transfer to settle. INCLUDES suspension time when
+  //     `backgroundedDuringTransfer` is true.
+  //   firstByteMs — start to the first progress callback carrying bytes; absent
+  //     when none fired. Separates slow-to-start (DNS/TLS/CDN) from
+  //     slow-throughput.
+  //   wireKbps — wireBytes * 8 / wallMs, completed transfers only. WIRE scale
+  //     deliberately: it is the number directly comparable to the 15 Mbit/s
+  //     Safari and 1.3 Mbit/s in-app figures in #4394. Only meaningful when
+  //     `backgroundedDuringTransfer` is false — a suspended transfer's wallMs
+  //     includes wall-clock time nobody was downloading.
+  //   backgroundedDuringTransfer: boolean.
+  //   resumed: boolean — always false today; reserved so the resume follow-up
+  //     needs no new prop.
+  //   sizeMismatch: boolean — only present when expectedDecodedBytes was known
+  //     and could be compared.
+  //   metered: boolean — the adapter's cached NetInfo verdict; absent before
+  //     NetInfo has reported.
+  //   offlineEngineEnabled: boolean.
+  OfflineArtifactTransfer: 'Offline Artifact Transfer',
   // A board's offline switch was flipped, either way. Props: { scopeKey,
   // enabled: boolean, source: 'manage' | 'storage' | 'more' | 'adopt',
   // offlineEngineEnabled }. The enable half is the entry point #4318's discovery

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -114,6 +114,7 @@ export {
   SnapshotSchemaStaleError,
   SnapshotPermanentMissError,
   SnapshotWatermarkRegressionError,
+  SnapshotArtifactTruncatedError,
 } from './sync/snapshot-bootstrap';
 export type {
   SnapshotSource,

--- a/packages/shared/offline-sync/src/sync/__tests__/bootstrap-failure-reason.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/bootstrap-failure-reason.test.ts
@@ -11,6 +11,7 @@ import {
   SnapshotSchemaStaleError,
   SnapshotPermanentMissError,
   SnapshotWatermarkRegressionError,
+  SnapshotArtifactTruncatedError,
 } from '../snapshot-bootstrap';
 
 describe('classifySnapshotBootstrapFailure', () => {
@@ -63,6 +64,24 @@ describe('classifySnapshotBootstrapFailure', () => {
     for (const message of cases) {
       expect(classifySnapshotBootstrapFailure(new Error(message)), message).toBe('artifact-invalid');
     }
+  });
+
+  it('separates a SHORT body from a corrupt one', () => {
+    // A cut-short response is a transport symptom, not bad bytes, and the two
+    // spend different budgets — so they must not share a bucket either.
+    expect(
+      classifySnapshotBootstrapFailure(
+        new SnapshotArtifactTruncatedError(
+          'snapshot download: short body for kilter:1 (expected 269316096 bytes, got 4096)',
+        ),
+      ),
+    ).toBe('artifact-truncated');
+    // The pre-existing `truncated artifact` marker on a plain Error is untouched.
+    expect(
+      classifySnapshotBootstrapFailure(
+        new Error('snapshot bootstrap: board_climbs row_count 900 != actual 12 (truncated artifact?)'),
+      ),
+    ).toBe('artifact-invalid');
   });
 
   it('buckets a dropped connection as network', () => {

--- a/packages/shared/offline-sync/src/sync/__tests__/bootstrap-retry.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/bootstrap-retry.test.ts
@@ -32,6 +32,7 @@ import {
   type BootstrapFailureKind,
   type BootstrapRetryState,
 } from '../bootstrap-retry';
+import { SnapshotArtifactTruncatedError } from '../snapshot-bootstrap';
 import { runMigrations } from '../../db/migrations';
 import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
 
@@ -76,6 +77,19 @@ describe('classifyBootstrapFailure', () => {
     expect(classifyBootstrapFailure({ cause: new Error('quick_check failed'), stage: 'import' })).toBe(
       'structural-artifact',
     );
+  });
+
+  it('routes a SHORT body at the download stage to the transport budget', () => {
+    // A cut-short response is a transport symptom. `structural-device` would
+    // durably settle the scope onto the paged crawl after two occurrences with
+    // no `builtAt` re-arm — far too harsh for what is at least as likely a
+    // one-off network fluke as a systematic device fault (issue #4394).
+    const cause = new SnapshotArtifactTruncatedError(
+      'snapshot download: short body for kilter:1 (expected 269316096 bytes, got 4096)',
+    );
+    expect(classifyBootstrapFailure({ cause, stage: 'download' })).toBe('transport');
+    // At the IMPORT stage every failure is artifact-attributable, unchanged.
+    expect(classifyBootstrapFailure({ cause, stage: 'import' })).toBe('structural-artifact');
   });
 
   it('attributes an unclassifiable download failure to the DEVICE, not the artifact', () => {

--- a/packages/shared/offline-sync/src/sync/bootstrap-failure-reason.ts
+++ b/packages/shared/offline-sync/src/sync/bootstrap-failure-reason.ts
@@ -35,6 +35,8 @@ export type SnapshotBootstrapFailureReason =
   | 'permanent-miss'
   /** `quick_check` failed, `snapshot_meta` was missing/mismatched, or the row count did not add up. */
   | 'artifact-invalid'
+  /** The transfer finished but the body was the wrong length — a cut-short response, not corrupt bytes. */
+  | 'artifact-truncated'
   /** Offline, or the connection dropped. The normal state of a phone on a plane. */
   | 'network'
   /** Nothing above matched — the bucket that should stay near zero. */
@@ -72,6 +74,7 @@ export function classifySnapshotBootstrapFailure(cause: unknown): SnapshotBootst
   if (name === 'SnapshotSchemaStaleError') return 'schema-stale';
   if (name === 'SnapshotWatermarkRegressionError') return 'watermark-regression';
   if (name === 'SnapshotPermanentMissError') return 'permanent-miss';
+  if (name === 'SnapshotArtifactTruncatedError') return 'artifact-truncated';
 
   if (classifySqliteLockError(cause).locked) return 'database-locked';
 

--- a/packages/shared/offline-sync/src/sync/bootstrap-retry.ts
+++ b/packages/shared/offline-sync/src/sync/bootstrap-retry.ts
@@ -198,6 +198,13 @@ export function classifyBootstrapFailure(input: {
   stage: 'manifest' | 'download' | 'import';
 }): BootstrapFailureKind {
   if (input.stage === 'import') return 'structural-artifact';
+  // A short body is a cut-short RESPONSE, so it belongs on the transport ladder
+  // (3 tries, cleared by any success) rather than `structural-device`, where two
+  // occurrences would durably settle the scope onto the paged crawl with no
+  // `builtAt` re-arm — far too harsh for what is at least as likely a one-off
+  // network fluke as a systematic device fault. Ahead of `isNetworkError`, which
+  // does not match it. Issue #4394.
+  if (input.cause instanceof Error && input.cause.name === 'SnapshotArtifactTruncatedError') return 'transport';
   if (isNetworkError(input.cause)) return 'transport';
   return 'structural-device';
 }

--- a/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
@@ -282,6 +282,24 @@ export class SnapshotPermanentMissError extends Error {
   }
 }
 
+/**
+ * The transfer finished but wrote a different number of bytes than the manifest
+ * promises (issue #4394). `entry.uncompressedBytes` is exact — the export writes
+ * the SQLite file's own byte length — so this is an unambiguous integrity gate
+ * that the gzip magic-byte sniff (two bytes) and `quick_check` (after the file
+ * has been retained and ATTACHed) do not give.
+ *
+ * Charged to the TRANSPORT budget, not `structural-device`: a short body IS a
+ * cut-short response, and the structural ladder would durably settle a scope
+ * onto the paged crawl after two occurrences with no `builtAt` re-arm.
+ */
+export class SnapshotArtifactTruncatedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SnapshotArtifactTruncatedError';
+  }
+}
+
 // --- Attempt / done markers (sync_meta, NOT under the checkpoint: prefix so the
 // sign-out checkpoint wipe leaves them alone, matching the board rows they
 // describe, which survive as the shared cache) ---------------------------------


### PR DESCRIPTION
## Summary

Refs #4394. Refs #4390. Second of a 2-PR stack — **based on `fix/offline-download-survives-backgrounding` (#4400)**, which must merge first.

#4394 says in-app snapshot transfers run ~1.3 Mbit/s where Safari on the same phone and network runs ~15 Mbit/s. Nothing in that gap is diagnosable from a Linux box, so this ships the seam and the measurement rather than a blind swap.

### The strategy seam

New pure resolver `download-strategy.ts` maps two PostHog booleans plus `Platform.OS` to one of three transports:

| `offline-download-task-api` | `offline-download-background-session` | iOS | Android |
| --- | --- | --- | --- |
| unset or `false` | anything | `download-file-async` | `download-file-async` |
| `true` | unset or `true` | `task-background` | `task-foreground` |
| `true` | `false` | `task-foreground` | `task-foreground` |

Both arms are real, not relabels: Android ignores `sessionType` but a `DownloadTask` builds its **own** `OkHttpClient` (60 s timeouts), and on iOS the task sessions use `delegateQueue: .main` where the legacy `downloadFileAsync` store uses `nil` — so `task-foreground` doubles as a main-thread-contention probe at zero native cost.

`snapshot-source.ts` gains module-level `activeStrategy`, set by an effect in `use-snapshot-source.ts`. Module state rather than a factory on purpose: `mobileSnapshotSource`'s object identity is a dependency of the scheduler effect in `offline-sync-bridge.tsx`, so rebuilding the source when a flag resolves would restart the sync scheduler mid-download. The strategy is latched at the start of each transfer so a flag resolving mid-download cannot mislabel the measurement.

`runTransfer` is the only place the two APIs differ. The `download-file-async` arm is byte-for-byte today's call, including the exact options shape the `offline-download-progress` kill switch restores. The task arms pass `sessionType` **explicitly** on both (never relying on expo's `.background` default, so the label and the behaviour cannot drift) and release the native handle in a `finally` after the promise settles. A task that resolves `null` — which expo only does for a *paused* transfer, which we never request — is treated as a failed transfer, not a silent success.

### The measurement

New permanent `Offline Artifact Transfer` event, once per transfer that moved bytes (a reused artifact emits nothing, so the denominator is always real network work): `strategy`, `artifact`, `boardType`/`layoutId`, `outcome`, `wireBytes`, `expectedDecodedBytes`, `bytesOnDisk`, `wallMs`, `firstByteMs`, `wireKbps`, `backgroundedDuringTransfer`, `resumed`, `sizeMismatch`, `metered`, `offlineEngineEnabled`. Every prop is absent-when-unknown, never zero. `wireKbps` is deliberately **wire** scale — the number directly comparable to the 15 Mbit/s and 1.3 Mbit/s anchors in the issue — and is only meaningful where `backgroundedDuringTransfer = false`, since a suspended transfer's `wallMs` includes wall-clock time nobody was downloading. `firstByteMs` separates slow-to-start (DNS/TLS/CDN) from slow-throughput in three lines, without the extra round trip a HEAD probe would cost.

The funnel's `Offline Board Download Failed` gains one value in its closed `reason` union (`artifact-truncated`) — dashboards that *enumerate* reasons need it added; failure-rate queries pick it up on their own.

### The integrity gate

Before the `.complete` sidecar is written, the finished file's size is compared against `entry.uncompressedBytes` — exact, because the export writes `rawBuffer.length`, the SQLite file's own byte length. A mismatch deletes the file, reports a handled error, and throws the new `SnapshotArtifactTruncatedError`. It runs **after** the gzip sniff, so a still-compressed body keeps reporting `permanent-miss`, and **before** the sidecar, so a bad body can never be retained, reused or ATTACHed.

It spends the **transport** budget, not `structural-device`: a short body is a cut-short response, and `structural-device` would durably settle a scope onto the paged crawl after two occurrences with no `builtAt` re-arm — far too harsh for what is at least as likely a one-off network fluke.

Also: superseded partials are swept at the **top** of `downloadSnapshotFile`, before the free-space precheck (a 271 MB stale partial used to sit in the cache until the next download succeeded — which it might not, because that partial counted against the precheck), and a retained artifact's size is re-verified before its sidecar is trusted.

### Why continuation and not resume

Measured against the live CDN object on 2026-08-13: `Content-Encoding: gzip` comes back unconditionally (even under `Accept-Encoding: identity` — stored-object metadata, not negotiated), and `Range: bytes=0-15` returns `206` with `Content-Range: bytes 0-15/102416919` and a body starting `1f 8b`. **Range addresses encoded bytes**; both platforms write **decoded** bytes to disk. expo's Android resume computes its offset as the destination file's length (`FileSystemDownloadTask.kt:92`) and sends `Range: bytes=<decoded>-` (line 112) — provably wrong for every gzip artifact we publish, off by 2.6× on kilter:1, with no JS-side fix. iOS `resumeData` validity over a `Content-Encoding` response cannot be established off-device. Persisted pause/resume is therefore deferred and documented in `docs/board-snapshots.md` so nobody "just turns resume on"; the size gate landing here is the precondition that would make it safe.

## Decisions for Marco

Plan decisions flagged `needsMarco`, landing on the chosen default:

- **What downloader ships as the default when the PostHog flags have not resolved?** → **Today's `File.downloadFileAsync`, on BOTH platforms.** The DownloadTask transports go live by setting `offline-download-task-api` in PostHog, staged 10% → 50% → 100%, after the device QA below passes. Reason: production OTAs auto-publish on every push to `main`, and a PostHog key that does not exist yet reads `undefined` on every device, so an "undefined → background session" default would have flipped the whole iOS fleet the hour this merged. The downside is not symmetric — a background `URLSession` runs out of `nsurlsessiond`, a different process from the in-process sessions the gzip cutover was validated against, and if it does not transparently gunzip, `snapshot-source` raises `SnapshotPermanentMissError`, which at the download stage burns the structural budget **and** marks the paged fallback, a durable settle that flipping the flag back does not undo. The cost: **#4390's iOS transport half is not live at merge.** PR 1 fixes Android at merge and stops iOS burning attempts everywhere; iOS continuation arrives with the flag.
- **Add a new permanent analytics event for per-transfer throughput?** → **Yes, `Offline Artifact Transfer`.** The existing funnel cannot answer #4394: `Completed` fires at scope completion, omits `downloadMs` whenever the delta pull lands in a later cycle, and has no strategy dimension, so a slow transfer is invisible unless the whole scope finishes in one cycle. Event names are permanent, so the name is about the transfer rather than the strategy experiment.
- **How do we test the iOS Low Data Mode / constrained-network hypothesis (#4394's top-ranked suspect)?** → **Device QA toggle first (free, two minutes); the code-level fix is `[native-train]`, never on `main`.** `allowsConstrainedNetworkAccess` / `allowsExpensiveNetworkAccess` / `networkServiceType` / `delegateQueue` all live in expo-file-system's Swift, so touching them means a bun patch or an upstream PR and a new native fingerprint.

## Release Notes

- We now measure how fast every board download actually runs, so we can chase the slow ones instead of guessing, and we check each downloaded board is complete before using it.
- Faster download paths for iPhone are behind a switch we'll turn on once we've timed them on real phones.

## Test plan

Local, all foreground, all green:

- `vp run typecheck:mobile` — pass
- `vp run typecheck:shared` — pass
- `vp test run --project offline-sync --reporter=agent` — 29 files, 621 tests passed
- `vp run test:mobile` — 647 files, 5930 tests passed
- `vp run check:mobile-bundle` — `android bundle: OK`
- `vp check` on every changed file — 0 errors

New coverage:

- `download-strategy.test.ts` (pure, no RN in the graph): the full matrix, including the corner an unset `taskApiFlag` resolves through — `download-file-async` on iOS **and** Android for `backgroundSessionFlag` of `undefined`/`true`/`false`; `true` + unset/true → `task-background` on iOS, `task-foreground` on Android; `true` + `false` → `task-foreground` everywhere; an unknown platform string never yields `task-background`.
- `snapshot-source.test.ts` (+26 cases; the expo fake gained a `createDownloadTask` arm and a controllable on-disk size): the default calls `downloadFileAsync` with exactly `{ idempotent: true, signal }` and the four-key object when progress is asked for; the task arms pass `sessionType` `background`/`foreground` and never touch `downloadFileAsync`; `release()` runs on both the success and the throw path; a task resolving `null` throws; a short body is deleted, gets no sidecar and throws `SnapshotArtifactTruncatedError`; a matching size writes the sidecar exactly as today; an entry with no `uncompressedBytes` skips the gate; an identity entry gates on `entry.bytes`; the gzip sniff still wins over the size gate; a truncated retained artifact is re-downloaded while a matching one is still reused; a superseded older-`builtAt` artifact is swept and a different layout is left alone; the transfer event carries `strategy`/`wireBytes`/`wallMs`/`outcome`, omits `firstByteMs` when no callback fired, reports `aborted` vs `failed`, and emits nothing for a reused artifact or a refused precheck.
- `bootstrap-failure-reason.test.ts`: `SnapshotArtifactTruncatedError` → `artifact-truncated`; the pre-existing `truncated artifact` message marker still → `artifact-invalid`.
- `bootstrap-retry.test.ts`: `classifyBootstrapFailure` returns `transport` for it at the download stage and `structural-artifact` at the import stage.
- `offline-sync-bridge.test.tsx` and `use-snapshot-source.test.tsx`: the resolved flags reach `setSnapshotDownloadStrategyFromFlags` and the source's identity is unchanged.

**Not provable in CI — needs a real phone.** Every task-strategy step starts by setting the flag in More → Feature Flags; Kilter layout 1 (102,416,919 wire / 269,316,096 decoded bytes) is the test artifact throughout.

1. **Background survival (iOS, flag ON)** — start the download, lock the screen 3 minutes, unlock. Progress resumes near where it was, the download completes, and PostHog shows an `Offline Artifact Transfer` with `backgroundedDuringTransfer: true, outcome: 'completed', strategy: 'task-background'`.
2. **Gzip decode on the background session** — the highest-blast-radius unknown, and it must be checked explicitly rather than inferred from "it completed": confirm Sentry has no new `snapshot artifact arrived still gzip-compressed` from that session, and no `reason: 'permanent-miss'` for any layout. If it fires, the flag stays off and the rollout stops.
3. **#4394 A/B on Marco's device** — three timed runs of the same artifact on the same wifi in one session: flag off; on + background-session off; on + background-session default. Record `wireKbps` and `firstByteMs` (all three must show `backgroundedDuringTransfer: false` — keep the screen on). Then open the same URL in Safari on the same phone in the same minute and time it.
4. **Low Data Mode** — Settings → Wi-Fi → (i) → Low Data Mode on, one run; off, one run; same strategy both times. A large delta promotes the `[native-train]` `allowsConstrainedNetworkAccess` work; no delta rules it out.
5. **Android transport** — flag on (resolves to `task-foreground`, a different OkHttpClient), record `wireKbps`. Android's 8m52s p50 is the bigger throughput prize.
6. **Progress bar (#4355)** — on every run the bar advances smoothly, never exceeds 100%, and shows wire-scale MB (~103 MB, never ~269 MB).
7. **Termination gap (document, do not fix)** — flag on, start, background, force-quit, reopen: the download restarts from 0 with no Sentry error and at most one aborted `Failed`.
8. **Guard rails** — no `sizeMismatch: true` and no `reason: 'artifact-truncated'` on any clean run; zero `reason: 'unknown-exit'` across the whole session.

### Rollout

Merge with both flags absent (the shipped path everywhere) and confirm from `Offline Artifact Transfer` that 100% of transfers report `strategy: 'download-file-async'` before touching anything. Then create `offline-download-task-api` in PostHog and take iOS to 10% for 24 h, 50% for 48 h, then 100%, watching `sizeMismatch`, `reason: 'permanent-miss'`, the gzip-compressed Sentry error and p50/p90 `wireKbps` at every step. Keep a permanent 10–20% holdout at `false` as the control arm, and give Android its own 20% arm.
