### PR TITLE
fix(web): finish the id-aware climb URL emission and lock the slug round-trip

### DIFF
--- a/packages/web/app/components/activity-feed/__tests__/ascent-thumbnail-url.test.tsx
+++ b/packages/web/app/components/activity-feed/__tests__/ascent-thumbnail-url.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vite-plus/test';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import type { RenderBoardConfig } from '@boardsesh/shared-schema';
+import AscentThumbnail from '../ascent-thumbnail';
+
+vi.mock('@/app/components/i18n/locale-link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
+}));
+
+// The thumbnail itself is irrelevant here — only the href it wraps is.
+vi.mock('@/app/components/board-renderer/board-image-layers', () => ({ default: () => null }));
+vi.mock('@/app/components/board-renderer/board-canvas-renderer', () => ({ default: () => null }));
+vi.mock('@/app/lib/board-render-worker/worker-manager', () => ({ useCanvasRendererReady: () => false }));
+vi.mock('../ascents-feed.module.css', () => ({
+  default: new Proxy({}, { get: (_target, prop) => String(prop) }),
+}));
+
+/**
+ * Kilter layout 1 carries two "12 x 12" squares — id 10 ("with kickboard") and
+ * id 27 ("without kickboard") — that both *name*-slug to `12x12-square`. The
+ * feed's `renderBoard` prop is the board the backend resolved for this ascent
+ * (the one it was logged on), so the thumbnail holds the numeric ids and must
+ * address the exact wall. Before #4417 it slugged from names and pointed a
+ * size-27 climber's own thumbnail at size 10's board.
+ *
+ * Same shape as `board-page/__tests__/header-create-url.test.tsx`, which locks
+ * the equivalent invariant for the header's Create button.
+ */
+function thumbnailHref(renderBoard: RenderBoardConfig) {
+  render(
+    <AscentThumbnail
+      boardType="kilter"
+      layoutId={1}
+      angle={40}
+      climbUuid="ABC123"
+      climbName="Test Climb"
+      frames="p1080r15"
+      isMirror={false}
+      renderBoard={renderBoard}
+    />,
+  );
+
+  return screen.getByRole('link').getAttribute('href');
+}
+
+describe('AscentThumbnail climb-view href', () => {
+  it('emits the qualified size slug for the shadowed size the ascent was logged on', () => {
+    expect(thumbnailHref({ layoutId: 1, sizeId: 27, setIds: [1, 20] })).toBe(
+      '/kilter/original/12x12-square-without-kickboard/screw_bolt/40/view/test-climb-ABC123',
+    );
+  });
+
+  it('leaves the size that owns the bare slug on it', () => {
+    expect(thumbnailHref({ layoutId: 1, sizeId: 10, setIds: [1, 20] })).toBe(
+      '/kilter/original/12x12-square/screw_bolt/40/view/test-climb-ABC123',
+    );
+  });
+});

--- a/packages/web/app/components/activity-feed/ascent-thumbnail.tsx
+++ b/packages/web/app/components/activity-feed/ascent-thumbnail.tsx
@@ -9,7 +9,7 @@ import { useCanvasRendererReady } from '@/app/lib/board-render-worker/worker-man
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { getDefaultBoardConfig } from '@/app/lib/default-board-configs';
 import type { RenderBoardConfig } from '@boardsesh/shared-schema';
