### PR TITLE
fix: clean stale open PR worktrees

### DIFF
--- a/scripts/__tests__/cleanup-merged-worktrees.test.ts
+++ b/scripts/__tests__/cleanup-merged-worktrees.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 
 import { spawnSync } from 'node:child_process';
-import { chmod, cp, mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { access, chmod, cp, mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -15,6 +15,7 @@ type Fixture = {
   candidateHead: string;
   candidateWorktree: string;
   primaryWorktree: string;
+  realGitPath: string;
   scriptPath: string;
   stubBinDirectory: string;
 };
@@ -63,6 +64,9 @@ async function createFixture(headAgeSeconds: number): Promise<Fixture> {
   const candidateWorktree = join(rootDirectory, 'feature');
   const stubBinDirectory = join(rootDirectory, 'stub-bin');
   const scriptPath = join(primaryWorktree, 'scripts/cleanup-merged-worktrees.sh');
+  const realGitResult = run('sh', ['-c', 'command -v git'], rootDirectory);
+  expect(realGitResult.status, realGitResult.stderr).toBe(0);
+  const realGitPath = realGitResult.stdout.trim();
 
   const initResult = run('git', ['init', '--bare', '--initial-branch=main', bareRepository], rootDirectory);
   expect(initResult.status, initResult.stderr).toBe(0);
@@ -106,19 +110,33 @@ async function createFixture(headAgeSeconds: number): Promise<Fixture> {
       '    shift\n' +
       '  done\n' +
       '  if [ "$head_branch" = feature ]; then printf "%s\\n" "$GH_PR_JSON"; exit 0; fi\n' +
-      '  if [ "$head_branch" = trigger ] && [ -n "$GH_MUTATE_WORKTREE" ]; then\n' +
-      '    git -c core.hooksPath=/dev/null -C "$GH_MUTATE_WORKTREE" commit --allow-empty -m "test: advance after scan" >/dev/null 2>&1\n' +
-      '  fi\n' +
       '  printf "%s\\n" "${GH_OTHER_PR_JSON:-[]}"\n' +
       '  exit 0\n' +
       'fi\n' +
       'exit 1\n',
+  );
+  await writeExecutable(
+    join(stubBinDirectory, 'git'),
+    '#!/bin/sh\n' +
+      'if [ -n "${GIT_MUTATE_WORKTREE:-}" ] && [ -n "${GIT_MUTATE_COUNT_FILE:-}" ] && ' +
+      '[ "$#" -eq 4 ] && [ "$1" = -C ] && [ "$2" = "$GIT_MUTATE_WORKTREE" ] && ' +
+      '[ "$3" = rev-parse ] && [ "$4" = HEAD ]; then\n' +
+      '  mutation_count=0\n' +
+      '  if [ -f "$GIT_MUTATE_COUNT_FILE" ]; then IFS= read -r mutation_count < "$GIT_MUTATE_COUNT_FILE"; fi\n' +
+      '  mutation_count=$((mutation_count + 1))\n' +
+      '  printf "%s\\n" "$mutation_count" > "$GIT_MUTATE_COUNT_FILE"\n' +
+      '  if [ "$mutation_count" -eq 2 ]; then\n' +
+      '    "$REAL_GIT_PATH" -c core.hooksPath=/dev/null -C "$GIT_MUTATE_WORKTREE" commit --allow-empty -m "test: advance before apply revalidation" >/dev/null 2>&1\n' +
+      '  fi\n' +
+      'fi\n' +
+      'exec "$REAL_GIT_PATH" "$@"\n',
   );
 
   return {
     candidateHead,
     candidateWorktree,
     primaryWorktree,
+    realGitPath,
     scriptPath,
     stubBinDirectory,
   };
@@ -135,6 +153,17 @@ function openPullRequest(headRefOid?: string): PullRequest {
   };
 }
 
+function mergedPullRequest(headRefOid: string): PullRequest {
+  return {
+    headRefOid,
+    mergeCommit: { oid: headRefOid },
+    mergedAt: '2026-01-01T00:00:00Z',
+    number: 41,
+    state: 'MERGED',
+    url: 'https://github.com/boardsesh/boardsesh/pull/41',
+  };
+}
+
 function runCleanup(
   fixture: Fixture,
   pullRequests: PullRequest[],
@@ -144,6 +173,7 @@ function runCleanup(
   return run('bash', [fixture.scriptPath, ...args], fixture.primaryWorktree, {
     GH_PR_JSON: JSON.stringify(pullRequests),
     PATH: `${fixture.stubBinDirectory}:${process.env.PATH ?? ''}`,
+    REAL_GIT_PATH: fixture.realGitPath,
     ...extraEnvironment,
   });
 }
@@ -154,7 +184,9 @@ describe('cleanup-merged-worktrees open PR handling', () => {
 
     expect(result.status, result.stderr).toBe(0);
     expect(result.stdout).toContain('./cleanup-merged-worktrees.sh           # dry-run');
-    expect(result.stdout).toContain('./cleanup-merged-worktrees.sh --apply   # actually remove');
+    expect(result.stdout).toContain(
+      './cleanup-merged-worktrees.sh --apply   # remove worktrees; preserve open-PR branches',
+    );
   });
 
   it('removes a clean, in-sync open PR worktree once HEAD is 48 hours old', async () => {
@@ -166,9 +198,37 @@ describe('cleanup-merged-worktrees open PR handling', () => {
     expect(result.stdout).toContain('PR #42 OPEN and in sync, HEAD 48h old');
     expect(result.stdout).toContain('Eligible for removal: 1');
     expect(result.stdout).toContain('Removed: 1');
+    expect(result.stdout).toContain('preserved local branch feature (PR remains open)');
     expect(runGit(['worktree', 'list', '--porcelain'], fixture.primaryWorktree)).not.toContain(
       fixture.candidateWorktree,
     );
+    await expect(access(fixture.candidateWorktree)).rejects.toThrow();
+    expect(runGit(['rev-parse', 'feature'], fixture.primaryWorktree)).toBe(fixture.candidateHead);
+  });
+
+  it('continues deleting the local branch after removing a merged-PR worktree', async () => {
+    const fixture = await createFixture(72 * 60 * 60);
+
+    const result = runCleanup(fixture, [mergedPullRequest(fixture.candidateHead)], ['--apply']);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('PR #41 merged');
+    expect(result.stdout).toContain('deleted branch feature');
+    expect(
+      run('git', ['show-ref', '--verify', '--quiet', 'refs/heads/feature'], fixture.primaryWorktree).status,
+    ).not.toBe(0);
+  });
+
+  it('continues deleting an old no-PR branch whose content matches main', async () => {
+    const fixture = await createFixture(8 * 24 * 60 * 60);
+    runGit(['-c', 'core.hooksPath=/dev/null', 'cherry-pick', fixture.candidateHead], fixture.primaryWorktree);
+    runGit(['push', 'origin', 'main'], fixture.primaryWorktree);
+
+    const result = runCleanup(fixture, [], ['--apply']);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('no PR; tree matches origin/main, HEAD 8d old');
+    expect(result.stdout).toContain('deleted branch feature');
     expect(
       run('git', ['show-ref', '--verify', '--quiet', 'refs/heads/feature'], fixture.primaryWorktree).status,
     ).not.toBe(0);
@@ -254,23 +314,11 @@ describe('cleanup-merged-worktrees open PR handling', () => {
 
   it('revalidates an open PR worktree immediately before applying removal', async () => {
     const fixture = await createFixture(72 * 60 * 60);
-    const triggerWorktree = join(dirname(fixture.primaryWorktree), 'trigger');
-    runGit(['worktree', 'add', '-b', 'trigger', triggerWorktree, 'main'], fixture.primaryWorktree);
-
-    // The gh stub advances feature when the later trigger entry is scanned, so
-    // feature must be queued first for this test to exercise apply-time revalidation.
-    const worktreeListing = runGit(['worktree', 'list', '--porcelain'], fixture.primaryWorktree);
-    const candidateEntryIndex = worktreeListing.indexOf(`worktree ${fixture.candidateWorktree}`);
-    const triggerEntryIndex = worktreeListing.indexOf(`worktree ${triggerWorktree}`);
-    expect(candidateEntryIndex, 'race fixture is missing the feature worktree entry').toBeGreaterThanOrEqual(0);
-    expect(triggerEntryIndex, 'race fixture is missing the trigger worktree entry').toBeGreaterThanOrEqual(0);
-    expect(
-      candidateEntryIndex,
-      'race fixture requires feature to be scanned before trigger mutates its HEAD',
-    ).toBeLessThan(triggerEntryIndex);
+    const mutationCountPath = join(dirname(fixture.primaryWorktree), 'git-mutation-count');
 
     const result = runCleanup(fixture, [openPullRequest(fixture.candidateHead)], ['--apply'], {
-      GH_MUTATE_WORKTREE: fixture.candidateWorktree,
+      GIT_MUTATE_COUNT_FILE: mutationCountPath,
+      GIT_MUTATE_WORKTREE: fixture.candidateWorktree,
     });
 
     expect(result.status, result.stderr).toBe(0);
@@ -278,7 +326,8 @@ describe('cleanup-merged-worktrees open PR handling', () => {
     expect(result.stdout).toContain('worktree changed after eligibility scan');
     expect(result.stdout).toContain('Removed: 0');
     expect(result.stdout).toContain('Skipped after scan: 1');
-    expect(runGit(['rev-parse', 'HEAD'], fixture.candidateWorktree)).not.toBe(fixture.candidateHead);
-    expect(runGit(['rev-parse', 'feature'], fixture.primaryWorktree)).not.toBe(fixture.candidateHead);
+    const advancedHead = runGit(['rev-parse', 'HEAD'], fixture.candidateWorktree);
+    expect(advancedHead).not.toBe(fixture.candidateHead);
+    expect(runGit(['rev-parse', 'feature'], fixture.primaryWorktree)).toBe(advancedHead);
   });
 });

--- a/scripts/__tests__/cleanup-merged-worktrees.test.ts
+++ b/scripts/__tests__/cleanup-merged-worktrees.test.ts
@@ -229,6 +229,18 @@ describe('cleanup-merged-worktrees open PR handling', () => {
     expect(result.stdout).toContain('Skipped — dirty:      1');
   });
 
+  it('fails closed when status cannot be read for an open PR worktree', async () => {
+    const fixture = await createFixture(72 * 60 * 60);
+    await rm(fixture.candidateWorktree, { force: true, recursive: true });
+
+    const result = runCleanup(fixture, [openPullRequest(fixture.candidateHead)]);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('PR #42 OPEN; failed to read status');
+    expect(result.stdout).toContain('Eligible for removal: 0');
+    expect(result.stdout).toContain('Skipped — open PR:    1');
+  });
+
   it('keeps an in-sync open PR worktree whose HEAD timestamp is in the future', async () => {
     const fixture = await createFixture(-90 * 60);
 
@@ -244,6 +256,18 @@ describe('cleanup-merged-worktrees open PR handling', () => {
     const fixture = await createFixture(72 * 60 * 60);
     const triggerWorktree = join(dirname(fixture.primaryWorktree), 'trigger');
     runGit(['worktree', 'add', '-b', 'trigger', triggerWorktree, 'main'], fixture.primaryWorktree);
+
+    // The gh stub advances feature when the later trigger entry is scanned, so
+    // feature must be queued first for this test to exercise apply-time revalidation.
+    const worktreeListing = runGit(['worktree', 'list', '--porcelain'], fixture.primaryWorktree);
+    const candidateEntryIndex = worktreeListing.indexOf(`worktree ${fixture.candidateWorktree}`);
+    const triggerEntryIndex = worktreeListing.indexOf(`worktree ${triggerWorktree}`);
+    expect(candidateEntryIndex, 'race fixture is missing the feature worktree entry').toBeGreaterThanOrEqual(0);
+    expect(triggerEntryIndex, 'race fixture is missing the trigger worktree entry').toBeGreaterThanOrEqual(0);
+    expect(
+      candidateEntryIndex,
+      'race fixture requires feature to be scanned before trigger mutates its HEAD',
+    ).toBeLessThan(triggerEntryIndex);
 
     const result = runCleanup(fixture, [openPullRequest(fixture.candidateHead)], ['--apply'], {
       GH_MUTATE_WORKTREE: fixture.candidateWorktree,

--- a/scripts/__tests__/cleanup-merged-worktrees.test.ts
+++ b/scripts/__tests__/cleanup-merged-worktrees.test.ts
@@ -1,0 +1,260 @@
+/// <reference types="node" />
+
+import { spawnSync } from 'node:child_process';
+import { chmod, cp, mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it, onTestFinished } from 'vitest';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const cleanupScript = join(repositoryRoot, 'scripts/cleanup-merged-worktrees.sh');
+
+type Fixture = {
+  candidateHead: string;
+  candidateWorktree: string;
+  primaryWorktree: string;
+  scriptPath: string;
+  stubBinDirectory: string;
+};
+
+type PullRequest = {
+  headRefOid?: string;
+  mergeCommit: null | { oid: string };
+  mergedAt: null | string;
+  number: number;
+  state: 'MERGED' | 'OPEN';
+  url: string;
+};
+
+function run(command: string, args: string[], cwd: string, extraEnvironment: NodeJS.ProcessEnv = {}) {
+  return spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GIT_CONFIG_GLOBAL: '/dev/null',
+      GIT_CONFIG_NOSYSTEM: '1',
+      ...extraEnvironment,
+    },
+  });
+}
+
+function runGit(args: string[], cwd: string, extraEnvironment: NodeJS.ProcessEnv = {}): string {
+  const result = run('git', args, cwd, extraEnvironment);
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed:\n${result.stderr}`);
+  }
+  return result.stdout.trim();
+}
+
+async function writeExecutable(path: string, contents: string): Promise<void> {
+  await writeFile(path, contents, 'utf8');
+  await chmod(path, 0o755);
+}
+
+async function createFixture(headAgeSeconds: number): Promise<Fixture> {
+  const rootDirectory = await mkdtemp(join(tmpdir(), 'boardsesh-worktree-cleanup-'));
+  onTestFinished(() => rm(rootDirectory, { force: true, recursive: true }));
+
+  const bareRepository = join(rootDirectory, 'origin.git');
+  const primaryWorktree = join(rootDirectory, 'main');
+  const candidateWorktree = join(rootDirectory, 'feature');
+  const stubBinDirectory = join(rootDirectory, 'stub-bin');
+  const scriptPath = join(primaryWorktree, 'scripts/cleanup-merged-worktrees.sh');
+
+  const initResult = run('git', ['init', '--bare', '--initial-branch=main', bareRepository], rootDirectory);
+  expect(initResult.status, initResult.stderr).toBe(0);
+  const cloneResult = run('git', ['clone', bareRepository, primaryWorktree], rootDirectory);
+  expect(cloneResult.status, cloneResult.stderr).toBe(0);
+
+  runGit(['config', 'user.email', 'cleanup@example.com'], primaryWorktree);
+  runGit(['config', 'user.name', 'Cleanup Fixture'], primaryWorktree);
+  await writeFile(join(primaryWorktree, 'README.md'), '# cleanup fixture\n', 'utf8');
+  runGit(['add', 'README.md'], primaryWorktree);
+  runGit(['-c', 'core.hooksPath=/dev/null', 'commit', '-m', 'chore: seed cleanup fixture'], primaryWorktree);
+  runGit(['push', '-u', 'origin', 'main'], primaryWorktree);
+
+  runGit(['worktree', 'add', '-b', 'feature', candidateWorktree, 'main'], primaryWorktree);
+  await writeFile(join(candidateWorktree, 'feature.txt'), 'finished feature\n', 'utf8');
+  runGit(['add', 'feature.txt'], candidateWorktree);
+
+  const commitTimestamp = Math.floor(Date.now() / 1000) - headAgeSeconds;
+  const commitEnvironment = {
+    GIT_AUTHOR_DATE: `@${commitTimestamp} +0000`,
+    GIT_COMMITTER_DATE: `@${commitTimestamp} +0000`,
+  };
+  runGit(
+    ['-c', 'core.hooksPath=/dev/null', 'commit', '-m', 'feat: finish worktree change'],
+    candidateWorktree,
+    commitEnvironment,
+  );
+  const candidateHead = runGit(['rev-parse', 'HEAD'], candidateWorktree);
+
+  await mkdir(dirname(scriptPath), { recursive: true });
+  await mkdir(stubBinDirectory, { recursive: true });
+  await cp(cleanupScript, scriptPath);
+  await chmod(scriptPath, 0o755);
+  await writeExecutable(
+    join(stubBinDirectory, 'gh'),
+    '#!/bin/sh\n' +
+      'if [ "$1" = auth ] && [ "$2" = status ]; then exit 0; fi\n' +
+      'if [ "$1" = pr ] && [ "$2" = list ]; then\n' +
+      '  while [ "$#" -gt 0 ]; do\n' +
+      '    if [ "$1" = --head ]; then shift; head_branch="$1"; break; fi\n' +
+      '    shift\n' +
+      '  done\n' +
+      '  if [ "$head_branch" = feature ]; then printf "%s\\n" "$GH_PR_JSON"; exit 0; fi\n' +
+      '  if [ "$head_branch" = trigger ] && [ -n "$GH_MUTATE_WORKTREE" ]; then\n' +
+      '    git -c core.hooksPath=/dev/null -C "$GH_MUTATE_WORKTREE" commit --allow-empty -m "test: advance after scan" >/dev/null 2>&1\n' +
+      '  fi\n' +
+      '  printf "%s\\n" "${GH_OTHER_PR_JSON:-[]}"\n' +
+      '  exit 0\n' +
+      'fi\n' +
+      'exit 1\n',
+  );
+
+  return {
+    candidateHead,
+    candidateWorktree,
+    primaryWorktree,
+    scriptPath,
+    stubBinDirectory,
+  };
+}
+
+function openPullRequest(headRefOid?: string): PullRequest {
+  return {
+    ...(headRefOid === undefined ? {} : { headRefOid }),
+    mergeCommit: null,
+    mergedAt: null,
+    number: 42,
+    state: 'OPEN',
+    url: 'https://github.com/boardsesh/boardsesh/pull/42',
+  };
+}
+
+function runCleanup(
+  fixture: Fixture,
+  pullRequests: PullRequest[],
+  args: string[] = [],
+  extraEnvironment: NodeJS.ProcessEnv = {},
+) {
+  return run('bash', [fixture.scriptPath, ...args], fixture.primaryWorktree, {
+    GH_PR_JSON: JSON.stringify(pullRequests),
+    PATH: `${fixture.stubBinDirectory}:${process.env.PATH ?? ''}`,
+    ...extraEnvironment,
+  });
+}
+
+describe('cleanup-merged-worktrees open PR handling', () => {
+  it('shows both dry-run and apply invocations in help output', () => {
+    const result = run('bash', [cleanupScript, '--help'], repositoryRoot);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('./cleanup-merged-worktrees.sh           # dry-run');
+    expect(result.stdout).toContain('./cleanup-merged-worktrees.sh --apply   # actually remove');
+  });
+
+  it('removes a clean, in-sync open PR worktree once HEAD is 48 hours old', async () => {
+    const fixture = await createFixture(48 * 60 * 60);
+
+    const result = runCleanup(fixture, [openPullRequest(fixture.candidateHead)], ['--apply']);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('PR #42 OPEN and in sync, HEAD 48h old');
+    expect(result.stdout).toContain('Eligible for removal: 1');
+    expect(result.stdout).toContain('Removed: 1');
+    expect(runGit(['worktree', 'list', '--porcelain'], fixture.primaryWorktree)).not.toContain(
+      fixture.candidateWorktree,
+    );
+    expect(
+      run('git', ['show-ref', '--verify', '--quiet', 'refs/heads/feature'], fixture.primaryWorktree).status,
+    ).not.toBe(0);
+  });
+
+  it('keeps an in-sync open PR worktree whose HEAD is younger than 48 hours', async () => {
+    const fixture = await createFixture(47 * 60 * 60);
+
+    const result = runCleanup(fixture, [openPullRequest(fixture.candidateHead)]);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('PR #42 OPEN and in sync, but HEAD is 47h old');
+    expect(result.stdout).toContain('Eligible for removal: 0');
+    expect(result.stdout).toContain('Skipped — too fresh:  1');
+  });
+
+  it('keeps an old open PR worktree when its local HEAD is not the PR head', async () => {
+    const fixture = await createFixture(72 * 60 * 60);
+    const historicalMergedPullRequest: PullRequest = {
+      headRefOid: fixture.candidateHead,
+      mergeCommit: { oid: fixture.candidateHead },
+      mergedAt: '2026-01-01T00:00:00Z',
+      number: 12,
+      state: 'MERGED',
+      url: 'https://github.com/boardsesh/boardsesh/pull/12',
+    };
+
+    const result = runCleanup(fixture, [
+      historicalMergedPullRequest,
+      openPullRequest('0000000000000000000000000000000000000000'),
+    ]);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('PR #42 OPEN, but local HEAD is not in sync with PR head');
+    expect(result.stdout).toContain('Eligible for removal: 0');
+    expect(result.stdout).toContain('Skipped — open PR:    1');
+  });
+
+  it('keeps an old open PR worktree when GitHub omits the PR head OID', async () => {
+    const fixture = await createFixture(72 * 60 * 60);
+
+    const result = runCleanup(fixture, [openPullRequest()]);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('PR #42 OPEN, but local HEAD is not in sync with PR head');
+    expect(result.stdout).toContain('Eligible for removal: 0');
+  });
+
+  it('keeps an old, in-sync open PR worktree when it has uncommitted changes', async () => {
+    const fixture = await createFixture(72 * 60 * 60);
+    await writeFile(join(fixture.candidateWorktree, 'uncommitted.txt'), 'keep me\n', 'utf8');
+
+    const result = runCleanup(fixture, [openPullRequest(fixture.candidateHead)]);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('PR #42 OPEN, but 1 uncommitted file(s)');
+    expect(result.stdout).toContain('Eligible for removal: 0');
+    expect(result.stdout).toContain('Skipped — dirty:      1');
+  });
+
+  it('keeps an in-sync open PR worktree whose HEAD timestamp is in the future', async () => {
+    const fixture = await createFixture(-90 * 60);
+
+    const result = runCleanup(fixture, [openPullRequest(fixture.candidateHead)]);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('PR #42 OPEN and in sync, but HEAD is -1h old');
+    expect(result.stdout).toContain('Eligible for removal: 0');
+    expect(result.stdout).toContain('Skipped — too fresh:  1');
+  });
+
+  it('revalidates an open PR worktree immediately before applying removal', async () => {
+    const fixture = await createFixture(72 * 60 * 60);
+    const triggerWorktree = join(dirname(fixture.primaryWorktree), 'trigger');
+    runGit(['worktree', 'add', '-b', 'trigger', triggerWorktree, 'main'], fixture.primaryWorktree);
+
+    const result = runCleanup(fixture, [openPullRequest(fixture.candidateHead)], ['--apply'], {
+      GH_MUTATE_WORKTREE: fixture.candidateWorktree,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('Eligible for removal: 1');
+    expect(result.stdout).toContain('worktree changed after eligibility scan');
+    expect(result.stdout).toContain('Removed: 0');
+    expect(result.stdout).toContain('Skipped after scan: 1');
+    expect(runGit(['rev-parse', 'HEAD'], fixture.candidateWorktree)).not.toBe(fixture.candidateHead);
+    expect(runGit(['rev-parse', 'feature'], fixture.primaryWorktree)).not.toBe(fixture.candidateHead);
+  });
+});

--- a/scripts/cleanup-merged-worktrees.sh
+++ b/scripts/cleanup-merged-worktrees.sh
@@ -7,7 +7,7 @@
 #
 # Usage:
 #   ./cleanup-merged-worktrees.sh           # dry-run: show what would be removed
-#   ./cleanup-merged-worktrees.sh --apply   # actually remove eligible worktrees
+#   ./cleanup-merged-worktrees.sh --apply   # remove worktrees; preserve open-PR branches
 
 set -euo pipefail
 
@@ -67,6 +67,8 @@ fi
 
 declare -a TO_REMOVE_PATHS=()
 declare -a TO_REMOVE_BRANCHES=()
+# Non-empty only for open-PR candidates. The OID is used for apply-time
+# revalidation and also marks the associated local branch for preservation.
 declare -a TO_REMOVE_EXPECTED_HEADS=()
 
 skipped_no_branch=0
@@ -389,7 +391,7 @@ fi
 
 if [ "$APPLY" -eq 0 ]; then
   echo
-  printf "%sDry run.%s Re-run with %s--apply%s to actually remove the worktrees and their branches.\n" \
+  printf "%sDry run.%s Re-run with %s--apply%s to remove eligible worktrees; open-PR branches are preserved.\n" \
     "$C_BLUE" "$C_RESET" "$C_BLUE" "$C_RESET"
   exit 0
 fi
@@ -426,7 +428,10 @@ for i in "${!TO_REMOVE_PATHS[@]}"; do
   if git_root worktree remove "$path"; then
     printf "  %s✓%s removed worktree %s\n" "$C_GREEN" "$C_RESET" "$path"
     if [ -n "$branch" ]; then
-      if git_root branch -D "$branch" >/dev/null 2>&1; then
+      if [ -n "$expected_head" ]; then
+        printf "  %s✓%s preserved local branch %s (PR remains open)\n" \
+          "$C_GREEN" "$C_RESET" "$branch"
+      elif git_root branch -D "$branch" >/dev/null 2>&1; then
         printf "  %s✓%s deleted branch %s\n" "$C_GREEN" "$C_RESET" "$branch"
       else
         printf "  %s!%s could not delete branch %s (may have unmerged commits)\n" "$C_YELLOW" "$C_RESET" "$branch"

--- a/scripts/cleanup-merged-worktrees.sh
+++ b/scripts/cleanup-merged-worktrees.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 #
-# Cleanup git worktrees whose branches have a merged PR and no uncommitted changes.
+# Cleanup inactive git worktrees that have no uncommitted work to preserve.
+#
+# Eligible worktrees either have a merged PR, or have an open PR whose head is
+# exactly in sync with a local HEAD commit that is at least 48 hours old.
 #
 # Usage:
 #   ./cleanup-merged-worktrees.sh           # dry-run: show what would be removed
@@ -13,7 +16,7 @@ for arg in "$@"; do
   case "$arg" in
     --apply) APPLY=1 ;;
     -h|--help)
-      sed -n '2,8p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     *)
@@ -64,6 +67,7 @@ fi
 
 declare -a TO_REMOVE_PATHS=()
 declare -a TO_REMOVE_BRANCHES=()
+declare -a TO_REMOVE_EXPECTED_HEADS=()
 
 skipped_no_branch=0
 skipped_no_pr=0
@@ -76,6 +80,10 @@ skipped_main=0
 # Branches with no PR but no extra content vs main need to be at least this old
 # (HEAD commit timestamp) before we'll remove them. 7 days = 604800 seconds.
 NO_PR_MIN_AGE_SECONDS=$((7 * 24 * 60 * 60))
+
+# Open PR worktrees are eligible only when their local HEAD exactly matches the
+# PR head and the shared commit has been inactive for at least 48 hours.
+OPEN_PR_MIN_AGE_SECONDS=$((48 * 60 * 60))
 
 # Resolve the upstream main reference (origin/main, or origin/master as fallback).
 # Used to check whether a branch with no PR has any content not already in main.
@@ -175,13 +183,15 @@ flush_entry() {
     fi
     TO_REMOVE_PATHS+=("$path")
     TO_REMOVE_BRANCHES+=("")
+    TO_REMOVE_EXPECTED_HEADS+=("")
     printf "%s✓ remove%s %s %s(detached; tree matches %s, HEAD %s old)%s\n" \
       "$C_GREEN" "$C_RESET" "$path" "$C_DIM" "$UPSTREAM_MAIN" \
       "$((age / 86400))d" "$C_RESET"
     return
   fi
 
-  # Look up PR(s) for this branch. Take MERGED if any; OPEN otherwise.
+  # Look up PR(s) for this branch. An OPEN PR takes precedence over a
+  # historical MERGED PR because branch names can be reused.
   local pr_json
   pr_json=$(gh pr list --head "$branch" --state all \
     --json number,state,mergedAt,url,headRefOid,mergeCommit 2>/dev/null || echo "[]")
@@ -236,19 +246,58 @@ flush_entry() {
 
     TO_REMOVE_PATHS+=("$path")
     TO_REMOVE_BRANCHES+=("$branch")
+    TO_REMOVE_EXPECTED_HEADS+=("")
     printf "%s✓ remove%s %s [%s] %s(no PR; tree matches %s, HEAD %s old)%s\n" \
       "$C_GREEN" "$C_RESET" "$path" "$branch" "$C_DIM" "$UPSTREAM_MAIN" \
       "$((age / 86400))d" "$C_RESET"
     return
   fi
 
-  if [ -z "$merged_pr" ]; then
-    skipped_open_pr=$((skipped_open_pr + 1))
-    local pr_num pr_url
+  if [ -n "$open_pr" ]; then
+    local pr_num pr_url pr_head_oid local_oid dirty age
     pr_num=$(echo "$open_pr" | jq -r '.number')
     pr_url=$(echo "$open_pr" | jq -r '.url')
-    printf "%s» skip%s %s [%s] %s(PR #%s OPEN: %s)%s\n" \
-      "$C_DIM" "$C_RESET" "$path" "$branch" "$C_YELLOW" "$pr_num" "$pr_url" "$C_RESET"
+    pr_head_oid=$(echo "$open_pr" | jq -r '.headRefOid // empty')
+
+    if ! dirty=$(git -C "$path" status --porcelain 2>/dev/null); then
+      skipped_open_pr=$((skipped_open_pr + 1))
+      printf "%s» skip%s %s [%s] %s(PR #%s OPEN; failed to read status)%s\n" \
+        "$C_RED" "$C_RESET" "$path" "$branch" "$C_RED" "$pr_num" "$C_RESET"
+      return
+    fi
+
+    if [ -n "$dirty" ]; then
+      skipped_dirty=$((skipped_dirty + 1))
+      local file_count
+      file_count=$(echo "$dirty" | wc -l | tr -d ' ')
+      printf "%s» keep%s %s [%s] %s(PR #%s OPEN, but %s uncommitted file(s))%s\n" \
+        "$C_YELLOW" "$C_RESET" "$path" "$branch" "$C_YELLOW" "$pr_num" "$file_count" "$C_RESET"
+      return
+    fi
+
+    local_oid=$(git -C "$path" rev-parse HEAD 2>/dev/null || echo "")
+    if [ -z "$pr_head_oid" ] || [ -z "$local_oid" ] || [ "$local_oid" != "$pr_head_oid" ]; then
+      skipped_open_pr=$((skipped_open_pr + 1))
+      printf "%s» keep%s %s [%s] %s(PR #%s OPEN, but local HEAD is not in sync with PR head: %s)%s\n" \
+        "$C_YELLOW" "$C_RESET" "$path" "$branch" "$C_YELLOW" "$pr_num" "$pr_url" "$C_RESET"
+      return
+    fi
+
+    age=$(head_age_seconds "$path") || age=0
+    if [ "$age" -lt "$OPEN_PR_MIN_AGE_SECONDS" ]; then
+      skipped_too_fresh=$((skipped_too_fresh + 1))
+      printf "%s» keep%s %s [%s] %s(PR #%s OPEN and in sync, but HEAD is %sh old)%s\n" \
+        "$C_YELLOW" "$C_RESET" "$path" "$branch" "$C_YELLOW" "$pr_num" \
+        "$((age / 3600))" "$C_RESET"
+      return
+    fi
+
+    TO_REMOVE_PATHS+=("$path")
+    TO_REMOVE_BRANCHES+=("$branch")
+    TO_REMOVE_EXPECTED_HEADS+=("$local_oid")
+    printf "%s✓ remove%s %s [%s] %s(PR #%s OPEN and in sync, HEAD %sh old)%s\n" \
+      "$C_GREEN" "$C_RESET" "$path" "$branch" "$C_DIM" "$pr_num" \
+      "$((age / 3600))" "$C_RESET"
     return
   fi
 
@@ -305,6 +354,7 @@ flush_entry() {
 
   TO_REMOVE_PATHS+=("$path")
   TO_REMOVE_BRANCHES+=("$branch")
+  TO_REMOVE_EXPECTED_HEADS+=("")
   printf "%s✓ remove%s %s [%s] %s(PR #%s merged)%s\n" \
     "$C_GREEN" "$C_RESET" "$path" "$branch" "$C_DIM" "$pr_num" "$C_RESET"
 }
@@ -348,9 +398,30 @@ echo
 echo "Removing worktrees..."
 removed=0
 failed=0
+skipped_during_apply=0
 for i in "${!TO_REMOVE_PATHS[@]}"; do
   path="${TO_REMOVE_PATHS[$i]}"
   branch="${TO_REMOVE_BRANCHES[$i]}"
+  expected_head="${TO_REMOVE_EXPECTED_HEADS[$i]}"
+
+  # Open-PR eligibility depends on the worktree still being clean and exactly
+  # at the PR head observed during the scan. Fail closed if anything changed
+  # before removal so a commit made during this run cannot be discarded.
+  if [ -n "$expected_head" ]; then
+    if ! worktree_clean "$path"; then
+      printf "  %s!%s skipped %s (worktree changed after eligibility scan)\n" \
+        "$C_YELLOW" "$C_RESET" "$path"
+      skipped_during_apply=$((skipped_during_apply + 1))
+      continue
+    fi
+    current_head=$(git -C "$path" rev-parse HEAD 2>/dev/null || echo "")
+    if [ "$current_head" != "$expected_head" ]; then
+      printf "  %s!%s skipped %s (worktree changed after eligibility scan)\n" \
+        "$C_YELLOW" "$C_RESET" "$path"
+      skipped_during_apply=$((skipped_during_apply + 1))
+      continue
+    fi
+  fi
 
   if git_root worktree remove "$path"; then
     printf "  %s✓%s removed worktree %s\n" "$C_GREEN" "$C_RESET" "$path"
@@ -369,7 +440,8 @@ for i in "${!TO_REMOVE_PATHS[@]}"; do
 done
 
 echo
-printf "Done. Removed: %s%d%s   Failed: %s%d%s\n" \
-  "$C_GREEN" "$removed" "$C_RESET" "$C_RED" "$failed" "$C_RESET"
+printf "Done. Removed: %s%d%s   Failed: %s%d%s   Skipped after scan: %s%d%s\n" \
+  "$C_GREEN" "$removed" "$C_RESET" "$C_RED" "$failed" "$C_RESET" \
+  "$C_YELLOW" "$skipped_during_apply" "$C_RESET"
 
 git_root worktree prune


### PR DESCRIPTION
## Summary

- clean open-PR worktrees when their commit is at least 48 hours old
- require a clean worktree and an exact match between local HEAD and the PR head
- remove the checked-out worktree and files while preserving the local branch for an open PR
- revalidate the worktree immediately before removal so a commit made during the scan is preserved
- keep current, main, dirty, fresh, missing-head, and diverged worktrees protected
- keep the existing branch-deletion behavior for merged and no-PR cleanup
- add focused fixture coverage for eligibility, successful removal, branch policy, status failures, and the apply-time race

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run scripts/__tests__/cleanup-merged-worktrees.test.ts --reporter=agent` (11 tests passed)
- `vp check scripts/cleanup-merged-worktrees.sh scripts/__tests__/cleanup-merged-worktrees.test.ts`
- `bash -n scripts/cleanup-merged-worktrees.sh`
- staged pre-commit checks passed