### PR TITLE
fix(db): drop the phantom gyms.website_vouched_by_owner from the tip snapshot

### DIFF
--- a/packages/db/drizzle/meta/0192_snapshot.json
+++ b/packages/db/drizzle/meta/0192_snapshot.json
@@ -4506,13 +4506,6 @@
           "primaryKey": false,
           "notNull": false
         },
-        "website_vouched_by_owner": {
-          "name": "website_vouched_by_owner",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
         "contact_email": {
           "name": "contact_email",
           "type": "text",


### PR DESCRIPTION
## What's wrong

`main`'s newest migration snapshot declares a column that does not exist anywhere else:

- `packages/db/drizzle/meta/0192_snapshot.json` has `gyms.website_vouched_by_owner`
- **No migration on `main` creates it** — I checked every `.sql` file in `packages/db/drizzle/`
- `packages/db/src/schema/app/gyms.ts` on `main` does not define it either

So production does not have the column, and the snapshot says it does.

## How it got there

The five-PR squash (`50260079`) that landed #4054, #4025 and #4052 was generated while #4058 was still in the stack lineage. The squash carried #4058's **snapshot state** without carrying its `ADD COLUMN` migration or its schema change — #4058 is still open.

`0192_snapshot.json` is the tip of the chain (`0193_moonboard_angle_dedup_backfill` is data-only, so it has no snapshot), which is what makes this bite.

## Why it needs fixing now

`drizzle-kit generate` diffs the built schema against the **newest** snapshot. Right now on `main` that comparison is "schema has no such column, snapshot does", so the next migration anyone generates off `main` carries:

```sql
ALTER TABLE "gyms" DROP COLUMN "website_vouched_by_owner";
```

for a column production does not have. That migration fails on apply.

It also blocks #4058 from the other direction: that branch's schema *does* have the column, so against this snapshot `generate` sees no delta at all and emits nothing. `vp run db:renumber` correctly refuses rather than guess — which is how this surfaced.

Repairing it inside #4058 does not work: `db-renumber-migration.ts` calls `resetMetaToBase`, which runs `git checkout <base> -- packages/db/drizzle/meta/` before generating, so it restores `main`'s version of the snapshot and blocks again. The fix has to be on `main` first.

## Why this edit is safe

- **Snapshots are never applied.** They are `drizzle-kit generate` metadata only. `packages/db/scripts/migrate.ts` applies journal entries and their `.sql` files.
- **No hash changes.** The ledger in `drizzle.__drizzle_migrations` is keyed on `.sql` content, so nothing replays and `VERIFY_MIGRATION_JOURNAL=1` is unaffected. `docs/db-migrations.md`'s "applied migrations are not editable" rule is about `.sql` bodies, which this does not touch.
- **It restores the truth.** After this, the snapshot chain describes the database that actually exists.

`vp run check:db-migrations -- --base origin/main` → *194 migrations, journal consistent.*

## After this lands

#4058 rebases and its `ADD COLUMN` generates normally against a truthful tip, which is the correct place for that column to enter the schema.

## Release Notes

- [x] No release note needed (internal / technical change)
