### PR TITLE
fix(web): playlists loading and empty states, home rail grid clamp

### DIFF
--- a/packages/shared/i18n/locales/de/playlists.json
+++ b/packages/shared/i18n/locales/de/playlists.json
@@ -88,7 +88,8 @@
     "empty": {
       "title": "Noch keine Playlists",
       "description": "Pack deine Projekte und Lieblingsboulder in eine Playlist, dann findest du sie schnell wieder.",
-      "createCta": "Playlist erstellen"
+      "createCta": "Playlist erstellen",
+      "cta": "Playlist in der App erstellen"
     },
     "createFab": {
       "ariaLabel": "Playlist erstellen"

--- a/packages/shared/i18n/locales/en-US/playlists.json
+++ b/packages/shared/i18n/locales/en-US/playlists.json
@@ -88,7 +88,8 @@
     "empty": {
       "title": "No playlists yet",
       "description": "Save your projects and go-to sends into a playlist so they're easy to find.",
-      "createCta": "Create playlist"
+      "createCta": "Create playlist",
+      "cta": "Build a playlist in the app"
     },
     "createFab": {
       "ariaLabel": "Create playlist"

--- a/packages/shared/i18n/locales/es/playlists.json
+++ b/packages/shared/i18n/locales/es/playlists.json
@@ -88,7 +88,8 @@
     "empty": {
       "title": "Aún no tienes playlists",
       "description": "Guarda tus proyectos y tus bloques favoritos en una playlist para tenerlos a mano.",
-      "createCta": "Crear playlist"
+      "createCta": "Crear playlist",
+      "cta": "Crear playlist en la app"
     },
     "createFab": {
       "ariaLabel": "Crear playlist"

--- a/packages/shared/i18n/locales/fr/playlists.json
+++ b/packages/shared/i18n/locales/fr/playlists.json
@@ -88,7 +88,8 @@
     "empty": {
       "title": "Aucune playlist pour l'instant",
       "description": "Enregistre tes projets et tes voies préférées dans une playlist pour les retrouver vite.",
-      "createCta": "Créer une playlist"
+      "createCta": "Créer une playlist",
+      "cta": "Créer une playlist dans l'app"
     },
     "createFab": {
       "ariaLabel": "Créer une playlist"

--- a/packages/web/app/components/board-entity/popular-board-rail.module.css
+++ b/packages/web/app/components/board-entity/popular-board-rail.module.css
@@ -1,3 +1,8 @@
+/* Matches the inset the homepage's other section labels use (the "Recent
+   beta" and "Get started" headers in home-page-content.tsx / home-recent-
+   beta-section.tsx both set `px: 0.5`, i.e. --spacing-1 on both sides) so all
+   three line up under the same left edge instead of drifting by a stray
+   magic number. */
 .title {
   color: var(--neutral-400);
   text-transform: uppercase;
@@ -5,14 +10,23 @@
   font-size: var(--font-size-xs);
   font-weight: 600;
   margin-bottom: var(--spacing-2);
-  padding-left: 2px;
+  padding: 0 var(--spacing-1);
 }
 
 /* An intentional grid, not a scroll rail: everything is on screen and in the
-   server HTML, so there is nothing to scroll to reveal. */
+   server HTML, so there is nothing to scroll to reveal.
+   `minmax(120px, 160px)` — not `1fr` — caps each column's width: `auto-fill`
+   already keeps the *count* of columns responsive (2 columns at 390px, 4 at
+   768px, 8 at 1440px, reasoned through the repeat-count algorithm at all
+   three), but an unbounded `1fr` upper bound lets the last, partially full
+   row stretch its cards to fill whatever's left — a handful of popular
+   configs on a wide viewport would otherwise blow up into oversized tiles.
+   160px keeps a card roughly thumbnail-sized at any width; the leftover
+   space past the last column is a trailing gutter instead of stretched
+   cards. */
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(120px, 160px));
   gap: var(--spacing-3);
 }
 

--- a/packages/web/app/components/board-entity/popular-board-rail.module.css
+++ b/packages/web/app/components/board-entity/popular-board-rail.module.css
@@ -15,23 +15,35 @@
 
 /* An intentional grid, not a scroll rail: everything is on screen and in the
    server HTML, so there is nothing to scroll to reveal.
-   `minmax(120px, 160px)` — not `1fr` — caps each column's width: `auto-fill`
-   already keeps the *count* of columns responsive (2 columns at 390px, 4 at
-   768px, 8 at 1440px, reasoned through the repeat-count algorithm at all
-   three), but an unbounded `1fr` upper bound lets the last, partially full
-   row stretch its cards to fill whatever's left — a handful of popular
-   configs on a wide viewport would otherwise blow up into oversized tiles.
-   160px keeps a card roughly thumbnail-sized at any width; the leftover
-   space past the last column is a trailing gutter instead of stretched
-   cards. */
+
+   `auto-fill` keeps the column *count* responsive on its own. What needed
+   bounding is the card: with bare `minmax(120px, 1fr)` columns the same board
+   thumbnail measured 184px on a 412px phone (2 columns) and 124.7px at 430px
+   (3 columns) — the narrower screen drew the bigger tile.
+
+   Capping the *column* at `minmax(120px, 160px)` fixes the size but stops the
+   grid filling its container: every column is exactly 160px, so all the
+   leftover piles up past the last one (measured 144px of dead space at a
+   1024px viewport, 66px at 430px) and the rail stops short of the page gutter
+   its sibling homepage sections run to. So cap the *card* instead and leave
+   the columns on `1fr`: the grid still fills the container, and slack only
+   shows up where a card has hit its 160px ceiling.
+
+   Measured in Chromium at 375/390/412/430/768/1024/1280/1440 (homepage box
+   model, main px: 2): card 124.7-160px, and at most 12px of slack per edge —
+   against 124.7-184px unbounded, or 144px dead at one edge when the column is
+   what's capped. */
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(120px, 160px));
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
   gap: var(--spacing-3);
+  justify-items: center;
 }
 
 .card {
   display: block;
+  width: 100%;
+  max-width: 160px;
   color: inherit;
   text-decoration: none;
 }

