### PR TITLE
feat: widen MoonBoard angle pickers behind moonboard-wide-angles flag

### DIFF
--- a/packages/backend/src/__tests__/moonboard-tick-angle.test.ts
+++ b/packages/backend/src/__tests__/moonboard-tick-angle.test.ts
@@ -299,6 +299,22 @@ describe('MoonBoard tick angle resolution (#3529)', () => {
     expect(snapEvents()).toHaveLength(0);
   });
 
+  // 4b. #3852 (moonboard-wide-angles): a tick at an angle outside MOONBOARD_ANGLES
+  // (25°/40°) can only have come from the wide-angle picker, which only exists
+  // behind the feature flag — there's no "stale narrow-UI mismatch" to correct at
+  // 35°, so rule (d) must not fire even though the climb is graded at 40 with no
+  // stats yet at 35.
+  it('leaves a MoonBoard tick alone at an angle outside the narrow 25/40 set', async () => {
+    await tickMutations.saveTick(
+      undefined,
+      { input: tickInput({ boardType: 'moonboard', climbUuid: MOON_GRADED_40, angle: 35 }) },
+      authCtx(),
+    );
+
+    expect(await storedAngles(MOON_GRADED_40)).toEqual([35]);
+    expect(snapEvents()).toHaveLength(0);
+  });
+
   // 5. The OTHER forward-compat guard, and the real removal trigger: #3851 sets
   // board_climbs.angle = NULL on the canonical climb, at which point rule (d)
   // must go inert on its own with no code change and no flag.

--- a/packages/db/src/queries/climbs/moonboard-tick-angle.ts
+++ b/packages/db/src/queries/climbs/moonboard-tick-angle.ts
@@ -1,7 +1,10 @@
 import { and, eq, exists, sql } from 'drizzle-orm';
 import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
+import { MOONBOARD_ANGLES } from '@boardsesh/board-config';
 import { boardClimbs, boardClimbStats } from '../../schema/boards/unified';
 import { statsRowCarriesRealCatalogData } from '../climb-stats/real-catalog-data';
+
+const MOONBOARD_ANGLE_SET: ReadonlySet<number> = new Set(MOONBOARD_ANGLES);
 
 // Same handle type the recompute core takes: any drizzle PgDatabase (postgres-js,
 // the script client, the Neon HTTP client) and the PgTransaction the backend
