### PR TITLE
feat: support multi-frame route/circuit creation

### DIFF
--- a/packages/board-constants/src/__tests__/hold-states.test.ts
+++ b/packages/board-constants/src/__tests__/hold-states.test.ts
@@ -8,6 +8,7 @@ import {
   parseFramesSegments,
   accumulateFramesToMaps,
   accumulatedMapsToFrameStrings,
+  encodeMapsToFramesString,
   flattenFramesToUnion,
   isSentinelHoldState,
   toFlatFrames,
@@ -316,6 +317,51 @@ describe('accumulatedMapsToFrameStrings', () => {
     ];
     const [string0] = accumulatedMapsToFrameStrings(maps, 'moonboard');
     expect(string0).toBe('p100r42');
+  });
+});
+
+describe('encodeMapsToFramesString', () => {
+  it('returns the empty string for an empty maps array', () => {
+    expect(encodeMapsToFramesString([], 'tension')).toBe('');
+  });
+
+  it('encodes a single frame identically to the legacy flat format', () => {
+    const maps = accumulateFramesToMaps('p100r1p200r2', 'tension');
+    expect(encodeMapsToFramesString(maps, 'tension')).toBe('p100r1p200r2');
+  });
+
+  it('round-trips adds, removes, and role changes across frames', () => {
+    const original = 'p100r1p200r2,"x100p300r2,"p300r3';
+    const maps = accumulateFramesToMaps(original, 'tension');
+    const reEncoded = encodeMapsToFramesString(maps, 'tension');
+    expect(accumulateFramesToMaps(reEncoded, 'tension')).toEqual(maps);
+  });
+
+  it('encodes two identical consecutive frames as a bare hold frame', () => {
+    const maps = [
+      { 100: { state: 'STARTING' as const, color: '#00FF00', displayColor: '#00FF00' } },
+      { 100: { state: 'STARTING' as const, color: '#00FF00', displayColor: '#00FF00' } },
+    ];
+    expect(encodeMapsToFramesString(maps, 'tension')).toBe('p100r1,"');
+  });
+
+  it('round-trips the Kilter Grips oracle fixtures', () => {
+    for (const climb of oracle.climbs) {
+      const maps = accumulateFramesToMaps(climb.auroraFrames, 'kilter');
+      const reEncoded = encodeMapsToFramesString(maps, 'kilter');
+      expect(accumulateFramesToMaps(reEncoded, 'kilter')).toEqual(maps);
+    }
+  });
+
+  it('drops holds whose state has no canonical code on this board', () => {
+    const maps = [
+      {
+        100: { state: 'STARTING' as const, color: '#00FF00', displayColor: '#00FF00' },
+        200: { state: 'FOOT' as const, color: '#FFAA00', displayColor: '#FFAA00' },
+      },
+    ];
+    // MoonBoard has no FOOT canonical code.
+    expect(encodeMapsToFramesString(maps, 'moonboard')).toBe('p100r42');
   });
 });
 