--- a/packages/web/app/components/playlists/playlist-card-skeleton.tsx
+++ b/packages/web/app/components/playlists/playlist-card-skeleton.tsx
@@ -24,8 +24,15 @@ export default function PlaylistCardSkeleton({ count = 4 }: PlaylistCardSkeleton
   return (
     <>
       {Array.from({ length: count }).map((_, index) => (
-        <div key={index} className={styles.cardCompact}>
-          <Skeleton variant="rounded" animation="wave" className={styles.cardCompactSquare} />
+        <div key={index} className={styles.skeletonCompact} data-testid="playlist-card-skeleton">
+          {/* 48x48 as props, not as a class: MUI's own Skeleton style sets
+              `height: 1.2em`, and a CSS-module rule only beats it if the module
+              stylesheet happens to land after emotion's — nothing guarantees
+              that (the app mounts AppRouterCacheProvider without
+              `enableCssLayer`). Props render as inline styles, so the square
+              holds wherever the cascade falls. Same call shape as
+              library/playlist-card-grid.tsx. */}
+          <Skeleton variant="rounded" animation="wave" width={48} height={48} />
           <div className={styles.cardCompactInfo}>
             <Skeleton variant="text" animation="wave" width="70%" />
             <Skeleton variant="text" animation="wave" width="40%" />

--- a/packages/web/app/components/playlists/playlist-card-skeleton.tsx
+++ b/packages/web/app/components/playlists/playlist-card-skeleton.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import React from 'react';
+import Skeleton from '@mui/material/Skeleton';
+import styles from './playlist-link-card.module.css';
+
+type PlaylistCardSkeletonProps = {
+  /** Number of skeleton cards to render. Matches the pre-W-13
+   *  `PlaylistScrollSection`'s `ScrollSkeletons` default of 4. */
+  count?: number;
+};
+
+/**
+ * Placeholder cards rendered inside `.cardGrid` while a section's playlists
+ * are still loading. Same compact shape as `PlaylistLinkCard` — a square plus
+ * two text lines — so nothing shifts once the real cards mount.
+ *
+ * `/playlists` lost this mounted loading state when W-13 replaced the
+ * horizontal-scroll `PlaylistScrollSection` (which had its own skeleton) with
+ * the plain static grid; this restores the same reserved-space behaviour for
+ * the grid layout.
+ */
+export default function PlaylistCardSkeleton({ count = 4 }: PlaylistCardSkeletonProps) {
+  return (
+    <>
+      {Array.from({ length: count }).map((_, index) => (
+        <div key={index} className={styles.cardCompact}>
+          <Skeleton variant="rounded" animation="wave" className={styles.cardCompactSquare} />
+          <div className={styles.cardCompactInfo}>
+            <Skeleton variant="text" animation="wave" width="70%" />
+            <Skeleton variant="text" animation="wave" width="40%" />
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}

--- a/packages/web/app/components/playlists/playlist-link-card.module.css
+++ b/packages/web/app/components/playlists/playlist-link-card.module.css
@@ -48,6 +48,21 @@
   padding-right: var(--spacing-2);
 }
 
+/* Loading placeholder for the same compact card — the card's box minus every
+   pointer affordance, so a placeholder never highlights on hover or offers a
+   click target. Same source as the card above: library.module.css's
+   `.skeletonCompact`. Geometry is deliberately identical to `.cardCompact`
+   (48px square, same info column) so swapping in the real card shifts
+   nothing. */
+.skeletonCompact {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  background-color: var(--semantic-surface);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
 .cardCompactName {
   font-size: 13px;
   font-weight: 500;

--- a/packages/web/app/components/playlists/playlist-link-card.tsx
+++ b/packages/web/app/components/playlists/playlist-link-card.tsx
@@ -25,7 +25,6 @@ export type PlaylistLinkCardProps = {
   icon?: string;
   href: string;
   index?: number;
-  isLikedClimbs?: boolean;
   fetchPriority?: 'high' | 'low' | 'auto';
 };
 
@@ -38,7 +37,6 @@ function PlaylistLinkCard({
   icon,
   href,
   index = 0,
-  isLikedClimbs,
   fetchPriority,
 }: PlaylistLinkCardProps) {
   const { t } = useTranslation('playlists');
@@ -54,7 +52,6 @@ function PlaylistLinkCard({
           layoutId={layoutId}
           color={color}
           icon={icon}
-          isLikedClimbs={isLikedClimbs}
           index={index}
           className={previewStyles.previewCompact}
           fetchPriority={fetchPriority}

--- a/packages/web/app/playlists/__tests__/library-page-content.test.tsx
+++ b/packages/web/app/playlists/__tests__/library-page-content.test.tsx
@@ -198,9 +198,9 @@ describe('LibraryPageContent read-only directory', () => {
       />,
     );
 
-    // The empty-owned-playlists state also renders here (its app-handoff CTA
-    // is covered by its own test above) — filter down to the playlist-detail
-    // anchors this test is actually about.
+    // The empty-owned-playlists state also renders here — its app-handoff CTA
+    // is covered by 'gives the empty state an app-handoff CTA, not a dead
+    // end'. Filter down to the playlist-detail anchors this test is about.
     const playlistHrefs = screen
       .getAllByRole('link')
       .map((link) => link.getAttribute('href'))
@@ -266,6 +266,9 @@ describe('LibraryPageContent read-only directory', () => {
     render(<LibraryPageContent initialMyBoards={[]} initialPlaylists={null} initialDiscoverPlaylists={NO_DISCOVER} />);
 
     expect(screen.getByText(tFromCatalog('playlists', 'library.sections.jumpBackIn'))).toBeTruthy();
+    // The heading alone would still render if the placeholder went missing, so
+    // count the placeholder cards themselves.
+    expect(screen.getAllByTestId('playlist-card-skeleton')).toHaveLength(4);
     // No real cards (anchors) have loaded yet — only skeleton placeholders.
     expect(screen.queryAllByRole('link')).toHaveLength(0);
   });
@@ -281,6 +284,7 @@ describe('LibraryPageContent read-only directory', () => {
     );
 
     expect(screen.getByRole('link').getAttribute('href')).toBe('/playlists/aaa');
+    expect(screen.queryAllByTestId('playlist-card-skeleton')).toHaveLength(0);
   });
 
   it('shows a Discover loading placeholder while nothing has arrived yet', () => {
@@ -294,6 +298,9 @@ describe('LibraryPageContent read-only directory', () => {
     );
 
     expect(screen.getByText(tFromCatalog('playlists', 'library.sections.discover'))).toBeTruthy();
+    // Jump Back In has already loaded, so every placeholder on the page belongs
+    // to Discover — one full set of four.
+    expect(screen.getAllByTestId('playlist-card-skeleton')).toHaveLength(4);
   });
 
   it('still offers the sign-in banner to signed-out visitors and opens the auth modal', async () => {

--- a/packages/web/app/playlists/__tests__/library-page-content.test.tsx
+++ b/packages/web/app/playlists/__tests__/library-page-content.test.tsx
@@ -5,6 +5,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { createTestQueryClient } from '@/app/test-utils/test-providers';
 import { PlaylistsAdapterTestProvider } from '@/app/test-utils/playlists-adapter-wrapper';
 import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import { APP_URL } from '@/app/lib/app-origin';
 import LibraryPageContent from '../library-page-content';
 import type { Playlist, DiscoverablePlaylist } from '@boardsesh/graphql/operations/playlists';
 import type { UserBoard } from '@boardsesh/shared-schema';
@@ -69,10 +70,11 @@ vi.mock('@/app/hooks/use-my-boards', () => ({
 // can be exercised without standing up the whole GraphQL hook.
 const mockLoadMorePlaylists = vi.fn();
 let mockPlaylistsHasMore = false;
+let mockPlaylistsLoading = false;
 vi.mock('@/app/hooks/use-user-playlists', () => ({
   useUserPlaylists: ({ initialData }: { initialData?: Playlist[] }) => ({
     playlists: initialData ?? [],
-    isLoading: false,
+    isLoading: mockPlaylistsLoading,
     isLoadingMore: false,
     hasMore: mockPlaylistsHasMore,
     hasError: false,
@@ -85,10 +87,12 @@ vi.mock('@/app/hooks/use-pinned-playlists', () => ({
   usePinnedPlaylists: () => ({ pinned: [], isLoading: false }),
 }));
 
+let mockDiscoverLoading = false;
 vi.mock('@/app/hooks/use-discover-playlists', () => ({
   useDiscoverPlaylists: ({ initialData }: { initialData?: { popular: DiscoverablePlaylist[] } }) => ({
     popular: initialData?.popular ?? [],
     recent: [],
+    isLoading: mockDiscoverLoading,
     isLoadingMore: false,
     hasMore: false,
     loadMore: vi.fn(),
@@ -145,6 +149,8 @@ const NO_DISCOVER = { popular: [], recent: [], popularHasMore: false, recentHasM
 beforeEach(() => {
   vi.clearAllMocks();
   mockPlaylistsHasMore = false;
+  mockPlaylistsLoading = false;
+  mockDiscoverLoading = false;
   mockSession.data = { user: { id: 'user-1' } };
   mockSession.status = 'authenticated';
 });
@@ -192,8 +198,14 @@ describe('LibraryPageContent read-only directory', () => {
       />,
     );
 
-    const hrefs = screen.getAllByRole('link').map((link) => link.getAttribute('href'));
-    expect(hrefs).toEqual(['/playlists/pub-1']);
+    // The empty-owned-playlists state also renders here (its app-handoff CTA
+    // is covered by its own test above) — filter down to the playlist-detail
+    // anchors this test is actually about.
+    const playlistHrefs = screen
+      .getAllByRole('link')
+      .map((link) => link.getAttribute('href'))
+      .filter((href): href is string => href !== null && href.startsWith('/playlists/'));
+    expect(playlistHrefs).toEqual(['/playlists/pub-1']);
   });
 
   it('shows "Show more" only when another page exists, and calls loadMore', () => {
@@ -232,6 +244,56 @@ describe('LibraryPageContent read-only directory', () => {
     );
 
     expect(screen.getByText(tFromCatalog('playlists', 'library.empty.title'))).toBeTruthy();
+  });
+
+  it('gives the empty state an app-handoff CTA, not a dead end', () => {
+    render(
+      <LibraryPageContent
+        initialMyBoards={[]}
+        initialPlaylists={{ playlists: [], totalCount: 0, hasMore: false }}
+        initialDiscoverPlaylists={NO_DISCOVER}
+      />,
+    );
+
+    // Nothing else on the empty state is a link, so this is the CTA.
+    const cta = screen.getByRole('link');
+    expect(cta.getAttribute('href')).toBe(`${APP_URL}/discover`);
+    expect(cta.textContent).toContain(tFromCatalog('playlists', 'library.empty.cta'));
+  });
+
+  it('shows a Jump Back In loading placeholder while nothing has arrived yet', () => {
+    mockPlaylistsLoading = true;
+    render(<LibraryPageContent initialMyBoards={[]} initialPlaylists={null} initialDiscoverPlaylists={NO_DISCOVER} />);
+
+    expect(screen.getByText(tFromCatalog('playlists', 'library.sections.jumpBackIn'))).toBeTruthy();
+    // No real cards (anchors) have loaded yet — only skeleton placeholders.
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
+  });
+
+  it('replaces the Jump Back In skeleton once playlists have loaded', () => {
+    mockPlaylistsLoading = false;
+    render(
+      <LibraryPageContent
+        initialMyBoards={[]}
+        initialPlaylists={{ playlists: [makePlaylist('aaa')], totalCount: 1, hasMore: false }}
+        initialDiscoverPlaylists={NO_DISCOVER}
+      />,
+    );
+
+    expect(screen.getByRole('link').getAttribute('href')).toBe('/playlists/aaa');
+  });
+
+  it('shows a Discover loading placeholder while nothing has arrived yet', () => {
+    mockDiscoverLoading = true;
+    render(
+      <LibraryPageContent
+        initialMyBoards={[]}
+        initialPlaylists={{ playlists: [makePlaylist('aaa')], totalCount: 1, hasMore: false }}
+        initialDiscoverPlaylists={null}
+      />,
+    );
+
+    expect(screen.getByText(tFromCatalog('playlists', 'library.sections.discover'))).toBeTruthy();
   });
 
   it('still offers the sign-in banner to signed-out visitors and opens the auth modal', async () => {

--- a/packages/web/app/playlists/library-page-content.tsx
+++ b/packages/web/app/playlists/library-page-content.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import MuiButton from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
-import { LabelOutlined, LoginOutlined, SentimentDissatisfiedOutlined } from '@mui/icons-material';
+import { AddOutlined, LabelOutlined, LoginOutlined, SentimentDissatisfiedOutlined } from '@mui/icons-material';
 import { useSession } from 'next-auth/react';
 import { useTranslation } from 'react-i18next';
 import { type Playlist, type DiscoverablePlaylist } from '@boardsesh/graphql/operations/playlists';
@@ -14,9 +14,11 @@ import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { useMyBoards } from '@/app/hooks/use-my-boards';
 import { findMatchingBoard } from '@/app/lib/find-matching-board';
 import { deriveIsAuthenticated } from '@/app/lib/derive-auth-status';
+import { buildAppHandoffUrl } from '@/app/lib/app-handoff';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import PlaylistLinkCard from '@/app/components/playlists/playlist-link-card';
+import PlaylistCardSkeleton from '@/app/components/playlists/playlist-card-skeleton';
 import styles from '@/app/components/ui/page-container.module.css';
 
 type LibraryPageContentProps = {
@@ -136,6 +138,7 @@ export default function LibraryPageContent({
   const {
     popular: popularPlaylists,
     recent: recentPlaylists,
+    isLoading: discoverLoading,
     isLoadingMore: discoverLoadingMore,
     hasMore: discoverHasMore,
     loadMore: loadMoreDiscover,
@@ -250,7 +253,35 @@ export default function LibraryPageContent({
           <Typography variant="body2" color="text.secondary" sx={{ maxWidth: 300, mb: 2 }}>
             {t('library.empty.description')}
           </Typography>
+          {/* Building a playlist lives in the app now — this surface reads,
+              it does not write (see the module doc comment above). A plain
+              cross-origin anchor, never a redirect: www and app share the
+              `.boardsesh.com` session cookie, so there is no token to hand
+              over (same contract as the "Climb this in the app" CTA on
+              playlist-detail-content.tsx). */}
+          <MuiButton
+            variant="contained"
+            component="a"
+            href={buildAppHandoffUrl('/discover')}
+            startIcon={<AddOutlined />}
+          >
+            {t('library.empty.cta')}
+          </MuiButton>
         </div>
+      )}
+
+      {/* Jump Back In skeleton — reserves the section's space while playlists
+          are still loading and nothing has arrived yet, so the grid doesn't
+          pop in without warning (mirrors the pre-W-13 PlaylistScrollSection
+          loading state). Once anything has landed the real cards below take
+          over instead. */}
+      {isAuthenticated && isLoading && jumpBackInPlaylists.length === 0 && (
+        <>
+          <div className={styles.sectionTitle}>{t('library.sections.jumpBackIn')}</div>
+          <div className={styles.cardGrid}>
+            <PlaylistCardSkeleton />
+          </div>
+        </>
       )}
 
       {/* Jump Back In — pinned playlists lead, the rest of the user's own
@@ -280,6 +311,17 @@ export default function LibraryPageContent({
               {t('library.showMore')}
             </MuiButton>
           )}
+        </>
+      )}
+
+      {/* Discover skeleton — same reserved-space treatment as Jump Back In,
+          shown regardless of auth since Discover is public. */}
+      {discoverLoading && discoverItems.length === 0 && (
+        <>
+          <div className={styles.sectionTitle}>{t('library.sections.discover')}</div>
+          <div className={styles.cardGrid}>
+            <PlaylistCardSkeleton />
+          </div>
         </>
       )}
 


### PR DESCRIPTION
## Summary

Part of #4358.
Closes #4426.

Five polish findings from adversarial QA on the merged W-13 PR (#4424):

1. **`/playlists` loading skeletons.** W-13's static grid dropped the loading state the old `PlaylistScrollSection` had — while playlists or Discover were still fetching, the page just showed nothing until data landed. Added `PlaylistCardSkeleton` (a new component under `components/playlists/`, matching `PlaylistLinkCard`'s square-plus-two-lines shape) and wired it into both the Jump Back In and Discover sections whenever they're loading and nothing has arrived yet. Once real data lands, the skeleton is replaced — no double-render, no layout shift. The placeholder gets its own `.skeletonCompact` class: the card's box exactly, minus the pointer affordances a placeholder has no business carrying, and the 48px square is set by `width`/`height` props so it can't lose a cascade race with MUI's `height: 1.2em` Skeleton base rule.
2. **Empty-state CTA.** The zero-playlists empty state was a dead end: title, description, nothing to click. `/playlists` is read-only now (creating a playlist lives in the app), so the CTA is a plain cross-origin anchor via `buildAppHandoffUrl('/discover')` — the same "no redirect, no token hand-off" contract the playlist-detail page's "Climb this in the app" CTA already uses (both origins share the `.boardsesh.com` session cookie).
3. **Home rail card clamp.** The popular-board rail's `repeat(auto-fill, minmax(120px, 1fr))` put no ceiling on card width: the same board thumbnail measured 184px on a 412px phone (2 columns) and 124.7px at 430px (3 columns) — the narrower screen drew the bigger tile. The ceiling belongs on the card, not the column. Capping the column (`minmax(120px, 160px)`) pins the size but stops the grid filling its container, since every column is then exactly 160px and the whole remainder piles up past the last one: 144px of dead space at a 1024px viewport, 66px at 430px, while every sibling homepage section runs to the page gutter. So the columns stay `1fr` and `.card` takes `max-width: 160px`, centred in its track. Measured in headless Chromium at 375/390/412/430/768/1024/1280/1440: card 124.7–160px with at most 12px of slack per edge.
4. **Dead prop.** `PlaylistLinkCard.isLikedClimbs` had zero callers (grep-verified) — `/playlists` never renders a "Liked Climbs" pseudo-playlist card. Removed the prop and its pass-through to `PlaylistPreviewSquare`.
5. **Token/alignment nits.** `popular-board-rail.module.css`'s `.title` used a bare `padding-left: 2px` — a magic number that also left it 2px out of step with the homepage's other section labels (`HomeRecentBetaSection`, the onboarding header), both of which use `px: 0.5` (i.e. `--spacing-1` on both sides). Switched to `padding: 0 var(--spacing-1)` so all three line up under the same left edge and nothing is a raw pixel value.

## Release Notes

- The playlists page shows loading placeholders and gives you somewhere to go when it is empty.

## Test plan

- [x] `vp check` — format + lint, clean on every changed file (the two pre-existing `docs/design/web-reposition/*.html` format failures come from `main`'s 19268ee78 and are untouched here)
- [x] `vp run typecheck:web` — clean
- [x] `vp test run --reporter=agent --project web` — 498 files / 6054 tests, all green (one pre-existing test updated: the empty-state CTA is now a real anchor, so a test asserting "no other links on the page" needed to filter to the discover-card hrefs it actually checks)
- [x] `vp run check:i18n` — no hardcoded strings
- [x] `vp run check:i18n:orphans` — no orphaned keys
- [x] New key `library.empty.cta` added to all four locale catalogs (en-US, es, fr, de)
- [x] `import-graph-invariant.test.ts` and `crawler-classic-invariant.test.ts` pass unmodified — the new skeleton component lives in `components/playlists/` (not the delete set) and nothing in the delete set gained an import
- [x] New/updated test coverage in `library-page-content.test.tsx`: empty-state CTA href + label, Jump Back In skeleton while loading, skeleton→real-card handoff once playlists arrive, Discover skeleton while loading
- [x] Loading tests mutation-checked: making `PlaylistCardSkeleton` return `null` fails both placeholder tests (they count placeholders by testid, not just the section heading the enclosing branch renders)
- [x] Rail grid measured in headless Chromium at 375/390/412/430/768/1024/1280/1440 against the homepage box model (`main` `px: 2`, 12 cards, `gap: var(--spacing-3)`): unbounded columns 124.7–184px card / 0 dead space; 160px column clamp 160px card / up to 144px dead space; shipped card clamp 124.7–160px card / ≤12px slack per edge
- [ ] Manual: load `/playlists` while throttling the network to see the skeleton, then confirm a zero-playlist account shows the CTA linking to `app.boardsesh.com/discover`
- [ ] Manual: check the homepage board rail at 390px, 768px and 1440px — card size stays consistent, no oversized tiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6Ur37Pg6Ro9kyFxUr8r97
