### PR TITLE
chore(mobile): prepare 2.4.0 store release

### DIFF
--- a/fastlane/metadata/android/de-DE/changelogs/default.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/default.txt
@@ -1,8 +1,4 @@
-Neu:
-- Lade ein Board herunter und klettere ohne Empfang. Begehungen syncen, sobald du zurück bist.
-- Der Boardsesh-Grad liest sich auf Kilter, Tension und MoonBoard gleich, aus echten Begehungen.
-- Jede Halle bekommt eine öffentliche Seite und ein Wand-Display für den Fernseher.
-- Android-Tablets bekommen die Zwei-Spalten-Wandansicht.
-- Sortierung Zufall, Projektfilter und angepinnte Filter.
-
-Behoben: schnelleres Bluetooth, und dein Board taucht beim Neuverbinden wieder auf.
+Neu in 2.4:
+- MoonBoard: Aktiviere „Griff darüber beleuchten“ für eine zweite, gedimmte LED über jedem beleuchteten Start- oder Handgriff auf unterstützten Controllern.
+- Panels schließen nach dem Wechsel in den Hintergrund oder zwischen Screens zuverlässig.
+- Geteilte Dateien bleiben im Boardsesh-Cache, auch wenn eine andere App einen ungewöhnlichen Namen liefert.

--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,8 +1,4 @@
-New:
-- Download a board and keep climbing with no signal. Sends sync when you're back.
-- The Boardsesh grade reads the same on Kilter, Tension and MoonBoard, built from real sends.
-- Every gym gets a public page, plus a TV wall screen at boardsesh.com/kiosk/your-gym.
-- Android tablets get the full two-pane wall layout.
-- A Random sort, a projects filter, and pinned filter shortcuts.
-
-Fixed: faster Bluetooth, and your board shows up again on reconnect.
+New in 2.4:
+- MoonBoard: turn on “Light the hold above” for a dimmer LED above each lit start and hand hold on supported controllers.
+- Sheets close reliably after backgrounding or moving between screens.
+- Files shared into Boardsesh stay safely inside its cache, even when another app sends an unusual filename.

--- a/fastlane/metadata/android/es-ES/changelogs/default.txt
+++ b/fastlane/metadata/android/es-ES/changelogs/default.txt
@@ -1,8 +1,4 @@
-Novedades:
-- Descarga un plafón y sigue escalando sin cobertura. Los encadenes se sincronizan al volver.
-- El grado Boardsesh se lee igual en Kilter, Tension y MoonBoard, hecho con encadenes reales.
-- Cada rocódromo tiene página pública y pantalla de muro para la tele.
-- Las tablets Android estrenan la vista de muro a dos paneles.
-- Orden Aleatorio, filtro de proyectos y filtros fijados.
-
-Arreglado: Bluetooth más rápido y tu plafón reaparece al reconectar.
+Novedades de 2.4:
+- MoonBoard: activa «Iluminar la presa de arriba» para añadir un LED tenue sobre cada presa de inicio o de mano iluminada en controladores compatibles.
+- Los paneles se cierran bien después de dejar la app en segundo plano o cambiar de pantalla.
+- Los archivos compartidos con Boardsesh se quedan dentro de su caché aunque otra app envíe un nombre poco habitual.

--- a/fastlane/metadata/android/fr-FR/changelogs/default.txt
+++ b/fastlane/metadata/android/fr-FR/changelogs/default.txt
@@ -1,8 +1,4 @@
-Nouveautés :
-- Télécharge une board et grimpe sans réseau. Tes croix se synchronisent à ton retour.
-- La cotation Boardsesh se lit pareil sur Kilter, Tension et MoonBoard, à partir de vraies croix.
-- Chaque salle a sa page publique et un écran de mur pour la télé.
-- Les tablettes Android passent à la vue mur en deux panneaux.
-- Un tri Aléatoire, un filtre projets et des filtres épinglés.
-
-Corrigé : Bluetooth plus rapide et ta board réapparaît à la reconnexion.
+Nouveautés de la version 2.4 :
+- MoonBoard : active « Allumer la prise du dessus » pour ajouter une LED plus tamisée au-dessus de chaque prise de départ ou de main allumée sur les contrôleurs compatibles.
+- Les panneaux se ferment correctement après un passage en arrière-plan ou un changement d’écran.
+- Les fichiers partagés avec Boardsesh restent dans son cache même si une autre app fournit un nom inhabituel.