@@ -43,7 +46,8 @@ export type MoonBoardTickAngleInput = {
  *       carrying REAL CATALOG DATA already exists at requestedAngle.
  *   (c) climb not in board_climbs, OR the climb is USER-CREATED
  *       (board_climbs.user_id IS NOT NULL), OR board_climbs.angle IS NULL, OR a
- *       catalog-data stats row already exists at requestedAngle → return
+ *       catalog-data stats row already exists at requestedAngle, OR
+ *       requestedAngle is not one of MOONBOARD_ANGLES (25°/40°) → return
  *       requestedAngle unchanged.
  *   (d) otherwise → return board_climbs.angle.
  *
@@ -82,9 +86,14 @@ export type MoonBoardTickAngleInput = {
  *     row, and rule (d) will snap a legitimate 25° tick on it. Whoever lands the
  *     re-import closes that window; until then this is the known cost, and it is
  *     the same cost as today's behaviour being wrong in the other direction.
- *   - #3852 (moonboard-wide-angles, flag off) deliberately lets climbers tick
- *     angles the catalog does not grade. Under rule (d) the first such tick is
- *     snapped back. Whoever lands #3852 must drop rule (d) or make it flag-aware.
+ *   - #3852 (moonboard-wide-angles) deliberately lets climbers tick angles the
+ *     catalog does not grade, once the feature flag is on. Resolved: rule (c)'s
+ *     new leg exempts any requestedAngle outside MOONBOARD_ANGLES from rule (d)
+ *     entirely. The narrow picker can only ever request 25 or 40, so a
+ *     non-catalog angle only reaches here via the wide picker — there's no
+ *     legitimate "stale narrow-UI mismatch" to correct at those angles, only a
+ *     deliberate wide-angle tick that must be left alone. No PostHog read is
+ *     needed server-side: the angle domain itself is the signal.
  *
  * NEVER THROWS on any path, and that is load-bearing: a non-retryable GraphQL
  * error dead-letters immediately in the offline drainer, so a hiccup here would
@@ -124,6 +133,7 @@ export async function resolveMoonBoardTickAngle(
     if (climb.ownerUserId != null) return requestedAngle;
     if (climb.gradedAngle == null) return requestedAngle;
     if (climb.catalogDataAtRequestedAngle) return requestedAngle;
+    if (!MOONBOARD_ANGLE_SET.has(requestedAngle)) return requestedAngle;
 
     return climb.gradedAngle;
   } catch (error) {

--- a/packages/mobile/src/components/play-drawer/AngleSelectorSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/AngleSelectorSheet.tsx
@@ -4,8 +4,8 @@ import { BottomSheetModal, BottomSheetView } from '@expo/ui/community/bottom-she
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import type { BoardName } from '@boardsesh/shared-schema';
-import { ANGLES } from '@boardsesh/board-config';
 import { Text } from '../Text';
+import { useBoardAngleOptions } from '../../hooks/use-board-angle-options';
 import { androidSafeSnapPoints } from '../sheet-snap-points';
 import { useClimbStatsHistory } from '../../lib/graphql/hooks';
 import { useGradeFormat } from '../../hooks/use-grade-format';
@@ -50,8 +50,9 @@ export const AngleSelectorSheet = memo(function AngleSelectorSheet({
   const snapPoints = useMemo(() => androidSafeSnapPoints(['90%']), []);
 
   // Valid angles come from the static per-board table (what web uses) — robust
-  // and offline, unlike a per-board query.
-  const angles = useMemo<number[]>(() => ANGLES[boardName as BoardName] ?? [], [boardName]);
+  // and offline, unlike a per-board query. MoonBoard swaps in the full
+  // Kilter/Tension-style range when the moonboard-wide-angles flag is on.
+  const angles = useBoardAngleOptions(boardName as BoardName);
 
   // Live preview angle. Applied to the board only when "Done" is pressed; the
   // diagram, grade, stars and sends all reflect this as the user slides.

--- a/packages/mobile/src/components/play-drawer/__tests__/angle-selector-sheet-stats-gate.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/angle-selector-sheet-stats-gate.test.tsx
@@ -74,7 +74,13 @@ vi.mock('../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
 }));
 
-vi.mock('@boardsesh/board-config', () => ({ ANGLES: { kilter: [20, 25, 30, 40] } }));
+vi.mock('@boardsesh/board-config', () => {
+  const angles: Record<string, number[]> = { kilter: [20, 25, 30, 40] };
+  return {
+    ANGLES: angles,
+    getBoardAngleOptions: (boardName: string) => angles[boardName] ?? [],
+  };
+});
 
 vi.mock('../../../hooks/use-grade-format', () => ({
   useGradeFormat: () => ({ gradeFormat: 'v_grade' }),

--- a/packages/mobile/src/components/you/LogbookEditSheet.tsx
+++ b/packages/mobile/src/components/you/LogbookEditSheet.tsx
@@ -4,7 +4,8 @@ import { type BottomSheet } from '@expo/ui/community/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import { useUpdateTick, useDeleteTick } from '@boardsesh/board-react';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
-import { ANGLES, formatBoardDisplayName } from '@boardsesh/board-config';
+import { formatBoardDisplayName } from '@boardsesh/board-config';
+import { useBoardAngleOptions } from '../../hooks/use-board-angle-options';
 import { getGradeColor } from '@boardsesh/board-constants/grade-colors';
 import type { BoardName } from '@boardsesh/shared-schema';
 import { track } from '../../lib/analytics';
@@ -86,7 +87,7 @@ export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheet
   // Valid angles come from the static per-board table (what web and the
   // play-drawer angle selector use) — robust and offline, unlike a per-board
   // query.
-  const angles = useMemo<number[]>(() => ANGLES[ascent?.boardType as BoardName] ?? [], [ascent?.boardType]);
+  const angles = useBoardAngleOptions(ascent?.boardType as BoardName | undefined);
 
   // Re-seed the form whenever a different ascent opens the sheet.
   useEffect(() => {

--- a/packages/mobile/src/hooks/__tests__/use-board-angle-options.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-board-angle-options.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+// Flag-gated MoonBoard angle widening: only MoonBoard is affected, and only when the flag resolves true.
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { ANGLES, MOONBOARD_WIDE_ANGLES } from '@boardsesh/board-config';
+import { FeatureFlagsProvider } from '../../providers/feature-flags-provider';
+import { resetFeatureFlagOverridesForTests } from '../../lib/feature-flag-overrides';
+import { useBoardAngleOptions } from '../use-board-angle-options';
+
+vi.mock('@react-native-async-storage/async-storage', () => {
+  let storage: Record<string, string> = {};
+  return {
+    default: {
+      getItem: vi.fn(async (key: string) => storage[key] ?? null),
+      setItem: vi.fn(async (key: string, value: string) => {
+        storage[key] = value;
+      }),
+      removeItem: vi.fn(async (key: string) => {
+        delete storage[key];
+      }),
+      __reset: () => {
+        storage = {};
+      },
+    },
+  };
+});
+
+function wrapper(flagValue: boolean | undefined) {
+  return ({ children }: { children: ReactNode }) => (
+    <FeatureFlagsProvider flags={{ 'moonboard-wide-angles': flagValue }}>{children}</FeatureFlagsProvider>
+  );
+}
+
+describe('useBoardAngleOptions', () => {
+  afterEach(() => {
+    resetFeatureFlagOverridesForTests();
+    (AsyncStorage as unknown as { __reset: () => void }).__reset();
+  });
+
+  it('returns an empty list when boardName is undefined', () => {
+    const { result } = renderHook(() => useBoardAngleOptions(undefined), { wrapper: wrapper(undefined) });
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns the narrow MoonBoard angle list when the flag is undefined (default OFF)', () => {
+    const { result } = renderHook(() => useBoardAngleOptions('moonboard'), { wrapper: wrapper(undefined) });
+    expect(result.current).toEqual([25, 40]);
+  });
+
+  it('returns the narrow MoonBoard angle list when the flag is explicitly off', () => {
+    const { result } = renderHook(() => useBoardAngleOptions('moonboard'), { wrapper: wrapper(false) });
+    expect(result.current).toEqual([25, 40]);
+  });
+
+  it('returns the full Kilter/Tension-style range for MoonBoard when the flag is on', () => {
+    const { result } = renderHook(() => useBoardAngleOptions('moonboard'), { wrapper: wrapper(true) });
+    expect(result.current).toEqual([...MOONBOARD_WIDE_ANGLES]);
+  });
+
+  it('never widens Kilter, flag on or off', () => {
+    const { result: offResult } = renderHook(() => useBoardAngleOptions('kilter'), { wrapper: wrapper(false) });
+    const { result: onResult } = renderHook(() => useBoardAngleOptions('kilter'), { wrapper: wrapper(true) });
+    expect(offResult.current).toEqual(ANGLES.kilter);
+    expect(onResult.current).toEqual(ANGLES.kilter);
+  });
+
+  it('never widens Tension, flag on or off', () => {
+    const { result: offResult } = renderHook(() => useBoardAngleOptions('tension'), { wrapper: wrapper(false) });
+    const { result: onResult } = renderHook(() => useBoardAngleOptions('tension'), { wrapper: wrapper(true) });
+    expect(offResult.current).toEqual(ANGLES.tension);
+    expect(onResult.current).toEqual(ANGLES.tension);
+  });
+});

--- a/packages/mobile/src/hooks/use-board-angle-options.ts
+++ b/packages/mobile/src/hooks/use-board-angle-options.ts
@@ -1,0 +1,13 @@
+import { getBoardAngleOptions } from '@boardsesh/board-config';
+import type { BoardName } from '@boardsesh/shared-schema';
+import { useFeatureFlag } from '../providers/feature-flags-provider';
+
+// Angle options for `boardName`: ANGLES[boardName] (from @boardsesh/board-config), except
+// MoonBoard swaps in the full Kilter/Tension-style range when the `moonboard-wide-angles`
+// flag is on. `boardName` is optional so call sites reading it off an async record (e.g. a
+// logbook ascent) don't need to gate the hook call itself.
+export function useBoardAngleOptions(boardName: BoardName | undefined): number[] {
+  const wideAnglesEnabled = useFeatureFlag('moonboard-wide-angles') === true;
+  if (!boardName) return [];
+  return getBoardAngleOptions(boardName, wideAnglesEnabled);
+}

--- a/packages/mobile/src/providers/feature-flags-provider.tsx
+++ b/packages/mobile/src/providers/feature-flags-provider.tsx
@@ -88,6 +88,12 @@ export const FEATURE_FLAG_DEFINITIONS = [
     description:
       'Show the data-science "Boardsesh grade" section in the play drawer (cross-board grade, confidence tier, send counts). Off hides the section.',
   },
+  {
+    key: 'moonboard-wide-angles',
+    label: 'MoonBoard wide angles',
+    description:
+      'Offer the full 0-70° MoonBoard angle range (matching Kilter/Tension) in angle pickers instead of just the 25°/40° Moon Climbing grades. Nothing server-side enforces the narrow range, so this is purely a UI rollout control.',
+  },
 ] as const satisfies readonly FeatureFlagDefinition[];
 
 // The literal key union (e.g. `'strava-integration'`), preserved via the

--- a/packages/shared/board-config/src/board-data.ts
+++ b/packages/shared/board-config/src/board-data.ts
@@ -1,7 +1,7 @@
 import { AURORA_BOARDS, SUPPORTED_BOARDS as ALL_SUPPORTED_BOARDS } from '@boardsesh/shared-schema';
 import type { BoardName } from '@boardsesh/shared-schema';
 import type { Angle } from './types';
-import { MOONBOARD_ENABLED, MOONBOARD_ANGLES } from './moonboard-config';
+import { MOONBOARD_ENABLED, MOONBOARD_ANGLES, MOONBOARD_WIDE_ANGLES } from './moonboard-config';
 
 type ImageDimensions = Record<
   string,
@@ -219,6 +219,21 @@ export const ANGLES: Record<BoardName, Angle[]> = {
   grasshopper: [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70],
   soill: [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70],
 };
+
+// Module scope so every call returns the same array reference (a stable dep/memo key).
+const MOONBOARD_WIDE_ANGLE_OPTIONS: Angle[] = [...MOONBOARD_WIDE_ANGLES];
+
+// Angle options for `boardName`: ANGLES[boardName], except MoonBoard swaps in
+// the full Kilter/Tension-style range when `wideAnglesEnabled` is true (the
+// `moonboard-wide-angles` feature flag, read by the platform-specific
+// `useBoardAngleOptions` hooks in web and mobile). Pure so it's shared as-is
+// by both platforms instead of duplicating the branch.
+export function getBoardAngleOptions(boardName: BoardName, wideAnglesEnabled: boolean): Angle[] {
+  if (boardName === 'moonboard' && wideAnglesEnabled) {
+    return MOONBOARD_WIDE_ANGLE_OPTIONS;
+  }
+  return ANGLES[boardName];
+}
 
 // BOULDER_GRADES + BoulderGrade live in @boardsesh/board-constants so display
 // utilities can depend on the grade taxonomy without pulling in the rest of

--- a/packages/shared/board-config/src/moonboard-config.ts
+++ b/packages/shared/board-config/src/moonboard-config.ts
@@ -118,8 +118,20 @@ const MOONBOARD_ROWS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 1
 
 export { MOONBOARD_GRID };
 
-// MoonBoard only supports 25 and 40 degree angles
+// The two angles Moon Climbing's own catalog grades problems at (25°/40°).
+// This is the default/fallback angle list every picker uses. It's a UI
+// convention, not a hard limit — nothing server-side rejects other angles for
+// MoonBoard (angle is a plain 0-90 bounded int everywhere it's validated) —
+// see the `moonboard-wide-angles` feature flag for the flag-gated wider range.
 export const MOONBOARD_ANGLES = [25, 40] as const;
+
+// The full angle range, matching Kilter/Tension (ANGLES.kilter/tension in
+// board-data.ts), offered by angle pickers when the `moonboard-wide-angles`
+// feature flag is on. A MoonBoard problem's holds don't change with angle —
+// Moon Climbing just never grades outside 25°/40°, so climbs graded at other
+// angles start with no catalog grade/stats until the community logs there,
+// exactly like any Aurora board today.
+export const MOONBOARD_WIDE_ANGLES = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70] as const;
 
 // MoonBoard has a single fixed size (all boards are same dimensions)
 export const MOONBOARD_SIZE = {

--- a/packages/web/app/components/board-page/angle-selector.tsx
+++ b/packages/web/app/components/board-page/angle-selector.tsx
@@ -17,7 +17,7 @@ import {
   CLIMB_STATS_FOR_ANGLES,
   type ClimbStatsForAnglesResponse,
 } from '@boardsesh/graphql/operations/climb-stats-for-angles';
-import { ANGLES } from '@/app/lib/board-data';
+import { useBoardAngleOptions } from '@/app/hooks/use-board-angles';
 import type { BoardName, BoardDetails, Climb } from '@/app/lib/types';
 import type { ClimbStatsForAngle } from '@/app/lib/data/queries';
 import { useIsDarkMode } from '@/app/hooks/use-is-dark-mode';
@@ -51,6 +51,7 @@ export default function AngleSelector({
   const currentAngleRef = useRef<HTMLDivElement>(null);
   const isDark = useIsDarkMode();
   const { activeSession, setSessionBoardPath } = usePersistentSession();
+  const angleOptions = useBoardAngleOptions(boardName);
 
   // Fetch climb stats for all angles when there's a current climb.
   // Runs through the GraphQL backend (graphql-request HTTP) rather than a
@@ -275,7 +276,7 @@ export default function AngleSelector({
             gap: 1,
           }}
         >
-          {ANGLES[boardName].map(renderAngleCard)}
+          {angleOptions.map(renderAngleCard)}
         </Box>
       </SwipeableDrawer>
     </>

--- a/packages/web/app/components/board-selector-drawer/board-config-selects.tsx
+++ b/packages/web/app/components/board-selector-drawer/board-config-selects.tsx
@@ -9,7 +9,8 @@ import MuiSelect, { type SelectChangeEvent } from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 
 import type { BoardName } from '@/app/lib/types';
-import { SUPPORTED_BOARDS, ANGLES } from '@/app/lib/board-data';
+import { SUPPORTED_BOARDS } from '@/app/lib/board-data';
+import { useBoardAngleOptions } from '@/app/hooks/use-board-angles';
 
 export type BoardConfigSelectsProps = {
   selectedBoard: BoardName | undefined;
@@ -43,6 +44,7 @@ export default function BoardConfigSelects({
   onAngleChange,
 }: BoardConfigSelectsProps) {
   const { t } = useTranslation('boards');
+  const angleOptions = useBoardAngleOptions(selectedBoard ?? 'kilter');
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
       <FormControl fullWidth size="small">
@@ -118,7 +120,7 @@ export default function BoardConfigSelects({
           disabled={!selectedBoard}
         >
           {selectedBoard &&
-            ANGLES[selectedBoard].map((angle) => (
+            angleOptions.map((angle) => (
               <MenuItem key={angle} value={angle}>
                 {angle}
               </MenuItem>

--- a/packages/web/app/components/board-selector-drawer/board-config-selects.tsx
+++ b/packages/web/app/components/board-selector-drawer/board-config-selects.tsx
@@ -44,7 +44,7 @@ export default function BoardConfigSelects({
   onAngleChange,
 }: BoardConfigSelectsProps) {
   const { t } = useTranslation('boards');
-  const angleOptions = useBoardAngleOptions(selectedBoard ?? 'kilter');
+  const angleOptions = useBoardAngleOptions(selectedBoard);
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
       <FormControl fullWidth size="small">

--- a/packages/web/app/components/create-climb/__tests__/create-climb-form.test.tsx
+++ b/packages/web/app/components/create-climb/__tests__/create-climb-form.test.tsx
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
-import { act, render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { act, render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { FeatureFlagsProvider } from '../../providers/feature-flags-provider';
+import { MOONBOARD_WIDE_ANGLES_FLAG } from '@/app/flags';
 import CreateClimbForm from '../create-climb-form';
 import { useBoardProvider } from '../../board-provider/board-provider-context';
 import { useCreateClimb } from '@boardsesh/create-climb-react';
@@ -197,6 +199,8 @@ vi.mock('@/app/lib/backend-url', () => ({
 
 vi.mock('@/app/lib/analytics', () => ({
   track: vi.fn(),
+  readPosthogFeatureFlags: () => ({}),
+  subscribePosthogFeatureFlags: () => () => {},
 }));
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
@@ -621,6 +625,29 @@ describe('CreateClimbForm — MoonBoard rendering', () => {
     expect(screen.getByText('createClimbForm.fields.angle')).toBeTruthy();
     expect(screen.getByText('createClimbForm.fields.grade')).toBeTruthy();
     expect(screen.queryByText('createClimbForm.fields.benchmark')).toBeNull();
+  });
+
+  it('angle picker offers only 25°/40° when moonboard-wide-angles is off (default)', () => {
+    renderMoonboard();
+    fireEvent.click(screen.getByRole('button', { name: /settings/i }));
+    const angleField = screen.getByText('createClimbForm.fields.angle').closest('div') as HTMLElement;
+    fireEvent.mouseDown(within(angleField).getByRole('combobox'));
+    expect(screen.getAllByRole('option')).toHaveLength(2);
+  });
+
+  it('angle picker offers the full 15-value range when moonboard-wide-angles is on', () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <FeatureFlagsProvider flags={{ [MOONBOARD_WIDE_ANGLES_FLAG]: true }}>
+          <CreateClimbForm {...MOONBOARD_PROPS} />
+        </FeatureFlagsProvider>
+      </QueryClientProvider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /settings/i }));
+    const angleField = screen.getByText('createClimbForm.fields.angle').closest('div') as HTMLElement;
+    fireEvent.mouseDown(within(angleField).getByRole('combobox'));
+    expect(screen.getAllByRole('option')).toHaveLength(15);
   });
 
   it('has Draft toggle checked by default', () => {

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -48,7 +48,8 @@ import { CLIMB_CHARACTERISTICS } from '@boardsesh/shared-schema';
 import type { BoardDetails, BoardName, Climb } from '@/app/lib/types';
 import { convertLitUpHoldsStringToMap } from '../board-renderer/util';
 import type { LitUpHoldsMap } from '../board-renderer/types';
-import { getMoonBoardGradeLabel, MOONBOARD_GRADES, MOONBOARD_ANGLES } from '@/app/lib/moonboard-config';
+import { getMoonBoardGradeLabel, MOONBOARD_GRADES } from '@/app/lib/moonboard-config';
+import { useBoardAngleOptions } from '@/app/hooks/use-board-angles';
 import { getSoftGradeColor } from '@/app/lib/grade-colors';
 import { useColorMode } from '@/app/hooks/use-color-mode';
 import { parseScreenshot } from '@boardsesh/moonboard-ocr/browser';
@@ -353,6 +354,7 @@ export default function CreateClimbForm({
   const [method, setMethod] = useState<MoonBoardMethodToken | ''>('');
   const userGradeLabel = useMemo(() => (userGrade ? getMoonBoardGradeLabel(userGrade) : undefined), [userGrade]);
   const [selectedAngle, setSelectedAngle] = useState<number>(angle);
+  const moonBoardAngleOptions = useBoardAngleOptions('moonboard');
   const [moonBoardDuplicateMatch, setMoonBoardDuplicateMatch] = useState<MoonBoardClimbDuplicateMatch | null>(null);
   const [isCheckingMoonBoardDuplicate, setIsCheckingMoonBoardDuplicate] = useState(false);
   // Set when a publish attempt is rejected by the server because the holds
@@ -1939,7 +1941,7 @@ export default function CreateClimbForm({
                   className={styles.settingsGradeField}
                   size="small"
                 >
-                  {MOONBOARD_ANGLES.map((a) => (
+                  {moonBoardAngleOptions.map((a) => (
                     <MenuItem key={a} value={a}>
                       {`${a}°`}
                     </MenuItem>

--- a/packages/web/app/components/logbook/logascent-form.tsx
+++ b/packages/web/app/components/logbook/logascent-form.tsx
@@ -21,7 +21,8 @@ import type { Climb, BoardDetails } from '@/app/lib/types';
 import { useBoardProvider } from '../board-provider/board-provider-context';
 import { useBoardPresenceControls } from '../board-presence/board-presence-context';
 import type { TickStatus } from '@boardsesh/board-react';
-import { getGradesForBoard, ANGLES } from '@/app/lib/board-data';
+import { getGradesForBoard } from '@/app/lib/board-data';
+import { useBoardAngleOptions } from '@/app/hooks/use-board-angles';
 import { isBetaVideoUrl, BETA_VIDEO_URL_VALIDATION_MESSAGE } from '@/app/lib/beta-video-url';
 import { useEffectiveAngle } from '@/app/hooks/use-effective-angle';
 import { useOptionalCurrentClimb } from '../graphql-queue/QueueContext';
@@ -107,7 +108,7 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({
   const { saveTick, isAuthenticated } = useBoardProvider();
   const { boardId: presenceBoardId } = useBoardPresenceControls();
   const grades = useMemo(() => getGradesForBoard(boardDetails.board_name), [boardDetails.board_name]);
-  const angleOptions = ANGLES[boardDetails.board_name];
+  const angleOptions = useBoardAngleOptions(boardDetails.board_name);
   // Resolve the wall's current angle (route → party session → climb record).
   // Never `|| 0` here — group-session feedback fix. If nothing resolves the
   // submit action stays disabled until the user picks one in the angle Select.

--- a/packages/web/app/components/playlist-generator/generator-options-form.tsx
+++ b/packages/web/app/components/playlist-generator/generator-options-form.tsx
@@ -12,7 +12,8 @@ import MuiButton from '@mui/material/Button';
 import type { SxProps, Theme } from '@mui/material/styles';
 import { RemoveOutlined, AddOutlined, RefreshOutlined } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
-import { ANGLES, getGradesForBoard } from '@/app/lib/board-data';
+import { getGradesForBoard } from '@/app/lib/board-data';
+import { useBoardAngleOptions } from '@/app/hooks/use-board-angles';
 import MinAscentsBucketPicker from '@/app/components/climb-quality-filter/min-ascents-bucket-picker';
 import { InlineGradePicker } from '@/app/components/grade-picker/inline-grade-picker';
 import { InlineStarPicker } from '@/app/components/logbook/tick-controls';
@@ -70,7 +71,7 @@ const GeneratorOptionsForm: React.FC<GeneratorOptionsFormProps> = ({
 }) => {
   const { t } = useTranslation('playlists');
   const grades = getGradesForBoard(boardDetails.board_name);
-  const angles = ANGLES[boardDetails.board_name] ?? [];
+  const angles = useBoardAngleOptions(boardDetails.board_name);
 
   const warmUpOptions = WARM_UP_OPTIONS.map((value) => ({
     value,

--- a/packages/web/app/components/social/create-proposal-form.tsx
+++ b/packages/web/app/components/social/create-proposal-form.tsx
@@ -20,7 +20,8 @@ import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { ClientError } from 'graphql-request';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import { CREATE_PROPOSAL } from '@boardsesh/graphql/operations/proposals';
-import { BOULDER_GRADES, ANGLES } from '@/app/lib/board-data';
+import { BOULDER_GRADES } from '@/app/lib/board-data';
+import { useBoardAngleOptions } from '@/app/hooks/use-board-angles';
 import { getGradeTintColor } from '@/app/lib/grade-colors';
 import SwipeableDrawer from '@/app/components/swipeable-drawer/swipeable-drawer';
 import type { Proposal, ProposalType } from '@boardsesh/shared-schema';
@@ -57,7 +58,8 @@ export default function CreateProposalForm({
   const [loading, setLoading] = useState(false);
   const [snackbar, setSnackbar] = useState('');
 
-  const boardAngles = boardName ? ANGLES[boardName as BoardName] || [] : [];
+  const angleOptions = useBoardAngleOptions((boardName as BoardName | undefined) ?? 'kilter');
+  const boardAngles = boardName ? angleOptions : [];
 
   const handleClose = useCallback(() => {
     setOpen(false);

--- a/packages/web/app/components/social/create-proposal-form.tsx
+++ b/packages/web/app/components/social/create-proposal-form.tsx
@@ -58,8 +58,7 @@ export default function CreateProposalForm({
   const [loading, setLoading] = useState(false);
   const [snackbar, setSnackbar] = useState('');
 
-  const angleOptions = useBoardAngleOptions((boardName as BoardName | undefined) ?? 'kilter');
-  const boardAngles = boardName ? angleOptions : [];
+  const boardAngles = useBoardAngleOptions(boardName as BoardName | undefined);
 
   const handleClose = useCallback(() => {
     setOpen(false);

--- a/packages/web/app/flags.ts
+++ b/packages/web/app/flags.ts
@@ -22,6 +22,16 @@ export const BOARDSESH_GRADE_FLAG = 'boardsesh-grade';
 // page is only reachable via a URL the gym owner configured on purpose.
 export const GYM_KIOSK_FLAG = 'gym-kiosk';
 
+// Gates offering MoonBoard's full 0-70° angle range in angle pickers (angle
+// drawer, board selector, playlist generator, log-ascent form, propose-change
+// form, create-climb form). OFF keeps every picker limited to MOONBOARD_ANGLES
+// (25°/40°, the two angles Moon Climbing's own catalog grades) — see
+// MOONBOARD_WIDE_ANGLES in @boardsesh/board-config. Nothing server-side
+// enforces this restriction (angle is a plain 0-90 bounded int everywhere it's
+// validated), so this is purely a UI rollout control, same as every other flag
+// here — matching the documented "flags gate the UI entry point only" pattern.
+export const MOONBOARD_WIDE_ANGLES_FLAG = 'moonboard-wide-angles';
+
 // Keys read from PostHog by FeatureFlagsProvider. Each must have a matching
 // PostHog feature flag; values stay `undefined` (OFF) until that flag resolves.
 export const FEATURE_FLAG_KEYS = [
@@ -29,6 +39,7 @@ export const FEATURE_FLAG_KEYS = [
   GARMIN_WATCH_FLAG,
   BOARDSESH_GRADE_FLAG,
   GYM_KIOSK_FLAG,
+  MOONBOARD_WIDE_ANGLES_FLAG,
 ] as const;
 
 // Vercel's flags discovery endpoint expects an allFlags export.

--- a/packages/web/app/hooks/__tests__/use-board-angles.test.tsx
+++ b/packages/web/app/hooks/__tests__/use-board-angles.test.tsx
@@ -15,6 +15,11 @@ function wrapper(flagValue: boolean | undefined) {
 }
 
 describe('useBoardAngleOptions', () => {
+  it('returns an empty list when boardName is undefined', () => {
+    const { result } = renderHook(() => useBoardAngleOptions(undefined), { wrapper: wrapper(true) });
+    expect(result.current).toEqual([]);
+  });
+
   it('returns the narrow MoonBoard angle list when the flag is undefined (default OFF)', () => {
     const { result } = renderHook(() => useBoardAngleOptions('moonboard'), { wrapper: wrapper(undefined) });
     expect(result.current).toEqual([25, 40]);

--- a/packages/web/app/hooks/__tests__/use-board-angles.test.tsx
+++ b/packages/web/app/hooks/__tests__/use-board-angles.test.tsx
@@ -1,0 +1,46 @@
+// Flag-gated MoonBoard angle widening: only MoonBoard is affected, and only when the flag resolves true.
+import { describe, it, expect } from 'vite-plus/test';
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { FeatureFlagsProvider } from '@/app/components/providers/feature-flags-provider';
+import { MOONBOARD_WIDE_ANGLES_FLAG } from '@/app/flags';
+import { ANGLES } from '@/app/lib/board-data';
+import { MOONBOARD_WIDE_ANGLES } from '@boardsesh/board-config';
+import { useBoardAngleOptions } from '../use-board-angles';
+
+function wrapper(flagValue: boolean | undefined) {
+  return ({ children }: { children: React.ReactNode }) => (
+    <FeatureFlagsProvider flags={{ [MOONBOARD_WIDE_ANGLES_FLAG]: flagValue }}>{children}</FeatureFlagsProvider>
+  );
+}
+
+describe('useBoardAngleOptions', () => {
+  it('returns the narrow MoonBoard angle list when the flag is undefined (default OFF)', () => {
+    const { result } = renderHook(() => useBoardAngleOptions('moonboard'), { wrapper: wrapper(undefined) });
+    expect(result.current).toEqual([25, 40]);
+  });
+
+  it('returns the narrow MoonBoard angle list when the flag is explicitly off', () => {
+    const { result } = renderHook(() => useBoardAngleOptions('moonboard'), { wrapper: wrapper(false) });
+    expect(result.current).toEqual([25, 40]);
+  });
+
+  it('returns the full Kilter/Tension-style range for MoonBoard when the flag is on', () => {
+    const { result } = renderHook(() => useBoardAngleOptions('moonboard'), { wrapper: wrapper(true) });
+    expect(result.current).toEqual([...MOONBOARD_WIDE_ANGLES]);
+  });
+
+  it('never widens Kilter, flag on or off', () => {
+    const { result: offResult } = renderHook(() => useBoardAngleOptions('kilter'), { wrapper: wrapper(false) });
+    const { result: onResult } = renderHook(() => useBoardAngleOptions('kilter'), { wrapper: wrapper(true) });
+    expect(offResult.current).toEqual(ANGLES.kilter);
+    expect(onResult.current).toEqual(ANGLES.kilter);
+  });
+
+  it('never widens Tension, flag on or off', () => {
+    const { result: offResult } = renderHook(() => useBoardAngleOptions('tension'), { wrapper: wrapper(false) });
+    const { result: onResult } = renderHook(() => useBoardAngleOptions('tension'), { wrapper: wrapper(true) });
+    expect(offResult.current).toEqual(ANGLES.tension);
+    expect(onResult.current).toEqual(ANGLES.tension);
+  });
+});

--- a/packages/web/app/hooks/use-board-angles.ts
+++ b/packages/web/app/hooks/use-board-angles.ts
@@ -1,0 +1,11 @@
+import { getBoardAngleOptions } from '@/app/lib/board-data';
+import { MOONBOARD_WIDE_ANGLES_FLAG } from '@/app/flags';
+import { useFeatureFlag } from '@/app/components/providers/feature-flags-provider';
+import type { BoardName } from '@/app/lib/types';
+import type { Angle } from '@boardsesh/board-config';
+
+// Angle options for `boardName`: ANGLES[boardName], except MoonBoard swaps in the full range when MOONBOARD_WIDE_ANGLES_FLAG is on.
+export function useBoardAngleOptions(boardName: BoardName): Angle[] {
+  const wideAnglesEnabled = useFeatureFlag(MOONBOARD_WIDE_ANGLES_FLAG) === true;
+  return getBoardAngleOptions(boardName, wideAnglesEnabled);
+}

--- a/packages/web/app/hooks/use-board-angles.ts
+++ b/packages/web/app/hooks/use-board-angles.ts
@@ -5,7 +5,10 @@ import type { BoardName } from '@/app/lib/types';
 import type { Angle } from '@boardsesh/board-config';
 
 // Angle options for `boardName`: ANGLES[boardName], except MoonBoard swaps in the full range when MOONBOARD_WIDE_ANGLES_FLAG is on.
-export function useBoardAngleOptions(boardName: BoardName): Angle[] {
+// `boardName` is optional so call sites reading it off an as-yet-unselected value
+// (e.g. a board picker before a board is chosen) don't need a throwaway fallback.
+export function useBoardAngleOptions(boardName: BoardName | undefined): Angle[] {
   const wideAnglesEnabled = useFeatureFlag(MOONBOARD_WIDE_ANGLES_FLAG) === true;
+  if (!boardName) return [];
   return getBoardAngleOptions(boardName, wideAnglesEnabled);
 }

--- a/packages/web/app/lib/board-data.ts
+++ b/packages/web/app/lib/board-data.ts
@@ -8,5 +8,6 @@ export {
   getGradesForBoard,
   fontGradeToDifficultyId,
   getGradeByDifficultyId,
+  getBoardAngleOptions,
 } from '@boardsesh/board-config';
 export type { BoulderGrade, SetIdList } from '@boardsesh/board-config';


### PR DESCRIPTION
## Summary

- Adds a `moonboard-wide-angles` PostHog flag (default **off**, per-user, same mechanism as `strava-integration` / `logbook-filters` / `kilter-oauth-linking`) that swaps every MoonBoard angle picker from the narrow `[25, 40]` list to the full `[0, 5, 10, ..., 70]` range Kilter/Tension already use.
- One shared `getBoardAngleOptions(boardName, wideAnglesEnabled)` helper lives in `@boardsesh/board-config` and is used by both a web hook (`useBoardAngleOptions`) and a mobile hook of the same name — so **Android gets the same picker behaviour as web**, not a web-only rollout. Touches the angle drawer, board selector, playlist generator, log-ascent form, propose-change form and create-climb form on web, plus the play-drawer angle sheet and logbook-edit sheet on mobile.
- Fixes the backend tick-angle snap-back rule (`resolveMoonBoardTickAngle`, #3529) so a tick at an angle outside `{25, 40}` is never snapped back to the climb's catalog-graded angle. That rule already carried a forward-compat comment naming this exact flag and requiring the fix.
- MoonBoard climb identity is angle-agnostic as of #3849/#3851 (both merged), so the timing hazard called out in the original (closed, unmerged) #3852 no longer applies — this PR restarts that work with mobile support added.
- `MOONBOARD_ANGLES` itself is untouched — OFF (the default until the flag is created in PostHog) changes nothing for any climber today.

## Release Notes

- Set up any MoonBoard at more than the usual 25° and 40° — grade and log it there like any other angle, on web or in the app. *(Rolling out gradually — ask if you don't see it yet.)*

## Test plan

- `packages/web/app/hooks/__tests__/use-board-angles.test.tsx` (new) + `packages/mobile/src/hooks/__tests__/use-board-angle-options.test.tsx` (new): flag off/undefined → narrow list, flag on → wide list, MoonBoard only, Kilter/Tension never affected.
- `create-climb-form.test.tsx`: added coverage for 2-option vs 15-option angle picker under the flag.
- `angle-selector-sheet-stats-gate.test.tsx`, `logbook-edit-sheet.test.tsx`: updated `@boardsesh/board-config` mocks for the new export, still green.
- `packages/backend/src/__tests__/moonboard-tick-angle.test.ts`: new case — a tick at 35° on a climb graded 40° is left alone instead of snapped.
- `vp run typecheck:web`, `:mobile`, `:backend`, `:db`: clean.
- `vp check`, `vp run check:i18n`, `vp run check:mobile-bundle`: clean.
- Full suites: web (5994 tests, 1 pre-existing unrelated timezone flake), mobile (5991 tests, pre-existing unrelated flakes only), backend (3380 tests, all green).

**Rollout note**: the `moonboard-wide-angles` PostHog flag still needs to be created in the project before this does anything, same one-time step every other flag here needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)