### PR TITLE
test(mobile): verify MoonBoard adjacent-hold re-light packet

### DIFF
--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -507,7 +507,7 @@ describe('useBoardBluetooth', () => {
     expect(activityListener).toHaveBeenCalledTimes(2);
   });
 
-  it('threads moonboardLightAdjacentHolds through to the packet builder', async () => {
+  it('uses an updated moonboardLightAdjacentHolds setting on the live connection', async () => {
     const fakeAdapter = makeFakeAdapter();
     vi.mocked(createBluetoothAdapter).mockReturnValue(
       fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
@@ -519,8 +519,15 @@ describe('useBoardBluetooth', () => {
       totalPlacements: 1,
       isClear: false,
     });
-    const { result } = renderHook(() =>
-      useBoardBluetooth({ boardName: 'moonboard', layoutId: 1, sizeId: 1, moonboardLightAdjacentHolds: true }),
+    const { result, rerender } = renderHook(
+      ({ lightAdjacentHolds }) =>
+        useBoardBluetooth({
+          boardName: 'moonboard',
+          layoutId: 1,
+          sizeId: 1,
+          moonboardLightAdjacentHolds: lightAdjacentHolds,
+        }),
+      { initialProps: { lightAdjacentHolds: false } },
     );
 
     await act(async () => {
@@ -529,8 +536,13 @@ describe('useBoardBluetooth', () => {
     await act(async () => {
       await result.current.sendFramesToBoard('p1r12');
     });
+    rerender({ lightAdjacentHolds: true });
+    await act(async () => {
+      await result.current.sendFramesToBoard('p1r12');
+    });
 
-    expect(mockGetMoonboardBluetoothPacket).toHaveBeenCalledWith('p1r12', 18, { lightAdjacentHolds: true });
+    expect(mockGetMoonboardBluetoothPacket).toHaveBeenNthCalledWith(1, 'p1r12', 18, { lightAdjacentHolds: false });
+    expect(mockGetMoonboardBluetoothPacket).toHaveBeenNthCalledWith(2, 'p1r12', 18, { lightAdjacentHolds: true });
   });
 
   it('tracks connect-initial MoonBoard frames until the adapter write settles', async () => {

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
-import { act, render, waitFor, cleanup } from '@testing-library/react';
+import { act, render, waitFor, cleanup, fireEvent } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createElement, type ReactNode } from 'react';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
 import type { BoardSerialConfig } from '@boardsesh/graphql/operations';
+import { getMoonboardBluetoothPacket } from '@boardsesh/ble-protocol/moonboard';
 import type { ResolvedBoardEntry } from '../../lib/ble/resolve-serials';
 import type { BleConnectionEnded, BleConnectionHandle, PickerState } from '../../lib/ble/use-board-bluetooth';
 import { setHoldColorOverridesPreference } from '../../lib/hold-color-overrides';
@@ -15,6 +16,7 @@ type BluetoothHookOptions = {
   onConnectSuccess?: (serial: string | null, connection: BleConnectionHandle) => void;
   onConnectionEnded?: (connection: BleConnectionEnded) => void;
   holdsData?: unknown;
+  moonboardLightAdjacentHolds?: boolean;
 };
 
 function makeConnectionHandle(
@@ -61,6 +63,7 @@ const queue = vi.hoisted(() => ({
 const bluetooth = vi.hoisted(() => {
   const mock = {
     options: undefined as BluetoothHookOptions | undefined,
+    sendFramesToBoardForOptions: null as ((options: BluetoothHookOptions) => SendFramesToBoard) | null,
     state: {
       isConnected: true,
       loading: false,
@@ -73,6 +76,12 @@ const bluetooth = vi.hoisted(() => {
     },
     useBoardBluetooth: vi.fn((options: BluetoothHookOptions) => {
       mock.options = options;
+      if (mock.sendFramesToBoardForOptions) {
+        return {
+          ...mock.state,
+          sendFramesToBoard: mock.sendFramesToBoardForOptions(options),
+        };
+      }
       return mock.state;
     }),
   };
@@ -112,9 +121,16 @@ vi.mock('react-native', () => ({
   AppState: { addEventListener: () => ({ remove: vi.fn() }) },
 }));
 
-vi.mock('../../settings', () => ({
-  useSetting: (key: string) => (key === 'autoDisconnectBle' ? [false, vi.fn()] : [30, vi.fn()]),
-}));
+vi.mock('../../settings', async () => {
+  const { useState } = await import('react');
+  return {
+    useSetting: (key: string) => {
+      const moonboardLightAdjacentHolds = useState(false);
+      if (key === 'moonboardLightAdjacentHolds') return moonboardLightAdjacentHolds;
+      return key === 'autoDisconnectBle' ? [false, vi.fn()] : [30, vi.fn()];
+    },
+  };
+});
 
 vi.mock('@boardsesh/play-view', () => ({
   emitWallConfirm: wallConfirm.emitWallConfirm,
@@ -159,6 +175,7 @@ vi.mock('../../lib/ble/resolve-serials', () => ({
 
 vi.mock('../../lib/ble/bluetooth-status-store', () => ({
   registerBluetoothConnection: vi.fn(() => vi.fn()),
+  disconnectAllBluetooth: vi.fn(),
 }));
 
 vi.mock('../../lib/haptics', () => ({
@@ -189,6 +206,15 @@ vi.mock('../../components/ble/DevicePickerSheet', () => ({
     pickerSheet.props = props;
     return createElement('div', { 'data-testid': 'device-picker' });
   },
+}));
+
+vi.mock('../../components/ble/BleControlSheet', () => ({
+  BleControlSheet: ({ onToggleLightAdjacentHolds }: { onToggleLightAdjacentHolds: (enabled: boolean) => void }) =>
+    createElement(
+      'button',
+      { type: 'button', onClick: () => onToggleLightAdjacentHolds(true) },
+      'toggle adjacent holds',
+    ),
 }));
 
 vi.mock('../queue-provider', () => ({
@@ -224,6 +250,7 @@ vi.mock('../../lib/board-details', () => ({
 }));
 
 import { BluetoothProvider, useBluetoothContext } from '../bluetooth-provider';
+import { BleControlSheetHost } from '../../components/ble/BleControlSheetHost';
 
 function makeQueueItem(uuid: string, frames = 'p1r12', mirrored = false): ClimbQueueItem {
   return {
@@ -272,6 +299,18 @@ function renderProvider(children?: ReactNode) {
   );
 }
 
+function renderMoonboardProvider(children?: ReactNode) {
+  return render(
+    createElement(BluetoothProvider, {
+      boardName: 'moonboard',
+      layoutId: 1,
+      sizeId: 1,
+      setIds: '1',
+      children: children ?? createElement('div', null),
+    }),
+  );
+}
+
 let capturedBluetooth: ReturnType<typeof useBluetoothContext> | null = null;
 
 function BluetoothProbe() {
@@ -310,6 +349,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
     pickerSheet.props = null;
     resolvedBoards.value = new Map();
     bluetooth.options = undefined;
+    bluetooth.sendFramesToBoardForOptions = null;
     bluetooth.state.isConnected = true;
     bluetooth.state.loading = false;
     bluetooth.state.pickerState = null;
@@ -356,6 +396,35 @@ describe('BluetoothProvider wall-confirm integration', () => {
 
     expect(wallConfirm.emitWallConfirm).toHaveBeenCalledWith('climb-1');
     expect(queue.confirmClimbOnWall).toHaveBeenCalledWith('climb-1');
+  });
+
+  it('writes the updated MoonBoard packet after the control sheet enables adjacent holds', async () => {
+    queue.currentClimbQueueItem = makeQueueItem('moon-climb', 'p1r42');
+    const adapterWrite = vi.fn(async (_packet: Uint8Array) => {});
+    bluetooth.sendFramesToBoardForOptions = (options) => async (frames) => {
+      const { packet } = getMoonboardBluetoothPacket(frames, 18, {
+        lightAdjacentHolds: options.moonboardLightAdjacentHolds,
+      });
+      await adapterWrite(packet);
+      return true;
+    };
+
+    const { getByText } = renderMoonboardProvider(
+      createElement(BleControlSheetHost, { visible: true, onClose: vi.fn() }),
+    );
+
+    await waitFor(() => {
+      expect(adapterWrite).toHaveBeenCalledTimes(1);
+    });
+    expect(new TextDecoder().decode(adapterWrite.mock.calls[0]?.[0])).toBe('l#S0#');
+
+    fireEvent.click(getByText('toggle adjacent holds'));
+
+    await waitFor(() => {
+      expect(adapterWrite).toHaveBeenCalledTimes(2);
+    });
+    expect(bluetooth.options?.moonboardLightAdjacentHolds).toBe(true);
+    expect(new TextDecoder().decode(adapterWrite.mock.calls[1]?.[0])).toBe('~Dl#S0#');
   });
 
   it('skips the duplicate send when connect() already wrote the same frames, but still confirms', async () => {

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -125,9 +125,8 @@ vi.mock('../../settings', async () => {
   const { useState } = await import('react');
   return {
     useSetting: (key: string) => {
-      const moonboardLightAdjacentHolds = useState(false);
-      if (key === 'moonboardLightAdjacentHolds') return moonboardLightAdjacentHolds;
-      return key === 'autoDisconnectBle' ? [false, vi.fn()] : [30, vi.fn()];
+      const initialValue = key === 'autoDisconnectBle' || key === 'moonboardLightAdjacentHolds' ? false : 30;
+      return useState(initialValue);
     },
   };
 });
@@ -209,10 +208,16 @@ vi.mock('../../components/ble/DevicePickerSheet', () => ({
 }));
 
 vi.mock('../../components/ble/BleControlSheet', () => ({
-  BleControlSheet: ({ onToggleLightAdjacentHolds }: { onToggleLightAdjacentHolds: (enabled: boolean) => void }) =>
+  BleControlSheet: ({
+    lightAdjacentHoldsEnabled,
+    onToggleLightAdjacentHolds,
+  }: {
+    lightAdjacentHoldsEnabled: boolean;
+    onToggleLightAdjacentHolds: (enabled: boolean) => void;
+  }) =>
     createElement(
       'button',
-      { type: 'button', onClick: () => onToggleLightAdjacentHolds(true) },
+      { type: 'button', onClick: () => onToggleLightAdjacentHolds(!lightAdjacentHoldsEnabled) },
       'toggle adjacent holds',
     ),
 }));
@@ -398,7 +403,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
     expect(queue.confirmClimbOnWall).toHaveBeenCalledWith('climb-1');
   });
 
-  it('writes the updated MoonBoard packet after the control sheet enables adjacent holds', async () => {
+  it('writes updated MoonBoard packets when the control sheet toggles adjacent holds', async () => {
     queue.currentClimbQueueItem = makeQueueItem('moon-climb', 'p1r42');
     const adapterWrite = vi.fn(async (_packet: Uint8Array) => {});
     bluetooth.sendFramesToBoardForOptions = (options) => async (frames) => {
@@ -425,6 +430,14 @@ describe('BluetoothProvider wall-confirm integration', () => {
     });
     expect(bluetooth.options?.moonboardLightAdjacentHolds).toBe(true);
     expect(new TextDecoder().decode(adapterWrite.mock.calls[1]?.[0])).toBe('~Dl#S0#');
+
+    fireEvent.click(getByText('toggle adjacent holds'));
+
+    await waitFor(() => {
+      expect(adapterWrite).toHaveBeenCalledTimes(3);
+    });
+    expect(bluetooth.options?.moonboardLightAdjacentHolds).toBe(false);
+    expect(new TextDecoder().decode(adapterWrite.mock.calls[2]?.[0])).toBe('l#S0#');
   });
 
   it('skips the duplicate send when connect() already wrote the same frames, but still confirms', async () => {

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -125,6 +125,9 @@ vi.mock('../../settings', async () => {
   const { useState } = await import('react');
   return {
     useSetting: (key: string) => {
+      // Mirror the real custom hook: every call owns one state slot. BluetoothProvider
+      // invokes its settings unconditionally in a fixed order, so this setter can
+      // rerender the provider without a test-only rerender seam.
       const initialValue = key === 'autoDisconnectBle' || key === 'moonboardLightAdjacentHolds' ? false : 30;
       return useState(initialValue);
     },


### PR DESCRIPTION
## Summary

Closes the test-quality gap found while reviewing the next-OTA aggregate (#4457).

- Mounts the real `BleControlSheetHost` inside `BluetoothProvider`.
- Toggles MoonBoard adjacent holds through the control-sheet callback and stateful provider setting.
- Lets `BluetoothAutoSender` perform the reasserted write.
- Observes the adapter seam with the real MoonBoard encoder: the live wall write round-trips `l#S0#` → `~Dl#S0#` → `l#S0#`.
- Strengthens the hook test so a connected `useBoardBluetooth` instance must use the updated option after rerender.

This PR’s two-file delta is test-only and does not change either native fingerprint. The branch still inherits the cumulative native train’s fingerprints relative to `main`, so the `native-fingerprint` label and native CI are expected.

## Regression strength

A mutation that hard-codes `BluetoothProvider` to pass `moonboardLightAdjacentHolds: false` makes the new provider integration fail. The previous call-order-only test did not catch that broken wiring.

Codex Sol performed the required Fable-equivalent BLE review on exact head `55281a105`: PASS, no P0–P3 findings.

## Validation

- `vp check` on both changed files
- focused BLE/provider suites, including the 46-case provider integration suite
- `vp run typecheck:mobile`
- `vp run test:mobile` — 669 files / 6,442 tests
- `vp run check:mobile-bundle` — iOS and Android
- pre-commit hook
- `git diff --check`

## Release Notes

- [x] No release note needed (internal / technical change)