### PR TITLE
fix(mobile): restore Android hold taps in the create-climb editor

### DIFF
--- a/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
+++ b/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useRef, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { View, StyleSheet, Pressable } from 'react-native';
 import Animated from 'react-native-reanimated';
-import { GestureDetector, type GestureType } from 'react-native-gesture-handler';
+import { GestureDetector, GestureHandlerRootView, type GestureType } from 'react-native-gesture-handler';
 import type { BoardName, LitUpHoldsMap } from '@boardsesh/shared-schema';
 import { BoardImageNative } from '../BoardImageNative';
 import { Text } from '../Text';
@@ -47,6 +47,16 @@ type InteractiveCreateBoardProps = {
  * 1-finger zoom-pan only mounts while zoomed (a conditional overlay) so idle
  * vertical drags fall through to the BottomSheetScrollView and scroll/close the
  * drawer instead of being eaten here.
+ *
+ * Wrapped in its own GestureHandlerRootView: on Android, CreateDrawer's sheet
+ * (`@expo/ui/community/bottom-sheet`) hosts its content inside a Jetpack Compose
+ * `ModalBottomSheet` via a native `RNHostView` bridge — a separate surface the
+ * app's single root-level GestureHandlerRootView (app/_layout.tsx) doesn't cover.
+ * Without a nested root here, every per-hold Gesture.Tap()/LongPress() and the
+ * pinch/pan gestures silently never receive touches on Android, so no hold can be
+ * painted (#4320). RNGH's own docs call out nesting a root per-Modal for exactly
+ * this reason; iOS isn't affected since its modal presentation doesn't split the
+ * touch-dispatch tree the same way.
  */
 export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard({
   boardName,
@@ -118,7 +128,7 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
   });
 
   return (
-    <View style={styles.root}>
+    <GestureHandlerRootView style={styles.root}>
       <GestureDetector gesture={pinchGesture}>
         <View style={[styles.clip, { width: renderWidth, height: renderHeight }]}>
           <Animated.View style={[styles.board, animatedZoomStyle]}>
@@ -180,7 +190,7 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
           ) : null}
         </View>
       </GestureDetector>
-    </View>
+    </GestureHandlerRootView>
   );
 });
 


### PR DESCRIPTION
## Summary

Closes #4320.

On Android, tapping holds while creating (or forking/editing) a climb did nothing — no paint, no long-press role sheet. iOS was unaffected. Independently flagged by @fallaciousreasoning on #4422 as a pre-existing bug on `main`.

## Root cause

`CreateDrawer` presents the editor inside `@expo/ui`'s native `BottomSheet` (`packages/mobile/src/components/create-climb/CreateDrawer.tsx`). On Android, that component hosts its RN children inside a Jetpack Compose `ModalBottomSheet` via a native `RNHostView` bridge (`@expo/ui/src/community/bottom-sheet/BottomSheet.android.tsx`) — a separate native surface that the app's single root-level `GestureHandlerRootView` (`app/_layout.tsx`) doesn't cover. `react-native-gesture-handler`'s `GestureDetector`s — every per-hold tap/long-press plus the pinch/pan zoom in `InteractiveCreateBoard.tsx` — never received touches as a result. This is a documented RNGH limitation for gesture handlers nested inside native modals/dialogs on Android.

I confirmed `InteractiveCreateBoard` is the *only* place in the mobile app that mixes RNGH `GestureDetector`s with `@expo/ui`'s native bottom sheet (grepped every other bottom-sheet consumer — none use `GestureDetector`), which is why nothing else in the app shows this symptom, and why it slipped through: the create-climb editor was rebuilt onto this native sheet relatively recently (#3167 migrated off `@gorhom/bottom-sheet`), and it's the first surface to combine it with multi-touch gesture content.

## Fix

`InteractiveCreateBoard` now wraps its root view in its own `GestureHandlerRootView`, re-establishing a touch-interception boundary inside the hosted native surface — the standard RNGH-recommended workaround for gesture handlers nested inside native modals.

## Release Notes

- Fixed: holds can be tapped again when creating or editing a climb on Android.

## Test plan

- `vp run typecheck:mobile` — clean.
- `vp test run --project mobile create-climb --reporter=agent` — 78/78 passing (all 15 create-climb test files).
- `vp run check:mobile-bundle` — Android bundle exports cleanly.
- `vp check` — clean (2 pre-existing, unrelated formatting issues in `docs/design/web-reposition/*.html`, not touched by this branch).
- **Could not drive a real Android emulator/device in this sandbox** — the local dev-client APK build fallback needs `sdkmanager --licenses`, which deadlocks indefinitely in this environment (the cached `rn-android-dev-*` release currently has no universal ABI, so it fell back to a local build). Needs a manual pass on a real Android device/emulator before merge: open create-climb, tap several holds at rest (should paint), long-press a hold (should open the role sheet), pinch-zoom and tap while zoomed (should still paint — exercises the existing `isPinchingSV`/`#2687` Android gating, which this change doesn't touch), and sanity-check iOS is unaffected. Full checklist in the PR's QA notes.