--- a/packages/board-constants/src/hold-states.ts
+++ b/packages/board-constants/src/hold-states.ts
@@ -295,6 +295,60 @@ export function accumulatedMapsToFrameStrings(maps: LitUpHoldsMap[], board: Boar
 }
 
 /**
+ * Encode per-frame lit-state snapshots into an Aurora `frames` string — the
+ * write-side counterpart to `accumulateFramesToMaps`.
+ *
+ * Frame 0 always encodes absolute (`p<id>r<code>` concatenation, matching a
+ * single-frame climb's flat format exactly — so a one-frame route's encoded
+ * string is byte-for-byte what it always was). Every later frame is a delta
+ * against the previous *decoded* snapshot: a hold present before but absent
+ * now emits `x<id>`; a hold that is new or changed state emits `p<id>r<code>`;
+ * an unchanged hold emits nothing. Two identical consecutive frames correctly
+ * produce a bare `"` — the documented "hold frame" in `parseFramesSegments`
+ * that repeats the previous snapshot for one more pace tick.
+ *
+ * `accumulateFramesToMaps(encodeMapsToFramesString(maps, board), board)`
+ * round-trips `maps` (module the `{holdId}={code}` sentinel for role codes
+ * `STATE_TO_PRIMARY_CODE` doesn't have a code for, which this function drops
+ * the same way `generateFramesString` always has).
+ */
+export function encodeMapsToFramesString(maps: LitUpHoldsMap[], board: BoardName): string {
+  const stateToCode = STATE_TO_PRIMARY_CODE[board];
+  const encodeAbsolute = (map: LitUpHoldsMap): string =>
+    Object.entries(map)
+      .filter(([, hold]) => hold.state !== 'OFF')
+      .flatMap(([holdId, hold]) => {
+        const code = stateToCode?.[hold.state];
+        return code === undefined ? [] : [`p${holdId}r${code}`];
+      })
+      .join('');
+
+  if (maps.length === 0) return '';
+
+  const segments = [encodeAbsolute(maps[0])];
+  for (let index = 1; index < maps.length; index += 1) {
+    const previous = maps[index - 1];
+    const current = maps[index];
+    const tokens: string[] = [];
+
+    for (const holdId of Object.keys(previous)) {
+      if (!(Number(holdId) in current)) tokens.push(`x${holdId}`);
+    }
+    for (const [holdId, hold] of Object.entries(current)) {
+      if (hold.state === 'OFF') continue;
+      const previousHold = previous[Number(holdId)];
+      if (previousHold?.state === hold.state) continue;
+      const code = stateToCode?.[hold.state];
+      if (code === undefined) continue;
+      tokens.push(`p${holdId}r${code}`);
+    }
+
+    segments.push(`"${tokens.join('')}`);
+  }
+  return segments.join(',');
+}
+
+/**
  * True when a decoded hold state is the `{holdId}={code}` sentinel that
  * `accumulateFramesToMaps` emits for a role code missing from
  * `HOLD_STATE_MAP`, rather than a real hold state.

--- a/packages/mobile/src/components/create-climb/CreateDrawer.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawer.tsx
@@ -206,6 +206,12 @@ export function CreateDrawer({
             onUndo={controller.undo}
             onRedo={controller.redo}
             onClear={controller.handleClear}
+            frameCount={controller.frameCount}
+            currentFrameIndex={controller.currentFrameIndex}
+            onDuplicateFrame={controller.duplicateFrame}
+            onDeleteFrame={controller.deleteFrame}
+            onPrevFrame={controller.prevFrame}
+            onNextFrame={controller.nextFrame}
             canSetActive={controller.canSetActive}
             onSetActive={controller.handleSetActive}
             saveState={controller.saveState}

--- a/packages/mobile/src/components/create-climb/CreateDrawerActionBar.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawerActionBar.tsx
@@ -32,6 +32,12 @@ type CreateDrawerActionBarProps = {
   onUndo: () => void;
   onRedo: () => void;
   onClear: () => void;
+  frameCount: number;
+  currentFrameIndex: number;
+  onDuplicateFrame: () => void;
+  onDeleteFrame: () => void;
+  onPrevFrame: () => void;
+  onNextFrame: () => void;
   canSetActive: boolean;
   onSetActive: () => void;
   saveState: SaveButtonState;
@@ -53,6 +59,12 @@ export const CreateDrawerActionBar = memo(function CreateDrawerActionBar({
   onUndo,
   onRedo,
   onClear,
+  frameCount,
+  currentFrameIndex,
+  onDuplicateFrame,
+  onDeleteFrame,
+  onPrevFrame,
+  onNextFrame,
   canSetActive,
   onSetActive,
   saveState,
@@ -143,6 +155,39 @@ export const CreateDrawerActionBar = memo(function CreateDrawerActionBar({
           onPress={onClear}
           accessibilityLabel={t('mobile.create.actions.clear')}
         />
+        <ActionButton
+          size="sm"
+          iconName="copy"
+          onPress={onDuplicateFrame}
+          accessibilityLabel={t('mobile.create.frames.duplicate')}
+        />
+        {frameCount > 1 && (
+          <>
+            <ActionButton
+              size="sm"
+              iconName="skip.previous"
+              onPress={onPrevFrame}
+              disabled={currentFrameIndex === 0}
+              accessibilityLabel={t('mobile.create.frames.prev')}
+            />
+            <Text variant="caption1" style={styles.frameCounter} numberOfLines={1}>
+              {t('mobile.create.frames.counter', { index: currentFrameIndex + 1, total: frameCount })}
+            </Text>
+            <ActionButton
+              size="sm"
+              iconName="skip.next"
+              onPress={onNextFrame}
+              disabled={currentFrameIndex >= frameCount - 1}
+              accessibilityLabel={t('mobile.create.frames.next')}
+            />
+            <ActionButton
+              size="sm"
+              iconName="frame.remove"
+              onPress={onDeleteFrame}
+              accessibilityLabel={t('mobile.create.frames.delete')}
+            />
+          </>
+        )}
 
         <View style={drawerActionBarStyles.spacer} />
 
@@ -208,5 +253,9 @@ const styles = StyleSheet.create({
   },
   chipLabel: {
     fontWeight: '600',
+  },
+  frameCounter: {
+    minWidth: 44,
+    textAlign: 'center',
   },
 });

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
@@ -31,13 +31,23 @@ const editClimb = vi.hoisted(() => ({ data: undefined as unknown }));
 // doesn't early-return), and `litUpHoldsMap` (for holdCount).
 const createClimb = vi.hoisted(() => ({
   litUpHoldsMap: { 1: { state: 'STARTING' }, 2: { state: 'HAND' }, 3: { state: 'FINISH' } },
+  frames: [{ 1: { state: 'STARTING' }, 2: { state: 'HAND' }, 3: { state: 'FINISH' } }],
+  frameCount: 1,
+  currentFrameIndex: 0,
   setHoldState: vi.fn(),
   generateFramesString: vi.fn(() => 'p1r12p2r13p3r14'),
+  currentFrameBleString: vi.fn(() => 'p1r12p2r13p3r14'),
   startingCount: 1,
   finishCount: 1,
   isValid: true,
   resetHolds: vi.fn(),
   loadHolds: vi.fn(),
+  loadFrames: vi.fn(),
+  duplicateFrame: vi.fn(),
+  deleteFrame: vi.fn(),
+  goToFrame: vi.fn(),
+  nextFrame: vi.fn(),
+  prevFrame: vi.fn(),
   undo: vi.fn(),
   redo: vi.fn(),
   canUndo: false,
@@ -70,7 +80,7 @@ vi.mock('@boardsesh/create-climb-react', () => ({
   // update branch is exercised by seeding a savedClimb via edit mode below.
   computeCanUpdate: (savedClimb: unknown) => savedClimb != null,
   computeEditLocked: () => false,
-  buildInitialHoldsMap: () => ({}),
+  buildInitialFrames: () => [{}],
 }));
 
 vi.mock('@boardsesh/board-react', () => ({

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-angle.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-angle.test.tsx
@@ -29,13 +29,23 @@ const editClimb = vi.hoisted(() => ({ data: undefined as unknown }));
 
 const createClimb = vi.hoisted(() => ({
   litUpHoldsMap: { 1: { state: 'STARTING' }, 2: { state: 'HAND' }, 3: { state: 'FINISH' } },
+  frames: [{ 1: { state: 'STARTING' }, 2: { state: 'HAND' }, 3: { state: 'FINISH' } }],
+  frameCount: 1,
+  currentFrameIndex: 0,
   setHoldState: vi.fn(),
   generateFramesString: vi.fn(() => 'p1r12p2r13p3r14'),
+  currentFrameBleString: vi.fn(() => 'p1r12p2r13p3r14'),
   startingCount: 1,
   finishCount: 1,
   isValid: true,
   resetHolds: vi.fn(),
   loadHolds: vi.fn(),
+  loadFrames: vi.fn(),
+  duplicateFrame: vi.fn(),
+  deleteFrame: vi.fn(),
+  goToFrame: vi.fn(),
+  nextFrame: vi.fn(),
+  prevFrame: vi.fn(),
   undo: vi.fn(),
   redo: vi.fn(),
   canUndo: false,
@@ -60,7 +70,7 @@ vi.mock('@boardsesh/create-climb-react', () => ({
   useCreateClimb: () => createClimb,
   computeCanUpdate: (savedClimb: unknown) => savedClimb != null,
   computeEditLocked: () => false,
-  buildInitialHoldsMap: () => ({}),
+  buildInitialFrames: () => [{}],
 }));
 vi.mock('@boardsesh/board-react', () => ({
   useBoardActions: () => ({

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
@@ -29,13 +29,23 @@ const appState = vi.hoisted(() => ({
 
 const createClimb = vi.hoisted(() => ({
   litUpHoldsMap: {} as Record<number, { state: string }>,
+  frames: [{} as Record<number, { state: string }>],
+  frameCount: 1,
+  currentFrameIndex: 0,
   setHoldState: vi.fn(),
   generateFramesString: vi.fn(() => ''),
+  currentFrameBleString: vi.fn(() => ''),
   startingCount: 0,
   finishCount: 0,
   isValid: false,
   resetHolds: vi.fn(),
   loadHolds: vi.fn(),
+  loadFrames: vi.fn(),
+  duplicateFrame: vi.fn(),
+  deleteFrame: vi.fn(),
+  goToFrame: vi.fn(),
+  nextFrame: vi.fn(),
+  prevFrame: vi.fn(),
   undo: vi.fn(),
   redo: vi.fn(),
   canUndo: false,
@@ -60,7 +70,7 @@ vi.mock('@boardsesh/create-climb-react', () => ({
   useCreateClimb: () => createClimb,
   computeCanUpdate: (savedClimb: unknown) => savedClimb != null,
   computeEditLocked: () => false,
-  buildInitialHoldsMap: () => ({}),
+  buildInitialFrames: () => [{}],
 }));
 vi.mock('@boardsesh/board-react', () => ({
   useBoardActions: () => ({

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-clear.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-clear.test.tsx
@@ -18,13 +18,23 @@ const router = vi.hoisted(() => ({ push: vi.fn() }));
 
 const createClimb = vi.hoisted(() => ({
   litUpHoldsMap: { 1: { state: 'STARTING' }, 2: { state: 'HAND' }, 3: { state: 'FINISH' } },
+  frames: [{ 1: { state: 'STARTING' }, 2: { state: 'HAND' }, 3: { state: 'FINISH' } }],
+  frameCount: 1,
+  currentFrameIndex: 0,
   setHoldState: vi.fn(),
   generateFramesString: vi.fn(() => 'p1r12p2r13p3r14'),
+  currentFrameBleString: vi.fn(() => 'p1r12p2r13p3r14'),
   startingCount: 1,
   finishCount: 1,
   isValid: true,
   resetHolds: vi.fn(),
   loadHolds: vi.fn(),
+  loadFrames: vi.fn(),
+  duplicateFrame: vi.fn(),
+  deleteFrame: vi.fn(),
+  goToFrame: vi.fn(),
+  nextFrame: vi.fn(),
+  prevFrame: vi.fn(),
   undo: vi.fn(),
   redo: vi.fn(),
   canUndo: false,
@@ -60,7 +70,7 @@ vi.mock('@boardsesh/create-climb-react', () => ({
   useCreateClimb: () => createClimb,
   computeCanUpdate: (savedClimb: unknown) => savedClimb != null,
   computeEditLocked: () => false,
-  buildInitialHoldsMap: () => ({}),
+  buildInitialFrames: () => [{}],
 }));
 
 vi.mock('@boardsesh/board-react', () => ({

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
@@ -30,13 +30,23 @@ const router = vi.hoisted(() => ({ push: vi.fn() }));
 
 const createClimb = vi.hoisted(() => ({
   litUpHoldsMap: { 1: { state: 'STARTING' }, 2: { state: 'HAND' }, 3: { state: 'FINISH' } },
+  frames: [{ 1: { state: 'STARTING' }, 2: { state: 'HAND' }, 3: { state: 'FINISH' } }],
+  frameCount: 1,
+  currentFrameIndex: 0,
   setHoldState: vi.fn(),
   generateFramesString: vi.fn(() => 'p1r12p2r13p3r14'),
+  currentFrameBleString: vi.fn(() => 'p1r12p2r13p3r14'),
   startingCount: 1,
   finishCount: 1,
   isValid: true,
   resetHolds: vi.fn(),
   loadHolds: vi.fn(),
+  loadFrames: vi.fn(),
+  duplicateFrame: vi.fn(),
+  deleteFrame: vi.fn(),
+  goToFrame: vi.fn(),
+  nextFrame: vi.fn(),
+  prevFrame: vi.fn(),
   undo: vi.fn(),
   redo: vi.fn(),
   canUndo: false,
@@ -61,7 +71,7 @@ vi.mock('@boardsesh/create-climb-react', () => ({
   useCreateClimb: () => createClimb,
   computeCanUpdate: (savedClimb: unknown) => savedClimb != null,
   computeEditLocked: () => false,
-  buildInitialHoldsMap: () => ({}),
+  buildInitialFrames: () => [{}],
 }));
 vi.mock('@boardsesh/board-react', () => ({
   useBoardActions: () => ({

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -10,7 +10,7 @@ import {
   useCreateClimb,
   computeCanUpdate,
   computeEditLocked,
-  buildInitialHoldsMap,
+  buildInitialFrames,
   type SavedClimbSnapshot,
 } from '@boardsesh/create-climb-react';
 import { useBoardActions, isDuplicateClimbError } from '@boardsesh/board-react';
@@ -106,10 +106,11 @@ export function useCreateClimbScreen({
   const isForking = !!forkFrames;
   const isEditing = !!editClimbUuid;
 
-  // Seed the editor from a fork's frames once; an empty start otherwise. Edit
-  // mode seeds asynchronously below (guarded by a ref).
-  const initialHoldsMap = useMemo(
-    () => (isForking && forkFrames ? buildInitialHoldsMap(forkFrames, board.boardName) : {}),
+  // Seed the editor from a fork's frames once, preserving every frame of a
+  // multi-frame source route (an empty single frame otherwise). Edit mode
+  // seeds asynchronously below (guarded by a ref).
+  const initialFrames = useMemo(
+    () => (isForking && forkFrames ? buildInitialFrames(forkFrames, board.boardName) : undefined),
     // Seed only once from the route param — board.boardName is stable per screen.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
@@ -117,18 +118,26 @@ export function useCreateClimbScreen({
 
   const {
     litUpHoldsMap,
+    frames,
+    frameCount,
+    currentFrameIndex,
     setHoldState,
     generateFramesString,
+    currentFrameBleString,
     startingCount,
     finishCount,
     isValid,
     resetHolds,
-    loadHolds,
+    loadFrames,
+    duplicateFrame,
+    deleteFrame,
+    nextFrame,
+    prevFrame,
     undo,
     redo,
     canUndo,
     canRedo,
-  } = useCreateClimb(board.boardName, { initialHoldsMap });
+  } = useCreateClimb(board.boardName, { initialFrames });
 
   const [selectedBrush, setSelectedBrush] = useState<BrushRole>('HAND');
   const [name, setName] = useState(isForking && forkName ? `${forkName} remix` : '');
@@ -219,7 +228,7 @@ export function useCreateClimbScreen({
   useEffect(() => {
     if (!editClimb || editSeededRef.current) return;
     editSeededRef.current = true;
-    loadHolds(buildInitialHoldsMap(editClimb.frames, board.boardName));
+    loadFrames(buildInitialFrames(editClimb.frames, board.boardName));
     setName(editClimb.name);
     setDescription(withNoMatch(editClimb.description ?? '', false));
     setNoMatch(isNoMatchClimb(editClimb.description));
@@ -231,7 +240,7 @@ export function useCreateClimbScreen({
       publishedAt: editClimb.published_at ?? null,
       isDraft: editClimb.is_draft ?? false,
     });
-  }, [editClimb, board.boardName, loadHolds]);
+  }, [editClimb, board.boardName, loadFrames]);
 
   // ---- Local autosave restore on mount. ----
   useEffect(() => {
@@ -246,8 +255,10 @@ export function useCreateClimbScreen({
         return;
       }
       try {
-        const parsed = JSON.parse(draft.holdsJson) as Record<number, { state: string }>;
-        loadHolds(parsed as Parameters<typeof loadHolds>[0]);
+        const frames = draft.framesJson
+          ? (JSON.parse(draft.framesJson) as Parameters<typeof loadFrames>[0])
+          : [JSON.parse(draft.holdsJson) as Parameters<typeof loadFrames>[0][number]];
+        loadFrames(frames);
       } catch {
         // Corrupt holds payload — ignore and start clean.
       }
@@ -266,13 +277,14 @@ export function useCreateClimbScreen({
 
   // ---- Local autosave (debounced). ----
   const holdsJson = useMemo(() => JSON.stringify(litUpHoldsMap), [litUpHoldsMap]);
+  const framesJson = useMemo(() => JSON.stringify(frames), [frames]);
   // The most recent autosave payload, kept current by the debounced effect so a
   // flush-on-unmount / background can persist it synchronously without waiting
   // for the (suspended-when-backgrounded) debounce timer. `dirty` gates whether
   // there is anything worth flushing for the current per-board new-draft slot.
   const pendingDraftRef = useRef<{ key: string; draft: CreateClimbDraft; dirty: boolean }>({
     key: draftKey,
-    draft: { holdsJson, name, description, isDraft },
+    draft: { holdsJson, framesJson, name, description, isDraft },
     dirty: false,
   });
   // Forks seed from another climb's frames and skip restore, so — like edit
@@ -288,8 +300,14 @@ export function useCreateClimbScreen({
       pendingDraftRef.current.dirty = false;
       return;
     }
-    const hasContent = holdsJson !== '{}' || name.trim() !== '' || description.trim() !== '';
-    const draft: CreateClimbDraft = { holdsJson, name, description: withNoMatch(description, noMatch), isDraft };
+    const hasContent = holdsJson !== '{}' || frameCount > 1 || name.trim() !== '' || description.trim() !== '';
+    const draft: CreateClimbDraft = {
+      holdsJson,
+      framesJson,
+      name,
+      description: withNoMatch(description, noMatch),
+      isDraft,
+    };
     // Mirror the latest payload so a flush (unmount/background) can persist the
     // pending edit even before the debounce fires.
     pendingDraftRef.current = { key: draftKey, draft, dirty: hasContent };
@@ -303,7 +321,7 @@ export function useCreateClimbScreen({
       pendingDraftRef.current.dirty = false;
     }, AUTOSAVE_DEBOUNCE_MS);
     return () => clearTimeout(handle);
-  }, [holdsJson, name, description, noMatch, isDraft, draftKey, autosaveDisabled]);
+  }, [holdsJson, framesJson, frameCount, name, description, noMatch, isDraft, draftKey, autosaveDisabled]);
 
   // ---- Flush the pending draft on unmount / background. ----
   // JS timers are suspended when the app is backgrounded and the cleanup's
@@ -334,10 +352,13 @@ export function useCreateClimbScreen({
   useEffect(() => {
     if (!bleConnected) return;
     const handle = setTimeout(() => {
-      void sendFramesRef.current?.(generateFramesString());
+      // The active frame only — the wall mirrors whatever you're painting
+      // right now, not multi-frame route syntax the BLE packet builder can't
+      // parse.
+      void sendFramesRef.current?.(currentFrameBleString());
     }, BLE_PREVIEW_DEBOUNCE_MS);
     return () => clearTimeout(handle);
-  }, [holdsJson, bleConnected, generateFramesString]);
+  }, [holdsJson, bleConnected, currentFrameBleString]);
 
   // ---- Painting + role assignment. ----
   const handlePaint = useCallback(
@@ -413,11 +434,12 @@ export function useCreateClimbScreen({
       published_at: savedClimb?.publishedAt ?? null,
       userAscents: 0,
       userAttempts: 0,
-      // The editor emits a single static frame (no multi-frame playback).
-      framesCount: 1,
+      framesCount: frameCount,
+      // 0/null both mean "use the default pace" — useClimbFrames falls back to
+      // DEFAULT_PACE_MS whenever framesPace isn't a positive number.
       framesPace: null,
     }),
-    [name, description, noMatch, profile, savedClimb, board.angle, board.boardName, board.layoutId, t],
+    [name, description, noMatch, profile, savedClimb, board.angle, board.boardName, board.layoutId, t, frameCount],
   );
 
   // Push the freshly saved climb into the queue as the current climb so the
@@ -449,8 +471,8 @@ export function useCreateClimbScreen({
     // connect tears down the first attempt's scan and strands the picker.
     if (bluetooth.loading) return;
     if (bluetooth.isConnected) void bluetooth.disconnect();
-    else void bluetooth.connect(generateFramesString());
-  }, [bluetooth, generateFramesString]);
+    else void bluetooth.connect(currentFrameBleString());
+  }, [bluetooth, currentFrameBleString]);
 
   // ---- Save state machine. ----
   const editLocked = computeEditLocked(savedClimb);
@@ -503,6 +525,8 @@ export function useCreateClimbScreen({
           description: fullDescription,
           frames,
           angle: board.angle,
+          framesCount: frameCount,
+          framesPace: 0,
           isDraft,
         });
         setSavedClimb({
@@ -528,6 +552,8 @@ export function useCreateClimbScreen({
           description: fullDescription,
           is_draft: isDraft,
           frames,
+          frames_count: frameCount,
+          frames_pace: 0,
           angle: board.angle,
         });
         setSavedClimb({
@@ -586,6 +612,7 @@ export function useCreateClimbScreen({
     savedClimb,
     litUpHoldsMap,
     generateFramesString,
+    frameCount,
     updateClimb,
     saveClimb,
     board,
@@ -618,6 +645,13 @@ export function useCreateClimbScreen({
     handleClear,
     showAllHolds,
     setShowAllHolds,
+    // frames (route/circuit editing)
+    frameCount,
+    currentFrameIndex,
+    duplicateFrame,
+    deleteFrame,
+    nextFrame,
+    prevFrame,
     // undo/redo (current editing session only)
     undo,
     redo,

--- a/packages/mobile/src/components/icon-map.ts
+++ b/packages/mobile/src/components/icon-map.ts
@@ -103,6 +103,9 @@ export const iconMap = {
   // mirrors the circled check used for `send`, so the climb-row status glyphs
   // (bolt / check / x) read as one matched set.
   'ascent.attempt': { ios: 'xmark.circle', android: 'close-circle-outline' },
+  // Remove-one-frame in the create-climb route editor — a circled X, distinct
+  // from the trash-can `delete` glyph the Clear-all-holds action already uses.
+  'frame.remove': { ios: 'xmark.circle', android: 'close-circle-outline' },
   // Intrinsic climb-attribute glyphs shown after the name (web parity:
   // climb-card/climb-icons.tsx © benchmark + ⊘ no-match).
   'no.match': { ios: 'hand.raised.slash', android: 'hand-back-right-off-outline' },

--- a/packages/mobile/src/lib/create-climb-draft-store.ts
+++ b/packages/mobile/src/lib/create-climb-draft-store.ts
@@ -11,8 +11,14 @@ import { getPreference, setPreference, removePreference, removePreferencesMatchi
 import type { UserStorageOwner } from './user-storage-owner';
 
 export type CreateClimbDraft = {
-  /** JSON.stringify of the editor's LitUpHoldsMap. */
+  /**
+   * JSON.stringify of the editor's active-frame LitUpHoldsMap. Kept for
+   * backward compatibility — `framesJson` below is the full route and takes
+   * priority when present.
+   */
   holdsJson: string;