--- a/fastlane/metadata/de-DE/release_notes.txt
+++ b/fastlane/metadata/de-DE/release_notes.txt
@@ -1,19 +1,6 @@
-Drei große Sachen in diesem Update: klettern ohne Empfang, ein Grad, der sich auf jedem Board gleich liest, und deine Halle auf Boardsesh.
+Neu in 2.4:
 
-Offline klettern:
-- Lade ein Board herunter und mach ohne Empfang weiter: Boulder suchen, Begehungen eintragen, Favoriten sichern. Alles reiht sich auf deinem Handy ein und synchronisiert sich, sobald du zurück bist. Downloads sind jetzt in Sekunden durch, und „Speicher verwalten“ zeigt dir, wie viel Speicher jedes Board belegt, damit du die entfernen kannst, an denen du gerade nicht kletterst.
-
-Der Boardsesh-Grad:
-- Ein Grad, der sich auf Kilter, Tension und MoonBoard gleich liest, gebaut aus jeder eingetragenen Begehung, mit Konfidenzniveau. Schalte „Boardsesh-Grade anzeigen“ in den Einstellungen ein. Boulder ohne eingetragene Begehung bekommen eine Schätzung aus ihrer Griffanordnung, statt ohne Grad dazustehen.
-
-Deine Halle:
-- Jede Halle hat jetzt eine öffentliche Seite: folge ihr, oder übernimm sie, wenn sie dir gehört. Bring deine Wände auf einen Fernseher unter boardsesh.com/kiosk/deine-halle: was auf jedem Board leuchtet, mit deinem Logo und in deinen Farben, mit einem Code, den Kletterer*innen scannen, um sich Boardsesh zu holen.
-
-Außerdem:
-- Mische deine Ergebnisse mit der neuen Sortierung Zufall, filtere auf die Projekte, die du versucht, aber noch nicht getoppt hast, und pinne dir die Filter, die du wirklich brauchst.
-- Der Kletter-Screen öffnet sich mit deiner eigenen Historie zum Boulder: deine Begehungen und Versuche, direkt im Blick.
-- Dein Routenbuch zählt sauber: doppelte Aurora-Begehungen landen einmal, importierte Tension-Versuche bleiben Versuche, und MoonBoard-2024-Begehungen werden richtig importiert.
-- Zeilen in Warteschlange und Boulderliste funktionieren jetzt mit VoiceOver.
-- Stabileres Bluetooth, stabilere Sessions mit deiner Crew und weniger Speicher-Abstürze an langen iPad-Tagen.
-
-Kostenlos, ohne Werbung, Open Source.
+- MoonBoard: Aktiviere „Griff darüber beleuchten“, damit unterstützte Controller eine zweite, gedimmte LED über jedem beleuchteten Start- oder Handgriff einschalten.
+- Android-Panels schließen nach dem Wechsel in den Hintergrund oder zwischen Screens zuverlässig.
+- Boardfotos und Griff-Overlays laden auf iOS ohne zusätzliche Pause.
+- Auf Android geteilte Dateien bleiben im Boardsesh-Cache, auch wenn eine andere App einen ungewöhnlichen Namen liefert.

--- a/fastlane/metadata/de-DE/release_notes.txt
+++ b/fastlane/metadata/de-DE/release_notes.txt
@@ -1,6 +1,4 @@
 Neu in 2.4:
 
 - MoonBoard: Aktiviere „Griff darüber beleuchten“, damit unterstützte Controller eine zweite, gedimmte LED über jedem beleuchteten Start- oder Handgriff einschalten.
-- Android-Panels schließen nach dem Wechsel in den Hintergrund oder zwischen Screens zuverlässig.
 - Boardfotos und Griff-Overlays laden auf iOS ohne zusätzliche Pause.
-- Auf Android geteilte Dateien bleiben im Boardsesh-Cache, auch wenn eine andere App einen ungewöhnlichen Namen liefert.

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,6 +1,4 @@
 New in 2.4:
 
 - MoonBoard: turn on “Light the hold above” to add a dimmer LED above each lit start and hand hold on supported controllers.
-- Sheets on Android close reliably after backgrounding or moving between screens.
 - Board photos and hold overlays load without the extra pause on iOS.
-- Files shared into Boardsesh on Android stay safely inside its cache, even when another app sends an unusual filename.

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,19 +1,6 @@
-Three big ones this update: climb with no signal, one grade that reads the same on every board, and your gym on Boardsesh.
+New in 2.4:
 
