### PR TITLE
fix(sync): report the terminal event a removed board's download owes, and re-arm the scheduler

### DIFF
--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -684,14 +684,14 @@ Five PostHog events (`@boardsesh/analytics`'s `SHARED_EVENTS`) make board downlo
 end-to-end (issue #4316). Before them the feature had exactly one — `Offline Board Download
 Completed` — so abandonment was structurally unmeasurable and failures went only to Sentry.
 
-| Event                              | When                                                   | Key props                                                                             |
-| ---------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------- |
-| `Offline Board Download Started`   | first time any cycle starts pulling a scope, once ever | `scopeKey`, `pathIntent`, `artifactBytes`, `trigger`, `offlineEngineEnabled`          |
-| `Offline Board Download Completed` | both board tables reached the tail, once ever          | `scopeKey`, `method`, `durationMs`, `bytes?`, `rowCount?`, `downloadMs?`, `importMs?` |
-| `Offline Board Download Failed`    | a bootstrap attempt ended without succeeding           | `scopeKey`, `stage`, `attempt`, `expected`, `reason`, `aborted`, `errorMessage`       |
-| `Offline Board Download Cancelled` | the board was switched off mid-download                | `scopeKey`, `source`, `stage?`, `fraction?`, `bytesDone?`                             |
-| `Offline Board Toggled`            | the offline switch was flipped, either way             | `scopeKey`, `enabled`, `source`                                                       |
-| `Offline Download All Tapped`      | the "download all my boards" switch was TAPPED         | `boardCount`                                                                          |
+| Event                              | When                                                                                   | Key props                                                                             |
+| ---------------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `Offline Board Download Started`   | first time any cycle starts pulling a scope, once ever                                 | `scopeKey`, `pathIntent`, `artifactBytes`, `trigger`, `offlineEngineEnabled`          |
+| `Offline Board Download Completed` | both board tables reached the tail, once ever                                          | `scopeKey`, `method`, `durationMs`, `bytes?`, `rowCount?`, `downloadMs?`, `importMs?` |
+| `Offline Board Download Failed`    | a bootstrap attempt ended without succeeding, or a removal ended the download for good | `scopeKey`, `stage`, `attempt`, `expected`, `reason`, `aborted`, `errorMessage`       |
+| `Offline Board Download Cancelled` | the board was switched off mid-download                                                | `scopeKey`, `source`, `stage?`, `fraction?`, `bytesDone?`                             |
+| `Offline Board Toggled`            | the offline switch was flipped, either way                                             | `scopeKey`, `enabled`, `source`                                                       |
+| `Offline Download All Tapped`      | the "download all my boards" switch was TAPPED                                         | `boardCount`                                                                          |
 
 **The once-ever contract.** Started and Completed are each guarded by a durable `sync_meta`
 marker — `scope-started:<scopeKey>` and `scope-complete:<scopeKey>` — so the funnel query is
@@ -748,8 +748,30 @@ explain, and it is the one abort-shaped outcome that still goes to Sentry (`sour
 
 **The invariant is scoped to the snapshot bootstrap.** A paged crawl is multi-cycle by design — an
 interrupted one has not failed, it is simply not finished — so the board-data loop does not report
-per-cycle aborts, and a paged Started legitimately stays open until its Completed lands. Abandonment
-on that path is measured as a Started with no Completed after N days, not as a Failed.
+per-cycle aborts, and a paged Started legitimately stays open until its Completed lands. Slow
+abandonment on that path is still measured as a Started with no Completed after N days, not as a
+Failed.
+
+**Except when the board is removed** (issue #4406). That is the one exit that ends a download for
+good: `removeBoardScopeData` deletes the `scope-started:` marker along with the rows, so once it
+commits nothing can tell an abandoned download from a board that was never downloaded. It therefore
+reads `scope-started:` / `scope-complete:` **before** its transaction and, when a download had
+announced itself and never completed, reports one
+`Offline Board Download Failed { stage: 'board-removed', reason: 'abandoned-removed', aborted: true, attempt: 0 }`
+after the commit. Unlike every other abort-shaped reason it fires **at most once per Started**, which
+makes "downloads the climber gave up on" a count rather than a subtraction. A removal landing
+mid-**bootstrap** would otherwise produce two terminals for one Started — the phase's own
+`aborted-wipe` and this one — so both claim against the purge generation `beginScopePurge` bumped
+(`sync/download-terminal-registry.ts`), and only the first claim reports.
+
+**A removal also re-arms the scheduler.** A removal latches its namespace for the seconds its delete
+transaction runs, and every purge guard in the pull client reads that latch as "purged" — so a cycle
+that starts inside the window skips the scope from top to bottom. That is correct (it must not write
+into a delete) but it also consumes the trigger, and the scheduler has no interval: a board switched
+back **on** during a removal used to sit on "waiting to download" until the next foreground or
+reconnect, which on Marco's phone meant nine hours and an app relaunch. `startSyncScheduler` now
+subscribes to `onPurgeSettled` and runs a cycle when the window closes — but only when a
+still-enabled board needs that namespace, so an ordinary removal costs no cycle.
 
 **Reading the props.** `pathIntent` on Started is an INTENT from cheap local facts, not an outcome —
 a snapshot-eligible scope can still fall back to the paged crawl after the manifest resolves. Split

--- a/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
+++ b/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
@@ -88,6 +88,7 @@ import {
   pullSync,
   startBackgroundTracking,
   subscribeMutationDelivery,
+  reportScopeDownloadAbandoned,
   __resetCoverageVerdictDedupeForTests,
   __resetMeteredStateForTests,
 } from '../offline-sync-adapter';
@@ -526,6 +527,34 @@ describe('snapshot-bootstrap bindings', () => {
         causeName: 'TypeError',
       }),
     );
+  });
+
+  // The abandoned-download terminal's event shape is a permanent analytics
+  // contract (issue #4406): reason and stage are enumerated by dashboards, and
+  // `aborted: true` is what keeps a Remove tap out of Sentry and out of every
+  // failure-rate query. The engine test asserts WHEN the seam fires and the
+  // remove-offline-board test asserts it is wired; this pins WHAT it emits.
+  it('reports an abandoned download as the funnel Failed shape, and never to Sentry', () => {
+    reportScopeDownloadAbandoned({
+      scopeKey: 'tension:11:8',
+      scope: { boardType: 'tension', layoutId: 11, sizeId: 8 },
+    });
+
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(trackMock).toHaveBeenCalledWith(
+      SHARED_EVENTS.OfflineBoardDownloadFailed,
+      expect.objectContaining({
+        scopeKey: 'tension:11:8',
+        stage: 'board-removed',
+        reason: 'abandoned-removed',
+        aborted: true,
+        expected: true,
+        attempt: 0,
+      }),
+    );
+    // A Remove tap is not a defect: `aborted: true` must stop the report at the
+    // funnel, or every board removal would land in Sentry as a bootstrap failure.
+    expect(reportHandledError).not.toHaveBeenCalled();
   });
 
   it('captures a PostHog event on scope-download completion with the method + duration', () => {

--- a/packages/mobile/src/offline/__tests__/remove-offline-board.test.ts
+++ b/packages/mobile/src/offline/__tests__/remove-offline-board.test.ts
@@ -53,6 +53,13 @@ vi.mock('../../lib/error-reporting', () => ({
   reportError: vi.fn(),
 }));
 
+// The adapter wires AppState and NetInfo at import time, so the one reporter this
+// module takes from it is stubbed rather than the whole of react-native (#4406).
+const reportScopeDownloadAbandoned = vi.fn();
+vi.mock('../offline-sync-adapter', () => ({
+  reportScopeDownloadAbandoned: (...args: unknown[]) => reportScopeDownloadAbandoned(...(args as [])),
+}));
+
 const sweepOverlaysForScope = vi.fn(async () => ({ beforeBytes: 0, freedBytes: 0, filesDeleted: 0 }));
 vi.mock('../../lib/sweep-caches', () => ({
   sweepOverlaysForScope: (...args: unknown[]) => sweepOverlaysForScope(...(args as [])),
@@ -146,6 +153,22 @@ describe('removeOfflineBoard', () => {
 
     await expect(removeOfflineBoard({ db, queryClient, scope: KILTER_12X14 })).rejects.toThrow('disk went away');
     expect(releasePurge).toHaveBeenCalledTimes(1);
+  });
+
+  // The funnel's terminal for a board removed mid-download (issue #4406). The
+  // engine owns WHEN it fires (it is the only code that can still read the
+  // `scope-started:` marker); this pins that the seam is wired at all — an
+  // unwired one is invisible, because the symptom is a missing analytics event.
+  it('hands the engine the abandoned-download reporter', async () => {
+    setSetting('syncEnabledBoards', ['kilter:1:7']);
+
+    await removeOfflineBoard({ db, queryClient, scope: KILTER_12X14 });
+
+    const [teardownParams] = removeBoardScopeData.mock.calls[0] as unknown as [
+      { onDownloadAbandoned?: (info: { scopeKey: string }) => void },
+    ];
+    teardownParams.onDownloadAbandoned?.({ scopeKey: 'kilter:1:7' });
+    expect(reportScopeDownloadAbandoned).toHaveBeenCalledWith({ scopeKey: 'kilter:1:7' });
   });
 
   it('retains every other enabled scope, and never the one being removed', async () => {

--- a/packages/mobile/src/offline/offline-sync-adapter.ts
+++ b/packages/mobile/src/offline/offline-sync-adapter.ts
@@ -45,6 +45,7 @@ import {
   type SnapshotSource,
   type SyncOptions,
   type SyncProgressSink,
+  type AbandonedDownloadInfo,
 } from '@boardsesh/offline-sync';
 import { SHARED_EVENTS, sanitizeErrorForAnalytics } from '@boardsesh/analytics';
 import { reportHandledError } from '../lib/error-reporting';
@@ -199,6 +200,32 @@ const reportSnapshotBootstrapError: SnapshotBootstrapErrorReporter = ({
       },
     },
   );
+};
+
+/**
+ * The funnel's other missing terminal (issue #4406): the climber removed the
+ * board while its download was still running.
+ *
+ * Routed through `reportSnapshotBootstrapError` rather than a `track()` of its
+ * own so the Failed leg has exactly one shape and one call site — the two could
+ * otherwise disagree about what a failed download looks like. `aborted: true`
+ * keeps it out of Sentry (a Remove tap is not a defect) and out of any failure
+ * RATE, while the `abandoned-removed` reason is what makes abandonment
+ * countable: it fires at most once per `Offline Board Download Started`, from
+ * the teardown that deletes the marker.
+ */
+export const reportScopeDownloadAbandoned = ({ scopeKey }: AbandonedDownloadInfo): void => {
+  reportSnapshotBootstrapError({
+    scopeKey,
+    stage: 'board-removed',
+    // No retry budget was spent — the same "nothing was burned" zero every other
+    // teardown report sends.
+    attempt: 0,
+    cause: new Error(`Offline download for ${scopeKey} was removed before it finished`),
+    expected: true,
+    reason: 'abandoned-removed',
+    aborted: true,
+  });
 };
 
 // Fired once per board scope's initial download so the snapshot-bootstrap

--- a/packages/mobile/src/offline/remove-offline-board.ts
+++ b/packages/mobile/src/offline/remove-offline-board.ts
@@ -21,6 +21,7 @@ import {
   type ScopeTeardownResult,
 } from '@boardsesh/offline-sync';
 import { getSetting, setOfflineBoardEnabled, forgetOfflineBoardScope } from '../settings';
+import { reportScopeDownloadAbandoned } from './offline-sync-adapter';
 import { reportHandledError } from '../lib/error-reporting';
 import { sweepOverlaysForScope } from '../lib/sweep-caches';
 
@@ -97,7 +98,17 @@ export async function removeOfflineBoard(params: {
 
   let result: ScopeTeardownResult;
   try {
-    result = await removeBoardScopeData({ db, scope, scopeKey: offlineBoardKey(scope), retainedScopes });
+    result = await removeBoardScopeData({
+      db,
+      scope,
+      scopeKey: offlineBoardKey(scope),
+      retainedScopes,
+      // The download funnel's terminal for a board removed mid-download (issue
+      // #4406). It belongs to the teardown because the teardown is what deletes
+      // the `scope-started:` marker: after this call nothing can tell an
+      // abandoned download from a board that was never downloaded.
+      onDownloadAbandoned: reportScopeDownloadAbandoned,
+    });
   } finally {
     // Unconditional: a latch left set would block this layout's downloads for the
     // rest of the app session.

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -413,8 +413,9 @@ export const SHARED_EVENTS = {
   // is shared, so a future web offline consumer would fire this too).
   OfflineBoardDownloadCompleted: 'Offline Board Download Completed',
   // A bootstrap stage failed, or was cut short. Props: { scopeKey, stage:
-  // 'manifest' | 'download' | 'import' | 'grades-download' | 'grades-import',
-  // attempt, expected, reason, aborted, errorMessage, offlineEngineEnabled }.
+  // 'manifest' | 'download' | 'import' | 'grades-download' | 'grades-import' |
+  // 'board-removed', attempt, expected, reason, aborted, errorMessage,
+  // offlineEngineEnabled }.
   // `expected: true` is a transport/reachability failure — a phone in a tunnel,
   // not a defect — and is the normal case, not an alarm. These previously went
   // only to Sentry, where they could not be joined to the funnel.
@@ -429,13 +430,22 @@ export const SHARED_EVENTS = {
   // `Failed where aborted = false` over Started.
   //
   // `reason` is a closed, low-cardinality bucket — 'aborted-wipe' |
-  // 'aborted-background' | 'database-locked' | 'schema-stale' |
-  // 'watermark-regression' | 'permanent-miss' | 'artifact-invalid' |
-  // 'artifact-truncated' | 'network' | 'unknown' | 'unknown-exit' — for
-  // grouping. The verbatim text stays on `errorMessage`. Dashboards that
-  // ENUMERATE reasons need 'artifact-truncated' added (issue #4394's exact
-  // decoded-size gate); failure-rate queries (`aborted = false`) pick it up on
-  // their own.
+  // 'aborted-background' | 'abandoned-removed' | 'database-locked' |
+  // 'schema-stale' | 'watermark-regression' | 'permanent-miss' |
+  // 'artifact-invalid' | 'artifact-truncated' | 'network' | 'unknown' |
+  // 'unknown-exit' — for grouping. The verbatim text stays on `errorMessage`.
+  // Dashboards that ENUMERATE reasons need 'artifact-truncated' (issue #4394's
+  // exact decoded-size gate) and 'abandoned-removed' (#4406) added;
+  // failure-rate queries (`aborted = false`) pick them up on their own.
+  //
+  // 'abandoned-removed' is the one reason that is a COUNT of abandonments rather
+  // than of interruptions (issue #4406): the climber removed the board while its
+  // download was still running, so it fires at most once per Started — from the
+  // teardown, which is the last code that can see the durable start marker — and
+  // always with `stage: 'board-removed'`. Every other abort-shaped reason can
+  // repeat for one download (a pocketed phone, a sibling board's removal), which
+  // is why "downloads given up on" was previously only derivable as
+  // Started-minus-Completed.
   //
   // One pairing changed with #4390: `aborted: true` can now arrive alongside an
   // `Offline Snapshot Retry Scheduled` with `failureKind: 'transport'` — the
@@ -455,7 +465,9 @@ export const SHARED_EVENTS = {
   // offlineEngineEnabled }. It needs a live progress frame naming the scope, so
   // today only the My Boards toggle mid-snapshot fires it: a paged crawl
   // publishes no such frame, and removing a board from Storage reports its exit
-  // as `Offline Board Toggled { enabled: false, source: 'storage' }` instead.
+  // as `Offline Board Toggled { enabled: false, source: 'storage' }` plus the
+  // funnel's own `Offline Board Download Failed { reason: 'abandoned-removed' }`
+  // (issue #4406) instead.
   OfflineBoardDownloadCancelled: 'Offline Board Download Cancelled',
   // One artifact transfer that actually moved bytes — the per-download
   // throughput measurement the funnel could not give us (issue #4394). Completed

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -191,7 +191,7 @@ export type { InvalidateKeys } from './sync/invalidate-keys';
 
 // --- Reclaiming a downloaded board's disk space ----------------------------------
 export { removeBoardScopeData, getScopeUsage, scopeSyncMetaKeys } from './sync/scope-teardown';
-export type { ScopeTeardownResult, ScopeUsage } from './sync/scope-teardown';
+export type { AbandonedDownloadInfo, ScopeTeardownResult, ScopeUsage } from './sync/scope-teardown';
 
 // --- Board-snapshot manifest (Phase 2 export ↔ Phase 3 bootstrap) ----------------
 export { parseSnapshotManifest, SNAPSHOT_MANIFEST_FORMAT_VERSION } from './sync/snapshot-manifest';

--- a/packages/shared/offline-sync/src/mutation-queue/drainer.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/drainer.ts
@@ -171,9 +171,55 @@ export function beginScopePurge(namespace: string): () => void {
     if (released) return;
     released = true;
     const inFlight = _purgesInFlight.get(namespace) ?? 0;
-    if (inFlight <= 1) _purgesInFlight.delete(namespace);
-    else _purgesInFlight.set(namespace, inFlight - 1);
+    if (inFlight <= 1) {
+      _purgesInFlight.delete(namespace);
+      notifyPurgeSettled(namespace);
+    } else _purgesInFlight.set(namespace, inFlight - 1);
   };
+}
+
+/**
+ * This namespace's purge generation. Read by the download funnel's terminal
+ * bookkeeping (issue #4406) so a removal and the cycle it tore down can tell
+ * they are talking about the SAME removal: both read the epoch the purge bumped,
+ * so the teardown's abandoned terminal and the pull client's own `aborted-wipe`
+ * terminal can never double up, while a LATER removal of the same scope reads a
+ * different epoch and reports its own.
+ */
+export function getPurgeEpoch(namespace: string): number {
+  return _purgeEpochs.get(namespace) ?? 0;
+}
+
+/**
+ * Fired when a namespace's LAST in-flight purge releases — the delete
+ * transaction has committed and work for that namespace is allowed again.
+ *
+ * The mirror image of `onTeardown`, and the reason it exists (issue #4406): a
+ * sync cycle that runs while the latch is set reads "purged" at every guard and
+ * skips the scope from top to bottom, reporting nothing. That is correct — but
+ * the trigger that kicked it is spent, and the scheduler has no interval, so a
+ * board switched back on DURING a removal sat on "waiting to download"
+ * indefinitely. Listeners must never throw.
+ */
+const purgeSettledListeners = new Set<(namespace: string) => void>();
+
+export function onPurgeSettled(listener: (namespace: string) => void): () => void {
+  purgeSettledListeners.add(listener);
+  return () => {
+    purgeSettledListeners.delete(listener);
+  };
+}
+
+function notifyPurgeSettled(namespace: string): void {
+  // Snapshot first, same as notifyTeardown: a listener that unsubscribes itself
+  // must not mutate the set being iterated.
+  for (const listener of [...purgeSettledListeners]) {
+    try {
+      listener(namespace);
+    } catch {
+      // A broken listener must never break a removal's release path.
+    }
+  }
 }
 
 /**
@@ -570,4 +616,5 @@ export function __resetDrainerStateForTests(): void {
   _purgesInFlight.clear();
   // A listener leaked by an aborted run would otherwise fire into the next test.
   teardownListeners.clear();
+  purgeSettledListeners.clear();
 }

--- a/packages/shared/offline-sync/src/sync/__tests__/purge-abandoned-download.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/purge-abandoned-download.test.ts
@@ -1,0 +1,355 @@
+// The field sequence behind issue #4406, replayed against the REAL client DDL.
+//
+// Marco's phone, 2026-08-14 12:32-12:33Z, scope tension:11:8:
+//
+//   12:32:59  Offline Board Download Started (snapshot, artifact sized)
+//   12:33:09  both artifacts transferred, imported, bootstrap-done stamped
+//   12:33:1x  the delta crawl is visibly paging
+//   12:33:39  the board is removed — beginScopePurge lands MID-CRAWL
+//             → no terminal event, ever: the board-data loop's purge exits are
+//               silent `continue`s and the funnel guard only covers the
+//               bootstrap phase
+//   12:33:41  the board is switched back ON, two seconds later
+//             → the next cycle runs INSIDE the removal's purge window, skips the
+//               scope for the whole cycle, and nothing re-schedules it: the board
+//               sits on "waiting to download" with no download attempt at all
+//
+// Both halves are asserted here: exactly one classified terminal event per
+// Started, and a fresh Started + bootstrap once the purge window closes.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { QueryInvalidator } from '../../database';
+import { pullSync, type ScopeDownloadStartInfo } from '../pull-client';
+import { removeBoardScopeData } from '../scope-teardown';
+import {
+  isScopeDownloadStarted,
+  isScopeDownloadComplete,
+  markScopeDownloadComplete,
+  getCheckpoint,
+  getCheckpointKey,
+} from '../checkpoints';
+import { isBootstrapDone, type SnapshotSource, type SnapshotBootstrapErrorReport } from '../snapshot-bootstrap';
+import { runMigrations, LATEST_SCHEMA_VERSION } from '../../db/migrations';
+import { ensureMutationQueueTable } from '../../mutation-queue/schema';
+import { beginScopePurge, __resetDrainerStateForTests } from '../../mutation-queue/drainer';
+import { __resetDownloadTerminalRegistryForTests } from '../download-terminal-registry';
+import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
+import { SCHEMA_STATEMENTS } from '../../db/schema';
+import type { OfflineBoardScope } from '../../offline-board-key';
+import type { SnapshotManifest, SnapshotManifestEntry } from '../snapshot-manifest';
+
+const SCOPE: OfflineBoardScope = { boardType: 'tension', layoutId: 11, sizeId: 8 };
+const SCOPE_KEY = 'tension:11:8';
+const NAMESPACE = 'tension:11';
+
+const SNAPSHOT_META_DDL = `
+CREATE TABLE IF NOT EXISTS snapshot_meta (
+  table_name TEXT PRIMARY KEY,
+  watermark_updated_at TEXT,
+  watermark_sync_seq TEXT,
+  row_count INTEGER,
+  built_at TEXT,
+  schema_version INTEGER,
+  format_version INTEGER
+);`;
+
+const WATERMARK = { updatedAt: '2026-05-02T00:00:00Z', syncSeq: '20' };
+
+/** A one-climb, one-stat artifact for the tension:11 layout. */
+function buildArtifact(filePath: string): void {
+  const artifact = new DatabaseSync(filePath);
+  try {
+    for (const statement of SCHEMA_STATEMENTS) artifact.exec(statement);
+    artifact.exec(SNAPSHOT_META_DDL);
+    artifact
+      .prepare(
+        `INSERT OR REPLACE INTO board_climbs
+          (uuid, board_type, layout_id, name, is_draft, is_listed, compatible_size_ids, updated_at, sync_seq)
+         VALUES (?, 'tension', 11, 'Artifact climb', 0, 1, ?, ?, ?)`,
+      )
+      .run('artifact-climb', JSON.stringify([8]), WATERMARK.updatedAt, Number(WATERMARK.syncSeq));
+    artifact
+      .prepare(
+        `INSERT OR REPLACE INTO board_climb_stats
+          (board_type, climb_uuid, angle, display_difficulty, updated_at, sync_seq)
+         VALUES ('tension', ?, 40, 20.0, ?, ?)`,
+      )
+      .run('artifact-climb', WATERMARK.updatedAt, Number(WATERMARK.syncSeq));
+    const meta = artifact.prepare(
+      `INSERT OR REPLACE INTO snapshot_meta
+        (table_name, watermark_updated_at, watermark_sync_seq, row_count, built_at, schema_version, format_version)
+       VALUES (?, ?, ?, 1, '2026-06-01T00:00:00.000Z', ?, 1)`,
+    );
+    meta.run('board_climbs', WATERMARK.updatedAt, WATERMARK.syncSeq, LATEST_SCHEMA_VERSION);
+    meta.run('board_climb_stats', WATERMARK.updatedAt, WATERMARK.syncSeq, LATEST_SCHEMA_VERSION);
+  } finally {
+    artifact.close();
+  }
+}
+
+function makeEntry(): SnapshotManifestEntry {
+  return {
+    boardType: 'tension',
+    layoutId: 11,
+    key: 'board-snapshots/v1/tension/11/2026-06-01.db',
+    url: 'https://example.test/tension-11.db',
+    bytes: 4096,
+    contentEncoding: 'gzip',
+    builtAt: '2026-06-01T00:00:00.000Z',
+    schemaVersion: LATEST_SCHEMA_VERSION,
+    tables: {
+      board_climbs: { watermarkUpdatedAt: WATERMARK.updatedAt, watermarkSyncSeq: WATERMARK.syncSeq, rowCount: 1 },
+      board_climb_stats: { watermarkUpdatedAt: WATERMARK.updatedAt, watermarkSyncSeq: WATERMARK.syncSeq, rowCount: 1 },
+    },
+  };
+}
+
+function makeManifest(): SnapshotManifest {
+  return { formatVersion: 1, generatedAt: '2026-06-01T00:00:00.000Z', entries: [makeEntry()] };
+}
+
+/** The injected snapshot I/O, with a hook that runs while the transfer is "on the wire". */
+function makeSnapshotSource(config: { filePath: string; onDownload?: () => void }): SnapshotSource {
+  return {
+    fetchManifest: vi.fn(async () => makeManifest()),
+    downloadArtifact: vi.fn(async () => {
+      config.onDownload?.();
+      return { filePath: config.filePath };
+    }),
+    deleteArtifact: vi.fn(async () => {}),
+  } as unknown as SnapshotSource;
+}
+
+type GraphqlFetchMock = <T>(query: string, variables?: Record<string, unknown>) => Promise<T>;
+
+const EMPTY_CURSOR = { updatedAt: '1970-01-01T00:00:00.000Z', syncSeq: '0' };
+
+/**
+ * Empty pages for everything, with a hook fired the first time the named board
+ * query is asked for — the moment the delta crawl is "visibly paging".
+ */
+function makeFetch(options?: { onQuery?: (queryName: string) => void }): GraphqlFetchMock {
+  const fetchMock = vi.fn(async (query: string, variables?: Record<string, unknown>) => {
+    const match = query.match(/\{\s*\n?\s*(sync[A-Za-z]+)\(/);
+    const queryName = match ? match[1] : 'unknown';
+    options?.onQuery?.(queryName);
+    if (queryName === 'syncDeletions') {
+      return { syncDeletions: { deletions: [], cursor: EMPTY_CURSOR, hasMore: false } };
+    }
+    return { [queryName]: { documents: [], cursor: variables?.cursor ?? EMPTY_CURSOR, hasMore: false } };
+  });
+  return fetchMock as unknown as GraphqlFetchMock;
+}
+
+function noopQueryClient(): QueryInvalidator {
+  return { invalidateQueries: vi.fn() } as unknown as QueryInvalidator;
+}
+
+/**
+ * The removal's latch: armed from inside a pull callback (the purge lands
+ * mid-cycle) and released later, so a test can hold the window open exactly as
+ * long as the real delete transaction does.
+ */
+function purgeLatch() {
+  const latch: { release: (() => void) | null } = { release: null };
+  return {
+    begin: () => {
+      if (!latch.release) latch.release = beginScopePurge(NAMESPACE);
+    },
+    release: () => latch.release?.(),
+  };
+}
+
+/** The terminal the mobile reporter builds from the teardown's seam. */
+function abandonedTerminal(scopeKey: string): SnapshotBootstrapErrorReport {
+  return {
+    scopeKey,
+    stage: 'board-removed',
+    attempt: 0,
+    cause: null,
+    reason: 'abandoned-removed',
+    aborted: true,
+    expected: true,
+  };
+}
+
+let workDir: string;
+let db: TestSqliteDb;
+let artifactPath: string;
+
+beforeEach(async () => {
+  workDir = mkdtempSync(join(tmpdir(), 'purge-abandoned-'));
+  db = createTestDatabase(join(workDir, 'client.db'));
+  await runMigrations(db);
+  await ensureMutationQueueTable(db);
+  artifactPath = join(workDir, 'tension-11.db');
+  buildArtifact(artifactPath);
+  __resetDrainerStateForTests();
+  __resetDownloadTerminalRegistryForTests();
+});
+
+afterEach(() => {
+  db.close();
+  __resetDrainerStateForTests();
+  __resetDownloadTerminalRegistryForTests();
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe('a board removed mid-crawl (issue #4406)', () => {
+  it('closes its Started with exactly one classified terminal event', async () => {
+    const started: ScopeDownloadStartInfo[] = [];
+    const terminals: SnapshotBootstrapErrorReport[] = [];
+    const completed = vi.fn();
+
+    // The removal lands while the delta crawl is paging board_climb_grades —
+    // after the artifacts imported and `bootstrap-done:` was stamped.
+    const removal = purgeLatch();
+    const fetch = makeFetch({
+      onQuery: (queryName) => {
+        if (queryName === 'syncClimbGrades') removal.begin();
+      },
+    });
+
+    await pullSync(db, noopQueryClient(), fetch, {
+      enabledBoards: [SCOPE_KEY],
+      snapshotSource: makeSnapshotSource({ filePath: artifactPath }),
+      onScopeDownloadStart: (info) => started.push(info),
+      onScopeDownloadComplete: completed,
+      onSnapshotBootstrapError: (report) => terminals.push(report),
+    });
+
+    // The Started the funnel is missing a terminal for.
+    expect(started).toHaveLength(1);
+    expect(started[0]).toMatchObject({ scopeKey: SCOPE_KEY, pathIntent: 'snapshot' });
+    expect(await isBootstrapDone(db, SCOPE_KEY)).toBe(true);
+    // The crawl never reached the tail, so no Completed — that is the abandonment.
+    expect(completed).not.toHaveBeenCalled();
+    expect(await isScopeDownloadComplete(db, SCOPE_KEY)).toBe(false);
+    expect(await isScopeDownloadStarted(db, SCOPE_KEY)).toBe(true);
+
+    // The teardown the purge belongs to. It is the last thing that can still see
+    // the durable `scope-started:` marker, which is why the terminal is emitted
+    // from here.
+    await removeBoardScopeData({
+      db,
+      scope: SCOPE,
+      scopeKey: SCOPE_KEY,
+      retainedScopes: [],
+      onDownloadAbandoned: ({ scopeKey }) => terminals.push(abandonedTerminal(scopeKey)),
+    });
+    removal.release();
+
+    expect(terminals).toHaveLength(1);
+    expect(terminals[0]).toMatchObject({
+      scopeKey: SCOPE_KEY,
+      reason: 'abandoned-removed',
+      aborted: true,
+      expected: true,
+      attempt: 0,
+    });
+  });
+
+  it('emits ONE terminal, not two, when the removal lands mid-bootstrap', async () => {
+    const terminals: SnapshotBootstrapErrorReport[] = [];
+    const removal = purgeLatch();
+
+    await pullSync(db, noopQueryClient(), makeFetch(), {
+      enabledBoards: [SCOPE_KEY],
+      // Purged while the artifact is on the wire: the bootstrap phase reports its
+      // own `aborted-wipe` terminal for this attempt.
+      snapshotSource: makeSnapshotSource({ filePath: artifactPath, onDownload: removal.begin }),
+      onSnapshotBootstrapError: (report) => terminals.push(report),
+    });
+
+    expect(terminals).toHaveLength(1);
+    expect(terminals[0]).toMatchObject({ reason: 'aborted-wipe', aborted: true });
+
+    await removeBoardScopeData({
+      db,
+      scope: SCOPE,
+      scopeKey: SCOPE_KEY,
+      retainedScopes: [],
+      onDownloadAbandoned: ({ scopeKey }) => terminals.push(abandonedTerminal(scopeKey)),
+    });
+    removal.release();
+
+    // Still one: the phase already closed this Started's funnel.
+    expect(terminals).toHaveLength(1);
+  });
+
+  it('stays silent for a board that was never downloaded', async () => {
+    const onDownloadAbandoned = vi.fn();
+    await removeBoardScopeData({ db, scope: SCOPE, scopeKey: SCOPE_KEY, retainedScopes: [], onDownloadAbandoned });
+    expect(onDownloadAbandoned).not.toHaveBeenCalled();
+  });
+
+  it('stays silent for a board whose download had already completed', async () => {
+    await pullSync(db, noopQueryClient(), makeFetch(), { enabledBoards: [SCOPE_KEY] });
+    await markScopeDownloadComplete(db, SCOPE_KEY);
+
+    const onDownloadAbandoned = vi.fn();
+    await removeBoardScopeData({ db, scope: SCOPE, scopeKey: SCOPE_KEY, retainedScopes: [], onDownloadAbandoned });
+    expect(onDownloadAbandoned).not.toHaveBeenCalled();
+  });
+});
+
+describe('re-enabling a board while its removal is still running (issue #4406)', () => {
+  it('runs a fresh bootstrap once the purge window closes', async () => {
+    const started: ScopeDownloadStartInfo[] = [];
+    const source = makeSnapshotSource({ filePath: artifactPath });
+
+    // Cycle 1: download, import, crawl — until the removal lands mid-crawl.
+    const removal = purgeLatch();
+    await pullSync(
+      db,
+      noopQueryClient(),
+      makeFetch({
+        onQuery: (queryName) => {
+          if (queryName === 'syncClimbGrades') removal.begin();
+        },
+      }),
+      {
+        enabledBoards: [SCOPE_KEY],
+        snapshotSource: source,
+        onScopeDownloadStart: (info) => started.push(info),
+        onSnapshotBootstrapError: vi.fn(),
+      },
+    );
+    await removeBoardScopeData({ db, scope: SCOPE, scopeKey: SCOPE_KEY, retainedScopes: [] });
+
+    // Cycle 2 is the one the re-enable kicks two seconds later: the removal's
+    // exclusive transaction is still latched, so every guard reads "purged" and
+    // the scope is skipped for the WHOLE cycle. Nothing is written and nothing
+    // is reported — this cycle is a no-op for the board, which is correct.
+    await pullSync(db, noopQueryClient(), makeFetch(), {
+      enabledBoards: [SCOPE_KEY],
+      snapshotSource: source,
+      onScopeDownloadStart: (info) => started.push(info),
+      onSnapshotBootstrapError: vi.fn(),
+    });
+    expect(started).toHaveLength(1);
+    expect(await isScopeDownloadStarted(db, SCOPE_KEY)).toBe(false);
+
+    // The purge window closes. THIS is the cycle the wedge swallowed: without a
+    // re-trigger the board never downloads again, in this session or any later
+    // one, because the scheduler has no interval.
+    removal.release();
+
+    await pullSync(db, noopQueryClient(), makeFetch(), {
+      enabledBoards: [SCOPE_KEY],
+      snapshotSource: source,
+      onScopeDownloadStart: (info) => started.push(info),
+      onSnapshotBootstrapError: vi.fn(),
+    });
+
+    expect(started).toHaveLength(2);
+    expect(started[1]).toMatchObject({ scopeKey: SCOPE_KEY, pathIntent: 'snapshot' });
+    expect(await isBootstrapDone(db, SCOPE_KEY)).toBe(true);
+    // From epoch, not from the crawl the removal interrupted.
+    expect(await getCheckpoint(db, getCheckpointKey('board_climbs', SCOPE_KEY))).not.toBeNull();
+  });
+});

--- a/packages/shared/offline-sync/src/sync/__tests__/sync-scheduler.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/sync-scheduler.test.ts
@@ -13,6 +13,7 @@ import {
   type SchedulerTriggers,
 } from '../sync-scheduler';
 import { pullSync } from '../pull-client';
+import { beginScopePurge, __resetDrainerStateForTests } from '../../mutation-queue/drainer';
 
 const mockPullSync = pullSync as ReturnType<typeof vi.fn>;
 
@@ -73,6 +74,7 @@ describe('sync-scheduler', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     __resetSyncSchedulerStateForTests();
+    __resetDrainerStateForTests();
     mockPullSync.mockResolvedValue(undefined);
   });
 
@@ -355,5 +357,85 @@ describe('sync-scheduler', () => {
 
     // The queued follow-up must NOT have fired a second cycle.
     expect(mockPullSync).toHaveBeenCalledTimes(1);
+  });
+
+  // Issue #4406. A removal's exclusive transaction latches its namespace for
+  // seconds, and every guard in the pull client reads that latch as "purged" —
+  // so a cycle kicked DURING it (the climber switching the board straight back
+  // on, two seconds later) skips the scope from top to bottom and reports
+  // nothing. Nothing picks it up afterwards: the scheduler wakes on foreground
+  // and on the offline→online edge and has no interval, so a phone that stays in
+  // the climber's hand never downloads that board again.
+  describe('a purge window closing', () => {
+    it('re-runs a cycle when the purged namespace still has an enabled board', async () => {
+      const drainQueue: DrainQueue = vi.fn().mockResolvedValue(undefined);
+      const queryClient = createMockQueryClient();
+      const fakeTriggers = createFakeTriggers();
+
+      startSyncScheduler(
+        mockDb,
+        queryClient,
+        mockGraphqlFetch,
+        () => ['tension:11:8'],
+        drainQueue,
+        fakeTriggers.triggers,
+      );
+      await flush();
+      expect(mockPullSync).toHaveBeenCalledTimes(1); // initial cycle
+
+      // The removal: epoch bump, exclusive transaction, release.
+      const release = beginScopePurge('tension:11');
+      await flush();
+      expect(mockPullSync).toHaveBeenCalledTimes(1); // nothing runs INTO the delete
+      release();
+      await flush();
+
+      expect(mockPullSync).toHaveBeenCalledTimes(2);
+    });
+
+    it('stays quiet when nothing enabled needs that namespace', async () => {
+      const drainQueue: DrainQueue = vi.fn().mockResolvedValue(undefined);
+      const queryClient = createMockQueryClient();
+      const fakeTriggers = createFakeTriggers();
+
+      startSyncScheduler(
+        mockDb,
+        queryClient,
+        mockGraphqlFetch,
+        () => ['kilter:1:5'],
+        drainQueue,
+        fakeTriggers.triggers,
+      );
+      await flush();
+      expect(mockPullSync).toHaveBeenCalledTimes(1);
+
+      beginScopePurge('tension:11')();
+      await flush();
+
+      // An ordinary removal — the board is gone and stays gone — costs no cycle.
+      expect(mockPullSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops listening once the scheduler is stopped', async () => {
+      const drainQueue: DrainQueue = vi.fn().mockResolvedValue(undefined);
+      const queryClient = createMockQueryClient();
+      const fakeTriggers = createFakeTriggers();
+
+      const stop = startSyncScheduler(
+        mockDb,
+        queryClient,
+        mockGraphqlFetch,
+        () => ['tension:11:8'],
+        drainQueue,
+        fakeTriggers.triggers,
+      );
+      await flush();
+      stop();
+
+      beginScopePurge('tension:11')();
+      await flush();
+
+      expect(mockPullSync).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/shared/offline-sync/src/sync/bootstrap-failure-reason.ts
+++ b/packages/shared/offline-sync/src/sync/bootstrap-failure-reason.ts
@@ -23,6 +23,16 @@ import { classifySqliteLockError } from '../db/lock-errors';
 export type SnapshotBootstrapFailureReason =
   /** A sign-out, or a local purge (removing ANY board), tore the cycle down. */
   | 'aborted-wipe'
+  /**
+   * The board was REMOVED while its download was still running, so the download
+   * is over for good (issue #4406). Distinct from `aborted-wipe`, which a cycle
+   * reports whenever it bails and which the same scope can collect many times
+   * over one download — a backgrounded phone, a sibling board's removal, a
+   * sign-out. This one is emitted once per `Offline Board Download Started`,
+   * from the teardown that deletes the marker, so it is the abandonment the
+   * funnel is trying to size rather than another interruption.
+   */
+  | 'abandoned-removed'
   /** The app went to the background mid-cycle. Resumes on the next foreground. */
   | 'aborted-background'
   /** SQLITE_BUSY / SQLITE_LOCKED — contention, not a broken database. */

--- a/packages/shared/offline-sync/src/sync/download-terminal-registry.ts
+++ b/packages/shared/offline-sync/src/sync/download-terminal-registry.ts
@@ -1,0 +1,66 @@
+// One terminal event per removal, shared between the two places that can emit it
+// (issue #4406).
+//
+// A board removed mid-download can be torn down from either side of the same
+// instant:
+//
+//  - the purge lands while `runBootstrapPhase` is working, and the phase reports
+//    its own `aborted-wipe` Failed for the attempt it just abandoned; or
+//  - the purge lands while the board-data loop is crawling, where the phase is
+//    long finished and every exit is a silent `continue` — the gap this module
+//    exists for. The teardown then emits the `abandoned-removed` terminal,
+//    because it is the last code that can still see the durable `scope-started:`
+//    marker before deleting it.
+//
+// Both can be true at once (a purge that lands mid-bootstrap runs the teardown
+// milliseconds later), and two terminals for one Started would break the funnel
+// invariant #4391 states. So the two agree through the purge GENERATION: the
+// epoch `beginScopePurge` bumped is the removal's identity, and a terminal is
+// claimed against it exactly once.
+//
+// Keyed on the epoch rather than a plain "already reported" flag on purpose. A
+// scope collects `aborted-wipe` terminals routinely — every sibling size of a
+// removed layout gets one, and none of those removals is its own — so a flag
+// would let one stale report suppress a real abandonment months later. The
+// epoch makes the claim specific to the removal in progress.
+//
+// Process-local, like every other purge-generation fact. A Started that survives
+// a relaunch is covered by the durable markers instead: the teardown reads
+// `scope-started:` / `scope-complete:` before its transaction, so a download
+// abandoned in an earlier launch still reports exactly one terminal when the
+// board is finally removed.
+
+import { getPurgeEpoch } from '../mutation-queue/drainer';
+import { purgeNamespaceForScopeKey } from '../offline-board-key';
+
+/** scopeKey → the purge epoch a terminal event was last reported against. */
+const terminalByScope = new Map<string, number>();
+
+/**
+ * A terminal event was just emitted for `scopeKey` by a torn-down cycle. Only
+ * teardown-shaped reports (`aborted-wipe`) reach here: an ordinary failure is
+ * this attempt's terminal but says nothing about a removal, and the download
+ * itself is still owed one.
+ */
+export function noteScopeDownloadTerminal(scopeKey: string): void {
+  const namespace = purgeNamespaceForScopeKey(scopeKey);
+  // A malformed key belongs to no namespace we can name, so there is no
+  // generation to record it against — and nothing will ever claim against it.
+  if (namespace === undefined) return;
+  terminalByScope.set(scopeKey, getPurgeEpoch(namespace));
+}
+
+/**
+ * Claim the abandoned terminal for the removal currently in progress. False when
+ * the cycle this removal tore down already reported one for the same generation.
+ */
+export function claimAbandonedDownloadTerminal(scopeKey: string, namespace: string): boolean {
+  const epoch = getPurgeEpoch(namespace);
+  if (terminalByScope.get(scopeKey) === epoch) return false;
+  terminalByScope.set(scopeKey, epoch);
+  return true;
+}
+
+export function __resetDownloadTerminalRegistryForTests(): void {
+  terminalByScope.clear();
+}

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -36,6 +36,7 @@ import {
 } from './snapshot-bootstrap';
 import { classifySnapshotBootstrapFailure, type SnapshotBootstrapFailureReason } from './bootstrap-failure-reason';
 import { createDownloadFunnelGuard } from './download-funnel-guard';
+import { noteScopeDownloadTerminal } from './download-terminal-registry';
 import {
   classifyBootstrapFailure,
   clearBootstrapPagedFallback,
@@ -1070,8 +1071,19 @@ async function runBootstrapPhase(params: {
   // own catch, a consumer callback blowing up — still closes the funnel. See
   // download-funnel-guard.ts for what counts as settled and why only a genuinely
   // unexplained exit reaches Sentry.
+  //
+  // Every report leaving this phase — the guard's own included — passes through
+  // `recordTerminal` first, so the teardown that is about to delete this scope
+  // knows a terminal event has already been spent on its removal (issue #4406).
+  const recordTerminal = (report: SnapshotBootstrapErrorReport): void => {
+    // Only the teardown-shaped reason: an ordinary failure ends this ATTEMPT but
+    // leaves the download itself owed a terminal, which is exactly the case the
+    // teardown must still report.
+    if (report.reason === 'aborted-wipe') noteScopeDownloadTerminal(report.scopeKey);
+    rawSnapshotBootstrapError?.(report);
+  };
   const funnelGuard = createDownloadFunnelGuard({
-    report: rawSnapshotBootstrapError,
+    report: rawSnapshotBootstrapError ? recordTerminal : undefined,
     // Scope-aware: an unexplained exit that merely COINCIDES with another
     // board's removal is no longer laundered as `aborted-wipe`, so it still
     // reaches Sentry as `unknown-exit` (issue #4370).
@@ -1087,7 +1099,7 @@ async function runBootstrapPhase(params: {
   const onSnapshotBootstrapError = rawSnapshotBootstrapError
     ? (report: BootstrapErrorInput): void => {
         funnelGuard.settle(report.scopeKey);
-        rawSnapshotBootstrapError({
+        recordTerminal({
           ...report,
           reason: report.reason ?? classifySnapshotBootstrapFailure(report.cause),
           aborted: report.aborted ?? false,
@@ -2444,6 +2456,17 @@ export async function pullSync(
     // purge only invalidates its own scope — the one being deleted right now,
     // which is still in this stale list — so it skips that scope and lets every
     // other board finish (issue #4370).
+    //
+    // NONE of the exits below reports a terminal event, and that is deliberate
+    // (issue #4406). A board-data crawl legitimately spans cycles — a 40k-climb
+    // layout is hundreds of pages, and the durable `scope-started:` marker keeps
+    // ONE Started open across all of them — so a Failed per interrupted cycle
+    // would turn every normal multi-cycle download into a stream of failures.
+    // The one exit that ends a download for good is the removal these purge
+    // checks are dodging, and `removeBoardScopeData` reports it from the other
+    // side: it is the last code that can still see the Started marker before
+    // deleting it, and it de-dups against the bootstrap phase's own
+    // `aborted-wipe` through the purge generation.
     if (cycleAborted()) return;
     if (scopePurged(boardScope)) continue;
     const scopeKey = boardScope.scopeKey;

--- a/packages/shared/offline-sync/src/sync/scope-teardown.ts
+++ b/packages/shared/offline-sync/src/sync/scope-teardown.ts
@@ -41,10 +41,14 @@ import type { OfflineBoardScope } from '../offline-board-key';
 import { climbsScopeFilter, isSizeScopedBoard, sizeMembershipClause } from './board-scope-sql';
 import {
   getCheckpointKey,
+  isScopeDownloadComplete,
+  isScopeDownloadStarted,
   SCOPE_COMPLETE_PREFIX,
   SCOPE_STARTED_PREFIX,
   SCOPE_DOWNLOAD_STARTED_PREFIX,
 } from './checkpoints';
+import { claimAbandonedDownloadTerminal } from './download-terminal-registry';
+import { purgeNamespaceKey } from '../offline-board-key';
 import {
   BOOTSTRAP_DONE_PREFIX,
   REUSED_IMPORT_FAILED_PREFIX,
@@ -64,6 +68,12 @@ export type ScopeUsage = {
   scope: OfflineBoardScope;
   climbCount: number;
   estimatedBytes: number;
+};
+
+/** A download that announced itself and was removed before it finished (#4406). */
+export type AbandonedDownloadInfo = {
+  scopeKey: string;
+  scope: OfflineBoardScope;
 };
 
 export type ScopeTeardownResult = {
@@ -242,8 +252,27 @@ export async function removeBoardScopeData(params: {
   scope: OfflineBoardScope;
   scopeKey: string;
   retainedScopes: readonly OfflineBoardScope[];
+  /**
+   * The download funnel's missing terminal (issue #4406). Called at most once per
+   * `Offline Board Download Started`, when this teardown is what ended a download
+   * that had announced itself and never completed. See the read below for why it
+   * has to happen here and nowhere else.
+   */
+  onDownloadAbandoned?: (info: AbandonedDownloadInfo) => void;
 }): Promise<ScopeTeardownResult> {
-  const { db, scope, scopeKey, retainedScopes } = params;
+  const { db, scope, scopeKey, retainedScopes, onDownloadAbandoned } = params;
+
+  // READ BEFORE THE TRANSACTION. `scope-started:` and `scope-complete:` are two
+  // of the rows `clearScopeSyncMeta` is about to delete, and they are the only
+  // durable record that a download was announced and never finished — the pull
+  // client's own exits cannot report it, because a board-data crawl legitimately
+  // spans cycles and the Started stays open across all of them. Once this
+  // transaction commits, nothing anywhere can tell an abandoned download from a
+  // board that was never downloaded at all.
+  const abandonedDownload =
+    onDownloadAbandoned !== undefined &&
+    (await isScopeDownloadStarted(db, scopeKey)) &&
+    !(await isScopeDownloadComplete(db, scopeKey));
 
   const retainedSizeIds = retainedScopes
     .filter((retained) => retained.boardType === scope.boardType && retained.layoutId === scope.layoutId)
@@ -307,6 +336,15 @@ export async function removeBoardScopeData(params: {
       removedAnyRows: climbs.changes + stats.changes + grades.changes > 0,
     };
   });
+
+  // AFTER the commit, deliberately: a cycle torn down by this same purge is
+  // still unwinding while the transaction holds its lock, and reporting first
+  // would race its `aborted-wipe` — the claim below would then be made before
+  // the report it exists to defer to. By the time the delete has committed, the
+  // in-flight cycle has had every one of its guards fire.
+  if (abandonedDownload && claimAbandonedDownloadTerminal(scopeKey, purgeNamespaceKey(scope))) {
+    onDownloadAbandoned?.({ scopeKey, scope });
+  }
 
   return result;
 }

--- a/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
@@ -198,7 +198,14 @@ export interface SnapshotSource {
 /** Where a bootstrap failed, for telemetry. */
 export type SnapshotBootstrapErrorReport = {
   scopeKey: string;
-  stage: 'manifest' | 'download' | 'import' | 'grades-download' | 'grades-import';
+  /**
+   * How far the attempt got. `board-removed` is the one value no bootstrap stage
+   * produces: it is reported by the teardown when a board is removed mid-download
+   * (issue #4406), which can happen at any stage — including the paged delta
+   * crawl that runs long after the bootstrap phase has finished — so naming a
+   * bootstrap stage there would invent a precision the teardown does not have.
+   */
+  stage: 'manifest' | 'download' | 'import' | 'grades-download' | 'grades-import' | 'board-removed';
   attempt: number;
   cause: unknown;
   /**

--- a/packages/shared/offline-sync/src/sync/sync-scheduler.ts
+++ b/packages/shared/offline-sync/src/sync/sync-scheduler.ts
@@ -12,6 +12,8 @@ import {
   type BootstrapPathRecoveredReporter,
 } from './pull-client';
 import type { SnapshotSource, SnapshotBootstrapErrorReporter } from './snapshot-bootstrap';
+import { onPurgeSettled } from '../mutation-queue/drainer';
+import { purgeNamespaceForScopeKey } from '../offline-board-key';
 
 /**
  * Optional progress sink for the pull phase. The bridge passes the sync-status
@@ -205,6 +207,29 @@ export function startSyncScheduler(
     wasConnected = isConnected;
   });
 
+  // The third wake-up, and the one that is not about the phone (issue #4406).
+  //
+  // Removing a board latches its namespace for the seconds its delete
+  // transaction runs, and every guard in the pull client reads that latch as
+  // "purged": a cycle that starts inside the window skips the scope from top to
+  // bottom. That is correct — it must not write into a delete — but it also
+  // CONSUMES the trigger. A climber who switches a board straight back on gets
+  // their kick collapsed into exactly that cycle (`runSync` is single-flight),
+  // and with no interval here, the next wake-up is a foreground or a
+  // reconnect that may not come for hours. Marco's phone sat on "waiting to
+  // download" for nine hours and an app relaunch.
+  //
+  // So the moment the window closes, re-run — but only when something still
+  // enabled actually needs that namespace's rows. An ordinary removal (the board
+  // is gone and stays gone) matches nothing and costs no cycle.
+  const unsubscribePurge = onPurgeSettled((namespace) => {
+    const isNamespaceStillWanted = getEnabledBoards().some(
+      (scopeKey) => purgeNamespaceForScopeKey(scopeKey) === namespace,
+    );
+    if (!isNamespaceStillWanted) return;
+    void runSync(db, queryClient, graphqlFetch, getEnabledBoards, drainQueue, options);
+  });
+
   // Run initial sync immediately
   void runSync(db, queryClient, graphqlFetch, getEnabledBoards, drainQueue, options);
 
@@ -212,6 +237,7 @@ export function startSyncScheduler(
     if (foregroundTimeout) clearTimeout(foregroundTimeout);
     unsubscribeForeground();
     unsubscribeConnectivity();
+    unsubscribePurge();
     // A trigger queued behind an in-flight cycle would otherwise fire that
     // cycle's finally-block re-run AFTER this scheduler stopped (sign-out,
     // flag flip). React runs this cleanup before any replacement scheduler's


### PR DESCRIPTION
Closes #4406

Marco's phone, 2026-08-14 12:32–12:33Z, `tension:11:8`. `Offline Board Download Started` at 12:32:59, both artifacts transferred by 12:33:09, imported, delta crawl visibly paging — then the board was removed at 12:33:39 and **no terminal event ever fired**. Switching it back on two seconds later produced no new download either, not in that session and not after an app relaunch nine hours later: the board sat on "waiting to download" with no attempt behind it.

Two separate bugs, one sequence.

## 1. A removal mid-crawl left the Started with no terminal event

The board-data loop's purge exits are silent `continue`s (`pull-client.ts:2448/2456/2466/2474/2546/2552`) and the funnel guard from #4316 only covers `runBootstrapPhase` — which, in this sequence, had already succeeded. So a Started for a board that would never finish emitted nothing at all, breaking the one-terminal-per-Started invariant (#4391) for exactly the population it was meant to size.

Per-cycle reporting in that loop is **not** the fix: a paged crawl legitimately spans cycles and its Started stays open across all of them, so a Failed per interruption would turn every normal multi-cycle download into a stream of failures. The only exit that ends a download for good is the removal itself, and the removal is also the last code that can still see the durable `scope-started:` marker before deleting it.

So `removeBoardScopeData` now reads `scope-started:` / `scope-complete:` **before** its transaction and, when a download had announced itself and never completed, emits one terminal after the commit:

```
Offline Board Download Failed { stage: 'board-removed', reason: 'abandoned-removed', aborted: true, expected: true, attempt: 0 }
```

`aborted: true` keeps it out of Sentry and out of any failure-rate query, exactly like the existing teardown reports. Mobile routes it through the same `reportSnapshotBootstrapError` call site as every other Failed leg, so the two can never disagree about what a failed download looks like.

**No double-emit.** A removal landing mid-*bootstrap* already produces the phase's own `aborted-wipe`. Both now claim against the purge generation `beginScopePurge` bumped (`sync/download-terminal-registry.ts`), so one removal yields exactly one terminal — while a *later* removal of the same scope reads a different epoch and reports its own.

## 2. The re-enable was swallowed by the removal's own purge window

The wedge is scheduling, not the engine. `hasPurgeLanded` reports true for a whole namespace while a delete transaction is latched (`drainer.ts:90`), which is what keeps a page or a marker write from being dispatched into the delete (#4404). A cycle that starts inside that window therefore skips the scope at every guard — `runBootstrapPhase`'s loop-top verdict (`pull-client.ts:1311`) and the board-data loop's `scopePurged` checks — and reports nothing. Correct, but it also **consumes the trigger**: `triggerSync` is single-flight, so the climber's re-enable collapses into precisely that cycle. And `startSyncScheduler` has no interval (`sync-scheduler.ts`) — it wakes on foreground and on the offline→online edge — so the next attempt waits for the app to be backgrounded and reopened, or for the network to flap.

`beginScopePurge`'s release now notifies `onPurgeSettled`, and the scheduler runs a cycle when the window closes — but only when a still-enabled board needs that namespace, so an ordinary removal (the board is gone and stays gone) costs no cycle at all.

## Failing test first

`packages/shared/offline-sync/src/sync/__tests__/purge-abandoned-download.test.ts` replays the field ordering against the real client DDL: snapshot bootstrap succeeds, `bootstrap-done:` is stamped, the delta crawl starts paging, and `beginScopePurge('tension:11')` lands mid-crawl. Before the fix it failed with `expected [] to have a length of 1 but got +0` — zero terminal events for that Started. The scheduler half failed with `expected "vi.fn()" to be called 2 times, but got 1 times`. Both pass now.

The engine half of the re-toggle case turned out to already work once the latch clears (a fresh cycle re-bootstraps from epoch, asserted in the same file), which is what pinned the wedge to the scheduler rather than to the pull client.

## Decisions

- **New reason `abandoned-removed` rather than reusing `aborted-wipe`.** Event names and reasons are permanent, so this was worth getting right. `aborted-wipe` is a per-*cycle* bail that one download can collect many times — a pocketed phone, a sibling board's removal, a sign-out — and it also covers sign-out and global wipes. The new reason fires at most once per Started, gated by a marker the same transaction deletes, so "downloads the climber gave up on" becomes a count instead of a Started-minus-Completed subtraction.
- **New stage `board-removed`.** The teardown cannot know which stage the download was in — it may have been mid-artifact or hundreds of pages into the grades crawl — so reporting `download` or `import` would invent a precision it does not have.
- **The terminal is emitted by the teardown, not by the board-data loop.** Only the teardown can distinguish an abandoned download from a board that was never downloaded, and only before its own transaction commits.
- **Dedup is process-local and epoch-keyed.** A Started that survives a relaunch is still covered: the durable markers are the gate, and the in-process registry only suppresses the double-emit within one removal.
- **The scheduler's re-run is gated on the enabled set.** Re-running unconditionally would cost a full cycle on every board removal, including "Remove all".

## Residual gap

The field's relaunch-scale symptom (nine hours later, still no download) is not reproducible in the harness: a fresh process re-reads `syncEnabledBoards`, finds no markers, and downloads — which the new test asserts. The in-process wedge above fully explains a session that never re-downloads, and covers the relaunch case only if the app stayed in the foreground throughout. If a board is ever seen stuck across a relaunch again, the `abandoned-removed` terminal from this PR is the event that will say so.

## Release Notes

Switching a board off and straight back on no longer leaves it stuck on "waiting to download" — the download starts again as soon as the old copy finishes clearing out.
