### PR TITLE
fix(backend): prevent DSM exhaustion in similarity and stats sync

### DIFF
--- a/packages/backend/src/__tests__/climb-similarity.test.ts
+++ b/packages/backend/src/__tests__/climb-similarity.test.ts
@@ -10,15 +10,45 @@ import {
   parseFramesToHoldEntries,
 } from '../graphql/resolvers/climbs/climb-similarity';
 
-const { mockDb } = vi.hoisted(() => ({
-  mockDb: {
+const { mockDb, mockTransactionDb } = vi.hoisted(() => {
+  const mockTransactionDb = {
     execute: vi.fn(),
-  },
-}));
+  };
+  return {
+    mockTransactionDb,
+    mockDb: {
+      execute: vi.fn(),
+      transaction: vi.fn((callback: (transactionDb: typeof mockTransactionDb) => unknown) =>
+        callback(mockTransactionDb),
+      ),
+    },
+  };
+});
 
 vi.mock('../db/client', () => ({
   db: mockDb,
 }));
+
+const dialect = new PgDialect();
+const SERIAL_PLAN_GUARD = /SET LOCAL max_parallel_workers_per_gather\s*=\s*0/i;
+
+function renderStatement(statement: unknown): string {
+  return dialect.sqlToQuery(statement as SQL).sql;
+}
+
+function mockSimilarClimbRows(rows: unknown[]): void {
+  mockTransactionDb.execute.mockImplementation((statement: unknown) =>
+    Promise.resolve(SERIAL_PLAN_GUARD.test(renderStatement(statement)) ? [] : rows),
+  );
+}
+
+function getRenderedSimilarityQuery(): { sql: string; params: unknown[] } {
+  const queryCall = mockTransactionDb.execute.mock.calls.find(
+    ([statement]) => !SERIAL_PLAN_GUARD.test(renderStatement(statement)),
+  );
+  if (!queryCall) throw new Error('Expected the similarity query to execute');
+  return dialect.sqlToQuery(queryCall[0] as SQL);
+}
 
 describe('parseFramesToHoldEntries', () => {
   it('parses a Kilter frame string into hold + state tuples', () => {
@@ -211,10 +241,11 @@ describe('findSimilarClimbs', () => {
     });
     expect(result).toEqual([]);
     expect(mockDb.execute).not.toHaveBeenCalled();
+    expect(mockDb.transaction).not.toHaveBeenCalled();
   });
 
   it('maps each row to the SimilarClimbResult shape', async () => {
-    mockDb.execute.mockResolvedValueOnce([
+    mockSimilarClimbRows([
       {
         uuid: 'similar-1',
         name: 'Dyno from Insta',
@@ -262,7 +293,7 @@ describe('findSimilarClimbs', () => {
     // so a stray refactor can't silently widen the funnel (threshold=0 would
     // need every candidate's overlap counted) or shrink it past the input
     // (threshold=1 cutoff > targetSize prunes everything but exact matches).
-    mockDb.execute.mockResolvedValueOnce([]);
+    mockSimilarClimbRows([]);
     await findSimilarClimbs({
       boardType: 'kilter',
       layoutId: 1,
@@ -275,16 +306,15 @@ describe('findSimilarClimbs', () => {
       threshold: 0,
     });
     {
-      const [query] = mockDb.execute.mock.calls[0];
-      const { params } = new PgDialect().sqlToQuery(query as SQL);
+      const { params } = getRenderedSimilarityQuery();
       // threshold=0 → CEIL(4 * 0) = 0; the HAVING simplifies to "shared >= 0"
       // which lets every candidate through, deliberately. The DB still drops
       // candidates with 0 overlap via the INNER JOIN before HAVING runs.
       expect(params).toContain(0);
     }
 
-    mockDb.execute.mockReset();
-    mockDb.execute.mockResolvedValueOnce([]);
+    mockTransactionDb.execute.mockReset();
+    mockSimilarClimbRows([]);
     await findSimilarClimbs({
       boardType: 'kilter',
       layoutId: 1,
@@ -297,8 +327,7 @@ describe('findSimilarClimbs', () => {
       threshold: 1,
     });
     {
-      const [query] = mockDb.execute.mock.calls[0];
-      const { params } = new PgDialect().sqlToQuery(query as SQL);
+      const { params } = getRenderedSimilarityQuery();
       // threshold=1 → CEIL(4 * 1) = 4; candidates need at least every target
       // hold to clear the prune. Anything less drops here, before Jaccard.
       expect(params).toContain(1);
@@ -313,7 +342,7 @@ describe('findSimilarClimbs', () => {
     // (e.g. STARTING → HAND) counts as one position, not two. Without the
     // dedupe, the targetSize denominator would double-count and depress
     // Jaccard below the threshold for legitimate extended-version matches.
-    mockDb.execute.mockResolvedValueOnce([
+    mockSimilarClimbRows([
       {
         uuid: 'pickled',
         name: 'pickled cucumbers',
@@ -338,5 +367,24 @@ describe('findSimilarClimbs', () => {
     });
     // Two distinct positions despite three input tuples.
     expect(result[0]?.targetHoldCount).toBe(2);
+  });
+
+  it('disables parallel workers before running the similarity CTE on the same transaction', async () => {
+    mockSimilarClimbRows([]);
+
+    await findSimilarClimbs({
+      boardType: 'tension',
+      layoutId: 10,
+      holds: [
+        { holdId: 439, holdState: 'STARTING' },
+        { holdId: 585, holdState: 'HAND' },
+      ],
+      threshold: 0.5,
+    });
+
+    expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+    expect(mockTransactionDb.execute).toHaveBeenCalledTimes(2);
+    expect(renderStatement(mockTransactionDb.execute.mock.calls[0][0])).toMatch(SERIAL_PLAN_GUARD);
+    expect(renderStatement(mockTransactionDb.execute.mock.calls[1][0])).toContain('WITH target_holds AS');
   });
 });

--- a/packages/backend/src/__tests__/sync-climb-stats-serial-plan.test.ts
+++ b/packages/backend/src/__tests__/sync-climb-stats-serial-plan.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+import type { ConnectionContext, SyncResult } from '@boardsesh/shared-schema';
+import { syncQueries } from '../graphql/resolvers/sync/queries';
+
+const { database, transactionDatabase, recordedHandles } = vi.hoisted(() => {
+  const recordedHandles: string[] = [];
+  const transactionDatabase = {
+    execute: vi.fn((_statement: unknown) => {
+      recordedHandles.push('transaction');
+      return Promise.resolve([]);
+    }),
+  };
+  const database = {
+    execute: vi.fn((_statement: unknown) => {
+      recordedHandles.push('database');
+      return Promise.resolve([]);
+    }),
+    transaction: vi.fn((callback: (transactionDb: typeof transactionDatabase) => unknown) =>
+      callback(transactionDatabase),
+    ),
+  };
+  return { database, transactionDatabase, recordedHandles };
+});
+
+vi.mock('../db/client', () => ({ db: database }));
+
+const dialect = new PgDialect();
+const SERIAL_PLAN_GUARD = /SET LOCAL max_parallel_workers_per_gather\s*=\s*0/i;
+
+function connectionContext(): ConnectionContext {
+  return {
+    connectionId: 'sync-stats-serial-plan',
+    isAuthenticated: true,
+    userId: 'user-1',
+    sessionId: null,
+    boardPath: null,
+    controllerId: null,
+    controllerApiKey: null,
+  } as unknown as ConnectionContext;
+}
+
+function renderStatement(statement: unknown): string {
+  return dialect.sqlToQuery(statement as SQL).sql;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  recordedHandles.length = 0;
+});
+
+describe('syncClimbStats serial-plan guard', () => {
+  it('runs SET LOCAL before the scoped page query on the same transaction', async () => {
+    const result = (await syncQueries.syncClimbStats(
+      undefined,
+      { boardType: 'tension', layoutId: 10, sizeId: 6, cursor: null, limit: 500 },
+      connectionContext(),
+    )) as SyncResult;
+
+    expect(result).toEqual({
+      documents: [],
+      cursor: { updatedAt: '1970-01-01T00:00:00.000Z', syncSeq: '0' },
+      hasMore: false,
+    });
+    expect(database.transaction).toHaveBeenCalledTimes(1);
+    expect(database.execute).not.toHaveBeenCalled();
+    expect(transactionDatabase.execute).toHaveBeenCalledTimes(2);
+    expect(recordedHandles).toEqual(['transaction', 'transaction']);
+    expect(renderStatement(transactionDatabase.execute.mock.calls[0][0])).toMatch(SERIAL_PLAN_GUARD);
+    expect(renderStatement(transactionDatabase.execute.mock.calls[1][0])).toContain('FROM board_climb_stats');
+  });
+});

--- a/packages/backend/src/graphql/resolvers/climbs/climb-similarity.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/climb-similarity.ts
@@ -8,6 +8,7 @@ import {
 } from '@boardsesh/board-constants/hold-states';
 import type { BoardName } from '@boardsesh/board-constants';
 import { executeRows } from '@boardsesh/db/client';
+import { withSerialPlan } from '@boardsesh/db/queries';
 import { db } from '../../../db/client';
 import { climbStatsEffectiveAngleSql } from '../../../db/queries/util/climb-stats-join';
 
@@ -292,23 +293,29 @@ export async function findSimilarClimbs({
   const safeLimit = Math.max(1, Math.min(200, limit));
   const targetHoldIdsJson = JSON.stringify(targetHoldIds);
 
-  const rows = await executeRows<{
-    uuid: string;
-    name: string | null;
-    setter_username: string | null;
-    angle: number | null;
-    layout_id: number;
-    frames: string | null;
-    difficulty_name: string | null;
-    quality_average: number | null;
-    ascensionist_count: number | null;
-    compatible_size_ids: number[] | null;
-    shared: number;
-    candidate_hold_count: number;
-    jaccard: number;
-  }>(
-    db,
-    sql`
+  // Production plans this catalog-wide aggregate with a Gather Merge. Bursts
+  // of similar-climb requests then allocate one DSM segment per worker until
+  // Railway Postgres's small /dev/shm is exhausted (Sentry BOARDSESH-AK,
+  // pgCode 53100). SET LOCAL only applies on the transaction connection, so
+  // both the guard and executeRows must use the handle supplied here.
+  const rows = await withSerialPlan(db, (transactionDb) =>
+    executeRows<{
+      uuid: string;
+      name: string | null;
+      setter_username: string | null;
+      angle: number | null;
+      layout_id: number;
+      frames: string | null;
+      difficulty_name: string | null;
+      quality_average: number | null;
+      ascensionist_count: number | null;
+      compatible_size_ids: number[] | null;
+      shared: number;
+      candidate_hold_count: number;
+      jaccard: number;
+    }>(
+      transactionDb,
+      sql`
       WITH target_holds AS (
         SELECT (value)::int AS hold_id
         FROM jsonb_array_elements(${targetHoldIdsJson}::jsonb) AS value
@@ -393,7 +400,8 @@ export async function findSimilarClimbs({
       WHERE (o.shared::float / (${targetSize} + cs.n - o.shared)) >= ${safeThreshold}
       ORDER BY jaccard DESC, COALESCE(${dbSchema.boardClimbStats.ascensionistCount}, 0) DESC, c.uuid ASC
       LIMIT ${safeLimit}
-    `,
+      `,
+    ),
   );
 
   return rows.map((row) => ({

--- a/packages/backend/src/graphql/resolvers/sync/queries.ts
+++ b/packages/backend/src/graphql/resolvers/sync/queries.ts
@@ -3,6 +3,7 @@ import type { ConnectionContext, SyncResult, SyncDeletionsResult, SyncCursorInpu
 import { isSizeScopedBoard } from '@boardsesh/board-config';
 import { db } from '../../../db/client';
 import { rowsFromResult } from '@boardsesh/db/client';
+import { withSerialPlan, type SerialPlanDb } from '@boardsesh/db/queries';
 import { requireAuthenticated } from '../shared/helpers';
 import { normalizeRow, toIso, type RawRow } from './row-normalize';
 import {
@@ -69,6 +70,7 @@ function cursorBounds(cursor: SyncCursorInput | null | undefined): { ts: string;
  * pass fully-qualified column references to avoid an ambiguous-column error.
  */
 async function runSyncPage(params: {
+  executor?: SerialPlanDb;
   selectList: SQL;
   fromClause: SQL;
   scope: SQL;
@@ -77,10 +79,10 @@ async function runSyncPage(params: {
   cursor: SyncCursorInput | null | undefined;
   limit: number;
 }): Promise<SyncResult> {
-  const { selectList, fromClause, scope, updatedAtColumn, seqColumn, cursor, limit } = params;
+  const { executor = db, selectList, fromClause, scope, updatedAtColumn, seqColumn, cursor, limit } = params;
   const { ts, seq } = cursorBounds(cursor);
 
-  const result = await db.execute(sql`
+  const result = await executor.execute(sql`
     SELECT ${selectList}, ${updatedAtColumn} AS __updated_at, ${seqColumn} AS __seq
     FROM ${fromClause}
     WHERE ${scope}
@@ -433,16 +435,24 @@ export const syncQueries = {
       scope = sql`board_type = ${validBoardType} AND EXISTS (SELECT 1 FROM board_climbs bc WHERE ${sub})`;
     }
 
-    return runSyncPage({
-      selectList: sql`board_type, climb_uuid, angle, display_difficulty, benchmark_difficulty,
-        ascensionist_count, difficulty_average, quality_average, fa_username, fa_at, updated_at, sync_seq`,
-      fromClause: sql`board_climb_stats`,
-      scope,
-      updatedAtColumn: sql`board_climb_stats.updated_at`,
-      seqColumn: sql`board_climb_stats.sync_seq`,
-      cursor,
-      limit: lim,
-    });
+    // A scoped stats pull walks board_climb_stats in cursor order and probes
+    // board_climbs through the EXISTS filter. Production chooses a Gather
+    // Merge for that shape, which has exhausted Postgres's DSM during sync
+    // bursts (Sentry BOARDSESH-AK, pgCode 53100). Keep SET LOCAL and the page
+    // SELECT on the exact same transaction handle.
+    return withSerialPlan(db, (transactionDb) =>
+      runSyncPage({
+        executor: transactionDb,
+        selectList: sql`board_type, climb_uuid, angle, display_difficulty, benchmark_difficulty,
+          ascensionist_count, difficulty_average, quality_average, fa_username, fa_at, updated_at, sync_seq`,
+        fromClause: sql`board_climb_stats`,
+        scope,
+        updatedAtColumn: sql`board_climb_stats.updated_at`,
+        seqColumn: sql`board_climb_stats.sync_seq`,
+        cursor,
+        limit: lim,
+      }),
+    );
   },
 
   /**


### PR DESCRIPTION
## Summary

- run `similarClimbs` inside the existing serial-plan guard so its catalog-wide aggregate cannot allocate parallel-worker dynamic shared memory
- route `syncClimbStats` through the same guarded transaction, including the exact transaction handle used by `SET LOCAL`
- add regression coverage that asserts guard-before-query ordering and same-handle execution for both paths

Sentry [BOARDSESH-AK](https://boardsesh.sentry.io/issues/7616183441/) recorded 121 recent `similarClimbs` failures and six `syncClimbStats` failures with PostgreSQL code 53100. Production `EXPLAIN` showed `Gather Merge` plans for both queries; disabling per-gather parallelism removes those nodes without changing results.

## Release Notes

Similar climbs and offline board stats keep loading during busy sessions.

## Test plan

- `vp test run packages/backend/src/__tests__/climb-similarity.test.ts packages/backend/src/__tests__/sync-climb-stats-serial-plan.test.ts --reporter=agent` (20 passed)
- `vp test run packages/backend/src/__tests__/sync-pull-board-scope.test.ts --reporter=agent` (9 passed)
- `vp test run packages/backend/src/__tests__/sync-pull.test.ts --reporter=agent` (12 passed)
- `vp run typecheck:backend`
- `vp check` on all four changed files
- read-only production `EXPLAIN` confirmed both guarded plans contain no `Gather`
- exact local `SimilarClimbs` GraphQL request returned two results with no errors
- canonical Tension climb page rendered HTTP 200
- the aggregate backend run hit unrelated shared-test-database interference; the affected `board-presence` and `moonboard-tick-angle` suites then passed in isolation (82 and 14 tests)