-Climb offline:
-- Download a board and keep going with no signal — search climbs, log sends, save favorites. Everything queues on your phone and syncs when you're back. Downloads finish in seconds now, and Manage storage shows what each board takes up so you can clear the ones you're not climbing on.
-
-The Boardsesh grade:
-- One grade that reads the same across Kilter, Tension and MoonBoard, built from every logged send, with a confidence level. Turn on "Show Boardsesh grades" in Settings. Problems nobody's logged yet get an estimate from their hold layout instead of sitting there ungraded.
-
-Your gym:
-- Every gym has a public page now — follow it, or claim it if it's yours. Put your walls on a TV at boardsesh.com/kiosk/your-gym: what's lit on every board, in your logo and colors, with a code climbers scan to get Boardsesh.
-
-Also:
-- Shuffle your results with the new Random sort, filter down to the projects you've tried but haven't sent, and pin the filter shortcuts you actually reach for.
-- The play screen opens on your own history with the climb — your sends and attempts, right where you can see them.
-- Your logbook counts straight: duplicate Aurora ascents land once, imported Tension attempts stay attempts, and MoonBoard 2024 sends import properly.
-- Queue rows and climb rows now work with VoiceOver.
-- Steadier Bluetooth, steadier sessions with your crew, and fewer memory crashes on long iPad days.
-
-Free, no ads, open source.
+- MoonBoard: turn on “Light the hold above” to add a dimmer LED above each lit start and hand hold on supported controllers.
+- Sheets on Android close reliably after backgrounding or moving between screens.
+- Board photos and hold overlays load without the extra pause on iOS.
+- Files shared into Boardsesh on Android stay safely inside its cache, even when another app sends an unusual filename.

--- a/fastlane/metadata/es-ES/release_notes.txt
+++ b/fastlane/metadata/es-ES/release_notes.txt
@@ -1,19 +1,6 @@
-Tres cosas grandes en esta actualización: escalar sin cobertura, un grado que se lee igual en todos los plafones, y tu rocódromo en Boardsesh.
+Novedades de 2.4:
 
-Escala sin conexión:
-- Descarga un plafón y sigue escalando sin cobertura: busca vías, registra encadenes y guarda favoritos. Todo se queda en cola en tu móvil y se sincroniza cuando vuelves. Las descargas ahora tardan segundos, y en Almacenamiento ves lo que ocupa cada plafón para borrar los que ya no escalas.
-
-El grado Boardsesh:
-- Un grado que se lee igual en Kilter, Tension y MoonBoard, hecho a partir de todos los encadenes registrados y con un nivel de confianza. Actívalo en Ajustes con "Mostrar grados Boardsesh". Los bloques que nadie ha registrado todavía reciben una estimación a partir de sus presas, en vez de quedarse sin grado.
-
-Tu rocódromo:
-- Cada rocódromo tiene ya su página pública: síguelo, o reclámalo si es tuyo. Pon tus muros en una tele en boardsesh.com/kiosk/tu-rocodromo: lo que está encendido en cada plafón, con tu logo y tus colores, y un código que los escaladores escanean para instalar Boardsesh.
-
-Además:
-- Mezcla tus resultados con el nuevo orden Aleatorio, filtra por los proyectos que has intentado pero no encadenado, y fija los filtros que de verdad usas.
-- La pantalla de escalada abre con tu propio historial de esa vía: tus encadenes e intentos, ahí donde puedes verlos.
-- Tu logbook cuenta bien: los ascensos duplicados de Aurora se cuentan una vez, los intentos importados de Tension siguen siendo intentos, y los encadenes de MoonBoard 2024 se importan como toca.
-- Las filas de la cola y de las vías ya funcionan con VoiceOver.
-- Bluetooth más estable, sesiones con tu gente más estables, y menos cierres por memoria en días largos de iPad.
-
-Gratis, sin anuncios, código abierto.
+- MoonBoard: activa «Iluminar la presa de arriba» para añadir un LED más tenue sobre cada presa de inicio o de mano iluminada en controladores compatibles.
+- En Android, los paneles se cierran bien después de dejar la app en segundo plano o cambiar de pantalla.
+- En iOS, las fotos del plafón y las superposiciones de presas cargan sin la pausa extra.
+- En Android, los archivos compartidos con Boardsesh se quedan dentro de su caché aunque otra app envíe un nombre poco habitual.