-import { constructClimbViewUrlWithSlugs, constructClimbViewUrl } from '@/app/lib/url-utils';
+import { constructClimbViewUrlWithSlugs, constructClimbViewUrl, tryConstructSlugViewUrl } from '@/app/lib/url-utils';
 import styles from './ascents-feed.module.css';
 
 type AscentThumbnailProps = {
@@ -66,6 +66,23 @@ const AscentThumbnail: React.FC<AscentThumbnailProps> = ({
   // Reuse the already-memoized boardDetails to build the climb view URL
   const climbViewPath = useMemo(() => {
     if (!boardDetails || !layoutId) return null;
+
+    // Id-aware first: `renderBoard` is the board this ascent was actually
+    // logged on, which can be a size that shares its base slug with another
+    // on the same layout (Kilter layout 1 sizes 10/27 — see `resolveSizeSlug`).
+    // Slugging from names alone would link this climber's own thumbnail to
+    // the OTHER physical board. Names stay the fallback for a board the
+    // static tables don't carry.
+    const idAwarePath = tryConstructSlugViewUrl(
+      boardDetails.board_name,
+      boardDetails.layout_id,
+      boardDetails.size_id,
+      boardDetails.set_ids,
+      angle,
+      climbUuid,
+      climbName,
+    );
+    if (idAwarePath) return idAwarePath;
 
     if (boardDetails.layout_name && boardDetails.size_name && boardDetails.set_names) {
       return constructClimbViewUrlWithSlugs(

--- a/packages/web/app/components/new-climb-feed/new-climb-feed-item.tsx
+++ b/packages/web/app/components/new-climb-feed/new-climb-feed-item.tsx
@@ -15,7 +15,7 @@ import AscentThumbnail from '@/app/components/activity-feed/ascent-thumbnail';
 import ClimbIcons from '@/app/components/climb-card/climb-icons';
 import { getDefaultBoardConfig, getDefaultClimbViewPath } from '@/app/lib/default-board-configs';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
-import { constructClimbViewUrlWithSlugs } from '@/app/lib/url-utils';
+import { constructClimbViewUrlWithSlugs, tryConstructSlugViewUrl } from '@/app/lib/url-utils';
 import type { BoardName } from '@/app/lib/types';
 import LocaleLink from '@/app/components/i18n/locale-link';
 
@@ -34,6 +34,21 @@ export default function NewClimbFeedItem({ item }: NewClimbFeedItemProps) {
     // Try to build friendly slug path using board details
     const defaultConfig = getDefaultBoardConfig(boardName, item.layoutId);
     if (defaultConfig) {
+      // Id-aware first: this matches every other view-URL call site. The
+      // layout default isn't a shadowed size today, but building from names
+      // is the shape that silently points at the wrong board the moment it
+      // becomes one (see `resolveSizeSlug`).
+      const idAwarePath = tryConstructSlugViewUrl(
+        boardName,
+        item.layoutId,
+        defaultConfig.sizeId,
+        defaultConfig.setIds,
+        angle,
+        item.uuid,
+        item.name || undefined,
+      );
+      if (idAwarePath) return idAwarePath;
+
       const details = getBoardDetailsForBoard({
         board_name: boardName,
         layout_id: item.layoutId,

--- a/packages/web/app/lib/__tests__/slug-utils-catalogue-round-trip.test.ts
+++ b/packages/web/app/lib/__tests__/slug-utils-catalogue-round-trip.test.ts
@@ -18,6 +18,18 @@ vi.mock('@/app/lib/db/db', () => ({
   },
 }));
 
+// `url-utils.server` calls these when a segment doesn't resolve. Throwing keeps
+// a miss loud instead of returning `undefined` into the assertions below.
+vi.mock('next/navigation', () => ({
+  notFound: () => {
+    throw new Error('notFound(): a segment this catalogue emitted did not parse back');
+  },
+  permanentRedirect: (target: string) => {
+    throw new Error(`permanentRedirect('${target}'): the emitted path was not already canonical`);
+  },
+}));
+
+import type { BoardName } from '@/app/lib/types';
 import { SUPPORTED_BOARDS } from '@boardsesh/shared-schema';
 import { getAllLayouts, getSetsForLayoutAndSize, getSizesForLayoutId } from '@boardsesh/board-constants/product-sizes';
 import {
@@ -27,6 +39,8 @@ import {
   resolveSizeSlug,
 } from '@boardsesh/play-view/readable-url-utils';
 import { getLayoutBySlug, getSetsBySlug, getSizeBySlug } from '@/app/lib/slug-utils';
+import { tryConstructSlugViewUrl } from '@/app/lib/url-utils';
+import { parseBoardRouteParamsWithSlugs } from '@/app/lib/url-utils.server';
 
 /**
  * The acceptance criterion for #4362: a round-trip over the WHOLE catalogue
@@ -37,6 +51,14 @@ import { getLayoutBySlug, getSetsBySlug, getSizeBySlug } from '@/app/lib/slug-ut
  * DIFFERENT resolver from web's `getSizeBySlug`, which layers its own
  * `findSizeBySlug` fallback and a DB leg on top. Nothing exercised that path
  * before this file.
+ *
+ * "The whole catalogue" here means every `(layout, size)` tuple reachable
+ * through a *listed* layout — 42 today, not the 44 non-MoonBoard rows in
+ * `product-sizes-data.ts`. `getSizesForLayoutId` drops 6 Kilter sizes whose
+ * layouts (2-7) aren't in `LAYOUTS` and Grasshopper size 1, and that is the
+ * same filter `resolveSizeSlug` and `getSizeBySlug` both apply — so a size it
+ * drops has no emittable readable slug in the first place and nothing to
+ * round-trip.
  *
  * Scoped to the static-tables leg only (the throwing `dbz` stub is
  * deliberate, see above) — `getSizeBySlug`'s DB leg (`findSizeBySlug` over
@@ -52,6 +74,23 @@ import { getLayoutBySlug, getSetsBySlug, getSizeBySlug } from '@/app/lib/slug-ut
 
 const auroraBoards = SUPPORTED_BOARDS.filter((boardName) => boardName !== 'moonboard');
 
+/**
+ * Tuples each board carries today. Asserted per board inside the round-trip
+ * loop so a `continue` that quietly stops walking part of the catalogue reds
+ * the loop that skipped it — rather than being re-derived by a second walk,
+ * which would only ever guard the catalogue data.
+ */
+const EXPECTED_TUPLE_FLOOR: Record<string, number> = {
+  kilter: 16,
+  tension: 15,
+  decoy: 3,
+  touchstone: 1,
+  grasshopper: 5,
+  soill: 2,
+};
+
+const ROUND_TRIP_ANGLE = 40;
+
 describe('getSizeBySlug catalogue round-trip (the resolver a www URL actually goes through)', () => {
   it.each(auroraBoards)('%s: every emitted board URL segment resolves back to its own ids', async (boardName) => {
     let checked = 0;
@@ -61,6 +100,8 @@ describe('getSizeBySlug catalogue round-trip (the resolver a www URL actually go
         const sets = getSetsForLayoutAndSize(boardName, layout.id, size.id);
         if (sets.length === 0) continue;
 
+        const setIds = sets.map((set) => set.id);
+        const sortedSetIds = [...setIds].sort((a, b) => a - b);
         const label = `${boardName} / ${layout.name} / ${size.name} (size id ${size.id})`;
 
         const sizeSlug = resolveSizeSlug(boardName, layout.id, size.id);
@@ -81,29 +122,72 @@ describe('getSizeBySlug catalogue round-trip (the resolver a www URL actually go
         expect(
           resolvedSets.map((set) => set.id).sort((a, b) => a - b),
           `${label}: getSetsBySlug('${setSlug}')`,
-        ).toEqual(sets.map((set) => set.id).sort((a, b) => a - b));
+        ).toEqual(sortedSetIds);
+
+        // The invariant a climber actually experiences: the path the emitter
+        // builds, fed to the parser the route handlers use, comes back as the
+        // ids it started from. The three assertions above compare each segment
+        // against a slug this test re-derived, so they can only catch a
+        // resolver/emitter disagreement per segment — a composition bug in
+        // `tryConstructSlugViewUrl` (segments in the wrong order, one dropped,
+        // a stray prefix) would sail past them. The uuid is Aurora-shaped
+        // because the parser pulls it off the end of the `crimpy-thing-<uuid>`
+        // segment with a 32-hex-char match.
+        const climbUuid = `${layout.id}${size.id}`.padStart(32, '0');
+        const emittedPath = tryConstructSlugViewUrl(
+          boardName,
+          layout.id,
+          size.id,
+          setIds,
+          ROUND_TRIP_ANGLE,
+          climbUuid,
+          'Round Trip',
+        );
+        expect(emittedPath, `${label}: tryConstructSlugViewUrl returned null`).not.toBeNull();
+
+        const [, emittedBoard, emittedLayout, emittedSize, emittedSets, emittedAngle, surface, emittedClimb] =
+          emittedPath!.split('/');
+        expect(surface, `${label}: emitted path ${emittedPath}`).toBe('view');
+
+        const parsed = await parseBoardRouteParamsWithSlugs({
+          board_name: emittedBoard,
+          layout_id: emittedLayout,
+          size_id: emittedSize,
+          set_ids: emittedSets,
+          angle: emittedAngle,
+          climb_uuid: emittedClimb,
+        });
+        expect(
+          {
+            board_name: parsed.board_name,
+            layout_id: parsed.layout_id,
+            size_id: parsed.size_id,
+            set_ids: [...parsed.set_ids].sort((a, b) => a - b),
+            angle: parsed.angle,
+            climb_uuid: parsed.climb_uuid,
+          },
+          `${label}: ${emittedPath} did not parse back to its own ids`,
+        ).toEqual({
+          board_name: boardName,
+          layout_id: layout.id,
+          size_id: size.id,
+          set_ids: sortedSetIds,
+          angle: ROUND_TRIP_ANGLE,
+          climb_uuid: climbUuid,
+        });
 
         checked += 1;
       }
     }
 
-    expect(checked).toBeGreaterThan(0);
+    expect(checked, `${boardName}: walked fewer tuples than the catalogue carries`).toBeGreaterThanOrEqual(
+      EXPECTED_TUPLE_FLOOR[boardName],
+    );
   });
 
-  it('checks at least the verified catalogue size (42 tuples across the 6 Aurora boards)', async () => {
-    let checked = 0;
-
-    for (const boardName of auroraBoards) {
-      for (const layout of getAllLayouts(boardName)) {
-        for (const size of getSizesForLayoutId(boardName, layout.id)) {
-          const sets = getSetsForLayoutAndSize(boardName, layout.id, size.id);
-          if (sets.length === 0) continue;
-          checked += 1;
-        }
-      }
-    }
-
-    expect(checked).toBeGreaterThanOrEqual(42);
+  it('covers every Aurora board, for the verified catalogue size of 42 tuples', () => {
+    expect(Object.keys(EXPECTED_TUPLE_FLOOR).sort()).toEqual([...auroraBoards].sort());
+    expect(Object.values(EXPECTED_TUPLE_FLOOR).reduce((total, count) => total + count, 0)).toBe(42);
   });
 });
 
@@ -117,18 +201,49 @@ describe('the Kilter 12x12 pair, through the resolver a www URL actually goes th
   });
 });
 
-describe("PERMANENT_SIZE_SLUG_ALIASES survive web's resolver too, not just play-view's", () => {
-  it('resolves every pinned Kilter alias through getSizeBySlug to its pinned size id', async () => {
-    const kilterAliases = PERMANENT_SIZE_SLUG_ALIASES.kilter ?? {};
-    const pinnedEntries = Object.entries(kilterAliases);
-    expect(pinnedEntries.length).toBeGreaterThan(0);
+/**
+ * Deliberately narrow: this asserts the *pinned strings* still resolve to their
+ * pinned ids through web's resolver, whichever branch of `resolveSizeSlugToId`
+ * happens to match. It is NOT a guard on the alias branch being consulted —
+ * both entries pinned today are byte-identical to the slug the generated branch
+ * already emits, so the alias branch is never reached from here. That branch is
+ * covered in `packages/shared/play-view/src/__tests__/readable-url-utils.test.ts`,
+ * which mutation-tests it directly. What this adds is that the pinned contract
+ * holds on web's side of the resolver split too, for every board in the table.
+ */
+describe('the pinned PERMANENT_SIZE_SLUG_ALIASES strings resolve through getSizeBySlug', () => {
+  it('resolves each pinned slug to its pinned size id, on every layout that carries that size', async () => {
+    const pinnedBoards = Object.entries(PERMANENT_SIZE_SLUG_ALIASES);
+    expect(pinnedBoards.length).toBeGreaterThan(0);
 
-    for (const [sizeIdString, aliases] of pinnedEntries) {
-      const pinnedSizeId = Number(sizeIdString);
-      for (const alias of aliases) {
-        const resolved = await getSizeBySlug('kilter', 1, alias);
-        expect(resolved?.id, `alias '${alias}' should still resolve to size ${pinnedSizeId}`).toBe(pinnedSizeId);
+    let resolvedAliases = 0;
+
+    for (const [pinnedBoardName, aliasesBySizeId] of pinnedBoards) {
+      const boardName = pinnedBoardName as BoardName;
+
+      for (const [sizeIdString, aliases] of Object.entries(aliasesBySizeId ?? {})) {
+        const pinnedSizeId = Number(sizeIdString);
+        const layoutsCarryingSize = getAllLayouts(boardName).filter((layout) =>
+          getSizesForLayoutId(boardName, layout.id).some((size) => size.id === pinnedSizeId),
+        );
+        expect(
+          layoutsCarryingSize.length,
+          `no listed ${boardName} layout carries pinned size ${pinnedSizeId}`,
+        ).toBeGreaterThan(0);
+
+        for (const layout of layoutsCarryingSize) {
+          for (const alias of aliases) {
+            const resolved = await getSizeBySlug(boardName, layout.id, alias);
+            expect(
+              resolved?.id,
+              `${boardName} layout ${layout.id}: alias '${alias}' should still resolve to size ${pinnedSizeId}`,
+            ).toBe(pinnedSizeId);
+            resolvedAliases += 1;
+          }
+        }
       }
     }
+
+    expect(resolvedAliases).toBeGreaterThan(0);
   });
 });

--- a/packages/web/app/lib/__tests__/slug-utils-catalogue-round-trip.test.ts
+++ b/packages/web/app/lib/__tests__/slug-utils-catalogue-round-trip.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vite-plus/test';
+
+// `@/app/lib/slug-utils` imports `@/app/lib/db/db`, whose module body calls
+// `createPool()`/`createDb()` at load time (the trap documented at
+// `packages/web/app/__tests__/crawler-classic-invariant.test.ts:54-58`). The
+// stub THROWS rather than returning empty rows: that turns the mock into a
+// second assertion for this whole file — every catalogue slug must resolve
+// off the static board tables (`getAllLayouts` / `getSizesForLayoutId` /
+// `getSetsForLayoutAndSize`), so touching `dbz` at all is a failure rather
+// than a silent DB fallback.
+vi.mock('server-only', () => ({}));
+vi.mock('@/app/lib/db/db', () => ({
+  dbz: {
+    select: () => {
+      throw new Error('a catalogue slug fell through to the database');
+    },
+  },
+}));
+
+import { SUPPORTED_BOARDS } from '@boardsesh/shared-schema';
+import { getAllLayouts, getSetsForLayoutAndSize, getSizesForLayoutId } from '@boardsesh/board-constants/product-sizes';
+import {
+  PERMANENT_SIZE_SLUG_ALIASES,
+  generateLayoutSlug,
+  generateSetSlug,
+  resolveSizeSlug,
+} from '@boardsesh/play-view/readable-url-utils';
+import { getLayoutBySlug, getSetsBySlug, getSizeBySlug } from '@/app/lib/slug-utils';
+
+/**
+ * The acceptance criterion for #4362: a round-trip over the WHOLE catalogue
+ * through `getSizeBySlug` — the async, DB-backed resolver every www climb URL
+ * actually goes through (`url-utils.server.ts`). The sibling suite at
+ * `packages/shared/play-view/src/__tests__/readable-url-utils.test.ts` already
+ * round-trips the same catalogue through `resolveSizeSlugToId`; that is a
+ * DIFFERENT resolver from web's `getSizeBySlug`, which layers its own
+ * `findSizeBySlug` fallback and a DB leg on top. Nothing exercised that path
+ * before this file.
+ *
+ * Scoped to the static-tables leg only (the throwing `dbz` stub is
+ * deliberate, see above) — `getSizeBySlug`'s DB leg (`findSizeBySlug` over
+ * rows read from `product_sizes`) is NOT exercised here. That is acceptable
+ * because every catalogue tuple this test walks resolves off the static
+ * `@boardsesh/board-constants` tables (`getAllLayouts` / `getSizesForLayoutId`
+ * / `getSetsForLayoutAndSize`) before `getSizeBySlug` ever reaches the DB
+ * query; the DB leg exists only for a board config the static tables don't
+ * carry, which no entry in this catalogue is. Covering that leg needs a
+ * real-DB test (a stub rebuilding the DB predicate would be a tautology, per
+ * the repo's SQL-stub testing convention) and is out of scope here.
+ */
+
+const auroraBoards = SUPPORTED_BOARDS.filter((boardName) => boardName !== 'moonboard');
+
+describe('getSizeBySlug catalogue round-trip (the resolver a www URL actually goes through)', () => {
+  it.each(auroraBoards)('%s: every emitted board URL segment resolves back to its own ids', async (boardName) => {
+    let checked = 0;
+
+    for (const layout of getAllLayouts(boardName)) {
+      for (const size of getSizesForLayoutId(boardName, layout.id)) {
+        const sets = getSetsForLayoutAndSize(boardName, layout.id, size.id);
+        if (sets.length === 0) continue;
+
+        const label = `${boardName} / ${layout.name} / ${size.name} (size id ${size.id})`;
+
+        const sizeSlug = resolveSizeSlug(boardName, layout.id, size.id);
+        expect(sizeSlug, `${label}: resolveSizeSlug returned null`).not.toBeNull();
+
+        // The acceptance criterion.
+        const resolvedSize = await getSizeBySlug(boardName, layout.id, sizeSlug!);
+        expect(resolvedSize?.id, `${label}: getSizeBySlug('${sizeSlug}') → ${resolvedSize?.id}`).toBe(size.id);
+
+        const layoutSlug = generateLayoutSlug(layout.name);
+        const resolvedLayout = await getLayoutBySlug(boardName, layoutSlug);
+        expect(resolvedLayout?.id, `${label}: getLayoutBySlug('${layoutSlug}') → ${resolvedLayout?.id}`).toBe(
+          layout.id,
+        );
+
+        const setSlug = generateSetSlug(sets.map((set) => set.name));
+        const resolvedSets = await getSetsBySlug(boardName, layout.id, size.id, setSlug);
+        expect(
+          resolvedSets.map((set) => set.id).sort((a, b) => a - b),
+          `${label}: getSetsBySlug('${setSlug}')`,
+        ).toEqual(sets.map((set) => set.id).sort((a, b) => a - b));
+
+        checked += 1;
+      }
+    }
+
+    expect(checked).toBeGreaterThan(0);
+  });
+
+  it('checks at least the verified catalogue size (42 tuples across the 6 Aurora boards)', async () => {
+    let checked = 0;
+
+    for (const boardName of auroraBoards) {
+      for (const layout of getAllLayouts(boardName)) {
+        for (const size of getSizesForLayoutId(boardName, layout.id)) {
+          const sets = getSetsForLayoutAndSize(boardName, layout.id, size.id);
+          if (sets.length === 0) continue;
+          checked += 1;
+        }
+      }
+    }
+
+    expect(checked).toBeGreaterThanOrEqual(42);
+  });
+});
+
+describe('the Kilter 12x12 pair, through the resolver a www URL actually goes through', () => {
+  it('gives size 10 ("with kickboard") and size 27 ("without kickboard") distinct slugs that each resolve back', async () => {
+    expect(resolveSizeSlug('kilter', 1, 10)).toBe('12x12-square');
+    expect(resolveSizeSlug('kilter', 1, 27)).toBe('12x12-square-without-kickboard');
+
+    expect((await getSizeBySlug('kilter', 1, '12x12-square'))?.id).toBe(10);
+    expect((await getSizeBySlug('kilter', 1, '12x12-square-without-kickboard'))?.id).toBe(27);
+  });
+});
+
+describe("PERMANENT_SIZE_SLUG_ALIASES survive web's resolver too, not just play-view's", () => {
+  it('resolves every pinned Kilter alias through getSizeBySlug to its pinned size id', async () => {
+    const kilterAliases = PERMANENT_SIZE_SLUG_ALIASES.kilter ?? {};
+    const pinnedEntries = Object.entries(kilterAliases);
+    expect(pinnedEntries.length).toBeGreaterThan(0);
+
+    for (const [sizeIdString, aliases] of pinnedEntries) {
+      const pinnedSizeId = Number(sizeIdString);
+      for (const alias of aliases) {
+        const resolved = await getSizeBySlug('kilter', 1, alias);
+        expect(resolved?.id, `alias '${alias}' should still resolve to size ${pinnedSizeId}`).toBe(pinnedSizeId);
+      }
+    }
+  });
+});

--- a/packages/web/app/lib/url-utils.ts
+++ b/packages/web/app/lib/url-utils.ts
@@ -527,6 +527,17 @@ export const constructSetterStatsUrl = (
   return searchQuery ? `${baseUrl}?search=${encodeURIComponent(searchQuery)}` : baseUrl;
 };
 
+/**
+ * Name-based, so it emits the *bare* size slug even for a size that shares one
+ * with another on the same layout (Kilter "12 x 12 without kickboard" — see
+ * `resolveSizeSlug` in @boardsesh/play-view). Such a link still resolves, just
+ * to the first match, which for a shadowed size is the wrong physical board.
+ *
+ * Prefer `tryConstructSlugListUrl` wherever the numeric ids are in hand; it
+ * takes them and emits the qualified slug, and `getSizeBySlug` resolves both
+ * forms. This stays as the fallback for a board the static tables don't carry,
+ * where names are all a caller has.
+ */
 export const constructClimbListWithSlugs = (
   board_name: string,
   layoutName: string,
@@ -651,6 +662,17 @@ const appendForkParams = (createUrl: string, forkParams?: ForkClimbParams): stri
   return `${createUrl}?${params.toString()}`;
 };
 
+/**
+ * Name-based, so it emits the *bare* size slug even for a size that shares one
+ * with another on the same layout (Kilter "12 x 12 without kickboard" — see
+ * `resolveSizeSlug` in @boardsesh/play-view). Such a link still resolves, just
+ * to the first match, which for a shadowed size is the wrong physical board.
+ *
+ * Prefer `tryConstructSlugCreateUrl` wherever the numeric ids are in hand; it
+ * takes them and emits the qualified slug, and `getSizeBySlug` resolves both
+ * forms. This stays as the fallback for a board the static tables don't carry,
+ * where names are all a caller has.
+ */
 export const constructCreateClimbUrl = (
   board_name: string,
   layoutName: string,


### PR DESCRIPTION
Part of #4358
Closes #4362

## Summary

#3823 already did ~90% of this work, in a different shape than #4362's issue text describes. That PR's 13-commit review campaign landed an id-aware *sibling* layer — `tryConstructSlug{View,List,Create}Url(ids…)` in `packages/web/app/lib/url-utils.ts`, delegating to `tryBuildReadableClimbViewPath`/`tryBuildReadableClimbListPath` in `packages/shared/play-view/src/readable-url-utils.ts`, which call `resolveSizeSlug` — instead of threading ids into `constructClimbViewUrlWithSlugs`/`constructClimbListWithSlugs` as the issue originally specified. That id-aware layer was already wired at 18 of 20 emission call sites.

This PR closes the two gaps that were left:

- **`activity-feed/ascent-thumbnail.tsx`** — a **live wrong-board link**. Its `renderBoard` prop is the backend-resolved board an ascent was actually logged on, so a climber on Kilter size 27 ("12 x 12 without kickboard") got feed thumbnails linking to size 10's board ("12 x 12 with kickboard") — a different physical wall that happens to share the bare `12x12-square` slug.
- **`new-climb-feed/new-climb-feed-item.tsx`** — latent only today (`getDefaultRenderBoard` picks the highest-ranked size for Kilter layout 1, never 27), but it builds from names the same way and would silently break the moment that stops being true.

Both now try `tryConstructSlugViewUrl(ids…)` first and fall back to the name-based builder only when it returns null, matching the shape already used at every other call site. `constructClimbViewUrlWithSlugs`, `constructClimbListWithSlugs` and `constructCreateClimbUrl` are **not** re-shaped — their signatures and bodies are untouched, per the plan. `constructClimbListWithSlugs` and `constructCreateClimbUrl` gain the same "id-aware first, this stays as the fallback" JSDoc that `constructClimbViewUrlWithSlugs` already carried, so the convention stays discoverable for future call sites.

Also adds the missing acceptance-criterion test: `packages/web/app/lib/__tests__/slug-utils-catalogue-round-trip.test.ts` round-trips the **whole** board catalogue through `getSizeBySlug` — the async, DB-backed resolver every `www` climb URL actually goes through (`url-utils.server.ts`). The existing suite at `packages/shared/play-view/src/__tests__/readable-url-utils.test.ts` already round-trips the same catalogue through a *different* resolver, `resolveSizeSlugToId`; nothing exercised `getSizeBySlug` before this PR.

**Catalogue analysis** (parsed `product-sizes-data.ts` directly): 42 `(board, layout, size)` tuples across 9 layouts / 6 Aurora boards, all with ≥1 set. Exactly **one** base-slug collision exists today — Kilter layout 1, sizes 10 and 27, both `description: 'Square'`. Zero collisions on tension/decoy/touchstone/grasshopper/soill. The test still ships as a regression guard against future upstream data churn, not because more collisions exist today.

**Scope note on the round-trip test**: it is asserted against the static board tables only — the `dbz.select` stub in the test **throws** rather than returning empty rows, which doubles as an assertion that no catalogue slug falls through to the database. `getSizeBySlug`'s DB leg (`findSizeBySlug` over rows read from `product_sizes`) is therefore **not exercised** by this test. That's acceptable here: every tuple in today's catalogue resolves off the static `@boardsesh/board-constants` tables before `getSizeBySlug` would ever reach its DB query, so the DB leg genuinely isn't reachable for anything this test walks. Covering that leg would need a real-DB test (a stub that rebuilds the DB predicate would be a tautology per this repo's SQL-stub-testing convention) and is out of scope here.

## Production targets

**Neither `app.boardsesh.com` nor the native store fleet.** Diff touches zero files under `packages/mobile/` or `packages/shared/`:

```
$ git diff --stat origin/main...HEAD
 .../__tests__/ascent-thumbnail-url.test.tsx        |  59 +++++
 .../components/activity-feed/ascent-thumbnail.tsx  |  19 +-
 .../new-climb-feed/new-climb-feed-item.tsx         |  17 +-
 .../slug-utils-catalogue-round-trip.test.ts        | 249 +++++++++++++++++++++
 packages/web/app/lib/url-utils.ts                  |  22 ++
 5 files changed, 364 insertions(+), 2 deletions(-)
```

All 5 changed files are under `packages/web`. GM (mobile typecheck + bundle check) was run anyway as insurance and came back green and effectively cache-hit (`typecheck:mobile` was a 6/7-cache-hit replay; `check:mobile-bundle` produced the expected bundle unchanged) — confirming nothing in the mobile graph moved. No Fable native-OTA review is needed for this PR.

## Verify #3 evidence — "no call site still builds a view/list URL from bare names while the ids resolve"

```
$ grep -rn 'constructClimbViewUrlWithSlugs\|constructClimbListWithSlugs\|constructCreateClimbUrl' --include='*.ts' --include='*.tsx' packages/web
```

Every non-definition, non-`__tests__` hit sits on the right-hand side of a `tryConstructSlug{View,List,Create}Url(...) ??` (or the equivalent early-return-if-id-aware pattern used in `ascent-thumbnail.tsx` and `new-climb-feed-item.tsx`, and inside `popularConfigListUrl`/`getContextAwareClimbViewUrl` in `url-utils.ts` itself). Confirmed call site by call site: `play/[climb_uuid]/page.tsx`, `list/page.tsx`, `[angle]/layout.tsx`, `list/layout.tsx`, `view/[climb_uuid]/page.tsx`, `board-page/header.tsx`, `bottom-tab-bar.tsx` (×2), `use-climb-actions.ts`, `board-selector-drawer.tsx`, `fork-action.tsx`, `use-drawer-url-sync.ts`, `similar-climbs-list.tsx`, `url-utils.ts` (`popularConfigListUrl`, `getContextAwareClimbViewUrl`), `ble/board-config-match.ts`, plus the two new sites this PR closes. No call site reaches the name-based builder while the numeric ids still resolve.

This is deliberately **not** read as "delete the name-based fallbacks" — they remain as the documented `?? fallback` for a board config the static `@boardsesh/board-constants` tables don't carry (a DB-only layout/size). Whether that case is reachable in production today is an open question for a follow-up (needs a read-only prod query against `user_boards`/`board_climbs`), out of scope here. The durable guard against future regression is the JSDoc added to all three name-based builders (`constructClimbViewUrlWithSlugs` already had it; this PR adds the same block to `constructClimbListWithSlugs` and `constructCreateClimbUrl`).

## Mutation-proofing the new test

Before committing, `packages/shared/play-view/src/readable-url-utils.ts`'s `sizeSlugsForLayout` was temporarily edited to always emit the bare (unqualified) slug — simulating the pre-#3823 name-based collision — and the new test file was re-run scoped to itself:

```
$ vp test run --reporter=agent --project web slug-utils-catalogue-round-trip
 ❯ |web| app/lib/__tests__/slug-utils-catalogue-round-trip.test.ts (9 tests | 2 failed)
     × kilter: every emitted board URL segment resolves back to its own ids
       AssertionError: kilter / Kilter Board Original / 12 x 12 without kickboard (size id 27):
       getSizeBySlug('12x12-square') → 10: expected 10 to be 27
     × gives size 10 ("with kickboard") and size 27 ("without kickboard") distinct slugs that each resolve back
       AssertionError: expected '12x12-square' to be '12x12-square-without-kickboard'
 Test Files  1 failed (1)
      Tests  2 failed | 7 passed (9)
```

The mutation was then reverted with `git checkout -- packages/shared/play-view/src/readable-url-utils.ts` (confirmed zero diff against `origin/main` afterward), and the test file re-run to confirm it's green again (9/9 passed). `packages/shared/play-view` is untouched in the committed diff.

## QA review follow-up (978455652)

A paired QA review found the PR's only behaviour change — the two feed thumbnail hrefs — shipping with no regression coverage, plus three soft spots in the round-trip test. All addressed in a test-only commit; no production code moved.

- **`activity-feed/__tests__/ascent-thumbnail-url.test.tsx` (new)** — asserts the href for a size-27 `renderBoard` (`/kilter/original/12x12-square-without-kickboard/screw_bolt/40/view/test-climb-ABC123`) and for a size-10 one (the unchanged bare `12x12-square`). Same shape as `board-page/__tests__/header-create-url.test.tsx`, the per-call-site precedent #3823 set. Mutation-tested twice: feeding `getDefaultBoardConfig`'s ids into the id-aware call reds both cases (`12x14-commerical`), and dropping the `if (idAwarePath) return idAwarePath` early-return — i.e. reverting this PR's behaviour change — reds the shadowed-size case (`12x12-square` where `12x12-square-without-kickboard` is expected).
- **Emit → parse leg in the round-trip loop** — the loop now builds the path with `tryConstructSlugViewUrl` and feeds the split segments to the real `parseBoardRouteParamsWithSlugs`, asserting board/layout/size/sets/angle/uuid come back identical. The three per-segment assertions could only catch a resolver/emitter disagreement; this catches a composition bug too. Mutation-tested: swapping the size and set segments in `buildReadableClimbViewPath` reds all 6 board cases (reverted, `packages/shared/play-view` still untouched).
- **Per-board tuple floors** — asserted inside the round-trip loop (kilter 16, tension 15, decoy 3, touchstone 1, grasshopper 5, soill 2) instead of by a second walk that only guarded the catalogue data. Adding `|| size.id === 27` to the loop's `continue` now reds Kilter (`expected 15 to be greater than or equal to 16`); under the old shape it stayed green. The remaining aggregate test is pure data — the floors cover every Aurora board and sum to 42.
- **Alias describe retitled and generalised** — it claimed to guard the `PERMANENT_SIZE_SLUG_ALIASES` branch, which it cannot: both pinned strings are byte-identical to what the generated branch emits, so web's resolver never reaches the alias branch from there (forcing `resolvePermanentSizeSlugAlias` to return null left the file green). It now says what it does assert, points the branch coverage at play-view's suite (where the same mutation reds 2 tests), and walks every board and every layout carrying a pinned size — the table is `Partial<Record<BoardName, …>>` and the test only walked `kilter` layout 1.
- **Universe documented** — one paragraph on why it is 42 tuples and not the 44 non-MoonBoard rows in `product-sizes-data.ts` (`getSizesForLayoutId` drops 6 Kilter sizes on unlisted layouts 2-7 and Grasshopper size 1; that is the same filter `resolveSizeSlug` and `getSizeBySlug` apply, so those sizes have no emittable slug).

Not taken, with reasoning: QA also flagged that the new id-aware block in `new-climb-feed-item.tsx` nearly duplicates `getDefaultClimbViewPath`. It does, but collapsing it drops the name-based readable-slug leg for a config the static tables don't carry — a behaviour change that belongs in its own PR. QA sized it the same way ("Follow-up sized, not this PR").

## Test plan

- `vp check` (via `vp staged` at commit time, scoped to the changed files) — pass
- `vp run typecheck` — pass (full workspace, no errors)
- `vp test run --reporter=agent --project web` — pass: 487 test files, 5998 tests
- `vp run typecheck:mobile` (insurance) — pass, 6/7 tasks cache-hit
- `vp run check:mobile-bundle` (insurance) — pass, bundle produced as expected
- `packages/web/app/lib/__tests__/slug-utils-catalogue-round-trip.test.ts`, scoped run — pass: 9/9 tests
  - Catalogue round-trip through `getSizeBySlug` for all 42 `(board, layout, size)` tuples across the 6 Aurora boards, plus `getLayoutBySlug`/`getSetsBySlug` on the same tuples
  - Emit → parse: the path `tryConstructSlugViewUrl` builds, parsed back by `parseBoardRouteParamsWithSlugs`, on the same 42 tuples
  - Per-board tuple floors summing to 42
  - The Kilter 10/27 pair through `getSizeBySlug` specifically
  - Every pinned `PERMANENT_SIZE_SLUG_ALIASES` slug, on every layout carrying that size, still resolves through `getSizeBySlug` to its pinned id
  - Mutation-tested (see above) — confirmed red on the exact regressions it guards against
- `packages/web/app/components/activity-feed/__tests__/ascent-thumbnail-url.test.tsx`, scoped run — pass: 2/2 tests, both mutation-tested

## Release Notes

- Feed thumbnails now open the board the send actually happened on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6Ur37Pg6Ro9kyFxUr8r97