+  /** JSON.stringify(LitUpHoldsMap[]) — the full frame sequence. */
+  framesJson?: string;
   name: string;
   description: string;
   isDraft: boolean;

--- a/packages/shared/create-climb-react/src/__tests__/helpers.test.ts
+++ b/packages/shared/create-climb-react/src/__tests__/helpers.test.ts
@@ -1,26 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { EDIT_WINDOW_MS, computeCanUpdate, computeEditLocked, buildInitialHoldsMap } from '../helpers';
-
-vi.mock('@boardsesh/board-constants/hold-states', () => ({
-  // Single-frame: `p{id}r{code}`. Multi-frame: comma-separated, later frames win.
-  convertLitUpHoldsStringToMap: (frames: string) => {
-    const result: Record<number, Record<number, { state: string; color: string; displayColor: string }>> = {};
-    frames
-      .split(',')
-      .filter(Boolean)
-      .forEach((frame, index) => {
-        const holds: Record<number, { state: string; color: string; displayColor: string }> = {};
-        for (const match of frame.matchAll(/p(\d+)r(\d+)/g)) {
-          const holdId = Number(match[1]);
-          const code = Number(match[2]);
-          const state = code === 42 ? 'STARTING' : code === 43 ? 'HAND' : 'FINISH';
-          holds[holdId] = { state, color: '#fff', displayColor: '#fff' };
-        }
-        result[index] = holds;
-      });
-    return result;
-  },
-}));
+import { describe, it, expect } from 'vitest';
+import { EDIT_WINDOW_MS, computeCanUpdate, computeEditLocked, buildInitialFrames } from '../helpers';
 
 const NOW = Date.parse('2026-06-03T12:00:00.000Z');
 const within = new Date(NOW - 60 * 60 * 1000).toISOString(); // 1h ago
@@ -73,21 +52,25 @@ describe('computeEditLocked', () => {
   });
 });
 
