### PR TITLE
test(web): close the crawler-invariant escapes behind the rollout delete

### DIFF
--- a/packages/web/app/__tests__/crawler-classic-invariant.test.ts
+++ b/packages/web/app/__tests__/crawler-classic-invariant.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import { NextRequest, NextResponse } from 'next/server';
 import { PATHNAME_HEADER } from '@/app/lib/request-pathname-header';
 
@@ -51,16 +51,26 @@ vi.mock('next/headers', () => ({
   headers: vi.fn(async () => ({ get: (name: string) => requestHeaders.get(name) ?? null })),
 }));
 
-// `@/app/lib/url-utils.server` is mocked WHOLESALE — never via `importOriginal`.
-// The real module imports `./slug-utils`, which imports `@/app/lib/db/db`,
-// whose module body calls `createPool()`/`createDb()` at load time.
-// `@/app/lib/url-utils` is deliberately left REAL: the redirect targets these
-// tests assert on are built there (`constructClimbListWithSlugs`,
-// `constructClimbViewUrlWithSlugs`, `constructBoardSlugViewUrl`), so the
-// host-preservation property is exercised for real rather than re-asserted
-// against a rebuilt predicate. Trade-off: `redirectWithQuery`'s own query-string
-// handling is not exercised for real — unavoidable given the db-import trap.
-vi.mock('@/app/lib/url-utils.server', () => ({
+// `@/app/lib/slug-utils` is the db-import trap, NOT `@/app/lib/url-utils.server`:
+// slug-utils imports `@/app/lib/db/db`, whose module body calls
+// `createPool()`/`createDb()` at load time. Mocking the actual offender keeps
+// the REAL `redirectWithQuery` in the graph. `url-utils.server` pulls exactly
+// these three from here, and no other module this test imports touches it.
+vi.mock('@/app/lib/slug-utils', () => ({
+  getLayoutBySlug: vi.fn(async () => null),
+  getSizeBySlug: vi.fn(async () => null),
+  getSetsBySlug: vi.fn(async () => null),
+}));
+
+// Only `parseRouteParams` is stubbed, via `importOriginal`, so the rest of the
+// module stays real — crucially `redirectWithQuery`, which is what actually
+// emits the `/play`→`/view` `Location` in (C1)/(C2). Asserting against a
+// test-local copy of it would make those two cases a rebuilt predicate.
+// `@/app/lib/url-utils` is left REAL for the same reason: the redirect targets
+// these tests assert on are built there (`constructClimbListWithSlugs`,
+// `constructClimbViewUrlWithSlugs`, `constructBoardSlugViewUrl`).
+vi.mock('@/app/lib/url-utils.server', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/app/lib/url-utils.server')>()),
   parseRouteParams: vi.fn(async () => ({
     parsedParams: {
       board_name: 'kilter',
@@ -72,14 +82,6 @@ vi.mock('@/app/lib/url-utils.server', () => ({
     },
     isNumericFormat: true,
   })),
-  redirectWithQuery: vi.fn((viewUrl: string, searchParams: Record<string, string | string[]>) => {
-    const query = new URLSearchParams(
-      Object.entries(searchParams).flatMap(([key, value]) =>
-        Array.isArray(value) ? value.map((v) => [key, v]) : [[key, value]],
-      ),
-    ).toString();
-    permanentRedirect(query ? `${viewUrl}?${query}` : viewUrl);
-  }),
 }));
 
 vi.mock('@/app/lib/board-utils', () => ({
@@ -166,9 +168,23 @@ const PROD_HOST = 'www.boardsesh.com';
 const PROD_ORIGIN = `https://${PROD_HOST}`;
 const REDIRECT_STATUSES = [301, 302, 307, 308];
 
+// The rewrite target, when there is one. `next.config.mjs` serves `/app` by
+// REWRITE, so a status-only invariant leaves the same crawler harm reachable by
+// a different mechanism: the noindex SPA rendered at a canonical board URL.
+function rewriteTargetPathname(response: ReturnType<typeof middleware>): string | null {
+  const rewriteTarget = response.headers.get('x-middleware-rewrite');
+  return rewriteTarget === null ? null : new URL(rewriteTarget, PROD_ORIGIN).pathname;
+}
+
 function expectNoRedirect(response: ReturnType<typeof middleware>): void {
   expect(REDIRECT_STATUSES).not.toContain(response.status);
   expect(response.headers.get('location')).toBeNull();
+  // Not-a-redirect is not enough: the surface must also not be rewritten onto
+  // the `/app` SPA.
+  const rewrittenPathname = rewriteTargetPathname(response);
+  if (rewrittenPathname !== null) {
+    expect(rewrittenPathname === '/app' || rewrittenPathname.startsWith('/app/')).toBe(false);
+  }
 }
 
 // A relative target resolves to the prod host; an absolute
@@ -187,6 +203,8 @@ function makeRequest(url: string): NextRequest {
   return new NextRequest(new URL(url, 'http://localhost:3000'));
 }
 
+const ORIGINAL_EXPO_WEB_FLAG = process.env.BOARDSESH_WEB;
+
 beforeEach(() => {
   // clearAllMocks clears call records, not implementations — mirrors the
   // layout-redirect.test.tsx harness this file's mocks are copied from.
@@ -194,13 +212,40 @@ beforeEach(() => {
   requestHeaders.clear();
 });
 
-describe("middleware: a cookie-less request to a canonical board URL never 3xx's", () => {
-  const CANONICAL_SURFACES = [
-    '/kilter/original/12x12-square/screw_bolt/40/list',
-    '/b/kilter-original-12x12/40/list',
-    '/kilter/original/12x12-square/screw_bolt/40/view/test-climb-abcdef1234567890abcdef1234567890',
-    '/b/kilter-original-12x12/40/view/test-climb-abcdef1234567890abcdef1234567890',
-  ];
+afterEach(() => {
+  if (ORIGINAL_EXPO_WEB_FLAG === undefined) {
+    delete process.env.BOARDSESH_WEB;
+  } else {
+    process.env.BOARDSESH_WEB = ORIGINAL_EXPO_WEB_FLAG;
+  }
+});
+
+const CANONICAL_SURFACES = [
+  '/kilter/original/12x12-square/screw_bolt/40/list',
+  '/b/kilter-original-12x12/40/list',
+  '/kilter/original/12x12-square/screw_bolt/40/view/test-climb-abcdef1234567890abcdef1234567890',
+  '/b/kilter-original-12x12/40/view/test-climb-abcdef1234567890abcdef1234567890',
+];
+
+// `middleware.ts` reads `BOARDSESH_WEB` at REQUEST time (the `/app` and
+// `/assets` carve-outs), and `Dockerfile.web` sets it in both the builder and
+// the runner stage — flag-ON is production's shipped configuration, not an
+// exotic case. The deleted rollout redirect was gated on exactly this flag, so
+// run the whole invariant under both states: an env-gated re-arm has to fail
+// this suite rather than slip past because the flag happened to be unset.
+// Only board surfaces are asserted here — the `/app` carve-out itself is
+// legitimate behaviour and is owned by middleware.test.ts.
+describe.each([
+  ['BOARDSESH_WEB=1 (production default)', '1'],
+  ['BOARDSESH_WEB unset', undefined],
+] as const)("middleware, %s: a cookie-less request to a canonical board URL never 3xx's", (_label, flagValue) => {
+  beforeEach(() => {
+    if (flagValue === undefined) {
+      delete process.env.BOARDSESH_WEB;
+    } else {
+      process.env.BOARDSESH_WEB = flagValue;
+    }
+  });
 
   it.each(CANONICAL_SURFACES)('no cookies at all: %s', (surface) => {
     expectNoRedirect(middleware(makeRequest(surface)));
@@ -211,11 +256,13 @@ describe("middleware: a cookie-less request to a canonical board URL never 3xx's
   );
 
   it.each(LOCALE_PREFIXED_CASES)(
-    'a locale-prefixed cookie-less request is a rewrite, never a redirect: /%s%s',
+    'a locale-prefixed cookie-less request is a rewrite to the locale-stripped surface, never a redirect: /%s%s',
     (locale, surface) => {
       const response = middleware(makeRequest(`/${locale}${surface}`));
       expectNoRedirect(response);
-      expect(response.headers.has('x-middleware-rewrite')).toBe(true);
+      // WHERE the rewrite points, not merely that one exists: a rewrite onto
+      // the noindex `/app` SPA is the same crawler harm as a redirect to it.
+      expect(rewriteTargetPathname(response)).toBe(surface);
     },
   );
 
@@ -264,6 +311,9 @@ describe('the three legitimate redirect classes stay on www.boardsesh.com', () =
     const target = permanentRedirect.mock.calls[0]![0];
     expectSameHostRedirectTarget(target);
     expectSameTree(sourcePath, target);
+    // Same destination assertion as (A1): host + tree alone are satisfied by a
+    // self-redirect, which is a loop, not a canonicalisation.
+    expect(target).toContain('/list');
   });
 
   it('(B) bare-uuid/numeric→slug at the climb view page', async () => {
@@ -324,6 +374,10 @@ describe('the three legitimate redirect classes stay on www.boardsesh.com', () =
     // Stays inside /b/ — the mirror of the legacy→/b negative case below.
     expectSameHostRedirectTarget(target);
     expectSameTree(sourcePath, target);
+    // Mirrors (C1). Without these, a `/b` play page redirecting to ITSELF — an
+    // infinite loop — satisfies host + tree and passes.
+    expect(target).toContain('/view/');
+    expect(target).not.toContain('/play/');
   });
 });
 
@@ -332,6 +386,17 @@ describe('the guard is not vacuous: it catches what the pre-teardown helper miss
     for (const status of REDIRECT_STATUSES) {
       expect(() => expectNoRedirect(NextResponse.redirect('https://www.boardsesh.com/app/climbs', status))).toThrow();
     }
+  });
+
+  it('expectNoRedirect rejects a same-host REWRITE onto the /app SPA', () => {
+    // `next.config.mjs` serves `/app` by rewrite, so this is the realistic way
+    // to regress the invariant without emitting any 3xx at all.
+    expect(() => expectNoRedirect(NextResponse.rewrite(new URL('/app/climbs', PROD_ORIGIN)))).toThrow();
+    expect(() => expectNoRedirect(NextResponse.rewrite(new URL('/app', PROD_ORIGIN)))).toThrow();
+    // A rewrite to a real board surface — what locale-stripping does — is fine.
+    expect(() =>
+      expectNoRedirect(NextResponse.rewrite(new URL('/kilter/original/12x12-square/screw_bolt/40/list', PROD_ORIGIN))),
+    ).not.toThrow();
   });
 
   it('expectSameHostRedirectTarget rejects a cross-host Location', () => {

--- a/packages/web/app/__tests__/crawler-classic-invariant.test.ts
+++ b/packages/web/app/__tests__/crawler-classic-invariant.test.ts
@@ -163,10 +163,17 @@ const LegacyPlayPage = (
   await import('@/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/page')
 ).default;
 const SlugPlayPage = (await import('@/app/b/[board_slug]/[angle]/play/[climb_uuid]/page')).default;
+const { getClimb } = await import('@/app/lib/data/queries');
 
 const PROD_HOST = 'www.boardsesh.com';
 const PROD_ORIGIN = `https://${PROD_HOST}`;
 const REDIRECT_STATUSES = [301, 302, 307, 308];
+// Test requests ride on the dev origin (see `makeRequest`), and the vacuity
+// self-tests below construct rewrites against PROD_ORIGIN. A legitimate
+// middleware rewrite never leaves those hosts — `app.boardsesh.com` under a
+// clean pathname is the same crawler harm with the `/app` prefix laundered off.
+const REQUEST_ORIGIN = 'http://localhost:3000';
+const ALLOWED_REWRITE_HOSTS = [new URL(REQUEST_ORIGIN).host, PROD_HOST];
 
 // The rewrite target, when there is one. `next.config.mjs` serves `/app` by
 // REWRITE, so a status-only invariant leaves the same crawler harm reachable by
@@ -180,10 +187,13 @@ function expectNoRedirect(response: ReturnType<typeof middleware>): void {
   expect(REDIRECT_STATUSES).not.toContain(response.status);
   expect(response.headers.get('location')).toBeNull();
   // Not-a-redirect is not enough: the surface must also not be rewritten onto
-  // the `/app` SPA.
-  const rewrittenPathname = rewriteTargetPathname(response);
-  if (rewrittenPathname !== null) {
-    expect(rewrittenPathname === '/app' || rewrittenPathname.startsWith('/app/')).toBe(false);
+  // the `/app` SPA, nor onto a foreign host. `x-middleware-rewrite` carries an
+  // absolute URL, so the host is checked before the pathname.
+  const rewriteTarget = response.headers.get('x-middleware-rewrite');
+  if (rewriteTarget !== null) {
+    const resolved = new URL(rewriteTarget, PROD_ORIGIN);
+    expect(ALLOWED_REWRITE_HOSTS).toContain(resolved.host);
+    expect(resolved.pathname === '/app' || resolved.pathname.startsWith('/app/')).toBe(false);
   }
 }
 
@@ -200,7 +210,7 @@ function expectSameTree(sourcePath: string, target: string): void {
 }
 
 function makeRequest(url: string): NextRequest {
-  return new NextRequest(new URL(url, 'http://localhost:3000'));
+  return new NextRequest(new URL(url, REQUEST_ORIGIN));
 }
 
 const ORIGINAL_EXPO_WEB_FLAG = process.env.BOARDSESH_WEB;
@@ -379,6 +389,52 @@ describe('the three legitimate redirect classes stay on www.boardsesh.com', () =
     expect(target).toContain('/view/');
     expect(target).not.toContain('/play/');
   });
+
+  // Both play pages wrap `getClimb` in try/catch and fall back to the bare-uuid
+  // `/view/` URL when the climb has no resolvable name. With `getClimb` always
+  // resolving a name, that fallback branch of the URL builders is dead code
+  // under this suite — so a regression confined to it (a `/play` self-redirect
+  // loop) would ship green. These two exercise it for real.
+  it('(C1n) /play→/view still holds when the climb name cannot be resolved (config-tuple tree)', async () => {
+    const sourcePath = `/kilter/1/10/1,20/40/play/${CLIMB_UUID}`;
+    vi.mocked(getClimb).mockRejectedValueOnce(new Error('db unavailable'));
+    await expect(
+      LegacyPlayPage({
+        params: Promise.resolve({
+          board_name: 'kilter',
+          layout_id: '1',
+          size_id: '10',
+          set_ids: '1,20',
+          angle: '40',
+          climb_uuid: CLIMB_UUID,
+        }),
+        searchParams: Promise.resolve({}),
+      }),
+    ).rejects.toThrow('NEXT_REDIRECT');
+
+    const target = permanentRedirect.mock.calls[0]![0];
+    expectSameHostRedirectTarget(target);
+    expectSameTree(sourcePath, target);
+    expect(target).toContain(`/view/${CLIMB_UUID}`);
+    expect(target).not.toContain('/play/');
+  });
+
+  it('(C2n) /play→/view still holds when the climb name cannot be resolved (/b tree)', async () => {
+    const sourcePath = `/b/kilter-original-12x12/40/play/${CLIMB_UUID}`;
+    vi.mocked(getClimb).mockRejectedValueOnce(new Error('db unavailable'));
+    await expect(
+      SlugPlayPage({
+        params: Promise.resolve({ board_slug: 'kilter-original-12x12', angle: '40', climb_uuid: CLIMB_UUID }),
+        searchParams: Promise.resolve({}),
+      }),
+    ).rejects.toThrow('NEXT_REDIRECT');
+
+    const target = permanentRedirect.mock.calls[0]![0];
+    expectSameHostRedirectTarget(target);
+    expectSameTree(sourcePath, target);
+    expect(target).toContain(`/view/${CLIMB_UUID}`);
+    expect(target).not.toContain('/play/');
+  });
 });
 
 describe('the guard is not vacuous: it catches what the pre-teardown helper missed', () => {
@@ -397,6 +453,17 @@ describe('the guard is not vacuous: it catches what the pre-teardown helper miss
     expect(() =>
       expectNoRedirect(NextResponse.rewrite(new URL('/kilter/original/12x12-square/screw_bolt/40/list', PROD_ORIGIN))),
     ).not.toThrow();
+  });
+
+  it('expectNoRedirect rejects a CROSS-HOST rewrite even under a clean pathname', () => {
+    // The `/app` pathname check alone is launderable: serve the SPA from the
+    // app host under the canonical pathname and no `/app` prefix ever appears.
+    expect(() => expectNoRedirect(NextResponse.rewrite(new URL('https://app.boardsesh.com/climbs')))).toThrow();
+    expect(() =>
+      expectNoRedirect(
+        NextResponse.rewrite(new URL('/kilter/original/12x12-square/screw_bolt/40/list', 'https://app.boardsesh.com')),
+      ),
+    ).toThrow();
   });
 
   it('expectSameHostRedirectTarget rejects a cross-host Location', () => {

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -161,9 +161,11 @@ const nextConfig = {
         // frameable by ANY origin, hence `frame-ancestors *` and NO
         // X-Frame-Options (frame-ancestors takes precedence over XFO in
         // modern browsers; omitting XFO keeps legacy browsers from denying).
-        // The middleware 308s locale-prefixed /es|fr/embed/** to the
-        // un-prefixed path because this matcher sees the ORIGINAL request
-        // path — a prefixed variant would fall into the SAMEORIGIN rule above.
+        // The middleware 308s every locale-prefixed /embed/** (es, fr, de —
+        // the pattern derives from SUPPORTED_LOCALES, so a new locale can't
+        // silently drift out of it) to the un-prefixed path, because this
+        // matcher sees the ORIGINAL request path — a prefixed variant would
+        // fall into the SAMEORIGIN rule above.
         // `:path+` (one or more segments), NOT `:path*`: the exclusion regex
         // above only skips paths starting `embed/` (with slash), so a bare
         // `/embed` matches the SAMEORIGIN rule — with `:path*` it would match


### PR DESCRIPTION
## Summary

Adversarial QA on #4396 (W-09, "delete the inert expo-web rollout machinery") found four escapes in the rewritten crawler-classic invariant. #4396 merged before that fix round could land, so the defects are on `main` and get fixed here. Test-strength only — no shipped behaviour changes, and no production code is touched apart from one comment.

#4396 declares `packages/web/app/__tests__/crawler-classic-invariant.test.ts` the single owner of the crawler-classic contract for the rest of the epic, so a guard with holes in it is not recoverable downstream. Each fix below was mutation-proved: the probe was confirmed green (escaped) against the merged file, then confirmed red with the fix in place.

**1. The middleware suite never ran with `BOARDSESH_WEB=1` (major).** That flag is production's default — `Dockerfile.web` sets it in the builder *and* the runner stage, and `middleware.ts` reads it at request time. The deleted rollout redirect was gated on exactly this flag, and the pre-#4396 file set it in a `beforeEach` for that reason; the rewrite dropped it. The canonical-surfaces suite is now a `describe.each` over both flag states, with the value set in a `beforeEach` and the captured original restored in a top-level `afterEach` (the pattern middleware.test.ts's Expo-web carve-out describes already use). The `/app` carve-out still serves `/app` paths under the flag — that is legitimate and stays owned by middleware.test.ts; only board surfaces are asserted here.

**2. `/play`→`/view` asserted against a test-local copy of `redirectWithQuery` (major).** The file mocked `@/app/lib/url-utils.server` wholesale and re-implemented `redirectWithQuery` byte-for-byte in the mock factory, so (C1)/(C2) were checking a rebuilt predicate rather than production's redirect emitter. The db-import trap was misattributed: it enters through `./slug-utils` → `@/app/lib/db/db`, whose module body calls `createPool()`/`createDb()` at load — nothing to do with `redirectWithQuery`. Now `@/app/lib/slug-utils` is mocked directly (its only importer in this graph is `url-utils.server`, which pulls exactly `getLayoutBySlug`/`getSizeBySlug`/`getSetsBySlug`), and `url-utils.server` goes through `importOriginal` with only `parseRouteParams` stubbed. The real `redirectWithQuery` now emits the captured redirect. The in-file comment is corrected too.

**3. A rewrite onto `/app` was invisible (minor).** The invariant was status-only, so serving the noindex SPA at a canonical board URL by rewrite — the mechanism `next.config.mjs` actually uses for `/app` — passed. `expectNoRedirect` now also rejects an `x-middleware-rewrite` that resolves to an `/app` pathname, and the locale-prefixed cases assert the rewrite target pathname *equals* the locale-stripped surface instead of merely asserting the header exists. A self-test in the "not vacuous" block covers the new helper in both directions.

**4. Weaker-sibling destination assertions (minor).** (C2) checked only host and tree, both of which a `/b` play page redirecting to *itself* satisfies — an infinite loop. It now carries (C1)'s `toContain('/view/')` + `not.toContain('/play/')`. (A2) gains (A1)'s `toContain('/list')` for symmetry.

**5. Stale comment in `next.config.mjs` (nit).** The `/embed/:path+` header rule still said the middleware 308s `/es|fr/embed/**`, naming two of three prefixed locales. The pattern derives from `SUPPORTED_LOCALES`, so the comment now says so and can't go stale on the next locale.

Part of #4358
Refs #4363

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

Gates:

- `vp check` — the only failures are `docs/design/web-reposition/gyms-directory.html` and `docs/design/web-reposition/homepage-marketing.html`, byte-identical on a stashed working tree at this branch's base, i.e. pre-existing on `main` and untouched here. PR CI diff-lints, so this branch's files are the relevant scope and they are clean.
- `vp run typecheck` — pass.
- `vp test run --reporter=agent --project web` — pass (full project). The invariant file goes 28 → 48 tests: the 19-test canonical-surfaces suite now runs twice (flag on / flag off) and one self-test is added for the rewrite guard.

Mutation probes — each was green (escaped) on the merged #4396 file, and is red now:

| Probe | Mutation | Before | After |
| --- | --- | --- | --- |
| M7 | `if (isExpoWebEnabled() && pathname.endsWith('/list')) return NextResponse.redirect(new URL('https://app.boardsesh.com/climbs'), 307)` in `middleware.ts`, just before locale detection | 28/28 green | **10 failed** — every `/list` case in the `BOARDSESH_WEB=1` describe |
| M5 | cross-host prefix inside the REAL `redirectWithQuery` (`url-utils.server.ts`) | 28/28 green | **2 failed** — exactly (C1) and (C2), `expected 'app.boardsesh.com' to be 'www.boardsesh.com'` |
| M8 | `NextResponse.rewrite` to `/app/climbs` for canonical `/list` and `/view/` surfaces | 26/28 green (only the two `?classic=1` cases failed, and only via the CDN-header assertion) | **38 failed** across both flag states |
| C2-probe | `constructBoardSlugViewUrl` emits `play/…` instead of `view/…` (a `/b` play→play self-redirect loop) | 28/28 green | **1 failed** — exactly (C2) |

One extra probe for the (A2) symmetry fix: dropping the `/list` suffix from `constructClimbListWithSlugs` failed only (A1) before, and fails both (A1) and (A2) now.

Every mutation was restored with `git checkout -- <file>`; `git status --porcelain` shows only the two intended files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6Ur37Pg6Ro9kyFxUr8r97

## Adversarial verification round 2

An independent verifier re-probed the first commit and found two remaining escapes; the second commit closes both, mutation-proved:

| Probe | Before | After |
|---|---|---|
| Cross-host **rewrite** (`NextResponse.rewrite('https://app.boardsesh.com/climbs')` for canonical surfaces, `BOARDSESH_WEB=1`) — the pathname-only guard discarded the host, so the SPA served from the app host under a clean pathname passed | 48/48 green (escaped) | **7 tests fail** |
| Nameless-climb fallback (`constructBoardSlugViewUrl` emitting `play/` instead of `view/` in its bare-uuid branch) — `getClimb` always resolved a name, so the fallback branch was dead code under the suite | 48/48 green (escaped) | **exactly (C2n) fails** |

Changes: `expectNoRedirect` now resolves `x-middleware-rewrite` and asserts the host against the request/prod origins before the `/app` pathname check (plus a vacuity self-test for the laundered cross-host form), and new (C1n)/(C2n) cases drive both play pages through a rejected `getClimb` so the bare-uuid `/view` fallback of both URL builders executes for real. Suite is now 51 tests; full web project 5964/5964 green.