--- a/fastlane/metadata/es-ES/release_notes.txt
+++ b/fastlane/metadata/es-ES/release_notes.txt
@@ -1,6 +1,4 @@
 Novedades de 2.4:
 
 - MoonBoard: activa «Iluminar la presa de arriba» para añadir un LED más tenue sobre cada presa de inicio o de mano iluminada en controladores compatibles.
-- En Android, los paneles se cierran bien después de dejar la app en segundo plano o cambiar de pantalla.
 - En iOS, las fotos del plafón y las superposiciones de presas cargan sin la pausa extra.
-- En Android, los archivos compartidos con Boardsesh se quedan dentro de su caché aunque otra app envíe un nombre poco habitual.

--- a/fastlane/metadata/es-MX/release_notes.txt
+++ b/fastlane/metadata/es-MX/release_notes.txt
@@ -1,19 +1,6 @@
-Tres cosas grandes en esta actualización: escalar sin cobertura, un grado que se lee igual en todos los plafones, y tu rocódromo en Boardsesh.
+Novedades de 2.4:
 
-Escala sin conexión:
-- Descarga un plafón y sigue escalando sin cobertura: busca vías, registra encadenes y guarda favoritos. Todo se queda en cola en tu móvil y se sincroniza cuando vuelves. Las descargas ahora tardan segundos, y en Almacenamiento ves lo que ocupa cada plafón para borrar los que ya no escalas.
-
-El grado Boardsesh:
-- Un grado que se lee igual en Kilter, Tension y MoonBoard, hecho a partir de todos los encadenes registrados y con un nivel de confianza. Actívalo en Ajustes con "Mostrar grados Boardsesh". Los bloques que nadie ha registrado todavía reciben una estimación a partir de sus presas, en vez de quedarse sin grado.
-
-Tu rocódromo:
-- Cada rocódromo tiene ya su página pública: síguelo, o reclámalo si es tuyo. Pon tus muros en una tele en boardsesh.com/kiosk/tu-rocodromo: lo que está encendido en cada plafón, con tu logo y tus colores, y un código que los escaladores escanean para instalar Boardsesh.
-
-Además:
-- Mezcla tus resultados con el nuevo orden Aleatorio, filtra por los proyectos que has intentado pero no encadenado, y fija los filtros que de verdad usas.
-- La pantalla de escalada abre con tu propio historial de esa vía: tus encadenes e intentos, ahí donde puedes verlos.
-- Tu logbook cuenta bien: los ascensos duplicados de Aurora se cuentan una vez, los intentos importados de Tension siguen siendo intentos, y los encadenes de MoonBoard 2024 se importan como toca.
-- Las filas de la cola y de las vías ya funcionan con VoiceOver.
-- Bluetooth más estable, sesiones con tu gente más estables, y menos cierres por memoria en días largos de iPad.
-
-Gratis, sin anuncios, código abierto.
+- MoonBoard: activa «Iluminar la presa de arriba» para añadir un LED más tenue sobre cada presa de inicio o de mano iluminada en controladores compatibles.
+- En Android, los paneles se cierran bien después de dejar la app en segundo plano o cambiar de pantalla.
+- En iOS, las fotos del plafón y las superposiciones de presas cargan sin la pausa extra.
+- En Android, los archivos compartidos con Boardsesh se quedan dentro de su caché aunque otra app envíe un nombre poco habitual.

--- a/fastlane/metadata/es-MX/release_notes.txt
+++ b/fastlane/metadata/es-MX/release_notes.txt
@@ -1,6 +1,4 @@
 Novedades de 2.4:
 
 - MoonBoard: activa «Iluminar la presa de arriba» para añadir un LED más tenue sobre cada presa de inicio o de mano iluminada en controladores compatibles.
-- En Android, los paneles se cierran bien después de dejar la app en segundo plano o cambiar de pantalla.
 - En iOS, las fotos del plafón y las superposiciones de presas cargan sin la pausa extra.
-- En Android, los archivos compartidos con Boardsesh se quedan dentro de su caché aunque otra app envíe un nombre poco habitual.

--- a/fastlane/metadata/fr-FR/release_notes.txt
+++ b/fastlane/metadata/fr-FR/release_notes.txt
@@ -1,19 +1,6 @@
-Trois grosses nouveautés dans cette mise à jour : grimper sans réseau, une cotation qui se lit pareil sur toutes les boards, et ta salle sur Boardsesh.
+Nouveautés de la version 2.4 :
 
