### PR TITLE
feat(mobile): let signed-out web visitors reach read-only board routes with a next= return

### DIFF
--- a/docs/expo-web-deployment.md
+++ b/docs/expo-web-deployment.md
@@ -147,7 +147,21 @@ the address bar does not survive the round trip on its own.
 
 `Board Route Handoff` fires once per board-route open on **both** platforms with
 `{ kind, status, source }`; it is the only signal for whether deep links resolve
-on the native fleet as well as on `app.boardsesh.com`.
+on the native fleet as well as on `app.boardsesh.com`. Two things about the
+wiring are load-bearing for reading the funnel:
+
+- `status: 'resolved'` is fired **imperatively** from inside the hand-off, not
+  derived from a rendered status. The hand-off effect calls
+  `router.replace` / `router.back` in the same body, React batches that with any
+  state update queued in the same flush, and the navigator drops the redirector
+  in the very render that would have carried the new status — so a
+  status-derived success leg never commits and the funnel reads as ~100%
+  failure. `join/[sessionId]` fires `Session Joined` the same way.
+- `status: 'not_found'` is **held back** for a parsed URL while the device is
+  offline. That state is the transient one `useAdoptedBoard`'s reconnect watcher
+  heals, so reporting it would file a failure for every offline cold open that
+  later lands, and count the same open twice. A URL that did not parse reports
+  either way.
 
 ### Telemetry (baked at build time)
 

--- a/docs/expo-web-deployment.md
+++ b/docs/expo-web-deployment.md
@@ -104,6 +104,51 @@ redirect allow-list accepts only the configured app origin and numbered app
 previews, and the shared `.boardsesh.com` session cookie is available when the
 Expo export reloads.
 
+### Signed-out read-only routes (the `?next=` return)
+
+The Next front door on `www` links every climb page into `app.boardsesh.com` at
+the same path. The browser export serves those paths to visitors who have never
+signed in, so the climb survives the login round trip.
+
+Relaxed shapes (`packages/mobile/src/lib/routing/read-only-routes.ts`), matched
+on shape only — never against the board catalogue, so a URL whose board is gone
+reaches that route's own not-found rather than a login wall:
+
+- `/b/{slug}`, `/b/{slug}/{angle}/list`, `/b/{slug}/{angle}/{view|play}/{climb}`
+- `/{board}/{layout}/{size}/{sets}/{angle}/list` and `…/{angle}/{view|play}/{climb}`
+- every one of the above under an `/es`, `/fr` or `/de` prefix — web keeps the
+  locale in the path, those URLs match no Expo route, so the matcher runs
+  `stripLocalePrefix` first
+
+**Native is untouched.** The relaxation lives in `anonymous-auth-gate.web.ts`;
+the native fork `anonymous-auth-gate.ts` is a constant module (`false`,
+`() => false`, `() => '/auth/login'`, `() => null`), so the gate in
+`auth-provider.tsx` behaves exactly as it does on the store fleet today. Every
+merge to `main` touching `packages/mobile/**` auto-publishes a production OTA
+onto every installed binary, which is why this is a fork rather than a
+`Platform.OS` check — and why both the module's inertness and the rendered gate
+are asserted by test.
+
+A relaxed route mounts, discovers it needs an account, and hands off to
+`/auth/login?next=<path>` rather than resolving anything anonymously: the
+config-tuple form mints a `UserBoard` through `createBoard`, which is
+`requireAuthenticated`. `auth-required` is therefore the terminal status for
+every relaxed route today, and the visitor lands on the climb after signing in.
+
+`next` passes two independent gates before it is followed: `isSafeReturnPath`
+(app-relative, length-capped, no scheme, no `//`, no backslash, no control
+characters) and `isReadOnlyAnonymousPath`, which pins the destination to a shape
+the gate itself could have produced. Values are read from
+`window.location.pathname` with `EXPO_BASE_URL` stripped (`/app` on the
+www-mounted export, `/` on the subdomain) and written back base-relative, since
+Expo Router re-applies the base. The browser-OAuth path carries `next` on the
+NextAuth `callbackUrl` (`src/lib/auth.web.ts`) — the document navigates away, so
+the address bar does not survive the round trip on its own.
+
+`Board Route Handoff` fires once per board-route open on **both** platforms with
+`{ kind, status, source }`; it is the only signal for whether deep links resolve
+on the native fleet as well as on `app.boardsesh.com`.
+
 ### Telemetry (baked at build time)
 
 `deploy-app-web` builds the export with `EXPO_PUBLIC_SENTRY_DSN`,

--- a/docs/web-reposition.md
+++ b/docs/web-reposition.md
@@ -132,6 +132,16 @@ plus `useOptionalPlaylistActivation`. Refactor `multiboard-climb-list.tsx` and
   — the climb-view page SSR-emits `ClimbViewSeoFragment` (the crawlable payload).
   Guards A2's drawer→static swap from dropping it.
 
+**W-06 (#4361) — the SPA end of the hand-off.** A front door that links into
+`app.boardsesh.com` is only worth building if the arrival works signed-out, so
+the Expo app's auth gate now stands aside for the read-only board URLs on web
+and carries the attempted path through login as a validated `?next=`. The URL
+shapes it relaxes, the two-gate `next` contract, the `.web.ts` fork that keeps
+the native gate a constant `false`, and why `auth_required` is a relaxed route's
+terminal status today are recorded in
+[`docs/expo-web-deployment.md`](./expo-web-deployment.md) under "Signed-out
+read-only routes".
+
 ## Phase A0 — blocking pre-delete QA gate (real devices)
 
 The teardown is a **hard delete** with no retained `?classic=1` runtime fallback,

--- a/packages/mobile/app/auth/__tests__/login-register-link.test.tsx
+++ b/packages/mobile/app/auth/__tests__/login-register-link.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+//
+// The one hop the rest of the W-06 suites can't see: login forwarding `next` to
+// the sign-up screen. `AuthProvider` is what navigates after registering (it
+// reads the value straight off the location), so without this the two ends of
+// the register leg are only ever tested in isolation.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+const router = vi.hoisted(() => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }));
+const returnHrefState = vi.hoisted(() => ({ current: null as string | null }));
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'web', Version: undefined },
+  KeyboardAvoidingView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+  Pressable: ({ onPress, children }: { onPress?: () => void; children?: ReactNode }) =>
+    createElement('button', { onClick: onPress }, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+}));
+
+vi.mock('expo-image', () => ({ Image: () => createElement('img', null) }));
+vi.mock('expo-router', () => ({ useRouter: () => router }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+vi.mock('../../../src/providers/auth-provider', () => ({ useAuth: () => ({ signInWithCredentials: vi.fn() }) }));
+vi.mock('../../../src/providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { label: '#000', secondaryLabel: '#666', separator: '#ccc', secondaryBackground: '#eee' },
+    brandColors: { primary: '#7c3aed', warning: '#f59e0b' },
+  }),
+}));
+vi.mock('../../../src/hooks/use-native-oauth-sign-in', () => ({
+  useNativeOAuthSignIn: () => ({ signIn: vi.fn(), inProgress: false }),
+}));
+vi.mock('../../../src/components/AuthFieldset', () => ({ AuthFieldset: () => null }));
+vi.mock('../../../src/components/Button', () => ({ Button: () => null }));
+vi.mock('../../../src/components/Icon', () => ({ Icon: () => null }));
+vi.mock('../../../src/components/auth/OAuthProviderButtons', () => ({
+  OAuthProviderButtons: () => null,
+  useOAuthProviders: () => ({ loading: false, error: null, apple: false, google: false }),
+}));
+vi.mock('../../../src/lib/analytics', () => ({ track: vi.fn() }));
+vi.mock('../../../src/lib/error-reporting', () => ({ reportError: vi.fn() }));
+vi.mock('../../../src/lib/haptics', () => ({ hapticLight: vi.fn() }));
+vi.mock('../../../src/lib/discord', () => ({ openDiscordInvite: vi.fn() }));
+vi.mock('../../../src/lib/routing/anonymous-auth-gate', () => ({
+  readPostLoginReturnHref: () => returnHrefState.current,
+}));
+
+const LoginScreen = (await import('../login')).default;
+
+/** The sign-up link, found by its translation key (the `t` stub is identity). */
+function signUpLink(container: HTMLElement): HTMLElement {
+  const link = [...container.querySelectorAll('button')].find((candidate) =>
+    candidate.textContent?.includes('login.submit.signUp'),
+  );
+  if (!link) throw new Error('sign-up link not rendered');
+  return link;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  returnHrefState.current = null;
+});
+
+describe('LoginScreen sign-up link', () => {
+  it('forwards a read-only return path to the register screen', () => {
+    const next = '/b/the-gym/40/view/crimpy-thing-0A1B2C3D4E5F60718293A4B5C6D7E8F9';
+    returnHrefState.current = next;
+
+    const { container } = render(<LoginScreen />);
+    fireEvent.click(signUpLink(container));
+
+    expect(router.push).toHaveBeenCalledWith({ pathname: '/auth/register', params: { next } });
+  });
+
+  // Native's `readPostLoginReturnHref()` is a constant `null`, so the ternary
+  // keeps the call there literally what it has always been.
+  it('pushes the bare register route when there is nothing to return to', () => {
+    const { container } = render(<LoginScreen />);
+    fireEvent.click(signUpLink(container));
+
+    expect(router.push).toHaveBeenCalledWith('/auth/register');
+  });
+});

--- a/packages/mobile/app/auth/__tests__/login-register-link.test.tsx
+++ b/packages/mobile/app/auth/__tests__/login-register-link.test.tsx
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
 //
-// The one hop the rest of the W-06 suites can't see: login forwarding `next` to
-// the sign-up screen. `AuthProvider` is what navigates after registering (it
-// reads the value straight off the location), so without this the two ends of
-// the register leg are only ever tested in isolation.
+// The two hops the rest of the W-06 suites can't see: login forwarding `next` to
+// the sign-up screen, and register handing it back. `AuthProvider` is what
+// navigates after signing in (it reads the value straight off the location), so
+// without this the ends of the register detour are only ever tested in
+// isolation — and a visitor who taps Sign up, changes their mind and taps Sign
+// in would drop the climb between two screens that each look correct alone.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, render } from '@testing-library/react';
@@ -24,15 +26,19 @@ vi.mock('react-native', () => ({
 }));
 
 vi.mock('expo-image', () => ({ Image: () => createElement('img', null) }));
