### PR TITLE
docs(web): classic-web rollback artifact and restore procedure

### DIFF
--- a/docs/web-reposition.md
+++ b/docs/web-reposition.md
@@ -166,3 +166,164 @@ Devices: a physical iPhone (iOS Safari) and a physical Android phone (Chrome).
 
 Sign-off on every box is the gate to start A5. If any fails, hold the delete and
 fix the sheet on expo-web first.
+
+## W-14 — the classic-web rollback artifact (#4368)
+
+W-16 deletes ~110k LOC of the interactive classic web app and swaps the root
+chrome in one commit, with no `?classic=1` runtime fallback (W-09 removed the
+last of that hatch). Reverting that under incident pressure with `git revert`
+means reintroducing that much code, re-mounting a provider tree, rebasing over
+every subsequent merge, and passing `check:i18n:orphans` — hours of work at the
+worst possible time.
+
+**The rollback is a deployable artifact, not a revert.** This is a locked
+decision: **no downstream PR (W-15/W-16/W-17 or anything after) may propose
+`git revert` as the recovery plan.** The recovery plan is always "promote
+`release/classic-web`" (below).
+
+### The artifact
+
+- **Tag `classic-web-last-good`** — an annotated tag at
+  `7bd5300d980f8c9a7b9c1f337ce57ec4d98d803f`, the last commit that serves the
+  full interactive classic web app (pre-W-15 front doors, W-13a merged).
+- **Branch `release/classic-web`** — pushed at the same commit, so it can be
+  fast-forwarded/read from without resolving a tag ref.
+
+Both were cut from `main` at that exact commit (verify with
+`git log --oneline -1 classic-web-last-good`). If `main` advances past this
+point before #4369 merges, **re-cut both** onto the new last-pre-W-15 commit —
+don't leave the artifact pointing at a stale, no-longer-last-good SHA:
+
+```bash
+git fetch origin main
+NEW_SHA=<last commit before #4369's merge, on main>
+git tag -f -a classic-web-last-good "$NEW_SHA" -m "Last commit serving the full interactive classic web app (pre-W-15 front doors).
+
+The web-reposition programme's rollback point: epic #4358, issue #4368 (W-14).
+The deployable artifact is branch release/classic-web at this same commit.
+Restore procedure: docs/web-reposition.md (W-14 section)."
+git push origin refs/tags/classic-web-last-good --force
+git branch -f release/classic-web "$NEW_SHA"
+git push origin release/classic-web --force
+```
+
+Update this section's SHA and the retention expiry date (below) after a re-cut,
+and re-run the local verification and preview dispatch described below against
+the new SHA before trusting the artifact again.
+
+### Restore procedure
+
+**Vercel's git auto-deploy is off** (`packages/web/vercel.json` →
+`git.deploymentEnabled: false`), so pushing `release/classic-web` — or any
+branch — deploys nothing by itself. **Production deploys only run from
+`.github/workflows/production-deploy.yml` on push to `main`.** That workflow
+also has a `workflow_dispatch` trigger, but every job that touches deploy
+secrets declares `environment: Production`, and the `Production` GitHub
+environment is scoped to the `main` branch — dispatching it from a non-`main`
+ref will not resolve those secrets (see `docs/branch-deploys.md`). **Do not
+attempt to dispatch `production-deploy.yml` from `release/classic-web`
+directly** — it will build but fail (or silently no-op) on every
+Production-environment step.
+
+So the honest restore path is a **tree-restore commit onto `main`**, landed
+through the normal PR + merge flow so it rides the existing pipeline:
+
+```bash
+git fetch origin
+git checkout -b restore/classic-web origin/main
+git read-tree -u --reset origin/release/classic-web
+git commit -m "revert: restore the classic interactive web app (rollback via release/classic-web)
+
+Refs #4368. This is the W-14 rollback artifact, not a git revert of the
+individual web-reposition commits — see docs/web-reposition.md."
+git push -u origin restore/classic-web
+```
+
+Then open a **fast-track PR** `restore/classic-web` → `main`. Merging it is a
+completely ordinary push to `main`: `production-deploy.yml`'s `detect-changes`
+job sees a normal file diff, `build-web`/`build-backend` build it, `migrate`
+gates it, and `deploy-web`/`deploy-production-backend` ship it to
+`www.boardsesh.com` — **no extra environment variables, no dashboard changes,
+no special alias.** The restore rides the same `Production` GitHub environment
+secrets (`VERCEL_TOKEN`, `DATABASE_URL`, `RAILWAY_TOKEN`, …) every other
+production release already uses. **Who can do it:** anyone with merge rights
+on `main` — no special access beyond the normal release path.
+
+**This command sequence was verified**, not just written down: run in a
+throwaway branch off `origin/main` with a dummy commit added first (to
+simulate `main` having drifted from the rollback point), `git read-tree -u
+--reset origin/release/classic-web` correctly staged the dummy file for
+deletion, and after committing, `git rev-parse HEAD^{tree}` and
+`git rev-parse origin/release/classic-web^{tree}` produced the **identical**
+tree SHA (`880b792ba7db3819c50c5d93d38a7b233dc86c10`) with an empty
+`git diff --stat` between the two — i.e. the restored tree is byte-identical
+to `release/classic-web`, regardless of what `main` looked like beforehand.
+
+### Preview verification
+
+The issue's gate is "the alias serves a working classic climb page with the
+queue drawer," proven by hand, not just a green build. The intended route is
+a PR preview at `{PRID}.preview.boardsesh.com` per `docs/branch-deploys.md`.
+**That pipeline is currently non-functional at the infrastructure level,
+independent of this artifact:**
+
+- `pull_request` triggers are commented out in `branch-deploy.yml`,
+  `branch-deploy-cleanup.yml`, and `branch-deploy-sweep.yml` (commit
+  `b2276e456`, "these workflows are currently broken and will be fixed
+  later"). Opening a PR does not auto-trigger a deploy.
+- The remaining `workflow_dispatch` trigger's `deploy` job requires
+  `runs-on: [self-hosted, homelab, ephemeral]`. `gh api
+repos/boardsesh/boardsesh/actions/runners` currently returns **zero
+  registered runners**. The last manual dispatch (2026-07-20, run
+  `29720371986`) shows `build-images` succeeding and `deploy` failing with
+  _"The job has exceeded the maximum execution time while awaiting a runner
+  for 24h0m0s."_
+
+**Preview PR #4427** (`preview/classic-web-rollback`, one empty commit on top
+of `release/classic-web`, draft, never-merge) is the standing verification
+route: whenever the homelab runner is healthy again, dispatch
+`branch-deploy.yml` with `pr_number=4427`, open
+`https://4427.preview.boardsesh.com`, and confirm the classic climb list page
+renders **with a working queue drawer** (open it, drag a climb in). Do this
+now to re-validate the artifact periodically, and do it again before ever
+promoting `release/classic-web` for a real incident, once the runner is back.
+
+Until the runner is restored, curl-level verification of the markup was done
+**locally** instead, against this exact commit (`vp run dev` in a worktree
+checked out at `classic-web-last-good`, against the shared dev Postgres):
+
+```bash
+curl -sk -o list-page.html -w "HTTP_CODE=%{http_code}\n" \
+  "https://localhost:3001/kilter/original/12x12-square/screw_bolt/40/list"
+# HTTP_CODE=200
+
+grep -o 'data-testid="bottom-bar-wrapper"' list-page.html   # 1 match
+grep -o 'data-testid="bottom-tab-bar"' list-page.html       # 1 match
+grep -o 'data-testid="queue-control-bar-shell"' list-page.html  # 1 match
+```
+
+All three mount markers from
+`packages/web/app/components/providers/persistent-session-wrapper.tsx`
+(`RootBottomBar`) are present — the persistent bottom-bar wrapper, the bottom
+tab bar, and the queue-control-bar shell (shown because a cookie-less request
+has no active queue yet, which is expected). This proves the classic chrome
+renders server-side at this commit; it does **not** prove the interactive
+queue drawer works in a real browser — that needs the preview-PR check above,
+and is left as an explicit unchecked item on the W-14 PR.
+
+### Retention — 90 days
+
+Cut **2026-08-14**. **Expires 2026-11-12.** Put a reminder on the epic
+(#4358) before that date:
+
+- If the web-reposition programme has shipped cleanly and nothing has needed
+  the rollback, **delete both** — `git push origin --delete release/classic-web`
+  and `git push origin --delete classic-web-last-good` (plus the local tag
+  with `git tag -d classic-web-last-good` if you have it checked out) — don't
+  let it silently rot as an ever-growing, never-reviewed fork of history.
+- If the programme is still mid-flight (W-16/W-17 not yet landed, or there's
+  active incident risk), **consciously re-cut** — same commands as the
+  "advances past this point" case above — and push the expiry another 90 days.
+
+Do not let this artifact linger unreviewed past its expiry date in either
+direction: it is either actively re-justified for another 90 days, or gone.

--- a/docs/web-reposition.md
+++ b/docs/web-reposition.md
@@ -207,6 +207,13 @@ git branch -f release/classic-web "$NEW_SHA"
 git push origin release/classic-web --force
 ```
 
+The re-cut rule is about commits that change what the web app serves. `main`
+gains automated `chore(changelog): refresh from merged PRs [skip ci]` commits
+that touch `CHANGELOG.md` and `packages/mobile/src/data/changelog.generated.json`
+only — it had already taken two of those within a day of the cut — and those
+don't make the artifact stale. Anything that touches `packages/web` or the
+packages it builds against does.
+
 Update this section's SHA and the retention expiry date (below) after a re-cut,
 and re-run the local verification and preview dispatch described below against
 the new SHA before trusting the artifact again.
@@ -226,75 +233,253 @@ directly** — it will build but fail (or silently no-op) on every
 Production-environment step.
 
 So the honest restore path is a **tree-restore commit onto `main`**, landed
-through the normal PR + merge flow so it rides the existing pipeline:
+through the normal PR + merge flow so it rides the existing pipeline. Build the
+commit with plumbing, so the tree is byte-identical by construction and no hook
+can rewrite it on the way in:
 
 ```bash
 git fetch origin
-git checkout -b restore/classic-web origin/main
-git read-tree -u --reset origin/release/classic-web
-git commit -m "revert: restore the classic interactive web app (rollback via release/classic-web)
+RESTORE=$(git commit-tree origin/release/classic-web^{tree} -p origin/main -m "revert: restore the classic interactive web app (rollback via release/classic-web)
 
 Refs #4368. This is the W-14 rollback artifact, not a git revert of the
-individual web-reposition commits — see docs/web-reposition.md."
+individual web-reposition commits — see docs/web-reposition.md.")
+git branch restore/classic-web "$RESTORE"
 git push -u origin restore/classic-web
+
+# Assert before opening the PR — must print nothing:
+git diff --stat restore/classic-web origin/release/classic-web
 ```
 
-Then open a **fast-track PR** `restore/classic-web` → `main`. Merging it is a
-completely ordinary push to `main`: `production-deploy.yml`'s `detect-changes`
-job sees a normal file diff, `build-web`/`build-backend` build it, `migrate`
-gates it, and `deploy-web`/`deploy-production-backend` ship it to
-`www.boardsesh.com` — **no extra environment variables, no dashboard changes,
-no special alias.** The restore rides the same `Production` GitHub environment
-secrets (`VERCEL_TOKEN`, `DATABASE_URL`, `RAILWAY_TOKEN`, …) every other
-production release already uses. **Who can do it:** anyone with merge rights
-on `main` — no special access beyond the normal release path.
+If you want the files in the working tree first (to read them, or to run the app
+locally before you ship it), the index form does the same job:
 
-**This command sequence was verified**, not just written down: run in a
+```bash
+git checkout -b restore/classic-web origin/main
+git read-tree -u --reset origin/release/classic-web
+git commit -m "revert: restore the classic interactive web app …"
+git diff --stat HEAD origin/release/classic-web   # must print nothing
+```
+
+— with one caveat: `git commit` runs this repo's pre-commit hook
+(`core.hooksPath=.vite-hooks`, `pre-commit` → `vp staged`, i.e.
+`vp check --fix`) across the **entire** staged restore. It is slow, it can abort
+the commit outright (it did when this sequence was re-run in a fresh worktree),
+and `--fix` rewrites staged files, which quietly breaks the byte-identical
+property. `git commit-tree` sidesteps all of that: it writes the commit straight
+from the artifact's tree object, touching no index and running no hook. Either
+way the `git diff --stat` assertion is part of the procedure, not a flourish —
+if it prints anything, the tree you are about to ship is not the artifact.
+
+Then open a **fast-track PR** `restore/classic-web` → `main`. Merging it is an
+ordinary push to `main`: `production-deploy.yml`'s `detect-changes` job sees a
+normal file diff, `build-web`/`build-backend` build it, `migrate` gates it, and
+`deploy-web`/`deploy-production-backend` ship it to `www.boardsesh.com`. It
+rides the same `Production` GitHub environment secrets (`VERCEL_TOKEN`,
+`DATABASE_URL`, `RAILWAY_TOKEN`, …) every other production release uses — no new
+secrets, no Vercel alias surgery. **Who can do it:** anyone with merge rights on
+`main`, no special access beyond the normal release path. The four subsections
+below are the parts that are _not_ ordinary; read them before merging.
+
+**The tree restore itself is verified**, not just written down: run in a
 throwaway branch off `origin/main` with a dummy commit added first (to
 simulate `main` having drifted from the rollback point), `git read-tree -u
 --reset origin/release/classic-web` correctly staged the dummy file for
-deletion, and after committing, `git rev-parse HEAD^{tree}` and
-`git rev-parse origin/release/classic-web^{tree}` produced the **identical**
-tree SHA (`880b792ba7db3819c50c5d93d38a7b233dc86c10`) with an empty
-`git diff --stat` between the two — i.e. the restored tree is byte-identical
-to `release/classic-web`, regardless of what `main` looked like beforehand.
+deletion, and the resulting commit's tree (`git rev-parse HEAD^{tree}`) came
+back **identical** to `git rev-parse origin/release/classic-web^{tree}` —
+`880b792ba7db3819c50c5d93d38a7b233dc86c10`, empty `git diff --stat` between the
+two — regardless of what `main` looked like beforehand. That property belongs to
+the restore **commit**; it does not survive the **merge** by itself.
 
-### Preview verification
+#### Re-verify at merge time — the merge is not the commit
 
-The issue's gate is "the alias serves a working classic climb page with the
-queue drawer," proven by hand, not just a green build. The intended route is
-a PR preview at `{PRID}.preview.boardsesh.com` per `docs/branch-deploys.md`.
-**That pipeline is currently non-functional at the infrastructure level,
-independent of this artifact:**
+Merging `restore/classic-web` is a three-way merge (squash included) whose base
+is `main` as it stood when you cut the branch. Anything that lands on `main`
+afterwards survives that merge with no conflict and no warning: the restore
+commit says nothing about files that didn't exist when it was written. Confirmed
+with `git merge-tree --write-tree` — add one file to `main` after cutting the
+restore branch and the merged tree contains it, so it differs from
+`release/classic-web` by exactly that file. `main` here takes automated
+`chore(changelog): refresh from merged PRs [skip ci]` pushes on top of normal
+merges, so the window is never empty; `main` had already moved past the cut
+point within a day of the cut.
 
-- `pull_request` triggers are commented out in `branch-deploy.yml`,
-  `branch-deploy-cleanup.yml`, and `branch-deploy-sweep.yml` (commit
-  `b2276e456`, "these workflows are currently broken and will be fixed
-  later"). Opening a PR does not auto-trigger a deploy.
-- The remaining `workflow_dispatch` trigger's `deploy` job requires
-  `runs-on: [self-hosted, homelab, ephemeral]`. `gh api
-repos/boardsesh/boardsesh/actions/runners` currently returns **zero
-  registered runners**. The last manual dispatch (2026-07-20, run
-  `29720371986`) shows `build-images` succeeding and `deploy` failing with
-  _"The job has exceeded the maximum execution time while awaiting a runner
-  for 24h0m0s."_
+A W-16-era file that only exists post-cut — a new expo-web front-door route,
+say — would then ship next to the restored classic `layout.tsx`: neither
+version, a red build at best and green-but-wrong at worst.
 
-**Preview PR #4427** (`preview/classic-web-rollback`, one empty commit on top
-of `release/classic-web`, draft, never-merge) is the standing verification
-route: whenever the homelab runner is healthy again, dispatch
-`branch-deploy.yml` with `pr_number=4427`, open
-`https://4427.preview.boardsesh.com`, and confirm the classic climb list page
-renders **with a working queue drawer** (open it, drag a climb in). Do this
-now to re-validate the artifact periodically, and do it again before ever
-promoting `release/classic-web` for a real incident, once the runner is back.
-
-Until the runner is restored, curl-level verification of the markup was done
-**locally** instead, against this exact commit (`vp run dev` in a worktree
-checked out at `classic-web-last-good`, against the shared dev Postgres):
+**The invariant to hold at merge time: `restore/classic-web`'s parent is the
+current `main` tip**, i.e. the PR merges as a fast-forward. Immediately before
+merging:
 
 ```bash
-curl -sk -o list-page.html -w "HTTP_CODE=%{http_code}\n" \
-  "https://localhost:3001/kilter/original/12x12-square/screw_bolt/40/list"
+git fetch origin
+git merge-base --is-ancestor origin/main restore/classic-web && echo "fast-forward OK"
+```
+
+If that fails, rebuild the branch — **`git rebase` does not re-restore the
+tree**, it replays the old diff and keeps the post-cut files:
+
+```bash
+git branch -f restore/classic-web \
+  "$(git commit-tree origin/release/classic-web^{tree} -p origin/main -m 'revert: restore the classic interactive web app (rollback via release/classic-web)')"
+git push --force-with-lease origin restore/classic-web
+git diff --stat restore/classic-web origin/release/classic-web   # must print nothing
+```
+
+#### The blast radius is the whole repo, not just the web app
+
+`git read-tree` restores **every path**, not `packages/web`. That sweeps up the
+paths the mobile pipeline watches — `packages/mobile/**`, `packages/shared/**`,
+`packages/shared-schema/**`, `packages/board-constants/**`, `package.json`,
+`bun.lock`, `patches/**` — and each of those is a push-to-`main` trigger for:
+
+- `mobile-ota-production.yml` — publishes a **production OTA** to every install
+  whose native fingerprint still matches, i.e. the restore merge republishes the
+  artifact's (by then old) JS bundle to the live native fleet.
+- `ios-testflight-rn.yml` and `android-apk-rn.yml` — native builds off the old
+  tree.
+- `production-deploy.yml`'s `deploy-app-web` job — its `app_changed` list is
+  `packages/mobile/*`, `packages/shared/*`, `packages/shared-schema/*`,
+  `scripts/build-expo-web-export.sh`, and the two CF Pages host files — so it
+  rebuilds and ships `app.boardsesh.com`, the expo-web app, off the old tree too.
+
+Not hypothetical: `main` already differs from `release/classic-web` in
+`packages/mobile/src/data/changelog.generated.json`, so a whole-tree restore
+today already touches `packages/mobile/**` and fires all four. The repo has form
+here — a parity-restoring revert once shipped a whole drift backlog to
+production (2026-07-17).
+
+Pick one before merging:
+
+1. **Scope the restore to the web surface** — the default when the incident is
+   web-only. `packages/web` appears in none of the mobile trigger lists. Delete
+   the current subtree first: a bare `git checkout <ref> -- packages/web`
+   restores the artifact's files but leaves behind any file W-15/W-16 _added_
+   under `packages/web`, which is how you get a tree that is neither version.
+
+   ```bash
+   git checkout -b restore/classic-web origin/main
+   git rm -rq packages/web
+   git checkout origin/release/classic-web -- packages/web
+   git diff --stat origin/release/classic-web -- packages/web   # must print nothing
+   ```
+
+   Verified the same way as the whole-tree restore: with a dummy
+   `packages/web/app/AFTER-CUT.ts` committed on top of `main`, the sequence
+   above removed it and left `packages/web` byte-identical to the artifact
+   (empty `git diff --stat`).
+
+   If the web build then fails against a drifted shared package, add that
+   package specifically (same delete-then-restore shape) and re-read the list
+   above: anything under `packages/shared*` puts the mobile workflows back in
+   play.
+
+2. **Whole-tree restore with the mobile side held.** Before merging,
+   `gh workflow disable mobile-ota-production.yml` (and `ios-testflight-rn.yml`,
+   `android-apk-rn.yml`), and set the repo variable `APP_WEB_DEPLOY_HOLD` —
+   `deploy-app-web` skips while it is non-empty, and `notify-app-web-held` posts
+   a reminder so the hold can't be silently forgotten. Re-enable all four and
+   publish forward once the web incident is closed.
+
+#### A pinned Instant Rollback stops the restore reaching www
+
+Instant Rollback is the first-line incident mitigation
+(`docs/branch-deploys.md` § "Instant Rollback interaction"), so the realistic
+order of events is: someone pins production to an older deployment, _then_ the
+restore PR merges. When `check-rollback` sees an active rollback, `deploy-web`
+runs `vercel deploy --prebuilt --prod --skip-domain` — uploaded, not assigned to
+the production domain — `deploy-production-backend` pushes the image to GHCR
+without redeploying Railway, and the post-deploy smoke against www is skipped.
+Every job goes green. The only signal is the `notify-no-promote` Discord
+message.
+
+Clear the Instant Rollback in the Vercel dashboard before merging the restore
+(or promote the staged deployment afterwards), and confirm www is actually
+serving it. A green pipeline is not proof here.
+
+#### The restore rolls back code, never the database
+
+`migrate` runs `db:migrate` forward only; nothing un-applies a migration. The
+`VERIFY_MIGRATION_JOURNAL=1` gate only fails when a migration file exists but is
+missing from the ledger (`findUnappliedMigrations`,
+`packages/db/scripts/migration-journal.ts`), so a restored tree with _fewer_
+migrations than the database passes it silently. Harmless for expand-phase
+migrations (new columns the classic code ignores); fatal for a contract-phase
+one — a column dropped or renamed after the cut is still gone after the restore,
+and classic code that reads it breaks.
+
+While this artifact is the rollback plan, every production migration must stay
+backward-compatible with `release/classic-web` — the same expand/contract rule
+`docs/branch-deploys.md` already states for Instant Rollback. If a
+contract-phase migration has landed since the cut, the restore needs a paired
+forward migration that re-adds what it removed: write that before the incident,
+not during it.
+
+### Preview verification — the alias gate is UNMET
+
+The issue's gate is "the alias serves a working classic climb page with the
+queue drawer," proven by hand, not just a green build. **That gate is not met**,
+and two independent pieces of infrastructure have to come back before it can be
+— the runner is only half of it:
+
+1. **No runner.** `pull_request` triggers are commented out in
+   `branch-deploy.yml`, `branch-deploy-cleanup.yml`, and
+   `branch-deploy-sweep.yml` (commit `b2276e456`, "these workflows are currently
+   broken and will be fixed later"), so opening a PR auto-triggers nothing. The
+   remaining `workflow_dispatch` path's `deploy` job wants
+   `runs-on: [self-hosted, homelab, ephemeral]`, and
+   `gh api repos/boardsesh/boardsesh/actions/runners` returns `total_count: 0`.
+   The last real dispatch before this work (2026-07-20, run `29720371986`) shows
+   `build-images` succeeding and `deploy` giving up after 24h "awaiting a
+   runner".
+2. **No DNS.** The wildcard `*.preview.boardsesh.com` CNAME → Cloudflare Tunnel
+   that `docs/branch-deploys.md` § 2.2 describes does not resolve at all:
+   `getent hosts 4427.preview.boardsesh.com` returns nothing (as does any other
+   `*.preview` name), while `www.boardsesh.com` resolves and answers 200 from
+   the same shell. Even with a healthy runner, the Traefik `Host()` rule the
+   deploy job writes has nothing routing to it until the record and the tunnel
+   are back.
+
+**Preview PR #4427** (`preview/classic-web-rollback`, one empty commit on top of
+`release/classic-web`, draft, never-merge) is the standing verification route
+once both are fixed. Dispatch it **against the branch**, not just the PR number:
+
+```bash
+gh workflow run branch-deploy.yml \
+  --ref preview/classic-web-rollback \
+  -f pr_number=4427
+```
+
+`--ref` is what decides which code gets built. `build-images` checks out with a
+bare `- uses: actions/checkout@v6` (no `ref:`), so on `workflow_dispatch` it
+builds the ref the workflow was dispatched against; `pr_number` only names the
+GHCR image tag (`boardsesh-web:pr-4427`), the Traefik `Host()` rule
+(`4427.preview.boardsesh.com`), and the `BASE_URL` / `NEXT_PUBLIC_WS_URL` build
+args. Dispatch from the default branch with `pr_number=4427` and you build
+`main` and serve it at the 4427 hostname — which is exactly what the first
+attempt here did (run `31797731863`: `headBranch: main`, `headSha: 31ccf56a6`).
+
+So confirm which build you are looking at before believing anything:
+
+```bash
+curl -s "https://4427.preview.boardsesh.com/kilter/original/12x12-square/screw_bolt/40/list" \
+  | grep -c 'data-testid="queue-control-bar-shell"'   # 1 = classic chrome, 0 = wrong build
+```
+
+Only then do the part that needs a human: open the page, open the queue drawer,
+drag a climb in. Re-run this periodically to keep the artifact honest, and again
+before ever promoting `release/classic-web` for a real incident.
+
+Until both prerequisites are back, verification of this commit is markup-level
+and local — `vp run dev` in a worktree checked out at `classic-web-last-good`,
+against the shared dev Postgres:
+
+```bash
+# Use whatever host/port `[dev]` prints on startup. The default is
+# http://localhost:3000; the run recorded here was on a Tailscale-TLS dev
+# server that had fallen through to 3001.
+curl -s -o list-page.html -w "HTTP_CODE=%{http_code}\n" \
+  "http://localhost:3000/kilter/original/12x12-square/screw_bolt/40/list"
 # HTTP_CODE=200
 
 grep -o 'data-testid="bottom-bar-wrapper"' list-page.html   # 1 match
@@ -307,9 +492,24 @@ All three mount markers from
 (`RootBottomBar`) are present — the persistent bottom-bar wrapper, the bottom
 tab bar, and the queue-control-bar shell (shown because a cookie-less request
 has no active queue yet, which is expected). This proves the classic chrome
-renders server-side at this commit; it does **not** prove the interactive
-queue drawer works in a real browser — that needs the preview-PR check above,
-and is left as an explicit unchecked item on the W-14 PR.
+renders server-side at this commit. It proves nothing about the interactive
+drawer.
+
+**The drawer-level check that can run today**, with no preview infrastructure,
+is the repo's own Playwright suite against a local checkout of the artifact —
+`packages/web/e2e/queue-persistence.spec.ts` double-clicks a climb card, waits
+for `[data-testid="queue-control-bar"]`, and asserts the queue survives
+navigation:
+
+```bash
+git worktree add ../classic-check classic-web-last-good
+cd ../classic-check && vp run test:e2e
+```
+
+Run that before promoting the artifact for a real incident. It is not a
+substitute for the alias gate — it says nothing about the image building or
+Traefik routing to it — but it is the only browser-level evidence available
+while the runner and the DNS record are both down.
 
 ### Retention — 90 days
 


### PR DESCRIPTION
## Summary

Part of #4358. Closes #4368.

W-14 documents the classic-web rollback artifact end to end in `docs/web-reposition.md`, so recovering from a bad W-15/W-16/W-17 release never means `git revert`ing ~110k LOC under incident pressure.

- **Tag `classic-web-last-good`** and **branch `release/classic-web`**, both at `7bd5300d980f8c9a7b9c1f337ce57ec4d98d803f` (the W-13a merge — last commit serving the fully-unwired classic interactive web app).
- **Restore procedure**, verified for real: build the restore with `git commit-tree` from the artifact's tree object, assert `git diff --stat` against `release/classic-web` is empty, land it through a fast-track PR to `main` so it rides `production-deploy.yml`.
- **Never-merge preview PR #4427** (`preview/classic-web-rollback`) — the standing verification route for re-checking the artifact still deploys, once the preview infrastructure is back.
- **90-day retention**: cut 2026-08-14, expires **2026-11-12**, with exact re-cut and teardown commands.
- The **locked decision** that no downstream PR may propose `git revert` as the recovery plan.

## What the QA review changed (second commit)

The first draft of the runbook was correct about the tree restore and wrong about everything downstream of it. Each fix below is verified against the workflows or against git:

- **The commit no longer goes through the pre-commit hook.** `core.hooksPath=.vite-hooks` → `pre-commit` = `vp staged` (`vp check --fix`) runs across the whole staged restore and `--fix` rewrites staged files, which silently breaks the byte-identical property. The documented sequence now uses `git commit-tree` (no index, no hook, tree identical by construction), keeps the `git read-tree` form as the "I want the files locally" variant, and makes the `git diff --stat` assertion part of the procedure.
- **The merge is not the commit.** The byte-identical property belongs to the restore commit; the merge is a three-way merge whose base is `main` at branch-cut time, so anything landing on `main` afterwards survives with no conflict. Shown with `git merge-tree --write-tree`: a file added to `main` after the cut is present in the merged tree. The doc now states the fast-forward invariant (`git merge-base --is-ancestor origin/main restore/classic-web`), the rebuild command, and that `git rebase` does **not** re-restore the tree.
- **A whole-tree restore is not web-only.** It reverts `packages/mobile/**`, `packages/shared/**`, `packages/shared-schema/**`, `package.json`, `bun.lock`, `patches/**` — the push-to-`main` trigger set for `mobile-ota-production.yml` (a production OTA to the live native fleet), `ios-testflight-rn.yml`, `android-apk-rn.yml`, and `production-deploy.yml`'s `deploy-app-web` (app.boardsesh.com). `main` already differs from the artifact in `packages/mobile/src/data/changelog.generated.json`, so this fires **today**. The doc adds a web-scoped restore (`git rm -rq packages/web` then `git checkout <artifact> -- packages/web`, verified to remove a simulated post-cut file and land byte-identical) and, for the whole-tree case, the hold: disable the three mobile workflows and set `APP_WEB_DEPLOY_HOLD`.
- **A pinned Vercel Instant Rollback swallows the restore.** `check-rollback` makes `deploy-web` run `vercel deploy --prebuilt --prod --skip-domain` and `deploy-production-backend` skip the Railway redeploy; both jobs go green, the www smoke is skipped, and the only signal is the `notify-no-promote` Discord message. Instant Rollback is the documented first-line mitigation, so this is the *likely* incident state, not an edge case. Clear it before merging, or promote the staged deployment after.
- **The restore rolls back code, never the database.** `migrate` only moves forward, and `VERIFY_MIGRATION_JOURNAL=1` only catches migrations present in the folder but missing from the ledger (`findUnappliedMigrations`), so a restored tree with *fewer* migrations passes silently. Expand-phase migrations are fine; a contract-phase one is fatal and needs a paired forward migration written in advance.
- The "no extra environment variables, no dashboard changes, no special alias" claim is gone — it was false in exactly the state a rollback happens in.

## Preview verification: the alias gate is UNMET

Two independent prerequisites are down, not one:

1. **No runner.** `pull_request` triggers are commented out repo-wide in `branch-deploy.yml` (commit `b2276e456`), and the `workflow_dispatch` path's `deploy` job needs `[self-hosted, homelab, ephemeral]` — `gh api repos/boardsesh/boardsesh/actions/runners` returns `total_count: 0`.
2. **No DNS.** The wildcard `*.preview.boardsesh.com` CNAME → Cloudflare Tunnel described in `docs/branch-deploys.md` § 2.2 does not resolve: `getent hosts 4427.preview.boardsesh.com` returns nothing (so does any other `*.preview` name), while `www.boardsesh.com` resolves and answers 200 from the same shell.

**The dispatch instruction was also wrong and is fixed.** `branch-deploy.yml`'s `build-images` checks out with a bare `- uses: actions/checkout@v6` (no `ref:`), so on `workflow_dispatch` it builds **the ref it was dispatched against**; `pr_number` only names the GHCR image tag, the Traefik `Host()` rule, and the `BASE_URL`/`NEXT_PUBLIC_WS_URL` build args. My dispatch of the original procedure (run [`31797731863`](https://github.com/boardsesh/boardsesh/actions/runs/31797731863)) reports `headBranch: main`, `headSha: 31ccf56a6` — it built `main` and would have served `main` at `4427.preview.boardsesh.com`. The runbook now uses `gh workflow run branch-deploy.yml --ref preview/classic-web-rollback -f pr_number=4427` and adds a post-deploy `grep` for `data-testid="queue-control-bar-shell"` so a mis-targeted dispatch is caught. (That run is still sitting `queued`; a cancel request was submitted but GitHub keeps it queued while the `deploy` job waits for a runner that never arrives. It holds nothing up.)

## Local verification (what actually proves what)

Ran `vp run dev` in a worktree at `classic-web-last-good` (`7bd5300d9`) against the shared dev Postgres and curled the classic climb list page. Use whatever host/port `[dev]` prints — the default is `http://localhost:3000`; the recorded run happened to be on a Tailscale-TLS dev server that had fallen through to 3001, which the doc now says explicitly instead of pinning `https://localhost:3001`.

```bash
curl -s -o list-page.html -w "HTTP_CODE=%{http_code}\n" \
  "http://localhost:3000/kilter/original/12x12-square/screw_bolt/40/list"
# HTTP_CODE=200

grep -o 'data-testid="bottom-bar-wrapper"' list-page.html      # 1 match
grep -o 'data-testid="bottom-tab-bar"' list-page.html          # 1 match
grep -o 'data-testid="queue-control-bar-shell"' list-page.html # 1 match
```

All three mount markers from `PersistentSessionWrapper`'s `RootBottomBar` are present in the server-rendered HTML — the classic chrome renders at this commit. It proves nothing about the interactive drawer. The doc names the drawer-level check that **can** run today without any preview infrastructure: `packages/web/e2e/queue-persistence.spec.ts` (double-clicks a climb card, waits for `[data-testid="queue-control-bar"]`, asserts the queue survives navigation) via `vp run test:e2e` in a worktree at `classic-web-last-good`.

- [ ] Manual (orchestrator/Marco): preview serves the classic climb page with the working queue drawer (screenshot) — **blocked on the runner and the DNS record above**

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check` — clean on the changed file. Two pre-existing failures remain in `docs/design/web-reposition/*.html` from merged commit `19268ee78`; untouched here.
- `vp run typecheck` — passed.
- `vp test run --reporter=agent --project web` — 498 test files, 6050 tests, all passed.
- `git read-tree` restore dry run against a drifted `main`: tree byte-identical to `release/classic-web` (`880b792ba7db3819c50c5d93d38a7b233dc86c10`).
- `git merge-tree --write-tree` drift check: a post-cut file survives the merge — the basis for the fast-forward invariant now in the doc.
- Web-scoped restore (`git rm -rq packages/web` + `git checkout <artifact> -- packages/web`) verified against a simulated post-cut `packages/web/app/AFTER-CUT.ts`: file removed, `git diff --stat` against the artifact empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6Ur37Pg6Ro9kyFxUr8r97