-describe('buildInitialHoldsMap', () => {
-  it('returns empty for empty frames', () => {
-    expect(buildInitialHoldsMap('', 'kilter')).toEqual({});
+describe('buildInitialFrames', () => {
+  it('returns a single empty frame for an empty frames string', () => {
+    expect(buildInitialFrames('', 'kilter')).toEqual([{}]);
   });
 
   it('parses a single frame', () => {
-    expect(buildInitialHoldsMap('p100r42p200r43', 'kilter')).toEqual({
-      100: { state: 'STARTING', color: '#fff', displayColor: '#fff' },
-      200: { state: 'HAND', color: '#fff', displayColor: '#fff' },
-    });
+    const frames = buildInitialFrames('p100r42p200r43', 'kilter');
+    expect(frames).toHaveLength(1);
+    expect(frames[0][100].state).toBe('STARTING');
+    expect(frames[0][200].state).toBe('HAND');
   });
 
-  it('merges multi-frame with later frames overriding', () => {
-    const map = buildInitialHoldsMap('p100r42,p100r43p200r44', 'kilter');
-    expect(map[100].state).toBe('HAND'); // later frame wins
-    expect(map[200].state).toBe('FINISH');
+  it('preserves frame separation instead of flattening to one map', () => {
+    // Frame 0 lights hold 100; frame 1 is a delta that re-roles it and adds 200.
+    const frames = buildInitialFrames('p100r42,"p100r43p200r44', 'kilter');
+    expect(frames).toHaveLength(2);
+    expect(frames[0][100].state).toBe('STARTING');
+    expect(frames[0][200]).toBeUndefined();
+    expect(frames[1][100].state).toBe('HAND');
+    expect(frames[1][200].state).toBe('FINISH');
   });
 });

--- a/packages/shared/create-climb-react/src/__tests__/use-create-climb.test.ts
+++ b/packages/shared/create-climb-react/src/__tests__/use-create-climb.test.ts
@@ -1,42 +1,50 @@
 import { describe, it, expect, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useCreateClimb, holdsReducer, HISTORY_LIMIT } from '../use-create-climb';
-import type { HoldsHistory } from '../use-create-climb';
+import { useCreateClimb, framesReducer, HISTORY_LIMIT } from '../use-create-climb';
+import type { FramesHistory, FramesSnapshot } from '../use-create-climb';
 import type { LitUpHoldsMap } from '@boardsesh/shared-schema';
 
-vi.mock('@boardsesh/board-constants/hold-states', () => ({
-  HOLD_STATE_MAP: {
-    kilter: {
-      42: { name: 'STARTING', color: '#00FF00', displayColor: '#00FF00' },
-      43: { name: 'HAND', color: '#00FFFF', displayColor: '#00FFFF' },
-      44: { name: 'FINISH', color: '#FF00FF', displayColor: '#FF00FF' },
-      45: { name: 'FOOT', color: '#FFA500', displayColor: '#FFA500' },
+vi.mock('@boardsesh/board-constants/hold-states', async () => {
+  const actual = await vi.importActual<typeof import('@boardsesh/board-constants/hold-states')>(
+    '@boardsesh/board-constants/hold-states',
+  );
+  return {
+    ...actual,
+    HOLD_STATE_MAP: {
+      kilter: {
+        42: { name: 'STARTING', color: '#00FF00', displayColor: '#00FF00' },
+        43: { name: 'HAND', color: '#00FFFF', displayColor: '#00FFFF' },
+        44: { name: 'FINISH', color: '#FF00FF', displayColor: '#FF00FF' },
+        45: { name: 'FOOT', color: '#FFA500', displayColor: '#FFA500' },
+      },
+      tension: {
+        1: { name: 'STARTING', color: '#00FF00', displayColor: '#00FF00' },
+        2: { name: 'HAND', color: '#00FFFF', displayColor: '#00FFFF' },
+        3: { name: 'FINISH', color: '#FF00FF', displayColor: '#FF00FF' },
+        4: { name: 'FOOT', color: '#FFA500', displayColor: '#FFA500' },
+      },
+      moonboard: {
+        1: { name: 'STARTING', color: '#00FF00', displayColor: '#00FF00' },
+        2: { name: 'HAND', color: '#00FFFF', displayColor: '#00FFFF' },
+        3: { name: 'FINISH', color: '#FF00FF', displayColor: '#FF00FF' },
+      },
     },
-    tension: {
-      1: { name: 'STARTING', color: '#00FF00', displayColor: '#00FF00' },
-      2: { name: 'HAND', color: '#00FFFF', displayColor: '#00FFFF' },
-      3: { name: 'FINISH', color: '#FF00FF', displayColor: '#FF00FF' },
-      4: { name: 'FOOT', color: '#FFA500', displayColor: '#FFA500' },
+    STATE_TO_PRIMARY_CODE: {
+      kilter: { STARTING: 42, HAND: 43, FINISH: 44, FOOT: 45 },
+      tension: { STARTING: 1, HAND: 2, FINISH: 3, FOOT: 4 },
+      moonboard: { STARTING: 42, HAND: 43, FINISH: 44 },
     },
-    moonboard: {
-      1: { name: 'STARTING', color: '#00FF00', displayColor: '#00FF00' },
-      2: { name: 'HAND', color: '#00FFFF', displayColor: '#00FFFF' },
-      3: { name: 'FINISH', color: '#FF00FF', displayColor: '#FF00FF' },
-    },
-  },
-  STATE_TO_PRIMARY_CODE: {
-    kilter: { STARTING: 42, HAND: 43, FINISH: 44, FOOT: 45 },
-    tension: { STARTING: 1, HAND: 2, FINISH: 3, FOOT: 4 },
-    moonboard: { STARTING: 42, HAND: 43, FINISH: 44 },
-  },
-}));
+  };
+});
 
 describe('useCreateClimb', () => {
   describe('initial state', () => {
-    it('has empty holdsMap', () => {
+    it('has empty holdsMap and a single frame', () => {
       const { result } = renderHook(() => useCreateClimb('kilter'));
 
       expect(result.current.litUpHoldsMap).toEqual({});
+      expect(result.current.frameCount).toBe(1);
+      expect(result.current.currentFrameIndex).toBe(0);
       expect(result.current.totalHolds).toBe(0);
       expect(result.current.startingCount).toBe(0);
       expect(result.current.finishCount).toBe(0);
@@ -119,6 +127,27 @@ describe('useCreateClimb', () => {
 
       expect(result.current.litUpHoldsMap[100]).toBeUndefined();
       expect(result.current.totalHolds).toBe(0);
+    });
+
+    it('only edits the active frame, not other frames in the route', () => {
+      const { result } = renderHook(() => useCreateClimb('kilter'));
+
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+      act(() => {
+        result.current.duplicateFrame();
+      });
+      act(() => {
+        result.current.setHoldState(200, 'HAND');
+      });
+
+      // Frame 1 (active) has both holds; frame 0 is untouched.
+      expect(Object.keys(result.current.litUpHoldsMap).sort()).toEqual(['100', '200']);
+      act(() => {
+        result.current.prevFrame();
+      });
+      expect(Object.keys(result.current.litUpHoldsMap)).toEqual(['100']);
     });
   });
 
@@ -212,6 +241,44 @@ describe('useCreateClimb', () => {
       const frames = result.current.generateFramesString();
       expect(frames).toBe('');
     });
+
+    it('encodes a multi-frame route with delta frames', () => {
+      const { result } = renderHook(() => useCreateClimb('kilter'));
+
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+      act(() => {
+        result.current.duplicateFrame();
+      });
+      act(() => {
+        result.current.setHoldState(200, 'HAND');
+      });
+
+      expect(result.current.generateFramesString()).toBe('p100r42,"p200r43');
+    });
+  });
+
+  describe('currentFrameBleString', () => {
+    it('only encodes the active frame, never multi-frame syntax', () => {
+      const { result } = renderHook(() => useCreateClimb('kilter'));
+
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+      act(() => {
+        result.current.duplicateFrame();
+      });
+      act(() => {
+        result.current.setHoldState(200, 'HAND');
+      });
+
+      expect(result.current.currentFrameBleString()).toBe('p100r42p200r43');
+      act(() => {
+        result.current.prevFrame();
+      });
+      expect(result.current.currentFrameBleString()).toBe('p100r42');
+    });
   });
 
   describe('resetHolds', () => {
@@ -235,6 +302,25 @@ describe('useCreateClimb', () => {
       expect(result.current.startingCount).toBe(0);
       expect(result.current.finishCount).toBe(0);
       expect(result.current.isValid).toBe(false);
+    });
+
+    it('collapses a multi-frame route back to a single empty frame', () => {
+      const { result } = renderHook(() => useCreateClimb('kilter'));
+
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+      act(() => {
+        result.current.duplicateFrame();
+      });
+      expect(result.current.frameCount).toBe(2);
+
+      act(() => {
+        result.current.resetHolds();
+      });
+
+      expect(result.current.frameCount).toBe(1);
+      expect(result.current.currentFrameIndex).toBe(0);
     });
   });
 
@@ -289,30 +375,75 @@ describe('useCreateClimb', () => {
 
       expect(result.current.isValid).toBe(true);
     });
+
+    it('are computed over the union of every frame, not just the active one', () => {
+      const { result } = renderHook(() => useCreateClimb('kilter'));
+
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+      act(() => {
+        result.current.duplicateFrame();
+      });
+      act(() => {
+        result.current.setHoldState(100, 'OFF');
+      });
+      act(() => {
+        result.current.setHoldState(200, 'FINISH');
+      });
+
+      // Frame 0: {100: STARTING}. Frame 1 (active): {200: FINISH}. Neither
+      // frame alone has both, but the route as a whole does.
+      expect(result.current.startingCount).toBe(1);
+      expect(result.current.finishCount).toBe(1);
+      expect(result.current.totalHolds).toBe(2);
+      expect(result.current.isValid).toBe(true);
+    });
   });
 
-  describe('initial holds map', () => {
-    it('works with initial holds map', () => {
-      const initialHoldsMap = {
-        100: { state: 'STARTING' as const, color: '#00FF00', displayColor: '#00FF00' },
-        200: { state: 'HAND' as const, color: '#00FFFF', displayColor: '#00FFFF' },
-      };
+  describe('initialFrames', () => {
+    it('works with a single initial frame', () => {
+      const initialFrames = [
+        {
+          100: { state: 'STARTING' as const, color: '#00FF00', displayColor: '#00FF00' },
+          200: { state: 'HAND' as const, color: '#00FFFF', displayColor: '#00FFFF' },
+        },
+      ];
 
-      const { result } = renderHook(() => useCreateClimb('kilter', { initialHoldsMap }));
+      const { result } = renderHook(() => useCreateClimb('kilter', { initialFrames }));
 
-      expect(result.current.litUpHoldsMap).toEqual(initialHoldsMap);
+      expect(result.current.litUpHoldsMap).toEqual(initialFrames[0]);
+      expect(result.current.frameCount).toBe(1);
       expect(result.current.totalHolds).toBe(2);
       expect(result.current.startingCount).toBe(1);
       expect(result.current.isValid).toBe(true);
     });
 
-    it('drops initial holds whose state cannot be saved for the board', () => {
-      const initialHoldsMap = {
-        100: { state: 'STARTING' as const, color: '#00FF00', displayColor: '#00FF00' },
-        200: { state: 'FOOT' as const, color: '#FFA500', displayColor: '#FFA500' },
-      };
+    it('preserves frame separation across multiple initial frames', () => {
+      const initialFrames: LitUpHoldsMap[] = [
+        { 100: { state: 'STARTING', color: '#00FF00', displayColor: '#00FF00' } },
+        { 200: { state: 'HAND', color: '#00FFFF', displayColor: '#00FFFF' } },
+      ];
 
-      const { result } = renderHook(() => useCreateClimb('moonboard', { initialHoldsMap }));
+      const { result } = renderHook(() => useCreateClimb('kilter', { initialFrames }));
+
+      expect(result.current.frameCount).toBe(2);
+      expect(result.current.litUpHoldsMap).toEqual(initialFrames[0]);
+      act(() => {
+        result.current.nextFrame();
+      });
+      expect(result.current.litUpHoldsMap).toEqual(initialFrames[1]);
+    });
+
+    it('drops initial holds whose state cannot be saved for the board', () => {
+      const initialFrames = [
+        {
+          100: { state: 'STARTING' as const, color: '#00FF00', displayColor: '#00FF00' },
+          200: { state: 'FOOT' as const, color: '#FFA500', displayColor: '#FFA500' },
+        },
+      ];
+
+      const { result } = renderHook(() => useCreateClimb('moonboard', { initialFrames }));
 
       expect(result.current.litUpHoldsMap).toEqual({
         100: { state: 'STARTING', color: '#00FF00', displayColor: '#00FF00' },
@@ -326,12 +457,14 @@ describe('useCreateClimb', () => {
     // during render, where nothing can catch it (#3804). 'decoy' is a real
     // BoardName that this file's STATE_TO_PRIMARY_CODE mock deliberately omits.
     it('seeds no holds for a board missing from the role table instead of throwing', () => {
-      const initialHoldsMap = {
-        100: { state: 'STARTING' as const, color: '#00FF00', displayColor: '#00FF00' },
-        200: { state: 'HAND' as const, color: '#00FFFF', displayColor: '#00FFFF' },
-      };
+      const initialFrames = [
+        {
+          100: { state: 'STARTING' as const, color: '#00FF00', displayColor: '#00FF00' },
+          200: { state: 'HAND' as const, color: '#00FFFF', displayColor: '#00FFFF' },
+        },
+      ];
 
-      const { result } = renderHook(() => useCreateClimb('decoy', { initialHoldsMap }));
+      const { result } = renderHook(() => useCreateClimb('decoy', { initialFrames }));
 
       expect(result.current.litUpHoldsMap).toEqual({});
       expect(result.current.totalHolds).toBe(0);
@@ -339,12 +472,15 @@ describe('useCreateClimb', () => {
     });
   });
 
-  describe('loadHolds', () => {
-    it('replaces the entire holds map', () => {
+  describe('loadHolds / loadFrames', () => {
+    it('loadHolds replaces the entire holds map with a single frame', () => {
       const { result } = renderHook(() => useCreateClimb('kilter'));
 
       act(() => {
         result.current.setHoldState(100, 'STARTING');
+      });
+      act(() => {
+        result.current.duplicateFrame();
       });
 
       const next = {
@@ -355,6 +491,7 @@ describe('useCreateClimb', () => {
         result.current.loadHolds(next);
       });
 
+      expect(result.current.frameCount).toBe(1);
       expect(result.current.litUpHoldsMap).toEqual(next);
       expect(result.current.litUpHoldsMap[100]).toBeUndefined();
     });
@@ -374,6 +511,26 @@ describe('useCreateClimb', () => {
       });
       expect(result.current.generateFramesString()).toBe('p100r43');
     });
+
+    it('loadFrames replaces the whole sequence, preserving frame separation', () => {
+      const { result } = renderHook(() => useCreateClimb('kilter'));
+
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+
+      const next: LitUpHoldsMap[] = [
+        { 200: { state: 'HAND', color: '#00FFFF', displayColor: '#00FFFF' } },
+        { 300: { state: 'FINISH', color: '#FF00FF', displayColor: '#FF00FF' } },
+      ];
+      act(() => {
+        result.current.loadFrames(next);
+      });
+
+      expect(result.current.frameCount).toBe(2);
+      expect(result.current.currentFrameIndex).toBe(0);
+      expect(result.current.litUpHoldsMap).toEqual(next[0]);
+    });
   });
 
   describe('tension board', () => {
@@ -386,6 +543,85 @@ describe('useCreateClimb', () => {
 
       const frames = result.current.generateFramesString();
       expect(frames).toBe('p100r1');
+    });
+  });
+
+  describe('frame navigation', () => {
+    it('duplicateFrame inserts a copy right after the active frame and moves there', () => {
+      const { result } = renderHook(() => useCreateClimb('kilter'));
+
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+      act(() => {
+        result.current.duplicateFrame();
+      });
+
+      expect(result.current.frameCount).toBe(2);
+      expect(result.current.currentFrameIndex).toBe(1);
+      expect(result.current.litUpHoldsMap[100].state).toBe('STARTING');
+    });
+
+    it('deleteFrame is a no-op with only one frame', () => {
+      const { result } = renderHook(() => useCreateClimb('kilter'));
+
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+      act(() => {
+        result.current.deleteFrame();
+      });
+
+      expect(result.current.frameCount).toBe(1);
+      expect(result.current.litUpHoldsMap[100]).toBeDefined();
+    });
+
+    it('deleteFrame removes the active frame and clamps the index', () => {
+      const { result } = renderHook(() => useCreateClimb('kilter'));
+
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+      act(() => {
+        result.current.duplicateFrame();
+      });
+      act(() => {
+        result.current.setHoldState(200, 'HAND');
+      });
+      // Now on frame 1 ({100, 200}); deleting it should land back on frame 0.
+      act(() => {
+        result.current.deleteFrame();
+      });
+
+      expect(result.current.frameCount).toBe(1);
+      expect(result.current.currentFrameIndex).toBe(0);
+      expect(Object.keys(result.current.litUpHoldsMap)).toEqual(['100']);
+    });
+
+    it('nextFrame / prevFrame clamp at the ends and are not undoable', () => {
+      const { result } = renderHook(() => useCreateClimb('kilter'));
+
+      act(() => {
+        result.current.prevFrame();
+      });
+      expect(result.current.currentFrameIndex).toBe(0);
+      expect(result.current.canUndo).toBe(false);
+
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+      act(() => {
+        result.current.duplicateFrame();
+      });
+      act(() => {
+        result.current.nextFrame();
+      });
+      expect(result.current.currentFrameIndex).toBe(1);
+
+      act(() => {
+        result.current.goToFrame(99);
+      });
+      expect(result.current.currentFrameIndex).toBe(1);
     });
   });
 
@@ -480,6 +716,31 @@ describe('useCreateClimb', () => {
       expect(result.current.litUpHoldsMap[200].state).toBe('HAND');
     });
 
+    it('duplicateFrame and deleteFrame are undoable', () => {
+      const { result } = renderHook(() => useCreateClimb('kilter'));
+
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+      act(() => {
+        result.current.duplicateFrame();
+      });
+      expect(result.current.frameCount).toBe(2);
+
+      act(() => {
+        result.current.undo();
+      });
+      expect(result.current.frameCount).toBe(1);
+      // Undoing the duplicate clamps the index back into range.
+      expect(result.current.currentFrameIndex).toBe(0);
+
+      act(() => {
+        result.current.redo();
+      });
+      expect(result.current.frameCount).toBe(2);
+      expect(result.current.currentFrameIndex).toBe(1);
+    });
+
     it('a new edit after undo clears the redo branch', () => {
       const { result } = renderHook(() => useCreateClimb('kilter'));
 
@@ -566,11 +827,9 @@ describe('useCreateClimb', () => {
       expect(result.current.totalHolds).toBe(10);
     });
 
-    it('with an initial holds map, undo cannot cross below the seed', () => {
-      const initialHoldsMap = {
-        100: { state: 'STARTING' as const, color: '#00FF00', displayColor: '#00FF00' },
-      };
-      const { result } = renderHook(() => useCreateClimb('kilter', { initialHoldsMap }));
+    it('with initial frames, undo cannot cross below the seed', () => {
+      const initialFrames = [{ 100: { state: 'STARTING' as const, color: '#00FF00', displayColor: '#00FF00' } }];
+      const { result } = renderHook(() => useCreateClimb('kilter', { initialFrames }));
 
       expect(result.current.canUndo).toBe(false);
 
@@ -598,17 +857,19 @@ describe('useCreateClimb', () => {
       const foot = (id: number): LitUpHoldsMap => ({
         [id]: { state: 'FOOT', color: '#FFA500', displayColor: '#FFA500' },
       });
+      const snapshot = (id: number): FramesSnapshot => ({ present: [foot(id)], currentFrameIndex: 0 });
 
-      const edgeState: HoldsHistory = {
-        past: Array.from({ length: HISTORY_LIMIT }, (_, i) => foot(i + 1)),
-        present: foot(HISTORY_LIMIT + 1),
-        future: [foot(HISTORY_LIMIT + 2)],
+      const edgeState: FramesHistory = {
+        past: Array.from({ length: HISTORY_LIMIT }, (_, i) => snapshot(i + 1)),
+        present: [foot(HISTORY_LIMIT + 1)],
+        future: [snapshot(HISTORY_LIMIT + 2)],
+        currentFrameIndex: 0,
       };
 
-      const next = holdsReducer(edgeState, { type: 'REDO' });
+      const next = framesReducer(edgeState, { type: 'REDO' });
 
       expect(next.past.length).toBeLessThanOrEqual(HISTORY_LIMIT);
-      expect(next.present).toEqual(foot(HISTORY_LIMIT + 2));
+      expect(next.present).toEqual([foot(HISTORY_LIMIT + 2)]);
       expect(next.future).toHaveLength(0);
     });
   });

--- a/packages/shared/create-climb-react/src/helpers.ts
+++ b/packages/shared/create-climb-react/src/helpers.ts
@@ -1,5 +1,5 @@
 import type { BoardName, LitUpHoldsMap } from '@boardsesh/shared-schema';
-import { convertLitUpHoldsStringToMap } from '@boardsesh/board-constants/hold-states';
+import { accumulateFramesToMaps } from '@boardsesh/board-constants/hold-states';
 
 /** Window after first publish during which a non-draft climb can still be edited. */
 export const EDIT_WINDOW_MS = 24 * 60 * 60 * 1000;
@@ -47,14 +47,16 @@ export function computeEditLocked(saved: SavedClimbSnapshot | null, now: number 
 }
 
 /**
- * Flatten a (possibly multi-frame) fork/draft frames string into a single
- * Aurora holds map for seeding the editor. Later frames override earlier ones,
- * matching the web form's draft-load behaviour.
+ * Decode a (possibly multi-frame) fork/draft/edit frames string into the
+ * editor's per-frame sequence, preserving frame separation — unlike the old
+ * flatten-to-one-map seeding this replaced, a multi-frame route/circuit no
+ * longer collapses into a single frame when you fork or edit it.
+ *
+ * Falls back to a single empty frame for an empty string, matching a
+ * brand-new climb's starting state.
  */
-export function buildInitialHoldsMap(frames: string, board: BoardName): LitUpHoldsMap {
-  if (!frames) return {};
-  const framesMap = convertLitUpHoldsStringToMap(frames, board);
-  return Object.entries(framesMap)
-    .sort(([a], [b]) => Number(a) - Number(b))
-    .reduce((acc, [, frame]) => ({ ...acc, ...frame }), {} as LitUpHoldsMap);
+export function buildInitialFrames(frames: string, board: BoardName): LitUpHoldsMap[] {
+  if (!frames) return [{}];
+  const maps = accumulateFramesToMaps(frames, board);
+  return maps.length > 0 ? maps : [{}];
 }

--- a/packages/shared/create-climb-react/src/index.ts
+++ b/packages/shared/create-climb-react/src/index.ts
@@ -8,6 +8,6 @@ export {
   EDIT_WINDOW_MS,
   computeCanUpdate,
   computeEditLocked,
-  buildInitialHoldsMap,
+  buildInitialFrames,
   type SavedClimbSnapshot,
 } from './helpers';

--- a/packages/shared/create-climb-react/src/use-create-climb.ts
+++ b/packages/shared/create-climb-react/src/use-create-climb.ts
@@ -1,9 +1,16 @@
 import { useCallback, useMemo, useReducer } from 'react';
-import { HOLD_STATE_MAP, STATE_TO_PRIMARY_CODE } from '@boardsesh/board-constants/hold-states';
+import {
+  HOLD_STATE_MAP,
+  STATE_TO_PRIMARY_CODE,
+  accumulatedMapsToFrameStrings,
+  encodeMapsToFramesString,
+  flattenFramesToUnion,
+} from '@boardsesh/board-constants/hold-states';
 import type { BoardName, HoldState, LitUpHoldsMap } from '@boardsesh/shared-schema';
 
 type UseCreateClimbOptions = {
-  initialHoldsMap?: LitUpHoldsMap;
+  /** Seeds the editor's full frame sequence (a fork, an edit, or an autosave restore). */
+  initialFrames?: LitUpHoldsMap[];
 };
 
 // Drop holds whose state the board doesn't support (e.g. a colour-only / MoonBoard
@@ -24,104 +31,197 @@ function filterSupportedHoldsMap(boardName: BoardName, holdsMap: LitUpHoldsMap):
   ) as LitUpHoldsMap;
 }
 
+function filterSupportedFrames(boardName: BoardName, frames: LitUpHoldsMap[]): LitUpHoldsMap[] {
+  const filtered = frames.map((frame) => filterSupportedHoldsMap(boardName, frame));
+  return filtered.length > 0 ? filtered : [{}];
+}
+
 /** Max number of editing steps kept for undo. Oldest steps fall off the front. */
 export const HISTORY_LIMIT = 50;
 
 /**
- * Past/present/future undo history for the holds map. `present` is the live
- * map; `past`/`future` are full snapshots (the maps are small immutable
- * objects, so snapshotting is cheap). History is in-memory only — it resets on
- * remount, which is exactly the "current editing session" scope we want.
+ * Past/present/future undo history for the editor's frame sequence. `present`
+ * is the live sequence (one `LitUpHoldsMap` per frame); `past`/`future` hold
+ * full `{present, currentFrameIndex}` snapshots — the maps are small
+ * immutable objects, so snapshotting is cheap. History is in-memory only —
+ * it resets on remount, which is exactly the "current editing session" scope
+ * we want.
+ *
+ * Each snapshot pairs the frame sequence with which frame was active *at
+ * that point*, so undo/redo restore both exactly — undoing a duplicate
+ * lands you back where you started, redoing it returns you to the new frame
+ * it created. Pure navigation (`nextFrame`/`prevFrame`/`goToFrame`) does NOT
+ * push a snapshot — moving between frames isn't itself an edit — so it never
+ * shows up as an undo step, but an undo/redo across it still restores the
+ * exact index the bracketing edit captured.
  */
-export type HoldsHistory = {
-  past: LitUpHoldsMap[];
-  present: LitUpHoldsMap;
-  future: LitUpHoldsMap[];
+export type FramesSnapshot = { present: LitUpHoldsMap[]; currentFrameIndex: number };
+
+export type FramesHistory = FramesSnapshot & {
+  past: FramesSnapshot[];
+  future: FramesSnapshot[];
 };
 
-type HoldsAction =
-  // Apply a functional update to the present map (paint/erase). Records history
-  // only when the updater returns a *new* reference, so every no-op early-out
-  // in `setHoldState` (blocked max-2, OFF-on-absent, same-state repaint) leaves
-  // history untouched.
+type FramesAction =
+  // Apply a functional update to the active frame (paint/erase). Records
+  // history only when the updater returns a *new* reference, so every no-op
+  // early-out in `setHoldState` (blocked max-2, OFF-on-absent, same-state
+  // repaint) leaves history untouched.
   | { type: 'APPLY'; updater: (prev: LitUpHoldsMap) => LitUpHoldsMap }
-  // Replace the map wholesale and establish a fresh baseline (draft load / edit
-  // seed / fork). You can't undo across a load into the pre-load state.
-  | { type: 'LOAD'; holds: LitUpHoldsMap }
-  // Clear all holds — undoable (one undo restores them).
+  // Replace the whole frame sequence and establish a fresh undo baseline
+  // (draft load / edit seed / fork / autosave restore). You can't undo across
+  // a load into the pre-load state. `frames` must be non-empty.
+  | { type: 'LOAD_FRAMES'; frames: LitUpHoldsMap[] }
+  // Clear every frame back to a single empty one — undoable.
   | { type: 'RESET' }
+  // Insert a copy of the active frame right after it and move there.
+  | { type: 'DUPLICATE_FRAME' }
+  // Remove the active frame (no-op with only one frame left).
+  | { type: 'DELETE_FRAME' }
+  // Pure navigation — not pushed to past/future.
+  | { type: 'SET_FRAME_INDEX'; index: number }
   | { type: 'UNDO' }
   | { type: 'REDO' };
 
-function capPast(past: LitUpHoldsMap[]): LitUpHoldsMap[] {
+function capPast(past: FramesSnapshot[]): FramesSnapshot[] {
   return past.length > HISTORY_LIMIT ? past.slice(past.length - HISTORY_LIMIT) : past;
 }
 
-export function holdsReducer(state: HoldsHistory, action: HoldsAction): HoldsHistory {
+function clampIndex(index: number, length: number): number {
+  return Math.min(Math.max(index, 0), length - 1);
+}
+
+function isEmptyFrame(frame: LitUpHoldsMap): boolean {
+  return Object.keys(frame).length === 0;
+}
+
+/** The state before an action ran — what an UNDO of it should restore. */
+function snapshotOf(state: FramesHistory): FramesSnapshot {
+  return { present: state.present, currentFrameIndex: state.currentFrameIndex };
+}
+
+export function framesReducer(state: FramesHistory, action: FramesAction): FramesHistory {
   switch (action.type) {
     case 'APPLY': {
-      const next = action.updater(state.present);
-      if (next === state.present) return state;
-      return { past: capPast([...state.past, state.present]), present: next, future: [] };
+      const activeFrame = state.present[state.currentFrameIndex];
+      const next = action.updater(activeFrame);
+      if (next === activeFrame) return state;
+      const present = state.present.map((frame, index) => (index === state.currentFrameIndex ? next : frame));
+      return {
+        past: capPast([...state.past, snapshotOf(state)]),
+        present,
+        future: [],
+        currentFrameIndex: state.currentFrameIndex,
+      };
     }
-    case 'LOAD': {
-      if (action.holds === state.present) return state;
-      return { past: [], present: action.holds, future: [] };
+    case 'LOAD_FRAMES': {
+      if (action.frames === state.present) return state;
+      return { past: [], present: action.frames, future: [], currentFrameIndex: 0 };
     }
     case 'RESET': {
-      if (Object.keys(state.present).length === 0) return state;
-      return { past: capPast([...state.past, state.present]), present: {}, future: [] };
+      if (state.present.length === 1 && isEmptyFrame(state.present[0])) return state;
+      return { past: capPast([...state.past, snapshotOf(state)]), present: [{}], future: [], currentFrameIndex: 0 };
+    }
+    case 'DUPLICATE_FRAME': {
+      const activeFrame = state.present[state.currentFrameIndex];
+      const present = [
+        ...state.present.slice(0, state.currentFrameIndex + 1),
+        { ...activeFrame },
+        ...state.present.slice(state.currentFrameIndex + 1),
+      ];
+      return {
+        past: capPast([...state.past, snapshotOf(state)]),
+        present,
+        future: [],
+        currentFrameIndex: state.currentFrameIndex + 1,
+      };
+    }
+    case 'DELETE_FRAME': {
+      if (state.present.length <= 1) return state;
+      const present = state.present.filter((_, index) => index !== state.currentFrameIndex);
+      return {
+        past: capPast([...state.past, snapshotOf(state)]),
+        present,
+        future: [],
+        currentFrameIndex: clampIndex(state.currentFrameIndex, present.length),
+      };
+    }
+    case 'SET_FRAME_INDEX': {
+      const index = clampIndex(action.index, state.present.length);
+      if (index === state.currentFrameIndex) return state;
+      return { ...state, currentFrameIndex: index };
     }
     case 'UNDO': {
       if (state.past.length === 0) return state;
       const previous = state.past[state.past.length - 1];
-      return { past: state.past.slice(0, -1), present: previous, future: [state.present, ...state.future] };
+      return {
+        past: state.past.slice(0, -1),
+        present: previous.present,
+        currentFrameIndex: previous.currentFrameIndex,
+        future: [snapshotOf(state), ...state.future],
+      };
     }
     case 'REDO': {
       if (state.future.length === 0) return state;
       const next = state.future[0];
-      return { past: capPast([...state.past, state.present]), present: next, future: state.future.slice(1) };
+      return {
+        past: capPast([...state.past, snapshotOf(state)]),
+        present: next.present,
+        currentFrameIndex: next.currentFrameIndex,
+        future: state.future.slice(1),
+      };
     }
     default:
       return state;
   }
 }
 
-function initHistory(boardName: BoardName, initialHoldsMap: LitUpHoldsMap | undefined): HoldsHistory {
-  return { past: [], present: filterSupportedHoldsMap(boardName, initialHoldsMap ?? {}), future: [] };
+function initHistory(boardName: BoardName, initialFrames: LitUpHoldsMap[] | undefined): FramesHistory {
+  return {
+    past: [],
+    present: filterSupportedFrames(boardName, initialFrames ?? [{}]),
+    future: [],
+    currentFrameIndex: 0,
+  };
 }
 
 /**
  * Aurora (Kilter/Tension/etc) hold-state machine for the create-climb editor.
  * Pure React + board-constants — shared verbatim by the web form and the
  * React Native editor. Keys holds by numeric id; enforces the max-2
- * STARTING/FINISH rule; serialises to the Aurora `p{holdId}r{code}` frame
- * string. Tracks in-memory undo/redo history for the current editing session.
+ * STARTING/FINISH rule (per frame); serialises the whole frame sequence to
+ * the Aurora frames string (delta-encoded past frame 0). Tracks in-memory
+ * undo/redo history for the current editing session.
+ *
+ * `litUpHoldsMap` is always the *active* frame — every existing single-frame
+ * consumer (board renderers, the hold-type picker, paint handlers) keeps
+ * working unchanged. Multi-frame/route support is opt-in via `frameCount`,
+ * `duplicateFrame`/`deleteFrame`, and the frame-navigation helpers below.
  */
 export function useCreateClimb(boardName: BoardName, options?: UseCreateClimbOptions) {
   // The editor mounts once per board route today, so this initial sanitizer only
   // needs the mount-time board. If a future caller swaps boardName mid-mount,
-  // remount this hook or re-sanitize the present map on board change.
-  const [history, dispatch] = useReducer(holdsReducer, options?.initialHoldsMap, (initial) =>
+  // remount this hook or re-sanitize the present frames on board change.
+  const [history, dispatch] = useReducer(framesReducer, options?.initialFrames, (initial) =>
     initHistory(boardName, initial),
   );
-  const litUpHoldsMap = history.present;
+  const litUpHoldsMap = history.present[history.currentFrameIndex] ?? {};
+  const frameCount = history.present.length;
+  const currentFrameIndex = history.currentFrameIndex;
 
-  // Derived state: count holds by type
+  // Derived state, computed over the union of every frame in the route so
+  // validity / duplicate-detection reflect the whole sequence, not just
+  // whichever frame is on screen right now.
+  const unionHolds = useMemo(() => flattenFramesToUnion(history.present), [history.present]);
+
   const startingCount = useMemo(
-    () => Object.values(litUpHoldsMap).filter((h) => h.state === 'STARTING').length,
-    [litUpHoldsMap],
+    () => Object.values(unionHolds).filter((h) => h.state === 'STARTING').length,
+    [unionHolds],
   );
 
-  const finishCount = useMemo(
-    () => Object.values(litUpHoldsMap).filter((h) => h.state === 'FINISH').length,
-    [litUpHoldsMap],
-  );
+  const finishCount = useMemo(() => Object.values(unionHolds).filter((h) => h.state === 'FINISH').length, [unionHolds]);
 
-  const totalHolds = useMemo(
-    () => Object.values(litUpHoldsMap).filter((h) => h.state !== 'OFF').length,
-    [litUpHoldsMap],
-  );
+  const totalHolds = useMemo(() => Object.values(unionHolds).filter((h) => h.state !== 'OFF').length, [unionHolds]);
 
   const isValid = totalHolds > 0;
 
@@ -143,8 +243,8 @@ export function useCreateClimb(boardName: BoardName, options?: UseCreateClimbOpt
           const currentHold = prev[holdId];
           if (currentHold?.state === nextState) return prev;
 
-          // Enforce max-2 STARTING / FINISH limits as a safety net — the picker
-          // already disables these options when at the cap.
+          // Enforce max-2 STARTING / FINISH limits per frame as a safety net —
+          // the picker already disables these options when at the cap.
           if (nextState === 'STARTING') {
             const startingCount = Object.values(prev).filter((h) => h.state === 'STARTING').length;
             if (startingCount >= 2) return prev;
@@ -181,27 +281,45 @@ export function useCreateClimb(boardName: BoardName, options?: UseCreateClimbOpt
     [boardName],
   );
 
-  // Generate frames string in Aurora format: p{holdId}r{stateCode}p{holdId}r{stateCode}...
-  // Holds whose state the board can't encode are skipped (parity with the init/load filter).
-  const generateFramesString = useCallback(() => {
-    const stateToCode = STATE_TO_PRIMARY_CODE[boardName];
-    return Object.entries(litUpHoldsMap)
-      .filter(([, hold]) => hold.state !== 'OFF')
-      .flatMap(([holdId, hold]) => {
-        const code = stateToCode?.[hold.state];
-        return code === undefined ? [] : [`p${holdId}r${code}`];
-      })
-      .join('');
-  }, [litUpHoldsMap, boardName]);
+  // Encode the whole route: frame 0 absolute, later frames delta-encoded.
+  // Single-frame climbs produce the same flat string they always have.
+  const generateFramesString = useCallback(
+    () => encodeMapsToFramesString(history.present, boardName),
+    [history.present, boardName],
+  );
 
-  // Reset all holds (undoable).
+  // BLE-ready single-frame string for *just* the active frame — for the
+  // live-preview-while-painting path, which must never see multi-frame
+  // syntax (commas / `"` / `x` tokens the BLE packet builder can't parse).
+  const currentFrameBleString = useCallback(
+    () => accumulatedMapsToFrameStrings([litUpHoldsMap], boardName)[0] ?? '',
+    [litUpHoldsMap, boardName],
+  );
+
+  // Reset every frame back to a single empty one (undoable).
   const resetHolds = useCallback(() => dispatch({ type: 'RESET' }), []);
 
-  // Replace the entire holds map in one shot (used when loading a draft back
-  // into the form). Establishes a fresh undo baseline and drops unsupported holds.
-  const loadHolds = useCallback(
-    (next: LitUpHoldsMap) => dispatch({ type: 'LOAD', holds: filterSupportedHoldsMap(boardName, next) }),
+  // Replace the entire frame sequence in one shot (draft load / edit seed /
+  // fork / autosave restore). Establishes a fresh undo baseline and drops
+  // unsupported holds from every frame.
+  const loadFrames = useCallback(
+    (frames: LitUpHoldsMap[]) => dispatch({ type: 'LOAD_FRAMES', frames: filterSupportedFrames(boardName, frames) }),
     [boardName],
+  );
+
+  // Convenience single-frame form of `loadFrames`.
+  const loadHolds = useCallback((next: LitUpHoldsMap) => loadFrames([next]), [loadFrames]);
+
+  const duplicateFrame = useCallback(() => dispatch({ type: 'DUPLICATE_FRAME' }), []);
+  const deleteFrame = useCallback(() => dispatch({ type: 'DELETE_FRAME' }), []);
+  const goToFrame = useCallback((index: number) => dispatch({ type: 'SET_FRAME_INDEX', index }), []);
+  const nextFrame = useCallback(
+    () => dispatch({ type: 'SET_FRAME_INDEX', index: currentFrameIndex + 1 }),
+    [currentFrameIndex],
+  );
+  const prevFrame = useCallback(
+    () => dispatch({ type: 'SET_FRAME_INDEX', index: currentFrameIndex - 1 }),
+    [currentFrameIndex],
   );
 
   const undo = useCallback(() => dispatch({ type: 'UNDO' }), []);
@@ -209,14 +327,24 @@ export function useCreateClimb(boardName: BoardName, options?: UseCreateClimbOpt
 
   return {
     litUpHoldsMap,
+    frames: history.present,
+    frameCount,
+    currentFrameIndex,
     setHoldState,
     generateFramesString,
+    currentFrameBleString,
     startingCount,
     finishCount,
     totalHolds,
     isValid,
     resetHolds,
     loadHolds,
+    loadFrames,
+    duplicateFrame,
+    deleteFrame,
+    goToFrame,
+    nextFrame,
+    prevFrame,
     undo,
     redo,
     canUndo: history.past.length > 0,

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -223,6 +223,12 @@
       "title": "Boulder leeren",
       "description": "Das entfernt alle Griffe und setzt das Formular zurück. Sicher?",
       "tooltip": "Alle Griffe entfernen"
+    },
+    "frames": {
+      "duplicateTooltip": "Bild duplizieren",
+      "deleteTooltip": "Bild löschen",
+      "deleteTitle": "Bild löschen",
+      "deleteDescription": "Das aktuelle Bild wird gelöscht. Sicher?"
     }
   },
   "actions": {
@@ -866,6 +872,13 @@
         "setActive": "Als aktiven Boulder setzen",
         "undo": "Rückgängig",
         "redo": "Wiederholen"
+      },
+      "frames": {
+        "duplicate": "Bild duplizieren",
+        "delete": "Bild löschen",
+        "prev": "Vorheriges Bild",
+        "next": "Nächstes Bild",
+        "counter": "{{index}}/{{total}}"
       },
       "holdRole": {
         "title": "Griff-Rolle festlegen",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -223,6 +223,12 @@
       "title": "Clear climb",
       "description": "This will clear all holds and reset the form. Are you sure?",
       "tooltip": "Clear all holds"
+    },
+    "frames": {
+      "duplicateTooltip": "Duplicate frame",
+      "deleteTooltip": "Delete frame",
+      "deleteTitle": "Delete frame",
+      "deleteDescription": "This will delete the current frame. Are you sure?"
     }
   },
   "actions": {
@@ -866,6 +872,13 @@
         "setActive": "Set as active climb",
         "undo": "Undo",
         "redo": "Redo"
+      },
+      "frames": {
+        "duplicate": "Duplicate frame",
+        "delete": "Delete frame",
+        "prev": "Previous frame",
+        "next": "Next frame",
+        "counter": "{{index}}/{{total}}"
       },
       "holdRole": {
         "title": "Set hold role",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -223,6 +223,12 @@
       "title": "Borrar bloque",
       "description": "Esto borrará todas las presas y reiniciará el formulario. ¿Seguro?",
       "tooltip": "Borrar todas las presas"
+    },
+    "frames": {
+      "duplicateTooltip": "Duplicar cuadro",
+      "deleteTooltip": "Eliminar cuadro",
+      "deleteTitle": "Eliminar cuadro",
+      "deleteDescription": "Esto eliminará el cuadro actual. ¿Seguro?"
     }
   },
   "actions": {
@@ -866,6 +872,13 @@
         "setActive": "Fijar como vía activa",
         "undo": "Deshacer",
         "redo": "Rehacer"
+      },
+      "frames": {
+        "duplicate": "Duplicar cuadro",
+        "delete": "Eliminar cuadro",
+        "prev": "Cuadro anterior",
+        "next": "Cuadro siguiente",
+        "counter": "{{index}}/{{total}}"
       },
       "holdRole": {
         "title": "Asignar rol de presa",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -223,6 +223,12 @@
       "title": "Effacer le bloc",
       "description": "Toutes les prises seront retirées et le formulaire remis à zéro. On y va ?",
       "tooltip": "Effacer toutes les prises"
+    },
+    "frames": {
+      "duplicateTooltip": "Dupliquer l'image",
+      "deleteTooltip": "Supprimer l'image",
+      "deleteTitle": "Supprimer l'image",
+      "deleteDescription": "L'image actuelle sera supprimée. On y va ?"
     }
   },
   "actions": {
@@ -866,6 +872,13 @@
         "setActive": "Définir comme voie active",
         "undo": "Annuler",
         "redo": "Rétablir"
+      },
+      "frames": {
+        "duplicate": "Dupliquer l'image",
+        "delete": "Supprimer l'image",
+        "prev": "Image précédente",
+        "next": "Image suivante",
+        "counter": "{{index}}/{{total}}"
       },
       "holdRole": {
         "title": "Définir le rôle de la prise",

--- a/packages/web/app/components/create-climb/__tests__/create-climb-form.test.tsx
+++ b/packages/web/app/components/create-climb/__tests__/create-climb-form.test.tsx
@@ -24,12 +24,19 @@ const mockReplaceQueueItem = vi.fn();
 const mockSaveClimb = vi.fn();
 const mockUpdateClimb = vi.fn();
 const mockLoadAuroraHolds = vi.fn();
+const mockLoadAuroraFrames = vi.fn();
 const mockResetAuroraHolds = vi.fn();
 const mockResetMoonboardHolds = vi.fn();
 const mockSetAuroraHoldState = vi.fn();
 const mockSetMoonboardHoldState = vi.fn();
 const mockSendFramesToBoard = vi.fn();
 const mockGenerateAuroraFramesString = vi.fn(() => 'test-frames');
+const mockCurrentFrameBleString = vi.fn(() => 'test-ble-frame');
+const mockDuplicateFrame = vi.fn();
+const mockDeleteFrame = vi.fn();
+const mockNextFrame = vi.fn();
+const mockPrevFrame = vi.fn();
+const mockBuildInitialFrames = vi.hoisted(() => vi.fn(() => [{} as LitUpHoldsMap]));
 let mockQueueActions: Record<string, unknown> | null = null;
 let mockCurrentClimbData: Record<string, unknown> | null = null;
 let mockAuroraCreateState: {
@@ -74,6 +81,8 @@ vi.mock('../../board-bluetooth-control/bluetooth-context', () => ({
 vi.mock('@boardsesh/create-climb-react', () => ({
   useCreateClimb: vi.fn(() => ({
     litUpHoldsMap: mockAuroraCreateState.litUpHoldsMap,
+    frameCount: 1,
+    currentFrameIndex: 0,
     setHoldState: mockSetAuroraHoldState,
     startingCount: 0,
     finishCount: 0,
@@ -81,8 +90,15 @@ vi.mock('@boardsesh/create-climb-react', () => ({
     isValid: mockAuroraCreateState.isValid,
     resetHolds: mockResetAuroraHolds,
     generateFramesString: mockGenerateAuroraFramesString,
+    currentFrameBleString: mockCurrentFrameBleString,
     loadHolds: mockLoadAuroraHolds,
+    loadFrames: mockLoadAuroraFrames,
+    duplicateFrame: mockDuplicateFrame,
+    deleteFrame: mockDeleteFrame,
+    nextFrame: mockNextFrame,
+    prevFrame: mockPrevFrame,
   })),
+  buildInitialFrames: mockBuildInitialFrames,
 }));
 
 vi.mock('../use-moonboard-create-climb', () => ({
@@ -862,6 +878,9 @@ describe('CreateClimbForm — Aurora rendering', () => {
     };
     vi.mocked(useCreateClimb).mockReturnValue({
       litUpHoldsMap: mockAuroraCreateState.litUpHoldsMap,
+      frames: [mockAuroraCreateState.litUpHoldsMap],
+      frameCount: 1,
+      currentFrameIndex: 0,
       setHoldState: mockSetAuroraHoldState,
       startingCount: 0,
       finishCount: 0,
@@ -869,7 +888,14 @@ describe('CreateClimbForm — Aurora rendering', () => {
       isValid: true,
       resetHolds: mockResetAuroraHolds,
       generateFramesString: mockGenerateAuroraFramesString,
+      currentFrameBleString: mockCurrentFrameBleString,
       loadHolds: mockLoadAuroraHolds,
+      loadFrames: mockLoadAuroraFrames,
+      duplicateFrame: mockDuplicateFrame,
+      deleteFrame: mockDeleteFrame,
+      goToFrame: vi.fn(),
+      nextFrame: mockNextFrame,
+      prevFrame: mockPrevFrame,
       undo: vi.fn(),
       redo: vi.fn(),
       canUndo: false,
@@ -878,8 +904,10 @@ describe('CreateClimbForm — Aurora rendering', () => {
 
     renderAuroraComponent();
 
+    // The direct-preview send uses the active-frame-only BLE string, never the
+    // full (possibly multi-frame) route string generateFramesString() returns.
     await waitFor(() => {
-      expect(mockSendFramesToBoard).toHaveBeenCalledWith('test-frames');
+      expect(mockSendFramesToBoard).toHaveBeenCalledWith('test-ble-frame');
     });
   });
 
@@ -905,6 +933,9 @@ describe('CreateClimbForm — Aurora rendering', () => {
     };
     vi.mocked(useCreateClimb).mockReturnValue({
       litUpHoldsMap: mockAuroraCreateState.litUpHoldsMap,
+      frames: [mockAuroraCreateState.litUpHoldsMap],
+      frameCount: 1,
+      currentFrameIndex: 0,
       setHoldState: mockSetAuroraHoldState,
       startingCount: 0,
       finishCount: 0,
@@ -912,7 +943,14 @@ describe('CreateClimbForm — Aurora rendering', () => {
       isValid: true,
       resetHolds: mockResetAuroraHolds,
       generateFramesString: mockGenerateAuroraFramesString,
+      currentFrameBleString: mockCurrentFrameBleString,
       loadHolds: mockLoadAuroraHolds,
+      loadFrames: mockLoadAuroraFrames,
+      duplicateFrame: mockDuplicateFrame,
+      deleteFrame: mockDeleteFrame,
+      goToFrame: vi.fn(),
+      nextFrame: mockNextFrame,
+      prevFrame: mockPrevFrame,
       undo: vi.fn(),
       redo: vi.fn(),
       canUndo: false,

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -28,6 +28,10 @@ import {
   CheckCircleOutlined,
   LockOutlined,
   PlayCircleOutlineOutlined,
+  ContentCopyOutlined,
+  SkipPreviousOutlined,
+  SkipNextOutlined,
+  RemoveCircleOutline,
 } from '@mui/icons-material';
 import { themeTokens } from '@/app/theme/theme-config';
 import HoldIndicator from './hold-indicator';
@@ -40,14 +44,12 @@ import MoonBoardRenderer from '../moonboard-renderer/moonboard-renderer';
 import ZoomableBoard from '../board-renderer/zoomable-board';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
 import { useBoardProvider } from '../board-provider/board-provider-context';
-import { useCreateClimb } from '@boardsesh/create-climb-react';
+import { useCreateClimb, buildInitialFrames } from '@boardsesh/create-climb-react';
 import { useMoonBoardCreateClimb } from './use-moonboard-create-climb';
 import { useOptionalBluetoothContext } from '../board-bluetooth-control/bluetooth-context';
 import type { MoonBoardClimbDuplicateMatch, UpdateClimbInput } from '@boardsesh/shared-schema';
 import { CLIMB_CHARACTERISTICS } from '@boardsesh/shared-schema';
 import type { BoardDetails, BoardName, Climb } from '@/app/lib/types';
-import { convertLitUpHoldsStringToMap } from '../board-renderer/util';
-import type { LitUpHoldsMap } from '../board-renderer/types';
 import { getMoonBoardGradeLabel, MOONBOARD_GRADES } from '@/app/lib/moonboard-config';
 import { useBoardAngleOptions } from '@/app/hooks/use-board-angles';
 import { getSoftGradeColor } from '@/app/lib/grade-colors';
@@ -185,15 +187,16 @@ export default function CreateClimbForm({
         (r.role === 'admin' || r.role === 'community_leader') && (r.boardType === null || r.boardType === 'moonboard'),
     );
 
-  // Convert fork frames to initial holds map if provided (Aurora only)
-  const initialHoldsMap = useMemo(() => {
+  // Convert fork frames to the editor's initial frame sequence if provided
+  // (Aurora only). Preserves every frame of a multi-frame source climb —
+  // previously this took only frame 0, silently dropping the rest of a route.
+  const initialFrames = useMemo(() => {
     if (boardType !== 'aurora' || !forkFrames || !boardDetails) return undefined;
-    const framesMap = convertLitUpHoldsStringToMap(forkFrames, boardDetails.board_name);
-    return framesMap[0] ?? undefined;
+    return buildInitialFrames(forkFrames, boardDetails.board_name);
   }, [boardType, forkFrames, boardDetails]);
 
   // Aurora hold management
-  const auroraClimb = useCreateClimb(boardDetails?.board_name || 'kilter', { initialHoldsMap });
+  const auroraClimb = useCreateClimb(boardDetails?.board_name || 'kilter', { initialFrames });
 
   // MoonBoard hold management
   const moonboardClimb = useMoonBoardCreateClimb();
@@ -211,8 +214,9 @@ export default function CreateClimbForm({
 
   const handCount = boardType === 'moonboard' ? moonboardClimb.handCount : 0;
   const generateFramesString = boardType === 'aurora' ? auroraClimb.generateFramesString : undefined;
+  const currentFrameBleString = boardType === 'aurora' ? auroraClimb.currentFrameBleString : undefined;
   const setLitUpHoldsMap = boardType === 'moonboard' ? moonboardClimb.setLitUpHoldsMap : undefined;
-  const loadAuroraHolds = boardType === 'aurora' ? auroraClimb.loadHolds : undefined;
+  const loadAuroraFrames = boardType === 'aurora' ? auroraClimb.loadFrames : undefined;
 
   // Bluetooth for Aurora boards. Share the single root-level connection (the
   // one the lightbulb actually drives) instead of spinning up a second adapter
@@ -418,11 +422,11 @@ export default function CreateClimbForm({
       if (cancelled) return;
       if (saved) {
         try {
-          const holds = JSON.parse(saved.holdsJson);
-          if (boardType === 'aurora' && loadAuroraHolds) {
-            loadAuroraHolds(holds);
+          if (boardType === 'aurora' && loadAuroraFrames) {
+            const frames = saved.framesJson ? JSON.parse(saved.framesJson) : [JSON.parse(saved.holdsJson)];
+            loadAuroraFrames(frames);
           } else if (boardType === 'moonboard' && setLitUpHoldsMap) {
-            setLitUpHoldsMap(holds);
+            setLitUpHoldsMap(JSON.parse(saved.holdsJson));
           }
           if (saved.climbName) setClimbName(saved.climbName);
           if (saved.description) setDescription(saved.description);
@@ -440,16 +444,19 @@ export default function CreateClimbForm({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Debounced autosave on changes
+  // Debounced autosave on changes. `framesJson` (the full route) is aurora-only;
+  // `holdsJson` covers moonboard and doubles as a backward-compatible fallback
+  // for aurora restores of an autosave written before this field existed.
   const autosaveData = useMemo(
     () => ({
       holdsJson: JSON.stringify(litUpHoldsMap),
+      framesJson: boardType === 'aurora' ? JSON.stringify(auroraClimb.frames) : undefined,
       climbName,
       description,
       isDraft,
       boardKey: autosaveBoardKey,
     }),
-    [litUpHoldsMap, climbName, description, isDraft, autosaveBoardKey],
+    [litUpHoldsMap, boardType, auroraClimb.frames, climbName, description, isDraft, autosaveBoardKey],
   );
   const debouncedAutosave = useDebouncedValue(autosaveData, 500);
   const debouncedTotalHolds = useDebouncedValue(totalHolds, 500);
@@ -487,10 +494,12 @@ export default function CreateClimbForm({
   // "building doesn't broadcast" rule.
   useEffect(() => {
     if (queueItemUuid != null) return;
-    if (boardType === 'aurora' && isConnected && generateFramesString) {
-      void sendFramesToBoard?.(generateFramesString());
+    if (boardType === 'aurora' && isConnected && currentFrameBleString) {
+      // The active frame only — the wall mirrors whatever you're painting right
+      // now, not multi-frame route syntax the BLE packet builder can't parse.
+      void sendFramesToBoard?.(currentFrameBleString());
     }
-  }, [boardType, litUpHoldsMap, isConnected, generateFramesString, sendFramesToBoard, queueItemUuid]);
+  }, [boardType, litUpHoldsMap, isConnected, currentFrameBleString, sendFramesToBoard, queueItemUuid]);
 
   // As soon as the user edits the climb after a successful save, flip the
   // button back to its normal "Save" state so they can save the revision.
@@ -883,7 +892,7 @@ export default function CreateClimbForm({
           description: description || '',
           frames,
           angle,
-          framesCount: 1,
+          framesCount: auroraClimb.frameCount,
           framesPace: 0,
           isDraft,
         };
@@ -932,7 +941,7 @@ export default function CreateClimbForm({
         description: description || '',
         is_draft: isDraft,
         frames,
-        frames_count: 1,
+        frames_count: auroraClimb.frameCount,
         frames_pace: 0,
         angle,
       });
@@ -992,6 +1001,7 @@ export default function CreateClimbForm({
   }, [
     boardDetails,
     generateFramesString,
+    auroraClimb.frameCount,
     saveClimb,
     updateClimb,
     climbName,
@@ -1311,22 +1321,14 @@ export default function CreateClimbForm({
   // Tracks the loaded row as savedClimb so subsequent Save presses update it
   // in place rather than creating a duplicate.
   //
-  // The create form only ever produces single-frame climbs (framesCount: 1),
-  // but a draft may originate from elsewhere with multiple frames. In that
-  // case we flatten every frame into a single map — later frames override
-  // earlier ones for the same hold id — so no holds are silently dropped.
-  // Frame separation is lost on re-save, which is acceptable because the
-  // editor has no concept of multiple frames.
+  // Preserves every frame of a multi-frame draft/edit source — previously this
+  // flattened every frame into one map (later frames overriding earlier ones),
+  // silently collapsing a route/circuit into a single static snapshot on load.
   const handleLoadDraft = useCallback(
     (climb: Climb) => {
-      if (boardType !== 'aurora' || !boardDetails || !loadAuroraHolds) return;
+      if (boardType !== 'aurora' || !boardDetails || !loadAuroraFrames) return;
 
-      const framesMap = convertLitUpHoldsStringToMap(climb.frames, boardDetails.board_name);
-      const frameEntries = Object.entries(framesMap)
-        .sort(([a], [b]) => Number(a) - Number(b))
-        .map(([, frame]) => frame);
-      const mergedHolds = frameEntries.reduce((acc, frame) => ({ ...acc, ...frame }), {} as LitUpHoldsMap);
-      loadAuroraHolds(mergedHolds);
+      loadAuroraFrames(buildInitialFrames(climb.frames, boardDetails.board_name));
       setClimbName(climb.name || '');
       setDescription(climb.description || '');
       setSavedClimb({
@@ -1349,7 +1351,7 @@ export default function CreateClimbForm({
       // The litUpHoldsMap effect at the top of this component pushes new frames
       // to a connected Bluetooth board automatically.
     },
-    [boardType, boardDetails, loadAuroraHolds, clearJustSaved, queueActions],
+    [boardType, boardDetails, loadAuroraFrames, clearJustSaved, queueActions],
   );
 
   const handleDraftDeleted = useCallback(
@@ -1370,11 +1372,11 @@ export default function CreateClimbForm({
   // saves update savedClimb in place and must not trigger another reload.
   const seededEditClimbUuidRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!editClimb || boardType !== 'aurora' || !boardDetails || !loadAuroraHolds) return;
+    if (!editClimb || boardType !== 'aurora' || !boardDetails || !loadAuroraFrames) return;
     if (seededEditClimbUuidRef.current === editClimb.uuid) return;
     seededEditClimbUuidRef.current = editClimb.uuid;
     handleLoadDraft(editClimb);
-  }, [editClimb, boardType, boardDetails, loadAuroraHolds, handleLoadDraft]);
+  }, [editClimb, boardType, boardDetails, loadAuroraFrames, handleLoadDraft]);
 
   // Surface a lookup failure from the create page (expired link, wrong
   // board, deleted row) exactly once per error value so the user knows why
@@ -1693,6 +1695,58 @@ export default function CreateClimbForm({
               )}
             </IconButton>
           </MuiTooltip>
+        )}
+        {boardType === 'aurora' && (
+          <>
+            <MuiTooltip title={t('create.frames.duplicateTooltip')}>
+              <IconButton
+                size="small"
+                onClick={auroraClimb.duplicateFrame}
+                aria-label={t('create.frames.duplicateTooltip')}
+              >
+                <ContentCopyOutlined fontSize="small" />
+              </IconButton>
+            </MuiTooltip>
+            {auroraClimb.frameCount > 1 && (
+              <Stack direction="row" alignItems="center" spacing={0.5}>
+                <IconButton
+                  size="small"
+                  onClick={auroraClimb.prevFrame}
+                  disabled={auroraClimb.currentFrameIndex === 0}
+                  aria-label={tCommon('playback.prevFrame')}
+                >
+                  <SkipPreviousOutlined fontSize="small" />
+                </IconButton>
+                <Typography variant="caption" sx={{ whiteSpace: 'nowrap', color: 'text.secondary' }}>
+                  {tCommon('playback.frameOfTotal', {
+                    index: auroraClimb.currentFrameIndex + 1,
+                    total: auroraClimb.frameCount,
+                  })}
+                </Typography>
+                <IconButton
+                  size="small"
+                  onClick={auroraClimb.nextFrame}
+                  disabled={auroraClimb.currentFrameIndex >= auroraClimb.frameCount - 1}
+                  aria-label={tCommon('playback.nextFrame')}
+                >
+                  <SkipNextOutlined fontSize="small" />
+                </IconButton>
+                <ConfirmPopover
+                  title={t('create.frames.deleteTitle')}
+                  description={t('create.frames.deleteDescription')}
+                  onConfirm={auroraClimb.deleteFrame}
+                  okText={tCommon('actions.delete')}
+                  cancelText={tCommon('actions.cancel')}
+                >
+                  <MuiTooltip title={t('create.frames.deleteTooltip')}>
+                    <IconButton size="small" aria-label={t('create.frames.deleteTooltip')}>
+                      <RemoveCircleOutline fontSize="small" />
+                    </IconButton>
+                  </MuiTooltip>
+                </ConfirmPopover>
+              </Stack>
+            )}
+          </>
         )}
         <ConfirmPopover
           title={t('create.clear.title')}

--- a/packages/web/app/lib/create-climb-autosave-db.ts
+++ b/packages/web/app/lib/create-climb-autosave-db.ts
@@ -4,8 +4,14 @@ const STORE_NAME = 'autosave';
 const AUTOSAVE_KEY = 'create-climb';
 
 export type CreateClimbAutosave = {
-  /** Serialised holds map (JSON stringified LitUpHoldsMap) */
+  /**
+   * MoonBoard: serialised holds map (JSON stringified LitUpHoldsMap).
+   * Aurora: serialised *active* frame only, kept for backward compatibility —
+   * `framesJson` below is the full route and takes priority when present.
+   */
   holdsJson: string;
+  /** Aurora only: JSON.stringify(LitUpHoldsMap[]) — the full frame sequence. */
+  framesJson?: string;
   climbName: string;
   description: string;
   isDraft: boolean;


### PR DESCRIPTION
## Summary

Closes #3785.

The create-climb editor could only ever produce single-frame boulders — the shared hold-state machine (`useCreateClimb`, used verbatim by web and mobile) held exactly one `LitUpHoldsMap` and had no way to encode more than one frame. Forking or editing an existing multi-frame route/circuit silently collapsed it into one frame (web fork took only frame 0; every other seed path unioned every frame's holds, later frames overriding earlier ones) — the bug the issue calls out.

Playback of multi-frame routes has worked since #2232; this closes the gap on the write side, per the issue's suggested MVP: the editor still starts single-frame, a **duplicate frame** button is always available, and once a climb has more than one frame the rest of the route UI (counter, prev/next, delete) shows up.

**Scope:** Aurora boards only (Kilter/Tension/decoy/touchstone/grasshopper/soill). MoonBoard's web editor is a separate, colour-based single-frame hook with no `frames` concept — unrelated, untouched. Mobile's create screen already routes every board (including MoonBoard) through the generic Aurora-style hook, so MoonBoard route creation on mobile is a side effect, not a target.

### What changed

- **`packages/board-constants`**: new `encodeMapsToFramesString` — the write-side counterpart to the existing `accumulateFramesToMaps` decoder. Frame 0 encodes absolute; later frames delta-encode against the previous frame (adds/removes/role-changes), matching the documented Aurora grammar. A single-frame route encodes byte-identical to the old flat format.
- **`packages/shared/create-climb-react`**: `useCreateClimb` now holds the full frame sequence + an active index instead of one map. `litUpHoldsMap` still means "the active frame," so every existing single-frame consumer is unaffected. New: `duplicateFrame`, `deleteFrame`, `nextFrame`/`prevFrame`/`goToFrame`, `loadFrames`, `frameCount`, `currentFrameIndex`, `currentFrameBleString` (BLE-ready single-frame string for the live-preview-while-painting path — never multi-frame syntax). Undo/redo now restore both frame content and which frame was active when the edit happened. `buildInitialFrames` replaces `buildInitialHoldsMap`, preserving frame separation on fork/edit/draft-restore instead of flattening.
- **Web + mobile**: new duplicate-frame toolbar button (always visible for Aurora boards), and — once `frameCount > 1` — a frame counter with prev/next stepper and a delete-frame button. Save payloads now report the real `frameCount` instead of a hardcoded `1`. Local autosave/crash-recovery persists the full frame array, not just the active frame.
- The live Bluetooth preview that fires while painting (both platforms) now sends only the active frame's BLE-ready string, never the multi-frame route string — the wall mirrors what you're currently painting, not an attempt to animate the whole route. **This touches Bluetooth code and needs Fable's review per CLAUDE.md before merge.**

## Release Notes

- Build routes and circuits, not just single-frame boulders — duplicate a frame, edit the copy, and step through your sequence as you build it.
- Forking or editing an existing route no longer collapses it into one frame.

## Test plan

- `vp check`, `vp run typecheck` (web/mobile/shared) — clean.
- `vp test run --reporter=agent` (full monorepo suite): 19643 passed, 11 skipped, 9 failed — all 9 failures are pre-existing and unrelated (`session-utils.test.ts`, `logbook-tab-grouped.test.tsx`, `feed-time-buckets.test.ts`; confirmed via `git diff main` that none of those files are touched by this branch — timezone-dependent flakes in this sandbox).
- `vp run check:i18n`, `vp run check:i18n:orphans`, `vp run check:mobile-bundle` — clean.
- New/updated unit tests: `encodeMapsToFramesString` round-trip tests (including against the real Kilter Grips oracle fixture) in `packages/board-constants`; full reducer test suite (duplicate/delete/nav/undo-redo-with-frames) in `packages/shared/create-climb-react`; updated web/mobile consumer tests for the new hook shape and save payloads.
- Manually verified against a real seeded 5-frame Kilter route (`board_climbs` row with `frames_count=5`): decoded via `accumulateFramesToMaps`, re-encoded via `encodeMapsToFramesString`, round-trips to an identical structure. Loaded the climb's view page (200, plays back correctly) and the create-fork page seeded from its `frames` string (200, no server error, new "Duplicate frame" control present in the rendered HTML).
- Did not have interactive browser tooling available in this environment to click through the new UI end-to-end — the QA notes at `.boardsesh/qa-notes.md` cover the manual flow (duplicate → edit → step → delete → save → verify playback; fork/edit a real multi-frame climb; BLE live-preview; mobile undo/redo; autosave restore) for follow-up manual QA.