-vi.mock('expo-router', () => ({ useRouter: () => router }));
+vi.mock('expo-router', () => ({ Stack: { Screen: () => null }, useRouter: () => router }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 
-vi.mock('../../../src/providers/auth-provider', () => ({ useAuth: () => ({ signInWithCredentials: vi.fn() }) }));
+vi.mock('../../../src/providers/auth-provider', () => ({
+  useAuth: () => ({ signInWithCredentials: vi.fn(), register: vi.fn() }),
+}));
 vi.mock('../../../src/providers/theme-provider', () => ({
   useTheme: () => ({
     systemColors: { label: '#000', secondaryLabel: '#666', separator: '#ccc', secondaryBackground: '#eee' },
     brandColors: { primary: '#7c3aed', warning: '#f59e0b' },
   }),
+  // `Text` reads this one, and `undefined` is its documented no-provider path.
+  useOptionalTheme: () => undefined,
 }));
 vi.mock('../../../src/hooks/use-native-oauth-sign-in', () => ({
   useNativeOAuthSignIn: () => ({ signIn: vi.fn(), inProgress: false }),
@@ -44,7 +50,7 @@ vi.mock('../../../src/components/auth/OAuthProviderButtons', () => ({
   OAuthProviderButtons: () => null,
   useOAuthProviders: () => ({ loading: false, error: null, apple: false, google: false }),
 }));
-vi.mock('../../../src/lib/analytics', () => ({ track: vi.fn() }));
+vi.mock('../../../src/lib/analytics', () => ({ track: vi.fn(), setPersonProperties: vi.fn() }));
 vi.mock('../../../src/lib/error-reporting', () => ({ reportError: vi.fn() }));
 vi.mock('../../../src/lib/haptics', () => ({ hapticLight: vi.fn() }));
 vi.mock('../../../src/lib/discord', () => ({ openDiscordInvite: vi.fn() }));
@@ -53,13 +59,12 @@ vi.mock('../../../src/lib/routing/anonymous-auth-gate', () => ({
 }));
 
 const LoginScreen = (await import('../login')).default;
+const RegisterScreen = (await import('../register')).default;
 
-/** The sign-up link, found by its translation key (the `t` stub is identity). */
-function signUpLink(container: HTMLElement): HTMLElement {
-  const link = [...container.querySelectorAll('button')].find((candidate) =>
-    candidate.textContent?.includes('login.submit.signUp'),
-  );
-  if (!link) throw new Error('sign-up link not rendered');
+/** A footer link, found by its translation key (the `t` stub is identity). */
+function linkByKey(container: HTMLElement, key: string): HTMLElement {
+  const link = [...container.querySelectorAll('button')].find((candidate) => candidate.textContent?.includes(key));
+  if (!link) throw new Error(`${key} link not rendered`);
   return link;
 }
 
@@ -68,23 +73,44 @@ beforeEach(() => {
   returnHrefState.current = null;
 });
 
+const RETURN_PATH = '/b/the-gym/40/view/crimpy-thing-0A1B2C3D4E5F60718293A4B5C6D7E8F9';
+
 describe('LoginScreen sign-up link', () => {
   it('forwards a read-only return path to the register screen', () => {
-    const next = '/b/the-gym/40/view/crimpy-thing-0A1B2C3D4E5F60718293A4B5C6D7E8F9';
-    returnHrefState.current = next;
+    returnHrefState.current = RETURN_PATH;
 
     const { container } = render(<LoginScreen />);
-    fireEvent.click(signUpLink(container));
+    fireEvent.click(linkByKey(container, 'login.submit.signUp'));
 
-    expect(router.push).toHaveBeenCalledWith({ pathname: '/auth/register', params: { next } });
+    expect(router.push).toHaveBeenCalledWith({ pathname: '/auth/register', params: { next: RETURN_PATH } });
   });
 
   // Native's `readPostLoginReturnHref()` is a constant `null`, so the ternary
   // keeps the call there literally what it has always been.
   it('pushes the bare register route when there is nothing to return to', () => {
     const { container } = render(<LoginScreen />);
-    fireEvent.click(signUpLink(container));
+    fireEvent.click(linkByKey(container, 'login.submit.signUp'));
 
     expect(router.push).toHaveBeenCalledWith('/auth/register');
+  });
+});
+
+// The way back. Without it the detour is one-directional: Sign up → "actually,
+// I have an account" → bare login, and the climb is gone in three taps.
+describe('RegisterScreen sign-in link', () => {
+  it('hands the return path back to login', () => {
+    returnHrefState.current = RETURN_PATH;
+
+    const { container } = render(<RegisterScreen />);
+    fireEvent.click(linkByKey(container, 'login.submit.signIn'));
+
+    expect(router.replace).toHaveBeenCalledWith({ pathname: '/auth/login', params: { next: RETURN_PATH } });
+  });
+
+  it('replaces with the bare login route when there is nothing to return to', () => {
+    const { container } = render(<RegisterScreen />);
+    fireEvent.click(linkByKey(container, 'login.submit.signIn'));
+
+    expect(router.replace).toHaveBeenCalledWith('/auth/login');
   });
 });

--- a/packages/mobile/app/auth/login.tsx
+++ b/packages/mobile/app/auth/login.tsx
@@ -17,12 +17,21 @@ import { reportError } from '../../src/lib/error-reporting';
 import { hapticLight } from '../../src/lib/haptics';
 import { openDiscordInvite } from '../../src/lib/discord';
 import { OAuthProviderButtons, useOAuthProviders } from '../../src/components/auth/OAuthProviderButtons';
+import { readPostLoginReturnHref } from '../../src/lib/routing/anonymous-auth-gate';
 
 export default function LoginScreen() {
   const { signInWithCredentials } = useAuth();
   const { t } = useTranslation('auth');
   const theme = useTheme();
   const router = useRouter();
+  // Web only: the climb a signed-out visitor arrived for, carried here as
+  // `?next=`. This screen deliberately never navigates with it — AuthProvider's
+  // `isAuthenticated && inAuthGroup` redirect reads the same value off the
+  // location in the same commit, and a `router.replace` here would race it. The
+  // one thing it owns is the sign-up hop, so someone who registers instead of
+  // signing in comes back to the same climb. Constant `null` on native, which
+  // keeps the call below literally `router.push('/auth/register')` there.
+  const returnHref = readPostLoginReturnHref();
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -235,7 +244,7 @@ export default function LoginScreen() {
           <Pressable
             onPress={() => {
               hapticLight();
-              router.push('/auth/register');
+              router.push(returnHref ? { pathname: '/auth/register', params: { next: returnHref } } : '/auth/register');
             }}
             hitSlop={{ top: 12, bottom: 12, left: 8, right: 8 }}
             style={styles.footerLinkHit}

--- a/packages/mobile/app/auth/register.tsx
+++ b/packages/mobile/app/auth/register.tsx
@@ -16,6 +16,7 @@ import { webApiUrl } from '../../src/lib/env';
 import { reportError } from '../../src/lib/error-reporting';
 import { hapticLight } from '../../src/lib/haptics';
 import { OAuthProviderButtons, useOAuthProviders } from '../../src/components/auth/OAuthProviderButtons';
+import { readPostLoginReturnHref } from '../../src/lib/routing/anonymous-auth-gate';
 
 type FieldKey = 'name' | 'email' | 'password' | 'confirmPassword';
 
@@ -24,6 +25,16 @@ export default function RegisterScreen() {
   const { t } = useTranslation('auth');
   const theme = useTheme();
   const router = useRouter();
+  // Web only: the climb a signed-out visitor arrived for, forwarded here by
+  // login's sign-up link. Handing it straight back is what makes the round trip
+  // symmetrical — someone who taps Sign up, thinks better of it and taps Sign in
+  // would otherwise land on a bare login and lose the climb in three taps.
+  // Constant `null` on native, so `signInHref` is the bare route string there
+  // and both hops below stay exactly the navigation the store fleet ships today.
+  const returnHref = readPostLoginReturnHref();
+  const signInHref = returnHref
+    ? ({ pathname: '/auth/login', params: { next: returnHref } } as const)
+    : ('/auth/login' as const);
 
   const [values, setValues] = useState({ name: '', email: '', password: '', confirmPassword: '' });
   const [fieldErrors, setFieldErrors] = useState<RegisterFieldErrors>({});
@@ -249,7 +260,7 @@ export default function RegisterScreen() {
               ) : null}
               <Button
                 title={t('login.submit.signIn')}
-                onPress={() => router.replace('/auth/login')}
+                onPress={() => router.replace(signInHref)}
                 variant="text"
                 size="large"
               />
@@ -377,7 +388,7 @@ export default function RegisterScreen() {
                 {/* replace (not back) so a deep-link straight to /auth/register still
                 lands on login rather than no-op'ing on an empty back stack. */}
                 <Pressable
-                  onPress={() => router.replace('/auth/login')}
+                  onPress={() => router.replace(signInHref)}
                   hitSlop={{ top: 12, bottom: 12, left: 8, right: 8 }}
                   style={styles.footerLinkHit}
                   accessibilityRole="link"

--- a/packages/mobile/src/components/BoardRouteRedirect.tsx
+++ b/packages/mobile/src/components/BoardRouteRedirect.tsx
@@ -18,7 +18,7 @@ import { Text } from './Text';
 import { useTheme } from '../providers/theme-provider';
 import { track } from '../lib/analytics';
 import { buildLoginHrefWithReturn } from '../lib/routing/anonymous-auth-gate';
-import type { BoardRouteTarget } from '../lib/routing/board-route-target';
+import { toBoardPath, type BoardRouteTarget } from '../lib/routing/board-route-target';
 import { useBoardRouteTarget, type BoardRouteMode, type BoardRouteStatus } from '../lib/routing/use-board-route-target';
 
 /** Where `app/+not-found.tsx` sends people; the dead end below has to match it. */
@@ -31,14 +31,23 @@ const HANDOFF_EVENT_STATUS = {
   'auth-required': 'auth_required',
 } as const satisfies Partial<Record<BoardRouteStatus, string>>;
 
+/** The URL a report is about, so two different climbs each get their own event. */
+function targetIdentity(target: BoardRouteTarget | null): string {
+  if (!target) return 'unparsed';
+  const climbUuid = target.kind === 'climb' || target.kind === 'slug-climb' ? target.climbUuid : '';
+  return `${toBoardPath(target)}#${climbUuid}`;
+}
+
 /**
  * One `Board Route Handoff` per board-route open, at the moment it settles.
  *
  * Deliberately cross-platform. It is the only signal for whether deep links
  * resolve on the native fleet as well as on app.boardsesh.com, and it is
- * additive telemetry rather than a behaviour change. The ref keys on what is
- * reported, not on a bare flag, so a second URL through the same mounted screen
- * still reports — and a re-render at the same status does not double-fire.
+ * additive telemetry rather than a behaviour change. The ref keys on the URL and
+ * the outcome — not a bare flag, and not the coarse event props — so a second
+ * URL through the same mounted screen reports even when it settles the same way,
+ * while a re-render at the same status does not double-fire. The URL never
+ * leaves this file: the event itself carries only `{ kind, status, source }`.
  */
 function useBoardRouteHandoffEvent(
   target: BoardRouteTarget | null,
@@ -49,13 +58,14 @@ function useBoardRouteHandoffEvent(
   const eventStatus = HANDOFF_EVENT_STATUS[status as keyof typeof HANDOFF_EVENT_STATUS];
   const kind = target?.kind ?? 'unparsed';
   const source = mode ?? 'deep-link';
+  const identity = targetIdentity(target);
   useEffect(() => {
     if (!eventStatus) return;
-    const reportKey = `${kind}#${source}#${eventStatus}`;
+    const reportKey = `${identity}#${source}#${eventStatus}`;
     if (reportedRef.current === reportKey) return;
     reportedRef.current = reportKey;
     track(SHARED_EVENTS.BoardRouteHandoff, { kind, status: eventStatus, source });
-  }, [eventStatus, kind, source]);
+  }, [eventStatus, identity, kind, source]);
 }
 
 export function BoardRouteRedirect({ status }: { status: BoardRouteStatus }) {

--- a/packages/mobile/src/components/BoardRouteRedirect.tsx
+++ b/packages/mobile/src/components/BoardRouteRedirect.tsx
@@ -6,10 +6,11 @@
 // not-found. Keeping that here means the seven route files stay at "read params,
 // build a target" and can't drift from each other.
 
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Redirect, Stack, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
+import { onlineManager } from '@tanstack/react-query';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { ActivityIndicator } from './ActivityIndicator';
 import { Button } from './Button';
@@ -24,12 +25,20 @@ import { useBoardRouteTarget, type BoardRouteMode, type BoardRouteStatus } from 
 /** Where `app/+not-found.tsx` sends people; the dead end below has to match it. */
 const HOME_TAB = '/(tabs)/home' as const;
 
-/** The terminal statuses worth a hand-off event, in the wire spelling. */
-const HANDOFF_EVENT_STATUS = {
-  resolved: 'resolved',
+/** How a board-route open ended, in the wire spelling. */
+type HandoffEventStatus = 'resolved' | 'not_found' | 'auth_required';
+
+/**
+ * The terminal statuses the screen SITS on, in the wire spelling.
+ *
+ * A successful hand-off is not among them — it has no status at all, because the
+ * effect that performs it also navigates this screen out of the tree. See
+ * `useBoardRouteHandoffReporter`.
+ */
+const RENDERED_EVENT_STATUS = {
   'not-found': 'not_found',
   'auth-required': 'auth_required',
-} as const satisfies Partial<Record<BoardRouteStatus, string>>;
+} as const satisfies Partial<Record<BoardRouteStatus, HandoffEventStatus>>;
 
 /** The URL a report is about, so two different climbs each get their own event. */
 function targetIdentity(target: BoardRouteTarget | null): string {
@@ -46,26 +55,33 @@ function targetIdentity(target: BoardRouteTarget | null): string {
  * additive telemetry rather than a behaviour change. The ref keys on the URL and
  * the outcome — not a bare flag, and not the coarse event props — so a second
  * URL through the same mounted screen reports even when it settles the same way,
- * while a re-render at the same status does not double-fire. The URL never
+ * while a re-render at the same outcome does not double-fire. The URL never
  * leaves this file: the event itself carries only `{ kind, status, source }`.
+ *
+ * Returns the reporter rather than firing on a status, because the outcomes
+ * arrive by two different routes. `not-found` and `auth-required` are statuses
+ * the screen sits on, so watching the status is enough. A successful hand-off
+ * never becomes a status: the effect that performs it calls `router.replace` /
+ * `router.back` in the same body, React batches that with anything else queued
+ * in the flush, and the navigator drops this screen in the very render that
+ * would have carried it — so `resolved` is fired imperatively from inside the
+ * hand-off, the way `join/[sessionId]` fires `Session Joined` before it replaces
+ * itself. Whichever route reports first, the key dedupes the other.
  */
-function useBoardRouteHandoffEvent(
-  target: BoardRouteTarget | null,
-  mode: BoardRouteMode | undefined,
-  status: BoardRouteStatus,
-) {
+function useBoardRouteHandoffReporter(target: BoardRouteTarget | null, mode: BoardRouteMode | undefined) {
   const reportedRef = useRef<string | null>(null);
-  const eventStatus = HANDOFF_EVENT_STATUS[status as keyof typeof HANDOFF_EVENT_STATUS];
   const kind = target?.kind ?? 'unparsed';
   const source = mode ?? 'deep-link';
   const identity = targetIdentity(target);
-  useEffect(() => {
-    if (!eventStatus) return;
-    const reportKey = `${identity}#${source}#${eventStatus}`;
-    if (reportedRef.current === reportKey) return;
-    reportedRef.current = reportKey;
-    track(SHARED_EVENTS.BoardRouteHandoff, { kind, status: eventStatus, source });
-  }, [eventStatus, identity, kind, source]);
+  return useCallback(
+    (eventStatus: HandoffEventStatus) => {
+      const reportKey = `${identity}#${source}#${eventStatus}`;
+      if (reportedRef.current === reportKey) return;
+      reportedRef.current = reportKey;
+      track(SHARED_EVENTS.BoardRouteHandoff, { kind, status: eventStatus, source });
+    },
+    [identity, kind, source],
+  );
 }
 
 export function BoardRouteRedirect({ status }: { status: BoardRouteStatus }) {
@@ -84,10 +100,10 @@ export function BoardRouteRedirect({ status }: { status: BoardRouteStatus }) {
       {/* Headerless: a redirector that shows a back chevron for the split second
           before it navigates away just looks like a broken screen. */}
       <Stack.Screen options={{ headerShown: false }} />
-      {/* `resolved` draws the same spinner as `resolving`: the screen has handed
-          off and is navigating away, and flashing the not-found on its way out
-          would be a lie. */}
-      {status === 'resolving' || status === 'resolved' ? (
+      {/* A handed-off screen keeps this spinner on its way out — nothing flips it
+          to the not-found, because the board and climb it handed off with are
+          both still there. */}
+      {status === 'resolving' ? (
         <ActivityIndicator size="large" />
       ) : (
         <>
@@ -112,8 +128,24 @@ export function BoardRouteRedirect({ status }: { status: BoardRouteStatus }) {
  * `target` is `null` when the URL didn't parse, which renders the not-found.
  */
 export function BoardRouteHandoff({ target, mode }: { target: BoardRouteTarget | null; mode?: BoardRouteMode }) {
-  const status = useBoardRouteTarget(target, { mode });
-  useBoardRouteHandoffEvent(target, mode, status);
+  const report = useBoardRouteHandoffReporter(target, mode);
+  const onHandedOff = useCallback(() => report('resolved'), [report]);
+  const status = useBoardRouteTarget(target, { mode, onHandedOff });
+
+  const renderedStatus = RENDERED_EVENT_STATUS[status as keyof typeof RENDERED_EVENT_STATUS];
+  const parsedUrl = target !== null;
+  useEffect(() => {
+    if (!renderedStatus) return;
+    // A parsed URL that fails with no network is not a dead link. The hook
+    // watches `onlineManager` and re-resolves when the signal comes back, and
+    // that second pass hands off — so reporting here would file a `not_found`
+    // for every offline cold open that later succeeds, and count the same open
+    // twice once the `resolved` follows it. A URL that didn't parse is a dead
+    // end whatever the network is doing.
+    if (renderedStatus === 'not_found' && parsedUrl && !onlineManager.isOnline()) return;
+    report(renderedStatus);
+  }, [parsedUrl, renderedStatus, report]);
+
   return <BoardRouteRedirect status={status} />;
 }
 

--- a/packages/mobile/src/components/BoardRouteRedirect.tsx
+++ b/packages/mobile/src/components/BoardRouteRedirect.tsx
@@ -6,31 +6,78 @@
 // not-found. Keeping that here means the seven route files stay at "read params,
 // build a target" and can't drift from each other.
 
+import { useEffect, useRef } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { Stack, useRouter } from 'expo-router';
+import { Redirect, Stack, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { ActivityIndicator } from './ActivityIndicator';
 import { Button } from './Button';
 import { Icon } from './Icon';
 import { Text } from './Text';
 import { useTheme } from '../providers/theme-provider';
+import { track } from '../lib/analytics';
+import { buildLoginHrefWithReturn } from '../lib/routing/anonymous-auth-gate';
 import type { BoardRouteTarget } from '../lib/routing/board-route-target';
 import { useBoardRouteTarget, type BoardRouteMode, type BoardRouteStatus } from '../lib/routing/use-board-route-target';
 
 /** Where `app/+not-found.tsx` sends people; the dead end below has to match it. */
 const HOME_TAB = '/(tabs)/home' as const;
 
+/** The terminal statuses worth a hand-off event, in the wire spelling. */
+const HANDOFF_EVENT_STATUS = {
+  resolved: 'resolved',
+  'not-found': 'not_found',
+  'auth-required': 'auth_required',
+} as const satisfies Partial<Record<BoardRouteStatus, string>>;
+
+/**
+ * One `Board Route Handoff` per board-route open, at the moment it settles.
+ *
+ * Deliberately cross-platform. It is the only signal for whether deep links
+ * resolve on the native fleet as well as on app.boardsesh.com, and it is
+ * additive telemetry rather than a behaviour change. The ref keys on what is
+ * reported, not on a bare flag, so a second URL through the same mounted screen
+ * still reports — and a re-render at the same status does not double-fire.
+ */
+function useBoardRouteHandoffEvent(
+  target: BoardRouteTarget | null,
+  mode: BoardRouteMode | undefined,
+  status: BoardRouteStatus,
+) {
+  const reportedRef = useRef<string | null>(null);
+  const eventStatus = HANDOFF_EVENT_STATUS[status as keyof typeof HANDOFF_EVENT_STATUS];
+  const kind = target?.kind ?? 'unparsed';
+  const source = mode ?? 'deep-link';
+  useEffect(() => {
+    if (!eventStatus) return;
+    const reportKey = `${kind}#${source}#${eventStatus}`;
+    if (reportedRef.current === reportKey) return;
+    reportedRef.current = reportKey;
+    track(SHARED_EVENTS.BoardRouteHandoff, { kind, status: eventStatus, source });
+  }, [eventStatus, kind, source]);
+}
+
 export function BoardRouteRedirect({ status }: { status: BoardRouteStatus }) {
   const { t } = useTranslation('climbs');
   const { systemColors } = useTheme();
   const router = useRouter();
+
+  // Web-only in practice: a signed-out visitor on a read-only board route. Send
+  // them to login carrying the path so the climb survives the round trip. On
+  // native `buildLoginHrefWithReturn()` is a constant `/auth/login` and this
+  // status is unreachable — `RELAXES_ANONYMOUS_ROUTES` is false there.
+  if (status === 'auth-required') return <Redirect href={buildLoginHrefWithReturn()} />;
 
   return (
     <View style={styles.container}>
       {/* Headerless: a redirector that shows a back chevron for the split second
           before it navigates away just looks like a broken screen. */}
       <Stack.Screen options={{ headerShown: false }} />
-      {status === 'resolving' ? (
+      {/* `resolved` draws the same spinner as `resolving`: the screen has handed
+          off and is navigating away, and flashing the not-found on its way out
+          would be a lie. */}
+      {status === 'resolving' || status === 'resolved' ? (
         <ActivityIndicator size="large" />
       ) : (
         <>
@@ -56,6 +103,7 @@ export function BoardRouteRedirect({ status }: { status: BoardRouteStatus }) {
  */
 export function BoardRouteHandoff({ target, mode }: { target: BoardRouteTarget | null; mode?: BoardRouteMode }) {
   const status = useBoardRouteTarget(target, { mode });
+  useBoardRouteHandoffEvent(target, mode, status);
   return <BoardRouteRedirect status={status} />;
 }
 

--- a/packages/mobile/src/components/__tests__/BoardRouteRedirect.test.tsx
+++ b/packages/mobile/src/components/__tests__/BoardRouteRedirect.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
@@ -15,6 +15,13 @@ const analytics = vi.hoisted(() => ({ track: vi.fn() }));
 const routeStatus = vi.hoisted(() => ({ current: 'resolving' as BoardRouteStatus }));
 const redirect = vi.hoisted(() => ({ hrefs: [] as string[] }));
 const router = vi.hoisted(() => ({ replace: vi.fn() }));
+// The hand-off callback the hook holds. A successful hand-off never becomes a
+// status — the real hook navigates the screen away in the same batch — so this
+// is the only handle a test has on the `resolved` leg.
+const handoff = vi.hoisted(() => ({ current: null as (() => void) | null }));
+// Whatever `onlineManager` reports when the not-found lands. An offline
+// not-found is the transient state a reconnect heals, not a dead link.
+const connectivity = vi.hoisted(() => ({ isOnline: true }));
 
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
@@ -47,8 +54,12 @@ vi.mock('../../lib/analytics', () => ({ track: analytics.track }));
 vi.mock('../../lib/routing/anonymous-auth-gate', () => ({
   buildLoginHrefWithReturn: () => LOGIN_HREF,
 }));
+vi.mock('@tanstack/react-query', () => ({ onlineManager: { isOnline: () => connectivity.isOnline } }));
 vi.mock('../../lib/routing/use-board-route-target', () => ({
-  useBoardRouteTarget: () => routeStatus.current,
+  useBoardRouteTarget: (_target: unknown, options?: { onHandedOff?: () => void }) => {
+    handoff.current = options?.onHandedOff ?? null;
+    return routeStatus.current;
+  },
 }));
 
 const { BoardRouteHandoff, BoardRouteRedirect } = await import('../BoardRouteRedirect');
@@ -69,13 +80,15 @@ beforeEach(() => {
   vi.clearAllMocks();
   redirect.hrefs = [];
   routeStatus.current = 'resolving';
+  handoff.current = null;
+  connectivity.isOnline = true;
 });
 
 describe('BoardRouteRedirect', () => {
-  // A handed-off screen is navigating away. Flashing the not-found on its way
-  // out would read as a broken link for a link that worked.
-  it.each(['resolving', 'resolved'] as const)('draws the spinner at %s', (status) => {
-    const { queryByTestId } = render(createElement(BoardRouteRedirect, { status }));
+  // A handed-off screen keeps this spinner on its way out. Flashing the
+  // not-found would read as a broken link for a link that worked.
+  it('draws the spinner while resolving', () => {
+    const { queryByTestId } = render(createElement(BoardRouteRedirect, { status: 'resolving' as BoardRouteStatus }));
 
     expect(queryByTestId('spinner')).not.toBeNull();
     expect(queryByTestId('error-icon')).toBeNull();
@@ -105,8 +118,33 @@ describe('BoardRouteRedirect', () => {
 });
 
 describe('Board Route Handoff event', () => {
+  /** Fire the hand-off the way the real hook does: from inside its effect. */
+  function handOff() {
+    if (!handoff.current) throw new Error('the hook was never handed an onHandedOff callback');
+    act(() => handoff.current?.());
+  }
+
+  // The success leg never arrives as a status: the hand-off effect navigates the
+  // screen out of the tree in the same React batch, so a render carrying
+  // `resolved` would be discarded with the fiber. It is reported imperatively
+  // instead, and this is what proves the wiring survives.
+  it('fires for a hand-off that the screen never renders a status for', () => {
+    routeStatus.current = 'resolving';
+
+    render(createElement(BoardRouteHandoff, { target: CLIMB_TARGET }));
+    expect(analytics.track).not.toHaveBeenCalled();
+
+    handOff();
+
+    expect(analytics.track).toHaveBeenCalledTimes(1);
+    expect(analytics.track).toHaveBeenCalledWith(SHARED_EVENTS.BoardRouteHandoff, {
+      kind: 'climb',
+      status: 'resolved',
+      source: 'deep-link',
+    });
+  });
+
   it.each([
-    ['resolved', CLIMB_TARGET, { kind: 'climb', status: 'resolved', source: 'deep-link' }],
     ['auth-required', SLUG_CLIMB_TARGET, { kind: 'slug-climb', status: 'auth_required', source: 'deep-link' }],
     ['not-found', null, { kind: 'unparsed', status: 'not_found', source: 'deep-link' }],
   ] as const)('fires once for the %s terminal status', (status, target, expected) => {
@@ -119,9 +157,8 @@ describe('Board Route Handoff event', () => {
   });
 
   it('tags an in-app open as its own source', () => {
-    routeStatus.current = 'resolved';
-
     render(createElement(BoardRouteHandoff, { target: CLIMB_TARGET, mode: 'in-app' }));
+    handOff();
 
     expect(analytics.track).toHaveBeenCalledWith(SHARED_EVENTS.BoardRouteHandoff, {
       kind: 'climb',
@@ -139,10 +176,18 @@ describe('Board Route Handoff event', () => {
   });
 
   it('does not double-fire when the same status re-renders', () => {
-    routeStatus.current = 'resolved';
+    routeStatus.current = 'not-found';
 
     const { rerender } = render(createElement(BoardRouteHandoff, { target: CLIMB_TARGET }));
     rerender(createElement(BoardRouteHandoff, { target: CLIMB_TARGET }));
+
+    expect(analytics.track).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not double-fire when a hand-off is reported twice', () => {
+    render(createElement(BoardRouteHandoff, { target: CLIMB_TARGET }));
+    handOff();
+    handOff();
 
     expect(analytics.track).toHaveBeenCalledTimes(1);
   });
@@ -152,15 +197,65 @@ describe('Board Route Handoff event', () => {
   // status, source }` — so deduplicating on the event props alone would silently
   // undercount every board-route open after the first.
   it('reports a second URL through the same mounted screen', () => {
-    routeStatus.current = 'resolved';
-
     const { rerender } = render(createElement(BoardRouteHandoff, { target: CLIMB_TARGET }));
+    handOff();
     rerender(
       createElement(BoardRouteHandoff, {
         target: { ...CLIMB_TARGET, climbUuid: 'F9E8D7C6B5A4938271605F4E3D2C1B0A' } as BoardRouteTarget,
       }),
     );
+    handOff();
 
     expect(analytics.track).toHaveBeenCalledTimes(2);
+  });
+
+  // A parsed URL that fails with no signal is the transient state the hook heals
+  // on reconnect, not a dead link. Reporting it would inflate `not_found` with
+  // every offline cold open that later succeeds — and count that open twice,
+  // since the `resolved` follows under a different report key.
+  it('holds the not-found back while the device is offline', () => {
+    connectivity.isOnline = false;
+    routeStatus.current = 'not-found';
+
+    render(createElement(BoardRouteHandoff, { target: CLIMB_TARGET }));
+
+    expect(analytics.track).not.toHaveBeenCalled();
+  });
+
+  // Nothing about the network can turn an unparsed URL into a climb.
+  it('reports an unparsed URL offline all the same', () => {
+    connectivity.isOnline = false;
+    routeStatus.current = 'not-found';
+
+    render(createElement(BoardRouteHandoff, { target: null }));
+
+    expect(analytics.track).toHaveBeenCalledWith(SHARED_EVENTS.BoardRouteHandoff, {
+      kind: 'unparsed',
+      status: 'not_found',
+      source: 'deep-link',
+    });
+  });
+
+  // The held-back not-found is not lost — a retry that fails with the network up
+  // is the verdict this event is meant to carry.
+  it('reports the not-found once the retry fails online', () => {
+    connectivity.isOnline = false;
+    routeStatus.current = 'not-found';
+
+    const { rerender } = render(createElement(BoardRouteHandoff, { target: CLIMB_TARGET }));
+    expect(analytics.track).not.toHaveBeenCalled();
+
+    connectivity.isOnline = true;
+    routeStatus.current = 'resolving';
+    rerender(createElement(BoardRouteHandoff, { target: CLIMB_TARGET }));
+    routeStatus.current = 'not-found';
+    rerender(createElement(BoardRouteHandoff, { target: CLIMB_TARGET }));
+
+    expect(analytics.track).toHaveBeenCalledTimes(1);
+    expect(analytics.track).toHaveBeenCalledWith(SHARED_EVENTS.BoardRouteHandoff, {
+      kind: 'climb',
+      status: 'not_found',
+      source: 'deep-link',
+    });
   });
 });

--- a/packages/mobile/src/components/__tests__/BoardRouteRedirect.test.tsx
+++ b/packages/mobile/src/components/__tests__/BoardRouteRedirect.test.tsx
@@ -6,6 +6,11 @@ import { SHARED_EVENTS } from '@boardsesh/analytics';
 import type { BoardRouteTarget } from '../../lib/routing/board-route-target';
 import type { BoardRouteStatus } from '../../lib/routing/use-board-route-target';
 
+// What the gate hands back, as a sentinel. This suite asserts the component
+// forwards that value VERBATIM; whether the value itself is right for a given
+// location is `anonymous-auth-gate.web.test.ts`'s job.
+const LOGIN_HREF = vi.hoisted(() => '/auth/login?next=%2Fb%2Fthe-gym%2F40%2Flist');
+
 const analytics = vi.hoisted(() => ({ track: vi.fn() }));
 const routeStatus = vi.hoisted(() => ({ current: 'resolving' as BoardRouteStatus }));
 const redirect = vi.hoisted(() => ({ hrefs: [] as string[] }));
@@ -40,7 +45,7 @@ vi.mock('../Button', () => ({
 
 vi.mock('../../lib/analytics', () => ({ track: analytics.track }));
 vi.mock('../../lib/routing/anonymous-auth-gate', () => ({
-  buildLoginHrefWithReturn: () => '/auth/login?next=%2Fb%2Fthe-gym%2F40%2Flist',
+  buildLoginHrefWithReturn: () => LOGIN_HREF,
 }));
 vi.mock('../../lib/routing/use-board-route-target', () => ({
   useBoardRouteTarget: () => routeStatus.current,
@@ -86,13 +91,14 @@ describe('BoardRouteRedirect', () => {
   });
 
   // Web only in practice: the signed-out visitor goes to login carrying the path
-  // so the climb survives the round trip.
-  it('redirects to the login href with the return path at auth-required', () => {
+  // so the climb survives the round trip. The claim under test is that the
+  // component forwards the gate's href unchanged — it must not rebuild one.
+  it('redirects to the login href the gate hands back at auth-required', () => {
     const { queryByTestId } = render(
       createElement(BoardRouteRedirect, { status: 'auth-required' as BoardRouteStatus }),
     );
 
-    expect(redirect.hrefs).toEqual(['/auth/login?next=%2Fb%2Fthe-gym%2F40%2Flist']);
+    expect(redirect.hrefs).toEqual([LOGIN_HREF]);
     expect(queryByTestId('spinner')).toBeNull();
     expect(queryByTestId('error-icon')).toBeNull();
   });

--- a/packages/mobile/src/components/__tests__/BoardRouteRedirect.test.tsx
+++ b/packages/mobile/src/components/__tests__/BoardRouteRedirect.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import type { BoardRouteTarget } from '../../lib/routing/board-route-target';
+import type { BoardRouteStatus } from '../../lib/routing/use-board-route-target';
+
+const analytics = vi.hoisted(() => ({ track: vi.fn() }));
+const routeStatus = vi.hoisted(() => ({ current: 'resolving' as BoardRouteStatus }));
+const redirect = vi.hoisted(() => ({ hrefs: [] as string[] }));
+const router = vi.hoisted(() => ({ replace: vi.fn() }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+}));
+
+vi.mock('expo-router', () => ({
+  Stack: { Screen: () => null },
+  useRouter: () => router,
+  Redirect: ({ href }: { href: string }) => {
+    redirect.hrefs.push(href);
+    return null;
+  },
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../../providers/theme-provider', () => ({ useTheme: () => ({ systemColors: { secondaryLabel: '#888' } }) }));
+
+vi.mock('../ActivityIndicator', () => ({
+  ActivityIndicator: () => createElement('div', { 'data-testid': 'spinner' }),
+}));
+vi.mock('../Icon', () => ({ Icon: () => createElement('div', { 'data-testid': 'error-icon' }) }));
+vi.mock('../Text', () => ({ Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children) }));
+vi.mock('../Button', () => ({
+  Button: ({ title, onPress }: { title: string; onPress: () => void }) =>
+    createElement('button', { 'data-testid': 'back-home', onClick: onPress }, title),
+}));
+
+vi.mock('../../lib/analytics', () => ({ track: analytics.track }));
+vi.mock('../../lib/routing/anonymous-auth-gate', () => ({
+  buildLoginHrefWithReturn: () => '/auth/login?next=%2Fb%2Fthe-gym%2F40%2Flist',
+}));
+vi.mock('../../lib/routing/use-board-route-target', () => ({
+  useBoardRouteTarget: () => routeStatus.current,
+}));
+
+const { BoardRouteHandoff, BoardRouteRedirect } = await import('../BoardRouteRedirect');
+
+const CLIMB_TARGET = {
+  kind: 'climb',
+  board: { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,20', angle: 40 },
+  climbUuid: '0A1B2C3D4E5F60718293A4B5C6D7E8F9',
+} as BoardRouteTarget;
+const SLUG_CLIMB_TARGET = {
+  kind: 'slug-climb',
+  slug: 'the-gym',
+  angle: 40,
+  climbUuid: '0A1B2C3D4E5F60718293A4B5C6D7E8F9',
+} as BoardRouteTarget;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  redirect.hrefs = [];
+  routeStatus.current = 'resolving';
+});
+
+describe('BoardRouteRedirect', () => {
+  // A handed-off screen is navigating away. Flashing the not-found on its way
+  // out would read as a broken link for a link that worked.
+  it.each(['resolving', 'resolved'] as const)('draws the spinner at %s', (status) => {
+    const { queryByTestId } = render(createElement(BoardRouteRedirect, { status }));
+
+    expect(queryByTestId('spinner')).not.toBeNull();
+    expect(queryByTestId('error-icon')).toBeNull();
+    expect(redirect.hrefs).toEqual([]);
+  });
+
+  it('draws the dead end at not-found', () => {
+    const { queryByTestId } = render(createElement(BoardRouteRedirect, { status: 'not-found' as BoardRouteStatus }));
+
+    expect(queryByTestId('error-icon')).not.toBeNull();
+    expect(queryByTestId('back-home')).not.toBeNull();
+    expect(queryByTestId('spinner')).toBeNull();
+  });
+
+  // Web only in practice: the signed-out visitor goes to login carrying the path
+  // so the climb survives the round trip.
+  it('redirects to the login href with the return path at auth-required', () => {
+    const { queryByTestId } = render(
+      createElement(BoardRouteRedirect, { status: 'auth-required' as BoardRouteStatus }),
+    );
+
+    expect(redirect.hrefs).toEqual(['/auth/login?next=%2Fb%2Fthe-gym%2F40%2Flist']);
+    expect(queryByTestId('spinner')).toBeNull();
+    expect(queryByTestId('error-icon')).toBeNull();
+  });
+});
+
+describe('Board Route Handoff event', () => {
+  it.each([
+    ['resolved', CLIMB_TARGET, { kind: 'climb', status: 'resolved', source: 'deep-link' }],
+    ['auth-required', SLUG_CLIMB_TARGET, { kind: 'slug-climb', status: 'auth_required', source: 'deep-link' }],
+    ['not-found', null, { kind: 'unparsed', status: 'not_found', source: 'deep-link' }],
+  ] as const)('fires once for the %s terminal status', (status, target, expected) => {
+    routeStatus.current = status;
+
+    render(createElement(BoardRouteHandoff, { target }));
+
+    expect(analytics.track).toHaveBeenCalledTimes(1);
+    expect(analytics.track).toHaveBeenCalledWith(SHARED_EVENTS.BoardRouteHandoff, expected);
+  });
+
+  it('tags an in-app open as its own source', () => {
+    routeStatus.current = 'resolved';
+
+    render(createElement(BoardRouteHandoff, { target: CLIMB_TARGET, mode: 'in-app' }));
+
+    expect(analytics.track).toHaveBeenCalledWith(SHARED_EVENTS.BoardRouteHandoff, {
+      kind: 'climb',
+      status: 'resolved',
+      source: 'in-app',
+    });
+  });
+
+  it('stays quiet while the route is still resolving', () => {
+    routeStatus.current = 'resolving';
+
+    render(createElement(BoardRouteHandoff, { target: CLIMB_TARGET }));
+
+    expect(analytics.track).not.toHaveBeenCalled();
+  });
+
+  it('does not double-fire when the same status re-renders', () => {
+    routeStatus.current = 'resolved';
+
+    const { rerender } = render(createElement(BoardRouteHandoff, { target: CLIMB_TARGET }));
+    rerender(createElement(BoardRouteHandoff, { target: CLIMB_TARGET }));
+
+    expect(analytics.track).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mobile/src/components/__tests__/BoardRouteRedirect.test.tsx
+++ b/packages/mobile/src/components/__tests__/BoardRouteRedirect.test.tsx
@@ -146,4 +146,21 @@ describe('Board Route Handoff event', () => {
 
     expect(analytics.track).toHaveBeenCalledTimes(1);
   });
+
+  // The web build reuses the mounted route component when a second link is
+  // tapped, and two climbs on the same board settle to an identical `{ kind,
+  // status, source }` — so deduplicating on the event props alone would silently
+  // undercount every board-route open after the first.
+  it('reports a second URL through the same mounted screen', () => {
+    routeStatus.current = 'resolved';
+
+    const { rerender } = render(createElement(BoardRouteHandoff, { target: CLIMB_TARGET }));
+    rerender(
+      createElement(BoardRouteHandoff, {
+        target: { ...CLIMB_TARGET, climbUuid: 'F9E8D7C6B5A4938271605F4E3D2C1B0A' } as BoardRouteTarget,
+      }),
+    );
+
+    expect(analytics.track).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/mobile/src/lib/__tests__/auth.web.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth.web.test.ts
@@ -77,6 +77,27 @@ describe('Expo web OAuth', () => {
     );
   });
 
+  // Without this the W-06 fix is dead on the most common signed-out login:
+  // "Continue with Google" navigates the document away, and the callback URL is
+  // rebuilt from scratch on the way back — dropping any `next` in the address
+  // bar. The two tests above are the regression lock for the no-`next` case:
+  // that callbackUrl stays byte-identical to what ships today.
+  it('carries a read-only return path through the OAuth callback', () => {
+    const next = '/b/the-gym/40/view/crimpy-thing-0A1B2C3D4E5F60718293A4B5C6D7E8F9';
+    const url = new URL(
+      buildWebOAuthStartUrl('google', 'https://app.boardsesh.com', 'attempt-google-2', false, '', next),
+    );
+
+    const callbackUrl = new URL(url.searchParams.get('callbackUrl') ?? '');
+    expect(callbackUrl.pathname).toBe('/auth/login');
+    // Verbatim: validation is `readPostLoginReturnHref`'s job on the way back
+    // in, not this builder's.
+    expect(callbackUrl.searchParams.get('next')).toBe(next);
+    // And the OAuth return markers are untouched.
+    expect(callbackUrl.searchParams.get('boardseshOAuthProvider')).toBe('google');
+    expect(callbackUrl.searchParams.get('boardseshOAuthAttempt')).toBe('attempt-google-2');
+  });
+
   it('reports browser navigation failures without throwing', async () => {
     vi.stubGlobal('window', {
       location: {

--- a/packages/mobile/src/lib/__tests__/auth.web.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth.web.test.ts
@@ -1,4 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Vitest resolves `anonymous-auth-gate` to the NATIVE fork, whose
+// `readPostLoginReturnHref()` is a constant `null` — so without this the wiring
+// from the address bar into the OAuth callback can't be exercised at all. The
+// default matches that native constant, leaving every other test in this file
+// untouched.
+const returnHrefState = vi.hoisted(() => ({ current: null as string | null }));
+vi.mock('../routing/anonymous-auth-gate', () => ({
+  readPostLoginReturnHref: () => returnHrefState.current,
+}));
+
 import { captureAuthCredentialGeneration, clearTokens, getAuthToken, synchronizeWebSession } from '../auth-store.web';
 import {
   buildWebOAuthStartUrl,
@@ -46,6 +57,7 @@ beforeEach(async () => {
   // the NextAuth callback from it. The standalone subdomain export case
   // (no base path → '/') has its own test below.
   vi.stubEnv('EXPO_BASE_URL', '/app');
+  returnHrefState.current = null;
   await clearTokens();
 });
 
@@ -96,6 +108,35 @@ describe('Expo web OAuth', () => {
     // And the OAuth return markers are untouched.
     expect(callbackUrl.searchParams.get('boardseshOAuthProvider')).toBe('google');
     expect(callbackUrl.searchParams.get('boardseshOAuthAttempt')).toBe('attempt-google-2');
+  });
+
+  // The wiring, not just the builder: tapping "Continue with Google" on a login
+  // (or sign-up) screen that carries a `next` must put that value on the
+  // callback URL, because the document unloads and the address bar does not
+  // come back.
+  it('puts the return path of the current screen on the OAuth start URL', async () => {
+    const next = '/b/the-gym/40/view/crimpy-thing-0A1B2C3D4E5F60718293A4B5C6D7E8F9';
+    returnHrefState.current = next;
+    const assign = vi.fn();
+    vi.stubGlobal('window', { location: { origin: 'https://app.boardsesh.com', assign } });
+
+    await signInWithGoogle('attempt-google-3');
+
+    const startUrl = new URL(assign.mock.calls[0]?.[0] as string);
+    const callbackUrl = new URL(startUrl.searchParams.get('callbackUrl') ?? '');
+    expect(callbackUrl.searchParams.get('next')).toBe(next);
+  });
+
+  it('leaves the OAuth start URL alone when there is no return path', async () => {
+    const assign = vi.fn();
+    vi.stubGlobal('window', { location: { origin: 'https://app.boardsesh.com', assign } });
+
+    await signInWithGoogle('attempt-google-4');
+
+    const startUrl = new URL(assign.mock.calls[0]?.[0] as string);
+    expect(startUrl.searchParams.get('callbackUrl')).toBe(
+      'https://app.boardsesh.com/app/auth/login?boardseshOAuthProvider=google&boardseshOAuthAttempt=attempt-google-4',
+    );
   });
 
   it('reports browser navigation failures without throwing', async () => {

--- a/packages/mobile/src/lib/auth.web.ts
+++ b/packages/mobile/src/lib/auth.web.ts
@@ -18,6 +18,7 @@ import {
   WEB_OAUTH_RETURN_ATTEMPT_PARAM,
   WEB_OAUTH_RETURN_PROVIDER_PARAM,
 } from './oauth-return-marker';
+import { readPostLoginReturnHref } from './routing/anonymous-auth-gate';
 
 export type AuthProvider = 'google' | 'apple';
 
@@ -505,6 +506,17 @@ export function isGoogleSignInConfigured(): boolean {
  * runs on WEB_BASE_URL (www in production), while the callback returns to the
  * exact auth route that initiated it: `/app/auth/...` for the same-origin build
  * and `/auth/...` for app.boardsesh.com.
+ *
+ * `returnHref` is the read-only board path a signed-out visitor arrived on. It
+ * has to ride the callback URL rather than the address bar, because "Continue
+ * with Google" navigates the document away and this function rebuilds the return
+ * URL from scratch on the way back — without it, the most common signed-out
+ * login silently drops the climb. Carrying it is safe with no www change: www's
+ * NextAuth redirect callback returns an allowed app-origin URL verbatim
+ * (`packages/web/app/lib/auth/auth-options.ts`), and `consumeWebOAuthReturn()`
+ * strips only the three `bs_oauth_*` params on arrival, so `next` is still in
+ * `window.location.search` when AuthProvider's authenticated branch reads it.
+ * The value is validated where it is consumed, not here.
  */
 export function buildWebOAuthStartUrl(
   provider: AuthProvider,
@@ -512,11 +524,13 @@ export function buildWebOAuthStartUrl(
   attemptId: string,
   isRegistration = false,
   exportBasePath = process.env.EXPO_BASE_URL || '/',
+  returnHref: string | null = null,
 ): string {
   const normalizedBasePath = exportBasePath === '/' ? '' : exportBasePath.replace(/\/$/, '');
   const callbackUrl = new URL(`${normalizedBasePath}/auth/${isRegistration ? 'register' : 'login'}`, appOrigin);
   callbackUrl.searchParams.set(WEB_OAUTH_RETURN_PROVIDER_PARAM, provider);
   callbackUrl.searchParams.set(WEB_OAUTH_RETURN_ATTEMPT_PARAM, attemptId);
+  if (returnHref) callbackUrl.searchParams.set('next', returnHref);
   const startUrl = new URL('/auth/native-start', WEB_BASE_URL);
   startUrl.searchParams.set('provider', provider);
   startUrl.searchParams.set('callbackUrl', callbackUrl.toString());
@@ -530,7 +544,16 @@ function startWebOAuth(provider: AuthProvider, attemptId?: string, isRegistratio
 
   try {
     const resolvedAttemptId = attemptId ?? createWebOAuthAttemptId();
-    window.location.assign(buildWebOAuthStartUrl(provider, window.location.origin, resolvedAttemptId, isRegistration));
+    window.location.assign(
+      buildWebOAuthStartUrl(
+        provider,
+        window.location.origin,
+        resolvedAttemptId,
+        isRegistration,
+        process.env.EXPO_BASE_URL || '/',
+        readPostLoginReturnHref(),
+      ),
+    );
     // The document is about to unload. This distinct result prevents the
     // in-process native flow from reporting success or checking the old cookie
     // before the provider round-trip returns.

--- a/packages/mobile/src/lib/routing/__tests__/anonymous-auth-gate.test.ts
+++ b/packages/mobile/src/lib/routing/__tests__/anonymous-auth-gate.test.ts
@@ -1,0 +1,67 @@
+// The native-unchanged guarantee, at module level.
+//
+// This PR auto-OTAs to every installed binary on merge to `main`, so "the web
+// relaxation cannot reach native" has to be an assertion, not an argument.
+// Vitest has no `.web` extension resolution (see `packages/mobile/vite.config.ts`,
+// whose alias list spells out every platform split), so the bare import below IS
+// the native fork — the same module Metro hands the store fleet.
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  buildLoginHrefWithReturn,
+  isAnonymousReadOnlyLocation,
+  readPostLoginReturnHref,
+  RELAXES_ANONYMOUS_ROUTES,
+} from '../anonymous-auth-gate';
+import { CLIMB_SEGMENT, GATED_PATHS, READ_ONLY_PATHS } from './read-only-route-corpus';
+
+const ALL_PATHS = [...READ_ONLY_PATHS, ...GATED_PATHS];
+
+/** Stand a `window.location` up so a fork that reads one has something to read. */
+function atLocation(pathname: string, search = '') {
+  vi.stubGlobal('window', { location: { pathname, search, origin: 'https://app.boardsesh.com' } });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('anonymous-auth-gate (native fork)', () => {
+  it('declares that native relaxes nothing', () => {
+    expect(RELAXES_ANONYMOUS_ROUTES).toBe(false);
+  });
+
+  // Driven through a stubbed location on purpose: passing every relaxed path and
+  // still getting `false` proves the fork ignores the address bar entirely,
+  // rather than merely happening to be false in this environment.
+  it.each(ALL_PATHS)('never relaxes the gate at %s', (path) => {
+    atLocation(path);
+    expect(isAnonymousReadOnlyLocation()).toBe(false);
+  });
+
+  it.each(ALL_PATHS)('hands back the bare login route at %s', (path) => {
+    atLocation(path);
+    expect(buildLoginHrefWithReturn()).toBe('/auth/login');
+  });
+
+  it('reads no return href, even with a valid next in the query', () => {
+    atLocation(`/b/the-gym/40/view/${CLIMB_SEGMENT}`, `?next=/b/the-gym/40/view/${CLIMB_SEGMENT}`);
+    expect(readPostLoginReturnHref()).toBeNull();
+  });
+
+  it('reads no return href with no window at all', () => {
+    expect(readPostLoginReturnHref()).toBeNull();
+  });
+});
+
+describe('anonymous-auth-gate fork parity', () => {
+  // The web AuthProvider suite substitutes the web fork for the native one via
+  // `vi.mock`. That substitution is only faithful while both forks export the
+  // same symbols — so a symbol added to one and forgotten in the other fails
+  // here rather than silently at runtime on one platform.
+  it('exports the same symbols from both forks', async () => {
+    const nativeFork = await import('../anonymous-auth-gate');
+    const webFork = await import('../anonymous-auth-gate.web');
+    expect(Object.keys(webFork).sort()).toEqual(Object.keys(nativeFork).sort());
+  });
+});

--- a/packages/mobile/src/lib/routing/__tests__/anonymous-auth-gate.web.test.ts
+++ b/packages/mobile/src/lib/routing/__tests__/anonymous-auth-gate.web.test.ts
@@ -83,6 +83,16 @@ describe('readPostLoginReturnHref', () => {
     goTo('/auth/login');
     expect(readPostLoginReturnHref()).toBeNull();
   });
+
+  // Login forwards `next` to the sign-up screen as an Expo Router param, which
+  // lands in the address bar. Reading it back is what makes "register instead of
+  // signing in" return to the same climb — and it is also what
+  // `startWebOAuth` reads when someone taps "Continue with Google" from there.
+  it('reads the same next off the register screen', () => {
+    const next = `/b/the-gym/40/view/${CLIMB_SEGMENT}`;
+    goTo(`/auth/register?next=${encodeURIComponent(next)}`);
+    expect(readPostLoginReturnHref()).toBe(next);
+  });
 });
 
 // `EXPO_BASE_URL` is `/app` on the www-mounted export and `/` on the

--- a/packages/mobile/src/lib/routing/__tests__/anonymous-auth-gate.web.test.ts
+++ b/packages/mobile/src/lib/routing/__tests__/anonymous-auth-gate.web.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+//
+// The web fork, imported by its explicit `.web` path — vitest resolves the bare
+// specifier to the native fork, so this suite is the only thing that exercises
+// the code app.boardsesh.com actually runs.
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  buildLoginHrefWithReturn,
+  isAnonymousReadOnlyLocation,
+  readPostLoginReturnHref,
+  RELAXES_ANONYMOUS_ROUTES,
+} from '../anonymous-auth-gate.web';
+import { CLIMB_SEGMENT, GATED_PATHS, READ_ONLY_PATHS } from './read-only-route-corpus';
+
+/** Move the jsdom address bar, which is what the fork reads. */
+function goTo(url: string) {
+  window.history.replaceState({}, '', url);
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  goTo('/');
+});
+
+describe('anonymous-auth-gate (web fork)', () => {
+  it('declares that web relaxes the gate', () => {
+    expect(RELAXES_ANONYMOUS_ROUTES).toBe(true);
+  });
+
+  it.each(READ_ONLY_PATHS)('relaxes the gate at %s', (path) => {
+    goTo(path);
+    expect(isAnonymousReadOnlyLocation()).toBe(true);
+  });
+
+  it.each(GATED_PATHS)('leaves the gate standing at %s', (path) => {
+    goTo(path);
+    expect(isAnonymousReadOnlyLocation()).toBe(false);
+  });
+
+  it.each(READ_ONLY_PATHS)('carries %s into the login href', (path) => {
+    goTo(path);
+    expect(buildLoginHrefWithReturn()).toBe(`/auth/login?next=${encodeURIComponent(path)}`);
+  });
+
+  // The redirect-loop guard: a gated path — `/auth/login` included — gets the
+  // bare login route, so a `next` can never name an auth route.
+  it.each(GATED_PATHS)('hands back the bare login route at %s', (path) => {
+    goTo(path);
+    expect(buildLoginHrefWithReturn()).toBe('/auth/login');
+  });
+
+  // The query is deliberately not carried: the canonical board URLs have no
+  // meaningful one, and dropping it stops `bs_oauth_*` residue riding along.
+  it('carries the path only, not the query', () => {
+    goTo('/b/the-gym/40/list?boardseshOAuthProvider=google');
+    expect(buildLoginHrefWithReturn()).toBe(`/auth/login?next=${encodeURIComponent('/b/the-gym/40/list')}`);
+  });
+});
+
+describe('readPostLoginReturnHref', () => {
+  it('returns a valid board path', () => {
+    const next = `/b/the-gym/40/view/${CLIMB_SEGMENT}`;
+    goTo(`/auth/login?next=${encodeURIComponent(next)}`);
+    expect(readPostLoginReturnHref()).toBe(next);
+  });
+
+  it.each([
+    ['an absolute URL', 'https://evil.example'],
+    ['a protocol-relative URL', '//evil.example'],
+    ['a double-encoded protocol-relative URL', '%2f%2fevil.example'],
+    ['a javascript: URL', 'javascript:alert(1)'],
+    ['a backslash escape', '/%5Cevil.example'],
+    // App-relative and perfectly safe, but outside the set the gate can produce.
+    // The second gate is what stops a hand-crafted next reaching any in-app route.
+    ['an in-app route outside the allow-set', '/(tabs)/profile'],
+  ])('drops %s', (_label, next) => {
+    goTo(`/auth/login?next=${next}`);
+    expect(readPostLoginReturnHref()).toBeNull();
+  });
+
+  it('returns null when there is no next at all', () => {
+    goTo('/auth/login');
+    expect(readPostLoginReturnHref()).toBeNull();
+  });
+});
+
+// `EXPO_BASE_URL` is `/app` on the www-mounted export and `/` on the
+// app.boardsesh.com subdomain export. `window.location.pathname` carries it;
+// the router path does not, and neither does the `next` we hand back.
+describe('EXPO_BASE_URL base stripping', () => {
+  it('relaxes a based path and emits a base-relative next', () => {
+    vi.stubEnv('EXPO_BASE_URL', '/app');
+    goTo('/app/b/the-gym/40/list');
+    expect(isAnonymousReadOnlyLocation()).toBe(true);
+    expect(buildLoginHrefWithReturn()).toBe(`/auth/login?next=${encodeURIComponent('/b/the-gym/40/list')}`);
+  });
+
+  it('does not relax the mount point itself', () => {
+    vi.stubEnv('EXPO_BASE_URL', '/app');
+    goTo('/app');
+    expect(isAnonymousReadOnlyLocation()).toBe(false);
+    expect(buildLoginHrefWithReturn()).toBe('/auth/login');
+  });
+});

--- a/packages/mobile/src/lib/routing/__tests__/anonymous-auth-gate.web.test.ts
+++ b/packages/mobile/src/lib/routing/__tests__/anonymous-auth-gate.web.test.ts
@@ -88,6 +88,16 @@ describe('readPostLoginReturnHref', () => {
   // lands in the address bar. Reading it back is what makes "register instead of
   // signing in" return to the same climb — and it is also what
   // `startWebOAuth` reads when someone taps "Continue with Google" from there.
+  // A Spanish, French or German share link is the case this whole feature was
+  // extended for, so the round trip is exercised end to end and not only through
+  // the predicate: the locale-prefixed path is what login is handed, and it has
+  // to come back out intact.
+  it.each(['es', 'fr', 'de'])('returns a /%s-prefixed board path', (locale) => {
+    const next = `/${locale}/b/the-gym/40/view/${CLIMB_SEGMENT}`;
+    goTo(`/auth/login?next=${encodeURIComponent(next)}`);
+    expect(readPostLoginReturnHref()).toBe(next);
+  });
+
   it('reads the same next off the register screen', () => {
     const next = `/b/the-gym/40/view/${CLIMB_SEGMENT}`;
     goTo(`/auth/register?next=${encodeURIComponent(next)}`);

--- a/packages/mobile/src/lib/routing/__tests__/read-only-route-corpus.ts
+++ b/packages/mobile/src/lib/routing/__tests__/read-only-route-corpus.ts
@@ -56,6 +56,12 @@ export const GATED_PATHS: readonly string[] = [
   // Prefixes that carry no destination of their own.
   '/b',
   '/es',
+  // Right segment count, routing syntax where a board identifier belongs. The
+  // group folder never appears in a browser URL and the relative segment is one
+  // the browser would have normalised away — neither is a path this gate could
+  // have produced, so neither is one it will follow back.
+  '/(tabs)/profile/a/b/40/list',
+  '/b/..',
 ];
 
 export { CLIMB_UUID, CLIMB_SEGMENT, TUPLE };

--- a/packages/mobile/src/lib/routing/__tests__/read-only-route-corpus.ts
+++ b/packages/mobile/src/lib/routing/__tests__/read-only-route-corpus.ts
@@ -1,0 +1,61 @@
+// The route corpus every anonymous-gate suite runs against.
+//
+// Not a suite itself (the mobile vitest `include` is `src/**/*.test.{ts,tsx}`),
+// just the two lists. Keeping them in one place is what makes "the native fork
+// is inert" and "the web fork relaxes exactly these" the same claim measured
+// against the same paths — a path added here is immediately asserted by the
+// predicate suite, both fork suites and both AuthProvider gate suites.
+
+const CLIMB_UUID = '0A1B2C3D4E5F60718293A4B5C6D7E8F9';
+
+/** A climb segment as the web front door writes it: slug tail plus uuid. */
+const CLIMB_SEGMENT = `crimpy-thing-${CLIMB_UUID}`;
+
+const TUPLE = '/kilter/original/12x12-square/screw_bolt';
+
+/** Every URL shape a signed-out visitor may land on. */
+export const READ_ONLY_PATHS: readonly string[] = [
+  // `/b/{slug}` — the named-board tree.
+  '/b/the-gym',
+  '/b/the-gym/40/list',
+  `/b/the-gym/40/view/${CLIMB_SEGMENT}`,
+  `/b/the-gym/40/play/${CLIMB_UUID}`,
+  // The canonical config-tuple tree, in both the named-slug and numeric-id forms
+  // the web app emits.
+  `${TUPLE}/40/list`,
+  '/kilter/1/10/1,20/40/list',
+  `${TUPLE}/40/view/${CLIMB_SEGMENT}`,
+  `${TUPLE}/40/play/${CLIMB_UUID}`,
+  // A negative angle is a real board angle, not a malformed segment.
+  `${TUPLE}/-15/list`,
+  // Locale-prefixed shares. Expo has no `[locale]` segment, so these match no
+  // route and land on `+not-found`, which strips the prefix and re-redirects —
+  // but the gate runs first, so it has to relax both forms or every non-English
+  // share link still hits a bare login wall.
+  `/es${TUPLE}/40/view/${CLIMB_SEGMENT}`,
+  `/fr${TUPLE}/40/view/${CLIMB_SEGMENT}`,
+  `/de/b/the-gym/40/view/${CLIMB_SEGMENT}`,
+];
+
+/** Everything else: still behind the login gate, on every platform. */
+export const GATED_PATHS: readonly string[] = [
+  '/',
+  '/(tabs)/home',
+  '/(tabs)/profile',
+  '/auth/login',
+  '/auth/register',
+  '/boards',
+  '/join/abc',
+  '/users/123',
+  '/play',
+  `/climbs/${CLIMB_UUID}`,
+  // Right shape, wrong angle segment — a broken URL, not a read-only one.
+  `${TUPLE}/notanangle/list`,
+  // A board surface that is not read-only.
+  `${TUPLE}/40/edit`,
+  // Prefixes that carry no destination of their own.
+  '/b',
+  '/es',
+];
+
+export { CLIMB_UUID, CLIMB_SEGMENT, TUPLE };

--- a/packages/mobile/src/lib/routing/__tests__/read-only-routes.test.ts
+++ b/packages/mobile/src/lib/routing/__tests__/read-only-routes.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { isReadOnlyAnonymousPath, isSafeReturnPath, MAX_RETURN_HREF_LENGTH } from '../read-only-routes';
+import { CLIMB_SEGMENT, GATED_PATHS, READ_ONLY_PATHS, TUPLE } from './read-only-route-corpus';
+
+describe('isReadOnlyAnonymousPath', () => {
+  it.each(READ_ONLY_PATHS)('relaxes %s', (path) => {
+    expect(isReadOnlyAnonymousPath(path)).toBe(true);
+  });
+
+  it.each(GATED_PATHS)('keeps %s gated', (path) => {
+    expect(isReadOnlyAnonymousPath(path)).toBe(false);
+  });
+
+  // The www front door appends campaign params to shared links, and the browser
+  // keeps the fragment. Neither changes which route the URL names.
+  it.each([
+    '/b/the-gym/40/list?utm_source=newsletter',
+    '/b/the-gym/40/list#holds',
+    `${TUPLE}/40/view/${CLIMB_SEGMENT}?page=2#beta`,
+  ])('ignores the query/hash tail on %s', (path) => {
+    expect(isReadOnlyAnonymousPath(path)).toBe(true);
+  });
+
+  it('tolerates a trailing slash', () => {
+    expect(isReadOnlyAnonymousPath('/b/the-gym/40/list/')).toBe(true);
+  });
+
+  // The locale has to be a whole segment — `stripLocalePrefix`'s rule. Chopping
+  // `es` off `estonia` would relax a route nobody asked for.
+  it.each(['/estonia/kilter/1/10/1,20/40/list', '/esp/b/the-gym/40/list'])(
+    'does not treat %s as locale-prefixed',
+    (path) => {
+      expect(isReadOnlyAnonymousPath(path)).toBe(false);
+    },
+  );
+});
+
+describe('isSafeReturnPath', () => {
+  it('accepts an app-relative board path', () => {
+    expect(isSafeReturnPath(`/b/the-gym/40/view/${CLIMB_SEGMENT}`)).toBe(true);
+  });
+
+  // One rejection test each for the open-redirect shapes. `\t` and the backslash
+  // forms are the ones that survive a naive "starts with /" check: browsers trim
+  // leading whitespace and normalise `\` to `/` before navigating.
+  it.each([
+    ['an absolute URL', 'https://evil.example/x'],
+    ['a protocol-relative URL', '//evil.example'],
+    ['a javascript: URL', 'javascript:alert(1)'],
+    ['a mixed-case scheme', 'JaVaScRiPt:alert(1)'],
+    ['a backslash escape', '/\\evil.example'],
+    ['a double backslash', '\\\\evil.example'],
+    ['a leading tab', '\t/b/the-gym/40/list'],
+    ['a leading newline', '\n//evil.example'],
+    ['a relative path', 'b/the-gym/40/list'],
+    ['an empty string', ''],
+    ['null', null],
+    ['undefined', undefined],
+  ])('rejects %s', (_label, value) => {
+    expect(isSafeReturnPath(value)).toBe(false);
+  });
+
+  it('rejects a path past the length cap', () => {
+    expect(isSafeReturnPath(`/b/${'a'.repeat(MAX_RETURN_HREF_LENGTH)}`)).toBe(false);
+  });
+
+  // `%2f%2fevil.example` arrives here already decoded — `URLSearchParams.get`
+  // decodes once — so the protocol-relative rule is what catches it.
+  it('rejects a percent-decoded protocol-relative value', () => {
+    expect(isSafeReturnPath(decodeURIComponent('%2f%2fevil.example'))).toBe(false);
+  });
+});

--- a/packages/mobile/src/lib/routing/__tests__/use-board-route-target.test.tsx
+++ b/packages/mobile/src/lib/routing/__tests__/use-board-route-target.test.tsx
@@ -539,7 +539,11 @@ describe('useBoardRouteTarget', () => {
     fetchAllMyBoards.mockResolvedValue([RESOLVED_BOARD]);
     act(() => connectivity.goOnline());
 
-    await waitFor(() => expect(setActiveBoard).toHaveBeenCalledWith(RESOLVED_BOARD));
+    // The healed resolve is the longest await chain in this file — a local-board
+    // probe, the owned-list walk and the resolver all have to settle before the
+    // board is adopted. `waitFor`'s 1s default loses that race on a loaded CI
+    // box (observed on PR #4418), so this one gets room.
+    await waitFor(() => expect(setActiveBoard).toHaveBeenCalledWith(RESOLVED_BOARD), { timeout: 5000 });
     expect(fetchAllMyBoards).toHaveBeenCalledTimes(1);
     // The healed resolve hands off; the stale not-found is gone either way.
     expect(statusOf(container)).not.toBe('not-found');

--- a/packages/mobile/src/lib/routing/__tests__/use-board-route-target.test.tsx
+++ b/packages/mobile/src/lib/routing/__tests__/use-board-route-target.test.tsx
@@ -26,6 +26,9 @@ const climbQuery = vi.hoisted(() => ({
 }));
 // Mirrors AuthProvider: `isLoading` starts true and the session resolves async.
 const authState = vi.hoisted(() => ({ current: { isAuthenticated: true, isLoading: false } }));
+// `false` is the native fork's value, which is what every pre-existing case in
+// this file runs against.
+const gateState = vi.hoisted(() => ({ relaxesRoutes: false }));
 // The hook reads connectivity straight off React Query's onlineManager (the
 // resolve runs once, so a reactive hook would be the wrong shape) and subscribes
 // to it to heal a resolve that failed offline. `goOnline` drives that transition
@@ -73,6 +76,17 @@ vi.mock('../../board-path-to-user-board', async (importOriginal) => ({
   resolveBoardForSession,
 }));
 vi.mock('../../open-climb-in-play-drawer', () => ({ openClimbInPlayDrawer }));
+// The platform switch, as a mutable so one suite can exercise both forks. A
+// getter (not a captured value) because the hook reads the constant on every
+// render and the mock factory runs once.
+vi.mock('../anonymous-auth-gate', () => ({
+  get RELAXES_ANONYMOUS_ROUTES() {
+    return gateState.relaxesRoutes;
+  },
+  isAnonymousReadOnlyLocation: () => false,
+  buildLoginHrefWithReturn: () => '/auth/login',
+  readPostLoginReturnHref: () => null,
+}));
 
 const { useBoardRouteTarget } = await import('../use-board-route-target');
 const { resolveBoardForSession: realResolveBoardForSession } = await vi.importActual<
@@ -148,6 +162,7 @@ beforeEach(() => {
   getOfflineBoards.mockReturnValue([]);
   climbQuery.current = { data: undefined, isError: false, isSuccess: false };
   authState.current = { isAuthenticated: true, isLoading: false };
+  gateState.relaxesRoutes = false;
   connectivity.isOnline = true;
   connectivity.listeners.clear();
 });
@@ -394,7 +409,8 @@ describe('useBoardRouteTarget', () => {
     await waitFor(() => expect(setActiveBoard).toHaveBeenCalledTimes(1));
     expect(fetchBoardByUuid).toHaveBeenCalledWith('existing-uuid');
     expect(setActiveBoard).toHaveBeenCalledWith({ ...existingBoard, angle: 40 });
-    expect(statusOf(container)).toBe('resolving');
+    // A recovered duplicate is a successful hand-off, not a dead end.
+    await waitFor(() => expect(statusOf(container)).toBe('resolved'));
   });
 
   // The headline optimization: the deep link almost always names the wall the
@@ -525,8 +541,10 @@ describe('useBoardRouteTarget', () => {
 
     await waitFor(() => expect(setActiveBoard).toHaveBeenCalledWith(RESOLVED_BOARD));
     expect(fetchAllMyBoards).toHaveBeenCalledTimes(1);
-    expect(statusOf(container)).toBe('resolving');
+    // The healed resolve hands off; the stale not-found is gone either way.
+    expect(statusOf(container)).not.toBe('not-found');
     await waitFor(() => expect(router.replace).toHaveBeenCalledWith('/(tabs)/climbs'));
+    await waitFor(() => expect(statusOf(container)).toBe('resolved'));
   });
 
   // A dead slug fails while ONLINE, so no offline→online transition can follow
@@ -704,5 +722,117 @@ describe('useBoardRouteTarget', () => {
     expect(router.back).not.toHaveBeenCalled();
     // Still in-app: a cold open must not adopt (or mint) the URL's board.
     expect(setActiveBoard).not.toHaveBeenCalled();
+  });
+});
+
+// Web only: `app.boardsesh.com` serves these routes to a signed-out visitor so
+// the climb they arrived for survives the login round trip. Board adoption is
+// what forces the short-circuit — the tuple form mints a UserBoard through
+// `createBoard`, which is `requireAuthenticated`.
+describe('useBoardRouteTarget signed-out on web', () => {
+  it('short-circuits a deep link to auth-required without resolving anything', async () => {
+    gateState.relaxesRoutes = true;
+    authState.current = { isAuthenticated: false, isLoading: false };
+
+    const { container } = render(
+      createElement(Harness, { target: { kind: 'list', board: KILTER_BOARD } as BoardRouteTarget }),
+    );
+
+    await waitFor(() => expect(statusOf(container)).toBe('auth-required'));
+    // The assertion that matters: nothing was asked of the server, and no board
+    // was adopted or minted, on behalf of someone with no account.
+    expect(resolveBoardForSession).not.toHaveBeenCalled();
+    expect(fetchAllMyBoards).not.toHaveBeenCalled();
+    expect(createBoardMutateAsync).not.toHaveBeenCalled();
+    expect(setActiveBoard).not.toHaveBeenCalled();
+    expect(openClimbInPlayDrawer).not.toHaveBeenCalled();
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  it('short-circuits a slug climb URL the same way', async () => {
+    gateState.relaxesRoutes = true;
+    authState.current = { isAuthenticated: false, isLoading: false };
+    climbQuery.current = { data: { uuid: CLIMB_UUID }, isError: false, isSuccess: true };
+
+    const { container } = render(
+      createElement(Harness, {
+        target: { kind: 'slug-climb', slug: 'the-gym', angle: 40, climbUuid: CLIMB_UUID } as BoardRouteTarget,
+      }),
+    );
+
+    await waitFor(() => expect(statusOf(container)).toBe('auth-required'));
+    expect(fetchBoardBySlug).not.toHaveBeenCalled();
+    expect(openClimbInPlayDrawer).not.toHaveBeenCalled();
+  });
+
+  // An unsettled session reads as signed-out for a beat on every cold open.
+  // Bouncing on it would send signed-in visitors to login too.
+  it('waits for the session to settle before deciding auth is required', () => {
+    gateState.relaxesRoutes = true;
+    authState.current = { isAuthenticated: false, isLoading: true };
+
+    const { container } = render(
+      createElement(Harness, { target: { kind: 'list', board: KILTER_BOARD } as BoardRouteTarget }),
+    );
+
+    expect(statusOf(container)).toBe('resolving');
+  });
+
+  // The native fork's constant `false` is what makes this whole branch
+  // unreachable on the store fleet — the same signed-out state resolves as it
+  // always has.
+  it('never reports auth-required when the platform does not relax routes', async () => {
+    gateState.relaxesRoutes = false;
+    authState.current = { isAuthenticated: false, isLoading: false };
+
+    const { container } = render(
+      createElement(Harness, { target: { kind: 'list', board: KILTER_BOARD } as BoardRouteTarget }),
+    );
+
+    await waitFor(() => expect(setActiveBoard).toHaveBeenCalledWith(RESOLVED_BOARD));
+    expect(statusOf(container)).not.toBe('auth-required');
+  });
+
+  // `in-app` adopts nothing, so there is nothing to need an account for.
+  it('does not short-circuit an in-app target', async () => {
+    gateState.relaxesRoutes = true;
+    authState.current = { isAuthenticated: false, isLoading: false };
+    climbQuery.current = { data: { uuid: CLIMB_UUID }, isError: false, isSuccess: true };
+
+    const { container } = render(
+      createElement(Harness, {
+        target: { kind: 'climb', board: KILTER_BOARD, climbUuid: CLIMB_UUID } as BoardRouteTarget,
+        mode: 'in-app',
+      }),
+    );
+
+    await waitFor(() => expect(openClimbInPlayDrawer).toHaveBeenCalledTimes(1));
+    expect(statusOf(container)).not.toBe('auth-required');
+  });
+});
+
+// `resolved` is a terminal status the hand-off telemetry can report. It renders
+// the same spinner as `resolving` — the screen is already navigating away.
+describe('useBoardRouteTarget terminal resolved status', () => {
+  it('reports resolved once a list URL has handed off', async () => {
+    const { container } = render(
+      createElement(Harness, { target: { kind: 'list', board: KILTER_BOARD } as BoardRouteTarget }),
+    );
+
+    await waitFor(() => expect(router.replace).toHaveBeenCalledWith('/(tabs)/climbs'));
+    await waitFor(() => expect(statusOf(container)).toBe('resolved'));
+  });
+
+  it('reports resolved once a climb URL has opened the drawer', async () => {
+    climbQuery.current = { data: { uuid: CLIMB_UUID }, isError: false, isSuccess: true };
+
+    const { container } = render(
+      createElement(Harness, {
+        target: { kind: 'climb', board: KILTER_BOARD, climbUuid: CLIMB_UUID } as BoardRouteTarget,
+      }),
+    );
+
+    await waitFor(() => expect(openClimbInPlayDrawer).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(statusOf(container)).toBe('resolved'));
   });
 });

--- a/packages/mobile/src/lib/routing/__tests__/use-board-route-target.test.tsx
+++ b/packages/mobile/src/lib/routing/__tests__/use-board-route-target.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { act, render, waitFor } from '@testing-library/react';
-import { createElement } from 'react';
+import { createElement, useLayoutEffect, useState } from 'react';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import type { BoardRouteTarget } from '../board-route-target';
 
@@ -24,6 +24,9 @@ const climbQuery = vi.hoisted(() => ({
     isSuccess: boolean;
   },
 }));
+// Every `useClimb` argument, so a test can assert the query was never armed —
+// `null` variables is what keeps it from reaching the server.
+const climbQueryVariables = vi.hoisted(() => ({ current: [] as unknown[] }));
 // Mirrors AuthProvider: `isLoading` starts true and the session resolves async.
 const authState = vi.hoisted(() => ({ current: { isAuthenticated: true, isLoading: false } }));
 // `false` is the native fork's value, which is what every pre-existing case in
@@ -56,8 +59,10 @@ vi.mock('@tanstack/react-query', () => ({
   },
 }));
 vi.mock('../../graphql/hooks', () => ({
-  useClimb: (variables: unknown) =>
-    variables ? climbQuery.current : { data: undefined, isError: false, isSuccess: false },
+  useClimb: (variables: unknown) => {
+    climbQueryVariables.current.push(variables);
+    return variables ? climbQuery.current : { data: undefined, isError: false, isSuccess: false };
+  },
   useCreateBoard: () => ({ mutateAsync: createBoardMutateAsync }),
   fetchAllMyBoards,
   fetchBoardByUuid,
@@ -143,8 +148,16 @@ function duplicateBoardRejection(existingBoardUuid: string) {
   };
 }
 
-function Harness({ target, mode }: { target: BoardRouteTarget | null; mode?: 'deep-link' | 'in-app' }) {
-  return createElement('span', { 'data-status': useBoardRouteTarget(target, { mode }) });
+function Harness({
+  target,
+  mode,
+  onHandedOff,
+}: {
+  target: BoardRouteTarget | null;
+  mode?: 'deep-link' | 'in-app';
+  onHandedOff?: () => void;
+}) {
+  return createElement('span', { 'data-status': useBoardRouteTarget(target, { mode, onHandedOff }) });
 }
 
 function statusOf(container: HTMLElement): string | null {
@@ -153,6 +166,9 @@ function statusOf(container: HTMLElement): string | null {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // `clearAllMocks` wipes calls, not implementations — and one case below gives
+  // `replace` a real one that unmounts the harness.
+  router.replace.mockReset();
   router.canGoBack.mockReturnValue(true);
   resolveBoardForSession.mockResolvedValue(RESOLVED_BOARD);
   fetchAllMyBoards.mockResolvedValue([]);
@@ -161,6 +177,7 @@ beforeEach(() => {
   getStoredActiveBoard.mockResolvedValue(null);
   getOfflineBoards.mockReturnValue([]);
   climbQuery.current = { data: undefined, isError: false, isSuccess: false };
+  climbQueryVariables.current = [];
   authState.current = { isAuthenticated: true, isLoading: false };
   gateState.relaxesRoutes = false;
   connectivity.isOnline = true;
@@ -410,7 +427,8 @@ describe('useBoardRouteTarget', () => {
     expect(fetchBoardByUuid).toHaveBeenCalledWith('existing-uuid');
     expect(setActiveBoard).toHaveBeenCalledWith({ ...existingBoard, angle: 40 });
     // A recovered duplicate is a successful hand-off, not a dead end.
-    await waitFor(() => expect(statusOf(container)).toBe('resolved'));
+    await waitFor(() => expect(router.replace).toHaveBeenCalledWith('/(tabs)/climbs'));
+    expect(statusOf(container)).not.toBe('not-found');
   });
 
   // The headline optimization: the deep link almost always names the wall the
@@ -548,7 +566,6 @@ describe('useBoardRouteTarget', () => {
     // The healed resolve hands off; the stale not-found is gone either way.
     expect(statusOf(container)).not.toBe('not-found');
     await waitFor(() => expect(router.replace).toHaveBeenCalledWith('/(tabs)/climbs'));
-    await waitFor(() => expect(statusOf(container)).toBe('resolved'));
   });
 
   // A dead slug fails while ONLINE, so no offline→online transition can follow
@@ -769,6 +786,43 @@ describe('useBoardRouteTarget signed-out on web', () => {
     expect(openClimbInPlayDrawer).not.toHaveBeenCalled();
   });
 
+  // The tuple form is the half that carries its whole board config in the URL,
+  // so nothing has to resolve before the climb query could arm itself. Leaving
+  // it armed would have a signed-out visitor pulling a climb from the server on
+  // the way to a login redirect.
+  it('asks the server for nothing on a tuple climb URL either', async () => {
+    gateState.relaxesRoutes = true;
+    authState.current = { isAuthenticated: false, isLoading: false };
+    climbQuery.current = { data: { uuid: CLIMB_UUID }, isError: false, isSuccess: true };
+
+    const { container } = render(
+      createElement(Harness, {
+        target: { kind: 'climb', board: KILTER_BOARD, climbUuid: CLIMB_UUID } as BoardRouteTarget,
+      }),
+    );
+
+    await waitFor(() => expect(statusOf(container)).toBe('auth-required'));
+    expect(climbQueryVariables.current.every((variables) => variables === null)).toBe(true);
+    expect(resolveBoardForSession).not.toHaveBeenCalled();
+    expect(openClimbInPlayDrawer).not.toHaveBeenCalled();
+  });
+
+  // The same URL signed IN still loads its climb — the gate above must not be a
+  // permanent muzzle on the query.
+  it('arms the climb query as soon as the visitor has an account', async () => {
+    gateState.relaxesRoutes = true;
+    climbQuery.current = { data: { uuid: CLIMB_UUID }, isError: false, isSuccess: true };
+
+    render(
+      createElement(Harness, {
+        target: { kind: 'climb', board: KILTER_BOARD, climbUuid: CLIMB_UUID } as BoardRouteTarget,
+      }),
+    );
+
+    await waitFor(() => expect(openClimbInPlayDrawer).toHaveBeenCalledTimes(1));
+    expect(climbQueryVariables.current).toContainEqual({ ...KILTER_BOARD, climbUuid: CLIMB_UUID });
+  });
+
   // An unsettled session reads as signed-out for a beat on every cold open.
   // Bouncing on it would send signed-in visitors to login too.
   it('waits for the session to settle before deciding auth is required', () => {
@@ -815,28 +869,76 @@ describe('useBoardRouteTarget signed-out on web', () => {
   });
 });
 
-// `resolved` is a terminal status the hand-off telemetry can report. It renders
-// the same spinner as `resolving` — the screen is already navigating away.
-describe('useBoardRouteTarget terminal resolved status', () => {
-  it('reports resolved once a list URL has handed off', async () => {
-    const { container } = render(
-      createElement(Harness, { target: { kind: 'list', board: KILTER_BOARD } as BoardRouteTarget }),
-    );
+// The hand-off is reported through a callback rather than a status because the
+// screen is gone by the time a status could be read: `leave()` removes it from
+// the navigator in the same React batch any state update would land in, so the
+// render carrying it is discarded with the fiber. The last case here is the one
+// that actually proves it — a router that really unmounts.
+describe('useBoardRouteTarget hand-off callback', () => {
+  it('reports once a list URL has handed off', async () => {
+    const onHandedOff = vi.fn();
+
+    render(createElement(Harness, { target: { kind: 'list', board: KILTER_BOARD } as BoardRouteTarget, onHandedOff }));
 
     await waitFor(() => expect(router.replace).toHaveBeenCalledWith('/(tabs)/climbs'));
-    await waitFor(() => expect(statusOf(container)).toBe('resolved'));
+    expect(onHandedOff).toHaveBeenCalledTimes(1);
   });
 
-  it('reports resolved once a climb URL has opened the drawer', async () => {
+  it('reports once a climb URL has opened the drawer', async () => {
     climbQuery.current = { data: { uuid: CLIMB_UUID }, isError: false, isSuccess: true };
+    const onHandedOff = vi.fn();
 
-    const { container } = render(
+    render(
       createElement(Harness, {
         target: { kind: 'climb', board: KILTER_BOARD, climbUuid: CLIMB_UUID } as BoardRouteTarget,
+        onHandedOff,
       }),
     );
 
     await waitFor(() => expect(openClimbInPlayDrawer).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(statusOf(container)).toBe('resolved'));
+    expect(onHandedOff).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays quiet while the board is still resolving', async () => {
+    const deferred = deferredBoard(RESOLVED_BOARD);
+    resolveBoardForSession.mockReturnValue(deferred.promise);
+    const onHandedOff = vi.fn();
+
+    render(createElement(Harness, { target: { kind: 'list', board: KILTER_BOARD } as BoardRouteTarget, onHandedOff }));
+
+    await waitFor(() => expect(resolveBoardForSession).toHaveBeenCalled());
+    expect(onHandedOff).not.toHaveBeenCalled();
+
+    await act(async () => {
+      deferred.release();
+    });
+    await waitFor(() => expect(onHandedOff).toHaveBeenCalledTimes(1));
+  });
+
+  // The regression the callback exists for. Every other case in this file runs
+  // against `replace: vi.fn()`, which leaves the redirector mounted — production
+  // does not. Here the replace really removes the screen, in the same batch the
+  // hand-off runs in, and the report still has to come out.
+  it('reports even when the replace unmounts the screen in the same batch', async () => {
+    const onHandedOff = vi.fn();
+    const navigator = { leave: () => {} };
+    router.replace.mockImplementation(() => navigator.leave());
+
+    function Navigator() {
+      const [mounted, setMounted] = useState(true);
+      // Layout effect, so `leave` is wired before the hook's passive hand-off
+      // effect runs in the same commit.
+      useLayoutEffect(() => {
+        navigator.leave = () => setMounted(false);
+      }, []);
+      return mounted
+        ? createElement(Harness, { target: { kind: 'list', board: KILTER_BOARD } as BoardRouteTarget, onHandedOff })
+        : createElement('span', { 'data-status': 'unmounted' });
+    }
+
+    const { container } = render(createElement(Navigator));
+
+    await waitFor(() => expect(statusOf(container)).toBe('unmounted'));
+    expect(onHandedOff).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mobile/src/lib/routing/anonymous-auth-gate.ts
+++ b/packages/mobile/src/lib/routing/anonymous-auth-gate.ts
@@ -1,0 +1,32 @@
+// NATIVE FORK — a constant module. Native never relaxes the auth gate.
+//
+// This file is what keeps the store fleet's behaviour identical across the OTA
+// that ships the web relaxation. Every merge to `main` touching
+// `packages/mobile/**` auto-publishes a production OTA, and a JS-only diff keeps
+// the same `fingerprint` runtimeVersion, so it lands on every installed binary
+// within hours. A `Platform.OS === 'web'` check inside the gate would put the
+// web behaviour in the native bundle and leave one boolean between the fleet and
+// an anonymous route tree. A separate fork cannot drift that way: on native
+// there is nothing to drift.
+//
+// `anonymous-auth-gate.web.ts` is the fork Metro picks for the browser export.
+// Both forks export the same four symbols; a parity test compares their export
+// keys so a symbol added to one can never go missing from the other.
+
+/** Native serves no route anonymously, so nothing here is ever relaxed. */
+export const RELAXES_ANONYMOUS_ROUTES = false;
+
+/** Constant `false`: the location is not consulted at all on native. */
+export function isAnonymousReadOnlyLocation(): boolean {
+  return false;
+}
+
+/** Constant: the bare login route the native gate has always redirected to. */
+export function buildLoginHrefWithReturn(): string {
+  return '/auth/login';
+}
+
+/** Constant `null`: native has no address bar, so there is no `?next=` to read. */
+export function readPostLoginReturnHref(): string | null {
+  return null;
+}

--- a/packages/mobile/src/lib/routing/anonymous-auth-gate.web.ts
+++ b/packages/mobile/src/lib/routing/anonymous-auth-gate.web.ts
@@ -1,0 +1,71 @@
+// WEB FORK — the browser export relaxes the auth gate for read-only board URLs.
+//
+// A visitor arriving from a www climb front door lands on the same path here.
+// Rather than bounce them to a login wall that forgets what they came for, the
+// route mounts, decides it needs an account, and hands the path to login as a
+// validated `?next=`. Once they sign in, `AuthProvider`'s authenticated branch
+// reads that value back and redirects there instead of Home.
+//
+// Hrefs handed to `<Redirect>` stay base-relative. Expo Router re-applies
+// `EXPO_BASE_URL` when it builds the browser URL — which is why every existing
+// `<Redirect href="/auth/login">` already works under the `/app` mount — but
+// `window.location.pathname` does NOT: it carries the base. So every read of the
+// address bar is base-stripped first, and every value written back is not.
+
+import { isReadOnlyAnonymousPath, isSafeReturnPath } from './read-only-routes';
+
+/** The web fork is the one that stands the gate down. */
+export const RELAXES_ANONYMOUS_ROUTES = true;
+
+/**
+ * The current path as the router sees it — `window.location.pathname` with the
+ * export's mount point removed. `EXPO_BASE_URL` is `/app` on the www-mounted
+ * export and `/` on the app.boardsesh.com subdomain export, and Expo CLI inlines
+ * it at build time. Mirrors `appCallbackUrl()` in `src/lib/auth.web.ts`.
+ */
+function currentAppPath(): string {
+  if (typeof window === 'undefined') return '/';
+  const exportBasePath = process.env.EXPO_BASE_URL || '/';
+  const normalisedBase = exportBasePath === '/' ? '' : exportBasePath.replace(/\/$/, '');
+  const { pathname } = window.location;
+  if (!normalisedBase) return pathname;
+  if (pathname === normalisedBase) return '/';
+  if (pathname.startsWith(`${normalisedBase}/`)) return pathname.slice(normalisedBase.length);
+  return pathname;
+}
+
+/** Is the browser currently on a board URL a signed-out visitor may render? */
+export function isAnonymousReadOnlyLocation(): boolean {
+  return isReadOnlyAnonymousPath(currentAppPath());
+}
+
+/**
+ * The login href a read-only route hands off to, carrying the path so the climb
+ * survives the round trip. Anything outside the allow-set gets the bare login
+ * route: a `next` the gate itself could not have produced is a `next` we do not
+ * want to be asked to honour.
+ *
+ * The path only — never `window.location.search`. The canonical board URLs carry
+ * no meaningful query, and excluding it stops `bs_oauth_*` residue riding along.
+ */
+export function buildLoginHrefWithReturn(): string {
+  const path = currentAppPath();
+  if (!isSafeReturnPath(path) || !isReadOnlyAnonymousPath(path)) return '/auth/login';
+  return `/auth/login?next=${encodeURIComponent(path)}`;
+}
+
+/**
+ * The `?next=` in the address bar, if we are willing to follow it.
+ *
+ * Two independent gates, not one. `isSafeReturnPath` is the open-redirect
+ * contract — app-relative, no scheme, no protocol-relative form.
+ * `isReadOnlyAnonymousPath` additionally pins the destination to the set the
+ * gate itself can produce, so a hand-crafted `?next=` can never reach an
+ * arbitrary in-app route. `URLSearchParams.get` decodes once, so `%2f%2fevil`
+ * arrives as `//evil` and the protocol-relative rule catches it.
+ */
+export function readPostLoginReturnHref(): string | null {
+  if (typeof window === 'undefined') return null;
+  const next = new URLSearchParams(window.location.search).get('next');
+  return isSafeReturnPath(next) && isReadOnlyAnonymousPath(next) ? next : null;
+}

--- a/packages/mobile/src/lib/routing/read-only-routes.ts
+++ b/packages/mobile/src/lib/routing/read-only-routes.ts
@@ -1,0 +1,94 @@
+// Which canonical board URLs a signed-out visitor is allowed to land on, and
+// what a `?next=` value has to look like before the app will follow it.
+//
+// The web front door on `www.boardsesh.com` links every climb page into
+// `app.boardsesh.com` at the same path. Until now those arrivals hit the auth
+// gate and lost the climb they came for; the allow-set below is the exact set of
+// URL shapes the gate stands aside for. Everything here is pure — no React, no
+// `window`, no platform — so the shape rules and the open-redirect rules are
+// unit-testable on their own, and the native bundle leaves the whole file out
+// (only `anonymous-auth-gate.web.ts` imports it).
+//
+// Matching is deliberately SHAPE-only: it never resolves a slug or a board
+// config against the catalogue. A well-formed URL whose board no longer exists
+// should reach that route's own not-found, not a login wall.
+
+import { stripLocalePrefix } from './strip-locale-prefix';
+
+/** Longest `?next=` we will carry. Comfortably above any board URL we emit. */
+export const MAX_RETURN_HREF_LENGTH = 512;
+
+/** An angle segment: `40`, `-15`. */
+const ANGLE = /^-?\d+$/;
+
+/** The two climb surfaces both URL trees share. */
+const CLIMB_SURFACES = new Set(['view', 'play']);
+
+/** Anything with a URI scheme in front of it (`https:`, `javascript:`, `JaVaScRiPt:`). */
+const SCHEME = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+
+/**
+ * Control characters, space and DEL — checked by code point rather than a regex
+ * literal so the source carries no invisible characters. A leading tab or
+ * newline otherwise sneaks past the leading-slash rule, because the browser
+ * trims it back off before navigating.
+ */
+function hasControlOrSpace(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const codePoint = value.charCodeAt(index);
+    if (codePoint <= 0x20 || codePoint === 0x7f) return true;
+  }
+  return false;
+}
+
+/** The path with its query/hash tail and locale prefix removed, split into segments. */
+function pathSegments(path: string): string[] {
+  const withoutTail = path.split(/[?#]/, 1)[0] ?? '';
+  const normalised = stripLocalePrefix(withoutTail) ?? withoutTail;
+  return normalised.split('/').filter(Boolean);
+}
+
+/**
+ * Is `path` one of the read-only board URLs the app serves to a signed-out
+ * visitor? Locale-prefixed forms (`/es/kilter/…`, `/fr/b/{slug}/…`) count — web
+ * keeps the locale in the path, and those links are the whole reason this
+ * exists.
+ *
+ * `/auth/*` is excluded by shape *and* by an explicit guard, because a `next`
+ * naming an auth route is how this feature would turn into a redirect loop.
+ */
+export function isReadOnlyAnonymousPath(path: string): boolean {
+  const segments = pathSegments(path);
+
+  // `/b/{slug}` and its angle-scoped children.
+  if (segments[0] === 'b') {
+    if (segments.length === 2) return true;
+    if (segments.length === 4) return ANGLE.test(segments[2]) && segments[3] === 'list';
+    if (segments.length === 5) return ANGLE.test(segments[2]) && CLIMB_SURFACES.has(segments[3]);
+    return false;
+  }
+
+  // The config-tuple tree: `/{board}/{layout}/{size}/{sets}/{angle}/…`.
+  if (segments[0] === undefined || segments[0] === 'auth') return false;
+  if (segments.length === 6) return ANGLE.test(segments[4]) && segments[5] === 'list';
+  if (segments.length === 7) return ANGLE.test(segments[4]) && CLIMB_SURFACES.has(segments[5]);
+  return false;
+}
+
+/**
+ * Is `value` an app-relative path we can hand to the router?
+ *
+ * This is the open-redirect contract: anything that is not unambiguously a
+ * same-origin path is refused. Backslashes go too — browsers normalise `\` to
+ * `/`, so `/\evil.example` is protocol-relative in practice.
+ */
+export function isSafeReturnPath(value: string | null | undefined): value is string {
+  if (!value) return false;
+  if (value.length > MAX_RETURN_HREF_LENGTH) return false;
+  if (hasControlOrSpace(value)) return false;
+  if (SCHEME.test(value)) return false;
+  if (!value.startsWith('/')) return false;
+  if (value.startsWith('//')) return false;
+  if (value.includes('\\')) return false;
+  return true;
+}

--- a/packages/mobile/src/lib/routing/read-only-routes.ts
+++ b/packages/mobile/src/lib/routing/read-only-routes.ts
@@ -57,6 +57,19 @@ function pathSegments(path: string): string[] {
 }
 
 /**
+ * Routing syntax rather than a board identifier: an Expo Router group folder
+ * (`(tabs)`) or a relative segment the browser would have normalised away.
+ *
+ * Neither can appear in a URL this app hands out — a board name, slug, layout,
+ * size, set list, angle and climb segment are all plain identifiers — and
+ * without this the segment-count rules below would accept shapes the gate itself
+ * can never produce, like `/(tabs)/profile/a/b/40/list`.
+ */
+function isStructuralSegment(segment: string): boolean {
+  return segment === '.' || segment === '..' || segment.includes('(') || segment.includes(')');
+}
+
+/**
  * Is `path` one of the read-only board URLs the app serves to a signed-out
  * visitor? Locale-prefixed forms (`/es/kilter/…`, `/fr/b/{slug}/…`) count — web
  * keeps the locale in the path, and those links are the whole reason this
@@ -67,6 +80,7 @@ function pathSegments(path: string): string[] {
  */
 export function isReadOnlyAnonymousPath(path: string): boolean {
   const segments = pathSegments(path);
+  if (segments.some(isStructuralSegment)) return false;
 
   // `/b/{slug}` and its angle-scoped children.
   if (segments[0] === 'b') {

--- a/packages/mobile/src/lib/routing/read-only-routes.ts
+++ b/packages/mobile/src/lib/routing/read-only-routes.ts
@@ -15,7 +15,15 @@
 
 import { stripLocalePrefix } from './strip-locale-prefix';
 
-/** Longest `?next=` we will carry. Comfortably above any board URL we emit. */
+/**
+ * Longest `?next=` we will carry, comfortably above any board URL we emit.
+ *
+ * Measured against the WHOLE value, query and fragment included — unlike the
+ * shape matcher below, which drops that tail before matching. That asymmetry is
+ * deliberate: this cap is on the string we would hand the router, so its full
+ * length is what matters, and a `next` padded out with query junk is one we
+ * would rather refuse than truncate.
+ */
 export const MAX_RETURN_HREF_LENGTH = 512;
 
 /** An angle segment: `40`, `-15`. */

--- a/packages/mobile/src/lib/routing/use-board-route-target.ts
+++ b/packages/mobile/src/lib/routing/use-board-route-target.ts
@@ -54,12 +54,16 @@ import { openClimbInPlayDrawer } from '../open-climb-in-play-drawer';
 /**
  * What the entry route should draw.
  *
- * `resolved` renders identically to `resolving` — the screen is already
- * navigating away — and exists so the hand-off telemetry has a terminal state to
- * report. `auth-required` is reachable on web only: the browser export serves
- * these routes to signed-out visitors, and board adoption needs an account.
+ * A successful hand-off has no status of its own. The screen keeps its spinner
+ * right up to the moment it leaves the tree, and a status that says "handed off"
+ * could not be observed anyway — the hand-off effect navigates this screen away
+ * in the same React batch a state update would land in, so the render carrying
+ * it never commits. `onHandedOff` is how a caller hears about it instead.
+ *
+ * `auth-required` is reachable on web only: the browser export serves these
+ * routes to signed-out visitors, and board adoption needs an account.
  */
-export type BoardRouteStatus = 'resolving' | 'resolved' | 'not-found' | 'auth-required';
+export type BoardRouteStatus = 'resolving' | 'not-found' | 'auth-required';
 
 /**
  * Where the target came from, which decides two things the caller can't:
@@ -379,7 +383,7 @@ function useAdoptedBoard(
  */
 export function useBoardRouteTarget(
   target: BoardRouteTarget | null,
-  options?: { mode?: BoardRouteMode },
+  options?: { mode?: BoardRouteMode; onHandedOff?: () => void },
 ): BoardRouteStatus {
   const mode = options?.mode ?? 'deep-link';
   const adoptsBoard = mode === 'deep-link';
@@ -417,7 +421,10 @@ export function useBoardRouteTarget(
   );
   const boardConfig = configFromUrl ?? configFromBoard;
 
-  const climbQuery = useClimb(boardConfig && climbUuid ? { ...boardConfig, climbUuid } : null);
+  // `!authRequired` is what makes the short-circuit below true to its word: the
+  // tuple form carries its whole config in the URL, so without this the climb
+  // query would fire for a visitor we have already decided to send to login.
+  const climbQuery = useClimb(!authRequired && boardConfig && climbUuid ? { ...boardConfig, climbUuid } : null);
   const climb = climbQuery.data;
 
   // Hand off exactly once per target. The ref guards a re-render firing the open
@@ -426,10 +433,18 @@ export function useBoardRouteTarget(
   // screen still gets its hand-off instead of sitting on the spinner forever.
   const targetKey = target ? `${toBoardPath(target)}#${wantsClimb ? climbUuid : ''}` : null;
   const handedOffRef = useRef<string | null>(null);
-  // The ref is what guards the hand-off; this mirror is what the status below
-  // reads, because a ref write doesn't re-render and `resolved` has to be
-  // observable.
-  const [handedOffTargetKey, setHandedOffTargetKey] = useState<string | null>(null);
+  // The hand-off is reported imperatively, from inside the effect, rather than
+  // through a status the caller could watch. It has to be: the same effect body
+  // calls `router.replace` / `router.back`, React batches that with anything
+  // else queued in the flush, and the navigator drops this screen in the very
+  // render that would have carried the new status — the update is discarded with
+  // the fiber and never commits. `join/[sessionId]` fires `Session Joined` the
+  // same way, immediately before replacing itself. Held in a ref so a caller
+  // passing a fresh closure each render can't re-enter the effect.
+  const onHandedOffRef = useRef(options?.onHandedOff);
+  useEffect(() => {
+    onHandedOffRef.current = options?.onHandedOff;
+  });
   useEffect(() => {
     if (!target || !targetKey || handedOffRef.current === targetKey) return;
     if (authRequired) return;
@@ -456,14 +471,14 @@ export function useBoardRouteTarget(
 
     if (!wantsClimb) {
       handedOffRef.current = targetKey;
-      setHandedOffTargetKey(targetKey);
+      onHandedOffRef.current?.();
       leave();
       return;
     }
 
     if (!climb || !boardConfig) return;
     handedOffRef.current = targetKey;
-    setHandedOffTargetKey(targetKey);
+    onHandedOffRef.current?.();
     // preview:true so a deep-linked climb doesn't disturb the queue — in a
     // session it would change the shared current climb for everyone. The drawer
     // shows a "Preview" badge with "Set active" to opt into playing it.
@@ -489,7 +504,6 @@ export function useBoardRouteTarget(
   // Before every resolution check: a signed-out visitor has no board to fail on,
   // and nothing was asked of the server on their behalf.
   if (authRequired) return 'auth-required';
-  if (handedOffTargetKey !== null && handedOffTargetKey === targetKey) return 'resolved';
   if (boardError) return 'not-found';
   // Only a settled query says the climb is gone: `isLoading` briefly reads false
   // in the render where the query switches on, which would flash a not-found

--- a/packages/mobile/src/lib/routing/use-board-route-target.ts
+++ b/packages/mobile/src/lib/routing/use-board-route-target.ts
@@ -32,6 +32,10 @@ import { onlineManager } from '@tanstack/react-query';
 import { isNetworkError } from '@boardsesh/offline-sync/error-classification';
 import type { CreateBoardInput, UserBoard } from '@boardsesh/shared-schema';
 import { toBoardPath, type BoardRouteTarget } from './board-route-target';
+// The platform switch is this constant, not `Platform.OS` — the hook then needs
+// no `react-native` import, whose RN 0.86 Flow entry the vitest node env cannot
+// parse (see the config's `hooks-dual-write` exclusion note).
+import { RELAXES_ANONYMOUS_ROUTES } from './anonymous-auth-gate';
 import { useClimb } from '../graphql/hooks';
 import { fetchAllMyBoards, fetchBoardBySlug, fetchBoardByUuid, useCreateBoard } from '../graphql/hooks';
 import { readDuplicateBoardError } from '../graphql/extract-error-message';
@@ -47,7 +51,15 @@ import {
 } from '../board-path-to-user-board';
 import { openClimbInPlayDrawer } from '../open-climb-in-play-drawer';
 
-export type BoardRouteStatus = 'resolving' | 'not-found';
+/**
+ * What the entry route should draw.
+ *
+ * `resolved` renders identically to `resolving` — the screen is already
+ * navigating away — and exists so the hand-off telemetry has a terminal state to
+ * report. `auth-required` is reachable on web only: the browser export serves
+ * these routes to signed-out visitors, and board adoption needs an account.
+ */
+export type BoardRouteStatus = 'resolving' | 'resolved' | 'not-found' | 'auth-required';
 
 /**
  * Where the target came from, which decides two things the caller can't:
@@ -373,7 +385,14 @@ export function useBoardRouteTarget(
   const adoptsBoard = mode === 'deep-link';
   const router = useRouter();
   const { openPlayDrawer } = useDrawerHost();
-  const { board, error: boardError } = useAdoptedBoard(target, adoptsBoard);
+  const { isAuthenticated, isLoading: authIsLoading } = useAuth();
+  // Only reachable on web: the native gate never serves these routes signed-out.
+  // Board adoption needs the account (the tuple form mints a UserBoard, which is
+  // `requireAuthenticated`), so the route hands the URL to login rather than
+  // resolving anything anonymously. An unsettled session waits — bouncing on
+  // `isLoading` would send a signed-in visitor to login on every cold open.
+  const authRequired = RELAXES_ANONYMOUS_ROUTES && adoptsBoard && !authIsLoading && !isAuthenticated;
+  const { board, error: boardError } = useAdoptedBoard(target, adoptsBoard && !authRequired);
 
   const wantsClimb = target?.kind === 'climb' || target?.kind === 'slug-climb';
   const climbUuid = wantsClimb ? target.climbUuid : undefined;
@@ -407,8 +426,13 @@ export function useBoardRouteTarget(
   // screen still gets its hand-off instead of sitting on the spinner forever.
   const targetKey = target ? `${toBoardPath(target)}#${wantsClimb ? climbUuid : ''}` : null;
   const handedOffRef = useRef<string | null>(null);
+  // The ref is what guards the hand-off; this mirror is what the status below
+  // reads, because a ref write doesn't re-render and `resolved` has to be
+  // observable.
+  const [handedOffTargetKey, setHandedOffTargetKey] = useState<string | null>(null);
   useEffect(() => {
     if (!target || !targetKey || handedOffRef.current === targetKey) return;
+    if (authRequired) return;
     // A deep link has to land on the adopted board — the Climbs tab behind the
     // drawer renders whatever the active board is.
     if (adoptsBoard && !board) return;
@@ -432,12 +456,14 @@ export function useBoardRouteTarget(
 
     if (!wantsClimb) {
       handedOffRef.current = targetKey;
+      setHandedOffTargetKey(targetKey);
       leave();
       return;
     }
 
     if (!climb || !boardConfig) return;
     handedOffRef.current = targetKey;
+    setHandedOffTargetKey(targetKey);
     // preview:true so a deep-linked climb doesn't disturb the queue — in a
     // session it would change the shared current climb for everyone. The drawer
     // shows a "Preview" badge with "Set active" to opt into playing it.
@@ -457,9 +483,13 @@ export function useBoardRouteTarget(
     }
     openDrawer();
     leave();
-  }, [adoptsBoard, board, boardConfig, climb, openPlayDrawer, router, target, targetKey, wantsClimb]);
+  }, [adoptsBoard, authRequired, board, boardConfig, climb, openPlayDrawer, router, target, targetKey, wantsClimb]);
 
   if (!target) return 'not-found';
+  // Before every resolution check: a signed-out visitor has no board to fail on,
+  // and nothing was asked of the server on their behalf.
+  if (authRequired) return 'auth-required';
+  if (handedOffTargetKey !== null && handedOffTargetKey === targetKey) return 'resolved';
   if (boardError) return 'not-found';
   // Only a settled query says the climb is gone: `isLoading` briefly reads false
   // in the render where the query switches on, which would flash a not-found

--- a/packages/mobile/src/providers/__tests__/auth-provider-anonymous-gate.web.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider-anonymous-gate.web.test.tsx
@@ -1,0 +1,440 @@
+// @vitest-environment jsdom
+//
+// The WEB half of the anonymous gate. Vitest resolves `anonymous-auth-gate` to
+// the native fork (it has no `.web` extension resolution), so this suite swaps
+// in the web fork through `vi.mock` — and the fork-parity test in
+// `lib/routing/__tests__/anonymous-auth-gate.test.ts` is what makes that
+// substitution faithful.
+//
+// The mock surface below mirrors `auth-provider.test.tsx`: AuthProvider's static
+// import graph reaches native modules that cannot load under vitest, so the
+// stubs are load guards rather than behaviour. Deliberately a separate file —
+// the native-parity suite next door must run against the REAL native fork, and
+// a `vi.mock` in that file would hollow out the guarantee it exists to make.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { onlineManager, QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const redirectMock = vi.hoisted(() => vi.fn());
+const platformState = vi.hoisted(() => ({ OS: 'web' }));
+const routerState = vi.hoisted(() => ({ segments: [] as string[] }));
+const appStateState = vi.hoisted(() => ({
+  listener: null as ((nextAppState: string) => void) | null,
+}));
+const authTokenEventsState = vi.hoisted(() => ({
+  listener: null as
+    | ((token: string | null, source: 'local' | 'remote' | 'remote-signout' | 'session' | 'hint') => void)
+    | null,
+  subscribe: vi.fn(),
+  unsubscribe: vi.fn(),
+}));
+const webSessionIdentityState = vi.hoisted(() => ({
+  userId: 'user-1',
+  authSessionId: 'login-1',
+  unavailableIdentity: null as { userId: string; authSessionId: string } | null,
+}));
+const userStorageOwnerState = vi.hoisted(() => ({
+  current: null as { userId: string; authSessionId: string } | null,
+  set: vi.fn(),
+}));
+const bumpAuthTransportRevisionMock = vi.hoisted(() => vi.fn());
+const consumeFreshOAuthPendingMock = vi.hoisted(() => vi.fn());
+const consumeWebOAuthReturnProviderMock = vi.hoisted(() => vi.fn());
+const trackMock = vi.hoisted(() => vi.fn());
+
+// expo-router and react-native both reach for the native runtime; stub the
+// thin surface AuthProvider consumes. `useSegments` returning `[]` keeps the
+// provider out of its `<Redirect>` branches so the child tree renders and the
+// auth context becomes readable.
+vi.mock('expo-router', () => ({
+  useSegments: () => routerState.segments,
+  Redirect: ({ href }: { href: string }) => {
+    redirectMock(href);
+    return null;
+  },
+}));
+
+vi.mock('react-native', () => ({
+  Platform: platformState,
+  AppState: {
+    addEventListener: vi.fn((_event: string, listener: (nextAppState: string) => void) => {
+      appStateState.listener = listener;
+      return {
+        remove: vi.fn(() => {
+          if (appStateState.listener === listener) appStateState.listener = null;
+        }),
+      };
+    }),
+  },
+}));
+
+// The loading-state splash renders react-native/expo-image primitives this
+// jsdom-mocked env doesn't provide; stub it to a detectable text marker (a
+// component may return a raw string) so a test can assert the loading window
+// renders the splash rather than a blank tree.
+vi.mock('../../components/AppLoadingSplash', () => ({
+  AppLoadingSplash: () => 'app-loading-splash',
+}));
+
+vi.mock('../../lib/screenshot-mode', () => ({
+  SCREENSHOT_USER_EMAIL: 'screenshots@example.com',
+  SCREENSHOT_USER_PASSWORD: 'screenshot-password',
+}));
+
+vi.mock('../../lib/auth-token-events', () => ({
+  subscribeAuthTokenChanges: (
+    listener: (token: string | null, source: 'local' | 'remote' | 'remote-signout' | 'session' | 'hint') => void,
+  ) => {
+    authTokenEventsState.listener = listener;
+    authTokenEventsState.subscribe(listener);
+    return () => {
+      if (authTokenEventsState.listener === listener) authTokenEventsState.listener = null;
+      authTokenEventsState.unsubscribe();
+    };
+  },
+}));
+
+vi.mock('../../lib/auth-session', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../lib/auth-session')>();
+  return {
+    ...original,
+    resolveAuthSession: async () => {
+      if (platformState.OS === 'web' && webSessionIdentityState.unavailableIdentity) {
+        return {
+          status: 'unavailable' as const,
+          error: new Error('bridge unavailable'),
+          confirmedIdentity: webSessionIdentityState.unavailableIdentity,
+          identityInvalidated: true,
+        };
+      }
+      const result = await original.resolveAuthSession();
+      if (platformState.OS === 'web' && result.status === 'authenticated') {
+        return {
+          ...result,
+          userId: webSessionIdentityState.userId,
+          authSessionId: webSessionIdentityState.authSessionId,
+        };
+      }
+      return result;
+    },
+  };
+});
+
+beforeEach(() => {
+  platformState.OS = 'web';
+  routerState.segments = [];
+  appStateState.listener = null;
+  redirectMock.mockReset();
+  isAuthCredentialGenerationCurrentMock.mockReset();
+  isAuthCredentialGenerationCurrentMock.mockReturnValue(true);
+  authTokenEventsState.listener = null;
+  authTokenEventsState.subscribe.mockReset();
+  authTokenEventsState.unsubscribe.mockReset();
+  webSessionIdentityState.userId = 'user-1';
+  webSessionIdentityState.authSessionId = 'login-1';
+  webSessionIdentityState.unavailableIdentity = null;
+  userStorageOwnerState.current = null;
+  userStorageOwnerState.set.mockReset();
+  userStorageOwnerState.set.mockImplementation((owner) => {
+    userStorageOwnerState.current = owner as { userId: string; authSessionId: string } | null;
+  });
+  bumpAuthTransportRevisionMock.mockReset();
+  consumeFreshOAuthPendingMock.mockReset();
+  consumeFreshOAuthPendingMock.mockResolvedValue(null);
+  consumeWebOAuthReturnProviderMock.mockReset();
+  consumeWebOAuthReturnProviderMock.mockReturnValue(null);
+  trackMock.mockReset();
+  reportHandledErrorMock.mockReset();
+  onlineManager.setOnline(true);
+  captureAuthCredentialGenerationMock.mockReset();
+  captureAuthCredentialGenerationMock.mockReturnValue(1);
+  authSignInWithCredentialsMock.mockReset();
+  authSignInWithGoogleWebMock.mockReset();
+  authSignInWithAppleWebMock.mockReset();
+  clearStoredQueueSnapshotMock.mockReset();
+  clearStoredQueueSnapshotMock.mockResolvedValue(undefined);
+  clearAllCreateClimbDraftsMock.mockReset();
+  clearAllCreateClimbDraftsMock.mockResolvedValue(undefined);
+  clearSessionCommentDraftMock.mockReset();
+  clearSessionCommentDraftMock.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+// Storage + side-effect mocks. Each one just records calls; signOut returning
+// successfully (no throw) is the only behaviour the unit cares about.
+const getAuthTokenMock = vi.fn();
+const isTokenExpiringSoonMock = vi.fn();
+const isAuthCredentialGenerationCurrentMock = vi.fn();
+const captureAuthCredentialGenerationMock = vi.fn(() => 1);
+vi.mock('../../lib/auth-store', () => ({
+  captureAuthCredentialGeneration: () => captureAuthCredentialGenerationMock(),
+  getAuthToken: () => getAuthTokenMock(),
+  isAuthCredentialGenerationCurrent: (...args: unknown[]) => isAuthCredentialGenerationCurrentMock(...args),
+  isTokenExpiringSoon: () => isTokenExpiringSoonMock(),
+}));
+
+// checkAuth reports keychain read failures; record the calls so the
+// rejection test can assert the failure was surfaced (and is a no-op otherwise).
+const reportErrorMock = vi.fn();
+const reportHandledErrorMock = vi.fn();
+vi.mock('../../lib/error-reporting', () => ({
+  reportError: (...args: unknown[]) => reportErrorMock(...args),
+  reportHandledError: (...args: unknown[]) => reportHandledErrorMock(...args),
+}));
+
+const resetAnalyticsMock = vi.hoisted(() => vi.fn());
+vi.mock('../../lib/analytics', () => ({
+  reset: resetAnalyticsMock,
+  track: (...args: unknown[]) => trackMock(...args),
+}));
+
+// Sign-out is about to DELETE the whole outbox (dead letters included). The
+// gauge that measures it must run before resetAnalytics() or the event lands on
+// an anonymous distinct_id — see the ordering test near the bottom of this file.
+const reportOutboxDiscardedOnSignOutMock = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => {}));
+vi.mock('../../offline/outbox-telemetry', () => ({
+  reportOutboxDiscardedOnSignOut: reportOutboxDiscardedOnSignOutMock,
+}));
+
+vi.mock('../../lib/oauth-pending-store', () => ({
+  consumeFreshOAuthPending: (...args: unknown[]) => consumeFreshOAuthPendingMock(...args),
+}));
+
+vi.mock('../../lib/oauth-return', () => ({
+  consumeWebOAuthReturn: (...args: unknown[]) => consumeWebOAuthReturnProviderMock(...args),
+}));
+
+const authSignOutMock = vi.fn();
+const authRegisterMock = vi.fn();
+const authSignInWithCredentialsMock = vi.fn();
+const authSignInWithGoogleWebMock = vi.fn();
+const authSignInWithAppleWebMock = vi.fn();
+vi.mock('../../lib/auth', () => ({
+  signInWithApple: vi.fn(),
+  signInWithGoogle: vi.fn(),
+  signInWithGoogleWeb: (...args: unknown[]) => authSignInWithGoogleWebMock(...args),
+  signInWithAppleWeb: (...args: unknown[]) => authSignInWithAppleWebMock(...args),
+  signOutForGeneration: (...args: unknown[]) => authSignOutMock(...args),
+  signInWithCredentials: (...args: unknown[]) => authSignInWithCredentialsMock(...args),
+  registerWithCredentials: (...args: unknown[]) => authRegisterMock(...args),
+}));
+
+const clearStoredSessionIdMock = vi.fn();
+vi.mock('../../lib/session-store', () => ({
+  clearStoredSessionId: (...args: unknown[]) => clearStoredSessionIdMock(...args),
+  // Device provenance for the leave-vs-end emphasis (#3502).
+  getStoredCreatedSessionId: vi.fn(async () => null),
+  setStoredCreatedSessionId: vi.fn(async () => {}),
+  clearStoredCreatedSessionId: vi.fn(async () => {}),
+}));
+
+const clearStoredActiveBoardMock = vi.fn();
+vi.mock('../../lib/active-board-store', () => ({
+  clearStoredActiveBoard: (...args: unknown[]) => clearStoredActiveBoardMock(...args),
+}));
+
+const clearStoredQueueSnapshotMock = vi.fn();
+vi.mock('../../lib/queue-snapshot-store', () => ({
+  clearStoredQueueSnapshot: (...args: unknown[]) => clearStoredQueueSnapshotMock(...args),
+}));
+
+const clearAllCreateClimbDraftsMock = vi.fn();
+vi.mock('../../lib/create-climb-draft-store', () => ({
+  clearAllCreateClimbDrafts: (...args: unknown[]) => clearAllCreateClimbDraftsMock(...args),
+}));
+
+const clearSessionCommentDraftMock = vi.fn();
+vi.mock('../../lib/session-comment-draft-store', () => ({
+  clearSessionCommentDraft: (...args: unknown[]) => clearSessionCommentDraftMock(...args),
+}));
+
+vi.mock('../../lib/user-storage-owner', () => ({
+  setCurrentUserStorageOwner: (owner: { userId: string; authSessionId: string } | null) => {
+    userStorageOwnerState.set(owner);
+  },
+}));
+
+vi.mock('../../lib/auth-transport-revision', () => ({
+  bumpAuthTransportRevision: () => bumpAuthTransportRevisionMock(),
+}));
+
+const resetHttpClientMock = vi.fn();
+vi.mock('../../lib/graphql/client', () => ({
+  resetHttpClient: () => resetHttpClientMock(),
+}));
+
+const disposeWsClientMock = vi.fn();
+vi.mock('../../lib/graphql/ws-client', () => ({
+  disposeWsClient: () => disposeWsClientMock(),
+}));
+
+vi.mock('../../lib/graphql/use-active-board', () => ({
+  ACTIVE_BOARD_QUERY_KEY: ['activeBoard'] as const,
+}));
+
+const getDatabaseHandleMock = vi.fn((): unknown => null);
+// Two different wipes: the selective one (downloaded board catalogs kept) and the
+// full one an explicit sign-out runs. Which one a given path picks is the regression
+// guard of issue #3621, so both are recorded rather than stubbed anonymously.
+const clearUserDataMock = vi.hoisted(() => vi.fn(async () => {}));
+const purgeLocalDataForSignOutMock = vi.hoisted(() =>
+  vi.fn(async () => ({ pendingDiscarded: 0, deadLettersDiscarded: 0, hadDownloads: false, vacuumed: true })),
+);
+vi.mock('../../db', () => ({
+  getDatabaseHandle: () => getDatabaseHandleMock(),
+  clearUserData: clearUserDataMock,
+  purgeLocalDataForSignOut: purgeLocalDataForSignOutMock,
+}));
+
+const resetSyncStatusMock = vi.hoisted(() => vi.fn());
+vi.mock('../../sync/sync-status', () => ({ resetSyncStatus: resetSyncStatusMock }));
+
+const drainMutationQueueMock = vi.fn(async (..._args: unknown[]) => {});
+// The sign-out drain gate reads the WHOLE outbox, pending plus dead letters: a device
+// holding only failed writes still has unsynced work this sign-out is about to delete.
+type OutboxSummary = {
+  pendingCount: number;
+  deadLetterCount: number;
+  oldestPendingAt: string | null;
+  oldestDeadLetterAt: string | null;
+};
+function outbox(pendingCount: number, deadLetterCount = 0): OutboxSummary {
+  return { pendingCount, deadLetterCount, oldestPendingAt: null, oldestDeadLetterAt: null };
+}
+const getOutboxSummaryMock = vi.fn(async (..._args: unknown[]): Promise<OutboxSummary> => outbox(0));
+vi.mock('@boardsesh/offline-sync', () => ({
+  getOutboxSummary: (...args: unknown[]) => getOutboxSummaryMock(...args),
+  setSigningOut: vi.fn(),
+}));
+vi.mock('../../offline/offline-sync-adapter', () => ({
+  drainMutationQueue: (...args: unknown[]) => drainMutationQueueMock(...args),
+}));
+// The offline-usage rollup's suppression map is in-memory and not keyed by user,
+// so the sign-out paths reset it (#4317) — otherwise a same-day account switch
+// inherits the previous user's counters and the new user's first offline day
+// silently never fires.
+const resetOfflineUsageSignalMock = vi.hoisted(() => vi.fn());
+vi.mock('../../offline/offline-usage-signal', () => ({
+  resetOfflineUsageSignal: () => resetOfflineUsageSignalMock(),
+}));
+
+const stopTokenManagementMock = vi.fn(async () => {});
+vi.mock('../../notifications', () => ({
+  stopTokenManagement: (_unregister: unknown) => stopTokenManagementMock(),
+}));
+
+// The provider clears the per-user offline-boards setting on sign-out. Stub the
+// settings barrel so the test's static graph never pulls react-native-mmkv (→ the
+// react-native Flow entry, which Rolldown's collection scan can't parse under RN 0.86).
+const setSettingMock = vi.hoisted(() => vi.fn());
+const clearOfflineBoardsMock = vi.hoisted(() => vi.fn());
+vi.mock('../../settings', () => ({
+  setSetting: (...args: unknown[]) => setSettingMock(...args),
+  clearOfflineBoards: () => clearOfflineBoardsMock(),
+}));
+
+// The provider registers its forced-sign-out cleanup against this lib-layer hook
+// (and lazily imports ensureFreshToken in checkAuth). Record the register/clear
+// calls so the lifecycle test can assert the contract.
+const setOnForcedSignOutMock = vi.fn();
+const ensureFreshTokenMock = vi.fn().mockResolvedValue(true);
+type MockRefreshResult =
+  | { status: 'refreshed'; generation: number }
+  | { status: 'rejected'; generation: number }
+  | { status: 'unavailable'; generation: number; error: unknown }
+  | { status: 'superseded' };
+// resolveAuthSession refreshes an expiring token through the status-returning
+// deduplicatedRefresh (not the boolean ensureFreshToken), so the refresh-fail
+// and superseded scenarios drive this mock's 4-way status.
+const deduplicatedRefreshMock = vi.fn<() => Promise<MockRefreshResult>>().mockResolvedValue({
+  status: 'refreshed',
+  generation: 1,
+});
+vi.mock('../../lib/auth-interceptor', () => ({
+  setOnForcedSignOut: (callback: (() => void) | null) => setOnForcedSignOutMock(callback),
+  ensureFreshToken: () => ensureFreshTokenMock(),
+  deduplicatedRefresh: () => deduplicatedRefreshMock(),
+}));
+
+// The whole point of this file: AuthProvider gets the fork the browser export
+// gets. Re-exported wholesale so the substitution can't drift from the real one.
+vi.mock('../../lib/routing/anonymous-auth-gate', async () => {
+  return await import('../../lib/routing/anonymous-auth-gate.web');
+});
+
+import { AuthProvider } from '../auth-provider';
+import { GATED_PATHS, READ_ONLY_PATHS } from '../../lib/routing/__tests__/read-only-route-corpus';
+
+function renderGate() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <span data-testid="child">app tree</span>
+      </AuthProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('AuthProvider anonymous read-only gate (web)', () => {
+  beforeEach(() => {
+    platformState.OS = 'web';
+    getAuthTokenMock.mockReset();
+    isTokenExpiringSoonMock.mockReset();
+    isTokenExpiringSoonMock.mockResolvedValue(false);
+    routerState.segments = [];
+    window.history.replaceState({}, '', '/');
+  });
+
+  // The whole point of W-06: a climb link from the www front door renders for
+  // someone who has never signed in, instead of bouncing them to a login wall
+  // that forgets which climb they came for.
+  it.each(READ_ONLY_PATHS)('renders the route tree for a signed-out visitor at %s', async (path) => {
+    getAuthTokenMock.mockResolvedValue(null);
+    window.history.replaceState({}, '', path);
+
+    const { queryByTestId } = renderGate();
+
+    await waitFor(() => expect(queryByTestId('child')).not.toBeNull());
+    expect(redirectMock).not.toHaveBeenCalledWith('/auth/login');
+  });
+
+  it.each(GATED_PATHS)('still sends a signed-out visitor at %s to login', async (path) => {
+    getAuthTokenMock.mockResolvedValue(null);
+    window.history.replaceState({}, '', path);
+
+    const { queryByTestId } = renderGate();
+
+    // Exactly the bare route: the `?next=` is appended by the read-only route's
+    // own hand-off, never by the gate.
+    await waitFor(() => expect(redirectMock).toHaveBeenCalledWith('/auth/login'));
+    expect(redirectMock).not.toHaveBeenCalledWith(expect.stringContaining('next='));
+    expect(queryByTestId('child')).toBeNull();
+  });
+
+  it('lands a freshly signed-in visitor on the climb their next= names', async () => {
+    const next = '/b/the-gym/40/view/crimpy-thing-0A1B2C3D4E5F60718293A4B5C6D7E8F9';
+    getAuthTokenMock.mockResolvedValue('jwt-token');
+    routerState.segments = ['auth', 'login'];
+    window.history.replaceState({}, '', `/auth/login?next=${encodeURIComponent(next)}`);
+
+    renderGate();
+
+    await waitFor(() => expect(redirectMock).toHaveBeenCalledWith(next));
+    expect(redirectMock).not.toHaveBeenCalledWith('/(tabs)/home');
+  });
+
+  it('drops a hostile next= and falls back to the home tab', async () => {
+    getAuthTokenMock.mockResolvedValue('jwt-token');
+    routerState.segments = ['auth', 'login'];
+    window.history.replaceState({}, '', '/auth/login?next=//evil.example');
+
+    renderGate();
+
+    await waitFor(() => expect(redirectMock).toHaveBeenCalledWith('/(tabs)/home'));
+    expect(redirectMock).not.toHaveBeenCalledWith(expect.stringContaining('evil.example'));
+  });
+});

--- a/packages/mobile/src/providers/__tests__/auth-provider-anonymous-gate.web.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider-anonymous-gate.web.test.tsx
@@ -427,6 +427,22 @@ describe('AuthProvider anonymous read-only gate (web)', () => {
     expect(redirectMock).not.toHaveBeenCalledWith('/(tabs)/home');
   });
 
+  // The register branch of the same flow: login forwards `next` to the sign-up
+  // screen as a router param, so someone who creates an account instead of
+  // signing in lands on the climb too. The provider navigates in both cases —
+  // `register.tsx` needs no change of its own.
+  it('lands a freshly registered visitor on the climb their next= names', async () => {
+    const next = '/b/the-gym/40/view/crimpy-thing-0A1B2C3D4E5F60718293A4B5C6D7E8F9';
+    getAuthTokenMock.mockResolvedValue('jwt-token');
+    routerState.segments = ['auth', 'register'];
+    window.history.replaceState({}, '', `/auth/register?next=${encodeURIComponent(next)}`);
+
+    renderGate();
+
+    await waitFor(() => expect(redirectMock).toHaveBeenCalledWith(next));
+    expect(redirectMock).not.toHaveBeenCalledWith('/(tabs)/home');
+  });
+
   it('drops a hostile next= and falls back to the home tab', async () => {
     getAuthTokenMock.mockResolvedValue('jwt-token');
     routerState.segments = ['auth', 'login'];

--- a/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
@@ -349,6 +349,7 @@ vi.mock('../../lib/auth-interceptor', () => ({
 }));
 
 import { AuthProvider, useAuth } from '../auth-provider';
+import { GATED_PATHS, READ_ONLY_PATHS } from '../../lib/routing/__tests__/read-only-route-corpus';
 
 describe('AuthProvider loading state', () => {
   beforeEach(() => {
@@ -2186,5 +2187,65 @@ describe('AuthProvider.checkAuth keychain read failure', () => {
 
     expect(redirectMock).toHaveBeenCalledWith('/auth/login');
     expect(redirectMock).not.toHaveBeenCalledWith('/auth/session-unavailable');
+  });
+});
+
+// The native half of W-06's "web only" claim. Every merge to `main` touching
+// `packages/mobile/**` auto-publishes a production OTA, and a JS-only diff keeps
+// the same `fingerprint` runtimeVersion — so this relaxation lands on every
+// installed binary whether or not it is meant for them. Byte-equality of this
+// file is impossible (it gained a condition), so the equivalent is asserted
+// here: under `Platform.OS = 'ios'` the gate emits exactly the redirect it
+// emitted before, for the entire route corpus, and never renders children to a
+// signed-out visitor.
+describe('native auth gate parity (this PR auto-OTAs to the store fleet)', () => {
+  beforeEach(() => {
+    platformState.OS = 'ios';
+    getAuthTokenMock.mockReset();
+    isTokenExpiringSoonMock.mockReset();
+    isTokenExpiringSoonMock.mockResolvedValue(false);
+  });
+
+  function renderGate() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <span data-testid="child">app tree</span>
+        </AuthProvider>
+      </QueryClientProvider>,
+    );
+  }
+
+  it.each([...READ_ONLY_PATHS, ...GATED_PATHS])(
+    'redirects a signed-out visitor at %s to the bare login route',
+    async (path) => {
+      getAuthTokenMock.mockResolvedValue(null);
+      routerState.segments = [];
+      window.history.replaceState({}, '', path);
+
+      const { queryByTestId } = renderGate();
+
+      await waitFor(() => expect(redirectMock).toHaveBeenCalledWith('/auth/login'));
+      // No `?next=` on native: the query is a web-fork product, and the gate
+      // itself never appends one on either platform.
+      expect(redirectMock).not.toHaveBeenCalledWith(expect.stringContaining('next='));
+      // And the tree below the gate stays withheld — a relaxed route on native
+      // would show up here first.
+      expect(queryByTestId('child')).toBeNull();
+    },
+  );
+
+  it('ignores a next= in the address bar on the authenticated branch', async () => {
+    const next = '/b/the-gym/40/view/0A1B2C3D4E5F60718293A4B5C6D7E8F9';
+    getAuthTokenMock.mockResolvedValue('jwt-token');
+    routerState.segments = ['auth', 'login'];
+    window.history.replaceState({}, '', `/auth/login?next=${encodeURIComponent(next)}`);
+
+    renderGate();
+
+    await waitFor(() => expect(redirectMock).toHaveBeenCalledWith('/(tabs)/home'));
+    expect(redirectMock).not.toHaveBeenCalledWith(next);
+    expect(redirectMock).not.toHaveBeenCalledWith(expect.stringContaining('next='));
   });
 });

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -43,6 +43,7 @@ import { reportOutboxDiscardedOnSignOut } from '../offline/outbox-telemetry';
 import { stopTokenManagement } from '../notifications';
 import { consumeFreshOAuthPending } from '../lib/oauth-pending-store';
 import { consumeWebOAuthReturn } from '../lib/oauth-return';
+import { isAnonymousReadOnlyLocation, readPostLoginReturnHref } from '../lib/routing/anonymous-auth-gate';
 
 type AuthState = {
   isAuthenticated: boolean;
@@ -1023,11 +1024,19 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
     return <Redirect href={isAuthenticated ? '/(tabs)/home' : '/auth/login'} />;
   }
 
-  if (!isAuthenticated && !inAuthGroup) {
+  // Web only: the canonical board URLs the Next front door links into render for
+  // a signed-out visitor instead of bouncing them to a login wall that loses the
+  // climb they arrived for. The route itself then hands off to login carrying the
+  // path (see BoardRouteRedirect). Native resolves anonymous-auth-gate to the
+  // inert fork — `isAnonymousReadOnlyLocation()` is a constant `false` and
+  // `readPostLoginReturnHref()` a constant `null` — so both branches below are
+  // exactly what ships today on the store fleet. Asserted by test, because this
+  // change auto-OTAs to every installed binary.
+  if (!isAuthenticated && !inAuthGroup && !isAnonymousReadOnlyLocation()) {
     return <Redirect href="/auth/login" />;
   }
   if (isAuthenticated && inAuthGroup) {
-    return <Redirect href="/(tabs)/home" />;
+    return <Redirect href={readPostLoginReturnHref() ?? '/(tabs)/home'} />;
   }
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -112,8 +112,10 @@ export const SHARED_EVENTS = {
   // App-only today: the native fleet and app.boardsesh.com both fire it, www
   // does not. Props: { kind: 'list' | 'climb' | 'slug-list' | 'slug-climb' |
   // 'unparsed', status: 'resolved' | 'not_found' | 'auth_required', source:
-  // 'deep-link' | 'in-app' }. The www-side counterpart, `Climb Handoff Clicked`,
-  // arrives with W-15 (#4369).
+  // 'deep-link' | 'in-app' }. `not_found` is held back for a parsed URL that
+  // failed while the device was offline — that one heals on reconnect and would
+  // otherwise double-count as a failure and a success. The www-side counterpart,
+  // `Climb Handoff Clicked`, arrives with W-15 (#4369).
   BoardRouteHandoff: 'Board Route Handoff',
   // Logbook
   LogbookRowClicked: 'Logbook Row Clicked',

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -107,6 +107,14 @@ export const SHARED_EVENTS = {
   WorkoutGenerated: 'Workout Generated',
   // Deep-link session join
   SessionJoined: 'Session Joined',
+  // Canonical board URLs — deep links and the www front door's hand-off.
+  //
+  // App-only today: the native fleet and app.boardsesh.com both fire it, www
+  // does not. Props: { kind: 'list' | 'climb' | 'slug-list' | 'slug-climb' |
+  // 'unparsed', status: 'resolved' | 'not_found' | 'auth_required', source:
+  // 'deep-link' | 'in-app' }. The www-side counterpart, `Climb Handoff Clicked`,
+  // arrives with W-15 (#4369).
+  BoardRouteHandoff: 'Board Route Handoff',
   // Logbook
   LogbookRowClicked: 'Logbook Row Clicked',
   // Logbook search / filter usage — privacy-safe (counts, field names, and the


### PR DESCRIPTION
## Summary

Part of #4358.
Closes #4361.

`app.boardsesh.com` bounced every signed-out arrival to `/auth/login` and forgot which climb they came for — the exact failure mode that makes the www front door (#4369) worth nothing. W-06 relaxes the Expo app's auth gate for the read-only board URLs **on web only**, and carries the attempted path through login as a validated `?next=`.

- `src/lib/routing/read-only-routes.ts` — the allow-set and the `next` contract, pure and platform-free. Shape-only matching: it never resolves a slug or config against the catalogue, so a well-formed URL whose board is gone reaches that route's own not-found instead of a login wall. Locale-prefixed shares (`/es/…`, `/fr/…`, `/de/…`) are stripped before matching, or every non-English share link still hits a bare wall (they match no Expo route and land on `+not-found`).
- `src/lib/routing/anonymous-auth-gate.ts` / `.web.ts` — the platform fork. Native is a **constant module** (`false`, `() => false`, `() => '/auth/login'`, `() => null`); the web fork reads `window.location`, base-strips `EXPO_BASE_URL` (`/app` on the www-mounted export, `/` on the subdomain) and hands back base-relative hrefs.
- `auth-provider.tsx` — the gate keeps its literal `<Redirect href="/auth/login" />`. The only change is `&& !isAnonymousReadOnlyLocation()` on the condition, plus `readPostLoginReturnHref() ?? '/(tabs)/home'` on the authenticated branch (post-login navigation lives here, not in `login.tsx`, which never navigates on success and would race this redirect).
- `use-board-route-target.ts` — a relaxed route short-circuits to a new `auth-required` status **before** any resolution: `useAdoptedBoard` is disabled, the climb query is left unarmed and the hand-off effect returns early, so `resolveBoardForSession` / `fetchAllMyBoards` / `createBoard` / `setActiveBoard` / `useClimb` / `openClimbInPlayDrawer` never fire for someone with no account.
- `BoardRouteRedirect.tsx` — `auth-required` redirects to `/auth/login?next=<path>`. A successful hand-off has no status of its own: it is reported through an `onHandedOff` callback the hook fires from inside the hand-off itself (see the telemetry note below).
- `auth.web.ts` — the browser-OAuth round trip carries `next` on the NextAuth `callbackUrl`. Without it the fix is dead on the most common signed-out login: "Continue with Google" navigates the document away and the callback URL is rebuilt from scratch. No www change needed — its redirect callback returns allowed app-origin URLs verbatim, and `consumeWebOAuthReturn()` strips only the three `bs_oauth_*` params.
- `SHARED_EVENTS.BoardRouteHandoff` — `'Board Route Handoff'` with `{ kind, status, source }`, deliberately cross-platform.

### Why the hand-off event is fired imperatively

`status: 'resolved'` cannot be derived from a rendered status, and a first cut that did would have shipped a funnel reading ~100% failure. The hand-off effect calls `router.replace` / `router.back` in the same body as anything else it queues; React batches them, the navigator drops the redirector in the very render that would have carried the new status, and the update is discarded with the fiber. A throwaway probe under the mobile vitest — a child that sets its own state and calls the parent's "remove me" callback in one effect — committed only the pre-hand-off status, never the second one. The two suites that appeared to cover it could not see the problem: `use-board-route-target.test.tsx` runs against `replace: vi.fn()`, which leaves the screen mounted, and `BoardRouteRedirect.test.tsx` mocks the hook outright. So the success leg is fired imperatively next to `handedOffRef.current = targetKey`, exactly the way `join/[sessionId]` fires `Session Joined` before it replaces itself, and there is now a case whose router really unmounts the harness in the same batch.

`status: 'not_found'` is held back for a **parsed** URL while the device is offline. That state is the transient one `useAdoptedBoard`'s reconnect watcher heals — the pre-existing `re-resolves when the network comes back after an offline failure` test asserts the app passes through it — so reporting it would file a failure for every offline cold open that later lands, and count the same open twice, since the `resolved` follows under a different report key. An unparsed URL is a dead end whatever the network is doing and still reports.

### Open-redirect contract

`next` passes **two** independent gates before it is followed. `isSafeReturnPath`: non-empty, ≤512 chars, no control characters or whitespace, no scheme, a single leading `/`, no `//`, no backslash (browsers normalise `\` to `/`, so `/\evil.example` is protocol-relative). Then `isReadOnlyAnonymousPath`, which pins the destination to a shape the gate itself could have produced — so a hand-crafted `?next=` can never reach an arbitrary in-app route. `URLSearchParams.get` decodes once, so `%2f%2fevil.example` arrives as `//evil.example` and the protocol-relative rule catches it. A `next` is only ever *produced* for the relaxed allow-set, which keeps "every `next` the app emits is one it would serve anonymously" true by construction on both sides. Rejections are tested one case each.

### Scope boundary (reconciling the epic's DoD wording)

A relaxed route **mounts** anonymously, then short-circuits to `auth_required` and sends the visitor to login carrying the path — they land on the climb **after** signing in, which is what this issue's own Verifies asks for. It does not resolve a board anonymously, and that is forced by the data layer rather than caution: the config-tuple form mints a `UserBoard` through `createBoard`, which is `requireAuthenticated` (`packages/backend/src/graphql/resolvers/social/boards.ts`), and the hand-off destination is the Climbs tab plus the play drawer. `boardBySlug` and `climb` **are** anonymous-capable, so a genuinely anonymous in-app climb preview is buildable — but it is a new surface, not a gate change, and it is out of scope here. The epic's DoD bullet ("a signed-out deep link … resolves to that climb") is satisfied in the after-login sense. Nothing at all is asked of the server for a visitor with no account: the config-tuple form carries its whole board config in the URL, so the public `climb` query would otherwise have armed itself with no board to wait for — it is gated on the same `authRequired` flag, and a signed-out tuple-climb case asserts it stays unarmed while a signed-in one asserts it still fires.

## Production targets (standing rule 2)

**`app.boardsesh.com` AND the native store fleet via auto-OTA.** `.github/workflows/mobile-ota-production.yml` fires on `packages/mobile/**` and `packages/shared/**`, and the `fingerprint` runtimeVersion policy is unchanged by a JS-only diff, so this lands on every installed binary within hours of merge.

The split, stated rather than implied:

- **Web-only, asserted native-inert.** The gate relaxation and the `?next=` return. `anonymous-auth-gate.test.ts` asserts the native fork returns `false` / `'/auth/login'` / `null` across the entire route corpus *while a `window.location` is stubbed for each path* — proving it ignores the address bar rather than merely happening to be false. The new `native auth gate parity` suite in `auth-provider.test.tsx` asserts at render level, under `Platform.OS = 'ios'`, that every relaxed path still redirects to exactly `'/auth/login'` with no query and **never renders children**, and that a valid `?next=` in `window.location.search` is ignored on the authenticated branch (`'/(tabs)/home'`). A fork export-parity test keeps the two forks from drifting.
- **Cross-platform and additive.** The `Board Route Handoff` event — one capture per board-route open, including in-app opens through `(tabs)/climbs/[climbUuid]`. It is the only signal for whether deep links resolve on the native fleet too, and it is the one thing in this diff a store-fleet user's app will start doing that it does not do today. Nothing about it is visible on screen: no navigation, no copy, no render changes. (The `resolved` route status an earlier revision added is gone again, so the fleet also loses the extra render it caused.)

## Staged rollout (standing rule 7)

Publish with `eoas publish --rollout-percentage`, not a full-fleet publish. **Last-good commit for an emergency re-publish: `52167a1e6cb465d1d38250fc3007173d2fe5ab9d`** (this branch's base; re-read `gh run list --workflow=mobile-ota-production.yml --branch main --limit 1` immediately before merge and use the real last-good if `main` has moved). Hold full rollout until the PostHog OTA-health signature is clean: `Downloaded` events with **nonzero** Status launches for the new `updateId`. A fingerprint-matched OTA bricked prod once already.

Per standing rule 1, the www CTA that consumes this ships in #4369, at least one production deploy later.

**Fable review required** — it auto-OTAs to the native fleet, and every `packages/mobile` PR gets a native-OTA review regardless of tier. The three Opus QA lenses (delete-safety, SEO, native-OTA) apply.

## Release Notes

- [x] No release note needed (internal / technical change)

No user-visible native change. The gate relaxation and the `?next=` return are web-fork-only, asserted inert on native by the two suites above. What does reach the store fleet is one additive analytics capture per board-route open — no navigation, no copy, nothing on screen — so there is nothing for the "What's New" screen. The user-visible copy for this flow ships with the www front door in #4369.

## Test plan

| Command | Result |
|---|---|
| `vp run typecheck:mobile` | pass |
| `vp run test:mobile` | pass — 658 files, 6258 tests |
| `vp run check:mobile-bundle` | pass — native Metro graph resolves the inert fork and never pulls `read-only-routes.ts` in (`isReadOnlyAnonymousPath` / `MAX_RETURN_HREF_LENGTH` absent from the Android bundle) |
| `vp run check:mobile-web-bundle` | pass — web export resolves `anonymous-auth-gate.web.ts` |
| `vp run typecheck` (full) | pass |
| `vp test run --reporter=agent --project web` | pass — 485 files, 5987 tests (`SHARED_EVENTS` is a web dependency too) |
| `vp check` | lint clean; format reports two **pre-existing** offenders only, `docs/design/web-reposition/{gyms-directory,homepage-marketing}.html`, untouched by this branch and already failing at `52167a1e6` |

New / extended suites:

- `src/lib/routing/__tests__/anonymous-auth-gate.test.ts` — native fork inert across the whole corpus with a stubbed location, plus fork export parity. **The native-unchanged guarantee.**
- `src/providers/__tests__/auth-provider.test.tsx` — new `native auth gate parity` suite (render-level, `Platform.OS = 'ios'`). Every pre-existing test in the file is untouched; their unchanged green is part of the evidence.
- `src/lib/routing/__tests__/anonymous-auth-gate.web.test.ts` — allow-set matching, the login href, one rejection each for absolute / protocol-relative / double-encoded / scheme-bearing / backslash / out-of-allow-set `next` values, and `EXPO_BASE_URL=/app` base stripping.
- `src/providers/__tests__/auth-provider-anonymous-gate.web.test.tsx` — the web gate renders children on relaxed paths, emits a bare `'/auth/login'` on gated ones, honours a valid `next` and drops `//evil.example`.
- `src/lib/routing/__tests__/read-only-routes.test.ts` — pure predicate coverage, incl. locale-prefixed URLs, the `/estonia` whole-segment guard, and the routing-syntax segments (`/(tabs)/…`, `/b/..`) that hit the right segment count without naming a board.
- `src/lib/routing/__tests__/use-board-route-target.test.tsx` — the `auth-required` short-circuit fires no board resolution and no climb query at all, while the same URL signed in still arms one; unreachable when `RELAXES_ANONYMOUS_ROUTES` is false; the hand-off callback, including a case whose `router.replace` really unmounts the harness in the hand-off's own batch.
- `src/components/__tests__/BoardRouteRedirect.test.tsx` — new. Redirect on `auth-required`, one `Board Route Handoff` per outcome with `{ kind, status, source }`, no double-fire from either leg, the hand-off reported for a screen that never renders a terminal status, and the offline `not_found` held back until the retry fails online.
- `src/lib/__tests__/auth.web.test.ts` — the OAuth `callbackUrl` carries `next`, is byte-identical to today's without one, and `signInWithGoogle` actually wires the current screen's return path into it (not just the builder in isolation).

- `app/auth/__tests__/login-register-link.test.tsx` — new. Both directions of the register detour: login's sign-up link attaches `next` as a router param, register's "Already have an account? Sign in" hands it back, and both fall through to the bare route when there is nothing to return to (which is what native always does).

Review follow-ups already applied. `b354e3f8c`: the register leg is covered on both sides (`readPostLoginReturnHref` off `/auth/register?next=…`, and the provider landing a freshly registered visitor on the climb), `signInWithGoogle` is asserted to wire the return path into the callback URL, the `BoardRouteRedirect` redirect test asserts the component forwards the gate's href rather than a literal, and `MAX_RETURN_HREF_LENGTH`'s whole-value scope (query included, unlike the shape matcher) is documented as deliberate. `bc57a5b2c`: the hand-off event now deduplicates on the **URL** plus outcome rather than the event props — two climbs on the same board settle to an identical `{ kind, status, source }`, so the props alone would have undercounted every board-route open after the first on a reused route component; the URL never leaves the component.

QA round 2, all applied on top:

1. **The `resolved` leg never fired in production** (see "Why the hand-off event is fired imperatively"). Two lenses landed on it independently; a probe under the mobile vitest confirmed the render never commits. Fixed by reporting through `onHandedOff` from inside the hand-off, and the now-unobservable `resolved` route status and its mirror `useState` are deleted rather than left as decoration — that also takes one render back off the store fleet.
2. **`not_found` was inflated by the offline heal.** One offline cold open that later succeeded reported `not_found` and then `resolved`, so the funnel double-counted it as both. Held back for a parsed URL while `onlineManager` says offline; the retry reports if it fails online.
3. **The `auth-required` short-circuit didn't stop every anonymous call.** The tuple form's `useClimb` armed itself off the URL's own config. Gated on `authRequired`, which makes the comment above the short-circuit true and the scope-boundary paragraph above accurate.
4. **The `?next=` round trip was one-directional.** Register's two "Sign in" affordances dropped it, so Sign up → change of mind → Sign in lost the climb in three taps. Both now read the same `signInHref`.
5. **The allow-set accepted shapes the gate can't produce.** `next=/(tabs)/profile/a/b/40/list` and `/b/..` matched on segment count alone. Not an open redirect (same-origin, dead-ends at `+not-found`), but the comment claimed a stronger property than the code enforced, so routing-syntax segments are now rejected outright and both are in the gated corpus.

Still to run on a preview deploy of `app.boardsesh.com` (needs a browser, not CI): private window → `/b/{slug}/{angle}/view/{uuid}` → spinner → `/auth/login?next=…` → sign in with credentials → lands on that climb; repeat with Google OAuth; repeat with `/es/kilter/…/view/…` to confirm the `+not-found` locale bounce keeps the climb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6Ur37Pg6Ro9kyFxUr8r97