-Grimpe hors ligne :
-- Télécharge une board et continue sans réseau : cherche des voies, enregistre tes croix, mets des favoris. Tout se met en file sur ton téléphone et se synchronise dès que tu reviens. Les téléchargements prennent maintenant quelques secondes, et Stockage te montre ce que pèse chaque board pour effacer celles que tu ne grimpes plus.
-
-La cotation Boardsesh :
-- Une cotation qui se lit pareil sur Kilter, Tension et MoonBoard, construite à partir de toutes les croix enregistrées, avec un niveau de confiance. Active « Afficher les grades Boardsesh » dans les Réglages. Les blocs que personne n'a encore enregistrés reçoivent une estimation à partir de leurs prises, au lieu de rester sans cotation.
-
-Ta salle :
-- Chaque salle a maintenant sa page publique : abonne-toi, ou revendique-la si c'est la tienne. Mets tes murs sur un écran avec boardsesh.com/kiosk/ta-salle : ce qui est allumé sur chaque board, avec ton logo et tes couleurs, et un code que les grimpeurs scannent pour installer Boardsesh.
-
-Aussi :
-- Mélange tes résultats avec le nouveau tri Aléatoire, filtre sur les projets que tu as essayés sans les enchaîner, et épingle les filtres que tu utilises vraiment.
-- L'écran de grimpe s'ouvre sur ton propre historique de la voie : tes croix et tes essais, là où tu peux les voir.
-- Ton logbook compte juste : les ascensions Aurora en double ne comptent qu'une fois, les essais importés de Tension restent des essais, et les croix MoonBoard 2024 s'importent correctement.
-- Les lignes de la file et des voies fonctionnent maintenant avec VoiceOver.
-- Bluetooth plus stable, séances avec tes potes plus stables, et moins de plantages mémoire sur les longues journées iPad.
-
-Gratuit, sans pub, open source.
+- MoonBoard : active « Allumer la prise du dessus » pour ajouter une LED plus tamisée au-dessus de chaque prise de départ ou de main allumée sur les contrôleurs compatibles.
+- Sur Android, les panneaux se ferment correctement après un passage en arrière-plan ou un changement d’écran.
+- Sur iOS, les photos de board et les superpositions de prises s’affichent sans pause supplémentaire.
+- Sur Android, les fichiers partagés avec Boardsesh restent dans son cache même si une autre app fournit un nom inhabituel.

--- a/fastlane/metadata/fr-FR/release_notes.txt
+++ b/fastlane/metadata/fr-FR/release_notes.txt
@@ -1,6 +1,4 @@
 Nouveautés de la version 2.4 :
 
 - MoonBoard : active « Allumer la prise du dessus » pour ajouter une LED plus tamisée au-dessus de chaque prise de départ ou de main allumée sur les contrôleurs compatibles.
-- Sur Android, les panneaux se ferment correctement après un passage en arrière-plan ou un changement d’écran.
 - Sur iOS, les photos de board et les superpositions de prises s’affichent sans pause supplémentaire.
-- Sur Android, les fichiers partagés avec Boardsesh restent dans son cache même si une autre app fournit un nom inhabituel.

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -275,7 +275,7 @@ export default ({ config, projectRoot }: ConfigContext): ExpoConfig & { newArchE
     name: appName,
     slug: 'boardsesh',
     owner: 'boardsesh',
-    version: '2.3.1',
+    version: '2.4.0',
     scheme: 'com.boardsesh.app',
     orientation: 'portrait',
     icon: iconPath,


### PR DESCRIPTION
## Summary

- Set the iOS and Android marketing version to 2.4.0 for the next native release.
- Replace every Fastlane/App Store and Google Play release-note locale with climber-facing notes for the native train.
- Keep iOS build numbers and Android version codes store-derived through the existing workflows.
- Targets the native release train in #4457.

## Release Notes

- [x] No release note needed (release packaging / store metadata only; the user-facing notes are the Fastlane files and #4457)

## Test plan

- `vp test run --project scripts --reporter=agent scripts/store-metadata-limits.test.ts` (29/29)
- `vp check packages/mobile/app.config.ts ...`
- `vp run typecheck:mobile`
- `vp run test:mobile` (670 files / 6,432 tests)
- `vp run check:mobile-bundle` (iOS and Android)
- Independent locale/version audit: PASS
- `git diff --check`
